### PR TITLE
fix(outbox): defend retryOutboxEntry against stale-snapshot race

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -9495,6 +9495,26 @@ export class DKGAgent {
       return;
     }
     try {
+      // Defend against the stale-snapshot race surfaced by the 2026-05
+      // rc9 soak: `processMessageOutboxOnConnect` iterates a snapshot
+      // of `pendingFor(peer)`; during the iteration a concurrent flush
+      // (triggered by a sibling `connection:open` in a reconnect storm)
+      // may have already completed delivery for THIS entry and called
+      // `markDelivered`. The `tryBeginAttempt` guard above only blocks
+      // TRULY-PARALLEL races (the prior flush is still mid-send) — once
+      // the prior flush completes and releases the inflight slot, this
+      // stale-snapshot caller would otherwise fire a duplicate wire
+      // send and, if it fails, `enqueueFailure` resurrects the deleted
+      // entry with `attempts=1`, triggering the full retry storm
+      // again. Re-checking presence inside the inflight guard
+      // (single-threaded, no yield between the check and the send)
+      // makes the no-op exit atomic. Smoking gun: 29 queues -> 63
+      // succeeded events in the soak, attempts counters resetting
+      // to 1 after `markDelivered` had run.
+      if (!this.messageOutbox.hasEntry(entry.recipientPeerId, entry.messageId)) {
+        return;
+      }
+
       // Forward the outbox entry's `messageId` into the wire-format
       // payload so the receiver's `idx_chat_msgid` partial unique
       // index recognises the retry as the same logical message as

--- a/packages/agent/src/message-outbox.ts
+++ b/packages/agent/src/message-outbox.ts
@@ -223,6 +223,31 @@ export class MessageOutbox {
   }
 
   /**
+   * Return `true` if an entry for this `(recipient, messageId)` pair
+   * is still in the queue (i.e. not yet delivered or expired). Used
+   * by `DKGAgent.retryOutboxEntry` to defend against the
+   * stale-snapshot race: `processMessageOutboxOnConnect` takes a
+   * snapshot of `pendingFor(peer)` and iterates it; during the iteration
+   * another concurrent `processMessageOutboxOnConnect` call (triggered
+   * by a sibling `connection:open` event in a reconnect storm) may
+   * have already completed delivery for some entry E and called
+   * `markDelivered(E)`. Without re-checking presence between
+   * `tryBeginAttempt` and `sendChat`, the stale-snapshot caller fires
+   * a duplicate wire send for E.
+   *
+   * Discovered in the 2026-05 rc9 soak: 29 outbox queues produced 63
+   * `Outbox redelivery succeeded` events (2.17x amplification),
+   * because `enqueueFailure` on the duplicate-send failure path
+   * resurrects the deleted entry with `attempts=1`, triggering the
+   * full retry storm again. `tryBeginAttempt` alone is insufficient
+   * — it only blocks TRULY-PARALLEL races, not
+   * stale-snapshot-after-completion.
+   */
+  hasEntry(recipientPeerId: string, messageId: string): boolean {
+    return this.queue.getEntry(chatOutboxKey(recipientPeerId, messageId)) !== undefined;
+  }
+
+  /**
    * Return all entries whose `nextAttemptAt` is at or before `now`.
    * Used by the periodic tick to find what to retry. Result is in
    * insertion order; callers that need per-recipient ordering should

--- a/packages/agent/test/message-outbox.test.ts
+++ b/packages/agent/test/message-outbox.test.ts
@@ -212,6 +212,59 @@ describe('MessageOutbox', () => {
     });
   });
 
+  // 🔴 Regression for the stale-snapshot race surfaced by the 2026-05
+  // rc9 soak. tryBeginAttempt only blocks TRULY-PARALLEL races (both
+  // attempters in flight simultaneously); once flush A completes,
+  // markDelivered+endAttempt, a stale-snapshot flush B from a sibling
+  // `connection:open` event sees no inflight slot and would resend the
+  // already-delivered entry. hasEntry is the atomic existence check
+  // that paired with the inflight guard makes the no-op exit safe.
+  // Smoking gun: 29 outbox queues → 63 daemon "succeeded" events.
+  describe('hasEntry stale-snapshot guard (PR 6 race fix)', () => {
+    it('returns true for an entry that has been enqueued', () => {
+      const outbox = new MessageOutbox();
+      outbox.enqueueFailure(makePayload(), 'fail', 1000);
+      expect(outbox.hasEntry(PEER_A, 'msg-1')).toBe(true);
+    });
+
+    it('returns false for an entry that was never enqueued', () => {
+      const outbox = new MessageOutbox();
+      expect(outbox.hasEntry(PEER_A, 'msg-never')).toBe(false);
+    });
+
+    it('returns false after markDelivered removes the entry — the stale-snapshot race signal', () => {
+      const outbox = new MessageOutbox();
+      outbox.enqueueFailure(makePayload(), 'fail', 1000);
+      expect(outbox.hasEntry(PEER_A, 'msg-1')).toBe(true);
+      outbox.markDelivered(PEER_A, 'msg-1');
+      // This is the exact check the retryOutboxEntry guard relies on:
+      // after a sibling flush delivered + dropped the entry, a
+      // stale-snapshot caller must see false here and exit before
+      // resending.
+      expect(outbox.hasEntry(PEER_A, 'msg-1')).toBe(false);
+    });
+
+    it('returns false after dropExpired removes the entry', () => {
+      const outbox = new MessageOutbox({ backoffs: [1], maxAgeMs: 100 });
+      outbox.enqueueFailure(makePayload(), 'fail', 1000);
+      expect(outbox.hasEntry(PEER_A, 'msg-1')).toBe(true);
+      outbox.dropExpired(1000 + 200); // 200ms > maxAgeMs (100ms)
+      expect(outbox.hasEntry(PEER_A, 'msg-1')).toBe(false);
+    });
+
+    it('is independent across recipients and messageIds — same key namespace as the rest of the queue', () => {
+      const outbox = new MessageOutbox();
+      outbox.enqueueFailure(makePayload({ recipientPeerId: PEER_A, messageId: 'm1' }), 'fail', 1000);
+      outbox.enqueueFailure(makePayload({ recipientPeerId: PEER_B, messageId: 'm2' }), 'fail', 1100);
+      expect(outbox.hasEntry(PEER_A, 'm1')).toBe(true);
+      expect(outbox.hasEntry(PEER_B, 'm2')).toBe(true);
+      // wrong recipient + right messageId
+      expect(outbox.hasEntry(PEER_B, 'm1')).toBe(false);
+      // right recipient + wrong messageId
+      expect(outbox.hasEntry(PEER_A, 'm2')).toBe(false);
+    });
+  });
+
   describe('defaults', () => {
     it('uses chat-tighter backoff ladder when not overridden', () => {
       expect(DEFAULT_CHAT_OUTBOX_BACKOFFS_MS).toEqual([

--- a/packages/agent/test/p2p-resilience.test.ts
+++ b/packages/agent/test/p2p-resilience.test.ts
@@ -368,5 +368,84 @@ describe('p2p resilience hooks', () => {
         await agent.stop().catch(() => {});
       }
     }, 15_000);
+
+    // 🔴 Regression for the stale-snapshot race surfaced by the 2026-05
+    // rc9 soak: `processMessageOutboxOnConnect` takes a snapshot of
+    // `pendingFor(peer)` and iterates it. If two `connection:open`
+    // events fire in rapid succession (relay reconnect storm), Flush A
+    // completes (`markDelivered` deletes the entry, `endAttempt` clears
+    // the inflight slot), then Flush B — holding the now-stale entry
+    // reference from its own pre-A snapshot — calls
+    // `retryOutboxEntry(staleEntry)`. The `tryBeginAttempt` guard
+    // returns true (Flush A already released the slot), and without
+    // the `hasEntry` re-check below it, Flush B fires a duplicate
+    // `sendChat` for an already-delivered message. Worst case the
+    // duplicate `sendChat` fails ("Remote closed connection during
+    // opening") and `enqueueFailure` resurrects the deleted entry
+    // with attempts=1, triggering the full retry storm again. Soak
+    // smoking gun: 29 outbox queues produced 63 daemon "succeeded"
+    // events (2.17x amplification).
+    it('does not re-send an entry that a sibling flush already markDelivered (stale-snapshot guard, PR 6)', async () => {
+      const agent = await DKGAgent.create({
+        name: 'StaleSnapshotGuard',
+        listenHost: '127.0.0.1',
+        chainAdapter: new MockChainAdapter(),
+      });
+      try {
+        await agent.start();
+
+        const peer = freshPeerIdString();
+        const messageId = 'soak-rc9-stale-snapshot-msg-1';
+
+        // Pre-populate the outbox with one failed entry so
+        // retryOutboxEntry has something to drain.
+        (agent as any).messageOutbox.enqueueFailure(
+          { recipientPeerId: peer, text: 'hi', messageId },
+          'initial transport failure',
+          Date.now(),
+        );
+        const staleEntry = (agent as any).messageOutbox.pendingFor(peer)[0];
+        expect(staleEntry).toBeTruthy();
+
+        // Capture every sendChat invocation. A correctly-guarded
+        // retryOutboxEntry must call sendChat EXACTLY ONCE across both
+        // flushes — the second flush's stale-snapshot entry should be
+        // dropped by the hasEntry guard before any wire I/O.
+        const sendChatCalls: Array<{ peer: string; messageId: string }> = [];
+        (agent as any).messageHandler = {
+          sendChat: vi.fn(async (peerId: string, _text: string, opts: any) => {
+            sendChatCalls.push({ peer: peerId, messageId: opts?.messageId });
+            return { delivered: true, messageId: opts?.messageId };
+          }),
+        };
+
+        // Flush A: drains the entry cleanly (sendChat returns
+        // delivered, markDelivered fires, entry removed, endAttempt
+        // clears inflight). Same entry reference is reused by Flush B
+        // below — modelling exactly what the sibling-snapshot
+        // iteration does in production.
+        await (agent as any).retryOutboxEntry(staleEntry);
+
+        // Verify Flush A succeeded and the entry is gone.
+        expect((agent as any).messageOutbox.hasEntry(peer, messageId)).toBe(false);
+        expect(sendChatCalls.length).toBe(1);
+
+        // Flush B: stale-snapshot iteration on the same entry. Without
+        // the hasEntry guard added in PR 6, this would call sendChat a
+        // second time (the inflight slot was already released by A).
+        await (agent as any).retryOutboxEntry(staleEntry);
+
+        // The whole regression is captured here: sendChat must NOT
+        // have been called twice.
+        expect(sendChatCalls.length).toBe(1);
+        expect(sendChatCalls[0].messageId).toBe(messageId);
+
+        // Entry must still be gone — Flush B must not have resurrected
+        // it via the enqueueFailure path either.
+        expect((agent as any).messageOutbox.hasEntry(peer, messageId)).toBe(false);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    }, 15_000);
   });
 });

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -142,8 +142,26 @@ export class ProtocolRouter {
     // to dial the peer directly, closing the relay and any in-flight streams).
     // We retry up to 3 times with back-off so the direct connection can
     // stabilise before the next attempt.
+    //
+    // Per-call exclude-set for the fast path: when an existing-connection
+    // reuse hits a recoverable failure (stream came back live but
+    // `send`/`close`/`readAll` blew up — the half-dead-connection case
+    // Codex flagged in PR #538), we mark that connection as "tried this
+    // round" so the next retry attempt picks a different live candidate
+    // or falls through to `dialProtocol`. libp2p's connection table
+    // doesn't always prune a torn-down connection between our 500 ms
+    // backoff and the next attempt, so without this guard the loop
+    // could spend all three retries on the same dead connection without
+    // ever exercising the resolver + dialProtocol path that exists
+    // specifically to recover from this case.
+    const triedConnections = new WeakSet<ReusableConnection>();
     let lastErr: unknown;
     for (let attempt = 0; attempt < 3; attempt++) {
+      // Track which connection (if any) the fast path picked this
+      // attempt so the catch block can blacklist it on failure
+      // without needing to inspect stream/connection internals from
+      // the error.
+      let pickedConnection: ReusableConnection | null = null;
       try {
         // RFC 07 §3.2: re-prime the libp2p peerStore on EVERY attempt.
         //
@@ -220,7 +238,7 @@ export class ProtocolRouter {
         // connection table per send — N is the total open-conn
         // count of the node, typically <100, so the cost is a few
         // microseconds and the correctness win is large.
-        const fastStream = await tryReuseExistingConnection(
+        const fastResult = await tryReuseExistingConnection(
           () => {
             try {
               const all = libp2p.getConnections() as ReadonlyArray<
@@ -258,8 +276,11 @@ export class ProtocolRouter {
               }
               return false;
             },
+            excludeConnections: triedConnections,
           },
         );
+        const fastStream = fastResult?.stream ?? null;
+        pickedConnection = fastResult?.connection ?? null;
 
         if (this.peerResolver && !fastStream) {
           const remaining = Math.max(0, timeoutMs - (Date.now() - startedAt));
@@ -297,6 +318,19 @@ export class ProtocolRouter {
         return response;
       } catch (err: unknown) {
         lastErr = err;
+        // If this attempt opened the stream via the fast path, mark
+        // the underlying connection as tried-and-failed so subsequent
+        // attempts don't pick it again. The half-dead-connection case
+        // (newStream succeeds, send/readAll blows up because the
+        // transport is gone) leaves the connection in libp2p's table
+        // for some non-zero time before libp2p's own teardown removes
+        // it — without this we'd re-pick the same dead connection on
+        // the next attempt and exhaust the retry budget without ever
+        // reaching dialProtocol. Codex review of PR #538 / PR #537
+        // fast path.
+        if (pickedConnection) {
+          triedConnections.add(pickedConnection);
+        }
         if (!isRecoverableSendError(err) || attempt >= 2) throw err;
         const backoff = (attempt + 1) * 500;
         await new Promise(r => setTimeout(r, backoff));
@@ -365,6 +399,33 @@ interface ReusableConnection {
  */
 interface TryReuseExistingConnectionOptions {
   peerHasDirectAddrs: () => Promise<boolean>;
+  /**
+   * Connections to skip when iterating candidates.
+   *
+   * Lives across multiple `tryReuseExistingConnection` calls within
+   * the same logical `send()` so a connection that already failed a
+   * stream this round isn't picked again on the next retry attempt.
+   * libp2p's connection table doesn't always prune a torn-down
+   * connection between our recoverable-failure backoff and the next
+   * fast-path retry — without this guard, all three retries of a
+   * send can be consumed on the same dead connection, never giving
+   * the resolver + dialProtocol path a chance to recover.
+   *
+   * Codex review feedback on PR #538: `fastStream` previously
+   * latched a half-dead connection for the whole retry budget.
+   */
+  excludeConnections?: WeakSet<ReusableConnection>;
+}
+
+/**
+ * Result of a successful fast-path pick: the freshly-opened stream
+ * plus the connection it was opened on. The caller blacklists
+ * `connection` via `excludeConnections` on failure so the next
+ * retry skips it.
+ */
+export interface TryReuseExistingConnectionResult {
+  stream: Stream;
+  connection: ReusableConnection;
 }
 
 // Minimal shape we depend on from libp2p — the real `Libp2p` type
@@ -378,13 +439,14 @@ export async function tryReuseExistingConnection(
   protocolId: string,
   signal: AbortSignal,
   options: TryReuseExistingConnectionOptions,
-): Promise<Stream | null> {
+): Promise<TryReuseExistingConnectionResult | null> {
   let candidates: ReadonlyArray<ReusableConnection> = [];
   try {
     candidates = getConnections();
   } catch {
     return null;
   }
+  const exclude = options.excludeConnections;
 
   // Lazy + memoized peerStore-direct-addrs probe.
   //
@@ -432,6 +494,7 @@ export async function tryReuseExistingConnection(
 
   for (const conn of candidates) {
     if (conn.status && conn.status !== 'open') continue;
+    if (exclude?.has(conn)) continue;
     if ((conn as unknown as { limits?: unknown }).limits) {
       if (await peerStoreHasDirectAddrs()) {
         continue;
@@ -467,7 +530,7 @@ export async function tryReuseExistingConnection(
         }
         continue;
       }
-      return s;
+      return { stream: s, connection: conn };
     } catch {
       // Try the next candidate connection (if any), then fall
       // through to dialProtocol on overall miss. Swallowing here is

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -645,4 +645,258 @@ describe('ProtocolRouter', () => {
       expect(dialCalls).toBe(0);
     });
   });
+
+  // Codex review of PR #538: the fast path previously latched a
+  // half-dead connection for the whole 3-attempt retry budget. If
+  // `newStream()` opened a stream on a stale connection and the
+  // subsequent `send`/`readAll` blew up with a recoverable error,
+  // the retry loop would just pick the same dead connection on the
+  // next attempt (libp2p doesn't always prune a torn-down connection
+  // before our 500 ms backoff fires). The fix is a per-`send()`
+  // exclude-set: once a connection produces a failure, it's
+  // blacklisted for the remaining attempts and the loop either
+  // picks a different live candidate or falls through to
+  // `dialProtocol`.
+  describe('fast path connection-blacklist on stream failure (PR #538 Codex feedback)', () => {
+    const FAKE_PEER_ID = '12D3KooWBzj7Hg2cKCdsKL6QcjC5UbLztKTvzCZQHaT4P4ZyJEAA';
+
+    // Stream that succeeds on send/close but throws a recoverable
+    // error during readAll — the stale-half-dead-connection shape
+    // the reviewer flagged.
+    function makeDeadReadStream() {
+      return {
+        writeStatus: 'open' as const,
+        send: () => undefined,
+        close: async () => undefined,
+        abort: () => undefined,
+        async *[Symbol.asyncIterator]() {
+          throw new Error('stream returned in closed state');
+        },
+      };
+    }
+
+    function makeWorkingStream(response: Uint8Array) {
+      let returned = false;
+      return {
+        writeStatus: 'open' as const,
+        send: () => undefined,
+        close: async () => undefined,
+        abort: () => undefined,
+        async *[Symbol.asyncIterator]() {
+          if (!returned) {
+            returned = true;
+            yield response;
+          }
+        },
+      };
+    }
+
+    function makeConn(opts: {
+      onNewStream: () => Promise<unknown>;
+      label: string;
+    }) {
+      return {
+        status: 'open' as const,
+        label: opts.label,
+        remotePeer: {
+          equals: (other: unknown) => String(other) === FAKE_PEER_ID,
+          toString: () => FAKE_PEER_ID,
+        },
+        newStream: opts.onNewStream,
+      };
+    }
+
+    it('skips a connection that failed on a prior attempt and picks the next live one', async () => {
+      // Two live connections to the same peer. The first one's
+      // newStream returns a stream that blows up on readAll
+      // (recoverable). The second is healthy. Without the
+      // blacklist, the retry loop would re-pick the first
+      // connection — libp2p's `getConnections()` returns the same
+      // list across the 500ms backoff. With the blacklist, attempt
+      // 2 picks the second connection and the send succeeds.
+      let connADials = 0;
+      let connBDials = 0;
+      let dialProtocolCalls = 0;
+      const connA = makeConn({
+        label: 'A-stale',
+        onNewStream: async () => {
+          connADials += 1;
+          return makeDeadReadStream() as any;
+        },
+      });
+      const connB = makeConn({
+        label: 'B-healthy',
+        onNewStream: async () => {
+          connBDials += 1;
+          return makeWorkingStream(new Uint8Array([0x42])) as any;
+        },
+      });
+      const node = {
+        libp2p: {
+          getConnections: () => [connA, connB],
+          dialProtocol: async () => {
+            dialProtocolCalls += 1;
+            throw new Error('dialProtocol should not be reached — second connection is healthy');
+          },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      const router = new ProtocolRouter(node, { peerResolver });
+
+      const out = await router.send(FAKE_PEER_ID, '/dkg/test/1.0.0', new Uint8Array([1]));
+      expect(out).toEqual(new Uint8Array([0x42]));
+      expect(connADials).toBe(1);
+      expect(connBDials).toBe(1);
+      expect(dialProtocolCalls).toBe(0);
+    });
+
+    it('falls through to dialProtocol after the only candidate connection is blacklisted', async () => {
+      // Single bad connection. After attempt 1 blacklists it, the
+      // fast path has no remaining candidates → returns null →
+      // dialProtocol runs on attempts 2 (and 3 if needed). This is
+      // the exact recovery the reviewer was looking for: an
+      // unconditional fallback would risk re-triggering the
+      // upgrade race the fast path was built to avoid, but
+      // blacklisting + relying on the existing `null →
+      // dialProtocol` fallback inside the same retry loop is safe.
+      let newStreamCalls = 0;
+      let dialProtocolCalls = 0;
+      const badConn = makeConn({
+        label: 'only-bad',
+        onNewStream: async () => {
+          newStreamCalls += 1;
+          return makeDeadReadStream() as any;
+        },
+      });
+      const node = {
+        libp2p: {
+          getConnections: () => [badConn],
+          dialProtocol: async () => {
+            dialProtocolCalls += 1;
+            return makeWorkingStream(new Uint8Array([0x77])) as any;
+          },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      const router = new ProtocolRouter(node, { peerResolver });
+
+      const out = await router.send(FAKE_PEER_ID, '/dkg/test/1.0.0', new Uint8Array([1]));
+      expect(out).toEqual(new Uint8Array([0x77]));
+      // Bad connection was tried exactly once before being
+      // blacklisted — the retry budget is spent on dialProtocol,
+      // not on hammering the same dead connection.
+      expect(newStreamCalls).toBe(1);
+      expect(dialProtocolCalls).toBe(1);
+    });
+
+    it('does not blacklist a connection used by a successful send (no false-positive eviction)', async () => {
+      // Sanity test: the blacklist only kicks in on failure. A
+      // successful send must not poison the connection for future
+      // sends. Because `triedConnections` is per-`send()` it's
+      // technically impossible for a successful send to leak its
+      // entries — but if a future refactor moved the WeakSet up
+      // to the router instance, this test would catch it.
+      let aDials = 0;
+      const goodConn = makeConn({
+        label: 'good',
+        onNewStream: async () => {
+          aDials += 1;
+          return makeWorkingStream(new Uint8Array([0x55])) as any;
+        },
+      });
+      const node = {
+        libp2p: {
+          getConnections: () => [goodConn],
+          dialProtocol: async () => { throw new Error('unused'); },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      const router = new ProtocolRouter(node, { peerResolver });
+
+      await router.send(FAKE_PEER_ID, '/dkg/test/1.0.0', new Uint8Array([1]));
+      await router.send(FAKE_PEER_ID, '/dkg/test/1.0.0', new Uint8Array([2]));
+      await router.send(FAKE_PEER_ID, '/dkg/test/1.0.0', new Uint8Array([3]));
+
+      // 3 successful sends → 3 newStream calls on the same conn.
+      // If a refactor accidentally promoted the blacklist to the
+      // router scope, sends 2+ would skip this conn and fall
+      // through to dialProtocol (which throws here).
+      expect(aDials).toBe(3);
+    });
+  });
+
+  // Direct unit tests on `tryReuseExistingConnection`'s
+  // `excludeConnections` wiring — independent of `ProtocolRouter.send`
+  // so a future refactor that changes how `send()` plumbs the
+  // blacklist still exercises the candidate-skip logic itself.
+  describe('tryReuseExistingConnection: excludeConnections wiring', () => {
+    it('skips connections present in the exclude WeakSet', async () => {
+      const { tryReuseExistingConnection } = await import('../src/protocol-router.js');
+      const callOrder: string[] = [];
+      const conns = [
+        { status: 'open', label: 'A', newStream: async () => { callOrder.push('A'); throw new Error('boom'); } },
+        { status: 'open', label: 'B', newStream: async () => {
+          callOrder.push('B');
+          return { writeStatus: 'open' } as any;
+        } },
+      ] as any[];
+      const exclude = new WeakSet<object>();
+      exclude.add(conns[0]);
+
+      const result = await tryReuseExistingConnection(
+        () => conns,
+        '/test/1.0.0',
+        AbortSignal.timeout(1000),
+        { peerHasDirectAddrs: async () => false, excludeConnections: exclude },
+      );
+
+      expect(callOrder).toEqual(['B']);
+      expect(result?.connection).toBe(conns[1]);
+    });
+
+    it('returns the connection alongside the stream so callers can blacklist on failure', async () => {
+      const { tryReuseExistingConnection } = await import('../src/protocol-router.js');
+      const targetConn = {
+        status: 'open',
+        newStream: async () => ({ writeStatus: 'open' } as any),
+      };
+      const result = await tryReuseExistingConnection(
+        () => [targetConn] as any[],
+        '/test/1.0.0',
+        AbortSignal.timeout(1000),
+        { peerHasDirectAddrs: async () => false },
+      );
+      expect(result).not.toBeNull();
+      expect(result!.connection).toBe(targetConn);
+      expect(result!.stream.writeStatus).toBe('open');
+    });
+
+    it('returns null when every candidate is excluded', async () => {
+      const { tryReuseExistingConnection } = await import('../src/protocol-router.js');
+      const conns = [
+        { status: 'open', newStream: async () => ({ writeStatus: 'open' } as any) },
+        { status: 'open', newStream: async () => ({ writeStatus: 'open' } as any) },
+      ];
+      const exclude = new WeakSet<object>();
+      exclude.add(conns[0]);
+      exclude.add(conns[1]);
+
+      const result = await tryReuseExistingConnection(
+        () => conns as any[],
+        '/test/1.0.0',
+        AbortSignal.timeout(1000),
+        { peerHasDirectAddrs: async () => false, excludeConnections: exclude },
+      );
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/scripts/libp2p-soak-test.sh
+++ b/scripts/libp2p-soak-test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# libp2p-soak-test.sh — bidirectional messaging soak test for DKG nodes
+#
+# Sends one tagged + sequenced message to RECIPIENT every INTERVAL_S
+# seconds, for TOTAL_CYCLES cycles. Before each send, snapshots local
+# daemon health, internet reachability, and target-peer libp2p state
+# (preflight.jsonl). After each send, snapshots the inbox filtered to
+# messages from RECIPIENT (inbox.jsonl). Send responses go to
+# sends.jsonl. Human-readable trace goes to main.log.
+#
+# Two operators run this against each other to validate the
+# bidirectional libp2p messaging stack over hours of real network
+# conditions. Symmetric preflight on both sides disambiguates "my
+# internet was down" from "remote was unreachable" from "real
+# transport hiccup" in postmortem.
+#
+# Defaults: 18 cycles × 20min = 6h, recipient = dkg-testnet-edge,
+# sender_tag = MILES, internet probe = cloudflare (1.1.1.1).
+#
+# Override via env vars: RECIPIENT, RECIPIENT_PEER_ID, SENDER_TAG,
+# TOTAL_CYCLES, INTERVAL_S, INTERNET_PROBE_HOST, API.
+# RECIPIENT_PEER_ID is optional; when set, enables per-peer preflight
+# probe of /api/peer-info (PR #533 fields incl. getConnectionsReturnsForPeer).
+#
+# Usage (run from anywhere — logs always go to ~/.dkg/soak-test-<ts>-<TAG>/):
+#   nohup caffeinate -i bash scripts/libp2p-soak-test.sh \
+#     RECIPIENT_PEER_ID=12D3Koo... \
+#     >> ~/.dkg/soak-test.out 2>&1 &
+#   disown
+#
+# Stop early:
+#   pkill -f libp2p-soak-test.sh
+
+set -uo pipefail
+
+RECIPIENT="${RECIPIENT:-dkg-testnet-edge}"
+RECIPIENT_PEER_ID="${RECIPIENT_PEER_ID:-}"   # optional; required for per-peer preflight diagnostics
+SENDER_TAG="${SENDER_TAG:-MILES}"
+TOTAL_CYCLES="${TOTAL_CYCLES:-18}"
+INTERVAL_S="${INTERVAL_S:-1200}"   # 20 min
+INTERNET_PROBE_HOST="${INTERNET_PROBE_HOST:-1.1.1.1}"   # cloudflare DNS — universal, fast, no captive-portal interception
+
+API="${API:-http://127.0.0.1:9200}"
+AUTH=$(grep -v '^#' "${HOME}/.dkg/auth.token" | head -1)
+
+LOG_DIR="${HOME}/.dkg/soak-test-$(date -u +%Y%m%d-%H%M%S)-${SENDER_TAG}"
+mkdir -p "$LOG_DIR"
+echo "$$" > "$LOG_DIR/pid"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" \
+    | tee -a "$LOG_DIR/main.log"
+}
+
+send_one() {
+  local seq=$1 total=$2 ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  local body
+  body=$(printf '{"to":"%s","text":"%s soak-test seq=%d/%d ts=%s"}' \
+    "$RECIPIENT" "$SENDER_TAG" "$seq" "$total" "$ts")
+  local resp
+  resp=$(curl -s --max-time 60 -X POST "$API/api/chat" \
+    -H "Authorization: Bearer $AUTH" \
+    -H "Content-Type: application/json" \
+    -d "$body")
+  printf '{"seq":%d,"sent_ts":"%s","resp":%s}\n' \
+    "$seq" "$ts" "${resp:-{\"error\":\"empty response\"\}}" \
+    >> "$LOG_DIR/sends.jsonl"
+  log "  send seq=$seq → ${resp:0:140}"
+}
+
+preflight_snapshot() {
+  local label=$1 ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  local status_json
+  status_json=$(curl -s --max-time 10 "$API/api/status" -H "Authorization: Bearer $AUTH")
+
+  local net_start net_end net_rtt_ms net_ok
+  net_start=$(python3 -c 'import time;print(int(time.time()*1000))')
+  if curl -sS --max-time 5 -o /dev/null "http://${INTERNET_PROBE_HOST}" 2>/dev/null; then
+    net_ok=true
+  else
+    net_ok=false
+  fi
+  net_end=$(python3 -c 'import time;print(int(time.time()*1000))')
+  net_rtt_ms=$((net_end - net_start))
+
+  local peer_json='null'
+  if [ -n "$RECIPIENT_PEER_ID" ]; then
+    peer_json=$(curl -s --max-time 10 \
+      "$API/api/peer-info?peerId=$RECIPIENT_PEER_ID" \
+      -H "Authorization: Bearer $AUTH")
+    peer_json="${peer_json:-null}"
+  fi
+
+  printf '{"label":"%s","ts":"%s","local":%s,"internet":{"host":"%s","ok":%s,"rtt_ms":%d},"peer":%s}\n' \
+    "$label" "$ts" "${status_json:-null}" "$INTERNET_PROBE_HOST" "$net_ok" "$net_rtt_ms" "$peer_json" \
+    >> "$LOG_DIR/preflight.jsonl"
+
+  local summary
+  summary=$(python3 -c "
+import json, sys
+try:
+  l = json.loads('''${status_json:-null}''')
+  peers = l.get('connectedPeers', '?')
+  relay = 'relay+' if l.get('relayConnected') else 'relay-'
+  conn = l.get('connections', {})
+  local_s = f'peers={peers} {relay} direct={conn.get(\"direct\", \"?\")} relayed={conn.get(\"relayed\", \"?\")}'
+except Exception as e:
+  local_s = f'local=err({e})'
+
+net_s = 'net+' if '${net_ok}' == 'true' else 'net-'
+
+try:
+  p = json.loads('''${peer_json:-null}''') if '''${peer_json:-null}''' != 'null' else None
+  if p:
+    last_seen_ms = p.get('lastSeen') or 0
+    age_s = ((${net_end} - last_seen_ms) // 1000) if last_seen_ms else -1
+    peer_s = (
+      f'peer.connected={p.get(\"connected\")} '
+      f'raw={p.get(\"rawConnectionCount\", \"?\")} '
+      f'forPeer={p.get(\"getConnectionsReturnsForPeer\", \"?\")} '
+      f'addrs={(p.get(\"peerStore\") or {{}}).get(\"knownMultiaddrCount\", \"?\")} '
+      f'outbox={(p.get(\"outbox\") or {{}}).get(\"pendingCount\", \"?\")} '
+      f'lastSeen={age_s}s'
+    )
+  else:
+    peer_s = 'peer=skipped(no RECIPIENT_PEER_ID)'
+except Exception as e:
+  peer_s = f'peer=err({e})'
+
+print(f'{local_s} | {net_s} | {peer_s}')
+" 2>/dev/null)
+  log "  preflight ($label): $summary"
+}
+
+snapshot_inbox() {
+  local label=$1 ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  local resp
+  resp=$(curl -s --max-time 30 \
+    "${API}/api/messages?peer=${RECIPIENT}&direction=in&limit=200&order=desc" \
+    -H "Authorization: Bearer $AUTH")
+  printf '{"label":"%s","ts":"%s","data":%s}\n' \
+    "$label" "$ts" "${resp:-{\"error\":\"empty response\"\}}" \
+    >> "$LOG_DIR/inbox.jsonl"
+  local count
+  count=$(printf '%s' "$resp" | python3 -c "
+import json, sys
+try:
+  d = json.loads(sys.stdin.read())
+  msgs = d.get('messages', []) if isinstance(d, dict) else (d if isinstance(d, list) else [])
+  soak = sum(1 for m in msgs if 'soak-test' in (m.get('text') or ''))
+  print(f'total_in={len(msgs)} soak_test_in={soak}')
+except Exception as e:
+  print(f'(parse error: {e})')
+" 2>/dev/null)
+  log "  inbox snapshot ($label): $count"
+}
+
+trap 'log "INTERRUPTED — stopping at cycle ${seq:-?}"; exit 130' INT TERM
+
+log "=== START soak-test ==="
+log "  recipient=$RECIPIENT"
+log "  recipient_peer_id=${RECIPIENT_PEER_ID:-<unset, per-peer preflight skipped>}"
+log "  sender_tag=$SENDER_TAG"
+log "  total_cycles=$TOTAL_CYCLES"
+log "  interval_s=$INTERVAL_S"
+log "  internet_probe=$INTERNET_PROBE_HOST"
+log "  log_dir=$LOG_DIR"
+log "  pid=$$"
+log ""
+log "Baseline preflight + inbox snapshot (before first send):"
+preflight_snapshot "baseline"
+snapshot_inbox "baseline"
+log ""
+
+for seq in $(seq 1 "$TOTAL_CYCLES"); do
+  log "--- CYCLE $seq/$TOTAL_CYCLES ---"
+  preflight_snapshot "pre-send-$seq"
+  send_one "$seq" "$TOTAL_CYCLES"
+  sleep 5
+  snapshot_inbox "post-send-$seq"
+  if [ "$seq" -lt "$TOTAL_CYCLES" ]; then
+    log "  ... sleeping ${INTERVAL_S}s until next cycle"
+    sleep "$INTERVAL_S"
+  fi
+done
+
+log ""
+log "All cycles done. Waiting 5min for any queued/retried inbound to land..."
+sleep 300
+snapshot_inbox "final"
+
+log ""
+log "=== END soak-test ==="
+log ""
+log "Summary:"
+sends_count=$(wc -l < "$LOG_DIR/sends.jsonl" | tr -d ' ')
+log "  total sends: $sends_count"
+delivered=$(grep -c '"delivered":true' "$LOG_DIR/sends.jsonl" 2>/dev/null || echo 0)
+log "  delivered: $delivered"
+queued=$(grep -c '"queued":true' "$LOG_DIR/sends.jsonl" 2>/dev/null || echo 0)
+log "  queued (transport-failed, retried): $queued"
+acl_rejects=$(grep -c 'unauthorized' "$LOG_DIR/sends.jsonl" 2>/dev/null || echo 0)
+log "  ACL-rejected: $acl_rejects"
+final_in=$(tail -1 "$LOG_DIR/inbox.jsonl" | python3 -c "
+import json, sys
+try:
+  d = json.loads(sys.stdin.readline())
+  msgs = d['data'].get('messages', []) if isinstance(d.get('data'), dict) else []
+  soak = sum(1 for m in msgs if 'soak-test' in (m.get('text') or ''))
+  print(soak)
+except: print(0)
+")
+log "  inbound soak-test messages received: $final_in (expected: $TOTAL_CYCLES from peer)"
+log ""
+log "Detailed logs:"
+log "  sends:  $LOG_DIR/sends.jsonl"
+log "  inbox:  $LOG_DIR/inbox.jsonl"
+log "  trace:  $LOG_DIR/main.log"

--- a/scripts/libp2p-soak-test.sh
+++ b/scripts/libp2p-soak-test.sh
@@ -33,6 +33,15 @@
 
 set -uo pipefail
 
+# Accept KEY=VALUE positional args as env vars (so `bash script.sh FOO=bar`
+# works the same as `FOO=bar bash script.sh`). Spotted by Lex during the
+# 2026-05 rc9 soak — silent fallback to defaults is a footgun otherwise.
+for kv in "$@"; do
+  case "$kv" in
+    *=*) export "$kv" ;;
+  esac
+done
+
 RECIPIENT="${RECIPIENT:-dkg-testnet-edge}"
 RECIPIENT_PEER_ID="${RECIPIENT_PEER_ID:-}"   # optional; required for per-peer preflight diagnostics
 SENDER_TAG="${SENDER_TAG:-MILES}"


### PR DESCRIPTION
fix(outbox): defend retryOutboxEntry against stale-snapshot race

Surfaced by the 2026-05 rc9 8h soak (29 outbox queues -> 63 daemon
"succeeded" events, 2.17x wire amplification). `processMessageOutboxOnConnect`
takes a snapshot of `pendingFor(peer)` and iterates it. When two
`connection:open` events fire in rapid succession during a relay
reconnect storm:

  Flush A: sendChat -> delivered -> markDelivered -> entry removed,
           endAttempt -> inflight slot released
  Flush B: (snapshot taken before A's markDelivered, so still holds
           the entry reference) -> tryBeginAttempt returns true
           (slot is free again) -> sendChat fires AGAIN for an
           already-delivered messageId

Worst case the duplicate sendChat fails ("Remote closed connection
during opening") and `enqueueFailure` resurrects the deleted entry
with `attempts=1`, restarting the full backoff ladder. We observed
this for >=10 messageIds in the soak, with one messageId producing 5
"succeeded" events.

`tryBeginAttempt` (added in PR #521) only blocks TRULY-PARALLEL
races where both attempters are mid-send simultaneously. It does not
block the stale-snapshot-after-completion case. The fix adds an
atomic `hasEntry` re-check between `tryBeginAttempt` and the
`sendChat` call -- single-threaded with no yields between them, so
the no-op exit is racy-safe.

Smoking gun for messageId=86a610cd in ~/.dkg/daemon.log:

  08:40:28  Outbox redelivery succeeded after 68 attempt(s)
  08:40:34  Outbox redelivery still failing (attempts=1)  <- resurrected
  08:40:50  Outbox redelivery succeeded after 3 attempt(s)
  08:40:55  Outbox redelivery succeeded after 2 attempt(s)

The receiver-side dedup added in PR #534 silently absorbs the
duplicate wire sends, so this bug was invisible to the recipient.
Both layers stay -- defense in depth -- but the sender now avoids
the wasted I/O and the spurious retry-storm restart.

Tests:
- 5 new unit tests for `MessageOutbox.hasEntry`
- 1 integration test in p2p-resilience that simulates the exact
  stale-snapshot race and asserts sendChat fires exactly once across
  two retryOutboxEntry calls on the same stale entry reference

Co-authored-by: Cursor <cursoragent@cursor.com>

