### PR TITLE
Strip OpenClaw channel metadata from chat turn user text

### DIFF
--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -781,6 +781,7 @@ export class ChatTurnWriter {
     const sessionId = this.deriveSessionId(ctx);
     if (!sessionId) return;
     const identity = this.identityFieldsFromPayload(ctx);
+    const stripChannelMetadataFromUserText = this.shouldStripChannelMetadataForChannel(identity.channelId);
     const externalCursorKey = this.externalCursorKeyFromSessionKey(identity.sessionKey);
     const typedW4bCursorKeys = this.typedW4bMarkerCursorKeys(identity);
     const w4bInflightSessionIds = this.w4bInflightGuardSessionIds(identity, sessionId);
@@ -811,6 +812,7 @@ export class ChatTurnWriter {
           typedW4bCursorKeys,
           w4bInflightSessionIds,
           w4aCrossPathSessionIds,
+          stripChannelMetadataFromUserText,
         );
       });
     this.w4aSessionChains.set(sessionId, work);
@@ -833,6 +835,7 @@ export class ChatTurnWriter {
     typedW4bCursorKeys: string[] = [],
     w4bInflightSessionIds: string[] = [sessionId],
     w4aCrossPathSessionIds: string[] = [sessionId],
+    stripChannelMetadataFromUserText = false,
   ): Promise<void> {
     try {
       // R18.2 — Take the MAX of W4a's pair-indexed watermark and W4b's
@@ -851,7 +854,7 @@ export class ChatTurnWriter {
         w4aCrossPathSessionIds,
       );
       const savedUpTo = this.savedUpToForSession(sessionId);
-      const pairs = this.computeDelta(event.messages, savedUpTo);
+      const pairs = this.computeDelta(event.messages, savedUpTo, stripChannelMetadataFromUserText);
       if (pairs.length === 0) return;
       // T362 — Cold-start clamp. When no prior watermark exists for this
       // session (savedUpTo === -1) AND `messages[]` carries more than one
@@ -1528,16 +1531,19 @@ export class ChatTurnWriter {
         void pendingReset.then(() => this.onMessageReceived(ev)).catch(() => undefined);
         return;
       }
-      const text = readEventText(ev);
+      const rawText = readEventText(ev);
+      const text = this.shouldStripChannelMetadataForChannel(channelId)
+        ? this.stripChannelMetadata(rawText)
+        : rawText;
       // R15.2 — Skip attachment-only / non-text inbound events. `readEventText`
       // returns "" when the envelope carries no text payload (e.g. an image
       // upload from Telegram). Enqueueing an empty string here would let the
       // next `message:sent` pair its assistant reply with a blank user side,
       // persisting an assistant-only turn for a conversation that had no
-      // textual inbound. Drop until we add a recoverable representation for
-      // attachment-only turns.
+      // textual inbound. Leading channel metadata that strips to empty is
+      // treated the same way because it is runtime-only context, not user text.
       if (!text) return;
-      const inboundDedupKey = this.messageHookDedupKey("inbound", ev, text);
+      const inboundDedupKey = this.messageHookDedupKey("inbound", ev, rawText);
       if (inboundDedupKey) {
         const existingConversationKey = this.messageHookInboundQueueKeys.get(inboundDedupKey);
         if (existingConversationKey && existingConversationKey !== conversationKey) {
@@ -1602,9 +1608,10 @@ export class ChatTurnWriter {
       // Strip injected `<recalled-memory>` from assistant text — the model may
       // echo the auto-recall block, and if we persist the raw version here
       // while the W4a path persists the stripped version, the two turnIds
-      // diverge and cross-path dedup misses. User text is NOT stripped:
-      // legitimate pastes (XML, logs) containing the tag would otherwise be
-      // silently corrupted.
+      // diverge and cross-path dedup misses. Telegram user text was already
+      // normalized at enqueue time by `stripChannelMetadata`, and user text is
+      // not passed through `stripRecalledMemory`: legitimate user pastes
+      // containing XML/log tags must survive verbatim.
       const assistantText = this.stripRecalledMemory(readEventText(ev));
       // R20.1 — Compute `assistantText` BEFORE consuming the pending user.
       // A `message:sent` with `success: true` but no textual content
@@ -2630,6 +2637,7 @@ export class ChatTurnWriter {
   private computeDelta(
     messages: ChatTurnMessage[],
     savedUpTo: number,
+    stripChannelMetadataFromUserText = false,
   ): ComputedChatTurnPair[] {
     const pairs: ComputedChatTurnPair[] = [];
     // R19.1 — Queue of unmatched user messages. Two transcript shapes
@@ -2693,12 +2701,19 @@ export class ChatTurnWriter {
         // that semantic in `computeDelta` or it produces an
         // assistant-only pair (`{ user: "", assistant: reply }`)
         // for any image-only user message followed by a reply.
-        const userText = this.extractText(msg.content);
+        const extractedUserText = this.extractText(msg.content);
+        const externalDirect = this.hasExternalDirectChannelMetadata(msg);
+        // A Telegram W4a transcript can include DKG UI/direct-channel
+        // backfill messages. Those carry their own canonical body and
+        // marker metadata, so preserve them verbatim for marker lookup.
+        const userText = stripChannelMetadataFromUserText && !externalDirect
+          ? this.stripChannelMetadata(extractedUserText)
+          : extractedUserText;
         if (userText) {
           pendingUsers.push({
             text: userText,
             externalTurnIds: this.extractExternalTurnIds(msg),
-            externalDirect: this.hasExternalDirectChannelMetadata(msg),
+            externalDirect,
             messageIds: this.extractMessageIds(msg),
           });
         }
@@ -2777,6 +2792,86 @@ export class ChatTurnWriter {
       value.toolResult === true ||
       value.tool_result === true,
     );
+  }
+
+  /**
+   * Strip leading runtime-only channel metadata blocks from persisted user text.
+   *
+   * OpenClaw's Telegram channel plugin can prepend fenced JSON context for the
+   * agent (Telegram conversation/sender details).
+   * That metadata is useful before the model responds, but persisting it as user
+   * text pollutes recall and may leak sender/chat identifiers.
+   *
+   * Call this only after trusted channel context says the source is Telegram;
+   * the labels below are user-writable text without that channel context. Keep
+   * the recognized labels to the concrete Telegram wrapper shape; broader
+   * channel/message labels need their own trusted source before they can be
+   * stripped safely. The leading `Conversation info` block is stripped, and the
+   * immediately following `Sender` block is stripped only when its JSON agrees
+   * with that conversation block. This keeps a user-pasted `Sender` example
+   * after a conversation-only wrapper verbatim. Separator blank lines after
+   * stripped blocks are removed, but indentation on the first real user line is
+   * kept.
+   *
+   * Because W4a and W4b both call this before turnId/content hashing, metadata
+   * changes do not create distinct persisted turn identities for the same user
+   * utterance. Existing historical turns are not rewritten.
+   */
+  private shouldStripChannelMetadataForChannel(channelId?: unknown): boolean {
+    return typeof channelId === "string" && channelId.trim().toLowerCase() === "telegram";
+  }
+
+  private stripChannelMetadata(text: string): string {
+    if (!text) return "";
+    const first = this.matchLeadingChannelMetadataBlock(text);
+    if (!first) return text;
+    if (first.label === "Sender") return text.slice(first.length);
+    let out = text.slice(first.length);
+    const sender = this.matchLeadingChannelMetadataBlock(out);
+    if (sender?.label === "Sender" && this.senderMetadataMatchesConversation(first.json, sender.json)) {
+      out = out.slice(sender.length);
+    }
+    return out;
+  }
+
+  private matchLeadingChannelMetadataBlock(text: string):
+    | { label: "Conversation info" | "Sender"; json: string; length: number }
+    | undefined {
+    const match =
+      /^(Conversation info|Sender) \(untrusted metadata\):[ \t]*\r?\n[ \t]*```json[ \t]*\r?\n([\s\S]*?)\r?\n[ \t]*```[ \t]*(?:[ \t]*\r?\n)*/.exec(text);
+    if (!match) return undefined;
+    return {
+      label: match[1] as "Conversation info" | "Sender",
+      json: match[2],
+      length: match[0].length,
+    };
+  }
+
+  private senderMetadataMatchesConversation(conversationJson: string, senderJson: string): boolean {
+    const conversation = this.parseChannelMetadataJson(conversationJson);
+    const sender = this.parseChannelMetadataJson(senderJson);
+    if (!conversation || !sender) return false;
+    const conversationSenderId = firstString(
+      conversation.sender_id,
+      conversation.senderId,
+      (conversation.sender as any)?.id,
+    );
+    const senderId = firstString(sender.id, sender.sender_id, sender.senderId);
+    return conversationSenderId !== undefined && senderId !== undefined && conversationSenderId === senderId;
+  }
+
+  private parseChannelMetadataJson(json: string): Record<string, unknown> | undefined {
+    try {
+      const parsed = JSON.parse(json);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Treat malformed metadata as non-matching; the leading Conversation
+      // block is still runtime-only, but optional Sender stripping must prove
+      // it belongs to the same wrapper.
+    }
+    return undefined;
   }
 
   /**

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -8,6 +8,58 @@ import type { AgentEndContext, InternalMessageEvent } from "../src/ChatTurnWrite
 /** Wait long enough for fire-and-forget persistOne() to complete. */
 const flushMicrotasks = () => new Promise((r) => setTimeout(r, 20));
 
+const conversationInfoMetadataBlock = [
+  "Conversation info (untrusted metadata):",
+  "```json",
+  "{",
+  " \"chat_id\": \"telegram:test-chat-001\",",
+  " \"message_id\": \"test-message-1021\",",
+  " \"sender_id\": \"test-sender-001\",",
+  " \"sender\": \"Test Sender\",",
+  " \"timestamp\": \"Mon 2026-05-04 13:08 GMT+2\"",
+  "}",
+  "```",
+].join("\n");
+
+const senderMetadataBlock = [
+  "Sender (untrusted metadata):",
+  "```json",
+  "{",
+  " \"label\": \"Test Sender (test-sender-001)\",",
+  " \"id\": \"test-sender-001\",",
+  " \"name\": \"Test Sender\",",
+  " \"username\": \"test_sender_001\"",
+  "}",
+  "```",
+].join("\n");
+
+const pastedSenderMetadataBlock = [
+  "Sender (untrusted metadata):",
+  "```json",
+  "{",
+  " \"label\": \"Pasted Sender (user-pasted-sender-999)\",",
+  " \"id\": \"user-pasted-sender-999\",",
+  " \"name\": \"Pasted Sender\",",
+  " \"username\": \"pasted_sender_999\"",
+  "}",
+  "```",
+].join("\n");
+
+const channelContextMetadataBlock = [
+  "Channel context (untrusted metadata):",
+  "```json",
+  "{",
+  " \"example\": \"user-pasted channel context\"",
+  "}",
+  "```",
+].join("\n");
+
+function telegramWrappedUserText(userText: string, opts: { sender?: boolean } = {}): string {
+  const blocks = [conversationInfoMetadataBlock];
+  if (opts.sender !== false) blocks.push(senderMetadataBlock);
+  return [...blocks, userText].join("\n\n");
+}
+
 describe("ChatTurnWriter", () => {
   let writer: ChatTurnWriter;
   let mockClient: {
@@ -1109,6 +1161,242 @@ describe("ChatTurnWriter", () => {
     expect(call[2]).toBe("answer text");
   });
 
+  it("T380 - W4a strips leading Conversation info and Sender metadata from persisted user text", async () => {
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: telegramWrappedUserText("hello") },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe("hello");
+    expect(persistedUser).not.toContain("Conversation info");
+    expect(persistedUser).not.toContain("Sender");
+    expect(persistedUser).not.toContain("chat_id");
+    expect(persistedUser).not.toContain("sender_id");
+    expect(persistedUser).not.toContain("username");
+    expect(persistedUser).not.toContain("timestamp");
+  });
+
+  it("T380 - W4a strips leading Conversation info-only metadata", async () => {
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: telegramWrappedUserText("hello", { sender: false }) },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe("hello");
+  });
+
+  it("T380 - W4a leaves pure user text unchanged", async () => {
+    const pureUserText = "  plain user text without channel metadata";
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: pureUserText },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(pureUserText);
+  });
+
+  it("T380 - W4a preserves multi-line user text after leading metadata blocks", async () => {
+    const actualUserText = "hello\nline two\n\nline four";
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: telegramWrappedUserText(actualUserText) },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(actualUserText);
+  });
+
+  it("T380 - W4a preserves indentation on the first user line after metadata blocks", async () => {
+    const actualUserText = "  const answer = 42;\n  return answer;";
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: telegramWrappedUserText(actualUserText) },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(actualUserText);
+  });
+
+  it("T380 - W4a preserves metadata-shaped text pasted in the middle", async () => {
+    const pastedMetadata = [
+      "Please inspect this payload:",
+      conversationInfoMetadataBlock,
+      "The block above is part of my message.",
+    ].join("\n");
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: pastedMetadata },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(pastedMetadata);
+    expect(persistedUser).toContain("Conversation info (untrusted metadata):");
+  });
+
+  it("T380 - W4a preserves leading metadata-shaped text outside Telegram context", async () => {
+    const pastedMetadata = telegramWrappedUserText("This block is part of my message");
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: pastedMetadata },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "discord", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(pastedMetadata);
+    expect(persistedUser).toContain("Conversation info (untrusted metadata):");
+  });
+
+  it("T380 - W4a preserves direct-channel backfill text before marker lookup in Telegram context", async () => {
+    const directUserText = telegramWrappedUserText("This metadata-shaped block belongs to DKG UI text");
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-metadata-shaped",
+      user: directUserText,
+      assistant: "node ui answer",
+    });
+    mockClient.storeChatTurn.mockClear();
+
+    writer.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        {
+          role: "user",
+          content: directUserText,
+          context: { Provider: "dkg-ui", DkgTurnId: "node-ui-corr-metadata-shaped" },
+        },
+        { role: "assistant", content: "node ui answer" },
+        { role: "user", content: telegramWrappedUserText("live telegram question") },
+        { role: "assistant", content: "telegram answer" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe("live telegram question");
+  });
+
+  it("T380 - W4a preserves leading metadata-shaped user text after Telegram wrapper", async () => {
+    const actualUserText = [conversationInfoMetadataBlock, "This block is part of my message"].join("\n");
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: telegramWrappedUserText(actualUserText) },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(actualUserText);
+    expect(persistedUser).toContain("Conversation info (untrusted metadata):");
+  });
+
+  it("T380 - W4a preserves pasted Sender block after Conversation-only Telegram wrapper", async () => {
+    const actualUserText = [pastedSenderMetadataBlock, "This Sender block is part of my message"].join("\n\n");
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: telegramWrappedUserText(actualUserText, { sender: false }) },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(actualUserText);
+    expect(persistedUser).toContain("Sender (untrusted metadata):");
+    expect(persistedUser).toContain("user-pasted-sender-999");
+  });
+
+  it("T380 - W4a preserves non-Telegram metadata labels after Telegram wrapper", async () => {
+    const actualUserText = [channelContextMetadataBlock, "This block is part of my message"].join("\n");
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: telegramWrappedUserText(actualUserText) },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(actualUserText);
+    expect(persistedUser).toContain("Channel context (untrusted metadata):");
+  });
+
+  it("T380 - W4a turnId hashing uses stripped user text", async () => {
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: telegramWrappedUserText("hello") },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const call = mockClient.storeChatTurn.mock.calls[0];
+    expect(call[1]).toBe("hello");
+    expect(call[3]?.turnId).toBe(
+      (writer as any).deterministicTurnId("openclaw:telegram:::sk", "hello", "reply", 0),
+    );
+    expect(call[3]?.turnId).not.toBe(
+      (writer as any).deterministicTurnId("openclaw:telegram:::sk", telegramWrappedUserText("hello"), "reply", 0),
+    );
+  });
+
   it("stores user message on onMessageReceived", () => {
     writer.onMessageReceived({
       sessionKey: "session-123",
@@ -1131,6 +1419,192 @@ describe("ChatTurnWriter", () => {
     });
     await flushMicrotasks();
     expect(mockClient.storeChatTurn).toHaveBeenCalled();
+  });
+
+  it("T380 - W4b onMessageReceived strips leading OpenClaw metadata before persist", async () => {
+    writer.onMessageReceived({
+      sessionKey: "key123",
+      direction: "inbound",
+      text: telegramWrappedUserText("hello"),
+      ...({ context: { channelId: "telegram" } } as any),
+    } as any);
+    await writer.onMessageSent({
+      sessionKey: "key123",
+      direction: "outbound",
+      text: "response",
+      ...({ context: { success: true, channelId: "telegram" } } as any),
+    } as any);
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe("hello");
+    expect(persistedUser).not.toContain("chat_id");
+    expect(persistedUser).not.toContain("username");
+  });
+
+  it("T380 - W4b persists canonical internal Telegram envelopes and logs success", async () => {
+    writer.onMessageReceived({
+      sessionKey: "key123",
+      direction: "inbound",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "telegram:test-chat-001",
+        content: telegramWrappedUserText("hello"),
+        messageId: "in-test-message-1021",
+      },
+    } as any);
+
+    await writer.onMessageSent({
+      sessionKey: "key123",
+      direction: "outbound",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "telegram:test-chat-001",
+        content: "response",
+        success: true,
+        messageId: "out-test-message-1022",
+      },
+    } as any);
+    await writer.flush();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    const [sessionId, persistedUser, persistedAssistant] = mockClient.storeChatTurn.mock.calls[0];
+    expect(sessionId).toBe("openclaw:telegram:bot:telegram%3Atest-chat-001:key123");
+    expect(persistedUser).toBe("hello");
+    expect(persistedAssistant).toBe("response");
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining("[ChatTurnWriter] Persisted turn"),
+    );
+  });
+
+  it("T380 - W4b preserves leading metadata-shaped text outside Telegram context", async () => {
+    const pastedMetadata = telegramWrappedUserText("This block is part of my message");
+    writer.onMessageReceived({
+      sessionKey: "key123",
+      direction: "inbound",
+      text: pastedMetadata,
+      ...({ context: { channelId: "discord" } } as any),
+    } as any);
+    await writer.onMessageSent({
+      sessionKey: "key123",
+      direction: "outbound",
+      text: "response",
+      ...({ context: { success: true, channelId: "discord" } } as any),
+    } as any);
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(pastedMetadata);
+    expect(persistedUser).toContain("Conversation info (untrusted metadata):");
+  });
+
+  it("T380 - W4b preserves leading metadata-shaped user text after Telegram wrapper", async () => {
+    const actualUserText = [conversationInfoMetadataBlock, "This block is part of my message"].join("\n");
+    writer.onMessageReceived({
+      sessionKey: "key123",
+      direction: "inbound",
+      text: telegramWrappedUserText(actualUserText),
+      ...({ context: { channelId: "telegram" } } as any),
+    } as any);
+    await writer.onMessageSent({
+      sessionKey: "key123",
+      direction: "outbound",
+      text: "response",
+      ...({ context: { success: true, channelId: "telegram" } } as any),
+    } as any);
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(actualUserText);
+    expect(persistedUser).toContain("Conversation info (untrusted metadata):");
+  });
+
+  it("T380 - W4b preserves pasted Sender block after Conversation-only Telegram wrapper", async () => {
+    const actualUserText = [pastedSenderMetadataBlock, "This Sender block is part of my message"].join("\n\n");
+    writer.onMessageReceived({
+      sessionKey: "key123",
+      direction: "inbound",
+      text: telegramWrappedUserText(actualUserText, { sender: false }),
+      ...({ context: { channelId: "telegram" } } as any),
+    } as any);
+    await writer.onMessageSent({
+      sessionKey: "key123",
+      direction: "outbound",
+      text: "response",
+      ...({ context: { success: true, channelId: "telegram" } } as any),
+    } as any);
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(actualUserText);
+    expect(persistedUser).toContain("Sender (untrusted metadata):");
+    expect(persistedUser).toContain("user-pasted-sender-999");
+  });
+
+  it("T380 - W4b preserves non-Telegram metadata labels after Telegram wrapper", async () => {
+    const actualUserText = [channelContextMetadataBlock, "This block is part of my message"].join("\n");
+    writer.onMessageReceived({
+      sessionKey: "key123",
+      direction: "inbound",
+      text: telegramWrappedUserText(actualUserText),
+      ...({ context: { channelId: "telegram" } } as any),
+    } as any);
+    await writer.onMessageSent({
+      sessionKey: "key123",
+      direction: "outbound",
+      text: "response",
+      ...({ context: { success: true, channelId: "telegram" } } as any),
+    } as any);
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(actualUserText);
+    expect(persistedUser).toContain("Channel context (untrusted metadata):");
+  });
+
+  it("T380 - W4b strips each queued inbound before joining", async () => {
+    writer.onMessageReceived({
+      sessionKey: "key123",
+      direction: "inbound",
+      text: telegramWrappedUserText("first"),
+      ...({ context: { channelId: "telegram", messageId: "in-1" } } as any),
+    } as any);
+    writer.onMessageReceived({
+      sessionKey: "key123",
+      direction: "inbound",
+      text: telegramWrappedUserText("second"),
+      ...({ context: { channelId: "telegram", messageId: "in-2" } } as any),
+    } as any);
+    await writer.onMessageSent({
+      sessionKey: "key123",
+      direction: "outbound",
+      text: "response",
+      ...({ context: { success: true, channelId: "telegram", messageId: "out-1" } } as any),
+    } as any);
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe("first\nsecond");
+  });
+
+  it("T380 - typed Telegram W4b path strips leading metadata via normalization", async () => {
+    writer.onTypedMessageReceived(
+      {
+        from: "user-1",
+        content: telegramWrappedUserText("hello"),
+        metadata: { chatId: "chat-1", messageId: "typed-in-1" },
+      },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-1" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "typed response", success: true, metadata: { messageId: "typed-out-1" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-1" },
+    );
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe("hello");
   });
 
   it("T359 - typed message hooks persist one Telegram turn without internal sessionKey", async () => {


### PR DESCRIPTION
﻿## Summary

- Strip leading OpenClaw Telegram metadata blocks from persisted user-side chat-turn text in both W4a `computeDelta` and W4b message-hook persistence.
- Keep runtime model input behavior unchanged: the Telegram/OpenClaw channel wrapper is not modified, and stripping happens only inside adapter chat-turn persistence.
- Preserve assistant-side `stripRecalledMemory` behavior while adding user-side coverage for Telegram metadata pollution from #380.

## Related

- Fixes #380
- Related to #362
- Related to #364
- Rebased after #457

## Files changed

| File | What |
|------|------|
| `packages/adapter-openclaw/src/ChatTurnWriter.ts` | Adds Telegram-gated channel metadata stripping, preserves main's durable cursor validation flow, skips direct-channel backfill normalization before marker lookup, and applies stripped text before W4a/W4b content identity. |
| `packages/adapter-openclaw/test/ChatTurnWriter.test.ts` | Adds T380 regressions for Telegram metadata stripping, W4a/W4b consistency, direct-channel marker safety, pasted metadata preservation, stripped-text turnId hashing, and synthetic privacy fixtures. |

## Metadata stripping behavior

- Runs only when trusted OpenClaw channel context identifies the source as Telegram.
- Strips a leading `Conversation info (untrusted metadata):` fenced JSON block.
- Strips a following `Sender (untrusted metadata):` fenced JSON block only when its sender ID matches the preceding conversation metadata; `Sender`-only leading metadata still strips for that runtime shape.
- Preserves pure user text, multi-line text, indentation on the first real user line, metadata-shaped content in the middle, leading metadata-shaped content outside Telegram, repeated/broader labels after the wrapper, and pasted `Sender` blocks after a conversation-only wrapper when they do not match the runtime conversation sender.
- Preserves DKG UI/direct-channel backfill message text before durable marker lookup, even when the surrounding W4a transcript is from Telegram.
- Does not change the OpenClaw Telegram channel plugin or the raw runtime context seen by the agent before persistence.

## Watermark/hash decision and migration note

- Stripping happens before W4a pending-user storage and before W4b inbound queueing for Telegram, so `deterministicTurnId`, `contentHash`, cross-path stamps, and typed W4b markers use the stripped persisted user text going forward.
- Numeric W4a watermarks and W4b counts are unchanged because they are pair-index/count based, not text-hash based.
- Existing persisted turns are not rewritten. If reset/compaction or state loss leaves only pre-fix metadata-hashed durable markers, those legacy markers may not suppress a stripped replay; PR #362's cold-start clamp still bounds W4a state-loss replay to the latest pair.

## Privacy notes

- Persisted `userText` no longer carries inline Telegram `chat_id`, `message_id`, `sender_id`, sender name, username, or timestamp from the channel metadata wrapper.
- Test fixtures now use synthetic Telegram-like identifiers only.
- Routing/session metadata outside `userText` remains unchanged and is out of scope for #380.

## Known risks or follow-ups

- No migration is included for already-persisted metadata-polluted turns; #380 marked historical rewrite out of scope.
- CI for the latest force-push is currently running on GitHub.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/ChatTurnWriter.test.ts -t "T380"` - passed, 20 tests.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/ChatTurnWriter.test.ts` - passed, 205 tests.
- [x] `pnpm --filter @origintrail-official/dkg-core run build` - passed.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw run build` - passed.
- [x] `git diff --check upstream/main...HEAD` - passed.
- [x] Local `.codex` PR review rounds - final sweep returned `{"comments":[]}`.
