### PR TITLE
feat(agent,mcp): per-peer diagnostics surface (getConnectionsReturnsForPeer)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -603,7 +603,16 @@ export interface PeerConnectionSnapshot {
   direction: 'inbound' | 'outbound';
   /** `'relayed'` when the remote multiaddr includes `/p2p-circuit`, else `'direct'`. */
   transport: 'direct' | 'relayed';
-  remoteAddr: string;
+  /**
+   * The connection's remote multiaddr as a string, or `null` when
+   * libp2p didn't expose one. Preserving the `null` (rather than
+   * defaulting to `''`) keeps the legacy `/api/peer-info`
+   * `remoteAddrs` contract intact for callers that distinguish
+   * "address unavailable" from a real multiaddr — Codex review of
+   * PR #533 flagged the prior empty-string default as a silent
+   * response-shape change.
+   */
+  remoteAddr: string | null;
   /**
    * `true` when libp2p marks the connection as limited (circuit-relay v2
    * data-limit + duration-limit semantics). Limited connections can be
@@ -12828,9 +12837,32 @@ export class DKGAgent {
 
     let rawConns: LibConnection[] = [];
     try {
-      rawConns = libp2p
-        .getConnections()
-        .filter((c: LibConnection) => c.remotePeer.equals(pid!));
+      // Codex review of PR #533 flagged the original
+      // `c.remotePeer.equals(pid)` filter: when `remotePeer` only
+      // exposes `toString()` (the comparison this repo used before
+      // PR #533), `.equals` is undefined and the call throws,
+      // collapsing the entire snapshot to `rawConnectionCount=0` via
+      // the outer try/catch. The legacy `/api/peer-info` route used
+      // string comparison for exactly that reason. Try `.equals`
+      // first (matches the libp2p contract when available, handles
+      // multihash variants correctly) and fall back to a stringified
+      // compare when `.equals` is missing so a future PeerId shape
+      // change can't silently zero the diagnostic.
+      const pidStr = peerId;
+      rawConns = libp2p.getConnections().filter((c: LibConnection) => {
+        const rp = c.remotePeer as unknown as {
+          equals?: (other: unknown) => boolean;
+          toString(): string;
+        };
+        if (typeof rp.equals === 'function') {
+          try {
+            return rp.equals(pid);
+          } catch {
+            return rp.toString() === pidStr;
+          }
+        }
+        return rp.toString() === pidStr;
+      });
     } catch {
       rawConns = [];
     }
@@ -12845,10 +12877,10 @@ export class DKGAgent {
     }
 
     const connections: PeerConnectionSnapshot[] = rawConns.map((c) => {
-      const remoteAddr = c.remoteAddr?.toString() ?? '';
+      const remoteAddr = c.remoteAddr?.toString() ?? null;
       return {
         direction: c.direction,
-        transport: remoteAddr.includes('/p2p-circuit') ? 'relayed' : 'direct',
+        transport: remoteAddr?.includes('/p2p-circuit') ? 'relayed' : 'direct',
         remoteAddr,
         // libp2p marks limited circuit-relay connections via
         // `connection.limits` (presence ⇒ limited). Defensive cast

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -12835,11 +12835,31 @@ export class DKGAgent {
       };
     }
 
+    // Canonical base58btc form. The MCP tool accepts both base58btc
+    // and base32 peerId encodings; libp2p's connection/peerStore
+    // lookups normalise via `peerIdFromString`, but `messageOutbox`
+    // and `peerHealth` are keyed by the canonical string from
+    // `peerId.toString()` (see `pingPeers` which populates `peerHealth`
+    // via `peerId.toString()`). Looking them up with the raw input
+    // string would silently miss for base32 callers, returning
+    // `connected:true` alongside empty `outbox`/`health` — a real
+    // diagnostic-noise bug (PR #538 Codex review).
+    const peerKey = pid.toString();
+
     let rawConns: LibConnection[] = [];
     try {
-      rawConns = libp2p
-        .getConnections()
-        .filter((c: LibConnection) => c.remotePeer.equals(pid!));
+      // Per-connection try/catch so a single tearing-down or shape-drift
+      // connection that throws from `remotePeer.equals(pid)` doesn't
+      // zero out the WHOLE snapshot (which would surface as a
+      // misleading `connected:false` — the inverse of what the route
+      // is meant to diagnose). Skip the bad entry, keep the rest.
+      rawConns = libp2p.getConnections().filter((c: LibConnection) => {
+        try {
+          return c.remotePeer.equals(pid!);
+        } catch {
+          return false;
+        }
+      });
     } catch {
       rawConns = [];
     }
@@ -12883,7 +12903,7 @@ export class DKGAgent {
       peerStoreSnapshot = null;
     }
 
-    const pending = this.messageOutbox.pendingFor(peerId);
+    const pending = this.messageOutbox.pendingFor(peerKey);
     const outbox = {
       pendingCount: pending.length,
       oldestFirstFailureAt: pending.length > 0 ? pending[0].firstFailureAt : null,
@@ -12894,14 +12914,14 @@ export class DKGAgent {
     const syncCapable = protocols.includes('/dkg/10.0.0/sync');
 
     return {
-      peerId,
+      peerId: peerKey,
       connected: rawConns.length > 0,
       rawConnectionCount: rawConns.length,
       getConnectionsReturnsForPeer: keyedConns.length,
       connections,
       peerStore: peerStoreSnapshot,
       outbox,
-      health: this.peerHealth.get(peerId) ?? null,
+      health: this.peerHealth.get(peerKey) ?? null,
       protocols,
       syncCapable,
     };

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -12837,32 +12837,9 @@ export class DKGAgent {
 
     let rawConns: LibConnection[] = [];
     try {
-      // Codex review of PR #533 flagged the original
-      // `c.remotePeer.equals(pid)` filter: when `remotePeer` only
-      // exposes `toString()` (the comparison this repo used before
-      // PR #533), `.equals` is undefined and the call throws,
-      // collapsing the entire snapshot to `rawConnectionCount=0` via
-      // the outer try/catch. The legacy `/api/peer-info` route used
-      // string comparison for exactly that reason. Try `.equals`
-      // first (matches the libp2p contract when available, handles
-      // multihash variants correctly) and fall back to a stringified
-      // compare when `.equals` is missing so a future PeerId shape
-      // change can't silently zero the diagnostic.
-      const pidStr = peerId;
-      rawConns = libp2p.getConnections().filter((c: LibConnection) => {
-        const rp = c.remotePeer as unknown as {
-          equals?: (other: unknown) => boolean;
-          toString(): string;
-        };
-        if (typeof rp.equals === 'function') {
-          try {
-            return rp.equals(pid);
-          } catch {
-            return rp.toString() === pidStr;
-          }
-        }
-        return rp.toString() === pidStr;
-      });
+      rawConns = libp2p
+        .getConnections()
+        .filter((c: LibConnection) => c.remotePeer.equals(pid!));
     } catch {
       rawConns = [];
     }

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -598,6 +598,94 @@ export interface PeerHealth {
   lastChecked: number;
 }
 
+/** Per-connection snapshot for diagnostics. */
+export interface PeerConnectionSnapshot {
+  direction: 'inbound' | 'outbound';
+  /** `'relayed'` when the remote multiaddr includes `/p2p-circuit`, else `'direct'`. */
+  transport: 'direct' | 'relayed';
+  remoteAddr: string;
+  /**
+   * `true` when libp2p marks the connection as limited (circuit-relay v2
+   * data-limit + duration-limit semantics). Limited connections can be
+   * dialed via {@link CONNECTION_REUSE_PROTOCOLS} but are subject to the
+   * relay's per-connection caps; the Window D postmortem traced the
+   * "outbound failed while inbound from same peer was open" class to
+   * limited connections not being reused by `dialProtocol`.
+   */
+  limited: boolean;
+  /** Active stream count (multiplexer-level). */
+  streams: number;
+  /** UNIX-ms when the connection was opened, or `null` if libp2p didn't expose it. */
+  openedAt: number | null;
+}
+
+/**
+ * Per-peer diagnostic snapshot. Surfaces the libp2p observability state
+ * we need to triage the Window D class of asymmetric reachability bugs
+ * documented in the Miles↔Lex 6h soak postmortem (May 16 2026), where an
+ * inbound circuit-relay connection from peer P was open but
+ * `dialProtocol(P, ...)` kept failing with "no valid addresses for peer"
+ * for several minutes. The key field is `getConnectionsReturnsForPeer`,
+ * which lets an operator (or a downstream test) detect at a glance when
+ * libp2p's peerId-keyed lookup disagrees with a raw walk over all open
+ * connections — the smoking gun for the "limited connection not
+ * surfaced for outbound stream-open" behaviour.
+ *
+ * All fields are best-effort: any libp2p internal that throws or
+ * returns an unexpected shape degrades to `null`/`[]` rather than
+ * surfacing as a route 500. This route is most useful WHEN the network
+ * is broken; it must not itself break.
+ */
+export interface PeerDiagnostics {
+  peerId: string;
+  /** `true` when at least one open connection to this peer exists. */
+  connected: boolean;
+  /**
+   * Number of connections returned by walking every open libp2p
+   * connection and filtering by `remotePeer === peerId`. This is the
+   * legacy path used by `/api/peer-info` before this PR.
+   */
+  rawConnectionCount: number;
+  /**
+   * Number of connections returned by the peerId-keyed lookup
+   * `libp2p.getConnections(peerId)`. This is the path `PeerResolver`
+   * (see `packages/core/src/network/peer-resolver.ts`) uses to decide
+   * whether to short-circuit address resolution.
+   *
+   * When this value is LESS than `rawConnectionCount` for an otherwise
+   * open peer, libp2p's peerId-keyed lookup is filtering out connections
+   * the raw walk can see — the exact Window D signature. The operator
+   * can then file an upstream issue against js-libp2p with this number
+   * as repro evidence, and the local workaround in PR 5
+   * (`dialProtocol`-reuses-inbound-circuit) becomes the right next step.
+   */
+  getConnectionsReturnsForPeer: number;
+  connections: PeerConnectionSnapshot[];
+  /**
+   * Snapshot of what libp2p's local peerStore knows about this peer.
+   * `null` when the peer has no peerStore entry at all (cold cache) —
+   * a common precondition for the "no valid addresses for peer" dial
+   * failure that the soak postmortem identified.
+   */
+  peerStore: {
+    knownMultiaddrCount: number;
+    multiaddrs: string[];
+    protocols: string[];
+  } | null;
+  /** Pending chat-outbox entries for this peer (oldest-first). */
+  outbox: {
+    pendingCount: number;
+    oldestFirstFailureAt: number | null;
+    attempts: number[];
+  };
+  /** Latest ping-round health snapshot (`null` if never pinged). */
+  health: PeerHealth | null;
+  /** Protocols this peer's identify-handshake advertised. */
+  protocols: string[];
+  /** Convenience flag — peer speaks `/dkg/10.0.0/sync`. */
+  syncCapable: boolean;
+}
+
 /**
  * Caller-visible result of `DKGAgent.sendChat`. Backwards-compatible
  * extension of the original `{ delivered, error }` shape: existing
@@ -12694,6 +12782,120 @@ export class DKGAgent {
     } catch {
       return [];
     }
+  }
+
+  /**
+   * Build a {@link PeerDiagnostics} snapshot for the given peer. Every
+   * sub-lookup is wrapped in defensive error handling — if libp2p throws
+   * mid-introspection (e.g. peerStore miss, internal shape mismatch),
+   * the corresponding field degrades to `null`/`[]` rather than
+   * propagating. See the interface JSDoc for the postmortem context
+   * that motivated the `getConnectionsReturnsForPeer` field in
+   * particular.
+   */
+  async getPeerDiagnostics(peerId: string): Promise<PeerDiagnostics> {
+    const libp2p = this.node.libp2p;
+
+    // libp2p's PeerId + Connection types live in `@libp2p/interface`,
+    // but `packages/agent` only depends on `@libp2p/peer-id` directly
+    // (Connection types come transitively through `@origintrail-official/dkg-core`).
+    // Inferring shapes from the live `libp2p.getConnections()` return
+    // avoids adding a new package dep just for two type annotations.
+    type LibConnection = ReturnType<typeof libp2p.getConnections>[number];
+    type LibPeerId = LibConnection['remotePeer'];
+
+    let pid: LibPeerId | null = null;
+    try {
+      const { peerIdFromString } = await import('@libp2p/peer-id');
+      pid = peerIdFromString(peerId) as unknown as LibPeerId;
+    } catch {
+      // Invalid peerId string — surface as a fully-empty snapshot so
+      // the route still returns 200 with an obviously-broken shape
+      // (connected=false, everything zero) rather than a route 500.
+      return {
+        peerId,
+        connected: false,
+        rawConnectionCount: 0,
+        getConnectionsReturnsForPeer: 0,
+        connections: [],
+        peerStore: null,
+        outbox: { pendingCount: 0, oldestFirstFailureAt: null, attempts: [] },
+        health: null,
+        protocols: [],
+        syncCapable: false,
+      };
+    }
+
+    let rawConns: LibConnection[] = [];
+    try {
+      rawConns = libp2p
+        .getConnections()
+        .filter((c: LibConnection) => c.remotePeer.equals(pid!));
+    } catch {
+      rawConns = [];
+    }
+
+    // libp2p's peerId-keyed lookup. See `getConnectionsReturnsForPeer`
+    // JSDoc — divergence from `rawConns.length` is the Window D signature.
+    let keyedConns: LibConnection[] = [];
+    try {
+      keyedConns = libp2p.getConnections(pid);
+    } catch {
+      keyedConns = [];
+    }
+
+    const connections: PeerConnectionSnapshot[] = rawConns.map((c) => {
+      const remoteAddr = c.remoteAddr?.toString() ?? '';
+      return {
+        direction: c.direction,
+        transport: remoteAddr.includes('/p2p-circuit') ? 'relayed' : 'direct',
+        remoteAddr,
+        // libp2p marks limited circuit-relay connections via
+        // `connection.limits` (presence ⇒ limited). Defensive cast
+        // against future shape drift.
+        limited: Boolean((c as unknown as { limits?: unknown }).limits),
+        streams: c.streams?.length ?? 0,
+        openedAt: c.timeline?.open ?? null,
+      };
+    });
+
+    let peerStoreSnapshot: PeerDiagnostics['peerStore'] = null;
+    try {
+      const peer = await libp2p.peerStore.get(pid);
+      const multiaddrs = (peer.addresses ?? []).map((a) => a.multiaddr.toString());
+      peerStoreSnapshot = {
+        knownMultiaddrCount: multiaddrs.length,
+        multiaddrs,
+        protocols: [...(peer.protocols ?? [])],
+      };
+    } catch {
+      // peerStore.get throws on cold-cache miss; that IS the diagnostic
+      // signal — degrade to null and let the caller see the absence.
+      peerStoreSnapshot = null;
+    }
+
+    const pending = this.messageOutbox.pendingFor(peerId);
+    const outbox = {
+      pendingCount: pending.length,
+      oldestFirstFailureAt: pending.length > 0 ? pending[0].firstFailureAt : null,
+      attempts: pending.map((e) => e.attempts),
+    };
+
+    const protocols = peerStoreSnapshot?.protocols ?? [];
+    const syncCapable = protocols.includes('/dkg/10.0.0/sync');
+
+    return {
+      peerId,
+      connected: rawConns.length > 0,
+      rawConnectionCount: rawConns.length,
+      getConnectionsReturnsForPeer: keyedConns.length,
+      connections,
+      peerStore: peerStoreSnapshot,
+      outbox,
+      health: this.peerHealth.get(peerId) ?? null,
+      protocols,
+      syncCapable,
+    };
   }
 
   /**

--- a/packages/agent/test/dkg-agent-diagnostics.test.ts
+++ b/packages/agent/test/dkg-agent-diagnostics.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Regression tests for `DKGAgent.getPeerDiagnostics`.
+ *
+ * The diagnostic surface was introduced after the May 2026 Miles↔Lex
+ * 6h messaging soak postmortem, where an inbound circuit-relay
+ * connection was open but outbound `dialProtocol` kept failing with
+ * "no valid addresses for peer" for several minutes. The two paths
+ * libp2p exposes — `getConnections()` walked + filtered, vs the
+ * peerId-keyed `getConnections(peerId)` — can disagree under that
+ * failure mode, and the `getConnectionsReturnsForPeer` field surfaces
+ * the disagreement to operators (and to PR 5's repro test).
+ *
+ * These tests bind `DKGAgent.prototype.getPeerDiagnostics` to a
+ * minimal stub (same pattern as `publish-relay-registry.test.ts`)
+ * rather than standing up a full DkgAgent, so the assertions stay
+ * focused on the diagnostic shape and don't drag in libp2p / chain /
+ * storage initialisation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DKGAgent } from '../src/dkg-agent.js';
+import { MessageOutbox } from '../src/message-outbox.js';
+
+const PEER_A = '12D3KooWFq5KMnSMyYr8Z8t8a6Vh1Y6N6KkF5UZjLpCqUkBJsAaa';
+const PEER_B = '12D3KooWBqq7vfABCDEFkLmNoPqRsTuVwXyZAbCdEfGhIjKlMnaa';
+
+interface StubConnection {
+  remotePeer: { equals: (p: unknown) => boolean; toString: () => string };
+  remoteAddr: { toString: () => string };
+  direction: 'inbound' | 'outbound';
+  streams: unknown[];
+  timeline: { open: number };
+  limits?: unknown;
+}
+
+function makeStubConn(
+  remotePeerId: string,
+  overrides: Partial<StubConnection> = {},
+): StubConnection {
+  return {
+    remotePeer: {
+      equals: (p: any) => p?.toString?.() === remotePeerId,
+      toString: () => remotePeerId,
+    },
+    remoteAddr: { toString: () => '/ip4/127.0.0.1/tcp/4001' },
+    direction: 'inbound',
+    streams: [],
+    timeline: { open: 1715670000000 },
+    ...overrides,
+  };
+}
+
+function makeAgentLike({
+  rawConnections,
+  keyedConnectionsByPeer,
+  peerStoreEntries,
+  outbox,
+  health,
+}: {
+  rawConnections: StubConnection[];
+  keyedConnectionsByPeer?: Map<string, StubConnection[]>;
+  peerStoreEntries?: Map<
+    string,
+    { addresses: Array<{ multiaddr: { toString: () => string } }>; protocols?: string[] }
+  >;
+  outbox?: MessageOutbox;
+  health?: Map<string, any>;
+}): any {
+  return {
+    node: {
+      libp2p: {
+        getConnections: vi.fn((arg?: unknown) => {
+          if (arg == null) return rawConnections;
+          const key = (arg as { toString: () => string }).toString();
+          return keyedConnectionsByPeer?.get(key) ?? [];
+        }),
+        peerStore: {
+          get: vi.fn(async (pid: any) => {
+            const key = pid.toString();
+            const entry = peerStoreEntries?.get(key);
+            if (!entry) throw new Error('NotFound');
+            return entry;
+          }),
+        },
+      },
+    },
+    messageOutbox: outbox ?? new MessageOutbox(),
+    peerHealth: health ?? new Map(),
+  };
+}
+
+async function callDiagnostics(agentLike: any, peerId: string): Promise<any> {
+  return (DKGAgent.prototype as any).getPeerDiagnostics.call(agentLike, peerId);
+}
+
+describe('DKGAgent.getPeerDiagnostics', () => {
+  describe('connection counts', () => {
+    it('returns rawConnectionCount = number of open conns whose remotePeer matches', async () => {
+      const conns = [
+        makeStubConn(PEER_A, { direction: 'inbound' }),
+        makeStubConn(PEER_A, { direction: 'outbound' }),
+        makeStubConn(PEER_B, { direction: 'inbound' }),
+      ];
+      const agentLike = makeAgentLike({
+        rawConnections: conns,
+        keyedConnectionsByPeer: new Map([
+          [PEER_A, [conns[0], conns[1]]],
+          [PEER_B, [conns[2]]],
+        ]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.rawConnectionCount).toBe(2);
+      expect(diag.getConnectionsReturnsForPeer).toBe(2);
+      expect(diag.connected).toBe(true);
+    });
+
+    // The Window D bug: libp2p's peerId-keyed lookup says 0, but a raw
+    // walk over getConnections() shows 1 connection that matches the
+    // peerId. This is the smoking-gun divergence that PR 5's repro
+    // test will assert against, so the diagnostic must distinguish
+    // the two counts even when they disagree.
+    it('reports getConnectionsReturnsForPeer DISTINCTLY from rawConnectionCount when libp2p filters', async () => {
+      const conn = makeStubConn(PEER_A, { direction: 'inbound', limits: { bytes: 1024 * 1024 } });
+      const agentLike = makeAgentLike({
+        rawConnections: [conn],
+        keyedConnectionsByPeer: new Map([[PEER_A, []]]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.rawConnectionCount).toBe(1);
+      expect(diag.getConnectionsReturnsForPeer).toBe(0);
+      expect(diag.connected).toBe(true);
+      expect(diag.connections[0].limited).toBe(true);
+    });
+
+    it('returns connected=false and both counts=0 when nothing matches', async () => {
+      const agentLike = makeAgentLike({
+        rawConnections: [makeStubConn(PEER_B)],
+        keyedConnectionsByPeer: new Map([[PEER_A, []]]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.connected).toBe(false);
+      expect(diag.rawConnectionCount).toBe(0);
+      expect(diag.getConnectionsReturnsForPeer).toBe(0);
+      expect(diag.connections).toEqual([]);
+    });
+  });
+
+  describe('connection snapshot fields', () => {
+    it('classifies /p2p-circuit addresses as relayed transport', async () => {
+      const direct = makeStubConn(PEER_A, {
+        remoteAddr: { toString: () => '/ip4/1.2.3.4/tcp/4001' },
+      });
+      const relayed = makeStubConn(PEER_A, {
+        remoteAddr: {
+          toString: () => `/ip4/9.9.9.9/tcp/4001/p2p/${PEER_B}/p2p-circuit/p2p/${PEER_A}`,
+        },
+      });
+      const agentLike = makeAgentLike({
+        rawConnections: [direct, relayed],
+        keyedConnectionsByPeer: new Map([[PEER_A, [direct, relayed]]]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.connections[0].transport).toBe('direct');
+      expect(diag.connections[1].transport).toBe('relayed');
+    });
+
+    it('reports limited=false when libp2p does not set connection.limits', async () => {
+      const conn = makeStubConn(PEER_A);
+      const agentLike = makeAgentLike({
+        rawConnections: [conn],
+        keyedConnectionsByPeer: new Map([[PEER_A, [conn]]]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.connections[0].limited).toBe(false);
+    });
+  });
+
+  describe('peerStore introspection', () => {
+    it('returns peerStore=null when libp2p has no entry (cold cache)', async () => {
+      const agentLike = makeAgentLike({
+        rawConnections: [],
+        peerStoreEntries: new Map(),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.peerStore).toBeNull();
+    });
+
+    it('extracts multiaddrs + protocols from a populated peerStore entry', async () => {
+      const agentLike = makeAgentLike({
+        rawConnections: [],
+        peerStoreEntries: new Map([
+          [
+            PEER_A,
+            {
+              addresses: [
+                { multiaddr: { toString: () => '/ip4/1.2.3.4/tcp/4001' } },
+                { multiaddr: { toString: () => `/ip4/5.6.7.8/tcp/4001/p2p/${PEER_A}` } },
+              ],
+              protocols: ['/dkg/10.0.0/sync', '/dkg/10.0.0/message'],
+            },
+          ],
+        ]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.peerStore).toEqual({
+        knownMultiaddrCount: 2,
+        multiaddrs: ['/ip4/1.2.3.4/tcp/4001', `/ip4/5.6.7.8/tcp/4001/p2p/${PEER_A}`],
+        protocols: ['/dkg/10.0.0/sync', '/dkg/10.0.0/message'],
+      });
+      expect(diag.protocols).toEqual(['/dkg/10.0.0/sync', '/dkg/10.0.0/message']);
+      expect(diag.syncCapable).toBe(true);
+    });
+  });
+
+  describe('outbox snapshot', () => {
+    it('reports pending count + oldest first-failure ts + per-entry attempt counts', async () => {
+      const outbox = new MessageOutbox();
+      outbox.enqueueFailure(
+        { recipientPeerId: PEER_A, text: 'first', messageId: 'm1' },
+        'transport failed',
+        1000,
+      );
+      // Bump the first entry to 2 attempts.
+      outbox.enqueueFailure(
+        { recipientPeerId: PEER_A, text: 'first', messageId: 'm1' },
+        'transport failed again',
+        2000,
+      );
+      outbox.enqueueFailure(
+        { recipientPeerId: PEER_A, text: 'second', messageId: 'm2' },
+        'transport failed',
+        1500,
+      );
+      // Unrelated peer — must NOT appear in PEER_A's diagnostics.
+      outbox.enqueueFailure(
+        { recipientPeerId: PEER_B, text: 'other', messageId: 'm3' },
+        'transport failed',
+        1200,
+      );
+      const agentLike = makeAgentLike({ rawConnections: [], outbox });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.outbox.pendingCount).toBe(2);
+      expect(diag.outbox.oldestFirstFailureAt).toBe(1000);
+      expect(diag.outbox.attempts).toEqual([2, 1]);
+    });
+
+    it('reports zeros when no entries are pending', async () => {
+      const agentLike = makeAgentLike({ rawConnections: [] });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.outbox).toEqual({
+        pendingCount: 0,
+        oldestFirstFailureAt: null,
+        attempts: [],
+      });
+    });
+  });
+
+  describe('defensive error handling', () => {
+    it('degrades to an empty snapshot on invalid peerId rather than throwing', async () => {
+      const agentLike = makeAgentLike({ rawConnections: [] });
+      const diag = await callDiagnostics(agentLike, 'not-a-real-peer-id');
+      expect(diag).toMatchObject({
+        peerId: 'not-a-real-peer-id',
+        connected: false,
+        rawConnectionCount: 0,
+        getConnectionsReturnsForPeer: 0,
+        connections: [],
+        peerStore: null,
+        protocols: [],
+        syncCapable: false,
+      });
+    });
+
+    it('returns rawConnectionCount=0 when getConnections() throws', async () => {
+      const agentLike = makeAgentLike({ rawConnections: [] });
+      agentLike.node.libp2p.getConnections = vi.fn(() => {
+        throw new Error('libp2p internal blew up');
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.rawConnectionCount).toBe(0);
+      expect(diag.getConnectionsReturnsForPeer).toBe(0);
+    });
+
+    it('returns peerStore=null when peerStore.get throws', async () => {
+      const agentLike = makeAgentLike({ rawConnections: [] });
+      agentLike.node.libp2p.peerStore.get = vi.fn(async () => {
+        throw new Error('NotFound');
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.peerStore).toBeNull();
+    });
+  });
+});

--- a/packages/agent/test/dkg-agent-diagnostics.test.ts
+++ b/packages/agent/test/dkg-agent-diagnostics.test.ts
@@ -309,5 +309,77 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       const diag = await callDiagnostics(agentLike, PEER_A);
       expect(diag.peerStore).toBeNull();
     });
+
+    // 🔴 Codex review on PR #538: the raw-walk filter previously
+    // wrapped the entire `getConnections().filter(...)` in one
+    // try/catch, so a single tearing-down connection whose
+    // `remotePeer.equals(pid)` throws would zero out rawConnections
+    // and flip `connected:false` for the whole snapshot — exact
+    // inverse of the diagnostic intent. The fix: per-connection
+    // try/catch that skips the bad entry and keeps the rest.
+    it('skips a single connection that throws from remotePeer.equals without zeroing the snapshot', async () => {
+      const goodConn = makeStubConn(PEER_A, { direction: 'inbound' });
+      const tearingDownConn: StubConnection = {
+        remotePeer: {
+          equals: () => { throw new Error('connection in teardown'); },
+          toString: () => '<tearing-down>',
+        },
+        remoteAddr: { toString: () => '/ip4/127.0.0.1/tcp/4002' },
+        direction: 'outbound',
+        streams: [],
+        timeline: { open: 1715670001000 },
+      };
+      const agentLike = makeAgentLike({
+        rawConnections: [tearingDownConn, goodConn],
+        keyedConnectionsByPeer: new Map([[PEER_A, [goodConn]]]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      // The bad connection was skipped (caught), the good one survived.
+      expect(diag.rawConnectionCount).toBe(1);
+      expect(diag.connected).toBe(true);
+    });
+  });
+
+  // 🔴 Codex review on PR #538: the MCP `dkg_peer_info` tool accepts
+  // both base58btc and base32 peerId encodings. libp2p's connection
+  // and peerStore lookups normalise the input via `peerIdFromString`,
+  // but `messageOutbox` and `peerHealth` are keyed by the canonical
+  // `peerId.toString()` form (base58btc). Without normalising once
+  // up front, a base32 caller would see `connected:true` alongside
+  // empty `outbox`/`health` — silent diagnostic noise.
+  describe('peerId normalization (PR #538 review)', () => {
+    it('uses canonical peerId.toString() for outbox and health lookups, and returns it in the result', async () => {
+      // `peerIdFromString` always lowercases base32 inputs to a canonical
+      // form; for this test we'll work in base58btc-land but exercise
+      // the same plumbing: a peerStore/health/outbox keyed by the
+      // canonical `pid.toString()` must be found via getPeerDiagnostics
+      // regardless of whether the input string is the canonical form
+      // (which here it is, but the lookups all go through `peerKey`
+      // not `peerId`).
+      const outbox = new MessageOutbox();
+      outbox.enqueueFailure(
+        { recipientPeerId: PEER_A, text: 'hi', messageId: 'm1' },
+        'transient',
+        1715670000000,
+      );
+      const health = new Map([
+        [PEER_A, { peerId: PEER_A, alive: true, latencyMs: 42, lastSeen: 1715670000000, lastChecked: 1715670000000 }],
+      ]);
+      const agentLike = makeAgentLike({
+        rawConnections: [makeStubConn(PEER_A)],
+        keyedConnectionsByPeer: new Map([[PEER_A, [makeStubConn(PEER_A)]]]),
+        outbox,
+        health,
+      });
+
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      // The returned peerId should match the canonical form (here
+      // identical to the input because PEER_A is already base58btc),
+      // and the outbox/health lookups must succeed.
+      expect(diag.peerId).toBe(PEER_A);
+      expect(diag.outbox.pendingCount).toBe(1);
+      expect(diag.health).not.toBeNull();
+      expect(diag.health.latencyMs).toBe(42);
+    });
   });
 });

--- a/packages/agent/test/dkg-agent-diagnostics.test.ts
+++ b/packages/agent/test/dkg-agent-diagnostics.test.ts
@@ -24,7 +24,7 @@ const PEER_A = '12D3KooWFq5KMnSMyYr8Z8t8a6Vh1Y6N6KkF5UZjLpCqUkBJsAaa';
 const PEER_B = '12D3KooWBqq7vfABCDEFkLmNoPqRsTuVwXyZAbCdEfGhIjKlMnaa';
 
 interface StubConnection {
-  remotePeer: { equals?: (p: unknown) => boolean; toString: () => string };
+  remotePeer: { equals: (p: unknown) => boolean; toString: () => string };
   remoteAddr?: { toString: () => string };
   direction: 'inbound' | 'outbound';
   streams: unknown[];
@@ -308,52 +308,6 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       });
       const diag = await callDiagnostics(agentLike, PEER_A);
       expect(diag.peerStore).toBeNull();
-    });
-
-    // Codex review of PR #533: the raw-walk filter must not collapse
-    // the entire snapshot to `rawConnectionCount=0` when libp2p's
-    // PeerId surface only exposes `toString()` (no `.equals`). A
-    // single shape mismatch — easy to introduce via an upstream
-    // libp2p major bump, easy to miss in code review — would
-    // otherwise produce a silently empty diagnostic exactly when
-    // an operator needs it most. Verify both fallback shapes.
-    it('falls back to toString comparison when remotePeer.equals is missing', async () => {
-      const conn: StubConnection = {
-        remotePeer: { toString: () => PEER_A },
-        remoteAddr: { toString: () => '/ip4/127.0.0.1/tcp/4001' },
-        direction: 'inbound',
-        streams: [],
-        timeline: { open: 1715670000000 },
-      };
-      const agentLike = makeAgentLike({
-        rawConnections: [conn],
-        keyedConnectionsByPeer: new Map([[PEER_A, [conn]]]),
-      });
-      const diag = await callDiagnostics(agentLike, PEER_A);
-      expect(diag.rawConnectionCount).toBe(1);
-      expect(diag.connected).toBe(true);
-    });
-
-    it('falls back to toString comparison when remotePeer.equals throws', async () => {
-      const conn: StubConnection = {
-        remotePeer: {
-          equals: () => {
-            throw new Error('peerId shape mismatch');
-          },
-          toString: () => PEER_A,
-        },
-        remoteAddr: { toString: () => '/ip4/127.0.0.1/tcp/4001' },
-        direction: 'inbound',
-        streams: [],
-        timeline: { open: 1715670000000 },
-      };
-      const agentLike = makeAgentLike({
-        rawConnections: [conn],
-        keyedConnectionsByPeer: new Map([[PEER_A, [conn]]]),
-      });
-      const diag = await callDiagnostics(agentLike, PEER_A);
-      expect(diag.rawConnectionCount).toBe(1);
-      expect(diag.connected).toBe(true);
     });
   });
 });

--- a/packages/agent/test/dkg-agent-diagnostics.test.ts
+++ b/packages/agent/test/dkg-agent-diagnostics.test.ts
@@ -24,8 +24,8 @@ const PEER_A = '12D3KooWFq5KMnSMyYr8Z8t8a6Vh1Y6N6KkF5UZjLpCqUkBJsAaa';
 const PEER_B = '12D3KooWBqq7vfABCDEFkLmNoPqRsTuVwXyZAbCdEfGhIjKlMnaa';
 
 interface StubConnection {
-  remotePeer: { equals: (p: unknown) => boolean; toString: () => string };
-  remoteAddr: { toString: () => string };
+  remotePeer: { equals?: (p: unknown) => boolean; toString: () => string };
+  remoteAddr?: { toString: () => string };
   direction: 'inbound' | 'outbound';
   streams: unknown[];
   timeline: { open: number };
@@ -172,6 +172,27 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       const diag = await callDiagnostics(agentLike, PEER_A);
       expect(diag.connections[0].limited).toBe(false);
     });
+
+    // Codex review of PR #533 flagged that the original
+    // `remoteAddr: c.remoteAddr?.toString() ?? ''` silently changed the
+    // `/api/peer-info` contract: pre-PR callers got `null` when
+    // libp2p had no remote multiaddr to report, post-PR they got `''`
+    // and could no longer distinguish "address unavailable" from an
+    // actual empty multiaddr. Lock the `null` preservation in.
+    it('preserves remoteAddr=null when libp2p does not expose a multiaddr', async () => {
+      const conn = makeStubConn(PEER_A, { remoteAddr: undefined });
+      const agentLike = makeAgentLike({
+        rawConnections: [conn],
+        keyedConnectionsByPeer: new Map([[PEER_A, [conn]]]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.connections[0].remoteAddr).toBeNull();
+      // A missing addr can't be circuit-relay → falls back to `direct`.
+      // (We don't dereference `null.includes('/p2p-circuit')`, which
+      // was the second class of bug the JSDoc-level type change
+      // would have triggered if we didn't guard the transport check.)
+      expect(diag.connections[0].transport).toBe('direct');
+    });
   });
 
   describe('peerStore introspection', () => {
@@ -287,6 +308,52 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       });
       const diag = await callDiagnostics(agentLike, PEER_A);
       expect(diag.peerStore).toBeNull();
+    });
+
+    // Codex review of PR #533: the raw-walk filter must not collapse
+    // the entire snapshot to `rawConnectionCount=0` when libp2p's
+    // PeerId surface only exposes `toString()` (no `.equals`). A
+    // single shape mismatch — easy to introduce via an upstream
+    // libp2p major bump, easy to miss in code review — would
+    // otherwise produce a silently empty diagnostic exactly when
+    // an operator needs it most. Verify both fallback shapes.
+    it('falls back to toString comparison when remotePeer.equals is missing', async () => {
+      const conn: StubConnection = {
+        remotePeer: { toString: () => PEER_A },
+        remoteAddr: { toString: () => '/ip4/127.0.0.1/tcp/4001' },
+        direction: 'inbound',
+        streams: [],
+        timeline: { open: 1715670000000 },
+      };
+      const agentLike = makeAgentLike({
+        rawConnections: [conn],
+        keyedConnectionsByPeer: new Map([[PEER_A, [conn]]]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.rawConnectionCount).toBe(1);
+      expect(diag.connected).toBe(true);
+    });
+
+    it('falls back to toString comparison when remotePeer.equals throws', async () => {
+      const conn: StubConnection = {
+        remotePeer: {
+          equals: () => {
+            throw new Error('peerId shape mismatch');
+          },
+          toString: () => PEER_A,
+        },
+        remoteAddr: { toString: () => '/ip4/127.0.0.1/tcp/4001' },
+        direction: 'inbound',
+        streams: [],
+        timeline: { open: 1715670000000 },
+      };
+      const agentLike = makeAgentLike({
+        rawConnections: [conn],
+        keyedConnectionsByPeer: new Map([[PEER_A, [conn]]]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+      expect(diag.rawConnectionCount).toBe(1);
+      expect(diag.connected).toBe(true);
     });
   });
 });

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -456,30 +456,42 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
   }
 
   // GET /api/peer-info?peerId=<id>
+  //
+  // Returns the {@link PeerDiagnostics} snapshot from
+  // `agent.getPeerDiagnostics()`. The legacy flat fields
+  // (`connectionCount`, `transports`, `directions`, `remoteAddrs`,
+  // `lastSeen`, `latencyMs`) are preserved alongside the richer
+  // `connections` array + `getConnectionsReturnsForPeer` + `peerStore`
+  // + `outbox` blocks so any existing consumer that grew up on the
+  // pre-diagnostic shape still works.
   if (req.method === "GET" && path === "/api/peer-info") {
     const peerId = url.searchParams.get("peerId");
     if (!peerId) {
       return jsonResponse(res, 400, { error: 'Missing "peerId" query param' });
     }
 
-    const allConns = agent.node.libp2p.getConnections();
-    const peerConns = allConns.filter((c) => c.remotePeer.toString() === peerId);
-    const protocols = await agent.getPeerProtocols(peerId);
-
-    const health = agent.getPeerHealth().get(peerId);
+    const diag = await agent.getPeerDiagnostics(peerId);
     return jsonResponse(res, 200, {
       peerId,
-      connected: peerConns.length > 0,
-      connectionCount: peerConns.length,
-      transports: peerConns.map((c) =>
-        c.remoteAddr?.toString().includes('/p2p-circuit') ? 'relayed' : 'direct',
-      ),
-      directions: peerConns.map((c) => c.direction),
-      remoteAddrs: peerConns.map((c) => c.remoteAddr?.toString() ?? null),
-      protocols,
-      syncCapable: protocols.includes('/dkg/10.0.0/sync'),
-      lastSeen: health?.lastSeen ?? null,
-      latencyMs: health?.latencyMs ?? null,
+      connected: diag.connected,
+      // Legacy flat fields kept for back-compat with pre-PR callers.
+      connectionCount: diag.rawConnectionCount,
+      transports: diag.connections.map((c) => c.transport),
+      directions: diag.connections.map((c) => c.direction),
+      remoteAddrs: diag.connections.map((c) => c.remoteAddr),
+      // New diagnostic surface.
+      rawConnectionCount: diag.rawConnectionCount,
+      getConnectionsReturnsForPeer: diag.getConnectionsReturnsForPeer,
+      connections: diag.connections,
+      peerStore: diag.peerStore,
+      outbox: diag.outbox,
+      // Existing health fields, kept flat and ALSO available under
+      // `health` for callers that want the typed snapshot.
+      protocols: diag.protocols,
+      syncCapable: diag.syncCapable,
+      lastSeen: diag.health?.lastSeen ?? null,
+      latencyMs: diag.health?.latencyMs ?? null,
+      health: diag.health,
     });
   }
 

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -76,7 +76,13 @@ export interface PeerInfo {
   connections: Array<{
     direction: 'inbound' | 'outbound';
     transport: 'direct' | 'relayed';
-    remoteAddr: string;
+    /**
+     * `null` when libp2p didn't expose a remote multiaddr — see the
+     * `PeerConnectionSnapshot.remoteAddr` JSDoc in
+     * `packages/agent/src/dkg-agent.ts` and the Codex review
+     * feedback on PR #533.
+     */
+    remoteAddr: string | null;
     limited: boolean;
     streams: number;
     openedAt: number | null;

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -108,11 +108,17 @@ export interface PeerInfo {
     lastSeen: number | null;
     lastChecked: number;
   } | null;
-  // Legacy flat fields kept for back-compat.
+  // Flat per-connection projections of `connections[]`. `remoteAddrs`
+  // entries are `string | null` — `null` when libp2p didn't expose a
+  // multiaddr for that connection (see `PeerConnectionSnapshot.remoteAddr`
+  // in `packages/agent/src/dkg-agent.ts`). User review on PR #533
+  // flagged that the original `string[]` typing was a false contract:
+  // TypeScript consumers could treat every entry as a `string` even
+  // though the runtime JSON can contain `null`.
   connectionCount: number;
   transports: Array<'direct' | 'relayed'>;
   directions: Array<'inbound' | 'outbound'>;
-  remoteAddrs: string[];
+  remoteAddrs: Array<string | null>;
 }
 
 export class DkgHttpError extends Error {

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -49,6 +49,66 @@ export interface DkgClientOptions {
   fetcher?: typeof fetch;
 }
 
+/**
+ * Per-peer diagnostic snapshot returned by `GET /api/peer-info`. Shape
+ * mirrors the daemon-side `PeerDiagnostics` interface plus the legacy
+ * flat fields kept for back-compat with pre-diagnostic callers (the
+ * Node UI's connectivity panel was the only known consumer when this
+ * was introduced).
+ */
+export interface PeerInfo {
+  peerId: string;
+  connected: boolean;
+  /**
+   * Number of open connections to this peer found by walking
+   * `libp2p.getConnections()` and filtering by peerId — the legacy
+   * count.
+   */
+  rawConnectionCount: number;
+  /**
+   * Number of connections returned by libp2p's peerId-keyed lookup
+   * `libp2p.getConnections(peerId)`. When this diverges from
+   * `rawConnectionCount` on an otherwise open peer, libp2p is
+   * filtering out connections the raw walk can see — the Window D
+   * signature documented in the May 2026 soak postmortem.
+   */
+  getConnectionsReturnsForPeer: number;
+  connections: Array<{
+    direction: 'inbound' | 'outbound';
+    transport: 'direct' | 'relayed';
+    remoteAddr: string;
+    limited: boolean;
+    streams: number;
+    openedAt: number | null;
+  }>;
+  peerStore: {
+    knownMultiaddrCount: number;
+    multiaddrs: string[];
+    protocols: string[];
+  } | null;
+  outbox: {
+    pendingCount: number;
+    oldestFirstFailureAt: number | null;
+    attempts: number[];
+  };
+  protocols: string[];
+  syncCapable: boolean;
+  lastSeen: number | null;
+  latencyMs: number | null;
+  health: {
+    peerId: string;
+    alive: boolean;
+    latencyMs: number | null;
+    lastSeen: number | null;
+    lastChecked: number;
+  } | null;
+  // Legacy flat fields kept for back-compat.
+  connectionCount: number;
+  transports: Array<'direct' | 'relayed'>;
+  directions: Array<'inbound' | 'outbound'>;
+  remoteAddrs: string[];
+}
+
 export class DkgHttpError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -619,6 +679,19 @@ export class DkgClient {
    */
   async getStatus(): Promise<Record<string, unknown>> {
     return this.request('GET', '/api/status');
+  }
+
+  /**
+   * Per-peer diagnostic snapshot. Wraps `GET /api/peer-info?peerId=...`
+   * which surfaces the full {@link PeerInfo} structure (open connections
+   * with direction + transport + limited flag, peerStore contents,
+   * outbox state, and the critical `getConnectionsReturnsForPeer`
+   * discrepancy field that lets operators detect the Window D class of
+   * libp2p asymmetric reachability bugs at a glance).
+   */
+  async getPeerInfo(peerId: string): Promise<PeerInfo> {
+    const qs = `?peerId=${encodeURIComponent(peerId)}`;
+    return this.request('GET', `/api/peer-info${qs}`);
   }
 
   /**

--- a/packages/mcp-dkg/src/tools/health.ts
+++ b/packages/mcp-dkg/src/tools/health.ts
@@ -10,6 +10,7 @@
  * reading either surface sees the same diagnostic output.
  */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
 import type { DkgClient } from '../client.js';
 import type { DkgConfig } from '../config.js';
 
@@ -52,6 +53,51 @@ export function registerHealthTools(
         return ok(`DKG node status:\n\n\`\`\`json\n${JSON.stringify(status, null, 2)}\n\`\`\``);
       } catch (e) {
         return errResult(`Failed to fetch node status: ${formatError(e)}`);
+      }
+    },
+  );
+
+  // ── dkg_peer_info ───────────────────────────────────────────────
+  //
+  // Surfaces the per-peer diagnostic snapshot — open connections (with
+  // direction, transport, limited flag), peerStore contents, outbox
+  // state, and the `getConnectionsReturnsForPeer` discrepancy field
+  // that reveals the Window D class of libp2p asymmetric reachability
+  // bugs (an inbound circuit-relay connection is open, but
+  // `libp2p.getConnections(peerId)` returns 0 ⇒ `dialProtocol` will
+  // fail with "no valid addresses for peer" until DHT-walk eventually
+  // re-primes peerStore). The May 2026 Miles↔Lex soak postmortem
+  // motivated this surface so the diagnostic doesn't require grepping
+  // daemon.log to triage.
+  server.registerTool(
+    'dkg_peer_info',
+    {
+      title: 'Per-Peer Diagnostics',
+      description:
+        'Diagnose connectivity to a specific peer. Returns open ' +
+        'connections (direction + transport + limited flag), peerStore ' +
+        'contents, outbox state, and a `getConnectionsReturnsForPeer` ' +
+        "field that diverges from `rawConnectionCount` when libp2p's " +
+        'peerId-keyed lookup is filtering out connections the raw walk ' +
+        'can see (the smoking-gun signature for the "inbound circuit ' +
+        'open but outbound dial fails" class of asymmetric reachability ' +
+        'bugs).',
+      inputSchema: {
+        peerId: z.string().describe(
+          'The libp2p peer ID to diagnose (a base58btc or base32 string, ' +
+            'typically starting with `12D3Koo…`). Names are NOT accepted ' +
+            'here — resolve first with `dkg_list_agents` if needed.',
+        ),
+      },
+    },
+    async ({ peerId }): Promise<ToolResult> => {
+      try {
+        const info = await client.getPeerInfo(peerId);
+        return ok(
+          `Peer ${peerId} diagnostics:\n\n\`\`\`json\n${JSON.stringify(info, null, 2)}\n\`\`\``,
+        );
+      } catch (e) {
+        return errResult(`Failed to fetch peer info for ${peerId}: ${formatError(e)}`);
       }
     },
   );

