### PR TITLE
Add semantic enrichment flow for imported attachments

### DIFF
--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -24,7 +24,7 @@ import secrets
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode
 
 from agent.memory_provider import MemoryProvider
@@ -520,6 +520,16 @@ QUAD_SCHEMA = {
     "required": ["subject", "predicate", "object"],
 }
 
+SEMANTIC_TRIPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "subject": {"type": "string", "description": "Subject URI."},
+        "predicate": {"type": "string", "description": "Predicate URI."},
+        "object": {"type": "string", "description": "Object URI or literal text."},
+    },
+    "required": ["subject", "predicate", "object"],
+}
+
 DKG_ASSERTION_CREATE_SCHEMA = {
     "name": "dkg_assertion_create",
     "description": "Create a Working Memory assertion in a context graph.",
@@ -597,7 +607,7 @@ DKG_ASSERTION_IMPORT_FILE_SCHEMA = {
 
 DKG_ASSERTION_QUERY_SCHEMA = {
     "name": "dkg_assertion_query",
-    "description": "Dump every quad from one Working Memory assertion. Use dkg_query for SPARQL.",
+    "description": "Dump every quad from one Working Memory assertion. Use dkg_query for SPARQL. Use this to inspect deterministic import quads before semantic enrichment.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -606,6 +616,60 @@ DKG_ASSERTION_QUERY_SCHEMA = {
             "sub_graph_name": {"type": "string", "description": "Optional sub-graph name."},
         },
         "required": ["context_graph_id", "name"],
+    },
+}
+
+DKG_IMPORT_ARTIFACT_RESOLVE_SCHEMA = {
+    "name": "dkg_import_artifact_resolve",
+    "description": "Resolve a completed imported attachment/assertion into deterministic artifact metadata. Skipped imports are rejected.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "context_graph_id": {"type": "string", "description": "Context graph ID from the attachment ref."},
+            "assertion_uri": {"type": "string", "description": "Completed imported assertion URI."},
+            "assertion_name": {"type": "string", "description": "Optional source assertion name to cross-check against assertion_uri."},
+            "file_hash": {"type": "string", "description": "Optional source file hash to verify."},
+            "sub_graph_name": {"type": "string", "description": "Optional sub-graph name."},
+        },
+        "required": ["context_graph_id", "assertion_uri"],
+    },
+}
+
+DKG_IMPORT_ARTIFACT_READ_MARKDOWN_SCHEMA = {
+    "name": "dkg_import_artifact_read_markdown",
+    "description": "Read Markdown for a completed imported attachment through daemon content-addressed storage, never arbitrary filesystem paths.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "context_graph_id": {"type": "string", "description": "Context graph ID from the attachment ref."},
+            "assertion_uri": {"type": "string", "description": "Completed imported assertion URI."},
+            "assertion_name": {"type": "string", "description": "Optional source assertion name to cross-check against assertion_uri."},
+            "file_hash": {"type": "string", "description": "Optional source file hash to verify."},
+            "sub_graph_name": {"type": "string", "description": "Optional sub-graph name."},
+            "max_bytes": {"type": "integer", "description": "Optional byte cap; daemon maximum is 5 MiB."},
+        },
+        "required": ["context_graph_id", "assertion_uri"],
+    },
+}
+
+DKG_SEMANTIC_ENRICHMENT_WRITE_SCHEMA = {
+    "name": "dkg_semantic_enrichment_write",
+    "description": "Write model-derived triples to a separate Working Memory assertion with provenance pointing to a completed import artifact. Does not promote or publish.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "context_graph_id": {"type": "string", "description": "Context graph ID from the attachment ref."},
+            "assertion_uri": {"type": "string", "description": "Source imported assertion URI from the attachment ref."},
+            "assertion_name": {"type": "string", "description": "Optional source assertion name to cross-check against assertion_uri."},
+            "file_hash": {"type": "string", "description": "Optional source file hash to verify."},
+            "name": {"type": "string", "description": "Optional target semantic enrichment assertion name."},
+            "semantic_quads": {"type": "array", "items": SEMANTIC_TRIPLE_SCHEMA, "description": "Model-derived triples written to the target assertion graph; provenance is added by the daemon."},
+            "generation_method": {"type": "string", "description": "Extraction/generation method label."},
+            "agent_identity": {"type": "string", "description": "Agent identity URI or label for provenance; only URIs are emitted as prov:wasAttributedTo resources."},
+            "generated_at": {"type": "string", "description": "ISO timestamp; defaults to daemon time."},
+            "sub_graph_name": {"type": "string", "description": "Optional sub-graph name."},
+        },
+        "required": ["context_graph_id", "assertion_uri", "semantic_quads"],
     },
 }
 
@@ -906,6 +970,8 @@ class DKGMemoryProvider(MemoryProvider):
             "  dkg_query — Search knowledge via SPARQL (fast, local)\n"
             "  dkg_assertion_create/write/promote/query/history/discard/import_file — Work with V10 WM assertions\n"
             "\n"
+            "  dkg_import_artifact_resolve/read_markdown + dkg_semantic_enrichment_write - Enrich imported attachments without modifying deterministic import assertions\n"
+            "\n"
             "COLLABORATION WORKFLOW:\n"
             "  dkg_share — Share findings to Shared Working Memory (team-visible, free)\n"
             f"{publish_guidance}"
@@ -965,6 +1031,9 @@ class DKGMemoryProvider(MemoryProvider):
             DKG_ASSERTION_DISCARD_SCHEMA,
             DKG_ASSERTION_IMPORT_FILE_SCHEMA,
             DKG_ASSERTION_QUERY_SCHEMA,
+            DKG_IMPORT_ARTIFACT_RESOLVE_SCHEMA,
+            DKG_IMPORT_ARTIFACT_READ_MARKDOWN_SCHEMA,
+            DKG_SEMANTIC_ENRICHMENT_WRITE_SCHEMA,
             DKG_ASSERTION_HISTORY_SCHEMA,
             DKG_SUB_GRAPH_CREATE_SCHEMA,
             DKG_SUB_GRAPH_LIST_SCHEMA,
@@ -1016,6 +1085,9 @@ class DKGMemoryProvider(MemoryProvider):
             "dkg_assertion_discard": self._handle_assertion_discard,
             "dkg_assertion_import_file": self._handle_assertion_import_file,
             "dkg_assertion_query": self._handle_assertion_query,
+            "dkg_import_artifact_resolve": self._handle_import_artifact_resolve,
+            "dkg_import_artifact_read_markdown": self._handle_import_artifact_read_markdown,
+            "dkg_semantic_enrichment_write": self._handle_semantic_enrichment_write,
             "dkg_assertion_history": self._handle_assertion_history,
             "dkg_sub_graph_create": self._handle_sub_graph_create,
             "dkg_sub_graph_list": self._handle_sub_graph_list,
@@ -1853,6 +1925,75 @@ class DKGMemoryProvider(MemoryProvider):
             return tool_error("name is required.")
         return json.dumps(self._client.query_assertion(name, cg, sub_graph_name=_first_text(args, "sub_graph_name")))
 
