### PR TITLE
fix(core): use Number.isSafeInteger for relayServerCapacity bounds

### DIFF
--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -98,6 +98,17 @@ export interface DerivedRelayCaps {
 export type RelayCapacityValidation =
   | { ok: true; value: number }
   | { ok: false; reason: string };
+/**
+ * Largest `relayServerCapacity` that keeps every derived cap within
+ * JavaScript's safe-integer range. `deriveRelayCaps` produces values up
+ * to `capacity * RELAY_CAPACITY_MULTIPLIER` and feeds them straight to
+ * libp2p config, so the safe ceiling is `MAX_SAFE_INTEGER /
+ * RELAY_CAPACITY_MULTIPLIER`. Operator-supplied values above this would
+ * silently lose precision when scaled (Codex review on PR #524 round 4
+ * — the previous `Number.isInteger` check accepts e.g.
+ * `9007199254740993` which fails round-trip equality with itself).
+ */
+export const MAX_RELAY_SERVER_CAPACITY = Math.floor(Number.MAX_SAFE_INTEGER / RELAY_CAPACITY_MULTIPLIER);
 export function validateRelayServerCapacity(input: unknown): RelayCapacityValidation | null {
   if (input == null) return null;
   if (typeof input !== 'number') {
@@ -106,11 +117,21 @@ export function validateRelayServerCapacity(input: unknown): RelayCapacityValida
   if (!Number.isFinite(input)) {
     return { ok: false, reason: `expected finite number, got ${input}` };
   }
-  if (!Number.isInteger(input)) {
-    return { ok: false, reason: `expected integer, got ${input}` };
+  // `isSafeInteger` instead of `isInteger` — the latter accepts values
+  // above 2^53 that have already lost their integer identity (e.g.
+  // `9007199254740993 === 9007199254740992`), which would corrupt the
+  // multiplied caps `deriveRelayCaps` hands to libp2p.
+  if (!Number.isSafeInteger(input)) {
+    return { ok: false, reason: `expected safe integer, got ${input}` };
   }
   if (input < 1) {
     return { ok: false, reason: `expected >= 1, got ${input}` };
+  }
+  if (input > MAX_RELAY_SERVER_CAPACITY) {
+    return {
+      ok: false,
+      reason: `expected <= ${MAX_RELAY_SERVER_CAPACITY} (so capacity × ${RELAY_CAPACITY_MULTIPLIER} stays a safe integer), got ${input}`,
+    };
   }
   return { ok: true, value: input };
 }
@@ -128,9 +149,10 @@ export function validateRelayServerCapacity(input: unknown): RelayCapacityValida
  * a defensive backstop for direct callers.
  */
 export function deriveRelayCaps(capacity: number): DerivedRelayCaps {
-  if (!Number.isInteger(capacity) || capacity < 1) {
+  if (!Number.isSafeInteger(capacity) || capacity < 1 || capacity > MAX_RELAY_SERVER_CAPACITY) {
     throw new TypeError(
-      `deriveRelayCaps: capacity must be a positive integer, got ${capacity}`,
+      `deriveRelayCaps: capacity must be a safe positive integer ` +
+        `<= ${MAX_RELAY_SERVER_CAPACITY}, got ${capacity}`,
     );
   }
   const streamCap = capacity * RELAY_CAPACITY_MULTIPLIER;

--- a/packages/core/test/relay-capacity.test.ts
+++ b/packages/core/test/relay-capacity.test.ts
@@ -28,6 +28,8 @@ import {
   RELAY_DEFAULT_DURATION_LIMIT_MS,
   RELAY_RESERVATION_TTL_MS,
   EDGE_NODE_MAX_CONNECTIONS,
+  MAX_RELAY_SERVER_CAPACITY,
+  RELAY_CAPACITY_MULTIPLIER,
   deriveRelayCaps,
   validateRelayServerCapacity,
   checkFdLimit,
@@ -129,6 +131,28 @@ describe('validateRelayServerCapacity', () => {
     expect(validateRelayServerCapacity(true as any)).toEqual({ ok: false, reason: expect.stringContaining('number') });
     expect(validateRelayServerCapacity({} as any)).toEqual({ ok: false, reason: expect.stringContaining('number') });
     expect(validateRelayServerCapacity([] as any)).toEqual({ ok: false, reason: expect.stringContaining('number') });
+  });
+
+  it('rejects values above Number.MAX_SAFE_INTEGER — would lose precision when multiplied', () => {
+    // Codex review on PR #524 round 4: `Number.isInteger(9007199254740993)`
+    // returns true even though that value already collapses into
+    // `9007199254740992` (i.e. it fails round-trip equality with itself).
+    // `deriveRelayCaps` then multiplies by RELAY_CAPACITY_MULTIPLIER and
+    // hands an imprecise cap to libp2p. We now reject anything outside
+    // the safe-integer range before it can leak through.
+    const beyondSafe = Number.MAX_SAFE_INTEGER + 2; // +2 because +1 collides with MAX_SAFE_INTEGER itself
+    expect(validateRelayServerCapacity(beyondSafe))
+      .toEqual({ ok: false, reason: expect.stringContaining('safe integer') });
+  });
+
+  it('rejects values whose derived cap would overflow safe-integer range', () => {
+    // The post-multiply ceiling matters: even if `capacity` is itself
+    // safe, `capacity * RELAY_CAPACITY_MULTIPLIER` (the value libp2p
+    // actually receives for the stream caps) must also stay safe.
+    expect(validateRelayServerCapacity(MAX_RELAY_SERVER_CAPACITY))
+      .toEqual({ ok: true, value: MAX_RELAY_SERVER_CAPACITY });
+    expect(validateRelayServerCapacity(MAX_RELAY_SERVER_CAPACITY + 1))
+      .toEqual({ ok: false, reason: expect.stringContaining(`capacity × ${RELAY_CAPACITY_MULTIPLIER}`) });
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #524 addressing a Codex review comment filed after the PR merged.

`Number.isInteger(9007199254740993)` returns `true` even though that value has already collapsed into `9007199254740992` (round-trip equality with itself fails). Operator config above 2^53 would pass the existing validator, then `deriveRelayCaps()` would multiply by `RELAY_CAPACITY_MULTIPLIER` and hand a precision-corrupted cap to libp2p.

## Changes

1. `validateRelayServerCapacity` now uses `Number.isSafeInteger` instead of `Number.isInteger`, **and** enforces an upper bound `MAX_RELAY_SERVER_CAPACITY = floor(MAX_SAFE_INTEGER / RELAY_CAPACITY_MULTIPLIER)`. Both the input and the derived caps stay safe; the old validator only checked the input.

2. `deriveRelayCaps` (the defensive backstop for direct callers) updated to the same check so the throw path can't be reached by a value that should have been rejected upstream.

3. Two new regression cases in `relay-capacity.test.ts`:
   - Reject `MAX_SAFE_INTEGER + 2` (the smallest representable value beyond safe range) with reason \"safe integer\".
   - Accept `MAX_RELAY_SERVER_CAPACITY` exactly; reject `MAX_RELAY_SERVER_CAPACITY + 1` with reason naming the `capacity × MULTIPLIER` overflow.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core test relay-capacity` — 21/21 pass (was 19; +2 new safe-integer cases)
- [x] Full `pnpm --filter @origintrail-official/dkg-core build` clean
- [ ] CI green

## Linked review

Codex comment on https://github.com/OriginTrail/dkg/pull/524#discussion_r3248480000 (line 110 of `packages/core/src/node.ts` after merge).


Made with [Cursor](https://cursor.com)