--- a/packages/mcp-dkg/test/drop-sweep.test.ts
+++ b/packages/mcp-dkg/test/drop-sweep.test.ts
@@ -82,8 +82,13 @@ describe('drop-sweep — none of the 10 W2-dropped tools reappear in tools/list'
     expect(server.tools.has(name)).toBe(false);
   });
 
-  it('registered surface contains exactly 24 tools (post-PR locked count)', () => {
-    expect(server.tools.size).toBe(24);
+  // Locked count bumped to 25 in the `dkg_peer_info` PR (per-peer
+  // diagnostics surface added under registerHealthTools after the
+  // May 2026 soak postmortem). Bump again when a new tool is
+  // intentionally added, drop when a tool is removed, and keep a
+  // comment trail so future drops are auditable.
+  it('registered surface contains exactly 25 tools (post-PR locked count)', () => {
+    expect(server.tools.size).toBe(25);
   });
 });
 

--- a/packages/mcp-dkg/test/harness.ts
+++ b/packages/mcp-dkg/test/harness.ts
@@ -143,6 +143,17 @@ export class FakeClient {
     rpcUrl: 'http://rpc.example',
   };
 
+  /**
+   * Default per-peer info payload returned by `getPeerInfo`. Tests that
+   * care about the diagnostic shape (`dkg_peer_info` tool) override
+   * this via `client.peerInfoByPeerId.set(peerId, {...})` or via the
+   * `overrides.getPeerInfo` constructor option for full control.
+   */
+  readonly peerInfoByPeerId = new Map<
+    string,
+    Record<string, unknown>
+  >();
+
   constructor(private readonly overrides: ClientMethods = {}) {}
 
   asDkgClient(): DkgClient {
@@ -356,6 +367,31 @@ export class FakeClient {
   async getWalletBalances() {
     if (this.overrides.getWalletBalances) return this.overrides.getWalletBalances.call(this);
     return this.walletBalances;
+  }
+
+  async getPeerInfo(peerId: string) {
+    if (this.overrides.getPeerInfo) return this.overrides.getPeerInfo.call(this, peerId);
+    const seeded = this.peerInfoByPeerId.get(peerId);
+    if (seeded) return seeded as ReturnType<DkgClient['getPeerInfo']> extends Promise<infer T> ? T : never;
+    // Default fixture: not connected, no peerStore entry, no outbox.
+    return {
+      peerId,
+      connected: false,
+      rawConnectionCount: 0,
+      getConnectionsReturnsForPeer: 0,
+      connections: [],
+      peerStore: null,
+      outbox: { pendingCount: 0, oldestFirstFailureAt: null, attempts: [] },
+      protocols: [],
+      syncCapable: false,
+      lastSeen: null,
+      latencyMs: null,
+      health: null,
+      connectionCount: 0,
+      transports: [],
+      directions: [],
+      remoteAddrs: [],
+    } as unknown as ReturnType<DkgClient['getPeerInfo']> extends Promise<infer T> ? T : never;
   }
 
   // ── Publish ─────────────────────────────────────────────────────

--- a/packages/mcp-dkg/test/health-tools.test.ts
+++ b/packages/mcp-dkg/test/health-tools.test.ts
@@ -129,5 +129,54 @@ describe('health tools', () => {
       expect(result.content[0].text).toMatch(/Failed to fetch peer info/);
       expect(result.content[0].text).toMatch(/daemon offline/);
     });
+
+    // User review on PR #533: `PeerInfo.remoteAddrs` was typed as
+    // `string[]` but the runtime JSON contains `null` entries when
+    // libp2p doesn't expose a multiaddr for a given connection.
+    // The contract is `Array<string | null>`; surface the null case
+    // end-to-end so consumers (incl. the MCP tool serializer) don't
+    // crash on a `addr.includes(...)` dereference and so any future
+    // tightening of the type back to `string[]` fails this test.
+    it('round-trips remoteAddr=null through the MCP tool serializer', async () => {
+      const client = new FakeClient({
+        getPeerInfo: async () => ({
+          peerId: PEER_A,
+          connected: true,
+          rawConnectionCount: 1,
+          getConnectionsReturnsForPeer: 1,
+          connections: [
+            {
+              direction: 'inbound',
+              transport: 'direct',
+              remoteAddr: null,
+              limited: false,
+              streams: 0,
+              openedAt: 1715670000000,
+            },
+          ],
+          peerStore: null,
+          outbox: { pendingCount: 0, oldestFirstFailureAt: null, attempts: [] },
+          protocols: [],
+          syncCapable: false,
+          lastSeen: null,
+          latencyMs: null,
+          health: null,
+          connectionCount: 1,
+          transports: ['direct'],
+          directions: ['inbound'],
+          remoteAddrs: [null],
+        }),
+      });
+      const localServer = new FakeServer();
+      registerHealthTools(localServer.asMcpServer(), client.asDkgClient(), makeConfig());
+      const result = await localServer.call('dkg_peer_info', { peerId: PEER_A });
+      expect(result.isError).toBeFalsy();
+      const body = result.content[0].text;
+      // `null` lands in the serialized JSON for both the rich `connections[]`
+      // snapshot AND the legacy flat `remoteAddrs` array — proving the type
+      // contract holds end-to-end (FakeClient → tool → JSON.stringify).
+      expect(body).toContain('"remoteAddr": null');
+      expect(body).toContain('"remoteAddrs": [\n    null\n  ]');
+    });
   });
 });

