### PR TITLE
fix(agent): close post-approval sync gap that hid freshly-joined curated CGs

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -576,6 +576,18 @@ export interface ContextGraphSub {
   participantIdentityIds?: bigint[];
   /** Participant agent addresses (V10 agent identity model). */
   participantAgents?: string[];
+  /**
+   * Set to true between receiving a curator `join-approved` notification
+   * and the first successful meta sync for this CG. Lets `listContextGraphs`
+   * surface freshly-joined curated CGs in the UI's "waiting for sync" state
+   * before `_meta` triples arrive — without this flag, a curated CG with
+   * no `onChainId` and no local content yet is filtered out as a "phantom"
+   * subscription and the project entry doesn't appear in the sidebar until
+   * the periodic catchup reconciler eventually pulls meta (~2 min worst
+   * case). In-memory only; not persisted because the periodic reconciler
+   * always recovers post-restart by populating `metaSynced` directly.
+   */
+  pendingMeta?: boolean;
 }
 
 export interface ContextGraphSubscriptionRecord {
@@ -1868,7 +1880,18 @@ export class DKGAgent {
               source: 'join-approved',
             });
             this.joinRequestAcceptedBy.delete(`${contextGraphId}::${approvedAddr.toLowerCase()}`);
-            this.syncContextGraphFromConnectedPeers(contextGraphId, { includeSharedMemory: true }).catch(() => {});
+            // Mark the subscription as "expecting meta" so listContextGraphs
+            // surfaces it in the UI immediately (with synced=false) instead
+            // of filtering it out as a phantom subscription until meta-sync
+            // completes. Cleared in `refreshMetaSyncedFlags` once meta lands.
+            this.markContextGraphSubscriptionState(contextGraphId, { pendingMeta: true });
+            // Sync immediately by targeting the curator peer we just received
+            // this notification from, instead of relying on the periodic
+            // catchup reconciler to pick it up minutes later. The previous
+            // `.catch(() => {})` swallowed every failure mode silently and
+            // also went through the regular peer-ranking path that produced
+            // zero sync attempts in the just-approved-but-no-meta-yet window.
+            void this.runImmediatePostApprovalSync(contextGraphId, peerId.toString());
             this.eventBus.emit(DKGEvent.JOIN_APPROVED, {
               contextGraphId,
               agentAddress: approvedAddr,
@@ -2915,6 +2938,70 @@ export class DKGAgent {
     await primeCatchupConnectionsAtom(this.node.libp2p as any, this.discovery, this.peerId);
   }
 
+  /**
+   * Pull `_meta` (and SWM) for a CG immediately after receiving a curator
+   * `join-approved` notification, targeting the curator peer directly.
+   *
+   * Fixes the ~107s window where a freshly-approved curated CG sat
+   * unsynced because the previous post-approval call
+   * (`syncContextGraphFromConnectedPeers(...).catch(() => {})`):
+   *
+   *   1. Swallowed every failure mode — including the case where the
+   *      regular peer-ranking heuristics produced zero sync attempts
+   *      because no other peer announced the CG yet (the freshly-
+   *      approved-but-no-meta-yet window). The next sync attempt only
+   *      came from the periodic catchup reconciler ~2 min later.
+   *
+   *   2. Re-walked the full `selectCatchupPeers` ranking even though
+   *      we already knew exactly who to ask: the curator peer that
+   *      just sent us the approval. Skipping that walk gets us to a
+   *      sync attempt within ~1s of approval.
+   *
+   * Falls back to the standard broadcast catchup if the curator-direct
+   * attempt yields zero successful peers — defensive for the case
+   * where the inbound notification connection was a one-shot relay
+   * that won't re-open for catchup, or the curator process happened
+   * to die between sending the approval and the catchup dial.
+   */
+  private async runImmediatePostApprovalSync(
+    contextGraphId: string,
+    curatorPeerId: string,
+  ): Promise<void> {
+    const ctx = createOperationContext('sync');
+    try {
+      await this.ensurePeerConnected(curatorPeerId);
+      const curatorRemote = this.node.libp2p
+        .getConnections()
+        .find((conn) => conn.remotePeer.toString() === curatorPeerId)?.remotePeer;
+      const curatorShort = curatorPeerId.slice(-8);
+      if (curatorRemote) {
+        const result = await this.runCatchupOverPeers(contextGraphId, true, [curatorRemote]);
+        if (result.peersSucceeded > 0) {
+          this.log.info(
+            ctx,
+            `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} fetched ${result.dataSynced} data + ${result.sharedMemorySynced} SWM triples`,
+          );
+          return;
+        }
+        this.log.warn(
+          ctx,
+          `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} produced no successful peer (denied=${result.denied}); falling back to broadcast catchup`,
+        );
+      } else {
+        this.log.warn(
+          ctx,
+          `Post-approval sync for "${contextGraphId}": curator ${curatorShort} not in connected peers after ensurePeerConnected; falling back to broadcast catchup`,
+        );
+      }
+      await this.syncContextGraphFromConnectedPeers(contextGraphId, { includeSharedMemory: true });
+    } catch (err) {
+      this.log.warn(
+        ctx,
+        `Post-approval sync for "${contextGraphId}" failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   private selectCatchupPeers(
     peers: Array<{ toString(): string }>,
     preferredPeerId?: string,
@@ -2956,6 +3043,13 @@ export class DKGAgent {
         if (sub.metaSynced !== true) {
           sub.metaSynced = true;
           this.persistContextGraphSubscription(contextGraphId);
+        }
+        if (sub.pendingMeta) {
+          // Meta arrived; the freshly-joined "waiting for sync" state
+          // (set by the join-approved handler) no longer applies — the
+          // CG will now surface via the normal `_meta` branch in
+          // `listContextGraphs`.
+          sub.pendingMeta = false;
         }
         this.queueSharedMemoryGossipSubscription(contextGraphId);
       }
@@ -10822,7 +10916,7 @@ export class DKGAgent {
         continue;
       }
 
-      // No declaration in ontology, agents, or _meta graphs. Two cases:
+      // No declaration in ontology, agents, or _meta graphs. Three cases:
       //
       //  1. Chain-attested but not-yet-synced (sub.onChainId set):
       //     auto-discovery from the on-chain registry found this CG and
@@ -10832,12 +10926,24 @@ export class DKGAgent {
       //     `subscribedContextGraphs` by the daemon's authoritative
       //     denial path (accessDeniedPeers > 0) before we get here.
       //
-      //  2. Not chain-attested AND no local content: a truly phantom
-      //     entry (pre-discovery subscribe that never resolved). Hide
-      //     it to avoid polluting the UI. If the user legitimately
-      //     subscribes later, the next catch-up writes _meta or data
-      //     and the entry will appear on the next refresh.
-      if (!sub.onChainId) {
+      //  2. Curator-approved but not-yet-meta-synced (sub.pendingMeta
+      //     set): the join-approved handler subscribed us seconds ago
+      //     and the first meta sync hasn't completed yet. Same UX
+      //     treatment as case 1 — surface as "waiting for sync" so the
+      //     project entry shows up in the sidebar immediately on
+      //     approval, instead of disappearing for ~107s until the
+      //     periodic catchup reconciler eventually pulls _meta. Cleared
+      //     in `refreshMetaSyncedFlags` once meta arrives, at which
+      //     point this entry instead surfaces via the `_meta` branch
+      //     above.
+      //
+      //  3. Not chain-attested, not pending-meta, AND no local content:
+      //     a truly phantom entry (pre-discovery subscribe that never
+      //     resolved). Hide it to avoid polluting the UI. If the user
+      //     legitimately subscribes later, the next catch-up writes
+      //     _meta or data and the entry will appear on the next
+      //     refresh.
+      if (!sub.onChainId && !sub.pendingMeta) {
         // Delegate to `contextGraphHasLocalContent()` so the check
         // covers sub-graphs, assertion graphs and SWM — not just the
         // root data graph. For any non-trivial project the root data

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1884,7 +1884,23 @@ export class DKGAgent {
             // surfaces it in the UI immediately (with synced=false) instead
             // of filtering it out as a phantom subscription until meta-sync
             // completes. Cleared in `refreshMetaSyncedFlags` once meta lands.
-            this.markContextGraphSubscriptionState(contextGraphId, { pendingMeta: true });
+            //
+            // `metaSynced: false` is set together with `pendingMeta: true`
+            // because the two are complementary, not redundant: `metaSynced`
+            // is the FACTUAL state that downstream safety guards check
+            // (`shouldCreateImplicitSharedMemoryContextGraph` and the curated
+            // gossip pre-meta gate in gossip-publish-handler.ts both use
+            // strict `metaSynced === false` equality), and `pendingMeta` is
+            // the UI affordance layered on top. Without `metaSynced: false`,
+            // a freshly-approved private CG slips past both guards in the
+            // window between approval and the first `_meta` arrival — any
+            // SWM write or inbound gossip in that window then gets inferred
+            // as a public CG locally, which is the exact corruption these
+            // guards exist to prevent. Lex review on PR #517 round 2 + Codex.
+            this.markContextGraphSubscriptionState(contextGraphId, {
+              pendingMeta: true,
+              metaSynced: false,
+            });
             // Sync immediately by targeting the curator peer we just received
             // this notification from, instead of relying on the periodic
             // catchup reconciler to pick it up minutes later. The previous

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2968,12 +2968,20 @@ export class DKGAgent {
     curatorPeerId: string,
   ): Promise<void> {
     const ctx = createOperationContext('sync');
+    const curatorShort = curatorPeerId.slice(-8);
+    let curatorTargetSucceeded = false;
+
+    // Curator-direct attempt. Any throw here (relay reservation gone,
+    // dial timeout, AbortSignal, transient `Remote closed connection
+    // during opening`) MUST fall through to the broadcast fallback
+    // below — wrapping both the curator-direct attempt AND the
+    // broadcast in a single try/catch reintroduces the silent-stall
+    // bug this method exists to fix (Lex review on PR #517 + Codex).
     try {
       await this.ensurePeerConnected(curatorPeerId);
       const curatorRemote = this.node.libp2p
         .getConnections()
         .find((conn) => conn.remotePeer.toString() === curatorPeerId)?.remotePeer;
-      const curatorShort = curatorPeerId.slice(-8);
       if (curatorRemote) {
         const result = await this.runCatchupOverPeers(contextGraphId, true, [curatorRemote]);
         if (result.peersSucceeded > 0) {
@@ -2981,24 +2989,35 @@ export class DKGAgent {
             ctx,
             `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} fetched ${result.dataSynced} data + ${result.sharedMemorySynced} SWM triples`,
           );
-          return;
+          curatorTargetSucceeded = true;
+        } else {
+          this.log.warn(
+            ctx,
+            `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} produced no successful peer (denied=${result.denied}); falling back to broadcast catchup`,
+          );
         }
-        this.log.warn(
-          ctx,
-          `Post-approval sync for "${contextGraphId}" from curator ${curatorShort} produced no successful peer (denied=${result.denied}); falling back to broadcast catchup`,
-        );
       } else {
         this.log.warn(
           ctx,
           `Post-approval sync for "${contextGraphId}": curator ${curatorShort} not in connected peers after ensurePeerConnected; falling back to broadcast catchup`,
         );
       }
-      await this.syncContextGraphFromConnectedPeers(contextGraphId, { includeSharedMemory: true });
     } catch (err) {
       this.log.warn(
         ctx,
-        `Post-approval sync for "${contextGraphId}" failed: ${err instanceof Error ? err.message : String(err)}`,
+        `Post-approval sync for "${contextGraphId}": curator-direct attempt to ${curatorShort} failed (${err instanceof Error ? err.message : String(err)}); falling back to broadcast catchup`,
       );
+    }
+
+    if (!curatorTargetSucceeded) {
+      try {
+        await this.syncContextGraphFromConnectedPeers(contextGraphId, { includeSharedMemory: true });
+      } catch (err) {
+        this.log.warn(
+          ctx,
+          `Post-approval broadcast fallback for "${contextGraphId}" failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
   }
 

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -872,6 +872,35 @@ describe('runImmediatePostApprovalSync', () => {
     });
   }, 15000);
 
+  // 🔴 Regression for the Lex-on-PR-#517 round-2 / Codex finding: the
+  // join-approved handler must leave `metaSynced: false` (not undefined)
+  // alongside `pendingMeta: true`, otherwise the strict-equality safety
+  // guards in `shouldCreateImplicitSharedMemoryContextGraph` and the
+  // curated gossip pre-meta gate (`metaSynced === false`) silently fall
+  // through and a freshly-approved private CG can be inferred as public
+  // locally during the window before _meta arrives. This test asserts
+  // the guard fires given the exact subscription shape the join-approved
+  // handler should produce — catches a future refactor that drops
+  // `metaSynced: false` from that call site.
+  it('shouldCreateImplicitSharedMemoryContextGraph rejects when pendingMeta+metaSynced:false', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    agent.subscribeToContextGraph('curated-cg-pendingmeta');
+    (agent as any).subscribedContextGraphs.set('curated-cg-pendingmeta', {
+      name: 'Curated CG',
+      subscribed: true,
+      synced: false,
+      pendingMeta: true,
+      metaSynced: false,
+    } satisfies ContextGraphSub);
+
+    await expect(
+      (agent as any).shouldCreateImplicitSharedMemoryContextGraph('curated-cg-pendingmeta'),
+    ).rejects.toThrow(/awaiting metadata sync/);
+  }, 15000);
+
   // 🔴 Regression for the Lex-on-PR-#517 / Codex catch-block finding.
   // If `ensurePeerConnected` throws (relay flap, dial timeout, abort),
   // the broadcast fallback MUST still run — wrapping curator-direct

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -756,3 +756,147 @@ describe('hash-vs-name duplication regression', () => {
     expect(ghosts.length).toBe(0);
   }, 15000);
 });
+
+// Direct unit coverage for the post-approval sync method introduced
+// alongside `pendingMeta`. Stubs `ensurePeerConnected`,
+// `node.libp2p.getConnections`, `runCatchupOverPeers`, and
+// `syncContextGraphFromConnectedPeers` directly on the live agent
+// instance so we exercise the real branching logic without standing
+// up a second libp2p node + catchup pipeline. Mirrors the existing
+// `(agent as any).subscribedContextGraphs.set(...)` precedent.
+describe('runImmediatePostApprovalSync', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  const CURATOR_PEER = '12D3KooWFakeCuratorPeerForRunImmediatePostApprovalSyncTest';
+
+  function installStubs(a: DKGAgent, opts: {
+    ensurePeerConnected?: (pid: string) => Promise<void>;
+    connectedPeers?: string[];
+    runCatchupResult?: {
+      peersSucceeded: number;
+      dataSynced: number;
+      sharedMemorySynced: number;
+      denied: boolean;
+    };
+    runCatchupThrows?: Error;
+    broadcastThrows?: Error;
+  }) {
+    const calls = {
+      ensurePeerConnectedCalls: [] as string[],
+      runCatchupCalls: [] as Array<{ cg: string; includeSwm: boolean; peers: string[] }>,
+      broadcastCalls: [] as Array<{ cg: string; includeSwm: boolean }>,
+    };
+    (a as any).ensurePeerConnected = async (pid: string) => {
+      calls.ensurePeerConnectedCalls.push(pid);
+      if (opts.ensurePeerConnected) await opts.ensurePeerConnected(pid);
+    };
+    (a as any).node.libp2p.getConnections = () =>
+      (opts.connectedPeers ?? []).map((pid) => ({
+        remotePeer: { toString: () => pid },
+      }));
+    (a as any).runCatchupOverPeers = async (
+      cg: string,
+      includeSwm: boolean,
+      peers: Array<{ toString(): string }>,
+    ) => {
+      calls.runCatchupCalls.push({
+        cg,
+        includeSwm,
+        peers: peers.map((p) => p.toString()),
+      });
+      if (opts.runCatchupThrows) throw opts.runCatchupThrows;
+      return {
+        connectedPeers: 1,
+        syncCapablePeers: 1,
+        peersTried: 1,
+        peersSucceeded: opts.runCatchupResult?.peersSucceeded ?? 0,
+        dataSynced: opts.runCatchupResult?.dataSynced ?? 0,
+        sharedMemorySynced: opts.runCatchupResult?.sharedMemorySynced ?? 0,
+        denied: opts.runCatchupResult?.denied ?? false,
+        diagnostics: { noProtocolPeers: 0 } as any,
+      };
+    };
+    (a as any).syncContextGraphFromConnectedPeers = async (
+      cg: string,
+      sopts?: { includeSharedMemory?: boolean },
+    ) => {
+      calls.broadcastCalls.push({ cg, includeSwm: sopts?.includeSharedMemory ?? false });
+      if (opts.broadcastThrows) throw opts.broadcastThrows;
+    };
+    return calls;
+  }
+
+  it('uses curator-direct catchup when curator is connected and skips broadcast on success', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const calls = installStubs(agent, {
+      connectedPeers: [CURATOR_PEER],
+      runCatchupResult: { peersSucceeded: 1, dataSynced: 7, sharedMemorySynced: 11, denied: false },
+    });
+
+    await (agent as any).runImmediatePostApprovalSync('test-cg-success', CURATOR_PEER);
+
+    expect(calls.ensurePeerConnectedCalls).toEqual([CURATOR_PEER]);
+    expect(calls.runCatchupCalls).toHaveLength(1);
+    expect(calls.runCatchupCalls[0]).toMatchObject({
+      cg: 'test-cg-success',
+      includeSwm: true,
+      peers: [CURATOR_PEER],
+    });
+    expect(calls.broadcastCalls).toHaveLength(0);
+  }, 15000);
+
+  it('falls back to broadcast when curator is not in connected peers after ensurePeerConnected', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const calls = installStubs(agent, {
+      connectedPeers: [],
+    });
+
+    await (agent as any).runImmediatePostApprovalSync('test-cg-missing-peer', CURATOR_PEER);
+
+    expect(calls.ensurePeerConnectedCalls).toEqual([CURATOR_PEER]);
+    expect(calls.runCatchupCalls).toHaveLength(0);
+    expect(calls.broadcastCalls).toHaveLength(1);
+    expect(calls.broadcastCalls[0]).toMatchObject({
+      cg: 'test-cg-missing-peer',
+      includeSwm: true,
+    });
+  }, 15000);
+
+  // 🔴 Regression for the Lex-on-PR-#517 / Codex catch-block finding.
+  // If `ensurePeerConnected` throws (relay flap, dial timeout, abort),
+  // the broadcast fallback MUST still run — wrapping curator-direct
+  // and broadcast in a single try/catch reintroduces the silent-stall
+  // bug this method was added to close.
+  it('falls back to broadcast when ensurePeerConnected throws (regression for catch-block bug)', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const calls = installStubs(agent, {
+      ensurePeerConnected: async () => {
+        throw new Error('Remote closed connection during opening');
+      },
+      connectedPeers: [CURATOR_PEER],
+    });
+
+    await (agent as any).runImmediatePostApprovalSync('test-cg-throw', CURATOR_PEER);
+
+    expect(calls.ensurePeerConnectedCalls).toEqual([CURATOR_PEER]);
+    expect(calls.runCatchupCalls).toHaveLength(0);
+    expect(calls.broadcastCalls).toHaveLength(1);
+    expect(calls.broadcastCalls[0]).toMatchObject({
+      cg: 'test-cg-throw',
+      includeSwm: true,
+    });
+  }, 15000);
+});

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -366,6 +366,55 @@ describe('listContextGraphs merge', () => {
     expect(entry!.callerInvolved).toBeUndefined();
   }, 15000);
 
+  // Regression for the "chatt-test takes ~107s to appear in the sidebar
+  // after curator approval" bug. A curated CG has no on-chain ID and no
+  // local content the moment we receive `join-approved` — until the first
+  // meta sync completes. Without `pendingMeta`, the case-2 phantom filter
+  // hides the entry entirely. With it, the entry surfaces with
+  // synced=false so the UI's existing "waiting for sync" badge fires
+  // immediately on approval.
+  it('includes curator-approved CGs with pendingMeta (no on-chain ID, no local content yet)', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    agent.subscribeToContextGraph('curator-only');
+    (agent as any).subscribedContextGraphs.set('curator-only', {
+      name: 'Curator Only',
+      subscribed: true,
+      synced: false,
+      pendingMeta: true,
+    } satisfies ContextGraphSub);
+
+    const contextGraphs = await agent.listContextGraphs();
+    const entry = contextGraphs.find(p => p.id === 'curator-only');
+    expect(entry).toBeDefined();
+    expect(entry!.subscribed).toBe(true);
+    expect(entry!.synced).toBe(false);
+    expect(entry!.name).toBe('Curator Only');
+    expect(entry!.onChainId).toBeUndefined();
+  }, 15000);
+
+  // Symmetric guard: a stale subscription with neither onChainId nor
+  // pendingMeta nor local content stays hidden as a phantom — the
+  // pendingMeta flag must not weaken the existing phantom filter for
+  // entries that don't actually have it set.
+  it('still hides phantom subscriptions (no onChainId, no pendingMeta, no local content)', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    agent.subscribeToContextGraph('phantom-cg');
+    (agent as any).subscribedContextGraphs.set('phantom-cg', {
+      name: 'Phantom',
+      subscribed: true,
+      synced: false,
+    } satisfies ContextGraphSub);
+
+    const contextGraphs = await agent.listContextGraphs();
+    expect(contextGraphs.find(p => p.id === 'phantom-cg')).toBeUndefined();
+  }, 15000);
+
   it('marks SPARQL-only contextGraphs (not in registry) as subscribed=false', async () => {
     const store = new OxigraphStore();
     const result = await createTestAgent({ store });


### PR DESCRIPTION
## Summary

When a curator approves a join request, the inviter's daemon receives a `join-approved` notification, marks the subscription, and is supposed to sync `_meta` immediately so the project shows up in the UI. In practice the project disappeared from the sidebar for **~2 minutes after approval** because two things conspired:

1. **Silent post-approval sync** — the join-approved handler called `syncContextGraphFromConnectedPeers(...).catch(() => {})`, which went through the regular peer-ranking heuristics and (in the freshly-approved-but-no-meta-yet window) often produced **zero** sync attempts because no other connected peer announced the CG yet. The next attempt only came from the periodic catchup reconciler ~2 minutes later. Failures were swallowed silently.

2. **`listContextGraphs` phantom filter** — for a curated CG with no on-chain ID and no local content yet, the case-2 fallback hid the entry as a "phantom subscription". So even though the SSE `join_approved` event correctly reached the UI within ~1s and triggered `loadCGs()`, the refreshed list came back without the new project. The entry only appeared when the periodic reconciler eventually pulled `_meta` ~107s later and emitted `project_synced`.

This PR fixes both ends.

## What changed

### `runImmediatePostApprovalSync(cgId, curatorPeerId)`
Targets the curator peer we just received the approval from directly, skipping the regular peer-ranking walk. Falls back to broadcast catchup if the curator-direct attempt yields zero successful peers, and logs every failure mode (no more silent swallow).

### `ContextGraphSub.pendingMeta`
Records "we just joined, expecting `_meta` shortly". Set in the join-approved handler, cleared by `refreshMetaSyncedFlags` when meta arrives. `listContextGraphs` surfaces these alongside chain-attested-but-not-synced CGs so the UI's existing "waiting for sync" badge fires within ~1s of approval. In-memory only — the periodic reconciler always recovers post-restart by populating `metaSynced` directly.

## Repro / verification

Real-world repro that prompted this PR:
- **23:31:42** — Miles sent a join-request for a curated CG; curator (Lex on \`dkg-testnet-edge\`) received and approved it, but the first \`notifyJoinApproval\` got dropped on a transient transport reset (curator-side one-shot delivery, separate bug).
- **23:53:17** — re-sent join-request → curator approved (idempotent) → Miles received \`join-approved\`, auto-subscribed, fired SSE.
- **23:53:17 → 23:55:04** — \`Skipping SWM sync for unauthorized or unconfirmed context graph .../chatt-test\` repeats every ~5–15s; **no meta-sync attempt**.
- **23:55:04** — periodic catchup reconciler fan-outs \`Syncing context graph .../chatt-test\` to **14 peers** at once; meta arrives; UI's next refresh shows the project. **107s gap.**

After this PR, expectation is:
- New \`Post-approval sync for "..." from curator <peerId-tail> fetched N data + M SWM triples\` log line within ~1s of join-approved.
- Project entry appears in PanelLeft sidebar in the same UI render that handles the SSE \`join_approved\` event (no \`project_synced\` round-trip needed for first paint).

## Tests

Two new regression tests in \`packages/agent/test/context-graph-discovery.test.ts > listContextGraphs merge\`:

- \`includes curator-approved CGs with pendingMeta (no on-chain ID, no local content yet)\` — pendingMeta CG must surface as \`subscribed: true, synced: false\`.
- \`still hides phantom subscriptions (no onChainId, no pendingMeta, no local content)\` — pendingMeta must not weaken the existing phantom filter.

Both pass; full \`listContextGraphs merge\` describe block stays green (8/8).

## Out of scope (follow-up)

The orthogonal \`notifyJoinApproval\`-is-one-shot bug on the curator side: the very first delivery attempt can be lost on a transient transport reset (\`Remote closed connection during opening\`), and there's no retry/redelivery queue. The invitee is then permanently stuck because they have no delegation yet to pass private-sync auth, so the "invitee re-subscribes will recover" comment in \`approveJoinRequest\` (~line 8733) doesn't actually work for the original-failure case. Filing as a separate issue.

## Test plan

- [x] \`pnpm --filter @origintrail-official/dkg-agent build\` — clean
- [x] \`pnpm run build:packages\` — clean (17/17)
- [x] \`vitest run test/context-graph-discovery.test.ts -t "listContextGraphs merge"\` — 8 passed, 20 skipped (chain-only)
- [ ] Manual: reproduce the 107s gap on \`main\`, confirm <2s on this branch using two paired DKG nodes.

---

Diagnosed jointly with **Lex** (Cursor agent on \`dkg-testnet-edge\`) over the Phase 1 agent-debug-chat channel — first cross-node-debug PR using \`dkg_send_message\` / \`dkg_check_inbox\` introduced in #510. 


Made with [Cursor](https://cursor.com)