### PR TITLE
feat(evm-module): track deployedBytecodeHash to detect contract drift

### DIFF
--- a/docs/TESTNET_RESET.md
+++ b/docs/TESTNET_RESET.md
@@ -128,10 +128,59 @@ registers all the new addresses in a single batch — see
   ownership, and have them call `setAndReinitializeContracts` from
   their wallet (or queue it through the MultiSig UI).
 
+**Picking which contracts to redeploy:**
+
+A full reset (every contract except Hub/Token) is correct for a true reset
+of the testnet. For a targeted upgrade — only the contracts whose source
+has actually changed — let the `deployedBytecodeHash` check do the picking
+instead of eyeballing git diffs:
+
+```bash
+pnpm --filter @origintrail-official/dkg-evm-module check-contracts:testnet
+```
+
+The script `keccak256`s the current artifact's `deployedBytecode` for
+every `deployed: true` entry in
+`packages/evm-module/deployments/base_sepolia_v10_contracts.json` and
+compares it against the `deployedBytecodeHash` recorded there at deploy
+time (or backfilled via `record-contract-hashes:testnet`). The output
+lists every contract whose current build differs from what's on chain —
+that's your redeploy candidate set. The hash detects:
+- direct source edits to the contract,
+- transitive changes via imported libraries / interfaces / abstracts,
+- compiler-version or optimizer-setting drift in `hardhat.node.config.ts`,
+- standard-library or remapping shifts.
+
+"Changed" in the hash sense means "bytecode would differ from what's at
+`evmAddress`," which corresponds to either a behavioural change or — more
+commonly — a metadata-trailer drift that invalidates basescan source
+verification. Both are reasons to consider redeploying; the decision is
+still yours.
+
+**Bootstrap when the JSON has no recorded hashes yet:**
+
+```bash
+# Reads eth_getCode for every deployed contract on the configured
+# network and writes its keccak256 into the deployments JSON. Run once
+# after introducing the field on a network that pre-dates it. Idempotent.
+pnpm --filter @origintrail-official/dkg-evm-module record-contract-hashes:testnet
+```
+
+This populates `deployedBytecodeHash` (and `contractClassName` where
+artifact-name ≠ Hub-name, e.g. `EpochStorageV6/V8 → EpochStorage`). Commit
+the resulting JSON change before running the check script.
+
+After the targeted redeploy below lands, the deploy pipeline auto-writes
+the new `deployedBytecodeHash` to the JSON via
+`utils/helpers.ts#updateDeploymentsJson`, so subsequent runs of
+`check-contracts:testnet` will see them as up-to-date.
+
 **Deploy procedure:**
 
 1. Open `packages/evm-module/deployments/base_sepolia_v10_contracts.json`.
