### PR TITLE
feat(core): bump Core Node relay capacity + TTLs + add operator knob (libp2p reachability hardening PR1/3)

### DIFF
--- a/docs/p2p-resilience.md
+++ b/docs/p2p-resilience.md
@@ -14,8 +14,20 @@ Two common DKG deployments sit behind home/office NAT:
 These nodes depend on the testnet **circuit relay** peers to be dialable by
 anyone else. The relay path is fragile by construction:
 
-1. A reservation must be held on the relay (5-minute TTL in our config,
-   `defaultDurationLimit: 5 * 60 * 1000` in `packages/core/src/node.ts`).
+1. A reservation must be held on the relay. Two distinct knobs from
+   libp2p's `circuitRelayServer({ reservations: ... })`, both set
+   explicitly in `packages/core/src/node.ts`:
+   - `reservationTtl` (libp2p `ServerReservationStoreInit.reservationTtl`,
+     `RELAY_RESERVATION_TTL_MS = 2h`) — how long a reservation lasts
+     before the reservee must renew. This is the actual reservation
+     expiry.
+   - `defaultDurationLimit`
+     (`ServerReservationStoreInit.defaultDurationLimit`,
+     `RELAY_DEFAULT_DURATION_LIMIT_MS = 30 min`) — the maximum lifetime
+     of a single relayed *circuit* (per-stream cap). Bumped from
+     libp2p's effectively-5-minute default so chat-style intermittent
+     traffic doesn't tear individual circuits down underneath the
+     application during quiet windows.
 2. The TCP connection to the relay must stay alive.
 3. Both sides must have a relay in common with live reservations, or one
    side must be directly dialable.

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -767,6 +767,17 @@ export interface DKGAgentConfig {
   /** Node deployment tier: 'core' (cloud, relay) or 'edge' (personal, behind NAT). Default: 'edge'. */
   nodeRole?: 'core' | 'edge';
   /**
+   * Core Node relay-server capacity tuning. Forwarded straight into
+   * `DKGNodeConfig.relayServerCapacity` — sets the maximum number of
+   * simultaneous circuit-relay v2 reservations this node will hold.
+   * HOP/STOP stream caps and `connectionManager.maxConnections` are
+   * derived at a 1:2 ratio. Default 1024 when omitted on a Core Node;
+   * ignored on edge nodes (with a startup warning). Invalid values
+   * fall back to the default. See `packages/core/src/types.ts` for
+   * the full rationale + ulimit -n requirements.
+   */
+  relayServerCapacity?: number;
+  /**
    * Path to the V10 Random Sampling prover write-ahead log. Core
    * nodes only; ignored on edge. When omitted, an in-memory WAL is
    * used (loses crash-recovery context on restart). Production
@@ -1329,6 +1340,7 @@ export class DKGAgent {
       enableMdns: !config.bootstrapPeers?.length && !config.relayPeers?.length,
       privateKey: keypair.secretKey,
       nodeRole,
+      relayServerCapacity: config.relayServerCapacity,
     };
 
     const node = new DKGNode(nodeConfig);

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -46,6 +46,55 @@ dkg shared-memory publish my-project
 dkg query my-project -q "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10"
 ```
 
+## Running a Core Node (relay operator)
+
+A Core Node is a publicly-reachable host that runs a libp2p circuit-relay v2
+server, providing NAT traversal for the (much larger) population of edge
+agents. Edge nodes don't need any of the configuration in this section — only
+operators of relay-serving Core Nodes do.
+
+### Capacity tuning
+
+Default capacity is **1024 simultaneous reservations**. From that single knob
+we derive all the other relay-related libp2p limits at a 1:2 ratio (HOP/STOP
+stream caps, `connectionManager.maxConnections`) so capacity=1024 → 2048
+streams + 2048 max conns. Override via the `relayServerCapacity` field in
+`DKGNodeConfig` (config.json) when you want to scale up for big iron or down
+for resource-constrained hosts (a Raspberry Pi runs comfortably at 256-512).
+
+```jsonc
+{
+  "nodeRole": "core",            // enables the relay server
+  "relayServerCapacity": 1024,   // default; bump or shrink as needed
+  // ...
+}
+```
+
+### Required `ulimit -n`
+
+Each open libp2p connection costs one file descriptor. With the default
+capacity and a 1:2 multiplier, the daemon needs **at least `max(4096,
+maxConnections × 2)` file descriptors** of headroom (the 4096 floor accounts
+for SQLite, log files, the daemon HTTP server, and other non-libp2p fd
+consumers). For default capacity that means `ulimit -n ≥ 4096`.
+
+The daemon checks the host's `RLIMIT_NOFILE` at startup and emits an
+operator-facing warning if the soft limit is below the recommended value.
+**Without the bump, the kernel will reject new `socket()` calls with
+`EMFILE` once the daemon hits the host limit, manifesting as silent peer
+rejections rather than a crash** — fix it preemptively:
+
+| Deployment shape | How to bump |
+|---|---|
+| Shell session | `ulimit -n 4096` before `dkg start` |
+| systemd unit | `LimitNOFILE=4096` in the `[Service]` block |
+| Docker | `--ulimit nofile=4096:4096` |
+| Kubernetes | `securityContext.sysctls` or container-runtime override |
+
+To verify the live daemon's effective limit, look for the startup log line
+`[dkg-core] relay server: ulimit -n soft=<N> >= recommended <M>, ok` (or the
+WARN equivalent if the host needs tuning).
+
 ## Commands
 
 | Command | Description |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,9 +74,16 @@ for resource-constrained hosts (a Raspberry Pi runs comfortably at 256-512).
 
 Each open libp2p connection costs one file descriptor. With the default
 capacity and a 1:2 multiplier, the daemon needs **at least `max(4096,
-maxConnections × 2)` file descriptors** of headroom (the 4096 floor accounts
-for SQLite, log files, the daemon HTTP server, and other non-libp2p fd
-consumers). For default capacity that means `ulimit -n ≥ 4096`.
+maxConnections × 2)` file descriptors** (equivalently `max(4096, capacity × 4)`
+since `maxConnections = capacity × 2`). The 4096 floor accounts for SQLite,
+log files, the daemon HTTP server, and other non-libp2p fd consumers.
+
+| `relayServerCapacity` | derived `maxConnections` | recommended `ulimit -n` |
+|---|---|---|
+| 256  (Pi-class)        | 512  | 4096 (floor wins) |
+| 1024 (default)         | 2048 | 4096 (floor wins) |
+| 2048                   | 4096 | 8192 |
+| 4096 (big iron)        | 8192 | 16384 |
 
 The daemon checks the host's `RLIMIT_NOFILE` at startup and emits an
 operator-facing warning if the soft limit is below the recommended value.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -254,6 +254,21 @@ export interface DkgConfig {
   apiHost?: string;
   listenPort: number;
   nodeRole: 'core' | 'edge';
+  /**
+   * Core Node relay-server capacity tuning. Forwarded into the libp2p
+   * relay configuration via `DKGNodeConfig.relayServerCapacity`. Sets
+   * the maximum number of simultaneous circuit-relay v2 reservations
+   * this node will hold; HOP/STOP stream caps and
+   * `connectionManager.maxConnections` are derived at a 1:2 ratio
+   * (capacity=1024 → 2048 streams + 2048 max conns).
+   *
+   * Default: 1024 when omitted on a Core Node. Ignored on edge nodes
+   * (with a startup warning if set there). Invalid values (0,
+   * negative, fractional, NaN) fall back to the default with a
+   * warning. See packages/core/src/types.ts and packages/cli/README.md
+   * for the full rationale + ulimit -n requirements.
+   */
+  relayServerCapacity?: number;
   /** Public multiaddrs to announce (for VPS/cloud nodes where the public IP is not on the interface). */
   announceAddresses?: string[];
   /** Bootstrap peer multiaddrs to connect to on startup (for direct peer discovery without relay). */

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -561,6 +561,7 @@ export async function runDaemonInner(
     relayPeers,
     announceAddresses: config.announceAddresses,
     nodeRole: role,
+    relayServerCapacity: config.relayServerCapacity,
     syncContextGraphs: syncContextGraphs,
     storeConfig: config.store ? {
       backend: config.store.backend,

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -219,6 +219,38 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(loaded.localAgentIntegrations?.openclaw?.manifest?.version).toBe('2026.4.12');
     expect(loaded.localAgentIntegrations?.openclaw?.runtime?.status).toBe('ready');
   });
+
+  it('round-trips relayServerCapacity through saveConfig/loadConfig (operator override)', async () => {
+    // PR #524 review (branarakic): the README documents
+    // `relayServerCapacity` as a `config.json` knob, so the CLI
+    // schema must actually persist + restore it. This guards
+    // against regressions where the field gets dropped from the
+    // DkgConfig type or stripped on serialization.
+    await saveConfig({
+      name: 'test-node',
+      apiPort: 9200,
+      listenPort: 0,
+      nodeRole: 'core',
+      relayServerCapacity: 2048,
+    });
+
+    const loaded = await loadConfig();
+    expect(loaded.nodeRole).toBe('core');
+    expect(loaded.relayServerCapacity).toBe(2048);
+  });
+
+  it('omits relayServerCapacity when not set (so DKGNode.start() applies the default)', async () => {
+    await saveConfig({
+      name: 'test-node',
+      apiPort: 9200,
+      listenPort: 0,
+      nodeRole: 'core',
+    });
+
+    const loaded = await loadConfig();
+    expect(loaded.nodeRole).toBe('core');
+    expect(loaded.relayServerCapacity).toBeUndefined();
+  });
 });
 
 describe('resolveChainConfig (field-level merge)', () => {

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -82,14 +82,57 @@ export interface DerivedRelayCaps {
 }
 
 /**
+ * Validate an operator-supplied `relayServerCapacity` value. Capacity comes
+ * from external config (config.json, env, etc.) so this defends against
+ * `0`, negatives, NaN, Infinity, fractional values, non-numbers, and empty
+ * strings — any of which would silently produce invalid limits or libp2p
+ * startup failures (a `0` capacity, for instance, would cap streams /
+ * connections at 0 and brick the relay; a fractional value would propagate
+ * into libp2p's `maxConnections` which expects an integer).
+ *
+ * Returns `null` when the input is unset (so callers can apply their own
+ * default). Returns an `{ ok: false }` verdict with a human-readable
+ * reason for invalid input — the caller (start()) downgrades to the
+ * default and emits an operator-facing warning.
+ */
+export type RelayCapacityValidation =
+  | { ok: true; value: number }
+  | { ok: false; reason: string };
+export function validateRelayServerCapacity(input: unknown): RelayCapacityValidation | null {
+  if (input == null) return null;
+  if (typeof input !== 'number') {
+    return { ok: false, reason: `expected number, got ${typeof input}` };
+  }
+  if (!Number.isFinite(input)) {
+    return { ok: false, reason: `expected finite number, got ${input}` };
+  }
+  if (!Number.isInteger(input)) {
+    return { ok: false, reason: `expected integer, got ${input}` };
+  }
+  if (input < 1) {
+    return { ok: false, reason: `expected >= 1, got ${input}` };
+  }
+  return { ok: true, value: input };
+}
+
+/**
  * Derive the full relay-related cap set from a single capacity value. The
  * 1:2 ratio is intentional: each reservation costs one long-lived control
  * connection, plus circuits going through this relay open additional
  * HOP+STOP streams (multiplexed) and other peers can connect for non-relay
  * reasons (DHT, gossip, direct dials). Doubling the capacity for streams
  * and connections gives realistic headroom without overcommitting.
+ *
+ * Throws on invalid input (non-finite, non-integer, < 1) — `start()`
+ * gates this with `validateRelayServerCapacity()` so the throw is purely
+ * a defensive backstop for direct callers.
  */
 export function deriveRelayCaps(capacity: number): DerivedRelayCaps {
+  if (!Number.isInteger(capacity) || capacity < 1) {
+    throw new TypeError(
+      `deriveRelayCaps: capacity must be a positive integer, got ${capacity}`,
+    );
+  }
   const streamCap = capacity * RELAY_CAPACITY_MULTIPLIER;
   return {
     maxReservations: capacity,
@@ -100,6 +143,15 @@ export function deriveRelayCaps(capacity: number): DerivedRelayCaps {
     maxInboundStopStreams: streamCap,
   };
 }
+
+/**
+ * Severity of a `checkFdLimit` log emission. The "ok" path is
+ * deliberately `info` — emitting it via `console.warn` would make the
+ * level unreliable for operator alerting (every healthy startup would
+ * trip warning-level filters). Only the under-provisioned and
+ * unreadable-limit paths are `warn`.
+ */
+export type FdLimitLogLevel = 'info' | 'warn';
 
 /**
  * Emit an informational/warning log at relay startup about the host's
@@ -113,8 +165,15 @@ export function deriveRelayCaps(capacity: number): DerivedRelayCaps {
  * EMFILE before libp2p hits its own cap, the only signal is opaque
  * "peer rejected" errors in logs. Surfacing the discrepancy at startup
  * gives operators a loud, actionable signal.
+ *
+ * The callback receives `(level, msg)` so consumers can route each
+ * emission to the appropriate logger sink (info vs warn). Mapping the
+ * "ok" line to `info` keeps the warn channel meaningful for alerting.
  */
-export function checkFdLimit(maxConnections: number, log: (msg: string) => void): void {
+export function checkFdLimit(
+  maxConnections: number,
+  log: (level: FdLimitLogLevel, msg: string) => void,
+): void {
   const recommended = Math.max(4096, maxConnections * RELAY_CAPACITY_MULTIPLIER);
   try {
     const report = (process as any).report?.getReport?.();
@@ -123,7 +182,8 @@ export function checkFdLimit(maxConnections: number, log: (msg: string) => void)
     if (typeof soft === 'number') {
       if (soft < recommended) {
         log(
-          `WARN: relay server enabled with maxConnections=${maxConnections}, ` +
+          'warn',
+          `relay server enabled with maxConnections=${maxConnections}, ` +
             `but host ulimit -n soft=${soft} is below the recommended ${recommended} ` +
             `(= max(4096, maxConnections × 2)). The kernel will reject new ` +
             `socket() calls with EMFILE once the daemon hits the limit, ` +
@@ -133,17 +193,20 @@ export function checkFdLimit(maxConnections: number, log: (msg: string) => void)
         );
       } else {
         log(
+          'info',
           `relay server: ulimit -n soft=${soft} >= recommended ${recommended}, ok`,
         );
       }
     } else {
       log(
+        'warn',
         `relay server: could not read host ulimit -n via process.report.userLimits; ` +
           `ensure ulimit -n >= ${recommended} on this host`,
       );
     }
   } catch (err: any) {
     log(
+      'warn',
       `relay server: error reading ulimit -n (${err?.message ?? String(err)}); ` +
         `ensure ulimit -n >= ${recommended} on this host`,
     );
@@ -265,10 +328,29 @@ export class DKGNode {
           `enableRelayServer=${this.config.enableRelayServer}); value ignored`,
       );
     }
-    const relayCapacity = enableRelay
-      ? (this.config.relayServerCapacity ?? DEFAULT_RELAY_SERVER_CAPACITY)
-      : null;
-    const relayCaps = relayCapacity != null ? deriveRelayCaps(relayCapacity) : null;
+    // Validate the operator-supplied capacity (defends against 0,
+    // negatives, NaN, Infinity, fractional values, non-numbers — any
+    // of which would propagate into libp2p's stream/connection caps
+    // and produce invalid limits or startup failures, per Codex
+    // tier-1 finding on PR #524). Invalid values fall back to the
+    // documented default with a loud warning so the misconfig is
+    // visible.
+    let effectiveRelayCapacity: number | null = null;
+    if (enableRelay) {
+      const verdict = validateRelayServerCapacity(this.config.relayServerCapacity);
+      if (verdict == null) {
+        effectiveRelayCapacity = DEFAULT_RELAY_SERVER_CAPACITY;
+      } else if (verdict.ok) {
+        effectiveRelayCapacity = verdict.value;
+      } else {
+        console.warn(
+          `[dkg-core] relayServerCapacity=${String(this.config.relayServerCapacity)} ` +
+            `is invalid (${verdict.reason}); falling back to default ${DEFAULT_RELAY_SERVER_CAPACITY}`,
+        );
+        effectiveRelayCapacity = DEFAULT_RELAY_SERVER_CAPACITY;
+      }
+    }
+    const relayCaps = effectiveRelayCapacity != null ? deriveRelayCaps(effectiveRelayCapacity) : null;
 
     // TCP keepAlive helps prevent idle relay connections from being dropped by
     // middleboxes or remote timeouts (common cause of ECONNRESET).
@@ -372,7 +454,16 @@ export class DKGNode {
           defaultDataLimit: BigInt(1 << 24),
         },
       });
-      checkFdLimit(relayCaps.maxConnections, (msg) => console.warn(`[dkg-core] ${msg}`));
+      // Route the ulimit log emission to the appropriate console sink
+      // by level. The "ok" line is purely informational; only the
+      // under-provisioned and unreadable-limit paths warrant warn.
+      checkFdLimit(relayCaps.maxConnections, (level, msg) => {
+        if (level === 'warn') {
+          console.warn(`[dkg-core] ${msg}`);
+        } else {
+          console.info(`[dkg-core] ${msg}`);
+        }
+      });
     }
 
     const listenAddrs = [

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -41,6 +41,115 @@ const RELAY_REDIAL_DELAY_MS = 1_500;
  */
 const RELAY_RESERVATION_GRACE_MS = 15_000;
 
+/**
+ * Default relay server capacity — the number of simultaneous circuit-relay v2
+ * reservations a Core Node will hold. All other relay-related caps (HOP/STOP
+ * stream limits, connectionManager.maxConnections) derive from this at a 1:2
+ * ratio so capacity=1024 → 2048 stream caps + 2048 max conns.
+ *
+ * Bumped from the previous hardcoded 256 (libp2p's stock default for the
+ * relay-v2 server is even lower — 15) which capped a single Core Node at
+ * ~256 concurrent edge agents. That was below the natural hundreds-to-
+ * thousands-of-agents trajectory the network is designed for; PR #510's
+ * agent-debug-chat exercised this directly and showed the cap was already
+ * a meaningful ceiling at ~5 active edges. See operator docs for the
+ * `ulimit -n` requirement.
+ */
+export const DEFAULT_RELAY_SERVER_CAPACITY = 1024;
+/** Multiplier for derived stream + connection caps (capacity × 2). */
+export const RELAY_CAPACITY_MULTIPLIER = 2;
+/**
+ * Per-circuit duration limit. Bumped from libp2p's 5-minute default to 30
+ * minutes so chat-style intermittent traffic (5-15 minute silent gaps are
+ * normal) doesn't tear circuits down underneath the application — this was
+ * the proximate cause of the May 2026 NO_RESERVATION blackout pair (Miles
+ * ↔ Lex) that motivated PRs #517, #521, and this one. Reservation TTL
+ * itself stays at the libp2p default (2h) but is set explicitly below for
+ * operator visibility.
+ */
+export const RELAY_DEFAULT_DURATION_LIMIT_MS = 30 * 60 * 1000;
+export const RELAY_RESERVATION_TTL_MS = 2 * 60 * 60 * 1000;
+/** maxConnections for nodes that don't run a relay server (edge default). */
+export const EDGE_NODE_MAX_CONNECTIONS = 500;
+
+export interface DerivedRelayCaps {
+  maxReservations: number;
+  maxConnections: number;
+  maxInboundHopStreams: number;
+  maxOutboundHopStreams: number;
+  maxOutboundStopStreams: number;
+  maxInboundStopStreams: number;
+}
+
+/**
+ * Derive the full relay-related cap set from a single capacity value. The
+ * 1:2 ratio is intentional: each reservation costs one long-lived control
+ * connection, plus circuits going through this relay open additional
+ * HOP+STOP streams (multiplexed) and other peers can connect for non-relay
+ * reasons (DHT, gossip, direct dials). Doubling the capacity for streams
+ * and connections gives realistic headroom without overcommitting.
+ */
+export function deriveRelayCaps(capacity: number): DerivedRelayCaps {
+  const streamCap = capacity * RELAY_CAPACITY_MULTIPLIER;
+  return {
+    maxReservations: capacity,
+    maxConnections: streamCap,
+    maxInboundHopStreams: streamCap,
+    maxOutboundHopStreams: streamCap,
+    maxOutboundStopStreams: streamCap,
+    maxInboundStopStreams: streamCap,
+  };
+}
+
+/**
+ * Emit an informational/warning log at relay startup about the host's
+ * `ulimit -n` (RLIMIT_NOFILE) versus what the configured maxConnections
+ * actually needs. We can read this losslessly from
+ * `process.report.getReport().userLimits.open_files` on POSIX (libp2p
+ * Core Nodes are POSIX-only in practice).
+ *
+ * Why this matters: libp2p's maxConnections is an upper bound libp2p
+ * tracks internally; if the kernel rejects the underlying socket() with
+ * EMFILE before libp2p hits its own cap, the only signal is opaque
+ * "peer rejected" errors in logs. Surfacing the discrepancy at startup
+ * gives operators a loud, actionable signal.
+ */
+export function checkFdLimit(maxConnections: number, log: (msg: string) => void): void {
+  const recommended = Math.max(4096, maxConnections * RELAY_CAPACITY_MULTIPLIER);
+  try {
+    const report = (process as any).report?.getReport?.();
+    const openFiles = report?.userLimits?.open_files;
+    const soft = openFiles?.soft;
+    if (typeof soft === 'number') {
+      if (soft < recommended) {
+        log(
+          `WARN: relay server enabled with maxConnections=${maxConnections}, ` +
+            `but host ulimit -n soft=${soft} is below the recommended ${recommended} ` +
+            `(= max(4096, maxConnections × 2)). The kernel will reject new ` +
+            `socket() calls with EMFILE once the daemon hits the limit, ` +
+            `manifesting as silent peer rejections. Bump with ` +
+            `'ulimit -n ${recommended}' (shell), 'LimitNOFILE=${recommended}' (systemd unit), ` +
+            `or '--ulimit nofile=${recommended}:${recommended}' (Docker).`,
+        );
+      } else {
+        log(
+          `relay server: ulimit -n soft=${soft} >= recommended ${recommended}, ok`,
+        );
+      }
+    } else {
+      log(
+        `relay server: could not read host ulimit -n via process.report.userLimits; ` +
+          `ensure ulimit -n >= ${recommended} on this host`,
+      );
+    }
+  } catch (err: any) {
+    log(
+      `relay server: error reading ulimit -n (${err?.message ?? String(err)}); ` +
+        `ensure ulimit -n >= ${recommended} on this host`,
+    );
+  }
+}
+
 interface RelayTarget {
   peerId: ReturnType<typeof peerIdFromString>;
   addr: any;
@@ -139,16 +248,47 @@ export class DKGNode {
       peerDiscovery.push(mdns());
     }
 
+    const isCore = this.config.nodeRole === 'core';
+    const enableRelay = this.config.enableRelayServer ?? isCore;
+
+    // Relay-server capacity tuning. When relay is enabled, derive HOP/STOP
+    // stream caps and the connectionManager.maxConnections ceiling from
+    // the operator-configured (or default) capacity. Edge nodes that
+    // don't run a relay server keep the legacy 500-connection ceiling and
+    // the upstream libp2p stream defaults — the bumped caps carry no
+    // benefit there and we don't want to inflate the blast radius of
+    // this change beyond Core Nodes.
+    if (this.config.relayServerCapacity != null && !enableRelay) {
+      console.warn(
+        `[dkg-core] relayServerCapacity=${this.config.relayServerCapacity} ` +
+          `set but relay server is not enabled (nodeRole=${this.config.nodeRole ?? 'edge'}, ` +
+          `enableRelayServer=${this.config.enableRelayServer}); value ignored`,
+      );
+    }
+    const relayCapacity = enableRelay
+      ? (this.config.relayServerCapacity ?? DEFAULT_RELAY_SERVER_CAPACITY)
+      : null;
+    const relayCaps = relayCapacity != null ? deriveRelayCaps(relayCapacity) : null;
+
     // TCP keepAlive helps prevent idle relay connections from being dropped by
     // middleboxes or remote timeouts (common cause of ECONNRESET).
     const transports: any[] = [
       tcp({ dialOpts: { keepAlive: true } }),
       webSockets(),
-      circuitRelayTransport(),
+      // STOP stream caps default to 300 in libp2p; on a Core Node holding
+      // 1024+ reservations that's a lower ceiling than maxReservations
+      // implies. Bump the transport-side caps to match the server-side
+      // capacity. Edge nodes keep the upstream defaults (passing
+      // undefined here is the same as omitting the field).
+      circuitRelayTransport(
+        relayCaps
+          ? {
+              maxInboundStopStreams: relayCaps.maxInboundStopStreams,
+              maxOutboundStopStreams: relayCaps.maxOutboundStopStreams,
+            }
+          : undefined,
+      ),
     ];
-
-    const isCore = this.config.nodeRole === 'core';
-    const enableRelay = this.config.enableRelayServer ?? isCore;
 
     // Nodes that already know their NAT status skip autoNAT probing:
     // - relayPeers set → agent behind NAT (knows it needs relay)
@@ -210,14 +350,29 @@ export class DKGNode {
       services.autoNAT = autoNAT();
     }
 
-    if (enableRelay) {
+    if (enableRelay && relayCaps) {
       services.relay = circuitRelayServer({
+        // Bumped from the libp2p default (no cap → unlimited but
+        // bottlenecked by maxOutboundStopStreams=300) to the derived
+        // capacity-scaled value so a Core Node can actually serve N
+        // simultaneous active circuits when N reservations are held.
+        maxInboundHopStreams: relayCaps.maxInboundHopStreams,
+        maxOutboundHopStreams: relayCaps.maxOutboundHopStreams,
+        maxOutboundStopStreams: relayCaps.maxOutboundStopStreams,
         reservations: {
-          maxReservations: 256,
-          defaultDurationLimit: 5 * 60 * 1000,
+          maxReservations: relayCaps.maxReservations,
+          // Per-circuit duration; bumped 5min → 30min so chat-style
+          // intermittent traffic doesn't tear circuits down underneath
+          // the application during quiet windows.
+          defaultDurationLimit: RELAY_DEFAULT_DURATION_LIMIT_MS,
+          // Reservation TTL set explicitly (matches libp2p default of
+          // 2h) so operators tuning relay behaviour see the value
+          // here instead of having to grep upstream.
+          reservationTtl: RELAY_RESERVATION_TTL_MS,
           defaultDataLimit: BigInt(1 << 24),
         },
       });
+      checkFdLimit(relayCaps.maxConnections, (msg) => console.warn(`[dkg-core] ${msg}`));
     }
 
     const listenAddrs = [
@@ -248,8 +403,11 @@ export class DKGNode {
       services,
       connectionManager: {
         minConnections: 0,
-        // Reserve capacity for relay peers so they are not evicted under load.
-        maxConnections: 500,
+        // Core Nodes scale this with relayServerCapacity (default
+        // capacity=1024 → maxConnections=2048). Edge nodes keep the
+        // legacy 500-connection ceiling — they have no relay-server
+        // pressure and wider headroom adds nothing.
+        maxConnections: relayCaps?.maxConnections ?? EDGE_NODE_MAX_CONNECTIONS,
       },
     } as any);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -45,6 +45,29 @@ export interface DKGNodeConfig {
    * Default: 'edge'.
    */
   nodeRole?: 'core' | 'edge';
+  /**
+   * Single-knob capacity tuning for the Core Node relay server. Sets the
+   * maximum number of simultaneous circuit-relay v2 reservations this
+   * node will hold; HOP/STOP stream caps and the libp2p
+   * connectionManager.maxConnections ceiling are derived from this value
+   * at a 1:2 ratio (so capacity=1024 → 2048 streams + 2048 max conns).
+   *
+   * Default: 1024 (replaces the prior hardcoded 256 cap that bottlenecked
+   * a Core Node at ~256 concurrent edge agents — too low for the
+   * hundreds-to-thousands-of-agents trajectory). Operators can dial down
+   * for resource-constrained hosts (e.g. a Raspberry Pi runs comfortably
+   * at 256-512) or up for big iron.
+   *
+   * IGNORED when this node is not running a relay server (i.e. role !==
+   * 'core' and enableRelayServer is false). The knob will log a warning
+   * if set on an edge node so the misconfig is visible.
+   *
+   * IMPORTANT: bumping this above the host's `ulimit -n` will cause
+   * silent peer rejections (EMFILE on socket()) once the connection
+   * count grows. Recommended host limit: max(4096, capacity × 2). The
+   * daemon emits a startup warning if the soft limit is below this.
+   */
+  relayServerCapacity?: number;
 }
 
 export type ConnectionTransport = 'direct' | 'relayed';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,8 +64,14 @@ export interface DKGNodeConfig {
    *
    * IMPORTANT: bumping this above the host's `ulimit -n` will cause
    * silent peer rejections (EMFILE on socket()) once the connection
-   * count grows. Recommended host limit: max(4096, capacity × 2). The
-   * daemon emits a startup warning if the soft limit is below this.
+   * count grows. Recommended host fd limit: `max(4096, capacity × 4)`
+   * (equivalently `max(4096, maxConnections × 2)` since
+   * `maxConnections = capacity × 2`). The daemon emits a startup
+   * warning if the soft limit is below this.
+   *
+   * Invalid values (0, negative, NaN, fractional, non-numeric) are
+   * rejected at startup and the daemon falls back to the default with
+   * an operator-facing warning.
    */
   relayServerCapacity?: number;
 }

--- a/packages/core/test/relay-capacity.test.ts
+++ b/packages/core/test/relay-capacity.test.ts
@@ -2,19 +2,24 @@
 //
 // Unit tests for the Core Node relay-server capacity tuning helpers
 // landed in `feat/libp2p-relay-capacity-and-ttl` (PR1 of the libp2p
-// reachability hardening series). Two surfaces under test:
+// reachability hardening series). Three surfaces under test:
 //
 //   1. `deriveRelayCaps(capacity)` — the pure 1:2 ratio derivation
 //      that turns the operator-facing `relayServerCapacity` knob into
 //      the full set of HOP/STOP stream caps + connectionManager limit.
+//      Now also asserts the defensive throw path for direct callers.
 //
-//   2. `checkFdLimit(maxConnections, log)` — the startup helper that
+//   2. `validateRelayServerCapacity(input)` — the input-validation
+//      gate that defends against operator config containing 0,
+//      negatives, NaN, Infinity, fractional values, non-numbers, etc.
+//      Added in response to Codex review on PR #524.
+//
+//   3. `checkFdLimit(maxConnections, log)` — the startup helper that
 //      reads the host's RLIMIT_NOFILE via process.report.userLimits
-//      and emits an actionable warning when the soft limit is below
-//      the recommended `max(4096, maxConnections × 2)`. Critical for
-//      operators on systemd / Docker hosts whose default limits are
-//      typically 1024 — silently below what a 1024-reservation Core
-//      Node needs.
+//      and routes log emissions to the appropriate severity level
+//      (info for ok, warn for under-provisioned / unreadable). The
+//      level split also came from PR #524 review — emitting the ok
+//      line at warn level breaks operator alerting downstream.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
@@ -24,6 +29,7 @@ import {
   RELAY_RESERVATION_TTL_MS,
   EDGE_NODE_MAX_CONNECTIONS,
   deriveRelayCaps,
+  validateRelayServerCapacity,
   checkFdLimit,
 } from '../src/node.js';
 
@@ -71,6 +77,59 @@ describe('deriveRelayCaps', () => {
     // bump multiplies across the network's broad install base.
     expect(EDGE_NODE_MAX_CONNECTIONS).toBe(500);
   });
+
+  it('throws on invalid input as a defensive backstop for direct callers', () => {
+    // start() gates this with validateRelayServerCapacity(); the
+    // throw is purely insurance in case some future caller wires
+    // around the validator. Hard fail is preferable to silently
+    // shipping invalid limits into libp2p.
+    expect(() => deriveRelayCaps(0)).toThrow(TypeError);
+    expect(() => deriveRelayCaps(-1)).toThrow(TypeError);
+    expect(() => deriveRelayCaps(1.5)).toThrow(TypeError);
+    expect(() => deriveRelayCaps(NaN)).toThrow(TypeError);
+    expect(() => deriveRelayCaps(Infinity)).toThrow(TypeError);
+  });
+});
+
+describe('validateRelayServerCapacity', () => {
+  it('returns null for unset/undefined input (so callers can apply their own default)', () => {
+    expect(validateRelayServerCapacity(undefined)).toBeNull();
+    expect(validateRelayServerCapacity(null)).toBeNull();
+  });
+
+  it('accepts positive integers', () => {
+    expect(validateRelayServerCapacity(1)).toEqual({ ok: true, value: 1 });
+    expect(validateRelayServerCapacity(256)).toEqual({ ok: true, value: 256 });
+    expect(validateRelayServerCapacity(DEFAULT_RELAY_SERVER_CAPACITY)).toEqual({
+      ok: true,
+      value: DEFAULT_RELAY_SERVER_CAPACITY,
+    });
+    expect(validateRelayServerCapacity(8192)).toEqual({ ok: true, value: 8192 });
+  });
+
+  it('rejects 0 and negatives — would brick the relay or produce garbage limits', () => {
+    expect(validateRelayServerCapacity(0)).toEqual({ ok: false, reason: expect.stringContaining('>= 1') });
+    expect(validateRelayServerCapacity(-1)).toEqual({ ok: false, reason: expect.stringContaining('>= 1') });
+    expect(validateRelayServerCapacity(-1024)).toEqual({ ok: false, reason: expect.stringContaining('>= 1') });
+  });
+
+  it('rejects NaN and Infinity — non-finite values would propagate undefined behaviour', () => {
+    expect(validateRelayServerCapacity(NaN)).toEqual({ ok: false, reason: expect.stringContaining('finite') });
+    expect(validateRelayServerCapacity(Infinity)).toEqual({ ok: false, reason: expect.stringContaining('finite') });
+    expect(validateRelayServerCapacity(-Infinity)).toEqual({ ok: false, reason: expect.stringContaining('finite') });
+  });
+
+  it('rejects fractional values — libp2p expects integer caps', () => {
+    expect(validateRelayServerCapacity(1.5)).toEqual({ ok: false, reason: expect.stringContaining('integer') });
+    expect(validateRelayServerCapacity(1024.0001)).toEqual({ ok: false, reason: expect.stringContaining('integer') });
+  });
+
+  it('rejects non-number types (strings, booleans, objects)', () => {
+    expect(validateRelayServerCapacity('1024' as any)).toEqual({ ok: false, reason: expect.stringContaining('number') });
+    expect(validateRelayServerCapacity(true as any)).toEqual({ ok: false, reason: expect.stringContaining('number') });
+    expect(validateRelayServerCapacity({} as any)).toEqual({ ok: false, reason: expect.stringContaining('number') });
+    expect(validateRelayServerCapacity([] as any)).toEqual({ ok: false, reason: expect.stringContaining('number') });
+  });
 });
 
 describe('checkFdLimit', () => {
@@ -88,14 +147,15 @@ describe('checkFdLimit', () => {
     return vi.spyOn(process.report, 'getReport').mockReturnValue(report);
   }
 
-  it('emits WARN when soft limit is below recommended (= max(4096, maxConnections × 2))', () => {
+  it('emits warn level when soft limit is below recommended (= max(4096, maxConnections × 2))', () => {
     spyOnReport({ userLimits: { open_files: { soft: 1024, hard: 'unlimited' } } });
     const log = vi.fn();
     // maxConnections=2048 → recommended = max(4096, 4096) = 4096; soft=1024 is below.
     checkFdLimit(2048, log);
     expect(log).toHaveBeenCalledTimes(1);
-    const msg = log.mock.calls[0][0] as string;
-    expect(msg).toMatch(/^WARN: relay server enabled/);
+    const [level, msg] = log.mock.calls[0];
+    expect(level).toBe('warn');
+    expect(msg).toMatch(/^relay server enabled/);
     expect(msg).toContain('soft=1024');
     expect(msg).toContain('recommended 4096');
     // Operator-facing remediation hint must surface all three deployment
@@ -105,12 +165,18 @@ describe('checkFdLimit', () => {
     expect(msg).toMatch(/--ulimit nofile=4096:4096/);
   });
 
-  it('emits the ok line when soft limit meets or exceeds the recommended value', () => {
+  it('emits info level (NOT warn) when soft limit meets or exceeds the recommended value', () => {
+    // Codex review on PR #524: emitting the ok line at warn level
+    // would trip operator-facing alerting downstream on every
+    // healthy startup. The level split is the contract being
+    // pinned here.
     spyOnReport({ userLimits: { open_files: { soft: 8192, hard: 'unlimited' } } });
     const log = vi.fn();
     checkFdLimit(2048, log);
     expect(log).toHaveBeenCalledTimes(1);
-    expect(log.mock.calls[0][0]).toMatch(/soft=8192 >= recommended 4096, ok/);
+    const [level, msg] = log.mock.calls[0];
+    expect(level).toBe('info');
+    expect(msg).toMatch(/soft=8192 >= recommended 4096, ok/);
   });
 
   it('uses the 4096 floor when 2 × maxConnections would be smaller', () => {
@@ -122,18 +188,21 @@ describe('checkFdLimit', () => {
     spyOnReport({ userLimits: { open_files: { soft: 1500, hard: 'unlimited' } } });
     const log = vi.fn();
     checkFdLimit(512, log);
-    const msg = log.mock.calls[0][0] as string;
+    const [level, msg] = log.mock.calls[0];
+    expect(level).toBe('warn');
     expect(msg).toContain('recommended 4096');
     expect(msg).not.toContain('recommended 1024');
   });
 
-  it('logs the can-not-read fallback when userLimits is missing (e.g. exotic Node build)', () => {
+  it('logs the can-not-read fallback at warn level when userLimits is missing (e.g. exotic Node build)', () => {
     spyOnReport({ userLimits: {} });
     const log = vi.fn();
     checkFdLimit(2048, log);
     expect(log).toHaveBeenCalledTimes(1);
-    expect(log.mock.calls[0][0]).toMatch(/could not read host ulimit/);
-    expect(log.mock.calls[0][0]).toContain('>= 4096');
+    const [level, msg] = log.mock.calls[0];
+    expect(level).toBe('warn');
+    expect(msg).toMatch(/could not read host ulimit/);
+    expect(msg).toContain('>= 4096');
   });
 
   it('logs the can-not-read fallback when soft is non-numeric (e.g. "unlimited")', () => {
@@ -144,18 +213,22 @@ describe('checkFdLimit', () => {
     const log = vi.fn();
     checkFdLimit(2048, log);
     expect(log).toHaveBeenCalledTimes(1);
-    expect(log.mock.calls[0][0]).toMatch(/could not read host ulimit/);
+    const [level, msg] = log.mock.calls[0];
+    expect(level).toBe('warn');
+    expect(msg).toMatch(/could not read host ulimit/);
   });
 
-  it('logs the error fallback when process.report.getReport() throws', () => {
+  it('logs the error fallback at warn level when process.report.getReport() throws', () => {
     vi.spyOn(process.report, 'getReport').mockImplementation(() => {
       throw new Error('exotic test environment');
     });
     const log = vi.fn();
     checkFdLimit(2048, log);
     expect(log).toHaveBeenCalledTimes(1);
-    expect(log.mock.calls[0][0]).toMatch(/error reading ulimit/);
-    expect(log.mock.calls[0][0]).toContain('exotic test environment');
-    expect(log.mock.calls[0][0]).toContain('>= 4096');
+    const [level, msg] = log.mock.calls[0];
+    expect(level).toBe('warn');
+    expect(msg).toMatch(/error reading ulimit/);
+    expect(msg).toContain('exotic test environment');
+    expect(msg).toContain('>= 4096');
   });
 });

--- a/packages/core/test/relay-capacity.test.ts
+++ b/packages/core/test/relay-capacity.test.ts
@@ -1,0 +1,161 @@
+// relay-capacity.test.ts
+//
+// Unit tests for the Core Node relay-server capacity tuning helpers
+// landed in `feat/libp2p-relay-capacity-and-ttl` (PR1 of the libp2p
+// reachability hardening series). Two surfaces under test:
+//
+//   1. `deriveRelayCaps(capacity)` — the pure 1:2 ratio derivation
+//      that turns the operator-facing `relayServerCapacity` knob into
+//      the full set of HOP/STOP stream caps + connectionManager limit.
+//
+//   2. `checkFdLimit(maxConnections, log)` — the startup helper that
+//      reads the host's RLIMIT_NOFILE via process.report.userLimits
+//      and emits an actionable warning when the soft limit is below
+//      the recommended `max(4096, maxConnections × 2)`. Critical for
+//      operators on systemd / Docker hosts whose default limits are
+//      typically 1024 — silently below what a 1024-reservation Core
+//      Node needs.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  DEFAULT_RELAY_SERVER_CAPACITY,
+  RELAY_CAPACITY_MULTIPLIER,
+  RELAY_DEFAULT_DURATION_LIMIT_MS,
+  RELAY_RESERVATION_TTL_MS,
+  EDGE_NODE_MAX_CONNECTIONS,
+  deriveRelayCaps,
+  checkFdLimit,
+} from '../src/node.js';
+
+describe('deriveRelayCaps', () => {
+  it('returns the default capacity-derived caps at the documented 1:2 ratio', () => {
+    const caps = deriveRelayCaps(DEFAULT_RELAY_SERVER_CAPACITY);
+    expect(caps).toEqual({
+      maxReservations: 1024,
+      maxConnections: 2048,
+      maxInboundHopStreams: 2048,
+      maxOutboundHopStreams: 2048,
+      maxOutboundStopStreams: 2048,
+      maxInboundStopStreams: 2048,
+    });
+  });
+
+  it('scales linearly — capacity=2048 doubles every derived cap', () => {
+    const caps = deriveRelayCaps(2048);
+    expect(caps.maxReservations).toBe(2048);
+    expect(caps.maxConnections).toBe(2048 * RELAY_CAPACITY_MULTIPLIER);
+    expect(caps.maxInboundHopStreams).toBe(caps.maxConnections);
+    expect(caps.maxOutboundHopStreams).toBe(caps.maxConnections);
+    expect(caps.maxOutboundStopStreams).toBe(caps.maxConnections);
+    expect(caps.maxInboundStopStreams).toBe(caps.maxConnections);
+  });
+
+  it('scales down for resource-constrained operators (Pi-class hosts)', () => {
+    const caps = deriveRelayCaps(256);
+    expect(caps.maxReservations).toBe(256);
+    expect(caps.maxConnections).toBe(512);
+  });
+
+  it('the per-circuit duration limit is documented at 30 minutes (bumped from libp2p default 5min)', () => {
+    expect(RELAY_DEFAULT_DURATION_LIMIT_MS).toBe(30 * 60 * 1000);
+  });
+
+  it('the reservation TTL is set explicitly at 2 hours (matches libp2p default but pinned for visibility)', () => {
+    expect(RELAY_RESERVATION_TTL_MS).toBe(2 * 60 * 60 * 1000);
+  });
+
+  it('edge-node default maxConnections stays at the legacy 500 (no blast radius for non-relay nodes)', () => {
+    // Sanity guard: this PR intentionally only touches Core Node
+    // capacity. If a future change starts scaling edge nodes too,
+    // this constant should be reconsidered carefully — every edge
+    // bump multiplies across the network's broad install base.
+    expect(EDGE_NODE_MAX_CONNECTIONS).toBe(500);
+  });
+});
+
+describe('checkFdLimit', () => {
+  // process.report.getReport() is the only cross-platform Node API
+  // that surfaces RLIMIT_NOFILE without a syscall dep. The
+  // `process.report` property itself is a read-only getter, so we
+  // spy on the `getReport` method (which is writable on the
+  // returned report object) per-test rather than reassigning the
+  // parent property.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function spyOnReport(report: any) {
+    return vi.spyOn(process.report, 'getReport').mockReturnValue(report);
+  }
+
+  it('emits WARN when soft limit is below recommended (= max(4096, maxConnections × 2))', () => {
+    spyOnReport({ userLimits: { open_files: { soft: 1024, hard: 'unlimited' } } });
+    const log = vi.fn();
+    // maxConnections=2048 → recommended = max(4096, 4096) = 4096; soft=1024 is below.
+    checkFdLimit(2048, log);
+    expect(log).toHaveBeenCalledTimes(1);
+    const msg = log.mock.calls[0][0] as string;
+    expect(msg).toMatch(/^WARN: relay server enabled/);
+    expect(msg).toContain('soft=1024');
+    expect(msg).toContain('recommended 4096');
+    // Operator-facing remediation hint must surface all three deployment
+    // shapes so people on the wrong one find their fix immediately.
+    expect(msg).toMatch(/ulimit -n 4096/);
+    expect(msg).toMatch(/LimitNOFILE=4096/);
+    expect(msg).toMatch(/--ulimit nofile=4096:4096/);
+  });
+
+  it('emits the ok line when soft limit meets or exceeds the recommended value', () => {
+    spyOnReport({ userLimits: { open_files: { soft: 8192, hard: 'unlimited' } } });
+    const log = vi.fn();
+    checkFdLimit(2048, log);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0][0]).toMatch(/soft=8192 >= recommended 4096, ok/);
+  });
+
+  it('uses the 4096 floor when 2 × maxConnections would be smaller', () => {
+    // For a small Core Node (capacity=256 → maxConnections=512),
+    // 2 × maxConnections = 1024. The floor at 4096 ensures we still
+    // recommend a sensible minimum — fd usage isn't dominated by
+    // libp2p alone on a real host (SQLite, log files, the daemon
+    // HTTP server, etc. all chip in).
+    spyOnReport({ userLimits: { open_files: { soft: 1500, hard: 'unlimited' } } });
+    const log = vi.fn();
+    checkFdLimit(512, log);
+    const msg = log.mock.calls[0][0] as string;
+    expect(msg).toContain('recommended 4096');
+    expect(msg).not.toContain('recommended 1024');
+  });
+
+  it('logs the can-not-read fallback when userLimits is missing (e.g. exotic Node build)', () => {
+    spyOnReport({ userLimits: {} });
+    const log = vi.fn();
+    checkFdLimit(2048, log);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0][0]).toMatch(/could not read host ulimit/);
+    expect(log.mock.calls[0][0]).toContain('>= 4096');
+  });
+
+  it('logs the can-not-read fallback when soft is non-numeric (e.g. "unlimited")', () => {
+    // POSIX returns either a number or the string "unlimited" for the
+    // hard limit; soft is usually numeric but the API contract
+    // doesn't strictly require it. Defence in depth.
+    spyOnReport({ userLimits: { open_files: { soft: 'unlimited', hard: 'unlimited' } } });
+    const log = vi.fn();
+    checkFdLimit(2048, log);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0][0]).toMatch(/could not read host ulimit/);
+  });
+
+  it('logs the error fallback when process.report.getReport() throws', () => {
+    vi.spyOn(process.report, 'getReport').mockImplementation(() => {
+      throw new Error('exotic test environment');
+    });
+    const log = vi.fn();
+    checkFdLimit(2048, log);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0][0]).toMatch(/error reading ulimit/);
+    expect(log.mock.calls[0][0]).toContain('exotic test environment');
+    expect(log.mock.calls[0][0]).toContain('>= 4096');
+  });
+});


### PR DESCRIPTION
First in a 3-PR series hardening libp2p circuit-relay reachability for Core Nodes. Motivated by the May 2026 Miles ↔ Lex `NO_RESERVATION` blackout pair that surfaced in the agent-debug-chat work (#510, #517, #521): the existing 5-minute per-circuit duration limit + 256-reservation cap were both meaningfully below what the network's hundreds-to-thousands-of-agents trajectory needs.

This PR is **intentionally config-only** — no behaviour change in code paths, only ceiling/TTL adjustments. PR2 (relay observability) lands next so PR3 (multi-reservation + proactive renewal) can be measured in production.

## What changed

### Per-circuit duration: 5min → 30min
`defaultDurationLimit` controls how long any single relayed circuit can stay open before being torn down. Chat-style intermittent traffic routinely has 5-15 minute silent gaps which were tearing circuits underneath the application. 30 min accommodates realistic quiet-window patterns; the reservation TTL itself stays at the libp2p-default 2h but is now set explicitly for operator visibility.

### Reservation capacity: 256 → 1024 (configurable)
New `DKGNodeConfig.relayServerCapacity?: number` operator knob (default 1024). All other relay-related caps derive from this at a 1:2 ratio:

```
capacity=1024 → maxConnections=2048, all HOP/STOP stream caps=2048
```

Edge nodes (no relay server) keep the legacy 500-connection ceiling and upstream libp2p stream defaults — this PR's blast radius is bounded to Core Nodes only. A misconfig (knob set on a node where the relay isn't enabled) logs a warning and is otherwise a no-op.

### Startup ulimit check
The bumped `maxConnections` only helps if the host's `RLIMIT_NOFILE` is correspondingly large. Daemon now reads `process.report.userLimits.open_files.soft` at relay startup and emits an actionable warning if it's below `max(4096, maxConnections × 2)`, with copy-pasteable remediation hints for shell / systemd / Docker. The 4096 floor accounts for non-libp2p fd consumers (SQLite, log files, the daemon HTTP server). Without this signal, `EMFILE` manifests as silent peer rejections rather than a crash — the warning gives operators a loud, actionable cue.

## Testing

- **New** `packages/core/test/relay-capacity.test.ts` — 12 tests, 4ms
  - 6 covering `deriveRelayCaps` math + the documented constants (TTL, duration limit, edge-node default ceiling)
  - 6 covering `checkFdLimit` (warn-below, ok-above, 4096 floor, missing `userLimits` fallback, non-numeric `soft` fallback, `getReport` throws)
- Existing relay integration suite (8 tests) still passes — including the explicit `connectionManager config` test
- **Full core test suite: 714/714 pass**

## Operator docs

New "Running a Core Node (relay operator)" section in `packages/cli/README.md`:
- `relayServerCapacity` knob + 1:2 derivation
- ulimit recommendation table (shell / systemd / Docker / k8s)
- The startup log line operators should grep for to verify the limit is correctly tuned

## Out of scope (deferred to follow-up PRs)

- Multi-reservation listening (push N `/p2p-circuit` listen addrs + `reservationConcurrency: N`) — **PR3**
- Proactive renewal in `watchdogTick` at TTL/2 — **PR3**
- libp2p Metrics adapter + `/api/relay/stats` — **PR2**
- Active address propagation on rotation — [OT-RFC-36](https://github.com/OriginTrail/dkgv10-spec/pull/108) (separate impl PR)

## Test plan for reviewer

- [ ] Read `deriveRelayCaps` — confirm 1:2 ratio matches the documented "1 reservation = 1 control conn + N circuits multiplexed onto separate streams + headroom for non-relay peers" rationale
- [ ] Read `checkFdLimit` — confirm the `process.report.getReport()` shape matches what's available on Node 22 (the test mocks it but it's worth a sanity `node -e` on the host)
- [ ] Confirm edge nodes are unaffected — search for `EDGE_NODE_MAX_CONNECTIONS` references; should land on the `connectionManager.maxConnections` fallback only
- [ ] Spot-check the `cli/README.md` ulimit table for any deployment shape that's missing