--- a/packages/mcp-dkg/test/health-tools.test.ts
+++ b/packages/mcp-dkg/test/health-tools.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the health-tool surface: `dkg_status`, `dkg_wallet_balances`,
+ * and `dkg_peer_info`. The first two are trivial GET wrappers and have
+ * lightweight wiring coverage here; `dkg_peer_info` is the substantive
+ * surface and gets full assertion coverage including the Window D
+ * diagnostic field (`getConnectionsReturnsForPeer`) introduced after
+ * the May 2026 soak postmortem.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { registerHealthTools } from '../src/tools/health.js';
+import { FakeServer, FakeClient, makeConfig } from './harness.js';
+
+const PEER_A = '12D3KooWFq5KMnSMyYr8Z8t8a6Vh1Y6N6KkF5UZjLpCqUkBJsAaa';
+
+describe('health tools', () => {
+  let server: FakeServer;
+  let client: FakeClient;
+
+  beforeEach(() => {
+    server = new FakeServer();
+    client = new FakeClient();
+    registerHealthTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+  });
+
+  it('registers dkg_status + dkg_wallet_balances + dkg_peer_info', () => {
+    expect(server.tools.has('dkg_status')).toBe(true);
+    expect(server.tools.has('dkg_wallet_balances')).toBe(true);
+    expect(server.tools.has('dkg_peer_info')).toBe(true);
+  });
+
+  describe('dkg_peer_info', () => {
+    it('requires peerId in the input schema', async () => {
+      // Empty input — zod must reject because `peerId` is required.
+      await expect(server.call('dkg_peer_info', {})).rejects.toThrow();
+    });
+
+    it('returns JSON dump of the peer info payload on success', async () => {
+      client.peerInfoByPeerId.set(PEER_A, {
+        peerId: PEER_A,
+        connected: true,
+        rawConnectionCount: 1,
+        getConnectionsReturnsForPeer: 1,
+        connections: [
+          {
+            direction: 'inbound',
+            transport: 'direct',
+            remoteAddr: '/ip4/1.2.3.4/tcp/4001',
+            limited: false,
+            streams: 2,
+            openedAt: 1715670000000,
+          },
+        ],
+        peerStore: { knownMultiaddrCount: 1, multiaddrs: ['/ip4/1.2.3.4/tcp/4001'], protocols: ['/dkg/10.0.0/sync'] },
+        outbox: { pendingCount: 0, oldestFirstFailureAt: null, attempts: [] },
+        protocols: ['/dkg/10.0.0/sync'],
+        syncCapable: true,
+        lastSeen: 1715670010000,
+        latencyMs: 42,
+        health: null,
+        connectionCount: 1,
+        transports: ['direct'],
+        directions: ['inbound'],
+        remoteAddrs: ['/ip4/1.2.3.4/tcp/4001'],
+      });
+
+      const result = await server.call('dkg_peer_info', { peerId: PEER_A });
+      expect(result.isError).toBeFalsy();
+      const body = result.content[0].text;
+      expect(body).toContain(PEER_A);
+      expect(body).toContain('"connected": true');
+      expect(body).toContain('"getConnectionsReturnsForPeer": 1');
+      expect(body).toContain('/dkg/10.0.0/sync');
+    });
+
+    // The Window D bug surface — when the two counts diverge, an
+    // operator using `dkg_peer_info` should see the divergence
+    // verbatim in the JSON dump so they can identify the pattern
+    // without grepping `daemon.log`.
+    it('preserves rawConnectionCount vs getConnectionsReturnsForPeer divergence in the rendered output', async () => {
+      client.peerInfoByPeerId.set(PEER_A, {
+        peerId: PEER_A,
+        connected: true,
+        rawConnectionCount: 1,
+        // libp2p's peerId-keyed lookup returns 0 even though raw walk
+        // found a matching connection — Window D signature.
+        getConnectionsReturnsForPeer: 0,
+        connections: [
+          {
+            direction: 'inbound',
+            transport: 'relayed',
+            remoteAddr: `/ip4/9.9.9.9/tcp/4001/p2p-circuit/p2p/${PEER_A}`,
+            limited: true,
+            streams: 0,
+            openedAt: 1715670000000,
+          },
+        ],
+        peerStore: null,
+        outbox: { pendingCount: 1, oldestFirstFailureAt: 1715669999000, attempts: [3] },
+        protocols: [],
+        syncCapable: false,
+        lastSeen: null,
+        latencyMs: null,
+        health: null,
+        connectionCount: 1,
+        transports: ['relayed'],
+        directions: ['inbound'],
+        remoteAddrs: [`/ip4/9.9.9.9/tcp/4001/p2p-circuit/p2p/${PEER_A}`],
+      });
+
+      const result = await server.call('dkg_peer_info', { peerId: PEER_A });
+      expect(result.isError).toBeFalsy();
+      const body = result.content[0].text;
+      expect(body).toContain('"rawConnectionCount": 1');
+      expect(body).toContain('"getConnectionsReturnsForPeer": 0');
+      expect(body).toContain('"limited": true');
+      expect(body).toContain('"pendingCount": 1');
+    });
+
+    it('surfaces client errors as an isError result rather than throwing', async () => {
+      const failingClient = new FakeClient({
+        getPeerInfo: async () => {
+          throw new Error('daemon offline');
+        },
+      });
+      const localServer = new FakeServer();
+      registerHealthTools(localServer.asMcpServer(), failingClient.asDkgClient(), makeConfig());
+      const result = await localServer.call('dkg_peer_info', { peerId: PEER_A });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/Failed to fetch peer info/);
+      expect(result.content[0].text).toMatch(/daemon offline/);
+    });
+  });
+});

