### PR TITLE
Codex/axiom 4 trust upgrades

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -9,6 +9,7 @@
     "benchmark:sync-worker": "node scripts/sync-worker-benchmark.cjs",
     "benchmark:sync-worker-responsiveness": "node scripts/sync-worker-responsiveness-benchmark.cjs",
     "test": "vitest run",
+    "test:unit": "vitest run --config vitest.unit.config.ts",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -9349,8 +9349,8 @@ export class DKGAgent {
     targetUalOrRoot: string,
   ): Promise<string[]> {
     assertSafeIri(targetUalOrRoot);
-    const dataGraph = contextGraphDataGraphUri(contextGraphId);
-    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const dataGraph = assertSafeIri(contextGraphDataGraphUri(contextGraphId));
+    const metaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
     const target = `<${targetUalOrRoot}>`;
     const namespaces = ['http://dkg.io/ontology/', 'https://dkg.network/ontology#'];
     const existsPatterns = [
@@ -9403,13 +9403,14 @@ export class DKGAgent {
   }
 
   private async getSubjectsForRoots(graph: string, roots: Iterable<string>): Promise<string[]> {
+    const safeGraph = assertSafeIri(graph);
     const rootEntities = [...new Set([...roots].filter(Boolean))];
     if (rootEntities.length === 0) return [];
     const filterClauses = rootEntities
-      .map(e => `(STR(?s) = ${JSON.stringify(e)} || STRSTARTS(STR(?s), ${JSON.stringify(e + '/.well-known/genid/')}))`)
+      .map(e => `(STR(?s) = ${sparqlString(e)} || STRSTARTS(STR(?s), ${sparqlString(e + '/.well-known/genid/')}))`)
       .join(' || ');
     const result = await this.store.query(
-      `SELECT DISTINCT ?s WHERE { GRAPH <${graph}> { ?s ?p ?o . FILTER(${filterClauses}) } }`,
+      `SELECT DISTINCT ?s WHERE { GRAPH <${safeGraph}> { ?s ?p ?o . FILTER(${filterClauses}) } }`,
     );
     const subjects = new Set(rootEntities);
     if (result.type === 'bindings') {
@@ -9495,7 +9496,7 @@ export class DKGAgent {
     const ctx = createOperationContext('verify');
 
     // 1. Look up batch merkle root from local metadata (use typed literal for batchId)
-    const metaGraph = contextGraphMetaGraphUri(opts.contextGraphId);
+    const metaGraph = assertSafeIri(contextGraphMetaGraphUri(opts.contextGraphId));
     const dkgNamespaces = ['http://dkg.io/ontology/', 'https://dkg.network/ontology#'];
     // Try typed literal first, fallback to untyped for backward compat.
     let batchBindings: Record<string, string>[] | null = null;
@@ -9759,8 +9760,8 @@ export class DKGAgent {
       }
     }
 
-    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
+    const metaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
+    const contextGraphUri = assertSafeIri(`did:dkg:context-graph:${contextGraphId}`);
     const result = await this.store.query(
       `SELECT ?identityId WHERE {
         GRAPH <${metaGraph}> {
@@ -9799,20 +9800,20 @@ export class DKGAgent {
       this.log.warn(createOperationContext('verify'), `No root entities found for batch ${batchId} — skipping VM promotion`);
       return;
     }
-    const dataGraph = contextGraphDataGraphUri(contextGraphId);
+    const dataGraph = assertSafeIri(contextGraphDataGraphUri(contextGraphId));
     // Query root entities AND their skolemized children (subjects starting
     // with the root entity URI, e.g. <root>/.well-known/genid/...).
     // We use FILTER with STRSTARTS to capture the full closure instead of
     // an exact VALUES match, which would miss child/blank-node subjects.
     const filterClauses = rootEntities
-      .map(e => `(STR(?s) = ${JSON.stringify(e)} || STRSTARTS(STR(?s), ${JSON.stringify(e + '/.well-known/genid/')}))`)
+      .map(e => `(STR(?s) = ${sparqlString(e)} || STRSTARTS(STR(?s), ${sparqlString(e + '/.well-known/genid/')}))`)
       .join(' || ');
     const result = await this.store.query(
       `SELECT ?s ?p ?o WHERE { GRAPH <${dataGraph}> { ?s ?p ?o . FILTER(${filterClauses}) } }`,
     );
     if (result.type !== 'bindings') return;
 
-    const vmGraph = contextGraphVerifiedMemoryUri(contextGraphId, verifiedMemoryId);
+    const vmGraph = assertSafeIri(contextGraphVerifiedMemoryUri(contextGraphId, verifiedMemoryId));
     const vmQuads: Quad[] = (result.bindings as Record<string, string>[])
       .filter(row => !isTrustLevelQuad({ predicate: row.p }))
       .map(row => ({
@@ -9861,7 +9862,7 @@ export class DKGAgent {
   }
 
   private async getRootEntities(contextGraphId: string, batchId: bigint): Promise<string[]> {
-    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const metaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
     // Try typed literal first, fallback to untyped for backward compat
     for (const ns of ['http://dkg.io/ontology/', 'https://dkg.network/ontology#']) {
       for (const literal of [`"${batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, `"${batchId}"`]) {
@@ -9893,7 +9894,7 @@ export class DKGAgent {
     contextGraphId: string,
     batchId: bigint,
   ): Promise<{ hash: string; blockNumber: number } | null> {
-    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const metaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
     for (const ns of ['http://dkg.io/ontology/', 'https://dkg.network/ontology#']) {
       for (const literal of [`"${batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, `"${batchId}"`]) {
         const result = await this.store.query(

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1728,22 +1728,28 @@ export class DKGAgent {
         agentAddress: verifyWallet.address,
         getBatchMerkleRoot: async (cgId: string, batchId: bigint) => {
           const metaGraph = contextGraphMetaGraphUri(cgId);
-          // Try typed literal first, fallback to untyped for backward compat
-          for (const literal of [`"${batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, `"${batchId}"`]) {
-            const result = await this.store.query(
-              `SELECT ?root WHERE { GRAPH <${metaGraph}> { ?kc <https://dkg.network/ontology#merkleRoot> ?root . ?kc <https://dkg.network/ontology#batchId> ${literal} } } LIMIT 1`,
-            );
-            if (result.type === 'bindings' && result.bindings.length > 0) {
-              const hex = (result.bindings[0] as Record<string, string>)['root'];
-              if (!hex) return null;
-              return ethers.getBytes(hex.startsWith('"') ? hex.slice(1, -1) : hex);
+          const namespaces = ['http://dkg.io/ontology/', 'https://dkg.network/ontology#'];
+          // Try typed literal first, fallback to untyped for backward compat.
+          for (const ns of namespaces) {
+            for (const literal of [`"${batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, `"${batchId}"`]) {
+              const result = await this.store.query(
+                `SELECT ?root WHERE { GRAPH <${metaGraph}> { ?kc <${ns}merkleRoot> ?root . ?kc <${ns}batchId> ${literal} } } LIMIT 1`,
+              );
+              if (result.type === 'bindings' && result.bindings.length > 0) {
+                const hex = (result.bindings[0] as Record<string, string>)['root'];
+                if (!hex) return null;
+                const merkleRootValue = /^"([^"]+)"/.exec(hex)?.[1] ?? hex;
+                return ethers.getBytes(
+                  merkleRootValue.startsWith('0x') ? merkleRootValue : `0x${merkleRootValue}`,
+                );
+              }
             }
           }
           return null;
         },
         getContextGraphIdOnChain: async (cgId: string) => {
-          const sub = this.subscribedContextGraphs.get(cgId);
-          return sub?.onChainId ? BigInt(sub.onChainId) : null;
+          const onChainId = await this.getContextGraphOnChainId(cgId);
+          return onChainId ? BigInt(onChainId) : null;
         },
       });
       this.router.register(PROTOCOL_VERIFY_PROPOSAL, verifyHandler.handler);
@@ -9515,8 +9521,8 @@ export class DKGAgent {
     );
 
     // 2. Look up context graph on-chain config
-    const sub = this.subscribedContextGraphs.get(opts.contextGraphId);
-    const contextGraphIdOnChain = sub?.onChainId ? BigInt(sub.onChainId) : null;
+    const onChainId = await this.getContextGraphOnChainId(opts.contextGraphId);
+    const contextGraphIdOnChain = onChainId ? BigInt(onChainId) : null;
     if (!contextGraphIdOnChain) {
       throw new Error(`Context graph ${opts.contextGraphId} not found on-chain`);
     }
@@ -9607,10 +9613,10 @@ export class DKGAgent {
     }
     const participantResolvedRemoteAddresses: string[] = [];
     for (const a of result.approvals) {
-      let id = a.identityId;
-      if ((!id || id === 0n) && typeof (this.chain as any).getIdentityIdForAddress === 'function') {
-        try { id = await (this.chain as any).getIdentityIdForAddress(a.approverAddress); } catch { /* use 0n */ }
-      }
+      let id = a.identityId || await this.resolveVerifyApprovalIdentityId(
+        a.approverAddress,
+        participantIdentityIds,
+      );
       if (!id || id === 0n) continue;
       if (!isEligibleParticipant(id)) continue;
       resolvedSignatures.push({ identityId: id, r: a.signatureR, vs: a.signatureVS });
@@ -9647,16 +9653,32 @@ export class DKGAgent {
 
     // 7. Submit on-chain only after quorum. Partial writes above are
     // metadata-only and deliberately do not claim a transaction hash.
-    if (typeof this.chain.verify !== 'function') {
-      throw new Error('Chain adapter does not support verify');
+    let txResult: { hash: string; blockNumber: number };
+    const existingContextGraphId = typeof this.chain.getKCContextGraphId === 'function'
+      ? await this.chain.getKCContextGraphId(opts.batchId).catch(() => 0n)
+      : 0n;
+    if (existingContextGraphId === contextGraphIdOnChain) {
+      const provenance = await this.getBatchChainProvenance(opts.contextGraphId, opts.batchId);
+      if (!provenance) {
+        throw new Error(`Batch ${opts.batchId} is already registered on-chain but local chain provenance is missing`);
+      }
+      txResult = provenance;
+      this.log.info(
+        ctx,
+        `Verify batch ${opts.batchId} already registered on-chain for context graph ${contextGraphIdOnChain}; ` +
+          `using publish tx ${txResult.hash.slice(0, 16)}... for ConsensusVerified metadata`,
+      );
+    } else {
+      if (typeof this.chain.verify !== 'function') {
+        throw new Error('Chain adapter does not support verify');
+      }
+      txResult = await this.chain.verify({
+        contextGraphId: contextGraphIdOnChain,
+        batchId: opts.batchId,
+        merkleRoot,
+        signerSignatures: resolvedSignatures,
+      });
     }
-
-    const txResult = await this.chain.verify({
-      contextGraphId: contextGraphIdOnChain,
-      batchId: opts.batchId,
-      merkleRoot,
-      signerSignatures: resolvedSignatures,
-    });
 
     // 8. Promote triples to Verified Memory (only include signers actually sent on-chain)
     await this.promoteToVerifiedMemory(
@@ -9678,6 +9700,45 @@ export class DKGAgent {
       status: 'verified',
       trustLevel: TrustLevel.ConsensusVerified,
     };
+  }
+
+  private async resolveVerifyApprovalIdentityId(
+    approverAddress: string,
+    participantIdentityIds: Set<bigint> | null,
+  ): Promise<bigint> {
+    if (typeof (this.chain as any).getIdentityIdForAddress === 'function') {
+      try {
+        const id = await (this.chain as any).getIdentityIdForAddress(approverAddress);
+        if (id && id !== 0n) return BigInt(id);
+      } catch {
+        // Fall through to participant-set probing below.
+      }
+    }
+
+    if (participantIdentityIds === null || participantIdentityIds.size === 0) return 0n;
+    if (typeof this.chain.verifyACKIdentity === 'function') {
+      for (const candidateIdentityId of participantIdentityIds) {
+        try {
+          if (await this.chain.verifyACKIdentity.call(this.chain, approverAddress, candidateIdentityId)) {
+            return candidateIdentityId;
+          }
+        } catch {
+          // Ignore individual lookup failures; another participant may still match.
+        }
+      }
+    }
+
+    if (typeof this.chain.isOperationalWalletRegistered !== 'function') return 0n;
+    for (const candidateIdentityId of participantIdentityIds) {
+      try {
+        if (await this.chain.isOperationalWalletRegistered.call(this.chain, candidateIdentityId, approverAddress)) {
+          return candidateIdentityId;
+        }
+      } catch {
+        // Ignore individual lookup failures; another participant may still match.
+      }
+    }
+    return 0n;
   }
 
   private async getVerifyParticipantIdentityIds(
@@ -9826,6 +9887,37 @@ export class DKGAgent {
       }
     }
     return [];
+  }
+
+  private async getBatchChainProvenance(
+    contextGraphId: string,
+    batchId: bigint,
+  ): Promise<{ hash: string; blockNumber: number } | null> {
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    for (const ns of ['http://dkg.io/ontology/', 'https://dkg.network/ontology#']) {
+      for (const literal of [`"${batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, `"${batchId}"`]) {
+        const result = await this.store.query(
+          `SELECT ?tx ?block WHERE {
+            GRAPH <${metaGraph}> {
+              ?kc <${ns}batchId> ${literal} .
+              ?kc <${ns}transactionHash> ?tx .
+              OPTIONAL { ?kc <${ns}blockNumber> ?block }
+            }
+          } LIMIT 1`,
+        );
+        if (result.type !== 'bindings' || result.bindings.length === 0) continue;
+        const row = result.bindings[0] as Record<string, string>;
+        const hash = /^"([^"]+)"/.exec(row.tx ?? '')?.[1] ?? row.tx;
+        if (!hash) continue;
+        const rawBlock = /^"([^"]+)"/.exec(row.block ?? '')?.[1] ?? row.block;
+        const blockNumber = rawBlock ? Number(rawBlock) : 0;
+        return {
+          hash,
+          blockNumber: Number.isFinite(blockNumber) ? blockNumber : 0,
+        };
+      }
+    }
+    return null;
   }
 
   // ── CCL ──────────────────────────────────────────────────────────────

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -9590,7 +9590,7 @@ export class DKGAgent {
       entities,
       proposerSignature: { r: ethers.getBytes(proposerSig.r), vs: ethers.getBytes(proposerSig.yParityAndS) },
       requiredSignatures,
-      timeoutMs: opts.timeoutMs ?? 30 * 60 * 1000, // 30 min default
+      timeoutMs: opts.timeoutMs ?? 30 * 60 * 1000, // 30 min default; VerifyCollector also enforces this as its max.
       allowPartial: true,
     });
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -19,8 +19,11 @@ import {
   GOSSIP_TYPE_WORKSPACE_PUBLISH,
   encodeFinalizationMessage, type FinalizationMessageMsg,
   getGenesisQuads, computeNetworkId, SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY,
-  Logger, createOperationContext, sparqlString, escapeSparqlLiteral, isSafeIri,
+  Logger, createOperationContext, sparqlString, escapeSparqlLiteral, isSafeIri, assertSafeIri,
   TrustLevel,
+  TRUST_LEVEL_PREDICATE,
+  buildTrustLevelQuads,
+  isTrustLevelQuad,
   buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, type AuthorAttestationTypedData,
   buildAssertionSealQuads, buildAssertionPublishReceiptQuads,
   parseAssertionSealQuads, type AssertionSeal,
@@ -5626,7 +5629,7 @@ export class DKGAgent {
     //     the post-strip set or it commits to a root the publish path
     //     can never recompute. (Round 4 review §8 — "assertionFinalize
     //     hashes WM-only urn:dkg:file: rows".)
-    const quads = rawQuads.filter((q) => !isReservedSubject(q.subject));
+    const quads = rawQuads.filter((q) => !isReservedSubject(q.subject) && !isTrustLevelQuad(q));
     if (quads.length === 0) {
       throw new Error(
         `Cannot finalize assertion <${assertionUri}>: every quad has a ` +
@@ -6635,14 +6638,9 @@ export class DKGAgent {
        */
       callerAgentAddress?: string;
       /**
-       * Minimum trust level for the verified-memory view (spec §14, P-13).
-       * When set to `TrustLevel.Endorsed`, the root content graph is
-       * excluded from resolution so only quorum-verified sub-graphs survive.
-       * Values above `Endorsed` (`PartiallyVerified`, `ConsensusVerified`)
-       * are currently rejected — see `QueryOptions.minTrust` in
-       * `packages/query/src/query-engine.ts` for the full rationale and
-       * the Q-1 gap tracking per-graph trust tagging.
-       * Ignored for views other than `verified-memory`.
+       * Minimum trust level for the verified-memory view (spec §14).
+       * Values above `SelfAttested` require explicit writer-side
+       * `dkg:trustLevel` metadata. Ignored for other views.
        */
       minTrust?: TrustLevel;
       /**
@@ -9340,6 +9338,82 @@ export class DKGAgent {
     this.log.info(ctx, `Ensured context graph "${opts.id}" locally (${opts.curated ? 'curated' : 'open'})`);
   }
 
+  private async resolveEndorsementTrustTargets(
+    contextGraphId: string,
+    targetUalOrRoot: string,
+  ): Promise<string[]> {
+    assertSafeIri(targetUalOrRoot);
+    const dataGraph = contextGraphDataGraphUri(contextGraphId);
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const target = `<${targetUalOrRoot}>`;
+    const namespaces = ['http://dkg.io/ontology/', 'https://dkg.network/ontology#'];
+    const existsPatterns = [
+      `GRAPH <${dataGraph}> { ${target} ?p ?o } BIND(${target} AS ?hit)`,
+      `GRAPH <${metaGraph}> { ${target} ?p ?o } BIND(${target} AS ?hit)`,
+      ...namespaces.flatMap((ns) => [
+        `GRAPH <${metaGraph}> { ?ka <${ns}rootEntity> ${target} } BIND(${target} AS ?hit)`,
+        `GRAPH <${metaGraph}> { ?ka <${ns}partOf> ${target} } BIND(?ka AS ?hit)`,
+      ]),
+    ];
+
+    const exists = await this.store.query(
+      `SELECT ?hit WHERE { ${existsPatterns.map((p) => `{ ${p} }`).join(' UNION ')} } LIMIT 1`,
+    );
+    if (exists.type !== 'bindings' || exists.bindings.length === 0) {
+      throw new Error(
+        `Endorsement target ${targetUalOrRoot} was not found in context graph ${contextGraphId}`,
+      );
+    }
+
+    const rootPatterns = namespaces.flatMap((ns) => [
+      `GRAPH <${metaGraph}> { ${target} <${ns}rootEntity> ?root . }`,
+      `GRAPH <${metaGraph}> { ?ka <${ns}partOf> ${target} ; <${ns}rootEntity> ?root . }`,
+    ]);
+    const roots = await this.store.query(
+      `SELECT DISTINCT ?root WHERE { ${rootPatterns.map((p) => `{ ${p} }`).join(' UNION ')} }`,
+    );
+    const rootEntities = roots.type === 'bindings'
+      ? (roots.bindings as Record<string, string>[]).map((row) => row.root).filter(Boolean)
+      : [];
+    return rootEntities.length > 0 ? rootEntities : [targetUalOrRoot];
+  }
+
+  private async stampTrustLevel(
+    graph: string,
+    subjects: Iterable<string>,
+    level: TrustLevel,
+  ): Promise<void> {
+    const quads = buildTrustLevelQuads(subjects, level, graph) as Quad[];
+    for (const quad of quads) {
+      await this.store.deleteByPattern({
+        graph: quad.graph,
+        subject: quad.subject,
+        predicate: TRUST_LEVEL_PREDICATE,
+      });
+    }
+    if (quads.length > 0) {
+      await this.store.insert(quads);
+    }
+  }
+
+  private async getSubjectsForRoots(graph: string, roots: Iterable<string>): Promise<string[]> {
+    const rootEntities = [...new Set([...roots].filter(Boolean))];
+    if (rootEntities.length === 0) return [];
+    const filterClauses = rootEntities
+      .map(e => `(STR(?s) = ${JSON.stringify(e)} || STRSTARTS(STR(?s), ${JSON.stringify(e + '/.well-known/genid/')}))`)
+      .join(' || ');
+    const result = await this.store.query(
+      `SELECT DISTINCT ?s WHERE { GRAPH <${graph}> { ?s ?p ?o . FILTER(${filterClauses}) } }`,
+    );
+    const subjects = new Set(rootEntities);
+    if (result.type === 'bindings') {
+      for (const row of result.bindings as Record<string, string>[]) {
+        if (row.s) subjects.add(row.s);
+      }
+    }
+    return [...subjects];
+  }
+
   // ── ENDORSE ─���────────────────────────────────────────────────────────
 
   /**
@@ -9371,12 +9445,25 @@ export class DKGAgent {
     // bearer token; see packages/cli/src/daemon.ts.
     const raw = opts.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
     const endorser = canonicalAgentDidSubject(raw);
+    const trustTargets = await this.resolveEndorsementTrustTargets(
+      opts.contextGraphId,
+      opts.knowledgeAssetUal,
+    );
     const quads = buildEndorsementQuads(
       endorser,
       opts.knowledgeAssetUal,
       opts.contextGraphId,
     );
-    return this.publish(opts.contextGraphId, quads);
+    const result = await this.publish(opts.contextGraphId, quads);
+    if (result.status === 'confirmed') {
+      const dataGraph = contextGraphDataGraphUri(opts.contextGraphId);
+      await this.stampTrustLevel(
+        dataGraph,
+        await this.getSubjectsForRoots(dataGraph, trustTargets),
+        TrustLevel.Endorsed,
+      );
+    }
+    return result;
   }
 
   // ── VERIFY ────────────────────────────────────────────────────────
@@ -9392,31 +9479,40 @@ export class DKGAgent {
     requiredSignatures?: number;
     timeoutMs?: number;
   }): Promise<{
-    txHash: string;
-    blockNumber: number;
+    txHash?: string;
+    blockNumber?: number;
     verifiedMemoryId: string;
     signers: string[];
+    status: 'verified' | 'partial' | 'no_quorum';
+    trustLevel: TrustLevel;
   }> {
     const ctx = createOperationContext('verify');
 
     // 1. Look up batch merkle root from local metadata (use typed literal for batchId)
     const metaGraph = contextGraphMetaGraphUri(opts.contextGraphId);
-    // Try typed literal first, fallback to untyped for backward compat
+    const dkgNamespaces = ['http://dkg.io/ontology/', 'https://dkg.network/ontology#'];
+    // Try typed literal first, fallback to untyped for backward compat.
     let batchBindings: Record<string, string>[] | null = null;
-    for (const literal of [`"${opts.batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, `"${opts.batchId}"`]) {
-      const r = await this.store.query(
-        `SELECT ?root WHERE { GRAPH <${metaGraph}> { ?kc <https://dkg.network/ontology#merkleRoot> ?root . ?kc <https://dkg.network/ontology#batchId> ${literal} } } LIMIT 1`,
-      );
-      if (r.type === 'bindings' && r.bindings.length > 0) {
-        batchBindings = r.bindings as Record<string, string>[];
-        break;
+    for (const ns of dkgNamespaces) {
+      for (const literal of [`"${opts.batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, `"${opts.batchId}"`]) {
+        const r = await this.store.query(
+          `SELECT ?root WHERE { GRAPH <${metaGraph}> { ?kc <${ns}merkleRoot> ?root . ?kc <${ns}batchId> ${literal} } } LIMIT 1`,
+        );
+        if (r.type === 'bindings' && r.bindings.length > 0) {
+          batchBindings = r.bindings as Record<string, string>[];
+          break;
+        }
       }
+      if (batchBindings) break;
     }
     if (!batchBindings) {
       throw new Error(`Batch ${opts.batchId} not found in context graph ${opts.contextGraphId}`);
     }
     const rootHex = batchBindings[0]['root'];
-    const merkleRoot = ethers.getBytes(rootHex.startsWith('"') ? rootHex.slice(1, -1) : rootHex);
+    const merkleRootValue = /^"([^"]+)"/.exec(rootHex)?.[1] ?? rootHex;
+    const merkleRoot = ethers.getBytes(
+      merkleRootValue.startsWith('0x') ? merkleRootValue : `0x${merkleRootValue}`,
+    );
 
     // 2. Look up context graph on-chain config
     const sub = this.subscribedContextGraphs.get(opts.contextGraphId);
@@ -9488,33 +9584,71 @@ export class DKGAgent {
       proposerSignature: { r: ethers.getBytes(proposerSig.r), vs: ethers.getBytes(proposerSig.yParityAndS) },
       requiredSignatures,
       timeoutMs: opts.timeoutMs ?? 30 * 60 * 1000, // 30 min default
+      allowPartial: true,
     });
 
-    // 6. Submit on-chain
-    if (typeof this.chain.verify !== 'function') {
-      throw new Error('Chain adapter does not support verify');
-    }
-
     // 6. Resolve identity IDs for each approver before on-chain submission.
-    const resolvedSignatures: Array<{ identityId: bigint; r: Uint8Array; vs: Uint8Array }> = [
-      {
+    const participantIdentityIds = await this.getVerifyParticipantIdentityIds(
+      opts.contextGraphId,
+      contextGraphIdOnChain,
+    );
+    const isEligibleParticipant = (identityId: bigint): boolean =>
+      participantIdentityIds === null || participantIdentityIds.has(identityId);
+
+    const resolvedSignatures: Array<{ identityId: bigint; r: Uint8Array; vs: Uint8Array }> = [];
+    const resolvedSignerAddresses: string[] = [];
+    if (this.identityId > 0n && isEligibleParticipant(this.identityId)) {
+      resolvedSignatures.push({
         identityId: this.identityId,
         r: ethers.getBytes(proposerSig.r),
         vs: ethers.getBytes(proposerSig.yParityAndS),
-      },
-    ];
-    const resolvedSignerAddresses: string[] = [proposerAddress];
+      });
+      resolvedSignerAddresses.push(proposerAddress);
+    }
+    const participantResolvedRemoteAddresses: string[] = [];
     for (const a of result.approvals) {
       let id = a.identityId;
       if ((!id || id === 0n) && typeof (this.chain as any).getIdentityIdForAddress === 'function') {
         try { id = await (this.chain as any).getIdentityIdForAddress(a.approverAddress); } catch { /* use 0n */ }
       }
       if (!id || id === 0n) continue;
+      if (!isEligibleParticipant(id)) continue;
       resolvedSignatures.push({ identityId: id, r: a.signatureR, vs: a.signatureVS });
       resolvedSignerAddresses.push(a.approverAddress);
+      if (participantIdentityIds !== null && participantIdentityIds.has(id)) {
+        participantResolvedRemoteAddresses.push(a.approverAddress);
+      }
     }
-    if (resolvedSignatures.length < requiredSignatures) {
-      throw new Error(`verify_identity_resolution: only ${resolvedSignatures.length}/${requiredSignatures} signers have resolvable identities (including proposer)`);
+    if (!result.quorumReached || resolvedSignatures.length < requiredSignatures) {
+      const trustLevel = participantResolvedRemoteAddresses.length > 0
+        ? TrustLevel.PartiallyVerified
+        : TrustLevel.SelfAttested;
+      const status = participantResolvedRemoteAddresses.length > 0 ? 'partial' : 'no_quorum';
+      await this.stampBatchTrustLevel(
+        opts.contextGraphId,
+        opts.batchId,
+        contextGraphDataGraphUri(opts.contextGraphId),
+        trustLevel,
+      );
+      this.log.info(
+        ctx,
+        `Verify batch ${opts.batchId} did not reach quorum ` +
+          `(${resolvedSignatures.length}/${requiredSignatures} identity-resolved signers, ` +
+          `${participantResolvedRemoteAddresses.length}/${result.requiredRemoteApprovals} participant remote approvals) — ` +
+          `stamped trustLevel=${trustLevel} without chain tx`,
+      );
+      return {
+        verifiedMemoryId: opts.verifiedMemoryId,
+        signers: resolvedSignerAddresses,
+        status,
+        trustLevel,
+      };
+    }
+
+    // 7. Submit on-chain only after quorum. Partial writes above are
+    // metadata-only and deliberately do not claim a transaction hash.
+    if (typeof this.chain.verify !== 'function') {
+      throw new Error('Chain adapter does not support verify');
     }
 
     const txResult = await this.chain.verify({
@@ -9524,7 +9658,7 @@ export class DKGAgent {
       signerSignatures: resolvedSignatures,
     });
 
-    // 7. Promote triples to Verified Memory (only include signers actually sent on-chain)
+    // 8. Promote triples to Verified Memory (only include signers actually sent on-chain)
     await this.promoteToVerifiedMemory(
       opts.contextGraphId,
       opts.verifiedMemoryId,
@@ -9541,7 +9675,53 @@ export class DKGAgent {
       blockNumber: txResult.blockNumber,
       verifiedMemoryId: opts.verifiedMemoryId,
       signers: resolvedSignerAddresses,
+      status: 'verified',
+      trustLevel: TrustLevel.ConsensusVerified,
     };
+  }
+
+  private async getVerifyParticipantIdentityIds(
+    contextGraphId: string,
+    contextGraphIdOnChain: bigint,
+  ): Promise<Set<bigint> | null> {
+    if (typeof this.chain.getContextGraphParticipants === 'function') {
+      try {
+        const participants = await this.chain.getContextGraphParticipants(contextGraphIdOnChain);
+        if (participants && participants.length > 0) {
+          return new Set(participants);
+        }
+      } catch (err) {
+        this.log.warn(
+          createOperationContext('verify'),
+          `Could not resolve on-chain participants for context graph ${contextGraphIdOnChain}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
+    const result = await this.store.query(
+      `SELECT ?identityId WHERE {
+        GRAPH <${metaGraph}> {
+          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID}> ?identityId
+        }
+      }`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) {
+      return null;
+    }
+    const ids = new Set<bigint>();
+    for (const row of result.bindings as Record<string, string>[]) {
+      const raw = row.identityId?.replace(/^"|"$/g, '');
+      if (!raw) continue;
+      try {
+        const parsed = BigInt(raw);
+        if (parsed > 0n) ids.add(parsed);
+      } catch {
+        // Ignore malformed local metadata; it is not usable for trust elevation.
+      }
+    }
+    return ids.size > 0 ? ids : null;
   }
 
   private async promoteToVerifiedMemory(
@@ -9572,15 +9752,22 @@ export class DKGAgent {
     if (result.type !== 'bindings') return;
 
     const vmGraph = contextGraphVerifiedMemoryUri(contextGraphId, verifiedMemoryId);
-    const vmQuads: Quad[] = (result.bindings as Record<string, string>[]).map(row => ({
-      subject: row['s'],
-      predicate: row['p'],
-      object: row['o'],
-      graph: vmGraph,
-    }));
+    const vmQuads: Quad[] = (result.bindings as Record<string, string>[])
+      .filter(row => !isTrustLevelQuad({ predicate: row.p }))
+      .map(row => ({
+        subject: row['s'],
+        predicate: row['p'],
+        object: row['o'],
+        graph: vmGraph,
+      }));
     if (vmQuads.length > 0) {
       await this.store.insert(vmQuads);
     }
+    await this.stampTrustLevel(
+      vmGraph,
+      [...new Set(vmQuads.map((q) => q.subject))],
+      TrustLevel.ConsensusVerified,
+    );
 
     // Write verification metadata
     const vmMetaGraph = contextGraphVerifiedMemoryMetaUri(contextGraphId, verifiedMemoryId);
@@ -9597,15 +9784,45 @@ export class DKGAgent {
     await this.store.insert(metaQuads);
   }
 
+  private async stampBatchTrustLevel(
+    contextGraphId: string,
+    batchId: bigint,
+    graph: string,
+    level: TrustLevel,
+  ): Promise<void> {
+    const subjects = await this.getBatchSubjects(contextGraphId, batchId);
+    await this.stampTrustLevel(graph, subjects, level);
+  }
+
+  private async getBatchSubjects(contextGraphId: string, batchId: bigint): Promise<string[]> {
+    const rootEntities = await this.getRootEntities(contextGraphId, batchId);
+    return this.getSubjectsForRoots(contextGraphDataGraphUri(contextGraphId), rootEntities);
+  }
+
   private async getRootEntities(contextGraphId: string, batchId: bigint): Promise<string[]> {
     const metaGraph = contextGraphMetaGraphUri(contextGraphId);
     // Try typed literal first, fallback to untyped for backward compat
-    for (const literal of [`"${batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, `"${batchId}"`]) {
-      const result = await this.store.query(
-        `SELECT ?entity WHERE { GRAPH <${metaGraph}> { ?ka <https://dkg.network/ontology#rootEntity> ?entity . ?ka <https://dkg.network/ontology#batchId> ${literal} } }`,
-      );
-      if (result.type === 'bindings' && result.bindings.length > 0) {
-        return (result.bindings as Record<string, string>[]).map(r => r['entity']).filter(Boolean);
+    for (const ns of ['http://dkg.io/ontology/', 'https://dkg.network/ontology#']) {
+      for (const literal of [`"${batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, `"${batchId}"`]) {
+        const result = await this.store.query(
+          `SELECT ?entity WHERE {
+            GRAPH <${metaGraph}> {
+              {
+                ?ka <${ns}rootEntity> ?entity .
+                ?ka <${ns}batchId> ${literal} .
+              }
+              UNION
+              {
+                ?ka <${ns}rootEntity> ?entity ;
+                    <${ns}partOf> ?kc .
+                ?kc <${ns}batchId> ${literal} .
+              }
+            }
+          }`,
+        );
+        if (result.type === 'bindings' && result.bindings.length > 0) {
+          return (result.bindings as Record<string, string>[]).map(r => r['entity']).filter(Boolean);
+        }
       }
     }
     return [];

--- a/packages/agent/src/endorse.ts
+++ b/packages/agent/src/endorse.ts
@@ -1,4 +1,4 @@
-import { contextGraphDataUri, DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import { assertSafeIri, contextGraphDataUri, DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 
 /** Ontology predicate: agent endorses a Knowledge Asset */
@@ -22,6 +22,9 @@ export function buildEndorsementQuads(
   const agentUri = `did:dkg:agent:${agentAddress}`;
   const graph = contextGraphDataUri(contextGraphId);
   const now = new Date().toISOString();
+  assertSafeIri(agentUri);
+  assertSafeIri(knowledgeAssetUal);
+  assertSafeIri(graph);
 
   return [
     {

--- a/packages/agent/test/e2e-dht-dial.test.ts
+++ b/packages/agent/test/e2e-dht-dial.test.ts
@@ -20,9 +20,27 @@
  */
 import { describe, it, expect, afterAll } from 'vitest';
 import { DKGAgent } from '../src/index.js';
-import { createEVMAdapter, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 
 function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)); }
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5_000,
+  intervalMs = 50,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(intervalMs);
+  }
+  throw new Error('Timed out waiting for peer connection state');
+}
+
+function isConnectedTo(agent: DKGAgent, peerId: string): boolean {
+  return agent.node.libp2p.getConnections().some(
+    (c: any) => c.remotePeer.toString() === peerId,
+  );
+}
 
 describe('DHT-resolved peer dial (V10 invite redemption)', () => {
   let nodeA: DKGAgent | null = null;
@@ -39,15 +57,15 @@ describe('DHT-resolved peer dial (V10 invite redemption)', () => {
       name: 'CuratorA',
       framework: 'DKG',
       listenPort: 0,
+      listenHost: '127.0.0.1',
       skills: [],
-      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
     });
     nodeB = await DKGAgent.create({
       name: 'JoinerB',
       framework: 'DKG',
       listenPort: 0,
+      listenHost: '127.0.0.1',
       skills: [],
-      chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC1_OP),
     });
     await nodeA.start();
     await nodeB.start();
@@ -68,17 +86,11 @@ describe('DHT-resolved peer dial (V10 invite redemption)', () => {
     // Disconnect, then redial via peer id only — the peer's addresses
     // must be resolved via peerRouting (peerStore-cached) without the
     // caller passing a multiaddr.
-    for (const conn of nodeB.node.libp2p.getConnections()) {
-      try { await conn.close(); } catch { /* best-effort */ }
-    }
-    await sleep(200);
+    await nodeB.node.libp2p.hangUp(nodeA.node.libp2p.peerId);
+    await waitFor(() => !isConnectedTo(nodeB!, nodeA!.peerId));
 
     await nodeB.connectToPeerId(nodeA.peerId);
-
-    const reconnected = nodeB.node.libp2p.getConnections().some(
-      (c: any) => c.remotePeer.toString() === nodeA!.peerId,
-    );
-    expect(reconnected).toBe(true);
+    await waitFor(() => isConnectedTo(nodeB!, nodeA!.peerId));
   }, 30000);
 
   it('throws INVALID_PEER_ID for malformed input', async () => {

--- a/packages/agent/test/endorse.test.ts
+++ b/packages/agent/test/endorse.test.ts
@@ -33,4 +33,14 @@ describe('buildEndorsementQuads', () => {
     const quads = buildEndorsementQuads('0x1', 'ual:1', 'my-project');
     expect(quads[0].graph).toBe('did:dkg:context-graph:my-project');
   });
+
+  it('rejects unsafe RDF terms before building endorsement quads', () => {
+    expect(() =>
+      buildEndorsementQuads('0x1', 'did:dkg:asset:1> } INSERT DATA { ?s ?p ?o } #', 'my-project'),
+    ).toThrow(/Unsafe or empty IRI value/);
+
+    expect(() =>
+      buildEndorsementQuads('0x1', 'did:dkg:asset:1', 'bad>graph'),
+    ).toThrow(/Unsafe or empty IRI value/);
+  });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [
+      'test/endorse.test.ts',
+      'test/query-min-trust-alias.test.ts',
+    ],
+    testTimeout: 60_000,
+    maxWorkers: 1,
+  },
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: [
       'test/endorse.test.ts',
+      'test/e2e-dht-dial.test.ts',
       'test/query-min-trust-alias.test.ts',
     ],
     testTimeout: 60_000,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
     "postinstall": "node ./scripts/bundle-markitdown-binaries.mjs --quiet --current-platform --best-effort",
     "markitdown:build": "node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform",
     "test": "vitest run",
+    "test:unit": "vitest run --config vitest.unit.config.ts",
     "test:benchmark:publish-async-get": "vitest run --config vitest.benchmark.config.ts",
     "test:coverage": "vitest run --coverage",
     "clean": "node -e \"const fs=require('fs');for(const d of['dist','network']){fs.rmSync(d,{recursive:true,force:true})};fs.rmSync('tsconfig.tsbuildinfo',{force:true})\""

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -679,12 +679,15 @@ export class ApiClient {
       assertionName?: string;
       subGraphName?: string;
       verifiedGraph?: string;
-      /**
-       * P-13: implementable tiers are `SelfAttested` (0) and `Endorsed`
-       * (1) only. `PartiallyVerified` / `ConsensusVerified` fail fast
-       * with a 400 at the daemon until Q-1 lands.
-       */
-      minTrust?: 'SelfAttested' | 'Endorsed' | 0 | 1;
+      minTrust?:
+        | 'SelfAttested'
+        | 'Endorsed'
+        | 'PartiallyVerified'
+        | 'ConsensusVerified'
+        | 0
+        | 1
+        | 2
+        | 3;
     },
   ): Promise<{ result: QueryResult }> {
     return this.post('/api/query', {
@@ -1125,7 +1128,14 @@ export class ApiClient {
     batchId: string;
     timeoutMs?: number;
     requiredSignatures?: number;
-  }): Promise<{ txHash: string; blockNumber: number; verifiedMemoryId: string; signers: string[] }> {
+  }): Promise<{
+    txHash?: string;
+    blockNumber?: number;
+    verifiedMemoryId: string;
+    signers: string[];
+    status?: 'verified' | 'partial' | 'no_quorum';
+    trustLevel?: number;
+  }> {
     return this.post('/api/verify', request);
   }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -66,6 +66,8 @@ import { registerIntegrationCommands } from './integrations/commands.js';
 
 /** Commander action callbacks receive parsed .option() values with loose types. */
 type ActionOpts = Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+const VERIFY_COLLECTION_TIMEOUT_MIN_MS = 1_000;
+const VERIFY_COLLECTION_TIMEOUT_MAX_MS = 30 * 60 * 1000;
 
 const STARTUP_BANNER = `
 \x1b[36m██████╗ ██╗  ██╗ ██████╗     ██╗   ██╗ ██╗ ██████╗
@@ -100,6 +102,26 @@ function getCliVersion(): string {
   } catch {
     return '0.0.0';
   }
+}
+
+function parseOptionalVerifyTimeoutOption(raw: unknown): number | undefined {
+  if (raw === undefined || raw === null || raw === '') return undefined;
+  const value = typeof raw === 'number'
+    ? raw
+    : typeof raw === 'string' && /^\d+$/.test(raw.trim())
+      ? Number(raw.trim())
+      : NaN;
+  if (
+    !Number.isSafeInteger(value) ||
+    value < VERIFY_COLLECTION_TIMEOUT_MIN_MS ||
+    value > VERIFY_COLLECTION_TIMEOUT_MAX_MS
+  ) {
+    throw new Error(
+      `--timeout must be an integer between ${VERIFY_COLLECTION_TIMEOUT_MIN_MS} ` +
+        `and ${VERIFY_COLLECTION_TIMEOUT_MAX_MS} milliseconds`,
+    );
+  }
+  return value;
 }
 
 function loadStructuredFile(filePath: string): any {
@@ -933,16 +955,17 @@ program
   .description('Propose M-of-N verification for a published batch')
   .requiredOption('--context-graph <id>', 'Context Graph ID')
   .requiredOption('--verified-graph <id>', 'Verified Graph ID')
-  .option('--timeout <ms>', 'Timeout in milliseconds (default: 30 min)')
+  .option('--timeout <ms>', `Timeout in milliseconds (default/max: ${VERIFY_COLLECTION_TIMEOUT_MAX_MS})`)
   .option('--required-signatures <n>', 'M-of-N quorum threshold (default: on-chain config, or 1 if adapter lacks getContextGraphConfig)')
   .action(async (batchId: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();
+      const timeoutMs = parseOptionalVerifyTimeoutOption(opts.timeout);
       const result = await client.verify({
         contextGraphId: opts.contextGraph,
         verifiedMemoryId: opts.verifiedGraph,
         batchId,
-        timeoutMs: opts.timeout ? Number(opts.timeout) : undefined,
+        timeoutMs,
         requiredSignatures: opts.requiredSignatures ? Number(opts.requiredSignatures) : undefined,
       });
       if (result.status === 'verified' || result.txHash) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -945,9 +945,17 @@ program
         timeoutMs: opts.timeout ? Number(opts.timeout) : undefined,
         requiredSignatures: opts.requiredSignatures ? Number(opts.requiredSignatures) : undefined,
       });
-      console.log(`Verified batch ${batchId} → _verified_memory/${result.verifiedMemoryId}`);
-      console.log(`  TX: ${result.txHash}`);
-      console.log(`  Block: ${result.blockNumber}`);
+      if (result.status === 'verified' || result.txHash) {
+        console.log(`Verified batch ${batchId} → _verified_memory/${result.verifiedMemoryId}`);
+        console.log(`  TX: ${result.txHash}`);
+        console.log(`  Block: ${result.blockNumber}`);
+      } else if (result.status === 'partial') {
+        console.log(`Partially verified batch ${batchId} (no chain tx)`);
+        console.log(`  Trust: ${result.trustLevel}`);
+      } else {
+        console.log(`Verification did not reach quorum for batch ${batchId} (no chain tx)`);
+        console.log(`  Trust: ${result.trustLevel ?? 'self-attested'}`);
+      }
       console.log(`  Signers: ${result.signers.join(', ')}`);
     } catch (err) {
       console.error(`Verify failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -852,11 +852,6 @@ WHERE {
       let resolvedPublishContextGraphId: string | null = null;
       if (publishContextGraphId != null) {
         resolvedPublishContextGraphId = String(publishContextGraphId);
-      } else if (!subGraphName) {
-        const onChainId = await agent.getContextGraphOnChainId(contextGraphId);
-        if (onChainId && /^\d+$/.test(onChainId)) {
-          resolvedPublishContextGraphId = onChainId;
-        }
       }
       const result = await tracker.trackPhase(ctx, "read-shared-memory", () =>
         agent.publishFromSharedMemory(contextGraphId, sel, {

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -58,7 +58,10 @@ const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
-import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
+import {
+  findReservedSubjectPrefix,
+  isSkolemizedUri,
+} from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
   MetricsCollector,
@@ -328,6 +331,38 @@ import {
 } from '../local-agents.js';
 
 import type { RequestContext } from './context.js';
+
+
+// Keep these in sync with VerifyCollector's hard enforcement in
+// packages/publisher/src/verify-collector.ts. They exist here so bad
+// HTTP input is rejected before the agent starts VERIFY work.
+const VERIFY_COLLECTION_TIMEOUT_MIN_MS = 1_000;
+const VERIFY_COLLECTION_TIMEOUT_MAX_MS = 30 * 60 * 1000;
+
+function parseVerifyTimeoutMs(
+  raw: unknown,
+): { value: number | undefined } | { error: string } {
+  if (raw === undefined || raw === null || raw === '') return { value: undefined };
+  let value: number;
+  if (typeof raw === 'number') {
+    value = raw;
+  } else if (typeof raw === 'string' && /^\d+$/.test(raw.trim())) {
+    value = Number(raw.trim());
+  } else {
+    return { error: 'timeoutMs must be an integer number of milliseconds' };
+  }
+  if (!Number.isSafeInteger(value)) {
+    return { error: 'timeoutMs must be a safe integer number of milliseconds' };
+  }
+  if (value < VERIFY_COLLECTION_TIMEOUT_MIN_MS || value > VERIFY_COLLECTION_TIMEOUT_MAX_MS) {
+    return {
+      error:
+        `timeoutMs must be between ${VERIFY_COLLECTION_TIMEOUT_MIN_MS} and ` +
+        `${VERIFY_COLLECTION_TIMEOUT_MAX_MS} milliseconds`,
+    };
+  }
+  return { value };
+}
 
 
 export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
@@ -917,6 +952,10 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       return jsonResponse(res, 400, { error: parsedSigs.error });
     }
     const validatedRequiredSigs = parsedSigs.value || undefined;
+    const parsedTimeout = parseVerifyTimeoutMs(timeoutMs);
+    if ("error" in parsedTimeout) {
+      return jsonResponse(res, 400, { error: parsedTimeout.error });
+    }
 
     // CLI-9 (
     // unparseable value used to throw `SyntaxError: Cannot convert ...
@@ -936,7 +975,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
         contextGraphId,
         verifiedMemoryId,
         batchId: parsedBatchId,
-        timeoutMs: timeoutMs ? Number(timeoutMs) : undefined,
+        timeoutMs: parsedTimeout.value,
         requiredSignatures: validatedRequiredSigs,
       });
       if (result.status === "verified") {

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -935,12 +935,21 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
         timeoutMs: timeoutMs ? Number(timeoutMs) : undefined,
         requiredSignatures: validatedRequiredSigs,
       });
-      emitMemoryGraphChanged?.({
-        contextGraphId,
-        layers: ["vm"],
-        operation: "verified_memory_updated",
-        source: "api",
-      });
+      if (result.status === "verified") {
+        emitMemoryGraphChanged?.({
+          contextGraphId,
+          layers: ["vm"],
+          operation: "verified_memory_updated",
+          source: "api",
+        });
+      } else if (result.status === "partial") {
+        emitMemoryGraphChanged?.({
+          contextGraphId,
+          layers: ["wm"],
+          operation: "trust_metadata_updated",
+          source: "api",
+        });
+      }
       return jsonResponse(res, 200, { ...result, batchId: String(batchId) });
     } catch (err) {
       // CLI-9 dup #158 #159: a non-existent (cgId, vmId, batchId)
@@ -1008,16 +1017,24 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
           `The endorser is resolved from the bearer token; omit body.agentAddress or use the matching agent's token.`,
       });
     }
-    const result = await agent.endorse({
-      contextGraphId,
-      knowledgeAssetUal: ual,
-      agentAddress: requestAgentAddress,
-    });
-    return jsonResponse(res, 200, {
-      endorsed: true,
-      endorserAddress: requestAgentAddress,
-      ...result,
-    });
+    try {
+      const result = await agent.endorse({
+        contextGraphId,
+        knowledgeAssetUal: ual,
+        agentAddress: requestAgentAddress,
+      });
+      return jsonResponse(res, 200, {
+        endorsed: true,
+        endorserAddress: requestAgentAddress,
+        ...result,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('Endorsement target') && msg.includes('not found')) {
+        return jsonResponse(res, 404, { error: msg });
+      }
+      throw err;
+    }
   }
 
   // POST /api/ccl/policy/publish

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -903,10 +903,14 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       timeoutMs,
       requiredSignatures,
     } = JSON.parse(body);
-    if (!contextGraphId || !verifiedMemoryId || !batchId) {
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
+    if (!verifiedMemoryId || !batchId) {
       return jsonResponse(res, 400, {
-        error: "Missing contextGraphId, verifiedMemoryId, or batchId",
+        error: "Missing verifiedMemoryId or batchId",
       });
+    }
+    if (typeof verifiedMemoryId !== 'string') {
+      return jsonResponse(res, 400, { error: '"verifiedMemoryId" must be a string' });
     }
     const parsedSigs = parseRequiredSignatures(requiredSignatures);
     if ("error" in parsedSigs) {
@@ -982,10 +986,14 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
     const body = await readBody(req, SMALL_BODY_BYTES);
     const parsed = JSON.parse(body);
     const { contextGraphId, ual } = parsed;
-    if (!contextGraphId || !ual) {
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
+    if (!ual) {
       return jsonResponse(res, 400, {
-        error: "Missing contextGraphId or ual",
+        error: "Missing ual",
       });
+    }
+    if (typeof ual !== 'string' || !isSafeIri(ual)) {
+      return jsonResponse(res, 400, { error: '"ual" must be a safe IRI' });
     }
     // A-12 review: the endorser MUST come from the authenticated bearer
     // token, not from the request body. Trusting body.agentAddress let

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -985,7 +985,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
           operation: "verified_memory_updated",
           source: "api",
         });
-      } else if (result.status === "partial") {
+      } else if (result.status === "partial" || result.status === "no_quorum") {
         emitMemoryGraphChanged?.({
           contextGraphId,
           layers: ["wm"],
@@ -993,7 +993,17 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
           source: "api",
         });
       }
-      return jsonResponse(res, 200, { ...result, batchId: String(batchId) });
+      if (result.status === "verified") {
+        return jsonResponse(res, 200, { ...result, batchId: String(batchId) });
+      }
+      return jsonResponse(res, 409, {
+        ...result,
+        batchId: String(batchId),
+        error:
+          result.status === "partial"
+            ? "Verification quorum was not reached; partial trust metadata was written without a chain transaction"
+            : "Verification quorum was not reached; no verified memory was written",
+      });
     } catch (err) {
       // CLI-9 dup #158 #159: a non-existent (cgId, vmId, batchId)
       // tuple used to bubble up a chain custom-error revert as a

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -379,6 +379,52 @@ describe('daemon memory_graph_changed route emissions', () => {
     expect(ctx.tracker.complete).toHaveBeenCalledWith(expect.anything(), { tripleCount: 2 });
   });
 
+  it('keeps implicit same-graph publishes out of the remap path', async () => {
+    const publishFromSharedMemory = vi.fn().mockResolvedValue({
+      kcId: 'kc-1',
+      status: 'confirmed',
+      kaManifest: [{ tokenId: 1n, rootEntity: 'urn:root' }],
+      publicQuads: [{ subject: 'urn:root', predicate: 'urn:p', object: 'urn:o', graph: 'urn:g' }],
+    });
+    const getContextGraphOnChainId = vi.fn().mockResolvedValue('7');
+    const ctx = createContext('/api/shared-memory/publish', {
+      contextGraphId: 'project-a',
+      selection: ['urn:root'],
+    }, {
+      agent: { publishFromSharedMemory, getContextGraphOnChainId } as unknown as RequestContext['agent'],
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(getContextGraphOnChainId).not.toHaveBeenCalled();
+    expect(publishFromSharedMemory.mock.calls[0][2]).not.toHaveProperty('contextGraphId');
+  });
+
+  it('still forwards explicit publishContextGraphId as a remap request', async () => {
+    const publishFromSharedMemory = vi.fn().mockResolvedValue({
+      kcId: 'kc-1',
+      status: 'confirmed',
+      kaManifest: [{ tokenId: 1n, rootEntity: 'urn:root' }],
+      publicQuads: [{ subject: 'urn:root', predicate: 'urn:p', object: 'urn:o', graph: 'urn:g' }],
+    });
+    const ctx = createContext('/api/shared-memory/publish', {
+      contextGraphId: 'project-a',
+      publishContextGraphId: '7',
+      selection: ['urn:root'],
+    }, {
+      agent: { publishFromSharedMemory } as unknown as RequestContext['agent'],
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(publishFromSharedMemory.mock.calls[0][2]).toMatchObject({
+      contextGraphId: '7',
+    });
+    expect(responseBody(ctx)).toMatchObject({ publishContextGraphId: '7' });
+  });
+
   it('emits VM refresh events after verified-memory verification', async () => {
     const emitMemoryGraphChanged = vi.fn();
     const verify = vi.fn().mockResolvedValue({ verified: true, status: 'verified' });

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -455,4 +455,72 @@ describe('daemon memory_graph_changed route emissions', () => {
       source: 'api',
     });
   });
+
+  it('returns 409 and emits WM refresh events for partial verification metadata', async () => {
+    const emitMemoryGraphChanged = vi.fn();
+    const verify = vi.fn().mockResolvedValue({
+      verifiedMemoryId: 'vm-1',
+      signers: ['0x0000000000000000000000000000000000000001'],
+      status: 'partial',
+      trustLevel: 2,
+    });
+    const ctx = createContext('/api/verify', {
+      contextGraphId: 'project-a',
+      verifiedMemoryId: 'vm-1',
+      batchId: '42',
+    }, {
+      agent: { verify } as unknown as RequestContext['agent'],
+      emitMemoryGraphChanged,
+    });
+
+    await handleQueryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(409);
+    expect(responseBody(ctx)).toMatchObject({
+      batchId: '42',
+      status: 'partial',
+      verifiedMemoryId: 'vm-1',
+      error: expect.stringContaining('partial trust metadata'),
+    });
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith({
+      contextGraphId: 'project-a',
+      layers: ['wm'],
+      operation: 'trust_metadata_updated',
+      source: 'api',
+    });
+  });
+
+  it('returns 409 for no-quorum verification without claiming a VM write', async () => {
+    const emitMemoryGraphChanged = vi.fn();
+    const verify = vi.fn().mockResolvedValue({
+      verifiedMemoryId: 'vm-1',
+      signers: [],
+      status: 'no_quorum',
+      trustLevel: 0,
+    });
+    const ctx = createContext('/api/verify', {
+      contextGraphId: 'project-a',
+      verifiedMemoryId: 'vm-1',
+      batchId: '42',
+    }, {
+      agent: { verify } as unknown as RequestContext['agent'],
+      emitMemoryGraphChanged,
+    });
+
+    await handleQueryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(409);
+    expect(responseBody(ctx)).toMatchObject({
+      batchId: '42',
+      status: 'no_quorum',
+      verifiedMemoryId: 'vm-1',
+      error: expect.stringContaining('no verified memory was written'),
+    });
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith({
+      contextGraphId: 'project-a',
+      layers: ['wm'],
+      operation: 'trust_metadata_updated',
+      source: 'api',
+    });
+  });
 });

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -381,7 +381,7 @@ describe('daemon memory_graph_changed route emissions', () => {
 
   it('emits VM refresh events after verified-memory verification', async () => {
     const emitMemoryGraphChanged = vi.fn();
-    const verify = vi.fn().mockResolvedValue({ verified: true });
+    const verify = vi.fn().mockResolvedValue({ verified: true, status: 'verified' });
     const ctx = createContext('/api/verify', {
       contextGraphId: 'project-a',
       verifiedMemoryId: 'vm-1',

--- a/packages/cli/test/trust-endpoint-validation.test.ts
+++ b/packages/cli/test/trust-endpoint-validation.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { Readable } from 'node:stream';
 import { handleQueryRoutes } from '../src/daemon/routes/query.js';
 
+const VERIFY_COLLECTION_TIMEOUT_MAX_MS = 30 * 60 * 1000;
+
 type CapturedResponse = {
   statusCode?: number;
   body?: string;
@@ -114,5 +116,18 @@ describe('trust endpoint input validation', () => {
     expect(result.status).toBe(400);
     expect(result.body.error).toMatch(/ual|safe IRI/i);
     expect(result.agent.endorse).not.toHaveBeenCalled();
+  });
+
+  it('/api/verify rejects oversized timeoutMs before agent.verify', async () => {
+    const result = await callTrustRoute('/api/verify', {
+      contextGraphId: 'cg-safe',
+      verifiedMemoryId: '1',
+      batchId: '1',
+      timeoutMs: VERIFY_COLLECTION_TIMEOUT_MAX_MS + 1,
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toMatch(/timeoutMs/);
+    expect(result.agent.verify).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/test/trust-endpoint-validation.test.ts
+++ b/packages/cli/test/trust-endpoint-validation.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Readable } from 'node:stream';
+import { handleQueryRoutes } from '../src/daemon/routes/query.js';
+
+type CapturedResponse = {
+  statusCode?: number;
+  body?: string;
+  writableEnded?: boolean;
+  writeHead: (statusCode: number, headers: Record<string, string>) => void;
+  end: (body: string) => void;
+};
+
+function response(): CapturedResponse {
+  return {
+    writeHead(statusCode) {
+      this.statusCode = statusCode;
+    },
+    end(body) {
+      this.body = body;
+      this.writableEnded = true;
+    },
+  };
+}
+
+function request(path: string, body: unknown): any {
+  const req = Readable.from([Buffer.from(JSON.stringify(body))]) as any;
+  req.method = 'POST';
+  req.url = path;
+  req.headers = { 'content-type': 'application/json' };
+  return req;
+}
+
+async function callTrustRoute(path: '/api/verify' | '/api/endorse', body: unknown) {
+  const req = request(path, body);
+  const res = response();
+  const agent = {
+    verify: vi.fn(async () => {
+      throw new Error('agent.verify should not be reached');
+    }),
+    endorse: vi.fn(async () => {
+      throw new Error('agent.endorse should not be reached');
+    }),
+  };
+
+  await handleQueryRoutes({
+    req,
+    res,
+    agent,
+    publisherControl: null,
+    publisherRuntime: null,
+    config: {},
+    startedAt: 0,
+    dashDb: null,
+    opWallets: {},
+    network: {},
+    tracker: {},
+    memoryManager: null,
+    bridgeAuthToken: undefined,
+    nodeVersion: 'test',
+    nodeCommit: 'test',
+    catchupTracker: { latestByContextGraph: new Map(), jobs: new Map() },
+    extractionRegistry: null,
+    fileStore: null,
+    extractionStatus: new Map(),
+    assertionImportLocks: new Map(),
+    vectorStore: null,
+    embeddingProvider: null,
+    validTokens: new Set(),
+    apiHost: '127.0.0.1',
+    apiPortRef: { value: 0 },
+    url: new URL(`http://127.0.0.1${path}`),
+    path,
+    requestToken: undefined,
+    requestAgentAddress: '0x0000000000000000000000000000000000000001',
+  } as any);
+
+  return {
+    status: res.statusCode,
+    body: JSON.parse(res.body ?? '{}') as { error?: string },
+    agent,
+  };
+}
+
+describe('trust endpoint input validation', () => {
+  it('/api/verify rejects unsafe contextGraphId before agent.verify', async () => {
+    const result = await callTrustRoute('/api/verify', {
+      contextGraphId: 'cg> } INSERT DATA { ?s ?p ?o } #',
+      verifiedMemoryId: '1',
+      batchId: '1',
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toMatch(/contextGraphId|context graph ID|disallowed/i);
+    expect(result.agent.verify).not.toHaveBeenCalled();
+  });
+
+  it('/api/endorse rejects unsafe contextGraphId before agent.endorse', async () => {
+    const result = await callTrustRoute('/api/endorse', {
+      contextGraphId: 'cg> } INSERT DATA { ?s ?p ?o } #',
+      ual: 'did:dkg:asset:1',
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toMatch(/contextGraphId|context graph ID|disallowed/i);
+    expect(result.agent.endorse).not.toHaveBeenCalled();
+  });
+
+  it('/api/endorse rejects unsafe UAL before agent.endorse', async () => {
+    const result = await callTrustRoute('/api/endorse', {
+      contextGraphId: 'cg-safe',
+      ual: 'did:dkg:asset:1> } INSERT DATA { ?s ?p ?o } #',
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toMatch(/ual|safe IRI/i);
+    expect(result.agent.endorse).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   test: {
     include: runsDaemonHttpBehavior
       ? ['test/daemon-http-behavior-extra.test.ts']
-      : ['test/api-client.test.ts', 'test/memory-graph-events.test.ts'],
+      : ['test/api-client.test.ts', 'test/memory-graph-events.test.ts', 'test/trust-endpoint-validation.test.ts'],
     testTimeout: runsDaemonHttpBehavior ? 120_000 : 60_000,
     globalSetup: runsDaemonHttpBehavior ? ['../chain/test/hardhat-global-setup.ts'] : [],
     env: runsDaemonHttpBehavior ? { HARDHAT_PORT: '9548' } : undefined,

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+
+const runsDaemonHttpBehavior = process.argv.some((arg) =>
+  arg.includes('daemon-http-behavior-extra.test.ts'),
+);
+
+if (runsDaemonHttpBehavior) {
+  process.env.HARDHAT_PORT = '9548';
+}
+
+export default defineConfig({
+  test: {
+    include: runsDaemonHttpBehavior
+      ? ['test/daemon-http-behavior-extra.test.ts']
+      : ['test/api-client.test.ts'],
+    testTimeout: runsDaemonHttpBehavior ? 120_000 : 60_000,
+    globalSetup: runsDaemonHttpBehavior ? ['../chain/test/hardhat-global-setup.ts'] : [],
+    env: runsDaemonHttpBehavior ? { HARDHAT_PORT: '9548' } : undefined,
+    maxWorkers: 1,
+  },
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   test: {
     include: runsDaemonHttpBehavior
       ? ['test/daemon-http-behavior-extra.test.ts']
-      : ['test/api-client.test.ts'],
+      : ['test/api-client.test.ts', 'test/memory-graph-events.test.ts'],
     testTimeout: runsDaemonHttpBehavior ? 120_000 : 60_000,
     globalSetup: runsDaemonHttpBehavior ? ['../chain/test/hardhat-global-setup.ts'] : [],
     env: runsDaemonHttpBehavior ? { HARDHAT_PORT: '9548' } : undefined,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types.js';
 export * from './constants.js';
 export * from './memory-model.js';
+export * from './trust.js';
 export * from './publisher-extension.js';
 export * from './event-bus.js';
 export { Logger, createOperationContext, type OperationContext, type OperationName, type LogSink } from './logger.js';

--- a/packages/core/src/trust.ts
+++ b/packages/core/src/trust.ts
@@ -1,0 +1,66 @@
+import { TrustLevel } from './memory-model.js';
+
+export const TRUST_LEVEL_PREDICATE = 'http://dkg.io/ontology/trustLevel';
+export const LEGACY_TRUST_LEVEL_PREDICATE = 'https://dkg.network/ontology#trustLevel';
+export const TRUST_LEVEL_VALUES = [
+  TrustLevel.SelfAttested,
+  TrustLevel.Endorsed,
+  TrustLevel.PartiallyVerified,
+  TrustLevel.ConsensusVerified,
+] as const;
+
+const TRUST_LEVEL_PREDICATES = new Set([
+  TRUST_LEVEL_PREDICATE,
+  LEGACY_TRUST_LEVEL_PREDICATE,
+]);
+
+type TrustLevelQuadLike = {
+  subject: string;
+  predicate: string;
+  object: string;
+  graph: string;
+};
+
+export function isTrustLevelQuad(quad: Pick<TrustLevelQuadLike, 'predicate'>): boolean {
+  return TRUST_LEVEL_PREDICATES.has(quad.predicate);
+}
+
+export function isTrustLevel(value: unknown): value is TrustLevel {
+  return typeof value === 'number' &&
+    Number.isInteger(value) &&
+    (TRUST_LEVEL_VALUES as readonly number[]).includes(value);
+}
+
+function trustLevelLiteral(level: TrustLevel): string {
+  if (!isTrustLevel(level)) {
+    throw new Error(`Invalid TrustLevel ${String(level)}`);
+  }
+  return `"${level}"^^<http://www.w3.org/2001/XMLSchema#integer>`;
+}
+
+export function buildTrustLevelQuads(
+  subjects: Iterable<string>,
+  level: TrustLevel,
+  graph: string,
+): TrustLevelQuadLike[] {
+  const uniqueSubjects = [...new Set([...subjects].filter(Boolean))];
+  return uniqueSubjects.map((subject) => ({
+    subject,
+    predicate: TRUST_LEVEL_PREDICATE,
+    object: trustLevelLiteral(level),
+    graph,
+  }));
+}
+
+export function assertNoUserAuthoredTrustLevelQuads(
+  quads: Iterable<Pick<TrustLevelQuadLike, 'subject' | 'predicate'>>,
+): void {
+  for (const quad of quads) {
+    if (isTrustLevelQuad(quad)) {
+      throw new Error(
+        `User-authored dkg:trustLevel metadata is not allowed for subject ${quad.subject}. ` +
+        'Trust metadata is protocol-generated after publish, endorse, or verify confirmation.',
+      );
+    }
+  }
+}

--- a/packages/core/test/trust.test.ts
+++ b/packages/core/test/trust.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TrustLevel,
+  TRUST_LEVEL_PREDICATE,
+  buildTrustLevelQuads,
+  isTrustLevelQuad,
+  assertNoUserAuthoredTrustLevelQuads,
+  isTrustLevel,
+} from '../src/index.js';
+
+describe('trust metadata helpers', () => {
+  it('builds canonical dkg:trustLevel quads from TrustLevel values', () => {
+    const quads = buildTrustLevelQuads(
+      ['urn:a', 'urn:a', 'urn:b'],
+      TrustLevel.ConsensusVerified,
+      'did:dkg:context-graph:cg',
+    );
+
+    expect(quads).toEqual([
+      {
+        subject: 'urn:a',
+        predicate: TRUST_LEVEL_PREDICATE,
+        object: '"3"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: 'did:dkg:context-graph:cg',
+      },
+      {
+        subject: 'urn:b',
+        predicate: TRUST_LEVEL_PREDICATE,
+        object: '"3"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: 'did:dkg:context-graph:cg',
+      },
+    ]);
+  });
+
+  it('recognizes canonical and legacy trustLevel predicates as protocol metadata', () => {
+    expect(isTrustLevelQuad({ predicate: TRUST_LEVEL_PREDICATE })).toBe(true);
+    expect(isTrustLevelQuad({ predicate: 'https://dkg.network/ontology#trustLevel' })).toBe(true);
+    expect(isTrustLevelQuad({ predicate: 'http://schema.org/name' })).toBe(false);
+  });
+
+  it('validates TrustLevel values at runtime', () => {
+    expect(isTrustLevel(TrustLevel.PartiallyVerified)).toBe(true);
+    expect(isTrustLevel(99)).toBe(false);
+    expect(() =>
+      buildTrustLevelQuads(['urn:a'], 99 as TrustLevel, 'did:dkg:context-graph:cg'),
+    ).toThrow(/Invalid TrustLevel 99/);
+  });
+
+  it('rejects user-authored trustLevel quads', () => {
+    expect(() =>
+      assertNoUserAuthoredTrustLevelQuads([
+        {
+          subject: 'urn:a',
+          predicate: TRUST_LEVEL_PREDICATE,
+        },
+      ]),
+    ).toThrow(/User-authored dkg:trustLevel metadata is not allowed/);
+  });
+});

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
+    "test:unit": "vitest run --config vitest.unit.config.ts",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, computePublishACKDigest, buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, computePublishACKDigest, buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import type { Publisher, PublishOptions, PublishResult, KAManifestEntry, PhaseCallback } from './publisher.js';
 import { autoPartition } from './auto-partition.js';
@@ -319,6 +319,47 @@ function rejectReservedSubjectPrefixes(quads: Quad[]): void {
       throw new ReservedNamespaceError(q.subject, findReservedSubjectPrefix(q.subject)!);
     }
   }
+}
+
+function rejectUserAuthoredProtocolMetadata(quads: Quad[]): void {
+  rejectReservedSubjectPrefixes(quads);
+  assertNoUserAuthoredTrustLevelQuads(quads);
+}
+
+async function stampTrustLevel(
+  store: TripleStore,
+  graph: string,
+  subjects: Iterable<string>,
+  level: TrustLevel,
+): Promise<void> {
+  const quads = buildTrustLevelQuads(subjects, level, graph) as Quad[];
+  for (const quad of quads) {
+    await store.deleteByPattern({
+      graph: quad.graph,
+      subject: quad.subject,
+      predicate: TRUST_LEVEL_PREDICATE,
+    });
+  }
+  if (quads.length > 0) {
+    await store.insert(quads);
+  }
+}
+
+function collectTrustSubjectsForRoots(
+  quads: Iterable<Pick<Quad, 'subject'>>,
+  roots: Iterable<string>,
+): string[] {
+  const rootSet = new Set([...roots].filter(Boolean));
+  const subjects = new Set(rootSet);
+  for (const quad of quads) {
+    for (const root of rootSet) {
+      if (quad.subject === root || quad.subject.startsWith(`${root}/.well-known/genid/`)) {
+        subjects.add(quad.subject);
+        break;
+      }
+    }
+  }
+  return [...subjects];
 }
 
 export class DKGPublisher implements Publisher {
@@ -747,7 +788,7 @@ export class DKGPublisher implements Publisher {
     // spec `19_MARKDOWN_CONTENT_TYPE.md §10.2`. Short-circuit so a
     // reserved-namespace violation cannot be masked by a lock timeout
     // or subject-level validation error downstream.
-    rejectReservedSubjectPrefixes(quads);
+    rejectUserAuthoredProtocolMetadata(quads);
     const subjects = [...new Set(quads.map(q => q.subject))];
     const lockPrefix = options.subGraphName ? `${contextGraphId}\0${options.subGraphName}` : contextGraphId;
     const lockKeys = subjects.map(s => `${lockPrefix}\0${s}`);
@@ -1009,7 +1050,7 @@ export class DKGPublisher implements Publisher {
     // CAS condition check (which could otherwise mask the namespace
     // violation with a StaleWriteError). Short-circuit per
     // `19_MARKDOWN_CONTENT_TYPE.md §10.2`.
-    rejectReservedSubjectPrefixes(quads);
+    rejectUserAuthoredProtocolMetadata(quads);
     for (const cond of options.conditions) {
       assertSafeIri(cond.subject);
       assertSafeIri(cond.predicate);
@@ -1176,8 +1217,9 @@ export class DKGPublisher implements Publisher {
     }
 
     const result = await this.store.query(sparql);
-    const quads: Quad[] =
-      result.type === 'quads' ? result.quads : [];
+    const quads: Quad[] = result.type === 'quads'
+      ? result.quads.filter((q) => !isTrustLevelQuad(q))
+      : [];
 
     if (quads.length === 0) {
       throw new Error(`No quads in shared memory for context graph ${contextGraphId} matching selection`);
@@ -1316,8 +1358,25 @@ export class DKGPublisher implements Publisher {
         ) {
           const storedQuads = publishResult.publicQuads.map(q => ({ ...q, graph: defaultDataGraph }));
           await this.store.insert(storedQuads.map(q => ({ ...q, graph: ctxDataGraph })));
+          const trustSubjects = collectTrustSubjectsForRoots(
+            storedQuads,
+            publishResult.kaManifest.map((ka) => ka.rootEntity),
+          );
+          await stampTrustLevel(
+            this.store,
+            ctxDataGraph,
+            trustSubjects,
+            TrustLevel.SelfAttested,
+          );
           if (ctxGraphId) {
             await this.store.delete(storedQuads);
+            for (const subject of trustSubjects) {
+              await this.store.deleteByPattern({
+                graph: defaultDataGraph,
+                subject,
+                predicate: TRUST_LEVEL_PREDICATE,
+              });
+            }
           }
         }
 
@@ -1541,8 +1600,8 @@ export class DKGPublisher implements Publisher {
     // `fromSharedMemory` retains its V10 ACK-path semantic
     // independently.
     if (!isInternalOrigin(options)) {
-      rejectReservedSubjectPrefixes(quads);
-      if (privateQuads.length > 0) rejectReservedSubjectPrefixes(privateQuads);
+      rejectUserAuthoredProtocolMetadata(quads);
+      if (privateQuads.length > 0) rejectUserAuthoredProtocolMetadata(privateQuads);
     }
     const ctx: OperationContext = operationCtx ?? createOperationContext('publish');
     const effectiveAccessPolicy = accessPolicy ?? (privateQuads.length > 0 ? 'ownerOnly' : 'public');
@@ -2254,6 +2313,15 @@ export class DKGPublisher implements Publisher {
           );
         }
         await this.store.insert(confirmedQuads);
+        await stampTrustLevel(
+          this.store,
+          dataGraph,
+          collectTrustSubjectsForRoots(
+            normalizedQuads,
+            manifestEntries.map((entry) => entry.rootEntity),
+          ),
+          TrustLevel.SelfAttested,
+        );
 
         // Agent authorship proof (spec §9.0.6): sign keccak256(merkleRoot) and store in _meta
         try {
@@ -2395,8 +2463,8 @@ export class DKGPublisher implements Publisher {
     // is a forward-looking safety net — the common path is always
     // guarded.
     if (!isInternalOrigin(options)) {
-      rejectReservedSubjectPrefixes(quads);
-      if (privateQuads.length > 0) rejectReservedSubjectPrefixes(privateQuads);
+      rejectUserAuthoredProtocolMetadata(quads);
+      if (privateQuads.length > 0) rejectUserAuthoredProtocolMetadata(privateQuads);
     }
     const ctx: OperationContext = operationCtx ?? createOperationContext('publish');
     let publisherContextGraphId: bigint | undefined;
@@ -3004,7 +3072,7 @@ export class DKGPublisher implements Publisher {
     }));
     // Round 9 Bug 25: reject user-authored quads whose subject is in a
     // protocol-reserved URN namespace. See RESERVED_SUBJECT_PREFIXES above.
-    rejectReservedSubjectPrefixes(quads);
+    rejectUserAuthoredProtocolMetadata(quads);
     await this.store.insert(quads);
   }
 
@@ -3097,7 +3165,9 @@ export class DKGPublisher implements Publisher {
     // semantically equivalent to `urn:dkg:file:...` and must be
     // filtered identically. See the helper's docstring for the full
     // argument.
-    quadsToPromote = quadsToPromote.filter((q) => !isReservedSubject(q.subject));
+    quadsToPromote = quadsToPromote.filter(
+      (q) => !isReservedSubject(q.subject) && !isTrustLevelQuad(q),
+    );
 
     if (opts?.entities && opts.entities !== 'all') {
       const entitySet = new Set(opts.entities);

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -8,6 +8,7 @@ import {
   Logger,
   createOperationContext,
   assertSafeIri,
+  assertNoUserAuthoredTrustLevelQuads,
   type PublishRequestMsg,
 } from '@origintrail-official/dkg-core';
 import type { ChainAdapter } from '@origintrail-official/dkg-chain';
@@ -217,6 +218,7 @@ export class PublishHandler {
 
       const nquadsStr = new TextDecoder().decode(request.nquads);
       const quads = parseSimpleNQuads(nquadsStr);
+      assertNoUserAuthoredTrustLevelQuads(quads);
 
       const manifest = request.kas.map((ka) => ({
         tokenId: BigInt(typeof ka.tokenId === 'number' ? ka.tokenId : 0),

--- a/packages/publisher/src/verify-collector.ts
+++ b/packages/publisher/src/verify-collector.ts
@@ -28,6 +28,8 @@ export interface VerifyCollectionResult {
   merkleRoot: Uint8Array;
   contextGraphId: string;
   verifiedMemoryId: bigint;
+  requiredRemoteApprovals: number;
+  quorumReached: boolean;
 }
 
 const MAX_RETRIES = 2;
@@ -58,11 +60,12 @@ export class VerifyCollector {
     proposerSignature: { r: Uint8Array; vs: Uint8Array };
     requiredSignatures: number;
     timeoutMs: number;
+    allowPartial?: boolean;
   }): Promise<VerifyCollectionResult> {
     const {
       contextGraphId, contextGraphIdOnChain, verifiedMemoryId,
       batchId, merkleRoot, entities, proposerSignature,
-      requiredSignatures, timeoutMs,
+      requiredSignatures, timeoutMs, allowPartial = false,
     } = params;
 
     const log = this.deps.log ?? (() => {});
@@ -92,9 +95,19 @@ export class VerifyCollector {
 
     const peers = this.deps.getParticipantPeers(contextGraphId);
     if (remoteRequired > 0 && peers.length === 0) {
+      if (allowPartial) {
+        return {
+          approvals: [],
+          merkleRoot,
+          contextGraphId,
+          verifiedMemoryId,
+          requiredRemoteApprovals: remoteRequired,
+          quorumReached: false,
+        };
+      }
       throw new Error('verify_no_peers: no participant peers connected');
     }
-    if (peers.length < remoteRequired) {
+    if (peers.length < remoteRequired && !allowPartial) {
       throw new Error(
         `verify_insufficient_peers: need ${remoteRequired} remote approvals but only ${peers.length} participants connected`,
       );
@@ -103,7 +116,14 @@ export class VerifyCollector {
     // Self-sign only (1-of-1): return immediately, no remote collection needed
     if (remoteRequired === 0) {
       log(`[VerifyCollector] Self-sign mode (1-of-1) — no remote approvals needed`);
-      return { approvals: [], merkleRoot, contextGraphId, verifiedMemoryId };
+      return {
+        approvals: [],
+        merkleRoot,
+        contextGraphId,
+        verifiedMemoryId,
+        requiredRemoteApprovals: 0,
+        quorumReached: true,
+      };
     }
 
     log(`[VerifyCollector] Requesting approvals from ${peers.length} participants (need ${remoteRequired} remote, ${requiredSignatures} total)`);
@@ -151,41 +171,53 @@ export class VerifyCollector {
     let quorumResolve: (() => void) | undefined;
     const quorumPromise = new Promise<void>(resolve => { quorumResolve = resolve; });
 
-    await Promise.race([
-      (async () => {
-        const promises = peers.map(async (peerId) => {
-          if (collected.length >= remoteRequired) return;
-          const approval = await requestApproval(peerId);
-          if (approval && !seenAddresses.has(approval.approverAddress)) {
-            seenAddresses.add(approval.approverAddress);
-            collected.push(approval);
-            if (collected.length >= remoteRequired) {
-              quorumResolve?.();
+    try {
+      await Promise.race([
+        (async () => {
+          const promises = peers.map(async (peerId) => {
+            if (collected.length >= remoteRequired) return;
+            const approval = await requestApproval(peerId);
+            if (approval && !seenAddresses.has(approval.approverAddress)) {
+              seenAddresses.add(approval.approverAddress);
+              collected.push(approval);
+              if (collected.length >= remoteRequired) {
+                quorumResolve?.();
+              }
             }
-          }
-        });
-        await Promise.race([Promise.allSettled(promises), quorumPromise]);
-      })(),
-      new Promise<never>((_, reject) =>
-        setTimeout(
-          () => reject(new Error(`verify_timeout: ${collected.length}/${remoteRequired} remote approvals within ${timeoutMs}ms`)),
-          timeoutMs,
+          });
+          await Promise.race([Promise.allSettled(promises), quorumPromise]);
+        })(),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error(`verify_timeout: ${collected.length}/${remoteRequired} remote approvals within ${timeoutMs}ms`)),
+            timeoutMs,
+          ),
         ),
-      ),
-    ]);
+      ]);
+    } catch (err) {
+      if (!allowPartial) throw err;
+      log(`[VerifyCollector] Partial verify collection: ${err instanceof Error ? err.message : String(err)}`);
+    }
 
-    if (collected.length < remoteRequired) {
+    if (collected.length < remoteRequired && !allowPartial) {
       throw new Error(
         `verify_insufficient: got ${collected.length}/${remoteRequired} valid remote approvals from ${peers.length} participants`,
       );
     }
 
-    log(`[VerifyCollector] Collected ${collected.length} approvals — quorum reached`);
+    const quorumReached = collected.length >= remoteRequired;
+    log(
+      quorumReached
+        ? `[VerifyCollector] Collected ${collected.length} approvals — quorum reached`
+        : `[VerifyCollector] Collected ${collected.length}/${remoteRequired} approvals — quorum not reached`,
+    );
     return {
       approvals: collected.slice(0, remoteRequired),
       merkleRoot,
       contextGraphId,
       verifiedMemoryId,
+      requiredRemoteApprovals: remoteRequired,
+      quorumReached,
     };
   }
 

--- a/packages/publisher/src/verify-collector.ts
+++ b/packages/publisher/src/verify-collector.ts
@@ -33,6 +33,23 @@ export interface VerifyCollectionResult {
 }
 
 const MAX_RETRIES = 2;
+export const VERIFY_COLLECTION_TIMEOUT_MIN_MS = 1_000;
+export const VERIFY_COLLECTION_TIMEOUT_MAX_MS = 30 * 60 * 1000;
+export const VERIFY_COLLECTION_TIMEOUT_DEFAULT_MS = VERIFY_COLLECTION_TIMEOUT_MAX_MS;
+
+export function assertVerifyCollectionTimeoutMs(timeoutMs: number): number {
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs < VERIFY_COLLECTION_TIMEOUT_MIN_MS ||
+    timeoutMs > VERIFY_COLLECTION_TIMEOUT_MAX_MS
+  ) {
+    throw new RangeError(
+      `verify_timeout_invalid: timeoutMs must be an integer between ` +
+        `${VERIFY_COLLECTION_TIMEOUT_MIN_MS} and ${VERIFY_COLLECTION_TIMEOUT_MAX_MS} milliseconds`,
+    );
+  }
+  return timeoutMs;
+}
 
 /**
  * VerifyCollector implements spec §10.1: collecting M-of-N approval
@@ -67,11 +84,15 @@ export class VerifyCollector {
       batchId, merkleRoot, entities, proposerSignature,
       requiredSignatures, timeoutMs, allowPartial = false,
     } = params;
+    const boundedTimeoutMs = Math.min(
+      assertVerifyCollectionTimeoutMs(timeoutMs),
+      VERIFY_COLLECTION_TIMEOUT_MAX_MS,
+    );
 
     const log = this.deps.log ?? (() => {});
 
     const proposalId = crypto.getRandomValues(new Uint8Array(16));
-    const expiresAt = new Date(Date.now() + timeoutMs).toISOString();
+    const expiresAt = new Date(Date.now() + boundedTimeoutMs).toISOString();
 
     // Use { low, high, unsigned } Long objects for uint64 fields to avoid
     // precision loss above 2^53 - 1 (protobufjs uint64 representation).
@@ -171,6 +192,7 @@ export class VerifyCollector {
     let quorumResolve: (() => void) | undefined;
     const quorumPromise = new Promise<void>(resolve => { quorumResolve = resolve; });
 
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     try {
       await Promise.race([
         (async () => {
@@ -187,16 +209,20 @@ export class VerifyCollector {
           });
           await Promise.race([Promise.allSettled(promises), quorumPromise]);
         })(),
-        new Promise<never>((_, reject) =>
-          setTimeout(
-            () => reject(new Error(`verify_timeout: ${collected.length}/${remoteRequired} remote approvals within ${timeoutMs}ms`)),
-            timeoutMs,
-          ),
-        ),
+        new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
+            () => reject(new Error(`verify_timeout: ${collected.length}/${remoteRequired} remote approvals within ${boundedTimeoutMs}ms`)),
+            boundedTimeoutMs,
+          );
+        }),
       ]);
     } catch (err) {
       if (!allowPartial) throw err;
       log(`[VerifyCollector] Partial verify collection: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+      }
     }
 
     if (collected.length < remoteRequired && !allowPartial) {

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -19,6 +19,7 @@ import {
   ENCRYPTED_WORKSPACE_ENVELOPE_TYPE,
   GOSSIP_TYPE_WORKSPACE_PUBLISH,
   SWM_SENDER_KEY_MESSAGE_TYPE,
+  assertNoUserAuthoredTrustLevelQuads,
 } from '@origintrail-official/dkg-core';
 import type { EncryptedWorkspacePayloadMsg, GossipEnvelopeMsg, OperationContext, SwmSenderKeyMessageMsg, WorkspaceCASConditionMsg, WorkspacePublishRequestMsg, WorkspaceRecipientEncryptionKey } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
@@ -312,6 +313,7 @@ export class SharedMemoryHandler {
 
       const nquadsStr = new TextDecoder().decode(nquads);
       const quads = parseSimpleNQuads(nquadsStr);
+      assertNoUserAuthoredTrustLevelQuads(quads);
       onPhase?.('decode', 'end');
 
       const manifestForValidation: KAManifestEntry[] = (manifest ?? []).map((m) => ({

--- a/packages/publisher/test/dkg-publisher.test.ts
+++ b/packages/publisher/test/dkg-publisher.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll, afterEach } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
-import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import {
+  TRUST_LEVEL_PREDICATE,
+  TrustLevel,
+  TypedEventBus,
+  generateEd25519Keypair,
+} from '@origintrail-official/dkg-core';
 import { DKGPublisher, RESERVED_SUBJECT_PREFIXES } from '../src/dkg-publisher.js';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { ethers } from 'ethers';
@@ -106,7 +111,18 @@ describe('DKGPublisher', () => {
     expect(result.status).toBe('confirmed');
 
     const count = await store.countQuads(GRAPH);
-    expect(count).toBe(2);
+    expect(count).toBe(3);
+    const trust = await store.query(
+      `SELECT ?level WHERE {
+        GRAPH <${GRAPH}> {
+          <${ENTITY}> <${TRUST_LEVEL_PREDICATE}> ?level .
+        }
+      }`,
+    );
+    expect(trust.type).toBe('bindings');
+    expect(trust.type === 'bindings' ? trust.bindings.map((row) => row.level) : []).toEqual([
+      `"${TrustLevel.SelfAttested}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+    ]);
 
     const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
     const metaCount = await store.countQuads(metaGraph);
@@ -763,4 +779,3 @@ describe('DKGPublisher', () => {
     });
   });
 });
-

--- a/packages/publisher/test/storage-ack-roster-and-verify-mofn-extra.test.ts
+++ b/packages/publisher/test/storage-ack-roster-and-verify-mofn-extra.test.ts
@@ -56,6 +56,7 @@ describe('P-8: VerifyCollector rejects single-voter promotion (requiredSignature
   const CG_ON_CHAIN = 42n;
   const VERIFIED_ID = 1n;
   const BATCH_ID = 7n;
+  const VALID_TIMEOUT_MS = 1_000;
   const merkleRoot = ethers.getBytes(
     ethers.keccak256(ethers.toUtf8Bytes('p8-verify-root')),
   );
@@ -93,7 +94,7 @@ describe('P-8: VerifyCollector rejects single-voter promotion (requiredSignature
         entities: ['urn:test:p8:entity'],
         proposerSignature,
         requiredSignatures: 2,
-        timeoutMs: 500,
+        timeoutMs: VALID_TIMEOUT_MS,
       }),
     ).rejects.toThrow(/verify_no_peers|verify_insufficient/);
   });
@@ -119,7 +120,7 @@ describe('P-8: VerifyCollector rejects single-voter promotion (requiredSignature
         entities: ['urn:test:p8:entity'],
         proposerSignature,
         requiredSignatures: 4,
-        timeoutMs: 500,
+        timeoutMs: VALID_TIMEOUT_MS,
       }),
     ).rejects.toThrow(/insufficient_peers/);
   });
@@ -149,9 +150,9 @@ describe('P-8: VerifyCollector rejects single-voter promotion (requiredSignature
         entities: ['urn:test:p8:entity'],
         proposerSignature,
         requiredSignatures: 2,
-        timeoutMs: 200,
+        timeoutMs: VALID_TIMEOUT_MS,
       }),
-    ).rejects.toThrow(/verify_(timeout|insufficient)/);
+    ).rejects.toThrow(/verify_timeout/);
   }, 15000);
 
   it('requiredSignatures=2 with 1 peer that signs for a DIFFERENT address is not counted (dedup by address)', async () => {

--- a/packages/publisher/test/trust-metadata.test.ts
+++ b/packages/publisher/test/trust-metadata.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import { MockChainAdapter, NoChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  AUTHOR_SCHEME_VERSION_V1,
+  TRUST_LEVEL_PREDICATE,
+  TrustLevel,
+  TypedEventBus,
+  buildAuthorAttestationTypedData,
+  generateEd25519Keypair,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { DKGPublisher, canonicalPublishPayload } from '../src/index.js';
+
+function quad(subject: string, predicate = 'http://schema.org/name', object = '"Root"'): Quad {
+  return { subject, predicate, object, graph: '' };
+}
+
+async function makePublisher(chain = new NoChainAdapter(), wallet?: ethers.Wallet) {
+  const keypair = await generateEd25519Keypair();
+  const store = new OxigraphStore();
+  const publisher = new DKGPublisher({
+    store,
+    chain,
+    eventBus: new TypedEventBus(),
+    keypair,
+    publisherPrivateKey: wallet?.privateKey,
+    publisherNodeIdentityId: wallet ? 1n : 0n,
+  });
+  return { publisher, store };
+}
+
+async function buildSeal(
+  chain: MockChainAdapter,
+  contextGraphId: bigint,
+  quads: Quad[],
+  author: ethers.Wallet,
+) {
+  const canonical = canonicalPublishPayload(quads, []);
+  const typed = buildAuthorAttestationTypedData({
+    chainId: await chain.getEvmChainId(),
+    kav10Address: await chain.getKnowledgeAssetsV10Address(),
+    contextGraphId,
+    merkleRoot: canonical.kcMerkleRoot,
+    authorAddress: author.address,
+    schemeVersion: AUTHOR_SCHEME_VERSION_V1,
+  });
+  const sig = ethers.Signature.from(await author.signTypedData(
+    typed.domain,
+    typed.types,
+    typed.message,
+  ));
+  return {
+    expectedMerkleRoot: canonical.kcMerkleRoot,
+    authorAddress: author.address,
+    signature: {
+      r: ethers.getBytes(sig.r),
+      vs: ethers.getBytes(sig.yParityAndS),
+    },
+    schemeVersion: AUTHOR_SCHEME_VERSION_V1,
+  };
+}
+
+describe('publisher trust metadata', () => {
+  it('rejects user-authored trustLevel quads in publish and SWM inputs', async () => {
+    const { publisher } = await makePublisher();
+    const trustQuad = quad('urn:trust:user', TRUST_LEVEL_PREDICATE, `"${TrustLevel.ConsensusVerified}"`);
+
+    await expect(
+      publisher.publish({
+        contextGraphId: 'trust-cg',
+        quads: [trustQuad],
+      }),
+    ).rejects.toThrow(/User-authored dkg:trustLevel metadata is not allowed/);
+
+    await expect(
+      publisher.share('trust-cg', [trustQuad], { publisherPeerId: 'peer-a' }),
+    ).rejects.toThrow(/User-authored dkg:trustLevel metadata is not allowed/);
+
+    await expect(
+      publisher.assertionWrite('trust-cg', 'draft', '0xabc', [trustQuad]),
+    ).rejects.toThrow(/User-authored dkg:trustLevel metadata is not allowed/);
+  });
+
+  it('stamps confirmed publish subjects as SelfAttested', async () => {
+    const wallet = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', wallet.address);
+    chain.seedIdentity(wallet.address, 1n);
+    const created = await chain.createOnChainContextGraph({
+      participantIdentityIds: [1n],
+      requiredSignatures: 1,
+      metadataBatchId: 0n,
+    });
+    const contextGraphId = created.contextGraphId;
+    const { publisher, store } = await makePublisher(chain, wallet);
+    const quads = [
+      quad('urn:trust:published-root'),
+      quad('urn:trust:published-root/.well-known/genid/child', 'http://schema.org/value', '"Child"'),
+    ];
+
+    const result = await publisher.publish({
+      contextGraphId: String(contextGraphId),
+      quads,
+      precomputedAttestation: await buildSeal(chain, contextGraphId, quads, wallet),
+    });
+
+    expect(result.status).toBe('confirmed');
+    const trust = await store.query(
+      `SELECT ?subject ?level WHERE {
+        GRAPH <did:dkg:context-graph:${contextGraphId}> {
+          VALUES ?subject {
+            <urn:trust:published-root>
+            <urn:trust:published-root/.well-known/genid/child>
+          }
+          ?subject <${TRUST_LEVEL_PREDICATE}> ?level .
+        }
+      }`,
+    );
+    expect(trust.type).toBe('bindings');
+    expect(trust.type === 'bindings' ? trust.bindings.map((row) => row.level).sort() : [])
+      .toEqual([
+        `"${TrustLevel.SelfAttested}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+        `"${TrustLevel.SelfAttested}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+      ]);
+  });
+});

--- a/packages/publisher/test/verify-collector.test.ts
+++ b/packages/publisher/test/verify-collector.test.ts
@@ -60,6 +60,8 @@ describe('VerifyCollector', () => {
     expect(result.approvals).toHaveLength(1);
     expect(result.contextGraphId).toBe('test-cg');
     expect(result.verifiedMemoryId).toBe(1n);
+    expect(result.requiredRemoteApprovals).toBe(1);
+    expect(result.quorumReached).toBe(true);
   });
 
   it('throws when not enough peers are connected', async () => {
@@ -98,5 +100,29 @@ describe('VerifyCollector', () => {
       requiredSignatures: 2, // needs 1 remote, but 0 peers → error
       timeoutMs: 1000,
     })).rejects.toThrow('verify_no_peers');
+  });
+
+  it('returns no-quorum metadata instead of throwing when partial collection is allowed and no peers are connected', async () => {
+    const collector = new VerifyCollector({
+      sendP2P: async () => new Uint8Array(0),
+      getParticipantPeers: () => [],
+    });
+
+    const result = await collector.collect({
+      contextGraphId: 'test-cg',
+      contextGraphIdOnChain: 42n,
+      verifiedMemoryId: 1n,
+      batchId: 100n,
+      merkleRoot: new Uint8Array(32),
+      entities: [],
+      proposerSignature: { r: new Uint8Array(32), vs: new Uint8Array(32) },
+      requiredSignatures: 2,
+      timeoutMs: 1000,
+      allowPartial: true,
+    });
+
+    expect(result.approvals).toEqual([]);
+    expect(result.requiredRemoteApprovals).toBe(1);
+    expect(result.quorumReached).toBe(false);
   });
 });

--- a/packages/publisher/test/verify-collector.test.ts
+++ b/packages/publisher/test/verify-collector.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { VerifyCollector } from '../src/verify-collector.js';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import {
+  VerifyCollector,
+  VERIFY_COLLECTION_TIMEOUT_MAX_MS,
+} from '../src/verify-collector.js';
 import { encodeVerifyApproval, decodeVerifyProposal } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 
@@ -15,6 +18,10 @@ function makeApproval(proposalId: Uint8Array, wallet: ethers.Wallet, digest: Uin
 }
 
 describe('VerifyCollector', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('collects M-of-N approvals from participants', async () => {
     const walletA = ethers.Wallet.createRandom();
     const walletB = ethers.Wallet.createRandom();
@@ -124,5 +131,63 @@ describe('VerifyCollector', () => {
     expect(result.approvals).toEqual([]);
     expect(result.requiredRemoteApprovals).toBe(1);
     expect(result.quorumReached).toBe(false);
+  });
+
+  it('rejects oversized timeout values before sending proposals', async () => {
+    const sendP2P = vi.fn(async () => new Uint8Array(0));
+    const collector = new VerifyCollector({
+      sendP2P,
+      getParticipantPeers: () => ['peer-a'],
+    });
+
+    await expect(collector.collect({
+      contextGraphId: 'test-cg',
+      contextGraphIdOnChain: 42n,
+      verifiedMemoryId: 1n,
+      batchId: 100n,
+      merkleRoot: new Uint8Array(32),
+      entities: [],
+      proposerSignature: { r: new Uint8Array(32), vs: new Uint8Array(32) },
+      requiredSignatures: 2,
+      timeoutMs: VERIFY_COLLECTION_TIMEOUT_MAX_MS + 1,
+    })).rejects.toThrow(/verify_timeout_invalid/);
+
+    expect(sendP2P).not.toHaveBeenCalled();
+  });
+
+  it('clears the timeout timer after quorum resolves', async () => {
+    vi.useFakeTimers();
+    const walletA = ethers.Wallet.createRandom();
+    const merkleRoot = ethers.getBytes(ethers.keccak256(ethers.toUtf8Bytes('timer-root')));
+    const sendP2P = async (_peerId: string, _protocol: string, data: Uint8Array) => {
+      const proposal = decodeVerifyProposal(data);
+      const contextGraphIdBig = BigInt(42);
+      const packed = new Uint8Array(64);
+      const cgBytes = new Uint8Array(32);
+      const view = new DataView(cgBytes.buffer);
+      view.setBigUint64(24, contextGraphIdBig);
+      packed.set(cgBytes, 0);
+      packed.set(proposal.merkleRoot, 32);
+      const digest = ethers.getBytes(ethers.keccak256(packed));
+      return makeApproval(proposal.proposalId, walletA, digest);
+    };
+    const collector = new VerifyCollector({
+      sendP2P,
+      getParticipantPeers: () => ['peer-a'],
+    });
+
+    await collector.collect({
+      contextGraphId: 'test-cg',
+      contextGraphIdOnChain: 42n,
+      verifiedMemoryId: 1n,
+      batchId: 100n,
+      merkleRoot,
+      entities: [],
+      proposerSignature: { r: new Uint8Array(32), vs: new Uint8Array(32) },
+      requiredSignatures: 2,
+      timeoutMs: 5000,
+    });
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/publisher/test/views-min-trust-extra.test.ts
+++ b/packages/publisher/test/views-min-trust-extra.test.ts
@@ -12,15 +12,9 @@
  *                   was declared on the query-engine `QueryOptions`
  *                   type, but the resolver silently ignored it.
  *
- * Fix: `resolveViewGraphs` now accepts `minTrust`. When it is set
- * above `TrustLevel.SelfAttested`, the root data graph (which holds
- * chain-confirmed SelfAttested triples) is dropped from the resolution.
- * Only quorum-verified sub-graphs under `/_verified_memory/{quorum}`
- * survive the resolution step.
- *
- * Note: per-quad trust filtering inside the surviving sub-graphs (based
- * on a `dkg:trustLevel` predicate on each triple) is tracked as Q-1 and
- * is out of scope for this test.
+ * Fix: `resolveViewGraphs` keeps the root data graph and verified-memory
+ * graphs as candidates. `DKGQueryEngine` then enforces `minTrust` with
+ * writer-side `dkg:trustLevel` metadata instead of graph-scope inference.
  */
 import { describe, expect, it } from 'vitest';
 import { TrustLevel } from '@origintrail-official/dkg-core';
@@ -55,16 +49,12 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
   });
 
   it(
-    'minTrust=Endorsed drops the root data graph — prevents SelfAttested triples ' +
-      'from leaking into Endorsed queries (',
+    'minTrust=Endorsed keeps root and verified-memory graphs as candidates',
     () => {
       const res = resolveViewGraphs('verified-memory', CG, {
         minTrust: TrustLevel.Endorsed,
       });
-      // Root data graph must not be present above SelfAttested.
-      expect(res.graphs).not.toContain(`did:dkg:context-graph:${CG}`);
-      expect(res.graphs).toEqual([]);
-      // Quorum-verified sub-graphs are still discovered via the prefix.
+      expect(res.graphs).toEqual([`did:dkg:context-graph:${CG}`]);
       expect(res.graphPrefixes).toEqual([
         `did:dkg:context-graph:${CG}/_verified_memory/`,
       ]);
@@ -72,21 +62,8 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
   );
 
   it(
-    'minTrust > Endorsed resolves to the /_verified_memory/ prefix — per-triple trust ' +
-      'filtering (Q-1) handles `PartiallyVerified` / `ConsensusVerified` downstream',
+    'minTrust > Endorsed keeps root and verified-memory graphs for trust-tag filtering',
     () => {
-      // Pre-Q-1 the resolver rejected above-Endorsed because per-graph
-      // trust metadata was not available and returning the same graph
-      // set as Endorsed would silently serve lower-trust data. Q-1
-      // closed the hole at the PER-TRIPLE level (see
-      // `DKGQueryEngine.queryWithView` + `injectMinTrustFilter`): the
-      // user SPARQL is rewritten so every subject MUST carry
-      // `<http://dkg.io/ontology/trustLevel> "N"` with
-      // `N ≥ minTrust`, so sub-threshold triples in the sub-graph
-      // prefix are excluded. The graph-scope resolution therefore
-      // collapses to the same shape for `Endorsed` /
-      // `PartiallyVerified` / `ConsensusVerified`: drop the root
-      // data graph, union over the quorum prefix.
       const partially = resolveViewGraphs('verified-memory', CG, {
         minTrust: TrustLevel.PartiallyVerified,
       });
@@ -94,8 +71,7 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
         minTrust: TrustLevel.ConsensusVerified,
       });
       for (const res of [partially, consensus]) {
-        expect(res.graphs).not.toContain(`did:dkg:context-graph:${CG}`);
-        expect(res.graphs).toEqual([]);
+        expect(res.graphs).toEqual([`did:dkg:context-graph:${CG}`]);
         expect(res.graphPrefixes).toEqual([
           `did:dkg:context-graph:${CG}/_verified_memory/`,
         ]);
@@ -118,40 +94,22 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
   );
 
   it(
-    'verifiedGraph + minTrust ABOVE Endorsed REJECTS — the engine cannot yet prove a ' +
-      'named sub-graph satisfies PartiallyVerified/ConsensusVerified, so silently ' +
-      'reading it would violate spec §14',
+    'verifiedGraph + minTrust above Endorsed is allowed and enforced by trust tags',
     () => {
-      // Codex review on PR #239 originally flagged the "ignore minTrust
-      // when verifiedGraph is set" behaviour as a trust-bypass hole.
-      // Iter-6 refined that: because every `/_verified_memory/<id>`
-      // graph is written only by quorum-verified paths, the implicit
-      // floor on this path is Endorsed. `verifiedGraph + Endorsed`
-      // therefore returns the single named graph (callers who want
-      // SelfAttested still get it, callers who want Endorsed get the
-      // same data), while `PartiallyVerified` / `ConsensusVerified`
-      // remain rejected until Q-1 lands per-graph trust metadata.
-      expect(() =>
-        resolveViewGraphs('verified-memory', CG, {
+      for (const minTrust of [
+        TrustLevel.Endorsed,
+        TrustLevel.PartiallyVerified,
+        TrustLevel.ConsensusVerified,
+      ]) {
+        const res = resolveViewGraphs('verified-memory', CG, {
           verifiedGraph: VM_QUORUM_A,
-          minTrust: TrustLevel.ConsensusVerified,
-        }),
-      ).toThrow(/verifiedGraph cannot be combined with minTrust above Endorsed/);
-      expect(() =>
-        resolveViewGraphs('verified-memory', CG, {
-          verifiedGraph: VM_QUORUM_A,
-          minTrust: TrustLevel.PartiallyVerified,
-        }),
-      ).toThrow(/verifiedGraph cannot be combined with minTrust above Endorsed/);
-      // Endorsed is now the Q-1 ceiling for the exact-graph path and
-      // MUST succeed — the returned graph is the single sub-graph URI.
-      const endorsed = resolveViewGraphs('verified-memory', CG, {
-        verifiedGraph: VM_QUORUM_A,
-        minTrust: TrustLevel.Endorsed,
-      });
-      expect(endorsed.graphs).toEqual([
-        `did:dkg:context-graph:${CG}/_verified_memory/${VM_QUORUM_A}`,
-      ]);
+          minTrust,
+        });
+        expect(res.graphs).toEqual([
+          `did:dkg:context-graph:${CG}/_verified_memory/${VM_QUORUM_A}`,
+        ]);
+        expect(res.graphPrefixes).toEqual([]);
+      }
     },
   );
 
@@ -181,9 +139,8 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
         ).toThrow(/Invalid minTrust/);
       }
       // Every valid TrustLevel (SelfAttested..ConsensusVerified) must
-      // resolve without throwing — per-triple filtering (Q-1) handles
-      // the above-Endorsed tiers downstream at
-      // `DKGQueryEngine.queryWithView` via `injectMinTrustFilter`.
+      // resolve without throwing. `DKGQueryEngine.queryWithView`
+      // enforces trust floors downstream via `injectMinTrustFilter`.
       for (const mt of [
         TrustLevel.SelfAttested,
         TrustLevel.Endorsed,
@@ -208,16 +165,9 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
       // engine-level normalisation `options.minTrust ?? options._minTrust`
       // MUST forward the legacy form through.
       //
-      // To prove the alias is actually honoured (not silently dropped)
-      // we rely on the graph-scope contract from `resolveViewGraphs`:
-      //   - `minTrust === undefined` (or SelfAttested) keeps the root
-      //     data graph in the resolution;
-      //   - `minTrust > SelfAttested` drops the root graph.
-      // We probe for the presence of the root graph by inserting a
-      // single root-graph quad and running a SELECT; if the alias is
-      // silently dropped the root graph stays in scope and the result
-      // carries at least one binding, otherwise the binding is
-      // filtered out at the graph-resolution layer.
+      // We probe with an untagged root-graph quad. If `_minTrust` is
+      // silently dropped, the row remains visible; if it is honoured,
+      // the trust metadata filter removes it.
       const { OxigraphStore } = await import('@origintrail-official/dkg-storage');
       const { DKGQueryEngine } = await import('@origintrail-official/dkg-query');
       const store = new OxigraphStore();
@@ -234,8 +184,8 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
       const probeSparql = 'SELECT ?s WHERE { ?s ?p ?o }';
 
       // `_minTrust=Endorsed` via the legacy key alone — the alias
-      // MUST propagate to `resolveViewGraphs`, which drops the root
-      // data graph. Result: the probe quad is no longer visible.
+      // MUST propagate to the trust metadata filter. Result: the
+      // untagged probe quad is no longer visible.
       const aliased = await engine.query(probeSparql, {
         contextGraphId: CG,
         view: 'verified-memory',
@@ -253,10 +203,9 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
       expect(unconstrained.bindings.length).toBeGreaterThan(0);
 
       // Explicit `minTrust` wins over `_minTrust`. With
-      // `minTrust: SelfAttested` the root graph stays in scope even
-      // when `_minTrust: Endorsed` would drop it, so the probe quad
-      // surfaces again — rules out the "alias overrides explicit
-      // field" bug.
+      // `minTrust: SelfAttested` no trust filter is applied, so the
+      // probe quad surfaces again and rules out the "alias overrides
+      // explicit field" bug.
       const precedence = await engine.query(probeSparql, {
         contextGraphId: CG,
         view: 'verified-memory',
@@ -291,9 +240,8 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
       // `DKGAgent.query` collapses `opts.minTrust ?? opts._minTrust`
       // before calling `engine.query`, so by the time the engine sees
       // it, only `minTrust` is set. The engine must honour that
-      // contract and apply the graph-scope resolution — specifically
-      // above-SelfAttested drops the root data graph, so the probe
-      // quad (which lives in the root graph) must not be returned.
+      // contract and apply the trust metadata filter; the untagged
+      // root-graph quad must not be returned.
       const aboveEndorsed = await engine.query(
         'SELECT ?s WHERE { ?s ?p ?o }',
         {
@@ -348,17 +296,13 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
   );
 
   it(
-    'verifiedGraph + minTrust=Endorsed is ALLOWED on the exact-graph path ' +
-      '(Codex PR #239 iter-6: the previous iteration rejected any minTrust above ' +
-      'SelfAttested on this path, but every `/_verified_memory/<id>` graph is ' +
-      'populated only by quorum-verified writes so it already satisfies Endorsed)',
+    'verifiedGraph + minTrust is ALLOWED on the exact-graph path and enforced by trust tags',
     async () => {
       const { OxigraphStore } = await import('@origintrail-official/dkg-storage');
       const { DKGQueryEngine } = await import('@origintrail-official/dkg-query');
       const store = new OxigraphStore();
       const engine = new DKGQueryEngine(store);
 
-      // Happy path: Endorsed + verifiedGraph → empty result, no throw.
       await expect(
         engine.query('SELECT ?s WHERE { ?s ?p ?o }', {
           contextGraphId: CG,
@@ -368,7 +312,6 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
         }),
       ).resolves.toBeDefined();
 
-      // Values ABOVE Endorsed must still be rejected (same Q-1 reason).
       await expect(
         engine.query('SELECT ?s WHERE { ?s ?p ?o }', {
           contextGraphId: CG,
@@ -376,19 +319,15 @@ describe('P-13: resolveViewGraphs handles minTrust for verified-memory', () => {
           verifiedGraph: 'some-quorum',
           minTrust: TrustLevel.PartiallyVerified,
         }),
-      ).rejects.toThrow(/cannot be combined with minTrust above Endorsed/);
+      ).resolves.toBeDefined();
     },
   );
 
   it(
-    'zero-graph resolution respects query form ' +
-      '(Codex PR #239 iter-5: returning `{ bindings: [] }` for an ASK/CONSTRUCT ' +
-      'breaks the SPARQL response contract)',
+    'empty trust-filtered results respect query form',
     async () => {
-      // A `verified-memory` query with `minTrust=Endorsed` on a context
-      // graph that has zero `/_verified_memory/*` sub-graphs resolves to
-      // an empty graph set. Each query form must still return a shape
-      // that matches its spec:
+      // A `verified-memory` query with `minTrust=Endorsed` and no matching
+      // trust metadata must still return a shape that matches its query form:
       //   - SELECT  → { bindings: [] }
       //   - ASK     → { bindings: [{ result: 'false' }] }
       //   - CONSTRUCT/DESCRIBE → { bindings: [], quads: [] }

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: [
       'test/trust-metadata.test.ts',
+      'test/storage-ack-roster-and-verify-mofn-extra.test.ts',
       'test/verification-metadata.test.ts',
       'test/verify-collector.test.ts',
       'test/verify-proposal-handler.test.ts',

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [
+      'test/trust-metadata.test.ts',
+      'test/verification-metadata.test.ts',
+      'test/verify-collector.test.ts',
+      'test/verify-proposal-handler.test.ts',
+      'test/views-min-trust-extra.test.ts',
+    ],
+    testTimeout: 60_000,
+    maxWorkers: 1,
+  },
+});

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -8,6 +8,7 @@ import {
   type GetView,
   REMOVED_VIEWS,
   TrustLevel,
+  TRUST_LEVEL_PREDICATE,
 } from '@origintrail-official/dkg-core';
 import {
   validateReadOnlySparql,
@@ -34,13 +35,9 @@ export interface ViewResolution {
  *
  * Spec reference: §12 GET — Declared State Views.
  *
- * Trust-level semantics for `verified-memory` (P-13):
- *   The root content graph `did:dkg:context-graph:{id}` holds chain-confirmed
- *   data at only `TrustLevel.SelfAttested` (on-chain anchoring proves the
- *   publisher signed it, not that a quorum endorsed it). Higher-trust data
- *   lives in per-quorum sub-graphs under `/_verified_memory/{quorum}`.
- *   When `minTrust > SelfAttested`, the root data graph is excluded from
- *   the resolution so low-trust triples cannot leak into a high-trust query.
+ * Trust-level semantics for `verified-memory`: graph scope is not a trust
+ * signal. The root graph and `/_verified_memory/*` graphs are candidates;
+ * `minTrust` is enforced by explicit writer-side `dkg:trustLevel` metadata.
  */
 export function resolveViewGraphs(
   view: GetView,
@@ -49,14 +46,7 @@ export function resolveViewGraphs(
     agentAddress?: string;
     verifiedGraph?: string;
     assertionName?: string;
-    /**
-     * Spec §12/§14 trust-gradient filter (P-13). When set above
-     * `TrustLevel.SelfAttested`, the verified-memory resolution narrows
-     * to anchored quorum sub-graphs (`.../_verified_memory/…`) only —
-     * the root data graph is removed because it can carry mixed-trust
-     * finalized data. Values above `Endorsed` are rejected until
-     * per-graph trust tagging (Q-1) lands; see body for details.
-     */
+    /** Spec §12/§14 trust-gradient filter. Enforced after graph resolution. */
     minTrust?: TrustLevel;
   },
 ): ViewResolution {
@@ -88,9 +78,7 @@ export function resolveViewGraphs(
         graphPrefixes: [],
       };
     case 'verified-memory': {
-      // P-13 review (iter-6): `minTrust` is a verified-memory concept
-      // — it is the only view whose graph resolution is actually
-      // gated by per-graph trust. The earlier iterations ran the
+      // `minTrust` is a verified-memory concept. The earlier iterations ran the
       // numeric/enum validation at the top of `resolveViewGraphs`,
       // but that meant a caller who passes a generic options object
       // (e.g. `{ agentAddress, minTrust }`) across views would get
@@ -117,31 +105,7 @@ export function resolveViewGraphs(
         }
       }
 
-      const requireHighTrust =
-        opts?.minTrust !== undefined && opts.minTrust > TrustLevel.SelfAttested;
       if (opts?.verifiedGraph) {
-        // P-13 review (iter-6): every `/_verified_memory/<id>` graph
-        // is populated only by quorum-verified write paths, so the
-        // floor for those sub-graphs is implicitly `Endorsed`. A
-        // caller pinning an exact `verifiedGraph` + `minTrust=Endorsed`
-        // therefore asks for the same data the engine would union
-        // from the prefix and must succeed. Only values ABOVE
-        // `Endorsed` need to be rejected — the engine still cannot
-        // prove a single named sub-graph satisfies
-        // `PartiallyVerified` / `ConsensusVerified` until per-graph
-        // trust metadata (Q-1) lands.
-        if (opts.minTrust !== undefined && opts.minTrust > TrustLevel.Endorsed) {
-          // Use the exact phrase "cannot be combined with" so the
-          // daemon's `/api/query` error classifier maps this to HTTP
-          // 400 (see packages/cli/src/daemon.ts). Without that
-          // wording the error escapes as a 500.
-          throw new Error(
-            `verified-memory: verifiedGraph cannot be combined with minTrust above Endorsed ` +
-            `(got minTrust=${opts.minTrust}). The engine cannot yet prove a named sub-graph satisfies ` +
-            `PartiallyVerified or ConsensusVerified; drop verifiedGraph to union across all ` +
-            `quorum-verified sub-graphs, or use minTrust=Endorsed to read the specific sub-graph.`,
-          );
-        }
         return {
           graphs: [contextGraphVerifiedMemoryUri(contextGraphId, opts.verifiedGraph)],
           graphPrefixes: [],
@@ -152,28 +116,10 @@ export function resolveViewGraphs(
       // finalization).  Any quorum-specific verified-memory sub-graphs live
       // under `_verified_memory/` and are unioned in as well.
       //
-      // P-13 (graph-scope) + Q-1 (per-triple) working together:
-      //   - Graph-scope (this function): when `minTrust > SelfAttested`
-      //     the root content graph is dropped (via `requireHighTrust`)
-      //     and only `/_verified_memory/<quorum>` sub-graphs survive.
-      //     That sub-graph prefix is populated only by quorum-verified
-      //     write paths, so the floor for those graphs is implicitly
-      //     `Endorsed`.
-      //   - Per-triple (DKGQueryEngine.queryWithView): when
-      //     `minTrust` is set, `injectMinTrustFilter` rewrites the user
-      //     SPARQL so every subject MUST carry an explicit
-      //     `<http://dkg.io/ontology/trustLevel> "N"` literal with
-      //     `N ≥ minTrust`. Subjects without such metadata are
-      //     silently rejected (fail-closed).
-      //
-      // Together this satisfies spec §14 for values above `Endorsed`:
-      // even though the engine cannot yet distinguish a
-      // `PartiallyVerified`-quorum sub-graph from a `ConsensusVerified`
-      // one at the graph level, a caller asking for `ConsensusVerified`
-      // data only ever sees quads whose triples carry the matching
-      // per-triple trust literal, so sub-threshold data cannot leak.
+      // Keep all verified-memory candidate graphs in scope. Trust is
+      // determined only by explicit metadata joined into the query below.
       return {
-        graphs: requireHighTrust ? [] : [contextGraphDataUri(contextGraphId)],
+        graphs: [contextGraphDataUri(contextGraphId)],
         graphPrefixes: [`did:dkg:context-graph:${contextGraphId}/_verified_memory/`],
       };
     }
@@ -329,32 +275,12 @@ export class DKGQueryEngine implements QueryEngine {
     // when we cannot prove the threshold was applied.
     let effectiveSparql = sparql;
     const effectiveMinTrust = options.minTrust ?? options._minTrust;
-    // `SelfAttested` (0) is the floor and means "no per-triple filter
-    // needed". Skip the rewrite at that level so SELECT queries that
-    // predate trust tagging still see every triple — the graph-scope
-    // resolution above keeps the root data graph in scope at
-    // SelfAttested, so the per-triple filter would otherwise reject
-    // every quad that lacks a `dkg:trustLevel` literal (i.e. every
-    // pre-Q-1 quad).
-    //
-    // we ALSO skip the per-triple filter at `Endorsed`. The graph-
-    // scope resolution above already drops the root data graph and
-    // unions only over `<…>/_verified_memory/{quorum}` sub-graphs,
-    // and any quad that landed in `_verified_memory` is by
-    // definition at least `Endorsed` (the on-chain quorum that
-    // promoted it IS the endorsement). Until the publisher / quorum
-    // writers actually emit `dkg:trustLevel` literals (tracked
-    // upstream), the per-triple join would silently turn every
-    // legitimate `minTrust=Endorsed` query into an empty result.
-    // Levels strictly above Endorsed (`PartiallyVerified`,
-    // `ConsensusVerified`) still require the per-triple filter
-    // because graph-scope alone cannot distinguish those tiers from
-    // a basic Endorsed write — a fail-closed empty result there is
-    // the correct behaviour until writers stamp the literal.
+    // `SelfAttested` (0) is the floor and means no trust filter is needed.
+    // Endorsed and above require explicit writer-side trust metadata.
     if (
       view === 'verified-memory' &&
       effectiveMinTrust !== undefined &&
-      effectiveMinTrust > TrustLevel.Endorsed
+      effectiveMinTrust > TrustLevel.SelfAttested
     ) {
       const rewritten = injectMinTrustFilter(sparql, effectiveMinTrust);
       if (!rewritten) {
@@ -399,6 +325,10 @@ export class DKGQueryEngine implements QueryEngine {
     const result = await this.store.query(sparql);
 
     if (result.type === 'bindings') {
+      if (result.bindings.length === 0) {
+        const empty = emptyResultForSparql(sparql);
+        if (empty.quads !== undefined) return empty;
+      }
       return { bindings: result.bindings };
     }
     if (result.type === 'quads') {
@@ -1340,21 +1270,21 @@ function injectMinTrustFilter(sparql: string, minTrust: number): string | null {
   for (const subjectVar of subjectVars) {
     const trustVar = `?__dkgTrust${i++}`;
     extraClauses.push(
-      `${subjectVar} <http://dkg.io/ontology/trustLevel> ${trustVar} . ` +
+      `${subjectVar} <${TRUST_LEVEL_PREDICATE}> ${trustVar} . ` +
         `FILTER(<http://www.w3.org/2001/XMLSchema#integer>(STR(${trustVar})) >= ${minTrust})`,
     );
   }
   for (const subjectIri of subjectIris) {
     const trustVar = `?__dkgTrust${i++}`;
     extraClauses.push(
-      `${subjectIri} <http://dkg.io/ontology/trustLevel> ${trustVar} . ` +
+      `${subjectIri} <${TRUST_LEVEL_PREDICATE}> ${trustVar} . ` +
         `FILTER(<http://www.w3.org/2001/XMLSchema#integer>(STR(${trustVar})) >= ${minTrust})`,
     );
   }
   for (const subjectPfx of subjectPrefixed) {
     const trustVar = `?__dkgTrust${i++}`;
     extraClauses.push(
-      `${subjectPfx} <http://dkg.io/ontology/trustLevel> ${trustVar} . ` +
+      `${subjectPfx} <${TRUST_LEVEL_PREDICATE}> ${trustVar} . ` +
         `FILTER(<http://www.w3.org/2001/XMLSchema#integer>(STR(${trustVar})) >= ${minTrust})`,
     );
   }

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -38,51 +38,11 @@ export interface QueryOptions {
    */
   excludeGraphPrefixes?: string[];
   /**
-   * Graph-level trust scope for a `verified-memory` view. This is **not**
-   * a per-triple filter — it selects which *named graphs* are unioned
-   * into the query, relying on the invariant that each named graph is
-   * populated by a single trust-tier write path:
-   *
-   *   - root `did:dkg:context-graph:{id}` — chain-confirmed, SelfAttested.
-   *   - `did:dkg:context-graph:{id}/_verified_memory/{quorum}` —
-   *     populated by the quorum's verified-memory write path; the quorum
-   *     identifier itself is the trust provenance.
-   *
-   * Semantics (PR #239 Codex iter-5):
-   *   - undefined or `SelfAttested`: union root + `/_verified_memory/*`.
-   *   - `Endorsed` (1): drop the root data graph, keep only
-   *     `/_verified_memory/*` sub-graphs. This prevents SelfAttested
-   *     chain data from bleeding into a quorum-verified query.
-   *   - `PartiallyVerified` (2) / `ConsensusVerified` (3): **rejected**
-   *     with a client error until Q-1 lands per-graph trust tagging.
-   *     The engine cannot currently prove that a given
-   *     `/_verified_memory/<quorum>` sub-graph satisfies these higher
-   *     tiers, and silently downgrading to `Endorsed` would leak
-   *     merely-endorsed data into a caller asking for stronger trust.
-   *     Callers must drop `minTrust` to `Endorsed` (1), or use the
-   *     exact-graph path below and accept `Endorsed` as the ceiling.
-   *
-   * View gating (iter-6): `minTrust` is **ignored** on the
-   * `working-memory` and `shared-working-memory` views — those views
-   * have their own access-control story and do not union across trust
-   * tiers. The validation therefore only fires on `verified-memory`
-   * queries, so callers who reuse a generic options object across
-   * views are not forced to strip the field on every call.
-   *
-   * Exact-graph path (iter-6): when `verifiedGraph` is set, the engine
-   * targets the single `_verified_memory/<id>` sub-graph. Because
-   * every graph in that prefix is populated only by quorum-verified
-   * write paths (implicit `Endorsed` floor), `minTrust=Endorsed` is
-   * honoured on this path. Values **above** `Endorsed` are still
-   * rejected for the same Q-1 reason as the union path.
-   *
-   * Known gap (tracked as Q-1): surviving `/_verified_memory/*` graphs
-   * are not filtered per-triple against a `dkg:trustLevel` predicate.
-   * If upstream writers respect the one-trust-tier-per-graph invariant
-   * this is safe; if a future writer stamps mixed-trust triples into a
-   * single sub-graph the graph-scope filter will not catch it. Do not
-   * rely on `minTrust` alone for a compliance-grade trust guarantee
-   * until Q-1 lands.
+   * Per-subject trust floor for `verified-memory`. Values above
+   * `SelfAttested` require every matched subject to carry an explicit
+   * `http://dkg.io/ontology/trustLevel` literal at or above `minTrust`.
+   * The root graph and `/_verified_memory/*` graphs remain candidates;
+   * trust is not inferred from graph scope. Ignored on other views.
    */
   minTrust?: TrustLevel;
   /**

--- a/packages/query/test/query-extra.test.ts
+++ b/packages/query/test/query-extra.test.ts
@@ -3,17 +3,10 @@
  *
  * Findings covered (see .test-audit/
  *
- *   Q-1  PROD-BUG  `QueryOptions.minTrust` on `verified-memory` view is a
- *                  *graph-scope* filter, not a per-triple filter. P-13
- *                  wired the graph-scope semantics end-to-end (drop root
- *                  when `minTrust > SelfAttested`), but the spec §14
- *                  trust-gradient guarantee also implies per-triple
- *                  filtering against `dkg:trustLevel` inside the
- *                  `/_verified_memory/*` sub-graphs. Test inserts mixed-
- *                  trust quads in a single sub-graph and asserts the
- *                  engine only returns HIGH-trust quads — the test
- *                  STAYS RED until Q-1 lands. P-13 (graph-scope) is
- *                  covered separately by publisher/test/views-min-trust-*.
+ *   Q-1  `QueryOptions.minTrust` on `verified-memory` view is enforced
+ *        with writer-side `dkg:trustLevel` metadata, not graph-scope trust
+ *        alone. Tests insert mixed-trust quads and assert the engine only
+ *        returns entities that meet the requested trust floor.
  *
  *   Q-2  SPEC-GAP  `QueryHandler.executeSparql` only wires `result.bindings`
  *                  into the response JSON. CONSTRUCT / DESCRIBE queries return
@@ -70,25 +63,11 @@ function quad(s: string, p: string, o: string, g: string): Quad {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Q-1  per-triple minTrust filtering — PROD-BUG (stays RED until engine honours
-//      `dkg:trustLevel` at the quad level inside /_verified_memory/*)
+// Q-1  writer-side minTrust filtering via `dkg:trustLevel`
 // ─────────────────────────────────────────────────────────────────────────────
-describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () => {
-  // P-13 closed the graph-scope half of minTrust (root is dropped when
-  // minTrust > SelfAttested). Q-1 is the remaining per-triple half: if a
-  // writer ever stamps mixed-trust quads into a single sub-graph, the
-  // graph-scope filter cannot catch it. This test pins that gap.
-  //
-  // the per-triple filter is now
-  // skipped at `Endorsed` because no production writer emits
-  // `dkg:trustLevel` literals — applying the join at Endorsed would
-  // collapse legitimate queries against real data. The per-triple
-  // filter still runs at `PartiallyVerified` / `ConsensusVerified`,
-  // where graph-scope alone cannot distinguish the tiers, and where
-  // a fail-closed empty result on un-tagged data is the correct
-  // behaviour. This test now exercises the per-triple filter at
-  // `ConsensusVerified` (the highest tier) — that path is what
-  // production callers asking for the strictest tier will hit.
+describe('[Q-1] DKGQueryEngine minTrust uses writer-side trust metadata', () => {
+  // All trust floors above SelfAttested require explicit writer-side
+  // trust metadata. Untagged production data fails closed for these queries.
   it('filters out sub-threshold trust quads WITHIN a verified-memory sub-graph at ConsensusVerified (Q-1)', async () => {
     const store = new OxigraphStore();
     const engine = new DKGQueryEngine(store);
@@ -104,7 +83,7 @@ describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () =>
       quad('urn:low', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.Endorsed}"`, mixedGraph),
       quad('urn:high', 'http://schema.org/name', '"HighTrust"', mixedGraph),
       quad('urn:high', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, mixedGraph),
-      // Root-level quad — P-13 graph-scope filter already excludes this.
+      // Untagged root-level quad — writer-side trust filtering excludes this.
       quad('urn:unknown', 'http://schema.org/name', '"UnknownTrust"', rootGraph),
     ]);
 
@@ -123,29 +102,18 @@ describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () =>
     expect(names).toEqual(['"HighTrust"']);
   });
 
-  // explicit pin that the new
-  // `> Endorsed` threshold leaves Endorsed queries reading from
-  // /_verified_memory/* sub-graphs without applying the per-triple
-  // join. Real production data lands in those sub-graphs WITHOUT a
-  // `dkg:trustLevel` literal (writer-side trust tagging is tracked
-  // upstream), so the previously-applied per-triple filter would
-  // collapse every Endorsed query to `[]`. This test exercises that
-  // exact production shape: data in /_verified_memory/{quorum}
-  // with NO trustLevel triples must still be visible at Endorsed.
-  it('Endorsed reads /_verified_memory/* WITHOUT requiring per-triple trustLevel (graph-scope is the trust gate)', async () => {
+  it('Endorsed uses writer-side trustLevel metadata instead of graph-scope trust', async () => {
     const store = new OxigraphStore();
     const engine = new DKGQueryEngine(store);
 
     const subGraph = contextGraphVerifiedMemoryUri(CG, 'no-trust-metadata-quorum');
     const rootGraph = contextGraphDataUri(CG);
 
-    // Production-shaped data: quads in a quorum sub-graph with NO
-    // trustLevel literals (matches today's publisher write path).
     await store.insert([
       quad('urn:prod1', 'http://schema.org/name', '"Production1"', subGraph),
       quad('urn:prod2', 'http://schema.org/name', '"Production2"', subGraph),
-      // Root-graph data must NOT leak into Endorsed (P-13 graph-scope filter).
       quad('urn:root', 'http://schema.org/name', '"RootDataGraph"', rootGraph),
+      quad('urn:root', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.Endorsed}"`, rootGraph),
     ]);
 
     const result = await engine.query(
@@ -158,9 +126,7 @@ describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () =>
     );
 
     const names = result.bindings.map((b) => b['name']).sort();
-    // BOTH quorum-sub-graph quads survive (no per-triple filter at
-    // Endorsed) and the root-graph quad is excluded by P-13.
-    expect(names).toEqual(['"Production1"', '"Production2"']);
+    expect(names).toEqual(['"RootDataGraph"']);
   });
 
   // pin that ConsensusVerified
@@ -377,10 +343,10 @@ describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () =>
     const engine = new DKGQueryEngine(store);
     const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
     await store.insert([
-      quad('urn:low', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.Unverified}"`, consensus),
+      quad('urn:low', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.SelfAttested}"`, consensus),
       quad('urn:low', 'http://example.org/name', '"Bob"', consensus),
     ]);
-    // ex:low has Unverified < ConsensusVerified, so the rewrite MUST
+    // ex:low has SelfAttested < ConsensusVerified, so the rewrite MUST
     // filter it out — not silently drop `_minTrust` and return "Bob".
     const sparql = [
       'PREFIX ex: <urn:>',
@@ -456,7 +422,7 @@ describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () =>
     const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
     await store.insert([
       quad('urn:hi', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
-      quad('urn:lo', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.Unverified}"`, consensus),
+      quad('urn:lo', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.SelfAttested}"`, consensus),
       quad('urn:hi', 'http://example.org/label', '"H"', consensus),
       quad('urn:lo', 'http://example.org/label', '"L"', consensus),
     ]);
@@ -470,7 +436,7 @@ describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () =>
       sparql,
       { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
     );
-    // `urn:lo` is Unverified — it must be filtered out, not silently
+    // `urn:lo` is SelfAttested — it must be filtered out, not silently
     // returned because the rewriter bailed on VALUES.
     expect(result.bindings.map((b) => b['l'])).toEqual(['"H"']);
   });
@@ -545,7 +511,7 @@ describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () =>
     const engine = new DKGQueryEngine(store);
     const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
     await store.insert([
-      quad('urn:lo', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.Unverified}"`, consensus),
+      quad('urn:lo', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.SelfAttested}"`, consensus),
       quad('urn:lo', 'http://schema.org/score', '"99"^^<http://www.w3.org/2001/XMLSchema#integer>', consensus),
     ]);
     const sparql = [


### PR DESCRIPTION
- ENDORSE/PUBLISH now stamp trust on the full KA subject closure, including skolemized children, not only roots.
- VERIFY now returns explicit verified | partial | no_quorum status.
- Partial trust elevation only uses identity-resolved context-graph participant approvals.
- /api/verify only emits VM refresh events for real verified/quorum results; partial metadata emits WM trust metadata instead.
- CLI no longer prints “Verified batch” for partial/no-quorum outcomes.
- Publisher/agent/CLI unit configs now cover the requested focused files without pulling broad Hardhat suites by default.