-2. For every entry **except** `Hub` and `Token`, set `deployed: false`:
+2. Set `deployed: false` on each contract. For a **full reset**, on every
+   entry except `Hub` and `Token`. For a **targeted upgrade**, on each
+   contract reported by `check-contracts:testnet`:
    ```bash
    node -e '
      const fs = require("fs");

--- a/network/testnet.json
+++ b/network/testnet.json
@@ -16,7 +16,7 @@
     "branch": "main",
     "checkIntervalMinutes": 5
   },
-  "chainResetMarker": "v10-rc6-pca-author-attestation-2026-05-10",
+  "chainResetMarker": "v10-profilestorage-paramstore-redeploy-2026-05-14",
   "chain": {
     "type": "evm",
     "rpcUrl": "https://sepolia.base.org",

--- a/packages/evm-module/deployments/base_sepolia_v10_contracts.json
+++ b/packages/evm-module/deployments/base_sepolia_v10_contracts.json
@@ -19,12 +19,12 @@
             "deployed": true
         },
         "ParametersStorage": {
-            "evmAddress": "0x016c780a1846e95f0a1d9d790793Fc2f20AA2484",
+            "evmAddress": "0x2Aca9CfEAD9f30a529E6617317b9B6dde578E646",
             "version": "1.0.0",
-            "gitBranch": "validate/v10-e2e-devnet",
-            "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
-            "deploymentBlock": 41331791,
-            "deploymentTimestamp": 1778431872689,
+            "gitBranch": "claude/frosty-beaver-a00722",
+            "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
+            "deploymentBlock": 41496000,
+            "deploymentTimestamp": 1778760288818,
             "deployed": true
         },
         "WhitelistStorage": {
@@ -64,12 +64,12 @@
             "deployed": true
         },
         "ProfileStorage": {
-            "evmAddress": "0x0b171EBD18F4cd261986dF35133e28151575324b",
-            "version": "1.0.0",
-            "gitBranch": "validate/v10-e2e-devnet",
-            "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
-            "deploymentBlock": 41331803,
-            "deploymentTimestamp": 1778431896883,
+            "evmAddress": "0x4AeFa321982fDC7B40635841BE17c9cb57D6b8e0",
+            "version": "1.1.0",
+            "gitBranch": "claude/frosty-beaver-a00722",
+            "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
+            "deploymentBlock": 41496003,
+            "deploymentTimestamp": 1778760297378,
             "deployed": true
         },
         "Chronos": {
@@ -208,21 +208,21 @@
             "deployed": true
         },
         "StakingKPI": {
-            "evmAddress": "0x47295Bc89DcC589e60A99A7D1C11C8eeD5c4fB0E",
+            "evmAddress": "0x877cAb635bA3fA4996363c7787c1007108D3CF53",
             "version": "2.0.0",
-            "gitBranch": "validate/v10-e2e-devnet",
-            "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
-            "deploymentBlock": 41331836,
-            "deploymentTimestamp": 1778431963039,
+            "gitBranch": "claude/frosty-beaver-a00722",
+            "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
+            "deploymentBlock": 41496006,
+            "deploymentTimestamp": 1778760300937,
             "deployed": true
         },
         "Profile": {
-            "evmAddress": "0x9fC6a5562659dC9295b6741c5848624462A7C15E",
-            "version": "1.1.0",
-            "gitBranch": "validate/v10-e2e-devnet",
-            "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
-            "deploymentBlock": 41331838,
-            "deploymentTimestamp": 1778431967685,
+            "evmAddress": "0xE4efbE7ADe09BFb45cEE8F6544162D55557674F5",
+            "version": "1.2.0",
+            "gitBranch": "claude/frosty-beaver-a00722",
+            "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
+            "deploymentBlock": 41496008,
+            "deploymentTimestamp": 1778760306857,
             "deployed": true
         },
         "KnowledgeCollection": {
@@ -388,30 +388,30 @@
             "deployed": true
         },
         "DKGPublishingConvictionNFT": {
-            "evmAddress": "0x78777BdfBcCF4521fC7D489f52eCC7E2eCAFeD4b",
+            "evmAddress": "0x41490Dcd0Ed0131e8e996F0CdD68643dcE533DC2",
             "version": "2.0.0",
-            "gitBranch": "validate/v10-e2e-devnet",
-            "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
-            "deploymentBlock": 41331862,
-            "deploymentTimestamp": 1778432015571,
+            "gitBranch": "claude/frosty-beaver-a00722",
+            "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
+            "deploymentBlock": 41496011,
+            "deploymentTimestamp": 1778760312991,
             "deployed": true
         },
         "KnowledgeAssetsV10": {
-            "evmAddress": "0x91232ffB87C1e7301946c0aF2Ddf687d4aB6f934",
+            "evmAddress": "0xAD28dA60D8362a9F60cb5E7FCAfBEC4846a07372",
             "version": "10.1.0",
-            "gitBranch": "validate/v10-e2e-devnet",
-            "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
-            "deploymentBlock": 41331865,
-            "deploymentTimestamp": 1778432020278,
+            "gitBranch": "claude/frosty-beaver-a00722",
+            "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
+            "deploymentBlock": 41496014,
+            "deploymentTimestamp": 1778760318899,
             "deployed": true
         },
         "StakingV10": {
-            "evmAddress": "0x1bCF8FfCabDa625533B08c6aB73375b72DB08883",
+            "evmAddress": "0xab461F7bC8cA212A0cE3a8132acf9Ed869BaF47C",
             "version": "3.0.0",
-            "gitBranch": "validate/v10-e2e-devnet",
-            "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
-            "deploymentBlock": 41331867,
-            "deploymentTimestamp": 1778432024969,
+            "gitBranch": "claude/frosty-beaver-a00722",
+            "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
+            "deploymentBlock": 41496017,
+            "deploymentTimestamp": 1778760325412,
             "deployed": true
         },
         "DKGStakingConvictionNFT": {

--- a/packages/evm-module/deployments/base_sepolia_v10_contracts.json
+++ b/packages/evm-module/deployments/base_sepolia_v10_contracts.json
@@ -7,7 +7,9 @@
             "gitCommitHash": "b152808eb793a737c77ad74b4cb5c9e5617dd021",
             "deploymentBlock": 38133666,
             "deploymentTimestamp": 1772035712303,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xffa5bc3d74002663a49c5264ee9d77c36e38994d61ee6b4b490afd1b3f5d896e",
+            "contractClassName": "Hub"
         },
         "Token": {
             "evmAddress": "0x2A58BdD13176D85906D804cdbFFA0D9119282DC8",
@@ -16,7 +18,9 @@
             "gitCommitHash": "b152808eb793a737c77ad74b4cb5c9e5617dd021",
             "deploymentBlock": 38133791,
             "deploymentTimestamp": 1772035985602,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x56d378844285f23b7ec67bc43fce507506243d9fd0d1d81fdac38563db99ae0a",
+            "contractClassName": "Token"
         },
         "ParametersStorage": {
             "evmAddress": "0x2Aca9CfEAD9f30a529E6617317b9B6dde578E646",
@@ -25,7 +29,9 @@
             "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
             "deploymentBlock": 41496000,
             "deploymentTimestamp": 1778760288818,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x11ef0a74cdeecc6a58983abc4a8777a58f81c9cfa4ce62fc20d938ac9b93eeb0",
+            "contractClassName": "ParametersStorage"
         },
         "WhitelistStorage": {
             "evmAddress": "0x68B727E165eA1043BE738D6be3237960f52de2e2",
@@ -34,7 +40,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331794,
             "deploymentTimestamp": 1778431878128,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xbfa277feacdcc78a3c4c20fd01eac88df03ede733ba073fef6f42038b560dc52",
+            "contractClassName": "WhitelistStorage"
         },
         "IdentityStorage": {
             "evmAddress": "0xabD2E5C5Ac182f1219d5074f6f613F86BC009faE",
@@ -43,7 +51,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331796,
             "deploymentTimestamp": 1778431882834,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x2d3ad701fb22fd62cd37a56f323af63c4b236e1341e3e8c12d3bfe791ab2db91",
+            "contractClassName": "IdentityStorage"
         },
         "ShardingTableStorage": {
             "evmAddress": "0x27f0b1Ac9901a4b236077247981901364b182ADE",
@@ -52,7 +62,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331798,
             "deploymentTimestamp": 1778431887446,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xda9ef15320ea7b4ac99b129198db4059ebde2e316d7505cb57c20c6c0e65b70f",
+            "contractClassName": "ShardingTableStorage"
         },
         "StakingStorage": {
             "evmAddress": "0xF343e306dbD6e240CBe9E5Fb3f063732b6227D2c",
@@ -61,7 +73,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331801,
             "deploymentTimestamp": 1778431892188,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x5287131df599ba05855519e47d5ad8ed417c9ef5a78810f75757f72bf8557ad5",
+            "contractClassName": "StakingStorage"
         },
         "ProfileStorage": {
             "evmAddress": "0x4AeFa321982fDC7B40635841BE17c9cb57D6b8e0",
@@ -70,7 +84,9 @@
             "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
             "deploymentBlock": 41496003,
             "deploymentTimestamp": 1778760297378,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x914508170eb91a499135dee7ac805eac0acf061130fca7b71b557ce85be3b16a",
+            "contractClassName": "ProfileStorage"
         },
         "Chronos": {
             "evmAddress": "0x117904e8De246171bec61FA7Cc6931E361A9A01a",
@@ -79,7 +95,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331805,
             "deploymentTimestamp": 1778431901773,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x5f2824e505768368b72a7c4b0d97d5b631e2dc2f598b0794c2b347483c10cf0d",
+            "contractClassName": "Chronos"
         },
         "EpochStorageV8": {
             "evmAddress": "0xeD1Be260AA48c727a4036087F972d4eE43a8d0B8",
@@ -88,7 +106,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331810,
             "deploymentTimestamp": 1778431911017,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xfc5ca275a1e9c476c1d5abb9e53fdabd3464a6b22a153064a3aa60e75abd68ec",
+            "contractClassName": "EpochStorage"
         },
         "KnowledgeCollectionStorage": {
             "evmAddress": "0x77F6244B60583aB041E6b5B4451DbA4d7c2f0930",
@@ -97,7 +117,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331812,
             "deploymentTimestamp": 1778431915734,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xe4b14af44292a7c108b1a611c3d94e346c149f1e3de6c7ac9eb98b428de54c5d",
+            "contractClassName": "KnowledgeCollectionStorage"
         },
         "ContextGraphsRegistry": {
             "evmAddress": null,
@@ -142,7 +164,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331815,
             "deploymentTimestamp": 1778431920356,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xc875c3def6079c4999c0666c5739715794ad148b302c225fc151c77bcb0704a5",
+            "contractClassName": "PaymasterManager"
         },
         "AskStorage": {
             "evmAddress": "0x61D1550Da234b1A8e9f46A677ABa1e6F485586FD",
@@ -151,7 +175,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331817,
             "deploymentTimestamp": 1778431925090,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x08a95986a85f5e3010802682903b47d3f9d349c3b1c043a5ee9e439eaf1dc554",
+            "contractClassName": "AskStorage"
         },
         "Identity": {
             "evmAddress": "0x65463AEf19183bAa904135Dcd0626B40057F13D2",
@@ -160,7 +186,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331819,
             "deploymentTimestamp": 1778431929807,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xdfde863f097501a4d842db48a06b007cbd926fc5e9667e2b499f6b6f0a11b33f",
+            "contractClassName": "Identity"
         },
         "ShardingTable": {
             "evmAddress": "0x7FA4175D88931A1D82AF55982d57B0Bf72CFFCaA",
@@ -169,7 +197,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331824,
             "deploymentTimestamp": 1778431939346,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x60e8fcf4cf0464df1f24ad02d9cf568910b2b38ace5e5e73ddeb9b15e26911ce",
+            "contractClassName": "ShardingTable"
         },
         "Ask": {
             "evmAddress": "0xb2b29c7173431776063d76B752624872F3C76C6C",
@@ -178,7 +208,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331827,
             "deploymentTimestamp": 1778431944001,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xf92f72abc3544bd35bfcbf2c3b411610b8b719d3b68bcd5bacf9c0ac19a258e1",
+            "contractClassName": "Ask"
         },
         "DelegatorsInfo": {
             "evmAddress": "0x3B9433884330Fbf6db5817ACA03a74f851519802",
@@ -187,7 +219,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331829,
             "deploymentTimestamp": 1778431948630,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x8c399ea96ab87f808000ce24c22eac6b8ace23f2267b92559962768c46f21af1",
+            "contractClassName": "DelegatorsInfo"
         },
         "RandomSamplingStorage": {
             "evmAddress": "0x251b51cf6e28ea34D06c2241751D1Dde769F4424",
@@ -196,7 +230,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331831,
             "deploymentTimestamp": 1778431953371,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xea24260b3261950e79f408fa96827b45e10640e78e5ceffc56f69d9e50e72f3e",
+            "contractClassName": "RandomSamplingStorage"
         },
         "Staking": {
             "evmAddress": "0x574808170fF11774C1A2402ad1C6d4b63Eb54830",
@@ -205,7 +241,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331834,
             "deploymentTimestamp": 1778431958265,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xdc634a46ec45bbe3be4cd7f6f0513810a672b7a33e3947e9b77ba247af9578dc",
+            "contractClassName": "Staking"
         },
         "StakingKPI": {
             "evmAddress": "0x877cAb635bA3fA4996363c7787c1007108D3CF53",
@@ -214,7 +252,9 @@
             "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
             "deploymentBlock": 41496006,
             "deploymentTimestamp": 1778760300937,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x58dbe9edb1eca323d968899d493a4e93533c2a6fc97dcc2ad6f8fea638eee46d",
+            "contractClassName": "StakingKPI"
         },
         "Profile": {
             "evmAddress": "0xE4efbE7ADe09BFb45cEE8F6544162D55557674F5",
@@ -223,7 +263,9 @@
             "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
             "deploymentBlock": 41496008,
             "deploymentTimestamp": 1778760306857,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xaea3706dd5cae1fa006c14702375f54d5518a990f77533165bae1dac3d139ae6",
+            "contractClassName": "Profile"
         },
         "KnowledgeCollection": {
             "evmAddress": "0x335f5DACfef409c59A04bC1350bf0A21F69DBdca",
@@ -232,7 +274,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331841,
             "deploymentTimestamp": 1778431972480,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xbb289a38415e172cc24e2e75875ec8e1d8fff14a34ba7692d1c5242dd5daf043",
+            "contractClassName": "KnowledgeCollection"
         },
         "ContextGraphStagingRegistry": {
             "evmAddress": null,
@@ -277,7 +321,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331848,
             "deploymentTimestamp": 1778431986550,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x4643b3b04f0713fa157590ae9d89b4d6548f42b53e7b5f00f48d5a3c7e130079",
+            "contractClassName": "RandomSampling"
         },
         "MigratorV8TuningPeriodRewards": {
             "evmAddress": null,
@@ -313,7 +359,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331850,
             "deploymentTimestamp": 1778431991308,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xa4da00e7683c45e88fa0041f4b87584cc7541465330ec4f5376a5debc14a4e6f",
+            "contractClassName": "KnowledgeAssetsStorage"
         },
         "KnowledgeAssets": {
             "evmAddress": "0x3dDcc811C8898c5B0F4201965d1c67F7c6639a1f",
@@ -322,7 +370,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331855,
             "deploymentTimestamp": 1778432000679,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x043f5b161653b19f65f47b317b55b697325a6fafb58dc040ecfeea5e84cf647e",
+            "contractClassName": "KnowledgeAssets"
         },
         "EpochStorageV6": {
             "evmAddress": "0x818B21EA61a5e000eb3412CcE6b2F0ddbCAeFa41",
@@ -331,7 +381,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331808,
             "deploymentTimestamp": 1778431906419,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xfc5ca275a1e9c476c1d5abb9e53fdabd3464a6b22a153064a3aa60e75abd68ec",
+            "contractClassName": "EpochStorage"
         },
         "ConvictionStakingStorage": {
             "evmAddress": "0xA5D86231Ed0d9CAdD3a9Edf1ea058C5641872b17",
@@ -340,7 +392,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331822,
             "deploymentTimestamp": 1778431934547,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xf6a5aed53fa2d812579f7b6957262eea09be7ed63b87bfa760aba72f6a2b18da",
+            "contractClassName": "ConvictionStakingStorage"
         },
         "ContextGraphStorage": {
             "evmAddress": "0x3707137F289307b5A12b7dd7375b82D7cc5c9E40",
@@ -349,7 +403,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331843,
             "deploymentTimestamp": 1778431977180,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x39a541a4c0a2132d75663b73f0eb798574ddbe7d8d4f2b97cf8ecd31d93de786",
+            "contractClassName": "ContextGraphStorage"
         },
         "ContextGraphValueStorage": {
             "evmAddress": "0xb22c90BbCa216Fa93835A6E6a983F681bC3676b4",
@@ -358,7 +414,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331845,
             "deploymentTimestamp": 1778431981794,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xf90ee04c7c7841d277d5d242ecb0dd8bea2035967d56c350bf822e446a6c1d99",
+            "contractClassName": "ContextGraphValueStorage"
         },
         "ContextGraphs": {
             "evmAddress": "0xA508D8910E654FD110E8Fdc25DE8476690Ad73DF",
@@ -367,7 +425,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331853,
             "deploymentTimestamp": 1778431995956,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xfe4fa66f074c55a738849085a23011ff33aa40df86f684fe07538c74e195b9a6",
+            "contractClassName": "ContextGraphs"
         },
         "ContextGraphNameRegistry": {
             "evmAddress": "0xE4507980F44061614c3D1472Bb4E7E25D017A0c6",
@@ -376,7 +436,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331857,
             "deploymentTimestamp": 1778432005261,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x99b3d8d42341698d1553001416db10317752e526eb1608e39db07dc0ea22f6fa",
+            "contractClassName": "ContextGraphNameRegistry"
         },
         "PublishingConvictionAccount": {
             "evmAddress": "0xc54789b1cb8aF5f50e22ebCf1ddeB5bef6aCe2F8",
@@ -385,7 +447,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331860,
             "deploymentTimestamp": 1778432010917,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x2bc1cd65b56d50523b9d73d57af378ac529724c1de530bc8de489984b9baf9ab",
+            "contractClassName": "PublishingConvictionAccount"
         },
         "DKGPublishingConvictionNFT": {
             "evmAddress": "0x41490Dcd0Ed0131e8e996F0CdD68643dcE533DC2",
@@ -394,7 +458,9 @@
             "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
             "deploymentBlock": 41496011,
             "deploymentTimestamp": 1778760312991,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x47ed84ca98c4c0815ff1ffdfef1b3fcc34271f1ae19ebdbc06824babb28e48e7",
+            "contractClassName": "DKGPublishingConvictionNFT"
         },
         "KnowledgeAssetsV10": {
             "evmAddress": "0xAD28dA60D8362a9F60cb5E7FCAfBEC4846a07372",
@@ -403,7 +469,9 @@
             "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
             "deploymentBlock": 41496014,
             "deploymentTimestamp": 1778760318899,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x2a1934b2185e7725f92ad897fb63a3afafa4f0a1c59a1263491a307a6ab964e5",
+            "contractClassName": "KnowledgeAssetsV10"
         },
         "StakingV10": {
             "evmAddress": "0xab461F7bC8cA212A0cE3a8132acf9Ed869BaF47C",
@@ -412,7 +480,9 @@
             "gitCommitHash": "7235e66913df6c23c555fe2827cf30fa79cddbd6",
             "deploymentBlock": 41496017,
             "deploymentTimestamp": 1778760325412,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0xa9433a66686563fd300f06deb1b3f09b0c66165e45560768bf3077bf88447166",
+            "contractClassName": "StakingV10"
         },
         "DKGStakingConvictionNFT": {
             "evmAddress": "0xF334e2754FC28693d9703301088A7C18d2c9C4fe",
@@ -421,7 +491,9 @@
             "gitCommitHash": "9f09d58f29f2ffed1d42790811531654c262caf0",
             "deploymentBlock": 41331869,
             "deploymentTimestamp": 1778432029610,
-            "deployed": true
+            "deployed": true,
+            "deployedBytecodeHash": "0x4f7d045bc0472337ccc23138e040c5d90c8f9c8f39095d4b1c71f1840a4afaa7",
+            "contractClassName": "DKGStakingConvictionNFT"
         }
     }
 }

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -17,6 +17,8 @@
     "test:integration": "hardhat test --network hardhat --config hardhat.node.config.ts --grep '@integration'",
     "deploy:localhost": "hardhat deploy --network hardhat --config hardhat.node.config.ts",
     "deploy:testnet": "hardhat deploy --network base_sepolia_v10 --config hardhat.node.config.ts",
+    "check-contracts:testnet": "hardhat run scripts/check-contract-hashes.ts --network base_sepolia_v10 --config hardhat.node.config.ts",
+    "record-contract-hashes:testnet": "hardhat run scripts/record-contract-hashes-from-chain.ts --network base_sepolia_v10 --config hardhat.node.config.ts",
     "typechain": "hardhat typechain"
   },
   "dependencies": {

--- a/packages/evm-module/scripts/check-contract-hashes.ts
+++ b/packages/evm-module/scripts/check-contract-hashes.ts
@@ -1,0 +1,113 @@
+/**
+ * Check which contracts changed since the last recorded deploy on a
+ * given network. Compares the keccak256 of each contract's current
+ * artifact `deployedBytecode` against the `deployedBytecodeHash`
+ * recorded in `deployments/<network>_contracts.json`.
+ *
+ * Exit codes:
+ *   0 — all deployed contracts match their recorded hash
+ *   1 — at least one contract has drifted; output lists which
+ *   2 — script-level error (artifact missing, RPC failure, etc.)
+ *
+ * Run:
+ *   pnpm --filter @origintrail-official/dkg-evm-module \
+ *     exec hardhat run scripts/check-contract-hashes.ts \
+ *     --network base_sepolia_v10 --config hardhat.node.config.ts
+ *
+ * Note: the network flag is consulted only for the network NAME (which
+ * deployments file to read). No RPC calls are made — the script
+ * compares artifact hashes vs the JSON, both local.
+ */
+import hre from 'hardhat';
+import {
+  loadDeployments,
+  getArtifactBytecodeHash,
+  resolveArtifactName,
+} from './contract-hashing-lib';
+
+async function main(): Promise<void> {
+  const networkName = hre.network.name;
+  const data = loadDeployments(networkName);
+
+  const changed: string[] = [];
+  const missingHash: string[] = [];
+  const okCount = { value: 0 };
+  const errors: Array<{ name: string; err: string }> = [];
+  let skippedNotDeployed = 0;
+
+  for (const [name, entry] of Object.entries(data.contracts)) {
+    if (!entry.deployed) {
+      skippedNotDeployed++;
+      continue;
+    }
+
+    let artifactName: string;
+    let artifactHash: string;
+    try {
+      artifactName = await resolveArtifactName(hre, name, entry);
+      artifactHash = await getArtifactBytecodeHash(hre, artifactName);
+    } catch (err) {
+      errors.push({
+        name,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    if (!entry.deployedBytecodeHash) {
+      missingHash.push(name);
+      continue;
+    }
+
+    if (
+      artifactHash.toLowerCase() !== entry.deployedBytecodeHash.toLowerCase()
+    ) {
+      changed.push(name);
+    } else {
+      okCount.value++;
+    }
+  }
+
+  console.log(`\n[hash-check] Network: ${networkName}`);
+  console.log(`  Up-to-date:                 ${okCount.value}`);
+  console.log(`  Changed since last deploy:  ${changed.length}`);
+  console.log(`  Missing recorded hash:      ${missingHash.length}`);
+  console.log(`  Artifact lookup errors:     ${errors.length}`);
+  console.log(`  Skipped (deployed: false):  ${skippedNotDeployed}`);
+
+  if (missingHash.length > 0) {
+    console.log(`\n[hash-check] Missing 'deployedBytecodeHash' (backfill needed):`);
+    for (const n of missingHash) console.log(`  - ${n}`);
+    console.log(
+      `\nBackfill with:\n  pnpm --filter @origintrail-official/dkg-evm-module \\\n` +
+        `    exec hardhat run scripts/record-contract-hashes-from-chain.ts \\\n` +
+        `    --network ${networkName} --config hardhat.node.config.ts`,
+    );
+  }
+
+  if (errors.length > 0) {
+    console.log(`\n[hash-check] Could not load artifact (rename or missing compile?):`);
+    for (const { name, err } of errors) console.log(`  - ${name}: ${err}`);
+  }
+
+  if (changed.length === 0) {
+    console.log(`\n[hash-check] No bytecode drift detected.`);
+    process.exit(missingHash.length > 0 || errors.length > 0 ? 1 : 0);
+  }
+
+  console.log(`\n[hash-check] CHANGED contracts (redeploy candidates):`);
+  for (const n of changed) console.log(`  - ${n}`);
+  console.log(
+    `\nTo redeploy: flip 'deployed: false' on each of the above in:\n` +
+      `  packages/evm-module/deployments/${networkName}_contracts.json\n` +
+      `then run:\n` +
+      `  pnpm --filter @origintrail-official/dkg-evm-module \\\n` +
+      `    exec hardhat deploy --network ${networkName} --config hardhat.node.config.ts`,
+  );
+  process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/packages/evm-module/scripts/contract-hashing-lib.ts
+++ b/packages/evm-module/scripts/contract-hashing-lib.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared helpers for deployed-bytecode hash tracking.
+ *
+ * The deployed-bytecode hash anchors which Solidity build is actually
+ * sitting at each `evmAddress` in `deployments/<network>_contracts.json`.
+ * Recording it at deploy time + re-computing it at check time turns
+ * "which contracts changed since the last deploy?" into a deterministic
+ * artifact comparison, instead of a brittle dance with git diffs.
+ *
+ * Hash strategy: `keccak256(deployedBytecode)` where `deployedBytecode`
+ * is the artifact's `deployedBytecode` (== `eth_getCode(addr)` after a
+ * fresh deploy). Includes the Solidity metadata trailer, so a
+ * comment-only edit will register as a change — that's fine for this
+ * use case (the metadata hash IS the source-verification anchor on
+ * basescan, and a comment edit without redeploy desyncs verified-source
+ * displays from on-chain truth).
+ *
+ * The hash IS reproducible from chain alone (just hash `eth_getCode(addr)`),
+ * which makes the recorded value auditable without needing the
+ * artifact.
+ */
+import * as fs from 'fs';
+import { keccak256, Provider } from 'ethers';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+export type DeploymentEntry = {
+  evmAddress: string;
+  version: string | null;
+  gitBranch: string;
+  gitCommitHash: string;
+  deploymentBlock: number;
+  deploymentTimestamp: number;
+  deployed: boolean;
+  migration?: boolean;
+  contractClassName?: string;
+  deployedBytecodeHash?: string;
+};
+
+export type DeploymentsFile = {
+  contracts: { [contractName: string]: DeploymentEntry };
+};
+
+export function deploymentsPath(networkName: string): string {
+  return `./deployments/${networkName}_contracts.json`;
+}
+
+export function loadDeployments(networkName: string): DeploymentsFile {
+  return JSON.parse(fs.readFileSync(deploymentsPath(networkName), 'utf8'));
+}
+
+export function saveDeployments(
+  networkName: string,
+  data: DeploymentsFile,
+): void {
+  // Match the existing 4-space indent + trailing newline of the hand-
+  // managed deployments JSON so diffs stay minimal.
+  fs.writeFileSync(
+    deploymentsPath(networkName),
+    JSON.stringify(data, null, 4) + '\n',
+  );
+}
+
+/**
+ * Resolve the artifact class name for a deployment entry. Resolution
+ * order:
+ *   1. Explicit `contractClassName` on the entry (set at deploy time
+ *      by helpers.ts for multi-deploys).
+ *   2. Direct match: the entry key is the artifact name.
+ *   3. Longest-prefix fallback: e.g. `EpochStorageV6` resolves to
+ *      `EpochStorage` because the latter is a strict prefix and the
+ *      only artifact that matches. Handles the case where an existing
+ *      JSON entry pre-dates the `contractClassName` field.
+ *
+ * Throws if none of the above resolve to an artifact, with a hint
+ * pointing at the manual fix (set `contractClassName` in the JSON).
+ */
+export async function resolveArtifactName(
+  hre: HardhatRuntimeEnvironment,
+  entryName: string,
+  entry: DeploymentEntry,
+): Promise<string> {
+  if (entry.contractClassName) return entry.contractClassName;
+
+  try {
+    await hre.artifacts.readArtifact(entryName);
+    return entryName;
+  } catch {
+    // Fall through to prefix search.
+  }
+
+  const allFqNames = await hre.artifacts.getAllFullyQualifiedNames();
+  let bestMatch: string | null = null;
+  for (const fq of allFqNames) {
+    // FQ name is "path/to/File.sol:ContractName".
+    const name = fq.split(':')[1];
+    if (!name) continue;
+    if (entryName.startsWith(name) && name !== entryName) {
+      if (!bestMatch || name.length > bestMatch.length) bestMatch = name;
+    }
+  }
+  if (bestMatch) return bestMatch;
+
+  throw new Error(
+    `No artifact found for deployment entry '${entryName}'. Direct + ` +
+      `prefix-fallback both failed. Set 'contractClassName' explicitly ` +
+      `on the entry in the deployments JSON.`,
+  );
+}
+
+/**
+ * Hash the runtime bytecode currently sitting at `address` on chain.
+ * Throws if the address has no code (contract self-destructed, never
+ * deployed, or wrong network).
+ */
+export async function getOnChainBytecodeHash(
+  address: string,
+  provider: Provider,
+): Promise<string> {
+  const code = await provider.getCode(address);
+  if (code === '0x' || code === '') {
+    throw new Error(
+      `No bytecode at ${address} (contract self-destructed, never deployed, or wrong network).`,
+    );
+  }
+  return keccak256(code);
+}
+
+/**
+ * Hash the runtime bytecode the current compilation produced for a
+ * given contract class. For a fresh deploy, this equals
+ * `getOnChainBytecodeHash(addr)` exactly. Drift between the two means
+ * the source has changed since deploy.
+ */
+export async function getArtifactBytecodeHash(
+  hre: HardhatRuntimeEnvironment,
+  artifactName: string,
+): Promise<string> {
+  const artifact = await hre.artifacts.readArtifact(artifactName);
+  return keccak256(artifact.deployedBytecode);
+}

--- a/packages/evm-module/scripts/record-contract-hashes-from-chain.ts
+++ b/packages/evm-module/scripts/record-contract-hashes-from-chain.ts
@@ -1,0 +1,89 @@
+/**
+ * Backfill `deployedBytecodeHash` for every `deployed: true` entry in
+ * `deployments/<network>_contracts.json` by querying `eth_getCode(addr)`
+ * on the configured network and writing `keccak256(code)` into the JSON.
+ *
+ * Use cases:
+ *   - One-shot bootstrap on networks whose deploy predates this hash
+ *     mechanism (records the on-chain hash so subsequent
+ *     `check-contract-hashes` can compare against current artifacts).
+ *   - Sanity check / drift recovery — re-runs after an external upgrade
+ *     pick up the new on-chain bytecode.
+ *
+ * After running, commit the updated JSON.
+ *
+ * Run:
+ *   pnpm --filter @origintrail-official/dkg-evm-module \
+ *     exec hardhat run scripts/record-contract-hashes-from-chain.ts \
+ *     --network base_sepolia_v10 --config hardhat.node.config.ts
+ */
+import hre from 'hardhat';
+import {
+  loadDeployments,
+  saveDeployments,
+  getOnChainBytecodeHash,
+  resolveArtifactName,
+} from './contract-hashing-lib';
+
+async function main(): Promise<void> {
+  const networkName = hre.network.name;
+  const data = loadDeployments(networkName);
+  const provider = hre.ethers.provider;
+
+  let updated = 0;
+  let skippedNotDeployed = 0;
+  const failed: Array<{ name: string; err: string }> = [];
+
+  for (const [name, entry] of Object.entries(data.contracts)) {
+    if (!entry.deployed) {
+      skippedNotDeployed++;
+      continue;
+    }
+    try {
+      const hash = await getOnChainBytecodeHash(entry.evmAddress, provider);
+      const wasSet = entry.deployedBytecodeHash;
+      const change =
+        wasSet && wasSet.toLowerCase() !== hash.toLowerCase()
+          ? ' (changed)'
+          : wasSet
+            ? ''
+            : ' (new)';
+      console.log(`${name.padEnd(36)} ${entry.evmAddress}  →  ${hash}${change}`);
+      entry.deployedBytecodeHash = hash;
+
+      // Also backfill `contractClassName` when missing so the check
+      // script's prefix-fallback lookup becomes an explicit, audited
+      // assignment. Soft-failure: if no artifact resolves, leave the
+      // field unset — check script will retry the fallback there.
+      if (!entry.contractClassName) {
+        try {
+          entry.contractClassName = await resolveArtifactName(
+            hre,
+            name,
+            entry,
+          );
+        } catch {
+          // Leave undefined — check script will surface the error.
+        }
+      }
+
+      updated++;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[record]  FAILED  ${name} @ ${entry.evmAddress}: ${msg}`);
+      failed.push({ name, err: msg });
+    }
+  }
+
+  saveDeployments(networkName, data);
+  console.log(
+    `\n[record] Wrote ${updated} hashes to ${networkName}_contracts.json ` +
+      `(skipped ${skippedNotDeployed} not-deployed, ${failed.length} failed).`,
+  );
+  process.exit(failed.length > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/packages/evm-module/utils/helpers.ts
+++ b/packages/evm-module/utils/helpers.ts
@@ -3,7 +3,7 @@ import 'dotenv/config';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 
-import { AddressLike, Contract } from 'ethers';
+import { AddressLike, Contract, keccak256 } from 'ethers';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 
 import { HubLib } from '../typechain/contracts/storage/Hub';
@@ -27,6 +27,24 @@ type ContractDeployments = {
       deploymentTimestamp: number;
       deployed: boolean;
       migration?: boolean;
+      /**
+       * Source class name for the artifact. Set when the deployed-contract
+       * name in Hub differs from the Solidity contract class (e.g. the
+       * `EpochStorage` class is deployed twice as `EpochStorageV6` and
+       * `EpochStorageV8`). Optional — defaults to the entry key when
+       * artifact name == Hub name. Used by the hash-tracking scripts to
+       * find the correct artifact for change detection.
+       */
+      contractClassName?: string;
+      /**
+       * `keccak256` of the runtime (deployed) bytecode actually on chain
+       * at `evmAddress`. Computed at deploy time from the artifact's
+       * `deployedBytecode` (which equals `eth_getCode(addr)` for a fresh
+       * deploy). `scripts/check-contract-hashes.ts` re-hashes the current
+       * artifact and flags any mismatch as a redeploy candidate. Strips
+       * the need to compare git diffs across deploys.
+       */
+      deployedBytecodeHash?: string;
     };
   };
 };