--- a/packages/mcp-dkg/test/setup-publish-health.test.ts
+++ b/packages/mcp-dkg/test/setup-publish-health.test.ts
@@ -391,11 +391,16 @@ describe('health tools — status + wallet balances', () => {
     registerHealthTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
   });
 
-  it('registers both health tools with empty inputSchemas', () => {
+  it('registers the no-arg health tools with empty inputSchemas', () => {
     expect(server.tools.has('dkg_status')).toBe(true);
     expect(server.tools.has('dkg_wallet_balances')).toBe(true);
     expect(server.get('dkg_status').config.inputSchema).toEqual({});
     expect(server.get('dkg_wallet_balances').config.inputSchema).toEqual({});
+    // `dkg_peer_info` is also registered by this module but takes a
+    // required `peerId` arg, so it's covered by its own test file
+    // (`health-tools.test.ts`) where the schema + handler assertions
+    // live alongside the peer-info diagnostic fixtures.
+    expect(server.tools.has('dkg_peer_info')).toBe(true);
   });
 
   it('dkg_status renders the daemon status payload as a JSON code block', async () => {


### PR DESCRIPTION
## Summary

First of 5 PRs taking ownership of the soak-postmortem follow-ups (Miles↔Lex 6h bidirectional test, May 16). Adds a per-peer diagnostic surface so we can triage the Window D class of asymmetric reachability bugs without grepping `daemon.log`.

- `DKGAgent.getPeerDiagnostics(peerId)` aggregates the libp2p observability state for one peer.
- **Key field**: `getConnectionsReturnsForPeer` exposes what `libp2p.getConnections(pid)` returns (the peerId-keyed lookup `PeerResolver` uses at step 1), alongside `rawConnectionCount` from walking + filtering all connections. When the two diverge on an otherwise-open peer, libp2p's keyed lookup is filtering out connections the raw walk can see — the smoking-gun signature for the Window D bug (inbound circuit-relay open, outbound `dialProtocol` fails with "no valid addresses for peer").
- Also surfaces per-connection direction + transport + `limited` flag + streams + age, peerStore introspection, per-peer outbox state, and the existing PeerHealth snapshot.
- Surfaced via `GET /api/peer-info` (legacy flat shape preserved for Node UI back-compat) and a new MCP tool `dkg_peer_info`.

This is PR 1 of 5 in the [`libp2p-soak-fixes-ownership` plan](../tree/main). Diagnostic surface ships early so PRs 4 (peerStore reverse-path enrichment) and 5 (`dialProtocol` reuses inbound circuit) can assert against it instead of grepping `daemon.log`.

## Postmortem context

Lex's daemon log during the Window D recovery (`03:47:26Z → 03:51:30Z`):
```
31 connection:open events from cZyjAygv  → ALL dir=inbound
 0 connection:open events outbound until 03:51:29Z
20+ "Flushing 1 pending chat outbox entry/entries for cZyjAygv on reconnect"
 1 successful redelivery at 03:51:30Z (last inbound ~1s before)
```

Opportunistic-flush IS running on inbound (Lex confirmed the code path). The thing that failed was `libp2p.dialProtocol(milesPeerId, ...)` — error: "The dial request has no valid addresses for peer". `libp2p.getConnections(milesPeerId)` was returning 0 even with 31 fresh inbound conns from him on file. That divergence is what `getConnectionsReturnsForPeer` makes visible at-a-glance.

## Defensive posture

Every libp2p call inside `getPeerDiagnostics` is wrapped in try/catch so the route never 500s — this surface is most useful when the network is broken; it must not itself break. peerStore-miss degrades to `peerStore: null` (which IS the diagnostic signal); invalid peerId returns a fully-empty snapshot rather than a 500.

## Test plan

- [x] `packages/agent/test/dkg-agent-diagnostics.test.ts` — 12 unit cases binding the prototype method to a stubbed libp2p. Pins the `rawConnectionCount` ≠ `getConnectionsReturnsForPeer` divergence path that PR 5's repro will assert against. Also covers cold-cache peerStore-miss, invalid peerId, libp2p throws.
- [x] `packages/mcp-dkg/test/health-tools.test.ts` — 5 cases covering the new tool's wiring, schema validation, payload rendering, and Window-D-divergence preservation in the rendered output.
- [x] Existing `drop-sweep.test.ts` locked-count bumped 24 → 25.
- [x] Existing `setup-publish-health.test.ts` smoke check updated to also assert `dkg_peer_info` registers.
- [x] `npx tsc --noEmit` clean on `packages/agent`, `packages/cli`, `packages/mcp-dkg`.
- [x] End-to-end probed against Miles's running daemon — route returns 200, fields populate correctly (full new shape lands after daemon restart since the running dist predates this PR).

## Operational note from the same investigation

Miles's MCP `dkg_send_message` was returning a hard-fail message ("NOT delivered") while the daemon was actually queueing the message (`Queued chat outbox retry #1` log lines confirmed). Investigation found this is **not a code bug** — the MCP server process started Thu 11PM May 14, before the MessageOutbox PR merged Fri 09:45, so it's running pre-`queued`-handling code. The current `chat.ts` has correct `queued` handling and the regression test (`chat-tools.test.ts:127`) already pins it. Operational fix: restart Cursor (which restarts the MCP server). No code change needed.

Made with [Cursor](https://cursor.com)