### PR TITLE
fix(openclaw): address PR #457 review — content-aware ordered fallback + idempotent marker writes

### DIFF
--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -884,8 +884,19 @@ export class ChatTurnWriter {
         for (let i = 0; i < pairs.length; i++) {
           const { user, assistant, pairIndex, externalTurnIds, externalDirect, messageIds, assistantMessageIds } = pairs[i];
           if (!user && !assistant) continue;
-          const laterExactExternalMarker = externalCursorKey
-            ? this.hasExternalTurnMarkerInLaterPairs(externalCursorKey, pairs, i + 1)
+          // Ordered fallback is content-agnostic; it would over-skip if
+          // a later pair already carries a direct-channel exact marker
+          // whose `(turnId, user, assistant)` matches THIS pair's
+          // content (e.g. T84: pair 1 is a real W4a turn whose text
+          // coincidentally matches a direct-persisted pair 2). In that
+          // case the exact marker will handle the later pair and this
+          // pair is a distinct turn that must persist. We only block
+          // ordered fallback when the later exact marker would actually
+          // cover this pair's content — a later exact marker for SOME
+          // OTHER direct turn (different content) must not block
+          // ordered dedupe of an earlier metadata-stripped pair.
+          const laterExactCoversThisPairContent = externalCursorKey
+            ? this.hasLaterExactMarkerForPairContent(externalCursorKey, pairs, i + 1, user, assistant)
             : false;
           const externalMarkerAction = externalCursorKey
             ? this.consumeExternalTurnMarkersForPair(
@@ -894,7 +905,7 @@ export class ChatTurnWriter {
               user,
               assistant,
               externalDirect,
-              i < lastIdx && !laterExactExternalMarker,
+              i < lastIdx && !laterExactCoversThisPairContent,
             )
             : { skip: false, markers: [], rollbackMarkers: [] };
           if (externalCursorKey && externalMarkerAction.markers.length > 0) {
@@ -1171,17 +1182,26 @@ export class ChatTurnWriter {
       marker,
       count: this.externalTurnMarkers.get(externalCursorKey)?.get(marker) ?? 0,
     }));
-    // The ordered marker is a one-shot ticket per direct persist; W4a
-    // consumes it (count - 1) when a historical non-latest pair has no
-    // exact/user marker. N direct persists must accumulate N tickets so
-    // N metadata-stripped UI backfill pairs can each be skipped. Live
-    // smoke (UI3 -> first Telegram) showed Math.max collapsing the
-    // count to 1 even after multiple UI persists, so only the first
-    // historical UI pair was skipped and the rest re-persisted as
-    // duplicates. Content-bound exact/user markers remain idempotent
-    // (Math.max) because identical (turnId + content) is the same
-    // daemon-success fact across replays.
-    this.incrementOrderedExternalTurnMarker(externalCursorKey);
+    // The ordered marker is a one-shot ticket per *distinct* direct
+    // persist. N distinct UI turns must leave N tickets so N metadata-
+    // stripped backfill pairs can each be skipped. A retry of the same
+    // direct persist (same turnId + user + assistant; e.g. the marker-
+    // write retry ladder in DkgChannelPlugin) must NOT add another
+    // ticket — content-bound markers stay at 1 via Math.max while the
+    // ordered count would otherwise drift upward on every retry,
+    // leaking tickets that W4a could later consume against unrelated
+    // stripped pairs. Detect replay by checking that at least one
+    // content marker for this opts already exists in the bucket; if so,
+    // skip the ordered increment. Content-bound exact/user markers
+    // remain idempotent (Math.max) because identical (turnId + content)
+    // is the same daemon-success fact across replays.
+    const isReplay = contentMarkers.length > 0
+      && contentMarkers.some((marker) =>
+        (this.externalTurnMarkers.get(externalCursorKey)?.get(marker) ?? 0) > 0,
+      );
+    if (!isReplay) {
+      this.incrementOrderedExternalTurnMarker(externalCursorKey);
+    }
     for (const marker of contentMarkers) {
       this.restoreExternalTurnMarker(externalCursorKey, marker);
     }
@@ -3152,13 +3172,28 @@ export class ChatTurnWriter {
     return { skip: false, markers: [], rollbackMarkers: [] };
   }
 
-  private hasExternalTurnMarkerInLaterPairs(
+  /**
+   * Returns true when some later pair in this `agent_end` carries a
+   * direct-channel exact marker whose `(turnId, user, assistant)` would
+   * match the SUPPLIED `user`/`assistant` content. Used to block
+   * ordered-fallback skipping for an earlier metadata-less pair whose
+   * content the later exact marker will already deduplicate against —
+   * see T84: a real W4a turn that coincidentally shares text with a
+   * later direct-persisted pair must persist, not be ordered-skipped.
+   *
+   * A later exact marker for SOME OTHER direct turn (different content)
+   * must NOT block ordered dedupe of this stripped pair — that's the
+   * pre-existing over-coarse check this PR is replacing.
+   */
+  private hasLaterExactMarkerForPairContent(
     sessionKeyCursor: string,
     pairs: ComputedChatTurnPair[],
     fromIndex: number,
+    user: string,
+    assistant: string,
   ): boolean {
     for (let i = fromIndex; i < pairs.length; i++) {
-      const { user, assistant, externalTurnIds, externalDirect } = pairs[i];
+      const { externalTurnIds, externalDirect } = pairs[i];
       for (const turnId of externalTurnIds) {
         const exactMarker = this.externalTurnMarkerId(turnId, user, assistant);
         if (exactMarker && this.hasExternalTurnMarker(sessionKeyCursor, exactMarker)) return true;
@@ -3168,6 +3203,7 @@ export class ChatTurnWriter {
     }
     return false;
   }
+
 
   private hasExternalTurnMarker(sessionKeyCursor: string, marker: string): boolean {
     const bucket = this.externalTurnMarkers.get(sessionKeyCursor);

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -3140,6 +3140,95 @@ describe("ChatTurnWriter", () => {
     writer.flushSync();
   });
 
+  it("T459 — ordered fallback runs for an earlier metadata-stripped UI pair even when a later pair carries an exact marker for a DIFFERENT direct turn", async () => {
+    // Mixed-metadata regression from PR #457 review round (Codex review
+    // comment on `laterExactExternalMarker`). Transcript shape: an
+    // earlier UI pair has lost its DkgTurnId, a later UI pair still
+    // carries DkgTurnId, then live Telegram. The pre-fix gating
+    // disabled ordered fallback for the earlier pair because SOME
+    // later exact marker existed in the bucket — even though that
+    // marker's content didn't match the earlier pair. After the fix,
+    // ordered fallback is only blocked when the later exact marker's
+    // `(turnId, user, assistant)` actually matches THIS pair's
+    // content; otherwise the earlier stripped pair is correctly
+    // ordered-skipped.
+    await writer.onAgentEnd({
+      sessionId: "seed",
+      messages: [
+        { role: "user", content: "previous telegram question" },
+        { role: "assistant", content: "previous telegram answer" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-older-stripped",
+      user: "older ui question",
+      assistant: "older ui answer",
+    });
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-newer-with-id",
+      user: "newer ui question",
+      assistant: "newer ui answer",
+    });
+
+    await writer.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "previous telegram question" },
+        { role: "assistant", content: "previous telegram answer" },
+        { role: "user", content: "older ui question" },
+        { role: "assistant", content: "older ui answer" },
+        {
+          role: "user",
+          content: "newer ui question",
+          context: { Provider: "dkg-ui", DkgTurnId: "node-ui-corr-newer-with-id" },
+        },
+        { role: "assistant", content: "newer ui answer" },
+        { role: "user", content: "next telegram question" },
+        { role: "assistant", content: "next telegram answer" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("next telegram question");
+    writer.flushSync();
+  });
+
+  it("T460 — markExternalTurnPersistedDurable replay does not double the ordered-marker count", async () => {
+    // Marker-only retry idempotency. PR #457 review round (Codex
+    // comment on `incrementOrderedExternalTurnMarker`): a marker-write
+    // retry with identical opts left content-bound markers idempotent
+    // via Math.max but still incremented the ordered ticket count.
+    // After N retries, N - 1 leftover tickets could be consumed by a
+    // later W4a pass against unrelated metadata-stripped pairs (e.g.,
+    // a stale non-latest Telegram pair). After the fix, a replay
+    // detects the existing content markers and skips the ordered
+    // increment.
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-retry",
+      user: "ui question",
+      assistant: "ui answer",
+    });
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-retry",
+      user: "ui question",
+      assistant: "ui answer",
+    });
+
+    const externalCursorKey = (writer as any).externalCursorKeyFromSessionKey("agent:main:main");
+    const bucket = (writer as any).externalTurnMarkers.get(externalCursorKey) as Map<string, number>;
+    const orderedKey = (writer as any).constructor.EXTERNAL_ORDERED_TURN_MARKER as string;
+    expect(bucket?.get(orderedKey) ?? 0).toBe(1);
+    writer.flushSync();
+  });
+
   it("T359 - typed Telegram W4b and Node-UI external markers both suppress W4a duplicates after restart", async () => {
     await writer.markExternalTurnPersistedDurable({
       sessionKey: "agent:main:main",


### PR DESCRIPTION
## Summary

Follow-up to PR #457. After merge, the Codex review on commit `714ca033` posted two `🔴 Bug` inline comments on the ordered direct-channel marker path. Both validated and addressed here.

## The two bugs

### 1. Over-coarse gating of ordered fallback (`ChatTurnWriter.runAgentEndPersist`)

The gate `i < lastIdx && !laterExactExternalMarker` blocked ordered fallback whenever *any* later pair in the transcript carried an exact-marker hit — regardless of whether that marker matched the current pair's content.

Concrete failure shape:

```
[UI_older_stripped, UI_newer_with_DkgTurnId, TG_live]
```

At pair 0 (older, stripped) the gate fired on pair 1's exact marker (for a different direct turn), ordered fallback was blocked, and pair 0 re-persisted as a duplicate.

**Fix:** replaced the pair-agnostic `hasExternalTurnMarkerInLaterPairs` with a content-aware `hasLaterExactMarkerForPairContent(cursor, pairs, fromIdx, currentUser, currentAssistant)`. The predicate now only returns true when a later exact marker would actually cover *this* pair's content — preserving the T84 invariant ("external markers are correlation-bound, not content-only" — a real W4a turn that coincidentally shares text with a later direct-persisted pair must persist) while letting ordered fallback do its job for the mixed-metadata case the reviewer surfaced.

### 2. Non-idempotent ordered marker increment (`ChatTurnWriter.markExternalTurnPersistedDurable`)

`incrementOrderedExternalTurnMarker` ran on every call. Content-bound exact/user markers stayed idempotent via `Math.max`, but the ordered count drifted upward on each marker-write retry (the retry ladder in `DkgChannelPlugin.scheduleExternalTurnMarkerRetry` replays the same `opts`).

After N retries, N − 1 leftover tickets remained. A later W4a pass could consume one of them against an unrelated metadata-stripped pair (e.g., a non-latest Telegram pair whose `externalTurnIds=[]` makes it eligible for ordered-fallback skipping) — **data loss**.

**Fix:** the ordered increment is now conditional on "this call introduces a fresh content-marker set." If any content marker (`externalTurnMarkerId` or `externalTurnUserMarkerId` for this opts) is already present in the bucket, the call is treated as a replay and the ordered ticket is not added a second time. Distinct direct persists (different turnId or different content) still accumulate one ticket each.

## Why this matters now and not before

PR #457's additive ordered-marker fix changed the blast radius of bug #1: pre-PR, the ordered count was clamped to 1, so the gating issue was rarely visible. Post-PR, multiple UI persists produce multiple tickets, and the gating bug becomes exploitable. Both layers needed correcting together.

## Regressions

| Test | Asserts |
|---|---|
| `T459` | Mixed-metadata transcript: an older stripped UI pair is correctly ordered-skipped even when a later UI pair carries an exact marker for a different direct turn. |
| `T460` | `markExternalTurnPersistedDurable` replay (same opts) does NOT double the ordered-marker count. |

The pre-existing T84 (correlation-bound markers) still passes — my first attempt at fix #1 was too aggressive and broke T84, which surfaced the need for the content-aware predicate.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw run build` — clean
- [x] Focused marker slice (`T457|T458|T459|T460|T84|T85|T86|T91|T92|T93|T83|T97|T99|T105|preserves loaded direct-channel markers|does not clear fresh direct-channel markers`) — 17/17
- [x] Full adapter persistence slice (`HookSurface`, `plugin`, `ChatTurnWriter`, `ChatTurnWriter.crashRecovery`, `dkg-channel`, `dkg-client`) — **567/567** (was 565; +2 regressions)
- [ ] Live mixed UI→Telegram smoke unchanged from PR #457 verification (1 UI → 1 TG, 2 UI → 1 TG, 3 TG only, restart-mixed). The fixes here are narrow corrections to the ordered-marker bookkeeping and shouldn't affect the green smoke scenarios.

## Related

- Follow-up to #457
- Addresses Codex review comments [`#discussion_r3227170117`](https://github.com/OriginTrail/dkg/pull/457#discussion_r3227170117) and [`#discussion_r3227170123`](https://github.com/OriginTrail/dkg/pull/457#discussion_r3227170123)