### PR TITLE
Codex/swm large literal blob storage

### DIFF
--- a/docs/SWM_LARGE_LITERAL_STORAGE_PR_DESCRIPTION.md
+++ b/docs/SWM_LARGE_LITERAL_STORAGE_PR_DESCRIPTION.md
@@ -1,0 +1,156 @@
+# PR Description: Fix SWM Large Payload Storage Amplification
+
+## Summary
+
+This PR fixes the Shared Working Memory large-payload storage amplification path
+that pushed Oxigraph WASM into `RuntimeError: unreachable` / `table index is out
+of bounds` failures during replicated public SWM writes.
+
+The change keeps the public SWM API unchanged while moving large bytes out of
+Oxigraph metadata and out of Oxigraph literal storage where possible:
+
+- New SWM share metadata no longer writes full public payloads as
+  `dkg:publicStagedQuads` JSON literals.
+- Async lift/publish resolution uses immutable per-operation public snapshots,
+  so an older queued `shareOperationId` does not silently read the root's newer
+  live SWM state.
+- Large public SWM literal object terms are externalized into content-addressed
+  blob files and hydrated back on query/lift results.
+- Public operation snapshots are now stored as compact graphless N-Quads files
+  instead of JSON quad arrays, with read compatibility for existing `.json`
+  snapshot files.
+
+## Implementation Details
+
+### Compact Operation Metadata
+
+`storeWorkspaceOperationPublicQuads()` now stores operation identity and
+fingerprints instead of serialized public payload bytes:
+
+- context graph id
+- optional subgraph name
+- share operation id
+- root entities
+- publisher peer id
+- timestamp
+- per-root public quad digest/count
+- per-root immutable snapshot reference
+
+Legacy `dkg:publicStagedQuads` records remain readable, but new writes do not
+create them.
+
+### Immutable Public Snapshots
+
+Each share operation has an immutable public snapshot backing store. Lift
+resolution checks the requested roots against the operation metadata, reads the
+snapshot, recomputes digest/count, and fails if the snapshot is missing or
+corrupt. It does not fall back to the current live SWM root state.
+
+```mermaid
+flowchart TD
+  A["/api/shared-memory/write"] --> B["Write live SWM graph"]
+  A --> C["Build operation-scoped public slice"]
+  C --> D["Persist immutable public snapshot"]
+  D --> E["Store compact snapshot ref + digest/count"]
+  E --> F["Async lift resolves by shareOperationId"]
+  F --> G{"Legacy publicStagedQuads exists?"}
+  G -->|yes| H["Read legacy JSON metadata snapshot"]
+  G -->|no| I["Read immutable snapshot ref"]
+  I --> J["Validate digest/count"]
+  J --> K["Return original public quads"]
+```
+
+### Large Literal Externalization
+
+Persistent Oxigraph-backed agent stores wrap the underlying triple store with
+large-literal externalization for public SWM graphs. Large RDF literal object
+terms are written to `<dataDir>/literal-blobs/<sha256>`, and Oxigraph stores a
+small typed placeholder:
+
+```text
+"sha256:<hex>"^^<http://dkg.io/ontology/externalLiteralRef>
+```
+
+Queries and lift results hydrate placeholders back to the original RDF literal
+term. Full SPARQL value semantics over externalized literal bytes are not
+promised; filters/functions inside Oxigraph see the placeholder.
+
+### N-Quads Public Snapshot Files
+
+The file-backed public snapshot store now writes:
+
+```text
+<dataDir>/swm-public-snapshots/aa/bb/<sha>.nq
+```
+
+instead of:
+
+```text
+<dataDir>/swm-public-snapshots/aa/bb/<sha>.json
+```
+
+The `.nq` file contains one graphless N-Quads line per public quad. Reads first
+try `.nq` and then fall back to legacy `.json`, so existing snapshot files stay
+compatible.
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Agent
+  participant Store as Oxigraph-backed store
+  participant Blobs as literal-blobs
+  participant Snapshots as swm-public-snapshots
+
+  Client->>Agent: shared-memory/write(public quads)
+  Agent->>Store: insert live SWM quads
+  Store->>Blobs: externalize large literal terms
+  Store-->>Agent: stored placeholders in Oxigraph
+  Agent->>Snapshots: write immutable public snapshot as .nq
+  Agent->>Store: insert compact metadata refs
+  Client->>Agent: enqueue/publish by shareOperationId
+  Agent->>Snapshots: read .nq snapshot
+  Agent->>Store: hydrate external literal refs
+  Agent-->>Client: publish/lift original RDF quads
+```
+
+## Verification
+
+Focused checks run:
+
+```bash
+pnpm --filter @origintrail-official/dkg-storage exec vitest run test/storage.test.ts test/external-literal-store.test.ts
+pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/async-lift-workspace.test.ts
+pnpm --filter @origintrail-official/dkg exec vitest run test/swm-large-payload-benchmark.test.ts
+pnpm --filter @origintrail-official/dkg exec vitest run test/swm-triple-volume-benchmark.test.ts
+pnpm --filter @origintrail-official/dkg-storage build
+pnpm --filter @origintrail-official/dkg-publisher build
+git diff --check
+```
+
+Live 5-node verification after the N-Quads snapshot patch:
+
+```bash
+pnpm --filter @origintrail-official/dkg benchmark:swm-triple-volume -- \
+  --ports 20501,20502,20503,20504,20505 \
+  --target-gib-per-node 1 \
+  --triples-per-write 1000 \
+  --write-concurrency 5 \
+  --max-writes 250 \
+  --diagnostic-interval-ms 10000 \
+  --output bench/results/swm-triple-volume-diagnostic-250w-nq-commit.json
+```
+
+Result:
+
+- `250/250` writes completed.
+- `250,000` triples converged on all five nodes.
+- `dkg:publicStagedQuads = 0` on all five nodes.
+- `dkg:publicSnapshotGraph = 0` on all five nodes.
+- `dkg:publicSnapshotRef = 250` on all five nodes.
+- No `RuntimeError: unreachable`.
+- No `table index is out of bounds`.
+- No Gossipsub payload-length failures.
+
+The benchmark still shows write-throughput decline as RDF store/snapshot state
+grows, but the run completes without data loss or Oxigraph WASM failure. The
+remaining throughput work is separate from the storage-amplification fix.

--- a/docs/SWM_LARGE_LITERAL_STORAGE_PR_DESCRIPTION.md
+++ b/docs/SWM_LARGE_LITERAL_STORAGE_PR_DESCRIPTION.md
@@ -19,6 +19,11 @@ Oxigraph metadata and out of Oxigraph literal storage where possible:
 - Public operation snapshots are now stored as compact graphless N-Quads files
   instead of JSON quad arrays, with read compatibility for existing `.json`
   snapshot files.
+- SWM catch-up sync transfers referenced snapshot blobs before inserting
+  `dkg:publicSnapshotRef` metadata, so late peers do not receive dangling local
+  file references.
+- Daemon publisher control uses the same snapshot store as the agent runtime,
+  so `/api/publisher/job-payload` can inspect ref-backed jobs.
 
 ## Implementation Details
 
@@ -45,6 +50,13 @@ Each share operation has an immutable public snapshot backing store. Lift
 resolution checks the requested roots against the operation metadata, reads the
 snapshot, recomputes digest/count, and fails if the snapshot is missing or
 corrupt. It does not fall back to the current live SWM root state.
+
+Catch-up sync treats snapshot refs as required backing data. When a peer fetches
+SWM meta/data and sees `dkg:publicSnapshotRef`, it requests the referenced
+snapshot over a dedicated sync phase, validates the received N-Quads against
+`dkg:publicQuadsDigest` and `dkg:publicQuadsCount`, writes the local snapshot
+file, and only then inserts the fetched RDF metadata. A missing or corrupt
+remote snapshot fails that peer sync instead of leaving unusable metadata.
 
 ```mermaid
 flowchart TD
@@ -97,6 +109,7 @@ compatible.
 sequenceDiagram
   participant Client
   participant Agent
+  participant Peer as Sync peer
   participant Store as Oxigraph-backed store
   participant Blobs as literal-blobs
   participant Snapshots as swm-public-snapshots
@@ -107,6 +120,11 @@ sequenceDiagram
   Store-->>Agent: stored placeholders in Oxigraph
   Agent->>Snapshots: write immutable public snapshot as .nq
   Agent->>Store: insert compact metadata refs
+  Peer->>Agent: SWM sync meta/data
+  Agent-->>Peer: publicSnapshotRef metadata
+  Peer->>Agent: SWM sync snapshot(ref)
+  Agent-->>Peer: graphless .nq snapshot page
+  Peer->>Snapshots: validate digest/count and write local .nq
   Client->>Agent: enqueue/publish by shareOperationId
   Agent->>Snapshots: read .nq snapshot
   Agent->>Store: hydrate external literal refs
@@ -120,6 +138,8 @@ Focused checks run:
 ```bash
 pnpm --filter @origintrail-official/dkg-storage exec vitest run test/storage.test.ts test/external-literal-store.test.ts
 pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/async-lift-workspace.test.ts
+pnpm --filter @origintrail-official/dkg-agent exec vitest run test/swm-snapshot-sync.test.ts
+pnpm --filter @origintrail-official/dkg exec vitest run test/publisher-route-snapshot.test.ts
 pnpm --filter @origintrail-official/dkg exec vitest run test/swm-large-payload-benchmark.test.ts
 pnpm --filter @origintrail-official/dkg exec vitest run test/swm-triple-volume-benchmark.test.ts
 pnpm --filter @origintrail-official/dkg-storage build

--- a/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
+++ b/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
@@ -24,11 +24,18 @@ After that failure, later queries could also fail with:
 table index is out of bounds
 ```
 
-The fix replaces full-payload metadata snapshots with compact operation
-metadata. New SWM writes store only references and provenance in
-`_shared_memory_meta`, while the public payload remains in the SWM data graph.
-Legacy metadata records that already contain `dkg:publicStagedQuads` remain
-readable.
+The fix has two layers:
+
+1. Full-payload metadata snapshots are replaced by compact immutable
+   share-operation metadata and per-root public quad fingerprints.
+2. Large public SWM literal object terms are externalized into
+   content-addressed blob files, leaving only a small placeholder literal in
+   Oxigraph.
+
+New SWM writes no longer serialize public payloads into
+`dkg:publicStagedQuads`, and persistent nodes no longer ask Oxigraph WASM to
+hold large literal bytes directly. Legacy metadata records that already contain
+`dkg:publicStagedQuads` remain readable.
 
 ## Problem
 
@@ -60,33 +67,82 @@ New SWM writes store compact share-operation metadata:
 - root entities
 - publisher peer id
 - published timestamp
+- public quad digest and count for each root
 
-The public payload is not serialized into metadata. Resolution reconstructs the
-operation payload by reading the current SWM graph for the operation roots.
+The public payload is not serialized into metadata. Resolution reconstructs and
+validates the operation payload by reading the current SWM graph for the
+operation roots, then comparing the hydrated quads to the stored digest/count.
 
 ```mermaid
 flowchart TD
   A["Client writes public SWM quads"] --> B["Store quads in SWM graph"]
   A --> C["Generate compact metadata"]
+  B --> L{"Large SWM literal?"}
+  L -->|No| M["Store RDF term inline"]
+  L -->|Yes| N["Write exact RDF object term to literal-blobs/sha256"]
+  N --> O["Store externalLiteralRef placeholder in Oxigraph"]
   C --> D["dkg:shareOperationId"]
   C --> E["dkg:rootEntity"]
   C --> F["dkg:publisherPeerId"]
   C --> G["dkg:publishedAt"]
   C --> H["dkg:contextGraphId"]
   C --> I["optional dkg:subGraphName"]
-  B --> J["Single payload copy in Oxigraph"]
+  C --> P["dkg:publicQuadsDigest + dkg:publicQuadsCount"]
+  M --> J["Small or normal RDF terms in Oxigraph"]
+  O --> J
   D --> K["Small operation reference metadata"]
   E --> K
   F --> K
   G --> K
   H --> K
   I --> K
+  P --> K
 ```
+
+## Large Literal Blob Storage
+
+Local Oxigraph-backed agent stores now enable large SWM literal storage by
+default when `dataDir` is configured. The default settings are:
+
+```ts
+largeLiteralStorage: {
+  enabled: true,
+  thresholdBytes: 65536,
+  directory: "<dataDir>/literal-blobs",
+}
+```
+
+Only RDF literal objects written to graphs ending in `/_shared_memory` are
+eligible. Small literals, IRIs, blank nodes, non-SWM graphs, Verified Memory,
+private encrypted staging, and file import blobs stay unchanged.
+
+For each large SWM literal, the wrapper computes `sha256` over the exact
+serialized RDF object term string and writes that string to:
+
+```text
+<dataDir>/literal-blobs/<sha256>
+```
+
+Oxigraph stores this placeholder instead of the full literal bytes:
+
+```text
+"sha256:<hex>"^^<http://dkg.io/ontology/externalLiteralRef>
+```
+
+Queries and lift resolution hydrate placeholders after Oxigraph returns
+bindings or constructed quads, so normal callers receive the original RDF
+literal term. Exact large-literal constants in simple `SELECT`, `ASK`, and
+equality-filter queries are also translated to the placeholder form before
+querying. Full SPARQL value semantics for functions over externalized literal
+values are intentionally not promised; those expressions still execute inside
+Oxigraph against the stored placeholder.
 
 ## Write Path
 
-The SWM write path still persists and gossips the public payload normally. The
-change is only in the metadata generated for the operation.
+The SWM write path still accepts and gossips normal public RDF quads. The
+storage wrapper externalizes large literal bytes at the local persistence
+boundary, and compact metadata records only operation provenance plus
+digest/count fingerprints.
 
 ```mermaid
 sequenceDiagram
@@ -99,6 +155,7 @@ sequenceDiagram
   Client->>API: POST /api/shared-memory/write
   API->>Publisher: share(contextGraphId, quads, subGraphName?)
   Publisher->>Store: store public quads in SWM graph
+  Store->>Store: externalize large SWM literals to literal-blobs
   Publisher->>Store: store compact share metadata
   Publisher->>Gossip: broadcast SWM operation
   Gossip-->>API: operation propagated to peers
@@ -113,7 +170,8 @@ New writes no longer emit:
 ```
 
 Instead they emit compact metadata that points to roots already present in the
-SWM data graph.
+SWM data graph and records immutable digest/count fingerprints for stale-write
+detection.
 
 ## Resolution Path
 
@@ -127,14 +185,17 @@ flowchart TD
   C -->|Yes| D["Parse legacy serialized quad snapshot"]
   C -->|No| E["Read root entities from metadata"]
   E --> F["Query current SWM graph for those roots"]
-  F --> G["Return public quads for operation"]
+  F --> I["Hydrate externalLiteralRef placeholders from blobs"]
+  I --> J["Compare hydrated digest/count with metadata"]
+  J --> G["Return public quads for operation"]
   D --> G
   G --> H["Build lift request payload"]
 ```
 
 For compact metadata, the resolver validates the operation roots and then reads
-the public quads from the current SWM graph. This keeps new writes small while
-preserving the ability to lift and publish shared-memory content.
+hydrated public quads from the current SWM graph. If the current root slice no
+longer matches the stored digest/count, resolution fails instead of silently
+publishing a mismatched public/private asset.
 
 ## Legacy Compatibility
 
@@ -160,9 +221,10 @@ This PR adds a reusable live benchmark:
 ```bash
 pnpm bench:swm-large-payload -- \
   --ports 19101,19102,19103,19104,19105 \
-  --payload-mib-per-node 100 \
+  --payload-mib-per-node 204.8 \
   --chunk-mib 0.5 \
-  --output bench/results/swm-large-payload-500mib.json
+  --write-concurrency 5 \
+  --output bench/results/swm-large-payload-1gib.json
 ```
 
 The benchmark:
@@ -172,7 +234,9 @@ The benchmark:
 3. Checks per-run metadata for `shareOperationId`, `rootEntity`,
    `publisherPeerId`, and `publishedAt`.
 4. Verifies `dkg:publicStagedQuads` did not grow.
-5. Optionally scans appended daemon logs for known Oxigraph and GossipSub
+5. Selects one sample payload literal per node to prove hydration returns the
+   original payload bytes.
+6. Optionally scans appended daemon logs for known Oxigraph and GossipSub
    failure signatures.
 
 ```mermaid
@@ -184,11 +248,11 @@ sequenceDiagram
   participant N4 as Node 4
   participant N5 as Node 5
 
-  Bench->>N1: write 100 MiB in chunks
-  Bench->>N2: write 100 MiB in chunks
-  Bench->>N3: write 100 MiB in chunks
-  Bench->>N4: write 100 MiB in chunks
-  Bench->>N5: write 100 MiB in chunks
+  Bench->>N1: write 204.8 MiB in chunks
+  Bench->>N2: write 204.8 MiB in chunks
+  Bench->>N3: write 204.8 MiB in chunks
+  Bench->>N4: write 204.8 MiB in chunks
+  Bench->>N5: write 204.8 MiB in chunks
 
   N1-->>N2: gossip SWM operations
   N1-->>N3: gossip SWM operations
@@ -210,16 +274,21 @@ sequenceDiagram
   Bench->>N3: verify compact metadata
   Bench->>N4: verify compact metadata
   Bench->>N5: verify compact metadata
+  Bench->>N1: select one hydrated sample literal
+  Bench->>N2: select one hydrated sample literal
+  Bench->>N3: select one hydrated sample literal
+  Bench->>N4: select one hydrated sample literal
+  Bench->>N5: select one hydrated sample literal
 ```
 
-The reproduced 5-node regression case used `5 x 100 MiB = 500 MiB` total. With
-the compact metadata model, all five nodes converged with:
+The 1 GiB target case uses `5 x 204.8 MiB = 1024 MiB` total. Acceptance is:
 
 ```text
-payload quads:        1000 per node
+payload quads:        all benchmark chunks on every node
 dkg:publicStagedQuads: 0 per node
-shareOperationIds:    1000 per node
-rootEntities:         1000 per node
+shareOperationIds:    one per benchmark write
+rootEntities:         one per benchmark write
+sample literal bytes: expected chunk payload size on every node
 ```
 
 No Oxigraph failure signatures were observed:
@@ -253,12 +322,36 @@ table index is out of bounds
   - Covers compact share-operation resolution.
   - Covers legacy `dkg:publicStagedQuads` compatibility.
   - Covers large literal writes without metadata payload duplication.
+  - Covers compact digest/count resolution over hydrated external SWM literals.
 
 - `packages/publisher/test/metadata.test.ts`
   - Covers the new compact share metadata shape.
 
+- `packages/storage/src/shared-memory-literal-blob-store.ts`
+  - Adds the content-addressed large SWM literal blob wrapper.
+  - Hydrates `SELECT` bindings and `CONSTRUCT` quads back to the original RDF
+    literal term.
+  - Translates deletes and exact large-literal query constants to the
+    placeholder representation.
+
+- `packages/storage/src/triple-store.ts`
+  - Adds the `largeLiteralStorage` configuration surface.
+
+- `packages/storage/test/external-literal-store.test.ts`
+  - Covers externalization, hydration, exact literal matching, deletes,
+    corrupt/missing blob failures, and reopen-from-disk behavior.
+
+- `packages/agent/src/dkg-agent.ts`
+  - Enables large SWM literal storage by default for local Oxigraph-backed
+    `DKGAgent.create({ dataDir })` stores.
+
+- `packages/agent/test/large-literal-storage.test.ts`
+  - Covers the default persistent agent store wiring.
+
 - `packages/cli/scripts/swm-large-payload-benchmark.cjs`
   - Adds the reusable live multi-node SWM payload benchmark.
+  - Uses hydrated sample literal selection instead of `STRLEN(STR(?o))`, so
+    count queries remain cheap and sample checks exercise blob hydration.
 
 - `packages/cli/test/swm-large-payload-benchmark.test.ts`
   - Covers benchmark argument parsing, chunk planning, and generated payload
@@ -273,6 +366,9 @@ Focused validation run for this change:
 
 ```bash
 pnpm --filter @origintrail-official/dkg exec vitest run test/swm-large-payload-benchmark.test.ts
+pnpm --filter @origintrail-official/dkg-storage exec vitest run test/storage.test.ts test/external-literal-store.test.ts
+pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/async-lift-workspace.test.ts
+pnpm --filter @origintrail-official/dkg-agent exec vitest run test/large-literal-storage.test.ts
 ```
 
 Additional validation performed during the fix:
@@ -286,11 +382,14 @@ Live benchmark validation:
 ```bash
 pnpm bench:swm-large-payload -- \
   --ports 19101,19102,19103,19104,19105 \
-  --payload-mib-per-node 100 \
+  --payload-mib-per-node 204.8 \
   --chunk-mib 0.5 \
+  --write-concurrency 5 \
   --auth-token <token> \
-  --output bench/results/swm-large-payload-500mib.json
+  --output bench/results/swm-large-payload-1gib.json
 ```
 
-The full 500 MiB run verified that each node could query all benchmark payloads
-and that `dkg:publicStagedQuads` remained at zero for the new writes.
+The live 1 GiB run should verify that each node converges, hydrated sample
+literals match the expected chunk size, `dkg:publicStagedQuads` remains zero,
+and the logs contain no `RuntimeError: unreachable` or
+`table index is out of bounds`.

--- a/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
+++ b/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
@@ -1,0 +1,296 @@
+# Fix SWM Large Payload Storage Amplification
+
+## Summary
+
+This change fixes Shared Working Memory large-payload storage amplification.
+Before this fix, each public SWM payload was stored twice per node:
+
+1. Once as normal RDF quads in the SWM data graph.
+2. Again as a JSON-stringified RDF literal in SWM metadata through
+   `dkg:publicStagedQuads`.
+
+For large replicated writes this doubled the effective Oxigraph payload and
+pushed the WASM store into memory failures. In the reproduced benchmark, the
+duplicated path failed around `202.5 MiB/store` with:
+
+```text
+RuntimeError: unreachable
+Store.load(...)
+```
+
+After that failure, later queries could also fail with:
+
+```text
+table index is out of bounds
+```
+
+The fix replaces full-payload metadata snapshots with compact operation
+metadata. New SWM writes store only references and provenance in
+`_shared_memory_meta`, while the public payload remains in the SWM data graph.
+Legacy metadata records that already contain `dkg:publicStagedQuads` remain
+readable.
+
+## Problem
+
+The old SWM share path made metadata carry the entire public payload:
+
+```mermaid
+flowchart TD
+  A["Client writes public SWM quads"] --> B["Store quads in SWM graph"]
+  A --> C["Serialize same quads as JSON"]
+  C --> D["Store JSON string as dkg:publicStagedQuads literal"]
+  B --> E["Oxigraph stores payload copy 1"]
+  D --> F["Oxigraph stores payload copy 2"]
+  E --> G["Large payload memory pressure"]
+  F --> G
+```
+
+That metadata snapshot was useful for later lift/share resolution, but it made
+the storage model scale with approximately `2x payload size` per node. The
+failure was reproduced without private mode and without Sender Key encryption,
+so the root cause was public SWM metadata amplification.
+
+## New Model
+
+New SWM writes store compact share-operation metadata:
+
+- context graph id
+- optional subgraph name
+- share operation id
+- root entities
+- publisher peer id
+- published timestamp
+
+The public payload is not serialized into metadata. Resolution reconstructs the
+operation payload by reading the current SWM graph for the operation roots.
+
+```mermaid
+flowchart TD
+  A["Client writes public SWM quads"] --> B["Store quads in SWM graph"]
+  A --> C["Generate compact metadata"]
+  C --> D["dkg:shareOperationId"]
+  C --> E["dkg:rootEntity"]
+  C --> F["dkg:publisherPeerId"]
+  C --> G["dkg:publishedAt"]
+  C --> H["dkg:contextGraphId"]
+  C --> I["optional dkg:subGraphName"]
+  B --> J["Single payload copy in Oxigraph"]
+  D --> K["Small operation reference metadata"]
+  E --> K
+  F --> K
+  G --> K
+  H --> K
+  I --> K
+```
+
+## Write Path
+
+The SWM write path still persists and gossips the public payload normally. The
+change is only in the metadata generated for the operation.
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant API as DKG API
+  participant Publisher as DKGPublisher
+  participant Store as Triple Store
+  participant Gossip as SWM Gossip
+
+  Client->>API: POST /api/shared-memory/write
+  API->>Publisher: share(contextGraphId, quads, subGraphName?)
+  Publisher->>Store: store public quads in SWM graph
+  Publisher->>Store: store compact share metadata
+  Publisher->>Gossip: broadcast SWM operation
+  Gossip-->>API: operation propagated to peers
+  API-->>Client: shareOperationId
+```
+
+The important behavior change is this:
+
+```text
+New writes no longer emit:
+  <share-operation> dkg:publicStagedQuads "<serialized full payload>"
+```
+
+Instead they emit compact metadata that points to roots already present in the
+SWM data graph.
+
+## Resolution Path
+
+Lift/share resolution now resolves the public payload from the graph itself
+when compact metadata is present.
+
+```mermaid
+flowchart TD
+  A["Lift request contains shareOperationId"] --> B["Read share operation metadata"]
+  B --> C{"Legacy dkg:publicStagedQuads present?"}
+  C -->|Yes| D["Parse legacy serialized quad snapshot"]
+  C -->|No| E["Read root entities from metadata"]
+  E --> F["Query current SWM graph for those roots"]
+  F --> G["Return public quads for operation"]
+  D --> G
+  G --> H["Build lift request payload"]
+```
+
+For compact metadata, the resolver validates the operation roots and then reads
+the public quads from the current SWM graph. This keeps new writes small while
+preserving the ability to lift and publish shared-memory content.
+
+## Legacy Compatibility
+
+Existing stores may already contain `dkg:publicStagedQuads`. Those records still
+work. The compatibility rule is:
+
+```mermaid
+flowchart LR
+  A["Existing metadata record"] --> B{"Has dkg:publicStagedQuads?"}
+  B -->|Yes| C["Use legacy serialized snapshot"]
+  B -->|No| D["Use compact root metadata"]
+  C --> E["Resolved public quads"]
+  D --> E
+```
+
+This means the fix is forward-looking for new writes, while old metadata remains
+readable and does not need a migration before use.
+
+## Benchmark
+
+This PR adds a reusable live benchmark:
+
+```bash
+pnpm bench:swm-large-payload -- \
+  --ports 19101,19102,19103,19104,19105 \
+  --payload-mib-per-node 100 \
+  --chunk-mib 0.5 \
+  --output bench/results/swm-large-payload-500mib.json
+```
+
+The benchmark:
+
+1. Writes large public SWM literals through each configured node.
+2. Polls every node until all benchmark payloads are queryable.
+3. Checks per-run metadata for `shareOperationId`, `rootEntity`,
+   `publisherPeerId`, and `publishedAt`.
+4. Verifies `dkg:publicStagedQuads` did not grow.
+5. Optionally scans appended daemon logs for known Oxigraph and GossipSub
+   failure signatures.
+
+```mermaid
+sequenceDiagram
+  participant Bench as Benchmark
+  participant N1 as Node 1
+  participant N2 as Node 2
+  participant N3 as Node 3
+  participant N4 as Node 4
+  participant N5 as Node 5
+
+  Bench->>N1: write 100 MiB in chunks
+  Bench->>N2: write 100 MiB in chunks
+  Bench->>N3: write 100 MiB in chunks
+  Bench->>N4: write 100 MiB in chunks
+  Bench->>N5: write 100 MiB in chunks
+
+  N1-->>N2: gossip SWM operations
+  N1-->>N3: gossip SWM operations
+  N2-->>N4: gossip SWM operations
+  N3-->>N5: gossip SWM operations
+  N4-->>N1: gossip SWM operations
+  N5-->>N2: gossip SWM operations
+
+  loop Until every node converges
+    Bench->>N1: count benchmark payloads
+    Bench->>N2: count benchmark payloads
+    Bench->>N3: count benchmark payloads
+    Bench->>N4: count benchmark payloads
+    Bench->>N5: count benchmark payloads
+  end
+
+  Bench->>N1: verify compact metadata
+  Bench->>N2: verify compact metadata
+  Bench->>N3: verify compact metadata
+  Bench->>N4: verify compact metadata
+  Bench->>N5: verify compact metadata
+```
+
+The reproduced 5-node regression case used `5 x 100 MiB = 500 MiB` total. With
+the compact metadata model, all five nodes converged with:
+
+```text
+payload quads:        1000 per node
+dkg:publicStagedQuads: 0 per node
+shareOperationIds:    1000 per node
+rootEntities:         1000 per node
+```
+
+No Oxigraph failure signatures were observed:
+
+```text
+RuntimeError: unreachable
+table index is out of bounds
+```
+
+## Files Changed
+
+- `packages/publisher/src/workspace-resolution.ts`
+  - Stops writing new full-payload `dkg:publicStagedQuads` metadata snapshots.
+  - Resolves compact share operations by reading root-scoped public quads from
+    the SWM graph.
+  - Keeps legacy snapshot reads for existing metadata.
+
+- `packages/publisher/src/metadata.ts`
+  - Extends share metadata with compact operation fields.
+  - Emits `dkg:publishedAt`, `dkg:shareOperationId`, `dkg:rootEntity`,
+    `dkg:publisherPeerId`, `dkg:contextGraphId`, and optional
+    `dkg:subGraphName`.
+
+- `packages/publisher/src/dkg-publisher.ts`
+  - Routes SWM share metadata generation through the compact metadata helper.
+
+- `packages/publisher/src/workspace-handler.ts`
+  - Applies the same compact metadata model for received SWM operations.
+
+- `packages/publisher/test/async-lift-workspace.test.ts`
+  - Covers compact share-operation resolution.
+  - Covers legacy `dkg:publicStagedQuads` compatibility.
+  - Covers large literal writes without metadata payload duplication.
+
+- `packages/publisher/test/metadata.test.ts`
+  - Covers the new compact share metadata shape.
+
+- `packages/cli/scripts/swm-large-payload-benchmark.cjs`
+  - Adds the reusable live multi-node SWM payload benchmark.
+
+- `packages/cli/test/swm-large-payload-benchmark.test.ts`
+  - Covers benchmark argument parsing, chunk planning, and generated payload
+    sizing.
+
+- `packages/cli/README.md`
+  - Documents the benchmark and the 5-node 500 MiB regression command.
+
+## Validation
+
+Focused validation run for this change:
+
+```bash
+pnpm --filter @origintrail-official/dkg exec vitest run test/swm-large-payload-benchmark.test.ts
+```
+
+Additional validation performed during the fix:
+
+```bash
+git diff --check
+```
+
+Live benchmark validation:
+
+```bash
+pnpm bench:swm-large-payload -- \
+  --ports 19101,19102,19103,19104,19105 \
+  --payload-mib-per-node 100 \
+  --chunk-mib 0.5 \
+  --auth-token <token> \
+  --output bench/results/swm-large-payload-500mib.json
+```
+
+The full 500 MiB run verified that each node could query all benchmark payloads
+and that `dkg:publicStagedQuads` remained at zero for the new writes.

--- a/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
+++ b/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
@@ -1,17 +1,36 @@
 # Fix SWM Large Payload Storage Amplification
 
-## Summary
+## PR Summary
 
-This change fixes Shared Working Memory large-payload storage amplification.
-Before this fix, each public SWM payload was stored twice per node:
+This PR fixes the Shared Working Memory large-payload failure mode by removing
+the two places where public SWM bytes were forced into Oxigraph WASM memory:
 
-1. Once as normal RDF quads in the SWM data graph.
-2. Again as a JSON-stringified RDF literal in SWM metadata through
-   `dkg:publicStagedQuads`.
+1. New share-operation metadata no longer stores full public quads as
+   JSON-stringified `dkg:publicStagedQuads` literals.
+2. Large public SWM literal object terms are stored out of line as
+   content-addressed blob files, with only a small typed placeholder in
+   Oxigraph.
 
-For large replicated writes this doubled the effective Oxigraph payload and
-pushed the WASM store into memory failures. In the reproduced benchmark, the
-duplicated path failed around `202.5 MiB/store` with:
+The public SWM API surface stays the same. `/api/shared-memory/write`,
+`/api/shared-memory/publish`, `/api/publisher/enqueue`, SWM gossip, lift
+resolution, and publish-from-SWM callers still send and receive normal RDF
+quads. The storage wrapper externalizes large literal bytes at the local
+persistence boundary and hydrates them back on query/lift results.
+
+Legacy metadata records that already contain `dkg:publicStagedQuads` remain
+readable, but new metadata writes use compact immutable fingerprints.
+
+## Root Cause
+
+Before this change, a public SWM write stored large payload bytes twice per
+node:
+
+- once as normal RDF quads in the SWM graph;
+- once again as a JSON string literal in SWM metadata through
+  `dkg:publicStagedQuads`.
+
+That doubled the effective Oxigraph payload. The reproduced public-SWM
+benchmark failed before private mode or Sender Key encryption started:
 
 ```text
 RuntimeError: unreachable
@@ -24,85 +43,120 @@ After that failure, later queries could also fail with:
 table index is out of bounds
 ```
 
-The fix has two layers:
-
-1. Full-payload metadata snapshots are replaced by compact immutable
-   share-operation metadata and per-root public quad fingerprints.
-2. Large public SWM literal object terms are externalized into
-   content-addressed blob files, leaving only a small placeholder literal in
-   Oxigraph.
-
-New SWM writes no longer serialize public payloads into
-`dkg:publicStagedQuads`, and persistent nodes no longer ask Oxigraph WASM to
-hold large literal bytes directly. Legacy metadata records that already contain
-`dkg:publicStagedQuads` remain readable.
-
-## Problem
-
-The old SWM share path made metadata carry the entire public payload:
+The failing path was therefore public SWM payload amplification, not encryption.
 
 ```mermaid
 flowchart TD
-  A["Client writes public SWM quads"] --> B["Store quads in SWM graph"]
-  A --> C["Serialize same quads as JSON"]
-  C --> D["Store JSON string as dkg:publicStagedQuads literal"]
-  B --> E["Oxigraph stores payload copy 1"]
-  D --> F["Oxigraph stores payload copy 2"]
-  E --> G["Large payload memory pressure"]
+  A["Client writes public SWM quads"] --> B["SWM data graph"]
+  A --> C["JSON.stringify(public quads)"]
+  C --> D["dkg:publicStagedQuads metadata literal"]
+  B --> E["Oxigraph payload copy 1"]
+  D --> F["Oxigraph payload copy 2"]
+  E --> G["WASM memory pressure"]
   F --> G
+  G --> H["RuntimeError: unreachable"]
 ```
 
-That metadata snapshot was useful for later lift/share resolution, but it made
-the storage model scale with approximately `2x payload size` per node. The
-failure was reproduced without private mode and without Sender Key encryption,
-so the root cause was public SWM metadata amplification.
+## New Storage Model
 
-## New Model
+New writes split operation identity from payload bytes:
 
-New SWM writes store compact share-operation metadata:
-
-- context graph id
-- optional subgraph name
-- share operation id
-- root entities
-- publisher peer id
-- published timestamp
-- public quad digest and count for each root
-
-The public payload is not serialized into metadata. Resolution reconstructs and
-validates the operation payload by reading the current SWM graph for the
-operation roots, then comparing the hydrated quads to the stored digest/count.
+- SWM metadata stores operation references and immutable fingerprints.
+- SWM graph data stores normal quads.
+- A per-operation public snapshot graph stores the immutable public slice for
+  async lift/publish resolution.
+- Large SWM literal bytes are externalized into `<dataDir>/literal-blobs`.
+- Query and lift callers receive hydrated RDF literal terms.
 
 ```mermaid
 flowchart TD
-  A["Client writes public SWM quads"] --> B["Store quads in SWM graph"]
-  A --> C["Generate compact metadata"]
-  B --> L{"Large SWM literal?"}
-  L -->|No| M["Store RDF term inline"]
-  L -->|Yes| N["Write exact RDF object term to literal-blobs/sha256"]
-  N --> O["Store externalLiteralRef placeholder in Oxigraph"]
-  C --> D["dkg:shareOperationId"]
-  C --> E["dkg:rootEntity"]
-  C --> F["dkg:publisherPeerId"]
-  C --> G["dkg:publishedAt"]
-  C --> H["dkg:contextGraphId"]
-  C --> I["optional dkg:subGraphName"]
-  C --> P["dkg:publicQuadsDigest + dkg:publicQuadsCount"]
-  M --> J["Small or normal RDF terms in Oxigraph"]
-  O --> J
-  D --> K["Small operation reference metadata"]
-  E --> K
-  F --> K
-  G --> K
-  H --> K
-  I --> K
-  P --> K
+  A["Public SWM write"] --> B["Normalize operation roots"]
+  A --> C["Insert public quads into live SWM graph"]
+  A --> P["Insert root-scoped quads into immutable snapshot graph"]
+  B --> D["Write compact metadata"]
+  C --> E{"Literal object term > threshold and graph ends /_shared_memory?"}
+  P --> E
+  E -->|No| F["Store term inline in Oxigraph"]
+  E -->|Yes| G["sha256(exact RDF object term)"]
+  G --> H["Write blob file"]
+  H --> I["Store externalLiteralRef placeholder in Oxigraph"]
+  D --> J["shareOperationId"]
+  D --> K["rootEntity"]
+  D --> L["publisherPeerId"]
+  D --> M["publishedAt"]
+  D --> N["contextGraphId and optional subGraphName"]
+  D --> O["publicSnapshotGraph, publicQuadsDigest, publicQuadsCount"]
 ```
 
-## Large Literal Blob Storage
+## Implementation Details
 
-Local Oxigraph-backed agent stores now enable large SWM literal storage by
-default when `dataDir` is configured. The default settings are:
+### Compact Share Metadata
+
+`storeWorkspaceOperationPublicQuads()` now keeps only operation metadata and
+per-root public quad fingerprints. It does not write full serialized payloads
+to `dkg:publicStagedQuads`.
+
+For each share operation, metadata includes:
+
+- `dkg:shareOperationId`
+- `dkg:contextGraphId`
+- `dkg:rootEntity`
+- `prov:wasAttributedTo` publisher peer id
+- `dkg:publishedAt`
+- optional `dkg:subGraphName`
+- per-root `dkg:publicSnapshotGraph`
+- per-root `dkg:publicQuadsDigest`
+- per-root `dkg:publicQuadsCount`
+
+The snapshot graph is an immutable per-operation graph, not a metadata literal.
+The digest is computed over the canonicalized hydrated public quads stored in
+that graph for each root. This keeps the operation selector immutable without
+putting the payload itself into metadata.
+
+### Immutable Snapshot Graphs
+
+The earlier compact-metadata fallback could have selected "whatever the root
+looks like now" if a root changed between the original write and a later async
+lift job. This PR fixes that by storing an immutable per-operation public
+snapshot graph.
+
+For non-legacy compact metadata:
+
+1. Load the operation root metadata for the requested `shareOperationId`.
+2. Read the `dkg:publicSnapshotGraph` for each requested root.
+3. Query that snapshot graph, not the current live SWM root.
+4. Recompute digest and count.
+5. Return the public slice only when digest and count match metadata.
+6. Throw only if snapshot metadata is missing or the snapshot graph is corrupt.
+
+This preserves the old immutable-snapshot semantics. A queued async publish for
+`write1` still resolves the `write1` public slice after the same root is later
+rewritten by `write2`, while the private slice remains keyed by the same
+`shareOperationId`.
+
+```mermaid
+flowchart TD
+  A["Lift request: shareOperationId + roots"] --> B["Read share-operation roots"]
+  B --> C{"Requested roots are part of operation?"}
+  C -->|No| X["Fail: roots not in operation"]
+  C -->|Yes| D{"Legacy publicStagedQuads exists?"}
+  D -->|Yes| E["Parse legacy JSON snapshot"]
+  D -->|No| F["Read snapshot graph + digest/count per root"]
+  F --> G["CONSTRUCT from immutable snapshot graph"]
+  G --> H["Hydrate externalLiteralRef placeholders from blobs"]
+  H --> I["Recompute digest/count"]
+  I --> J{"Matches metadata?"}
+  J -->|No| Y["Fail: missing or corrupt snapshot"]
+  J -->|Yes| K["Return public quads for lift/publish"]
+  E --> K
+```
+
+### Large Literal Blob Store
+
+`SharedMemoryLiteralBlobStore` wraps a normal `TripleStore` and externalizes
+only large RDF literal object terms written to SWM graphs.
+
+Default persistent configuration:
 
 ```ts
 largeLiteralStorage: {
@@ -112,132 +166,347 @@ largeLiteralStorage: {
 }
 ```
 
-Only RDF literal objects written to graphs ending in `/_shared_memory` are
-eligible. Small literals, IRIs, blank nodes, non-SWM graphs, Verified Memory,
-private encrypted staging, and file import blobs stay unchanged.
+Externalization eligibility:
 
-For each large SWM literal, the wrapper computes `sha256` over the exact
-serialized RDF object term string and writes that string to:
+- graph URI must end in `/_shared_memory`;
+- RDF object term must be a serialized literal;
+- serialized UTF-8 term size must be greater than the threshold;
+- the term must not already be an external literal reference.
+
+Blob format:
 
 ```text
 <dataDir>/literal-blobs/<sha256>
 ```
 
-Oxigraph stores this placeholder instead of the full literal bytes:
+The `sha256` is computed over the exact serialized RDF object term string, not
+over a decoded lexical value. Oxigraph stores this compact placeholder:
 
 ```text
 "sha256:<hex>"^^<http://dkg.io/ontology/externalLiteralRef>
 ```
 
-Queries and lift resolution hydrate placeholders after Oxigraph returns
-bindings or constructed quads, so normal callers receive the original RDF
-literal term. Exact large-literal constants in simple `SELECT`, `ASK`, and
-equality-filter queries are also translated to the placeholder form before
-querying. Full SPARQL value semantics for functions over externalized literal
-values are intentionally not promised; those expressions still execute inside
-Oxigraph against the stored placeholder.
+The wrapper verifies existing content-addressed files before reusing them and
+fails loudly on missing or corrupt blobs during hydration.
 
-## Write Path
+### Query Hydration Semantics
 
-The SWM write path still accepts and gossips normal public RDF quads. The
-storage wrapper externalizes large literal bytes at the local persistence
-boundary, and compact metadata records only operation provenance plus
-digest/count fingerprints.
+After `store.query()` returns:
+
+- `SELECT` bindings are hydrated back to the original RDF literal term.
+- `CONSTRUCT` quads are hydrated back to the original RDF literal term.
+- `ASK` results are passed through.
+- deletes passed with the original large literal term are translated to the
+  placeholder before reaching Oxigraph.
+- simple exact large-literal constants in `SELECT`, `ASK`, and equality
+  filters are translated to placeholder form before querying.
+
+This PR does not claim full SPARQL value semantics for externalized large
+literals inside Oxigraph. Functions and filters that execute inside Oxigraph
+over the literal value still operate on the placeholder representation. The
+intended contract is hydrated query/lift results plus exact-match support.
+
+## UML Architecture
+
+```mermaid
+classDiagram
+  direction LR
+
+  class DKGAgent {
+    create(config)
+    share(contextGraphId, quads)
+    publishFromSharedMemory(request)
+  }
+
+  class PublisherRunner {
+    createPublisherStore(dataDir, config)
+    defaultLargeLiteralStorage()
+  }
+
+  class TripleStore {
+    <<interface>>
+    insert()
+    delete()
+    deleteByPattern()
+    query()
+    flush()
+    close()
+  }
+
+  class SharedMemoryLiteralBlobStore {
+    blobDir
+    thresholdBytes
+    insert()
+    delete()
+    query()
+    hydrateQueryResult()
+    rewriteLargeLiteralConstants()
+  }
+
+  class OxigraphStore {
+    insert()
+    query()
+    flush()
+    close()
+  }
+
+  class WorkspaceResolution {
+    storeWorkspaceOperationPublicQuads()
+    resolveLiftWorkspaceSlice()
+    resolveWorkspaceSelection()
+    publicQuadsDigest()
+  }
+
+  class PrivateContentStore {
+    getPrivateTriplesForOperation()
+  }
+
+  class LiteralBlobDirectory {
+    sha256Files
+  }
+
+  DKGAgent --> TripleStore : creates default persistent store
+  PublisherRunner --> TripleStore : creates daemon store
+  SharedMemoryLiteralBlobStore ..|> TripleStore
+  SharedMemoryLiteralBlobStore o-- TripleStore : wraps
+  SharedMemoryLiteralBlobStore --> LiteralBlobDirectory : reads/writes
+  OxigraphStore ..|> TripleStore
+  WorkspaceResolution --> TripleStore : metadata and SWM graph queries
+  WorkspaceResolution --> PrivateContentStore : private slice lookup
+```
+
+## Write Sequence
 
 ```mermaid
 sequenceDiagram
   participant Client
   participant API as DKG API
   participant Publisher as DKGPublisher
-  participant Store as Triple Store
+  participant Resolution as WorkspaceResolution
+  participant Store as SharedMemoryLiteralBlobStore
+  participant Inner as Oxigraph
+  participant Blobs as literal-blobs
   participant Gossip as SWM Gossip
 
   Client->>API: POST /api/shared-memory/write
-  API->>Publisher: share(contextGraphId, quads, subGraphName?)
-  Publisher->>Store: store public quads in SWM graph
-  Store->>Store: externalize large SWM literals to literal-blobs
-  Publisher->>Store: store compact share metadata
-  Publisher->>Gossip: broadcast SWM operation
-  Gossip-->>API: operation propagated to peers
+  API->>Publisher: writeToWorkspace(contextGraphId, quads)
+  Publisher->>Store: insert public SWM quads
+  loop Each quad
+    Store->>Store: check graph suffix, literal type, byte threshold
+    alt Large SWM literal
+      Store->>Blobs: write exact RDF object term by sha256
+      Store->>Inner: insert externalLiteralRef placeholder
+    else Small, non-literal, or non-SWM
+      Store->>Inner: insert original term
+    end
+  end
+  Publisher->>Resolution: storeWorkspaceOperationPublicQuads()
+  Resolution->>Store: insert root-scoped immutable snapshot graph
+  Store->>Blobs: externalize large snapshot literals by same sha256
+  Resolution->>Store: insert compact metadata with snapshot graph and digest/count
+  Store->>Inner: store compact metadata inline
+  Publisher->>Gossip: broadcast normal SWM operation
   API-->>Client: shareOperationId
 ```
 
-The important behavior change is this:
-
-```text
-New writes no longer emit:
-  <share-operation> dkg:publicStagedQuads "<serialized full payload>"
-```
-
-Instead they emit compact metadata that points to roots already present in the
-SWM data graph and records immutable digest/count fingerprints for stale-write
-detection.
-
-## Resolution Path
-
-Lift/share resolution now resolves the public payload from the graph itself
-when compact metadata is present.
+## Receive And Replication Sequence
 
 ```mermaid
-flowchart TD
-  A["Lift request contains shareOperationId"] --> B["Read share operation metadata"]
-  B --> C{"Legacy dkg:publicStagedQuads present?"}
-  C -->|Yes| D["Parse legacy serialized quad snapshot"]
-  C -->|No| E["Read root entities from metadata"]
-  E --> F["Query current SWM graph for those roots"]
-  F --> I["Hydrate externalLiteralRef placeholders from blobs"]
-  I --> J["Compare hydrated digest/count with metadata"]
-  J --> G["Return public quads for operation"]
-  D --> G
-  G --> H["Build lift request payload"]
+sequenceDiagram
+  participant Sender as Sender Node
+  participant Gossip as GossipSub
+  participant Receiver as Receiver Node
+  participant Handler as WorkspaceHandler
+  participant Store as SharedMemoryLiteralBlobStore
+  participant Blobs as literal-blobs
+  participant Meta as SWM Metadata Graph
+
+  Sender->>Gossip: SWM operation with normal public quads
+  Gossip->>Receiver: deliver operation
+  Receiver->>Handler: validate sender and operation envelope
+  Handler->>Store: insert received public quads
+  Store->>Blobs: externalize large SWM literal terms
+  Store->>Store: insert placeholders into SWM graph
+  Handler->>Meta: write compact share-operation metadata
+  Handler-->>Receiver: operation available for query/lift
 ```
 
-For compact metadata, the resolver validates the operation roots and then reads
-hydrated public quads from the current SWM graph. If the current root slice no
-longer matches the stored digest/count, resolution fails instead of silently
-publishing a mismatched public/private asset.
+## Query Hydration Sequence
+
+```mermaid
+sequenceDiagram
+  participant Caller
+  participant Store as SharedMemoryLiteralBlobStore
+  participant Inner as Oxigraph
+  participant Blobs as literal-blobs
+
+  Caller->>Store: query(SPARQL)
+  Store->>Store: rewrite exact large literal constants when possible
+  Store->>Inner: query(original and/or rewritten SPARQL)
+  Inner-->>Store: bindings or constructed quads with placeholders
+  loop Each returned term
+    alt externalLiteralRef placeholder
+      Store->>Blobs: read sha256 blob
+      Store->>Store: verify sha256(content)
+      Store-->>Store: replace placeholder with original RDF literal term
+    else normal term
+      Store-->>Store: keep term
+    end
+  end
+  Store-->>Caller: hydrated result
+```
+
+## Lift / Publish Resolution Sequence
+
+```mermaid
+sequenceDiagram
+  participant Job as Async Lift Job
+  participant Resolution as WorkspaceResolution
+  participant Store as TripleStore
+  participant Snapshot as Snapshot Graph
+  participant Meta as SWM Meta Graph
+  participant Private as PrivateContentStore
+  participant Publisher as Publish Pipeline
+
+  Job->>Resolution: resolveLiftWorkspaceSlice(request)
+  Resolution->>Meta: read share-operation roots and publisherPeerId
+  Resolution->>Meta: check legacy dkg:publicStagedQuads
+  alt Legacy snapshot present
+    Meta-->>Resolution: serialized public quads
+    Resolution->>Resolution: parse legacy payload
+  else Compact metadata
+    Meta-->>Resolution: snapshot graph + digest/count per requested root
+    Resolution->>Snapshot: CONSTRUCT immutable per-operation public quads
+    Snapshot-->>Resolution: hydrated public quads
+    Resolution->>Resolution: recompute digest/count
+    alt digest/count mismatch
+      Resolution-->>Job: fail missing or corrupt snapshot
+    else matches
+      Resolution-->>Resolution: accept public slice
+    end
+  end
+  Resolution->>Private: getPrivateTriplesForOperation()
+  Private-->>Resolution: private slice for same shareOperationId
+  Resolution-->>Publisher: public slice + private slice + publisher identity
+```
 
 ## Legacy Compatibility
 
-Existing stores may already contain `dkg:publicStagedQuads`. Those records still
-work. The compatibility rule is:
+Existing stores may already contain full serialized public snapshots. Those are
+still supported:
 
 ```mermaid
 flowchart LR
-  A["Existing metadata record"] --> B{"Has dkg:publicStagedQuads?"}
-  B -->|Yes| C["Use legacy serialized snapshot"]
+  A["Metadata for shareOperationId"] --> B{"Has dkg:publicStagedQuads?"}
+  B -->|Yes| C["Parse JSON serialized public quads"]
   B -->|No| D["Use compact root metadata"]
-  C --> E["Resolved public quads"]
-  D --> E
+  D --> E["Read hydrated snapshot graph slice"]
+  E --> F["Validate digest/count"]
+  C --> G["Resolved public quads"]
+  F --> G
 ```
 
-This means the fix is forward-looking for new writes, while old metadata remains
-readable and does not need a migration before use.
+This is intentionally asymmetric:
 
-## Benchmark
+- old metadata remains readable;
+- new writes never create large `dkg:publicStagedQuads` snapshots.
 
-This PR adds a reusable live benchmark:
+## Files Changed
+
+- `packages/publisher/src/workspace-resolution.ts`
+  - Replaces full-payload metadata writes with compact operation metadata.
+  - Stores per-root public quad digest/count fingerprints.
+  - Stores immutable per-operation public snapshot graphs for async lift
+    resolution.
+  - Keeps legacy `dkg:publicStagedQuads` reads.
+  - Avoids falling back to live SWM root state when snapshot metadata is
+    missing.
+
+- `packages/publisher/src/metadata.ts`
+  - Emits compact share-operation fields used by lift resolution.
+
+- `packages/publisher/src/dkg-publisher.ts`
+  - Routes local SWM writes through compact metadata persistence.
+
+- `packages/publisher/src/workspace-handler.ts`
+  - Applies the same compact metadata model for received SWM operations.
+
+- `packages/storage/src/shared-memory-literal-blob-store.ts`
+  - Adds content-addressed large SWM literal externalization.
+  - Hydrates `SELECT` bindings and `CONSTRUCT` quads.
+  - Translates deletes and exact large-literal constants.
+  - Verifies missing/corrupt blob files.
+
+- `packages/storage/src/triple-store.ts`
+  - Adds `largeLiteralStorage` to `TripleStoreConfig`.
+  - Wraps configured local stores with `SharedMemoryLiteralBlobStore`.
+
+- `packages/agent/src/dkg-agent.ts`
+  - Enables default large literal storage for persistent local Oxigraph stores
+    created with `DKGAgent.create({ dataDir })`.
+
+- `packages/cli/src/config.ts`
+  - Adds the daemon config surface for `largeLiteralStorage`.
+
+- `packages/cli/src/publisher-runner.ts`
+  - Enables default large literal storage for persistent daemon stores.
+
+- `packages/cli/scripts/swm-large-payload-benchmark.cjs`
+  - Adds/updates the reusable live multi-node SWM payload benchmark.
+  - Uses count queries for convergence and one hydrated sample literal per node
+    instead of pulling the whole payload into memory.
+  - Checks `dkg:publicStagedQuads` on both operation metadata subjects
+    (`dkg:rootEntity`) and per-root slice metadata subjects
+    (`dkg:publicSliceRootEntity`) so a regression on
+    `urn:dkg:public-stage:*` records is not missed.
+
+- Tests:
+  - `packages/storage/test/external-literal-store.test.ts`
+  - `packages/publisher/test/async-lift-workspace.test.ts`
+  - `packages/agent/test/large-literal-storage.test.ts`
+  - `packages/cli/test/swm-large-payload-benchmark.test.ts`
+
+## Test Coverage
+
+Focused tests cover:
+
+- large SWM literals are externalized;
+- small literals stay inline;
+- non-SWM graph literals stay inline;
+- `SELECT` hydration returns the original literal term;
+- `CONSTRUCT` hydration returns original quads;
+- exact large literal constants work for simple matching;
+- deletes work when passed the original large literal term;
+- reopening a persistent store hydrates from existing blobs;
+- missing/corrupt blob files fail loudly;
+- compact metadata does not contain serialized public payloads;
+- share-operation resolution returns expected hydrated quads;
+- superseded share operations resolve from immutable public snapshots;
+- compact metadata without a snapshot graph does not fall back to live SWM;
+- legacy `dkg:publicStagedQuads` metadata remains readable;
+- compact digest/count detects missing or corrupt immutable snapshots;
+- the benchmark detects per-run `dkg:publicStagedQuads` on public slice
+  metadata subjects;
+- persistent `DKGAgent.create({ dataDir })` uses literal blob storage by
+  default.
+
+Focused validation commands:
 
 ```bash
-pnpm bench:swm-large-payload -- \
-  --ports 19101,19102,19103,19104,19105 \
-  --payload-mib-per-node 204.8 \
-  --chunk-mib 0.5 \
-  --write-concurrency 5 \
-  --output bench/results/swm-large-payload-1gib.json
+pnpm --filter @origintrail-official/dkg-storage exec vitest run test/storage.test.ts test/external-literal-store.test.ts
+pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/async-lift-workspace.test.ts
+pnpm --filter @origintrail-official/dkg exec vitest run test/swm-large-payload-benchmark.test.ts
+pnpm --filter @origintrail-official/dkg-agent exec vitest run test/large-literal-storage.test.ts
+pnpm --filter @origintrail-official/dkg-storage build
+pnpm --filter @origintrail-official/dkg-publisher build
+git diff --check
 ```
 
-The benchmark:
+## Live Benchmark
 
-1. Writes large public SWM literals through each configured node.
-2. Polls every node until all benchmark payloads are queryable.
-3. Checks per-run metadata for `shareOperationId`, `rootEntity`,
-   `publisherPeerId`, and `publishedAt`.
-4. Verifies `dkg:publicStagedQuads` did not grow.
-5. Selects one sample payload literal per node to prove hydration returns the
-   original payload bytes.
-6. Optionally scans appended daemon logs for known Oxigraph and GossipSub
-   failure signatures.
+The reusable benchmark writes large public SWM literals through each configured
+node, waits for all nodes to converge, validates compact metadata, hydrates one
+sample literal per node, and scans daemon logs for known failure signatures.
 
 ```mermaid
 sequenceDiagram
@@ -248,148 +517,119 @@ sequenceDiagram
   participant N4 as Node 4
   participant N5 as Node 5
 
-  Bench->>N1: write 204.8 MiB in chunks
-  Bench->>N2: write 204.8 MiB in chunks
-  Bench->>N3: write 204.8 MiB in chunks
-  Bench->>N4: write 204.8 MiB in chunks
-  Bench->>N5: write 204.8 MiB in chunks
-
-  N1-->>N2: gossip SWM operations
-  N1-->>N3: gossip SWM operations
-  N2-->>N4: gossip SWM operations
-  N3-->>N5: gossip SWM operations
-  N4-->>N1: gossip SWM operations
-  N5-->>N2: gossip SWM operations
-
-  loop Until every node converges
-    Bench->>N1: count benchmark payloads
-    Bench->>N2: count benchmark payloads
-    Bench->>N3: count benchmark payloads
-    Bench->>N4: count benchmark payloads
-    Bench->>N5: count benchmark payloads
+  par Concurrent writes
+    Bench->>N1: write chunks
+    Bench->>N2: write chunks
+    Bench->>N3: write chunks
+    Bench->>N4: write chunks
+    Bench->>N5: write chunks
   end
 
-  Bench->>N1: verify compact metadata
-  Bench->>N2: verify compact metadata
-  Bench->>N3: verify compact metadata
-  Bench->>N4: verify compact metadata
-  Bench->>N5: verify compact metadata
-  Bench->>N1: select one hydrated sample literal
-  Bench->>N2: select one hydrated sample literal
-  Bench->>N3: select one hydrated sample literal
-  Bench->>N4: select one hydrated sample literal
-  Bench->>N5: select one hydrated sample literal
+  N1-->>N2: SWM gossip
+  N2-->>N3: SWM gossip
+  N3-->>N4: SWM gossip
+  N4-->>N5: SWM gossip
+  N5-->>N1: SWM gossip
+
+  loop Until every node has every chunk
+    Bench->>N1: COUNT benchmark payloads
+    Bench->>N2: COUNT benchmark payloads
+    Bench->>N3: COUNT benchmark payloads
+    Bench->>N4: COUNT benchmark payloads
+    Bench->>N5: COUNT benchmark payloads
+  end
+
+  Bench->>N1: verify metadata and hydrated sample
+  Bench->>N2: verify metadata and hydrated sample
+  Bench->>N3: verify metadata and hydrated sample
+  Bench->>N4: verify metadata and hydrated sample
+  Bench->>N5: verify metadata and hydrated sample
+  Bench->>Bench: scan daemon logs
 ```
 
-The 1 GiB target case uses `5 x 204.8 MiB = 1024 MiB` total. Acceptance is:
+### 1 GiB Total Regression Run
+
+```bash
+pnpm bench:swm-large-payload \
+  --ports 19101,19102,19103,19104,19105 \
+  --payload-mib-per-node 204.8 \
+  --chunk-mib 0.5 \
+  --write-concurrency 5 \
+  --output bench/results/swm-large-payload-1gib.json
+```
+
+This validates the original target shape: `5 x 204.8 MiB = 1024 MiB` total.
+
+### 1 GiB Per Node Verification
+
+The larger verification requested after the implementation used:
+
+```bash
+pnpm bench:swm-large-payload \
+  --ports 20101,20102,20103,20104,20105 \
+  --payload-mib-per-node 1024 \
+  --chunk-mib 0.5 \
+  --write-concurrency 5 \
+  --replication-timeout-ms 1200000 \
+  --devnet-dir /private/tmp/dkg-v9-swm-1gib-devnet-5g \
+  --auth-token <token> \
+  --output bench/results/swm-large-payload-5gib.json
+```
+
+Result:
 
 ```text
-payload quads:        all benchmark chunks on every node
-dkg:publicStagedQuads: 0 per node
-shareOperationIds:    one per benchmark write
-rootEntities:         one per benchmark write
-sample literal bytes: expected chunk payload size on every node
+ok: true
+nodes: 5
+payloadMiBPerNode: 1024
+totalPayloadMiB: 5120
+totalOperations: 10240
+chunkMiB: 0.5
+replication: converged
+counts: 10240 on every node
+publicStagedQuadsForRun: 0 on every node
+publicStagedQuadsGlobalDelta: 0 on every node
+samplePayloadBytes: 524288 on every node
+logMatches: 0
 ```
 
-No Oxigraph failure signatures were observed:
+No daemon log matches were found for:
 
 ```text
 RuntimeError: unreachable
 table index is out of bounds
 ```
 
-## Files Changed
+Benchmark artifact:
 
-- `packages/publisher/src/workspace-resolution.ts`
-  - Stops writing new full-payload `dkg:publicStagedQuads` metadata snapshots.
-  - Resolves compact share operations by reading root-scoped public quads from
-    the SWM graph.
-  - Keeps legacy snapshot reads for existing metadata.
-
-- `packages/publisher/src/metadata.ts`
-  - Extends share metadata with compact operation fields.
-  - Emits `dkg:publishedAt`, `dkg:shareOperationId`, `dkg:rootEntity`,
-    `dkg:publisherPeerId`, `dkg:contextGraphId`, and optional
-    `dkg:subGraphName`.
-
-- `packages/publisher/src/dkg-publisher.ts`
-  - Routes SWM share metadata generation through the compact metadata helper.
-
-- `packages/publisher/src/workspace-handler.ts`
-  - Applies the same compact metadata model for received SWM operations.
-
-- `packages/publisher/test/async-lift-workspace.test.ts`
-  - Covers compact share-operation resolution.
-  - Covers legacy `dkg:publicStagedQuads` compatibility.
-  - Covers large literal writes without metadata payload duplication.
-  - Covers compact digest/count resolution over hydrated external SWM literals.
-
-- `packages/publisher/test/metadata.test.ts`
-  - Covers the new compact share metadata shape.
-
-- `packages/storage/src/shared-memory-literal-blob-store.ts`
-  - Adds the content-addressed large SWM literal blob wrapper.
-  - Hydrates `SELECT` bindings and `CONSTRUCT` quads back to the original RDF
-    literal term.
-  - Translates deletes and exact large-literal query constants to the
-    placeholder representation.
-
-- `packages/storage/src/triple-store.ts`
-  - Adds the `largeLiteralStorage` configuration surface.
-
-- `packages/storage/test/external-literal-store.test.ts`
-  - Covers externalization, hydration, exact literal matching, deletes,
-    corrupt/missing blob failures, and reopen-from-disk behavior.
-
-- `packages/agent/src/dkg-agent.ts`
-  - Enables large SWM literal storage by default for local Oxigraph-backed
-    `DKGAgent.create({ dataDir })` stores.
-
-- `packages/agent/test/large-literal-storage.test.ts`
-  - Covers the default persistent agent store wiring.
-
-- `packages/cli/scripts/swm-large-payload-benchmark.cjs`
-  - Adds the reusable live multi-node SWM payload benchmark.
-  - Uses hydrated sample literal selection instead of `STRLEN(STR(?o))`, so
-    count queries remain cheap and sample checks exercise blob hydration.
-
-- `packages/cli/test/swm-large-payload-benchmark.test.ts`
-  - Covers benchmark argument parsing, chunk planning, and generated payload
-    sizing.
-
-- `packages/cli/README.md`
-  - Documents the benchmark and the 5-node 500 MiB regression command.
-
-## Validation
-
-Focused validation run for this change:
-
-```bash
-pnpm --filter @origintrail-official/dkg exec vitest run test/swm-large-payload-benchmark.test.ts
-pnpm --filter @origintrail-official/dkg-storage exec vitest run test/storage.test.ts test/external-literal-store.test.ts
-pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/async-lift-workspace.test.ts
-pnpm --filter @origintrail-official/dkg-agent exec vitest run test/large-literal-storage.test.ts
+```text
+bench/results/swm-large-payload-5gib.json
 ```
 
-Additional validation performed during the fix:
+## Operational Notes
 
-```bash
-git diff --check
-```
+- Default externalization is enabled for persistent local Oxigraph/worker
+  stores when `dataDir` is available.
+- Explicit stores supplied by callers are respected.
+- Normal data graphs, Verified Memory, private encrypted staging, and file
+  import blobs are not changed by this wrapper.
+- Garbage collection for orphaned blob files is intentionally out of scope for
+  this first pass.
+- Content-addressed blob files make duplicate literal writes cheap because the
+  same exact RDF object term maps to the same file.
+- The query contract is hydrated results, not full in-engine SPARQL value
+  semantics over externalized literal bytes.
 
-Live benchmark validation:
+## Reviewer Checklist
 
-```bash
-pnpm bench:swm-large-payload -- \
-  --ports 19101,19102,19103,19104,19105 \
-  --payload-mib-per-node 204.8 \
-  --chunk-mib 0.5 \
-  --write-concurrency 5 \
-  --auth-token <token> \
-  --output bench/results/swm-large-payload-1gib.json
-```
-
-The live 1 GiB run should verify that each node converges, hydrated sample
-literals match the expected chunk size, `dkg:publicStagedQuads` remains zero,
-and the logs contain no `RuntimeError: unreachable` or
-`table index is out of bounds`.
+- Confirm new metadata writes do not contain serialized public payload literals.
+- Confirm legacy `dkg:publicStagedQuads` reads still work.
+- Confirm older queued async lift/publish jobs resolve from immutable snapshot
+  graphs after the live root is rewritten.
+- Confirm compact metadata without snapshot graph does not fall back to live
+  SWM root state.
+- Confirm large SWM literals are externalized only for `/_shared_memory`
+  graphs.
+- Confirm query/lift callers receive hydrated RDF literal terms.
+- Confirm the 5-node `1024 MiB/node` benchmark artifact remains clean:
+  convergence true, metadata amplification zero, and no Oxigraph failure logs.

--- a/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
+++ b/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
@@ -466,6 +466,9 @@ This is intentionally asymmetric:
     `--target-gib-per-node 1`.
   - Uses count queries and one sample triple per node so verification does not
     pull the full graph back into the client.
+  - Records interval throughput, latency percentiles, node store/log/process
+    diagnostics, and daemon-log counters; writes a Markdown throughput analysis
+    next to the JSON report for diagnosing slowdown causes.
 
 - Tests:
   - `packages/storage/test/external-literal-store.test.ts`

--- a/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
+++ b/docs/SWM_LARGE_PAYLOAD_STORAGE_AMPLIFICATION_PR.md
@@ -460,11 +460,19 @@ This is intentionally asymmetric:
     (`dkg:publicSliceRootEntity`) so a regression on
     `urn:dkg:public-stage:*` records is not missed.
 
+- `packages/cli/scripts/swm-triple-volume-benchmark.cjs`
+  - Adds a separate live multi-node benchmark for many-small-triple SWM scale.
+  - Targets estimated serialized N-Quad bytes per node, for example
+    `--target-gib-per-node 1`.
+  - Uses count queries and one sample triple per node so verification does not
+    pull the full graph back into the client.
+
 - Tests:
   - `packages/storage/test/external-literal-store.test.ts`
   - `packages/publisher/test/async-lift-workspace.test.ts`
   - `packages/agent/test/large-literal-storage.test.ts`
   - `packages/cli/test/swm-large-payload-benchmark.test.ts`
+  - `packages/cli/test/swm-triple-volume-benchmark.test.ts`
 
 ## Test Coverage
 
@@ -496,6 +504,7 @@ Focused validation commands:
 pnpm --filter @origintrail-official/dkg-storage exec vitest run test/storage.test.ts test/external-literal-store.test.ts
 pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/async-lift-workspace.test.ts
 pnpm --filter @origintrail-official/dkg exec vitest run test/swm-large-payload-benchmark.test.ts
+pnpm --filter @origintrail-official/dkg exec vitest run test/swm-triple-volume-benchmark.test.ts
 pnpm --filter @origintrail-official/dkg-agent exec vitest run test/large-literal-storage.test.ts
 pnpm --filter @origintrail-official/dkg-storage build
 pnpm --filter @origintrail-official/dkg-publisher build

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bench:html": "ESBENCH_HTML=1 ESBENCH_PUBLISH_ASYNC_GET_HTML=1 esbench --config esbench.config.mjs",
     "bench:analysis": "node --experimental-strip-types bench/analyze-publish-async-get.ts",
     "bench:profile": "node bench/profile-publish-async-get.mjs",
+    "bench:swm-large-payload": "pnpm --filter @origintrail-official/dkg benchmark:swm-large-payload --",
     "bench:baseline": "ESBENCH_RESULT=bench/results/baseline.json ESBENCH_HTML=1 ESBENCH_HTML_FILE=bench/results/baseline.html esbench --config esbench.config.mjs",
     "bench:compare": "ESBENCH_DIFF=bench/results/baseline.json ESBENCH_RESULT=bench/results/compare.json ESBENCH_HTML=1 ESBENCH_HTML_FILE=bench/results/compare.html esbench --config esbench.config.mjs",
     "lint": "turbo lint",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "bench:analysis": "node --experimental-strip-types bench/analyze-publish-async-get.ts",
     "bench:profile": "node bench/profile-publish-async-get.mjs",
     "bench:swm-large-payload": "pnpm --filter @origintrail-official/dkg benchmark:swm-large-payload --",
+    "bench:swm-triple-volume": "pnpm --filter @origintrail-official/dkg benchmark:swm-triple-volume --",
     "bench:baseline": "ESBENCH_RESULT=bench/results/baseline.json ESBENCH_HTML=1 ESBENCH_HTML_FILE=bench/results/baseline.html esbench --config esbench.config.mjs",
     "bench:compare": "ESBENCH_DIFF=bench/results/baseline.json ESBENCH_RESULT=bench/results/compare.json ESBENCH_HTML=1 ESBENCH_HTML_FILE=bench/results/compare.html esbench --config esbench.config.mjs",
     "lint": "turbo lint",

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -67,11 +67,13 @@ import {
   validateLiftPublishPayload,
   subtractFinalizedExactQuads,
   TripleStoreAsyncLiftPublisher,
+  FileWorkspacePublicSnapshotStore,
   type PublishOptions, type PublishResult, type PhaseCallback, type KAMetadata, type CASCondition,
   type CollectedACK, type LiftAuthorityProof, type LiftTransitionType,
   type LiftRequest, type LiftRequestAuthorSeal,
   type WorkspaceAgentRecipient,
   type WorkspaceSenderKeyEncryptInput,
+  type SharedMemoryPublicSnapshotStorageConfig, type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
 import { join } from 'node:path';
@@ -670,6 +672,10 @@ export interface DKGAgentConfig {
   storeConfig?: TripleStoreConfig;
   /** Out-of-line storage for large public SWM RDF literal object terms. Defaults on for local Oxigraph-backed dataDir stores. */
   largeLiteralStorage?: LargeLiteralStorageConfig;
+  /** Out-of-Oxigraph immutable public SWM operation snapshots. Defaults on when dataDir is set. */
+  sharedMemoryPublicSnapshotStorage?: SharedMemoryPublicSnapshotStorageConfig;
+  /** When false, peer-connect sync skips SWM catch-up and relies on gossip for new SWM writes. */
+  syncSharedMemoryOnConnect?: boolean;
   /** Node deployment tier: 'core' (cloud, relay) or 'edge' (personal, behind NAT). Default: 'edge'. */
   nodeRole?: 'core' | 'edge';
   /**
@@ -890,6 +896,14 @@ function defaultLargeLiteralStorage(
   };
 }
 
+function createPublicSnapshotStore(
+  dataDir: string | undefined,
+  config: SharedMemoryPublicSnapshotStorageConfig | undefined,
+): WorkspacePublicSnapshotStore | undefined {
+  if (!dataDir || config?.enabled === false) return undefined;
+  return new FileWorkspacePublicSnapshotStore(config?.directory ?? join(dataDir, 'swm-public-snapshots'));
+}
+
 function applyDefaultLargeLiteralStorage(
   storeConfig: TripleStoreConfig,
   dataDir: string | undefined,
@@ -939,6 +953,7 @@ export class DKGAgent {
   private readonly workspaceOwnedEntities: Map<string, Map<string, string>>;
   /** Shared write locks so gossip writes serialize against local CAS writes. */
   private readonly writeLocks: Map<string, Promise<void>>;
+  private readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
   private sharedMemoryHandler?: InstanceType<typeof SharedMemoryHandler>;
   private gossipPublishHandler?: GossipPublishHandler;
   private finalizationHandler?: FinalizationHandler;
@@ -1108,6 +1123,7 @@ export class DKGAgent {
     chain: ChainAdapter,
     workspaceOwnedEntities: Map<string, Map<string, string>>,
     writeLocks: Map<string, Promise<void>>,
+    publicSnapshotStore?: WorkspacePublicSnapshotStore,
   ) {
     this.config = config;
     this.wallet = wallet;
@@ -1117,6 +1133,7 @@ export class DKGAgent {
     this.queryEngine = queryEngine;
     this.workspaceOwnedEntities = workspaceOwnedEntities;
     this.writeLocks = writeLocks;
+    this.publicSnapshotStore = publicSnapshotStore;
     this.eventBus = eventBus;
     this.chain = chain;
     this.discovery = new DiscoveryClient(queryEngine);
@@ -1205,6 +1222,7 @@ export class DKGAgent {
     const node = new DKGNode(nodeConfig);
     const workspaceOwnedEntities = new Map<string, Map<string, string>>();
     const writeLocks = new Map<string, Promise<void>>();
+    const publicSnapshotStore = createPublicSnapshotStore(config.dataDir, config.sharedMemoryPublicSnapshotStorage);
     const legacyAdapterOperationalKey = opKeys?.[0];
     const legacyAdapterOperationalAddress = privateKeyAddress(legacyAdapterOperationalKey);
     const configuredPublisherAddress = normalizeAdapterPublisherAddress(config.publisherAddress);
@@ -1232,6 +1250,7 @@ export class DKGAgent {
         : (contextGraphId?: bigint) => inferAdapterPublisherAddress(chain, contextGraphId),
       sharedMemoryOwnedEntities: workspaceOwnedEntities,
       writeLocks,
+      publicSnapshotStore,
     });
 
     try {
@@ -1249,7 +1268,7 @@ export class DKGAgent {
 
     return new DKGAgent(
       config, wallet, node, store, publisher, queryEngine, eventBus, chain,
-      workspaceOwnedEntities, writeLocks,
+      workspaceOwnedEntities, writeLocks, publicSnapshotStore,
     );
   }
 
@@ -2244,6 +2263,7 @@ export class DKGAgent {
       refreshMetaSyncedFlags: (contextGraphIds) => this.refreshMetaSyncedFlags(contextGraphIds),
       discoverContextGraphsFromStore: () => this.discoverContextGraphsFromStore(),
       syncSharedMemoryFromPeer: (peerId, contextGraphIds) => this.syncSharedMemoryFromPeer(peerId, contextGraphIds),
+      syncSharedMemoryOnConnect: this.config.syncSharedMemoryOnConnect ?? true,
       logInfo: (ctx, message) => this.log.info(ctx, message),
       onPeerSkippedNoSync: (peerId) => {
         this.skippedNoSyncPeers.add(peerId);
@@ -4929,7 +4949,9 @@ export class DKGAgent {
       }
     }
 
-    const asyncPublisher = new TripleStoreAsyncLiftPublisher(this.store);
+    const asyncPublisher = new TripleStoreAsyncLiftPublisher(this.store, {
+      publicSnapshotStore: this.publicSnapshotStore,
+    });
     const captureID = await asyncPublisher.lift({
       ...liftRequestDraft,
       ...(seal !== undefined ? { seal } : {}),
@@ -6887,6 +6909,7 @@ export class DKGAgent {
         workspaceRecipientPrivateKeys: () => this.getLocalWorkspaceRecipientPrivateKeys(),
         workspaceSenderKeyDecryptor: (message: SwmSenderKeyMessageMsg, contextGraphId: string, ctx: OperationContext) =>
           this.decryptWorkspacePayloadWithSenderKey(message, contextGraphId, ctx),
+        publicSnapshotStore: this.publicSnapshotStore,
       });
     }
     return this.sharedMemoryHandler;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -53,7 +53,7 @@ import {
   type SwmSenderKeyPackageMsg,
   type WorkspaceRecipientEncryptionKey,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -74,6 +74,7 @@ import {
   type WorkspaceSenderKeyEncryptInput,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
+import { join } from 'node:path';
 import {
   DKGQueryEngine, QueryHandler,
   emptyQueryResultForKind,
@@ -667,6 +668,8 @@ export interface DKGAgentConfig {
   store?: TripleStore;
   /** Triple store backend configuration (e.g. oxigraph-worker, blazegraph). If omitted, defaults to oxigraph-worker when dataDir is set. */
   storeConfig?: TripleStoreConfig;
+  /** Out-of-line storage for large public SWM RDF literal object terms. Defaults on for local Oxigraph-backed dataDir stores. */
+  largeLiteralStorage?: LargeLiteralStorageConfig;
   /** Node deployment tier: 'core' (cloud, relay) or 'edge' (personal, behind NAT). Default: 'edge'. */
   nodeRole?: 'core' | 'edge';
   /**
@@ -874,6 +877,38 @@ async function inferAdapterPublisherAddress(
   } catch {
     return undefined;
   }
+}
+
+function defaultLargeLiteralStorage(
+  dataDir: string,
+  config: LargeLiteralStorageConfig | undefined,
+): LargeLiteralStorageConfig {
+  return {
+    enabled: config?.enabled ?? true,
+    thresholdBytes: config?.thresholdBytes,
+    directory: config?.directory ?? join(dataDir, 'literal-blobs'),
+  };
+}
+
+function applyDefaultLargeLiteralStorage(
+  storeConfig: TripleStoreConfig,
+  dataDir: string | undefined,
+  config: LargeLiteralStorageConfig | undefined,
+): TripleStoreConfig {
+  if (storeConfig.largeLiteralStorage || !dataDir || !isLocalOxigraphConfig(storeConfig)) {
+    return storeConfig;
+  }
+
+  return {
+    ...storeConfig,
+    largeLiteralStorage: defaultLargeLiteralStorage(dataDir, config),
+  };
+}
+
+function isLocalOxigraphConfig(storeConfig: TripleStoreConfig): boolean {
+  return storeConfig.backend === 'oxigraph'
+    || storeConfig.backend === 'oxigraph-worker'
+    || storeConfig.backend === 'oxigraph-persistent';
 }
 
 /**
@@ -1108,12 +1143,16 @@ export class DKGAgent {
     if (config.store) {
       store = config.store;
     } else if (config.storeConfig) {
-      store = await createTripleStore(config.storeConfig);
+      store = await createTripleStore(applyDefaultLargeLiteralStorage(config.storeConfig, config.dataDir, config.largeLiteralStorage));
       log.info(ctx, `Triple store backend: ${config.storeConfig.backend}`);
     } else if (config.dataDir) {
       const { join } = await import('node:path');
       const persistPath = join(config.dataDir, 'store.nq');
-      store = await createTripleStore({ backend: 'oxigraph-worker', options: { path: persistPath } });
+      store = await createTripleStore({
+        backend: 'oxigraph-worker',
+        options: { path: persistPath },
+        largeLiteralStorage: defaultLargeLiteralStorage(config.dataDir, config.largeLiteralStorage),
+      });
       log.info(ctx, `Persistent triple store (worker thread): ${persistPath}`);
     } else {
       store = await createTripleStore({ backend: 'oxigraph' });

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -68,6 +68,7 @@ import {
   subtractFinalizedExactQuads,
   TripleStoreAsyncLiftPublisher,
   FileWorkspacePublicSnapshotStore,
+  parseWorkspacePublicSnapshotNQuads,
   type PublishOptions, type PublishResult, type PhaseCallback, type KAMetadata, type CASCondition,
   type CollectedACK, type LiftAuthorityProof, type LiftTransitionType,
   type LiftRequest, type LiftRequestAuthorSeal,
@@ -149,7 +150,7 @@ import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch
 import { getSyncCheckpointKey } from './sync/checkpoint/state.js';
 import { runDurableSync } from './sync/requester/durable-sync.js';
 import { runSharedMemorySync } from './sync/requester/shared-memory-sync.js';
-import { buildSyncRequestEnvelope } from './sync/auth/request-build.js';
+import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
 import { runSyncOnConnect } from './sync/on-connect/sync-on-connect.js';
@@ -526,7 +527,8 @@ interface SyncRequestEnvelope {
   offset: number;
   limit: number;
   includeSharedMemory: boolean;
-  phase?: 'data' | 'meta';
+  phase?: SyncPhase;
+  snapshotRef?: string;
   targetPeerId?: string;
   requesterPeerId?: string;
   requestId?: string;
@@ -535,6 +537,11 @@ interface SyncRequestEnvelope {
   requesterAgentAddress?: string;
   requesterSignatureR?: string;
   requesterSignatureVS?: string;
+}
+
+function normalizeSyncPhase(value: unknown): SyncPhase {
+  if (value === 'meta' || value === 'snapshot') return value;
+  return 'data';
 }
 
 /** Health status of a peer from the last ping round. */
@@ -1733,6 +1740,7 @@ export class DKGAgent {
       syncPageSize: SYNC_PAGE_SIZE,
       sharedMemoryTtlMs: this.config.sharedMemoryTtlMs ?? DEFAULT_SWM_TTL_MS,
       store: this.store,
+      publicSnapshotStore: this.publicSnapshotStore,
       peerId: this.peerId,
       parseSyncRequest: this.parseSyncRequest.bind(this),
       authorizeSyncRequest: this.authorizeSyncRequest.bind(this),
@@ -2461,9 +2469,10 @@ export class DKGAgent {
     remotePeerId: string,
     contextGraphId: string,
     includeSharedMemory: boolean,
-    phase: 'data' | 'meta',
+    phase: SyncPhase,
     graphUri: string,
     deadline: number,
+    snapshotRef?: string,
   ): Promise<SyncPageResult> {
     return fetchSyncPages({
       ctx,
@@ -2472,6 +2481,7 @@ export class DKGAgent {
       includeSharedMemory,
       phase,
       graphUri,
+      snapshotRef,
       deadline,
       syncPageTimeoutMs: SYNC_PAGE_TIMEOUT_MS,
       syncRouterAttempts: SYNC_ROUTER_ATTEMPTS,
@@ -2490,7 +2500,13 @@ export class DKGAgent {
       protocolSync: PROTOCOL_SYNC,
       checkpointStore: this.syncCheckpoints,
       buildSyncRequest: this.buildSyncRequest.bind(this),
-      parseAndFilter: (nquadsText, targetGraphUri, targetContextGraphId) => this.getOrCreateSyncVerifyWorker().parseAndFilter(nquadsText, targetGraphUri, targetContextGraphId),
+      parseAndFilter: (nquadsText, targetGraphUri, targetContextGraphId) => {
+        if (phase === 'snapshot') {
+          const quads = parseWorkspacePublicSnapshotNQuads(nquadsText, snapshotRef ?? 'unknown');
+          return Promise.resolve({ quads, totalQuads: quads.length });
+        }
+        return this.getOrCreateSyncVerifyWorker().parseAndFilter(nquadsText, targetGraphUri, targetContextGraphId);
+      },
       send: (peerId, protocolId, data, sendTimeoutMs) => this.messenger.sendToPeer(peerId, protocolId, data, { timeoutMs: sendTimeoutMs }),
       logWarn: (opCtx, message) => this.log.warn(opCtx, message),
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
@@ -2552,6 +2568,7 @@ export class DKGAgent {
         await graphManager.ensureContextGraph(contextGraphId);
       },
       storeInsert: (quads) => this.store.insert(quads),
+      publicSnapshotStore: this.publicSnapshotStore,
       deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
       setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
       ensureOwnedMap: (contextGraphId) => {
@@ -9743,7 +9760,8 @@ export class DKGAgent {
         offset: parsed.offset ?? 0,
         limit: Math.min(parsed.limit ?? SYNC_PAGE_SIZE, SYNC_PAGE_SIZE),
         includeSharedMemory: parsed.includeSharedMemory ?? false,
-        phase: parsed.phase === 'meta' ? 'meta' : 'data',
+        phase: normalizeSyncPhase(parsed.phase),
+        snapshotRef: typeof parsed.snapshotRef === 'string' ? parsed.snapshotRef : undefined,
         targetPeerId: parsed.targetPeerId,
         requesterPeerId: parsed.requesterPeerId,
         requestId: parsed.requestId,
@@ -9763,12 +9781,14 @@ export class DKGAgent {
     const ctxGraphPart = parts[0] || '';
     const includeSharedMemory = ctxGraphPart.startsWith('workspace:');
     const contextGraphId = includeSharedMemory ? ctxGraphPart.slice('workspace:'.length) : (ctxGraphPart || SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const phase = normalizeSyncPhase(parts[3]);
     return {
       contextGraphId,
       offset: parseInt(parts[1], 10) || 0,
       limit: Math.min(parseInt(parts[2], 10) || SYNC_PAGE_SIZE, SYNC_PAGE_SIZE),
       includeSharedMemory,
-      phase: parts[3] === 'meta' ? 'meta' : 'data',
+      phase,
+      snapshotRef: phase === 'snapshot' ? parts[4] : undefined,
     };
   }
 
@@ -9841,7 +9861,8 @@ export class DKGAgent {
     limit: number,
     includeSharedMemory: boolean,
     responderPeerId: string,
-    phase: 'data' | 'meta' = 'data',
+    phase: SyncPhase = 'data',
+    snapshotRef?: string,
   ): Promise<Uint8Array> {
     const isPrivate = await this.isPrivateContextGraph(contextGraphId);
 
@@ -9861,6 +9882,7 @@ export class DKGAgent {
       targetPeerId: responderPeerId,
       requesterPeerId: this.peerId,
       phase,
+      snapshotRef,
       needsAuth,
       computeSyncDigest: this.computeSyncDigest.bind(this),
       getIdentityId: () => this.chain.getIdentityId(),

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -1,5 +1,7 @@
 import { ethers } from 'ethers';
 
+export type SyncPhase = 'data' | 'meta' | 'snapshot';
+
 export interface SyncRequestEnvelope {
   contextGraphId: string;
   offset: number;
@@ -13,7 +15,8 @@ export interface SyncRequestEnvelope {
   requesterAgentAddress?: string;
   requesterSignatureR?: string;
   requesterSignatureVS?: string;
-  phase?: 'data' | 'meta';
+  phase?: SyncPhase;
+  snapshotRef?: string;
 }
 
 interface BuildSyncRequestParams {
@@ -23,7 +26,8 @@ interface BuildSyncRequestParams {
   includeSharedMemory: boolean;
   targetPeerId: string;
   requesterPeerId: string;
-  phase?: 'data' | 'meta';
+  phase?: SyncPhase;
+  snapshotRef?: string;
   needsAuth: boolean;
   computeSyncDigest: (
     contextGraphId: string,
@@ -59,6 +63,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     targetPeerId,
     requesterPeerId,
     phase,
+    snapshotRef,
     needsAuth,
     computeSyncDigest,
     getIdentityId,
@@ -69,7 +74,11 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
 
   if (!needsAuth) {
     const prefix = includeSharedMemory ? `workspace:${contextGraphId}` : contextGraphId;
-    const phaseSuffix = phase === 'meta' ? '|meta' : '';
+    const phaseSuffix = phase === 'meta'
+      ? '|meta'
+      : phase === 'snapshot'
+        ? `|snapshot|${snapshotRef ?? ''}`
+        : '';
     return new TextEncoder().encode(`${prefix}|${offset}|${limit}${phaseSuffix}`);
   }
 
@@ -84,6 +93,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     issuedAtMs: Date.now(),
   };
   if (phase) request.phase = phase;
+  if (snapshotRef) request.snapshotRef = snapshotRef;
 
   // Bind the "on behalf of" agent claim INTO the signed digest so the
   // responder's per-agent delegation lookup can't be steered by post-

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -1,3 +1,5 @@
+import type { SyncPhase } from '../auth/request-build.js';
+
 export interface SyncCheckpointStore {
   get(key: string): number | undefined;
   set(key: string, value: number): void;
@@ -8,7 +10,9 @@ export function getSyncCheckpointKey(
   remotePeerId: string,
   contextGraphId: string,
   includeSharedMemory: boolean,
-  phase: 'data' | 'meta',
+  phase: SyncPhase,
+  snapshotRef?: string,
 ): string {
-  return `${remotePeerId}|${contextGraphId}|${includeSharedMemory ? 'swm' : 'durable'}|${phase}`;
+  const refSuffix = phase === 'snapshot' && snapshotRef ? `|${snapshotRef}` : '';
+  return `${remotePeerId}|${contextGraphId}|${includeSharedMemory ? 'swm' : 'durable'}|${phase}${refSuffix}`;
 }

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -10,6 +10,7 @@ interface SyncOnConnectContext {
   refreshMetaSyncedFlags: (contextGraphIds: Iterable<string>) => Promise<void>;
   discoverContextGraphsFromStore: () => Promise<number>;
   syncSharedMemoryFromPeer: (peerId: string, contextGraphIds: string[]) => Promise<number>;
+  syncSharedMemoryOnConnect?: boolean;
   logInfo: (ctx: OperationContext, message: string) => void;
   /**
    * Optional. Called when the peer is reachable but does not currently
@@ -45,6 +46,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<v
     refreshMetaSyncedFlags,
     discoverContextGraphsFromStore,
     syncSharedMemoryFromPeer,
+    syncSharedMemoryOnConnect = true,
     logInfo,
   } = context;
 
@@ -94,9 +96,11 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<v
     }
 
     const wsContextGraphIds = getSyncContextGraphs() ?? [];
-    if (wsContextGraphIds.length > 0) {
+    if (syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
       const wsSynced = await syncSharedMemoryFromPeer(remotePeer, wsContextGraphIds);
       logInfo(ctx, `Synced ${wsSynced} shared memory triples from peer ${shortPeer}`);
+    } else if (!syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
+      logInfo(ctx, `Skipping shared memory sync from peer ${shortPeer} (syncSharedMemoryOnConnect=false)`);
     }
 
     context.onPeerSynced?.(remotePeer);

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -1,6 +1,7 @@
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { sendSyncRequest } from '../../p2p/sync-transport.js';
+import type { SyncPhase } from '../auth/request-build.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from '../checkpoint/state.js';
 
 export interface SyncPageResult {
@@ -17,8 +18,9 @@ interface FetchSyncPagesParams {
   remotePeerId: string;
   contextGraphId: string;
   includeSharedMemory: boolean;
-  phase: 'data' | 'meta';
+  phase: SyncPhase;
   graphUri: string;
+  snapshotRef?: string;
   deadline: number;
   syncPageTimeoutMs: number;
   syncRouterAttempts: number;
@@ -39,7 +41,7 @@ interface FetchSyncPagesParams {
   debugSyncProgress: boolean;
   protocolSync: string;
   checkpointStore: SyncCheckpointStore;
-  buildSyncRequest: (contextGraphId: string, offset: number, limit: number, includeSharedMemory: boolean, remotePeerId: string, phase?: 'data' | 'meta') => Promise<Uint8Array>;
+  buildSyncRequest: (contextGraphId: string, offset: number, limit: number, includeSharedMemory: boolean, remotePeerId: string, phase?: SyncPhase, snapshotRef?: string) => Promise<Uint8Array>;
   parseAndFilter: (nquadsText: string, graphUri: string, contextGraphId: string) => Promise<{ quads: Quad[]; totalQuads: number }>;
   send: (peerId: string, protocolId: string, data: Uint8Array, timeoutMs: number) => Promise<Uint8Array>;
   logWarn: (ctx: OperationContext, message: string) => void;
@@ -55,6 +57,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     includeSharedMemory,
     phase,
     graphUri,
+    snapshotRef,
     deadline,
     syncPageTimeoutMs,
     syncRouterAttempts,
@@ -74,7 +77,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   } = params;
 
   const allQuads: Quad[] = [];
-  const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase);
+  const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase, snapshotRef);
   let offset = checkpointStore.get(checkpointKey) ?? 0;
   const resumedFromOffset = offset;
   let bytesReceived = 0;
@@ -101,7 +104,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       contextGraphId,
       offset,
       protocolId: protocolSync,
-      requestFactory: () => buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase),
+      requestFactory: () => buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef),
       send,
       onRetry: (attempt, delay, err) => {
         logWarn(ctx, `Sync page retry ${attempt}/${syncPageRetryAttempts} for offset ${offset} (delay ${Math.round(delay)}ms): ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -1,7 +1,11 @@
 import { contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri } from '@origintrail-official/dkg-core';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
+import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
+import type { SyncPhase } from '../auth/request-build.js';
 import type { SyncPageResult } from './page-fetch.js';
+
+const DKG = 'http://dkg.io/ontology/';
 
 export interface SharedMemorySyncSummary {
   insertedTriples: number;
@@ -27,9 +31,10 @@ interface SharedMemorySyncContext {
     remotePeerId: string,
     contextGraphId: string,
     includeSharedMemory: boolean,
-    phase: 'data' | 'meta',
+    phase: SyncPhase,
     graphUri: string,
     deadline: number,
+    snapshotRef?: string,
   ) => Promise<SyncPageResult>;
   processSharedMemoryBatch: (wsDataQuads: Quad[], wsMetaQuads: Quad[]) => Promise<{
     verifiedData: Quad[];
@@ -42,6 +47,7 @@ interface SharedMemorySyncContext {
   }>;
   ensureContextGraph: (contextGraphId: string) => Promise<void>;
   storeInsert: (quads: Quad[]) => Promise<void>;
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
   deleteCheckpoint: (key: string) => void;
   setCheckpoint: (key: string, offset: number) => void;
   ensureOwnedMap: (contextGraphId: string) => Map<string, string>;
@@ -60,6 +66,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     processSharedMemoryBatch,
     ensureContextGraph,
     storeInsert,
+    publicSnapshotStore,
     deleteCheckpoint,
     setCheckpoint,
     ensureOwnedMap,
@@ -116,6 +123,22 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         summary.droppedDataTriples += dropped;
       }
 
+      const snapshotStartedAt = Date.now();
+      const snapshotSync = await syncPublicSnapshotsForMeta({
+        ctx,
+        remotePeerId,
+        contextGraphId: pid,
+        deadline,
+        metaQuads: processed.verifiedMeta,
+        publicSnapshotStore,
+        fetchSyncPages,
+        deleteCheckpoint,
+        setCheckpoint,
+      });
+      summary.bytesReceived += snapshotSync.bytesReceived;
+      summary.resumedPhases += snapshotSync.resumedPhases;
+      const snapshotDurationMs = Date.now() - snapshotStartedAt;
+
       const storeStartedAt = Date.now();
       await ensureContextGraph(pid);
 
@@ -143,10 +166,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const storeDurationMs = Date.now() - storeStartedAt;
 
       logInfo(ctx, `SWM sync for "${pid}": ${validWsQuads.length} data + ${processed.verifiedMeta.length} meta triples`);
-      if (fetchDurationMs + verifyDurationMs + storeDurationMs > 100) {
+      if (fetchDurationMs + verifyDurationMs + snapshotDurationMs + storeDurationMs > 100) {
         logDebug(
           ctx,
-          `Requester SWM timing for "${pid}": fetch=${fetchDurationMs}ms verify=${verifyDurationMs}ms store+ownership=${storeDurationMs}ms`,
+          `Requester SWM timing for "${pid}": fetch=${fetchDurationMs}ms verify=${verifyDurationMs}ms snapshots=${snapshotDurationMs}ms store+ownership=${storeDurationMs}ms`,
         );
       }
     }
@@ -162,4 +185,135 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
   }
 
   return summary;
+}
+
+interface PublicSnapshotMetadata {
+  ref: string;
+  digest: string;
+  count: number;
+}
+
+async function syncPublicSnapshotsForMeta(params: {
+  ctx: OperationContext;
+  remotePeerId: string;
+  contextGraphId: string;
+  deadline: number;
+  metaQuads: readonly Quad[];
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
+  fetchSyncPages: SharedMemorySyncContext['fetchSyncPages'];
+  deleteCheckpoint: (key: string) => void;
+  setCheckpoint: (key: string, offset: number) => void;
+}): Promise<{ bytesReceived: number; resumedPhases: number }> {
+  const snapshots = collectPublicSnapshotMetadata(params.metaQuads);
+  if (snapshots.length === 0) {
+    return { bytesReceived: 0, resumedPhases: 0 };
+  }
+  if (!params.publicSnapshotStore) {
+    throw new Error(
+      `Cannot sync shared-memory public snapshot refs for "${params.contextGraphId}" without a public snapshot store`,
+    );
+  }
+
+  let bytesReceived = 0;
+  let resumedPhases = 0;
+  for (const snapshot of snapshots) {
+    if (await hasValidSnapshot(params.publicSnapshotStore, snapshot)) {
+      continue;
+    }
+
+    const result = await params.fetchSyncPages(
+      params.ctx,
+      params.remotePeerId,
+      params.contextGraphId,
+      true,
+      'snapshot',
+      '',
+      params.deadline,
+      snapshot.ref,
+    );
+    bytesReceived += result.bytesReceived;
+    resumedPhases += result.resumedFromOffset > 0 ? 1 : 0;
+
+    if (result.completed) params.deleteCheckpoint(result.checkpointKey);
+    else {
+      params.setCheckpoint(result.checkpointKey, result.nextOffset);
+      throw new Error(`Timed out while syncing shared-memory public snapshot ${snapshot.ref}`);
+    }
+
+    const snapshotQuads = result.quads.map((quad) => ({ ...quad, graph: '' }));
+    const actualDigest = workspacePublicQuadsDigest(snapshotQuads);
+    if (actualDigest !== snapshot.digest || snapshotQuads.length !== snapshot.count) {
+      throw new Error(
+        `Shared-memory public snapshot ${snapshot.ref} failed digest/count validation ` +
+        `(expected ${snapshot.digest}/${snapshot.count}, got ${actualDigest}/${snapshotQuads.length})`,
+      );
+    }
+    await params.publicSnapshotStore.putSnapshot({ digest: snapshot.digest, quads: snapshotQuads });
+  }
+
+  return { bytesReceived, resumedPhases };
+}
+
+function collectPublicSnapshotMetadata(metaQuads: readonly Quad[]): PublicSnapshotMetadata[] {
+  const bySubject = new Map<string, { ref?: string; digest?: string; count?: number }>();
+  for (const quad of metaQuads) {
+    if (
+      quad.predicate !== `${DKG}publicSnapshotRef` &&
+      quad.predicate !== `${DKG}publicQuadsDigest` &&
+      quad.predicate !== `${DKG}publicQuadsCount`
+    ) {
+      continue;
+    }
+    const entry = bySubject.get(quad.subject) ?? {};
+    if (quad.predicate === `${DKG}publicSnapshotRef`) entry.ref = stripLiteral(quad.object)?.trim();
+    if (quad.predicate === `${DKG}publicQuadsDigest`) entry.digest = stripLiteral(quad.object)?.trim();
+    if (quad.predicate === `${DKG}publicQuadsCount`) entry.count = parseIntegerLiteral(quad.object);
+    bySubject.set(quad.subject, entry);
+  }
+
+  const byRef = new Map<string, PublicSnapshotMetadata>();
+  for (const [subject, entry] of bySubject) {
+    if (!entry.ref) continue;
+    if (!entry.digest || !Number.isInteger(entry.count)) {
+      throw new Error(`Shared-memory public snapshot metadata for ${subject} is missing digest/count`);
+    }
+    const existing = byRef.get(entry.ref);
+    const metadata = { ref: entry.ref, digest: entry.digest, count: entry.count! };
+    if (existing && (existing.digest !== metadata.digest || existing.count !== metadata.count)) {
+      throw new Error(`Conflicting shared-memory public snapshot metadata for ${entry.ref}`);
+    }
+    byRef.set(entry.ref, metadata);
+  }
+  return [...byRef.values()];
+}
+
+async function hasValidSnapshot(
+  publicSnapshotStore: WorkspacePublicSnapshotStore,
+  snapshot: PublicSnapshotMetadata,
+): Promise<boolean> {
+  let quads: Quad[] | null;
+  try {
+    quads = await publicSnapshotStore.getSnapshot(snapshot.ref);
+  } catch {
+    return false;
+  }
+  if (!quads) return false;
+  return quads.length === snapshot.count && workspacePublicQuadsDigest(quads) === snapshot.digest;
+}
+
+function stripLiteral(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const match = value.match(/^"((?:[^"\\]|\\.)*)"(?:@[-A-Za-z0-9]+|\^\^<[^>]+>)?$/);
+  if (!match) return value;
+  return match[1]
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+}
+
+function parseIntegerLiteral(value: string | undefined): number | undefined {
+  const parsed = Number.parseInt(stripLiteral(value) ?? '', 10);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -1,6 +1,7 @@
 import { createOperationContext, DKG_ONTOLOGY, MemoryLayer, type OperationContext } from '@origintrail-official/dkg-core';
 import { contextGraphDataGraphUri, contextGraphMetaGraphUri, contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri } from '@origintrail-official/dkg-core';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import { serializeWorkspacePublicSnapshotQuads, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
 
 interface RegisterSyncHandlerParams {
@@ -10,6 +11,7 @@ interface RegisterSyncHandlerParams {
   syncPageSize: number;
   sharedMemoryTtlMs: number;
   store: TripleStore;
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
   peerId: string;
   parseSyncRequest: (data: Uint8Array) => SyncRequestEnvelope;
   authorizeSyncRequest: (request: SyncRequestEnvelope, remotePeerId: string) => Promise<boolean>;
@@ -25,6 +27,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     syncPageSize,
     sharedMemoryTtlMs,
     store,
+    publicSnapshotStore,
     parseSyncRequest,
     authorizeSyncRequest,
     logWarn,
@@ -57,7 +60,22 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       const wsMetaGraph = contextGraphWorkspaceMetaGraphUri(contextGraphId);
       const cutoff = sharedMemoryTtlMs > 0 ? new Date(Date.now() - sharedMemoryTtlMs).toISOString() : null;
 
-      if (phase === 'meta') {
+      if (phase === 'snapshot') {
+        const snapshotRef = request.snapshotRef?.trim();
+        if (!snapshotRef || !publicSnapshotStore) {
+          return new TextEncoder().encode('');
+        }
+        const snapshot = await publicSnapshotStore.getSnapshot(snapshotRef);
+        if (!snapshot) {
+          return new TextEncoder().encode('');
+        }
+        const page = snapshot.slice(offset, offset + limit);
+        if (page.length === 0) {
+          return new TextEncoder().encode('');
+        }
+        nquads.push(serializeWorkspacePublicSnapshotQuads(page).trimEnd());
+        logDebug(createOperationContext('sync'), `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
+      } else if (phase === 'meta') {
         const metaQuery = cutoff != null
           ? `SELECT ?s ?p ?o WHERE {
               GRAPH <${wsMetaGraph}> { ?s ?p ?o }

--- a/packages/agent/test/large-literal-storage.test.ts
+++ b/packages/agent/test/large-literal-storage.test.ts
@@ -1,0 +1,93 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DKGAgent } from '../src/index.js';
+
+const SWM_GRAPH = 'did:dkg:context-graph:test/_shared_memory';
+
+describe('DKGAgent large literal storage defaults', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('externalizes large SWM literals for the default persistent dataDir store', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-agent-large-literal-'));
+    tempDirs.push(dataDir);
+    const largeLiteral = `"${'agent-large-literal'.repeat(8)}"`;
+    const hash = createHash('sha256').update(largeLiteral, 'utf8').digest('hex');
+
+    const agent = await DKGAgent.create({
+      name: 'LargeLiteralStorageAgent',
+      dataDir,
+      listenHost: '127.0.0.1',
+      largeLiteralStorage: { thresholdBytes: 20 },
+    });
+
+    try {
+      await agent.store.insert([{
+        subject: 'urn:test:agent-large-literal',
+        predicate: 'http://schema.org/value',
+        object: largeLiteral,
+        graph: SWM_GRAPH,
+      }]);
+      await agent.store.flush?.();
+
+      const storeNq = await readFile(join(dataDir, 'store.nq'), 'utf8');
+      expect(storeNq).toContain(`"sha256:${hash}"^^<http://dkg.io/ontology/externalLiteralRef>`);
+      expect(storeNq).not.toContain('agent-large-literalagent-large-literalagent-large-literal');
+      expect(await readFile(join(dataDir, 'literal-blobs', hash), 'utf8')).toBe(largeLiteral);
+
+      const result = await agent.store.query(
+        `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <urn:test:agent-large-literal> <http://schema.org/value> ?o } }`,
+      );
+      expect(result.type).toBe('bindings');
+      if (result.type === 'bindings') {
+        expect(result.bindings).toEqual([{ o: largeLiteral }]);
+      }
+    } finally {
+      await agent.stop().catch(() => {});
+      await agent.store.close().catch(() => {});
+    }
+  });
+
+  it('also wraps explicit local Oxigraph store configs when dataDir is available', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-agent-local-oxigraph-literal-'));
+    tempDirs.push(dataDir);
+    const largeLiteral = `"${'agent-local-oxigraph'.repeat(8)}"`;
+    const hash = createHash('sha256').update(largeLiteral, 'utf8').digest('hex');
+
+    const agent = await DKGAgent.create({
+      name: 'LocalOxigraphLargeLiteralStorageAgent',
+      dataDir,
+      listenHost: '127.0.0.1',
+      storeConfig: { backend: 'oxigraph' },
+      largeLiteralStorage: { thresholdBytes: 20 },
+    });
+
+    try {
+      await agent.store.insert([{
+        subject: 'urn:test:agent-local-oxigraph-large-literal',
+        predicate: 'http://schema.org/value',
+        object: largeLiteral,
+        graph: SWM_GRAPH,
+      }]);
+
+      expect(await readFile(join(dataDir, 'literal-blobs', hash), 'utf8')).toBe(largeLiteral);
+
+      const result = await agent.store.query(
+        `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <urn:test:agent-local-oxigraph-large-literal> <http://schema.org/value> ?o } }`,
+      );
+      expect(result.type).toBe('bindings');
+      if (result.type === 'bindings') {
+        expect(result.bindings).toEqual([{ o: largeLiteral }]);
+      }
+    } finally {
+      await agent.stop().catch(() => {});
+      await agent.store.close().catch(() => {});
+    }
+  });
+});

--- a/packages/agent/test/swm-snapshot-sync.test.ts
+++ b/packages/agent/test/swm-snapshot-sync.test.ts
@@ -1,0 +1,208 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri, type OperationContext } from '@origintrail-official/dkg-core';
+import { FileWorkspacePublicSnapshotStore, serializeWorkspacePublicSnapshotQuads, TripleStoreAsyncLiftPublisher } from '@origintrail-official/dkg-publisher';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+import { DKGAgent } from '../src/index.js';
+
+const CONTEXT_GRAPH = 'swm-snapshot-sync';
+const ENTITY = 'urn:swm:snapshot-sync:entity';
+const REMOTE_PEER = '12D3KooWSnapshotSyncRemote';
+
+describe('SWM snapshot catch-up sync', () => {
+  const tempDirs: string[] = [];
+  const agents: DKGAgent[] = [];
+
+  afterEach(async () => {
+    await Promise.all(agents.splice(0).map(async (agent) => {
+      await agent.stop().catch(() => {});
+      await agent.store.close().catch(() => {});
+    }));
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('syncs disk public snapshots before inserting publicSnapshotRef metadata', async () => {
+    const nodeADataDir = await tempDataDir();
+    const nodeBDataDir = await tempDataDir();
+    const nodeA = await createAgent(nodeADataDir, 'SnapshotSyncA');
+    const nodeB = await createAgent(nodeBDataDir, 'SnapshotSyncB');
+    const sourceSnapshots = new FileWorkspacePublicSnapshotStore(join(nodeADataDir, 'swm-public-snapshots'));
+    const targetSnapshots = new FileWorkspacePublicSnapshotStore(join(nodeBDataDir, 'swm-public-snapshots'));
+
+    const write = await nodeA.publisher.writeToWorkspace(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Synced Snapshot"', graph: '' },
+      { subject: `${ENTITY}/.well-known/genid/child`, predicate: 'http://schema.org/value', object: '"Nested"', graph: '' },
+    ], { publisherPeerId: 'peer-a' });
+
+    installSharedMemorySyncMock(nodeB, nodeA, sourceSnapshots);
+
+    const inserted = await nodeB.syncSharedMemoryFromPeer(REMOTE_PEER, [CONTEXT_GRAPH]);
+    expect(inserted).toBeGreaterThan(0);
+
+    await expect(targetSnapshots.getSnapshot(await getSnapshotRef(nodeB, write.shareOperationId))).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ subject: ENTITY, predicate: 'http://schema.org/name', object: '"Synced Snapshot"', graph: '' }),
+        expect.objectContaining({ subject: `${ENTITY}/.well-known/genid/child`, predicate: 'http://schema.org/value', object: '"Nested"', graph: '' }),
+      ]),
+    );
+
+    const metaGraph = contextGraphWorkspaceMetaGraphUri(CONTEXT_GRAPH);
+    const legacyPayloads = await nodeB.store.query(
+      `SELECT ?payload WHERE { GRAPH <${metaGraph}> { ?s <http://dkg.io/ontology/publicStagedQuads> ?payload } }`,
+    );
+    expect(legacyPayloads.type).toBe('bindings');
+    if (legacyPayloads.type === 'bindings') {
+      expect(legacyPayloads.bindings).toHaveLength(0);
+    }
+
+    const asyncPublisher = new TripleStoreAsyncLiftPublisher(nodeB.store, { publicSnapshotStore: targetSnapshots });
+    const jobId = await asyncPublisher.lift({
+      swmId: 'swm-main',
+      shareOperationId: write.shareOperationId,
+      roots: [ENTITY],
+      contextGraphId: CONTEXT_GRAPH,
+      namespace: 'aloha',
+      scope: 'person-profile',
+      transitionType: 'CREATE',
+      authority: { type: 'owner', proofRef: 'proof:owner:1' },
+    });
+    const payload = await asyncPublisher.inspectPreparedPayload(jobId);
+    expect(payload?.publishOptions.quads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject: expect.stringMatching(/^dkg:swm-snapshot-sync:aloha:person-profile\/entity-/),
+          predicate: 'http://schema.org/name',
+          object: '"Synced Snapshot"',
+          graph: '',
+        }),
+        expect.objectContaining({
+          subject: expect.stringMatching(/^dkg:swm-snapshot-sync:aloha:person-profile\/entity-.*\/\.well-known\/genid\/child$/),
+          predicate: 'http://schema.org/value',
+          object: '"Nested"',
+          graph: '',
+        }),
+      ]),
+    );
+  });
+
+  it('does not insert dangling publicSnapshotRef metadata when remote snapshots are unavailable', async () => {
+    const nodeADataDir = await tempDataDir();
+    const nodeBDataDir = await tempDataDir();
+    const nodeA = await createAgent(nodeADataDir, 'SnapshotSyncMissingA');
+    const nodeB = await createAgent(nodeBDataDir, 'SnapshotSyncMissingB');
+    const sourceSnapshots = new FileWorkspacePublicSnapshotStore(join(nodeADataDir, 'swm-public-snapshots'));
+
+    await nodeA.publisher.writeToWorkspace(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Missing Snapshot"', graph: '' },
+    ], { publisherPeerId: 'peer-a' });
+
+    installSharedMemorySyncMock(nodeB, nodeA, sourceSnapshots, { omitSnapshots: true });
+
+    const detailed = await (nodeB as unknown as {
+      syncSharedMemoryFromPeerDetailed(peerId: string, contextGraphIds: string[]): Promise<{ failedPeers: number; insertedTriples: number }>;
+    }).syncSharedMemoryFromPeerDetailed(REMOTE_PEER, [CONTEXT_GRAPH]);
+    expect(detailed.failedPeers).toBe(1);
+    expect(detailed.insertedTriples).toBe(0);
+
+    const metaGraph = contextGraphWorkspaceMetaGraphUri(CONTEXT_GRAPH);
+    const refs = await nodeB.store.query(
+      `SELECT ?ref WHERE { GRAPH <${metaGraph}> { ?s <http://dkg.io/ontology/publicSnapshotRef> ?ref } }`,
+    );
+    expect(refs.type).toBe('bindings');
+    if (refs.type === 'bindings') {
+      expect(refs.bindings).toHaveLength(0);
+    }
+  });
+
+  async function tempDataDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'dkg-swm-snapshot-sync-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  async function createAgent(dataDir: string, name: string): Promise<DKGAgent> {
+    const agent = await DKGAgent.create({
+      name,
+      dataDir,
+      listenHost: '127.0.0.1',
+    });
+    agents.push(agent);
+    return agent;
+  }
+});
+
+function installSharedMemorySyncMock(
+  target: DKGAgent,
+  source: DKGAgent,
+  sourceSnapshots: FileWorkspacePublicSnapshotStore,
+  options: { omitSnapshots?: boolean } = {},
+): void {
+  (target as unknown as { canUseSharedMemoryForContextGraph: () => Promise<boolean> }).canUseSharedMemoryForContextGraph = async () => true;
+  (target as unknown as {
+    fetchSyncPages: (
+      ctx: OperationContext,
+      remotePeerId: string,
+      contextGraphId: string,
+      includeSharedMemory: boolean,
+      phase: 'data' | 'meta' | 'snapshot',
+      graphUri: string,
+      deadline: number,
+      snapshotRef?: string,
+    ) => Promise<SyncPageResult>;
+  }).fetchSyncPages = async (_ctx, _remotePeerId, contextGraphId, _includeSharedMemory, phase, graphUri, _deadline, snapshotRef) => {
+    let quads: Quad[] = [];
+    if (phase === 'snapshot') {
+      quads = options.omitSnapshots || !snapshotRef
+        ? []
+        : (await sourceSnapshots.getSnapshot(snapshotRef)) ?? [];
+    } else {
+      quads = await selectGraphQuads(source, graphUri || (
+        phase === 'meta'
+          ? contextGraphWorkspaceMetaGraphUri(contextGraphId)
+          : contextGraphWorkspaceGraphUri(contextGraphId)
+      ));
+    }
+    return {
+      quads,
+      bytesReceived: phase === 'snapshot'
+        ? Buffer.byteLength(serializeWorkspacePublicSnapshotQuads(quads), 'utf8')
+        : Buffer.byteLength(JSON.stringify(quads), 'utf8'),
+      resumedFromOffset: 0,
+      nextOffset: quads.length,
+      checkpointKey: `mock:${phase}:${snapshotRef ?? 'graph'}`,
+      completed: true,
+    };
+  };
+}
+
+async function selectGraphQuads(agent: DKGAgent, graph: string): Promise<Quad[]> {
+  const result = await agent.store.query(
+    `SELECT ?s ?p ?o WHERE { GRAPH <${graph}> { ?s ?p ?o } } ORDER BY ?s ?p ?o`,
+  );
+  if (result.type !== 'bindings') return [];
+  return result.bindings.map((row) => ({
+    subject: row['s'],
+    predicate: row['p'],
+    object: row['o'],
+    graph,
+  }));
+}
+
+async function getSnapshotRef(agent: DKGAgent, shareOperationId: string): Promise<string> {
+  const metaGraph = contextGraphWorkspaceMetaGraphUri(CONTEXT_GRAPH);
+  const result = await agent.store.query(
+    `SELECT ?ref WHERE {
+      GRAPH <${metaGraph}> {
+        ?s <http://dkg.io/ontology/shareOperationId> "${shareOperationId}" ;
+           <http://dkg.io/ontology/publicSnapshotRef> ?ref .
+      }
+    } LIMIT 1`,
+  );
+  if (result.type !== 'bindings') throw new Error('Unexpected snapshot ref query result');
+  const ref = result.bindings[0]?.['ref']?.replace(/^"|"$/g, '');
+  if (!ref) throw new Error(`Missing snapshot ref for ${shareOperationId}`);
+  return ref;
+}

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -82,6 +82,32 @@ describe('runSyncOnConnect callbacks', () => {
     expect(skipped).toEqual([]);
     expect(synced).toEqual([remotePeer]);
   });
+
+  it('can skip shared-memory catch-up on connect while still running durable sync', async () => {
+    const remotePeer = freshPeerIdString();
+    const syncFromPeer = vi.fn().mockResolvedValue(3);
+    const syncSharedMemoryFromPeer = vi.fn().mockResolvedValue(11);
+    const synced: string[] = [];
+
+    await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['devnet-test'],
+      syncFromPeer,
+      refreshMetaSyncedFlags: async () => {},
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer,
+      syncSharedMemoryOnConnect: false,
+      logInfo: noopLog,
+      onPeerSynced: (peerId) => synced.push(peerId),
+    });
+
+    expect(syncFromPeer).toHaveBeenCalledOnce();
+    expect(syncSharedMemoryFromPeer).not.toHaveBeenCalled();
+    expect(synced).toEqual([remotePeer]);
+  });
 });
 
 describe('DKGAgent sync retry — event-driven via peer:update', () => {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -267,6 +267,34 @@ counts, write timing summaries, replication polls, metadata counts for
 `publicStagedQuads` delta, and an appended log scan for known
 Oxigraph/GossipSub failure signatures when a devnet directory is available.
 
+### SWM Triple-Volume Benchmark
+
+The live SWM triple-volume benchmark is aimed at Oxigraph graph/index scale,
+not large literal storage. It writes many small triples through every node in a
+running devnet, waits until every node can count all replicated benchmark
+triples from shared working memory, and stores a JSON report with write timing,
+replication polls, sample triples, and log-scan results.
+
+For a 5-node run targeting roughly 1 GiB of serialized N-Quad triples per node:
+
+```bash
+DEVNET_SWM_SYNC_ON_CONNECT=0 ./scripts/devnet.sh start 5
+pnpm bench:swm-triple-volume -- \
+  --ports 20101,20102,20103,20104,20105 \
+  --target-gib-per-node 1 \
+  --triples-per-write 1000 \
+  --write-concurrency 5 \
+  --output bench/results/swm-triple-volume-1gib-per-node.json
+```
+
+The target is based on estimated serialized N-Quad bytes for generated triples.
+This benchmark can be much harder on local Oxigraph than the large-literal
+benchmark because every triple and index entry still lives in the RDF store.
+`DEVNET_SWM_SYNC_ON_CONNECT=0` avoids a peer-connect catch-up storm during bulk
+write runs; live SWM gossip still replicates new writes. The report also checks
+that per-operation public snapshots are stored as disk refs, not Oxigraph
+snapshot graphs or `dkg:publicStagedQuads` literals.
+
 ## Extending the Node
 
 The V9 "installable apps" framework (iframe-hosted third-party UIs loaded from

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -242,6 +242,31 @@ subset while doing quick local smoke checks:
 - upload payload to local working memory
 - lift local working memory to shared working memory
 
+### SWM Large-Payload Benchmark
+
+The live SWM large-payload benchmark is aimed at replication and storage
+amplification regressions. It writes large public literals through every node in
+a running devnet, waits until every node can query every benchmark payload from
+shared working memory, and verifies that the run did not create
+`dkg:publicStagedQuads` snapshot literals in SWM metadata.
+
+For the 5-node, 500 MiB regression case, start or reuse a 5-node devnet and run:
+
+```bash
+pnpm bench:swm-large-payload -- \
+  --ports 19101,19102,19103,19104,19105 \
+  --payload-mib-per-node 100 \
+  --chunk-mib 0.5 \
+  --output bench/results/swm-large-payload-500mib.json
+```
+
+Use `--auth-token`, `--auth-token-file`, or `DKG_BENCH_AUTH_TOKEN` when the
+target nodes require bearer auth. The final JSON includes per-node payload
+counts, write timing summaries, replication polls, metadata counts for
+`shareOperationId`, `rootEntity`, and `publishedAt`, the global
+`publicStagedQuads` delta, and an appended log scan for known
+Oxigraph/GossipSub failure signatures when a devnet directory is available.
+
 ## Extending the Node
 
 The V9 "installable apps" framework (iframe-hosted third-party UIs loaded from

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -295,6 +295,12 @@ write runs; live SWM gossip still replicates new writes. The report also checks
 that per-operation public snapshots are stored as disk refs, not Oxigraph
 snapshot graphs or `dkg:publicStagedQuads` literals.
 
+For throughput-drop diagnosis, add `--max-writes <count>` to stop at a smaller
+partial run and leave diagnostics enabled. The JSON report records interval
+throughput, write latency percentiles, per-node `store.nq`/snapshot/log/process
+samples, and appended daemon-log counters. A Markdown summary is written to
+`<output>.analysis.md` by default, or to `--analysis-output <path>`.
+
 ## Extending the Node
 
 The V9 "installable apps" framework (iframe-hosted third-party UIs loaded from

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
     "benchmark:daemon-responsiveness": "node scripts/daemon-responsiveness-benchmark.cjs",
     "benchmark:publish-async-get": "node scripts/publish-async-get-benchmark.cjs",
     "benchmark:swm-large-payload": "node scripts/swm-large-payload-benchmark.cjs",
+    "benchmark:swm-triple-volume": "node scripts/swm-triple-volume-benchmark.cjs",
     "postinstall": "node ./scripts/bundle-markitdown-binaries.mjs --quiet --current-platform --best-effort",
     "markitdown:build": "node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform",
     "test": "vitest run",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
     "benchmark:catchup-runner": "node scripts/catchup-runner-benchmark.cjs",
     "benchmark:daemon-responsiveness": "node scripts/daemon-responsiveness-benchmark.cjs",
     "benchmark:publish-async-get": "node scripts/publish-async-get-benchmark.cjs",
+    "benchmark:swm-large-payload": "node scripts/swm-large-payload-benchmark.cjs",
     "postinstall": "node ./scripts/bundle-markitdown-binaries.mjs --quiet --current-platform --best-effort",
     "markitdown:build": "node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform",
     "test": "vitest run",

--- a/packages/cli/scripts/swm-large-payload-benchmark.cjs
+++ b/packages/cli/scripts/swm-large-payload-benchmark.cjs
@@ -1,0 +1,798 @@
+#!/usr/bin/env node
+
+const { createReadStream, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } = require('node:fs');
+const { dirname, join, resolve } = require('node:path');
+const { performance } = require('node:perf_hooks');
+const { createInterface } = require('node:readline');
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+const DKG_ONTOLOGY = 'http://dkg.io/ontology/';
+const DEFAULT_CONTEXT_GRAPH_ID = 'devnet-test';
+const DEFAULT_PREDICATE = 'urn:dkg:benchmark:swm-large-payload:payload';
+const DEFAULT_NAMESPACE = 'swm-large-payload';
+const FAILURE_PATTERNS = [
+  { name: 'oxigraphWasmUnreachable', text: 'RuntimeError: unreachable' },
+  { name: 'oxigraphTableIndexOutOfBounds', text: 'table index is out of bounds' },
+  { name: 'gossipsubInvalidDataLength', text: 'InvalidDataLengthError' },
+  { name: 'gossipsubMessageTooLong', text: 'Message length too long' },
+];
+
+function usage() {
+  return `Usage: pnpm --filter @origintrail-official/dkg benchmark:swm-large-payload -- [options]
+
+Writes large public SWM payloads to a running multi-node devnet and verifies that
+the replicated payload is not duplicated into dkg:publicStagedQuads metadata.
+
+Options:
+  --ports <list>                 Comma-separated daemon API ports. Default derives from --api-port-base and --nodes.
+  --api-port-base <port>         First daemon API port when --ports is omitted. Default: 9201.
+  --nodes <count>                Node count when --ports is omitted. Default: 5.
+  --context-graph-id <id>        Context graph to write/query. Default: devnet-test.
+  --payload-mib-per-node <MiB>   Payload size written through each node. Default: 100.
+  --chunk-mib <MiB>              Payload literal size per SWM write. Default: 0.5.
+  --write-concurrency <count>    Concurrent write requests. Default: 1.
+  --replication-timeout-ms <ms>  Time to wait for every node to see every payload. Default: 900000.
+  --poll-interval-ms <ms>        Replication polling interval. Default: 5000.
+  --request-timeout-ms <ms>      Per-request timeout. Default: 180000.
+  --query-timeout-ms <ms>        Per-query timeout. Default: 120000.
+  --auth-token <token>           Bearer token. Also reads DKG_BENCH_AUTH_TOKEN, DKG_AUTH_TOKEN, DKG_TOKEN, DEVNET_TOKEN, or DKG_AUTH.
+  --auth-token-file <path>       File containing bearer token. Defaults to DEVNET_DIR/node1/auth.token, if present.
+  --no-auth                      Send requests without Authorization.
+  --run-id <id>                  Stable run id. Default: timestamp + random suffix.
+  --namespace <name>             Subject namespace segment. Default: swm-large-payload.
+  --predicate <iri>              Payload predicate IRI. Default: ${DEFAULT_PREDICATE}.
+  --progress-every <count>       Emit a progress line every N writes. Default: 25.
+  --output <path>                Write the final JSON result to a file.
+  --skip-write                   Only verify an existing run id.
+  --devnet-dir <path>            Devnet directory for appended log scanning. Default: DEVNET_DIR or repo .devnet.
+  --scan-logs / --no-scan-logs   Scan appended daemon logs for known failure signatures. Default: scan when devnet dir exists.
+  --quiet                        Suppress progress events on stderr.
+  -h, --help                     Show this help.
+
+Environment mirrors the main options with DKG_BENCH_SWM_* names, for example
+DKG_BENCH_SWM_PORTS, DKG_BENCH_SWM_PAYLOAD_MIB_PER_NODE, DKG_BENCH_SWM_CHUNK_MIB,
+DKG_BENCH_SWM_OUTPUT, DKG_BENCH_SWM_SCAN_LOGS, and DKG_BENCH_SWM_NO_AUTH.`;
+}
+
+function parsePositiveInteger(name, value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer (got ${JSON.stringify(value)})`);
+  }
+  return parsed;
+}
+
+function parsePositiveNumber(name, value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number (got ${JSON.stringify(value)})`);
+  }
+  return parsed;
+}
+
+function parseBoolean(value, defaultValue = false) {
+  if (value === undefined || value === null || value === '') return defaultValue;
+  if (typeof value === 'boolean') return value;
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+  throw new Error(`Invalid boolean value ${JSON.stringify(value)}`);
+}
+
+function parsePorts(value) {
+  if (value === undefined || value === null || String(value).trim() === '') return undefined;
+  const ports = String(value)
+    .split(',')
+    .map((part) => parsePositiveInteger('port', part.trim()));
+  if (ports.length === 0) return undefined;
+  return ports;
+}
+
+function nextArgValue(argv, index, name, inlineValue) {
+  if (inlineValue !== undefined) return { value: inlineValue, nextIndex: index };
+  if (index + 1 >= argv.length || argv[index + 1].startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  return { value: argv[index + 1], nextIndex: index + 1 };
+}
+
+function readAuthTokenFile(path) {
+  const text = readFileSync(path, 'utf8');
+  const tokens = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'))
+    .flatMap((line) => line.split(/\s+/))
+    .filter(Boolean);
+  return tokens.at(-1);
+}
+
+function resolveAuthToken(options, env, devnetDir) {
+  if (options.noAuth) return undefined;
+  const inline = options.authToken
+    ?? env.DKG_BENCH_AUTH_TOKEN
+    ?? env.DKG_AUTH_TOKEN
+    ?? env.DKG_TOKEN
+    ?? env.DEVNET_TOKEN
+    ?? env.DKG_AUTH;
+  if (inline) return inline;
+
+  const tokenFile = options.authTokenFile
+    ?? env.DKG_BENCH_AUTH_TOKEN_FILE
+    ?? (devnetDir ? join(devnetDir, 'node1', 'auth.token') : undefined);
+  if (tokenFile && existsSync(tokenFile)) {
+    return readAuthTokenFile(tokenFile);
+  }
+  return undefined;
+}
+
+function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const raw = argv[index];
+    if (raw === '--') {
+      continue;
+    }
+    if (raw === '-h' || raw === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (raw === '--no-auth') {
+      options.noAuth = true;
+      continue;
+    }
+    if (raw === '--skip-write') {
+      options.skipWrite = true;
+      continue;
+    }
+    if (raw === '--quiet') {
+      options.quiet = true;
+      continue;
+    }
+    if (raw === '--scan-logs') {
+      options.scanLogs = true;
+      continue;
+    }
+    if (raw === '--no-scan-logs') {
+      options.scanLogs = false;
+      continue;
+    }
+    if (!raw.startsWith('--')) {
+      throw new Error(`Unexpected argument ${JSON.stringify(raw)}`);
+    }
+
+    const eqIndex = raw.indexOf('=');
+    const name = eqIndex >= 0 ? raw.slice(2, eqIndex) : raw.slice(2);
+    const inlineValue = eqIndex >= 0 ? raw.slice(eqIndex + 1) : undefined;
+    const { value, nextIndex } = nextArgValue(argv, index, `--${name}`, inlineValue);
+    index = nextIndex;
+
+    switch (name) {
+      case 'ports':
+        options.ports = parsePorts(value);
+        break;
+      case 'api-port-base':
+        options.apiPortBase = parsePositiveInteger('--api-port-base', value);
+        break;
+      case 'nodes':
+        options.nodes = parsePositiveInteger('--nodes', value);
+        break;
+      case 'context-graph-id':
+        options.contextGraphId = value;
+        break;
+      case 'payload-mib-per-node':
+        options.payloadMiBPerNode = parsePositiveNumber('--payload-mib-per-node', value);
+        break;
+      case 'chunk-mib':
+        options.chunkMiB = parsePositiveNumber('--chunk-mib', value);
+        break;
+      case 'write-concurrency':
+        options.writeConcurrency = parsePositiveInteger('--write-concurrency', value);
+        break;
+      case 'replication-timeout-ms':
+        options.replicationTimeoutMs = parsePositiveInteger('--replication-timeout-ms', value);
+        break;
+      case 'poll-interval-ms':
+        options.pollIntervalMs = parsePositiveInteger('--poll-interval-ms', value);
+        break;
+      case 'request-timeout-ms':
+        options.requestTimeoutMs = parsePositiveInteger('--request-timeout-ms', value);
+        break;
+      case 'query-timeout-ms':
+        options.queryTimeoutMs = parsePositiveInteger('--query-timeout-ms', value);
+        break;
+      case 'auth-token':
+        options.authToken = value;
+        break;
+      case 'auth-token-file':
+        options.authTokenFile = resolve(value);
+        break;
+      case 'run-id':
+        options.runId = value;
+        break;
+      case 'namespace':
+        options.namespace = value;
+        break;
+      case 'predicate':
+        options.predicate = value;
+        break;
+      case 'progress-every':
+        options.progressEvery = parsePositiveInteger('--progress-every', value);
+        break;
+      case 'output':
+        options.output = resolve(value);
+        break;
+      case 'devnet-dir':
+        options.devnetDir = resolve(value);
+        break;
+      default:
+        throw new Error(`Unknown option --${name}`);
+    }
+  }
+
+  const envPorts = parsePorts(env.DKG_BENCH_SWM_PORTS);
+  const devnetDir = options.devnetDir
+    ?? env.DKG_BENCH_SWM_DEVNET_DIR
+    ?? env.DEVNET_DIR
+    ?? join(REPO_ROOT, '.devnet');
+  const nodes = options.nodes
+    ?? (env.DKG_BENCH_SWM_NODES ? parsePositiveInteger('DKG_BENCH_SWM_NODES', env.DKG_BENCH_SWM_NODES) : 5);
+  const apiPortBase = options.apiPortBase
+    ?? (env.DKG_BENCH_SWM_API_PORT_BASE
+      ? parsePositiveInteger('DKG_BENCH_SWM_API_PORT_BASE', env.DKG_BENCH_SWM_API_PORT_BASE)
+      : (env.API_PORT_BASE ? parsePositiveInteger('API_PORT_BASE', env.API_PORT_BASE) : 9201));
+  const ports = options.ports ?? envPorts ?? Array.from({ length: nodes }, (_, index) => apiPortBase + index);
+  const noAuth = options.noAuth ?? parseBoolean(env.DKG_BENCH_SWM_NO_AUTH ?? env.DEVNET_NO_AUTH, false);
+  const config = {
+    help: Boolean(options.help),
+    contextGraphId: options.contextGraphId ?? env.DKG_BENCH_SWM_CONTEXT_GRAPH_ID ?? env.DKG_BENCH_CONTEXT_GRAPH_ID ?? DEFAULT_CONTEXT_GRAPH_ID,
+    ports,
+    nodes: ports.length,
+    apiPortBase,
+    payloadMiBPerNode: options.payloadMiBPerNode
+      ?? (env.DKG_BENCH_SWM_PAYLOAD_MIB_PER_NODE
+        ? parsePositiveNumber('DKG_BENCH_SWM_PAYLOAD_MIB_PER_NODE', env.DKG_BENCH_SWM_PAYLOAD_MIB_PER_NODE)
+        : 100),
+    chunkMiB: options.chunkMiB
+      ?? (env.DKG_BENCH_SWM_CHUNK_MIB ? parsePositiveNumber('DKG_BENCH_SWM_CHUNK_MIB', env.DKG_BENCH_SWM_CHUNK_MIB) : 0.5),
+    writeConcurrency: options.writeConcurrency
+      ?? (env.DKG_BENCH_SWM_WRITE_CONCURRENCY
+        ? parsePositiveInteger('DKG_BENCH_SWM_WRITE_CONCURRENCY', env.DKG_BENCH_SWM_WRITE_CONCURRENCY)
+        : 1),
+    replicationTimeoutMs: options.replicationTimeoutMs
+      ?? (env.DKG_BENCH_SWM_REPLICATION_TIMEOUT_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_REPLICATION_TIMEOUT_MS', env.DKG_BENCH_SWM_REPLICATION_TIMEOUT_MS)
+        : 900_000),
+    pollIntervalMs: options.pollIntervalMs
+      ?? (env.DKG_BENCH_SWM_POLL_INTERVAL_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_POLL_INTERVAL_MS', env.DKG_BENCH_SWM_POLL_INTERVAL_MS)
+        : 5_000),
+    requestTimeoutMs: options.requestTimeoutMs
+      ?? (env.DKG_BENCH_SWM_REQUEST_TIMEOUT_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_REQUEST_TIMEOUT_MS', env.DKG_BENCH_SWM_REQUEST_TIMEOUT_MS)
+        : 180_000),
+    queryTimeoutMs: options.queryTimeoutMs
+      ?? (env.DKG_BENCH_SWM_QUERY_TIMEOUT_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_QUERY_TIMEOUT_MS', env.DKG_BENCH_SWM_QUERY_TIMEOUT_MS)
+        : 120_000),
+    runId: options.runId ?? env.DKG_BENCH_SWM_RUN_ID ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    namespace: options.namespace ?? env.DKG_BENCH_SWM_NAMESPACE ?? DEFAULT_NAMESPACE,
+    predicate: options.predicate ?? env.DKG_BENCH_SWM_PREDICATE ?? DEFAULT_PREDICATE,
+    progressEvery: options.progressEvery
+      ?? (env.DKG_BENCH_SWM_PROGRESS_EVERY
+        ? parsePositiveInteger('DKG_BENCH_SWM_PROGRESS_EVERY', env.DKG_BENCH_SWM_PROGRESS_EVERY)
+        : 25),
+    output: options.output ?? (env.DKG_BENCH_SWM_OUTPUT ? resolve(env.DKG_BENCH_SWM_OUTPUT) : undefined),
+    skipWrite: options.skipWrite ?? parseBoolean(env.DKG_BENCH_SWM_SKIP_WRITE, false),
+    noAuth,
+    devnetDir,
+    scanLogs: options.scanLogs ?? parseBoolean(env.DKG_BENCH_SWM_SCAN_LOGS, existsSync(devnetDir)),
+    quiet: options.quiet ?? parseBoolean(env.DKG_BENCH_SWM_QUIET, false),
+  };
+  config.authToken = resolveAuthToken({ ...options, noAuth }, env, devnetDir);
+  return Object.freeze(config);
+}
+
+function bytesFromMiB(value) {
+  return Math.round(value * 1024 * 1024);
+}
+
+function buildBenchmarkPlan(config) {
+  const payloadBytesPerNode = bytesFromMiB(config.payloadMiBPerNode);
+  const chunkBytes = bytesFromMiB(config.chunkMiB);
+  if (payloadBytesPerNode <= 0) throw new Error('payloadMiBPerNode resolved to zero bytes');
+  if (chunkBytes <= 0) throw new Error('chunkMiB resolved to zero bytes');
+  const chunksPerNode = Math.ceil(payloadBytesPerNode / chunkBytes);
+  const totalOperations = config.ports.length * chunksPerNode;
+  const totalPayloadBytes = payloadBytesPerNode * config.ports.length;
+  const rootPrefix = `urn:dkg:benchmark:${config.namespace}:${config.runId}:`;
+  return Object.freeze({
+    payloadBytesPerNode,
+    chunkBytes,
+    chunksPerNode,
+    totalOperations,
+    totalPayloadBytes,
+    totalPayloadMiB: Number((totalPayloadBytes / 1024 / 1024).toFixed(3)),
+    rootPrefix,
+    metadataGraph: `did:dkg:context-graph:${config.contextGraphId}/_shared_memory_meta`,
+  });
+}
+
+function payloadBytesForChunk(plan, chunkNumber) {
+  const writtenBefore = (chunkNumber - 1) * plan.chunkBytes;
+  return Math.min(plan.chunkBytes, plan.payloadBytesPerNode - writtenBefore);
+}
+
+function makePayload(runId, nodeNumber, chunkNumber, sizeBytes) {
+  const prefix = `swm-large run=${runId} node=${nodeNumber} chunk=${chunkNumber} `;
+  const prefixBytes = Buffer.byteLength(prefix, 'utf8');
+  if (prefixBytes > sizeBytes) {
+    throw new Error(`Payload prefix is ${prefixBytes} bytes, larger than requested ${sizeBytes} byte chunk`);
+  }
+  const fillChar = String.fromCharCode(97 + ((nodeNumber + chunkNumber) % 26));
+  return prefix + fillChar.repeat(sizeBytes - prefixBytes);
+}
+
+function sparqlString(value) {
+  return JSON.stringify(String(value));
+}
+
+function bindingValue(result, name) {
+  return result?.bindings?.[0]?.[name]?.value ?? result?.bindings?.[0]?.[name];
+}
+
+function numericBinding(result, name) {
+  const value = bindingValue(result, name);
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const typedLiteral = value.match(/^"([^"]+)"\^\^<[^>]+>$/);
+    const lexical = typedLiteral ? typedLiteral[1] : value;
+    const parsed = Number(lexical);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return Number.NaN;
+}
+
+async function postJson(port, path, body, config, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const headers = { 'content-type': 'application/json' };
+    if (config.authToken && !config.noAuth) headers.authorization = `Bearer ${config.authToken}`;
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let json;
+    try {
+      json = text ? JSON.parse(text) : {};
+    } catch {
+      json = { raw: text };
+    }
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${path} on ${port}: ${text.slice(0, 500)}`);
+    }
+    return json;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function query(port, sparql, config, options = {}) {
+  const response = await postJson(port, '/api/query', { sparql, ...options }, config, config.queryTimeoutMs);
+  return response.result ?? response;
+}
+
+async function writeChunk(config, plan, nodeIndex, chunkNumber) {
+  const port = config.ports[nodeIndex];
+  const nodeNumber = nodeIndex + 1;
+  const sizeBytes = payloadBytesForChunk(plan, chunkNumber);
+  const subject = `${plan.rootPrefix}node:${nodeNumber}:chunk:${chunkNumber}`;
+  const payload = makePayload(config.runId, nodeNumber, chunkNumber, sizeBytes);
+  const startedAt = performance.now();
+  const response = await postJson(port, '/api/shared-memory/write', {
+    contextGraphId: config.contextGraphId,
+    quads: [{
+      subject,
+      predicate: config.predicate,
+      object: JSON.stringify(payload),
+      graph: '',
+    }],
+  }, config, config.requestTimeoutMs);
+  const durationMs = performance.now() - startedAt;
+  return {
+    port,
+    nodeNumber,
+    chunkNumber,
+    subject,
+    payloadBytes: sizeBytes,
+    durationMs: Number(durationMs.toFixed(2)),
+    operationId: response.operationId,
+  };
+}
+
+function percentile(values, p) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, rank))];
+}
+
+function summarizeWrites(records, config) {
+  const durations = records.map((record) => record.durationMs);
+  const perNode = config.ports.map((port) => {
+    const nodeRecords = records.filter((record) => record.port === port);
+    const nodeDurations = nodeRecords.map((record) => record.durationMs);
+    const nodeBytes = nodeRecords.reduce((sum, record) => sum + record.payloadBytes, 0);
+    return {
+      port,
+      operations: nodeRecords.length,
+      payloadMiB: Number((nodeBytes / 1024 / 1024).toFixed(3)),
+      minMs: Number(Math.min(...nodeDurations).toFixed(2)),
+      maxMs: Number(Math.max(...nodeDurations).toFixed(2)),
+      meanMs: Number((nodeDurations.reduce((sum, value) => sum + value, 0) / Math.max(1, nodeDurations.length)).toFixed(2)),
+      p50Ms: Number(percentile(nodeDurations, 50).toFixed(2)),
+      p95Ms: Number(percentile(nodeDurations, 95).toFixed(2)),
+    };
+  });
+  return {
+    operations: records.length,
+    minMs: Number(Math.min(...durations).toFixed(2)),
+    maxMs: Number(Math.max(...durations).toFixed(2)),
+    meanMs: Number((durations.reduce((sum, value) => sum + value, 0) / Math.max(1, durations.length)).toFixed(2)),
+    p50Ms: Number(percentile(durations, 50).toFixed(2)),
+    p95Ms: Number(percentile(durations, 95).toFixed(2)),
+    perNode,
+  };
+}
+
+function emitProgress(config, event) {
+  if (!config.quiet) {
+    process.stderr.write(`${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`);
+  }
+}
+
+async function runWrites(config, plan) {
+  if (config.skipWrite) {
+    return { durationMs: 0, records: [], summary: undefined };
+  }
+
+  const tasks = [];
+  for (let nodeIndex = 0; nodeIndex < config.ports.length; nodeIndex += 1) {
+    for (let chunkNumber = 1; chunkNumber <= plan.chunksPerNode; chunkNumber += 1) {
+      tasks.push({ nodeIndex, chunkNumber });
+    }
+  }
+
+  const records = [];
+  let nextTask = 0;
+  let completed = 0;
+  const startedAt = performance.now();
+
+  async function worker() {
+    while (nextTask < tasks.length) {
+      const task = tasks[nextTask];
+      nextTask += 1;
+      const record = await writeChunk(config, plan, task.nodeIndex, task.chunkNumber);
+      records.push(record);
+      completed += 1;
+      if (completed === 1 || completed === tasks.length || completed % config.progressEvery === 0) {
+        emitProgress(config, {
+          event: 'write-progress',
+          completed,
+          total: tasks.length,
+          port: record.port,
+          operationId: record.operationId,
+          durationMs: record.durationMs,
+        });
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(config.writeConcurrency, tasks.length) }, () => worker());
+  await Promise.all(workers);
+  const durationMs = performance.now() - startedAt;
+  return {
+    durationMs: Number(durationMs.toFixed(2)),
+    records,
+    summary: summarizeWrites(records, config),
+  };
+}
+
+async function countPayloads(port, config, plan) {
+  const result = await query(
+    port,
+    `SELECT (COUNT(?s) AS ?count) WHERE {
+       ?s <${config.predicate}> ?o .
+       FILTER(STRSTARTS(STR(?s), ${sparqlString(plan.rootPrefix)}))
+     }`,
+    config,
+    { contextGraphId: config.contextGraphId, view: 'shared-working-memory' },
+  );
+  return numericBinding(result, 'count');
+}
+
+async function samplePayloadBytes(port, config, plan) {
+  const result = await query(
+    port,
+    `SELECT (STRLEN(STR(?o)) AS ?len) WHERE {
+       ?s <${config.predicate}> ?o .
+       FILTER(STRSTARTS(STR(?s), ${sparqlString(plan.rootPrefix)}))
+     } LIMIT 1`,
+    config,
+    { contextGraphId: config.contextGraphId, view: 'shared-working-memory' },
+  );
+  return numericBinding(result, 'len');
+}
+
+async function countGlobalMetaPredicate(port, config, plan, predicate) {
+  const result = await query(
+    port,
+    `SELECT (COUNT(?value) AS ?count) WHERE {
+       GRAPH <${plan.metadataGraph}> { ?op <${predicate}> ?value }
+     }`,
+    config,
+  );
+  return numericBinding(result, 'count');
+}
+
+async function countRunMetaPredicate(port, config, plan, predicate) {
+  const result = await query(
+    port,
+    `SELECT (COUNT(?value) AS ?count) WHERE {
+       GRAPH <${plan.metadataGraph}> {
+         ?op <${DKG_ONTOLOGY}rootEntity> ?root ;
+             <${predicate}> ?value .
+         FILTER(STRSTARTS(STR(?root), ${sparqlString(plan.rootPrefix)}))
+       }
+     }`,
+    config,
+  );
+  return numericBinding(result, 'count');
+}
+
+async function countRunRootEntities(port, config, plan) {
+  const result = await query(
+    port,
+    `SELECT (COUNT(?root) AS ?count) WHERE {
+       GRAPH <${plan.metadataGraph}> {
+         ?op <${DKG_ONTOLOGY}rootEntity> ?root .
+         FILTER(STRSTARTS(STR(?root), ${sparqlString(plan.rootPrefix)}))
+       }
+     }`,
+    config,
+  );
+  return numericBinding(result, 'count');
+}
+
+async function collectPublicStagedQuadsBaseline(config, plan) {
+  const entries = [];
+  for (const port of config.ports) {
+    entries.push({
+      port,
+      publicStagedQuadsGlobal: await countGlobalMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publicStagedQuads`),
+    });
+  }
+  return entries;
+}
+
+async function pollReplication(config, plan) {
+  const startedAt = performance.now();
+  const polls = [];
+  while (performance.now() - startedAt <= config.replicationTimeoutMs) {
+    const counts = [];
+    for (const port of config.ports) {
+      try {
+        counts.push({ port, count: await countPayloads(port, config, plan) });
+      } catch (error) {
+        counts.push({ port, error: error instanceof Error ? error.message : String(error) });
+      }
+    }
+    polls.push({ atMs: Number((performance.now() - startedAt).toFixed(2)), counts });
+    emitProgress(config, { event: 'replication-poll', counts });
+    if (counts.every((entry) => entry.count === plan.totalOperations)) {
+      return {
+        converged: true,
+        durationMs: Number((performance.now() - startedAt).toFixed(2)),
+        polls,
+      };
+    }
+    await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
+  }
+  return {
+    converged: false,
+    durationMs: Number((performance.now() - startedAt).toFixed(2)),
+    polls,
+  };
+}
+
+async function collectMetadata(config, plan, baseline) {
+  const byPort = new Map(baseline.map((entry) => [entry.port, entry]));
+  const entries = [];
+  for (const port of config.ports) {
+    const before = byPort.get(port)?.publicStagedQuadsGlobal ?? 0;
+    const after = await countGlobalMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publicStagedQuads`);
+    const payloadCount = await countPayloads(port, config, plan);
+    const rootEntities = await countRunRootEntities(port, config, plan);
+    const shareOperationIds = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}shareOperationId`);
+    const publicStagedQuadsForRun = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publicStagedQuads`);
+    const publisherPeerIds = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publisherPeerId`);
+    const publishedAt = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publishedAt`);
+    const timestamps = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}timestamp`);
+    entries.push({
+      port,
+      payloadCount,
+      samplePayloadBytes: await samplePayloadBytes(port, config, plan),
+      publicStagedQuadsForRun,
+      publicStagedQuadsGlobalBefore: before,
+      publicStagedQuadsGlobalAfter: after,
+      publicStagedQuadsGlobalDelta: after - before,
+      shareOperationIds,
+      rootEntities,
+      publisherPeerIds,
+      publishedAt,
+      timestamps,
+      ok: payloadCount === plan.totalOperations
+        && publicStagedQuadsForRun === 0
+        && after - before === 0
+        && shareOperationIds === plan.totalOperations
+        && rootEntities === plan.totalOperations
+        && publishedAt === plan.totalOperations,
+    });
+  }
+  return entries;
+}
+
+function captureLogOffsets(devnetDir) {
+  if (!devnetDir || !existsSync(devnetDir)) return [];
+  return readdirSync(devnetDir)
+    .filter((name) => /^node\d+$/.test(name))
+    .map((name) => join(devnetDir, name, 'daemon.log'))
+    .filter((file) => existsSync(file))
+    .map((file) => ({ file, offset: statSync(file).size }));
+}
+
+async function scanLogsFromOffsets(offsets) {
+  const matches = [];
+  for (const { file, offset } of offsets) {
+    if (!existsSync(file)) continue;
+    const stream = createReadStream(file, { start: offset, encoding: 'utf8' });
+    const lines = createInterface({ input: stream, crlfDelay: Infinity });
+    let lineNumber = 0;
+    for await (const line of lines) {
+      lineNumber += 1;
+      for (const pattern of FAILURE_PATTERNS) {
+        if (line.includes(pattern.text)) {
+          matches.push({
+            file,
+            lineOffset: lineNumber,
+            pattern: pattern.name,
+            text: pattern.text,
+            line: line.slice(0, 500),
+          });
+        }
+      }
+    }
+  }
+  return {
+    scannedFiles: offsets.map((entry) => entry.file),
+    matches,
+    ok: matches.length === 0,
+  };
+}
+
+function sanitizeConfig(config) {
+  return {
+    contextGraphId: config.contextGraphId,
+    ports: config.ports,
+    payloadMiBPerNode: config.payloadMiBPerNode,
+    chunkMiB: config.chunkMiB,
+    writeConcurrency: config.writeConcurrency,
+    replicationTimeoutMs: config.replicationTimeoutMs,
+    pollIntervalMs: config.pollIntervalMs,
+    requestTimeoutMs: config.requestTimeoutMs,
+    queryTimeoutMs: config.queryTimeoutMs,
+    runId: config.runId,
+    namespace: config.namespace,
+    predicate: config.predicate,
+    skipWrite: config.skipWrite,
+    noAuth: config.noAuth,
+    hasAuthToken: Boolean(config.authToken && !config.noAuth),
+    devnetDir: config.devnetDir,
+    scanLogs: config.scanLogs,
+  };
+}
+
+async function runSwmLargePayloadBenchmark(config) {
+  const startedAtIso = new Date().toISOString();
+  const startedAt = performance.now();
+  const plan = buildBenchmarkPlan(config);
+  const logOffsets = config.scanLogs ? captureLogOffsets(config.devnetDir) : [];
+  emitProgress(config, {
+    event: 'benchmark-start',
+    runId: config.runId,
+    nodes: config.ports.length,
+    totalPayloadMiB: plan.totalPayloadMiB,
+    totalOperations: plan.totalOperations,
+    chunkMiB: config.chunkMiB,
+  });
+
+  const baseline = await collectPublicStagedQuadsBaseline(config, plan);
+  const write = await runWrites(config, plan);
+  const replication = await pollReplication(config, plan);
+  const metadata = await collectMetadata(config, plan, baseline);
+  const logScan = config.scanLogs ? await scanLogsFromOffsets(logOffsets) : undefined;
+  const finishedAt = performance.now();
+
+  const ok = replication.converged
+    && metadata.every((entry) => entry.ok)
+    && (logScan ? logScan.ok : true);
+
+  return {
+    benchmark: 'swm-large-payload',
+    ok,
+    startedAt: startedAtIso,
+    finishedAt: new Date().toISOString(),
+    durationMs: Number((finishedAt - startedAt).toFixed(2)),
+    config: sanitizeConfig(config),
+    plan: {
+      payloadBytesPerNode: plan.payloadBytesPerNode,
+      chunkBytes: plan.chunkBytes,
+      chunksPerNode: plan.chunksPerNode,
+      totalOperations: plan.totalOperations,
+      totalPayloadBytes: plan.totalPayloadBytes,
+      totalPayloadMiB: plan.totalPayloadMiB,
+      rootPrefix: plan.rootPrefix,
+      metadataGraph: plan.metadataGraph,
+    },
+    baseline,
+    write: {
+      durationMs: write.durationMs,
+      summary: write.summary,
+    },
+    replication,
+    metadata,
+    logScan,
+  };
+}
+
+async function main(argv = process.argv.slice(2), env = process.env) {
+  const config = parseBenchmarkArgs(argv, env);
+  if (config.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  if (config.chunkMiB > 1) {
+    emitProgress(config, {
+      event: 'warning',
+      message: 'chunkMiB is above 1 MiB; local GossipSub limits may reject very large single-message writes.',
+    });
+  }
+  const result = await runSwmLargePayloadBenchmark(config);
+  if (config.output) {
+    mkdirSync(dirname(config.output), { recursive: true });
+    writeFileSync(config.output, `${JSON.stringify(result, null, 2)}\n`);
+  }
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildBenchmarkPlan,
+  makePayload,
+  numericBinding,
+  parseBenchmarkArgs,
+  payloadBytesForChunk,
+  runSwmLargePayloadBenchmark,
+  usage,
+};

--- a/packages/cli/scripts/swm-large-payload-benchmark.cjs
+++ b/packages/cli/scripts/swm-large-payload-benchmark.cjs
@@ -578,16 +578,40 @@ async function countGlobalMetaPredicate(port, config, plan, predicate) {
 async function countRunMetaPredicate(port, config, plan, predicate) {
   const result = await query(
     port,
-    `SELECT (COUNT(?value) AS ?count) WHERE {
-       GRAPH <${plan.metadataGraph}> {
-         ?op <${DKG_ONTOLOGY}rootEntity> ?root ;
-             <${predicate}> ?value .
-         FILTER(STRSTARTS(STR(?root), ${sparqlString(plan.rootPrefix)}))
-       }
-     }`,
+    buildRunMetaPredicateCountQuery(plan, predicate),
     config,
   );
   return numericBinding(result, 'count');
+}
+
+async function countRunPublicStagedQuads(port, config, plan) {
+  const result = await query(
+    port,
+    buildRunMetaPredicateCountQuery(
+      plan,
+      `${DKG_ONTOLOGY}publicStagedQuads`,
+      [`${DKG_ONTOLOGY}rootEntity`, `${DKG_ONTOLOGY}publicSliceRootEntity`],
+    ),
+    config,
+  );
+  return numericBinding(result, 'count');
+}
+
+function buildRunMetaPredicateCountQuery(plan, predicate, rootPredicates = [`${DKG_ONTOLOGY}rootEntity`]) {
+  const rootClauses = rootPredicates
+    .map((rootPredicate) => `{ ?op <${rootPredicate}> ?root . }`)
+    .join('\n           UNION\n           ');
+  return `SELECT (COUNT(?value) AS ?count) WHERE {
+       {
+         SELECT DISTINCT ?op ?value WHERE {
+           GRAPH <${plan.metadataGraph}> {
+             ?op <${predicate}> ?value .
+             ${rootClauses}
+             FILTER(STRSTARTS(STR(?root), ${sparqlString(plan.rootPrefix)}))
+           }
+         }
+       }
+     }`;
 }
 
 async function countRunRootEntities(port, config, plan) {
@@ -654,7 +678,7 @@ async function collectMetadata(config, plan, baseline) {
     const payloadCount = await countPayloads(port, config, plan);
     const rootEntities = await countRunRootEntities(port, config, plan);
     const shareOperationIds = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}shareOperationId`);
-    const publicStagedQuadsForRun = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publicStagedQuads`);
+    const publicStagedQuadsForRun = await countRunPublicStagedQuads(port, config, plan);
     const publisherPeerIds = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publisherPeerId`);
     const publishedAt = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publishedAt`);
     const timestamps = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}timestamp`);
@@ -826,6 +850,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  buildRunMetaPredicateCountQuery,
   buildWriteTasks,
   buildBenchmarkPlan,
   makePayload,

--- a/packages/cli/scripts/swm-large-payload-benchmark.cjs
+++ b/packages/cli/scripts/swm-large-payload-benchmark.cjs
@@ -333,6 +333,16 @@ function makePayload(runId, nodeNumber, chunkNumber, sizeBytes) {
   return prefix + fillChar.repeat(sizeBytes - prefixBytes);
 }
 
+function buildWriteTasks(config, plan) {
+  const tasks = [];
+  for (let chunkNumber = 1; chunkNumber <= plan.chunksPerNode; chunkNumber += 1) {
+    for (let nodeIndex = 0; nodeIndex < config.ports.length; nodeIndex += 1) {
+      tasks.push({ nodeIndex, chunkNumber });
+    }
+  }
+  return tasks;
+}
+
 function sparqlString(value) {
   return JSON.stringify(String(value));
 }
@@ -460,12 +470,7 @@ async function runWrites(config, plan) {
     return { durationMs: 0, records: [], summary: undefined };
   }
 
-  const tasks = [];
-  for (let nodeIndex = 0; nodeIndex < config.ports.length; nodeIndex += 1) {
-    for (let chunkNumber = 1; chunkNumber <= plan.chunksPerNode; chunkNumber += 1) {
-      tasks.push({ nodeIndex, chunkNumber });
-    }
-  }
+  const tasks = buildWriteTasks(config, plan);
 
   const records = [];
   let nextTask = 0;
@@ -788,6 +793,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  buildWriteTasks,
   buildBenchmarkPlan,
   makePayload,
   numericBinding,

--- a/packages/cli/scripts/swm-large-payload-benchmark.cjs
+++ b/packages/cli/scripts/swm-large-payload-benchmark.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const { createReadStream, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } = require('node:fs');
-const { dirname, join, resolve } = require('node:path');
+const { dirname, isAbsolute, join, resolve } = require('node:path');
 const { performance } = require('node:perf_hooks');
 const { createInterface } = require('node:readline');
 
@@ -10,6 +10,7 @@ const DKG_ONTOLOGY = 'http://dkg.io/ontology/';
 const DEFAULT_CONTEXT_GRAPH_ID = 'devnet-test';
 const DEFAULT_PREDICATE = 'urn:dkg:benchmark:swm-large-payload:payload';
 const DEFAULT_NAMESPACE = 'swm-large-payload';
+const INVOCATION_CWD = process.env.INIT_CWD || process.cwd();
 const FAILURE_PATTERNS = [
   { name: 'oxigraphWasmUnreachable', text: 'RuntimeError: unreachable' },
   { name: 'oxigraphTableIndexOutOfBounds', text: 'table index is out of bounds' },
@@ -118,7 +119,7 @@ function resolveAuthToken(options, env, devnetDir) {
   if (inline) return inline;
 
   const tokenFile = options.authTokenFile
-    ?? env.DKG_BENCH_AUTH_TOKEN_FILE
+    ?? (env.DKG_BENCH_AUTH_TOKEN_FILE ? resolveInputPath(env.DKG_BENCH_AUTH_TOKEN_FILE) : undefined)
     ?? (devnetDir ? join(devnetDir, 'node1', 'auth.token') : undefined);
   if (tokenFile && existsSync(tokenFile)) {
     return readAuthTokenFile(tokenFile);
@@ -205,7 +206,7 @@ function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
         options.authToken = value;
         break;
       case 'auth-token-file':
-        options.authTokenFile = resolve(value);
+        options.authTokenFile = resolveInputPath(value);
         break;
       case 'run-id':
         options.runId = value;
@@ -220,10 +221,10 @@ function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
         options.progressEvery = parsePositiveInteger('--progress-every', value);
         break;
       case 'output':
-        options.output = resolve(value);
+        options.output = resolveInputPath(value);
         break;
       case 'devnet-dir':
-        options.devnetDir = resolve(value);
+        options.devnetDir = resolveInputPath(value);
         break;
       default:
         throw new Error(`Unknown option --${name}`);
@@ -232,8 +233,8 @@ function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
 
   const envPorts = parsePorts(env.DKG_BENCH_SWM_PORTS);
   const devnetDir = options.devnetDir
-    ?? env.DKG_BENCH_SWM_DEVNET_DIR
-    ?? env.DEVNET_DIR
+    ?? (env.DKG_BENCH_SWM_DEVNET_DIR ? resolveInputPath(env.DKG_BENCH_SWM_DEVNET_DIR) : undefined)
+    ?? (env.DEVNET_DIR ? resolveInputPath(env.DEVNET_DIR) : undefined)
     ?? join(REPO_ROOT, '.devnet');
   const nodes = options.nodes
     ?? (env.DKG_BENCH_SWM_NODES ? parsePositiveInteger('DKG_BENCH_SWM_NODES', env.DKG_BENCH_SWM_NODES) : 5);
@@ -282,7 +283,7 @@ function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
       ?? (env.DKG_BENCH_SWM_PROGRESS_EVERY
         ? parsePositiveInteger('DKG_BENCH_SWM_PROGRESS_EVERY', env.DKG_BENCH_SWM_PROGRESS_EVERY)
         : 25),
-    output: options.output ?? (env.DKG_BENCH_SWM_OUTPUT ? resolve(env.DKG_BENCH_SWM_OUTPUT) : undefined),
+    output: options.output ?? (env.DKG_BENCH_SWM_OUTPUT ? resolveInputPath(env.DKG_BENCH_SWM_OUTPUT) : undefined),
     skipWrite: options.skipWrite ?? parseBoolean(env.DKG_BENCH_SWM_SKIP_WRITE, false),
     noAuth,
     devnetDir,
@@ -291,6 +292,10 @@ function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
   };
   config.authToken = resolveAuthToken({ ...options, noAuth }, env, devnetDir);
   return Object.freeze(config);
+}
+
+function resolveInputPath(value) {
+  return isAbsolute(value) ? value : resolve(INVOCATION_CWD, value);
 }
 
 function bytesFromMiB(value) {
@@ -361,6 +366,31 @@ function numericBinding(result, name) {
     if (Number.isFinite(parsed)) return parsed;
   }
   return Number.NaN;
+}
+
+function literalLexicalValue(value) {
+  if (value == null) return undefined;
+  if (typeof value !== 'string') return String(value);
+  if (!value.startsWith('"')) return value;
+  const closingQuote = findClosingLiteralQuote(value);
+  if (closingQuote < 0) return value;
+  try {
+    return JSON.parse(value.slice(0, closingQuote + 1));
+  } catch {
+    return value.slice(1, closingQuote);
+  }
+}
+
+function findClosingLiteralQuote(term) {
+  for (let i = 1; i < term.length; i += 1) {
+    if (term[i] !== '"') continue;
+    let backslashes = 0;
+    for (let j = i - 1; j >= 0 && term[j] === '\\'; j -= 1) {
+      backslashes += 1;
+    }
+    if (backslashes % 2 === 0) return i;
+  }
+  return -1;
 }
 
 async function postJson(port, path, body, config, timeoutMs) {
@@ -523,14 +553,15 @@ async function countPayloads(port, config, plan) {
 async function samplePayloadBytes(port, config, plan) {
   const result = await query(
     port,
-    `SELECT (STRLEN(STR(?o)) AS ?len) WHERE {
+    `SELECT ?s ?o WHERE {
        ?s <${config.predicate}> ?o .
        FILTER(STRSTARTS(STR(?s), ${sparqlString(plan.rootPrefix)}))
-     } LIMIT 1`,
+     } ORDER BY ?s LIMIT 1`,
     config,
     { contextGraphId: config.contextGraphId, view: 'shared-working-memory' },
   );
-  return numericBinding(result, 'len');
+  const value = literalLexicalValue(bindingValue(result, 'o'));
+  return typeof value === 'string' ? Buffer.byteLength(value, 'utf8') : Number.NaN;
 }
 
 async function countGlobalMetaPredicate(port, config, plan, predicate) {
@@ -627,10 +658,11 @@ async function collectMetadata(config, plan, baseline) {
     const publisherPeerIds = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publisherPeerId`);
     const publishedAt = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}publishedAt`);
     const timestamps = await countRunMetaPredicate(port, config, plan, `${DKG_ONTOLOGY}timestamp`);
+    const sampleBytes = await samplePayloadBytes(port, config, plan);
     entries.push({
       port,
       payloadCount,
-      samplePayloadBytes: await samplePayloadBytes(port, config, plan),
+      samplePayloadBytes: sampleBytes,
       publicStagedQuadsForRun,
       publicStagedQuadsGlobalBefore: before,
       publicStagedQuadsGlobalAfter: after,
@@ -641,6 +673,7 @@ async function collectMetadata(config, plan, baseline) {
       publishedAt,
       timestamps,
       ok: payloadCount === plan.totalOperations
+        && sampleBytes === payloadBytesForChunk(plan, 1)
         && publicStagedQuadsForRun === 0
         && after - before === 0
         && shareOperationIds === plan.totalOperations

--- a/packages/cli/scripts/swm-triple-volume-benchmark.cjs
+++ b/packages/cli/scripts/swm-triple-volume-benchmark.cjs
@@ -4,6 +4,7 @@ const { createReadStream, existsSync, mkdirSync, readFileSync, readdirSync, stat
 const { dirname, isAbsolute, join, resolve } = require('node:path');
 const { performance } = require('node:perf_hooks');
 const { createInterface } = require('node:readline');
+const { execFileSync } = require('node:child_process');
 
 const REPO_ROOT = resolve(__dirname, '../../..');
 const DEFAULT_CONTEXT_GRAPH_ID = 'devnet-test';
@@ -17,6 +18,22 @@ const FAILURE_PATTERNS = [
   { name: 'gossipsubInvalidDataLength', text: 'InvalidDataLengthError' },
   { name: 'gossipsubMessageTooLong', text: 'Message length too long' },
   { name: 'heapOutOfMemory', text: 'JavaScript heap out of memory' },
+];
+const DIAGNOSTIC_LOG_PATTERNS = [
+  ...FAILURE_PATTERNS,
+  { name: 'sharedMemoryWritesStarted', text: 'quads to SWM' },
+  { name: 'sharedMemoryWritesCompleted', text: 'Shared memory write complete' },
+  { name: 'replicatedWritesStored', text: 'Stored SWM write' },
+  { name: 'queryAllContextGraph', text: 'Query on contextGraph="all"' },
+  { name: 'syncingFromPeer', text: 'Syncing from peer' },
+  { name: 'syncTimeout', text: 'Sync timeout' },
+  { name: 'syncFailed', text: 'Sync from ' },
+  { name: 'protocolSyncSend', text: 'send /dkg/10.0.0/sync' },
+  { name: 'skippedSwmSync', text: 'Skipping shared memory sync' },
+  { name: 'rsTick', text: '[rs.tick' },
+  { name: 'rsLoopError', text: '[rs.loop.tick-threw]' },
+  { name: 'socketHangUp', text: 'socket hang up' },
+  { name: 'shuttingDown', text: 'Shutting down' },
 ];
 
 function usage() {
@@ -48,7 +65,11 @@ Options:
   --namespace <name>                Subject namespace segment. Default: swm-triple-volume.
   --predicate-base <iri>            Predicate IRI prefix. Default: ${DEFAULT_PREDICATE_BASE}.
   --progress-every <count>          Emit a progress line every N writes. Default: 25.
+  --max-writes <count>              Stop after N total writes, useful for diagnostic runs.
+  --diagnostic-interval-ms <ms>     Collect process/store/log diagnostics every N ms. Default: 30000.
+  --no-diagnostics                  Disable diagnostic snapshots during the write phase.
   --output <path>                   Write the final JSON result to a file.
+  --analysis-output <path>          Write a Markdown throughput analysis. Default: <output>.analysis.md.
   --skip-write                      Only verify an existing run id.
   --devnet-dir <path>               Devnet directory for appended log scanning. Default: DEVNET_DIR or repo .devnet.
   --scan-logs / --no-scan-logs      Scan appended daemon logs for known failure signatures. Default: scan when devnet dir exists.
@@ -162,6 +183,10 @@ function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
       options.scanLogs = false;
       continue;
     }
+    if (raw === '--no-diagnostics') {
+      options.diagnostics = false;
+      continue;
+    }
     if (!raw.startsWith('--')) throw new Error(`Unexpected argument ${JSON.stringify(raw)}`);
 
     const eqIndex = raw.indexOf('=');
@@ -231,8 +256,17 @@ function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
       case 'progress-every':
         options.progressEvery = parsePositiveInteger('--progress-every', value);
         break;
+      case 'max-writes':
+        options.maxWrites = parsePositiveInteger('--max-writes', value);
+        break;
+      case 'diagnostic-interval-ms':
+        options.diagnosticIntervalMs = parsePositiveInteger('--diagnostic-interval-ms', value);
+        break;
       case 'output':
         options.output = resolveInputPath(value);
+        break;
+      case 'analysis-output':
+        options.analysisOutput = resolveInputPath(value);
         break;
       case 'devnet-dir':
         options.devnetDir = resolveInputPath(value);
@@ -305,11 +339,19 @@ function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
     predicateBase: options.predicateBase ?? env.DKG_BENCH_SWM_TRIPLES_PREDICATE_BASE ?? DEFAULT_PREDICATE_BASE,
     progressEvery: options.progressEvery
       ?? (env.DKG_BENCH_SWM_TRIPLES_PROGRESS_EVERY ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_PROGRESS_EVERY', env.DKG_BENCH_SWM_TRIPLES_PROGRESS_EVERY) : 25),
+    maxWrites: options.maxWrites
+      ?? (env.DKG_BENCH_SWM_TRIPLES_MAX_WRITES ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_MAX_WRITES', env.DKG_BENCH_SWM_TRIPLES_MAX_WRITES) : undefined),
+    diagnosticIntervalMs: options.diagnosticIntervalMs
+      ?? (env.DKG_BENCH_SWM_TRIPLES_DIAGNOSTIC_INTERVAL_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_DIAGNOSTIC_INTERVAL_MS', env.DKG_BENCH_SWM_TRIPLES_DIAGNOSTIC_INTERVAL_MS)
+        : 30_000),
     output: options.output ?? (env.DKG_BENCH_SWM_TRIPLES_OUTPUT ? resolveInputPath(env.DKG_BENCH_SWM_TRIPLES_OUTPUT) : undefined),
+    analysisOutput: options.analysisOutput ?? (env.DKG_BENCH_SWM_TRIPLES_ANALYSIS_OUTPUT ? resolveInputPath(env.DKG_BENCH_SWM_TRIPLES_ANALYSIS_OUTPUT) : undefined),
     skipWrite: options.skipWrite ?? parseBoolean(env.DKG_BENCH_SWM_TRIPLES_SKIP_WRITE, false),
     noAuth,
     devnetDir,
     scanLogs: options.scanLogs ?? parseBoolean(env.DKG_BENCH_SWM_TRIPLES_SCAN_LOGS ?? env.DKG_BENCH_SWM_SCAN_LOGS, existsSync(devnetDir)),
+    diagnostics: options.diagnostics ?? parseBoolean(env.DKG_BENCH_SWM_TRIPLES_DIAGNOSTICS, true),
     quiet: options.quiet ?? parseBoolean(env.DKG_BENCH_SWM_TRIPLES_QUIET ?? env.DKG_BENCH_SWM_QUIET, false),
   };
   config.authToken = resolveAuthToken({ ...options, noAuth }, env, devnetDir);
@@ -398,6 +440,9 @@ function buildWriteTasks(config, plan) {
   for (let writeNumber = 1; writeNumber <= plan.writesPerNode; writeNumber += 1) {
     for (let nodeIndex = 0; nodeIndex < config.ports.length; nodeIndex += 1) {
       tasks.push({ nodeIndex, writeNumber });
+      if (config.maxWrites && tasks.length >= config.maxWrites) {
+        return tasks;
+      }
     }
   }
   return tasks;
@@ -426,6 +471,7 @@ function numericBinding(result, name) {
 async function postJson(port, path, body, config, timeoutMs) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const startedAt = performance.now();
   try {
     const headers = { 'content-type': 'application/json' };
     if (config.authToken && !config.noAuth) headers.authorization = `Bearer ${config.authToken}`;
@@ -446,6 +492,14 @@ async function postJson(port, path, body, config, timeoutMs) {
       throw new Error(`HTTP ${response.status} ${path} on ${port}: ${text.slice(0, 500)}`);
     }
     return json;
+  } catch (error) {
+    const durationMs = Number((performance.now() - startedAt).toFixed(2));
+    const cause = error?.cause;
+    const causeCode = cause?.code ? ` cause=${cause.code}` : '';
+    const message = error instanceof Error ? error.message : String(error);
+    const wrapped = new Error(`${path} on port ${port} failed after ${durationMs}ms: ${message}${causeCode}`);
+    wrapped.cause = error;
+    throw wrapped;
   } finally {
     clearTimeout(timer);
   }
@@ -486,6 +540,25 @@ function percentile(values, p) {
   return sorted[Math.max(0, Math.min(sorted.length - 1, rank))];
 }
 
+function durationSummary(values) {
+  if (values.length === 0) {
+    return {
+      minMs: 0,
+      maxMs: 0,
+      meanMs: 0,
+      p50Ms: 0,
+      p95Ms: 0,
+    };
+  }
+  return {
+    minMs: Number(Math.min(...values).toFixed(2)),
+    maxMs: Number(Math.max(...values).toFixed(2)),
+    meanMs: Number((values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(2)),
+    p50Ms: Number(percentile(values, 50).toFixed(2)),
+    p95Ms: Number(percentile(values, 95).toFixed(2)),
+  };
+}
+
 function summarizeWrites(records, config) {
   const durations = records.map((record) => record.durationMs);
   const perNode = config.ports.map((port) => {
@@ -498,22 +571,14 @@ function summarizeWrites(records, config) {
       writes: nodeRecords.length,
       triples,
       estimatedMiB: Number((estimatedBytes / 1024 / 1024).toFixed(3)),
-      minMs: Number(Math.min(...nodeDurations).toFixed(2)),
-      maxMs: Number(Math.max(...nodeDurations).toFixed(2)),
-      meanMs: Number((nodeDurations.reduce((sum, value) => sum + value, 0) / Math.max(1, nodeDurations.length)).toFixed(2)),
-      p50Ms: Number(percentile(nodeDurations, 50).toFixed(2)),
-      p95Ms: Number(percentile(nodeDurations, 95).toFixed(2)),
+      ...durationSummary(nodeDurations),
     };
   });
   return {
     writes: records.length,
     triples: records.reduce((sum, record) => sum + record.triples, 0),
     estimatedMiB: Number((records.reduce((sum, record) => sum + record.estimatedNQuadBytes, 0) / 1024 / 1024).toFixed(3)),
-    minMs: Number(Math.min(...durations).toFixed(2)),
-    maxMs: Number(Math.max(...durations).toFixed(2)),
-    meanMs: Number((durations.reduce((sum, value) => sum + value, 0) / Math.max(1, durations.length)).toFixed(2)),
-    p50Ms: Number(percentile(durations, 50).toFixed(2)),
-    p95Ms: Number(percentile(durations, 95).toFixed(2)),
+    ...durationSummary(durations),
     perNode,
   };
 }
@@ -522,23 +587,303 @@ function emitProgress(config, event) {
   if (!config.quiet) process.stderr.write(`${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`);
 }
 
-async function runWrites(config, plan) {
-  if (config.skipWrite) return { durationMs: 0, records: [], summary: undefined };
+function errorRecord(error) {
+  return {
+    message: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+    cause: error?.cause instanceof Error ? error.cause.message : undefined,
+  };
+}
+
+function safeFileSize(path) {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+function directoryStats(path) {
+  const totals = { files: 0, bytes: 0 };
+  function visit(dir) {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const child = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(child);
+      } else if (entry.isFile()) {
+        totals.files += 1;
+        totals.bytes += safeFileSize(child);
+      }
+    }
+  }
+  visit(path);
+  totals.mib = Number((totals.bytes / 1024 / 1024).toFixed(3));
+  return totals;
+}
+
+function readPid(path) {
+  try {
+    const value = readFileSync(path, 'utf8').trim();
+    const parsed = Number(value);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parsePsRows() {
+  try {
+    const out = execFileSync('ps', ['-axo', 'pid,ppid,stat,etime,rss,pcpu,command'], {
+      encoding: 'utf8',
+      timeout: 3000,
+      maxBuffer: 5 * 1024 * 1024,
+    });
+    const lines = out.trimEnd().split(/\r?\n/).slice(1);
+    return lines.map((line) => {
+      const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\d+)\s+([\d.]+)\s+(.*)$/);
+      if (!match) return undefined;
+      return {
+        pid: Number(match[1]),
+        ppid: Number(match[2]),
+        stat: match[3],
+        etime: match[4],
+        rssKiB: Number(match[5]),
+        cpuPercent: Number(match[6]),
+        command: match[7],
+      };
+    }).filter(Boolean);
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function processTreeStats(rootPid, psRows) {
+  if (!rootPid || !Array.isArray(psRows)) return undefined;
+  const byParent = new Map();
+  for (const row of psRows) {
+    if (!byParent.has(row.ppid)) byParent.set(row.ppid, []);
+    byParent.get(row.ppid).push(row);
+  }
+  const rows = [];
+  const stack = [rootPid];
+  const seen = new Set();
+  while (stack.length > 0) {
+    const pid = stack.pop();
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    const row = psRows.find((candidate) => candidate.pid === pid);
+    if (row) rows.push(row);
+    for (const child of byParent.get(pid) ?? []) {
+      stack.push(child.pid);
+    }
+  }
+  if (rows.length === 0) return undefined;
+  const rssKiB = rows.reduce((sum, row) => sum + row.rssKiB, 0);
+  const cpuPercent = rows.reduce((sum, row) => sum + row.cpuPercent, 0);
+  return {
+    rootPid,
+    processes: rows.length,
+    rssMiB: Number((rssKiB / 1024).toFixed(2)),
+    cpuPercent: Number(cpuPercent.toFixed(1)),
+    commands: rows.slice(0, 5).map((row) => ({
+      pid: row.pid,
+      ppid: row.ppid,
+      stat: row.stat,
+      etime: row.etime,
+      rssMiB: Number((row.rssKiB / 1024).toFixed(2)),
+      cpuPercent: row.cpuPercent,
+      command: row.command.slice(0, 160),
+    })),
+  };
+}
+
+async function countLogPatternsFromOffsets(offsets, patterns = DIAGNOSTIC_LOG_PATTERNS, options = {}) {
+  const byNode = [];
+  for (const entry of offsets) {
+    const counts = Object.fromEntries(patterns.map((pattern) => [pattern.name, 0]));
+    let bytes = 0;
+    if (existsSync(entry.file)) {
+      const end = safeFileSize(entry.file);
+      bytes = Math.max(0, end - entry.offset);
+      if (bytes > 0) {
+        const stream = createReadStream(entry.file, {
+          encoding: 'utf8',
+          start: entry.offset,
+        });
+        const rl = createInterface({ input: stream, crlfDelay: Infinity });
+        for await (const line of rl) {
+          for (const pattern of patterns) {
+            if (line.includes(pattern.text)) counts[pattern.name] += 1;
+          }
+        }
+      }
+      if (options.updateOffsets) entry.offset = end;
+    }
+    byNode.push({ nodeName: entry.nodeName, bytes, counts });
+  }
+  const totals = Object.fromEntries(patterns.map((pattern) => [pattern.name, 0]));
+  for (const entry of byNode) {
+    for (const [key, value] of Object.entries(entry.counts)) {
+      totals[key] = (totals[key] ?? 0) + value;
+    }
+  }
+  return { totals, byNode };
+}
+
+function emptyLogTotals(patterns = DIAGNOSTIC_LOG_PATTERNS) {
+  return Object.fromEntries(patterns.map((pattern) => [pattern.name, 0]));
+}
+
+function addLogTotals(target, source) {
+  for (const [key, value] of Object.entries(source)) {
+    target[key] = (target[key] ?? 0) + value;
+  }
+}
+
+async function collectDiagnosticSnapshot(config, state, logOffsets, cumulativeLogTotals) {
+  if (!config.diagnostics || !config.devnetDir || !existsSync(config.devnetDir)) return undefined;
+  const psRows = parsePsRows();
+  const logCounters = await countLogPatternsFromOffsets(logOffsets, DIAGNOSTIC_LOG_PATTERNS, {
+    updateOffsets: Boolean(cumulativeLogTotals),
+  });
+  if (cumulativeLogTotals) {
+    addLogTotals(cumulativeLogTotals, logCounters.totals);
+    logCounters.deltaTotals = logCounters.totals;
+    logCounters.totals = { ...cumulativeLogTotals };
+  }
+  const nodes = config.ports.map((port, index) => {
+    const nodeName = `node${index + 1}`;
+    const nodeDir = join(config.devnetDir, nodeName);
+    const rootPid = readPid(join(nodeDir, 'daemon.pid')) ?? readPid(join(nodeDir, 'devnet.pid'));
+    const storePath = join(nodeDir, 'store.nq');
+    const snapshotDir = join(nodeDir, 'swm-public-snapshots');
+    return {
+      nodeName,
+      port,
+      pid: rootPid,
+      process: processTreeStats(rootPid, psRows),
+      storeNqMiB: Number((safeFileSize(storePath) / 1024 / 1024).toFixed(3)),
+      publicSnapshotStore: directoryStats(snapshotDir),
+      daemonLogMiB: Number((safeFileSize(join(nodeDir, 'daemon.log')) / 1024 / 1024).toFixed(3)),
+    };
+  });
+  return {
+    atMs: Number((performance.now() - state.startedAt).toFixed(2)),
+    completed: state.completed,
+    estimatedMiBWritten: Number((state.estimatedBytes / 1024 / 1024).toFixed(3)),
+    nodes,
+    logCounters,
+    psError: psRows.error,
+  };
+}
+
+async function runWrites(config, plan, logOffsets = []) {
+  if (config.skipWrite) {
+    return {
+      ok: true,
+      durationMs: 0,
+      attemptedWrites: 0,
+      completedWrites: 0,
+      records: [],
+      intervals: [],
+      diagnostics: [],
+      summary: undefined,
+    };
+  }
 
   const tasks = buildWriteTasks(config, plan);
   const records = [];
+  const intervals = [];
+  const diagnostics = [];
   let nextTask = 0;
   let completed = 0;
+  let estimatedBytes = 0;
+  let failedError;
   const startedAt = performance.now();
+  let lastProgressAt = startedAt;
+  let lastProgressCompleted = 0;
+  let lastProgressBytes = 0;
+  let lastProgressRecordIndex = 0;
+  const state = { startedAt, completed, estimatedBytes };
+  const diagnosticLogOffsets = logOffsets.map((entry) => ({ ...entry }));
+  const cumulativeLogTotals = emptyLogTotals();
+  let diagnosticInFlight = Promise.resolve();
+
+  function queueDiagnosticSnapshot() {
+    if (!config.diagnostics) return;
+    diagnosticInFlight = diagnosticInFlight
+      .catch(() => {})
+      .then(async () => {
+        const snapshot = await collectDiagnosticSnapshot(config, state, diagnosticLogOffsets, cumulativeLogTotals);
+        if (snapshot) diagnostics.push(snapshot);
+      });
+  }
+
+  const diagnosticTimer = config.diagnostics
+    ? setInterval(queueDiagnosticSnapshot, config.diagnosticIntervalMs)
+    : undefined;
+  if (diagnosticTimer?.unref) diagnosticTimer.unref();
 
   async function worker() {
     while (nextTask < tasks.length) {
+      if (failedError) return;
       const task = tasks[nextTask];
       nextTask += 1;
-      const record = await writeBatch(config, plan, task.nodeIndex, task.writeNumber);
+      let record;
+      try {
+        record = await writeBatch(config, plan, task.nodeIndex, task.writeNumber);
+      } catch (error) {
+        failedError = error;
+        emitProgress(config, {
+          event: 'write-error',
+          completed,
+          total: tasks.length,
+          nodeIndex: task.nodeIndex,
+          port: config.ports[task.nodeIndex],
+          writeNumber: task.writeNumber,
+          error: errorRecord(error).message,
+        });
+        return;
+      }
       records.push(record);
       completed += 1;
+      estimatedBytes += record.estimatedNQuadBytes;
+      state.completed = completed;
+      state.estimatedBytes = estimatedBytes;
       if (completed === 1 || completed === tasks.length || completed % config.progressEvery === 0) {
+        const now = performance.now();
+        const intervalRecords = records.slice(lastProgressRecordIndex);
+        const intervalMs = now - lastProgressAt;
+        const intervalWrites = completed - lastProgressCompleted;
+        const intervalBytes = estimatedBytes - lastProgressBytes;
+        const intervalDurations = intervalRecords.map((entry) => entry.durationMs);
+        const progress = {
+          atMs: Number((now - startedAt).toFixed(2)),
+          completed,
+          total: tasks.length,
+          intervalWrites,
+          intervalMs: Number(intervalMs.toFixed(2)),
+          writesPerSec: Number((intervalWrites / Math.max(1, intervalMs / 1000)).toFixed(3)),
+          miBPerSec: Number((intervalBytes / 1024 / 1024 / Math.max(1, intervalMs / 1000)).toFixed(3)),
+          estimatedMiBWritten: Number((estimatedBytes / 1024 / 1024).toFixed(3)),
+          latencyMs: {
+            mean: Number((intervalDurations.reduce((sum, value) => sum + value, 0) / Math.max(1, intervalDurations.length)).toFixed(2)),
+            p50: Number(percentile(intervalDurations, 50).toFixed(2)),
+            p95: Number(percentile(intervalDurations, 95).toFixed(2)),
+            max: Number(Math.max(...intervalDurations, 0).toFixed(2)),
+          },
+          perPortWrites: Object.fromEntries(config.ports.map((port) => [
+            port,
+            intervalRecords.filter((entry) => entry.port === port).length,
+          ])),
+        };
+        intervals.push(progress);
         emitProgress(config, {
           event: 'write-progress',
           completed,
@@ -547,18 +892,37 @@ async function runWrites(config, plan) {
           triples: record.triples,
           estimatedMiB: Number((record.estimatedNQuadBytes / 1024 / 1024).toFixed(3)),
           durationMs: record.durationMs,
+          writesPerSec: progress.writesPerSec,
+          miBPerSec: progress.miBPerSec,
+          p95Ms: progress.latencyMs.p95,
         });
+        lastProgressAt = now;
+        lastProgressCompleted = completed;
+        lastProgressBytes = estimatedBytes;
+        lastProgressRecordIndex = records.length;
       }
     }
   }
 
   const workers = Array.from({ length: Math.min(config.writeConcurrency, tasks.length) }, () => worker());
-  await Promise.all(workers);
+  try {
+    await Promise.all(workers);
+  } finally {
+    if (diagnosticTimer) clearInterval(diagnosticTimer);
+    queueDiagnosticSnapshot();
+    await diagnosticInFlight.catch(() => {});
+  }
   const durationMs = performance.now() - startedAt;
   return {
+    ok: !failedError && completed === tasks.length,
     durationMs: Number(durationMs.toFixed(2)),
+    attemptedWrites: tasks.length,
+    completedWrites: completed,
     records,
-    summary: summarizeWrites(records, config),
+    intervals,
+    diagnostics,
+    error: failedError ? errorRecord(failedError) : undefined,
+    summary: records.length > 0 ? summarizeWrites(records, config) : undefined,
   };
 }
 
@@ -610,7 +974,7 @@ async function countRunMetaPredicate(port, config, plan, predicate, rootPredicat
   return numericBinding(result, 'count');
 }
 
-async function collectMetadata(config, plan) {
+async function collectMetadata(config, plan, expectedWrites = plan.totalWrites) {
   const entries = [];
   for (const port of config.ports) {
     const publicStagedQuads = await countRunMetaPredicate(
@@ -641,13 +1005,13 @@ async function collectMetadata(config, plan) {
       publicSnapshotRefs,
       ok: publicStagedQuads === 0
         && publicSnapshotGraphs === 0
-        && publicSnapshotRefs === plan.totalWrites,
+        && publicSnapshotRefs === expectedWrites,
     });
   }
   return entries;
 }
 
-async function pollReplication(config, plan) {
+async function pollReplication(config, plan, expectedTriples = plan.totalTriples) {
   const startedAt = performance.now();
   const polls = [];
   while (performance.now() - startedAt <= config.replicationTimeoutMs) {
@@ -661,7 +1025,7 @@ async function pollReplication(config, plan) {
     }
     polls.push({ atMs: Number((performance.now() - startedAt).toFixed(2)), counts });
     emitProgress(config, { event: 'replication-poll', counts });
-    if (counts.every((entry) => entry.count === plan.totalTriples)) {
+    if (counts.every((entry) => entry.count === expectedTriples)) {
       return {
         converged: true,
         durationMs: Number((performance.now() - startedAt).toFixed(2)),
@@ -677,7 +1041,7 @@ async function pollReplication(config, plan) {
   };
 }
 
-async function collectSamples(config, plan) {
+async function collectSamples(config, plan, expectedTriples = plan.totalTriples) {
   const entries = [];
   for (const port of config.ports) {
     const count = await countTriples(port, config, plan);
@@ -686,7 +1050,7 @@ async function collectSamples(config, plan) {
       port,
       count,
       sample,
-      ok: count === plan.totalTriples && Boolean(sample),
+      ok: count === expectedTriples && Boolean(sample),
     });
   }
   return entries;
@@ -744,6 +1108,10 @@ function sanitizeConfig(config) {
     pollIntervalMs: config.pollIntervalMs,
     requestTimeoutMs: config.requestTimeoutMs,
     queryTimeoutMs: config.queryTimeoutMs,
+    progressEvery: config.progressEvery,
+    maxWrites: config.maxWrites,
+    diagnosticIntervalMs: config.diagnosticIntervalMs,
+    diagnostics: config.diagnostics,
     runId: config.runId,
     namespace: config.namespace,
     predicateBase: config.predicateBase,
@@ -753,6 +1121,227 @@ function sanitizeConfig(config) {
     devnetDir: config.devnetDir,
     scanLogs: config.scanLogs,
   };
+}
+
+function finiteNumber(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function summarizeInterval(interval) {
+  if (!interval) return undefined;
+  return {
+    atMs: finiteNumber(interval.atMs),
+    completed: finiteNumber(interval.completed),
+    writesPerSec: finiteNumber(interval.writesPerSec),
+    miBPerSec: finiteNumber(interval.miBPerSec),
+    p95Ms: finiteNumber(interval.latencyMs?.p95),
+    maxMs: finiteNumber(interval.latencyMs?.max),
+  };
+}
+
+function latestDiagnosticWithNodes(diagnostics) {
+  if (!Array.isArray(diagnostics)) return undefined;
+  for (let index = diagnostics.length - 1; index >= 0; index -= 1) {
+    if (Array.isArray(diagnostics[index]?.nodes)) return diagnostics[index];
+  }
+  return diagnostics.at(-1);
+}
+
+function analyzeThroughput(result) {
+  const write = result?.write ?? {};
+  const intervals = Array.isArray(write.intervals)
+    ? write.intervals.filter((interval) => Number.isFinite(Number(interval.writesPerSec)))
+    : [];
+  const first = intervals[0];
+  const peak = intervals.reduce((best, interval) => (
+    finiteNumber(interval.writesPerSec) > finiteNumber(best?.writesPerSec) ? interval : best
+  ), undefined);
+  const final = intervals.at(-1);
+  const peakRate = finiteNumber(peak?.writesPerSec);
+  const finalRate = finiteNumber(final?.writesPerSec);
+  const dropFromPeak = peakRate > 0 ? Number(((peakRate - finalRate) / peakRate).toFixed(3)) : 0;
+  const halfPeakAt = peakRate > 0
+    ? intervals.find((interval) => (
+      finiteNumber(interval.atMs) > finiteNumber(peak?.atMs)
+        && finiteNumber(interval.writesPerSec) <= peakRate / 2
+    ))
+    : undefined;
+  const latestDiagnostic = latestDiagnosticWithNodes(write.diagnostics);
+  const logTotals = latestDiagnostic?.logCounters?.totals
+    ?? result?.logScan?.diagnosticCounts?.totals
+    ?? {};
+  const nodeStorage = Array.isArray(latestDiagnostic?.nodes)
+    ? latestDiagnostic.nodes.map((node) => ({
+      nodeName: node.nodeName,
+      port: node.port,
+      storeNqMiB: finiteNumber(node.storeNqMiB),
+      snapshotMiB: finiteNumber(node.publicSnapshotStore?.mib),
+      snapshotFiles: finiteNumber(node.publicSnapshotStore?.files),
+      daemonLogMiB: finiteNumber(node.daemonLogMiB),
+      rssMiB: finiteNumber(node.process?.rssMiB),
+      cpuPercent: finiteNumber(node.process?.cpuPercent),
+      processes: finiteNumber(node.process?.processes),
+    }))
+    : [];
+
+  const signals = [];
+  if (write.error) {
+    signals.push({
+      name: 'write-failure',
+      severity: 'high',
+      detail: write.error.message,
+    });
+  }
+  if (dropFromPeak >= 0.5 && intervals.length >= 2) {
+    signals.push({
+      name: 'throughput-drop',
+      severity: 'high',
+      detail: `Final interval is ${(dropFromPeak * 100).toFixed(1)}% below peak throughput.`,
+    });
+  }
+  const syncSignals = ['syncTimeout', 'syncFailed', 'syncingFromPeer', 'protocolSyncSend']
+    .reduce((sum, key) => sum + finiteNumber(logTotals[key]), 0);
+  if (syncSignals > 0) {
+    signals.push({
+      name: 'sync-backpressure',
+      severity: 'medium',
+      detail: `Observed ${syncSignals} durable-sync or catch-up log events during the measured window.`,
+    });
+  }
+  if (finiteNumber(logTotals.queryAllContextGraph) > 0) {
+    signals.push({
+      name: 'status-query-load',
+      severity: 'medium',
+      detail: `Observed ${finiteNumber(logTotals.queryAllContextGraph)} all-context query log events during the measured window.`,
+    });
+  }
+  const rpcSignals = ['rsLoopError', 'socketHangUp']
+    .reduce((sum, key) => sum + finiteNumber(logTotals[key]), 0);
+  if (rpcSignals > 0) {
+    signals.push({
+      name: 'rpc-instability',
+      severity: 'high',
+      detail: `Observed ${rpcSignals} RPC loop or socket hang-up events during the measured window.`,
+    });
+  }
+  const storageMiB = nodeStorage.reduce((sum, node) => sum + node.storeNqMiB, 0);
+  if (storageMiB > 0) {
+    signals.push({
+      name: 'store-growth',
+      severity: 'info',
+      detail: `Latest sampled store.nq total is ${storageMiB.toFixed(1)} MiB across ${nodeStorage.length} nodes.`,
+    });
+  }
+
+  return {
+    attemptedWrites: finiteNumber(write.attemptedWrites),
+    completedWrites: finiteNumber(write.completedWrites),
+    intervalCount: intervals.length,
+    firstInterval: summarizeInterval(first),
+    peakInterval: summarizeInterval(peak),
+    finalInterval: summarizeInterval(final),
+    dropFromPeak,
+    halfPeakAt: summarizeInterval(halfPeakAt),
+    slowestIntervals: [...intervals]
+      .sort((a, b) => finiteNumber(a.writesPerSec) - finiteNumber(b.writesPerSec))
+      .slice(0, 5)
+      .map(summarizeInterval),
+    latestDiagnosticsAtMs: finiteNumber(latestDiagnostic?.atMs),
+    nodeStorage,
+    logTotals,
+    signals,
+  };
+}
+
+function tableOrPlaceholder(headers, rows) {
+  if (rows.length === 0) return '_No samples captured._';
+  return [
+    `| ${headers.join(' | ')} |`,
+    `| ${headers.map(() => '---').join(' | ')} |`,
+    ...rows.map((row) => `| ${row.join(' | ')} |`),
+  ].join('\n');
+}
+
+function renderAnalysisMarkdown(result) {
+  const analysis = result.analysis ?? analyzeThroughput(result);
+  const signals = Array.isArray(analysis.signals) ? analysis.signals : [];
+  const slowestIntervals = Array.isArray(analysis.slowestIntervals) ? analysis.slowestIntervals : [];
+  const nodeStorage = Array.isArray(analysis.nodeStorage) ? analysis.nodeStorage : [];
+  const lines = [
+    '# SWM Triple-Volume Throughput Analysis',
+    '',
+    `- Status: ${result.ok ? 'pass' : 'fail'}`,
+    `- Run id: ${result.config?.runId ?? 'unknown'}`,
+    `- Completed writes: ${analysis.completedWrites}/${analysis.attemptedWrites}`,
+    `- Peak throughput: ${analysis.peakInterval?.writesPerSec ?? 0} writes/sec (${analysis.peakInterval?.miBPerSec ?? 0} MiB/sec)`,
+    `- Final throughput: ${analysis.finalInterval?.writesPerSec ?? 0} writes/sec (${analysis.finalInterval?.miBPerSec ?? 0} MiB/sec)`,
+    `- Drop from peak: ${(finiteNumber(analysis.dropFromPeak) * 100).toFixed(1)}%`,
+    '',
+    '## Signals',
+    '',
+  ];
+
+  if (signals.length === 0) {
+    lines.push('_No throughput-drop signal was detected in the captured intervals._');
+  } else {
+    for (const signal of signals) {
+      lines.push(`- ${signal.severity}: ${signal.name} - ${signal.detail}`);
+    }
+  }
+
+  lines.push(
+    '',
+    '## Slowest Intervals',
+    '',
+    tableOrPlaceholder(
+      ['at ms', 'completed', 'writes/sec', 'MiB/sec', 'p95 ms', 'max ms'],
+      slowestIntervals.map((interval) => [
+        interval.atMs,
+        interval.completed,
+        interval.writesPerSec,
+        interval.miBPerSec,
+        interval.p95Ms,
+        interval.maxMs,
+      ]),
+    ),
+    '',
+    '## Latest Node Snapshot',
+    '',
+    tableOrPlaceholder(
+      ['node', 'port', 'store MiB', 'snap MiB', 'snap files', 'rss MiB', 'cpu %', 'log MiB'],
+      nodeStorage.map((node) => [
+        node.nodeName,
+        node.port,
+        node.storeNqMiB,
+        node.snapshotMiB,
+        node.snapshotFiles,
+        node.rssMiB,
+        node.cpuPercent,
+        node.daemonLogMiB,
+      ]),
+    ),
+    '',
+    '## Diagnostic Log Counters',
+    '',
+    '```json',
+    JSON.stringify(analysis.logTotals ?? {}, null, 2),
+    '```',
+    '',
+    '## Interpretation',
+    '',
+    'This benchmark measures write-path throughput while SWM gossip, durable sync, status queries, and Oxigraph persistence are active. A throughput drop with sync-backpressure or all-context query counters points at runtime load around replication/catch-up and query traffic, not large literal externalization. A drop without those counters points more directly at local RDF store/index growth or daemon resource pressure.',
+    '',
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+function defaultAnalysisOutput(output) {
+  if (!output) return undefined;
+  return output.endsWith('.json')
+    ? `${output.slice(0, -'.json'.length)}.analysis.md`
+    : `${output}.analysis.md`;
 }
 
 async function runSwmTripleVolumeBenchmark(config) {
@@ -772,18 +1361,55 @@ async function runSwmTripleVolumeBenchmark(config) {
     totalTriples: plan.totalTriples,
   });
 
-  const write = await runWrites(config, plan);
-  const replication = await pollReplication(config, plan);
-  const samples = await collectSamples(config, plan);
-  const metadata = await collectMetadata(config, plan);
+  const write = await runWrites(config, plan, logOffsets);
+  const expectedWrites = config.skipWrite ? plan.totalWrites : write.completedWrites;
+  const expectedTriples = expectedWrites * config.triplesPerWrite;
+  let replication = {
+    skipped: true,
+    reason: write.ok ? 'not run' : 'write phase failed',
+    converged: false,
+    polls: [],
+  };
+  let samples = [];
+  let metadata = [];
+  let verificationError;
+  if (write.ok) {
+    try {
+      replication = await pollReplication(config, plan, expectedTriples);
+      samples = await collectSamples(config, plan, expectedTriples);
+      metadata = await collectMetadata(config, plan, expectedWrites);
+    } catch (error) {
+      verificationError = errorRecord(error);
+      replication = {
+        skipped: false,
+        converged: false,
+        polls: replication.polls ?? [],
+        error: verificationError,
+      };
+      emitProgress(config, {
+        event: 'verification-error',
+        error: verificationError.message,
+      });
+    }
+  } else {
+    emitProgress(config, {
+      event: 'verification-skipped',
+      reason: 'write phase failed',
+      completedWrites: write.completedWrites,
+      attemptedWrites: write.attemptedWrites,
+    });
+  }
+  const diagnosticCounts = config.scanLogs ? await countLogPatternsFromOffsets(logOffsets) : undefined;
   const logScan = config.scanLogs ? await scanLogsFromOffsets(logOffsets) : undefined;
+  if (logScan && diagnosticCounts) logScan.diagnosticCounts = diagnosticCounts;
   const finishedAt = performance.now();
-  const ok = replication.converged
+  const ok = write.ok
+    && !verificationError
+    && replication.converged
     && samples.every((entry) => entry.ok)
     && metadata.every((entry) => entry.ok)
     && (logScan ? logScan.ok : true);
-
-  return {
+  const result = {
     benchmark: 'swm-triple-volume',
     ok,
     startedAt: startedAtIso,
@@ -793,13 +1419,22 @@ async function runSwmTripleVolumeBenchmark(config) {
     plan,
     metadata,
     write: {
+      ok: write.ok,
       durationMs: write.durationMs,
+      attemptedWrites: write.attemptedWrites,
+      completedWrites: write.completedWrites,
       summary: write.summary,
+      intervals: write.intervals,
+      diagnostics: write.diagnostics,
+      error: write.error,
     },
     replication,
     samples,
     logScan,
+    error: verificationError,
   };
+  result.analysis = analyzeThroughput(result);
+  return result;
 }
 
 async function main(argv = process.argv.slice(2), env = process.env) {
@@ -812,6 +1447,11 @@ async function main(argv = process.argv.slice(2), env = process.env) {
   if (config.output) {
     mkdirSync(dirname(config.output), { recursive: true });
     writeFileSync(config.output, `${JSON.stringify(result, null, 2)}\n`);
+  }
+  const analysisOutput = config.analysisOutput ?? defaultAnalysisOutput(config.output);
+  if (analysisOutput) {
+    mkdirSync(dirname(analysisOutput), { recursive: true });
+    writeFileSync(analysisOutput, renderAnalysisMarkdown(result));
   }
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   if (!result.ok) process.exitCode = 1;
@@ -827,11 +1467,14 @@ if (require.main === module) {
 module.exports = {
   buildBenchmarkPlan,
   buildWriteTasks,
+  defaultAnalysisOutput,
   estimateQuadNQuadBytes,
   estimateQuadsNQuadBytes,
   makeObjectLexical,
   makeQuads,
+  analyzeThroughput,
   parseBenchmarkArgs,
+  renderAnalysisMarkdown,
   runSwmTripleVolumeBenchmark,
   usage,
 };

--- a/packages/cli/scripts/swm-triple-volume-benchmark.cjs
+++ b/packages/cli/scripts/swm-triple-volume-benchmark.cjs
@@ -1,0 +1,837 @@
+#!/usr/bin/env node
+
+const { createReadStream, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } = require('node:fs');
+const { dirname, isAbsolute, join, resolve } = require('node:path');
+const { performance } = require('node:perf_hooks');
+const { createInterface } = require('node:readline');
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+const DEFAULT_CONTEXT_GRAPH_ID = 'devnet-test';
+const DEFAULT_NAMESPACE = 'swm-triple-volume';
+const DEFAULT_PREDICATE_BASE = 'urn:dkg:benchmark:swm-triple-volume:p';
+const DKG_ONTOLOGY = 'http://dkg.io/ontology/';
+const INVOCATION_CWD = process.env.INIT_CWD || process.cwd();
+const FAILURE_PATTERNS = [
+  { name: 'oxigraphWasmUnreachable', text: 'RuntimeError: unreachable' },
+  { name: 'oxigraphTableIndexOutOfBounds', text: 'table index is out of bounds' },
+  { name: 'gossipsubInvalidDataLength', text: 'InvalidDataLengthError' },
+  { name: 'gossipsubMessageTooLong', text: 'Message length too long' },
+  { name: 'heapOutOfMemory', text: 'JavaScript heap out of memory' },
+];
+
+function usage() {
+  return `Usage: pnpm --filter @origintrail-official/dkg benchmark:swm-triple-volume -- [options]
+
+Writes many small public SWM triples to a running multi-node devnet and verifies
+that every node can count the replicated triple volume. This stresses Oxigraph
+triple/index volume rather than large literal byte externalization.
+
+Options:
+  --ports <list>                    Comma-separated daemon API ports. Default derives from --api-port-base and --nodes.
+  --api-port-base <port>            First daemon API port when --ports is omitted. Default: 9201.
+  --nodes <count>                   Node count when --ports is omitted. Default: 5.
+  --context-graph-id <id>           Context graph to write/query. Default: devnet-test.
+  --target-mib-per-node <MiB>       Approximate serialized N-Quad bytes to write per node. Default: 1024.
+  --target-gib-per-node <GiB>       Same target in GiB; overrides --target-mib-per-node.
+  --triples-per-write <count>       Small triples per /api/shared-memory/write request. Default: 1000.
+  --object-bytes <bytes>            Lexical bytes for generated literal objects. Default: 64.
+  --predicate-count <count>         Number of predicates to rotate through. Default: 8.
+  --write-concurrency <count>       Concurrent write requests. Default: 1.
+  --replication-timeout-ms <ms>     Time to wait for every node to see every triple. Default: 1800000.
+  --poll-interval-ms <ms>           Replication polling interval. Default: 10000.
+  --request-timeout-ms <ms>         Per-request timeout. Default: 180000.
+  --query-timeout-ms <ms>           Per-query timeout. Default: 180000.
+  --auth-token <token>              Bearer token. Also reads DKG_BENCH_AUTH_TOKEN, DKG_AUTH_TOKEN, DKG_TOKEN, DEVNET_TOKEN, or DKG_AUTH.
+  --auth-token-file <path>          File containing bearer token. Defaults to DEVNET_DIR/node1/auth.token, if present.
+  --no-auth                         Send requests without Authorization.
+  --run-id <id>                     Stable run id. Default: timestamp + random suffix.
+  --namespace <name>                Subject namespace segment. Default: swm-triple-volume.
+  --predicate-base <iri>            Predicate IRI prefix. Default: ${DEFAULT_PREDICATE_BASE}.
+  --progress-every <count>          Emit a progress line every N writes. Default: 25.
+  --output <path>                   Write the final JSON result to a file.
+  --skip-write                      Only verify an existing run id.
+  --devnet-dir <path>               Devnet directory for appended log scanning. Default: DEVNET_DIR or repo .devnet.
+  --scan-logs / --no-scan-logs      Scan appended daemon logs for known failure signatures. Default: scan when devnet dir exists.
+  --quiet                           Suppress progress events on stderr.
+  -h, --help                        Show this help.
+
+Example 1 GiB per node:
+  pnpm bench:swm-triple-volume -- \\
+    --ports 20101,20102,20103,20104,20105 \\
+    --target-gib-per-node 1 \\
+    --triples-per-write 1000 \\
+    --write-concurrency 5 \\
+    --output bench/results/swm-triple-volume-1gib-per-node.json`;
+}
+
+function parsePositiveInteger(name, value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer (got ${JSON.stringify(value)})`);
+  }
+  return parsed;
+}
+
+function parsePositiveNumber(name, value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number (got ${JSON.stringify(value)})`);
+  }
+  return parsed;
+}
+
+function parseBoolean(value, defaultValue = false) {
+  if (value === undefined || value === null || value === '') return defaultValue;
+  if (typeof value === 'boolean') return value;
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+  throw new Error(`Invalid boolean value ${JSON.stringify(value)}`);
+}
+
+function parsePorts(value) {
+  if (value === undefined || value === null || String(value).trim() === '') return undefined;
+  const ports = String(value)
+    .split(',')
+    .map((part) => parsePositiveInteger('port', part.trim()));
+  return ports.length > 0 ? ports : undefined;
+}
+
+function nextArgValue(argv, index, name, inlineValue) {
+  if (inlineValue !== undefined) return { value: inlineValue, nextIndex: index };
+  if (index + 1 >= argv.length || argv[index + 1].startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  return { value: argv[index + 1], nextIndex: index + 1 };
+}
+
+function readAuthTokenFile(path) {
+  const text = readFileSync(path, 'utf8');
+  const tokens = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'))
+    .flatMap((line) => line.split(/\s+/))
+    .filter(Boolean);
+  return tokens.at(-1);
+}
+
+function resolveAuthToken(options, env, devnetDir) {
+  if (options.noAuth) return undefined;
+  const inline = options.authToken
+    ?? env.DKG_BENCH_AUTH_TOKEN
+    ?? env.DKG_AUTH_TOKEN
+    ?? env.DKG_TOKEN
+    ?? env.DEVNET_TOKEN
+    ?? env.DKG_AUTH;
+  if (inline) return inline;
+
+  const tokenFile = options.authTokenFile
+    ?? (env.DKG_BENCH_AUTH_TOKEN_FILE ? resolveInputPath(env.DKG_BENCH_AUTH_TOKEN_FILE) : undefined)
+    ?? (devnetDir ? join(devnetDir, 'node1', 'auth.token') : undefined);
+  if (tokenFile && existsSync(tokenFile)) return readAuthTokenFile(tokenFile);
+  return undefined;
+}
+
+function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.env) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const raw = argv[index];
+    if (raw === '--') continue;
+    if (raw === '-h' || raw === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (raw === '--no-auth') {
+      options.noAuth = true;
+      continue;
+    }
+    if (raw === '--skip-write') {
+      options.skipWrite = true;
+      continue;
+    }
+    if (raw === '--quiet') {
+      options.quiet = true;
+      continue;
+    }
+    if (raw === '--scan-logs') {
+      options.scanLogs = true;
+      continue;
+    }
+    if (raw === '--no-scan-logs') {
+      options.scanLogs = false;
+      continue;
+    }
+    if (!raw.startsWith('--')) throw new Error(`Unexpected argument ${JSON.stringify(raw)}`);
+
+    const eqIndex = raw.indexOf('=');
+    const name = eqIndex >= 0 ? raw.slice(2, eqIndex) : raw.slice(2);
+    const inlineValue = eqIndex >= 0 ? raw.slice(eqIndex + 1) : undefined;
+    const { value, nextIndex } = nextArgValue(argv, index, `--${name}`, inlineValue);
+    index = nextIndex;
+
+    switch (name) {
+      case 'ports':
+        options.ports = parsePorts(value);
+        break;
+      case 'api-port-base':
+        options.apiPortBase = parsePositiveInteger('--api-port-base', value);
+        break;
+      case 'nodes':
+        options.nodes = parsePositiveInteger('--nodes', value);
+        break;
+      case 'context-graph-id':
+        options.contextGraphId = value;
+        break;
+      case 'target-mib-per-node':
+        options.targetMiBPerNode = parsePositiveNumber('--target-mib-per-node', value);
+        break;
+      case 'target-gib-per-node':
+        options.targetMiBPerNode = parsePositiveNumber('--target-gib-per-node', value) * 1024;
+        break;
+      case 'triples-per-write':
+        options.triplesPerWrite = parsePositiveInteger('--triples-per-write', value);
+        break;
+      case 'object-bytes':
+        options.objectBytes = parsePositiveInteger('--object-bytes', value);
+        break;
+      case 'predicate-count':
+        options.predicateCount = parsePositiveInteger('--predicate-count', value);
+        break;
+      case 'write-concurrency':
+        options.writeConcurrency = parsePositiveInteger('--write-concurrency', value);
+        break;
+      case 'replication-timeout-ms':
+        options.replicationTimeoutMs = parsePositiveInteger('--replication-timeout-ms', value);
+        break;
+      case 'poll-interval-ms':
+        options.pollIntervalMs = parsePositiveInteger('--poll-interval-ms', value);
+        break;
+      case 'request-timeout-ms':
+        options.requestTimeoutMs = parsePositiveInteger('--request-timeout-ms', value);
+        break;
+      case 'query-timeout-ms':
+        options.queryTimeoutMs = parsePositiveInteger('--query-timeout-ms', value);
+        break;
+      case 'auth-token':
+        options.authToken = value;
+        break;
+      case 'auth-token-file':
+        options.authTokenFile = resolveInputPath(value);
+        break;
+      case 'run-id':
+        options.runId = value;
+        break;
+      case 'namespace':
+        options.namespace = value;
+        break;
+      case 'predicate-base':
+        options.predicateBase = value;
+        break;
+      case 'progress-every':
+        options.progressEvery = parsePositiveInteger('--progress-every', value);
+        break;
+      case 'output':
+        options.output = resolveInputPath(value);
+        break;
+      case 'devnet-dir':
+        options.devnetDir = resolveInputPath(value);
+        break;
+      default:
+        throw new Error(`Unknown option --${name}`);
+    }
+  }
+
+  const envPorts = parsePorts(env.DKG_BENCH_SWM_TRIPLES_PORTS ?? env.DKG_BENCH_SWM_PORTS);
+  const devnetDir = options.devnetDir
+    ?? (env.DKG_BENCH_SWM_TRIPLES_DEVNET_DIR ? resolveInputPath(env.DKG_BENCH_SWM_TRIPLES_DEVNET_DIR) : undefined)
+    ?? (env.DKG_BENCH_SWM_DEVNET_DIR ? resolveInputPath(env.DKG_BENCH_SWM_DEVNET_DIR) : undefined)
+    ?? (env.DEVNET_DIR ? resolveInputPath(env.DEVNET_DIR) : undefined)
+    ?? join(REPO_ROOT, '.devnet');
+  const nodes = options.nodes
+    ?? (env.DKG_BENCH_SWM_TRIPLES_NODES
+      ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_NODES', env.DKG_BENCH_SWM_TRIPLES_NODES)
+      : (env.DKG_BENCH_SWM_NODES ? parsePositiveInteger('DKG_BENCH_SWM_NODES', env.DKG_BENCH_SWM_NODES) : 5));
+  const apiPortBase = options.apiPortBase
+    ?? (env.DKG_BENCH_SWM_TRIPLES_API_PORT_BASE
+      ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_API_PORT_BASE', env.DKG_BENCH_SWM_TRIPLES_API_PORT_BASE)
+      : (env.DKG_BENCH_SWM_API_PORT_BASE
+        ? parsePositiveInteger('DKG_BENCH_SWM_API_PORT_BASE', env.DKG_BENCH_SWM_API_PORT_BASE)
+        : (env.API_PORT_BASE ? parsePositiveInteger('API_PORT_BASE', env.API_PORT_BASE) : 9201)));
+  const ports = options.ports ?? envPorts ?? Array.from({ length: nodes }, (_, index) => apiPortBase + index);
+  const noAuth = options.noAuth ?? parseBoolean(env.DKG_BENCH_SWM_TRIPLES_NO_AUTH ?? env.DKG_BENCH_SWM_NO_AUTH ?? env.DEVNET_NO_AUTH, false);
+  const targetMiBPerNode = options.targetMiBPerNode
+    ?? (env.DKG_BENCH_SWM_TRIPLES_TARGET_GIB_PER_NODE
+      ? parsePositiveNumber('DKG_BENCH_SWM_TRIPLES_TARGET_GIB_PER_NODE', env.DKG_BENCH_SWM_TRIPLES_TARGET_GIB_PER_NODE) * 1024
+      : (env.DKG_BENCH_SWM_TRIPLES_TARGET_MIB_PER_NODE
+        ? parsePositiveNumber('DKG_BENCH_SWM_TRIPLES_TARGET_MIB_PER_NODE', env.DKG_BENCH_SWM_TRIPLES_TARGET_MIB_PER_NODE)
+        : 1024));
+
+  const config = {
+    help: Boolean(options.help),
+    contextGraphId: options.contextGraphId ?? env.DKG_BENCH_SWM_TRIPLES_CONTEXT_GRAPH_ID ?? env.DKG_BENCH_SWM_CONTEXT_GRAPH_ID ?? DEFAULT_CONTEXT_GRAPH_ID,
+    ports,
+    nodes: ports.length,
+    apiPortBase,
+    targetMiBPerNode,
+    triplesPerWrite: options.triplesPerWrite
+      ?? (env.DKG_BENCH_SWM_TRIPLES_PER_WRITE ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_PER_WRITE', env.DKG_BENCH_SWM_TRIPLES_PER_WRITE) : 1000),
+    objectBytes: options.objectBytes
+      ?? (env.DKG_BENCH_SWM_TRIPLES_OBJECT_BYTES ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_OBJECT_BYTES', env.DKG_BENCH_SWM_TRIPLES_OBJECT_BYTES) : 64),
+    predicateCount: options.predicateCount
+      ?? (env.DKG_BENCH_SWM_TRIPLES_PREDICATE_COUNT ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_PREDICATE_COUNT', env.DKG_BENCH_SWM_TRIPLES_PREDICATE_COUNT) : 8),
+    writeConcurrency: options.writeConcurrency
+      ?? (env.DKG_BENCH_SWM_TRIPLES_WRITE_CONCURRENCY
+        ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_WRITE_CONCURRENCY', env.DKG_BENCH_SWM_TRIPLES_WRITE_CONCURRENCY)
+        : 1),
+    replicationTimeoutMs: options.replicationTimeoutMs
+      ?? (env.DKG_BENCH_SWM_TRIPLES_REPLICATION_TIMEOUT_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_REPLICATION_TIMEOUT_MS', env.DKG_BENCH_SWM_TRIPLES_REPLICATION_TIMEOUT_MS)
+        : 1_800_000),
+    pollIntervalMs: options.pollIntervalMs
+      ?? (env.DKG_BENCH_SWM_TRIPLES_POLL_INTERVAL_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_POLL_INTERVAL_MS', env.DKG_BENCH_SWM_TRIPLES_POLL_INTERVAL_MS)
+        : 10_000),
+    requestTimeoutMs: options.requestTimeoutMs
+      ?? (env.DKG_BENCH_SWM_TRIPLES_REQUEST_TIMEOUT_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_REQUEST_TIMEOUT_MS', env.DKG_BENCH_SWM_TRIPLES_REQUEST_TIMEOUT_MS)
+        : 180_000),
+    queryTimeoutMs: options.queryTimeoutMs
+      ?? (env.DKG_BENCH_SWM_TRIPLES_QUERY_TIMEOUT_MS
+        ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_QUERY_TIMEOUT_MS', env.DKG_BENCH_SWM_TRIPLES_QUERY_TIMEOUT_MS)
+        : 180_000),
+    runId: options.runId ?? env.DKG_BENCH_SWM_TRIPLES_RUN_ID ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    namespace: options.namespace ?? env.DKG_BENCH_SWM_TRIPLES_NAMESPACE ?? DEFAULT_NAMESPACE,
+    predicateBase: options.predicateBase ?? env.DKG_BENCH_SWM_TRIPLES_PREDICATE_BASE ?? DEFAULT_PREDICATE_BASE,
+    progressEvery: options.progressEvery
+      ?? (env.DKG_BENCH_SWM_TRIPLES_PROGRESS_EVERY ? parsePositiveInteger('DKG_BENCH_SWM_TRIPLES_PROGRESS_EVERY', env.DKG_BENCH_SWM_TRIPLES_PROGRESS_EVERY) : 25),
+    output: options.output ?? (env.DKG_BENCH_SWM_TRIPLES_OUTPUT ? resolveInputPath(env.DKG_BENCH_SWM_TRIPLES_OUTPUT) : undefined),
+    skipWrite: options.skipWrite ?? parseBoolean(env.DKG_BENCH_SWM_TRIPLES_SKIP_WRITE, false),
+    noAuth,
+    devnetDir,
+    scanLogs: options.scanLogs ?? parseBoolean(env.DKG_BENCH_SWM_TRIPLES_SCAN_LOGS ?? env.DKG_BENCH_SWM_SCAN_LOGS, existsSync(devnetDir)),
+    quiet: options.quiet ?? parseBoolean(env.DKG_BENCH_SWM_TRIPLES_QUIET ?? env.DKG_BENCH_SWM_QUIET, false),
+  };
+  config.authToken = resolveAuthToken({ ...options, noAuth }, env, devnetDir);
+  return Object.freeze(config);
+}
+
+function resolveInputPath(value) {
+  return isAbsolute(value) ? value : resolve(INVOCATION_CWD, value);
+}
+
+function bytesFromMiB(value) {
+  return Math.round(value * 1024 * 1024);
+}
+
+function makeObjectLexical(runId, nodeNumber, writeNumber, tripleIndex, objectBytes) {
+  const prefix = `r=${runId};n=${nodeNumber};w=${writeNumber};t=${tripleIndex};`;
+  const prefixBytes = Buffer.byteLength(prefix, 'utf8');
+  if (prefixBytes > objectBytes) {
+    throw new Error(`Object prefix is ${prefixBytes} bytes, larger than requested ${objectBytes} bytes`);
+  }
+  const fillChar = String.fromCharCode(97 + ((nodeNumber + writeNumber + tripleIndex) % 26));
+  return prefix + fillChar.repeat(objectBytes - prefixBytes);
+}
+
+function makeQuads(config, plan, nodeNumber, writeNumber, tripleCount = config.triplesPerWrite) {
+  const root = `${plan.rootPrefix}node:${nodeNumber}:write:${writeNumber}`;
+  const quads = [{
+    subject: root,
+    predicate: `${config.predicateBase}:root`,
+    object: JSON.stringify(`root run=${config.runId} node=${nodeNumber} write=${writeNumber} triples=${tripleCount}`),
+    graph: '',
+  }];
+
+  for (let index = 1; index < tripleCount; index += 1) {
+    quads.push({
+      subject: `${root}/.well-known/genid/t${index}`,
+      predicate: `${config.predicateBase}:${index % config.predicateCount}`,
+      object: JSON.stringify(makeObjectLexical(config.runId, nodeNumber, writeNumber, index, config.objectBytes)),
+      graph: '',
+    });
+  }
+
+  return quads;
+}
+
+function estimateQuadNQuadBytes(quad) {
+  const object = quad.object.startsWith('"') ? quad.object : `<${quad.object}>`;
+  return Buffer.byteLength(`<${quad.subject}> <${quad.predicate}> ${object} .\n`, 'utf8');
+}
+
+function estimateQuadsNQuadBytes(quads) {
+  return quads.reduce((sum, quad) => sum + estimateQuadNQuadBytes(quad), 0);
+}
+
+function buildBenchmarkPlan(config) {
+  const targetBytesPerNode = bytesFromMiB(config.targetMiBPerNode);
+  const sampleQuads = makeQuads(config, { rootPrefix: `urn:dkg:benchmark:${config.namespace}:sample:` }, 1, 1);
+  const estimatedBytesPerWrite = estimateQuadsNQuadBytes(sampleQuads);
+  const writesPerNode = Math.ceil(targetBytesPerNode / estimatedBytesPerWrite);
+  const totalWrites = writesPerNode * config.ports.length;
+  const triplesPerNode = writesPerNode * config.triplesPerWrite;
+  const totalTriples = triplesPerNode * config.ports.length;
+  const estimatedBytesPerNode = estimatedBytesPerWrite * writesPerNode;
+  const totalEstimatedBytes = estimatedBytesPerNode * config.ports.length;
+  const rootPrefix = `urn:dkg:benchmark:${config.namespace}:${config.runId}:`;
+  const metadataGraph = `did:dkg:context-graph:${config.contextGraphId}/_shared_memory_meta`;
+  return Object.freeze({
+    targetBytesPerNode,
+    targetMiBPerNode: Number((targetBytesPerNode / 1024 / 1024).toFixed(3)),
+    estimatedBytesPerWrite,
+    writesPerNode,
+    totalWrites,
+    triplesPerNode,
+    totalTriples,
+    estimatedBytesPerNode,
+    estimatedMiBPerNode: Number((estimatedBytesPerNode / 1024 / 1024).toFixed(3)),
+    totalEstimatedBytes,
+    totalEstimatedMiB: Number((totalEstimatedBytes / 1024 / 1024).toFixed(3)),
+    rootPrefix,
+    metadataGraph,
+  });
+}
+
+function buildWriteTasks(config, plan) {
+  const tasks = [];
+  for (let writeNumber = 1; writeNumber <= plan.writesPerNode; writeNumber += 1) {
+    for (let nodeIndex = 0; nodeIndex < config.ports.length; nodeIndex += 1) {
+      tasks.push({ nodeIndex, writeNumber });
+    }
+  }
+  return tasks;
+}
+
+function sparqlString(value) {
+  return JSON.stringify(String(value));
+}
+
+function bindingValue(result, name) {
+  return result?.bindings?.[0]?.[name]?.value ?? result?.bindings?.[0]?.[name];
+}
+
+function numericBinding(result, name) {
+  const value = bindingValue(result, name);
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const typedLiteral = value.match(/^"([^"]+)"\^\^<[^>]+>$/);
+    const lexical = typedLiteral ? typedLiteral[1] : value;
+    const parsed = Number(lexical);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return Number.NaN;
+}
+
+async function postJson(port, path, body, config, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const headers = { 'content-type': 'application/json' };
+    if (config.authToken && !config.noAuth) headers.authorization = `Bearer ${config.authToken}`;
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let json;
+    try {
+      json = text ? JSON.parse(text) : {};
+    } catch {
+      json = { raw: text };
+    }
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${path} on ${port}: ${text.slice(0, 500)}`);
+    }
+    return json;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function query(port, sparql, config, options = {}) {
+  const response = await postJson(port, '/api/query', { sparql, ...options }, config, config.queryTimeoutMs);
+  return response.result ?? response;
+}
+
+async function writeBatch(config, plan, nodeIndex, writeNumber) {
+  const port = config.ports[nodeIndex];
+  const nodeNumber = nodeIndex + 1;
+  const quads = makeQuads(config, plan, nodeNumber, writeNumber);
+  const estimatedNQuadBytes = estimateQuadsNQuadBytes(quads);
+  const startedAt = performance.now();
+  const response = await postJson(port, '/api/shared-memory/write', {
+    contextGraphId: config.contextGraphId,
+    quads,
+  }, config, config.requestTimeoutMs);
+  const durationMs = performance.now() - startedAt;
+  return {
+    port,
+    nodeNumber,
+    writeNumber,
+    root: quads[0].subject,
+    triples: quads.length,
+    estimatedNQuadBytes,
+    durationMs: Number(durationMs.toFixed(2)),
+    operationId: response.operationId ?? response.shareOperationId,
+  };
+}
+
+function percentile(values, p) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, rank))];
+}
+
+function summarizeWrites(records, config) {
+  const durations = records.map((record) => record.durationMs);
+  const perNode = config.ports.map((port) => {
+    const nodeRecords = records.filter((record) => record.port === port);
+    const nodeDurations = nodeRecords.map((record) => record.durationMs);
+    const estimatedBytes = nodeRecords.reduce((sum, record) => sum + record.estimatedNQuadBytes, 0);
+    const triples = nodeRecords.reduce((sum, record) => sum + record.triples, 0);
+    return {
+      port,
+      writes: nodeRecords.length,
+      triples,
+      estimatedMiB: Number((estimatedBytes / 1024 / 1024).toFixed(3)),
+      minMs: Number(Math.min(...nodeDurations).toFixed(2)),
+      maxMs: Number(Math.max(...nodeDurations).toFixed(2)),
+      meanMs: Number((nodeDurations.reduce((sum, value) => sum + value, 0) / Math.max(1, nodeDurations.length)).toFixed(2)),
+      p50Ms: Number(percentile(nodeDurations, 50).toFixed(2)),
+      p95Ms: Number(percentile(nodeDurations, 95).toFixed(2)),
+    };
+  });
+  return {
+    writes: records.length,
+    triples: records.reduce((sum, record) => sum + record.triples, 0),
+    estimatedMiB: Number((records.reduce((sum, record) => sum + record.estimatedNQuadBytes, 0) / 1024 / 1024).toFixed(3)),
+    minMs: Number(Math.min(...durations).toFixed(2)),
+    maxMs: Number(Math.max(...durations).toFixed(2)),
+    meanMs: Number((durations.reduce((sum, value) => sum + value, 0) / Math.max(1, durations.length)).toFixed(2)),
+    p50Ms: Number(percentile(durations, 50).toFixed(2)),
+    p95Ms: Number(percentile(durations, 95).toFixed(2)),
+    perNode,
+  };
+}
+
+function emitProgress(config, event) {
+  if (!config.quiet) process.stderr.write(`${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`);
+}
+
+async function runWrites(config, plan) {
+  if (config.skipWrite) return { durationMs: 0, records: [], summary: undefined };
+
+  const tasks = buildWriteTasks(config, plan);
+  const records = [];
+  let nextTask = 0;
+  let completed = 0;
+  const startedAt = performance.now();
+
+  async function worker() {
+    while (nextTask < tasks.length) {
+      const task = tasks[nextTask];
+      nextTask += 1;
+      const record = await writeBatch(config, plan, task.nodeIndex, task.writeNumber);
+      records.push(record);
+      completed += 1;
+      if (completed === 1 || completed === tasks.length || completed % config.progressEvery === 0) {
+        emitProgress(config, {
+          event: 'write-progress',
+          completed,
+          total: tasks.length,
+          port: record.port,
+          triples: record.triples,
+          estimatedMiB: Number((record.estimatedNQuadBytes / 1024 / 1024).toFixed(3)),
+          durationMs: record.durationMs,
+        });
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(config.writeConcurrency, tasks.length) }, () => worker());
+  await Promise.all(workers);
+  const durationMs = performance.now() - startedAt;
+  return {
+    durationMs: Number(durationMs.toFixed(2)),
+    records,
+    summary: summarizeWrites(records, config),
+  };
+}
+
+async function countTriples(port, config, plan) {
+  const result = await query(
+    port,
+    `SELECT (COUNT(?s) AS ?count) WHERE {
+       ?s ?p ?o .
+       FILTER(STRSTARTS(STR(?s), ${sparqlString(plan.rootPrefix)}))
+     }`,
+    config,
+    { contextGraphId: config.contextGraphId, view: 'shared-working-memory' },
+  );
+  return numericBinding(result, 'count');
+}
+
+async function sampleTriple(port, config, plan) {
+  const result = await query(
+    port,
+    `SELECT ?s ?p ?o WHERE {
+       ?s ?p ?o .
+       FILTER(STRSTARTS(STR(?s), ${sparqlString(plan.rootPrefix)}))
+     } ORDER BY ?s ?p LIMIT 1`,
+    config,
+    { contextGraphId: config.contextGraphId, view: 'shared-working-memory' },
+  );
+  return result?.bindings?.[0] ?? undefined;
+}
+
+async function countRunMetaPredicate(port, config, plan, predicate, rootPredicates = [`${DKG_ONTOLOGY}rootEntity`]) {
+  const rootClauses = rootPredicates
+    .map((rootPredicate) => `{ ?op <${rootPredicate}> ?root . }`)
+    .join('\n           UNION\n           ');
+  const result = await query(
+    port,
+    `SELECT (COUNT(?value) AS ?count) WHERE {
+       {
+         SELECT DISTINCT ?op ?value WHERE {
+           GRAPH <${plan.metadataGraph}> {
+             ?op <${predicate}> ?value .
+             ${rootClauses}
+             FILTER(STRSTARTS(STR(?root), ${sparqlString(plan.rootPrefix)}))
+           }
+         }
+       }
+     }`,
+    config,
+  );
+  return numericBinding(result, 'count');
+}
+
+async function collectMetadata(config, plan) {
+  const entries = [];
+  for (const port of config.ports) {
+    const publicStagedQuads = await countRunMetaPredicate(
+      port,
+      config,
+      plan,
+      `${DKG_ONTOLOGY}publicStagedQuads`,
+      [`${DKG_ONTOLOGY}rootEntity`, `${DKG_ONTOLOGY}publicSliceRootEntity`],
+    );
+    const publicSnapshotGraphs = await countRunMetaPredicate(
+      port,
+      config,
+      plan,
+      `${DKG_ONTOLOGY}publicSnapshotGraph`,
+      [`${DKG_ONTOLOGY}rootEntity`, `${DKG_ONTOLOGY}publicSliceRootEntity`],
+    );
+    const publicSnapshotRefs = await countRunMetaPredicate(
+      port,
+      config,
+      plan,
+      `${DKG_ONTOLOGY}publicSnapshotRef`,
+      [`${DKG_ONTOLOGY}rootEntity`, `${DKG_ONTOLOGY}publicSliceRootEntity`],
+    );
+    entries.push({
+      port,
+      publicStagedQuads,
+      publicSnapshotGraphs,
+      publicSnapshotRefs,
+      ok: publicStagedQuads === 0
+        && publicSnapshotGraphs === 0
+        && publicSnapshotRefs === plan.totalWrites,
+    });
+  }
+  return entries;
+}
+
+async function pollReplication(config, plan) {
+  const startedAt = performance.now();
+  const polls = [];
+  while (performance.now() - startedAt <= config.replicationTimeoutMs) {
+    const counts = [];
+    for (const port of config.ports) {
+      try {
+        counts.push({ port, count: await countTriples(port, config, plan) });
+      } catch (error) {
+        counts.push({ port, error: error instanceof Error ? error.message : String(error) });
+      }
+    }
+    polls.push({ atMs: Number((performance.now() - startedAt).toFixed(2)), counts });
+    emitProgress(config, { event: 'replication-poll', counts });
+    if (counts.every((entry) => entry.count === plan.totalTriples)) {
+      return {
+        converged: true,
+        durationMs: Number((performance.now() - startedAt).toFixed(2)),
+        polls,
+      };
+    }
+    await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
+  }
+  return {
+    converged: false,
+    durationMs: Number((performance.now() - startedAt).toFixed(2)),
+    polls,
+  };
+}
+
+async function collectSamples(config, plan) {
+  const entries = [];
+  for (const port of config.ports) {
+    const count = await countTriples(port, config, plan);
+    const sample = await sampleTriple(port, config, plan);
+    entries.push({
+      port,
+      count,
+      sample,
+      ok: count === plan.totalTriples && Boolean(sample),
+    });
+  }
+  return entries;
+}
+
+function captureLogOffsets(devnetDir) {
+  if (!devnetDir || !existsSync(devnetDir)) return [];
+  return readdirSync(devnetDir)
+    .filter((name) => /^node\d+$/.test(name))
+    .map((nodeName) => {
+      const file = join(devnetDir, nodeName, 'daemon.log');
+      return existsSync(file) ? { nodeName, file, offset: statSync(file).size } : undefined;
+    })
+    .filter(Boolean);
+}
+
+async function scanLogsFromOffsets(offsets) {
+  const matches = [];
+  for (const entry of offsets) {
+    if (!existsSync(entry.file)) continue;
+    const stream = createReadStream(entry.file, {
+      encoding: 'utf8',
+      start: entry.offset,
+    });
+    const rl = createInterface({ input: stream, crlfDelay: Infinity });
+    let lineNumber = 0;
+    for await (const line of rl) {
+      lineNumber += 1;
+      for (const pattern of FAILURE_PATTERNS) {
+        if (line.includes(pattern.text)) {
+          matches.push({
+            nodeName: entry.nodeName,
+            file: entry.file,
+            lineOffset: lineNumber,
+            pattern: pattern.name,
+            text: line.slice(0, 500),
+          });
+        }
+      }
+    }
+  }
+  return { scannedFiles: offsets.map((entry) => entry.file), matches, ok: matches.length === 0 };
+}
+
+function sanitizeConfig(config) {
+  return {
+    contextGraphId: config.contextGraphId,
+    ports: config.ports,
+    targetMiBPerNode: config.targetMiBPerNode,
+    triplesPerWrite: config.triplesPerWrite,
+    objectBytes: config.objectBytes,
+    predicateCount: config.predicateCount,
+    writeConcurrency: config.writeConcurrency,
+    replicationTimeoutMs: config.replicationTimeoutMs,
+    pollIntervalMs: config.pollIntervalMs,
+    requestTimeoutMs: config.requestTimeoutMs,
+    queryTimeoutMs: config.queryTimeoutMs,
+    runId: config.runId,
+    namespace: config.namespace,
+    predicateBase: config.predicateBase,
+    skipWrite: config.skipWrite,
+    noAuth: config.noAuth,
+    hasAuthToken: Boolean(config.authToken),
+    devnetDir: config.devnetDir,
+    scanLogs: config.scanLogs,
+  };
+}
+
+async function runSwmTripleVolumeBenchmark(config) {
+  const startedAt = performance.now();
+  const startedAtIso = new Date().toISOString();
+  const logOffsets = config.scanLogs ? captureLogOffsets(config.devnetDir) : [];
+  const plan = buildBenchmarkPlan(config);
+
+  emitProgress(config, {
+    event: 'plan',
+    nodes: config.ports.length,
+    targetMiBPerNode: plan.targetMiBPerNode,
+    estimatedMiBPerNode: plan.estimatedMiBPerNode,
+    triplesPerWrite: config.triplesPerWrite,
+    writesPerNode: plan.writesPerNode,
+    triplesPerNode: plan.triplesPerNode,
+    totalTriples: plan.totalTriples,
+  });
+
+  const write = await runWrites(config, plan);
+  const replication = await pollReplication(config, plan);
+  const samples = await collectSamples(config, plan);
+  const metadata = await collectMetadata(config, plan);
+  const logScan = config.scanLogs ? await scanLogsFromOffsets(logOffsets) : undefined;
+  const finishedAt = performance.now();
+  const ok = replication.converged
+    && samples.every((entry) => entry.ok)
+    && metadata.every((entry) => entry.ok)
+    && (logScan ? logScan.ok : true);
+
+  return {
+    benchmark: 'swm-triple-volume',
+    ok,
+    startedAt: startedAtIso,
+    finishedAt: new Date().toISOString(),
+    durationMs: Number((finishedAt - startedAt).toFixed(2)),
+    config: sanitizeConfig(config),
+    plan,
+    metadata,
+    write: {
+      durationMs: write.durationMs,
+      summary: write.summary,
+    },
+    replication,
+    samples,
+    logScan,
+  };
+}
+
+async function main(argv = process.argv.slice(2), env = process.env) {
+  const config = parseBenchmarkArgs(argv, env);
+  if (config.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  const result = await runSwmTripleVolumeBenchmark(config);
+  if (config.output) {
+    mkdirSync(dirname(config.output), { recursive: true });
+    writeFileSync(config.output, `${JSON.stringify(result, null, 2)}\n`);
+  }
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildBenchmarkPlan,
+  buildWriteTasks,
+  estimateQuadNQuadBytes,
+  estimateQuadsNQuadBytes,
+  makeObjectLexical,
+  makeQuads,
+  parseBenchmarkArgs,
+  runSwmTripleVolumeBenchmark,
+  usage,
+};

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -134,6 +134,12 @@ export interface ChainConfig {
   mockIdentityId?: string;
 }
 
+export interface LargeLiteralStorageConfig {
+  enabled?: boolean;
+  thresholdBytes?: number;
+  directory?: string;
+}
+
 /** Optional LLM config for the Node UI chatbot (OpenAI-compatible API). */
 export interface LlmConfig {
   /** API key (e.g. OpenAI, Anthropic, or compatible provider). */
@@ -227,6 +233,8 @@ export interface DkgConfig {
   blockExplorerUrl?: string;
   /** Triple store backend override (default: oxigraph-worker with file persistence). */
   store?: { backend: string; options?: Record<string, unknown> };
+  /** Out-of-line storage for large public SWM RDF literal object terms. */
+  largeLiteralStorage?: LargeLiteralStorageConfig;
   /**
    * Generic local agent integration registry used by node-owned connect/install
    * flows. Framework-specific bridges (OpenClaw now, Hermes next) should store

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -140,6 +140,11 @@ export interface LargeLiteralStorageConfig {
   directory?: string;
 }
 
+export interface SharedMemoryPublicSnapshotStorageConfig {
+  enabled?: boolean;
+  directory?: string;
+}
+
 /** Optional LLM config for the Node UI chatbot (OpenAI-compatible API). */
 export interface LlmConfig {
   /** API key (e.g. OpenAI, Anthropic, or compatible provider). */
@@ -235,6 +240,10 @@ export interface DkgConfig {
   store?: { backend: string; options?: Record<string, unknown> };
   /** Out-of-line storage for large public SWM RDF literal object terms. */
   largeLiteralStorage?: LargeLiteralStorageConfig;
+  /** Out-of-line storage for immutable public SWM operation snapshots. */
+  sharedMemoryPublicSnapshotStorage?: SharedMemoryPublicSnapshotStorageConfig;
+  /** Disable expensive peer-connect SWM catch-up for bulk benchmark/devnet runs. */
+  syncSharedMemoryOnConnect?: boolean;
   /**
    * Generic local agent integration registry used by node-owned connect/install
    * flows. Framework-specific bridges (OpenClaw now, Hermes next) should store

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -565,6 +565,7 @@ export async function runDaemonInner(
       backend: config.store.backend,
       options: config.store.options,
     } : undefined,
+    largeLiteralStorage: config.largeLiteralStorage,
     chainAdapter: mockChainAdapter,
     // Only forward chain to the agent when both required fields resolved.
     // resolveChainConfig() may return a partial block if neither config nor

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -101,7 +101,7 @@ import {
   slotEntryPoint,
   CLI_NPM_PACKAGE,
 } from '../config.js';
-import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
+import { createPublicSnapshotStore, createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
 import { loadTokens, httpAuthGuard } from '../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
@@ -637,7 +637,10 @@ export async function runDaemonInner(
   let publisherRuntime: PublisherRuntime | null = null;
 
   const networkId = await computeNetworkId();
-  const publisherControl = createPublisherControlFromStore(agent.store);
+  const publisherControl = createPublisherControlFromStore(
+    agent.store,
+    createPublicSnapshotStore(dkgDir(), config),
+  );
   log(`Network: ${networkId.slice(0, 16)}...`);
   if (network?.networkId && network.networkId !== networkId) {
     log(

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -566,6 +566,8 @@ export async function runDaemonInner(
       options: config.store.options,
     } : undefined,
     largeLiteralStorage: config.largeLiteralStorage,
+    sharedMemoryPublicSnapshotStorage: config.sharedMemoryPublicSnapshotStorage,
+    syncSharedMemoryOnConnect: config.syncSharedMemoryOnConnect,
     chainAdapter: mockChainAdapter,
     // Only forward chain to the agent when both required fields resolved.
     // resolveChainConfig() may return a partial block if neither config nor

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -444,13 +444,36 @@ export function parsePositiveIntegerOption(value: string, optionName: string): n
 
 async function createPublisherStore(dataDir: string, config: DkgConfig): Promise<TripleStore> {
   if (config.store) {
-    return await createTripleStore(config.store as any);
+    const storeConfig = config.store as any;
+    return await createTripleStore({
+      ...storeConfig,
+      largeLiteralStorage: config.largeLiteralStorage ?? (
+        isLocalOxigraphStoreConfig(storeConfig)
+          ? defaultLargeLiteralStorage(dataDir, config)
+          : undefined
+      ),
+    });
   }
 
   return await createTripleStore({
     backend: 'oxigraph-worker',
     options: { path: join(dataDir, 'store.nq') },
+    largeLiteralStorage: defaultLargeLiteralStorage(dataDir, config),
   });
+}
+
+function defaultLargeLiteralStorage(dataDir: string, config: DkgConfig) {
+  return {
+    enabled: config.largeLiteralStorage?.enabled ?? true,
+    thresholdBytes: config.largeLiteralStorage?.thresholdBytes,
+    directory: config.largeLiteralStorage?.directory ?? join(dataDir, 'literal-blobs'),
+  };
+}
+
+function isLocalOxigraphStoreConfig(storeConfig: { backend?: unknown }): boolean {
+  return storeConfig.backend === 'oxigraph'
+    || storeConfig.backend === 'oxigraph-worker'
+    || storeConfig.backend === 'oxigraph-persistent';
 }
 
 async function loadOrCreateAgentWallet(dataDir: string): Promise<DKGAgentWallet> {

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 import { DKGAgentWallet } from '@origintrail-official/dkg-agent';
 import { EVMChainAdapter, NoChainAdapter } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, type Ed25519Keypair } from '@origintrail-official/dkg-core';
-import { ACKCollector, AsyncLiftRunner, DKGPublisher, TripleStoreAsyncLiftPublisher, type AsyncLiftPublishExecutionInput, type AsyncLiftPublisher, type AsyncLiftPublisherRecoveryResult, type LiftJobBroadcast, type LiftJobIncluded, type PublishOptions } from '@origintrail-official/dkg-publisher';
+import { ACKCollector, AsyncLiftRunner, DKGPublisher, FileWorkspacePublicSnapshotStore, TripleStoreAsyncLiftPublisher, type AsyncLiftPublishExecutionInput, type AsyncLiftPublisher, type AsyncLiftPublisherRecoveryResult, type LiftJobBroadcast, type LiftJobIncluded, type PublishOptions, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import { createTripleStore, type TripleStore } from '@origintrail-official/dkg-storage';
 import { loadNetworkConfig, resolveChainConfig, type DkgConfig } from './config.js';
 import { loadPublisherWallets } from './publisher-wallets.js';
@@ -53,6 +53,7 @@ export async function startPublisherRuntimeIfEnabled(args: {
       pollIntervalMs: args.config.publisher.pollIntervalMs,
       errorBackoffMs: args.config.publisher.errorBackoffMs,
       maxRetries: args.config.publisher.maxRetries,
+      config: args.config,
       ackTransportFactory: args.ackTransportFactory,
     });
     await runtime.runner.start();
@@ -83,6 +84,7 @@ interface PublisherRuntimeBaseArgs {
   maxRetries?: number;
   ackTransportFactory?: () => ACKTransportFactory;
   v10ACKProviderFactory?: () => PublishOptions['v10ACKProvider'];
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
   closeStoreOnStop: boolean;
 }
 
@@ -101,6 +103,7 @@ export async function createPublisherRuntime(args: {
   const network = await loadNetworkConfig();
   const keypair = await loadOrCreateAgentWallet(args.dataDir);
   const store = await createPublisherStore(args.dataDir, args.config);
+  const publicSnapshotStore = createPublicSnapshotStore(args.dataDir, args.config);
   // Field-merge config + network/<env>.json#chain, then guard for the
   // strict { rpcUrl, hubAddress, chainId? } shape the publisher runtime
   // expects. If either required field is missing, pass undefined and let
@@ -118,6 +121,7 @@ export async function createPublisherRuntime(args: {
     pollIntervalMs: args.pollIntervalMs,
     errorBackoffMs: args.errorBackoffMs,
     maxRetries: args.maxRetries ?? args.config.publisher?.maxRetries,
+    publicSnapshotStore,
     closeStoreOnStop: true,
   });
 }
@@ -127,12 +131,16 @@ export async function createPublisherInspector(args: {
   config: DkgConfig;
 }): Promise<PublisherInspector> {
   const store = await createPublisherStore(args.dataDir, args.config);
-  return createPublisherInspectorFromStore(store, true);
+  return createPublisherInspectorFromStore(store, true, createPublicSnapshotStore(args.dataDir, args.config));
 }
 
-export function createPublisherInspectorFromStore(store: TripleStore, closeStoreOnStop = false): PublisherInspector {
+export function createPublisherInspectorFromStore(
+  store: TripleStore,
+  closeStoreOnStop = false,
+  publicSnapshotStore?: WorkspacePublicSnapshotStore,
+): PublisherInspector {
   return {
-    publisher: new TripleStoreAsyncLiftPublisher(store),
+    publisher: new TripleStoreAsyncLiftPublisher(store, { publicSnapshotStore }),
     stop: async () => {
       if (closeStoreOnStop) {
         await store.close();
@@ -157,6 +165,7 @@ export async function createPublisherRuntimeFromAgent(args: {
   pollIntervalMs?: number;
   errorBackoffMs?: number;
   maxRetries?: number;
+  config?: Pick<DkgConfig, 'sharedMemoryPublicSnapshotStorage'>;
   ackTransportFactory?: () => ACKTransportFactory;
   v10ACKProviderFactory?: () => PublishOptions['v10ACKProvider'];
 }): Promise<PublisherRuntime> {
@@ -170,6 +179,7 @@ export async function createPublisherRuntimeFromAgent(args: {
     maxRetries: args.maxRetries,
     ackTransportFactory: args.ackTransportFactory,
     v10ACKProviderFactory: args.v10ACKProviderFactory,
+    publicSnapshotStore: createPublicSnapshotStore(args.dataDir, args.config),
     closeStoreOnStop: false,
   });
 }
@@ -208,6 +218,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
         keypair: args.keypair,
         publisherNodeIdentityId: identityId,
         publisherPrivateKey: wallet.privateKey,
+        publicSnapshotStore: args.publicSnapshotStore,
       }),
     );
   }
@@ -235,6 +246,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
   const asyncPublisher = new TripleStoreAsyncLiftPublisher(args.store, {
     chainRecoveryResolver: hasChainRecovery ? createChainRecoveryResolver(publishers) : undefined,
     maxRetries: args.maxRetries,
+    publicSnapshotStore: args.publicSnapshotStore,
     publishExecutor: async ({ walletId, publishOptions }: AsyncLiftPublishExecutionInput) => {
       const publisher = publishers.get(walletId);
       if (!publisher) {
@@ -468,6 +480,17 @@ function defaultLargeLiteralStorage(dataDir: string, config: DkgConfig) {
     thresholdBytes: config.largeLiteralStorage?.thresholdBytes,
     directory: config.largeLiteralStorage?.directory ?? join(dataDir, 'literal-blobs'),
   };
+}
+
+function createPublicSnapshotStore(
+  dataDir: string,
+  config?: Pick<DkgConfig, 'sharedMemoryPublicSnapshotStorage'>,
+): WorkspacePublicSnapshotStore | undefined {
+  const snapshotConfig = config?.sharedMemoryPublicSnapshotStorage;
+  if (snapshotConfig?.enabled === false) {
+    return undefined;
+  }
+  return new FileWorkspacePublicSnapshotStore(snapshotConfig?.directory ?? join(dataDir, 'swm-public-snapshots'));
 }
 
 function isLocalOxigraphStoreConfig(storeConfig: { backend?: unknown }): boolean {

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -149,8 +149,11 @@ export function createPublisherInspectorFromStore(
   };
 }
 
-export function createPublisherControlFromStore(store: TripleStore): AsyncLiftPublisher {
-  return new TripleStoreAsyncLiftPublisher(store);
+export function createPublisherControlFromStore(
+  store: TripleStore,
+  publicSnapshotStore?: WorkspacePublicSnapshotStore,
+): AsyncLiftPublisher {
+  return new TripleStoreAsyncLiftPublisher(store, { publicSnapshotStore });
 }
 
 export async function createPublisherRuntimeFromAgent(args: {
@@ -482,7 +485,7 @@ function defaultLargeLiteralStorage(dataDir: string, config: DkgConfig) {
   };
 }
 
-function createPublicSnapshotStore(
+export function createPublicSnapshotStore(
   dataDir: string,
   config?: Pick<DkgConfig, 'sharedMemoryPublicSnapshotStorage'>,
 ): WorkspacePublicSnapshotStore | undefined {

--- a/packages/cli/test/publisher-route-snapshot.test.ts
+++ b/packages/cli/test/publisher-route-snapshot.test.ts
@@ -1,0 +1,152 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import { generateEd25519Keypair, TypedEventBus } from '@origintrail-official/dkg-core';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { DKGPublisher, FileWorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
+import { createPublisherControlFromStore } from '../src/publisher-runner.js';
+import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+const CONTEXT_GRAPH = 'publisher-route-snapshot';
+const ENTITY = 'urn:publisher-route:snapshot:entity';
+
+describe('publisher routes with disk public snapshot refs', () => {
+  const tempDirs: string[] = [];
+  const stores: OxigraphStore[] = [];
+
+  afterEach(async () => {
+    await Promise.all(stores.splice(0).map((store) => store.close().catch(() => {})));
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('inspects an enqueued job payload backed by publicSnapshotRef files', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-route-snapshot-'));
+    tempDirs.push(dataDir);
+    const store = new OxigraphStore();
+    stores.push(store);
+    const publicSnapshotStore = new FileWorkspacePublicSnapshotStore(join(dataDir, 'swm-public-snapshots'));
+    const publisher = new DKGPublisher({
+      store,
+      chain: new NoChainAdapter(),
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+      publicSnapshotStore,
+    });
+    const write = await publisher.share(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Route Snapshot"', graph: '' },
+    ], { publisherPeerId: 'peer-route' });
+
+    const publisherControl = createPublisherControlFromStore(store, publicSnapshotStore);
+    const enqueue = createContext('POST', '/api/publisher/enqueue', {
+      contextGraphId: CONTEXT_GRAPH,
+      shareOperationId: write.shareOperationId,
+      roots: [ENTITY],
+      namespace: 'aloha',
+      scope: 'person-profile',
+      transitionType: 'CREATE',
+      authorityProofRef: 'proof:owner:route',
+    }, publisherControl);
+
+    await handlePublisherRoutes(enqueue);
+    expect(responseStatus(enqueue)).toBe(200);
+    const jobId = String(responseBody(enqueue).jobId);
+
+    const payloadCtx = createContext('GET', `/api/publisher/job-payload?id=${encodeURIComponent(jobId)}`, undefined, publisherControl);
+    await handlePublisherRoutes(payloadCtx);
+
+    expect(responseStatus(payloadCtx)).toBe(200);
+    const body = responseBody(payloadCtx) as {
+      payload?: { publishOptions?: { quads?: Array<{ subject: string; predicate: string; object: string }> } };
+    };
+    expect(body.payload?.publishOptions?.quads).toEqual([
+      expect.objectContaining({
+        subject: expect.stringMatching(/^dkg:publisher-route-snapshot:aloha:person-profile\/entity-/),
+        predicate: 'http://schema.org/name',
+        object: '"Route Snapshot"',
+      }),
+    ]);
+  });
+});
+
+function createContext(
+  method: 'GET' | 'POST',
+  path: string,
+  body: unknown,
+  publisherControl: RequestContext['publisherControl'],
+): RequestContext {
+  const url = new URL(`http://127.0.0.1${path}`);
+  return {
+    req: createRequest(method, path, body),
+    res: createResponse() as unknown as ServerResponse,
+    agent: {} as RequestContext['agent'],
+    publisherControl,
+    publisherRuntime: null,
+    config: {} as RequestContext['config'],
+    startedAt: 0,
+    dashDb: {} as RequestContext['dashDb'],
+    opWallets: { adminWallet: { address: '0x0', privateKey: '0x0' }, wallets: [] } as RequestContext['opWallets'],
+    network: null as RequestContext['network'],
+    tracker: {} as RequestContext['tracker'],
+    memoryManager: {} as RequestContext['memoryManager'],
+    bridgeAuthToken: undefined,
+    nodeVersion: 'test',
+    nodeCommit: 'test',
+    catchupTracker: {} as RequestContext['catchupTracker'],
+    extractionRegistry: {} as RequestContext['extractionRegistry'],
+    fileStore: {} as RequestContext['fileStore'],
+    extractionStatus: new Map(),
+    assertionImportLocks: new Map(),
+    vectorStore: {} as RequestContext['vectorStore'],
+    embeddingProvider: null,
+    validTokens: new Set(),
+    apiHost: '127.0.0.1',
+    apiPortRef: { value: 0 },
+    url,
+    path: url.pathname,
+    requestToken: undefined,
+    requestAgentAddress: '0x0',
+  };
+}
+
+function createRequest(method: 'GET' | 'POST', path: string, body: unknown): RequestContext['req'] {
+  const payload = body === undefined ? [] : [Buffer.from(JSON.stringify(body))];
+  const request = Readable.from(payload);
+  Object.assign(request, {
+    method,
+    url: path,
+    headers: { host: '127.0.0.1' },
+  });
+  return request as RequestContext['req'];
+}
+
+function createResponse() {
+  return {
+    statusCode: 0,
+    headers: undefined as Record<string, string> | undefined,
+    body: '',
+    writableEnded: false,
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+      return this;
+    },
+    end(body?: string) {
+      this.body = body ?? '';
+      this.writableEnded = true;
+      return this;
+    },
+  };
+}
+
+function responseStatus(ctx: RequestContext): number {
+  return (ctx.res as unknown as { statusCode: number }).statusCode;
+}
+
+function responseBody(ctx: RequestContext): Record<string, unknown> {
+  return JSON.parse((ctx.res as unknown as { body: string }).body) as Record<string, unknown>;
+}

--- a/packages/cli/test/swm-large-payload-benchmark.test.ts
+++ b/packages/cli/test/swm-large-payload-benchmark.test.ts
@@ -1,0 +1,127 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const benchmark = require('../scripts/swm-large-payload-benchmark.cjs') as {
+  buildBenchmarkPlan: (config: Record<string, unknown>) => {
+    payloadBytesPerNode: number;
+    chunkBytes: number;
+    chunksPerNode: number;
+    totalOperations: number;
+    totalPayloadBytes: number;
+    totalPayloadMiB: number;
+    rootPrefix: string;
+    metadataGraph: string;
+  };
+  makePayload: (runId: string, nodeNumber: number, chunkNumber: number, sizeBytes: number) => string;
+  parseBenchmarkArgs: (argv: string[], env: Record<string, string | undefined>) => Record<string, unknown>;
+  payloadBytesForChunk: (plan: { payloadBytesPerNode: number; chunkBytes: number }, chunkNumber: number) => number;
+};
+
+describe('swm large payload benchmark', () => {
+  it('parses live-devnet benchmark arguments and hides auth from the sanitized config', () => {
+    const config = benchmark.parseBenchmarkArgs([
+      '--',
+      '--ports',
+      '19101,19102,19103',
+      '--context-graph-id',
+      'devnet-test',
+      '--payload-mib-per-node',
+      '12.5',
+      '--chunk-mib',
+      '0.25',
+      '--write-concurrency',
+      '2',
+      '--replication-timeout-ms',
+      '1000',
+      '--poll-interval-ms',
+      '100',
+      '--request-timeout-ms',
+      '2000',
+      '--query-timeout-ms',
+      '3000',
+      '--run-id',
+      'fixed-run',
+      '--namespace',
+      'swm-regression',
+      '--predicate',
+      'urn:test:payload',
+      '--progress-every',
+      '5',
+      '--no-scan-logs',
+      '--auth-token',
+      'secret-token',
+    ], {});
+
+    expect(config).toMatchObject({
+      ports: [19101, 19102, 19103],
+      nodes: 3,
+      contextGraphId: 'devnet-test',
+      payloadMiBPerNode: 12.5,
+      chunkMiB: 0.25,
+      writeConcurrency: 2,
+      replicationTimeoutMs: 1000,
+      pollIntervalMs: 100,
+      requestTimeoutMs: 2000,
+      queryTimeoutMs: 3000,
+      runId: 'fixed-run',
+      namespace: 'swm-regression',
+      predicate: 'urn:test:payload',
+      progressEvery: 5,
+      scanLogs: false,
+      authToken: 'secret-token',
+    });
+  });
+
+  it('derives ports and auth from environment defaults', () => {
+    const config = benchmark.parseBenchmarkArgs([], {
+      DKG_BENCH_SWM_API_PORT_BASE: '18101',
+      DKG_BENCH_SWM_NODES: '2',
+      DKG_BENCH_SWM_PAYLOAD_MIB_PER_NODE: '1',
+      DKG_BENCH_SWM_CHUNK_MIB: '0.5',
+      DKG_BENCH_AUTH_TOKEN: 'env-token',
+      DKG_BENCH_SWM_SCAN_LOGS: '0',
+    });
+
+    expect(config).toMatchObject({
+      ports: [18101, 18102],
+      nodes: 2,
+      payloadMiBPerNode: 1,
+      chunkMiB: 0.5,
+      authToken: 'env-token',
+      scanLogs: false,
+    });
+  });
+
+  it('plans exact chunk counts and a smaller final chunk when needed', () => {
+    const plan = benchmark.buildBenchmarkPlan({
+      contextGraphId: 'devnet-test',
+      ports: [9201, 9202],
+      payloadMiBPerNode: 1.25,
+      chunkMiB: 0.5,
+      runId: 'plan-run',
+      namespace: 'swm-large-payload',
+    });
+
+    expect(plan).toMatchObject({
+      payloadBytesPerNode: 1.25 * 1024 * 1024,
+      chunkBytes: 0.5 * 1024 * 1024,
+      chunksPerNode: 3,
+      totalOperations: 6,
+      totalPayloadBytes: 2.5 * 1024 * 1024,
+      totalPayloadMiB: 2.5,
+      rootPrefix: 'urn:dkg:benchmark:swm-large-payload:plan-run:',
+      metadataGraph: 'did:dkg:context-graph:devnet-test/_shared_memory_meta',
+    });
+    expect(benchmark.payloadBytesForChunk(plan, 1)).toBe(512 * 1024);
+    expect(benchmark.payloadBytesForChunk(plan, 2)).toBe(512 * 1024);
+    expect(benchmark.payloadBytesForChunk(plan, 3)).toBe(256 * 1024);
+  });
+
+  it('generates payload literals at the requested byte size', () => {
+    const payload = benchmark.makePayload('payload-run', 5, 7, 1024);
+
+    expect(Buffer.byteLength(payload, 'utf8')).toBe(1024);
+    expect(payload).toContain('run=payload-run node=5 chunk=7');
+  });
+});

--- a/packages/cli/test/swm-large-payload-benchmark.test.ts
+++ b/packages/cli/test/swm-large-payload-benchmark.test.ts
@@ -4,6 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const benchmark = require('../scripts/swm-large-payload-benchmark.cjs') as {
+  buildRunMetaPredicateCountQuery: (
+    plan: { metadataGraph: string; rootPrefix: string },
+    predicate: string,
+    rootPredicates?: string[],
+  ) => string;
   buildWriteTasks: (
     config: { ports: number[] },
     plan: { chunksPerNode: number },
@@ -147,5 +152,25 @@ describe('swm large payload benchmark', () => {
       { nodeIndex: 1, chunkNumber: 2 },
       { nodeIndex: 2, chunkNumber: 2 },
     ]);
+  });
+
+  it('counts per-run publicStagedQuads on operation and public slice metadata subjects', () => {
+    const query = benchmark.buildRunMetaPredicateCountQuery(
+      {
+        metadataGraph: 'did:dkg:context-graph:devnet-test/_shared_memory_meta',
+        rootPrefix: 'urn:dkg:benchmark:swm-large-payload:run-1:',
+      },
+      'http://dkg.io/ontology/publicStagedQuads',
+      [
+        'http://dkg.io/ontology/rootEntity',
+        'http://dkg.io/ontology/publicSliceRootEntity',
+      ],
+    );
+
+    expect(query).toContain('SELECT DISTINCT ?op ?value');
+    expect(query).toContain('<http://dkg.io/ontology/rootEntity> ?root');
+    expect(query).toContain('<http://dkg.io/ontology/publicSliceRootEntity> ?root');
+    expect(query).toContain('<http://dkg.io/ontology/publicStagedQuads> ?value');
+    expect(query).toContain('STRSTARTS(STR(?root), "urn:dkg:benchmark:swm-large-payload:run-1:")');
   });
 });

--- a/packages/cli/test/swm-large-payload-benchmark.test.ts
+++ b/packages/cli/test/swm-large-payload-benchmark.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
@@ -52,6 +53,12 @@ describe('swm large payload benchmark', () => {
       'urn:test:payload',
       '--progress-every',
       '5',
+      '--output',
+      'bench/results/out.json',
+      '--devnet-dir',
+      '.devnet',
+      '--auth-token-file',
+      'auth.token',
       '--no-scan-logs',
       '--auth-token',
       'secret-token',
@@ -74,6 +81,8 @@ describe('swm large payload benchmark', () => {
       progressEvery: 5,
       scanLogs: false,
       authToken: 'secret-token',
+      output: resolve(process.env.INIT_CWD ?? process.cwd(), 'bench/results/out.json'),
+      devnetDir: resolve(process.env.INIT_CWD ?? process.cwd(), '.devnet'),
     });
   });
 

--- a/packages/cli/test/swm-large-payload-benchmark.test.ts
+++ b/packages/cli/test/swm-large-payload-benchmark.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const benchmark = require('../scripts/swm-large-payload-benchmark.cjs') as {
+  buildWriteTasks: (
+    config: { ports: number[] },
+    plan: { chunksPerNode: number },
+  ) => Array<{ nodeIndex: number; chunkNumber: number }>;
   buildBenchmarkPlan: (config: Record<string, unknown>) => {
     payloadBytesPerNode: number;
     chunkBytes: number;
@@ -123,5 +127,16 @@ describe('swm large payload benchmark', () => {
 
     expect(Buffer.byteLength(payload, 'utf8')).toBe(1024);
     expect(payload).toContain('run=payload-run node=5 chunk=7');
+  });
+
+  it('interleaves write tasks across nodes for concurrent live benchmarks', () => {
+    expect(benchmark.buildWriteTasks({ ports: [9201, 9202, 9203] }, { chunksPerNode: 2 })).toEqual([
+      { nodeIndex: 0, chunkNumber: 1 },
+      { nodeIndex: 1, chunkNumber: 1 },
+      { nodeIndex: 2, chunkNumber: 1 },
+      { nodeIndex: 0, chunkNumber: 2 },
+      { nodeIndex: 1, chunkNumber: 2 },
+      { nodeIndex: 2, chunkNumber: 2 },
+    ]);
   });
 });

--- a/packages/cli/test/swm-triple-volume-benchmark.test.ts
+++ b/packages/cli/test/swm-triple-volume-benchmark.test.ts
@@ -1,0 +1,185 @@
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const benchmark = require('../scripts/swm-triple-volume-benchmark.cjs') as {
+  buildBenchmarkPlan: (config: Record<string, unknown>) => {
+    targetBytesPerNode: number;
+    estimatedBytesPerWrite: number;
+    writesPerNode: number;
+    totalWrites: number;
+    triplesPerNode: number;
+    totalTriples: number;
+    estimatedBytesPerNode: number;
+    rootPrefix: string;
+  };
+  buildWriteTasks: (
+    config: { ports: number[] },
+    plan: { writesPerNode: number },
+  ) => Array<{ nodeIndex: number; writeNumber: number }>;
+  estimateQuadsNQuadBytes: (quads: Array<{ subject: string; predicate: string; object: string; graph: string }>) => number;
+  makeObjectLexical: (
+    runId: string,
+    nodeNumber: number,
+    writeNumber: number,
+    tripleIndex: number,
+    objectBytes: number,
+  ) => string;
+  makeQuads: (
+    config: Record<string, unknown>,
+    plan: { rootPrefix: string },
+    nodeNumber: number,
+    writeNumber: number,
+    tripleCount?: number,
+  ) => Array<{ subject: string; predicate: string; object: string; graph: string }>;
+  parseBenchmarkArgs: (argv: string[], env: Record<string, string | undefined>) => Record<string, unknown>;
+};
+
+describe('swm triple volume benchmark', () => {
+  it('parses 1 GiB per-node benchmark arguments', () => {
+    const config = benchmark.parseBenchmarkArgs([
+      '--',
+      '--ports',
+      '20101,20102',
+      '--target-gib-per-node',
+      '1',
+      '--triples-per-write',
+      '250',
+      '--object-bytes',
+      '48',
+      '--predicate-count',
+      '4',
+      '--write-concurrency',
+      '2',
+      '--replication-timeout-ms',
+      '1000',
+      '--poll-interval-ms',
+      '100',
+      '--request-timeout-ms',
+      '2000',
+      '--query-timeout-ms',
+      '3000',
+      '--run-id',
+      'triple-run',
+      '--namespace',
+      'triple-volume',
+      '--predicate-base',
+      'urn:test:p',
+      '--output',
+      'bench/results/triples.json',
+      '--devnet-dir',
+      '.devnet',
+      '--no-scan-logs',
+      '--auth-token',
+      'secret-token',
+    ], {});
+
+    expect(config).toMatchObject({
+      ports: [20101, 20102],
+      nodes: 2,
+      targetMiBPerNode: 1024,
+      triplesPerWrite: 250,
+      objectBytes: 48,
+      predicateCount: 4,
+      writeConcurrency: 2,
+      replicationTimeoutMs: 1000,
+      pollIntervalMs: 100,
+      requestTimeoutMs: 2000,
+      queryTimeoutMs: 3000,
+      runId: 'triple-run',
+      namespace: 'triple-volume',
+      predicateBase: 'urn:test:p',
+      scanLogs: false,
+      authToken: 'secret-token',
+      output: resolve(process.env.INIT_CWD ?? process.cwd(), 'bench/results/triples.json'),
+      devnetDir: resolve(process.env.INIT_CWD ?? process.cwd(), '.devnet'),
+    });
+  });
+
+  it('uses a default object size that fits generated run ids', () => {
+    const config = benchmark.parseBenchmarkArgs(['--run-id', '1760000000000-abcdefgh'], {});
+
+    expect(config).toMatchObject({ objectBytes: 64 });
+    expect(() => benchmark.buildBenchmarkPlan(config)).not.toThrow();
+  });
+
+  it('builds root-scoped quads so one write stays one SWM root', () => {
+    const config = {
+      runId: 'run-a',
+      namespace: 'swm-triple-volume',
+      predicateBase: 'urn:test:p',
+      predicateCount: 2,
+      objectBytes: 32,
+      triplesPerWrite: 4,
+    };
+    const quads = benchmark.makeQuads(
+      config,
+      { rootPrefix: 'urn:dkg:benchmark:swm-triple-volume:run-a:' },
+      3,
+      7,
+    );
+
+    expect(quads).toHaveLength(4);
+    expect(quads[0].subject).toBe('urn:dkg:benchmark:swm-triple-volume:run-a:node:3:write:7');
+    expect(quads.slice(1).every((quad) => quad.subject.startsWith(`${quads[0].subject}/.well-known/genid/`))).toBe(true);
+    expect(quads.map((quad) => quad.predicate)).toContain('urn:test:p:1');
+  });
+
+  it('generates fixed-size literal lexical values', () => {
+    const value = benchmark.makeObjectLexical('run-a', 1, 2, 3, 64);
+    expect(Buffer.byteLength(value, 'utf8')).toBe(64);
+    expect(value).toContain('r=run-a;n=1;w=2;t=3;');
+  });
+
+  it('plans enough writes to meet the target estimated byte volume', () => {
+    const config = {
+      contextGraphId: 'devnet-test',
+      ports: [9201, 9202],
+      targetMiBPerNode: 1,
+      triplesPerWrite: 10,
+      objectBytes: 32,
+      predicateCount: 4,
+      runId: 'plan-run',
+      namespace: 'swm-triple-volume',
+      predicateBase: 'urn:test:p',
+    };
+    const plan = benchmark.buildBenchmarkPlan(config);
+
+    expect(plan.targetBytesPerNode).toBe(1024 * 1024);
+    expect(plan.estimatedBytesPerWrite).toBeGreaterThan(0);
+    expect(plan.estimatedBytesPerNode).toBeGreaterThanOrEqual(plan.targetBytesPerNode);
+    expect(plan.totalWrites).toBe(plan.writesPerNode * 2);
+    expect(plan.triplesPerNode).toBe(plan.writesPerNode * 10);
+    expect(plan.totalTriples).toBe(plan.triplesPerNode * 2);
+  });
+
+  it('interleaves write tasks across nodes', () => {
+    expect(benchmark.buildWriteTasks({ ports: [9201, 9202, 9203] }, { writesPerNode: 2 })).toEqual([
+      { nodeIndex: 0, writeNumber: 1 },
+      { nodeIndex: 1, writeNumber: 1 },
+      { nodeIndex: 2, writeNumber: 1 },
+      { nodeIndex: 0, writeNumber: 2 },
+      { nodeIndex: 1, writeNumber: 2 },
+      { nodeIndex: 2, writeNumber: 2 },
+    ]);
+  });
+
+  it('estimates serialized N-Quad bytes for generated triples', () => {
+    const quads = benchmark.makeQuads(
+      {
+        runId: 'run-a',
+        namespace: 'swm-triple-volume',
+        predicateBase: 'urn:test:p',
+        predicateCount: 2,
+        objectBytes: 32,
+        triplesPerWrite: 3,
+      },
+      { rootPrefix: 'urn:dkg:benchmark:swm-triple-volume:run-a:' },
+      1,
+      1,
+    );
+
+    expect(benchmark.estimateQuadsNQuadBytes(quads)).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/test/swm-triple-volume-benchmark.test.ts
+++ b/packages/cli/test/swm-triple-volume-benchmark.test.ts
@@ -15,9 +15,11 @@ const benchmark = require('../scripts/swm-triple-volume-benchmark.cjs') as {
     rootPrefix: string;
   };
   buildWriteTasks: (
-    config: { ports: number[] },
+    config: { ports: number[]; maxWrites?: number },
     plan: { writesPerNode: number },
   ) => Array<{ nodeIndex: number; writeNumber: number }>;
+  analyzeThroughput: (result: Record<string, unknown>) => Record<string, unknown>;
+  renderAnalysisMarkdown: (result: Record<string, unknown>) => string;
   estimateQuadsNQuadBytes: (quads: Array<{ subject: string; predicate: string; object: string; graph: string }>) => number;
   makeObjectLexical: (
     runId: string,
@@ -52,6 +54,10 @@ describe('swm triple volume benchmark', () => {
       '4',
       '--write-concurrency',
       '2',
+      '--max-writes',
+      '125',
+      '--diagnostic-interval-ms',
+      '5000',
       '--replication-timeout-ms',
       '1000',
       '--poll-interval-ms',
@@ -68,9 +74,12 @@ describe('swm triple volume benchmark', () => {
       'urn:test:p',
       '--output',
       'bench/results/triples.json',
+      '--analysis-output',
+      'bench/results/triples.analysis.md',
       '--devnet-dir',
       '.devnet',
       '--no-scan-logs',
+      '--no-diagnostics',
       '--auth-token',
       'secret-token',
     ], {});
@@ -83,6 +92,9 @@ describe('swm triple volume benchmark', () => {
       objectBytes: 48,
       predicateCount: 4,
       writeConcurrency: 2,
+      maxWrites: 125,
+      diagnosticIntervalMs: 5000,
+      diagnostics: false,
       replicationTimeoutMs: 1000,
       pollIntervalMs: 100,
       requestTimeoutMs: 2000,
@@ -93,6 +105,7 @@ describe('swm triple volume benchmark', () => {
       scanLogs: false,
       authToken: 'secret-token',
       output: resolve(process.env.INIT_CWD ?? process.cwd(), 'bench/results/triples.json'),
+      analysisOutput: resolve(process.env.INIT_CWD ?? process.cwd(), 'bench/results/triples.analysis.md'),
       devnetDir: resolve(process.env.INIT_CWD ?? process.cwd(), '.devnet'),
     });
   });
@@ -165,6 +178,15 @@ describe('swm triple volume benchmark', () => {
     ]);
   });
 
+  it('can cap write tasks for diagnostic runs', () => {
+    expect(benchmark.buildWriteTasks({ ports: [9201, 9202, 9203], maxWrites: 4 }, { writesPerNode: 3 })).toEqual([
+      { nodeIndex: 0, writeNumber: 1 },
+      { nodeIndex: 1, writeNumber: 1 },
+      { nodeIndex: 2, writeNumber: 1 },
+      { nodeIndex: 0, writeNumber: 2 },
+    ]);
+  });
+
   it('estimates serialized N-Quad bytes for generated triples', () => {
     const quads = benchmark.makeQuads(
       {
@@ -181,5 +203,51 @@ describe('swm triple volume benchmark', () => {
     );
 
     expect(benchmark.estimateQuadsNQuadBytes(quads)).toBeGreaterThan(0);
+  });
+
+  it('analyzes throughput drops with runtime log signals', () => {
+    const result = {
+      ok: false,
+      config: { runId: 'analysis-run' },
+      write: {
+        attemptedWrites: 100,
+        completedWrites: 80,
+        error: { message: 'fetch failed' },
+        intervals: [
+          { atMs: 1000, completed: 25, writesPerSec: 20, miBPerSec: 2, latencyMs: { p95: 250, max: 300 } },
+          { atMs: 2000, completed: 50, writesPerSec: 25, miBPerSec: 2.5, latencyMs: { p95: 300, max: 350 } },
+          { atMs: 3000, completed: 75, writesPerSec: 5, miBPerSec: 0.5, latencyMs: { p95: 1800, max: 2100 } },
+        ],
+        diagnostics: [{
+          atMs: 3200,
+          logCounters: {
+            totals: {
+              syncTimeout: 2,
+              syncingFromPeer: 3,
+              queryAllContextGraph: 1,
+              socketHangUp: 1,
+            },
+          },
+          nodes: [{
+            nodeName: 'node1',
+            port: 9201,
+            storeNqMiB: 512,
+            daemonLogMiB: 8,
+            publicSnapshotStore: { files: 80, mib: 1.5 },
+            process: { rssMiB: 1024, cpuPercent: 80, processes: 3 },
+          }],
+        }],
+      },
+    };
+
+    const analysis = benchmark.analyzeThroughput(result);
+    expect(analysis).toMatchObject({
+      completedWrites: 80,
+      attemptedWrites: 100,
+      dropFromPeak: 0.8,
+    });
+    expect(String(JSON.stringify(analysis))).toContain('sync-backpressure');
+    expect(String(JSON.stringify(analysis))).toContain('rpc-instability');
+    expect(benchmark.renderAnalysisMarkdown({ ...result, analysis })).toContain('SWM Triple-Volume Throughput Analysis');
   });
 });

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -71,6 +71,7 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
   private readonly chainRecoveryResolver?: AsyncLiftPublisherRecoveryResolver;
   private readonly publishExecutor?: AsyncLiftPublisherConfig['publishExecutor'];
   private readonly resolvedSliceOverrides?: Partial<LiftResolvedPublishSlice>;
+  private readonly publicSnapshotStore?: AsyncLiftPublisherConfig['publicSnapshotStore'];
   private readonly graphManager: GraphManager;
   private paused = false;
   private graphEnsured = false;
@@ -89,6 +90,7 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
     this.chainRecoveryResolver = config.chainRecoveryResolver;
     this.publishExecutor = config.publishExecutor;
     this.resolvedSliceOverrides = config.resolvedSliceOverrides;
+    this.publicSnapshotStore = config.publicSnapshotStore;
     this.graphManager = new GraphManager(store);
   }
 
@@ -225,6 +227,7 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
       store: this.store,
       graphManager: this.graphManager,
       request: job.request,
+      publicSnapshotStore: this.publicSnapshotStore,
     });
     const validated = validateLiftPublishPayload({
       request: job.request,
@@ -270,6 +273,7 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
         store: this.store,
         graphManager: this.graphManager,
         request: claimed.request,
+        publicSnapshotStore: this.publicSnapshotStore,
       });
       const validated = validateLiftPublishPayload({
         request: claimed.request,

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -2,6 +2,7 @@ import type { LiftJob, LiftJobBroadcast, LiftJobFinalizationMetadata, LiftJobInc
 import type { PublishOptions, PublishResult } from './publisher.js';
 import type { AsyncLiftPublishFailureInput } from './async-lift-publish-result.js';
 import type { AsyncPreparedPublishPayload, LiftResolvedPublishSlice } from './async-lift-publish-options.js';
+import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 
 export interface AsyncLiftPublisher {
   lift(request: LiftRequest): Promise<string>;
@@ -45,4 +46,5 @@ export interface AsyncLiftPublisherConfig {
   chainRecoveryResolver?: AsyncLiftPublisherRecoveryResolver;
   publishExecutor?: (input: AsyncLiftPublishExecutionInput) => Promise<PublishResult>;
   resolvedSliceOverrides?: Partial<LiftResolvedPublishSlice>;
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
 }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -19,7 +19,6 @@ import { validatePublishRequest } from './validation.js';
 import {
   generateTentativeMetadata,
   generateConfirmedFullMetadata,
-  generateShareMetadata,
   generateOwnershipQuads,
   generateAuthorshipProof,
   generateShareTransitionMetadata,
@@ -891,17 +890,7 @@ export class DKGPublisher implements Publisher {
     await this.store.insert(normalized);
 
     const rootEntities = manifestEntries.map((m) => m.rootEntity);
-    const metaQuads = generateShareMetadata(
-      {
-        shareOperationId,
-        contextGraphId,
-        rootEntities,
-        publisherPeerId: options.publisherPeerId,
-        timestamp: new Date(),
-      },
-      swmMetaGraph,
-    );
-    await this.store.insert(metaQuads);
+    const operationTimestamp = new Date();
     await storeWorkspaceOperationPublicQuads({
       store: this.store,
       graphManager: this.graphManager,
@@ -911,6 +900,7 @@ export class DKGPublisher implements Publisher {
       quads: normalized,
       publisherPeerId: options.publisherPeerId,
       subGraphName: options.subGraphName,
+      timestamp: operationTimestamp,
     });
 
     if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {
@@ -3233,11 +3223,7 @@ export class DKGPublisher implements Publisher {
     // _shareImpl and the remote SharedMemoryHandler both produce, so the
     // promoting node and replicas converge on identical ownership state.
     if (opts?.publisherPeerId) {
-      const metaQuads = generateShareMetadata(
-        { shareOperationId: operationId, contextGraphId, rootEntities: effectiveRoots, publisherPeerId: opts.publisherPeerId, timestamp: new Date() },
-        swmMetaGraph,
-      );
-      await this.store.insert(metaQuads);
+      const operationTimestamp = new Date();
       await storeWorkspaceOperationPublicQuads({
         store: this.store,
         graphManager: this.graphManager,
@@ -3247,6 +3233,7 @@ export class DKGPublisher implements Publisher {
         quads: swmQuads,
         publisherPeerId: opts.publisherPeerId,
         subGraphName: opts.subGraphName,
+        timestamp: operationTimestamp,
       });
 
       if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -32,6 +32,7 @@ import {
   type KAMetadata,
 } from './metadata.js';
 import { storeWorkspaceOperationPublicQuads } from './workspace-resolution.js';
+import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 import { ethers } from 'ethers';
 import type { WorkspaceAgentRecipientResolver } from './workspace-agent-recipients.js';
 
@@ -63,6 +64,8 @@ export interface DKGPublisherConfig {
   workspaceAgentRecipientResolver?: WorkspaceAgentRecipientResolver;
   /** Encrypts private/agent-gated SWM gossip with the node's Sender Key epoch state. */
   workspaceSenderKeyEncryptor?: WorkspaceSenderKeyEncryptor;
+  /** Optional out-of-Oxigraph store for immutable public SWM operation snapshots. */
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
 }
 
 export interface WorkspaceSenderKeyEncryptInput {
@@ -342,6 +345,7 @@ export class DKGPublisher implements Publisher {
   private readonly sessionId = Date.now().toString(36);
   private tentativeCounter = 0;
   readonly writeLocks: Map<string, Promise<void>>;
+  private readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
 
   constructor(config: DKGPublisherConfig) {
     this.store = config.store;
@@ -394,6 +398,7 @@ export class DKGPublisher implements Publisher {
     this.writeLocks = config.writeLocks ?? new Map();
     this.workspaceAgentRecipientResolver = config.workspaceAgentRecipientResolver;
     this.workspaceSenderKeyEncryptor = config.workspaceSenderKeyEncryptor;
+    this.publicSnapshotStore = config.publicSnapshotStore;
   }
 
   setWorkspaceAgentRecipientResolver(resolver: WorkspaceAgentRecipientResolver | undefined): void {
@@ -901,6 +906,7 @@ export class DKGPublisher implements Publisher {
       publisherPeerId: options.publisherPeerId,
       subGraphName: options.subGraphName,
       timestamp: operationTimestamp,
+      publicSnapshotStore: this.publicSnapshotStore,
     });
 
     if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {
@@ -3234,6 +3240,7 @@ export class DKGPublisher implements Publisher {
         publisherPeerId: opts.publisherPeerId,
         subGraphName: opts.subGraphName,
         timestamp: operationTimestamp,
+        publicSnapshotStore: this.publicSnapshotStore,
       });
 
       if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -169,6 +169,11 @@ export {
   type AsyncLiftPublishFailureInput,
 } from './async-lift-publish-result.js';
 export { SharedMemoryHandler, WorkspaceHandler } from './workspace-handler.js';
+export {
+  FileWorkspacePublicSnapshotStore,
+  type SharedMemoryPublicSnapshotStorageConfig,
+  type WorkspacePublicSnapshotStore,
+} from './workspace-snapshot-store.js';
 export { UpdateHandler } from './update-handler.js';
 export { ChainEventPoller, type ChainEventPollerConfig, type OnContextGraphCreated } from './chain-event-poller.js';
 export { AccessHandler, type AccessPolicy } from './access-handler.js';

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -171,6 +171,9 @@ export {
 export { SharedMemoryHandler, WorkspaceHandler } from './workspace-handler.js';
 export {
   FileWorkspacePublicSnapshotStore,
+  parseWorkspacePublicSnapshotNQuads,
+  serializeWorkspacePublicSnapshotQuads,
+  workspacePublicQuadsDigest,
   type SharedMemoryPublicSnapshotStorageConfig,
   type WorkspacePublicSnapshotStore,
 } from './workspace-snapshot-store.js';

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -354,6 +354,7 @@ export interface ShareMetadata {
   rootEntities: string[];
   publisherPeerId: string;
   timestamp: Date;
+  subGraphName?: string;
 }
 
 /** @deprecated Use ShareMetadata */
@@ -372,6 +373,9 @@ export function generateShareMetadata(
 
   quads.push(
     mq(subject, `${RDF}type`, `${DKG}WorkspaceOperation`, swmMetaGraph),
+    mq(subject, `${DKG}contextGraphId`, lit(meta.contextGraphId), swmMetaGraph),
+    mq(subject, `${DKG}shareOperationId`, lit(meta.shareOperationId), swmMetaGraph),
+    mq(subject, `${DKG}publisherPeerId`, lit(meta.publisherPeerId), swmMetaGraph),
     mq(
       subject,
       `${PROV}wasAttributedTo`,
@@ -385,6 +389,10 @@ export function generateShareMetadata(
       swmMetaGraph,
     ),
   );
+
+  if (meta.subGraphName) {
+    quads.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), swmMetaGraph));
+  }
 
   for (const rootEntity of meta.rootEntities) {
     quads.push(

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -23,7 +23,7 @@ import {
 import type { EncryptedWorkspacePayloadMsg, GossipEnvelopeMsg, OperationContext, SwmSenderKeyMessageMsg, WorkspaceCASConditionMsg, WorkspacePublishRequestMsg, WorkspaceRecipientEncryptionKey } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 import { validatePublishRequest } from './validation.js';
-import { generateShareMetadata, generateOwnershipQuads, generateSubGraphRegistration } from './metadata.js';
+import { generateOwnershipQuads, generateSubGraphRegistration } from './metadata.js';
 import { parseSimpleNQuads } from './publish-handler.js';
 import { storeWorkspaceOperationPublicQuads } from './workspace-resolution.js';
 import type { KAManifestEntry } from './publisher.js';
@@ -367,16 +367,8 @@ export class SharedMemoryHandler {
         await this.store.insert(normalized);
 
         const rootEntities = manifestForValidation.map((m) => m.rootEntity);
-        const metaQuads = generateShareMetadata(
-          {
-            shareOperationId,
-            contextGraphId,
-            rootEntities,
-            publisherPeerId,
-            timestamp: new Date(Number(timestampMs)),
-          },
-          swmMetaGraph,
-        );
+        const operationTimestamp = new Date(Number(timestampMs));
+        const metaQuads: Quad[] = [];
 
         for (const m of manifestForValidation) {
           if (m.privateMerkleRoot && m.privateMerkleRoot.length > 0) {
@@ -390,7 +382,9 @@ export class SharedMemoryHandler {
           }
         }
 
-        await this.store.insert(metaQuads);
+        if (metaQuads.length > 0) {
+          await this.store.insert(metaQuads);
+        }
         await storeWorkspaceOperationPublicQuads({
           store: this.store,
           graphManager: this.graphManager,
@@ -400,6 +394,7 @@ export class SharedMemoryHandler {
           quads: normalized,
           publisherPeerId,
           subGraphName,
+          timestamp: operationTimestamp,
         });
 
         if (!this.sharedMemoryOwnedEntities.has(swmOwnershipKey)) {

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -27,6 +27,7 @@ import { generateOwnershipQuads, generateSubGraphRegistration } from './metadata
 import { parseSimpleNQuads } from './publish-handler.js';
 import { storeWorkspaceOperationPublicQuads } from './workspace-resolution.js';
 import type { KAManifestEntry } from './publisher.js';
+import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 
 interface WorkspaceGossipDecodeResult {
   request?: WorkspacePublishRequestMsg;
@@ -61,6 +62,7 @@ export class SharedMemoryHandler {
   ) => readonly WorkspaceRecipientEncryptionKey[] | Promise<readonly WorkspaceRecipientEncryptionKey[]>;
   private readonly workspaceSenderKeyDecryptor?: WorkspaceSenderKeyDecryptor;
   private readonly now: () => number;
+  private readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
   private readonly log = new Logger('SharedMemoryHandler');
 
   constructor(
@@ -75,6 +77,7 @@ export class SharedMemoryHandler {
       ) => readonly WorkspaceRecipientEncryptionKey[] | Promise<readonly WorkspaceRecipientEncryptionKey[]>;
       workspaceSenderKeyDecryptor?: WorkspaceSenderKeyDecryptor;
       now?: () => number;
+      publicSnapshotStore?: WorkspacePublicSnapshotStore;
     },
   ) {
     this.store = store;
@@ -88,6 +91,7 @@ export class SharedMemoryHandler {
     this.workspaceRecipientPrivateKeys = options?.workspaceRecipientPrivateKeys;
     this.workspaceSenderKeyDecryptor = options?.workspaceSenderKeyDecryptor;
     this.now = options?.now ?? (() => Date.now());
+    this.publicSnapshotStore = options?.publicSnapshotStore;
   }
 
   private async withWriteLocks<T>(keys: string[], fn: () => Promise<T>): Promise<T> {
@@ -395,6 +399,7 @@ export class SharedMemoryHandler {
           publisherPeerId,
           subGraphName,
           timestamp: operationTimestamp,
+          publicSnapshotStore: this.publicSnapshotStore,
         });
 
         if (!this.sharedMemoryOwnedEntities.has(swmOwnershipKey)) {

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -109,10 +109,21 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       subGraphName,
     );
     const rootQuads = filterQuadsForRoot(normalizedQuads, root);
+    const snapshotGraph = workspaceOperationPublicSnapshotGraph(
+      params.contextGraphId,
+      params.shareOperationId,
+      root,
+      subGraphName,
+    );
+    await params.store.dropGraph(snapshotGraph);
+    if (rootQuads.length > 0) {
+      await params.store.insert(rootQuads.map((quad) => ({ ...quad, graph: snapshotGraph })));
+    }
     snapshotQuads.push(
       { subject, predicate: `${DKG}contextGraphId`, object: lit(params.contextGraphId), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}shareOperationId`, object: lit(params.shareOperationId), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicSliceRootEntity`, object: root, graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}publicSnapshotGraph`, object: snapshotGraph, graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicQuadsDigest`, object: lit(publicQuadsDigest(rootQuads)), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicQuadsCount`, object: intLit(rootQuads.length), graph: workspaceMetaGraph },
       { subject, predicate: `${PROV}wasAttributedTo`, object: lit(publisherPeerId), graph: workspaceMetaGraph },
@@ -268,7 +279,7 @@ async function resolveWorkspaceOperationPublicQuads(params: {
   const compact = await resolveCompactWorkspaceOperationPublicQuads(params);
   if (compact.staleRoots.length > 0) {
     throw new Error(
-      `Shared-memory operation ${params.shareOperationId} no longer matches current public SWM data for roots: ${compact.staleRoots.join(', ')}`,
+      `Immutable public snapshot for shared-memory operation ${params.shareOperationId} is missing or corrupt for roots: ${compact.staleRoots.join(', ')}`,
     );
   }
 
@@ -319,9 +330,10 @@ async function resolveCompactWorkspaceOperationPublicQuads(params: {
       params.subGraphName,
     );
     const result = await params.store.query(
-      `SELECT ?digest ?count ?publisherPeerId WHERE {
+      `SELECT ?snapshotGraph ?digest ?count ?publisherPeerId WHERE {
         GRAPH <${assertSafeIri(workspaceMetaGraph)}> {
-          <${assertSafeIri(subject)}> <${DKG}publicQuadsDigest> ?digest ;
+          <${assertSafeIri(subject)}> <${DKG}publicSnapshotGraph> ?snapshotGraph ;
+            <${DKG}publicQuadsDigest> ?digest ;
             <${DKG}publicQuadsCount> ?count .
           OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?publisherPeerId }
         }
@@ -335,25 +347,20 @@ async function resolveCompactWorkspaceOperationPublicQuads(params: {
 
     const expectedDigest = stripLiteral(result.bindings[0]?.['digest'])?.trim();
     const expectedCount = parseIntegerLiteral(result.bindings[0]?.['count']);
-    if (!expectedDigest || !Number.isInteger(expectedCount)) {
+    const snapshotGraph = result.bindings[0]?.['snapshotGraph'];
+    if (!expectedDigest || !Number.isInteger(expectedCount) || !snapshotGraph || !isSafeIri(snapshotGraph)) {
       missingRoots.push(root);
       continue;
     }
 
-    const currentQuads = await resolveWorkspaceSelection({
-      store: params.store,
-      graphManager: params.graphManager,
-      contextGraphId: params.contextGraphId,
-      selection: { rootEntities: [root] },
-      subGraphName: params.subGraphName,
-    });
-    const currentDigest = publicQuadsDigest(currentQuads);
-    if (currentDigest !== expectedDigest || currentQuads.length !== expectedCount) {
+    const snapshotQuads = await resolveSnapshotGraphQuads(params.store, snapshotGraph);
+    const snapshotDigest = publicQuadsDigest(snapshotQuads);
+    if (snapshotDigest !== expectedDigest || snapshotQuads.length !== expectedCount) {
       staleRoots.push(root);
       continue;
     }
 
-    quads.push(...currentQuads);
+    quads.push(...snapshotQuads);
     const publisherPeerId = stripLiteral(result.bindings[0]?.['publisherPeerId'])?.trim();
     if (publisherPeerId) publisherPeerIds.push(publisherPeerId);
   }
@@ -495,6 +502,28 @@ function workspaceOperationPublicSliceSubject(
   const subject = `urn:dkg:public-stage:${parts.join(':')}`;
   assertSafeIri(subject);
   return subject;
+}
+
+function workspaceOperationPublicSnapshotGraph(
+  contextGraphId: string,
+  shareOperationId: string,
+  rootEntity: string,
+  subGraphName?: string,
+): string {
+  const parts = [contextGraphId, subGraphName ?? '_', shareOperationId, rootEntity]
+    .map((part) => encodeURIComponent(part));
+  const graph = `did:dkg:context-graph:${parts[0]}/_shared_memory_snapshots/${parts[1]}/${parts[2]}/${parts[3]}/_shared_memory`;
+  assertSafeIri(graph);
+  return graph;
+}
+
+async function resolveSnapshotGraphQuads(store: TripleStore, snapshotGraph: string): Promise<Quad[]> {
+  const result = await store.query(
+    `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(snapshotGraph)}> { ?s ?p ?o } }`,
+  );
+  return result.type === 'quads'
+    ? result.quads.map((quad) => ({ ...quad, graph: '' }))
+    : [];
 }
 
 function parseStoredPublicQuads(value: string | undefined, shareOperationId: string, rootEntity: string): Quad[] {

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -1,11 +1,10 @@
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { assertSafeIri, isSafeIri, validateSubGraphName } from '@origintrail-official/dkg-core';
-import { createHash } from 'node:crypto';
 import type { LiftRequest } from './lift-job.js';
 import type { LiftResolvedPublishSlice } from './async-lift-publish-options.js';
 import { generateShareMetadata } from './metadata.js';
-import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
+import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const PROV = 'http://www.w3.org/ns/prov#';
@@ -111,7 +110,7 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       subGraphName,
     );
     const rootQuads = filterQuadsForRoot(normalizedQuads, root);
-    const digest = publicQuadsDigest(rootQuads);
+    const digest = workspacePublicQuadsDigest(rootQuads);
     let snapshotRef: string | undefined;
     let snapshotGraph: string | undefined;
     if (params.publicSnapshotStore) {
@@ -387,7 +386,7 @@ async function resolveCompactWorkspaceOperationPublicQuads(params: {
       missingRoots.push(root);
       continue;
     }
-    const snapshotDigest = publicQuadsDigest(snapshotQuads);
+    const snapshotDigest = workspacePublicQuadsDigest(snapshotQuads);
     if (snapshotDigest !== expectedDigest || snapshotQuads.length !== expectedCount) {
       staleRoots.push(root);
       continue;
@@ -585,15 +584,6 @@ function parseStoredPublicQuads(value: string | undefined, shareOperationId: str
 
 function filterQuadsForRoot(quads: readonly Quad[], root: string): Quad[] {
   return quads.filter((quad) => quad.subject === root || quad.subject.startsWith(`${root}/.well-known/genid/`));
-}
-
-function publicQuadsDigest(quads: readonly Quad[]): string {
-  const canonical = quads
-    .map((quad) => [quad.subject, quad.predicate, quad.object, ''])
-    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
-  const hash = createHash('sha256');
-  hash.update(JSON.stringify(canonical));
-  return `sha256:${hash.digest('hex')}`;
 }
 
 function lit(value: string): string {

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -5,6 +5,7 @@ import { createHash } from 'node:crypto';
 import type { LiftRequest } from './lift-job.js';
 import type { LiftResolvedPublishSlice } from './async-lift-publish-options.js';
 import { generateShareMetadata } from './metadata.js';
+import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const PROV = 'http://www.w3.org/ns/prov#';
@@ -66,6 +67,7 @@ export async function storeWorkspaceOperationPublicQuads(params: {
   publisherPeerId?: string;
   subGraphName?: string;
   timestamp?: Date;
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
 }): Promise<void> {
   const roots = normalizeRoots(params.rootEntities);
   if (roots.length === 0) return;
@@ -109,26 +111,38 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       subGraphName,
     );
     const rootQuads = filterQuadsForRoot(normalizedQuads, root);
-    const snapshotGraph = workspaceOperationPublicSnapshotGraph(
-      params.contextGraphId,
-      params.shareOperationId,
-      root,
-      subGraphName,
-    );
-    await params.store.dropGraph(snapshotGraph);
-    if (rootQuads.length > 0) {
-      await params.store.insert(rootQuads.map((quad) => ({ ...quad, graph: snapshotGraph })));
+    const digest = publicQuadsDigest(rootQuads);
+    let snapshotRef: string | undefined;
+    let snapshotGraph: string | undefined;
+    if (params.publicSnapshotStore) {
+      snapshotRef = (await params.publicSnapshotStore.putSnapshot({ digest, quads: rootQuads })).ref;
+    } else {
+      snapshotGraph = workspaceOperationPublicSnapshotGraph(
+        params.contextGraphId,
+        params.shareOperationId,
+        root,
+        subGraphName,
+      );
+      await params.store.dropGraph(snapshotGraph);
+      if (rootQuads.length > 0) {
+        await params.store.insert(rootQuads.map((quad) => ({ ...quad, graph: snapshotGraph! })));
+      }
     }
     snapshotQuads.push(
       { subject, predicate: `${DKG}contextGraphId`, object: lit(params.contextGraphId), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}shareOperationId`, object: lit(params.shareOperationId), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicSliceRootEntity`, object: root, graph: workspaceMetaGraph },
-      { subject, predicate: `${DKG}publicSnapshotGraph`, object: snapshotGraph, graph: workspaceMetaGraph },
-      { subject, predicate: `${DKG}publicQuadsDigest`, object: lit(publicQuadsDigest(rootQuads)), graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}publicQuadsDigest`, object: lit(digest), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicQuadsCount`, object: intLit(rootQuads.length), graph: workspaceMetaGraph },
       { subject, predicate: `${PROV}wasAttributedTo`, object: lit(publisherPeerId), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publishedAt`, object: dateLit(timestamp), graph: workspaceMetaGraph },
     );
+    if (snapshotRef) {
+      snapshotQuads.push({ subject, predicate: `${DKG}publicSnapshotRef`, object: lit(snapshotRef), graph: workspaceMetaGraph });
+    }
+    if (snapshotGraph) {
+      snapshotQuads.push({ subject, predicate: `${DKG}publicSnapshotGraph`, object: snapshotGraph, graph: workspaceMetaGraph });
+    }
     if (subGraphName) {
       snapshotQuads.push({ subject, predicate: `${DKG}subGraphName`, object: lit(subGraphName), graph: workspaceMetaGraph });
     }
@@ -187,6 +201,7 @@ export async function resolveLiftWorkspaceSlice(params: {
   store: TripleStore;
   graphManager: GraphManager;
   request: LiftRequest;
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
 }): Promise<LiftResolvedPublishSlice> {
   const request = params.request;
   const shareOperationId = request.shareOperationId;
@@ -228,6 +243,7 @@ export async function resolveLiftWorkspaceSlice(params: {
     roots: requestedRoots,
     subGraphName,
     operation,
+    publicSnapshotStore: params.publicSnapshotStore,
   });
   const privateStore = new PrivateContentStore(params.store, params.graphManager);
   const privateQuads = (
@@ -261,6 +277,7 @@ async function resolveWorkspaceOperationPublicQuads(params: {
   roots: readonly string[];
   subGraphName?: string;
   operation?: ResolvedWorkspaceOperation;
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
 }): Promise<WorkspaceOperationPublicSnapshot> {
   const roots = normalizeRoots(params.roots);
   const legacy = await resolveLegacyWorkspaceOperationPublicQuads(params);
@@ -314,6 +331,7 @@ async function resolveCompactWorkspaceOperationPublicQuads(params: {
   shareOperationId: string;
   roots: readonly string[];
   subGraphName?: string;
+  publicSnapshotStore?: WorkspacePublicSnapshotStore;
 }): Promise<CompactWorkspaceOperationPublicSnapshot> {
   const roots = normalizeRoots(params.roots);
   const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, params.subGraphName);
@@ -330,11 +348,12 @@ async function resolveCompactWorkspaceOperationPublicQuads(params: {
       params.subGraphName,
     );
     const result = await params.store.query(
-      `SELECT ?snapshotGraph ?digest ?count ?publisherPeerId WHERE {
+      `SELECT ?snapshotRef ?snapshotGraph ?digest ?count ?publisherPeerId WHERE {
         GRAPH <${assertSafeIri(workspaceMetaGraph)}> {
-          <${assertSafeIri(subject)}> <${DKG}publicSnapshotGraph> ?snapshotGraph ;
-            <${DKG}publicQuadsDigest> ?digest ;
+          <${assertSafeIri(subject)}> <${DKG}publicQuadsDigest> ?digest ;
             <${DKG}publicQuadsCount> ?count .
+          OPTIONAL { <${assertSafeIri(subject)}> <${DKG}publicSnapshotRef> ?snapshotRef }
+          OPTIONAL { <${assertSafeIri(subject)}> <${DKG}publicSnapshotGraph> ?snapshotGraph }
           OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?publisherPeerId }
         }
       } LIMIT 1`,
@@ -347,13 +366,27 @@ async function resolveCompactWorkspaceOperationPublicQuads(params: {
 
     const expectedDigest = stripLiteral(result.bindings[0]?.['digest'])?.trim();
     const expectedCount = parseIntegerLiteral(result.bindings[0]?.['count']);
+    const snapshotRef = stripLiteral(result.bindings[0]?.['snapshotRef'])?.trim();
     const snapshotGraph = result.bindings[0]?.['snapshotGraph'];
-    if (!expectedDigest || !Number.isInteger(expectedCount) || !snapshotGraph || !isSafeIri(snapshotGraph)) {
+    if (!expectedDigest || !Number.isInteger(expectedCount)) {
       missingRoots.push(root);
       continue;
     }
 
-    const snapshotQuads = await resolveSnapshotGraphQuads(params.store, snapshotGraph);
+    let snapshotQuads: Quad[] | null = null;
+    if (snapshotRef) {
+      if (!params.publicSnapshotStore) {
+        missingRoots.push(root);
+        continue;
+      }
+      snapshotQuads = await params.publicSnapshotStore.getSnapshot(snapshotRef);
+    } else if (snapshotGraph && isSafeIri(snapshotGraph)) {
+      snapshotQuads = await resolveSnapshotGraphQuads(params.store, snapshotGraph);
+    }
+    if (!snapshotQuads) {
+      missingRoots.push(root);
+      continue;
+    }
     const snapshotDigest = publicQuadsDigest(snapshotQuads);
     if (snapshotDigest !== expectedDigest || snapshotQuads.length !== expectedCount) {
       staleRoots.push(root);

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -1,12 +1,14 @@
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { assertSafeIri, isSafeIri, validateSubGraphName } from '@origintrail-official/dkg-core';
+import { createHash } from 'node:crypto';
 import type { LiftRequest } from './lift-job.js';
 import type { LiftResolvedPublishSlice } from './async-lift-publish-options.js';
 import { generateShareMetadata } from './metadata.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const PROV = 'http://www.w3.org/ns/prov#';
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
 
 export type WorkspaceSelection = 'all' | { rootEntities: readonly string[] };
 
@@ -23,6 +25,12 @@ interface WorkspaceOperationPublicSnapshot {
 interface LegacyWorkspaceOperationPublicSnapshot extends WorkspaceOperationPublicSnapshot {
   readonly complete: boolean;
   readonly missingRoots: string[];
+}
+
+interface CompactWorkspaceOperationPublicSnapshot extends WorkspaceOperationPublicSnapshot {
+  readonly complete: boolean;
+  readonly missingRoots: string[];
+  readonly staleRoots: string[];
 }
 
 export async function resolveWorkspaceSelection(params: {
@@ -65,6 +73,8 @@ export async function storeWorkspaceOperationPublicQuads(params: {
   const subGraphName = normalizeOptionalSubGraphName(params.subGraphName);
   const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, subGraphName);
   const operationSubject = workspaceOperationSubject(params.contextGraphId, params.shareOperationId);
+  const publisherPeerId = params.publisherPeerId?.trim() || 'unknown';
+  const timestamp = params.timestamp ?? new Date();
 
   for (const root of roots) {
     const legacySubject = workspaceOperationPublicSliceSubject(
@@ -82,12 +92,37 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       shareOperationId: params.shareOperationId,
       contextGraphId: params.contextGraphId,
       rootEntities: roots,
-      publisherPeerId: params.publisherPeerId?.trim() || 'unknown',
-      timestamp: params.timestamp ?? new Date(),
+      publisherPeerId,
+      timestamp,
       subGraphName,
     },
     workspaceMetaGraph,
   ));
+
+  const normalizedQuads = params.quads.map((quad) => ({ ...quad, graph: '' }));
+  const snapshotQuads: Quad[] = [];
+  for (const root of roots) {
+    const subject = workspaceOperationPublicSliceSubject(
+      params.contextGraphId,
+      params.shareOperationId,
+      root,
+      subGraphName,
+    );
+    const rootQuads = filterQuadsForRoot(normalizedQuads, root);
+    snapshotQuads.push(
+      { subject, predicate: `${DKG}contextGraphId`, object: lit(params.contextGraphId), graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}shareOperationId`, object: lit(params.shareOperationId), graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}publicSliceRootEntity`, object: root, graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}publicQuadsDigest`, object: lit(publicQuadsDigest(rootQuads)), graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}publicQuadsCount`, object: intLit(rootQuads.length), graph: workspaceMetaGraph },
+      { subject, predicate: `${PROV}wasAttributedTo`, object: lit(publisherPeerId), graph: workspaceMetaGraph },
+      { subject, predicate: `${DKG}publishedAt`, object: dateLit(timestamp), graph: workspaceMetaGraph },
+    );
+    if (subGraphName) {
+      snapshotQuads.push({ subject, predicate: `${DKG}subGraphName`, object: lit(subGraphName), graph: workspaceMetaGraph });
+    }
+  }
+  await params.store.insert(snapshotQuads);
 }
 
 /**
@@ -230,23 +265,105 @@ async function resolveWorkspaceOperationPublicQuads(params: {
     };
   }
 
-  if (!params.operation) {
+  const compact = await resolveCompactWorkspaceOperationPublicQuads(params);
+  if (compact.staleRoots.length > 0) {
     throw new Error(
-      `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId} roots: ${legacy.missingRoots.join(', ')}`,
+      `Shared-memory operation ${params.shareOperationId} no longer matches current public SWM data for roots: ${compact.staleRoots.join(', ')}`,
     );
   }
 
-  const quads = await resolveWorkspaceSelection({
-    store: params.store,
-    graphManager: params.graphManager,
-    contextGraphId: params.contextGraphId,
-    selection: { rootEntities: roots },
-    subGraphName: params.subGraphName,
-  });
+  if (compact.complete) {
+    if (compact.quads.length === 0) {
+      throw new Error(
+        `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId}`,
+      );
+    }
+    return {
+      quads: compact.quads,
+      publisherPeerId: compact.publisherPeerId ?? params.operation?.publisherPeerId,
+    };
+  }
+
+  if (!params.operation || compact.missingRoots.length > 0) {
+    const missingRoots = compact.missingRoots.length > 0 ? compact.missingRoots : legacy.missingRoots;
+    throw new Error(
+      `No immutable public snapshot metadata found for context graph ${params.contextGraphId} share operation ${params.shareOperationId} roots: ${missingRoots.join(', ')}`,
+    );
+  }
+
+  throw new Error(
+    `No immutable public snapshot metadata found for context graph ${params.contextGraphId} share operation ${params.shareOperationId} roots: ${roots.join(', ')}`,
+  );
+}
+
+async function resolveCompactWorkspaceOperationPublicQuads(params: {
+  store: TripleStore;
+  graphManager: GraphManager;
+  contextGraphId: string;
+  shareOperationId: string;
+  roots: readonly string[];
+  subGraphName?: string;
+}): Promise<CompactWorkspaceOperationPublicSnapshot> {
+  const roots = normalizeRoots(params.roots);
+  const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, params.subGraphName);
+  const quads: Quad[] = [];
+  const publisherPeerIds: string[] = [];
+  const missingRoots: string[] = [];
+  const staleRoots: string[] = [];
+
+  for (const root of roots) {
+    const subject = workspaceOperationPublicSliceSubject(
+      params.contextGraphId,
+      params.shareOperationId,
+      root,
+      params.subGraphName,
+    );
+    const result = await params.store.query(
+      `SELECT ?digest ?count ?publisherPeerId WHERE {
+        GRAPH <${assertSafeIri(workspaceMetaGraph)}> {
+          <${assertSafeIri(subject)}> <${DKG}publicQuadsDigest> ?digest ;
+            <${DKG}publicQuadsCount> ?count .
+          OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?publisherPeerId }
+        }
+      } LIMIT 1`,
+    );
+
+    if (result.type !== 'bindings' || result.bindings.length === 0) {
+      missingRoots.push(root);
+      continue;
+    }
+
+    const expectedDigest = stripLiteral(result.bindings[0]?.['digest'])?.trim();
+    const expectedCount = parseIntegerLiteral(result.bindings[0]?.['count']);
+    if (!expectedDigest || !Number.isInteger(expectedCount)) {
+      missingRoots.push(root);
+      continue;
+    }
+
+    const currentQuads = await resolveWorkspaceSelection({
+      store: params.store,
+      graphManager: params.graphManager,
+      contextGraphId: params.contextGraphId,
+      selection: { rootEntities: [root] },
+      subGraphName: params.subGraphName,
+    });
+    const currentDigest = publicQuadsDigest(currentQuads);
+    if (currentDigest !== expectedDigest || currentQuads.length !== expectedCount) {
+      staleRoots.push(root);
+      continue;
+    }
+
+    quads.push(...currentQuads);
+    const publisherPeerId = stripLiteral(result.bindings[0]?.['publisherPeerId'])?.trim();
+    if (publisherPeerId) publisherPeerIds.push(publisherPeerId);
+  }
 
   return {
+    complete: missingRoots.length === 0 && staleRoots.length === 0,
+    missingRoots,
+    staleRoots,
     quads,
-    publisherPeerId: params.operation.publisherPeerId,
+    publisherPeerId: publisherPeerIds[0],
   };
 }
 
@@ -404,6 +521,31 @@ function parseStoredPublicQuads(value: string | undefined, shareOperationId: str
   });
 }
 
+function filterQuadsForRoot(quads: readonly Quad[], root: string): Quad[] {
+  return quads.filter((quad) => quad.subject === root || quad.subject.startsWith(`${root}/.well-known/genid/`));
+}
+
+function publicQuadsDigest(quads: readonly Quad[]): string {
+  const canonical = quads
+    .map((quad) => [quad.subject, quad.predicate, quad.object, ''])
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const hash = createHash('sha256');
+  hash.update(JSON.stringify(canonical));
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function lit(value: string): string {
+  return JSON.stringify(value);
+}
+
+function intLit(value: number): string {
+  return `"${value}"^^<${XSD}integer>`;
+}
+
+function dateLit(value: Date): string {
+  return `"${value.toISOString()}"^^<${XSD}dateTime>`;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -422,6 +564,11 @@ function stripLiteral(value: string | undefined): string | undefined {
     }
   }
   return value;
+}
+
+function parseIntegerLiteral(value: string | undefined): number {
+  const parsed = Number(stripLiteral(value));
+  return Number.isInteger(parsed) ? parsed : NaN;
 }
 
 function isPresent<T>(value: T | undefined): value is T {

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -3,6 +3,7 @@ import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-sto
 import { assertSafeIri, isSafeIri, validateSubGraphName } from '@origintrail-official/dkg-core';
 import type { LiftRequest } from './lift-job.js';
 import type { LiftResolvedPublishSlice } from './async-lift-publish-options.js';
+import { generateShareMetadata } from './metadata.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const PROV = 'http://www.w3.org/ns/prov#';
@@ -19,13 +20,20 @@ interface WorkspaceOperationPublicSnapshot {
   readonly publisherPeerId?: string;
 }
 
+interface LegacyWorkspaceOperationPublicSnapshot extends WorkspaceOperationPublicSnapshot {
+  readonly complete: boolean;
+  readonly missingRoots: string[];
+}
+
 export async function resolveWorkspaceSelection(params: {
   store: TripleStore;
   graphManager: GraphManager;
   contextGraphId: string;
   selection: WorkspaceSelection;
+  subGraphName?: string;
 }): Promise<Quad[]> {
-  const workspaceGraph = params.graphManager.workspaceGraphUri(params.contextGraphId);
+  const subGraphName = normalizeOptionalSubGraphName(params.subGraphName);
+  const workspaceGraph = params.graphManager.sharedMemoryUri(params.contextGraphId, subGraphName);
   const sparql = buildWorkspaceSelectionQuery(workspaceGraph, params.contextGraphId, params.selection);
   const result = await params.store.query(sparql);
   const quads: Quad[] = result.type === 'quads'
@@ -45,46 +53,41 @@ export async function storeWorkspaceOperationPublicQuads(params: {
   contextGraphId: string;
   shareOperationId: string;
   rootEntities: readonly string[];
+  // Retained for API compatibility; new metadata stores roots, not serialized payloads.
   quads: readonly Quad[];
   publisherPeerId?: string;
   subGraphName?: string;
+  timestamp?: Date;
 }): Promise<void> {
   const roots = normalizeRoots(params.rootEntities);
   if (roots.length === 0) return;
 
-  const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, params.subGraphName);
-  const publisherPeerId = params.publisherPeerId?.trim();
-  const stagedQuads: Quad[] = [];
+  const subGraphName = normalizeOptionalSubGraphName(params.subGraphName);
+  const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, subGraphName);
+  const operationSubject = workspaceOperationSubject(params.contextGraphId, params.shareOperationId);
 
   for (const root of roots) {
-    const subject = workspaceOperationPublicSliceSubject(
+    const legacySubject = workspaceOperationPublicSliceSubject(
       params.contextGraphId,
       params.shareOperationId,
       root,
-      params.subGraphName,
+      subGraphName,
     );
-    await params.store.deleteByPattern({ graph: workspaceMetaGraph, subject });
-
-    stagedQuads.push({
-      subject,
-      predicate: `${DKG}publicStagedQuads`,
-      object: JSON.stringify(JSON.stringify(selectQuadsForRoots(params.quads, [root]))),
-      graph: workspaceMetaGraph,
-    });
-
-    if (publisherPeerId) {
-      stagedQuads.push({
-        subject,
-        predicate: `${PROV}wasAttributedTo`,
-        object: JSON.stringify(publisherPeerId),
-        graph: workspaceMetaGraph,
-      });
-    }
+    await params.store.deleteByPattern({ graph: workspaceMetaGraph, subject: legacySubject });
   }
 
-  if (stagedQuads.length > 0) {
-    await params.store.insert(stagedQuads);
-  }
+  await params.store.deleteByPattern({ graph: workspaceMetaGraph, subject: operationSubject });
+  await params.store.insert(generateShareMetadata(
+    {
+      shareOperationId: params.shareOperationId,
+      contextGraphId: params.contextGraphId,
+      rootEntities: roots,
+      publisherPeerId: params.publisherPeerId?.trim() || 'unknown',
+      timestamp: params.timestamp ?? new Date(),
+      subGraphName,
+    },
+    workspaceMetaGraph,
+  ));
 }
 
 /**
@@ -178,6 +181,7 @@ export async function resolveLiftWorkspaceSlice(params: {
     shareOperationId,
     roots: requestedRoots,
     subGraphName,
+    operation,
   });
   const privateStore = new PrivateContentStore(params.store, params.graphManager);
   const privateQuads = (
@@ -210,7 +214,50 @@ async function resolveWorkspaceOperationPublicQuads(params: {
   shareOperationId: string;
   roots: readonly string[];
   subGraphName?: string;
+  operation?: ResolvedWorkspaceOperation;
 }): Promise<WorkspaceOperationPublicSnapshot> {
+  const roots = normalizeRoots(params.roots);
+  const legacy = await resolveLegacyWorkspaceOperationPublicQuads(params);
+  if (legacy.complete) {
+    if (legacy.quads.length === 0) {
+      throw new Error(
+        `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId}`,
+      );
+    }
+    return {
+      quads: legacy.quads,
+      publisherPeerId: legacy.publisherPeerId,
+    };
+  }
+
+  if (!params.operation) {
+    throw new Error(
+      `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId} roots: ${legacy.missingRoots.join(', ')}`,
+    );
+  }
+
+  const quads = await resolveWorkspaceSelection({
+    store: params.store,
+    graphManager: params.graphManager,
+    contextGraphId: params.contextGraphId,
+    selection: { rootEntities: roots },
+    subGraphName: params.subGraphName,
+  });
+
+  return {
+    quads,
+    publisherPeerId: params.operation.publisherPeerId,
+  };
+}
+
+async function resolveLegacyWorkspaceOperationPublicQuads(params: {
+  store: TripleStore;
+  graphManager: GraphManager;
+  contextGraphId: string;
+  shareOperationId: string;
+  roots: readonly string[];
+  subGraphName?: string;
+}): Promise<LegacyWorkspaceOperationPublicSnapshot> {
   const roots = normalizeRoots(params.roots);
   const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, params.subGraphName);
   const quads: Quad[] = [];
@@ -243,18 +290,9 @@ async function resolveWorkspaceOperationPublicQuads(params: {
     if (publisherPeerId) publisherPeerIds.push(publisherPeerId);
   }
 
-  if (missingRoots.length > 0) {
-    throw new Error(
-      `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId} roots: ${missingRoots.join(', ')}`,
-    );
-  }
-  if (quads.length === 0) {
-    throw new Error(
-      `No public staged quads found for context graph ${params.contextGraphId} share operation ${params.shareOperationId}`,
-    );
-  }
-
   return {
+    complete: missingRoots.length === 0,
+    missingRoots,
     quads,
     publisherPeerId: publisherPeerIds[0],
   };
@@ -304,14 +342,6 @@ function buildWorkspaceSelectionQuery(
       )
     }
   }`;
-}
-
-function selectQuadsForRoots(quads: readonly Quad[], roots: readonly string[]): Quad[] {
-  return quads
-    .filter((quad) => roots.some((root) =>
-      quad.subject === root || quad.subject.startsWith(`${root}/.well-known/genid/`),
-    ))
-    .map((quad) => ({ ...quad, graph: '' }));
 }
 
 function normalizeRoots(roots: readonly string[]): string[] {

--- a/packages/publisher/src/workspace-snapshot-store.ts
+++ b/packages/publisher/src/workspace-snapshot-store.ts
@@ -1,0 +1,86 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+export interface SharedMemoryPublicSnapshotStorageConfig {
+  enabled?: boolean;
+  directory?: string;
+}
+
+export interface WorkspacePublicSnapshotStore {
+  putSnapshot(input: {
+    readonly digest: string;
+    readonly quads: readonly Quad[];
+  }): Promise<{ readonly ref: string; readonly byteLength: number }>;
+  getSnapshot(ref: string): Promise<Quad[] | null>;
+}
+
+export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshotStore {
+  constructor(private readonly directory: string) {}
+
+  async putSnapshot(input: {
+    readonly digest: string;
+    readonly quads: readonly Quad[];
+  }): Promise<{ readonly ref: string; readonly byteLength: number }> {
+    const hash = snapshotHash(input.digest);
+    const filePath = snapshotPath(this.directory, hash);
+    const payload = `${JSON.stringify(input.quads.map((quad) => [
+      quad.subject,
+      quad.predicate,
+      quad.object,
+      quad.graph ?? '',
+    ]))}\n`;
+
+    await mkdir(dirname(filePath), { recursive: true });
+    const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    await writeFile(tempPath, payload, 'utf8');
+    await rename(tempPath, filePath).catch(async (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EEXIST') return;
+      throw err;
+    });
+
+    return {
+      ref: input.digest,
+      byteLength: Buffer.byteLength(payload, 'utf8'),
+    };
+  }
+
+  async getSnapshot(ref: string): Promise<Quad[] | null> {
+    const hash = snapshotHash(ref);
+    const filePath = snapshotPath(this.directory, hash);
+    let raw: string;
+    try {
+      raw = await readFile(filePath, 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw err;
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    return parsed.map((entry) => {
+      if (!Array.isArray(entry) || entry.length < 3) {
+        throw new Error(`Invalid shared-memory public snapshot blob ${ref}`);
+      }
+      return {
+        subject: String(entry[0]),
+        predicate: String(entry[1]),
+        object: String(entry[2]),
+        graph: '',
+      };
+    });
+  }
+}
+
+function snapshotHash(ref: string): string {
+  const trimmed = ref.trim();
+  const hash = trimmed.startsWith('sha256:') ? trimmed.slice('sha256:'.length) : trimmed;
+  if (!/^[a-f0-9]{64}$/i.test(hash)) {
+    throw new Error(`Invalid shared-memory public snapshot ref ${ref}`);
+  }
+  return hash.toLowerCase();
+}
+
+function snapshotPath(directory: string, hash: string): string {
+  return join(directory, hash.slice(0, 2), hash.slice(2, 4), `${hash}.json`);
+}

--- a/packages/publisher/src/workspace-snapshot-store.ts
+++ b/packages/publisher/src/workspace-snapshot-store.ts
@@ -23,13 +23,8 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
     readonly quads: readonly Quad[];
   }): Promise<{ readonly ref: string; readonly byteLength: number }> {
     const hash = snapshotHash(input.digest);
-    const filePath = snapshotPath(this.directory, hash);
-    const payload = `${JSON.stringify(input.quads.map((quad) => [
-      quad.subject,
-      quad.predicate,
-      quad.object,
-      quad.graph ?? '',
-    ]))}\n`;
+    const filePath = snapshotPath(this.directory, hash, 'nq');
+    const payload = serializeQuadsToNQuads(input.quads);
 
     await mkdir(dirname(filePath), { recursive: true });
     const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
@@ -47,10 +42,23 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
 
   async getSnapshot(ref: string): Promise<Quad[] | null> {
     const hash = snapshotHash(ref);
-    const filePath = snapshotPath(this.directory, hash);
+    const nquadsPath = snapshotPath(this.directory, hash, 'nq');
     let raw: string;
     try {
-      raw = await readFile(filePath, 'utf8');
+      raw = await readFile(nquadsPath, 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      return this.getLegacyJsonSnapshot(ref, hash);
+    }
+
+    return parseQuadsFromNQuads(raw, ref);
+  }
+
+  private async getLegacyJsonSnapshot(ref: string, hash: string): Promise<Quad[] | null> {
+    const jsonPath = snapshotPath(this.directory, hash, 'json');
+    let raw: string;
+    try {
+      raw = await readFile(jsonPath, 'utf8');
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
       throw err;
@@ -81,6 +89,144 @@ function snapshotHash(ref: string): string {
   return hash.toLowerCase();
 }
 
-function snapshotPath(directory: string, hash: string): string {
-  return join(directory, hash.slice(0, 2), hash.slice(2, 4), `${hash}.json`);
+function snapshotPath(directory: string, hash: string, extension: 'json' | 'nq'): string {
+  return join(directory, hash.slice(0, 2), hash.slice(2, 4), `${hash}.${extension}`);
+}
+
+function serializeQuadsToNQuads(quads: readonly Quad[]): string {
+  if (quads.length === 0) return '';
+  return `${quads.map(quadToNQuad).join('\n')}\n`;
+}
+
+function quadToNQuad(quad: Quad): string {
+  return `${formatNodeTerm(quad.subject)} <${escapeIri(quad.predicate)}> ${formatObjectTerm(quad.object)} .`;
+}
+
+function formatNodeTerm(term: string): string {
+  if (term.startsWith('_:')) return term;
+  if (term.startsWith('<') && term.endsWith('>')) return term;
+  return `<${escapeIri(term)}>`;
+}
+
+function formatObjectTerm(term: string): string {
+  if (term.startsWith('"')) {
+    const bareDatatype = term.match(/^("(?:[^"\\]|\\.)*")\^\^(?!<)(.+)$/);
+    return bareDatatype ? `${bareDatatype[1]}^^<${escapeIri(bareDatatype[2])}>` : term;
+  }
+  return formatNodeTerm(term);
+}
+
+function escapeIri(iri: string): string {
+  return iri.replace(/[<>"{}|\\^`]/g, '');
+}
+
+function parseQuadsFromNQuads(raw: string, ref: string): Quad[] {
+  const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  return lines.map((line, index) => parseNQuadLine(line, ref, index));
+}
+
+function parseNQuadLine(line: string, ref: string, index: number): Quad {
+  const parsedSubject = readTerm(line, 0);
+  if (!parsedSubject) throw invalidSnapshotBlob(ref, index);
+
+  const parsedPredicate = readTerm(line, parsedSubject.end);
+  if (!parsedPredicate || !isIriTerm(parsedPredicate.term)) throw invalidSnapshotBlob(ref, index);
+
+  const parsedObject = readTerm(line, parsedPredicate.end);
+  if (!parsedObject) throw invalidSnapshotBlob(ref, index);
+
+  const rest = line.slice(parsedObject.end).trim();
+  if (rest !== '.') throw invalidSnapshotBlob(ref, index);
+
+  return {
+    subject: normalizeParsedResourceTerm(parsedSubject.term),
+    predicate: normalizeParsedResourceTerm(parsedPredicate.term),
+    object: normalizeParsedObjectTerm(parsedObject.term),
+    graph: '',
+  };
+}
+
+function readTerm(input: string, start: number): { term: string; end: number } | null {
+  let cursor = skipWhitespace(input, start);
+  if (cursor >= input.length) return null;
+
+  if (input[cursor] === '<') {
+    const end = input.indexOf('>', cursor + 1);
+    if (end < 0) return null;
+    return { term: input.slice(cursor, end + 1), end: end + 1 };
+  }
+
+  if (input.startsWith('_:', cursor)) {
+    const end = readUntilWhitespace(input, cursor);
+    return { term: input.slice(cursor, end), end };
+  }
+
+  if (input[cursor] === '"') {
+    return readLiteralTerm(input, cursor);
+  }
+
+  return null;
+}
+
+function readLiteralTerm(input: string, start: number): { term: string; end: number } | null {
+  const quoteEnd = findClosingLiteralQuote(input, start);
+  if (quoteEnd < 0) return null;
+
+  let end = quoteEnd + 1;
+  if (input[end] === '@') {
+    end += 1;
+    while (end < input.length && /[A-Za-z0-9-]/.test(input[end])) end += 1;
+  } else if (input.slice(end, end + 2) === '^^') {
+    end += 2;
+    if (input[end] === '<') {
+      const datatypeEnd = input.indexOf('>', end + 1);
+      if (datatypeEnd < 0) return null;
+      end = datatypeEnd + 1;
+    } else {
+      end = readUntilWhitespace(input, end);
+    }
+  }
+
+  return { term: input.slice(start, end), end };
+}
+
+function findClosingLiteralQuote(input: string, start: number): number {
+  for (let i = start + 1; i < input.length; i += 1) {
+    if (input[i] !== '"') continue;
+    let backslashes = 0;
+    for (let j = i - 1; j >= start && input[j] === '\\'; j -= 1) {
+      backslashes += 1;
+    }
+    if (backslashes % 2 === 0) return i;
+  }
+  return -1;
+}
+
+function skipWhitespace(input: string, start: number): number {
+  let cursor = start;
+  while (cursor < input.length && /\s/.test(input[cursor])) cursor += 1;
+  return cursor;
+}
+
+function readUntilWhitespace(input: string, start: number): number {
+  let cursor = start;
+  while (cursor < input.length && !/\s/.test(input[cursor])) cursor += 1;
+  return cursor;
+}
+
+function isIriTerm(term: string): boolean {
+  return term.startsWith('<') && term.endsWith('>');
+}
+
+function normalizeParsedResourceTerm(term: string): string {
+  if (isIriTerm(term)) return term.slice(1, -1);
+  return term;
+}
+
+function normalizeParsedObjectTerm(term: string): string {
+  return isIriTerm(term) ? term.slice(1, -1) : term;
+}
+
+function invalidSnapshotBlob(ref: string, index: number): Error {
+  return new Error(`Invalid shared-memory public snapshot blob ${ref} at line ${index + 1}`);
 }

--- a/packages/publisher/src/workspace-snapshot-store.ts
+++ b/packages/publisher/src/workspace-snapshot-store.ts
@@ -1,4 +1,5 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import type { Quad } from '@origintrail-official/dkg-storage';
 
@@ -24,7 +25,7 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
   }): Promise<{ readonly ref: string; readonly byteLength: number }> {
     const hash = snapshotHash(input.digest);
     const filePath = snapshotPath(this.directory, hash, 'nq');
-    const payload = serializeQuadsToNQuads(input.quads);
+    const payload = serializeWorkspacePublicSnapshotQuads(input.quads);
 
     await mkdir(dirname(filePath), { recursive: true });
     const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
@@ -51,7 +52,7 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
       return this.getLegacyJsonSnapshot(ref, hash);
     }
 
-    return parseQuadsFromNQuads(raw, ref);
+    return parseWorkspacePublicSnapshotNQuads(raw, ref);
   }
 
   private async getLegacyJsonSnapshot(ref: string, hash: string): Promise<Quad[] | null> {
@@ -93,9 +94,18 @@ function snapshotPath(directory: string, hash: string, extension: 'json' | 'nq')
   return join(directory, hash.slice(0, 2), hash.slice(2, 4), `${hash}.${extension}`);
 }
 
-function serializeQuadsToNQuads(quads: readonly Quad[]): string {
+export function serializeWorkspacePublicSnapshotQuads(quads: readonly Quad[]): string {
   if (quads.length === 0) return '';
   return `${quads.map(quadToNQuad).join('\n')}\n`;
+}
+
+export function workspacePublicQuadsDigest(quads: readonly Quad[]): string {
+  const canonical = quads
+    .map((quad) => [quad.subject, quad.predicate, quad.object, ''])
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const hash = createHash('sha256');
+  hash.update(JSON.stringify(canonical));
+  return `sha256:${hash.digest('hex')}`;
 }
 
 function quadToNQuad(quad: Quad): string {
@@ -120,7 +130,7 @@ function escapeIri(iri: string): string {
   return iri.replace(/[<>"{}|\\^`]/g, '');
 }
 
-function parseQuadsFromNQuads(raw: string, ref: string): Quad[] {
+export function parseWorkspacePublicSnapshotNQuads(raw: string, ref: string): Quad[] {
   const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   return lines.map((line, index) => parseNQuadLine(line, ref, index));
 }

--- a/packages/publisher/test/async-lift-workspace.test.ts
+++ b/packages/publisher/test/async-lift-workspace.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { GraphManager, OxigraphStore, PrivateContentStore, SharedMemoryLiteralBlobStore } from '@origintrail-official/dkg-storage';
 import { NoChainAdapter } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
@@ -13,6 +13,86 @@ const ENTITY = 'urn:test:entity:1';
 const ENTITY_2 = 'urn:test:entity:2';
 const DKG = 'http://dkg.io/ontology/';
 const PROV = 'http://www.w3.org/ns/prov#';
+const SNAPSHOT_DIGEST = `sha256:${'a'.repeat(64)}`;
+
+describe('FileWorkspacePublicSnapshotStore', () => {
+  it('writes graphless N-Quads snapshots and keeps legacy JSON absent for new writes', async () => {
+    const snapshotDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-public-snapshots-'));
+    const publicSnapshotStore = new FileWorkspacePublicSnapshotStore(snapshotDir);
+    const quads = [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+      {
+        subject: `${ENTITY}/.well-known/genid/child`,
+        predicate: 'http://schema.org/count',
+        object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: '',
+      },
+      { subject: ENTITY, predicate: 'http://schema.org/lang', object: '"Zdravo"@sr-Latn', graph: '' },
+    ];
+
+    try {
+      const stored = await publicSnapshotStore.putSnapshot({ digest: SNAPSHOT_DIGEST, quads });
+
+      expect(stored.ref).toBe(SNAPSHOT_DIGEST);
+      await expect(access(snapshotFilePath(snapshotDir, SNAPSHOT_DIGEST, 'nq'))).resolves.toBeUndefined();
+      await expect(access(snapshotFilePath(snapshotDir, SNAPSHOT_DIGEST, 'json'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+      const raw = await readFile(snapshotFilePath(snapshotDir, SNAPSHOT_DIGEST, 'nq'), 'utf8');
+      expect(raw).toContain(`<${ENTITY}> <http://schema.org/name> "One" .`);
+      expect(raw).toContain(`<${ENTITY}/.well-known/genid/child> <http://schema.org/count> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .`);
+      expect(raw).toContain(`<${ENTITY}> <http://schema.org/lang> "Zdravo"@sr-Latn .`);
+      expect(stored.byteLength).toBe(Buffer.byteLength(raw, 'utf8'));
+
+      await expect(publicSnapshotStore.getSnapshot(SNAPSHOT_DIGEST)).resolves.toEqual(quads);
+    } finally {
+      await rm(snapshotDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads legacy JSON snapshots when no N-Quads snapshot exists', async () => {
+    const snapshotDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-public-snapshots-'));
+    const publicSnapshotStore = new FileWorkspacePublicSnapshotStore(snapshotDir);
+    const legacyQuads = [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Legacy JSON"', graph: '' },
+    ];
+    const jsonPath = snapshotFilePath(snapshotDir, SNAPSHOT_DIGEST, 'json');
+
+    try {
+      await mkdir(dirname(jsonPath), { recursive: true });
+      await writeFile(
+        jsonPath,
+        `${JSON.stringify(legacyQuads.map((quad) => [quad.subject, quad.predicate, quad.object, quad.graph]))}\n`,
+        'utf8',
+      );
+
+      await expect(publicSnapshotStore.getSnapshot(SNAPSHOT_DIGEST)).resolves.toEqual(legacyQuads);
+    } finally {
+      await rm(snapshotDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects malformed N-Quads snapshots without falling back to legacy JSON', async () => {
+    const snapshotDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-public-snapshots-'));
+    const publicSnapshotStore = new FileWorkspacePublicSnapshotStore(snapshotDir);
+    const nquadsPath = snapshotFilePath(snapshotDir, SNAPSHOT_DIGEST, 'nq');
+    const jsonPath = snapshotFilePath(snapshotDir, SNAPSHOT_DIGEST, 'json');
+
+    try {
+      await mkdir(dirname(nquadsPath), { recursive: true });
+      await writeFile(nquadsPath, `<${ENTITY}> <http://schema.org/name> "broken"\n`, 'utf8');
+      await writeFile(
+        jsonPath,
+        `${JSON.stringify([[ENTITY, 'http://schema.org/name', '"Legacy JSON"', '']])}\n`,
+        'utf8',
+      );
+
+      await expect(publicSnapshotStore.getSnapshot(SNAPSHOT_DIGEST))
+        .rejects.toThrow(`Invalid shared-memory public snapshot blob ${SNAPSHOT_DIGEST}`);
+    } finally {
+      await rm(snapshotDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('async lift workspace resolution', () => {
   let store: OxigraphStore;
@@ -417,12 +497,20 @@ describe('async lift workspace resolution', () => {
         }`,
       );
       expect(metadata.type).toBe('bindings');
+      let snapshotRef: string | undefined;
       if (metadata.type === 'bindings') {
         expect(metadata.bindings.some((row) => row['snapshotRef']?.includes('sha256:'))).toBe(true);
         expect(metadata.bindings.some((row) => row['snapshotGraph'])).toBe(false);
         expect(metadata.bindings.some((row) => row['payload'])).toBe(false);
         expect(JSON.stringify(metadata.bindings)).not.toContain(marker);
+        snapshotRef = metadata.bindings.map((row) => stripLiteral(row['snapshotRef'])).find(Boolean);
       }
+      expect(snapshotRef).toBeDefined();
+      const snapshotFile = snapshotFilePath(snapshotDir, snapshotRef!, 'nq');
+      await expect(access(snapshotFile)).resolves.toBeUndefined();
+      await expect(access(snapshotFilePath(snapshotDir, snapshotRef!, 'json'))).rejects.toMatchObject({ code: 'ENOENT' });
+      const snapshotRaw = await readFile(snapshotFile, 'utf8');
+      expect(snapshotRaw).toContain(marker);
 
       const snapshotGraphRows = await store.query(
         `SELECT ?g WHERE {
@@ -452,6 +540,62 @@ describe('async lift workspace resolution', () => {
       });
       expect(resolved.quads).toHaveLength(1);
       expect(resolved.quads[0]?.object).toContain(marker);
+    } finally {
+      await rm(snapshotDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails corrupted N-Quads snapshots instead of resolving live SWM data', async () => {
+    const snapshotDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-public-snapshots-'));
+    const publicSnapshotStore = new FileWorkspacePublicSnapshotStore(snapshotDir);
+    const keypair = await generateEd25519Keypair();
+    const snapshotPublisher = new DKGPublisher({
+      store,
+      chain: new NoChainAdapter(),
+      eventBus: new TypedEventBus(),
+      keypair,
+      publicSnapshotStore,
+    });
+
+    try {
+      const write1 = await snapshotPublisher.share(CONTEXT_GRAPH, [
+        { subject: ENTITY, predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+      ], { publisherPeerId: 'peer1' });
+      await snapshotPublisher.share(CONTEXT_GRAPH, [
+        { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+      ], { publisherPeerId: 'peer1' });
+
+      const snapshotRef = await getPublicSnapshotRef(store, graphManager, write1.shareOperationId);
+      const snapshotFile = snapshotFilePath(snapshotDir, snapshotRef, 'nq');
+      await writeFile(snapshotFile, `<${ENTITY}> <http://schema.org/name> "corrupt"\n`, 'utf8');
+
+      await expect(
+        resolveLiftWorkspaceSlice({
+          store,
+          graphManager,
+          publicSnapshotStore,
+          request: {
+            swmId: 'swm-main',
+            shareOperationId: write1.shareOperationId,
+            roots: [ENTITY],
+            contextGraphId: CONTEXT_GRAPH,
+            namespace: 'aloha',
+            scope: 'person-profile',
+            transitionType: 'CREATE',
+            authority: { type: 'owner', proofRef: 'proof:owner:1' },
+          },
+        }),
+      ).rejects.toThrow(`Invalid shared-memory public snapshot blob ${snapshotRef}`);
+
+      const liveQuads = await resolveWorkspaceSelection({
+        store,
+        graphManager,
+        contextGraphId: CONTEXT_GRAPH,
+        selection: { rootEntities: [ENTITY] },
+      });
+      expect(liveQuads).toEqual([
+        { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+      ]);
     } finally {
       await rm(snapshotDir, { recursive: true, force: true });
     }
@@ -630,3 +774,35 @@ describe('async lift workspace resolution', () => {
     ).rejects.toThrow('Shared-memory resolution rejected unsafe shareOperationId: bad>op');
   });
 });
+
+function snapshotFilePath(directory: string, ref: string, extension: 'json' | 'nq'): string {
+  const hash = ref.replace(/^"?(?:sha256:)?/, '').replace(/"?$/, '');
+  return join(directory, hash.slice(0, 2), hash.slice(2, 4), `${hash}.${extension}`);
+}
+
+function stripLiteral(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (!value.startsWith('"')) return value;
+  try {
+    return JSON.parse(value) as string;
+  } catch {
+    return value.slice(1, value.lastIndexOf('"'));
+  }
+}
+
+async function getPublicSnapshotRef(store: OxigraphStore, graphManager: GraphManager, shareOperationId: string): Promise<string> {
+  const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+  const result = await store.query(
+    `SELECT ?snapshotRef WHERE {
+      GRAPH <${metaGraph}> {
+        ?s <${DKG}shareOperationId> "${shareOperationId}" ;
+           <${DKG}publicSnapshotRef> ?snapshotRef .
+      }
+    } LIMIT 1`,
+  );
+  expect(result.type).toBe('bindings');
+  if (result.type !== 'bindings') throw new Error('Unexpected snapshot metadata result');
+  const snapshotRef = stripLiteral(result.bindings[0]?.['snapshotRef']);
+  if (!snapshotRef) throw new Error(`Missing public snapshot ref for ${shareOperationId}`);
+  return snapshotRef;
+}

--- a/packages/publisher/test/async-lift-workspace.test.ts
+++ b/packages/publisher/test/async-lift-workspace.test.ts
@@ -237,7 +237,7 @@ describe('async lift workspace resolution', () => {
     ]);
   });
 
-  it('rejects stale public resolution when a requested share operation has been superseded', async () => {
+  it('resolves superseded share operations from immutable public snapshots', async () => {
     const privateStore = new PrivateContentStore(store, graphManager);
     const secretPredicate = 'http://schema.org/secret';
     const write1 = await publisher.share(CONTEXT_GRAPH, [
@@ -251,13 +251,57 @@ describe('async lift workspace resolution', () => {
       { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
     ], { publisherPeerId: 'peer1' });
 
+    const resolved = await resolveLiftWorkspaceSlice({
+      store,
+      graphManager,
+      request: {
+        swmId: 'swm-main',
+        shareOperationId: write1.shareOperationId,
+        roots: [ENTITY],
+        contextGraphId: CONTEXT_GRAPH,
+        namespace: 'aloha',
+        scope: 'person-profile',
+        transitionType: 'CREATE',
+        authority: { type: 'owner', proofRef: 'proof:owner:1' },
+      },
+    });
+
+    expect(resolved.quads).toEqual([
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+    ]);
+    expect(resolved.privateQuads).toEqual([
+      { subject: ENTITY, predicate: secretPredicate, object: '"first"', graph: '' },
+    ]);
+
+    const liveQuads = await resolveWorkspaceSelection({
+      store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH,
+      selection: { rootEntities: [ENTITY] },
+    });
+    expect(liveQuads).toEqual([
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+    ]);
+  });
+
+  it('does not fall back to live SWM data when compact snapshot metadata is missing', async () => {
+    const write = await publisher.share(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+    ], { publisherPeerId: 'peer1' });
+    const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+
+    await store.deleteByPattern({
+      graph: metaGraph,
+      predicate: `${DKG}publicSnapshotGraph`,
+    });
+
     await expect(
       resolveLiftWorkspaceSlice({
         store,
         graphManager,
         request: {
           swmId: 'swm-main',
-          shareOperationId: write1.shareOperationId,
+          shareOperationId: write.shareOperationId,
           roots: [ENTITY],
           contextGraphId: CONTEXT_GRAPH,
           namespace: 'aloha',
@@ -266,7 +310,7 @@ describe('async lift workspace resolution', () => {
           authority: { type: 'owner', proofRef: 'proof:owner:1' },
         },
       }),
-    ).rejects.toThrow(`Shared-memory operation ${write1.shareOperationId} no longer matches current public SWM data`);
+    ).rejects.toThrow(`No immutable public snapshot metadata found for context graph ${CONTEXT_GRAPH}`);
   });
 
   it('keeps legacy publicStagedQuads metadata readable', async () => {
@@ -394,11 +438,12 @@ describe('async lift workspace resolution', () => {
 
       const metaGraph = wrappedGraphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
       const metadata = await wrappedStore.query(
-        `SELECT ?digest ?count ?payload WHERE {
+        `SELECT ?digest ?count ?payload ?snapshotGraph WHERE {
           GRAPH <${metaGraph}> {
             OPTIONAL { ?s <${DKG}publicQuadsDigest> ?digest }
             OPTIONAL { ?s <${DKG}publicQuadsCount> ?count }
             OPTIONAL { ?s <${DKG}publicStagedQuads> ?payload }
+            OPTIONAL { ?s <${DKG}publicSnapshotGraph> ?snapshotGraph }
           }
         }`,
       );
@@ -408,6 +453,19 @@ describe('async lift workspace resolution', () => {
         expect(metadata.bindings.some((row) => row['count'] === '"1"^^<http://www.w3.org/2001/XMLSchema#integer>')).toBe(true);
         expect(metadata.bindings.some((row) => row['payload'])).toBe(false);
         expect(JSON.stringify(metadata.bindings)).not.toContain('externalized-');
+      }
+
+      const snapshotGraph = metadata.type === 'bindings'
+        ? metadata.bindings.find((row) => row['snapshotGraph'])?.['snapshotGraph']
+        : undefined;
+      if (!snapshotGraph) throw new Error('Expected compact metadata to include publicSnapshotGraph');
+      const rawSnapshot = await inner.query(
+        `SELECT ?o WHERE { GRAPH <${snapshotGraph}> { <${ENTITY}> <http://schema.org/name> ?o } } LIMIT 1`,
+      );
+      expect(rawSnapshot.type).toBe('bindings');
+      if (rawSnapshot.type === 'bindings') {
+        expect(rawSnapshot.bindings[0]?.['o']).toContain('sha256:');
+        expect(rawSnapshot.bindings[0]?.['o']).not.toContain('externalized-');
       }
     } finally {
       await wrappedStore.close().catch(() => {});

--- a/packages/publisher/test/async-lift-workspace.test.ts
+++ b/packages/publisher/test/async-lift-workspace.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { GraphManager, OxigraphStore, PrivateContentStore } from '@origintrail-official/dkg-storage';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GraphManager, OxigraphStore, PrivateContentStore, SharedMemoryLiteralBlobStore } from '@origintrail-official/dkg-storage';
 import { NoChainAdapter } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
 import { DKGPublisher, generateSubGraphRegistration } from '../src/index.js';
@@ -337,6 +340,78 @@ describe('async lift workspace resolution', () => {
     expect(metaResult.type).toBe('bindings');
     if (metaResult.type === 'bindings') {
       expect(JSON.stringify(metaResult.bindings)).not.toContain(marker);
+    }
+  });
+
+  it('resolves compact share metadata against hydrated external SWM literals', async () => {
+    const blobDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-literal-blobs-'));
+    const inner = new OxigraphStore();
+    const wrappedStore = new SharedMemoryLiteralBlobStore(inner, { blobDir, thresholdBytes: 20 });
+    const wrappedGraphManager = new GraphManager(wrappedStore);
+    const keypair = await generateEd25519Keypair();
+    const wrappedPublisher = new DKGPublisher({
+      store: wrappedStore,
+      chain: new NoChainAdapter(),
+      eventBus: new TypedEventBus(),
+      keypair,
+    });
+    const largeValue = `externalized-${'x'.repeat(1024)}`;
+    const largeLiteral = JSON.stringify(largeValue);
+
+    try {
+      const write = await wrappedPublisher.share(CONTEXT_GRAPH, [
+        { subject: ENTITY, predicate: 'http://schema.org/name', object: largeLiteral, graph: '' },
+      ], { publisherPeerId: 'peer1' });
+
+      const swmGraph = wrappedGraphManager.sharedMemoryUri(CONTEXT_GRAPH);
+      const raw = await inner.query(
+        `SELECT ?o WHERE { GRAPH <${swmGraph}> { <${ENTITY}> <http://schema.org/name> ?o } } LIMIT 1`,
+      );
+      expect(raw.type).toBe('bindings');
+      if (raw.type === 'bindings') {
+        expect(raw.bindings[0]?.['o']).toContain('sha256:');
+        expect(raw.bindings[0]?.['o']).not.toContain('externalized-');
+      }
+
+      const resolved = await resolveLiftWorkspaceSlice({
+        store: wrappedStore,
+        graphManager: wrappedGraphManager,
+        request: {
+          swmId: 'swm-main',
+          shareOperationId: write.shareOperationId,
+          roots: [ENTITY],
+          contextGraphId: CONTEXT_GRAPH,
+          namespace: 'aloha',
+          scope: 'person-profile',
+          transitionType: 'CREATE',
+          authority: { type: 'owner', proofRef: 'proof:owner:1' },
+        },
+      });
+
+      expect(resolved.quads).toEqual([
+        { subject: ENTITY, predicate: 'http://schema.org/name', object: largeLiteral, graph: '' },
+      ]);
+
+      const metaGraph = wrappedGraphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+      const metadata = await wrappedStore.query(
+        `SELECT ?digest ?count ?payload WHERE {
+          GRAPH <${metaGraph}> {
+            OPTIONAL { ?s <${DKG}publicQuadsDigest> ?digest }
+            OPTIONAL { ?s <${DKG}publicQuadsCount> ?count }
+            OPTIONAL { ?s <${DKG}publicStagedQuads> ?payload }
+          }
+        }`,
+      );
+      expect(metadata.type).toBe('bindings');
+      if (metadata.type === 'bindings') {
+        expect(metadata.bindings.some((row) => row['digest']?.includes('sha256:'))).toBe(true);
+        expect(metadata.bindings.some((row) => row['count'] === '"1"^^<http://www.w3.org/2001/XMLSchema#integer>')).toBe(true);
+        expect(metadata.bindings.some((row) => row['payload'])).toBe(false);
+        expect(JSON.stringify(metadata.bindings)).not.toContain('externalized-');
+      }
+    } finally {
+      await wrappedStore.close().catch(() => {});
+      await rm(blobDir, { recursive: true, force: true });
     }
   });
 

--- a/packages/publisher/test/async-lift-workspace.test.ts
+++ b/packages/publisher/test/async-lift-workspace.test.ts
@@ -107,6 +107,23 @@ describe('async lift workspace resolution', () => {
     if (payloads.type === 'bindings') {
       expect(payloads.bindings).toHaveLength(0);
     }
+
+    const fingerprints = await store.query(
+      `SELECT ?digest ?count WHERE {
+        GRAPH <${metaGraph}> {
+          ?s <${DKG}publicQuadsDigest> ?digest ;
+             <${DKG}publicQuadsCount> ?count .
+        }
+      }`,
+    );
+
+    expect(fingerprints.type).toBe('bindings');
+    if (fingerprints.type === 'bindings') {
+      expect(fingerprints.bindings).toHaveLength(2);
+      expect(fingerprints.bindings.every((row) => row['digest']?.includes('sha256:'))).toBe(true);
+      expect(JSON.stringify(fingerprints.bindings)).not.toContain('One');
+      expect(JSON.stringify(fingerprints.bindings)).not.toContain('Two');
+    }
   });
 
   it('resolves async lift payloads from the requested sub-graph partition', async () => {
@@ -215,6 +232,38 @@ describe('async lift workspace resolution', () => {
     expect(liveQuads).toEqual([
       { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
     ]);
+  });
+
+  it('rejects stale public resolution when a requested share operation has been superseded', async () => {
+    const privateStore = new PrivateContentStore(store, graphManager);
+    const secretPredicate = 'http://schema.org/secret';
+    const write1 = await publisher.share(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+    ], { publisherPeerId: 'peer1' });
+    await privateStore.storePrivateTriplesForOperation(CONTEXT_GRAPH, write1.shareOperationId, ENTITY, [
+      { subject: ENTITY, predicate: secretPredicate, object: '"first"', graph: '' },
+    ]);
+
+    await publisher.share(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+    ], { publisherPeerId: 'peer1' });
+
+    await expect(
+      resolveLiftWorkspaceSlice({
+        store,
+        graphManager,
+        request: {
+          swmId: 'swm-main',
+          shareOperationId: write1.shareOperationId,
+          roots: [ENTITY],
+          contextGraphId: CONTEXT_GRAPH,
+          namespace: 'aloha',
+          scope: 'person-profile',
+          transitionType: 'CREATE',
+          authority: { type: 'owner', proofRef: 'proof:owner:1' },
+        },
+      }),
+    ).rejects.toThrow(`Shared-memory operation ${write1.shareOperationId} no longer matches current public SWM data`);
   });
 
   it('keeps legacy publicStagedQuads metadata readable', async () => {

--- a/packages/publisher/test/async-lift-workspace.test.ts
+++ b/packages/publisher/test/async-lift-workspace.test.ts
@@ -1,15 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { GraphManager, OxigraphStore, PrivateContentStore } from '@origintrail-official/dkg-storage';
-import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
-import { ethers } from 'ethers';
 import { DKGPublisher, generateSubGraphRegistration } from '../src/index.js';
 import { resolveLiftWorkspaceSlice, resolveWorkspaceSelection } from '../src/workspace-resolution.js';
-import { createEVMAdapter, getSharedContext, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 
 const CONTEXT_GRAPH = 'test-workspace';
 const ENTITY = 'urn:test:entity:1';
 const ENTITY_2 = 'urn:test:entity:2';
+const DKG = 'http://dkg.io/ontology/';
+const PROV = 'http://www.w3.org/ns/prov#';
 
 describe('async lift workspace resolution', () => {
   let store: OxigraphStore;
@@ -18,15 +18,12 @@ describe('async lift workspace resolution', () => {
   beforeEach(async () => {
     store = new OxigraphStore();
     graphManager = new GraphManager(store);
-    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     const keypair = await generateEd25519Keypair();
     publisher = new DKGPublisher({
       store,
-      chain,
+      chain: new NoChainAdapter(),
       eventBus: new TypedEventBus(),
       keypair,
-      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
-      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
     });
   });
 
@@ -95,6 +92,23 @@ describe('async lift workspace resolution', () => {
     expect(resolved.publisherPeerId).toBe('peer1');
   });
 
+  it('does not store new public payload snapshots in shared-memory metadata', async () => {
+    await publisher.share(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+      { subject: ENTITY_2, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
+    ], { publisherPeerId: 'peer1' });
+
+    const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+    const payloads = await store.query(
+      `SELECT ?payload WHERE { GRAPH <${metaGraph}> { ?s <${DKG}publicStagedQuads> ?payload } }`,
+    );
+
+    expect(payloads.type).toBe('bindings');
+    if (payloads.type === 'bindings') {
+      expect(payloads.bindings).toHaveLength(0);
+    }
+  });
+
   it('resolves async lift payloads from the requested sub-graph partition', async () => {
     const subGraphName = 'research';
     const privateStore = new PrivateContentStore(store, graphManager);
@@ -151,7 +165,7 @@ describe('async lift workspace resolution', () => {
     ]);
   });
 
-  it('resolves public and private async lift payloads by shareOperationId instead of combining root history', async () => {
+  it('resolves public and private async lift payloads for the current share operation', async () => {
     const privateStore = new PrivateContentStore(store, graphManager);
     const secretPredicate = 'http://schema.org/secret';
     const write1 = await publisher.share(CONTEXT_GRAPH, [
@@ -174,7 +188,7 @@ describe('async lift workspace resolution', () => {
       graphManager,
       request: {
         swmId: 'swm-main',
-        shareOperationId: write1.shareOperationId,
+        shareOperationId: write2.shareOperationId,
         roots: [ENTITY],
         contextGraphId: CONTEXT_GRAPH,
         namespace: 'aloha',
@@ -185,10 +199,10 @@ describe('async lift workspace resolution', () => {
     });
 
     expect(resolved.quads).toEqual([
-      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"One"', graph: '' },
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
     ]);
     expect(resolved.privateQuads).toEqual([
-      { subject: ENTITY, predicate: secretPredicate, object: '"first"', graph: '' },
+      { subject: ENTITY, predicate: secretPredicate, object: '"second"', graph: '' },
     ]);
     expect(resolved.publisherPeerId).toBe('peer1');
 
@@ -201,6 +215,80 @@ describe('async lift workspace resolution', () => {
     expect(liveQuads).toEqual([
       { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Two"', graph: '' },
     ]);
+  });
+
+  it('keeps legacy publicStagedQuads metadata readable', async () => {
+    const shareOperationId = 'legacy-op-1';
+    const legacyQuads = [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Legacy"', graph: '' },
+    ];
+    const legacySubject = `urn:dkg:public-stage:${[
+      CONTEXT_GRAPH,
+      '_',
+      shareOperationId,
+      ENTITY,
+    ].map((part) => encodeURIComponent(part)).join(':')}`;
+    const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+
+    await store.insert([
+      {
+        subject: legacySubject,
+        predicate: `${DKG}publicStagedQuads`,
+        object: JSON.stringify(JSON.stringify(legacyQuads)),
+        graph: metaGraph,
+      },
+      {
+        subject: legacySubject,
+        predicate: `${PROV}wasAttributedTo`,
+        object: JSON.stringify('legacy-peer'),
+        graph: metaGraph,
+      },
+    ]);
+
+    const resolved = await resolveLiftWorkspaceSlice({
+      store,
+      graphManager,
+      request: {
+        swmId: 'swm-main',
+        shareOperationId,
+        roots: [ENTITY],
+        contextGraphId: CONTEXT_GRAPH,
+        namespace: 'aloha',
+        scope: 'person-profile',
+        transitionType: 'CREATE',
+        authority: { type: 'owner', proofRef: 'proof:owner:1' },
+      },
+    });
+
+    expect(resolved.quads).toEqual(legacyQuads);
+    expect(resolved.publisherPeerId).toBe('legacy-peer');
+  });
+
+  it('does not duplicate large public literals into metadata', async () => {
+    const marker = 'large-public-literal-marker';
+    const largeValue = `${marker}-${'x'.repeat(512 * 1024)}`;
+
+    await publisher.share(CONTEXT_GRAPH, [
+      { subject: ENTITY, predicate: 'http://schema.org/name', object: JSON.stringify(largeValue), graph: '' },
+    ], { publisherPeerId: 'peer1' });
+
+    const swmGraph = graphManager.sharedMemoryUri(CONTEXT_GRAPH);
+    const swmResult = await store.query(
+      `SELECT ?o WHERE { GRAPH <${swmGraph}> { <${ENTITY}> <http://schema.org/name> ?o } } LIMIT 1`,
+    );
+    expect(swmResult.type).toBe('bindings');
+    if (swmResult.type === 'bindings') {
+      expect(swmResult.bindings[0]?.['o']).toContain(marker);
+    }
+
+    const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+    const metaResult = await store.query(
+      `SELECT ?o WHERE { GRAPH <${metaGraph}> { ?s ?p ?o } }`,
+    );
+    expect(metaResult.type).toBe('bindings');
+    if (metaResult.type === 'bindings') {
+      expect(JSON.stringify(metaResult.bindings)).not.toContain(marker);
+    }
   });
 
   it('carries Lift request access policy into resolved publish options', async () => {

--- a/packages/publisher/test/async-lift-workspace.test.ts
+++ b/packages/publisher/test/async-lift-workspace.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { GraphManager, OxigraphStore, PrivateContentStore, SharedMemoryLiteralBlobStore } from '@origintrail-official/dkg-storage';
 import { NoChainAdapter } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
-import { DKGPublisher, generateSubGraphRegistration } from '../src/index.js';
+import { DKGPublisher, FileWorkspacePublicSnapshotStore, generateSubGraphRegistration } from '../src/index.js';
 import { resolveLiftWorkspaceSlice, resolveWorkspaceSelection } from '../src/workspace-resolution.js';
 
 const CONTEXT_GRAPH = 'test-workspace';
@@ -387,17 +387,90 @@ describe('async lift workspace resolution', () => {
     }
   });
 
+  it('stores immutable public operation snapshots as disk refs when configured', async () => {
+    const snapshotDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-public-snapshots-'));
+    const publicSnapshotStore = new FileWorkspacePublicSnapshotStore(snapshotDir);
+    const keypair = await generateEd25519Keypair();
+    const snapshotPublisher = new DKGPublisher({
+      store,
+      chain: new NoChainAdapter(),
+      eventBus: new TypedEventBus(),
+      keypair,
+      publicSnapshotStore,
+    });
+
+    try {
+      const marker = 'disk-public-snapshot-marker';
+      const write = await snapshotPublisher.share(CONTEXT_GRAPH, [
+        { subject: ENTITY, predicate: 'http://schema.org/name', object: JSON.stringify(`${marker}-${'x'.repeat(1024)}`), graph: '' },
+      ], { publisherPeerId: 'peer1' });
+
+      const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+      const metadata = await store.query(
+        `SELECT ?snapshotRef ?snapshotGraph ?payload WHERE {
+          GRAPH <${metaGraph}> {
+            ?s <${DKG}shareOperationId> "${write.shareOperationId}" .
+            OPTIONAL { ?s <${DKG}publicSnapshotRef> ?snapshotRef }
+            OPTIONAL { ?s <${DKG}publicSnapshotGraph> ?snapshotGraph }
+            OPTIONAL { ?s <${DKG}publicStagedQuads> ?payload }
+          }
+        }`,
+      );
+      expect(metadata.type).toBe('bindings');
+      if (metadata.type === 'bindings') {
+        expect(metadata.bindings.some((row) => row['snapshotRef']?.includes('sha256:'))).toBe(true);
+        expect(metadata.bindings.some((row) => row['snapshotGraph'])).toBe(false);
+        expect(metadata.bindings.some((row) => row['payload'])).toBe(false);
+        expect(JSON.stringify(metadata.bindings)).not.toContain(marker);
+      }
+
+      const snapshotGraphRows = await store.query(
+        `SELECT ?g WHERE {
+          GRAPH ?g { ?s ?p ?o }
+          FILTER(CONTAINS(STR(?g), "/_shared_memory_snapshots/"))
+        } LIMIT 1`,
+      );
+      expect(snapshotGraphRows.type).toBe('bindings');
+      if (snapshotGraphRows.type === 'bindings') {
+        expect(snapshotGraphRows.bindings).toHaveLength(0);
+      }
+
+      const resolved = await resolveLiftWorkspaceSlice({
+        store,
+        graphManager,
+        publicSnapshotStore,
+        request: {
+          swmId: 'swm-main',
+          shareOperationId: write.shareOperationId,
+          roots: [ENTITY],
+          contextGraphId: CONTEXT_GRAPH,
+          namespace: 'aloha',
+          scope: 'person-profile',
+          transitionType: 'CREATE',
+          authority: { type: 'owner', proofRef: 'proof:owner:1' },
+        },
+      });
+      expect(resolved.quads).toHaveLength(1);
+      expect(resolved.quads[0]?.object).toContain(marker);
+    } finally {
+      await rm(snapshotDir, { recursive: true, force: true });
+    }
+  });
+
   it('resolves compact share metadata against hydrated external SWM literals', async () => {
     const blobDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-literal-blobs-'));
+    const snapshotDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-public-snapshots-'));
     const inner = new OxigraphStore();
     const wrappedStore = new SharedMemoryLiteralBlobStore(inner, { blobDir, thresholdBytes: 20 });
     const wrappedGraphManager = new GraphManager(wrappedStore);
+    const publicSnapshotStore = new FileWorkspacePublicSnapshotStore(snapshotDir);
     const keypair = await generateEd25519Keypair();
     const wrappedPublisher = new DKGPublisher({
       store: wrappedStore,
       chain: new NoChainAdapter(),
       eventBus: new TypedEventBus(),
       keypair,
+      publicSnapshotStore,
     });
     const largeValue = `externalized-${'x'.repeat(1024)}`;
     const largeLiteral = JSON.stringify(largeValue);
@@ -420,6 +493,7 @@ describe('async lift workspace resolution', () => {
       const resolved = await resolveLiftWorkspaceSlice({
         store: wrappedStore,
         graphManager: wrappedGraphManager,
+        publicSnapshotStore,
         request: {
           swmId: 'swm-main',
           shareOperationId: write.shareOperationId,
@@ -438,11 +512,12 @@ describe('async lift workspace resolution', () => {
 
       const metaGraph = wrappedGraphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
       const metadata = await wrappedStore.query(
-        `SELECT ?digest ?count ?payload ?snapshotGraph WHERE {
+        `SELECT ?digest ?count ?payload ?snapshotRef ?snapshotGraph WHERE {
           GRAPH <${metaGraph}> {
             OPTIONAL { ?s <${DKG}publicQuadsDigest> ?digest }
             OPTIONAL { ?s <${DKG}publicQuadsCount> ?count }
             OPTIONAL { ?s <${DKG}publicStagedQuads> ?payload }
+            OPTIONAL { ?s <${DKG}publicSnapshotRef> ?snapshotRef }
             OPTIONAL { ?s <${DKG}publicSnapshotGraph> ?snapshotGraph }
           }
         }`,
@@ -452,24 +527,14 @@ describe('async lift workspace resolution', () => {
         expect(metadata.bindings.some((row) => row['digest']?.includes('sha256:'))).toBe(true);
         expect(metadata.bindings.some((row) => row['count'] === '"1"^^<http://www.w3.org/2001/XMLSchema#integer>')).toBe(true);
         expect(metadata.bindings.some((row) => row['payload'])).toBe(false);
+        expect(metadata.bindings.some((row) => row['snapshotRef']?.includes('sha256:'))).toBe(true);
+        expect(metadata.bindings.some((row) => row['snapshotGraph'])).toBe(false);
         expect(JSON.stringify(metadata.bindings)).not.toContain('externalized-');
-      }
-
-      const snapshotGraph = metadata.type === 'bindings'
-        ? metadata.bindings.find((row) => row['snapshotGraph'])?.['snapshotGraph']
-        : undefined;
-      if (!snapshotGraph) throw new Error('Expected compact metadata to include publicSnapshotGraph');
-      const rawSnapshot = await inner.query(
-        `SELECT ?o WHERE { GRAPH <${snapshotGraph}> { <${ENTITY}> <http://schema.org/name> ?o } } LIMIT 1`,
-      );
-      expect(rawSnapshot.type).toBe('bindings');
-      if (rawSnapshot.type === 'bindings') {
-        expect(rawSnapshot.bindings[0]?.['o']).toContain('sha256:');
-        expect(rawSnapshot.bindings[0]?.['o']).not.toContain('externalized-');
       }
     } finally {
       await wrappedStore.close().catch(() => {});
       await rm(blobDir, { recursive: true, force: true });
+      await rm(snapshotDir, { recursive: true, force: true });
     }
   });
 

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -323,6 +323,26 @@ describe('generateShareMetadata', () => {
     expect(preds).toContain(`${DKG}publishedAt`);
     expect(preds).toContain('http://www.w3.org/ns/prov#wasAttributedTo');
   });
+
+  it('includes compact operation reference fields', () => {
+    const quads = generateShareMetadata({ ...wsMeta, subGraphName: 'research' }, wsGraph);
+    expect(quads).toContainEqual(expect.objectContaining({
+      predicate: `${DKG}contextGraphId`,
+      object: `"${CONTEXT_GRAPH}"`,
+    }));
+    expect(quads).toContainEqual(expect.objectContaining({
+      predicate: `${DKG}shareOperationId`,
+      object: '"op-123"',
+    }));
+    expect(quads).toContainEqual(expect.objectContaining({
+      predicate: `${DKG}publisherPeerId`,
+      object: '"12D3KooWTestPeer"',
+    }));
+    expect(quads).toContainEqual(expect.objectContaining({
+      predicate: `${DKG}subGraphName`,
+      object: '"research"',
+    }));
+  });
 });
 
 describe('generateAuthorshipProof', () => {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -7,9 +7,17 @@ export {
   type AskResult,
   type TripleStoreConfig,
   type TripleStoreBackend,
+  type LargeLiteralStorageConfig,
   registerTripleStoreAdapter,
   createTripleStore,
 } from './triple-store.js';
+export {
+  EXTERNAL_LITERAL_REF_DATATYPE,
+  SHARED_MEMORY_GRAPH_SUFFIX,
+  DEFAULT_LARGE_LITERAL_THRESHOLD_BYTES,
+  SharedMemoryLiteralBlobStore,
+  type SharedMemoryLiteralBlobStoreOptions,
+} from './shared-memory-literal-blob-store.js';
 
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -1,0 +1,423 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type {
+  ConstructResult,
+  Quad,
+  QueryResult,
+  SelectResult,
+  TripleStore,
+} from './triple-store.js';
+
+export const EXTERNAL_LITERAL_REF_DATATYPE = 'http://dkg.io/ontology/externalLiteralRef';
+export const SHARED_MEMORY_GRAPH_SUFFIX = '/_shared_memory';
+export const DEFAULT_LARGE_LITERAL_THRESHOLD_BYTES = 65_536;
+
+export interface SharedMemoryLiteralBlobStoreOptions {
+  /**
+   * Directory containing content-addressed RDF literal term blobs.
+   * Files are named `<sha256>` and contain the exact serialized
+   * RDF object term string received by `insert`.
+   */
+  blobDir: string;
+  /**
+   * Externalize SWM literal object terms whose UTF-8 serialized term size
+   * is strictly greater than this value.
+   */
+  thresholdBytes: number;
+}
+
+export class SharedMemoryLiteralBlobStore implements TripleStore {
+  private readonly inner: TripleStore;
+  private readonly blobDir: string;
+  private readonly thresholdBytes: number;
+
+  constructor(inner: TripleStore, options: SharedMemoryLiteralBlobStoreOptions) {
+    if (!options.blobDir?.trim()) {
+      throw new Error('SharedMemoryLiteralBlobStore requires options.blobDir');
+    }
+    if (!Number.isSafeInteger(options.thresholdBytes) || options.thresholdBytes < 0) {
+      throw new Error('SharedMemoryLiteralBlobStore requires a non-negative integer thresholdBytes');
+    }
+    this.inner = inner;
+    this.blobDir = options.blobDir;
+    this.thresholdBytes = options.thresholdBytes;
+  }
+
+  async insert(quads: Quad[]): Promise<void> {
+    if (quads.length === 0) return this.inner.insert(quads);
+    const externalized = await Promise.all(
+      quads.map((quad) => this.externalizeInsertQuad(quad)),
+    );
+    return this.inner.insert(externalized);
+  }
+
+  async delete(quads: Quad[]): Promise<void> {
+    if (quads.length === 0) return this.inner.delete(quads);
+    return this.inner.delete(quads.map((quad) => this.translateDeleteQuad(quad)));
+  }
+
+  async deleteByPattern(pattern: Partial<Quad>): Promise<number> {
+    const translated = this.translateDeletePattern(pattern);
+    if (!Array.isArray(translated)) {
+      return this.inner.deleteByPattern(translated);
+    }
+
+    let removed = 0;
+    for (const item of translated) {
+      removed += await this.inner.deleteByPattern(item);
+    }
+    return removed;
+  }
+
+  async query(sparql: string): Promise<QueryResult> {
+    const rewritten = this.rewriteLargeLiteralConstants(sparql);
+    if (!rewritten) {
+      const result = await this.inner.query(sparql);
+      return this.hydrateQueryResult(result);
+    }
+
+    const [original, placeholder] = await Promise.all([
+      this.inner.query(sparql),
+      this.inner.query(rewritten),
+    ]);
+    return this.hydrateQueryResult(mergeQueryResults(original, placeholder));
+  }
+
+  async hasGraph(graphUri: string): Promise<boolean> {
+    return this.inner.hasGraph(graphUri);
+  }
+
+  async createGraph(graphUri: string): Promise<void> {
+    return this.inner.createGraph(graphUri);
+  }
+
+  async dropGraph(graphUri: string): Promise<void> {
+    return this.inner.dropGraph(graphUri);
+  }
+
+  async listGraphs(): Promise<string[]> {
+    return this.inner.listGraphs();
+  }
+
+  async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
+    return this.inner.deleteBySubjectPrefix(graphUri, prefix);
+  }
+
+  async countQuads(graphUri?: string): Promise<number> {
+    return this.inner.countQuads(graphUri);
+  }
+
+  async flush(): Promise<void> {
+    await this.inner.flush?.();
+  }
+
+  async close(): Promise<void> {
+    return this.inner.close();
+  }
+
+  private async externalizeInsertQuad(quad: Quad): Promise<Quad> {
+    if (!shouldExternalizeLiteral(quad, this.thresholdBytes)) return quad;
+
+    const hash = sha256Term(quad.object);
+    await this.writeBlob(hash, quad.object);
+    return { ...quad, object: externalLiteralRefTerm(hash) };
+  }
+
+  private translateDeleteQuad(quad: Quad): Quad {
+    if (!shouldExternalizeLiteral(quad, this.thresholdBytes)) return quad;
+    return { ...quad, object: externalLiteralRefTerm(sha256Term(quad.object)) };
+  }
+
+  private translateDeletePattern(pattern: Partial<Quad>): Partial<Quad> | Array<Partial<Quad>> {
+    if (
+      !pattern.object ||
+      !isSerializedLiteralObjectTerm(pattern.object) ||
+      externalLiteralRefHash(pattern.object) ||
+      serializedTermByteLength(pattern.object) <= this.thresholdBytes
+    ) {
+      return pattern;
+    }
+
+    const placeholderPattern = {
+      ...pattern,
+      object: externalLiteralRefTerm(sha256Term(pattern.object)),
+    };
+
+    if (pattern.graph) {
+      return isSharedMemoryGraph(pattern.graph) ? placeholderPattern : pattern;
+    }
+
+    // Without a graph constraint, preserve normal deleteByPattern semantics for
+    // inline triples while also deleting the SWM placeholder form.
+    return [pattern, placeholderPattern];
+  }
+
+  private async hydrateQueryResult(result: QueryResult): Promise<QueryResult> {
+    if (result.type === 'boolean') return result;
+    const cache = new Map<string, Promise<string>>();
+
+    if (result.type === 'bindings') {
+      const bindings = await Promise.all(
+        result.bindings.map(async (row) => {
+          const hydrated: Record<string, string> = {};
+          for (const [key, value] of Object.entries(row)) {
+            hydrated[key] = await this.hydrateTerm(value, cache);
+          }
+          return hydrated;
+        }),
+      );
+      return { type: 'bindings', bindings } satisfies SelectResult;
+    }
+
+    const quads = await Promise.all(
+      result.quads.map(async (quad) => ({
+        ...quad,
+        object: await this.hydrateTerm(quad.object, cache),
+      })),
+    );
+    return { type: 'quads', quads } satisfies ConstructResult;
+  }
+
+  private async hydrateTerm(term: string, cache: Map<string, Promise<string>>): Promise<string> {
+    const hash = externalLiteralRefHash(term);
+    if (!hash) return term;
+    let pending = cache.get(hash);
+    if (!pending) {
+      pending = this.readBlob(hash);
+      cache.set(hash, pending);
+    }
+    return pending;
+  }
+
+  private rewriteLargeLiteralConstants(sparql: string): string | undefined {
+    const rewritten = rewriteSerializedLiteralTerms(sparql, (term) => {
+      if (!isSerializedLiteralObjectTerm(term)) return term;
+      if (externalLiteralRefHash(term)) return term;
+      if (serializedTermByteLength(term) <= this.thresholdBytes) return term;
+      return externalLiteralRefTerm(sha256Term(term));
+    });
+    return rewritten === sparql ? undefined : rewritten;
+  }
+
+  private async writeBlob(hash: string, term: string): Promise<void> {
+    assertSha256Hex(hash);
+    await mkdir(this.blobDir, { recursive: true });
+    const path = this.blobPath(hash);
+
+    try {
+      await writeFile(path, term, { encoding: 'utf8', flag: 'wx' });
+    } catch (err) {
+      if (isNodeError(err, 'EEXIST')) {
+        await this.readBlob(hash);
+        return;
+      }
+      throw err;
+    }
+
+    await this.readBlob(hash);
+  }
+
+  private async readBlob(hash: string): Promise<string> {
+    assertSha256Hex(hash);
+    const path = this.blobPath(hash);
+    let content: string;
+    try {
+      content = await readFile(path, 'utf8');
+    } catch (err) {
+      if (isNodeError(err, 'ENOENT')) {
+        throw new Error(`SWM external literal blob missing for sha256:${hash} at ${path}`);
+      }
+      throw err;
+    }
+
+    const actual = sha256Term(content);
+    if (actual !== hash) {
+      throw new Error(
+        `SWM external literal blob corrupt for sha256:${hash} at ${path}: found sha256:${actual}`,
+      );
+    }
+    return content;
+  }
+
+  private blobPath(hash: string): string {
+    return join(this.blobDir, hash);
+  }
+}
+
+function shouldExternalizeLiteral(quad: Quad, thresholdBytes: number): boolean {
+  return (
+    isSharedMemoryGraph(quad.graph) &&
+    isSerializedLiteralObjectTerm(quad.object) &&
+    !externalLiteralRefHash(quad.object) &&
+    serializedTermByteLength(quad.object) > thresholdBytes
+  );
+}
+
+function isSharedMemoryGraph(graph: string | undefined): boolean {
+  return Boolean(graph && graph.endsWith(SHARED_MEMORY_GRAPH_SUFFIX));
+}
+
+function serializedTermByteLength(term: string): number {
+  return Buffer.byteLength(term, 'utf8');
+}
+
+function isSerializedLiteralObjectTerm(term: string): boolean {
+  if (!term.startsWith('"')) return false;
+  const closingQuote = findClosingLiteralQuote(term);
+  if (closingQuote < 0) return false;
+  const suffix = term.slice(closingQuote + 1);
+  return (
+    suffix === '' ||
+    /^@[A-Za-z]+(?:-[A-Za-z0-9]+)*$/.test(suffix) ||
+    /^\^\^(?:<[^>]+>|[^\s]+)$/.test(suffix)
+  );
+}
+
+function findClosingLiteralQuote(term: string): number {
+  for (let i = 1; i < term.length; i += 1) {
+    if (term[i] !== '"') continue;
+    let backslashes = 0;
+    for (let j = i - 1; j >= 0 && term[j] === '\\'; j -= 1) {
+      backslashes += 1;
+    }
+    if (backslashes % 2 === 0) return i;
+  }
+  return -1;
+}
+
+function externalLiteralRefTerm(hash: string): string {
+  assertSha256Hex(hash);
+  return `"sha256:${hash}"^^<${EXTERNAL_LITERAL_REF_DATATYPE}>`;
+}
+
+function externalLiteralRefHash(term: string): string | null {
+  const match = term.match(EXTERNAL_LITERAL_REF_PATTERN);
+  return match ? match[1].toLowerCase() : null;
+}
+
+function rewriteSerializedLiteralTerms(
+  sparql: string,
+  rewrite: (term: string) => string,
+): string {
+  let output = '';
+  let cursor = 0;
+
+  while (cursor < sparql.length) {
+    const start = sparql.indexOf('"', cursor);
+    if (start < 0) {
+      output += sparql.slice(cursor);
+      break;
+    }
+
+    output += sparql.slice(cursor, start);
+    const parsed = readSparqlLiteralToken(sparql, start);
+    if (!parsed) {
+      output += sparql[start];
+      cursor = start + 1;
+      continue;
+    }
+
+    output += rewrite(parsed.term);
+    cursor = parsed.end;
+  }
+
+  return output;
+}
+
+function readSparqlLiteralToken(input: string, start: number): { term: string; end: number } | undefined {
+  const close = findClosingLiteralQuoteFrom(input, start);
+  if (close < 0) return undefined;
+
+  let end = close + 1;
+  if (input[end] === '@') {
+    end += 1;
+    while (end < input.length && /[A-Za-z0-9-]/.test(input[end])) end += 1;
+  } else if (input.slice(end, end + 2) === '^^') {
+    end += 2;
+    if (input[end] === '<') {
+      const datatypeEnd = input.indexOf('>', end + 1);
+      if (datatypeEnd < 0) return undefined;
+      end = datatypeEnd + 1;
+    } else {
+      while (end < input.length && !/[\s;,.()[\]{}]/.test(input[end])) end += 1;
+    }
+  }
+
+  return { term: input.slice(start, end), end };
+}
+
+function findClosingLiteralQuoteFrom(term: string, start: number): number {
+  for (let i = start + 1; i < term.length; i += 1) {
+    if (term[i] !== '"') continue;
+    let backslashes = 0;
+    for (let j = i - 1; j >= start && term[j] === '\\'; j -= 1) {
+      backslashes += 1;
+    }
+    if (backslashes % 2 === 0) return i;
+  }
+  return -1;
+}
+
+function mergeQueryResults(first: QueryResult, second: QueryResult): QueryResult {
+  if (first.type !== second.type) {
+    return first.type === 'boolean'
+      ? first
+      : second.type === 'boolean'
+        ? second
+        : first;
+  }
+
+  if (first.type === 'boolean' && second.type === 'boolean') {
+    return { type: 'boolean', value: first.value || second.value };
+  }
+
+  if (first.type === 'bindings' && second.type === 'bindings') {
+    const seen = new Set<string>();
+    const bindings = [...first.bindings, ...second.bindings].filter((row) => {
+      const key = stableRecordKey(row);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    return { type: 'bindings', bindings };
+  }
+
+  const seen = new Set<string>();
+  const quads = [
+    ...(first as ConstructResult).quads,
+    ...(second as ConstructResult).quads,
+  ].filter((quad) => {
+    const key = `${quad.subject}\n${quad.predicate}\n${quad.object}\n${quad.graph}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  return { type: 'quads', quads };
+}
+
+function stableRecordKey(row: Record<string, string>): string {
+  return JSON.stringify(Object.entries(row).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function sha256Term(term: string): string {
+  return createHash('sha256').update(term, 'utf8').digest('hex');
+}
+
+function assertSha256Hex(hash: string): void {
+  if (!/^[a-f0-9]{64}$/i.test(hash)) {
+    throw new Error(`Invalid sha256 literal blob key: ${hash}`);
+  }
+}
+
+function isNodeError(err: unknown, code: string): boolean {
+  return err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === code;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const EXTERNAL_LITERAL_REF_PATTERN = new RegExp(
+  `^"sha256:([a-fA-F0-9]{64})"\\^\\^<${escapeRegExp(EXTERNAL_LITERAL_REF_DATATYPE)}>$`,
+);

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -4,6 +4,12 @@
  * Neptune, GraphDB, Jena, etc.) can implement this interface.
  */
 
+import { dirname, join } from 'node:path';
+import {
+  DEFAULT_LARGE_LITERAL_THRESHOLD_BYTES,
+  SharedMemoryLiteralBlobStore,
+} from './shared-memory-literal-blob-store.js';
+
 export interface Quad {
   subject: string;
   predicate: string;
@@ -59,9 +65,19 @@ export interface TripleStore {
 
 export type TripleStoreBackend = 'oxigraph' | 'oxigraph-persistent' | 'oxigraph-worker' | 'blazegraph' | 'sparql-http' | string;
 
+export interface LargeLiteralStorageConfig {
+  /** Enable large SWM literal blob storage. Defaults to true when present. */
+  enabled?: boolean;
+  /** Externalize literal object terms larger than this UTF-8 byte size. */
+  thresholdBytes?: number;
+  /** Content-addressed blob directory. Defaults to `<dirname(options.path)>/literal-blobs` when a persistent path is available. */
+  directory?: string;
+}
+
 export interface TripleStoreConfig {
   backend: TripleStoreBackend;
   options?: Record<string, unknown>;
+  largeLiteralStorage?: LargeLiteralStorageConfig;
 }
 
 type AdapterFactory = (
@@ -87,5 +103,31 @@ export async function createTripleStore(
         `Registered: [${[...adapterRegistry.keys()].join(', ')}]`,
     );
   }
-  return factory(config.options);
+  const store = await factory(config.options);
+  const largeLiteralStorage = resolveLargeLiteralStorageOptions(config);
+  if (!largeLiteralStorage) return store;
+  return new SharedMemoryLiteralBlobStore(store, largeLiteralStorage);
+}
+
+function resolveLargeLiteralStorageOptions(
+  config: TripleStoreConfig,
+): { blobDir: string; thresholdBytes: number } | undefined {
+  const largeLiteralStorage = config.largeLiteralStorage;
+  if (!largeLiteralStorage || largeLiteralStorage.enabled === false) return undefined;
+
+  const thresholdBytes = largeLiteralStorage.thresholdBytes ?? DEFAULT_LARGE_LITERAL_THRESHOLD_BYTES;
+  const directory = largeLiteralStorage.directory ?? inferLiteralBlobDirectory(config.options);
+  if (!directory) {
+    throw new Error(
+      'largeLiteralStorage.directory is required when the triple-store options do not include a persistent path',
+    );
+  }
+
+  return { blobDir: directory, thresholdBytes };
+}
+
+function inferLiteralBlobDirectory(options: Record<string, unknown> | undefined): string | undefined {
+  const persistPath = options?.path;
+  if (typeof persistPath !== 'string' || persistPath.trim().length === 0) return undefined;
+  return join(dirname(persistPath), 'literal-blobs');
 }

--- a/packages/storage/test/external-literal-store.test.ts
+++ b/packages/storage/test/external-literal-store.test.ts
@@ -1,0 +1,274 @@
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  EXTERNAL_LITERAL_REF_DATATYPE,
+  OxigraphStore,
+  SharedMemoryLiteralBlobStore,
+  createTripleStore,
+  type Quad,
+} from '../src/index.js';
+
+const SWM_GRAPH = 'did:dkg:context-graph:test/_shared_memory';
+const NON_SWM_GRAPH = 'did:dkg:context-graph:test';
+
+describe('SharedMemoryLiteralBlobStore', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function tempBlobDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'dkg-storage-literal-blobs-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('externalizes only large SWM literal object terms and hydrates SELECT and CONSTRUCT results', async () => {
+    const blobDir = await tempBlobDir();
+    const inner = new OxigraphStore();
+    const store = new SharedMemoryLiteralBlobStore(inner, { blobDir, thresholdBytes: 40 });
+    const largeLiteral = `"${'x'.repeat(80)}"^^<http://www.w3.org/2001/XMLSchema#string>`;
+    const smallLiteral = '"small literal"';
+    const largeNonSwmLiteral = `"${'y'.repeat(80)}"`;
+
+    await store.insert([
+      quad('http://ex.org/large', largeLiteral, SWM_GRAPH),
+      quad('http://ex.org/small', smallLiteral, SWM_GRAPH),
+      quad('http://ex.org/non-swm', largeNonSwmLiteral, NON_SWM_GRAPH),
+      {
+        subject: 'http://ex.org/iri',
+        predicate: 'http://schema.org/url',
+        object: 'http://ex.org/not-a-literal',
+        graph: SWM_GRAPH,
+      },
+    ]);
+
+    const hash = sha256Term(largeLiteral);
+    expect(await readFile(blobPath(blobDir, hash), 'utf8')).toBe(largeLiteral);
+
+    const raw = await inner.query(
+      `SELECT ?s ?o WHERE { GRAPH <${SWM_GRAPH}> { ?s <http://schema.org/value> ?o } }`,
+    );
+    expect(raw.type).toBe('bindings');
+    if (raw.type === 'bindings') {
+      expect(raw.bindings).toContainEqual({
+        s: 'http://ex.org/large',
+        o: externalRef(hash),
+      });
+      expect(raw.bindings).toContainEqual({
+        s: 'http://ex.org/small',
+        o: smallLiteral,
+      });
+    }
+
+    const select = await store.query(
+      `SELECT ?s ?o WHERE { GRAPH <${SWM_GRAPH}> { ?s <http://schema.org/value> ?o } }`,
+    );
+    expect(select.type).toBe('bindings');
+    if (select.type === 'bindings') {
+      expect(select.bindings).toContainEqual({
+        s: 'http://ex.org/large',
+        o: largeLiteral,
+      });
+      expect(select.bindings).toContainEqual({
+        s: 'http://ex.org/small',
+        o: smallLiteral,
+      });
+    }
+
+    const construct = await store.query(
+      `CONSTRUCT { ?s <http://schema.org/value> ?o } WHERE { GRAPH <${SWM_GRAPH}> { ?s <http://schema.org/value> ?o } }`,
+    );
+    expect(construct.type).toBe('quads');
+    if (construct.type === 'quads') {
+      expect(construct.quads).toContainEqual(quad('http://ex.org/large', largeLiteral, ''));
+      expect(construct.quads).toContainEqual(quad('http://ex.org/small', smallLiteral, ''));
+    }
+
+    const nonSwm = await inner.query(
+      `SELECT ?o WHERE { GRAPH <${NON_SWM_GRAPH}> { <http://ex.org/non-swm> <http://schema.org/value> ?o } }`,
+    );
+    expect(nonSwm.type).toBe('bindings');
+    if (nonSwm.type === 'bindings') {
+      expect(nonSwm.bindings[0].o).toBe(largeNonSwmLiteral);
+    }
+  });
+
+  it('matches exact large literal constants through SELECT, ASK, and FILTER equality', async () => {
+    const blobDir = await tempBlobDir();
+    const store = new SharedMemoryLiteralBlobStore(new OxigraphStore(), { blobDir, thresholdBytes: 20 });
+    const largeLiteral = `"${'exact-match'.repeat(8)}"`;
+    const q = quad('http://ex.org/exact', largeLiteral, SWM_GRAPH);
+
+    await store.insert([q]);
+
+    const select = await store.query(
+      `SELECT ?s WHERE { GRAPH <${SWM_GRAPH}> { ?s <http://schema.org/value> ${largeLiteral} } }`,
+    );
+    expect(select.type).toBe('bindings');
+    if (select.type === 'bindings') {
+      expect(select.bindings).toEqual([{ s: q.subject }]);
+    }
+
+    const ask = await store.query(
+      `ASK WHERE { GRAPH <${SWM_GRAPH}> { <${q.subject}> <http://schema.org/value> ${largeLiteral} } }`,
+    );
+    expect(ask).toEqual({ type: 'boolean', value: true });
+
+    const filtered = await store.query(
+      `SELECT ?o WHERE {
+        GRAPH <${SWM_GRAPH}> {
+          <${q.subject}> <http://schema.org/value> ?o .
+          FILTER(?o = ${largeLiteral})
+        }
+      }`,
+    );
+    expect(filtered.type).toBe('bindings');
+    if (filtered.type === 'bindings') {
+      expect(filtered.bindings).toEqual([{ o: largeLiteral }]);
+    }
+  });
+
+  it('translates deletes passed with the original large literal term', async () => {
+    const blobDir = await tempBlobDir();
+    const inner = new OxigraphStore();
+    const store = new SharedMemoryLiteralBlobStore(inner, { blobDir, thresholdBytes: 20 });
+    const largeLiteral = `"${'delete-me'.repeat(8)}"`;
+    const q = quad('http://ex.org/delete', largeLiteral, SWM_GRAPH);
+
+    await store.insert([q]);
+    expect(await inner.countQuads(SWM_GRAPH)).toBe(1);
+
+    await store.delete([q]);
+    expect(await inner.countQuads(SWM_GRAPH)).toBe(0);
+  });
+
+  it('translates deleteByPattern object filters passed with the original large literal term', async () => {
+    const blobDir = await tempBlobDir();
+    const inner = new OxigraphStore();
+    const store = new SharedMemoryLiteralBlobStore(inner, { blobDir, thresholdBytes: 20 });
+    const largeLiteral = `"${'pattern-delete'.repeat(8)}"`;
+
+    await store.insert([
+      quad('http://ex.org/delete-1', largeLiteral, SWM_GRAPH),
+      quad('http://ex.org/delete-2', largeLiteral, SWM_GRAPH),
+    ]);
+
+    const removed = await store.deleteByPattern({ object: largeLiteral, graph: SWM_GRAPH });
+    expect(removed).toBe(2);
+    expect(await inner.countQuads(SWM_GRAPH)).toBe(0);
+  });
+
+  it('fails loudly when hydrating a missing or corrupt blob', async () => {
+    const blobDir = await tempBlobDir();
+    const store = new SharedMemoryLiteralBlobStore(new OxigraphStore(), { blobDir, thresholdBytes: 20 });
+    const largeLiteral = `"${'hydrate-me'.repeat(8)}"`;
+    const hash = sha256Term(largeLiteral);
+
+    await store.insert([quad('http://ex.org/corrupt', largeLiteral, SWM_GRAPH)]);
+    await rm(blobPath(blobDir, hash));
+
+    await expect(
+      store.query(`SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { ?s <http://schema.org/value> ?o } }`),
+    ).rejects.toThrow(/external literal blob missing/);
+
+    await writeFile(blobPath(blobDir, hash), '"wrong"', 'utf8');
+    await expect(
+      store.query(`SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { ?s <http://schema.org/value> ?o } }`),
+    ).rejects.toThrow(/external literal blob corrupt/);
+  });
+
+  it('verifies an existing content-addressed file before reusing it on write', async () => {
+    const blobDir = await tempBlobDir();
+    const store = new SharedMemoryLiteralBlobStore(new OxigraphStore(), { blobDir, thresholdBytes: 20 });
+    const largeLiteral = `"${'existing-file'.repeat(8)}"`;
+    const hash = sha256Term(largeLiteral);
+    await mkdir(blobDir, { recursive: true });
+    await writeFile(blobPath(blobDir, hash), '"wrong"', 'utf8');
+
+    await expect(
+      store.insert([quad('http://ex.org/existing', largeLiteral, SWM_GRAPH)]),
+    ).rejects.toThrow(/external literal blob corrupt/);
+  });
+
+  it('can be enabled through createTripleStore configuration', async () => {
+    const blobDir = await tempBlobDir();
+    const store = await createTripleStore({
+      backend: 'oxigraph',
+      largeLiteralStorage: { directory: blobDir, thresholdBytes: 20 },
+    });
+    const largeLiteral = `"${'configured'.repeat(8)}"`;
+
+    await store.insert([quad('http://ex.org/configured', largeLiteral, SWM_GRAPH)]);
+
+    const result = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <http://ex.org/configured> <http://schema.org/value> ?o } }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      expect(result.bindings[0].o).toBe(largeLiteral);
+    }
+    await store.close();
+  });
+
+  it('reopens persisted placeholders from disk and hydrates from existing blobs', async () => {
+    const dataDir = await tempBlobDir();
+    const storePath = join(dataDir, 'store.nq');
+    const blobDir = join(dataDir, 'literal-blobs');
+    const largeLiteral = `"${'persisted'.repeat(16)}"`;
+
+    const first = await createTripleStore({
+      backend: 'oxigraph-persistent',
+      options: { path: storePath },
+      largeLiteralStorage: { directory: blobDir, thresholdBytes: 20 },
+    });
+    await first.insert([quad('http://ex.org/persisted', largeLiteral, SWM_GRAPH)]);
+    await first.flush?.();
+    await first.close();
+
+    const storeNq = await readFile(storePath, 'utf8');
+    const hash = sha256Term(largeLiteral);
+    expect(storeNq).toContain(externalRef(hash));
+    expect(storeNq).not.toContain('persistedpersistedpersisted');
+    expect(await readFile(blobPath(blobDir, hash), 'utf8')).toBe(largeLiteral);
+
+    const reopened = await createTripleStore({
+      backend: 'oxigraph-persistent',
+      options: { path: storePath },
+      largeLiteralStorage: { directory: blobDir, thresholdBytes: 20 },
+    });
+    const result = await reopened.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <http://ex.org/persisted> <http://schema.org/value> ?o } }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      expect(result.bindings).toEqual([{ o: largeLiteral }]);
+    }
+    await reopened.close();
+  });
+});
+
+function quad(subject: string, object: string, graph: string): Quad {
+  return {
+    subject,
+    predicate: 'http://schema.org/value',
+    object,
+    graph,
+  };
+}
+
+function sha256Term(term: string): string {
+  return createHash('sha256').update(term, 'utf8').digest('hex');
+}
+
+function externalRef(hash: string): string {
+  return `"sha256:${hash}"^^<${EXTERNAL_LITERAL_REF_DATATYPE}>`;
+}
+
+function blobPath(blobDir: string, hash: string): string {
+  return join(blobDir, hash);
+}

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -1,7 +1,10 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { defineConfig } from 'vitest/config';
 import { tornadoStorageCoverage } from '../../vitest.coverage';
 
 export default defineConfig({
+  cacheDir: join(tmpdir(), 'dkg-storage-vitest-cache'),
   test: {
     include: ['test/**/*.test.ts'],
     coverage: {

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -24,6 +24,8 @@
 #                 Enable the async publisher runtime on each node
 #   DEVNET_EPCIS_CONTEXT_GRAPH
 #                 Context graph used by /api/epcis/capture when publisher is enabled
+#   DEVNET_SWM_SYNC_ON_CONNECT=0
+#                 Skip peer-connect SWM catch-up, useful for bulk SWM benchmarks
 #
 set -euo pipefail
 
@@ -425,6 +427,12 @@ create_node_config() {
     publisher_block='"publisher": { "enabled": true, "pollIntervalMs": 500, "errorBackoffMs": 500, "maxRetries": 10 },'
     epcis_block="\"epcis\": { \"contextGraphId\": \"${DEVNET_EPCIS_CONTEXT_GRAPH:-devnet-test}\" },"
   fi
+  local swm_sync_block=""
+  case "${DEVNET_SWM_SYNC_ON_CONNECT:-1}" in
+    0|false|FALSE|no|NO)
+      swm_sync_block='"syncSharedMemoryOnConnect": false,'
+      ;;
+  esac
 
   # Random Sampling prover (core-only). For devnet we want a
   # persistent WAL (so `dkg rs wal-tail` / smoke tests can read the
@@ -446,6 +454,7 @@ create_node_config() {
   ${relay_value}
   ${store_block}
   "contextGraphs": ["devnet-test", "devnet-isolation"],
+  ${swm_sync_block}
   "publisher": {
     "enabled": true,
     "pollIntervalMs": 12000,


### PR DESCRIPTION
# PR Description: Fix SWM Large Payload Storage Amplification

## Summary

This PR fixes the Shared Working Memory large-payload storage amplification path
that pushed Oxigraph WASM into `RuntimeError: unreachable` / `table index is out
of bounds` failures during replicated public SWM writes.

The change keeps the public SWM API unchanged while moving large bytes out of
Oxigraph metadata and out of Oxigraph literal storage where possible:

- New SWM share metadata no longer writes full public payloads as
  `dkg:publicStagedQuads` JSON literals.
- Async lift/publish resolution uses immutable per-operation public snapshots,
  so an older queued `shareOperationId` does not silently read the root's newer
  live SWM state.
- Large public SWM literal object terms are externalized into content-addressed
  blob files and hydrated back on query/lift results.
- Public operation snapshots are now stored as compact graphless N-Quads files
  instead of JSON quad arrays, with read compatibility for existing `.json`
  snapshot files.

## Implementation Details

### Compact Operation Metadata

`storeWorkspaceOperationPublicQuads()` now stores operation identity and
fingerprints instead of serialized public payload bytes:

- context graph id
- optional subgraph name
- share operation id
- root entities
- publisher peer id
- timestamp
- per-root public quad digest/count
- per-root immutable snapshot reference

Legacy `dkg:publicStagedQuads` records remain readable, but new writes do not
create them.

### Immutable Public Snapshots

Each share operation has an immutable public snapshot backing store. Lift
resolution checks the requested roots against the operation metadata, reads the
snapshot, recomputes digest/count, and fails if the snapshot is missing or
corrupt. It does not fall back to the current live SWM root state.

```mermaid
flowchart TD
  A["/api/shared-memory/write"] --> B["Write live SWM graph"]
  A --> C["Build operation-scoped public slice"]
  C --> D["Persist immutable public snapshot"]
  D --> E["Store compact snapshot ref + digest/count"]
  E --> F["Async lift resolves by shareOperationId"]
  F --> G{"Legacy publicStagedQuads exists?"}
  G -->|yes| H["Read legacy JSON metadata snapshot"]
  G -->|no| I["Read immutable snapshot ref"]
  I --> J["Validate digest/count"]
  J --> K["Return original public quads"]
```

### Large Literal Externalization

Persistent Oxigraph-backed agent stores wrap the underlying triple store with
large-literal externalization for public SWM graphs. Large RDF literal object
terms are written to `<dataDir>/literal-blobs/<sha256>`, and Oxigraph stores a
small typed placeholder:

```text
"sha256:<hex>"^^<http://dkg.io/ontology/externalLiteralRef>
```

Queries and lift results hydrate placeholders back to the original RDF literal
term. Full SPARQL value semantics over externalized literal bytes are not
promised; filters/functions inside Oxigraph see the placeholder.

### N-Quads Public Snapshot Files

The file-backed public snapshot store now writes:

```text
<dataDir>/swm-public-snapshots/aa/bb/<sha>.nq
```

instead of:

```text
<dataDir>/swm-public-snapshots/aa/bb/<sha>.json
```

The `.nq` file contains one graphless N-Quads line per public quad. Reads first
try `.nq` and then fall back to legacy `.json`, so existing snapshot files stay
compatible.

```mermaid
sequenceDiagram
  participant Client
  participant Agent
  participant Store as Oxigraph-backed store
  participant Blobs as literal-blobs
  participant Snapshots as swm-public-snapshots

  Client->>Agent: shared-memory/write(public quads)
  Agent->>Store: insert live SWM quads
  Store->>Blobs: externalize large literal terms
  Store-->>Agent: stored placeholders in Oxigraph
  Agent->>Snapshots: write immutable public snapshot as .nq
  Agent->>Store: insert compact metadata refs
  Client->>Agent: enqueue/publish by shareOperationId
  Agent->>Snapshots: read .nq snapshot
  Agent->>Store: hydrate external literal refs
  Agent-->>Client: publish/lift original RDF quads
```

## Verification

Focused checks run:

```bash
pnpm --filter @origintrail-official/dkg-storage exec vitest run test/storage.test.ts test/external-literal-store.test.ts
pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/async-lift-workspace.test.ts
pnpm --filter @origintrail-official/dkg exec vitest run test/swm-large-payload-benchmark.test.ts
pnpm --filter @origintrail-official/dkg exec vitest run test/swm-triple-volume-benchmark.test.ts
pnpm --filter @origintrail-official/dkg-storage build
pnpm --filter @origintrail-official/dkg-publisher build
git diff --check
```

Live 5-node verification after the N-Quads snapshot patch:

```bash
pnpm --filter @origintrail-official/dkg benchmark:swm-triple-volume -- \
  --ports 20501,20502,20503,20504,20505 \
  --target-gib-per-node 1 \
  --triples-per-write 1000 \
  --write-concurrency 5 \
  --max-writes 250 \
  --diagnostic-interval-ms 10000 \
  --output bench/results/swm-triple-volume-diagnostic-250w-nq-commit.json
```

Result:

- `250/250` writes completed.
- `250,000` triples converged on all five nodes.
- `dkg:publicStagedQuads = 0` on all five nodes.
- `dkg:publicSnapshotGraph = 0` on all five nodes.
- `dkg:publicSnapshotRef = 250` on all five nodes.
- No `RuntimeError: unreachable`.
- No `table index is out of bounds`.
- No Gossipsub payload-length failures.

The benchmark still shows write-throughput decline as RDF store/snapshot state
grows, but the run completes without data loss or Oxigraph WASM failure. The
remaining throughput work is separate from the storage-amplification fix.
