### PR TITLE
fix(cli): bundle MarkItDown in workspace installs + diagnose missing converter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,12 @@ jobs:
           merge-multiple: true
           path: release-assets
 
+      - name: Verify MarkItDown release assets
+        # Fail-fast presence + sidecar check: every supported platform must
+        # have a binary, .sha256, and .meta.json whose cliVersion matches
+        # the release tag (issue #467 acceptance criterion).
+        run: node packages/cli/scripts/bundle-markitdown-binaries.mjs --verify-release-artifacts release-assets --version "${{ needs.release-preflight.outputs.version }}"
+
       - name: Extract release notes
         id: notes
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ packages/evm-module/deployments/hardhat_contracts.json
 packages/evm-module/deployments/localhost_contracts.json
 snapshots/_cache_phase1_neuroweb_epoch16.json
 .claude/
+
+# MarkItDown bundled binaries — platform-specific, ~50MB each, staged by
+# postinstall or markitdown:bundle. Distribution is via GitHub Release
+# assets, not the repo. Keep the directory itself via .gitkeep so the
+# bundler can write into it without creating it on every install.
+packages/cli/bin/*
+!packages/cli/bin/.gitkeep

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
     "benchmark:daemon-responsiveness": "node scripts/daemon-responsiveness-benchmark.cjs",
     "benchmark:publish-async-get": "node scripts/publish-async-get-benchmark.cjs",
     "postinstall": "node ./scripts/bundle-markitdown-binaries.mjs --quiet --current-platform --best-effort",
+    "markitdown:bundle": "node ./scripts/bundle-markitdown-binaries.mjs --current-platform --force",
     "markitdown:build": "node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform",
     "test": "vitest run",
     "test:benchmark:publish-async-get": "vitest run --config vitest.benchmark.config.ts",

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -706,6 +706,7 @@ export async function bundleImplicitCurrentPlatform({
   warn,
   showRestartHint = true,
   fetchLatestTag = fetchLatestReleaseTag,
+  buildReleaseUrl = releaseBaseUrl,
 }) {
   const resolvedPackageDir = resolvePackageDir(packageDir);
   const resolvedVersion = version ?? readCliVersion(resolvedPackageDir);
@@ -750,7 +751,7 @@ export async function bundleImplicitCurrentPlatform({
     return { status: 'ci-skipped' };
   }
 
-  const baseUrl = releaseBaseUrlOverride ?? releaseBaseUrl(resolvedVersion, releaseRepo);
+  const baseUrl = releaseBaseUrlOverride ?? buildReleaseUrl(resolvedVersion, releaseRepo);
   try {
     const result = await downloadBinaryAsset({
       assetName: target.assetName,
@@ -779,7 +780,7 @@ export async function bundleImplicitCurrentPlatform({
       }
       const latestVersion = latestTag.replace(/^v/, '');
       log(`MarkItDown bundle: v${resolvedVersion} has no release asset; falling back to latest tag ${latestTag}.`);
-      const latestBaseUrl = releaseBaseUrl(latestVersion, releaseRepo);
+      const latestBaseUrl = buildReleaseUrl(latestVersion, releaseRepo);
       try {
         const fallbackResult = await downloadBinaryAsset({
           assetName: target.assetName,
@@ -869,7 +870,7 @@ async function main() {
     return;
   }
 
-  await bundleImplicitCurrentPlatform({
+  const implicitResult = await bundleImplicitCurrentPlatform({
     packageDir,
     outputDir: opts.outputDir,
     version,
@@ -883,6 +884,17 @@ async function main() {
     warn,
     showRestartHint: true,
   });
+
+  // `bundleImplicitCurrentPlatform` deliberately returns `{ status: 'failed' }`
+  // instead of throwing so the postinstall path (which sets `--best-effort`)
+  // can record the remediation message and still exit 0. For an explicit
+  // top-level invocation (e.g. `pnpm run markitdown:bundle`, no
+  // `--best-effort`) the user expects a non-zero exit when staging failed —
+  // re-raise here so the IIFE's error handler at the bottom of this file
+  // surfaces it as a fatal error.
+  if (implicitResult?.status === 'failed' && !opts.bestEffort) {
+    throw new Error(`failed to stage current-platform binary (${implicitResult.reason ?? 'unknown reason'}); see remediation message above`);
+  }
 }
 
 const isMainModule = process.argv[1] && resolve(process.argv[1]) === __filename;

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -97,6 +97,7 @@ function parseArgs(argv) {
     releaseBaseUrl: null,
     releaseRepo: DEFAULT_RELEASE_REPO,
     quiet: false,
+    verifyReleaseArtifacts: null,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -123,12 +124,14 @@ function parseArgs(argv) {
       opts.releaseBaseUrl = argv[++i];
     } else if (arg === '--release-repo') {
       opts.releaseRepo = argv[++i];
+    } else if (arg === '--verify-release-artifacts') {
+      opts.verifyReleaseArtifacts = resolve(argv[++i]);
     } else {
       throw new Error(`Unknown argument: ${arg}`);
     }
   }
 
-  if (!opts.all && !opts.currentPlatform && !opts.buildCurrentPlatform) {
+  if (!opts.all && !opts.currentPlatform && !opts.buildCurrentPlatform && !opts.verifyReleaseArtifacts) {
     opts.currentPlatform = true;
   }
 
@@ -373,7 +376,53 @@ function resolvePythonCommand() {
       // Try the next candidate.
     }
   }
-  throw new Error('Python executable not found. Install python3/python or set the PYTHON environment variable.');
+  throw new Error(rewriteVenvErrorMessage(
+    'Python executable not found. Install python3/python or set the PYTHON environment variable.',
+    'missing-python',
+  ));
+}
+
+// Per-OS install hints used when the build-from-source path fails because
+// python3-venv (or python itself) is not present on the host. The bundle
+// script's main `--best-effort` postinstall path does NOT invoke the
+// build-from-source flow, so this hint only fires for explicit
+// `markitdown:build` runs.
+const VENV_INSTALL_HINTS = [
+  '  Debian / Ubuntu / WSL: `sudo apt install -y python3-venv python3-pip`',
+  '  Fedora / RHEL:         `sudo dnf install -y python3 python3-pip`',
+  '  macOS (Homebrew):      `brew install python@3`',
+  '  Windows:               install Python 3.11+ from python.org and reopen the shell',
+];
+
+function rewriteVenvErrorMessage(originalMessage, kind) {
+  const header = kind === 'missing-python'
+    ? 'MarkItDown build: a working Python 3 is required for the build-from-source path.'
+    : 'MarkItDown build: python3 venv support is required for the build-from-source path.';
+  return [
+    header,
+    ...VENV_INSTALL_HINTS,
+    'Then re-run: pnpm --filter @origintrail-official/dkg run markitdown:build',
+    `(underlying error: ${originalMessage.trim()})`,
+  ].join('\n');
+}
+
+export function rewriteVenvError(err) {
+  const stderr = String(err?.stderr ?? '');
+  const stdout = String(err?.stdout ?? '');
+  const message = String(err?.message ?? '');
+  const text = `${stderr}\n${stdout}\n${message}`;
+  const venvSupportMissing =
+    /ensurepip is not available/i.test(text)
+    || /No module named ['"]?venv['"]?/i.test(text)
+    || /python3-venv/i.test(text);
+  const pythonMissing =
+    /command not found.*python/i.test(text)
+    || /ENOENT/i.test(text)
+    || /is not recognized as an internal or external command/i.test(text);
+  if (!venvSupportMissing && !pythonMissing) return err;
+  const wrapped = new Error(rewriteVenvErrorMessage(message, venvSupportMissing ? 'missing-venv' : 'missing-python'));
+  wrapped.cause = err;
+  return wrapped;
 }
 
 function venvPythonPath(venvDir) {
@@ -414,7 +463,11 @@ export async function buildCurrentPlatformBinary({
   const python = resolvePythonCommand();
 
   try {
-    await execFile(python.command, [...python.args, '-m', 'venv', venvDir], { cwd: tmpRoot, timeout: 120_000 });
+    try {
+      await execFile(python.command, [...python.args, '-m', 'venv', venvDir], { cwd: tmpRoot, timeout: 120_000 });
+    } catch (venvErr) {
+      throw rewriteVenvError(venvErr);
+    }
     const venvPython = venvPythonPath(venvDir);
 
     await execFile(venvPython, ['-m', 'pip', 'install', '--upgrade', 'pip'], {
@@ -535,15 +588,255 @@ export async function ensureCurrentPlatformBinary({
   }
 }
 
+function isHttp404Error(err) {
+  return /returned 404/.test(String(err?.message ?? ''));
+}
+
+export async function fetchLatestReleaseTag(repo) {
+  // GitHub's /releases/latest endpoint excludes prereleases and returns 404
+  // for repos that only publish prereleases (the OriginTrail/dkg case — all
+  // v10.0.0-rc.* tags are flagged prerelease). Use the listing endpoint so
+  // both stable and prerelease tags are eligible. Drafts are skipped.
+  const url = `https://api.github.com/repos/${repo}/releases?per_page=10`;
+  const res = await fetch(url, {
+    headers: { Accept: 'application/vnd.github+json' },
+    signal: AbortSignal.timeout(RELEASE_CHECKSUM_FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`${url} returned ${res.status}`);
+  const body = await res.json();
+  if (!Array.isArray(body)) return null;
+  for (const entry of body) {
+    if (!entry || typeof entry !== 'object') continue;
+    if (entry.draft === true) continue;
+    if (typeof entry.tag_name === 'string' && entry.tag_name.length > 0) {
+      return entry.tag_name;
+    }
+  }
+  return null;
+}
+
+function emitMissingBinaryRemediation(warn, version, reason) {
+  warn(`MarkItDown bundle: could not stage the binary automatically (${reason}).`);
+  warn('PDF / DOCX / PPTX / XLSX / CSV / HTML / EPUB / XML extraction will be unavailable on this node.');
+  warn('To enable, once you have network access:');
+  warn('  pnpm --filter @origintrail-official/dkg run markitdown:bundle');
+  warn('Or to build locally from source (requires python3-venv):');
+  warn('  pnpm --filter @origintrail-official/dkg run markitdown:build');
+  warn('Then restart any running `dkg start` daemon.');
+}
+
+function maybeLogRestartHint(log) {
+  // Postinstall fires before the daemon is ever started, so the restart hint
+  // is noise there. Only surface it for explicit top-level runs of
+  // `markitdown:bundle` / `markitdown:build` where a running daemon is plausible.
+  if (process.env.npm_lifecycle_event === 'postinstall') return;
+  log('Restart any running `dkg start` daemon to pick up the new extraction pipelines.');
+}
+
+export async function verifyReleaseArtifacts({ directory, version, packageDir = DEFAULT_PACKAGE_DIR }) {
+  const expectedVersion = version ?? readCliVersion(packageDir);
+  const errors = [];
+  for (const target of SUPPORTED_TARGETS) {
+    const binaryPath = join(directory, target.assetName);
+    const checksumPath = checksumPathFor(binaryPath);
+    const metadataPath = metadataPathFor(binaryPath);
+    if (!existsSync(binaryPath)) {
+      errors.push(`${target.assetName}: binary missing at ${binaryPath}`);
+      continue;
+    }
+    if (!existsSync(checksumPath)) {
+      errors.push(`${target.assetName}: .sha256 sidecar missing`);
+      continue;
+    }
+    if (!existsSync(metadataPath)) {
+      errors.push(`${target.assetName}: .meta.json sidecar missing`);
+      continue;
+    }
+    let expectedHash;
+    try {
+      expectedHash = parseSha256File(await readFile(checksumPath, 'utf-8'));
+    } catch (err) {
+      errors.push(`${target.assetName}: malformed .sha256 (${err?.message ?? err})`);
+      continue;
+    }
+    const actualHash = sha256Hex(await readFile(binaryPath));
+    if (actualHash !== expectedHash) {
+      errors.push(`${target.assetName}: checksum mismatch (expected ${expectedHash}, got ${actualHash})`);
+      continue;
+    }
+    let metadata;
+    try {
+      metadata = parseMetadataText(await readFile(metadataPath, 'utf-8'));
+    } catch (err) {
+      errors.push(`${target.assetName}: malformed .meta.json (${err?.message ?? err})`);
+      continue;
+    }
+    if (metadata?.cliVersion !== expectedVersion) {
+      errors.push(`${target.assetName}: meta.cliVersion is "${metadata?.cliVersion}" but expected "${expectedVersion}"`);
+    }
+  }
+  return { ok: errors.length === 0, errors, expectedVersion, targetCount: SUPPORTED_TARGETS.length };
+}
+
+/**
+ * Implicit current-platform postinstall flow (issue #467).
+ *
+ * Workspace and published-install both attempt the release-asset download.
+ * The workspace-only branch falls back to the latest published tag when the
+ * local version has no matching asset yet.
+ *
+ * Pure-ish: env-var inputs (DKG_SKIP_MARKITDOWN_DOWNLOAD, CI, DKG_FORCE_…) and
+ * the latest-tag fetcher are passed in, not read here — so tests can inject
+ * mocks without mutating process.env.
+ *
+ * Returns a status object describing what happened. Never throws on failure
+ * paths; the caller decides whether to surface them.
+ */
+export async function bundleImplicitCurrentPlatform({
+  packageDir,
+  outputDir = null,
+  version = null,
+  workspace = null,
+  releaseBaseUrl: releaseBaseUrlOverride = null,
+  releaseRepo = DEFAULT_RELEASE_REPO,
+  force = false,
+  skipDownload = false,
+  ciMode = false,
+  log,
+  warn,
+  showRestartHint = true,
+  fetchLatestTag = fetchLatestReleaseTag,
+}) {
+  const resolvedPackageDir = resolvePackageDir(packageDir);
+  const resolvedVersion = version ?? readCliVersion(resolvedPackageDir);
+  const resolvedWorkspace = workspace ?? isWorkspaceCheckout(resolvedPackageDir);
+
+  if (skipDownload) {
+    log('MarkItDown bundle: DKG_SKIP_MARKITDOWN_DOWNLOAD=1; skipping implicit release-asset download.');
+    emitMissingBinaryRemediation(log, resolvedVersion, 'opt-out via DKG_SKIP_MARKITDOWN_DOWNLOAD=1');
+    return { status: 'opted-out' };
+  }
+
+  const target = getSupportedTarget();
+  if (!target) {
+    log(`MarkItDown bundle: ${process.platform}-${process.arch} is not a supported bundled target. Skipping.`);
+    return { status: 'unsupported' };
+  }
+  const binaryPath = targetBinaryPath(target, resolvedPackageDir, outputDir);
+
+  if (!force && existsSync(binaryPath)) {
+    const releaseExpected = { source: 'release', cliVersion: resolvedVersion };
+    let buildExpected = null;
+    try {
+      buildExpected = {
+        source: 'build',
+        cliVersion: resolvedVersion,
+        buildFingerprint: buildFingerprintForPackage(resolvedPackageDir),
+      };
+    } catch {
+      // Entry script may be absent in test fixtures — fall back to release-only check.
+    }
+    const alreadyStaged =
+      (await hasVerifiedBundledBinary(binaryPath, releaseExpected))
+      || (buildExpected ? await hasVerifiedBundledBinary(binaryPath, buildExpected) : false);
+    if (alreadyStaged) {
+      log(`MarkItDown bundle: already staged ${binaryPath}.`);
+      return { status: 'already-staged', binaryPath };
+    }
+  }
+
+  if (ciMode) {
+    log('MarkItDown bundle: CI environment detected; skipping implicit release-asset download. Set DKG_FORCE_MARKITDOWN_DOWNLOAD=1 to override.');
+    return { status: 'ci-skipped' };
+  }
+
+  const baseUrl = releaseBaseUrlOverride ?? releaseBaseUrl(resolvedVersion, releaseRepo);
+  try {
+    const result = await downloadBinaryAsset({
+      assetName: target.assetName,
+      destinationDir: resolveBinDir(resolvedPackageDir, outputDir),
+      baseUrl,
+      cliVersion: resolvedVersion,
+      force,
+    });
+    log(`MarkItDown bundle: staged ${result.binaryPath} (release v${resolvedVersion}).`);
+    if (showRestartHint) maybeLogRestartHint(log);
+    return { status: 'staged', binaryPath: result.binaryPath, releaseTag: `v${resolvedVersion}` };
+  } catch (versionedErr) {
+    // Workspace-mode fallback only — published installs at a known release
+    // version should not silently swap in a different version's binary.
+    if (resolvedWorkspace && releaseBaseUrlOverride == null && isHttp404Error(versionedErr)) {
+      let latestTag = null;
+      try {
+        latestTag = await fetchLatestTag(releaseRepo);
+      } catch (latestErr) {
+        emitMissingBinaryRemediation(warn, resolvedVersion, `latest-release lookup failed: ${latestErr?.message ?? latestErr}`);
+        return { status: 'failed', reason: 'latest-lookup-error' };
+      }
+      if (!latestTag) {
+        emitMissingBinaryRemediation(warn, resolvedVersion, 'no published releases found for repo');
+        return { status: 'failed', reason: 'no-releases' };
+      }
+      const latestVersion = latestTag.replace(/^v/, '');
+      log(`MarkItDown bundle: v${resolvedVersion} has no release asset; falling back to latest tag ${latestTag}.`);
+      const latestBaseUrl = releaseBaseUrl(latestVersion, releaseRepo);
+      try {
+        const fallbackResult = await downloadBinaryAsset({
+          assetName: target.assetName,
+          destinationDir: resolveBinDir(resolvedPackageDir, outputDir),
+          baseUrl: latestBaseUrl,
+          cliVersion: latestVersion,
+          force,
+        });
+        // The downloaded meta.json claims cliVersion=latestVersion (matches the
+        // release we actually pulled from). But the daemon's converter check
+        // requires meta.cliVersion === local-package version, otherwise it
+        // logs "Ignoring bundled MarkItDown binary with incompatible metadata"
+        // and refuses to register the converter. For the workspace fallback
+        // path we rewrite the meta to reflect the LOCAL cliVersion (so the
+        // binary is actually usable), while preserving the actual release
+        // provenance in `effectiveTag` for operator inspection.
+        const overrideMeta = {
+          source: 'release',
+          cliVersion: resolvedVersion,
+          effectiveTag: latestTag,
+        };
+        await writeMetadataFile(fallbackResult.binaryPath, overrideMeta);
+        log(`MarkItDown bundle: staged ${fallbackResult.binaryPath} (release ${latestTag}, meta tagged v${resolvedVersion}).`);
+        if (showRestartHint) maybeLogRestartHint(log);
+        return { status: 'fallback-staged', binaryPath: fallbackResult.binaryPath, releaseTag: latestTag };
+      } catch (fallbackErr) {
+        emitMissingBinaryRemediation(warn, resolvedVersion, `latest-release download failed: ${fallbackErr?.message ?? fallbackErr}`);
+        return { status: 'failed', reason: 'fallback-download-error' };
+      }
+    }
+    emitMissingBinaryRemediation(warn, resolvedVersion, versionedErr?.message ?? String(versionedErr));
+    return { status: 'failed', reason: 'download-error' };
+  }
+}
+
 async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const packageDir = resolvePackageDir(opts.packageDir);
   const version = opts.version ?? readCliVersion(packageDir);
   const workspace = isWorkspaceCheckout(packageDir);
   const log = opts.quiet ? () => {} : logLine;
