### PR TITLE
fix: fund admin wallet with setup faucet

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,12 +312,12 @@ analysis reports are under `bench/results/profiles/`, including
 
 ## Testnet Funding
 
-A DKG testnet node needs Base Sepolia ETH (to pay gas for on-chain operations) and test TRAC (for staking and publishing). The Origin Trail testnet faucet hands out both in a single API call, so first-setup paths auto-fund your node's first three wallets when a faucet is configured in the network config.
+A DKG testnet node needs Base Sepolia ETH (to pay gas for on-chain operations) and test TRAC (for staking and publishing). The Origin Trail testnet faucet hands out both in a single API call, so first-setup paths auto-fund the generated admin wallet plus the three operational wallets when a faucet is configured in the network config.
 
 Three entry points cover the common flows:
 
-- **Manual install (`dkg init`)** — on testnet, `dkg init` auto-funds the node's wallets when `network.faucet.url` is set (the default for the bundled testnet config).
-- **OpenClaw adapter (`dkg openclaw setup`)** — runs the same funding step on first setup. Pass `--no-fund` to skip it (for pre-funded wallets, CI, or offline runs).
+- **Manual install (`dkg init`)** — on testnet, `dkg init` auto-funds the generated admin and operational wallets when `network.faucet.url` is set (the default for the bundled testnet config).
+- **OpenClaw, Hermes, and MCP setup (`dkg openclaw setup`, `dkg hermes setup`, `dkg mcp setup`)** — run the same funding step on first setup. Pass `--no-fund` to skip it (for pre-funded wallets, CI, or offline runs).
 - **Direct API / custom scripts** — the full request/response shape, idempotency semantics, and error codes live in [`docs/setup/TESTNET_FAUCET.md`](docs/setup/TESTNET_FAUCET.md).
 
 Faucet calls are best-effort: a failed call logs a ready-to-paste `curl` block and setup continues. The node is usable without funding — you just can't publish or stake until it's topped up. Rate limits and error codes are documented in the [faucet reference](docs/setup/TESTNET_FAUCET.md#rate-limits-and-cooldowns).

--- a/docs/setup/SETUP_HERMES.md
+++ b/docs/setup/SETUP_HERMES.md
@@ -46,7 +46,7 @@ dkg hermes setup
 ```
 
 `dkg hermes setup` bootstraps `~/.dkg/config.json` when missing, starts the
-DKG daemon (unless `--no-start` is passed), funds the node's first wallets
+DKG daemon (unless `--no-start` is passed), funds the node's generated admin and operational wallets
 through the testnet faucet (unless `--no-fund` is passed), installs the DKG
 Hermes plugin, elects DKG as the active `memory.provider` (replacing any
 prior provider with a timestamped backup; `--preserve-provider` opts out),
@@ -119,7 +119,7 @@ custom daemon URL or gateway does not fall back to localhost during
 | `--dry-run` | off | Preview planned file changes, daemon start, and faucet calls without writing or invoking anything. No backup file is written. |
 | `--no-verify` | off | Skip the post-setup verification pass. |
 | `--no-start` | off (daemon starts) | Skip starting the DKG daemon. Best-effort daemon registration still fires against an already-running daemon. |
-| `--no-fund` / `--fund` | `--fund` | Fund the node's first wallets through the testnet faucet. `--no-fund` skips the faucet call. Faucet failures are non-fatal; a manual `curl` block is logged. |
+| `--no-fund` / `--fund` | `--fund` | Fund the node's generated admin and operational wallets through the testnet faucet. `--no-fund` skips the faucet call. Faucet failures are non-fatal; a manual `curl` block is logged. |
 | `--preserve-provider` | off (replace) | Refuse to replace an existing non-DKG `memory.provider`. Restores the pre-#386 throw-on-conflict behavior for advanced users. |
 | `--no-replace-provider` | off (replace) | Alias for `--preserve-provider`. |
 

--- a/docs/setup/TESTNET_FAUCET.md
+++ b/docs/setup/TESTNET_FAUCET.md
@@ -6,7 +6,7 @@ Fund your DKG V9 node wallets with Base Sepolia testnet ETH and TRAC in a single
 
 ## Fund wallets
 
-Send a `POST /fund` request with your node wallet addresses (up to 3 per call). Each wallet receives both Base Sepolia ETH and test TRAC.
+Send a `POST /fund` request with your node wallet addresses (up to 4 per call). Each wallet receives both Base Sepolia ETH and test TRAC.
 
 ```bash
 curl -X POST "https://euphoria.origin-trail.network/faucet/fund" \
@@ -24,7 +24,7 @@ curl -X POST "https://euphoria.origin-trail.network/faucet/fund" \
 | Field | Required | Description |
 |-------|----------|-------------|
 | `mode` | Yes | Must be `"v10_base_sepolia"` |
-| `wallets` | Yes | Array of EVM addresses (1-3, no duplicates) |
+| `wallets` | Yes | Array of EVM addresses (1-4, no duplicates) |
 | `callerId` | No | Stable identifier for your installer/node — enables per-caller cooldown |
 
 ### Headers

--- a/docs/setup/TESTNET_FAUCET.md
+++ b/docs/setup/TESTNET_FAUCET.md
@@ -60,6 +60,11 @@ Each wallet produces 2 result entries (ETH + TRAC). Possible `status` values: `s
 
 On `429` responses, back off using the `retry-after` header.
 
+Bundled setup commands such as `dkg init`, `dkg openclaw setup`, `dkg hermes setup`,
+and `dkg mcp setup` send a stable `callerId` derived from the configured node or
+agent name. Removing `~/.dkg` / `~/.dkg-dev` and re-running setup with the same
+name can therefore still hit caller cooldown even when new wallets are generated.
+
 ## Dry run (test without sending transactions)
 
 `POST /dry-run` accepts the same body but doesn't broadcast transactions. Use it to verify your request while avoiding on-chain transactions; note that dry-run requests still count against the shared funding rate limit.

--- a/docs/setup/TESTNET_FAUCET.md
+++ b/docs/setup/TESTNET_FAUCET.md
@@ -65,6 +65,12 @@ block later wallets in the same 4-wallet funding request. They still send a
 deterministic `Idempotency-Key` derived from the node/agent name and wallet batch
 so retrying the same funding operation remains safe.
 
+Bundled setup commands wait up to 3 minutes for a faucet response because a
+4-wallet request can broadcast both ETH and TRAC transactions for each wallet
+before the faucet returns. If the client still times out, check wallet balances
+before retrying because the faucet may finish the on-chain work after the local
+request is aborted.
+
 ## Dry run (test without sending transactions)
 
 `POST /dry-run` accepts the same body but doesn't broadcast transactions. Use it to verify your request while avoiding on-chain transactions; note that dry-run requests still count against the shared funding rate limit.

--- a/docs/setup/TESTNET_FAUCET.md
+++ b/docs/setup/TESTNET_FAUCET.md
@@ -14,8 +14,7 @@ curl -X POST "https://euphoria.origin-trail.network/faucet/fund" \
   -H "Idempotency-Key: my-unique-key-001" \
   --data-raw '{
     "mode": "v10_base_sepolia",
-    "wallets": ["0xYOUR_WALLET_ADDRESS"],
-    "callerId": "my-node-installer"
+    "wallets": ["0xYOUR_WALLET_ADDRESS"]
   }'
 ```
 
@@ -25,7 +24,7 @@ curl -X POST "https://euphoria.origin-trail.network/faucet/fund" \
 |-------|----------|-------------|
 | `mode` | Yes | Must be `"v10_base_sepolia"` |
 | `wallets` | Yes | Array of EVM addresses (1-4, no duplicates) |
-| `callerId` | No | Stable identifier for your installer/node — enables per-caller cooldown |
+| `callerId` | No | Stable identifier for your installer/node; enables per-caller cooldown. Bundled setup commands omit this field and rely on `Idempotency-Key` for retry safety. |
 
 ### Headers
 
@@ -61,9 +60,10 @@ Each wallet produces 2 result entries (ETH + TRAC). Possible `status` values: `s
 On `429` responses, back off using the `retry-after` header.
 
 Bundled setup commands such as `dkg init`, `dkg openclaw setup`, `dkg hermes setup`,
-and `dkg mcp setup` send a stable `callerId` derived from the configured node or
-agent name. Removing `~/.dkg` / `~/.dkg-dev` and re-running setup with the same
-name can therefore still hit caller cooldown even when new wallets are generated.
+and `dkg mcp setup` do not send `callerId` because caller cooldown can otherwise
+block later wallets in the same 4-wallet funding request. They still send a
+deterministic `Idempotency-Key` derived from the node/agent name and wallet batch
+so retrying the same funding operation remains safe.
 
 ## Dry run (test without sending transactions)
 

--- a/packages/adapter-hermes/README.md
+++ b/packages/adapter-hermes/README.md
@@ -88,7 +88,7 @@ is set, setup uses that exact profile home.
 | `--port <port>` | `9200` | Shortcut for `--daemon-url http://127.0.0.1:<port>`. |
 | `--memory-mode <mode>` | `primary` | `primary` elects DKG as the Hermes memory provider; `tools-only` skips provider election. |
 | `--no-start` | off (daemon starts) | Skip starting the DKG daemon. Best-effort daemon registration still fires against an already-running daemon. |
-| `--no-fund` / `--fund` | `--fund` | Fund the node's first wallets through the testnet faucet. `--no-fund` skips. Faucet failures are non-fatal. |
+| `--no-fund` / `--fund` | `--fund` | Fund the node's generated admin and operational wallets through the testnet faucet. `--no-fund` skips. Faucet failures are non-fatal. |
 | `--preserve-provider` | off (replace) | Refuse to replace an existing non-DKG `memory.provider`. Restores the pre-#386 throw-on-conflict behavior. Aliased as `--no-replace-provider`. |
 | `--no-verify` | off | Skip the post-setup verification pass. |
 | `--dry-run` | off | Preview planned changes without writing files, starting the daemon, calling the faucet, or taking a config backup. |

--- a/packages/adapter-hermes/src/setup.ts
+++ b/packages/adapter-hermes/src/setup.ts
@@ -72,7 +72,7 @@ export interface HermesCliOptions {
   verify?: boolean;
   start?: boolean;
   /**
-   * Fund the first node wallets via the testnet faucet on first setup.
+   * Fund the node's generated admin and operational wallets via the testnet faucet on first setup.
    * Defaults to `true`; `--no-fund` flips to `false`. Mirrors OpenClaw
    * `OpenClawSetupCliOptions.fund` (issue #386 acceptance).
    */

--- a/packages/adapter-hermes/src/setup.ts
+++ b/packages/adapter-hermes/src/setup.ts
@@ -691,7 +691,7 @@ export async function runHermesSetup(req: HermesSetupRequest): Promise<HermesSet
       try {
         await fundWalletsBestEffort({
           network,
-          callerId: setupOptions.agentName ?? profile.profileName ?? 'hermes-setup',
+          idempotencySeed: setupOptions.agentName ?? profile.profileName ?? 'hermes-setup',
           didStartDaemon: shouldStart,
         });
         // fundWalletsBestEffort never throws and never returns funded list;

--- a/packages/adapter-openclaw/README.md
+++ b/packages/adapter-openclaw/README.md
@@ -10,7 +10,7 @@ The adapter is a thin bridge into the DKG node. It does not run its own DKG node
 - keeps connected-agent chat persisted in DKG Working Memory via the `chat-turns` assertion of the `agent-context` context graph
 - registers the DKG memory provider as OpenClaw's memory-slot capability, so slot-backed recall reads flow through real V10 primitives (assertion-scoped SPARQL queries with `view: 'working-memory'`, `'shared-working-memory'`, and `'verified-memory'`) rather than the legacy filesystem-watcher path
 - exposes DKG agent-network tools to the OpenClaw runtime
-- funds the first three node wallets via the testnet faucet on first setup (skippable with `--no-fund`; failures are non-fatal and log manual `curl` instructions)
+- funds the generated admin wallet plus operational wallets via the testnet faucet on first setup (skippable with `--no-fund`; failures are non-fatal and log manual `curl` instructions)
 
 Memory writes are not exposed as an adapter tool. The agent persists memory through direct daemon routes listed in `packages/cli/skills/dkg-node/SKILL.md` §5 (`POST /api/assertion/create` on first use of a fresh project CG, then `POST /api/assertion/:name/write` for each write). The daemon serves the skill document at `GET /.well-known/skill.md`, so the agent sees it on startup and calls the routes directly.
 

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -9,7 +9,7 @@
  *     not wrong-slot-wired) so deterministic setup errors fail fast
  *     before daemon start and the faucet call burn resources
  *  5. Start the DKG daemon
- *  6. Read wallets and fund the first three via the testnet faucet
+ *  6. Read wallets and fund the admin + operational wallets via the testnet faucet
  *     (skippable with `--no-fund`; non-fatal on failure)
  *  7. Copy the canonical DKG node skill into the OpenClaw workspace
  *  8. Merge adapter plugin into ~/.openclaw/openclaw.json (including
@@ -67,7 +67,7 @@ export interface SetupOptions {
   start?: boolean;
   dryRun?: boolean;
   /**
-   * Fund the first three node wallets via the testnet faucet on first setup.
+   * Fund the node's admin + operational wallets via the testnet faucet on first setup.
    * Defaults to `true`; the adapter treats `fund === false` (set by
    * `--no-fund`) as the only opt-out. Faucet failures are non-fatal — a
    * failed call logs manual `curl` instructions and setup continues.

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -270,8 +270,8 @@ export function discoverAgentName(workspaceDir: string, override?: string): stri
   // the same first-wins semantics for this field (existing.name wins unless
   // --name is passed); mirroring that here keeps re-runs on an
   // IDENTITY.md-absent workspace stable across invocations, which in turn
-  // keeps the faucet `callerId` and `Idempotency-Key` stable so retries
-  // don't create duplicate faucet requests.
+  // keeps the faucet `Idempotency-Key` stable so retries don't create
+  // duplicate faucet requests.
   const persistedName = readPersistedAgentName();
   if (persistedName) {
     log(`Using persisted agent name "${persistedName}" from ${join(dkgDir(), 'config.json')}`);
@@ -1581,11 +1581,11 @@ export async function runSetup(options: SetupOptions): Promise<void> {
   }
   let effectivePort = apiPort;
   // The post-merge `name` wins over the freshly-discovered `agentName` for
-  // downstream use (notably the faucet `callerId` / `Idempotency-Key`), so
+  // downstream use (notably the faucet `Idempotency-Key` seed), so
   // that a later IDENTITY.md edit — which changes what `discoverAgentName`
-  // returns — doesn't drift the faucet identity away from the node's
+  // returns — doesn't drift retry identity away from the node's
   // actual persisted identity. `writeDkgConfig` already enforces first-wins
-  // on `name` unless `--name` was passed; this line makes the faucet caller
+  // on `name` unless `--name` was passed; this line makes retry identity
   // agree with whatever that enforcement produces. Starts as the pre-merge
   // value so the dry-run / skipped-writeDkgConfig path still has something
   // sensible to pass.

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -1652,7 +1652,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
   if (!dryRun && shouldFund && network) {
     await fundWalletsBestEffort({
       network,
-      callerId: effectiveAgentName,
+      idempotencySeed: effectiveAgentName,
       didStartDaemon: shouldStart,
     });
   } else if (!dryRun && !shouldFund) {

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -3474,6 +3474,61 @@ describe('runSetup preflight runs before faucet (C10)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// readWallets — wallets.json address selection
+// ---------------------------------------------------------------------------
+
+describe('readWallets', () => {
+  let originalDkg: string | undefined;
+  let dkgHome: string;
+
+  beforeEach(() => {
+    originalDkg = process.env.DKG_HOME;
+    dkgHome = join(testDir, '.dkg');
+    mkdirSync(dkgHome, { recursive: true });
+    process.env.DKG_HOME = dkgHome;
+  });
+
+  afterEach(() => {
+    process.env.DKG_HOME = originalDkg;
+  });
+
+  it('returns the generated admin wallet before the three operational wallets', () => {
+    const admin = '0xAAAA000000000000000000000000000000000001';
+    const wallets = [
+      '0xBBBB000000000000000000000000000000000001',
+      '0xBBBB000000000000000000000000000000000002',
+      '0xBBBB000000000000000000000000000000000003',
+    ];
+    writeFileSync(
+      join(dkgHome, 'wallets.json'),
+      JSON.stringify({
+        adminWallet: { address: admin, privateKey: '0xadmin' },
+        wallets: wallets.map(address => ({ address, privateKey: `key-${address}` })),
+      }),
+    );
+
+    expect(readWallets()).toEqual([admin, ...wallets]);
+  });
+
+  it('deduplicates a malformed admin/operational overlap defensively', () => {
+    const shared = '0xCCCC000000000000000000000000000000000001';
+    const other = '0xCCCC000000000000000000000000000000000002';
+    writeFileSync(
+      join(dkgHome, 'wallets.json'),
+      JSON.stringify({
+        adminWallet: { address: shared, privateKey: '0xadmin' },
+        wallets: [
+          { address: shared, privateKey: '0xoperational-1' },
+          { address: other, privateKey: '0xoperational-2' },
+        ],
+      }),
+    );
+
+    expect(readWallets()).toEqual([shared, other]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // readWalletsWithRetry — retry accounting (C4a extraction)
 // ---------------------------------------------------------------------------
 
@@ -3536,7 +3591,7 @@ describe('logManualFundingInstructions', () => {
     logSpy.mockRestore();
   });
 
-  it('caps the curl body at the first 3 addresses matching the auto-path cap', () => {
+  it('batches the curl bodies at 4 addresses matching the auto-path cap', () => {
     const addrs = [
       '0x1111111111111111111111111111111111111111',
       '0x2222222222222222222222222222222222222222',
@@ -3547,36 +3602,38 @@ describe('logManualFundingInstructions', () => {
     logManualFundingInstructions(addrs, 'https://faucet.example.com/fund', 'v10_base_sepolia');
 
     const logged = logSpy.mock.calls.map(c => String(c[0])).join('\n');
-    // The curl body is built from JSON.stringify(fundable) — assert the
-    // cap by looking for the exact first-three array in the output and
-    // the absence of the 4th/5th addresses inside the curl line.
-    expect(logged).toContain(JSON.stringify(addrs.slice(0, 3)));
-    const curlLine = logSpy.mock.calls
+    // The curl body is built from JSON.stringify(batch) — assert the
+    // cap by looking for the exact first-four array in the output and
+    // the fifth address inside the second curl line.
+    expect(logged).toContain(JSON.stringify(addrs.slice(0, 4)));
+    expect(logged).toContain(JSON.stringify(addrs.slice(4)));
+    const curlLines = logSpy.mock.calls
       .map(c => String(c[0]))
-      .find(line => line.includes('--data-raw'));
-    expect(curlLine).toBeDefined();
-    expect(curlLine).not.toContain(addrs[3]);
-    expect(curlLine).not.toContain(addrs[4]);
+      .filter(line => line.includes('--data-raw'));
+    expect(curlLines).toHaveLength(2);
+    expect(curlLines[0]).not.toContain(addrs[4]);
+    expect(curlLines[1]).toContain(addrs[4]);
   });
 
-  // "emits a follow-on note listing the omitted wallets when more than 3
+  // "emits a follow-on note listing the omitted wallets when more than 4
   // are passed" removed: `logManualFundingInstructions` now batches long
   // address lists instead of truncating-with-note, so the
-  // `toMatch(/faucet supports up to 3 wallets/i)` + `toContain('2 wallet')`
+  // `toMatch(/faucet supports up to 4 wallets/i)` + `toContain('1 wallet')`
   // sentinels no longer match the output shape. Batching is already
   // covered by sibling tests.
 
-  it('does not emit the extras note when exactly 3 (or fewer) addresses are passed', () => {
+  it('does not emit the batching note when exactly 4 (or fewer) addresses are passed', () => {
     const addrs = [
       '0x1111111111111111111111111111111111111111',
       '0x2222222222222222222222222222222222222222',
       '0x3333333333333333333333333333333333333333',
+      '0x4444444444444444444444444444444444444444',
     ];
     logManualFundingInstructions(addrs, 'https://faucet.example.com/fund', 'v10_base_sepolia');
 
     const logged = logSpy.mock.calls.map(c => String(c[0])).join('\n');
     expect(logged).toContain('To fund wallets manually');
-    expect(logged).not.toMatch(/up to 3 wallets per call/i);
+    expect(logged).not.toMatch(/up to 4 wallets per call/i);
     expect(logged).not.toMatch(/remaining/i);
   });
 });
@@ -3593,7 +3650,12 @@ describe('logManualFundingInstructions', () => {
 // ---------------------------------------------------------------------------
 
 describe('runSetup Step 5 — faucet funding', () => {
-  const SEEDED_WALLET = '0xAAAA0000000000000000000000000000000000AA';
+  const SEEDED_ADMIN_WALLET = '0xAAAA0000000000000000000000000000000000AA';
+  const SEEDED_OPERATIONAL_WALLETS = [
+    '0xBBBB0000000000000000000000000000000000BB',
+    '0xCCCC0000000000000000000000000000000000CC',
+    '0xDDDD0000000000000000000000000000000000DD',
+  ];
 
   function setupFaucetEnv() {
     const dkgHome = join(testDir, '.dkg');
@@ -3606,12 +3668,15 @@ describe('runSetup Step 5 — faucet funding', () => {
       join(openclawHome, 'openclaw.json'),
       JSON.stringify({ plugins: {} }, null, 2) + '\n',
     );
-    // Pre-seed wallets.json so readWallets() returns a wallet on the first
+    // Pre-seed wallets.json so readWallets() returns wallets on the first
     // attempt (bypasses the retry loop — that behavior is covered by the
     // readWalletsWithRetry suite above).
     writeFileSync(
       join(dkgHome, 'wallets.json'),
-      JSON.stringify({ wallets: [{ address: SEEDED_WALLET, privateKey: '0xdeadbeef' }] }),
+      JSON.stringify({
+        adminWallet: { address: SEEDED_ADMIN_WALLET, privateKey: '0xadmin' },
+        wallets: SEEDED_OPERATIONAL_WALLETS.map(address => ({ address, privateKey: `key-${address}` })),
+      }),
     );
 
     const originalDkg = process.env.DKG_HOME;
@@ -3653,7 +3718,7 @@ describe('runSetup Step 5 — faucet funding', () => {
       expect(url).toMatch(/^https?:\/\//);
       expect(typeof mode).toBe('string');
       expect(mode.length).toBeGreaterThan(0);
-      expect(addresses).toEqual([SEEDED_WALLET]);
+      expect(addresses).toEqual([SEEDED_ADMIN_WALLET, ...SEEDED_OPERATIONAL_WALLETS]);
       expect(nodeName).toBe('test-agent');
 
       // AC3 invariant (plugins.slots.memory === 'adapter-openclaw') must still

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -3510,6 +3510,20 @@ describe('readWallets', () => {
     expect(readWallets()).toEqual([admin, ...wallets]);
   });
 
+  it('returns only operational wallets for legacy wallets.json arrays', () => {
+    const wallets = [
+      '0xBBBB000000000000000000000000000000000001',
+      '0xBBBB000000000000000000000000000000000002',
+      '0xBBBB000000000000000000000000000000000003',
+    ];
+    writeFileSync(
+      join(dkgHome, 'wallets.json'),
+      JSON.stringify(wallets.map(address => ({ address, privateKey: `key-${address}` }))),
+    );
+
+    expect(readWallets()).toEqual(wallets);
+  });
+
   it('deduplicates a malformed admin/operational overlap defensively', () => {
     const shared = '0xCCCC000000000000000000000000000000000001';
     const other = '0xCCCC000000000000000000000000000000000002';

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -3844,7 +3844,7 @@ describe('runSetup Step 5 — faucet funding', () => {
   });
 
   it('continues non-fatally when requestFaucetFunding throws an AbortError (timeout path)', async () => {
-    // `requestFaucetFunding` in core wraps fetch with AbortSignal.timeout(30_000).
+    // `requestFaucetFunding` in core wraps fetch with AbortSignal.timeout(...).
     // A triggered timeout surfaces as a DOMException with name "TimeoutError"
     // (or AbortError on some runtimes). Cover both.
     const timeoutErr = new DOMException('The operation was aborted due to timeout', 'TimeoutError');

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -30,7 +30,7 @@ vi.mock('@origintrail-official/dkg-core', async () => {
   return {
     ...actual,
     requestFaucetFunding: requestFaucetFundingSpy,
-    fundWalletsBestEffort: vi.fn(async ({ network, callerId, didStartDaemon }) => {
+    fundWalletsBestEffort: vi.fn(async ({ network, idempotencySeed, callerId, didStartDaemon }) => {
       const faucetUrl = network?.faucet?.url;
       const faucetMode = network?.faucet?.mode;
       if (!faucetUrl || !faucetMode) return;
@@ -41,7 +41,12 @@ vi.mock('@origintrail-official/dkg-core', async () => {
       if (!walletAddresses.length) return;
 
       try {
-        const result = await requestFaucetFundingSpy(faucetUrl, faucetMode, walletAddresses, callerId);
+        const result = await requestFaucetFundingSpy(
+          faucetUrl,
+          faucetMode,
+          walletAddresses,
+          idempotencySeed ?? callerId,
+        );
         if (!result.success || result.error) {
           actual.logManualFundingInstructions(
             result.failedWallets?.length ? result.failedWallets : walletAddresses,

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -3886,14 +3886,14 @@ describe('runSetup Step 5 — faucet funding', () => {
 
   // ---- C9: effective-name drift protection -----------------------------
   //
-  // The faucet's callerId and Idempotency-Key are derived from the
+  // The faucet Idempotency-Key seed is derived from the
   // `agentName` argument. `writeDkgConfig` uses first-wins semantics on
   // `name` (existing value wins unless --name was passed), so on re-runs
   // the name the node actually persists can differ from whatever
   // `discoverAgentName` returned in-memory this run (specifically when
   // IDENTITY.md has changed between runs). runSetup must thread the
-  // post-writeDkgConfig effective name through to the faucet so the
-  // caller identity matches what's persisted on disk.
+  // post-writeDkgConfig effective name through to the faucet so retry
+  // identity matches what's persisted on disk.
 
   it('faucet receives the persisted config.json name when IDENTITY.md changes between re-runs', async () => {
     const env = setupFaucetEnv();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,7 +9,14 @@ import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 import { writeFile, unlink } from 'node:fs/promises';
 import { ethers } from 'ethers';
-import { dkgAuthTokenPath, FAUCET_WALLETS_PER_REQUEST, requestFaucetFunding, toErrorMessage, hasErrorCode } from '@origintrail-official/dkg-core';
+import {
+  dkgAuthTokenPath,
+  FAUCET_WALLETS_PER_REQUEST,
+  getFundableWalletAddresses,
+  requestFaucetFunding,
+  toErrorMessage,
+  hasErrorCode,
+} from '@origintrail-official/dkg-core';
 import yaml from 'js-yaml';
 import {
   loadConfig, saveConfig, configExists, configPath,
@@ -386,10 +393,7 @@ program
     try {
       const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
       const opWallets = await loadOpWallets(dkgDir());
-      walletAddresses = [
-        ...(opWallets.adminWallet ? [opWallets.adminWallet.address] : []),
-        ...opWallets.wallets.map((w: { address: string }) => w.address),
-      ];
+      walletAddresses = getFundableWalletAddresses(opWallets);
     } catch (err: any) {
       console.warn(`\nWarning: could not generate wallets (${err?.message ?? String(err)}).`);
       console.warn('Wallets will be auto-generated on first "dkg start".');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 import { writeFile, unlink } from 'node:fs/promises';
 import { ethers } from 'ethers';
-import { dkgAuthTokenPath, requestFaucetFunding, toErrorMessage, hasErrorCode } from '@origintrail-official/dkg-core';
+import { dkgAuthTokenPath, FAUCET_WALLETS_PER_REQUEST, requestFaucetFunding, toErrorMessage, hasErrorCode } from '@origintrail-official/dkg-core';
 import yaml from 'js-yaml';
 import {
   loadConfig, saveConfig, configExists, configPath,
@@ -433,8 +433,8 @@ program
 
     // Auto-fund from testnet faucet if available
     if (network?.faucet?.url && walletAddresses.length > 0) {
-      if (walletAddresses.length > 3) {
-        console.log(`\nNote: faucet supports up to 3 wallets per request; funding wallets in batches.`);
+      if (walletAddresses.length > FAUCET_WALLETS_PER_REQUEST) {
+        console.log(`\nNote: faucet supports up to ${FAUCET_WALLETS_PER_REQUEST} wallets per request; funding wallets in batches.`);
       }
       console.log(`\nRequesting testnet tokens from faucet...`);
       try {

--- a/packages/cli/src/hermes-setup.ts
+++ b/packages/cli/src/hermes-setup.ts
@@ -14,7 +14,7 @@ export interface HermesSetupCliOptions {
   verify?: boolean;
   start?: boolean;
   /**
-   * Fund the first node wallets via the testnet faucet on first setup.
+   * Fund the generated admin and operational wallets via the testnet faucet on first setup.
    * Defaults to `true`; the adapter treats `fund === false` (set by
    * `--no-fund`) as the only opt-out. Faucet failures are non-fatal — a
    * failed call logs manual `curl` instructions and setup continues.

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -1844,8 +1844,17 @@ export async function mcpSetupAction(
               if (result?.success === false) {
                 console.warn('[setup] Faucet returned failure; emitting manual instructions.');
                 deps.logManualFundingInstructions(wallets, faucetUrl, faucetMode);
+              } else if (result?.error) {
+                const failedWallets = Array.isArray(result.failedWallets) && result.failedWallets.length
+                  ? result.failedWallets
+                  : wallets;
+                console.warn(`[setup] Faucet partially completed (${result.error}); emitting manual instructions for remaining wallet(s).`);
+                deps.logManualFundingInstructions(failedWallets, faucetUrl, faucetMode);
               } else {
-                console.log(`[setup] Funded ${wallets.length} wallet(s) via testnet faucet.`);
+                const fundedWalletCount = Array.isArray(result?.fundedWallets) && result.fundedWallets.length
+                  ? result.fundedWallets.length
+                  : wallets.length;
+                console.log(`[setup] Funded ${fundedWalletCount} wallet(s) via testnet faucet.`);
               }
             } catch (err: any) {
               console.warn(`[setup] Faucet call failed (${err?.message ?? err}); emitting manual instructions.`);

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -1842,7 +1842,9 @@ export async function mcpSetupAction(
             try {
               const result = await deps.requestFaucetFunding(faucetUrl, faucetMode, wallets, effectiveAgentName);
               if (result?.success === false) {
-                console.warn('[setup] Faucet returned failure; emitting manual instructions.');
+                console.warn(
+                  `[setup] Faucet returned failure${result.error ? ` (${result.error})` : ''}; emitting manual instructions.`,
+                );
                 deps.logManualFundingInstructions(wallets, faucetUrl, faucetMode);
               } else if (result?.error) {
                 const failedWallets = Array.isArray(result.failedWallets) && result.failedWallets.length

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -148,8 +148,11 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
       defaultNodeRole: 'edge',
       faucet: { url: 'http://faucet.test', mode: 'testnet' },
     }) as any);
-    const readWalletsWithRetry = vi.fn(async () => ['0xtest1', '0xtest2', '0xtest3']);
-    const requestFaucetFunding = vi.fn(async () => ({ success: true }) as any);
+    const readWalletsWithRetry = vi.fn(async () => ['0xadmin', '0xtest1', '0xtest2', '0xtest3']);
+    const requestFaucetFunding = vi.fn(async () => ({
+      success: true,
+      fundedWallets: ['0xadmin', '0xtest1', '0xtest2', '0xtest3'],
+    }) as any);
     const logManualFundingInstructions = vi.fn(() => {});
     // Phase-2: detectContext defaults to "installed" by returning null
     // from findDkgMonorepoRoot. Tests that exercise the monorepo path
@@ -336,6 +339,8 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     // Funding MUST proceed — daemon is reachable, --no-fund was not
     // supplied. This is the bug F14 fixes.
     expect(deps.requestFaucetFunding).toHaveBeenCalledTimes(1);
+    expect((deps.requestFaucetFunding as any).mock.calls[0][2])
+      .toEqual(['0xadmin', '0xtest1', '0xtest2', '0xtest3']);
 
     fetchSpy.mockRestore();
   });
@@ -448,6 +453,32 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
 
     expect(deps.logManualFundingInstructions).toHaveBeenCalledTimes(1);
     // Registration still proceeds.
+    expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(true);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('faucet partial success logs manual instructions for remaining wallets only', async () => {
+    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
+    const deps = makeDeps({
+      requestFaucetFunding: vi.fn(async () => ({
+        success: true,
+        fundedWallets: ['0xadmin', '0xtest1'],
+        failedWallets: ['0xtest2', '0xtest3'],
+        error: 'Faucet did not fund all wallets: 0xtest2, 0xtest3',
+      }) as any),
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      return new Response('{}', { status: 200 }) as any;
+    });
+
+    await mcpSetupAction({ verify: false }, deps);
+
+    expect(deps.logManualFundingInstructions).toHaveBeenCalledTimes(1);
+    expect((deps.logManualFundingInstructions as any).mock.calls[0][0])
+      .toEqual(['0xtest2', '0xtest3']);
+    const warned = (warnSpy.mock.calls as any[]).map((c) => c.join(' ')).join('\n');
+    expect(warned).toMatch(/Faucet partially completed/);
     expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(true);
 
     fetchSpy.mockRestore();

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -458,6 +458,31 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     fetchSpy.mockRestore();
   });
 
+  it('faucet result failures log faucet-provided reasons', async () => {
+    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
+    const deps = makeDeps({
+      requestFaucetFunding: vi.fn(async () => ({
+        success: false,
+        fundedWallets: [],
+        failedWallets: ['0xadmin', '0xtest1', '0xtest2', '0xtest3'],
+        error: 'Faucet did not fund all wallets: 0xadmin. Faucet reported: cooldown_active: Caller cooldown active until 2026-05-11T19:17:45.000Z',
+      }) as any),
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      return new Response('{}', { status: 200 }) as any;
+    });
+
+    await mcpSetupAction({ verify: false }, deps);
+
+    expect(deps.logManualFundingInstructions).toHaveBeenCalledTimes(1);
+    const warned = (warnSpy.mock.calls as any[]).map((c) => c.join(' ')).join('\n');
+    expect(warned).toContain('cooldown_active');
+    expect(warned).toContain('2026-05-11T19:17:45.000Z');
+    expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(true);
+
+    fetchSpy.mockRestore();
+  });
+
   it('faucet partial success logs manual instructions for remaining wallets only', async () => {
     mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
     const deps = makeDeps({

--- a/packages/core/src/faucet-orchestration.ts
+++ b/packages/core/src/faucet-orchestration.ts
@@ -25,7 +25,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveDkgConfigHome } from './dkg-home.js';
-import { FAUCET_WALLETS_PER_REQUEST, requestFaucetFunding } from './faucet.js';
+import { FAUCET_WALLETS_PER_REQUEST, getFundableWalletAddresses, requestFaucetFunding } from './faucet.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -67,41 +67,11 @@ export function readWallets(): string[] {
     warn('wallets.json is malformed or still being written — skipping');
     return [];
   }
-  // The daemon writes { adminWallet, wallets: [{ address, privateKey }] }.
-  // Include admin first so profile/key-management transactions have gas, then
-  // fall back to the legacy operational-only array shapes.
-  const walletList: any[] = Array.isArray(raw?.wallets) ? raw.wallets
-    : Array.isArray(raw) ? raw
-    : [];
-  const operationalAddresses: string[] = [];
-  const operationalSeen = new Set<string>();
-  for (const w of walletList) {
-    const address = w?.address;
-    if (typeof address !== 'string' || address.length === 0) continue;
-    const key = address.toLowerCase();
-    if (operationalSeen.has(key)) continue;
-    operationalSeen.add(key);
-    operationalAddresses.push(address);
-  }
-  if (operationalAddresses.length === 0) {
+  const addresses = getFundableWalletAddresses(raw);
+  if (addresses.length === 0) {
     warn('wallets.json has no operational wallets — skipping faucet funding');
     return [];
   }
-
-  const addresses: string[] = [];
-  const seen = new Set<string>();
-  const addAddress = (address: unknown) => {
-    if (typeof address !== 'string' || address.length === 0) return;
-    const key = address.toLowerCase();
-    if (seen.has(key)) return;
-    seen.add(key);
-    addresses.push(address);
-  };
-  addAddress(raw?.adminWallet?.address);
-  for (const address of operationalAddresses) {
-    addAddress(address);
-  }
-
   if (addresses.length) {
     log(`Wallets: ${addresses.join(', ')}`);
   }

--- a/packages/core/src/faucet-orchestration.ts
+++ b/packages/core/src/faucet-orchestration.ts
@@ -150,6 +150,10 @@ export interface FundWalletsNetworkConfig {
  */
 export interface FundWalletsBestEffortOptions {
   network: FundWalletsNetworkConfig;
+  /**
+   * Historical option name. Used only as the faucet idempotency-key seed;
+   * the request body intentionally omits faucet `callerId`.
+   */
   callerId: string;
   didStartDaemon: boolean;
 }

--- a/packages/core/src/faucet-orchestration.ts
+++ b/packages/core/src/faucet-orchestration.ts
@@ -150,11 +150,10 @@ export interface FundWalletsNetworkConfig {
  */
 export interface FundWalletsBestEffortOptions {
   network: FundWalletsNetworkConfig;
-  /**
-   * Historical option name. Used only as the faucet idempotency-key seed;
-   * the request body intentionally omits faucet `callerId`.
-   */
-  callerId: string;
+  /** Stable seed for deterministic faucet idempotency keys. */
+  idempotencySeed?: string;
+  /** @deprecated Use `idempotencySeed`; the faucet request body omits `callerId`. */
+  callerId?: string;
   didStartDaemon: boolean;
 }
 
@@ -180,7 +179,8 @@ export interface FundWalletsBestEffortOptions {
  *     by design — keeps it simple; cancellation lives in the caller).
  */
 export async function fundWalletsBestEffort(opts: FundWalletsBestEffortOptions): Promise<void> {
-  const { network, callerId, didStartDaemon } = opts;
+  const { network, didStartDaemon } = opts;
+  const idempotencySeed = opts.idempotencySeed ?? opts.callerId ?? 'setup';
   const faucetUrl = network?.faucet?.url;
   const faucetMode = network?.faucet?.mode;
   if (!faucetUrl || !faucetMode) {
@@ -200,7 +200,7 @@ export async function fundWalletsBestEffort(opts: FundWalletsBestEffortOptions):
 
   log('Funding wallets via testnet faucet...');
   try {
-    const result = await requestFaucetFunding(faucetUrl, faucetMode, walletAddresses, callerId);
+    const result = await requestFaucetFunding(faucetUrl, faucetMode, walletAddresses, idempotencySeed);
     if (result.success) {
       log(`Funded: ${result.funded.join(', ')}`);
       if (result.error) {

--- a/packages/core/src/faucet-orchestration.ts
+++ b/packages/core/src/faucet-orchestration.ts
@@ -25,7 +25,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveDkgConfigHome } from './dkg-home.js';
-import { requestFaucetFunding } from './faucet.js';
+import { FAUCET_WALLETS_PER_REQUEST, requestFaucetFunding } from './faucet.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -113,13 +113,13 @@ export function readWallets(): string[] {
  * only on faucet failure; the caller is expected to continue (funding is
  * best-effort / non-fatal).
  *
- * Addresses are split into batches of 3 to match the faucet's per-request
+ * Addresses are split into batches of 4 to match the faucet's per-request
  * cap. Including more wallets in one body would be rejected by the faucet.
  */
 export function logManualFundingInstructions(addresses: string[], faucetUrl: string, mode: string): void {
   const batches: string[][] = [];
-  for (let i = 0; i < addresses.length; i += 3) {
-    batches.push(addresses.slice(i, i + 3));
+  for (let i = 0; i < addresses.length; i += FAUCET_WALLETS_PER_REQUEST) {
+    batches.push(addresses.slice(i, i + FAUCET_WALLETS_PER_REQUEST));
   }
   console.log('\nTo fund wallets manually, run:');
   batches.forEach((batch, index) => {
@@ -132,7 +132,7 @@ export function logManualFundingInstructions(addresses: string[], faucetUrl: str
     console.log(`    --data-raw '{"mode":"${mode}","wallets":${JSON.stringify(batch)}}'`);
   });
   if (batches.length > 1) {
-    console.log(`\nNote: faucet supports up to 3 wallets per call; run each batch above.`);
+    console.log(`\nNote: faucet supports up to ${FAUCET_WALLETS_PER_REQUEST} wallets per call; run each batch above.`);
   }
   console.log('');
 }

--- a/packages/core/src/faucet.ts
+++ b/packages/core/src/faucet.ts
@@ -97,7 +97,7 @@ export async function requestFaucetFunding(
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Idempotency-Key': `init-v2-${mode}-${safeNodeName}-${[...batch].sort().join(',')}`,
+          'Idempotency-Key': `init-${mode}-${safeNodeName}-${[...batch].sort().join(',')}`,
         },
         body: JSON.stringify({ mode, wallets: batch }),
         signal: AbortSignal.timeout(FAUCET_REQUEST_TIMEOUT_MS),

--- a/packages/core/src/faucet.ts
+++ b/packages/core/src/faucet.ts
@@ -7,6 +7,7 @@ export interface FaucetResult {
 }
 
 const EXPECTED_FAUCET_TRANSFERS_PER_WALLET = 2;
+const FAUCET_REQUEST_TIMEOUT_MS = 180_000;
 export const FAUCET_WALLETS_PER_REQUEST = 4;
 
 export interface FundableWalletEntryLike {
@@ -19,6 +20,20 @@ export interface FundableWalletConfigLike {
 }
 
 export type FundableWalletSource = FundableWalletConfigLike | unknown[];
+
+function isFaucetTimeoutError(err: unknown): boolean {
+  const maybeError = err as { name?: unknown; message?: unknown } | null | undefined;
+  if (maybeError?.name === 'TimeoutError' || maybeError?.name === 'AbortError') return true;
+  return typeof maybeError?.message === 'string'
+    && /aborted due to timeout|timeout/i.test(maybeError.message);
+}
+
+function formatFaucetRequestError(err: unknown): string {
+  if (isFaucetTimeoutError(err)) {
+    return `Faucet request timed out after ${Math.round(FAUCET_REQUEST_TIMEOUT_MS / 1000)}s; funding may still complete. Check wallet balances before retrying.`;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
 
 export function getFundableWalletAddresses(source: FundableWalletSource | null | undefined): string[] {
   const walletList = Array.isArray(source)
@@ -85,7 +100,7 @@ export async function requestFaucetFunding(
           'Idempotency-Key': `init-v2-${mode}-${safeNodeName}-${[...batch].sort().join(',')}`,
         },
         body: JSON.stringify({ mode, wallets: batch }),
-        signal: AbortSignal.timeout(30_000),
+        signal: AbortSignal.timeout(FAUCET_REQUEST_TIMEOUT_MS),
       });
       if (!res.ok) {
         const text = await res.text().catch(() => '');
@@ -154,9 +169,10 @@ export async function requestFaucetFunding(
       }
     } catch (err) {
       if (!sawSuccess && funded.length === 0 && fundedWallets.size === 0) {
+        if (isFaucetTimeoutError(err)) throw new Error(formatFaucetRequestError(err));
         throw err;
       }
-      errors.push(`Faucet request failed: ${err instanceof Error ? err.message : String(err)}`);
+      errors.push(`Faucet request failed: ${formatFaucetRequestError(err)}`);
       for (const wallet of batch) {
         failedWallets.add(wallet);
         fundedWallets.delete(wallet);

--- a/packages/core/src/faucet.ts
+++ b/packages/core/src/faucet.ts
@@ -82,9 +82,9 @@ export async function requestFaucetFunding(
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Idempotency-Key': `init-${mode}-${safeNodeName}-${[...batch].sort().join(',')}`,
+          'Idempotency-Key': `init-v2-${mode}-${safeNodeName}-${[...batch].sort().join(',')}`,
         },
-        body: JSON.stringify({ mode, wallets: batch, callerId: `dkg-node:${nodeName}` }),
+        body: JSON.stringify({ mode, wallets: batch }),
         signal: AbortSignal.timeout(30_000),
       });
       if (!res.ok) {

--- a/packages/core/src/faucet.ts
+++ b/packages/core/src/faucet.ts
@@ -73,6 +73,7 @@ export async function requestFaucetFunding(
   const fundedWallets = new Set<string>();
   const failedWallets = new Set<string>();
   const errors: string[] = [];
+  const faucetFailureReasons = new Set<string>();
   let sawSuccess = false;
 
   for (const batch of batches) {
@@ -113,6 +114,12 @@ export async function requestFaucetFunding(
       for (const result of results) {
         if (!result || typeof result !== 'object') continue;
         const record = result as Record<string, unknown>;
+        if (typeof record.status === 'string' && record.status !== 'success') {
+          const reason = typeof record.error === 'string' && record.error.length > 0
+            ? `${record.status}: ${record.error}`
+            : record.status;
+          faucetFailureReasons.add(reason);
+        }
         if (typeof record.address !== 'string' || typeof record.status !== 'string') continue;
         const key = record.address.toLowerCase();
         const statuses = resultStatusesByAddress.get(key) ?? [];
@@ -158,7 +165,12 @@ export async function requestFaucetFunding(
   }
 
   if (failedWallets.size > 0 && errors.length === 0) {
-    errors.push(`Faucet did not fund all wallets: ${Array.from(failedWallets).join(', ')}`);
+    const reasons = Array.from(faucetFailureReasons);
+    errors.push(
+      `Faucet did not fund all wallets: ${Array.from(failedWallets).join(', ')}${reasons.length > 0
+        ? `. Faucet reported: ${reasons.join('; ')}`
+        : ''}`,
+    );
   }
 
   if (errors.length > 0) {

--- a/packages/core/src/faucet.ts
+++ b/packages/core/src/faucet.ts
@@ -9,6 +9,52 @@ export interface FaucetResult {
 const EXPECTED_FAUCET_TRANSFERS_PER_WALLET = 2;
 export const FAUCET_WALLETS_PER_REQUEST = 4;
 
+export interface FundableWalletEntryLike {
+  address?: unknown;
+}
+
+export interface FundableWalletConfigLike {
+  adminWallet?: FundableWalletEntryLike | null;
+  wallets?: unknown;
+}
+
+export type FundableWalletSource = FundableWalletConfigLike | unknown[];
+
+export function getFundableWalletAddresses(source: FundableWalletSource | null | undefined): string[] {
+  const walletList = Array.isArray(source)
+    ? source
+    : Array.isArray(source?.wallets)
+      ? source.wallets
+      : [];
+
+  const operationalAddresses: string[] = [];
+  for (const wallet of walletList) {
+    const address = (wallet as FundableWalletEntryLike | null | undefined)?.address;
+    if (typeof address !== 'string' || address.length === 0) continue;
+    operationalAddresses.push(address);
+  }
+  if (operationalAddresses.length === 0) return [];
+
+  const addresses: string[] = [];
+  const seen = new Set<string>();
+  const addAddress = (address: unknown) => {
+    if (typeof address !== 'string' || address.length === 0) return;
+    const key = address.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    addresses.push(address);
+  };
+
+  if (!Array.isArray(source)) {
+    addAddress(source?.adminWallet?.address);
+  }
+  for (const address of operationalAddresses) {
+    addAddress(address);
+  }
+
+  return addresses;
+}
+
 export async function requestFaucetFunding(
   faucetUrl: string,
   mode: string,

--- a/packages/core/src/faucet.ts
+++ b/packages/core/src/faucet.ts
@@ -7,6 +7,7 @@ export interface FaucetResult {
 }
 
 const EXPECTED_FAUCET_TRANSFERS_PER_WALLET = 2;
+export const FAUCET_WALLETS_PER_REQUEST = 4;
 
 export async function requestFaucetFunding(
   faucetUrl: string,
@@ -16,8 +17,8 @@ export async function requestFaucetFunding(
   _fetch = globalThis.fetch,
 ): Promise<FaucetResult> {
   const batches: string[][] = [];
-  for (let i = 0; i < wallets.length; i += 3) {
-    batches.push(wallets.slice(i, i + 3));
+  for (let i = 0; i < wallets.length; i += FAUCET_WALLETS_PER_REQUEST) {
+    batches.push(wallets.slice(i, i + FAUCET_WALLETS_PER_REQUEST));
   }
   if (batches.length === 0) return { success: false, funded: [], error: 'no wallets' };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,7 @@ export {
   blueGreenSlotEntryPoint,
   blueGreenSlotReady,
 } from './blue-green.js';
-export { requestFaucetFunding, type FaucetResult } from './faucet.js';
+export { FAUCET_WALLETS_PER_REQUEST, requestFaucetFunding, type FaucetResult } from './faucet.js';
 export {
   fundWalletsBestEffort,
   logManualFundingInstructions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,15 @@ export {
   blueGreenSlotEntryPoint,
   blueGreenSlotReady,
 } from './blue-green.js';
-export { FAUCET_WALLETS_PER_REQUEST, requestFaucetFunding, type FaucetResult } from './faucet.js';
+export {
+  FAUCET_WALLETS_PER_REQUEST,
+  getFundableWalletAddresses,
+  requestFaucetFunding,
+  type FaucetResult,
+  type FundableWalletConfigLike,
+  type FundableWalletEntryLike,
+  type FundableWalletSource,
+} from './faucet.js';
 export {
   fundWalletsBestEffort,
   logManualFundingInstructions,

--- a/packages/core/test/faucet.test.ts
+++ b/packages/core/test/faucet.test.ts
@@ -47,7 +47,7 @@ describe('requestFaucetFunding', () => {
     expect(reqBody.mode).toBe('v10_base_sepolia');
   });
 
-  it('funds wallets in batches of 3', async () => {
+  it('funds wallets in batches of 4', async () => {
     const { fetch, calls } = createTrackingFetch(200, { summary: { success: 1 }, results: [] });
     await requestFaucetFunding(
       'https://faucet.example.com/fund', 'test',
@@ -55,10 +55,10 @@ describe('requestFaucetFunding', () => {
     );
     expect(calls).toHaveLength(2);
     const reqBody = JSON.parse(calls[0].init.body as string);
-    expect(reqBody.wallets).toHaveLength(3);
-    expect(reqBody.wallets).toEqual(['0x1', '0x2', '0x3']);
+    expect(reqBody.wallets).toHaveLength(4);
+    expect(reqBody.wallets).toEqual(['0x1', '0x2', '0x3', '0x4']);
     const secondReqBody = JSON.parse(calls[1].init.body as string);
-    expect(secondReqBody.wallets).toEqual(['0x4', '0x5']);
+    expect(secondReqBody.wallets).toEqual(['0x5']);
   });
 
   it('returns error on HTTP failure', async () => {
@@ -78,7 +78,7 @@ describe('requestFaucetFunding', () => {
       calls.push({ url: url as any, init: init as RequestInit });
       if (calls.length === 1) {
         return new Response(JSON.stringify({
-          summary: { success: 6 },
+          summary: { success: 8 },
           results: [{ chainId: 'eth-sepolia', amount: '0.01', status: 'success' }],
         }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
@@ -87,14 +87,14 @@ describe('requestFaucetFunding', () => {
 
     const result = await requestFaucetFunding(
       'https://faucet.example.com/fund', 'test',
-      ['0x1', '0x2', '0x3', '0x4'], 'partial-node', fetch,
+      ['0x1', '0x2', '0x3', '0x4', '0x5'], 'partial-node', fetch,
     );
 
     expect(calls).toHaveLength(2);
     expect(result.success).toBe(true);
     expect(result.funded).toEqual(['0.01 ETH']);
-    expect(result.fundedWallets).toEqual(['0x1', '0x2', '0x3']);
-    expect(result.failedWallets).toEqual(['0x4']);
+    expect(result.fundedWallets).toEqual(['0x1', '0x2', '0x3', '0x4']);
+    expect(result.failedWallets).toEqual(['0x5']);
     expect(result.error).toContain('429');
   });
 
@@ -174,7 +174,7 @@ describe('requestFaucetFunding', () => {
       calls.push({ url: url as any, init: init as RequestInit });
       if (calls.length === 1) {
         return new Response(JSON.stringify({
-          summary: { success: 6 },
+          summary: { success: 8 },
           results: [],
         }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
@@ -183,12 +183,12 @@ describe('requestFaucetFunding', () => {
 
     const result = await requestFaucetFunding(
       'https://faucet.example.com/fund', 'test',
-      ['0x1', '0x2', '0x3', '0x4'], 'throwing-node', fetch,
+      ['0x1', '0x2', '0x3', '0x4', '0x5'], 'throwing-node', fetch,
     );
 
     expect(result.success).toBe(true);
-    expect(result.fundedWallets).toEqual(['0x1', '0x2', '0x3']);
-    expect(result.failedWallets).toEqual(['0x4']);
+    expect(result.fundedWallets).toEqual(['0x1', '0x2', '0x3', '0x4']);
+    expect(result.failedWallets).toEqual(['0x5']);
     expect(result.error).toContain('faucet offline');
   });
 

--- a/packages/core/test/faucet.test.ts
+++ b/packages/core/test/faucet.test.ts
@@ -291,15 +291,15 @@ describe('requestFaucetFunding', () => {
     expect(result.error).toContain('faucet offline');
   });
 
-  it('includes nodeName in callerId and Idempotency-Key', async () => {
+  it('includes nodeName in the Idempotency-Key without sending callerId', async () => {
     const { fetch, calls } = createTrackingFetch(200, { summary: { success: 0 }, results: [] });
     await requestFaucetFunding(
       'https://faucet.example.com/fund', 'test', ['0xAAA'], 'my-special-node', fetch,
     );
     const reqBody = JSON.parse(calls[0].init.body as string);
-    expect(reqBody.callerId).toBe('dkg-node:my-special-node');
+    expect(reqBody).toEqual({ mode: 'test', wallets: ['0xAAA'] });
     const headers = calls[0].init.headers as Record<string, string>;
-    expect(headers['Idempotency-Key']).toMatch(/^init-test-my-special-node-/);
+    expect(headers['Idempotency-Key']).toMatch(/^init-v2-test-my-special-node-/);
   });
 
   it('sanitizes non-ASCII node names in Idempotency-Key header', async () => {
@@ -309,7 +309,7 @@ describe('requestFaucetFunding', () => {
     );
     const headers = calls[0].init.headers as Record<string, string>;
     const key = headers['Idempotency-Key'];
-    expect(key).toMatch(/^init-test-mon-n_ud-_l_ve-0xAAA$/);
+    expect(key).toMatch(/^init-v2-test-mon-n_ud-_l_ve-0xAAA$/);
     expect(key).toMatch(/^[\x20-\x7E]+$/);
   });
 });

--- a/packages/core/test/faucet.test.ts
+++ b/packages/core/test/faucet.test.ts
@@ -205,6 +205,36 @@ describe('requestFaucetFunding', () => {
     expect(result.error).toContain('0x2');
   });
 
+  it('surfaces faucet result reasons when no wallets are funded', async () => {
+    const { fetch } = createTrackingFetch(200, {
+      summary: { success: 0, failed: 2 },
+      results: [
+        {
+          chainId: 'v10_base_sepolia_eth',
+          address: '0x1',
+          status: 'cooldown_active',
+          error: 'Caller cooldown active until 2026-05-11T19:17:45.000Z',
+        },
+        {
+          chainId: 'v10_base_sepolia_trac',
+          address: '0x1',
+          status: 'cooldown_active',
+          error: 'Caller cooldown active until 2026-05-11T19:17:49.000Z',
+        },
+      ],
+    });
+    const result = await requestFaucetFunding(
+      'https://faucet.example.com/fund', 'test', ['0x1'], 'cooldown-node', fetch,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fundedWallets).toEqual([]);
+    expect(result.failedWallets).toEqual(['0x1']);
+    expect(result.error).toContain('Faucet did not fund all wallets: 0x1');
+    expect(result.error).toContain('cooldown_active: Caller cooldown active until 2026-05-11T19:17:45.000Z');
+    expect(result.error).toContain('cooldown_active: Caller cooldown active until 2026-05-11T19:17:49.000Z');
+  });
+
   it('returns no-wallets error for empty array', async () => {
     const { fetch, calls } = createTrackingFetch(200, {});
     const result = await requestFaucetFunding(

--- a/packages/core/test/faucet.test.ts
+++ b/packages/core/test/faucet.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { requestFaucetFunding } from '../src/faucet.js';
+import { getFundableWalletAddresses, requestFaucetFunding } from '../src/faucet.js';
 
 interface FetchCall {
   url: string | URL | Request;
@@ -21,6 +21,75 @@ function createTrackingFetch(status: number, body: unknown): { fetch: typeof glo
   };
   return { fetch: fn as typeof globalThis.fetch, calls };
 }
+
+describe('getFundableWalletAddresses', () => {
+  it('returns the admin wallet before operational wallets for the current shape', () => {
+    const result = getFundableWalletAddresses({
+      adminWallet: { address: '0xAdmin' },
+      wallets: [
+        { address: '0xWallet1' },
+        { address: '0xWallet2' },
+        { address: '0xWallet3' },
+      ],
+    });
+
+    expect(result).toEqual(['0xAdmin', '0xWallet1', '0xWallet2', '0xWallet3']);
+  });
+
+  it('returns only operational wallets for the legacy array shape', () => {
+    const result = getFundableWalletAddresses([
+      { address: '0xWallet1' },
+      { address: '0xWallet2' },
+    ]);
+
+    expect(result).toEqual(['0xWallet1', '0xWallet2']);
+  });
+
+  it('returns only operational wallets when adminWallet is missing', () => {
+    const result = getFundableWalletAddresses({
+      wallets: [
+        { address: '0xWallet1' },
+        { address: '0xWallet2' },
+      ],
+    });
+
+    expect(result).toEqual(['0xWallet1', '0xWallet2']);
+  });
+
+  it('deduplicates addresses case-insensitively with admin position winning', () => {
+    const result = getFundableWalletAddresses({
+      adminWallet: { address: '0xAdmin' },
+      wallets: [
+        { address: '0xadmin' },
+        { address: '0xWallet1' },
+        { address: '0xwallet1' },
+      ],
+    });
+
+    expect(result).toEqual(['0xAdmin', '0xWallet1']);
+  });
+
+  it('returns an empty list when there are no operational wallet addresses', () => {
+    expect(getFundableWalletAddresses({ adminWallet: { address: '0xAdmin' }, wallets: [] }))
+      .toEqual([]);
+    expect(getFundableWalletAddresses({ adminWallet: { address: '0xAdmin' } }))
+      .toEqual([]);
+  });
+
+  it('ignores malformed wallet address fields', () => {
+    const result = getFundableWalletAddresses({
+      adminWallet: { address: 123 },
+      wallets: [
+        { address: '' },
+        { address: null },
+        {},
+        { address: '0xWallet1' },
+      ],
+    });
+
+    expect(result).toEqual(['0xWallet1']);
+  });
+});
 
 describe('requestFaucetFunding', () => {
   it('returns funded amounts on success', async () => {

--- a/packages/core/test/faucet.test.ts
+++ b/packages/core/test/faucet.test.ts
@@ -316,7 +316,7 @@ describe('requestFaucetFunding', () => {
     expect(result.error).toContain('faucet offline');
   });
 
-  it('includes nodeName in the Idempotency-Key without sending callerId', async () => {
+  it('includes the idempotency seed in the Idempotency-Key without sending callerId', async () => {
     const { fetch, calls } = createTrackingFetch(200, { summary: { success: 0 }, results: [] });
     await requestFaucetFunding(
       'https://faucet.example.com/fund', 'test', ['0xAAA'], 'my-special-node', fetch,
@@ -324,7 +324,7 @@ describe('requestFaucetFunding', () => {
     const reqBody = JSON.parse(calls[0].init.body as string);
     expect(reqBody).toEqual({ mode: 'test', wallets: ['0xAAA'] });
     const headers = calls[0].init.headers as Record<string, string>;
-    expect(headers['Idempotency-Key']).toMatch(/^init-v2-test-my-special-node-/);
+    expect(headers['Idempotency-Key']).toMatch(/^init-test-my-special-node-/);
   });
 
   it('sanitizes non-ASCII node names in Idempotency-Key header', async () => {
@@ -334,7 +334,7 @@ describe('requestFaucetFunding', () => {
     );
     const headers = calls[0].init.headers as Record<string, string>;
     const key = headers['Idempotency-Key'];
-    expect(key).toMatch(/^init-v2-test-mon-n_ud-_l_ve-0xAAA$/);
+    expect(key).toMatch(/^init-test-mon-n_ud-_l_ve-0xAAA$/);
     expect(key).toMatch(/^[\x20-\x7E]+$/);
   });
 });

--- a/packages/core/test/faucet.test.ts
+++ b/packages/core/test/faucet.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { getFundableWalletAddresses, requestFaucetFunding } from '../src/faucet.js';
 
 interface FetchCall {
@@ -114,6 +114,21 @@ describe('requestFaucetFunding', () => {
     const reqBody = JSON.parse(calls[0].init.body as string);
     expect(reqBody.wallets).toEqual(['0xAAA', '0xBBB']);
     expect(reqBody.mode).toBe('v10_base_sepolia');
+  });
+
+  it('uses a three-minute timeout for faucet batches', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
+      .mockReturnValue(new AbortController().signal);
+    const { fetch } = createTrackingFetch(200, { summary: { success: 0 }, results: [] });
+    try {
+      await requestFaucetFunding(
+        'https://faucet.example.com/fund', 'test', ['0xAAA'], 'timeout-node', fetch,
+      );
+
+      expect(timeoutSpy).toHaveBeenCalledWith(180_000);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 
   it('funds wallets in batches of 4', async () => {
@@ -265,6 +280,16 @@ describe('requestFaucetFunding', () => {
     await expect(requestFaucetFunding(
       'https://faucet.example.com/fund', 'test', ['0xAAA'], 'test-node', fetch,
     )).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('explains that a first-batch timeout may still complete on-chain', async () => {
+    const fetch = (async () => {
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    }) as unknown as typeof globalThis.fetch;
+
+    await expect(requestFaucetFunding(
+      'https://faucet.example.com/fund', 'test', ['0xAAA'], 'timeout-node', fetch,
+    )).rejects.toThrow('funding may still complete');
   });
 
   it('preserves earlier funded wallets when a later batch throws', async () => {

--- a/packages/mcp-dkg/README.md
+++ b/packages/mcp-dkg/README.md
@@ -17,7 +17,7 @@ dkg mcp setup                                # one-shot: init + start + fund + r
 
 1. Initializes `~/.dkg/config.json` if absent (skipped silently when present)
 2. Starts the DKG daemon as a background process (skipped if already running)
-3. Funds the node's wallets via the testnet faucet (skip with `--no-fund`)
+3. Funds the node's generated admin and operational wallets via the testnet faucet (skip with `--no-fund`)
 4. Detects each MCP-aware client by its config file and writes the canonical entry. **You confirm per detected client interactively** (`Register DKG MCP with <client>? [Y/n]`) unless `--yes` is passed; non-TTY invocations (CI, piped stdin) auto-confirm so scripts don't hang. The detection set is seven clients: **Cursor** (`~/.cursor/mcp.json`), **Claude Code** (`~/.claude.json`), **Claude Desktop** (per-platform — `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows, `$XDG_CONFIG_HOME/Claude/claude_desktop_config.json` (or `~/.config/Claude/...` when XDG_CONFIG_HOME is unset) on Linux), **Windsurf** (`~/.codeium/windsurf/mcp_config.json`), **VSCode + GitHub Copilot Chat** (per-platform Code user-settings dir + `mcp.json` — note this client uses the `servers.dkg` shape, not `mcpServers.dkg`), **Cline** (deep-nested under VSCode's per-extension globalStorage at `Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`), and **Codex CLI** (`~/.codex/config.toml` — TOML format, table key `mcp_servers.dkg`). The clients receive the same canonical entry, serialized into each client's native format
 5. Verifies the daemon is healthy
 


### PR DESCRIPTION
﻿## Summary

- Update the shared faucet request cap from 3 to 4 wallets so the generated admin wallet and three operational wallets can be sent in one funding request.
- Add a core `getFundableWalletAddresses()` helper so `dkg init` and setup flows share the same admin-first, legacy-compatible wallet address selection policy.
- Keep setup funding output aligned across `dkg init`, OpenClaw/Hermes setup, and MCP setup, including partial-success handling for remaining failed wallets.
- Preserve faucet-provided result reasons such as `cooldown_active` so fresh setup failures explain cooldowns instead of only saying all wallets failed.
- Omit faucet JSON `callerId` from bundled setup requests to avoid intra-batch caller cooldown, while keeping stable deterministic `init-*` idempotency keys for retry safety across client upgrades.
- Rename shared setup usage from `callerId` to `idempotencySeed`, with a deprecated compatibility alias for older callers.
- Extend the shared faucet request timeout to 3 minutes and warn that timed-out requests may still finish on-chain, so operators check balances before retrying.
- Refresh setup and faucet docs to describe admin-plus-operational wallet funding, the 1-4 wallet faucet request shape, bundled setup idempotency behavior, and the longer client wait.

## Related

- None

## Files changed

| File | What |
|------|------|
| `packages/core/src/faucet.ts` | Adds the shared 4-wallet faucet request cap, `getFundableWalletAddresses()`, richer per-result faucet failure messages, omits JSON `callerId`, keeps stable generated idempotency keys, and extends faucet request timeout/error text. |
| `packages/core/src/index.ts` | Exports the faucet cap, request helper, and fundable wallet selection helper/types. |
| `packages/core/src/faucet-orchestration.ts` | Uses the shared cap and helper for setup wallet reading plus manual fallback curl batching, and exposes `idempotencySeed` for the shared faucet key seed. |
| `packages/cli/src/cli.ts` | Uses the shared helper in `dkg init` and the shared cap in batching notes. |
| `packages/cli/src/mcp-setup.ts` | Handles faucet partial success by logging remaining failed wallets only, and includes faucet error details on full failure. |
| `packages/adapter-openclaw/src/setup.ts`, `packages/adapter-hermes/src/setup.ts` | Pass agent names as `idempotencySeed` instead of `callerId` when invoking shared setup funding. |
| `packages/adapter-openclaw/test/setup.test.ts`, `packages/core/test/faucet.test.ts`, `packages/cli/test/mcp-setup.test.ts` | Cover admin+operational funding, legacy wallet files, helper behavior, 4-wallet batches, MCP partial-success behavior, cooldown reason reporting, callerId omission, stable idempotency keys, and timeout behavior. |
| `README.md`, `docs/setup/*`, adapter/MCP READMEs | Update funding docs from first-three/1-3 wording to admin-plus-operational/1-4 wording and document bundled setup idempotency/timeout behavior. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core exec vitest run test/faucet.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw run test -- test/setup.test.ts`
- [x] `pnpm exec vitest run test/mcp-setup.test.ts` from `packages/cli`
- [x] `pnpm exec vitest run test/hermes-setup-orchestration.test.ts` from `packages/cli`
- [x] `pnpm run build:runtime:packages`
- [x] Local PR review round 1 using `.codex/review-prompt.md` / `.codex/review-schema.json` returned no comments after the helper refactor
- [x] Local PR review round 2 using `.codex/review-prompt.md` / `.codex/review-schema.json` returned no comments after the cooldown reporting fix
- [x] Local PR review round 3 using `.codex/review-prompt.md` / `.codex/review-schema.json` returned no comments after omitting `callerId`
- [x] Local PR review round 4 using `.codex/review-prompt.md` / `.codex/review-schema.json` returned no comments after extending the faucet timeout
- [x] Local PR review round 5 flagged an unrelated daemon memory-route event issue; not addressed in this faucet review patch
