### PR TITLE
Preserve standalone Telegram Sender metadata text

### DIFF
--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -2828,10 +2828,10 @@ export class ChatTurnWriter {
    * channel/message labels need their own trusted source before they can be
    * stripped safely. The leading `Conversation info` block is stripped, and the
    * immediately following `Sender` block is stripped only when its JSON agrees
-   * with that conversation block. This keeps a user-pasted `Sender` example
-   * after a conversation-only wrapper verbatim. Separator blank lines after
-   * stripped blocks are removed, but indentation on the first real user line is
-   * kept.
+   * with that conversation block. Standalone `Sender` blocks are preserved as
+   * user-authored text because there is no trusted wrapper context to bind them
+   * to. Separator blank lines after stripped blocks are removed, but indentation
+   * on the first real user line is kept.
    *
    * Because W4a and W4b both call this before turnId/content hashing, metadata
    * changes do not create distinct persisted turn identities for the same user
@@ -2845,7 +2845,7 @@ export class ChatTurnWriter {
     if (!text) return "";
     const first = this.matchLeadingChannelMetadataBlock(text);
     if (!first) return text;
-    if (first.label === "Sender") return text.slice(first.length);
+    if (first.label === "Sender") return text;
     let out = text.slice(first.length);
     const sender = this.matchLeadingChannelMetadataBlock(out);
     if (sender?.label === "Sender" && this.senderMetadataMatchesConversation(first.json, sender.json)) {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -1357,6 +1357,24 @@ describe("ChatTurnWriter", () => {
     expect(persistedUser).toContain("user-pasted-sender-999");
   });
 
+  it("T380 - W4a preserves standalone leading Sender block as user text", async () => {
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: pastedSenderMetadataBlock },
+        { role: "assistant", content: "reply" },
+      ],
+    };
+
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(pastedSenderMetadataBlock);
+    expect(persistedUser).toContain("Sender (untrusted metadata):");
+    expect(persistedUser).toContain("user-pasted-sender-999");
+  });
+
   it("T380 - W4a preserves non-Telegram metadata labels after Telegram wrapper", async () => {
     const actualUserText = [channelContextMetadataBlock, "This block is part of my message"].join("\n");
     const event: AgentEndContext = {
@@ -1539,6 +1557,27 @@ describe("ChatTurnWriter", () => {
 
     const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
     expect(persistedUser).toBe(actualUserText);
+    expect(persistedUser).toContain("Sender (untrusted metadata):");
+    expect(persistedUser).toContain("user-pasted-sender-999");
+  });
+
+  it("T380 - W4b preserves standalone leading Sender block as user text", async () => {
+    writer.onMessageReceived({
+      sessionKey: "key123",
+      direction: "inbound",
+      text: pastedSenderMetadataBlock,
+      ...({ context: { channelId: "telegram" } } as any),
+    } as any);
+    await writer.onMessageSent({
+      sessionKey: "key123",
+      direction: "outbound",
+      text: "response",
+      ...({ context: { success: true, channelId: "telegram" } } as any),
+    } as any);
+    await flushMicrotasks();
+
+    const [, persistedUser] = mockClient.storeChatTurn.mock.calls[0];
+    expect(persistedUser).toBe(pastedSenderMetadataBlock);
     expect(persistedUser).toContain("Sender (untrusted metadata):");
     expect(persistedUser).toContain("user-pasted-sender-999");
   });


### PR DESCRIPTION
﻿## Summary

- Preserve standalone leading `Sender (untrusted metadata)` blocks as user-authored Telegram text.
- Keep stripping the runtime `Sender` wrapper only when it follows a stripped `Conversation info` block and its JSON sender ID matches the conversation metadata.
- Add W4a and W4b regressions so a standalone `Sender` block is persisted instead of stripped or dropped.

## Related

- Follow-up to #388
- Addresses https://github.com/OriginTrail/dkg/pull/388#discussion_r3227566360
- Related to #380

## Files changed

| File | What |
|------|------|
| `packages/adapter-openclaw/src/ChatTurnWriter.ts` | Removes the Sender-only strip path and clarifies the helper contract. |
| `packages/adapter-openclaw/test/ChatTurnWriter.test.ts` | Adds W4a and W4b coverage for standalone leading `Sender` blocks as user text. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/ChatTurnWriter.test.ts -t "T380"` - passed, 22 tests.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/ChatTurnWriter.test.ts` - passed, 209 tests.
- [x] `pnpm --filter @origintrail-official/dkg-core run build` - passed.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw run build` - passed.
- [x] `git diff --check` - passed with Windows LF-to-CRLF checkout warnings only.
