### PR TITLE
Fix Telegram chat turn persistence after stale cursor state

### DIFF
--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -875,13 +875,6 @@ export class ChatTurnWriter {
         );
         pairs.splice(0, dropped);
       }
-      this.logExternalMarkerStateBeforeW4aPersist(
-        sessionId,
-        externalCursorKey,
-        typedW4bCursorKeys,
-        savedUpTo,
-        pairs,
-      );
       // Persist sequentially so a transient failure on pair N leaves the
       // watermark at N-1 and the next agent_end call retries from the same
       // point. Without sequencing, a failed middle pair could be skipped
@@ -894,7 +887,6 @@ export class ChatTurnWriter {
           const laterExactExternalMarker = externalCursorKey
             ? this.hasExternalTurnMarkerInLaterPairs(externalCursorKey, pairs, i + 1)
             : false;
-          const allowOrderedFallback = i < lastIdx && !laterExactExternalMarker;
           const externalMarkerAction = externalCursorKey
             ? this.consumeExternalTurnMarkersForPair(
               externalCursorKey,
@@ -902,22 +894,9 @@ export class ChatTurnWriter {
               user,
               assistant,
               externalDirect,
-              allowOrderedFallback,
+              i < lastIdx && !laterExactExternalMarker,
             )
             : { skip: false, markers: [], rollbackMarkers: [] };
-          this.logExternalMarkerPerPair(
-            sessionId,
-            externalCursorKey,
-            i,
-            lastIdx,
-            pairIndex,
-            user,
-            externalTurnIds,
-            externalDirect,
-            laterExactExternalMarker,
-            allowOrderedFallback,
-            externalMarkerAction,
-          );
           if (externalCursorKey && externalMarkerAction.markers.length > 0) {
             const watermarkSnapshot = this.snapshotWatermarkState(sessionId);
             if (externalMarkerAction.skip) this.bumpWatermark(sessionId, pairIndex);
@@ -3196,58 +3175,6 @@ export class ChatTurnWriter {
       this.externalTurnMarkers.delete(sessionKeyCursor);
     }
     return true;
-  }
-
-  private logExternalMarkerStateBeforeW4aPersist(
-    sessionId: string,
-    externalCursorKey: string | undefined,
-    typedW4bCursorKeys: string[],
-    savedUpTo: number,
-    pairs: ComputedChatTurnPair[],
-  ): void {
-    if (!this.logger.info) return;
-    const bucket = externalCursorKey ? this.externalTurnMarkers.get(externalCursorKey) : undefined;
-    const allBucketKeys = Array.from(this.externalTurnMarkers.keys());
-    this.logger.info(
-      `[ChatTurnWriter:w4a-pre-persist] sessionId=${sessionId} ` +
-      `externalCursorKey=${externalCursorKey ?? '<none>'} ` +
-      `markerBucketSize=${bucket?.size ?? 0} ` +
-      `allBucketKeys=${JSON.stringify(allBucketKeys)} ` +
-      `typedW4bCursorKeys=${JSON.stringify(typedW4bCursorKeys)} ` +
-      `savedUpTo=${savedUpTo} pairs=${pairs.length}`,
-    );
-  }
-
-  private logExternalMarkerPerPair(
-    sessionId: string,
-    externalCursorKey: string | undefined,
-    loopIndex: number,
-    lastIdx: number,
-    pairIndex: number,
-    user: string,
-    externalTurnIds: string[],
-    externalDirect: boolean,
-    laterExactExternalMarker: boolean,
-    allowOrderedFallback: boolean,
-    action: ExternalMarkerAction,
-  ): void {
-    if (!this.logger.info) return;
-    const preview = typeof user === 'string' ? user.slice(0, 80) : '';
-    const orderedAvailable = externalCursorKey
-      ? (this.externalTurnMarkers.get(externalCursorKey)?.get(ChatTurnWriter.EXTERNAL_ORDERED_TURN_MARKER) ?? 0) > 0
-      : false;
-    this.logger.info(
-      `[ChatTurnWriter:w4a-pair] sessionId=${sessionId} ` +
-      `loopIndex=${loopIndex}/${lastIdx} pairIndex=${pairIndex} ` +
-      `externalDirect=${externalDirect} ` +
-      `externalTurnIds=${JSON.stringify(externalTurnIds)} ` +
-      `laterExactMarker=${laterExactExternalMarker} ` +
-      `allowOrderedFallback=${allowOrderedFallback} ` +
-      `orderedAvailable=${orderedAvailable} ` +
-      `markerSkip=${action.skip} ` +
-      `markersConsumed=${JSON.stringify(action.markers)} ` +
-      `userPreview=${JSON.stringify(preview)}`,
-    );
   }
 
   private restoreExternalTurnMarker(sessionKeyCursor: string, marker: string): void {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1338,6 +1338,11 @@ export class ChatTurnWriter {
       // N turns" no longer maps to the new pair indices. Leaving stale
       // count would skip new pairs in `computeDelta`.
       this.w4bSessionCounts.delete(sessionId);
+      // `runReset` includes `identity.externalCursorKey` in the iteration
+      // set so this call is meaningful only when the loop reaches an
+      // entry of `openclaw:transcript:<sk>` shape; for composed session
+      // ids it's a no-op. The coupling is intentional but easy to miss
+      // when refactoring `runReset` later — keep them in sync.
       this.clearExternalOrderedTurnMarker(sessionId);
       this.markDurableCursorKeyTrusted(sessionId);
     }
@@ -2429,8 +2434,16 @@ export class ChatTurnWriter {
           );
         }
       }
+      // Mark every non-stale key trusted, including external cursor keys.
+      // Re-validation runs again only when an explicit lifecycle event
+      // (disk load, legacy migration, client swap) flags the key untrusted
+      // through `markDurableCursorKeyUntrusted`. Without this, every
+      // subsequent `onAgentEnd` for a session that owns durable transcript
+      // markers would re-issue the 2-query `getChatTurnStoreStatus` round
+      // trip on the hot Telegram persistence path — and re-validation
+      // doesn't actually verify per-marker content against daemon data,
+      // so the only thing the perpetual untrusted state cost was latency.
       for (const key of untrustedKeys) {
-        if (externalCursorKeys.includes(key) && status.hasAnyChatTurnData) continue;
         if (!staleKeys.has(key)) this.markDurableCursorKeyTrusted(key);
       }
     } catch (err) {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1179,19 +1179,31 @@ export class ChatTurnWriter {
   }): Promise<void> {
     const externalCursorKey = this.externalCursorKeyFromSessionKey(opts.sessionKey);
     const markerUsers = this.uniqueStrings([opts.user, ...(opts.userAliases ?? [])]);
-    const markers = this.uniqueStrings([
-      ChatTurnWriter.EXTERNAL_ORDERED_TURN_MARKER,
-      ...markerUsers.flatMap((user) => [
+    const contentMarkers = this.uniqueStrings(
+      markerUsers.flatMap((user) => [
         this.externalTurnMarkerId(opts.turnId, user, opts.assistant),
         this.externalTurnUserMarkerId(opts.turnId, user),
-      ]),
-    ].filter(Boolean));
-    if (!externalCursorKey || markers.length === 0) return;
-    const previousMarkerCounts = markers.map((marker) => ({
+      ]).filter(Boolean),
+    );
+    const orderedMarker = ChatTurnWriter.EXTERNAL_ORDERED_TURN_MARKER;
+    const allMarkers = [orderedMarker, ...contentMarkers];
+    if (!externalCursorKey) return;
+    const previousMarkerCounts = allMarkers.map((marker) => ({
       marker,
       count: this.externalTurnMarkers.get(externalCursorKey)?.get(marker) ?? 0,
     }));
-    for (const marker of markers) {
+    // The ordered marker is a one-shot ticket per direct persist; W4a
+    // consumes it (count - 1) when a historical non-latest pair has no
+    // exact/user marker. N direct persists must accumulate N tickets so
+    // N metadata-stripped UI backfill pairs can each be skipped. Live
+    // smoke (UI3 -> first Telegram) showed Math.max collapsing the
+    // count to 1 even after multiple UI persists, so only the first
+    // historical UI pair was skipped and the rest re-persisted as
+    // duplicates. Content-bound exact/user markers remain idempotent
+    // (Math.max) because identical (turnId + content) is the same
+    // daemon-success fact across replays.
+    this.incrementOrderedExternalTurnMarker(externalCursorKey);
+    for (const marker of contentMarkers) {
       this.restoreExternalTurnMarker(externalCursorKey, marker);
     }
     if (!this.commitWatermarkStateSync(externalCursorKey)) {
@@ -1200,6 +1212,14 @@ export class ChatTurnWriter {
       }
       throw new Error("Failed to write external chat-turn marker");
     }
+  }
+
+  private incrementOrderedExternalTurnMarker(sessionKeyCursor: string): void {
+    this.bumpDurableCursorKeyRevision(sessionKeyCursor);
+    const bucket = this.externalTurnMarkers.get(sessionKeyCursor) ?? new Map<string, number>();
+    const marker = ChatTurnWriter.EXTERNAL_ORDERED_TURN_MARKER;
+    bucket.set(marker, (bucket.get(marker) ?? 0) + 1);
+    this.externalTurnMarkers.set(sessionKeyCursor, bucket);
   }
 
   private restoreFailedMigrationDestination(

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -875,6 +875,13 @@ export class ChatTurnWriter {
         );
         pairs.splice(0, dropped);
       }
+      this.logExternalMarkerStateBeforeW4aPersist(
+        sessionId,
+        externalCursorKey,
+        typedW4bCursorKeys,
+        savedUpTo,
+        pairs,
+      );
       // Persist sequentially so a transient failure on pair N leaves the
       // watermark at N-1 and the next agent_end call retries from the same
       // point. Without sequencing, a failed middle pair could be skipped
@@ -887,6 +894,7 @@ export class ChatTurnWriter {
           const laterExactExternalMarker = externalCursorKey
             ? this.hasExternalTurnMarkerInLaterPairs(externalCursorKey, pairs, i + 1)
             : false;
+          const allowOrderedFallback = i < lastIdx && !laterExactExternalMarker;
           const externalMarkerAction = externalCursorKey
             ? this.consumeExternalTurnMarkersForPair(
               externalCursorKey,
@@ -894,9 +902,22 @@ export class ChatTurnWriter {
               user,
               assistant,
               externalDirect,
-              i < lastIdx && !laterExactExternalMarker,
+              allowOrderedFallback,
             )
             : { skip: false, markers: [], rollbackMarkers: [] };
+          this.logExternalMarkerPerPair(
+            sessionId,
+            externalCursorKey,
+            i,
+            lastIdx,
+            pairIndex,
+            user,
+            externalTurnIds,
+            externalDirect,
+            laterExactExternalMarker,
+            allowOrderedFallback,
+            externalMarkerAction,
+          );
           if (externalCursorKey && externalMarkerAction.markers.length > 0) {
             const watermarkSnapshot = this.snapshotWatermarkState(sessionId);
             if (externalMarkerAction.skip) this.bumpWatermark(sessionId, pairIndex);
@@ -3155,6 +3176,58 @@ export class ChatTurnWriter {
       this.externalTurnMarkers.delete(sessionKeyCursor);
     }
     return true;
+  }
+
+  private logExternalMarkerStateBeforeW4aPersist(
+    sessionId: string,
+    externalCursorKey: string | undefined,
+    typedW4bCursorKeys: string[],
+    savedUpTo: number,
+    pairs: ComputedChatTurnPair[],
+  ): void {
+    if (!this.logger.info) return;
+    const bucket = externalCursorKey ? this.externalTurnMarkers.get(externalCursorKey) : undefined;
+    const allBucketKeys = Array.from(this.externalTurnMarkers.keys());
+    this.logger.info(
+      `[ChatTurnWriter:w4a-pre-persist] sessionId=${sessionId} ` +
+      `externalCursorKey=${externalCursorKey ?? '<none>'} ` +
+      `markerBucketSize=${bucket?.size ?? 0} ` +
+      `allBucketKeys=${JSON.stringify(allBucketKeys)} ` +
+      `typedW4bCursorKeys=${JSON.stringify(typedW4bCursorKeys)} ` +
+      `savedUpTo=${savedUpTo} pairs=${pairs.length}`,
+    );
+  }
+
+  private logExternalMarkerPerPair(
+    sessionId: string,
+    externalCursorKey: string | undefined,
+    loopIndex: number,
+    lastIdx: number,
+    pairIndex: number,
+    user: string,
+    externalTurnIds: string[],
+    externalDirect: boolean,
+    laterExactExternalMarker: boolean,
+    allowOrderedFallback: boolean,
+    action: ExternalMarkerAction,
+  ): void {
+    if (!this.logger.info) return;
+    const preview = typeof user === 'string' ? user.slice(0, 80) : '';
+    const orderedAvailable = externalCursorKey
+      ? (this.externalTurnMarkers.get(externalCursorKey)?.get(ChatTurnWriter.EXTERNAL_ORDERED_TURN_MARKER) ?? 0) > 0
+      : false;
+    this.logger.info(
+      `[ChatTurnWriter:w4a-pair] sessionId=${sessionId} ` +
+      `loopIndex=${loopIndex}/${lastIdx} pairIndex=${pairIndex} ` +
+      `externalDirect=${externalDirect} ` +
+      `externalTurnIds=${JSON.stringify(externalTurnIds)} ` +
+      `laterExactMarker=${laterExactExternalMarker} ` +
+      `allowOrderedFallback=${allowOrderedFallback} ` +
+      `orderedAvailable=${orderedAvailable} ` +
+      `markerSkip=${action.skip} ` +
+      `markersConsumed=${JSON.stringify(action.markers)} ` +
+      `userPreview=${JSON.stringify(preview)}`,
+    );
   }
 
   private restoreExternalTurnMarker(sessionKeyCursor: string, marker: string): void {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -10,11 +10,17 @@ import {
 
 /**
  * Durable direct-channel marker lifecycle:
- * `markExternalTurnPersistedDurable` creates content-bound markers only after
- * channel-side daemon `storeChatTurn` succeeds; marker keys include `turnId`
- * plus canonical user/assistant text to avoid false dedupe for reused IDs or
- * content. W4a matches them in `consumeExternalTurnMarkersForPair` during
- * `runAgentEndPersist`, advancing pair watermarks only after durable commit.
+ * `markExternalTurnPersistedDurable` creates markers only after channel-side
+ * daemon `storeChatTurn` succeeds; exact marker keys include `turnId` plus
+ * canonical user/assistant text to avoid false dedupe for reused IDs or
+ * content. Direct-channel transcripts also get a `turnId` + canonical user-body
+ * marker because OpenClaw can retain a rendered assistant shape that differs
+ * from the final daemon-persisted text, plus one ordered marker for later
+ * transcripts that have stripped direct-channel metadata entirely. W4a
+ * matches them in
+ * `consumeExternalTurnMarkersForPair` during `runAgentEndPersist`, advancing
+ * pair watermarks only after durable commit; the ordered fallback is limited
+ * to historical non-latest pairs so it cannot drop the live Telegram turn.
  * Create failures roll back marker snapshots when `commitWatermarkStateSync`
  * fails; `setStateDir` migrates per-session `m`
  * markers, and graceful `DkgChannelPlugin.stop()` drains in-flight first writes.
@@ -67,7 +73,7 @@ interface ComputedChatTurnPair {
 interface ExternalMarkerAction {
   skip: boolean;
   markers: string[];
-  rollbackMarkers: string[];
+  rollbackMarkers: Array<{ marker: string; count: number }>;
 }
 
 interface WatermarkStateSnapshot {
@@ -80,6 +86,23 @@ interface LegacyMergeSource {
   markerKey: string;
   contentHash: string;
   watermarkFilePath: string;
+}
+
+interface ChatTurnStoreStatus {
+  hasAnyChatTurnData: boolean;
+  existingSessionIds: string[];
+}
+
+interface ChatTurnStoreStatusClient {
+  getChatTurnStoreStatus?: (sessionIds: string[]) => Promise<ChatTurnStoreStatus>;
+}
+
+interface DurableCursorKeySnapshot {
+  cachedWatermark?: number;
+  pendingIndex?: number;
+  w4bCount?: number;
+  markers: Map<string, number>;
+  revision: number;
 }
 
 /**
@@ -194,6 +217,12 @@ export class ChatTurnWriter {
   // skip exactly those already-persisted UI pairs across restarts without
   // confusing two legitimate same-content turns.
   private externalTurnMarkers: Map<string, Map<string, number>> = new Map();
+  private static readonly EXTERNAL_ORDERED_TURN_MARKER = "__external_ordered_turns__";
+  // Cursor facts loaded from disk (active or migrated legacy watermark files)
+  // are only local claims. Before W4a lets those facts suppress a fresh
+  // Telegram `agent_end`, validate them against the daemon's chat-turn store.
+  private untrustedDaemonCursorKeys: Set<string> = new Set();
+  private durableCursorKeyRevisions: Map<string, number> = new Map();
   // In-flight persist tracking — `resetSessionState()` awaits these so a
   // pre-reset persist can't advance the just-reset watermark afterward.
   // Both W4a (`onAgentEnd`) and W4b (`onMessageSent`) MUST register their
@@ -287,6 +316,7 @@ export class ChatTurnWriter {
 
   setClient(client: any): void {
     this.client = client;
+    this.markAllDurableCursorKeysUntrusted();
   }
 
   /**
@@ -501,6 +531,7 @@ export class ChatTurnWriter {
         const data = JSON.parse(content);
         if (data && typeof data === "object") {
           for (const [key, val] of Object.entries(data)) {
+            let loadedCursorState = false;
             // T17 — Two formats supported for backward compat:
             //   * Number `5`             → legacy: watermark only
             //   * Object `{ w: 5, b: 3 }` → watermark + W4b session count
@@ -512,13 +543,16 @@ export class ChatTurnWriter {
             // backfill — daemon-side duplicate writes.
             if (typeof val === "number") {
               this.cachedWatermarks.set(key, val);
+              loadedCursorState = true;
             } else if (val && typeof val === "object") {
               const obj = val as { w?: unknown; b?: unknown; m?: unknown };
               if (typeof obj.w === "number") {
                 this.cachedWatermarks.set(key, obj.w);
+                loadedCursorState = true;
               }
               if (typeof obj.b === "number") {
                 this.w4bSessionCounts.set(key, obj.b);
+                loadedCursorState = true;
               }
               if (obj.m && typeof obj.m === "object" && !Array.isArray(obj.m)) {
                 const markers = new Map<string, number>();
@@ -529,9 +563,11 @@ export class ChatTurnWriter {
                 }
                 if (markers.size > 0) {
                   this.externalTurnMarkers.set(key, markers);
+                  loadedCursorState = true;
                 }
               }
             }
+            if (loadedCursorState) this.markDurableCursorKeyUntrusted(key);
           }
         }
       }
@@ -708,26 +744,32 @@ export class ChatTurnWriter {
     const data = JSON.parse(content);
     if (!data || typeof data !== "object") return;
     for (const [key, val] of Object.entries(data)) {
+      let loadedCursorState = false;
       if (typeof val === "number") {
         targetWm.set(key, Math.max(targetWm.get(key) ?? -1, val));
         mirrorWm?.set(key, val);
+        loadedCursorState = true;
       } else if (val && typeof val === "object") {
         const obj = val as { w?: unknown; b?: unknown; m?: unknown };
         if (typeof obj.w === "number") {
           targetWm.set(key, Math.max(targetWm.get(key) ?? -1, obj.w));
           mirrorWm?.set(key, obj.w);
+          loadedCursorState = true;
         }
         if (typeof obj.b === "number") {
           targetBc.set(key, Math.max(targetBc.get(key) ?? 0, obj.b));
           mirrorBc?.set(key, obj.b);
+          loadedCursorState = true;
         }
         if (obj.m && typeof obj.m === "object" && !Array.isArray(obj.m)) {
           this.mergeExternalTurnMarkers(targetMarkers, key, obj.m as Record<string, unknown>);
           if (mirrorMarkers) {
             this.mergeExternalTurnMarkers(mirrorMarkers, key, obj.m as Record<string, unknown>);
           }
+          loadedCursorState = true;
         }
       }
+      if (loadedCursorState) this.markDurableCursorKeyUntrusted(key);
     }
   }
 
@@ -801,9 +843,14 @@ export class ChatTurnWriter {
       // after the upgrade would otherwise treat every prior pair as
       // unsaved backfill and re-persist it. Using the W4b count as a
       // floor ensures `computeDelta` skips those.
-      const w4aWatermark = this.loadWatermark(sessionId);
-      const w4bCount = this.w4bSessionCounts.get(sessionId) ?? 0;
-      const savedUpTo = Math.max(w4aWatermark, w4bCount - 1);
+      await this.validateUntrustedDurableCursorsBeforeW4a(
+        sessionId,
+        externalCursorKey,
+        typedW4bCursorKeys,
+        w4bInflightSessionIds,
+        w4aCrossPathSessionIds,
+      );
+      const savedUpTo = this.savedUpToForSession(sessionId);
       const pairs = this.computeDelta(event.messages, savedUpTo);
       if (pairs.length === 0) return;
       // T362 — Cold-start clamp. When no prior watermark exists for this
@@ -835,14 +882,19 @@ export class ChatTurnWriter {
       const lastIdx = pairs.length - 1;
       const job = this.trackPersistJob(sessionId, async () => {
         for (let i = 0; i < pairs.length; i++) {
-          const { user, assistant, pairIndex, externalTurnIds, messageIds, assistantMessageIds } = pairs[i];
+          const { user, assistant, pairIndex, externalTurnIds, externalDirect, messageIds, assistantMessageIds } = pairs[i];
           if (!user && !assistant) continue;
+          const laterExactExternalMarker = externalCursorKey
+            ? this.hasExternalTurnMarkerInLaterPairs(externalCursorKey, pairs, i + 1)
+            : false;
           const externalMarkerAction = externalCursorKey
             ? this.consumeExternalTurnMarkersForPair(
               externalCursorKey,
               externalTurnIds,
               user,
               assistant,
+              externalDirect,
+              i < lastIdx && !laterExactExternalMarker,
             )
             : { skip: false, markers: [], rollbackMarkers: [] };
           if (externalCursorKey && externalMarkerAction.markers.length > 0) {
@@ -850,7 +902,7 @@ export class ChatTurnWriter {
             if (externalMarkerAction.skip) this.bumpWatermark(sessionId, pairIndex);
             if (!this.commitWatermarkStateSync(sessionId)) {
               for (const marker of externalMarkerAction.rollbackMarkers) {
-                this.restoreExternalTurnMarker(externalCursorKey, marker);
+                this.restoreExternalTurnMarkerCount(externalCursorKey, marker.marker, marker.count);
               }
               this.restoreWatermarkState(sessionId, watermarkSnapshot);
               throw new Error("Failed to write external chat-turn marker consumption");
@@ -1101,12 +1153,18 @@ export class ChatTurnWriter {
     sessionKey?: string;
     turnId?: string;
     user: string;
+    userAliases?: string[];
     assistant: string;
   }): Promise<void> {
     const externalCursorKey = this.externalCursorKeyFromSessionKey(opts.sessionKey);
-    const markers = [
-      this.externalTurnMarkerId(opts.turnId, opts.user, opts.assistant),
-    ].filter(Boolean);
+    const markerUsers = this.uniqueStrings([opts.user, ...(opts.userAliases ?? [])]);
+    const markers = this.uniqueStrings([
+      ChatTurnWriter.EXTERNAL_ORDERED_TURN_MARKER,
+      ...markerUsers.flatMap((user) => [
+        this.externalTurnMarkerId(opts.turnId, user, opts.assistant),
+        this.externalTurnUserMarkerId(opts.turnId, user),
+      ]),
+    ].filter(Boolean));
     if (!externalCursorKey || markers.length === 0) return;
     const previousMarkerCounts = markers.map((marker) => ({
       marker,
@@ -1167,7 +1225,10 @@ export class ChatTurnWriter {
     sessionKey?: string;
     externalCursorKey?: string;
   }): Promise<void> {
-    const sessionIds = this.collectResetSessionIds(identity);
+    const sessionIds = this.uniqueStrings([
+      ...this.collectResetSessionIds(identity),
+      identity.externalCursorKey,
+    ]);
     if (sessionIds.length === 0) return;
     const preResetChains = new Map<string, Promise<void>>();
     for (const sessionId of sessionIds) {
@@ -1257,6 +1318,8 @@ export class ChatTurnWriter {
       // N turns" no longer maps to the new pair indices. Leaving stale
       // count would skip new pairs in `computeDelta`.
       this.w4bSessionCounts.delete(sessionId);
+      this.clearExternalOrderedTurnMarker(sessionId);
+      this.markDurableCursorKeyTrusted(sessionId);
     }
     this.clearMessageHookDedupForSessions(ids);
     // External markers record daemon-success facts from direct-channel
@@ -1669,6 +1732,7 @@ export class ChatTurnWriter {
                 sessionId,
                 (this.w4bSessionCounts.get(sessionId) ?? 0) + 1,
               );
+              this.bumpDurableCursorKeyRevision(sessionId);
               // T17 — Persist the new count/marker to disk via the
               // debounced flush so a process restart preserves the
               // "skip these pairs in computeDelta" fact.
@@ -2246,6 +2310,251 @@ export class ChatTurnWriter {
     return this.writeWatermarkFile();
   }
 
+  private savedUpToForSession(sessionId: string): number {
+    const w4aWatermark = this.loadWatermark(sessionId);
+    const w4bCount = this.w4bSessionCounts.get(sessionId) ?? 0;
+    return Math.max(w4aWatermark, w4bCount - 1);
+  }
+
+  private markDurableCursorKeyUntrusted(key: string | undefined): void {
+    if (typeof key === "string" && key.length > 0) {
+      this.untrustedDaemonCursorKeys.add(key);
+    }
+  }
+
+  private markDurableCursorKeyTrusted(key: string | undefined): void {
+    if (typeof key === "string" && key.length > 0) {
+      this.untrustedDaemonCursorKeys.delete(key);
+    }
+  }
+
+  private durableCursorRevision(key: string): number {
+    return this.durableCursorKeyRevisions.get(key) ?? 0;
+  }
+
+  private bumpDurableCursorKeyRevision(key: string | undefined): void {
+    if (typeof key !== "string" || key.length === 0) return;
+    this.durableCursorKeyRevisions.set(key, this.durableCursorRevision(key) + 1);
+  }
+
+  private markAllDurableCursorKeysUntrusted(): void {
+    for (const key of this.cachedWatermarks.keys()) this.markDurableCursorKeyUntrusted(key);
+    for (const key of this.w4bSessionCounts.keys()) this.markDurableCursorKeyUntrusted(key);
+    for (const key of this.externalTurnMarkers.keys()) this.markDurableCursorKeyUntrusted(key);
+    for (const key of this.debounceTimers.keys()) this.markDurableCursorKeyUntrusted(key);
+  }
+
+  private hasDurableCursorState(key: string): boolean {
+    return (
+      this.cachedWatermarks.has(key) ||
+      this.w4bSessionCounts.has(key) ||
+      this.externalTurnMarkers.has(key) ||
+      this.debounceTimers.has(key)
+    );
+  }
+
+  private async validateUntrustedDurableCursorsBeforeW4a(
+    sessionId: string,
+    externalCursorKey?: string,
+    typedW4bCursorKeys: string[] = [],
+    w4bInflightSessionIds: string[] = [sessionId],
+    w4aCrossPathSessionIds: string[] = [sessionId],
+  ): Promise<void> {
+    const statusReader = (this.client as ChatTurnStoreStatusClient | undefined)
+      ?.getChatTurnStoreStatus;
+    if (typeof statusReader !== "function") return;
+
+    const candidateSessionIds = this.uniqueStrings([
+      sessionId,
+      ...w4bInflightSessionIds,
+      ...w4aCrossPathSessionIds,
+    ]).filter((candidate) => this.parseComposedSessionId(candidate));
+    const cursorKeys = this.uniqueStrings([
+      ...typedW4bCursorKeys,
+    ]);
+    const externalCursorKeys = this.uniqueStrings([externalCursorKey]);
+    const allKeys = this.uniqueStrings([...candidateSessionIds, ...cursorKeys, ...externalCursorKeys]);
+    const untrustedKeys = allKeys.filter((key) =>
+      this.untrustedDaemonCursorKeys.has(key) && this.hasDurableCursorState(key)
+    );
+    if (untrustedKeys.length === 0) return;
+    const validationSnapshots = this.snapshotDurableCursorKeys(untrustedKeys);
+
+    try {
+      const status = await statusReader.call(this.client, candidateSessionIds);
+      const staleKeys = new Set<string>();
+      const untrustedKeySet = new Set(untrustedKeys);
+      if (!status.hasAnyChatTurnData) {
+        for (const key of untrustedKeys) staleKeys.add(key);
+      } else {
+        const existingSessionIds = new Set(status.existingSessionIds);
+        for (const candidate of candidateSessionIds) {
+          if (!existingSessionIds.has(candidate) && untrustedKeySet.has(candidate)) {
+            staleKeys.add(candidate);
+          }
+        }
+        if (!existingSessionIds.has(sessionId)) {
+          for (const key of cursorKeys) {
+            if (untrustedKeySet.has(key)) staleKeys.add(key);
+          }
+        }
+      }
+
+      if (staleKeys.size > 0) {
+        const clearedKeys = this.clearStaleDurableCursorKeys(staleKeys, validationSnapshots);
+        if (clearedKeys.length > 0) {
+          this.logger.warn?.(
+            "[ChatTurnWriter.onAgentEnd] Cleared stale chat-turn cursor state absent from daemon WM.",
+            { sessionId, clearedKeys },
+          );
+        }
+      }
+      for (const key of untrustedKeys) {
+        if (externalCursorKeys.includes(key) && status.hasAnyChatTurnData) continue;
+        if (!staleKeys.has(key)) this.markDurableCursorKeyTrusted(key);
+      }
+    } catch (err) {
+      this.logger.warn?.(
+        "[ChatTurnWriter.onAgentEnd] Failed to validate chat-turn cursor state against daemon WM; preserving local cursor state.",
+        { err, sessionId },
+      );
+    }
+  }
+
+  private clearStaleDurableCursorKeys(
+    keys: Iterable<string>,
+    validationSnapshots?: Map<string, DurableCursorKeySnapshot>,
+  ): string[] {
+    const parsedSessionIds: string[] = [];
+    const clearedKeys: string[] = [];
+    let changed = false;
+    for (const key of keys) {
+      const keyChanged = validationSnapshots
+        ? this.clearStaleDurableCursorKeyFromSnapshot(key, validationSnapshots.get(key))
+        : this.clearAllDurableCursorStateForKey(key);
+      if (!keyChanged) continue;
+      changed = true;
+      clearedKeys.push(key);
+      if (this.parseComposedSessionId(key) && !this.hasDurableCursorState(key)) {
+        parsedSessionIds.push(key);
+        this.clearSessionTurnIds(key);
+      }
+    }
+    if (parsedSessionIds.length > 0) {
+      this.clearMessageHookDedupForSessions(parsedSessionIds);
+    }
+    if (changed && !this.writeWatermarkFile()) {
+      this.logger.warn?.(
+        "[ChatTurnWriter.onAgentEnd] Failed to persist stale chat-turn cursor cleanup.",
+        { clearedKeys },
+      );
+    }
+    return clearedKeys;
+  }
+
+  private snapshotDurableCursorKeys(keys: string[]): Map<string, DurableCursorKeySnapshot> {
+    return new Map(keys.map((key) => [key, this.snapshotDurableCursorKey(key)] as const));
+  }
+
+  private snapshotDurableCursorKey(key: string): DurableCursorKeySnapshot {
+    return {
+      cachedWatermark: this.cachedWatermarks.get(key),
+      pendingIndex: this.debounceTimers.get(key)?.pendingIndex,
+      w4bCount: this.w4bSessionCounts.get(key),
+      markers: new Map(this.externalTurnMarkers.get(key) ?? []),
+      revision: this.durableCursorRevision(key),
+    };
+  }
+
+  private clearStaleDurableCursorKeyFromSnapshot(
+    key: string,
+    snapshot?: DurableCursorKeySnapshot,
+  ): boolean {
+    if (!snapshot) return false;
+    const revisionChanged = this.durableCursorRevision(key) !== snapshot.revision;
+    let changed = false;
+    const pending = this.debounceTimers.get(key);
+    if (!revisionChanged && pending && pending.pendingIndex === snapshot.pendingIndex) {
+      clearTimeout(pending.timer);
+      this.debounceTimers.delete(key);
+      changed = true;
+    }
+    if (
+      snapshot.pendingIndex !== undefined &&
+      !this.debounceTimers.has(key) &&
+      this.cachedWatermarks.get(key) === snapshot.pendingIndex
+    ) {
+      this.cachedWatermarks.delete(key);
+      changed = true;
+    }
+    if (
+      snapshot.cachedWatermark !== undefined &&
+      this.cachedWatermarks.get(key) === snapshot.cachedWatermark
+    ) {
+      this.cachedWatermarks.delete(key);
+      changed = true;
+    }
+    if (
+      snapshot.w4bCount !== undefined &&
+      this.w4bSessionCounts.get(key) === snapshot.w4bCount
+    ) {
+      this.w4bSessionCounts.delete(key);
+      changed = true;
+    }
+    const bucket = this.externalTurnMarkers.get(key);
+    if (bucket && snapshot.markers.size > 0) {
+      for (const [marker, snapshotCount] of snapshot.markers) {
+        const currentCount = bucket.get(marker);
+        if (currentCount === undefined) continue;
+        if (revisionChanged && currentCount === snapshotCount) continue;
+        if (currentCount <= snapshotCount) {
+          bucket.delete(marker);
+        } else {
+          bucket.set(marker, currentCount - snapshotCount);
+        }
+        changed = true;
+      }
+      if (bucket.size === 0) {
+        this.externalTurnMarkers.delete(key);
+      }
+    }
+    if (!changed) {
+      if (revisionChanged) {
+        this.logger.debug?.(
+          "[ChatTurnWriter.onAgentEnd] Preserved chat-turn cursor state changed during daemon validation.",
+          { key },
+        );
+      }
+      return false;
+    }
+    if (!this.hasDurableCursorState(key)) this.markDurableCursorKeyTrusted(key);
+    this.bumpDurableCursorKeyRevision(key);
+    return true;
+  }
+
+  private clearAllDurableCursorStateForKey(key: string): boolean {
+    let changed = false;
+    const pending = this.debounceTimers.get(key);
+    if (pending) {
+      clearTimeout(pending.timer);
+      this.debounceTimers.delete(key);
+      changed = true;
+    }
+    if (this.cachedWatermarks.delete(key)) changed = true;
+    if (this.w4bSessionCounts.delete(key)) changed = true;
+    if (this.externalTurnMarkers.delete(key)) changed = true;
+    if (!changed) return false;
+    this.markDurableCursorKeyTrusted(key);
+    this.bumpDurableCursorKeyRevision(key);
+    return true;
+  }
+
+  private uniqueStrings(values: Array<string | undefined>): string[] {
+    return Array.from(new Set(
+      values.filter((value): value is string => typeof value === "string" && value.length > 0),
+    ));
+  }
+
   private snapshotWatermarksForWrite(): Map<string, number> {
     const wm = new Map(this.cachedWatermarks);
     for (const [key, entry] of this.debounceTimers.entries()) {
@@ -2660,6 +2969,12 @@ export class ChatTurnWriter {
     return `external-id::${idHash}::${this.contentHash(user, this.stripRecalledMemory(assistant))}`;
   }
 
+  private externalTurnUserMarkerId(turnId?: unknown, user?: string): string {
+    if (typeof turnId !== "string" || turnId.trim().length === 0 || typeof user !== "string") return "";
+    const idHash = createHash("sha256").update(turnId.trim()).digest("hex").slice(0, 16);
+    return `external-user::${idHash}::${this.identityHash([user])}`;
+  }
+
   private typedW4bExternalMarkerId(user: string, assistant: string, occurrence: string): string {
     if (!occurrence) return "";
     return `weak-w4b::${this.identityHash([occurrence])}::${this.contentHash(user, this.stripRecalledMemory(assistant))}`;
@@ -2757,7 +3072,10 @@ export class ChatTurnWriter {
         bucket.set(marker, (bucket.get(marker) ?? 0) + 1);
         changed = true;
       }
-      if (bucket.size > 0) this.externalTurnMarkers.set(cursor, bucket);
+      if (bucket.size > 0) {
+        this.externalTurnMarkers.set(cursor, bucket);
+        if (changed) this.bumpDurableCursorKeyRevision(cursor);
+      }
     }
     return changed;
   }
@@ -2767,6 +3085,8 @@ export class ChatTurnWriter {
     turnIds: string[],
     user: string,
     assistant: string,
+    externalDirect: boolean,
+    allowOrderedFallback: boolean,
   ): ExternalMarkerAction {
     for (const turnId of turnIds) {
       const marker = this.externalTurnMarkerId(turnId, user, assistant);
@@ -2777,8 +3097,43 @@ export class ChatTurnWriter {
         // safe GC.
         return { skip: true, markers: [marker], rollbackMarkers: [] };
       }
+      const userMarker = externalDirect ? this.externalTurnUserMarkerId(turnId, user) : "";
+      if (userMarker && this.hasExternalTurnMarker(sessionKeyCursor, userMarker)) {
+        // Direct-channel user/turn markers cover OpenClaw transcript rendering
+        // drift on the assistant side while still requiring the explicit
+        // direct-channel turnId and canonical user body to match.
+        return { skip: true, markers: [userMarker], rollbackMarkers: [] };
+      }
+    }
+    if (allowOrderedFallback && turnIds.length === 0) {
+      const orderedMarker = ChatTurnWriter.EXTERNAL_ORDERED_TURN_MARKER;
+      const count = this.externalTurnMarkers.get(sessionKeyCursor)?.get(orderedMarker) ?? 0;
+      if (count > 0 && this.consumeExternalTurnMarker(sessionKeyCursor, orderedMarker)) {
+        return {
+          skip: true,
+          markers: [orderedMarker],
+          rollbackMarkers: [{ marker: orderedMarker, count }],
+        };
+      }
     }
     return { skip: false, markers: [], rollbackMarkers: [] };
+  }
+
+  private hasExternalTurnMarkerInLaterPairs(
+    sessionKeyCursor: string,
+    pairs: ComputedChatTurnPair[],
+    fromIndex: number,
+  ): boolean {
+    for (let i = fromIndex; i < pairs.length; i++) {
+      const { user, assistant, externalTurnIds, externalDirect } = pairs[i];
+      for (const turnId of externalTurnIds) {
+        const exactMarker = this.externalTurnMarkerId(turnId, user, assistant);
+        if (exactMarker && this.hasExternalTurnMarker(sessionKeyCursor, exactMarker)) return true;
+        const userMarker = externalDirect ? this.externalTurnUserMarkerId(turnId, user) : "";
+        if (userMarker && this.hasExternalTurnMarker(sessionKeyCursor, userMarker)) return true;
+      }
+    }
+    return false;
   }
 
   private hasExternalTurnMarker(sessionKeyCursor: string, marker: string): boolean {
@@ -2804,6 +3159,7 @@ export class ChatTurnWriter {
 
   private restoreExternalTurnMarker(sessionKeyCursor: string, marker: string): void {
     if (!marker) return;
+    this.bumpDurableCursorKeyRevision(sessionKeyCursor);
     const bucket = this.externalTurnMarkers.get(sessionKeyCursor) ?? new Map<string, number>();
     bucket.set(marker, Math.max(bucket.get(marker) ?? 0, 1));
     this.externalTurnMarkers.set(sessionKeyCursor, bucket);
@@ -2811,6 +3167,7 @@ export class ChatTurnWriter {
 
   private restoreExternalTurnMarkerCount(sessionKeyCursor: string, marker: string, count: number): void {
     if (!marker) return;
+    this.bumpDurableCursorKeyRevision(sessionKeyCursor);
     const bucket = this.externalTurnMarkers.get(sessionKeyCursor);
     if (count > 0) {
       const target = bucket ?? new Map<string, number>();
@@ -2820,6 +3177,16 @@ export class ChatTurnWriter {
     }
     if (!bucket) return;
     bucket.delete(marker);
+    if (bucket.size === 0) {
+      this.externalTurnMarkers.delete(sessionKeyCursor);
+    }
+  }
+
+  private clearExternalOrderedTurnMarker(sessionKeyCursor: string): void {
+    const bucket = this.externalTurnMarkers.get(sessionKeyCursor);
+    if (!bucket) return;
+    if (!bucket.delete(ChatTurnWriter.EXTERNAL_ORDERED_TURN_MARKER)) return;
+    this.bumpDurableCursorKeyRevision(sessionKeyCursor);
     if (bucket.size === 0) {
       this.externalTurnMarkers.delete(sessionKeyCursor);
     }
@@ -3346,6 +3713,7 @@ export class ChatTurnWriter {
   }
 
   private saveWatermark(sessionId: string, index: number): void {
+    this.bumpDurableCursorKeyRevision(sessionId);
     const existing = this.debounceTimers.get(sessionId);
     if (existing) clearTimeout(existing.timer);
     const timer = setTimeout(() => {
@@ -3375,6 +3743,7 @@ export class ChatTurnWriter {
       this.debounceTimers.delete(sessionId);
       opts = { ...opts, pendingIndex: existing.pendingIndex };
     }
+    this.bumpDurableCursorKeyRevision(sessionId);
     const currentWatermark = opts.pendingIndex ?? this.cachedWatermarks.get(sessionId) ?? -1;
     const timer = setTimeout(() => {
       this.debounceTimers.delete(sessionId);
@@ -3440,6 +3809,7 @@ export class ChatTurnWriter {
         if (typeof opts?.pairIndex === "number") {
           this.bumpWatermark(sessionId, opts.pairIndex);
         }
+        this.markDurableCursorKeyTrusted(sessionId);
         // T71 — Info-level persist log so Telegram / W4b chat turns are as
         // visible in the gateway log as Node-UI / W4a turns (which log via
         // DkgChannelPlugin's `[dkg-channel] Turn persisted to DKG graph: …`

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -213,6 +213,17 @@ function buildAgentBody(text: string, opts?: { attachmentRefs?: OpenClawAttachme
   }
   return sections.join('\n\n');
 }
+
+function buildMarkerUserAliases(...values: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const aliases: string[] = [];
+  for (const value of values) {
+    if (typeof value !== 'string' || value.length === 0 || seen.has(value)) continue;
+    seen.add(value);
+    aliases.push(value);
+  }
+  return aliases;
+}
 const moduleRequire = createRequire(import.meta.url);
 
 interface PendingRequest {
@@ -228,15 +239,21 @@ interface PersistTurnOptions {
   sessionKey?: string;
   turnId?: string;
   markerUser?: string;
+  markerUserAliases?: string[];
 }
 
 interface ExternalTurnMarkerPersistOptions {
   sessionKey?: string;
   turnId: string;
   user: string;
+  userAliases?: string[];
   assistant: string;
   correlationId: string;
 }
+
+type ChannelOutboundReplyWithMarkerAliases = ChannelOutboundReply & {
+  markerUserAliases?: string[];
+};
 
 interface InboundChatOptions {
   attachmentRefs?: OpenClawAttachmentRef[];
@@ -1294,8 +1311,11 @@ export class DkgChannelPlugin {
           attachmentRefs,
           sessionKey,
           markerUser: markerUserMessage,
+          markerUserAliases: reply.markerUserAliases,
         }, true);
-        return reply;
+        const publicReply = { ...reply };
+        delete publicReply.markerUserAliases;
+        return publicReply;
       } catch (err: any) {
         api.logger.warn?.(`[dkg-channel] dispatchViaPluginSdk failed: ${err.message}`);
         throw err;
@@ -1346,6 +1366,7 @@ export class DkgChannelPlugin {
         attachmentRefs,
         sessionKey: returnedSessionKey || undefined,
         markerUser: markerUserMessage,
+        markerUserAliases: buildMarkerUserAliases(markerUserMessage, text),
       }, true);
       return normalizedReply;
     }
@@ -1367,7 +1388,7 @@ export class DkgChannelPlugin {
     attachmentRefs?: OpenClawAttachmentRef[],
     contextEntries?: ChatContextEntry[],
     uiContextGraphId?: string,
-  ): Promise<ChannelOutboundReply> {
+  ): Promise<ChannelOutboundReplyWithMarkerAliases> {
     const log = this.api!.logger;
     const runtime = this.runtime;
     const cfg = this.cfg;
@@ -1484,11 +1505,11 @@ export class DkgChannelPlugin {
     storePath: string,
     ctxPayload: any,
     correlationId: string,
-  ): Promise<ChannelOutboundReply> {
+  ): Promise<ChannelOutboundReplyWithMarkerAliases> {
     const log = this.api!.logger;
     const runtime = this.runtime;
 
-    return new Promise<ChannelOutboundReply>((resolve, reject) => {
+    return new Promise<ChannelOutboundReplyWithMarkerAliases>((resolve, reject) => {
       const TIMEOUT_MS = CHANNEL_RESPONSE_TIMEOUT_MS;
       const timer = setTimeout(() => {
         reject(new Error('Agent response timeout'));
@@ -1519,7 +1540,17 @@ export class DkgChannelPlugin {
         clearTimeout(timer);
         const replyText = finalizeAgentReplyText(replyChunks.join('\n'));
         log.info?.(`[dkg-channel] Reply dispatched (${replyText.length} chars) for ${correlationId}`);
-        resolve({ text: replyText, correlationId, sessionKey: route.sessionKey });
+        resolve({
+          text: replyText,
+          correlationId,
+          sessionKey: route.sessionKey,
+          markerUserAliases: buildMarkerUserAliases(
+            ctxPayload?.Body,
+            ctxPayload?.BodyForAgent,
+            ctxPayload?.CommandBody,
+            ctxPayload?.RawBody,
+          ),
+        });
       }).catch((err: any) => {
         clearTimeout(timer);
         log.warn?.(`[dkg-channel] dispatchInboundReplyWithBase failed: ${err.message}`);
@@ -1535,10 +1566,10 @@ export class DkgChannelPlugin {
     storePath: string,
     ctxPayload: any,
     correlationId: string,
-  ): Promise<ChannelOutboundReply> {
+  ): Promise<ChannelOutboundReplyWithMarkerAliases> {
     const log = this.api!.logger;
 
-    return new Promise<ChannelOutboundReply>((resolve, reject) => {
+    return new Promise<ChannelOutboundReplyWithMarkerAliases>((resolve, reject) => {
       const TIMEOUT_MS = CHANNEL_RESPONSE_TIMEOUT_MS;
       const timer = setTimeout(() => {
         reject(new Error('Agent response timeout'));
@@ -1568,7 +1599,17 @@ export class DkgChannelPlugin {
           clearTimeout(timer);
           const replyText = finalizeAgentReplyText(replyChunks.join('\n'));
           log.info?.(`[dkg-channel] Reply dispatched (${replyText.length} chars) for ${correlationId}`);
-          resolve({ text: replyText, correlationId, sessionKey: route.sessionKey });
+          resolve({
+            text: replyText,
+            correlationId,
+            sessionKey: route.sessionKey,
+            markerUserAliases: buildMarkerUserAliases(
+              ctxPayload?.Body,
+              ctxPayload?.BodyForAgent,
+              ctxPayload?.CommandBody,
+              ctxPayload?.RawBody,
+            ),
+          });
         })
         .catch((err: any) => {
           clearTimeout(timer);
@@ -1767,6 +1808,7 @@ export class DkgChannelPlugin {
           attachmentRefs,
           sessionKey: route.sessionKey,
           markerUser: agentBody,
+          markerUserAliases: buildMarkerUserAliases(formattedBody, agentBody, commandBody, text),
         }, true);
       } else if (resolvedTerminalState === 'failed') {
         this.queueTurnPersistence(
@@ -1780,6 +1822,7 @@ export class DkgChannelPlugin {
             attachmentRefs,
             sessionKey: route.sessionKey,
             markerUser: agentBody,
+            markerUserAliases: buildMarkerUserAliases(formattedBody, agentBody, commandBody, text),
           },
           true,
         );
@@ -1795,6 +1838,7 @@ export class DkgChannelPlugin {
             attachmentRefs,
             sessionKey: route.sessionKey,
             markerUser: agentBody,
+            markerUserAliases: buildMarkerUserAliases(formattedBody, agentBody, commandBody, text),
           },
           true,
         );
@@ -2011,6 +2055,7 @@ export class DkgChannelPlugin {
       sessionKey: opts?.sessionKey,
       turnId: opts?.turnId ?? correlationId,
       user: opts?.markerUser ?? userMessage,
+      userAliases: opts?.markerUserAliases,
       assistant: assistantReply,
       correlationId,
     }, allowDuringShutdown);
@@ -2044,6 +2089,7 @@ export class DkgChannelPlugin {
       sessionKey: opts.sessionKey,
       turnId: opts.turnId,
       user: opts.user,
+      ...(opts.userAliases?.length ? { userAliases: opts.userAliases } : {}),
       assistant: opts.assistant,
     });
   }

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -224,21 +224,6 @@ function buildMarkerUserAliases(...values: Array<string | undefined>): string[] 
   }
   return aliases;
 }
-
-// Diagnostic helpers — mirror ChatTurnWriter's encodeIdField/externalCursorKeyFromSessionKey
-// so log lines on the channel side and the writer side can be cross-checked by an operator
-// running a live UI->Telegram smoke.
-function describeSessionKey(sessionKey: unknown): string {
-  if (typeof sessionKey !== 'string') return '<missing>';
-  if (sessionKey.length === 0) return '<empty>';
-  return sessionKey;
-}
-
-function describeExternalCursorKey(sessionKey: unknown): string {
-  if (typeof sessionKey !== 'string' || sessionKey.trim().length === 0) return '<none>';
-  const encoded = sessionKey.replace(/[%:]/g, (c) => (c === '%' ? '%25' : '%3A'));
-  return `openclaw:transcript:${encoded}`;
-}
 const moduleRequire = createRequire(import.meta.url);
 
 interface PendingRequest {
@@ -2081,21 +2066,8 @@ export class DkgChannelPlugin {
     opts: ExternalTurnMarkerPersistOptions,
     allowDuringShutdown: boolean,
   ): Promise<void> {
-    if (!this.chatTurnWriter) {
-      this.api?.logger.info?.(
-        `[dkg-channel:marker-write] skip correlationId=${opts.correlationId} reason=no-chat-turn-writer sessionKey=${describeSessionKey(opts.sessionKey)}`,
-      );
-      return;
-    }
-    if (!opts.sessionKey) {
-      this.api?.logger.info?.(
-        `[dkg-channel:marker-write] skip correlationId=${opts.correlationId} reason=no-session-key turnId=${opts.turnId}`,
-      );
-      return;
-    }
-    this.api?.logger.info?.(
-      `[dkg-channel:marker-write] begin correlationId=${opts.correlationId} sessionKey=${describeSessionKey(opts.sessionKey)} externalCursorKey=${describeExternalCursorKey(opts.sessionKey)} turnId=${opts.turnId} aliases=${opts.userAliases?.length ?? 0}`,
-    );
+    if (!this.chatTurnWriter) return;
+    if (!opts.sessionKey) return;
     const markerWrite = this.writeExternalTurnMarker(opts);
     this.pendingMarkerPersistence.set(opts.correlationId, {
       attempt: 1,
@@ -2107,9 +2079,6 @@ export class DkgChannelPlugin {
     try {
       await markerWrite;
       this.deletePendingMarkerPersistence(opts.correlationId);
-      this.api?.logger.info?.(
-        `[dkg-channel:marker-write] ok correlationId=${opts.correlationId} sessionKey=${describeSessionKey(opts.sessionKey)} externalCursorKey=${describeExternalCursorKey(opts.sessionKey)} turnId=${opts.turnId}`,
-      );
     } catch (err: any) {
       this.scheduleExternalTurnMarkerRetry(opts, 1, allowDuringShutdown, err);
     }

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -224,6 +224,21 @@ function buildMarkerUserAliases(...values: Array<string | undefined>): string[] 
   }
   return aliases;
 }
+
+// Diagnostic helpers — mirror ChatTurnWriter's encodeIdField/externalCursorKeyFromSessionKey
+// so log lines on the channel side and the writer side can be cross-checked by an operator
+// running a live UI->Telegram smoke.
+function describeSessionKey(sessionKey: unknown): string {
+  if (typeof sessionKey !== 'string') return '<missing>';
+  if (sessionKey.length === 0) return '<empty>';
+  return sessionKey;
+}
+
+function describeExternalCursorKey(sessionKey: unknown): string {
+  if (typeof sessionKey !== 'string' || sessionKey.trim().length === 0) return '<none>';
+  const encoded = sessionKey.replace(/[%:]/g, (c) => (c === '%' ? '%25' : '%3A'));
+  return `openclaw:transcript:${encoded}`;
+}
 const moduleRequire = createRequire(import.meta.url);
 
 interface PendingRequest {
@@ -2066,8 +2081,21 @@ export class DkgChannelPlugin {
     opts: ExternalTurnMarkerPersistOptions,
     allowDuringShutdown: boolean,
   ): Promise<void> {
-    if (!this.chatTurnWriter) return;
-    if (!opts.sessionKey) return;
+    if (!this.chatTurnWriter) {
+      this.api?.logger.info?.(
+        `[dkg-channel:marker-write] skip correlationId=${opts.correlationId} reason=no-chat-turn-writer sessionKey=${describeSessionKey(opts.sessionKey)}`,
+      );
+      return;
+    }
+    if (!opts.sessionKey) {
+      this.api?.logger.info?.(
+        `[dkg-channel:marker-write] skip correlationId=${opts.correlationId} reason=no-session-key turnId=${opts.turnId}`,
+      );
+      return;
+    }
+    this.api?.logger.info?.(
+      `[dkg-channel:marker-write] begin correlationId=${opts.correlationId} sessionKey=${describeSessionKey(opts.sessionKey)} externalCursorKey=${describeExternalCursorKey(opts.sessionKey)} turnId=${opts.turnId} aliases=${opts.userAliases?.length ?? 0}`,
+    );
     const markerWrite = this.writeExternalTurnMarker(opts);
     this.pendingMarkerPersistence.set(opts.correlationId, {
       attempt: 1,
@@ -2079,6 +2107,9 @@ export class DkgChannelPlugin {
     try {
       await markerWrite;
       this.deletePendingMarkerPersistence(opts.correlationId);
+      this.api?.logger.info?.(
+        `[dkg-channel:marker-write] ok correlationId=${opts.correlationId} sessionKey=${describeSessionKey(opts.sessionKey)} externalCursorKey=${describeExternalCursorKey(opts.sessionKey)} turnId=${opts.turnId}`,
+      );
     } catch (err: any) {
       this.scheduleExternalTurnMarkerRetry(opts, 1, allowDuringShutdown, err);
     }

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -156,16 +156,16 @@ function bindingCount(result: any): number {
 }
 
 function isChatTurnStoreNotFoundError(err: unknown): boolean {
+  // Only treat a daemon 404 as "no chat-turn data yet" when the error
+  // message names the specific assertion this query reads. Broader
+  // substring matches (just "not found" / "context" / "graph") would
+  // swallow unrelated 404s and silently clear local cursor state via
+  // validateUntrustedDurableCursorsBeforeW4a, turning real daemon
+  // failures into cold-start replays.
   const msg = err instanceof Error ? err.message : String(err);
   const lower = msg.toLowerCase();
   if (!lower.includes('responded 404')) return false;
-  return (
-    lower.includes('not found') ||
-    lower.includes('assertion') ||
-    lower.includes('context') ||
-    lower.includes('graph') ||
-    lower.includes(CHAT_TURNS_ASSERTION_NAME)
-  );
+  return lower.includes(CHAT_TURNS_ASSERTION_NAME);
 }
 
 export class DkgDaemonClient {

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -39,6 +39,11 @@ export interface OpenClawAttachmentRef {
   rootEntity?: string;
 }
 
+export interface ChatTurnStoreStatus {
+  hasAnyChatTurnData: boolean;
+  existingSessionIds: string[];
+}
+
 export interface LocalAgentIntegrationCapabilities {
   localChat?: boolean;
   connectFromUi?: boolean;
@@ -103,6 +108,64 @@ export interface AgentIdentity {
   framework?: string;
   peerId: string;
   nodeIdentityId: string;
+}
+
+const CHAT_TURNS_CONTEXT_GRAPH_ID = 'agent-context';
+const CHAT_TURNS_ASSERTION_NAME = 'chat-turns';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const SCHEMA = 'http://schema.org/';
+const DKG_ONT = 'http://dkg.io/ontology/';
+
+function queryBindings(result: any): Array<Record<string, unknown>> {
+  const candidates = [
+    result?.results?.bindings,
+    result?.result?.bindings,
+    result?.result?.results?.bindings,
+    result?.bindings,
+  ];
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) return candidate as Array<Record<string, unknown>>;
+  }
+  return [];
+}
+
+function bindingValue(binding: Record<string, unknown>, key: string): string | undefined {
+  const value = binding[key];
+  if (typeof value === 'string') return stripRdfLiteral(value);
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (typeof record.value === 'string') return stripRdfLiteral(record.value);
+    if (typeof record.id === 'string') return stripRdfLiteral(record.id);
+  }
+  return undefined;
+}
+
+function stripRdfLiteral(value: string): string {
+  if (!value) return '';
+  const typed = value.match(/^"([\s\S]*)"(?:\^\^<[^>]+>)?(?:@[a-zA-Z-]+)?$/);
+  return typed ? typed[1] : value;
+}
+
+function bindingCount(result: any): number {
+  const binding = queryBindings(result)[0];
+  if (!binding) return 0;
+  const value = bindingValue(binding, 'c') ?? bindingValue(binding, 'count');
+  if (!value) return 0;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function isChatTurnStoreNotFoundError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+  if (!lower.includes('responded 404')) return false;
+  return (
+    lower.includes('not found') ||
+    lower.includes('assertion') ||
+    lower.includes('context') ||
+    lower.includes('graph') ||
+    lower.includes(CHAT_TURNS_ASSERTION_NAME)
+  );
 }
 
 export class DkgDaemonClient {
@@ -475,6 +538,59 @@ export class DkgDaemonClient {
   // ---------------------------------------------------------------------------
   // Chat turn persistence  (reuses the existing ChatMemoryManager pathway)
   // ---------------------------------------------------------------------------
+
+  async getChatTurnStoreStatus(sessionIds: string[]): Promise<ChatTurnStoreStatus> {
+    const identity = await this.getAgentIdentity();
+    const agentAddress = identity.ok ? identity.identity?.agentAddress?.trim() : '';
+    if (!agentAddress) {
+      throw new Error(
+        `Unable to resolve daemon agent identity for chat-turn WM status: ${identity.error ?? 'missing agentAddress'}`,
+      );
+    }
+    const wmReadOpts = {
+      contextGraphId: CHAT_TURNS_CONTEXT_GRAPH_ID,
+      view: 'working-memory' as const,
+      assertionName: CHAT_TURNS_ASSERTION_NAME,
+      agentAddress,
+    };
+    try {
+      const countResult = await this.query(
+        'SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }',
+        wmReadOpts,
+      );
+      const hasAnyChatTurnData = bindingCount(countResult) > 0;
+      if (!hasAnyChatTurnData) {
+        return { hasAnyChatTurnData: false, existingSessionIds: [] };
+      }
+      const uniqueSessionIds = Array.from(new Set(
+        sessionIds.map((sessionId) => sessionId.trim()).filter(Boolean),
+      ));
+      if (uniqueSessionIds.length === 0) {
+        return { hasAnyChatTurnData: true, existingSessionIds: [] };
+      }
+      const sessionValues = uniqueSessionIds.map((sessionId) => JSON.stringify(sessionId)).join(' ');
+      const sessionResult = await this.query(
+        `SELECT DISTINCT ?sid WHERE {
+          VALUES ?sid { ${sessionValues} }
+          ?session <${RDF_TYPE}> <${SCHEMA}Conversation> .
+          ?session <${DKG_ONT}sessionId> ?sid .
+        }`,
+        wmReadOpts,
+      );
+      const requested = new Set(uniqueSessionIds);
+      const existingSessionIds = Array.from(new Set(
+        queryBindings(sessionResult)
+          .map((binding) => bindingValue(binding, 'sid'))
+          .filter((value): value is string => typeof value === 'string' && requested.has(value)),
+      ));
+      return { hasAnyChatTurnData: true, existingSessionIds };
+    } catch (err) {
+      if (isChatTurnStoreNotFoundError(err)) {
+        return { hasAnyChatTurnData: false, existingSessionIds: [] };
+      }
+      throw err;
+    }
+  }
 
   /**
    * Persist a chat turn through the daemon's `/api/openclaw-channel/persist-turn`

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -3004,6 +3004,65 @@ describe("ChatTurnWriter", () => {
     writer.flushSync();
   });
 
+  it("T458 — N direct persists accumulate ordered tickets for N metadata-stripped UI backfill pairs", async () => {
+    // Seed prior Telegram persistence so savedUpTo > -1 and the
+    // cold-start clamp does not pre-drop historical UI pairs. This
+    // mirrors the live UI -> first Telegram regression: by the time
+    // the first Telegram agent_end fires after multiple direct UI
+    // persists, the OpenClaw transcript already carries every UI pair
+    // but their direct-channel metadata has been stripped, so only
+    // the ordered marker fallback can dedupe them.
+    await writer.onAgentEnd({
+      sessionId: "seed",
+      messages: [
+        { role: "user", content: "previous telegram question" },
+        { role: "assistant", content: "previous telegram answer" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-1",
+      user: "raw ui question 1",
+      assistant: "node ui answer 1",
+    });
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-2",
+      user: "raw ui question 2",
+      assistant: "node ui answer 2",
+    });
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-3",
+      user: "raw ui question 3",
+      assistant: "node ui answer 3",
+    });
+
+    await writer.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "previous telegram question" },
+        { role: "assistant", content: "previous telegram answer" },
+        { role: "user", content: "raw ui question 1" },
+        { role: "assistant", content: "[DKG UI delivered] rendered transcript answer 1" },
+        { role: "user", content: "raw ui question 2" },
+        { role: "assistant", content: "[DKG UI delivered] rendered transcript answer 2" },
+        { role: "user", content: "raw ui question 3" },
+        { role: "assistant", content: "[DKG UI delivered] rendered transcript answer 3" },
+        { role: "user", content: "next telegram question" },
+        { role: "assistant", content: "next telegram answer" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("next telegram question");
+    writer.flushSync();
+  });
+
   it("T359 - typed Telegram W4b and Node-UI external markers both suppress W4a duplicates after restart", async () => {
     await writer.markExternalTurnPersistedDurable({
       sessionKey: "agent:main:main",

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -10,7 +10,10 @@ const flushMicrotasks = () => new Promise((r) => setTimeout(r, 20));
 
 describe("ChatTurnWriter", () => {
   let writer: ChatTurnWriter;
-  let mockClient: { storeChatTurn: ReturnType<typeof vi.fn> };
+  let mockClient: {
+    storeChatTurn: ReturnType<typeof vi.fn>;
+    getChatTurnStoreStatus?: ReturnType<typeof vi.fn>;
+  };
   let mockLogger: {
     debug: ReturnType<typeof vi.fn>;
     info: ReturnType<typeof vi.fn>;
@@ -70,6 +73,479 @@ describe("ChatTurnWriter", () => {
       expect(fs.existsSync(path.join(directStateDir, "dkg-adapter", "chat-turn-watermarks.json"))).toBe(false);
     } finally {
       directWriter.flushSync();
+      fs.rmSync(directStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("validates a loaded stale watermark against empty daemon chat-turn WM before W4a skips", async () => {
+    const directStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-stale-direct-"));
+    const sessionId = "openclaw:tg:acct:conv:sk-stale";
+    const directFile = path.join(directStateDir, "chat-turn-watermarks.json");
+    const localClient = {
+      storeChatTurn: vi.fn().mockResolvedValue(undefined),
+      getChatTurnStoreStatus: vi.fn().mockResolvedValue({
+        hasAnyChatTurnData: false,
+        existingSessionIds: [],
+      }),
+    };
+    const directWriter = new ChatTurnWriter({
+      client: localClient,
+      logger: mockLogger,
+      stateDir: directStateDir,
+      stateLayout: "direct",
+    });
+    try {
+      fs.writeFileSync(directFile, JSON.stringify({ [sessionId]: { w: 99, b: 0 } }));
+      const restarted = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      await restarted.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "fresh telegram user" },
+            { role: "assistant", content: "fresh telegram reply" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "sk-stale" },
+      );
+      await restarted.flush();
+
+      expect(localClient.getChatTurnStoreStatus).toHaveBeenCalledWith(expect.arrayContaining([sessionId]));
+      expect(localClient.storeChatTurn).toHaveBeenCalledTimes(1);
+      expect(localClient.storeChatTurn.mock.calls[0][0]).toBe(sessionId);
+      expect(localClient.storeChatTurn.mock.calls[0][1]).toBe("fresh telegram user");
+      expect(localClient.storeChatTurn.mock.calls[0][2]).toBe("fresh telegram reply");
+      const persisted = JSON.parse(fs.readFileSync(directFile, "utf-8"));
+      expect(persisted[sessionId]).toEqual({ w: 0, b: 0 });
+      restarted.flushSync();
+    } finally {
+      directWriter.flushSync();
+      fs.rmSync(directStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("validates migrated legacy stale watermarks against empty daemon chat-turn WM", async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-stale-legacy-"));
+    const legacyStateDir = path.join(workspace, ".openclaw");
+    const newStateDir = path.join(workspace, ".dkg-adapter");
+    const legacyFile = path.join(legacyStateDir, "dkg-adapter", "chat-turn-watermarks.json");
+    const newFile = path.join(newStateDir, "chat-turn-watermarks.json");
+    const sessionId = "openclaw:tg:acct:conv:sk-legacy-stale";
+    const localClient = {
+      storeChatTurn: vi.fn().mockResolvedValue(undefined),
+      getChatTurnStoreStatus: vi.fn().mockResolvedValue({
+        hasAnyChatTurnData: false,
+        existingSessionIds: [],
+      }),
+    };
+    try {
+      fs.mkdirSync(path.dirname(legacyFile), { recursive: true });
+      fs.writeFileSync(legacyFile, JSON.stringify({ [sessionId]: { w: 42, b: 0 } }));
+      const migrated = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: newStateDir,
+        stateLayout: "direct",
+        legacyStateDirs: [legacyStateDir],
+      });
+      await migrated.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "after wm recreation" },
+            { role: "assistant", content: "stored again" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "sk-legacy-stale" },
+      );
+      await migrated.flush();
+
+      expect(localClient.storeChatTurn).toHaveBeenCalledTimes(1);
+      expect(localClient.storeChatTurn.mock.calls[0][0]).toBe(sessionId);
+      const persisted = JSON.parse(fs.readFileSync(newFile, "utf-8"));
+      expect(persisted[sessionId]).toEqual({ w: 0, b: 0 });
+      migrated.flushSync();
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a loaded high watermark when daemon confirms the session exists", async () => {
+    const directStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-stale-positive-"));
+    const sessionId = "openclaw:tg:acct:conv:sk-present";
+    const directFile = path.join(directStateDir, "chat-turn-watermarks.json");
+    const localClient = {
+      storeChatTurn: vi.fn().mockResolvedValue(undefined),
+      getChatTurnStoreStatus: vi.fn().mockResolvedValue({
+        hasAnyChatTurnData: true,
+        existingSessionIds: [sessionId],
+      }),
+    };
+    try {
+      fs.writeFileSync(directFile, JSON.stringify({ [sessionId]: { w: 99, b: 0 } }));
+      const restarted = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      await restarted.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "already saved" },
+            { role: "assistant", content: "already saved reply" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "sk-present" },
+      );
+      await restarted.flush();
+
+      expect(localClient.getChatTurnStoreStatus).toHaveBeenCalledWith(expect.arrayContaining([sessionId]));
+      expect(localClient.storeChatTurn).not.toHaveBeenCalled();
+      restarted.flushSync();
+    } finally {
+      fs.rmSync(directStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves loaded direct-channel markers when daemon has chat data but the Telegram session is absent", async () => {
+    const directStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-stale-external-marker-"));
+    const sessionId = "openclaw:tg:acct:conv:shared-sk";
+    const externalCursorKey = "openclaw:transcript:shared-sk";
+    const directFile = path.join(directStateDir, "chat-turn-watermarks.json");
+    const localClient = {
+      storeChatTurn: vi.fn().mockResolvedValue(undefined),
+      getChatTurnStoreStatus: vi.fn().mockResolvedValue({
+        hasAnyChatTurnData: true,
+        existingSessionIds: [],
+      }),
+    };
+    try {
+      const seeder = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      await seeder.markExternalTurnPersistedDurable({
+        sessionKey: "shared-sk",
+        turnId: "ui-turn",
+        user: "ui user",
+        assistant: "ui assistant",
+      });
+      seeder.flushSync();
+      localClient.storeChatTurn.mockClear();
+      localClient.getChatTurnStoreStatus.mockClear();
+
+      const restarted = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      await restarted.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "ui user", context: { channelId: "dkg-ui", turnId: "ui-turn" } },
+            { role: "assistant", content: "ui assistant" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "shared-sk" },
+      );
+      await restarted.flush();
+
+      expect(localClient.getChatTurnStoreStatus).toHaveBeenCalledWith(expect.arrayContaining([sessionId]));
+      expect(localClient.storeChatTurn).not.toHaveBeenCalled();
+      const persisted = JSON.parse(fs.readFileSync(directFile, "utf-8"));
+      expect(persisted[sessionId]).toEqual({ w: 0, b: 0 });
+      expect(Object.keys(persisted[externalCursorKey]?.m ?? {})).toHaveLength(3);
+      restarted.flushSync();
+    } finally {
+      fs.rmSync(directStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not clear fresh direct-channel markers written while stale daemon validation is in flight", async () => {
+    const directStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-stale-marker-race-"));
+    const sessionId = "openclaw:tg:acct:conv:race-sk";
+    const externalCursorKey = "openclaw:transcript:race-sk";
+    const directFile = path.join(directStateDir, "chat-turn-watermarks.json");
+    let resolveStatus!: (value: { hasAnyChatTurnData: boolean; existingSessionIds: string[] }) => void;
+    const statusPromise = new Promise<{ hasAnyChatTurnData: boolean; existingSessionIds: string[] }>((resolve) => {
+      resolveStatus = resolve;
+    });
+    const localClient = {
+      storeChatTurn: vi.fn().mockResolvedValue(undefined),
+      getChatTurnStoreStatus: vi.fn().mockReturnValue(statusPromise),
+    };
+    try {
+      const seeder = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      await seeder.markExternalTurnPersistedDurable({
+        sessionKey: "race-sk",
+        turnId: "old-ui-turn",
+        user: "old ui user",
+        assistant: "old ui assistant",
+      });
+      seeder.flushSync();
+      localClient.storeChatTurn.mockClear();
+      localClient.getChatTurnStoreStatus.mockClear();
+
+      const restarted = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      await restarted.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "old ui user", context: { channelId: "dkg-ui", turnId: "old-ui-turn" } },
+            { role: "assistant", content: "old ui assistant" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "race-sk" },
+      );
+      for (let i = 0; i < 10 && localClient.getChatTurnStoreStatus.mock.calls.length === 0; i++) {
+        await flushMicrotasks();
+      }
+      expect(localClient.getChatTurnStoreStatus).toHaveBeenCalled();
+
+      await restarted.markExternalTurnPersistedDurable({
+        sessionKey: "race-sk",
+        turnId: "fresh-ui-turn",
+        user: "fresh ui user",
+        assistant: "fresh ui assistant",
+      });
+      resolveStatus({ hasAnyChatTurnData: false, existingSessionIds: [] });
+      await restarted.flush();
+
+      expect(localClient.storeChatTurn).not.toHaveBeenCalled();
+      const persisted = JSON.parse(fs.readFileSync(directFile, "utf-8"));
+      expect(Object.keys(persisted[externalCursorKey]?.m ?? {})).toHaveLength(5);
+      restarted.flushSync();
+    } finally {
+      fs.rmSync(directStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clears stale W4a watermark but preserves fresh W4b state written during daemon validation", async () => {
+    const directStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-stale-w4b-race-"));
+    const sessionId = "openclaw:tg:acct:conv:race-sk";
+    const directFile = path.join(directStateDir, "chat-turn-watermarks.json");
+    let resolveStatus!: (value: { hasAnyChatTurnData: boolean; existingSessionIds: string[] }) => void;
+    const statusPromise = new Promise<{ hasAnyChatTurnData: boolean; existingSessionIds: string[] }>((resolve) => {
+      resolveStatus = resolve;
+    });
+    const localClient = {
+      storeChatTurn: vi.fn().mockResolvedValue(undefined),
+      getChatTurnStoreStatus: vi.fn().mockReturnValue(statusPromise),
+    };
+    try {
+      fs.writeFileSync(directFile, JSON.stringify({ [sessionId]: { w: 99, b: 0 } }));
+      const restarted = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      await restarted.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "race user" },
+            { role: "assistant", content: "race assistant" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "race-sk" },
+      );
+      for (let i = 0; i < 10 && localClient.getChatTurnStoreStatus.mock.calls.length === 0; i++) {
+        await flushMicrotasks();
+      }
+      expect(localClient.getChatTurnStoreStatus).toHaveBeenCalled();
+
+      restarted.onMessageReceived({
+        sessionKey: "race-sk",
+        context: {
+          content: "race user",
+          channelId: "tg",
+          accountId: "acct",
+          conversationId: "conv",
+          messageId: "in-race",
+        },
+      });
+      await restarted.onMessageSent({
+        sessionKey: "race-sk",
+        context: {
+          content: "race assistant",
+          channelId: "tg",
+          accountId: "acct",
+          conversationId: "conv",
+          messageId: "out-race",
+          success: true,
+        },
+      });
+
+      resolveStatus({ hasAnyChatTurnData: false, existingSessionIds: [] });
+      await restarted.flush();
+
+      expect(localClient.storeChatTurn).toHaveBeenCalledTimes(1);
+      const persisted = JSON.parse(fs.readFileSync(directFile, "utf-8"));
+      expect(persisted[sessionId]?.w).toBe(-1);
+      expect(persisted[sessionId]?.b).toBe(1);
+      expect((restarted as any).peekCrossPathStamp(
+        sessionId,
+        (restarted as any).w4bOriginKey("race user", "race assistant"),
+      )).toBe(true);
+      restarted.flushSync();
+    } finally {
+      fs.rmSync(directStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clears stale pending watermarks that roll into cached state during daemon validation", async () => {
+    const directStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-stale-pending-rollover-"));
+    const sessionId = "openclaw:tg:acct:conv:pending-sk";
+    let resolveStatus!: (value: { hasAnyChatTurnData: boolean; existingSessionIds: string[] }) => void;
+    const statusPromise = new Promise<{ hasAnyChatTurnData: boolean; existingSessionIds: string[] }>((resolve) => {
+      resolveStatus = resolve;
+    });
+    const localClient = {
+      storeChatTurn: vi.fn().mockResolvedValue(undefined),
+      getChatTurnStoreStatus: vi.fn().mockReturnValue(statusPromise),
+    };
+    try {
+      const restarted = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      (restarted as any).saveWatermark(sessionId, 99);
+      restarted.setClient(localClient);
+      await restarted.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "pending user" },
+            { role: "assistant", content: "pending assistant" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "pending-sk" },
+      );
+      for (let i = 0; i < 10 && localClient.getChatTurnStoreStatus.mock.calls.length === 0; i++) {
+        await flushMicrotasks();
+      }
+      expect(localClient.getChatTurnStoreStatus).toHaveBeenCalled();
+      await new Promise((resolve) => setTimeout(resolve, 70));
+      expect((restarted as any).cachedWatermarks.get(sessionId)).toBe(99);
+
+      resolveStatus({ hasAnyChatTurnData: false, existingSessionIds: [] });
+      await restarted.flush();
+
+      expect(localClient.storeChatTurn).toHaveBeenCalledTimes(1);
+      expect(localClient.storeChatTurn.mock.calls[0][1]).toBe("pending user");
+      expect(localClient.storeChatTurn.mock.calls[0][2]).toBe("pending assistant");
+      restarted.flushSync();
+    } finally {
+      fs.rmSync(directStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clears stale cursor state then cold-start clamps a longer transcript to the latest pair", async () => {
+    const directStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-stale-clamp-"));
+    const sessionId = "openclaw:tg:acct:conv:sk-clamp";
+    const directFile = path.join(directStateDir, "chat-turn-watermarks.json");
+    const localClient = {
+      storeChatTurn: vi.fn().mockResolvedValue(undefined),
+      getChatTurnStoreStatus: vi.fn().mockResolvedValue({
+        hasAnyChatTurnData: false,
+        existingSessionIds: [],
+      }),
+    };
+    try {
+      fs.writeFileSync(directFile, JSON.stringify({ [sessionId]: { w: 0, b: 0 } }));
+      const restarted = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      await restarted.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "old u1" },
+            { role: "assistant", content: "old a1" },
+            { role: "user", content: "old u2" },
+            { role: "assistant", content: "old a2" },
+            { role: "user", content: "current u3" },
+            { role: "assistant", content: "current a3" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "sk-clamp" },
+      );
+      await restarted.flush();
+
+      expect(localClient.storeChatTurn).toHaveBeenCalledTimes(1);
+      expect(localClient.storeChatTurn.mock.calls[0][1]).toBe("current u3");
+      expect(localClient.storeChatTurn.mock.calls[0][2]).toBe("current a3");
+      const persisted = JSON.parse(fs.readFileSync(directFile, "utf-8"));
+      expect(persisted[sessionId]).toEqual({ w: 2, b: 0 });
+      restarted.flushSync();
+    } finally {
+      fs.rmSync(directStateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves local cursor state when daemon status validation fails", async () => {
+    const directStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-stale-validation-failure-"));
+    const sessionId = "openclaw:tg:acct:conv:sk-validation-failure";
+    const directFile = path.join(directStateDir, "chat-turn-watermarks.json");
+    const localClient = {
+      storeChatTurn: vi.fn().mockResolvedValue(undefined),
+      getChatTurnStoreStatus: vi.fn().mockRejectedValue(new Error("network unavailable")),
+    };
+    try {
+      fs.writeFileSync(directFile, JSON.stringify({ [sessionId]: { w: 99, b: 0 } }));
+      const restarted = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      await restarted.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "should remain skipped" },
+            { role: "assistant", content: "validation failed" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "sk-validation-failure" },
+      );
+      await restarted.flush();
+
+      expect(localClient.storeChatTurn).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to validate chat-turn cursor state"),
+        expect.objectContaining({ sessionId }),
+      );
+      const persisted = JSON.parse(fs.readFileSync(directFile, "utf-8"));
+      expect(persisted[sessionId]).toEqual({ w: 99, b: 0 });
+      restarted.flushSync();
+    } finally {
       fs.rmSync(directStateDir, { recursive: true, force: true });
     }
   });
@@ -2429,6 +2905,105 @@ describe("ChatTurnWriter", () => {
     restarted.flushSync();
   });
 
+  it("T457 — direct-channel marker aliases skip formatted OpenClaw transcript bodies with assistant render drift", async () => {
+    await writer.onAgentEnd({
+      sessionId: "seed",
+      messages: [
+        { role: "user", content: "previous telegram question" },
+        { role: "assistant", content: "previous telegram answer" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-formatted",
+      user: "raw ui question",
+      userAliases: ["[DKG UI Owner] raw ui question"],
+      assistant: "node ui answer",
+    });
+
+    await writer.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "previous telegram question" },
+        { role: "assistant", content: "previous telegram answer" },
+        {
+          role: "user",
+          content: "[DKG UI Owner] raw ui question",
+          context: { Provider: "dkg-ui", DkgTurnId: "node-ui-corr-formatted" },
+        },
+        { role: "assistant", content: "[DKG UI delivered] node ui answer" },
+        { role: "user", content: "next telegram question" },
+        { role: "assistant", content: "next telegram answer" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("next telegram question");
+    writer.flushSync();
+  });
+
+  it("T457 — ordered direct-channel marker skips metadata-stripped UI backfill before live Telegram pair", async () => {
+    await writer.onAgentEnd({
+      sessionId: "seed",
+      messages: [
+        { role: "user", content: "previous telegram question" },
+        { role: "assistant", content: "previous telegram answer" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-stripped",
+      user: "raw ui question",
+      assistant: "node ui answer",
+    });
+
+    await writer.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "previous telegram question" },
+        { role: "assistant", content: "previous telegram answer" },
+        { role: "user", content: "raw ui question" },
+        { role: "assistant", content: "[DKG UI delivered] rendered transcript answer" },
+        { role: "user", content: "next telegram question" },
+        { role: "assistant", content: "next telegram answer" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("next telegram question");
+    writer.flushSync();
+  });
+
+  it("T457 — ordered direct-channel marker does not skip the live pair when no historical pair is present", async () => {
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-missing",
+      user: "ui question not in transcript",
+      assistant: "ui answer not in transcript",
+    });
+
+    await writer.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "telegram only question" },
+        { role: "assistant", content: "telegram only answer" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("telegram only question");
+    writer.flushSync();
+  });
+
   it("T359 - typed Telegram W4b and Node-UI external markers both suppress W4a duplicates after restart", async () => {
     await writer.markExternalTurnPersistedDurable({
       sessionKey: "agent:main:main",
@@ -2573,7 +3148,7 @@ describe("ChatTurnWriter", () => {
 
     const externalCursorKey = (writer as any).externalCursorKeyFromSessionKey("agent:main:main");
     const bucket: Map<string, number> | undefined = (writer as any).externalTurnMarkers.get(externalCursorKey);
-    expect(Array.from(bucket?.values() ?? [])).toEqual([1]);
+    expect(Array.from(bucket?.values() ?? [])).toEqual([1, 1, 1]);
     writeSpy.mockRestore();
   });
 
@@ -2686,7 +3261,7 @@ describe("ChatTurnWriter", () => {
     restarted.flushSync();
   });
 
-  it("T85 - session-key external markers require an exact ID", async () => {
+  it("T85 - ordered direct marker skips an ID-less historical direct pair before the live pair", async () => {
     await writer.markExternalTurnPersistedDurable({
       sessionKey: "agent:main:main",
       turnId: "node-ui-corr-unique-content",
@@ -2696,9 +3271,10 @@ describe("ChatTurnWriter", () => {
     const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
     mockClient.storeChatTurn.mockClear();
     // T362 — Seed past cold-start; the clamp would otherwise discard
-    // the historical UI pair and only emit the latest Telegram pair,
-    // defeating this test's verification that BOTH pairs persist
-    // when the external marker doesn't match an exact ID.
+    // the historical UI pair and only emit the latest Telegram pair.
+    // T457 — The historical direct-channel pair has lost its exact
+    // DkgTurnId by the time Telegram W4a scans the shared transcript,
+    // so the ordered direct marker skips exactly that non-latest pair.
     restarted.onAgentEnd({
       sessionId: "seed",
       messages: [
@@ -2722,9 +3298,8 @@ describe("ChatTurnWriter", () => {
     }, { channelId: "telegram", sessionKey: "agent:main:main" });
     await flushMicrotasks();
 
-    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
     expect(mockClient.storeChatTurn.mock.calls.map((call) => call[1])).toEqual([
-      "unique ui question",
       "telegram question",
     ]);
     restarted.flushSync();

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -271,6 +271,83 @@ describe("ChatTurnWriter", () => {
     }
   });
 
+  it("validates daemon WM once then trusts the external cursor key on the hot path", async () => {
+    // Regression: an earlier draft kept external cursor keys perpetually
+    // marked untrusted while the daemon had any chat-turn data, so every
+    // subsequent onAgentEnd re-issued the 2-query getChatTurnStoreStatus
+    // round trip even after the first validation already proved the keys
+    // were non-stale. Validation is a one-shot operation per
+    // untrusted-marked key; lifecycle events (load, migrate, setClient)
+    // re-mark it untrusted at the right time.
+    const directStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-trust-once-"));
+    const sessionId = "openclaw:tg:acct:conv:trust-sk";
+    const directFile = path.join(directStateDir, "chat-turn-watermarks.json");
+    const localClient = {
+      storeChatTurn: vi.fn().mockResolvedValue(undefined),
+      getChatTurnStoreStatus: vi.fn().mockResolvedValue({
+        hasAnyChatTurnData: true,
+        existingSessionIds: [sessionId],
+      }),
+    };
+    try {
+      const seeder = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+      await seeder.markExternalTurnPersistedDurable({
+        sessionKey: "trust-sk",
+        turnId: "ui-turn",
+        user: "ui user",
+        assistant: "ui assistant",
+      });
+      seeder.flushSync();
+      localClient.storeChatTurn.mockClear();
+      localClient.getChatTurnStoreStatus.mockClear();
+
+      const restarted = new ChatTurnWriter({
+        client: localClient,
+        logger: mockLogger,
+        stateDir: directStateDir,
+        stateLayout: "direct",
+      });
+
+      await restarted.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "tg user 1" },
+            { role: "assistant", content: "tg assistant 1" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "trust-sk" },
+      );
+      await restarted.flush();
+      expect(localClient.getChatTurnStoreStatus).toHaveBeenCalledTimes(1);
+
+      await restarted.onAgentEnd(
+        {
+          sessionId,
+          messages: [
+            { role: "user", content: "tg user 1" },
+            { role: "assistant", content: "tg assistant 1" },
+            { role: "user", content: "tg user 2" },
+            { role: "assistant", content: "tg assistant 2" },
+          ],
+        },
+        { channelId: "tg", accountId: "acct", conversationId: "conv", sessionKey: "trust-sk" },
+      );
+      await restarted.flush();
+      expect(localClient.getChatTurnStoreStatus).toHaveBeenCalledTimes(1);
+      const persistedDoc = JSON.parse(fs.readFileSync(directFile, "utf-8"));
+      expect(persistedDoc["openclaw:transcript:trust-sk"]?.m).toBeDefined();
+      restarted.flushSync();
+    } finally {
+      fs.rmSync(directStateDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not clear fresh direct-channel markers written while stale daemon validation is in flight", async () => {
     const directStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "chatturnwriter-stale-marker-race-"));
     const sessionId = "openclaw:tg:acct:conv:race-sk";

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -2101,12 +2101,13 @@ describe('DkgChannelPlugin', () => {
       'Agent reply',
       { turnId: 'corr-persist' },
     ]);
-    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith({
+    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith(expect.objectContaining({
       sessionKey: 'session-1',
       turnId: 'corr-persist',
       user: 'User message',
+      userAliases: expect.arrayContaining(['[DKG UI Owner] Hello', 'User message']),
       assistant: 'Agent reply',
-    });
+    }));
   });
 
   it('processInbound should persist without throwing when ChatTurnWriter is not wired', async () => {
@@ -2437,12 +2438,12 @@ describe('DkgChannelPlugin', () => {
 
       expect(stopSettled).toBe(true);
       expect(markExternalTurnPersistedDurable).toHaveBeenCalledTimes(1);
-      expect(markExternalTurnPersistedDurable).toHaveBeenLastCalledWith({
+      expect(markExternalTurnPersistedDurable).toHaveBeenLastCalledWith(expect.objectContaining({
         sessionKey: 'session-1',
         turnId: 'corr-marker-initial-hang',
         user: 'Already stored',
         assistant: 'Persisted reply',
-      });
+      }));
       expect((plugin as any).pendingMarkerPersistence.size).toBe(0);
     } finally {
       vi.useRealTimers();
@@ -2497,12 +2498,12 @@ describe('DkgChannelPlugin', () => {
       expect(stopSettled).toBe(true);
       expect(storeCalls).toHaveLength(1);
       expect(markExternalTurnPersistedDurable).toHaveBeenCalledTimes(1);
-      expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith({
+      expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith(expect.objectContaining({
         sessionKey: 'session-1',
         turnId: 'corr-late-marker-after-store',
         user: 'Late store',
         assistant: 'Persisted reply',
-      });
+      }));
       expect((plugin as any).pendingTurnPersistence.size).toBe(0);
       expect((plugin as any).pendingMarkerPersistence.size).toBe(0);
     } finally {
@@ -2610,12 +2611,12 @@ describe('DkgChannelPlugin', () => {
 
       expect(stopSettled).toBe(true);
       expect(markExternalTurnPersistedDurable).toHaveBeenCalledTimes(2);
-      expect(markExternalTurnPersistedDurable).toHaveBeenLastCalledWith({
+      expect(markExternalTurnPersistedDurable).toHaveBeenLastCalledWith(expect.objectContaining({
         sessionKey: 'session-1',
         turnId: 'corr-marker-stop-timeout',
         user: 'Already stored',
         assistant: 'Persisted reply',
-      });
+      }));
       expect((plugin as any).pendingMarkerPersistence.size).toBe(0);
     } finally {
       vi.useRealTimers();
@@ -2844,12 +2845,13 @@ describe('DkgChannelPlugin', () => {
       'Reply!',
       { turnId: 'corr-route-marker' },
     ]);
-    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith({
+    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith(expect.objectContaining({
       sessionKey: 'agent:main:main',
       turnId: 'corr-route-marker',
       user: 'Hello',
+      userAliases: expect.arrayContaining(['Hello']),
       assistant: 'Reply!',
-    });
+    }));
   });
 
   it('processInbound routeInboundMessage fallback hashes the routed agent body for direct-channel markers', async () => {
@@ -2872,12 +2874,13 @@ describe('DkgChannelPlugin', () => {
 
     expect(routeInboundMessage.calls[0][0].text).toContain('Context for this chat turn:');
     expect(storeCalls[0][1]).toBe('Hello');
-    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith({
+    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith(expect.objectContaining({
       sessionKey: 'agent:main:main',
       turnId: 'corr-route-context-marker',
       user: expect.stringContaining('Context for this chat turn:'),
+      userAliases: expect.arrayContaining(['Hello']),
       assistant: 'Reply!',
-    });
+    }));
   });
 
   it('processInbound routeInboundMessage fallback does not collapse owner-like identities into the owner marker bucket', async () => {
@@ -2900,12 +2903,12 @@ describe('DkgChannelPlugin', () => {
     }));
     expect(routeInboundMessage.calls[0][0]).not.toHaveProperty('sessionKey');
     expect(routeInboundMessage.calls[0][0]).not.toHaveProperty('SessionKey');
-    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith({
+    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith(expect.objectContaining({
       sessionKey: 'agent:main:owner',
       turnId: 'corr-route-ownerish',
       user: 'Hello',
       assistant: 'Reply!',
-    });
+    }));
   });
 
   it('processInbound routeInboundMessage fallback marks non-owner direct-channel persists with the non-owner session key', async () => {
@@ -2935,12 +2938,12 @@ describe('DkgChannelPlugin', () => {
       'Worker reply',
       { turnId: 'corr-route-worker' },
     ]);
-    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith({
+    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith(expect.objectContaining({
       sessionKey: 'agent:main:background-worker',
       turnId: 'corr-route-worker',
       user: 'Work item',
       assistant: 'Worker reply',
-    });
+    }));
   });
 
   it('processInbound routeInboundMessage fallback accepts uppercase reply SessionKey for marker persistence', async () => {
@@ -2960,12 +2963,12 @@ describe('DkgChannelPlugin', () => {
 
     expect((reply as any).SessionKey).toBe('agent:legacy:actual');
     expect(reply.sessionKey).toBe('agent:legacy:actual');
-    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith({
+    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith(expect.objectContaining({
       sessionKey: 'agent:legacy:actual',
       turnId: 'corr-route-uppercase-session',
       user: 'Hello',
       assistant: 'Reply!',
-    });
+    }));
   });
 
   it('processInbound routeInboundMessage fallback skips marker persistence when the route does not return its resolved session key', async () => {
@@ -3164,12 +3167,13 @@ describe('DkgChannelPlugin', () => {
       'Streamed reply',
       { turnId: 'corr-stream-runtime', attachmentRefs },
     ]);
-    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith({
+    expect(markExternalTurnPersistedDurable).toHaveBeenCalledWith(expect.objectContaining({
       sessionKey: 'session-1',
       turnId: 'corr-stream-runtime',
       user: expect.stringContaining('Attached Working Memory items:'),
+      userAliases: expect.arrayContaining(['Hello']),
       assistant: 'Streamed reply',
-    });
+    }));
   });
 
   it('processInboundStream should wait for a still-running dispatch to settle before persisting a closed stream', async () => {

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -297,6 +297,27 @@ describe('DkgDaemonClient', () => {
       .toThrow('responded 500');
   });
 
+  it('getChatTurnStoreStatus propagates unrelated 404s instead of swallowing them as "no chat data"', async () => {
+    // Regression: an early matcher accepted any 404 whose message mentioned
+    // generic words like "context" or "graph", which would silently clear
+    // local cursor state for unrelated daemon failures. The not-found check
+    // must require the chat-turns assertion name specifically.
+    fetchResponses.push(
+      new Response(JSON.stringify({
+        agentAddress: '0x1234567890123456789012345678901234567890',
+        agentDid: 'did:dkg:agent:0x1234567890123456789012345678901234567890',
+        name: 'default-agent',
+        peerId: '12D3KooWPeer',
+        nodeIdentityId: '7',
+      }), { status: 200 }),
+      new Response(JSON.stringify({ error: 'Context graph some-other-graph not found' }), { status: 404 }),
+    );
+
+    await expect(client.getChatTurnStoreStatus(['openclaw:tg:::sk']))
+      .rejects
+      .toThrow('responded 404');
+  });
+
   // ---------------------------------------------------------------------------
   // Workspace write
   // ---------------------------------------------------------------------------

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -195,6 +195,108 @@ describe('DkgDaemonClient', () => {
     expect(body.subGraphName).toBe('protocols');
   });
 
+  it('getChatTurnStoreStatus queries chat-turn WM status and returns matching sessions', async () => {
+    fetchResponses.push(
+      new Response(JSON.stringify({
+        agentAddress: '0x1234567890123456789012345678901234567890',
+        agentDid: 'did:dkg:agent:0x1234567890123456789012345678901234567890',
+        name: 'default-agent',
+        peerId: '12D3KooWPeer',
+        nodeIdentityId: '7',
+      }), { status: 200 }),
+      new Response(JSON.stringify({
+        result: { bindings: [{ c: '"8"^^<http://www.w3.org/2001/XMLSchema#integer>' }] },
+      }), { status: 200 }),
+      new Response(JSON.stringify({
+        result: { bindings: [{ sid: '"openclaw:tg:::sk-1"' }] },
+      }), { status: 200 }),
+    );
+
+    const status = await client.getChatTurnStoreStatus([
+      'openclaw:tg:::sk-1',
+      'openclaw:tg:::missing',
+    ]);
+
+    expect(status).toEqual({
+      hasAnyChatTurnData: true,
+      existingSessionIds: ['openclaw:tg:::sk-1'],
+    });
+    expect(fetchCalls).toHaveLength(3);
+    expect(fetchCalls[0][0]).toBe('http://localhost:9200/api/agent/identity');
+    const countBody = JSON.parse(fetchCalls[1][1]?.body as string);
+    expect(countBody).toMatchObject({
+      contextGraphId: 'agent-context',
+      view: 'working-memory',
+      assertionName: 'chat-turns',
+      agentAddress: '0x1234567890123456789012345678901234567890',
+    });
+    expect(countBody.sparql).toContain('COUNT(*) AS ?c');
+    const sessionBody = JSON.parse(fetchCalls[2][1]?.body as string);
+    expect(sessionBody).toMatchObject({
+      contextGraphId: 'agent-context',
+      view: 'working-memory',
+      assertionName: 'chat-turns',
+      agentAddress: '0x1234567890123456789012345678901234567890',
+    });
+    expect(sessionBody.sparql).toContain('VALUES ?sid');
+    expect(sessionBody.sparql).toContain('"openclaw:tg:::sk-1"');
+    expect(sessionBody.sparql).toContain('"openclaw:tg:::missing"');
+  });
+
+  it('getChatTurnStoreStatus returns empty status when chat-turn assertion has no data', async () => {
+    fetchResponses.push(
+      new Response(JSON.stringify({
+        agentAddress: '0x1234567890123456789012345678901234567890',
+        agentDid: 'did:dkg:agent:0x1234567890123456789012345678901234567890',
+        name: 'default-agent',
+        peerId: '12D3KooWPeer',
+        nodeIdentityId: '7',
+      }), { status: 200 }),
+      new Response(JSON.stringify({
+        results: { bindings: [{ c: { value: '0' } }] },
+      }), { status: 200 }),
+    );
+
+    const status = await client.getChatTurnStoreStatus(['openclaw:tg:::sk']);
+
+    expect(status).toEqual({ hasAnyChatTurnData: false, existingSessionIds: [] });
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  it('getChatTurnStoreStatus returns empty status for missing chat-turn assertion/context', async () => {
+    fetchResponses.push(
+      new Response(JSON.stringify({
+        agentAddress: '0x1234567890123456789012345678901234567890',
+        agentDid: 'did:dkg:agent:0x1234567890123456789012345678901234567890',
+        name: 'default-agent',
+        peerId: '12D3KooWPeer',
+        nodeIdentityId: '7',
+      }), { status: 200 }),
+      new Response(JSON.stringify({ error: 'Assertion chat-turns not found' }), { status: 404 }),
+    );
+
+    const status = await client.getChatTurnStoreStatus(['openclaw:tg:::sk']);
+
+    expect(status).toEqual({ hasAnyChatTurnData: false, existingSessionIds: [] });
+  });
+
+  it('getChatTurnStoreStatus propagates unexpected daemon failures', async () => {
+    fetchResponses.push(
+      new Response(JSON.stringify({
+        agentAddress: '0x1234567890123456789012345678901234567890',
+        agentDid: 'did:dkg:agent:0x1234567890123456789012345678901234567890',
+        name: 'default-agent',
+        peerId: '12D3KooWPeer',
+        nodeIdentityId: '7',
+      }), { status: 200 }),
+      new Response(JSON.stringify({ error: 'boom' }), { status: 500 }),
+    );
+
+    await expect(client.getChatTurnStoreStatus(['openclaw:tg:::sk']))
+      .rejects
+      .toThrow('responded 500');
+  });
+
   // ---------------------------------------------------------------------------
   // Workspace write
   // ---------------------------------------------------------------------------

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -6641,12 +6641,12 @@ describe('DkgNodePlugin', () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(storeCalls).toHaveLength(1);
-      expect(markerSpy).toHaveBeenCalledWith({
+      expect(markerSpy).toHaveBeenCalledWith(expect.objectContaining({
         sessionKey: 'session-order',
         turnId: 'corr-writer-order',
         user: 'Immediate inbound',
         assistant: 'Immediate reply',
-      });
+      }));
       expect((plugin as any).channelPlugin.chatTurnWriter).toBe((plugin as any).chatTurnWriter);
     } finally {
       markerSpy.mockRestore();


### PR DESCRIPTION
## Summary

This PR closes two distinct bugs that both manifested as Telegram chat-turn persistence misbehaving on the openclaw adapter:

1. **Stale local cursor outliving daemon WM** — if `ChatTurnWriter` loaded a watermark from disk but the daemon `agent-context/chat-turns` working memory had been wiped, the first Telegram `agent_end` would skip every pair as "already persisted" and silently drop the turn. Fix: validate untrusted (loaded/migrated) cursor state against the daemon WM before W4a trusts it. If the daemon proves the assertion is empty or the session is absent, clear only the candidate cursor keys and let the cold-start clamp persist the latest visible turn.
2. **Mixed Node-UI → first Telegram persisted duplicate UI pairs** — after the stale-cursor fix landed, live smoke showed that one Node-UI turn followed by a Telegram turn still produced 2 W4a persists (one duplicate of the UI pair + the live Telegram pair). Root cause: the `__external_ordered_turns__` marker was written through the same `Math.max(prev, 1)` helper used for content-bound markers. That clamps the ordered count to 1 regardless of how many UI turns happened — but the ordered marker is a one-shot ticket per direct persist that W4a *consumes* (`count - 1`) when a metadata-stripped historical UI pair has no exact/user marker. N direct UI persists must leave N tickets so W4a can skip N historical pairs. Fix: route the ordered marker write through a dedicated additive helper (`incrementOrderedExternalTurnMarker`) while content-bound exact/user markers continue to use `restoreExternalTurnMarker` (idempotent `Math.max`, which is correct for them).

## Root cause distinction

The non-obvious property that the prior fix attempts missed:

| Marker shape | Semantics | Write |
|---|---|---|
| Exact (`turnId + user + assistant`) | Content-bound durable success fact. Repeated writes for the same content are the same fact. | Idempotent (`Math.max(prev, 1)`) |
| User (`turnId + user`) | Same, with assistant-render tolerance for `externalDirect=true`. | Idempotent (`Math.max(prev, 1)`) |
| Ordered (`__external_ordered_turns__`) | One-shot ticket per direct persist. W4a consumes one ticket per metadata-stripped historical pair. | **Additive (`prev + 1`)** |

The idempotent invariant is right for content-bound markers and was the reason the prior team chose `Math.max` (see existing lessons: "Marker Counts Are Multiplicities" and "Exact Marker Migrations Are Idempotent"). The ordered marker is structurally different and needs additive accumulation.

## Live smoke evidence

After the fix, the four scenarios that previously misbehaved or risked regression all pass:

| Scenario | Pre-fix expectation | Post-fix observed |
|---|---|---|
| 1 UI → 1 Telegram | 1 persist (TG) | 1 persist ✓ |
| 2 UI → 1 Telegram | 1 persist (TG); both UI pairs skipped | Pair 0 `markerSkip=true orderedAvailable=true`, pair 1 `markerSkip=true orderedAvailable=false`, pair 2 (TG) persisted ✓ |
| 3 Telegram in a row | 3 persists, ordered marker untouched | `markerBucketSize=58` stable, 3 persists ✓ |
| Restart → 1 TG, 1 UI, 1 TG | Markers durable; mixed path works post-restart | Bucket size loaded back 58; UI write bumps to 65; next TG consumes one ordered ticket ✓ |

## Files changed

| File | What |
|------|------|
| `packages/adapter-openclaw/src/ChatTurnWriter.ts` | Validates untrusted loaded/migrated cursor state against daemon WM (stale-cursor fix). Splits external-turn marker writes so the ordered marker accumulates additively while content-bound markers stay idempotent (duplicate-persist fix). Adds `incrementOrderedExternalTurnMarker` helper. |
| `packages/adapter-openclaw/src/DkgChannelPlugin.ts` | Supplies direct-channel marker aliases for raw, agent-body, and formatted transcript user-body variants without exposing them in public replies. |
| `packages/adapter-openclaw/src/dkg-client.ts` | Adds `getChatTurnStoreStatus` daemon query helper with canonical agent identity and RDF literal binding parsing. |
| `packages/adapter-openclaw/test/ChatTurnWriter.test.ts` | Adds stale-watermark, legacy migration, partial cleanup, concurrent state, validation-failure, direct-channel drift, ordered-marker fallback, and N-direct-persist (T458) regressions. |
| `packages/adapter-openclaw/test/dkg-channel.test.ts` | Covers marker alias wiring while preserving direct-channel persistence behavior. |
| `packages/adapter-openclaw/test/dkg-client.test.ts` | Covers chat-turn status query body, RDF literal bindings, missing assertions, and failure propagation. |
| `packages/adapter-openclaw/test/plugin.test.ts` | Keeps the writer-before-channel-route wiring regression aligned with marker aliases. |

## Related

- Follow-up to #359
- Follow-up to #362
- Related symptom class: #410

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw run build` — clean
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/HookSurface.test.ts test/plugin.test.ts test/ChatTurnWriter.test.ts test/ChatTurnWriter.crashRecovery.test.ts test/dkg-channel.test.ts test/dkg-client.test.ts` — **563 tests passed** (was 562; +1 for new T458)
- [x] Targeted marker slice (`T457|T458|T84|T85|T86|T91|T92|T93|T83|T97|T99|T105`) — 17 tests passed
- [x] Live stale-cursor Telegram smoke (daemon WM wiped, adapter retained): first message persists, logs show stale-cursor cleanup + cold-start clamp
- [x] Live gateway-restart Telegram smoke: post-restart message persists exactly once with no cleanup loop
- [x] Live mixed Node-UI → first Telegram smoke: exactly one persist for the Telegram pair (no UI duplicates) — verified across 1+1, 2+1, 3-TG-only, and restart-mixed variants
- [ ] CLI daemon `persist-turn` slice: attempted locally, blocked by pre-existing `TypeError: Cannot read properties of undefined (reading 'AGENTS')` in `packages/agent/src/profile.ts`; left for CI

## Commits

- `09e9e8fc` — stale-cursor validation against daemon WM (original PR scope)
- `b2c1a281` — accumulate ordered direct-channel marker per UI persist
- `fd084772` + `facc3c82` — info-level diagnostics added during investigation and removed once the fix was confirmed by live smoke (net zero code change; visible only in PR history)