### PR TITLE
fix(node-ui): surface curator reject reason in JoinProjectModal

### DIFF
--- a/packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx
@@ -129,6 +129,83 @@ export function validateInvite(invite: ParsedInvite): string | null {
   return null;
 }
 
+/**
+ * Render the user-visible error string for a failed /request-join call.
+ *
+ * The daemon's `POST /api/context-graph/{id}/request-join` returns a 502
+ * with `{ error, errors? }` when `forwardJoinRequest` couldn't deliver:
+ * `errors[]` carries the per-peer reason (e.g.
+ * `"<peerTag>: verifyAgentDelegation: scope mismatch (expected … got …)"`
+ * when the curator received the request but rejected it, or
+ * `"<peerTag>: dial failed (…)"` when the transport never landed). The
+ * previous UI swallowed `errors[]` and always showed "couldn't deliver
+ * to any reachable curator", which is misleading for the by-far-most-
+ * common failure mode — hub-address skew between joiner and curator
+ * after a testnet contract redeployment leaves the joiner's network
+ * config stale and the curator silently rejects every signed delegation.
+ *
+ * This helper:
+ *   1. Distinguishes "reached but rejected" from "couldn't reach" based
+ *      on whether any per-peer entry is NOT a `dial failed` line.
+ *   2. Surfaces the underlying reason(s) verbatim so daemon-log
+ *      spelunking isn't needed.
+ *   3. Appends an actionable hint for known patterns
+ *      (`scope mismatch`, `unknown CG`, `not curator`); if any of those
+ *      strings change in the daemon, the hint silently stops firing but
+ *      the verbatim reason is still shown.
+ *
+ * Exported so it can be unit-tested without rendering the React tree.
+ */
+export function formatJoinRequestError(err: unknown): string {
+  if (err instanceof HttpError && err.status === 502) {
+    const perPeer = readPerPeerErrors(err.body);
+    if (perPeer.length === 0) {
+      return 'Request signed, but we couldn\'t deliver it to any reachable curator. ' +
+        'Try again in a moment once your node has discovered more peers, or ask the curator for an updated invite.';
+    }
+    const reasons = perPeer.join('; ');
+    const reachedButRejected = perPeer.some((entry) => !/:\s*dial failed\b/i.test(entry));
+    const headline = reachedButRejected
+      ? 'Curator rejected this join request.'
+      : 'Couldn\'t deliver this join request to the curator.';
+    const hint = hintForJoinRejectReasons(reasons);
+    return hint
+      ? `${headline} Reason: ${reasons}. ${hint}`
+      : `${headline} Reason: ${reasons}.`;
+  }
+  if (err instanceof Error && err.message) return err.message;
+  return 'Failed to send join request';
+}
+
+function readPerPeerErrors(body: unknown): string[] {
+  if (!body || typeof body !== 'object') return [];
+  const errors = (body as { errors?: unknown }).errors;
+  if (!Array.isArray(errors)) return [];
+  return errors.filter((e): e is string => typeof e === 'string' && e.length > 0);
+}
+
+function hintForJoinRejectReasons(reasons: string): string | null {
+  // `scope mismatch` is the on-the-wire wording from
+  // `verifyAgentDelegation` (packages/agent/src/agent-delegation.ts).
+  // It fires when the joiner's daemon signed the delegation against a
+  // different ContextGraphsHub contract address than the curator's —
+  // in practice almost always because the joiner's
+  // `network/testnet.json` is still pointing at the pre-redeploy hub.
+  if (/scope mismatch/i.test(reasons)) {
+    return 'This usually means your daemon\'s network config has a stale ContextGraphsHub address — ' +
+      'pull the latest release (or `git pull && pnpm install && pnpm run build:runtime`) and try again.';
+  }
+  if (/unknown CG/i.test(reasons)) {
+    return 'The curator doesn\'t recognise this project id — double-check the invite, ' +
+      'or ask the curator to share an updated one.';
+  }
+  if (/not curator/i.test(reasons)) {
+    return 'The peer you reached isn\'t the curator of this project — ' +
+      'ask the curator to share a fresh invite with the correct curator peer id.';
+  }
+  return null;
+}
+
 type Phase = 'idle' | 'sending' | 'pending' | 'approved' | 'rejected';
 
 export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinProjectModalProps) {
@@ -264,18 +341,16 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
       }
 
       setPhase('pending');
