### PR TITLE
[kafka pr-1 · 02/6] Slice 02 — Explicit local-vs-shared CG choice + lazy kafka-local

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -6251,7 +6251,13 @@ export class DKGAgent {
     });
   }
 
-  private async isPrivateContextGraph(contextGraphId: string): Promise<boolean> {
+  /**
+   * Returns true when the CG carries a `"private"` access-policy triple in
+   * the ontology or `_meta` graph, OR when its `_meta` graph contains any
+   * allowlist predicate (`DKG_ALLOWED_PEER`, `DKG_ALLOWED_AGENT`, or
+   * `DKG_PARTICIPANT_AGENT`). System paranets always return false.
+   */
+  async isPrivateContextGraph(contextGraphId: string): Promise<boolean> {
     if ((Object.values(SYSTEM_PARANETS) as string[]).includes(contextGraphId)) {
       return false;
     }

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -551,14 +551,24 @@ export class ApiClient {
     return this.get(`/api/context-graph/${encodeURIComponent(contextGraphId)}/participants`);
   }
 
-  async registerKafkaEndpoint(request: {
-    contextGraphId: string;
-    broker: string;
-    topic: string;
-    messageFormat: string;
-  }): Promise<{
+  async registerKafkaEndpoint(
+    request:
+      | {
+          contextGraphId: string;
+          broker: string;
+          topic: string;
+          messageFormat: string;
+        }
+      | {
+          useLocalCg: true;
+          broker: string;
+          topic: string;
+          messageFormat: string;
+        },
+  ): Promise<{
     uri: string;
     contextGraphId: string;
+    cgScope: 'local' | 'shared';
   }> {
     return this.post('/api/kafka/endpoint', request);
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { readFileSync, existsSync } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { spawn, execSync } from 'node:child_process';
@@ -1733,8 +1733,17 @@ const kafkaEndpointCmd = kafkaCmd
 kafkaEndpointCmd
   .command('register')
   .description('Register a Kafka topic endpoint as a knowledge asset in a context graph (named or kafka-local)')
-  .option('--cg <id>', 'Target named context graph (mutually exclusive with --local)')
-  .option('--local', 'Publish into the node-local "kafka-local" free CG (mutually exclusive with --cg)')
+  // Mutual exclusion is wired declaratively via `Option#conflicts` so the
+  // pairing lives next to the option definition. commander throws before
+  // the action runs if both --cg and --local are passed.
+  .addOption(
+    new Option('--cg <id>', 'Target named context graph (mutually exclusive with --local)')
+      .conflicts('local'),
+  )
+  .addOption(
+    new Option('--local', 'Publish into the node-local "kafka-local" free CG (mutually exclusive with --cg)')
+      .conflicts('cg'),
+  )
   .requiredOption('--broker <host:port>', 'Kafka broker host:port')
   .requiredOption('--topic <name>', 'Kafka topic name')
   .option('--format <mime>', 'Kafka message format MIME type', 'application/json')
@@ -1746,10 +1755,11 @@ kafkaEndpointCmd
     const cgId = typeof opts.cg === 'string' ? opts.cg : undefined;
     const useLocal = opts.local === true;
 
-    // Mutual-exclusion is enforced at the parser level via .conflicts() below
-    // (commander throws before this action runs). The "neither" case is the
-    // only thing left to guard here: commander treats both options as
-    // optional, so we check that exactly one is set.
+    // Mutual-exclusion is enforced at the parser level via Option#conflicts
+    // on the addOption() declarations above (commander throws before this
+    // action runs). The "neither" case is the only thing left to guard here:
+    // commander treats both options as optional, so we check that exactly
+    // one is set.
     if (!cgId && !useLocal) {
       console.error(
         'Pass exactly one of "--cg <id>" (publish into a named shared CG) ' +
@@ -1783,17 +1793,6 @@ kafkaEndpointCmd
       process.exit(1);
     }
   });
-
-// commander supports parser-level mutual exclusion via .conflicts(). Looking
-// up the option object after the chain because commander returns the command
-// instance from .option().
-const kafkaRegisterCmd = kafkaEndpointCmd.commands.find((c) => c.name() === 'register');
-if (kafkaRegisterCmd) {
-  const cgOption = kafkaRegisterCmd.options.find((o) => o.long === '--cg');
-  const localOption = kafkaRegisterCmd.options.find((o) => o.long === '--local');
-  cgOption?.conflicts('local');
-  localOption?.conflicts('cg');
-}
 
 // ─── dkg openclaw ───────────────────────────────────────────────────
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1725,30 +1725,75 @@ const kafkaEndpointCmd = kafkaCmd
   .command('endpoint')
   .description('Kafka topic endpoint operations');
 
+// ADR-0004: explicit local-vs-shared CG choice. The caller must pick
+// `--cg <id>` (publish into a named shared CG) or `--local` (publish into the
+// node-local "kafka-local" free CG, lazy-created on first use). Passing
+// neither — or both — is rejected by commander before any network call so
+// the user gets a clean error pre-network.
 kafkaEndpointCmd
   .command('register')
-  .description('Register a Kafka topic endpoint as a knowledge asset in a named context graph')
-  .requiredOption('--cg <id>', 'Target context graph')
+  .description('Register a Kafka topic endpoint as a knowledge asset in a context graph (named or kafka-local)')
+  .option('--cg <id>', 'Target named context graph (mutually exclusive with --local)')
+  .option('--local', 'Publish into the node-local "kafka-local" free CG (mutually exclusive with --cg)')
   .requiredOption('--broker <host:port>', 'Kafka broker host:port')
   .requiredOption('--topic <name>', 'Kafka topic name')
   .option('--format <mime>', 'Kafka message format MIME type', 'application/json')
+  .addHelpText(
+    'after',
+    '\nExactly one of --cg or --local must be passed. There is no implicit default.',
+  )
   .action(async (opts: ActionOpts) => {
+    const cgId = typeof opts.cg === 'string' ? opts.cg : undefined;
+    const useLocal = opts.local === true;
+
+    // Mutual-exclusion is enforced at the parser level via .conflicts() below
+    // (commander throws before this action runs). The "neither" case is the
+    // only thing left to guard here: commander treats both options as
+    // optional, so we check that exactly one is set.
+    if (!cgId && !useLocal) {
+      console.error(
+        'Pass exactly one of "--cg <id>" (publish into a named shared CG) ' +
+        'or "--local" (publish into the local "kafka-local" free CG).',
+      );
+      process.exit(1);
+    }
+
     try {
       const client = await ApiClient.connect();
-      const result = await client.registerKafkaEndpoint({
-        contextGraphId: opts.cg,
-        broker: opts.broker,
-        topic: opts.topic,
-        messageFormat: opts.format,
-      });
+      const request = useLocal
+        ? {
+            useLocalCg: true as const,
+            broker: opts.broker,
+            topic: opts.topic,
+            messageFormat: opts.format,
+          }
+        : {
+            contextGraphId: cgId!,
+            broker: opts.broker,
+            topic: opts.topic,
+            messageFormat: opts.format,
+          };
+      const result = await client.registerKafkaEndpoint(request);
       console.log('Kafka endpoint registered:');
       console.log(`  URI:            ${result.uri}`);
       console.log(`  Context graph:  ${result.contextGraphId}`);
+      console.log(`  CG scope:       ${result.cgScope}`);
     } catch (err) {
       console.error(toErrorMessage(err));
       process.exit(1);
     }
   });
+
+// commander supports parser-level mutual exclusion via .conflicts(). Looking
+// up the option object after the chain because commander returns the command
+// instance from .option().
+const kafkaRegisterCmd = kafkaEndpointCmd.commands.find((c) => c.name() === 'register');
+if (kafkaRegisterCmd) {
+  const cgOption = kafkaRegisterCmd.options.find((o) => o.long === '--cg');
+  const localOption = kafkaRegisterCmd.options.find((o) => o.long === '--local');
+  cgOption?.conflicts('local');
+  localOption?.conflicts('cg');
+}
 
 // ─── dkg openclaw ───────────────────────────────────────────────────
 

--- a/packages/cli/src/daemon/routes/kafka-adapters.ts
+++ b/packages/cli/src/daemon/routes/kafka-adapters.ts
@@ -43,6 +43,7 @@ export function kafkaLocalCgFromAgent(
 ): LocalCgPrimitive {
   return {
     contextGraphExists: (id) => agent.contextGraphExists(id),
+    isPrivateContextGraph: (id) => agent.isPrivateContextGraph(id),
     createPrivateContextGraph: (opts) =>
       agent.createContextGraph({
         ...opts,

--- a/packages/cli/src/daemon/routes/kafka-adapters.ts
+++ b/packages/cli/src/daemon/routes/kafka-adapters.ts
@@ -28,8 +28,14 @@ export function kafkaPublisherFromAgent(agent: DKGAgent): KafkaEndpointPublisher
 
 /**
  * Adapts the agent's free-CG surface to the `LocalCgPrimitive` shape the
- * `kafka-local` ensurer consumes. `callerAgentAddress` is threaded into
+ * kafka-local ensurer consumes. `callerAgentAddress` is threaded into
  * `createContextGraph` so the create runs under the requesting agent.
+ *
+ * The `private: true` flag is hardcoded HERE — the kafka package never sees
+ * the boolean, so a future refactor cannot accidentally drop it. Without
+ * `private: true`, the agent auto-subscribes to the CG's gossip topic and
+ * broadcasts the CG definition (`dkg-agent.ts:3837`); the slice-02 spec
+ * requires kafka-local to be truly node-local, which means no gossip.
  */
 export function kafkaLocalCgFromAgent(
   agent: DKGAgent,
@@ -37,7 +43,11 @@ export function kafkaLocalCgFromAgent(
 ): LocalCgPrimitive {
   return {
     contextGraphExists: (id) => agent.contextGraphExists(id),
-    createContextGraph: (opts) =>
-      agent.createContextGraph({ ...opts, callerAgentAddress }),
+    createPrivateContextGraph: (opts) =>
+      agent.createContextGraph({
+        ...opts,
+        private: true,
+        callerAgentAddress,
+      }),
   };
 }

--- a/packages/cli/src/daemon/routes/kafka-adapters.ts
+++ b/packages/cli/src/daemon/routes/kafka-adapters.ts
@@ -1,0 +1,43 @@
+// Adapters that bind the daemon's `DKGAgent` to the small interfaces the
+// `@origintrail-official/dkg-kafka` package depends on. Kept on the CLI side
+// because the agent type lives here; the kafka package stays agent-agnostic.
+//
+// Slice 02 only consumes these from `routes/kafka.ts`; later kafka routes
+// (discover, revoke) will reuse them — one home, one responsibility each.
+
+import type { DKGAgent } from '@origintrail-official/dkg-agent';
+import type {
+  KafkaEndpointPublisher,
+  LocalCgPrimitive,
+} from '@origintrail-official/dkg-kafka';
+
+/**
+ * Wraps `agent.publish` with the daemon's `{ public: content }` envelope so
+ * the kafka package can stay envelope-agnostic.
+ */
+export function kafkaPublisherFromAgent(agent: DKGAgent): KafkaEndpointPublisher {
+  return {
+    async publish(contextGraphId, knowledgeAsset) {
+      await agent.publish(
+        contextGraphId,
+        { public: knowledgeAsset } as Record<string, unknown>,
+      );
+    },
+  };
+}
+
+/**
+ * Adapts the agent's free-CG surface to the `LocalCgPrimitive` shape the
+ * `kafka-local` ensurer consumes. `callerAgentAddress` is threaded into
+ * `createContextGraph` so the create runs under the requesting agent.
+ */
+export function kafkaLocalCgFromAgent(
+  agent: DKGAgent,
+  callerAgentAddress: string,
+): LocalCgPrimitive {
+  return {
+    contextGraphExists: (id) => agent.contextGraphExists(id),
+    createContextGraph: (opts) =>
+      agent.createContextGraph({ ...opts, callerAgentAddress }),
+  };
+}

--- a/packages/cli/src/daemon/routes/kafka.ts
+++ b/packages/cli/src/daemon/routes/kafka.ts
@@ -1,7 +1,7 @@
 import { jsonResponse, readBody, isValidContextGraphId } from '../http-utils.js';
 import type { RequestContext } from './context.js';
 import {
-  ensureKafkaLocalCg,
+  createKafkaLocalCgEnsurer,
   registerKafkaEndpoint,
   validateContextGraphSelection,
   type KafkaEndpointPublisher,
@@ -74,16 +74,19 @@ export async function handleKafkaRoutes(ctx: RequestContext): Promise<void> {
 
     // Bind the V10 free-CG primitive to the local-cg module's expected shape.
     // The `kafka-local` CG is a free CG: created locally via
-    // `agent.createContextGraph` with no on-chain registration.
-    const ensureLocalCg = () =>
-      ensureKafkaLocalCg({
-        contextGraphExists: (id) => agent.contextGraphExists(id),
-        createContextGraph: (opts) =>
-          agent.createContextGraph({
-            ...opts,
-            callerAgentAddress: requestAgentAddress,
-          }),
-      });
+    // `agent.createContextGraph` with no on-chain registration. The ensurer
+    // owns its own in-flight gate (per-request scope is fine — we'd benefit
+    // from hoisting it per-agent if concurrent registrations on the same
+    // agent become hot, but the underlying "already exists" guard plus the
+    // exists-check make repeat creates cheap and idempotent regardless).
+    const ensureLocalCg = createKafkaLocalCgEnsurer({
+      contextGraphExists: (id) => agent.contextGraphExists(id),
+      createContextGraph: (opts) =>
+        agent.createContextGraph({
+          ...opts,
+          callerAgentAddress: requestAgentAddress,
+        }),
+    });
 
     const result = await registerKafkaEndpoint({
       selection,

--- a/packages/cli/src/daemon/routes/kafka.ts
+++ b/packages/cli/src/daemon/routes/kafka.ts
@@ -1,7 +1,9 @@
-import { jsonResponse, readBody, validateRequiredContextGraphId } from '../http-utils.js';
+import { jsonResponse, readBody, isValidContextGraphId } from '../http-utils.js';
 import type { RequestContext } from './context.js';
 import {
+  ensureKafkaLocalCg,
   registerKafkaEndpoint,
+  validateContextGraphSelection,
   type KafkaEndpointPublisher,
 } from '@origintrail-official/dkg-kafka';
 
@@ -29,15 +31,28 @@ export async function handleKafkaRoutes(ctx: RequestContext): Promise<void> {
 
     const {
       contextGraphId,
+      useLocalCg,
       broker,
       topic,
       messageFormat,
     } = parsed as Record<string, unknown>;
 
-    if (!validateRequiredContextGraphId(contextGraphId, res)) {
-      return;
+    // ADR-0004: explicit local-vs-shared CG choice. The pure validation
+    // module enforces "exactly one of contextGraphId or useLocalCg" — neither
+    // and both are 4xx with a clear message naming both options. We rethrow
+    // its message into the daemon's standard error envelope.
+    let selection;
+    try {
+      selection = validateContextGraphSelection({ contextGraphId, useLocalCg });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return jsonResponse(res, 400, { error: message });
     }
-    const targetContextGraphId = contextGraphId as string;
+
+    if (selection.kind === 'shared' && !isValidContextGraphId(selection.contextGraphId)) {
+      return jsonResponse(res, 400, { error: 'Invalid "contextGraphId"' });
+    }
+
     if (!isNonEmptyString(broker)) {
       return jsonResponse(res, 400, { error: '"broker" must be a non-empty string' });
     }
@@ -57,13 +72,27 @@ export async function handleKafkaRoutes(ctx: RequestContext): Promise<void> {
       },
     };
 
+    // Bind the V10 free-CG primitive to the local-cg module's expected shape.
+    // The `kafka-local` CG is a free CG: created locally via
+    // `agent.createContextGraph` with no on-chain registration.
+    const ensureLocalCg = () =>
+      ensureKafkaLocalCg({
+        contextGraphExists: (id) => agent.contextGraphExists(id),
+        createContextGraph: (opts) =>
+          agent.createContextGraph({
+            ...opts,
+            callerAgentAddress: requestAgentAddress,
+          }),
+      });
+
     const result = await registerKafkaEndpoint({
-      contextGraphId: targetContextGraphId,
+      selection,
       owner: requestAgentAddress.toLowerCase(),
       broker,
       topic,
       messageFormat,
       publisher,
+      ensureLocalCg,
     });
 
     return jsonResponse(res, 200, result);

--- a/packages/cli/src/daemon/routes/kafka.ts
+++ b/packages/cli/src/daemon/routes/kafka.ts
@@ -4,8 +4,11 @@ import {
   createKafkaLocalCgEnsurer,
   registerKafkaEndpoint,
   validateContextGraphSelection,
-  type KafkaEndpointPublisher,
 } from '@origintrail-official/dkg-kafka';
+import {
+  kafkaLocalCgFromAgent,
+  kafkaPublisherFromAgent,
+} from './kafka-adapters.js';
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
@@ -37,10 +40,8 @@ export async function handleKafkaRoutes(ctx: RequestContext): Promise<void> {
       messageFormat,
     } = parsed as Record<string, unknown>;
 
-    // ADR-0004: explicit local-vs-shared CG choice. The pure validation
-    // module enforces "exactly one of contextGraphId or useLocalCg" — neither
-    // and both are 4xx with a clear message naming both options. We rethrow
-    // its message into the daemon's standard error envelope.
+    // ADR-0004: explicit local-vs-shared CG choice. We surface the pure
+    // validator's error message via the daemon's standard 400 envelope.
     let selection;
     try {
       selection = validateContextGraphSelection({ contextGraphId, useLocalCg });
@@ -63,39 +64,16 @@ export async function handleKafkaRoutes(ctx: RequestContext): Promise<void> {
       return jsonResponse(res, 400, { error: '"messageFormat" must be a non-empty string' });
     }
 
-    const publisher: KafkaEndpointPublisher = {
-      async publish(cgId, content) {
-        await agent.publish(
-          cgId,
-          { public: content } as Record<string, unknown>,
-        );
-      },
-    };
-
-    // Bind the V10 free-CG primitive to the local-cg module's expected shape.
-    // The `kafka-local` CG is a free CG: created locally via
-    // `agent.createContextGraph` with no on-chain registration. The ensurer
-    // owns its own in-flight gate (per-request scope is fine — we'd benefit
-    // from hoisting it per-agent if concurrent registrations on the same
-    // agent become hot, but the underlying "already exists" guard plus the
-    // exists-check make repeat creates cheap and idempotent regardless).
-    const ensureLocalCg = createKafkaLocalCgEnsurer({
-      contextGraphExists: (id) => agent.contextGraphExists(id),
-      createContextGraph: (opts) =>
-        agent.createContextGraph({
-          ...opts,
-          callerAgentAddress: requestAgentAddress,
-        }),
-    });
-
     const result = await registerKafkaEndpoint({
       selection,
       owner: requestAgentAddress.toLowerCase(),
       broker,
       topic,
       messageFormat,
-      publisher,
-      ensureLocalCg,
+      publisher: kafkaPublisherFromAgent(agent),
+      ensureLocalCg: createKafkaLocalCgEnsurer(
+        kafkaLocalCgFromAgent(agent, requestAgentAddress),
+      ),
     });
 
     return jsonResponse(res, 200, result);

--- a/packages/cli/src/daemon/routes/kafka.ts
+++ b/packages/cli/src/daemon/routes/kafka.ts
@@ -73,8 +73,11 @@ export async function handleKafkaRoutes(ctx: RequestContext): Promise<void> {
       publisher: kafkaPublisherFromAgent(agent),
       // Fresh ensurer per request; hoisting per-agent is a deferred optimization
       // (the agent's "already exists" guard plus the exists-check make repeats cheap).
+      // The peer-id scopes the kafka-local CG id per node — `kafka-local-{peerId}` —
+      // so two nodes cannot collide on the literal "kafka-local" id.
       ensureLocalCg: createKafkaLocalCgEnsurer(
         kafkaLocalCgFromAgent(agent, requestAgentAddress),
+        agent.peerId,
       ),
     });
 

--- a/packages/cli/src/daemon/routes/kafka.ts
+++ b/packages/cli/src/daemon/routes/kafka.ts
@@ -71,6 +71,8 @@ export async function handleKafkaRoutes(ctx: RequestContext): Promise<void> {
       topic,
       messageFormat,
       publisher: kafkaPublisherFromAgent(agent),
+      // Fresh ensurer per request; hoisting per-agent is a deferred optimization
+      // (the agent's "already exists" guard plus the exists-check make repeats cheap).
       ensureLocalCg: createKafkaLocalCgEnsurer(
         kafkaLocalCgFromAgent(agent, requestAgentAddress),
       ),

--- a/packages/cli/test/kafka-cli-smoke.test.ts
+++ b/packages/cli/test/kafka-cli-smoke.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, afterAll, describe, expect, it } from 'vitest';
+import { beforeAll, afterAll, beforeEach, describe, expect, it } from 'vitest';
 import { createServer } from 'node:http';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -18,6 +18,7 @@ describe.sequential('kafka CLI smoke', () => {
   let smokeApiPort: string;
   let lastBody = '';
   let lastAuthHeader = '';
+  let nextResponse: { status: number; body: unknown } = { status: 200, body: {} };
 
   beforeAll(async () => {
     dkgHome = await mkdtemp(join(tmpdir(), 'dkg-kafka-cli-'));
@@ -38,11 +39,8 @@ describe.sequential('kafka CLI smoke', () => {
           chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
         }
         lastBody = Buffer.concat(chunks).toString('utf8');
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          uri: 'urn:dkg:kafka-endpoint:0xabc:hash',
-          contextGraphId: 'devnet-test',
-        }));
+        res.writeHead(nextResponse.status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(nextResponse.body));
         return;
       }
 
@@ -60,12 +58,25 @@ describe.sequential('kafka CLI smoke', () => {
     });
   });
 
+  beforeEach(() => {
+    lastBody = '';
+    lastAuthHeader = '';
+    nextResponse = {
+      status: 200,
+      body: {
+        uri: 'urn:dkg:kafka-endpoint:0xabc:hash',
+        contextGraphId: 'devnet-test',
+        cgScope: 'shared',
+      },
+    };
+  });
+
   afterAll(async () => {
     await new Promise<void>((resolve) => server.close(() => resolve()));
     await rm(dkgHome, { recursive: true, force: true });
   });
 
-  it('registers a Kafka endpoint through the CLI', async () => {
+  it('registers a Kafka endpoint through the CLI with --cg', async () => {
     const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: smokeApiPort };
 
     const result = await execFileAsync('node', [
@@ -84,6 +95,7 @@ describe.sequential('kafka CLI smoke', () => {
     expect(result.stdout).toContain('Kafka endpoint registered:');
     expect(result.stdout).toContain('urn:dkg:kafka-endpoint:0xabc:hash');
     expect(result.stdout).toContain('devnet-test');
+    expect(result.stdout).toContain('CG scope:       shared');
     expect(lastAuthHeader).toBe('Bearer smoke-token');
     expect(JSON.parse(lastBody)).toEqual({
       contextGraphId: 'devnet-test',
@@ -91,5 +103,89 @@ describe.sequential('kafka CLI smoke', () => {
       topic: 'orders.created',
       messageFormat: 'application/json',
     });
+  }, 15000);
+
+  it('registers a Kafka endpoint through the CLI with --local', async () => {
+    nextResponse = {
+      status: 200,
+      body: {
+        uri: 'urn:dkg:kafka-endpoint:0xabc:hash',
+        contextGraphId: 'kafka-local',
+        cgScope: 'local',
+      },
+    };
+    const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: smokeApiPort };
+
+    const result = await execFileAsync('node', [
+      CLI_ENTRY,
+      'kafka',
+      'endpoint',
+      'register',
+      '--local',
+      '--broker',
+      'kafka.example.com:9092',
+      '--topic',
+      'orders.created',
+    ], { env });
+
+    expect(result.stdout).toContain('Kafka endpoint registered:');
+    expect(result.stdout).toContain('urn:dkg:kafka-endpoint:0xabc:hash');
+    expect(result.stdout).toContain('kafka-local');
+    expect(result.stdout).toContain('CG scope:       local');
+    expect(JSON.parse(lastBody)).toEqual({
+      useLocalCg: true,
+      broker: 'kafka.example.com:9092',
+      topic: 'orders.created',
+      messageFormat: 'application/json',
+    });
+  }, 15000);
+
+  it('rejects --cg and --local together at the parser level (no network call)', async () => {
+    const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: smokeApiPort };
+    lastBody = '__no_request__';
+
+    await expect(
+      execFileAsync('node', [
+        CLI_ENTRY,
+        'kafka',
+        'endpoint',
+        'register',
+        '--cg',
+        'devnet-test',
+        '--local',
+        '--broker',
+        'kafka.example.com:9092',
+        '--topic',
+        'orders.created',
+      ], { env }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringMatching(/--cg.*--local|--local.*--cg/i),
+    });
+
+    expect(lastBody).toBe('__no_request__');
+  }, 15000);
+
+  it('rejects neither --cg nor --local at the action level (no network call)', async () => {
+    const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: smokeApiPort };
+    lastBody = '__no_request__';
+
+    await expect(
+      execFileAsync('node', [
+        CLI_ENTRY,
+        'kafka',
+        'endpoint',
+        'register',
+        '--broker',
+        'kafka.example.com:9092',
+        '--topic',
+        'orders.created',
+      ], { env }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringMatching(/--cg.*--local|--local.*--cg/),
+    });
+
+    expect(lastBody).toBe('__no_request__');
   }, 15000);
 });

--- a/packages/cli/test/kafka-cli-smoke.test.ts
+++ b/packages/cli/test/kafka-cli-smoke.test.ts
@@ -106,11 +106,16 @@ describe.sequential('kafka CLI smoke', () => {
   }, 15000);
 
   it('registers a Kafka endpoint through the CLI with --local', async () => {
+    // The daemon scopes the kafka-local CG id per-node as
+    // `kafka-local-{peerId}`. The smoke test mocks the daemon, so we choose
+    // a realistic prefixed value here and assert the CLI prints it back.
+    const stubPeerId = '12D3KooWStubPeerIdForSmokeTest';
+    const stubLocalId = `kafka-local-${stubPeerId}`;
     nextResponse = {
       status: 200,
       body: {
         uri: 'urn:dkg:kafka-endpoint:0xabc:hash',
-        contextGraphId: 'kafka-local',
+        contextGraphId: stubLocalId,
         cgScope: 'local',
       },
     };
@@ -130,7 +135,7 @@ describe.sequential('kafka CLI smoke', () => {
 
     expect(result.stdout).toContain('Kafka endpoint registered:');
     expect(result.stdout).toContain('urn:dkg:kafka-endpoint:0xabc:hash');
-    expect(result.stdout).toContain('kafka-local');
+    expect(result.stdout).toContain(stubLocalId);
     expect(result.stdout).toContain('CG scope:       local');
     expect(JSON.parse(lastBody)).toEqual({
       useLocalCg: true,

--- a/packages/kafka/src/endpoint.ts
+++ b/packages/kafka/src/endpoint.ts
@@ -1,5 +1,6 @@
 import { buildKafkaEndpointKnowledgeAsset } from './ka-builder.js';
 import { buildKafkaEndpointUri } from './uri.js';
+import type { KafkaContextGraphSelection } from './validation.js';
 
 /**
  * Dependency-inversion boundary: the kafka package needs something that can
@@ -15,24 +16,53 @@ export interface KafkaEndpointPublisher {
   ): Promise<unknown>;
 }
 
+export type CgScope = 'local' | 'shared';
+
 export interface RegisterKafkaEndpointInput {
-  contextGraphId: string;
+  /** Pre-validated selection produced by `validateContextGraphSelection`. */
+  selection: KafkaContextGraphSelection;
   owner: string;
   broker: string;
   topic: string;
   messageFormat: string;
   issuedAt?: string;
   publisher: KafkaEndpointPublisher;
+  /**
+   * Required when `selection.kind === 'local'`. Resolves the destination CG
+   * id by lazily creating `kafka-local` if needed. The orchestrator stays
+   * agent-agnostic by depending on this thunk rather than importing the V10
+   * primitive directly — see `local-cg.ts` for the concrete implementation
+   * the route handler binds.
+   */
+  ensureLocalCg?: () => Promise<string>;
 }
 
 export interface RegisterKafkaEndpointResult {
   uri: string;
   contextGraphId: string;
+  cgScope: CgScope;
 }
 
 export async function registerKafkaEndpoint(
   input: RegisterKafkaEndpointInput,
 ): Promise<RegisterKafkaEndpointResult> {
+  let resolvedContextGraphId: string;
+  let cgScope: CgScope;
+
+  if (input.selection.kind === 'shared') {
+    resolvedContextGraphId = input.selection.contextGraphId;
+    cgScope = 'shared';
+  } else {
+    if (!input.ensureLocalCg) {
+      throw new Error(
+        '"ensureLocalCg" is required when selection.kind is "local". ' +
+        'The route handler must bind a thunk that lazy-creates the kafka-local free CG.',
+      );
+    }
+    resolvedContextGraphId = await input.ensureLocalCg();
+    cgScope = 'local';
+  }
+
   const issuedAt = input.issuedAt ?? new Date().toISOString();
   const uri = buildKafkaEndpointUri(input);
   const knowledgeAsset = buildKafkaEndpointKnowledgeAsset({
@@ -43,10 +73,11 @@ export async function registerKafkaEndpoint(
     issuedAt,
   });
 
-  await input.publisher.publish(input.contextGraphId, knowledgeAsset);
+  await input.publisher.publish(resolvedContextGraphId, knowledgeAsset);
 
   return {
     uri,
-    contextGraphId: input.contextGraphId,
+    contextGraphId: resolvedContextGraphId,
+    cgScope,
   };
 }

--- a/packages/kafka/src/endpoint.ts
+++ b/packages/kafka/src/endpoint.ts
@@ -52,7 +52,10 @@ async function resolveSelection(
     return { contextGraphId: selection.contextGraphId, cgScope: 'shared' };
   }
   if (!ensureLocalCg) {
-    throw new Error('"ensureLocalCg" is required when selection.kind is "local".');
+    throw new Error(
+      '"ensureLocalCg" is required when selection.kind is "local". ' +
+      'The caller must bind a thunk that lazy-creates the kafka-local free CG.',
+    );
   }
   return { contextGraphId: await ensureLocalCg(), cgScope: 'local' };
 }

--- a/packages/kafka/src/endpoint.ts
+++ b/packages/kafka/src/endpoint.ts
@@ -1,4 +1,7 @@
-import { buildKafkaEndpointKnowledgeAsset } from './ka-builder.js';
+import {
+  buildKafkaEndpointKnowledgeAsset,
+  type KafkaEndpointKnowledgeAsset,
+} from './ka-builder.js';
 import { buildKafkaEndpointUri } from './uri.js';
 import type { KafkaContextGraphSelection } from './validation.js';
 
@@ -7,13 +10,11 @@ import type { KafkaContextGraphSelection } from './validation.js';
  * publish a JSON-LD knowledge asset. The package hands the bare KA across this
  * interface; envelope wrapping (e.g. `{ public: ... }`) belongs to the caller.
  */
-export type KafkaEndpointKnowledgeAsset = ReturnType<typeof buildKafkaEndpointKnowledgeAsset>;
-
 export interface KafkaEndpointPublisher {
   publish(
     contextGraphId: string,
     knowledgeAsset: KafkaEndpointKnowledgeAsset,
-  ): Promise<unknown>;
+  ): Promise<void>;
 }
 
 export type CgScope = 'local' | 'shared';
@@ -43,25 +44,26 @@ export interface RegisterKafkaEndpointResult {
   cgScope: CgScope;
 }
 
+async function resolveSelection(
+  selection: KafkaContextGraphSelection,
+  ensureLocalCg?: () => Promise<string>,
+): Promise<{ contextGraphId: string; cgScope: CgScope }> {
+  if (selection.kind === 'shared') {
+    return { contextGraphId: selection.contextGraphId, cgScope: 'shared' };
+  }
+  if (!ensureLocalCg) {
+    throw new Error('"ensureLocalCg" is required when selection.kind is "local".');
+  }
+  return { contextGraphId: await ensureLocalCg(), cgScope: 'local' };
+}
+
 export async function registerKafkaEndpoint(
   input: RegisterKafkaEndpointInput,
 ): Promise<RegisterKafkaEndpointResult> {
-  let resolvedContextGraphId: string;
-  let cgScope: CgScope;
-
-  if (input.selection.kind === 'shared') {
-    resolvedContextGraphId = input.selection.contextGraphId;
-    cgScope = 'shared';
-  } else {
-    if (!input.ensureLocalCg) {
-      throw new Error(
-        '"ensureLocalCg" is required when selection.kind is "local". ' +
-        'The route handler must bind a thunk that lazy-creates the kafka-local free CG.',
-      );
-    }
-    resolvedContextGraphId = await input.ensureLocalCg();
-    cgScope = 'local';
-  }
+  const { contextGraphId, cgScope } = await resolveSelection(
+    input.selection,
+    input.ensureLocalCg,
+  );
 
   const issuedAt = input.issuedAt ?? new Date().toISOString();
   const uri = buildKafkaEndpointUri(input);
@@ -73,11 +75,7 @@ export async function registerKafkaEndpoint(
     issuedAt,
   });
 
-  await input.publisher.publish(resolvedContextGraphId, knowledgeAsset);
+  await input.publisher.publish(contextGraphId, knowledgeAsset);
 
-  return {
-    uri,
-    contextGraphId: resolvedContextGraphId,
-    cgScope,
-  };
+  return { uri, contextGraphId, cgScope };
 }

--- a/packages/kafka/src/index.ts
+++ b/packages/kafka/src/index.ts
@@ -1,3 +1,5 @@
 export * from './uri.js';
 export * from './ka-builder.js';
 export * from './endpoint.js';
+export * from './validation.js';
+export * from './local-cg.js';

--- a/packages/kafka/src/ka-builder.ts
+++ b/packages/kafka/src/ka-builder.ts
@@ -15,7 +15,21 @@ export interface BuildKafkaEndpointKnowledgeAssetInput {
   issuedAt: string;
 }
 
-export function buildKafkaEndpointKnowledgeAsset(input: BuildKafkaEndpointKnowledgeAssetInput) {
+export interface KafkaEndpointKnowledgeAsset {
+  '@context': typeof KAFKA_ENDPOINT_CONTEXT;
+  '@id': string;
+  '@type': readonly [string, string];
+  'dcat:endpointURL': { '@id': string };
+  'dkg:broker': string;
+  'dkg:topic': string;
+  'dkg:messageFormat': string;
+  'dct:publisher': { '@id': string };
+  'dct:issued': { '@value': string; '@type': 'xsd:dateTime' };
+}
+
+export function buildKafkaEndpointKnowledgeAsset(
+  input: BuildKafkaEndpointKnowledgeAssetInput,
+): KafkaEndpointKnowledgeAsset {
   const owner = input.owner.toLowerCase();
 
   return {

--- a/packages/kafka/src/local-cg.ts
+++ b/packages/kafka/src/local-cg.ts
@@ -13,6 +13,11 @@
 //     id without re-issuing the create. This is enforced by an in-process
 //     promise gate, not by relying on the underlying store's "already exists"
 //     guard alone (the guard is the second-line defence).
+//
+// The gate must be bound to a specific `cg` primitive so two different
+// agents (e.g. multiple sub-processes sharing this module) don't accidentally
+// serialize against each other. `createKafkaLocalCgEnsurer(cg)` returns a
+// thunk whose closure owns its own gate — see the factory below.
 
 const KAFKA_LOCAL_DEFAULT_NAME = 'Kafka Local';
 
@@ -28,17 +33,29 @@ export interface LocalCgPrimitive {
   createContextGraph(opts: { id: string; name: string }): Promise<void>;
 }
 
-// In-flight promise gate. Concurrent callers that arrive while a create is
-// running await the same promise instead of racing to issue parallel creates
-// against the underlying store.
-let inFlight: Promise<string> | null = null;
+/**
+ * Create an ensurer thunk bound to a specific V10 free-CG primitive. The
+ * returned function is a single-shot gate per concurrent burst: parallel
+ * callers within the same burst share one in-flight create; once that create
+ * resolves the gate clears in `finally`, so a future call (e.g. after the
+ * local CG was deleted out from under the process) re-runs the exists-check
+ * and short-circuits when the CG is present.
+ *
+ * The gate lives in this closure rather than at module scope so each
+ * primitive instance gets its own gate — this prevents hidden coupling where
+ * two callers with different `cg` primitives would otherwise silently share
+ * one gate keyed only on the literal `kafka-local`.
+ */
+export function createKafkaLocalCgEnsurer(
+  cg: LocalCgPrimitive,
+): () => Promise<string> {
+  let inFlight: Promise<string> | null = null;
 
-export async function ensureKafkaLocalCg(cg: LocalCgPrimitive): Promise<string> {
-  if (inFlight) {
-    return inFlight;
-  }
-  inFlight = (async () => {
-    try {
+  return async function ensureKafkaLocalCg(): Promise<string> {
+    if (inFlight) {
+      return inFlight;
+    }
+    inFlight = (async () => {
       const exists = await cg.contextGraphExists(KAFKA_LOCAL_CG_ID);
       if (exists) {
         return KAFKA_LOCAL_CG_ID;
@@ -60,13 +77,13 @@ export async function ensureKafkaLocalCg(cg: LocalCgPrimitive): Promise<string> 
         }
       }
       return KAFKA_LOCAL_CG_ID;
-    } finally {
+    })().finally(() => {
       // Clear the gate so future startups (e.g. after the local CG was
       // deleted out from under us) re-run the exists check rather than
       // returning a cached id from a stale process state. Effectively a
       // single-shot gate per concurrent burst.
       inFlight = null;
-    }
-  })();
-  return inFlight;
+    });
+    return inFlight;
+  };
 }

--- a/packages/kafka/src/local-cg.ts
+++ b/packages/kafka/src/local-cg.ts
@@ -1,0 +1,72 @@
+// Lazy-creation orchestrator for the node-local "kafka-local" free CG.
+//
+// "Free CG" = local-only context graph, never registered on-chain. Created via
+// the V10 `agent.createContextGraph()` primitive without any
+// `agent.registerContextGraph()` follow-up. The id `kafka-local` is reserved
+// at the package level: callers must not pick `kafka-local` as a shared CG id.
+//
+// Idempotency contract:
+//   - First call when the CG is missing → creates it once.
+//   - Subsequent calls → return the id without touching the store.
+//   - Concurrent calls during a single daemon startup → exactly one create
+//     wins; the others observe the in-flight create and resolve to the same
+//     id without re-issuing the create. This is enforced by an in-process
+//     promise gate, not by relying on the underlying store's "already exists"
+//     guard alone (the guard is the second-line defence).
+
+const KAFKA_LOCAL_DEFAULT_NAME = 'Kafka Local';
+
+export const KAFKA_LOCAL_CG_ID = 'kafka-local';
+
+/**
+ * Minimal V10 free-CG creation surface this module needs. Injected as a
+ * dependency so unit tests can run without spinning up a real DKG agent and
+ * so the same code path serves both production (real agent) and tests.
+ */
+export interface LocalCgPrimitive {
+  contextGraphExists(id: string): Promise<boolean>;
+  createContextGraph(opts: { id: string; name: string }): Promise<void>;
+}
+
+// In-flight promise gate. Concurrent callers that arrive while a create is
+// running await the same promise instead of racing to issue parallel creates
+// against the underlying store.
+let inFlight: Promise<string> | null = null;
+
+export async function ensureKafkaLocalCg(cg: LocalCgPrimitive): Promise<string> {
+  if (inFlight) {
+    return inFlight;
+  }
+  inFlight = (async () => {
+    try {
+      const exists = await cg.contextGraphExists(KAFKA_LOCAL_CG_ID);
+      if (exists) {
+        return KAFKA_LOCAL_CG_ID;
+      }
+      try {
+        await cg.createContextGraph({
+          id: KAFKA_LOCAL_CG_ID,
+          name: KAFKA_LOCAL_DEFAULT_NAME,
+        });
+      } catch (err: unknown) {
+        // Race tolerance: another path (e.g. a different in-flight register
+        // call from a previous run already past its gate, or external
+        // creation by /api/context-graph/create) may have created
+        // kafka-local between our exists-check and our create. The agent's
+        // own "already exists" guard surfaces with this message.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!/already exists/i.test(msg)) {
+          throw err;
+        }
+      }
+      return KAFKA_LOCAL_CG_ID;
+    } finally {
+      // Clear the gate so future startups (e.g. after the local CG was
+      // deleted out from under us) re-run the exists check rather than
+      // returning a cached id from a stale process state. Effectively a
+      // single-shot gate per concurrent burst.
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}

--- a/packages/kafka/src/local-cg.ts
+++ b/packages/kafka/src/local-cg.ts
@@ -1,33 +1,66 @@
-// Lazy-creation orchestrator for the node-local "kafka-local" free CG.
+// Lazy-creation orchestrator for the node-local kafka-local free CG.
 //
 // "Free CG" = local-only context graph, never registered on-chain. Created
-// via `agent.createContextGraph()` with no `registerContextGraph()` follow-up.
-// The id `kafka-local` is reserved at the package level: callers must not
-// pick it as a shared CG id.
+// via `agent.createContextGraph({ private: true })` so the V10 agent skips
+// gossip subscription/broadcast (`dkg-agent.ts:3837` flips `subscribed` off
+// when `private: true`). Hardcoding `private: true` at the route adapter is
+// what makes the CG truly node-local — without it, the agent would still
+// auto-subscribe to its own gossip topics and leak the CG definition.
+//
+// Per-node uniqueness: the CG id is `kafka-local-{peerId}` rather than a bare
+// `kafka-local`. This makes a cross-node id collision impossible by
+// construction — two nodes literally cannot pick the same id — and removes
+// the need for a post-create privacy probe. We pick the libp2p peer-id (not
+// a wallet address) because peer-id is the canonical, stable node identity:
+// `DKG_CREATOR` already records `did:dkg:agent:{peerId}` and a node may run
+// multiple operational wallets that rotate independently.
+//
+// Promotion path (informational): a node-local kafka-local CG can be promoted
+// in place via the existing V10 primitives — `dkg assertion promote` moves
+// quads from the assertion graph (LWM) into the shared-memory graph (SWM)
+// inside the SAME CG, and `dkg context-graph register` anchors the CG
+// on-chain and flips `subscribed: false → true` (`dkg-agent.ts:4227-4236`),
+// at which point SWM data starts flowing to peers. Slice 02 ships no
+// promotion code of its own — the platform already covers it.
 
-export const KAFKA_LOCAL_CG_ID = 'kafka-local';
-
-const KAFKA_LOCAL_DEFAULT_NAME = 'Kafka Local';
+export const KAFKA_LOCAL_CG_ID_PREFIX = 'kafka-local-';
+export const KAFKA_LOCAL_CG_BARE_ID = 'kafka-local';
 
 /**
- * Minimal V10 free-CG creation surface this module needs. Injected so unit
- * tests run without a real DKG agent and the same code path serves both.
+ * Builds the per-node kafka-local CG id from a libp2p peer-id. Two nodes
+ * cannot collide on this id by construction.
  */
-export interface LocalCgPrimitive {
-  contextGraphExists(id: string): Promise<boolean>;
-  createContextGraph(opts: { id: string; name: string }): Promise<void>;
+export function kafkaLocalCgIdFor(peerId: string): string {
+  return `${KAFKA_LOCAL_CG_ID_PREFIX}${peerId}`;
 }
 
 /**
- * Returns a thunk that ensures `kafka-local` exists and resolves to its id.
- * Concurrent callers in a burst share one in-flight create; the gate clears
- * in `finally` so a later call after deletion re-runs the exists-check. The
- * gate lives in this closure so two ensurers built from different primitives
- * don't accidentally share state keyed only on the literal `kafka-local`.
+ * Minimal V10 free-CG creation surface this module needs. Injected so unit
+ * tests run without a real DKG agent and the same code path serves both. The
+ * `createPrivateContextGraph` name is deliberate — the privacy guarantee is
+ * encoded in the method name rather than a boolean flag, so a future caller
+ * cannot accidentally drop `private: true` at the boundary.
+ */
+export interface LocalCgPrimitive {
+  contextGraphExists(id: string): Promise<boolean>;
+  createPrivateContextGraph(opts: { id: string; name: string }): Promise<void>;
+}
+
+/**
+ * Returns a thunk that ensures the per-node kafka-local CG exists and resolves
+ * to its id. Concurrent callers in a burst share one in-flight create; the
+ * gate clears in `finally` so a later call after deletion re-runs the
+ * exists-check. The gate lives in this closure so two ensurers built from
+ * different primitives don't accidentally share state keyed only on the id.
  */
 export function createKafkaLocalCgEnsurer(
   cg: LocalCgPrimitive,
+  peerId: string,
 ): () => Promise<string> {
+  const id = kafkaLocalCgIdFor(peerId);
+  // Truncate the peer-id in the human-facing CG name so operator UIs don't
+  // get a 50-char id glued onto every label. The id itself stays full-length.
+  const displayName = `Kafka Local (${peerId.slice(0, 12)}…)`;
   let inFlight: Promise<string> | null = null;
 
   return async function ensureKafkaLocalCg(): Promise<string> {
@@ -35,25 +68,22 @@ export function createKafkaLocalCgEnsurer(
       return inFlight;
     }
     inFlight = (async () => {
-      const exists = await cg.contextGraphExists(KAFKA_LOCAL_CG_ID);
+      const exists = await cg.contextGraphExists(id);
       if (exists) {
-        return KAFKA_LOCAL_CG_ID;
+        return id;
       }
       try {
-        await cg.createContextGraph({
-          id: KAFKA_LOCAL_CG_ID,
-          name: KAFKA_LOCAL_DEFAULT_NAME,
-        });
+        await cg.createPrivateContextGraph({ id, name: displayName });
       } catch (err: unknown) {
-        // Race tolerance: another path (peer sync, parallel CLI) may have
-        // created `kafka-local` between our exists-check and our create.
+        // Race tolerance: another path (parallel CLI, restart-replay) may
+        // have created the CG between our exists-check and our create.
         // The agent surfaces this with an "already exists" message.
         const msg = err instanceof Error ? err.message : String(err);
         if (!/already exists/i.test(msg)) {
           throw err;
         }
       }
-      return KAFKA_LOCAL_CG_ID;
+      return id;
     })().finally(() => {
       inFlight = null;
     });

--- a/packages/kafka/src/local-cg.ts
+++ b/packages/kafka/src/local-cg.ts
@@ -40,9 +40,15 @@ export function kafkaLocalCgIdFor(peerId: string): string {
  * `createPrivateContextGraph` name is deliberate — the privacy guarantee is
  * encoded in the method name rather than a boolean flag, so a future caller
  * cannot accidentally drop `private: true` at the boundary.
+ *
+ * `isPrivateContextGraph` is required (not optional) so the ensurer can verify
+ * defence-in-depth that a pre-existing CG with our reserved id is actually
+ * private — protects against a non-private CG having been created out-of-band
+ * via `/api/context-graph/create` directly with a colliding id.
  */
 export interface LocalCgPrimitive {
   contextGraphExists(id: string): Promise<boolean>;
+  isPrivateContextGraph(id: string): Promise<boolean>;
   createPrivateContextGraph(opts: { id: string; name: string }): Promise<void>;
 }
 
@@ -68,9 +74,21 @@ export function createKafkaLocalCgEnsurer(
       return inFlight;
     }
     inFlight = (async () => {
-      const exists = await cg.contextGraphExists(id);
-      if (exists) {
-        return id;
+      // Defence-in-depth: `contextGraphExists` only proves an id is in the
+      // local store, not that it's the private kafka-local CG we expect. A
+      // pre-existing non-private CG with a colliding id (created via
+      // `/api/context-graph/create` directly, or stale data from before this
+      // fix) would otherwise be reused — publishing into a non-local graph
+      // while the API still reports `cgScope: 'local'`. Verify privacy.
+      if (await cg.contextGraphExists(id)) {
+        if (await cg.isPrivateContextGraph(id)) {
+          return id;
+        }
+        throw new Error(
+          `Context graph "${id}" exists locally but is not private. ` +
+            `The "${KAFKA_LOCAL_CG_BARE_ID}" prefix is reserved for private node-local CGs. ` +
+            `Either rename or delete the conflicting CG, or report a bug if you did not create it.`,
+        );
       }
       try {
         await cg.createPrivateContextGraph({ id, name: displayName });
@@ -81,6 +99,15 @@ export function createKafkaLocalCgEnsurer(
         const msg = err instanceof Error ? err.message : String(err);
         if (!/already exists/i.test(msg)) {
           throw err;
+        }
+        // Re-verify privacy: a parallel creator may have used the reserved
+        // id for a NON-private CG. Same threat model as the exists-branch
+        // check above — fail loudly rather than silently leak.
+        if (!(await cg.isPrivateContextGraph(id))) {
+          throw new Error(
+            `Context graph "${id}" was created concurrently but is not private. ` +
+              `Reserved id was used for a non-private CG — investigate.`,
+          );
         }
       }
       return id;

--- a/packages/kafka/src/local-cg.ts
+++ b/packages/kafka/src/local-cg.ts
@@ -1,32 +1,17 @@
 // Lazy-creation orchestrator for the node-local "kafka-local" free CG.
 //
-// "Free CG" = local-only context graph, never registered on-chain. Created via
-// the V10 `agent.createContextGraph()` primitive without any
-// `agent.registerContextGraph()` follow-up. The id `kafka-local` is reserved
-// at the package level: callers must not pick `kafka-local` as a shared CG id.
-//
-// Idempotency contract:
-//   - First call when the CG is missing → creates it once.
-//   - Subsequent calls → return the id without touching the store.
-//   - Concurrent calls during a single daemon startup → exactly one create
-//     wins; the others observe the in-flight create and resolve to the same
-//     id without re-issuing the create. This is enforced by an in-process
-//     promise gate, not by relying on the underlying store's "already exists"
-//     guard alone (the guard is the second-line defence).
-//
-// The gate must be bound to a specific `cg` primitive so two different
-// agents (e.g. multiple sub-processes sharing this module) don't accidentally
-// serialize against each other. `createKafkaLocalCgEnsurer(cg)` returns a
-// thunk whose closure owns its own gate — see the factory below.
-
-const KAFKA_LOCAL_DEFAULT_NAME = 'Kafka Local';
+// "Free CG" = local-only context graph, never registered on-chain. Created
+// via `agent.createContextGraph()` with no `registerContextGraph()` follow-up.
+// The id `kafka-local` is reserved at the package level: callers must not
+// pick it as a shared CG id.
 
 export const KAFKA_LOCAL_CG_ID = 'kafka-local';
 
+const KAFKA_LOCAL_DEFAULT_NAME = 'Kafka Local';
+
 /**
- * Minimal V10 free-CG creation surface this module needs. Injected as a
- * dependency so unit tests can run without spinning up a real DKG agent and
- * so the same code path serves both production (real agent) and tests.
+ * Minimal V10 free-CG creation surface this module needs. Injected so unit
+ * tests run without a real DKG agent and the same code path serves both.
  */
 export interface LocalCgPrimitive {
   contextGraphExists(id: string): Promise<boolean>;
@@ -34,17 +19,11 @@ export interface LocalCgPrimitive {
 }
 
 /**
- * Create an ensurer thunk bound to a specific V10 free-CG primitive. The
- * returned function is a single-shot gate per concurrent burst: parallel
- * callers within the same burst share one in-flight create; once that create
- * resolves the gate clears in `finally`, so a future call (e.g. after the
- * local CG was deleted out from under the process) re-runs the exists-check
- * and short-circuits when the CG is present.
- *
- * The gate lives in this closure rather than at module scope so each
- * primitive instance gets its own gate — this prevents hidden coupling where
- * two callers with different `cg` primitives would otherwise silently share
- * one gate keyed only on the literal `kafka-local`.
+ * Returns a thunk that ensures `kafka-local` exists and resolves to its id.
+ * Concurrent callers in a burst share one in-flight create; the gate clears
+ * in `finally` so a later call after deletion re-runs the exists-check. The
+ * gate lives in this closure so two ensurers built from different primitives
+ * don't accidentally share state keyed only on the literal `kafka-local`.
  */
 export function createKafkaLocalCgEnsurer(
   cg: LocalCgPrimitive,
@@ -66,11 +45,9 @@ export function createKafkaLocalCgEnsurer(
           name: KAFKA_LOCAL_DEFAULT_NAME,
         });
       } catch (err: unknown) {
-        // Race tolerance: another path (e.g. a different in-flight register
-        // call from a previous run already past its gate, or external
-        // creation by /api/context-graph/create) may have created
-        // kafka-local between our exists-check and our create. The agent's
-        // own "already exists" guard surfaces with this message.
+        // Race tolerance: another path (peer sync, parallel CLI) may have
+        // created `kafka-local` between our exists-check and our create.
+        // The agent surfaces this with an "already exists" message.
         const msg = err instanceof Error ? err.message : String(err);
         if (!/already exists/i.test(msg)) {
           throw err;
@@ -78,10 +55,6 @@ export function createKafkaLocalCgEnsurer(
       }
       return KAFKA_LOCAL_CG_ID;
     })().finally(() => {
-      // Clear the gate so future startups (e.g. after the local CG was
-      // deleted out from under us) re-run the exists check rather than
-      // returning a cached id from a stale process state. Effectively a
-      // single-shot gate per concurrent burst.
       inFlight = null;
     });
     return inFlight;

--- a/packages/kafka/src/validation.ts
+++ b/packages/kafka/src/validation.ts
@@ -1,0 +1,65 @@
+// Pure validation for the context-graph selection on a Kafka endpoint
+// registration. The caller must pass exactly one of `contextGraphId` (publish
+// into a named shared CG) or `useLocalCg: true` (publish into the node-local
+// `kafka-local` free CG). Passing neither — or both — is a hard error.
+//
+// This module is pure: input in, validated/normalized output or thrown error
+// out. It MUST NOT take a DKG client dependency; the calling layer is the
+// route handler in `packages/cli/src/daemon/routes/kafka.ts`, which maps the
+// thrown error to a 400 response.
+//
+// See ADR-0004: explicit local-vs-shared CG choice. The API rejects implicit
+// defaults so the caller can never accidentally publish into the wrong place.
+
+const BOTH_OPTIONS_HINT =
+  'Pass exactly one of "contextGraphId" (publish into a named shared CG) ' +
+  'or "useLocalCg": true (publish into the local "kafka-local" free CG).';
+
+export interface KafkaContextGraphSelectionInput {
+  contextGraphId?: unknown;
+  useLocalCg?: unknown;
+}
+
+export type KafkaContextGraphSelection =
+  | { kind: 'shared'; contextGraphId: string }
+  | { kind: 'local' };
+
+export function validateContextGraphSelection(
+  input: KafkaContextGraphSelectionInput,
+): KafkaContextGraphSelection {
+  const hasCg = input.contextGraphId !== undefined && input.contextGraphId !== null;
+  const hasLocal = input.useLocalCg !== undefined && input.useLocalCg !== null;
+
+  if (hasCg && hasLocal) {
+    throw new Error(
+      `"contextGraphId" and "useLocalCg" are mutually exclusive. ${BOTH_OPTIONS_HINT}`,
+    );
+  }
+
+  if (hasLocal) {
+    if (typeof input.useLocalCg !== 'boolean') {
+      throw new Error('"useLocalCg" must be a boolean (true).');
+    }
+    if (input.useLocalCg === true) {
+      return { kind: 'local' };
+    }
+    // useLocalCg: false collapses to "no CG selected" — fall through to the
+    // missing-field error below so the caller sees the same actionable message
+    // they would have seen if they had omitted both fields entirely.
+  }
+
+  if (hasCg) {
+    if (typeof input.contextGraphId !== 'string') {
+      throw new Error('"contextGraphId" must be a string.');
+    }
+    const trimmed = input.contextGraphId.trim();
+    if (trimmed.length === 0) {
+      throw new Error('"contextGraphId" must be a non-empty string.');
+    }
+    return { kind: 'shared', contextGraphId: input.contextGraphId };
+  }
+
+  throw new Error(
+    `Missing context-graph selection. ${BOTH_OPTIONS_HINT}`,
+  );
+}

--- a/packages/kafka/src/validation.ts
+++ b/packages/kafka/src/validation.ts
@@ -1,8 +1,11 @@
 // Pure validation for the context-graph selection on a Kafka endpoint
 // registration. Caller must pass exactly one of `contextGraphId` (named
 // shared CG) or `useLocalCg: true` (the node-local `kafka-local` free CG).
-// Neither and both are hard errors. No DKG dependency: the route handler
-// maps a thrown error to a 400 response. See ADR-0004.
+// Neither and both are hard errors. No DKG client dependency: the route
+// handler maps a thrown error to a 400 response. The local-cg constant
+// import below is just a string literal — no I/O. See ADR-0004.
+
+import { KAFKA_LOCAL_CG_ID } from './local-cg.js';
 
 const BOTH_OPTIONS_HINT =
   'Pass exactly one of "contextGraphId" (publish into a named shared CG) ' +
@@ -21,19 +24,31 @@ export function validateContextGraphSelection(
   input: KafkaContextGraphSelectionInput,
 ): KafkaContextGraphSelection {
   const hasCg = input.contextGraphId != null;
-  const hasLocal = input.useLocalCg != null;
+  const localValue = input.useLocalCg;
 
-  if (hasCg && hasLocal) {
+  // Type-check `useLocalCg` first so that explicit non-boolean values like `0`
+  // or `'true'` always fail with a type error, regardless of whether a
+  // `contextGraphId` is also present. Coercion would silently mask caller bugs.
+  if (
+    localValue !== undefined &&
+    localValue !== null &&
+    typeof localValue !== 'boolean'
+  ) {
+    throw new Error('"useLocalCg" must be a boolean (true).');
+  }
+
+  // Treat `useLocalCg: false` as equivalent to omission (matches typical
+  // JSON-default serialization patterns where a client emits all fields with
+  // their defaults). Only `useLocalCg === true` is a positive selection.
+  const wantsLocal = localValue === true;
+
+  if (hasCg && wantsLocal) {
     throw new Error(
       `"contextGraphId" and "useLocalCg" are mutually exclusive. ${BOTH_OPTIONS_HINT}`,
     );
   }
 
-  if (hasLocal && typeof input.useLocalCg !== 'boolean') {
-    throw new Error('"useLocalCg" must be a boolean (true).');
-  }
-
-  if (input.useLocalCg === true) {
+  if (wantsLocal) {
     return { kind: 'local' };
   }
 
@@ -44,6 +59,11 @@ export function validateContextGraphSelection(
     const trimmed = input.contextGraphId.trim();
     if (trimmed.length === 0) {
       throw new Error('"contextGraphId" must be a non-empty string.');
+    }
+    if (trimmed === KAFKA_LOCAL_CG_ID) {
+      throw new Error(
+        `"contextGraphId" cannot be "${KAFKA_LOCAL_CG_ID}" — that id is reserved for the local free CG. Use "useLocalCg": true instead.`,
+      );
     }
     return { kind: 'shared', contextGraphId: trimmed };
   }

--- a/packages/kafka/src/validation.ts
+++ b/packages/kafka/src/validation.ts
@@ -56,7 +56,10 @@ export function validateContextGraphSelection(
     if (trimmed.length === 0) {
       throw new Error('"contextGraphId" must be a non-empty string.');
     }
-    return { kind: 'shared', contextGraphId: input.contextGraphId };
+    // Return the trimmed form so the validation module is self-consistent:
+    // we already inspected the trimmed value to gate emptiness, and surface
+    // whitespace at the boundaries is never meaningful for a CG id.
+    return { kind: 'shared', contextGraphId: trimmed };
   }
 
   throw new Error(

--- a/packages/kafka/src/validation.ts
+++ b/packages/kafka/src/validation.ts
@@ -1,15 +1,8 @@
 // Pure validation for the context-graph selection on a Kafka endpoint
-// registration. The caller must pass exactly one of `contextGraphId` (publish
-// into a named shared CG) or `useLocalCg: true` (publish into the node-local
-// `kafka-local` free CG). Passing neither — or both — is a hard error.
-//
-// This module is pure: input in, validated/normalized output or thrown error
-// out. It MUST NOT take a DKG client dependency; the calling layer is the
-// route handler in `packages/cli/src/daemon/routes/kafka.ts`, which maps the
-// thrown error to a 400 response.
-//
-// See ADR-0004: explicit local-vs-shared CG choice. The API rejects implicit
-// defaults so the caller can never accidentally publish into the wrong place.
+// registration. Caller must pass exactly one of `contextGraphId` (named
+// shared CG) or `useLocalCg: true` (the node-local `kafka-local` free CG).
+// Neither and both are hard errors. No DKG dependency: the route handler
+// maps a thrown error to a 400 response. See ADR-0004.
 
 const BOTH_OPTIONS_HINT =
   'Pass exactly one of "contextGraphId" (publish into a named shared CG) ' +
@@ -27,8 +20,8 @@ export type KafkaContextGraphSelection =
 export function validateContextGraphSelection(
   input: KafkaContextGraphSelectionInput,
 ): KafkaContextGraphSelection {
-  const hasCg = input.contextGraphId !== undefined && input.contextGraphId !== null;
-  const hasLocal = input.useLocalCg !== undefined && input.useLocalCg !== null;
+  const hasCg = input.contextGraphId != null;
+  const hasLocal = input.useLocalCg != null;
 
   if (hasCg && hasLocal) {
     throw new Error(
@@ -36,16 +29,12 @@ export function validateContextGraphSelection(
     );
   }
 
-  if (hasLocal) {
-    if (typeof input.useLocalCg !== 'boolean') {
-      throw new Error('"useLocalCg" must be a boolean (true).');
-    }
-    if (input.useLocalCg === true) {
-      return { kind: 'local' };
-    }
-    // useLocalCg: false collapses to "no CG selected" — fall through to the
-    // missing-field error below so the caller sees the same actionable message
-    // they would have seen if they had omitted both fields entirely.
+  if (hasLocal && typeof input.useLocalCg !== 'boolean') {
+    throw new Error('"useLocalCg" must be a boolean (true).');
+  }
+
+  if (input.useLocalCg === true) {
+    return { kind: 'local' };
   }
 
   if (hasCg) {
@@ -56,13 +45,8 @@ export function validateContextGraphSelection(
     if (trimmed.length === 0) {
       throw new Error('"contextGraphId" must be a non-empty string.');
     }
-    // Return the trimmed form so the validation module is self-consistent:
-    // we already inspected the trimmed value to gate emptiness, and surface
-    // whitespace at the boundaries is never meaningful for a CG id.
     return { kind: 'shared', contextGraphId: trimmed };
   }
 
-  throw new Error(
-    `Missing context-graph selection. ${BOTH_OPTIONS_HINT}`,
-  );
+  throw new Error(`Missing context-graph selection. ${BOTH_OPTIONS_HINT}`);
 }

--- a/packages/kafka/src/validation.ts
+++ b/packages/kafka/src/validation.ts
@@ -1,15 +1,18 @@
 // Pure validation for the context-graph selection on a Kafka endpoint
 // registration. Caller must pass exactly one of `contextGraphId` (named
-// shared CG) or `useLocalCg: true` (the node-local `kafka-local` free CG).
+// shared CG) or `useLocalCg: true` (the node-local kafka-local free CG).
 // Neither and both are hard errors. No DKG client dependency: the route
 // handler maps a thrown error to a 400 response. The local-cg constant
-// import below is just a string literal — no I/O. See ADR-0004.
+// imports below are just string literals — no I/O. See ADR-0004.
 
-import { KAFKA_LOCAL_CG_ID } from './local-cg.js';
+import {
+  KAFKA_LOCAL_CG_BARE_ID,
+  KAFKA_LOCAL_CG_ID_PREFIX,
+} from './local-cg.js';
 
 const BOTH_OPTIONS_HINT =
   'Pass exactly one of "contextGraphId" (publish into a named shared CG) ' +
-  'or "useLocalCg": true (publish into the local "kafka-local" free CG).';
+  'or "useLocalCg": true (publish into the local kafka-local free CG).';
 
 export interface KafkaContextGraphSelectionInput {
   contextGraphId?: unknown;
@@ -60,9 +63,17 @@ export function validateContextGraphSelection(
     if (trimmed.length === 0) {
       throw new Error('"contextGraphId" must be a non-empty string.');
     }
-    if (trimmed === KAFKA_LOCAL_CG_ID) {
+    // Reject both the bare reserved id and any per-node prefixed form
+    // (`kafka-local-{peerId}`). The prefix space is owned by the local-CG
+    // ensurer; letting a caller smuggle one of those ids through the shared
+    // path would bypass the lazy-create gate and risk publishing into another
+    // node's local CG.
+    if (
+      trimmed === KAFKA_LOCAL_CG_BARE_ID ||
+      trimmed.startsWith(KAFKA_LOCAL_CG_ID_PREFIX)
+    ) {
       throw new Error(
-        `"contextGraphId" cannot be "${KAFKA_LOCAL_CG_ID}" — that id is reserved for the local free CG. Use "useLocalCg": true instead.`,
+        `"contextGraphId" cannot be "${trimmed}" — the "${KAFKA_LOCAL_CG_BARE_ID}" prefix is reserved for per-node local free CGs. Use "useLocalCg": true instead.`,
       );
     }
     return { kind: 'shared', contextGraphId: trimmed };

--- a/packages/kafka/test/e2e/walking-skeleton.test.ts
+++ b/packages/kafka/test/e2e/walking-skeleton.test.ts
@@ -176,6 +176,7 @@ describe('kafka walking skeleton e2e', () => {
     expect(result.stdout).toContain('Kafka endpoint registered:');
     expect(result.stdout).toContain(expectedUri);
     expect(result.stdout).toContain(CONTEXT_GRAPH_ID);
+    expect(result.stdout).toContain('CG scope:       shared');
 
     const row = await waitForEndpointRow(client, CONTEXT_GRAPH_ID, expectedUri);
 
@@ -186,4 +187,96 @@ describe('kafka walking skeleton e2e', () => {
     expect(stripIriDelimiters(row.endpointUrl ?? '')).toBe(`kafka://${broker}/${topic}`);
     expect(Number.isNaN(Date.parse(stripQuotedLiteral(row.issued ?? '')))).toBe(false);
   }, 90_000);
+
+  it('registers a Kafka endpoint into kafka-local with --local and discovers it via SPARQL', async () => {
+    const broker = 'kafka.e2e.local:9092';
+    const topic = `walking-skeleton-local.${Date.now()}`;
+    const messageFormat = 'application/cloudevents+json';
+    const expectedUri = buildKafkaEndpointUri({ owner, broker, topic });
+
+    const result = await execFileAsync(
+      'node',
+      [
+        CLI_ENTRY,
+        'kafka',
+        'endpoint',
+        'register',
+        '--local',
+        '--broker',
+        broker,
+        '--topic',
+        topic,
+        '--format',
+        messageFormat,
+      ],
+      {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          DKG_HOME: DEVNET_NODE1_HOME,
+          DKG_API_PORT: String(port),
+        },
+      },
+    );
+
+    expect(result.stdout).toContain('Kafka endpoint registered:');
+    expect(result.stdout).toContain(expectedUri);
+    expect(result.stdout).toContain('kafka-local');
+    expect(result.stdout).toContain('CG scope:       local');
+
+    const row = await waitForEndpointRow(client, 'kafka-local', expectedUri);
+
+    expect(stripQuotedLiteral(row.broker ?? '')).toBe(broker);
+    expect(stripQuotedLiteral(row.topic ?? '')).toBe(topic);
+    expect(stripQuotedLiteral(row.messageFormat ?? '')).toBe(messageFormat);
+    expect(stripIriDelimiters(row.publisher ?? '')).toBe(`urn:dkg:agent:${owner}`);
+    expect(stripIriDelimiters(row.endpointUrl ?? '')).toBe(`kafka://${broker}/${topic}`);
+    expect(Number.isNaN(Date.parse(stripQuotedLiteral(row.issued ?? '')))).toBe(false);
+  }, 90_000);
+
+  it('rejects a request with neither contextGraphId nor useLocalCg with a 4xx', async () => {
+    const broker = 'kafka.e2e.local:9092';
+    const topic = `walking-skeleton-bad-${Date.now()}`;
+    const messageFormat = 'application/json';
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/kafka/endpoint`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ broker, topic, messageFormat }),
+    });
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error?: string };
+    expect(payload.error ?? '').toMatch(/contextGraphId/);
+    expect(payload.error ?? '').toMatch(/useLocalCg/);
+  }, 30_000);
+
+  it('rejects a request with both contextGraphId and useLocalCg with a 4xx', async () => {
+    const broker = 'kafka.e2e.local:9092';
+    const topic = `walking-skeleton-bad-${Date.now()}`;
+    const messageFormat = 'application/json';
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/kafka/endpoint`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        contextGraphId: CONTEXT_GRAPH_ID,
+        useLocalCg: true,
+        broker,
+        topic,
+        messageFormat,
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error?: string };
+    expect(payload.error ?? '').toMatch(/contextGraphId/);
+    expect(payload.error ?? '').toMatch(/useLocalCg/);
+  }, 30_000);
 });

--- a/packages/kafka/test/e2e/walking-skeleton.test.ts
+++ b/packages/kafka/test/e2e/walking-skeleton.test.ts
@@ -188,7 +188,7 @@ describe('kafka walking skeleton e2e', () => {
     expect(Number.isNaN(Date.parse(stripQuotedLiteral(row.issued ?? '')))).toBe(false);
   }, 90_000);
 
-  it('registers a Kafka endpoint into kafka-local with --local and discovers it via SPARQL', async () => {
+  it('registers a Kafka endpoint into kafka-local-{peerId} with --local and discovers it via SPARQL', async () => {
     const broker = 'kafka.e2e.local:9092';
     const topic = `walking-skeleton-local.${Date.now()}`;
     const messageFormat = 'application/cloudevents+json';
@@ -224,7 +224,15 @@ describe('kafka walking skeleton e2e', () => {
     expect(result.stdout).toContain('kafka-local');
     expect(result.stdout).toContain('CG scope:       local');
 
-    const row = await waitForEndpointRow(client, 'kafka-local', expectedUri);
+    // The daemon scopes the kafka-local CG id per-node as
+    // `kafka-local-{peerId}`. Parse the resolved id from the CLI output and
+    // SPARQL-query against THAT id so the test stays correct on any node.
+    const cgLineMatch = result.stdout.match(/Context graph:\s+(\S+)/);
+    expect(cgLineMatch?.[1]).toBeDefined();
+    const resolvedCgId = cgLineMatch![1]!;
+    expect(resolvedCgId.startsWith('kafka-local-')).toBe(true);
+
+    const row = await waitForEndpointRow(client, resolvedCgId, expectedUri);
 
     expect(stripQuotedLiteral(row.broker ?? '')).toBe(broker);
     expect(stripQuotedLiteral(row.topic ?? '')).toBe(topic);

--- a/packages/kafka/test/endpoint.register.test.ts
+++ b/packages/kafka/test/endpoint.register.test.ts
@@ -113,8 +113,10 @@ describe('registerKafkaEndpoint', () => {
   });
 
   it('defaults issuedAt to "now" when caller omits it', async () => {
+    const calls: Array<{ contextGraphId: string; content: unknown }> = [];
     const publisher = {
-      async publish() {
+      async publish(contextGraphId: string, content: unknown) {
+        calls.push({ contextGraphId, content });
         return { ual: 'did:dkg:test/1', kcId: '1', status: 'confirmed' as const };
       },
     };
@@ -130,8 +132,15 @@ describe('registerKafkaEndpoint', () => {
     });
     const after = Date.now();
 
-    // Sanity: no throws, and "now" was within the test window. The
-    // assertion only proves we exercised the default-issuedAt branch.
-    expect(after).toBeGreaterThanOrEqual(before);
+    // Verify the default-issuedAt branch by reading the timestamp the
+    // builder actually stamped onto the published KA, not by re-asserting
+    // wall-clock monotonicity. The KA carries it as a typed xsd:dateTime
+    // literal at `dct:issued.@value` — see ka-builder.ts.
+    expect(calls).toHaveLength(1);
+    const content = calls[0]!.content as { 'dct:issued': { '@value': string } };
+    const issuedMs = Date.parse(content['dct:issued']['@value']);
+    expect(Number.isNaN(issuedMs)).toBe(false);
+    expect(issuedMs).toBeGreaterThanOrEqual(before);
+    expect(issuedMs).toBeLessThanOrEqual(after);
   });
 });

--- a/packages/kafka/test/endpoint.register.test.ts
+++ b/packages/kafka/test/endpoint.register.test.ts
@@ -111,4 +111,27 @@ describe('registerKafkaEndpoint', () => {
       }),
     ).rejects.toThrow(/ensureLocalCg/);
   });
+
+  it('defaults issuedAt to "now" when caller omits it', async () => {
+    const publisher = {
+      async publish() {
+        return { ual: 'did:dkg:test/1', kcId: '1', status: 'confirmed' as const };
+      },
+    };
+
+    const before = Date.now();
+    await registerKafkaEndpoint({
+      selection: { kind: 'shared', contextGraphId: 'devnet-test' },
+      owner: '0xAbCDEFabcdefABCDEFabcdefABCDEFabcdefABCD',
+      broker: 'kafka.example.com:9092',
+      topic: 'orders.created',
+      messageFormat: 'application/json',
+      publisher,
+    });
+    const after = Date.now();
+
+    // Sanity: no throws, and "now" was within the test window. The
+    // assertion only proves we exercised the default-issuedAt branch.
+    expect(after).toBeGreaterThanOrEqual(before);
+  });
 });

--- a/packages/kafka/test/endpoint.register.test.ts
+++ b/packages/kafka/test/endpoint.register.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { registerKafkaEndpoint } from '../src/endpoint.js';
 
 describe('registerKafkaEndpoint', () => {
-  it('publishes the Kafka endpoint KA into the named context graph', async () => {
+  it('publishes the Kafka endpoint KA into the named context graph (shared scope)', async () => {
     const calls: Array<{ contextGraphId: string; content: unknown }> = [];
     const publisher = {
       async publish(contextGraphId: string, content: unknown) {
@@ -12,7 +12,7 @@ describe('registerKafkaEndpoint', () => {
     };
 
     const result = await registerKafkaEndpoint({
-      contextGraphId: 'devnet-test',
+      selection: { kind: 'shared', contextGraphId: 'devnet-test' },
       owner: '0xAbCDEFabcdefABCDEFabcdefABCDEFabcdefABCD',
       broker: 'kafka.example.com:9092',
       topic: 'orders.created',
@@ -25,6 +25,7 @@ describe('registerKafkaEndpoint', () => {
       uri: 'urn:dkg:kafka-endpoint:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd:' +
         '33b58f60595c766739f72b29e4ee417888d1a46af8339a4b5bdb1c3a5692f652',
       contextGraphId: 'devnet-test',
+      cgScope: 'shared',
     });
 
     expect(calls).toHaveLength(1);
@@ -54,5 +55,60 @@ describe('registerKafkaEndpoint', () => {
         },
       },
     });
+  });
+
+  it('publishes into the resolved local CG when selection.kind is "local"', async () => {
+    const calls: Array<{ contextGraphId: string; content: unknown }> = [];
+    const publisher = {
+      async publish(contextGraphId: string, content: unknown) {
+        calls.push({ contextGraphId, content });
+        return { ual: 'did:dkg:test/1', kcId: '1', status: 'confirmed' as const };
+      },
+    };
+    let ensureCalls = 0;
+    const ensureLocalCg = async (): Promise<string> => {
+      ensureCalls += 1;
+      return 'kafka-local';
+    };
+
+    const result = await registerKafkaEndpoint({
+      selection: { kind: 'local' },
+      owner: '0xAbCDEFabcdefABCDEFabcdefABCDEFabcdefABCD',
+      broker: 'kafka.example.com:9092',
+      topic: 'orders.created',
+      messageFormat: 'application/json',
+      issuedAt: '2026-05-04T12:34:56.000Z',
+      publisher,
+      ensureLocalCg,
+    });
+
+    expect(ensureCalls).toBe(1);
+    expect(result).toEqual({
+      uri: 'urn:dkg:kafka-endpoint:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd:' +
+        '33b58f60595c766739f72b29e4ee417888d1a46af8339a4b5bdb1c3a5692f652',
+      contextGraphId: 'kafka-local',
+      cgScope: 'local',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.contextGraphId).toBe('kafka-local');
+  });
+
+  it('throws when selection.kind is "local" but ensureLocalCg is not provided', async () => {
+    const publisher = {
+      async publish() {
+        return { ual: 'did:dkg:test/1', kcId: '1', status: 'confirmed' as const };
+      },
+    };
+
+    await expect(
+      registerKafkaEndpoint({
+        selection: { kind: 'local' },
+        owner: '0xAbCDEFabcdefABCDEFabcdefABCDEFabcdefABCD',
+        broker: 'kafka.example.com:9092',
+        topic: 'orders.created',
+        messageFormat: 'application/json',
+        publisher,
+      }),
+    ).rejects.toThrow(/ensureLocalCg/);
   });
 });

--- a/packages/kafka/test/local-cg.test.ts
+++ b/packages/kafka/test/local-cg.test.ts
@@ -1,31 +1,37 @@
 import { describe, expect, it } from 'vitest';
 import {
-  KAFKA_LOCAL_CG_ID,
+  KAFKA_LOCAL_CG_BARE_ID,
+  KAFKA_LOCAL_CG_ID_PREFIX,
   createKafkaLocalCgEnsurer,
+  kafkaLocalCgIdFor,
 } from '../src/local-cg.js';
+
+const TEST_PEER_ID = '12D3KooWAbcDEFghiJKLmnoPQRstuVWxyZ';
+const EXPECTED_ID = `${KAFKA_LOCAL_CG_ID_PREFIX}${TEST_PEER_ID}`;
 
 interface FakeCgStore {
   exists: Set<string>;
   createCalls: Array<{ id: string; name: string }>;
 }
 
-function makeFakeCg(initial: { withKafkaLocal?: boolean } = {}) {
+function makeFakeCg(initial: { withId?: string } = {}) {
   const store: FakeCgStore = {
-    exists: new Set(initial.withKafkaLocal ? [KAFKA_LOCAL_CG_ID] : []),
+    exists: new Set(initial.withId ? [initial.withId] : []),
     createCalls: [],
   };
 
   // The dependency injected into createKafkaLocalCgEnsurer models the V10
-  // free-CG primitive: `contextGraphExists` is a check, `createContextGraph`
-  // is the creation. Both await — close enough to the real V10 surface that
-  // idempotency proofs translate.
+  // free-CG primitive. The method is `createPrivateContextGraph` — the
+  // privacy guarantee is encoded in the method name so the kafka package
+  // never sees the boolean. Both calls await — close enough to the real V10
+  // surface that idempotency proofs translate.
   const cg = {
     contextGraphExists: async (id: string): Promise<boolean> => {
       // microtask hop so two parallel calls actually interleave their checks
       await Promise.resolve();
       return store.exists.has(id);
     },
-    createContextGraph: async (opts: { id: string; name: string }): Promise<void> => {
+    createPrivateContextGraph: async (opts: { id: string; name: string }): Promise<void> => {
       // microtask hop, then atomic check-and-set so a real backing store
       // cannot double-create. Mirrors `agent.createContextGraph`'s own
       // "already exists" guard.
@@ -41,33 +47,44 @@ function makeFakeCg(initial: { withKafkaLocal?: boolean } = {}) {
   return { store, cg };
 }
 
+describe('kafkaLocalCgIdFor', () => {
+  it('builds a per-node id by prefixing the peer-id', () => {
+    expect(kafkaLocalCgIdFor(TEST_PEER_ID)).toBe(EXPECTED_ID);
+  });
+
+  it('exposes the prefix and bare id as separate constants', () => {
+    expect(KAFKA_LOCAL_CG_ID_PREFIX).toBe('kafka-local-');
+    expect(KAFKA_LOCAL_CG_BARE_ID).toBe('kafka-local');
+  });
+});
+
 describe('createKafkaLocalCgEnsurer', () => {
-  it('creates the kafka-local CG on first call and returns its id', async () => {
+  it('creates the per-node kafka-local CG on first call and returns its id', async () => {
     const { store, cg } = makeFakeCg();
-    const ensure = createKafkaLocalCgEnsurer(cg);
+    const ensure = createKafkaLocalCgEnsurer(cg, TEST_PEER_ID);
 
     const id = await ensure();
 
-    expect(id).toBe(KAFKA_LOCAL_CG_ID);
-    expect(store.exists.has(KAFKA_LOCAL_CG_ID)).toBe(true);
+    expect(id).toBe(EXPECTED_ID);
+    expect(store.exists.has(EXPECTED_ID)).toBe(true);
     expect(store.createCalls).toEqual([
-      { id: KAFKA_LOCAL_CG_ID, name: expect.any(String) },
+      { id: EXPECTED_ID, name: expect.any(String) },
     ]);
   });
 
-  it('skips creation when kafka-local already exists (idempotent on subsequent calls)', async () => {
-    const { store, cg } = makeFakeCg({ withKafkaLocal: true });
-    const ensure = createKafkaLocalCgEnsurer(cg);
+  it('skips creation when the per-node CG already exists (idempotent on subsequent calls)', async () => {
+    const { store, cg } = makeFakeCg({ withId: EXPECTED_ID });
+    const ensure = createKafkaLocalCgEnsurer(cg, TEST_PEER_ID);
 
     const id = await ensure();
 
-    expect(id).toBe(KAFKA_LOCAL_CG_ID);
+    expect(id).toBe(EXPECTED_ID);
     expect(store.createCalls).toEqual([]);
   });
 
-  it('serializes parallel callers (same ensurer) so kafka-local is created exactly once', async () => {
+  it('serializes parallel callers (same ensurer) so the per-node CG is created exactly once', async () => {
     const { store, cg } = makeFakeCg();
-    const ensure = createKafkaLocalCgEnsurer(cg);
+    const ensure = createKafkaLocalCgEnsurer(cg, TEST_PEER_ID);
 
     const ids = await Promise.all([
       ensure(),
@@ -78,69 +95,98 @@ describe('createKafkaLocalCgEnsurer', () => {
     ]);
 
     expect(ids).toEqual([
-      KAFKA_LOCAL_CG_ID,
-      KAFKA_LOCAL_CG_ID,
-      KAFKA_LOCAL_CG_ID,
-      KAFKA_LOCAL_CG_ID,
-      KAFKA_LOCAL_CG_ID,
+      EXPECTED_ID,
+      EXPECTED_ID,
+      EXPECTED_ID,
+      EXPECTED_ID,
+      EXPECTED_ID,
     ]);
     expect(store.createCalls).toHaveLength(1);
+    expect(store.createCalls[0]?.id).toBe(EXPECTED_ID);
   });
 
-  it('reserves the literal id "kafka-local"', () => {
-    expect(KAFKA_LOCAL_CG_ID).toBe('kafka-local');
+  // The agent's `createPrivateContextGraph` adapter hardcodes `private: true`
+  // at the route boundary; the kafka package depends on that name. Asserting
+  // that the ensurer calls THIS method (not a generic create) locks the
+  // privacy guarantee at the type-system level — a future refactor that
+  // renames the method back to a generic create would break this test before
+  // it could leak data.
+  it('invokes createPrivateContextGraph (not a generic create) on the injected primitive', async () => {
+    let createPrivateCalls = 0;
+    const cg = {
+      contextGraphExists: async (_id: string): Promise<boolean> => false,
+      createPrivateContextGraph: async (_opts: {
+        id: string;
+        name: string;
+      }): Promise<void> => {
+        createPrivateCalls += 1;
+      },
+    };
+    const ensure = createKafkaLocalCgEnsurer(cg, TEST_PEER_ID);
+
+    await ensure();
+
+    expect(createPrivateCalls).toBe(1);
   });
 
   // Defence-in-depth path: the in-flight gate already serializes concurrent
-  // callers in-process, but if an external creator (another route, a CLI in
-  // another shell, a peer sync) wins the race between our exists-check and
-  // our create-call, the underlying store will throw "already exists". The
-  // ensurer must swallow that specific error and return the id anyway, while
-  // non-"already exists" errors must still bubble up.
+  // callers in-process, but if an external creator wins the race between our
+  // exists-check and our create-call, the underlying store will throw
+  // "already exists". The ensurer must swallow that specific error and
+  // return the id anyway, while non-"already exists" errors must still
+  // bubble up.
   it('treats a concurrent "already exists" create error as success', async () => {
     const cg = {
       contextGraphExists: async (_id: string): Promise<boolean> => false,
-      createContextGraph: async (_opts: { id: string; name: string }): Promise<void> => {
-        throw new Error('Context graph "kafka-local" already exists');
+      createPrivateContextGraph: async (_opts: { id: string; name: string }): Promise<void> => {
+        throw new Error(`Context graph "${EXPECTED_ID}" already exists`);
       },
     };
-    const ensure = createKafkaLocalCgEnsurer(cg);
+    const ensure = createKafkaLocalCgEnsurer(cg, TEST_PEER_ID);
 
     const id = await ensure();
 
-    expect(id).toBe(KAFKA_LOCAL_CG_ID);
+    expect(id).toBe(EXPECTED_ID);
   });
 
   it('rethrows non-"already exists" create errors', async () => {
     const cg = {
       contextGraphExists: async (_id: string): Promise<boolean> => false,
-      createContextGraph: async (_opts: { id: string; name: string }): Promise<void> => {
+      createPrivateContextGraph: async (_opts: { id: string; name: string }): Promise<void> => {
         throw new Error('storage offline');
       },
     };
-    const ensure = createKafkaLocalCgEnsurer(cg);
+    const ensure = createKafkaLocalCgEnsurer(cg, TEST_PEER_ID);
 
     await expect(ensure()).rejects.toThrow(/storage offline/);
   });
 
   // Hidden-coupling regression test: two ensurers built from two different
-  // primitive instances must NOT share their gate. If they did, a parallel
-  // burst across both would only create kafka-local in one store, silently
-  // ignoring the other primitive — see the factory docstring.
-  it('two ensurers built from different primitives each create their own kafka-local independently', async () => {
+  // primitive instances AND different peer-ids must NOT share their gate. If
+  // they did, a parallel burst across both would only create the CG in one
+  // store, silently ignoring the other primitive — see the factory docstring.
+  // Different peer-ids also exercises the per-node uniqueness guarantee:
+  // each ensurer resolves to its own `kafka-local-{peerId}`.
+  it('two ensurers with different primitives and peer-ids each create their own CG independently', async () => {
+    const peerA = '12D3KooWPeerAAAAAAAAAAAAAAAAAAAAAAAAA';
+    const peerB = '12D3KooWPeerBBBBBBBBBBBBBBBBBBBBBBBBB';
     const a = makeFakeCg();
     const b = makeFakeCg();
-    const ensureA = createKafkaLocalCgEnsurer(a.cg);
-    const ensureB = createKafkaLocalCgEnsurer(b.cg);
+    const ensureA = createKafkaLocalCgEnsurer(a.cg, peerA);
+    const ensureB = createKafkaLocalCgEnsurer(b.cg, peerB);
 
     const [idA, idB] = await Promise.all([ensureA(), ensureB()]);
 
-    expect(idA).toBe(KAFKA_LOCAL_CG_ID);
-    expect(idB).toBe(KAFKA_LOCAL_CG_ID);
+    expect(idA).toBe(kafkaLocalCgIdFor(peerA));
+    expect(idB).toBe(kafkaLocalCgIdFor(peerB));
+    expect(idA).not.toBe(idB);
     // Each store saw exactly one create — neither piggy-backed on the other.
     expect(a.store.createCalls).toHaveLength(1);
     expect(b.store.createCalls).toHaveLength(1);
-    expect(a.store.exists.has(KAFKA_LOCAL_CG_ID)).toBe(true);
-    expect(b.store.exists.has(KAFKA_LOCAL_CG_ID)).toBe(true);
+    expect(a.store.exists.has(idA)).toBe(true);
+    expect(b.store.exists.has(idB)).toBe(true);
+    // Cross-isolation: peer-A's id never lands in peer-B's store, and vice versa.
+    expect(a.store.exists.has(idB)).toBe(false);
+    expect(b.store.exists.has(idA)).toBe(false);
   });
 });

--- a/packages/kafka/test/local-cg.test.ts
+++ b/packages/kafka/test/local-cg.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   KAFKA_LOCAL_CG_ID,
-  ensureKafkaLocalCg,
+  createKafkaLocalCgEnsurer,
 } from '../src/local-cg.js';
 
 interface FakeCgStore {
@@ -15,9 +15,9 @@ function makeFakeCg(initial: { withKafkaLocal?: boolean } = {}) {
     createCalls: [],
   };
 
-  // The dependency injected into ensureKafkaLocalCg models the V10 free-CG
-  // primitive: `contextGraphExists` is a check, `createContextGraph` is the
-  // creation. Both await — close enough to the real V10 surface that
+  // The dependency injected into createKafkaLocalCgEnsurer models the V10
+  // free-CG primitive: `contextGraphExists` is a check, `createContextGraph`
+  // is the creation. Both await — close enough to the real V10 surface that
   // idempotency proofs translate.
   const cg = {
     contextGraphExists: async (id: string): Promise<boolean> => {
@@ -41,11 +41,12 @@ function makeFakeCg(initial: { withKafkaLocal?: boolean } = {}) {
   return { store, cg };
 }
 
-describe('ensureKafkaLocalCg', () => {
+describe('createKafkaLocalCgEnsurer', () => {
   it('creates the kafka-local CG on first call and returns its id', async () => {
     const { store, cg } = makeFakeCg();
+    const ensure = createKafkaLocalCgEnsurer(cg);
 
-    const id = await ensureKafkaLocalCg(cg);
+    const id = await ensure();
 
     expect(id).toBe(KAFKA_LOCAL_CG_ID);
     expect(store.exists.has(KAFKA_LOCAL_CG_ID)).toBe(true);
@@ -56,22 +57,24 @@ describe('ensureKafkaLocalCg', () => {
 
   it('skips creation when kafka-local already exists (idempotent on subsequent calls)', async () => {
     const { store, cg } = makeFakeCg({ withKafkaLocal: true });
+    const ensure = createKafkaLocalCgEnsurer(cg);
 
-    const id = await ensureKafkaLocalCg(cg);
+    const id = await ensure();
 
     expect(id).toBe(KAFKA_LOCAL_CG_ID);
     expect(store.createCalls).toEqual([]);
   });
 
-  it('serializes parallel callers so kafka-local is created exactly once', async () => {
+  it('serializes parallel callers (same ensurer) so kafka-local is created exactly once', async () => {
     const { store, cg } = makeFakeCg();
+    const ensure = createKafkaLocalCgEnsurer(cg);
 
     const ids = await Promise.all([
-      ensureKafkaLocalCg(cg),
-      ensureKafkaLocalCg(cg),
-      ensureKafkaLocalCg(cg),
-      ensureKafkaLocalCg(cg),
-      ensureKafkaLocalCg(cg),
+      ensure(),
+      ensure(),
+      ensure(),
+      ensure(),
+      ensure(),
     ]);
 
     expect(ids).toEqual([
@@ -91,9 +94,9 @@ describe('ensureKafkaLocalCg', () => {
   // Defence-in-depth path: the in-flight gate already serializes concurrent
   // callers in-process, but if an external creator (another route, a CLI in
   // another shell, a peer sync) wins the race between our exists-check and
-  // our create-call, the underlying store will throw "already exists".
-  // ensureKafkaLocalCg must swallow that specific error and return the id
-  // anyway, while non-"already exists" errors must still bubble up.
+  // our create-call, the underlying store will throw "already exists". The
+  // ensurer must swallow that specific error and return the id anyway, while
+  // non-"already exists" errors must still bubble up.
   it('treats a concurrent "already exists" create error as success', async () => {
     const cg = {
       contextGraphExists: async (_id: string): Promise<boolean> => false,
@@ -101,8 +104,9 @@ describe('ensureKafkaLocalCg', () => {
         throw new Error('Context graph "kafka-local" already exists');
       },
     };
+    const ensure = createKafkaLocalCgEnsurer(cg);
 
-    const id = await ensureKafkaLocalCg(cg);
+    const id = await ensure();
 
     expect(id).toBe(KAFKA_LOCAL_CG_ID);
   });
@@ -114,7 +118,29 @@ describe('ensureKafkaLocalCg', () => {
         throw new Error('storage offline');
       },
     };
+    const ensure = createKafkaLocalCgEnsurer(cg);
 
-    await expect(ensureKafkaLocalCg(cg)).rejects.toThrow(/storage offline/);
+    await expect(ensure()).rejects.toThrow(/storage offline/);
+  });
+
+  // Hidden-coupling regression test: two ensurers built from two different
+  // primitive instances must NOT share their gate. If they did, a parallel
+  // burst across both would only create kafka-local in one store, silently
+  // ignoring the other primitive — see the factory docstring.
+  it('two ensurers built from different primitives each create their own kafka-local independently', async () => {
+    const a = makeFakeCg();
+    const b = makeFakeCg();
+    const ensureA = createKafkaLocalCgEnsurer(a.cg);
+    const ensureB = createKafkaLocalCgEnsurer(b.cg);
+
+    const [idA, idB] = await Promise.all([ensureA(), ensureB()]);
+
+    expect(idA).toBe(KAFKA_LOCAL_CG_ID);
+    expect(idB).toBe(KAFKA_LOCAL_CG_ID);
+    // Each store saw exactly one create — neither piggy-backed on the other.
+    expect(a.store.createCalls).toHaveLength(1);
+    expect(b.store.createCalls).toHaveLength(1);
+    expect(a.store.exists.has(KAFKA_LOCAL_CG_ID)).toBe(true);
+    expect(b.store.exists.has(KAFKA_LOCAL_CG_ID)).toBe(true);
   });
 });

--- a/packages/kafka/test/local-cg.test.ts
+++ b/packages/kafka/test/local-cg.test.ts
@@ -11,12 +11,18 @@ const EXPECTED_ID = `${KAFKA_LOCAL_CG_ID_PREFIX}${TEST_PEER_ID}`;
 
 interface FakeCgStore {
   exists: Set<string>;
+  // Tracks privacy per-id. Default-true on create unless the test seeds a
+  // non-private id explicitly. `isPrivateContextGraph` reads from this set.
+  privateIds: Set<string>;
   createCalls: Array<{ id: string; name: string }>;
 }
 
-function makeFakeCg(initial: { withId?: string } = {}) {
+function makeFakeCg(initial: { withId?: string; nonPrivate?: boolean } = {}) {
   const store: FakeCgStore = {
     exists: new Set(initial.withId ? [initial.withId] : []),
+    privateIds: new Set(
+      initial.withId && !initial.nonPrivate ? [initial.withId] : [],
+    ),
     createCalls: [],
   };
 
@@ -31,6 +37,10 @@ function makeFakeCg(initial: { withId?: string } = {}) {
       await Promise.resolve();
       return store.exists.has(id);
     },
+    isPrivateContextGraph: async (id: string): Promise<boolean> => {
+      await Promise.resolve();
+      return store.privateIds.has(id);
+    },
     createPrivateContextGraph: async (opts: { id: string; name: string }): Promise<void> => {
       // microtask hop, then atomic check-and-set so a real backing store
       // cannot double-create. Mirrors `agent.createContextGraph`'s own
@@ -40,6 +50,9 @@ function makeFakeCg(initial: { withId?: string } = {}) {
         throw new Error(`Context graph "${opts.id}" already exists`);
       }
       store.exists.add(opts.id);
+      // The real adapter hardcodes `private: true`, so any successful create
+      // through this primitive yields a private CG.
+      store.privateIds.add(opts.id);
       store.createCalls.push({ id: opts.id, name: opts.name });
     },
   };
@@ -115,6 +128,7 @@ describe('createKafkaLocalCgEnsurer', () => {
     let createPrivateCalls = 0;
     const cg = {
       contextGraphExists: async (_id: string): Promise<boolean> => false,
+      isPrivateContextGraph: async (_id: string): Promise<boolean> => true,
       createPrivateContextGraph: async (_opts: {
         id: string;
         name: string;
@@ -138,6 +152,9 @@ describe('createKafkaLocalCgEnsurer', () => {
   it('treats a concurrent "already exists" create error as success', async () => {
     const cg = {
       contextGraphExists: async (_id: string): Promise<boolean> => false,
+      // The parallel creator was OUR adapter (private: true), so the
+      // resulting CG is private and the post-race verification passes.
+      isPrivateContextGraph: async (_id: string): Promise<boolean> => true,
       createPrivateContextGraph: async (_opts: { id: string; name: string }): Promise<void> => {
         throw new Error(`Context graph "${EXPECTED_ID}" already exists`);
       },
@@ -152,6 +169,7 @@ describe('createKafkaLocalCgEnsurer', () => {
   it('rethrows non-"already exists" create errors', async () => {
     const cg = {
       contextGraphExists: async (_id: string): Promise<boolean> => false,
+      isPrivateContextGraph: async (_id: string): Promise<boolean> => true,
       createPrivateContextGraph: async (_opts: { id: string; name: string }): Promise<void> => {
         throw new Error('storage offline');
       },
@@ -159,6 +177,39 @@ describe('createKafkaLocalCgEnsurer', () => {
     const ensure = createKafkaLocalCgEnsurer(cg, TEST_PEER_ID);
 
     await expect(ensure()).rejects.toThrow(/storage offline/);
+  });
+
+  // Defence-in-depth: `contextGraphExists` only proves an id is in the local
+  // store, not that it's the private kafka-local CG we expect. A pre-existing
+  // non-private CG with a colliding id (created via /api/context-graph/create
+  // directly, or stale data from before this fix) must be REJECTED — not
+  // silently reused, which would publish into a non-local graph while the API
+  // still reports `cgScope: 'local'`.
+  it('throws when a CG with the reserved id exists locally but is not private', async () => {
+    const { cg } = makeFakeCg({ withId: EXPECTED_ID, nonPrivate: true });
+    const ensure = createKafkaLocalCgEnsurer(cg, TEST_PEER_ID);
+
+    await expect(ensure()).rejects.toThrow(
+      new RegExp(`${EXPECTED_ID}.*not private`, 'i'),
+    );
+  });
+
+  // Race-tolerance must not silently accept a non-private CG. If a parallel
+  // creator beat us with `private: false`, the post-race re-verification has
+  // to fail loudly with a distinct error that points at the race.
+  it('throws when a parallel "already exists" create yields a non-private CG', async () => {
+    const cg = {
+      contextGraphExists: async (_id: string): Promise<boolean> => false,
+      isPrivateContextGraph: async (_id: string): Promise<boolean> => false,
+      createPrivateContextGraph: async (_opts: { id: string; name: string }): Promise<void> => {
+        throw new Error(`Context graph "${EXPECTED_ID}" already exists`);
+      },
+    };
+    const ensure = createKafkaLocalCgEnsurer(cg, TEST_PEER_ID);
+
+    await expect(ensure()).rejects.toThrow(
+      /created concurrently but is not private/i,
+    );
   });
 
   // Hidden-coupling regression test: two ensurers built from two different

--- a/packages/kafka/test/local-cg.test.ts
+++ b/packages/kafka/test/local-cg.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  KAFKA_LOCAL_CG_ID,
+  ensureKafkaLocalCg,
+} from '../src/local-cg.js';
+
+interface FakeCgStore {
+  exists: Set<string>;
+  createCalls: Array<{ id: string; name: string }>;
+}
+
+function makeFakeCg(initial: { withKafkaLocal?: boolean } = {}) {
+  const store: FakeCgStore = {
+    exists: new Set(initial.withKafkaLocal ? [KAFKA_LOCAL_CG_ID] : []),
+    createCalls: [],
+  };
+
+  // The dependency injected into ensureKafkaLocalCg models the V10 free-CG
+  // primitive: `contextGraphExists` is a check, `createContextGraph` is the
+  // creation. Both await — close enough to the real V10 surface that
+  // idempotency proofs translate.
+  const cg = {
+    contextGraphExists: async (id: string): Promise<boolean> => {
+      // microtask hop so two parallel calls actually interleave their checks
+      await Promise.resolve();
+      return store.exists.has(id);
+    },
+    createContextGraph: async (opts: { id: string; name: string }): Promise<void> => {
+      // microtask hop, then atomic check-and-set so a real backing store
+      // cannot double-create. Mirrors `agent.createContextGraph`'s own
+      // "already exists" guard.
+      await Promise.resolve();
+      if (store.exists.has(opts.id)) {
+        throw new Error(`Context graph "${opts.id}" already exists`);
+      }
+      store.exists.add(opts.id);
+      store.createCalls.push({ id: opts.id, name: opts.name });
+    },
+  };
+
+  return { store, cg };
+}
+
+describe('ensureKafkaLocalCg', () => {
+  it('creates the kafka-local CG on first call and returns its id', async () => {
+    const { store, cg } = makeFakeCg();
+
+    const id = await ensureKafkaLocalCg(cg);
+
+    expect(id).toBe(KAFKA_LOCAL_CG_ID);
+    expect(store.exists.has(KAFKA_LOCAL_CG_ID)).toBe(true);
+    expect(store.createCalls).toEqual([
+      { id: KAFKA_LOCAL_CG_ID, name: expect.any(String) },
+    ]);
+  });
+
+  it('skips creation when kafka-local already exists (idempotent on subsequent calls)', async () => {
+    const { store, cg } = makeFakeCg({ withKafkaLocal: true });
+
+    const id = await ensureKafkaLocalCg(cg);
+
+    expect(id).toBe(KAFKA_LOCAL_CG_ID);
+    expect(store.createCalls).toEqual([]);
+  });
+
+  it('serializes parallel callers so kafka-local is created exactly once', async () => {
+    const { store, cg } = makeFakeCg();
+
+    const ids = await Promise.all([
+      ensureKafkaLocalCg(cg),
+      ensureKafkaLocalCg(cg),
+      ensureKafkaLocalCg(cg),
+      ensureKafkaLocalCg(cg),
+      ensureKafkaLocalCg(cg),
+    ]);
+
+    expect(ids).toEqual([
+      KAFKA_LOCAL_CG_ID,
+      KAFKA_LOCAL_CG_ID,
+      KAFKA_LOCAL_CG_ID,
+      KAFKA_LOCAL_CG_ID,
+      KAFKA_LOCAL_CG_ID,
+    ]);
+    expect(store.createCalls).toHaveLength(1);
+  });
+
+  it('reserves the literal id "kafka-local"', () => {
+    expect(KAFKA_LOCAL_CG_ID).toBe('kafka-local');
+  });
+});

--- a/packages/kafka/test/local-cg.test.ts
+++ b/packages/kafka/test/local-cg.test.ts
@@ -87,4 +87,34 @@ describe('ensureKafkaLocalCg', () => {
   it('reserves the literal id "kafka-local"', () => {
     expect(KAFKA_LOCAL_CG_ID).toBe('kafka-local');
   });
+
+  // Defence-in-depth path: the in-flight gate already serializes concurrent
+  // callers in-process, but if an external creator (another route, a CLI in
+  // another shell, a peer sync) wins the race between our exists-check and
+  // our create-call, the underlying store will throw "already exists".
+  // ensureKafkaLocalCg must swallow that specific error and return the id
+  // anyway, while non-"already exists" errors must still bubble up.
+  it('treats a concurrent "already exists" create error as success', async () => {
+    const cg = {
+      contextGraphExists: async (_id: string): Promise<boolean> => false,
+      createContextGraph: async (_opts: { id: string; name: string }): Promise<void> => {
+        throw new Error('Context graph "kafka-local" already exists');
+      },
+    };
+
+    const id = await ensureKafkaLocalCg(cg);
+
+    expect(id).toBe(KAFKA_LOCAL_CG_ID);
+  });
+
+  it('rethrows non-"already exists" create errors', async () => {
+    const cg = {
+      contextGraphExists: async (_id: string): Promise<boolean> => false,
+      createContextGraph: async (_opts: { id: string; name: string }): Promise<void> => {
+        throw new Error('storage offline');
+      },
+    };
+
+    await expect(ensureKafkaLocalCg(cg)).rejects.toThrow(/storage offline/);
+  });
 });

--- a/packages/kafka/test/validation.test.ts
+++ b/packages/kafka/test/validation.test.ts
@@ -65,13 +65,11 @@ describe('validateContextGraphSelection', () => {
     ).toThrow(/useLocalCg/);
   });
 
-  // Strict-typing decision: `useLocalCg: false` collapses to "no CG selected"
-  // (the actionable "missing selection" message), while `useLocalCg: 0` (and
-  // any other non-boolean) is a type error at the API boundary. We keep this
-  // asymmetry on purpose: callers should pass a real boolean. Coercing
-  // truthy/falsy values to booleans here would mask the type bug at the
-  // boundary and make wrong-type usage feel valid. These two tests document
-  // and lock in that behavior.
+  // `useLocalCg: false` is treated as equivalent to omission, which matches
+  // typical JSON-default serialization patterns where a client emits every
+  // field with its default. Non-boolean values like `0` / `'true'` / `1` are
+  // still rejected as type errors at the API boundary — coercing them would
+  // silently mask caller bugs. These tests lock that behavior in.
   it('treats useLocalCg: false as "missing selection" (boolean false collapses)', () => {
     expect(() =>
       validateContextGraphSelection({ useLocalCg: false }),
@@ -82,5 +80,32 @@ describe('validateContextGraphSelection', () => {
     expect(() =>
       validateContextGraphSelection({ useLocalCg: 0 as unknown as boolean }),
     ).toThrow(/"useLocalCg" must be a boolean/);
+  });
+
+  // Bug 1 regression: a client that auto-emits boolean defaults (e.g. JSON
+  // serializing `useLocalCg: false`) alongside a real `contextGraphId` must
+  // be accepted as a shared selection, not rejected as "mutually exclusive".
+  it('accepts contextGraphId paired with useLocalCg: false as shared (trimmed)', () => {
+    expect(
+      validateContextGraphSelection({
+        contextGraphId: '  devnet-test  ',
+        useLocalCg: false,
+      }),
+    ).toEqual({ kind: 'shared', contextGraphId: 'devnet-test' });
+  });
+
+  // Bug 2 regression: `kafka-local` is reserved at the package level for the
+  // node-local free CG (see local-cg.ts). Passing it as a shared id would
+  // double-write into the reserved id and bypass the lazy-create path.
+  it('rejects contextGraphId: "kafka-local" with a hint to use useLocalCg: true', () => {
+    expect(() =>
+      validateContextGraphSelection({ contextGraphId: 'kafka-local' }),
+    ).toThrow(/"useLocalCg":\s*true/);
+  });
+
+  it('rejects whitespace-padded "kafka-local" (trim happens before the reserved-id check)', () => {
+    expect(() =>
+      validateContextGraphSelection({ contextGraphId: '  kafka-local  ' }),
+    ).toThrow(/kafka-local/);
   });
 });

--- a/packages/kafka/test/validation.test.ts
+++ b/packages/kafka/test/validation.test.ts
@@ -94,9 +94,10 @@ describe('validateContextGraphSelection', () => {
     ).toEqual({ kind: 'shared', contextGraphId: 'devnet-test' });
   });
 
-  // Bug 2 regression: `kafka-local` is reserved at the package level for the
-  // node-local free CG (see local-cg.ts). Passing it as a shared id would
-  // double-write into the reserved id and bypass the lazy-create path.
+  // Bug 2 regression: the `kafka-local` namespace is reserved at the package
+  // level for node-local free CGs (see local-cg.ts). The reservation covers
+  // both the bare id and any `kafka-local-{peerId}` prefix form — the prefix
+  // space is owned by the local-CG ensurer.
   it('rejects contextGraphId: "kafka-local" with a hint to use useLocalCg: true', () => {
     expect(() =>
       validateContextGraphSelection({ contextGraphId: 'kafka-local' }),
@@ -107,5 +108,22 @@ describe('validateContextGraphSelection', () => {
     expect(() =>
       validateContextGraphSelection({ contextGraphId: '  kafka-local  ' }),
     ).toThrow(/kafka-local/);
+  });
+
+  it('rejects the per-node prefixed form "kafka-local-{peerId}" with the same hint', () => {
+    expect(() =>
+      validateContextGraphSelection({
+        contextGraphId: 'kafka-local-12D3KooWAbcDEFghiJKLmnoPQRstuVWxyZ',
+      }),
+    ).toThrow(/"useLocalCg":\s*true/);
+  });
+
+  // Boundary: only the literal `kafka-local-` prefix is reserved. Ids that
+  // happen to start with the substring `kafkalocal` (no dash) are perfectly
+  // valid shared ids and must NOT be swept up by the prefix check.
+  it('accepts a shared id that merely contains "kafkalocal" without the reserved prefix', () => {
+    expect(
+      validateContextGraphSelection({ contextGraphId: 'kafkalocal' }),
+    ).toEqual({ kind: 'shared', contextGraphId: 'kafkalocal' });
   });
 });

--- a/packages/kafka/test/validation.test.ts
+++ b/packages/kafka/test/validation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { validateContextGraphSelection } from '../src/validation.js';
+
+describe('validateContextGraphSelection', () => {
+  it('accepts a non-empty contextGraphId alone and resolves to shared scope', () => {
+    expect(
+      validateContextGraphSelection({ contextGraphId: 'devnet-test' }),
+    ).toEqual({ kind: 'shared', contextGraphId: 'devnet-test' });
+  });
+
+  it('accepts useLocalCg: true alone and resolves to local scope', () => {
+    expect(validateContextGraphSelection({ useLocalCg: true })).toEqual({
+      kind: 'local',
+    });
+  });
+
+  it('rejects neither field with an error mentioning both options', () => {
+    expect(() => validateContextGraphSelection({})).toThrow(
+      /contextGraphId.*useLocalCg|useLocalCg.*contextGraphId/,
+    );
+  });
+
+  it('rejects both fields with an error mentioning both options', () => {
+    expect(() =>
+      validateContextGraphSelection({
+        contextGraphId: 'devnet-test',
+        useLocalCg: true,
+      }),
+    ).toThrow(/contextGraphId.*useLocalCg|useLocalCg.*contextGraphId/);
+  });
+
+  it('rejects useLocalCg: false alone (treated as neither field set)', () => {
+    expect(() =>
+      validateContextGraphSelection({ useLocalCg: false }),
+    ).toThrow(/contextGraphId.*useLocalCg|useLocalCg.*contextGraphId/);
+  });
+
+  it('rejects an empty-string contextGraphId', () => {
+    expect(() =>
+      validateContextGraphSelection({ contextGraphId: '' }),
+    ).toThrow(/contextGraphId/);
+  });
+
+  it('rejects a whitespace-only contextGraphId', () => {
+    expect(() =>
+      validateContextGraphSelection({ contextGraphId: '   ' }),
+    ).toThrow(/contextGraphId/);
+  });
+
+  it('rejects a non-string contextGraphId', () => {
+    expect(() =>
+      validateContextGraphSelection({ contextGraphId: 42 as unknown as string }),
+    ).toThrow(/contextGraphId/);
+  });
+
+  it('rejects a non-boolean useLocalCg', () => {
+    expect(() =>
+      validateContextGraphSelection({ useLocalCg: 'yes' as unknown as boolean }),
+    ).toThrow(/useLocalCg/);
+  });
+});

--- a/packages/kafka/test/validation.test.ts
+++ b/packages/kafka/test/validation.test.ts
@@ -8,6 +8,12 @@ describe('validateContextGraphSelection', () => {
     ).toEqual({ kind: 'shared', contextGraphId: 'devnet-test' });
   });
 
+  it('normalizes a whitespace-padded contextGraphId by trimming it', () => {
+    expect(
+      validateContextGraphSelection({ contextGraphId: '  devnet-test  ' }),
+    ).toEqual({ kind: 'shared', contextGraphId: 'devnet-test' });
+  });
+
   it('accepts useLocalCg: true alone and resolves to local scope', () => {
     expect(validateContextGraphSelection({ useLocalCg: true })).toEqual({
       kind: 'local',
@@ -57,5 +63,24 @@ describe('validateContextGraphSelection', () => {
     expect(() =>
       validateContextGraphSelection({ useLocalCg: 'yes' as unknown as boolean }),
     ).toThrow(/useLocalCg/);
+  });
+
+  // Strict-typing decision: `useLocalCg: false` collapses to "no CG selected"
+  // (the actionable "missing selection" message), while `useLocalCg: 0` (and
+  // any other non-boolean) is a type error at the API boundary. We keep this
+  // asymmetry on purpose: callers should pass a real boolean. Coercing
+  // truthy/falsy values to booleans here would mask the type bug at the
+  // boundary and make wrong-type usage feel valid. These two tests document
+  // and lock in that behavior.
+  it('treats useLocalCg: false as "missing selection" (boolean false collapses)', () => {
+    expect(() =>
+      validateContextGraphSelection({ useLocalCg: false }),
+    ).toThrow(/Missing context-graph selection/);
+  });
+
+  it('treats useLocalCg: 0 as a type error ("must be a boolean")', () => {
+    expect(() =>
+      validateContextGraphSelection({ useLocalCg: 0 as unknown as boolean }),
+    ).toThrow(/"useLocalCg" must be a boolean/);
   });
 });

--- a/vitest.coverage.ts
+++ b/vitest.coverage.ts
@@ -162,7 +162,7 @@ export const kosavaEpcisCoverage: CoverageThresholds = {
 export const kosavaKafkaCoverage: CoverageThresholds = {
   lines: 100,
   functions: 100,
-  branches: 97,
+  branches: 96,
   statements: 100,
 };
 

--- a/vitest.coverage.ts
+++ b/vitest.coverage.ts
@@ -162,7 +162,7 @@ export const kosavaEpcisCoverage: CoverageThresholds = {
 export const kosavaKafkaCoverage: CoverageThresholds = {
   lines: 100,
   functions: 100,
-  branches: 96,
+  branches: 97,
   statements: 100,
 };
 

--- a/vitest.coverage.ts
+++ b/vitest.coverage.ts
@@ -162,7 +162,7 @@ export const kosavaEpcisCoverage: CoverageThresholds = {
 export const kosavaKafkaCoverage: CoverageThresholds = {
   lines: 100,
   functions: 100,
-  branches: 50,
+  branches: 97,
   statements: 100,
 };
 


### PR DESCRIPTION
## Stack position

Sub-PR stacking on the kafka foundation branch (PR #390).

\`\`\`
main
 └── feat/kafka-walking-skeleton    (foundation rollup, PR #390 — draft)
      └── feat/kafka-explicit-cg    ← THIS PR
\`\`\`

Independent siblings (no merge order requirement):
- Slice 03 — Default-private KAs
- Slice 04 — Opportunistic Kafka probe

All three siblings touch \`packages/cli/src/daemon/routes/kafka.ts\`. Whichever
sibling lands second/third rebases onto the updated foundation — conflict is
mechanical (3 unrelated route-handler additions in one file; keep all of
them).

## What slice 02 adds

Caller must explicitly choose where the KA lands. The walking skeleton
required \`contextGraphId\`; this slice opens up the second valid form
(\`useLocalCg: true\`) and forces caller to pick exactly one — neither /
both → 4xx with a message naming both options. Implements the
local-vs-shared half of ADR-0004.

- \`packages/kafka/src/validation.ts\` — pure mutual-exclusion check
- \`packages/kafka/src/local-cg.ts\` — lazy-creates \`kafka-local\` (free CG, never on-chain), idempotent
- Route accepts new contract; 400s on neither/both
- Response echoes \`contextGraphId\` + \`cgScope: "local" | "shared"\`
- CLI gains \`--local\` flag, mutually exclusive with \`--cg\` at the parser level

## Test plan

- [x] Unit tests: validation (all 4 input combinations), local-cg idempotency
- [x] Integration: endpoint.register with both paths + new response shape
- [x] CLI smoke: \`--local\` happy path, mutual-exclusion errors at parser
- [x] e2e: \`--local\` register → SPARQL \`kafka-local\` returns the KA
- [x] e2e: 4xx for neither / both
- [x] Slice-01 named-CG path unchanged (regression check)
- [x] Coverage ratchet updated to new actuals

## Related

- ADR-0004 (the local-vs-shared half)
- Issue: \`.scratch/kafka-registry/issues/02-explicit-cg-choice.md\`