### PR TITLE
fix(node-ui): resolve 404 + add markdown viewer for imported documents

### DIFF
--- a/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
@@ -4,7 +4,8 @@ import { DashboardView } from '../../views/DashboardView.js';
 import { ProjectView } from '../../views/ProjectView.js';
 import { MemoryLayerView } from '../../views/MemoryLayerView.js';
 import { MemoryStackView } from '../../views/MemoryStackView.js';
-import { authHeaders } from '../../api.js';
+import { authHeaders, fileUrl } from '../../api.js';
+import { MarkdownMessage } from '../chat/MarkdownMessage.js';
 
 const CLOSE_ICON = (
   <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -57,7 +58,14 @@ function TabBar() {
 const TEXT_CONTENT_TYPES = ['text/', 'application/json', 'application/xml', 'application/javascript', 'application/x-yaml'];
 function isTextContentType(ct: string) { return TEXT_CONTENT_TYPES.some(t => ct.startsWith(t)); }
 
-function DocumentViewer({ docRef }: { docRef: string }) {
+// `expectedContentType` is the MIME the document list recorded for this file
+// (from the tab-id encoding). It is a hint passed to the daemon so it serves
+// the file inline with the right type; the authoritative type used for the
+// render branches below is `contentType`, read from the fetch response
+// headers. `docRef` is the full `urn:dkg:file:keccak256:<hex>` urn, or — when
+// the document has no source file — the entity uri, which does not start with
+// `urn:dkg:file:` and drives the "source not available" empty state.
+function DocumentViewer({ docRef, contentType: expectedContentType }: { docRef: string; contentType: string }) {
   const { tabs, activeTabId, closeTab } = useTabsStore();
   const setActiveTab = useTabsStore(s => s.setActiveTab);
   const [content, setContent] = useState<string | null>(null);
@@ -65,7 +73,9 @@ function DocumentViewer({ docRef }: { docRef: string }) {
   const [contentType, setContentType] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<'formatted' | 'raw'>('formatted');
 
+  const hasFileRef = docRef.startsWith('urn:dkg:file:');
   const currentTab = tabs.find(t => t.id === activeTabId);
   const docLabel = currentTab?.label ?? 'Document';
 
@@ -85,10 +95,21 @@ function DocumentViewer({ docRef }: { docRef: string }) {
     setBlobUrl(null);
     setContentType('');
 
+    // No source file linked (docRef is the entity uri, not a file urn) —
+    // skip the request entirely; the render shows the empty state.
+    if (!hasFileRef) {
+      setLoading(false);
+      return;
+    }
+
+    // Strip only the `urn:dkg:file:` prefix so the algorithm-qualified
+    // digest (`keccak256:<hex>`) survives. fileUrl() passes it through
+    // unchanged and appends `?contentType=` so the daemon resolves the
+    // keccak pointer and serves the file inline with the right MIME type.
     const fileHash = docRef.replace('urn:dkg:file:', '');
     const controller = new AbortController();
 
-    fetch(`/api/file/${encodeURIComponent(fileHash)}`, { headers: authHeaders(), signal: controller.signal })
+    fetch(fileUrl(fileHash, expectedContentType || undefined), { headers: authHeaders(), signal: controller.signal })
       .then(async res => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const ct = res.headers.get('content-type') ?? 'application/octet-stream';
@@ -115,6 +136,14 @@ function DocumentViewer({ docRef }: { docRef: string }) {
       cancelled = true;
       controller.abort();
     };
+  }, [docRef, hasFileRef, expectedContentType]);
+
+  // Each newly opened document starts in the documented default view
+  // (Formatted). The toggle is per-document state, so it must reset when
+  // the viewer switches to a different doc — otherwise opening doc B after
+  // toggling doc A to Raw would surprise the user by showing B raw.
+  useEffect(() => {
+    setViewMode('formatted');
   }, [docRef]);
 
   useEffect(() => {
@@ -124,6 +153,14 @@ function DocumentViewer({ docRef }: { docRef: string }) {
 
   const isImage = contentType.startsWith('image/');
   const isPdf = contentType === 'application/pdf';
+  // Treat the document as markdown when either the served response type or
+  // the type recorded at import time says so — the daemon now returns the
+  // correct `text/markdown` for these files, but fall back to the encoded
+  // hint so the formatted view still engages if the header is generic.
+  const isMarkdown =
+    contentType.startsWith('text/markdown') ||
+    expectedContentType.startsWith('text/markdown');
+  const showToggle = !loading && !error && hasFileRef && isMarkdown && content !== null;
 
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
@@ -142,25 +179,85 @@ function DocumentViewer({ docRef }: { docRef: string }) {
           ← Back to Project
         </button>
         <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>📄 {docLabel}</span>
+        {showToggle && (
+          <div
+            role="group"
+            aria-label="Document view mode"
+            style={{
+              marginLeft: 'auto', display: 'flex', gap: 2, padding: 2,
+              border: '1px solid var(--border-default)', borderRadius: 6,
+              background: 'var(--bg-surface)',
+            }}
+          >
+            {(['formatted', 'raw'] as const).map(mode => {
+              const active = viewMode === mode;
+              return (
+                <button
+                  key={mode}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => setViewMode(mode)}
+                  style={{
+                    border: 'none', borderRadius: 4, cursor: 'pointer',
+                    padding: '3px 12px', fontSize: 11, fontWeight: 600,
+                    fontFamily: 'var(--font-sans)',
+                    color: active ? 'var(--text-primary)' : 'var(--text-secondary)',
+                    background: active ? 'var(--bg-elevated)' : 'transparent',
+                  }}
+                >
+                  {mode === 'formatted' ? 'Formatted' : 'Raw'}
+                </button>
+              );
+            })}
+          </div>
+        )}
       </div>
       <div style={{ flex: 1, overflow: 'auto', padding: '20px 24px' }}>
-        {loading && <div style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>Loading document...</div>}
-        {error && <div style={{ color: 'var(--accent-red)', fontSize: 12 }}>Failed to load: {error}</div>}
-        {!loading && isImage && blobUrl && (
-          <img src={blobUrl} alt={docLabel} style={{ maxWidth: '100%', borderRadius: 8 }} />
-        )}
-        {!loading && isPdf && blobUrl && (
-          <iframe src={blobUrl} title={docLabel} style={{ width: '100%', height: '100%', border: 'none', borderRadius: 8 }} />
-        )}
-        {content && !isImage && !isPdf && (
-          <pre style={{
-            fontFamily: 'var(--font-mono)', fontSize: 12, lineHeight: 1.7,
-            color: 'var(--text-primary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
-            background: 'var(--bg-surface)', borderRadius: 8, padding: 16,
-            border: '1px solid var(--border-default)', margin: 0,
+        {!hasFileRef ? (
+          <div style={{
+            display: 'flex', flexDirection: 'column', alignItems: 'center',
+            justifyContent: 'center', gap: 10, height: '100%',
+            color: 'var(--text-tertiary)', textAlign: 'center',
           }}>
-            {content}
-          </pre>
+            <span style={{ fontSize: 28, opacity: 0.6 }}>📄</span>
+            <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-secondary)' }}>
+              Source file not available for this document
+            </span>
+            <span style={{ fontSize: 12, maxWidth: 360, lineHeight: 1.6 }}>
+              This document was indexed into the graph without a stored source
+              file, so there is nothing to preview here. You can still explore
+              its extracted entities and relationships in the graph.
+            </span>
+          </div>
+        ) : (
+          <>
+            {loading && <div style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>Loading document...</div>}
+            {error && <div style={{ color: 'var(--accent-red)', fontSize: 12 }}>Failed to load: {error}</div>}
+            {!loading && isImage && blobUrl && (
+              <img src={blobUrl} alt={docLabel} style={{ maxWidth: '100%', borderRadius: 8 }} />
+            )}
+            {!loading && isPdf && blobUrl && (
+              <iframe src={blobUrl} title={docLabel} style={{ width: '100%', height: '100%', border: 'none', borderRadius: 8 }} />
+            )}
+            {content !== null && !isImage && !isPdf && isMarkdown && viewMode === 'formatted' && (
+              <div style={{
+                background: 'var(--bg-surface)', borderRadius: 8, padding: '16px 20px',
+                border: '1px solid var(--border-default)', color: 'var(--text-primary)',
+              }}>
+                <MarkdownMessage content={content} />
+              </div>
+            )}
+            {content !== null && !isImage && !isPdf && !(isMarkdown && viewMode === 'formatted') && (
+              <pre style={{
+                fontFamily: 'var(--font-mono)', fontSize: 12, lineHeight: 1.7,
+                color: 'var(--text-primary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+                background: 'var(--bg-surface)', borderRadius: 8, padding: 16,
+                border: '1px solid var(--border-default)', margin: 0,
+              }}>
+                {content}
+              </pre>
+            )}
+          </>
         )}
       </div>
     </div>
@@ -222,10 +319,19 @@ function ViewContainer() {
   }
 
   if (activeTabId.startsWith('doc:')) {
-    const raw = activeTabId.slice(4);
-    const lastColon = raw.lastIndexOf(':');
-    const docRef = lastColon > 0 ? raw.slice(lastColon + 1) : raw;
-    return <DocumentViewer docRef={docRef} />;
+    // Tab id shape: `doc:<contextGraphId>|<fileRef>|<contentType>` (see
+    // DocumentsList.handleOpenDoc). Split on the first and last `|` so a
+    // context-graph id containing `:` (or even `|`) stays intact: only the
+    // middle segment is the file ref. `fileRef` keeps its full
+    // `urn:dkg:file:keccak256:<hex>` form so the daemon resolves the digest
+    // with the correct algorithm. A legacy id with no `|` falls back to the
+    // whole payload as docRef (the viewer then shows the empty state).
+    const raw = activeTabId.slice('doc:'.length);
+    const firstPipe = raw.indexOf('|');
+    const lastPipe = raw.lastIndexOf('|');
+    const docRef = firstPipe < 0 ? raw : raw.slice(firstPipe + 1, lastPipe);
+    const contentType = firstPipe < 0 ? '' : raw.slice(lastPipe + 1);
+    return <DocumentViewer docRef={docRef} contentType={contentType} />;
   }
 
   if (activeTabId.startsWith('wm:')) {

--- a/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
@@ -5,6 +5,7 @@ import { ProjectView } from '../../views/ProjectView.js';
 import { MemoryLayerView } from '../../views/MemoryLayerView.js';
 import { MemoryStackView } from '../../views/MemoryStackView.js';
 import { authHeaders, fileUrl } from '../../api.js';
+import { DOC_TAB_PREFIX, decodeDocTabId } from '../../lib/doc-tab-id.js';
 import { MarkdownMessage } from '../chat/MarkdownMessage.js';
 
 const CLOSE_ICON = (
@@ -318,19 +319,11 @@ function ViewContainer() {
     }
   }
 
-  if (activeTabId.startsWith('doc:')) {
-    // Tab id shape: `doc:<contextGraphId>|<fileRef>|<contentType>` (see
-    // DocumentsList.handleOpenDoc). Split on the first and last `|` so a
-    // context-graph id containing `:` (or even `|`) stays intact: only the
-    // middle segment is the file ref. `fileRef` keeps its full
-    // `urn:dkg:file:keccak256:<hex>` form so the daemon resolves the digest
-    // with the correct algorithm. A legacy id with no `|` falls back to the
-    // whole payload as docRef (the viewer then shows the empty state).
-    const raw = activeTabId.slice('doc:'.length);
-    const firstPipe = raw.indexOf('|');
-    const lastPipe = raw.lastIndexOf('|');
-    const docRef = firstPipe < 0 ? raw : raw.slice(firstPipe + 1, lastPipe);
-    const contentType = firstPipe < 0 ? '' : raw.slice(lastPipe + 1);
+  if (activeTabId.startsWith(DOC_TAB_PREFIX)) {
+    // Tab id shape: `doc:<contextGraphId>|<docRef>|<contentType>`. The
+    // encode/decode contract lives in doc-tab-id.ts (kept pure so it is
+    // unit-testable without mounting React).
+    const { docRef, contentType } = decodeDocTabId(activeTabId);
     return <DocumentViewer docRef={docRef} contentType={contentType} />;
   }
 

--- a/packages/node-ui/src/ui/lib/doc-tab-id.ts
+++ b/packages/node-ui/src/ui/lib/doc-tab-id.ts
@@ -34,6 +34,28 @@ export interface DecodedDocTab {
   contentType: string;
 }
 
+/**
+ * Choose which file ref + content-type hint to encode for a document entity.
+ *
+ * Prefer the **markdown form** (the human-readable extracted text). Its hint
+ * MUST be `text/markdown`: a document entity's `sourceContentType` describes
+ * the ORIGINAL upload (e.g. `application/pdf` for a PDF whose markdown
+ * intermediate is the markdown-form ref). Forwarding that original MIME
+ * alongside the markdown ref would make `DocumentViewer` request markdown
+ * bytes under a binary content type and take the wrong (PDF/image) render
+ * path. Only when falling back to the raw source file is `sourceContentType`
+ * the correct hint.
+ */
+export function resolveDocRef(
+  markdownFormRef: string | undefined,
+  sourceFileRef: string | undefined,
+  sourceContentType: string,
+): { ref: string | undefined; contentType: string } {
+  if (markdownFormRef) return { ref: markdownFormRef, contentType: 'text/markdown' };
+  if (sourceFileRef) return { ref: sourceFileRef, contentType: sourceContentType };
+  return { ref: undefined, contentType: sourceContentType };
+}
+
 export function decodeDocTabId(tabId: string): DecodedDocTab {
   const raw = tabId.slice(DOC_TAB_PREFIX.length);
   const firstPipe = raw.indexOf('|');

--- a/packages/node-ui/src/ui/lib/doc-tab-id.ts
+++ b/packages/node-ui/src/ui/lib/doc-tab-id.ts
@@ -1,0 +1,51 @@
+// Encode/decode the center-pane document tab id.
+//
+// Shape: `doc:<contextGraphId>|<docRef>|<contentType>`.
+//
+// The `|` delimiter mirrors the `agent:` tab convention and cannot appear in
+// a `urn:dkg:file:keccak256:<hex>` ref, a context-graph id, or a MIME type,
+// so decoding on the first/last `|` is unambiguous even when the context
+// graph id itself contains `:` or `/`. `docRef` is kept in its full
+// `urn:dkg:file:keccak256:<hex>` form on purpose: stripping the `keccak256:`
+// algorithm prefix makes the daemon misread the digest as sha256 and return
+// 404 — the bug this module's callers fix.
+//
+// Extracted as pure functions (rather than inlined in the component) so the
+// encode/decode contract is unit-testable without mounting React.
+
+export const DOC_TAB_PREFIX = 'doc:';
+
+export function encodeDocTabId(
+  contextGraphId: string,
+  docRef: string,
+  contentType: string,
+): string {
+  return `${DOC_TAB_PREFIX}${contextGraphId}|${docRef}|${contentType}`;
+}
+
+export interface DecodedDocTab {
+  /**
+   * Full `urn:dkg:file:keccak256:<hex>` ref, or — when the document has no
+   * stored source file — the entity uri (which does not start with
+   * `urn:dkg:file:`, so the viewer shows its friendly empty state).
+   */
+  docRef: string;
+  /** MIME hint recorded at import time; `''` when unknown or legacy. */
+  contentType: string;
+}
+
+export function decodeDocTabId(tabId: string): DecodedDocTab {
+  const raw = tabId.slice(DOC_TAB_PREFIX.length);
+  const firstPipe = raw.indexOf('|');
+  const lastPipe = raw.lastIndexOf('|');
+  // Legacy / persisted ids had no `|` (the old `doc:<scope>:<hash>` shape):
+  // treat the whole payload as docRef so the viewer degrades to its empty
+  // state instead of firing a doomed request.
+  if (firstPipe < 0) {
+    return { docRef: raw, contentType: '' };
+  }
+  return {
+    docRef: raw.slice(firstPipe + 1, lastPipe),
+    contentType: raw.slice(lastPipe + 1),
+  };
+}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useCallback, useEffect, lazy, Suspense } from
 import type { ReactNode } from 'react';
 import { useFetch } from '../../hooks.js';
 import { api } from '../../api-wrapper.js';
-import { encodeDocTabId } from '../../lib/doc-tab-id.js';
+import { encodeDocTabId, resolveDocRef } from '../../lib/doc-tab-id.js';
 import {
   listJoinRequests, approveJoinRequest, rejectJoinRequest,
   listParticipants, listAssertions, promoteAssertion,
@@ -1796,10 +1796,18 @@ export function DocumentsList({ entities, contextGraphId }: { entities: MemoryEn
     // daemon misread the digest as sha256 and 404. When no source file is
     // linked we encode the entity uri; the viewer detects the missing
     // `urn:dkg:file:` prefix and shows a friendly empty state.
-    const fileRef = e.connections.find(c => c.predicate === MARKDOWN_FORM || c.predicate === SOURCE_FILE)?.targetUri;
-    const contentType = e.properties.get(SOURCE_CONTENT_TYPE)?.[0] ?? '';
+    //
+    // The content-type hint must describe the *chosen* ref, not the original
+    // upload: for a converter-backed import (e.g. PDF → markdown intermediate)
+    // the markdown-form ref holds markdown bytes while `sourceContentType` is
+    // `application/pdf`. `resolveDocRef` returns `text/markdown` for the
+    // markdown form and only forwards `sourceContentType` for the raw source.
+    const markdownFormRef = e.connections.find(c => c.predicate === MARKDOWN_FORM)?.targetUri;
+    const sourceFileRef = e.connections.find(c => c.predicate === SOURCE_FILE)?.targetUri;
+    const sourceContentType = e.properties.get(SOURCE_CONTENT_TYPE)?.[0] ?? '';
+    const { ref, contentType } = resolveDocRef(markdownFormRef, sourceFileRef, sourceContentType);
     openTab({
-      id: encodeDocTabId(contextGraphId ?? '', fileRef ?? e.uri, contentType),
+      id: encodeDocTabId(contextGraphId ?? '', ref ?? e.uri, contentType),
       label: e.label,
       closable: true,
       icon: '📄',

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1787,11 +1787,18 @@ export function DocumentsList({ entities, contextGraphId }: { entities: MemoryEn
   }, [entities]);
 
   const handleOpenDoc = (e: MemoryEntity) => {
+    // Tab id shape: `doc:<contextGraphId>|<fileRef>|<contentType>`. The `|`
+    // delimiter mirrors the `agent:` tab convention; it cannot appear in a
+    // `urn:dkg:file:keccak256:<hex>` ref, a context-graph id, or a MIME type,
+    // so the decoder can split unambiguously. We keep the FULL file ref
+    // (algorithm prefix intact) — stripping `keccak256:` would make the
+    // daemon misread the digest as sha256 and 404. When no source file is
+    // linked we encode the entity uri; the viewer detects the missing
+    // `urn:dkg:file:` prefix and shows a friendly empty state.
     const fileRef = e.connections.find(c => c.predicate === MARKDOWN_FORM || c.predicate === SOURCE_FILE)?.targetUri;
-    const fileHash = fileRef?.replace('urn:dkg:file:', '') ?? '';
-    const scope = contextGraphId ? `${contextGraphId}:` : '';
+    const contentType = e.properties.get(SOURCE_CONTENT_TYPE)?.[0] ?? '';
     openTab({
-      id: `doc:${scope}${fileHash || e.uri}`,
+      id: `doc:${contextGraphId ?? ''}|${fileRef ?? e.uri}|${contentType}`,
       label: e.label,
       closable: true,
       icon: '📄',

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useCallback, useEffect, lazy, Suspense } from
 import type { ReactNode } from 'react';
 import { useFetch } from '../../hooks.js';
 import { api } from '../../api-wrapper.js';
+import { encodeDocTabId } from '../../lib/doc-tab-id.js';
 import {
   listJoinRequests, approveJoinRequest, rejectJoinRequest,
   listParticipants, listAssertions, promoteAssertion,
@@ -1798,7 +1799,7 @@ export function DocumentsList({ entities, contextGraphId }: { entities: MemoryEn
     const fileRef = e.connections.find(c => c.predicate === MARKDOWN_FORM || c.predicate === SOURCE_FILE)?.targetUri;
     const contentType = e.properties.get(SOURCE_CONTENT_TYPE)?.[0] ?? '';
     openTab({
-      id: `doc:${contextGraphId ?? ''}|${fileRef ?? e.uri}|${contentType}`,
+      id: encodeDocTabId(contextGraphId ?? '', fileRef ?? e.uri, contentType),
       label: e.label,
       closable: true,
       icon: '📄',

--- a/packages/node-ui/test/doc-tab-roundtrip.test.ts
+++ b/packages/node-ui/test/doc-tab-roundtrip.test.ts
@@ -1,0 +1,366 @@
+// @vitest-environment happy-dom
+//
+// Covers the imported-document viewer 404 fix (PR fix/doc-viewer-404):
+//
+//   1. `DocumentsList.handleOpenDoc` encodes the center-tab id as
+//      `doc:<contextGraphId>|<fileRef>|<contentType>`, keeping the FULL
+//      `urn:dkg:file:keccak256:<hex>` ref (no prefix loss).
+//   2. The `doc:` decoder in `ViewContainer` splits on the first/last `|`
+//      and hands `{ docRef, contentType }` to `DocumentViewer`.
+//   3. `DocumentViewer` builds the request URL via `fileUrl()` so the
+//      keccak256 prefix and `?contentType=` survive to the daemon, then
+//      renders markdown formatted (MarkdownMessage) with a Raw toggle, and
+//      shows a friendly empty state — never a 404 — when no source file is
+//      linked.
+//
+// These assert the client-side encode/decode/URL contract, so `fetch` is
+// stubbed to capture the request the component issues and return a
+// controlled response (no backend; the daemon route is validated
+// separately). All other collaborators — the real zustand tabs store, the
+// real `fileUrl()`/`authHeaders()` helpers, the real components — run
+// unmocked.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { useTabsStore } from '../src/ui/stores/tabs.js';
+import {
+  MARKDOWN_FORM,
+  SOURCE_CONTENT_TYPE,
+} from '../src/ui/views/project/helpers.js';
+import type { MemoryEntity } from '../src/ui/hooks/useMemoryEntities.js';
+
+const HEX = 'a'.repeat(64);
+const FILE_REF = `urn:dkg:file:keccak256:${HEX}`;
+
+function docEntity(overrides: Partial<MemoryEntity> = {}): MemoryEntity {
+  return {
+    uri: 'urn:dkg:entity:doc-1',
+    label: 'Quarterly Report.md',
+    types: ['http://dkg.io/ontology/Document'],
+    trustLevel: 'working',
+    layers: new Set(['working']),
+    subGraphs: new Set(['main']),
+    properties: new Map([[SOURCE_CONTENT_TYPE, ['text/markdown']]]),
+    connections: [
+      { predicate: MARKDOWN_FORM, targetUri: FILE_REF, targetLabel: 'source.md' },
+    ],
+    ...overrides,
+  };
+}
+
+function resetTabs() {
+  useTabsStore.setState({
+    tabs: [{ id: 'dashboard', label: 'Dashboard', closable: false }],
+    activeTabId: 'dashboard',
+  });
+}
+
+interface Mounted {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => Promise<void>;
+}
+
+/**
+ * Flush the DocumentViewer fetch chain. The effect does
+ * `fetch().then(res => res.text()).then(setState)` — several microtask hops
+ * plus the body promise — so a single `Promise.resolve()` is not enough.
+ * Drain a handful of `act`-wrapped microtask turns; deterministic, no timers.
+ */
+async function flushAsync(turns = 6): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => { await Promise.resolve(); });
+  }
+}
+
+async function mount(node: React.ReactElement): Promise<Mounted> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: async () => {
+      await act(async () => { root.unmount(); });
+      container.remove();
+    },
+  };
+}
+
+/**
+ * Replace global fetch with a recorder that returns a controlled markdown
+ * (or arbitrary) response. Returns the list of URLs the component requested.
+ *
+ * Uses `vi.stubGlobal` rather than a bare `globalThis.fetch =` assignment so
+ * vitest deterministically restores the original in `afterEach`
+ * (`vi.unstubAllGlobals`). A manual assignment plus a module-load-time
+ * `realFetch` capture is order-sensitive: if another suite in the same
+ * worker mutates `globalThis.fetch`, the captured "original" is already
+ * polluted and these tests flake depending on file execution order.
+ */
+function stubFetch(body: string, contentType: string) {
+  const calls: string[] = [];
+  const fn = vi.fn(async (input: any) => {
+    calls.push(String(input));
+    return new Response(body, {
+      status: 200,
+      headers: { 'content-type': contentType },
+    });
+  });
+  vi.stubGlobal('fetch', fn);
+  return { calls, fn };
+}
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '';
+  resetTabs();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  resetTabs();
+});
+
+describe('doc tab-id encode → decode round-trip', () => {
+  it('encodes the full keccak256 ref + contentType, never a bare hex', async () => {
+    const { DocumentsList } = await import('../src/ui/views/project/components.js');
+    const { container, unmount } = await mount(
+      React.createElement(DocumentsList, {
+        entities: [docEntity()],
+        contextGraphId: 'cg-1',
+      }),
+    );
+
+    const row = container.querySelector('.v10-item-row') as HTMLElement;
+    expect(row).toBeTruthy();
+    await act(async () => {
+      row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const tab = useTabsStore.getState().tabs.find(t => t.id.startsWith('doc:'));
+    expect(tab).toBeTruthy();
+    // Full ref preserved — keccak256 prefix intact, no bare hex.
+    expect(tab!.id).toBe(`doc:cg-1|${FILE_REF}|text/markdown`);
+    expect(tab!.id).toContain('keccak256:');
+
+    await unmount();
+  });
+
+  it('survives a contextGraphId that itself contains colons and slashes', async () => {
+    const { DocumentsList } = await import('../src/ui/views/project/components.js');
+    const cg = 'urn:dkg:context:weird/id:with:colons';
+    const { container, unmount } = await mount(
+      React.createElement(DocumentsList, {
+        entities: [docEntity()],
+        contextGraphId: cg,
+      }),
+    );
+
+    await act(async () => {
+      (container.querySelector('.v10-item-row') as HTMLElement)
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const id = useTabsStore.getState().tabs.find(t => t.id.startsWith('doc:'))!.id;
+    expect(id).toBe(`doc:${cg}|${FILE_REF}|text/markdown`);
+
+    // Decode the way ViewContainer does (first/last pipe) and confirm the
+    // middle segment is the untouched full file ref even with separators in
+    // the cgId.
+    const raw = id.slice('doc:'.length);
+    const firstPipe = raw.indexOf('|');
+    const lastPipe = raw.lastIndexOf('|');
+    expect(raw.slice(0, firstPipe)).toBe(cg);
+    expect(raw.slice(firstPipe + 1, lastPipe)).toBe(FILE_REF);
+    expect(raw.slice(lastPipe + 1)).toBe('text/markdown');
+
+    await unmount();
+  });
+
+  it('falls back to the entity uri when no source file is linked', async () => {
+    const { DocumentsList } = await import('../src/ui/views/project/components.js');
+    const { container, unmount } = await mount(
+      React.createElement(DocumentsList, {
+        entities: [docEntity({ connections: [] })],
+        contextGraphId: 'cg-1',
+      }),
+    );
+    await act(async () => {
+      (container.querySelector('.v10-item-row') as HTMLElement)
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const id = useTabsStore.getState().tabs.find(t => t.id.startsWith('doc:'))!.id;
+    expect(id).toBe('doc:cg-1|urn:dkg:entity:doc-1|text/markdown');
+    expect(id).not.toContain('urn:dkg:file:');
+
+    await unmount();
+  });
+});
+
+describe('DocumentViewer URL construction via fileUrl()', () => {
+  it('requests /api/file/keccak256:<hex>?contentType=text/markdown (prefix kept)', async () => {
+    const { calls } = stubFetch('# Title\n\nBody text.', 'text/markdown');
+    const { PanelCenter } = await import('../src/ui/components/Shell/PanelCenter.js');
+
+    useTabsStore.setState({
+      tabs: [
+        { id: 'dashboard', label: 'Dashboard', closable: false },
+        { id: `doc:cg-1|${FILE_REF}|text/markdown`, label: 'Doc', closable: true },
+      ],
+      activeTabId: `doc:cg-1|${FILE_REF}|text/markdown`,
+    });
+
+    const { unmount } = await mount(React.createElement(PanelCenter));
+    await flushAsync();
+
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toBe(
+      `/api/file/${encodeURIComponent(`keccak256:${HEX}`)}?contentType=${encodeURIComponent('text/markdown')}`,
+    );
+    // Crucially NOT a bare-hex sha256 path (the original 404 cause).
+    expect(calls[0]).toContain('keccak256%3A');
+    expect(calls[0]).not.toBe(`/api/file/${HEX}`);
+
+    await unmount();
+  });
+});
+
+describe('DocumentViewer markdown render + Formatted/Raw toggle', () => {
+  async function openMarkdownDoc() {
+    const { PanelCenter } = await import('../src/ui/components/Shell/PanelCenter.js');
+    const tabId = `doc:cg-1|${FILE_REF}|text/markdown`;
+    useTabsStore.setState({
+      tabs: [
+        { id: 'dashboard', label: 'Dashboard', closable: false },
+        { id: tabId, label: 'Doc', closable: true },
+      ],
+      activeTabId: tabId,
+    });
+    const mounted = await mount(React.createElement(PanelCenter));
+    await flushAsync();
+    return mounted;
+  }
+
+  it('defaults to Formatted (MarkdownMessage) and toggles to Raw (<pre>)', async () => {
+    stubFetch('# Heading One\n\nSome paragraph.', 'text/markdown');
+    const { container, unmount } = await openMarkdownDoc();
+
+    // Formatted by default: MarkdownMessage renders its .v10-md wrapper with
+    // a real <h1>, and there is no raw <pre>.
+    expect(container.querySelector('.v10-md')).toBeTruthy();
+    expect(container.querySelector('.v10-md-h1')?.textContent).toContain('Heading One');
+    expect(container.querySelector('pre')).toBeNull();
+
+    // The toggle is offered for markdown.
+    const rawBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent === 'Raw') as HTMLButtonElement;
+    expect(rawBtn).toBeTruthy();
+
+    await act(async () => {
+      rawBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // Raw: source text in a <pre>, no formatted markdown tree.
+    const pre = container.querySelector('pre');
+    expect(pre).toBeTruthy();
+    expect(pre!.textContent).toBe('# Heading One\n\nSome paragraph.');
+    expect(container.querySelector('.v10-md')).toBeNull();
+
+    await unmount();
+  });
+
+  it('shows the friendly empty state (no fetch) when no source file is linked', async () => {
+    const { fn } = stubFetch('unused', 'text/markdown');
+    const { PanelCenter } = await import('../src/ui/components/Shell/PanelCenter.js');
+    // Missing-fileRef: handleOpenDoc encodes the entity uri in the fileRef
+    // slot; that does not start with `urn:dkg:file:`.
+    const tabId = 'doc:cg-1|urn:dkg:entity:doc-1|text/markdown';
+    useTabsStore.setState({
+      tabs: [
+        { id: 'dashboard', label: 'Dashboard', closable: false },
+        { id: tabId, label: 'Doc', closable: true },
+      ],
+      activeTabId: tabId,
+    });
+
+    const { container, unmount } = await mount(React.createElement(PanelCenter));
+    await flushAsync();
+
+    expect(container.textContent).toContain('Source file not available for this document');
+    // No doomed request fired, and certainly no "Failed to load: HTTP 404".
+    expect(fn).not.toHaveBeenCalled();
+    expect(container.textContent).not.toContain('Failed to load');
+
+    await unmount();
+  });
+});
+
+describe('legacy no-pipe doc: tab id (firstPipe < 0 fallback, contract 1b)', () => {
+  // Pre-fix / persisted tab ids had no `|` delimiter (the old encoding was
+  // `doc:<scope>:<hash>`). The decoder must still degrade gracefully:
+  // docRef = the whole payload, contentType = ''. Both downstream outcomes
+  // are exercised below.
+
+  it('non-file legacy payload → docRef=raw, contentType="", empty state, no fetch', async () => {
+    const { fn } = stubFetch('unused', 'text/markdown');
+    const { PanelCenter } = await import('../src/ui/components/Shell/PanelCenter.js');
+    // Realistic legacy shape: old `doc:<contextGraphId>:<barehex>` id with no
+    // `|`. The payload is not a `urn:dkg:file:` ref, so the viewer shows the
+    // friendly empty state instead of firing a doomed (404) request.
+    const tabId = `doc:cg-1:${HEX}`;
+    expect(tabId.includes('|')).toBe(false);
+    useTabsStore.setState({
+      tabs: [
+        { id: 'dashboard', label: 'Dashboard', closable: false },
+        { id: tabId, label: 'Legacy Doc', closable: true },
+      ],
+      activeTabId: tabId,
+    });
+
+    const { container, unmount } = await mount(React.createElement(PanelCenter));
+    await flushAsync();
+
+    // firstPipe < 0 ⇒ docRef = raw (`cg-1:<hex>`), contentType = ''. That raw
+    // does not start with `urn:dkg:file:`, so: empty state, no request.
+    expect(container.textContent).toContain('Source file not available for this document');
+    expect(fn).not.toHaveBeenCalled();
+    expect(container.textContent).not.toContain('Failed to load');
+
+    await unmount();
+  });
+
+  it('legacy payload that IS a file urn → fetches via fileUrl() with NO ?contentType=', async () => {
+    const { calls } = stubFetch('# Legacy\n\nStored body.', 'text/markdown');
+    const { PanelCenter } = await import('../src/ui/components/Shell/PanelCenter.js');
+    // No `|` at all, and the whole payload is the full file ref. Decoder:
+    // docRef = the file urn, contentType = '' (the firstPipe < 0 branch).
+    const tabId = `doc:${FILE_REF}`;
+    expect(tabId.includes('|')).toBe(false);
+    useTabsStore.setState({
+      tabs: [
+        { id: 'dashboard', label: 'Dashboard', closable: false },
+        { id: tabId, label: 'Legacy Doc', closable: true },
+      ],
+      activeTabId: tabId,
+    });
+
+    const { unmount } = await mount(React.createElement(PanelCenter));
+    await flushAsync();
+
+    // It fetches (raw IS a urn:dkg:file:), keccak256 prefix preserved, and
+    // because contentType decoded to '' the hint query is omitted entirely.
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toBe(`/api/file/${encodeURIComponent(`keccak256:${HEX}`)}`);
+    expect(calls[0]).not.toContain('?contentType=');
+    expect(calls[0]).toContain('keccak256%3A');
+
+    await unmount();
+  });
+});

--- a/packages/node-ui/test/doc-tab-roundtrip.test.ts
+++ b/packages/node-ui/test/doc-tab-roundtrip.test.ts
@@ -1,375 +1,139 @@
-// @vitest-environment happy-dom
+// Covers the imported-document viewer 404 fix (PR fix/doc-viewer-404).
 //
-// Covers the imported-document viewer 404 fix (PR fix/doc-viewer-404):
+// The original bug: the `doc:` center-tab id was built/parsed inline, and the
+// decoder dropped the `keccak256:` algorithm prefix, so the viewer requested
+// `/api/file/<barehex>` — which the daemon resolves as sha256 → 404.
 //
-//   1. `DocumentsList.handleOpenDoc` encodes the center-tab id as
-//      `doc:<contextGraphId>|<fileRef>|<contentType>`, keeping the FULL
-//      `urn:dkg:file:keccak256:<hex>` ref (no prefix loss).
-//   2. The `doc:` decoder in `ViewContainer` splits on the first/last `|`
-//      and hands `{ docRef, contentType }` to `DocumentViewer`.
-//   3. `DocumentViewer` builds the request URL via `fileUrl()` so the
-//      keccak256 prefix and `?contentType=` survive to the daemon, then
-//      renders markdown formatted (MarkdownMessage) with a Raw toggle, and
-//      shows a friendly empty state — never a 404 — when no source file is
-//      linked.
+// The fix is two pure, side-effect-free contracts, exercised here directly
+// (no React mount, no global fetch stub — deliberately: an earlier
+// integration-style version of this file mounted the full shell repeatedly
+// and destabilised the parallel node-ui suite. The 404 root cause is pure
+// string/URL logic, so unit-testing the extracted helpers covers the
+// regression precisely and deterministically):
 //
-// These assert the client-side encode/decode/URL contract, so `fetch` is
-// stubbed to capture the request the component issues and return a
-// controlled response (no backend; the daemon route is validated
-// separately). All other collaborators — the real zustand tabs store, the
-// real `fileUrl()`/`authHeaders()` helpers, the real components — run
-// unmocked.
+//   1. `encodeDocTabId` / `decodeDocTabId` (src/ui/lib/doc-tab-id.ts) — the
+//      tab-id round-trip must preserve the FULL `urn:dkg:file:keccak256:<hex>`
+//      ref and the content-type, and degrade safely for legacy/no-pipe ids.
+//   2. `fileUrl()` (src/ui/api.ts) — must keep the `keccak256:` prefix and
+//      append `?contentType=`, never collapse a keccak digest to a bare/
+//      sha256 path.
 
-import React, { act } from 'react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createRoot, type Root } from 'react-dom/client';
+import { describe, expect, it } from 'vitest';
 
-import { useTabsStore } from '../src/ui/stores/tabs.js';
 import {
-  MARKDOWN_FORM,
-  SOURCE_CONTENT_TYPE,
-} from '../src/ui/views/project/helpers.js';
-import type { MemoryEntity } from '../src/ui/hooks/useMemoryEntities.js';
+  DOC_TAB_PREFIX,
+  encodeDocTabId,
+  decodeDocTabId,
+} from '../src/ui/lib/doc-tab-id.js';
+import { fileUrl } from '../src/ui/api.js';
 
 const HEX = 'a'.repeat(64);
 const FILE_REF = `urn:dkg:file:keccak256:${HEX}`;
 
-function docEntity(overrides: Partial<MemoryEntity> = {}): MemoryEntity {
-  return {
-    uri: 'urn:dkg:entity:doc-1',
-    label: 'Quarterly Report.md',
-    types: ['http://dkg.io/ontology/Document'],
-    trustLevel: 'working',
-    layers: new Set(['working']),
-    subGraphs: new Set(['main']),
-    properties: new Map([[SOURCE_CONTENT_TYPE, ['text/markdown']]]),
-    connections: [
-      { predicate: MARKDOWN_FORM, targetUri: FILE_REF, targetLabel: 'source.md' },
-    ],
-    ...overrides,
-  };
-}
-
-function resetTabs() {
-  useTabsStore.setState({
-    tabs: [{ id: 'dashboard', label: 'Dashboard', closable: false }],
-    activeTabId: 'dashboard',
-  });
-}
-
-interface Mounted {
-  container: HTMLDivElement;
-  root: Root;
-  unmount: () => Promise<void>;
-}
-
-/**
- * Flush the DocumentViewer fetch chain. The effect does
- * `fetch().then(res => res.text()).then(setState)` — several microtask hops
- * plus the body promise — so a single `Promise.resolve()` is not enough.
- * Drain a handful of `act`-wrapped microtask turns; deterministic, no timers.
- */
-async function flushAsync(turns = 6): Promise<void> {
-  for (let i = 0; i < turns; i++) {
-    // eslint-disable-next-line no-await-in-loop
-    await act(async () => { await Promise.resolve(); });
-  }
-}
-
-async function mount(node: React.ReactElement): Promise<Mounted> {
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-  const root = createRoot(container);
-  await act(async () => {
-    root.render(node);
-  });
-  return {
-    container,
-    root,
-    unmount: async () => {
-      await act(async () => { root.unmount(); });
-      container.remove();
-    },
-  };
-}
-
-// Records every fetch the component issues. `beforeEach` installs a default
-// stub so EVERY test (incl. the DocumentsList encode tests that never fetch)
-// runs against a clean, deterministic `globalThis.fetch` from the very first
-// render — never an unstubbed or cross-file-contaminated global. vitest runs
-// test files in parallel workers sharing one globalThis, and ~6 sibling
-// suites also stub `fetch`; installing the stub in `beforeEach` (mirroring
-// use-memory-entities-live-updates.test.ts) + `vi.unstubAllGlobals()` in
-// `afterEach` is the proven isolation pattern in this package. Stubbing
-// mid-test (after render) instead races React effects and flakes.
-let fetchCalls: string[] = [];
-let fetchMock: ReturnType<typeof vi.fn>;
-
-/** Reconfigure the active fetch stub's response. Returns the live recorder. */
-function stubFetch(body: string, contentType: string) {
-  fetchMock.mockImplementation(async (input: any) => {
-    fetchCalls.push(String(input));
-    return new Response(body, {
-      status: 200,
-      headers: { 'content-type': contentType },
-    });
-  });
-  return { calls: fetchCalls, fn: fetchMock };
-}
-
-beforeEach(() => {
-  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
-  document.body.innerHTML = '';
-  resetTabs();
-  fetchCalls = [];
-  // Default: a 404 recorder. Tests that expect a successful body call
-  // stubFetch() to override; tests asserting "no fetch" simply assert the
-  // mock was never called (a leaked real fetch cannot satisfy that).
-  fetchMock = vi.fn(async (input: any) => {
-    fetchCalls.push(String(input));
-    return new Response('not found', { status: 404 });
-  });
-  vi.stubGlobal('fetch', fetchMock);
-});
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-  vi.restoreAllMocks();
-  resetTabs();
-});
-
 describe('doc tab-id encode → decode round-trip', () => {
-  it('encodes the full keccak256 ref + contentType, never a bare hex', async () => {
-    const { DocumentsList } = await import('../src/ui/views/project/components.js');
-    const { container, unmount } = await mount(
-      React.createElement(DocumentsList, {
-        entities: [docEntity()],
-        contextGraphId: 'cg-1',
-      }),
-    );
+  it('preserves the full keccak256 ref + contentType (never a bare hex)', () => {
+    const id = encodeDocTabId('cg-1', FILE_REF, 'text/markdown');
+    expect(id).toBe(`${DOC_TAB_PREFIX}cg-1|${FILE_REF}|text/markdown`);
+    expect(id).toContain('keccak256:');
 
-    const row = container.querySelector('.v10-item-row') as HTMLElement;
-    expect(row).toBeTruthy();
-    await act(async () => {
-      row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    const tab = useTabsStore.getState().tabs.find(t => t.id.startsWith('doc:'));
-    expect(tab).toBeTruthy();
-    // Full ref preserved — keccak256 prefix intact, no bare hex.
-    expect(tab!.id).toBe(`doc:cg-1|${FILE_REF}|text/markdown`);
-    expect(tab!.id).toContain('keccak256:');
-
-    await unmount();
+    const decoded = decodeDocTabId(id);
+    expect(decoded).toEqual({ docRef: FILE_REF, contentType: 'text/markdown' });
+    // The digest survives with its algorithm prefix — this is the 404 fix.
+    expect(decoded.docRef).toBe(FILE_REF);
+    expect(decoded.docRef).not.toBe(HEX);
   });
 
-  it('survives a contextGraphId that itself contains colons and slashes', async () => {
-    const { DocumentsList } = await import('../src/ui/views/project/components.js');
+  it('survives a contextGraphId that itself contains colons and slashes', () => {
     const cg = 'urn:dkg:context:weird/id:with:colons';
-    const { container, unmount } = await mount(
-      React.createElement(DocumentsList, {
-        entities: [docEntity()],
-        contextGraphId: cg,
-      }),
-    );
-
-    await act(async () => {
-      (container.querySelector('.v10-item-row') as HTMLElement)
-        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    const id = useTabsStore.getState().tabs.find(t => t.id.startsWith('doc:'))!.id;
-    expect(id).toBe(`doc:${cg}|${FILE_REF}|text/markdown`);
-
-    // Decode the way ViewContainer does (first/last pipe) and confirm the
-    // middle segment is the untouched full file ref even with separators in
-    // the cgId.
-    const raw = id.slice('doc:'.length);
-    const firstPipe = raw.indexOf('|');
-    const lastPipe = raw.lastIndexOf('|');
-    expect(raw.slice(0, firstPipe)).toBe(cg);
-    expect(raw.slice(firstPipe + 1, lastPipe)).toBe(FILE_REF);
-    expect(raw.slice(lastPipe + 1)).toBe('text/markdown');
-
-    await unmount();
+    const id = encodeDocTabId(cg, FILE_REF, 'text/markdown');
+    const decoded = decodeDocTabId(id);
+    // Only the middle (first..last `|`) segment is the ref; the colon-laden
+    // cgId before the first `|` does not bleed into docRef.
+    expect(decoded.docRef).toBe(FILE_REF);
+    expect(decoded.contentType).toBe('text/markdown');
   });
 
-  it('falls back to the entity uri when no source file is linked', async () => {
-    const { DocumentsList } = await import('../src/ui/views/project/components.js');
-    const { container, unmount } = await mount(
-      React.createElement(DocumentsList, {
-        entities: [docEntity({ connections: [] })],
-        contextGraphId: 'cg-1',
-      }),
-    );
-    await act(async () => {
-      (container.querySelector('.v10-item-row') as HTMLElement)
-        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    const id = useTabsStore.getState().tabs.find(t => t.id.startsWith('doc:'))!.id;
-    expect(id).toBe('doc:cg-1|urn:dkg:entity:doc-1|text/markdown');
-    expect(id).not.toContain('urn:dkg:file:');
+  it('round-trips an empty contentType (no trailing-segment loss)', () => {
+    const id = encodeDocTabId('cg-1', FILE_REF, '');
+    expect(id).toBe(`${DOC_TAB_PREFIX}cg-1|${FILE_REF}|`);
+    expect(decodeDocTabId(id)).toEqual({ docRef: FILE_REF, contentType: '' });
+  });
 
-    await unmount();
+  it('passes through the entity uri when no source file is linked', () => {
+    // handleOpenDoc encodes the entity uri in the docRef slot when there is
+    // no markdownForm/sourceFile connection. It is not a `urn:dkg:file:` ref,
+    // so the viewer shows its empty state — decode must hand it back intact.
+    const entityUri = 'urn:dkg:entity:doc-1';
+    const id = encodeDocTabId('cg-1', entityUri, 'text/markdown');
+    const decoded = decodeDocTabId(id);
+    expect(decoded.docRef).toBe(entityUri);
+    expect(decoded.docRef.startsWith('urn:dkg:file:')).toBe(false);
   });
 });
 
-describe('DocumentViewer URL construction via fileUrl()', () => {
-  it('requests /api/file/keccak256:<hex>?contentType=text/markdown (prefix kept)', async () => {
-    const { calls } = stubFetch('# Title\n\nBody text.', 'text/markdown');
-    const { PanelCenter } = await import('../src/ui/components/Shell/PanelCenter.js');
+describe('decodeDocTabId legacy no-pipe fallback (contract 1b)', () => {
+  // Pre-fix / persisted ids had no `|` (old `doc:<scope>:<hash>` shape). The
+  // decoder must degrade gracefully: docRef = whole payload, contentType = ''.
 
-    useTabsStore.setState({
-      tabs: [
-        { id: 'dashboard', label: 'Dashboard', closable: false },
-        { id: `doc:cg-1|${FILE_REF}|text/markdown`, label: 'Doc', closable: true },
-      ],
-      activeTabId: `doc:cg-1|${FILE_REF}|text/markdown`,
-    });
+  it('non-file legacy payload → docRef = raw payload, contentType = ""', () => {
+    const id = `${DOC_TAB_PREFIX}cg-1:${HEX}`;
+    expect(id.includes('|')).toBe(false);
+    const decoded = decodeDocTabId(id);
+    expect(decoded).toEqual({ docRef: `cg-1:${HEX}`, contentType: '' });
+    // Not a urn:dkg:file: ref ⇒ caller shows the empty state, no request.
+    expect(decoded.docRef.startsWith('urn:dkg:file:')).toBe(false);
+  });
 
-    const { unmount } = await mount(React.createElement(PanelCenter));
-    await flushAsync();
+  it('legacy payload that IS a file urn → docRef keeps the keccak256 prefix', () => {
+    const id = `${DOC_TAB_PREFIX}${FILE_REF}`;
+    expect(id.includes('|')).toBe(false);
+    const decoded = decodeDocTabId(id);
+    expect(decoded.docRef).toBe(FILE_REF);
+    expect(decoded.contentType).toBe('');
+  });
+});
 
-    expect(calls.length).toBe(1);
-    expect(calls[0]).toBe(
+describe('fileUrl() request contract (the 404 linchpin)', () => {
+  it('keeps the keccak256: prefix and appends ?contentType=', () => {
+    const url = fileUrl(`keccak256:${HEX}`, 'text/markdown');
+    expect(url).toBe(
       `/api/file/${encodeURIComponent(`keccak256:${HEX}`)}?contentType=${encodeURIComponent('text/markdown')}`,
     );
-    // Crucially NOT a bare-hex sha256 path (the original 404 cause).
-    expect(calls[0]).toContain('keccak256%3A');
-    expect(calls[0]).not.toBe(`/api/file/${HEX}`);
+    expect(url).toContain('keccak256%3A');
+    // The exact original-bug shape must NOT be produced.
+    expect(url).not.toBe(`/api/file/${HEX}`);
+  });
 
-    await unmount();
+  it('omits the query entirely when contentType is unknown (legacy path)', () => {
+    const url = fileUrl(`keccak256:${HEX}`);
+    expect(url).toBe(`/api/file/${encodeURIComponent(`keccak256:${HEX}`)}`);
+    expect(url).not.toContain('?contentType=');
+    expect(url).toContain('keccak256%3A');
+  });
+
+  it('documents the original defect: a BARE hex is treated as sha256', () => {
+    // This is exactly what the buggy decoder used to feed in; the daemon then
+    // looked the keccak digest up as sha256 and 404'd. Asserting it pins down
+    // why the prefix must be preserved end-to-end.
+    const url = fileUrl(HEX);
+    expect(url).toBe(`/api/file/${encodeURIComponent(`sha256:${HEX}`)}`);
+    expect(url).toContain('sha256%3A');
   });
 });
 
-describe('DocumentViewer markdown render + Formatted/Raw toggle', () => {
-  async function openMarkdownDoc() {
-    const { PanelCenter } = await import('../src/ui/components/Shell/PanelCenter.js');
-    const tabId = `doc:cg-1|${FILE_REF}|text/markdown`;
-    useTabsStore.setState({
-      tabs: [
-        { id: 'dashboard', label: 'Dashboard', closable: false },
-        { id: tabId, label: 'Doc', closable: true },
-      ],
-      activeTabId: tabId,
-    });
-    const mounted = await mount(React.createElement(PanelCenter));
-    await flushAsync();
-    return mounted;
-  }
+describe('end-to-end encode → decode → fileUrl (regression for the 404)', () => {
+  it('a markdown import yields a keccak256 request with the content-type hint', () => {
+    const tabId = encodeDocTabId('project-x', FILE_REF, 'text/markdown');
+    const { docRef, contentType } = decodeDocTabId(tabId);
 
-  it('defaults to Formatted (MarkdownMessage) and toggles to Raw (<pre>)', async () => {
-    stubFetch('# Heading One\n\nSome paragraph.', 'text/markdown');
-    const { container, unmount } = await openMarkdownDoc();
+    // The viewer strips only the `urn:dkg:file:` prefix before calling
+    // fileUrl(); mirror that here to assert the full chain.
+    const hash = docRef.replace('urn:dkg:file:', '');
+    const url = fileUrl(hash, contentType || undefined);
 
-    // Formatted by default: MarkdownMessage renders its .v10-md wrapper with
-    // a real <h1>, and there is no raw <pre>.
-    expect(container.querySelector('.v10-md')).toBeTruthy();
-    expect(container.querySelector('.v10-md-h1')?.textContent).toContain('Heading One');
-    expect(container.querySelector('pre')).toBeNull();
-
-    // The toggle is offered for markdown.
-    const rawBtn = Array.from(container.querySelectorAll('button'))
-      .find(b => b.textContent === 'Raw') as HTMLButtonElement;
-    expect(rawBtn).toBeTruthy();
-
-    await act(async () => {
-      rawBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    // Raw: source text in a <pre>, no formatted markdown tree.
-    const pre = container.querySelector('pre');
-    expect(pre).toBeTruthy();
-    expect(pre!.textContent).toBe('# Heading One\n\nSome paragraph.');
-    expect(container.querySelector('.v10-md')).toBeNull();
-
-    await unmount();
-  });
-
-  it('shows the friendly empty state (no fetch) when no source file is linked', async () => {
-    const { fn } = stubFetch('unused', 'text/markdown');
-    const { PanelCenter } = await import('../src/ui/components/Shell/PanelCenter.js');
-    // Missing-fileRef: handleOpenDoc encodes the entity uri in the fileRef
-    // slot; that does not start with `urn:dkg:file:`.
-    const tabId = 'doc:cg-1|urn:dkg:entity:doc-1|text/markdown';
-    useTabsStore.setState({
-      tabs: [
-        { id: 'dashboard', label: 'Dashboard', closable: false },
-        { id: tabId, label: 'Doc', closable: true },
-      ],
-      activeTabId: tabId,
-    });
-
-    const { container, unmount } = await mount(React.createElement(PanelCenter));
-    await flushAsync();
-
-    expect(container.textContent).toContain('Source file not available for this document');
-    // No doomed request fired, and certainly no "Failed to load: HTTP 404".
-    expect(fn).not.toHaveBeenCalled();
-    expect(container.textContent).not.toContain('Failed to load');
-
-    await unmount();
-  });
-});
-
-describe('legacy no-pipe doc: tab id (firstPipe < 0 fallback, contract 1b)', () => {
-  // Pre-fix / persisted tab ids had no `|` delimiter (the old encoding was
-  // `doc:<scope>:<hash>`). The decoder must still degrade gracefully:
-  // docRef = the whole payload, contentType = ''. Both downstream outcomes
-  // are exercised below.
-
-  it('non-file legacy payload → docRef=raw, contentType="", empty state, no fetch', async () => {
-    const { fn } = stubFetch('unused', 'text/markdown');
-    const { PanelCenter } = await import('../src/ui/components/Shell/PanelCenter.js');
-    // Realistic legacy shape: old `doc:<contextGraphId>:<barehex>` id with no
-    // `|`. The payload is not a `urn:dkg:file:` ref, so the viewer shows the
-    // friendly empty state instead of firing a doomed (404) request.
-    const tabId = `doc:cg-1:${HEX}`;
-    expect(tabId.includes('|')).toBe(false);
-    useTabsStore.setState({
-      tabs: [
-        { id: 'dashboard', label: 'Dashboard', closable: false },
-        { id: tabId, label: 'Legacy Doc', closable: true },
-      ],
-      activeTabId: tabId,
-    });
-
-    const { container, unmount } = await mount(React.createElement(PanelCenter));
-    await flushAsync();
-
-    // firstPipe < 0 ⇒ docRef = raw (`cg-1:<hex>`), contentType = ''. That raw
-    // does not start with `urn:dkg:file:`, so: empty state, no request.
-    expect(container.textContent).toContain('Source file not available for this document');
-    expect(fn).not.toHaveBeenCalled();
-    expect(container.textContent).not.toContain('Failed to load');
-
-    await unmount();
-  });
-
-  it('legacy payload that IS a file urn → fetches via fileUrl() with NO ?contentType=', async () => {
-    const { calls } = stubFetch('# Legacy\n\nStored body.', 'text/markdown');
-    const { PanelCenter } = await import('../src/ui/components/Shell/PanelCenter.js');
-    // No `|` at all, and the whole payload is the full file ref. Decoder:
-    // docRef = the file urn, contentType = '' (the firstPipe < 0 branch).
-    const tabId = `doc:${FILE_REF}`;
-    expect(tabId.includes('|')).toBe(false);
-    useTabsStore.setState({
-      tabs: [
-        { id: 'dashboard', label: 'Dashboard', closable: false },
-        { id: tabId, label: 'Legacy Doc', closable: true },
-      ],
-      activeTabId: tabId,
-    });
-
-    const { unmount } = await mount(React.createElement(PanelCenter));
-    await flushAsync();
-
-    // It fetches (raw IS a urn:dkg:file:), keccak256 prefix preserved, and
-    // because contentType decoded to '' the hint query is omitted entirely.
-    expect(calls.length).toBe(1);
-    expect(calls[0]).toBe(`/api/file/${encodeURIComponent(`keccak256:${HEX}`)}`);
-    expect(calls[0]).not.toContain('?contentType=');
-    expect(calls[0]).toContain('keccak256%3A');
-
-    await unmount();
+    expect(url).toBe(
+      `/api/file/${encodeURIComponent(`keccak256:${HEX}`)}?contentType=${encodeURIComponent('text/markdown')}`,
+    );
+    expect(url).not.toBe(`/api/file/${HEX}`);
   });
 });

--- a/packages/node-ui/test/doc-tab-roundtrip.test.ts
+++ b/packages/node-ui/test/doc-tab-roundtrip.test.ts
@@ -24,6 +24,7 @@ import {
   DOC_TAB_PREFIX,
   encodeDocTabId,
   decodeDocTabId,
+  resolveDocRef,
 } from '../src/ui/lib/doc-tab-id.js';
 import { fileUrl } from '../src/ui/api.js';
 
@@ -135,5 +136,38 @@ describe('end-to-end encode → decode → fileUrl (regression for the 404)', ()
       `/api/file/${encodeURIComponent(`keccak256:${HEX}`)}?contentType=${encodeURIComponent('text/markdown')}`,
     );
     expect(url).not.toBe(`/api/file/${HEX}`);
+  });
+});
+
+describe('resolveDocRef content-type hint (Codex review fix)', () => {
+  const MD_REF = `urn:dkg:file:keccak256:${'c'.repeat(64)}`;
+  const SRC_REF = `urn:dkg:file:keccak256:${'d'.repeat(64)}`;
+
+  it('converter-backed import (PDF→markdown): markdown ref + text/markdown hint, NOT application/pdf', () => {
+    // The regression: a PDF import has a markdown-form ref but
+    // sourceContentType = application/pdf. The hint must describe the chosen
+    // (markdown) ref, else the viewer requests markdown bytes as a PDF.
+    const { ref, contentType } = resolveDocRef(MD_REF, SRC_REF, 'application/pdf');
+    expect(ref).toBe(MD_REF);
+    expect(contentType).toBe('text/markdown');
+    expect(contentType).not.toBe('application/pdf');
+  });
+
+  it('markdown-native import: markdown ref + text/markdown hint', () => {
+    const { ref, contentType } = resolveDocRef(MD_REF, undefined, 'text/markdown');
+    expect(ref).toBe(MD_REF);
+    expect(contentType).toBe('text/markdown');
+  });
+
+  it('raw source only (no markdown form): forwards the source content type', () => {
+    const { ref, contentType } = resolveDocRef(undefined, SRC_REF, 'image/png');
+    expect(ref).toBe(SRC_REF);
+    expect(contentType).toBe('image/png');
+  });
+
+  it('no linked file: ref undefined (caller falls back to entity uri → empty state)', () => {
+    const { ref, contentType } = resolveDocRef(undefined, undefined, 'application/pdf');
+    expect(ref).toBeUndefined();
+    expect(contentType).toBe('application/pdf');
   });
 });

--- a/packages/node-ui/test/doc-tab-roundtrip.test.ts
+++ b/packages/node-ui/test/doc-tab-roundtrip.test.ts
@@ -93,34 +93,43 @@ async function mount(node: React.ReactElement): Promise<Mounted> {
   };
 }
 
-/**
- * Replace global fetch with a recorder that returns a controlled markdown
- * (or arbitrary) response. Returns the list of URLs the component requested.
- *
- * Uses `vi.stubGlobal` rather than a bare `globalThis.fetch =` assignment so
- * vitest deterministically restores the original in `afterEach`
- * (`vi.unstubAllGlobals`). A manual assignment plus a module-load-time
- * `realFetch` capture is order-sensitive: if another suite in the same
- * worker mutates `globalThis.fetch`, the captured "original" is already
- * polluted and these tests flake depending on file execution order.
- */
+// Records every fetch the component issues. `beforeEach` installs a default
+// stub so EVERY test (incl. the DocumentsList encode tests that never fetch)
+// runs against a clean, deterministic `globalThis.fetch` from the very first
+// render — never an unstubbed or cross-file-contaminated global. vitest runs
+// test files in parallel workers sharing one globalThis, and ~6 sibling
+// suites also stub `fetch`; installing the stub in `beforeEach` (mirroring
+// use-memory-entities-live-updates.test.ts) + `vi.unstubAllGlobals()` in
+// `afterEach` is the proven isolation pattern in this package. Stubbing
+// mid-test (after render) instead races React effects and flakes.
+let fetchCalls: string[] = [];
+let fetchMock: ReturnType<typeof vi.fn>;
+
+/** Reconfigure the active fetch stub's response. Returns the live recorder. */
 function stubFetch(body: string, contentType: string) {
-  const calls: string[] = [];
-  const fn = vi.fn(async (input: any) => {
-    calls.push(String(input));
+  fetchMock.mockImplementation(async (input: any) => {
+    fetchCalls.push(String(input));
     return new Response(body, {
       status: 200,
       headers: { 'content-type': contentType },
     });
   });
-  vi.stubGlobal('fetch', fn);
-  return { calls, fn };
+  return { calls: fetchCalls, fn: fetchMock };
 }
 
 beforeEach(() => {
   (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
   document.body.innerHTML = '';
   resetTabs();
+  fetchCalls = [];
+  // Default: a 404 recorder. Tests that expect a successful body call
+  // stubFetch() to override; tests asserting "no fetch" simply assert the
+  // mock was never called (a leaked real fetch cannot satisfy that).
+  fetchMock = vi.fn(async (input: any) => {
+    fetchCalls.push(String(input));
+    return new Response('not found', { status: 404 });
+  });
+  vi.stubGlobal('fetch', fetchMock);
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

- **Fixes the HTTP 404** when opening a document from **Working / Shared-Working Memory → Documents**. The original markdown was never shown (also failed after promotion to SWM).
- **Root cause (two compounding defects, both in `packages/node-ui`):**
  1. *Tab-id delimiter collision* — `DocumentsList.handleOpenDoc` built the tab id as `doc:<cg>:<hash>`; the `ViewContainer` decoder split on `lastIndexOf(':')`, which sliced *inside* `keccak256:<hex>` and produced a **bare hex** `docRef` (algorithm prefix lost).
  2. *Bare-hex misread as sha256* — `DocumentViewer` fetched `/api/file/<barehex>` directly. The daemon treats a bare hex as **sha256**, but the digest is **keccak256** → file-store miss → **404**. No `?contentType=` was sent either, so even a hit returned `application/octet-stream` + `attachment`.
- **Fix (node-ui only; daemon validated, no change required):**
  - The encode/decode contract is extracted into a new pure module `src/ui/lib/doc-tab-id.ts` (`encodeDocTabId` / `decodeDocTabId`) — a single source of truth used by both `DocumentsList` and `ViewContainer` (behaviour-preserving; also makes the contract unit-testable without mounting React).
  - Encode the tab id as `` `doc:<contextGraphId>|<fileRef>|<contentType>` `` using the collision-free `|` delimiter (mirrors the existing `agent:` tab convention); the **full** `urn:dkg:file:keccak256:<hex>` ref is preserved.
  - Decode via first/last `|` so a `contextGraphId` containing `:` (or `/`) stays intact; legacy no-pipe ids degrade gracefully to the empty state.
  - Fetch through the existing `fileUrl()` helper so the `keccak256:` prefix survives and `?contentType=` is sent → daemon serves the file **inline** with the correct MIME type. WM/SWM retrieval is identical (content-addressed file store; `markdownForm`/`sourceFile` linkage is promoted, so `DocumentsList` still resolves the ref in SWM).
  - Render markdown via the existing hardened `MarkdownMessage` (react-markdown + remark-gfm, href/img hardening) with a **Formatted (default) / Raw** segmented toggle; `viewMode` resets to the documented Formatted default on document switch. A missing source file shows a friendly empty state instead of a 404. Image/PDF/text branches unchanged.

## Related

- None (no tracking issue provided; originates from user-reported screenshots).

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/lib/doc-tab-id.ts` | **New** — pure `encodeDocTabId` / `decodeDocTabId` (first/last `\|` split, `firstPipe<0` legacy fallback). Single source of truth for the tab-id contract. |
| `packages/node-ui/src/ui/views/project/components.tsx` | `handleOpenDoc` calls `encodeDocTabId(...)` (full keccak256 ref preserved, `e.uri` fallback when no source file). |
| `packages/node-ui/src/ui/components/Shell/PanelCenter.tsx` | `doc:` route uses `decodeDocTabId()`; `DocumentViewer` fetches via `fileUrl()` with `!hasFileRef` guard; Formatted/Raw toggle; `viewMode` reset on doc switch; friendly empty state. |
| `packages/node-ui/test/doc-tab-roundtrip.test.ts` | **New** — 10 pure unit tests (no React mount): encode→decode round-trip incl. separator-laden contextGraphId & empty contentType, entity-uri pass-through, legacy no-pipe `firstPipe<0` fallback (both branches), `fileUrl()` URL contract (keccak256 kept, query omitted when unknown, bare-hex→sha256 documents the original defect), and an end-to-end encode→decode→fileUrl regression. |

## Test plan

- [x] **Unit (vitest, node-ui):** `pnpm --filter @origintrail-official/dkg-node-ui test` (equivalently `npx vitest run` from `packages/node-ui`). Result: **32 files / 575 passed / 38 skipped / 0 failed** (565 baseline + 10 new). `doc-tab-roundtrip.test.ts` = 10/10 (~6 ms). Determinism independently re-verified by QA on the exact committed commit `5380f931` (clean tree): a cold run (vite caches cleared) + 14 consecutive warm re-runs — **15/15 runs, 32 files / 575 / 0** every time. Sample sized deliberately against the prior ~20-30% warm-run failure rate (15 consecutive greens at that rate has < 0.5% chance — strong evidence the pure-function rewrite removed the contention source).
  - Note: `--filter node-ui` does **not** match — pnpm filters by package name (`@origintrail-official/dkg-node-ui`).
  - **CI / clean-checkout prerequisite:** build the workspace package `@origintrail-official/dkg-graph-viz` (e.g. `pnpm --filter @origintrail-official/dkg-graph-viz build`, or full `pnpm build`) **before** running node-ui tests. `components.tsx` lazy-imports `@origintrail-official/dkg-graph-viz/react`; an empty `dist` makes Vite import-analysis fail to resolve any `components.tsx`-importing suite. This is a cold-cache build-ordering note, not a code defect; CI's shared `build` job already satisfies it before the node-ui test job.
- [ ] **End-to-end (manual):** Import a markdown file into a context graph → Working Memory → Documents → click the doc → renders **Formatted**; toggle **Raw** shows source; toggle back. **Promote the assertion to SWM**, repeat from the SWM Documents tab → same success. Sanity-check a PDF/image import still renders as before (no regression).
- [ ] **Daemon check:** `GET /api/file/keccak256:<hex>?contentType=text/markdown` (with auth header) returns `200`, `Content-Type: text/markdown`, `Content-Disposition: inline`. (Code-traced and confirmed against `packages/cli/src/daemon/routes/assertion.ts` — no daemon change needed.)

### Test-isolation defect found in this PR — and how it was resolved

Honest account (the resolution evolved during review):

- The first version of `doc-tab-roundtrip.test.ts` was integration-style: it mounted the **full `PanelCenter` shell** repeatedly via `createRoot` and stubbed global `fetch`. Under vitest's default parallel runner this destabilised the **whole** node-ui package — the suite was clean (565/0) with the file excluded but cascaded 6+ failures across **unrelated** suites (`composer-autosize`, `panel-right.component`, `dropzone`, `attachment-chip`, `agent-tab-menu`) and intermittently the new file itself, on warm re-runs.
- Intermediate in-test stubbing tweaks (module-load `realFetch` capture → `vi.stubGlobal`/`vi.unstubAllGlobals`, commit `0f514b4d`) addressed a secondary silent-collection-drop symptom **but did not resolve the cascade** (reproduced failing on warm re-runs).
- **Resolution (commit `5380f931`, maintainer-approved):** the 404 root cause is pure string/URL logic, so the encode/decode contract was extracted into `src/ui/lib/doc-tab-id.ts` and the suite rewritten as **pure unit tests** of those helpers + `fileUrl()` — no React mount, no global stub. The contamination source is eliminated. Verified deterministic: full node-ui suite **575/0 across 15 consecutive runs (1 cold + 14 warm) on the committed commit `5380f931`, independently re-verified by QA**; the targeted file runs in ~10 ms.
- **Trade-off (explicitly accepted):** the heavy full-render integration coverage is dropped in favour of determinism. The viewer's render/toggle/empty-state behaviour is unchanged by this decision (it is exercised by the existing component code paths and manual e2e); the encode→decode→`fileUrl()` 404 regression — the actual bug — is covered precisely and deterministically.

### Known / unrelated environment note

- **CLI `markitdown-binary` postinstall** fails on this worktree — CLI-only, unrelated to this node-ui-only change; does not affect the node-ui test gate or the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


