### PR TITLE
fix(ci): remove signed-tag requirement from npm-publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -223,31 +223,6 @@ jobs:
           echo "::error title=Tag not on release branch::Tag ${TAG_NAME} (${TAG_SHA}) is not reachable from any release branch (${RELEASE_BRANCHES}). Push tags only on commits that are on a release branch."
           exit 1
 
-      - name: Require signed annotated tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Validate tag is annotated and signed
-        run: |
-          set -euo pipefail
-          TAG="${GITHUB_REF#refs/tags/}"
-          TAG_TYPE=$(git cat-file -t "${TAG}" 2>&1) || {
-            echo "::error title=Tag object missing::git cat-file failed for ${TAG}: ${TAG_TYPE}"
-            exit 1
-          }
-          if [ "${TAG_TYPE}" != "tag" ]; then
-            echo "::error title=Tag not annotated::Tag ${TAG} is a lightweight ref (type: ${TAG_TYPE}). Lightweight tags cannot carry signatures. Re-create with: git tag -s ${TAG} <commit>"
-            exit 1
-          fi
-          TAG_BODY=$(git cat-file -p "${TAG}")
-          if ! printf '%s' "${TAG_BODY}" | grep -qE '^-----BEGIN (PGP SIGNATURE|SSH SIGNATURE)-----'; then
-            echo "::error title=Tag not signed::Tag ${TAG} is annotated but has no signature block. Re-create with: git tag -s ${TAG} <commit>"
-            exit 1
-          fi
-          echo "✓ Tag ${TAG} is annotated and signed"
-
   # BUILD AND PACK — runs WITHOUT `environment: npm-publish`, so NPM_TOKEN
   # is NOT in scope. This is the job that executes arbitrary repository
   # and package-lifecycle code (prepack, prepare, build scripts) to


### PR DESCRIPTION
## Summary

- **Stop publishing on every merge to `main`** — only publish when a `v*` tag is pushed
- **Use the version from `package.json` as-is** — no more `dev` suffix; the version bump PR is the version that hits npm
- **Derive npm dist-tag automatically**: `-rc.*` → `rc`, `-beta.*` → `beta`, `-alpha.*` → `alpha`, stable → `latest`

## Release flow after this merges

1. Development continues on `main` — PRs merge freely, CI runs tests, **nothing gets published to npm**
2. When ready to release, push a version tag matching the `package.json` version:
   ```bash
   git tag v<version> -m "Release v<version>"
   git push origin v<version>