### PR TITLE
core(network): add Network interface + LibP2PNetwork wrapper (RFC 07 PR-1)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,14 @@ export { Logger, createOperationContext, type OperationContext, type OperationNa
 export * from './crypto/index.js';
 export * from './proto/index.js';
 export { DKGNode } from './node.js';
+export {
+  type Network,
+  type NodeIdentity,
+  type Address,
+  type DialOpts,
+  type ProtocolHandler,
+  LibP2PNetwork,
+} from './network/index.js';
 export { ProtocolRouter, DEFAULT_MAX_READ_BYTES } from './protocol-router.js';
 export { GossipSubManager, type GossipMessageHandler } from './gossipsub-manager.js';
 export { PeerDiscoveryManager } from './discovery.js';

--- a/packages/core/src/network/index.ts
+++ b/packages/core/src/network/index.ts
@@ -1,0 +1,9 @@
+export type {
+  Network,
+  NodeIdentity,
+  Address,
+  DialOpts,
+  ProtocolHandler,
+} from './network.js';
+
+export { LibP2PNetwork } from './libp2p-network.js';

--- a/packages/core/src/network/libp2p-network.ts
+++ b/packages/core/src/network/libp2p-network.ts
@@ -60,13 +60,43 @@ export class LibP2PNetwork implements Network {
     // caller supplied one, honour it as-is; otherwise mint one off the
     // timeout so a runaway dial doesn't pin a stream slot indefinitely.
     const signal = opts?.signal ?? AbortSignal.timeout(timeoutMs);
-    return this.node.libp2p.dialProtocol(pid, protocolId, { signal });
+    // V10 edge/core traffic regularly traverses circuit-relay limited
+    // connections (RFC 04). The pre-RFC-07 dial path
+    // (ProtocolRouter.send) sets runOnLimitedConnection: true for that
+    // reason; preserve the same default here so that the first
+    // consumer migrated to Network.dialProtocol() doesn't regress on
+    // relay-only links. Codex PR #494 round 1.
+    return this.node.libp2p.dialProtocol(pid, protocolId, {
+      signal,
+      runOnLimitedConnection: true,
+    });
   }
 
   async handle(protocolId: string, handler: ProtocolHandler): Promise<void> {
-    await this.node.libp2p.handle(protocolId, (stream, connection) => {
-      void handler(stream, connection.remotePeer.toString());
-    });
+    // Mirror ProtocolRouter.register semantics so the wrapper doesn't
+    // silently regress two behaviours the existing dial path relies on:
+    //  1. await the handler so an async rejection isn't swallowed as
+    //     an unhandled promise — abort the stream on failure instead
+    //     of leaving it half-open.
+    //  2. pass runOnLimitedConnection: true so inbound protocols keep
+    //     working when the only available connection is a relay-limited
+    //     one (RFC 04 / V10 edge↔core via circuit-relay).
+    // Codex PR #494 round 1.
+    await this.node.libp2p.handle(
+      protocolId,
+      async (stream, connection) => {
+        try {
+          await handler(stream, connection.remotePeer.toString());
+        } catch (err) {
+          try {
+            stream.abort(err instanceof Error ? err : new Error('handler error'));
+          } catch {
+            // stream already closed/aborted — nothing to do.
+          }
+        }
+      },
+      { runOnLimitedConnection: true },
+    );
   }
 
   async unhandle(protocolId: string): Promise<void> {

--- a/packages/core/src/network/libp2p-network.ts
+++ b/packages/core/src/network/libp2p-network.ts
@@ -1,0 +1,98 @@
+/**
+ * Libp2p implementation of the {@link Network} interface — RFC 07 §5.
+ *
+ * Thin facade over an existing {@link DKGNode}: every method delegates
+ * directly to the libp2p instance the node already owns. No state is
+ * duplicated; lifecycle is shared.
+ *
+ * v1 ships this as the only `Network` implementation. The interface
+ * boundary is what RFC 07 commits to architecturally; the implementation
+ * is libp2p because that's what the rest of V10 already runs on.
+ */
+import type { Stream, Connection } from '@libp2p/interface';
+import { peerIdFromString } from '@libp2p/peer-id';
+import { multiaddr } from '@multiformats/multiaddr';
+import type { Network, NodeIdentity, Address, DialOpts, ProtocolHandler } from './network.js';
+import type { DKGNode } from '../node.js';
+
+const DEFAULT_DIAL_TIMEOUT_MS = 10_000;
+const DEFAULT_FIND_PEER_TIMEOUT_MS = 5_000;
+
+export class LibP2PNetwork implements Network {
+  private readonly node: DKGNode;
+
+  constructor(node: DKGNode) {
+    this.node = node;
+  }
+
+  get localId(): NodeIdentity {
+    return this.node.peerId;
+  }
+
+  get localAddresses(): Address[] {
+    return this.node.multiaddrs;
+  }
+
+  get isStarted(): boolean {
+    return this.node.isStarted;
+  }
+
+  async start(): Promise<void> {
+    if (!this.node.isStarted) {
+      await this.node.start();
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.node.isStarted) {
+      await this.node.stop();
+    }
+  }
+
+  async dialProtocol(
+    peerId: NodeIdentity,
+    protocolId: string,
+    opts?: DialOpts,
+  ): Promise<Stream> {
+    const pid = peerIdFromString(peerId);
+    const timeoutMs = opts?.timeoutMs ?? DEFAULT_DIAL_TIMEOUT_MS;
+    // libp2p dialProtocol accepts an AbortSignal directly. If the
+    // caller supplied one, honour it as-is; otherwise mint one off the
+    // timeout so a runaway dial doesn't pin a stream slot indefinitely.
+    const signal = opts?.signal ?? AbortSignal.timeout(timeoutMs);
+    return this.node.libp2p.dialProtocol(pid, protocolId, { signal });
+  }
+
+  async handle(protocolId: string, handler: ProtocolHandler): Promise<void> {
+    await this.node.libp2p.handle(protocolId, (stream, connection) => {
+      void handler(stream, connection.remotePeer.toString());
+    });
+  }
+
+  async unhandle(protocolId: string): Promise<void> {
+    await this.node.libp2p.unhandle(protocolId);
+  }
+
+  getConnections(peerId: NodeIdentity): Connection[] {
+    const pid = peerIdFromString(peerId);
+    return this.node.libp2p.getConnections(pid);
+  }
+
+  async addKnownAddresses(peerId: NodeIdentity, addrs: Address[]): Promise<void> {
+    if (addrs.length === 0) return;
+    const pid = peerIdFromString(peerId);
+    const ma = addrs.map((a) => multiaddr(a));
+    await this.node.libp2p.peerStore.merge(pid, { multiaddrs: ma });
+  }
+
+  async findPeer(
+    peerId: NodeIdentity,
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
+  ): Promise<Address[]> {
+    const pid = peerIdFromString(peerId);
+    const timeoutMs = opts?.timeoutMs ?? DEFAULT_FIND_PEER_TIMEOUT_MS;
+    const signal = opts?.signal ?? AbortSignal.timeout(timeoutMs);
+    const info = await this.node.libp2p.peerRouting.findPeer(pid, { signal });
+    return (info?.multiaddrs ?? []).map((m) => m.toString());
+  }
+}

--- a/packages/core/src/network/network.ts
+++ b/packages/core/src/network/network.ts
@@ -1,0 +1,134 @@
+/**
+ * Network interface — RFC 07 §5.
+ *
+ * The transport-pluggable boundary in front of the in-process network
+ * stack. Every component that needs to dial a peer or open a protocol
+ * stream should depend on this interface, not on libp2p directly.
+ *
+ * v1 ships with `LibP2PNetwork` as the only implementation. Multi-stack
+ * is enabled architecturally — extra transports plug in behind this
+ * interface — but adding iroh / QUIC / any other stack is a separate,
+ * gated effort. See RFC 07 §5.1 for the rationale.
+ *
+ * The companion `PeerResolver` (RFC 07 §3) is the only thing that
+ * SHOULD call `dialProtocol` outside of the application protocols
+ * themselves; PR-4 of the RFC 07 rollout adds a CI grep gate that
+ * keeps this property honest as new protocols are added.
+ *
+ * See `dkgv10-spec/production_mainnet/07_IN_PROCESS_PEER_RESOLVER.md`.
+ */
+import type { Stream, Connection } from '@libp2p/interface';
+
+/**
+ * Transport-encoded peer identifier. For the v1 libp2p implementation
+ * this is the canonical libp2p PeerId string form (e.g. "12D3KooW…").
+ *
+ * Future transports may use different encodings — iroh would use the
+ * Ed25519 public key in z-base-32 form, etc. — but the contract is:
+ * a transport produces and consumes its own canonical string identifier
+ * end-to-end; consumers treat it as opaque.
+ */
+export type NodeIdentity = string;
+
+/**
+ * Multiaddr-shaped network address. v1 carries libp2p multiaddr strings
+ * (e.g. `/ip4/1.2.3.4/tcp/9090/p2p/12D3KooW…`); future transports may
+ * use different schemes (iroh node tickets, QUIC URIs, etc.).
+ */
+export type Address = string;
+
+export interface DialOpts {
+  /** Per-dial timeout (ms). Default: 10_000. */
+  timeoutMs?: number;
+  /** AbortSignal to cancel an in-flight dial. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Handler invoked for every inbound stream on a registered protocol.
+ * Implementations should fully consume `stream` (read + close) before
+ * returning, or hand it off to a long-lived consumer.
+ */
+export type ProtocolHandler = (stream: Stream, remote: NodeIdentity) => void | Promise<void>;
+
+/**
+ * The minimum set of transport operations every consumer in the
+ * application uses. Keeps the libp2p coupling out of dial-path code
+ * (sync, chat, skill invoke, /api/connect, …) so the same code can run
+ * over a non-libp2p transport in future without re-plumbing every
+ * call site.
+ */
+export interface Network {
+  /** This node's transport-encoded identity. Stable for the daemon's lifetime. */
+  readonly localId: NodeIdentity;
+
+  /** This node's currently-bound listen addresses, transport-encoded. */
+  readonly localAddresses: Address[];
+
+  /** True once `start()` has resolved and false again after `stop()`. */
+  readonly isStarted: boolean;
+
+  /**
+   * Open a stream to `peerId` on `protocolId`. Implementations should
+   * use whatever resolution / dial logic the underlying transport
+   * provides — peer-routing, address book, NAT traversal, … The
+   * application's `PeerResolver` (RFC 07 §3) is responsible for
+   * populating the transport's address book before calling this.
+   */
+  dialProtocol(peerId: NodeIdentity, protocolId: string, opts?: DialOpts): Promise<Stream>;
+
+  /**
+   * Register `handler` for inbound streams on `protocolId`. Idempotent
+   * with libp2p semantics: registering twice for the same protocol is
+   * a runtime error (libp2p throws DuplicateProtocolHandlerError); call
+   * `unhandle` first if replacing.
+   */
+  handle(protocolId: string, handler: ProtocolHandler): Promise<void>;
+
+  /**
+   * Unregister a previously-registered protocol handler. No-op if the
+   * protocol was never registered.
+   */
+  unhandle(protocolId: string): Promise<void>;
+
+  /**
+   * Currently-open connections to `peerId`. Returns an empty array
+   * when no live connection exists. Sub-millisecond; safe to call on
+   * hot paths.
+   */
+  getConnections(peerId: NodeIdentity): Connection[];
+
+  /**
+   * Hint a known set of addresses for `peerId` to the transport's
+   * address book. Implementations should store the addresses durably
+   * enough that subsequent `dialProtocol(peerId)` calls can use them
+   * without re-resolving — but are free to evict on their own policy
+   * (LRU, TTL, dial-failure feedback, etc.).
+   *
+   * Used by `PeerResolver` to push freshly-resolved multiaddrs into
+   * the transport's cache before dialing.
+   */
+  addKnownAddresses(peerId: NodeIdentity, addrs: Address[]): Promise<void>;
+
+  /**
+   * Optional: ask the transport's peer-routing layer to find addresses
+   * for `peerId`. For libp2p this is a Kademlia DHT walk; for future
+   * transports it may be a different mechanism (or absent entirely
+   * for transports that have no peer-routing source).
+   *
+   * Implementations that don't support peer routing should leave this
+   * undefined; callers should treat `findPeer === undefined` as
+   * "transport has no peer-routing source", not as an error.
+   */
+  findPeer?(
+    peerId: NodeIdentity,
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
+  ): Promise<Address[]>;
+
+  /**
+   * Lifecycle. Implementations are idempotent: calling `start()` on an
+   * already-started instance, or `stop()` on a stopped one, is a no-op.
+   */
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}

--- a/packages/core/test/libp2p-network.test.ts
+++ b/packages/core/test/libp2p-network.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { multiaddr } from '@multiformats/multiaddr';
+import { DKGNode } from '../src/node.js';
+import { LibP2PNetwork } from '../src/network/libp2p-network.js';
+
+/**
+ * RFC 07 §5 — `LibP2PNetwork` is a thin facade over `DKGNode.libp2p`.
+ * These tests exercise it against two real libp2p instances rather
+ * than mocking; the `Network` interface contract is what we verify,
+ * not internal libp2p mechanics.
+ */
+describe('LibP2PNetwork', () => {
+  const nodes: DKGNode[] = [];
+
+  afterEach(async () => {
+    for (const n of nodes) {
+      await n.stop();
+    }
+    nodes.length = 0;
+  });
+
+  function spawn(): DKGNode {
+    const n = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+    });
+    nodes.push(n);
+    return n;
+  }
+
+  it('exposes localId / localAddresses / isStarted that mirror DKGNode', async () => {
+    const node = spawn();
+    const net = new LibP2PNetwork(node);
+    expect(net.isStarted).toBe(false);
+    await net.start();
+    expect(net.isStarted).toBe(true);
+    expect(net.localId).toBe(node.peerId);
+    expect(net.localAddresses).toEqual(node.multiaddrs);
+    await net.stop();
+    expect(net.isStarted).toBe(false);
+  });
+
+  it('start / stop are idempotent', async () => {
+    const node = spawn();
+    const net = new LibP2PNetwork(node);
+    await net.start();
+    await net.start();
+    expect(net.isStarted).toBe(true);
+    await net.stop();
+    await net.stop();
+    expect(net.isStarted).toBe(false);
+  });
+
+  it('handle + dialProtocol round-trips a stream', async () => {
+    const a = spawn();
+    const b = spawn();
+    const netA = new LibP2PNetwork(a);
+    const netB = new LibP2PNetwork(b);
+    await netA.start();
+    await netB.start();
+
+    // Point A at B without using libp2p directly.
+    await netA.addKnownAddresses(b.peerId, b.multiaddrs);
+
+    const protocol = '/test/network-iface/1.0.0';
+    const received: { remote: string; payload: string }[] = [];
+    const dec = new TextDecoder();
+    await netB.handle(protocol, async (stream, remote) => {
+      // Drain the stream so we can record what the dialer sent.
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk.subarray()));
+      }
+      const total = chunks.reduce((s, c) => s + c.length, 0);
+      const merged = new Uint8Array(total);
+      let off = 0;
+      for (const c of chunks) {
+        merged.set(c, off);
+        off += c.length;
+      }
+      received.push({ remote, payload: dec.decode(merged) });
+      await stream.close();
+    });
+
+    const stream = await netA.dialProtocol(b.peerId, protocol);
+    const enc = new TextEncoder();
+    stream.send(enc.encode('hello'));
+    await stream.close();
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(received).toEqual([{ remote: a.peerId, payload: 'hello' }]);
+  }, 15000);
+
+  it('getConnections returns empty before connect, non-empty after', async () => {
+    const a = spawn();
+    const b = spawn();
+    const netA = new LibP2PNetwork(a);
+    await netA.start();
+    await b.start();
+
+    expect(netA.getConnections(b.peerId)).toHaveLength(0);
+
+    await a.libp2p.dial(multiaddr(b.multiaddrs[0]));
+    await new Promise((r) => setTimeout(r, 300));
+
+    const conns = netA.getConnections(b.peerId);
+    expect(conns.length).toBeGreaterThan(0);
+    expect(conns[0].remotePeer.toString()).toBe(b.peerId);
+  }, 15000);
+
+  it('addKnownAddresses populates the peer store so subsequent dials skip resolution', async () => {
+    const a = spawn();
+    const b = spawn();
+    const netA = new LibP2PNetwork(a);
+    await netA.start();
+    await b.start();
+
+    await netA.addKnownAddresses(b.peerId, b.multiaddrs);
+
+    // libp2p.dialProtocol given just a peer id will use the address book;
+    // if the previous step worked, this dial succeeds without an explicit
+    // multiaddr.
+    const protocol = '/test/known-addrs/1.0.0';
+    await b.libp2p.handle(protocol, (stream) => {
+      void stream.close();
+    });
+    const stream = await netA.dialProtocol(b.peerId, protocol);
+    expect(stream).toBeDefined();
+    await stream.close();
+  }, 15000);
+
+  it('addKnownAddresses with empty array is a no-op', async () => {
+    const a = spawn();
+    const b = spawn();
+    const netA = new LibP2PNetwork(a);
+    await netA.start();
+    await b.start();
+
+    await expect(netA.addKnownAddresses(b.peerId, [])).resolves.toBeUndefined();
+  });
+
+  it('unhandle removes a previously-registered protocol', async () => {
+    const a = spawn();
+    const b = spawn();
+    const netA = new LibP2PNetwork(a);
+    const netB = new LibP2PNetwork(b);
+    await netA.start();
+    await netB.start();
+    await netA.addKnownAddresses(b.peerId, b.multiaddrs);
+
+    const protocol = '/test/unhandle/1.0.0';
+    await netB.handle(protocol, async (stream) => {
+      await stream.close();
+    });
+    const s1 = await netA.dialProtocol(b.peerId, protocol);
+    await s1.close();
+
+    await netB.unhandle(protocol);
+
+    // After unhandle, B should refuse the protocol.
+    await expect(netA.dialProtocol(b.peerId, protocol, { timeoutMs: 2000 })).rejects.toThrow();
+  }, 15000);
+});

