### PR TITLE
feat(agent): reverse-path peerStore enrichment on inbound circuit-relay open

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2268,37 +2268,48 @@ export class DKGAgent {
       });
 
       // Reverse-path peerStore enrichment for inbound circuit-relay
-      // connections. Closes the "Window D" class from the May 2026
-      // Miles↔Lex 6h soak postmortem: an inbound circuit connection
-      // from peer P via relay R was open and live, but every
+      // connections, then the symmetric chat-outbox flush.
+      //
+      // Closes the "Window D" class from the May 2026 Miles↔Lex 6h
+      // soak postmortem: an inbound circuit connection from peer P
+      // via relay R was open and live, but every
       // `dialProtocol(P, ...)` retry on our side failed with "no
-      // valid addresses for peer" because P's identify-push
-      // didn't replicate the reservation address into our peerStore.
-      // By echoing the inbound circuit's relay back as an outbound
-      // multiaddr for P (`<R>/p2p-circuit/p2p/<P>`), the next
-      // dialProtocol can find an address and try it. The merge runs
-      // BEFORE the outbox flush above completes (fire-and-forget on
-      // both), but the next retry tick — or the next opportunistic
-      // flush triggered by ANY subsequent inbound from P — picks up
-      // the freshly-merged address. We deliberately do not block the
-      // outbox flush on the merge to avoid coupling the latency of
-      // peerStore.merge (which can trigger CM auto-dial side effects,
-      // see docs/archive/UPSTREAM_ISSUE_DRAFT.md) into the chat
-      // delivery hot path.
-      this.enrichPeerStoreFromInboundCircuit(evt.detail).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        this.log.warn(ctx, `Reverse-path peerStore enrichment failed for ${remotePeer}: ${message}`);
-      });
-
-      // Symmetric flush for the chat outbox: any messages we tried to
-      // send to this peer while they were unreachable get a fresh
-      // delivery attempt now that the peer is back. Independent of
-      // the join-approval flush above (different queue, different
-      // payload shape), but same opportunistic-on-reconnect rationale.
-      this.processMessageOutboxOnConnect(remotePeer).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        this.log.warn(ctx, `Opportunistic message-outbox retry on connect failed for ${remotePeer}: ${message}`);
-      });
+      // valid addresses for peer" because P's identify-push didn't
+      // replicate the reservation address into our peerStore.
+      // Echoing the inbound circuit's relay back as an outbound
+      // multiaddr for P (`<R>/p2p-circuit/p2p/<P>`) lets the next
+      // dialProtocol find an address and try it.
+      //
+      // User review on PR #536 caught the original ordering bug:
+      // running enrichment and the outbox flush in parallel
+      // fire-and-forget meant the first flush attempt could
+      // still hit `dialProtocol` against an EMPTY peerStore and
+      // fail with the same "no valid addresses" error this PR is
+      // meant to heal — pushing recovery onto the next 30s tick
+      // or another reconnect. Sequence the two: await enrichment
+      // first, then flush. Both stay wrapped in their own
+      // try/catch so an enrichment failure logs a warning and
+      // still lets the outbox flush proceed (it might succeed
+      // anyway via a stale-but-usable cached path).
+      //
+      // The whole chain runs as a fire-and-forget IIFE so the
+      // listener itself doesn't await — libp2p's
+      // `connection:open` emitter is synchronous and we don't
+      // want to slow down other listeners.
+      void (async () => {
+        try {
+          await this.enrichPeerStoreFromInboundCircuit(evt.detail);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.log.warn(ctx, `Reverse-path peerStore enrichment failed for ${remotePeer}: ${message}`);
+        }
+        try {
+          await this.processMessageOutboxOnConnect(remotePeer);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.log.warn(ctx, `Opportunistic message-outbox retry on connect failed for ${remotePeer}: ${message}`);
+        }
+      })();
 
       const now = Date.now();
       const last = this.catchupOnConnectAt.get(remotePeer) ?? 0;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2267,6 +2267,29 @@ export class DKGAgent {
         this.log.warn(ctx, `Opportunistic join-approval retry on connect failed for ${remotePeer}: ${message}`);
       });
 