@@ -433,6 +451,16 @@ export class Helpers {
       contractVersion = null;
     }
 
+    // Hash the runtime bytecode the compiler produced for this contract
+    // class. For a fresh deploy this equals `eth_getCode(addr)` exactly,
+    // so it anchors the on-chain identity of the deployed code. The
+    // hash-check script (`scripts/check-contract-hashes.ts`) re-runs this
+    // computation on later compiles and flags any drift as a redeploy
+    // candidate — no more diffing git ranges to figure out what changed.
+    const artifactName = originalContractName ?? newContractName;
+    const artifact = await this.hre.artifacts.readArtifact(artifactName);
+    const deployedBytecodeHash = keccak256(artifact.deployedBytecode);
+
     this.contractDeployments.contracts[newContractName] = {
       evmAddress: newContractAddress,
       version: contractVersion,
@@ -441,6 +469,8 @@ export class Helpers {
       deploymentBlock: deploymentBlock,
       deploymentTimestamp: Date.now(),
       deployed: true,
+      contractClassName: artifactName,
+      deployedBytecodeHash,
     };
   }
 


### PR DESCRIPTION
> **Stacked on top of [#511](https://github.com/OriginTrail/dkg/pull/511)** — base is set to `claude/frosty-beaver-a00722` so the diff shows only this PR's mechanism. Once #511 merges to main, GitHub will auto-rebase this PR's base to `main` and only the two commits below will remain.

## Why

Picking which contracts to redeploy by diffing git ranges (as we did for [#511](https://github.com/OriginTrail/dkg/pull/511)) is brittle. It misses:

- transitive dependency changes (e.g. a `library`/`interface` tweak that re-bytecodes its consumers via metadata trailer drift),
- compiler-version or optimizer-setting drift in `hardhat.node.config.ts`,
- `node_modules` / remapping shifts in OpenZeppelin or solady.

All of those produce a new on-chain bytecode that won't match basescan source verification even when the contract's own `.sol` file is untouched.

This PR adds an authoritative anchor: **per-contract `deployedBytecodeHash` stored in the deployments JSON, recorded at deploy time, verifiable from chain alone**.

## How it works

`deployedBytecodeHash = keccak256(deployedBytecode)` where `deployedBytecode` is the runtime code on chain (== `eth_getCode(addr)` after a fresh deploy). Re-hashable from chain alone:

```js
keccak256(await provider.getCode(addr)) === entry.deployedBytecodeHash
```

The hash includes the Solidity metadata trailer, so any source-tree change in the contract's transitive dep graph registers as drift. That's intentional — keeping basescan verified sources aligned with on-chain bytecode is generally what we want.

## What's added

- [packages/evm-module/utils/helpers.ts](packages/evm-module/utils/helpers.ts) — `updateDeploymentsJson()` now hashes the artifact's `deployedBytecode` and writes `deployedBytecodeHash` + `contractClassName` to the entry. Multi-deploys of a single class (e.g. `EpochStorage` → `EpochStorageV6` + `EpochStorageV8`) get the artifact name recorded so the check script can find the source.
- [scripts/contract-hashing-lib.ts](packages/evm-module/scripts/contract-hashing-lib.ts) — shared utility (`getOnChainBytecodeHash`, `getArtifactBytecodeHash`, `resolveArtifactName` with explicit / direct / prefix-fallback resolution, `load`/`saveDeployments`).
- [scripts/check-contract-hashes.ts](packages/evm-module/scripts/check-contract-hashes.ts) — compare current artifact hashes vs recorded; prints up-to-date / changed / missing counts; exits `1` on drift.
- [scripts/record-contract-hashes-from-chain.ts](packages/evm-module/scripts/record-contract-hashes-from-chain.ts) — one-shot bootstrap that reads `eth_getCode` for every deployed entry and writes its hash + resolved `contractClassName` into the JSON.
- `pnpm` scripts: `check-contracts:testnet` and `record-contract-hashes:testnet`.
- [docs/TESTNET_RESET.md](docs/TESTNET_RESET.md) — Phase B now documents the targeted-upgrade workflow alongside the existing full-reset path.

## Backfill included

Second commit ([8b27dcca](commit/8b27dcca)) is the one-shot population for `base_sepolia_v10`. 36 deployed contracts got their on-chain hash + class name. The 11 `deployed: false` entries (V9-era ContextGraph + Migrator stubs that were never deployed in the V10 reset) are skipped.

## Surprise finding from running it

Right after backfill, `check-contracts:testnet` reports **12 contracts as drifted** vs current main artifact:

```
Up-to-date:                 24
Changed since last deploy:  12
Hub
Chronos
KnowledgeCollectionStorage
AskStorage
ShardingTable
Ask
Staking
KnowledgeCollection
RandomSampling
KnowledgeAssets
ContextGraphs
DKGStakingConvictionNFT
```

The 7 contracts redeployed in [#511](https://github.com/OriginTrail/dkg/pull/511) all show as up-to-date — good. The 12 drifted are from compiler/dep-graph shifts since their original `9f09d58f` / `b152808eb` deploy commit. **None were caught by the git-diff approach** — the new hash check finds them automatically.

Whether to redeploy them is a separate decision (cost of gas + chainResetMarker bump vs cost of basescan-verification drift). Filed as a follow-up.

## Usage

```bash
# Detect drift (no RPC calls; pure local artifact vs JSON comparison)
pnpm --filter @origintrail-official/dkg-evm-module check-contracts:testnet

# Bootstrap on a network that pre-dates the field (idempotent)
pnpm --filter @origintrail-official/dkg-evm-module record-contract-hashes:testnet
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)