+    def _handle_import_artifact_resolve(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline.")
+        cg = _first_text(args, "context_graph_id")
+        assertion_uri = _first_text(args, "assertion_uri") or _first_text(args, "source_assertion_uri")
+        assertion_name = _first_text(args, "assertion_name")
+        if not cg:
+            return tool_error("context_graph_id is required.")
+        if not assertion_uri:
+            return tool_error("assertion_uri is required.")
+        return json.dumps(self._client.resolve_import_artifact(
+            cg,
+            assertion_uri=assertion_uri,
+            assertion_name=assertion_name,
+            file_hash=_first_text(args, "file_hash"),
+            sub_graph_name=_first_text(args, "sub_graph_name"),
+        ))
+
+    def _handle_import_artifact_read_markdown(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline.")
+        cg = _first_text(args, "context_graph_id")
+        assertion_uri = _first_text(args, "assertion_uri") or _first_text(args, "source_assertion_uri")
+        assertion_name = _first_text(args, "assertion_name")
+        if not cg:
+            return tool_error("context_graph_id is required.")
+        if not assertion_uri:
+            return tool_error("assertion_uri is required.")
+        max_bytes = args.get("max_bytes")
+        if max_bytes is not None:
+            try:
+                max_bytes = int(max_bytes)
+            except Exception:
+                return tool_error("max_bytes must be an integer.")
+        return json.dumps(self._client.read_import_artifact_markdown(
+            cg,
+            assertion_uri=assertion_uri,
+            assertion_name=assertion_name,
+            file_hash=_first_text(args, "file_hash"),
+            sub_graph_name=_first_text(args, "sub_graph_name"),
+            max_bytes=max_bytes,
+        ))
+
+    def _handle_semantic_enrichment_write(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline.")
+        cg = _first_text(args, "context_graph_id")
+        assertion_uri = _first_text(args, "assertion_uri") or _first_text(args, "source_assertion_uri")
+        assertion_name = _first_text(args, "assertion_name")
+        if not cg:
+            return tool_error("context_graph_id is required.")
+        if not assertion_uri:
+            return tool_error("assertion_uri is required.")
+        quads, quad_error = _normalize_semantic_quads(args.get("semantic_quads"))
+        if quad_error:
+            return tool_error(quad_error)
+        return json.dumps(self._client.write_semantic_enrichment(
+            cg,
+            quads,
+            assertion_uri=assertion_uri,
+            assertion_name=assertion_name,
+            file_hash=_first_text(args, "file_hash"),
+            name=_first_text(args, "name") or _first_text(args, "semantic_assertion_name"),
+            generation_method=_first_text(args, "generation_method"),
+            agent_identity=_first_text(args, "agent_identity"),
+            generated_at=_first_text(args, "generated_at"),
+            sub_graph_name=_first_text(args, "sub_graph_name"),
+        ))
+
     def _handle_assertion_history(self, args: Dict[str, Any]) -> str:
         if self._offline:
             return tool_error("DKG daemon is offline.")
@@ -2096,9 +2237,17 @@ class DKGMemoryProvider(MemoryProvider):
 # Helpers
 # ---------------------------------------------------------------------------
 
+_IRI_SCHEME_RE = re.compile(r'^[A-Za-z][A-Za-z0-9+.-]*:[^\s<>"{}|\\^`\x00-\x20]+$')
+
+
+def _is_safe_iri(value: str) -> bool:
+    """Mirror the daemon/core safe-IRI contract for SPARQL-interpolated terms."""
+    return bool(value) and bool(_IRI_SCHEME_RE.match(value))
+
+
 def _is_uri(value: str) -> bool:
-    """Check if a value looks like a URI."""
-    return bool(value) and any(value.startswith(p) for p in ("http://", "https://", "urn:", "did:"))
+    """Check if a value is a safe scheme-based IRI."""
+    return _is_safe_iri(value)
 
 
 def _escape_sparql(text: str) -> str:
@@ -2213,6 +2362,28 @@ def _normalize_quads(raw_quads: Any) -> List[Dict[str, str]]:
             quad["graph"] = str(raw.get("graph", ""))
         quads.append(quad)
     return quads
+
+
+def _normalize_semantic_quads(raw_quads: Any) -> Tuple[List[Dict[str, str]], Optional[str]]:
+    if not isinstance(raw_quads, list) or not raw_quads:
+        return [], "semantic_quads must contain at least one item with subject, predicate, and object."
+    quads: List[Dict[str, str]] = []
+    for index, raw in enumerate(raw_quads):
+        if not isinstance(raw, dict):
+            return [], f"semantic_quads[{index}] must be an object."
+        if raw.get("graph") is not None:
+            return [], f"semantic_quads[{index}].graph is not supported; semantic triples are written to the target assertion graph."
+        subject = str(raw.get("subject", "")).strip()
+        predicate = str(raw.get("predicate", "")).strip()
+        object_value = str(raw.get("object", "")).strip()
+        if not subject or not predicate or not object_value:
+            return [], f"semantic_quads[{index}] must include non-empty subject, predicate, and object."
+        quads.append({
+            "subject": subject,
+            "predicate": predicate,
+            "object": object_value if _is_safe_iri(object_value) or object_value.startswith('"') else _quote_literal(object_value),
+        })
+    return quads, None
 
 
 def _quad_root_entities(quads: List[Dict[str, str]]) -> List[str]:

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -646,7 +646,7 @@ DKG_IMPORT_ARTIFACT_READ_MARKDOWN_SCHEMA = {
             "assertion_name": {"type": "string", "description": "Optional source assertion name to cross-check against assertion_uri."},
             "file_hash": {"type": "string", "description": "Optional source file hash to verify."},
             "sub_graph_name": {"type": "string", "description": "Optional sub-graph name."},
-            "max_bytes": {"type": "integer", "description": "Optional byte cap; daemon maximum is 5 MiB."},
+            "max_bytes": {"type": "integer", "description": "Optional positive integer byte cap; daemon maximum is 5 MiB."},
         },
         "required": ["context_graph_id", "assertion_uri"],
     },
@@ -1955,10 +1955,20 @@ class DKGMemoryProvider(MemoryProvider):
             return tool_error("assertion_uri is required.")
         max_bytes = args.get("max_bytes")
         if max_bytes is not None:
-            try:
-                max_bytes = int(max_bytes)
-            except Exception:
-                return tool_error("max_bytes must be an integer.")
+            if isinstance(max_bytes, bool):
+                return tool_error("max_bytes must be a positive integer.")
+            if isinstance(max_bytes, str):
+                stripped_max_bytes = max_bytes.strip()
+                if not stripped_max_bytes:
+                    return tool_error("max_bytes must be a positive integer.")
+                try:
+                    max_bytes = int(stripped_max_bytes)
+                except Exception:
+                    return tool_error("max_bytes must be a positive integer.")
+            elif not isinstance(max_bytes, int):
+                return tool_error("max_bytes must be a positive integer.")
+            if max_bytes <= 0:
+                return tool_error("max_bytes must be a positive integer.")
         return json.dumps(self._client.read_import_artifact_markdown(
             cg,
             assertion_uri=assertion_uri,

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -621,7 +621,7 @@ DKG_ASSERTION_QUERY_SCHEMA = {
 
 DKG_IMPORT_ARTIFACT_RESOLVE_SCHEMA = {
     "name": "dkg_import_artifact_resolve",
-    "description": "Resolve a completed imported attachment/assertion into deterministic artifact metadata. Skipped imports are rejected.",
+    "description": "Optional validation/debug helper. Resolve a completed imported attachment/assertion into deterministic artifact metadata. Skipped imports are rejected.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -654,7 +654,7 @@ DKG_IMPORT_ARTIFACT_READ_MARKDOWN_SCHEMA = {
 
 DKG_SEMANTIC_ENRICHMENT_WRITE_SCHEMA = {
     "name": "dkg_semantic_enrichment_write",
-    "description": "Write model-derived triples to a separate Working Memory assertion with provenance pointing to a completed import artifact. Does not promote or publish.",
+    "description": "Append model-derived triples to a completed imported assertion with daemon-stamped provenance. Does not promote, finalize, or publish.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -662,8 +662,7 @@ DKG_SEMANTIC_ENRICHMENT_WRITE_SCHEMA = {
             "assertion_uri": {"type": "string", "description": "Source imported assertion URI from the attachment ref."},
             "assertion_name": {"type": "string", "description": "Optional source assertion name to cross-check against assertion_uri."},
             "file_hash": {"type": "string", "description": "Optional source file hash to verify."},
-            "name": {"type": "string", "description": "Optional target semantic enrichment assertion name."},
-            "semantic_quads": {"type": "array", "items": SEMANTIC_TRIPLE_SCHEMA, "description": "Model-derived triples written to the target assertion graph; provenance is added by the daemon."},
+            "semantic_quads": {"type": "array", "items": SEMANTIC_TRIPLE_SCHEMA, "description": "Model-derived triples appended to the source imported assertion graph; provenance is added by the daemon."},
             "generation_method": {"type": "string", "description": "Extraction/generation method label."},
             "agent_identity": {"type": "string", "description": "Agent identity URI or label for provenance; only URIs are emitted as prov:wasAttributedTo resources."},
             "generated_at": {"type": "string", "description": "ISO timestamp; defaults to daemon time."},
@@ -970,7 +969,8 @@ class DKGMemoryProvider(MemoryProvider):
             "  dkg_query — Search knowledge via SPARQL (fast, local)\n"
             "  dkg_assertion_create/write/promote/query/history/discard/import_file — Work with V10 WM assertions\n"
             "\n"
-            "  dkg_import_artifact_resolve/read_markdown + dkg_semantic_enrichment_write - Enrich imported attachments without modifying deterministic import assertions\n"
+            "  dkg_import_artifact_read_markdown + dkg_semantic_enrichment_write - Read imported attachment Markdown and append semantic triples to the imported assertion\n"
+            "  dkg_import_artifact_resolve - Optional metadata re-check for imported attachments\n"
             "\n"
             "COLLABORATION WORKFLOW:\n"
             "  dkg_share — Share findings to Shared Working Memory (team-visible, free)\n"
@@ -1978,6 +1978,8 @@ class DKGMemoryProvider(MemoryProvider):
             return tool_error("context_graph_id is required.")
         if not assertion_uri:
             return tool_error("assertion_uri is required.")
+        if "name" in args or "semanticAssertionName" in args or "semantic_assertion_name" in args:
+            return tool_error("Semantic enrichment is written into the source import assertion; target assertion names are not supported.")
         quads, quad_error = _normalize_semantic_quads(args.get("semantic_quads"))
         if quad_error:
             return tool_error(quad_error)
@@ -1987,7 +1989,6 @@ class DKGMemoryProvider(MemoryProvider):
             assertion_uri=assertion_uri,
             assertion_name=assertion_name,
             file_hash=_first_text(args, "file_hash"),
-            name=_first_text(args, "name") or _first_text(args, "semantic_assertion_name"),
             generation_method=_first_text(args, "generation_method"),
             agent_identity=_first_text(args, "agent_identity"),
             generated_at=_first_text(args, "generated_at"),
@@ -2372,7 +2373,7 @@ def _normalize_semantic_quads(raw_quads: Any) -> Tuple[List[Dict[str, str]], Opt
         if not isinstance(raw, dict):
             return [], f"semantic_quads[{index}] must be an object."
         if raw.get("graph") is not None:
-            return [], f"semantic_quads[{index}].graph is not supported; semantic triples are written to the target assertion graph."
+            return [], f"semantic_quads[{index}].graph is not supported; semantic triples are written to the source imported assertion graph."
         subject = str(raw.get("subject", "")).strip()
         predicate = str(raw.get("predicate", "")).strip()
         object_value = str(raw.get("object", "")).strip()

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -2257,8 +2257,8 @@ def _is_safe_iri(value: str) -> bool:
 
 
 def _is_uri(value: str) -> bool:
-    """Check if a value is a safe scheme-based IRI."""
-    return _is_safe_iri(value)
+    """Check if a value looks like a URI for legacy generic quad writes."""
+    return bool(value) and any(value.startswith(prefix) for prefix in ("http://", "https://", "urn:", "did:"))
 
 
 def _escape_sparql(text: str) -> str:

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -412,13 +412,12 @@ class DKGClient:
         assertion_uri: Optional[str] = None,
         assertion_name: Optional[str] = None,
         file_hash: Optional[str] = None,
-        name: Optional[str] = None,
         generation_method: Optional[str] = None,
         agent_identity: Optional[str] = None,
         generated_at: Optional[str] = None,
         sub_graph_name: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Write model-derived triples to a separate WM enrichment assertion with provenance."""
+        """Append model-derived triples to a completed imported assertion with provenance."""
         payload: Dict[str, Any] = {
             "contextGraphId": context_graph_id,
             "semanticQuads": semantic_quads,
@@ -429,8 +428,6 @@ class DKGClient:
             payload["assertionName"] = assertion_name
         if file_hash:
             payload["fileHash"] = file_hash
-        if name:
-            payload["name"] = name
         if generation_method:
             payload["generationMethod"] = generation_method
         if agent_identity:

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -362,6 +362,85 @@ class DKGClient:
             payload["sparql"] = sparql
         return self._post(f"/api/assertion/{quote(assertion_name, safe='')}/query", payload)
 
+    def resolve_import_artifact(
+        self,
+        context_graph_id: str,
+        assertion_uri: Optional[str] = None,
+        assertion_name: Optional[str] = None,
+        file_hash: Optional[str] = None,
+        sub_graph_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Resolve deterministic metadata for a completed imported attachment/assertion."""
+        payload: Dict[str, Any] = {"contextGraphId": context_graph_id}
+        if assertion_uri:
+            payload["assertionUri"] = assertion_uri
+        if assertion_name:
+            payload["assertionName"] = assertion_name
+        if file_hash:
+            payload["fileHash"] = file_hash
+        if sub_graph_name:
+            payload["subGraphName"] = sub_graph_name
+        return self._post("/api/assertion/import-artifact/resolve", payload)
+
+    def read_import_artifact_markdown(
+        self,
+        context_graph_id: str,
+        assertion_uri: Optional[str] = None,
+        assertion_name: Optional[str] = None,
+        file_hash: Optional[str] = None,
+        sub_graph_name: Optional[str] = None,
+        max_bytes: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Read Markdown for a completed imported attachment via daemon content-addressed storage."""
+        payload: Dict[str, Any] = {"contextGraphId": context_graph_id}
+        if assertion_uri:
+            payload["assertionUri"] = assertion_uri
+        if assertion_name:
+            payload["assertionName"] = assertion_name
+        if file_hash:
+            payload["fileHash"] = file_hash
+        if sub_graph_name:
+            payload["subGraphName"] = sub_graph_name
+        if max_bytes is not None:
+            payload["maxBytes"] = max_bytes
+        return self._post("/api/assertion/import-artifact/read-markdown", payload)
+
+    def write_semantic_enrichment(
+        self,
+        context_graph_id: str,
+        semantic_quads: List[Dict[str, str]],
+        assertion_uri: Optional[str] = None,
+        assertion_name: Optional[str] = None,
+        file_hash: Optional[str] = None,
+        name: Optional[str] = None,
+        generation_method: Optional[str] = None,
+        agent_identity: Optional[str] = None,
+        generated_at: Optional[str] = None,
+        sub_graph_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Write model-derived triples to a separate WM enrichment assertion with provenance."""
+        payload: Dict[str, Any] = {
+            "contextGraphId": context_graph_id,
+            "semanticQuads": semantic_quads,
+        }
+        if assertion_uri:
+            payload["assertionUri"] = assertion_uri
+        if assertion_name:
+            payload["assertionName"] = assertion_name
+        if file_hash:
+            payload["fileHash"] = file_hash
+        if name:
+            payload["name"] = name
+        if generation_method:
+            payload["generationMethod"] = generation_method
+        if agent_identity:
+            payload["agentIdentity"] = agent_identity
+        if generated_at:
+            payload["generatedAt"] = generated_at
+        if sub_graph_name:
+            payload["subGraphName"] = sub_graph_name
+        return self._post("/api/assertion/semantic-enrichment/write", payload)
+
     def promote_assertion(self, assertion_name: str, context_graph_id: str,
                           entities: Optional[Any] = None,
                           sub_graph_name: Optional[str] = None) -> Dict[str, Any]:

--- a/packages/adapter-hermes/src/types.ts
+++ b/packages/adapter-hermes/src/types.ts
@@ -244,6 +244,7 @@ export interface HermesChannelMessage {
 
 export interface HermesChannelAttachmentRef {
   assertionUri: string;
+  assertionName?: string;
   fileHash: string;
   contextGraphId: string;
   fileName: string;
@@ -251,10 +252,14 @@ export interface HermesChannelAttachmentRef {
   extractionStatus?: 'completed';
   tripleCount?: number;
   rootEntity?: string;
+  mdIntermediateHash?: string;
+  markdownHash?: string;
+  markdownForm?: string;
 }
 
 export interface HermesChannelAttachmentImportResult {
   assertionUri: string;
+  assertionName?: string;
   fileHash: string;
   contextGraphId: string;
   fileName: string;

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -2138,6 +2138,9 @@ expected_default = [
     "dkg_assertion_promote",
     "dkg_assertion_query",
     "dkg_assertion_write",
+    "dkg_import_artifact_read_markdown",
+    "dkg_import_artifact_resolve",
+    "dkg_semantic_enrichment_write",
     "dkg_context_graph_create",
     "dkg_context_graph_invite",
     "dkg_find_agents",
@@ -2312,6 +2315,17 @@ client.create_context_graph("OpenExplicit", "x", access_policy=0)
 
 client.subscribe("cg:test", include_shared_memory=True)
 client.write_assertion("a b", "cg:test", [{"subject": "urn:s", "predicate": "urn:p", "object": '"o"'}], "sub")
+client.resolve_import_artifact("cg:test", assertion_uri="did:dkg:context-graph:cg:test/assertion/agent/imported", file_hash="sha256:" + "a" * 64, sub_graph_name="sub")
+client.read_import_artifact_markdown("cg:test", assertion_uri="did:dkg:context-graph:cg:test/assertion/agent/imported", max_bytes=4096)
+client.write_semantic_enrichment(
+    "cg:test",
+    [{"subject": "urn:doc:1", "predicate": "http://schema.org/about", "object": '"Topic"'}],
+    assertion_uri="did:dkg:context-graph:cg:test/assertion/agent/imported",
+    name="semantic-imported",
+    generation_method="test-model",
+    agent_identity="did:dkg:agent:test",
+    generated_at="2026-05-11T00:00:00.000Z",
+)
 client.discard_assertion("a b", "cg:test")
 client.assertion_history("a b", "cg:test", agent_address="agent", sub_graph_name="sub")
 client.create_sub_graph("cg:test", "notes")
@@ -2331,6 +2345,9 @@ assert calls == [
     ("POST", "/api/context-graph/create", {"id": "openexplicit", "name": "OpenExplicit", "description": "x", "accessPolicy": 0}),
     ("POST", "/api/context-graph/subscribe", {"contextGraphId": "cg:test", "includeSharedMemory": True}),
     ("POST", "/api/assertion/a%20b/write", {"contextGraphId": "cg:test", "quads": [{"subject": "urn:s", "predicate": "urn:p", "object": '"o"'}], "subGraphName": "sub"}),
+    ("POST", "/api/assertion/import-artifact/resolve", {"contextGraphId": "cg:test", "assertionUri": "did:dkg:context-graph:cg:test/assertion/agent/imported", "fileHash": "sha256:" + "a" * 64, "subGraphName": "sub"}),
+    ("POST", "/api/assertion/import-artifact/read-markdown", {"contextGraphId": "cg:test", "assertionUri": "did:dkg:context-graph:cg:test/assertion/agent/imported", "maxBytes": 4096}),
+    ("POST", "/api/assertion/semantic-enrichment/write", {"contextGraphId": "cg:test", "semanticQuads": [{"subject": "urn:doc:1", "predicate": "http://schema.org/about", "object": '"Topic"'}], "assertionUri": "did:dkg:context-graph:cg:test/assertion/agent/imported", "name": "semantic-imported", "generationMethod": "test-model", "agentIdentity": "did:dkg:agent:test", "generatedAt": "2026-05-11T00:00:00.000Z"}),
     ("POST", "/api/assertion/a%20b/discard", {"contextGraphId": "cg:test"}),
     ("GET", "/api/assertion/a%20b/history?contextGraphId=cg%3Atest&agentAddress=agent&subGraphName=sub", {}),
     ("POST", "/api/sub-graph/create", {"contextGraphId": "cg:test", "subGraphName": "notes"}),
@@ -2547,6 +2564,41 @@ result = json.loads(provider.handle_tool_call("dkg_query", {
 }))
 assert result["ok"] is True, result
 assert provider._client.queries[-1][2]["agent_address"] == "peer-default", provider._client.queries
+
+class SemanticClient:
+    def __init__(self):
+        self.calls = []
+
+    def write_semantic_enrichment(self, context_graph_id, semantic_quads, **kwargs):
+        self.calls.append((context_graph_id, semantic_quads, kwargs))
+        return {"ok": True}
+
+provider._client = SemanticClient()
+result = json.loads(provider.handle_tool_call("dkg_semantic_enrichment_write", {
+    "context_graph_id": "cg:test",
+    "assertion_uri": "did:dkg:context-graph:cg:test/assertion/agent/imported",
+    "semantic_quads": [
+        {"subject": "urn:doc:1", "predicate": "http://schema.org/about", "object": "Topic"},
+        {"subject": "urn:doc:1", "predicate": "http://schema.org/author", "object": "mailto:alice@example.org"},
+        {"subject": "urn:doc:1", "predicate": "http://schema.org/sameAs", "object": "ipfs://bafy-test"},
+    ],
+}))
+assert result["ok"] is True, result
+assert provider._client.calls[-1][1] == [
+    {"subject": "urn:doc:1", "predicate": "http://schema.org/about", "object": '"Topic"'},
+    {"subject": "urn:doc:1", "predicate": "http://schema.org/author", "object": "mailto:alice@example.org"},
+    {"subject": "urn:doc:1", "predicate": "http://schema.org/sameAs", "object": "ipfs://bafy-test"},
+], provider._client.calls
+
+graph_result = json.loads(provider.handle_tool_call("dkg_semantic_enrichment_write", {
+    "context_graph_id": "cg:test",
+    "assertion_uri": "did:dkg:context-graph:cg:test/assertion/agent/imported",
+    "semantic_quads": [
+        {"subject": "urn:doc:1", "predicate": "http://schema.org/about", "object": "Topic", "graph": "urn:graph:bad"},
+    ],
+}))
+assert "graph" in graph_result["error"], graph_result
+provider._client = QueryClient()
 provider._config = {"publish_tool": "direct", "allow_direct_publish": True}
 for tool_name, args in [
     ("memory_search", {"query": "alpha beta", "context_graph": "legacy"}),

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -2596,6 +2596,25 @@ for bad_max_bytes in [0, -1, 1.5, True, "   "]:
     assert "positive integer" in result["error"], (bad_max_bytes, result)
 assert len(provider._client.calls) == 1, provider._client.calls
 
+class AssertionWriteClient:
+    def __init__(self):
+        self.calls = []
+
+    def write_assertion(self, name, context_graph_id, quads, sub_graph_name=None):
+        self.calls.append((name, context_graph_id, quads, sub_graph_name))
+        return {"ok": True}
+
+provider._client = AssertionWriteClient()
+result = json.loads(provider.handle_tool_call("dkg_assertion_write", {
+    "context_graph_id": "cg:test",
+    "name": "notes",
+    "quads": [
+        {"subject": "urn:doc:1", "predicate": "http://schema.org/contactPoint", "object": "mailto:alice@example.org"},
+    ],
+}))
+assert result["ok"] is True, result
+assert provider._client.calls[-1][2][0]["object"] == '"mailto:alice@example.org"', provider._client.calls
+
 class SemanticClient:
     def __init__(self):
         self.calls = []

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -2184,6 +2184,12 @@ assert "sub_graph_name" in share_schema["parameters"]["properties"], share_schem
 assert share_schema["parameters"]["required"] == ["content", "context_graph_id"], share_schema
 missing_cg = provider.handle_tool_call("dkg_share", {"content": "alpha"})
 assert "context_graph_id is required" in missing_cg, missing_cg
+semantic_schema = next(schema for schema in provider.get_tool_schemas() if schema["name"] == "dkg_semantic_enrichment_write")
+assert "name" not in semantic_schema["parameters"]["properties"], semantic_schema
+assert "Append model-derived triples" in semantic_schema["description"], semantic_schema
+assert "separate Working Memory assertion" not in semantic_schema["description"], semantic_schema
+resolver_schema = next(schema for schema in provider.get_tool_schemas() if schema["name"] == "dkg_import_artifact_resolve")
+assert "Optional validation/debug helper" in resolver_schema["description"], resolver_schema
 
 provider._config = {
     "publish_tool": "disabled",
@@ -2321,7 +2327,6 @@ client.write_semantic_enrichment(
     "cg:test",
     [{"subject": "urn:doc:1", "predicate": "http://schema.org/about", "object": '"Topic"'}],
     assertion_uri="did:dkg:context-graph:cg:test/assertion/agent/imported",
-    name="semantic-imported",
     generation_method="test-model",
     agent_identity="did:dkg:agent:test",
     generated_at="2026-05-11T00:00:00.000Z",
@@ -2347,7 +2352,7 @@ assert calls == [
     ("POST", "/api/assertion/a%20b/write", {"contextGraphId": "cg:test", "quads": [{"subject": "urn:s", "predicate": "urn:p", "object": '"o"'}], "subGraphName": "sub"}),
     ("POST", "/api/assertion/import-artifact/resolve", {"contextGraphId": "cg:test", "assertionUri": "did:dkg:context-graph:cg:test/assertion/agent/imported", "fileHash": "sha256:" + "a" * 64, "subGraphName": "sub"}),
     ("POST", "/api/assertion/import-artifact/read-markdown", {"contextGraphId": "cg:test", "assertionUri": "did:dkg:context-graph:cg:test/assertion/agent/imported", "maxBytes": 4096}),
-    ("POST", "/api/assertion/semantic-enrichment/write", {"contextGraphId": "cg:test", "semanticQuads": [{"subject": "urn:doc:1", "predicate": "http://schema.org/about", "object": '"Topic"'}], "assertionUri": "did:dkg:context-graph:cg:test/assertion/agent/imported", "name": "semantic-imported", "generationMethod": "test-model", "agentIdentity": "did:dkg:agent:test", "generatedAt": "2026-05-11T00:00:00.000Z"}),
+    ("POST", "/api/assertion/semantic-enrichment/write", {"contextGraphId": "cg:test", "semanticQuads": [{"subject": "urn:doc:1", "predicate": "http://schema.org/about", "object": '"Topic"'}], "assertionUri": "did:dkg:context-graph:cg:test/assertion/agent/imported", "generationMethod": "test-model", "agentIdentity": "did:dkg:agent:test", "generatedAt": "2026-05-11T00:00:00.000Z"}),
     ("POST", "/api/assertion/a%20b/discard", {"contextGraphId": "cg:test"}),
     ("GET", "/api/assertion/a%20b/history?contextGraphId=cg%3Atest&agentAddress=agent&subGraphName=sub", {}),
     ("POST", "/api/sub-graph/create", {"contextGraphId": "cg:test", "subGraphName": "notes"}),
@@ -2589,6 +2594,17 @@ assert provider._client.calls[-1][1] == [
     {"subject": "urn:doc:1", "predicate": "http://schema.org/author", "object": "mailto:alice@example.org"},
     {"subject": "urn:doc:1", "predicate": "http://schema.org/sameAs", "object": "ipfs://bafy-test"},
 ], provider._client.calls
+assert "name" not in provider._client.calls[-1][2], provider._client.calls
+
+name_result = json.loads(provider.handle_tool_call("dkg_semantic_enrichment_write", {
+    "context_graph_id": "cg:test",
+    "assertion_uri": "did:dkg:context-graph:cg:test/assertion/agent/imported",
+    "semanticAssertionName": "semantic-imported",
+    "semantic_quads": [
+        {"subject": "urn:doc:1", "predicate": "http://schema.org/about", "object": "Topic"},
+    ],
+}))
+assert "target assertion names are not supported" in name_result["error"], name_result
 
 graph_result = json.loads(provider.handle_tool_call("dkg_semantic_enrichment_write", {
     "context_graph_id": "cg:test",

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -2570,6 +2570,32 @@ result = json.loads(provider.handle_tool_call("dkg_query", {
 assert result["ok"] is True, result
 assert provider._client.queries[-1][2]["agent_address"] == "peer-default", provider._client.queries
 
+class ReadMarkdownClient:
+    def __init__(self):
+        self.calls = []
+
+    def read_import_artifact_markdown(self, context_graph_id, **kwargs):
+        self.calls.append((context_graph_id, kwargs))
+        return {"ok": True}
+
+provider._client = ReadMarkdownClient()
+result = json.loads(provider.handle_tool_call("dkg_import_artifact_read_markdown", {
+    "context_graph_id": "cg:test",
+    "assertion_uri": "did:dkg:context-graph:cg:test/assertion/agent/imported",
+    "max_bytes": "4096",
+}))
+assert result["ok"] is True, result
+assert provider._client.calls[-1][1]["max_bytes"] == 4096, provider._client.calls
+
+for bad_max_bytes in [0, -1, 1.5, True, "   "]:
+    result = json.loads(provider.handle_tool_call("dkg_import_artifact_read_markdown", {
+        "context_graph_id": "cg:test",
+        "assertion_uri": "did:dkg:context-graph:cg:test/assertion/agent/imported",
+        "max_bytes": bad_max_bytes,
+    }))
+    assert "positive integer" in result["error"], (bad_max_bytes, result)
+assert len(provider._client.calls) == 1, provider._client.calls
+
 class SemanticClient:
     def __init__(self):
         self.calls = []

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -74,6 +74,9 @@ function normalizeAttachmentRef(raw: unknown): OpenClawAttachmentRef | null {
   if (!assertionUri || !fileHash || !contextGraphId || !fileName) return null;
 
   const normalized: OpenClawAttachmentRef = { assertionUri, fileHash, contextGraphId, fileName };
+  if (typeof record.assertionName === 'string' && record.assertionName.trim()) {
+    normalized.assertionName = record.assertionName.trim();
+  }
   if (typeof record.detectedContentType === 'string' && record.detectedContentType.trim()) {
     normalized.detectedContentType = record.detectedContentType.trim();
   }
@@ -87,6 +90,15 @@ function normalizeAttachmentRef(raw: unknown): OpenClawAttachmentRef | null {
   }
   if (typeof record.rootEntity === 'string' && record.rootEntity.trim()) {
     normalized.rootEntity = record.rootEntity.trim();
+  }
+  if (typeof record.mdIntermediateHash === 'string' && record.mdIntermediateHash.trim()) {
+    normalized.mdIntermediateHash = record.mdIntermediateHash.trim();
+  }
+  if (typeof record.markdownHash === 'string' && record.markdownHash.trim()) {
+    normalized.markdownHash = record.markdownHash.trim();
+  }
+  if (typeof record.markdownForm === 'string' && record.markdownForm.trim()) {
+    normalized.markdownForm = record.markdownForm.trim();
   }
   return normalized;
 }
@@ -142,6 +154,9 @@ function sanitizeAttachmentRefForContext(ref: OpenClawAttachmentRef): OpenClawAt
     contextGraphId: sanitizeAttachmentContextValue(ref.contextGraphId),
     fileName: sanitizeAttachmentContextValue(ref.fileName),
   };
+  if (ref.assertionName) {
+    sanitized.assertionName = sanitizeAttachmentContextValue(ref.assertionName);
+  }
   if (ref.detectedContentType) {
     sanitized.detectedContentType = sanitizeAttachmentContextValue(ref.detectedContentType);
   }
@@ -153,6 +168,15 @@ function sanitizeAttachmentRefForContext(ref: OpenClawAttachmentRef): OpenClawAt
   }
   if (ref.rootEntity) {
     sanitized.rootEntity = sanitizeAttachmentContextValue(ref.rootEntity);
+  }
+  if (ref.mdIntermediateHash) {
+    sanitized.mdIntermediateHash = sanitizeAttachmentContextValue(ref.mdIntermediateHash);
+  }
+  if (ref.markdownHash) {
+    sanitized.markdownHash = sanitizeAttachmentContextValue(ref.markdownHash);
+  }
+  if (ref.markdownForm) {
+    sanitized.markdownForm = sanitizeAttachmentContextValue(ref.markdownForm);
   }
   return sanitized;
 }
@@ -169,15 +193,24 @@ function formatAttachmentContext(attachmentRefs: OpenClawAttachmentRef[]): strin
     const graph = ref.contextGraphId ? ` in ${sanitizeAttachmentPromptField(ref.contextGraphId, 'unknown context graph')}` : '';
     const details = [
       ref.detectedContentType ? `contentType=${sanitizeAttachmentPromptField(ref.detectedContentType, 'unknown content type')}` : null,
+      ref.assertionName ? `assertionName=${sanitizeAttachmentPromptField(ref.assertionName, 'unknown assertion name')}` : null,
       ref.fileHash ? `fileHash=${sanitizeAttachmentPromptField(ref.fileHash, 'unknown hash')}` : null,
       ref.extractionStatus ? `status=${sanitizeAttachmentPromptField(ref.extractionStatus, 'unknown status')}` : null,
       ref.tripleCount != null ? `tripleCount=${ref.tripleCount}` : null,
       ref.rootEntity ? `rootEntity=${sanitizeAttachmentPromptField(ref.rootEntity, 'unknown root entity')}` : null,
+      ref.mdIntermediateHash ? `mdIntermediateHash=${sanitizeAttachmentPromptField(ref.mdIntermediateHash, 'unknown markdown intermediate hash')}` : null,
+      ref.markdownHash ? `markdownHash=${sanitizeAttachmentPromptField(ref.markdownHash, 'unknown markdown hash')}` : null,
+      ref.markdownForm ? `markdownForm=${sanitizeAttachmentPromptField(ref.markdownForm, 'unknown markdown form')}` : null,
     ].filter((item): item is string => item != null);
     const detailText = details.length ? ` [${details.join('; ')}]` : '';
     return `- ${label}${graph}${detailText} -> ${sanitizeAttachmentPromptField(ref.assertionUri, 'unknown assertion')}`;
   });
-  return ['Attached Working Memory items:', ...lines].join('\n');
+  return [
+    'Attached Working Memory items:',
+    ...lines,
+    'For completed imported attachments, resolve the artifact with dkg_import_artifact_resolve, read Markdown with dkg_import_artifact_read_markdown when needed, inspect deterministic quads with dkg_assertion_query, and write model-derived triples only through dkg_semantic_enrichment_write.',
+    'Keep deterministic import assertions separate from semantic enrichment assertions; do not promote or publish enrichment output unless explicitly instructed.',
+  ].join('\n');
 }
 
 interface ChatContextEntry {

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -208,8 +208,8 @@ function formatAttachmentContext(attachmentRefs: OpenClawAttachmentRef[]): strin
   return [
     'Attached Working Memory items:',
     ...lines,
-    'For completed imported attachments, resolve the artifact with dkg_import_artifact_resolve, read Markdown with dkg_import_artifact_read_markdown when needed, inspect deterministic quads with dkg_assertion_query, and write model-derived triples only through dkg_semantic_enrichment_write.',
-    'Keep deterministic import assertions separate from semantic enrichment assertions; do not promote or publish enrichment output unless explicitly instructed.',
+    'For completed imported attachments, read Markdown with dkg_import_artifact_read_markdown when needed, inspect assertion quads with dkg_assertion_query when useful, and append model-derived triples to the imported assertion with dkg_semantic_enrichment_write.',
+    'Use dkg_import_artifact_resolve only when you need to re-check artifact metadata. Do not promote or publish enrichment output unless explicitly instructed.',
   ].join('\n');
 }
 

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -21,6 +21,7 @@ import {
   createDkgPublisherExtension,
   type DkgPublisherExtension,
   escapeDkgRdfLiteral,
+  isSafeIri,
   resolveDkgHome,
   toEip55Checksum,
 } from '@origintrail-official/dkg-core';
@@ -93,6 +94,51 @@ function stripRdfTerm(value: unknown): string {
   const literalMatch = raw.match(/^("[\s\S]*")(\^\^.*|@.*)?$/);
   if (literalMatch) return decodeLiteral(literalMatch[1]);
   return raw;
+}
+
+function quoteOpenClawLiteral(value: string): string {
+  const escaped = escapeDkgRdfLiteral(value).replace(
+    new RegExp(
+      '[' +
+        String.fromCharCode(0x00) + '-' + String.fromCharCode(0x1F) +
+        String.fromCharCode(0x7F) +
+      ']',
+      'g',
+    ),
+    (ch) => '\\u' + ch.charCodeAt(0).toString(16).padStart(4, '0').toUpperCase(),
+  );
+  return `"${escaped}"`;
+}
+
+function normalizeSemanticEnrichmentQuads(rawQuads: unknown): {
+  quads?: Array<{ subject: string; predicate: string; object: string }>;
+  error?: string;
+} {
+  if (!Array.isArray(rawQuads) || rawQuads.length === 0) {
+    return { error: '"semantic_quads" must be a non-empty array of {subject, predicate, object} objects.' };
+  }
+  const quads: Array<{ subject: string; predicate: string; object: string }> = [];
+  for (const [index, raw] of rawQuads.entries()) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return { error: `"semantic_quads[${index}]" must be an object.` };
+    }
+    const record = raw as Record<string, unknown>;
+    if (record.graph !== undefined && record.graph !== null) {
+      return { error: `"semantic_quads[${index}].graph" is not supported; semantic triples are written to the target assertion graph.` };
+    }
+    const subject = typeof record.subject === 'string' ? record.subject.trim() : '';
+    const predicate = typeof record.predicate === 'string' ? record.predicate.trim() : '';
+    const object = typeof record.object === 'string' ? record.object.trim() : '';
+    if (!subject || !predicate || !object) {
+      return { error: `"semantic_quads[${index}]" must include non-empty subject, predicate, and object strings.` };
+    }
+    quads.push({
+      subject,
+      predicate,
+      object: isSafeIri(object) || object.startsWith('"') ? object : quoteOpenClawLiteral(object),
+    });
+  }
+  return { quads };
 }
 
 function queryCatalogSlugFromIri(iri: string, marker: string, fallback: string): string {
@@ -2999,6 +3045,78 @@ export class DkgNodePlugin {
         execute: async (_toolCallId, args) => this.handleAssertionQuery(args),
       },
       {
+        name: 'dkg_import_artifact_resolve',
+        description:
+          'Resolve a completed imported attachment/assertion into deterministic artifact metadata: source file hash, ' +
+          'Markdown hash/form when available, extraction method, root entity, and structural counts. Skipped imports are rejected.',
+        parameters: {
+          type: 'object',
+          properties: {
+            context_graph_id: { type: 'string', description: 'Context graph ID from the attachment ref.' },
+            assertion_uri: { type: 'string', description: 'Completed imported assertion URI from the attachment ref.' },
+            assertion_name: { type: 'string', description: 'Optional source assertion name to cross-check against assertion_uri.' },
+            file_hash: { type: 'string', description: 'Optional source file hash to verify against deterministic metadata.' },
+            sub_graph_name: { type: 'string', description: 'Optional sub-graph for the imported assertion.' },
+          },
+          required: ['context_graph_id', 'assertion_uri'],
+        },
+        execute: async (_toolCallId, args) => this.handleImportArtifactResolve(args),
+      },
+      {
+        name: 'dkg_import_artifact_read_markdown',
+        description:
+          'Read the Markdown source for a completed imported attachment through the daemon content-addressed file store. ' +
+          'Never reads arbitrary filesystem paths; the daemon resolves the Markdown hash from import metadata.',
+        parameters: {
+          type: 'object',
+          properties: {
+            context_graph_id: { type: 'string', description: 'Context graph ID from the attachment ref.' },
+            assertion_uri: { type: 'string', description: 'Completed imported assertion URI from the attachment ref.' },
+            assertion_name: { type: 'string', description: 'Optional source assertion name to cross-check against assertion_uri.' },
+            file_hash: { type: 'string', description: 'Optional source file hash to verify against deterministic metadata.' },
+            sub_graph_name: { type: 'string', description: 'Optional sub-graph for the imported assertion.' },
+            max_bytes: { type: 'number', description: 'Optional byte cap; daemon maximum is 5 MiB.' },
+          },
+          required: ['context_graph_id', 'assertion_uri'],
+        },
+        execute: async (_toolCallId, args) => this.handleImportArtifactReadMarkdown(args),
+      },
+      {
+        name: 'dkg_semantic_enrichment_write',
+        description:
+          'Write model-derived semantic triples into a separate Working Memory assertion with provenance pointing to a completed ' +
+          'import artifact. This does not modify the deterministic import assertion and does not promote or publish.',
+        parameters: {
+          type: 'object',
+          properties: {
+            context_graph_id: { type: 'string', description: 'Context graph ID from the attachment ref.' },
+            assertion_uri: { type: 'string', description: 'Source imported assertion URI from the attachment ref.' },
+            assertion_name: { type: 'string', description: 'Optional source assertion name to cross-check against assertion_uri.' },
+            file_hash: { type: 'string', description: 'Optional source file hash to verify against deterministic metadata.' },
+            name: { type: 'string', description: 'Optional target semantic enrichment assertion name; generated if omitted.' },
+            semantic_quads: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  subject: { type: 'string', description: 'Semantic subject URI.' },
+                  predicate: { type: 'string', description: 'Semantic predicate URI.' },
+                  object: { type: 'string', description: 'Semantic object URI, RDF literal, or plain text literal.' },
+                },
+                required: ['subject', 'predicate', 'object'],
+              },
+              description: 'Model-derived triples to write into the target assertion graph. Plain-text objects become RDF literals; provenance quads are added by the daemon.',
+            },
+            generation_method: { type: 'string', description: 'Extraction/generation method label.' },
+            agent_identity: { type: 'string', description: 'Agent identity URI or label for provenance; only URIs are emitted as prov:wasAttributedTo resources.' },
+            generated_at: { type: 'string', description: 'ISO timestamp for generation; defaults to daemon time.' },
+            sub_graph_name: { type: 'string', description: 'Optional sub-graph for source and target assertions.' },
+          },
+          required: ['context_graph_id', 'assertion_uri', 'semantic_quads'],
+        },
+        execute: async (_toolCallId, args) => this.handleSemanticEnrichmentWrite(args),
+      },
+      {
         name: 'dkg_assertion_history',
         description:
           'Fetch an assertion\'s lifecycle descriptor (author, extraction status, promotion state). ' +
@@ -4170,6 +4288,75 @@ export class DkgNodePlugin {
       if (!name) return this.error('"name" is required.');
       const subGraphName = args.sub_graph_name ? String(args.sub_graph_name) : undefined;
       const result = await this.client.queryAssertion(contextGraphId, name, { subGraphName });
+      return this.json(result);
+    } catch (err: any) {
+      return this.daemonError(err);
+    }
+  }
+
+  private async handleImportArtifactResolve(args: Record<string, unknown>): Promise<OpenClawToolResult> {
+    try {
+      const contextGraphId = String(args.context_graph_id ?? '').trim();
+      if (!contextGraphId) return this.error('"context_graph_id" is required.');
+      const assertionUri = String(args.assertion_uri ?? args.source_assertion_uri ?? '').trim() || undefined;
+      const assertionName = String(args.assertion_name ?? '').trim() || undefined;
+      if (!assertionUri) return this.error('"assertion_uri" is required.');
+      const result = await this.client.resolveImportArtifact({
+        contextGraphId,
+        assertionUri,
+        assertionName,
+        fileHash: String(args.file_hash ?? '').trim() || undefined,
+        subGraphName: String(args.sub_graph_name ?? '').trim() || undefined,
+      });
+      return this.json(result);
+    } catch (err: any) {
+      return this.daemonError(err);
+    }
+  }
+
+  private async handleImportArtifactReadMarkdown(args: Record<string, unknown>): Promise<OpenClawToolResult> {
+    try {
+      const contextGraphId = String(args.context_graph_id ?? '').trim();
+      if (!contextGraphId) return this.error('"context_graph_id" is required.');
+      const assertionUri = String(args.assertion_uri ?? args.source_assertion_uri ?? '').trim() || undefined;
+      const assertionName = String(args.assertion_name ?? '').trim() || undefined;
+      if (!assertionUri) return this.error('"assertion_uri" is required.');
+      const maxBytes = typeof args.max_bytes === 'number' ? args.max_bytes : undefined;
+      const result = await this.client.readImportArtifactMarkdown({
+        contextGraphId,
+        assertionUri,
+        assertionName,
+        fileHash: String(args.file_hash ?? '').trim() || undefined,
+        subGraphName: String(args.sub_graph_name ?? '').trim() || undefined,
+        maxBytes,
+      });
+      return this.json(result);
+    } catch (err: any) {
+      return this.daemonError(err);
+    }
+  }
+
+  private async handleSemanticEnrichmentWrite(args: Record<string, unknown>): Promise<OpenClawToolResult> {
+    try {
+      const contextGraphId = String(args.context_graph_id ?? '').trim();
+      if (!contextGraphId) return this.error('"context_graph_id" is required.');
+      const assertionUri = String(args.assertion_uri ?? args.source_assertion_uri ?? '').trim() || undefined;
+      const assertionName = String(args.assertion_name ?? '').trim() || undefined;
+      if (!assertionUri) return this.error('"assertion_uri" is required.');
+      const normalized = normalizeSemanticEnrichmentQuads(args.semantic_quads);
+      if (normalized.error || !normalized.quads) return this.error(normalized.error ?? '"semantic_quads" is invalid.');
+      const result = await this.client.writeSemanticEnrichment({
+        contextGraphId,
+        assertionUri,
+        assertionName,
+        fileHash: String(args.file_hash ?? '').trim() || undefined,
+        name: String(args.name ?? args.semantic_assertion_name ?? '').trim() || undefined,
+        semanticQuads: normalized.quads,
+        generationMethod: String(args.generation_method ?? '').trim() || undefined,
+        agentIdentity: String(args.agent_identity ?? '').trim() || undefined,
+        generatedAt: String(args.generated_at ?? '').trim() || undefined,
+        subGraphName: String(args.sub_graph_name ?? '').trim() || undefined,
+      });
       return this.json(result);
     } catch (err: any) {
       return this.daemonError(err);

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -124,7 +124,7 @@ function normalizeSemanticEnrichmentQuads(rawQuads: unknown): {
     }
     const record = raw as Record<string, unknown>;
     if (record.graph !== undefined && record.graph !== null) {
-      return { error: `"semantic_quads[${index}].graph" is not supported; semantic triples are written to the target assertion graph.` };
+      return { error: `"semantic_quads[${index}].graph" is not supported; semantic triples are written to the source imported assertion graph.` };
     }
     const subject = typeof record.subject === 'string' ? record.subject.trim() : '';
     const predicate = typeof record.predicate === 'string' ? record.predicate.trim() : '';
@@ -3047,7 +3047,7 @@ export class DkgNodePlugin {
       {
         name: 'dkg_import_artifact_resolve',
         description:
-          'Resolve a completed imported attachment/assertion into deterministic artifact metadata: source file hash, ' +
+          'Optional validation/debug helper. Resolve a completed imported attachment/assertion into deterministic artifact metadata: source file hash, ' +
           'Markdown hash/form when available, extraction method, root entity, and structural counts. Skipped imports are rejected.',
         parameters: {
           type: 'object',
@@ -3084,8 +3084,8 @@ export class DkgNodePlugin {
       {
         name: 'dkg_semantic_enrichment_write',
         description:
-          'Write model-derived semantic triples into a separate Working Memory assertion with provenance pointing to a completed ' +
-          'import artifact. This does not modify the deterministic import assertion and does not promote or publish.',
+          'Append model-derived semantic triples into the completed imported assertion with daemon-stamped provenance. ' +
+          'This does not promote, finalize, or publish.',
         parameters: {
           type: 'object',
           properties: {
@@ -3093,7 +3093,6 @@ export class DkgNodePlugin {
             assertion_uri: { type: 'string', description: 'Source imported assertion URI from the attachment ref.' },
             assertion_name: { type: 'string', description: 'Optional source assertion name to cross-check against assertion_uri.' },
             file_hash: { type: 'string', description: 'Optional source file hash to verify against deterministic metadata.' },
-            name: { type: 'string', description: 'Optional target semantic enrichment assertion name; generated if omitted.' },
             semantic_quads: {
               type: 'array',
               items: {
@@ -3105,12 +3104,12 @@ export class DkgNodePlugin {
                 },
                 required: ['subject', 'predicate', 'object'],
               },
-              description: 'Model-derived triples to write into the target assertion graph. Plain-text objects become RDF literals; provenance quads are added by the daemon.',
+              description: 'Model-derived triples to append to the source imported assertion graph. Plain-text objects become RDF literals; provenance quads are added by the daemon.',
             },
             generation_method: { type: 'string', description: 'Extraction/generation method label.' },
             agent_identity: { type: 'string', description: 'Agent identity URI or label for provenance; only URIs are emitted as prov:wasAttributedTo resources.' },
             generated_at: { type: 'string', description: 'ISO timestamp for generation; defaults to daemon time.' },
-            sub_graph_name: { type: 'string', description: 'Optional sub-graph for source and target assertions.' },
+            sub_graph_name: { type: 'string', description: 'Optional sub-graph for the source imported assertion.' },
           },
           required: ['context_graph_id', 'assertion_uri', 'semantic_quads'],
         },
@@ -4343,6 +4342,13 @@ export class DkgNodePlugin {
       const assertionUri = String(args.assertion_uri ?? args.source_assertion_uri ?? '').trim() || undefined;
       const assertionName = String(args.assertion_name ?? '').trim() || undefined;
       if (!assertionUri) return this.error('"assertion_uri" is required.');
+      if (
+        args.name !== undefined ||
+        args.semanticAssertionName !== undefined ||
+        args.semantic_assertion_name !== undefined
+      ) {
+        return this.error('Semantic enrichment is written into the source import assertion; target assertion names are not supported.');
+      }
       const normalized = normalizeSemanticEnrichmentQuads(args.semantic_quads);
       if (normalized.error || !normalized.quads) return this.error(normalized.error ?? '"semantic_quads" is invalid.');
       const result = await this.client.writeSemanticEnrichment({
@@ -4350,7 +4356,6 @@ export class DkgNodePlugin {
         assertionUri,
         assertionName,
         fileHash: String(args.file_hash ?? '').trim() || undefined,
-        name: String(args.name ?? args.semantic_assertion_name ?? '').trim() || undefined,
         semanticQuads: normalized.quads,
         generationMethod: String(args.generation_method ?? '').trim() || undefined,
         agentIdentity: String(args.agent_identity ?? '').trim() || undefined,

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -3075,7 +3075,7 @@ export class DkgNodePlugin {
             assertion_name: { type: 'string', description: 'Optional source assertion name to cross-check against assertion_uri.' },
             file_hash: { type: 'string', description: 'Optional source file hash to verify against deterministic metadata.' },
             sub_graph_name: { type: 'string', description: 'Optional sub-graph for the imported assertion.' },
-            max_bytes: { type: 'number', description: 'Optional byte cap; daemon maximum is 5 MiB.' },
+            max_bytes: { type: 'integer', description: 'Optional positive integer byte cap; daemon maximum is 5 MiB.' },
           },
           required: ['context_graph_id', 'assertion_uri'],
         },
@@ -4320,7 +4320,16 @@ export class DkgNodePlugin {
       const assertionUri = String(args.assertion_uri ?? args.source_assertion_uri ?? '').trim() || undefined;
       const assertionName = String(args.assertion_name ?? '').trim() || undefined;
       if (!assertionUri) return this.error('"assertion_uri" is required.');
-      const maxBytes = typeof args.max_bytes === 'number' ? args.max_bytes : undefined;
+      let maxBytes: number | undefined;
+      if (args.max_bytes !== undefined) {
+        const rawMaxBytes = typeof args.max_bytes === 'string' && args.max_bytes.trim()
+          ? Number(args.max_bytes.trim())
+          : args.max_bytes;
+        if (typeof rawMaxBytes !== 'number' || !Number.isInteger(rawMaxBytes) || rawMaxBytes <= 0) {
+          return this.error('"max_bytes" must be a positive integer.');
+        }
+        maxBytes = rawMaxBytes;
+      }
       const result = await this.client.readImportArtifactMarkdown({
         contextGraphId,
         assertionUri,

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -75,8 +75,6 @@ export interface ImportedArtifactResolution {
 }
 
 export interface SemanticEnrichmentWriteRequest extends ImportedArtifactRequest {
-  name?: string;
-  semanticAssertionName?: string;
   semanticQuads: Array<{ subject: string; predicate: string; object: string }>;
   generationMethod?: string;
   agentIdentity?: string;
@@ -504,9 +502,8 @@ export class DkgDaemonClient {
   }
 
   /**
-   * Write model-derived semantic triples into a separate WM assertion with
-   * provenance that points back to the deterministic import artifact. The
-   * daemon intentionally does not promote or publish this assertion.
+   * Append model-derived semantic triples into the completed imported assertion
+   * with provenance. The daemon intentionally does not promote or publish.
    */
   async writeSemanticEnrichment(
     request: SemanticEnrichmentWriteRequest,

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -30,6 +30,7 @@ export interface DkgClientOptions {
 
 export interface OpenClawAttachmentRef {
   assertionUri: string;
+  assertionName?: string;
   fileHash: string;
   contextGraphId: string;
   fileName: string;
@@ -37,6 +38,49 @@ export interface OpenClawAttachmentRef {
   extractionStatus?: 'completed';
   tripleCount?: number;
   rootEntity?: string;
+  mdIntermediateHash?: string;
+  markdownHash?: string;
+  markdownForm?: string;
+}
+
+export interface ImportedArtifactRequest {
+  contextGraphId: string;
+  assertionUri: string;
+  assertionName?: string;
+  fileHash?: string;
+  subGraphName?: string;
+}
+
+export interface ImportedArtifactResolution {
+  contextGraphId: string;
+  assertionUri: string;
+  assertionName?: string;
+  assertionAgentAddress?: string;
+  subGraphName?: string;
+  fileHash: string;
+  sourceFileHash: string;
+  detectedContentType: string;
+  sourceContentType: string;
+  extractionStatus: 'completed';
+  extractionMethod?: string;
+  rootEntity?: string;
+  sourceFileName?: string;
+  tripleCount?: number;
+  structuralTripleCount?: number;
+  semanticTripleCount?: number;
+  mdIntermediateHash?: string;
+  markdownForm?: string;
+  markdownHash?: string;
+  canReadMarkdown: boolean;
+}
+
+export interface SemanticEnrichmentWriteRequest extends ImportedArtifactRequest {
+  name?: string;
+  semanticAssertionName?: string;
+  semanticQuads: Array<{ subject: string; predicate: string; object: string }>;
+  generationMethod?: string;
+  agentIdentity?: string;
+  generatedAt?: string;
 }
 
 export interface ChatTurnStoreStatus {
@@ -429,6 +473,45 @@ export class DkgDaemonClient {
       contextGraphId,
       subGraphName: opts?.subGraphName,
     });
+  }
+
+  /**
+   * Resolve deterministic import metadata for a completed attachment ref.
+   * This does not read arbitrary paths; it only returns graph/file-store
+   * metadata already attached to the imported assertion.
+   */
+  async resolveImportArtifact(
+    request: ImportedArtifactRequest,
+  ): Promise<{ artifact: ImportedArtifactResolution }> {
+    return this.post('/api/assertion/import-artifact/resolve', request);
+  }
+
+  /**
+   * Read the Markdown source for a completed imported assertion. The daemon
+   * resolves the markdown hash from deterministic import metadata and reads
+   * the content-addressed file store; callers never supply filesystem paths.
+   */
+  async readImportArtifactMarkdown(
+    request: ImportedArtifactRequest & { maxBytes?: number },
+  ): Promise<{
+    artifact: ImportedArtifactResolution;
+    markdownHash: string;
+    contentType: 'text/markdown';
+    bytes: number;
+    markdown: string;
+  }> {
+    return this.post('/api/assertion/import-artifact/read-markdown', request);
+  }
+
+  /**
+   * Write model-derived semantic triples into a separate WM assertion with
+   * provenance that points back to the deterministic import artifact. The
+   * daemon intentionally does not promote or publish this assertion.
+   */
+  async writeSemanticEnrichment(
+    request: SemanticEnrichmentWriteRequest,
+  ): Promise<Record<string, unknown>> {
+    return this.post('/api/assertion/semantic-enrichment/write', request);
   }
 
   /**

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -2140,6 +2140,7 @@ describe('DkgChannelPlugin', () => {
     const attachmentRefs = [
       {
         assertionUri: 'did:dkg:context-graph:cg-1/assertion/chat-doc',
+        assertionName: 'chat-doc',
         fileHash: 'sha256:feedbeef',
         contextGraphId: 'cg-1',
         fileName: 'chat-doc.pdf',
@@ -2147,6 +2148,9 @@ describe('DkgChannelPlugin', () => {
         extractionStatus: 'completed' as const,
         tripleCount: 42,
         rootEntity: 'did:dkg:context-graph:cg-1/assertion/chat-doc',
+        mdIntermediateHash: 'sha256:mdhash',
+        markdownHash: 'sha256:mdhash',
+        markdownForm: 'urn:dkg:file:sha256:mdhash',
       },
     ];
     const mockRuntime = {
@@ -2188,9 +2192,13 @@ describe('DkgChannelPlugin', () => {
       AttachmentRefs: attachmentRefs,
     });
     expect(dispatched.ctx.BodyForAgent).toContain('fileHash="sha256:feedbeef"');
+    expect(dispatched.ctx.BodyForAgent).toContain('assertionName="chat-doc"');
     expect(dispatched.ctx.BodyForAgent).toContain('status="completed"');
     expect(dispatched.ctx.BodyForAgent).toContain('tripleCount=42');
     expect(dispatched.ctx.BodyForAgent).toContain('rootEntity="did:dkg:context-graph:cg-1/assertion/chat-doc"');
+    expect(dispatched.ctx.BodyForAgent).toContain('markdownHash="sha256:mdhash"');
+    expect(dispatched.ctx.BodyForAgent).toContain('dkg_import_artifact_read_markdown');
+    expect(dispatched.ctx.BodyForAgent).toContain('dkg_semantic_enrichment_write');
     await new Promise((resolve) => setTimeout(resolve, 10));
     expect(storeSpy).toHaveBeenCalledWith(
       'openclaw:dkg-ui',

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -2199,6 +2199,9 @@ describe('DkgChannelPlugin', () => {
     expect(dispatched.ctx.BodyForAgent).toContain('markdownHash="sha256:mdhash"');
     expect(dispatched.ctx.BodyForAgent).toContain('dkg_import_artifact_read_markdown');
     expect(dispatched.ctx.BodyForAgent).toContain('dkg_semantic_enrichment_write');
+    expect(dispatched.ctx.BodyForAgent).toContain('Use dkg_import_artifact_resolve only when you need to re-check artifact metadata');
+    expect(dispatched.ctx.BodyForAgent).not.toContain('resolve the artifact with dkg_import_artifact_resolve');
+    expect(dispatched.ctx.BodyForAgent).not.toContain('Keep deterministic import assertions separate');
     await new Promise((resolve) => setTimeout(resolve, 10));
     expect(storeSpy).toHaveBeenCalledWith(
       'openclaw:dkg-ui',

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -556,7 +556,6 @@ describe('DkgDaemonClient', () => {
     await client.writeSemanticEnrichment({
       contextGraphId: 'ctx',
       assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
-      name: 'semantic-imported',
       semanticQuads: [
         { subject: 'urn:doc:1', predicate: 'http://schema.org/about', object: '"Topic"' },
       ],
@@ -572,7 +571,6 @@ describe('DkgDaemonClient', () => {
     expect(body).toEqual({
       contextGraphId: 'ctx',
       assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
-      name: 'semantic-imported',
       semanticQuads: [
         { subject: 'urn:doc:1', predicate: 'http://schema.org/about', object: '"Topic"' },
       ],
@@ -580,6 +578,8 @@ describe('DkgDaemonClient', () => {
       agentIdentity: 'did:dkg:agent:test',
       generatedAt: '2026-05-11T00:00:00.000Z',
     });
+    expect(body).not.toHaveProperty('name');
+    expect(body).not.toHaveProperty('semanticAssertionName');
     expect(body).not.toHaveProperty('promote');
     expect(body).not.toHaveProperty('publish');
   });

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -510,6 +510,80 @@ describe('DkgDaemonClient', () => {
     expect(body).not.toHaveProperty('sparql');
   });
 
+  it('resolveImportArtifact POSTs the completed ref to the resolver route', async () => {
+    fetchResponses.push(new Response(JSON.stringify({ artifact: { assertionUri: 'urn:assertion' } }), { status: 200 }));
+
+    await client.resolveImportArtifact({
+      contextGraphId: 'ctx',
+      assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+      fileHash: `sha256:${'a'.repeat(64)}`,
+      subGraphName: 'protocols',
+    });
+
+    const [url, opts] = fetchCalls[0];
+    expect(url).toBe('http://localhost:9200/api/assertion/import-artifact/resolve');
+    expect(opts?.method).toBe('POST');
+    expect(JSON.parse(opts?.body as string)).toEqual({
+      contextGraphId: 'ctx',
+      assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+      fileHash: `sha256:${'a'.repeat(64)}`,
+      subGraphName: 'protocols',
+    });
+  });
+
+  it('readImportArtifactMarkdown POSTs maxBytes to the safe markdown read route', async () => {
+    fetchResponses.push(new Response(JSON.stringify({ markdown: '# Doc' }), { status: 200 }));
+
+    await client.readImportArtifactMarkdown({
+      contextGraphId: 'ctx',
+      assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+      maxBytes: 4096,
+    });
+
+    const [url, opts] = fetchCalls[0];
+    expect(url).toBe('http://localhost:9200/api/assertion/import-artifact/read-markdown');
+    expect(opts?.method).toBe('POST');
+    expect(JSON.parse(opts?.body as string)).toEqual({
+      contextGraphId: 'ctx',
+      assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+      maxBytes: 4096,
+    });
+  });
+
+  it('writeSemanticEnrichment POSTs semantic quads without promotion flags', async () => {
+    fetchResponses.push(new Response(JSON.stringify({ promoted: false, published: false }), { status: 200 }));
+
+    await client.writeSemanticEnrichment({
+      contextGraphId: 'ctx',
+      assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+      name: 'semantic-imported',
+      semanticQuads: [
+        { subject: 'urn:doc:1', predicate: 'http://schema.org/about', object: '"Topic"' },
+      ],
+      generationMethod: 'test-model',
+      agentIdentity: 'did:dkg:agent:test',
+      generatedAt: '2026-05-11T00:00:00.000Z',
+    });
+
+    const [url, opts] = fetchCalls[0];
+    expect(url).toBe('http://localhost:9200/api/assertion/semantic-enrichment/write');
+    expect(opts?.method).toBe('POST');
+    const body = JSON.parse(opts?.body as string);
+    expect(body).toEqual({
+      contextGraphId: 'ctx',
+      assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+      name: 'semantic-imported',
+      semanticQuads: [
+        { subject: 'urn:doc:1', predicate: 'http://schema.org/about', object: '"Topic"' },
+      ],
+      generationMethod: 'test-model',
+      agentIdentity: 'did:dkg:agent:test',
+      generatedAt: '2026-05-11T00:00:00.000Z',
+    });
+    expect(body).not.toHaveProperty('promote');
+    expect(body).not.toHaveProperty('publish');
+  });
+
   it('getAssertionHistory hits /api/assertion/:name/history as GET with camelCase query params', async () => {
     fetchResponses.push(new Response(JSON.stringify({ createdAt: 't' }), { status: 200 }));
 

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -628,6 +628,9 @@ describe('DkgNodePlugin', () => {
     expect(toolNames).toContain('dkg_assertion_import_file');
     expect(toolNames).toContain('dkg_assertion_query');
     expect(toolNames).toContain('dkg_assertion_history');
+    expect(toolNames).toContain('dkg_import_artifact_resolve');
+    expect(toolNames).toContain('dkg_import_artifact_read_markdown');
+    expect(toolNames).toContain('dkg_semantic_enrichment_write');
     expect(toolNames).toContain('dkg_sub_graph_create');
     expect(toolNames).toContain('dkg_sub_graph_list');
     expect(toolNames).toContain('dkg_shared_memory_publish');
@@ -640,7 +643,7 @@ describe('DkgNodePlugin', () => {
     expect(toolNames).toContain('memory_search');
     // Keep this resilient as main adds new exported tools; this test already
     // asserts presence of the critical tool set above.
-    expect(registeredTools.length).toBeGreaterThanOrEqual(29);
+    expect(registeredTools.length).toBeGreaterThanOrEqual(32);
   });
 
   it('new dkg_assertion_* and dkg_sub_graph_* tools have the expected schema shape', () => {
@@ -682,6 +685,9 @@ describe('DkgNodePlugin', () => {
     expectRequired('dkg_assertion_discard', ['context_graph_id', 'name']);
     expectRequired('dkg_assertion_import_file', ['context_graph_id', 'name', 'file_path']);
     expectRequired('dkg_assertion_query', ['context_graph_id', 'name']);
+    expectRequired('dkg_import_artifact_resolve', ['context_graph_id', 'assertion_uri']);
+    expectRequired('dkg_import_artifact_read_markdown', ['context_graph_id', 'assertion_uri']);
+    expectRequired('dkg_semantic_enrichment_write', ['context_graph_id', 'assertion_uri', 'semantic_quads']);
     expectRequired('dkg_assertion_history', ['context_graph_id', 'name']);
     expectRequired('dkg_sub_graph_create', ['context_graph_id', 'sub_graph_name']);
     expectRequired('dkg_sub_graph_list', ['context_graph_id']);
@@ -807,6 +813,88 @@ describe('DkgNodePlugin', () => {
         name: 'chat-turns',
         subGraphName: 'protocols',
       });
+    });
+
+    it('dkg_import_artifact_resolve forwards snake_case to the resolver route', async () => {
+      const { fetchMock, byName } = setupPluginWithFetch({ artifact: { assertionUri: 'urn:x' } });
+      await byName.get('dkg_import_artifact_resolve')!.execute('tc', {
+        context_graph_id: 'ctx',
+        assertion_uri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+        file_hash: `sha256:${'a'.repeat(64)}`,
+        sub_graph_name: 'protocols',
+      });
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://localhost:9200/api/assertion/import-artifact/resolve');
+      expect(JSON.parse(init.body as string)).toEqual({
+        contextGraphId: 'ctx',
+        assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+        fileHash: `sha256:${'a'.repeat(64)}`,
+        subGraphName: 'protocols',
+      });
+    });
+
+    it('dkg_import_artifact_read_markdown forwards max_bytes to the safe read route', async () => {
+      const { fetchMock, byName } = setupPluginWithFetch({ markdown: '# Doc' });
+      await byName.get('dkg_import_artifact_read_markdown')!.execute('tc', {
+        context_graph_id: 'ctx',
+        assertion_uri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+        max_bytes: 4096,
+      });
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://localhost:9200/api/assertion/import-artifact/read-markdown');
+      expect(JSON.parse(init.body as string)).toEqual({
+        contextGraphId: 'ctx',
+        assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+        maxBytes: 4096,
+      });
+    });
+
+    it('dkg_semantic_enrichment_write normalizes plain semantic objects without promotion flags', async () => {
+      const { fetchMock, byName } = setupPluginWithFetch({ promoted: false, published: false });
+      await byName.get('dkg_semantic_enrichment_write')!.execute('tc', {
+        context_graph_id: 'ctx',
+        assertion_uri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+        name: 'semantic-imported',
+        semantic_quads: [
+          { subject: 'urn:doc:1', predicate: 'http://schema.org/about', object: 'Topic' },
+          { subject: 'urn:doc:1', predicate: 'http://schema.org/author', object: 'mailto:alice@example.org' },
+        ],
+        generation_method: 'test-model',
+        agent_identity: 'did:dkg:agent:test',
+        generated_at: '2026-05-11T00:00:00.000Z',
+      });
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://localhost:9200/api/assertion/semantic-enrichment/write');
+      const body = JSON.parse(init.body as string);
+      expect(body).toEqual({
+        contextGraphId: 'ctx',
+        assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+        name: 'semantic-imported',
+        semanticQuads: [
+          { subject: 'urn:doc:1', predicate: 'http://schema.org/about', object: '"Topic"' },
+          { subject: 'urn:doc:1', predicate: 'http://schema.org/author', object: 'mailto:alice@example.org' },
+        ],
+        generationMethod: 'test-model',
+        agentIdentity: 'did:dkg:agent:test',
+        generatedAt: '2026-05-11T00:00:00.000Z',
+      });
+      expect(body).not.toHaveProperty('promote');
+      expect(body).not.toHaveProperty('publish');
+    });
+
+    it('dkg_semantic_enrichment_write rejects semantic graph placement at the adapter boundary', async () => {
+      const { fetchMock, byName } = setupPluginWithFetch({ promoted: false, published: false });
+      const result = await byName.get('dkg_semantic_enrichment_write')!.execute('tc', {
+        context_graph_id: 'ctx',
+        assertion_uri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+        semantic_quads: [
+          { subject: 'urn:doc:1', predicate: 'http://schema.org/about', object: 'Topic', graph: 'urn:graph:forged' },
+        ],
+      });
+
+      expect(result.content[0].text).toMatch(/graph.*not supported/);
+      expect(result.details).toEqual(expect.objectContaining({ error: expect.stringMatching(/graph.*not supported/) }));
+      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('dkg_context_graph_invite forwards snake_case → camelCase body', async () => {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -692,6 +692,10 @@ describe('DkgNodePlugin', () => {
     expect(byName.get('dkg_import_artifact_resolve')!.description).toMatch(/Optional validation\/debug helper/);
     expect(byName.get('dkg_semantic_enrichment_write')!.description).toMatch(/Append model-derived semantic triples/);
     expect(byName.get('dkg_semantic_enrichment_write')!.description).not.toMatch(/separate Working Memory assertion/);
+    expect(byName.get('dkg_import_artifact_read_markdown')!.parameters.properties.max_bytes).toMatchObject({
+      type: 'integer',
+    });
+    expect(byName.get('dkg_import_artifact_read_markdown')!.parameters.properties.max_bytes.description).toMatch(/positive integer/);
     expectRequired('dkg_assertion_history', ['context_graph_id', 'name']);
     expectRequired('dkg_sub_graph_create', ['context_graph_id', 'sub_graph_name']);
     expectRequired('dkg_sub_graph_list', ['context_graph_id']);
@@ -851,6 +855,26 @@ describe('DkgNodePlugin', () => {
         assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
         maxBytes: 4096,
       });
+    });
+
+    it('dkg_import_artifact_read_markdown coerces quoted max_bytes integers and rejects fractions', async () => {
+      const { fetchMock, byName } = setupPluginWithFetch({ markdown: '# Doc' });
+      await byName.get('dkg_import_artifact_read_markdown')!.execute('tc', {
+        context_graph_id: 'ctx',
+        assertion_uri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+        max_bytes: '4096',
+      });
+      expect(JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string)).toMatchObject({
+        maxBytes: 4096,
+      });
+
+      const invalid = await byName.get('dkg_import_artifact_read_markdown')!.execute('tc', {
+        context_graph_id: 'ctx',
+        assertion_uri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+        max_bytes: 1.5,
+      });
+      expect(invalid.details?.error).toMatch(/positive integer/);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('dkg_semantic_enrichment_write normalizes plain semantic objects without promotion flags', async () => {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -688,6 +688,10 @@ describe('DkgNodePlugin', () => {
     expectRequired('dkg_import_artifact_resolve', ['context_graph_id', 'assertion_uri']);
     expectRequired('dkg_import_artifact_read_markdown', ['context_graph_id', 'assertion_uri']);
     expectRequired('dkg_semantic_enrichment_write', ['context_graph_id', 'assertion_uri', 'semantic_quads']);
+    expect(byName.get('dkg_semantic_enrichment_write')!.parameters.properties).not.toHaveProperty('name');
+    expect(byName.get('dkg_import_artifact_resolve')!.description).toMatch(/Optional validation\/debug helper/);
+    expect(byName.get('dkg_semantic_enrichment_write')!.description).toMatch(/Append model-derived semantic triples/);
+    expect(byName.get('dkg_semantic_enrichment_write')!.description).not.toMatch(/separate Working Memory assertion/);
     expectRequired('dkg_assertion_history', ['context_graph_id', 'name']);
     expectRequired('dkg_sub_graph_create', ['context_graph_id', 'sub_graph_name']);
     expectRequired('dkg_sub_graph_list', ['context_graph_id']);
@@ -854,7 +858,6 @@ describe('DkgNodePlugin', () => {
       await byName.get('dkg_semantic_enrichment_write')!.execute('tc', {
         context_graph_id: 'ctx',
         assertion_uri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
-        name: 'semantic-imported',
         semantic_quads: [
           { subject: 'urn:doc:1', predicate: 'http://schema.org/about', object: 'Topic' },
           { subject: 'urn:doc:1', predicate: 'http://schema.org/author', object: 'mailto:alice@example.org' },
@@ -869,7 +872,6 @@ describe('DkgNodePlugin', () => {
       expect(body).toEqual({
         contextGraphId: 'ctx',
         assertionUri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
-        name: 'semantic-imported',
         semanticQuads: [
           { subject: 'urn:doc:1', predicate: 'http://schema.org/about', object: '"Topic"' },
           { subject: 'urn:doc:1', predicate: 'http://schema.org/author', object: 'mailto:alice@example.org' },
@@ -878,8 +880,25 @@ describe('DkgNodePlugin', () => {
         agentIdentity: 'did:dkg:agent:test',
         generatedAt: '2026-05-11T00:00:00.000Z',
       });
+      expect(body).not.toHaveProperty('name');
+      expect(body).not.toHaveProperty('semanticAssertionName');
       expect(body).not.toHaveProperty('promote');
       expect(body).not.toHaveProperty('publish');
+    });
+
+    it('dkg_semantic_enrichment_write rejects legacy target assertion names at the adapter boundary', async () => {
+      const { fetchMock, byName } = setupPluginWithFetch({ promoted: false, published: false });
+      const result = await byName.get('dkg_semantic_enrichment_write')!.execute('tc', {
+        context_graph_id: 'ctx',
+        assertion_uri: 'did:dkg:context-graph:ctx/assertion/peer/imported',
+        semanticAssertionName: 'semantic-imported',
+        semantic_quads: [
+          { subject: 'urn:doc:1', predicate: 'http://schema.org/about', object: 'Topic' },
+        ],
+      });
+
+      expect(result.content[0].text).toMatch(/target assertion names are not supported/);
+      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('dkg_semantic_enrichment_write rejects semantic graph placement at the adapter boundary', async () => {

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -127,6 +127,9 @@ Drop to HTTP when the operation isn't in the table — participant self-service 
 | `dkg_assertion_import_file` | `POST /api/assertion/{name}/import-file` | Multipart upload a document + extract triples |
 | `dkg_assertion_query` | `POST /api/assertion/{name}/query` | Dump every quad in a single assertion (not SPARQL) |
 | `dkg_assertion_history` | `GET /api/assertion/{name}/history` | Read an assertion's lifecycle descriptor |
+| `dkg_import_artifact_read_markdown` | `POST /api/assertion/import-artifact/read-markdown` | Safely read Markdown for a completed imported attachment by content-addressed hash |
+| `dkg_import_artifact_resolve` | `POST /api/assertion/import-artifact/resolve` | Optional metadata re-check for completed imported attachments |
+| `dkg_semantic_enrichment_write` | `POST /api/assertion/semantic-enrichment/write` | Append model-derived semantic triples and provenance to the imported assertion |
 | `dkg_publish` | `POST /api/shared-memory/write` + `POST /api/shared-memory/publish` | **Two-call helper**: first writes supplied quads to SWM via `/write`, then publishes all SWM → VM (TRAC). Calling only the `/publish` route skips the write — if dropping to raw HTTP, use both calls in order |
 | `dkg_shared_memory_publish` | `POST /api/shared-memory/publish` | **Canonical finalizer** after `dkg_assertion_promote`: publish SWM → VM, no fresh quads |
 | `dkg_share` | `POST /api/shared-memory/write` | Directly write concise team-visible knowledge to SWM without staging a WM assertion. Prefer the WM assertion → promote flow for durable/canonical work. Both Hermes and OpenClaw expose the same tool schema (required `content` and `context_graph_id`, optional `sub_graph_name`), so MCP-discovered call signatures are portable. The OpenClaw implementation additionally validates content as non-whitespace, mints a unique subject per share (returned in the response), and N-Triples-quotes content; Hermes is currently looser on those points — the parallel hardening is tracked in OriginTrail/dkg#414. |
@@ -506,6 +509,26 @@ atomic; do not treat a non-zero `tripleCount` on `failed` as partial-write
 evidence. `skipped` usually means no converter was available, so the file was
 stored but no triples were written. `GET /api/assertion/{name}/extraction-status?contextGraphId=...`
 returns `404` if no import-file record exists or the tracker was TTL-pruned.
+
+### Imported attachment semantic enrichment
+
+When Node UI chat provides a completed imported attachment ref, treat its
+`contextGraphId`, `assertionUri`, `fileHash`, status, counts, and Markdown
+hash/form as the starting point. Do not read local filesystem paths.
+
+Canonical flow:
+
+1. Call `dkg_import_artifact_read_markdown` when you need the Markdown text. The
+   daemon validates the import and reads only the content-addressed Markdown blob.
+2. Optionally call `dkg_assertion_query` to inspect existing triples, or
+   `dkg_import_artifact_resolve` when you need to re-check artifact metadata.
+3. Call `dkg_semantic_enrichment_write` with `contextGraphId`, `assertionUri`,
+   `semanticQuads`, and optional generation metadata.
+
+`dkg_semantic_enrichment_write` appends model-derived semantic triples and
+daemon-stamped provenance to the same imported assertion graph. It rejects skipped
+or incomplete imports, rejects per-quad `graph`, rejects target assertion names,
+and does not promote, finalize, or publish.
 
 - `GET /api/file/{fileHash}` — fetch a stored file. Accepts `sha256:<hex>`,
   `keccak256:<hex>`, or bare `<hex>` (treated as sha256). The daemon does not

--- a/packages/cli/src/daemon/openclaw.ts
+++ b/packages/cli/src/daemon/openclaw.ts
@@ -653,6 +653,7 @@ export function isValidOpenClawPersistTurnPayload(payload: {
 
 export interface OpenClawAttachmentRef {
   assertionUri: string;
+  assertionName?: string;
   fileHash: string;
   contextGraphId: string;
   fileName: string;
@@ -660,6 +661,9 @@ export interface OpenClawAttachmentRef {
   extractionStatus?: 'completed';
   tripleCount?: number;
   rootEntity?: string;
+  mdIntermediateHash?: string;
+  markdownHash?: string;
+  markdownForm?: string;
 }
 
 export interface OpenClawAttachmentImportResult {
@@ -685,6 +689,9 @@ export function normalizeOpenClawAttachmentRef(raw: unknown): OpenClawAttachment
   if (!assertionUri || !fileHash || !contextGraphId || !fileName) return null;
 
   const normalized: OpenClawAttachmentRef = { assertionUri, fileHash, contextGraphId, fileName };
+  if (typeof raw.assertionName === 'string' && raw.assertionName.trim()) {
+    normalized.assertionName = raw.assertionName.trim();
+  }
   if (typeof raw.detectedContentType === 'string' && raw.detectedContentType.trim()) {
     normalized.detectedContentType = raw.detectedContentType.trim();
   }
@@ -698,6 +705,15 @@ export function normalizeOpenClawAttachmentRef(raw: unknown): OpenClawAttachment
   }
   if (typeof raw.rootEntity === 'string' && raw.rootEntity.trim()) {
     normalized.rootEntity = raw.rootEntity.trim();
+  }
+  if (typeof raw.mdIntermediateHash === 'string' && raw.mdIntermediateHash.trim()) {
+    normalized.mdIntermediateHash = raw.mdIntermediateHash.trim();
+  }
+  if (typeof raw.markdownHash === 'string' && raw.markdownHash.trim()) {
+    normalized.markdownHash = raw.markdownHash.trim();
+  }
+  if (typeof raw.markdownForm === 'string' && raw.markdownForm.trim()) {
+    normalized.markdownForm = raw.markdownForm.trim();
   }
   return normalized;
 }
@@ -1151,6 +1167,48 @@ export function stripOpenClawAttachmentLiteral(raw: string | undefined): string 
   return match ? unescapeOpenClawAttachmentLiteralBody(match[1]) : raw;
 }
 
+function openClawBindingValue(cell: unknown): string {
+  if (typeof cell === 'string') return cell;
+  if (cell && typeof cell === 'object' && 'value' in cell) {
+    const value = (cell as { value?: unknown }).value;
+    return typeof value === 'string' ? value : '';
+  }
+  return '';
+}
+
+function stripOpenClawBindingLiteral(cell: unknown): string {
+  return stripOpenClawAttachmentLiteral(openClawBindingValue(cell)).trim();
+}
+
+function normalizeOpenClawBindingIri(cell: unknown): string {
+  return openClawBindingValue(cell).replace(/^<|>$/g, '').trim();
+}
+
+function openClawHashFromFileUrn(value: string | undefined): string | undefined {
+  const prefix = 'urn:dkg:file:';
+  if (!value?.startsWith(prefix)) return undefined;
+  const hash = value.slice(prefix.length);
+  return /^(?:sha256:|keccak256:)?[0-9a-f]{64}$/i.test(hash) ? hash : undefined;
+}
+
+function openClawMarkdownHashFor(
+  fileHash: string,
+  contentType: string | undefined,
+  mdIntermediateHash: string | undefined,
+): string | undefined {
+  return mdIntermediateHash
+    ?? (normalizeDetectedContentType(contentType) === 'text/markdown' ? fileHash : undefined);
+}
+
+function openClawAssertionNameFromUri(assertionUri: string): string | undefined {
+  const marker = '/assertion/';
+  const index = assertionUri.indexOf(marker);
+  if (index < 0) return undefined;
+  const tail = assertionUri.slice(index + marker.length);
+  const slash = tail.indexOf('/');
+  return slash >= 0 ? tail.slice(slash + 1) : undefined;
+}
+
 export function parseOpenClawAttachmentTripleCount(raw: string | undefined): number | undefined {
   const value = stripOpenClawAttachmentLiteral(raw).trim();
   if (!value) return undefined;
@@ -1188,7 +1246,36 @@ export function extractionRecordMatchesOpenClawAttachmentRef(
   if (ref.extractionStatus && ref.extractionStatus !== 'completed') return false;
   if (ref.tripleCount != null && ref.tripleCount !== record.tripleCount) return false;
   if (ref.rootEntity && ref.rootEntity !== record.rootEntity) return false;
+  if (ref.mdIntermediateHash && ref.mdIntermediateHash !== record.mdIntermediateHash) return false;
+  const markdownHash = openClawMarkdownHashFor(
+    record.fileHash,
+    record.detectedContentType,
+    record.mdIntermediateHash,
+  );
+  if (ref.markdownHash && ref.markdownHash !== markdownHash) return false;
+  if (ref.markdownForm && openClawHashFromFileUrn(ref.markdownForm) !== markdownHash) return false;
   return true;
+}
+
+function verifiedOpenClawAttachmentRefFromRecord(
+  ref: OpenClawAttachmentRef,
+  record: ExtractionStatusRecord,
+): OpenClawAttachmentRef {
+  const markdownHash = openClawMarkdownHashFor(
+    record.fileHash,
+    record.detectedContentType,
+    record.mdIntermediateHash,
+  );
+  return {
+    ...ref,
+    assertionUri: ref.assertionUri,
+    contextGraphId: ref.contextGraphId,
+    fileName: record.fileName ?? ref.fileName,
+    fileHash: record.fileHash,
+    extractionStatus: 'completed',
+    ...(record.mdIntermediateHash ? { mdIntermediateHash: record.mdIntermediateHash } : {}),
+    ...(markdownHash ? { markdownHash, markdownForm: `urn:dkg:file:${markdownHash}` } : {}),
+  };
 }
 
 export async function verifyOpenClawAttachmentRefsProvenance(
@@ -1198,20 +1285,31 @@ export async function verifyOpenClawAttachmentRefsProvenance(
 ): Promise<OpenClawAttachmentRef[] | undefined> {
   if (!attachmentRefs) return attachmentRefs;
 
+  const verified: OpenClawAttachmentRef[] = [];
   for (const ref of attachmentRefs) {
     if (!isSafeIri(ref.assertionUri)) return undefined;
     if (ref.rootEntity && !isSafeIri(ref.rootEntity)) return undefined;
+    if (ref.markdownForm && !isSafeIri(ref.markdownForm)) return undefined;
     if (!isOpenClawAttachmentAssertionUriForContextGraph(ref.assertionUri, ref.contextGraphId)) return undefined;
 
     const extractionRecord = getExtractionStatusRecord(extractionStatus, ref.assertionUri);
     if (extractionRecord) {
       if (!extractionRecordMatchesOpenClawAttachmentRef(ref, extractionRecord)) return undefined;
-      if (extractionRecord.fileName === ref.fileName) continue;
+      const recordMarkdownHash = openClawMarkdownHashFor(
+        extractionRecord.fileHash,
+        extractionRecord.detectedContentType,
+        extractionRecord.mdIntermediateHash,
+      );
+      const refHasMarkdownMetadata = Boolean(ref.mdIntermediateHash || ref.markdownHash || ref.markdownForm);
+      if (!recordMarkdownHash && !refHasMarkdownMetadata) {
+        verified.push(verifiedOpenClawAttachmentRefFromRecord(ref, extractionRecord));
+        continue;
+      }
     }
 
     const metaGraph = contextGraphMetaUri(ref.contextGraphId);
     const metaResult = await agent.store.query(`
-      SELECT ?fileHash ?contentType ?rootEntity ?extractionStatus ?tripleCount ?sourceFileName WHERE {
+      SELECT ?fileHash ?contentType ?rootEntity ?extractionStatus ?tripleCount ?sourceFileName ?mdIntermediateHash WHERE {
         GRAPH <${metaGraph}> {
           <${ref.assertionUri}> <http://dkg.io/ontology/sourceFileHash> ?fileHash .
           OPTIONAL { <${ref.assertionUri}> <http://dkg.io/ontology/sourceContentType> ?contentType }
@@ -1219,15 +1317,16 @@ export async function verifyOpenClawAttachmentRefsProvenance(
           OPTIONAL { <${ref.assertionUri}> <http://dkg.io/ontology/extractionStatus> ?extractionStatus }
           OPTIONAL { <${ref.assertionUri}> <http://dkg.io/ontology/structuralTripleCount> ?tripleCount }
           OPTIONAL { <${ref.assertionUri}> <http://dkg.io/ontology/sourceFileName> ?sourceFileName }
+          OPTIONAL { <${ref.assertionUri}> <http://dkg.io/ontology/mdIntermediateHash> ?mdIntermediateHash }
         }
       }
       LIMIT 1
-    `) as { bindings?: Array<Record<string, string>> };
+    `) as { bindings?: Array<Record<string, unknown>> };
     const binding = metaResult?.bindings?.[0];
     if (!binding) return undefined;
 
-    if (stripOpenClawAttachmentLiteral(binding.fileHash ?? '') !== ref.fileHash) return undefined;
-    const storedContentType = stripOpenClawAttachmentLiteral(binding.contentType ?? '').trim();
+    if (stripOpenClawBindingLiteral(binding.fileHash) !== ref.fileHash) return undefined;
+    const storedContentType = stripOpenClawBindingLiteral(binding.contentType);
     if (
       ref.detectedContentType &&
       storedContentType &&
@@ -1235,24 +1334,55 @@ export async function verifyOpenClawAttachmentRefsProvenance(
     ) {
       return undefined;
     }
-    const storedExtractionStatus = stripOpenClawAttachmentLiteral(binding.extractionStatus ?? '').trim();
-    if (storedExtractionStatus && storedExtractionStatus !== 'completed') return undefined;
     if (ref.extractionStatus && ref.extractionStatus !== 'completed') return undefined;
+    const storedExtractionStatus = stripOpenClawBindingLiteral(binding.extractionStatus);
+    if (storedExtractionStatus && storedExtractionStatus !== 'completed') return undefined;
 
-    const storedTripleCount = parseOpenClawAttachmentTripleCount(binding.tripleCount ?? '');
+    const storedTripleCount = parseOpenClawAttachmentTripleCount(openClawBindingValue(binding.tripleCount));
     if (ref.tripleCount != null && storedTripleCount != null && ref.tripleCount !== storedTripleCount) {
       return undefined;
     }
-    const storedFileName = stripOpenClawAttachmentLiteral(binding.sourceFileName ?? '').trim();
+    const storedFileName = stripOpenClawBindingLiteral(binding.sourceFileName);
     if (storedFileName && storedFileName !== ref.fileName) return undefined;
 
-    const storedRootEntity = typeof binding.rootEntity === 'string'
-      ? binding.rootEntity.replace(/[<>]/g, '').trim()
-      : '';
+    const storedRootEntity = normalizeOpenClawBindingIri(binding.rootEntity);
     if (ref.rootEntity && storedRootEntity && ref.rootEntity !== storedRootEntity) return undefined;
+
+    const mdIntermediateHash = stripOpenClawBindingLiteral(binding.mdIntermediateHash) || undefined;
+    if (ref.mdIntermediateHash && ref.mdIntermediateHash !== mdIntermediateHash) return undefined;
+    const markdownFormResult = await agent.store.query(`
+      SELECT DISTINCT ?markdownForm WHERE {
+        GRAPH <${ref.assertionUri}> {
+          ?document <http://dkg.io/ontology/markdownForm> ?markdownForm .
+        }
+      }
+    `) as { bindings?: Array<Record<string, unknown>> };
+    const markdownHash = openClawMarkdownHashFor(ref.fileHash, storedContentType, mdIntermediateHash);
+    const storedMarkdownForms = (markdownFormResult?.bindings ?? [])
+      .map((storedBinding) => normalizeOpenClawBindingIri(storedBinding.markdownForm))
+      .filter(Boolean);
+    for (const storedMarkdownForm of storedMarkdownForms) {
+      const markdownFormHash = openClawHashFromFileUrn(storedMarkdownForm);
+      if (!markdownFormHash || !markdownHash || markdownFormHash !== markdownHash) return undefined;
+    }
+    if (ref.markdownHash && ref.markdownHash !== markdownHash) return undefined;
+    if (ref.markdownForm && (!markdownHash || openClawHashFromFileUrn(ref.markdownForm) !== markdownHash)) {
+      return undefined;
+    }
+
+    verified.push({
+      ...ref,
+      assertionUri: ref.assertionUri,
+      contextGraphId: ref.contextGraphId,
+      fileName: storedFileName || ref.fileName,
+      fileHash: ref.fileHash,
+      extractionStatus: 'completed',
+      ...(mdIntermediateHash ? { mdIntermediateHash } : {}),
+      ...(markdownHash ? { markdownHash, markdownForm: `urn:dkg:file:${markdownHash}` } : {}),
+    });
   }
 
-  return attachmentRefs;
+  return verified;
 }
 
 function extractionRecordMatchesOpenClawAttachmentImportResult(

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -403,7 +403,8 @@ function validateContentHash(hash: string): boolean {
 function parseImportedAssertionUri(
   assertionUri: string,
   contextGraphId: string,
-): { assertionAgentAddress: string; assertionName: string; subGraphName?: string } | null {
+  legacyAssertionAgentAddress?: string,
+): { assertionAgentAddress: string; assertionName: string; subGraphName?: string; legacy?: boolean } | null {
   const prefix = `did:dkg:context-graph:${contextGraphId}/`;
   if (!assertionUri.startsWith(prefix)) return null;
   const tail = assertionUri.slice(prefix.length);
@@ -421,6 +422,14 @@ function parseImportedAssertionUri(
   }
 
   const slash = assertionTail.indexOf('/');
+  if (slash === -1 && legacyAssertionAgentAddress && assertionTail) {
+    return {
+      assertionAgentAddress: legacyAssertionAgentAddress,
+      assertionName: assertionTail,
+      ...(subGraphName ? { subGraphName } : {}),
+      legacy: true,
+    };
+  }
   if (slash <= 0 || slash === assertionTail.length - 1) return null;
   const assertionAgentAddress = assertionTail.slice(0, slash);
   const assertionName = assertionTail.slice(slash + 1);
@@ -698,8 +707,12 @@ async function resolveImportedArtifact(
     throw new ImportArtifactRouteError(400, 'Invalid assertionUri');
   }
 
-  const assertionUri = rawAssertionUri;
-  const parsedAssertion = parseImportedAssertionUri(assertionUri, contextGraphId);
+  const inputAssertionUri = rawAssertionUri;
+  const parsedAssertion = parseImportedAssertionUri(
+    inputAssertionUri,
+    contextGraphId,
+    ownerGuard?.requestAgentAddress,
+  );
   if (!parsedAssertion) {
     throw new ImportArtifactRouteError(400, 'assertionUri is not an assertion in the supplied contextGraphId');
   }
@@ -713,9 +726,10 @@ async function resolveImportedArtifact(
     parsedAssertion.assertionName,
     parsedAssertion.subGraphName,
   );
-  if (reconstructedAssertionUri !== assertionUri) {
+  if (reconstructedAssertionUri !== inputAssertionUri && !parsedAssertion.legacy) {
     throw new ImportArtifactRouteError(400, 'assertionUri is not in canonical assertion URI form');
   }
+  const assertionUri = reconstructedAssertionUri;
   if (ownerGuard) {
     assertImportedArtifactOwnerAddress(
       parsedAssertion.assertionAgentAddress,

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -339,8 +339,8 @@ const DEFAULT_MARKDOWN_READ_BYTES = 1024 * 1024;
 type ImportedArtifactResolution = {
   contextGraphId: string;
   assertionUri: string;
-  assertionName?: string;
-  assertionAgentAddress?: string;
+  assertionName: string;
+  assertionAgentAddress: string;
   subGraphName?: string;
   fileHash: string;
   sourceFileHash: string;
@@ -443,7 +443,7 @@ function normalizeSemanticQuads(raw: unknown): Array<{ subject: string; predicat
     if (record.graph != null) {
       throw new ImportArtifactRouteError(
         400,
-        `semanticQuads[${index}].graph is not supported; semantic triples are written to the target assertion graph`,
+        `semanticQuads[${index}].graph is not supported; semantic triples are written to the source imported assertion graph`,
       );
     }
     if (!subject || !predicate || !object) {
@@ -575,35 +575,6 @@ function buildSemanticEnrichmentProvenanceQuads(args: {
   return provenanceQuads;
 }
 
-function semanticEnrichmentAssertionName(source: ImportedArtifactResolution): string {
-  const sourceName = source.assertionName ?? source.assertionUri.split('/').pop() ?? 'attachment';
-  const sourceSlug = sourceName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 42) || 'attachment';
-  return `semantic-enrichment-${sourceSlug}-${Date.now()}-${randomUUID().slice(0, 8)}`;
-}
-
-async function semanticEnrichmentTargetExists(
-  ctx: RequestContext,
-  assertionUri: string,
-  contextGraphId: string,
-): Promise<boolean> {
-  const store = ctx.agent.store as typeof ctx.agent.store & { hasGraph?: (graphUri: string) => Promise<boolean> };
-  if (typeof store.hasGraph === 'function' && await store.hasGraph(assertionUri)) return true;
-  const metaGraph = contextGraphMetaUri(contextGraphId);
-  const result = await ctx.agent.store.query(`
-    SELECT ?p ?o WHERE {
-      GRAPH <${metaGraph}> {
-        <${assertionUri}> ?p ?o .
-      }
-    }
-    LIMIT 1
-  `) as { type?: string; bindings?: Array<Record<string, unknown>> };
-  return Boolean(result.bindings?.length);
-}
-
 function sortAssertionQuads<T>(quads: T[]): T[] {
   return [...quads].sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
 }
@@ -706,6 +677,19 @@ async function resolveImportedArtifact(
   if (!parsedAssertion) {
     throw new ImportArtifactRouteError(400, 'assertionUri is not an assertion in the supplied contextGraphId');
   }
+  const parsedNameValidation = validateAssertionName(parsedAssertion.assertionName);
+  if (!parsedNameValidation.valid) {
+    throw new ImportArtifactRouteError(400, `Invalid assertionUri assertion name: ${parsedNameValidation.reason}`);
+  }
+  const reconstructedAssertionUri = contextGraphAssertionUri(
+    contextGraphId,
+    parsedAssertion.assertionAgentAddress,
+    parsedAssertion.assertionName,
+    parsedAssertion.subGraphName,
+  );
+  if (reconstructedAssertionUri !== assertionUri) {
+    throw new ImportArtifactRouteError(400, 'assertionUri is not in canonical assertion URI form');
+  }
   if (assertionName && assertionName !== parsedAssertion.assertionName) {
     throw new ImportArtifactRouteError(400, '"assertionName" does not match assertionUri');
   }
@@ -751,7 +735,10 @@ async function resolveImportedArtifact(
   }
 
   const durableExtractionStatus = normalizeLiteralBinding(metaBinding.extractionStatus) || undefined;
-  if (durableExtractionStatus && durableExtractionStatus !== 'completed') {
+  if (!durableExtractionStatus) {
+    throw new ImportArtifactRouteError(409, 'Import metadata is missing completed extraction status');
+  }
+  if (durableExtractionStatus !== 'completed') {
     throw new ImportArtifactRouteError(
       409,
       `Import artifact is not a completed extraction (status: ${durableExtractionStatus})`,
@@ -912,24 +899,31 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
   }
 
   // POST /api/assertion/semantic-enrichment/write
-  // Write model-derived semantic triples to a separate WM assertion with provenance.
+  // Write model-derived semantic triples into the completed imported assertion with provenance.
   if (req.method === "POST" && path === "/api/assertion/semantic-enrichment/write") {
     const body = await readBody(req);
     const parsed = safeParseJson(body, res);
     if (!parsed) return;
     try {
       const record = parsed as Record<string, unknown>;
-      const artifact = await resolveImportedArtifact(ctx, record);
-      const targetName = typeof record.name === 'string' && record.name.trim()
-        ? record.name.trim()
-        : typeof record.semanticAssertionName === 'string' && record.semanticAssertionName.trim()
-          ? record.semanticAssertionName.trim()
-          : semanticEnrichmentAssertionName(artifact);
-      const nameValidation = validateAssertionName(targetName);
-      if (!nameValidation.valid) {
-        throw new ImportArtifactRouteError(400, `Invalid semantic assertion name: ${nameValidation.reason}`);
+      if (
+        record.name !== undefined ||
+        record.semanticAssertionName !== undefined ||
+        record.semantic_assertion_name !== undefined
+      ) {
+        throw new ImportArtifactRouteError(
+          400,
+          'Semantic enrichment is written into the source import assertion; target assertion names are not supported',
+        );
       }
+      const artifact = await resolveImportedArtifact(ctx, record);
       const semanticQuads = normalizeSemanticQuads(record.semanticQuads);
+      if (artifact.assertionAgentAddress !== requestAgentAddress) {
+        throw new ImportArtifactRouteError(
+          403,
+          'Semantic enrichment can only modify imported assertions owned by the requesting agent',
+        );
+      }
       const generatedAt = normalizeGeneratedAt(record.generatedAt);
       const generationMethod = typeof record.generationMethod === 'string' && record.generationMethod.trim()
         ? record.generationMethod.trim()
@@ -944,88 +938,36 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
         generationMethod,
         semanticQuads,
       });
-      const targetSubGraphName = artifact.subGraphName;
-      const assertionUri = contextGraphAssertionUri(
-        artifact.contextGraphId,
-        requestAgentAddress,
-        targetName,
-        targetSubGraphName,
-      );
-      if (assertionUri === artifact.assertionUri) {
-        throw new ImportArtifactRouteError(
-          409,
-          'Semantic enrichment assertion must be separate from the source import assertion',
-        );
-      }
-      if (await semanticEnrichmentTargetExists(ctx, assertionUri, artifact.contextGraphId)) {
-        throw new ImportArtifactRouteError(
-          409,
-          'Semantic enrichment assertion already exists; choose a unique target name',
-        );
-      }
-      try {
-        await agent.publisher.assertionCreate(
-          artifact.contextGraphId,
-          targetName,
-          requestAgentAddress,
-          targetSubGraphName,
-        );
-      } catch (err: any) {
-        if (err?.message?.includes('already exists')) {
-          throw new ImportArtifactRouteError(
-            409,
-            'Semantic enrichment assertion already exists; choose a unique target name',
-          );
-        }
-        throw err;
-      }
       const quads = [...semanticQuads, ...provenanceQuads];
-      try {
-        await agent.publisher.assertionWrite(
-          artifact.contextGraphId,
-          targetName,
-          requestAgentAddress,
-          quads,
-          targetSubGraphName,
-        );
-      } catch (err: any) {
-        try {
-          await agent.publisher.assertionDiscard(
-            artifact.contextGraphId,
-            targetName,
-            requestAgentAddress,
-            targetSubGraphName,
-          );
-        } catch (rollbackErr: any) {
-          const writeMessage = err instanceof Error ? err.message : String(err);
-          const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
-          throw new Error(
-            `Semantic enrichment write failed and rollback failed: ${writeMessage}; rollback: ${rollbackMessage}`,
-          );
-        }
-        throw err;
+      const targetAssertionUri = contextGraphAssertionUri(
+        artifact.contextGraphId,
+        artifact.assertionAgentAddress,
+        artifact.assertionName,
+        artifact.subGraphName,
+      );
+      if (targetAssertionUri !== artifact.assertionUri) {
+        throw new ImportArtifactRouteError(409, 'Resolved import artifact target does not match assertionUri');
       }
+      await agent.publisher.assertionWrite(
+        artifact.contextGraphId,
+        artifact.assertionName,
+        artifact.assertionAgentAddress,
+        quads,
+        artifact.subGraphName,
+      );
       emitMemoryGraphChanged?.({
         contextGraphId: artifact.contextGraphId,
         layers: ["wm"],
-        subGraphName: targetSubGraphName,
-        operation: "assertion_created",
-        source: "api",
-        counts: { triples: 0 },
-      });
-      emitMemoryGraphChanged?.({
-        contextGraphId: artifact.contextGraphId,
-        layers: ["wm"],
-        subGraphName: targetSubGraphName,
+        subGraphName: artifact.subGraphName,
         operation: "semantic_enrichment_written",
         source: "api",
         counts: { triples: quads.length },
       });
       return jsonResponse(res, 200, {
-        assertionUri,
-        assertionName: targetName,
+        assertionUri: artifact.assertionUri,
+        assertionName: artifact.assertionName,
         contextGraphId: artifact.contextGraphId,
-        ...(targetSubGraphName ? { subGraphName: targetSubGraphName } : {}),
+        ...(artifact.subGraphName ? { subGraphName: artifact.subGraphName } : {}),
         sourceAssertionUri: artifact.assertionUri,
         sourceFileHash: artifact.fileHash,
         markdownHash: artifact.markdownHash,

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -57,7 +57,7 @@ const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, assertionLifecycleUri } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, escapeDkgRdfLiteral, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, assertionLifecycleUri } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri, type PublishOptions } from '@origintrail-official/dkg-publisher';
 import { validatePreSignedAuthorAttestation } from './memory.js';
 import {
@@ -328,6 +328,498 @@ import {
 
 import type { RequestContext } from './context.js';
 
+const DKG_ONTOLOGY = 'http://dkg.io/ontology/';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const PROV = 'http://www.w3.org/ns/prov#';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
+const MAX_MARKDOWN_READ_BYTES = 5 * 1024 * 1024;
+const DEFAULT_MARKDOWN_READ_BYTES = 1024 * 1024;
+
+type ImportedArtifactResolution = {
+  contextGraphId: string;
+  assertionUri: string;
+  assertionName?: string;
+  assertionAgentAddress?: string;
+  subGraphName?: string;
+  fileHash: string;
+  sourceFileHash: string;
+  detectedContentType: string;
+  sourceContentType: string;
+  extractionStatus: 'completed';
+  extractionMethod?: string;
+  rootEntity?: string;
+  sourceFileName?: string;
+  tripleCount?: number;
+  structuralTripleCount?: number;
+  semanticTripleCount?: number;
+  mdIntermediateHash?: string;
+  markdownForm?: string;
+  markdownHash?: string;
+  canReadMarkdown: boolean;
+};
+
+class ImportArtifactRouteError extends Error {
+  constructor(
+    readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+function bindingCellValue(cell: unknown): string {
+  if (typeof cell === 'string') return cell;
+  if (cell && typeof cell === 'object' && 'value' in cell) {
+    const value = (cell as { value?: unknown }).value;
+    return typeof value === 'string' ? value : '';
+  }
+  return '';
+}
+
+function normalizeLiteralBinding(cell: unknown): string {
+  return stripOpenClawAttachmentLiteral(bindingCellValue(cell)).trim();
+}
+
+function normalizeIriBinding(cell: unknown): string {
+  return bindingCellValue(cell).replace(/^<|>$/g, '').trim();
+}
+
+function optionalPositiveInteger(cell: unknown): number | undefined {
+  return parseOpenClawAttachmentTripleCount(bindingCellValue(cell));
+}
+
+function hashFromFileUrn(value: string | undefined): string | undefined {
+  const prefix = 'urn:dkg:file:';
+  if (!value?.startsWith(prefix)) return undefined;
+  const hash = value.slice(prefix.length);
+  return /^[a-z0-9]+:[0-9a-f]{64}$/i.test(hash) ? hash : undefined;
+}
+
+function validateContentHash(hash: string): boolean {
+  return /^(?:sha256:|keccak256:)?[0-9a-f]{64}$/i.test(hash);
+}
+
+function parseImportedAssertionUri(
+  assertionUri: string,
+  contextGraphId: string,
+): { assertionAgentAddress: string; assertionName: string; subGraphName?: string } | null {
+  const prefix = `did:dkg:context-graph:${contextGraphId}/`;
+  if (!assertionUri.startsWith(prefix)) return null;
+  const tail = assertionUri.slice(prefix.length);
+  let subGraphName: string | undefined;
+  let assertionTail = tail;
+  if (tail.startsWith('assertion/')) {
+    assertionTail = tail.slice('assertion/'.length);
+  } else {
+    const marker = tail.indexOf('/assertion/');
+    if (marker <= 0) return null;
+    subGraphName = tail.slice(0, marker);
+    const subGraphValidation = validateSubGraphName(subGraphName);
+    if (!subGraphValidation.valid) return null;
+    assertionTail = tail.slice(marker + '/assertion/'.length);
+  }
+
+  const slash = assertionTail.indexOf('/');
+  if (slash <= 0 || slash === assertionTail.length - 1) return null;
+  const assertionAgentAddress = assertionTail.slice(0, slash);
+  const assertionName = assertionTail.slice(slash + 1);
+  if (!assertionAgentAddress || !assertionName) return null;
+  return { assertionAgentAddress, assertionName, subGraphName };
+}
+
+function normalizeSemanticQuads(raw: unknown): Array<{ subject: string; predicate: string; object: string }> {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new ImportArtifactRouteError(400, '"semanticQuads" must be a non-empty array');
+  }
+  return raw.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new ImportArtifactRouteError(400, `semanticQuads[${index}] must be an object`);
+    }
+    const record = entry as Record<string, unknown>;
+    const subject = typeof record.subject === 'string' ? record.subject.trim() : '';
+    const predicate = typeof record.predicate === 'string' ? record.predicate.trim() : '';
+    const object = typeof record.object === 'string' ? record.object.trim() : '';
+    if (record.graph != null) {
+      throw new ImportArtifactRouteError(
+        400,
+        `semanticQuads[${index}].graph is not supported; semantic triples are written to the target assertion graph`,
+      );
+    }
+    if (!subject || !predicate || !object) {
+      throw new ImportArtifactRouteError(
+        400,
+        `semanticQuads[${index}] must include non-empty subject, predicate, and object strings`,
+      );
+    }
+    assertSafeIri(subject);
+    assertSafeIri(predicate);
+    let normalizedObject = object;
+    if (object.startsWith('"')) {
+      assertSafeRdfTerm(object);
+    } else if (isSafeIri(object)) {
+      assertSafeIri(object);
+    } else {
+      normalizedObject = rdfLiteral(object);
+    }
+    return { subject, predicate, object: normalizedObject };
+  });
+}
+
+function rdfLiteral(value: string): string {
+  return `"${escapeRdfLiteralBody(value)}"`;
+}
+
+function typedLiteral(value: string | number, typeIri: string): string {
+  return `"${escapeRdfLiteralBody(String(value))}"^^<${typeIri}>`;
+}
+
+function escapeRdfLiteralBody(value: string): string {
+  return escapeDkgRdfLiteral(value).replace(
+    /[\x00-\x07\x0B\x0E-\x1F\x7F]/g,
+    (char) => `\\u${char.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')}`,
+  );
+}
+
+function buildSemanticEnrichmentProvenanceQuads(args: {
+  enrichmentUri: string;
+  source: ImportedArtifactResolution;
+  generatedBy: string;
+  generatedAt: string;
+  generationMethod: string;
+  semanticQuads: Array<{ subject: string; predicate: string; object: string }>;
+}): Array<{ subject: string; predicate: string; object: string }> {
+  const markdownHash = args.source.markdownHash ?? args.source.mdIntermediateHash;
+  const markdownForm = args.source.markdownForm
+    ?? (markdownHash ? `urn:dkg:file:${markdownHash}` : undefined);
+  const provenanceQuads: Array<{ subject: string; predicate: string; object: string }> = [
+    {
+      subject: args.enrichmentUri,
+      predicate: RDF_TYPE,
+      object: `${DKG_ONTOLOGY}SemanticEnrichment`,
+    },
+    {
+      subject: args.enrichmentUri,
+      predicate: `${DKG_ONTOLOGY}sourceAssertion`,
+      object: args.source.assertionUri,
+    },
+    {
+      subject: args.enrichmentUri,
+      predicate: `${PROV}wasDerivedFrom`,
+      object: args.source.assertionUri,
+    },
+    {
+      subject: args.enrichmentUri,
+      predicate: `${DKG_ONTOLOGY}sourceFileHash`,
+      object: rdfLiteral(args.source.fileHash),
+    },
+    {
+      subject: args.enrichmentUri,
+      predicate: `${DKG_ONTOLOGY}generationMethod`,
+      object: rdfLiteral(args.generationMethod),
+    },
+    {
+      subject: args.enrichmentUri,
+      predicate: `${DKG_ONTOLOGY}generatedBy`,
+      object: args.generatedBy,
+    },
+    {
+      subject: args.enrichmentUri,
+      predicate: `${DKG_ONTOLOGY}generatedAt`,
+      object: typedLiteral(args.generatedAt, XSD_DATE_TIME),
+    },
+    {
+      subject: args.enrichmentUri,
+      predicate: `${DKG_ONTOLOGY}semanticTripleCount`,
+      object: typedLiteral(args.semanticQuads.length, XSD_INTEGER),
+    },
+  ];
+
+  if (markdownHash) {
+    provenanceQuads.push({
+      subject: args.enrichmentUri,
+      predicate: `${DKG_ONTOLOGY}markdownHash`,
+      object: rdfLiteral(markdownHash),
+    });
+  }
+  if (markdownForm) {
+    provenanceQuads.push({
+      subject: args.enrichmentUri,
+      predicate: `${DKG_ONTOLOGY}markdownForm`,
+      object: markdownForm,
+    });
+  }
+  if (isSafeIri(args.generatedBy)) {
+    provenanceQuads.push({
+      subject: args.enrichmentUri,
+      predicate: `${PROV}wasAttributedTo`,
+      object: args.generatedBy,
+    });
+  }
+
+  for (const subject of new Set(args.semanticQuads.map((quad) => quad.subject))) {
+    provenanceQuads.push(
+      {
+        subject,
+        predicate: `${PROV}wasGeneratedBy`,
+        object: args.enrichmentUri,
+      },
+      {
+        subject,
+        predicate: `${PROV}wasDerivedFrom`,
+        object: args.source.assertionUri,
+      },
+    );
+  }
+
+  return provenanceQuads;
+}
+
+function semanticEnrichmentAssertionName(source: ImportedArtifactResolution): string {
+  const sourceName = source.assertionName ?? source.assertionUri.split('/').pop() ?? 'attachment';
+  const sourceSlug = sourceName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 42) || 'attachment';
+  return `semantic-enrichment-${sourceSlug}-${Date.now()}-${randomUUID().slice(0, 8)}`;
+}
+
+async function semanticEnrichmentTargetExists(
+  ctx: RequestContext,
+  assertionUri: string,
+  contextGraphId: string,
+): Promise<boolean> {
+  const store = ctx.agent.store as typeof ctx.agent.store & { hasGraph?: (graphUri: string) => Promise<boolean> };
+  if (typeof store.hasGraph === 'function' && await store.hasGraph(assertionUri)) return true;
+  const metaGraph = contextGraphMetaUri(contextGraphId);
+  const result = await ctx.agent.store.query(`
+    SELECT ?p ?o WHERE {
+      GRAPH <${metaGraph}> {
+        <${assertionUri}> ?p ?o .
+      }
+    }
+    LIMIT 1
+  `) as { type?: string; bindings?: Array<Record<string, unknown>> };
+  return Boolean(result.bindings?.length);
+}
+
+function sortAssertionQuads<T>(quads: T[]): T[] {
+  return [...quads].sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+}
+
+function normalizeMarkdownReadLimit(raw: unknown): number {
+  if (raw == null) return DEFAULT_MARKDOWN_READ_BYTES;
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw <= 0) {
+    throw new ImportArtifactRouteError(400, '"maxBytes" must be a positive integer');
+  }
+  return Math.min(raw, MAX_MARKDOWN_READ_BYTES);
+}
+
+function normalizeGeneratedAt(raw: unknown): string {
+  if (raw == null) return new Date().toISOString();
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new ImportArtifactRouteError(400, '"generatedAt" must be an ISO date-time string');
+  }
+  const parsed = new Date(raw);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new ImportArtifactRouteError(400, '"generatedAt" must be an ISO date-time string');
+  }
+  return parsed.toISOString();
+}
+
+function normalizeGeneratedBy(raw: unknown, requestAgentAddress: string): string {
+  const requestAgent = requestAgentAddress.trim();
+  const fallback = isSafeIri(requestAgent) ? requestAgent : `did:dkg:agent:${requestAgent}`;
+  if (raw == null) return fallback;
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new ImportArtifactRouteError(400, '"agentIdentity" must be a non-empty string');
+  }
+  const value = raw.trim();
+  if (isSafeIri(value)) return value;
+  return rdfLiteral(value);
+}
+
+function handleImportArtifactRouteError(res: ServerResponse, err: unknown): boolean {
+  if (err instanceof ImportArtifactRouteError) {
+    jsonResponse(res, err.statusCode, { error: err.message });
+    return true;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  if (
+    message.includes('Invalid') ||
+    message.includes('Unsafe') ||
+    message.includes('reserved namespace') ||
+    message.includes('not found') ||
+    (err as { name?: string })?.name === 'ReservedNamespaceError'
+  ) {
+    jsonResponse(res, 400, { error: message });
+    return true;
+  }
+  return false;
+}
+
+async function resolveImportedArtifact(
+  ctx: RequestContext,
+  raw: Record<string, unknown>,
+): Promise<ImportedArtifactResolution> {
+  const contextGraphId = typeof raw.contextGraphId === 'string' ? raw.contextGraphId.trim() : '';
+  if (!contextGraphId) {
+    throw new ImportArtifactRouteError(400, '"contextGraphId" is required');
+  }
+  if (!isValidContextGraphId(contextGraphId)) {
+    throw new ImportArtifactRouteError(400, 'Invalid contextGraphId');
+  }
+
+  const subGraphName = typeof raw.subGraphName === 'string' && raw.subGraphName.trim()
+    ? raw.subGraphName.trim()
+    : undefined;
+  if (subGraphName) {
+    const subGraphValidation = validateSubGraphName(subGraphName);
+    if (!subGraphValidation.valid) {
+      throw new ImportArtifactRouteError(400, `Invalid subGraphName: ${subGraphValidation.reason}`);
+    }
+  }
+
+  const assertionName = typeof raw.assertionName === 'string' && raw.assertionName.trim()
+    ? raw.assertionName.trim()
+    : undefined;
+  if (assertionName) {
+    const nameValidation = validateAssertionName(assertionName);
+    if (!nameValidation.valid) {
+      throw new ImportArtifactRouteError(400, `Invalid assertionName: ${nameValidation.reason}`);
+    }
+  }
+
+  const rawAssertionUri = typeof raw.assertionUri === 'string' && raw.assertionUri.trim()
+    ? raw.assertionUri.trim()
+    : undefined;
+  if (!rawAssertionUri) {
+    throw new ImportArtifactRouteError(400, '"assertionUri" is required');
+  }
+  if (rawAssertionUri && !isSafeIri(rawAssertionUri)) {
+    throw new ImportArtifactRouteError(400, 'Invalid assertionUri');
+  }
+
+  const assertionUri = rawAssertionUri;
+  const parsedAssertion = parseImportedAssertionUri(assertionUri, contextGraphId);
+  if (!parsedAssertion) {
+    throw new ImportArtifactRouteError(400, 'assertionUri is not an assertion in the supplied contextGraphId');
+  }
+  if (assertionName && assertionName !== parsedAssertion.assertionName) {
+    throw new ImportArtifactRouteError(400, '"assertionName" does not match assertionUri');
+  }
+  if (subGraphName && subGraphName !== parsedAssertion.subGraphName) {
+    throw new ImportArtifactRouteError(400, '"subGraphName" does not match assertionUri');
+  }
+
+  const requestedFileHash = typeof raw.fileHash === 'string' && raw.fileHash.trim()
+    ? raw.fileHash.trim()
+    : undefined;
+  if (requestedFileHash && !validateContentHash(requestedFileHash)) {
+    throw new ImportArtifactRouteError(400, 'Invalid fileHash');
+  }
+
+  const extractionRecord = getExtractionStatusRecord(ctx.extractionStatus, assertionUri);
+  if (extractionRecord && extractionRecord.status !== 'completed') {
+    throw new ImportArtifactRouteError(
+      409,
+      `Import artifact is not a completed extraction (status: ${extractionRecord.status})`,
+    );
+  }
+
+  const metaGraph = contextGraphMetaUri(contextGraphId);
+  const metaResult = await ctx.agent.store.query(`
+    SELECT ?fileHash ?contentType ?rootEntity ?structuralTripleCount ?semanticTripleCount ?extractionMethod ?extractionStatus ?mdIntermediateHash ?sourceFileName WHERE {
+      GRAPH <${metaGraph}> {
+        <${assertionUri}> <${DKG_ONTOLOGY}sourceFileHash> ?fileHash .
+        OPTIONAL { <${assertionUri}> <${DKG_ONTOLOGY}sourceContentType> ?contentType }
+        OPTIONAL { <${assertionUri}> <${DKG_ONTOLOGY}rootEntity> ?rootEntity }
+        OPTIONAL { <${assertionUri}> <${DKG_ONTOLOGY}structuralTripleCount> ?structuralTripleCount }
+        OPTIONAL { <${assertionUri}> <${DKG_ONTOLOGY}semanticTripleCount> ?semanticTripleCount }
+        OPTIONAL { <${assertionUri}> <${DKG_ONTOLOGY}extractionMethod> ?extractionMethod }
+        OPTIONAL { <${assertionUri}> <${DKG_ONTOLOGY}extractionStatus> ?extractionStatus }
+        OPTIONAL { <${assertionUri}> <${DKG_ONTOLOGY}mdIntermediateHash> ?mdIntermediateHash }
+        OPTIONAL { <${assertionUri}> <${DKG_ONTOLOGY}sourceFileName> ?sourceFileName }
+      }
+    }
+    LIMIT 1
+  `) as { type?: string; bindings?: Array<Record<string, unknown>> };
+  const metaBinding = metaResult.bindings?.[0];
+  if (!metaBinding) {
+    throw new ImportArtifactRouteError(404, 'No completed import metadata found for assertionUri');
+  }
+
+  const durableExtractionStatus = normalizeLiteralBinding(metaBinding.extractionStatus) || undefined;
+  if (durableExtractionStatus && durableExtractionStatus !== 'completed') {
+    throw new ImportArtifactRouteError(
+      409,
+      `Import artifact is not a completed extraction (status: ${durableExtractionStatus})`,
+    );
+  }
+
+  const sourceFileHash = normalizeLiteralBinding(metaBinding.fileHash);
+  if (!sourceFileHash || !validateContentHash(sourceFileHash)) {
+    throw new ImportArtifactRouteError(409, 'Import metadata is missing a valid source file hash');
+  }
+  if (requestedFileHash && requestedFileHash !== sourceFileHash) {
+    throw new ImportArtifactRouteError(400, 'fileHash does not match import metadata');
+  }
+
+  const durableSourceContentType = normalizeLiteralBinding(metaBinding.contentType) || undefined;
+  const sourceContentType = normalizeDetectedContentType(
+    durableSourceContentType || extractionRecord?.detectedContentType,
+  );
+  const mdIntermediateHash = normalizeLiteralBinding(metaBinding.mdIntermediateHash) || undefined;
+  if (mdIntermediateHash && !validateContentHash(mdIntermediateHash)) {
+    throw new ImportArtifactRouteError(409, 'Import metadata is missing a valid Markdown intermediate hash');
+  }
+  const markdownFormResult = await ctx.agent.store.query(`
+    SELECT DISTINCT ?markdownForm WHERE {
+      GRAPH <${assertionUri}> {
+        ?document <${DKG_ONTOLOGY}markdownForm> ?markdownForm .
+      }
+    }
+  `) as { type?: string; bindings?: Array<Record<string, unknown>> };
+  const authoritativeMarkdownHash = mdIntermediateHash
+    ?? (durableSourceContentType && normalizeDetectedContentType(durableSourceContentType) === 'text/markdown'
+      ? sourceFileHash
+      : undefined);
+  const graphMarkdownForms = (markdownFormResult.bindings ?? [])
+    .map((binding) => normalizeIriBinding(binding.markdownForm))
+    .filter(Boolean);
+  for (const graphMarkdownForm of graphMarkdownForms) {
+    const markdownFormHash = hashFromFileUrn(graphMarkdownForm);
+    if (!markdownFormHash || !authoritativeMarkdownHash || markdownFormHash !== authoritativeMarkdownHash) {
+      throw new ImportArtifactRouteError(409, 'Import metadata markdown hash does not match assertion markdownForm');
+    }
+  }
+  const markdownHash = authoritativeMarkdownHash;
+  const markdownForm = markdownHash ? `urn:dkg:file:${markdownHash}` : undefined;
+
+  return {
+    contextGraphId,
+    assertionUri,
+    assertionName: parsedAssertion.assertionName,
+    assertionAgentAddress: parsedAssertion.assertionAgentAddress,
+    ...(parsedAssertion.subGraphName ? { subGraphName: parsedAssertion.subGraphName } : {}),
+    fileHash: sourceFileHash,
+    sourceFileHash,
+    detectedContentType: sourceContentType,
+    sourceContentType,
+    extractionStatus: 'completed',
+    extractionMethod: normalizeLiteralBinding(metaBinding.extractionMethod) || extractionRecord?.pipelineUsed || undefined,
+    rootEntity: normalizeIriBinding(metaBinding.rootEntity) || extractionRecord?.rootEntity || undefined,
+    sourceFileName: normalizeLiteralBinding(metaBinding.sourceFileName) || extractionRecord?.fileName || undefined,
+    tripleCount: optionalPositiveInteger(metaBinding.structuralTripleCount) ?? extractionRecord?.tripleCount,
+    structuralTripleCount: optionalPositiveInteger(metaBinding.structuralTripleCount) ?? extractionRecord?.tripleCount,
+    semanticTripleCount: optionalPositiveInteger(metaBinding.semanticTripleCount),
+    ...(mdIntermediateHash ? { mdIntermediateHash } : {}),
+    ...(markdownForm ? { markdownForm } : {}),
+    ...(markdownHash ? { markdownHash } : {}),
+    canReadMarkdown: Boolean(markdownHash),
+  };
+}
 
 export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> {
   const {
@@ -362,6 +854,195 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     emitMemoryGraphChanged,
   } = ctx;
 
+  // POST /api/assertion/import-artifact/resolve
+  // Resolve a completed deterministic import artifact from graph metadata.
+  if (req.method === "POST" && path === "/api/assertion/import-artifact/resolve") {
+    const body = await readBody(req, SMALL_BODY_BYTES);
+    const parsed = safeParseJson(body, res);
+    if (!parsed) return;
+    try {
+      const artifact = await resolveImportedArtifact(ctx, parsed as Record<string, unknown>);
+      return jsonResponse(res, 200, { artifact });
+    } catch (err) {
+      if (handleImportArtifactRouteError(res, err)) return;
+      throw err;
+    }
+  }
+
+  // POST /api/assertion/import-artifact/read-markdown
+  // Read only the Markdown blob tied to a completed imported assertion.
+  if (req.method === "POST" && path === "/api/assertion/import-artifact/read-markdown") {
+    const body = await readBody(req, SMALL_BODY_BYTES);
+    const parsed = safeParseJson(body, res);
+    if (!parsed) return;
+    try {
+      const artifact = await resolveImportedArtifact(ctx, parsed as Record<string, unknown>);
+      const maxBytes = normalizeMarkdownReadLimit((parsed as Record<string, unknown>).maxBytes);
+      if (!artifact.markdownHash) {
+        return jsonResponse(res, 409, {
+          error: 'Import artifact does not have a readable Markdown source',
+          artifact,
+        });
+      }
+      const bytes = await fileStore.get(artifact.markdownHash);
+      if (!bytes) {
+        return jsonResponse(res, 404, {
+          error: 'Markdown content is not present in the file store',
+          artifact,
+        });
+      }
+      if (bytes.length > maxBytes) {
+        return jsonResponse(res, 413, {
+          error: `Markdown content exceeds maxBytes (${maxBytes})`,
+          artifact,
+          bytes: bytes.length,
+        });
+      }
+      return jsonResponse(res, 200, {
+        artifact,
+        markdownHash: artifact.markdownHash,
+        contentType: 'text/markdown',
+        bytes: bytes.length,
+        markdown: bytes.toString('utf8'),
+      });
+    } catch (err) {
+      if (handleImportArtifactRouteError(res, err)) return;
+      throw err;
+    }
+  }
+
+  // POST /api/assertion/semantic-enrichment/write
+  // Write model-derived semantic triples to a separate WM assertion with provenance.
+  if (req.method === "POST" && path === "/api/assertion/semantic-enrichment/write") {
+    const body = await readBody(req);
+    const parsed = safeParseJson(body, res);
+    if (!parsed) return;
+    try {
+      const record = parsed as Record<string, unknown>;
+      const artifact = await resolveImportedArtifact(ctx, record);
+      const targetName = typeof record.name === 'string' && record.name.trim()
+        ? record.name.trim()
+        : typeof record.semanticAssertionName === 'string' && record.semanticAssertionName.trim()
+          ? record.semanticAssertionName.trim()
+          : semanticEnrichmentAssertionName(artifact);
+      const nameValidation = validateAssertionName(targetName);
+      if (!nameValidation.valid) {
+        throw new ImportArtifactRouteError(400, `Invalid semantic assertion name: ${nameValidation.reason}`);
+      }
+      const semanticQuads = normalizeSemanticQuads(record.semanticQuads);
+      const generatedAt = normalizeGeneratedAt(record.generatedAt);
+      const generationMethod = typeof record.generationMethod === 'string' && record.generationMethod.trim()
+        ? record.generationMethod.trim()
+        : 'agent-semantic-enrichment';
+      const generatedBy = normalizeGeneratedBy(record.agentIdentity, requestAgentAddress);
+      const enrichmentUri = `urn:dkg:semantic-enrichment:${randomUUID()}`;
+      const provenanceQuads = buildSemanticEnrichmentProvenanceQuads({
+        enrichmentUri,
+        source: artifact,
+        generatedBy,
+        generatedAt,
+        generationMethod,
+        semanticQuads,
+      });
+      const targetSubGraphName = artifact.subGraphName;
+      const assertionUri = contextGraphAssertionUri(
+        artifact.contextGraphId,
+        requestAgentAddress,
+        targetName,
+        targetSubGraphName,
+      );
+      if (assertionUri === artifact.assertionUri) {
+        throw new ImportArtifactRouteError(
+          409,
+          'Semantic enrichment assertion must be separate from the source import assertion',
+        );
+      }
+      if (await semanticEnrichmentTargetExists(ctx, assertionUri, artifact.contextGraphId)) {
+        throw new ImportArtifactRouteError(
+          409,
+          'Semantic enrichment assertion already exists; choose a unique target name',
+        );
+      }
+      try {
+        await agent.publisher.assertionCreate(
+          artifact.contextGraphId,
+          targetName,
+          requestAgentAddress,
+          targetSubGraphName,
+        );
+      } catch (err: any) {
+        if (err?.message?.includes('already exists')) {
+          throw new ImportArtifactRouteError(
+            409,
+            'Semantic enrichment assertion already exists; choose a unique target name',
+          );
+        }
+        throw err;
+      }
+      const quads = [...semanticQuads, ...provenanceQuads];
+      try {
+        await agent.publisher.assertionWrite(
+          artifact.contextGraphId,
+          targetName,
+          requestAgentAddress,
+          quads,
+          targetSubGraphName,
+        );
+      } catch (err: any) {
+        try {
+          await agent.publisher.assertionDiscard(
+            artifact.contextGraphId,
+            targetName,
+            requestAgentAddress,
+            targetSubGraphName,
+          );
+        } catch (rollbackErr: any) {
+          const writeMessage = err instanceof Error ? err.message : String(err);
+          const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+          throw new Error(
+            `Semantic enrichment write failed and rollback failed: ${writeMessage}; rollback: ${rollbackMessage}`,
+          );
+        }
+        throw err;
+      }
+      emitMemoryGraphChanged?.({
+        contextGraphId: artifact.contextGraphId,
+        layers: ["wm"],
+        subGraphName: targetSubGraphName,
+        operation: "assertion_created",
+        source: "api",
+        counts: { triples: 0 },
+      });
+      emitMemoryGraphChanged?.({
+        contextGraphId: artifact.contextGraphId,
+        layers: ["wm"],
+        subGraphName: targetSubGraphName,
+        operation: "semantic_enrichment_written",
+        source: "api",
+        counts: { triples: quads.length },
+      });
+      return jsonResponse(res, 200, {
+        assertionUri,
+        assertionName: targetName,
+        contextGraphId: artifact.contextGraphId,
+        ...(targetSubGraphName ? { subGraphName: targetSubGraphName } : {}),
+        sourceAssertionUri: artifact.assertionUri,
+        sourceFileHash: artifact.fileHash,
+        markdownHash: artifact.markdownHash,
+        markdownForm: artifact.markdownForm,
+        enrichmentUri,
+        written: quads.length,
+        semanticTripleCount: semanticQuads.length,
+        provenanceTripleCount: provenanceQuads.length,
+        promoted: false,
+        published: false,
+        artifact,
+      });
+    } catch (err) {
+      if (handleImportArtifactRouteError(res, err)) return;
+      throw err;
+    }
+  }
 
   // POST /api/assertion/create
   //   Body: {
@@ -656,7 +1337,8 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
         assertionName,
         subGraphName ? { subGraphName } : undefined,
       );
-      return jsonResponse(res, 200, { quads, count: quads.length });
+      const sortedQuads = sortAssertionQuads(quads);
+      return jsonResponse(res, 200, { quads: sortedQuads, count: sortedQuads.length });
     } catch (err: any) {
       if (
         err.message?.includes("not found") ||

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -389,6 +389,13 @@ function optionalPositiveInteger(cell: unknown): number | undefined {
   return parseOpenClawAttachmentTripleCount(bindingCellValue(cell));
 }
 
+function optionalStrictPositiveInteger(cell: unknown): number | undefined {
+  const value = normalizeLiteralBinding(cell);
+  if (!/^\+?\d+$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 function hashFromFileUrn(value: string | undefined): string | undefined {
   const prefix = 'urn:dkg:file:';
   if (!value?.startsWith(prefix)) return undefined;
@@ -782,14 +789,16 @@ async function resolveImportedArtifact(
   }
 
   const durableExtractionStatus = normalizeLiteralBinding(metaBinding.extractionStatus) || undefined;
-  if (!durableExtractionStatus) {
-    throw new ImportArtifactRouteError(409, 'Import metadata is missing completed extraction status');
-  }
-  if (durableExtractionStatus !== 'completed') {
+  const structuralTripleCount = optionalPositiveInteger(metaBinding.structuralTripleCount);
+  const legacyCompletedStructuralTripleCount = optionalStrictPositiveInteger(metaBinding.structuralTripleCount);
+  if (durableExtractionStatus && durableExtractionStatus !== 'completed') {
     throw new ImportArtifactRouteError(
       409,
       `Import artifact is not a completed extraction (status: ${durableExtractionStatus})`,
     );
+  }
+  if (!durableExtractionStatus && (legacyCompletedStructuralTripleCount ?? 0) <= 0) {
+    throw new ImportArtifactRouteError(409, 'Import metadata is missing completed extraction status');
   }
 
   const sourceFileHash = normalizeLiteralBinding(metaBinding.fileHash);
@@ -845,8 +854,8 @@ async function resolveImportedArtifact(
     extractionMethod: normalizeLiteralBinding(metaBinding.extractionMethod) || extractionRecord?.pipelineUsed || undefined,
     rootEntity: normalizeIriBinding(metaBinding.rootEntity) || extractionRecord?.rootEntity || undefined,
     sourceFileName: normalizeLiteralBinding(metaBinding.sourceFileName) || extractionRecord?.fileName || undefined,
-    tripleCount: optionalPositiveInteger(metaBinding.structuralTripleCount) ?? extractionRecord?.tripleCount,
-    structuralTripleCount: optionalPositiveInteger(metaBinding.structuralTripleCount) ?? extractionRecord?.tripleCount,
+    tripleCount: structuralTripleCount ?? extractionRecord?.tripleCount,
+    structuralTripleCount: structuralTripleCount ?? extractionRecord?.tripleCount,
     semanticTripleCount: optionalPositiveInteger(metaBinding.semanticTripleCount),
     ...(mdIntermediateHash ? { mdIntermediateHash } : {}),
     ...(markdownForm ? { markdownForm } : {}),
@@ -2685,14 +2694,21 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
           object: JSON.stringify("structural"),
           graph: metaGraph,
         },
-        // Row 18
+        // Row 18 - durable terminal import state used by artifact readers after restart.
+        {
+          subject: assertionUri,
+          predicate: "http://dkg.io/ontology/extractionStatus",
+          object: JSON.stringify("completed"),
+          graph: metaGraph,
+        },
+        // Row 19
         {
           subject: assertionUri,
           predicate: "http://dkg.io/ontology/structuralTripleCount",
           object: `"${triples.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
           graph: metaGraph,
         },
-        // Row 19 — V10.0 has no semantic (Layer 2) extraction, so always zero.
+        // Row 20 - V10.0 has no semantic (Layer 2) extraction, so always zero.
         {
           subject: assertionUri,
           predicate: "http://dkg.io/ontology/semanticTripleCount",

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -611,6 +611,28 @@ function normalizeGeneratedBy(raw: unknown, requestAgentAddress: string): string
   return rdfLiteral(value);
 }
 
+function comparableAgentAddress(value: string): string {
+  const trimmed = value.trim();
+  const unwrapped = trimmed.startsWith('did:dkg:agent:')
+    ? trimmed.slice('did:dkg:agent:'.length)
+    : trimmed;
+  return /^0x[0-9a-fA-F]{40}$/.test(unwrapped) ? unwrapped.toLowerCase() : unwrapped;
+}
+
+function isSameAgentAddress(left: string, right: string): boolean {
+  return left === right || comparableAgentAddress(left) === comparableAgentAddress(right);
+}
+
+function assertImportedArtifactOwnerAddress(
+  assertionAgentAddress: string,
+  requestAgentAddress: string,
+  message: string,
+): void {
+  if (!isSameAgentAddress(assertionAgentAddress, requestAgentAddress)) {
+    throw new ImportArtifactRouteError(403, message);
+  }
+}
+
 function handleImportArtifactRouteError(res: ServerResponse, err: unknown): boolean {
   if (err instanceof ImportArtifactRouteError) {
     jsonResponse(res, err.statusCode, { error: err.message });
@@ -633,6 +655,10 @@ function handleImportArtifactRouteError(res: ServerResponse, err: unknown): bool
 async function resolveImportedArtifact(
   ctx: RequestContext,
   raw: Record<string, unknown>,
+  ownerGuard?: {
+    requestAgentAddress: string;
+    message: string;
+  },
 ): Promise<ImportedArtifactResolution> {
   const contextGraphId = typeof raw.contextGraphId === 'string' ? raw.contextGraphId.trim() : '';
   if (!contextGraphId) {
@@ -689,6 +715,13 @@ async function resolveImportedArtifact(
   );
   if (reconstructedAssertionUri !== assertionUri) {
     throw new ImportArtifactRouteError(400, 'assertionUri is not in canonical assertion URI form');
+  }
+  if (ownerGuard) {
+    assertImportedArtifactOwnerAddress(
+      parsedAssertion.assertionAgentAddress,
+      ownerGuard.requestAgentAddress,
+      ownerGuard.message,
+    );
   }
   if (assertionName && assertionName !== parsedAssertion.assertionName) {
     throw new ImportArtifactRouteError(400, '"assertionName" does not match assertionUri');
@@ -848,7 +881,10 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     const parsed = safeParseJson(body, res);
     if (!parsed) return;
     try {
-      const artifact = await resolveImportedArtifact(ctx, parsed as Record<string, unknown>);
+      const artifact = await resolveImportedArtifact(ctx, parsed as Record<string, unknown>, {
+        requestAgentAddress,
+        message: 'Import artifact metadata can only be read from imported assertions owned by the requesting agent',
+      });
       return jsonResponse(res, 200, { artifact });
     } catch (err) {
       if (handleImportArtifactRouteError(res, err)) return;
@@ -863,7 +899,10 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     const parsed = safeParseJson(body, res);
     if (!parsed) return;
     try {
-      const artifact = await resolveImportedArtifact(ctx, parsed as Record<string, unknown>);
+      const artifact = await resolveImportedArtifact(ctx, parsed as Record<string, unknown>, {
+        requestAgentAddress,
+        message: 'Import artifact Markdown can only be read from imported assertions owned by the requesting agent',
+      });
       const maxBytes = normalizeMarkdownReadLimit((parsed as Record<string, unknown>).maxBytes);
       if (!artifact.markdownHash) {
         return jsonResponse(res, 409, {
@@ -916,14 +955,11 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
           'Semantic enrichment is written into the source import assertion; target assertion names are not supported',
         );
       }
-      const artifact = await resolveImportedArtifact(ctx, record);
+      const artifact = await resolveImportedArtifact(ctx, record, {
+        requestAgentAddress,
+        message: 'Semantic enrichment can only modify imported assertions owned by the requesting agent',
+      });
       const semanticQuads = normalizeSemanticQuads(record.semanticQuads);
-      if (artifact.assertionAgentAddress !== requestAgentAddress) {
-        throw new ImportArtifactRouteError(
-          403,
-          'Semantic enrichment can only modify imported assertions owned by the requesting agent',
-        );
-      }
       const generatedAt = normalizeGeneratedAt(record.generatedAt);
       const generationMethod = typeof record.generationMethod === 'string' && record.generationMethod.trim()
         ? record.generationMethod.trim()

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -483,8 +483,8 @@ function buildHermesNodeUiSystemPrompt(
     for (const attachment of attachmentRefs) {
       lines.push(formatHermesAttachmentPromptLine(attachment));
     }
-    lines.push('For completed imported attachments, resolve the artifact with dkg_import_artifact_resolve, read Markdown with dkg_import_artifact_read_markdown when needed, inspect deterministic quads with dkg_assertion_query, and write model-derived triples only through dkg_semantic_enrichment_write unless the user explicitly asks for a different assertion workflow.');
-    lines.push('Keep deterministic import assertions separate from semantic enrichment assertions; do not promote or publish enrichment output unless explicitly instructed.');
+    lines.push('For completed imported attachments, read Markdown with dkg_import_artifact_read_markdown when needed, inspect assertion quads with dkg_assertion_query when useful, and append model-derived triples to the imported assertion with dkg_semantic_enrichment_write.');
+    lines.push('Use dkg_import_artifact_resolve only when you need to re-check artifact metadata. Do not promote or publish enrichment output unless explicitly instructed.');
   }
   return lines.join('\n');
 }

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -483,6 +483,8 @@ function buildHermesNodeUiSystemPrompt(
     for (const attachment of attachmentRefs) {
       lines.push(formatHermesAttachmentPromptLine(attachment));
     }
+    lines.push('For completed imported attachments, resolve the artifact with dkg_import_artifact_resolve, read Markdown with dkg_import_artifact_read_markdown when needed, inspect deterministic quads with dkg_assertion_query, and write model-derived triples only through dkg_semantic_enrichment_write unless the user explicitly asks for a different assertion workflow.');
+    lines.push('Keep deterministic import assertions separate from semantic enrichment assertions; do not promote or publish enrichment output unless explicitly instructed.');
   }
   return lines.join('\n');
 }
@@ -491,11 +493,15 @@ function formatHermesAttachmentPromptLine(attachment: OpenClawAttachmentRef): st
   const details = [
     `assertionUri=${formatHermesPromptValue(attachment.assertionUri)}`,
     `contextGraphId=${formatHermesPromptValue(attachment.contextGraphId)}`,
+    attachment.assertionName ? `assertionName=${formatHermesPromptValue(attachment.assertionName)}` : null,
     `fileHash=${formatHermesPromptValue(attachment.fileHash)}`,
     attachment.detectedContentType ? `contentType=${formatHermesPromptValue(attachment.detectedContentType)}` : null,
     attachment.extractionStatus ? `status=${formatHermesPromptValue(attachment.extractionStatus)}` : null,
     attachment.tripleCount != null ? `tripleCount=${attachment.tripleCount}` : null,
     attachment.rootEntity ? `rootEntity=${formatHermesPromptValue(attachment.rootEntity)}` : null,
+    attachment.mdIntermediateHash ? `mdIntermediateHash=${formatHermesPromptValue(attachment.mdIntermediateHash)}` : null,
+    attachment.markdownHash ? `markdownHash=${formatHermesPromptValue(attachment.markdownHash)}` : null,
+    attachment.markdownForm ? `markdownForm=${formatHermesPromptValue(attachment.markdownForm)}` : null,
   ].filter((item): item is string => item != null);
   return `- ${formatHermesPromptValue(attachment.fileName)}: ${details.join('; ')}`;
 }

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -1804,6 +1804,9 @@ describe('Hermes daemon routes', () => {
     expect(systemPrompt).toContain(`markdownHash="${attachmentRef.fileHash}"`);
     expect(systemPrompt).toContain('dkg_import_artifact_read_markdown');
     expect(systemPrompt).toContain('dkg_semantic_enrichment_write');
+    expect(systemPrompt).toContain('Use dkg_import_artifact_resolve only when you need to re-check artifact metadata');
+    expect(systemPrompt).not.toContain('resolve the artifact with dkg_import_artifact_resolve');
+    expect(systemPrompt).not.toContain('Keep deterministic import assertions separate');
     expect(storeChatExchange).toHaveBeenCalledWith(
       'hermes:dkg-ui:attachments',
       'summarize attached context',

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -84,6 +84,41 @@ function freshExtractionStatusTimes() {
   return { startedAt, completedAt };
 }
 
+function makeHermesAttachmentStore(refs: Array<{
+  assertionUri: string;
+  fileHash: string;
+  fileName: string;
+  detectedContentType?: string;
+  rootEntity?: string;
+  tripleCount?: number;
+  mdIntermediateHash?: string;
+  markdownForm?: string;
+}>) {
+  return {
+    query: vi.fn(async (sparql: string) => {
+      const ref = refs.find((candidate) => sparql.includes(`<${candidate.assertionUri}>`));
+      if (!ref) return { bindings: [] };
+      if (sparql.includes('SELECT ?fileHash')) {
+        return {
+          bindings: [{
+            fileHash: ref.fileHash,
+            contentType: ref.detectedContentType,
+            rootEntity: ref.rootEntity,
+            extractionStatus: 'completed',
+            tripleCount: ref.tripleCount != null ? String(ref.tripleCount) : undefined,
+            sourceFileName: ref.fileName,
+            mdIntermediateHash: ref.mdIntermediateHash,
+          }],
+        };
+      }
+      if (sparql.includes('?markdownForm')) {
+        return { bindings: ref.markdownForm ? [{ markdownForm: ref.markdownForm }] : [] };
+      }
+      return { bindings: [] };
+    }),
+  };
+}
+
 function deferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -106,7 +141,7 @@ function makeHermesRouteContext(
     ctx: {
       req,
       res,
-      agent: { store: {} },
+      agent: { store: { query: vi.fn(async () => ({ bindings: [] })) } },
       config: makeConfig({
         localAgentIntegrations: {
           hermes: {
@@ -1294,6 +1329,7 @@ describe('Hermes daemon routes', () => {
       hasChatTurn: vi.fn(async () => false),
       storeChatExchange: vi.fn(async () => {}),
     }, {}, '/api/hermes-channel/send');
+    ctx.agent.store = makeHermesAttachmentStore([attachmentRef]);
     ctx.extractionStatus.set(attachmentRef.assertionUri, {
       status: 'completed',
       fileName: attachmentRef.fileName,
@@ -1318,7 +1354,7 @@ describe('Hermes daemon routes', () => {
     expect(forwardedBodies).toHaveLength(1);
     expect(forwardedBodies[0]).toMatchObject({
       contextGraphId: 'project-1',
-      attachmentRefs: [attachmentRef],
+      attachmentRefs: [verifiedAttachmentRef],
     });
     expect(forwardedBodies[0].contextEntries[0]).toEqual(contextEntries[0]);
     expect(forwardedBodies[0].contextEntries[1]).toMatchObject({
@@ -1737,6 +1773,11 @@ describe('Hermes daemon routes', () => {
       pipelineUsed: null,
       tripleCount: 0,
     };
+    const verifiedAttachmentRef = {
+      ...attachmentRef,
+      markdownHash: attachmentRef.fileHash,
+      markdownForm: `urn:dkg:file:${attachmentRef.fileHash}`,
+    };
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), body: JSON.parse(String(init?.body)) });
       return new Response(JSON.stringify({
@@ -1767,6 +1808,7 @@ describe('Hermes daemon routes', () => {
         },
       },
     }, '/api/hermes-channel/send');
+    ctx.agent.store = makeHermesAttachmentStore([attachmentRef]);
     ctx.extractionStatus.set(attachmentRef.assertionUri, {
       status: 'completed',
       fileName: attachmentRef.fileName,

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -1265,6 +1265,11 @@ describe('Hermes daemon routes', () => {
       pipelineUsed: null,
       tripleCount: 0,
     };
+    const verifiedAttachmentRef = {
+      ...attachmentRef,
+      markdownHash: attachmentRef.fileHash,
+      markdownForm: `urn:dkg:file:${attachmentRef.fileHash}`,
+    };
     const contextEntries = [{
       key: 'target_context_graph',
       label: 'Target context graph',
@@ -1796,13 +1801,16 @@ describe('Hermes daemon routes', () => {
     expect(systemPrompt).toContain('status="completed"');
     expect(systemPrompt).toContain('tripleCount=12');
     expect(systemPrompt).toContain('rootEntity="did:dkg:context-graph:project-1/assertion/notes"');
+    expect(systemPrompt).toContain(`markdownHash="${attachmentRef.fileHash}"`);
+    expect(systemPrompt).toContain('dkg_import_artifact_read_markdown');
+    expect(systemPrompt).toContain('dkg_semantic_enrichment_write');
     expect(storeChatExchange).toHaveBeenCalledWith(
       'hermes:dkg-ui:attachments',
       'summarize attached context',
       'Hermes attachment reply',
       undefined,
       expect.objectContaining({
-        attachmentRefs: [attachmentRef],
+        attachmentRefs: [verifiedAttachmentRef],
         persistenceState: 'stored',
       }),
     );

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -1571,6 +1571,62 @@ describe('OpenClaw persist-turn validation', () => {
     expect(queryCalls).toHaveLength(0);
   });
 
+  it('does not let extraction status authorize Markdown metadata without durable _meta verification', async () => {
+    const now = new Date();
+    const startedAt = new Date(now.getTime() - 1000).toISOString();
+    const completedAt = now.toISOString();
+    const fileHash = `sha256:${'a'.repeat(64)}`;
+    const attachmentRefs = [{
+      assertionUri: 'did:dkg:context-graph:cg1/assertion/chat-doc',
+      fileHash,
+      contextGraphId: 'cg1',
+      fileName: 'chat-doc.md',
+      detectedContentType: 'text/markdown',
+      extractionStatus: 'completed' as const,
+      markdownHash: fileHash,
+      markdownForm: `urn:dkg:file:${fileHash}`,
+    }];
+    const queryCalls: unknown[][] = [];
+    const store = {
+      query: async (...args: unknown[]) => {
+        queryCalls.push(args);
+        const sparql = String(args[0]);
+        if (sparql.includes('SELECT ?fileHash')) {
+          return {
+            bindings: [{
+              fileHash: `"${fileHash}"`,
+              sourceFileName: '"chat-doc.md"',
+            }],
+          };
+        }
+        if (sparql.includes('SELECT ?markdownForm')) {
+          return {
+            bindings: [{ markdownForm: `urn:dkg:file:${fileHash}` }],
+          };
+        }
+        return { bindings: [] };
+      },
+    };
+    const extractionStatus = new Map([
+      ['did:dkg:context-graph:cg1/assertion/chat-doc', {
+        status: 'completed',
+        fileHash,
+        fileName: 'chat-doc.md',
+        detectedContentType: 'text/markdown',
+        pipelineUsed: 'text/markdown',
+        tripleCount: 42,
+        rootEntity: 'did:dkg:context-graph:cg1/assertion/chat-doc',
+        startedAt,
+        completedAt,
+      }],
+    ]);
+
+    await expect(
+      verifyOpenClawAttachmentRefsProvenance({ store } as any, extractionStatus as any, attachmentRefs),
+    ).resolves.toBeUndefined();
+    expect(queryCalls).toHaveLength(2);
+  });
+
   it('accepts sub-graph attachment refs backed by extraction status records without querying the store', async () => {
     const now = new Date();
     const startedAt = new Date(now.getTime() - 1000).toISOString();
@@ -1632,6 +1688,37 @@ describe('OpenClaw persist-turn validation', () => {
     expect(String(queryCalls[0][0])).toContain('GRAPH <did:dkg:context-graph:cg1/_meta>');
     expect(String(queryCalls[0][0])).not.toContain('did:dkg:context-graph:cg1/decisions/_meta');
     expect(String(queryCalls[0][0])).toContain('<did:dkg:context-graph:cg1/decisions/assertion/0xAgent/chat-doc>');
+  });
+
+  it('rejects completed attachment refs backed by skipped durable metadata after cache expiry', async () => {
+    const attachmentRefs = [{
+      assertionUri: 'did:dkg:context-graph:cg1/assertion/chat-doc',
+      fileHash: 'sha256:abc123',
+      contextGraphId: 'cg1',
+      fileName: 'chat-doc.bin',
+      detectedContentType: 'application/octet-stream',
+      extractionStatus: 'completed' as const,
+    }];
+    const queryCalls: unknown[][] = [];
+    const store = {
+      query: async (...args: unknown[]) => {
+        queryCalls.push(args);
+        return {
+          bindings: [{
+            fileHash: '"sha256:abc123"',
+            contentType: '"application/octet-stream"',
+            sourceFileName: '"chat-doc.bin"',
+            extractionStatus: '"skipped"',
+          }],
+        };
+      },
+    };
+
+    await expect(
+      verifyOpenClawAttachmentRefsProvenance({ store } as any, new Map(), attachmentRefs),
+    ).resolves.toBeUndefined();
+    expect(queryCalls).toHaveLength(1);
+    expect(String(queryCalls[0][0])).toContain('dkg.io/ontology/extractionStatus');
   });
 
   it('unescapes RDF string literals before comparing stored source file names', async () => {

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -1,0 +1,821 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  contextGraphAssertionUri,
+  contextGraphMetaUri,
+} from '@origintrail-official/dkg-core';
+import { FileStore } from '../src/file-store.js';
+import type { ExtractionStatusRecord } from '../src/extraction-status.js';
+import { handleAssertionRoutes } from '../src/daemon/routes/assertion.js';
+
+const DKG = 'http://dkg.io/ontology/';
+const PROV = 'http://www.w3.org/ns/prov#';
+
+type Quad = { subject: string; predicate: string; object: string };
+
+describe('import artifact daemon routes', () => {
+  let tempDir: string;
+  let fileStore: FileStore;
+  let server: Server | undefined;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'dkg-import-artifact-routes-'));
+    fileStore = new FileStore(join(tempDir, 'files'));
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server!.close((err) => (err ? reject(err) : resolve()));
+      });
+      server = undefined;
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function startRoutes(args: {
+    agent: any;
+    extractionStatus?: Map<string, ExtractionStatusRecord>;
+    events?: unknown[];
+  }) {
+    const events = args.events ?? [];
+    server = createServer(async (req, res) => {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      try {
+        await handleAssertionRoutes({
+          req,
+          res,
+          agent: args.agent,
+          publisherControl: {},
+          publisherRuntime: null,
+          config: {},
+          startedAt: Date.now(),
+          dashDb: {},
+          opWallets: {},
+          network: {},
+          tracker: {},
+          memoryManager: {},
+          bridgeAuthToken: undefined,
+          nodeVersion: 'test',
+          nodeCommit: 'test',
+          catchupTracker: { jobs: new Map(), latestByContextGraph: new Map() },
+          extractionRegistry: {},
+          fileStore,
+          extractionStatus: args.extractionStatus ?? new Map(),
+          assertionImportLocks: new Map(),
+          vectorStore: {},
+          embeddingProvider: null,
+          validTokens: new Set(),
+          apiHost: '127.0.0.1',
+          apiPortRef: { value: 0 },
+          url,
+          path: url.pathname,
+          requestToken: undefined,
+          requestAgentAddress: 'did:dkg:agent:test',
+          emitMemoryGraphChanged: (event) => events.push(event),
+        } as any);
+        if (!res.writableEnded) {
+          res.statusCode = 404;
+          res.end();
+        }
+      } catch (err) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+      }
+    });
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  }
+
+  async function post(path: string, body: Record<string, unknown>) {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { status: res.status, body: await res.json() };
+  }
+
+  function makeAgent(args: {
+    contextGraphId: string;
+    assertionName: string;
+    assertionUri: string;
+    fileHash: string;
+    markdownHash: string;
+    markdownForm: string | string[];
+    contentType?: string | null;
+    extractionStatus?: string;
+    mdIntermediateHash?: string;
+    publisherCreateError?: Error;
+    publisherWriteError?: Error;
+    publisherDiscardError?: Error;
+    targetGraphExists?: boolean;
+    queryQuads?: Quad[];
+  }) {
+    const created: Array<{
+      contextGraphId: string;
+      name: string;
+      agentAddress?: string;
+      subGraphName?: string;
+      opts?: unknown;
+    }> = [];
+    const writes: Array<{
+      contextGraphId: string;
+      name: string;
+      agentAddress?: string;
+      quads: Quad[];
+      subGraphName?: string;
+      opts?: unknown;
+    }> = [];
+    const discards: Array<{
+      contextGraphId: string;
+      name: string;
+      agentAddress?: string;
+      subGraphName?: string;
+    }> = [];
+    const queryQuads = args.queryQuads ?? [
+      { subject: 'urn:z', predicate: 'urn:p', object: 'urn:o' },
+      { subject: 'urn:a', predicate: 'urn:p', object: '"A"' },
+    ];
+    const agent = {
+      assertion: {
+        async create(contextGraphId: string, name: string, opts?: unknown) {
+          created.push({ contextGraphId, name, opts });
+          return contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', name);
+        },
+        async write(contextGraphId: string, name: string, quads: Quad[], opts?: unknown) {
+          writes.push({ contextGraphId, name, quads, opts });
+        },
+        async query() {
+          return queryQuads;
+        },
+      },
+      publisher: {
+        async assertionCreate(
+          contextGraphId: string,
+          name: string,
+          agentAddress: string,
+          subGraphName?: string,
+        ) {
+          if (args.publisherCreateError) throw args.publisherCreateError;
+          created.push({ contextGraphId, name, agentAddress, subGraphName });
+          return contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
+        },
+        async assertionWrite(
+          contextGraphId: string,
+          name: string,
+          agentAddress: string,
+          quads: Quad[],
+          subGraphName?: string,
+        ) {
+          if (args.publisherWriteError) throw args.publisherWriteError;
+          writes.push({ contextGraphId, name, agentAddress, quads, subGraphName });
+        },
+        async assertionDiscard(
+          contextGraphId: string,
+          name: string,
+          agentAddress: string,
+          subGraphName?: string,
+        ) {
+          if (args.publisherDiscardError) throw args.publisherDiscardError;
+          discards.push({ contextGraphId, name, agentAddress, subGraphName });
+        },
+      },
+      store: {
+        async hasGraph() {
+          return Boolean(args.targetGraphExists);
+        },
+        async query(sparql: string) {
+          if (sparql.includes('SELECT ?p ?o')) {
+            return { type: 'bindings', bindings: [] };
+          }
+          if (sparql.includes('SELECT ?fileHash')) {
+            expect(sparql).toContain(`<${contextGraphMetaUri(args.contextGraphId)}>`);
+            expect(sparql).toContain(`<${args.assertionUri}> <${DKG}sourceFileHash>`);
+            return {
+              type: 'bindings',
+              bindings: [{
+                fileHash: args.fileHash,
+                ...(args.contentType !== null ? { contentType: args.contentType ?? 'text/markdown' } : {}),
+                rootEntity: 'urn:doc:imported',
+                structuralTripleCount: '3',
+                semanticTripleCount: '0',
+                extractionMethod: 'text/markdown',
+                ...(args.extractionStatus ? { extractionStatus: args.extractionStatus } : {}),
+                ...(args.mdIntermediateHash ? { mdIntermediateHash: args.mdIntermediateHash } : {}),
+                sourceFileName: 'imported.md',
+              }],
+            };
+          }
+          if (sparql.includes('?markdownForm')) {
+            const markdownForms = Array.isArray(args.markdownForm)
+              ? args.markdownForm
+              : [args.markdownForm];
+            expect(sparql).toContain(`GRAPH <${args.assertionUri}>`);
+            return {
+              type: 'bindings',
+              bindings: markdownForms.map((markdownForm) => ({ markdownForm })),
+            };
+          }
+          throw new Error(`unexpected query: ${sparql}`);
+        },
+      },
+    };
+    return { agent, created, writes, discards };
+  }
+
+  it('resolves and safely reads a completed Markdown import artifact by content hash', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n\nHello DKG.\n'), 'text/markdown');
+    const contextGraphId = 'cg-import-artifact';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const markdownForm = `urn:dkg:file:${entry.keccak256}`;
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm,
+    });
+    await startRoutes({ agent });
+
+    const resolved = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+      assertionName,
+      fileHash: entry.keccak256,
+    });
+    expect(resolved.status).toBe(200);
+    expect(resolved.body.artifact).toMatchObject({
+      contextGraphId,
+      assertionUri,
+      assertionName,
+      assertionAgentAddress: 'did:dkg:agent:source',
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm,
+      canReadMarkdown: true,
+      extractionStatus: 'completed',
+    });
+
+    const read = await post('/api/assertion/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri,
+      maxBytes: 1024,
+    });
+    expect(read.status).toBe(200);
+    expect(read.body).toMatchObject({
+      markdownHash: entry.keccak256,
+      contentType: 'text/markdown',
+      bytes: Buffer.byteLength('# Imported\n\nHello DKG.\n'),
+      markdown: '# Imported\n\nHello DKG.\n',
+    });
+  });
+
+  it('requires full assertionUri instead of guessing the source author from assertionName', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-import-artifact-uri-required';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionName,
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toMatch(/"assertionUri" is required/);
+  });
+
+  it('writes semantic enrichment to a separate WM assertion with explicit provenance only', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-semantic-enrichment';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const markdownForm = `urn:dkg:file:${entry.keccak256}`;
+    const events: unknown[] = [];
+    const { agent, created, writes } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm,
+    });
+    await startRoutes({ agent, events });
+
+    const result = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri,
+      name: 'semantic-imported-md',
+      semanticQuads: [
+        { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
+      ],
+      generationMethod: 'unit-test-model',
+      agentIdentity: 'did:dkg:agent:reviewer',
+      generatedAt: '2026-05-11T00:00:00.000Z',
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({
+      assertionName: 'semantic-imported-md',
+      sourceAssertionUri: assertionUri,
+      sourceFileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm,
+      semanticTripleCount: 1,
+      promoted: false,
+      published: false,
+    });
+    expect(created).toEqual([{
+      contextGraphId,
+      name: 'semantic-imported-md',
+      agentAddress: 'did:dkg:agent:test',
+      subGraphName: undefined,
+    }]);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.name).toBe('semantic-imported-md');
+    expect(writes[0]!.agentAddress).toBe('did:dkg:agent:test');
+    expect(writes[0]!.quads).toEqual(expect.arrayContaining([
+      { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${DKG}sourceAssertion`, object: assertionUri },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${DKG}sourceFileHash`, object: `"${entry.keccak256}"` },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${DKG}markdownHash`, object: `"${entry.keccak256}"` },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${DKG}markdownForm`, object: markdownForm },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${DKG}generationMethod`, object: '"unit-test-model"' },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${DKG}generatedBy`, object: 'did:dkg:agent:reviewer' },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${PROV}wasAttributedTo`, object: 'did:dkg:agent:reviewer' },
+      { subject: 'urn:doc:imported', predicate: `${PROV}wasDerivedFrom`, object: assertionUri },
+    ]));
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ operation: 'assertion_created', layers: ['wm'] }),
+      expect.objectContaining({ operation: 'semantic_enrichment_written', layers: ['wm'] }),
+    ]));
+  });
+
+  it('stores non-IRI agent identity labels without emitting prov attribution resources', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-semantic-enrichment-label-agent';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent, writes } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri,
+      name: 'semantic-imported-md',
+      semanticQuads: [
+        { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: 'Semantic topic' },
+      ],
+      agentIdentity: 'Reviewer Bot',
+    });
+
+    expect(result.status).toBe(200);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.quads).toEqual(expect.arrayContaining([
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${DKG}generatedBy`, object: '"Reviewer Bot"' },
+    ]));
+    expect(writes[0]!.quads.filter((quad) => quad.predicate === `${PROV}wasAttributedTo`)).toHaveLength(0);
+  });
+
+  it('escapes control bytes in direct semantic enrichment literal inputs', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-semantic-enrichment-control-literals';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent, writes } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri,
+      name: 'semantic-imported-md',
+      semanticQuads: [
+        {
+          subject: 'urn:doc:imported',
+          predicate: 'http://schema.org/about',
+          object: 'Topic\u0000vertical\u000Bdel\u007F',
+        },
+      ],
+      generationMethod: 'model\u0000unit\u007F',
+      agentIdentity: 'Reviewer\u000BBot',
+    });
+
+    expect(result.status).toBe(200);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.quads).toEqual(expect.arrayContaining([
+      { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Topic\\u0000vertical\\u000Bdel\\u007F"' },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${DKG}generationMethod`, object: '"model\\u0000unit\\u007F"' },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${DKG}generatedBy`, object: '"Reviewer\\u000BBot"' },
+    ]));
+    expect(writes[0]!.quads.filter((quad) => quad.predicate === `${PROV}wasAttributedTo`)).toHaveLength(0);
+  });
+
+  it('uses an existing DID request agent as fallback provenance without double-prefixing it', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-semantic-enrichment-default-agent';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent, writes } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri,
+      name: 'semantic-imported-md',
+      semanticQuads: [
+        { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: 'Fallback topic' },
+      ],
+    });
+
+    expect(result.status).toBe(200);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.quads).toEqual(expect.arrayContaining([
+      { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Fallback topic"' },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${DKG}generatedBy`, object: 'did:dkg:agent:test' },
+      { subject: expect.stringMatching(/^urn:dkg:semantic-enrichment:/), predicate: `${PROV}wasAttributedTo`, object: 'did:dkg:agent:test' },
+    ]));
+    expect(writes[0]!.quads).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ object: 'did:dkg:agent:did:dkg:agent:test' }),
+    ]));
+  });
+
+  it('rolls back a newly created semantic enrichment assertion when writing quads fails', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-semantic-enrichment-write-failure';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const events: unknown[] = [];
+    const { agent, created, writes, discards } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      publisherWriteError: new Error('simulated semantic write failure'),
+    });
+    await startRoutes({ agent, events });
+
+    const result = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri,
+      name: 'semantic-imported-md',
+      semanticQuads: [
+        { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
+      ],
+    });
+
+    expect(result.status).toBe(500);
+    expect(result.body.error).toContain('simulated semantic write failure');
+    expect(created).toEqual([{
+      contextGraphId,
+      name: 'semantic-imported-md',
+      agentAddress: 'did:dkg:agent:test',
+      subGraphName: undefined,
+    }]);
+    expect(writes).toHaveLength(0);
+    expect(discards).toEqual([{
+      contextGraphId,
+      name: 'semantic-imported-md',
+      agentAddress: 'did:dkg:agent:test',
+      subGraphName: undefined,
+    }]);
+    expect(events).toEqual([]);
+  });
+
+  it('rejects semantic enrichment writes that would target the source import assertion', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-semantic-enrichment-separate';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent, writes } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri,
+      name: assertionName,
+      semanticQuads: [
+        { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
+      ],
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toMatch(/must be separate/);
+    expect(writes).toHaveLength(0);
+  });
+
+  it('rejects semantic enrichment quads with graph fields instead of silently dropping them', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-semantic-enrichment-graph-reject';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent, writes } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri,
+      name: 'semantic-imported-md',
+      semanticQuads: [
+        {
+          subject: 'urn:doc:imported',
+          predicate: 'http://schema.org/about',
+          object: '"Semantic topic"',
+          graph: 'urn:graph:unexpected',
+        },
+      ],
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toMatch(/graph is not supported/);
+    expect(writes).toHaveLength(0);
+  });
+
+  it('rejects reused target semantic enrichment assertion names instead of appending', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-semantic-enrichment-existing-target';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent, writes } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      targetGraphExists: true,
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri,
+      name: 'semantic-imported-md',
+      semanticQuads: [
+        { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
+      ],
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toMatch(/already exists/);
+    expect(writes).toHaveLength(0);
+  });
+
+  it('rejects assertion markdownForm that points at a different hash than _meta', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-markdown-consistency';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:keccak256:${'0'.repeat(64)}`,
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toMatch(/markdown hash does not match assertion markdownForm/);
+  });
+
+  it('rejects malformed assertion markdownForm instead of surfacing it as provenance', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-markdown-malformed';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: 'urn:dkg:file:not-a-content-hash',
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toMatch(/markdown hash does not match assertion markdownForm/);
+  });
+
+  it('rejects any mismatched assertion markdownForm when multiple values are present', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-multiple-markdown-forms';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: [
+        `urn:dkg:file:${entry.keccak256}`,
+        `urn:dkg:file:keccak256:${'1'.repeat(64)}`,
+      ],
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toMatch(/markdown hash does not match assertion markdownForm/);
+  });
+
+  it('does not use transient extraction status as the authoritative Markdown intermediate hash', async () => {
+    const originalEntry = await fileStore.put(Buffer.from('%PDF-1.4'), 'application/pdf');
+    const markdownEntry = await fileStore.put(Buffer.from('# Converted\n'), 'text/markdown');
+    const contextGraphId = 'cg-transient-md-hash';
+    const assertionName = 'imported-pdf';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: originalEntry.keccak256,
+      markdownHash: markdownEntry.keccak256,
+      markdownForm: `urn:dkg:file:${markdownEntry.keccak256}`,
+      contentType: 'application/pdf',
+    });
+    const extractionStatus = new Map<string, ExtractionStatusRecord>([
+      [assertionUri, {
+        status: 'completed',
+        assertionName,
+        assertionUri,
+        fileHash: originalEntry.keccak256,
+        fileName: 'imported.pdf',
+        detectedContentType: 'application/pdf',
+        pipelineUsed: 'application/pdf',
+        tripleCount: 3,
+        rootEntity: 'urn:doc:imported',
+        mdIntermediateHash: markdownEntry.keccak256,
+        startedAt: '2026-05-11T00:00:00.000Z',
+        completedAt: '2026-05-11T00:00:01.000Z',
+      }],
+    ]);
+    await startRoutes({ agent, extractionStatus });
+
+    const result = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toMatch(/markdown hash does not match assertion markdownForm/);
+  });
+
+  it('does not use transient extraction status as the authoritative native Markdown content type', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-transient-content-type';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      contentType: null,
+    });
+    const extractionStatus = new Map<string, ExtractionStatusRecord>([
+      [assertionUri, {
+        status: 'completed',
+        assertionName,
+        assertionUri,
+        fileHash: entry.keccak256,
+        fileName: 'imported.md',
+        detectedContentType: 'text/markdown',
+        pipelineUsed: 'text/markdown',
+        tripleCount: 3,
+        rootEntity: 'urn:doc:imported',
+        startedAt: '2026-05-11T00:00:00.000Z',
+        completedAt: '2026-05-11T00:00:01.000Z',
+      }],
+    ]);
+    await startRoutes({ agent, extractionStatus });
+
+    const result = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toMatch(/markdown hash does not match assertion markdownForm/);
+  });
+
+  it('rejects skipped imports and returns deterministic assertion quads in sorted order', async () => {
+    const entry = await fileStore.put(Buffer.from('# Skipped\n'), 'text/markdown');
+    const contextGraphId = 'cg-skipped-import';
+    const assertionName = 'skipped-import';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      extractionStatus: 'skipped',
+    });
+    const extractionStatus = new Map<string, ExtractionStatusRecord>([
+      [assertionUri, {
+        status: 'skipped',
+        assertionName,
+        assertionUri,
+        fileHash: entry.keccak256,
+        detectedContentType: 'application/octet-stream',
+        pipelineUsed: null,
+        tripleCount: 0,
+        startedAt: '2026-05-11T00:00:00.000Z',
+        completedAt: '2026-05-11T00:00:01.000Z',
+      }],
+    ]);
+    await startRoutes({ agent, extractionStatus });
+
+    const skipped = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+    expect(skipped.status).toBe(409);
+    expect(skipped.body.error).toMatch(/not a completed extraction/);
+
+    const query = await post(`/api/assertion/${encodeURIComponent(assertionName)}/query`, {
+      contextGraphId,
+    });
+    expect(query.status).toBe(200);
+    expect(query.body.quads).toEqual([
+      { subject: 'urn:a', predicate: 'urn:p', object: '"A"' },
+      { subject: 'urn:z', predicate: 'urn:p', object: 'urn:o' },
+    ]);
+  });
+});

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -140,6 +140,7 @@ describe('import artifact daemon routes', () => {
       agentAddress?: string;
       subGraphName?: string;
     }> = [];
+    const queries: string[] = [];
     const queryQuads = args.queryQuads ?? [
       { subject: 'urn:z', predicate: 'urn:p', object: 'urn:o' },
       { subject: 'urn:a', predicate: 'urn:p', object: '"A"' },
@@ -193,6 +194,7 @@ describe('import artifact daemon routes', () => {
           return Boolean(args.targetGraphExists);
         },
         async query(sparql: string) {
+          queries.push(sparql);
           if (sparql.includes('SELECT ?p ?o')) {
             return { type: 'bindings', bindings: [] };
           }
@@ -228,14 +230,14 @@ describe('import artifact daemon routes', () => {
         },
       },
     };
-    return { agent, created, writes, discards };
+    return { agent, created, writes, discards, queries };
   }
 
   it('resolves and safely reads a completed Markdown import artifact by content hash', async () => {
     const entry = await fileStore.put(Buffer.from('# Imported\n\nHello DKG.\n'), 'text/markdown');
     const contextGraphId = 'cg-import-artifact';
     const assertionName = 'imported-md';
-    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
     const markdownForm = `urn:dkg:file:${entry.keccak256}`;
     const { agent } = makeAgent({
       contextGraphId,
@@ -258,7 +260,7 @@ describe('import artifact daemon routes', () => {
       contextGraphId,
       assertionUri,
       assertionName,
-      assertionAgentAddress: 'did:dkg:agent:source',
+      assertionAgentAddress: 'did:dkg:agent:test',
       fileHash: entry.keccak256,
       markdownHash: entry.keccak256,
       markdownForm,
@@ -278,6 +280,53 @@ describe('import artifact daemon routes', () => {
       bytes: Buffer.byteLength('# Imported\n\nHello DKG.\n'),
       markdown: '# Imported\n\nHello DKG.\n',
     });
+  });
+
+  it('rejects cross-agent import artifact metadata and Markdown reads', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-import-artifact-cross-agent-read';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent, queries } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+    });
+    const extractionStatus = new Map<string, ExtractionStatusRecord>([[
+      assertionUri,
+      {
+        status: 'skipped',
+        assertionName,
+        assertionUri,
+        fileHash: entry.keccak256,
+        detectedContentType: 'application/octet-stream',
+        pipelineUsed: null,
+        tripleCount: 0,
+        startedAt: '2026-05-11T00:00:00.000Z',
+        completedAt: '2026-05-11T00:00:01.000Z',
+      },
+    ]]);
+    await startRoutes({ agent, extractionStatus });
+
+    const resolved = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+      fileHash: entry.keccak256,
+    });
+    expect(resolved.status).toBe(403);
+    expect(resolved.body.error).toMatch(/owned by the requesting agent/);
+
+    const read = await post('/api/assertion/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri,
+      maxBytes: 1024,
+    });
+    expect(read.status).toBe(403);
+    expect(read.body.error).toMatch(/owned by the requesting agent/);
+    expect(queries).toHaveLength(0);
   });
 
   it('requires full assertionUri instead of guessing the source author from assertionName', async () => {
@@ -372,7 +421,7 @@ describe('import artifact daemon routes', () => {
     const contextGraphId = 'cg-semantic-enrichment-cross-agent';
     const assertionName = 'imported-md';
     const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
-    const { agent, writes } = makeAgent({
+    const { agent, writes, queries } = makeAgent({
       contextGraphId,
       assertionName,
       assertionUri,
@@ -380,7 +429,21 @@ describe('import artifact daemon routes', () => {
       markdownHash: entry.keccak256,
       markdownForm: `urn:dkg:file:${entry.keccak256}`,
     });
-    await startRoutes({ agent });
+    const extractionStatus = new Map<string, ExtractionStatusRecord>([[
+      assertionUri,
+      {
+        status: 'skipped',
+        assertionName,
+        assertionUri,
+        fileHash: entry.keccak256,
+        detectedContentType: 'application/octet-stream',
+        pipelineUsed: null,
+        tripleCount: 0,
+        startedAt: '2026-05-11T00:00:00.000Z',
+        completedAt: '2026-05-11T00:00:01.000Z',
+      },
+    ]]);
+    await startRoutes({ agent, extractionStatus });
 
     const result = await post('/api/assertion/semantic-enrichment/write', {
       contextGraphId,
@@ -393,6 +456,7 @@ describe('import artifact daemon routes', () => {
     expect(result.status).toBe(403);
     expect(result.body.error).toMatch(/owned by the requesting agent/);
     expect(writes).toHaveLength(0);
+    expect(queries).toHaveLength(0);
   });
 
   it('stores non-IRI agent identity labels without emitting prov attribution resources', async () => {

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -85,7 +85,7 @@ describe('import artifact daemon routes', () => {
       } catch (err) {
         res.statusCode = 500;
         res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+        res.end(JSON.stringify({ error: 'Unhandled test route error' }));
       }
     });
     await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
@@ -279,6 +279,66 @@ describe('import artifact daemon routes', () => {
       contentType: 'text/markdown',
       bytes: Buffer.byteLength('# Imported\n\nHello DKG.\n'),
       markdown: '# Imported\n\nHello DKG.\n',
+    });
+  });
+
+  it('accepts legacy ownerless attachment assertion URIs by resolving them to the requesting agent assertion', async () => {
+    const entry = await fileStore.put(Buffer.from('# Legacy Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-import-artifact-legacy-uri';
+    const assertionName = 'legacy-md';
+    const legacyAssertionUri = `did:dkg:context-graph:${contextGraphId}/assertion/${assertionName}`;
+    const canonicalAssertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const markdownForm = `urn:dkg:file:${entry.keccak256}`;
+    const { agent, writes } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri: canonicalAssertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm,
+    });
+    await startRoutes({ agent });
+
+    const resolved = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri: legacyAssertionUri,
+      assertionName,
+      fileHash: entry.keccak256,
+    });
+    expect(resolved.status).toBe(200);
+    expect(resolved.body.artifact).toMatchObject({
+      contextGraphId,
+      assertionUri: canonicalAssertionUri,
+      assertionAgentAddress: 'did:dkg:agent:test',
+      assertionName,
+      markdownHash: entry.keccak256,
+    });
+
+    const read = await post('/api/assertion/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri: legacyAssertionUri,
+    });
+    expect(read.status).toBe(200);
+    expect(read.body.markdown).toBe('# Legacy Imported\n');
+
+    const enriched = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri: legacyAssertionUri,
+      semanticQuads: [
+        { subject: 'urn:doc:legacy', predicate: 'http://schema.org/about', object: 'Legacy topic' },
+      ],
+    });
+    expect(enriched.status).toBe(200);
+    expect(enriched.body).toMatchObject({
+      sourceAssertionUri: canonicalAssertionUri,
+      assertionUri: canonicalAssertionUri,
+      semanticTripleCount: 1,
+    });
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      contextGraphId,
+      name: assertionName,
+      agentAddress: 'did:dkg:agent:test',
     });
   });
 
@@ -591,7 +651,7 @@ describe('import artifact daemon routes', () => {
     });
 
     expect(result.status).toBe(500);
-    expect(result.body.error).toContain('simulated semantic write failure');
+    expect(result.body.error).toBe('Unhandled test route error');
     expect(created).toEqual([]);
     expect(writes).toHaveLength(0);
     expect(discards).toEqual([]);

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -112,6 +112,8 @@ describe('import artifact daemon routes', () => {
     markdownForm: string | string[];
     contentType?: string | null;
     extractionStatus?: string;
+    omitExtractionStatus?: boolean;
+    structuralTripleCount?: string;
     mdIntermediateHash?: string;
     publisherCreateError?: Error;
     publisherWriteError?: Error;
@@ -207,10 +209,10 @@ describe('import artifact daemon routes', () => {
                 fileHash: args.fileHash,
                 ...(args.contentType !== null ? { contentType: args.contentType ?? 'text/markdown' } : {}),
                 rootEntity: 'urn:doc:imported',
-                structuralTripleCount: '3',
+                structuralTripleCount: args.structuralTripleCount ?? '3',
                 semanticTripleCount: '0',
                 extractionMethod: 'text/markdown',
-                extractionStatus: args.extractionStatus ?? 'completed',
+                ...(args.omitExtractionStatus ? {} : { extractionStatus: args.extractionStatus ?? 'completed' }),
                 ...(args.mdIntermediateHash ? { mdIntermediateHash: args.mdIntermediateHash } : {}),
                 sourceFileName: 'imported.md',
               }],
@@ -341,6 +343,65 @@ describe('import artifact daemon routes', () => {
       agentAddress: 'did:dkg:agent:test',
     });
   });
+
+  it('accepts legacy completed import metadata that predates durable extractionStatus', async () => {
+    const entry = await fileStore.put(Buffer.from('# Legacy Completed\n'), 'text/markdown');
+    const contextGraphId = 'cg-import-artifact-legacy-status';
+    const assertionName = 'legacy-completed-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      omitExtractionStatus: true,
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.artifact).toMatchObject({
+      assertionUri,
+      extractionStatus: 'completed',
+      structuralTripleCount: 3,
+      canReadMarkdown: true,
+    });
+  });
+
+  for (const structuralTripleCount of ['0', '1.5', '1junk']) {
+    it(`still rejects missing durable extractionStatus when structuralTripleCount is ${structuralTripleCount}`, async () => {
+      const entry = await fileStore.put(Buffer.from('# Ambiguous\n'), 'text/markdown');
+      const suffix = structuralTripleCount.replace(/[^a-z0-9]+/gi, '-');
+      const contextGraphId = `cg-import-artifact-missing-status-${suffix}`;
+      const assertionName = `ambiguous-md-${suffix}`;
+      const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+      const { agent } = makeAgent({
+        contextGraphId,
+        assertionName,
+        assertionUri,
+        fileHash: entry.keccak256,
+        markdownHash: entry.keccak256,
+        markdownForm: `urn:dkg:file:${entry.keccak256}`,
+        omitExtractionStatus: true,
+        structuralTripleCount,
+      });
+      await startRoutes({ agent });
+
+      const result = await post('/api/assertion/import-artifact/resolve', {
+        contextGraphId,
+        assertionUri,
+      });
+
+      expect(result.status).toBe(409);
+      expect(result.body.error).toMatch(/missing completed extraction status/);
+    });
+  }
 
   it('rejects cross-agent import artifact metadata and Markdown reads', async () => {
     const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -208,7 +208,7 @@ describe('import artifact daemon routes', () => {
                 structuralTripleCount: '3',
                 semanticTripleCount: '0',
                 extractionMethod: 'text/markdown',
-                ...(args.extractionStatus ? { extractionStatus: args.extractionStatus } : {}),
+                extractionStatus: args.extractionStatus ?? 'completed',
                 ...(args.mdIntermediateHash ? { mdIntermediateHash: args.mdIntermediateHash } : {}),
                 sourceFileName: 'imported.md',
               }],
@@ -304,7 +304,7 @@ describe('import artifact daemon routes', () => {
     expect(result.body.error).toMatch(/"assertionUri" is required/);
   });
 
-  it('writes semantic enrichment to a separate WM assertion with explicit provenance only', async () => {
+  it('appends semantic enrichment to the imported assertion with explicit provenance', async () => {
     const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
     const contextGraphId = 'cg-semantic-enrichment';
     const assertionName = 'imported-md';
@@ -324,7 +324,6 @@ describe('import artifact daemon routes', () => {
     const result = await post('/api/assertion/semantic-enrichment/write', {
       contextGraphId,
       assertionUri,
-      name: 'semantic-imported-md',
       semanticQuads: [
         { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
       ],
@@ -335,7 +334,8 @@ describe('import artifact daemon routes', () => {
 
     expect(result.status).toBe(200);
     expect(result.body).toMatchObject({
-      assertionName: 'semantic-imported-md',
+      assertionUri,
+      assertionName,
       sourceAssertionUri: assertionUri,
       sourceFileHash: entry.keccak256,
       markdownHash: entry.keccak256,
@@ -344,14 +344,9 @@ describe('import artifact daemon routes', () => {
       promoted: false,
       published: false,
     });
-    expect(created).toEqual([{
-      contextGraphId,
-      name: 'semantic-imported-md',
-      agentAddress: 'did:dkg:agent:test',
-      subGraphName: undefined,
-    }]);
+    expect(created).toEqual([]);
     expect(writes).toHaveLength(1);
-    expect(writes[0]!.name).toBe('semantic-imported-md');
+    expect(writes[0]!.name).toBe(assertionName);
     expect(writes[0]!.agentAddress).toBe('did:dkg:agent:test');
     expect(writes[0]!.quads).toEqual(expect.arrayContaining([
       { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
@@ -365,9 +360,39 @@ describe('import artifact daemon routes', () => {
       { subject: 'urn:doc:imported', predicate: `${PROV}wasDerivedFrom`, object: assertionUri },
     ]));
     expect(events).toEqual(expect.arrayContaining([
-      expect.objectContaining({ operation: 'assertion_created', layers: ['wm'] }),
       expect.objectContaining({ operation: 'semantic_enrichment_written', layers: ['wm'] }),
     ]));
+    expect(events).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ operation: 'assertion_created', layers: ['wm'] }),
+    ]));
+  });
+
+  it('rejects semantic enrichment of imported assertions owned by another agent', async () => {
+    const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-semantic-enrichment-cross-agent';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent, writes } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+    });
+    await startRoutes({ agent });
+
+    const result = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri,
+      semanticQuads: [
+        { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
+      ],
+    });
+
+    expect(result.status).toBe(403);
+    expect(result.body.error).toMatch(/owned by the requesting agent/);
+    expect(writes).toHaveLength(0);
   });
 
   it('stores non-IRI agent identity labels without emitting prov attribution resources', async () => {
@@ -388,7 +413,6 @@ describe('import artifact daemon routes', () => {
     const result = await post('/api/assertion/semantic-enrichment/write', {
       contextGraphId,
       assertionUri,
-      name: 'semantic-imported-md',
       semanticQuads: [
         { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: 'Semantic topic' },
       ],
@@ -421,7 +445,6 @@ describe('import artifact daemon routes', () => {
     const result = await post('/api/assertion/semantic-enrichment/write', {
       contextGraphId,
       assertionUri,
-      name: 'semantic-imported-md',
       semanticQuads: [
         {
           subject: 'urn:doc:imported',
@@ -461,7 +484,6 @@ describe('import artifact daemon routes', () => {
     const result = await post('/api/assertion/semantic-enrichment/write', {
       contextGraphId,
       assertionUri,
-      name: 'semantic-imported-md',
       semanticQuads: [
         { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: 'Fallback topic' },
       ],
@@ -479,7 +501,7 @@ describe('import artifact daemon routes', () => {
     ]));
   });
 
-  it('rolls back a newly created semantic enrichment assertion when writing quads fails', async () => {
+  it('does not create or discard assertions when same-assertion semantic append fails', async () => {
     const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
     const contextGraphId = 'cg-semantic-enrichment-write-failure';
     const assertionName = 'imported-md';
@@ -499,7 +521,6 @@ describe('import artifact daemon routes', () => {
     const result = await post('/api/assertion/semantic-enrichment/write', {
       contextGraphId,
       assertionUri,
-      name: 'semantic-imported-md',
       semanticQuads: [
         { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
       ],
@@ -507,23 +528,13 @@ describe('import artifact daemon routes', () => {
 
     expect(result.status).toBe(500);
     expect(result.body.error).toContain('simulated semantic write failure');
-    expect(created).toEqual([{
-      contextGraphId,
-      name: 'semantic-imported-md',
-      agentAddress: 'did:dkg:agent:test',
-      subGraphName: undefined,
-    }]);
+    expect(created).toEqual([]);
     expect(writes).toHaveLength(0);
-    expect(discards).toEqual([{
-      contextGraphId,
-      name: 'semantic-imported-md',
-      agentAddress: 'did:dkg:agent:test',
-      subGraphName: undefined,
-    }]);
+    expect(discards).toEqual([]);
     expect(events).toEqual([]);
   });
 
-  it('rejects semantic enrichment writes that would target the source import assertion', async () => {
+  it('rejects target assertion names because enrichment appends to the source import assertion', async () => {
     const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
     const contextGraphId = 'cg-semantic-enrichment-separate';
     const assertionName = 'imported-md';
@@ -547,8 +558,8 @@ describe('import artifact daemon routes', () => {
       ],
     });
 
-    expect(result.status).toBe(409);
-    expect(result.body.error).toMatch(/must be separate/);
+    expect(result.status).toBe(400);
+    expect(result.body.error).toMatch(/target assertion names are not supported/);
     expect(writes).toHaveLength(0);
   });
 
@@ -570,7 +581,6 @@ describe('import artifact daemon routes', () => {
     const result = await post('/api/assertion/semantic-enrichment/write', {
       contextGraphId,
       assertionUri,
-      name: 'semantic-imported-md',
       semanticQuads: [
         {
           subject: 'urn:doc:imported',
@@ -586,7 +596,7 @@ describe('import artifact daemon routes', () => {
     expect(writes).toHaveLength(0);
   });
 
-  it('rejects reused target semantic enrichment assertion names instead of appending', async () => {
+  it('rejects legacy semanticAssertionName target fields', async () => {
     const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
     const contextGraphId = 'cg-semantic-enrichment-existing-target';
     const assertionName = 'imported-md';
@@ -598,21 +608,20 @@ describe('import artifact daemon routes', () => {
       fileHash: entry.keccak256,
       markdownHash: entry.keccak256,
       markdownForm: `urn:dkg:file:${entry.keccak256}`,
-      targetGraphExists: true,
     });
     await startRoutes({ agent });
 
     const result = await post('/api/assertion/semantic-enrichment/write', {
       contextGraphId,
       assertionUri,
-      name: 'semantic-imported-md',
+      semanticAssertionName: 'semantic-imported-md',
       semanticQuads: [
         { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
       ],
     });
 
-    expect(result.status).toBe(409);
-    expect(result.body.error).toMatch(/already exists/);
+    expect(result.status).toBe(400);
+    expect(result.body.error).toMatch(/target assertion names are not supported/);
     expect(writes).toHaveLength(0);
   });
 

--- a/packages/cli/test/import-file-integration.test.ts
+++ b/packages/cli/test/import-file-integration.test.ts
@@ -965,6 +965,7 @@ async function runImportFileOrchestration(params: {
     { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: metaGraph },
     { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceFileHash', object: JSON.stringify(fileStoreEntry.keccak256), graph: metaGraph },
     { subject: assertionUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify('structural'), graph: metaGraph },
+    { subject: assertionUri, predicate: 'http://dkg.io/ontology/extractionStatus', object: JSON.stringify('completed'), graph: metaGraph },
     { subject: assertionUri, predicate: 'http://dkg.io/ontology/structuralTripleCount', object: `"${triples.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
     { subject: assertionUri, predicate: 'http://dkg.io/ontology/semanticTripleCount', object: `"0"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
   ];
@@ -2522,7 +2523,7 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
     expect(written.some(q => q.subject.startsWith('urn:dkg:extraction:'))).toBe(true);
   });
 
-  it('text/markdown import writes rows 14-19 into the CG root _meta graph and omits row 20', async () => {
+  it('text/markdown import writes completed status into the CG root _meta graph and omits mdIntermediateHash', async () => {
     const body = buildMultipart([
       { kind: 'text', name: 'contextGraphId', value: 'cg' },
       { kind: 'file', name: 'file', filename: 'note.md', contentType: 'text/markdown', content: Buffer.from('# Note\n\nBody.\n', 'utf-8') },
@@ -2537,9 +2538,9 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
     const metaForAssertion = agent.insertedQuads.filter(q =>
       q.graph === metaGraph && q.subject === result.assertionUri,
     );
-    // Rows 14-19 plus Round 9 Bug 27 `dkg:sourceFileName` (7 total) —
-    // no row 20 because Phase 1 did not run for a direct markdown upload.
-    expect(metaForAssertion).toHaveLength(7);
+    // Rows 14-20 plus Round 9 Bug 27 `dkg:sourceFileName` (8 total) -
+    // no mdIntermediateHash because Phase 1 did not run for a direct markdown upload.
+    expect(metaForAssertion).toHaveLength(8);
 
     const byPredicate = (predLocal: string) =>
       metaForAssertion.find(q => q.predicate === `${DKG}${predLocal}`);
@@ -2555,11 +2556,11 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
     expect(byPredicate('sourceFileHash')?.object).toBe(`"${result.fileHash}"`);
     // Row 17
     expect(byPredicate('extractionMethod')?.object).toBe('"structural"');
-    // Row 18 — structural triple count matches the Phase 2 result
+    expect(byPredicate('extractionStatus')?.object).toBe('"completed"');
+    // Row 19 - structural triple count matches the Phase 2 result
     expect(byPredicate('structuralTripleCount')?.object).toBe(`"${result.extraction.tripleCount}"^^<${XSD_INTEGER}>`);
-    // Row 19 — V10.0 has no semantic extraction yet
+    // Row 20 - V10.0 has no semantic extraction yet
     expect(byPredicate('semanticTripleCount')?.object).toBe(`"0"^^<${XSD_INTEGER}>`);
-    // Row 20 — absent because Phase 1 did not run for a direct markdown upload
     expect(byPredicate('mdIntermediateHash')).toBeUndefined();
     // Round 9 Bug 27 — `dkg:sourceFileName` present on the UAL, carrying
     // the original upload filename literal. This is the new home for
@@ -2567,7 +2568,7 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
     expect(byPredicate('sourceFileName')?.object).toBe('"note.md"');
   });
 
-  it('application/pdf import writes row 15 in _meta and row 20 for mdIntermediateHash, with rows 2 and 15 both = application/pdf', async () => {
+  it('application/pdf import writes completed status and mdIntermediateHash in _meta, with rows 2 and 15 both = application/pdf', async () => {
     const convertedMarkdown = '---\nid: paper\n---\n\n# Paper\n\nBody.\n';
     const stubConverter: ExtractionPipeline = {
       contentTypes: ['application/pdf'],
@@ -2594,15 +2595,16 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
     const metaForAssertion = agent.insertedQuads.filter(q =>
       q.graph === metaGraph && q.subject === result.assertionUri,
     );
-    // Rows 14-20 + Round 9 Bug 27 `dkg:sourceFileName` = 8 rows total.
-    expect(metaForAssertion).toHaveLength(8);
+    // Rows 14-21 + Round 9 Bug 27 `dkg:sourceFileName` = 9 rows total.
+    expect(metaForAssertion).toHaveLength(9);
 
     const byPredicate = (predLocal: string) =>
       metaForAssertion.find(q => q.predicate === `${DKG}${predLocal}`);
 
     // Row 15 — original content type is application/pdf in _meta
     expect(byPredicate('sourceContentType')?.object).toBe('"application/pdf"');
-    // Row 20 — mdIntermediateHash now present, matching the wire value
+    expect(byPredicate('extractionStatus')?.object).toBe('"completed"');
+    // mdIntermediateHash now present, matching the wire value
     expect(byPredicate('mdIntermediateHash')?.object).toBe(`"${result.extraction.mdIntermediateHash}"`);
     // Round 9 Bug 27 — sourceFileName present on the UAL for the PDF upload.
     expect(byPredicate('sourceFileName')?.object).toBe('"paper.pdf"');
@@ -4534,10 +4536,10 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
     expect(ctB).toHaveLength(1);
   });
 
-  it('Round 9 Bug 27: no-filename upload skips `dkg:sourceFileName` entirely (matches row 20 optional pattern)', async () => {
+  it('Round 9 Bug 27: no-filename upload skips `dkg:sourceFileName` entirely (matches optional metadata pattern)', async () => {
     // Symmetric negative guard — when the multipart part carries no
     // filename (or a whitespace-only filename), the daemon skips
-    // the `_meta` row entirely, same way row 20 (`mdIntermediateHash`)
+    // the `_meta` row entirely, same way `mdIntermediateHash`
     // is absent for markdown-direct imports.
     const body = buildMultipart([
       { kind: 'text', name: 'contextGraphId', value: 'cg' },

--- a/packages/cli/test/skill-endpoint.test.ts
+++ b/packages/cli/test/skill-endpoint.test.ts
@@ -113,6 +113,17 @@ describe('SKILL.md file', () => {
     expect(skillContent).toContain('/api/assertion/{name}/extraction-status');
   });
 
+  it('documents imported attachment semantic enrichment as same-assertion append', () => {
+    expect(skillContent).toContain('dkg_import_artifact_read_markdown');
+    expect(skillContent).toContain('dkg_import_artifact_resolve');
+    expect(skillContent).toContain('dkg_semantic_enrichment_write');
+    expect(skillContent).toContain('appends model-derived semantic triples');
+    expect(skillContent).toContain('same imported assertion graph');
+    expect(skillContent).toContain('Optional metadata re-check');
+    expect(skillContent).toContain('rejects target assertion names');
+    expect(skillContent).not.toContain('separate Working Memory assertion');
+  });
+
   it('documents error status codes', () => {
     expect(skillContent).toContain('| 400 |');
     expect(skillContent).toContain('| 401 |');

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -362,6 +362,72 @@ export class DkgClient {
     );
   }
 
+  /** Resolve deterministic metadata for a completed imported assertion. */
+  async resolveImportArtifact(args: {
+    contextGraphId: string;
+    assertionUri: string;
+    assertionName?: string;
+    fileHash?: string;
+    subGraphName?: string;
+  }): Promise<Record<string, unknown>> {
+    const body: Record<string, unknown> = {
+      contextGraphId: args.contextGraphId,
+    };
+    body.assertionUri = args.assertionUri;
+    if (args.assertionName) body.assertionName = args.assertionName;
+    if (args.fileHash) body.fileHash = args.fileHash;
+    if (args.subGraphName) body.subGraphName = args.subGraphName;
+    return this.request('POST', '/api/assertion/import-artifact/resolve', body);
+  }
+
+  /** Read Markdown for a completed import via content-addressed daemon storage. */
+  async readImportArtifactMarkdown(args: {
+    contextGraphId: string;
+    assertionUri: string;
+    assertionName?: string;
+    fileHash?: string;
+    subGraphName?: string;
+    maxBytes?: number;
+  }): Promise<Record<string, unknown>> {
+    const body: Record<string, unknown> = {
+      contextGraphId: args.contextGraphId,
+    };
+    body.assertionUri = args.assertionUri;
+    if (args.assertionName) body.assertionName = args.assertionName;
+    if (args.fileHash) body.fileHash = args.fileHash;
+    if (args.subGraphName) body.subGraphName = args.subGraphName;
+    if (args.maxBytes != null) body.maxBytes = args.maxBytes;
+    return this.request('POST', '/api/assertion/import-artifact/read-markdown', body);
+  }
+
+  /** Write model-derived semantic triples to a separate WM assertion. */
+  async writeSemanticEnrichment(args: {
+    contextGraphId: string;
+    assertionUri: string;
+    assertionName?: string;
+    fileHash?: string;
+    subGraphName?: string;
+    name?: string;
+    semanticQuads: Array<{ subject: string; predicate: string; object: string }>;
+    generationMethod?: string;
+    agentIdentity?: string;
+    generatedAt?: string;
+  }): Promise<Record<string, unknown>> {
+    const body: Record<string, unknown> = {
+      contextGraphId: args.contextGraphId,
+      semanticQuads: args.semanticQuads,
+    };
+    body.assertionUri = args.assertionUri;
+    if (args.assertionName) body.assertionName = args.assertionName;
+    if (args.fileHash) body.fileHash = args.fileHash;
+    if (args.subGraphName) body.subGraphName = args.subGraphName;
+    if (args.name) body.name = args.name;
+    if (args.generationMethod) body.generationMethod = args.generationMethod;
+    if (args.agentIdentity) body.agentIdentity = args.agentIdentity;
+    if (args.generatedAt) body.generatedAt = args.generatedAt;
+    return this.request('POST', '/api/assertion/semantic-enrichment/write', body);
+  }
+
   /**
    * Lifecycle descriptor for an assertion: author, extraction status,
    * promotion state, timestamps. Returns 404 (`DkgHttpError`) when no

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -400,14 +400,13 @@ export class DkgClient {
     return this.request('POST', '/api/assertion/import-artifact/read-markdown', body);
   }
 
-  /** Write model-derived semantic triples to a separate WM assertion. */
+  /** Append model-derived semantic triples to the completed imported assertion. */
   async writeSemanticEnrichment(args: {
     contextGraphId: string;
     assertionUri: string;
     assertionName?: string;
     fileHash?: string;
     subGraphName?: string;
-    name?: string;
     semanticQuads: Array<{ subject: string; predicate: string; object: string }>;
     generationMethod?: string;
     agentIdentity?: string;
@@ -421,7 +420,6 @@ export class DkgClient {
     if (args.assertionName) body.assertionName = args.assertionName;
     if (args.fileHash) body.fileHash = args.fileHash;
     if (args.subGraphName) body.subGraphName = args.subGraphName;
-    if (args.name) body.name = args.name;
     if (args.generationMethod) body.generationMethod = args.generationMethod;
     if (args.agentIdentity) body.agentIdentity = args.agentIdentity;
     if (args.generatedAt) body.generatedAt = args.generatedAt;

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -306,6 +306,129 @@ export function registerAssertionTools(
   // the daemon's extraction pipeline turns markdown / PDF / DOCX /
   // etc. into RDF triples and writes them into the assertion's graph.
   server.registerTool(
+    'dkg_import_artifact_resolve',
+    {
+      title: 'Resolve Imported Artifact',
+      description:
+        'Resolve a completed imported attachment/assertion into deterministic metadata: source file hash, Markdown hash/form, extraction method, root entity, and structural counts. Skipped imports are rejected.',
+      inputSchema: {
+        projectId: z.string().optional().describe('contextGraphId; defaults to .dkg/config.yaml'),
+        assertionUri: z.string().min(1).describe('Completed imported assertion URI from the attachment ref'),
+        fileHash: z.string().optional().describe('Optional source file hash to verify'),
+        subGraphName: z.string().optional(),
+      },
+    },
+    async ({ projectId, assertionUri, fileHash, subGraphName }): Promise<ToolResult> => {
+      const pid = resolveProject(projectId, config);
+      if (!pid) return projectErr();
+      try {
+        const result = await client.resolveImportArtifact({
+          contextGraphId: pid,
+          assertionUri,
+          fileHash,
+          subGraphName,
+        });
+        return ok(`Imported artifact:\n\n\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``);
+      } catch (e) {
+        return errResult(`Failed to resolve imported artifact: ${formatError(e)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'dkg_import_artifact_read_markdown',
+    {
+      title: 'Read Imported Artifact Markdown',
+      description:
+        'Read Markdown for a completed imported attachment via the daemon content-addressed file store. This never reads arbitrary filesystem paths.',
+      inputSchema: {
+        projectId: z.string().optional().describe('contextGraphId; defaults to .dkg/config.yaml'),
+        assertionUri: z.string().min(1).describe('Completed imported assertion URI from the attachment ref'),
+        fileHash: z.string().optional().describe('Optional source file hash to verify'),
+        subGraphName: z.string().optional(),
+        maxBytes: z.number().int().positive().optional().describe('Optional byte cap; daemon maximum is 5 MiB'),
+      },
+    },
+    async ({ projectId, assertionUri, fileHash, subGraphName, maxBytes }): Promise<ToolResult> => {
+      const pid = resolveProject(projectId, config);
+      if (!pid) return projectErr();
+      try {
+        const result = await client.readImportArtifactMarkdown({
+          contextGraphId: pid,
+          assertionUri,
+          fileHash,
+          subGraphName,
+          maxBytes,
+        });
+        return ok(`Imported artifact Markdown:\n\n\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``);
+      } catch (e) {
+        return errResult(`Failed to read imported artifact Markdown: ${formatError(e)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'dkg_semantic_enrichment_write',
+    {
+      title: 'Write Semantic Enrichment',
+      description:
+        'Write model-derived semantic triples into a separate Working Memory assertion with provenance pointing to a completed import artifact. Does not modify deterministic import assertions, promote, or publish.',
+      inputSchema: {
+        projectId: z.string().optional().describe('contextGraphId; defaults to .dkg/config.yaml'),
+        assertionUri: z.string().min(1).describe('Source imported assertion URI from the attachment ref'),
+        fileHash: z.string().optional().describe('Optional source file hash to verify'),
+        name: z.string().optional().describe('Optional target semantic enrichment assertion name'),
+        semanticQuads: z
+          .array(
+            z
+              .object({
+                subject: z.string(),
+                predicate: z.string(),
+                object: z.string(),
+              })
+              .strict(),
+          )
+          .min(1)
+          .describe('Model-derived semantic triples; plain-text objects become RDF literals, provenance is added by the daemon, and all triples are written to the target assertion graph'),
+        generationMethod: z.string().optional(),
+        agentIdentity: z.string().optional().describe('Agent identity URI or label; only URIs are emitted as prov:wasAttributedTo resources'),
+        generatedAt: z.string().optional(),
+        subGraphName: z.string().optional(),
+      },
+    },
+    async ({
+      projectId,
+      assertionUri,
+      fileHash,
+      name,
+      semanticQuads,
+      generationMethod,
+      agentIdentity,
+      generatedAt,
+      subGraphName,
+    }): Promise<ToolResult> => {
+      const pid = resolveProject(projectId, config);
+      if (!pid) return projectErr();
+      try {
+        const result = await client.writeSemanticEnrichment({
+          contextGraphId: pid,
+          assertionUri,
+          fileHash,
+          subGraphName,
+          name,
+          semanticQuads,
+          generationMethod,
+          agentIdentity,
+          generatedAt,
+        });
+        return ok(`Semantic enrichment written:\n\n\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``);
+      } catch (e) {
+        return errResult(`Failed to write semantic enrichment: ${formatError(e)}`);
+      }
+    },
+  );
+
+  server.registerTool(
     'dkg_assertion_import_file',
     {
       title: 'Import File into Assertion',

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -310,7 +310,7 @@ export function registerAssertionTools(
     {
       title: 'Resolve Imported Artifact',
       description:
-        'Resolve a completed imported attachment/assertion into deterministic metadata: source file hash, Markdown hash/form, extraction method, root entity, and structural counts. Skipped imports are rejected.',
+        'Optional validation/debug helper: resolve a completed imported attachment/assertion into deterministic metadata such as source file hash, Markdown hash/form, extraction method, root entity, and structural counts. Skipped imports are rejected.',
       inputSchema: {
         projectId: z.string().optional().describe('contextGraphId; defaults to .dkg/config.yaml'),
         assertionUri: z.string().min(1).describe('Completed imported assertion URI from the attachment ref'),
@@ -372,12 +372,11 @@ export function registerAssertionTools(
     {
       title: 'Write Semantic Enrichment',
       description:
-        'Write model-derived semantic triples into a separate Working Memory assertion with provenance pointing to a completed import artifact. Does not modify deterministic import assertions, promote, or publish.',
+        'Append model-derived semantic triples to a completed imported assertion with daemon-stamped provenance. Does not promote, finalize, or publish.',
       inputSchema: {
         projectId: z.string().optional().describe('contextGraphId; defaults to .dkg/config.yaml'),
         assertionUri: z.string().min(1).describe('Source imported assertion URI from the attachment ref'),
         fileHash: z.string().optional().describe('Optional source file hash to verify'),
-        name: z.string().optional().describe('Optional target semantic enrichment assertion name'),
         semanticQuads: z
           .array(
             z
@@ -389,7 +388,7 @@ export function registerAssertionTools(
               .strict(),
           )
           .min(1)
-          .describe('Model-derived semantic triples; plain-text objects become RDF literals, provenance is added by the daemon, and all triples are written to the target assertion graph'),
+          .describe('Model-derived semantic triples; plain-text objects become RDF literals, provenance is added by the daemon, and all triples are appended to the source imported assertion graph'),
         generationMethod: z.string().optional(),
         agentIdentity: z.string().optional().describe('Agent identity URI or label; only URIs are emitted as prov:wasAttributedTo resources'),
         generatedAt: z.string().optional(),
@@ -400,7 +399,6 @@ export function registerAssertionTools(
       projectId,
       assertionUri,
       fileHash,
-      name,
       semanticQuads,
       generationMethod,
       agentIdentity,
@@ -415,7 +413,6 @@ export function registerAssertionTools(
           assertionUri,
           fileHash,
           subGraphName,
-          name,
           semanticQuads,
           generationMethod,
           agentIdentity,

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -56,8 +56,18 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
       ],
     });
     expect(enrichment.isError).toBeFalsy();
+    expect(enrichment.content[0].text).toContain(`"assertionUri": "${assertionUri}"`);
+    expect(enrichment.content[0].text).toContain('"sourceAssertionUri": "did:dkg:context-graph:test-cg/assertion/peer-test/imported-doc"');
     expect(enrichment.content[0].text).toContain('"promoted": false');
     expect(enrichment.content[0].text).toContain('"published": false');
+  });
+
+  it('does not expose a target assertion name on the semantic enrichment schema', () => {
+    const tool = server.tools.get('dkg_semantic_enrichment_write');
+    expect(tool).toBeTruthy();
+    expect(tool!.config.description).toMatch(/Append model-derived semantic triples/);
+    expect(tool!.config.description).not.toMatch(/separate Working Memory assertion/);
+    expect(tool!.config.inputSchema).not.toHaveProperty('name');
   });
 
   it('rejects semantic enrichment quads that try to set a graph at the MCP layer', async () => {

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -15,19 +15,67 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     registerAssertionTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
   });
 
-  it('registers all seven assertion-family tools', () => {
+  it('registers all ten assertion-family tools', () => {
     const expected = [
       'dkg_assertion_create',
       'dkg_assertion_write',
       'dkg_assertion_promote',
       'dkg_assertion_discard',
       'dkg_assertion_query',
+      'dkg_import_artifact_resolve',
+      'dkg_import_artifact_read_markdown',
+      'dkg_semantic_enrichment_write',
       'dkg_assertion_import_file',
       'dkg_assertion_history',
     ];
     for (const name of expected) {
       expect(server.tools.has(name)).toBe(true);
     }
+  });
+
+  it('exposes imported attachment resolve/read/enrichment helpers without promoting', async () => {
+    const assertionUri = 'did:dkg:context-graph:test-cg/assertion/peer-test/imported-doc';
+
+    const resolved = await server.call('dkg_import_artifact_resolve', {
+      assertionUri,
+    });
+    expect(resolved.isError).toBeFalsy();
+    expect(resolved.content[0].text).toContain('"canReadMarkdown": true');
+
+    const markdown = await server.call('dkg_import_artifact_read_markdown', {
+      assertionUri,
+      maxBytes: 1024,
+    });
+    expect(markdown.isError).toBeFalsy();
+    expect(markdown.content[0].text).toContain('# Imported');
+
+    const enrichment = await server.call('dkg_semantic_enrichment_write', {
+      assertionUri,
+      semanticQuads: [
+        { subject: 'urn:dkg:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
+      ],
+    });
+    expect(enrichment.isError).toBeFalsy();
+    expect(enrichment.content[0].text).toContain('"promoted": false');
+    expect(enrichment.content[0].text).toContain('"published": false');
+  });
+
+  it('rejects semantic enrichment quads that try to set a graph at the MCP layer', async () => {
+    const assertionUri = 'did:dkg:context-graph:test-cg/assertion/peer-test/imported-doc';
+
+    await expect(
+      server.call('dkg_semantic_enrichment_write', {
+        assertionUri,
+        semanticQuads: [
+          {
+            subject: 'urn:dkg:doc:imported',
+            predicate: 'http://schema.org/about',
+            object: '"Semantic topic"',
+            graph: 'urn:dkg:graph:forged',
+          },
+        ],
+      }),
+    ).rejects.toThrow();
   });
 
   it('round-trips create → write → promote → query, preserving @en language tags on literals', async () => {

--- a/packages/mcp-dkg/test/drop-sweep.test.ts
+++ b/packages/mcp-dkg/test/drop-sweep.test.ts
@@ -7,7 +7,7 @@
  *    NOT reappear in `tools/list` output. The bug-class-most-likely is a
  *    well-meaning re-registration during a future cycle ("oh that look
  *    useful, let me revive it") slipping past review because the surface
- *    was 21 before the change and 22 after. This test catches that at the
+ *    was 24 before the change and 25 after. This test catches that at the
  *    suite level, not at the surface-probe level (which is harder to
  *    enforce in CI without a daemon).
  *
@@ -82,8 +82,8 @@ describe('drop-sweep — none of the 10 W2-dropped tools reappear in tools/list'
     expect(server.tools.has(name)).toBe(false);
   });
 
-  it('registered surface contains exactly 21 tools (post-PR locked count)', () => {
-    expect(server.tools.size).toBe(21);
+  it('registered surface contains exactly 24 tools (post-PR locked count)', () => {
+    expect(server.tools.size).toBe(24);
   });
 });
 

--- a/packages/mcp-dkg/test/harness.ts
+++ b/packages/mcp-dkg/test/harness.ts
@@ -207,6 +207,60 @@ export class FakeClient {
     return { quads: cell.quads, count: cell.quads.length };
   }
 
+  async resolveImportArtifact(args: {
+    contextGraphId: string;
+    assertionUri: string;
+    fileHash?: string;
+  }) {
+    if (this.overrides.resolveImportArtifact) return this.overrides.resolveImportArtifact.call(this, args);
+    return {
+      artifact: {
+        contextGraphId: args.contextGraphId,
+        assertionUri: args.assertionUri,
+        assertionName: args.assertionUri.split('/').pop(),
+        fileHash: args.fileHash ?? `sha256:${'a'.repeat(64)}`,
+        markdownHash: `sha256:${'b'.repeat(64)}`,
+        markdownForm: `urn:dkg:file:sha256:${'b'.repeat(64)}`,
+        extractionStatus: 'completed',
+        canReadMarkdown: true,
+      },
+    };
+  }
+
+  async readImportArtifactMarkdown(args: {
+    contextGraphId: string;
+    assertionUri: string;
+    fileHash?: string;
+    maxBytes?: number;
+  }) {
+    if (this.overrides.readImportArtifactMarkdown) return this.overrides.readImportArtifactMarkdown.call(this, args);
+    const artifact = await this.resolveImportArtifact(args);
+    return {
+      ...artifact,
+      markdownHash: `sha256:${'b'.repeat(64)}`,
+      contentType: 'text/markdown',
+      bytes: 18,
+      markdown: '# Imported\n\nBody.',
+    };
+  }
+
+  async writeSemanticEnrichment(args: {
+    contextGraphId: string;
+    assertionUri: string;
+    name?: string;
+    semanticQuads: Array<{ subject: string; predicate: string; object: string }>;
+  }) {
+    if (this.overrides.writeSemanticEnrichment) return this.overrides.writeSemanticEnrichment.call(this, args);
+    return {
+      assertionName: args.name ?? 'semantic-enrichment-imported',
+      sourceAssertionUri: args.assertionUri,
+      semanticTripleCount: args.semanticQuads.length,
+      provenanceTripleCount: 8,
+      promoted: false,
+      published: false,
+    };
+  }
+
   async getAssertionHistory(args: { contextGraphId: string; assertionName: string }) {
     if (this.overrides.getAssertionHistory) return this.overrides.getAssertionHistory.call(this, args);
     return {

--- a/packages/mcp-dkg/test/harness.ts
+++ b/packages/mcp-dkg/test/harness.ts
@@ -247,12 +247,12 @@ export class FakeClient {
   async writeSemanticEnrichment(args: {
     contextGraphId: string;
     assertionUri: string;
-    name?: string;
     semanticQuads: Array<{ subject: string; predicate: string; object: string }>;
   }) {
     if (this.overrides.writeSemanticEnrichment) return this.overrides.writeSemanticEnrichment.call(this, args);
     return {
-      assertionName: args.name ?? 'semantic-enrichment-imported',
+      assertionUri: args.assertionUri,
+      assertionName: 'imported-doc',
       sourceAssertionUri: args.assertionUri,
       semanticTripleCount: args.semanticQuads.length,
       provenanceTripleCount: 8,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -815,6 +815,9 @@ export interface LocalAgentChatAttachmentRef {
   extractionStatus?: 'completed';
   tripleCount?: number;
   rootEntity?: string;
+  mdIntermediateHash?: string;
+  markdownHash?: string;
+  markdownForm?: string;
 }
 
 export interface LocalAgentChatAttachmentImportResult {

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -136,6 +136,9 @@ function normalizeAttachmentFileName(file: File): string {
 
 function draftToAttachmentRef(draft: LocalAgentAttachmentDraft): LocalAgentChatAttachmentRef | null {
   if (draft.status !== 'completed' || !draft.result) return null;
+  const mdIntermediateHash = draft.result.extraction.mdIntermediateHash;
+  const markdownHash = mdIntermediateHash
+    ?? (draft.result.detectedContentType === 'text/markdown' ? draft.result.fileHash : undefined);
   return {
     id: draft.id,
     fileName: normalizeAttachmentFileName(draft.file),
@@ -147,6 +150,8 @@ function draftToAttachmentRef(draft: LocalAgentAttachmentDraft): LocalAgentChatA
     rootEntity: draft.result.rootEntity,
     extractionStatus: 'completed',
     tripleCount: draft.result.extraction.tripleCount ?? draft.result.extraction.triplesWritten,
+    ...(mdIntermediateHash ? { mdIntermediateHash } : {}),
+    ...(markdownHash ? { markdownHash, markdownForm: `urn:dkg:file:${markdownHash}` } : {}),
   };
 }
 


### PR DESCRIPTION
﻿## Summary
- Adds daemon APIs to resolve completed imported attachment artifacts, safely read their Markdown source by content hash, query deterministic quads in stable order, and write separate Working Memory semantic enrichment assertions with provenance.
- Extends MCP, OpenClaw, and Hermes tool surfaces/prompts so agents can resolve/read/inspect/enrich imported chat attachments without mutating deterministic import assertions or auto-promoting/publishing.
- Propagates Markdown artifact hashes through Node UI attachment refs and hardens completed-ref verification so skipped imports and inconsistent Markdown metadata do not become enrichment sources.

## Related
Fixes #456.

Builds on the attachment delivery work from #446 and the original attachment delivery issue #256.

## Files changed
- `packages/cli/src/daemon/routes/assertion.ts`, `packages/cli/src/daemon/openclaw.ts`, `packages/cli/src/daemon/routes/hermes.ts`: artifact resolver, safe Markdown read, semantic enrichment write, deterministic query sorting, provenance, and verified attachment metadata hardening.
- `packages/mcp-dkg/**`: MCP client/tool additions and tests for import artifact resolve/read plus semantic enrichment write.
- `packages/adapter-openclaw/**`: OpenClaw client/tool schemas, handlers, channel prompt updates, and tests.
- `packages/adapter-hermes/**`: Hermes Python plugin/client/tool schemas, bridge prompt updates, types, and tests.
- `packages/node-ui/src/ui/**`: attachment refs now carry Markdown artifact hashes/forms for completed imports.
- `packages/cli/test/import-artifact-routes.test.ts`, `packages/cli/test/daemon-openclaw.test.ts`, `packages/cli/test/daemon-hermes.test.ts`: daemon route and agent-visible regression coverage, including skipped and inconsistent-metadata negatives.

## Test plan
- `pnpm --filter @origintrail-official/dkg-mcp exec vitest run test/assertion-lifecycle.test.ts`
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/dkg-client.test.ts`
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/dkg-client.test.ts test/dkg-channel.test.ts test/plugin.test.ts --testNamePattern "import_artifact|semantic_enrichment|carry attachment refs|expected schema shape|exported tools|safe import artifact|semantic enrichment"`
- `pnpm --filter @origintrail-official/dkg-adapter-hermes exec vitest run test/hermes-adapter.test.ts --testNamePattern "tool names|routes Hermes parity tools|semantic enrichment|import artifact"`
- `pnpm --filter @origintrail-official/dkg exec vitest run test/import-artifact-routes.test.ts --reporter verbose`
- From `packages/cli`: `pnpm exec vitest run .\test\import-file-integration.test.ts --testNamePattern 'markdownForm|mdIntermediateHash|semanticTripleCount' --reporter verbose`
- `pnpm --filter @origintrail-official/dkg run build`

Known local note: a targeted `daemon-openclaw.test.ts` run failed before the selected test executed because the local Hardhat deploy setup hit a nonce/setup error; the added test is included for CI coverage and the CLI route/build checks above passed locally.