+  const warn = opts.quiet ? () => {} : warnLine;
 
-  if (workspace && !opts.all && !opts.buildCurrentPlatform) {
-    log('MarkItDown bundle: workspace checkout detected; skipping implicit release-asset download.');
+  // --verify-release-artifacts: standalone validation mode used by the release
+  // workflow before publishing assets. Fails loudly so a broken matrix job
+  // can't ship a Release with missing/mismatched sidecars.
+  if (opts.verifyReleaseArtifacts) {
+    const result = await verifyReleaseArtifacts({
+      directory: opts.verifyReleaseArtifacts,
+      version,
+      packageDir,
+    });
+    if (!result.ok) {
+      for (const err of result.errors) warn(`MarkItDown release verification: ${err}`);
+      throw new Error(`MarkItDown release verification failed for v${result.expectedVersion}: ${result.errors.length} error(s) across ${result.targetCount} supported target(s).`);
+    }
+    log(`MarkItDown release verification: ok (${result.targetCount} target(s), v${result.expectedVersion}).`);
     return;
   }
 
@@ -557,6 +850,7 @@ async function main() {
       force: opts.force,
     });
     log(`MarkItDown bundle: staged ${result.results.length} release asset(s) for v${version}.`);
+    maybeLogRestartHint(log);
     return;
   }
 
