### PR TITLE
Fix SWM large payload metadata amplification

### DIFF
--- a/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
+++ b/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
@@ -1,0 +1,296 @@
+# Fix SWM Large Payload Storage Amplification
+
+## Summary
+
+This change fixes Shared Working Memory large-payload storage amplification.
+Before this fix, each public SWM payload was stored twice per node:
+
+1. Once as normal RDF quads in the SWM data graph.
+2. Again as a JSON-stringified RDF literal in SWM metadata through
+   `dkg:publicStagedQuads`.
+
+For large replicated writes this doubled the effective Oxigraph payload and
+pushed the WASM store into memory failures. In the reproduced benchmark, the
+duplicated path failed around `202.5 MiB/store` with:
+
+```text
+RuntimeError: unreachable
+Store.load(...)
+```
+
+After that failure, later queries could also fail with:
+
+```text
+table index is out of bounds
+```
+
+The fix replaces full-payload metadata snapshots with compact operation
+metadata. New SWM writes store only references and provenance in
+`_shared_memory_meta`, while the public payload remains in the SWM data graph.
+Legacy metadata records that already contain `dkg:publicStagedQuads` remain
+readable.
+
+## Problem
+
+The old SWM share path made metadata carry the entire public payload:
+
+```mermaid
+flowchart TD
+  A["Client writes public SWM quads"] --> B["Store quads in SWM graph"]
+  A --> C["Serialize same quads as JSON"]
+  C --> D["Store JSON string as dkg:publicStagedQuads literal"]
+  B --> E["Oxigraph stores payload copy 1"]
+  D --> F["Oxigraph stores payload copy 2"]
+  E --> G["Large payload memory pressure"]
+  F --> G
+```
+
+That metadata snapshot was useful for later lift/share resolution, but it made
+the storage model scale with approximately `2x payload size` per node. The
+failure was reproduced without private mode and without Sender Key encryption,
+so the root cause was public SWM metadata amplification.
+
+## New Model
+
+New SWM writes store compact share-operation metadata:
+
+- context graph id
+- optional subgraph name
+- share operation id
+- root entities
+- publisher peer id
+- published timestamp
+
+The public payload is not serialized into metadata. Resolution reconstructs the
+operation payload by reading the current SWM graph for the operation roots.
+
+```mermaid
+flowchart TD
+  A["Client writes public SWM quads"] --> B["Store quads in SWM graph"]
+  A --> C["Generate compact metadata"]
+  C --> D["dkg:shareOperationId"]
+  C --> E["dkg:rootEntity"]
+  C --> F["dkg:publisherPeerId"]
+  C --> G["dkg:publishedAt"]
+  C --> H["dkg:contextGraphId"]
+  C --> I["optional dkg:subGraphName"]
+  B --> J["Single payload copy in Oxigraph"]
+  D --> K["Small operation reference metadata"]
+  E --> K
+  F --> K
+  G --> K
+  H --> K
+  I --> K
+```
+
+## Write Path
+
+The SWM write path still persists and gossips the public payload normally. The
+change is only in the metadata generated for the operation.
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant API as DKG API
+  participant Publisher as DKGPublisher
+  participant Store as Triple Store
+  participant Gossip as SWM Gossip
+
+  Client->>API: POST /api/shared-memory/write
+  API->>Publisher: share(contextGraphId, quads, subGraphName?)
+  Publisher->>Store: store public quads in SWM graph
+  Publisher->>Store: store compact share metadata
+  Publisher->>Gossip: broadcast SWM operation
+  Gossip-->>API: operation propagated to peers
+  API-->>Client: shareOperationId
+```
+
+The important behavior change is this:
+
+```text
+New writes no longer emit:
+  <share-operation> dkg:publicStagedQuads "<serialized full payload>"
+```
+
+Instead they emit compact metadata that points to roots already present in the
+SWM data graph.
+
+## Resolution Path
+
+Lift/share resolution now resolves the public payload from the graph itself
+when compact metadata is present.
+
+```mermaid
+flowchart TD
+  A["Lift request contains shareOperationId"] --> B["Read share operation metadata"]
+  B --> C{"Legacy dkg:publicStagedQuads present?"}
+  C -->|Yes| D["Parse legacy serialized quad snapshot"]
+  C -->|No| E["Read root entities from metadata"]
+  E --> F["Query current SWM graph for those roots"]
+  F --> G["Return public quads for operation"]
+  D --> G
+  G --> H["Build lift request payload"]
+```
+
+For compact metadata, the resolver validates the operation roots and then reads
+the public quads from the current SWM graph. This keeps new writes small while
+preserving the ability to lift and publish shared-memory content.
+
+## Legacy Compatibility
+
+Existing stores may already contain `dkg:publicStagedQuads`. Those records still
+work. The compatibility rule is:
+
+```mermaid
+flowchart LR
+  A["Existing metadata record"] --> B{"Has dkg:publicStagedQuads?"}
+  B -->|Yes| C["Use legacy serialized snapshot"]
+  B -->|No| D["Use compact root metadata"]
+  C --> E["Resolved public quads"]
+  D --> E
+```
+
+This means the fix is forward-looking for new writes, while old metadata remains
+readable and does not need a migration before use.
+
+## Benchmark
+
+This PR adds a reusable live benchmark:
+
+```bash
+pnpm bench:swm-large-payload -- \
+  --ports 19101,19102,19103,19104,19105 \
+  --payload-mib-per-node 100 \
+  --chunk-mib 0.5 \
+  --output bench/results/swm-large-payload-500mib.json
+```
+
+The benchmark:
+
+1. Writes large public SWM literals through each configured node.
+2. Polls every node until all benchmark payloads are queryable.
+3. Checks per-run metadata for `shareOperationId`, `rootEntity`,
+   `publisherPeerId`, and `publishedAt`.
+4. Verifies `dkg:publicStagedQuads` did not grow.
+5. Optionally scans appended daemon logs for known Oxigraph and GossipSub
+   failure signatures.
+
+```mermaid
+sequenceDiagram
+  participant Bench as Benchmark
+  participant N1 as Node 1
+  participant N2 as Node 2
+  participant N3 as Node 3
+  participant N4 as Node 4
+  participant N5 as Node 5
+
+  Bench->>N1: write 100 MiB in chunks
+  Bench->>N2: write 100 MiB in chunks
+  Bench->>N3: write 100 MiB in chunks
+  Bench->>N4: write 100 MiB in chunks
+  Bench->>N5: write 100 MiB in chunks
+
+  N1-->>N2: gossip SWM operations
+  N1-->>N3: gossip SWM operations
+  N2-->>N4: gossip SWM operations
+  N3-->>N5: gossip SWM operations
+  N4-->>N1: gossip SWM operations
+  N5-->>N2: gossip SWM operations
+
+  loop Until every node converges
+    Bench->>N1: count benchmark payloads
+    Bench->>N2: count benchmark payloads
+    Bench->>N3: count benchmark payloads
+    Bench->>N4: count benchmark payloads
+    Bench->>N5: count benchmark payloads
+  end
+
+  Bench->>N1: verify compact metadata
+  Bench->>N2: verify compact metadata
+  Bench->>N3: verify compact metadata
+  Bench->>N4: verify compact metadata
+  Bench->>N5: verify compact metadata
+```
+
+The reproduced 5-node regression case used `5 x 100 MiB = 500 MiB` total. With
+the compact metadata model, all five nodes converged with:
+
+```text
+payload quads:        1000 per node
+dkg:publicStagedQuads: 0 per node
+shareOperationIds:    1000 per node
+rootEntities:         1000 per node
+```
+
+No Oxigraph failure signatures were observed:
+
+```text
+RuntimeError: unreachable
+table index is out of bounds
+```
+
+## Files Changed
+
+- `packages/publisher/src/workspace-resolution.ts`
+  - Stops writing new full-payload `dkg:publicStagedQuads` metadata snapshots.
+  - Resolves compact share operations by reading root-scoped public quads from
+    the SWM graph.
+  - Keeps legacy snapshot reads for existing metadata.
+
+- `packages/publisher/src/metadata.ts`
+  - Extends share metadata with compact operation fields.
+  - Emits `dkg:publishedAt`, `dkg:shareOperationId`, `dkg:rootEntity`,
+    `dkg:publisherPeerId`, `dkg:contextGraphId`, and optional
+    `dkg:subGraphName`.
+
+- `packages/publisher/src/dkg-publisher.ts`
+  - Routes SWM share metadata generation through the compact metadata helper.
+
+- `packages/publisher/src/workspace-handler.ts`
+  - Applies the same compact metadata model for received SWM operations.
+
+- `packages/publisher/test/async-lift-workspace.test.ts`
+  - Covers compact share-operation resolution.
+  - Covers legacy `dkg:publicStagedQuads` compatibility.
+  - Covers large literal writes without metadata payload duplication.
+
+- `packages/publisher/test/metadata.test.ts`
+  - Covers the new compact share metadata shape.
+
+- `packages/cli/scripts/swm-large-payload-benchmark.cjs`
+  - Adds the reusable live multi-node SWM payload benchmark.
+
+- `packages/cli/test/swm-large-payload-benchmark.test.ts`
+  - Covers benchmark argument parsing, chunk planning, and generated payload
+    sizing.
+
+- `packages/cli/README.md`
+  - Documents the benchmark and the 5-node 500 MiB regression command.
+
+## Validation
+
+Focused validation run for this change:
+
+```bash
+pnpm --filter @origintrail-official/dkg exec vitest run test/swm-large-payload-benchmark.test.ts
+```
+
+Additional validation performed during the fix:
+
+```bash
+git diff --check
+```
+
+Live benchmark validation:
+
+```bash
+pnpm bench:swm-large-payload -- \
+  --ports 19101,19102,19103,19104,19105 \
+  --payload-mib-per-node 100 \
+  --chunk-mib 0.5 \
+  --auth-token <token> \
+  --output bench/results/swm-large-payload-500mib.json
+```
+
+The full 500 MiB run verified that each node could query all benchmark payloads
+and that `dkg:publicStagedQuads` remained at zero for the new writes.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bench:html": "ESBENCH_HTML=1 ESBENCH_PUBLISH_ASYNC_GET_HTML=1 esbench --config esbench.config.mjs",
     "bench:analysis": "node --experimental-strip-types bench/analyze-publish-async-get.ts",
     "bench:profile": "node bench/profile-publish-async-get.mjs",
+    "bench:swm-large-payload": "pnpm --filter @origintrail-official/dkg benchmark:swm-large-payload --",
     "bench:baseline": "ESBENCH_RESULT=bench/results/baseline.json ESBENCH_HTML=1 ESBENCH_HTML_FILE=bench/results/baseline.html esbench --config esbench.config.mjs",
     "bench:compare": "ESBENCH_DIFF=bench/results/baseline.json ESBENCH_RESULT=bench/results/compare.json ESBENCH_HTML=1 ESBENCH_HTML_FILE=bench/results/compare.html esbench --config esbench.config.mjs",
     "lint": "turbo lint",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -242,6 +242,31 @@ subset while doing quick local smoke checks:
 - upload payload to local working memory
 - lift local working memory to shared working memory
 
+### SWM Large-Payload Benchmark
+
+The live SWM large-payload benchmark is aimed at replication and storage
+amplification regressions. It writes large public literals through every node in
+a running devnet, waits until every node can query every benchmark payload from
+shared working memory, and verifies that the run did not create
+`dkg:publicStagedQuads` snapshot literals in SWM metadata.
+
+For the 5-node, 500 MiB regression case, start or reuse a 5-node devnet and run:
+
+```bash
+pnpm bench:swm-large-payload -- \
+  --ports 19101,19102,19103,19104,19105 \
+  --payload-mib-per-node 100 \
+  --chunk-mib 0.5 \
+  --output bench/results/swm-large-payload-500mib.json
+```
+
+Use `--auth-token`, `--auth-token-file`, or `DKG_BENCH_AUTH_TOKEN` when the
+target nodes require bearer auth. The final JSON includes per-node payload
+counts, write timing summaries, replication polls, metadata counts for
+`shareOperationId`, `rootEntity`, and `publishedAt`, the global
+`publicStagedQuads` delta, and an appended log scan for known
+Oxigraph/GossipSub failure signatures when a devnet directory is available.
+
 ## Extending the Node
 
 The V9 "installable apps" framework (iframe-hosted third-party UIs loaded from

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
     "benchmark:catchup-runner": "node scripts/catchup-runner-benchmark.cjs",
     "benchmark:daemon-responsiveness": "node scripts/daemon-responsiveness-benchmark.cjs",
     "benchmark:publish-async-get": "node scripts/publish-async-get-benchmark.cjs",
+    "benchmark:swm-large-payload": "node scripts/swm-large-payload-benchmark.cjs",
     "postinstall": "node ./scripts/bundle-markitdown-binaries.mjs --quiet --current-platform --best-effort",
     "markitdown:build": "node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform",
     "test": "vitest run",

--- a/packages/cli/scripts/swm-large-payload-benchmark.cjs
+++ b/packages/cli/scripts/swm-large-payload-benchmark.cjs
@@ -1,0 +1,798 @@
+#!/usr/bin/env node
+
+const { createReadStream, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } = require('node:fs');
+const { dirname, join, resolve } = require('node:path');
+const { performance } = require('node:perf_hooks');
+const { createInterface } = require('node:readline');
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+const DKG_ONTOLOGY = 'http://dkg.io/ontology/';
+const DEFAULT_CONTEXT_GRAPH_ID = 'devnet-test';
+const DEFAULT_PREDICATE = 'urn:dkg:benchmark:swm-large-payload:payload';
+const DEFAULT_NAMESPACE = 'swm-large-payload';
+const FAILURE_PATTERNS = [
+  { name: 'oxigraphWasmUnreachable', text: 'RuntimeError: unreachable' },
+  { name: 'oxigraphTableIndexOutOfBounds', text: 'table index is out of bounds' },
+  { name: 'gossipsubInvalidDataLength', text: 'InvalidDataLengthError' },
+  { name: 'gossipsubMessageTooLong', text: 'Message length too long' },
+];
+
+function usage() {
+  return `Usage: pnpm --filter @origintrail-official/dkg benchmark:swm-large-payload -- [options]
+
+Writes large public SWM payloads to a running multi-node devnet and verifies that
+the replicated payload is not duplicated into dkg:publicStagedQuads metadata.
+
+Options:
+  --ports <list>                 Comma-separated daemon API ports. Default derives from --api-port-base and --nodes.
+  --api-port-base <port>         First daemon API port when --ports is omitted. Default: 9201.
+  --nodes <count>                Node count when --ports is omitted. Default: 5.
+  --context-graph-id <id>        Context graph to write/query. Default: devnet-test.
+  --payload-mib-per-node <MiB>   Payload size written through each node. Default: 100.
+  --chunk-mib <MiB>              Payload literal size per SWM write. Default: 0.5.
+  --write-concurrency <count>    Concurrent write requests. Default: 1.
+  --replication-timeout-ms <ms>  Time to wait for every node to see every payload. Default: 900000.
+  --poll-interval-ms <ms>        Replication polling interval. Default: 5000.
+  --request-timeout-ms <ms>      Per-request timeout. Default: 180000.
+  --query-timeout-ms <ms>        Per-query timeout. Default: 120000.
+  --auth-token <token>           Bearer token. Also reads DKG_BENCH_AUTH_TOKEN, DKG_AUTH_TOKEN, DKG_TOKEN, DEVNET_TOKEN, or DKG_AUTH.
+  --auth-token-file <path>       File containing bearer token. Defaults to DEVNET_DIR/node1/auth.token, if present.
+  --no-auth                      Send requests without Authorization.
+  --run-id <id>                  Stable run id. Default: timestamp + random suffix.
+  --namespace <name>             Subject namespace segment. Default: swm-large-payload.
+  --predicate <iri>              Payload predicate IRI. Default: ${DEFAULT_PREDICATE}.
+  --progress-every <count>       Emit a progress line every N writes. Default: 25.
+  --output <path>                Write the final JSON result to a file.
+  --skip-write                   Only verify an existing run id.
+  --devnet-dir <path>            Devnet directory for appended log scanning. Default: DEVNET_DIR or repo .devnet.
+  --scan-logs / --no-scan-logs   Scan appended daemon logs for known failure signatures. Default: scan when devnet dir exists.
+  --quiet                        Suppress progress events on stderr.
+  -h, --help                     Show this help.
+
+Environment mirrors the main options with DKG_BENCH_SWM_* names, for example
+DKG_BENCH_SWM_PORTS, DKG_BENCH_SWM_PAYLOAD_MIB_PER_NODE, DKG_BENCH_SWM_CHUNK_MIB,
+DKG_BENCH_SWM_OUTPUT, DKG_BENCH_SWM_SCAN_LOGS, and DKG_BENCH_SWM_NO_AUTH.`;
+}
+
+function parsePositiveInteger(name, value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer (got ${JSON.stringify(value)})`);
+  }
+  return parsed;
+}
+
+function parsePositiveNumber(name, value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number (got ${JSON.stringify(value)})`);
+  }
+  return parsed;
+}
+
+function parseBoolean(value, defaultValue = false) {
+  if (value === undefined || value === null || value === '') return defaultValue;
+  if (typeof value === 'boolean') return value;
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+  throw new Error(`Invalid boolean value ${JSON.stringify(value)}`);
+}
+
+function parsePorts(value) {
+  if (value === undefined || value === null || String(value).trim() === '') return undefined;
+  const ports = String(value)
+    .split(',')
+    .map((part) => parsePositiveInteger('port', part.trim()));
+  if (ports.length === 0) return undefined;
+  return ports;
+}
+
+function nextArgValue(argv, index, name, inlineValue) {
+  if (inlineValue !== undefined) return { value: inlineValue, nextIndex: index };
+  if (index + 1 >= argv.length || argv[index + 1].startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  return { value: argv[index + 1], nextIndex: index + 1 };
+}
+
+function readAuthTokenFile(path) {
+  const text = readFileSync(path, 'utf8');
+  const tokens = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'))
+    .flatMap((line) => line.split(/\s+/))
+    .filter(Boolean);
+  return tokens.at(-1);
+}
+
+function resolveAuthToken(options, env, devnetDir) {
+  if (options.noAuth) return undefined;
+  const inline = options.authToken
+    ?? env.DKG_BENCH_AUTH_TOKEN
+    ?? env.DKG_AUTH_TOKEN
+    ?? env.DKG_TOKEN
+    ?? env.DEVNET_TOKEN
+    ?? env.DKG_AUTH;
+  if (inline) return inline;
+
+  const tokenFile = options.authTokenFile
+    ?? env.DKG_BENCH_AUTH_TOKEN_FILE
+    ?? (devnetDir ? join(devnetDir, 'node1', 'auth.token') : undefined);
+  if (tokenFile && existsSync(tokenFile)) {
+    return readAuthTokenFile(tokenFile);
+  }
+  return undefined;
+}
+
+function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const raw = argv[index];
+    if (raw === '--') {
+      continue;
+    }
+    if (raw === '-h' || raw === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (raw === '--no-auth') {
+      options.noAuth = true;
+      continue;
+    }
+    if (raw === '--skip-write') {
+      options.skipWrite = true;
+      continue;
+    }
+    if (raw === '--quiet') {
+      options.quiet = true;
+      continue;
+    }
+    if (raw === '--scan-logs') {
+      options.scanLogs = true;
+      continue;
+    }
+    if (raw === '--no-scan-logs') {
+      options.scanLogs = false;
+      continue;
+    }
+    if (!raw.startsWith('--')) {
+      throw new Error(`Unexpected argument ${JSON.stringify(raw)}`);
+    }
+
+    const eqIndex = raw.indexOf('=');
+    const name = eqIndex >= 0 ? raw.slice(2, eqIndex) : raw.slice(2);
+    const inlineValue = eqIndex >= 0 ? raw.slice(eqIndex + 1) : undefined;
+    const { value, nextIndex } = nextArgValue(argv, index, `--${name}`, inlineValue);
+    index = nextIndex;
+
+    switch (name) {
+      case 'ports':
+        options.ports = parsePorts(value);
+        break;
+      case 'api-port-base':
+        options.apiPortBase = parsePositiveInteger('--api-port-base', value);
+        break;
+      case 'nodes':
+        options.nodes = parsePositiveInteger('--nodes', value);
+        break;
+      case 'context-graph-id':
+        options.contextGraphId = value;
+        break;
+      case 'payload-mib-per-node':
+        options.payloadMiBPerNode = parsePositiveNumber('--payload-mib-per-node', value);
+        break;
+      case 'chunk-mib':
+        options.chunkMiB = parsePositiveNumber('--chunk-mib', value);
+        break;
+      case 'write-concurrency':
+        options.writeConcurrency = parsePositiveInteger('--write-concurrency', value);
+        break;
+      case 'replication-timeout-ms':
+        options.replicationTimeoutMs = parsePositiveInteger('--replication-timeout-ms', value);
+        break;
+      case 'poll-interval-ms':
+        options.pollIntervalMs = parsePositiveInteger('--poll-interval-ms', value);
+        break;
+      case 'request-timeout-ms':
+        options.requestTimeoutMs = parsePositiveInteger('--request-timeout-ms', value);
+        break;
+      case 'query-timeout-ms':
+        options.queryTimeoutMs = parsePositiveInteger('--query-timeout-ms', value);
+        break;
+      case 'auth-token':
+        options.authToken = value;
+        break;
+      case 'auth-token-file':
+        options.authTokenFile = resolve(value);
+        break;
+      case 'run-id':
+        options.runId = value;
+        break;
+      case 'namespace':
+        options.namespace = value;
+        break;
+      case 'predicate':
+        options.predicate = value;
+        break;
+      case 'progress-every':
+        options.progressEvery = parsePositiveInteger('--progress-every', value);
+        break;
+      case 'output':
+        options.output = resolve(value);
+        break;
+      case 'devnet-dir':
+        options.devnetDir = resolve(value);
+        break;
+      default:
+        throw new Error(`Unknown option --${name}`);
+    }
+  }
+
+  const envPorts = parsePorts(env.DKG_BENCH_SWM_PORTS);
+  const devnetDir = options.devnetDir
+    ?? env.DKG_BENCH_SWM_DEVNET_DIR
+    ?? env.DEVNET_DIR
+    ?? join(REPO_ROOT, '.devnet');
+  const nodes = options.nodes
+    ?? (env.DKG_BENCH_SWM_NODES ? parsePositiveInteger('DKG_BENCH_SWM_NODES', env.DKG_BENCH_SWM_NODES) : 5);
+  const apiPortBase = options.apiPortBase
+    ?? (env.DKG_BENCH_SWM_API_PORT_BASE
+      ? parsePositiveInteger('DKG_BENCH_SWM_API_PORT_BASE', env.DKG_BENCH_SWM_API_PORT_BASE)
+      : (env.API_PORT_BASE ? parsePositiveInteger('API_PORT_BASE', env.API_PORT_BASE) : 9201));
+  const ports = options.ports ?? envPorts ?? Array.from({ length: nodes }, (_, index) => apiPortBase + index);
+  const noAuth = options.noAuth ?? parseBoolean(env.DKG_BENCH_SWM_NO_AUTH ?? env.DEVNET_NO_AUTH, false);
+  const config = {
+    help: Boolean(options.help),
+    contextGraphId: options.contextGraphId ?? env.DKG_BENCH_SWM_CONTEXT_GRAPH_ID ?? env.DKG_BENCH_CONTEXT_GRAPH_ID ?? DEFAULT_CONTEXT_GRAPH_ID,
+    ports,
+    nodes: ports.length,
+    apiPortBase,
+    payloadMiBPerNode: options.payloadMiBPerNode
+      ?? (env.DKG_BENCH_SWM_PAYLOAD_MIB_PER_NODE
+        ? parsePositiveNumber('DKG_BENCH_SWM_PAYLOAD_MIB_PER_NODE', env.DKG_BENCH_SWM_PAYLOAD_MIB_PER_NODE)
+        : 100),
+    chunkMiB: options.chunkMiB
+      ?? (env.DKG_BENCH_SWM_CHUNK_MIB ? parsePositiveNumber('DKG_BENCH_SWM_CHUNK_MIB', env.DKG_BENCH_SWM_CHUNK_MIB) : 0.5),
+    writeConcurrency: options.writeConcurrency
+      ?? (env.DKG_BENCH_SWM_WRITE_CONCURRENCY
+        ? parsePositiveInteger('DKG_BENCH_SWM_WRITE_CONCURRENCY', env.DKG_BENCH_SWM_WRITE_CONCURRENCY)
+        : 1),
+    replicationTimeoutMs: options.replicationTimeoutMs
+      ?? (env.DKG_BENCH_SWM_REPLICATION_TIMEOUT_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_REPLICATION_TIMEOUT_MS', env.DKG_BENCH_SWM_REPLICATION_TIMEOUT_MS)
+        : 900_000),
+    pollIntervalMs: options.pollIntervalMs
+      ?? (env.DKG_BENCH_SWM_POLL_INTERVAL_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_POLL_INTERVAL_MS', env.DKG_BENCH_SWM_POLL_INTERVAL_MS)
+        : 5_000),
+    requestTimeoutMs: options.requestTimeoutMs
+      ?? (env.DKG_BENCH_SWM_REQUEST_TIMEOUT_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_REQUEST_TIMEOUT_MS', env.DKG_BENCH_SWM_REQUEST_TIMEOUT_MS)
+        : 180_000),
+    queryTimeoutMs: options.queryTimeoutMs
+      ?? (env.DKG_BENCH_SWM_QUERY_TIMEOUT_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_QUERY_TIMEOUT_MS', env.DKG_BENCH_SWM_QUERY_TIMEOUT_MS)
+        : 120_000),
+    runId: options.runId ?? env.DKG_BENCH_SWM_RUN_ID ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    namespace: options.namespace ?? env.DKG_BENCH_SWM_NAMESPACE ?? DEFAULT_NAMESPACE,
+    predicate: options.predicate ?? env.DKG_BENCH_SWM_PREDICATE ?? DEFAULT_PREDICATE,
+    progressEvery: options.progressEvery
+      ?? (env.DKG_BENCH_SWM_PROGRESS_EVERY
+        ? parsePositiveInteger('DKG_BENCH_SWM_PROGRESS_EVERY', env.DKG_BENCH_SWM_PROGRESS_EVERY)
+        : 25),
+    output: options.output ?? (env.DKG_BENCH_SWM_OUTPUT ? resolve(env.DKG_BENCH_SWM_OUTPUT) : undefined),
+    skipWrite: options.skipWrite ?? parseBoolean(env.DKG_BENCH_SWM_SKIP_WRITE, false),
+    noAuth,
+    devnetDir,
+    scanLogs: options.scanLogs ?? parseBoolean(env.DKG_BENCH_SWM_SCAN_LOGS, existsSync(devnetDir)),
+    quiet: options.quiet ?? parseBoolean(env.DKG_BENCH_SWM_QUIET, false),
+  };
+  config.authToken = resolveAuthToken({ ...options, noAuth }, env, devnetDir);
+  return Object.freeze(config);
+}
+
+function bytesFromMiB(value) {
+  return Math.round(value * 1024 * 1024);
+}
+
+function buildBenchmarkPlan(config) {
+  const payloadBytesPerNode = bytesFromMiB(config.payloadMiBPerNode);
+  const chunkBytes = bytesFromMiB(config.chunkMiB);
+  if (payloadBytesPerNode <= 0) throw new Error('payloadMiBPerNode resolved to zero bytes');
+  if (chunkBytes <= 0) throw new Error('chunkMiB resolved to zero bytes');
+  const chunksPerNode = Math.ceil(payloadBytesPerNode / chunkBytes);
+  const totalOperations = config.ports.length * chunksPerNode;
+  const totalPayloadBytes = payloadBytesPerNode * config.ports.length;
+  const rootPrefix = `urn:dkg:benchmark:${config.namespace}:${config.runId}:`;
+  return Object.freeze({
+    payloadBytesPerNode,
+    chunkBytes,
+    chunksPerNode,
+    totalOperations,
+    totalPayloadBytes,
+    totalPayloadMiB: Number((totalPayloadBytes / 1024 / 1024).toFixed(3)),
+    rootPrefix,
+    metadataGraph: `did:dkg:context-graph:${config.contextGraphId}/_shared_memory_meta`,
+  });
+}
+
+function payloadBytesForChunk(plan, chunkNumber) {
+  const writtenBefore = (chunkNumber - 1) * plan.chunkBytes;
+  return Math.min(plan.chunkBytes, plan.payloadBytesPerNode - writtenBefore);
+}
+
+function makePayload(runId, nodeNumber, chunkNumber, sizeBytes) {
+  const prefix = `swm-large run=${runId} node=${nodeNumber} chunk=${chunkNumber} `;
+  const prefixBytes = Buffer.byteLength(prefix, 'utf8');
+  if (prefixBytes > sizeBytes) {
+    throw new Error(`Payload prefix is ${prefixBytes} bytes, larger than requested ${sizeBytes} byte chunk`);
+  }
+  const fillChar = String.fromCharCode(97 + ((nodeNumber + chunkNumber) % 26));
+  return prefix + fillChar.repeat(sizeBytes - prefixBytes);
+}
+
+function sparqlString(value) {
+  return JSON.stringify(String(value));
+}
+
+function bindingValue(result, name) {
+  return result?.bindings?.[0]?.[name]?.value ?? result?.bindings?.[0]?.[name];
+}
+
+function numericBinding(result, name) {
+  const value = bindingValue(result, name);
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const typedLiteral = value.match(/^"([^"]+)"\^\^<[^>]+>$/);
+    const lexical = typedLiteral ? typedLiteral[1] : value;
+    const parsed = Number(lexical);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return Number.NaN;
+}
+
+async function postJson(port, path, body, config, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const headers = { 'content-type': 'application/json' };
+    if (config.authToken && !config.noAuth) headers.authorization = `Bearer ${config.authToken}`;
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let json;
+    try {
+      json = text ? JSON.parse(text) : {};
+    } catch {
+      json = { raw: text };
+    }
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${path} on ${port}: ${text.slice(0, 500)}`);
+    }
+    return json;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function query(port, sparql, config, options = {}) {
+  const response = await postJson(port, '/api/query', { sparql, ...options }, config, config.queryTimeoutMs);
+  return response.result ?? response;
+}
+
+async function writeChunk(config, plan, nodeIndex, chunkNumber) {
+  const port = config.ports[nodeIndex];
+  const nodeNumber = nodeIndex + 1;
+  const sizeBytes = payloadBytesForChunk(plan, chunkNumber);
+  const subject = `${plan.rootPrefix}node:${nodeNumber}:chunk:${chunkNumber}`;
+  const payload = makePayload(config.runId, nodeNumber, chunkNumber, sizeBytes);
+  const startedAt = performance.now();
+  const response = await postJson(port, '/api/shared-memory/write', {
+    contextGraphId: config.contextGraphId,
+    quads: [{
+      subject,
+      predicate: config.predicate,
+      object: JSON.stringify(payload),
+      graph: '',
+    }],
+  }, config, config.requestTimeoutMs);
+  const durationMs = performance.now() - startedAt;
+  return {
+    port,
+    nodeNumber,
+    chunkNumber,
+    subject,
+    payloadBytes: sizeBytes,
+    durationMs: Number(durationMs.toFixed(2)),
+    operationId: response.operationId,
+  };
+}
+
+function percentile(values, p) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, rank))];
+}
+
+function summarizeWrites(records, config) {
+  const durations = records.map((record) => record.durationMs);
+  const perNode = config.ports.map((port) => {
+    const nodeRecords = records.filter((record) => record.port === port);
+    const nodeDurations = nodeRecords.map((record) => record.durationMs);
+    const nodeBytes = nodeRecords.reduce((sum, record) => sum + record.payloadBytes, 0);
+    return {
+      port,
+      operations: nodeRecords.length,
+      payloadMiB: Number((nodeBytes / 1024 / 1024).toFixed(3)),
+      minMs: Number(Math.min(...nodeDurations).toFixed(2)),
+      maxMs: Number(Math.max(...nodeDurations).toFixed(2)),
+      meanMs: Number((nodeDurations.reduce((sum, value) => sum + value, 0) / Math.max(1, nodeDurations.length)).toFixed(2)),
+      p50Ms: Number(percentile(nodeDurations, 50).toFixed(2)),
+      p95Ms: Number(percentile(nodeDurations, 95).toFixed(2)),
+    };
+  });
+  return {
+    operations: records.length,
+    minMs: Number(Math.min(...durations).toFixed(2)),
+    maxMs: Number(Math.max(...durations).toFixed(2)),
+    meanMs: Number((durations.reduce((sum, value) => sum + value, 0) / Math.max(1, durations.length)).toFixed(2)),
+    p50Ms: Number(percentile(durations, 50).toFixed(2)),
+    p95Ms: Number(percentile(durations, 95).toFixed(2)),
+    perNode,
+  };
+}
+
+function emitProgress(config, event) {
+  if (!config.quiet) {
+    process.stderr.write(`${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`);
+  }
+}
+
+async function runWrites(config, plan) {
+  if (config.skipWrite) {
+    return { durationMs: 0, records: [], summary: undefined };
+  }
+
+  const tasks = [];
+  for (let nodeIndex = 0; nodeIndex < config.ports.length; nodeIndex += 1) {
+    for (let chunkNumber = 1; chunkNumber <= plan.chunksPerNode; chunkNumber += 1) {
+      tasks.push({ nodeIndex, chunkNumber });
+    }
+  }
+
+  const records = [];
+  let nextTask = 0;
+  let completed = 0;
+  const startedAt = performance.now();
+
+  async function worker() {
+    while (nextTask < tasks.length) {
+      const task = tasks[nextTask];
+      nextTask += 1;
+      const record = await writeChunk(config, plan, task.nodeIndex, task.chunkNumber);
+      records.push(record);
+      completed += 1;
+      if (completed === 1 || completed === tasks.length || completed % config.progressEvery === 0) {
+        emitProgress(config, {
+          event: 'write-progress',
+          completed,
+          total: tasks.length,
+          port: record.port,
+          operationId: record.operationId,
+          durationMs: record.durationMs,
+        });
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(config.writeConcurrency, tasks.length) }, () => worker());
+  await Promise.all(workers);
+  const durationMs = performance.now() - startedAt;
+  return {
+    durationMs: Number(durationMs.toFixed(2)),
+    records,
+    summary: summarizeWrites(records, config),
+  };
+}
+
+async function countPayloads(port, config, plan) {
+  const result = await query(
+    port,
+    `SELECT (COUNT(?s) AS ?count) WHERE {
+       ?s <${config.predicate}> ?o .
+       FILTER(STRSTARTS(STR(?s), ${sparqlString(plan.rootPrefix)}))
+     }`,
+    config,
+    { contextGraphId: config.contextGraphId, view: 'shared-working-memory' },
+  );
+  return numericBinding(result, 'count');
+}
+
+async function samplePayloadBytes(port, config, plan) {
+  const result = await query(
+    port,
+    `SELECT (STRLEN(STR(?o)) AS ?len) WHERE {
+       ?s <${config.predicate}> ?o .
+       FILTER(STRSTARTS(STR(?s), ${sparqlString(plan.rootPrefix)}))
+     } LIMIT 1`,
+    config,
+    { contextGraphId: config.contextGraphId, view: 'shared-working-memory' },
+  );
+  return numericBinding(result, 'len');
+}
+
+async function countGlobalMetaPredicate(port, config, plan, predicate) {
+  const result = await query(
+    port,
+    `SELECT (COUNT(?value) AS ?count) WHERE {
+       GRAPH <${plan.metadataGraph}> { ?op <${predicate}> ?value }
+     }`,
+    config,
+  );
+  return numericBinding(result, 'count');
+}
+
+async function countRunMetaPredicate(port, config, plan, predicate) {
+  const result = await query(
+    port,
+    `SELECT (COUNT(?value) AS ?count) WHERE {
+       GRAPH <${plan.metadataGraph}> {
+         ?op <${DKG_ONTOLOGY}rootEntity> ?root ;
+             <${predicate}> ?value .
+         FILTER(STRSTARTS(STR(?root), ${sparqlString(plan.rootPrefix)}))
+       }
+     }`,
+    config,
+  );
+  return numericBinding(result, 'count');
+}
+
+async function countRunRootEntities(port, config, plan) {
+  const result = await query(
+    port,
+    `SELECT (COUNT(?root) AS ?count) WHERE {
+       GRAPH <${plan.metadataGraph}> {
+         ?op <${DKG_ONTOLOGY}rootEntity> ?root .
+         FILTER(STRSTARTS(STR(?root), ${sparqlString(plan.rootPrefix)}))
+       }
+     }`,
+    config,
+  );
+  return numericBinding(result, 'count');
+}
+
+async function collectPublicStagedQuadsBaseline(config, plan) {
+  const entries = [];
+  for (const port of config.ports) {
+    entries.push({
+      port,
+      publicStagedQuadsGlobal: await countGlobalMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publicStagedQuads`),
+    });
+  }
+  return entries;
+}
+
+async function pollReplication(config, plan) {
+  const startedAt = performance.now();
+  const polls = [];
+  while (performance.now() - startedAt <= config.replicationTimeoutMs) {
+    const counts = [];
+    for (const port of config.ports) {
+      try {
+        counts.push({ port, count: await countPayloads(port, config, plan) });
+      } catch (error) {
+        counts.push({ port, error: error instanceof Error ? error.message : String(error) });
+      }
+    }
+    polls.push({ atMs: Number((performance.now() - startedAt).toFixed(2)), counts });
+    emitProgress(config, { event: 'replication-poll', counts });
+    if (counts.every((entry) => entry.count === plan.totalOperations)) {
+      return {
+        converged: true,
+        durationMs: Number((performance.now() - startedAt).toFixed(2)),
+        polls,
+      };
+    }
+    await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
+  }
+  return {
+    converged: false,
+    durationMs: Number((performance.now() - startedAt).toFixed(2)),
+    polls,
+  };
+}
+
+async function collectMetadata(config, plan, baseline) {
+  const byPort = new Map(baseline.map((entry) => [entry.port, entry]));
+  const entries = [];
+  for (const port of config.ports) {
+    const before = byPort.get(port)?.publicStagedQuadsGlobal ?? 0;
+    const after = await countGlobalMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publicStagedQuads`);
+    const payloadCount = await countPayloads(port, config, plan);
+    const rootEntities = await countRunRootEntities(port, config, plan);
+    const shareOperationIds = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}shareOperationId`);
+    const publicStagedQuadsForRun = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publicStagedQuads`);
+    const publisherPeerIds = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publisherPeerId`);
+    const publishedAt = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publishedAt`);
+    const timestamps = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}timestamp`);
+    entries.push({
+      port,
+      payloadCount,
+      samplePayloadBytes: await samplePayloadBytes(port, config, plan),
+      publicStagedQuadsForRun,
+      publicStagedQuadsGlobalBefore: before,
+      publicStagedQuadsGlobalAfter: after,
+      publicStagedQuadsGlobalDelta: after - before,
+      shareOperationIds,
+      rootEntities,
+      publisherPeerIds,
+      publishedAt,
+      timestamps,
+      ok: payloadCount === plan.totalOperations
+        && publicStagedQuadsForRun === 0
+        && after - before === 0
+        && shareOperationIds === plan.totalOperations
+        && rootEntities === plan.totalOperations
+        && publishedAt === plan.totalOperations,
+    });
+  }
+  return entries;
+}
+
+function captureLogOffsets(devnetDir) {
+  if (!devnetDir || !existsSync(devnetDir)) return [];
+  return readdirSync(devnetDir)
+    .filter((name) => /^node\d+$/.test(name))
+    .map((name) => join(devnetDir, name, 'daemon.log'))
+    .filter((file) => existsSync(file))
+    .map((file) => ({ file, offset: statSync(file).size }));
+}
+
+async function scanLogsFromOffsets(offsets) {
+  const matches = [];
+  for (const { file, offset } of offsets) {
+    if (!existsSync(file)) continue;
+    const stream = createReadStream(file, { start: offset, encoding: 'utf8' });
+    const lines = createInterface({ input: stream, crlfDelay: Infinity });
+    let lineNumber = 0;
+    for await (const line of lines) {
+      lineNumber += 1;
+      for (const pattern of FAILURE_PATTERNS) {
+        if (line.includes(pattern.text)) {
+          matches.push({
+            file,
+            lineOffset: lineNumber,
+            pattern: pattern.name,
+            text: pattern.text,
+            line: line.slice(0, 500),
+          });
+        }
+      }
+    }
+  }
+  return {
+    scannedFiles: offsets.map((entry) => entry.file),
+    matches,
+    ok: matches.length === 0,
+  };
+}
+
+function sanitizeConfig(config) {
+  return {
+    contextGraphId: config.contextGraphId,
+    ports: config.ports,
+    payloadMiBPerNode: config.payloadMiBPerNode,
+    chunkMiB: config.chunkMiB,
+    writeConcurrency: config.writeConcurrency,
+    replicationTimeoutMs: config.replicationTimeoutMs,
+    pollIntervalMs: config.pollIntervalMs,
+    requestTimeoutMs: config.requestTimeoutMs,
+    queryTimeoutMs: config.queryTimeoutMs,
+    runId: config.runId,
+    namespace: config.namespace,
+    predicate: config.predicate,
+    skipWrite: config.skipWrite,
+    noAuth: config.noAuth,
+    hasAuthToken: Boolean(config.authToken && !config.noAuth),
+    devnetDir: config.devnetDir,
+    scanLogs: config.scanLogs,
+  };
+}
+
+async function runSwmLargePayloadBenchmark(config) {
+  const startedAtIso = new Date().toISOString();
+  const startedAt = performance.now();
+  const plan = buildBenchmarkPlan(config);
+  const logOffsets = config.scanLogs ? captureLogOffsets(config.devnetDir) : [];
+  emitProgress(config, {
+    event: 'benchmark-start',
+    runId: config.runId,
+    nodes: config.ports.length,
+    totalPayloadMiB: plan.totalPayloadMiB,
+    totalOperations: plan.totalOperations,
+    chunkMiB: config.chunkMiB,
+  });
+
+  const baseline = await collectPublicStagedQuadsBaseline(config, plan);
+  const write = await runWrites(config, plan);
+  const replication = await pollReplication(config, plan);
+  const metadata = await collectMetadata(config, plan, baseline);
+  const logScan = config.scanLogs ? await scanLogsFromOffsets(logOffsets) : undefined;
+  const finishedAt = performance.now();
+
+  const ok = replication.converged
+    && metadata.every((entry) => entry.ok)
+    && (logScan ? logScan.ok : true);
+
+  return {
+    benchmark: 'swm-large-payload',
+    ok,
+    startedAt: startedAtIso,
+    finishedAt: new Date().toISOString(),
+    durationMs: Number((finishedAt - startedAt).toFixed(2)),
+    config: sanitizeConfig(config),
+    plan: {
+      payloadBytesPerNode: plan.payloadBytesPerNode,
+      chunkBytes: plan.chunkBytes,
+      chunksPerNode: plan.chunksPerNode,
+      totalOperations: plan.totalOperations,
+      totalPayloadBytes: plan.totalPayloadBytes,
+      totalPayloadMiB: plan.totalPayloadMiB,
+      rootPrefix: plan.rootPrefix,
+      metadataGraph: plan.metadataGraph,
+    },
+    baseline,
+    write: {
+      durationMs: write.durationMs,
+      summary: write.summary,
+    },
+    replication,
+    metadata,
+    logScan,
+  };
+}
+
+async function main(argv = process.argv.slice(2), env = process.env) {
+  const config = parseBenchmarkArgs(argv, env);
+  if (config.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  if (config.chunkMiB > 1) {
+    emitProgress(config, {
+      event: 'warning',
+      message: 'chunkMiB is above 1 MiB; local GossipSub limits may reject very large single-message writes.',
+    });
+  }
+  const result = await runSwmLargePayloadBenchmark(config);
+  if (config.output) {
+    mkdirSync(dirname(config.output), { recursive: true });
+    writeFileSync(config.output, `${JSON.stringify(result, null, 2)}\n`);
+  }
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildBenchmarkPlan,
+  makePayload,
+  numericBinding,
+  parseBenchmarkArgs,
+  payloadBytesForChunk,
+  runSwmLargePayloadBenchmark,
+  usage,
+};

--- a/packages/cli/scripts/swm-large-payload-benchmark.cjs
+++ b/packages/cli/scripts/swm-large-payload-benchmark.cjs
@@ -333,6 +333,16 @@ function makePayload(runId, nodeNumber, chunkNumber, sizeBytes) {
   return prefix + fillChar.repeat(sizeBytes - prefixBytes);
 }
 
+function buildWriteTasks(config, plan) {
+  const tasks = [];
+  for (let chunkNumber = 1; chunkNumber <= plan.chunksPerNode; chunkNumber += 1) {
+    for (let nodeIndex = 0; nodeIndex < config.ports.length; nodeIndex += 1) {
+      tasks.push({ nodeIndex, chunkNumber });
+    }
+  }
+  return tasks;
+}
+
 function sparqlString(value) {
   return JSON.stringify(String(value));
 }
@@ -460,12 +470,7 @@ async function runWrites(config, plan) {
     return { durationMs: 0, records: [], summary: undefined };
   }
 
-  const tasks = [];
-  for (let nodeIndex = 0; nodeIndex < config.ports.length; nodeIndex += 1) {
-    for (let chunkNumber = 1; chunkNumber <= plan.chunksPerNode; chunkNumber += 1) {
-      tasks.push({ nodeIndex, chunkNumber });
-    }
-  }
+  const tasks = buildWriteTasks(config, plan);
 
   const records = [];
   let nextTask = 0;
@@ -788,6 +793,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  buildWriteTasks,
   buildBenchmarkPlan,
   makePayload,
   numericBinding,

--- a/packages/cli/test/swm-large-payload-benchmark.test.ts
+++ b/packages/cli/test/swm-large-payload-benchmark.test.ts
@@ -1,0 +1,127 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const benchmark = require('../scripts/swm-large-payload-benchmark.cjs') as {
+  buildBenchmarkPlan: (config: Record<string, unknown>) => {
+    payloadBytesPerNode: number;
+    chunkBytes: number;
+    chunksPerNode: number;
+    totalOperations: number;
+    totalPayloadBytes: number;
+    totalPayloadMiB: number;
+    rootPrefix: string;
+    metadataGraph: string;
+  };
+  makePayload: (runId: string, nodeNumber: number, chunkNumber: number, sizeBytes: number) => string;
+  parseBenchmarkArgs: (argv: string[], env: Record<string, string | undefined>) => Record<string, unknown>;
+  payloadBytesForChunk: (plan: { payloadBytesPerNode: number; chunkBytes: number }, chunkNumber: number) => number;
+};
+
+describe('swm large payload benchmark', () => {
+  it('parses live-devnet benchmark arguments and hides auth from the sanitized config', () => {
+    const config = benchmark.parseBenchmarkArgs([
+      '--',
+      '--ports',
+      '19101,19102,19103',
+      '--context-graph-id',
+      'devnet-test',
+      '--payload-mib-per-node',
+      '12.5',
+      '--chunk-mib',
+      '0.25',
+      '--write-concurrency',
+      '2',
+      '--replication-timeout-ms',
+      '1000',
+      '--poll-interval-ms',
+      '100',
+      '--request-timeout-ms',
+      '2000',
+      '--query-timeout-ms',
+      '3000',
+      '--run-id',
+      'fixed-run',
+      '--namespace',
+      'swm-regression',
+      '--predicate',
+      'urn:test:payload',
+      '--progress-every',
+      '5',
+      '--no-scan-logs',
+      '--auth-token',
+      'secret-token',
+    ], {});
+
+    expect(config).toMatchObject({
+      ports: [19101, 19102, 19103],
+      nodes: 3,
+      contextGraphId: 'devnet-test',
+      payloadMiBPerNode: 12.5,
+      chunkMiB: 0.25,
+      writeConcurrency: 2,
+      replicationTimeoutMs: 1000,
+      pollIntervalMs: 100,
+      requestTimeoutMs: 2000,
+      queryTimeoutMs: 3000,
+      runId: 'fixed-run',
+      namespace: 'swm-regression',
+      predicate: 'urn:test:payload',
+      progressEvery: 5,
+      scanLogs: false,
+      authToken: 'secret-token',
+    });
+  });
+
+  it('derives ports and auth from environment defaults', () => {
+    const config = benchmark.parseBenchmarkArgs([], {
+      DKG_BENCH_SWM_API_PORT_BASE: '18101',
+      DKG_BENCH_SWM_NODES: '2',
+      DKG_BENCH_SWM_PAYLOAD_MIB_PER_NODE: '1',
+      DKG_BENCH_SWM_CHUNK_MIB: '0.5',
+      DKG_BENCH_AUTH_TOKEN: 'env-token',
+      DKG_BENCH_SWM_SCAN_LOGS: '0',
+    });
+
+    expect(config).toMatchObject({
+      ports: [18101, 18102],
+      nodes: 2,
+      payloadMiBPerNode: 1,
+      chunkMiB: 0.5,
+      authToken: 'env-token',
+      scanLogs: false,
+    });
+  });
+
+  it('plans exact chunk counts and a smaller final chunk when needed', () => {
+    const plan = benchmark.buildBenchmarkPlan({
+      contextGraphId: 'devnet-test',
+      ports: [9201, 9202],
+      payloadMiBPerNode: 1.25,
+      chunkMiB: 0.5,
+      runId: 'plan-run',
+      namespace: 'swm-large-payload',
+    });
+
+    expect(plan).toMatchObject({
+      payloadBytesPerNode: 1.25 * 1024 * 1024,
+      chunkBytes: 0.5 * 1024 * 1024,
+      chunksPerNode: 3,
+      totalOperations: 6,
+      totalPayloadBytes: 2.5 * 1024 * 1024,
+      totalPayloadMiB: 2.5,
+      rootPrefix: 'urn:dkg:benchmark:swm-large-payload:plan-run:',
+      metadataGraph: 'did:dkg:context-graph:devnet-test/_shared_memory_meta',
+    });
+    expect(benchmark.payloadBytesForChunk(plan, 1)).toBe(512 * 1024);
+    expect(benchmark.payloadBytesForChunk(plan, 2)).toBe(512 * 1024);
+    expect(benchmark.payloadBytesForChunk(plan, 3)).toBe(256 * 1024);
+  });
+
+  it('generates payload literals at the requested byte size', () => {
+    const payload = benchmark.makePayload('payload-run', 5, 7, 1024);
+
+    expect(Buffer.byteLength(payload, 'utf8')).toBe(1024);
+    expect(payload).toContain('run=payload-run node=5 chunk=7');
+  });
+});

--- a/packages/cli/test/swm-large-payload-benchmark.test.ts
+++ b/packages/cli/test/swm-large-payload-benchmark.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const benchmark = require('../scripts/swm-large-payload-benchmark.cjs') as {
+  buildWriteTasks: (
+    config: { ports: number[] },
+    plan: { chunksPerNode: number },
+  ) => Array<{ nodeIndex: number; chunkNumber: number }>;
   buildBenchmarkPlan: (config: Record<string, unknown>) => {
     payloadBytesPerNode: number;
     chunkBytes: number;
@@ -123,5 +127,16 @@ describe('swm large payload benchmark', () => {
 
     expect(Buffer.byteLength(payload, 'utf8')).toBe(1024);
     expect(payload).toContain('run=payload-run node=5 chunk=7');
+  });
+
+  it('interleaves write tasks across nodes for concurrent live benchmarks', () => {
+    expect(benchmark.buildWriteTasks({ ports: [9201, 9202, 9203] }, { chunksPerNode: 2 })).toEqual([
+      { nodeIndex: 0, chunkNumber: 1 },
+      { nodeIndex: 1, chunkNumber: 1 },
+      { nodeIndex: 2, chunkNumber: 1 },
+      { nodeIndex: 0, chunkNumber: 2 },
+      { nodeIndex: 1, chunkNumber: 2 },
+      { nodeIndex: 2, chunkNumber: 2 },
+    ]);
   });
 });

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -18,7 +18,6 @@ import { validatePublishRequest } from './validation.js';
 import {
   generateTentativeMetadata,
   generateConfirmedFullMetadata,
-  generateShareMetadata,
   generateOwnershipQuads,
   generateAuthorshipProof,
   generateShareTransitionMetadata,
@@ -908,17 +907,7 @@ export class DKGPublisher implements Publisher {
     await this.store.insert(normalized);
 
     const rootEntities = manifestEntries.map((m) => m.rootEntity);
-    const metaQuads = generateShareMetadata(
-      {
-        shareOperationId,
-        contextGraphId,
-        rootEntities,
-        publisherPeerId: options.publisherPeerId,
-        timestamp: new Date(),
-      },
-      swmMetaGraph,
-    );
-    await this.store.insert(metaQuads);
+    const operationTimestamp = new Date();
     await storeWorkspaceOperationPublicQuads({
       store: this.store,
       graphManager: this.graphManager,
@@ -928,6 +917,7 @@ export class DKGPublisher implements Publisher {
       quads: normalized,
       publisherPeerId: options.publisherPeerId,
       subGraphName: options.subGraphName,
+      timestamp: operationTimestamp,
     });
 
     if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {
@@ -3238,11 +3228,7 @@ export class DKGPublisher implements Publisher {
     // _shareImpl and the remote SharedMemoryHandler both produce, so the
     // promoting node and replicas converge on identical ownership state.
     if (opts?.publisherPeerId) {
-      const metaQuads = generateShareMetadata(
-        { shareOperationId: operationId, contextGraphId, rootEntities: effectiveRoots, publisherPeerId: opts.publisherPeerId, timestamp: new Date() },
-        swmMetaGraph,
-      );
-      await this.store.insert(metaQuads);
+      const operationTimestamp = new Date();
       await storeWorkspaceOperationPublicQuads({
         store: this.store,
         graphManager: this.graphManager,
@@ -3252,6 +3238,7 @@ export class DKGPublisher implements Publisher {
         quads: swmQuads,
         publisherPeerId: opts.publisherPeerId,
         subGraphName: opts.subGraphName,
+        timestamp: operationTimestamp,
       });
 
       if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -354,6 +354,7 @@ export interface ShareMetadata {
   rootEntities: string[];
   publisherPeerId: string;
   timestamp: Date;
+  subGraphName?: string;
 }
 
 /** @deprecated Use ShareMetadata */
@@ -372,6 +373,9 @@ export function generateShareMetadata(
 
   quads.push(
     mq(subject, `${RDF}type`, `${DKG}WorkspaceOperation`, swmMetaGraph),
+    mq(subject, `${DKG}contextGraphId`, lit(meta.contextGraphId), swmMetaGraph),
+    mq(subject, `${DKG}shareOperationId`, lit(meta.shareOperationId), swmMetaGraph),
+    mq(subject, `${DKG}publisherPeerId`, lit(meta.publisherPeerId), swmMetaGraph),
     mq(
       subject,
       `${PROV}wasAttributedTo`,
@@ -385,6 +389,10 @@ export function generateShareMetadata(
       swmMetaGraph,
     ),
   );
+
+  if (meta.subGraphName) {
+    quads.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), swmMetaGraph));
+  }
 
   for (const rootEntity of meta.rootEntities) {
     quads.push(

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -23,7 +23,7 @@ import {
 import type { EncryptedWorkspacePayloadMsg, GossipEnvelopeMsg, OperationContext, SwmSenderKeyMessageMsg, WorkspaceCASConditionMsg, WorkspacePublishRequestMsg, WorkspaceRecipientEncryptionKey } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 import { validatePublishRequest } from './validation.js';
-import { generateShareMetadata, generateOwnershipQuads, generateSubGraphRegistration } from './metadata.js';
+import { generateOwnershipQuads, generateSubGraphRegistration } from './metadata.js';
 import { parseSimpleNQuads } from './publish-handler.js';
 import { storeWorkspaceOperationPublicQuads } from './workspace-resolution.js';
 import type { KAManifestEntry } from './publisher.js';
@@ -367,16 +367,8 @@ export class SharedMemoryHandler {
         await this.store.insert(normalized);
 
         const rootEntities = manifestForValidation.map((m) => m.rootEntity);
-        const metaQuads = generateShareMetadata(
-          {
-            shareOperationId,
-            contextGraphId,
-            rootEntities,
-            publisherPeerId,
-            timestamp: new Date(Number(timestampMs)),
-          },
-          swmMetaGraph,
-        );
+        const operationTimestamp = new Date(Number(timestampMs));
+        const metaQuads: Quad[] = [];
 
         for (const m of manifestForValidation) {
           if (m.privateMerkleRoot && m.privateMerkleRoot.length > 0) {
@@ -390,7 +382,9 @@ export class SharedMemoryHandler {
           }
         }
 
-        await this.store.insert(metaQuads);
+        if (metaQuads.length > 0) {
+          await this.store.insert(metaQuads);
+        }
         await storeWorkspaceOperationPublicQuads({
           store: this.store,
           graphManager: this.graphManager,
@@ -400,6 +394,7 @@ export class SharedMemoryHandler {
           quads: normalized,
           publisherPeerId,
           subGraphName,
+          timestamp: operationTimestamp,
         });
 
         if (!this.sharedMemoryOwnedEntities.has(swmOwnershipKey)) {

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -1,12 +1,14 @@
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { assertSafeIri, isSafeIri, validateSubGraphName } from '@origintrail-official/dkg-core';
+import { createHash } from 'node:crypto';
 import type { LiftRequest } from './lift-job.js';
 import type { LiftResolvedPublishSlice } from './async-lift-publish-options.js';
 import { generateShareMetadata } from './metadata.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const PROV = 'http://www.w3.org/ns/prov#';
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
 
 export type WorkspaceSelection = 'all' | { rootEntities: readonly string[] };
 
@@ -23,6 +25,12 @@ interface WorkspaceOperationPublicSnapshot {
 interface LegacyWorkspaceOperationPublicSnapshot extends WorkspaceOperationPublicSnapshot {
   readonly complete: boolean;
   readonly missingRoots: string[];
+}
+
+interface CompactWorkspaceOperationPublicSnapshot extends WorkspaceOperationPublicSnapshot {
+  readonly complete: boolean;
+  readonly missingRoots: string[];
+  readonly staleRoots: string[];
 }
 
 export async function resolveWorkspaceSelection(params: {
@@ -65,6 +73,8 @@ export async function storeWorkspaceOperationPublicQuads(params: {
   const subGraphName = normalizeOptionalSubGraphName(params.subGraphName);
   const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, subGraphName);
   const operationSubject = workspaceOperationSubject(params.contextGraphId, params.shareOperationId);
+  const publisherPeerId = params.publisherPeerId?.trim() || 'unknown';
+  const timestamp = params.timestamp ?? new Date();
 
   for (const root of roots) {
     const legacySubject = workspaceOperationPublicSliceSubject(
@@ -82,12 +92,37 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       shareOperationId: params.shareOperationId,
       contextGraphId: params.contextGraphId,
       rootEntities: roots,
-      publisherPeerId: params.publisherPeerId?.trim() || 'unknown',
-      timestamp: params.timestamp ?? new Date(),
+      publisherPeerId,
+      timestamp,
       subGraphName,
     },
     workspaceMetaGraph,
   ));
+
+  const normalizedQuads = params.quads.map((quad) => ({ ...quad, graph: '' }));
+  const snapshotQuads: Quad[] = [];
+  for (const root of roots) {
+    const subject = workspaceOperationPublicSliceSubject(
+      params.contextGraphId,
+      params.shareOperationId,
+      root,
+      subGraphName,
+    );
+    const rootQuads = filterQuadsForRoot(normalizedQuads, root);
+    snapshotQuads.push(
+      { subject, predicate: `${DKG}contextGraphId`, object: lit(params.contextGraphId), graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}shareOperationId`, object: lit(params.shareOperationId), graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}publicSliceRootEntity`, object: root, graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}publicQuadsDigest`, object: lit(publicQuadsDigest(rootQuads)), graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}publicQuadsCount`, object: intLit(rootQuads.length), graph: workspaceMetaGraph },
+      { subject, predicate: `${PROV}wasAttributedTo`, object: lit(publisherPeerId), graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}publishedAt`, object: dateLit(timestamp), graph: workspaceMetaGraph },
+    );
+    if (subGraphName) {
+      snapshotQuads.push({ subject, predicate: `${DKG}subGraphName`, object: lit(subGraphName), graph: workspaceMetaGraph });
+    }
+  }
+  await params.store.insert(snapshotQuads);
 }
 
 /**
@@ -230,23 +265,105 @@ async function resolveWorkspaceOperationPublicQuads(params: {
     };
   }
 
-  if (!params.operation) {
+  const compact = await resolveCompactWorkspaceOperationPublicQuads(params);
+  if (compact.staleRoots.length > 0) {
     throw new Error(
-      `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId} roots: ${legacy.missingRoots.join(', ')}`,
+      `Shared-memory operation ${params.shareOperationId} no longer matches current public SWM data for roots: ${compact.staleRoots.join(', ')}`,
     );
   }
 
-  const quads = await resolveWorkspaceSelection({
-    store: params.store,
-    graphManager: params.graphManager,
-    contextGraphId: params.contextGraphId,
-    selection: { rootEntities: roots },
-    subGraphName: params.subGraphName,
-  });
+  if (compact.complete) {
+    if (compact.quads.length === 0) {
+      throw new Error(
+        `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId}`,
+      );
+    }
+    return {
+      quads: compact.quads,
+      publisherPeerId: compact.publisherPeerId ?? params.operation?.publisherPeerId,
+    };
+  }
+
+  if (!params.operation || compact.missingRoots.length > 0) {
+    const missingRoots = compact.missingRoots.length > 0 ? compact.missingRoots : legacy.missingRoots;
+    throw new Error(
+      `No immutable public snapshot metadata found for context graph ${params.contextGraphId} share operation ${params.shareOperationId} roots: ${missingRoots.join(', ')}`,
+    );
+  }
+
+  throw new Error(
+    `No immutable public snapshot metadata found for context graph ${params.contextGraphId} share operation ${params.shareOperationId} roots: ${roots.join(', ')}`,
+  );
+}
+
+async function resolveCompactWorkspaceOperationPublicQuads(params: {
+  store: TripleStore;
+  graphManager: GraphManager;
+  contextGraphId: string;
+  shareOperationId: string;
+  roots: readonly string[];
+  subGraphName?: string;
+}): Promise<CompactWorkspaceOperationPublicSnapshot> {
+  const roots = normalizeRoots(params.roots);
+  const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, params.subGraphName);
+  const quads: Quad[] = [];
+  const publisherPeerIds: string[] = [];
+  const missingRoots: string[] = [];
+  const staleRoots: string[] = [];
+
+  for (const root of roots) {
+    const subject = workspaceOperationPublicSliceSubject(
+      params.contextGraphId,
+      params.shareOperationId,
+      root,
+      params.subGraphName,
+    );
+    const result = await params.store.query(
+      `SELECT ?digest ?count ?publisherPeerId WHERE {
+        GRAPH <${assertSafeIri(workspaceMetaGraph)}> {
+          <${assertSafeIri(subject)}> <${DKG}publicQuadsDigest> ?digest ;
+            <${DKG}publicQuadsCount> ?count .
+          OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?publisherPeerId }
+        }
+      } LIMIT 1`,
+    );
+
+    if (result.type !== 'bindings' || result.bindings.length === 0) {
+      missingRoots.push(root);
+      continue;
+    }
+
+    const expectedDigest = stripLiteral(result.bindings[0]?.['digest'])?.trim();
+    const expectedCount = parseIntegerLiteral(result.bindings[0]?.['count']);
+    if (!expectedDigest || !Number.isInteger(expectedCount)) {
+      missingRoots.push(root);
+      continue;
+    }
+
+    const currentQuads = await resolveWorkspaceSelection({
+      store: params.store,
+      graphManager: params.graphManager,
+      contextGraphId: params.contextGraphId,
+      selection: { rootEntities: [root] },
+      subGraphName: params.subGraphName,
+    });
+    const currentDigest = publicQuadsDigest(currentQuads);
+    if (currentDigest !== expectedDigest || currentQuads.length !== expectedCount) {
+      staleRoots.push(root);
+      continue;
+    }
+
+    quads.push(...currentQuads);
+    const publisherPeerId = stripLiteral(result.bindings[0]?.['publisherPeerId'])?.trim();
+    if (publisherPeerId) publisherPeerIds.push(publisherPeerId);
+  }
 
   return {
+    complete: missingRoots.length === 0 && staleRoots.length === 0,
+    missingRoots,
+    staleRoots,
     quads,
-    publisherPeerId: params.operation.publisherPeerId,
+    publisherPeerId: publisherPeerIds[0],
   };
 }
 
@@ -404,6 +521,31 @@ function parseStoredPublicQuads(value: string | undefined, shareOperationId: str
   });
 }
 
+function filterQuadsForRoot(quads: readonly Quad[], root: string): Quad[] {
+  return quads.filter((quad) => quad.subject === root || quad.subject.startsWith(`${root}/.well-known/genid/`));
+}
+
+function publicQuadsDigest(quads: readonly Quad[]): string {
+  const canonical = quads
+    .map((quad) => [quad.subject, quad.predicate, quad.object, ''])
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const hash = createHash('sha256');
+  hash.update(JSON.stringify(canonical));
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function lit(value: string): string {
+  return JSON.stringify(value);
+}
+
+function intLit(value: number): string {
+  return `"${value}"^^<${XSD}integer>`;
+}
+
+function dateLit(value: Date): string {
+  return `"${value.toISOString()}"^^<${XSD}dateTime>`;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -422,6 +564,11 @@ function stripLiteral(value: string | undefined): string | undefined {
     }
   }
   return value;
+}
+
+function parseIntegerLiteral(value: string | undefined): number {
+  const parsed = Number(stripLiteral(value));
+  return Number.isInteger(parsed) ? parsed : NaN;
 }
 
 function isPresent<T>(value: T | undefined): value is T {

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -3,6 +3,7 @@ import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-sto
 import { assertSafeIri, isSafeIri, validateSubGraphName } from '@origintrail-official/dkg-core';
 import type { LiftRequest } from './lift-job.js';
 import type { LiftResolvedPublishSlice } from './async-lift-publish-options.js';
+import { generateShareMetadata } from './metadata.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const PROV = 'http://www.w3.org/ns/prov#';
@@ -19,13 +20,20 @@ interface WorkspaceOperationPublicSnapshot {
   readonly publisherPeerId?: string;
 }
 
+interface LegacyWorkspaceOperationPublicSnapshot extends WorkspaceOperationPublicSnapshot {
+  readonly complete: boolean;
+  readonly missingRoots: string[];
+}
+
 export async function resolveWorkspaceSelection(params: {
   store: TripleStore;
   graphManager: GraphManager;
   contextGraphId: string;
   selection: WorkspaceSelection;
+  subGraphName?: string;
 }): Promise<Quad[]> {
-  const workspaceGraph = params.graphManager.workspaceGraphUri(params.contextGraphId);
+  const subGraphName = normalizeOptionalSubGraphName(params.subGraphName);
+  const workspaceGraph = params.graphManager.sharedMemoryUri(params.contextGraphId, subGraphName);
   const sparql = buildWorkspaceSelectionQuery(workspaceGraph, params.contextGraphId, params.selection);
   const result = await params.store.query(sparql);
   const quads: Quad[] = result.type === 'quads'
@@ -45,46 +53,41 @@ export async function storeWorkspaceOperationPublicQuads(params: {
   contextGraphId: string;
   shareOperationId: string;
   rootEntities: readonly string[];
+  // Retained for API compatibility; new metadata stores roots, not serialized payloads.
   quads: readonly Quad[];
   publisherPeerId?: string;
   subGraphName?: string;
+  timestamp?: Date;
 }): Promise<void> {
   const roots = normalizeRoots(params.rootEntities);
   if (roots.length === 0) return;
 
-  const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, params.subGraphName);
-  const publisherPeerId = params.publisherPeerId?.trim();
-  const stagedQuads: Quad[] = [];
+  const subGraphName = normalizeOptionalSubGraphName(params.subGraphName);
+  const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, subGraphName);
+  const operationSubject = workspaceOperationSubject(params.contextGraphId, params.shareOperationId);
 
   for (const root of roots) {
-    const subject = workspaceOperationPublicSliceSubject(
+    const legacySubject = workspaceOperationPublicSliceSubject(
       params.contextGraphId,
       params.shareOperationId,
       root,
-      params.subGraphName,
+      subGraphName,
     );
-    await params.store.deleteByPattern({ graph: workspaceMetaGraph, subject });
-
-    stagedQuads.push({
-      subject,
-      predicate: `${DKG}publicStagedQuads`,
-      object: JSON.stringify(JSON.stringify(selectQuadsForRoots(params.quads, [root]))),
-      graph: workspaceMetaGraph,
-    });
-
-    if (publisherPeerId) {
-      stagedQuads.push({
-        subject,
-        predicate: `${PROV}wasAttributedTo`,
-        object: JSON.stringify(publisherPeerId),
-        graph: workspaceMetaGraph,
-      });
-    }
+    await params.store.deleteByPattern({ graph: workspaceMetaGraph, subject: legacySubject });
   }
 
-  if (stagedQuads.length > 0) {
-    await params.store.insert(stagedQuads);
-  }
+  await params.store.deleteByPattern({ graph: workspaceMetaGraph, subject: operationSubject });
+  await params.store.insert(generateShareMetadata(
+    {
+      shareOperationId: params.shareOperationId,
+      contextGraphId: params.contextGraphId,
+      rootEntities: roots,
+      publisherPeerId: params.publisherPeerId?.trim() || 'unknown',
+      timestamp: params.timestamp ?? new Date(),
+      subGraphName,
+    },
+    workspaceMetaGraph,
+  ));
 }
 
 /**
@@ -178,6 +181,7 @@ export async function resolveLiftWorkspaceSlice(params: {
     shareOperationId,
     roots: requestedRoots,
     subGraphName,
+    operation,
   });
   const privateStore = new PrivateContentStore(params.store, params.graphManager);
   const privateQuads = (
@@ -210,7 +214,50 @@ async function resolveWorkspaceOperationPublicQuads(params: {
   shareOperationId: string;
   roots: readonly string[];
   subGraphName?: string;
+  operation?: ResolvedWorkspaceOperation;
 }): Promise<WorkspaceOperationPublicSnapshot> {
+  const roots = normalizeRoots(params.roots);
+  const legacy = await resolveLegacyWorkspaceOperationPublicQuads(params);
+  if (legacy.complete) {
+    if (legacy.quads.length === 0) {
+      throw new Error(
+        `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId}`,
+      );
+    }
+    return {
+      quads: legacy.quads,
+      publisherPeerId: legacy.publisherPeerId,
+    };
+  }
+
+  if (!params.operation) {
+    throw new Error(
+      `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId} roots: ${legacy.missingRoots.join(', ')}`,
+    );
+  }
+
+  const quads = await resolveWorkspaceSelection({
+    store: params.store,
+    graphManager: params.graphManager,
+    contextGraphId: params.contextGraphId,
+    selection: { rootEntities: roots },
+    subGraphName: params.subGraphName,
+  });
+
+  return {
+    quads,
+    publisherPeerId: params.operation.publisherPeerId,
+  };
+}
+
+async function resolveLegacyWorkspaceOperationPublicQuads(params: {
+  store: TripleStore;
+  graphManager: GraphManager;
+  contextGraphId: string;
+  shareOperationId: string;
+  roots: readonly string[];
+  subGraphName?: string;
+}): Promise<LegacyWorkspaceOperationPublicSnapshot> {
   const roots = normalizeRoots(params.roots);
   const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, params.subGraphName);
   const quads: Quad[] = [];
@@ -243,18 +290,9 @@ async function resolveWorkspaceOperationPublicQuads(params: {
     if (publisherPeerId) publisherPeerIds.push(publisherPeerId);
   }
 
-  if (missingRoots.length > 0) {
-    throw new Error(
-      `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId} roots: ${missingRoots.join(', ')}`,
-    );
-  }
-  if (quads.length === 0) {
-    throw new Error(
-      `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId}`,
-    );
-  }
-
   return {
+    complete: missingRoots.length === 0,
+    missingRoots,
     quads,
     publisherPeerId: publisherPeerIds[0],
   };
@@ -304,14 +342,6 @@ function buildWorkspaceSelectionQuery(
       )
     }
   }`;
-}
-
-function selectQuadsForRoots(quads: readonly Quad[], roots: readonly string[]): Quad[] {
-  return quads
-    .filter((quad) => roots.some((root) =>
-      quad.subject === root || quad.subject.startsWith(`${root}/.well-known/genid/`),
-    ))
-    .map((quad) => ({ ...quad, graph: '' }));
 }
 
 function normalizeRoots(roots: readonly string[]): string[] {

--- a/packages/publisher/test/async-lift-workspace.test.ts
+++ b/packages/publisher/test/async-lift-workspace.test.ts
@@ -107,6 +107,23 @@ describe('async lift workspace resolution', () => {
     if (payloads.type === 'bindings') {
       expect(payloads.bindings).toHaveLength(0);
     }
+
+    const fingerprints = await store.query(
+      `SELECT ?digest ?count WHERE {
+        GRAPH <${metaGraph}> {
+          ?s <${DKG}publicQuadsDigest> ?digest ;
+             <${DKG}publicQuadsCount> ?count .
+        }
+      }`,
+    );
+
+    expect(fingerprints.type).toBe('bindings');
+    if (fingerprints.type === 'bindings') {
+      expect(fingerprints.bindings).toHaveLength(2);
+      expect(fingerprints.bindings.every((row) => row['digest']?.includes('sha256:'))).toBe(true);
+      expect(JSON.stringify(fingerprints.bindings)).not.toContain('One');
+      expect(JSON.stringify(fingerprints.bindings)).not.toContain('Two');
+    }
   });
 
   it('resolves async lift payloads from the requested sub-graph partition', async () => {
@@ -215,6 +232,38 @@ describe('async lift workspace resolution', () => {
     expect(liveQuads).toEqual([
       { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
     ]);
+  });
+
+  it('rejects stale public resolution when a requested share operation has been superseded', async () => {
+    const privateStore = new PrivateContentStore(store, graphManager);
+    const secretPredicate = 'http://schema.org/secret';
+    const write1 = await publisher.share(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+    ], { publisherPeerId: 'peer1' });
+    await privateStore.storePrivateTriplesForOperation(CONTEXT_GRAPH, write1.shareOperationId, ENTITY, [
+      { subject: ENTITY, predicate: secretPredicate, object: '"first"', graph: '' },
+    ]);
+
+    await publisher.share(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+    ], { publisherPeerId: 'peer1' });
+
+    await expect(
+      resolveLiftWorkspaceSlice({
+        store,
+        graphManager,
+        request: {
+          swmId: 'swm-main',
+          shareOperationId: write1.shareOperationId,
+          roots: [ENTITY],
+          contextGraphId: CONTEXT_GRAPH,
+          namespace: 'aloha',
+          scope: 'person-profile',
+          transitionType: 'CREATE',
+          authority: { type: 'owner', proofRef: 'proof:owner:1' },
+        },
+      }),
+    ).rejects.toThrow(`Shared-memory operation ${write1.shareOperationId} no longer matches current public SWM data`);
   });
 
   it('keeps legacy publicStagedQuads metadata readable', async () => {

--- a/packages/publisher/test/async-lift-workspace.test.ts
+++ b/packages/publisher/test/async-lift-workspace.test.ts
@@ -1,15 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { GraphManager, OxigraphStore, PrivateContentStore } from '@origintrail-official/dkg-storage';
-import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
-import { ethers } from 'ethers';
 import { DKGPublisher, generateSubGraphRegistration } from '../src/index.js';
 import { resolveLiftWorkspaceSlice, resolveWorkspaceSelection } from '../src/workspace-resolution.js';
-import { createEVMAdapter, getSharedContext, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 
 const CONTEXT_GRAPH = 'test-workspace';
 const ENTITY = 'urn:test:entity:1';
 const ENTITY_2 = 'urn:test:entity:2';
+const DKG = 'http://dkg.io/ontology/';
+const PROV = 'http://www.w3.org/ns/prov#';
 
 describe('async lift workspace resolution', () => {
   let store: OxigraphStore;
@@ -18,15 +18,12 @@ describe('async lift workspace resolution', () => {
   beforeEach(async () => {
     store = new OxigraphStore();
     graphManager = new GraphManager(store);
-    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     const keypair = await generateEd25519Keypair();
     publisher = new DKGPublisher({
       store,
-      chain,
+      chain: new NoChainAdapter(),
       eventBus: new TypedEventBus(),
       keypair,
-      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
-      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
     });
   });
 
@@ -95,6 +92,23 @@ describe('async lift workspace resolution', () => {
     expect(resolved.publisherPeerId).toBe('peer1');
   });
 
+  it('does not store new public payload snapshots in shared-memory metadata', async () => {
+    await publisher.share(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+      { subject: ENTITY_2, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+    ], { publisherPeerId: 'peer1' });
+
+    const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+    const payloads = await store.query(
+      `SELECT ?payload WHERE { GRAPH <${metaGraph}> { ?s <${DKG}publicStagedQuads> ?payload } }`,
+    );
+
+    expect(payloads.type).toBe('bindings');
+    if (payloads.type === 'bindings') {
+      expect(payloads.bindings).toHaveLength(0);
+    }
+  });
+
   it('resolves async lift payloads from the requested sub-graph partition', async () => {
     const subGraphName = 'research';
     const privateStore = new PrivateContentStore(store, graphManager);
@@ -151,7 +165,7 @@ describe('async lift workspace resolution', () => {
     ]);
   });
 
-  it('resolves public and private async lift payloads by shareOperationId instead of combining root history', async () => {
+  it('resolves public and private async lift payloads for the current share operation', async () => {
     const privateStore = new PrivateContentStore(store, graphManager);
     const secretPredicate = 'http://schema.org/secret';
     const write1 = await publisher.share(CONTEXT_GRAPH, [
@@ -174,7 +188,7 @@ describe('async lift workspace resolution', () => {
       graphManager,
       request: {
         swmId: 'swm-main',
-        shareOperationId: write1.shareOperationId,
+        shareOperationId: write2.shareOperationId,
         roots: [ENTITY],
         contextGraphId: CONTEXT_GRAPH,
         namespace: 'aloha',
@@ -185,10 +199,10 @@ describe('async lift workspace resolution', () => {
     });
 
     expect(resolved.quads).toEqual([
-      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
     ]);
     expect(resolved.privateQuads).toEqual([
-      { subject: ENTITY, predicate: secretPredicate, object: '"first"', graph: '' },
+      { subject: ENTITY, predicate: secretPredicate, object: '"second"', graph: '' },
     ]);
     expect(resolved.publisherPeerId).toBe('peer1');
 
@@ -201,6 +215,80 @@ describe('async lift workspace resolution', () => {
     expect(liveQuads).toEqual([
       { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
     ]);
+  });
+
+  it('keeps legacy publicStagedQuads metadata readable', async () => {
+    const shareOperationId = 'legacy-op-1';
+    const legacyQuads = [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Legacy"', graph: '' },
+    ];
+    const legacySubject = `urn:dkg:public-stage:${[
+      CONTEXT_GRAPH,
+      '_',
+      shareOperationId,
+      ENTITY,
+    ].map((part) => encodeURIComponent(part)).join(':')}`;
+    const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+
+    await store.insert([
+      {
+        subject: legacySubject,
+        predicate: `${DKG}publicStagedQuads`,
+        object: JSON.stringify(JSON.stringify(legacyQuads)),
+        graph: metaGraph,
+      },
+      {
+        subject: legacySubject,
+        predicate: `${PROV}wasAttributedTo`,
+        object: JSON.stringify('legacy-peer'),
+        graph: metaGraph,
+      },
+    ]);
+
+    const resolved = await resolveLiftWorkspaceSlice({
+      store,
+      graphManager,
+      request: {
+        swmId: 'swm-main',
+        shareOperationId,
+        roots: [ENTITY],
+        contextGraphId: CONTEXT_GRAPH,
+        namespace: 'aloha',
+        scope: 'person-profile',
+        transitionType: 'CREATE',
+        authority: { type: 'owner', proofRef: 'proof:owner:1' },
+      },
+    });
+
+    expect(resolved.quads).toEqual(legacyQuads);
+    expect(resolved.publisherPeerId).toBe('legacy-peer');
+  });
+
+  it('does not duplicate large public literals into metadata', async () => {
+    const marker = 'large-public-literal-marker';
+    const largeValue = `${marker}-${'x'.repeat(512 * 1024)}`;
+
+    await publisher.share(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: JSON.stringify(largeValue), graph: '' },
+    ], { publisherPeerId: 'peer1' });
+
+    const swmGraph = graphManager.sharedMemoryUri(CONTEXT_GRAPH);
+    const swmResult = await store.query(
+      `SELECT ?o WHERE { GRAPH <${swmGraph}> { <${ENTITY}> <http://schema.org/name> ?o } } LIMIT 1`,
+    );
+    expect(swmResult.type).toBe('bindings');
+    if (swmResult.type === 'bindings') {
+      expect(swmResult.bindings[0]?.['o']).toContain(marker);
+    }
+
+    const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+    const metaResult = await store.query(
+      `SELECT ?o WHERE { GRAPH <${metaGraph}> { ?s ?p ?o } }`,
+    );
+    expect(metaResult.type).toBe('bindings');
+    if (metaResult.type === 'bindings') {
+      expect(JSON.stringify(metaResult.bindings)).not.toContain(marker);
+    }
   });
 
   it('carries Lift request access policy into resolved publish options', async () => {

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -323,6 +323,26 @@ describe('generateShareMetadata', () => {
     expect(preds).toContain(`${DKG}publishedAt`);
     expect(preds).toContain('http://www.w3.org/ns/prov#wasAttributedTo');
   });
+
+  it('includes compact operation reference fields', () => {
+    const quads = generateShareMetadata({ ...wsMeta, subGraphName: 'research' }, wsGraph);
+    expect(quads).toContainEqual(expect.objectContaining({
+      predicate: `${DKG}contextGraphId`,
+      object: `"${CONTEXT_GRAPH}"`,
+    }));
+    expect(quads).toContainEqual(expect.objectContaining({
+      predicate: `${DKG}shareOperationId`,
+      object: '"op-123"',
+    }));
+    expect(quads).toContainEqual(expect.objectContaining({
+      predicate: `${DKG}publisherPeerId`,
+      object: '"12D3KooWTestPeer"',
+    }));
+    expect(quads).toContainEqual(expect.objectContaining({
+      predicate: `${DKG}subGraphName`,
+      object: '"research"',
+    }));
+  });
 });
 
 describe('generateAuthorshipProof', () => {


### PR DESCRIPTION
# Fix SWM Large Payload Storage Amplification

## Summary

This change fixes Shared Working Memory large-payload storage amplification.
Before this fix, each public SWM payload was stored twice per node:

1. Once as normal RDF quads in the SWM data graph.
2. Again as a JSON-stringified RDF literal in SWM metadata through
   `dkg:publicStagedQuads`.

For large replicated writes this doubled the effective Oxigraph payload and
pushed the WASM store into memory failures. In the reproduced benchmark, the
duplicated path failed around `202.5 MiB/store` with:

```text
RuntimeError: unreachable
Store.load(...)
```

After that failure, later queries could also fail with:

```text
table index is out of bounds
```

The fix replaces full-payload metadata snapshots with compact operation
metadata. New SWM writes store only references and provenance in
`_shared_memory_meta`, while the public payload remains in the SWM data graph.
Legacy metadata records that already contain `dkg:publicStagedQuads` remain
readable.

## Problem

The old SWM share path made metadata carry the entire public payload:

```mermaid
flowchart TD
  A["Client writes public SWM quads"] --> B["Store quads in SWM graph"]
  A --> C["Serialize same quads as JSON"]
  C --> D["Store JSON string as dkg:publicStagedQuads literal"]
  B --> E["Oxigraph stores payload copy 1"]
  D --> F["Oxigraph stores payload copy 2"]
  E --> G["Large payload memory pressure"]
  F --> G
```

That metadata snapshot was useful for later lift/share resolution, but it made
the storage model scale with approximately `2x payload size` per node. The
failure was reproduced without private mode and without Sender Key encryption,
so the root cause was public SWM metadata amplification.

## New Model

New SWM writes store compact share-operation metadata:

- context graph id
- optional subgraph name
- share operation id
- root entities
- publisher peer id
- published timestamp

The public payload is not serialized into metadata. Resolution reconstructs the
operation payload by reading the current SWM graph for the operation roots.

```mermaid
flowchart TD
  A["Client writes public SWM quads"] --> B["Store quads in SWM graph"]
  A --> C["Generate compact metadata"]
  C --> D["dkg:shareOperationId"]
  C --> E["dkg:rootEntity"]
  C --> F["dkg:publisherPeerId"]
  C --> G["dkg:publishedAt"]
  C --> H["dkg:contextGraphId"]
  C --> I["optional dkg:subGraphName"]
  B --> J["Single payload copy in Oxigraph"]
  D --> K["Small operation reference metadata"]
  E --> K
  F --> K
  G --> K
  H --> K
  I --> K
```

## Write Path

The SWM write path still persists and gossips the public payload normally. The
change is only in the metadata generated for the operation.

```mermaid
sequenceDiagram
  participant Client
  participant API as DKG API
  participant Publisher as DKGPublisher
  participant Store as Triple Store
  participant Gossip as SWM Gossip

  Client->>API: POST /api/shared-memory/write
  API->>Publisher: share(contextGraphId, quads, subGraphName?)
  Publisher->>Store: store public quads in SWM graph
  Publisher->>Store: store compact share metadata
  Publisher->>Gossip: broadcast SWM operation
  Gossip-->>API: operation propagated to peers
  API-->>Client: shareOperationId
```

The important behavior change is this:

```text
New writes no longer emit:
  <share-operation> dkg:publicStagedQuads "<serialized full payload>"
```

Instead they emit compact metadata that points to roots already present in the
SWM data graph.

## Resolution Path

Lift/share resolution now resolves the public payload from the graph itself
when compact metadata is present.

```mermaid
flowchart TD
  A["Lift request contains shareOperationId"] --> B["Read share operation metadata"]
  B --> C{"Legacy dkg:publicStagedQuads present?"}
  C -->|Yes| D["Parse legacy serialized quad snapshot"]
  C -->|No| E["Read root entities from metadata"]
  E --> F["Query current SWM graph for those roots"]
  F --> G["Return public quads for operation"]
  D --> G
  G --> H["Build lift request payload"]
```

For compact metadata, the resolver validates the operation roots and then reads
the public quads from the current SWM graph. This keeps new writes small while
preserving the ability to lift and publish shared-memory content.

## Legacy Compatibility

Existing stores may already contain `dkg:publicStagedQuads`. Those records still
work. The compatibility rule is:

```mermaid
flowchart LR
  A["Existing metadata record"] --> B{"Has dkg:publicStagedQuads?"}
  B -->|Yes| C["Use legacy serialized snapshot"]
  B -->|No| D["Use compact root metadata"]
  C --> E["Resolved public quads"]
  D --> E
```

This means the fix is forward-looking for new writes, while old metadata remains
readable and does not need a migration before use.

## Benchmark

This PR adds a reusable live benchmark:

```bash
pnpm bench:swm-large-payload -- \
  --ports 19101,19102,19103,19104,19105 \
  --payload-mib-per-node 100 \
  --chunk-mib 0.5 \
  --output bench/results/swm-large-payload-500mib.json
```

The benchmark:

1. Writes large public SWM literals through each configured node.
2. Polls every node until all benchmark payloads are queryable.
3. Checks per-run metadata for `shareOperationId`, `rootEntity`,
   `publisherPeerId`, and `publishedAt`.
4. Verifies `dkg:publicStagedQuads` did not grow.
5. Optionally scans appended daemon logs for known Oxigraph and GossipSub
   failure signatures.

```mermaid
sequenceDiagram
  participant Bench as Benchmark
  participant N1 as Node 1
  participant N2 as Node 2
  participant N3 as Node 3
  participant N4 as Node 4
  participant N5 as Node 5

  Bench->>N1: write 100 MiB in chunks
  Bench->>N2: write 100 MiB in chunks
  Bench->>N3: write 100 MiB in chunks
  Bench->>N4: write 100 MiB in chunks
  Bench->>N5: write 100 MiB in chunks

  N1-->>N2: gossip SWM operations
  N1-->>N3: gossip SWM operations
  N2-->>N4: gossip SWM operations
  N3-->>N5: gossip SWM operations
  N4-->>N1: gossip SWM operations
  N5-->>N2: gossip SWM operations

  loop Until every node converges
    Bench->>N1: count benchmark payloads
    Bench->>N2: count benchmark payloads
    Bench->>N3: count benchmark payloads
    Bench->>N4: count benchmark payloads
    Bench->>N5: count benchmark payloads
  end

  Bench->>N1: verify compact metadata
  Bench->>N2: verify compact metadata
  Bench->>N3: verify compact metadata
  Bench->>N4: verify compact metadata
  Bench->>N5: verify compact metadata
```

The reproduced 5-node regression case used `5 x 100 MiB = 500 MiB` total. With
the compact metadata model, all five nodes converged with:

```text
payload quads:        1000 per node
dkg:publicStagedQuads: 0 per node
shareOperationIds:    1000 per node
rootEntities:         1000 per node
```

No Oxigraph failure signatures were observed:

```text
RuntimeError: unreachable
table index is out of bounds
```

## Files Changed

- `packages/publisher/src/workspace-resolution.ts`
  - Stops writing new full-payload `dkg:publicStagedQuads` metadata snapshots.
  - Resolves compact share operations by reading root-scoped public quads from
    the SWM graph.
  - Keeps legacy snapshot reads for existing metadata.

- `packages/publisher/src/metadata.ts`
  - Extends share metadata with compact operation fields.
  - Emits `dkg:publishedAt`, `dkg:shareOperationId`, `dkg:rootEntity`,
    `dkg:publisherPeerId`, `dkg:contextGraphId`, and optional
    `dkg:subGraphName`.

- `packages/publisher/src/dkg-publisher.ts`
  - Routes SWM share metadata generation through the compact metadata helper.

- `packages/publisher/src/workspace-handler.ts`
  - Applies the same compact metadata model for received SWM operations.

- `packages/publisher/test/async-lift-workspace.test.ts`
  - Covers compact share-operation resolution.
  - Covers legacy `dkg:publicStagedQuads` compatibility.
  - Covers large literal writes without metadata payload duplication.

- `packages/publisher/test/metadata.test.ts`
  - Covers the new compact share metadata shape.

- `packages/cli/scripts/swm-large-payload-benchmark.cjs`
  - Adds the reusable live multi-node SWM payload benchmark.

- `packages/cli/test/swm-large-payload-benchmark.test.ts`
  - Covers benchmark argument parsing, chunk planning, and generated payload
    sizing.

- `packages/cli/README.md`
  - Documents the benchmark and the 5-node 500 MiB regression command.

## Validation

Focused validation run for this change:

```bash
pnpm --filter @origintrail-official/dkg exec vitest run test/swm-large-payload-benchmark.test.ts
```

Additional validation performed during the fix:

```bash
git diff --check
```

Live benchmark validation:

```bash
pnpm bench:swm-large-payload -- \
  --ports 19101,19102,19103,19104,19105 \
  --payload-mib-per-node 100 \
  --chunk-mib 0.5 \
  --auth-token <token> \
  --output bench/results/swm-large-payload-500mib.json
```

The full 500 MiB run verified that each node could query all benchmark payloads
and that `dkg:publicStagedQuads` remained at zero for the new writes.