+      // Reverse-path peerStore enrichment for inbound circuit-relay
+      // connections. Closes the "Window D" class from the May 2026
+      // Miles↔Lex 6h soak postmortem: an inbound circuit connection
+      // from peer P via relay R was open and live, but every
+      // `dialProtocol(P, ...)` retry on our side failed with "no
+      // valid addresses for peer" because P's identify-push
+      // didn't replicate the reservation address into our peerStore.
+      // By echoing the inbound circuit's relay back as an outbound
+      // multiaddr for P (`<R>/p2p-circuit/p2p/<P>`), the next
+      // dialProtocol can find an address and try it. The merge runs
+      // BEFORE the outbox flush above completes (fire-and-forget on
+      // both), but the next retry tick — or the next opportunistic
+      // flush triggered by ANY subsequent inbound from P — picks up
+      // the freshly-merged address. We deliberately do not block the
+      // outbox flush on the merge to avoid coupling the latency of
+      // peerStore.merge (which can trigger CM auto-dial side effects,
+      // see docs/archive/UPSTREAM_ISSUE_DRAFT.md) into the chat
+      // delivery hot path.
+      this.enrichPeerStoreFromInboundCircuit(evt.detail).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        this.log.warn(ctx, `Reverse-path peerStore enrichment failed for ${remotePeer}: ${message}`);
+      });
+
       // Symmetric flush for the chat outbox: any messages we tried to
       // send to this peer while they were unreachable get a fresh
       // delivery attempt now that the peer is back. Independent of
@@ -9476,6 +9499,85 @@ export class DKGAgent {
         );
       }
     }
