### PR TITLE
[kafka pr-1 · 06/6] Slice 06 — Auth scopes (HITL)

### DIFF
--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -740,6 +740,12 @@ export class ApiClient {
       scopes: string[] | '*';
       name?: string;
       createdAt?: string;
+      // Codex bug 4: surfaces which rows are revocable via DELETE.
+      // Only `'file'` rows can be revoked through this API; `'config'`
+      // requires editing dkg.config.yaml; `'agent'` is auto-issued by
+      // /api/agent/register and cleared on daemon restart. Optional
+      // for forward-compat with older daemons that omit the field.
+      source?: 'file' | 'config' | 'agent';
     }>;
   }> {
     return this.get('/api/auth/tokens');

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -711,6 +711,43 @@ export class ApiClient {
     return this.post('/api/kafka/endpoint/verify', request);
   }
 
+  // ─── Token administration (slice 06 — root-only) ──────────────────────────
+  //
+  // Wrappers around `/api/auth/tokens`. The mint endpoint returns the full
+  // secret EXACTLY ONCE; the CLI is responsible for surfacing it to the
+  // operator with a clear "save this — it won't be shown again" notice.
+  // List + revoke responses never carry full secrets.
+
+  async mintAuthToken(request: {
+    scope: string | string[];
+    name?: string;
+  }): Promise<{
+    token: string;
+    prefix: string;
+    scopes: string[] | '*';
+    name?: string;
+    createdAt: string;
+  }> {
+    const body: Record<string, unknown> = { scope: request.scope };
+    if (request.name !== undefined) body.name = request.name;
+    return this.post('/api/auth/tokens', body);
+  }
+
+  async listAuthTokens(): Promise<{
+    tokens: Array<{
+      prefix: string;
+      scopes: string[] | '*';
+      name?: string;
+      createdAt?: string;
+    }>;
+  }> {
+    return this.get('/api/auth/tokens');
+  }
+
+  async revokeAuthToken(prefix: string): Promise<Record<string, never>> {
+    return this.delete(`/api/auth/tokens/${encodeURIComponent(prefix)}`);
+  }
+
   async signJoinRequest(contextGraphId: string): Promise<{
     ok: boolean;
     status?: string;
@@ -1054,6 +1091,9 @@ export class ApiClient {
       const data = await res.json().catch(() => ({ error: res.statusText }));
       throw ApiClient.httpError(res.status, ApiClient.errorMessageFromBody(data, res.statusText), data);
     }
+    // 204 No Content has an empty body — `res.json()` would throw. Return
+    // an empty object so callers don't need to special-case the type.
+    if (res.status === 204) return {} as T;
     return res.json() as Promise<T>;
   }
 

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -728,9 +728,10 @@ export class ApiClient {
     name?: string;
     createdAt: string;
   }> {
-    const body: Record<string, unknown> = { scope: request.scope };
-    if (request.name !== undefined) body.name = request.name;
-    return this.post('/api/auth/tokens', body);
+    return this.post('/api/auth/tokens', {
+      scope: request.scope,
+      ...(request.name !== undefined ? { name: request.name } : {}),
+    });
   }
 
   async listAuthTokens(): Promise<{

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -24,6 +24,7 @@ import {
   serializeTokenStore,
   lookupTokenRecord,
   setTokenRecord,
+  tokenPrefix,
   type ParsedTokenFile,
   type TokenStore,
   type TokenRecord,
@@ -111,7 +112,7 @@ export async function loadTokenStore(authConfig?: AuthConfig): Promise<TokenStor
       const existing = lookupTokenRecord(t, parsed.store);
       if (existing) continue;
       const record: TokenRecord = {
-        prefix: t.length >= 8 ? t.slice(0, 8) : t,
+        prefix: tokenPrefix(t),
         fullToken: t,
         scopes: '*',
       };
@@ -124,7 +125,7 @@ export async function loadTokenStore(authConfig?: AuthConfig): Promise<TokenStor
   if (parsed.store.size === 0) {
     const token = generateToken();
     const record: TokenRecord = {
-      prefix: token.slice(0, 8),
+      prefix: tokenPrefix(token),
       fullToken: token,
       scopes: '*',
     };
@@ -169,9 +170,14 @@ export function verifyToken(token: string | undefined, validTokens: Set<string>)
 /**
  * Verify a bearer token has the requested scope.
  *
- *   - `'*'` (root) grants any scope.
+ *   - `'*'` (root) grants any NON-EMPTY scope.
  *   - Explicit scope arrays are exact-match (no globbing).
  *   - Unknown / unrecognized tokens fail closed (false).
+ *   - Empty / undefined `requiredScope` fails closed (false). The TS
+ *     signature forbids this, but a JS caller (or a `someValue as Scope`
+ *     cast) could still slip through; without the guard, a wildcard
+ *     token would grant a "no scope" check, which is exactly the
+ *     forgotten-argument bug we want loud rather than silent.
  *
  * Pure function — every input is explicit, no global state. Callers are
  * expected to send the appropriate 403 (NOT 401: the token IS valid; the
@@ -183,6 +189,10 @@ export function verifyTokenScope(
   store: TokenStore,
 ): boolean {
   if (!token) return false;
+  // Fail-closed BEFORE the wildcard shortcut so a forgotten/empty scope
+  // argument can never accidentally grant access to a root token. See
+  // review I1: slice 07 will copy this guard verbatim.
+  if (!requiredScope) return false;
   const record = lookupTokenRecord(token, store);
   if (!record) return false;
   if (record.scopes === '*') return true;

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -34,13 +34,15 @@ import {
 // Re-export the deep-module types + helpers so call sites only import from
 // `auth.ts`. Keeps the seam between the deep parser/serializer module and
 // the I/O-bearing auth surface visible in one place.
-export type { TokenStore, TokenRecord, Scope } from './token-store.js';
+export type { TokenStore, TokenRecord, Scope, TokenSource } from './token-store.js';
 export {
   lookupTokenRecord,
   toPublicRecord,
   tokenPrefix,
   setTokenRecord,
   deleteTokenRecord,
+  addTokenToStore,
+  removeTokenFromStore,
   serializeTokenStore,
   parseTokenFile,
   type PublicTokenRecord,
@@ -105,7 +107,10 @@ export async function loadTokenStore(authConfig?: AuthConfig): Promise<TokenStor
 
   // Insert config tokens AFTER file tokens so a config token can't
   // accidentally clobber a file-only one (the parser already de-dupes
-  // file lines by prefix).
+  // file lines by prefix). Stamped `source: 'config'` so the operator
+  // sees them flagged as such in `dkg auth list-tokens` and DELETE
+  // doesn't fool them into thinking the token is gone (it'd still be
+  // re-loaded from config on the next restart).
   if (authConfig?.tokens) {
     for (const t of authConfig.tokens) {
       if (t.length === 0) continue;
@@ -115,19 +120,23 @@ export async function loadTokenStore(authConfig?: AuthConfig): Promise<TokenStor
         prefix: tokenPrefix(t),
         fullToken: t,
         scopes: '*',
+        source: 'config',
       };
       setTokenRecord(parsed.store, record);
     }
   }
 
   // Auto-generate on first run. Legacy single-line format so a
-  // downgrade to a pre-slice-06 daemon still reads it correctly.
+  // downgrade to a pre-slice-06 daemon still reads it correctly. The
+  // record IS `source: 'file'` because we're about to write it to disk
+  // — this is the canonical operator-managed root token.
   if (parsed.store.size === 0) {
     const token = generateToken();
     const record: TokenRecord = {
       prefix: tokenPrefix(token),
       fullToken: token,
       scopes: '*',
+      source: 'file',
     };
     setTokenRecord(parsed.store, record);
     parsed.preserved.push({

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -3,14 +3,47 @@
  *
  * Uses bearer tokens stored on disk. Tokens are auto-generated on first start.
  * Any interface that needs auth calls `verifyToken(token)` against the loaded set.
+ *
+ * Slice 06 — added scoped tokens via the `token-store` deep module. The
+ * auth file format is extended to allow per-token scopes (see ADR-0003);
+ * legacy scope-less lines continue to grant full access. The new
+ * `loadTokenStore` returns the structured map; `loadTokens` is a thin
+ * wrapper that returns just the set of full-token strings, so the 13
+ * existing call sites keep compiling and behaving identically for legacy
+ * tokens.
  */
 
 import { randomBytes } from 'node:crypto';
-import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
+import { readFile, mkdir, chmod, writeFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { dkgDir } from './config.js';
+import {
+  parseTokenFile,
+  serializeTokenStore,
+  lookupTokenRecord,
+  setTokenRecord,
+  type ParsedTokenFile,
+  type TokenStore,
+  type TokenRecord,
+  type Scope,
+} from './token-store.js';
+
+// Re-export the deep-module types + helpers so call sites only import from
+// `auth.ts`. Keeps the seam between the deep parser/serializer module and
+// the I/O-bearing auth surface visible in one place.
+export type { TokenStore, TokenRecord, Scope } from './token-store.js';
+export {
+  lookupTokenRecord,
+  toPublicRecord,
+  tokenPrefix,
+  setTokenRecord,
+  deleteTokenRecord,
+  serializeTokenStore,
+  parseTokenFile,
+  type PublicTokenRecord,
+} from './token-store.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -27,7 +60,12 @@ export interface AuthConfig {
 // Token file management
 // ---------------------------------------------------------------------------
 
-function tokenFilePath(): string {
+/**
+ * Resolve the on-disk auth-token path. Goes through `dkgDir()` so test
+ * harnesses can redirect via `DKG_HOME=/tmp/...` without touching the
+ * production location.
+ */
+export function tokenFilePath(): string {
   return join(dkgDir(), 'auth.token');
 }
 
@@ -36,42 +74,83 @@ function generateToken(): string {
 }
 
 /**
- * Load tokens from disk + config. Auto-generates a token file if none exists.
- * Returns the set of valid tokens.
+ * Load the structured token store from disk + config. Auto-generates a
+ * token file (legacy single-line format → scopes = `'*'`) if none exists.
+ *
+ * Config-defined tokens (from `dkg.config.yaml`) are inserted as
+ * scope-less = root tokens — they are typically operator-supplied
+ * preshared secrets, and slice 06's contract is "legacy = full access".
+ *
+ * Reads the file with `parseTokenFile`, which skips malformed lines
+ * with a warning rather than crashing. The warning sink defaults to
+ * `console.warn` — the daemon can route these through `Logger` later.
  */
-export async function loadTokens(authConfig?: AuthConfig): Promise<Set<string>> {
-  const tokens = new Set<string>();
-
-  // Add any config-defined tokens
-  if (authConfig?.tokens) {
-    for (const t of authConfig.tokens) {
-      if (t.length > 0) tokens.add(t);
-    }
-  }
-
-  // Load or generate the file-based token
+export async function loadTokenStore(authConfig?: AuthConfig): Promise<TokenStore> {
   const filePath = tokenFilePath();
+
+  let parsed: ParsedTokenFile = { store: new Map(), preserved: [] };
+
   if (existsSync(filePath)) {
     try {
       const raw = await readFile(filePath, 'utf-8');
-      for (const line of raw.split('\n')) {
-        const t = line.trim();
-        if (t.length > 0 && !t.startsWith('#')) tokens.add(t);
-      }
+      parsed = parseTokenFile(raw, {
+        onWarning: (msg) => console.warn(`[auth] ${msg}`),
+      });
     } catch {
-      // Unreadable — generate a fresh one
+      // Unreadable — fall through to auto-generate, same as the pre-slice-06
+      // behavior. Don't lock the operator out of a fresh restart.
     }
   }
 
-  if (tokens.size === 0) {
+  // Insert config tokens AFTER file tokens so a config token can't
+  // accidentally clobber a file-only one (the parser already de-dupes
+  // file lines by prefix).
+  if (authConfig?.tokens) {
+    for (const t of authConfig.tokens) {
+      if (t.length === 0) continue;
+      const existing = lookupTokenRecord(t, parsed.store);
+      if (existing) continue;
+      const record: TokenRecord = {
+        prefix: t.length >= 8 ? t.slice(0, 8) : t,
+        fullToken: t,
+        scopes: '*',
+      };
+      setTokenRecord(parsed.store, record);
+    }
+  }
+
+  // Auto-generate on first run. Legacy single-line format so a
+  // downgrade to a pre-slice-06 daemon still reads it correctly.
+  if (parsed.store.size === 0) {
     const token = generateToken();
-    tokens.add(token);
+    const record: TokenRecord = {
+      prefix: token.slice(0, 8),
+      fullToken: token,
+      scopes: '*',
+    };
+    setTokenRecord(parsed.store, record);
+    parsed.preserved.push({
+      text: '# DKG node API token — treat this like a password',
+      index: 0,
+    });
     await mkdir(dirname(filePath), { recursive: true });
-    await writeFile(filePath, `# DKG node API token — treat this like a password\n${token}\n`, { mode: 0o600 });
+    const out = serializeTokenStore(parsed);
+    await writeFile(filePath, out, { mode: 0o600 });
     await chmod(filePath, 0o600);
   }
 
-  return tokens;
+  return parsed.store;
+}
+
+/**
+ * Backward-compat wrapper. Returns the set of full-token strings — the
+ * pre-slice-06 shape of `loadTokens`. Used by 13 call sites (the daemon
+ * lifecycle, every route module, the api-client). They continue to work
+ * unchanged for legacy tokens.
+ */
+export async function loadTokens(authConfig?: AuthConfig): Promise<Set<string>> {
+  const store = await loadTokenStore(authConfig);
+  return new Set([...store.values()].map((r) => r.fullToken));
 }
 
 // ---------------------------------------------------------------------------
@@ -85,6 +164,29 @@ export async function loadTokens(authConfig?: AuthConfig): Promise<Set<string>> 
 export function verifyToken(token: string | undefined, validTokens: Set<string>): boolean {
   if (!token) return false;
   return validTokens.has(token);
+}
+
+/**
+ * Verify a bearer token has the requested scope.
+ *
+ *   - `'*'` (root) grants any scope.
+ *   - Explicit scope arrays are exact-match (no globbing).
+ *   - Unknown / unrecognized tokens fail closed (false).
+ *
+ * Pure function — every input is explicit, no global state. Callers are
+ * expected to send the appropriate 403 (NOT 401: the token IS valid; the
+ * scope is wrong).
+ */
+export function verifyTokenScope(
+  token: string | undefined,
+  requiredScope: Scope,
+  store: TokenStore,
+): boolean {
+  if (!token) return false;
+  const record = lookupTokenRecord(token, store);
+  if (!record) return false;
+  if (record.scopes === '*') return true;
+  return record.scopes.includes(requiredScope);
 }
 
 /**
@@ -128,6 +230,11 @@ function isPublicPath(pathname: string): boolean {
  *
  * Usage in the server handler:
  *   if (!httpAuthGuard(req, res, authEnabled, validTokens)) return;
+ *
+ * Note: scope checks live PER ROUTE (see `daemon/routes/kafka.ts`). The
+ * guard only enforces "valid token present" — pushing per-route scope
+ * knowledge into the guard would force it to know every route's required
+ * scope, which is exactly the smell ADR-0003 calls out.
  */
 export function httpAuthGuard(
   req: IncomingMessage,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -485,7 +485,10 @@ authCmd
 
 authCmd
   .command('rotate')
-  .description('Generate a new auth token (replaces the file-based token)')
+  .description(
+    "Replace the entire token file with a single new root token " +
+      "(WARNING: any tokens minted via 'dkg auth mint-token' will be deleted)",
+  )
   .action(async () => {
     const { randomBytes } = await import('node:crypto');
     const { writeFile, chmod, mkdir } = await import('node:fs/promises');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -514,6 +514,102 @@ authCmd
     }
   });
 
+// ── Slice 06 ── token-admin subcommands (root-only). Hit the daemon's
+// `/api/auth/tokens` so the running token set is updated atomically and
+// the file write goes through the daemon's serialization mutex. We
+// deliberately do NOT mutate the file directly from the CLI — that would
+// race with daemon-side mints and lose records.
+
+authCmd
+  .command('mint-token')
+  .description('Mint a new scoped API token (daemon must be running, root token required)')
+  .requiredOption('--scope <list>', 'Comma-separated scope list (e.g. "kafka:endpoint:read,kafka:endpoint:write")')
+  .option('--name <label>', 'Optional human-readable label for the token')
+  .action(async (opts: ActionOpts) => {
+    const client = await ApiClient.connect();
+    try {
+      const result = await client.mintAuthToken({
+        scope: String(opts.scope),
+        ...(opts.name ? { name: String(opts.name) } : {}),
+      });
+      console.log('New token minted:');
+      console.log('');
+      console.log(`  ${result.token}`);
+      console.log('');
+      console.log('  Prefix:    ' + result.prefix);
+      console.log('  Scopes:    ' + (Array.isArray(result.scopes) ? result.scopes.join(', ') : result.scopes));
+      if (result.name) console.log('  Name:      ' + result.name);
+      console.log('  Created:   ' + result.createdAt);
+      console.log('');
+      console.log('Save this token now — it will NOT be shown again. Subsequent');
+      console.log('`dkg auth list-tokens` calls will only show its prefix.');
+    } catch (err) {
+      const status = (err as { httpStatus?: number }).httpStatus;
+      if (status === 403) {
+        console.error('Forbidden: token administration requires a root token (one with scope "*").');
+        console.error('Use the legacy auto-generated token in ~/.dkg/auth.token.');
+        process.exit(1);
+      }
+      throw err;
+    }
+  });
+
+authCmd
+  .command('list-tokens')
+  .description('List all API tokens (prefixes only — full tokens are never returned)')
+  .action(async () => {
+    const client = await ApiClient.connect();
+    try {
+      const { tokens } = await client.listAuthTokens();
+      if (tokens.length === 0) {
+        console.log('No tokens configured.');
+        return;
+      }
+      // Two-column table — prefix + scopes/name. We print prefix first
+      // because that's the identifier the operator uses to revoke.
+      const colName = 'PREFIX'.padEnd(10);
+      const colScopes = 'SCOPES'.padEnd(40);
+      console.log(`${colName}${colScopes}NAME / CREATED`);
+      console.log('─'.repeat(80));
+      for (const t of tokens) {
+        const scopes = Array.isArray(t.scopes) ? t.scopes.join(',') : t.scopes;
+        const meta = [t.name, t.createdAt].filter(Boolean).join('  ');
+        console.log(
+          `${t.prefix.padEnd(10)}${scopes.slice(0, 38).padEnd(40)}${meta}`,
+        );
+      }
+    } catch (err) {
+      const status = (err as { httpStatus?: number }).httpStatus;
+      if (status === 403) {
+        console.error('Forbidden: listing tokens requires a root token (one with scope "*").');
+        process.exit(1);
+      }
+      throw err;
+    }
+  });
+
+authCmd
+  .command('revoke-token <prefix>')
+  .description('Revoke a token by its 8-char prefix')
+  .action(async (prefix: string) => {
+    const client = await ApiClient.connect();
+    try {
+      await client.revokeAuthToken(prefix);
+      console.log(`Token ${prefix} revoked.`);
+    } catch (err) {
+      const status = (err as { httpStatus?: number }).httpStatus;
+      if (status === 403) {
+        console.error('Forbidden: revoking tokens requires a root token (one with scope "*").');
+        process.exit(1);
+      }
+      if (status === 404) {
+        console.error(`No token with prefix "${prefix}".`);
+        process.exit(1);
+      }
+      throw err;
+    }
+  });
+
 // ─── dkg start ───────────────────────────────────────────────────────
 
 program

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -568,17 +568,25 @@ authCmd
         console.log('No tokens configured.');
         return;
       }
-      // Two-column table — prefix + scopes/name. We print prefix first
-      // because that's the identifier the operator uses to revoke.
-      const colName = 'PREFIX'.padEnd(10);
+      // 4-column table — PREFIX | SOURCE | SCOPES | NAME / CREATED.
+      // SOURCE was added per Codex bug 4: only `'file'` rows are
+      // revocable via `dkg auth revoke-token`; `'config'` requires
+      // editing dkg.config.yaml; `'agent'` is auto-issued by
+      // `/api/agent/register` and lives in daemon memory only.
+      const colPrefix = 'PREFIX'.padEnd(10);
+      const colSource = 'SOURCE'.padEnd(8);
       const colScopes = 'SCOPES'.padEnd(40);
-      console.log(`${colName}${colScopes}NAME / CREATED`);
-      console.log('─'.repeat(80));
+      console.log(`${colPrefix}${colSource}${colScopes}NAME / CREATED`);
+      console.log('─'.repeat(85));
       for (const t of tokens) {
         const scopes = Array.isArray(t.scopes) ? t.scopes.join(',') : t.scopes;
         const meta = [t.name, t.createdAt].filter(Boolean).join('  ');
+        // `t.source` is required on the wire shape; defaulting to
+        // 'file' on the off chance an older daemon omits it keeps the
+        // CLI forward-compatible.
+        const source = (t.source ?? 'file').padEnd(8);
         console.log(
-          `${t.prefix.padEnd(10)}${scopes.slice(0, 38).padEnd(40)}${meta}`,
+          `${t.prefix.padEnd(10)}${source}${scopes.slice(0, 38).padEnd(40)}${meta}`,
         );
       }
     } catch (err) {

--- a/packages/cli/src/daemon/fs-utils.ts
+++ b/packages/cli/src/daemon/fs-utils.ts
@@ -4,11 +4,28 @@
 
 import { _autoUpdateIo } from './manifest.js';
 
+export interface WriteFileAtomicOptions {
+  /**
+   * POSIX file mode to apply to the destination. When provided, the temp
+   * file is CREATED with this mode (closing the umask-derived
+   * permission window — see slice 06 review C1) AND a defensive
+   * `chmod` is issued after rename in case the destination already
+   * existed and the source-mode transfer wasn't consistent.
+   *
+   * Without this, a `~/.dkg/auth.token` writer that does the historical
+   * "writeFile with default mode then chmod" pair leaves a brief
+   * 0o644 window during which a same-host adversary can read the
+   * secret. Auth-bearing writers MUST pass `{ mode: 0o600 }`.
+   */
+  mode?: number;
+}
+
 /**
  * Write `data` to `path` via temp file + POSIX rename so a crash mid-write
  * never leaves a partially-written file at `path`. Used for bookkeeping
  * files that the daemon reads on startup or compares against —
- * `.current-commit`, `.current-version`, `.update-pending.json`.
+ * `.current-commit`, `.current-version`, `.update-pending.json`,
+ * `auth.token` (slice 06 mint/revoke).
  *
  * Witnessed corruption that motivates this: on dkg-v9-relay-01 we found
  * `.current-commit` containing the same 40-char SHA written end-to-end with
@@ -18,24 +35,43 @@ import { _autoUpdateIo } from './manifest.js';
  * "update available" loop that never converged.
  *
  * Falls back to a non-atomic write if `rename` is not available on the IO
- * surface (older test stubs); production always has it.
+ * surface (older test stubs); production always has it. The fallback
+ * still honors `options.mode` so secret-bearing callers don't lose
+ * permission enforcement when running against a partial IO surface.
  */
-export async function writeFileAtomic(path: string, data: string): Promise<void> {
-  const { writeFile, rename, unlink } = _autoUpdateIo;
+export async function writeFileAtomic(
+  path: string,
+  data: string,
+  options?: WriteFileAtomicOptions,
+): Promise<void> {
+  const { writeFile, rename, unlink, chmod } = _autoUpdateIo;
+  const mode = options?.mode;
+  const writeOpts = mode !== undefined ? { mode } : undefined;
+
   if (typeof rename !== 'function') {
     // Older test stubs may not provide `rename`. Production fs/promises
     // always does, so this branch only matters in unit tests with partial
     // IO surfaces. Falling back to a direct write keeps the helper usable
     // (without atomicity) instead of throwing TypeError on destructure.
-    await writeFile(path, data);
+    await writeFile(path, data, writeOpts);
+    if (mode !== undefined && typeof chmod === 'function') {
+      await chmod(path, mode);
+    }
     return;
   }
   const tmp = `${path}.tmp.${process.pid}.${Date.now().toString(36)}`;
-  await writeFile(tmp, data);
+  await writeFile(tmp, data, writeOpts);
   try {
     await rename(tmp, path);
   } catch (err) {
     try { await unlink?.(tmp); } catch { /* best-effort cleanup */ }
     throw err;
+  }
+  // Defensive `chmod` after rename: when the destination existed before
+  // the rename, some platforms preserve the destination's old mode
+  // instead of inheriting the temp file's. Re-asserting the mode here
+  // makes the contract explicit regardless of platform.
+  if (mode !== undefined && typeof chmod === 'function') {
+    await chmod(path, mode);
   }
 }

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -101,7 +101,7 @@ import {
 } from '../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
-import { loadTokens, httpAuthGuard, extractBearerToken } from '../auth.js';
+import { loadTokens, httpAuthGuard, extractBearerToken, type TokenStore } from '../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../extraction/index.js';
 import {
@@ -356,6 +356,12 @@ export async function handleRequest(
   vectorStore: VectorStore,
   embeddingProvider: EmbeddingProvider | null,
   validTokens: Set<string>,
+  // Slice 06 — structured token store; the kafka routes (and the
+  // upcoming auth-admin routes) read scopes off this. `validTokens`
+  // is kept in the signature unchanged because the rest of the
+  // codebase uses the Set-shape; the store is the supplementary
+  // surface the scope-aware routes consume.
+  tokenStore: TokenStore,
   // API socket identity — passed in from the outer daemon closure so
   // `manifestSelfClient()` can build a self-pointing URL from trusted
   // server state instead of request headers (SSRF defence).
@@ -394,6 +400,7 @@ export async function handleRequest(
     vectorStore,
     embeddingProvider,
     validTokens,
+    tokenStore,
     apiHost,
     apiPortRef,
     url,

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -402,6 +402,12 @@ export async function handleRequest(
     embeddingProvider,
     validTokens,
     tokenStore,
+    // Master auth-enabled flag — single source of truth derived from
+    // config so per-route scope gates can match the `httpAuthGuard`
+    // bypass. `config.auth?.enabled !== false` (defaults to true) is
+    // the same predicate the lifecycle uses to set the guard's
+    // behavior.
+    authEnabled: config.auth?.enabled !== false,
     apiHost,
     apiPortRef,
     url,

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -331,6 +331,7 @@ import { handleQueryRoutes } from './routes/query.js';
 import { handleLocalAgentsRoutes } from './routes/local-agents.js';
 import { handleEpcisRoutes } from './routes/epcis.js';
 import { handleKafkaRoutes } from './routes/kafka.js';
+import { handleAuthRoutes } from './routes/auth.js';
 
 
 export async function handleRequest(
@@ -440,6 +441,9 @@ export async function handleRequest(
   if (res.writableEnded) return;
 
   await handleKafkaRoutes(ctx);
+  if (res.writableEnded) return;
+
+  await handleAuthRoutes(ctx);
   if (res.writableEnded) return;
 
   jsonResponse(res, 404, { error: 'Not found' });

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -103,7 +103,7 @@ import {
 } from '../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
-import { loadTokens, loadTokenStore, httpAuthGuard, setTokenRecord, tokenPrefix, type TokenRecord } from '../auth.js';
+import { loadTokens, loadTokenStore, httpAuthGuard, addTokenToStore, tokenPrefix, type TokenRecord } from '../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../extraction/index.js';
 import {
@@ -1365,21 +1365,30 @@ export async function runDaemonInner(
 
   const authEnabled = config.auth?.enabled !== false;
   // Slice 06 — load the structured store first; the Set view is derived
-  // from it. Per-agent tokens are added to BOTH so the existing
-  // httpAuthGuard (Set-based) continues to accept them, and the new
-  // scope-aware routes see them as full-access (`scopes: '*'`).
+  // from it. Per-agent tokens are added via the lockstep
+  // `addTokenToStore` helper (Codex bug 3) so the structured map and
+  // the Set view never drift — same helper the runtime
+  // `/api/agent/register` route uses, and the same helper the mint
+  // route uses on persistence success.
   const tokenStore = await loadTokenStore(config.auth);
+  // Build the Set view BEFORE seeding per-agent tokens so
+  // `addTokenToStore` keeps the two structures in sync from the start.
+  const validTokens = new Set([...tokenStore.values()].map((r) => r.fullToken));
   for (const a of agent.listLocalAgents()) {
     const record: TokenRecord = {
       prefix: tokenPrefix(a.authToken),
       fullToken: a.authToken,
       // Per-agent tokens are not user-mintable and have always granted
-      // unscoped access. Treat them as `'*'` for slice 06's scope check.
+      // unscoped access on the existing API surface. Slice 06 keeps
+      // them at `scopes: '*'` so kafka and other gated routes accept
+      // them, but stamps `source: 'agent'` so `requireRoot` rejects
+      // them from the new admin routes (Codex bug 2 — privilege-
+      // escalation guard).
       scopes: '*',
+      source: 'agent',
     };
-    setTokenRecord(tokenStore, record);
+    addTokenToStore(tokenStore, validTokens, record);
   }
-  const validTokens = new Set([...tokenStore.values()].map((r) => r.fullToken));
   const bridgeAuthToken =
     (await loadBridgeAuthToken()) ??
     (validTokens.size > 0

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -103,7 +103,7 @@ import {
 } from '../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
-import { loadTokens, loadTokenStore, httpAuthGuard, setTokenRecord, type TokenRecord } from '../auth.js';
+import { loadTokens, loadTokenStore, httpAuthGuard, setTokenRecord, tokenPrefix, type TokenRecord } from '../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../extraction/index.js';
 import {
@@ -1371,7 +1371,7 @@ export async function runDaemonInner(
   const tokenStore = await loadTokenStore(config.auth);
   for (const a of agent.listLocalAgents()) {
     const record: TokenRecord = {
-      prefix: a.authToken.length >= 8 ? a.authToken.slice(0, 8) : a.authToken,
+      prefix: tokenPrefix(a.authToken),
       fullToken: a.authToken,
       // Per-agent tokens are not user-mintable and have always granted
       // unscoped access. Treat them as `'*'` for slice 06's scope check.

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -103,7 +103,7 @@ import {
 } from '../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
-import { loadTokens, httpAuthGuard } from '../auth.js';
+import { loadTokens, loadTokenStore, httpAuthGuard, setTokenRecord, type TokenRecord } from '../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../extraction/index.js';
 import {
@@ -1364,16 +1364,27 @@ export async function runDaemonInner(
   // --- Authentication ---
 
   const authEnabled = config.auth?.enabled !== false;
-  const validTokens = await loadTokens(config.auth);
+  // Slice 06 — load the structured store first; the Set view is derived
+  // from it. Per-agent tokens are added to BOTH so the existing
+  // httpAuthGuard (Set-based) continues to accept them, and the new
+  // scope-aware routes see them as full-access (`scopes: '*'`).
+  const tokenStore = await loadTokenStore(config.auth);
+  for (const a of agent.listLocalAgents()) {
+    const record: TokenRecord = {
+      prefix: a.authToken.length >= 8 ? a.authToken.slice(0, 8) : a.authToken,
+      fullToken: a.authToken,
+      // Per-agent tokens are not user-mintable and have always granted
+      // unscoped access. Treat them as `'*'` for slice 06's scope check.
+      scopes: '*',
+    };
+    setTokenRecord(tokenStore, record);
+  }
+  const validTokens = new Set([...tokenStore.values()].map((r) => r.fullToken));
   const bridgeAuthToken =
     (await loadBridgeAuthToken()) ??
     (validTokens.size > 0
       ? (validTokens.values().next().value as string)
       : undefined);
-  // Register per-agent Bearer tokens so the auth guard accepts them
-  for (const a of agent.listLocalAgents()) {
-    validTokens.add(a.authToken);
-  }
 
   if (authEnabled) {
     log(
@@ -1625,6 +1636,7 @@ export async function runDaemonInner(
         vectorStore,
         embeddingProvider,
         validTokens,
+        tokenStore,
         apiHost,
         apiPortRef,
       );

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -106,7 +106,7 @@ import {
 } from '../../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
-import { loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
+import { loadTokens, httpAuthGuard, extractBearerToken, addTokenToStore, tokenPrefix, type TokenRecord } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
 import {
@@ -354,6 +354,7 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
     vectorStore,
     embeddingProvider,
     validTokens,
+    tokenStore,
     apiHost,
     apiPortRef,
     url,
@@ -373,7 +374,21 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
     }
     try {
       const record = await agent.registerAgent(name, { publicKey, framework });
-      validTokens.add(record.authToken);
+      // Slice 06 (Codex bug 3): runtime-issued agent tokens MUST land
+      // in BOTH `validTokens` (for httpAuthGuard) AND `tokenStore`
+      // (for verifyTokenScope). Without this, the daemon accepted the
+      // new token at the auth guard but 403'd it at every kafka /
+      // scope-gated route until restart. Stamped `source: 'agent'` so
+      // the new admin routes (`requireRoot`) reject it — agent
+      // registration must NEVER produce a token that can mint other
+      // tokens (privilege-escalation guard, Codex bug 2).
+      const tokenRecord: TokenRecord = {
+        prefix: tokenPrefix(record.authToken),
+        fullToken: record.authToken,
+        scopes: '*',
+        source: 'agent',
+      };
+      addTokenToStore(tokenStore, validTokens, tokenRecord);
       const response: Record<string, unknown> = {
         agentAddress: record.agentAddress,
         authToken: record.authToken,

--- a/packages/cli/src/daemon/routes/auth.ts
+++ b/packages/cli/src/daemon/routes/auth.ts
@@ -21,7 +21,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { mkdir, chmod, readFile } from 'node:fs/promises';
+import { mkdir, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import {
@@ -246,30 +246,45 @@ async function handleMint(ctx: RequestContext): Promise<void> {
   };
   if (fields.name !== undefined) record.name = fields.name;
 
-  await withMintMutex(async () => {
-    // Read-modify-write: re-read the file inside the mutex so we don't
-    // clobber records added by a concurrent CLI mint that landed
-    // BETWEEN the daemon's startup load and now. Without this, two
-    // sequential API mints would each append their record but only
-    // the second would survive on disk.
-    const filePath = tokenFilePath();
-    const existing = existsSync(filePath)
-      ? parseTokenFile(await readFile(filePath, 'utf-8'), {
-          onWarning: (msg) => console.warn(`[auth] ${msg}`),
-        })
-      : { store: new Map(), preserved: [] as Array<{ text: string; index: number }> };
+  try {
+    await withMintMutex(async () => {
+      // Read-modify-write: re-read the file inside the mutex so we don't
+      // clobber records added by a concurrent CLI mint that landed
+      // BETWEEN the daemon's startup load and now. Without this, two
+      // sequential API mints would each append their record but only
+      // the second would survive on disk.
+      const filePath = tokenFilePath();
+      const existing = existsSync(filePath)
+        ? parseTokenFile(await readFile(filePath, 'utf-8'), {
+            onWarning: (msg) => console.warn(`[auth] ${msg}`),
+          })
+        : { store: new Map(), preserved: [] as Array<{ text: string; index: number }> };
 
-    setTokenRecord(existing.store, record);
+      // Apply the mutation to the file's in-memory copy ONLY. The
+      // shared `ctx.tokenStore` and `ctx.validTokens` stay untouched
+      // until the disk write succeeds — see review I2: previously the
+      // in-memory state was mutated first, so a writeFileAtomic failure
+      // would leave the daemon accepting a token that is absent from
+      // disk; a restart would then silently revoke it.
+      setTokenRecord(existing.store, record);
 
-    // Mirror into the in-memory store so subsequent requests within
-    // this daemon process accept the new token without a restart.
-    setTokenRecord(ctx.tokenStore, record);
-    ctx.validTokens.add(newToken);
+      await mkdir(dirname(filePath), { recursive: true });
+      // `mode: 0o600` is enforced inside writeFileAtomic — the temp file
+      // is created with the right mode AND chmod'd defensively after
+      // rename, closing the umask-derived 0o644 window that review C1
+      // flagged.
+      await writeFileAtomic(filePath, serializeTokenStore(existing), { mode: 0o600 });
 
-    await mkdir(dirname(filePath), { recursive: true });
-    await writeFileAtomic(filePath, serializeTokenStore(existing));
-    await chmod(filePath, 0o600);
-  });
+      // Disk-write succeeded — now safe to publish the change to the
+      // running daemon's token set.
+      setTokenRecord(ctx.tokenStore, record);
+      ctx.validTokens.add(newToken);
+    });
+  } catch (err) {
+    return jsonResponse(res, 500, {
+      error: `Failed to persist token: ${err instanceof Error ? err.message : 'unknown error'}`,
+    });
+  }
 
   // Mint response — the ONLY surface that returns the full token.
   // Subsequent GET/DELETE responses MUST never include `token`.
@@ -323,24 +338,36 @@ async function handleRevoke(ctx: RequestContext): Promise<void> {
     });
   }
 
-  const result = await withMintMutex(async () => {
-    const filePath = tokenFilePath();
-    if (!existsSync(filePath)) return { found: false };
+  let result: { found: boolean };
+  try {
+    result = await withMintMutex(async () => {
+      const filePath = tokenFilePath();
+      if (!existsSync(filePath)) return { found: false };
 
-    const existing = parseTokenFile(await readFile(filePath, 'utf-8'), {
-      onWarning: (msg) => console.warn(`[auth] ${msg}`),
+      const existing = parseTokenFile(await readFile(filePath, 'utf-8'), {
+        onWarning: (msg) => console.warn(`[auth] ${msg}`),
+      });
+      const target = existing.store.get(prefix);
+      if (!target) return { found: false };
+
+      // Same disk-first ordering as the mint path (review I2): write
+      // the new file content BEFORE mutating the in-memory store, so a
+      // write failure leaves the daemon's accepted-token set
+      // consistent with what's on disk. Without this, a failed disk
+      // revoke would leave the daemon rejecting a token that is still
+      // in the file — a restart would resurrect it.
+      deleteTokenRecord(existing.store, prefix);
+      await writeFileAtomic(filePath, serializeTokenStore(existing), { mode: 0o600 });
+
+      deleteTokenRecord(ctx.tokenStore, prefix);
+      ctx.validTokens.delete(target.fullToken);
+      return { found: true };
     });
-    const target = existing.store.get(prefix);
-    if (!target) return { found: false };
-
-    deleteTokenRecord(existing.store, prefix);
-    deleteTokenRecord(ctx.tokenStore, prefix);
-    ctx.validTokens.delete(target.fullToken);
-
-    await writeFileAtomic(filePath, serializeTokenStore(existing));
-    await chmod(filePath, 0o600);
-    return { found: true };
-  });
+  } catch (err) {
+    return jsonResponse(res, 500, {
+      error: `Failed to persist token revocation: ${err instanceof Error ? err.message : 'unknown error'}`,
+    });
+  }
 
   if (!result.found) {
     // Documented choice: 404 on miss (NOT 204). The semantic is "the

--- a/packages/cli/src/daemon/routes/auth.ts
+++ b/packages/cli/src/daemon/routes/auth.ts
@@ -1,0 +1,357 @@
+/**
+ * `/api/auth/tokens` route group — root-only token administration.
+ *
+ * Slice 06 (ADR-0003). Adds three verbs:
+ *
+ *   POST   /api/auth/tokens               mint a scoped token
+ *   GET    /api/auth/tokens               list (prefix + scopes only — never the secret)
+ *   DELETE /api/auth/tokens/<prefix>      revoke by prefix (idempotent: 204 on hit, 404 on miss)
+ *
+ * Root-only: a "root" caller is one whose bearer token's scope set is
+ * `'*'` in the loaded store. Every other caller (any explicitly-scoped
+ * token) gets 403. ADR-0003 explicitly forbids an `auth:tokens:write`
+ * scope — letting a scope mint scopes is a privilege-escalation path.
+ *
+ * The full token is returned ONCE on mint. Subsequent list/get responses
+ * carry only `{prefix, scopes, name?, createdAt?}`. Storing the token
+ * (so `verifyToken` matches on later requests) goes through
+ * `writeFileAtomic` from `daemon/fs-utils.ts` — same atomic-rename
+ * pattern the auto-update flow uses, so concurrent CLI + API mints
+ * cannot interleave bytes.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { mkdir, chmod, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import {
+  jsonResponse,
+  readBody,
+  safeDecodeURIComponent,
+} from '../http-utils.js';
+import {
+  lookupTokenRecord,
+  parseTokenFile,
+  serializeTokenStore,
+  setTokenRecord,
+  deleteTokenRecord,
+  toPublicRecord,
+  tokenFilePath,
+  tokenPrefix,
+  type Scope,
+  type TokenRecord,
+} from '../../auth.js';
+import { writeFileAtomic } from '../fs-utils.js';
+import type { RequestContext } from './context.js';
+
+const BASE_PATH = '/api/auth/tokens';
+
+/**
+ * Serialization mutex. The on-disk write goes through `writeFileAtomic`
+ * (POSIX-rename atomic), but rename atomicity only guarantees that the
+ * resulting file is one of the inputs — under concurrent N parallel
+ * writes you'd lose N-1 of them because each write reads-modifies-writes
+ * a snapshot of the in-memory state.
+ *
+ * The mutex serializes the read-modify-write critical section on a
+ * SINGLE-PROCESS basis. Multi-process mints (e.g. simultaneous CLI +
+ * daemon API call) need a separate file-lock — out of scope for slice 06,
+ * documented as a known limitation.
+ */
+let mintMutex: Promise<void> = Promise.resolve();
+async function withMintMutex<T>(work: () => Promise<T>): Promise<T> {
+  const prev = mintMutex;
+  let release!: () => void;
+  mintMutex = new Promise((r) => { release = r; });
+  try {
+    await prev;
+    return await work();
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Generate a fresh secret. Same shape as the daemon's first-run token
+ * (32 bytes of entropy → base64url) — keeps the on-disk representation
+ * uniform across legacy and scoped lines.
+ */
+function generateSecret(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Verify the caller is "root" (scope set is exactly `'*'`). Sends a 403
+ * + returns false if not. We accept ONLY the wildcard — an explicit list
+ * that happens to include every known scope is NOT root, because new
+ * scopes will be added over time and we don't want to grandfather old
+ * lists into administering them.
+ */
+function requireRoot(ctx: RequestContext): boolean {
+  const record = lookupTokenRecord(ctx.requestToken, ctx.tokenStore);
+  if (!record || record.scopes !== '*') {
+    jsonResponse(ctx.res, 403, {
+      error: 'Root token required for token administration',
+    });
+    return false;
+  }
+  return true;
+}
+
+export async function handleAuthRoutes(ctx: RequestContext): Promise<void> {
+  const { req, path } = ctx;
+
+  if (req.method === 'POST' && path === BASE_PATH) {
+    if (!requireRoot(ctx)) return;
+    return handleMint(ctx);
+  }
+
+  if (req.method === 'GET' && path === BASE_PATH) {
+    if (!requireRoot(ctx)) return;
+    return handleList(ctx);
+  }
+
+  if (req.method === 'DELETE' && path.startsWith(`${BASE_PATH}/`)) {
+    if (!requireRoot(ctx)) return;
+    return handleRevoke(ctx);
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// POST /api/auth/tokens — mint
+// ───────────────────────────────────────────────────────────────────────────
+
+interface MintRequestBody {
+  scope?: unknown;
+  scopes?: unknown;
+  name?: unknown;
+}
+
+/**
+ * Parse the request body into a normalized `{scopes, name?}` shape.
+ * Returns null on a parse error (a 400 has already been written).
+ *
+ * The HTTP API accepts both `scope` and `scopes`; both can be either a
+ * comma-separated string or an array of strings. The CLI sends `scope`
+ * as a string for ergonomic flag handling, but UI clients tend to send
+ * arrays — so we accept both.
+ */
+function parseMintBody(
+  ctx: RequestContext,
+  body: MintRequestBody,
+): { scopes: Scope[] | '*'; name?: string } | null {
+  const { res } = ctx;
+  const rawScopes = body.scopes ?? body.scope;
+
+  if (rawScopes === undefined || rawScopes === null) {
+    jsonResponse(res, 400, {
+      error: '"scope" (or "scopes") is required: comma-separated string or array',
+    });
+    return null;
+  }
+
+  let scopeList: string[];
+  if (Array.isArray(rawScopes)) {
+    if (!rawScopes.every((s): s is string => typeof s === 'string')) {
+      jsonResponse(res, 400, { error: '"scopes" array entries must all be strings' });
+      return null;
+    }
+    scopeList = rawScopes.map((s) => s.trim()).filter((s) => s.length > 0);
+  } else if (typeof rawScopes === 'string') {
+    scopeList = rawScopes.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+  } else {
+    jsonResponse(res, 400, { error: '"scope" must be a string or array of strings' });
+    return null;
+  }
+
+  if (scopeList.length === 0) {
+    jsonResponse(res, 400, { error: 'at least one scope is required' });
+    return null;
+  }
+
+  // ADR-0003 forbids both wildcard mints AND an auth-management scope:
+  //   - wildcard `*` would mint a new root (privilege escalation).
+  //   - `auth:tokens:*` would let a scoped token mint scoped tokens
+  //     (privilege escalation).
+  // Both checks fire BEFORE the character allowlist so the operator
+  // gets a precise diagnostic message instead of "disallowed characters".
+  if (scopeList.includes('*')) {
+    jsonResponse(res, 400, {
+      error: 'wildcard scope "*" cannot be minted via API (root tokens are operator-managed)',
+    });
+    return null;
+  }
+  for (const s of scopeList) {
+    if (s.startsWith('auth:tokens:')) {
+      jsonResponse(res, 400, {
+        error: `scope "${s}" is reserved (token administration is root-only)`,
+      });
+      return null;
+    }
+    // Character allowlist (no `*` — that's the wildcard case above).
+    if (!/^[A-Za-z0-9_.:\-]+$/.test(s)) {
+      jsonResponse(res, 400, { error: `scope "${s}" contains disallowed characters` });
+      return null;
+    }
+  }
+
+  let name: string | undefined;
+  if (body.name !== undefined && body.name !== null) {
+    if (typeof body.name !== 'string') {
+      jsonResponse(res, 400, { error: '"name" must be a string when provided' });
+      return null;
+    }
+    const trimmed = body.name.trim();
+    if (trimmed.length > 0) {
+      // The on-disk format uses TAB as a field separator — names with TABs
+      // would corrupt the row. Reject early with a clear message.
+      if (trimmed.includes('\t') || trimmed.includes('\n')) {
+        jsonResponse(res, 400, {
+          error: '"name" cannot contain tab or newline characters',
+        });
+        return null;
+      }
+      name = trimmed;
+    }
+  }
+
+  const result: { scopes: Scope[] | '*'; name?: string } = { scopes: scopeList };
+  if (name !== undefined) result.name = name;
+  return result;
+}
+
+async function handleMint(ctx: RequestContext): Promise<void> {
+  const { req, res } = ctx;
+
+  const rawBody = await readBody(req);
+  let parsed: MintRequestBody;
+  try {
+    parsed = (rawBody.length === 0 ? {} : JSON.parse(rawBody)) as MintRequestBody;
+  } catch {
+    return jsonResponse(res, 400, { error: 'Invalid JSON in request body' });
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return jsonResponse(res, 400, { error: 'Body must be a JSON object' });
+  }
+
+  const fields = parseMintBody(ctx, parsed);
+  if (fields === null) return;
+
+  const newToken = generateSecret();
+  const record: TokenRecord = {
+    prefix: tokenPrefix(newToken),
+    fullToken: newToken,
+    scopes: fields.scopes,
+    createdAt: new Date().toISOString(),
+  };
+  if (fields.name !== undefined) record.name = fields.name;
+
+  await withMintMutex(async () => {
+    // Read-modify-write: re-read the file inside the mutex so we don't
+    // clobber records added by a concurrent CLI mint that landed
+    // BETWEEN the daemon's startup load and now. Without this, two
+    // sequential API mints would each append their record but only
+    // the second would survive on disk.
+    const filePath = tokenFilePath();
+    const existing = existsSync(filePath)
+      ? parseTokenFile(await readFile(filePath, 'utf-8'), {
+          onWarning: (msg) => console.warn(`[auth] ${msg}`),
+        })
+      : { store: new Map(), preserved: [] as Array<{ text: string; index: number }> };
+
+    setTokenRecord(existing.store, record);
+
+    // Mirror into the in-memory store so subsequent requests within
+    // this daemon process accept the new token without a restart.
+    setTokenRecord(ctx.tokenStore, record);
+    ctx.validTokens.add(newToken);
+
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFileAtomic(filePath, serializeTokenStore(existing));
+    await chmod(filePath, 0o600);
+  });
+
+  // Mint response — the ONLY surface that returns the full token.
+  // Subsequent GET/DELETE responses MUST never include `token`.
+  return jsonResponse(res, 201, {
+    token: newToken,
+    prefix: record.prefix,
+    scopes: record.scopes,
+    ...(record.name !== undefined ? { name: record.name } : {}),
+    createdAt: record.createdAt,
+  });
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// GET /api/auth/tokens — list (no secrets)
+// ───────────────────────────────────────────────────────────────────────────
+
+async function handleList(ctx: RequestContext): Promise<void> {
+  const { res } = ctx;
+  // `toPublicRecord` strips `fullToken`. Keep the iteration order from
+  // the in-memory store (insertion order) so the operator sees the
+  // mint order they remember.
+  const tokens = [...ctx.tokenStore.values()].map(toPublicRecord);
+  return jsonResponse(res, 200, { tokens });
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// DELETE /api/auth/tokens/<prefix> — revoke
+// ───────────────────────────────────────────────────────────────────────────
+
+async function handleRevoke(ctx: RequestContext): Promise<void> {
+  const { res, path } = ctx;
+  const encoded = path.slice(`${BASE_PATH}/`.length);
+  if (!encoded) {
+    return jsonResponse(res, 400, { error: 'Missing token prefix in path' });
+  }
+  if (encoded.includes('/')) {
+    return jsonResponse(res, 404, { error: 'Not found' });
+  }
+  const prefix = safeDecodeURIComponent(encoded, res);
+  if (prefix === null) return; // 400 already sent
+
+  // Guard against revoking yourself out of the system. We'd survive in
+  // memory until the next process restart, but the on-disk file would
+  // no longer carry the token, so the next daemon start would auto-
+  // generate a fresh one — disruptive and easy to footgun. Block it
+  // and tell the caller why.
+  const callerRecord = lookupTokenRecord(ctx.requestToken, ctx.tokenStore);
+  if (callerRecord && callerRecord.prefix === prefix) {
+    return jsonResponse(res, 400, {
+      error: 'Refusing to revoke the bearer token used to make this request',
+    });
+  }
+
+  const result = await withMintMutex(async () => {
+    const filePath = tokenFilePath();
+    if (!existsSync(filePath)) return { found: false };
+
+    const existing = parseTokenFile(await readFile(filePath, 'utf-8'), {
+      onWarning: (msg) => console.warn(`[auth] ${msg}`),
+    });
+    const target = existing.store.get(prefix);
+    if (!target) return { found: false };
+
+    deleteTokenRecord(existing.store, prefix);
+    deleteTokenRecord(ctx.tokenStore, prefix);
+    ctx.validTokens.delete(target.fullToken);
+
+    await writeFileAtomic(filePath, serializeTokenStore(existing));
+    await chmod(filePath, 0o600);
+    return { found: true };
+  });
+
+  if (!result.found) {
+    // Documented choice: 404 on miss (NOT 204). The semantic is "the
+    // resource you tried to delete doesn't exist", which 404 expresses
+    // more honestly than 204's "I deleted it" (lying about the world).
+    // Idempotency is preserved in the sense that repeating the call
+    // continues to return 404 deterministically.
+    return jsonResponse(res, 404, { error: `No token with prefix "${prefix}"` });
+  }
+  // 204 has no body per RFC 7230. Bypass `jsonResponse` (which always
+  // writes one) so we don't ship `null` as a body.
+  res.writeHead(204);
+  res.end();
+}

--- a/packages/cli/src/daemon/routes/auth.ts
+++ b/packages/cli/src/daemon/routes/auth.ts
@@ -34,7 +34,8 @@ import {
   parseTokenFile,
   serializeTokenStore,
   setTokenRecord,
-  deleteTokenRecord,
+  addTokenToStore,
+  removeTokenFromStore,
   toPublicRecord,
   tokenFilePath,
   tokenPrefix,
@@ -81,15 +82,35 @@ function generateSecret(): string {
 }
 
 /**
- * Verify the caller is "root" (scope set is exactly `'*'`). Sends a 403
- * + returns false if not. We accept ONLY the wildcard — an explicit list
- * that happens to include every known scope is NOT root, because new
- * scopes will be added over time and we don't want to grandfather old
- * lists into administering them.
+ * Verify the caller is "root" (scope set is exactly `'*'`) AND the
+ * caller's token came from an OPERATOR-managed source — `'file'` (the
+ * on-disk auth.token) or `'config'` (dkg.config.yaml). Sends 403 +
+ * returns false otherwise.
+ *
+ * Why source matters (Codex bug 2): per-agent tokens issued by
+ * `/api/agent/register` carry `scopes: '*'` for backward-compat on every
+ * other API surface — pre-slice-06 they had unscoped access to
+ * everything. Slice 06 added the admin routes; without a source check,
+ * any registered agent could mint/list/revoke node auth tokens — a
+ * privilege-escalation path. The source field walls off auth admin
+ * to operator-controlled tokens.
+ *
+ * `'config'` IS accepted as root: putting a token in `dkg.config.yaml`
+ * is itself an operator action, and the test/dev workflow relies on it.
+ *
+ * We accept ONLY the wildcard scope — an explicit list that happens
+ * to include every known scope is NOT root, because new scopes will be
+ * added over time and we don't want to grandfather old lists into
+ * administering them.
+ *
+ * When `auth.enabled = false` the guard short-circuits to true (Codex
+ * bug 1), matching `httpAuthGuard`'s bypass semantics.
  */
 function requireRoot(ctx: RequestContext): boolean {
+  if (!ctx.authEnabled) return true;
   const record = lookupTokenRecord(ctx.requestToken, ctx.tokenStore);
-  if (!record || record.scopes !== '*') {
+  const isOperatorSource = record?.source === 'file' || record?.source === 'config';
+  if (!record || record.scopes !== '*' || !isOperatorSource) {
     jsonResponse(ctx.res, 403, {
       error: 'Root token required for token administration',
     });
@@ -241,6 +262,8 @@ async function handleMint(ctx: RequestContext): Promise<void> {
     fullToken: newToken,
     scopes: fields.scopes,
     createdAt: new Date().toISOString(),
+    // Mint always writes to disk, so the canonical source is `'file'`.
+    source: 'file',
   };
   if (fields.name !== undefined) record.name = fields.name;
 
@@ -274,9 +297,11 @@ async function handleMint(ctx: RequestContext): Promise<void> {
       await writeFileAtomic(filePath, serializeTokenStore(existing), { mode: 0o600 });
 
       // Disk-write succeeded — now safe to publish the change to the
-      // running daemon's token set.
-      setTokenRecord(ctx.tokenStore, record);
-      ctx.validTokens.add(newToken);
+      // running daemon's token set. Goes through `addTokenToStore` so
+      // the structured store and the legacy `validTokens` Set never
+      // drift (Codex bug 3 — same helper the runtime agent register
+      // path uses).
+      addTokenToStore(ctx.tokenStore, ctx.validTokens, record);
     });
   } catch (err) {
     return jsonResponse(res, 500, {
@@ -354,11 +379,11 @@ async function handleRevoke(ctx: RequestContext): Promise<void> {
       // consistent with what's on disk. Without this, a failed disk
       // revoke would leave the daemon rejecting a token that is still
       // in the file — a restart would resurrect it.
-      deleteTokenRecord(existing.store, prefix);
+      existing.store.delete(prefix);
       await writeFileAtomic(filePath, serializeTokenStore(existing), { mode: 0o600 });
 
-      deleteTokenRecord(ctx.tokenStore, prefix);
-      ctx.validTokens.delete(target.fullToken);
+      // Lockstep removal from BOTH structures (Codex bug 3).
+      removeTokenFromStore(ctx.tokenStore, ctx.validTokens, prefix);
       return { found: true };
     });
   } catch (err) {

--- a/packages/cli/src/daemon/routes/auth.ts
+++ b/packages/cli/src/daemon/routes/auth.ts
@@ -5,7 +5,7 @@
  *
  *   POST   /api/auth/tokens               mint a scoped token
  *   GET    /api/auth/tokens               list (prefix + scopes only — never the secret)
- *   DELETE /api/auth/tokens/<prefix>      revoke by prefix (idempotent: 204 on hit, 404 on miss)
+ *   DELETE /api/auth/tokens/<prefix>      revoke by prefix (204 on first delete; 404 if already gone)
  *
  * Root-only: a "root" caller is one whose bearer token's scope set is
  * `'*'` in the loaded store. Every other caller (any explicitly-scoped
@@ -215,9 +215,7 @@ function parseMintBody(
     }
   }
 
-  const result: { scopes: Scope[] | '*'; name?: string } = { scopes: scopeList };
-  if (name !== undefined) result.name = name;
-  return result;
+  return { scopes: scopeList, ...(name !== undefined ? { name } : {}) };
 }
 
 async function handleMint(ctx: RequestContext): Promise<void> {

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -52,8 +52,20 @@ export interface RequestContext {
    * `verifyTokenScope`. Legacy tokens carry scope `'*'` and pass every
    * scope check, preserving backward compat for the routes that have
    * not yet been gated.
+   *
+   * Mutation MUST go through `addTokenToStore` / `removeTokenFromStore`
+   * so the structured map and the `validTokens` Set never drift (Codex
+   * bug 3 — runtime agent register).
    */
   tokenStore: TokenStore;
+  /**
+   * Master auth-enabled flag (mirrors `config.auth?.enabled !== false`).
+   * Per-route scope gates (`requireScope`, `requireRoot`) MUST honor
+   * this — when auth is disabled, `httpAuthGuard` short-circuits to
+   * allow all requests, and a downstream scope gate that ignored the
+   * flag would 403 the same requests (Codex bug 1 regression).
+   */
+  authEnabled: boolean;
   // API socket identity — trusted server-side state for manifestSelfClient
   // SSRF defence.
   apiHost: string;

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -21,6 +21,7 @@ import type { ExtractionStatusRecord } from '../../extraction-status.js';
 import type { FileStore } from '../../file-store.js';
 import type { VectorStore, EmbeddingProvider } from '../../vector-store.js';
 import type { CatchupTracker } from '../types.js';
+import type { TokenStore } from '../../auth.js';
 
 export interface RequestContext {
   req: IncomingMessage;
@@ -45,6 +46,14 @@ export interface RequestContext {
   vectorStore: VectorStore;
   embeddingProvider: EmbeddingProvider | null;
   validTokens: Set<string>;
+  /**
+   * Slice 06 — structured token store backing `validTokens`. Routes that
+   * need scope checks (e.g. kafka, auth admin) read from here via
+   * `verifyTokenScope`. Legacy tokens carry scope `'*'` and pass every
+   * scope check, preserving backward compat for the routes that have
+   * not yet been gated.
+   */
+  tokenStore: TokenStore;
   // API socket identity — trusted server-side state for manifestSelfClient
   // SSRF defence.
   apiHost: string;

--- a/packages/cli/src/daemon/routes/kafka.ts
+++ b/packages/cli/src/daemon/routes/kafka.ts
@@ -11,6 +11,7 @@ import {
   type KafkaEndpointRequestBody,
   type KafkaEndpointVerifyRequestBody,
 } from '../parsers/kafka-request.js';
+import { verifyTokenScope, type Scope } from '../../auth.js';
 import type { RequestContext } from './context.js';
 import {
   getKafkaEndpoint,
@@ -37,31 +38,58 @@ const VALID_LIST_STATUSES: ReadonlySet<KafkaEndpointListStatus> = new Set([
   'all',
 ]);
 
+/**
+ * Per-route scope guard. Returns true when the caller's bearer token
+ * carries `scope` (or wildcard `*`); when false, a 403 (NOT 401) has
+ * already been written to the response — caller must early-return.
+ *
+ * 403 distinguishes "valid token, wrong permission" from 401's "no /
+ * invalid token". The httpAuthGuard at the top of the request pipeline
+ * already enforces 401; by the time a kafka handler runs we know the
+ * token is valid, so any rejection here is a scope mismatch.
+ *
+ * No `WWW-Authenticate` header — that header is reserved for 401
+ * responses by RFC 7235; sending it on a 403 confuses clients about
+ * whether to re-prompt for credentials.
+ */
+function requireScope(ctx: RequestContext, scope: Scope): boolean {
+  if (verifyTokenScope(ctx.requestToken, scope, ctx.tokenStore)) return true;
+  jsonResponse(ctx.res, 403, {
+    error: `Token lacks required scope: ${scope}`,
+  });
+  return false;
+}
+
 export async function handleKafkaRoutes(ctx: RequestContext): Promise<void> {
   const { req, path } = ctx;
 
-  // POST /api/kafka/endpoint — register
+  // POST /api/kafka/endpoint — register (write)
   if (req.method === 'POST' && path === ENDPOINT_BASE_PATH) {
+    if (!requireScope(ctx, 'kafka:endpoint:write')) return;
     return handleRegister(ctx);
   }
 
-  // POST /api/kafka/endpoint/verify — re-verify
+  // POST /api/kafka/endpoint/verify — re-verify (write — mutates the KA)
   if (req.method === 'POST' && path === `${ENDPOINT_BASE_PATH}/verify`) {
+    if (!requireScope(ctx, 'kafka:endpoint:write')) return;
     return handleVerify(ctx);
   }
 
-  // GET /api/kafka/endpoint?contextGraphId=X[&status=...] — list
+  // GET /api/kafka/endpoint?contextGraphId=X[&status=...] — list (read)
   if (req.method === 'GET' && path === ENDPOINT_BASE_PATH) {
+    if (!requireScope(ctx, 'kafka:endpoint:read')) return;
     return handleList(ctx);
   }
 
-  // GET /api/kafka/endpoint/<urlencoded-uri> — single fetch
+  // GET /api/kafka/endpoint/<urlencoded-uri> — single fetch (read)
   if (req.method === 'GET' && path.startsWith(`${ENDPOINT_BASE_PATH}/`)) {
+    if (!requireScope(ctx, 'kafka:endpoint:read')) return;
     return handleGetByUri(ctx);
   }
 
-  // DELETE /api/kafka/endpoint/<urlencoded-uri> — soft-revoke
+  // DELETE /api/kafka/endpoint/<urlencoded-uri> — soft-revoke (write)
   if (req.method === 'DELETE' && path.startsWith(`${ENDPOINT_BASE_PATH}/`)) {
+    if (!requireScope(ctx, 'kafka:endpoint:write')) return;
     return handleRevoke(ctx);
   }
 }

--- a/packages/cli/src/daemon/routes/kafka.ts
+++ b/packages/cli/src/daemon/routes/kafka.ts
@@ -51,8 +51,15 @@ const VALID_LIST_STATUSES: ReadonlySet<KafkaEndpointListStatus> = new Set([
  * No `WWW-Authenticate` header — that header is reserved for 401
  * responses by RFC 7235; sending it on a 403 confuses clients about
  * whether to re-prompt for credentials.
+ *
+ * When `auth.enabled = false` the guard short-circuits to true (Codex
+ * bug 1). `httpAuthGuard` already bypasses auth in that mode, so a
+ * scope check that ignored the flag would 403 requests that used to
+ * succeed unauthenticated — a regression for every operator running
+ * with auth disabled (typical dev/test setup).
  */
 function requireScope(ctx: RequestContext, scope: Scope): boolean {
+  if (!ctx.authEnabled) return true;
   if (verifyTokenScope(ctx.requestToken, scope, ctx.tokenStore)) return true;
   jsonResponse(ctx.res, 403, {
     error: `Token lacks required scope: ${scope}`,

--- a/packages/cli/src/token-store.ts
+++ b/packages/cli/src/token-store.ts
@@ -1,0 +1,384 @@
+/**
+ * Pure parser + serializer for the DKG auth token file.
+ *
+ * File format (extension over the legacy single-line format — backward
+ * compat is non-negotiable, see ADR-0003):
+ *
+ *   <token>                                              # legacy → scopes = '*'
+ *   <token><TAB><scope1,scope2,...>                      # scoped
+ *   <token><TAB><scopes><TAB><name>                      # scoped + name
+ *   <token><TAB><scopes><TAB><name><TAB><createdAt>      # full record
+ *   # comment                                            # preserved on round-trip
+ *                                                        # blank line preserved
+ *
+ * Deep-module discipline: no I/O, no global state. The I/O lives in
+ * `auth.ts` (which calls `parseTokenFile` on the on-disk content).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * A scope is a free-form string (e.g. `kafka:endpoint:write`). The literal
+ * string `'*'` is the wildcard "full access" marker — used for legacy
+ * scope-less tokens AND for explicitly-root tokens minted via the API.
+ */
+export type Scope = string;
+
+/**
+ * Records survive a round-trip: parsing then serializing the same input
+ * yields the same bytes for any input that already carries full records
+ * (token + scopes + name + createdAt). For inputs missing optional fields
+ * (legacy scope-less, or scope-only-no-name lines), the serializer emits
+ * the canonical field count for what's present — see `serializeTokenStore`.
+ */
+export interface TokenRecord {
+  /** First 8 chars of the full token. Used for list/revoke API surfaces. */
+  prefix: string;
+  /** The on-disk secret. NEVER returned in list/get responses. */
+  fullToken: string;
+  /** Either `'*'` (full access) or a list of explicit scope strings. */
+  scopes: Scope[] | '*';
+  /** Optional human-readable label. */
+  name?: string;
+  /** ISO-8601 timestamp the token was minted. */
+  createdAt?: string;
+}
+
+/**
+ * Map keyed by token prefix. We key by prefix (not by full token) because
+ * the prefix is the public identifier (used by list/revoke) — full-token
+ * lookup goes through `lookupTokenRecord`.
+ *
+ * Insertion order is preserved (JS Maps do this), and the serializer
+ * relies on it for round-trip determinism.
+ */
+export type TokenStore = Map<string, TokenRecord>;
+
+/**
+ * Comments + blank lines that lived in the source file. Stored alongside
+ * the records (with their position relative to the records) so the
+ * serializer can re-emit them in the right place. Without this, a
+ * round-trip would silently strip `# comment` headers from operator-edited
+ * files.
+ *
+ * Position semantics: `index` is the record-position the line appears
+ * BEFORE. An `index` equal to `records.length` means "after the last
+ * record" (trailing comments / blank lines).
+ */
+export interface PreservedLine {
+  /** Verbatim line content (no trailing newline). */
+  text: string;
+  /** Insertion position relative to records. */
+  index: number;
+}
+
+/**
+ * Output of `parseTokenFile`. The serializer takes the same shape so a
+ * full round-trip stays byte-identical for well-formed inputs.
+ */
+export interface ParsedTokenFile {
+  store: TokenStore;
+  preserved: PreservedLine[];
+}
+
+/**
+ * The first 8 chars of a token are the public identifier. Kept short so
+ * it fits in a CLI table, kept consistent across the codebase by going
+ * through this single helper.
+ *
+ * If a token is shorter than 8 chars (only happens in malformed test
+ * fixtures — production tokens are 43 chars of base64url) we use the
+ * whole thing.
+ */
+export function tokenPrefix(token: string): string {
+  return token.length >= 8 ? token.slice(0, 8) : token;
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+export interface ParseTokenFileOptions {
+  /**
+   * Optional sink for warnings (malformed lines, duplicate prefixes). We
+   * route through a callback rather than `console.warn` so the daemon can
+   * forward them to its `Logger`. Defaults to silent.
+   */
+  onWarning?: (msg: string) => void;
+}
+
+/**
+ * Parse a token-file blob. Skips malformed lines with a warning instead of
+ * throwing — a single bad line should never lock an operator out.
+ *
+ * Lines starting with `#` are comments. Blank lines are preserved. Both
+ * are recorded as `PreservedLine` entries so the serializer can re-emit
+ * them in their original positions.
+ */
+export function parseTokenFile(
+  raw: string,
+  opts: ParseTokenFileOptions = {},
+): ParsedTokenFile {
+  const onWarning = opts.onWarning ?? (() => { /* silent */ });
+
+  const store: TokenStore = new Map();
+  const preserved: PreservedLine[] = [];
+
+  // Splitting on `\n` and stripping a trailing `\r` keeps round-trip
+  // semantics correct on both LF and CRLF inputs without forcing one or
+  // the other on the serializer (we always emit LF — see
+  // `serializeTokenStore`'s contract). A trailing `\n` produces a final
+  // empty entry which we skip below.
+  const lines = raw.split('\n');
+
+  // Drop a single trailing empty entry produced by a file that ends in
+  // `\n` — this lets the round-trip be byte-identical instead of growing
+  // an extra blank line on every save.
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+
+    // Comments + blank lines: preserve verbatim, skip parsing.
+    if (line.length === 0 || line.startsWith('#')) {
+      preserved.push({ text: line, index: store.size });
+      continue;
+    }
+
+    // We tolerate leading/trailing whitespace around the WHOLE line for
+    // legacy compatibility (the old parser called `.trim()`), but we do
+    // NOT trim per-field — TAB-separated fields can legitimately contain
+    // leading spaces in the `name` field. Inner whitespace is the
+    // operator's business.
+    //
+    // The fields:
+    //   [0] token (required)
+    //   [1] scopes (comma-separated; empty → `'*'`? NO — empty is a
+    //       parse error; '*' must be explicit. Legacy lines have NO field
+    //       1 at all, which IS the '*' case.)
+    //   [2] name (optional, free-form)
+    //   [3] createdAt (optional, ISO-8601)
+    //
+    // Lines with more than 4 fields are malformed. Lines with empty
+    // token field are malformed.
+    const fields = line.split('\t');
+    const token = fields[0]?.trim() ?? '';
+    if (token.length === 0) {
+      onWarning(`token-store: skipping malformed line (empty token): ${truncateForLog(line)}`);
+      continue;
+    }
+
+    let scopes: Scope[] | '*';
+    if (fields.length === 1) {
+      // Legacy: token-only line. Full access.
+      scopes = '*';
+    } else {
+      const scopesField = fields[1] ?? '';
+      const parsed = parseScopesField(scopesField);
+      if (parsed === null) {
+        onWarning(
+          `token-store: skipping malformed line (bad scopes field "${truncateForLog(scopesField)}"): token=${tokenPrefix(token)}`,
+        );
+        continue;
+      }
+      scopes = parsed;
+    }
+
+    if (fields.length > 4) {
+      onWarning(
+        `token-store: skipping malformed line (too many tab-separated fields, expected ≤4 got ${fields.length}): token=${tokenPrefix(token)}`,
+      );
+      continue;
+    }
+
+    const name = fields[2] && fields[2].length > 0 ? fields[2] : undefined;
+    const createdAt = fields[3] && fields[3].length > 0 ? fields[3] : undefined;
+
+    const prefix = tokenPrefix(token);
+
+    if (store.has(prefix)) {
+      onWarning(
+        `token-store: duplicate token prefix ${prefix} — keeping first occurrence`,
+      );
+      continue;
+    }
+
+    const record: TokenRecord = { prefix, fullToken: token, scopes };
+    if (name !== undefined) record.name = name;
+    if (createdAt !== undefined) record.createdAt = createdAt;
+    store.set(prefix, record);
+  }
+
+  return { store, preserved };
+}
+
+/**
+ * Parse a single scopes field. Returns `'*'` when the literal `*` is
+ * supplied, an array of trimmed non-empty scopes for a comma list, or
+ * `null` to signal a malformed field (caller skips the whole line).
+ *
+ * An empty string is treated as malformed because legacy "no scopes →
+ * full access" comes from a missing field 1, not an empty one.
+ */
+function parseScopesField(raw: string): Scope[] | '*' | null {
+  const value = raw.trim();
+  if (value.length === 0) return null;
+  if (value === '*') return '*';
+  const parts = value.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+  if (parts.length === 0) return null;
+  // Reject obviously-malformed scope strings. We allow `:` (the slice 06
+  // verb-namespace separator), letters/digits/dash/dot/underscore. Reject
+  // whitespace and tabs and the wildcard mixed with other entries.
+  for (const p of parts) {
+    if (!/^[A-Za-z0-9_.:\-*]+$/.test(p)) return null;
+  }
+  // A list containing `*` is meaningless — `*` must stand alone. Reject.
+  if (parts.includes('*')) return null;
+  return parts;
+}
+
+function truncateForLog(s: string): string {
+  return s.length > 80 ? s.slice(0, 77) + '...' : s;
+}
+
+// ---------------------------------------------------------------------------
+// Serializer
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a token store back to file content. Round-trip-safe for inputs
+ * produced by `parseTokenFile`: parsing the output of `serializeTokenStore`
+ * applied to a `ParsedTokenFile` yields the same `ParsedTokenFile`.
+ *
+ * Field-count discipline:
+ *   - legacy `'*'` records with no name/createdAt → token-only line
+ *   - explicit-`'*'` records with name → token + `*` + name
+ *   - scoped records → token + scopes + (name?) + (createdAt?), trailing
+ *     empty fields suppressed
+ *
+ * Comments and blank lines from `preserved` are re-emitted at their
+ * recorded positions.
+ */
+export function serializeTokenStore(parsed: ParsedTokenFile): string {
+  const { store, preserved } = parsed;
+  const records = [...store.values()];
+
+  const lines: string[] = [];
+
+  // Pre-bucket preserved lines by the record-index they precede. Multiple
+  // entries with the same `index` keep their original order.
+  const buckets = new Map<number, PreservedLine[]>();
+  for (const p of preserved) {
+    const bucket = buckets.get(p.index) ?? [];
+    bucket.push(p);
+    buckets.set(p.index, bucket);
+  }
+
+  for (let i = 0; i < records.length; i++) {
+    const before = buckets.get(i);
+    if (before) {
+      for (const p of before) lines.push(p.text);
+    }
+    lines.push(formatRecord(records[i]!));
+  }
+
+  // Trailing preserved lines (after the last record).
+  const trailing = buckets.get(records.length);
+  if (trailing) {
+    for (const p of trailing) lines.push(p.text);
+  }
+
+  return lines.length === 0 ? '' : lines.join('\n') + '\n';
+}
+
+function formatRecord(r: TokenRecord): string {
+  const fields: string[] = [r.fullToken];
+
+  // Legacy single-field shape: only used when scopes is '*' AND there's no
+  // name/createdAt. Any record with a name or timestamp must emit at
+  // least the scopes field so the parser knows the trailing fields are
+  // metadata, not part of a malformed token.
+  if (r.scopes === '*' && r.name === undefined && r.createdAt === undefined) {
+    return fields[0]!;
+  }
+
+  fields.push(r.scopes === '*' ? '*' : r.scopes.join(','));
+
+  if (r.name !== undefined || r.createdAt !== undefined) {
+    fields.push(r.name ?? '');
+  }
+  if (r.createdAt !== undefined) {
+    fields.push(r.createdAt);
+  }
+
+  return fields.join('\t');
+}
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the record for a given full token, or undefined. Done as a
+ * sequential scan because the map is keyed by prefix and prefix collisions
+ * are possible (extremely rare for 32-byte base64url tokens — birthday
+ * collision on 8 chars of base64url is ~1 in 2^48 — but possible). On a
+ * collision we still want to find the record whose `fullToken` matches.
+ *
+ * For the common case (no collision) the prefix lookup hits in O(1) and
+ * we compare one full token.
+ */
+export function lookupTokenRecord(
+  fullToken: string | undefined,
+  store: TokenStore,
+): TokenRecord | undefined {
+  if (!fullToken) return undefined;
+  const prefix = tokenPrefix(fullToken);
+  const candidate = store.get(prefix);
+  if (candidate && candidate.fullToken === fullToken) return candidate;
+  // Collision fallback: linear scan.
+  for (const r of store.values()) {
+    if (r.fullToken === fullToken) return r;
+  }
+  return undefined;
+}
+
+/**
+ * Add a record. Returns the same store (mutated). If a prefix collision
+ * occurs (vanishingly unlikely with random 43-char tokens, but possible
+ * in tests / for short fixtures), the new record replaces the old one
+ * and the caller is responsible for any rollback. Mint flows MUST
+ * detect collisions before calling this — the API gives them the
+ * `lookupTokenRecord` helper for that.
+ */
+export function setTokenRecord(store: TokenStore, record: TokenRecord): TokenStore {
+  store.set(record.prefix, record);
+  return store;
+}
+
+/** Remove a record by prefix. Returns true when an entry was deleted. */
+export function deleteTokenRecord(store: TokenStore, prefix: string): boolean {
+  return store.delete(prefix);
+}
+
+/**
+ * Sanitized public view of a record — drops `fullToken`. List/get APIs
+ * MUST go through this to avoid leaking secrets in subsequent responses.
+ */
+export interface PublicTokenRecord {
+  prefix: string;
+  scopes: Scope[] | '*';
+  name?: string;
+  createdAt?: string;
+}
+
+export function toPublicRecord(r: TokenRecord): PublicTokenRecord {
+  const out: PublicTokenRecord = { prefix: r.prefix, scopes: r.scopes };
+  if (r.name !== undefined) out.name = r.name;
+  if (r.createdAt !== undefined) out.createdAt = r.createdAt;
+  return out;
+}

--- a/packages/cli/src/token-store.ts
+++ b/packages/cli/src/token-store.ts
@@ -27,6 +27,20 @@
 export type Scope = string;
 
 /**
+ * Where a token came from. In-memory only — the parser never reads it
+ * (everything from disk is implicitly `'file'`) and the serializer
+ * never writes it. Drives:
+ *   - `requireRoot` (Codex bug 2): only `'file'` and `'config'` tokens
+ *     can pass — `'agent'` tokens have always been auto-issued by
+ *     `/api/agent/register` and treating them as root admin would be
+ *     a privilege-escalation path.
+ *   - `dkg auth list-tokens` rendering (Codex bug 4): operator sees
+ *     at a glance which rows are revocable via DELETE (only `'file'`)
+ *     vs. which require config edits / agent restarts.
+ */
+export type TokenSource = 'file' | 'config' | 'agent';
+
+/**
  * Records survive a round-trip: parsing then serializing the same input
  * yields the same bytes for any input that already carries full records
  * (token + scopes + name + createdAt). For inputs missing optional fields
@@ -44,6 +58,13 @@ export interface TokenRecord {
   name?: string;
   /** ISO-8601 timestamp the token was minted. */
   createdAt?: string;
+  /**
+   * Where the token came from. In-memory only; never serialized. The
+   * parser stamps every line as `'file'`; consumer code (lifecycle,
+   * agent register, mint route) is responsible for tagging non-file
+   * sources before inserting into the store.
+   */
+  source: TokenSource;
 }
 
 /**
@@ -207,7 +228,10 @@ export function parseTokenFile(
       continue;
     }
 
-    const record: TokenRecord = { prefix, fullToken: token, scopes };
+    // Every line read off disk is by definition `source: 'file'`. The
+    // `'config'` and `'agent'` sources are stamped by lifecycle wiring,
+    // never appear in the file format, and never round-trip to disk.
+    const record: TokenRecord = { prefix, fullToken: token, scopes, source: 'file' };
     if (name !== undefined) record.name = name;
     if (createdAt !== undefined) record.createdAt = createdAt;
     store.set(prefix, record);
@@ -348,6 +372,46 @@ export function lookupTokenRecord(
 }
 
 /**
+ * Add a record to BOTH the structured store AND the legacy
+ * `validTokens` Set in lockstep (Codex bug 3). Anything that issues a
+ * new token at runtime — startup loader, mint route, runtime agent
+ * register at `/api/agent/register` — MUST go through this single
+ * helper so the two structures never drift.
+ *
+ * Without this, the historical `validTokens.add(...)` pattern at the
+ * agent-register site bypassed the structured store, so freshly
+ * registered agents passed `httpAuthGuard` (Set-based) but got 403
+ * from every scope-checked route until daemon restart.
+ *
+ * Returns the record so callers can chain.
+ */
+export function addTokenToStore(
+  store: TokenStore,
+  validTokens: Set<string>,
+  record: TokenRecord,
+): TokenRecord {
+  setTokenRecord(store, record);
+  validTokens.add(record.fullToken);
+  return record;
+}
+
+/**
+ * Remove a record from BOTH structures in lockstep — the dual of
+ * `addTokenToStore`. Returns true when an entry was removed.
+ */
+export function removeTokenFromStore(
+  store: TokenStore,
+  validTokens: Set<string>,
+  prefix: string,
+): boolean {
+  const target = store.get(prefix);
+  if (!target) return false;
+  deleteTokenRecord(store, prefix);
+  validTokens.delete(target.fullToken);
+  return true;
+}
+
+/**
  * Add a record. Returns the same store (mutated). If a prefix collision
  * occurs (vanishingly unlikely with random 43-char tokens, but possible
  * in tests / for short fixtures), the new record replaces the old one
@@ -368,16 +432,23 @@ export function deleteTokenRecord(store: TokenStore, prefix: string): boolean {
 /**
  * Sanitized public view of a record — drops `fullToken`. List/get APIs
  * MUST go through this to avoid leaking secrets in subsequent responses.
+ *
+ * `source` IS included (Codex bug 4): operators need to know which rows
+ * are revocable via `DELETE /api/auth/tokens/<prefix>` (only `'file'`
+ * — `'config'` requires editing dkg.config.yaml; `'agent'` is auto-
+ * issued by `/api/agent/register` and lives in the running daemon's
+ * memory only).
  */
 export interface PublicTokenRecord {
   prefix: string;
   scopes: Scope[] | '*';
   name?: string;
   createdAt?: string;
+  source: TokenSource;
 }
 
 export function toPublicRecord(r: TokenRecord): PublicTokenRecord {
-  const out: PublicTokenRecord = { prefix: r.prefix, scopes: r.scopes };
+  const out: PublicTokenRecord = { prefix: r.prefix, scopes: r.scopes, source: r.source };
   if (r.name !== undefined) out.name = r.name;
   if (r.createdAt !== undefined) out.createdAt = r.createdAt;
   return out;

--- a/packages/cli/test/auth-cli-smoke.test.ts
+++ b/packages/cli/test/auth-cli-smoke.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Slice 06 — CLI smoke tests for `dkg auth mint-token / list-tokens / revoke-token`.
+ *
+ * Stands up a real CLI subprocess (`node dist/cli.js`) against a stub
+ * HTTP server impersonating the daemon. Mirrors the approach in
+ * `kafka-cli-smoke.test.ts` so the auth-token flows are exercised
+ * end-to-end through commander.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createServer } from 'node:http';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_ENTRY = join(__dirname, '..', 'dist', 'cli.js');
+
+interface CapturedRequest {
+  url: string;
+  body: string;
+  authHeader: string;
+  method: string;
+}
+interface NextResponse {
+  status: number;
+  body?: unknown;
+}
+
+describe.sequential('auth CLI smoke', () => {
+  let dkgHome: string;
+  let server: ReturnType<typeof createServer>;
+  let port: string;
+  let last: CapturedRequest = { url: '', body: '', authHeader: '', method: '' };
+  let mintResponse: NextResponse | null = null;
+  let listResponse: NextResponse | null = null;
+  let revokeResponse: NextResponse | null = null;
+
+  beforeAll(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-auth-cli-'));
+    if (!existsSync(CLI_ENTRY)) {
+      await execFileAsync('pnpm', ['build'], { cwd: join(__dirname, '..') });
+    }
+    if (!existsSync(CLI_ENTRY)) {
+      throw new Error(`CLI entry not found after build: ${CLI_ENTRY}`);
+    }
+
+    await writeFile(join(dkgHome, 'auth.token'), 'smoke-root-token\n');
+
+    server = createServer(async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      const body = Buffer.concat(chunks).toString('utf8');
+      last = {
+        url: req.url ?? '',
+        body,
+        authHeader: String(req.headers.authorization ?? ''),
+        method: req.method ?? '',
+      };
+
+      if (req.method === 'POST' && req.url === '/api/auth/tokens' && mintResponse) {
+        const r = mintResponse;
+        mintResponse = null;
+        res.writeHead(r.status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(r.body ?? {}));
+        return;
+      }
+      if (req.method === 'GET' && req.url === '/api/auth/tokens' && listResponse) {
+        const r = listResponse;
+        listResponse = null;
+        res.writeHead(r.status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(r.body ?? {}));
+        return;
+      }
+      if (req.method === 'DELETE' && req.url?.startsWith('/api/auth/tokens/') && revokeResponse) {
+        const r = revokeResponse;
+        revokeResponse = null;
+        if (r.status === 204) {
+          res.writeHead(204);
+          res.end();
+        } else {
+          res.writeHead(r.status, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(r.body ?? {}));
+        }
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address();
+        port = typeof addr === 'object' && addr ? String(addr.port) : '0';
+        resolve();
+      });
+    });
+  }, 90_000);
+
+  beforeEach(() => {
+    last = { url: '', body: '', authHeader: '', method: '' };
+    mintResponse = null;
+    listResponse = null;
+    revokeResponse = null;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('dkg auth mint-token --scope kafka:endpoint:write prints the full token once', async () => {
+    mintResponse = {
+      status: 201,
+      body: {
+        token: 'minted-secret-XYZ',
+        prefix: 'minted-s',
+        scopes: ['kafka:endpoint:write'],
+        name: 'producer-bot',
+        createdAt: '2026-05-04T13:00:00.000Z',
+      },
+    };
+    const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: port };
+    const result = await execFileAsync('node', [
+      CLI_ENTRY,
+      'auth',
+      'mint-token',
+      '--scope',
+      'kafka:endpoint:write',
+      '--name',
+      'producer-bot',
+    ], { env });
+
+    expect(last.method).toBe('POST');
+    expect(last.url).toBe('/api/auth/tokens');
+    expect(last.authHeader).toBe('Bearer smoke-root-token');
+    expect(JSON.parse(last.body)).toEqual({
+      scope: 'kafka:endpoint:write',
+      name: 'producer-bot',
+    });
+    expect(result.stdout).toContain('minted-secret-XYZ');
+    expect(result.stdout).toContain('Save this token now');
+    expect(result.stdout).toContain('Prefix:');
+    expect(result.stdout).toContain('producer-bot');
+  }, 30_000);
+
+  it('dkg auth mint-token without --scope exits with error (commander required-option)', async () => {
+    const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: port };
+    let exited = false;
+    let stderr = '';
+    try {
+      await execFileAsync('node', [CLI_ENTRY, 'auth', 'mint-token'], { env });
+    } catch (err) {
+      exited = true;
+      stderr = String((err as { stderr?: string }).stderr ?? '');
+    }
+    expect(exited).toBe(true);
+    expect(stderr).toMatch(/required option.*--scope/i);
+  }, 30_000);
+
+  it('dkg auth list-tokens prints prefix-only rows', async () => {
+    listResponse = {
+      status: 200,
+      body: {
+        tokens: [
+          { prefix: 'rootabcd', scopes: '*' },
+          {
+            prefix: 'reader01',
+            scopes: ['kafka:endpoint:read'],
+            name: 'catchup',
+            createdAt: '2026-05-04T13:00:00.000Z',
+          },
+        ],
+      },
+    };
+    const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: port };
+    const result = await execFileAsync('node', [CLI_ENTRY, 'auth', 'list-tokens'], { env });
+    expect(last.method).toBe('GET');
+    expect(last.url).toBe('/api/auth/tokens');
+    expect(result.stdout).toContain('PREFIX');
+    expect(result.stdout).toContain('rootabcd');
+    expect(result.stdout).toContain('reader01');
+    expect(result.stdout).toContain('kafka:endpoint:read');
+    expect(result.stdout).toContain('catchup');
+  }, 30_000);
+
+  it('dkg auth list-tokens shows "No tokens" on empty list', async () => {
+    listResponse = { status: 200, body: { tokens: [] } };
+    const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: port };
+    const result = await execFileAsync('node', [CLI_ENTRY, 'auth', 'list-tokens'], { env });
+    expect(result.stdout).toContain('No tokens configured');
+  }, 30_000);
+
+  it('dkg auth revoke-token <prefix> on hit prints success', async () => {
+    revokeResponse = { status: 204 };
+    const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: port };
+    const result = await execFileAsync('node', [
+      CLI_ENTRY, 'auth', 'revoke-token', 'reader01',
+    ], { env });
+    expect(last.method).toBe('DELETE');
+    expect(last.url).toBe('/api/auth/tokens/reader01');
+    expect(result.stdout).toContain('reader01 revoked');
+  }, 30_000);
+
+  it('dkg auth revoke-token <prefix> on miss exits 1 with helpful message', async () => {
+    revokeResponse = { status: 404, body: { error: 'No token with prefix "missing0"' } };
+    const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: port };
+    let exited = false;
+    let stderr = '';
+    try {
+      await execFileAsync('node', [
+        CLI_ENTRY, 'auth', 'revoke-token', 'missing0',
+      ], { env });
+    } catch (err) {
+      exited = true;
+      stderr = String((err as { stderr?: string }).stderr ?? '');
+    }
+    expect(exited).toBe(true);
+    expect(stderr).toContain('missing0');
+  }, 30_000);
+
+  it('dkg auth mint-token surfaces 403 with a clear "root token required" message', async () => {
+    mintResponse = {
+      status: 403,
+      body: { error: 'Root token required for token administration' },
+    };
+    const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: port };
+    let exited = false;
+    let stderr = '';
+    try {
+      await execFileAsync('node', [
+        CLI_ENTRY, 'auth', 'mint-token', '--scope', 'kafka:endpoint:read',
+      ], { env });
+    } catch (err) {
+      exited = true;
+      stderr = String((err as { stderr?: string }).stderr ?? '');
+    }
+    expect(exited).toBe(true);
+    expect(stderr).toMatch(/root token/i);
+  }, 30_000);
+});

--- a/packages/cli/test/auth-cli-smoke.test.ts
+++ b/packages/cli/test/auth-cli-smoke.test.ts
@@ -172,17 +172,23 @@ describe.sequential('auth CLI smoke', () => {
     expect(stderr).toMatch(/required option.*--scope/i);
   }, 30_000);
 
-  it('dkg auth list-tokens prints prefix-only rows', async () => {
+  it('dkg auth list-tokens prints prefix-only rows + per-row source (Codex bug 4)', async () => {
     listResponse = {
       status: 200,
       body: {
         tokens: [
-          { prefix: 'rootabcd', scopes: '*' },
+          { prefix: 'rootabcd', scopes: '*', source: 'file' },
           {
             prefix: 'reader01',
             scopes: ['kafka:endpoint:read'],
             name: 'catchup',
             createdAt: '2026-05-04T13:00:00.000Z',
+            source: 'file',
+          },
+          {
+            prefix: 'agentXyz',
+            scopes: '*',
+            source: 'agent',
           },
         ],
       },
@@ -192,10 +198,15 @@ describe.sequential('auth CLI smoke', () => {
     expect(last.method).toBe('GET');
     expect(last.url).toBe('/api/auth/tokens');
     expect(result.stdout).toContain('PREFIX');
+    expect(result.stdout).toContain('SOURCE');
     expect(result.stdout).toContain('rootabcd');
     expect(result.stdout).toContain('reader01');
     expect(result.stdout).toContain('kafka:endpoint:read');
     expect(result.stdout).toContain('catchup');
+    // The agent-sourced row IS visible — operator needs to see it
+    // exists, but it's flagged so they know it's not revocable here.
+    expect(result.stdout).toContain('agentXyz');
+    expect(result.stdout).toContain('agent');
   }, 30_000);
 
   it('dkg auth list-tokens shows "No tokens" on empty list', async () => {

--- a/packages/cli/test/auth-cli-smoke.test.ts
+++ b/packages/cli/test/auth-cli-smoke.test.ts
@@ -146,7 +146,13 @@ describe.sequential('auth CLI smoke', () => {
       scope: 'kafka:endpoint:write',
       name: 'producer-bot',
     });
-    expect(result.stdout).toContain('minted-secret-XYZ');
+    // I4: assert EXACTLY one occurrence of the secret on stdout. A
+    // `toContain` would silently pass if a future debug/error path
+    // re-printed the token — that's the single most security-relevant
+    // regression in this slice.
+    expect(result.stdout.match(/minted-secret-XYZ/g)?.length).toBe(1);
+    // Negative-control: the secret must never appear on stderr either.
+    expect(result.stderr).not.toContain('minted-secret-XYZ');
     expect(result.stdout).toContain('Save this token now');
     expect(result.stdout).toContain('Prefix:');
     expect(result.stdout).toContain('producer-bot');

--- a/packages/cli/test/auth-scopes.test.ts
+++ b/packages/cli/test/auth-scopes.test.ts
@@ -47,6 +47,30 @@ describe('verifyTokenScope', () => {
     expect(verifyTokenScope('not-in-store', 'any', store)).toBe(false);
   });
 
+  it('fails closed when requiredScope is empty/undefined, even for a wildcard token (review I1)', () => {
+    // The TS signature forbids an empty-or-undefined requiredScope, but a
+    // JS caller (or an `as Scope` cast) could slip one through. Without
+    // the fail-closed guard, the wildcard shortcut would grant access.
+    // Slice 07 will copy this guard verbatim — pin the contract here so
+    // a regression in either copy fails loudly.
+    const store = buildStore([
+      { prefix: 'rooty-tk', fullToken: 'rooty-tkABCDEF', scopes: '*' },
+    ]);
+    expect(verifyTokenScope('rooty-tkABCDEF', '', store)).toBe(false);
+    expect(verifyTokenScope('rooty-tkABCDEF', undefined as unknown as string, store)).toBe(false);
+    expect(verifyTokenScope('rooty-tkABCDEF', null as unknown as string, store)).toBe(false);
+    // The same fail-closed semantic applies to scoped records.
+    const scopedStore = buildStore([
+      {
+        prefix: 'reader-x',
+        fullToken: 'reader-xAAAAAA',
+        scopes: ['kafka:endpoint:read'],
+      },
+    ]);
+    expect(verifyTokenScope('reader-xAAAAAA', '', scopedStore)).toBe(false);
+    expect(verifyTokenScope('reader-xAAAAAA', undefined as unknown as string, scopedStore)).toBe(false);
+  });
+
   it('does not perform glob/wildcard matching on non-"*" lists', () => {
     // ADR-0003: no CG-bound scopes, no wildcards within lists. A scope
     // string is exact-match against the required scope.

--- a/packages/cli/test/auth-scopes.test.ts
+++ b/packages/cli/test/auth-scopes.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Slice 06 — unit tests for `verifyTokenScope`.
+ *
+ * Pure function — no I/O, no fixtures. Property: `'*'` grants every
+ * scope; explicit lists grant exactly the listed scopes; unknown tokens
+ * fail closed.
+ */
+import { describe, expect, it } from 'vitest';
+import { verifyTokenScope, type TokenStore } from '../src/auth.js';
+import type { TokenRecord } from '../src/token-store.js';
+
+function buildStore(records: TokenRecord[]): TokenStore {
+  const store = new Map<string, TokenRecord>();
+  for (const r of records) store.set(r.prefix, r);
+  return store;
+}
+
+describe('verifyTokenScope', () => {
+  it('grants any scope when the record is wildcard "*"', () => {
+    const store = buildStore([
+      { prefix: 'rooty-tk', fullToken: 'rooty-tkABCDEF', scopes: '*' },
+    ]);
+    expect(verifyTokenScope('rooty-tkABCDEF', 'kafka:endpoint:read', store)).toBe(true);
+    expect(verifyTokenScope('rooty-tkABCDEF', 'kafka:endpoint:write', store)).toBe(true);
+    expect(verifyTokenScope('rooty-tkABCDEF', 'arbitrary:scope:we-invent', store)).toBe(true);
+  });
+
+  it('grants only listed scopes for a scoped record', () => {
+    const store = buildStore([
+      {
+        prefix: 'reader-1',
+        fullToken: 'reader-1XXXXXX',
+        scopes: ['kafka:endpoint:read'],
+      },
+    ]);
+    expect(verifyTokenScope('reader-1XXXXXX', 'kafka:endpoint:read', store)).toBe(true);
+    expect(verifyTokenScope('reader-1XXXXXX', 'kafka:endpoint:write', store)).toBe(false);
+    expect(verifyTokenScope('reader-1XXXXXX', 'anything-else', store)).toBe(false);
+  });
+
+  it('returns false for unknown / undefined / empty tokens', () => {
+    const store = buildStore([
+      { prefix: 'rooty-tk', fullToken: 'rooty-tkABCDEF', scopes: '*' },
+    ]);
+    expect(verifyTokenScope(undefined, 'any', store)).toBe(false);
+    expect(verifyTokenScope('', 'any', store)).toBe(false);
+    expect(verifyTokenScope('not-in-store', 'any', store)).toBe(false);
+  });
+
+  it('does not perform glob/wildcard matching on non-"*" lists', () => {
+    // ADR-0003: no CG-bound scopes, no wildcards within lists. A scope
+    // string is exact-match against the required scope.
+    const store = buildStore([
+      { prefix: 'glob-bad', fullToken: 'glob-badZZZZZZ', scopes: ['kafka:*'] },
+    ]);
+    expect(verifyTokenScope('glob-badZZZZZZ', 'kafka:endpoint:read', store)).toBe(false);
+    // The literal "kafka:*" does match its own string, but that's a
+    // pathological scope name no caller should ever ask for. Documenting
+    // for future maintainers, not endorsing.
+    expect(verifyTokenScope('glob-badZZZZZZ', 'kafka:*', store)).toBe(true);
+  });
+
+  it('handles multiple scoped records in the same store independently', () => {
+    const store = buildStore([
+      {
+        prefix: 'reader-x',
+        fullToken: 'reader-xAAAAAA',
+        scopes: ['kafka:endpoint:read'],
+      },
+      {
+        prefix: 'writer-y',
+        fullToken: 'writer-yBBBBBB',
+        scopes: ['kafka:endpoint:write'],
+      },
+    ]);
+    expect(verifyTokenScope('reader-xAAAAAA', 'kafka:endpoint:read', store)).toBe(true);
+    expect(verifyTokenScope('reader-xAAAAAA', 'kafka:endpoint:write', store)).toBe(false);
+    expect(verifyTokenScope('writer-yBBBBBB', 'kafka:endpoint:write', store)).toBe(true);
+    expect(verifyTokenScope('writer-yBBBBBB', 'kafka:endpoint:read', store)).toBe(false);
+  });
+});

--- a/packages/cli/test/auth-scopes.test.ts
+++ b/packages/cli/test/auth-scopes.test.ts
@@ -9,9 +9,13 @@ import { describe, expect, it } from 'vitest';
 import { verifyTokenScope, type TokenStore } from '../src/auth.js';
 import type { TokenRecord } from '../src/token-store.js';
 
-function buildStore(records: TokenRecord[]): TokenStore {
+// Tests for `verifyTokenScope` don't care about the `source` field
+// (Codex bug 2 added it; only `requireRoot` consults it). Default to
+// `'file'` here so each fixture stays focused on the scope semantics
+// under test.
+function buildStore(records: Array<Omit<TokenRecord, 'source'> & { source?: TokenRecord['source'] }>): TokenStore {
   const store = new Map<string, TokenRecord>();
-  for (const r of records) store.set(r.prefix, r);
+  for (const r of records) store.set(r.prefix, { ...r, source: r.source ?? 'file' });
   return store;
 }
 

--- a/packages/cli/test/daemon-auth-scopes.test.ts
+++ b/packages/cli/test/daemon-auth-scopes.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Slice 06 — auth scopes integration tests.
+ *
+ * The single most important test in this file is the backward-compat one:
+ * a legacy scope-less token (the format every existing deployment carries
+ * on disk) must continue to grant access to every kafka route. If that
+ * test ever goes red, every existing daemon's API surface silently locks
+ * up after a slice 06 upgrade — non-negotiable backward compat.
+ *
+ * The test uses a REAL on-disk token file (no mocks of token-store) so
+ * the legacy file format is exercised end to end through the same parser
+ * the daemon uses at startup.
+ *
+ * Mock surface: a stub `agent` with the same shape `handleKafkaRoutes`
+ * consumes — `query`, `update`, `publish`, `resolveAgentAddress`. No real
+ * chain or storage. The regression we are guarding is in the
+ * route-handler scope-check + token-store wiring, not the V10 publisher.
+ */
+import { Readable } from 'node:stream';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleKafkaRoutes } from '../src/daemon/routes/kafka.js';
+import {
+  loadTokenStore,
+  verifyTokenScope,
+  type TokenStore,
+} from '../src/auth.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+const VALID_OWNER = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const VALID_URI =
+  `urn:dkg:kafka-endpoint:${VALID_OWNER}:33b58f60595c766739f72b29e4ee417888d1a46af8339a4b5bdb1c3a5692f652`;
+
+function buildMockReq(
+  method: string,
+  path: string,
+  body?: unknown,
+  authHeader?: string,
+): Readable & { method: string; url: string; headers: Record<string, string | undefined> } {
+  const stream = new Readable();
+  if (body !== undefined) {
+    stream.push(typeof body === 'string' ? body : JSON.stringify(body));
+  }
+  stream.push(null);
+  Object.assign(stream, {
+    method,
+    url: path,
+    headers: { authorization: authHeader },
+  });
+  return stream as Readable & {
+    method: string;
+    url: string;
+    headers: Record<string, string | undefined>;
+  };
+}
+
+interface CapturedResponse {
+  status: number;
+  body: unknown;
+  headers: Record<string, string | string[] | number>;
+}
+
+function buildMockRes(): { res: any; captured: CapturedResponse } {
+  const captured: CapturedResponse = { status: 0, body: undefined, headers: {} };
+  const res: any = {
+    headersSent: false,
+    writableEnded: false,
+    writeHead(status: number, headers?: Record<string, string | string[] | number>) {
+      captured.status = status;
+      if (headers) Object.assign(captured.headers, headers);
+      return res;
+    },
+    end(payload?: string) {
+      res.writableEnded = true;
+      if (payload !== undefined) {
+        try {
+          captured.body = JSON.parse(payload);
+        } catch {
+          captured.body = payload;
+        }
+      }
+    },
+  };
+  return { res, captured };
+}
+
+function buildAgent(opts: {
+  endpointBindings?: Array<Record<string, string>>;
+  listBindings?: Array<Record<string, string>>;
+} = {}): any {
+  return {
+    query: vi.fn(async (_sparql: string, _opts?: { contextGraphId?: string }) => {
+      // Heuristic: list-shape vs single-shape. Tests only need "non-empty"
+      // bindings to exercise route-success paths; precise SPARQL discrimination
+      // is the kafka package's concern, exercised by package tests.
+      if (opts.endpointBindings) return { bindings: opts.endpointBindings };
+      if (opts.listBindings) return { bindings: opts.listBindings };
+      return { bindings: [] };
+    }),
+    update: vi.fn(async () => ({})),
+    publish: vi.fn(async () => ({})),
+    resolveAgentAddress: vi.fn(() => VALID_OWNER),
+  };
+}
+
+function buildCtx(
+  req: any,
+  res: any,
+  agent: any,
+  store: TokenStore,
+  token: string | undefined,
+): RequestContext {
+  const url = new URL(`http://localhost${req.url}`);
+  return {
+    req,
+    res,
+    agent,
+    path: url.pathname,
+    url,
+    requestAgentAddress: VALID_OWNER,
+    requestToken: token,
+    validTokens: new Set([...store.values()].map((r) => r.fullToken)),
+    tokenStore: store,
+  } as unknown as RequestContext;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Backward compat — non-negotiable
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('slice 06 — backward compat: legacy scope-less token', () => {
+  let dkgHome: string;
+
+  beforeEach(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-auth-bwc-'));
+    process.env.DKG_HOME = dkgHome;
+  });
+
+  afterEach(async () => {
+    delete process.env.DKG_HOME;
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('a legacy scope-less token file grants access to ALL kafka routes', async () => {
+    // Write a real legacy-format token file (single line, no TAB).
+    const legacyToken = 'legacy-no-scopes-token';
+    await writeFile(
+      join(dkgHome, 'auth.token'),
+      `# DKG node API token — treat this like a password\n${legacyToken}\n`,
+    );
+
+    const store = await loadTokenStore();
+
+    // The token MUST verify against every conceivable scope (full access).
+    expect(verifyTokenScope(legacyToken, 'kafka:endpoint:read', store)).toBe(true);
+    expect(verifyTokenScope(legacyToken, 'kafka:endpoint:write', store)).toBe(true);
+    expect(verifyTokenScope(legacyToken, 'any-other-scope:we-dream-up', store)).toBe(true);
+
+    // Hit each kafka route with the legacy token — every one must accept it
+    // and reach the route body (i.e. no 401/403 from the scope guard).
+
+    const agent = buildAgent({
+      endpointBindings: [
+        {
+          endpoint: `<${VALID_URI}>`,
+          broker: '"k.example:9092"',
+          topic: '"orders"',
+          messageFormat: '"application/json"',
+          publisher: `<urn:dkg:agent:${VALID_OWNER}>`,
+          endpointUrl: '<kafka://k.example:9092/orders>',
+          issued: '"2026-05-04T12:34:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>',
+        },
+      ],
+    });
+
+    // GET list — kafka:endpoint:read
+    {
+      const req = buildMockReq(
+        'GET',
+        `/api/kafka/endpoint?contextGraphId=cg1`,
+        undefined,
+        `Bearer ${legacyToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, legacyToken));
+      expect([200, 500]).toContain(captured.status); // 500 acceptable for stubbed query, NOT 401/403
+      expect(captured.status).not.toBe(401);
+      expect(captured.status).not.toBe(403);
+    }
+
+    // GET single — kafka:endpoint:read
+    {
+      const req = buildMockReq(
+        'GET',
+        `/api/kafka/endpoint/${encodeURIComponent(VALID_URI)}?contextGraphId=cg1`,
+        undefined,
+        `Bearer ${legacyToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, legacyToken));
+      expect(captured.status).not.toBe(401);
+      expect(captured.status).not.toBe(403);
+    }
+
+    // POST register — kafka:endpoint:write
+    {
+      const req = buildMockReq(
+        'POST',
+        `/api/kafka/endpoint`,
+        {
+          contextGraphId: 'cg1',
+          broker: 'k.example:9092',
+          topic: 'orders',
+          messageFormat: 'application/json',
+        },
+        `Bearer ${legacyToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, legacyToken));
+      expect(captured.status).not.toBe(401);
+      expect(captured.status).not.toBe(403);
+    }
+
+    // POST verify — kafka:endpoint:write
+    {
+      const req = buildMockReq(
+        'POST',
+        `/api/kafka/endpoint/verify`,
+        {
+          contextGraphId: 'cg1',
+          uri: VALID_URI,
+          securityProtocol: 'PLAINTEXT',
+        },
+        `Bearer ${legacyToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, legacyToken));
+      expect(captured.status).not.toBe(401);
+      expect(captured.status).not.toBe(403);
+    }
+
+    // DELETE revoke — kafka:endpoint:write
+    {
+      const req = buildMockReq(
+        'DELETE',
+        `/api/kafka/endpoint/${encodeURIComponent(VALID_URI)}?contextGraphId=cg1`,
+        undefined,
+        `Bearer ${legacyToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, legacyToken));
+      expect(captured.status).not.toBe(401);
+      expect(captured.status).not.toBe(403);
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Per-route scope enforcement
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('slice 06 — per-route scope enforcement', () => {
+  let dkgHome: string;
+
+  beforeEach(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-auth-scope-'));
+    process.env.DKG_HOME = dkgHome;
+  });
+
+  afterEach(async () => {
+    delete process.env.DKG_HOME;
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('a read-scoped token is accepted on GET and rejected (403) on POST register', async () => {
+    const readToken = 'read-only-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    await writeFile(
+      join(dkgHome, 'auth.token'),
+      `${readToken}\tkafka:endpoint:read\n`,
+    );
+    const store = await loadTokenStore();
+
+    expect(verifyTokenScope(readToken, 'kafka:endpoint:read', store)).toBe(true);
+    expect(verifyTokenScope(readToken, 'kafka:endpoint:write', store)).toBe(false);
+
+    const agent = buildAgent({
+      listBindings: [], // empty list is fine for the contract test
+    });
+
+    // GET — must NOT 403
+    {
+      const req = buildMockReq(
+        'GET',
+        `/api/kafka/endpoint?contextGraphId=cg1`,
+        undefined,
+        `Bearer ${readToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, readToken));
+      expect(captured.status).not.toBe(403);
+    }
+
+    // POST register — must 403
+    {
+      const req = buildMockReq(
+        'POST',
+        `/api/kafka/endpoint`,
+        {
+          contextGraphId: 'cg1',
+          broker: 'k.example:9092',
+          topic: 'orders',
+          messageFormat: 'application/json',
+        },
+        `Bearer ${readToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, readToken));
+      expect(captured.status).toBe(403);
+      expect((captured.body as any)?.error).toContain('kafka:endpoint:write');
+      // 403 must NOT carry a WWW-Authenticate header — that header signals
+      // "no/invalid credentials"; this is "wrong scope".
+      expect(
+        Object.keys(captured.headers).map((k) => k.toLowerCase()),
+      ).not.toContain('www-authenticate');
+    }
+
+    // POST verify — must 403
+    {
+      const req = buildMockReq(
+        'POST',
+        `/api/kafka/endpoint/verify`,
+        { contextGraphId: 'cg1', uri: VALID_URI, securityProtocol: 'PLAINTEXT' },
+        `Bearer ${readToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, readToken));
+      expect(captured.status).toBe(403);
+    }
+
+    // DELETE revoke — must 403
+    {
+      const req = buildMockReq(
+        'DELETE',
+        `/api/kafka/endpoint/${encodeURIComponent(VALID_URI)}?contextGraphId=cg1`,
+        undefined,
+        `Bearer ${readToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, readToken));
+      expect(captured.status).toBe(403);
+    }
+  });
+
+  it('a write-scoped token is accepted on POST and rejected (403) on GET list', async () => {
+    const writeToken = 'write-only-token-bbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    await writeFile(
+      join(dkgHome, 'auth.token'),
+      `${writeToken}\tkafka:endpoint:write\n`,
+    );
+    const store = await loadTokenStore();
+
+    expect(verifyTokenScope(writeToken, 'kafka:endpoint:write', store)).toBe(true);
+    expect(verifyTokenScope(writeToken, 'kafka:endpoint:read', store)).toBe(false);
+
+    const agent = buildAgent();
+
+    // GET list — must 403
+    {
+      const req = buildMockReq(
+        'GET',
+        `/api/kafka/endpoint?contextGraphId=cg1`,
+        undefined,
+        `Bearer ${writeToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, writeToken));
+      expect(captured.status).toBe(403);
+      expect((captured.body as any)?.error).toContain('kafka:endpoint:read');
+    }
+
+    // GET single — must 403
+    {
+      const req = buildMockReq(
+        'GET',
+        `/api/kafka/endpoint/${encodeURIComponent(VALID_URI)}?contextGraphId=cg1`,
+        undefined,
+        `Bearer ${writeToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, writeToken));
+      expect(captured.status).toBe(403);
+    }
+
+    // POST register — must NOT 403
+    {
+      const req = buildMockReq(
+        'POST',
+        `/api/kafka/endpoint`,
+        {
+          contextGraphId: 'cg1',
+          broker: 'k.example:9092',
+          topic: 'orders',
+          messageFormat: 'application/json',
+        },
+        `Bearer ${writeToken}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(buildCtx(req, res, agent, store, writeToken));
+      expect(captured.status).not.toBe(403);
+    }
+  });
+});

--- a/packages/cli/test/daemon-auth-scopes.test.ts
+++ b/packages/cli/test/daemon-auth-scopes.test.ts
@@ -22,6 +22,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { handleKafkaRoutes } from '../src/daemon/routes/kafka.js';
+import { handleAuthRoutes } from '../src/daemon/routes/auth.js';
 import {
   loadTokenStore,
   verifyTokenScope,
@@ -111,6 +112,7 @@ function buildCtx(
   agent: any,
   store: TokenStore,
   token: string | undefined,
+  opts: { authEnabled?: boolean } = {},
 ): RequestContext {
   const url = new URL(`http://localhost${req.url}`);
   return {
@@ -123,6 +125,11 @@ function buildCtx(
     requestToken: token,
     validTokens: new Set([...store.values()].map((r) => r.fullToken)),
     tokenStore: store,
+    // Default `authEnabled: true` — Codex bug 1's fix short-circuits the
+    // scope/root check when this is false; tests that exercise the gates
+    // need it enabled. The auth-disabled bypass has its own dedicated
+    // test below.
+    authEnabled: opts.authEnabled ?? true,
   } as unknown as RequestContext;
 }
 
@@ -410,5 +417,190 @@ describe('slice 06 — per-route scope enforcement', () => {
       await handleKafkaRoutes(buildCtx(req, res, agent, store, writeToken));
       expect(captured.status).not.toBe(403);
     }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Codex bug 1 — auth-disabled bypasses scope gates
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('slice 06 — Codex bug 1: auth.enabled=false bypasses scope gates', () => {
+  let dkgHome: string;
+
+  beforeEach(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-auth-disabled-'));
+    process.env.DKG_HOME = dkgHome;
+    // Pre-populate so the loader doesn't auto-generate. Even with auth
+    // disabled, the store will exist; the gate just doesn't consult it.
+    await writeFile(join(dkgHome, 'auth.token'), `auth-disabled-root-tk\n`);
+  });
+
+  afterEach(async () => {
+    delete process.env.DKG_HOME;
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('with auth.enabled=false, every kafka route accepts requests with NO bearer token (200/non-403)', async () => {
+    const store = await loadTokenStore();
+    const agent = buildAgent();
+
+    // POST register — no Authorization header at all. Pre-Codex-bug-1
+    // fix this would 403 because verifyTokenScope(undefined, ...) fails.
+    {
+      const req = buildMockReq(
+        'POST',
+        `/api/kafka/endpoint`,
+        {
+          contextGraphId: 'cg1',
+          broker: 'k.example:9092',
+          topic: 'orders',
+          messageFormat: 'application/json',
+        },
+        undefined, // NO bearer header
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(
+        buildCtx(req, res, agent, store, undefined, { authEnabled: false }),
+      );
+      expect(captured.status).not.toBe(401);
+      expect(captured.status).not.toBe(403);
+    }
+
+    // GET list — same, no token.
+    {
+      const req = buildMockReq(
+        'GET',
+        `/api/kafka/endpoint?contextGraphId=cg1`,
+        undefined,
+        undefined,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(
+        buildCtx(req, res, agent, store, undefined, { authEnabled: false }),
+      );
+      expect(captured.status).not.toBe(401);
+      expect(captured.status).not.toBe(403);
+    }
+
+    // DELETE revoke — same.
+    {
+      const req = buildMockReq(
+        'DELETE',
+        `/api/kafka/endpoint/${encodeURIComponent(VALID_URI)}?contextGraphId=cg1`,
+        undefined,
+        undefined,
+      );
+      const { res, captured } = buildMockRes();
+      await handleKafkaRoutes(
+        buildCtx(req, res, agent, store, undefined, { authEnabled: false }),
+      );
+      expect(captured.status).not.toBe(401);
+      expect(captured.status).not.toBe(403);
+    }
+  });
+
+  it('with auth.enabled=false, mint/list/revoke /api/auth/tokens accept requests with NO bearer token', async () => {
+    const store = await loadTokenStore();
+    const validTokens = new Set([...store.values()].map((r) => r.fullToken));
+
+    // POST mint — no Authorization header.
+    {
+      const req = buildMockReq(
+        'POST',
+        `/api/auth/tokens`,
+        { scope: 'kafka:endpoint:read' },
+        undefined,
+      );
+      const { res, captured } = buildMockRes();
+      await handleAuthRoutes({
+        req,
+        res,
+        path: '/api/auth/tokens',
+        url: new URL('http://localhost/api/auth/tokens'),
+        requestToken: undefined,
+        tokenStore: store,
+        validTokens,
+        authEnabled: false,
+      } as unknown as RequestContext);
+      // 201 (mint succeeded) — NOT 403 (pre-Codex-bug-1 fix would have 403'd
+      // because lookupTokenRecord(undefined) returns undefined and
+      // requireRoot rejected).
+      expect(captured.status).toBe(201);
+    }
+
+    // GET list — no header.
+    {
+      const req = buildMockReq(
+        'GET',
+        `/api/auth/tokens`,
+        undefined,
+        undefined,
+      );
+      const { res, captured } = buildMockRes();
+      await handleAuthRoutes({
+        req,
+        res,
+        path: '/api/auth/tokens',
+        url: new URL('http://localhost/api/auth/tokens'),
+        requestToken: undefined,
+        tokenStore: store,
+        validTokens,
+        authEnabled: false,
+      } as unknown as RequestContext);
+      expect(captured.status).toBe(200);
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Codex bug 3 — runtime agent token works on scope-gated routes
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('slice 06 — Codex bug 3: runtime token added to BOTH structures works on scope-gated routes', () => {
+  let dkgHome: string;
+
+  beforeEach(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-runtime-add-'));
+    process.env.DKG_HOME = dkgHome;
+    await writeFile(join(dkgHome, 'auth.token'), `bug3-root-token-aaaaaaaaa\n`);
+  });
+
+  afterEach(async () => {
+    delete process.env.DKG_HOME;
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('addTokenToStore-issued runtime token passes the kafka scope gate immediately (no restart)', async () => {
+    const { addTokenToStore } = await import('../src/auth.js');
+    const store = await loadTokenStore();
+    const validTokens = new Set([...store.values()].map((r) => r.fullToken));
+    const agent = buildAgent();
+
+    // Simulate /api/agent/register issuing a fresh runtime token. The
+    // helper must mutate BOTH structures so the daemon's scope gates
+    // accept it on the very next request.
+    const NEW_AGENT_TOKEN = 'runtime-agent-token-bbbbbbbbbbbbbbbbb';
+    addTokenToStore(store, validTokens, {
+      prefix: NEW_AGENT_TOKEN.slice(0, 8),
+      fullToken: NEW_AGENT_TOKEN,
+      scopes: '*', // agent tokens carry full access on non-admin routes
+      source: 'agent',
+    });
+
+    // GET list with the brand-new token — pre-Codex-bug-3 fix this
+    // would 403 (Set had it, store didn't, scope gate consults store).
+    const req = buildMockReq(
+      'GET',
+      `/api/kafka/endpoint?contextGraphId=cg1`,
+      undefined,
+      `Bearer ${NEW_AGENT_TOKEN}`,
+    );
+    const { res, captured } = buildMockRes();
+    await handleKafkaRoutes(buildCtx(req, res, agent, store, NEW_AGENT_TOKEN));
+    expect(captured.status).not.toBe(401);
+    expect(captured.status).not.toBe(403);
+    // Both structures stayed in sync.
+    expect(validTokens.has(NEW_AGENT_TOKEN)).toBe(true);
+    expect(store.has(NEW_AGENT_TOKEN.slice(0, 8))).toBe(true);
   });
 });

--- a/packages/cli/test/daemon-token-mint-failures.test.ts
+++ b/packages/cli/test/daemon-token-mint-failures.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Slice 06 — failure-mode tests for `/api/auth/tokens` (review I2).
+ *
+ * Pins the disk-first ordering invariant: when `writeFileAtomic` throws,
+ * the in-memory `tokenStore` + `validTokens` MUST be unchanged so the
+ * daemon's accepted-token set stays consistent with the on-disk file. A
+ * mint that disagrees with disk would silently disappear on restart;
+ * a revoke that disagrees with disk would silently come back.
+ *
+ * Failure injection: make the parent directory read-only so the temp
+ * file write inside `writeFileAtomic` fails. Real fs surface, no mocks
+ * — the same code path production runs hits the real EACCES.
+ */
+import { Readable } from 'node:stream';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { handleAuthRoutes } from '../src/daemon/routes/auth.js';
+import { loadTokenStore, type TokenStore } from '../src/auth.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+function buildMockReq(
+  method: string,
+  path: string,
+  body: unknown,
+  authHeader: string,
+): Readable & { method: string; url: string; headers: Record<string, string | undefined> } {
+  const stream = new Readable();
+  stream.push(typeof body === 'string' ? body : JSON.stringify(body));
+  stream.push(null);
+  Object.assign(stream, {
+    method,
+    url: path,
+    headers: { authorization: authHeader },
+  });
+  return stream as Readable & {
+    method: string;
+    url: string;
+    headers: Record<string, string | undefined>;
+  };
+}
+
+interface CapturedResponse {
+  status: number;
+  body: unknown;
+}
+function buildMockRes(): { res: any; captured: CapturedResponse } {
+  const captured: CapturedResponse = { status: 0, body: undefined };
+  const res: any = {
+    headersSent: false,
+    writableEnded: false,
+    writeHead(status: number) {
+      captured.status = status;
+      return res;
+    },
+    end(payload?: string) {
+      res.writableEnded = true;
+      if (payload !== undefined) {
+        try {
+          captured.body = JSON.parse(payload);
+        } catch {
+          captured.body = payload;
+        }
+      }
+    },
+  };
+  return { res, captured };
+}
+
+function buildCtx(
+  req: any,
+  res: any,
+  store: TokenStore,
+  validTokens: Set<string>,
+  token: string,
+): RequestContext {
+  const url = new URL(`http://localhost${req.url}`);
+  return {
+    req,
+    res,
+    path: url.pathname,
+    url,
+    requestToken: token,
+    tokenStore: store,
+    validTokens,
+  } as unknown as RequestContext;
+}
+
+const ROOT_TOKEN = 'root-token-failures-aaaaaaaaaaaaaaaaa';
+
+describe('mint failure leaves in-memory state unchanged (review I2)', () => {
+  let dkgHome: string;
+
+  beforeEach(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-mint-failure-'));
+    process.env.DKG_HOME = dkgHome;
+    await writeFile(join(dkgHome, 'auth.token'), `${ROOT_TOKEN}\n`);
+  });
+
+  afterEach(async () => {
+    delete process.env.DKG_HOME;
+    // Restore mode in case a test left it locked (otherwise rm fails).
+    try { await chmod(dkgHome, 0o700); } catch { /* best-effort */ }
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('mint: disk-write failure → 500, in-memory store unchanged, file unchanged', async () => {
+    const store = await loadTokenStore();
+    const validTokens = new Set([...store.values()].map((r) => r.fullToken));
+    const sizeBefore = store.size;
+    const validBefore = new Set(validTokens);
+
+    // Snapshot the file content before the failure so we can confirm
+    // it didn't change.
+    const fileBefore = await readFile(join(dkgHome, 'auth.token'), 'utf-8');
+
+    // Lock the dkg home directory read-only — writeFileAtomic's temp
+    // file creation will fail with EACCES.
+    await chmod(dkgHome, 0o500);
+
+    const req = buildMockReq(
+      'POST',
+      '/api/auth/tokens',
+      { scope: 'kafka:endpoint:read', name: 'doomed' },
+      `Bearer ${ROOT_TOKEN}`,
+    );
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+
+    // 5xx — the persistence failed and the route surfaced it.
+    expect(captured.status).toBeGreaterThanOrEqual(500);
+    expect(captured.status).toBeLessThan(600);
+    expect((captured.body as any).error).toMatch(/persist/i);
+
+    // Restore so the assertions below can read the directory.
+    await chmod(dkgHome, 0o700);
+
+    // In-memory store + Set are UNCHANGED. No new prefix appeared, and
+    // no new full-token entered the validTokens Set. (The implementation
+    // must apply the disk write before mutating; review I2.)
+    expect(store.size).toBe(sizeBefore);
+    expect(validTokens.size).toBe(validBefore.size);
+    expect([...validTokens].sort()).toEqual([...validBefore].sort());
+
+    // The on-disk file is byte-identical to before.
+    const fileAfter = await readFile(join(dkgHome, 'auth.token'), 'utf-8');
+    expect(fileAfter).toBe(fileBefore);
+
+    // No subsequent request should accept whatever token would have
+    // been minted — but we don't have a token to compare to (the
+    // generator runs only on success). The in-memory size + set
+    // checks above already prove no orphan token leaked in.
+  });
+
+  it('revoke: disk-write failure → 500, target token still valid in memory + on disk', async () => {
+    // Pre-populate a target token to revoke.
+    const TARGET = 'target-to-revoke-aaaaaaaaaaaaaaaaaaa';
+    await writeFile(
+      join(dkgHome, 'auth.token'),
+      `${ROOT_TOKEN}\n${TARGET}\tkafka:endpoint:read\n`,
+    );
+    const store = await loadTokenStore();
+    const validTokens = new Set([...store.values()].map((r) => r.fullToken));
+    const sizeBefore = store.size;
+
+    expect(validTokens.has(TARGET)).toBe(true);
+    const targetPrefix = TARGET.slice(0, 8);
+    expect(store.has(targetPrefix)).toBe(true);
+
+    const fileBefore = await readFile(join(dkgHome, 'auth.token'), 'utf-8');
+
+    // Lock the directory so writeFileAtomic's temp create fails.
+    await chmod(dkgHome, 0o500);
+
+    const req = buildMockReq(
+      'DELETE',
+      `/api/auth/tokens/${targetPrefix}`,
+      undefined as unknown as string,
+      `Bearer ${ROOT_TOKEN}`,
+    );
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+
+    expect(captured.status).toBeGreaterThanOrEqual(500);
+    expect(captured.status).toBeLessThan(600);
+    expect((captured.body as any).error).toMatch(/persist/i);
+
+    await chmod(dkgHome, 0o700);
+
+    // Target token is STILL in the in-memory store + Set (i.e. NOT
+    // prematurely revoked). Without the disk-first ordering, the
+    // delete would have applied to memory and the on-disk file would
+    // resurrect the token on the next daemon restart.
+    expect(store.size).toBe(sizeBefore);
+    expect(store.has(targetPrefix)).toBe(true);
+    expect(validTokens.has(TARGET)).toBe(true);
+
+    // The on-disk file is byte-identical to before.
+    const fileAfter = await readFile(join(dkgHome, 'auth.token'), 'utf-8');
+    expect(fileAfter).toBe(fileBefore);
+  });
+});

--- a/packages/cli/test/daemon-token-mint-failures.test.ts
+++ b/packages/cli/test/daemon-token-mint-failures.test.ts
@@ -84,6 +84,7 @@ function buildCtx(
     requestToken: token,
     tokenStore: store,
     validTokens,
+    authEnabled: true,
   } as unknown as RequestContext;
 }
 

--- a/packages/cli/test/daemon-token-mint.test.ts
+++ b/packages/cli/test/daemon-token-mint.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Slice 06 — integration tests for `/api/auth/tokens` (mint / list / revoke).
+ *
+ * Stands up `handleAuthRoutes` directly with a real on-disk auth file so
+ * the read-modify-write critical section is exercised end to end. No
+ * mocks of `token-store`. Critical contracts pinned:
+ *
+ *   - root token (scopes='*') CAN mint, list, revoke
+ *   - any explicitly-scoped token CANNOT (403 — privilege-escalation guard)
+ *   - mint response carries the full token EXACTLY ONCE; subsequent
+ *     list/get responses MUST not leak it
+ *   - file write goes through writeFileAtomic (POSIX-rename atomic);
+ *     a parallel-mints test covers the well-formed-file invariant
+ *   - DELETE returns 204 on hit, 404 on miss; refuses to revoke the
+ *     bearer token the request was made with
+ */
+import { Readable } from 'node:stream';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { handleAuthRoutes } from '../src/daemon/routes/auth.js';
+import { loadTokenStore, type TokenStore } from '../src/auth.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+function buildMockReq(
+  method: string,
+  path: string,
+  body?: unknown,
+  authHeader?: string,
+): Readable & { method: string; url: string; headers: Record<string, string | undefined> } {
+  const stream = new Readable();
+  if (body !== undefined) {
+    stream.push(typeof body === 'string' ? body : JSON.stringify(body));
+  }
+  stream.push(null);
+  Object.assign(stream, {
+    method,
+    url: path,
+    headers: { authorization: authHeader },
+  });
+  return stream as Readable & {
+    method: string;
+    url: string;
+    headers: Record<string, string | undefined>;
+  };
+}
+
+interface CapturedResponse {
+  status: number;
+  body: unknown;
+  headers: Record<string, string | string[] | number>;
+}
+
+function buildMockRes(): { res: any; captured: CapturedResponse } {
+  const captured: CapturedResponse = { status: 0, body: undefined, headers: {} };
+  const res: any = {
+    headersSent: false,
+    writableEnded: false,
+    writeHead(status: number, headers?: Record<string, string | string[] | number>) {
+      captured.status = status;
+      if (headers) Object.assign(captured.headers, headers);
+      return res;
+    },
+    end(payload?: string) {
+      res.writableEnded = true;
+      if (payload !== undefined) {
+        try {
+          captured.body = JSON.parse(payload);
+        } catch {
+          captured.body = payload;
+        }
+      }
+    },
+  };
+  return { res, captured };
+}
+
+function buildCtx(
+  req: any,
+  res: any,
+  store: TokenStore,
+  validTokens: Set<string>,
+  token?: string,
+): RequestContext {
+  const url = new URL(`http://localhost${req.url}`);
+  return {
+    req,
+    res,
+    path: url.pathname,
+    url,
+    requestToken: token,
+    tokenStore: store,
+    validTokens,
+  } as unknown as RequestContext;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Setup helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+async function loadStoreAndSet(): Promise<{ store: TokenStore; validTokens: Set<string> }> {
+  const store = await loadTokenStore();
+  const validTokens = new Set([...store.values()].map((r) => r.fullToken));
+  return { store, validTokens };
+}
+
+describe('POST /api/auth/tokens — mint', () => {
+  let dkgHome: string;
+  const ROOT_TOKEN = 'root-token-aaaaaaaaaaaaaaaaaaaaa';
+
+  beforeEach(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-mint-'));
+    process.env.DKG_HOME = dkgHome;
+    // Pre-populate with a single root (legacy) token so we have a known
+    // caller to exercise the root-only check.
+    await writeFile(join(dkgHome, 'auth.token'), `${ROOT_TOKEN}\n`);
+  });
+
+  afterEach(async () => {
+    delete process.env.DKG_HOME;
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('mints a scoped token; response carries the full secret ONCE', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq('POST', '/api/auth/tokens', {
+      scope: 'kafka:endpoint:write',
+      name: 'kafka-publisher-bot',
+    }, `Bearer ${ROOT_TOKEN}`);
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+    expect(captured.status).toBe(201);
+    const body = captured.body as any;
+    expect(typeof body.token).toBe('string');
+    expect(body.token.length).toBeGreaterThan(20);
+    expect(body.prefix.length).toBe(8);
+    expect(body.prefix).toBe(body.token.slice(0, 8));
+    expect(body.scopes).toEqual(['kafka:endpoint:write']);
+    expect(body.name).toBe('kafka-publisher-bot');
+    expect(typeof body.createdAt).toBe('string');
+
+    // The minted token now lives in the store and on disk.
+    expect(validTokens.has(body.token)).toBe(true);
+    const onDisk = await readFile(join(dkgHome, 'auth.token'), 'utf-8');
+    expect(onDisk).toContain(body.token);
+    expect(onDisk).toContain('kafka:endpoint:write');
+    expect(onDisk).toContain('kafka-publisher-bot');
+  });
+
+  it('mints with a comma-separated scope string', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq('POST', '/api/auth/tokens', {
+      scope: 'kafka:endpoint:read, kafka:endpoint:write',
+    }, `Bearer ${ROOT_TOKEN}`);
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+    expect(captured.status).toBe(201);
+    expect((captured.body as any).scopes).toEqual([
+      'kafka:endpoint:read',
+      'kafka:endpoint:write',
+    ]);
+  });
+
+  it('mints with a scopes array', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq('POST', '/api/auth/tokens', {
+      scopes: ['kafka:endpoint:read'],
+    }, `Bearer ${ROOT_TOKEN}`);
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+    expect(captured.status).toBe(201);
+    expect((captured.body as any).scopes).toEqual(['kafka:endpoint:read']);
+  });
+
+  it('rejects when no scope is supplied (400)', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq('POST', '/api/auth/tokens', {}, `Bearer ${ROOT_TOKEN}`);
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+    expect(captured.status).toBe(400);
+    expect((captured.body as any).error).toContain('scope');
+  });
+
+  it('rejects an attempt to mint a wildcard "*" scope (privilege-escalation guard)', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq('POST', '/api/auth/tokens', {
+      scope: '*',
+    }, `Bearer ${ROOT_TOKEN}`);
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+    expect(captured.status).toBe(400);
+    expect((captured.body as any).error).toContain('wildcard');
+  });
+
+  it('rejects an attempt to mint an auth:tokens:* scope (privilege-escalation guard)', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq('POST', '/api/auth/tokens', {
+      scope: 'auth:tokens:write',
+    }, `Bearer ${ROOT_TOKEN}`);
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+    expect(captured.status).toBe(400);
+    expect((captured.body as any).error).toContain('reserved');
+  });
+
+  it('rejects when a scoped (non-root) token attempts to mint (403)', async () => {
+    // Pre-create a scoped (non-root) token on disk so it lands in the
+    // loaded store.
+    const SCOPED = 'scoped-only-bbbbbbbbbbbbbbbbbbbbb';
+    await writeFile(
+      join(dkgHome, 'auth.token'),
+      `${ROOT_TOKEN}\n${SCOPED}\tkafka:endpoint:read\n`,
+    );
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq('POST', '/api/auth/tokens', {
+      scope: 'kafka:endpoint:write',
+    }, `Bearer ${SCOPED}`);
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, SCOPED));
+    expect(captured.status).toBe(403);
+    expect((captured.body as any).error).toContain('Root');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// GET /api/auth/tokens — list (no secrets)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/auth/tokens — list', () => {
+  let dkgHome: string;
+  const ROOT_TOKEN = 'root-token-cccccccccccccccccccccc';
+
+  beforeEach(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-list-'));
+    process.env.DKG_HOME = dkgHome;
+    // Pre-populate with one root + one scoped token.
+    await writeFile(
+      join(dkgHome, 'auth.token'),
+      `${ROOT_TOKEN}\n` +
+        `scoped-Aaaaaaaaaaaaaaaaaaaa\tkafka:endpoint:read\tcatchup-bot\t2026-05-04T12:00:00.000Z\n`,
+    );
+  });
+
+  afterEach(async () => {
+    delete process.env.DKG_HOME;
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('lists tokens with prefix + scopes only (no fullToken)', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq('GET', '/api/auth/tokens', undefined, `Bearer ${ROOT_TOKEN}`);
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+    expect(captured.status).toBe(200);
+    const body = captured.body as { tokens: Array<Record<string, unknown>> };
+    expect(body.tokens.length).toBe(2);
+    for (const t of body.tokens) {
+      expect((t as any).fullToken).toBeUndefined();
+      expect((t as any).token).toBeUndefined();
+      expect(typeof t.prefix).toBe('string');
+      expect((t.prefix as string).length).toBeLessThanOrEqual(8);
+    }
+    // The full token must NOT appear ANYWHERE in the serialized response.
+    expect(JSON.stringify(captured.body)).not.toContain(ROOT_TOKEN);
+    expect(JSON.stringify(captured.body)).not.toContain('scoped-Aaaaaaaaaaaaaaaaaaaa');
+  });
+
+  it('rejects a scoped (non-root) caller with 403', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq(
+      'GET',
+      '/api/auth/tokens',
+      undefined,
+      `Bearer scoped-Aaaaaaaaaaaaaaaaaaaa`,
+    );
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(
+      buildCtx(req, res, store, validTokens, 'scoped-Aaaaaaaaaaaaaaaaaaaa'),
+    );
+    expect(captured.status).toBe(403);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// DELETE /api/auth/tokens/<prefix> — revoke
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/auth/tokens/<prefix>', () => {
+  let dkgHome: string;
+  const ROOT_TOKEN = 'root-token-ddddddddddddddddddddd';
+
+  beforeEach(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-revoke-'));
+    process.env.DKG_HOME = dkgHome;
+    await writeFile(
+      join(dkgHome, 'auth.token'),
+      `${ROOT_TOKEN}\n` +
+        `target01XXXXXXXXXXXXX\tkafka:endpoint:read\n`,
+    );
+  });
+
+  afterEach(async () => {
+    delete process.env.DKG_HOME;
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('revokes by prefix: 204 on hit, file no longer contains the token', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq(
+      'DELETE',
+      '/api/auth/tokens/target01',
+      undefined,
+      `Bearer ${ROOT_TOKEN}`,
+    );
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+    expect(captured.status).toBe(204);
+    const onDisk = await readFile(join(dkgHome, 'auth.token'), 'utf-8');
+    expect(onDisk).not.toContain('target01XXXXXXXXXXXXX');
+    expect(validTokens.has('target01XXXXXXXXXXXXX')).toBe(false);
+  });
+
+  it('returns 404 when revoking a non-existent prefix (idempotent)', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq(
+      'DELETE',
+      '/api/auth/tokens/notreall',
+      undefined,
+      `Bearer ${ROOT_TOKEN}`,
+    );
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+    expect(captured.status).toBe(404);
+    // Repeating the call MUST stay deterministic (still 404).
+    const req2 = buildMockReq(
+      'DELETE',
+      '/api/auth/tokens/notreall',
+      undefined,
+      `Bearer ${ROOT_TOKEN}`,
+    );
+    const { res: res2, captured: captured2 } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req2, res2, store, validTokens, ROOT_TOKEN));
+    expect(captured2.status).toBe(404);
+  });
+
+  it('refuses to revoke the bearer token used to make the request (400)', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const rootPrefix = ROOT_TOKEN.slice(0, 8);
+    const req = buildMockReq(
+      'DELETE',
+      `/api/auth/tokens/${rootPrefix}`,
+      undefined,
+      `Bearer ${ROOT_TOKEN}`,
+    );
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+    expect(captured.status).toBe(400);
+    expect((captured.body as any).error).toContain('Refusing to revoke');
+  });
+
+  it('rejects a scoped (non-root) caller with 403', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+    const req = buildMockReq(
+      'DELETE',
+      '/api/auth/tokens/target01',
+      undefined,
+      `Bearer target01XXXXXXXXXXXXX`,
+    );
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(
+      buildCtx(req, res, store, validTokens, 'target01XXXXXXXXXXXXX'),
+    );
+    expect(captured.status).toBe(403);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// END-TO-END: mint → list → use → revoke
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('end-to-end mint flow', () => {
+  let dkgHome: string;
+  const ROOT_TOKEN = 'root-token-eeeeeeeeeeeeeeeeeeeee';
+
+  beforeEach(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-e2e-mint-'));
+    process.env.DKG_HOME = dkgHome;
+    await writeFile(join(dkgHome, 'auth.token'), `${ROOT_TOKEN}\n`);
+  });
+
+  afterEach(async () => {
+    delete process.env.DKG_HOME;
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('mint → list reveals it (no secret) → revoke clears it from list', async () => {
+    const { store, validTokens } = await loadStoreAndSet();
+
+    // mint
+    const mintReq = buildMockReq(
+      'POST',
+      '/api/auth/tokens',
+      { scope: 'kafka:endpoint:write', name: 'producer' },
+      `Bearer ${ROOT_TOKEN}`,
+    );
+    const { res: mintRes, captured: mintCaptured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(mintReq, mintRes, store, validTokens, ROOT_TOKEN));
+    expect(mintCaptured.status).toBe(201);
+    const mintBody = mintCaptured.body as { token: string; prefix: string };
+
+    // list — appears, no secret
+    const listReq = buildMockReq('GET', '/api/auth/tokens', undefined, `Bearer ${ROOT_TOKEN}`);
+    const { res: listRes, captured: listCaptured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(listReq, listRes, store, validTokens, ROOT_TOKEN));
+    expect(listCaptured.status).toBe(200);
+    const listBody = listCaptured.body as { tokens: Array<{ prefix: string }> };
+    const found = listBody.tokens.find((t) => t.prefix === mintBody.prefix);
+    expect(found).toBeDefined();
+    expect(JSON.stringify(listCaptured.body)).not.toContain(mintBody.token);
+
+    // revoke
+    const revokeReq = buildMockReq(
+      'DELETE',
+      `/api/auth/tokens/${mintBody.prefix}`,
+      undefined,
+      `Bearer ${ROOT_TOKEN}`,
+    );
+    const { res: revokeRes, captured: revokeCaptured } = buildMockRes();
+    await handleAuthRoutes(
+      buildCtx(revokeReq, revokeRes, store, validTokens, ROOT_TOKEN),
+    );
+    expect(revokeCaptured.status).toBe(204);
+
+    // list again — no longer present
+    const listReq2 = buildMockReq('GET', '/api/auth/tokens', undefined, `Bearer ${ROOT_TOKEN}`);
+    const { res: listRes2, captured: listCaptured2 } = buildMockRes();
+    await handleAuthRoutes(buildCtx(listReq2, listRes2, store, validTokens, ROOT_TOKEN));
+    expect(
+      (listCaptured2.body as { tokens: Array<{ prefix: string }> }).tokens.find(
+        (t) => t.prefix === mintBody.prefix,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/cli/test/daemon-token-mint.test.ts
+++ b/packages/cli/test/daemon-token-mint.test.ts
@@ -82,6 +82,7 @@ function buildCtx(
   store: TokenStore,
   validTokens: Set<string>,
   token?: string,
+  opts: { authEnabled?: boolean } = {},
 ): RequestContext {
   const url = new URL(`http://localhost${req.url}`);
   return {
@@ -92,6 +93,9 @@ function buildCtx(
     requestToken: token,
     tokenStore: store,
     validTokens,
+    // Default true so `requireRoot` actually enforces — the auth-disabled
+    // bypass has its own dedicated test (Codex bug 1).
+    authEnabled: opts.authEnabled ?? true,
   } as unknown as RequestContext;
 }
 
@@ -220,6 +224,70 @@ describe('POST /api/auth/tokens — mint', () => {
     await handleAuthRoutes(buildCtx(req, res, store, validTokens, SCOPED));
     expect(captured.status).toBe(403);
     expect((captured.body as any).error).toContain('Root');
+  });
+
+  it('rejects an agent-source token even when it has wildcard scope (Codex bug 2 — privilege-escalation guard)', async () => {
+    // Per-agent tokens carry `scopes: '*'` for backward-compat on every
+    // other API surface, but MUST NOT pass `requireRoot` — otherwise
+    // any registered agent could mint/list/revoke node auth tokens.
+    const { addTokenToStore } = await import('../src/auth.js');
+    const { store, validTokens } = await loadStoreAndSet();
+    const AGENT_TOKEN = 'agent-issued-token-cccccccccccccccc';
+    addTokenToStore(store, validTokens, {
+      prefix: AGENT_TOKEN.slice(0, 8),
+      fullToken: AGENT_TOKEN,
+      scopes: '*',
+      source: 'agent',
+    });
+
+    // POST mint — must 403 because source is 'agent', not 'file'/'config'.
+    {
+      const req = buildMockReq('POST', '/api/auth/tokens',
+        { scope: 'kafka:endpoint:read' }, `Bearer ${AGENT_TOKEN}`);
+      const { res, captured } = buildMockRes();
+      await handleAuthRoutes(buildCtx(req, res, store, validTokens, AGENT_TOKEN));
+      expect(captured.status).toBe(403);
+      expect((captured.body as any).error).toContain('Root');
+    }
+
+    // GET list — same.
+    {
+      const req = buildMockReq('GET', '/api/auth/tokens',
+        undefined as unknown as string, `Bearer ${AGENT_TOKEN}`);
+      const { res, captured } = buildMockRes();
+      await handleAuthRoutes(buildCtx(req, res, store, validTokens, AGENT_TOKEN));
+      expect(captured.status).toBe(403);
+    }
+
+    // DELETE revoke — same.
+    {
+      const req = buildMockReq('DELETE',
+        `/api/auth/tokens/${ROOT_TOKEN.slice(0, 8)}`,
+        undefined as unknown as string, `Bearer ${AGENT_TOKEN}`);
+      const { res, captured } = buildMockRes();
+      await handleAuthRoutes(buildCtx(req, res, store, validTokens, AGENT_TOKEN));
+      expect(captured.status).toBe(403);
+    }
+  });
+
+  it('accepts a config-source token as root (operator put it in dkg.config.yaml)', async () => {
+    // Config tokens are operator-controlled — putting one in
+    // dkg.config.yaml IS an operator action, so it qualifies as root
+    // for admin routes (documented choice in `requireRoot` JSDoc).
+    const CONFIG_TOKEN = 'config-tk-dddddddddddddddddddddddd';
+    const { store, validTokens } = await (async () => {
+      // Re-load with the config token wired through `loadTokenStore`
+      // (which stamps `source: 'config'`).
+      const s = await loadTokenStore({ tokens: [CONFIG_TOKEN] });
+      return { store: s, validTokens: new Set([...s.values()].map((r) => r.fullToken)) };
+    })();
+
+    const req = buildMockReq('POST', '/api/auth/tokens',
+      { scope: 'kafka:endpoint:read', name: 'config-mint' },
+      `Bearer ${CONFIG_TOKEN}`);
+    const { res, captured } = buildMockRes();
+    await handleAuthRoutes(buildCtx(req, res, store, validTokens, CONFIG_TOKEN));
+    expect(captured.status).toBe(201);
   });
 });
 

--- a/packages/cli/test/kafka-route-verify.test.ts
+++ b/packages/cli/test/kafka-route-verify.test.ts
@@ -106,9 +106,25 @@ function buildMockAgent(opts: MockAgentOptions = {}): any {
 function buildCtx(req: any, res: any, agent: any): RequestContext {
   // Many RequestContext fields are unused by handleKafkaRoutes; cast to any
   // so we don't need a full DKGAgent / DkgConfig / OperationTracker. The
-  // route reads only `req`, `res`, `agent`, `path`, `url`, and
-  // `requestAgentAddress` — all populated below.
+  // route reads only `req`, `res`, `agent`, `path`, `url`,
+  // `requestAgentAddress`, plus slice 06's `requestToken` + `tokenStore`
+  // for the scope guard — all populated below. The store maps the test
+  // bearer token to scope `'*'` so verify-route assertions are unaffected
+  // by the scope check (covered separately in `daemon-auth-scopes.test.ts`).
   const url = new URL(`http://localhost${req.url}`);
+  const ROOT_TOKEN = 'ROOTROOT-verify-test-token';
+  const tokenStore = new Map([
+    [ROOT_TOKEN.slice(0, 8), {
+      prefix: ROOT_TOKEN.slice(0, 8),
+      fullToken: ROOT_TOKEN,
+      scopes: '*' as const,
+    }],
+  ]);
+  // Mutate req headers so extractBearerToken finds the root token. The
+  // route reads `ctx.requestToken` directly when set, but the daemon
+  // pipeline derives it from req.headers.authorization — populating both
+  // keeps the mock honest if either path is exercised.
+  if (req.headers) req.headers.authorization = `Bearer ${ROOT_TOKEN}`;
   return {
     req,
     res,
@@ -116,6 +132,9 @@ function buildCtx(req: any, res: any, agent: any): RequestContext {
     path: url.pathname,
     url,
     requestAgentAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+    requestToken: ROOT_TOKEN,
+    tokenStore,
+    validTokens: new Set([ROOT_TOKEN]),
   } as unknown as RequestContext;
 }
 

--- a/packages/cli/test/kafka-route-verify.test.ts
+++ b/packages/cli/test/kafka-route-verify.test.ts
@@ -118,6 +118,7 @@ function buildCtx(req: any, res: any, agent: any): RequestContext {
       prefix: ROOT_TOKEN.slice(0, 8),
       fullToken: ROOT_TOKEN,
       scopes: '*' as const,
+      source: 'file' as const,
     }],
   ]);
   // Mutate req headers so extractBearerToken finds the root token. The
@@ -135,6 +136,7 @@ function buildCtx(req: any, res: any, agent: any): RequestContext {
     requestToken: ROOT_TOKEN,
     tokenStore,
     validTokens: new Set([ROOT_TOKEN]),
+    authEnabled: true,
   } as unknown as RequestContext;
 }
 

--- a/packages/cli/test/token-store-concurrency.test.ts
+++ b/packages/cli/test/token-store-concurrency.test.ts
@@ -96,6 +96,7 @@ function buildCtx(
     requestToken: token,
     tokenStore: store,
     validTokens,
+    authEnabled: true,
   } as unknown as RequestContext;
 }
 

--- a/packages/cli/test/token-store-concurrency.test.ts
+++ b/packages/cli/test/token-store-concurrency.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Slice 06 — concurrency test for parallel token mints.
+ *
+ * Reuses the real mint route (not a stub) so the read-modify-write
+ * critical section + `writeFileAtomic` + the in-process mutex are
+ * exercised together. The invariant we're guarding:
+ *
+ *   `Promise.all` of N parallel mints produces a well-formed token file
+ *   that, when re-parsed from disk, contains all N records (no truncation,
+ *   no interleaved bytes, no lost records).
+ *
+ * Without the mutex, two parallel mints would each read the same
+ * pre-write snapshot and each WRITE only its own delta back, so N-1
+ * mints would silently disappear from the file. The mutex serializes
+ * the critical section per-process; the test would fail with N=10 → 1-2
+ * records on disk.
+ *
+ * Multi-process mints (e.g. CLI + daemon-API simultaneously) are out of
+ * scope for slice 06 and are documented as a known limitation in the
+ * route module.
+ */
+import { Readable } from 'node:stream';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { handleAuthRoutes } from '../src/daemon/routes/auth.js';
+import {
+  loadTokenStore,
+  parseTokenFile,
+  type TokenStore,
+} from '../src/auth.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+function buildMockReq(
+  method: string,
+  path: string,
+  body: unknown,
+  authHeader: string,
+): Readable & { method: string; url: string; headers: Record<string, string | undefined> } {
+  const stream = new Readable();
+  stream.push(JSON.stringify(body));
+  stream.push(null);
+  Object.assign(stream, {
+    method,
+    url: path,
+    headers: { authorization: authHeader },
+  });
+  return stream as Readable & {
+    method: string;
+    url: string;
+    headers: Record<string, string | undefined>;
+  };
+}
+
+interface CapturedResponse {
+  status: number;
+  body: unknown;
+}
+function buildMockRes(): { res: any; captured: CapturedResponse } {
+  const captured: CapturedResponse = { status: 0, body: undefined };
+  const res: any = {
+    headersSent: false,
+    writableEnded: false,
+    writeHead(status: number) {
+      captured.status = status;
+      return res;
+    },
+    end(payload?: string) {
+      res.writableEnded = true;
+      if (payload !== undefined) {
+        try {
+          captured.body = JSON.parse(payload);
+        } catch {
+          captured.body = payload;
+        }
+      }
+    },
+  };
+  return { res, captured };
+}
+
+function buildCtx(
+  req: any,
+  res: any,
+  store: TokenStore,
+  validTokens: Set<string>,
+  token: string,
+): RequestContext {
+  const url = new URL(`http://localhost${req.url}`);
+  return {
+    req,
+    res,
+    path: url.pathname,
+    url,
+    requestToken: token,
+    tokenStore: store,
+    validTokens,
+  } as unknown as RequestContext;
+}
+
+describe('parallel mint concurrency', () => {
+  let dkgHome: string;
+  const ROOT_TOKEN = 'root-token-fffffffffffffffffffffff';
+
+  beforeEach(async () => {
+    dkgHome = await mkdtemp(join(tmpdir(), 'dkg-mint-concurrency-'));
+    process.env.DKG_HOME = dkgHome;
+    await writeFile(join(dkgHome, 'auth.token'), `${ROOT_TOKEN}\n`);
+  });
+
+  afterEach(async () => {
+    delete process.env.DKG_HOME;
+    await rm(dkgHome, { recursive: true, force: true });
+  });
+
+  it('Promise.all of 10 parallel mints yields a well-formed file with all 10 records', async () => {
+    const store = await loadTokenStore();
+    const validTokens = new Set([...store.values()].map((r) => r.fullToken));
+
+    const N = 10;
+    const mintOne = async (i: number): Promise<{ status: number; token: string; prefix: string }> => {
+      const req = buildMockReq(
+        'POST',
+        '/api/auth/tokens',
+        { scope: 'kafka:endpoint:read', name: `parallel-${i}` },
+        `Bearer ${ROOT_TOKEN}`,
+      );
+      const { res, captured } = buildMockRes();
+      await handleAuthRoutes(buildCtx(req, res, store, validTokens, ROOT_TOKEN));
+      const body = captured.body as { token: string; prefix: string };
+      return { status: captured.status, token: body.token, prefix: body.prefix };
+    };
+
+    const results = await Promise.all(
+      Array.from({ length: N }, (_unused, i) => mintOne(i)),
+    );
+
+    // Every mint succeeded.
+    for (const r of results) {
+      expect(r.status).toBe(201);
+      expect(typeof r.token).toBe('string');
+      expect(r.token.length).toBeGreaterThan(20);
+    }
+
+    // The on-disk file is well-formed: re-parsing it yields the root +
+    // all N minted records, with no malformed-line warnings.
+    const onDisk = await readFile(join(dkgHome, 'auth.token'), 'utf-8');
+    const warnings: string[] = [];
+    const parsed = parseTokenFile(onDisk, { onWarning: (m) => warnings.push(m) });
+
+    expect(warnings).toEqual([]);
+    expect(parsed.store.size).toBe(N + 1); // root + 10 minted
+
+    // Every minted prefix is present on disk.
+    for (const r of results) {
+      const record = parsed.store.get(r.prefix);
+      expect(record).toBeDefined();
+      expect(record!.fullToken).toBe(r.token);
+      expect(record!.scopes).toEqual(['kafka:endpoint:read']);
+      expect(record!.name).toMatch(/^parallel-\d$/);
+      expect(record!.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    }
+
+    // The root token survived unchanged.
+    const rootPrefix = ROOT_TOKEN.slice(0, 8);
+    const rootRecord = parsed.store.get(rootPrefix);
+    expect(rootRecord?.fullToken).toBe(ROOT_TOKEN);
+    expect(rootRecord?.scopes).toBe('*');
+  });
+});

--- a/packages/cli/test/token-store.test.ts
+++ b/packages/cli/test/token-store.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Slice 06 — pure unit tests for `token-store.ts`.
+ *
+ * No I/O. The token-store module is intentionally pure (parse + serialize
+ * + lookup); the real fs touches happen in `auth.ts`. Tests cover:
+ *   - legacy-only files (every line lacks a TAB)
+ *   - scoped-only files
+ *   - mixed files (legacy + scoped + scoped-with-name + full record)
+ *   - malformed lines (skipped, not crashing)
+ *   - round-trip determinism (parse → serialize → parse)
+ *   - lookup helpers (prefix collision fallback, public-record sanitization)
+ */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseTokenFile,
+  serializeTokenStore,
+  lookupTokenRecord,
+  toPublicRecord,
+  tokenPrefix,
+  setTokenRecord,
+  deleteTokenRecord,
+  type TokenRecord,
+} from '../src/token-store.js';
+
+// ───────────────────────────────────────────────────────────────────────────
+// parser: legacy / scoped / mixed
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('parseTokenFile — legacy-only', () => {
+  it('parses a single legacy token line as scopes="*"', () => {
+    const { store } = parseTokenFile('legacy-token-aaaaaaaaaaaaa\n');
+    expect(store.size).toBe(1);
+    const r = [...store.values()][0]!;
+    expect(r.fullToken).toBe('legacy-token-aaaaaaaaaaaaa');
+    expect(r.scopes).toBe('*');
+    expect(r.name).toBeUndefined();
+    expect(r.createdAt).toBeUndefined();
+    expect(r.prefix).toBe('legacy-t');
+  });
+
+  it('parses multiple legacy lines, preserves comments + blank lines', () => {
+    const raw = `# DKG node API token — treat this like a password
+alphalegacy-token-1aaaaaaaa
+
+# secondary
+betalegacy-token-2bbbbbbbb
+`;
+    const { store, preserved } = parseTokenFile(raw);
+    expect(store.size).toBe(2);
+    expect([...store.values()].every((r) => r.scopes === '*')).toBe(true);
+    expect(preserved.length).toBe(3); // header comment, blank, secondary comment
+  });
+});
+
+describe('parseTokenFile — scoped-only', () => {
+  it('parses scopes from a comma-separated list', () => {
+    const { store } = parseTokenFile('tk-aaaaaaaaaaaaaaaa\tkafka:endpoint:read,kafka:endpoint:write\n');
+    const r = [...store.values()][0]!;
+    expect(r.scopes).toEqual(['kafka:endpoint:read', 'kafka:endpoint:write']);
+  });
+
+  it('parses an explicit "*" scope as full access', () => {
+    const { store } = parseTokenFile('tk-bbbbbbbbbbbbbbbb\t*\n');
+    const r = [...store.values()][0]!;
+    expect(r.scopes).toBe('*');
+  });
+
+  it('parses scopes + name', () => {
+    const { store } = parseTokenFile('tk-cccccccccccccccc\tkafka:endpoint:read\tcatchup-bot\n');
+    const r = [...store.values()][0]!;
+    expect(r.scopes).toEqual(['kafka:endpoint:read']);
+    expect(r.name).toBe('catchup-bot');
+    expect(r.createdAt).toBeUndefined();
+  });
+
+  it('parses a full record (scopes + name + createdAt)', () => {
+    const raw = 'tk-dddddddddddddddd\tkafka:endpoint:read\tcatchup-bot\t2026-05-04T12:00:00.000Z\n';
+    const { store } = parseTokenFile(raw);
+    const r = [...store.values()][0]!;
+    expect(r.scopes).toEqual(['kafka:endpoint:read']);
+    expect(r.name).toBe('catchup-bot');
+    expect(r.createdAt).toBe('2026-05-04T12:00:00.000Z');
+  });
+});
+
+describe('parseTokenFile — mixed', () => {
+  it('parses mixed legacy + scoped lines in the same file', () => {
+    const raw = `# old
+legacy-aaaaaaaaaaaaaaaaaaaaa
+scoped-bbbbbbbbbbbbbbbbbbbbb\tkafka:endpoint:read
+named-ccccccccccccccccccccc\tkafka:endpoint:write\tcatchup
+full-ddddddddddddddddddddd\t*\troot\t2026-05-04T12:00:00.000Z
+`;
+    const { store } = parseTokenFile(raw);
+    expect(store.size).toBe(4);
+    const records = [...store.values()];
+    expect(records[0]!.scopes).toBe('*');
+    expect(records[0]!.name).toBeUndefined();
+    expect(records[1]!.scopes).toEqual(['kafka:endpoint:read']);
+    expect(records[2]!.name).toBe('catchup');
+    expect(records[3]!.scopes).toBe('*');
+    expect(records[3]!.createdAt).toBe('2026-05-04T12:00:00.000Z');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// parser: malformed inputs
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('parseTokenFile — malformed lines', () => {
+  it('skips lines with empty token field, warning sink fires', () => {
+    const warnings: string[] = [];
+    const { store } = parseTokenFile('\tkafka:endpoint:read\nvalid-token-aaaaaaaaaaaaaaa\n', {
+      onWarning: (m) => warnings.push(m),
+    });
+    expect(store.size).toBe(1);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('empty token');
+  });
+
+  it('skips lines with empty scopes field (token + bare TAB)', () => {
+    const warnings: string[] = [];
+    const { store } = parseTokenFile('tk-eeeeeeeeeeeeeeee\t\nvalid-token-bbbbbbbbbbb\n', {
+      onWarning: (m) => warnings.push(m),
+    });
+    expect(store.size).toBe(1);
+    expect(warnings[0]).toContain('bad scopes field');
+  });
+
+  it('skips lines with too many tab fields (>4)', () => {
+    const warnings: string[] = [];
+    const raw = 'tk-fffffffffffffffff\tkafka:endpoint:read\tname\t2026-05-04T12:00:00.000Z\textra\n';
+    const { store } = parseTokenFile(raw, { onWarning: (m) => warnings.push(m) });
+    expect(store.size).toBe(0);
+    expect(warnings[0]).toContain('too many tab-separated fields');
+  });
+
+  it('skips lines with disallowed scope characters (whitespace/special)', () => {
+    const warnings: string[] = [];
+    const { store } = parseTokenFile('tk-gggggggggggggggg\tbad scope with space\n', {
+      onWarning: (m) => warnings.push(m),
+    });
+    expect(store.size).toBe(0);
+    expect(warnings[0]).toContain('bad scopes field');
+  });
+
+  it('skips lines that mix `*` with explicit scopes (privilege-escalation guard)', () => {
+    const warnings: string[] = [];
+    const { store } = parseTokenFile('tk-hhhhhhhhhhhhhhhh\t*,kafka:endpoint:read\n', {
+      onWarning: (m) => warnings.push(m),
+    });
+    expect(store.size).toBe(0);
+    expect(warnings[0]).toContain('bad scopes field');
+  });
+
+  it('keeps the first record on prefix collision and warns', () => {
+    const warnings: string[] = [];
+    const raw = `firstcollideZZZZZ\nfirstcollideQQQQQ\n`;
+    const { store } = parseTokenFile(raw, { onWarning: (m) => warnings.push(m) });
+    expect(store.size).toBe(1);
+    expect([...store.values()][0]!.fullToken).toBe('firstcollideZZZZZ');
+    expect(warnings[0]).toContain('duplicate token prefix');
+  });
+
+  it('does not crash on empty file', () => {
+    const { store, preserved } = parseTokenFile('');
+    expect(store.size).toBe(0);
+    expect(preserved.length).toBe(0);
+  });
+
+  it('does not crash on file with only comments/blank lines', () => {
+    const { store, preserved } = parseTokenFile('# just a comment\n\n# another\n');
+    expect(store.size).toBe(0);
+    expect(preserved.length).toBe(3);
+  });
+
+  it('handles CRLF-terminated lines', () => {
+    const { store } = parseTokenFile('legacy-crlf-token-aaa\r\nscoped-crlf-bbb\tkafka:endpoint:read\r\n');
+    expect(store.size).toBe(2);
+    const records = [...store.values()];
+    expect(records[0]!.fullToken).toBe('legacy-crlf-token-aaa');
+    expect(records[1]!.scopes).toEqual(['kafka:endpoint:read']);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// serializer + round-trip
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('serializeTokenStore', () => {
+  it('round-trips a legacy-only file byte-identically', () => {
+    const raw = `# DKG node API token — treat this like a password
+legacy-tok-aaaaaaaaaaaaaaaaaa
+`;
+    const parsed = parseTokenFile(raw);
+    const out = serializeTokenStore(parsed);
+    expect(out).toBe(raw);
+  });
+
+  it('round-trips a fully-formed scoped file byte-identically', () => {
+    const raw = `# header
+tok-aaaaaaaaaaaaaaaaaaaaa\tkafka:endpoint:read\tbot\t2026-05-04T12:00:00.000Z
+
+# trailing comment
+tok-bbbbbbbbbbbbbbbbbbbbb\t*\troot\t2026-05-04T12:01:00.000Z
+`;
+    const parsed = parseTokenFile(raw);
+    const out = serializeTokenStore(parsed);
+    expect(out).toBe(raw);
+  });
+
+  it('emits a single-field line for a `*`-scope record with no name/createdAt', () => {
+    const out = serializeTokenStore({
+      store: new Map([
+        ['legacy-x', {
+          prefix: 'legacy-x',
+          fullToken: 'legacy-xxxx',
+          scopes: '*' as const,
+        }],
+      ]),
+      preserved: [],
+    });
+    expect(out).toBe('legacy-xxxx\n');
+  });
+
+  it('emits scopes+empty-name when only createdAt is set on a scoped record', () => {
+    // Edge case: the parser exposes name=undefined, createdAt=string — the
+    // serializer must keep the createdAt by emitting an empty name field
+    // so the field-count survives.
+    const out = serializeTokenStore({
+      store: new Map([
+        ['scope-on', {
+          prefix: 'scope-on',
+          fullToken: 'scope-on-token',
+          scopes: ['kafka:endpoint:read'],
+          createdAt: '2026-05-04T12:00:00.000Z',
+        }],
+      ]),
+      preserved: [],
+    });
+    expect(out).toBe('scope-on-token\tkafka:endpoint:read\t\t2026-05-04T12:00:00.000Z\n');
+  });
+
+  it('round-trips an empty file', () => {
+    const out = serializeTokenStore({ store: new Map(), preserved: [] });
+    expect(out).toBe('');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// lookup helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('lookupTokenRecord', () => {
+  it('returns the record for a known token', () => {
+    const { store } = parseTokenFile('the-token-aaaaaaaaaaaaaa\tkafka:endpoint:read\n');
+    const r = lookupTokenRecord('the-token-aaaaaaaaaaaaaa', store);
+    expect(r?.fullToken).toBe('the-token-aaaaaaaaaaaaaa');
+  });
+
+  it('returns undefined for an unknown token', () => {
+    const { store } = parseTokenFile('the-token-aaaaaaaaaaaaaa\n');
+    expect(lookupTokenRecord('not-stored', store)).toBeUndefined();
+    expect(lookupTokenRecord(undefined, store)).toBeUndefined();
+  });
+
+  it('falls back to linear scan on prefix collision', () => {
+    // Force a manual store with two records sharing a prefix. The parser
+    // would warn-and-skip the second; the lookup helper must still find a
+    // legitimate insertion (e.g. via setTokenRecord overriding).
+    const store = new Map<string, TokenRecord>();
+    store.set('prefix01', { prefix: 'prefix01', fullToken: 'prefix01-XXXX', scopes: '*' });
+    // Intentional second-record-with-same-prefix in a wrong key (wouldn't
+    // happen via parser but represents the collision condition).
+    store.set('prefix02', { prefix: 'prefix01', fullToken: 'prefix01-YYYY', scopes: ['kafka:endpoint:read'] });
+    const r = lookupTokenRecord('prefix01-YYYY', store);
+    expect(r?.scopes).toEqual(['kafka:endpoint:read']);
+  });
+});
+
+describe('toPublicRecord', () => {
+  it('drops the fullToken', () => {
+    const r: TokenRecord = {
+      prefix: 'pr',
+      fullToken: 'long-secret-stuff',
+      scopes: ['kafka:endpoint:read'],
+      name: 'bot',
+      createdAt: '2026-05-04T12:00:00.000Z',
+    };
+    const pub = toPublicRecord(r);
+    expect((pub as any).fullToken).toBeUndefined();
+    expect(pub.prefix).toBe('pr');
+    expect(pub.scopes).toEqual(['kafka:endpoint:read']);
+    expect(pub.name).toBe('bot');
+    expect(pub.createdAt).toBe('2026-05-04T12:00:00.000Z');
+  });
+
+  it('elides undefined name/createdAt instead of emitting them', () => {
+    const r: TokenRecord = { prefix: 'pr', fullToken: 'x', scopes: '*' };
+    const pub = toPublicRecord(r);
+    expect(Object.keys(pub).sort()).toEqual(['prefix', 'scopes']);
+  });
+});
+
+describe('store mutation helpers', () => {
+  it('setTokenRecord adds and replaces by prefix', () => {
+    const store = new Map<string, TokenRecord>();
+    setTokenRecord(store, { prefix: 'aa', fullToken: 'aaa-1', scopes: '*' });
+    expect(store.size).toBe(1);
+    setTokenRecord(store, { prefix: 'aa', fullToken: 'aaa-2', scopes: ['x:y'] });
+    expect(store.size).toBe(1);
+    expect(store.get('aa')!.fullToken).toBe('aaa-2');
+  });
+
+  it('deleteTokenRecord removes by prefix and reports presence', () => {
+    const store = new Map<string, TokenRecord>();
+    setTokenRecord(store, { prefix: 'aa', fullToken: 'aaa', scopes: '*' });
+    expect(deleteTokenRecord(store, 'aa')).toBe(true);
+    expect(deleteTokenRecord(store, 'aa')).toBe(false);
+  });
+});
+
+describe('tokenPrefix', () => {
+  it('returns the first 8 characters', () => {
+    expect(tokenPrefix('abcdefghij')).toBe('abcdefgh');
+  });
+
+  it('returns the whole token if shorter than 8 chars', () => {
+    expect(tokenPrefix('short')).toBe('short');
+  });
+});

--- a/packages/cli/test/token-store.test.ts
+++ b/packages/cli/test/token-store.test.ts
@@ -19,6 +19,8 @@ import {
   tokenPrefix,
   setTokenRecord,
   deleteTokenRecord,
+  addTokenToStore,
+  removeTokenFromStore,
   type TokenRecord,
 } from '../src/token-store.js';
 
@@ -27,7 +29,7 @@ import {
 // ───────────────────────────────────────────────────────────────────────────
 
 describe('parseTokenFile — legacy-only', () => {
-  it('parses a single legacy token line as scopes="*"', () => {
+  it('parses a single legacy token line as scopes="*" with source="file"', () => {
     const { store } = parseTokenFile('legacy-token-aaaaaaaaaaaaa\n');
     expect(store.size).toBe(1);
     const r = [...store.values()][0]!;
@@ -36,6 +38,10 @@ describe('parseTokenFile — legacy-only', () => {
     expect(r.name).toBeUndefined();
     expect(r.createdAt).toBeUndefined();
     expect(r.prefix).toBe('legacy-t');
+    // Codex bug 2: every line read off disk is by definition `source:
+    // 'file'`. The parser MUST stamp this so `requireRoot` distinguishes
+    // operator-managed tokens from agent-issued ones.
+    expect(r.source).toBe('file');
   });
 
   it('parses multiple legacy lines, preserves comments + blank lines', () => {
@@ -216,6 +222,7 @@ tok-bbbbbbbbbbbbbbbbbbbbb\t*\troot\t2026-05-04T12:01:00.000Z
           prefix: 'legacy-x',
           fullToken: 'legacy-xxxx',
           scopes: '*' as const,
+          source: 'file' as const,
         }],
       ]),
       preserved: [],
@@ -234,6 +241,7 @@ tok-bbbbbbbbbbbbbbbbbbbbb\t*\troot\t2026-05-04T12:01:00.000Z
           fullToken: 'scope-on-token',
           scopes: ['kafka:endpoint:read'],
           createdAt: '2026-05-04T12:00:00.000Z',
+          source: 'file' as const,
         }],
       ]),
       preserved: [],
@@ -269,23 +277,24 @@ describe('lookupTokenRecord', () => {
     // would warn-and-skip the second; the lookup helper must still find a
     // legitimate insertion (e.g. via setTokenRecord overriding).
     const store = new Map<string, TokenRecord>();
-    store.set('prefix01', { prefix: 'prefix01', fullToken: 'prefix01-XXXX', scopes: '*' });
+    store.set('prefix01', { prefix: 'prefix01', fullToken: 'prefix01-XXXX', scopes: '*', source: 'file' });
     // Intentional second-record-with-same-prefix in a wrong key (wouldn't
     // happen via parser but represents the collision condition).
-    store.set('prefix02', { prefix: 'prefix01', fullToken: 'prefix01-YYYY', scopes: ['kafka:endpoint:read'] });
+    store.set('prefix02', { prefix: 'prefix01', fullToken: 'prefix01-YYYY', scopes: ['kafka:endpoint:read'], source: 'file' });
     const r = lookupTokenRecord('prefix01-YYYY', store);
     expect(r?.scopes).toEqual(['kafka:endpoint:read']);
   });
 });
 
 describe('toPublicRecord', () => {
-  it('drops the fullToken', () => {
+  it('drops the fullToken; preserves source', () => {
     const r: TokenRecord = {
       prefix: 'pr',
       fullToken: 'long-secret-stuff',
       scopes: ['kafka:endpoint:read'],
       name: 'bot',
       createdAt: '2026-05-04T12:00:00.000Z',
+      source: 'file',
     };
     const pub = toPublicRecord(r);
     expect((pub as any).fullToken).toBeUndefined();
@@ -293,30 +302,55 @@ describe('toPublicRecord', () => {
     expect(pub.scopes).toEqual(['kafka:endpoint:read']);
     expect(pub.name).toBe('bot');
     expect(pub.createdAt).toBe('2026-05-04T12:00:00.000Z');
+    expect(pub.source).toBe('file');
   });
 
-  it('elides undefined name/createdAt instead of emitting them', () => {
-    const r: TokenRecord = { prefix: 'pr', fullToken: 'x', scopes: '*' };
+  it('elides undefined name/createdAt but keeps required fields (prefix, scopes, source)', () => {
+    const r: TokenRecord = { prefix: 'pr', fullToken: 'x', scopes: '*', source: 'agent' };
     const pub = toPublicRecord(r);
-    expect(Object.keys(pub).sort()).toEqual(['prefix', 'scopes']);
+    expect(Object.keys(pub).sort()).toEqual(['prefix', 'scopes', 'source']);
+    expect(pub.source).toBe('agent');
   });
 });
 
 describe('store mutation helpers', () => {
   it('setTokenRecord adds and replaces by prefix', () => {
     const store = new Map<string, TokenRecord>();
-    setTokenRecord(store, { prefix: 'aa', fullToken: 'aaa-1', scopes: '*' });
+    setTokenRecord(store, { prefix: 'aa', fullToken: 'aaa-1', scopes: '*', source: 'file' });
     expect(store.size).toBe(1);
-    setTokenRecord(store, { prefix: 'aa', fullToken: 'aaa-2', scopes: ['x:y'] });
+    setTokenRecord(store, { prefix: 'aa', fullToken: 'aaa-2', scopes: ['x:y'], source: 'file' });
     expect(store.size).toBe(1);
     expect(store.get('aa')!.fullToken).toBe('aaa-2');
   });
 
   it('deleteTokenRecord removes by prefix and reports presence', () => {
     const store = new Map<string, TokenRecord>();
-    setTokenRecord(store, { prefix: 'aa', fullToken: 'aaa', scopes: '*' });
+    setTokenRecord(store, { prefix: 'aa', fullToken: 'aaa', scopes: '*', source: 'file' });
     expect(deleteTokenRecord(store, 'aa')).toBe(true);
     expect(deleteTokenRecord(store, 'aa')).toBe(false);
+  });
+
+  it('addTokenToStore mutates BOTH the structured map and the validTokens Set in lockstep (Codex bug 3)', () => {
+    const store = new Map<string, TokenRecord>();
+    const validTokens = new Set<string>();
+    addTokenToStore(store, validTokens, {
+      prefix: 'mm', fullToken: 'mmAGENT-token', scopes: '*', source: 'agent',
+    });
+    expect(store.has('mm')).toBe(true);
+    expect(validTokens.has('mmAGENT-token')).toBe(true);
+    expect(store.get('mm')!.source).toBe('agent');
+  });
+
+  it('removeTokenFromStore deletes from BOTH structures and reports presence', () => {
+    const store = new Map<string, TokenRecord>();
+    const validTokens = new Set<string>();
+    addTokenToStore(store, validTokens, {
+      prefix: 'mm', fullToken: 'mmAGENT-token', scopes: '*', source: 'agent',
+    });
+    expect(removeTokenFromStore(store, validTokens, 'mm')).toBe(true);
+    expect(store.has('mm')).toBe(false);
+    expect(validTokens.has('mmAGENT-token')).toBe(false);
+    expect(removeTokenFromStore(store, validTokens, 'mm')).toBe(false);
   });
 });
 

--- a/packages/kafka/test/e2e/walking-skeleton.test.ts
+++ b/packages/kafka/test/e2e/walking-skeleton.test.ts
@@ -415,6 +415,95 @@ describe('kafka walking skeleton e2e', () => {
       240_000,
     );
   });
+
+  describe('auth scopes (slice 06)', () => {
+    it(
+      'mints a write-only scoped token via CLI; register works with it; list-with-same-token → 403',
+      async () => {
+        // 1. Mint a write-scoped token via the CLI (which hits the daemon's
+        //    `/api/auth/tokens` mint endpoint with the root token already
+        //    on disk in DEVNET_NODE1_HOME). The full token comes back on
+        //    stdout exactly once — we capture it for the next two steps.
+        const mintResult = await execFileAsync(
+          'node',
+          [
+            CLI_ENTRY,
+            'auth',
+            'mint-token',
+            '--scope',
+            'kafka:endpoint:write',
+            '--name',
+            'e2e-write-only',
+          ],
+          {
+            cwd: REPO_ROOT,
+            env: {
+              ...process.env,
+              DKG_HOME: DEVNET_NODE1_HOME,
+              DKG_API_PORT: String(port),
+            },
+          },
+        );
+
+        // The mint command prints the full token on its own line as a
+        // 2-space-indented run — match that to extract.
+        const mintedToken = (() => {
+          for (const rawLine of mintResult.stdout.split('\n')) {
+            const line = rawLine.trim();
+            // base64url tokens are URL-safe (no padding, length 43 for
+            // 32 random bytes). Match conservatively to avoid mistaking
+            // labels like "Prefix:" for the token.
+            if (/^[A-Za-z0-9_-]{40,}$/.test(line)) return line;
+          }
+          throw new Error(`could not extract minted token from CLI stdout:\n${mintResult.stdout}`);
+        })();
+        expect(mintedToken.length).toBeGreaterThan(20);
+
+        // 2. With the write-scoped token, registering an endpoint via the
+        //    HTTP API must succeed.
+        const writeClient = new ApiClient(port, mintedToken);
+        const broker = `kafka.scopes.${Date.now()}.local:9092`;
+        const topic = `auth-scopes.${Date.now()}`;
+        const messageFormat = 'application/cloudevents+json';
+        const expectedUri = buildKafkaEndpointUri({ owner, broker, topic });
+
+        const registerResult = await writeClient.registerKafkaEndpoint({
+          contextGraphId: CONTEXT_GRAPH_ID,
+          broker,
+          topic,
+          messageFormat,
+        });
+        expect(registerResult.uri).toBe(expectedUri);
+
+        // 3. With the same write-only token, listing endpoints must 403 —
+        //    the read scope is missing.
+        let listError: { httpStatus?: number } | undefined;
+        try {
+          await writeClient.listKafkaEndpoints({ contextGraphId: CONTEXT_GRAPH_ID });
+        } catch (err) {
+          listError = err as { httpStatus?: number };
+        }
+        expect(listError).toBeDefined();
+        expect(listError?.httpStatus).toBe(403);
+
+        // Cleanup: revoke the e2e token so it doesn't pile up in the
+        // devnet token file across runs.
+        await execFileAsync(
+          'node',
+          [CLI_ENTRY, 'auth', 'revoke-token', mintedToken.slice(0, 8)],
+          {
+            cwd: REPO_ROOT,
+            env: {
+              ...process.env,
+              DKG_HOME: DEVNET_NODE1_HOME,
+              DKG_API_PORT: String(port),
+            },
+          },
+        );
+      },
+      240_000,
+    );
+  });
 });
 
 async function waitForRevokedRow(


### PR DESCRIPTION
## Stack position

LAST sub-PR for the kafka foundation (PR #390). Stacked on slice 05's PR #395.

```
main
 └── feat/kafka-walking-skeleton    (foundation rollup, PR #390 — draft)
      └── feat/kafka-list-revoke-verify    (slice 05, PR #395)
           └── feat/kafka-auth-scopes      ← THIS PR (HITL)
```

Base is slice 05's branch — diff is just slice 06's 6 commits / 19 files. Once slice 05 merges into the foundation, retarget this PR's base to `feat/kafka-walking-skeleton`.

## ⚠️ HITL — human inspection required before merge

This slice modifies `packages/cli/src/auth.ts`, the single source of truth for daemon auth across HTTP / MCP / SSE. SDD review passed all four stages (implementer → spec → code quality → polish), with one critical fix loop on the code-quality stage. The human MUST inspect the diff themselves before merging. Specifically verify:

- The exact backward-compat code path: legacy lines (no TAB) → `*` scope set → grants all routes
- The atomic-write implementation: race window between rename and crash
- The mint response surface: full token returned ONCE; never in list responses
- Per-route scope strings match the PRD table exactly: `kafka:endpoint:write` for write routes, `kafka:endpoint:read` for read routes

## What slice 06 adds

Per-token scopes via extended bearer-token file format. Implements ADR-0003.

- New `token-store` deep module extracted from `auth.ts` — pure parser/serializer for the token file format
- File format extended: `<token><TAB><scopes-comma-separated>[<TAB><name>[<TAB><createdAt>]]`. Legacy lines (no TAB) continue to grant full access (`*` scope) — non-negotiable
- New `verifyTokenScope(token, requiredScope, store)` helper with explicit fail-closed guard for empty/undefined required scope
- All 5 kafka endpoint routes gated by their scope per PRD table; 403 (not 401) on scope mismatch; no `WWW-Authenticate` header on 403
- Token mint flows: `POST /api/auth/tokens` (root-only), `GET /api/auth/tokens` (root-only, prefixes only), `DELETE /api/auth/tokens/<prefix>` (root-only)
- CLI: `dkg auth mint-token / list-tokens / revoke-token` (under existing `dkg auth` group)
- Concurrency-safe write to `~/.dkg/auth.token` via shared `writeFileAtomic` helper (extended to accept `{ mode: 0o600 }` so the temp file is created secure from the start, closing the umask window)
- Disk-first write order in mint/revoke: persist before mutating in-memory state, with try/catch rollback and 5xx on write failure

## Test plan

- [x] Backward compat: legacy token file (no TABs anywhere) grants full access on every kafka route — uses real on-disk legacy file, no mocks
- [x] Unit: `token-store` parse/serialize/round-trip across legacy/scoped/mixed/malformed (30 cases)
- [x] Unit: `verifyTokenScope` semantics including `*` grants all + fail-closed on empty/undefined required scope (6 cases)
- [x] Integration: token scoped `kafka:endpoint:read` rejected (403) on POST /api/kafka/endpoint, accepted on GET — asserts no `WWW-Authenticate` on 403
- [x] Integration: scoped token cannot mint another token via API (403); root token can; mint of `*` scope rejected; `auth:tokens:*` scope rejected
- [x] Integration: mint returns full token ONCE; subsequent list calls strip via `toPublicRecord`; assertion: full token string never appears in list response body
- [x] Persistence-failure injection: `chmod 0o500` on dkg-home mid-test → 5xx returned, in-memory store unchanged, on-disk file byte-identical
- [x] Concurrency: parallel writes (10 Promise.all mints) produce well-formed file, no truncation, all 10 records survive
- [x] CLI smoke: full token printed exactly once on stdout (`match(/.../g)?.length === 1` strict count); negative-control: secret never appears on stderr
- [x] e2e: mint scoped token via CLI, register endpoint with it, attempt list → 403; cleanup via revoke
- Coverage ratchets unchanged: kafka package coverage unaffected (no kafka/ source touched); CLI uses package-level ratchet (not per-module), so the 1300+ LOC of new well-tested cli/ code can only raise it

## SDD pipeline outcome

| Stage | Verdict |
|---|---|
| Implementer | DONE |
| Spec compliance review | ✅ SPEC COMPLIANT |
| Code quality review | ❌ → ✅ APPROVED (after 1 critical + 4 important fixes in `e5bd1512`) |
| Polish review | 📝 SUGGESTIONS (3 mechanical wins applied in `294b6182`) |

Critical fix in the loop: `writeFileAtomic` originally created the temp file with default umask (0o644 typically), opening a brief permissions window on `~/.dkg/auth.token` between rename and the explicit chmod. Fixed at the helper level so slice 07 inherits the secure default by construction.

## Pre-existing footguns surfaced (not fixed in this slice)

- `dkg auth show` (pre-slice-06) prints all token strings including new scoped tokens. Description unchanged.
- `dkg auth rotate` (pre-slice-06) silently overwrites scoped tokens. Description prose updated to warn operators (this slice); behavior unchanged. Full fix is slice 07 cleanup territory.
- Multi-process write races: slice 06 routes all admin via the daemon's in-process mutex (CLI commands hit the API). Cross-daemon-process races aren't covered but aren't a normal config.

## Risk notes

Highest-risk slice in the foundation:
- auth.ts is daemon-wide; mistakes silently lock or unlock entire deployments
- Concurrency-safe write must be correct under realistic contention
- Token leakage paths (logs, list responses, error responses) are the worst possible bug

## Related

- ADR-0003 (auth scopes via extended bearer-token file)
- Issue: `.scratch/kafka-registry/issues/06-auth-scopes.md`