@@ -571,23 +865,24 @@ async function main() {
       return;
     }
     log(`MarkItDown bundle: built ${result.binaryPath}.`);
+    maybeLogRestartHint(log);
     return;
   }
 
-  const result = await ensureCurrentPlatformBinary({
+  await bundleImplicitCurrentPlatform({
     packageDir,
     outputDir: opts.outputDir,
     version,
-    releaseBaseUrlOverride: opts.releaseBaseUrl,
+    workspace,
+    releaseBaseUrl: opts.releaseBaseUrl,
     releaseRepo: opts.releaseRepo,
     force: opts.force,
-    allowBuildFromSource: workspace,
+    skipDownload: process.env.DKG_SKIP_MARKITDOWN_DOWNLOAD === '1',
+    ciMode: process.env.CI === 'true' && process.env.DKG_FORCE_MARKITDOWN_DOWNLOAD !== '1',
+    log,
+    warn,
+    showRestartHint: true,
   });
-  if (result.status === 'unsupported') {
-    log(`MarkItDown bundle: ${process.platform}-${process.arch} is not a supported bundled target.`);
-    return;
-  }
-  log(`MarkItDown bundle: staged ${result.binaryPath} (${result.source ?? result.status}).`);
 }
 
 const isMainModule = process.argv[1] && resolve(process.argv[1]) === __filename;

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -16,9 +16,9 @@ This skill teaches you the full node API surface so you can operate autonomously
 - **Base URL:** (dynamic)
 - **Peer ID:** (dynamic)
 - **Node role:** (dynamic — `core` or `edge`)
-- **Available extraction pipelines:** (dynamic)
+- **Available extraction pipelines:** (dynamic — call `dkg_status` for the live list and any `warnings`)
 
-To see which context graphs (projects) are currently subscribed, call `GET /api/context-graph/list` — this returns a live list that stays current as projects are created or subscribed during the session.
+To see which context graphs (projects) are currently subscribed, call the `dkg_status` tool (or `GET /api/context-graph/list`) — it returns a live list that stays current as projects are created or subscribed during the session.
 
 ## 2. Capabilities Overview
 

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1532,7 +1532,10 @@ export async function runDaemonInner(
   log(`Extraction pipelines: ${supportedIngestionTypes.join(", ")}`);
   if (!isMarkItDownAvailable()) {
     log(
-      "MarkItDown binary not found — non-markdown document extraction unavailable (files stored as blobs)",
+      "MarkItDown binary not found — non-markdown document extraction unavailable (files stored as blobs).",
+    );
+    log(
+      "To enable: run `pnpm --filter @origintrail-official/dkg run markitdown:bundle`, then restart this daemon.",
     );
   }
 

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -632,17 +632,28 @@ export function buildSkillMd(opts: {
   peerId: string;
   nodeRole: string;
   extractionPipelines: string[];
+  unavailablePipelines?: string[];
 }): string {
   const template = loadSkillTemplate();
-  const dynamicSection = [
+  const unavailable = opts.unavailablePipelines ?? [];
+  const dynamicLines = [
     `- **Node version:** ${opts.version}`,
     `- **Base URL:** ${opts.baseUrl}`,
     `- **Peer ID:** ${opts.peerId}`,
     `- **Node role:** ${opts.nodeRole}`,
     `- **Available extraction pipelines:** ${opts.extractionPipelines.length > 0 ? opts.extractionPipelines.join(", ") : "none (install markitdown to enable document conversion)"}`,
+  ];
+  if (unavailable.length > 0) {
+    dynamicLines.push(
+      `- **Unavailable extraction pipelines:** ${unavailable.join(", ")} (MarkItDown binary not installed — run \`pnpm --filter @origintrail-official/dkg run markitdown:bundle\` then restart the daemon)`,
+    );
+  }
+  dynamicLines.push(
     '',
-    'To see which context graphs (projects) are currently subscribed, call `GET /api/context-graph/list` — this returns a live list that stays current as projects are created or subscribed during the session.',
-  ].join("\n");
+    'To see which context graphs (projects) are currently subscribed, call the `dkg_status` tool (or `GET /api/context-graph/list`) — it returns a live list that stays current as projects are created or subscribed during the session.',
+    'The `dkg_status` tool also surfaces `extractionPipelines` and `warnings` — call it if a file import returns `extraction.status = "skipped"` to discover why (e.g. `markitdown_unavailable`).',
+  );
+  const dynamicSection = dynamicLines.join("\n");
 
   const staticPlaceholder =
     "> This section is dynamically generated from node state at serve-time.\n\n" +
@@ -650,9 +661,9 @@ export function buildSkillMd(opts: {
     "- **Base URL:** (dynamic)\n" +
     "- **Peer ID:** (dynamic)\n" +
     "- **Node role:** (dynamic — `core` or `edge`)\n" +
-    "- **Available extraction pipelines:** (dynamic)\n" +
+    "- **Available extraction pipelines:** (dynamic — call `dkg_status` for the live list and any `warnings`)\n" +
     "\n" +
-    "To see which context graphs (projects) are currently subscribed, call `GET /api/context-graph/list` — this returns a live list that stays current as projects are created or subscribed during the session.";
+    "To see which context graphs (projects) are currently subscribed, call the `dkg_status` tool (or `GET /api/context-graph/list`) — it returns a live list that stays current as projects are created or subscribed during the session.";
 
   return template.replace(staticPlaceholder, dynamicSection);
 }

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -110,7 +110,7 @@ import type { IntegrationEntry, TrustTier } from '../../integrations/schema.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
 import { loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
-import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
+import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm, MARKITDOWN_CONTENT_TYPES } from '../../extraction/index.js';
 import {
   expectedBundledMarkItDownBuildMetadata,
   readCliPackageVersion,
@@ -424,12 +424,15 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     // skill-driven clients see Markdown ingestion as supported regardless of
     // converter availability.
     const pipelines = extractionRegistry.availableContentTypes();
+    const available = new Set(pipelines);
+    const unavailablePipelines = MARKITDOWN_CONTENT_TYPES.filter((ct) => !available.has(ct));
     const content = buildSkillMd({
       version: nodeVersion,
       baseUrl,
       peerId: agent.peerId,
       nodeRole: config.nodeRole ?? "edge",
       extractionPipelines: [...new Set(["text/markdown", ...pipelines])],
+      unavailablePipelines,
     });
     const etag = skillEtag(content);
     if (req.headers["if-none-match"] === etag) {
@@ -477,6 +480,23 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       config.blockExplorerUrl ?? deriveBlockExplorerUrl(chainConf?.chainId);
     const identityId = agent.publisher.getIdentityId();
     const localAgentIntegrations = listLocalAgentIntegrations(config);
+    // text/markdown is always natively handled by the import-file route,
+    // mirroring the /.well-known/skill.md surface. The registry only carries
+    // Phase-1 converters (currently MarkItDown), so the merge here keeps
+    // markdown in the advertised list regardless of converter availability.
+    const registeredPipelines = extractionRegistry.availableContentTypes();
+    const extractionPipelines = [...new Set(["text/markdown", ...registeredPipelines])];
+    const availablePipelineSet = new Set(registeredPipelines);
+    const warnings: Array<{ code: string; message: string; remediation?: string }> = [];
+    if (!MARKITDOWN_CONTENT_TYPES.every((ct) => availablePipelineSet.has(ct))) {
+      warnings.push({
+        code: "markitdown_unavailable",
+        message:
+          "MarkItDown binary not registered — PDF, DOCX, PPTX, XLSX, CSV, HTML, EPUB, and XML extraction unavailable. Imports of those types will return extraction.status='skipped' and the file will be stored as a blob.",
+        remediation:
+          "Run `pnpm --filter @origintrail-official/dkg run markitdown:bundle`, then restart the daemon.",
+      });
+    }
     return jsonResponse(res, 200, {
       name: config.name,
       version: nodeVersion,
@@ -506,6 +526,8 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         daemonState.lastUpdateCheck.checkedAt > 0 ? !daemonState.lastUpdateCheck.upToDate : null,
       latestCommit: daemonState.lastUpdateCheck.latestCommit || null,
       latestVersion: daemonState.lastUpdateCheck.latestVersion || null,
+      extractionPipelines,
+      warnings,
     });
   }
 

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  bundleImplicitCurrentPlatform,
   checksumPathFor,
   downloadBinaryAsset,
   ensureCurrentPlatformBinary,
@@ -16,8 +17,10 @@ import {
   releaseAssetUrl,
   releaseBaseUrl,
   releaseTagForVersion,
+  rewriteVenvError,
   sha256Hex,
   SUPPORTED_TARGETS,
+  verifyReleaseArtifacts,
 } from '../scripts/bundle-markitdown-binaries.mjs';
 
 describe('bundle-markitdown-binaries helpers', () => {
@@ -450,5 +453,482 @@ describe('bundle-markitdown-binaries helpers', () => {
     expect(workflowRaw).toContain('Hello from MarkItDown smoke test.');
     expect(workflowRaw).toContain('Hello from DOCX smoke test.');
     expect(workflowRaw).toContain('.meta.json');
+  });
+
+  it('release workflow verifies bundled MarkItDown assets before publishing', async () => {
+    const workflowRaw = await readFile(new URL('../../../.github/workflows/release.yml', import.meta.url), 'utf-8');
+    // Acceptance criterion from issue #467: release/CI checks cover the
+    // presence/validation of bundled MarkItDown assets.
+    expect(workflowRaw).toContain('--verify-release-artifacts');
+    expect(workflowRaw).toContain('release-assets');
+  });
+});
+
+describe('bundleImplicitCurrentPlatform (issue #467)', () => {
+  const CLI_VERSION = '99.0.0-rc.1';
+  const LATEST_TAG = 'v98.0.0';
+  const LATEST_VERSION = '98.0.0';
+  const RELEASE_METADATA_TEXT = (version: string) =>
+    `${JSON.stringify({ source: 'release', cliVersion: version }, null, 2)}\n`;
+  let tmpPaths: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tmpPaths.map((path) => rm(path, { recursive: true, force: true })));
+    tmpPaths = [];
+  });
+
+  // Workspace fixture: `src/` + `tsconfig.json` make isWorkspaceCheckout()
+  // return true, mirroring a real `git clone` + `pnpm install` scenario.
+  async function makeWorkspaceFixture(): Promise<{ packageDir: string; outputDir: string }> {
+    const packageDir = await mkdtemp(join(tmpdir(), 'dkg-implicit-pkg-'));
+    const outputDir = await mkdtemp(join(tmpdir(), 'dkg-implicit-out-'));
+    tmpPaths.push(packageDir, outputDir);
+    await writeFile(join(packageDir, 'package.json'), JSON.stringify({ version: CLI_VERSION }, null, 2));
+    await writeFile(join(packageDir, 'tsconfig.json'), '{}');
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(join(packageDir, 'src'), { recursive: true });
+    return { packageDir, outputDir };
+  }
+
+  function makeAssetServer(
+    target: { assetName: string },
+    { versionedBytes, fallbackBytes }: { versionedBytes: Buffer | null; fallbackBytes: Buffer | null },
+  ): { server: ReturnType<typeof createServer>; baseUrlForVersion: (v: string) => string } {
+    // Routes:
+    //   /release/v{CLI_VERSION}/...  → 404 when versionedBytes is null
+    //   /release/v{LATEST_VERSION}/... → fallbackBytes
+    const versionedHash = versionedBytes ? sha256Hex(versionedBytes) : null;
+    const fallbackHash = fallbackBytes ? sha256Hex(fallbackBytes) : null;
+    const server = createServer((req, res) => {
+      const url = req.url ?? '';
+      const versionPath = `/release/v${CLI_VERSION}`;
+      const latestPath = `/release/v${LATEST_VERSION}`;
+      if (versionedBytes && versionedHash) {
+        if (url === `${versionPath}/${target.assetName}`) {
+          res.writeHead(200, { 'content-type': 'application/octet-stream' });
+          res.end(versionedBytes);
+          return;
+        }
+        if (url === `${versionPath}/${target.assetName}.sha256`) {
+          res.writeHead(200, { 'content-type': 'text/plain' });
+          res.end(`${versionedHash}  ${target.assetName}\n`);
+          return;
+        }
+        if (url === `${versionPath}/${target.assetName}.meta.json`) {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(RELEASE_METADATA_TEXT(CLI_VERSION));
+          return;
+        }
+      }
+      if (fallbackBytes && fallbackHash) {
+        if (url === `${latestPath}/${target.assetName}`) {
+          res.writeHead(200, { 'content-type': 'application/octet-stream' });
+          res.end(fallbackBytes);
+          return;
+        }
+        if (url === `${latestPath}/${target.assetName}.sha256`) {
+          res.writeHead(200, { 'content-type': 'text/plain' });
+          res.end(`${fallbackHash}  ${target.assetName}\n`);
+          return;
+        }
+        if (url === `${latestPath}/${target.assetName}.meta.json`) {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(RELEASE_METADATA_TEXT(LATEST_VERSION));
+          return;
+        }
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    return {
+      server,
+      baseUrlForVersion: (v: string) => `http://127.0.0.1:${(server.address() as { port: number }).port}/release/v${v}`,
+    };
+  }
+
+  function makeLogCapture(): { log: (m: string) => void; warn: (m: string) => void; logs: string[]; warns: string[] } {
+    const logs: string[] = [];
+    const warns: string[] = [];
+    return {
+      log: (m) => { logs.push(String(m)); },
+      warn: (m) => { warns.push(String(m)); },
+      logs,
+      warns,
+    };
+  }
+
+  it('workspace + no binary → downloads the version-tagged release asset', async () => {
+    const target = getSupportedTarget();
+    expect(target).not.toBeNull();
+    if (!target) return;
+    const { packageDir, outputDir } = await makeWorkspaceFixture();
+    const bytes = Buffer.from('workspace versioned binary', 'utf-8');
+    const { server, baseUrlForVersion } = makeAssetServer(target, { versionedBytes: bytes, fallbackBytes: null });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const capture = makeLogCapture();
+
+    try {
+      const result = await bundleImplicitCurrentPlatform({
+        packageDir,
+        outputDir,
+        releaseBaseUrl: baseUrlForVersion(CLI_VERSION),
+        log: capture.log,
+        warn: capture.warn,
+        showRestartHint: false,
+        fetchLatestTag: async () => { throw new Error('should not be called'); },
+      });
+
+      expect(result.status).toBe('staged');
+      expect(result.binaryPath).toBeTruthy();
+      expect(existsSync(join(outputDir, target.assetName))).toBe(true);
+      expect(await readFile(join(outputDir, target.assetName))).toEqual(bytes);
+      expect(capture.logs.some((line) => line.includes(`release v${CLI_VERSION}`))).toBe(true);
+      expect(capture.warns).toEqual([]);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('workspace + binary already staged → skips network entirely', async () => {
+    const target = getSupportedTarget();
+    expect(target).not.toBeNull();
+    if (!target) return;
+    const { packageDir, outputDir } = await makeWorkspaceFixture();
+
+    // Pre-stage a valid binary + sidecars matching the local CLI version.
+    const bytes = Buffer.from('already-staged binary', 'utf-8');
+    const hash = sha256Hex(bytes);
+    const binaryPath = join(outputDir, target.assetName);
+    await writeFile(binaryPath, bytes);
+    await writeFile(checksumPathFor(binaryPath), `${hash}  ${target.assetName}\n`, 'utf-8');
+    await writeFile(metadataPathFor(binaryPath), RELEASE_METADATA_TEXT(CLI_VERSION), 'utf-8');
+
+    const capture = makeLogCapture();
+    const result = await bundleImplicitCurrentPlatform({
+      packageDir,
+      outputDir,
+      // Point at an unreachable URL — if we hit it the test fails with a timeout.
+      releaseBaseUrl: 'http://127.0.0.1:1/release/should-never-be-called',
+      log: capture.log,
+      warn: capture.warn,
+      showRestartHint: false,
+      fetchLatestTag: async () => { throw new Error('should not be called'); },
+    });
+
+    expect(result.status).toBe('already-staged');
+    expect(result.binaryPath).toBe(binaryPath);
+    expect(capture.logs.some((line) => line.includes('already staged'))).toBe(true);
+  });
+
+  it('workspace + version-tag 404 → falls back to latest tag and stages it', async () => {
+    const target = getSupportedTarget();
+    expect(target).not.toBeNull();
+    if (!target) return;
+    const { packageDir, outputDir } = await makeWorkspaceFixture();
+    const fallbackBytes = Buffer.from('fallback latest binary', 'utf-8');
+    const { server } = makeAssetServer(target, { versionedBytes: null, fallbackBytes });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+    const capture = makeLogCapture();
+    let fetchLatestCalled = 0;
+
+    try {
+      const result = await bundleImplicitCurrentPlatform({
+        packageDir,
+        outputDir,
+        releaseBaseUrl: null, // important: fallback only triggers when no override
+        releaseRepo: `test-org/dkg-test-${port}`, // arbitrary; injected fetchLatestTag ignores it
+        log: capture.log,
+        warn: capture.warn,
+        showRestartHint: false,
+        fetchLatestTag: async () => {
+          fetchLatestCalled += 1;
+          return LATEST_TAG;
+        },
+      });
+
+      // The default releaseBaseUrl() points at https://github.com/... which we
+      // cannot reach in the test. To exercise the fallback path against our
+      // local server we need to also redirect both attempts to localhost.
+      // Easier: test via a second variant that simulates the production URL
+      // shape directly.
+      // For now: fallback path only succeeds when the second URL is reachable,
+      // which we cannot mock without monkey-patching fetch. So we assert the
+      // error path: version 404 → fallback tries the GitHub-shaped URL → fails
+      // (network unreachable) → remediation warning fired.
+      expect([
+        'fallback-staged',
+        'failed',
+      ]).toContain(result.status);
+      if (result.status === 'failed') {
+        expect(result.reason).toBe('fallback-download-error');
+        expect(capture.warns.some((line) => /could not stage the binary/i.test(line))).toBe(true);
+      }
+      expect(fetchLatestCalled).toBeGreaterThanOrEqual(0); // depends on path taken
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('workspace + 404 + injected latest URL stages the fallback binary', async () => {
+    // This variant exercises the happy-path fallback by serving BOTH the
+    // (404) version-tag AND the latest-tag from the same local server, with
+    // releaseBaseUrl pinned to the version tag so the fallback re-targets the
+    // latest-tag URL on the same host.
+    const target = getSupportedTarget();
+    expect(target).not.toBeNull();
+    if (!target) return;
+    const { packageDir, outputDir } = await makeWorkspaceFixture();
+    const fallbackBytes = Buffer.from('fallback latest binary v2', 'utf-8');
+    const fallbackHash = sha256Hex(fallbackBytes);
+
+    const server = createServer((req, res) => {
+      const url = req.url ?? '';
+      // Version tag is unconditionally 404.
+      if (url.startsWith(`/release/v${CLI_VERSION}/`)) {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      // Latest tag: real bytes/sidecars.
+      if (url === `/release/v${LATEST_VERSION}/${target.assetName}`) {
+        res.writeHead(200, { 'content-type': 'application/octet-stream' });
+        res.end(fallbackBytes);
+        return;
+      }
+      if (url === `/release/v${LATEST_VERSION}/${target.assetName}.sha256`) {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end(`${fallbackHash}  ${target.assetName}\n`);
+        return;
+      }
+      if (url === `/release/v${LATEST_VERSION}/${target.assetName}.meta.json`) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(RELEASE_METADATA_TEXT(LATEST_VERSION));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+
+    // To make the fallback target the same host, we monkey-patch the global
+    // GitHub URL builder by passing releaseBaseUrl=null but also overriding
+    // releaseRepo so the fallback uses our server. Easiest: pass releaseRepo
+    // with a fake repo and use a custom fetchLatestTag — the fallback path
+    // calls releaseBaseUrl(latestVersion, releaseRepo) which hits github.com.
+    // Workaround: pass releaseBaseUrl explicitly (skip fallback) for the
+    // primary call, force a 404 via wrong asset URL pattern, then trigger
+    // fallback to localhost via injected fetchLatestTag returning a tag and
+    // by overriding releaseBaseUrl semantics. Simpler: assert the failed-
+    // gracefully outcome instead and trust the unit-level fallback
+    // construction is exercised by the dedicated `it` above.
+
+    const capture = makeLogCapture();
+    try {
+      const result = await bundleImplicitCurrentPlatform({
+        packageDir,
+        outputDir,
+        // Force a 404 on the primary attempt by pointing at the test server's
+        // version-tag path. The fallback path constructs the latest-tag URL
+        // via `releaseBaseUrl(latestVersion, releaseRepo)` which targets
+        // github.com — unreachable from the test sandbox. Expect a graceful
+        // failure with the remediation message.
+        releaseBaseUrl: `http://127.0.0.1:${port}/release/v${CLI_VERSION}`,
+        log: capture.log,
+        warn: capture.warn,
+        showRestartHint: false,
+        fetchLatestTag: async () => LATEST_TAG,
+      });
+
+      // releaseBaseUrl was set, so the fallback path is INTENTIONALLY skipped
+      // (we don't want a published install at a known version to swap binaries).
+      // Outcome: graceful failure with remediation.
+      expect(result.status).toBe('failed');
+      expect(result.reason).toBe('download-error');
+      expect(capture.warns.some((line) => /could not stage the binary/i.test(line))).toBe(true);
+      expect(capture.warns.some((line) => /markitdown:bundle/.test(line))).toBe(true);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('skipDownload=true → opts out without hitting the network', async () => {
+    const target = getSupportedTarget();
+    if (!target) return;
+    const { packageDir, outputDir } = await makeWorkspaceFixture();
+
+    const capture = makeLogCapture();
+    const result = await bundleImplicitCurrentPlatform({
+      packageDir,
+      outputDir,
+      releaseBaseUrl: 'http://127.0.0.1:1/should-never-be-called',
+      skipDownload: true,
+      log: capture.log,
+      warn: capture.warn,
+      showRestartHint: false,
+      fetchLatestTag: async () => { throw new Error('should not be called'); },
+    });
+
+    expect(result.status).toBe('opted-out');
+    expect(capture.logs.some((line) => /DKG_SKIP_MARKITDOWN_DOWNLOAD/.test(line))).toBe(true);
+    expect(capture.logs.some((line) => /could not stage the binary/i.test(line))).toBe(true);
+    expect(existsSync(join(outputDir, target.assetName))).toBe(false);
+  });
+
+  it('ciMode=true + no binary → skips silently with a one-line message', async () => {
+    const target = getSupportedTarget();
+    if (!target) return;
+    const { packageDir, outputDir } = await makeWorkspaceFixture();
+
+    const capture = makeLogCapture();
+    const result = await bundleImplicitCurrentPlatform({
+      packageDir,
+      outputDir,
+      releaseBaseUrl: 'http://127.0.0.1:1/should-never-be-called',
+      ciMode: true,
+      log: capture.log,
+      warn: capture.warn,
+      showRestartHint: false,
+      fetchLatestTag: async () => { throw new Error('should not be called'); },
+    });
+
+    expect(result.status).toBe('ci-skipped');
+    expect(capture.logs.some((line) => /CI environment detected/.test(line))).toBe(true);
+    expect(capture.warns).toEqual([]); // CI skip is a notice, not a warning
+    expect(existsSync(join(outputDir, target.assetName))).toBe(false);
+  });
+
+  it('total download failure → returns failed with actionable remediation', async () => {
+    const target = getSupportedTarget();
+    if (!target) return;
+    const { packageDir, outputDir } = await makeWorkspaceFixture();
+    const server = createServer((_req, res) => { res.writeHead(500); res.end(); });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+
+    const capture = makeLogCapture();
+    try {
+      const result = await bundleImplicitCurrentPlatform({
+        packageDir,
+        outputDir,
+        releaseBaseUrl: `http://127.0.0.1:${port}/release`,
+        log: capture.log,
+        warn: capture.warn,
+        showRestartHint: false,
+        fetchLatestTag: async () => { throw new Error('should not be called'); },
+      });
+
+      expect(result.status).toBe('failed');
+      expect(result.reason).toBe('download-error');
+      const remediation = capture.warns.join('\n');
+      expect(remediation).toMatch(/could not stage the binary/i);
+      expect(remediation).toMatch(/markitdown:bundle/);
+      expect(remediation).toMatch(/markitdown:build/);
+      expect(remediation).toMatch(/python3-venv/);
+      expect(remediation).toMatch(/restart any running/i);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+});
+
+describe('rewriteVenvError (issue #467)', () => {
+  it('rewrites "ensurepip is not available" with per-OS install hints', () => {
+    const original = new Error('Command failed: python3 -m venv /tmp/x');
+    (original as any).stderr = 'The virtual environment was not created successfully because ensurepip is not available.\n';
+    const wrapped = rewriteVenvError(original);
+    expect(wrapped).not.toBe(original);
+    expect(wrapped.message).toContain('python3-venv');
+    expect(wrapped.message).toContain('apt install -y python3-venv');
+    expect(wrapped.message).toContain('brew install python@3');
+    expect(wrapped.message).toContain('markitdown:build');
+  });
+
+  it('rewrites "No module named venv" failures', () => {
+    const original = new Error("Command failed: python -m venv /tmp/x: No module named 'venv'");
+    const wrapped = rewriteVenvError(original);
+    expect(wrapped).not.toBe(original);
+    expect(wrapped.message).toContain('python3-venv');
+  });
+
+  it('passes through unrelated errors untouched', () => {
+    const original = new Error('PyInstaller crashed on entry script');
+    const result = rewriteVenvError(original);
+    expect(result).toBe(original);
+  });
+});
+
+describe('verifyReleaseArtifacts (issue #467)', () => {
+  let tmpPaths: string[] = [];
+  const TEST_VERSION = '99.0.0-rc.1';
+
+  afterEach(async () => {
+    await Promise.all(tmpPaths.map((path) => rm(path, { recursive: true, force: true })));
+    tmpPaths = [];
+  });
+
+  async function stageOneTarget(directory: string, target: { assetName: string }, version: string): Promise<void> {
+    const bytes = Buffer.from(`fake binary ${target.assetName}`, 'utf-8');
+    const hash = sha256Hex(bytes);
+    await writeFile(join(directory, target.assetName), bytes);
+    await writeFile(join(directory, `${target.assetName}.sha256`), `${hash}  ${target.assetName}\n`, 'utf-8');
+    await writeFile(
+      join(directory, `${target.assetName}.meta.json`),
+      `${JSON.stringify({ source: 'build', cliVersion: version }, null, 2)}\n`,
+      'utf-8',
+    );
+  }
+
+  it('accepts a complete artifact directory with matching version', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-verify-ok-'));
+    tmpPaths.push(directory);
+    for (const target of SUPPORTED_TARGETS) {
+      await stageOneTarget(directory, target, TEST_VERSION);
+    }
+    const result = await verifyReleaseArtifacts({ directory, version: TEST_VERSION });
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.targetCount).toBe(SUPPORTED_TARGETS.length);
+  });
+
+  it('fails when a binary is missing', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-verify-missing-bin-'));
+    tmpPaths.push(directory);
+    // Stage all but the first target.
+    for (let i = 1; i < SUPPORTED_TARGETS.length; i += 1) {
+      await stageOneTarget(directory, SUPPORTED_TARGETS[i], TEST_VERSION);
+    }
+    const result = await verifyReleaseArtifacts({ directory, version: TEST_VERSION });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e: string) => e.includes(SUPPORTED_TARGETS[0].assetName))).toBe(true);
+    expect(result.errors.some((e: string) => /binary missing/.test(e))).toBe(true);
+  });
+
+  it('fails when a .meta.json reports a different cliVersion than the release tag', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-verify-version-mismatch-'));
+    tmpPaths.push(directory);
+    for (const target of SUPPORTED_TARGETS) {
+      await stageOneTarget(directory, target, '88.0.0-rc.9'); // wrong version in meta
+    }
+    const result = await verifyReleaseArtifacts({ directory, version: TEST_VERSION });
+    expect(result.ok).toBe(false);
+    expect(result.errors.every((e: string) => /meta\.cliVersion/.test(e))).toBe(true);
+  });
+
+  it('fails when a checksum does not match the binary', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-verify-bad-checksum-'));
+    tmpPaths.push(directory);
+    for (const target of SUPPORTED_TARGETS) {
+      await stageOneTarget(directory, target, TEST_VERSION);
+    }
+    // Corrupt the first target's binary so its sidecar hash no longer matches.
+    const tampered = SUPPORTED_TARGETS[0];
+    await writeFile(join(directory, tampered.assetName), Buffer.from('tampered'), 'utf-8');
+    const result = await verifyReleaseArtifacts({ directory, version: TEST_VERSION });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e: string) => e.includes(tampered.assetName) && /checksum mismatch/.test(e))).toBe(true);
   });
 });

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -621,62 +621,12 @@ describe('bundleImplicitCurrentPlatform (issue #467)', () => {
     expect(capture.logs.some((line) => line.includes('already staged'))).toBe(true);
   });
 
-  it('workspace + version-tag 404 → falls back to latest tag and stages it', async () => {
-    const target = getSupportedTarget();
-    expect(target).not.toBeNull();
-    if (!target) return;
-    const { packageDir, outputDir } = await makeWorkspaceFixture();
-    const fallbackBytes = Buffer.from('fallback latest binary', 'utf-8');
-    const { server } = makeAssetServer(target, { versionedBytes: null, fallbackBytes });
-
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
-    const port = (server.address() as { port: number }).port;
-    const capture = makeLogCapture();
-    let fetchLatestCalled = 0;
-
-    try {
-      const result = await bundleImplicitCurrentPlatform({
-        packageDir,
-        outputDir,
-        releaseBaseUrl: null, // important: fallback only triggers when no override
-        releaseRepo: `test-org/dkg-test-${port}`, // arbitrary; injected fetchLatestTag ignores it
-        log: capture.log,
-        warn: capture.warn,
-        showRestartHint: false,
-        fetchLatestTag: async () => {
-          fetchLatestCalled += 1;
-          return LATEST_TAG;
-        },
-      });
-
-      // The default releaseBaseUrl() points at https://github.com/... which we
-      // cannot reach in the test. To exercise the fallback path against our
-      // local server we need to also redirect both attempts to localhost.
-      // Easier: test via a second variant that simulates the production URL
-      // shape directly.
-      // For now: fallback path only succeeds when the second URL is reachable,
-      // which we cannot mock without monkey-patching fetch. So we assert the
-      // error path: version 404 → fallback tries the GitHub-shaped URL → fails
-      // (network unreachable) → remediation warning fired.
-      expect([
-        'fallback-staged',
-        'failed',
-      ]).toContain(result.status);
-      if (result.status === 'failed') {
-        expect(result.reason).toBe('fallback-download-error');
-        expect(capture.warns.some((line) => /could not stage the binary/i.test(line))).toBe(true);
-      }
-      expect(fetchLatestCalled).toBeGreaterThanOrEqual(0); // depends on path taken
-    } finally {
-      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
-    }
-  });
-
-  it('workspace + 404 + injected latest URL stages the fallback binary', async () => {
-    // This variant exercises the happy-path fallback by serving BOTH the
-    // (404) version-tag AND the latest-tag from the same local server, with
-    // releaseBaseUrl pinned to the version tag so the fallback re-targets the
-    // latest-tag URL on the same host.
+  it('workspace + version-tag 404 + injected URL builder stages the fallback binary with rewritten meta', async () => {
+    // Happy-path fallback: version-tag 404 → latest-tag 200. Both URLs
+    // resolve to the test server via the injectable `buildReleaseUrl` so we
+    // don't depend on github.com. Verifies the meta sidecar is rewritten
+    // with the LOCAL cliVersion (otherwise the daemon's converter check
+    // rejects the binary — issue #467 was originally regressed here).
     const target = getSupportedTarget();
     expect(target).not.toBeNull();
     if (!target) return;
@@ -686,7 +636,8 @@ describe('bundleImplicitCurrentPlatform (issue #467)', () => {
 
     const server = createServer((req, res) => {
       const url = req.url ?? '';
-      // Version tag is unconditionally 404.
+      // Version tag: unconditionally 404 (release for local CLI_VERSION does
+      // not exist yet — common pre-release state).
       if (url.startsWith(`/release/v${CLI_VERSION}/`)) {
         res.writeHead(404);
         res.end();
@@ -714,42 +665,49 @@ describe('bundleImplicitCurrentPlatform (issue #467)', () => {
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
     const port = (server.address() as { port: number }).port;
 
-    // To make the fallback target the same host, we monkey-patch the global
-    // GitHub URL builder by passing releaseBaseUrl=null but also overriding
-    // releaseRepo so the fallback uses our server. Easiest: pass releaseRepo
-    // with a fake repo and use a custom fetchLatestTag — the fallback path
-    // calls releaseBaseUrl(latestVersion, releaseRepo) which hits github.com.
-    // Workaround: pass releaseBaseUrl explicitly (skip fallback) for the
-    // primary call, force a 404 via wrong asset URL pattern, then trigger
-    // fallback to localhost via injected fetchLatestTag returning a tag and
-    // by overriding releaseBaseUrl semantics. Simpler: assert the failed-
-    // gracefully outcome instead and trust the unit-level fallback
-    // construction is exercised by the dedicated `it` above.
-
     const capture = makeLogCapture();
+    let fetchLatestCalled = 0;
+
     try {
       const result = await bundleImplicitCurrentPlatform({
         packageDir,
         outputDir,
-        // Force a 404 on the primary attempt by pointing at the test server's
-        // version-tag path. The fallback path constructs the latest-tag URL
-        // via `releaseBaseUrl(latestVersion, releaseRepo)` which targets
-        // github.com — unreachable from the test sandbox. Expect a graceful
-        // failure with the remediation message.
-        releaseBaseUrl: `http://127.0.0.1:${port}/release/v${CLI_VERSION}`,
+        // releaseBaseUrl deliberately unset — that's required for the
+        // workspace fallback branch to engage (overrides are an explicit
+        // user choice and should not silently swap binaries).
         log: capture.log,
         warn: capture.warn,
         showRestartHint: false,
-        fetchLatestTag: async () => LATEST_TAG,
+        fetchLatestTag: async () => {
+          fetchLatestCalled += 1;
+          return LATEST_TAG;
+        },
+        // Redirect BOTH the primary and fallback URLs to the local test
+        // server. Without this the fallback would hit github.com.
+        buildReleaseUrl: (v: string) => `http://127.0.0.1:${port}/release/v${v}`,
       });
 
-      // releaseBaseUrl was set, so the fallback path is INTENTIONALLY skipped
-      // (we don't want a published install at a known version to swap binaries).
-      // Outcome: graceful failure with remediation.
-      expect(result.status).toBe('failed');
-      expect(result.reason).toBe('download-error');
-      expect(capture.warns.some((line) => /could not stage the binary/i.test(line))).toBe(true);
-      expect(capture.warns.some((line) => /markitdown:bundle/.test(line))).toBe(true);
+      // The fallback happy path.
+      expect(result.status).toBe('fallback-staged');
+      expect(result.releaseTag).toBe(LATEST_TAG);
+      expect(result.binaryPath).toBe(join(outputDir, target.assetName));
+      expect(fetchLatestCalled).toBe(1);
+      // Binary actually staged.
+      expect(existsSync(join(outputDir, target.assetName))).toBe(true);
+      expect(await readFile(join(outputDir, target.assetName))).toEqual(fallbackBytes);
+      // CRITICAL invariant for issue #467: meta sidecar must report the
+      // LOCAL cliVersion (so the daemon's converter check accepts the
+      // binary) AND preserve the actual release tag in `effectiveTag` for
+      // operator inspection.
+      const metaContents = await readFile(metadataPathFor(join(outputDir, target.assetName)), 'utf-8');
+      const meta = JSON.parse(metaContents) as { source?: string; cliVersion?: string; effectiveTag?: string };
+      expect(meta.source).toBe('release');
+      expect(meta.cliVersion).toBe(CLI_VERSION);
+      expect(meta.effectiveTag).toBe(LATEST_TAG);
+      // Log surfacing.
+      expect(capture.logs.some((line) => line.includes('falling back to latest tag'))).toBe(true);
+      expect(capture.logs.some((line) => line.includes(`meta tagged v${CLI_VERSION}`))).toBe(true);
+      expect(capture.warns).toEqual([]);
     } finally {
       await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
     }


### PR DESCRIPTION
## Summary

- Workspace/dev `pnpm install` now stages the MarkItDown binary by default so PDF/DOCX/PPTX/XLSX/CSV/HTML/EPUB/XML extraction works out of the box, matching the published-install experience. Previously the postinstall silently skipped the release-asset download for source checkouts and PDFs returned `extraction.status='skipped'`.
- When the local `package.json` version is ahead of the latest published tag (the common pre-release case), the bundler falls back to the newest non-draft release and rewrites the meta sidecar with the local `cliVersion` (preserving the release tag in an `effectiveTag` field) so the daemon's converter check accepts the binary instead of rejecting it as a fingerprint mismatch.
- A missing converter is now visible to operators and agents: `/api/status` carries `extractionPipelines: string[]` + `warnings: [{code, message, remediation?}]`, the live `/.well-known/skill.md` adds an `Unavailable extraction pipelines` line, the static `SKILL.md` template points agents at the `dkg_status` tool, and the daemon startup warning tells operators exactly which command to run and that a restart is required.
- Failure UX hardened: `DKG_SKIP_MARKITDOWN_DOWNLOAD=1` opt-out, automatic silent skip in CI, per-OS install hint when `python3-venv` is missing from `markitdown:build`, and a release-time `--verify-release-artifacts` check in `release.yml` that fails the workflow if any matrix-built binary or sidecar is missing/mismatched before `softprops/action-gh-release` publishes.

## Related

- Fixes #467
- Follow-up to #446 / #256 — the manual PDF attachment validation that surfaced this gap
- Out of scope (documented in #467 and worth a separate PR): extending the import-file `skipped` response with a structured reason field, and loosening the OpenClaw attachment-ref normalizer to allow non-`completed` statuses so agents see the skip reason

## Files changed

| File | What |
|------|------|
| `packages/cli/scripts/bundle-markitdown-binaries.mjs` | New `bundleImplicitCurrentPlatform()` workflow with workspace fallback to latest tag, `fetchLatestReleaseTag()` (uses `/releases` listing — `/releases/latest` returns 404 on prerelease-only repos), `verifyReleaseArtifacts()`, `rewriteVenvError()`, restart-hint logging, opt-out env vars. Removed the silent workspace-skip short-circuit. |
| `packages/cli/src/daemon/routes/status.ts` | `extractionPipelines` and `warnings[]` on `/api/status`; `unavailablePipelines` passed to `buildSkillMd` for the live skill manifest. |
| `packages/cli/src/daemon/manifest.ts` | `buildSkillMd` accepts `unavailablePipelines`, renders the diagnostic line, placeholder match updated in lockstep with the template wording. |
| `packages/cli/src/daemon/lifecycle.ts` | Startup warning now includes `pnpm --filter @origintrail-official/dkg run markitdown:bundle` + restart-the-daemon remediation. |
| `packages/cli/skills/dkg-node/SKILL.md` | §1 placeholder points agents at the `dkg_status` tool (matching the template's tool-first convention) instead of raw HTTP for the live pipeline list. |
| `.github/workflows/release.yml` | New verification step (`--verify-release-artifacts`) runs before `softprops/action-gh-release` and fails the workflow if any matrix-built binary or sidecar is missing/mismatched. |
| `.gitignore` + `packages/cli/bin/.gitkeep` | Defensive: keeps platform-specific MarkItDown binaries out of git while preserving the directory so the bundler can write into it. |
| `packages/cli/test/markitdown-binaries.test.ts` | 14 new vitest cases covering workspace download, already-staged skip, version-ahead fallback, total-failure remediation, opt-out env vars, CI skip, venv error rewriter, and release-artifact verifier. |

## Test plan

- [x] `pnpm exec vitest run test/markitdown-binaries.test.ts test/extraction-markitdown.test.ts test/document-processor-e2e.test.ts` → 50 passed, 4 skipped (the skipIf'd e2e cases need a real converter; follow-up could remove the guards now that the workspace flow actually stages one).
- [x] `pnpm exec tsc --noEmit` in `packages/cli/` → clean.
- [x] Manual smoke (Windows worktree): fresh `pnpm install` stages `markitdown-win32-x64.exe` via fallback to `v10.0.0-rc.4`; `bin/markitdown-win32-x64.exe.meta.json` reports `cliVersion: "10.0.0-rc.6", effectiveTag: "v10.0.0-rc.4"`; `extraction-markitdown.test.ts` no longer logs the "Ignoring bundled binary with incompatible metadata sidecar" warning that fires before this PR.
- [ ] CI matrix run on Linux. Windows symlink-permission failures in `slot-helpers`, `migration`, `rollback`, `blue-green-integration`, `auto-update`, etc. on the dev machine are pre-existing and unrelated to these files.
- [ ] Operator manual: with binary present, `curl /api/status | jq '.extractionPipelines, .warnings'` returns the full pipeline list and `[]`. With binary deleted and daemon restarted, returns just `text/markdown` and a single `markitdown_unavailable` warning with `remediation`.
- [ ] Operator manual: `curl /.well-known/skill.md | grep -i 'extraction pipelines'` shows the `Available` line when the binary is present, and BOTH an `Available` and an `Unavailable` line (listing the 9 MIME types) when it is missing.
- [ ] PDF round-trip: import a PDF via `POST /api/assertion/test-pdf/import-file` → response carries `extraction.status: "completed"`, `pipelineUsed: "application/pdf"`, `tripleCount > 0`, and an `mdIntermediateHash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)