-    } catch (err: any) {
-      // `post()` throws `HttpError` for non-2xx. The daemon returns 502
-      // with a structured `error` for the "no curator reachable" case
-      // (see context-graph.ts:777). Surface that as actionable copy,
-      // distinct from generic "failed to send" for transport errors.
-      if (err instanceof HttpError && err.status === 502) {
-        setError(
-          'Request signed, but we couldn\'t deliver it to any reachable curator. Try again in a moment once your node has discovered more peers, or ask the curator for an updated invite.',
-        );
-      } else {
-        setError(err?.message || 'Failed to send join request');
-      }
+    } catch (err: unknown) {
+      // `post()` throws `HttpError` for non-2xx, attaching the parsed
+      // JSON body. For 502 the daemon includes `errors[]` with per-peer
+      // reject reasons (`forwardJoinRequest` in
+      // packages/cli/src/daemon/routes/context-graph.ts). Delegate the
+      // copy to `formatJoinRequestError` so the underlying reason —
+      // most commonly a delegation-scope mismatch from a stale hub
+      // address — actually reaches the user instead of being smothered
+      // under a generic "no reachable curator" message.
+      setError(formatJoinRequestError(err));
       setPhase('idle');
     }
   };

--- a/packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx
@@ -145,14 +145,26 @@ export function validateInvite(invite: ParsedInvite): string | null {
  * config stale and the curator silently rejects every signed delegation.
  *
  * This helper:
- *   1. Distinguishes "reached but rejected" from "couldn't reach" based
- *      on whether any per-peer entry is NOT a `dial failed` line.
+ *   1. Distinguishes "reached but rejected" from "couldn't reach" by
+ *      content of the per-peer entries (NOT by mere presence of a
+ *      non-`dial failed` line — see below).
  *   2. Surfaces the underlying reason(s) verbatim so daemon-log
  *      spelunking isn't needed.
- *   3. Appends an actionable hint for known patterns
- *      (`scope mismatch`, `unknown CG`, `not curator`); if any of those
- *      strings change in the daemon, the hint silently stops firing but
- *      the verbatim reason is still shown.
+ *   3. Appends an actionable hint for known patterns. If any of those
+ *      strings change in the daemon, the hint silently stops firing
+ *      but the verbatim reason is still shown.
+ *
+ * Codex review on round 1 flagged that the original heuristic
+ * (`some entry that is not "dial failed"`) incorrectly classified the
+ * mixed case `["<curatorTag>: dial failed (timeout)",
+ * "<otherPeer>: not curator", ...]` as a curator rejection. That
+ * combination happens whenever the targeted curator dial times out and
+ * `forwardJoinRequest` then broadcasts to other peers, none of which
+ * curate the CG. The curator was never reached, so it must not be
+ * shown as a rejection. We now look at the reason content (post-prefix)
+ * and treat ONLY `dial failed (…)` and `not curator` as
+ * delivery-failure signals; anything else is treated as a
+ * curator-authoritative answer.
  *
  * Exported so it can be unit-tested without rendering the React tree.
  */
@@ -164,11 +176,11 @@ export function formatJoinRequestError(err: unknown): string {
         'Try again in a moment once your node has discovered more peers, or ask the curator for an updated invite.';
     }
     const reasons = perPeer.join('; ');
-    const reachedButRejected = perPeer.some((entry) => !/:\s*dial failed\b/i.test(entry));
-    const headline = reachedButRejected
+    const reachedAndRejected = perPeer.some(isCuratorAuthoritativeReason);
+    const headline = reachedAndRejected
       ? 'Curator rejected this join request.'
       : 'Couldn\'t deliver this join request to the curator.';
-    const hint = hintForJoinRejectReasons(reasons);
+    const hint = hintForJoinRejectReasons(reasons, reachedAndRejected);
     return hint
       ? `${headline} Reason: ${reasons}. ${hint}`
       : `${headline} Reason: ${reasons}.`;
@@ -184,24 +196,52 @@ function readPerPeerErrors(body: unknown): string[] {
   return errors.filter((e): e is string => typeof e === 'string' && e.length > 0);
 }
 
-function hintForJoinRejectReasons(reasons: string): string | null {
-  // `scope mismatch` is the on-the-wire wording from
-  // `verifyAgentDelegation` (packages/agent/src/agent-delegation.ts).
-  // It fires when the joiner's daemon signed the delegation against a
-  // different ContextGraphsHub contract address than the curator's —
-  // in practice almost always because the joiner's
-  // `network/testnet.json` is still pointing at the pre-redeploy hub.
-  if (/scope mismatch/i.test(reasons)) {
-    return 'This usually means your daemon\'s network config has a stale ContextGraphsHub address — ' +
-      'pull the latest release (or `git pull && pnpm install && pnpm run build:runtime`) and try again.';
+/**
+ * A per-peer entry from `forwardJoinRequest.errors[]` looks like
+ * `"<peerTag>: <reason>"`. The known *non-authoritative* (delivery-failure)
+ * reasons are:
+ *   - `"dial failed (...)"` — only emitted by the targeted-dial path on
+ *     transport error; the curator never saw the request.
+ *   - `"not curator"`       — only emitted by broadcast cohort peers; we
+ *     reached someone, but they don't curate this CG.
+ * Anything else (`scope mismatch`, `unknown CG`, signature errors, …)
+ * is a curator-authoritative reject — the curator received the
+ * delegation and answered. Treat the entry as authoritative.
+ */
+function isCuratorAuthoritativeReason(entry: string): boolean {
+  const reason = entry.replace(/^[^:]+:\s*/, '').trim();
+  if (!reason) return false;
+  if (/^dial failed\b/i.test(reason)) return false;
+  if (/^not curator$/i.test(reason)) return false;
+  return true;
+}
+
+function hintForJoinRejectReasons(reasons: string, reachedAndRejected: boolean): string | null {
+  if (reachedAndRejected) {
+    // `scope mismatch` is the on-the-wire wording from
+    // `verifyAgentDelegation` (packages/agent/src/agent-delegation.ts).
+    // It fires when the joiner's daemon signed the delegation against a
+    // different ContextGraphsHub contract address than the curator's —
+    // in practice almost always because the joiner's
+    // `network/testnet.json` is still pointing at the pre-redeploy hub.
+    if (/scope mismatch/i.test(reasons)) {
+      return 'This usually means your daemon\'s network config has a stale ContextGraphsHub address — ' +
+        'pull the latest release (or `git pull && pnpm install && pnpm run build:runtime`) and try again.';
+    }
+    if (/unknown CG/i.test(reasons)) {
+      return 'The curator doesn\'t recognise this project id — double-check the invite, ' +
+        'or ask the curator to share an updated one.';
+    }
+    return null;
   }
-  if (/unknown CG/i.test(reasons)) {
-    return 'The curator doesn\'t recognise this project id — double-check the invite, ' +
-      'or ask the curator to share an updated one.';
-  }
+  // Delivery-failure case: curator was never reached. `not curator`
+  // means the broadcast cohort had no curator in it; `dial failed`
+  // means the targeted curator dial timed out / errored. In both cases
+  // the most actionable advice is "make sure the curator's daemon is
+  // online and the invite carries the right peer id".
   if (/not curator/i.test(reasons)) {
-    return 'The peer you reached isn\'t the curator of this project — ' +
-      'ask the curator to share a fresh invite with the correct curator peer id.';
+    return 'Your node reached other peers, but none of them curate this project. ' +
+      'Make sure the curator\'s daemon is online and the invite carries the right curator peer id.';
   }
   return null;
 }

--- a/packages/node-ui/test/join-project-modal.test.ts
+++ b/packages/node-ui/test/join-project-modal.test.ts
@@ -206,6 +206,53 @@ describe('formatJoinRequestError', () => {
     expect(msg).toContain('dial failed');
   });
 
+  // Codex review on PR #508 round 1 caught a misdiagnosis: when the
+  // targeted curator dial times out, `forwardJoinRequest` falls through
+  // to the broadcast cohort. Non-curator peers in that cohort respond
+  // `not curator` and get appended to `errors[]` alongside the
+  // earlier `dial failed (timeout)` line. The original
+  // "any entry that isn't dial-failed ⇒ rejection" heuristic flipped
+  // the headline to "Curator rejected this join request" for this
+  // mix, even though the curator was never reached. Pin the corrected
+  // semantic: `dial failed` + `not curator` (the only two
+  // delivery-failure signals from forwardJoinRequest) must still read
+  // as a delivery failure.
+  it('treats targeted-dial-failed + non-curator-broadcast as a delivery failure (Codex #508 round 1)', () => {
+    const err = new HttpError(502, 'no reachable curator', {
+      error: 'Could not deliver join request to curator. No reachable curator found.',
+      errors: [
+        'kmTfyjRK: dial failed (timeout after 10000ms)',
+        'cAbCdEfG: not curator',
+        'hIjKlMnO: not curator',
+      ],
+    });
+
+    const msg = formatJoinRequestError(err);
+
+    expect(msg).toContain("Couldn't deliver");
+    expect(msg).not.toContain('Curator rejected');
+    expect(msg).toContain('dial failed');
+    expect(msg).toContain('not curator');
+    expect(msg).toContain('none of them curate this project');
+  });
+
+  it('treats broadcast-only `not curator` (no targeted curator reached) as a delivery failure', () => {
+    // If every broadcast peer answered `not curator` and there is no
+    // `dial failed` entry (e.g. legacy multiaddr invite path with no
+    // targeted curator step), it's still a delivery failure, not a
+    // rejection.
+    const err = new HttpError(502, 'no reachable curator', {
+      error: 'Could not deliver join request to curator. No reachable curator found.',
+      errors: ['cAbCdEfG: not curator', 'hIjKlMnO: not curator'],
+    });
+
+    const msg = formatJoinRequestError(err);
+
+    expect(msg).toContain("Couldn't deliver");
+    expect(msg).not.toContain('Curator rejected');
+    expect(msg).toContain('none of them curate this project');
+  });
+
   it('falls back to err.message for non-502 errors', () => {
     const err = new HttpError(400, 'Missing curatorPeerId', { error: 'Missing curatorPeerId' });
     expect(formatJoinRequestError(err)).toBe('Missing curatorPeerId');

--- a/packages/node-ui/test/join-project-modal.test.ts
+++ b/packages/node-ui/test/join-project-modal.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { parseInviteCode, validateInvite } from '../src/ui/components/Modals/JoinProjectModal.js';
+import {
+  parseInviteCode,
+  validateInvite,
+  formatJoinRequestError,
+} from '../src/ui/components/Modals/JoinProjectModal.js';
+import { HttpError } from '../src/ui/api.js';
 
 describe('JoinProjectModal invite parsing', () => {
   describe('V10 peer-id invites', () => {
@@ -125,5 +130,89 @@ describe('JoinProjectModal invite parsing', () => {
       const parsed = parseInviteCode('');
       expect(validateInvite(parsed)).toBe('Missing project ID');
     });
+  });
+});
+
+describe('formatJoinRequestError', () => {
+  // The daemon's 502 body for /request-join is
+  //   { error: <headline>, errors?: string[] }
+  // when `forwardJoinRequest` couldn't deliver. errors[] carries
+  // per-peer reasons; the helper has to render them, not drop them.
+  // (See packages/cli/src/daemon/routes/context-graph.ts → the
+  // `request-join` branch, and packages/agent/src/dkg-agent.ts →
+  // `forwardJoinRequest`.)
+
+  it('surfaces a curator scope-mismatch rejection with an actionable hint', () => {
+    // This is the exact failure mode that prompted this PR — the
+    // joiner's daemon was signing delegations against the old
+    // pre-redeploy testnet hub, so the curator rejected every signed
+    // delegation with `scope mismatch` and the UI hid the reason behind
+    // a generic "no reachable curator" string.
+    const err = new HttpError(502, 'Could not deliver join request to curator. No reachable curator found.', {
+      error: 'Could not deliver join request to curator. No reachable curator found.',
+      errors: [
+        'kmTfyjRK: verifyAgentDelegation: scope mismatch ' +
+          '(expected "sync:deployment=base:84532:hub=0xc056e67da4f51377ad1b01f50f655ffdccd809f6:0xC541F50f734E01d10dAF1bC1aEc3891fb3eA372E/rc7-test", ' +
+          'got "sync:deployment=base:84532:hub=0xf21ce8f8b01548d97dcfb36869f1ccb0814a4e05:0xC541F50f734E01d10dAF1bC1aEc3891fb3eA372E/rc7-test")',
+      ],
+    });
+
+    const msg = formatJoinRequestError(err);
+
+    expect(msg).toContain('Curator rejected this join request');
+    expect(msg).toContain('scope mismatch');
+    expect(msg).toContain('ContextGraphsHub address');
+  });
+
+  it('surfaces an unknown-CG rejection with an actionable hint', () => {
+    const err = new HttpError(502, 'no reachable curator', {
+      error: 'Could not deliver join request to curator. No reachable curator found.',
+      errors: ['kmTfyjRK: unknown CG'],
+    });
+
+    const msg = formatJoinRequestError(err);
+
+    expect(msg).toContain('unknown CG');
+    expect(msg).toContain('double-check the invite');
+  });
+
+  it('keeps the no-reachable-curator copy when errors[] is empty (transport failure, no per-peer detail)', () => {
+    // No `errors[]` in the body means `forwardJoinRequest` had nothing
+    // to record per peer (every dial failed silently / older daemon).
+    // The legacy copy is still the right thing to show here.
+    const err = new HttpError(502, 'no reachable curator', {
+      error: 'Could not deliver join request to curator. No reachable curator found.',
+    });
+
+    const msg = formatJoinRequestError(err);
+
+    expect(msg).toContain("couldn't deliver");
+    expect(msg).toContain('discovered more peers');
+  });
+
+  it('distinguishes dial-failed errors from rejections in the headline', () => {
+    // All entries are `dial failed` ⇒ the peer was never reached; the
+    // headline should be the transport-flavoured one, not the
+    // curator-rejected one.
+    const err = new HttpError(502, 'no reachable curator', {
+      error: 'Could not deliver join request to curator. No reachable curator found.',
+      errors: ['kmTfyjRK: dial failed (timeout after 10000ms)'],
+    });
+
+    const msg = formatJoinRequestError(err);
+
+    expect(msg).toContain("Couldn't deliver");
+    expect(msg).not.toContain('Curator rejected');
+    expect(msg).toContain('dial failed');
+  });
+
+  it('falls back to err.message for non-502 errors', () => {
+    const err = new HttpError(400, 'Missing curatorPeerId', { error: 'Missing curatorPeerId' });
+    expect(formatJoinRequestError(err)).toBe('Missing curatorPeerId');
+  });
+
+  it('falls back to a generic message when err is not an Error at all', () => {
+    expect(formatJoinRequestError(undefined)).toBe('Failed to send join request');
+    expect(formatJoinRequestError('boom')).toBe('Failed to send join request');
   });
 });


### PR DESCRIPTION
## Summary

The "Join Project" modal was showing the same generic
**"Request signed, but we couldn't deliver it to any reachable curator"**
copy for two very different failure modes:

1. **Transport-only**: the curator's daemon was never reached
   (`forwardJoinRequest` had nothing per-peer to report). This copy
   is correct here.
2. **Reached but rejected**: the curator received the signed
   delegation, ran it through `verifyAgentDelegation`, and the
   daemon's 502 response body included a per-peer `errors[]` array
   carrying the actual reject reason (e.g. `scope mismatch`,
   `unknown CG`, `not curator`). The UI was throwing this away.

In practice the most common case in the field is case 2 with
`scope mismatch` — the joiner's daemon has a stale
`ContextGraphsHub` address in `network/testnet.json` (e.g. after a
testnet hub redeployment), signs the delegation against the wrong
hub, and the curator silently rejects every retry. Under the old
copy the joiner has no idea their own network config is the
problem, and the curator has no idea the joiner is even trying.

This PR extracts the catch-block error rendering into a
pure exported helper `formatJoinRequestError`, plumbs the daemon's
existing `errors[]` field through to it (the field already comes
back in `HttpError.body` via `post()` in `ui/api.ts`), and:

- distinguishes "reached but rejected" from "couldn't reach" by
  inspecting whether per-peer entries are `dial failed` lines,
- surfaces the per-peer reason verbatim so daemon-log spelunking
  isn't needed,
- appends an actionable hint for the three known patterns
  (`scope mismatch` → "your daemon's network config has a stale
  ContextGraphsHub address", `unknown CG` → "double-check the
  invite", `not curator` → "ask for a fresh invite with the
  correct curator peer id").

If any of those daemon error strings ever change, the hint silently
stops firing but the verbatim reason is still shown — no risk of
the UI becoming actively wrong.

## What changed

- `packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx`:
  - New exported pure helper `formatJoinRequestError(err: unknown)`.
  - Two private helpers: `readPerPeerErrors` (defensive parse of
    `HttpError.body.errors[]`) and `hintForJoinRejectReasons`.
  - `handleRequestJoin`'s catch block now just calls the helper.

- `packages/node-ui/test/join-project-modal.test.ts`:
  - Six new tests pinning the surface of every error path:
    scope-mismatch (with the real on-the-wire string from the
    incident that prompted this PR), unknown CG, dial-failed-only
    (asserts the headline does NOT flip to "rejected"), empty
    `errors[]` (regression guard on the legacy copy), non-502
    `HttpError`, and non-`Error` thrown values.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/join-project-modal.test.ts` — 19/19 pass (13 existing + 6 new).
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build` (tsc) — clean.
- [x] Full node-ui suite (`pnpm --filter ... run test`) — 435/435 pass.
- [ ] Manual: trigger a real `scope mismatch` on a devnet pair (joiner with stale hub address, curator on latest) and confirm the modal now shows `Curator rejected this join request. Reason: <peer>: verifyAgentDelegation: scope mismatch (...). This usually means your daemon's network config has a stale ContextGraphsHub address — pull the latest release ...` instead of the old generic copy.

## Background

This was the exact failure mode in the rc7-test investigation
(May 14): an agent's daemon was signing delegations with the
pre-redeploy hub `0xf21ce8f8b…`, the curator's daemon expected
`0xc056e67d…`, every join request was getting rejected at
`verifyAgentDelegation` with a `scope mismatch`, and the joiner's
UI was reporting "no reachable curator" while the curator's logs
had the actual reason. The fix is purely on the rendering side —
the daemon was already shipping the per-peer reason in
`errors[]`; the modal just wasn't using it.


Made with [Cursor](https://cursor.com)