### PR TITLE
core(network): add PeerResolver + migrate Messenger (RFC 07 PR-2)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1,5 +1,6 @@
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
+  LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
   PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
   PROTOCOL_SWM_SENDER_KEY,
   contextGraphPublishTopic, contextGraphWorkspaceTopic, contextGraphAppTopic, contextGraphUpdateTopic, contextGraphFinalizationTopic,
@@ -898,6 +899,9 @@ export class DKGAgent {
   gossip!: GossipSubManager;
   router!: ProtocolRouter;
   messenger!: Messenger;
+  /** Single in-process peer-address resolver (RFC 07 §3). Used by Messenger
+   * today; ProtocolRouter / /api/connect migrate in PR-3 / PR-4. */
+  peerResolver!: PeerResolver;
   readonly eventBus: TypedEventBus;
   private readonly chain: ChainAdapter;
   /** Shared memory-owned root entities per context graph: entity → creatorPeerId. Used by publisher and shared memory handler. */
@@ -1311,10 +1315,27 @@ export class DKGAgent {
     }
 
     this.router = new ProtocolRouter(this.node);
+    const network = new LibP2PNetwork(this.node);
+    const peerResolver = new PeerResolver({
+      network,
+      registry: new StubNetworkStateRegistry(),
+      agentDirectory: {
+        // Wraps DiscoveryClient.findAgentByPeerId in the resolver's
+        // minimal AgentDirectoryLookup shape so packages/core doesn't
+        // need to know about the agents-CG SPARQL surface. Replaced
+        // when RFC 04 Phase 2 lands — at that point, the registry
+        // step takes precedence and this fallback is rarely hit.
+        findRelayForPeer: async (peerId) => {
+          const agent = await this.discovery.findAgentByPeerId(peerId);
+          return agent?.relayAddress ?? null;
+        },
+      },
+      bootstrapSeeds: this.config.bootstrapPeers ?? [],
+    });
+    this.peerResolver = peerResolver;
     this.messenger = new Messenger({
-      libp2p: this.node.libp2p as any,
+      resolver: peerResolver,
       router: this.router,
-      discovery: this.discovery,
     });
     this.gossip = new GossipSubManager(this.node, this.eventBus);
     await this.loadSwmSenderKeyState();

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1326,20 +1326,39 @@ export class DKGAgent {
         // when RFC 04 Phase 2 lands — at that point, the registry
         // step takes precedence and this fallback is rarely hit.
         //
-        // Note: AgentDirectoryLookup.findRelayForPeer accepts an
-        // optional `opts.signal` so the resolver can cancel an
-        // in-flight SPARQL on outer-deadline expiry. The legacy
-        // DiscoveryClient.findAgentByPeerId doesn't expose
-        // cancellation today (its SPARQL fetch is fire-and-await),
-        // so the signal is intentionally ignored here. Wiring it up
-        // is a follow-up that touches DiscoveryClient internals;
-        // until then the resolver's pre-step `signal.aborted` check
-        // still prevents NEW agent-directory work from starting once
-        // the deadline elapses, even if an already-running query
-        // can't be torn down.
-        findRelayForPeer: async (peerId, _opts) => {
-          const agent = await this.discovery.findAgentByPeerId(peerId);
-          return agent?.relayAddress ?? null;
+        // Codex review feedback on PR #496 round 5: the previous
+        // revision dropped `opts.signal` entirely, leaving the
+        // resolver's documented cancellation guarantee unhonored at
+        // the only production AgentDirectoryLookup. DiscoveryClient
+        // itself doesn't (yet) accept an AbortSignal, so we honor
+        // the contract at the adapter boundary instead: if the
+        // signal aborts the adapter resolves to `null` immediately,
+        // unblocking the resolver and the outer caller. The
+        // underlying SPARQL fetch then completes in the background
+        // and its result is discarded — a small leak in the abort
+        // path, acceptable given:
+        //   (a) it's bounded by the discovery client's own internal
+        //       timeout
+        //   (b) RFC 04 Phase 2 replaces this fallback path entirely
+        //   (c) the alternative (refactoring DiscoveryClient end-to-
+        //       end signal threading) is out of scope for this PR
+        // The follow-up to plumb signals into DiscoveryClient is
+        // tracked separately.
+        findRelayForPeer: async (peerId, opts) => {
+          if (opts?.signal?.aborted) return null;
+          const lookup = this.discovery.findAgentByPeerId(peerId)
+            .then((agent) => agent?.relayAddress ?? null);
+          if (!opts?.signal) return lookup;
+          return Promise.race<string | null>([
+            lookup,
+            new Promise<null>((resolve) => {
+              opts.signal!.addEventListener(
+                'abort',
+                () => resolve(null),
+                { once: true },
+              );
+            }),
+          ]);
         },
       },
       // Bootstrap is a libp2p-startup concern (`bootstrap({ list })` in

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1325,7 +1325,19 @@ export class DKGAgent {
         // need to know about the agents-CG SPARQL surface. Replaced
         // when RFC 04 Phase 2 lands — at that point, the registry
         // step takes precedence and this fallback is rarely hit.
-        findRelayForPeer: async (peerId) => {
+        //
+        // Note: AgentDirectoryLookup.findRelayForPeer accepts an
+        // optional `opts.signal` so the resolver can cancel an
+        // in-flight SPARQL on outer-deadline expiry. The legacy
+        // DiscoveryClient.findAgentByPeerId doesn't expose
+        // cancellation today (its SPARQL fetch is fire-and-await),
+        // so the signal is intentionally ignored here. Wiring it up
+        // is a follow-up that touches DiscoveryClient internals;
+        // until then the resolver's pre-step `signal.aborted` check
+        // still prevents NEW agent-directory work from starting once
+        // the deadline elapses, even if an already-running query
+        // can't be torn down.
+        findRelayForPeer: async (peerId, _opts) => {
           const agent = await this.discovery.findAgentByPeerId(peerId);
           return agent?.relayAddress ?? null;
         },

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1330,7 +1330,9 @@ export class DKGAgent {
           return agent?.relayAddress ?? null;
         },
       },
-      bootstrapSeeds: this.config.bootstrapPeers ?? [],
+      // Bootstrap is a libp2p-startup concern (`bootstrap({ list })` in
+      // peerDiscovery, see node.ts) — not a per-peer resolution concern.
+      // Removed here per Codex review feedback on PR #496.
     });
     this.peerResolver = peerResolver;
     this.messenger = new Messenger({

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1348,11 +1348,24 @@ export class DKGAgent {
           if (opts?.signal?.aborted) return null;
           const lookup = this.discovery.findAgentByPeerId(peerId)
             .then((agent) => agent?.relayAddress ?? null);
-          if (!opts?.signal) return lookup;
+          const signal = opts?.signal;
+          if (!signal) return lookup;
           return Promise.race<string | null>([
             lookup,
             new Promise<null>((resolve) => {
-              opts.signal!.addEventListener(
+              // Codex PR #499 round 5 (dkg-agent.ts:1354): the early
+              // `signal.aborted` check above and `addEventListener`
+              // are not atomic — the signal could fire in between, and
+              // since `abort` is a one-shot event, our late listener
+              // would never see it and this Promise would hang for the
+              // full lookup duration. Re-check INSIDE the constructor
+              // before subscribing so the abort branch resolves
+              // immediately if we lost that race.
+              if (signal.aborted) {
+                resolve(null);
+                return;
+              }
+              signal.addEventListener(
                 'abort',
                 () => resolve(null),
                 { once: true },

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -1,22 +1,8 @@
-import { multiaddr } from '@multiformats/multiaddr';
-import type { ProtocolRouter } from '@origintrail-official/dkg-core';
-import type { DiscoveryClient } from '../discovery.js';
-
-/**
- * Minimal libp2p surface the Messenger needs. Defined locally to keep
- * test mocking trivial — production code passes `node.libp2p`.
- */
-interface Libp2pLike {
-  getConnections(peerId?: unknown): Array<unknown>;
-  peerStore: {
-    merge(peer: unknown, update: { multiaddrs: unknown[] }): Promise<void>;
-  };
-}
+import type { ProtocolRouter, PeerResolver } from '@origintrail-official/dkg-core';
 
 export interface MessengerDeps {
-  libp2p: Libp2pLike;
+  resolver: PeerResolver;
   router: ProtocolRouter;
-  discovery: DiscoveryClient;
 }
 
 export interface SendOpts {
@@ -27,32 +13,33 @@ export interface SendOpts {
  * Single outbound P2P sending primitive.
  *
  * Two responsibilities:
- *  1. Best-effort prime a /p2p-circuit relay route into the libp2p peerStore
- *     before dialling, so NAT'd peers reachable only via a circuit relay can
- *     be dialled by `dialProtocol` (which otherwise falls back to direct dial
- *     and fails for NAT'd peers without an active connection).
+ *  1. Best-effort consult `PeerResolver` to populate the libp2p
+ *     peerStore with whatever multiaddrs the resolution order finds
+ *     (live conn, DHT, RFC 04 registry, agents-CG, bootstrap seeds).
+ *     The patch is the resolver's side effect; this code just
+ *     triggers the lookup before dialing.
  *  2. Forward the bytes via `ProtocolRouter.send` (which itself owns
- *     transport-level retry on recoverable errors — see protocol-router.ts).
+ *     transport-level retry on recoverable errors — see
+ *     protocol-router.ts).
  *
- * Centralising this in one place removes a class of "this code path forgot to
- * call ensureCircuitRelayAddress" defects (the latent bug behind PR #448's
- * Laptop B invite failure).
+ * Centralising this in one place removes a class of "this code path
+ * forgot to ensure an address was known" defects (the latent bug
+ * behind PR #448's Laptop B invite failure).
  *
- * Discovery is currently SPARQL-first against the agents context graph; this
- * is preserved verbatim from the previous DKGAgent.ensureCircuitRelayAddress
- * implementation. See dkgv10-spec/production_mainnet/04_NETWORK_STATE_REGISTRY.md
- * for the planned chain-driven replacement, and 07_IN_PROCESS_PEER_RESOLVER.md
- * for the in-process resolver that all dial paths will eventually consume.
+ * After RFC 07 PR-2: resolution is delegated to `PeerResolver` rather
+ * than inlined. PR-3 of the RFC 07 rollout migrates `ProtocolRouter`
+ * itself, after which the resolver is consulted on every dial path
+ * (chat / sync / skill invoke / `/api/connect`) — not just chat.
+ *
+ * See `dkgv10-spec/production_mainnet/07_IN_PROCESS_PEER_RESOLVER.md`.
  */
 export class Messenger {
-  private readonly libp2p: Libp2pLike;
+  private readonly resolver: PeerResolver;
   private readonly router: ProtocolRouter;
-  private readonly discovery: DiscoveryClient;
 
   constructor(deps: MessengerDeps) {
-    this.libp2p = deps.libp2p;
+    this.resolver = deps.resolver;
     this.router = deps.router;
-    this.discovery = deps.discovery;
   }
 
   async sendToPeer(
@@ -61,41 +48,12 @@ export class Messenger {
     data: Uint8Array,
     opts: SendOpts = {},
   ): Promise<Uint8Array> {
-    await this.ensureCircuitRelayAddress(peerId);
+    // Best-effort: fire the resolver to populate peerStore. Failures
+    // are swallowed deliberately — the router's send() will surface
+    // a real transport error from dialProtocol if the peer is
+    // unreachable, and the resolver itself never throws on resolution
+    // failure (it returns an empty array).
+    await this.resolver.resolve(peerId).catch(() => undefined);
     return this.router.send(peerId, protocolId, data, opts.timeoutMs);
-  }
-
-  /**
-   * Best-effort: if the peer is not currently connected and the agent
-   * registry advertises a relay for them, add a /p2p-circuit multiaddr
-   * to the peer store so dialProtocol can route through the relay.
-   *
-   * Failures are swallowed deliberately — the caller's send() will surface
-   * a proper transport error from dialProtocol if the peer is unreachable.
-   *
-   * TODO(follow-up): prefer chain-driven discovery via the network-state
-   * registry (RFC 04) for freshness; SPARQL profile lookup as last-resort
-   * fallback.
-   */
-  private async ensureCircuitRelayAddress(peerIdStr: string): Promise<void> {
-    try {
-      const { peerIdFromString } = await import('@libp2p/peer-id');
-      const peerId = peerIdFromString(peerIdStr);
-
-      const conns = this.libp2p.getConnections(peerId);
-      if (conns.length > 0) return;
-
-      const agent = await this.discovery.findAgentByPeerId(peerIdStr);
-      if (!agent?.relayAddress) return;
-
-      const circuitAddr = multiaddr(
-        `${agent.relayAddress}/p2p-circuit/p2p/${peerIdStr}`,
-      );
-      await this.libp2p.peerStore.merge(peerId, {
-        multiaddrs: [circuitAddr],
-      });
-    } catch {
-      // Best-effort — let the caller's send() surface the real error.
-    }
   }
 }

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -53,7 +53,24 @@ export class Messenger {
     // a real transport error from dialProtocol if the peer is
     // unreachable, and the resolver itself never throws on resolution
     // failure (it returns an empty array).
-    await this.resolver.resolve(peerId).catch(() => undefined);
+    //
+    // Codex feedback on PR #496: pass `opts.timeoutMs` through so the
+    // resolver's per-step DHT walk doesn't run unbounded against a
+    // cold peer when the caller explicitly asked for a short send
+    // budget. Note: PR-3 of the RFC 07 stack moves the resolver call
+    // into ProtocolRouter and removes this inline call entirely;
+    // until then the budget passthrough keeps PR #496 sound on its
+    // own merits.
+    if (opts.timeoutMs != null) {
+      await this.resolver
+        .resolve(peerId, {
+          signal: AbortSignal.timeout(opts.timeoutMs),
+          perStepTimeoutMs: opts.timeoutMs,
+        })
+        .catch(() => undefined);
+    } else {
+      await this.resolver.resolve(peerId).catch(() => undefined);
+    }
     return this.router.send(peerId, protocolId, data, opts.timeoutMs);
   }
 }

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -54,23 +54,29 @@ export class Messenger {
     // unreachable, and the resolver itself never throws on resolution
     // failure (it returns an empty array).
     //
-    // Codex feedback on PR #496: pass `opts.timeoutMs` through so the
-    // resolver's per-step DHT walk doesn't run unbounded against a
-    // cold peer when the caller explicitly asked for a short send
-    // budget. Note: PR-3 of the RFC 07 stack moves the resolver call
-    // into ProtocolRouter and removes this inline call entirely;
-    // until then the budget passthrough keeps PR #496 sound on its
-    // own merits.
-    if (opts.timeoutMs != null) {
-      await this.resolver
-        .resolve(peerId, {
-          signal: AbortSignal.timeout(opts.timeoutMs),
-          perStepTimeoutMs: opts.timeoutMs,
-        })
-        .catch(() => undefined);
-    } else {
-      await this.resolver.resolve(peerId).catch(() => undefined);
-    }
+    // Codex review feedback on PR #496:
+    //   round 1 — "pass timeoutMs through so the resolver doesn't run
+    //              unbounded"
+    //   round 3 — "but then timeoutMs is double-spent: once by the
+    //              resolver, once by router.send()"
+    // Both correct. The RIGHT fix is to share a single deadline /
+    // AbortSignal across resolver + router.send, but ProtocolRouter
+    // doesn't accept an external signal today (it builds its own
+    // internally from `timeoutMs`). Plumbing a shared signal through
+    // the router is its own refactor.
+    //
+    // For PR #496 in isolation: this entire code path is transient.
+    // PR-3 of the RFC 07 stack moves resolution into ProtocolRouter
+    // (where the budget can be shared without leaking through public
+    // surfaces) and reduces Messenger to a pass-through. Reverting
+    // the round-1 timeoutMs passthrough avoids the double-spend
+    // regression Codex flagged in round 3 without needing a router
+    // refactor that PR-3 supersedes anyway. The pre-PR behaviour
+    // (resolver runs with default budget, router runs with caller
+    // budget) is what Messenger users (chat / sync) had before this
+    // PR; both use generous timeouts (≥30s) so the resolver's 5s
+    // default doesn't push them over.
+    await this.resolver.resolve(peerId).catch(() => undefined);
     return this.router.send(peerId, protocolId, data, opts.timeoutMs);
   }
 }

--- a/packages/agent/test/p2p-messenger.test.ts
+++ b/packages/agent/test/p2p-messenger.test.ts
@@ -1,123 +1,98 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Messenger } from '../src/p2p/messenger.js';
-import type { ProtocolRouter } from '@origintrail-official/dkg-core';
-import type { DiscoveryClient } from '../src/discovery.js';
+import type { ProtocolRouter, PeerResolver } from '@origintrail-official/dkg-core';
 
-// 12D3Koo... peer ids must be valid base58 to satisfy peerIdFromString. Two
-// arbitrary valid ed25519 peer IDs taken from existing tests.
 const PEER_A = '12D3KooWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const PEER_B = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
-const RELAY_ADDR = '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
 
 interface MockSetup {
-  libp2pConnections: Array<unknown>;
+  resolveMock: ReturnType<typeof vi.fn>;
   routerSendMock: ReturnType<typeof vi.fn>;
-  peerStoreMergeMock: ReturnType<typeof vi.fn>;
-  findAgentMock: ReturnType<typeof vi.fn>;
 }
 
-function makeMessenger(overrides: Partial<MockSetup> = {}): { messenger: Messenger; mocks: MockSetup; callOrder: string[] } {
+function makeMessenger(overrides: Partial<MockSetup> = {}): {
+  messenger: Messenger;
+  mocks: MockSetup;
+  callOrder: string[];
+} {
   const callOrder: string[] = [];
 
   const mocks: MockSetup = {
-    libp2pConnections: overrides.libp2pConnections ?? [],
-    routerSendMock: overrides.routerSendMock ?? vi.fn(async () => {
-      callOrder.push('router.send');
-      return new Uint8Array([0x01, 0x02]);
-    }),
-    peerStoreMergeMock: overrides.peerStoreMergeMock ?? vi.fn(async () => {
-      callOrder.push('peerStore.merge');
-    }),
-    findAgentMock: overrides.findAgentMock ?? vi.fn(async () => {
-      callOrder.push('discovery.findAgentByPeerId');
-      return { peerId: PEER_B, name: 'remote', agentUri: 'urn:agent:remote', relayAddress: RELAY_ADDR };
-    }),
+    resolveMock:
+      overrides.resolveMock ??
+      vi.fn(async () => {
+        callOrder.push('resolver.resolve');
+        return [];
+      }),
+    routerSendMock:
+      overrides.routerSendMock ??
+      vi.fn(async () => {
+        callOrder.push('router.send');
+        return new Uint8Array([0x01, 0x02]);
+      }),
   };
 
   const messenger = new Messenger({
-    libp2p: {
-      getConnections: () => mocks.libp2pConnections,
-      peerStore: { merge: mocks.peerStoreMergeMock },
-    },
+    resolver: { resolve: mocks.resolveMock } as unknown as PeerResolver,
     router: { send: mocks.routerSendMock } as unknown as ProtocolRouter,
-    discovery: { findAgentByPeerId: mocks.findAgentMock } as unknown as DiscoveryClient,
   });
 
   return { messenger, mocks, callOrder };
 }
 
 describe('Messenger.sendToPeer', () => {
-  it('skips relay prime when peer is already connected', async () => {
-    const { messenger, mocks } = makeMessenger({
-      libp2pConnections: [{ remotePeer: { toString: () => PEER_B } }],
-    });
+  it('calls resolver.resolve before router.send', async () => {
+    const { messenger, mocks, callOrder } = makeMessenger();
 
     await messenger.sendToPeer(PEER_B, '/dkg/test/1.0.0', new Uint8Array([0xff]));
 
-    expect(mocks.findAgentMock).not.toHaveBeenCalled();
-    expect(mocks.peerStoreMergeMock).not.toHaveBeenCalled();
+    expect(mocks.resolveMock).toHaveBeenCalledWith(PEER_B);
     expect(mocks.routerSendMock).toHaveBeenCalledOnce();
+    expect(callOrder.indexOf('resolver.resolve')).toBeLessThan(callOrder.indexOf('router.send'));
   });
 
-  it('primes /p2p-circuit multiaddr when peer not connected and profile advertises a relay', async () => {
-    const { messenger, mocks } = makeMessenger();
-
-    await messenger.sendToPeer(PEER_B, '/dkg/test/1.0.0', new Uint8Array([0xff]));
-
-    expect(mocks.findAgentMock).toHaveBeenCalledWith(PEER_B);
-    expect(mocks.peerStoreMergeMock).toHaveBeenCalledOnce();
-    const mergeCall = mocks.peerStoreMergeMock.mock.calls[0];
-    const multiaddrs = (mergeCall[1] as { multiaddrs: Array<{ toString(): string }> }).multiaddrs;
-    expect(multiaddrs[0].toString()).toContain('/p2p-circuit/p2p/' + PEER_B);
-    expect(mocks.routerSendMock).toHaveBeenCalledOnce();
-  });
-
-  it('skips relay prime when discovery returns no relayAddress', async () => {
-    const { messenger, mocks } = makeMessenger({
-      findAgentMock: vi.fn(async () => ({ peerId: PEER_B, name: 'remote', agentUri: 'urn:agent:remote' })),
-    });
-
-    await messenger.sendToPeer(PEER_B, '/dkg/test/1.0.0', new Uint8Array([0xff]));
-
-    expect(mocks.findAgentMock).toHaveBeenCalled();
-    expect(mocks.peerStoreMergeMock).not.toHaveBeenCalled();
-    expect(mocks.routerSendMock).toHaveBeenCalledOnce();
-  });
-
-  it('tolerates discovery throwing — proceeds to router.send anyway', async () => {
-    const { messenger, mocks } = makeMessenger({
-      findAgentMock: vi.fn(async () => { throw new Error('discovery boom'); }),
-    });
-
-    await messenger.sendToPeer(PEER_B, '/dkg/test/1.0.0', new Uint8Array([0xff]));
-
-    expect(mocks.peerStoreMergeMock).not.toHaveBeenCalled();
-    expect(mocks.routerSendMock).toHaveBeenCalledOnce();
-  });
-
-  it('regression: ensureCircuitRelayAddress fires BEFORE router.send (the Laptop B bug)', async () => {
+  it('regression: resolver fires BEFORE router.send (the Laptop B bug)', async () => {
+    // The bug fixed by this primitive: forwardJoinRequest used to call
+    // router.send directly without first priming peer-address resolution,
+    // causing "no reachable curator" failures for NAT'd peers. The fix
+    // is structural — every send through Messenger primes first. The
+    // priming mechanism moved from inline SPARQL patching to the
+    // PeerResolver in RFC 07 PR-2, but the structural property remains.
     const { messenger, callOrder } = makeMessenger();
 
     await messenger.sendToPeer(PEER_B, '/dkg/test/1.0.0', new Uint8Array([0xff]));
 
-    // The bug fixed by this primitive: forwardJoinRequest used to call
-    // router.send directly without first priming the relay route, causing
-    // "no reachable curator" failures for NAT'd peers. The fix is structural
-    // — every send through Messenger primes first.
-    const mergeIdx = callOrder.indexOf('peerStore.merge');
+    const resolveIdx = callOrder.indexOf('resolver.resolve');
     const sendIdx = callOrder.indexOf('router.send');
-    expect(mergeIdx).toBeGreaterThanOrEqual(0);
+    expect(resolveIdx).toBeGreaterThanOrEqual(0);
     expect(sendIdx).toBeGreaterThanOrEqual(0);
-    expect(mergeIdx).toBeLessThan(sendIdx);
+    expect(resolveIdx).toBeLessThan(sendIdx);
+  });
+
+  it('tolerates resolver throwing — proceeds to router.send anyway', async () => {
+    const { messenger, mocks } = makeMessenger({
+      resolveMock: vi.fn(async () => {
+        throw new Error('resolver boom');
+      }),
+    });
+
+    await messenger.sendToPeer(PEER_B, '/dkg/test/1.0.0', new Uint8Array([0xff]));
+
+    expect(mocks.routerSendMock).toHaveBeenCalledOnce();
   });
 
   it('forwards timeoutMs to router.send', async () => {
-    const { messenger, mocks } = makeMessenger({
-      libp2pConnections: [{ remotePeer: { toString: () => PEER_B } }],
+    const { messenger, mocks } = makeMessenger();
+
+    await messenger.sendToPeer(PEER_A, '/dkg/test/1.0.0', new Uint8Array([0xff]), {
+      timeoutMs: 5000,
     });
 
-    await messenger.sendToPeer(PEER_A, '/dkg/test/1.0.0', new Uint8Array([0xff]), { timeoutMs: 5000 });
-
-    expect(mocks.routerSendMock).toHaveBeenCalledWith(PEER_A, '/dkg/test/1.0.0', expect.any(Uint8Array), 5000);
+    expect(mocks.routerSendMock).toHaveBeenCalledWith(
+      PEER_A,
+      '/dkg/test/1.0.0',
+      expect.any(Uint8Array),
+      5000,
+    );
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,13 @@ export {
   type DialOpts,
   type ProtocolHandler,
   LibP2PNetwork,
+  type NetworkStateRegistry,
+  StubNetworkStateRegistry,
+  type AgentDirectoryLookup,
+  type PeerResolverDeps,
+  type PeerResolverLogger,
+  type ResolveOpts,
+  PeerResolver,
 } from './network/index.js';
 export { ProtocolRouter, DEFAULT_MAX_READ_BYTES } from './protocol-router.js';
 export { GossipSubManager, type GossipMessageHandler } from './gossipsub-manager.js';

--- a/packages/core/src/network/index.ts
+++ b/packages/core/src/network/index.ts
@@ -7,3 +7,14 @@ export type {
 } from './network.js';
 
 export { LibP2PNetwork } from './libp2p-network.js';
+
+export type { NetworkStateRegistry } from './network-state-registry.js';
+export { StubNetworkStateRegistry } from './network-state-registry.js';
+
+export type {
+  AgentDirectoryLookup,
+  PeerResolverDeps,
+  PeerResolverLogger,
+  ResolveOpts,
+} from './peer-resolver.js';
+export { PeerResolver } from './peer-resolver.js';

--- a/packages/core/src/network/network-state-registry.ts
+++ b/packages/core/src/network/network-state-registry.ts
@@ -9,6 +9,16 @@
  * Phase 2 (submitProofV2 + per-round attestation KCs) lands. The
  * interface is fixed so the future PR-4 of the RFC 07 rollout can
  * wire the real implementation in without touching consumers.
+ *
+ * Codex review feedback on PR #496 (round 4): `lookup` returns
+ * `Promise<Address[]>` — not `Address[]`. The v1 stub is in-memory
+ * and could be sync, but the real RFC 04 Phase 2 implementation may
+ * consult a database, an SWM channel, or another async source.
+ * Freezing the contract as sync now would either force the real
+ * impl to block the event loop or require a public-API breaking
+ * change in `@origintrail-official/dkg-core` later. Async from day
+ * one keeps the upgrade path open without observable cost (the v1
+ * stub returns a resolved promise instantly).
  */
 import type { NodeIdentity, Address } from './network.js';
 
@@ -19,7 +29,7 @@ export interface NetworkStateRegistry {
    * today, because no attestation KCs are minted before RFC 04
    * Phase 2 lands.
    */
-  lookup(peerId: NodeIdentity): Address[];
+  lookup(peerId: NodeIdentity): Promise<Address[]>;
 }
 
 /**
@@ -28,7 +38,7 @@ export interface NetworkStateRegistry {
  * `system-dkg-network` syncs to in-memory state.
  */
 export class StubNetworkStateRegistry implements NetworkStateRegistry {
-  lookup(_peerId: NodeIdentity): Address[] {
+  async lookup(_peerId: NodeIdentity): Promise<Address[]> {
     return [];
   }
 }

--- a/packages/core/src/network/network-state-registry.ts
+++ b/packages/core/src/network/network-state-registry.ts
@@ -1,0 +1,34 @@
+/**
+ * NetworkStateRegistry — RFC 04 §3.3 / RFC 07 §3.1 step 3.
+ *
+ * In-memory index of multiaddrs keyed on peerId, populated by
+ * PROTOCOL_SYNC delivery of `system-dkg-network` attestation KCs.
+ * `PeerResolver` consults it as step 3 of the resolution order.
+ *
+ * **v1 stub.** Returns empty arrays from `lookup()` until RFC 04
+ * Phase 2 (submitProofV2 + per-round attestation KCs) lands. The
+ * interface is fixed so the future PR-4 of the RFC 07 rollout can
+ * wire the real implementation in without touching consumers.
+ */
+import type { NodeIdentity, Address } from './network.js';
+
+export interface NetworkStateRegistry {
+  /**
+   * Return the multiaddrs the network registry knows for `peerId`.
+   * Empty array means "no record" — which is the entire population
+   * today, because no attestation KCs are minted before RFC 04
+   * Phase 2 lands.
+   */
+  lookup(peerId: NodeIdentity): Address[];
+}
+
+/**
+ * Stub implementation. Always returns `[]`. Used during RFC 07
+ * PRs 1-4; replaced by the real registry in the PR that wires
+ * `system-dkg-network` syncs to in-memory state.
+ */
+export class StubNetworkStateRegistry implements NetworkStateRegistry {
+  lookup(_peerId: NodeIdentity): Address[] {
+    return [];
+  }
+}

--- a/packages/core/src/network/peer-resolver.ts
+++ b/packages/core/src/network/peer-resolver.ts
@@ -52,8 +52,21 @@ export interface AgentDirectoryLookup {
    * Returns the relay multiaddr advertised for `peerId` in the agents
    * context graph, or `null` if none is recorded. The resolver
    * appends `/p2p-circuit/p2p/<peerId>` to construct the dialable form.
+   *
+   * Codex review feedback on PR #496 round 4: takes an optional
+   * `opts.signal` so an in-flight SPARQL query can be cancelled when
+   * the resolver's outer signal aborts. Without this, `resolve()`
+   * still checks `signal.aborted` BEFORE step 4 starts, but once
+   * `findRelayForPeer` is running a timed-out call would block until
+   * the SPARQL request finished naturally — defeating the end-to-end
+   * deadline guarantee for `connectToPeerId({ timeoutMs })` callers.
+   * Implementations that can't cancel (e.g. legacy DiscoveryClient)
+   * may ignore the signal; the contract is best-effort.
    */
-  findRelayForPeer(peerId: NodeIdentity): Promise<Address | null>;
+  findRelayForPeer(
+    peerId: NodeIdentity,
+    opts?: { signal?: AbortSignal },
+  ): Promise<Address | null>;
 }
 
 export interface PeerResolverDeps {
@@ -205,7 +218,7 @@ export class PeerResolver {
     // skipping steps 4+).
     if (aborted()) return accumulated;
     try {
-      const registryAddrs = this.registry.lookup(peerId);
+      const registryAddrs = await this.registry.lookup(peerId);
       if (registryAddrs.length > 0) {
         append(registryAddrs);
         await this.network.addKnownAddresses(peerId, registryAddrs);
@@ -215,10 +228,14 @@ export class PeerResolver {
     }
 
     // Step 4: agent-directory SPARQL fallback. Replaces the chat-only
-    // Messenger.ensureCircuitRelayAddress path.
+    // Messenger.ensureCircuitRelayAddress path. Pass `opts.signal`
+    // through so an in-flight SPARQL query honours the outer deadline
+    // (Codex review feedback on PR #496 round 4).
     if (aborted()) return accumulated;
     try {
-      const relay = await this.agentDirectory.findRelayForPeer(peerId);
+      const relay = await this.agentDirectory.findRelayForPeer(peerId, {
+        signal: opts?.signal,
+      });
       if (relay) {
         const circuitAddr = `${relay}/p2p-circuit/p2p/${peerId}`;
         append([circuitAddr]);

--- a/packages/core/src/network/peer-resolver.ts
+++ b/packages/core/src/network/peer-resolver.ts
@@ -123,10 +123,24 @@ export class PeerResolver {
     // Step 1: active-connection cache. Sub-millisecond. If a live
     // connection exists the caller will reuse it via libp2p
     // connection-deduplication; no need to walk further.
-    const live = this.network.getConnections(peerId);
-    if (live.length > 0) {
-      append(live.map((c) => c.remoteAddr.toString()));
-      return accumulated;
+    //
+    // Codex feedback on PR #496: `getConnections(peerId)` calls
+    // `peerIdFromString(peerId)` under the hood (via LibP2PNetwork)
+    // and that throws on a malformed peerId. The class doc-comment
+    // promises `resolve()` never throws, so wrap step 1 in the same
+    // best-effort handler the later steps use. A bad peerId then
+    // falls through, every later step fails identically, and the
+    // resolver returns []. Callers downstream (e.g. ProtocolRouter
+    // and connectToPeerId) get a clean DIAL_FAILED / PEER_NOT_FOUND
+    // instead of an unhandled exception.
+    try {
+      const live = this.network.getConnections(peerId);
+      if (live.length > 0) {
+        append(live.map((c) => c.remoteAddr.toString()));
+        return accumulated;
+      }
+    } catch (err) {
+      this.logger.debug?.(`live-conn lookup for ${peerId} failed: ${errMsg(err)}`);
     }
 
     // Step 2: DHT lookup. Cheap for peers in the routing table;

--- a/packages/core/src/network/peer-resolver.ts
+++ b/packages/core/src/network/peer-resolver.ts
@@ -107,6 +107,15 @@ export class PeerResolver {
    * Resolve `peerId` to an ordered list of multiaddrs to attempt.
    * See class doc for the resolution order; never throws — failures
    * in one step proceed to the next.
+   *
+   * Cancellation: if `opts.signal` is set, every step checks
+   * `signal.aborted` before running. An already-aborted signal
+   * returns whatever's been accumulated so far (or `[]` if nothing
+   * yet). Per-step timeouts are layered ON TOP of the outer signal,
+   * not subordinated to it: each step that has its own timeout
+   * (DHT today; future: registry, agents-CG) composes a step-local
+   * `AbortSignal.any([opts.signal, AbortSignal.timeout(perStep)])`
+   * so neither input is silently ignored.
    */
   async resolve(peerId: NodeIdentity, opts?: ResolveOpts): Promise<Address[]> {
     const accumulated: Address[] = [];
@@ -118,6 +127,29 @@ export class PeerResolver {
           accumulated.push(a);
         }
       }
+    };
+
+    // Codex feedback PR #499 round 3: callers thread a single
+    // AbortSignal through all steps, but only step 2 (DHT) was
+    // honouring it. After timeout, registry + agents-CG still ran
+    // unbounded, so connectToPeerId({ timeoutMs }) could overrun the
+    // deadline by the registry+SPARQL latency. The check below makes
+    // every step short-circuit when the signal is aborted.
+    const aborted = (): boolean => opts?.signal?.aborted === true;
+
+    // Codex feedback PR #496 round 3: `ResolveOpts.perStepTimeoutMs`
+    // was documented as a real per-step cap, but when `opts.signal`
+    // was also passed, `LibP2PNetwork.findPeer` honoured the signal
+    // and silently dropped the timeout. Compose a step-local signal
+    // that combines BOTH inputs so the per-step contract holds even
+    // when the outer signal is longer-lived. Returns undefined when
+    // no per-step cap and no outer signal are provided.
+    const stepSignal = (perStepMs?: number): AbortSignal | undefined => {
+      const withTimeout =
+        perStepMs && perStepMs > 0 ? AbortSignal.timeout(perStepMs) : undefined;
+      const outer = opts?.signal;
+      if (withTimeout && outer) return AbortSignal.any([withTimeout, outer]);
+      return withTimeout ?? outer;
     };
 
     // Step 1: active-connection cache. Sub-millisecond. If a live
@@ -133,6 +165,7 @@ export class PeerResolver {
     // resolver returns []. Callers downstream (e.g. ProtocolRouter
     // and connectToPeerId) get a clean DIAL_FAILED / PEER_NOT_FOUND
     // instead of an unhandled exception.
+    if (aborted()) return accumulated;
     try {
       const live = this.network.getConnections(peerId);
       if (live.length > 0) {
@@ -147,10 +180,12 @@ export class PeerResolver {
     // expensive for cold peers. Skipped if caller asked or transport
     // doesn't support peer-routing.
     if (!opts?.skipDht && typeof this.network.findPeer === 'function') {
+      if (aborted()) return accumulated;
       try {
+        const perStepMs = opts?.perStepTimeoutMs ?? DEFAULT_PER_STEP_TIMEOUT_MS;
         const dhtAddrs = await this.network.findPeer(peerId, {
-          signal: opts?.signal,
-          timeoutMs: opts?.perStepTimeoutMs ?? DEFAULT_PER_STEP_TIMEOUT_MS,
+          signal: stepSignal(perStepMs),
+          timeoutMs: perStepMs,
         });
         if (dhtAddrs.length > 0) {
           append(dhtAddrs);
@@ -168,6 +203,7 @@ export class PeerResolver {
     // try/catch is the contract that protects callers from a transient
     // registry hiccup aborting the whole resolve() (and silently
     // skipping steps 4+).
+    if (aborted()) return accumulated;
     try {
       const registryAddrs = this.registry.lookup(peerId);
       if (registryAddrs.length > 0) {
@@ -180,6 +216,7 @@ export class PeerResolver {
 
     // Step 4: agent-directory SPARQL fallback. Replaces the chat-only
     // Messenger.ensureCircuitRelayAddress path.
+    if (aborted()) return accumulated;
     try {
       const relay = await this.agentDirectory.findRelayForPeer(peerId);
       if (relay) {

--- a/packages/core/src/network/peer-resolver.ts
+++ b/packages/core/src/network/peer-resolver.ts
@@ -189,6 +189,30 @@ export class PeerResolver {
       this.logger.debug?.(`live-conn lookup for ${peerId} failed: ${errMsg(err)}`);
     }
 
+    // Codex review (PR #496 round 6, peer-resolver.ts:205): the
+    // returned `accumulated` list is the resolver's contract surface —
+    // callers (and ProtocolRouter via the migration in PR #497) treat
+    // a non-empty return as proof the peerStore is primed. Steps 2-4
+    // therefore MUST only append an address after `addKnownAddresses`
+    // has actually written it. The previous order (append → merge)
+    // would on a peerStore failure leave the caller thinking
+    // resolution succeeded while the bare peer-id dial silently
+    // missed every address.
+    const primeAndAppend = async (
+      addrs: Address[],
+      stepLabel: string,
+    ): Promise<void> => {
+      if (addrs.length === 0) return;
+      try {
+        await this.network.addKnownAddresses(peerId, addrs);
+        append(addrs);
+      } catch (err) {
+        this.logger.debug?.(
+          `peerStore merge during ${stepLabel} for ${peerId} failed: ${errMsg(err)}`,
+        );
+      }
+    };
+
     // Step 2: DHT lookup. Cheap for peers in the routing table;
     // expensive for cold peers. Skipped if caller asked or transport
     // doesn't support peer-routing.
@@ -200,10 +224,7 @@ export class PeerResolver {
           signal: stepSignal(perStepMs),
           timeoutMs: perStepMs,
         });
-        if (dhtAddrs.length > 0) {
-          append(dhtAddrs);
-          await this.network.addKnownAddresses(peerId, dhtAddrs);
-        }
+        await primeAndAppend(dhtAddrs, 'DHT');
       } catch (err) {
         // DHT miss is the steady-state expectation for non-staked or
         // not-yet-discovered peers. Log at debug only.
@@ -219,10 +240,7 @@ export class PeerResolver {
     if (aborted()) return accumulated;
     try {
       const registryAddrs = await this.registry.lookup(peerId);
-      if (registryAddrs.length > 0) {
-        append(registryAddrs);
-        await this.network.addKnownAddresses(peerId, registryAddrs);
-      }
+      await primeAndAppend(registryAddrs, 'registry');
     } catch (err) {
       this.logger.debug?.(`registry lookup for ${peerId} failed: ${errMsg(err)}`);
     }
@@ -238,8 +256,7 @@ export class PeerResolver {
       });
       if (relay) {
         const circuitAddr = `${relay}/p2p-circuit/p2p/${peerId}`;
-        append([circuitAddr]);
-        await this.network.addKnownAddresses(peerId, [circuitAddr]);
+        await primeAndAppend([circuitAddr], 'agents-CG');
       }
     } catch (err) {
       this.logger.debug?.(`agents-CG lookup for ${peerId} failed: ${errMsg(err)}`);

--- a/packages/core/src/network/peer-resolver.ts
+++ b/packages/core/src/network/peer-resolver.ts
@@ -1,0 +1,190 @@
+/**
+ * PeerResolver — RFC 07 §3.
+ *
+ * Single in-process service every dial path consults before
+ * `network.dialProtocol(peerId, …)`. Defined resolution order
+ * (RFC 07 §3.1):
+ *
+ *   1. Active-connection cache — `network.getConnections(peerId)`.
+ *      If a live conn exists the caller doesn't need any new addresses;
+ *      we return its remote multiaddr and stop.
+ *   2. DHT lookup — `network.findPeer(peerId)` with a per-step timeout.
+ *   3. NetworkStateRegistry (RFC 04) — chain-anchored attestations.
+ *      Stub in v1; populated when RFC 04 Phase 2 lands.
+ *   4. Agent directory (agents-CG SPARQL) — preserves the chat-only
+ *      `Messenger.ensureCircuitRelayAddress` behaviour we're replacing.
+ *   5. Bootstrap seeds — last resort, only used when steps 1-4
+ *      produced nothing (cold-start situation).
+ *
+ * Each step that finds addresses calls `network.addKnownAddresses` so
+ * a subsequent `dialProtocol(peerId)` hits the transport's address
+ * book without re-resolving. Returned list is deduplicated, ordered
+ * freshest-first; callers should try in order and stop on first
+ * successful dial.
+ *
+ * v1 implements `recordDialSuccess` / `recordDialFailure` /
+ * `isHealthy` as stubs; address-health scoring is deferred to a
+ * follow-up RFC.
+ *
+ * See also: `dkgv10-spec/production_mainnet/07_IN_PROCESS_PEER_RESOLVER.md`.
+ */
+import type { Network, NodeIdentity, Address } from './network.js';
+import type { NetworkStateRegistry } from './network-state-registry.js';
+
+/**
+ * Minimal interface PeerResolver needs from the agents-CG. Defined in
+ * core so PeerResolver doesn't import from `packages/agent`. The
+ * existing `DiscoveryClient.findAgentByPeerId` shape is wrapped at
+ * the construction site (see `dkg-agent.ts`).
+ */
+export interface AgentDirectoryLookup {
+  /**
+   * Returns the relay multiaddr advertised for `peerId` in the agents
+   * context graph, or `null` if none is recorded. The resolver
+   * appends `/p2p-circuit/p2p/<peerId>` to construct the dialable form.
+   */
+  findRelayForPeer(peerId: NodeIdentity): Promise<Address | null>;
+}
+
+export interface PeerResolverDeps {
+  network: Network;
+  registry: NetworkStateRegistry;
+  agentDirectory: AgentDirectoryLookup;
+  bootstrapSeeds?: Address[];
+  /** Optional logger; defaults to silent except for serious errors. */
+  logger?: PeerResolverLogger;
+}
+
+export interface PeerResolverLogger {
+  warn(msg: string): void;
+  debug?(msg: string): void;
+}
+
+export interface ResolveOpts {
+  /**
+   * Skip the DHT lookup step. Used by callers that already know the
+   * peer isn't in the routing table — e.g. cold-start `/api/connect`.
+   */
+  skipDht?: boolean;
+  /**
+   * Per-step timeout in ms; default 5_000. Caller is responsible for
+   * the overall timeout budget across steps.
+   */
+  perStepTimeoutMs?: number;
+  /** AbortSignal to cancel in-flight resolution. */
+  signal?: AbortSignal;
+}
+
+const DEFAULT_PER_STEP_TIMEOUT_MS = 5_000;
+
+const SILENT_LOGGER: PeerResolverLogger = {
+  warn: () => undefined,
+};
+
+export class PeerResolver {
+  private readonly network: Network;
+  private readonly registry: NetworkStateRegistry;
+  private readonly agentDirectory: AgentDirectoryLookup;
+  private readonly bootstrapSeeds: Address[];
+  private readonly logger: PeerResolverLogger;
+
+  constructor(deps: PeerResolverDeps) {
+    this.network = deps.network;
+    this.registry = deps.registry;
+    this.agentDirectory = deps.agentDirectory;
+    this.bootstrapSeeds = deps.bootstrapSeeds ?? [];
+    this.logger = deps.logger ?? SILENT_LOGGER;
+  }
+
+  /**
+   * Resolve `peerId` to an ordered list of multiaddrs to attempt.
+   * See class doc for the resolution order; never throws — failures
+   * in one step proceed to the next.
+   */
+  async resolve(peerId: NodeIdentity, opts?: ResolveOpts): Promise<Address[]> {
+    const accumulated: Address[] = [];
+    const seen = new Set<string>();
+    const append = (addrs: Address[]): void => {
+      for (const a of addrs) {
+        if (a && !seen.has(a)) {
+          seen.add(a);
+          accumulated.push(a);
+        }
+      }
+    };
+
+    // Step 1: active-connection cache. Sub-millisecond. If a live
+    // connection exists the caller will reuse it via libp2p
+    // connection-deduplication; no need to walk further.
+    const live = this.network.getConnections(peerId);
+    if (live.length > 0) {
+      append(live.map((c) => c.remoteAddr.toString()));
+      return accumulated;
+    }
+
+    // Step 2: DHT lookup. Cheap for peers in the routing table;
+    // expensive for cold peers. Skipped if caller asked or transport
+    // doesn't support peer-routing.
+    if (!opts?.skipDht && typeof this.network.findPeer === 'function') {
+      try {
+        const dhtAddrs = await this.network.findPeer(peerId, {
+          signal: opts?.signal,
+          timeoutMs: opts?.perStepTimeoutMs ?? DEFAULT_PER_STEP_TIMEOUT_MS,
+        });
+        if (dhtAddrs.length > 0) {
+          append(dhtAddrs);
+          await this.network.addKnownAddresses(peerId, dhtAddrs);
+        }
+      } catch (err) {
+        // DHT miss is the steady-state expectation for non-staked or
+        // not-yet-discovered peers. Log at debug only.
+        this.logger.debug?.(`DHT lookup for ${peerId} failed: ${errMsg(err)}`);
+      }
+    }
+
+    // Step 3: NetworkStateRegistry (RFC 04). Stub in v1.
+    const registryAddrs = this.registry.lookup(peerId);
+    if (registryAddrs.length > 0) {
+      append(registryAddrs);
+      await this.network.addKnownAddresses(peerId, registryAddrs);
+    }
+
+    // Step 4: agent-directory SPARQL fallback. Replaces the chat-only
+    // Messenger.ensureCircuitRelayAddress path.
+    try {
+      const relay = await this.agentDirectory.findRelayForPeer(peerId);
+      if (relay) {
+        const circuitAddr = `${relay}/p2p-circuit/p2p/${peerId}`;
+        append([circuitAddr]);
+        await this.network.addKnownAddresses(peerId, [circuitAddr]);
+      }
+    } catch (err) {
+      this.logger.debug?.(`agents-CG lookup for ${peerId} failed: ${errMsg(err)}`);
+    }
+
+    // Step 5: bootstrap seeds. Only when 1-4 produced nothing — by
+    // then it's cold-start and the seeds may be the only way to
+    // bootstrap a DHT walk on the next attempt.
+    if (accumulated.length === 0 && this.bootstrapSeeds.length > 0) {
+      append(this.bootstrapSeeds);
+    }
+
+    return accumulated;
+  }
+
+  recordDialSuccess(_addr: Address): void {
+    // v1: no-op. Address-health scoring is a follow-up RFC.
+  }
+
+  recordDialFailure(addr: Address, reason: string): void {
+    this.logger.debug?.(`dial failure for ${addr}: ${reason}`);
+  }
+
+  isHealthy(_addr: Address): boolean {
+    return true;
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/core/src/network/peer-resolver.ts
+++ b/packages/core/src/network/peer-resolver.ts
@@ -13,14 +13,24 @@
  *      Stub in v1; populated when RFC 04 Phase 2 lands.
  *   4. Agent directory (agents-CG SPARQL) — preserves the chat-only
  *      `Messenger.ensureCircuitRelayAddress` behaviour we're replacing.
- *   5. Bootstrap seeds — last resort, only used when steps 1-4
- *      produced nothing (cold-start situation).
  *
  * Each step that finds addresses calls `network.addKnownAddresses` so
  * a subsequent `dialProtocol(peerId)` hits the transport's address
  * book without re-resolving. Returned list is deduplicated, ordered
  * freshest-first; callers should try in order and stop on first
- * successful dial.
+ * successful dial. Never throws — every step's failure is caught and
+ * the resolver falls through to the next.
+ *
+ * Note (Codex review feedback on PR #496): the previous draft included
+ * a step 5 that emitted configured `bootstrapPeers` as candidate
+ * addresses for the target peer. That was semantically wrong: a
+ * bootstrap seed multiaddr names some seed peer (typically a
+ * relay/curator), NOT the requested target. Returning it as a
+ * candidate would either fail loudly (libp2p rejects the
+ * `/p2p/<seed>`-vs-target peerId mismatch) or quietly mislead the
+ * caller. Bootstrap is a libp2p-startup concern (`bootstrap({ list })`
+ * peerDiscovery in `node.ts`), not a per-peer resolution concern;
+ * step 5 has been removed.
  *
  * v1 implements `recordDialSuccess` / `recordDialFailure` /
  * `isHealthy` as stubs; address-health scoring is deferred to a
@@ -50,7 +60,6 @@ export interface PeerResolverDeps {
   network: Network;
   registry: NetworkStateRegistry;
   agentDirectory: AgentDirectoryLookup;
-  bootstrapSeeds?: Address[];
   /** Optional logger; defaults to silent except for serious errors. */
   logger?: PeerResolverLogger;
 }
@@ -85,14 +94,12 @@ export class PeerResolver {
   private readonly network: Network;
   private readonly registry: NetworkStateRegistry;
   private readonly agentDirectory: AgentDirectoryLookup;
-  private readonly bootstrapSeeds: Address[];
   private readonly logger: PeerResolverLogger;
 
   constructor(deps: PeerResolverDeps) {
     this.network = deps.network;
     this.registry = deps.registry;
     this.agentDirectory = deps.agentDirectory;
-    this.bootstrapSeeds = deps.bootstrapSeeds ?? [];
     this.logger = deps.logger ?? SILENT_LOGGER;
   }
 
@@ -142,11 +149,19 @@ export class PeerResolver {
       }
     }
 
-    // Step 3: NetworkStateRegistry (RFC 04). Stub in v1.
-    const registryAddrs = this.registry.lookup(peerId);
-    if (registryAddrs.length > 0) {
-      append(registryAddrs);
-      await this.network.addKnownAddresses(peerId, registryAddrs);
+    // Step 3: NetworkStateRegistry (RFC 04). Stub in v1; the real
+    // implementation can hit a database / mutex / SWM channel, so the
+    // try/catch is the contract that protects callers from a transient
+    // registry hiccup aborting the whole resolve() (and silently
+    // skipping steps 4+).
+    try {
+      const registryAddrs = this.registry.lookup(peerId);
+      if (registryAddrs.length > 0) {
+        append(registryAddrs);
+        await this.network.addKnownAddresses(peerId, registryAddrs);
+      }
+    } catch (err) {
+      this.logger.debug?.(`registry lookup for ${peerId} failed: ${errMsg(err)}`);
     }
 
     // Step 4: agent-directory SPARQL fallback. Replaces the chat-only
@@ -160,13 +175,6 @@ export class PeerResolver {
       }
     } catch (err) {
       this.logger.debug?.(`agents-CG lookup for ${peerId} failed: ${errMsg(err)}`);
-    }
-
-    // Step 5: bootstrap seeds. Only when 1-4 produced nothing — by
-    // then it's cold-start and the seeds may be the only way to
-    // bootstrap a DHT walk on the next attempt.
-    if (accumulated.length === 0 && this.bootstrapSeeds.length > 0) {
-      append(this.bootstrapSeeds);
     }
 
     return accumulated;

--- a/packages/core/test/peer-resolver.test.ts
+++ b/packages/core/test/peer-resolver.test.ts
@@ -14,16 +14,21 @@ const PEER_B = '12D3KooWB' + 'b'.repeat(43);
 const RELAY_ADDR =
   '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
 
+type FindPeerImpl = (
+  peerId: NodeIdentity,
+  opts?: { signal?: AbortSignal; timeoutMs?: number },
+) => Promise<Address[]>;
+
 interface MockNetwork extends Network {
   __conns: Map<NodeIdentity, Array<{ remoteAddr: { toString(): string } }>>;
   __addedAddresses: Array<{ peerId: NodeIdentity; addrs: Address[] }>;
-  __findPeerImpl: ((peerId: NodeIdentity) => Promise<Address[]>) | null;
+  __findPeerImpl: FindPeerImpl | null;
 }
 
 function makeNetwork(): MockNetwork {
   const conns = new Map<NodeIdentity, Array<{ remoteAddr: { toString(): string } }>>();
   const added: Array<{ peerId: NodeIdentity; addrs: Address[] }> = [];
-  let findPeerImpl: ((peerId: NodeIdentity) => Promise<Address[]>) | null = null;
+  let findPeerImpl: FindPeerImpl | null = null;
   const net: Partial<MockNetwork> = {
     localId: PEER_A,
     localAddresses: [],
@@ -41,9 +46,9 @@ function makeNetwork(): MockNetwork {
     async addKnownAddresses(peerId: NodeIdentity, addrs: Address[]) {
       added.push({ peerId, addrs });
     },
-    async findPeer(peerId: NodeIdentity) {
+    async findPeer(peerId: NodeIdentity, opts?: { signal?: AbortSignal; timeoutMs?: number }) {
       if (!findPeerImpl) throw new Error('findPeer not configured');
-      return findPeerImpl(peerId);
+      return findPeerImpl(peerId, opts);
     },
   };
   Object.defineProperty(net, '__conns', { value: conns, enumerable: false });
@@ -238,6 +243,116 @@ describe('PeerResolver', () => {
 
     // Falls through to step 4 cleanly.
     expect(out).toEqual([`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`]);
+  });
+
+  // Codex feedback PR #499 round 3: outer signal must short-circuit
+  // every resolver step (not just step 2 / DHT).
+
+  it('aborts before any step runs when signal is already aborted', async () => {
+    let stepsRan = 0;
+    const countingNet = makeNetwork();
+    const origGetConnections = countingNet.getConnections;
+    countingNet.getConnections = (pid) => {
+      stepsRan++;
+      return origGetConnections(pid);
+    };
+    countingNet.__findPeerImpl = async () => {
+      stepsRan++;
+      return ['/ip4/1.2.3.4/tcp/9090'];
+    };
+    const countingRegistry: NetworkStateRegistry = {
+      lookup: () => {
+        stepsRan++;
+        return [];
+      },
+    };
+    const countingDir: AgentDirectoryLookup = {
+      findRelayForPeer: async () => {
+        stepsRan++;
+        return null;
+      },
+    };
+
+    const resolver = new PeerResolver({
+      network: countingNet,
+      registry: countingRegistry,
+      agentDirectory: countingDir,
+    });
+
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const out = await resolver.resolve(PEER_B, { signal: ctrl.signal });
+
+    expect(out).toEqual([]);
+    expect(stepsRan).toBe(0);
+  });
+
+  it('skips later steps once signal is aborted mid-resolve', async () => {
+    let registryCalled = false;
+    let directoryCalled = false;
+    const ctrl = new AbortController();
+
+    net.__findPeerImpl = async () => {
+      ctrl.abort();
+      return [];
+    };
+    const trackingRegistry: NetworkStateRegistry = {
+      lookup: () => {
+        registryCalled = true;
+        return [];
+      },
+    };
+    const trackingDir: AgentDirectoryLookup = {
+      findRelayForPeer: async () => {
+        directoryCalled = true;
+        return null;
+      },
+    };
+
+    const resolver = new PeerResolver({
+      network: net,
+      registry: trackingRegistry,
+      agentDirectory: trackingDir,
+    });
+    await resolver.resolve(PEER_B, { signal: ctrl.signal });
+
+    expect(registryCalled).toBe(false);
+    expect(directoryCalled).toBe(false);
+  });
+
+  // Codex feedback PR #496 round 3: when both signal and
+  // perStepTimeoutMs are passed, both must be honoured. Pre-fix,
+  // signal silently won and the per-step cap was lost.
+
+  it('composes step-local signal honouring both perStepTimeoutMs and outer signal', async () => {
+    const seenSignals: AbortSignal[] = [];
+    const seenTimeouts: number[] = [];
+    net.__findPeerImpl = async (_pid, opts) => {
+      if (opts?.signal) seenSignals.push(opts.signal);
+      if (opts?.timeoutMs != null) seenTimeouts.push(opts.timeoutMs);
+      return [];
+    };
+
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(),
+    });
+    const ctrl = new AbortController();
+    await resolver.resolve(PEER_B, {
+      signal: ctrl.signal,
+      perStepTimeoutMs: 1234,
+    });
+
+    expect(seenTimeouts).toEqual([1234]);
+    expect(seenSignals).toHaveLength(1);
+    // Step-local signal IS NOT the outer signal (it's a composition).
+    expect(seenSignals[0]).not.toBe(ctrl.signal);
+    expect(seenSignals[0].aborted).toBe(false);
+
+    // Aborting the outer should propagate.
+    ctrl.abort();
+    expect(seenSignals[0].aborted).toBe(true);
   });
 
   it('returns empty array when nothing resolves', async () => {

--- a/packages/core/test/peer-resolver.test.ts
+++ b/packages/core/test/peer-resolver.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  PeerResolver,
+  StubNetworkStateRegistry,
+  type Network,
+  type NetworkStateRegistry,
+  type AgentDirectoryLookup,
+  type Address,
+  type NodeIdentity,
+} from '../src/network/index.js';
+
+const PEER_A = '12D3KooWA' + 'a'.repeat(43);
+const PEER_B = '12D3KooWB' + 'b'.repeat(43);
+const RELAY_ADDR =
+  '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+const BOOTSTRAP =
+  '/dns4/seed.example.com/tcp/9090/p2p/12D3KooWSeedSeedSeedSeedSeedSeedSeedSeedSeedSeed';
+
+interface MockNetwork extends Network {
+  __conns: Map<NodeIdentity, Array<{ remoteAddr: { toString(): string } }>>;
+  __addedAddresses: Array<{ peerId: NodeIdentity; addrs: Address[] }>;
+  __findPeerImpl: ((peerId: NodeIdentity) => Promise<Address[]>) | null;
+}
+
+function makeNetwork(): MockNetwork {
+  const conns = new Map<NodeIdentity, Array<{ remoteAddr: { toString(): string } }>>();
+  const added: Array<{ peerId: NodeIdentity; addrs: Address[] }> = [];
+  let findPeerImpl: ((peerId: NodeIdentity) => Promise<Address[]>) | null = null;
+  const net: Partial<MockNetwork> = {
+    localId: PEER_A,
+    localAddresses: [],
+    isStarted: true,
+    async start() {},
+    async stop() {},
+    async dialProtocol() {
+      throw new Error('not used in resolver tests');
+    },
+    async handle() {},
+    async unhandle() {},
+    getConnections(peerId: NodeIdentity) {
+      return (conns.get(peerId) ?? []) as never;
+    },
+    async addKnownAddresses(peerId: NodeIdentity, addrs: Address[]) {
+      added.push({ peerId, addrs });
+    },
+    async findPeer(peerId: NodeIdentity) {
+      if (!findPeerImpl) throw new Error('findPeer not configured');
+      return findPeerImpl(peerId);
+    },
+  };
+  Object.defineProperty(net, '__conns', { value: conns, enumerable: false });
+  Object.defineProperty(net, '__addedAddresses', { value: added, enumerable: false });
+  Object.defineProperty(net, '__findPeerImpl', {
+    get: () => findPeerImpl,
+    set: (v) => {
+      findPeerImpl = v;
+    },
+    enumerable: false,
+  });
+  return net as MockNetwork;
+}
+
+function makeAgentDir(
+  fn?: (peerId: NodeIdentity) => Promise<Address | null>,
+): AgentDirectoryLookup {
+  return { findRelayForPeer: fn ?? (async () => null) };
+}
+
+describe('PeerResolver', () => {
+  let net: MockNetwork;
+  let registry: NetworkStateRegistry;
+
+  beforeEach(() => {
+    net = makeNetwork();
+    registry = new StubNetworkStateRegistry();
+  });
+
+  it('step 1: returns live-conn remoteAddr and stops', async () => {
+    net.__conns.set(PEER_B, [{ remoteAddr: { toString: () => '/ip4/10.0.0.1/tcp/9090' } }]);
+    const findPeerSpy = vi.fn();
+    net.__findPeerImpl = findPeerSpy;
+    const dirSpy = vi.fn(async () => RELAY_ADDR);
+
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(dirSpy),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toEqual(['/ip4/10.0.0.1/tcp/9090']);
+    expect(findPeerSpy).not.toHaveBeenCalled();
+    expect(dirSpy).not.toHaveBeenCalled();
+    expect(net.__addedAddresses).toEqual([]);
+  });
+
+  it('step 2: walks DHT when no live conn, merges into peerStore', async () => {
+    net.__findPeerImpl = async () => ['/ip4/1.2.3.4/tcp/9090'];
+
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toContain('/ip4/1.2.3.4/tcp/9090');
+    expect(net.__addedAddresses).toContainEqual({
+      peerId: PEER_B,
+      addrs: ['/ip4/1.2.3.4/tcp/9090'],
+    });
+  });
+
+  it('step 2: opts.skipDht bypasses findPeer entirely', async () => {
+    const findPeerSpy = vi.fn();
+    net.__findPeerImpl = findPeerSpy;
+
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(),
+    });
+    await resolver.resolve(PEER_B, { skipDht: true });
+
+    expect(findPeerSpy).not.toHaveBeenCalled();
+  });
+
+  it('step 2: DHT failures are swallowed and resolution proceeds', async () => {
+    net.__findPeerImpl = async () => {
+      throw new Error('dht boom');
+    };
+    const dirSpy = vi.fn(async () => RELAY_ADDR);
+
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(dirSpy),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(dirSpy).toHaveBeenCalledWith(PEER_B);
+    expect(out).toContain(`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`);
+  });
+
+  it('step 3: registry hits are appended after DHT', async () => {
+    net.__findPeerImpl = async () => ['/ip4/1.2.3.4/tcp/9090'];
+    const customRegistry: NetworkStateRegistry = {
+      lookup: () => ['/ip4/5.6.7.8/tcp/9090'],
+    };
+
+    const resolver = new PeerResolver({
+      network: net,
+      registry: customRegistry,
+      agentDirectory: makeAgentDir(),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toEqual(['/ip4/1.2.3.4/tcp/9090', '/ip4/5.6.7.8/tcp/9090']);
+  });
+
+  it('step 4: agents-CG relay is wrapped as /p2p-circuit/p2p/<peerId>', async () => {
+    net.__findPeerImpl = async () => [];
+    const dirSpy = vi.fn(async () => RELAY_ADDR);
+
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(dirSpy),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toEqual([`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`]);
+    expect(net.__addedAddresses).toContainEqual({
+      peerId: PEER_B,
+      addrs: [`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`],
+    });
+  });
+
+  it('step 4: agents-CG returning null is fine, falls through to bootstrap', async () => {
+    net.__findPeerImpl = async () => [];
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(async () => null),
+      bootstrapSeeds: [BOOTSTRAP],
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toEqual([BOOTSTRAP]);
+  });
+
+  it('step 4: agents-CG throwing does not abort resolution', async () => {
+    net.__findPeerImpl = async () => [];
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: {
+        findRelayForPeer: async () => {
+          throw new Error('sparql boom');
+        },
+      },
+      bootstrapSeeds: [BOOTSTRAP],
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toEqual([BOOTSTRAP]);
+  });
+
+  it('step 5: bootstrap seeds only used when previous steps produced nothing', async () => {
+    net.__findPeerImpl = async () => ['/ip4/1.2.3.4/tcp/9090'];
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(),
+      bootstrapSeeds: [BOOTSTRAP],
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toEqual(['/ip4/1.2.3.4/tcp/9090']);
+    expect(out).not.toContain(BOOTSTRAP);
+  });
+
+  it('returns empty array when nothing resolves and no seeds configured', async () => {
+    net.__findPeerImpl = async () => [];
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toEqual([]);
+  });
+
+  it('deduplicates addresses across steps', async () => {
+    const dup = '/ip4/1.2.3.4/tcp/9090';
+    net.__findPeerImpl = async () => [dup];
+    const customRegistry: NetworkStateRegistry = {
+      lookup: () => [dup, '/ip4/9.9.9.9/tcp/9090'],
+    };
+
+    const resolver = new PeerResolver({
+      network: net,
+      registry: customRegistry,
+      agentDirectory: makeAgentDir(),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toEqual([dup, '/ip4/9.9.9.9/tcp/9090']);
+  });
+
+  it('skips DHT step when network does not implement findPeer', async () => {
+    const noRoutingNet = { ...net, findPeer: undefined } as Network;
+    const resolver = new PeerResolver({
+      network: noRoutingNet,
+      registry,
+      agentDirectory: makeAgentDir(async () => RELAY_ADDR),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    expect(out).toEqual([`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`]);
+  });
+
+  it('recordDialFailure / isHealthy / recordDialSuccess are stubs that do not throw', () => {
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(),
+    });
+    expect(() => resolver.recordDialSuccess('/ip4/1.2.3.4/tcp/9090')).not.toThrow();
+    expect(() => resolver.recordDialFailure('/ip4/1.2.3.4/tcp/9090', 'ETIMEDOUT')).not.toThrow();
+    expect(resolver.isHealthy('/ip4/1.2.3.4/tcp/9090')).toBe(true);
+  });
+});

--- a/packages/core/test/peer-resolver.test.ts
+++ b/packages/core/test/peer-resolver.test.ts
@@ -202,6 +202,26 @@ describe('PeerResolver', () => {
     expect(out).toEqual(['/ip4/1.2.3.4/tcp/9090']);
   });
 
+  it('step 1 (Codex PR #496 r2): live-conn lookup throwing does not abort resolution', async () => {
+    // Simulates `network.getConnections(peerId)` throwing on a malformed
+    // peerId — which LibP2PNetwork does today by calling peerIdFromString.
+    const throwingNet: typeof net = makeNetwork();
+    throwingNet.getConnections = () => {
+      throw new Error('peerIdFromString boom');
+    };
+    throwingNet.__findPeerImpl = async () => ['/ip4/1.2.3.4/tcp/9090'];
+
+    const resolver = new PeerResolver({
+      network: throwingNet,
+      registry,
+      agentDirectory: makeAgentDir(),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    // Falls through cleanly to step 2.
+    expect(out).toEqual(['/ip4/1.2.3.4/tcp/9090']);
+  });
+
   it('step 3 (Codex PR #496 feedback): registry throwing does not abort resolution', async () => {
     net.__findPeerImpl = async () => [];
     const throwingRegistry: NetworkStateRegistry = {

--- a/packages/core/test/peer-resolver.test.ts
+++ b/packages/core/test/peer-resolver.test.ts
@@ -141,14 +141,14 @@ describe('PeerResolver', () => {
     });
     const out = await resolver.resolve(PEER_B);
 
-    expect(dirSpy).toHaveBeenCalledWith(PEER_B);
+    expect(dirSpy).toHaveBeenCalledWith(PEER_B, expect.any(Object));
     expect(out).toContain(`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`);
   });
 
   it('step 3: registry hits are appended after DHT', async () => {
     net.__findPeerImpl = async () => ['/ip4/1.2.3.4/tcp/9090'];
     const customRegistry: NetworkStateRegistry = {
-      lookup: () => ['/ip4/5.6.7.8/tcp/9090'],
+      lookup: async () => ['/ip4/5.6.7.8/tcp/9090'],
     };
 
     const resolver = new PeerResolver({
@@ -230,7 +230,7 @@ describe('PeerResolver', () => {
   it('step 3 (Codex PR #496 feedback): registry throwing does not abort resolution', async () => {
     net.__findPeerImpl = async () => [];
     const throwingRegistry: NetworkStateRegistry = {
-      lookup: () => {
+      lookup: async () => {
         throw new Error('registry boom');
       },
     };
@@ -261,7 +261,7 @@ describe('PeerResolver', () => {
       return ['/ip4/1.2.3.4/tcp/9090'];
     };
     const countingRegistry: NetworkStateRegistry = {
-      lookup: () => {
+      lookup: async () => {
         stepsRan++;
         return [];
       },
@@ -297,7 +297,7 @@ describe('PeerResolver', () => {
       return [];
     };
     const trackingRegistry: NetworkStateRegistry = {
-      lookup: () => {
+      lookup: async () => {
         registryCalled = true;
         return [];
       },
@@ -355,6 +355,27 @@ describe('PeerResolver', () => {
     expect(seenSignals[0].aborted).toBe(true);
   });
 
+  it('step 4 (Codex PR #496 round 4): forwards opts.signal to agentDirectory.findRelayForPeer', async () => {
+    net.__findPeerImpl = async () => [];
+    const ctrl = new AbortController();
+    let receivedSignal: AbortSignal | undefined;
+    const signalingDir: AgentDirectoryLookup = {
+      findRelayForPeer: async (_pid, opts) => {
+        receivedSignal = opts?.signal;
+        return null;
+      },
+    };
+
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: signalingDir,
+    });
+    await resolver.resolve(PEER_B, { signal: ctrl.signal });
+
+    expect(receivedSignal).toBe(ctrl.signal);
+  });
+
   it('returns empty array when nothing resolves', async () => {
     net.__findPeerImpl = async () => [];
     const resolver = new PeerResolver({
@@ -371,7 +392,7 @@ describe('PeerResolver', () => {
     const dup = '/ip4/1.2.3.4/tcp/9090';
     net.__findPeerImpl = async () => [dup];
     const customRegistry: NetworkStateRegistry = {
-      lookup: () => [dup, '/ip4/9.9.9.9/tcp/9090'],
+      lookup: async () => [dup, '/ip4/9.9.9.9/tcp/9090'],
     };
 
     const resolver = new PeerResolver({

--- a/packages/core/test/peer-resolver.test.ts
+++ b/packages/core/test/peer-resolver.test.ts
@@ -13,8 +13,6 @@ const PEER_A = '12D3KooWA' + 'a'.repeat(43);
 const PEER_B = '12D3KooWB' + 'b'.repeat(43);
 const RELAY_ADDR =
   '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
-const BOOTSTRAP =
-  '/dns4/seed.example.com/tcp/9090/p2p/12D3KooWSeedSeedSeedSeedSeedSeedSeedSeedSeedSeed';
 
 interface MockNetwork extends Network {
   __conns: Map<NodeIdentity, Array<{ remoteAddr: { toString(): string } }>>;
@@ -176,21 +174,20 @@ describe('PeerResolver', () => {
     });
   });
 
-  it('step 4: agents-CG returning null is fine, falls through to bootstrap', async () => {
+  it('step 4: agents-CG returning null is fine, returns empty', async () => {
     net.__findPeerImpl = async () => [];
     const resolver = new PeerResolver({
       network: net,
       registry,
       agentDirectory: makeAgentDir(async () => null),
-      bootstrapSeeds: [BOOTSTRAP],
     });
     const out = await resolver.resolve(PEER_B);
 
-    expect(out).toEqual([BOOTSTRAP]);
+    expect(out).toEqual([]);
   });
 
   it('step 4: agents-CG throwing does not abort resolution', async () => {
-    net.__findPeerImpl = async () => [];
+    net.__findPeerImpl = async () => ['/ip4/1.2.3.4/tcp/9090'];
     const resolver = new PeerResolver({
       network: net,
       registry,
@@ -199,28 +196,31 @@ describe('PeerResolver', () => {
           throw new Error('sparql boom');
         },
       },
-      bootstrapSeeds: [BOOTSTRAP],
-    });
-    const out = await resolver.resolve(PEER_B);
-
-    expect(out).toEqual([BOOTSTRAP]);
-  });
-
-  it('step 5: bootstrap seeds only used when previous steps produced nothing', async () => {
-    net.__findPeerImpl = async () => ['/ip4/1.2.3.4/tcp/9090'];
-    const resolver = new PeerResolver({
-      network: net,
-      registry,
-      agentDirectory: makeAgentDir(),
-      bootstrapSeeds: [BOOTSTRAP],
     });
     const out = await resolver.resolve(PEER_B);
 
     expect(out).toEqual(['/ip4/1.2.3.4/tcp/9090']);
-    expect(out).not.toContain(BOOTSTRAP);
   });
 
-  it('returns empty array when nothing resolves and no seeds configured', async () => {
+  it('step 3 (Codex PR #496 feedback): registry throwing does not abort resolution', async () => {
+    net.__findPeerImpl = async () => [];
+    const throwingRegistry: NetworkStateRegistry = {
+      lookup: () => {
+        throw new Error('registry boom');
+      },
+    };
+    const resolver = new PeerResolver({
+      network: net,
+      registry: throwingRegistry,
+      agentDirectory: makeAgentDir(async () => RELAY_ADDR),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    // Falls through to step 4 cleanly.
+    expect(out).toEqual([`${RELAY_ADDR}/p2p-circuit/p2p/${PEER_B}`]);
+  });
+
+  it('returns empty array when nothing resolves', async () => {
     net.__findPeerImpl = async () => [];
     const resolver = new PeerResolver({
       network: net,

--- a/packages/core/test/peer-resolver.test.ts
+++ b/packages/core/test/peer-resolver.test.ts
@@ -207,6 +207,34 @@ describe('PeerResolver', () => {
     expect(out).toEqual(['/ip4/1.2.3.4/tcp/9090']);
   });
 
+  it('Codex PR #496 round 6: addr is omitted from result when peerStore merge fails', async () => {
+    // Regression guard: the resolver returns Address[] as a contract
+    // that "the peerStore is primed for these addresses". Earlier
+    // rounds appended addresses BEFORE awaiting addKnownAddresses, so
+    // a peerStore merge failure left the caller seeing a non-empty
+    // resolution while the bare peer-id dial silently missed every
+    // address. Fix: only append after the merge succeeds; on merge
+    // failure the addr stays out of the returned list AND resolution
+    // continues into the next step.
+    const failingNet = makeNetwork();
+    failingNet.__findPeerImpl = async () => ['/ip4/1.2.3.4/tcp/9090'];
+    failingNet.addKnownAddresses = async () => {
+      throw new Error('peerStore merge boom');
+    };
+
+    const resolver = new PeerResolver({
+      network: failingNet,
+      registry,
+      agentDirectory: makeAgentDir(async () => RELAY_ADDR),
+    });
+    const out = await resolver.resolve(PEER_B);
+
+    // DHT merge failed → DHT addr is NOT in the result.
+    // Step 4's relay merge ALSO failed (same stub) → relay addr also out.
+    // Resolver returns []; caller knows nothing was actually primed.
+    expect(out).toEqual([]);
+  });
+
   it('step 1 (Codex PR #496 r2): live-conn lookup throwing does not abort resolution', async () => {
     // Simulates `network.getConnections(peerId)` throwing on a malformed
     // peerId — which LibP2PNetwork does today by calling peerIdFromString.


### PR DESCRIPTION
## Summary

Second of 5 stacked PRs implementing [RFC 07 — In-Process Peer Resolver](../blob/feat/rfc07-pr2-peer-resolver/dkgv10-spec/production_mainnet/07_IN_PROCESS_PEER_RESOLVER.md). Builds on [#494](../pull/494) (PR-1).

This PR introduces the single in-process service every dial path will consult before \`dialProtocol\`, and migrates \`Messenger\` as the first consumer.

## What lands

**New (\`packages/core\`):**

- \`src/network/network-state-registry.ts\` — \`NetworkStateRegistry\` interface + \`StubNetworkStateRegistry\`. Returns empty arrays until RFC 04 Phase 2 lands; the interface is fixed so the future PR can swap the implementation without touching consumers.
- \`src/network/peer-resolver.ts\` — \`PeerResolver\` implementing RFC 07 §3.1 resolution order:
  1. Active-connection cache (\`network.getConnections\`)
  2. DHT lookup (\`network.findPeer\` with per-step timeout)
  3. \`NetworkStateRegistry\` (stub in v1)
  4. \`AgentDirectoryLookup\` (agents-CG SPARQL fallback; minimal interface defined here so \`packages/core\` has no dependency on \`packages/agent\`)
  5. Bootstrap seeds (only when 1-4 produced nothing)

  Each step that finds addresses calls \`network.addKnownAddresses\` so the transport's address book is primed before the caller dials. Returns deduplicated, freshest-first; never throws.
- \`test/peer-resolver.test.ts\` — 13 cases covering the resolution order, failure tolerance, dedup, \`skipDht\`, missing \`findPeer\`, and the stubbed health-scoring surface.

**Migrated (\`packages/agent\`):**

- \`src/p2p/messenger.ts\` — drops \`Libp2pLike\` + \`DiscoveryClient\` deps; consumes \`PeerResolver\` instead. The chat-only inline patching path (\`ensureCircuitRelayAddress\`) is now subsumed by step 4 of the resolver — same SPARQL lookup, same \`/p2p-circuit/p2p/<peerId>\` shape, but available to every dial path that consults the resolver.
- \`test/p2p-messenger.test.ts\` — slimmed to verify the structural property (resolver fires before \`router.send\`) and timeout forwarding; the resolution-order cases moved to \`peer-resolver.test.ts\` where they belong.
- \`src/dkg-agent.ts\` — wires \`LibP2PNetwork\` + \`PeerResolver\` + \`StubNetworkStateRegistry\`, exposes \`peerResolver\` as a public field so PR-3 / PR-4 can reuse the same instance.

## What this does NOT do (intentional)

- Does NOT migrate \`ProtocolRouter.send\` — PR-3.
- Does NOT migrate \`/api/connect\` — PR-4.
- Does NOT add the CI grep gate — PR-4.
- Does NOT wire the registry to chain data — that's RFC 07 Phase 4 (after RFC 04 Phase 2 lands; ~100 LoC at that point).
- Does NOT implement address-health scoring — \`recordDialSuccess\` / \`recordDialFailure\` / \`isHealthy\` are stubs. Deferred to a follow-up RFC.

## Stack

\`\`\`
PR-1 (#494) — Network interface + LibP2PNetwork wrapper
PR-2 (this) — PeerResolver skeleton + Messenger migration       ← here
PR-3        — Migrate ProtocolRouter to PeerResolver
PR-4        — Migrate /api/connect + add CI grep gate
PR-5        — Lock in gossipsub msgIdFn (cross-backend constant)
\`\`\`

Base branch: \`feat/rfc07-pr1-network-iface\`. When PR-1 merges, this rebases onto its merge target cleanly.

## Test plan

- [x] \`pnpm --filter @origintrail-official/dkg-core test\` — 648/648 (+13 new)
- [x] \`pnpm --filter @origintrail-official/dkg-agent test\` — 429/429 (Messenger tests rewritten, all green)
- [x] \`pnpm -r build\` — clean across all 14 packages
- [ ] CI green

Made with [Cursor](https://cursor.com)