### PR TITLE
feat(core,node-ui): relay observability — Metrics adapter, snapshot persistence, /api/relay/stats (libp2p reachability hardening PR2/3)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -96,7 +96,7 @@ rejections rather than a crash** — fix it preemptively:
 | Shell session | `ulimit -n 4096` before `dkg start` |
 | systemd unit | `LimitNOFILE=4096` in the `[Service]` block |
 | Docker | `--ulimit nofile=4096:4096` |
-| Kubernetes | `securityContext.sysctls` or container-runtime override |
+| Kubernetes | Configure at the **container runtime**, not in the pod spec — `nofile` is an rlimit, not a kernel sysctl, so `securityContext.sysctls` will NOT raise it. Set `LimitNOFILE` in the containerd / CRI-O runtime config (e.g. `[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options].LimitNOFILE = 4096`), or use a `RuntimeClass` whose underlying runtime has the bump baked in. Confirm with `kubectl exec <pod> -- sh -c 'ulimit -n'`. |
 
 To verify the live daemon's effective limit, look for the startup log line
 `[dkg-core] relay server: ulimit -n soft=<N> >= recommended <M>, ok` (or the

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1794,7 +1794,22 @@ export async function runDaemonInner(
 
       // Node UI routes (metrics, operations, logs, saved queries, chat, static UI)
       const firstToken = validTokens.size > 0 ? validTokens.values().next().value as string : undefined;
-      const handled = await handleNodeUIRequest(req, res, reqUrl, dashDb, nodeUiStaticDir, undefined, metricsCollector, authEnabled ? firstToken : undefined, memoryManager, llmSettings, telemetrySettings, resolveCorsOrigin(req, corsAllowed), () => agent.node.getRelayStats());
+      // Only inject the relay-stats provider when this node is actually
+      // running a relay server. Without this gate, edge nodes always
+      // hit the `relayStatsProvider != null` branch in `api.ts` and
+      // surface the "not yet ready" 404 path even though they're a
+      // perfectly healthy non-relay node — Codex review on PR #525
+      // (round 2) flagged this as a misleading 404. The "this node is
+      // not running a relay server" branch was unreachable in
+      // production until now.
+      //
+      // The daemon's DkgConfig doesn't expose `enableRelayServer`
+      // independently of `nodeRole` — DKGNode.start() defaults
+      // `enableRelayServer` to `nodeRole === 'core'`, and that's the
+      // only path the daemon uses. So role-based gating here matches
+      // the actual runtime behaviour.
+      const relayStatsProvider = role === 'core' ? () => agent.node.getRelayStats() : undefined;
+      const handled = await handleNodeUIRequest(req, res, reqUrl, dashDb, nodeUiStaticDir, undefined, metricsCollector, authEnabled ? firstToken : undefined, memoryManager, llmSettings, telemetrySettings, resolveCorsOrigin(req, corsAllowed), relayStatsProvider);
       if (handled) return;
 
       await handleRequest(

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1049,6 +1049,24 @@ export async function runDaemonInner(
     },
     getRpcLatencyMs: async () => 0,
     isRpcHealthy: async () => true,
+    getRelayStats: () => {
+      // Returns null on edge nodes (no relay server); the collector
+      // tolerates undefined/null and writes the relay_* columns as
+      // NULL in that case.
+      const stats = agent.node.getRelayStats();
+      if (!stats) return null;
+      // Strip the unbounded `reservations[]` array — that lives only
+      // on the live `/api/relay/stats` route, not in the periodic
+      // SQLite snapshot. See RelayStatsSnapshot docstring in
+      // metrics-collector.ts for the full rationale.
+      return {
+        capacity: stats.capacity,
+        reservationCount: stats.reservationCount,
+        activeCircuits: stats.activeCircuits,
+        bytesIn: stats.bytesIn,
+        bytesOut: stats.bytesOut,
+      };
+    },
   };
 
   const metricsCollector = new MetricsCollector(
@@ -1776,7 +1794,7 @@ export async function runDaemonInner(
 
       // Node UI routes (metrics, operations, logs, saved queries, chat, static UI)
       const firstToken = validTokens.size > 0 ? validTokens.values().next().value as string : undefined;
-      const handled = await handleNodeUIRequest(req, res, reqUrl, dashDb, nodeUiStaticDir, undefined, metricsCollector, authEnabled ? firstToken : undefined, memoryManager, llmSettings, telemetrySettings, resolveCorsOrigin(req, corsAllowed));
+      const handled = await handleNodeUIRequest(req, res, reqUrl, dashDb, nodeUiStaticDir, undefined, metricsCollector, authEnabled ? firstToken : undefined, memoryManager, llmSettings, telemetrySettings, resolveCorsOrigin(req, corsAllowed), () => agent.node.getRelayStats());
       if (handled) return;
 
       await handleRequest(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,13 +24,6 @@ export {
   type DerivedRelayCaps,
 } from './node.js';
 export {
-  RelayMetricsAdapter,
-  isRelayServerStream,
-  RELAY_V2_HOP_CODEC,
-  RELAY_V2_STOP_CODEC,
-  type RelayBytesSnapshot,
-} from './libp2p-metrics-adapter.js';
-export {
   type Network,
   type NodeIdentity,
   type Address,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,27 @@ export * from './event-bus.js';
 export { Logger, createOperationContext, type OperationContext, type OperationName, type LogSink } from './logger.js';
 export * from './crypto/index.js';
 export * from './proto/index.js';
-export { DKGNode } from './node.js';
+export {
+  DKGNode,
+  type RelayStats,
+  type RelayReservationDetail,
+  // Capacity helpers + constants from PR #524 (libp2p reachability hardening PR1).
+  // Re-exported here so dashboards / route handlers can import them
+  // without reaching into the deep import path.
+  DEFAULT_RELAY_SERVER_CAPACITY,
+  RELAY_CAPACITY_MULTIPLIER,
+  RELAY_DEFAULT_DURATION_LIMIT_MS,
+  RELAY_RESERVATION_TTL_MS,
+  EDGE_NODE_MAX_CONNECTIONS,
+  deriveRelayCaps,
+  checkFdLimit,
+  type DerivedRelayCaps,
+} from './node.js';
+export {
+  RelayMetricsAdapter,
+  isCircuitRelayConnection,
+  type RelayBytesSnapshot,
+} from './libp2p-metrics-adapter.js';
 export {
   type Network,
   type NodeIdentity,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,9 @@ export {
 } from './node.js';
 export {
   RelayMetricsAdapter,
-  isCircuitRelayConnection,
+  isRelayServerStream,
+  RELAY_V2_HOP_CODEC,
+  RELAY_V2_STOP_CODEC,
   type RelayBytesSnapshot,
 } from './libp2p-metrics-adapter.js';
 export {

--- a/packages/core/src/libp2p-metrics-adapter.ts
+++ b/packages/core/src/libp2p-metrics-adapter.ts
@@ -31,6 +31,20 @@
 // throughput we have to instrument at the protocol-stream level via
 // `trackProtocolStream`, filtering for HOP+STOP codecs.
 //
+// Direction filter (server-only):
+//   A node may run the relay server AND have its own `relayPeers`
+//   configured (the daemon falls back to network relays unless
+//   `relay: "none"`). Without filtering by `stream.direction`, the
+//   client-side HOP/STOP streams (this node dialing through some
+//   other relay, or being a reservee) would inflate the counters
+//   even though no traffic was actually forwarded BY this relay.
+//   So we filter:
+//     - HOP inbound:  dialer → relay (the relay is receiving)
+//     - STOP outbound: relay → reservee (the relay is initiating)
+//   Anything else (HOP outbound, STOP inbound) is the client-side
+//   surface and is dropped. See `isRelayServerStream` JSDoc for the
+//   full direction-vs-protocol matrix.
+//
 // Caveats of stream-level counting:
 //   - Each HOP/STOP stream carries a small protobuf control header
 //     (RESERVE/CONNECT request + response) before any data flow. For
@@ -39,12 +53,15 @@
 //     forwarded payload. Net effect: ~tens of bytes of inflation per
 //     reservation lifecycle, which is in the noise floor of any
 //     real-world Core Node serving forwarded chat / SWM gossip.
-//   - bytesIn = aggregate of `'message'` events on HOP+STOP streams
+//   - bytesIn = aggregate of `'message'` events on tracked streams
 //     (= bytes ARRIVING at the relay's HOP+STOP endpoints from the
 //     remote dialer / reservee).
-//   - bytesOut = aggregate of `.send()` calls on HOP+STOP streams
-//     (= bytes DEPARTING from the relay's HOP+STOP endpoints toward
-//     the remote dialer / reservee).
+//   - bytesOut = aggregate of `.send()` calls on tracked streams,
+//     incremented AFTER the delegated send returns (= bytes that
+//     actually left the relay's HOP+STOP endpoints toward the remote
+//     dialer / reservee). Counting before send() would double-count
+//     chunks that fail on a closed stream — Codex review caught this
+//     during PR #525.
 //   In a healthy bidirectional circuit, bytesIn ≈ bytesOut: every
 //   payload byte is `'message'`d on one side and `.send()`d on the
 //   other after the pipe (`pipe(src, dst, src)`).
@@ -94,15 +111,38 @@ export interface RelayBytesSnapshot {
 }
 
 /**
- * Predicate for "is this stream a HOP/STOP relay-server stream we
- * should count bytes for". On a Core Node these are the only streams
- * whose payload reflects forwarded relay traffic. Exposed for tests;
- * production always uses this default.
+ * Predicate for "is this stream the relay SERVER side of a HOP/STOP
+ * stream we should count bytes for". On a Core Node these are the
+ * only streams whose payload reflects forwarded relay traffic.
+ *
+ * Direction matters because a node may run the relay server AND have
+ * its own `relayPeers` configured (the daemon falls back to network
+ * relays for both core and edge unless explicitly disabled). Without
+ * the direction filter, the client-side HOP/STOP streams (this node
+ * dialing through another relay or being a reservee) would inflate
+ * `bytesIn` / `bytesOut` even though no traffic was actually
+ * "forwarded by this relay".
+ *
+ * Server-side semantics:
+ *   - HOP inbound:  the dialer opened a HOP stream TO this relay
+ *     (RESERVE or CONNECT request) — the relay receives it.
+ *   - STOP outbound: this relay opened a STOP stream TO the reservee
+ *     to push the dialer's bytes — the relay initiates it.
+ *
+ * Client-side (filtered out here):
+ *   - HOP outbound: this node dialing through some other relay.
+ *   - STOP inbound: this node IS the reservee receiving relayed
+ *     traffic from some peer.
+ *
+ * Exposed for tests; production always uses this default.
  */
 export function isRelayServerStream(stream: Stream): boolean {
   try {
     const protocol = stream.protocol;
-    return protocol === RELAY_V2_HOP_CODEC || protocol === RELAY_V2_STOP_CODEC;
+    const direction = stream.direction;
+    if (protocol === RELAY_V2_HOP_CODEC) return direction === 'inbound';
+    if (protocol === RELAY_V2_STOP_CODEC) return direction === 'outbound';
+    return false;
   } catch {
     return false;
   }
@@ -228,16 +268,35 @@ export class RelayMetricsAdapter implements Metrics {
     };
     stream.addEventListener('message', onMessage);
 
-    // OUTBOUND: wrap .send() so every chunk passed in gets its
-    // byteLength added to the counter before delegating to the
-    // original send. Preserves the original return value (false ==
-    // backpressure signal). On the relay's HOP stream, bytes sent
-    // here go to the dialer; on the STOP stream, to the reservee.
+    // OUTBOUND: wrap .send() so every chunk that successfully leaves
+    // the stream gets its byteLength added to the counter AFTER the
+    // delegated send returns / resolves. Counting before send() would
+    // double-count any chunk that throws on a closed/broken stream
+    // (Codex review on PR #525) — the dashboard would show bytes
+    // that were never actually forwarded.
+    //
+    // libp2p's .send() returns either `boolean` (sync, false ==
+    // backpressure) or `Promise<boolean>` (some impls async). We handle
+    // both: synchronous returns increment immediately; promises
+    // increment in a `.then()` callback. Errors in either case skip
+    // the increment.
     const originalSend = stream.send.bind(stream);
     stream.send = (data: any) => {
       const n = chunkByteLength(data);
+      let result: any;
+      try {
+        result = originalSend(data);
+      } catch (err) {
+        throw err;
+      }
+      if (result && typeof result.then === 'function') {
+        return result.then((v: boolean) => {
+          if (n > 0) this.bytesOut += BigInt(n);
+          return v;
+        });
+      }
       if (n > 0) this.bytesOut += BigInt(n);
-      return originalSend(data);
+      return result;
     };
 
     // CLOSE: on close, remove the message listener and decrement the

--- a/packages/core/src/libp2p-metrics-adapter.ts
+++ b/packages/core/src/libp2p-metrics-adapter.ts
@@ -1,0 +1,233 @@
+// libp2p-metrics-adapter.ts
+//
+// Minimal in-process implementation of @libp2p/interface's `Metrics`
+// surface, scoped to ONE thing: counting bytes that flow through
+// circuit-relay v2 forwarded connections on a Core Node. We don't ship
+// a full prom-client-style metrics stack here because the entire
+// observability story for the dashboard already runs through
+// MetricsCollector + DashboardDB; libp2p's Metrics interface just
+// happens to be the only seam where forwarded byte counts are
+// observable without forking the relay-server module.
+//
+// The other ~50 methods on the interface (registerMetric*,
+// registerCounter*, registerHistogram*, registerSummary*,
+// trackProtocolStream, traceFunction, createTrace) are returned as
+// no-op stubs so the libp2p runtime stays happy. The only "real"
+// behaviour is in `trackMultiaddrConnection` — when libp2p hands us a
+// new connection whose remote address contains `/p2p-circuit`, we
+// subscribe to the connection's `'message'` event for inbound bytes
+// and wrap its `.send()` method for outbound bytes.
+//
+// Event-based design rationale: the libp2p 3.x MultiaddrConnection
+// is a MessageStream — it dispatches `'message'` events for inbound
+// data and exposes `.send(Uint8Array | Uint8ArrayList)` for outbound.
+// (Older libp2p versions used duplex iterators with `source`/`sink`
+// — that surface no longer exists in the version we ship.)
+
+import type {
+  Counter,
+  CounterGroup,
+  Histogram,
+  HistogramGroup,
+  Metric,
+  MetricGroup,
+  Metrics,
+  MultiaddrConnection,
+  Stream,
+  StreamMessageEvent,
+  Summary,
+  SummaryGroup,
+} from '@libp2p/interface';
+
+/** Live view of relay byte traffic this node has forwarded since startup. */
+export interface RelayBytesSnapshot {
+  /** Total bytes received via 'message' events on relayed connections. */
+  bytesIn: bigint;
+  /** Total bytes sent via .send() on relayed connections. */
+  bytesOut: bigint;
+  /** Connections currently being byte-counted (open + tracked). */
+  activeTracked: number;
+  /** Connections we have ever started tracking since startup. */
+  totalTracked: number;
+}
+
+/**
+ * Predicate for "is this connection a circuit-relay forwarded connection
+ * we should count bytes for". Exposed for tests; in production the only
+ * thing that matters is whether the multiaddr contains `/p2p-circuit`.
+ */
+export function isCircuitRelayConnection(maConn: MultiaddrConnection): boolean {
+  try {
+    const addr = maConn.remoteAddr?.toString?.() ?? '';
+    return addr.includes('/p2p-circuit');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the byte length of a chunk. libp2p chunks are
+ * `Uint8Array | Uint8ArrayList` — both expose `byteLength`. The
+ * `length` fallback is for defence-in-depth; production chunks
+ * always have byteLength.
+ */
+function chunkByteLength(chunk: unknown): number {
+  if (chunk == null) return 0;
+  const c = chunk as { byteLength?: unknown; length?: unknown };
+  if (typeof c.byteLength === 'number') return c.byteLength;
+  if (typeof c.length === 'number') return c.length;
+  return 0;
+}
+
+/** No-op metric — every register* method on the adapter returns one of these. */
+const NOOP_METRIC: Metric = {
+  update: () => {},
+  increment: () => {},
+  decrement: () => {},
+  reset: () => {},
+  timer: () => () => {},
+};
+
+const NOOP_METRIC_GROUP: MetricGroup = {
+  update: () => {},
+  increment: () => {},
+  decrement: () => {},
+  reset: () => {},
+  timer: () => () => {},
+};
+
+const NOOP_COUNTER: Counter = {
+  increment: () => {},
+  reset: () => {},
+};
+
+const NOOP_COUNTER_GROUP: CounterGroup = {
+  increment: () => {},
+  reset: () => {},
+};
+
+const NOOP_HISTOGRAM: Histogram = {
+  observe: () => {},
+  reset: () => {},
+  timer: () => () => {},
+};
+
+const NOOP_HISTOGRAM_GROUP: HistogramGroup = {
+  observe: () => {},
+  reset: () => {},
+  timer: () => () => {},
+};
+
+const NOOP_SUMMARY: Summary = {
+  observe: () => {},
+  reset: () => {},
+  timer: () => () => {},
+};
+
+const NOOP_SUMMARY_GROUP: SummaryGroup = {
+  observe: () => {},
+  reset: () => {},
+  timer: () => () => {},
+};
+
+/**
+ * Adapter implementing libp2p's `Metrics` interface with byte-counting
+ * for circuit-relay forwarded connections only. All other Metrics
+ * surface methods return no-op objects so libp2p starts cleanly
+ * without us shipping a full prometheus-style stack.
+ */
+export class RelayMetricsAdapter implements Metrics {
+  private bytesIn = 0n;
+  private bytesOut = 0n;
+  private activeTracked = 0;
+  private totalTracked = 0;
+
+  /**
+   * Override predicate for tests. Production always uses
+   * `isCircuitRelayConnection`; tests can pass `() => true` to count
+   * bytes on every connection without setting up a full circuit-
+   * relay test rig.
+   */
+  constructor(
+    private readonly shouldTrack: (maConn: MultiaddrConnection) => boolean = isCircuitRelayConnection,
+  ) {}
+
+  /** Snapshot of the byte counters; safe to call concurrently with traffic. */
+  snapshot(): RelayBytesSnapshot {
+    return {
+      bytesIn: this.bytesIn,
+      bytesOut: this.bytesOut,
+      activeTracked: this.activeTracked,
+      totalTracked: this.totalTracked,
+    };
+  }
+
+  // ─── Metrics interface — the one method we actually instrument ─────
+
+  trackMultiaddrConnection(maConn: MultiaddrConnection): void {
+    if (!this.shouldTrack(maConn)) return;
+    this.activeTracked += 1;
+    this.totalTracked += 1;
+
+    // INBOUND: subscribe to the 'message' event. Each event's `.data`
+    // is the chunk that just arrived from the remote peer.
+    const onMessage = (evt: StreamMessageEvent) => {
+      const n = chunkByteLength(evt.data);
+      if (n > 0) this.bytesIn += BigInt(n);
+    };
+    maConn.addEventListener('message', onMessage);
+
+    // OUTBOUND: wrap .send() so every chunk passed in gets its
+    // byteLength added to the counter before delegating to the
+    // original send. Preserves the original return value (false ==
+    // backpressure signal).
+    const originalSend = maConn.send.bind(maConn);
+    maConn.send = (data: any) => {
+      const n = chunkByteLength(data);
+      if (n > 0) this.bytesOut += BigInt(n);
+      return originalSend(data);
+    };
+
+    // CLOSE: on close, remove the message listener and decrement the
+    // active counter. Libp2p emits a 'close' event when the
+    // underlying transport tears down (either side).
+    let alreadyDecremented = false;
+    const onClose = () => {
+      if (alreadyDecremented) return;
+      alreadyDecremented = true;
+      this.activeTracked = Math.max(0, this.activeTracked - 1);
+      maConn.removeEventListener('message', onMessage);
+      maConn.removeEventListener('close', onClose as any);
+    };
+    maConn.addEventListener('close', onClose as any);
+  }
+
+  // ─── Metrics interface — no-op stubs (we don't ship a full stack) ──
+
+  trackProtocolStream(_stream: Stream): void {
+    // Bytes inside individual protocol streams are already counted at
+    // the parent connection level via trackMultiaddrConnection, so
+    // double-counting here would inflate the relay byte total.
+  }
+
+  registerMetric(..._args: any[]): any { return NOOP_METRIC; }
+  registerMetricGroup(..._args: any[]): any { return NOOP_METRIC_GROUP; }
+  registerCounter(..._args: any[]): any { return NOOP_COUNTER; }
+  registerCounterGroup(..._args: any[]): any { return NOOP_COUNTER_GROUP; }
+  registerHistogram(..._args: any[]): any { return NOOP_HISTOGRAM; }
+  registerHistogramGroup(..._args: any[]): any { return NOOP_HISTOGRAM_GROUP; }
+  registerSummary(..._args: any[]): any { return NOOP_SUMMARY; }
+  registerSummaryGroup(..._args: any[]): any { return NOOP_SUMMARY_GROUP; }
+
+  traceFunction<F extends (...args: any[]) => any>(_name: string, fn: F): F {
+    // Tracing is a no-op — return the function unwrapped. libp2p's
+    // built-in metrics module wraps functions for OTEL spans; since
+    // we don't ship OTEL plumbing, the unwrapped passthrough is the
+    // correct semantic.
+    return fn;
+  }
+
+  createTrace(): any {
+    return undefined;
+  }
+}

--- a/packages/core/src/libp2p-metrics-adapter.ts
+++ b/packages/core/src/libp2p-metrics-adapter.ts
@@ -2,27 +2,58 @@
 //
 // Minimal in-process implementation of @libp2p/interface's `Metrics`
 // surface, scoped to ONE thing: counting bytes that flow through
-// circuit-relay v2 forwarded connections on a Core Node. We don't ship
-// a full prom-client-style metrics stack here because the entire
+// circuit-relay v2 forwarded traffic on a Core Node. We don't ship a
+// full prom-client-style metrics stack here because the entire
 // observability story for the dashboard already runs through
 // MetricsCollector + DashboardDB; libp2p's Metrics interface just
 // happens to be the only seam where forwarded byte counts are
 // observable without forking the relay-server module.
 //
-// The other ~50 methods on the interface (registerMetric*,
-// registerCounter*, registerHistogram*, registerSummary*,
-// trackProtocolStream, traceFunction, createTrace) are returned as
-// no-op stubs so the libp2p runtime stays happy. The only "real"
-// behaviour is in `trackMultiaddrConnection` — when libp2p hands us a
-// new connection whose remote address contains `/p2p-circuit`, we
-// subscribe to the connection's `'message'` event for inbound bytes
-// and wrap its `.send()` method for outbound bytes.
+// IMPORTANT — why we instrument PROTOCOL STREAMS, not MultiaddrConnections:
 //
-// Event-based design rationale: the libp2p 3.x MultiaddrConnection
-// is a MessageStream — it dispatches `'message'` events for inbound
-// data and exposes `.send(Uint8Array | Uint8ArrayList)` for outbound.
-// (Older libp2p versions used duplex iterators with `source`/`sink`
-// — that surface no longer exists in the version we ship.)
+// On a circuit-relay v2 server, forwarded traffic does NOT flow over
+// `/p2p-circuit` connections. The `/p2p-circuit` multiaddr only exists
+// on the EDGE endpoints (dialer + reservee). On the relay host, the
+// data path is two raw protocol streams piped together inside the
+// relay-server module:
+//
+//   1. The dialer opens an inbound HOP stream to the relay over its
+//      direct connection (protocol `/libp2p/circuit/relay/0.2.0/hop`).
+//   2. The relay opens an outbound STOP stream to the reservee over
+//      the reservee's direct connection (protocol
+//      `/libp2p/circuit/relay/0.2.0/stop`).
+//   3. `createLimitedRelay()` in `@libp2p/circuit-relay-v2/utils.ts`
+//      then `pipe(src, dst, src)`s the two streams together.
+//
+// So a `MultiaddrConnection`-level filter for `/p2p-circuit` (the
+// previous design) would always count zero on a relay server — the
+// addr only ever shows up on the edge endpoints. To capture relay
+// throughput we have to instrument at the protocol-stream level via
+// `trackProtocolStream`, filtering for HOP+STOP codecs.
+//
+// Caveats of stream-level counting:
+//   - Each HOP/STOP stream carries a small protobuf control header
+//     (RESERVE/CONNECT request + response) before any data flow. For
+//     RESERVE-only HOP streams (no CONNECT), this is the ONLY traffic.
+//     For CONNECT'd streams, the protobuf overhead is dwarfed by the
+//     forwarded payload. Net effect: ~tens of bytes of inflation per
+//     reservation lifecycle, which is in the noise floor of any
+//     real-world Core Node serving forwarded chat / SWM gossip.
+//   - bytesIn = aggregate of `'message'` events on HOP+STOP streams
+//     (= bytes ARRIVING at the relay's HOP+STOP endpoints from the
+//     remote dialer / reservee).
+//   - bytesOut = aggregate of `.send()` calls on HOP+STOP streams
+//     (= bytes DEPARTING from the relay's HOP+STOP endpoints toward
+//     the remote dialer / reservee).
+//   In a healthy bidirectional circuit, bytesIn ≈ bytesOut: every
+//   payload byte is `'message'`d on one side and `.send()`d on the
+//   other after the pipe (`pipe(src, dst, src)`).
+//
+// Event-based design: libp2p 3.x Stream extends MessageStream — it
+// dispatches `'message'` events for inbound data and exposes
+// `.send(Uint8Array | Uint8ArrayList)` for outbound. (Older libp2p
+// versions used duplex iterators with `source`/`sink` — that surface
+// no longer exists in the version we ship.)
 
 import type {
   Counter,
@@ -39,27 +70,39 @@ import type {
   SummaryGroup,
 } from '@libp2p/interface';
 
+/**
+ * libp2p protocol codec for the relay HOP stream (dialer ↔ relay).
+ * Pinned here so the build doesn't depend on the @libp2p/circuit-relay-v2
+ * package's constants module just for two strings — the codec is part
+ * of the wire-stable circuit-relay v2 spec, not an internal libp2p
+ * implementation detail.
+ */
+export const RELAY_V2_HOP_CODEC = '/libp2p/circuit/relay/0.2.0/hop';
+/** libp2p protocol codec for the relay STOP stream (relay ↔ reservee). */
+export const RELAY_V2_STOP_CODEC = '/libp2p/circuit/relay/0.2.0/stop';
+
 /** Live view of relay byte traffic this node has forwarded since startup. */
 export interface RelayBytesSnapshot {
-  /** Total bytes received via 'message' events on relayed connections. */
+  /** Total bytes received via 'message' events on tracked streams. */
   bytesIn: bigint;
-  /** Total bytes sent via .send() on relayed connections. */
+  /** Total bytes sent via .send() on tracked streams. */
   bytesOut: bigint;
-  /** Connections currently being byte-counted (open + tracked). */
+  /** Streams currently being byte-counted (open + tracked). */
   activeTracked: number;
-  /** Connections we have ever started tracking since startup. */
+  /** Streams we have ever started tracking since startup. */
   totalTracked: number;
 }
 
 /**
- * Predicate for "is this connection a circuit-relay forwarded connection
- * we should count bytes for". Exposed for tests; in production the only
- * thing that matters is whether the multiaddr contains `/p2p-circuit`.
+ * Predicate for "is this stream a HOP/STOP relay-server stream we
+ * should count bytes for". On a Core Node these are the only streams
+ * whose payload reflects forwarded relay traffic. Exposed for tests;
+ * production always uses this default.
  */
-export function isCircuitRelayConnection(maConn: MultiaddrConnection): boolean {
+export function isRelayServerStream(stream: Stream): boolean {
   try {
-    const addr = maConn.remoteAddr?.toString?.() ?? '';
-    return addr.includes('/p2p-circuit');
+    const protocol = stream.protocol;
+    return protocol === RELAY_V2_HOP_CODEC || protocol === RELAY_V2_STOP_CODEC;
   } catch {
     return false;
   }
@@ -132,9 +175,14 @@ const NOOP_SUMMARY_GROUP: SummaryGroup = {
 
 /**
  * Adapter implementing libp2p's `Metrics` interface with byte-counting
- * for circuit-relay forwarded connections only. All other Metrics
+ * for circuit-relay v2 HOP+STOP streams only. All other Metrics
  * surface methods return no-op objects so libp2p starts cleanly
  * without us shipping a full prometheus-style stack.
+ *
+ * Production wires this to a relay-server's `metrics:` option in
+ * `createLibp2p()`; the libp2p runtime then calls
+ * `trackProtocolStream(stream)` on every newly opened protocol
+ * stream — we filter for HOP+STOP codecs and instrument those.
  */
 export class RelayMetricsAdapter implements Metrics {
   private bytesIn = 0n;
@@ -144,12 +192,12 @@ export class RelayMetricsAdapter implements Metrics {
 
   /**
    * Override predicate for tests. Production always uses
-   * `isCircuitRelayConnection`; tests can pass `() => true` to count
-   * bytes on every connection without setting up a full circuit-
-   * relay test rig.
+   * `isRelayServerStream`; tests can pass `() => true` to count
+   * bytes on every stream without setting up a full circuit-relay
+   * test rig.
    */
   constructor(
-    private readonly shouldTrack: (maConn: MultiaddrConnection) => boolean = isCircuitRelayConnection,
+    private readonly shouldTrack: (stream: Stream) => boolean = isRelayServerStream,
   ) {}
 
   /** Snapshot of the byte counters; safe to call concurrently with traffic. */
@@ -164,50 +212,58 @@ export class RelayMetricsAdapter implements Metrics {
 
   // ─── Metrics interface — the one method we actually instrument ─────
 
-  trackMultiaddrConnection(maConn: MultiaddrConnection): void {
-    if (!this.shouldTrack(maConn)) return;
+  trackProtocolStream(stream: Stream): void {
+    if (!this.shouldTrack(stream)) return;
     this.activeTracked += 1;
     this.totalTracked += 1;
 
     // INBOUND: subscribe to the 'message' event. Each event's `.data`
-    // is the chunk that just arrived from the remote peer.
+    // is the chunk that just arrived from the remote peer. On the
+    // relay's HOP stream this is bytes from the dialer; on the
+    // STOP stream it's bytes from the reservee. Either way, an
+    // arriving byte counts as bytesIn (relay-perspective).
     const onMessage = (evt: StreamMessageEvent) => {
       const n = chunkByteLength(evt.data);
       if (n > 0) this.bytesIn += BigInt(n);
     };
-    maConn.addEventListener('message', onMessage);
+    stream.addEventListener('message', onMessage);
 
     // OUTBOUND: wrap .send() so every chunk passed in gets its
     // byteLength added to the counter before delegating to the
     // original send. Preserves the original return value (false ==
-    // backpressure signal).
-    const originalSend = maConn.send.bind(maConn);
-    maConn.send = (data: any) => {
+    // backpressure signal). On the relay's HOP stream, bytes sent
+    // here go to the dialer; on the STOP stream, to the reservee.
+    const originalSend = stream.send.bind(stream);
+    stream.send = (data: any) => {
       const n = chunkByteLength(data);
       if (n > 0) this.bytesOut += BigInt(n);
       return originalSend(data);
     };
 
     // CLOSE: on close, remove the message listener and decrement the
-    // active counter. Libp2p emits a 'close' event when the
-    // underlying transport tears down (either side).
+    // active counter. libp2p emits 'close' (sometimes 'remoteCloseWrite'
+    // / 'remoteCloseRead' first) when the underlying stream tears down.
     let alreadyDecremented = false;
     const onClose = () => {
       if (alreadyDecremented) return;
       alreadyDecremented = true;
       this.activeTracked = Math.max(0, this.activeTracked - 1);
-      maConn.removeEventListener('message', onMessage);
-      maConn.removeEventListener('close', onClose as any);
+      stream.removeEventListener('message', onMessage);
+      stream.removeEventListener('close', onClose as any);
     };
-    maConn.addEventListener('close', onClose as any);
+    stream.addEventListener('close', onClose as any);
   }
 
   // ─── Metrics interface — no-op stubs (we don't ship a full stack) ──
 
-  trackProtocolStream(_stream: Stream): void {
-    // Bytes inside individual protocol streams are already counted at
-    // the parent connection level via trackMultiaddrConnection, so
-    // double-counting here would inflate the relay byte total.
+  trackMultiaddrConnection(_maConn: MultiaddrConnection): void {
+    // Bytes are counted at the protocol-stream level via
+    // trackProtocolStream — the only stream codecs we care about
+    // (HOP/STOP) carry the relay's forwarded payload. Counting at
+    // the connection level here would inflate the totals because
+    // every MultiaddrConnection carries many non-relay streams
+    // (DHT, gossipsub, ping, identify, …) and the actual relay
+    // bytes are already accounted for by trackProtocolStream.
   }
 
   registerMetric(..._args: any[]): any { return NOOP_METRIC; }

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -307,6 +307,16 @@ export class DKGNode {
   async start(): Promise<void> {
     if (this.node) return;
 
+    // Reset sticky relay state so a node restarted with a different
+    // role / capacity doesn't leak the previous run's adapter or
+    // capacity number into getRelayStats(). Codex review on PR #525
+    // flagged that without this guard, restarting a `nodeRole: 'core'`
+    // instance as edge would still inject the old metrics adapter
+    // and report the prior capacity. Cheap to do unconditionally
+    // since both fields are set below only when relay is enabled.
+    this.relayMetrics = null;
+    this.relayCapacity = null;
+
     let privateKey;
     if (this.config.privateKey) {
       // privateKeyFromRaw needs 64 bytes for Ed25519: seed(32) + publicKey(32)
@@ -862,6 +872,8 @@ export class DKGNode {
     this.relayWatchdogConsecutiveFailures = 0;
     this.relayReservationRedialAt.clear();
     this.relayedPeers.clear();
+    this.relayMetrics = null;
+    this.relayCapacity = null;
     await this.node.stop();
     this.node = null;
   }
@@ -894,16 +906,20 @@ export class DKGNode {
    *
    *   - `capacity`         — operator-configured maxReservations
    *   - `reservationCount` — how many reservations are currently held
-   *   - `activeCircuits`   — count of relay STOP streams currently open
-   *                          on this node. On a relay server, each
+   *   - `activeCircuits`   — count of OUTBOUND STOP streams currently
+   *                          open on this node. On a relay server, each
    *                          forwarded circuit is implemented as a HOP
-   *                          stream (from the dialer) piped into a STOP
-   *                          stream (to the reservee); counting open
-   *                          STOP streams gives exactly one per active
-   *                          forwarded circuit. NOTE: forwarded relay
-   *                          traffic does NOT show up as `/p2p-circuit`
-   *                          connections on the relay host — that
-   *                          multiaddr exists only on the edge endpoints.
+   *                          stream (from the dialer) piped into an
+   *                          outbound STOP stream (to the reservee);
+   *                          counting outbound STOP streams alone gives
+   *                          exactly one per forwarded circuit. The
+   *                          `direction === 'outbound'` filter excludes
+   *                          inbound STOP streams (which are this node
+   *                          BEING a reservee, not forwarding traffic).
+   *                          NOTE: forwarded relay traffic does NOT
+   *                          show up as `/p2p-circuit` connections on
+   *                          the relay host — that multiaddr exists
+   *                          only on the edge endpoints.
    *   - `bytesIn` / `bytesOut`  — total bytes seen on HOP+STOP streams
    *                                since relay startup, counted by the
    *                                RelayMetricsAdapter via libp2p's
@@ -956,19 +972,33 @@ export class DKGNode {
       });
     }
 
-    // Count active forwarded circuits by counting open STOP streams
-    // across all connections. Each relayed circuit on this node = exactly
-    // one outbound STOP stream the relay opened to the reservee. The
-    // matching HOP stream is also open during the lifetime of a circuit,
-    // but counting STOP streams alone gives exactly N rather than 2N.
-    // (See libp2p-metrics-adapter.ts for the full architecture comment.)
+    // Count active forwarded circuits by counting OUTBOUND STOP streams
+    // across all connections. On the relay server, each forwarded circuit
+    // = exactly one STOP stream the relay opened (outbound) to the
+    // reservee. The matching HOP stream is also open during the
+    // lifetime of a circuit, but counting STOP alone gives exactly N
+    // rather than 2N.
+    //
+    // The `direction === 'outbound'` filter is critical when this node
+    // is also a relay client (relayPeers configured). Without it, the
+    // STOP streams opened TO us as a reservee (direction='inbound')
+    // would be counted as forwarded circuits even though no traffic
+    // is being relayed BY this node — same architectural concern as the
+    // adapter's `isRelayServerStream` direction filter. Codex review
+    // on PR #525 (round 2) caught this for the metrics counters; this
+    // line was the parallel issue in `getRelayStats()`.
+    //
+    // (See libp2p-metrics-adapter.ts for the full HOP/STOP architecture
+    // comment + direction matrix.)
     let activeCircuits = 0;
     try {
       for (const conn of this.node.getConnections()) {
-        const streams = (conn as any).streams as Array<{ protocol?: string }> | undefined;
+        const streams = (conn as any).streams as Array<{ protocol?: string; direction?: string }> | undefined;
         if (!Array.isArray(streams)) continue;
         for (const s of streams) {
-          if (s?.protocol === RELAY_V2_STOP_CODEC) activeCircuits += 1;
+          if (s?.protocol === RELAY_V2_STOP_CODEC && s?.direction === 'outbound') {
+            activeCircuits += 1;
+          }
         }
       }
     } catch {

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -18,7 +18,7 @@ import { peerIdFromString } from '@libp2p/peer-id';
 import { ed25519GetPublicKey } from './crypto/ed25519.js';
 import type { ConnectionTransport, DKGNodeConfig } from './types.js';
 import { DHT_PROTOCOL, DKG_GOSSIP_MAX_RPC_BYTES } from './constants.js';
-import { RelayMetricsAdapter, type RelayBytesSnapshot } from './libp2p-metrics-adapter.js';
+import { RelayMetricsAdapter, RELAY_V2_STOP_CODEC } from './libp2p-metrics-adapter.js';
 
 export interface DKGServices extends Record<string, unknown> {
   dht: KadDHT;
@@ -894,15 +894,25 @@ export class DKGNode {
    *
    *   - `capacity`         — operator-configured maxReservations
    *   - `reservationCount` — how many reservations are currently held
-   *   - `activeCircuits`   — count of `/p2p-circuit` connections open RIGHT NOW
-   *                          (these are connections this node is currently
-   *                          forwarding for; distinct from reservations,
-   *                          which are the reservee's RIGHT to be relayed)
-   *   - `bytesIn` / `bytesOut`  — total bytes counted on the source/sink
-   *                                of every `/p2p-circuit` connection since
-   *                                relay startup. BigInt because a busy
-   *                                Core Node can saturate Number.MAX_SAFE
-   *                                in a few weeks of high traffic.
+   *   - `activeCircuits`   — count of relay STOP streams currently open
+   *                          on this node. On a relay server, each
+   *                          forwarded circuit is implemented as a HOP
+   *                          stream (from the dialer) piped into a STOP
+   *                          stream (to the reservee); counting open
+   *                          STOP streams gives exactly one per active
+   *                          forwarded circuit. NOTE: forwarded relay
+   *                          traffic does NOT show up as `/p2p-circuit`
+   *                          connections on the relay host — that
+   *                          multiaddr exists only on the edge endpoints.
+   *   - `bytesIn` / `bytesOut`  — total bytes seen on HOP+STOP streams
+   *                                since relay startup, counted by the
+   *                                RelayMetricsAdapter via libp2p's
+   *                                `trackProtocolStream` seam. bytesIn
+   *                                is bytes ARRIVING at the relay's
+   *                                HOP+STOP endpoints; bytesOut is bytes
+   *                                DEPARTING. BigInt because a busy Core
+   *                                Node can saturate Number.MAX_SAFE in
+   *                                a few weeks of high traffic.
    *   - `reservations[]`   — per-reservee detail: peerId, expiry timestamp,
    *                          optional limit copy. Suitable for
    *                          /api/relay/stats but NOT for the periodic
@@ -946,14 +956,23 @@ export class DKGNode {
       });
     }
 
+    // Count active forwarded circuits by counting open STOP streams
+    // across all connections. Each relayed circuit on this node = exactly
+    // one outbound STOP stream the relay opened to the reservee. The
+    // matching HOP stream is also open during the lifetime of a circuit,
+    // but counting STOP streams alone gives exactly N rather than 2N.
+    // (See libp2p-metrics-adapter.ts for the full architecture comment.)
     let activeCircuits = 0;
     try {
-      activeCircuits = this.node
-        .getConnections()
-        .filter((c) => c.remoteAddr?.toString?.().includes('/p2p-circuit'))
-        .length;
+      for (const conn of this.node.getConnections()) {
+        const streams = (conn as any).streams as Array<{ protocol?: string }> | undefined;
+        if (!Array.isArray(streams)) continue;
+        for (const s of streams) {
+          if (s?.protocol === RELAY_V2_STOP_CODEC) activeCircuits += 1;
+        }
+      }
     } catch {
-      /* defensive: connection list iteration shouldn't throw */
+      /* defensive: connection / stream list iteration shouldn't throw */
     }
 
     const bytes = this.relayMetrics.snapshot();
@@ -1000,11 +1019,17 @@ export interface RelayStats {
   capacity: number;
   /** Number of reservations currently held. Always ≤ capacity in healthy state. */
   reservationCount: number;
-  /** Open `/p2p-circuit` connections RIGHT NOW (forwarding traffic). */
+  /**
+   * Active forwarded circuits RIGHT NOW. Counted as the number of open
+   * STOP streams (`/libp2p/circuit/relay/0.2.0/stop`) on this node — one
+   * per circuit being forwarded. NOTE: forwarded circuits do not show up
+   * as `/p2p-circuit` connections on the relay host; that multiaddr only
+   * exists on the edge endpoints (dialer + reservee).
+   */
   activeCircuits: number;
-  /** Total bytes seen on the source side of forwarded conns since startup. */
+  /** Bytes received via 'message' events on HOP+STOP relay-server streams since startup. */
   bytesIn: bigint;
-  /** Total bytes seen on the sink side of forwarded conns since startup. */
+  /** Bytes sent via .send() on HOP+STOP relay-server streams since startup. */
   bytesOut: bigint;
   /** Per-reservee detail (unbounded; suitable for the /api/relay/stats route, NOT for periodic snapshots). */
   reservations: RelayReservationDetail[];

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -19,6 +19,7 @@ import { ed25519GetPublicKey } from './crypto/ed25519.js';
 import type { ConnectionTransport, DKGNodeConfig } from './types.js';
 import { DHT_PROTOCOL, DKG_GOSSIP_MAX_RPC_BYTES } from './constants.js';
 import { RelayMetricsAdapter, RELAY_V2_STOP_CODEC } from './libp2p-metrics-adapter.js';
+import { readRelayReservations, readConnectionStreams } from './relay-internal-shapes.js';
 
 export interface DKGServices extends Record<string, unknown> {
   dht: KadDHT;
@@ -937,40 +938,43 @@ export class DKGNode {
   getRelayStats(): RelayStats | null {
     if (!this.node || !this.relayMetrics) return null;
 
-    const relayService = (this.node.services as any).relay;
-    if (!relayService) return null;
+    // Reservations + per-connection streams are libp2p-internal shapes
+    // that aren't part of the public TypeScript types. Codex review on
+    // PR #525 round 4 caught that scattering `(x as any).y` casts at
+    // the use sites makes a future libp2p refactor silently break the
+    // metrics — these helpers concentrate the brittleness in one
+    // tested module that returns null on shape mismatch.
+    const reservationsMap = readRelayReservations(this.node);
+    if (!reservationsMap) return null;
 
-    const reservationsMap: Map<{ toString(): string }, RelayReservationInfo> | undefined =
-      relayService.reservations;
     const reservations: RelayReservationDetail[] = [];
     let reservationCount = 0;
-    if (reservationsMap && typeof reservationsMap.forEach === 'function') {
-      reservationsMap.forEach((reservation, peerId) => {
-        reservationCount += 1;
-        try {
-          const expiry = reservation?.expiry instanceof Date ? reservation.expiry.getTime() : null;
-          const addr = reservation?.addr?.toString?.() ?? null;
-          reservations.push({
-            peerId: peerId.toString(),
-            expiryTs: expiry,
-            addr,
-            limitDurationMs:
-              typeof reservation?.limit?.duration === 'number'
-                ? reservation.limit.duration
+    reservationsMap.forEach((rawReservation, peerId) => {
+      reservationCount += 1;
+      try {
+        const reservation = rawReservation as RelayReservationInfo | undefined;
+        const expiry = reservation?.expiry instanceof Date ? reservation.expiry.getTime() : null;
+        const addr = reservation?.addr?.toString?.() ?? null;
+        reservations.push({
+          peerId: peerId.toString(),
+          expiryTs: expiry,
+          addr,
+          limitDurationMs:
+            typeof reservation?.limit?.duration === 'number'
+              ? reservation.limit.duration
+              : null,
+          limitDataBytes:
+            typeof reservation?.limit?.data === 'bigint'
+              ? Number(reservation.limit.data)
+              : typeof reservation?.limit?.data === 'number'
+                ? reservation.limit.data
                 : null,
-            limitDataBytes:
-              typeof reservation?.limit?.data === 'bigint'
-                ? Number(reservation.limit.data)
-                : typeof reservation?.limit?.data === 'number'
-                  ? reservation.limit.data
-                  : null,
-          });
-        } catch {
-          // Best-effort — a single misshapen reservation entry must
-          // not poison the whole stats payload.
-        }
-      });
-    }
+        });
+      } catch {
+        // Best-effort — a single misshapen reservation entry must
+        // not poison the whole stats payload.
+      }
+    });
 
     // Count active forwarded circuits by counting OUTBOUND STOP streams
     // across all connections. On the relay server, each forwarded circuit
@@ -993,8 +997,8 @@ export class DKGNode {
     let activeCircuits = 0;
     try {
       for (const conn of this.node.getConnections()) {
-        const streams = (conn as any).streams as Array<{ protocol?: string; direction?: string }> | undefined;
-        if (!Array.isArray(streams)) continue;
+        const streams = readConnectionStreams(conn);
+        if (!streams) continue;
         for (const s of streams) {
           if (s?.protocol === RELAY_V2_STOP_CODEC && s?.direction === 'outbound') {
             activeCircuits += 1;

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -18,6 +18,7 @@ import { peerIdFromString } from '@libp2p/peer-id';
 import { ed25519GetPublicKey } from './crypto/ed25519.js';
 import type { ConnectionTransport, DKGNodeConfig } from './types.js';
 import { DHT_PROTOCOL, DKG_GOSSIP_MAX_RPC_BYTES } from './constants.js';
+import { RelayMetricsAdapter, type RelayBytesSnapshot } from './libp2p-metrics-adapter.js';
 
 export interface DKGServices extends Record<string, unknown> {
   dht: KadDHT;
@@ -282,6 +283,22 @@ export class DKGNode {
    * the new reservation on the wire.
    */
   private relayReservationRedialAt: Map<string, number> = new Map();
+  /**
+   * In-process libp2p Metrics adapter. Instantiated only when this node
+   * runs a relay server (`enableRelay` true) — its sole job is counting
+   * bytes that flow through `/p2p-circuit` forwarded connections so the
+   * dashboard can surface "actual relay traffic served" alongside the
+   * static reservation count. Null on edge nodes; `getRelayStats()`
+   * returns null in that case.
+   */
+  private relayMetrics: RelayMetricsAdapter | null = null;
+  /**
+   * Cached value of `relayServerCapacity` after defaulting + role-gating
+   * applied by `start()`. Exposed via `getRelayStats()` so consumers can
+   * compute utilization (reservationCount / capacity) without re-reading
+   * the config.
+   */
+  private relayCapacity: number | null = null;
 
   constructor(config: DKGNodeConfig = {}) {
     this.config = config;
@@ -433,6 +450,14 @@ export class DKGNode {
     }
 
     if (enableRelay && relayCaps) {
+      // Stash the capacity for later getRelayStats() so consumers can
+      // compute utilization without re-deriving it.
+      this.relayCapacity = relayCaps.maxReservations;
+      // Instantiate the byte-counting Metrics adapter ONLY when the
+      // relay server is enabled — there's no point counting relay
+      // bytes on a node that isn't relaying. The adapter is passed
+      // into createLibp2p() below.
+      this.relayMetrics = new RelayMetricsAdapter();
       services.relay = circuitRelayServer({
         // Bumped from the libp2p default (no cap → unlimited but
         // bottlenecked by maxOutboundStopStreams=300) to the derived
@@ -500,6 +525,10 @@ export class DKGNode {
         // pressure and wider headroom adds nothing.
         maxConnections: relayCaps?.maxConnections ?? EDGE_NODE_MAX_CONNECTIONS,
       },
+      // Inject the byte-counting Metrics adapter only on Core Nodes
+      // (relay enabled). On edge nodes libp2p uses its built-in
+      // no-op metrics; the adapter is purely additive.
+      ...(this.relayMetrics ? { metrics: () => this.relayMetrics! } : {}),
     } as any);
 
     this.setupConnectionObservability();
@@ -859,8 +888,124 @@ export class DKGNode {
     return this.node !== null;
   }
 
+  /**
+   * Live relay-server statistics. Returns `null` on edge nodes (no
+   * relay server enabled). On Core Nodes returns:
+   *
+   *   - `capacity`         — operator-configured maxReservations
+   *   - `reservationCount` — how many reservations are currently held
+   *   - `activeCircuits`   — count of `/p2p-circuit` connections open RIGHT NOW
+   *                          (these are connections this node is currently
+   *                          forwarding for; distinct from reservations,
+   *                          which are the reservee's RIGHT to be relayed)
+   *   - `bytesIn` / `bytesOut`  — total bytes counted on the source/sink
+   *                                of every `/p2p-circuit` connection since
+   *                                relay startup. BigInt because a busy
+   *                                Core Node can saturate Number.MAX_SAFE
+   *                                in a few weeks of high traffic.
+   *   - `reservations[]`   — per-reservee detail: peerId, expiry timestamp,
+   *                          optional limit copy. Suitable for
+   *                          /api/relay/stats but NOT for the periodic
+   *                          snapshot table (it's unbounded).
+   */
+  getRelayStats(): RelayStats | null {
+    if (!this.node || !this.relayMetrics) return null;
+
+    const relayService = (this.node.services as any).relay;
+    if (!relayService) return null;
+
+    const reservationsMap: Map<{ toString(): string }, RelayReservationInfo> | undefined =
+      relayService.reservations;
+    const reservations: RelayReservationDetail[] = [];
+    let reservationCount = 0;
+    if (reservationsMap && typeof reservationsMap.forEach === 'function') {
+      reservationsMap.forEach((reservation, peerId) => {
+        reservationCount += 1;
+        try {
+          const expiry = reservation?.expiry instanceof Date ? reservation.expiry.getTime() : null;
+          const addr = reservation?.addr?.toString?.() ?? null;
+          reservations.push({
+            peerId: peerId.toString(),
+            expiryTs: expiry,
+            addr,
+            limitDurationMs:
+              typeof reservation?.limit?.duration === 'number'
+                ? reservation.limit.duration
+                : null,
+            limitDataBytes:
+              typeof reservation?.limit?.data === 'bigint'
+                ? Number(reservation.limit.data)
+                : typeof reservation?.limit?.data === 'number'
+                  ? reservation.limit.data
+                  : null,
+          });
+        } catch {
+          // Best-effort — a single misshapen reservation entry must
+          // not poison the whole stats payload.
+        }
+      });
+    }
+
+    let activeCircuits = 0;
+    try {
+      activeCircuits = this.node
+        .getConnections()
+        .filter((c) => c.remoteAddr?.toString?.().includes('/p2p-circuit'))
+        .length;
+    } catch {
+      /* defensive: connection list iteration shouldn't throw */
+    }
+
+    const bytes = this.relayMetrics.snapshot();
+
+    return {
+      capacity: this.relayCapacity ?? 0,
+      reservationCount,
+      activeCircuits,
+      bytesIn: bytes.bytesIn,
+      bytesOut: bytes.bytesOut,
+      reservations,
+    };
+  }
+
   private requireNode(): Libp2p<DKGServices> {
     if (!this.node) throw new Error('DKGNode not started');
     return this.node;
   }
+}
+
+interface RelayReservationInfo {
+  expiry?: Date;
+  addr?: { toString(): string };
+  limit?: { duration?: number; data?: bigint | number };
+}
+
+/** Per-reservee detail returned by `getRelayStats()`. */
+export interface RelayReservationDetail {
+  /** PeerId of the reservee (the node holding the reservation). */
+  peerId: string;
+  /** Reservation expiry as a unix-ms timestamp; null if upstream omits it. */
+  expiryTs: number | null;
+  /** Multiaddr string the reservation was issued for; null if unreadable. */
+  addr: string | null;
+  /** Per-circuit duration cap in ms, or null if upstream omits it. */
+  limitDurationMs: number | null;
+  /** Per-circuit data cap in bytes, or null if upstream omits it. */
+  limitDataBytes: number | null;
+}
+
+/** Live relay-server statistics returned by `DKGNode.getRelayStats()`. */
+export interface RelayStats {
+  /** Operator-configured maxReservations cap. */
+  capacity: number;
+  /** Number of reservations currently held. Always ≤ capacity in healthy state. */
+  reservationCount: number;
+  /** Open `/p2p-circuit` connections RIGHT NOW (forwarding traffic). */
+  activeCircuits: number;
+  /** Total bytes seen on the source side of forwarded conns since startup. */
+  bytesIn: bigint;
+  /** Total bytes seen on the sink side of forwarded conns since startup. */
+  bytesOut: bigint;
+  /** Per-reservee detail (unbounded; suitable for the /api/relay/stats route, NOT for periodic snapshots). */
+  reservations: RelayReservationDetail[];
 }

--- a/packages/core/src/relay-internal-shapes.ts
+++ b/packages/core/src/relay-internal-shapes.ts
@@ -1,0 +1,98 @@
+/**
+ * Compatibility helpers for libp2p internal shapes that the relay
+ * metrics path depends on but that libp2p does NOT expose as part of
+ * its public TypeScript types.
+ *
+ * Two specific reads:
+ *
+ *   1. `libp2pNode.services.relay.reservations` — the live reservations
+ *      Map maintained by `circuitRelayServer({ reservations })`. We
+ *      need its iteration surface and `size` to surface
+ *      `RelayStats.reservationCount` + per-reservee detail.
+ *
+ *   2. `connection.streams` — the per-Connection list of multiplexed
+ *      Streams. We need it to count "active circuits" (outbound STOP
+ *      streams) on a relay-server node.
+ *
+ * Both used to be inlined as `(x as any).y` reads at the call sites in
+ * `node.ts`. Codex review on PR #525 round 4 flagged that this ties
+ * the metrics surface to private libp2p object shapes — a minor
+ * libp2p upgrade can silently turn the counters into 0 / empty data
+ * with no type error.
+ *
+ * This module concentrates the brittleness in one tested place. Each
+ * helper validates the shape it expects (object, has the right
+ * field, the field has the expected `forEach` / `Array.isArray`
+ * surface) and returns `null` on mismatch — so a libp2p change makes
+ * the metrics report `null` (visible) instead of silently stale
+ * data, and the regression tests in `relay-internal-shapes.test.ts`
+ * fail loudly the next time libp2p restructures these fields.
+ */
+
+/**
+ * Minimum surface we need from libp2p's relay reservation Map. Real
+ * libp2p uses `Map<PeerId, ServerReservation>` from
+ * `@libp2p/circuit-relay-v2/dist/src/server/reservation-store.d.ts`.
+ * We intentionally narrow to just what `getRelayStats()` actually
+ * touches so that future libp2p restructures of the internal Map
+ * value type don't force us to update.
+ */
+export interface RelayReservationsLike {
+  /**
+   * Iterate (peerId, reservation) pairs. Same call signature as
+   * `Map.prototype.forEach`. The reservation value is `unknown`
+   * because we read its fields defensively at the use site.
+   */
+  forEach(callback: (value: unknown, key: { toString(): string }) => void): void;
+  /** Number of live reservations. Used as the cap utilization signal. */
+  readonly size?: number;
+}
+
+/**
+ * Read the live reservations Map from a libp2p relay service.
+ * Returns `null` if the relay service isn't configured (e.g. edge
+ * node) OR if its shape no longer matches the expected
+ * `{ reservations: Map<...> }` contract — both treated as
+ * "metrics not available right now" by `getRelayStats()`.
+ */
+export function readRelayReservations(libp2pNode: unknown): RelayReservationsLike | null {
+  if (!libp2pNode || typeof libp2pNode !== 'object') return null;
+  const services = (libp2pNode as { services?: unknown }).services;
+  if (!services || typeof services !== 'object') return null;
+  const relay = (services as Record<string, unknown>).relay;
+  if (!relay || typeof relay !== 'object') return null;
+  const reservations = (relay as Record<string, unknown>).reservations;
+  if (!reservations || typeof (reservations as { forEach?: unknown }).forEach !== 'function') {
+    return null;
+  }
+  return reservations as RelayReservationsLike;
+}
+
+/**
+ * Minimum surface we need from a libp2p Stream for the
+ * activeCircuits computation. Real libp2p Stream is
+ * `MessageStream` (from `@libp2p/interface`), but only the protocol
+ * + direction fields matter for this counter and they are stable
+ * public fields on the type.
+ */
+export interface LibP2PStreamShape {
+  /** Negotiated protocol identifier (e.g. `/libp2p/circuit/relay/0.2.0/stop`). */
+  protocol?: string;
+  /** Stream direction relative to this node — `inbound` if the peer initiated, `outbound` if we did. */
+  direction?: 'inbound' | 'outbound';
+}
+
+/**
+ * Read the per-connection Stream array from a libp2p Connection.
+ * libp2p exposes `connection.streams` but doesn't include it in the
+ * public `Connection` type (it's been on the implementing class
+ * stably across all v0.x and v1.x releases though). Returns `null`
+ * when the field is missing or not an array — caller treats `null`
+ * as "no circuits visible on this connection".
+ */
+export function readConnectionStreams(conn: unknown): LibP2PStreamShape[] | null {
+  if (!conn || typeof conn !== 'object') return null;
+  const streams = (conn as { streams?: unknown }).streams;
+  if (!Array.isArray(streams)) return null;
+  return streams as LibP2PStreamShape[];
+}

--- a/packages/core/test/libp2p-metrics-adapter.test.ts
+++ b/packages/core/test/libp2p-metrics-adapter.test.ts
@@ -4,10 +4,15 @@
 // the relay-observability PR (PR2 of the libp2p reachability hardening
 // series). Three contracts under test:
 //
-//   1. `isCircuitRelayConnection` — the predicate that decides whether
-//      a libp2p MultiaddrConnection should be byte-counted. Production
-//      passes only `/p2p-circuit` connections through the adapter; we
-//      verify both the positive and negative paths.
+//   1. `isRelayServerStream` — the predicate that decides whether a
+//      libp2p Stream should be byte-counted. Production passes only
+//      HOP/STOP relay-server streams through the adapter; we verify
+//      both the positive and negative paths. (Replaces the previous
+//      `isCircuitRelayConnection` predicate, which counted zero on
+//      real relay servers — see branarakic's PR #525 review:
+//      forwarded relay traffic does not flow over `/p2p-circuit`
+//      MultiaddrConnections on the relay host; the relay pipes raw
+//      HOP+STOP protocol streams together internally.)
 //
 //   2. The no-op surface — registerMetric/Group/Counter/Histogram/Summary
 //      return objects whose methods don't throw. libp2p calls these at
@@ -15,25 +20,31 @@
 //      is missing a method, libp2p will TypeError in production. We
 //      therefore exercise every method on every returned shape.
 //
-//   3. `trackMultiaddrConnection` — the only "real" code path. Subscribes
-//      to the connection's `'message'` event for inbound bytes and
-//      wraps `.send()` for outbound bytes. We simulate traffic via
-//      both surfaces and assert the running totals.
+//   3. `trackProtocolStream` — the only "real" code path. Subscribes to
+//      the stream's `'message'` event for inbound bytes and wraps
+//      `.send()` for outbound bytes. We simulate traffic via both
+//      surfaces and assert the running totals.
+//      `trackMultiaddrConnection` is now a no-op (counting at the
+//      connection level would inflate totals by including non-relay
+//      streams like DHT / gossipsub).
 
 import { describe, it, expect } from 'vitest';
 import {
   RelayMetricsAdapter,
-  isCircuitRelayConnection,
+  isRelayServerStream,
+  RELAY_V2_HOP_CODEC,
+  RELAY_V2_STOP_CODEC,
   type RelayBytesSnapshot,
 } from '../src/libp2p-metrics-adapter.js';
 
 /**
- * Fake MultiaddrConnection minimal enough to flow through the adapter.
+ * Fake Stream minimal enough to flow through the adapter.
  * Inherits EventTarget so `addEventListener('message'|'close')` works
  * just like the real libp2p MessageStream contract.
  */
-class FakeMaConn extends EventTarget {
-  remoteAddr: { toString: () => string };
+class FakeStream extends EventTarget {
+  readonly id: string;
+  readonly protocol: string;
   // Captures everything passed to send() so tests can inspect the
   // outbound stream.
   sentChunks: any[] = [];
@@ -41,9 +52,10 @@ class FakeMaConn extends EventTarget {
   // a Promise<void>; we just emit the event synchronously.
   closed = false;
 
-  constructor(remoteAddr: string) {
+  constructor(protocol: string, id = 'stream-1') {
     super();
-    this.remoteAddr = { toString: () => remoteAddr };
+    this.id = id;
+    this.protocol = protocol;
   }
 
   send(data: any): boolean {
@@ -65,31 +77,27 @@ class FakeMaConn extends EventTarget {
   }
 }
 
-describe('isCircuitRelayConnection', () => {
-  it('returns true for /p2p-circuit relayed multiaddrs', () => {
-    expect(
-      isCircuitRelayConnection({
-        remoteAddr: { toString: () => '/ip4/1.2.3.4/tcp/4001/p2p/12D3.../p2p-circuit/p2p/12D3...edge' },
-      } as any),
-    ).toBe(true);
+describe('isRelayServerStream', () => {
+  it('returns true for HOP relay-server streams', () => {
+    expect(isRelayServerStream({ protocol: RELAY_V2_HOP_CODEC } as any)).toBe(true);
   });
 
-  it('returns false for direct (non-circuit) multiaddrs', () => {
-    expect(
-      isCircuitRelayConnection({
-        remoteAddr: { toString: () => '/ip4/1.2.3.4/tcp/4001/p2p/12D3...peer' },
-      } as any),
-    ).toBe(false);
+  it('returns true for STOP relay-server streams', () => {
+    expect(isRelayServerStream({ protocol: RELAY_V2_STOP_CODEC } as any)).toBe(true);
   });
 
-  it('returns false defensively when remoteAddr is missing or throws', () => {
-    expect(isCircuitRelayConnection({} as any)).toBe(false);
+  it('returns false for unrelated protocol streams (DHT, gossipsub, identify)', () => {
+    expect(isRelayServerStream({ protocol: '/ipfs/kad/1.0.0' } as any)).toBe(false);
+    expect(isRelayServerStream({ protocol: '/meshsub/1.1.0' } as any)).toBe(false);
+    expect(isRelayServerStream({ protocol: '/ipfs/id/1.0.0' } as any)).toBe(false);
+  });
+
+  it('returns false defensively when protocol is missing or throws', () => {
+    expect(isRelayServerStream({} as any)).toBe(false);
     expect(
-      isCircuitRelayConnection({
-        remoteAddr: {
-          toString: () => {
-            throw new Error('boom');
-          },
+      isRelayServerStream({
+        get protocol() {
+          throw new Error('boom');
         },
       } as any),
     ).toBe(false);
@@ -153,24 +161,32 @@ describe('RelayMetricsAdapter — no-op surface', () => {
     expect(m.createTrace()).toBeUndefined();
   });
 
-  it('trackProtocolStream is a no-op (bytes are counted at the connection level)', () => {
+  it('trackMultiaddrConnection is a no-op (bytes are counted at the protocol-stream level)', () => {
+    // Codex review on PR #525 + branarakic's finding: the previous
+    // design counted bytes on /p2p-circuit MultiaddrConnections, but
+    // those don't exist on the relay host — only on the edge
+    // endpoints. Counting at the connection level was always
+    // returning zero in production. The new design moves byte
+    // counting onto trackProtocolStream + HOP/STOP codec filter, and
+    // makes trackMultiaddrConnection a deliberate no-op so it can't
+    // re-introduce zero-rate counters by mistake.
     const m = new RelayMetricsAdapter();
-    expect(() => m.trackProtocolStream({} as any)).not.toThrow();
-    // Stream tracking must NOT inflate the byte counters — we count at
-    // the multiaddr-conn level only, so streams must contribute zero.
+    expect(() => m.trackMultiaddrConnection({} as any)).not.toThrow();
     expect(m.snapshot().bytesIn).toBe(0n);
     expect(m.snapshot().bytesOut).toBe(0n);
+    expect(m.snapshot().activeTracked).toBe(0);
+    expect(m.snapshot().totalTracked).toBe(0);
   });
 });
 
-describe('RelayMetricsAdapter — trackMultiaddrConnection (the real path)', () => {
-  it('does not count bytes on direct (non-/p2p-circuit) connections', () => {
+describe('RelayMetricsAdapter — trackProtocolStream (the real path)', () => {
+  it('does not count bytes on non-relay protocol streams (DHT, gossipsub, identify)', () => {
     const m = new RelayMetricsAdapter();
-    const conn = new FakeMaConn('/ip4/1.2.3.4/tcp/4001/p2p/12D3...direct');
-    m.trackMultiaddrConnection(conn as any);
+    const dht = new FakeStream('/ipfs/kad/1.0.0', 'dht-1');
+    m.trackProtocolStream(dht as any);
 
-    conn.emitInbound(new Uint8Array(100));
-    conn.send(new Uint8Array(200));
+    dht.emitInbound(new Uint8Array(100));
+    dht.send(new Uint8Array(200));
 
     expect(m.snapshot().bytesIn).toBe(0n);
     expect(m.snapshot().bytesOut).toBe(0n);
@@ -178,46 +194,70 @@ describe('RelayMetricsAdapter — trackMultiaddrConnection (the real path)', () 
     expect(m.snapshot().totalTracked).toBe(0);
   });
 
-  it('counts inbound bytes (message events) on /p2p-circuit connections', () => {
+  it('counts inbound bytes (message events) on HOP relay-server streams', () => {
     const m = new RelayMetricsAdapter();
-    const conn = new FakeMaConn('/ip4/1.2.3.4/tcp/4001/p2p/relay/p2p-circuit/p2p/edge');
-    m.trackMultiaddrConnection(conn as any);
+    const hop = new FakeStream(RELAY_V2_HOP_CODEC, 'hop-1');
+    m.trackProtocolStream(hop as any);
 
     expect(m.snapshot().activeTracked).toBe(1);
     expect(m.snapshot().totalTracked).toBe(1);
 
-    conn.emitInbound(new Uint8Array(100));
-    conn.emitInbound(new Uint8Array(200));
-    conn.emitInbound(new Uint8Array(50));
+    hop.emitInbound(new Uint8Array(100));
+    hop.emitInbound(new Uint8Array(200));
+    hop.emitInbound(new Uint8Array(50));
 
     expect(m.snapshot().bytesIn).toBe(350n);
     expect(m.snapshot().bytesOut).toBe(0n);
   });
 
-  it('counts outbound bytes (.send() wrapper) on /p2p-circuit connections', () => {
+  it('counts outbound bytes (.send() wrapper) on STOP relay-server streams', () => {
     const m = new RelayMetricsAdapter();
-    const conn = new FakeMaConn('/ip4/1.2.3.4/tcp/4001/p2p/relay/p2p-circuit/p2p/edge');
-    m.trackMultiaddrConnection(conn as any);
+    const stop = new FakeStream(RELAY_V2_STOP_CODEC, 'stop-1');
+    m.trackProtocolStream(stop as any);
 
-    const ok1 = conn.send(new Uint8Array(64));
-    const ok2 = conn.send(new Uint8Array(128));
+    const ok1 = stop.send(new Uint8Array(64));
+    const ok2 = stop.send(new Uint8Array(128));
 
     // The wrapper preserves the original send's return value.
     expect(ok1).toBe(true);
     expect(ok2).toBe(true);
     // Outbound chunks reach the underlying send() unchanged.
-    expect(conn.sentChunks).toHaveLength(2);
+    expect(stop.sentChunks).toHaveLength(2);
     expect(m.snapshot().bytesOut).toBe(192n);
     expect(m.snapshot().bytesIn).toBe(0n);
   });
 
+  it('counts forwarded-circuit traffic across both HOP and STOP streams', () => {
+    // Realistic relay forwarding scenario: dialer sends bytes via HOP
+    // (inbound to relay), relay pipes them out via STOP (outbound
+    // from relay), reservee replies via STOP (inbound), relay sends
+    // back via HOP (outbound). Verifies bytesIn/bytesOut aggregate
+    // both sides correctly, mirroring `pipe(src, dst, src)` semantics
+    // in @libp2p/circuit-relay-v2/utils.ts.
+    const m = new RelayMetricsAdapter();
+    const hop = new FakeStream(RELAY_V2_HOP_CODEC, 'hop-1');
+    const stop = new FakeStream(RELAY_V2_STOP_CODEC, 'stop-1');
+    m.trackProtocolStream(hop as any);
+    m.trackProtocolStream(stop as any);
+
+    hop.emitInbound(new Uint8Array(1000));
+    stop.send(new Uint8Array(1000));
+    stop.emitInbound(new Uint8Array(500));
+    hop.send(new Uint8Array(500));
+
+    expect(m.snapshot().bytesIn).toBe(1500n);
+    expect(m.snapshot().bytesOut).toBe(1500n);
+    expect(m.snapshot().activeTracked).toBe(2);
+    expect(m.snapshot().totalTracked).toBe(2);
+  });
+
   it('decrements activeTracked on close (but keeps totalTracked = lifetime count)', () => {
     const m = new RelayMetricsAdapter();
-    const conn = new FakeMaConn('/ip4/1.2.3.4/tcp/4001/p2p/relay/p2p-circuit/p2p/edge');
-    m.trackMultiaddrConnection(conn as any);
+    const hop = new FakeStream(RELAY_V2_HOP_CODEC);
+    m.trackProtocolStream(hop as any);
     expect(m.snapshot().activeTracked).toBe(1);
 
-    conn.emitClose();
+    hop.emitClose();
     expect(m.snapshot().activeTracked).toBe(0);
     // totalTracked is a lifetime counter, never decremented.
     expect(m.snapshot().totalTracked).toBe(1);
@@ -225,54 +265,33 @@ describe('RelayMetricsAdapter — trackMultiaddrConnection (the real path)', () 
     // Idempotent — a second close event must not double-decrement
     // activeTracked into negatives, otherwise repeated teardowns
     // would cause underflow.
-    conn.emitClose();
+    hop.emitClose();
     expect(m.snapshot().activeTracked).toBe(0);
   });
 
   it('stops counting inbound bytes after close (listener was removed)', () => {
     const m = new RelayMetricsAdapter();
-    const conn = new FakeMaConn('/p2p-circuit/p2p/edge');
-    m.trackMultiaddrConnection(conn as any);
+    const stop = new FakeStream(RELAY_V2_STOP_CODEC);
+    m.trackProtocolStream(stop as any);
 
-    conn.emitInbound(new Uint8Array(10));
+    stop.emitInbound(new Uint8Array(10));
     expect(m.snapshot().bytesIn).toBe(10n);
 
-    conn.emitClose();
+    stop.emitClose();
     // Post-close inbound events must NOT inflate the counter — the
     // listener has been removed by the close handler.
-    conn.emitInbound(new Uint8Array(100));
+    stop.emitInbound(new Uint8Array(100));
     expect(m.snapshot().bytesIn).toBe(10n);
-  });
-
-  it('aggregates bytes across multiple concurrent connections', () => {
-    const m = new RelayMetricsAdapter();
-    const a = new FakeMaConn('/p2p-circuit/p2p/edge-a');
-    const b = new FakeMaConn('/p2p-circuit/p2p/edge-b');
-    m.trackMultiaddrConnection(a as any);
-    m.trackMultiaddrConnection(b as any);
-
-    expect(m.snapshot().activeTracked).toBe(2);
-
-    a.emitInbound(new Uint8Array(10));
-    b.emitInbound(new Uint8Array(20));
-    b.emitInbound(new Uint8Array(30));
-
-    expect(m.snapshot().bytesIn).toBe(60n);
-    expect(m.snapshot().totalTracked).toBe(2);
-
-    a.emitClose();
-    expect(m.snapshot().activeTracked).toBe(1);
-    expect(m.snapshot().totalTracked).toBe(2);
   });
 
   it('handles Uint8ArrayList-style chunks via byteLength fallback', () => {
     const m = new RelayMetricsAdapter();
-    const conn = new FakeMaConn('/p2p-circuit/p2p/edge');
-    m.trackMultiaddrConnection(conn as any);
+    const stream = new FakeStream(RELAY_V2_HOP_CODEC);
+    m.trackProtocolStream(stream as any);
 
     // Sneak a Uint8ArrayList-shaped chunk through both surfaces.
-    conn.emitInbound({ byteLength: 17 } as any);
-    conn.send({ byteLength: 42 } as any);
+    stream.emitInbound({ byteLength: 17 } as any);
+    stream.send({ byteLength: 42 } as any);
 
     expect(m.snapshot().bytesIn).toBe(17n);
     expect(m.snapshot().bytesOut).toBe(42n);
@@ -280,10 +299,10 @@ describe('RelayMetricsAdapter — trackMultiaddrConnection (the real path)', () 
 
   it('snapshot() is independently readable as a plain object (not a live binding)', () => {
     const m = new RelayMetricsAdapter();
-    const conn = new FakeMaConn('/p2p-circuit/p2p/edge');
-    m.trackMultiaddrConnection(conn as any);
+    const stream = new FakeStream(RELAY_V2_HOP_CODEC);
+    m.trackProtocolStream(stream as any);
     const before: RelayBytesSnapshot = m.snapshot();
-    conn.emitInbound(new Uint8Array(7));
+    stream.emitInbound(new Uint8Array(7));
     const after: RelayBytesSnapshot = m.snapshot();
     // Each snapshot is a fresh capture; before's bytesIn must NOT
     // mutate when the adapter increments its internal counter.
@@ -293,19 +312,19 @@ describe('RelayMetricsAdapter — trackMultiaddrConnection (the real path)', () 
 });
 
 describe('RelayMetricsAdapter — custom shouldTrack predicate (test override)', () => {
-  it('counts bytes on direct connections when shouldTrack returns true', () => {
+  it('counts bytes on non-relay protocol streams when shouldTrack returns true', () => {
     const m = new RelayMetricsAdapter(() => true);
-    const conn = new FakeMaConn('/ip4/1.2.3.4/tcp/4001/direct');
-    m.trackMultiaddrConnection(conn as any);
-    conn.emitInbound(new Uint8Array(99));
+    const dht = new FakeStream('/ipfs/kad/1.0.0');
+    m.trackProtocolStream(dht as any);
+    dht.emitInbound(new Uint8Array(99));
     expect(m.snapshot().bytesIn).toBe(99n);
   });
 
-  it('skips all connections when shouldTrack returns false', () => {
+  it('skips all streams when shouldTrack returns false', () => {
     const m = new RelayMetricsAdapter(() => false);
-    const conn = new FakeMaConn('/p2p-circuit/p2p/edge');
-    m.trackMultiaddrConnection(conn as any);
-    conn.emitInbound(new Uint8Array(99));
+    const stream = new FakeStream(RELAY_V2_STOP_CODEC);
+    m.trackProtocolStream(stream as any);
+    stream.emitInbound(new Uint8Array(99));
     expect(m.snapshot().bytesIn).toBe(0n);
     expect(m.snapshot().activeTracked).toBe(0);
   });

--- a/packages/core/test/libp2p-metrics-adapter.test.ts
+++ b/packages/core/test/libp2p-metrics-adapter.test.ts
@@ -1,0 +1,312 @@
+// libp2p-metrics-adapter.test.ts
+//
+// Unit tests for the byte-counting libp2p Metrics adapter shipped in
+// the relay-observability PR (PR2 of the libp2p reachability hardening
+// series). Three contracts under test:
+//
+//   1. `isCircuitRelayConnection` — the predicate that decides whether
+//      a libp2p MultiaddrConnection should be byte-counted. Production
+//      passes only `/p2p-circuit` connections through the adapter; we
+//      verify both the positive and negative paths.
+//
+//   2. The no-op surface — registerMetric/Group/Counter/Histogram/Summary
+//      return objects whose methods don't throw. libp2p calls these at
+//      startup for its built-in metrics modules; if any returned object
+//      is missing a method, libp2p will TypeError in production. We
+//      therefore exercise every method on every returned shape.
+//
+//   3. `trackMultiaddrConnection` — the only "real" code path. Subscribes
+//      to the connection's `'message'` event for inbound bytes and
+//      wraps `.send()` for outbound bytes. We simulate traffic via
+//      both surfaces and assert the running totals.
+
+import { describe, it, expect } from 'vitest';
+import {
+  RelayMetricsAdapter,
+  isCircuitRelayConnection,
+  type RelayBytesSnapshot,
+} from '../src/libp2p-metrics-adapter.js';
+
+/**
+ * Fake MultiaddrConnection minimal enough to flow through the adapter.
+ * Inherits EventTarget so `addEventListener('message'|'close')` works
+ * just like the real libp2p MessageStream contract.
+ */
+class FakeMaConn extends EventTarget {
+  remoteAddr: { toString: () => string };
+  // Captures everything passed to send() so tests can inspect the
+  // outbound stream.
+  sentChunks: any[] = [];
+  // Track whether we've recorded a close. Real libp2p .close() returns
+  // a Promise<void>; we just emit the event synchronously.
+  closed = false;
+
+  constructor(remoteAddr: string) {
+    super();
+    this.remoteAddr = { toString: () => remoteAddr };
+  }
+
+  send(data: any): boolean {
+    this.sentChunks.push(data);
+    // Mirror libp2p's send() return type: false signals backpressure.
+    // We always return true here to keep tests deterministic.
+    return true;
+  }
+
+  // Fire a fake inbound 'message' event with arbitrary chunk data.
+  emitInbound(data: any): void {
+    this.dispatchEvent(new MessageEvent('message', { data }));
+  }
+
+  // Fire a fake 'close' event.
+  emitClose(): void {
+    this.closed = true;
+    this.dispatchEvent(new Event('close'));
+  }
+}
+
+describe('isCircuitRelayConnection', () => {
+  it('returns true for /p2p-circuit relayed multiaddrs', () => {
+    expect(
+      isCircuitRelayConnection({
+        remoteAddr: { toString: () => '/ip4/1.2.3.4/tcp/4001/p2p/12D3.../p2p-circuit/p2p/12D3...edge' },
+      } as any),
+    ).toBe(true);
+  });
+
+  it('returns false for direct (non-circuit) multiaddrs', () => {
+    expect(
+      isCircuitRelayConnection({
+        remoteAddr: { toString: () => '/ip4/1.2.3.4/tcp/4001/p2p/12D3...peer' },
+      } as any),
+    ).toBe(false);
+  });
+
+  it('returns false defensively when remoteAddr is missing or throws', () => {
+    expect(isCircuitRelayConnection({} as any)).toBe(false);
+    expect(
+      isCircuitRelayConnection({
+        remoteAddr: {
+          toString: () => {
+            throw new Error('boom');
+          },
+        },
+      } as any),
+    ).toBe(false);
+  });
+});
+
+describe('RelayMetricsAdapter — no-op surface', () => {
+  it('returns Metric/Counter/Histogram/Summary objects whose methods do not throw', () => {
+    const m = new RelayMetricsAdapter();
+
+    // registerMetric — Metric has update/increment/decrement/reset/timer
+    const metric = m.registerMetric('foo');
+    expect(() => metric.update(1)).not.toThrow();
+    expect(() => metric.increment()).not.toThrow();
+    expect(() => metric.decrement()).not.toThrow();
+    expect(() => metric.reset()).not.toThrow();
+    const stop = metric.timer();
+    expect(typeof stop).toBe('function');
+    expect(() => stop()).not.toThrow();
+
+    // registerMetricGroup — same shape but with `update(values)` etc.
+    const group = m.registerMetricGroup('bar');
+    expect(() => group.update({ key: 1 })).not.toThrow();
+    expect(() => group.increment({ key: 1 })).not.toThrow();
+    expect(() => group.decrement({ key: 1 })).not.toThrow();
+    expect(() => group.reset()).not.toThrow();
+    expect(() => group.timer('key')()).not.toThrow();
+
+    // Counters — increment + reset only
+    const counter = m.registerCounter('c1');
+    expect(() => counter.increment()).not.toThrow();
+    expect(() => counter.reset()).not.toThrow();
+
+    const counterGroup = m.registerCounterGroup('cg');
+    expect(() => counterGroup.increment({ a: 1 })).not.toThrow();
+    expect(() => counterGroup.reset()).not.toThrow();
+
+    // Histograms
+    const hist = m.registerHistogram('h');
+    expect(() => hist.observe(0.5)).not.toThrow();
+    expect(() => hist.reset()).not.toThrow();
+    expect(() => hist.timer()()).not.toThrow();
+
+    const histGroup = m.registerHistogramGroup('hg');
+    expect(() => histGroup.observe({ a: 0.5 })).not.toThrow();
+    expect(() => histGroup.reset()).not.toThrow();
+
+    // Summaries
+    const sum = m.registerSummary('s');
+    expect(() => sum.observe(0.5)).not.toThrow();
+    expect(() => sum.reset()).not.toThrow();
+    expect(() => sum.timer()()).not.toThrow();
+
+    const sumGroup = m.registerSummaryGroup('sg');
+    expect(() => sumGroup.observe({ a: 0.5 })).not.toThrow();
+    expect(() => sumGroup.reset()).not.toThrow();
+
+    // Tracing — passthrough, must return the same function reference.
+    const fn = (x: number) => x * 2;
+    expect(m.traceFunction('f', fn)).toBe(fn);
+    expect(m.createTrace()).toBeUndefined();
+  });
+
+  it('trackProtocolStream is a no-op (bytes are counted at the connection level)', () => {
+    const m = new RelayMetricsAdapter();
+    expect(() => m.trackProtocolStream({} as any)).not.toThrow();
+    // Stream tracking must NOT inflate the byte counters — we count at
+    // the multiaddr-conn level only, so streams must contribute zero.
+    expect(m.snapshot().bytesIn).toBe(0n);
+    expect(m.snapshot().bytesOut).toBe(0n);
+  });
+});
+
+describe('RelayMetricsAdapter — trackMultiaddrConnection (the real path)', () => {
+  it('does not count bytes on direct (non-/p2p-circuit) connections', () => {
+    const m = new RelayMetricsAdapter();
+    const conn = new FakeMaConn('/ip4/1.2.3.4/tcp/4001/p2p/12D3...direct');
+    m.trackMultiaddrConnection(conn as any);
+
+    conn.emitInbound(new Uint8Array(100));
+    conn.send(new Uint8Array(200));
+
+    expect(m.snapshot().bytesIn).toBe(0n);
+    expect(m.snapshot().bytesOut).toBe(0n);
+    expect(m.snapshot().activeTracked).toBe(0);
+    expect(m.snapshot().totalTracked).toBe(0);
+  });
+
+  it('counts inbound bytes (message events) on /p2p-circuit connections', () => {
+    const m = new RelayMetricsAdapter();
+    const conn = new FakeMaConn('/ip4/1.2.3.4/tcp/4001/p2p/relay/p2p-circuit/p2p/edge');
+    m.trackMultiaddrConnection(conn as any);
+
+    expect(m.snapshot().activeTracked).toBe(1);
+    expect(m.snapshot().totalTracked).toBe(1);
+
+    conn.emitInbound(new Uint8Array(100));
+    conn.emitInbound(new Uint8Array(200));
+    conn.emitInbound(new Uint8Array(50));
+
+    expect(m.snapshot().bytesIn).toBe(350n);
+    expect(m.snapshot().bytesOut).toBe(0n);
+  });
+
+  it('counts outbound bytes (.send() wrapper) on /p2p-circuit connections', () => {
+    const m = new RelayMetricsAdapter();
+    const conn = new FakeMaConn('/ip4/1.2.3.4/tcp/4001/p2p/relay/p2p-circuit/p2p/edge');
+    m.trackMultiaddrConnection(conn as any);
+
+    const ok1 = conn.send(new Uint8Array(64));
+    const ok2 = conn.send(new Uint8Array(128));
+
+    // The wrapper preserves the original send's return value.
+    expect(ok1).toBe(true);
+    expect(ok2).toBe(true);
+    // Outbound chunks reach the underlying send() unchanged.
+    expect(conn.sentChunks).toHaveLength(2);
+    expect(m.snapshot().bytesOut).toBe(192n);
+    expect(m.snapshot().bytesIn).toBe(0n);
+  });
+
+  it('decrements activeTracked on close (but keeps totalTracked = lifetime count)', () => {
+    const m = new RelayMetricsAdapter();
+    const conn = new FakeMaConn('/ip4/1.2.3.4/tcp/4001/p2p/relay/p2p-circuit/p2p/edge');
+    m.trackMultiaddrConnection(conn as any);
+    expect(m.snapshot().activeTracked).toBe(1);
+
+    conn.emitClose();
+    expect(m.snapshot().activeTracked).toBe(0);
+    // totalTracked is a lifetime counter, never decremented.
+    expect(m.snapshot().totalTracked).toBe(1);
+
+    // Idempotent — a second close event must not double-decrement
+    // activeTracked into negatives, otherwise repeated teardowns
+    // would cause underflow.
+    conn.emitClose();
+    expect(m.snapshot().activeTracked).toBe(0);
+  });
+
+  it('stops counting inbound bytes after close (listener was removed)', () => {
+    const m = new RelayMetricsAdapter();
+    const conn = new FakeMaConn('/p2p-circuit/p2p/edge');
+    m.trackMultiaddrConnection(conn as any);
+
+    conn.emitInbound(new Uint8Array(10));
+    expect(m.snapshot().bytesIn).toBe(10n);
+
+    conn.emitClose();
+    // Post-close inbound events must NOT inflate the counter — the
+    // listener has been removed by the close handler.
+    conn.emitInbound(new Uint8Array(100));
+    expect(m.snapshot().bytesIn).toBe(10n);
+  });
+
+  it('aggregates bytes across multiple concurrent connections', () => {
+    const m = new RelayMetricsAdapter();
+    const a = new FakeMaConn('/p2p-circuit/p2p/edge-a');
+    const b = new FakeMaConn('/p2p-circuit/p2p/edge-b');
+    m.trackMultiaddrConnection(a as any);
+    m.trackMultiaddrConnection(b as any);
+
+    expect(m.snapshot().activeTracked).toBe(2);
+
+    a.emitInbound(new Uint8Array(10));
+    b.emitInbound(new Uint8Array(20));
+    b.emitInbound(new Uint8Array(30));
+
+    expect(m.snapshot().bytesIn).toBe(60n);
+    expect(m.snapshot().totalTracked).toBe(2);
+
+    a.emitClose();
+    expect(m.snapshot().activeTracked).toBe(1);
+    expect(m.snapshot().totalTracked).toBe(2);
+  });
+
+  it('handles Uint8ArrayList-style chunks via byteLength fallback', () => {
+    const m = new RelayMetricsAdapter();
+    const conn = new FakeMaConn('/p2p-circuit/p2p/edge');
+    m.trackMultiaddrConnection(conn as any);
+
+    // Sneak a Uint8ArrayList-shaped chunk through both surfaces.
+    conn.emitInbound({ byteLength: 17 } as any);
+    conn.send({ byteLength: 42 } as any);
+
+    expect(m.snapshot().bytesIn).toBe(17n);
+    expect(m.snapshot().bytesOut).toBe(42n);
+  });
+
+  it('snapshot() is independently readable as a plain object (not a live binding)', () => {
+    const m = new RelayMetricsAdapter();
+    const conn = new FakeMaConn('/p2p-circuit/p2p/edge');
+    m.trackMultiaddrConnection(conn as any);
+    const before: RelayBytesSnapshot = m.snapshot();
+    conn.emitInbound(new Uint8Array(7));
+    const after: RelayBytesSnapshot = m.snapshot();
+    // Each snapshot is a fresh capture; before's bytesIn must NOT
+    // mutate when the adapter increments its internal counter.
+    expect(before.bytesIn).toBe(0n);
+    expect(after.bytesIn).toBe(7n);
+  });
+});
+
+describe('RelayMetricsAdapter — custom shouldTrack predicate (test override)', () => {
+  it('counts bytes on direct connections when shouldTrack returns true', () => {
+    const m = new RelayMetricsAdapter(() => true);
+    const conn = new FakeMaConn('/ip4/1.2.3.4/tcp/4001/direct');
+    m.trackMultiaddrConnection(conn as any);
+    conn.emitInbound(new Uint8Array(99));
+    expect(m.snapshot().bytesIn).toBe(99n);
+  });
+
+  it('skips all connections when shouldTrack returns false', () => {
+    const m = new RelayMetricsAdapter(() => false);
+    const conn = new FakeMaConn('/p2p-circuit/p2p/edge');
+    m.trackMultiaddrConnection(conn as any);
+    conn.emitInbound(new Uint8Array(99));
+    expect(m.snapshot().bytesIn).toBe(0n);
+    expect(m.snapshot().activeTracked).toBe(0);
+  });
+});

--- a/packages/core/test/libp2p-metrics-adapter.test.ts
+++ b/packages/core/test/libp2p-metrics-adapter.test.ts
@@ -40,37 +40,51 @@ import {
 /**
  * Fake Stream minimal enough to flow through the adapter.
  * Inherits EventTarget so `addEventListener('message'|'close')` works
- * just like the real libp2p MessageStream contract.
+ * just like the real libp2p MessageStream contract. Direction defaults
+ * to the server-side semantics for each codec (HOP=inbound, STOP=outbound)
+ * so existing tests that didn't pass direction still hit the tracked path.
  */
 class FakeStream extends EventTarget {
   readonly id: string;
   readonly protocol: string;
-  // Captures everything passed to send() so tests can inspect the
-  // outbound stream.
+  readonly direction: 'inbound' | 'outbound';
+  // Allow tests to make send() throw / return a promise to exercise the
+  // bytesOut-after-send invariant introduced in the PR2 review round.
+  sendImpl: ((data: any) => boolean | Promise<boolean>) | null = null;
   sentChunks: any[] = [];
-  // Track whether we've recorded a close. Real libp2p .close() returns
-  // a Promise<void>; we just emit the event synchronously.
   closed = false;
 
-  constructor(protocol: string, id = 'stream-1') {
+  constructor(
+    protocol: string,
+    id = 'stream-1',
+    direction?: 'inbound' | 'outbound',
+  ) {
     super();
     this.id = id;
     this.protocol = protocol;
+    // Default to the relay-server-side direction for each codec so older
+    // tests don't need to be touched.
+    if (direction != null) {
+      this.direction = direction;
+    } else if (protocol === RELAY_V2_HOP_CODEC) {
+      this.direction = 'inbound';
+    } else if (protocol === RELAY_V2_STOP_CODEC) {
+      this.direction = 'outbound';
+    } else {
+      this.direction = 'inbound';
+    }
   }
 
-  send(data: any): boolean {
+  send(data: any): boolean | Promise<boolean> {
+    if (this.sendImpl) return this.sendImpl(data);
     this.sentChunks.push(data);
-    // Mirror libp2p's send() return type: false signals backpressure.
-    // We always return true here to keep tests deterministic.
     return true;
   }
 
-  // Fire a fake inbound 'message' event with arbitrary chunk data.
   emitInbound(data: any): void {
     this.dispatchEvent(new MessageEvent('message', { data }));
   }
 
-  // Fire a fake 'close' event.
   emitClose(): void {
     this.closed = true;
     this.dispatchEvent(new Event('close'));
@@ -78,18 +92,43 @@ class FakeStream extends EventTarget {
 }
 
 describe('isRelayServerStream', () => {
-  it('returns true for HOP relay-server streams', () => {
-    expect(isRelayServerStream({ protocol: RELAY_V2_HOP_CODEC } as any)).toBe(true);
+  it('accepts HOP inbound (dialer → relay) — the relay is receiving', () => {
+    expect(
+      isRelayServerStream({ protocol: RELAY_V2_HOP_CODEC, direction: 'inbound' } as any),
+    ).toBe(true);
   });
 
-  it('returns true for STOP relay-server streams', () => {
-    expect(isRelayServerStream({ protocol: RELAY_V2_STOP_CODEC } as any)).toBe(true);
+  it('accepts STOP outbound (relay → reservee) — the relay is initiating', () => {
+    expect(
+      isRelayServerStream({ protocol: RELAY_V2_STOP_CODEC, direction: 'outbound' } as any),
+    ).toBe(true);
   });
 
-  it('returns false for unrelated protocol streams (DHT, gossipsub, identify)', () => {
-    expect(isRelayServerStream({ protocol: '/ipfs/kad/1.0.0' } as any)).toBe(false);
-    expect(isRelayServerStream({ protocol: '/meshsub/1.1.0' } as any)).toBe(false);
-    expect(isRelayServerStream({ protocol: '/ipfs/id/1.0.0' } as any)).toBe(false);
+  it('rejects HOP outbound (this node dialing through some other relay — client side)', () => {
+    // PR #525 round-2 review (branarakic): without this filter, a node
+    // running the relay server AND configured with `relayPeers` would
+    // double-count its own client-side traffic as "forwarded by this
+    // relay". HOP outbound means we're the dialer, not the relay.
+    expect(
+      isRelayServerStream({ protocol: RELAY_V2_HOP_CODEC, direction: 'outbound' } as any),
+    ).toBe(false);
+  });
+
+  it('rejects STOP inbound (this node IS the reservee receiving relayed traffic — client side)', () => {
+    // Same scenario as above: STOP inbound means we're the reservee
+    // and someone is forwarding bytes TO us — that's not "served by"
+    // this relay.
+    expect(
+      isRelayServerStream({ protocol: RELAY_V2_STOP_CODEC, direction: 'inbound' } as any),
+    ).toBe(false);
+  });
+
+  it('rejects unrelated protocol streams (DHT, gossipsub, identify) regardless of direction', () => {
+    for (const dir of ['inbound', 'outbound'] as const) {
+      expect(isRelayServerStream({ protocol: '/ipfs/kad/1.0.0', direction: dir } as any)).toBe(false);
+      expect(isRelayServerStream({ protocol: '/meshsub/1.1.0', direction: dir } as any)).toBe(false);
+      expect(isRelayServerStream({ protocol: '/ipfs/id/1.0.0', direction: dir } as any)).toBe(false);
+    }
   });
 
   it('returns false defensively when protocol is missing or throws', () => {
@@ -308,6 +347,120 @@ describe('RelayMetricsAdapter — trackProtocolStream (the real path)', () => {
     // mutate when the adapter increments its internal counter.
     expect(before.bytesIn).toBe(0n);
     expect(after.bytesIn).toBe(7n);
+  });
+});
+
+describe('RelayMetricsAdapter — direction filter (PR #525 round-2 fix)', () => {
+  it('does not count client-side HOP outbound (this node dialing through some other relay)', () => {
+    // Reproduces the inflate-self-as-relay scenario branarakic flagged.
+    // A node running the relay server AND configured with relayPeers
+    // also opens HOP streams of its own (when dialing through another
+    // relay). Those bytes must NOT be attributed to "traffic forwarded
+    // by this relay".
+    const m = new RelayMetricsAdapter();
+    const clientHop = new FakeStream(RELAY_V2_HOP_CODEC, 'client-hop', 'outbound');
+    m.trackProtocolStream(clientHop as any);
+
+    clientHop.emitInbound(new Uint8Array(500));
+    clientHop.send(new Uint8Array(800));
+
+    expect(m.snapshot().bytesIn).toBe(0n);
+    expect(m.snapshot().bytesOut).toBe(0n);
+    expect(m.snapshot().activeTracked).toBe(0);
+    expect(m.snapshot().totalTracked).toBe(0);
+  });
+
+  it('does not count client-side STOP inbound (this node IS the reservee receiving relayed bytes)', () => {
+    // Mirror of the above: an edge node behind NAT receives forwarded
+    // bytes via STOP streams (inbound). On a node that ALSO runs the
+    // relay server (e.g. a core node that still falls back to network
+    // relays), those bytes would otherwise be falsely counted as
+    // "forwarded by this relay".
+    const m = new RelayMetricsAdapter();
+    const clientStop = new FakeStream(RELAY_V2_STOP_CODEC, 'client-stop', 'inbound');
+    m.trackProtocolStream(clientStop as any);
+
+    clientStop.emitInbound(new Uint8Array(500));
+    clientStop.send(new Uint8Array(800));
+
+    expect(m.snapshot().bytesIn).toBe(0n);
+    expect(m.snapshot().bytesOut).toBe(0n);
+    expect(m.snapshot().activeTracked).toBe(0);
+    expect(m.snapshot().totalTracked).toBe(0);
+  });
+
+  it('counts only the server-side seam when both client + server streams are open simultaneously', () => {
+    // Realistic mixed scenario: a core node is both a relay server
+    // (forwarding bytes for others via HOP-in/STOP-out) AND a relay
+    // client (dialing peers via HOP-out / receiving via STOP-in).
+    // Only the server-side bytes should land in the snapshot.
+    const m = new RelayMetricsAdapter();
+    const serverHop = new FakeStream(RELAY_V2_HOP_CODEC, 'server-hop', 'inbound');
+    const serverStop = new FakeStream(RELAY_V2_STOP_CODEC, 'server-stop', 'outbound');
+    const clientHop = new FakeStream(RELAY_V2_HOP_CODEC, 'client-hop', 'outbound');
+    const clientStop = new FakeStream(RELAY_V2_STOP_CODEC, 'client-stop', 'inbound');
+    m.trackProtocolStream(serverHop as any);
+    m.trackProtocolStream(serverStop as any);
+    m.trackProtocolStream(clientHop as any);
+    m.trackProtocolStream(clientStop as any);
+
+    serverHop.emitInbound(new Uint8Array(100));
+    serverStop.send(new Uint8Array(100));
+    clientHop.emitInbound(new Uint8Array(9999));
+    clientStop.send(new Uint8Array(9999));
+
+    expect(m.snapshot().bytesIn).toBe(100n);
+    expect(m.snapshot().bytesOut).toBe(100n);
+    expect(m.snapshot().activeTracked).toBe(2);
+    expect(m.snapshot().totalTracked).toBe(2);
+  });
+});
+
+describe('RelayMetricsAdapter — bytesOut-after-send (PR #525 round-2 fix)', () => {
+  it('does NOT increment bytesOut when send() throws synchronously', () => {
+    // Codex review on PR #525: if .send() throws on a closed/broken
+    // stream, the dashboard would otherwise count bytes that never
+    // actually left the relay. The fix is to increment AFTER
+    // delegated send returns successfully.
+    const m = new RelayMetricsAdapter();
+    const stop = new FakeStream(RELAY_V2_STOP_CODEC);
+    stop.sendImpl = () => {
+      throw new Error('stream is closed');
+    };
+    m.trackProtocolStream(stop as any);
+
+    expect(() => stop.send(new Uint8Array(500))).toThrow('stream is closed');
+    expect(m.snapshot().bytesOut).toBe(0n);
+  });
+
+  it('increments bytesOut only AFTER the awaited send promise resolves', async () => {
+    // Some libp2p Stream impls return Promise<boolean>. The fix must
+    // wait for that promise to resolve before incrementing — otherwise
+    // a rejected send still inflates the counter.
+    const m = new RelayMetricsAdapter();
+    const stop = new FakeStream(RELAY_V2_STOP_CODEC);
+    let resolveSend: (v: boolean) => void = () => {};
+    stop.sendImpl = () => new Promise<boolean>((r) => { resolveSend = r; });
+    m.trackProtocolStream(stop as any);
+
+    const sendPromise = stop.send(new Uint8Array(750));
+    // Pre-resolve: send is in-flight, counter must NOT have moved yet.
+    expect(m.snapshot().bytesOut).toBe(0n);
+
+    resolveSend(true);
+    await sendPromise;
+
+    expect(m.snapshot().bytesOut).toBe(750n);
+  });
+
+  it('does NOT increment bytesOut when an awaited send promise rejects', async () => {
+    const m = new RelayMetricsAdapter();
+    const stop = new FakeStream(RELAY_V2_STOP_CODEC);
+    stop.sendImpl = () => Promise.reject(new Error('connection reset'));
+    m.trackProtocolStream(stop as any);
+
+    await expect(stop.send(new Uint8Array(750))).rejects.toThrow('connection reset');
+    expect(m.snapshot().bytesOut).toBe(0n);
   });
 });
 

--- a/packages/core/test/relay-internal-shapes.test.ts
+++ b/packages/core/test/relay-internal-shapes.test.ts
@@ -1,0 +1,85 @@
+// Regression coverage for the libp2p-internal shape readers used by
+// `getRelayStats()`. Codex review on PR #525 round 4 flagged that
+// reading `(libp2p.services as any).relay.reservations` and
+// `(conn as any).streams` directly ties our metrics surface to private
+// libp2p object shapes — a future libp2p upgrade can silently break
+// the counters with no type error. These tests pin the expected
+// shapes so a libp2p change that breaks them fails loud here.
+//
+// What we assert:
+//   1. The "happy path" shapes return non-null and behave correctly.
+//   2. Each individual shape mismatch (missing services, wrong type,
+//      missing relay key, wrong reservations type, missing streams,
+//      non-array streams) returns null — which `getRelayStats()`
+//      treats as "metrics not available" rather than crashing or
+//      reporting silently-stale data.
+import { describe, it, expect } from 'vitest';
+import {
+  readRelayReservations,
+  readConnectionStreams,
+} from '../src/relay-internal-shapes.js';
+
+describe('readRelayReservations', () => {
+  it('returns the reservations Map when libp2p shape matches the expected contract', () => {
+    const res = new Map<{ toString(): string }, unknown>();
+    res.set({ toString: () => 'peerA' }, { expiry: new Date(), addr: { toString: () => '/foo' } });
+    const node = { services: { relay: { reservations: res } } };
+    const got = readRelayReservations(node);
+    expect(got).toBe(res);
+    let count = 0;
+    got?.forEach(() => { count += 1; });
+    expect(count).toBe(1);
+  });
+
+  it('returns null when the libp2p node is missing entirely', () => {
+    expect(readRelayReservations(undefined)).toBeNull();
+    expect(readRelayReservations(null)).toBeNull();
+  });
+
+  it('returns null when `services` is missing or not an object', () => {
+    expect(readRelayReservations({})).toBeNull();
+    expect(readRelayReservations({ services: null })).toBeNull();
+    expect(readRelayReservations({ services: 'not-an-object' })).toBeNull();
+  });
+
+  it('returns null on edge nodes (relay service not configured)', () => {
+    expect(readRelayReservations({ services: {} })).toBeNull();
+    expect(readRelayReservations({ services: { relay: null } })).toBeNull();
+  });
+
+  it('returns null when the relay shape no longer matches (reservations missing or wrong type)', () => {
+    expect(readRelayReservations({ services: { relay: {} } })).toBeNull();
+    expect(readRelayReservations({ services: { relay: { reservations: null } } })).toBeNull();
+    expect(readRelayReservations({ services: { relay: { reservations: 'string' } } })).toBeNull();
+    expect(readRelayReservations({ services: { relay: { reservations: { /* no forEach */ } } } })).toBeNull();
+  });
+});
+
+describe('readConnectionStreams', () => {
+  it('returns the stream array when libp2p Connection shape matches', () => {
+    const streams = [
+      { protocol: '/libp2p/circuit/relay/0.2.0/stop', direction: 'outbound' as const },
+      { protocol: '/ipfs/id/1.0.0', direction: 'inbound' as const },
+    ];
+    const conn = { streams };
+    const got = readConnectionStreams(conn);
+    expect(got).toBe(streams);
+    expect(got).toHaveLength(2);
+  });
+
+  it('returns null when conn is missing entirely', () => {
+    expect(readConnectionStreams(undefined)).toBeNull();
+    expect(readConnectionStreams(null)).toBeNull();
+  });
+
+  it('returns null when `streams` is missing or not an array', () => {
+    expect(readConnectionStreams({})).toBeNull();
+    expect(readConnectionStreams({ streams: null })).toBeNull();
+    expect(readConnectionStreams({ streams: 'not-an-array' })).toBeNull();
+    expect(readConnectionStreams({ streams: { length: 1 } })).toBeNull();
+  });
+
+  it('returns an empty array when the connection has streams but none are open', () => {
+    expect(readConnectionStreams({ streams: [] })).toEqual([]);
+  });
+});

--- a/packages/node-ui/src/api.ts
+++ b/packages/node-ui/src/api.ts
@@ -2,10 +2,20 @@ import { type IncomingMessage, type ServerResponse } from 'node:http';
 import { join, resolve, relative, sep, isAbsolute } from 'node:path';
 import { createReadStream, existsSync } from 'node:fs';
 import { readFile, stat, realpath } from 'node:fs/promises';
-import { PayloadTooLargeError } from '@origintrail-official/dkg-core';
+import { PayloadTooLargeError, type RelayStats } from '@origintrail-official/dkg-core';
 import type { DashboardDB } from './db.js';
 import { type ChatMemoryManager } from './chat-memory.js';
 import type { MetricsCollector } from './metrics-collector.js';
+
+/**
+ * Live relay-stats provider — wraps `DKGNode.getRelayStats()`. Returns
+ * `null` when the node is not running a relay server (i.e. edge node)
+ * so the route can respond 404. The `/api/relay/stats` route reads
+ * this directly rather than going through the MetricsCollector path
+ * because it needs the per-reservee detail array, which is too large
+ * to persist in periodic snapshots.
+ */
+export type RelayStatsProvider = () => RelayStats | null;
 
 const MIME: Record<string, string> = {
   '.html': 'text/html',
@@ -87,6 +97,7 @@ export async function handleNodeUIRequest(
   llmSettings?: LlmSettingsCallbacks,
   telemetrySettings?: TelemetrySettingsCallbacks,
   corsOrigin?: string | null,
+  relayStatsProvider?: RelayStatsProvider,
 ): Promise<boolean> {
   (res as any).__corsOrigin = corsOrigin ?? null;
   const path = url.pathname;
@@ -113,6 +124,53 @@ export async function handleNodeUIRequest(
     const maxPoints = parseInt(url.searchParams.get('maxPoints') ?? '500', 10);
     const snapshots = db.getSnapshotHistory(from, to, maxPoints);
     return json(res, 200, { snapshots });
+  }
+
+  // --- Relay observability ---
+  //
+  // Live relay-server stats. Always 404 on edge nodes (no relay).
+  // Per-reservee detail is included here but NOT in the periodic
+  // snapshot table — the array is unbounded with reservation count
+  // and not useful for time-series graphing.
+  if (req.method === 'GET' && path === '/api/relay/stats') {
+    if (!relayStatsProvider) {
+      return json(res, 404, {
+        error: 'relay-stats-not-available',
+        message: 'This node is not running a relay server (set nodeRole: "core" + enableRelayServer: true).',
+      });
+    }
+    const stats = relayStatsProvider();
+    if (!stats) {
+      return json(res, 404, {
+        error: 'relay-stats-not-available',
+        message: 'Relay server not started or not yet ready.',
+      });
+    }
+    // Bigints don't survive JSON.stringify. Stringify the cumulative
+    // byte counters so dashboard clients see "12345678901234567890"
+    // (a string they can BigInt-parse) rather than a serialization
+    // error. Number-typed fields stay numeric.
+    return json(res, 200, {
+      capacity: stats.capacity,
+      reservationCount: stats.reservationCount,
+      activeCircuits: stats.activeCircuits,
+      utilization: stats.capacity > 0
+        ? Math.round((stats.reservationCount / stats.capacity) * 10000) / 100
+        : null,
+      bytesIn: stats.bytesIn.toString(),
+      bytesOut: stats.bytesOut.toString(),
+      reservations: stats.reservations.map((r) => ({
+        peerId: r.peerId,
+        expiryTs: r.expiryTs,
+        // Convenience: time-to-expiry in ms so dashboards don't have
+        // to compute it client-side. Negative if already expired (a
+        // libp2p teardown race we'd surface for debugging).
+        ttlMs: r.expiryTs != null ? r.expiryTs - Date.now() : null,
+        addr: r.addr,
+        limitDurationMs: r.limitDurationMs,
+        limitDataBytes: r.limitDataBytes,
+      })),
+    });
   }
 
   // --- Error hotspots ---

--- a/packages/node-ui/src/api.ts
+++ b/packages/node-ui/src/api.ts
@@ -136,7 +136,11 @@ export async function handleNodeUIRequest(
     if (!relayStatsProvider) {
       return json(res, 404, {
         error: 'relay-stats-not-available',
-        message: 'This node is not running a relay server (set nodeRole: "core" + enableRelayServer: true).',
+        // nodeRole: "core" alone is sufficient — `DKGNode.start()`
+        // defaults `enableRelayServer` to true when role is core.
+        // `enableRelayServer: true` is only required to override the
+        // default on a non-core node, which is unusual.
+        message: 'This node is not running a relay server (set nodeRole: "core" in config.json).',
       });
     }
     const stats = relayStatsProvider();

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 import { join } from 'node:path';
 
-const SCHEMA_VERSION = 9;
+const SCHEMA_VERSION = 10;
 const DEFAULT_RETENTION_DAYS = 90;
 
 export interface DashboardDBOptions {
@@ -61,7 +61,12 @@ export class DashboardDB {
           confirmed_kcs INTEGER,
           tentative_kcs INTEGER,
           rpc_latency_ms INTEGER,
-          rpc_healthy INTEGER
+          rpc_healthy INTEGER,
+          relay_capacity INTEGER,
+          relay_reservation_count INTEGER,
+          relay_active_circuits INTEGER,
+          relay_bytes_in INTEGER,
+          relay_bytes_out INTEGER
         );
         CREATE INDEX IF NOT EXISTS idx_snapshots_ts ON metric_snapshots(ts);
 
@@ -267,6 +272,29 @@ export class DashboardDB {
       }
     }
 
+    if (version < 10) {
+      // Relay observability columns. Populated only on Core Nodes (relay
+      // server enabled); edge nodes leave them NULL since
+      // DKGNode.getRelayStats() returns null off-relay. Idempotent
+      // ALTER ADDs guarded by PRAGMA so re-running the migration on a
+      // partially-applied DB is safe.
+      const columns = this.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>;
+      const have = new Set(columns.map((c) => c.name));
+      const ensure = (col: string, type: string) => {
+        if (!have.has(col)) {
+          this.db.exec(`ALTER TABLE metric_snapshots ADD COLUMN ${col} ${type};`);
+        }
+      };
+      ensure('relay_capacity', 'INTEGER');
+      ensure('relay_reservation_count', 'INTEGER');
+      ensure('relay_active_circuits', 'INTEGER');
+      // BigInt-shaped totals stored as INTEGER (SQLite stores up to 8
+      // bytes signed = ~9.2e18 ≈ 9.2 EB, well above any realistic
+      // relay byte total before retention pruning kicks in).
+      ensure('relay_bytes_in', 'INTEGER');
+      ensure('relay_bytes_out', 'INTEGER');
+    }
+
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
 
     const savedRetention = this.db.prepare("SELECT value FROM settings WHERE key = 'retentionDays'").get() as { value: string } | undefined;
@@ -302,21 +330,40 @@ export class DashboardDB {
   // --- Metric snapshots ---
 
   insertSnapshot(snap: MetricSnapshotRow): void {
+    // Default the v10 relay columns to null when the caller passes a
+    // pre-v10-shaped row. Better-sqlite3 throws "Missing named parameter"
+    // for any `@field` not present on the param object, so we can't rely
+    // on undefined here — coerce to an explicit null. Production callers
+    // (MetricsCollector) always supply these fields; this just keeps the
+    // surface backward-compatible for test fixtures and any external
+    // consumers of DashboardDB.insertSnapshot().
+    const row: MetricSnapshotRow = {
+      ...snap,
+      relay_capacity: snap.relay_capacity ?? null,
+      relay_reservation_count: snap.relay_reservation_count ?? null,
+      relay_active_circuits: snap.relay_active_circuits ?? null,
+      relay_bytes_in: snap.relay_bytes_in ?? null,
+      relay_bytes_out: snap.relay_bytes_out ?? null,
+    };
     this.stmt('insertSnapshot', `
       INSERT INTO metric_snapshots (
         ts, cpu_percent, mem_used_bytes, mem_total_bytes,
         disk_used_bytes, disk_total_bytes, heap_used_bytes, uptime_seconds,
         peer_count, direct_peers, relayed_peers, mesh_peers, contextGraph_count,
         total_triples, total_kcs, total_kas, store_bytes,
-        confirmed_kcs, tentative_kcs, rpc_latency_ms, rpc_healthy
+        confirmed_kcs, tentative_kcs, rpc_latency_ms, rpc_healthy,
+        relay_capacity, relay_reservation_count, relay_active_circuits,
+        relay_bytes_in, relay_bytes_out
       ) VALUES (
         @ts, @cpu_percent, @mem_used_bytes, @mem_total_bytes,
         @disk_used_bytes, @disk_total_bytes, @heap_used_bytes, @uptime_seconds,
         @peer_count, @direct_peers, @relayed_peers, @mesh_peers, @contextGraph_count,
         @total_triples, @total_kcs, @total_kas, @store_bytes,
-        @confirmed_kcs, @tentative_kcs, @rpc_latency_ms, @rpc_healthy
+        @confirmed_kcs, @tentative_kcs, @rpc_latency_ms, @rpc_healthy,
+        @relay_capacity, @relay_reservation_count, @relay_active_circuits,
+        @relay_bytes_in, @relay_bytes_out
       )
-    `).run(snap);
+    `).run(row);
   }
 
   getLatestSnapshot(): MetricSnapshotRow | undefined {
@@ -1370,6 +1417,24 @@ export interface MetricSnapshotRow {
   tentative_kcs: number | null;
   rpc_latency_ms: number | null;
   rpc_healthy: number | null;
+  /**
+   * Operator-configured relay reservation cap (DKGNodeConfig.relayServerCapacity).
+   * NULL on edge nodes (no relay server) and on rows written by pre-v10 collectors.
+   */
+  relay_capacity: number | null;
+  /** Live count of held reservations at snapshot time. NULL off-relay. */
+  relay_reservation_count: number | null;
+  /** Open `/p2p-circuit` connections at snapshot time (forwarded traffic in flight). NULL off-relay. */
+  relay_active_circuits: number | null;
+  /**
+   * Total bytes seen on the SOURCE side of `/p2p-circuit` connections since the
+   * relay started. Stored as plain integer (SQLite INTEGER is 8 bytes signed
+   * = ~9.2e18, well above any realistic relay byte total before retention pruning).
+   * NULL off-relay or on pre-v10 rows.
+   */
+  relay_bytes_in: number | null;
+  /** Same as relay_bytes_in but for the SINK side (bytes flowing out to the reservee). */
+  relay_bytes_out: number | null;
 }
 
 export interface OperationRow {

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -1420,21 +1420,40 @@ export interface MetricSnapshotRow {
   /**
    * Operator-configured relay reservation cap (DKGNodeConfig.relayServerCapacity).
    * NULL on edge nodes (no relay server) and on rows written by pre-v10 collectors.
+   *
+   * NOTE: optional on the *insert* shape so pre-v10 callers (test fixtures,
+   * external consumers) that omit relay columns still type-check. The runtime
+   * `insertSnapshot()` defaults missing values to NULL (see migration in
+   * `migrate()` for v9→v10). Rows returned from SQLite SELECTs always have
+   * all columns present (just possibly NULL), so the optional-with-null
+   * shape is safe for both directions.
    */
-  relay_capacity: number | null;
+  relay_capacity?: number | null;
   /** Live count of held reservations at snapshot time. NULL off-relay. */
-  relay_reservation_count: number | null;
-  /** Open `/p2p-circuit` connections at snapshot time (forwarded traffic in flight). NULL off-relay. */
-  relay_active_circuits: number | null;
+  relay_reservation_count?: number | null;
   /**
-   * Total bytes seen on the SOURCE side of `/p2p-circuit` connections since the
-   * relay started. Stored as plain integer (SQLite INTEGER is 8 bytes signed
-   * = ~9.2e18, well above any realistic relay byte total before retention pruning).
-   * NULL off-relay or on pre-v10 rows.
+   * Active forwarded circuits at snapshot time, counted as the number of
+   * open relay STOP streams (`/libp2p/circuit/relay/0.2.0/stop`). NOTE:
+   * forwarded circuits do not appear as `/p2p-circuit` connections on the
+   * relay host — that multiaddr only exists on the edge endpoints. NULL
+   * off-relay.
    */
-  relay_bytes_in: number | null;
-  /** Same as relay_bytes_in but for the SINK side (bytes flowing out to the reservee). */
-  relay_bytes_out: number | null;
+  relay_active_circuits?: number | null;
+  /**
+   * Total bytes received via 'message' events on relay HOP+STOP streams
+   * since the relay started (= bytes ARRIVING at the relay's HOP+STOP
+   * endpoints from the dialer / reservee). Stored as plain integer
+   * (SQLite INTEGER is 8 bytes signed = ~9.2e18, well above any
+   * realistic relay byte total before retention pruning). NULL off-relay
+   * or on pre-v10 rows.
+   */
+  relay_bytes_in?: number | null;
+  /**
+   * Same as relay_bytes_in but for outbound traffic — bytes sent via
+   * `.send()` on relay HOP+STOP streams (= bytes DEPARTING from the
+   * relay toward the dialer / reservee). NULL off-relay.
+   */
+  relay_bytes_out?: number | null;
 }
 
 export interface OperationRow {

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -272,6 +272,35 @@ export class DashboardDB {
       }
     }
 
+    if (version < 10) {
+      // The V1 CREATE statement above already lists the relay_* columns,
+      // which covers fresh installs. For nodes upgrading from a pre-V10
+      // schema the table already exists, so `CREATE TABLE IF NOT EXISTS`
+      // is a no-op and the new columns wouldn't be added — `insertSnapshot()`
+      // would then fail with `no such column: relay_capacity` on the next
+      // metric tick. This block uses the same defensive idempotent
+      // PRAGMA-then-ALTER pattern as `version < 9` to add any missing
+      // relay_* columns. Not "V9 backward compat" in the data-preservation
+      // sense — just making the schema bump safe to apply to whatever
+      // table happens to already exist.
+      const cols = new Set(
+        (this.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>)
+          .map((c) => c.name),
+      );
+      const relayCols = [
+        'relay_capacity',
+        'relay_reservation_count',
+        'relay_active_circuits',
+        'relay_bytes_in',
+        'relay_bytes_out',
+      ];
+      for (const col of relayCols) {
+        if (!cols.has(col)) {
+          this.db.exec(`ALTER TABLE metric_snapshots ADD COLUMN ${col} INTEGER;`);
+        }
+      }
+    }
+
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
 
     const savedRetention = this.db.prepare("SELECT value FROM settings WHERE key = 'retentionDays'").get() as { value: string } | undefined;

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -272,29 +272,6 @@ export class DashboardDB {
       }
     }
 
-    if (version < 10) {
-      // Relay observability columns. Populated only on Core Nodes (relay
-      // server enabled); edge nodes leave them NULL since
-      // DKGNode.getRelayStats() returns null off-relay. Idempotent
-      // ALTER ADDs guarded by PRAGMA so re-running the migration on a
-      // partially-applied DB is safe.
-      const columns = this.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>;
-      const have = new Set(columns.map((c) => c.name));
-      const ensure = (col: string, type: string) => {
-        if (!have.has(col)) {
-          this.db.exec(`ALTER TABLE metric_snapshots ADD COLUMN ${col} ${type};`);
-        }
-      };
-      ensure('relay_capacity', 'INTEGER');
-      ensure('relay_reservation_count', 'INTEGER');
-      ensure('relay_active_circuits', 'INTEGER');
-      // BigInt-shaped totals stored as INTEGER (SQLite stores up to 8
-      // bytes signed = ~9.2e18 ≈ 9.2 EB, well above any realistic
-      // relay byte total before retention pruning kicks in).
-      ensure('relay_bytes_in', 'INTEGER');
-      ensure('relay_bytes_out', 'INTEGER');
-    }
-
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
 
     const savedRetention = this.db.prepare("SELECT value FROM settings WHERE key = 'retentionDays'").get() as { value: string } | undefined;
@@ -330,21 +307,6 @@ export class DashboardDB {
   // --- Metric snapshots ---
 
   insertSnapshot(snap: MetricSnapshotRow): void {
-    // Default the v10 relay columns to null when the caller passes a
-    // pre-v10-shaped row. Better-sqlite3 throws "Missing named parameter"
-    // for any `@field` not present on the param object, so we can't rely
-    // on undefined here — coerce to an explicit null. Production callers
-    // (MetricsCollector) always supply these fields; this just keeps the
-    // surface backward-compatible for test fixtures and any external
-    // consumers of DashboardDB.insertSnapshot().
-    const row: MetricSnapshotRow = {
-      ...snap,
-      relay_capacity: snap.relay_capacity ?? null,
-      relay_reservation_count: snap.relay_reservation_count ?? null,
-      relay_active_circuits: snap.relay_active_circuits ?? null,
-      relay_bytes_in: snap.relay_bytes_in ?? null,
-      relay_bytes_out: snap.relay_bytes_out ?? null,
-    };
     this.stmt('insertSnapshot', `
       INSERT INTO metric_snapshots (
         ts, cpu_percent, mem_used_bytes, mem_total_bytes,
@@ -363,7 +325,7 @@ export class DashboardDB {
         @relay_capacity, @relay_reservation_count, @relay_active_circuits,
         @relay_bytes_in, @relay_bytes_out
       )
-    `).run(row);
+    `).run(snap);
   }
 
   getLatestSnapshot(): MetricSnapshotRow | undefined {
@@ -1419,18 +1381,11 @@ export interface MetricSnapshotRow {
   rpc_healthy: number | null;
   /**
    * Operator-configured relay reservation cap (DKGNodeConfig.relayServerCapacity).
-   * NULL on edge nodes (no relay server) and on rows written by pre-v10 collectors.
-   *
-   * NOTE: optional on the *insert* shape so pre-v10 callers (test fixtures,
-   * external consumers) that omit relay columns still type-check. The runtime
-   * `insertSnapshot()` defaults missing values to NULL (see migration in
-   * `migrate()` for v9→v10). Rows returned from SQLite SELECTs always have
-   * all columns present (just possibly NULL), so the optional-with-null
-   * shape is safe for both directions.
+   * NULL on edge nodes (no relay server enabled).
    */
-  relay_capacity?: number | null;
+  relay_capacity: number | null;
   /** Live count of held reservations at snapshot time. NULL off-relay. */
-  relay_reservation_count?: number | null;
+  relay_reservation_count: number | null;
   /**
    * Active forwarded circuits at snapshot time, counted as the number of
    * open relay STOP streams (`/libp2p/circuit/relay/0.2.0/stop`). NOTE:
@@ -1438,22 +1393,21 @@ export interface MetricSnapshotRow {
    * relay host — that multiaddr only exists on the edge endpoints. NULL
    * off-relay.
    */
-  relay_active_circuits?: number | null;
+  relay_active_circuits: number | null;
   /**
    * Total bytes received via 'message' events on relay HOP+STOP streams
    * since the relay started (= bytes ARRIVING at the relay's HOP+STOP
    * endpoints from the dialer / reservee). Stored as plain integer
    * (SQLite INTEGER is 8 bytes signed = ~9.2e18, well above any
-   * realistic relay byte total before retention pruning). NULL off-relay
-   * or on pre-v10 rows.
+   * realistic relay byte total before retention pruning). NULL off-relay.
    */
-  relay_bytes_in?: number | null;
+  relay_bytes_in: number | null;
   /**
    * Same as relay_bytes_in but for outbound traffic — bytes sent via
    * `.send()` on relay HOP+STOP streams (= bytes DEPARTING from the
    * relay toward the dialer / reservee). NULL off-relay.
    */
-  relay_bytes_out?: number | null;
+  relay_bytes_out: number | null;
 }
 
 export interface OperationRow {

--- a/packages/node-ui/src/metrics-collector.ts
+++ b/packages/node-ui/src/metrics-collector.ts
@@ -6,6 +6,23 @@ import { promisify } from 'node:util';
 const statfsAsync = promisify(statfs);
 import type { DashboardDB, MetricSnapshotRow } from './db.js';
 
+/**
+ * Aggregate relay-server snapshot consumed by MetricsCollector. Always
+ * has the same shape as `RelayStats` from `@origintrail-official/dkg-core`
+ * minus the unbounded `reservations[]` array — that lives only on the
+ * live `/api/relay/stats` route, not in the periodic SQLite snapshot
+ * (per-reservee detail would blow up the snapshot row size and isn't
+ * useful for time-series graphing). The source returns `null` when the
+ * node is not running a relay server.
+ */
+export interface RelayStatsSnapshot {
+  capacity: number;
+  reservationCount: number;
+  activeCircuits: number;
+  bytesIn: bigint;
+  bytesOut: bigint;
+}
+
 export interface MetricsSource {
   getPeerCount(): number;
   getDirectPeerCount(): number;
@@ -20,9 +37,28 @@ export interface MetricsSource {
   getStoreBytes(): Promise<number>;
   getRpcLatencyMs(): Promise<number>;
   isRpcHealthy(): Promise<boolean>;
+  /**
+   * Optional. Returns a relay snapshot on Core Nodes (relay server enabled),
+   * or null on edge nodes. Method is optional so existing tests / external
+   * consumers of MetricsSource don't have to stub it.
+   */
+  getRelayStats?(): RelayStatsSnapshot | null;
 }
 
 const SNAPSHOT_INTERVAL_MS = 120_000; // 2 minutes
+
+/**
+ * Clamp a bigint relay byte count to a safe JS Number for SQLite storage.
+ * Returns Number.MAX_SAFE_INTEGER (9.007e15) if the value would overflow,
+ * which is harmless for graphing — if you ever see that exact value in a
+ * snapshot column, the relay has forwarded ≥9 PB in this retention window
+ * and we should switch the column representation to per-snapshot deltas.
+ */
+function bigintToSafeNumber(v: bigint): number {
+  if (v > BigInt(Number.MAX_SAFE_INTEGER)) return Number.MAX_SAFE_INTEGER;
+  if (v < 0n) return 0;
+  return Number(v);
+}
 
 /**
  * Periodically collects system, network, knowledge, and chain metrics
@@ -114,6 +150,30 @@ export class MetricsCollector {
     try { tentativeKCs = await this.source.getTentativeKCs(); } catch { /* ignore */ }
     try { contextGraphCount = await this.source.getContextGraphCount(); } catch { /* ignore */ }
 
+    let relayCapacity: number | null = null;
+    let relayReservationCount: number | null = null;
+    let relayActiveCircuits: number | null = null;
+    let relayBytesIn: number | null = null;
+    let relayBytesOut: number | null = null;
+    try {
+      const relay = this.source.getRelayStats?.();
+      if (relay) {
+        relayCapacity = relay.capacity;
+        relayReservationCount = relay.reservationCount;
+        relayActiveCircuits = relay.activeCircuits;
+        // Clamp BigInt totals to Number for SQLite. Snapshot retention
+        // pruning runs on a 90-day default cutoff, so the cumulative
+        // total inside any retained row stays comfortably below
+        // Number.MAX_SAFE_INTEGER (9.007e15) for any realistic relay
+        // (would need ~9 PB of forwarded traffic in a single retention
+        // window to overflow). If we ever hit that scale the right
+        // answer is per-snapshot DELTA bytes, not raw cumulative; for
+        // now Number is fine.
+        relayBytesIn = bigintToSafeNumber(relay.bytesIn);
+        relayBytesOut = bigintToSafeNumber(relay.bytesOut);
+      }
+    } catch { /* ignore — collector keeps shipping non-relay metrics */ }
+
     return {
       ts: Date.now(),
       cpu_percent: cpuPercent,
@@ -136,6 +196,11 @@ export class MetricsCollector {
       tentative_kcs: tentativeKCs,
       rpc_latency_ms: rpcLatency,
       rpc_healthy: rpcHealthy,
+      relay_capacity: relayCapacity,
+      relay_reservation_count: relayReservationCount,
+      relay_active_circuits: relayActiveCircuits,
+      relay_bytes_in: relayBytesIn,
+      relay_bytes_out: relayBytesOut,
     };
   }
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -19,8 +19,8 @@ afterEach(() => {
 
 describe('DashboardDB — metric snapshots', () => {
   it('inserts and retrieves the latest snapshot', () => {
-    db.insertSnapshot({ ts: 1000, cpu_percent: 42.5, mem_used_bytes: 100, mem_total_bytes: 200, disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: 50, uptime_seconds: 60, peer_count: 3, direct_peers: 2, relayed_peers: 1, mesh_peers: 3, contextGraph_count: 1, total_triples: 500, total_kcs: 10, total_kas: 20, store_bytes: 1024, confirmed_kcs: 8, tentative_kcs: 2, rpc_latency_ms: 15, rpc_healthy: 1 });
-    db.insertSnapshot({ ts: 2000, cpu_percent: 55.0, mem_used_bytes: 120, mem_total_bytes: 200, disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: 60, uptime_seconds: 120, peer_count: 5, direct_peers: 3, relayed_peers: 2, mesh_peers: 4, contextGraph_count: 2, total_triples: 600, total_kcs: 12, total_kas: 24, store_bytes: 2048, confirmed_kcs: 10, tentative_kcs: 2, rpc_latency_ms: 20, rpc_healthy: 1 });
+    db.insertSnapshot({ ts: 1000, cpu_percent: 42.5, mem_used_bytes: 100, mem_total_bytes: 200, disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: 50, uptime_seconds: 60, peer_count: 3, direct_peers: 2, relayed_peers: 1, mesh_peers: 3, contextGraph_count: 1, total_triples: 500, total_kcs: 10, total_kas: 20, store_bytes: 1024, confirmed_kcs: 8, tentative_kcs: 2, rpc_latency_ms: 15, rpc_healthy: 1, relay_capacity: null, relay_reservation_count: null, relay_active_circuits: null, relay_bytes_in: null, relay_bytes_out: null });
+    db.insertSnapshot({ ts: 2000, cpu_percent: 55.0, mem_used_bytes: 120, mem_total_bytes: 200, disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: 60, uptime_seconds: 120, peer_count: 5, direct_peers: 3, relayed_peers: 2, mesh_peers: 4, contextGraph_count: 2, total_triples: 600, total_kcs: 12, total_kas: 24, store_bytes: 2048, confirmed_kcs: 10, tentative_kcs: 2, rpc_latency_ms: 20, rpc_healthy: 1, relay_capacity: null, relay_reservation_count: null, relay_active_circuits: null, relay_bytes_in: null, relay_bytes_out: null });
 
     const latest = db.getLatestSnapshot();
     expect(latest).toBeDefined();
@@ -35,7 +35,7 @@ describe('DashboardDB — metric snapshots', () => {
 
   it('retrieves snapshot history within a time range', () => {
     for (let i = 1; i <= 10; i++) {
-      db.insertSnapshot({ ts: i * 1000, cpu_percent: i, mem_used_bytes: null, mem_total_bytes: null, disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: null, uptime_seconds: null, peer_count: null, direct_peers: null, relayed_peers: null, mesh_peers: null, contextGraph_count: null, total_triples: null, total_kcs: null, total_kas: null, store_bytes: null, confirmed_kcs: null, tentative_kcs: null, rpc_latency_ms: null, rpc_healthy: null });
+      db.insertSnapshot({ ts: i * 1000, cpu_percent: i, mem_used_bytes: null, mem_total_bytes: null, disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: null, uptime_seconds: null, peer_count: null, direct_peers: null, relayed_peers: null, mesh_peers: null, contextGraph_count: null, total_triples: null, total_kcs: null, total_kas: null, store_bytes: null, confirmed_kcs: null, tentative_kcs: null, rpc_latency_ms: null, rpc_healthy: null, relay_capacity: null, relay_reservation_count: null, relay_active_circuits: null, relay_bytes_in: null, relay_bytes_out: null });
     }
 
     const history = db.getSnapshotHistory(3000, 7000);
@@ -46,7 +46,7 @@ describe('DashboardDB — metric snapshots', () => {
 
   it('downsamples when exceeding maxPoints', () => {
     for (let i = 1; i <= 100; i++) {
-      db.insertSnapshot({ ts: i * 1000, cpu_percent: i, mem_used_bytes: null, mem_total_bytes: null, disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: null, uptime_seconds: null, peer_count: null, direct_peers: null, relayed_peers: null, mesh_peers: null, contextGraph_count: null, total_triples: null, total_kcs: null, total_kas: null, store_bytes: null, confirmed_kcs: null, tentative_kcs: null, rpc_latency_ms: null, rpc_healthy: null });
+      db.insertSnapshot({ ts: i * 1000, cpu_percent: i, mem_used_bytes: null, mem_total_bytes: null, disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: null, uptime_seconds: null, peer_count: null, direct_peers: null, relayed_peers: null, mesh_peers: null, contextGraph_count: null, total_triples: null, total_kcs: null, total_kas: null, store_bytes: null, confirmed_kcs: null, tentative_kcs: null, rpc_latency_ms: null, rpc_healthy: null, relay_capacity: null, relay_reservation_count: null, relay_active_circuits: null, relay_bytes_in: null, relay_bytes_out: null });
     }
 
     const sampled = db.getSnapshotHistory(1000, 100000, 10);
@@ -226,7 +226,7 @@ describe('DashboardDB — retention', () => {
   it('prunes data older than retention period', () => {
     const db2 = new DashboardDB({ dataDir: dir, retentionDays: 0 });
 
-    db2.insertSnapshot({ ts: Date.now() - 100_000, cpu_percent: 10, mem_used_bytes: null, mem_total_bytes: null, disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: null, uptime_seconds: null, peer_count: null, direct_peers: null, relayed_peers: null, mesh_peers: null, contextGraph_count: null, total_triples: null, total_kcs: null, total_kas: null, store_bytes: null, confirmed_kcs: null, tentative_kcs: null, rpc_latency_ms: null, rpc_healthy: null });
+    db2.insertSnapshot({ ts: Date.now() - 100_000, cpu_percent: 10, mem_used_bytes: null, mem_total_bytes: null, disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: null, uptime_seconds: null, peer_count: null, direct_peers: null, relayed_peers: null, mesh_peers: null, contextGraph_count: null, total_triples: null, total_kcs: null, total_kas: null, store_bytes: null, confirmed_kcs: null, tentative_kcs: null, rpc_latency_ms: null, rpc_healthy: null, relay_capacity: null, relay_reservation_count: null, relay_active_circuits: null, relay_bytes_in: null, relay_bytes_out: null });
     db2.insertLog({ ts: Date.now() - 100_000, level: 'info', module: 'A', message: 'old' });
     db2.insertOperation({ operation_id: 'old-op', operation_name: 'query', started_at: Date.now() - 100_000 });
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import Database from 'better-sqlite3';
 import { DashboardDB } from '../src/db.js';
 
 let db: DashboardDB;
@@ -51,6 +52,74 @@ describe('DashboardDB — metric snapshots', () => {
 
     const sampled = db.getSnapshotHistory(1000, 100000, 10);
     expect(sampled.length).toBeLessThanOrEqual(10);
+  });
+
+  it('migrates a pre-V10 metric_snapshots table by adding the relay_* columns', () => {
+    // Codex review on PR #525 round 3 flagged that bumping SCHEMA_VERSION
+    // to 10 without an explicit ALTER for existing tables would leave V9
+    // schemas without the new relay_* columns, causing insertSnapshot()
+    // to throw `no such column: relay_capacity`. This regression locks
+    // in the idempotent column-add path in `version < 10`.
+    //
+    // Strategy: take the freshly-created V10 db (full schema), simulate
+    // a V9 baseline by dropping the new relay_* columns and resetting
+    // user_version to 9, then reopen via DashboardDB and verify the
+    // upgrade restores the columns and lets insertSnapshot succeed.
+    const dbPath = join(dir, 'node-ui.db');
+    db.close();
+
+    const raw = new Database(dbPath);
+    for (const col of [
+      'relay_capacity',
+      'relay_reservation_count',
+      'relay_active_circuits',
+      'relay_bytes_in',
+      'relay_bytes_out',
+    ]) {
+      raw.exec(`ALTER TABLE metric_snapshots DROP COLUMN ${col};`);
+    }
+    const recentTs = Date.now() - 60_000;
+    raw.prepare(
+      `INSERT INTO metric_snapshots (ts, cpu_percent, peer_count) VALUES (?, 10, 3)`,
+    ).run(recentTs);
+    raw.pragma('user_version = 9');
+    raw.close();
+
+    db = new DashboardDB({ dataDir: dir });
+    expect(db.db.pragma('user_version', { simple: true })).toBe(10);
+
+    const cols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>)
+      .map((c) => c.name);
+    for (const col of [
+      'relay_capacity',
+      'relay_reservation_count',
+      'relay_active_circuits',
+      'relay_bytes_in',
+      'relay_bytes_out',
+    ]) {
+      expect(cols).toContain(col);
+    }
+
+    const newTs = Date.now();
+    expect(() => db.insertSnapshot({
+      ts: newTs, cpu_percent: 20, mem_used_bytes: null, mem_total_bytes: null,
+      disk_used_bytes: null, disk_total_bytes: null, heap_used_bytes: null,
+      uptime_seconds: null, peer_count: 4, direct_peers: 2, relayed_peers: 2,
+      mesh_peers: null, contextGraph_count: null, total_triples: null,
+      total_kcs: null, total_kas: null, store_bytes: null, confirmed_kcs: null,
+      tentative_kcs: null, rpc_latency_ms: null, rpc_healthy: null,
+      relay_capacity: 1024, relay_reservation_count: 3, relay_active_circuits: 5,
+      relay_bytes_in: 12345, relay_bytes_out: 67890,
+    })).not.toThrow();
+
+    const latest = db.getLatestSnapshot();
+    expect(latest!.ts).toBe(newTs);
+    expect(latest!.relay_capacity).toBe(1024);
+    expect(latest!.relay_active_circuits).toBe(5);
+
+    const preExisting = db.getSnapshotHistory(recentTs, recentTs);
+    expect(preExisting).toHaveLength(1);
+    expect(preExisting[0].relay_capacity).toBeNull();
   });
 });
 

--- a/packages/node-ui/test/metrics-collector.test.ts
+++ b/packages/node-ui/test/metrics-collector.test.ts
@@ -148,4 +148,126 @@ describe('MetricsCollector', () => {
     expect(snap2.cpu_percent).toBeTypeOf('number');
     expect(snap2.cpu_percent).toBeGreaterThanOrEqual(0);
   });
+
+  // ─── PR2: Relay observability ────────────────────────────────────
+  //
+  // The relay-server columns (relay_capacity, relay_reservation_count,
+  // relay_active_circuits, relay_bytes_in, relay_bytes_out) are NULL
+  // on edge nodes (sources without `getRelayStats`) and populated
+  // from the source on Core Nodes. These tests pin the contract.
+
+  describe('relay-stats integration', () => {
+    it('omits getRelayStats on edge sources → all relay_* columns null', async () => {
+      const collector = new MetricsCollector(db, mockSource(), dir);
+      const snap = await collector.collect();
+      expect(snap.relay_capacity).toBeNull();
+      expect(snap.relay_reservation_count).toBeNull();
+      expect(snap.relay_active_circuits).toBeNull();
+      expect(snap.relay_bytes_in).toBeNull();
+      expect(snap.relay_bytes_out).toBeNull();
+    });
+
+    it('passes through relay snapshot when source provides it (Core Node path)', async () => {
+      const collector = new MetricsCollector(
+        db,
+        mockSource({
+          getRelayStats: () => ({
+            capacity: 1024,
+            reservationCount: 42,
+            activeCircuits: 17,
+            bytesIn: 123_456_789n,
+            bytesOut: 987_654_321n,
+          }),
+        }),
+        dir,
+      );
+      const snap = await collector.collect();
+      expect(snap.relay_capacity).toBe(1024);
+      expect(snap.relay_reservation_count).toBe(42);
+      expect(snap.relay_active_circuits).toBe(17);
+      expect(snap.relay_bytes_in).toBe(123_456_789);
+      expect(snap.relay_bytes_out).toBe(987_654_321);
+    });
+
+    it('returns null relay columns when source.getRelayStats() returns null (edge tier)', async () => {
+      const collector = new MetricsCollector(
+        db,
+        mockSource({ getRelayStats: () => null }),
+        dir,
+      );
+      const snap = await collector.collect();
+      expect(snap.relay_capacity).toBeNull();
+      expect(snap.relay_reservation_count).toBeNull();
+      expect(snap.relay_active_circuits).toBeNull();
+    });
+
+    it('clamps oversized bigint byte totals to MAX_SAFE_INTEGER (defence in depth)', async () => {
+      // 9 PB ≈ 9.0e15 fits MAX_SAFE_INTEGER (9.007e15) but 10 PB doesn't.
+      // The clamp guarantees SQLite gets a finite Number even in the
+      // pathological "relay forwarded EB-scale traffic in one
+      // retention window" case. If you ever see this value in
+      // production, the snapshot column representation should
+      // switch to deltas — see the helper docstring.
+      const collector = new MetricsCollector(
+        db,
+        mockSource({
+          getRelayStats: () => ({
+            capacity: 1024,
+            reservationCount: 1,
+            activeCircuits: 1,
+            bytesIn: BigInt(Number.MAX_SAFE_INTEGER) + 1_000_000n,
+            bytesOut: 0n,
+          }),
+        }),
+        dir,
+      );
+      const snap = await collector.collect();
+      expect(snap.relay_bytes_in).toBe(Number.MAX_SAFE_INTEGER);
+      expect(snap.relay_bytes_out).toBe(0);
+    });
+
+    it('persists relay columns through insertSnapshot → getLatestSnapshot round-trip (schema v10)', async () => {
+      const collector = new MetricsCollector(
+        db,
+        mockSource({
+          getRelayStats: () => ({
+            capacity: 512,
+            reservationCount: 7,
+            activeCircuits: 3,
+            bytesIn: 2_048n,
+            bytesOut: 4_096n,
+          }),
+        }),
+        dir,
+      );
+      await collector.collectAndStore();
+
+      const stored = db.getLatestSnapshot();
+      expect(stored).toBeDefined();
+      expect(stored!.relay_capacity).toBe(512);
+      expect(stored!.relay_reservation_count).toBe(7);
+      expect(stored!.relay_active_circuits).toBe(3);
+      expect(stored!.relay_bytes_in).toBe(2_048);
+      expect(stored!.relay_bytes_out).toBe(4_096);
+    });
+
+    it('isolates relay-source errors — non-relay metrics still ship', async () => {
+      const collector = new MetricsCollector(
+        db,
+        mockSource({
+          getRelayStats: () => {
+            throw new Error('relay service exploded');
+          },
+        }),
+        dir,
+      );
+      const snap = await collector.collect();
+      // Non-relay metrics survive the error path.
+      expect(snap.peer_count).toBe(5);
+      expect(snap.total_triples).toBe(1000);
+      // Relay columns end up NULL because the source threw.
+      expect(snap.relay_capacity).toBeNull();
+      expect(snap.relay_bytes_in).toBeNull();
+    });
+  });
 });

--- a/packages/node-ui/test/relay-stats-route.test.ts
+++ b/packages/node-ui/test/relay-stats-route.test.ts
@@ -1,0 +1,204 @@
+// relay-stats-route.test.ts
+//
+// Integration tests for `GET /api/relay/stats` introduced in PR2 of
+// the libp2p reachability hardening series. Three contracts under
+// test:
+//
+//   1. 404 contract — edge nodes (no relay-stats provider injected, or
+//      provider returns null) get 404 with a structured error body.
+//      Dashboards rely on this to hide the relay panel cleanly.
+//
+//   2. 200 contract — Core Nodes get the full body shape: capacity,
+//      reservationCount, activeCircuits, utilization (rounded %),
+//      stringified bigints for bytesIn/bytesOut, and the
+//      reservations[] array with derived ttlMs.
+//
+//   3. JSON safety — bigint byte counters MUST be serialised as
+//      strings (otherwise JSON.stringify throws) and ttlMs MUST be
+//      computed relative to the live `Date.now()` so dashboards see
+//      a fresh value per request.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { handleNodeUIRequest } from '../src/api.js';
+import { DashboardDB } from '../src/db.js';
+import type { RelayStats } from '@origintrail-official/dkg-core';
+
+let server: Server;
+let baseUrl: string;
+let db: DashboardDB;
+let dataDir: string;
+
+// We swap the relayStatsProvider per-test by mutating this slot, so
+// the same long-lived server instance can route both edge and core
+// scenarios. Default = no provider (edge-node 404 path).
+let currentProvider: (() => RelayStats | null) | undefined = undefined;
+
+beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), 'dkg-relay-route-test-'));
+  db = new DashboardDB({ dataDir });
+
+  server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    handleNodeUIRequest(
+      req,
+      res,
+      url,
+      db,
+      '.',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      currentProvider,
+    )
+      .then((handled) => {
+        if (!handled && !res.headersSent) {
+          res.statusCode = 404;
+          res.end('Not Found');
+        }
+      })
+      .catch((err) => {
+        if (!res.headersSent) {
+          res.statusCode = 500;
+          res.end(String(err));
+        }
+      });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  db.close();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('GET /api/relay/stats — edge node (404 contract)', () => {
+  it('returns 404 + structured error when no relayStatsProvider is wired (edge default)', async () => {
+    currentProvider = undefined;
+    const res = await fetch(`${baseUrl}/api/relay/stats`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      error: 'relay-stats-not-available',
+    });
+    expect(typeof body.message).toBe('string');
+  });
+
+  it('returns 404 when the provider returns null (relay not started yet)', async () => {
+    currentProvider = () => null;
+    const res = await fetch(`${baseUrl}/api/relay/stats`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('relay-stats-not-available');
+  });
+});
+
+describe('GET /api/relay/stats — Core Node (200 contract)', () => {
+  it('returns the full body shape with stringified bigints and computed utilization', async () => {
+    const expiry = Date.now() + 60_000; // 1 min from now
+    currentProvider = (): RelayStats => ({
+      capacity: 1024,
+      reservationCount: 256,
+      activeCircuits: 100,
+      bytesIn: 1_234_567_890n,
+      bytesOut: 9_876_543_210n,
+      reservations: [
+        {
+          peerId: '12D3KooWedge1',
+          expiryTs: expiry,
+          addr: '/ip4/1.2.3.4/tcp/4001/p2p/12D3KooWrelay',
+          limitDurationMs: 30 * 60 * 1000,
+          limitDataBytes: 1 << 24,
+        },
+      ],
+    });
+
+    const res = await fetch(`${baseUrl}/api/relay/stats`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.capacity).toBe(1024);
+    expect(body.reservationCount).toBe(256);
+    expect(body.activeCircuits).toBe(100);
+    // utilization = 256/1024 * 100 = 25.00 (rounded to 2 decimals)
+    expect(body.utilization).toBe(25);
+
+    // Bigints must serialise as strings (otherwise JSON.stringify throws).
+    expect(body.bytesIn).toBe('1234567890');
+    expect(body.bytesOut).toBe('9876543210');
+    expect(BigInt(body.bytesIn)).toBe(1_234_567_890n);
+
+    expect(Array.isArray(body.reservations)).toBe(true);
+    expect(body.reservations).toHaveLength(1);
+    const r = body.reservations[0];
+    expect(r.peerId).toBe('12D3KooWedge1');
+    expect(r.expiryTs).toBe(expiry);
+    // ttlMs is the route-derived "expiry - now" — must be > 0 and ≤ 60s.
+    expect(r.ttlMs).toBeGreaterThan(0);
+    expect(r.ttlMs).toBeLessThanOrEqual(60_000);
+    expect(r.addr).toContain('/p2p/12D3KooWrelay');
+    expect(r.limitDurationMs).toBe(30 * 60 * 1000);
+    expect(r.limitDataBytes).toBe(1 << 24);
+  });
+
+  it('utilization is null when capacity is 0 (defensive — no divide-by-zero)', async () => {
+    currentProvider = (): RelayStats => ({
+      capacity: 0,
+      reservationCount: 0,
+      activeCircuits: 0,
+      bytesIn: 0n,
+      bytesOut: 0n,
+      reservations: [],
+    });
+    const res = await fetch(`${baseUrl}/api/relay/stats`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.utilization).toBeNull();
+    expect(body.reservations).toEqual([]);
+    expect(body.bytesIn).toBe('0');
+    expect(body.bytesOut).toBe('0');
+  });
+
+  it('passes through null fields on individual reservations (libp2p may omit limit/addr)', async () => {
+    currentProvider = (): RelayStats => ({
+      capacity: 100,
+      reservationCount: 1,
+      activeCircuits: 0,
+      bytesIn: 0n,
+      bytesOut: 0n,
+      reservations: [
+        {
+          peerId: '12D3KooWnull',
+          expiryTs: null,
+          addr: null,
+          limitDurationMs: null,
+          limitDataBytes: null,
+        },
+      ],
+    });
+    const res = await fetch(`${baseUrl}/api/relay/stats`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const r = body.reservations[0];
+    expect(r.peerId).toBe('12D3KooWnull');
+    expect(r.expiryTs).toBeNull();
+    expect(r.ttlMs).toBeNull();
+    expect(r.addr).toBeNull();
+    expect(r.limitDurationMs).toBeNull();
+    expect(r.limitDataBytes).toBeNull();
+  });
+});


### PR DESCRIPTION
**Stacked on #524** (libp2p reachability hardening PR1 — capacity + TTLs + operator knob). PR2 of 3 in the series. Pure additive surface area, zero conflict footprint with PR1 or the upcoming PR3 (multi-reservation + proactive renewal).

## Why

When the relay starts shedding reservations under load, operators currently discover the problem via "agent is unreachable" reports. PR2 closes the loop:

- **Time-series visibility** of reservation count, active circuits, and bytes forwarded — written to the existing `metric_snapshots` table that already powers the dashboard.
- **Live forensic detail** at `GET /api/relay/stats`: per-reservee peerId, expiry, ttlMs, addr, limits.
- **Single dial in `DKGNodeConfig.relayServerCapacity`** (added in PR1) gives operators capacity, plus this PR gives them visibility into what they're actually serving.

Closes the operator-feedback loop the user asked for after the chatter-with-Lex blackout incident.

## What changed

### Operator-visible
- `GET /api/relay/stats` — full live state. 200 on Core Nodes, 404 on edge.
- New columns on `metric_snapshots` (schema bumped 9 → 10): `relay_capacity`, `relay_reservation_count`, `relay_active_circuits`, `relay_bytes_in`, `relay_bytes_out`. Existing `/api/metrics/history` route surfaces them automatically.

### Implementation
- `packages/core/src/libp2p-metrics-adapter.ts` (new, ~225 LOC) — minimal Metrics-interface implementation. Real behaviour is byte-counting on `/p2p-circuit` MultiaddrConnections via the libp2p MessageStream event/.send() seam; everything else is a no-op stub so libp2p starts cleanly without us shipping a full prom-client stack.
- `DKGNode.getRelayStats()` — combines the adapter's byte snapshot with `services.relay.reservations` (PeerMap) and a connection-list scan for active circuits. Returns `null` on edge nodes.
- `MetricsSource.getRelayStats?()` (optional) lets the existing collector pick up relay metrics. BigInt totals clamped to `MAX_SAFE_INTEGER` before SQLite persistence (defence in depth — would need 9 PB of forwarded traffic in one retention window to hit that ceiling).
- `insertSnapshot` defaults the v10 columns to null when callers pass pre-v10 row shapes — backward compat for external consumers.

## Tests (33 new, all green)

- `libp2p-metrics-adapter.test.ts` (15) — predicate, no-op surface (every register* method exercised), inbound/outbound counting, close idempotency, multi-conn aggregation, byteLength fallback for Uint8ArrayList chunks, snapshot immutability.
- `metrics-collector.test.ts` (5 new) — null relay columns on edge sources, pass-through on Core sources, `MAX_SAFE_INTEGER` clamping, v10 schema persistence round-trip, error isolation.
- `relay-stats-route.test.ts` (5) — 404 contract (no provider / null), full body shape with bigint→string serialisation, `utilization=null` on `capacity=0`, null reservation-field passthrough.

PR1's 12 capacity tests + 8 existing relay integration tests still pass after the merge.

## Test plan

- [ ] PR1 (#524) lands first
- [ ] Verify on Miles after rebase: `curl -s http://127.0.0.1:<port>/api/relay/stats | jq` returns 404 (Miles is an edge node)
- [ ] On a Core Node devnet: capacity utilization climbs as edges connect; `bytesIn/bytesOut` grow with chat activity
- [ ] Dashboard `/api/metrics/history` includes the new relay_* fields after 2 minutes (one snapshot interval)
- [ ] Schema migration smoke: existing v9 dashboard DBs migrate to v10 without data loss

## Stacked PR sequence

- **PR1** ← #524 — capacity + TTLs + operator knob
- **PR2** ← this PR — observability
- **PR3** ← next — 3-reservation pool + proactive renewal at TTL/2


Made with [Cursor](https://cursor.com)