### PR TITLE
feat(context-graph): wire PCA id at registration so PCA agents can publish (rebase of #423)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7792,11 +7792,20 @@ export class DKGAgent {
       if (typeof rawPublishAuthorityAccountId === 'bigint') {
         requestedPublishAuthorityAccountId = rawPublishAuthorityAccountId;
       } else if (typeof rawPublishAuthorityAccountId === 'number') {
-        if (!Number.isInteger(rawPublishAuthorityAccountId) || rawPublishAuthorityAccountId <= 0) {
+        // Codex PR #502 round-9: reject unsafe JS integers. Anything
+        // above `Number.MAX_SAFE_INTEGER` (2^53-1) is silently
+        // rounded BEFORE `BigInt(...)` sees it, which would let an
+        // untyped caller register against an entirely different PCA
+        // account id than they intended. Mirrors
+        // `parseOptionalPcaAccountId` in the daemon route.
+        if (!Number.isSafeInteger(rawPublishAuthorityAccountId) || rawPublishAuthorityAccountId <= 0) {
           throw new Error('PCA account id must be a positive integer.');
         }
         requestedPublishAuthorityAccountId = BigInt(rawPublishAuthorityAccountId);
       } else if (typeof rawPublishAuthorityAccountId === 'string' && /^[1-9]\d*$/.test(rawPublishAuthorityAccountId)) {
+        // Decimal strings can carry arbitrary-precision values
+        // safely (BigInt preserves them), so no safe-integer ceiling
+        // applies — that's the recommended path for ids above 2^53.
         requestedPublishAuthorityAccountId = BigInt(rawPublishAuthorityAccountId);
       } else {
         throw new Error('PCA account id must be a positive integer.');
@@ -7969,7 +7978,7 @@ export class DKGAgent {
       // probe so future readers can't confuse it with a publish-time
       // delegate principal.
       if (isPcaCurated && publishAuthority) {
-        const chainSigner = await this.getRegistrationTxSignerAddress(id);
+        const chainSigner = await this.getRegistrationTxSignerAddress();
         if (!chainSigner) {
           throw new Error(
             `Context graph "${id}" cannot be PCA-registered: the chain adapter does not expose its registration-tx signer, so the "chain signer == PCA owner" invariant cannot be verified. PCA mode requires a chain adapter that surfaces its signer (e.g. via \`signerAddress\` / \`getSignerAddress()\` / \`getOperationalPrivateKey()\`) so the on-chain governance NFT is guaranteed to mint to the advertised PCA owner.`,
@@ -11054,19 +11063,66 @@ export class DKGAgent {
    * the adapter binds to `contracts.contextGraphs` and invokes
    * `createContextGraph`/`updatePublishPolicy`/etc with).
    *
-   * Codex PR #502 round-8: split out from `getChainPublishAuthorityAddress`
-   * so the PCA "chain signer == PCA owner" invariant has a dedicated,
-   * explicitly-documented probe. In practice the underlying resolution
-   * is identical today — `getChainPublishAuthorityAddress` already
-   * passes `includeReservingPublisherProbe: false` so it never returns
-   * a per-CG publish-time delegate — but a dedicated method makes the
-   * intent (the tx-signing wallet, not any publish-time principal)
-   * obvious to future readers / reviewers and gives us a clean
-   * extension point if an adapter ever needs to advertise a separate
-   * registration signer.
+   * Codex PR #502 round-8/round-9: this MUST be the actual tx signer,
+   * NOT the publishing principal. We deliberately skip:
+   *   - `config.publisherAddress` — the configured KA publisher
+   *     address, which can be a publishing delegate that does NOT
+   *     sign chain txs.
+   *   - `getAuthorizedPublisherAddress(contextGraphId)` — per-CG
+   *     publish-time delegate registered on chain.
+   *   - The generic `signMessage` probe — returns the adapter's
+   *     signing principal for arbitrary messages, not its tx-signing
+   *     wallet specifically.
+   *
+   * We only probe signer-specific adapter surfaces:
+   *   1. `getSignerAddress()` (modern method — used by the EVM
+   *      adapter).
+   *   2. `getSignerAddresses()` (multi-signer pool; we take the
+   *      first valid address).
+   *   3. `signerAddress` property (mock adapter and parity tests).
+   *   4. `getOperationalPrivateKey()` (legacy adapters).
+   *
+   * Returning `undefined` triggers the round-5 "fail closed" branch
+   * in `registerContextGraph`: PCA registration is rejected because
+   * the invariant cannot be verified.
    */
-  private async getRegistrationTxSignerAddress(contextGraphId?: string): Promise<string | undefined> {
-    return this.getChainPublishAuthorityAddress(contextGraphId);
+  private async getRegistrationTxSignerAddress(): Promise<string | undefined> {
+    const chain = this.chain;
+
+    const signerAddressGetter = (chain as unknown as { getSignerAddress?: () => unknown }).getSignerAddress;
+    if (typeof signerAddressGetter === 'function') {
+      try {
+        const address = normalizeAdapterPublisherAddress(await Promise.resolve(signerAddressGetter.call(chain)));
+        if (address) return address;
+      } catch {
+        // Best-effort probe; fall through to broader signer surfaces.
+      }
+    }
+
+    const signerAddressesGetter = (chain as unknown as { getSignerAddresses?: () => unknown }).getSignerAddresses;
+    if (typeof signerAddressesGetter === 'function') {
+      try {
+        const advertised = await Promise.resolve(signerAddressesGetter.call(chain));
+        if (Array.isArray(advertised)) {
+          for (const value of advertised) {
+            const address = normalizeAdapterPublisherAddress(value);
+            if (address) return address;
+          }
+        }
+      } catch {
+        // Best-effort probe.
+      }
+    }
+
+    const signerAddress = normalizeAdapterPublisherAddress(
+      (chain as unknown as { signerAddress?: unknown }).signerAddress,
+    );
+    if (signerAddress) return signerAddress;
+
+    const adapterOperationalAddress = adapterOperationalPrivateKeyAddress(chain);
+    if (adapterOperationalAddress) return adapterOperationalAddress;
+
+    return undefined;
   }
 
   private async getChainPublishAuthorityAddress(contextGraphId?: string): Promise<string | undefined> {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7277,6 +7277,15 @@ export class DKGAgent {
     const isCurated = opts.accessPolicy === LOCAL_ACCESS_CURATED
       || (opts.allowedAgents && opts.allowedAgents.length > 0)
       || (opts.allowedPeers && opts.allowedPeers.length > 0);
+    // pcaAccountId at create time is validated but NOT persisted —
+    // callers must (re)supply it at `registerContextGraph` time. Codex
+    // PR #502 round-3 flagged the create-time persist as unsafe: a
+    // bad id silently replays from local metadata on every later
+    // register retry that omits the param. Treating pcaAccountId as a
+    // register-time-only knob removes the foot-gun entirely; this
+    // parameter remains on `createContextGraph` for backwards-compat
+    // shape validation (it would be confusing to silently drop the
+    // shape mismatch), but its only effect now is input validation.
     const publishAuthorityAccountId = opts.publishAuthorityAccountId;
     if (publishAuthorityAccountId !== undefined) {
       if (publishAuthorityAccountId <= 0n) {
@@ -7323,19 +7332,15 @@ export class DKGAgent {
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: `"${isCurated || opts.private ? 'private' : 'public'}"`, graph: defGraph },
     ];
 
-    // Store registration status and curator in _meta
+    // Store registration status and curator in _meta. NOTE: we
+    // deliberately do NOT persist `publishAuthorityAccountId` here even
+    // though the param was validated above — see the comment near
+    // `const publishAuthorityAccountId = opts.publishAuthorityAccountId`
+    // above for why (Codex PR #502 round-3).
     quads.push(
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"unregistered"`, graph: cgMetaGraph },
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
     );
-    if (publishAuthorityAccountId !== undefined) {
-      quads.push({
-        subject: contextGraphUri,
-        predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
-        object: `"${publishAuthorityAccountId.toString()}"`,
-        graph: cgMetaGraph,
-      });
-    }
 
     // Store peer allowlist for curated CGs (with validation)
     if (opts.allowedPeers && opts.allowedPeers.length > 0) {
@@ -11047,26 +11052,6 @@ export class DKGAgent {
       predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
       object: `"${accountId.toString()}"`,
     }]);
-  }
-
-  /**
-   * Clear the persisted `publishAuthorityAccountId` triple for a context
-   * graph. Used by the daemon's create+register flow to roll back a
-   * pcaAccountId that was written at create time when the immediately-
-   * following register call fails — otherwise a bad PCA id would stick
-   * in local CG metadata and silently replay on every later register
-   * attempt that omits the param (Codex review #502 follow-up).
-   *
-   * Public so the daemon route can invoke it; idempotent.
-   */
-  async clearContextGraphPublishAuthorityAccountId(contextGraphId: string): Promise<void> {
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
-    const cgUri = `did:dkg:context-graph:${contextGraphId}`;
-    await this.store.deleteByPattern({
-      graph: cgMetaGraph,
-      subject: cgUri,
-      predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
-    });
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7777,7 +7777,18 @@ export class DKGAgent {
         throw new Error('PCA account id must be a positive integer.');
       }
     }
-    if (publishPolicy === EVM_PUBLISH_OPEN && publishAuthorityAccountId !== undefined) {
+    // PCA account ids are only valid for curated/private context graphs.
+    // Reject in TWO orthogonal cases (Codex review #502 follow-up):
+    //   (a) publishPolicy resolves to EVM_PUBLISH_OPEN — the on-chain
+    //       contract's PCA branch in `isAuthorizedPublisher` never fires
+    //       for open publish policy.
+    //   (b) resolvedLocalAccessPolicy is LOCAL_ACCESS_OPEN — even if the
+    //       caller explicitly forces `publishPolicy=0 (curated)`, a CG
+    //       that is locally OPEN (public/discoverable) does not match
+    //       the "curated/private" contract enforced at create time and
+    //       advertised by the new API messages.
+    if (publishAuthorityAccountId !== undefined
+      && (publishPolicy === EVM_PUBLISH_OPEN || resolvedLocalAccessPolicy === LOCAL_ACCESS_OPEN)) {
       throw new Error('PCA account id can only be used with curated/private context graphs.');
     }
     // NOTE: we intentionally defer persisting `requestedPublishAuthorityAccountId`
@@ -7850,19 +7861,40 @@ export class DKGAgent {
         if (typeof this.chain.getPublishingConvictionAccountOwner !== 'function') {
           throw new Error('PCA curated context graph registration requires chain adapter PCA owner lookup support.');
         }
-        // Translate raw chain reverts on a nonexistent PCA token to a
-        // stable, caller-input-shaped error so the daemon route can map
-        // it cleanly to 4xx instead of bleeding execution-revert text
-        // through as a 500 (Codex review #502-3).
+        // Translate KNOWN nonexistent-token reverts on the PCA NFT into
+        // a stable, caller-input-shaped error so the daemon route can
+        // map it cleanly to 404. Anything else (RPC outage, network
+        // glitch, adapter-internal failure) is rethrown with its
+        // original class/message so the daemon's catch surfaces it as a
+        // retriable 500/503 rather than a misleading 404 (Codex review
+        // #502-3 follow-up: don't blanket-translate every adapter
+        // failure as "does not exist").
         try {
           publishAuthority = ethers.getAddress(
             await this.chain.getPublishingConvictionAccountOwner(publishAuthorityAccountId),
           );
         } catch (lookupErr: any) {
-          const lookupMsg = String(lookupErr?.message ?? lookupErr ?? 'unknown error');
-          throw new Error(
-            `PCA account ${publishAuthorityAccountId} does not exist or cannot be looked up: ${lookupMsg}`,
-          );
+          const lookupMsg = String(lookupErr?.message ?? lookupErr ?? '');
+          const errCode = String(lookupErr?.code ?? '');
+          // Patterns we recognise as "this PCA token doesn't exist":
+          //   - OZ ERC721 custom error (modern: `ERC721NonexistentToken`,
+          //     legacy: `ERC721: invalid token ID` / `nonexistent token`).
+          //   - The mock adapter's `No mock PCA owner for account ...`
+          //     parity throw used in unit tests.
+          //   - ethers v6 surfaces these as `BAD_DATA` / `CALL_EXCEPTION`
+          //     with the OZ error name in the message.
+          const isNonexistentToken =
+            /ERC721NonexistentToken/.test(lookupMsg)
+            || /invalid token ID/i.test(lookupMsg)
+            || /nonexistent token/i.test(lookupMsg)
+            || /No mock PCA owner for account/.test(lookupMsg)
+            || (errCode === 'CALL_EXCEPTION' && /ERC721/.test(lookupMsg));
+          if (isNonexistentToken) {
+            throw new Error(
+              `PCA account ${publishAuthorityAccountId} does not exist or cannot be looked up: ${lookupMsg}`,
+            );
+          }
+          throw lookupErr;
         }
       } else {
         publishAuthority = await this.getChainPublishAuthorityAddress(id);
@@ -11015,6 +11047,26 @@ export class DKGAgent {
       predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
       object: `"${accountId.toString()}"`,
     }]);
+  }
+
+  /**
+   * Clear the persisted `publishAuthorityAccountId` triple for a context
+   * graph. Used by the daemon's create+register flow to roll back a
+   * pcaAccountId that was written at create time when the immediately-
+   * following register call fails — otherwise a bad PCA id would stick
+   * in local CG metadata and silently replay on every later register
+   * attempt that omits the param (Codex review #502 follow-up).
+   *
+   * Public so the daemon route can invoke it; idempotent.
+   */
+  async clearContextGraphPublishAuthorityAccountId(contextGraphId: string): Promise<void> {
+    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
+    const cgUri = `did:dkg:context-graph:${contextGraphId}`;
+    await this.store.deleteByPattern({
+      graph: cgMetaGraph,
+      subject: cgUri,
+      predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+    });
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7244,6 +7244,8 @@ export class DKGAgent {
     requiredSignatures?: number;
     /** Participant agent addresses for on-chain context graphs. */
     participantAgents?: string[];
+    /** Publishing Conviction Account id for PCA-curated on-chain registration. */
+    publishAuthorityAccountId?: bigint;
     /** When true, skips gossip subscription and broadcast. Data stays local-only. */
     private?: boolean;
     /** Caller's agent address (resolved from token). Used for curator/creator triples. */
@@ -7275,6 +7277,15 @@ export class DKGAgent {
     const isCurated = opts.accessPolicy === LOCAL_ACCESS_CURATED
       || (opts.allowedAgents && opts.allowedAgents.length > 0)
       || (opts.allowedPeers && opts.allowedPeers.length > 0);
+    const publishAuthorityAccountId = opts.publishAuthorityAccountId;
+    if (publishAuthorityAccountId !== undefined) {
+      if (publishAuthorityAccountId <= 0n) {
+        throw new Error('PCA account id must be a positive integer.');
+      }
+      if (!isCurated && opts.private !== true) {
+        throw new Error('PCA account id can only be used with curated/private context graphs.');
+      }
+    }
 
     if (opts.private) {
       this.log.info(ctx, `Creating private context graph "${opts.id}" (local-only, no gossip)`);
@@ -7317,6 +7328,14 @@ export class DKGAgent {
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"unregistered"`, graph: cgMetaGraph },
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
     );
+    if (publishAuthorityAccountId !== undefined) {
+      quads.push({
+        subject: contextGraphUri,
+        predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+        object: `"${publishAuthorityAccountId.toString()}"`,
+        graph: cgMetaGraph,
+      });
+    }
 
     // Store peer allowlist for curated CGs (with validation)
     if (opts.allowedPeers && opts.allowedPeers.length > 0) {
@@ -7611,6 +7630,7 @@ export class DKGAgent {
     accessPolicy?: number;
     publishPolicy?: number;
     callerAgentAddress?: string;
+    publishAuthorityAccountId?: bigint;
   }): Promise<{ onChainId: string; txHash?: string }> {
     const ctx = createOperationContext('system');
 
@@ -7749,6 +7769,22 @@ export class DKGAgent {
     const publishPolicy = opts?.publishPolicy ?? (resolvedLocalAccessPolicy === LOCAL_ACCESS_CURATED
       ? EVM_PUBLISH_CURATED
       : EVM_PUBLISH_OPEN);
+    const storedPublishAuthorityAccountId = await this.getContextGraphPublishAuthorityAccountId(id);
+    const requestedPublishAuthorityAccountId = opts?.publishAuthorityAccountId;
+    const publishAuthorityAccountId = requestedPublishAuthorityAccountId ?? storedPublishAuthorityAccountId;
+    if (requestedPublishAuthorityAccountId !== undefined) {
+      if (requestedPublishAuthorityAccountId <= 0n) {
+        throw new Error('PCA account id must be a positive integer.');
+      }
+    }
+    if (publishPolicy === EVM_PUBLISH_OPEN && publishAuthorityAccountId !== undefined) {
+      throw new Error('PCA account id can only be used with curated/private context graphs.');
+    }
+    if (requestedPublishAuthorityAccountId !== undefined) {
+      await this.setContextGraphPublishAuthorityAccountId(id, requestedPublishAuthorityAccountId);
+    }
+    const isPcaCurated = publishPolicy === EVM_PUBLISH_CURATED
+      && publishAuthorityAccountId !== undefined;
 
     const participantsResult = await this.store.query(
       `SELECT ?identityId WHERE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID}> ?identityId } }`,
@@ -7806,30 +7842,44 @@ export class DKGAgent {
         `${MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS} addresses after merging local allowedAgents.`,
       );
     }
-    const publishAuthority = publishPolicy === EVM_PUBLISH_CURATED
-      ? await this.getChainPublishAuthorityAddress(id)
-      : undefined;
-    if (
-      publishPolicy === EVM_PUBLISH_CURATED
-      && publishAuthority
-      && ownerAddress.toLowerCase() !== publishAuthority.toLowerCase()
-    ) {
-      throw new Error(
-        `Context graph "${id}" cannot be registered as curated by local curator ${ownerAddress} ` +
-        `because the configured chain signer is ${publishAuthority}. Per-agent chain signers are not supported yet.`,
-      );
-    }
-    if (
-      publishPolicy === EVM_PUBLISH_CURATED
-      && !publishAuthority
-      && opts?.callerAgentAddress
-      && this.defaultAgentAddress
-      && opts.callerAgentAddress.toLowerCase() !== this.defaultAgentAddress.toLowerCase()
-    ) {
-      throw new Error(
-        `Context graph "${id}" cannot be registered as curated by non-default local curator ` +
-        `${opts.callerAgentAddress} without chain signer introspection. Per-agent chain signers are not supported yet.`,
-      );
+    let publishAuthority: string | undefined;
+    if (publishPolicy === EVM_PUBLISH_CURATED) {
+      if (isPcaCurated) {
+        if (typeof this.chain.getPublishingConvictionAccountOwner !== 'function') {
+          throw new Error('PCA curated context graph registration requires chain adapter PCA owner lookup support.');
+        }
+        publishAuthority = ethers.getAddress(
+          await this.chain.getPublishingConvictionAccountOwner(publishAuthorityAccountId),
+        );
+      } else {
+        publishAuthority = await this.getChainPublishAuthorityAddress(id);
+      }
+      // Uniform strict check across EOA and PCA modes:
+      //  - EOA: publishAuthority is the chain signer; local curator
+      //    must equal the chain signer.
+      //  - PCA: publishAuthority is ownerOf(pcaAccountId); local curator
+      //    must equal the PCA owner. Registered agents are publish-time
+      //    delegates only — publish-time authorization lives on chain in
+      //    `ContextGraphs.isAuthorizedPublisher`.
+      if (publishAuthority && ownerAddress.toLowerCase() !== publishAuthority.toLowerCase()) {
+        const reason = isPcaCurated
+          ? `PCA account ${publishAuthorityAccountId} is owned by ${publishAuthority}; only the PCA owner can register, registered agents may only publish.`
+          : `the configured chain signer is ${publishAuthority}. Per-agent chain signers are not supported yet.`;
+        throw new Error(
+          `Context graph "${id}" cannot be registered as curated by local curator ${ownerAddress} because ${reason}`,
+        );
+      }
+      if (
+        !publishAuthority
+        && opts?.callerAgentAddress
+        && this.defaultAgentAddress
+        && opts.callerAgentAddress.toLowerCase() !== this.defaultAgentAddress.toLowerCase()
+      ) {
+        throw new Error(
+          `Context graph "${id}" cannot be registered as curated by non-default local curator ` +
+          `${opts.callerAgentAddress} without chain signer introspection. Per-agent chain signers are not supported yet.`,
+        );
+      }
     }
 
     const result = await this.registerContextGraphOnChain({
@@ -7838,6 +7888,7 @@ export class DKGAgent {
       accessPolicy: resolvedLocalAccessPolicy,
       publishPolicy,
       ...(publishAuthority ? { publishAuthority } : {}),
+      ...(isPcaCurated ? { publishAuthorityAccountId } : {}),
       participantAgents,
     });
     const onChainId = result.contextGraphId.toString();
@@ -10908,6 +10959,42 @@ export class DKGAgent {
       includeReservingPublisherProbe: false,
       includeGenericSignMessageProbe: false,
     });
+  }
+
+  private async getContextGraphPublishAuthorityAccountId(contextGraphId: string): Promise<bigint | undefined> {
+    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
+    const cgUri = `did:dkg:context-graph:${contextGraphId}`;
+    const result = await this.store.query(
+      `SELECT ?accountId WHERE { GRAPH <${cgMetaGraph}> { <${cgUri}> <${DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID}> ?accountId } } LIMIT 1`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
+
+    const raw = result.bindings[0]?.['accountId']?.replace(/^"|"$/g, '');
+    if (!raw) return undefined;
+    if (!/^\d+$/.test(raw)) {
+      throw new Error(`Context graph "${contextGraphId}" has invalid PCA account id "${raw}".`);
+    }
+    const accountId = BigInt(raw);
+    if (accountId <= 0n) {
+      throw new Error(`Context graph "${contextGraphId}" has invalid PCA account id "${raw}".`);
+    }
+    return accountId;
+  }
+
+  private async setContextGraphPublishAuthorityAccountId(contextGraphId: string, accountId: bigint): Promise<void> {
+    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
+    const cgUri = `did:dkg:context-graph:${contextGraphId}`;
+    await this.store.deleteByPattern({
+      graph: cgMetaGraph,
+      subject: cgUri,
+      predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+    });
+    await this.store.insert([{
+      graph: cgMetaGraph,
+      subject: cgUri,
+      predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+      object: `"${accountId.toString()}"`,
+    }]);
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7780,9 +7780,11 @@ export class DKGAgent {
     if (publishPolicy === EVM_PUBLISH_OPEN && publishAuthorityAccountId !== undefined) {
       throw new Error('PCA account id can only be used with curated/private context graphs.');
     }
-    if (requestedPublishAuthorityAccountId !== undefined) {
-      await this.setContextGraphPublishAuthorityAccountId(id, requestedPublishAuthorityAccountId);
-    }
+    // NOTE: we intentionally defer persisting `requestedPublishAuthorityAccountId`
+    // until *after* on-chain registration succeeds (further down). If we
+    // wrote it here and the subsequent owner check / on-chain call failed
+    // with a bad PCA id, the bad id would stick in local CG metadata and
+    // every retry would replay the same failure (Codex review #502-1).
     const isPcaCurated = publishPolicy === EVM_PUBLISH_CURATED
       && publishAuthorityAccountId !== undefined;
 
@@ -7848,9 +7850,20 @@ export class DKGAgent {
         if (typeof this.chain.getPublishingConvictionAccountOwner !== 'function') {
           throw new Error('PCA curated context graph registration requires chain adapter PCA owner lookup support.');
         }
-        publishAuthority = ethers.getAddress(
-          await this.chain.getPublishingConvictionAccountOwner(publishAuthorityAccountId),
-        );
+        // Translate raw chain reverts on a nonexistent PCA token to a
+        // stable, caller-input-shaped error so the daemon route can map
+        // it cleanly to 4xx instead of bleeding execution-revert text
+        // through as a 500 (Codex review #502-3).
+        try {
+          publishAuthority = ethers.getAddress(
+            await this.chain.getPublishingConvictionAccountOwner(publishAuthorityAccountId),
+          );
+        } catch (lookupErr: any) {
+          const lookupMsg = String(lookupErr?.message ?? lookupErr ?? 'unknown error');
+          throw new Error(
+            `PCA account ${publishAuthorityAccountId} does not exist or cannot be looked up: ${lookupMsg}`,
+          );
+        }
       } else {
         publishAuthority = await this.getChainPublishAuthorityAddress(id);
       }
@@ -7905,6 +7918,13 @@ export class DKGAgent {
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"registered"`, graph: cgMetaGraph },
       { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`, object: `"${onChainId}"`, graph: ontologyGraph },
     ]);
+
+    // Persist the (now-validated) PCA account id locally. Deferred until
+    // after on-chain registration succeeds so a bad pcaAccountId never
+    // leaves stale state behind (Codex review #502-1).
+    if (requestedPublishAuthorityAccountId !== undefined) {
+      await this.setContextGraphPublishAuthorityAccountId(id, requestedPublishAuthorityAccountId);
+    }
 
     // Update in-memory subscription record and ensure we're subscribed
     const sub = this.subscribedContextGraphs.get(id);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7244,7 +7244,16 @@ export class DKGAgent {
     requiredSignatures?: number;
     /** Participant agent addresses for on-chain context graphs. */
     participantAgents?: string[];
-    /** Publishing Conviction Account id for PCA-curated on-chain registration. */
+    /**
+     * Publishing Conviction Account id. NOT a `createContextGraph` knob —
+     * supply on {@link registerContextGraph} instead. Accepted here only
+     * so callers get an immediate error rather than a silent no-op:
+     * `createContextGraph` no longer persists the PCA id (Codex PR #502
+     * round-3) and direct agent callers would otherwise have no signal
+     * that the create-time value was being dropped (Codex round-6).
+     *
+     * @deprecated Use `publishAuthorityAccountId` on `registerContextGraph` instead.
+     */
     publishAuthorityAccountId?: bigint;
     /** When true, skips gossip subscription and broadcast. Data stays local-only. */
     private?: boolean;
@@ -7277,23 +7286,22 @@ export class DKGAgent {
     const isCurated = opts.accessPolicy === LOCAL_ACCESS_CURATED
       || (opts.allowedAgents && opts.allowedAgents.length > 0)
       || (opts.allowedPeers && opts.allowedPeers.length > 0);
-    // pcaAccountId at create time is validated but NOT persisted —
-    // callers must (re)supply it at `registerContextGraph` time. Codex
-    // PR #502 round-3 flagged the create-time persist as unsafe: a
-    // bad id silently replays from local metadata on every later
-    // register retry that omits the param. Treating pcaAccountId as a
-    // register-time-only knob removes the foot-gun entirely; this
-    // parameter remains on `createContextGraph` for backwards-compat
-    // shape validation (it would be confusing to silently drop the
-    // shape mismatch), but its only effect now is input validation.
-    const publishAuthorityAccountId = opts.publishAuthorityAccountId;
-    if (publishAuthorityAccountId !== undefined) {
-      if (publishAuthorityAccountId <= 0n) {
-        throw new Error('PCA account id must be a positive integer.');
-      }
-      if (!isCurated && opts.private !== true) {
-        throw new Error('PCA account id can only be used with curated/private context graphs.');
-      }
+    // pcaAccountId is a register-time-only knob (Codex PR #502 round-3:
+    // `createContextGraph` no longer persists it). Direct agent
+    // callers used to receive a silent drop; per Codex round-6 we now
+    // fail fast at the boundary so they get an immediate, actionable
+    // error instead of a confusing "EOA-curated when I asked for PCA"
+    // outcome at register time. Daemon callers can't hit this path —
+    // the HTTP route already strips the param before calling
+    // `createContextGraph`.
+    if (opts.publishAuthorityAccountId !== undefined) {
+      throw new Error(
+        '`publishAuthorityAccountId` is not supported on createContextGraph(). '
+        + 'PCA account ids are register-time-only — supply `publishAuthorityAccountId` '
+        + 'on registerContextGraph() instead. Background: createContextGraph no '
+        + 'longer persists PCA ids locally, so any value passed here would silently '
+        + 'be dropped before registration (Codex PR #502 round-3/round-6).',
+      );
     }
 
     if (opts.private) {
@@ -7332,11 +7340,10 @@ export class DKGAgent {
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: `"${isCurated || opts.private ? 'private' : 'public'}"`, graph: defGraph },
     ];
 
-    // Store registration status and curator in _meta. NOTE: we
-    // deliberately do NOT persist `publishAuthorityAccountId` here even
-    // though the param was validated above — see the comment near
-    // `const publishAuthorityAccountId = opts.publishAuthorityAccountId`
-    // above for why (Codex PR #502 round-3).
+    // Store registration status and curator in _meta. We do NOT
+    // store any PCA account id here — that param is register-time-only
+    // and createContextGraph rejects it at the boundary (Codex PR
+    // #502 round-3 + round-6).
     quads.push(
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"unregistered"`, graph: cgMetaGraph },
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
@@ -7774,9 +7781,14 @@ export class DKGAgent {
     const publishPolicy = opts?.publishPolicy ?? (resolvedLocalAccessPolicy === LOCAL_ACCESS_CURATED
       ? EVM_PUBLISH_CURATED
       : EVM_PUBLISH_OPEN);
-    const storedPublishAuthorityAccountId = await this.getContextGraphPublishAuthorityAccountId(id);
+    // PCA account id is ONLY honored from the explicit option here.
+    // We deliberately do NOT fall back to a stored value (Codex PR
+    // #502 round-6): legacy CGs created under the old create-time
+    // persistence could have stale/bad ids that would silently replay
+    // on every register retry that omits the param. With explicit-only
+    // resolution, `undefined` unambiguously means "no PCA".
     const requestedPublishAuthorityAccountId = opts?.publishAuthorityAccountId;
-    const publishAuthorityAccountId = requestedPublishAuthorityAccountId ?? storedPublishAuthorityAccountId;
+    const publishAuthorityAccountId = requestedPublishAuthorityAccountId;
     if (requestedPublishAuthorityAccountId !== undefined) {
       if (requestedPublishAuthorityAccountId <= 0n) {
         throw new Error('PCA account id must be a positive integer.');
@@ -7884,14 +7896,22 @@ export class DKGAgent {
           // Patterns we recognise as "this PCA token doesn't exist":
           //   - OZ ERC721 custom error (modern: `ERC721NonexistentToken`,
           //     legacy: `ERC721: invalid token ID` / `nonexistent token`).
-          //   - The mock adapter's `No mock PCA owner for account ...`
-          //     parity throw used in unit tests.
+          //   - The built-in `MockChainAdapter.getPublishingConvictionAccountOwner`
+          //     throws `Mock: PCA account <id> does not exist` (production
+          //     mock used by SDK callers). Recognized via the broader
+          //     `/PCA account \d+ does not exist/` pattern (Codex PR #502
+          //     round-6: this matcher used to recognize only the test
+          //     double's wording, so the built-in mock path bypassed
+          //     normalization).
+          //   - The agent-test test double's `No mock PCA owner for
+          //     account ...` parity throw.
           //   - ethers v6 surfaces these as `BAD_DATA` / `CALL_EXCEPTION`
           //     with the OZ error name in the message.
           const isNonexistentToken =
             /ERC721NonexistentToken/.test(lookupMsg)
             || /invalid token ID/i.test(lookupMsg)
             || /nonexistent token/i.test(lookupMsg)
+            || /PCA account \d+ does not exist/.test(lookupMsg)
             || /No mock PCA owner for account/.test(lookupMsg)
             || (errCode === 'CALL_EXCEPTION' && /ERC721/.test(lookupMsg));
           if (isNonexistentToken) {
@@ -7981,13 +8001,11 @@ export class DKGAgent {
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"registered"`, graph: cgMetaGraph },
       { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`, object: `"${onChainId}"`, graph: ontologyGraph },
     ]);
-
-    // Persist the (now-validated) PCA account id locally. Deferred until
-    // after on-chain registration succeeds so a bad pcaAccountId never
-    // leaves stale state behind (Codex review #502-1).
-    if (requestedPublishAuthorityAccountId !== undefined) {
-      await this.setContextGraphPublishAuthorityAccountId(id, requestedPublishAuthorityAccountId);
-    }
+    // We no longer persist `publishAuthorityAccountId` locally even on
+    // success (Codex PR #502 round-6 follow-through): with the
+    // stored-value fallback gone, nothing reads it. A CG can only
+    // register on-chain once anyway — re-reads of the stored id
+    // wouldn't be useful.
 
     // Update in-memory subscription record and ensure we're subscribed
     const sub = this.subscribedContextGraphs.get(id);
@@ -11044,41 +11062,14 @@ export class DKGAgent {
     });
   }
 
-  private async getContextGraphPublishAuthorityAccountId(contextGraphId: string): Promise<bigint | undefined> {
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
-    const cgUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(
-      `SELECT ?accountId WHERE { GRAPH <${cgMetaGraph}> { <${cgUri}> <${DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID}> ?accountId } } LIMIT 1`,
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
-
-    const raw = result.bindings[0]?.['accountId']?.replace(/^"|"$/g, '');
-    if (!raw) return undefined;
-    if (!/^\d+$/.test(raw)) {
-      throw new Error(`Context graph "${contextGraphId}" has invalid PCA account id "${raw}".`);
-    }
-    const accountId = BigInt(raw);
-    if (accountId <= 0n) {
-      throw new Error(`Context graph "${contextGraphId}" has invalid PCA account id "${raw}".`);
-    }
-    return accountId;
-  }
-
-  private async setContextGraphPublishAuthorityAccountId(contextGraphId: string, accountId: bigint): Promise<void> {
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
-    const cgUri = `did:dkg:context-graph:${contextGraphId}`;
-    await this.store.deleteByPattern({
-      graph: cgMetaGraph,
-      subject: cgUri,
-      predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
-    });
-    await this.store.insert([{
-      graph: cgMetaGraph,
-      subject: cgUri,
-      predicate: DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
-      object: `"${accountId.toString()}"`,
-    }]);
-  }
+  // NOTE: `getContextGraphPublishAuthorityAccountId` and
+  // `setContextGraphPublishAuthorityAccountId` helpers were removed in
+  // Codex PR #502 round-6. With `registerContextGraph` no longer
+  // falling back to stored values and `createContextGraph` no longer
+  // persisting them, nothing on this code path reads or writes the
+  // `DKG_PUBLISH_AUTHORITY_ACCOUNT_ID` triple anymore — pcaAccountId
+  // lives strictly in the explicit `publishAuthorityAccountId` opt on
+  // `registerContextGraph`.
 
   /**
    * Return true when `senderPeerId` is currently acting as the curator

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7919,6 +7919,25 @@ export class DKGAgent {
           `Context graph "${id}" cannot be registered as curated by local curator ${ownerAddress} because ${reason}`,
         );
       }
+      // PCA-only: the chain signer (= msg.sender for the registration
+      // tx) MUST equal the PCA owner. `ContextGraphs.createContextGraph`
+      // on-chain mints the governance NFT to msg.sender, so any
+      // divergence between the configured chain signer and the PCA
+      // owner would make the chain signer (not the advertised PCA owner)
+      // the actual on-chain context-graph owner — breaking later
+      // `onlyContextGraphOwner` operations (publish-policy/authority
+      // updates, etc.). Per Codex PR #502 round-4: keep "advertised
+      // curator == on-chain owner == chain signer == PCA owner" until
+      // the registration tx can be submitted by a signer the PCA
+      // owner actually controls.
+      if (isPcaCurated && publishAuthority) {
+        const chainSigner = await this.getChainPublishAuthorityAddress(id);
+        if (chainSigner && chainSigner.toLowerCase() !== publishAuthority.toLowerCase()) {
+          throw new Error(
+            `Context graph "${id}" cannot be PCA-registered: chain signer ${chainSigner} differs from PCA owner ${publishAuthority}. The PCA owner must control the chain signer used to submit the registration tx; otherwise the on-chain governance NFT mints to ${chainSigner} rather than the advertised curator.`,
+          );
+        }
+      }
       if (
         !publishAuthority
         && opts?.callerAgentAddress

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7244,17 +7244,6 @@ export class DKGAgent {
     requiredSignatures?: number;
     /** Participant agent addresses for on-chain context graphs. */
     participantAgents?: string[];
-    /**
-     * Publishing Conviction Account id. NOT a `createContextGraph` knob —
-     * supply on {@link registerContextGraph} instead. Accepted here only
-     * so callers get an immediate error rather than a silent no-op:
-     * `createContextGraph` no longer persists the PCA id (Codex PR #502
-     * round-3) and direct agent callers would otherwise have no signal
-     * that the create-time value was being dropped (Codex round-6).
-     *
-     * @deprecated Use `publishAuthorityAccountId` on `registerContextGraph` instead.
-     */
-    publishAuthorityAccountId?: bigint;
     /** When true, skips gossip subscription and broadcast. Data stays local-only. */
     private?: boolean;
     /** Caller's agent address (resolved from token). Used for curator/creator triples. */
@@ -7286,21 +7275,25 @@ export class DKGAgent {
     const isCurated = opts.accessPolicy === LOCAL_ACCESS_CURATED
       || (opts.allowedAgents && opts.allowedAgents.length > 0)
       || (opts.allowedPeers && opts.allowedPeers.length > 0);
-    // pcaAccountId is a register-time-only knob (Codex PR #502 round-3:
-    // `createContextGraph` no longer persists it). Direct agent
-    // callers used to receive a silent drop; per Codex round-6 we now
-    // fail fast at the boundary so they get an immediate, actionable
+    // pcaAccountId is a register-time-only knob (Codex PR #502
+    // round-3: `createContextGraph` no longer persists it). The field
+    // is intentionally NOT part of the public `createContextGraph`
+    // TypeScript signature — TS-first callers get a compile-time
+    // excess-property error if they try to set it (Codex round-7).
+    // The runtime check below still fires so untyped/JS callers (or
+    // typed callers using `as any`) get an immediate, actionable
     // error instead of a confusing "EOA-curated when I asked for PCA"
     // outcome at register time. Daemon callers can't hit this path —
     // the HTTP route already strips the param before calling
     // `createContextGraph`.
-    if (opts.publishAuthorityAccountId !== undefined) {
+    const optsRecord = opts as unknown as Record<string, unknown>;
+    if (optsRecord.publishAuthorityAccountId !== undefined) {
       throw new Error(
         '`publishAuthorityAccountId` is not supported on createContextGraph(). '
         + 'PCA account ids are register-time-only — supply `publishAuthorityAccountId` '
         + 'on registerContextGraph() instead. Background: createContextGraph no '
         + 'longer persists PCA ids locally, so any value passed here would silently '
-        + 'be dropped before registration (Codex PR #502 round-3/round-6).',
+        + 'be dropped before registration (Codex PR #502 round-3/round-6/round-7).',
       );
     }
 
@@ -7794,19 +7787,20 @@ export class DKGAgent {
         throw new Error('PCA account id must be a positive integer.');
       }
     }
-    // PCA account ids are only valid for curated/private context graphs.
-    // Reject in TWO orthogonal cases (Codex review #502 follow-up):
-    //   (a) publishPolicy resolves to EVM_PUBLISH_OPEN — the on-chain
-    //       contract's PCA branch in `isAuthorizedPublisher` never fires
-    //       for open publish policy.
-    //   (b) resolvedLocalAccessPolicy is LOCAL_ACCESS_OPEN — even if the
-    //       caller explicitly forces `publishPolicy=0 (curated)`, a CG
-    //       that is locally OPEN (public/discoverable) does not match
-    //       the "curated/private" contract enforced at create time and
-    //       advertised by the new API messages.
-    if (publishAuthorityAccountId !== undefined
-      && (publishPolicy === EVM_PUBLISH_OPEN || resolvedLocalAccessPolicy === LOCAL_ACCESS_OPEN)) {
-      throw new Error('PCA account id can only be used with curated/private context graphs.');
+    // PCA account ids are only invalid when the publish policy is
+    // open (`publishPolicy === EVM_PUBLISH_OPEN`) — that combination
+    // is incoherent on-chain because `isAuthorizedPublisher`'s PCA
+    // branch never fires for open publish policy.
+    //
+    // We do NOT also reject `accessPolicy=0 (public/discoverable)`
+    // here: the on-chain `ContextGraphs.createContextGraph` contract
+    // explicitly supports `{ accessPolicy: 0, publishPolicy: 0,
+    // publishAuthorityAccountId: !=0 }` — a publicly-discoverable CG
+    // where only the PCA owner / authorized publishers can write.
+    // Rejecting that combo client-side blocks a valid registration
+    // mode (Codex PR #502 round-7).
+    if (publishAuthorityAccountId !== undefined && publishPolicy === EVM_PUBLISH_OPEN) {
+      throw new Error('PCA account id can only be used with curated publish policy.');
     }
     // NOTE: we intentionally defer persisting `requestedPublishAuthorityAccountId`
     // until *after* on-chain registration succeeds (further down). If we

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7780,13 +7780,32 @@ export class DKGAgent {
     // persistence could have stale/bad ids that would silently replay
     // on every register retry that omits the param. With explicit-only
     // resolution, `undefined` unambiguously means "no PCA".
-    const requestedPublishAuthorityAccountId = opts?.publishAuthorityAccountId;
-    const publishAuthorityAccountId = requestedPublishAuthorityAccountId;
-    if (requestedPublishAuthorityAccountId !== undefined) {
+    //
+    // The option type advertises `bigint`, but untyped / JS callers can
+    // pass `1` or `'1'` — comparing a non-bigint to `0n` would throw a
+    // raw `TypeError: Cannot mix BigInt and other types` instead of the
+    // actionable validation error this API is supposed to provide
+    // (Codex PR #502 round-8). Coerce safely before the `<= 0n` check.
+    const rawPublishAuthorityAccountId = opts?.publishAuthorityAccountId as unknown;
+    let requestedPublishAuthorityAccountId: bigint | undefined;
+    if (rawPublishAuthorityAccountId !== undefined && rawPublishAuthorityAccountId !== null) {
+      if (typeof rawPublishAuthorityAccountId === 'bigint') {
+        requestedPublishAuthorityAccountId = rawPublishAuthorityAccountId;
+      } else if (typeof rawPublishAuthorityAccountId === 'number') {
+        if (!Number.isInteger(rawPublishAuthorityAccountId) || rawPublishAuthorityAccountId <= 0) {
+          throw new Error('PCA account id must be a positive integer.');
+        }
+        requestedPublishAuthorityAccountId = BigInt(rawPublishAuthorityAccountId);
+      } else if (typeof rawPublishAuthorityAccountId === 'string' && /^[1-9]\d*$/.test(rawPublishAuthorityAccountId)) {
+        requestedPublishAuthorityAccountId = BigInt(rawPublishAuthorityAccountId);
+      } else {
+        throw new Error('PCA account id must be a positive integer.');
+      }
       if (requestedPublishAuthorityAccountId <= 0n) {
         throw new Error('PCA account id must be a positive integer.');
       }
     }
+    const publishAuthorityAccountId = requestedPublishAuthorityAccountId;
     // PCA account ids are only invalid when the publish policy is
     // open (`publishPolicy === EVM_PUBLISH_OPEN`) — that combination
     // is incoherent on-chain because `isAuthorizedPublisher`'s PCA
@@ -7945,9 +7964,12 @@ export class DKGAgent {
       // FAIL CLOSED when the registration signer cannot be
       // introspected — a custom adapter that exposes
       // `getPublishingConvictionAccountOwner()` but not its tx signer
-      // would otherwise sneak past the invariant.
+      // would otherwise sneak past the invariant. Codex PR #502
+      // round-8: use the dedicated `getRegistrationTxSignerAddress`
+      // probe so future readers can't confuse it with a publish-time
+      // delegate principal.
       if (isPcaCurated && publishAuthority) {
-        const chainSigner = await this.getChainPublishAuthorityAddress(id);
+        const chainSigner = await this.getRegistrationTxSignerAddress(id);
         if (!chainSigner) {
           throw new Error(
             `Context graph "${id}" cannot be PCA-registered: the chain adapter does not expose its registration-tx signer, so the "chain signer == PCA owner" invariant cannot be verified. PCA mode requires a chain adapter that surfaces its signer (e.g. via \`signerAddress\` / \`getSignerAddress()\` / \`getOperationalPrivateKey()\`) so the on-chain governance NFT is guaranteed to mint to the advertised PCA owner.`,
@@ -11025,6 +11047,26 @@ export class DKGAgent {
     return !!this.defaultAgentAddress
       && ethers.isAddress(this.defaultAgentAddress)
       && ownerAddress.toLowerCase() === this.defaultAgentAddress.toLowerCase();
+  }
+
+  /**
+   * Address that will SIGN on-chain CG-state-changing txs (the wallet
+   * the adapter binds to `contracts.contextGraphs` and invokes
+   * `createContextGraph`/`updatePublishPolicy`/etc with).
+   *
+   * Codex PR #502 round-8: split out from `getChainPublishAuthorityAddress`
+   * so the PCA "chain signer == PCA owner" invariant has a dedicated,
+   * explicitly-documented probe. In practice the underlying resolution
+   * is identical today — `getChainPublishAuthorityAddress` already
+   * passes `includeReservingPublisherProbe: false` so it never returns
+   * a per-CG publish-time delegate — but a dedicated method makes the
+   * intent (the tx-signing wallet, not any publish-time principal)
+   * obvious to future readers / reviewers and gives us a clean
+   * extension point if an adapter ever needs to advertise a separate
+   * registration signer.
+   */
+  private async getRegistrationTxSignerAddress(contextGraphId?: string): Promise<string | undefined> {
+    return this.getChainPublishAuthorityAddress(contextGraphId);
   }
 
   private async getChainPublishAuthorityAddress(contextGraphId?: string): Promise<string | undefined> {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7926,13 +7926,20 @@ export class DKGAgent {
       // owner would make the chain signer (not the advertised PCA owner)
       // the actual on-chain context-graph owner — breaking later
       // `onlyContextGraphOwner` operations (publish-policy/authority
-      // updates, etc.). Per Codex PR #502 round-4: keep "advertised
-      // curator == on-chain owner == chain signer == PCA owner" until
-      // the registration tx can be submitted by a signer the PCA
-      // owner actually controls.
+      // updates, etc.). Per Codex PR #502 round-4/5: keep "advertised
+      // curator == on-chain owner == chain signer == PCA owner" and
+      // FAIL CLOSED when the registration signer cannot be
+      // introspected — a custom adapter that exposes
+      // `getPublishingConvictionAccountOwner()` but not its tx signer
+      // would otherwise sneak past the invariant.
       if (isPcaCurated && publishAuthority) {
         const chainSigner = await this.getChainPublishAuthorityAddress(id);
-        if (chainSigner && chainSigner.toLowerCase() !== publishAuthority.toLowerCase()) {
+        if (!chainSigner) {
+          throw new Error(
+            `Context graph "${id}" cannot be PCA-registered: the chain adapter does not expose its registration-tx signer, so the "chain signer == PCA owner" invariant cannot be verified. PCA mode requires a chain adapter that surfaces its signer (e.g. via \`signerAddress\` / \`getSignerAddress()\` / \`getOperationalPrivateKey()\`) so the on-chain governance NFT is guaranteed to mint to the advertised PCA owner.`,
+          );
+        }
+        if (chainSigner.toLowerCase() !== publishAuthority.toLowerCase()) {
           throw new Error(
             `Context graph "${id}" cannot be PCA-registered: chain signer ${chainSigner} differs from PCA owner ${publishAuthority}. The PCA owner must control the chain signer used to submit the registration tx; otherwise the on-chain governance NFT mints to ${chainSigner} rather than the advertised curator.`,
           );

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -2611,6 +2611,107 @@ decisions: []
     await agent.stop().catch(() => {});
   });
 
+  // Codex review #502-1: a failed PCA registration must not leave the
+  // requested pcaAccountId persisted in local CG metadata. If it did,
+  // every retry would silently replay the same bad id from storage even
+  // after the caller corrects their request.
+  it('does NOT persist the requested PCA account id when registration fails (e.g. nonexistent token)', async () => {
+    const badAccountId = 999n;
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map());
+    // Use the chain's own signer as the local curator so the EOA-curated
+    // branch (the fallback after persist-rollback) can succeed without
+    // chain-signer mismatch. The bad id throws on owner lookup (no entry
+    // in the map), so the persist must NOT fire.
+    const ownerAddr = ethers.getAddress(chain.signerAddress);
+    const agent = await DKGAgent.create({
+      name: 'PcaPersistRollbackBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    await agent.createContextGraph({
+      id: 'pca-persist-rollback',
+      name: 'PCA Persist Rollback',
+      accessPolicy: 1,
+      callerAgentAddress: ownerAddr,
+    });
+
+    // First attempt: bad pcaAccountId. PcaCuratedRegistrationChainAdapter
+    // throws on `getPublishingConvictionAccountOwner(badAccountId)`, which
+    // the agent now wraps into a stable "PCA account ... does not exist"
+    // error (#502-3) and short-circuits before persisting.
+    await expect(agent.registerContextGraph('pca-persist-rollback', {
+      callerAgentAddress: ownerAddr,
+      publishAuthorityAccountId: badAccountId,
+    })).rejects.toThrow(/PCA account 999 does not exist/);
+    expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
+
+    // Second attempt: caller omits pcaAccountId. If the bad id had been
+    // persisted on the failed first attempt, the resolver would replay
+    // it from storage and the call would throw the same "PCA account 999
+    // does not exist" error again. With the fix it doesn't — the
+    // resolver finds no stored id and falls through to the EOA-curated
+    // branch (publishAuthority = chain signer = local curator).
+    await expect(agent.registerContextGraph('pca-persist-rollback', {
+      callerAgentAddress: ownerAddr,
+    })).resolves.toMatchObject({ onChainId: expect.any(String) });
+
+    expect(chain.createOnChainContextGraphCalls).toHaveLength(1);
+    expect(chain.createOnChainContextGraphCalls[0]).toMatchObject({
+      publishPolicy: 0,
+      publishAuthority: ownerAddr,
+    });
+    // No `publishAuthorityAccountId` on the on-chain call confirms the
+    // bad id is gone (the field is conditionally spread only when
+    // `isPcaCurated`).
+    expect(chain.createOnChainContextGraphCalls[0]?.publishAuthorityAccountId ?? 0n).toBe(0n);
+    await agent.stop().catch(() => {});
+  });
+
+  // Codex review #502-2: `{ private: true, accessPolicy: 0,
+  // pcaAccountId }` create+register must not flip-flop between curated
+  // (at create time) and open (at register time). The daemon route's
+  // `inferredAccessPolicy` keeps both legs aligned; this test pins the
+  // agent-level contract: `private: true` is a curated signal that
+  // dominates accessPolicy=0.
+  it('treats private:true as a curated signal that dominates accessPolicy=0 for PCA registration', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const pcaAccountId = 77n;
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaPrivateOverridesAccessPolicyBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    await agent.createContextGraph({
+      id: 'pca-private-dominates',
+      name: 'PCA Private Dominates AccessPolicy',
+      private: true,
+      publishAuthorityAccountId: pcaAccountId,
+      callerAgentAddress: pcaOwner,
+    });
+
+    // Register with accessPolicy=1 (matches the daemon route's
+    // `inferredAccessPolicy` for `private: true`). The agent must accept
+    // and route into the PCA curated branch.
+    await expect(agent.registerContextGraph('pca-private-dominates', {
+      accessPolicy: 1,
+      callerAgentAddress: pcaOwner,
+    })).resolves.toMatchObject({ onChainId: expect.any(String) });
+
+    expect(chain.createOnChainContextGraphCalls[0]).toMatchObject({
+      publishPolicy: 0,
+      publishAuthority: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    });
+    await agent.stop().catch(() => {});
+  });
+
 	  it('requires address-scoped curator authority for on-chain registration', async () => {
     const store = new OxigraphStore();
     const chain = new CapturingContextGraphChainAdapter();

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -2670,6 +2670,92 @@ decisions: []
     await agent.stop().catch(() => {});
   });
 
+  // Codex review #502 follow-up: PCA mode must be rejected when EITHER
+  // axis is open, not just publishPolicy. A caller cannot bypass the
+  // "curated/private only" contract by explicitly forcing
+  // `publishPolicy: 0 (curated)` together with `accessPolicy: 0 (open)`.
+  it('rejects PCA registration when accessPolicy is open even with explicit publishPolicy=0 (curated)', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const pcaAccountId = 88n;
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaOpenAccessPolicyBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    // Create as open (no accessPolicy / private / allowlists). The
+    // agent's createContextGraph PCA gate rejects this at create time,
+    // so we have to set up a CG that's open locally without going
+    // through createContextGraph's PCA branch — use a plain create and
+    // then attempt to force the contradictory combo at register time.
+    await agent.createContextGraph({
+      id: 'reject-open-access-with-pca',
+      name: 'Reject Open AccessPolicy with PCA',
+      callerAgentAddress: pcaOwner,
+    });
+
+    await expect(agent.registerContextGraph('reject-open-access-with-pca', {
+      callerAgentAddress: pcaOwner,
+      accessPolicy: 0,
+      publishPolicy: 0,
+      publishAuthorityAccountId: pcaAccountId,
+    })).rejects.toThrow(/PCA account id can only be used with curated\/private context graphs/);
+
+    expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
+    await agent.stop().catch(() => {});
+  });
+
+  // Codex review #502 follow-up: only KNOWN nonexistent-token reverts
+  // should be translated to "PCA account ... does not exist". Transient
+  // RPC / adapter failures must preserve their original message so the
+  // daemon mapping doesn't synthesize a 404 for retriable issues.
+  it('does NOT rewrite generic adapter failures (e.g. RPC outages) as "PCA does not exist"', async () => {
+    const rpcOutageMsg = 'connection refused: chain RPC unreachable';
+    class RpcOutageChainAdapter extends AsyncSignerAddressContextGraphChainAdapter {
+      async getPublishingConvictionAccountOwner(_accountId: bigint): Promise<string> {
+        throw new Error(rpcOutageMsg);
+      }
+    }
+    const chain = new RpcOutageChainAdapter();
+    const pcaOwner = ethers.getAddress(chain.signerAddress);
+    const agent = await DKGAgent.create({
+      name: 'PcaRpcOutageBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    await agent.createContextGraph({
+      id: 'rpc-outage-during-register',
+      name: 'RPC Outage During Register',
+      accessPolicy: 1,
+      callerAgentAddress: pcaOwner,
+    });
+
+    // The thrown error must preserve the original RPC outage message
+    // verbatim and must NOT be wrapped as "PCA account ... does not
+    // exist" — the daemon mapping would otherwise turn a retriable
+    // 5xx-class infrastructure failure into a misleading 404.
+    let caught: Error | undefined;
+    try {
+      await agent.registerContextGraph('rpc-outage-during-register', {
+        callerAgentAddress: pcaOwner,
+        publishAuthorityAccountId: 42n,
+      });
+    } catch (err: any) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.message ?? '').toContain(rpcOutageMsg);
+    expect(caught?.message ?? '').not.toMatch(/PCA account 42 does not exist/);
+
+    await agent.stop().catch(() => {});
+  });
+
   // Codex review #502-2: `{ private: true, accessPolicy: 0,
   // pcaAccountId }` create+register must not flip-flop between curated
   // (at create time) and open (at register time). The daemon route's

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -2514,12 +2514,17 @@ decisions: []
       id: 'register-pca-curated-policy',
       name: 'PCA Curated Policy',
       accessPolicy: 1,
-      publishAuthorityAccountId: pcaAccountId,
       callerAgentAddress: pcaOwner,
     });
 
-    await expect(agent.registerContextGraph('register-pca-curated-policy', { callerAgentAddress: pcaOwner }))
-      .resolves.toMatchObject({ onChainId: expect.any(String) });
+    // pcaAccountId is a register-time knob now (Codex PR #502 round-3);
+    // callers must resupply it on `registerContextGraph` rather than
+    // relying on a create-time persist that could silently replay a
+    // stale id.
+    await expect(agent.registerContextGraph('register-pca-curated-policy', {
+      callerAgentAddress: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    })).resolves.toMatchObject({ onChainId: expect.any(String) });
 
     expect(chain.createOnChainContextGraphCalls[0]).toMatchObject({
       publishPolicy: 0,
@@ -2599,12 +2604,14 @@ decisions: []
       id: 'reject-pca-non-owner',
       name: 'Reject PCA non-owner',
       accessPolicy: 1,
-      publishAuthorityAccountId: pcaAccountId,
       callerAgentAddress: nonOwner,
     });
 
+    // pcaAccountId at register time (not create) per Codex PR #502
+    // round-3 contract change.
     await expect(agent.registerContextGraph('reject-pca-non-owner', {
       callerAgentAddress: nonOwner,
+      publishAuthorityAccountId: pcaAccountId,
     })).rejects.toThrow(/PCA account 99|only the PCA owner/i);
 
     expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
@@ -2778,16 +2785,17 @@ decisions: []
       id: 'pca-private-dominates',
       name: 'PCA Private Dominates AccessPolicy',
       private: true,
-      publishAuthorityAccountId: pcaAccountId,
       callerAgentAddress: pcaOwner,
     });
 
     // Register with accessPolicy=1 (matches the daemon route's
     // `inferredAccessPolicy` for `private: true`). The agent must accept
-    // and route into the PCA curated branch.
+    // and route into the PCA curated branch when pcaAccountId is
+    // supplied at register time (Codex PR #502 round-3).
     await expect(agent.registerContextGraph('pca-private-dominates', {
       accessPolicy: 1,
       callerAgentAddress: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
     })).resolves.toMatchObject({ onChainId: expect.any(String) });
 
     expect(chain.createOnChainContextGraphCalls[0]).toMatchObject({

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -102,6 +102,22 @@ class SignerListContextGraphChainAdapter extends CapturingContextGraphChainAdapt
   }
 }
 
+class PcaCuratedRegistrationChainAdapter extends AsyncSignerAddressContextGraphChainAdapter {
+  constructor(
+    private readonly accountOwners: Map<bigint, string>,
+  ) {
+    super();
+  }
+
+  async getPublishingConvictionAccountOwner(accountId: bigint): Promise<string> {
+    const owner = this.accountOwners.get(accountId);
+    if (!owner) {
+      throw new Error(`No mock PCA owner for account ${accountId}`);
+    }
+    return owner;
+  }
+}
+
 class NonRegisteringACKChainAdapter extends MockChainAdapter {
   async ensureOperationalWalletsRegistered(options?: {
     identityId?: bigint;
@@ -2478,6 +2494,120 @@ decisions: []
     await agent.registerContextGraph('register-curated-signer-list-policy', { callerAgentAddress: ownerAgent });
 
     expect(chain.createOnChainContextGraphCalls[0]?.publishAuthority).toBe(ownerAgent);
+    await agent.stop().catch(() => {});
+  });
+
+  it('registers PCA curated context graphs without requiring the chain signer to equal the local curator', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const pcaAccountId = 42n;
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaRegistrationBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    expect(pcaOwner.toLowerCase()).not.toBe(chain.signerAddress.toLowerCase());
+    await agent.createContextGraph({
+      id: 'register-pca-curated-policy',
+      name: 'PCA Curated Policy',
+      accessPolicy: 1,
+      publishAuthorityAccountId: pcaAccountId,
+      callerAgentAddress: pcaOwner,
+    });
+
+    await expect(agent.registerContextGraph('register-pca-curated-policy', { callerAgentAddress: pcaOwner }))
+      .resolves.toMatchObject({ onChainId: expect.any(String) });
+
+    expect(chain.createOnChainContextGraphCalls[0]).toMatchObject({
+      publishPolicy: 0,
+      publishAuthority: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    });
+    await agent.stop().catch(() => {});
+  });
+
+  it('registers PCA curated context graphs when the PCA account id is supplied at registration time', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const pcaAccountId = 43n;
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaRegistrationOverrideBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    await agent.createContextGraph({
+      id: 'register-pca-curated-override-policy',
+      name: 'PCA Curated Override Policy',
+      accessPolicy: 1,
+      callerAgentAddress: pcaOwner,
+    });
+
+    await expect(agent.registerContextGraph('register-pca-curated-override-policy', {
+      callerAgentAddress: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    })).resolves.toMatchObject({ onChainId: expect.any(String) });
+
+    expect(chain.createOnChainContextGraphCalls[0]).toMatchObject({
+      publishPolicy: 0,
+      publishAuthority: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    });
+    await agent.stop().catch(() => {});
+  });
+
+  it('rejects PCA account ids on open context graphs', async () => {
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[7n, ethers.Wallet.createRandom().address]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaOpenPolicyBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    await expect(agent.createContextGraph({
+      id: 'register-open-pca-policy',
+      name: 'Open PCA Policy',
+      publishAuthorityAccountId: 7n,
+      callerAgentAddress: ethers.getAddress(chain.signerAddress),
+    })).rejects.toThrow(/PCA account id.*curated/i);
+
+    await agent.stop().catch(() => {});
+  });
+
+  it('rejects PCA curated registration when local curator is not the PCA owner', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const nonOwner = new ethers.Wallet(HARDHAT_KEYS.REC2_OP).address;
+    const pcaAccountId = 99n;
+    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaRejectsNonOwnerBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    expect(nonOwner.toLowerCase()).not.toBe(pcaOwner.toLowerCase());
+    await agent.createContextGraph({
+      id: 'reject-pca-non-owner',
+      name: 'Reject PCA non-owner',
+      accessPolicy: 1,
+      publishAuthorityAccountId: pcaAccountId,
+      callerAgentAddress: nonOwner,
+    });
+
+    await expect(agent.registerContextGraph('reject-pca-non-owner', {
+      callerAgentAddress: nonOwner,
+    })).rejects.toThrow(/PCA account 99|only the PCA owner/i);
+
+    expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
     await agent.stop().catch(() => {});
   });
 

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -2552,6 +2552,53 @@ decisions: []
     await agent.stop().catch(() => {});
   });
 
+  // Codex PR #502 round-5: PCA registration must fail-closed when the
+  // chain adapter exposes `getPublishingConvictionAccountOwner()` but
+  // doesn't surface its tx signer in any introspectable way. Without
+  // this guard, a custom adapter could sneak past the
+  // "chain signer == PCA owner" invariant and the registration tx
+  // would still mint the governance NFT to whatever address the
+  // adapter actually signs with.
+  it('rejects PCA registration when chain adapter does not expose its tx signer', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const pcaAccountId = 242n;
+    class SignerlessPcaChainAdapter extends PcaCuratedRegistrationChainAdapter {
+      constructor(accountOwners: Map<bigint, string>) {
+        // signerAddress = zero address: every probe path in
+        // inferAdapterPublisherAddress filters it out via
+        // normalizeAdapterPublisherAddress, so
+        // getChainPublishAuthorityAddress returns undefined.
+        super(accountOwners, ethers.ZeroAddress);
+      }
+      override async getSignerAddress(): Promise<string> {
+        throw new Error('signer address not exposed by this adapter');
+      }
+    }
+    const chain = new SignerlessPcaChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    const agent = await DKGAgent.create({
+      name: 'PcaSignerlessAdapterBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    await agent.createContextGraph({
+      id: 'reject-pca-signerless-adapter',
+      name: 'Reject PCA signerless adapter',
+      accessPolicy: 1,
+      callerAgentAddress: pcaOwner,
+    });
+
+    await expect(agent.registerContextGraph('reject-pca-signerless-adapter', {
+      callerAgentAddress: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    })).rejects.toThrow(/does not expose its registration-tx signer|invariant cannot be verified/);
+
+    expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
+    await agent.stop().catch(() => {});
+  });
+
   // Codex PR #502 round-4: rejects PCA registration when the chain
   // signer (registration-tx msg.sender) doesn't match the PCA owner.
   // Without this guard, `ContextGraphs.createContextGraph` on-chain

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -2675,7 +2675,11 @@ decisions: []
     await agent.stop().catch(() => {});
   });
 
-  it('rejects PCA account ids on open context graphs', async () => {
+  // Codex PR #502 round-6: createContextGraph used to accept-then-drop
+  // `publishAuthorityAccountId` silently. Direct agent callers (SDK)
+  // now get an immediate error explaining the param belongs on
+  // `registerContextGraph` instead.
+  it('rejects publishAuthorityAccountId on createContextGraph() — PCA ids are register-time-only', async () => {
     const chain = new PcaCuratedRegistrationChainAdapter(new Map([[7n, ethers.Wallet.createRandom().address]]));
     const agent = await DKGAgent.create({
       name: 'PcaOpenPolicyBot',
@@ -2685,12 +2689,22 @@ decisions: []
     });
     await agent.start();
 
+    // Both axes (curated AND open) reject — the param is no longer
+    // a "validate at create time" knob, it's just unsupported here.
     await expect(agent.createContextGraph({
-      id: 'register-open-pca-policy',
-      name: 'Open PCA Policy',
+      id: 'reject-pca-create-open',
+      name: 'Reject PCA Create (Open)',
       publishAuthorityAccountId: 7n,
       callerAgentAddress: ethers.getAddress(chain.signerAddress),
-    })).rejects.toThrow(/PCA account id.*curated/i);
+    })).rejects.toThrow(/not supported on createContextGraph|register-time-only/i);
+
+    await expect(agent.createContextGraph({
+      id: 'reject-pca-create-curated',
+      name: 'Reject PCA Create (Curated)',
+      accessPolicy: 1,
+      publishAuthorityAccountId: 7n,
+      callerAgentAddress: ethers.getAddress(chain.signerAddress),
+    })).rejects.toThrow(/not supported on createContextGraph|register-time-only/i);
 
     await agent.stop().catch(() => {});
   });

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -105,8 +105,13 @@ class SignerListContextGraphChainAdapter extends CapturingContextGraphChainAdapt
 class PcaCuratedRegistrationChainAdapter extends AsyncSignerAddressContextGraphChainAdapter {
   constructor(
     private readonly accountOwners: Map<bigint, string>,
+    signerAddress?: string,
   ) {
-    super();
+    // Forward an explicit signer to MockChainAdapter so tests can keep
+    // the "chain signer == PCA owner" invariant the agent enforces
+    // (Codex PR #502 round-4: msg.sender for the registration tx mints
+    // the on-chain governance NFT, so the PCA owner must control it).
+    super('mock:31337', signerAddress);
   }
 
   async getPublishingConvictionAccountOwner(accountId: bigint): Promise<string> {
@@ -2497,10 +2502,23 @@ decisions: []
     await agent.stop().catch(() => {});
   });
 
-  it('registers PCA curated context graphs without requiring the chain signer to equal the local curator', async () => {
+  // Codex PR #502 round-4: replaces the previous "without requiring
+  // chain signer == local curator" test. The agent now enforces
+  // "advertised curator == on-chain owner == chain signer == PCA
+  // owner" so the registration tx's msg.sender (which mints the
+  // on-chain governance NFT) is the same address as the PCA owner.
+  // Non-default node operators CAN still PCA-register — they just
+  // need to control the chain signer used for the registration tx.
+  it('registers PCA curated context graphs when the PCA owner controls the chain signer (non-default operator)', async () => {
     const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
     const pcaAccountId = 42n;
-    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    // Chain signer is configured to BE the PCA owner — the PCA owner
+    // controls the registration-tx msg.sender, so the governance NFT
+    // mints to them.
+    const chain = new PcaCuratedRegistrationChainAdapter(
+      new Map([[pcaAccountId, pcaOwner]]),
+      pcaOwner,
+    );
     const agent = await DKGAgent.create({
       name: 'PcaRegistrationBot',
       store: new OxigraphStore(),
@@ -2509,7 +2527,7 @@ decisions: []
     });
     await agent.start();
 
-    expect(pcaOwner.toLowerCase()).not.toBe(chain.signerAddress.toLowerCase());
+    expect(pcaOwner.toLowerCase()).toBe(chain.signerAddress.toLowerCase());
     await agent.createContextGraph({
       id: 'register-pca-curated-policy',
       name: 'PCA Curated Policy',
@@ -2518,7 +2536,7 @@ decisions: []
     });
 
     // pcaAccountId is a register-time knob now (Codex PR #502 round-3);
-    // callers must resupply it on `registerContextGraph` rather than
+    // callers must supply it on `registerContextGraph` rather than
     // relying on a create-time persist that could silently replay a
     // stale id.
     await expect(agent.registerContextGraph('register-pca-curated-policy', {
@@ -2534,10 +2552,54 @@ decisions: []
     await agent.stop().catch(() => {});
   });
 
+  // Codex PR #502 round-4: rejects PCA registration when the chain
+  // signer (registration-tx msg.sender) doesn't match the PCA owner.
+  // Without this guard, `ContextGraphs.createContextGraph` on-chain
+  // mints the governance NFT to msg.sender while local metadata says
+  // the PCA owner is the curator — phantom-owner bug breaking later
+  // `onlyContextGraphOwner` ops.
+  it('rejects PCA registration when chain signer differs from PCA owner', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const pcaAccountId = 142n;
+    // Chain signer is INTENTIONALLY different from the PCA owner —
+    // simulates a node operator trying to PCA-register a CG using a
+    // PCA they don't control the signer for.
+    const chain = new PcaCuratedRegistrationChainAdapter(
+      new Map([[pcaAccountId, pcaOwner]]),
+      /* signerAddress: */ undefined,  // default MOCK_DEFAULT_SIGNER (0x1111...)
+    );
+    const agent = await DKGAgent.create({
+      name: 'PcaSignerMismatchBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    expect(pcaOwner.toLowerCase()).not.toBe(chain.signerAddress.toLowerCase());
+    await agent.createContextGraph({
+      id: 'reject-pca-signer-mismatch',
+      name: 'Reject PCA signer mismatch',
+      accessPolicy: 1,
+      callerAgentAddress: pcaOwner,
+    });
+
+    await expect(agent.registerContextGraph('reject-pca-signer-mismatch', {
+      callerAgentAddress: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    })).rejects.toThrow(/chain signer .* differs from PCA owner|governance NFT mints to/);
+
+    expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
+    await agent.stop().catch(() => {});
+  });
+
   it('registers PCA curated context graphs when the PCA account id is supplied at registration time', async () => {
     const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
     const pcaAccountId = 43n;
-    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    const chain = new PcaCuratedRegistrationChainAdapter(
+      new Map([[pcaAccountId, pcaOwner]]),
+      pcaOwner,
+    );
     const agent = await DKGAgent.create({
       name: 'PcaRegistrationOverrideBot',
       store: new OxigraphStore(),
@@ -2772,7 +2834,12 @@ decisions: []
   it('treats private:true as a curated signal that dominates accessPolicy=0 for PCA registration', async () => {
     const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
     const pcaAccountId = 77n;
-    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    // PCA owner controls the chain signer (Codex PR #502 round-4
+    // contract: chain signer == PCA owner required for PCA mode).
+    const chain = new PcaCuratedRegistrationChainAdapter(
+      new Map([[pcaAccountId, pcaOwner]]),
+      pcaOwner,
+    );
     const agent = await DKGAgent.create({
       name: 'PcaPrivateOverridesAccessPolicyBot',
       store: new OxigraphStore(),

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -2675,10 +2675,16 @@ decisions: []
     await agent.stop().catch(() => {});
   });
 
-  // Codex PR #502 round-6: createContextGraph used to accept-then-drop
-  // `publishAuthorityAccountId` silently. Direct agent callers (SDK)
-  // now get an immediate error explaining the param belongs on
-  // `registerContextGraph` instead.
+  // Codex PR #502 round-6/round-7:
+  //   - round-6: createContextGraph used to accept-then-drop
+  //     `publishAuthorityAccountId` silently. Now fails fast at the
+  //     boundary.
+  //   - round-7: the field was also removed from the public TS
+  //     signature, so typed callers get a compile-time
+  //     excess-property error before they ever hit the runtime guard.
+  //     This test exercises the runtime path via `as any` to simulate
+  //     untyped/JS callers (or typed callers casting around the
+  //     signature).
   it('rejects publishAuthorityAccountId on createContextGraph() — PCA ids are register-time-only', async () => {
     const chain = new PcaCuratedRegistrationChainAdapter(new Map([[7n, ethers.Wallet.createRandom().address]]));
     const agent = await DKGAgent.create({
@@ -2691,12 +2697,14 @@ decisions: []
 
     // Both axes (curated AND open) reject — the param is no longer
     // a "validate at create time" knob, it's just unsupported here.
+    // `as any` deliberately bypasses the (now-narrower) TS signature
+    // to reach the runtime guard.
     await expect(agent.createContextGraph({
       id: 'reject-pca-create-open',
       name: 'Reject PCA Create (Open)',
       publishAuthorityAccountId: 7n,
       callerAgentAddress: ethers.getAddress(chain.signerAddress),
-    })).rejects.toThrow(/not supported on createContextGraph|register-time-only/i);
+    } as any)).rejects.toThrow(/not supported on createContextGraph|register-time-only/i);
 
     await expect(agent.createContextGraph({
       id: 'reject-pca-create-curated',
@@ -2704,7 +2712,7 @@ decisions: []
       accessPolicy: 1,
       publishAuthorityAccountId: 7n,
       callerAgentAddress: ethers.getAddress(chain.signerAddress),
-    })).rejects.toThrow(/not supported on createContextGraph|register-time-only/i);
+    } as any)).rejects.toThrow(/not supported on createContextGraph|register-time-only/i);
 
     await agent.stop().catch(() => {});
   });
@@ -2800,39 +2808,83 @@ decisions: []
     await agent.stop().catch(() => {});
   });
 
-  // Codex review #502 follow-up: PCA mode must be rejected when EITHER
-  // axis is open, not just publishPolicy. A caller cannot bypass the
-  // "curated/private only" contract by explicitly forcing
-  // `publishPolicy: 0 (curated)` together with `accessPolicy: 0 (open)`.
-  it('rejects PCA registration when accessPolicy is open even with explicit publishPolicy=0 (curated)', async () => {
+  // Codex PR #502 round-7: a previous iteration of this test asserted
+  // that `accessPolicy=0 + publishPolicy=0 + pcaAccountId` should be
+  // rejected client-side as "curated/private only". That was wrong —
+  // the on-chain `ContextGraphs.createContextGraph` contract supports
+  // this exact combo (publicly-discoverable CG, only PCA-authorized
+  // publishers can write). The agent guard now rejects ONLY
+  // `publishPolicy === EVM_PUBLISH_OPEN + PCA`. This positive test
+  // pins the broader valid-mode contract.
+  it('accepts PCA registration with accessPolicy=0 (public) + publishPolicy=0 (curated) + pcaAccountId — public-discoverable + PCA-curated is on-chain valid', async () => {
     const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
     const pcaAccountId = 88n;
-    const chain = new PcaCuratedRegistrationChainAdapter(new Map([[pcaAccountId, pcaOwner]]));
+    // Chain signer == PCA owner per the round-4 invariant.
+    const chain = new PcaCuratedRegistrationChainAdapter(
+      new Map([[pcaAccountId, pcaOwner]]),
+      pcaOwner,
+    );
     const agent = await DKGAgent.create({
-      name: 'PcaOpenAccessPolicyBot',
+      name: 'PcaPublicDiscoverableBot',
       store: new OxigraphStore(),
       chainAdapter: chain,
       nodeRole: 'core',
     });
     await agent.start();
 
-    // Create as open (no accessPolicy / private / allowlists). The
-    // agent's createContextGraph PCA gate rejects this at create time,
-    // so we have to set up a CG that's open locally without going
-    // through createContextGraph's PCA branch — use a plain create and
-    // then attempt to force the contradictory combo at register time.
+    // Create as a plain (no allowlist, no private) CG.
     await agent.createContextGraph({
-      id: 'reject-open-access-with-pca',
-      name: 'Reject Open AccessPolicy with PCA',
+      id: 'accept-public-discoverable-pca',
+      name: 'Accept public-discoverable + PCA',
       callerAgentAddress: pcaOwner,
     });
 
-    await expect(agent.registerContextGraph('reject-open-access-with-pca', {
+    await expect(agent.registerContextGraph('accept-public-discoverable-pca', {
       callerAgentAddress: pcaOwner,
       accessPolicy: 0,
       publishPolicy: 0,
       publishAuthorityAccountId: pcaAccountId,
-    })).rejects.toThrow(/PCA account id can only be used with curated\/private context graphs/);
+    })).resolves.toMatchObject({ onChainId: expect.any(String) });
+
+    expect(chain.createOnChainContextGraphCalls[0]).toMatchObject({
+      accessPolicy: 0,
+      publishPolicy: 0,
+      publishAuthority: pcaOwner,
+      publishAuthorityAccountId: pcaAccountId,
+    });
+    await agent.stop().catch(() => {});
+  });
+
+  // Codex PR #502 round-7 (complementary negative test): the only
+  // axis where PCA is incoherent is `publishPolicy === EVM_PUBLISH_OPEN`.
+  // The on-chain `isAuthorizedPublisher`'s PCA branch never fires for
+  // open publish policy, so the combo is genuinely meaningless.
+  it('rejects PCA registration when publishPolicy is open (regardless of accessPolicy)', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const pcaAccountId = 188n;
+    const chain = new PcaCuratedRegistrationChainAdapter(
+      new Map([[pcaAccountId, pcaOwner]]),
+      pcaOwner,
+    );
+    const agent = await DKGAgent.create({
+      name: 'PcaOpenPublishPolicyBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    await agent.createContextGraph({
+      id: 'reject-open-publish-policy-pca',
+      name: 'Reject open publishPolicy + PCA',
+      callerAgentAddress: pcaOwner,
+    });
+
+    await expect(agent.registerContextGraph('reject-open-publish-policy-pca', {
+      callerAgentAddress: pcaOwner,
+      publishPolicy: 1,  // open
+      publishAuthorityAccountId: pcaAccountId,
+    })).rejects.toThrow(/curated publish policy/i);
 
     expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
     await agent.stop().catch(() => {});

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -2938,6 +2938,61 @@ decisions: []
     await agent.stop().catch(() => {});
   });
 
+  // Codex PR #502 round-9: untyped callers can pass `1` / `'1'` /
+  // `1n` for pcaAccountId. The previous round-8 coercion accepted
+  // `Number.isInteger(...)`, which silently lets unsafe ints
+  // (above 2^53-1) round-trip through `BigInt(...)` with the wrong
+  // value. Test pins the safer `Number.isSafeInteger` contract.
+  it('rejects unsafe JS integers as publishAuthorityAccountId — only safe ints / bigints / decimal strings accepted', async () => {
+    const pcaOwner = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const chain = new PcaCuratedRegistrationChainAdapter(
+      new Map([[42n, pcaOwner]]),
+      pcaOwner,
+    );
+    const agent = await DKGAgent.create({
+      name: 'PcaUnsafeIntegerBot',
+      store: new OxigraphStore(),
+      chainAdapter: chain,
+      nodeRole: 'core',
+    });
+    await agent.start();
+
+    await agent.createContextGraph({
+      id: 'reject-unsafe-int-pca',
+      name: 'Reject unsafe int PCA',
+      accessPolicy: 1,
+      callerAgentAddress: pcaOwner,
+    });
+
+    // 2^60 — well above Number.MAX_SAFE_INTEGER (2^53-1). JS would
+    // silently round before BigInt(...) sees it.
+    await expect(agent.registerContextGraph('reject-unsafe-int-pca', {
+      callerAgentAddress: pcaOwner,
+      publishAuthorityAccountId: Math.pow(2, 60) as unknown as bigint,
+    })).rejects.toThrow(/PCA account id must be a positive integer/);
+
+    // Negative number.
+    await expect(agent.registerContextGraph('reject-unsafe-int-pca', {
+      callerAgentAddress: pcaOwner,
+      publishAuthorityAccountId: -1 as unknown as bigint,
+    })).rejects.toThrow(/PCA account id must be a positive integer/);
+
+    // Floating-point.
+    await expect(agent.registerContextGraph('reject-unsafe-int-pca', {
+      callerAgentAddress: pcaOwner,
+      publishAuthorityAccountId: 1.5 as unknown as bigint,
+    })).rejects.toThrow(/PCA account id must be a positive integer/);
+
+    // Non-numeric string.
+    await expect(agent.registerContextGraph('reject-unsafe-int-pca', {
+      callerAgentAddress: pcaOwner,
+      publishAuthorityAccountId: 'abc' as unknown as bigint,
+    })).rejects.toThrow(/PCA account id must be a positive integer/);
+
+    expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
+    await agent.stop().catch(() => {});
+  });
+
   // Codex review #502-2: `{ private: true, accessPolicy: 0,
   // pcaAccountId }` create+register must not flip-flop between curated
   // (at create time) and open (at register time). The daemon route's

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -582,6 +582,13 @@ export interface ChainAdapter {
   getConvictionDiscount?(accountId: bigint): Promise<{ discountBps: number; conviction: bigint }>;
   getConvictionAccountInfo?(accountId: bigint): Promise<ConvictionAccountInfo | null>;
   /**
+   * Live owner lookup for a PCA NFT — wraps `DKGPublishingConvictionNFT.ownerOf(accountId)`.
+   * Used by the daemon's curated-CG registration preflight to enforce
+   * `local curator == ownerOf(pcaAccountId)` so an agent wallet cannot
+   * impersonate ownership when tying a CG to a PCA.
+   */
+  getPublishingConvictionAccountOwner?(accountId: bigint): Promise<string>;
+  /**
    * Authorize an EOA to draw down on the PCA's discounted publishing
    * allowance. Wraps `PublishingConvictionAccount.addAuthorizedKey(accountId, key)`,
    * which the contract gates on `msg.sender == account.admin` — i.e. the

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -2570,6 +2570,13 @@ export class EVMChainAdapter implements ChainAdapter {
     }
   }
 
+  async getPublishingConvictionAccountOwner(accountId: bigint): Promise<string> {
+    await this.init();
+    const nft = await this.resolveContract('DKGPublishingConvictionNFT');
+    const owner = await nft.ownerOf(accountId);
+    return ethers.getAddress(owner);
+  }
+
   async getConvictionDiscount(accountId: bigint): Promise<{ discountBps: number; conviction: bigint }> {
     await this.init();
     if (!this.contracts.publishingConvictionAccount) {

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -674,6 +674,22 @@ export class MockChainAdapter implements ChainAdapter {
     return 0;
   }
 
+  /**
+   * Mock owner-lookup for the daemon's curated-CG registration
+   * preflight (`local curator == ownerOf(pcaAccountId)`).
+   *
+   * Mock does not model PCA NFT transfers, so the account `admin`
+   * doubles as the current "owner" for parity-test purposes. Real-chain
+   * tests use `EVMChainAdapter`, which queries `DKGPublishingConvictionNFT.ownerOf`.
+   */
+  async getPublishingConvictionAccountOwner(accountId: bigint): Promise<string> {
+    const acct = this.convictionAccounts.get(accountId);
+    if (!acct) {
+      throw new Error(`Mock: PCA account ${accountId} does not exist`);
+    }
+    return ethers.getAddress(acct.admin);
+  }
+
   // --- Staking Conviction ---
 
   private delegatorLocks = new Map<string, { lockTier: number; startEpoch: number }>();
@@ -768,11 +784,14 @@ export class MockChainAdapter implements ChainAdapter {
     }
     publishAuthority = ethers.getAddress(publishAuthority);
     if (publishPolicy === 0) {
-      if (publishAuthorityAccountId !== 0n) {
-        throw new Error('Mock: PCA publishAuthorityAccountId is not supported');
-      }
       if (publishAuthority === ethers.ZeroAddress) {
         publishAuthority = ethers.getAddress(this.signerAddress);
+      }
+      if (publishAuthorityAccountId !== 0n) {
+        const pcaOwner = await this.getPublishingConvictionAccountOwner(publishAuthorityAccountId);
+        if (publishAuthority.toLowerCase() !== pcaOwner.toLowerCase()) {
+          throw new Error('Mock: PCA publishAuthority must match account owner');
+        }
       }
     } else {
       if (publishAuthority !== ethers.ZeroAddress) {

--- a/packages/chain/src/no-chain-adapter.ts
+++ b/packages/chain/src/no-chain-adapter.ts
@@ -49,6 +49,7 @@ export class NoChainAdapter implements ChainAdapter {
   async isOperationalWalletRegistered(_identityId: bigint, _address: string): Promise<boolean> { return false; }
   async getKnowledgeAssetsV10Address(): Promise<string> { noChain(); }
   async getEvmChainId(): Promise<bigint> { noChain(); }
+  async getPublishingConvictionAccountOwner(_accountId: bigint): Promise<string> { noChain(); }
   isV10Ready(): boolean { return false; }
   isRandomSamplingReady(): boolean { return false; }
 }

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -284,12 +284,34 @@ describe('MockChainAdapter API parity with EVMChainAdapter [CH-8]', () => {
       ...base,
       publishPolicy: 0,
       publishAuthorityAccountId: 1n,
-    })).rejects.toThrow(/PCA publishAuthorityAccountId is not supported/);
+    })).rejects.toThrow(/PCA account 1 does not exist/);
+
+    const { accountId } = await mock.createConvictionAccount(1n, 1);
 
     await expect(mock.createOnChainContextGraph({
       ...base,
       publishPolicy: 0,
+      publishAuthority: '0x2222222222222222222222222222222222222222',
+      publishAuthorityAccountId: accountId,
+    })).rejects.toThrow(/PCA publishAuthority must match account owner/);
+
+    await expect(mock.createOnChainContextGraph({
+      ...base,
+      publishPolicy: 0,
+      publishAuthority: '0x1111111111111111111111111111111111111111',
+      publishAuthorityAccountId: accountId,
     })).resolves.toMatchObject({ contextGraphId: 1n });
+
+    await expect(mock.createOnChainContextGraph({
+      ...base,
+      publishPolicy: 0,
+      publishAuthorityAccountId: accountId,
+    })).resolves.toMatchObject({ contextGraphId: 2n });
+
+    await expect(mock.createOnChainContextGraph({
+      ...base,
+      publishPolicy: 0,
+    })).resolves.toMatchObject({ contextGraphId: 3n });
   });
 
   it('requires explicit mock support for address-specific V10 publishing', async () => {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -896,15 +896,31 @@ export class ApiClient {
     participantAgents?: string[];
     participantIdentityIds?: Array<string | number | bigint>;
     requiredSignatures?: number;
-    // NOTE: pcaAccountId is intentionally NOT a `createContextGraph`
-    // option here — the agent's createContextGraph no longer persists
-    // it (Codex PR #502 round-4), so passing it on the create call
-    // would be a silent no-op. Use the `pcaAccountId` field on
-    // `registerContextGraph` instead, or call POST /api/context-graph/create
-    // directly with `register: true` for the inline combined flow.
+    /**
+     * Atomic combined-flow flag. When `true`, the daemon registers the
+     * CG on-chain in the same call after the local create step
+     * succeeds. Required when `pcaAccountId` is supplied (a standalone
+     * `createContextGraph` does NOT persist PCA ids — Codex PR #502
+     * round-3).
+     */
+    register?: boolean;
+    /**
+     * Publishing Conviction Account id for PCA-curated registration.
+     * Only meaningful together with `register: true`. The daemon
+     * rejects the create-only-with-pcaAccountId combo with a 400
+     * (Codex PR #502 round-5). For a two-step flow, use
+     * {@link registerContextGraph} instead.
+     */
+    pcaAccountId?: string | number | bigint;
   }, allowedPeers?: string[]): Promise<{
     created: string;
     uri: string;
+    /** Present only when caller passed `register: true`. */
+    registered?: boolean;
+    onChainId?: string;
+    /** Present when `register: true` was requested but the register leg failed. */
+    registerError?: string;
+    hint?: string;
   }> {
     return this.post('/api/context-graph/create', {
       id,
@@ -919,6 +935,8 @@ export class ApiClient {
         ? { participantIdentityIds: options.participantIdentityIds.map((id) => id.toString()) }
         : {}),
       ...(options?.requiredSignatures != null ? { requiredSignatures: options.requiredSignatures } : {}),
+      ...(options?.register === true ? { register: true } : {}),
+      ...(options?.pcaAccountId != null ? { pcaAccountId: options.pcaAccountId.toString() } : {}),
     });
   }
 

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -905,6 +905,18 @@ export class ApiClient {
      */
     register?: boolean;
     /**
+     * Publish policy override forwarded to `registerContextGraph` in
+     * the combined-flow path. Only meaningful together with
+     * `register: true`. The agent otherwise defaults
+     * `publishPolicy = curated (0)` for curated/private CGs and
+     * `publishPolicy = open (1)` for public CGs — which makes the
+     * valid `{ accessPolicy: 0 (public), publishPolicy: 0 (curated),
+     * pcaAccountId }` combo unreachable unless the caller can pin
+     * `publishPolicy` explicitly. Codex PR #502 round-10 (raised by
+     * @branarakic).
+     */
+    publishPolicy?: number;
+    /**
      * Publishing Conviction Account id for PCA-curated registration.
      * Only meaningful together with `register: true`. The daemon
      * rejects the create-only-with-pcaAccountId combo with a 400
@@ -936,6 +948,7 @@ export class ApiClient {
         : {}),
       ...(options?.requiredSignatures != null ? { requiredSignatures: options.requiredSignatures } : {}),
       ...(options?.register === true ? { register: true } : {}),
+      ...(options?.publishPolicy != null ? { publishPolicy: options.publishPolicy } : {}),
       ...(options?.pcaAccountId != null ? { pcaAccountId: options.pcaAccountId.toString() } : {}),
     });
   }

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -896,6 +896,7 @@ export class ApiClient {
     participantAgents?: string[];
     participantIdentityIds?: Array<string | number | bigint>;
     requiredSignatures?: number;
+    pcaAccountId?: string | number | bigint;
   }, allowedPeers?: string[]): Promise<{
     created: string;
     uri: string;
@@ -913,6 +914,7 @@ export class ApiClient {
         ? { participantIdentityIds: options.participantIdentityIds.map((id) => id.toString()) }
         : {}),
       ...(options?.requiredSignatures != null ? { requiredSignatures: options.requiredSignatures } : {}),
+      ...(options?.pcaAccountId != null ? { pcaAccountId: options.pcaAccountId.toString() } : {}),
     });
   }
 
@@ -928,6 +930,7 @@ export class ApiClient {
     revealOnChain?: boolean;
     accessPolicy?: number;
     publishPolicy?: number;
+    pcaAccountId?: string | number | bigint;
   }): Promise<{
     registered: string;
     onChainId: string;
@@ -937,6 +940,7 @@ export class ApiClient {
       id,
       ...(opts?.accessPolicy != null ? { accessPolicy: opts.accessPolicy } : {}),
       ...(opts?.publishPolicy != null ? { publishPolicy: opts.publishPolicy } : {}),
+      ...(opts?.pcaAccountId != null ? { pcaAccountId: opts.pcaAccountId.toString() } : {}),
     });
   }
 

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -896,7 +896,12 @@ export class ApiClient {
     participantAgents?: string[];
     participantIdentityIds?: Array<string | number | bigint>;
     requiredSignatures?: number;
-    pcaAccountId?: string | number | bigint;
+    // NOTE: pcaAccountId is intentionally NOT a `createContextGraph`
+    // option here — the agent's createContextGraph no longer persists
+    // it (Codex PR #502 round-4), so passing it on the create call
+    // would be a silent no-op. Use the `pcaAccountId` field on
+    // `registerContextGraph` instead, or call POST /api/context-graph/create
+    // directly with `register: true` for the inline combined flow.
   }, allowedPeers?: string[]): Promise<{
     created: string;
     uri: string;
@@ -914,7 +919,6 @@ export class ApiClient {
         ? { participantIdentityIds: options.participantIdentityIds.map((id) => id.toString()) }
         : {}),
       ...(options?.requiredSignatures != null ? { requiredSignatures: options.requiredSignatures } : {}),
-      ...(options?.pcaAccountId != null ? { pcaAccountId: options.pcaAccountId.toString() } : {}),
     });
   }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1313,7 +1313,6 @@ contextGraphCmd
     [] as string[],
   )
   .option('--required-signatures <n>', 'Required signatures threshold for participant-based context graphs')
-  .option('--pca-account-id <id>', 'Publishing Conviction Account id for PCA-curated on-chain registration')
   .option('--subscribe', 'Also subscribe to the context graph after creation', true)
   .option('--save', 'Persist subscription to config')
   .action(async (id: string, opts: ActionOpts) => {
@@ -1328,14 +1327,13 @@ contextGraphCmd
 
       const participantIdentityIds = (opts.participantIdentityId as string[] | undefined) ?? [];
       const allowedAgents = (opts.allowedAgent as string[] | undefined) ?? [];
-      const pcaAccountId = opts.pcaAccountId as string | undefined;
-      if (pcaAccountId && !/^[1-9]\d*$/.test(pcaAccountId)) {
-        throw new Error('--pca-account-id must be a positive decimal integer');
-      }
-      if (pcaAccountId && opts.accessPolicy === 0 && !opts.private) {
-        throw new Error('--pca-account-id can only be used with curated/private context graphs');
-      }
-      const accessPolicy = allowedAgents.length > 0 || pcaAccountId ? 1 : (opts.accessPolicy as number | undefined);
+      // pcaAccountId is intentionally NOT a flag on `create` —
+      // `createContextGraph` no longer persists the id, so a
+      // create-time flag would silently drop the PCA configuration
+      // before `register <id>` is run (Codex PR #502 round-4). Users
+      // who want PCA-curated registration pass `--pca-account-id` on
+      // `dkg context-graph register <id>` instead.
+      const accessPolicy = allowedAgents.length > 0 ? 1 : (opts.accessPolicy as number | undefined);
 
       const result = await client.createContextGraph(id, opts.name ?? id, opts.description, {
         private: !!opts.private,
@@ -1343,7 +1341,6 @@ contextGraphCmd
         allowedAgents: allowedAgents.length > 0 ? allowedAgents : undefined,
         participantIdentityIds,
         requiredSignatures: opts.requiredSignatures != null ? Number(opts.requiredSignatures) : undefined,
-        pcaAccountId,
       }, opts.invite as string[] | undefined);
       console.log(`Context graph created:`);
       console.log(`  ID:   ${result.created}`);
@@ -1360,9 +1357,6 @@ contextGraphCmd
       }
       if (opts.requiredSignatures != null) {
         console.log(`  Required signatures: ${opts.requiredSignatures}`);
-      }
-      if (pcaAccountId) {
-        console.log(`  PCA account id: ${pcaAccountId}`);
       }
       console.log(`  Run 'dkg context-graph register ${id}' to register on-chain (unlocks Verified Memory).`);
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1313,6 +1313,7 @@ contextGraphCmd
     [] as string[],
   )
   .option('--required-signatures <n>', 'Required signatures threshold for participant-based context graphs')
+  .option('--pca-account-id <id>', 'Publishing Conviction Account id for PCA-curated on-chain registration')
   .option('--subscribe', 'Also subscribe to the context graph after creation', true)
   .option('--save', 'Persist subscription to config')
   .action(async (id: string, opts: ActionOpts) => {
@@ -1327,7 +1328,14 @@ contextGraphCmd
 
       const participantIdentityIds = (opts.participantIdentityId as string[] | undefined) ?? [];
       const allowedAgents = (opts.allowedAgent as string[] | undefined) ?? [];
-      const accessPolicy = allowedAgents.length > 0 ? 1 : (opts.accessPolicy as number | undefined);
+      const pcaAccountId = opts.pcaAccountId as string | undefined;
+      if (pcaAccountId && !/^[1-9]\d*$/.test(pcaAccountId)) {
+        throw new Error('--pca-account-id must be a positive decimal integer');
+      }
+      if (pcaAccountId && opts.accessPolicy === 0 && !opts.private) {
+        throw new Error('--pca-account-id can only be used with curated/private context graphs');
+      }
+      const accessPolicy = allowedAgents.length > 0 || pcaAccountId ? 1 : (opts.accessPolicy as number | undefined);
 
       const result = await client.createContextGraph(id, opts.name ?? id, opts.description, {
         private: !!opts.private,
@@ -1335,6 +1343,7 @@ contextGraphCmd
         allowedAgents: allowedAgents.length > 0 ? allowedAgents : undefined,
         participantIdentityIds,
         requiredSignatures: opts.requiredSignatures != null ? Number(opts.requiredSignatures) : undefined,
+        pcaAccountId,
       }, opts.invite as string[] | undefined);
       console.log(`Context graph created:`);
       console.log(`  ID:   ${result.created}`);
@@ -1351,6 +1360,9 @@ contextGraphCmd
       }
       if (opts.requiredSignatures != null) {
         console.log(`  Required signatures: ${opts.requiredSignatures}`);
+      }
+      if (pcaAccountId) {
+        console.log(`  PCA account id: ${pcaAccountId}`);
       }
       console.log(`  Run 'dkg context-graph register ${id}' to register on-chain (unlocks Verified Memory).`);
 
@@ -1385,19 +1397,28 @@ contextGraphCmd
   .option('--reveal', 'Deprecated: V10 ContextGraphs registration does not reveal cleartext metadata on-chain')
   .option('--access-policy <n>', 'Access policy: 0 = public/discoverable, 1 = private/curated', parseInt)
   .option('--publish-policy <n>', 'Publish policy: 0 = curated, 1 = open', parseInt)
+  .option('--pca-account-id <id>', 'Publishing Conviction Account id for PCA-curated registration')
   .action(async (id: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();
       if (opts.reveal) {
         console.warn('--reveal is deprecated and ignored for V10 ContextGraphs registration.');
       }
+      const pcaAccountId = opts.pcaAccountId as string | undefined;
+      if (pcaAccountId && !/^[1-9]\d*$/.test(pcaAccountId)) {
+        throw new Error('--pca-account-id must be a positive decimal integer');
+      }
       const result = await client.registerContextGraph(id, {
         accessPolicy: opts.accessPolicy != null ? Number(opts.accessPolicy) : undefined,
         publishPolicy: opts.publishPolicy != null ? Number(opts.publishPolicy) : undefined,
+        pcaAccountId,
       });
       console.log(`Context graph registered on-chain:`);
       console.log(`  ID:         ${id}`);
       console.log(`  On-chain:   ${result.onChainId}`);
+      if (pcaAccountId) {
+        console.log(`  PCA account id: ${pcaAccountId}`);
+      }
       console.log(`  ${result.hint ?? 'You can now publish SWM to Verified Memory.'}`);
     } catch (err) {
       console.error(toErrorMessage(err));

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -327,6 +327,50 @@ import {
 
 import type { RequestContext } from './context.js';
 
+/**
+ * Map a `registerContextGraph` failure message to an HTTP status +
+ * stable error body. Shared by:
+ *   - POST /api/context-graph/register (standalone register call).
+ *   - POST /api/context-graph/create { register: true, pcaAccountId }
+ *     (atomic combined-flow inline register leg).
+ *
+ * Codex PR #502 round-8: the combined-flow register failure used to
+ * always return HTTP 200 with `registered: false`, which silently
+ * masks PCA / authz / shape errors as success unless callers
+ * remember to inspect the response body. Both endpoints now share
+ * the same 4xx / 5xx mapping for caller-input / unsupported-feature
+ * failures; only genuinely transient chain failures keep the
+ * 200-partial-success shape via `genericFallbackStatus = 200`.
+ *
+ * Returns `undefined` when no specific mapping applies — callers
+ * decide whether that means generic 500 (standalone /register
+ * shape) or a 200-partial-success body (combined flow's transient
+ * fallback).
+ */
+function classifyRegisterContextGraphError(msg: string): { status: number; body?: Record<string, unknown> } | undefined {
+  if (msg.includes('already registered')) return { status: 409, body: { error: msg } };
+  if (msg.includes('does not exist')) return { status: 404, body: { error: msg } };
+  if (msg.includes('no known creator')) return { status: 503, body: { error: msg, hint: 'Creator not yet synced. Retry after sync completes.' } };
+  if (msg.includes('Only the context graph creator')) return { status: 403, body: { error: msg } };
+  if (msg.includes('Only the context graph curator')) return { status: 403, body: { error: msg } };
+  if (msg.includes('address-scoped curator')) return { status: 403, body: { error: msg } };
+  if (msg.includes('PCA account id can only be used with curated publish policy')
+    || msg.includes('PCA account id can only be used with curated/private context graphs')) {
+    return { status: 400, body: { error: msg } };
+  }
+  if (msg.includes('PCA account id must be a positive integer')) return { status: 400, body: { error: msg } };
+  if (msg.includes('requires chain adapter PCA owner lookup support')) return { status: 501, body: { error: msg } };
+  if (/PCA account \d+ does not exist or cannot be looked up/.test(msg)) return { status: 404, body: { error: msg } };
+  if (/PCA account \d+ is owned by/.test(msg)) return { status: 403, body: { error: msg } };
+  // PCA chain-signer / signer-introspection invariants (Codex round-4/5/8):
+  if (msg.includes('chain signer') && msg.includes('differs from PCA owner')) return { status: 403, body: { error: msg } };
+  if (msg.includes('does not expose its registration-tx signer')
+    || msg.includes('invariant cannot be verified')) {
+    return { status: 501, body: { error: msg } };
+  }
+  return undefined;
+}
+
 function parseOptionalPcaAccountId(body: Record<string, unknown>): { value?: bigint; error?: string } {
   const raw = body.pcaAccountId;
   if (raw === undefined || raw === null || raw === '') return {};
@@ -565,17 +609,40 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
           onChainId: regResult.onChainId,
         });
       } catch (regErr: any) {
-        process.stderr.write(`[DKG-Daemon] WARN: Context graph "${id}" created locally but on-chain registration failed: ${regErr?.message ?? 'unknown error'}\n`);
+        const regMsg = regErr?.message ?? 'unknown error';
+        process.stderr.write(`[DKG-Daemon] WARN: Context graph "${id}" created locally but on-chain registration failed: ${regMsg}\n`);
         // No rollback of `pcaAccountId` needed: `createContextGraph`
         // no longer persists it (Codex PR #502 round-3) — callers must
         // resupply at register time, so a failed register leg simply
         // leaves the CG with no stored PCA id, which is the correct
         // "no PCA yet" state.
+        //
+        // Map caller-input / unsupported-feature failures to the same
+        // 4xx / 5xx status codes /api/context-graph/register uses —
+        // returning 200 here silently masked bad PCA ids, authz
+        // failures, etc. as success unless callers remembered to
+        // inspect `registered: false` (Codex PR #502 round-8). The
+        // response body carries `created: true` so callers know the
+        // local create succeeded and they can retry the register leg.
+        const classified = classifyRegisterContextGraphError(regMsg);
+        if (classified) {
+          return jsonResponse(res, classified.status, {
+            ...(classified.body ?? { error: regMsg }),
+            created: id,
+            uri: `did:dkg:context-graph:${id}`,
+            registered: false,
+            registerError: regMsg,
+            hint: 'CG created locally. Fix the register-leg input and call POST /api/context-graph/register to retry on-chain registration.',
+          });
+        }
+        // Unclassified failures (transient chain errors, unknown
+        // adapter reverts) keep the legacy 200-partial-success shape
+        // so callers can retry cheaply without losing the local CG.
         return jsonResponse(res, 200, {
           created: id,
           uri: `did:dkg:context-graph:${id}`,
           registered: false,
-          registerError: regErr?.message ?? 'Registration failed',
+          registerError: regMsg,
           hint: 'CG created locally. Use POST /api/context-graph/register to retry on-chain registration.',
         });
       }
@@ -623,43 +690,9 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       });
     } catch (err: any) {
       const msg = err?.message ?? '';
-      if (msg.includes('already registered')) {
-        return jsonResponse(res, 409, { error: msg });
-      }
-      if (msg.includes('does not exist')) {
-        return jsonResponse(res, 404, { error: msg });
-      }
-      if (msg.includes('no known creator')) {
-        return jsonResponse(res, 503, { error: msg, hint: 'Creator not yet synced. Retry after sync completes.' });
-      }
-      if (msg.includes('Only the context graph creator')) {
-        return jsonResponse(res, 403, { error: msg });
-      }
-      if (msg.includes('Only the context graph curator')) {
-        return jsonResponse(res, 403, { error: msg });
-      }
-      if (msg.includes('address-scoped curator')) {
-        return jsonResponse(res, 403, { error: msg });
-      }
-      if (msg.includes('PCA account id can only be used with curated publish policy')
-        || msg.includes('PCA account id can only be used with curated/private context graphs')) {
-        return jsonResponse(res, 400, { error: msg });
-      }
-      // PCA-specific 4xx mapping (Codex review #502-3): caller-input or
-      // unsupported-feature failures should not surface as 500s with raw
-      // chain/adapter revert text. Order matters — more specific matches
-      // come first.
-      if (msg.includes('PCA account id must be a positive integer')) {
-        return jsonResponse(res, 400, { error: msg });
-      }
-      if (msg.includes('requires chain adapter PCA owner lookup support')) {
-        return jsonResponse(res, 501, { error: msg });
-      }
-      if (/PCA account \d+ does not exist or cannot be looked up/.test(msg)) {
-        return jsonResponse(res, 404, { error: msg });
-      }
-      if (/PCA account \d+ is owned by/.test(msg)) {
-        return jsonResponse(res, 403, { error: msg });
+      const classified = classifyRegisterContextGraphError(msg);
+      if (classified) {
+        return jsonResponse(res, classified.status, classified.body ?? { error: msg });
       }
       return jsonResponse(res, 500, { error: msg });
     }

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -465,14 +465,19 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     if (parsedPcaAccountId.error) {
       return jsonResponse(res, 400, { error: parsedPcaAccountId.error });
     }
-    // pcaAccountId is a curated signal: reject explicit incoherent combos
-    // (`publishPolicy: 1 (open)` or `accessPolicy: 0 (open)`) at the API
-    // boundary instead of letting them surface as 500s from the agent.
+    // pcaAccountId is a curated-publish signal: reject ONLY the
+    // explicit `publishPolicy: 1 (open)` combo at the API boundary
+    // instead of letting it surface as a 500 from the agent.
+    //
+    // Note: we deliberately do NOT reject `accessPolicy: 0 (public)`
+    // alongside pcaAccountId — the on-chain
+    // `ContextGraphs.createContextGraph` contract supports
+    // `{ accessPolicy: 0, publishPolicy: 0, pcaAccountId: !=0 }`
+    // (publicly-discoverable CG where only PCA-authorized publishers
+    // can write). Rejecting it here would block a valid registration
+    // mode (Codex PR #502 round-7).
     if (parsedPcaAccountId.value !== undefined && publishPolicy === 1) {
-      return jsonResponse(res, 400, { error: 'pcaAccountId is only valid for curated context graphs (publishPolicy=0)' });
-    }
-    if (parsedPcaAccountId.value !== undefined && accessPolicy === 0 && parsed.private !== true) {
-      return jsonResponse(res, 400, { error: 'pcaAccountId is only valid for curated/private context graphs' });
+      return jsonResponse(res, 400, { error: 'pcaAccountId is only valid with curated publish policy (publishPolicy=0)' });
     }
     // pcaAccountId on a create-only request is a silent foot-gun:
     // `createContextGraph()` no longer persists it (Codex PR #502
@@ -636,7 +641,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       if (msg.includes('address-scoped curator')) {
         return jsonResponse(res, 403, { error: msg });
       }
-      if (msg.includes('PCA account id can only be used with curated/private context graphs')) {
+      if (msg.includes('PCA account id can only be used with curated publish policy')
+        || msg.includes('PCA account id can only be used with curated/private context graphs')) {
         return jsonResponse(res, 400, { error: msg });
       }
       // PCA-specific 4xx mapping (Codex review #502-3): caller-input or

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -542,20 +542,11 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
         });
       } catch (regErr: any) {
         process.stderr.write(`[DKG-Daemon] WARN: Context graph "${id}" created locally but on-chain registration failed: ${regErr?.message ?? 'unknown error'}\n`);
-        // Roll back the create-time pcaAccountId persist on register
-        // failure. Without this, a bad id supplied via /create
-        // { register: true } would stick in local CG metadata and
-        // silently replay on every retry that omits the param (Codex
-        // review #502 follow-up on dkg-agent.ts:7175).
-        if (parsedPcaAccountId.value !== undefined) {
-          try {
-            await agent.clearContextGraphPublishAuthorityAccountId(id);
-          } catch (clearErr: any) {
-            process.stderr.write(
-              `[DKG-Daemon] WARN: failed to roll back pcaAccountId for "${id}" after register failure: ${clearErr?.message ?? 'unknown error'}\n`,
-            );
-          }
-        }
+        // No rollback of `pcaAccountId` needed: `createContextGraph`
+        // no longer persists it (Codex PR #502 round-3) — callers must
+        // resupply at register time, so a failed register leg simply
+        // leaves the CG with no stored PCA id, which is the correct
+        // "no PCA yet" state.
         return jsonResponse(res, 200, {
           created: id,
           uri: `did:dkg:context-graph:${id}`,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -327,6 +327,23 @@ import {
 
 import type { RequestContext } from './context.js';
 
+function parseOptionalPcaAccountId(body: Record<string, unknown>): { value?: bigint; error?: string } {
+  const raw = body.pcaAccountId;
+  if (raw === undefined || raw === null || raw === '') return {};
+  if (typeof raw === 'number') {
+    if (!Number.isSafeInteger(raw) || raw <= 0) {
+      return { error: 'pcaAccountId must be a positive safe integer' };
+    }
+    return { value: BigInt(raw) };
+  }
+  if (typeof raw === 'string') {
+    if (!/^[1-9]\d*$/.test(raw)) {
+      return { error: 'pcaAccountId must be a positive decimal integer string' };
+    }
+    return { value: BigInt(raw) };
+  }
+  return { error: 'pcaAccountId must be a positive integer or decimal integer string' };
+}
 
 export async function handleContextGraphRoutes(ctx: RequestContext): Promise<void> {
   const {
@@ -444,6 +461,28 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       return jsonResponse(res, 400, { error: 'Missing "id" or "name"' });
     if (!isValidContextGraphId(id))
       return jsonResponse(res, 400, { error: "Invalid context graph id" });
+    const parsedPcaAccountId = parseOptionalPcaAccountId(parsed);
+    if (parsedPcaAccountId.error) {
+      return jsonResponse(res, 400, { error: parsedPcaAccountId.error });
+    }
+    // pcaAccountId is a curated signal: reject explicit incoherent combos
+    // (`publishPolicy: 1 (open)` or `accessPolicy: 0 (open)`) at the API
+    // boundary instead of letting them surface as 500s from the agent.
+    if (parsedPcaAccountId.value !== undefined && publishPolicy === 1) {
+      return jsonResponse(res, 400, { error: 'pcaAccountId is only valid for curated context graphs (publishPolicy=0)' });
+    }
+    if (parsedPcaAccountId.value !== undefined && accessPolicy === 0 && parsed.private !== true) {
+      return jsonResponse(res, 400, { error: 'pcaAccountId is only valid for curated/private context graphs' });
+    }
+    // When pcaAccountId is supplied without an explicit accessPolicy, infer
+    // curated. Matches Codex review feedback: pcaAccountId on its own is a
+    // curated signal so raw HTTP/SDK callers don't have to know to also set
+    // accessPolicy=1 just to get past validation.
+    const inferredAccessPolicy = typeof accessPolicy === 'number'
+      ? accessPolicy
+      : parsedPcaAccountId.value !== undefined
+        ? 1
+        : undefined;
     try {
       await agent.createContextGraph({
         id,
@@ -452,8 +491,9 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
         allowedAgents: Array.isArray(allowedAgents) ? allowedAgents : undefined,
         allowedPeers: Array.isArray(allowedPeers) ? allowedPeers : undefined,
         participantAgents: Array.isArray(participantAgents) ? participantAgents : undefined,
-        accessPolicy: typeof accessPolicy === 'number' ? accessPolicy : undefined,
+        accessPolicy: inferredAccessPolicy,
         callerAgentAddress: requestAgentAddress,
+        publishAuthorityAccountId: parsedPcaAccountId.value,
         ...(parsed.private === true ? { private: true } : {}),
         ...(Array.isArray(parsed.participantIdentityIds)
           ? { participantIdentityIds: parsed.participantIdentityIds.map((v: string | number) => BigInt(v)) }
@@ -480,6 +520,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
           callerAgentAddress: requestAgentAddress,
           accessPolicy: typeof accessPolicy === 'number' ? accessPolicy : undefined,
           publishPolicy: typeof publishPolicy === 'number' ? publishPolicy : undefined,
+          publishAuthorityAccountId: parsedPcaAccountId.value,
         });
         return jsonResponse(res, 200, {
           created: id,
@@ -516,8 +557,23 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     if (publishPolicy !== undefined && (publishPolicy !== 0 && publishPolicy !== 1)) {
       return jsonResponse(res, 400, { error: '"publishPolicy" must be 0 (curated) or 1 (open)' });
     }
+    const parsedPcaAccountId = parseOptionalPcaAccountId(parsed);
+    if (parsedPcaAccountId.error) {
+      return jsonResponse(res, 400, { error: parsedPcaAccountId.error });
+    }
+    // Early-reject obvious mismatch: explicit open publishPolicy with a PCA
+    // account id makes no sense. The agent enforces the canonical check too,
+    // but this gives callers a 400 at the API boundary instead of a 500.
+    if (parsedPcaAccountId.value !== undefined && publishPolicy === 1) {
+      return jsonResponse(res, 400, { error: 'pcaAccountId is only valid for curated context graphs (publishPolicy=0)' });
+    }
     try {
-      const result = await agent.registerContextGraph(id, { accessPolicy, publishPolicy, callerAgentAddress: requestAgentAddress });
+      const result = await agent.registerContextGraph(id, {
+        accessPolicy,
+        publishPolicy,
+        callerAgentAddress: requestAgentAddress,
+        publishAuthorityAccountId: parsedPcaAccountId.value,
+      });
       return jsonResponse(res, 200, {
         registered: id,
         onChainId: result.onChainId,
@@ -543,6 +599,9 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       }
       if (msg.includes('address-scoped curator')) {
         return jsonResponse(res, 403, { error: msg });
+      }
+      if (msg.includes('PCA account id can only be used with curated/private context graphs')) {
+        return jsonResponse(res, 400, { error: msg });
       }
       return jsonResponse(res, 500, { error: msg });
     }

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -509,6 +509,13 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     if (parsedPcaAccountId.error) {
       return jsonResponse(res, 400, { error: parsedPcaAccountId.error });
     }
+    // publishPolicy override is forwarded to `registerContextGraph` in
+    // the combined-flow path (Codex PR #502 round-10) — validate the
+    // shape the same way /api/context-graph/register does so callers
+    // get an actionable 400 instead of a 500 from the agent layer.
+    if (publishPolicy !== undefined && publishPolicy !== 0 && publishPolicy !== 1) {
+      return jsonResponse(res, 400, { error: '"publishPolicy" must be 0 (curated) or 1 (open)' });
+    }
     // pcaAccountId is a curated-publish signal: reject ONLY the
     // explicit `publishPolicy: 1 (open)` combo at the API boundary
     // instead of letting it surface as a 500 from the agent.

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -617,32 +617,26 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
         // leaves the CG with no stored PCA id, which is the correct
         // "no PCA yet" state.
         //
-        // Map caller-input / unsupported-feature failures to the same
-        // 4xx / 5xx status codes /api/context-graph/register uses —
-        // returning 200 here silently masked bad PCA ids, authz
-        // failures, etc. as success unless callers remembered to
-        // inspect `registered: false` (Codex PR #502 round-8). The
-        // response body carries `created: true` so callers know the
-        // local create succeeded and they can retry the register leg.
+        // We deliberately keep the 200 partial-success shape here even
+        // for "classified" register failures (Codex PR #502 round-9
+        // reversal of round-8). The create leg already succeeded —
+        // the CG exists locally — so returning a hard HTTP error
+        // would break existing callers that rely on
+        // `created: true, registered: false` to retry the register
+        // step without re-running create (or hitting 409). Callers
+        // detect register-leg failures by inspecting `registered`
+        // (`true`/`false`) and `registerError`; the classified
+        // status code from `classifyRegisterContextGraphError` is
+        // surfaced as `registerErrorStatus` so SDK callers can map
+        // it to the same 4xx semantics as the standalone /register
+        // endpoint without changing the HTTP envelope status.
         const classified = classifyRegisterContextGraphError(regMsg);
-        if (classified) {
-          return jsonResponse(res, classified.status, {
-            ...(classified.body ?? { error: regMsg }),
-            created: id,
-            uri: `did:dkg:context-graph:${id}`,
-            registered: false,
-            registerError: regMsg,
-            hint: 'CG created locally. Fix the register-leg input and call POST /api/context-graph/register to retry on-chain registration.',
-          });
-        }
-        // Unclassified failures (transient chain errors, unknown
-        // adapter reverts) keep the legacy 200-partial-success shape
-        // so callers can retry cheaply without losing the local CG.
         return jsonResponse(res, 200, {
           created: id,
           uri: `did:dkg:context-graph:${id}`,
           registered: false,
           registerError: regMsg,
+          ...(classified ? { registerErrorStatus: classified.status } : {}),
           hint: 'CG created locally. Use POST /api/context-graph/register to retry on-chain registration.',
         });
       }

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -474,15 +474,27 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     if (parsedPcaAccountId.value !== undefined && accessPolicy === 0 && parsed.private !== true) {
       return jsonResponse(res, 400, { error: 'pcaAccountId is only valid for curated/private context graphs' });
     }
-    // When pcaAccountId is supplied without an explicit accessPolicy, infer
-    // curated. Matches Codex review feedback: pcaAccountId on its own is a
-    // curated signal so raw HTTP/SDK callers don't have to know to also set
-    // accessPolicy=1 just to get past validation.
-    const inferredAccessPolicy = typeof accessPolicy === 'number'
-      ? accessPolicy
-      : parsedPcaAccountId.value !== undefined
-        ? 1
-        : undefined;
+    // Effective accessPolicy for both the create and the (optional)
+    // register-during-create leg below. Priority:
+    //   1. `private: true` is a curated signal that overrides any
+    //      explicit `accessPolicy` (matches the agent's createContextGraph
+    //      treatment of the legacy `private` flag).
+    //   2. Explicit `accessPolicy` wins next.
+    //   3. `pcaAccountId` alone is a curated signal — coerce to 1 so raw
+    //      HTTP/SDK callers don't have to also know to set accessPolicy.
+    //   4. Otherwise leave undefined and let the agent default it.
+    // Codex review #502-2: the register leg used to read raw `accessPolicy`
+    // here, so `{ private: true, accessPolicy: 0, pcaAccountId, register: true }`
+    // created the CG locally and then immediately failed registration as
+    // open-with-PCA. Routing through `inferredAccessPolicy` keeps the
+    // create+register pair consistent.
+    const inferredAccessPolicy = parsed.private === true
+      ? 1
+      : typeof accessPolicy === 'number'
+        ? accessPolicy
+        : parsedPcaAccountId.value !== undefined
+          ? 1
+          : undefined;
     try {
       await agent.createContextGraph({
         id,
@@ -518,7 +530,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       try {
         const regResult = await agent.registerContextGraph(id, {
           callerAgentAddress: requestAgentAddress,
-          accessPolicy: typeof accessPolicy === 'number' ? accessPolicy : undefined,
+          accessPolicy: inferredAccessPolicy,
           publishPolicy: typeof publishPolicy === 'number' ? publishPolicy : undefined,
           publishAuthorityAccountId: parsedPcaAccountId.value,
         });
@@ -602,6 +614,22 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       }
       if (msg.includes('PCA account id can only be used with curated/private context graphs')) {
         return jsonResponse(res, 400, { error: msg });
+      }
+      // PCA-specific 4xx mapping (Codex review #502-3): caller-input or
+      // unsupported-feature failures should not surface as 500s with raw
+      // chain/adapter revert text. Order matters — more specific matches
+      // come first.
+      if (msg.includes('PCA account id must be a positive integer')) {
+        return jsonResponse(res, 400, { error: msg });
+      }
+      if (msg.includes('requires chain adapter PCA owner lookup support')) {
+        return jsonResponse(res, 501, { error: msg });
+      }
+      if (/PCA account \d+ does not exist or cannot be looked up/.test(msg)) {
+        return jsonResponse(res, 404, { error: msg });
+      }
+      if (/PCA account \d+ is owned by/.test(msg)) {
+        return jsonResponse(res, 403, { error: msg });
       }
       return jsonResponse(res, 500, { error: msg });
     }

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -511,6 +511,11 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
           ? 1
           : undefined;
     try {
+      // NOTE: parsedPcaAccountId.value is intentionally NOT forwarded
+      // to `agent.createContextGraph` — the agent now rejects that
+      // param at the boundary (Codex PR #502 round-6). The daemon
+      // route uses parsedPcaAccountId.value below in the (optional)
+      // register leg only.
       await agent.createContextGraph({
         id,
         name,
@@ -520,7 +525,6 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
         participantAgents: Array.isArray(participantAgents) ? participantAgents : undefined,
         accessPolicy: inferredAccessPolicy,
         callerAgentAddress: requestAgentAddress,
-        publishAuthorityAccountId: parsedPcaAccountId.value,
         ...(parsed.private === true ? { private: true } : {}),
         ...(Array.isArray(parsed.participantIdentityIds)
           ? { participantIdentityIds: parsed.participantIdentityIds.map((v: string | number) => BigInt(v)) }

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -542,6 +542,20 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
         });
       } catch (regErr: any) {
         process.stderr.write(`[DKG-Daemon] WARN: Context graph "${id}" created locally but on-chain registration failed: ${regErr?.message ?? 'unknown error'}\n`);
+        // Roll back the create-time pcaAccountId persist on register
+        // failure. Without this, a bad id supplied via /create
+        // { register: true } would stick in local CG metadata and
+        // silently replay on every retry that omits the param (Codex
+        // review #502 follow-up on dkg-agent.ts:7175).
+        if (parsedPcaAccountId.value !== undefined) {
+          try {
+            await agent.clearContextGraphPublishAuthorityAccountId(id);
+          } catch (clearErr: any) {
+            process.stderr.write(
+              `[DKG-Daemon] WARN: failed to roll back pcaAccountId for "${id}" after register failure: ${clearErr?.message ?? 'unknown error'}\n`,
+            );
+          }
+        }
         return jsonResponse(res, 200, {
           created: id,
           uri: `did:dkg:context-graph:${id}`,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -474,6 +474,21 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     if (parsedPcaAccountId.value !== undefined && accessPolicy === 0 && parsed.private !== true) {
       return jsonResponse(res, 400, { error: 'pcaAccountId is only valid for curated/private context graphs' });
     }
+    // pcaAccountId on a create-only request is a silent foot-gun:
+    // `createContextGraph()` no longer persists it (Codex PR #502
+    // round-3), so a later `/register` call without re-supplying the
+    // id would register as plain EOA-curated. Reject the
+    // create-without-register combo so callers either bundle the
+    // combined flow (`register: true`) or move the id to the
+    // dedicated `/register` call. Codex PR #502 round-5.
+    if (parsedPcaAccountId.value !== undefined && parsed.register !== true) {
+      return jsonResponse(res, 400, {
+        error:
+          'pcaAccountId on POST /api/context-graph/create requires `register: true` in the same call. '
+          + 'For two-step flows, pass pcaAccountId on POST /api/context-graph/register instead — '
+          + 'create-only requests do not persist the PCA id locally.',
+      });
+    }
     // Effective accessPolicy for both the create and the (optional)
     // register-during-create leg below. Priority:
     //   1. `private: true` is a curated signal that overrides any

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -517,6 +517,37 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
     // "duplicate" / "conflict" substrings.
     expect(second.status).toBe(409);
   });
+
+  it('returns 400 when registering an existing open context graph with a PCA account id', async () => {
+    const d = daemon!;
+    const cgId = 'open-pca-register-' + Math.random().toString(36).slice(2, 8);
+    const create = await fetch(urlFor(d, '/api/context-graph/create'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({ id: cgId, name: cgId }),
+    });
+    expect([200, 201]).toContain(create.status);
+
+    const register = await fetch(urlFor(d, '/api/context-graph/register'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({ id: cgId, pcaAccountId: '1' }),
+    });
+    expect(register.status).toBe(400);
+    const body = await register.json();
+    expect(body.error).toMatch(/pcaAccountId|PCA account id/i);
+  });
+
+  it('treats pcaAccountId as curated input when creating a context graph', async () => {
+    const d = daemon!;
+    const cgId = 'pca-create-' + Math.random().toString(36).slice(2, 8);
+    const create = await fetch(urlFor(d, '/api/context-graph/create'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({ id: cgId, name: cgId, pcaAccountId: '1' }),
+    });
+    expect([200, 201]).toContain(create.status);
+  });
 });
 
 describe('DKG-419 — lazy context graph metadata from SWM writes', () => {

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -581,25 +581,27 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
         register: true,
       }),
     });
-    // /create itself succeeds (CG is created locally); the register
-    // leg fails because the PCA token doesn't exist. Codex PR #502
-    // round-8: register-leg failures now map to the same 4xx / 5xx
-    // status codes used by /api/context-graph/register — nonexistent
-    // PCA tokens → 404. The response body still carries
-    // `created: id, registered: false, registerError` so callers can
-    // distinguish "local CG exists, retry register" from "create
-    // failed".
-    expect(createAndRegister.status).toBe(404);
+    // /create itself succeeds (CG is created locally); only the
+    // register leg fails. Codex PR #502 round-9: the 200
+    // partial-success contract is preserved (backwards compat) —
+    // existing SDK callers rely on `created: true, registered: false`
+    // to retry the register step without re-running create. The new
+    // `registerErrorStatus` field surfaces what HTTP status the
+    // standalone /register endpoint would have returned for the same
+    // error (here: 404, nonexistent PCA token) so callers can map it
+    // to 4xx semantics without changing the envelope status.
+    expect(createAndRegister.status).toBe(200);
     const body = (await createAndRegister.json()) as {
-      error?: string;
       created?: string;
       registered?: boolean;
       registerError?: string;
+      registerErrorStatus?: number;
     };
     expect(body.created).toBe(cgId);
     expect(body.registered).toBe(false);
     expect(typeof body.registerError).toBe('string');
     expect(body.registerError ?? '').toMatch(/PCA account 99999999999999999999 does not exist/);
+    expect(body.registerErrorStatus).toBe(404);
 
     // Follow-up /register call omitting pcaAccountId. If the rollback
     // worked, the agent resolver finds NOTHING in storage and falls

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -538,15 +538,22 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
     expect(body.error).toMatch(/pcaAccountId|PCA account id/i);
   });
 
-  it('treats pcaAccountId as curated input when creating a context graph', async () => {
+  // Codex PR #502 round-5: pcaAccountId on a create-only request used
+  // to be silently accepted (and silently dropped because
+  // createContextGraph no longer persists it). The daemon now rejects
+  // the create-without-register combo at the API boundary.
+  it('rejects pcaAccountId on POST /api/context-graph/create when register is not true', async () => {
     const d = daemon!;
-    const cgId = 'pca-create-' + Math.random().toString(36).slice(2, 8);
+    const cgId = 'pca-create-only-' + Math.random().toString(36).slice(2, 8);
     const create = await fetch(urlFor(d, '/api/context-graph/create'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
       body: JSON.stringify({ id: cgId, name: cgId, pcaAccountId: '1' }),
     });
-    expect([200, 201]).toContain(create.status);
+    expect(create.status).toBe(400);
+    const body = (await create.json()) as { error?: string };
+    expect(body.error ?? '').toMatch(/register: true|register=true|register/i);
+    expect(body.error ?? '').toMatch(/pcaAccountId/);
   });
 
   // Codex review #502 round-3: pcaAccountId is a register-time knob —

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -548,6 +548,48 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
     });
     expect([200, 201]).toContain(create.status);
   });
+
+  // Codex review #502-3: a bad pcaAccountId on /register surfaces as a
+  // chain revert ("ERC721NonexistentToken" or similar) from the EVM
+  // adapter. The daemon must translate it into a clean 4xx with the
+  // wrapped agent-error message — never a generic 500 with raw revert
+  // hex bleeding through.
+  it('maps a nonexistent pcaAccountId on register to a 4xx (not 500)', async () => {
+    const d = daemon!;
+    const cgId = 'pca-register-nonexistent-' + Math.random().toString(36).slice(2, 8);
+    const create = await fetch(urlFor(d, '/api/context-graph/create'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({ id: cgId, name: cgId, accessPolicy: 1 }),
+    });
+    expect([200, 201]).toContain(create.status);
+
+    // An astronomically high id that no minted PCA NFT will ever match
+    // on the shared Hardhat node. The agent wraps the ERC721 revert into
+    // "PCA account ... does not exist or cannot be looked up: ..." and
+    // the daemon catch maps that prefix to 404.
+    const register = await fetch(urlFor(d, '/api/context-graph/register'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({ id: cgId, pcaAccountId: '99999999999999999999' }),
+    });
+
+    // The exact 4xx code depends on which branch fires first:
+    //   - 404 when the wrapped "PCA account ... does not exist" error
+    //     bubbles up (EVM contract-deployed-but-token-missing case).
+    //   - 501 when this daemon's EVM adapter version pre-dates
+    //     `getPublishingConvictionAccountOwner` (older deployments).
+    //   - 400 when the value fails pcaAccountId parsing (shouldn't here,
+    //     but guards against regressions in the parser).
+    // The hard contract: NEVER a 5xx — that's the whole point of #502-3.
+    expect(register.status).toBeGreaterThanOrEqual(400);
+    expect(register.status).toBeLessThan(500);
+    const body = await register.json();
+    expect(typeof body.error).toBe('string');
+    // No raw revert hex / Hardhat internal frames in the surfaced
+    // message — callers should see something human-readable.
+    expect(body.error).not.toMatch(/^0x[0-9a-fA-F]+$/);
+  });
 });
 
 describe('DKG-419 — lazy context graph metadata from SWM writes', () => {

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -581,15 +581,25 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
         register: true,
       }),
     });
-    // /create itself succeeds (CG is created locally); only the
-    // register leg fails, so the response is 200 with `registered: false`.
-    expect(createAndRegister.status).toBe(200);
+    // /create itself succeeds (CG is created locally); the register
+    // leg fails because the PCA token doesn't exist. Codex PR #502
+    // round-8: register-leg failures now map to the same 4xx / 5xx
+    // status codes used by /api/context-graph/register — nonexistent
+    // PCA tokens → 404. The response body still carries
+    // `created: id, registered: false, registerError` so callers can
+    // distinguish "local CG exists, retry register" from "create
+    // failed".
+    expect(createAndRegister.status).toBe(404);
     const body = (await createAndRegister.json()) as {
+      error?: string;
+      created?: string;
       registered?: boolean;
       registerError?: string;
     };
+    expect(body.created).toBe(cgId);
     expect(body.registered).toBe(false);
     expect(typeof body.registerError).toBe('string');
+    expect(body.registerError ?? '').toMatch(/PCA account 99999999999999999999 does not exist/);
 
     // Follow-up /register call omitting pcaAccountId. If the rollback
     // worked, the agent resolver finds NOTHING in storage and falls
@@ -613,6 +623,22 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
       expect([200, 201]).toContain(retryRegister.status);
     }
   });
+
+  // Codex PR #502 round-8: combined-flow register failures (caller
+  // input / unsupported feature) used to silently return 200 with
+  // `registered: false`. They now share the /register endpoint's 4xx
+  // mappings — this test pins the 501 mapping when the chain adapter
+  // is asked for a PCA registration but cannot introspect its tx
+  // signer.
+  //
+  // The shared test daemon uses the EVM adapter against a Hardhat node
+  // (which DOES introspect its signer), so we can't directly exercise
+  // the 501 path here. The complementary "rejects pcaAccountId on
+  // POST /api/context-graph/create when register is not true" test
+  // and the 404 mapping above already cover the realistic adapter
+  // scenarios — leaving this as a documentation marker.
+  // TODO(devnet-smoke): cover the 501 mapping via an adapter that
+  // surfaces `getPublishingConvictionAccountOwner()` but no signer.
 
   // Codex review #502-3: a bad pcaAccountId on /register surfaces as a
   // chain revert ("ERC721NonexistentToken" or similar) from the EVM

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -642,6 +642,47 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
   // TODO(devnet-smoke): cover the 501 mapping via an adapter that
   // surfaces `getPublishingConvictionAccountOwner()` but no signer.
 
+  // Codex PR #502 round-10 (raised by @branarakic): the combined-flow
+  // path must be able to send `{ accessPolicy: 0, publishPolicy: 0,
+  // pcaAccountId, register: true }` — public-discoverable but
+  // PCA-curated. Before round-10 the API client didn't forward
+  // `publishPolicy`, so `registerContextGraph` defaulted it to
+  // `open` (from `accessPolicy: 0`) and rejected the PCA id with
+  // "PCA account id can only be used with curated publish policy".
+  // This test pins the API-boundary contract: the request shape is
+  // NOT rejected by the daemon's input validation, and the
+  // register-leg failure (no such PCA token on the test chain) is
+  // surfaced via 200 + `registerErrorStatus: 404` — proving the
+  // combo reaches the chain layer.
+  it('accepts accessPolicy=0 + publishPolicy=0 + pcaAccountId + register=true (public-discoverable + PCA-curated combined flow)', async () => {
+    const d = daemon!;
+    const cgId = 'pca-public-discoverable-' + Math.random().toString(36).slice(2, 8);
+    const res = await fetch(urlFor(d, '/api/context-graph/create'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({
+        id: cgId,
+        name: cgId,
+        accessPolicy: 0,
+        publishPolicy: 0,
+        pcaAccountId: '99999999999999999999',
+        register: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      created?: string;
+      registered?: boolean;
+      registerError?: string;
+      registerErrorStatus?: number;
+    };
+    expect(body.created).toBe(cgId);
+    expect(body.registered).toBe(false);
+    expect(body.registerErrorStatus).toBe(404);
+    expect(body.registerError ?? '').toMatch(/PCA account 99999999999999999999 does not exist/);
+    expect(body.registerError ?? '').not.toMatch(/curated publish policy/);
+  });
+
   // Codex review #502-3: a bad pcaAccountId on /register surfaces as a
   // chain revert ("ERC721NonexistentToken" or similar) from the EVM
   // adapter. The daemon must translate it into a clean 4xx with the

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -549,20 +549,20 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
     expect([200, 201]).toContain(create.status);
   });
 
-  // Codex review #502 follow-up: when /create { register: true }
-  // includes a bad pcaAccountId, the create-time persist must NOT
-  // leave the bad id in local CG metadata after the register leg
-  // fails. The daemon catch rolls it back so a subsequent /register
-  // call that omits the param falls through cleanly instead of
-  // silently replaying the bad id from storage.
-  it('rolls back the create-time pcaAccountId persist when register fails inside /create', async () => {
+  // Codex review #502 round-3: pcaAccountId is a register-time knob —
+  // /create no longer persists it locally. A failed /create
+  // { register: true } leg must therefore leave NO stored PCA id
+  // behind, so a follow-up /register that omits the param can NOT
+  // silently replay the bad id.
+  it('never persists a bad pcaAccountId locally when /create { register: true } register leg fails', async () => {
     const d = daemon!;
-    const cgId = 'pca-create-register-rollback-' + Math.random().toString(36).slice(2, 8);
+    const cgId = 'pca-create-register-no-persist-' + Math.random().toString(36).slice(2, 8);
 
     // /create { register: true } with a bad pcaAccountId. The register
-    // leg fails on chain owner-lookup; the daemon route's catch must
-    // call clearContextGraphPublishAuthorityAccountId so the persisted
-    // id is wiped.
+    // leg fails on chain owner-lookup. Per Codex round-3, the create
+    // path validates but does NOT persist pcaAccountId, so there's
+    // nothing to roll back and a follow-up /register without the
+    // param must NOT see the stale id.
     const createAndRegister = await fetch(urlFor(d, '/api/context-graph/create'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...authHeaders(d) },

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -549,6 +549,64 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
     expect([200, 201]).toContain(create.status);
   });
 
+  // Codex review #502 follow-up: when /create { register: true }
+  // includes a bad pcaAccountId, the create-time persist must NOT
+  // leave the bad id in local CG metadata after the register leg
+  // fails. The daemon catch rolls it back so a subsequent /register
+  // call that omits the param falls through cleanly instead of
+  // silently replaying the bad id from storage.
+  it('rolls back the create-time pcaAccountId persist when register fails inside /create', async () => {
+    const d = daemon!;
+    const cgId = 'pca-create-register-rollback-' + Math.random().toString(36).slice(2, 8);
+
+    // /create { register: true } with a bad pcaAccountId. The register
+    // leg fails on chain owner-lookup; the daemon route's catch must
+    // call clearContextGraphPublishAuthorityAccountId so the persisted
+    // id is wiped.
+    const createAndRegister = await fetch(urlFor(d, '/api/context-graph/create'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({
+        id: cgId,
+        name: cgId,
+        accessPolicy: 1,
+        pcaAccountId: '99999999999999999999',
+        register: true,
+      }),
+    });
+    // /create itself succeeds (CG is created locally); only the
+    // register leg fails, so the response is 200 with `registered: false`.
+    expect(createAndRegister.status).toBe(200);
+    const body = (await createAndRegister.json()) as {
+      registered?: boolean;
+      registerError?: string;
+    };
+    expect(body.registered).toBe(false);
+    expect(typeof body.registerError).toBe('string');
+
+    // Follow-up /register call omitting pcaAccountId. If the rollback
+    // worked, the agent resolver finds NOTHING in storage and falls
+    // through to the EOA-curated branch (which on the test daemon's
+    // edge node + shared Hardhat signer succeeds → 200). The
+    // alternative scenario — failure for *any* reason that isn't
+    // "PCA account 99... does not exist" — also counts: the only thing
+    // the rollback contract forbids is silently replaying the stale
+    // bad id.
+    const retryRegister = await fetch(urlFor(d, '/api/context-graph/register'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({ id: cgId, accessPolicy: 1 }),
+    });
+    const retryBody = (await retryRegister.json()) as { error?: string; registered?: string };
+    if (retryRegister.status >= 400) {
+      expect(retryBody.error ?? '').not.toMatch(/99999999999999999999.*does not exist/);
+    } else {
+      // 2xx success path: the create-time bad id is fully gone — the
+      // register call didn't even try the PCA branch.
+      expect([200, 201]).toContain(retryRegister.status);
+    }
+  });
+
   // Codex review #502-3: a bad pcaAccountId on /register surfaces as a
   // chain revert ("ERC721NonexistentToken" or similar) from the EVM
   // adapter. The daemon must translate it into a clean 4xx with the

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -174,6 +174,7 @@ export const DKG_ONTOLOGY = {
   DKG_ACCESS_POLICY: `${DKG}accessPolicy`,
   DKG_PARTICIPANT_IDENTITY_ID: `${DKG}participantIdentityId`,
   DKG_PARTICIPANT_AGENT: `${DKG}participantAgent`,
+  DKG_PUBLISH_AUTHORITY_ACCOUNT_ID: `${DKG}publishAuthorityAccountId`,
   // Agent-signed delegation: when an agent (allowedAgent / participantAgent)
   // is approved, the join request carries an AgentDelegation naming the
   // node that hosts the agent. The curator persists those delegatee


### PR DESCRIPTION
> **Note:** this supersedes #423. Same intent and same surface area, rebased onto current `main` (which now includes #466, #470, and the `publishPolicy` split). Picked up because the original author is away and the gap is blocking PCA-curated CG flows end-to-end.

## TL;DR

Before this PR, only the wallet that registered a curated context graph
could publish to it. After this PR, the PCA owner can authorize multiple
agent wallets to publish — by registering them on their PCA NFT.

```
                Publishing to a curated CG (tied to PCA #42)
            ┌─────────────────┬──────────────────────────────────┐
            │     Before      │     After (this PR)              │
            ├─────────────────┼──────────────────────────────────┤
  Owner     │       ✓         │       ✓                          │
  Agent     │       ✗         │       ✓ once registerAgent(42,…) │
  Random    │       ✗         │       ✗                          │
            └─────────────────┴──────────────────────────────────┘
```

## How it actually works

The contract has accepted a `pcaAccountId` field on `createContextGraph`
for a while, and `isAuthorizedPublisher` already knows how to check
"is this wallet the PCA owner OR a registered agent of that PCA?".
The daemon just wasn't sending the id. This PR sends it.

```
  Before:  register tx ──→ createContextGraph(authority)
  After:   register tx ──→ createContextGraph(authority, pcaAccountId)
                                                          ▲
                                                      one number
```

## Sample flow

```bash
# Alice owns PCA #42. Creates the curated CG, tags it with the PCA.
alice $ dkg context-graph create my-cg --access-policy 1 --pca-account-id 42
alice $ dkg context-graph register my-cg

# Alice authorizes Bob to publish (one tx on the PCA NFT contract).
alice $ cast send $PCA_NFT 'registerAgent(uint256,address)' 42 $BOB

# Bob runs his own daemon with his own key. Publishes successfully.
bob   $ dkg publish my-cg ./asset.ttl     # ✓

# Alice revokes Bob anytime.
alice $ cast send $PCA_NFT 'deregisterAgent(uint256,address)' 42 $BOB
bob   $ dkg publish my-cg ./asset.ttl     # ✗ UnauthorizedPublisher
```

## What this PR does NOT change

- **Registration** still requires the PCA owner's wallet. Daemon enforces
  `local curator == ownerOf(pcaAccountId)`. Agents cannot register CGs.
- **Publish-path code** is untouched. Authorization logic already lives
  in `ContextGraphs.isAuthorizedPublisher`.
- **EOA-curated** and **open** CGs behave exactly as before.

## Rebase notes (delta vs. #423)

main has moved since #423 was opened. Conflict resolutions worth flagging:

- **daemon `/register`** now forwards `accessPolicy`, `publishPolicy` AND
  `publishAuthorityAccountId`. The incoherent-combo guard checks
  `publishPolicy === 1` (open) instead of the old `accessPolicy === 0`,
  matching the canonical agent-side check on `EVM_PUBLISH_OPEN`.
- **daemon `/create`** keeps "pcaAccountId implies curated" coercion AND
  adds an explicit reject for `accessPolicy=0 + pcaAccountId` so raw
  HTTP/SDK callers get a 400 at the API boundary instead of a 500 from
  the agent (Codex review #423-3).
- **dkg-agent**: predicate-quad subject renamed `paranetUri` →
  `contextGraphUri` to match main's naming; `get/setContextGraphPublishAuthorityAccountId`
  use single-line SPARQL like the existing participant-identity-id query.
- **chain-adapter**: kept HEAD's V10 PCA agent surface
  (`getConvictionAgentAccountId`, `getConvictionAccountLockDurationEpochs`,
  `addPCAAuthorizedKey`, `isPCAAuthorizedKey`) and added the new
  `getPublishingConvictionAccountOwner` next to them.

## Codex review (PR #423) follow-ups addressed

| # | Comment | Status |
|---|---------|--------|
| 1 | daemon `/register` returns 500 for `pcaAccountId` on an existing open CG | Fixed — agent throws the canonical PCA error, route catches it and maps to **400** |
| 2 | mock-adapter parity: PCA owner check before zero-authority default | No-op on current main — the mock already defaults `publishAuthority=0` to the signer before the PCA owner check |
| 3 | `pcaAccountId` should imply curated for raw HTTP/SDK callers | Fixed — `/create` now coerces `accessPolicy=1` when only `pcaAccountId` is supplied, and rejects explicit `accessPolicy=0 + pcaAccountId` with a clear 400 |

## Files

```
chain      chain-adapter.ts   evm-adapter.ts   mock-adapter.ts   no-chain-adapter.ts
core       genesis.ts (1 ontology predicate)
agent      dkg-agent.ts (accept, persist, forward pcaAccountId)
cli        api-client.ts   cli.ts (--pca-account-id flag)   daemon/routes/context-graph.ts
tests      agent / chain-mock-parity / cli-http
```

## Test plan

- [x] `packages/chain` — full suite (223 tests) ✓
- [x] `packages/agent` — full suite (443 tests) ✓
- [x] `packages/cli` — full suite (1101 tests) ✓
- [x] `packages/core` — full suite (629 tests) ✓
- [ ] devnet smoke: end-to-end PCA-curated CG: alice creates + registers, alice `registerAgent(bob)`, bob publishes, alice `deregisterAgent(bob)`, bob's publish is rejected.

## Out of scope

Defense-in-depth contract change adding `require(msg.sender == ownerOf(accountId))`
to `ContextGraphs.createContextGraph` — tracked as a follow-up.

Made with [Cursor](https://cursor.com)