### PR TITLE
feat(node-ui): chat panel PR5 — My-projects picker + hover timestamps + inline streaming caret

### DIFF
--- a/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
@@ -17,12 +17,9 @@ import {
 import {
   belongsInContextOracleSidebar,
   belongsInMyProjectsSidebar,
+  toSidebarIdentity,
   type AgentSidebarIdentity,
 } from '../../lib/contextGraphSidebar.js';
-
-function toSidebarIdentity(a: AgentIdentity): AgentSidebarIdentity {
-  return { agentDid: a.agentDid, peerId: a.peerId };
-}
 
 const CHEVRON_ICON = '▸';
 const COLLAPSE_ICON = '◂';

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -414,6 +414,20 @@ function renderMessageContent(
   streaming: boolean,
 ): React.ReactNode {
   const normalized = normalizeMessageContent(content);
+  // Pre-first-token wait: an assistant turn starts as `{ streaming:
+  // true, content: '' }`. The inline streaming caret lives inside the
+  // last text node, so with no content yet there is nothing to anchor
+  // it to and the row would render blank. Show an explicit animated
+  // "Thinking…" indicator until the first token arrives, at which
+  // point this falls through to the markdown path (whose inline caret
+  // then takes over). `role=status`/`aria-live` announces it to AT.
+  if (role === 'assistant' && streaming && normalized.trim() === '') {
+    return (
+      <span className="v10-chat-thinking" role="status" aria-live="polite">
+        Thinking…
+      </span>
+    );
+  }
   // Markdown rendering applies only to agent-authored assistant output
   // — the only content that's actually written as markdown. Everything
   // else falls back to plain text:

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react';
+import React, { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import { useJourneyStore } from '../../stores/journey.js';
 import { useProjectsStore, type ContextGraph } from '../../stores/projects.js';
 import {
@@ -29,6 +29,7 @@ import { useDropzone } from 'react-dropzone';
 import { ArrowDown, ArrowUp, Ban, ChevronDown, ChevronRight, Folder, Loader2, MoreHorizontal, Paperclip, Square, Upload, X } from 'lucide-react';
 import { Select } from '../common/Select.js';
 import { MarkdownMessage } from '../chat/MarkdownMessage.js';
+import { computeSelectableProjects, toSidebarIdentity } from '../../lib/contextGraphSidebar.js';
 
 export interface LocalAgentMessage {
   id: string;
@@ -410,6 +411,7 @@ function renderMessageContent(
   content: string,
   role: 'user' | 'assistant',
   synthesized: boolean,
+  streaming: boolean,
 ): React.ReactNode {
   const normalized = normalizeMessageContent(content);
   // Markdown rendering applies only to agent-authored assistant output
@@ -425,9 +427,16 @@ function renderMessageContent(
   //     bubble (CFNsU / CFXYU / CGpe9). The CFThj relative-link guard
   //     doesn't help — those hrefs are absolute and allowed.
   if (role === 'assistant' && !synthesized) {
-    return <MarkdownMessage content={normalized} />;
+    return <MarkdownMessage content={normalized} streaming={streaming} />;
   }
-  return <span className="v10-chat-plaintext">{normalized}</span>;
+  // Plaintext path (user / synthetic): keep the caret inline with the
+  // text rather than as a block sibling that drops to a new line.
+  return (
+    <span className="v10-chat-plaintext">
+      {normalized}
+      {streaming && <span className="v10-chat-cursor" />}
+    </span>
+  );
 }
 
 export function getLocalAgentConversationStateKey(
@@ -939,6 +948,10 @@ export function ConnectedAgentsTab(props: {
   localSending: boolean;
   activeProjectId: string | null;
   availableProjects: ContextGraph[];
+  /** Membership-filtered subset for the project picker (see container).
+   *  Optional: defaults to the full `availableProjects` so any renderer
+   *  that doesn't supply it keeps the pre-PR5 behaviour. */
+  selectableProjects?: ContextGraph[];
   projectsLoading: boolean;
   onSelectProject: (projectId: string) => void;
   attachments: LocalAgentAttachmentDraft[];
@@ -976,6 +989,9 @@ export function ConnectedAgentsTab(props: {
     onAddAttachments,
     onRemoveAttachment,
   } = props;
+  // Defaults to the full list when a renderer doesn't supply the
+  // membership-filtered subset (the real container always does).
+  const selectableProjects = props.selectableProjects ?? availableProjects;
   const selectedAttachmentDrafts = attachments;
   const hasSendableAttachmentDrafts = selectedAttachmentDrafts.some(isSendableAttachmentDraft);
   const attachmentTargetIds = [...new Set(selectedAttachmentDrafts.map((attachment) => attachment.contextGraphId))];
@@ -1362,8 +1378,12 @@ export function ConnectedAgentsTab(props: {
               {localMessages.map((message) => (
                 <div key={message.id} className={`v10-chat-msg ${message.role}`}>
                   <div className={`v10-chat-bubble ${message.role}`}>
-                    {renderMessageContent(message.content, message.role, Boolean(message.synthesized))}
-                    {message.streaming && <span className="v10-chat-cursor" />}
+                    {renderMessageContent(
+                      message.content,
+                      message.role,
+                      Boolean(message.synthesized),
+                      Boolean(message.streaming),
+                    )}
                   </div>
                   {message.attachments && message.attachments.length > 0 && (
                     <div className="v10-local-agent-attachment-row" style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 6 }}>
@@ -1584,14 +1604,14 @@ export function ConnectedAgentsTab(props: {
                               ...(activeProjectId
                                 ? [{ value: '', label: 'No project (clear selection)' }]
                                 : []),
-                              ...availableProjects.map((project) => ({ value: project.id, label: project.name })),
+                              ...selectableProjects.map((project) => ({ value: project.id, label: project.name })),
                             ]}
                             placeholder={projectsLoading ? 'Loading projects…' : 'Choose a project'}
                             // Disable while loading. When no project is active
                             // and the list is empty there's nothing to pick
                             // yet, so disable then too — once a project is
                             // active the clear row is always there.
-                            disabled={projectsLoading || (!activeProjectId && availableProjects.length === 0)}
+                            disabled={projectsLoading || (!activeProjectId && selectableProjects.length === 0)}
                             ariaLabel="Active project"
                             prefixIcon={<Folder size={12} aria-hidden="true" />}
                           />
@@ -1978,6 +1998,23 @@ export function PanelRight() {
   const projectsLoading = useProjectsStore((state) => state.loading);
   const activeProjectId = useProjectsStore((state) => state.activeProjectId);
   const setActiveProject = useProjectsStore((state) => state.setActiveProject);
+
+  // The project picker must mirror the left sidebar's "My projects"
+  // *membership* (created/joined), not the full context-graph list —
+  // same `belongsInMyProjectsSidebar` predicate PanelLeft uses. The
+  // local "hidden from sidebar" dismissal is intentionally NOT applied
+  // here: hiding a project from the sidebar must not stop you posting
+  // chat to it. Other `availableProjects` consumers
+  // (getProjectDisplayName, buildChatContextEntries) deliberately keep
+  // the full list — only the picker is membership-scoped.
+  const selectableProjects = useMemo(
+    () => computeSelectableProjects(
+      availableProjects,
+      currentAgent ? toSidebarIdentity(currentAgent) : null,
+      activeProjectId,
+    ),
+    [availableProjects, currentAgent, activeProjectId],
+  );
 
   const localSessions = summarizeLocalAgentSessions(memorySessions, integrations);
   const {
@@ -2692,6 +2729,7 @@ export function PanelRight() {
           localSending={localSending}
           activeProjectId={activeProjectId}
           availableProjects={availableProjects}
+          selectableProjects={selectableProjects}
           projectsLoading={projectsLoading}
           onSelectProject={handleSelectProject}
           attachments={selectedAttachmentDrafts}

--- a/packages/node-ui/src/ui/components/chat/MarkdownMessage.tsx
+++ b/packages/node-ui/src/ui/components/chat/MarkdownMessage.tsx
@@ -53,8 +53,13 @@ function rehypeStreamingCaret() {
         ) {
           if (!inCode) target = { siblings: children, index: i };
         } else if (child.type === 'element') {
-          const tag = child.tagName;
-          walk(child, inCode || tag === 'code' || tag === 'pre');
+          // Only fenced/preformatted code is excluded — those text
+          // nodes are rebuilt from the raw AST by the `pre`/CodeBlock
+          // renderer so an injected sibling there is dropped. Inline
+          // code is a bare `<code>` (no `<pre>` ancestor); a stream
+          // ending in `` `inline` `` must still get the caret, so do
+          // NOT propagate `inCode` for a standalone `code` tag.
+          walk(child, inCode || child.tagName === 'pre');
         }
       }
     };

--- a/packages/node-ui/src/ui/components/chat/MarkdownMessage.tsx
+++ b/packages/node-ui/src/ui/components/chat/MarkdownMessage.tsx
@@ -32,6 +32,12 @@ interface MarkdownMessageProps {
 function rehypeStreamingCaret() {
   return (tree: unknown): void => {
     let target: { siblings: unknown[]; index: number } | null = null;
+    // Did we see any non-whitespace text at all *inside* code? Used to
+    // distinguish a code-only stream (caret intentionally suppressed —
+    // matches ChatGPT, ux-lead-approved) from a stream with no text
+    // node anywhere (e.g. ends in an image: still streaming, must show
+    // a caret) when no normal text target was found.
+    let sawCodeText = false;
     const walk = (node: { children?: unknown[] }, inCode: boolean): void => {
       const children = node.children;
       if (!Array.isArray(children)) return;
@@ -51,7 +57,8 @@ function rehypeStreamingCaret() {
           // dropping the caret after the block instead of inside it.
           child.value.trim().length > 0
         ) {
-          if (!inCode) target = { siblings: children, index: i };
+          if (inCode) sawCodeText = true;
+          else target = { siblings: children, index: i };
         } else if (child.type === 'element') {
           // Only fenced/preformatted code is excluded — those text
           // nodes are rebuilt from the raw AST by the `pre`/CodeBlock
@@ -63,15 +70,25 @@ function rehypeStreamingCaret() {
         }
       }
     };
-    walk(tree as { children?: unknown[] }, false);
+    const root = tree as { children?: unknown[] };
+    walk(root, false);
+    const caret = {
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['v10-chat-cursor'] },
+      children: [],
+    };
     if (target) {
       const { siblings, index } = target;
-      siblings.splice(index + 1, 0, {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: ['v10-chat-cursor'] },
-        children: [],
-      });
+      siblings.splice(index + 1, 0, caret);
+    } else if (!sawCodeText && Array.isArray(root.children) && root.children.length > 0) {
+      // No eligible text node anywhere AND the content isn't code-only
+      // (e.g. the message currently ends in an image placeholder).
+      // Without this the turn looks finished while still streaming, so
+      // fall back to a trailing caret after the last block. A code-only
+      // stream deliberately falls through with no caret (ChatGPT
+      // parity, ux-lead-approved).
+      root.children.push(caret);
     }
   };
 }

--- a/packages/node-ui/src/ui/components/chat/MarkdownMessage.tsx
+++ b/packages/node-ui/src/ui/components/chat/MarkdownMessage.tsx
@@ -6,6 +6,69 @@ import { CodeBlock } from './CodeBlock.js';
 
 interface MarkdownMessageProps {
   content: string;
+  /** When true, a blinking caret is rendered inline after the last
+   *  streamed text node (not as a block sibling below the content). */
+  streaming?: boolean;
+}
+
+/**
+ * rehype transform that appends an inline `<span class="v10-chat-cursor">`
+ * immediately after the last rendered text node, so the streaming caret
+ * sits right after the last streamed glyph regardless of markdown
+ * structure (end of a paragraph, list item, table cell, …) instead of
+ * orphaning onto its own line below the block.
+ *
+ * Chosen over a sentinel character injected into the markdown source
+ * (the original plan): a tree transform cannot leak a stray glyph into
+ * visible text if parsing splits unexpectedly, and it's equally
+ * structure-independent.
+ *
+ * Text inside a fenced code block is skipped: those nodes are rebuilt
+ * from the raw AST by the `pre`/`CodeBlock` renderer, so an injected
+ * sibling there would be dropped anyway. While a stream is momentarily
+ * ending inside an unclosed fence the caret is simply not shown that
+ * frame — transient and acceptable.
+ */
+function rehypeStreamingCaret() {
+  return (tree: unknown): void => {
+    let target: { siblings: unknown[]; index: number } | null = null;
+    const walk = (node: { children?: unknown[] }, inCode: boolean): void => {
+      const children = node.children;
+      if (!Array.isArray(children)) return;
+      for (let i = 0; i < children.length; i++) {
+        const child = children[i] as {
+          type?: string;
+          value?: unknown;
+          tagName?: string;
+          children?: unknown[];
+        };
+        if (
+          child.type === 'text' &&
+          typeof child.value === 'string' &&
+          // Skip whitespace-only nodes: hast inserts `\n` text nodes
+          // between block elements (e.g. between `<li>`s), and the
+          // trailing one would otherwise be picked as the "last text",
+          // dropping the caret after the block instead of inside it.
+          child.value.trim().length > 0
+        ) {
+          if (!inCode) target = { siblings: children, index: i };
+        } else if (child.type === 'element') {
+          const tag = child.tagName;
+          walk(child, inCode || tag === 'code' || tag === 'pre');
+        }
+      }
+    };
+    walk(tree as { children?: unknown[] }, false);
+    if (target) {
+      const { siblings, index } = target;
+      siblings.splice(index + 1, 0, {
+        type: 'element',
+        tagName: 'span',
+        properties: { className: ['v10-chat-cursor'] },
+        children: [],
+      });
+    }
+  };
 }
 
 // Chat content is untrusted. Relative hrefs (`/admin`, `../foo`, `#section`)
@@ -21,11 +84,12 @@ function classifyHref(href: string | undefined): 'http' | 'mailto' | 'inert' {
   return 'inert';
 }
 
-export function MarkdownMessage({ content }: MarkdownMessageProps) {
+export function MarkdownMessage({ content, streaming }: MarkdownMessageProps) {
   return (
     <div className="v10-md">
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks]}
+        rehypePlugins={streaming ? [rehypeStreamingCaret] : []}
         components={{
           // Agent output is untrusted. The default `img` renderer would fetch
           // arbitrary URLs (`![pixel](https://attacker.example/x.png)`),

--- a/packages/node-ui/src/ui/components/chat/MarkdownMessage.tsx
+++ b/packages/node-ui/src/ui/components/chat/MarkdownMessage.tsx
@@ -38,6 +38,14 @@ function rehypeStreamingCaret() {
     // node anywhere (e.g. ends in an image: still streaming, must show
     // a caret) when no normal text target was found.
     let sawCodeText = false;
+    // True when a fenced `<pre>` appears *after* the last non-code text
+    // target in document order — i.e. the message currently ends with a
+    // code block following earlier prose. Reset every time a new target
+    // is recorded, set when a `<pre>` is entered, so its final value
+    // reflects "is there trailing code after the last prose?". In that
+    // case the caret must NOT be left at the stale earlier prose; it is
+    // suppressed (ChatGPT parity / ux-lead-approved no-caret-in-code).
+    let trailingCode = false;
     const walk = (node: { children?: unknown[] }, inCode: boolean): void => {
       const children = node.children;
       if (!Array.isArray(children)) return;
@@ -58,8 +66,12 @@ function rehypeStreamingCaret() {
           child.value.trim().length > 0
         ) {
           if (inCode) sawCodeText = true;
-          else target = { siblings: children, index: i };
+          else {
+            target = { siblings: children, index: i };
+            trailingCode = false;
+          }
         } else if (child.type === 'element') {
+          if (child.tagName === 'pre') trailingCode = true;
           // Only fenced/preformatted code is excluded — those text
           // nodes are rebuilt from the raw AST by the `pre`/CodeBlock
           // renderer so an injected sibling there is dropped. Inline
@@ -78,9 +90,15 @@ function rehypeStreamingCaret() {
       properties: { className: ['v10-chat-cursor'] },
       children: [],
     };
-    if (target) {
+    if (target && !trailingCode) {
       const { siblings, index } = target;
       siblings.splice(index + 1, 0, caret);
+    } else if (target && trailingCode) {
+      // Prose followed by a trailing fenced code block: the last text
+      // target is stale (earlier prose). Splicing there would park the
+      // caret mid-message before the code. Suppress it — same outcome
+      // as a code-only stream (no inline caret while the tail is code).
+      return;
     } else if (!sawCodeText && Array.isArray(root.children) && root.children.length > 0) {
       // No eligible text node anywhere AND the content isn't code-only
       // (e.g. the message currently ends in an image placeholder).

--- a/packages/node-ui/src/ui/components/chat/MarkdownMessage.tsx
+++ b/packages/node-ui/src/ui/components/chat/MarkdownMessage.tsx
@@ -31,21 +31,24 @@ interface MarkdownMessageProps {
  */
 function rehypeStreamingCaret() {
   return (tree: unknown): void => {
+    // The caret must follow the *last rendered content* in document
+    // order, not merely the last text node. `tail` records what that
+    // trailing content is:
+    //   'text' — injectable inline text → splice the caret right there
+    //   'code' — a fenced block (rebuilt by CodeBlock, a spliced
+    //            sibling is dropped) → suppress the caret entirely
+    //            (ChatGPT parity, ux-lead-approved no-caret-in-code)
+    //   'leaf' — a non-text leaf (img / hr / br): no text to sit in, so
+    //            append a trailing caret so the turn doesn't look
+    //            finished while still streaming
+    //   'none' — nothing renderable yet (empty content is handled
+    //            upstream by the "Thinking…" indicator before this runs)
+    // This generalises the earlier `<pre>`-only stale-anchor guard to
+    // every non-text tail (Codex: trailing image / hr / hard break).
+    type Tail = 'none' | 'text' | 'code' | 'leaf';
+    let tail: Tail = 'none';
     let target: { siblings: unknown[]; index: number } | null = null;
-    // Did we see any non-whitespace text at all *inside* code? Used to
-    // distinguish a code-only stream (caret intentionally suppressed —
-    // matches ChatGPT, ux-lead-approved) from a stream with no text
-    // node anywhere (e.g. ends in an image: still streaming, must show
-    // a caret) when no normal text target was found.
-    let sawCodeText = false;
-    // True when a fenced `<pre>` appears *after* the last non-code text
-    // target in document order — i.e. the message currently ends with a
-    // code block following earlier prose. Reset every time a new target
-    // is recorded, set when a `<pre>` is entered, so its final value
-    // reflects "is there trailing code after the last prose?". In that
-    // case the caret must NOT be left at the stale earlier prose; it is
-    // suppressed (ChatGPT parity / ux-lead-approved no-caret-in-code).
-    let trailingCode = false;
+    const LEAF_TAGS = new Set(['img', 'hr', 'br']);
     const walk = (node: { children?: unknown[] }, inCode: boolean): void => {
       const children = node.children;
       if (!Array.isArray(children)) return;
@@ -59,26 +62,28 @@ function rehypeStreamingCaret() {
         if (
           child.type === 'text' &&
           typeof child.value === 'string' &&
-          // Skip whitespace-only nodes: hast inserts `\n` text nodes
-          // between block elements (e.g. between `<li>`s), and the
-          // trailing one would otherwise be picked as the "last text",
-          // dropping the caret after the block instead of inside it.
+          // Whitespace-only nodes are hast's inter-block `\n`; ignore
+          // them so a trailing one isn't taken as the last content.
           child.value.trim().length > 0
         ) {
-          if (inCode) sawCodeText = true;
-          else {
+          if (inCode) {
+            tail = 'code';
+          } else {
             target = { siblings: children, index: i };
-            trailingCode = false;
+            tail = 'text';
           }
         } else if (child.type === 'element') {
-          if (child.tagName === 'pre') trailingCode = true;
-          // Only fenced/preformatted code is excluded — those text
-          // nodes are rebuilt from the raw AST by the `pre`/CodeBlock
-          // renderer so an injected sibling there is dropped. Inline
-          // code is a bare `<code>` (no `<pre>` ancestor); a stream
-          // ending in `` `inline` `` must still get the caret, so do
-          // NOT propagate `inCode` for a standalone `code` tag.
-          walk(child, inCode || child.tagName === 'pre');
+          const tag = child.tagName;
+          if (tag === 'pre') {
+            tail = 'code';
+            walk(child, true);
+          } else if (tag && LEAF_TAGS.has(tag)) {
+            tail = 'leaf';
+          } else {
+            // Inline code is a bare `<code>` (no `<pre>`): its text
+            // must stay eligible, so don't force inCode here.
+            walk(child, inCode);
+          }
         }
       }
     };
@@ -90,24 +95,13 @@ function rehypeStreamingCaret() {
       properties: { className: ['v10-chat-cursor'] },
       children: [],
     };
-    if (target && !trailingCode) {
+    if (tail === 'text' && target) {
       const { siblings, index } = target;
       siblings.splice(index + 1, 0, caret);
-    } else if (target && trailingCode) {
-      // Prose followed by a trailing fenced code block: the last text
-      // target is stale (earlier prose). Splicing there would park the
-      // caret mid-message before the code. Suppress it — same outcome
-      // as a code-only stream (no inline caret while the tail is code).
-      return;
-    } else if (!sawCodeText && Array.isArray(root.children) && root.children.length > 0) {
-      // No eligible text node anywhere AND the content isn't code-only
-      // (e.g. the message currently ends in an image placeholder).
-      // Without this the turn looks finished while still streaming, so
-      // fall back to a trailing caret after the last block. A code-only
-      // stream deliberately falls through with no caret (ChatGPT
-      // parity, ux-lead-approved).
+    } else if (tail === 'leaf' && Array.isArray(root.children)) {
       root.children.push(caret);
     }
+    // tail 'code' / 'none': intentionally no caret.
   };
 }
 

--- a/packages/node-ui/src/ui/lib/contextGraphSidebar.ts
+++ b/packages/node-ui/src/ui/lib/contextGraphSidebar.ts
@@ -13,6 +13,15 @@ export interface AgentSidebarIdentity {
   peerId?: string;
 }
 
+/**
+ * Narrow the full agent identity to the fields the sidebar predicates need.
+ * Structural param (not `api.AgentIdentity`) so this shared lib stays
+ * decoupled from the api layer; both panels pass an object that satisfies it.
+ */
+export function toSidebarIdentity(a: { agentDid: string; peerId?: string }): AgentSidebarIdentity {
+  return { agentDid: a.agentDid, peerId: a.peerId };
+}
+
 function normalizeAccessPolicy(raw?: string): 'public' | 'private' | 'unknown' {
   if (!raw?.trim()) return 'unknown';
   const t = raw.trim().replace(/^["']|["']$/g, '').toLowerCase();
@@ -48,6 +57,28 @@ export function belongsInMyProjectsSidebar(cg: ContextGraph, identity: AgentSide
     return true;
   }
   return false;
+}
+
+/**
+ * Projects offered by the chat composer's project picker: the agent's
+ * "My projects" *membership* set (same predicate as the sidebar), with
+ * one coherence rule — if `activeProjectId` is set but isn't a member
+ * project, it is still surfaced (prepended) so the picker shows the
+ * true active target instead of silently falling back to the
+ * placeholder. The local "hidden from sidebar" dismissal is
+ * deliberately NOT applied here.
+ */
+export function computeSelectableProjects(
+  available: ContextGraph[],
+  identity: AgentSidebarIdentity | null,
+  activeProjectId: string | null,
+): ContextGraph[] {
+  const mine = available.filter((cg) => belongsInMyProjectsSidebar(cg, identity));
+  if (activeProjectId && !mine.some((cg) => cg.id === activeProjectId)) {
+    const active = available.find((cg) => cg.id === activeProjectId);
+    if (active) return [active, ...mine];
+  }
+  return mine;
 }
 
 /**

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -2285,6 +2285,43 @@ button:focus:not(:focus-visible) { outline: none; }
   vertical-align: text-bottom;
 }
 
+/* Pre-first-token "thinking" indicator (ChatGPT-style sheen sweep).
+   `color: var(--text-secondary)` is declared first as the graceful
+   fallback — if `background-clip: text` is unsupported the word still
+   shows at the AA-clearing secondary tone (5.58:1 dark / 7.17:1
+   light). The animated highlight only sweeps brighter (toward
+   --text-primary), so contrast never drops below the base. */
+.v10-chat-thinking {
+  display: inline-block;
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: linear-gradient(
+    90deg,
+    var(--text-secondary) 0%,
+    var(--text-secondary) 35%,
+    var(--text-primary) 50%,
+    var(--text-secondary) 65%,
+    var(--text-secondary) 100%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: v10-thinking-sheen 1.6s ease-in-out infinite;
+}
+@keyframes v10-thinking-sheen {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  /* Static, fully legible — no sweep. */
+  .v10-chat-thinking {
+    animation: none;
+    background: none;
+    -webkit-text-fill-color: var(--text-secondary);
+  }
+}
+
 /* Sessions list */
 .v10-sessions-list { padding: 8px 0; }
 .v10-session-item {

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -1355,12 +1355,30 @@ button:focus:not(:focus-visible) { outline: none; }
   font-size: 10px;
   color: var(--text-secondary);
   font-family: var(--font-mono);
+  /* Hidden by default, revealed on message hover/focus — same recipe
+     as `.v10-md-copy`. Reduces transcript noise now that PR4 made
+     assistant turns full-width with no bubble. Colour/contrast (AA per
+     Task #68) is unchanged; only visibility toggles. */
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+}
+.v10-chat-msg:hover .v10-local-agent-msg-time,
+.v10-chat-msg:focus-within .v10-local-agent-msg-time {
+  opacity: 1;
 }
 .v10-local-agent-msg-time.user {
   align-self: flex-end;
 }
 .v10-local-agent-msg-time.assistant {
   align-self: flex-start;
+}
+/* Touch (no hover) and reduced-motion users always see the timestamp —
+   mirrors the `.v10-md-copy` accessibility fallbacks. */
+@media (hover: none) {
+  .v10-local-agent-msg-time { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .v10-local-agent-msg-time { opacity: 1; transition: none; }
 }
 .v10-local-agent-setup {
   display: flex;

--- a/packages/node-ui/test/contextGraphSidebar.test.ts
+++ b/packages/node-ui/test/contextGraphSidebar.test.ts
@@ -3,6 +3,7 @@ import {
   belongsInContextOracleSidebar,
   belongsInMyProjectsSidebar,
   canonicalAgentDid,
+  computeSelectableProjects,
 } from '../src/ui/lib/contextGraphSidebar.js';
 import type { ContextGraph } from '../src/ui/stores/projects.js';
 
@@ -117,5 +118,36 @@ describe('contextGraphSidebar', () => {
       creator: 'did:dkg:agent:0x2000000000000000000000000000000000000000',
     } as ContextGraph;
     expect(belongsInContextOracleSidebar(cg, id)).toBe(false);
+  });
+});
+
+describe('computeSelectableProjects (chat project picker)', () => {
+  const mine1 = { id: 'm1', name: 'Mine 1', callerInvolved: true } as ContextGraph;
+  const mine2 = { id: 'm2', name: 'Mine 2', callerInvolved: true } as ContextGraph;
+  const notMine = { id: 'n1', name: 'Not Mine', callerInvolved: false, accessPolicy: 'public' } as ContextGraph;
+
+  it('includes member projects and excludes non-member ones', () => {
+    const out = computeSelectableProjects([mine1, notMine, mine2], id, null);
+    expect(out.map((c) => c.id)).toEqual(['m1', 'm2']);
+  });
+
+  it('still surfaces the active project even when it is not a member (prepended once)', () => {
+    const out = computeSelectableProjects([mine1, notMine, mine2], id, 'n1');
+    expect(out.map((c) => c.id)).toEqual(['n1', 'm1', 'm2']);
+  });
+
+  it('does not duplicate the active project when it is already a member', () => {
+    const out = computeSelectableProjects([mine1, notMine, mine2], id, 'm2');
+    expect(out.map((c) => c.id)).toEqual(['m1', 'm2']);
+  });
+
+  it('ignores an active id that is not in the available list', () => {
+    const out = computeSelectableProjects([mine1, notMine], id, 'ghost');
+    expect(out.map((c) => c.id)).toEqual(['m1']);
+  });
+
+  it('null identity → only daemon-confirmed (callerInvolved) member projects', () => {
+    const out = computeSelectableProjects([mine1, notMine], null, null);
+    expect(out.map((c) => c.id)).toEqual(['m1']);
   });
 });

--- a/packages/node-ui/test/markdown-message.test.ts
+++ b/packages/node-ui/test/markdown-message.test.ts
@@ -389,6 +389,18 @@ describe('MarkdownMessage streaming caret (PR5 item C)', () => {
     await unmount();
   });
 
+  it('injects the caret into a trailing INLINE code span (not skipped like fenced code)', async () => {
+    // Regression for Codex PR5: inline code is a bare <code> with no
+    // <pre> ancestor — a stream ending in `inline` must still show the
+    // caret, otherwise the message looks finished early.
+    const { container, unmount } = await renderStreaming('run `npm test`', true);
+    const inlineCode = container.querySelector('code.v10-md-code');
+    expect(inlineCode).toBeTruthy();
+    expect(inlineCode?.querySelector('.v10-chat-cursor')).toBeTruthy();
+    expect(container.querySelectorAll('.v10-chat-cursor').length).toBe(1);
+    await unmount();
+  });
+
   it('does not inject the caret into a trailing fenced code block', async () => {
     const { container, unmount } = await renderStreaming('text\n\n```\ncode line\n```', true);
     // Code content is rebuilt from the raw AST by CodeBlock, so a caret

--- a/packages/node-ui/test/markdown-message.test.ts
+++ b/packages/node-ui/test/markdown-message.test.ts
@@ -326,3 +326,75 @@ describe('MarkdownMessage rendering', () => {
     await unmount();
   });
 });
+
+describe('MarkdownMessage streaming caret (PR5 item C)', () => {
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    document.body.innerHTML = '';
+    vi.resetModules();
+    shikiImportCount = 0;
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function renderStreaming(
+    content: string,
+    streaming: boolean,
+  ): Promise<{ container: HTMLDivElement; unmount: () => Promise<void> }> {
+    const { MarkdownMessage } = await import('../src/ui/components/chat/MarkdownMessage.js');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(React.createElement(MarkdownMessage, { content, streaming }));
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    return {
+      container,
+      unmount: async () => {
+        await act(async () => { root.unmount(); });
+        container.remove();
+      },
+    };
+  }
+
+  it('renders no caret when not streaming', async () => {
+    const { container, unmount } = await renderStreaming('# Title\n\n- a\n- b', false);
+    expect(container.querySelectorAll('.v10-chat-cursor').length).toBe(0);
+    await unmount();
+  });
+
+  it('injects exactly one caret inside the last text node, not as a block sibling', async () => {
+    const { container, unmount } = await renderStreaming('# Title\n\nFirst para\n\n- a\n- b', true);
+    const carets = container.querySelectorAll('.v10-chat-cursor');
+    expect(carets.length).toBe(1);
+    // The caret lives inside the LAST list item (last rendered text),
+    // not as a trailing child of `.v10-md`.
+    const lastLi = container.querySelector('.v10-md-li:last-child');
+    expect(lastLi?.querySelector('.v10-chat-cursor')).toBeTruthy();
+    const md = container.querySelector('.v10-md')!;
+    expect(md.lastElementChild?.classList.contains('v10-chat-cursor')).toBe(false);
+    await unmount();
+  });
+
+  it('places the caret at the end of a trailing paragraph', async () => {
+    const { container, unmount } = await renderStreaming('Hello world', true);
+    const p = container.querySelector('.v10-md-p');
+    expect(p?.querySelector('.v10-chat-cursor')).toBeTruthy();
+    // Visible text is unaffected — no sentinel glyph leaks.
+    expect(p?.textContent).toBe('Hello world');
+    await unmount();
+  });
+
+  it('does not inject the caret into a trailing fenced code block', async () => {
+    const { container, unmount } = await renderStreaming('text\n\n```\ncode line\n```', true);
+    // Code content is rebuilt from the raw AST by CodeBlock, so a caret
+    // there would be dropped — assert it is NOT inside the code block.
+    const codeRegion = container.querySelector('pre, code');
+    expect(codeRegion?.querySelector('.v10-chat-cursor')).toBeFalsy();
+    await unmount();
+  });
+});

--- a/packages/node-ui/test/markdown-message.test.ts
+++ b/packages/node-ui/test/markdown-message.test.ts
@@ -404,9 +404,13 @@ describe('MarkdownMessage streaming caret (PR5 item C)', () => {
   it('does not inject the caret into a trailing fenced code block', async () => {
     const { container, unmount } = await renderStreaming('text\n\n```\ncode line\n```', true);
     // Code content is rebuilt from the raw AST by CodeBlock, so a caret
-    // there would be dropped — assert it is NOT inside the code block.
-    const codeRegion = container.querySelector('pre, code');
-    expect(codeRegion?.querySelector('.v10-chat-cursor')).toBeFalsy();
+    // there would be dropped — assert it is NOT inside the fenced block.
+    // Scope to `.v10-md-pre` (the CodeBlock container) specifically:
+    // a bare `pre, code` selector would also match inline <code>, which
+    // legitimately CAN hold the caret (see the inline-code test above).
+    const fenced = container.querySelector('.v10-md-pre');
+    expect(fenced).toBeTruthy();
+    expect(fenced?.querySelector('.v10-chat-cursor')).toBeFalsy();
     await unmount();
   });
 });

--- a/packages/node-ui/test/markdown-message.test.ts
+++ b/packages/node-ui/test/markdown-message.test.ts
@@ -401,16 +401,34 @@ describe('MarkdownMessage streaming caret (PR5 item C)', () => {
     await unmount();
   });
 
-  it('does not inject the caret into a trailing fenced code block', async () => {
-    const { container, unmount } = await renderStreaming('text\n\n```\ncode line\n```', true);
-    // Code content is rebuilt from the raw AST by CodeBlock, so a caret
-    // there would be dropped — assert it is NOT inside the fenced block.
-    // Scope to `.v10-md-pre` (the CodeBlock container) specifically:
-    // a bare `pre, code` selector would also match inline <code>, which
-    // legitimately CAN hold the caret (see the inline-code test above).
+  it('suppresses the caret (not parked at stale prose) when a fenced block trails prose', async () => {
+    // Regression for Codex PR5: prose then a trailing fenced code block.
+    // The last non-code text target is the *earlier* prose; splicing the
+    // caret there would park it mid-message before the code block. The
+    // caret must be fully suppressed in that case (ChatGPT parity /
+    // ux-lead-approved no-caret-while-tail-is-code), NOT left on the
+    // stale prose.
+    const { container, unmount } = await renderStreaming('Here is the code:\n\n```\nx = 1\n```', true);
     const fenced = container.querySelector('.v10-md-pre');
     expect(fenced).toBeTruthy();
-    expect(fenced?.querySelector('.v10-chat-cursor')).toBeFalsy();
+    // Zero carets anywhere — and specifically none parked in the prose.
+    expect(container.querySelectorAll('.v10-chat-cursor').length).toBe(0);
+    const prose = container.querySelector('.v10-md-p');
+    expect(prose?.textContent).toContain('Here is the code:');
+    expect(prose?.querySelector('.v10-chat-cursor')).toBeFalsy();
+    await unmount();
+  });
+
+  it('still places the caret in the last prose when code is NOT the trailing block', async () => {
+    // Inverse guard: code earlier, prose after → caret belongs in the
+    // trailing prose (trailingCode reset by the later text target).
+    const { container, unmount } = await renderStreaming('```\nx = 1\n```\n\nDone explaining', true);
+    const carets = container.querySelectorAll('.v10-chat-cursor');
+    expect(carets.length).toBe(1);
+    const paras = [...container.querySelectorAll('.v10-md-p')];
+    const last = paras[paras.length - 1];
+    expect(last?.textContent).toContain('Done explaining');
+    expect(last?.querySelector('.v10-chat-cursor')).toBeTruthy();
     await unmount();
   });
 

--- a/packages/node-ui/test/markdown-message.test.ts
+++ b/packages/node-ui/test/markdown-message.test.ts
@@ -443,6 +443,40 @@ describe('MarkdownMessage streaming caret (PR5 item C)', () => {
     await unmount();
   });
 
+  it('falls back to a trailing caret when an image follows earlier prose (not parked at prose)', async () => {
+    // Codex generalization: a non-text tail (image) after prose left the
+    // caret stale on the earlier prose. Expect one caret, not in prose.
+    const { container, unmount } = await renderStreaming(
+      'See diagram\n\n![img](https://example.com/x.png)',
+      true,
+    );
+    expect(container.querySelectorAll('.v10-chat-cursor').length).toBe(1);
+    const prose = container.querySelector('.v10-md-p');
+    expect(prose?.textContent).toContain('See diagram');
+    expect(prose?.querySelector('.v10-chat-cursor')).toBeFalsy();
+    await unmount();
+  });
+
+  it('falls back to a trailing caret when a horizontal rule follows prose', async () => {
+    const { container, unmount } = await renderStreaming('Done\n\n---', true);
+    expect(container.querySelector('.v10-md-hr')).toBeTruthy();
+    expect(container.querySelectorAll('.v10-chat-cursor').length).toBe(1);
+    const prose = container.querySelector('.v10-md-p');
+    expect(prose?.querySelector('.v10-chat-cursor')).toBeFalsy();
+    await unmount();
+  });
+
+  it('keeps the caret in the last text line when a <br> is mid-paragraph (not a tail)', async () => {
+    // remark-breaks turns a single newline into <br>. A mid-paragraph
+    // <br> is followed by more text, so the caret stays inline at the
+    // real end — the leaf tail only triggers when nothing text follows.
+    const { container, unmount } = await renderStreaming('line one\nline two', true);
+    const p = container.querySelector('.v10-md-p');
+    expect(p?.querySelector('.v10-chat-cursor')).toBeTruthy();
+    expect(container.querySelectorAll('.v10-chat-cursor').length).toBe(1);
+    await unmount();
+  });
+
   it('keeps NO caret for a code-only stream (fallback must not regress the ux-approved behavior)', async () => {
     // A stream that is only a fenced code block has text, but all of it
     // is code (rebuilt by CodeBlock). Per ux-lead sign-off this shows

--- a/packages/node-ui/test/markdown-message.test.ts
+++ b/packages/node-ui/test/markdown-message.test.ts
@@ -413,4 +413,26 @@ describe('MarkdownMessage streaming caret (PR5 item C)', () => {
     expect(fenced?.querySelector('.v10-chat-cursor')).toBeFalsy();
     await unmount();
   });
+
+  it('falls back to a trailing caret when the stream ends with no text node (image)', async () => {
+    // Regression for Codex PR5: a streamed message ending in an image
+    // has no HAST text node, so the per-text-node anchor finds nothing.
+    // Without the fallback the turn looks finished while still
+    // streaming. Expect exactly one caret, appended after the content.
+    const { container, unmount } = await renderStreaming('![diagram](https://example.com/x.png)', true);
+    expect(container.querySelector('.v10-md-image-placeholder')).toBeTruthy();
+    expect(container.querySelectorAll('.v10-chat-cursor').length).toBe(1);
+    await unmount();
+  });
+
+  it('keeps NO caret for a code-only stream (fallback must not regress the ux-approved behavior)', async () => {
+    // A stream that is only a fenced code block has text, but all of it
+    // is code (rebuilt by CodeBlock). Per ux-lead sign-off this shows
+    // no caret (ChatGPT parity). The image fallback must not leak a
+    // caret here — `sawCodeText` suppresses it.
+    const { container, unmount } = await renderStreaming('```\ncode only\n```', true);
+    expect(container.querySelector('.v10-md-pre')).toBeTruthy();
+    expect(container.querySelectorAll('.v10-chat-cursor').length).toBe(0);
+    await unmount();
+  });
 });

--- a/packages/node-ui/test/panel-right.logic.test.ts
+++ b/packages/node-ui/test/panel-right.logic.test.ts
@@ -106,6 +106,14 @@ function renderConnectedAgentsTab(overrides: Record<string, unknown> = {}) {
       { id: 'testing', name: 'Testing' },
       { id: 'agents', name: 'Agents' },
     ],
+    // ConnectedAgentsTab is presentational; the container derives this
+    // membership-filtered subset (covered by contextGraphSidebar
+    // computeSelectableProjects tests). Mirror availableProjects so the
+    // existing option-rendering assertions are unaffected.
+    selectableProjects: [
+      { id: 'testing', name: 'Testing' },
+      { id: 'agents', name: 'Agents' },
+    ],
     projectsLoading: false,
     onSelectProject: noop,
     attachments: [],

--- a/packages/node-ui/test/panel-right.logic.test.ts
+++ b/packages/node-ui/test/panel-right.logic.test.ts
@@ -506,6 +506,33 @@ describe('ConnectedAgentsTab rendering', () => {
     expect(markup).not.toContain('aria-label="Uploading attachments"');
   });
 
+  it('shows the animated "Thinking…" indicator while an assistant turn is streaming with no content yet (PR5)', () => {
+    const markup = renderConnectedAgentsTab({
+      localMessages: [
+        { id: 'u', role: 'user', content: 'give me some friday ideas', ts: '10:00' },
+        { id: 'a', role: 'assistant', content: '', ts: '10:01', streaming: true },
+      ],
+      localSending: true,
+    });
+    expect(markup).toContain('v10-chat-thinking');
+    expect(markup).toContain('Thinking');
+    expect(markup).toContain('role="status"');
+    // No inline caret yet — there is no text node to anchor it to.
+    expect(markup).not.toContain('v10-chat-cursor');
+  });
+
+  it('drops the "Thinking…" indicator once the first token arrives (hands off to inline caret)', () => {
+    const markup = renderConnectedAgentsTab({
+      localMessages: [
+        { id: 'u', role: 'user', content: 'hi', ts: '10:00' },
+        { id: 'a', role: 'assistant', content: 'The Friday ideas are', ts: '10:01', streaming: true },
+      ],
+      localSending: true,
+    });
+    expect(markup).not.toContain('v10-chat-thinking');
+    expect(markup).toContain('v10-chat-cursor');
+  });
+
   it('renders assistant bubble with no surface styling (PR4 — full-width no-bubble layout)', () => {
     // PR4 drops the assistant bubble to match Claude Desktop / ChatGPT /
     // VS Code Copilot: only user content stays as a pill. We pin two


### PR DESCRIPTION
## Summary

Three deferred chat-panel follow-ups (post-#516). Per user direction, #3 assistant-turn separators and #1 Select typeahead were dropped.

- **A — Project picker = "My projects" membership.** The composer's project `<Select>` listed every context graph; now it mirrors the left sidebar's membership predicate (`belongsInMyProjectsSidebar`). Extracted shared `toSidebarIdentity` + new pure `computeSelectableProjects` into `contextGraphSidebar.ts`. The local "hidden from sidebar" dismissal is intentionally NOT applied. An active-but-non-member project is still surfaced so the trigger never silently retargets. Other `availableProjects` consumers keep the full list.
- **B — Hover-only timestamps.** Hidden by default, revealed on message hover / keyboard `:focus-within`, reusing the `.v10-md-copy` recipe. Touch + reduced-motion always show it. AA contrast unchanged. Pure CSS.
- **C — Inline streaming caret.** Caret was a block sibling after the markdown (orphaned below code/tables/lists). Now injected inline after the last rendered text node via a small rehype tree transform (whitespace-only and fenced-code text skipped). Chosen over the planned sentinel char (leak-proof).

## Tests

- New `computeSelectableProjects` unit cases (membership, active-but-non-member inclusion, no-dup, null identity) in `contextGraphSidebar.test.ts`.
- New streaming-caret cases in `markdown-message.test.ts` (one caret in last text node, none when not streaming, end-of-paragraph, not inside fenced code).
- Full node-ui suite: **574 passed / 38 skipped / 0 failed** (after building runtime workspace deps in the fresh worktree).

## Test plan

- [ ] Picker lists only created/joined projects; a public non-member CG (visible in Context Oracle) does not appear; active-but-non-member still selectable; "No project (clear selection)" works.
- [ ] Timestamps hidden until message hover / keyboard focus; always visible on touch / reduced-motion; contrast unchanged dark + light.
- [ ] During a live stream the caret sits inline after the last streamed character (incl. after lists/tables); vanishes on final; no stray glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)