### PR TITLE
feat(context-graph): wire PCA id at registration so PCA agents can publish

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3989,6 +3989,8 @@ export class DKGAgent {
     requiredSignatures?: number;
     /** Participant agent addresses for on-chain context graphs. */
     participantAgents?: string[];
+    /** Publishing Conviction Account id for PCA-curated on-chain registration. */
+    publishAuthorityAccountId?: bigint;
     /** When true, skips gossip subscription and broadcast. Data stays local-only. */
     private?: boolean;
     /** Caller's agent address (resolved from token). Used for curator/creator triples. */
@@ -4020,6 +4022,15 @@ export class DKGAgent {
     const isCurated = opts.accessPolicy === LOCAL_ACCESS_CURATED
       || (opts.allowedAgents && opts.allowedAgents.length > 0)
       || (opts.allowedPeers && opts.allowedPeers.length > 0);
+    const publishAuthorityAccountId = opts.publishAuthorityAccountId;
+    if (publishAuthorityAccountId !== undefined) {
+      if (publishAuthorityAccountId <= 0n) {
+        throw new Error('PCA account id must be a positive integer.');
+      }
+      if (!isCurated && opts.private !== true) {
+        throw new Error('PCA account id can only be used with curated/private context graphs.');
+      }
+    }
 
     if (opts.private) {
       this.log.info(ctx, `Creating private context graph "${opts.id}" (local-only, no gossip)`);
@@ -4062,6 +4073,14 @@ export class DKGAgent {
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"unregistered"`, graph: cgMetaGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
     );
+    if (publishAuthorityAccountId !== undefined) {
+      quads.push({
+        subject: paranetUri,
+        predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+        object: `"${publishAuthorityAccountId.toString()}"`,
+        graph: cgMetaGraph,
+      });
+    }
 
     // Store peer allowlist for curated CGs (with validation)
     if (opts.allowedPeers && opts.allowedPeers.length > 0) {
@@ -4355,6 +4374,7 @@ export class DKGAgent {
     revealOnChain?: boolean;
     accessPolicy?: number;
     callerAgentAddress?: string;
+    publishAuthorityAccountId?: bigint;
   }): Promise<{ onChainId: string; txHash?: string }> {
     const ctx = createOperationContext('system');
 
@@ -4490,6 +4510,22 @@ export class DKGAgent {
     const publishPolicy = resolvedLocalAccessPolicy === LOCAL_ACCESS_CURATED
       ? EVM_PUBLISH_CURATED
       : EVM_PUBLISH_OPEN;
+    const storedPublishAuthorityAccountId = await this.getContextGraphPublishAuthorityAccountId(id);
+    const requestedPublishAuthorityAccountId = opts?.publishAuthorityAccountId;
+    const publishAuthorityAccountId = requestedPublishAuthorityAccountId ?? storedPublishAuthorityAccountId;
+    if (requestedPublishAuthorityAccountId !== undefined) {
+      if (requestedPublishAuthorityAccountId <= 0n) {
+        throw new Error('PCA account id must be a positive integer.');
+      }
+    }
+    if (publishPolicy === EVM_PUBLISH_OPEN && publishAuthorityAccountId !== undefined) {
+      throw new Error('PCA account id can only be used with curated/private context graphs.');
+    }
+    if (requestedPublishAuthorityAccountId !== undefined) {
+      await this.setContextGraphPublishAuthorityAccountId(id, requestedPublishAuthorityAccountId);
+    }
+    const isPcaCurated = publishPolicy === EVM_PUBLISH_CURATED
+      && publishAuthorityAccountId !== undefined;
 
     const participantsResult = await this.store.query(
       `SELECT ?identityId WHERE { GRAPH <${cgMetaGraph}> { <${paranetUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID}> ?identityId } }`,
@@ -4547,30 +4583,44 @@ export class DKGAgent {
         `${MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS} addresses after merging local allowedAgents.`,
       );
     }
-    const publishAuthority = publishPolicy === EVM_PUBLISH_CURATED
-      ? await this.getChainPublishAuthorityAddress(id)
-      : undefined;
-    if (
-      publishPolicy === EVM_PUBLISH_CURATED
-      && publishAuthority
-      && ownerAddress.toLowerCase() !== publishAuthority.toLowerCase()
-    ) {
-      throw new Error(
-        `Context graph "${id}" cannot be registered as curated by local curator ${ownerAddress} ` +
-        `because the configured chain signer is ${publishAuthority}. Per-agent chain signers are not supported yet.`,
-      );
-    }
-    if (
-      publishPolicy === EVM_PUBLISH_CURATED
-      && !publishAuthority
-      && opts?.callerAgentAddress
-      && this.defaultAgentAddress
-      && opts.callerAgentAddress.toLowerCase() !== this.defaultAgentAddress.toLowerCase()
-    ) {
-      throw new Error(
-        `Context graph "${id}" cannot be registered as curated by non-default local curator ` +
-        `${opts.callerAgentAddress} without chain signer introspection. Per-agent chain signers are not supported yet.`,
-      );
+    let publishAuthority: string | undefined;
+    if (publishPolicy === EVM_PUBLISH_CURATED) {
+      if (isPcaCurated) {
+        if (typeof this.chain.getPublishingConvictionAccountOwner !== 'function') {
+          throw new Error('PCA curated context graph registration requires chain adapter PCA owner lookup support.');
+        }
+        publishAuthority = ethers.getAddress(
+          await this.chain.getPublishingConvictionAccountOwner(publishAuthorityAccountId),
+        );
+      } else {
+        publishAuthority = await this.getChainPublishAuthorityAddress(id);
+      }
+      // Uniform strict check across EOA and PCA modes:
+      //  - EOA: publishAuthority is the chain signer; local curator
+      //    must equal the chain signer.
+      //  - PCA: publishAuthority is ownerOf(pcaAccountId); local curator
+      //    must equal the PCA owner. Registered agents are publish-time
+      //    delegates only — publish-time authorization lives on chain in
+      //    `ContextGraphs.isAuthorizedPublisher`.
+      if (publishAuthority && ownerAddress.toLowerCase() !== publishAuthority.toLowerCase()) {
+        const reason = isPcaCurated
+          ? `PCA account ${publishAuthorityAccountId} is owned by ${publishAuthority}; only the PCA owner can register, registered agents may only publish.`
+          : `the configured chain signer is ${publishAuthority}. Per-agent chain signers are not supported yet.`;
+        throw new Error(
+          `Context graph "${id}" cannot be registered as curated by local curator ${ownerAddress} because ${reason}`,
+        );
+      }
+      if (
+        !publishAuthority
+        && opts?.callerAgentAddress
+        && this.defaultAgentAddress
+        && opts.callerAgentAddress.toLowerCase() !== this.defaultAgentAddress.toLowerCase()
+      ) {
+        throw new Error(
+          `Context graph "${id}" cannot be registered as curated by non-default local curator ` +
+          `${opts.callerAgentAddress} without chain signer introspection. Per-agent chain signers are not supported yet.`,
+        );
+      }
     }
 
     const result = await this.registerContextGraphOnChain({
@@ -4578,6 +4628,7 @@ export class DKGAgent {
       requiredSignatures: effectiveRequiredSignatures,
       publishPolicy,
       ...(publishAuthority ? { publishAuthority } : {}),
+      ...(isPcaCurated ? { publishAuthorityAccountId } : {}),
       participantAgents,
     });
     const onChainId = result.contextGraphId.toString();
@@ -7302,6 +7353,46 @@ export class DKGAgent {
       includeReservingPublisherProbe: false,
       includeGenericSignMessageProbe: false,
     });
+  }
+
+  private async getContextGraphPublishAuthorityAccountId(contextGraphId: string): Promise<bigint | undefined> {
+    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
+    const paranetUri = `did:dkg:context-graph:${contextGraphId}`;
+    const result = await this.store.query(
+      `SELECT ?accountId WHERE {
+        GRAPH <${cgMetaGraph}> {
+          <${paranetUri}> <${DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID}> ?accountId .
+        }
+      } LIMIT 1`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
+
+    const raw = result.bindings[0]?.['accountId']?.replace(/^"|"$/g, '');
+    if (!raw) return undefined;
+    if (!/^\d+$/.test(raw)) {
+      throw new Error(`Context graph "${contextGraphId}" has invalid PCA account id "${raw}".`);
+    }
+    const accountId = BigInt(raw);
+    if (accountId <= 0n) {
+      throw new Error(`Context graph "${contextGraphId}" has invalid PCA account id "${raw}".`);
+    }
+    return accountId;
+  }
+
+  private async setContextGraphPublishAuthorityAccountId(contextGraphId: string, accountId: bigint): Promise<void> {
+    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
+    const paranetUri = `did:dkg:context-graph:${contextGraphId}`;
+    await this.store.deleteByPattern({
+      graph: cgMetaGraph,
+      subject: paranetUri,
+      predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+    });
+    await this.store.insert([{
+      graph: cgMetaGraph,
+      subject: paranetUri,
+      predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+      object: `"${accountId.toString()}"`,
+    }]);
   }
 
   /**

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -69,6 +69,22 @@ class SignerListContextGraphChainAdapter extends CapturingContextGraphChainAdapt
   }
 }
 
+class PcaCuratedRegistrationChainAdapter extends AsyncSignerAddressContextGraphChainAdapter {
+  constructor(
+    private readonly accountOwners: Map<bigint, string>,
+  ) {
+    super();
+  }
+
+  async getPublishingConvictionAccountOwner(accountId: bigint): Promise<string> {
+    const owner = this.accountOwners.get(accountId);
+    if (!owner) {
+      throw new Error(`No mock PCA owner for account ${accountId}`);
+    }
+    return owner;
+  }
+}
+
 class NonRegisteringACKChainAdapter extends MockChainAdapter {
   async ensureOperationalWalletsRegistered(options?: {
     identityId?: bigint;
@@ -2314,6 +2330,120 @@ decisions: []
     await agent.registerContextGraph('register-curated-signer-list-policy', { callerAgentAddress: ownerAgent });
 
     expect(chain.createOnChainContextGraphCalls[0]?.publishAuthority).toBe(ownerAgent);
+    await agent.stop().catch(() => {});
+  });
+
+  it('registers PCA curated context graphs without requiring the chain signer to equal the local curator', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const pcaAccountId = 42n;
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaRegistrationBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    expect(pcaOwner.toLowerCase()).not.toBe(chain.signerAddress.toLowerCase());
+    await agent.createContextGraph({
+      id: 'register-pca-curated-policy',
+      name: 'PCA Curated Policy',
+      accessPolicy: 1,
+      publishAuthorityAccountId: pcaAccountId,
+      callerAgentAddress: pcaOwner,
+    });
+
+    await expect(agent.registerContextGraph('register-pca-curated-policy', { callerAgentAddress: pcaOwner }))
+      .resolves.toMatchObject({ onChainId: expect.any(String) });
+
+    expect(chain.createOnChainContextGraphCalls[0]).toMatchObject({
+      publishPolicy: 0,
+      publishAuthority: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    });
+    await agent.stop().catch(() => {});
+  });
+
+  it('registers PCA curated context graphs when the PCA account id is supplied at registration time', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const pcaAccountId = 43n;
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaRegistrationOverrideBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    await agent.createContextGraph({
+      id: 'register-pca-curated-override-policy',
+      name: 'PCA Curated Override Policy',
+      accessPolicy: 1,
+      callerAgentAddress: pcaOwner,
+    });
+
+    await expect(agent.registerContextGraph('register-pca-curated-override-policy', {
+      callerAgentAddress: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    })).resolves.toMatchObject({ onChainId: expect.any(String) });
+
+    expect(chain.createOnChainContextGraphCalls[0]).toMatchObject({
+      publishPolicy: 0,
+      publishAuthority: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    });
+    await agent.stop().catch(() => {});
+  });
+
+  it('rejects PCA account ids on open context graphs', async () => {
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[7n, ethers.Wallet.createRandom().address]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaOpenPolicyBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    await expect(agent.createContextGraph({
+      id: 'register-open-pca-policy',
+      name: 'Open PCA Policy',
+      publishAuthorityAccountId: 7n,
+      callerAgentAddress: ethers.getAddress(chain.signerAddress),
+    })).rejects.toThrow(/PCA account id.*curated/i);
+
+    await agent.stop().catch(() => {});
+  });
+
+  it('rejects PCA curated registration when local curator is not the PCA owner', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const nonOwner = new ethers.Wallet(HARDHAT_KEYS.REC2_OP).address;
+    const pcaAccountId = 99n;
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaRejectsNonOwnerBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    expect(nonOwner.toLowerCase()).not.toBe(pcaOwner.toLowerCase());
+    await agent.createContextGraph({
+      id: 'reject-pca-non-owner',
+      name: 'Reject PCA non-owner',
+      accessPolicy: 1,
+      publishAuthorityAccountId: pcaAccountId,
+      callerAgentAddress: nonOwner,
+    });
+
+    await expect(agent.registerContextGraph('reject-pca-non-owner', {
+      callerAgentAddress: nonOwner,
+    })).rejects.toThrow(/PCA account 99|only the PCA owner/i);
+
+    expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
     await agent.stop().catch(() => {});
   });
 

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -514,6 +514,7 @@ export interface ChainAdapter {
   extendConvictionLock?(accountId: bigint, additionalEpochs: number): Promise<TxResult>;
   getConvictionDiscount?(accountId: bigint): Promise<{ discountBps: number; conviction: bigint }>;
   getConvictionAccountInfo?(accountId: bigint): Promise<ConvictionAccountInfo | null>;
+  getPublishingConvictionAccountOwner?(accountId: bigint): Promise<string>;
 
   // Permanent Publishing
   publishKnowledgeAssetsPermanent?(params: PermanentPublishParams): Promise<OnChainPublishResult>;

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -2318,6 +2318,13 @@ export class EVMChainAdapter implements ChainAdapter {
     }
   }
 
+  async getPublishingConvictionAccountOwner(accountId: bigint): Promise<string> {
+    await this.init();
+    const nft = await this.resolveContract('DKGPublishingConvictionNFT');
+    const owner = await nft.ownerOf(accountId);
+    return ethers.getAddress(owner);
+  }
+
   async getConvictionDiscount(accountId: bigint): Promise<{ discountBps: number; conviction: bigint }> {
     await this.init();
     if (!this.contracts.publishingConvictionAccount) {

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -592,6 +592,15 @@ export class MockChainAdapter implements ChainAdapter {
     };
   }
 
+  async getPublishingConvictionAccountOwner(accountId: bigint): Promise<string> {
+    const acct = this.convictionAccounts.get(accountId);
+    if (!acct) {
+      throw new Error(`Mock: PCA account ${accountId} does not exist`);
+    }
+    // The mock does not model PCA NFT transfers, so the account admin is its owner.
+    return ethers.getAddress(acct.admin);
+  }
+
   // --- Staking Conviction ---
 
   private delegatorLocks = new Map<string, { lockTier: number; startEpoch: number }>();
@@ -681,11 +690,14 @@ export class MockChainAdapter implements ChainAdapter {
     }
     publishAuthority = ethers.getAddress(publishAuthority);
     if (publishPolicy === 0) {
-      if (publishAuthorityAccountId !== 0n) {
-        throw new Error('Mock: PCA publishAuthorityAccountId is not supported');
-      }
       if (publishAuthority === ethers.ZeroAddress) {
         publishAuthority = ethers.getAddress(this.signerAddress);
+      }
+      if (publishAuthorityAccountId !== 0n) {
+        const pcaOwner = await this.getPublishingConvictionAccountOwner(publishAuthorityAccountId);
+        if (publishAuthority.toLowerCase() !== pcaOwner.toLowerCase()) {
+          throw new Error('Mock: PCA publishAuthority must match account owner');
+        }
       }
     } else {
       if (publishAuthority !== ethers.ZeroAddress) {

--- a/packages/chain/src/no-chain-adapter.ts
+++ b/packages/chain/src/no-chain-adapter.ts
@@ -48,6 +48,7 @@ export class NoChainAdapter implements ChainAdapter {
   async isOperationalWalletRegistered(_identityId: bigint, _address: string): Promise<boolean> { return false; }
   async getKnowledgeAssetsV10Address(): Promise<string> { noChain(); }
   async getEvmChainId(): Promise<bigint> { noChain(); }
+  async getPublishingConvictionAccountOwner(_accountId: bigint): Promise<string> { noChain(); }
   isV10Ready(): boolean { return false; }
   isRandomSamplingReady(): boolean { return false; }
 }

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -278,12 +278,34 @@ describe('MockChainAdapter API parity with EVMChainAdapter [CH-8]', () => {
       ...base,
       publishPolicy: 0,
       publishAuthorityAccountId: 1n,
-    })).rejects.toThrow(/PCA publishAuthorityAccountId is not supported/);
+    })).rejects.toThrow(/PCA account 1 does not exist/);
+
+    const { accountId } = await mock.createConvictionAccount(1n, 1);
 
     await expect(mock.createOnChainContextGraph({
       ...base,
       publishPolicy: 0,
+      publishAuthority: '0x2222222222222222222222222222222222222222',
+      publishAuthorityAccountId: accountId,
+    })).rejects.toThrow(/PCA publishAuthority must match account owner/);
+
+    await expect(mock.createOnChainContextGraph({
+      ...base,
+      publishPolicy: 0,
+      publishAuthority: '0x1111111111111111111111111111111111111111',
+      publishAuthorityAccountId: accountId,
     })).resolves.toMatchObject({ contextGraphId: 1n });
+
+    await expect(mock.createOnChainContextGraph({
+      ...base,
+      publishPolicy: 0,
+      publishAuthorityAccountId: accountId,
+    })).resolves.toMatchObject({ contextGraphId: 2n });
+
+    await expect(mock.createOnChainContextGraph({
+      ...base,
+      publishPolicy: 0,
+    })).resolves.toMatchObject({ contextGraphId: 3n });
   });
 
   it('requires explicit mock support for address-specific V10 publishing', async () => {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -491,6 +491,7 @@ export class ApiClient {
     participantAgents?: string[];
     participantIdentityIds?: Array<string | number | bigint>;
     requiredSignatures?: number;
+    pcaAccountId?: string | number | bigint;
   }, allowedPeers?: string[]): Promise<{
     created: string;
     uri: string;
@@ -508,6 +509,7 @@ export class ApiClient {
         ? { participantIdentityIds: options.participantIdentityIds.map((id) => id.toString()) }
         : {}),
       ...(options?.requiredSignatures != null ? { requiredSignatures: options.requiredSignatures } : {}),
+      ...(options?.pcaAccountId != null ? { pcaAccountId: options.pcaAccountId.toString() } : {}),
     });
   }
 
@@ -515,6 +517,7 @@ export class ApiClient {
     /** @deprecated V10 ContextGraphs registration ignores metadata reveal. */
     revealOnChain?: boolean;
     accessPolicy?: number;
+    pcaAccountId?: string | number | bigint;
   }): Promise<{
     registered: string;
     onChainId: string;
@@ -523,6 +526,7 @@ export class ApiClient {
     return this.post('/api/context-graph/register', {
       id,
       ...(opts?.accessPolicy != null ? { accessPolicy: opts.accessPolicy } : {}),
+      ...(opts?.pcaAccountId != null ? { pcaAccountId: opts.pcaAccountId.toString() } : {}),
     });
   }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1265,6 +1265,7 @@ contextGraphCmd
     [] as string[],
   )
   .option('--required-signatures <n>', 'Required signatures threshold for participant-based context graphs')
+  .option('--pca-account-id <id>', 'Publishing Conviction Account id for PCA-curated on-chain registration')
   .option('--subscribe', 'Also subscribe to the context graph after creation', true)
   .option('--save', 'Persist subscription to config')
   .action(async (id: string, opts: ActionOpts) => {
@@ -1279,7 +1280,14 @@ contextGraphCmd
 
       const participantIdentityIds = (opts.participantIdentityId as string[] | undefined) ?? [];
       const allowedAgents = (opts.allowedAgent as string[] | undefined) ?? [];
-      const accessPolicy = allowedAgents.length > 0 ? 1 : (opts.accessPolicy as number | undefined);
+      const pcaAccountId = opts.pcaAccountId as string | undefined;
+      if (pcaAccountId && !/^[1-9]\d*$/.test(pcaAccountId)) {
+        throw new Error('--pca-account-id must be a positive decimal integer');
+      }
+      if (pcaAccountId && opts.accessPolicy === 0 && !opts.private) {
+        throw new Error('--pca-account-id can only be used with curated/private context graphs');
+      }
+      const accessPolicy = allowedAgents.length > 0 || pcaAccountId ? 1 : (opts.accessPolicy as number | undefined);
 
       const result = await client.createContextGraph(id, opts.name ?? id, opts.description, {
         private: !!opts.private,
@@ -1287,6 +1295,7 @@ contextGraphCmd
         allowedAgents: allowedAgents.length > 0 ? allowedAgents : undefined,
         participantIdentityIds,
         requiredSignatures: opts.requiredSignatures != null ? Number(opts.requiredSignatures) : undefined,
+        pcaAccountId,
       }, opts.invite as string[] | undefined);
       console.log(`Context graph created:`);
       console.log(`  ID:   ${result.created}`);
@@ -1303,6 +1312,9 @@ contextGraphCmd
       }
       if (opts.requiredSignatures != null) {
         console.log(`  Required signatures: ${opts.requiredSignatures}`);
+      }
+      if (pcaAccountId) {
+        console.log(`  PCA account id: ${pcaAccountId}`);
       }
       console.log(`  Run 'dkg context-graph register ${id}' to register on-chain (unlocks Verified Memory).`);
 
@@ -1335,16 +1347,24 @@ contextGraphCmd
   .command('register <id>')
   .description('Register an existing context graph on-chain (unlocks Verified Memory, requires TRAC)')
   .option('--reveal', 'Deprecated: V10 ContextGraphs registration does not reveal cleartext metadata on-chain')
+  .option('--pca-account-id <id>', 'Publishing Conviction Account id for PCA-curated registration')
   .action(async (id: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();
       if (opts.reveal) {
         console.warn('--reveal is deprecated and ignored for V10 ContextGraphs registration.');
       }
-      const result = await client.registerContextGraph(id);
+      const pcaAccountId = opts.pcaAccountId as string | undefined;
+      if (pcaAccountId && !/^[1-9]\d*$/.test(pcaAccountId)) {
+        throw new Error('--pca-account-id must be a positive decimal integer');
+      }
+      const result = await client.registerContextGraph(id, { pcaAccountId });
       console.log(`Context graph registered on-chain:`);
       console.log(`  ID:         ${id}`);
       console.log(`  On-chain:   ${result.onChainId}`);
+      if (pcaAccountId) {
+        console.log(`  PCA account id: ${pcaAccountId}`);
+      }
       console.log(`  ${result.hint ?? 'You can now publish SWM to Verified Memory.'}`);
     } catch (err) {
       console.error(toErrorMessage(err));

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -328,6 +328,23 @@ import {
 
 import type { RequestContext } from './context.js';
 
+function parseOptionalPcaAccountId(body: Record<string, unknown>): { value?: bigint; error?: string } {
+  const raw = body.pcaAccountId;
+  if (raw === undefined || raw === null || raw === '') return {};
+  if (typeof raw === 'number') {
+    if (!Number.isSafeInteger(raw) || raw <= 0) {
+      return { error: 'pcaAccountId must be a positive safe integer' };
+    }
+    return { value: BigInt(raw) };
+  }
+  if (typeof raw === 'string') {
+    if (!/^[1-9]\d*$/.test(raw)) {
+      return { error: 'pcaAccountId must be a positive decimal integer string' };
+    }
+    return { value: BigInt(raw) };
+  }
+  return { error: 'pcaAccountId must be a positive integer or decimal integer string' };
+}
 
 export async function handleContextGraphRoutes(ctx: RequestContext): Promise<void> {
   const {
@@ -444,6 +461,18 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       return jsonResponse(res, 400, { error: 'Missing "id" or "name"' });
     if (!isValidContextGraphId(id))
       return jsonResponse(res, 400, { error: "Invalid context graph id" });
+    const parsedPcaAccountId = parseOptionalPcaAccountId(parsed);
+    if (parsedPcaAccountId.error) {
+      return jsonResponse(res, 400, { error: parsedPcaAccountId.error });
+    }
+    if (parsedPcaAccountId.value !== undefined && accessPolicy === 0 && parsed.private !== true) {
+      return jsonResponse(res, 400, { error: 'pcaAccountId is only valid for curated/private context graphs' });
+    }
+    const inferredAccessPolicy = typeof accessPolicy === 'number'
+      ? accessPolicy
+      : parsedPcaAccountId.value !== undefined
+        ? 1
+        : undefined;
     try {
       await agent.createContextGraph({
         id,
@@ -452,8 +481,9 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
         allowedAgents: Array.isArray(allowedAgents) ? allowedAgents : undefined,
         allowedPeers: Array.isArray(allowedPeers) ? allowedPeers : undefined,
         participantAgents: Array.isArray(participantAgents) ? participantAgents : undefined,
-        accessPolicy: typeof accessPolicy === 'number' ? accessPolicy : undefined,
+        accessPolicy: inferredAccessPolicy,
         callerAgentAddress: requestAgentAddress,
+        publishAuthorityAccountId: parsedPcaAccountId.value,
         ...(parsed.private === true ? { private: true } : {}),
         ...(Array.isArray(parsed.participantIdentityIds)
           ? { participantIdentityIds: parsed.participantIdentityIds.map((v: string | number) => BigInt(v)) }
@@ -476,7 +506,10 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     // registered later via POST /api/context-graph/register.
     if (register === true) {
       try {
-        const regResult = await agent.registerContextGraph(id, { callerAgentAddress: requestAgentAddress });
+        const regResult = await agent.registerContextGraph(id, {
+          callerAgentAddress: requestAgentAddress,
+          publishAuthorityAccountId: parsedPcaAccountId.value,
+        });
         return jsonResponse(res, 200, {
           created: id,
           uri: `did:dkg:context-graph:${id}`,
@@ -509,8 +542,19 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     if (accessPolicy !== undefined && (accessPolicy !== 0 && accessPolicy !== 1)) {
       return jsonResponse(res, 400, { error: '"accessPolicy" must be 0 (open) or 1 (private)' });
     }
+    const parsedPcaAccountId = parseOptionalPcaAccountId(parsed);
+    if (parsedPcaAccountId.error) {
+      return jsonResponse(res, 400, { error: parsedPcaAccountId.error });
+    }
+    if (parsedPcaAccountId.value !== undefined && accessPolicy === 0) {
+      return jsonResponse(res, 400, { error: 'pcaAccountId is only valid for curated/private context graphs' });
+    }
     try {
-      const result = await agent.registerContextGraph(id, { accessPolicy, callerAgentAddress: requestAgentAddress });
+      const result = await agent.registerContextGraph(id, {
+        accessPolicy,
+        callerAgentAddress: requestAgentAddress,
+        publishAuthorityAccountId: parsedPcaAccountId.value,
+      });
       return jsonResponse(res, 200, {
         registered: id,
         onChainId: result.onChainId,
@@ -536,6 +580,9 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       }
       if (msg.includes('address-scoped curator')) {
         return jsonResponse(res, 403, { error: msg });
+      }
+      if (msg.includes('PCA account id can only be used with curated/private context graphs')) {
+        return jsonResponse(res, 400, { error: msg });
       }
       return jsonResponse(res, 500, { error: msg });
     }

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -517,6 +517,37 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
     // "duplicate" / "conflict" substrings.
     expect(second.status).toBe(409);
   });
+
+  it('returns 400 when registering an existing open context graph with a PCA account id', async () => {
+    const d = daemon!;
+    const cgId = 'open-pca-register-' + Math.random().toString(36).slice(2, 8);
+    const create = await fetch(urlFor(d, '/api/context-graph/create'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({ id: cgId, name: cgId }),
+    });
+    expect([200, 201]).toContain(create.status);
+
+    const register = await fetch(urlFor(d, '/api/context-graph/register'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({ id: cgId, pcaAccountId: '1' }),
+    });
+    expect(register.status).toBe(400);
+    const body = await register.json();
+    expect(body.error).toMatch(/pcaAccountId|PCA account id/i);
+  });
+
+  it('treats pcaAccountId as curated input when creating a context graph', async () => {
+    const d = daemon!;
+    const cgId = 'pca-create-' + Math.random().toString(36).slice(2, 8);
+    const create = await fetch(urlFor(d, '/api/context-graph/create'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({ id: cgId, name: cgId, pcaAccountId: '1' }),
+    });
+    expect([200, 201]).toContain(create.status);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -181,6 +181,7 @@ export const DKG_ONTOLOGY = {
   DKG_ACCESS_POLICY: `${DKG}accessPolicy`,
   DKG_PARTICIPANT_IDENTITY_ID: `${DKG}participantIdentityId`,
   DKG_PARTICIPANT_AGENT: `${DKG}participantAgent`,
+  DKG_PUBLISH_AUTHORITY_ACCOUNT_ID: `${DKG}publishAuthorityAccountId`,
   DKG_CCL_POLICY: `${DKG}CCLPolicy`,
   DKG_POLICY_BINDING: `${DKG}PolicyBinding`,
   DKG_POLICY_APPLIES_TO_PARANET: `${DKG}appliesToParanet`,


### PR DESCRIPTION
## TL;DR

Before this PR, only the wallet that registered a curated context graph
could publish to it. After this PR, the PCA owner can authorize multiple
agent wallets to publish — by registering them on their PCA NFT.

```
                Publishing to a curated CG (tied to PCA #42)
            ┌─────────────────┬──────────────────────────────────┐
            │     Before      │     After (this PR)              │
            ├─────────────────┼──────────────────────────────────┤
  Owner     │       ✓         │       ✓                          │
  Agent     │       ✗         │       ✓ once registerAgent(42,…) │
  Random    │       ✗         │       ✗                          │
            └─────────────────┴──────────────────────────────────┘
```

## How it actually works

The contract has accepted a `pcaAccountId` field on `createContextGraph`
for a while, and `isAuthorizedPublisher` already knows how to check
"is this wallet the PCA owner OR a registered agent of that PCA?".
The daemon just wasn't sending the id. This PR sends it.

```
  Before:  register tx ──→ createContextGraph(authority)
  After:   register tx ──→ createContextGraph(authority, pcaAccountId)
                                                          ▲
                                                      one number
```

## Sample flow

```bash
# Alice owns PCA #42. Creates the curated CG, tags it with the PCA.
alice $ dkg context-graph create my-cg --access-policy 1 --pca-account-id 42
alice $ dkg context-graph register my-cg

# Alice authorizes Bob to publish (one tx on the PCA NFT contract).
alice $ cast send $PCA_NFT 'registerAgent(uint256,address)' 42 $BOB

# Bob runs his own daemon with his own key. Publishes successfully.
bob   $ dkg publish my-cg ./asset.ttl     # ✓

# Alice revokes Bob anytime.
alice $ cast send $PCA_NFT 'deregisterAgent(uint256,address)' 42 $BOB
bob   $ dkg publish my-cg ./asset.ttl     # ✗ UnauthorizedPublisher
```

## What this PR does NOT change

- **Registration** still requires the PCA owner's wallet. Daemon enforces
  `local curator == ownerOf(pcaAccountId)`. Agents cannot register CGs.
- **Publish-path code** is untouched. Authorization logic already lives
  in `ContextGraphs.isAuthorizedPublisher`.
- **EOA-curated** and **open** CGs behave exactly as before.

## Files

```
chain      chain-adapter.ts   evm-adapter.ts   mock-adapter.ts   no-chain-adapter.ts
core       genesis.ts (1 ontology predicate)
agent      dkg-agent.ts (accept, persist, forward pcaAccountId)
cli        api-client.ts   cli.ts (--pca-account-id flag)   daemon/routes/context-graph.ts
tests      agent / chain-mock-parity / cli-http
```

## Out of scope

Defense-in-depth contract change adding `require(msg.sender == ownerOf(accountId))`
to `ContextGraphs.createContextGraph` — tracked as a follow-up.