--- a/packages/core/test/libp2p-network.test.ts
+++ b/packages/core/test/libp2p-network.test.ts
@@ -139,6 +139,61 @@ describe('LibP2PNetwork', () => {
     await expect(netA.addKnownAddresses(b.peerId, [])).resolves.toBeUndefined();
   });
 
+  it('handle aborts the stream when an async handler rejects (Codex PR #494)', async () => {
+    // Regression guard: the wrapper used to fire-and-forget the handler
+    // promise, so an async rejection became an unhandledRejection AND
+    // left the inbound stream half-open. The dialer would only notice
+    // when its own read timeout fired, by which time minutes might have
+    // passed. The fix awaits the handler in try/catch and aborts the
+    // stream on failure.
+    //
+    // Test strategy: handler awaits a barrier, THEN throws. Dialer
+    // sends, half-closes, then drains. If the fix works, the drain
+    // either returns clean EOF (handler aborted before any reply was
+    // sent) or throws a stream error — both well under the 5s deadline
+    // we assert on. Without the fix, the drain hangs until vitest's
+    // 10s test timeout.
+    const a = spawn();
+    const b = spawn();
+    const netA = new LibP2PNetwork(a);
+    const netB = new LibP2PNetwork(b);
+    await netA.start();
+    await netB.start();
+    await netA.addKnownAddresses(b.peerId, b.multiaddrs);
+
+    const protocol = '/test/handler-rejects/1.0.0';
+    let handlerEntered = false;
+    await netB.handle(protocol, async () => {
+      handlerEntered = true;
+      // Brief async barrier so the dialer-side send/close completes
+      // before the handler aborts the stream — gives us a clean
+      // observation point for the drain timing assertion.
+      await new Promise((r) => setTimeout(r, 50));
+      throw new Error('intentional handler failure');
+    });
+
+    const stream = await netA.dialProtocol(b.peerId, protocol);
+    try {
+      stream.send(new TextEncoder().encode('ping'));
+      await stream.close();
+    } catch {
+      // Stream may already be aborted by the time we send — that's OK,
+      // it's the same root cause we're testing for.
+    }
+
+    const drainStart = Date.now();
+    try {
+      for await (const _chunk of stream) { /* discard */ }
+    } catch {
+      // Aborted-stream error is one of the two acceptable outcomes.
+    }
+    const drainMs = Date.now() - drainStart;
+    expect(handlerEntered).toBe(true);
+    // Without the fix, the drain hangs until libp2p's own timeout (>>5s).
+    // With the fix, abort propagates immediately.
+    expect(drainMs).toBeLessThan(5000);
+  }, 10000);
+
   it('unhandle removes a previously-registered protocol', async () => {
     const a = spawn();
     const b = spawn();


### PR DESCRIPTION
## Summary

First of 5 stacked PRs implementing [RFC 07 — In-Process Peer Resolver](../blob/feat/461-relay-registry/dkgv10-spec/production_mainnet/07_IN_PROCESS_PEER_RESOLVER.md). This PR introduces only the transport boundary (RFC 07 §5); no consumer is migrated yet.

**Goal of RFC 07** (recap): unify all peer-dial code paths in the daemon behind a single resolver, so chat / sync / `/api/connect` / future protocols cannot disagree about how to reach a peer. Today the codebase has at least three independent resolution paths (`Messenger.ensureCircuitRelayAddress`, `ProtocolRouter.send`, `/api/connect`) which silently disagree on cache freshness — the symptom space behind broken invites and intermittent sync failures.

This PR (the boundary):

- **`packages/core/src/network/network.ts`** — `Network`, `NodeIdentity`, `Address`, `DialOpts`, `ProtocolHandler`. The minimum surface every dial-path consumer needs.
- **`packages/core/src/network/libp2p-network.ts`** — `LibP2PNetwork` is a thin facade over an existing `DKGNode`. No state duplicated, lifecycle shared.
- **`packages/core/test/libp2p-network.test.ts`** — exercises the contract against two real libp2p instances (dial round-trip, `getConnections`, `addKnownAddresses`, `unhandle`, lifecycle idempotency).

Purely additive. `DKGNode.libp2p` direct accessor stays during the RFC 07 transition; consumers will be migrated in PR-3 / PR-4.

## What this does NOT do (intentional)

- Does not migrate `Messenger`, `ProtocolRouter`, `/api/connect`, or anything else. PR-2 onwards.
- Does not introduce `PeerResolver`. PR-2.
- Does not add the CI grep gate. PR-4.
- Does not ship a non-libp2p transport. RFC 07 §6 explicitly defers this.

## Stack

```
PR-1 (this) — Network interface + LibP2PNetwork wrapper       ← here
PR-2        — PeerResolver skeleton + Messenger migration
PR-3        — Migrate ProtocolRouter to PeerResolver
PR-4        — Migrate /api/connect + add CI grep gate
PR-5        — Lock in gossipsub msgIdFn (cross-backend constant)
```

Base branch: `feat/461-relay-registry` (PR #471). When that merges, this rebases onto `main` cleanly.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core test` — 635/635 pass (7 new)
- [x] `pnpm -r build` — clean across all packages
- [ ] CI green

Made with [Cursor](https://cursor.com)