+  }
+
+  /**
+   * "Reverse-path peerStore enrichment" — when an inbound circuit-relay
+   * connection from peer P via relay R opens, echo the inbound circuit
+   * back as an outbound multiaddr for P (`<R>/p2p-circuit/p2p/<P>`)
+   * and merge it into the local peerStore.
+   *
+   * The Miles↔Lex May 2026 6h soak postmortem identified the "Window D"
+   * class: an inbound circuit connection from P was open and live, but
+   * every `libp2p.dialProtocol(P, ...)` retry on our side failed with
+   * "The dial request has no valid addresses for peer" for several
+   * minutes. Daemon logs showed 31 `connection:open` events from P
+   * (all inbound, all via R) + 20 opportunistic-flush attempts, all
+   * failing dialProtocol — and then the moment ONE outbound connection
+   * succeeded (which populated peerStore from outbound identify), the
+   * very next opportunistic-flush delivered the queued message.
+   *
+   * The clean fix would be inside libp2p (`dialProtocol` should reuse
+   * an existing open connection of any direction — see PR 5 in the
+   * postmortem follow-up plan), but until that lands, populating
+   * peerStore from the inbound circuit's address gives the dialer
+   * something to find on the very next attempt.
+   *
+   * Public so a unit test can exercise it directly without standing up
+   * a full libp2p network (the listener that calls it is registered
+   * inside the giant `start()` method and is not easily mockable
+   * end-to-end).
+   *
+   * Guarantees:
+   * - Direct connections are a no-op (nothing to enrich — the dialer
+   *   already has the address it used to open the connection).
+   * - Outbound connections are a no-op (peerStore was already
+   *   populated to make the dial; re-merging the same address is
+   *   harmless but pointless).
+   * - Throws are swallowed by the caller's `.catch()` — the
+   *   `connection:open` listener must never propagate exceptions.
+   * - Merging an address libp2p already knows about is a no-op
+   *   (`peerStore.merge` dedupes internally).
+   *
+   * Trade-off (referenced from `docs/archive/UPSTREAM_ISSUE_DRAFT.md`):
+   * `peerStore.merge` can wake the connection manager to dial direct,
+   * which has been observed to disrupt streams mid-negotiation. We're
+   * NOT in mid-negotiation here (the call runs from
+   * `connection:open`, not from inside `newStream`), and the address
+   * we're merging IS the same relay path that the inbound connection
+   * already uses — so the worst case is the CM redundantly dialing
+   * out through R, which is exactly what we want.
+   */
+  async enrichPeerStoreFromInboundCircuit(connection: {
+    direction: 'inbound' | 'outbound';
+    remoteAddr?: { toString(): string };
+    remotePeer: { toString(): string };
+  }): Promise<void> {
+    if (connection.direction !== 'inbound') return;
+    const remoteStr = connection.remoteAddr?.toString();
+    if (!remoteStr) return;
+    const circIdx = remoteStr.indexOf('/p2p-circuit');
+    if (circIdx < 0) return;
+
+    const remotePeer = connection.remotePeer.toString();
+    if (remotePeer === this.node.libp2p.peerId.toString()) return;
+
+    // Reverse-path multiaddr: take the relay prefix up to (but not
+    // including) the `/p2p-circuit` segment, append the canonical
+    // `/p2p-circuit/p2p/<P>` suffix. Works whether the inbound
+    // remoteAddr ends at `/p2p-circuit` (the typical listener-side
+    // shape) OR already includes a trailing `/p2p/<self>` (defensive
+    // — older libp2p versions and some test transports surface the
+    // explicit-destination shape). Slicing on the FIRST occurrence
+    // of `/p2p-circuit` is correct either way.
+    const relayPrefix = remoteStr.slice(0, circIdx);
+    const reverseAddrStr = `${relayPrefix}/p2p-circuit/p2p/${remotePeer}`;
+
+    const { peerIdFromString } = await import('@libp2p/peer-id');
+    const { multiaddr } = await import('@multiformats/multiaddr');
+    const pid = peerIdFromString(remotePeer);
+    const reverseAddr = multiaddr(reverseAddrStr);
+    await this.node.libp2p.peerStore.merge(pid, { multiaddrs: [reverseAddr] });
   }
 
   /**

--- a/packages/agent/test/dkg-agent-reverse-path.test.ts
+++ b/packages/agent/test/dkg-agent-reverse-path.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+// Peer IDs are real-shape v4 UUIDs in the canonical libp2p format
+// so `peerIdFromString` accepts them. These are NOT real keys —
+// they're the same fixtures the `p2p-messenger` suite uses.
+const SELF_PEER = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+const RELAY_PEER = '12D3KooWLb1bH9NfMSjJDmsZxufmw5UFD8wajVKnvD5HfL3VbqGq';
+const REMOTE_PEER = '12D3KooWGiQrwo1jXJsHaQK4kFYx3xVDp5tWHPEnpUUEUbygP4WL';
+
+// `enrichPeerStoreFromInboundCircuit` only needs `this.node.libp2p`
+// for the self-peer guard and the peerStore.merge call — build the
+// minimum that satisfies both so we don't pull the full DKGAgent
+// init path into the test.
+function makeAgent(): {
+  agent: DKGAgent;
+  mergeMock: ReturnType<typeof vi.fn>;
+} {
+  const mergeMock = vi.fn(async () => undefined);
+  const fakeLibp2p = {
+    peerId: { toString: () => SELF_PEER },
+    peerStore: { merge: mergeMock },
+  };
+  const fakeNode = { libp2p: fakeLibp2p };
+  const agent = Object.create(DKGAgent.prototype) as DKGAgent;
+  // `node` is private but the test reaches in directly via Object.assign
+  // — same pattern the `dkg-agent-diagnostics` suite (PR #533) uses.
+  Object.assign(agent, { node: fakeNode });
+  return { agent, mergeMock };
+}
+
+describe('DKGAgent.enrichPeerStoreFromInboundCircuit — reverse-path peerStore enrichment', () => {
+  let agent: DKGAgent;
+  let mergeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    ({ agent, mergeMock } = makeAgent());
+  });
+
+  // Headline behaviour: when an inbound circuit-relay connection
+  // opens, we echo the inbound circuit address back as an outbound
+  // multiaddr for the remote peer and merge it into peerStore. This
+  // is the May 2026 Window D fix: future `dialProtocol(remote, ...)`
+  // calls now have an address to try instead of returning "no valid
+  // addresses for peer".
+  it('merges the reverse-path multiaddr for an inbound circuit-relay connection', async () => {
+    const inboundAddr = `/ip4/1.2.3.4/tcp/4001/p2p/${RELAY_PEER}/p2p-circuit`;
+    await agent.enrichPeerStoreFromInboundCircuit({
+      direction: 'inbound',
+      remoteAddr: { toString: () => inboundAddr },
+      remotePeer: { toString: () => REMOTE_PEER },
+    });
+    expect(mergeMock).toHaveBeenCalledTimes(1);
+    const [calledPid, opts] = mergeMock.mock.calls[0];
+    expect(calledPid.toString()).toBe(REMOTE_PEER);
+    expect(opts.multiaddrs).toHaveLength(1);
+    expect(opts.multiaddrs[0].toString()).toBe(
+      `/ip4/1.2.3.4/tcp/4001/p2p/${RELAY_PEER}/p2p-circuit/p2p/${REMOTE_PEER}`,
+    );
+  });
+
+  // Defensive: some libp2p versions / transports surface the
+  // inbound circuit remoteAddr WITH the trailing `/p2p/<self>`
+  // segment (explicit-destination shape). The reverse-path build
+  // must slice on the FIRST `/p2p-circuit` and rebuild from the
+  // relay prefix, NOT just append — otherwise we'd produce a
+  // double-circuit multiaddr like
+  //   `/<R>/p2p-circuit/p2p/<self>/p2p/<remote>`
+  // which is uninterpretable and would poison the peerStore.
+  it('handles inbound circuit remoteAddr that already includes /p2p/<self>', async () => {
+    const inboundAddr = `/ip4/1.2.3.4/tcp/4001/p2p/${RELAY_PEER}/p2p-circuit/p2p/${SELF_PEER}`;
+    await agent.enrichPeerStoreFromInboundCircuit({
+      direction: 'inbound',
+      remoteAddr: { toString: () => inboundAddr },
+      remotePeer: { toString: () => REMOTE_PEER },
+    });
+    expect(mergeMock).toHaveBeenCalledTimes(1);
+    const [, opts] = mergeMock.mock.calls[0];
+    expect(opts.multiaddrs[0].toString()).toBe(
+      `/ip4/1.2.3.4/tcp/4001/p2p/${RELAY_PEER}/p2p-circuit/p2p/${REMOTE_PEER}`,
+    );
+  });
+
+  // Outbound connections — peerStore was ALREADY populated to make
+  // the dial happen, so re-merging the same address is pointless.
+  // More importantly: if we DID merge on outbound, we'd race the
+  // libp2p stream-negotiation issue documented at
+  // docs/archive/UPSTREAM_ISSUE_DRAFT.md (peerStore.merge during a
+  // newStream call closes the connection mid-negotiation). Outbound
+  // is the case where that race matters most.
+  it('is a no-op for outbound connections (regardless of circuit-ness)', async () => {
+    const outboundAddr = `/ip4/1.2.3.4/tcp/4001/p2p/${RELAY_PEER}/p2p-circuit`;
+    await agent.enrichPeerStoreFromInboundCircuit({
+      direction: 'outbound',
+      remoteAddr: { toString: () => outboundAddr },
+      remotePeer: { toString: () => REMOTE_PEER },
+    });
+    expect(mergeMock).not.toHaveBeenCalled();
+  });
+
+  // Direct (non-circuit) inbound connections have nothing to enrich
+  // — the dialer side already had the address it used to connect,
+  // and our outbound dialer will get that same address via the
+  // normal identify exchange. Re-merging would be redundant and
+  // could pollute peerStore with addresses that don't make sense as
+  // outbound dial targets (e.g. inbound TCP from a private IP).
+  it('is a no-op for direct (non-circuit) inbound connections', async () => {
+    const directAddr = `/ip4/192.168.1.10/tcp/45678/p2p/${REMOTE_PEER}`;
+    await agent.enrichPeerStoreFromInboundCircuit({
+      direction: 'inbound',
+      remoteAddr: { toString: () => directAddr },
+      remotePeer: { toString: () => REMOTE_PEER },
+    });
+    expect(mergeMock).not.toHaveBeenCalled();
+  });
+
+  // The libp2p loopback case — a node briefly self-dials during
+  // bootstrap (mostly in tests, but also in some relay configs).
+  // Merging our own peerId into our own peerStore is meaningless
+  // and the guard is the same one the surrounding listener
+  // (`connection:open`) already applies for the outbox flush.
+  // Defensive coverage so a refactor of the listener can't strip
+  // the guard from this code path independently.
+  it('is a no-op when the remote peer is self (loopback bootstrap)', async () => {
+    const inboundAddr = `/ip4/1.2.3.4/tcp/4001/p2p/${RELAY_PEER}/p2p-circuit`;
+    await agent.enrichPeerStoreFromInboundCircuit({
+      direction: 'inbound',
+      remoteAddr: { toString: () => inboundAddr },
+      remotePeer: { toString: () => SELF_PEER },
+    });
+    expect(mergeMock).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when remoteAddr is missing or empty', async () => {
+    await agent.enrichPeerStoreFromInboundCircuit({
+      direction: 'inbound',
+      remoteAddr: undefined,
+      remotePeer: { toString: () => REMOTE_PEER },
+    });
+    await agent.enrichPeerStoreFromInboundCircuit({
+      direction: 'inbound',
+      remoteAddr: { toString: () => '' },
+      remotePeer: { toString: () => REMOTE_PEER },
+    });
+    expect(mergeMock).not.toHaveBeenCalled();
+  });
+
+  // Defensive: a peerStore.merge that throws (e.g. shutdown race,
+  // libp2p internal shape mismatch) must propagate so the caller's
+  // `.catch()` in the `connection:open` listener logs and moves on.
+  // The connection:open listener wrapping the call already gates
+  // against throws crossing the libp2p event boundary; here we only
+  // assert the helper itself does NOT silently swallow.
+  it('propagates peerStore.merge errors to the caller (listener does the swallow)', async () => {
+    const failingAgent = makeAgent();
+    failingAgent.mergeMock.mockRejectedValueOnce(new Error('peerStore is down'));
+    const inboundAddr = `/ip4/1.2.3.4/tcp/4001/p2p/${RELAY_PEER}/p2p-circuit`;
+    await expect(
+      failingAgent.agent.enrichPeerStoreFromInboundCircuit({
+        direction: 'inbound',
+        remoteAddr: { toString: () => inboundAddr },
+        remotePeer: { toString: () => REMOTE_PEER },
+      }),
+    ).rejects.toThrow('peerStore is down');
+  });
+});

--- a/packages/agent/test/p2p-resilience.test.ts
+++ b/packages/agent/test/p2p-resilience.test.ts
@@ -302,5 +302,71 @@ describe('p2p resilience hooks', () => {
         await agent.stop().catch(() => {});
       }
     }, 15_000);
+
+    // User review on PR #536: the `connection:open` listener used to
+    // call `enrichPeerStoreFromInboundCircuit` and
+    // `processMessageOutboxOnConnect` in parallel fire-and-forget,
+    // which meant the first outbox flush attempt could still hit
+    // `dialProtocol` against an EMPTY peerStore — exact same "no
+    // valid addresses for peer" failure the PR is meant to heal.
+    // Fix wraps both in a sequential IIFE so the flush sees the
+    // freshly-merged reverse-path address. Pin the ordering.
+    it('awaits enrichment BEFORE the outbox flush on inbound circuit open (PR #536 review)', async () => {
+      const agent = await DKGAgent.create({
+        name: 'ReversePathEnrichBeforeFlush',
+        listenHost: '127.0.0.1',
+        chainAdapter: new MockChainAdapter(),
+      });
+      try {
+        await agent.start();
+
+        const events: string[] = [];
+        let enrichResolve: (() => void) | null = null;
+        const enrichDone = new Promise<void>((r) => { enrichResolve = r; });
+
+        // Slow enrichment by 80ms so flush ordering is observable even if
+        // microtask queue races sneak in. We push markers in BOTH methods
+        // and the assertion is purely temporal — enrich-finish must precede
+        // flush-start, no overlapping window.
+        (agent as any).enrichPeerStoreFromInboundCircuit = async () => {
+          events.push('enrich:start');
+          await new Promise(r => setTimeout(r, 80));
+          events.push('enrich:end');
+          enrichResolve?.();
+        };
+        (agent as any).processMessageOutboxOnConnect = async () => {
+          events.push('flush:start');
+        };
+
+        const remotePeer = freshPeerIdString();
+        const relayPeer = freshPeerIdString();
+        agent.node.libp2p.dispatchEvent(new CustomEvent('connection:open', {
+          detail: {
+            remotePeer: { toString: () => remotePeer },
+            remoteAddr: {
+              toString: () =>
+                `/ip4/1.2.3.4/tcp/4001/p2p/${relayPeer}/p2p-circuit`,
+            },
+            direction: 'inbound',
+            timeline: { open: Date.now() },
+          },
+        } as any));
+
+        await enrichDone;
+        // Give the IIFE one more tick to schedule the flush.
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(events).toContain('enrich:start');
+        expect(events).toContain('enrich:end');
+        expect(events).toContain('flush:start');
+        // The critical ordering: enrich:end MUST appear before flush:start.
+        // If the listener went back to parallel fire-and-forget, enrich:end
+        // would appear AFTER flush:start (since flush is synchronous and
+        // enrich sleeps 80ms).
+        expect(events.indexOf('enrich:end')).toBeLessThan(events.indexOf('flush:start'));
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    }, 15_000);
   });
 });


### PR DESCRIPTION
## Summary

Addresses the **"Window D" failure class** from the May 2026 Miles↔Lex 6h soak postmortem: an inbound circuit-relay connection from peer P via relay R was open and live, but every `libp2p.dialProtocol(P, ...)` retry on our side failed with **"no valid addresses for peer"** for several minutes. Daemon logs showed 31 inbound `connection:open` events from P + 20 opportunistic-flush attempts, all failing on the dialer. The moment ONE outbound connection happened to succeed (populating peerStore from outbound identify), the very next opportunistic-flush delivered the queued message — confirming the root cause was an empty peerStore, not a stuck transport.

### The fix

Adds `DKGAgent.enrichPeerStoreFromInboundCircuit(connection)` which fires from the `connection:open` listener and, for inbound circuit-relay connections, echoes the inbound circuit address back as an outbound multiaddr for the remote peer:

```
inbound : /<R>/p2p-circuit                  (from R to us)
enrich  : /<R>/p2p-circuit/p2p/<P>          (from us to P, via R)
```

The next `dialProtocol` attempt now has an address to try instead of returning empty-peerstore.

### Defensive scope (all no-ops)

- Direct (non-circuit) inbound connections — the dialer side already has the address it used to connect; outbound identify populates peerStore via the normal path.
- Outbound connections — peerStore was already populated to make the dial happen, and avoiding `peerStore.merge` on outbound sidesteps the known mid-stream-negotiation race documented at `docs/archive/UPSTREAM_ISSUE_DRAFT.md`.
- Self-loopback peer ID.
- Missing/empty remoteAddr.
- Already-known address (`peerStore.merge` dedupes internally).
- RemoteAddr containing trailing `/p2p/<self>` (explicit-destination shape on some libp2p versions): correctly slices on the FIRST `/p2p-circuit` so we don't produce a double-circuit multiaddr.

The merge runs fire-and-forget from the listener (caller catches and logs) — same pattern as the existing join-approval and message-outbox opportunistic flushes that share the listener.

### Why this is a workaround, not the proper fix

This is sender-side compensation for what is ultimately a libp2p behaviour gap. The proper fix lives one layer deeper: `dialProtocol` should reuse an existing open connection of any direction instead of requiring peerStore lookup to succeed (that's **PR 5** in the soak postmortem follow-up plan). Until that lands, populating peerStore from the inbound circuit covers the same observable symptom.

### Postmortem PR series context

This is **PR 4 of 5** from the Miles↔Lex soak follow-up:
1. ~~MCP queued-response propagation~~ — operational (stale MCP process), no code change.
2. Peer diagnostics surface (`getPeerDiagnostics` / `/api/peer-info` / `dkg_peer_info`) — shipped as #533.
3. Receiver-side dedup by `messageId` (V11 schema migration) — shipped as #534.
4. **This PR** — reverse-path peerStore enrichment on inbound circuit-relay.
5. `dialProtocol` reuses inbound circuit connection (root fix; this PR is a defensive complement).

## Test plan

Added 7 unit tests in `packages/agent/test/dkg-agent-reverse-path.test.ts`:

- [x] Happy path: inbound circuit + correct reverse-path multiaddr merged.
- [x] Defensive: inbound circuit remoteAddr with trailing `/p2p/<self>` builds the correct reverse-path (no double-circuit).
- [x] No-op for outbound connections (regardless of circuit-ness).
- [x] No-op for direct (non-circuit) inbound connections.
- [x] No-op for self-loopback peer ID.
- [x] No-op for missing/empty remoteAddr.
- [x] `peerStore.merge` errors propagate to the caller (listener does the `.catch()` swallow, not the helper itself).

Existing agent suites I re-ran on this branch:
- [x] `messaging-chat-acl.test.ts`: 9/9
- [x] `message-outbox.test.ts`: 22/22
- [x] `agent.test.ts`: 115/115

Pre-existing failure on main (unrelated to chat/networking): `packages/agent/test/swm-snapshot-sync.test.ts`.

## Validation plan after merge

Re-run the 6h Miles↔Lex soak from the May 2026 postmortem with PRs #533 + #534 + this one + PR 5 all landed, and verify:
- `inbox.jsonl` no longer shows the seq=13 duplicate class (PR #534 already addresses this).
- `main.log` shows the daemon merging reverse-path addresses for each new inbound circuit (this PR — confirms the enrichment is running).
- The Window D failure mode (long-tail outbound failures while inbound from the same peer is open) is gone.

Made with [Cursor](https://cursor.com)