### PR TITLE
feat(core,cli,agent): edge multi-reservation tuning (libp2p reachability hardening PR3/3)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -784,9 +784,12 @@ export interface DKGAgentConfig {
    * Number of relay reservations to hold in parallel when behind NAT.
    * Forwarded straight into `DKGNodeConfig.relayReservationCount`.
    * Default 3 when relayPeers are configured (N-2 tolerance to relay
-   * blackouts). Capped at 16. Ignored when no relayPeers are set.
-   * Invalid values fall back to the default with a warning. See
-   * `packages/core/src/types.ts` for the full rationale.
+   * blackouts). Capped at 16. Ignored (with a warning when set
+   * explicitly) when no relayPeers are configured or when the node
+   * itself runs a relay server — relay servers don't multi-reserve
+   * through other relays. Invalid values fall back to the default
+   * with a warning. See `packages/core/src/types.ts` for the full
+   * rationale.
    */
   relayReservationCount?: number;
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -778,6 +778,15 @@ export interface DKGAgentConfig {
    */
   relayServerCapacity?: number;
   /**
+   * Number of relay reservations to hold in parallel when behind NAT.
+   * Forwarded straight into `DKGNodeConfig.relayReservationCount`.
+   * Default 3 when relayPeers are configured (N-2 tolerance to relay
+   * blackouts). Capped at 16. Ignored when no relayPeers are set.
+   * Invalid values fall back to the default with a warning. See
+   * `packages/core/src/types.ts` for the full rationale.
+   */
+  relayReservationCount?: number;
+  /**
    * Path to the V10 Random Sampling prover write-ahead log. Core
    * nodes only; ignored on edge. When omitted, an in-memory WAL is
    * used (loses crash-recovery context on restart). Production
@@ -1341,6 +1350,7 @@ export class DKGAgent {
       privateKey: keypair.secretKey,
       nodeRole,
       relayServerCapacity: config.relayServerCapacity,
+      relayReservationCount: config.relayReservationCount,
     };
 
     const node = new DKGNode(nodeConfig);

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -125,15 +125,32 @@ down to 1 for the legacy behavior.
 }
 ```
 
-The knob is **ignored when no `relayPeers` are configured** (a public node
-doesn't need relay reservations). Invalid values (0, negative, fractional,
-non-numeric, > 16) fall back to the default with an operator-facing warning.
+The knob is:
+- **Edge-only**. Core / relay-server nodes don't multi-reserve through
+  other relays — they have public addresses for incoming traffic. The
+  daemon's CLI fallback supplies `network.relays` to both core and edge
+  by default, so without this gate every core node would also push 3
+  `/p2p-circuit` listen addrs and consume relay slots network-wide.
+  When set on a core node the value is ignored with a warning.
+- **Clamped to `relayPeers.length`**. Requesting more reservations than
+  there are configured relays can't deliver the documented tolerance
+  and just queues an unattainable target. The clamp emits a warning so
+  the misconfig is visible.
+- **Ignored when no `relayPeers` are configured** (a node not behind NAT
+  doesn't need reservations). Invalid values (0, negative, fractional,
+  non-numeric, > 16) fall back to the default with a warning.
 
 Reservation renewal is **automatic** — libp2p refreshes each reservation 5
 minutes before its 2-hour TTL expires, so no application-level renewal
-loop is required. The local watchdog still handles the harder failure
-mode of a fully-dropped relay connection (which auto-renewal can't recover
-from on its own).
+loop is required. The local relay watchdog handles the harder failure
+modes auto-renewal can't recover from:
+
+- a fully-dropped relay connection (TCP RST, NAT pinhole expiry, ISP
+  routing flap), and
+- per-relay reservation loss when multi-reservation is enabled (e.g. a
+  refresh that returns an error and removes the slot without retrying
+  on the same relay) — without this, N reservations would silently
+  degrade to N-1 and stay there until restart.
 
 ## Commands
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -102,6 +102,39 @@ To verify the live daemon's effective limit, look for the startup log line
 `[dkg-core] relay server: ulimit -n soft=<N> >= recommended <M>, ok` (or the
 WARN equivalent if the host needs tuning).
 
+## Edge tuning
+
+### Multi-reservation (NAT'd nodes)
+
+By default an edge node behind NAT holds **3 simultaneous circuit-relay
+reservations** instead of the single reservation it used to hold. Three
+gives N-2 tolerance — two relays can blink concurrently and incoming
+dialers still find a working circuit. Override with `relayReservationCount`
+in `config.json` when you want to dial up tolerance (max 16) or strip back
+down to 1 for the legacy behavior.
+
+```jsonc
+{
+  "nodeRole": "edge",
+  "relayPeers": [
+    "/dns4/relay-a.example.com/tcp/4001/p2p/12D3Koo...",
+    "/dns4/relay-b.example.com/tcp/4001/p2p/12D3Koo...",
+    "/dns4/relay-c.example.com/tcp/4001/p2p/12D3Koo..."
+  ],
+  "relayReservationCount": 3   // default; cap is 16
+}
+```
+
+The knob is **ignored when no `relayPeers` are configured** (a public node
+doesn't need relay reservations). Invalid values (0, negative, fractional,
+non-numeric, > 16) fall back to the default with an operator-facing warning.
+
+Reservation renewal is **automatic** — libp2p refreshes each reservation 5
+minutes before its 2-hour TTL expires, so no application-level renewal
+loop is required. The local watchdog still handles the harder failure
+mode of a fully-dropped relay connection (which auto-renewal can't recover
+from on its own).
+
 ## Commands
 
 | Command | Description |

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -269,6 +269,16 @@ export interface DkgConfig {
    * for the full rationale + ulimit -n requirements.
    */
   relayServerCapacity?: number;
+  /**
+   * Number of relay reservations to hold in parallel when behind NAT.
+   * Forwarded into `DKGNodeConfig.relayReservationCount`. Defaults to 3
+   * when relayPeers are configured (N-2 tolerance to relay blackouts).
+   * Capped at 16. Ignored when no relayPeers are set. Invalid values
+   * (0/neg/NaN/fractional/non-numeric/over-cap) fall back to the
+   * default with a warning. See packages/core/src/types.ts for the
+   * full rationale.
+   */
+  relayReservationCount?: number;
   /** Public multiaddrs to announce (for VPS/cloud nodes where the public IP is not on the interface). */
   announceAddresses?: string[];
   /** Bootstrap peer multiaddrs to connect to on startup (for direct peer discovery without relay). */

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -273,7 +273,10 @@ export interface DkgConfig {
    * Number of relay reservations to hold in parallel when behind NAT.
    * Forwarded into `DKGNodeConfig.relayReservationCount`. Defaults to 3
    * when relayPeers are configured (N-2 tolerance to relay blackouts).
-   * Capped at 16. Ignored when no relayPeers are set. Invalid values
+   * Capped at 16. Ignored (with a warning when set explicitly) in two
+   * cases: no relayPeers configured, or the node itself runs a relay
+   * server (core / `enableRelayServer: true` — relay servers don't
+   * multi-reserve through other relays). Invalid values
    * (0/neg/NaN/fractional/non-numeric/over-cap) fall back to the
    * default with a warning. See packages/core/src/types.ts for the
    * full rationale.

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -562,6 +562,7 @@ export async function runDaemonInner(
     announceAddresses: config.announceAddresses,
     nodeRole: role,
     relayServerCapacity: config.relayServerCapacity,
+    relayReservationCount: config.relayReservationCount,
     syncContextGraphs: syncContextGraphs,
     storeConfig: config.store ? {
       backend: config.store.backend,

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -239,6 +239,39 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(loaded.relayServerCapacity).toBe(2048);
   });
 
+  it('round-trips relayReservationCount through saveConfig/loadConfig (operator override)', async () => {
+    // PR3 multi-reservation tuning: same contract as
+    // relayServerCapacity above — operators should be able to
+    // override the default 3-reservation count from config.json.
+    // This guards against the field getting dropped from the
+    // DkgConfig schema or stripped on serialization.
+    await saveConfig({
+      name: 'test-node',
+      apiPort: 9200,
+      listenPort: 0,
+      nodeRole: 'edge',
+      relayPeers: ['/dns4/relay.example.com/tcp/4001/p2p/12D3KooWFakeRelayPeerIdForTest'],
+      relayReservationCount: 5,
+    });
+
+    const loaded = await loadConfig();
+    expect(loaded.nodeRole).toBe('edge');
+    expect(loaded.relayReservationCount).toBe(5);
+  });
+
+  it('omits relayReservationCount when not set (so DKGNode.start() applies the default)', async () => {
+    await saveConfig({
+      name: 'test-node',
+      apiPort: 9200,
+      listenPort: 0,
+      nodeRole: 'edge',
+      relayPeers: ['/dns4/relay.example.com/tcp/4001/p2p/12D3KooWFakeRelayPeerIdForTest'],
+    });
+
+    const loaded = await loadConfig();
+    expect(loaded.relayReservationCount).toBeUndefined();
+  });
+
   it('omits relayServerCapacity when not set (so DKGNode.start() applies the default)', async () => {
     await saveConfig({
       name: 'test-node',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,14 @@ export {
   EDGE_NODE_MAX_CONNECTIONS,
   deriveRelayCaps,
   checkFdLimit,
+  validateRelayServerCapacity,
+  type RelayCapacityValidation,
   type DerivedRelayCaps,
+  // Multi-reservation tuning (PR3).
+  DEFAULT_RELAY_RESERVATION_COUNT,
+  MAX_RELAY_RESERVATION_COUNT,
+  validateRelayReservationCount,
+  type RelayReservationCountValidation,
 } from './node.js';
 export {
   RelayMetricsAdapter,

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -612,6 +612,16 @@ export class DKGNode {
     const isEdgeWithRelays = !enableRelay && usableRelayCandidates.length > 0;
     if (isEdgeWithRelays) {
       const verdict = validateRelayReservationCount(this.config.relayReservationCount);
+      // Only an `ok` verdict means the operator EXPLICITLY supplied a
+      // valid count. `null` (unset → default) and a `not ok` verdict
+      // (invalid → fell back to default with its own warning) both
+      // produce the default value, and we shouldn't double-warn on
+      // clamps that result from the default sizing not matching a
+      // small relay set. Codex PR #526 round 5d caught that healthy
+      // 1-relay edge nodes were emitting a "clamping to 1" warning
+      // on every startup with no operator misconfig — buries real
+      // problems in log noise.
+      const isExplicitOverride = verdict?.ok === true;
       if (verdict == null) {
         relayReservationCount = DEFAULT_RELAY_RESERVATION_COUNT;
       } else if (verdict.ok) {
@@ -630,10 +640,15 @@ export class DKGNode {
       // gate `reservedRelayCount >= target` is achievable.
       const usableCount = usableRelayCandidates.length;
       if (relayReservationCount > usableCount) {
-        console.warn(
-          `[dkg-core] relayReservationCount=${relayReservationCount} exceeds ` +
-            `usable relay peers=${usableCount}; clamping to ${usableCount}`,
-        );
+        if (isExplicitOverride) {
+          // Operator explicitly asked for more reservations than there
+          // are usable relays — surface that loudly, it's almost
+          // certainly a config error.
+          console.warn(
+            `[dkg-core] relayReservationCount=${relayReservationCount} exceeds ` +
+              `usable relay peers=${usableCount}; clamping to ${usableCount}`,
+          );
+        }
         relayReservationCount = usableCount;
       }
     } else if (

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -349,6 +349,16 @@ export class DKGNode {
    */
   private relayReservationRedialAt: Map<string, number> = new Map();
   /**
+   * Target number of simultaneous relay reservations for this edge node
+   * (1 by default, up to `relayReservationCount` for multi-reservation
+   * edges from PR #526). The watchdog uses this to decide whether the
+   * "any /p2p-circuit self-addr exists" healthy gate is sufficient
+   * (target=1) or whether per-relay reservation presence must be
+   * verified (target>1, otherwise N-1 reservations silently degrade
+   * to N-1 forever — Codex review on PR #526).
+   */
+  private relayReservationCountTarget = 1;
+  /**
    * In-process libp2p Metrics adapter. Instantiated only when this node
    * runs a relay server (`enableRelay` true) — its sole job is counting
    * bytes that flow through `/p2p-circuit` forwarded connections so the
@@ -378,9 +388,11 @@ export class DKGNode {
     // flagged that without this guard, restarting a `nodeRole: 'core'`
     // instance as edge would still inject the old metrics adapter
     // and report the prior capacity. Cheap to do unconditionally
-    // since both fields are set below only when relay is enabled.
+    // since these fields are populated below only when relay /
+    // multi-reservation is enabled.
     this.relayMetrics = null;
     this.relayCapacity = null;
+    this.relayReservationCountTarget = 1;
 
     let privateKey;
     if (this.config.privateKey) {
@@ -444,13 +456,32 @@ export class DKGNode {
     }
     const relayCaps = effectiveRelayCapacity != null ? deriveRelayCaps(effectiveRelayCapacity) : null;
 
-    // Number of relay reservations an edge node tries to hold in parallel.
-    // Only meaningful for nodes with relayPeers configured (i.e. behind
-    // NAT). Defaults to 3 — N-2 tolerance for two simultaneous relay
-    // blackouts. Validation defends against the same surface as
-    // relayServerCapacity (0/neg/NaN/fractional/non-number/over-cap).
+    // Number of relay reservations to hold in parallel. Only meaningful
+    // for EDGE nodes behind NAT (relayPeers configured AND no relay
+    // server enabled here). Core / relay-server nodes have public
+    // addresses and don't need to reserve slots on other relays for
+    // incoming traffic — branarakic's PR #526 review caught that the
+    // daemon's CLI fallback supplies `network.relays` to both core and
+    // edge by default, so amplifying 1 → 3 on the core fleet would
+    // multiply reservation-slot consumption network-wide for no
+    // benefit.
+    //
+    // Behaviour by role:
+    //   - Core node  (enableRelay=true) + relayPeers set:  push 1
+    //     `/p2p-circuit` (legacy fallback behaviour, preserves any
+    //     defensive multi-relay config) and IGNORE
+    //     relayReservationCount with a warning if it was set.
+    //   - Edge node  (enableRelay=false) + relayPeers set: apply
+    //     relayReservationCount (default 3, clamped to relayPeers.length
+    //     so we never request more reservations than there are
+    //     configured relays to fulfil them).
+    //   - Any node without relayPeers: skip entirely.
+    //
+    // Validation defends against the same surface as relayServerCapacity
+    // (0/neg/NaN/fractional/non-number/over-cap).
     let relayReservationCount = DEFAULT_RELAY_RESERVATION_COUNT;
-    if (this.config.relayPeers?.length) {
+    const isEdgeWithRelays = !enableRelay && (this.config.relayPeers?.length ?? 0) > 0;
+    if (isEdgeWithRelays) {
       const verdict = validateRelayReservationCount(this.config.relayReservationCount);
       if (verdict == null) {
         relayReservationCount = DEFAULT_RELAY_RESERVATION_COUNT;
@@ -463,10 +494,32 @@ export class DKGNode {
         );
         relayReservationCount = DEFAULT_RELAY_RESERVATION_COUNT;
       }
-    } else if (this.config.relayReservationCount != null) {
+      // Clamp to relayPeers.length — requesting more reservations than
+      // there are configured relays can't deliver the documented N-(N-1)
+      // tolerance and risks duplicate-reservation churn against an
+      // unattainable target. Codex review on PR #526 caught this.
+      const peerCount = this.config.relayPeers!.length;
+      if (relayReservationCount > peerCount) {
+        console.warn(
+          `[dkg-core] relayReservationCount=${relayReservationCount} exceeds ` +
+            `configured relayPeers.length=${peerCount}; clamping to ${peerCount}`,
+        );
+        relayReservationCount = peerCount;
+      }
+    } else if (
+      this.config.relayReservationCount != null &&
+      !this.config.relayPeers?.length
+    ) {
       console.warn(
         `[dkg-core] relayReservationCount=${this.config.relayReservationCount} ` +
           `set but no relayPeers configured; value ignored`,
+      );
+    } else if (this.config.relayReservationCount != null && enableRelay) {
+      console.warn(
+        `[dkg-core] relayReservationCount=${this.config.relayReservationCount} ` +
+          `set but this node runs a relay server (nodeRole=${this.config.nodeRole ?? 'edge'}, ` +
+          `enableRelayServer=${this.config.enableRelayServer}); ` +
+          `relay servers don't multi-reserve through other relays; value ignored`,
       );
     }
 
@@ -486,18 +539,18 @@ export class DKGNode {
       // which serializes our N pending /p2p-circuit slots and effectively
       // collapses multi-reservation back to single-reservation. Set to
       // relayReservationCount so all N slots are attempted concurrently
-      // at startup. Only set when behind NAT (otherwise no relayPeers
-      // are configured and the field is irrelevant).
+      // at startup. Only set on EDGE nodes with relayPeers — core /
+      // relay-server nodes don't multi-reserve through other relays.
       circuitRelayTransport(
         relayCaps
           ? {
               maxInboundStopStreams: relayCaps.maxInboundStopStreams,
               maxOutboundStopStreams: relayCaps.maxOutboundStopStreams,
-              ...(this.config.relayPeers?.length
+              ...(isEdgeWithRelays
                 ? { reservationConcurrency: relayReservationCount }
                 : {}),
             }
-          : this.config.relayPeers?.length
+          : isEdgeWithRelays
             ? { reservationConcurrency: relayReservationCount }
             : undefined,
       ),
@@ -618,12 +671,24 @@ export class DKGNode {
     // slot in libp2p's transport reservation store (see
     // `@libp2p/circuit-relay-v2/transport/reservation-store.js#reserveRelay`),
     // so pushing N entries → N reservations on N (preferentially distinct)
-    // relays. Combined with `reservationConcurrency` above, this gives
-    // the edge N-(N-1) tolerance to relay failures.
-    if (this.config.relayPeers?.length) {
+    // relays.
+    //
+    // Edge nodes get N (relayReservationCount, default 3, clamped to
+    // relayPeers.length) for N-(N-1) fault tolerance. Core / relay-server
+    // nodes that also have relayPeers set keep the legacy single
+    // `/p2p-circuit` (preserves any defensive multi-relay config without
+    // multiplying slot consumption across the core fleet — branarakic
+    // PR #526 review).
+    if (isEdgeWithRelays) {
       for (let i = 0; i < relayReservationCount; i++) {
         listenAddrs.push('/p2p-circuit');
       }
+      this.relayReservationCountTarget = relayReservationCount;
+    } else if (this.config.relayPeers?.length) {
+      // Core node with explicit relayPeers — push the legacy single
+      // /p2p-circuit listen addr.
+      listenAddrs.push('/p2p-circuit');
+      this.relayReservationCountTarget = 1;
     }
 
     this.node = await createLibp2p<DKGServices>({
@@ -768,19 +833,48 @@ export class DKGNode {
         a.includes(`/p2p/${relayPidStr}/p2p-circuit`),
       );
 
-      // Happy path: transport is up AND either this relay is the one
-      // holding our reservation, OR we already have a reservation on some
-      // other relay (libp2p only requests one at a time by default, so
-      // "other relays are connected but idle" is the normal steady state).
-      if (transportUp && (thisRelayHasReservation || haveAnyReservation)) {
+      // Happy path semantics depend on the multi-reservation target:
+      //
+      // - Single reservation (target=1): "transport up AND any reservation
+      //   exists" is healthy — historical libp2p behavior reserved one
+      //   relay slot at a time, so other configured relays sit connected
+      //   but idle as the steady state. Don't tear them down.
+      //
+      // - Multi reservation (target>1, PR #526 edge nodes): EACH relay
+      //   must hold a reservation. Without this, if reservation N gets
+      //   dropped (e.g. libp2p's auto-renewal at TTL/2 failed because
+      //   the relay returned an error), the other N-1 reservations keep
+      //   `haveAnyReservation=true` and the watchdog would silently let
+      //   N degrade to N-1 forever — Codex review on PR #526 flagged
+      //   this as the silent-degradation bug. Falling through to the
+      //   "no reservation" branch redials this specific relay and
+      //   restores the slot.
+      const reservationGateSatisfied =
+        thisRelayHasReservation ||
+        (this.relayReservationCountTarget <= 1 && haveAnyReservation);
+      if (transportUp && reservationGateSatisfied) {
         this.relayReservationRedialAt.delete(relayPidStr);
         continue;
       }
 
-      // Transport is up but we have ZERO reservations across all relays.
-      // Something has gone wrong in libp2p's reservation-pool management;
-      // force a re-listen on this relay by dropping + redialing.
-      if (transportUp && !haveAnyReservation) {
+      // Reservation-recovery branch. Two scenarios both call for
+      // dropping + redialing THIS relay:
+      //
+      //   1. (Single-reservation) transport is up but ZERO reservations
+      //      exist anywhere — libp2p's reservation-pool management has
+      //      lost the only slot.
+      //
+      //   2. (Multi-reservation, target > 1) transport is up but this
+      //      specific relay no longer holds a reservation, even though
+      //      others do. Without this branch, the watchdog would let
+      //      N degrade to N-1 forever — Codex review on PR #526.
+      const needsForcedReservationRedial =
+        transportUp &&
+        (
+          !haveAnyReservation ||
+          (this.relayReservationCountTarget > 1 && !thisRelayHasReservation)
+        );
+      if (needsForcedReservationRedial) {
         const lastForcedRedial = this.relayReservationRedialAt.get(relayPidStr) ?? 0;
         if (now - lastForcedRedial < RELAY_RESERVATION_GRACE_MS) {
           // We just redialed; give libp2p time to finish negotiating a new
@@ -797,8 +891,11 @@ export class DKGNode {
         // Actual corrective action below (drop + redial); this is a
         // real failure the watchdog must back off on.
         onlyWaitingOnGraceWindow = false;
+        const reason = !haveAnyReservation
+          ? 'no circuit reservation anywhere (0 /p2p-circuit self-addrs)'
+          : `target=${this.relayReservationCountTarget} but this relay holds no reservation`;
         console.log(
-          `[${ts()}] Relay watchdog: no circuit reservation anywhere (0 /p2p-circuit self-addrs); ` +
+          `[${ts()}] Relay watchdog: ${reason}; ` +
           `dropping + redialing ${short(relayPidStr)} to force reserve`,
         );
         this.relayReservationRedialAt.set(relayPidStr, now);
@@ -824,15 +921,22 @@ export class DKGNode {
         } catch (err: any) {
           console.log(`[${ts()}] Relay watchdog: reservation-redial failed for ${short(relayPidStr)}: ${err.message}`);
         }
-        // Stop after one reservation-recovery attempt per tick. libp2p's
-        // circuit-relay-v2 only holds one reservation at a time by default,
-        // so if this redial restored a reservation, every remaining relay
-        // in `this.relayTargets` would otherwise still see the stale
-        // `!haveAnyReservation` snapshot from line ~251 and tear-down +
-        // redial itself in the same tick, briefly dropping all relay paths
-        // at once. One recovery per tick is enough; the next tick re-reads
-        // multiaddrs and will handle any remaining unhealthy relays.
-        if (redialed) break;
+        // For single-reservation deployments (target<=1) stop after one
+        // recovery attempt per tick: libp2p only holds one reservation at
+        // a time, so if this redial restored it, every remaining relay
+        // in `this.relayTargets` would still see the stale
+        // `!haveAnyReservation` snapshot and tear-down + redial itself
+        // in the same tick, briefly dropping all relay paths at once.
+        // For multi-reservation (target>1) we want to keep going so all
+        // missing slots are restored in a single tick — each relay has
+        // an independent per-relay reservation, so restoring relay A
+        // doesn't change whether relay B needs the same recovery. We
+        // refresh the snapshot first so the next iteration sees the
+        // up-to-date reservation set.
+        if (redialed) {
+          if (this.relayReservationCountTarget <= 1) break;
+          refreshReservationSnapshot();
+        }
         continue;
       }
 
@@ -986,6 +1090,7 @@ export class DKGNode {
     this.relayedPeers.clear();
     this.relayMetrics = null;
     this.relayCapacity = null;
+    this.relayReservationCountTarget = 1;
     await this.node.stop();
     this.node = null;
   }

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -73,6 +73,71 @@ export const RELAY_RESERVATION_TTL_MS = 2 * 60 * 60 * 1000;
 /** maxConnections for nodes that don't run a relay server (edge default). */
 export const EDGE_NODE_MAX_CONNECTIONS = 500;
 
+/**
+ * Default number of relay reservations an edge node tries to hold
+ * simultaneously. The previous default (1) was a single point of failure:
+ * if the only reserved relay went unreachable, the edge dropped off the
+ * network until the watchdog redialed and re-reserved. Holding 3 in
+ * parallel gives N-2 tolerance — two relays can blink concurrently and
+ * incoming dialers can still find a working circuit.
+ *
+ * Implementation: each `/p2p-circuit` listen address triggers a separate
+ * reservation slot in libp2p's transport reservation store, so the
+ * config translates to N duplicate `/p2p-circuit` entries in the
+ * libp2p `addresses.listen` array, paired with `reservationConcurrency:
+ * N` on the circuit-relay transport so they're attempted in parallel.
+ *
+ * NOTE: libp2p auto-renews each reservation 5 minutes before expiry
+ * (REFRESH_TIMEOUT in @libp2p/circuit-relay-v2/transport/reservation-store.js),
+ * so no application-level proactive renewal is needed in our watchdog.
+ * The watchdog still handles the harder failure mode of a fully-dropped
+ * relay connection, which auto-renewal can't recover from.
+ */
+export const DEFAULT_RELAY_RESERVATION_COUNT = 3;
+/**
+ * Hard cap on `relayReservationCount` to keep operators from accidentally
+ * configuring an edge node to hammer the network. Reserving on more than
+ * ~16 relays at a time is a smell — it costs memory + control-stream
+ * keepalive on every reserved relay, and the marginal failure-tolerance
+ * benefit past 4-5 is minimal.
+ */
+export const MAX_RELAY_RESERVATION_COUNT = 16;
+
+/**
+ * Validate an operator-supplied `relayReservationCount`. Same shape +
+ * defensive surface as `validateRelayServerCapacity` (rejects 0,
+ * negatives, NaN, Infinity, fractional, non-numbers). Additionally
+ * caps at `MAX_RELAY_RESERVATION_COUNT` to avoid the
+ * everyone-reserves-on-everyone failure mode on large networks.
+ */
+export type RelayReservationCountValidation =
+  | { ok: true; value: number }
+  | { ok: false; reason: string };
+export function validateRelayReservationCount(
+  input: unknown,
+): RelayReservationCountValidation | null {
+  if (input == null) return null;
+  if (typeof input !== 'number') {
+    return { ok: false, reason: `expected number, got ${typeof input}` };
+  }
+  if (!Number.isFinite(input)) {
+    return { ok: false, reason: `expected finite number, got ${input}` };
+  }
+  if (!Number.isInteger(input)) {
+    return { ok: false, reason: `expected integer, got ${input}` };
+  }
+  if (input < 1) {
+    return { ok: false, reason: `expected >= 1, got ${input}` };
+  }
+  if (input > MAX_RELAY_RESERVATION_COUNT) {
+    return {
+      ok: false,
+      reason: `expected <= ${MAX_RELAY_RESERVATION_COUNT}, got ${input}`,
+    };
+  }
+  return { ok: true, value: input };
+}
+
 export interface DerivedRelayCaps {
   maxReservations: number;
   maxConnections: number;
@@ -379,6 +444,32 @@ export class DKGNode {
     }
     const relayCaps = effectiveRelayCapacity != null ? deriveRelayCaps(effectiveRelayCapacity) : null;
 
+    // Number of relay reservations an edge node tries to hold in parallel.
+    // Only meaningful for nodes with relayPeers configured (i.e. behind
+    // NAT). Defaults to 3 — N-2 tolerance for two simultaneous relay
+    // blackouts. Validation defends against the same surface as
+    // relayServerCapacity (0/neg/NaN/fractional/non-number/over-cap).
+    let relayReservationCount = DEFAULT_RELAY_RESERVATION_COUNT;
+    if (this.config.relayPeers?.length) {
+      const verdict = validateRelayReservationCount(this.config.relayReservationCount);
+      if (verdict == null) {
+        relayReservationCount = DEFAULT_RELAY_RESERVATION_COUNT;
+      } else if (verdict.ok) {
+        relayReservationCount = verdict.value;
+      } else {
+        console.warn(
+          `[dkg-core] relayReservationCount=${String(this.config.relayReservationCount)} ` +
+            `is invalid (${verdict.reason}); falling back to default ${DEFAULT_RELAY_RESERVATION_COUNT}`,
+        );
+        relayReservationCount = DEFAULT_RELAY_RESERVATION_COUNT;
+      }
+    } else if (this.config.relayReservationCount != null) {
+      console.warn(
+        `[dkg-core] relayReservationCount=${this.config.relayReservationCount} ` +
+          `set but no relayPeers configured; value ignored`,
+      );
+    }
+
     // TCP keepAlive helps prevent idle relay connections from being dropped by
     // middleboxes or remote timeouts (common cause of ECONNRESET).
     const transports: any[] = [
@@ -389,13 +480,26 @@ export class DKGNode {
       // implies. Bump the transport-side caps to match the server-side
       // capacity. Edge nodes keep the upstream defaults (passing
       // undefined here is the same as omitting the field).
+      //
+      // reservationConcurrency controls how many reservations libp2p will
+      // attempt in parallel on different relays. Default upstream is 1,
+      // which serializes our N pending /p2p-circuit slots and effectively
+      // collapses multi-reservation back to single-reservation. Set to
+      // relayReservationCount so all N slots are attempted concurrently
+      // at startup. Only set when behind NAT (otherwise no relayPeers
+      // are configured and the field is irrelevant).
       circuitRelayTransport(
         relayCaps
           ? {
               maxInboundStopStreams: relayCaps.maxInboundStopStreams,
               maxOutboundStopStreams: relayCaps.maxOutboundStopStreams,
+              ...(this.config.relayPeers?.length
+                ? { reservationConcurrency: relayReservationCount }
+                : {}),
             }
-          : undefined,
+          : this.config.relayPeers?.length
+            ? { reservationConcurrency: relayReservationCount }
+            : undefined,
       ),
     ];
 
@@ -510,8 +614,16 @@ export class DKGNode {
 
     // When relay peers are configured, listen on circuit addresses to ensure
     // the node requests a reservation and becomes reachable through relays.
+    // Each `/p2p-circuit` listen address triggers a separate reservation
+    // slot in libp2p's transport reservation store (see
+    // `@libp2p/circuit-relay-v2/transport/reservation-store.js#reserveRelay`),
+    // so pushing N entries → N reservations on N (preferentially distinct)
+    // relays. Combined with `reservationConcurrency` above, this gives
+    // the edge N-(N-1) tolerance to relay failures.
     if (this.config.relayPeers?.length) {
-      listenAddrs.push('/p2p-circuit');
+      for (let i = 0; i < relayReservationCount; i++) {
+        listenAddrs.push('/p2p-circuit');
+      }
     }
 
     this.node = await createLibp2p<DKGServices>({

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -541,11 +541,16 @@ export class DKGNode {
       // order on dial, so a stale transport doesn't take the relay
       // out of rotation. Same peerId with the SAME multiaddr (e.g.
       // `[relayA, relayA]` or copy-paste) is the true-duplicate
-      // case and gets dropped + warned. Codex PR #526 round 5c
-      // caught that the round-5 fix conflated these two cases and
-      // dropped alternate-transport addrs as duplicates.
+      // case and gets dropped + warned.
+      //
+      // Map keyed by `pid.toString()` (the canonical peerId
+      // encoding) rather than the raw `/p2p/<value>` string a user
+      // might have written — Codex PR #526 round 5e caught that the
+      // raw string can be base58btc OR base32 OR other encodings of
+      // the same peerId, so a mixed-encoding config would bypass
+      // the dedupe and inflate `usableRelayCandidates.length`.
       const candidateByPid = new Map<string, RelayTarget>();
-      const seenAddrStrings = new Set<string>();
+      const seenAddrKeys = new Set<string>();
       let malformed = 0;
       let selfHits = 0;
       let dupAddrs = 0;
@@ -574,31 +579,47 @@ export class DKGNode {
           selfHits += 1;
           continue;
         }
-        const maStr = ma.toString();
-        if (seenAddrStrings.has(maStr)) {
+        // Build a canonical address key (transport prefix + canonical
+        // peerId) so duplicates are detected regardless of which
+        // peerId encoding the operator wrote.
+        const pidStr = pid.toString();
+        const transportPrefix = ma.toString().split('/p2p/')[0] ?? ma.toString();
+        const canonicalAddrKey = `${transportPrefix}/p2p/${pidStr}`;
+        if (seenAddrKeys.has(canonicalAddrKey)) {
           dupAddrs += 1;
           continue;
         }
-        seenAddrStrings.add(maStr);
-        const existing = candidateByPid.get(p2p);
+        seenAddrKeys.add(canonicalAddrKey);
+        const existing = candidateByPid.get(pidStr);
         if (existing) {
           existing.addrs.push(ma);
           altAddrs += 1;
         } else {
           const target: RelayTarget = { peerId: pid, addrs: [ma] };
-          candidateByPid.set(p2p, target);
+          candidateByPid.set(pidStr, target);
           usableRelayCandidates.push(target);
         }
       }
-      if (malformed || selfHits || dupAddrs || altAddrs) {
-        const reasons: string[] = [];
-        if (malformed) reasons.push(`${malformed} malformed (no /p2p component or unparseable)`);
-        if (selfHits) reasons.push(`${selfHits} pointing at this node's own peerId`);
-        if (dupAddrs) reasons.push(`${dupAddrs} exact-duplicate multiaddrs`);
+      // Codex PR #526 round 5e: only emit at warn level when there's
+      // an actual problem (malformed/self/duplicate). Pure alternate-
+      // address aggregation is a healthy supported config and
+      // shouldn't trip operator log filters at warning level on
+      // every startup.
+      const problemReasons: string[] = [];
+      if (malformed) problemReasons.push(`${malformed} malformed (no /p2p component or unparseable)`);
+      if (selfHits) problemReasons.push(`${selfHits} pointing at this node's own peerId`);
+      if (dupAddrs) problemReasons.push(`${dupAddrs} exact-duplicate multiaddrs`);
+      if (problemReasons.length > 0) {
+        const reasons = [...problemReasons];
         if (altAddrs) reasons.push(`${altAddrs} alternate addrs merged into existing relay peers`);
         console.warn(
           `[dkg-core] relayPeers: ${this.config.relayPeers.length} entries supplied, ` +
             `${usableRelayCandidates.length} distinct relay peers usable (${reasons.join(', ')})`,
+        );
+      } else if (altAddrs) {
+        console.log(
+          `[dkg-core] relayPeers: ${this.config.relayPeers.length} entries supplied, ` +
+            `${usableRelayCandidates.length} distinct relay peers (${altAddrs} alternate addrs merged)`,
         );
       }
     }

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -816,9 +816,21 @@ export class DKGNode {
     // hint stays accurate within a single iteration.
     let circuitSelfAddrs = node.getMultiaddrs().map(ma => ma.toString()).filter(a => a.includes('/p2p-circuit'));
     let haveAnyReservation = circuitSelfAddrs.length > 0;
+    // Distinct count of CONFIGURED relays that currently hold a
+    // reservation. This is the "do we have enough reservations?"
+    // signal — not "does every peer hold one?". Recomputed alongside
+    // `circuitSelfAddrs` so a successful mid-tick redial that brings
+    // the count up to target flips remaining peers' gates from
+    // "needs recovery" to "satisfied" without further churn.
+    const computeReservedRelayCount = () => this.relayTargets.filter(({ peerId }) =>
+      !peerId.equals(node.peerId) &&
+      circuitSelfAddrs.some(a => a.includes(`/p2p/${peerId.toString()}/p2p-circuit`)),
+    ).length;
+    let reservedRelayCount = computeReservedRelayCount();
     const refreshReservationSnapshot = () => {
       circuitSelfAddrs = node.getMultiaddrs().map(ma => ma.toString()).filter(a => a.includes('/p2p-circuit'));
       haveAnyReservation = circuitSelfAddrs.length > 0;
+      reservedRelayCount = computeReservedRelayCount();
     };
     const now = Date.now();
 
@@ -833,46 +845,48 @@ export class DKGNode {
         a.includes(`/p2p/${relayPidStr}/p2p-circuit`),
       );
 
-      // Happy path semantics depend on the multi-reservation target:
+      // Happy path. A peer's gate is satisfied if either:
       //
-      // - Single reservation (target=1): "transport up AND any reservation
-      //   exists" is healthy — historical libp2p behavior reserved one
-      //   relay slot at a time, so other configured relays sit connected
-      //   but idle as the steady state. Don't tear them down.
+      //   (a) this peer personally holds our reservation, OR
+      //   (b) we already have ENOUGH distinct reservations elsewhere
+      //       (`reservedRelayCount >= target`).
       //
-      // - Multi reservation (target>1, PR #526 edge nodes): EACH relay
-      //   must hold a reservation. Without this, if reservation N gets
-      //   dropped (e.g. libp2p's auto-renewal at TTL/2 failed because
-      //   the relay returned an error), the other N-1 reservations keep
-      //   `haveAnyReservation=true` and the watchdog would silently let
-      //   N degrade to N-1 forever — Codex review on PR #526 flagged
-      //   this as the silent-degradation bug. Falling through to the
-      //   "no reservation" branch redials this specific relay and
-      //   restores the slot.
+      // The total-count check (b) is the critical fix vs round 2 of
+      // PR #526. The previous "every relay must hold one when target>1"
+      // gate broke valid configs like `relayPeers=3, relayReservationCount=2`:
+      // the third peer never reserves (count clamps at target=2), so
+      // `!thisRelayHasReservation` stayed true forever and the watchdog
+      // would tear down + redial it on every grace-window expiry.
+      // Codex review on PR #526 round 3 flagged this — see
+      // https://github.com/OriginTrail/dkg/pull/526. Counting reserved
+      // relays preserves the round-2 fix (silent degradation when
+      // target > current is still detected and recovered) without
+      // demanding 100% coverage when target < relayPeers.length.
       const reservationGateSatisfied =
         thisRelayHasReservation ||
-        (this.relayReservationCountTarget <= 1 && haveAnyReservation);
+        reservedRelayCount >= this.relayReservationCountTarget;
       if (transportUp && reservationGateSatisfied) {
         this.relayReservationRedialAt.delete(relayPidStr);
         continue;
       }
 
-      // Reservation-recovery branch. Two scenarios both call for
-      // dropping + redialing THIS relay:
+      // Reservation-recovery branch. Drop + redial THIS relay when:
       //
-      //   1. (Single-reservation) transport is up but ZERO reservations
-      //      exist anywhere — libp2p's reservation-pool management has
-      //      lost the only slot.
+      //   1. transport is up AND reservations exist nowhere — libp2p's
+      //      reservation-pool management has lost every slot.
       //
-      //   2. (Multi-reservation, target > 1) transport is up but this
-      //      specific relay no longer holds a reservation, even though
-      //      others do. Without this branch, the watchdog would let
-      //      N degrade to N-1 forever — Codex review on PR #526.
+      //   2. transport is up AND `reservedRelayCount < target` AND this
+      //      specific peer is missing one — try to claim one of the
+      //      missing slots from this peer. Once the redial succeeds
+      //      (`refreshReservationSnapshot` updates `reservedRelayCount`),
+      //      remaining peers' gates may flip to "satisfied" naturally
+      //      and we stop redialing — no over-reservation, no churn on
+      //      the unconfigured-as-target peers.
       const needsForcedReservationRedial =
         transportUp &&
         (
           !haveAnyReservation ||
-          (this.relayReservationCountTarget > 1 && !thisRelayHasReservation)
+          (reservedRelayCount < this.relayReservationCountTarget && !thisRelayHasReservation)
         );
       if (needsForcedReservationRedial) {
         const lastForcedRedial = this.relayReservationRedialAt.get(relayPidStr) ?? 0;
@@ -893,7 +907,7 @@ export class DKGNode {
         onlyWaitingOnGraceWindow = false;
         const reason = !haveAnyReservation
           ? 'no circuit reservation anywhere (0 /p2p-circuit self-addrs)'
-          : `target=${this.relayReservationCountTarget} but this relay holds no reservation`;
+          : `${reservedRelayCount}/${this.relayReservationCountTarget} reservations held; this relay missing`;
         console.log(
           `[${ts()}] Relay watchdog: ${reason}; ` +
           `dropping + redialing ${short(relayPidStr)} to force reserve`,

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -494,17 +494,43 @@ export class DKGNode {
         );
         relayReservationCount = DEFAULT_RELAY_RESERVATION_COUNT;
       }
-      // Clamp to relayPeers.length — requesting more reservations than
-      // there are configured relays can't deliver the documented N-(N-1)
-      // tolerance and risks duplicate-reservation churn against an
-      // unattainable target. Codex review on PR #526 caught this.
-      const peerCount = this.config.relayPeers!.length;
-      if (relayReservationCount > peerCount) {
+      // Clamp to the count of DISTINCT relay peers — requesting more
+      // reservations than there are unique relays can't deliver the
+      // documented N-(N-1) tolerance and risks duplicate-reservation
+      // churn against an unattainable target. Codex review on PR #526
+      // round 1 caught the over-cap case; round 4 caught that we also
+      // need to dedupe by peerId here, otherwise a config like
+      // `[relayA, relayA]` with `relayReservationCount: 2` looks like
+      // 2 distinct slots to the clamp and the watchdog later "sees"
+      // 2 reservations when only 1 actual relay is involved — which
+      // defeats the redundancy guarantee. Parsing failures are
+      // tolerated here (skipped); the same parser runs again at the
+      // relayTargets push and any malformed entry is dropped consistently.
+      const { multiaddr: parseMultiaddr } = await import('@multiformats/multiaddr');
+      const distinctRelayPeerIds = new Set<string>();
+      for (const raw of this.config.relayPeers!) {
+        try {
+          const ma = parseMultiaddr(raw);
+          const p2p = ma.getComponents().find((c) => c.name === 'p2p')?.value;
+          if (p2p) distinctRelayPeerIds.add(p2p);
+        } catch {
+          // Skipped; will also be dropped at relayTargets push.
+        }
+      }
+      const distinctRelayPeerCount = distinctRelayPeerIds.size;
+      if (distinctRelayPeerCount < this.config.relayPeers!.length) {
+        console.warn(
+          `[dkg-core] relayPeers contains ${this.config.relayPeers!.length} entries but only ` +
+            `${distinctRelayPeerCount} distinct peerIds; using distinct count for ` +
+            `multi-reservation sizing`,
+        );
+      }
+      if (relayReservationCount > distinctRelayPeerCount) {
         console.warn(
           `[dkg-core] relayReservationCount=${relayReservationCount} exceeds ` +
-            `configured relayPeers.length=${peerCount}; clamping to ${peerCount}`,
+            `distinct relay peers=${distinctRelayPeerCount}; clamping to ${distinctRelayPeerCount}`,
         );
-        relayReservationCount = peerCount;
+        relayReservationCount = distinctRelayPeerCount;
       }
     } else if (
       this.config.relayReservationCount != null &&
@@ -725,6 +751,12 @@ export class DKGNode {
     if (this.config.relayPeers?.length) {
       const { multiaddr } = await import('@multiformats/multiaddr');
 
+      // Dedup by peerId (Codex PR #526 round 4): without this a duplicate
+      // entry like `[relayA, relayA]` would be pushed twice, the watchdog
+      // would iterate it twice, and `reservedRelayCount` would count the
+      // single underlying reservation twice — making the gate think the
+      // target is met when only one actual relay is reserved.
+      const seenRelayPeerIds = new Set<string>();
       for (const addr of this.config.relayPeers) {
         const ma = multiaddr(addr);
         const p2pComponent = ma.getComponents().find(c => c.name === 'p2p');
@@ -732,6 +764,8 @@ export class DKGNode {
 
         const peerId = peerIdFromString(p2pComponent.value);
         if (peerId.equals(this.node.peerId)) continue;
+        if (seenRelayPeerIds.has(p2pComponent.value)) continue;
+        seenRelayPeerIds.add(p2pComponent.value);
 
         this.relayTargets.push({ peerId, addr: ma });
 

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -304,7 +304,15 @@ export function checkFdLimit(
 
 interface RelayTarget {
   peerId: ReturnType<typeof peerIdFromString>;
-  addr: any;
+  /**
+   * All multiaddrs supplied for this relay peer. A config like
+   * `[relayA-tcp, relayA-ws]` (same peerId, different transports)
+   * collapses to one `RelayTarget` whose `addrs` holds both — libp2p
+   * tries each in order so a stale address doesn't take the relay
+   * out of rotation. Codex PR #526 round 5c caught the round-5
+   * regression where same-peerId entries were dropped as duplicates.
+   */
+  addrs: any[];
 }
 
 /**
@@ -527,10 +535,21 @@ export class DKGNode {
     const usableRelayCandidates: RelayTarget[] = [];
     if (this.config.relayPeers?.length) {
       const { multiaddr: parseMultiaddr } = await import('@multiformats/multiaddr');
-      const seenPids = new Set<string>();
+      // Per-peerId aggregation: same peerId with DIFFERENT multiaddrs
+      // (e.g. `[relayA-tcp, relayA-ws]`) collapses to one
+      // `RelayTarget` carrying BOTH addrs — libp2p tries each in
+      // order on dial, so a stale transport doesn't take the relay
+      // out of rotation. Same peerId with the SAME multiaddr (e.g.
+      // `[relayA, relayA]` or copy-paste) is the true-duplicate
+      // case and gets dropped + warned. Codex PR #526 round 5c
+      // caught that the round-5 fix conflated these two cases and
+      // dropped alternate-transport addrs as duplicates.
+      const candidateByPid = new Map<string, RelayTarget>();
+      const seenAddrStrings = new Set<string>();
       let malformed = 0;
       let selfHits = 0;
-      let dupes = 0;
+      let dupAddrs = 0;
+      let altAddrs = 0;
       for (const raw of this.config.relayPeers) {
         let ma;
         try {
@@ -555,21 +574,31 @@ export class DKGNode {
           selfHits += 1;
           continue;
         }
-        if (seenPids.has(p2p)) {
-          dupes += 1;
+        const maStr = ma.toString();
+        if (seenAddrStrings.has(maStr)) {
+          dupAddrs += 1;
           continue;
         }
-        seenPids.add(p2p);
-        usableRelayCandidates.push({ peerId: pid, addr: ma });
+        seenAddrStrings.add(maStr);
+        const existing = candidateByPid.get(p2p);
+        if (existing) {
+          existing.addrs.push(ma);
+          altAddrs += 1;
+        } else {
+          const target: RelayTarget = { peerId: pid, addrs: [ma] };
+          candidateByPid.set(p2p, target);
+          usableRelayCandidates.push(target);
+        }
       }
-      if (malformed || selfHits || dupes) {
+      if (malformed || selfHits || dupAddrs || altAddrs) {
         const reasons: string[] = [];
         if (malformed) reasons.push(`${malformed} malformed (no /p2p component or unparseable)`);
         if (selfHits) reasons.push(`${selfHits} pointing at this node's own peerId`);
-        if (dupes) reasons.push(`${dupes} duplicate peerIds`);
+        if (dupAddrs) reasons.push(`${dupAddrs} exact-duplicate multiaddrs`);
+        if (altAddrs) reasons.push(`${altAddrs} alternate addrs merged into existing relay peers`);
         console.warn(
           `[dkg-core] relayPeers: ${this.config.relayPeers.length} entries supplied, ` +
-            `${usableRelayCandidates.length} usable (skipped ${reasons.join(', ')})`,
+            `${usableRelayCandidates.length} distinct relay peers usable (${reasons.join(', ')})`,
         );
       }
     }
@@ -668,10 +697,18 @@ export class DKGNode {
     ];
 
     // Nodes that already know their NAT status skip autoNAT probing:
-    // - relayPeers set → agent behind NAT (knows it needs relay)
+    // - usable relayPeers configured → agent behind NAT (knows it needs relay)
     // - enableRelayServer/core → public node acting as relay
+    //
+    // Gated on `usableRelayCandidates.length > 0` rather than raw
+    // `relayPeers.length` (Codex PR #526 round 5c): when every
+    // configured relay is filtered out as malformed/self/duplicate,
+    // the node falls back to the no-relays path and would otherwise
+    // also lose AutoNAT — leaving it with neither relay reachability
+    // nor NAT probing. Re-using the same predicate as
+    // `isEdgeWithRelays` keeps the two gates in sync.
     const useAutoNAT = this.config.enableAutoNAT ??
-      !(this.config.relayPeers?.length || enableRelay);
+      !(usableRelayCandidates.length > 0 || enableRelay);
 
     const services: Record<string, any> = {
       identify: identify(),
@@ -853,15 +890,20 @@ export class DKGNode {
       for (const candidate of usableRelayCandidates) {
         this.relayTargets.push(candidate);
 
+        // Merge ALL addrs for this peer so libp2p can fall back to
+        // alternates if the primary multiaddr is stale (Codex PR #526
+        // round 5c).
         await this.node.peerStore.merge(candidate.peerId, {
-          multiaddrs: [candidate.addr],
+          multiaddrs: candidate.addrs,
           tags: {
             'keep-alive-dkg-relay': { value: 100 },
           },
         });
 
         try {
-          await this.node.dial(candidate.addr);
+          // libp2p `dial` accepts an array of multiaddrs and tries
+          // them in order — leverages every supplied transport.
+          await this.node.dial(candidate.addrs);
         } catch {
           // watchdog will retry
         }
@@ -973,7 +1015,7 @@ export class DKGNode {
     let forcedRedialsThisTick = 0;
     const now = Date.now();
 
-    for (const { peerId, addr } of this.relayTargets) {
+    for (const { peerId, addrs } of this.relayTargets) {
       if (peerId.equals(node.peerId)) continue;
 
       const relayPidStr = peerId.toString();
@@ -1029,15 +1071,19 @@ export class DKGNode {
         );
       if (needsForcedReservationRedial) {
         // Honour the per-tick redial budget. `missingSlotsAtTickStart`
-        // is the deficit at tick start; once we've dispatched dials
-        // for every missing slot we stop, even if the new
-        // `/p2p-circuit` self-addrs haven't shown up yet — the
-        // in-flight reservations will fill the deficit and the next
-        // tick will reassess. Treat this as a benign "still
+        // is the deficit at tick start; once we've SUCCESSFULLY
+        // dispatched dials for every missing slot we stop, even if
+        // the new `/p2p-circuit` self-addrs haven't shown up yet —
+        // the in-flight reservations will fill the deficit and the
+        // next tick will reassess. Treat this as a benign "still
         // recovering" state, same as a recent forced redial within
         // the grace window: account for it as not-fully-healthy but
         // don't apply exponential backoff (the next tick needs to
         // arrive to see whether the in-flight dials succeeded).
+        //
+        // Only SUCCESSFUL redials count against the budget (Codex
+        // PR #526 round 5c): a failed `node.dial()` shouldn't lock us
+        // out of trying the next eligible relay this tick.
         if (
           this.relayReservationCountTarget > 1 &&
           missingSlotsAtTickStart > 0 &&
@@ -1058,7 +1104,6 @@ export class DKGNode {
           continue;
         }
 
-        forcedRedialsThisTick += 1;
         allHealthy = false;
         // Actual corrective action below (drop + redial); this is a
         // real failure the watchdog must back off on.
@@ -1087,8 +1132,11 @@ export class DKGNode {
         await new Promise(r => setTimeout(r, delayMs));
         let redialed = false;
         try {
-          await node.dial(addr);
+          // Pass all addrs so libp2p tries each transport in order
+          // (preserves multi-multiaddr-per-relay configs).
+          await node.dial(addrs);
           redialed = true;
+          forcedRedialsThisTick += 1;
           console.log(`[${ts()}] Relay watchdog: redialed ${short(relayPidStr)} for fresh reservation`);
         } catch (err: any) {
           console.log(`[${ts()}] Relay watchdog: reservation-redial failed for ${short(relayPidStr)}: ${err.message}`);
@@ -1120,7 +1168,7 @@ export class DKGNode {
       const delayMs = RELAY_REDIAL_DELAY_MS + Math.floor(Math.random() * 1000);
       await new Promise(r => setTimeout(r, delayMs));
       try {
-        await node.dial(addr);
+        await node.dial(addrs);
         console.log(`[${ts()}] Relay watchdog: reconnected to ${short(relayPidStr)}`);
         // Reservation may have been restored by this dial; refresh the
         // snapshot so the next iteration doesn't tear down another

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -795,9 +795,19 @@ export class DKGNode {
         listenAddrs.push('/p2p-circuit');
       }
       this.relayReservationCountTarget = relayReservationCount;
-    } else if (this.config.relayPeers?.length) {
-      // Core node with explicit relayPeers — push the legacy single
-      // /p2p-circuit listen addr.
+    } else if (enableRelay && this.config.relayPeers?.length) {
+      // Core / relay-server node with explicit relayPeers — push the
+      // legacy single /p2p-circuit listen addr (preserves defensive
+      // multi-relay config without multiplying slot consumption).
+      //
+      // Gated on `enableRelay` (Codex PR #526 round 5): the previous
+      // `else if (relayPeers?.length)` also matched edge nodes where
+      // every relayPeers entry got filtered out as
+      // malformed/self/duplicate (so isEdgeWithRelays became false).
+      // That left the edge half-configured — a `/p2p-circuit`
+      // listener with nothing to reserve against — and inconsistent
+      // with the "value ignored" warning we already emitted up top.
+      // Now the unusable case truly hits the no-relays path.
       listenAddrs.push('/p2p-circuit');
       this.relayReservationCountTarget = 1;
     }

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -14,7 +14,7 @@ import { circuitRelayServer } from '@libp2p/circuit-relay-v2';
 import { dcutr } from '@libp2p/dcutr';
 import { autoNAT } from '@libp2p/autonat';
 import { generateKeyPair, privateKeyFromRaw } from '@libp2p/crypto/keys';
-import { peerIdFromString } from '@libp2p/peer-id';
+import { peerIdFromString, peerIdFromPrivateKey } from '@libp2p/peer-id';
 import { ed25519GetPublicKey } from './crypto/ed25519.js';
 import type { ConnectionTransport, DKGNodeConfig } from './types.js';
 import { DHT_PROTOCOL, DKG_GOSSIP_MAX_RPC_BYTES } from './constants.js';
@@ -502,8 +502,85 @@ export class DKGNode {
     //
     // Validation defends against the same surface as relayServerCapacity
     // (0/neg/NaN/fractional/non-number/over-cap).
+    // Build the canonical "usable relay candidates" list ONCE, before
+    // anything else looks at relayPeers. The set produced here is the
+    // single source of truth for both the reservation-count clamp
+    // below AND the `relayTargets` push later — keeping them in sync.
+    //
+    // Codex PR #526 round 5 caught that the previous "distinct peerId
+    // count" used by the clamp could disagree with the actual
+    // `relayTargets` set in two ways: it counted entries pointing at
+    // this node's own peerId (later filtered out), and it could be 0
+    // when every entry was malformed (which then clamped a perfectly
+    // valid `relayReservationCount` to 0 — silently disabling
+    // multi-reservation). The canonical list here applies all three
+    // filters (parse → drop-self → dedup) once, with explicit warnings
+    // for each rejection category.
+    //
+    // Self-peerId derivation: needs `peerIdFromPrivateKey(privateKey)`
+    // here because libp2p hasn't been created yet (`this.node` is set
+    // by `createLibp2p({ privateKey, ... })` further down). We have
+    // `privateKey` from the keypair-setup block above, and libp2p's
+    // own peerId is deterministic from it, so this matches what
+    // `this.node.peerId` will be.
+    const selfPeerIdEarly = peerIdFromPrivateKey(privateKey);
+    const usableRelayCandidates: RelayTarget[] = [];
+    if (this.config.relayPeers?.length) {
+      const { multiaddr: parseMultiaddr } = await import('@multiformats/multiaddr');
+      const seenPids = new Set<string>();
+      let malformed = 0;
+      let selfHits = 0;
+      let dupes = 0;
+      for (const raw of this.config.relayPeers) {
+        let ma;
+        try {
+          ma = parseMultiaddr(raw);
+        } catch {
+          malformed += 1;
+          continue;
+        }
+        const p2p = ma.getComponents().find((c) => c.name === 'p2p')?.value;
+        if (!p2p) {
+          malformed += 1;
+          continue;
+        }
+        let pid;
+        try {
+          pid = peerIdFromString(p2p);
+        } catch {
+          malformed += 1;
+          continue;
+        }
+        if (pid.equals(selfPeerIdEarly)) {
+          selfHits += 1;
+          continue;
+        }
+        if (seenPids.has(p2p)) {
+          dupes += 1;
+          continue;
+        }
+        seenPids.add(p2p);
+        usableRelayCandidates.push({ peerId: pid, addr: ma });
+      }
+      if (malformed || selfHits || dupes) {
+        const reasons: string[] = [];
+        if (malformed) reasons.push(`${malformed} malformed (no /p2p component or unparseable)`);
+        if (selfHits) reasons.push(`${selfHits} pointing at this node's own peerId`);
+        if (dupes) reasons.push(`${dupes} duplicate peerIds`);
+        console.warn(
+          `[dkg-core] relayPeers: ${this.config.relayPeers.length} entries supplied, ` +
+            `${usableRelayCandidates.length} usable (skipped ${reasons.join(', ')})`,
+        );
+      }
+    }
+
     let relayReservationCount = DEFAULT_RELAY_RESERVATION_COUNT;
-    const isEdgeWithRelays = !enableRelay && (this.config.relayPeers?.length ?? 0) > 0;
+    // Gate multi-reservation on USABLE peers, not raw config length —
+    // a config like `relayPeers: [malformed, self]` has length>0 but
+    // 0 usable, so the node should fall back to the no-relays path
+    // (no `/p2p-circuit` listen addrs, no watchdog, no
+    // reservationConcurrency override). Codex PR #526 round 5.
+    const isEdgeWithRelays = !enableRelay && usableRelayCandidates.length > 0;
     if (isEdgeWithRelays) {
       const verdict = validateRelayReservationCount(this.config.relayReservationCount);
       if (verdict == null) {
@@ -517,43 +594,18 @@ export class DKGNode {
         );
         relayReservationCount = DEFAULT_RELAY_RESERVATION_COUNT;
       }
-      // Clamp to the count of DISTINCT relay peers — requesting more
-      // reservations than there are unique relays can't deliver the
-      // documented N-(N-1) tolerance and risks duplicate-reservation
-      // churn against an unattainable target. Codex review on PR #526
-      // round 1 caught the over-cap case; round 4 caught that we also
-      // need to dedupe by peerId here, otherwise a config like
-      // `[relayA, relayA]` with `relayReservationCount: 2` looks like
-      // 2 distinct slots to the clamp and the watchdog later "sees"
-      // 2 reservations when only 1 actual relay is involved — which
-      // defeats the redundancy guarantee. Parsing failures are
-      // tolerated here (skipped); the same parser runs again at the
-      // relayTargets push and any malformed entry is dropped consistently.
-      const { multiaddr: parseMultiaddr } = await import('@multiformats/multiaddr');
-      const distinctRelayPeerIds = new Set<string>();
-      for (const raw of this.config.relayPeers!) {
-        try {
-          const ma = parseMultiaddr(raw);
-          const p2p = ma.getComponents().find((c) => c.name === 'p2p')?.value;
-          if (p2p) distinctRelayPeerIds.add(p2p);
-        } catch {
-          // Skipped; will also be dropped at relayTargets push.
-        }
-      }
-      const distinctRelayPeerCount = distinctRelayPeerIds.size;
-      if (distinctRelayPeerCount < this.config.relayPeers!.length) {
-        console.warn(
-          `[dkg-core] relayPeers contains ${this.config.relayPeers!.length} entries but only ` +
-            `${distinctRelayPeerCount} distinct peerIds; using distinct count for ` +
-            `multi-reservation sizing`,
-        );
-      }
-      if (relayReservationCount > distinctRelayPeerCount) {
+      // Clamp to the USABLE relay count (post-parse, post-self-filter,
+      // post-dedup). This guarantees the runtime
+      // `this.relayReservationCountTarget` always matches the actual
+      // `this.relayTargets.length` the watchdog will iterate, so the
+      // gate `reservedRelayCount >= target` is achievable.
+      const usableCount = usableRelayCandidates.length;
+      if (relayReservationCount > usableCount) {
         console.warn(
           `[dkg-core] relayReservationCount=${relayReservationCount} exceeds ` +
-            `distinct relay peers=${distinctRelayPeerCount}; clamping to ${distinctRelayPeerCount}`,
+            `usable relay peers=${usableCount}; clamping to ${usableCount}`,
         );
-        relayReservationCount = distinctRelayPeerCount;
+        relayReservationCount = usableCount;
       }
     } else if (
       this.config.relayReservationCount != null &&
@@ -562,6 +614,16 @@ export class DKGNode {
       console.warn(
         `[dkg-core] relayReservationCount=${this.config.relayReservationCount} ` +
           `set but no relayPeers configured; value ignored`,
+      );
+    } else if (
+      this.config.relayReservationCount != null &&
+      !enableRelay &&
+      this.config.relayPeers?.length &&
+      usableRelayCandidates.length === 0
+    ) {
+      console.warn(
+        `[dkg-core] relayReservationCount=${this.config.relayReservationCount} ` +
+          `set but no usable relayPeers (all malformed/self/duplicate); value ignored`,
       );
     } else if (this.config.relayReservationCount != null && enableRelay) {
       console.warn(
@@ -771,36 +833,25 @@ export class DKGNode {
 
     // Connect to relay peers and tag them as keep-alive so libp2p's
     // connection manager maintains the connection and auto-redials.
-    if (this.config.relayPeers?.length) {
-      const { multiaddr } = await import('@multiformats/multiaddr');
+    // The list `usableRelayCandidates` was already fully filtered
+    // (parse + drop-self + dedup) up top — push it as-is so
+    // `this.relayTargets` is exactly the same set the clamp sized
+    // against. Codex PR #526 round 5 fixed the previous mismatch
+    // where the clamp could pass a count larger than what
+    // `relayTargets` actually held.
+    if (usableRelayCandidates.length > 0) {
+      for (const candidate of usableRelayCandidates) {
+        this.relayTargets.push(candidate);
 
-      // Dedup by peerId (Codex PR #526 round 4): without this a duplicate
-      // entry like `[relayA, relayA]` would be pushed twice, the watchdog
-      // would iterate it twice, and `reservedRelayCount` would count the
-      // single underlying reservation twice — making the gate think the
-      // target is met when only one actual relay is reserved.
-      const seenRelayPeerIds = new Set<string>();
-      for (const addr of this.config.relayPeers) {
-        const ma = multiaddr(addr);
-        const p2pComponent = ma.getComponents().find(c => c.name === 'p2p');
-        if (!p2pComponent?.value) continue;
-
-        const peerId = peerIdFromString(p2pComponent.value);
-        if (peerId.equals(this.node.peerId)) continue;
-        if (seenRelayPeerIds.has(p2pComponent.value)) continue;
-        seenRelayPeerIds.add(p2pComponent.value);
-
-        this.relayTargets.push({ peerId, addr: ma });
-
-        await this.node.peerStore.merge(peerId, {
-          multiaddrs: [ma],
+        await this.node.peerStore.merge(candidate.peerId, {
+          multiaddrs: [candidate.addr],
           tags: {
             'keep-alive-dkg-relay': { value: 100 },
           },
         });
 
         try {
-          await this.node.dial(ma);
+          await this.node.dial(candidate.addr);
         } catch {
           // watchdog will retry
         }
@@ -889,6 +940,27 @@ export class DKGNode {
       haveAnyReservation = circuitSelfAddrs.length > 0;
       reservedRelayCount = computeReservedRelayCount();
     };
+    // Per-tick budget for forced reservation-redials. Codex PR #526
+    // round 5: a completed `node.dial()` does NOT guarantee the new
+    // `/p2p-circuit` self-address has propagated, so during recovery
+    // from `1/2 reservations` in a `3 peers, target=2` setup the
+    // post-dial `refreshReservationSnapshot()` may still report
+    // `reservedRelayCount === 1` and the loop would keep redialing the
+    // remaining peer too — overshooting the target and re-introducing
+    // the churn this PR is meant to avoid. Cap forced redials at the
+    // missing-slot count computed at TICK START (deliberately not
+    // recomputed mid-tick): once we've initiated dials for every
+    // missing slot, the in-flight reservations will fill them
+    // asynchronously, and the next watchdog tick will reassess. If a
+    // dial happens to propagate fast enough that
+    // `reservationGateSatisfied` flips for the next peer, the happy
+    // path skips it naturally — this cap only matters when the
+    // reservations haven't propagated yet.
+    const missingSlotsAtTickStart = Math.max(
+      0,
+      this.relayReservationCountTarget - reservedRelayCount,
+    );
+    let forcedRedialsThisTick = 0;
     const now = Date.now();
 
     for (const { peerId, addr } of this.relayTargets) {
@@ -946,6 +1018,24 @@ export class DKGNode {
           (reservedRelayCount < this.relayReservationCountTarget && !thisRelayHasReservation)
         );
       if (needsForcedReservationRedial) {
+        // Honour the per-tick redial budget. `missingSlotsAtTickStart`
+        // is the deficit at tick start; once we've dispatched dials
+        // for every missing slot we stop, even if the new
+        // `/p2p-circuit` self-addrs haven't shown up yet — the
+        // in-flight reservations will fill the deficit and the next
+        // tick will reassess. Treat this as a benign "still
+        // recovering" state, same as a recent forced redial within
+        // the grace window: account for it as not-fully-healthy but
+        // don't apply exponential backoff (the next tick needs to
+        // arrive to see whether the in-flight dials succeeded).
+        if (
+          this.relayReservationCountTarget > 1 &&
+          missingSlotsAtTickStart > 0 &&
+          forcedRedialsThisTick >= missingSlotsAtTickStart
+        ) {
+          allHealthy = false;
+          continue;
+        }
         const lastForcedRedial = this.relayReservationRedialAt.get(relayPidStr) ?? 0;
         if (now - lastForcedRedial < RELAY_RESERVATION_GRACE_MS) {
           // We just redialed; give libp2p time to finish negotiating a new
@@ -958,6 +1048,7 @@ export class DKGNode {
           continue;
         }
 
+        forcedRedialsThisTick += 1;
         allHealthy = false;
         // Actual corrective action below (drop + redial); this is a
         // real failure the watchdog must back off on.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -93,9 +93,16 @@ export interface DKGNodeConfig {
    * Default: 3. Capped at 16 (above which the failure-tolerance
    * benefit is marginal but the per-relay cost is real).
    *
-   * IGNORED when no relayPeers are configured (i.e. the node isn't
-   * behind NAT). Invalid values (0, negative, NaN, fractional,
-   * non-numeric, > 16) fall back to the default with a warning.
+   * IGNORED in two cases (with a startup warning when set explicitly):
+   *   - No relayPeers configured (the node isn't behind NAT — nothing
+   *     to multi-reserve against).
+   *   - Node is itself a relay server (`enableRelayServer: true` or
+   *     `nodeRole: 'core'`) — relay servers don't multi-reserve
+   *     through other relays; that path falls back to the legacy
+   *     single `/p2p-circuit` listener.
+   *
+   * Invalid values (0, negative, NaN, fractional, non-numeric, > 16)
+   * fall back to the default with a warning.
    */
   relayReservationCount?: number;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -74,6 +74,30 @@ export interface DKGNodeConfig {
    * an operator-facing warning.
    */
   relayServerCapacity?: number;
+  /**
+   * Number of relay reservations to hold in parallel when behind NAT.
+   * The previous behavior (1) was a single point of failure: if the
+   * sole reserved relay went unreachable, the edge dropped off the
+   * network until the watchdog noticed and re-reserved. Holding 3 in
+   * parallel gives N-2 tolerance — two relays can blink concurrently
+   * and incoming dialers can still find a working circuit.
+   *
+   * Implementation: each `/p2p-circuit` listen address triggers a
+   * separate reservation slot in libp2p's transport reservation store,
+   * so this value translates to N duplicate `/p2p-circuit` entries in
+   * `addresses.listen` paired with `reservationConcurrency: N` on the
+   * circuit-relay transport so all slots are attempted in parallel
+   * at startup. libp2p auto-renews each reservation 5 minutes before
+   * expiry so no application-level renewal is needed.
+   *
+   * Default: 3. Capped at 16 (above which the failure-tolerance
+   * benefit is marginal but the per-relay cost is real).
+   *
+   * IGNORED when no relayPeers are configured (i.e. the node isn't
+   * behind NAT). Invalid values (0, negative, NaN, fractional,
+   * non-numeric, > 16) fall back to the default with a warning.
+   */
+  relayReservationCount?: number;
 }
 
 export type ConnectionTransport = 'direct' | 'relayed';

--- a/packages/core/test/relay-reservation-count.test.ts
+++ b/packages/core/test/relay-reservation-count.test.ts
@@ -1,0 +1,143 @@
+// relay-reservation-count.test.ts
+//
+// Unit tests for the multi-reservation tuning landed in
+// `feat/libp2p-multi-reservation` (PR3 of the libp2p reachability
+// hardening series). Two surfaces under test:
+//
+//   1. `validateRelayReservationCount(input)` — input-validation gate
+//      modelled on `validateRelayServerCapacity` from PR1. Defends
+//      against operator config containing 0, negatives, NaN, Infinity,
+//      fractional, non-numbers, and over-cap (> 16) values. Same
+//      shape (`{ ok, value | reason } | null`) so the call sites can
+//      share the warn-and-fall-back pattern.
+//
+//   2. The exported constants `DEFAULT_RELAY_RESERVATION_COUNT` and
+//      `MAX_RELAY_RESERVATION_COUNT` — pinned at 3 / 16 by intent
+//      (see node.ts JSDoc); changing them is a breaking config
+//      contract for operators and should be a deliberate decision,
+//      not an accidental edit.
+//
+// The wiring into `start()` (N `/p2p-circuit` listen entries +
+// `reservationConcurrency: N`) is exercised at the integration level
+// — it depends on real libp2p transport bring-up, which the unit
+// suite intentionally doesn't simulate. The source-reading spike
+// documented in the PR description is what gives us confidence the
+// wiring is correct: each `/p2p-circuit` listen addr triggers one
+// `reserveRelay()` call in `@libp2p/circuit-relay-v2/transport/
+// reservation-store.js`, so N entries produces N pending IDs, and
+// `reservationConcurrency: N` lets all N be fulfilled in parallel
+// rather than serialised through the default-1 PeerQueue.
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_RELAY_RESERVATION_COUNT,
+  MAX_RELAY_RESERVATION_COUNT,
+  validateRelayReservationCount,
+} from '../src/node.js';
+
+describe('relay reservation-count constants', () => {
+  it('default is 3 — N-2 tolerance to simultaneous relay blackouts', () => {
+    // The point of multi-reservation is that 1 reserved relay is a
+    // single point of failure. 2 gives N-1 (one blink tolerated); 3
+    // gives N-2 (two blinks tolerated). We pick 3 because the
+    // observed Miles ↔ Lex blackouts that motivated this PR series
+    // were rarely individual: the underlying causes (NAT pinhole
+    // expiry, ISP routing flaps) tend to affect multiple peers in a
+    // burst. Bumping past 3 is configurable but defaults stay
+    // conservative — every reservation costs a held connection on
+    // the relay host.
+    expect(DEFAULT_RELAY_RESERVATION_COUNT).toBe(3);
+  });
+
+  it('hard cap is 16 — beyond this the marginal benefit is dwarfed by per-relay cost', () => {
+    // The cap is intentional. Reserving on every public relay would
+    // make every edge node O(N_public_relays) memory / control
+    // streams, which doesn't scale as the network grows. 16 is the
+    // ceiling we're willing to defend; operators wanting more
+    // should be opening a discussion, not editing a config.
+    expect(MAX_RELAY_RESERVATION_COUNT).toBe(16);
+  });
+});
+
+describe('validateRelayReservationCount', () => {
+  it('returns null for unset/undefined input (so callers can apply their own default)', () => {
+    expect(validateRelayReservationCount(undefined)).toBeNull();
+    expect(validateRelayReservationCount(null)).toBeNull();
+  });
+
+  it('accepts positive integers up to the cap', () => {
+    expect(validateRelayReservationCount(1)).toEqual({ ok: true, value: 1 });
+    expect(validateRelayReservationCount(3)).toEqual({ ok: true, value: 3 });
+    expect(validateRelayReservationCount(MAX_RELAY_RESERVATION_COUNT)).toEqual({
+      ok: true,
+      value: MAX_RELAY_RESERVATION_COUNT,
+    });
+  });
+
+  it('rejects 0 and negatives — would disable relay listening or produce garbage limits', () => {
+    expect(validateRelayReservationCount(0)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('>= 1'),
+    });
+    expect(validateRelayReservationCount(-1)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('>= 1'),
+    });
+  });
+
+  it('rejects NaN and Infinity — non-finite values would propagate undefined behaviour', () => {
+    expect(validateRelayReservationCount(NaN)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('finite'),
+    });
+    expect(validateRelayReservationCount(Infinity)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('finite'),
+    });
+    expect(validateRelayReservationCount(-Infinity)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('finite'),
+    });
+  });
+
+  it('rejects fractional values — listen-addr count must be a whole number', () => {
+    expect(validateRelayReservationCount(1.5)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('integer'),
+    });
+    expect(validateRelayReservationCount(3.0001)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('integer'),
+    });
+  });
+
+  it('rejects values above the hard cap to prevent O(N_relays) reservation storms', () => {
+    expect(validateRelayReservationCount(MAX_RELAY_RESERVATION_COUNT + 1)).toEqual({
+      ok: false,
+      reason: expect.stringContaining(`<= ${MAX_RELAY_RESERVATION_COUNT}`),
+    });
+    expect(validateRelayReservationCount(100)).toEqual({
+      ok: false,
+      reason: expect.stringContaining(`<= ${MAX_RELAY_RESERVATION_COUNT}`),
+    });
+  });
+
+  it('rejects non-number types (strings, booleans, objects, arrays)', () => {
+    expect(validateRelayReservationCount('3' as any)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('number'),
+    });
+    expect(validateRelayReservationCount(true as any)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('number'),
+    });
+    expect(validateRelayReservationCount({} as any)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('number'),
+    });
+    expect(validateRelayReservationCount([] as any)).toEqual({
+      ok: false,
+      reason: expect.stringContaining('number'),
+    });
+  });
+});

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -462,6 +462,80 @@ describe('Circuit Relay', () => {
     warnSpy.mockRestore();
   }, 15000);
 
+  it('dedupes duplicate relayPeers entries by peerId for clamp + relayTargets', async () => {
+    // Codex review on PR #526 round 4 caught that `reservedRelayCount`
+    // was derived from raw `relayTargets`, so a duplicate config like
+    // `[relayA-with-suffix-A, relayA-with-suffix-B]` (two entries that
+    // resolve to the same peerId) was counted twice. With
+    // `relayReservationCount: 2`, the watchdog would think target is
+    // met by one actual reservation duplicated in its view — defeating
+    // the redundancy guarantee.
+    //
+    // Fix asserts:
+    //   1. The clamp warns when distinct count < raw entry count, and
+    //      the chosen `relayReservationCount` is bounded by the distinct
+    //      count, not the raw length.
+    //   2. The edge ends up with exactly 1 distinct `/p2p-circuit`
+    //      self-addr (one reservation on the one real relay), not 2
+    //      duplicate entries that would falsely satisfy the watchdog.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const relay = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    nodes.push(relay);
+    await relay.start();
+
+    const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relayAddr, relayAddr],
+      relayReservationCount: 2,
+    });
+    nodes.push(edge);
+    await edge.start();
+
+    const dedupWarn = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === 'string'
+      && call[0].includes('2 entries')
+      && call[0].includes('1 distinct peerIds'),
+    );
+    expect(
+      dedupWarn,
+      `expected dedup warning; got: ${JSON.stringify(warnSpy.mock.calls.map(c => c[0]))}`,
+    ).toBeDefined();
+
+    const clampWarn = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === 'string'
+      && call[0].includes('clamping to 1'),
+    );
+    expect(
+      clampWarn,
+      `expected clamp-to-distinct-count warning; got: ${JSON.stringify(warnSpy.mock.calls.map(c => c[0]))}`,
+    ).toBeDefined();
+
+    const deadline = Date.now() + 5_000;
+    let circuitAddrs: string[] = [];
+    while (Date.now() < deadline) {
+      circuitAddrs = edge.libp2p
+        .getMultiaddrs()
+        .map(ma => ma.toString())
+        .filter(a => a.includes('/p2p-circuit'));
+      if (circuitAddrs.length > 0) break;
+      await new Promise(r => setTimeout(r, 250));
+    }
+    const distinctRelayPids = new Set(
+      circuitAddrs.map(a => a.match(/\/p2p\/([^/]+)\/p2p-circuit/)?.[1]).filter(Boolean),
+    );
+    expect(distinctRelayPids.size).toBe(1);
+
+    warnSpy.mockRestore();
+  }, 15000);
+
   it('does not churn the unreserved relay when relayReservationCount < relayPeers.length', async () => {
     // Codex review on PR #526 round 3 caught a real bug in the round-2
     // watchdog: with target>1, the per-relay gate required EVERY

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -460,6 +460,21 @@ describe('Circuit Relay', () => {
     ).toBeDefined();
 
     warnSpy.mockRestore();
+
+    // Also assert the actual NON-amplification contract — Codex PR #526
+    // round 5d caught that the warning-only assertion above wouldn't
+    // catch a regression where the warning still fires but the
+    // listener was wrongly amplified. Core nodes with relayPeers must
+    // get AT MOST one `/p2p-circuit` listen address (the legacy
+    // single-reservation fallback), regardless of relayReservationCount.
+    const coreCircuitSelfAddrs = core.libp2p
+      .getMultiaddrs()
+      .map(ma => ma.toString())
+      .filter(a => a.includes('/p2p-circuit'));
+    expect(
+      coreCircuitSelfAddrs.length,
+      `core node with relayPeers must NOT amplify into multiple /p2p-circuit reservations; got: ${JSON.stringify(coreCircuitSelfAddrs)}`,
+    ).toBeLessThanOrEqual(1);
   }, 15000);
 
   it('dedupes duplicate relayPeers entries by peerId for clamp + relayTargets', async () => {

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -8,6 +8,12 @@ describe('Circuit Relay', () => {
   const nodes: DKGNode[] = [];
 
   afterEach(async () => {
+    // Unconditionally restore any console spies created in the test
+    // body. Codex PR #526 round 5e: per-test spies were restored
+    // inline at the bottom of each test, but a thrown assertion or
+    // start() error left them mocked and corrupted later tests.
+    // Restoring at this scope guarantees cleanup even on failure.
+    vi.restoreAllMocks();
     for (const n of nodes) {
       try {
         await n.stop();
@@ -663,7 +669,14 @@ describe('Circuit Relay', () => {
     // count stays 1, AND the edge actually establishes a relay
     // reservation (the real addr works even though the alternate
     // one is unreachable).
+    // Round-5e adjustment: alt-addrs aggregation is a healthy
+    // supported config and is now logged at info level
+    // (`console.log`), NOT at warn level. The test must spy on log
+    // to observe it AND must NOT see any warn call mentioning
+    // "alternate addrs" (otherwise we've regressed to noisy warnings
+    // on healthy startup).
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     const relay = new DKGNode({
       listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
@@ -687,16 +700,22 @@ describe('Circuit Relay', () => {
     nodes.push(edge);
     await edge.start();
 
-    const altWarn = warnSpy.mock.calls.find((call) =>
+    const altInfo = logSpy.mock.calls.find((call) =>
       typeof call[0] === 'string'
       && call[0].includes('alternate addrs merged')
-      && call[0].includes('1 distinct relay peers usable'),
+      && call[0].includes('1 distinct relay peers'),
+    );
+    expect(
+      altInfo,
+      `expected alt-addrs-merged info log; got: ${JSON.stringify(logSpy.mock.calls.map(c => c[0]))}`,
+    ).toBeDefined();
+    const altWarn = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === 'string' && call[0].includes('alternate addrs'),
     );
     expect(
       altWarn,
-      `expected alt-addrs-merged warning; got: ${JSON.stringify(warnSpy.mock.calls.map(c => c[0]))}`,
-    ).toBeDefined();
-    warnSpy.mockRestore();
+      `alt-addrs aggregation must NOT trigger a warn-level log on a healthy config; got warn calls: ${JSON.stringify(warnSpy.mock.calls.map(c => c[0]))}`,
+    ).toBeUndefined();
 
     const deadline = Date.now() + 5_000;
     let circuitAddrs: string[] = [];

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -502,8 +502,8 @@ describe('Circuit Relay', () => {
     const dedupWarn = warnSpy.mock.calls.find((call) =>
       typeof call[0] === 'string'
       && call[0].includes('2 entries supplied')
-      && call[0].includes('1 usable')
-      && call[0].includes('duplicate peerIds'),
+      && call[0].includes('1 distinct relay peers usable')
+      && call[0].includes('exact-duplicate multiaddrs'),
     );
     expect(
       dedupWarn,
@@ -627,6 +627,78 @@ describe('Circuit Relay', () => {
     expect(distinctRelayPids.size).toBe(1);
   }, 15000);
 
+  it('preserves alternate multiaddrs for the same peerId as fallbacks (Codex PR #526 round 5c)', async () => {
+    // Bug Codex caught: the round-5 dedup-by-peerId dropped alternate
+    // multiaddrs for the same relay (e.g. `[relayA-tcp, relayA-ws]`
+    // collapsed to one address) — defeating libp2p's transport-fallback
+    // behaviour and clamping the node to fewer reservations than
+    // configured if the surviving address went stale.
+    //
+    // Round-5c fix: dedup is now by full multiaddr STRING, not by
+    // peerId; same-peerId-different-multiaddr entries get aggregated
+    // into one `RelayTarget` whose `addrs` carries both, and the
+    // node passes `addrs` (an array) to `node.dial()` so libp2p
+    // tries each in order.
+    //
+    // Test: spin up a real relay. Configure edge with the relay's
+    // real multiaddr PLUS a fake unreachable multiaddr that resolves
+    // to the SAME peerId (different transport endpoint).
+    // Expected: edge merges them under one peer, the warning
+    // categorises them as "alternate addrs merged", reservation
+    // count stays 1, AND the edge actually establishes a relay
+    // reservation (the real addr works even though the alternate
+    // one is unreachable).
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const relay = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    nodes.push(relay);
+    await relay.start();
+    const realAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const realPidMatch = realAddr.match(/\/p2p\/([^/]+)$/);
+    expect(realPidMatch, 'relay multiaddr must include /p2p/<peerId>').not.toBeNull();
+    const relayPid = realPidMatch![1];
+    const fakeAlternateAddr = `/ip4/127.0.0.1/tcp/9/p2p/${relayPid}`;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [realAddr, fakeAlternateAddr],
+      relayReservationCount: 1,
+    });
+    nodes.push(edge);
+    await edge.start();
+
+    const altWarn = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === 'string'
+      && call[0].includes('alternate addrs merged')
+      && call[0].includes('1 distinct relay peers usable'),
+    );
+    expect(
+      altWarn,
+      `expected alt-addrs-merged warning; got: ${JSON.stringify(warnSpy.mock.calls.map(c => c[0]))}`,
+    ).toBeDefined();
+    warnSpy.mockRestore();
+
+    const deadline = Date.now() + 5_000;
+    let circuitAddrs: string[] = [];
+    while (Date.now() < deadline) {
+      circuitAddrs = edge.libp2p
+        .getMultiaddrs()
+        .map(ma => ma.toString())
+        .filter(a => a.includes('/p2p-circuit'));
+      if (circuitAddrs.length > 0) break;
+      await new Promise(r => setTimeout(r, 250));
+    }
+    expect(
+      circuitAddrs.length,
+      `edge should have established a reservation via the working addr; got: ${JSON.stringify(circuitAddrs)}`,
+    ).toBeGreaterThan(0);
+  }, 15000);
+
   it('falls back to no-relays path when every relayPeers entry is unusable (Codex PR #526 round 5b)', async () => {
     // Bug Codex caught: the legacy `/p2p-circuit` listener fallback
     // was gated on `else if (this.config.relayPeers?.length)`, which
@@ -654,12 +726,12 @@ describe('Circuit Relay', () => {
 
     const usableWarn = warnSpy.mock.calls.find((call) =>
       typeof call[0] === 'string'
-      && call[0].includes('0 usable')
+      && call[0].includes('0 distinct relay peers usable')
       && call[0].includes('malformed'),
     );
     expect(
       usableWarn,
-      `expected "0 usable / malformed" warning; got: ${JSON.stringify(warnSpy.mock.calls.map(c => c[0]))}`,
+      `expected "0 distinct relay peers usable / malformed" warning; got: ${JSON.stringify(warnSpy.mock.calls.map(c => c[0]))}`,
     ).toBeDefined();
     warnSpy.mockRestore();
 

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -627,6 +627,54 @@ describe('Circuit Relay', () => {
     expect(distinctRelayPids.size).toBe(1);
   }, 15000);
 
+  it('falls back to no-relays path when every relayPeers entry is unusable (Codex PR #526 round 5b)', async () => {
+    // Bug Codex caught: the legacy `/p2p-circuit` listener fallback
+    // was gated on `else if (this.config.relayPeers?.length)`, which
+    // matched not only the intended core-node case but also edge
+    // nodes whose relayPeers were ALL filtered out
+    // (malformed/self/duplicate) — leaving them half-configured
+    // (`/p2p-circuit` listener with nothing to reserve against).
+    // Round-5b fix: gate the fallback on `enableRelay && relayPeers`,
+    // so the unusable case truly hits the no-relays path.
+    //
+    // Test: edge with `relayPeers: [malformed, malformed]`.
+    //   - Expected: NO `/p2p-circuit` in listen addresses, no
+    //     watchdog started, no `/p2p-circuit` self-addrs ever
+    //     advertised.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: ['/not-a-multiaddr', 'also-malformed'],
+      relayReservationCount: 2,
+    });
+    nodes.push(edge);
+    await edge.start();
+
+    const usableWarn = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === 'string'
+      && call[0].includes('0 usable')
+      && call[0].includes('malformed'),
+    );
+    expect(
+      usableWarn,
+      `expected "0 usable / malformed" warning; got: ${JSON.stringify(warnSpy.mock.calls.map(c => c[0]))}`,
+    ).toBeDefined();
+    warnSpy.mockRestore();
+
+    await new Promise(r => setTimeout(r, 500));
+
+    const circuitAddrs = edge.libp2p
+      .getMultiaddrs()
+      .map(ma => ma.toString())
+      .filter(a => a.includes('/p2p-circuit'));
+    expect(
+      circuitAddrs,
+      `expected NO /p2p-circuit self-addrs (edge should have fallen back to no-relays path); got: ${JSON.stringify(circuitAddrs)}`,
+    ).toHaveLength(0);
+  }, 10000);
+
   it('caps forced reservation-redials per tick at the missing-slot count (Codex PR #526 round 5)', async () => {
     // Bug Codex caught: the round-4 watchdog called
     // `refreshReservationSnapshot()` after each successful

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -461,4 +461,110 @@ describe('Circuit Relay', () => {
 
     warnSpy.mockRestore();
   }, 15000);
+
+  it('does not churn the unreserved relay when relayReservationCount < relayPeers.length', async () => {
+    // Codex review on PR #526 round 3 caught a real bug in the round-2
+    // watchdog: with target>1, the per-relay gate required EVERY
+    // configured peer to hold a reservation. For configs like 3 peers
+    // + count=2, the unreserved third peer's gate
+    // (`!thisRelayHasReservation`) stayed true forever and the
+    // watchdog would tear it down + redial on every grace-window
+    // expiry — wasted churn at best, breaks the existing 2 reservations
+    // at worst (drop+redial closes the existing connection).
+    //
+    // Round-3 fix: gate is now "this peer holds OR `reservedRelayCount
+    // >= target`". For 2-of-3 we expect 2 reservations and the
+    // watchdog should leave the third peer alone.
+    //
+    // We assert the absence of churn by spying on the watchdog's
+    // dropping/redial log line and triggering watchdogTick directly
+    // (it's `private` so we type-cast — same escape hatch as a few
+    // other tests in this file).
+    const relay1 = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    const relay2 = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    const relay3 = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    nodes.push(relay1, relay2, relay3);
+    await relay1.start();
+    await relay2.start();
+    await relay3.start();
+
+    const relay1Addr = relay1.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const relay2Addr = relay2.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const relay3Addr = relay3.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relay1Addr, relay2Addr, relay3Addr],
+      relayReservationCount: 2,
+    });
+    nodes.push(edge);
+    await edge.start();
+
+    const deadline = Date.now() + 10_000;
+    let circuitAddrs: string[] = [];
+    while (Date.now() < deadline) {
+      circuitAddrs = edge.libp2p
+        .getMultiaddrs()
+        .map(ma => ma.toString())
+        .filter(a => a.includes('/p2p-circuit'));
+      const distinct = new Set(
+        circuitAddrs.map(a => a.match(/\/p2p\/([^/]+)\/p2p-circuit/)?.[1]).filter(Boolean),
+      );
+      if (distinct.size >= 2) break;
+      await new Promise(r => setTimeout(r, 250));
+    }
+    const initialReservedPids = new Set(
+      circuitAddrs.map(a => a.match(/\/p2p\/([^/]+)\/p2p-circuit/)?.[1]).filter(Boolean),
+    );
+    expect(
+      initialReservedPids.size,
+      `expected exactly 2 reservations from 2-of-3 config; got circuitAddrs=${JSON.stringify(circuitAddrs)}`,
+    ).toBe(2);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await (edge as unknown as { watchdogTick: () => Promise<void> }).watchdogTick();
+
+      const churnLog = logSpy.mock.calls.find((call) =>
+        typeof call[0] === 'string'
+        && call[0].includes('Relay watchdog')
+        && (
+          call[0].includes('this relay missing')
+          || call[0].includes('to force reserve')
+          || call[0].includes('reservation-redial')
+        ),
+      );
+      expect(
+        churnLog,
+        `expected NO watchdog churn for the unreserved peer; got: ${JSON.stringify(logSpy.mock.calls.map(c => c[0]))}`,
+      ).toBeUndefined();
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    const finalCircuitAddrs = edge.libp2p
+      .getMultiaddrs()
+      .map(ma => ma.toString())
+      .filter(a => a.includes('/p2p-circuit'));
+    const finalReservedPids = new Set(
+      finalCircuitAddrs.map(a => a.match(/\/p2p\/([^/]+)\/p2p-circuit/)?.[1]).filter(Boolean),
+    );
+    expect(finalReservedPids.size).toBe(2);
+    for (const pid of initialReservedPids) {
+      expect(finalReservedPids.has(pid as string)).toBe(true);
+    }
+  }, 25000);
 });

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { DKGNode } from '../src/node.js';
 import { ProtocolRouter } from '../src/protocol-router.js';
 import { PeerDiscoveryManager } from '../src/discovery.js';
@@ -354,4 +354,111 @@ describe('Circuit Relay', () => {
     expect(hasRelay1, `expected reservation on relay1; circuitAddrs=${JSON.stringify(circuitAddrs)}`).toBe(true);
     expect(hasRelay2, `expected reservation on relay2; circuitAddrs=${JSON.stringify(circuitAddrs)}`).toBe(true);
   }, 20000);
+
+  it('clamps relayReservationCount to relayPeers.length and warns', async () => {
+    // Codex review on PR #526: requesting 3 reservations when only 1
+    // relay is configured can't deliver the documented N-(N-1)
+    // tolerance and would queue an unattainable target. The fix is
+    // to clamp + warn at start(). We verify the warn fires and the
+    // edge actually only ends up with 1 /p2p-circuit self-addr (not
+    // 3 attempts queued forever).
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const relay = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    nodes.push(relay);
+    await relay.start();
+
+    const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relayAddr],
+      relayReservationCount: 3,
+    });
+    nodes.push(edge);
+    await edge.start();
+
+    const clampWarn = warnSpy.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('clamping to 1'),
+    );
+    expect(clampWarn, `expected clamp warning; got: ${JSON.stringify(warnSpy.mock.calls)}`).toBeDefined();
+
+    // Wait for the (single) reservation, then assert exactly one
+    // distinct circuit self-addr (i.e. no extra duplicate listen addrs
+    // hung up waiting for a relay that doesn't exist).
+    const deadline = Date.now() + 5_000;
+    let circuitAddrs: string[] = [];
+    while (Date.now() < deadline) {
+      circuitAddrs = edge.libp2p
+        .getMultiaddrs()
+        .map(ma => ma.toString())
+        .filter(a => a.includes('/p2p-circuit'));
+      if (circuitAddrs.length > 0) break;
+      await new Promise(r => setTimeout(r, 250));
+    }
+    const distinctRelayPids = new Set(
+      circuitAddrs.map(a => a.match(/\/p2p\/([^/]+)\/p2p-circuit/)?.[1]).filter(Boolean),
+    );
+    expect(distinctRelayPids.size).toBe(1);
+
+    warnSpy.mockRestore();
+  }, 15000);
+
+  it('skips multi-reservation amplification on relay-server (core) nodes with relayPeers', async () => {
+    // PR #526 round-2 review (branarakic): the daemon's CLI fallback
+    // supplies network.relays to BOTH core and edge nodes by default,
+    // so without this gate a `nodeRole: "core"` instance would push
+    // 3 `/p2p-circuit` listen addrs and try to reserve on other
+    // relays. That contradicts the docs framing ("public node doesn't
+    // need relay reservations") and multiplies relay-slot consumption
+    // network-wide. The fix: core nodes with relayPeers fall back to
+    // the legacy single /p2p-circuit listen addr, and
+    // relayReservationCount is ignored with a warning.
+    //
+    // Note: the existing "node with relay peers starts with tcp
+    // keepAlive" test above asserts a core node still functions when
+    // relayPeers are set — this test pins the warning + the absence
+    // of the multi-reservation amplification.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const upstreamRelay = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    nodes.push(upstreamRelay);
+    await upstreamRelay.start();
+
+    const upstreamRelayAddr = upstreamRelay.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    // Core node ALSO running a relay server, which ALSO has a
+    // relayPeer (the daemon-fallback scenario branarakic flagged).
+    // We set count=3 to make sure it's actively ignored.
+    const core = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+      relayPeers: [upstreamRelayAddr],
+      relayReservationCount: 3,
+    });
+    nodes.push(core);
+    await core.start();
+
+    const ignoreWarn = warnSpy.mock.calls.find(call =>
+      typeof call[0] === 'string'
+      && call[0].includes('relayReservationCount=3')
+      && call[0].includes('relay servers don\'t multi-reserve'),
+    );
+    expect(
+      ignoreWarn,
+      `expected core-ignore warning; got: ${JSON.stringify(warnSpy.mock.calls)}`,
+    ).toBeDefined();
+
+    warnSpy.mockRestore();
+  }, 15000);
 });

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -288,4 +288,70 @@ describe('Circuit Relay', () => {
     expect(edge.libp2p.getConnections().length).toBeGreaterThan(0);
     expect(edge.isStarted).toBe(true);
   }, 15000);
+
+  it('edge with relayReservationCount=2 and 2 relays reserves on both', async () => {
+    // PR3 multi-reservation behavior: by configuring N `/p2p-circuit`
+    // listen addrs + `reservationConcurrency: N` we expect libp2p to
+    // hold N parallel reservations on N distinct relays (subject to
+    // discovery — bootstrap supplies the relayPeers list directly so
+    // there's no random-walk delay). This test pins the wiring
+    // end-to-end: 2 relays + 1 edge with count=2 must produce 2
+    // distinct `/p2p-circuit` self-addresses on the edge, each tagged
+    // with a different relay's PeerId.
+    //
+    // Why count=2 not the default 3: keeps the test light (one fewer
+    // libp2p instance to spin up + tear down) while still exercising
+    // the N>1 path. The validation tests cover the full default range.
+    const relay1 = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    const relay2 = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    nodes.push(relay1, relay2);
+    await relay1.start();
+    await relay2.start();
+
+    const relay1Addr = relay1.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const relay2Addr = relay2.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relay1Addr, relay2Addr],
+      relayReservationCount: 2,
+    });
+    nodes.push(edge);
+    await edge.start();
+
+    // Poll for both reservations — discovery + reservation HOP roundtrip
+    // takes a beat per relay. Bound the wait at 10s (ample margin over
+    // the typical 1-2s observed locally) and bail early when both
+    // /p2p-circuit self-addrs land. We assert the relay PeerIds are
+    // distinct so a single reservation announcing two equivalent addrs
+    // can't false-positive.
+    const relay1PidStr = relay1.peerId;
+    const relay2PidStr = relay2.peerId;
+    const deadline = Date.now() + 10_000;
+    let circuitAddrs: string[] = [];
+    while (Date.now() < deadline) {
+      circuitAddrs = edge.libp2p
+        .getMultiaddrs()
+        .map(ma => ma.toString())
+        .filter(a => a.includes('/p2p-circuit'));
+      const hasRelay1 = circuitAddrs.some(a => a.includes(`/p2p/${relay1PidStr}/p2p-circuit`));
+      const hasRelay2 = circuitAddrs.some(a => a.includes(`/p2p/${relay2PidStr}/p2p-circuit`));
+      if (hasRelay1 && hasRelay2) break;
+      await new Promise(r => setTimeout(r, 250));
+    }
+
+    const hasRelay1 = circuitAddrs.some(a => a.includes(`/p2p/${relay1PidStr}/p2p-circuit`));
+    const hasRelay2 = circuitAddrs.some(a => a.includes(`/p2p/${relay2PidStr}/p2p-circuit`));
+    expect(hasRelay1, `expected reservation on relay1; circuitAddrs=${JSON.stringify(circuitAddrs)}`).toBe(true);
+    expect(hasRelay2, `expected reservation on relay2; circuitAddrs=${JSON.stringify(circuitAddrs)}`).toBe(true);
+  }, 20000);
 });

--- a/packages/core/test/relay.test.ts
+++ b/packages/core/test/relay.test.ts
@@ -501,8 +501,9 @@ describe('Circuit Relay', () => {
 
     const dedupWarn = warnSpy.mock.calls.find((call) =>
       typeof call[0] === 'string'
-      && call[0].includes('2 entries')
-      && call[0].includes('1 distinct peerIds'),
+      && call[0].includes('2 entries supplied')
+      && call[0].includes('1 usable')
+      && call[0].includes('duplicate peerIds'),
     );
     expect(
       dedupWarn,
@@ -535,6 +536,175 @@ describe('Circuit Relay', () => {
 
     warnSpy.mockRestore();
   }, 15000);
+
+  it('drops self-peerId entries from the clamp + relayTargets (Codex PR #526 round 5)', async () => {
+    // Bug Codex caught: the round-4 distinct-peerId clamp counted
+    // entries pointing at this node's OWN peerId, even though the
+    // relayTargets push later filters them out. Result: clamp could
+    // pass `count = N + 1` against actual `relayTargets.length = N`,
+    // making the watchdog gate (`reservedRelayCount >= target`)
+    // unattainable.
+    //
+    // Test: edge with `[realRelayAddr, selfAddr]` and
+    // `relayReservationCount: 2`. Expected behaviour with the
+    // round-5 fix:
+    //   1. Self-filter warning fires (`1 pointing at this node's
+    //      own peerId`).
+    //   2. Clamp warning fires (`clamping to 1`) — the canonical
+    //      usable count is 1, not 2.
+    //   3. Edge gets exactly 1 reservation; watchdog never tries to
+    //      claim a 2nd because target was clamped to the achievable
+    //      1, not the over-counted 2.
+    const { ed25519GetPublicKey } = await import('../src/crypto/ed25519.js');
+    const { peerIdFromPrivateKey } = await import('@libp2p/peer-id');
+    const { privateKeyFromRaw } = await import('@libp2p/crypto/keys');
+    const { randomBytes } = await import('crypto');
+
+    const seed = new Uint8Array(randomBytes(32));
+    const pub = await ed25519GetPublicKey(seed);
+    const raw64 = new Uint8Array(64);
+    raw64.set(seed, 0);
+    raw64.set(pub, 32);
+    const pk = privateKeyFromRaw(raw64);
+    const selfPid = peerIdFromPrivateKey(pk);
+    const selfMultiaddr = `/ip4/127.0.0.1/tcp/9999/p2p/${selfPid.toString()}`;
+
+    const relay = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      enableRelayServer: true,
+    });
+    nodes.push(relay);
+    await relay.start();
+    const relayAddr = relay.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const edge = new DKGNode({
+      privateKey: seed,
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relayAddr, selfMultiaddr],
+      relayReservationCount: 2,
+    });
+    nodes.push(edge);
+    await edge.start();
+
+    const selfFilterWarn = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === 'string'
+      && call[0].includes("pointing at this node's own peerId"),
+    );
+    expect(
+      selfFilterWarn,
+      `expected self-filter warning; got: ${JSON.stringify(warnSpy.mock.calls.map(c => c[0]))}`,
+    ).toBeDefined();
+
+    const clampWarn = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === 'string'
+      && call[0].includes('usable relay peers=1')
+      && call[0].includes('clamping to 1'),
+    );
+    expect(
+      clampWarn,
+      `expected clamp-to-usable-count warning; got: ${JSON.stringify(warnSpy.mock.calls.map(c => c[0]))}`,
+    ).toBeDefined();
+
+    warnSpy.mockRestore();
+
+    const deadline = Date.now() + 5_000;
+    let circuitAddrs: string[] = [];
+    while (Date.now() < deadline) {
+      circuitAddrs = edge.libp2p
+        .getMultiaddrs()
+        .map(ma => ma.toString())
+        .filter(a => a.includes('/p2p-circuit'));
+      if (circuitAddrs.length > 0) break;
+      await new Promise(r => setTimeout(r, 250));
+    }
+    const distinctRelayPids = new Set(
+      circuitAddrs.map(a => a.match(/\/p2p\/([^/]+)\/p2p-circuit/)?.[1]).filter(Boolean),
+    );
+    expect(distinctRelayPids.size).toBe(1);
+  }, 15000);
+
+  it('caps forced reservation-redials per tick at the missing-slot count (Codex PR #526 round 5)', async () => {
+    // Bug Codex caught: the round-4 watchdog called
+    // `refreshReservationSnapshot()` after each successful
+    // `node.dial()` but kept iterating. A completed dial doesn't
+    // guarantee the new `/p2p-circuit` self-addr is advertised yet,
+    // so during recovery from `1/2 → 2/2` in a `3 peers, target=2`
+    // setup, the post-dial snapshot would still see
+    // `reservedRelayCount === 1` and the loop would redial the
+    // third relay too — overshooting the target.
+    //
+    // Round-5 fix: cap forced redials per tick at the missing-slot
+    // count computed at TICK START. For 3 peers / target=2 / starting
+    // 2 reservations held, missing=0 → no forced redials at all
+    // even if the snapshot transiently lies about which peer is
+    // reserved during a tick.
+    //
+    // We can't easily simulate "1/2 reservations" deterministically,
+    // so we assert the simpler invariant: when target is fully met,
+    // the watchdog must never log "to force reserve" for any peer.
+    // This catches both the existing round-3 bug AND any regression
+    // where the budget cap is computed incorrectly (since
+    // missing=0 should hard-cap at 0 forced redials regardless of
+    // the per-peer gate state).
+    const relay1 = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false, enableRelayServer: true });
+    const relay2 = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false, enableRelayServer: true });
+    const relay3 = new DKGNode({ listenAddresses: ['/ip4/127.0.0.1/tcp/0'], enableMdns: false, enableRelayServer: true });
+    nodes.push(relay1, relay2, relay3);
+    await relay1.start();
+    await relay2.start();
+    await relay3.start();
+    const relay1Addr = relay1.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const relay2Addr = relay2.multiaddrs.find(a => a.includes('/tcp/'))!;
+    const relay3Addr = relay3.multiaddrs.find(a => a.includes('/tcp/'))!;
+
+    const edge = new DKGNode({
+      listenAddresses: ['/ip4/127.0.0.1/tcp/0'],
+      enableMdns: false,
+      relayPeers: [relay1Addr, relay2Addr, relay3Addr],
+      relayReservationCount: 2,
+    });
+    nodes.push(edge);
+    await edge.start();
+
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      const distinct = new Set(
+        edge.libp2p.getMultiaddrs()
+          .map(ma => ma.toString())
+          .filter(a => a.includes('/p2p-circuit'))
+          .map(a => a.match(/\/p2p\/([^/]+)\/p2p-circuit/)?.[1])
+          .filter(Boolean),
+      );
+      if (distinct.size >= 2) break;
+      await new Promise(r => setTimeout(r, 250));
+    }
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      // Three back-to-back ticks: even if one tick saw a stale
+      // snapshot, the per-tick budget should keep total forced
+      // redials at 0 across all of them when the target is met.
+      const tick = (edge as unknown as { watchdogTick: () => Promise<void> }).watchdogTick.bind(edge);
+      await tick();
+      await tick();
+      await tick();
+      const churnLogs = logSpy.mock.calls.filter((call) =>
+        typeof call[0] === 'string'
+        && call[0].includes('Relay watchdog')
+        && call[0].includes('to force reserve'),
+      );
+      expect(
+        churnLogs,
+        `expected 0 forced-redial logs across 3 ticks; got: ${JSON.stringify(churnLogs.map(c => c[0]))}`,
+      ).toHaveLength(0);
+    } finally {
+      logSpy.mockRestore();
+    }
+  }, 25000);
 
   it('does not churn the unreserved relay when relayReservationCount < relayPeers.length', async () => {
     // Codex review on PR #526 round 3 caught a real bug in the round-2


### PR DESCRIPTION
## Summary

Final PR in the libp2p reachability hardening series (stacks on #525, which stacks on #524). Defaults edge nodes behind NAT to **3 simultaneous circuit-relay reservations** instead of the legacy 1 — N-2 tolerance to relay blackouts. Operator-tunable via `relayReservationCount` (range 1-16).

The original PR3 plan also included watchdog-driven proactive renewal, but source-reading the libp2p reservation store revealed it's **already done by libp2p itself** (5-min-before-TTL refresh in `@libp2p/circuit-relay-v2/transport/reservation-store.js`). So this PR is just the multi-reservation half.

## Changes

- `DKGNodeConfig.relayReservationCount` (default `3`, capped at `16`):
  - Pushes N duplicate `/p2p-circuit` entries into `addresses.listen` → N reservation slots in libp2p's transport `ReservationStore.reserveRelay()`.
  - Sets `reservationConcurrency: N` on `circuitRelayTransport()` so all N slots are attempted in parallel (upstream default 1 would serialize them and collapse the behavior).
- `validateRelayReservationCount(input)`: rejects 0/neg/NaN/Infinity/fractional/non-numbers + over-cap (matching the validation surface introduced for `relayServerCapacity` in #524).
- Plumbed end-to-end: `DkgConfig` (cli) → `DKGAgentConfig` (agent) → `DKGNodeConfig` (core).
- `cli/README.md` gains an "Edge tuning → Multi-reservation" section with the new knob, defaults, cap, and an explicit note that renewal is automatic.

## Why no proactive renewal?

The libp2p reservation store registers a `setTimeout` per successful reservation that fires `addRelay(peerId, type)` 5 minutes before expiry (`REFRESH_TIMEOUT` constant). With our 2h TTL that's a refresh every 1h55m. Adding application-level renewal on top would be redundant at best, contention-inducing at worst (duplicate HOP RESERVE round-trips on the same connection).

The local watchdog stays in place because it handles the harder failure mode auto-renewal can't recover from: a fully-dropped relay connection (TCP RST, NAT pinhole expiry, ISP routing flap). When the underlying connection dies, libp2p's setTimeout-based refresh has nothing to refresh through; the watchdog's redial loop is what brings the reservation back.

## Test plan

- [x] **Unit (validation):** `relay-reservation-count.test.ts` (9 tests) — pins constants + full validation surface (0/neg/NaN/Infinity/fractional/non-number/over-cap, all rejected with type-appropriate reason strings).
- [x] **Integration (end-to-end):** `relay.test.ts` — new test \"edge with relayReservationCount=2 and 2 relays reserves on both\" spins up 2 relay servers + 1 edge with count=2, polls until both relay PeerIds appear in the edge's `/p2p-circuit` self-addresses. Passes locally in ~360ms (well inside the 20s timeout).
- [x] **CLI config:** 2 new round-trip tests in `config.test.ts` (operator override + unset default).
- [x] **Full suites:** core 747/747, cli config 28/28. The single pre-existing cli failure (`auto-update-versioned-e2e.test.ts`, EDITOR-unset env issue, also fails on PR2 tip) is unaffected.
- [ ] **Manual verification on Miles** (post-merge): observe 3 distinct `/p2p-circuit` self-addresses in `dkg status` and 3 reservations in the relay's `/api/relay/stats` (#525) for a Miles edge.

## Stacking

Branched off `feat/libp2p-relay-observability` (#525). Merge after #524 → #525 → this.

Made with [Cursor](https://cursor.com)