### PR TITLE
fix: lazily resolve context graph metadata

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -5239,10 +5239,11 @@ export class DKGAgent {
    * When localOnly is false (default), replicates via GossipSub shared memory topic.
    * When localOnly is true, stores locally without broadcasting — use for private data.
    */
-  async share(contextGraphId: string, quads: Quad[], opts?: { localOnly?: boolean; operationCtx?: OperationContext; subGraphName?: string }): Promise<{ shareOperationId: string }> {
+  async share(contextGraphId: string, quads: Quad[], opts?: { localOnly?: boolean; operationCtx?: OperationContext; subGraphName?: string; callerAgentAddress?: string }): Promise<{ shareOperationId: string }> {
     const ctx = opts?.operationCtx ?? createOperationContext('share');
     const sgLabel = opts?.subGraphName ? ` (sub-graph: ${opts.subGraphName})` : '';
     this.log.info(ctx, `Sharing ${quads.length} quads to SWM for context graph ${contextGraphId}${sgLabel}${opts?.localOnly ? ' (local-only)' : ''}`);
+    const shouldCreateImplicitContextGraph = await this.shouldCreateImplicitSharedMemoryContextGraph(contextGraphId);
     const gossipSigner = opts?.localOnly ? null : await this.resolveWorkspaceGossipSigningAgent(contextGraphId);
     const { shareOperationId, message } = await this.publisher.writeToWorkspace(contextGraphId, quads, {
       publisherPeerId: this.node.peerId.toString(),
@@ -5251,6 +5252,11 @@ export class DKGAgent {
       localOnly: opts?.localOnly,
       senderAgentAddress: gossipSigner?.agentAddress,
     });
+    if (shouldCreateImplicitContextGraph) {
+      await this.ensureImplicitSharedMemoryContextGraph(contextGraphId, {
+        callerAgentAddress: opts?.callerAgentAddress,
+      });
+    }
     if (!opts?.localOnly) {
       await this.publishWorkspaceGossip(contextGraphId, message, ctx, gossipSigner);
     }
@@ -5266,11 +5272,12 @@ export class DKGAgent {
     contextGraphId: string,
     quads: Quad[],
     conditions: CASCondition[],
-    opts?: { localOnly?: boolean; operationCtx?: OperationContext; subGraphName?: string },
+    opts?: { localOnly?: boolean; operationCtx?: OperationContext; subGraphName?: string; callerAgentAddress?: string },
   ): Promise<{ shareOperationId: string }> {
     const ctx = opts?.operationCtx ?? createOperationContext('share');
     const sgLabel = opts?.subGraphName ? ` (sub-graph: ${opts.subGraphName})` : '';
     this.log.info(ctx, `CAS write: ${quads.length} quads, ${conditions.length} conditions for ${contextGraphId}${sgLabel}`);
+    const shouldCreateImplicitContextGraph = await this.shouldCreateImplicitSharedMemoryContextGraph(contextGraphId);
     const gossipSigner = opts?.localOnly ? null : await this.resolveWorkspaceGossipSigningAgent(contextGraphId);
     const { shareOperationId, message } = await this.publisher.writeConditionalToWorkspace(contextGraphId, quads, {
       publisherPeerId: this.node.peerId.toString(),
@@ -5280,10 +5287,113 @@ export class DKGAgent {
       localOnly: opts?.localOnly,
       senderAgentAddress: gossipSigner?.agentAddress,
     });
+    if (shouldCreateImplicitContextGraph) {
+      await this.ensureImplicitSharedMemoryContextGraph(contextGraphId, {
+        callerAgentAddress: opts?.callerAgentAddress,
+      });
+    }
     if (!opts?.localOnly) {
       await this.publishWorkspaceGossip(contextGraphId, message, ctx, gossipSigner);
     }
     return { shareOperationId };
+  }
+
+  private async hasAuthoritativeContextGraphDefinition(contextGraphId: string): Promise<boolean> {
+    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const result = await this.store.query(`
+      ASK WHERE {
+        {
+          GRAPH <${ontologyGraph}> {
+            <${contextGraphUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+          }
+        }
+        UNION
+        {
+          GRAPH <${cgMetaGraph}> {
+            <${contextGraphUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+          }
+        }
+      }
+    `);
+    return result.type === 'boolean' && result.value === true;
+  }
+
+  private async shouldCreateImplicitSharedMemoryContextGraph(contextGraphId: string): Promise<boolean> {
+    if (await this.hasAuthoritativeContextGraphDefinition(contextGraphId)) {
+      return false;
+    }
+
+    if ((await this.getContextGraphAgentGateAddresses(contextGraphId)) !== null) {
+      return false;
+    }
+
+    const existingSub = this.subscribedContextGraphs.get(contextGraphId);
+    if (existingSub?.metaSynced === false) {
+      throw new Error(
+        `Context graph "${contextGraphId}" is awaiting metadata sync; refusing to infer public metadata from an SWM write`,
+      );
+    }
+
+    return true;
+  }
+
+  private async ensureImplicitSharedMemoryContextGraph(
+    contextGraphId: string,
+    opts: { callerAgentAddress?: string } = {},
+  ): Promise<void> {
+    if (!(await this.shouldCreateImplicitSharedMemoryContextGraph(contextGraphId))) {
+      return;
+    }
+
+    const gm = new GraphManager(this.store);
+    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const now = new Date().toISOString();
+    const existingSub = this.subscribedContextGraphs.get(contextGraphId);
+    const name = existingSub?.name ?? contextGraphId;
+    const curatorAgentAddress = opts.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId;
+    const quads: Quad[] = [
+      { subject: contextGraphUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: contextGraphUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: `"${escapeSparqlLiteral(name)}"`, graph: ontologyGraph },
+      { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: `did:dkg:agent:${this.peerId}`, graph: ontologyGraph },
+      { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATED_AT, object: `"${now}"`, graph: ontologyGraph },
+      { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_GOSSIP_TOPIC, object: `"${contextGraphPublishTopic(contextGraphId)}"`, graph: ontologyGraph },
+      { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REPLICATION_POLICY, object: '"full"', graph: ontologyGraph },
+      { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+      { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: '"unregistered"', graph: cgMetaGraph },
+      { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${curatorAgentAddress}`, graph: cgMetaGraph },
+    ];
+
+    await this.store.insert(quads);
+    await gm.ensureContextGraph(contextGraphId);
+    await this.store.flush?.();
+    this.subscribeToContextGraph(contextGraphId);
+    this.setContextGraphSubscription(contextGraphId, {
+      ...existingSub,
+      name,
+      subscribed: true,
+      synced: true,
+      metaSynced: true,
+    });
+
+    if (curatorAgentAddress) {
+      this.upsertContextGraphMember({
+        contextGraphId,
+        principalType: 'agent',
+        principalId: curatorAgentAddress,
+        role: 'curator',
+        status: 'active',
+        source: 'implicit-swm-write',
+      });
+    }
+
+    this.log.info(
+      createOperationContext('share'),
+      `Implicitly registered public context graph "${contextGraphId}" from first SWM write`,
+    );
   }
 
   /**

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -141,6 +141,129 @@ describe('ensureContextGraphLocal', () => {
   }, 15000);
 });
 
+describe('implicit SWM context graph metadata', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('direct share to a fresh context graph registers useful public metadata', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const contextGraphId = 'lazy-swm-direct';
+    const caller = new ethers.Wallet(HARDHAT_KEYS.DEPLOYER).address;
+
+    await agent.share(contextGraphId, [
+      {
+        subject: 'urn:lazy-swm-direct:root',
+        predicate: 'http://schema.org/name',
+        object: '"Lazy SWM Direct"',
+        graph: '',
+      },
+    ], { callerAgentAddress: caller });
+
+    const contextGraphs = await agent.listContextGraphs({ callerAgentAddress: caller });
+    const entry = contextGraphs.find(p => p.id === contextGraphId);
+    expect(entry).toBeDefined();
+    expect(entry).toMatchObject({
+      id: contextGraphId,
+      uri: contextGraphDataGraphUri(contextGraphId),
+      name: contextGraphId,
+      creator: `did:dkg:agent:${agent.peerId}`,
+      curator: `did:dkg:agent:${caller}`,
+      accessPolicy: 'public',
+      isSystem: false,
+      subscribed: true,
+      synced: true,
+      callerInvolved: true,
+    });
+    expect(Date.parse(entry!.createdAt!)).not.toBeNaN();
+
+    const sub = agent.getSubscribedContextGraphs().get(contextGraphId);
+    expect(sub).toMatchObject({
+      name: contextGraphId,
+      subscribed: true,
+      synced: true,
+      metaSynced: true,
+    });
+  }, 15000);
+
+  it('does not overwrite an explicitly created context graph on later SWM writes', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const contextGraphId = 'lazy-swm-explicit';
+    const caller = new ethers.Wallet(HARDHAT_KEYS.DEPLOYER).address;
+    await agent.createContextGraph({
+      id: contextGraphId,
+      name: 'Explicit Private Context',
+      accessPolicy: 1,
+      allowedAgents: [caller],
+      callerAgentAddress: caller,
+    });
+
+    const before = (await agent.listContextGraphs({ callerAgentAddress: caller }))
+      .find(p => p.id === contextGraphId);
+    expect(before).toBeDefined();
+
+    await agent.share(contextGraphId, [
+      {
+        subject: 'urn:lazy-swm-explicit:root',
+        predicate: 'http://schema.org/name',
+        object: '"Preserve Explicit"',
+        graph: '',
+      },
+    ], { localOnly: true, callerAgentAddress: caller });
+
+    const after = (await agent.listContextGraphs({ callerAgentAddress: caller }))
+      .find(p => p.id === contextGraphId);
+    expect(after).toBeDefined();
+    expect(after!.name).toBe('Explicit Private Context');
+    expect(after!.accessPolicy).toBe('private');
+    expect(after!.curator).toBe(`did:dkg:agent:${caller}`);
+    expect(after!.createdAt).toBe(before!.createdAt);
+    expect(after!.callerInvolved).toBe(true);
+  }, 15000);
+
+  it('ignores non-authoritative user triples when deciding whether metadata exists', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const contextGraphId = 'lazy-swm-user-type-triple';
+    await result.store.insert([{
+      subject: contextGraphDataGraphUri(contextGraphId),
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph: contextGraphSharedMemoryUri(contextGraphId),
+    }]);
+
+    await agent.share(contextGraphId, [
+      {
+        subject: 'urn:lazy-swm-user-type-triple:root',
+        predicate: 'http://schema.org/name',
+        object: '"User Authored Type"',
+        graph: '',
+      },
+    ], { localOnly: true });
+
+    const entry = (await agent.listContextGraphs()).find(p => p.id === contextGraphId);
+    expect(entry).toBeDefined();
+    expect(entry).toMatchObject({
+      id: contextGraphId,
+      name: contextGraphId,
+      accessPolicy: 'public',
+      subscribed: true,
+      synced: true,
+    });
+    expect(Date.parse(entry!.createdAt!)).not.toBeNaN();
+  }, 15000);
+});
+
 describe('discoverContextGraphsFromStore', () => {
   let agent: DKGAgent | undefined;
 

--- a/packages/agent/test/swm-gossip-signing.test.ts
+++ b/packages/agent/test/swm-gossip-signing.test.ts
@@ -32,6 +32,12 @@ interface DKGAgentInternals {
 class CapturingGossip {
   messages: Array<{ topic: string; data: Uint8Array }> = [];
 
+  subscribe(_topic: string): void {}
+
+  unsubscribe(_topic: string): void {}
+
+  onMessage(_topic: string, _handler: (topic: string, data: Uint8Array, from?: string) => void | Promise<void>): void {}
+
   async publish(topic: string, data: Uint8Array): Promise<void> {
     this.messages.push({ topic, data });
   }

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -570,11 +570,9 @@ WHERE {
       return jsonResponse(res, 400, { error: '"localOnly" must be a boolean' });
     }
     const contextGraphId = parsed.contextGraphId;
-    if (!contextGraphId || !quads?.length) {
-      return jsonResponse(res, 400, {
-        error: 'Missing "contextGraphId" or "quads"',
-      });
-    }
+    if (!quads?.length)
+      return jsonResponse(res, 400, { error: 'Missing "quads"' });
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     if (!validateOptionalSubGraphName(subGraphName, res)) return;
     const ctx = createOperationContext("share");
     tracker.start(ctx, {
@@ -590,6 +588,7 @@ WHERE {
           subGraphName,
           localOnly,
           operationCtx: ctx,
+          callerAgentAddress: requestAgentAddress,
         }),
       );
       tracker.complete(ctx, { tripleCount: quads.length });
@@ -958,7 +957,7 @@ WHERE {
         contextGraphId,
         quads,
         conditions,
-        { subGraphName, operationCtx: ctx },
+        { subGraphName, operationCtx: ctx, callerAgentAddress: requestAgentAddress },
       );
       tracker.complete(ctx, { tripleCount: quads.length });
       emitMemoryGraphChanged?.({
@@ -1137,7 +1136,12 @@ WHERE {
         tracker.start(ctx, { contextGraphId, details: { tripleCount: shareQuads.length, source: 'memory-turn', subGraphName } });
         try {
           await tracker.trackPhase(ctx, 'store', () =>
-            agent.share(contextGraphId, shareQuads, { subGraphName, localOnly: false, operationCtx: ctx }),
+            agent.share(contextGraphId, shareQuads, {
+              subGraphName,
+              localOnly: false,
+              operationCtx: ctx,
+              callerAgentAddress: requestAgentAddress,
+            }),
           );
           tracker.complete(ctx, { tripleCount: shareQuads.length });
         } catch (err: any) {

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -10,6 +10,7 @@
 
 import { execFile, execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { stat } from 'node:fs/promises';
 import { resolve, join } from 'node:path';
 import { platform, arch } from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -128,6 +129,9 @@ export class MarkItDownConverter implements ExtractionPipeline {
   readonly contentTypes = [...MARKITDOWN_CONTENT_TYPES];
 
   async extract(input: ExtractionInput): Promise<ConverterOutput> {
+    if ((await stat(input.filePath)).size === 0) {
+      return { mdIntermediate: '' };
+    }
     const markdown = await runMarkItDown(input.filePath);
     return { mdIntermediate: markdown };
   }

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -129,6 +129,13 @@ export class MarkItDownConverter implements ExtractionPipeline {
   readonly contentTypes = [...MARKITDOWN_CONTENT_TYPES];
 
   async extract(input: ExtractionInput): Promise<ConverterOutput> {
+    // Binary availability is a node-level configuration concern that is true
+    // regardless of input file state. Surface it before any I/O on the input
+    // so callers always get the actionable "install markitdown" error instead
+    // of an ENOENT stat() failure when both the binary and the file are absent.
+    if (!isMarkItDownAvailable()) {
+      return { mdIntermediate: await runMarkItDown(input.filePath) };
+    }
     if ((await stat(input.filePath)).size === 0) {
       return { mdIntermediate: '' };
     }

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -519,6 +519,47 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
   });
 });
 
+describe('DKG-419 — lazy context graph metadata from SWM writes', () => {
+  it('POST /api/shared-memory/write makes a fresh context graph visible in /api/context-graph/list', async () => {
+    const d = daemon!;
+    const contextGraphId = 'lazy-swm-http-' + Math.random().toString(36).slice(2, 8);
+    const write = await fetch(urlFor(d, '/api/shared-memory/write'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({
+        contextGraphId,
+        quads: [
+          {
+            subject: `urn:${contextGraphId}:root`,
+            predicate: 'http://schema.org/name',
+            object: '"Lazy HTTP Context Graph"',
+            graph: '',
+          },
+        ],
+      }),
+    });
+    expect(write.status).toBe(200);
+
+    const list = await fetch(urlFor(d, '/api/context-graph/list'), {
+      headers: authHeaders(d),
+    });
+    expect(list.status).toBe(200);
+    const body = await list.json() as { contextGraphs?: Array<Record<string, unknown>> };
+    const entry = body.contextGraphs?.find((row) => row.id === contextGraphId);
+    expect(entry).toBeDefined();
+    expect(entry).toMatchObject({
+      id: contextGraphId,
+      name: contextGraphId,
+      accessPolicy: 'public',
+      subscribed: true,
+      synced: true,
+    });
+    expect(entry?.creator).toEqual(expect.stringMatching(/^did:dkg:agent:/));
+    expect(entry?.curator).toEqual(expect.stringMatching(/^did:dkg:agent:/));
+    expect(Date.parse(String(entry?.createdAt))).not.toBeNaN();
+  }, 30_000);
+});
+
 // ---------------------------------------------------------------------------
 // CLI-8 — CONSTRUCT + access control (dup #83)
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -78,7 +78,7 @@ function createContext(path: string, body: unknown, overrides: Partial<RequestCo
     url,
     path: url.pathname,
     requestToken: undefined,
-    requestAgentAddress: '0x0',
+    requestAgentAddress: '0x0000000000000000000000000000000000000001',
     ...overrides,
   };
 }
@@ -104,6 +104,11 @@ describe('daemon memory_graph_changed route emissions', () => {
 
     expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
     expect(responseBody(ctx)).toMatchObject({ contextGraphId: 'project-a', triplesWritten: 1 });
+    expect(share.mock.calls[0][2]).toMatchObject({
+      subGraphName: 'notes',
+      localOnly: false,
+      callerAgentAddress: '0x0000000000000000000000000000000000000001',
+    });
     expect(emitMemoryGraphChanged).toHaveBeenCalledWith({
       contextGraphId: 'project-a',
       layers: ['swm'],
@@ -266,6 +271,70 @@ describe('daemon memory_graph_changed route emissions', () => {
     expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(400);
     expect(share).not.toHaveBeenCalled();
     expect(emitMemoryGraphChanged).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe shared-memory contextGraphId before calling the agent', async () => {
+    const emitMemoryGraphChanged = vi.fn();
+    const share = vi.fn();
+    const ctx = createContext('/api/shared-memory/write', {
+      contextGraphId: 'bad<id',
+      quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' }],
+    }, {
+      agent: { share } as unknown as RequestContext['agent'],
+      emitMemoryGraphChanged,
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(400);
+    expect(responseBody(ctx).error).toMatch(/Invalid "contextGraphId"/);
+    expect(share).not.toHaveBeenCalled();
+    expect(emitMemoryGraphChanged).not.toHaveBeenCalled();
+  });
+
+  it('threads callerAgentAddress into conditional shared-memory writes', async () => {
+    const conditionalShare = vi.fn().mockResolvedValue({ shareOperationId: 'op-cas' });
+    const ctx = createContext('/api/shared-memory/conditional-write', {
+      contextGraphId: 'project-a',
+      quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' }],
+      conditions: [{ subject: 'urn:s', predicate: 'urn:p', expectedValue: null }],
+    }, {
+      agent: { conditionalShare } as unknown as RequestContext['agent'],
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(conditionalShare.mock.calls[0][3]).toMatchObject({
+      callerAgentAddress: '0x0000000000000000000000000000000000000001',
+    });
+  });
+
+  it('threads callerAgentAddress into memory-turn SWM writes', async () => {
+    const share = vi.fn().mockResolvedValue({ shareOperationId: 'op-turn' });
+    const emitMemoryGraphChanged = vi.fn();
+    const fileStore = {
+      put: vi.fn().mockResolvedValue({ keccak256: 'turnhash' }),
+    };
+    const ctx = createContext('/api/memory/turn', {
+      contextGraphId: 'project-a',
+      markdown: '# Turn\n\nRemember this.',
+      layer: 'swm',
+    }, {
+      agent: { peerId: 'peer-test', share } as unknown as RequestContext['agent'],
+      fileStore: fileStore as unknown as RequestContext['fileStore'],
+      emitMemoryGraphChanged,
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(responseBody(ctx)).toMatchObject({ layer: 'swm', fileHash: 'turnhash' });
+    expect(share.mock.calls[0][2]).toMatchObject({
+      subGraphName: undefined,
+      localOnly: false,
+      callerAgentAddress: '0x0000000000000000000000000000000000000001',
+    });
   });
 
   it('emits SWM and VM refresh events after confirmed selective publishes', async () => {


### PR DESCRIPTION
## Summary

- Lazily resolves public context graph metadata when on-chain discovery only exposes the hash/id first.
- Keeps unresolved context graphs as pending/discoverable instead of auto-subscribing with missing cleartext metadata.
- Preserves curated/private graph privacy by avoiding leaked auto-subscription while still allowing authorized/manual resolution.
- Adds agent and CLI regression coverage for lazy discovery, SWM signing metadata, memory graph events, and daemon route behavior.

Fixes #419

## Tests

- `node scripts/audit-create-random.mjs`
- `node --test scripts/audit-create-random.test.mjs`
- `pnpm check:npm-metadata`
- `DKG_SKIP_EVM_BUILD=1 pnpm run build:packages`
- Agent CI shards `1/10` through `10/10` via `node scripts/ci-shard-agent.mjs`
- `pnpm --filter @origintrail-official/dkg test`
- `git diff --check`
