### PR TITLE
feat(core,node-ui): Universal Messenger substrate primitives (rc.9 PR-1)

### DIFF
--- a/docs/messenger.md
+++ b/docs/messenger.md
@@ -1,0 +1,209 @@
+# Universal Messenger
+
+> Status: shipping in `v10.0.0-rc.9`. Skeleton landed in PR-1 (rc.9 plan). Subsequent PRs flesh out per-protocol coverage; PR-13 is the final coherence pass.
+
+The Universal Messenger is the reliability substrate every short
+peer-to-peer DKG protocol travels through. It generalises the chat-
+specific outbox + receiver-dedup work from rc.8 (PRs #533, #534, #536,
+#537, #538) into a single layer that wraps `ProtocolRouter.send` and
+gives every caller — chat, skill request, query, swm-sender-key,
+private-access, join-request, storage-ack, verify-proposal — the same
+delivery guarantees:
+
+- **At-least-once delivery** with sender-side durable retry (survives
+  daemon crash mid-retry).
+- **Exactly-once application semantics** via receiver-side idempotency
+  by `messageId`.
+- **Stale-snapshot-safe retries** (the rc.9 #538 lesson, lifted into
+  the generic substrate).
+- **Caller-visible delivery state** — `{ delivered, queued, attempts,
+  messageId }` so MCP / HTTP callers can surface "queued" vs "sent"
+  to the operator.
+
+This page is the architecture reference. Two siblings live alongside it:
+
+- [`messenger-add-protocol.md`](./messenger-add-protocol.md) — recipe
+  for migrating an existing protocol onto the Messenger, or adding a
+  new short-message protocol.
+- [`messenger-operator.md`](./messenger-operator.md) — how to read
+  `/api/slo`, what `--relay-preferred` does, and how to debug a peer
+  that "should be" reachable but isn't.
+
+## Architecture
+
+```
+caller (chat, query, etc.)
+  │
+  ▼
+Messenger.sendToPeer(peerId, protocol, payload, { messageId? })
+  │  1. (sender-side) check `MessageIdempotencyStore` for direction='out':
+  │       seen? → return cached response (re-issue path)
+  │  2. wrap payload in `ReliableEnvelope { messageId, version, tsMs, payload }`
+  │  3. ProtocolRouter.send (existing low-level wire I/O)
+  │  4a. success → record `(peer, protocol, msgId, 'out')` in idempotency store
+  │  4b. failure → enqueue in `ProtocolOutboxStore`; background tick + connect-flush retry
+  ▼
+ProtocolRouter.send  (unchanged; just wire I/O + path selection)
+  │
+  ▼
+[ libp2p / circuit-relay / direct ]
+  │
+  ▼
+ProtocolRouter receives
+  │
+  ▼
+Messenger.register(protocol, handler)
+  │  1. decode `ReliableEnvelope`
+  │  2. check `MessageIdempotencyStore` for direction='in':
+  │       seen + cached response → return cached response (no app handler call)
+  │       seen + mark-only       → return RESPONSE_GONE
+  │       not seen               → invoke handler(payload, peerId)
+  │  3. record `(peer, protocol, msgId, 'in', responseBytes)`
+  ▼
+application handler (existing protocol-specific code)
+```
+
+The substrate is composed of:
+
+1. **`ReliableEnvelope` proto** (`packages/core/src/proto/reliable-envelope.ts`)
+   — uniform `{ messageId, version, tsMs, payload }` outer wrapper.
+   The application payload (chat protobuf, JSON request, pipe-
+   delimited frame) stays inside `payload` byte-identical.
+
+2. **`MessageIdempotencyStore`** (interface in
+   `packages/core/src/messenger-types.ts`; SQLite-backed in
+   `packages/node-ui/src/db.ts`'s `SqliteMessageIdempotencyStore`) —
+   keyed by `(peer, protocol, messageId, direction)`, with inline
+   response cache up to 256 KiB and mark-only beyond.
+
+3. **`ProtocolOutbox` + `ProtocolOutboxStore`**
+   (`packages/core/src/protocol-outbox.ts`; SQLite-backed in
+   `SqliteProtocolOutboxStore`) — durable send-side retry queue keyed
+   by `(peer, protocol, messageId)`. Backoff ladder: 5s → 15s → 30s →
+   60s → 5m → 30m → 2h, capped 24h.
+
+4. **`Messenger`** class (`packages/agent/src/messenger.ts`) — wires
+   the above together around `ProtocolRouter`. Provides `sendToPeer`
+   + `register` as the only public surface every protocol needs. _PR-2._
+
+## Wire format
+
+Every message on `/dkg/10.0.1/*` is `ReliableEnvelope` encoded:
+
+```protobuf
+message ReliableEnvelope {
+  string message_id = 1;     // UUID v4, Messenger-managed
+  uint32 version = 2;        // 1 = current
+  uint64 ts_ms = 3;          // sender wall-clock at send time
+  bytes payload = 4;         // original protocol bytes (existing protobuf, JSON, etc.)
+}
+```
+
+**Protocol prefix bump from `/dkg/10.0.0/*` → `/dkg/10.0.1/*`** is the
+coarse-grained compatibility break that signals "envelope wrapper now
+present"; the `version` field inside the envelope handles fine-grained
+evolution within the prefix. Hard cutover — no negotiation logic, no
+codepath that mixes wrapped + bare frames. Two nodes on different
+prefixes simply don't talk on the migrated protocol until both reach
+rc.9.
+
+## V12 schema (PR-1)
+
+The SQLite-backed stores live in `DashboardDB` (`packages/node-ui/src/db.ts`).
+V12 migration is pure additive — chat continues to write to
+`chat_messages.message_id` until PR-3 cuts over.
+
+```sql
+CREATE TABLE message_idempotency (
+  peer_id TEXT NOT NULL,
+  protocol TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK (direction IN ('in', 'out')),
+  response_blob BLOB,            -- inline cache up to 256 KiB; NULL = mark-only
+  response_size INTEGER NOT NULL DEFAULT 0,
+  ts INTEGER NOT NULL,
+  PRIMARY KEY (peer_id, protocol, message_id, direction)
+);
+CREATE INDEX idx_idem_ts ON message_idempotency(ts);
+
+CREATE TABLE protocol_outbox (
+  peer_id TEXT NOT NULL,
+  protocol TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  payload BLOB NOT NULL,         -- envelope-wrapped wire bytes (not raw app payload)
+  attempts INTEGER NOT NULL DEFAULT 0,
+  first_failure_at INTEGER NOT NULL,
+  last_attempt_at INTEGER NOT NULL,
+  next_attempt_at INTEGER NOT NULL,
+  last_error TEXT,
+  PRIMARY KEY (peer_id, protocol, message_id)
+);
+CREATE INDEX idx_outbox_next_attempt ON protocol_outbox(next_attempt_at);
+```
+
+Periodic prune (24h TTL) runs in `DashboardDB.prune()`.
+
+## Response caching policy
+
+Fixed at 256 KiB inline cache. No per-protocol or per-call knob.
+
+| Response size                       | Behaviour                                                                                |
+| ----------------------------------- | ---------------------------------------------------------------------------------------- |
+| `<=` 256 KiB                        | Stored inline in `response_blob`. Duplicate receive returns cached bytes.                |
+| `>` 256 KiB                         | Stored mark-only (`response_blob = NULL`, `response_size` set). Duplicate → RESPONSE_GONE. |
+
+Callers on the receive of `RESPONSE_GONE` decide whether to re-issue
+with a fresh `messageId` (acceptable for `/query-remote` since SPARQL
+is idempotent at the app layer) or surface a terminal error.
+
+## Per-protocol coverage
+
+> Filled in as protocols migrate. Empty rows are placeholders for the
+> milestone they land in.
+
+| Protocol                        | Migrated in | parallelPaths | Notes                                                                              |
+| ------------------------------- | ----------- | ------------- | ---------------------------------------------------------------------------------- |
+| `/dkg/10.0.1/message` (chat)    | PR-3        | 2 (PR-4)      | Pilot. Wire-format break replaces `chat_messages.message_id` index uniqueness.     |
+| `/dkg/10.0.1/skill_request`     | PR-3        | 1             | Migrated alongside chat (shares `agent.sendMessage` path).                         |
+| `/dkg/10.0.1/swm-sender-key`    | PR-8        | 1             | Batch with `/private-access`.                                                      |
+| `/dkg/10.0.1/private-access`    | PR-8        | 1             | Batch with `/swm-sender-key`.                                                      |
+| `/dkg/10.0.1/query-remote`      | PR-9        | 1             | First caller exercising RESPONSE_GONE retry path.                                  |
+| `/dkg/10.0.1/join-request`      | PR-10       | 1             | Removes `JoinApprovalRetryQueue` in favour of generic outbox.                      |
+| `/dkg/10.0.1/storage-ack`       | PR-11       | 1             | ACKCollector quorum stays untouched; only the transport swaps.                     |
+| `/dkg/10.0.1/verify-proposal`   | PR-11       | 1             | Same shape as storage-ack.                                                         |
+
+## Recovery primitives
+
+> Documented as they ship. Linked PRs are in the rc.9 plan.
+
+- **Outbox-driven retry** (rc.8 carry-over) — backoff ladder above.
+- **Opportunistic-flush on `connection:open`** — when a peer
+  reconnects, drain its `pendingFor(peer)` queue immediately rather
+  than wait for backoff. Stale-snapshot-safe via `hasEntry` guard
+  (rc.9 #538).
+- **`parallelPaths`** _(PR-4)_ — `Messenger.sendToPeer` can race N
+  candidate paths; receiver dedup absorbs duplicates.
+- **DHT walk on stall** _(PR-5)_ — outbox entry with ≥ 5 attempts of
+  "no valid addresses for peer" triggers a time-bounded, rate-limited
+  `libp2p.peerRouting.findPeer()`.
+- **Gossip peer-hints** _(PR-6, conditional)_ — only ships if Gate B
+  shows DHT walk insufficient.
+
+## SLO
+
+Defined fully in [`messenger-operator.md`](./messenger-operator.md).
+TL;DR: per-message latency clock starts at `Messenger.sendToPeer`
+invocation and ends at the promise resolving `{ delivered: true }`
+(includes queue + retries; this is the operator-visible "I clicked
+send → it arrived" time). Target: ≥ 99%/15s on chat/skill/query,
+≥ 99.5% on the rest. Per-protocol histograms via PR-12's `/api/slo`
+endpoint (localhost-only by default).
+
+## Open questions / future work
+
+- Multi-recipient fan-out (broadcast to N peers with single
+  `messageId`) — out of scope for rc.9; explored in a follow-up RFC.
+- Cross-process idempotency (multiple daemons sharing the same store)
+  — not needed today (one daemon per node) but the schema accommodates it.
+- Operator-relay infrastructure — code-side in PR-7; actual relay
+  provisioning is an out-of-band ops track.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,23 @@ export {
   type RetryQueueOptions,
 } from './retry-queue.js';
 export {
+  type MessageIdempotencyStore,
+  type MessageDirection,
+  type IdempotencyCheckResult,
+  type ProtocolOutboxStore,
+  type ProtocolOutboxEntry,
+  RESPONSE_CACHE_BYTES,
+  RESPONSE_GONE_MARKER,
+} from './messenger-types.js';
+export {
+  ProtocolOutbox,
+  type ProtocolOutboxOptions,
+  DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS,
+  DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS,
+  InMemoryProtocolOutboxStore,
+  InMemoryMessageIdempotencyStore,
+} from './protocol-outbox.js';
+export {
   findPackageRepoDir,
   blueGreenSlotEntryPoint,
   blueGreenSlotReady,

--- a/packages/core/src/messenger-types.ts
+++ b/packages/core/src/messenger-types.ts
@@ -1,0 +1,233 @@
+/**
+ * Storage port interfaces for the Universal Messenger substrate (rc.9
+ * plan PR-1). Defined in `packages/core` so `packages/agent`'s
+ * `Messenger` class can depend on these abstract ports without
+ * pulling in `packages/node-ui` (which holds the concrete SQLite
+ * implementations against `DashboardDB`).
+ *
+ * Two stores, two concerns:
+ *
+ *   * `MessageIdempotencyStore` — receiver-side dedup + sender-side
+ *     "did we already deliver this?" cache. Keyed by
+ *     `(peer, protocol, messageId, direction)`. Records optionally
+ *     cache the original response bytes so a retry of an already-
+ *     delivered request can return the same response without re-
+ *     invoking the application handler (idempotent re-delivery).
+ *
+ *   * `ProtocolOutboxStore` — sender-side durable retry queue. Keyed
+ *     by `(peer, protocol, messageId)`. Holds the envelope-wrapped
+ *     payload bytes + retry metadata (attempts, last error, next
+ *     attempt time) so a daemon crash mid-retry doesn't drop the
+ *     message (the rc9 chat outbox lost in-flight entries on every
+ *     daemon restart — durable across-restart retry is the floor
+ *     this substrate sets).
+ *
+ * Both stores are keyed by `protocol` (the libp2p protocol string,
+ * e.g. `/dkg/10.0.1/message`) so a single `message_idempotency` or
+ * `protocol_outbox` table can hold entries from every protocol
+ * without collisions. The substrate's design constraint is that
+ * adding a new short-message protocol requires no new storage —
+ * just calling `Messenger.register(protocolId, handler)`.
+ *
+ * Response caching policy (locked in PR-2 design, documented here
+ * because it constrains the store shape):
+ *
+ *   * Responses up to `RESPONSE_CACHE_BYTES` (= 256 KiB) bytes are
+ *     stored in `response_blob` with `response_size = blob.length`.
+ *
+ *   * Responses larger than the limit are stored "mark-only" — the
+ *     row is inserted but `response_blob` is left NULL and
+ *     `response_size` records the actual byte size. The receiver-
+ *     side handler wrapper, on a duplicate receive whose original
+ *     response was mark-only, signals `RESPONSE_GONE` to the sender;
+ *     the sender's caller can decide whether to re-issue with a
+ *     fresh `messageId` (acceptable for `/query-remote` where SPARQL
+ *     is idempotent at the app layer) or surface a terminal error.
+ *
+ * No per-protocol or per-call knob (`cacheResponse` / `responseCacheBytes`
+ * from earlier plan iterations) — the fixed 256 KiB limit comfortably
+ * covers chat acks, skill results, swm keys, access verdicts, join
+ * verdicts; only `/query-remote` results might exceed it.
+ *
+ * Caller responsibilities:
+ *   - Caller never normalises keys. The store is opaque about peer ID
+ *     encoding — pass whatever string the libp2p caller already uses
+ *     (typically `peerId.toString()`, the rc9 PR #533 lesson).
+ *   - Caller supplies `now: number` for time-related queries (`due`,
+ *     `dropExpired`); the store does not call `Date.now()` so tests
+ *     can drive deterministic timestamps.
+ *   - All write methods are synchronous (SQLite better-sqlite3 is
+ *     sync). The implementations may use prepared statements + WAL
+ *     for throughput but the API stays simple.
+ */
+
+/**
+ * Fixed inline cache limit for response bodies in
+ * `message_idempotency.response_blob`. Responses exceeding this size
+ * are stored mark-only (blob NULL, size recorded) and trigger
+ * `RESPONSE_GONE` on duplicate receive.
+ *
+ * 256 KiB chosen because it comfortably covers chat acks, skill
+ * results, swm keys, access verdicts, join verdicts. Only
+ * `/query-remote` SPARQL results may exceed it, and `/query-remote`
+ * is idempotent at the app layer so the `RESPONSE_GONE` re-issue
+ * path is acceptable for that one caller.
+ */
+export const RESPONSE_CACHE_BYTES = 256 * 1024;
+
+/**
+ * Discriminator returned in `IdempotencyCheckResult.cachedResponse`
+ * when the original response was stored mark-only (too big to cache).
+ * The receiver's handler wrapper emits the literal string
+ * `'RESPONSE_GONE'` (not a special value) so it surfaces cleanly to
+ * the sender as a typed protocol-level signal rather than getting
+ * confused with a normal payload.
+ */
+export const RESPONSE_GONE_MARKER = 'RESPONSE_GONE';
+
+/** Direction marker for idempotency entries. */
+export type MessageDirection = 'in' | 'out';
+
+/**
+ * Result of `MessageIdempotencyStore.check`. Two-shape return: either
+ * we've never seen this `(peer, protocol, messageId, direction)`
+ * triple before, or we have — in which case the cached response (if
+ * any) is returned. A `seen: true` result with `cachedResponse:
+ * undefined` means "we processed this message but the response was
+ * too large to cache and got marked-only" — the caller should treat
+ * it as a `RESPONSE_GONE` signal.
+ */
+export type IdempotencyCheckResult =
+  | { seen: false }
+  | { seen: true; cachedResponse?: Uint8Array };
+
+export interface MessageIdempotencyStore {
+  /**
+   * Returns whether the `(peer, protocol, messageId, direction)` triple
+   * has been recorded before, plus the cached response if any.
+   *
+   * Synchronous: better-sqlite3 reads return immediately. The
+   * receiver-side handler wrapper calls this on every inbound message
+   * to decide whether to invoke the handler or return the cached
+   * response.
+   */
+  check(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    direction: MessageDirection,
+  ): IdempotencyCheckResult;
+
+  /**
+   * Records a `(peer, protocol, messageId, direction)` triple with
+   * optional response body. Pass `response: undefined` to record
+   * "seen but no response cached" (i.e. mark-only for too-big
+   * responses). Pass a response shorter than
+   * `RESPONSE_CACHE_BYTES` to cache it inline.
+   *
+   * Idempotent: re-recording the same triple is a no-op (PRIMARY KEY
+   * conflict resolved via `ON CONFLICT DO NOTHING` — Codex #534
+   * lesson: never use blanket `INSERT OR IGNORE` which would swallow
+   * unrelated constraint violations).
+   *
+   * The store decides mark-only vs inline based on `response.length`
+   * vs `RESPONSE_CACHE_BYTES`. Callers don't pass the threshold.
+   */
+  record(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    direction: MessageDirection,
+    response?: Uint8Array,
+  ): void;
+
+  /**
+   * Drop every idempotency record older than `tsMs`. Returns the
+   * number of rows dropped, useful for periodic-prune diagnostics.
+   * Called by a background tick to bound table growth (24h TTL by
+   * default).
+   */
+  pruneOlderThan(tsMs: number): number;
+}
+
+/**
+ * A single durable outbox entry. The `payload` is the
+ * envelope-wrapped bytes (i.e. the `ReliableEnvelope` proto output
+ * from `Messenger.sendToPeer`), not the raw application payload —
+ * this lets retries replay byte-identical wire frames without re-
+ * encoding the envelope.
+ */
+export interface ProtocolOutboxEntry {
+  peer: string;
+  protocol: string;
+  messageId: string;
+  payload: Uint8Array;
+  attempts: number;
+  firstFailureAt: number;
+  lastAttemptAt: number;
+  nextAttemptAt: number;
+  lastError: string;
+}
+
+export interface ProtocolOutboxStore {
+  /**
+   * Insert or update an outbox entry for `(peer, protocol, messageId)`.
+   * First failure creates the entry with `attempts = 1`. Subsequent
+   * failures bump `attempts`, update `lastAttemptAt`/`lastError`, and
+   * schedule `nextAttemptAt = now + backoff(attempts)`.
+   *
+   * Returns the resulting entry so the caller can log it / surface
+   * delivery-state to the application.
+   */
+  enqueue(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    payload: Uint8Array,
+    error: string,
+    now: number,
+  ): ProtocolOutboxEntry;
+
+  /**
+   * Remove the outbox entry for `(peer, protocol, messageId)`.
+   * Returns `true` if an entry was actually removed (i.e. this was a
+   * retry success, not a first-attempt success).
+   */
+  markDelivered(peer: string, protocol: string, messageId: string): boolean;
+
+  /**
+   * Whether an entry exists for `(peer, protocol, messageId)`. Used
+   * by the stale-snapshot guard in `Messenger.processOutboxOnConnect`
+   * — between `tryBeginAttempt` (inflight lock) and the wire send,
+   * a sibling flush may have already delivered + removed the entry,
+   * and we must not double-send. The rc9 #538 fix lifted into the
+   * generic substrate.
+   */
+  hasEntry(peer: string, protocol: string, messageId: string): boolean;
+
+  /**
+   * All entries for a specific peer, regardless of `nextAttemptAt`.
+   * Used by `processOutboxOnConnect`: a reconnection is the signal
+   * we were waiting for, so attempt now even if backoff isn't due
+   * yet. Sorted by `firstFailureAt` ascending for FIFO per-peer
+   * drain.
+   */
+  pendingFor(peer: string): ProtocolOutboxEntry[];
+
+  /**
+   * All entries whose `nextAttemptAt <= now`. Used by the periodic
+   * tick to find what's due for retry, regardless of peer
+   * reachability.
+   */
+  due(now: number): ProtocolOutboxEntry[];
+
+  /**
+   * Drop entries whose `firstFailureAt` is older than the
+   * configured max-age. Returns the dropped entries so the caller
+   * can log them ("we gave up on this after 24h" diagnostic).
+   */
+  dropExpired(now: number): ProtocolOutboxEntry[];
+
+  /** Total entries currently queued. For diagnostics + tests. */
+  size(): number;
+}

--- a/packages/core/src/proto/index.ts
+++ b/packages/core/src/proto/index.ts
@@ -42,6 +42,13 @@ export {
 } from './message.js';
 
 export {
+  type ReliableEnvelopeMsg,
+  RELIABLE_ENVELOPE_VERSION,
+  encodeReliableEnvelope,
+  decodeReliableEnvelope,
+} from './reliable-envelope.js';
+
+export {
   type WorkspacePublishRequestMsg,
   type WorkspaceManifestEntryMsg,
   type WorkspaceCASConditionMsg,

--- a/packages/core/src/proto/reliable-envelope.ts
+++ b/packages/core/src/proto/reliable-envelope.ts
@@ -1,0 +1,97 @@
+/**
+ * Universal protobuf envelope used by `Messenger.sendToPeer` to wrap
+ * every short peer-to-peer message before handing it to
+ * `ProtocolRouter.send`, and unwrap on the receiver side inside
+ * `Messenger.register`'s handler wrapper.
+ *
+ * Background
+ * ----------
+ * The Universal Messenger substrate (rc.9 plan) wraps every short
+ * protocol payload — chat, skill, query, join, storage-ack, verify,
+ * swm-key, private-access — in a uniform outer envelope so the
+ * substrate can provide reliability (receiver-side dedup, durable
+ * outbox, retry-with-idempotency) without per-protocol special cases.
+ *
+ * The envelope adds three correlation fields to whatever bytes the
+ * application protocol already produces:
+ *
+ *   - `messageId` — a UUID v4 (caller-supplied or Messenger-generated)
+ *     used by the receiver-side idempotency table to dedupe duplicate
+ *     deliveries (e.g. from a multi-path race in PR-4 or a stale-
+ *     snapshot outbox flush in the post-#538 generic outbox), and by
+ *     the sender-side outbox to key persistent retry state.
+ *
+ *   - `version` — a uint32 schema version (`= 1` today) so future
+ *     envelope shape changes can be detected without bumping the
+ *     entire libp2p protocol prefix again. The protocol-prefix bump
+ *     (e.g. `/dkg/10.0.0/X` → `/dkg/10.0.1/X`) is the coarse-grained
+ *     compatibility break; the version field is for fine-grained
+ *     evolution within a prefix.
+ *
+ *   - `tsMs` — the sender's wall-clock at send time (ms since epoch).
+ *     Used by the receiver for staleness reasoning (drop messages
+ *     more than ~24h old) and by the SLO histogram in PR-12 to
+ *     compute end-to-end latency.
+ *
+ * The original protocol bytes — whether protobuf-encoded
+ * `AccessRequest`, JSON-encoded `JoinRequest`, pipe-delimited sync
+ * frame, etc. — are carried verbatim in the `payload` field. The
+ * application handler never sees the envelope: `Messenger.register`'s
+ * wrapper decodes it, checks idempotency, then invokes the handler
+ * with the original `Uint8Array` payload.
+ *
+ * Existing per-protocol correlation IDs (`proposalId`, `operationId`,
+ * `conversationId`, `requestId`, etc.) stay untouched inside the
+ * payload for app-level semantics — they're orthogonal to the
+ * envelope's `messageId`.
+ *
+ * Mirrors the encode/decode pattern in `./message.ts` (the
+ * `AgentMessage` protobuf for chat). No external runtime dependency
+ * beyond `protobufjs`, which is already pulled in by `./message.ts`.
+ *
+ * @internal — `ReliableEnvelopeSchema` is exported for the same
+ * backwards-compat reason as `AgentMessageSchema`; prefer the
+ * `ReliableEnvelopeMsg` type + `encodeReliableEnvelope` /
+ * `decodeReliableEnvelope` re-exported from `./index.ts`.
+ */
+import protobuf from 'protobufjs';
+
+const { Type, Field } = protobuf;
+
+export const ReliableEnvelopeSchema = new Type('ReliableEnvelope')
+  .add(new Field('messageId', 1, 'string'))
+  .add(new Field('version', 2, 'uint32'))
+  .add(new Field('tsMs', 3, 'uint64'))
+  .add(new Field('payload', 4, 'bytes'));
+
+type Long = { low: number; high: number; unsigned: boolean };
+
+/** Current `ReliableEnvelope.version` value emitted by `encodeReliableEnvelope`. */
+export const RELIABLE_ENVELOPE_VERSION = 1;
+
+export interface ReliableEnvelopeMsg {
+  /** UUID v4 string. Caller-supplied or Messenger-generated. */
+  messageId: string;
+  /** Envelope schema version. Always `RELIABLE_ENVELOPE_VERSION` (= 1) today. */
+  version: number;
+  /**
+   * Sender's wall-clock timestamp (ms since epoch) at send time.
+   * `Long` shape comes from protobufjs's default `uint64` decoder — callers
+   * that need a plain `number` can use `Number(msg.tsMs)` when the value
+   * is within the safe-integer range (always true for ms-since-epoch
+   * timestamps until year 287396).
+   */
+  tsMs: number | Long;
+  /** Original protocol bytes — the existing protobuf/JSON/pipe-delimited payload, unchanged. */
+  payload: Uint8Array;
+}
+
+export function encodeReliableEnvelope(msg: ReliableEnvelopeMsg): Uint8Array {
+  return ReliableEnvelopeSchema.encode(
+    ReliableEnvelopeSchema.create(msg),
+  ).finish();
+}
+
+export function decodeReliableEnvelope(buf: Uint8Array): ReliableEnvelopeMsg {
+  return ReliableEnvelopeSchema.decode(buf) as unknown as ReliableEnvelopeMsg;
+}

--- a/packages/core/src/protocol-outbox.ts
+++ b/packages/core/src/protocol-outbox.ts
@@ -1,0 +1,391 @@
+/**
+ * Generic, protocol-agnostic, store-backed retry outbox for short
+ * peer-to-peer messages. The Universal Messenger substrate's
+ * sender-side reliability primitive (rc.9 plan PR-1).
+ *
+ * Generalises `packages/agent/src/message-outbox.ts` (chat-specific,
+ * in-memory) into:
+ *
+ *   - **protocol-agnostic** — keyed by `(peer, protocol, messageId)`
+ *     so a single instance serves every Messenger-routed protocol.
+ *
+ *   - **store-backed** — composes any `ProtocolOutboxStore` (in-memory
+ *     `InMemoryProtocolOutboxStore` for tests; SQLite-backed
+ *     `SqliteProtocolOutboxStore` for the daemon, defined in
+ *     `packages/node-ui/src/db.ts`). Adds inflight-lock + backoff +
+ *     prune logic on top of the raw storage primitive.
+ *
+ *   - **stale-snapshot-safe** — preserves the `hasEntry` guard from
+ *     PR #538 (rc9 outbox-dup fix). Generalised as a contract test
+ *     the substrate must pass: between `tryBeginAttempt` and the
+ *     wire send, the caller MUST re-check `hasEntry` because a
+ *     sibling flush may have completed delivery during the interleave.
+ *
+ * The class itself is pure plumbing — no I/O, no clocks. All
+ * `now: number` values are supplied by the caller so tests can drive
+ * deterministic timestamps. The actual wire I/O lives in
+ * `Messenger.sendToPeer` (PR-2); this class just stores + schedules.
+ */
+
+import type {
+  IdempotencyCheckResult,
+  MessageDirection,
+  MessageIdempotencyStore,
+  ProtocolOutboxEntry,
+  ProtocolOutboxStore,
+} from './messenger-types.js';
+import { RESPONSE_CACHE_BYTES } from './messenger-types.js';
+
+export interface ProtocolOutboxOptions {
+  /**
+   * Backoff ladder in milliseconds. `attempts = 1` (first failure)
+   * uses `backoffs[0]`, `attempts = N` uses
+   * `backoffs[min(N-1, backoffs.length-1)]`. Must be non-empty.
+   *
+   * Defaults to `DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS` (5s → 2h ladder,
+   * matched to chat's pre-substrate ladder so the substrate doesn't
+   * regress timing on chat retries).
+   */
+  backoffs?: readonly number[];
+  /**
+   * Max age (ms) from `firstFailureAt` before an entry is dropped on
+   * the next `dropExpired(now)` call. Defaults to 24h.
+   */
+  maxAgeMs?: number;
+}
+
+/**
+ * Default backoff ladder for the Universal Messenger outbox. Matches
+ * the chat-specific ladder from `packages/agent/src/message-outbox.ts`
+ * (5s → 15s → 30s → 60s → 5m → 30m → 2h) so the chat pilot migration
+ * in PR-3 preserves the same retry timing the rc9 soak validated.
+ *
+ * Tighter ladders (e.g. for interactive callers) or looser ladders
+ * (e.g. for storage-ack fan-out) can override per-instance via
+ * `ProtocolOutboxOptions.backoffs`.
+ */
+export const DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS: readonly number[] = [
+  5_000,
+  15_000,
+  30_000,
+  60_000,
+  5 * 60_000,
+  30 * 60_000,
+  2 * 60 * 60_000,
+];
+
+/** Default max retry age: 24h since first failure. */
+export const DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+function inflightKey(peer: string, protocol: string, messageId: string): string {
+  return `${peer}\x00${protocol}\x00${messageId}`;
+}
+
+export class ProtocolOutbox {
+  private readonly store: ProtocolOutboxStore;
+  private readonly backoffs: readonly number[];
+  /**
+   * Per-key inflight set to prevent concurrent retry attempts for the
+   * same `(peer, protocol, messageId)`. Two trigger surfaces — the
+   * periodic tick (`Messenger.processOutboxTick`) and the
+   * opportunistic flush on `connection:open`
+   * (`Messenger.processOutboxOnConnect`) — can interleave: the tick
+   * starts the send for entry E, JS yields, `connection:open` fires,
+   * the on-connect handler reads `pendingFor(peer)` (entry E is still
+   * there — `markDelivered` hasn't fired yet because the in-flight
+   * send hasn't resolved), and would start a CONCURRENT second send
+   * for the same entry. Worst case both succeed and the receiver sees
+   * the same payload twice (receiver dedup absorbs it, but we waste
+   * a round-trip and amplify load).
+   *
+   * `tryBeginAttempt` is an atomic check-and-set: the second
+   * concurrent attempter sees `false` and exits without dialing.
+   *
+   * Lifted into the generic substrate from `MessageOutbox` (rc9 #521
+   * fix); the in-memory set is per-process — daemon restart resets
+   * it, which is fine because all in-flight sends die with the
+   * process anyway and the persistent outbox itself survives.
+   */
+  private readonly inflight = new Set<string>();
+
+  constructor(store: ProtocolOutboxStore, options: ProtocolOutboxOptions = {}) {
+    const backoffs = options.backoffs ?? DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS;
+    if (backoffs.length === 0) {
+      throw new Error('ProtocolOutbox: backoffs must be non-empty');
+    }
+    this.store = store;
+    this.backoffs = backoffs;
+    // maxAgeMs is consumed by the store impl (it's the one that
+    // implements dropExpired's age-check); we don't carry it here.
+    void options.maxAgeMs;
+  }
+
+  /**
+   * Atomic check-and-set for the per-key inflight guard. Returns
+   * `true` if the caller now owns the in-flight slot and should
+   * proceed with the wire send; returns `false` if another caller is
+   * already attempting it and the current caller should exit.
+   *
+   * MUST be paired with `endAttempt(...)` in a try/finally — leaking
+   * an inflight entry would permanently block future retries for
+   * that key.
+   */
+  tryBeginAttempt(peer: string, protocol: string, messageId: string): boolean {
+    const key = inflightKey(peer, protocol, messageId);
+    if (this.inflight.has(key)) return false;
+    this.inflight.add(key);
+    return true;
+  }
+
+  /** Release the per-key inflight slot. Idempotent. */
+  endAttempt(peer: string, protocol: string, messageId: string): void {
+    this.inflight.delete(inflightKey(peer, protocol, messageId));
+  }
+
+  /**
+   * Enqueue a failed send. First failure creates the entry with
+   * `attempts = 1`; subsequent failures bump `attempts` and reschedule
+   * `nextAttemptAt = now + backoff(attempts)`. Returns the resulting
+   * entry so the caller can surface delivery-state to the application.
+   */
+  enqueueFailure(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    payload: Uint8Array,
+    error: string,
+    now: number,
+  ): ProtocolOutboxEntry {
+    return this.store.enqueue(peer, protocol, messageId, payload, error, now);
+  }
+
+  /**
+   * Mark an entry as successfully delivered and remove it from the
+   * outbox. Returns `true` when an entry was actually removed.
+   *
+   * Callers MUST also call `endAttempt(...)` (via the try/finally
+   * pattern) to release the inflight slot — this method only touches
+   * the persistent store.
+   */
+  markDelivered(peer: string, protocol: string, messageId: string): boolean {
+    return this.store.markDelivered(peer, protocol, messageId);
+  }
+
+  /**
+   * Whether an entry for `(peer, protocol, messageId)` is still in
+   * the outbox. The stale-snapshot guard (rc9 #538): between
+   * `tryBeginAttempt` and the wire send, a sibling flush may have
+   * completed delivery + called `markDelivered`. Callers MUST check
+   * `hasEntry` immediately before the wire send and skip if `false`.
+   * The generic substrate's contract test verifies this.
+   */
+  hasEntry(peer: string, protocol: string, messageId: string): boolean {
+    return this.store.hasEntry(peer, protocol, messageId);
+  }
+
+  /** Entries whose `nextAttemptAt <= now`. */
+  due(now: number): ProtocolOutboxEntry[] {
+    return this.store.due(now);
+  }
+
+  /**
+   * All entries for `peer`, regardless of `nextAttemptAt`. Used by
+   * `Messenger.processOutboxOnConnect` for opportunistic flush on
+   * reconnection.
+   */
+  pendingFor(peer: string): ProtocolOutboxEntry[] {
+    return this.store.pendingFor(peer);
+  }
+
+  /** Drop entries older than the store's configured max-age. */
+  dropExpired(now: number): ProtocolOutboxEntry[] {
+    return this.store.dropExpired(now);
+  }
+
+  /** Total entries currently queued. */
+  size(): number {
+    return this.store.size();
+  }
+
+  /** Compute backoff for a given attempt count. Exposed for testing. */
+  backoffFor(attempts: number): number {
+    const idx = Math.min(Math.max(attempts - 1, 0), this.backoffs.length - 1);
+    return this.backoffs[idx];
+  }
+}
+
+/**
+ * Reference in-memory implementation of `ProtocolOutboxStore`. Used
+ * by tests + by the substrate before the SQLite-backed store is
+ * wired in `lifecycle.ts` (PR-2). The SQLite-backed implementation
+ * lives in `packages/node-ui/src/db.ts` and has the same semantics
+ * — this class exists as the executable spec for the contract.
+ *
+ * Implements the same backoff ladder the wrapper `ProtocolOutbox`
+ * uses so the test fixture is self-contained.
+ */
+export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
+  private readonly entries = new Map<string, ProtocolOutboxEntry>();
+  private readonly backoffs: readonly number[];
+  private readonly maxAgeMs: number;
+
+  constructor(options: ProtocolOutboxOptions = {}) {
+    this.backoffs = options.backoffs ?? DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS;
+    this.maxAgeMs = options.maxAgeMs ?? DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS;
+  }
+
+  private static key(peer: string, protocol: string, messageId: string): string {
+    return `${peer}\x00${protocol}\x00${messageId}`;
+  }
+
+  private backoffFor(attempts: number): number {
+    const idx = Math.min(Math.max(attempts - 1, 0), this.backoffs.length - 1);
+    return this.backoffs[idx];
+  }
+
+  enqueue(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    payload: Uint8Array,
+    error: string,
+    now: number,
+  ): ProtocolOutboxEntry {
+    const key = InMemoryProtocolOutboxStore.key(peer, protocol, messageId);
+    const existing = this.entries.get(key);
+    if (existing) {
+      existing.attempts += 1;
+      existing.lastAttemptAt = now;
+      existing.nextAttemptAt = now + this.backoffFor(existing.attempts);
+      existing.lastError = error;
+      return { ...existing };
+    }
+    const entry: ProtocolOutboxEntry = {
+      peer,
+      protocol,
+      messageId,
+      payload,
+      attempts: 1,
+      firstFailureAt: now,
+      lastAttemptAt: now,
+      nextAttemptAt: now + this.backoffFor(1),
+      lastError: error,
+    };
+    this.entries.set(key, entry);
+    return { ...entry };
+  }
+
+  markDelivered(peer: string, protocol: string, messageId: string): boolean {
+    return this.entries.delete(InMemoryProtocolOutboxStore.key(peer, protocol, messageId));
+  }
+
+  hasEntry(peer: string, protocol: string, messageId: string): boolean {
+    return this.entries.has(InMemoryProtocolOutboxStore.key(peer, protocol, messageId));
+  }
+
+  pendingFor(peer: string): ProtocolOutboxEntry[] {
+    return Array.from(this.entries.values())
+      .filter((e) => e.peer === peer)
+      .sort((a, b) => a.firstFailureAt - b.firstFailureAt)
+      .map((e) => ({ ...e }));
+  }
+
+  due(now: number): ProtocolOutboxEntry[] {
+    return Array.from(this.entries.values())
+      .filter((e) => e.nextAttemptAt <= now)
+      .map((e) => ({ ...e }));
+  }
+
+  dropExpired(now: number): ProtocolOutboxEntry[] {
+    const dropped: ProtocolOutboxEntry[] = [];
+    for (const [key, entry] of this.entries) {
+      if (now - entry.firstFailureAt > this.maxAgeMs) {
+        dropped.push({ ...entry });
+        this.entries.delete(key);
+      }
+    }
+    return dropped;
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+}
+
+/**
+ * Reference in-memory implementation of `MessageIdempotencyStore`.
+ * Same role as `InMemoryProtocolOutboxStore` — executable spec for
+ * tests + a fallback the substrate can use before the SQLite-backed
+ * store is wired.
+ */
+
+interface IdempotencyRecord {
+  responseBlob: Uint8Array | undefined;
+  ts: number;
+}
+
+export class InMemoryMessageIdempotencyStore implements MessageIdempotencyStore {
+  private readonly records = new Map<string, IdempotencyRecord>();
+  /**
+   * Clock used for `ts` values. Default `Date.now()`; tests can
+   * override via the options for determinism. Mirrors the
+   * SQLite-backed store, which stamps `ts = now` at record time.
+   */
+  private readonly clock: () => number;
+
+  constructor(options: { clock?: () => number } = {}) {
+    this.clock = options.clock ?? (() => Date.now());
+  }
+
+  private static key(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    direction: MessageDirection,
+  ): string {
+    return `${peer}\x00${protocol}\x00${messageId}\x00${direction}`;
+  }
+
+  check(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    direction: MessageDirection,
+  ): IdempotencyCheckResult {
+    const rec = this.records.get(InMemoryMessageIdempotencyStore.key(peer, protocol, messageId, direction));
+    if (!rec) return { seen: false };
+    return rec.responseBlob !== undefined
+      ? { seen: true, cachedResponse: rec.responseBlob }
+      : { seen: true };
+  }
+
+  record(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    direction: MessageDirection,
+    response?: Uint8Array,
+  ): void {
+    const key = InMemoryMessageIdempotencyStore.key(peer, protocol, messageId, direction);
+    if (this.records.has(key)) {
+      // Idempotent re-record: no-op (matches SQLite ON CONFLICT DO NOTHING).
+      return;
+    }
+    const blob =
+      response !== undefined && response.length <= RESPONSE_CACHE_BYTES
+        ? response
+        : undefined;
+    this.records.set(key, { responseBlob: blob, ts: this.clock() });
+  }
+
+  pruneOlderThan(tsMs: number): number {
+    let dropped = 0;
+    for (const [key, rec] of this.records) {
+      if (rec.ts < tsMs) {
+        this.records.delete(key);
+        dropped += 1;
+      }
+    }
+    return dropped;
+  }
+}

--- a/packages/core/src/protocol-outbox.ts
+++ b/packages/core/src/protocol-outbox.ts
@@ -81,6 +81,22 @@ function inflightKey(peer: string, protocol: string, messageId: string): string 
   return `${peer}\x00${protocol}\x00${messageId}`;
 }
 
+function cloneBytes(bytes: Uint8Array): Uint8Array {
+  return new Uint8Array(bytes);
+}
+
+function cloneOutboxEntry(entry: ProtocolOutboxEntry): ProtocolOutboxEntry {
+  return { ...entry, payload: cloneBytes(entry.payload) };
+}
+
+interface ProtocolOutboxStorePolicy extends ProtocolOutboxOptions {
+  backoffFor: (attempts: number) => number;
+}
+
+type PolicyAwareProtocolOutboxStore = ProtocolOutboxStore & {
+  configurePolicy?: (policy: ProtocolOutboxStorePolicy) => void;
+};
+
 export class ProtocolOutbox {
   private readonly store: ProtocolOutboxStore;
   private readonly backoffs: readonly number[];
@@ -115,9 +131,11 @@ export class ProtocolOutbox {
     }
     this.store = store;
     this.backoffs = backoffs;
-    // maxAgeMs is consumed by the store impl (it's the one that
-    // implements dropExpired's age-check); we don't carry it here.
-    void options.maxAgeMs;
+    (this.store as PolicyAwareProtocolOutboxStore).configurePolicy?.({
+      backoffs,
+      maxAgeMs: options.maxAgeMs ?? DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS,
+      backoffFor: (attempts) => this.backoffFor(attempts),
+    });
   }
 
   /**
@@ -226,12 +244,11 @@ export class ProtocolOutbox {
  */
 export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
   private readonly entries = new Map<string, ProtocolOutboxEntry>();
-  private readonly backoffs: readonly number[];
-  private readonly maxAgeMs: number;
+  private backoffs: readonly number[] = DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS;
+  private maxAgeMs = DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS;
 
   constructor(options: ProtocolOutboxOptions = {}) {
-    this.backoffs = options.backoffs ?? DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS;
-    this.maxAgeMs = options.maxAgeMs ?? DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS;
+    this.configurePolicy(options);
   }
 
   private static key(peer: string, protocol: string, messageId: string): string {
@@ -241,6 +258,15 @@ export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
   private backoffFor(attempts: number): number {
     const idx = Math.min(Math.max(attempts - 1, 0), this.backoffs.length - 1);
     return this.backoffs[idx];
+  }
+
+  configurePolicy(options: ProtocolOutboxOptions = {}): void {
+    const backoffs = options.backoffs ?? this.backoffs;
+    if (backoffs.length === 0) {
+      throw new Error('ProtocolOutbox: backoffs must be non-empty');
+    }
+    this.backoffs = backoffs;
+    this.maxAgeMs = options.maxAgeMs ?? this.maxAgeMs;
   }
 
   enqueue(
@@ -258,13 +284,13 @@ export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
       existing.lastAttemptAt = now;
       existing.nextAttemptAt = now + this.backoffFor(existing.attempts);
       existing.lastError = error;
-      return { ...existing };
+      return cloneOutboxEntry(existing);
     }
     const entry: ProtocolOutboxEntry = {
       peer,
       protocol,
       messageId,
-      payload,
+      payload: cloneBytes(payload),
       attempts: 1,
       firstFailureAt: now,
       lastAttemptAt: now,
@@ -272,7 +298,7 @@ export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
       lastError: error,
     };
     this.entries.set(key, entry);
-    return { ...entry };
+    return cloneOutboxEntry(entry);
   }
 
   markDelivered(peer: string, protocol: string, messageId: string): boolean {
@@ -287,20 +313,20 @@ export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
     return Array.from(this.entries.values())
       .filter((e) => e.peer === peer)
       .sort((a, b) => a.firstFailureAt - b.firstFailureAt)
-      .map((e) => ({ ...e }));
+      .map(cloneOutboxEntry);
   }
 
   due(now: number): ProtocolOutboxEntry[] {
     return Array.from(this.entries.values())
       .filter((e) => e.nextAttemptAt <= now)
-      .map((e) => ({ ...e }));
+      .map(cloneOutboxEntry);
   }
 
   dropExpired(now: number): ProtocolOutboxEntry[] {
     const dropped: ProtocolOutboxEntry[] = [];
     for (const [key, entry] of this.entries) {
       if (now - entry.firstFailureAt > this.maxAgeMs) {
-        dropped.push({ ...entry });
+        dropped.push(cloneOutboxEntry(entry));
         this.entries.delete(key);
       }
     }
@@ -355,7 +381,7 @@ export class InMemoryMessageIdempotencyStore implements MessageIdempotencyStore 
     const rec = this.records.get(InMemoryMessageIdempotencyStore.key(peer, protocol, messageId, direction));
     if (!rec) return { seen: false };
     return rec.responseBlob !== undefined
-      ? { seen: true, cachedResponse: rec.responseBlob }
+      ? { seen: true, cachedResponse: cloneBytes(rec.responseBlob) }
       : { seen: true };
   }
 
@@ -373,7 +399,7 @@ export class InMemoryMessageIdempotencyStore implements MessageIdempotencyStore 
     }
     const blob =
       response !== undefined && response.length <= RESPONSE_CACHE_BYTES
-        ? response
+        ? cloneBytes(response)
         : undefined;
     this.records.set(key, { responseBlob: blob, ts: this.clock() });
   }

--- a/packages/core/test/proto/reliable-envelope.test.ts
+++ b/packages/core/test/proto/reliable-envelope.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RELIABLE_ENVELOPE_VERSION,
+  decodeReliableEnvelope,
+  encodeReliableEnvelope,
+} from '../../src/proto/reliable-envelope.js';
+
+describe('ReliableEnvelope encode/decode', () => {
+  it('round-trips a small payload with all fields preserved', () => {
+    const payload = new TextEncoder().encode('hello messenger');
+    const encoded = encodeReliableEnvelope({
+      messageId: '00000000-0000-4000-8000-000000000001',
+      version: RELIABLE_ENVELOPE_VERSION,
+      tsMs: 1_700_000_000_000,
+      payload,
+    });
+    const decoded = decodeReliableEnvelope(encoded);
+
+    expect(decoded.messageId).toBe('00000000-0000-4000-8000-000000000001');
+    expect(decoded.version).toBe(RELIABLE_ENVELOPE_VERSION);
+    expect(Number(decoded.tsMs)).toBe(1_700_000_000_000);
+    expect(Array.from(decoded.payload)).toEqual(Array.from(payload));
+  });
+
+  it('round-trips a large binary payload (32 KiB random bytes)', () => {
+    // Realistic for a `/query-remote` SPARQL result before it bumps
+    // up against the 256 KiB cache cutoff.
+    const payload = new Uint8Array(32 * 1024);
+    for (let i = 0; i < payload.length; i++) payload[i] = i % 256;
+    const encoded = encodeReliableEnvelope({
+      messageId: 'q-1',
+      version: 1,
+      tsMs: 1,
+      payload,
+    });
+    const decoded = decodeReliableEnvelope(encoded);
+    expect(decoded.payload.length).toBe(payload.length);
+    // Spot-check a few bytes — full equality on 32 KiB would generate
+    // noisy failure output but byte-level equality is implied by the
+    // length check + proto's bytes field semantics.
+    expect(decoded.payload[0]).toBe(0);
+    expect(decoded.payload[255]).toBe(255);
+    expect(decoded.payload[1024]).toBe(0);
+  });
+
+  it('preserves an empty payload', () => {
+    const encoded = encodeReliableEnvelope({
+      messageId: 'empty',
+      version: 1,
+      tsMs: 1,
+      payload: new Uint8Array(0),
+    });
+    const decoded = decodeReliableEnvelope(encoded);
+    expect(decoded.payload.length).toBe(0);
+    expect(decoded.messageId).toBe('empty');
+  });
+});

--- a/packages/core/test/protocol-outbox.test.ts
+++ b/packages/core/test/protocol-outbox.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS,
+  InMemoryMessageIdempotencyStore,
+  InMemoryProtocolOutboxStore,
+  ProtocolOutbox,
+} from '../src/protocol-outbox.js';
+import { RESPONSE_CACHE_BYTES } from '../src/messenger-types.js';
+
+const PEER_A = '12D3KooWMilesPlaceholder';
+const PEER_B = '12D3KooWLexPlaceholder';
+const PROTO = '/dkg/10.0.1/message';
+const MSG_1 = '00000000-0000-4000-8000-000000000001';
+const MSG_2 = '00000000-0000-4000-8000-000000000002';
+const PAYLOAD = new TextEncoder().encode('payload-bytes');
+
+function fixture() {
+  const store = new InMemoryProtocolOutboxStore();
+  const outbox = new ProtocolOutbox(store);
+  return { store, outbox };
+}
+
+describe('ProtocolOutbox.enqueueFailure', () => {
+  it('creates a new entry on first failure with default backoff', () => {
+    const { outbox } = fixture();
+    const t0 = 1_000_000;
+    const entry = outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'reset', t0);
+
+    expect(entry.peer).toBe(PEER_A);
+    expect(entry.protocol).toBe(PROTO);
+    expect(entry.messageId).toBe(MSG_1);
+    expect(entry.attempts).toBe(1);
+    expect(entry.firstFailureAt).toBe(t0);
+    expect(entry.lastAttemptAt).toBe(t0);
+    expect(entry.nextAttemptAt).toBe(t0 + DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS[0]);
+    expect(entry.lastError).toBe('reset');
+  });
+
+  it('bumps attempts and reschedules on repeat failure for the same key', () => {
+    const { outbox } = fixture();
+    const t0 = 1_000_000;
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'first', t0);
+    const second = outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'second', t0 + 2000);
+
+    expect(second.attempts).toBe(2);
+    expect(second.firstFailureAt).toBe(t0);
+    expect(second.lastAttemptAt).toBe(t0 + 2000);
+    expect(second.nextAttemptAt).toBe(t0 + 2000 + DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS[1]);
+    expect(second.lastError).toBe('second');
+  });
+
+  it('treats different protocols on the same peer as independent entries', () => {
+    const { outbox } = fixture();
+    outbox.enqueueFailure(PEER_A, '/dkg/10.0.1/message', MSG_1, PAYLOAD, 'a', 1000);
+    outbox.enqueueFailure(PEER_A, '/dkg/10.0.1/skill_request', MSG_1, PAYLOAD, 'b', 1000);
+    expect(outbox.size()).toBe(2);
+  });
+
+  it('treats different messageIds as independent entries', () => {
+    const { outbox } = fixture();
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'a', 1000);
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_2, PAYLOAD, 'b', 1000);
+    expect(outbox.size()).toBe(2);
+  });
+});
+
+describe('ProtocolOutbox.markDelivered + hasEntry', () => {
+  it('markDelivered removes the entry and returns true', () => {
+    const { outbox } = fixture();
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
+    expect(outbox.hasEntry(PEER_A, PROTO, MSG_1)).toBe(true);
+    expect(outbox.markDelivered(PEER_A, PROTO, MSG_1)).toBe(true);
+    expect(outbox.hasEntry(PEER_A, PROTO, MSG_1)).toBe(false);
+  });
+
+  it('markDelivered returns false when no entry exists (first-attempt success)', () => {
+    const { outbox } = fixture();
+    expect(outbox.markDelivered(PEER_A, PROTO, MSG_1)).toBe(false);
+  });
+
+  it('hasEntry is the stale-snapshot guard required by the substrate contract', () => {
+    // Models the rc9 #538 race: two sibling flushes both got the same
+    // entry from `pendingFor`, one completed delivery + markDelivered,
+    // the other races to retry. The second MUST check `hasEntry` after
+    // `tryBeginAttempt` returns true, because tryBeginAttempt only
+    // guards against TRULY concurrent attempts, not stale-snapshot-
+    // after-completion.
+    const { outbox } = fixture();
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
+    expect(outbox.tryBeginAttempt(PEER_A, PROTO, MSG_1)).toBe(true);
+    // Sibling flush completes delivery in between.
+    outbox.markDelivered(PEER_A, PROTO, MSG_1);
+    // Caller MUST check `hasEntry` and bail.
+    expect(outbox.hasEntry(PEER_A, PROTO, MSG_1)).toBe(false);
+    outbox.endAttempt(PEER_A, PROTO, MSG_1);
+  });
+});
+
+describe('ProtocolOutbox.tryBeginAttempt / endAttempt', () => {
+  it('returns true exactly once for concurrent attempts on the same key', () => {
+    const { outbox } = fixture();
+    expect(outbox.tryBeginAttempt(PEER_A, PROTO, MSG_1)).toBe(true);
+    expect(outbox.tryBeginAttempt(PEER_A, PROTO, MSG_1)).toBe(false);
+    outbox.endAttempt(PEER_A, PROTO, MSG_1);
+    expect(outbox.tryBeginAttempt(PEER_A, PROTO, MSG_1)).toBe(true);
+  });
+
+  it('different keys can hold inflight slots simultaneously', () => {
+    const { outbox } = fixture();
+    expect(outbox.tryBeginAttempt(PEER_A, PROTO, MSG_1)).toBe(true);
+    expect(outbox.tryBeginAttempt(PEER_A, PROTO, MSG_2)).toBe(true);
+    expect(outbox.tryBeginAttempt(PEER_B, PROTO, MSG_1)).toBe(true);
+  });
+});
+
+describe('ProtocolOutbox.due / pendingFor', () => {
+  it('due returns entries whose nextAttemptAt is at or before now', () => {
+    const { outbox } = fixture();
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
+    const expectedNext = 1000 + DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS[0];
+    expect(outbox.due(expectedNext - 1)).toHaveLength(0);
+    expect(outbox.due(expectedNext)).toHaveLength(1);
+  });
+
+  it('pendingFor returns all entries for a peer in firstFailureAt ascending order', () => {
+    const { outbox } = fixture();
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_2, PAYLOAD, 'e', 2000);
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
+    outbox.enqueueFailure(PEER_B, PROTO, MSG_1, PAYLOAD, 'e', 500);
+    const peerA = outbox.pendingFor(PEER_A);
+    expect(peerA.map((e) => e.messageId)).toEqual([MSG_1, MSG_2]);
+    expect(outbox.pendingFor(PEER_B)).toHaveLength(1);
+  });
+});
+
+describe('ProtocolOutbox.dropExpired', () => {
+  it('drops entries older than the default 24h maxAgeMs', () => {
+    const { outbox } = fixture();
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 0);
+    const past24h = 24 * 60 * 60 * 1000 + 1;
+    const dropped = outbox.dropExpired(past24h);
+    expect(dropped).toHaveLength(1);
+    expect(outbox.size()).toBe(0);
+  });
+
+  it('does not drop entries within the maxAgeMs window', () => {
+    const { outbox } = fixture();
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 0);
+    const dropped = outbox.dropExpired(24 * 60 * 60 * 1000 - 1);
+    expect(dropped).toHaveLength(0);
+    expect(outbox.size()).toBe(1);
+  });
+});
+
+describe('ProtocolOutbox construction', () => {
+  it('rejects empty backoff arrays at construction time', () => {
+    const store = new InMemoryProtocolOutboxStore();
+    expect(() => new ProtocolOutbox(store, { backoffs: [] })).toThrow(
+      /backoffs must be non-empty/,
+    );
+  });
+
+  it('caps backoff at the last ladder rung for attempts beyond the ladder length', () => {
+    const store = new InMemoryProtocolOutboxStore({ backoffs: [10, 20, 30] });
+    const outbox = new ProtocolOutbox(store, { backoffs: [10, 20, 30] });
+    // Simulate 5 failures — should cap at 30 (last rung).
+    let lastEntry = outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 0);
+    for (let i = 0; i < 4; i++) {
+      lastEntry = outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', lastEntry.lastAttemptAt);
+    }
+    expect(lastEntry.attempts).toBe(5);
+    // Last attempt happened at t = lastEntry.lastAttemptAt; nextAttemptAt
+    // == lastAttemptAt + 30 (last-rung cap).
+    expect(lastEntry.nextAttemptAt - lastEntry.lastAttemptAt).toBe(30);
+  });
+});
+
+describe('InMemoryMessageIdempotencyStore', () => {
+  it('check returns { seen: false } for unrecorded triples', () => {
+    const store = new InMemoryMessageIdempotencyStore();
+    expect(store.check(PEER_A, PROTO, MSG_1, 'in')).toEqual({ seen: false });
+  });
+
+  it('check returns the cached response after record with a small payload', () => {
+    const store = new InMemoryMessageIdempotencyStore();
+    const resp = new TextEncoder().encode('ack');
+    store.record(PEER_A, PROTO, MSG_1, 'in', resp);
+    const result = store.check(PEER_A, PROTO, MSG_1, 'in');
+    expect(result.seen).toBe(true);
+    expect(result.seen && result.cachedResponse).toEqual(resp);
+  });
+
+  it('check returns { seen: true } without cachedResponse for mark-only (oversize) responses', () => {
+    const store = new InMemoryMessageIdempotencyStore();
+    const oversize = new Uint8Array(RESPONSE_CACHE_BYTES + 1);
+    store.record(PEER_A, PROTO, MSG_1, 'in', oversize);
+    const result = store.check(PEER_A, PROTO, MSG_1, 'in');
+    expect(result).toEqual({ seen: true });
+  });
+
+  it('record with undefined response stores mark-only sentinel', () => {
+    const store = new InMemoryMessageIdempotencyStore();
+    store.record(PEER_A, PROTO, MSG_1, 'in');
+    expect(store.check(PEER_A, PROTO, MSG_1, 'in')).toEqual({ seen: true });
+  });
+
+  it('direction partitions the namespace (Codex #534 lesson lifted)', () => {
+    const store = new InMemoryMessageIdempotencyStore();
+    store.record(PEER_A, PROTO, MSG_1, 'in');
+    expect(store.check(PEER_A, PROTO, MSG_1, 'in')).toEqual({ seen: true });
+    expect(store.check(PEER_A, PROTO, MSG_1, 'out')).toEqual({ seen: false });
+  });
+
+  it('record is idempotent — re-recording the same triple does not throw', () => {
+    const store = new InMemoryMessageIdempotencyStore();
+    const resp = new TextEncoder().encode('ack');
+    store.record(PEER_A, PROTO, MSG_1, 'in', resp);
+    // Re-record with a different response — first record wins (matches
+    // SQLite ON CONFLICT DO NOTHING semantics).
+    store.record(PEER_A, PROTO, MSG_1, 'in', new TextEncoder().encode('ack-v2'));
+    const result = store.check(PEER_A, PROTO, MSG_1, 'in');
+    expect(result.seen && result.cachedResponse).toEqual(resp);
+  });
+
+  it('pruneOlderThan drops records whose ts < threshold', () => {
+    let now = 1_000_000;
+    const store = new InMemoryMessageIdempotencyStore({ clock: () => now });
+    store.record(PEER_A, PROTO, MSG_1, 'in');
+    now = 2_000_000;
+    store.record(PEER_A, PROTO, MSG_2, 'in');
+    expect(store.pruneOlderThan(1_500_000)).toBe(1);
+    expect(store.check(PEER_A, PROTO, MSG_1, 'in')).toEqual({ seen: false });
+    expect(store.check(PEER_A, PROTO, MSG_2, 'in')).toEqual({ seen: true });
+  });
+});

--- a/packages/core/test/protocol-outbox.test.ts
+++ b/packages/core/test/protocol-outbox.test.ts
@@ -62,6 +62,21 @@ describe('ProtocolOutbox.enqueueFailure', () => {
     outbox.enqueueFailure(PEER_A, PROTO, MSG_2, PAYLOAD, 'b', 1000);
     expect(outbox.size()).toBe(2);
   });
+
+  it('snapshots payload bytes on write and read', () => {
+    const { outbox } = fixture();
+    const payload = new Uint8Array([1, 2, 3]);
+    const entry = outbox.enqueueFailure(PEER_A, PROTO, MSG_1, payload, 'e', 1000);
+
+    payload[0] = 9;
+    entry.payload[1] = 8;
+
+    const pending = outbox.pendingFor(PEER_A);
+    expect(Array.from(pending[0].payload)).toEqual([1, 2, 3]);
+
+    pending[0].payload[2] = 7;
+    expect(Array.from(outbox.due(6000)[0].payload)).toEqual([1, 2, 3]);
+  });
 });
 
 describe('ProtocolOutbox.markDelivered + hasEntry', () => {
@@ -150,6 +165,15 @@ describe('ProtocolOutbox.dropExpired', () => {
     expect(dropped).toHaveLength(0);
     expect(outbox.size()).toBe(1);
   });
+
+  it('applies ProtocolOutbox maxAgeMs to the wrapped store', () => {
+    const store = new InMemoryProtocolOutboxStore();
+    const outbox = new ProtocolOutbox(store, { maxAgeMs: 60 });
+    outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 0);
+
+    expect(outbox.dropExpired(60)).toHaveLength(0);
+    expect(outbox.dropExpired(61)).toHaveLength(1);
+  });
 });
 
 describe('ProtocolOutbox construction', () => {
@@ -161,7 +185,7 @@ describe('ProtocolOutbox construction', () => {
   });
 
   it('caps backoff at the last ladder rung for attempts beyond the ladder length', () => {
-    const store = new InMemoryProtocolOutboxStore({ backoffs: [10, 20, 30] });
+    const store = new InMemoryProtocolOutboxStore();
     const outbox = new ProtocolOutbox(store, { backoffs: [10, 20, 30] });
     // Simulate 5 failures — should cap at 30 (last rung).
     let lastEntry = outbox.enqueueFailure(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 0);
@@ -188,6 +212,22 @@ describe('InMemoryMessageIdempotencyStore', () => {
     const result = store.check(PEER_A, PROTO, MSG_1, 'in');
     expect(result.seen).toBe(true);
     expect(result.seen && result.cachedResponse).toEqual(resp);
+  });
+
+  it('snapshots cached responses on write and read', () => {
+    const store = new InMemoryMessageIdempotencyStore();
+    const resp = new Uint8Array([1, 2, 3]);
+    store.record(PEER_A, PROTO, MSG_1, 'in', resp);
+
+    resp[0] = 9;
+    const first = store.check(PEER_A, PROTO, MSG_1, 'in');
+    expect(first.seen && Array.from(first.cachedResponse ?? [])).toEqual([1, 2, 3]);
+
+    if (first.seen && first.cachedResponse) {
+      first.cachedResponse[1] = 8;
+    }
+    const second = store.check(PEER_A, PROTO, MSG_1, 'in');
+    expect(second.seen && Array.from(second.cachedResponse ?? [])).toEqual([1, 2, 3]);
   });
 
   it('check returns { seen: true } without cachedResponse for mark-only (oversize) responses', () => {

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -469,15 +469,13 @@ export class DashboardDB {
     this.db.exec(`DELETE FROM chat_messages WHERE ts < ${cutoff}`);
     this.db.exec(`DELETE FROM chat_persistence_jobs WHERE updated_at < ${cutoff} AND status IN ('stored', 'failed')`);
     this.db.exec(`DELETE FROM notifications WHERE ts < ${cutoff}`);
-    // Universal Messenger substrate tables. Shorter TTL than the
-    // 90-day operator retention: 24h is plenty for both idempotency
-    // (no realistic dedup window beyond a day) and outbox (entries
-    // older than 24h have hit `maxAgeMs` and are dropped by the
-    // substrate's own `dropExpired` tick anyway — this is the
-    // belt-and-braces sweep for crash-recovered state).
+    // Universal Messenger idempotency table. Shorter TTL than the
+    // 90-day operator retention: no realistic dedup window extends
+    // beyond a day. The protocol_outbox table is intentionally not
+    // pruned here; its max-age is store policy and must be applied
+    // by SqliteProtocolOutboxStore.dropExpired().
     const messengerCutoff = Date.now() - 24 * 60 * 60 * 1000;
     this.db.exec(`DELETE FROM message_idempotency WHERE ts < ${messengerCutoff}`);
-    this.db.exec(`DELETE FROM protocol_outbox WHERE first_failure_at < ${messengerCutoff}`);
   }
 
   // --- Prepared statements (lazy-initialized) ---
@@ -1614,16 +1612,12 @@ export class SqliteMessageIdempotencyStore implements MessageIdempotencyStore {
       | { response_blob: Buffer | null }
       | undefined;
     if (!row) return { seen: false };
-    // better-sqlite3 returns Node Buffer for BLOB columns; convert to
-    // Uint8Array view (zero-copy) so the substrate stays Buffer-free.
+    // better-sqlite3 returns Node Buffer for BLOB columns; copy into a
+    // Uint8Array so callers cannot mutate the cached DB snapshot.
     if (row.response_blob === null) return { seen: true };
     return {
       seen: true,
-      cachedResponse: new Uint8Array(
-        row.response_blob.buffer,
-        row.response_blob.byteOffset,
-        row.response_blob.byteLength,
-      ),
+      cachedResponse: new Uint8Array(row.response_blob),
     };
   }
 
@@ -1641,7 +1635,7 @@ export class SqliteMessageIdempotencyStore implements MessageIdempotencyStore {
     // design decision — no per-protocol/per-call knob.
     const blob =
       response !== undefined && response.length <= RESPONSE_CACHE_BYTES
-        ? Buffer.from(response.buffer, response.byteOffset, response.byteLength)
+        ? Buffer.from(response)
         : null;
     // Targeted ON CONFLICT — never the broader INSERT OR IGNORE which
     // would silently swallow unrelated constraint violations (the
@@ -1706,13 +1700,17 @@ export interface SqliteProtocolOutboxStoreOptions {
 
 export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
   private readonly db: Database.Database;
-  private readonly maxAgeMs: number;
-  private readonly backoffFor: (attempts: number) => number;
+  private maxAgeMs = 24 * 60 * 60 * 1000;
+  private backoffFor: (attempts: number) => number = (_attempts) => 5_000;
 
   constructor(dashboard: DashboardDB, options: SqliteProtocolOutboxStoreOptions = {}) {
     this.db = dashboard.db;
-    this.maxAgeMs = options.maxAgeMs ?? 24 * 60 * 60 * 1000;
-    this.backoffFor = options.backoffFor ?? ((_attempts) => 5_000);
+    this.configurePolicy(options);
+  }
+
+  configurePolicy(options: SqliteProtocolOutboxStoreOptions = {}): void {
+    this.maxAgeMs = options.maxAgeMs ?? this.maxAgeMs;
+    this.backoffFor = options.backoffFor ?? this.backoffFor;
   }
 
   enqueue(
@@ -1756,11 +1754,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
         peer,
         protocol,
         messageId,
-        payload: new Uint8Array(
-          existing.payload.buffer,
-          existing.payload.byteOffset,
-          existing.payload.byteLength,
-        ),
+        payload: new Uint8Array(existing.payload),
         attempts: newAttempts,
         firstFailureAt: existing.first_failure_at,
         lastAttemptAt: now,
@@ -1771,7 +1765,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
 
     const attempts = 1;
     const nextAttemptAt = now + this.backoffFor(attempts);
-    const blob = Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength);
+    const blob = Buffer.from(payload);
     this.db
       .prepare(
         `INSERT INTO protocol_outbox
@@ -1784,7 +1778,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
       peer,
       protocol,
       messageId,
-      payload,
+      payload: new Uint8Array(blob),
       attempts,
       firstFailureAt: now,
       lastAttemptAt: now,
@@ -1892,7 +1886,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
       peer: row.peer_id,
       protocol: row.protocol,
       messageId: row.message_id,
-      payload: new Uint8Array(row.payload.buffer, row.payload.byteOffset, row.payload.byteLength),
+      payload: new Uint8Array(row.payload),
       attempts: row.attempts,
       firstFailureAt: row.first_failure_at,
       lastAttemptAt: row.last_attempt_at,

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -1,7 +1,15 @@
 import Database from 'better-sqlite3';
 import { join } from 'node:path';
+import {
+  RESPONSE_CACHE_BYTES,
+  type IdempotencyCheckResult,
+  type MessageDirection,
+  type MessageIdempotencyStore,
+  type ProtocolOutboxEntry,
+  type ProtocolOutboxStore,
+} from '@origintrail-official/dkg-core';
 
-const SCHEMA_VERSION = 11;
+const SCHEMA_VERSION = 12;
 const DEFAULT_RETENTION_DAYS = 90;
 
 export interface DashboardDBOptions {
@@ -356,6 +364,90 @@ export class DashboardDB {
       `);
     }
 
+    if (version < 12) {
+      // Universal Messenger substrate (rc.9 plan PR-1).
+      //
+      // Two new tables back the substrate's `MessageIdempotencyStore`
+      // and `ProtocolOutboxStore` ports — protocol-agnostic
+      // counterparts to the chat-specific `idx_chat_msgid` (V11) and
+      // the in-memory `MessageOutbox` (rc.8). Adding them at V12
+      // before any caller migrates onto Messenger (PR-3+) so the
+      // tables are present + tested by the time the substrate
+      // actually wires them.
+      //
+      // The substrate's design constraint: adding a new short-message
+      // protocol requires no new storage. A single
+      // `message_idempotency` row + a single `protocol_outbox` row
+      // describes any peer-to-peer short message regardless of the
+      // protocol prefix (`/dkg/10.0.1/message`, `/dkg/10.0.1/skill_request`,
+      // `/dkg/10.0.1/swm-sender-key`, etc.) — the `protocol` column
+      // partitions the namespace.
+      //
+      // `message_idempotency` design:
+      //   - PRIMARY KEY = (peer_id, protocol, message_id, direction).
+      //     `direction` separates inbound vs outbound so a sender's
+      //     "did I deliver this" cache lives in a distinct namespace
+      //     from a receiver's "did I process this" dedup table — the
+      //     Codex #534 lesson generalised.
+      //   - `response_blob BLOB` holds responses up to
+      //     `RESPONSE_CACHE_BYTES` (256 KiB) for idempotent re-delivery.
+      //     Larger responses store `response_blob = NULL` with the
+      //     actual size in `response_size` (mark-only); duplicate
+      //     receives in that case surface `RESPONSE_GONE` to the
+      //     sender's caller.
+      //   - `ts` is the record-time wall-clock, used by the periodic
+      //     prune (24h TTL default).
+      //
+      // `protocol_outbox` design:
+      //   - PRIMARY KEY = (peer_id, protocol, message_id). One in-
+      //     flight retry slot per `(peer, protocol, message)` tuple.
+      //   - `payload BLOB` stores the envelope-wrapped wire bytes
+      //     (i.e. the `ReliableEnvelope` proto output, not the raw
+      //     application payload), so retries replay byte-identical
+      //     frames without re-encoding.
+      //   - `idx_outbox_next_attempt` indexes the periodic-tick query
+      //     (`SELECT ... WHERE next_attempt_at <= ?`); the
+      //     opportunistic-flush query
+      //     (`SELECT ... WHERE peer_id = ?`) uses an implicit scan
+      //     on the PK prefix, which is fast enough at expected
+      //     queue sizes (~tens of entries per peer).
+      //
+      // No data migration: pure additive. The chat-specific
+      // `idx_chat_msgid` from V11 stays in place — PR-3 will drop
+      // it (V13) once chat migrates onto the substrate and
+      // `message_id` is enforced via `message_idempotency` instead.
+      // V13 will also preserve `chat_messages.message_id` as
+      // nullable + unwritten for rollback safety.
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS message_idempotency (
+          peer_id TEXT NOT NULL,
+          protocol TEXT NOT NULL,
+          message_id TEXT NOT NULL,
+          direction TEXT NOT NULL CHECK (direction IN ('in', 'out')),
+          response_blob BLOB,
+          response_size INTEGER NOT NULL DEFAULT 0,
+          ts INTEGER NOT NULL,
+          PRIMARY KEY (peer_id, protocol, message_id, direction)
+        );
+        CREATE INDEX IF NOT EXISTS idx_idem_ts ON message_idempotency(ts);
+
+        CREATE TABLE IF NOT EXISTS protocol_outbox (
+          peer_id TEXT NOT NULL,
+          protocol TEXT NOT NULL,
+          message_id TEXT NOT NULL,
+          payload BLOB NOT NULL,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          first_failure_at INTEGER NOT NULL,
+          last_attempt_at INTEGER NOT NULL,
+          next_attempt_at INTEGER NOT NULL,
+          last_error TEXT,
+          PRIMARY KEY (peer_id, protocol, message_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_outbox_next_attempt
+          ON protocol_outbox(next_attempt_at);
+      `);
+    }
+
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
 
     const savedRetention = this.db.prepare("SELECT value FROM settings WHERE key = 'retentionDays'").get() as { value: string } | undefined;
@@ -377,6 +469,15 @@ export class DashboardDB {
     this.db.exec(`DELETE FROM chat_messages WHERE ts < ${cutoff}`);
     this.db.exec(`DELETE FROM chat_persistence_jobs WHERE updated_at < ${cutoff} AND status IN ('stored', 'failed')`);
     this.db.exec(`DELETE FROM notifications WHERE ts < ${cutoff}`);
+    // Universal Messenger substrate tables. Shorter TTL than the
+    // 90-day operator retention: 24h is plenty for both idempotency
+    // (no realistic dedup window beyond a day) and outbox (entries
+    // older than 24h have hit `maxAgeMs` and are dropped by the
+    // substrate's own `dropExpired` tick anyway — this is the
+    // belt-and-braces sweep for crash-recovered state).
+    const messengerCutoff = Date.now() - 24 * 60 * 60 * 1000;
+    this.db.exec(`DELETE FROM message_idempotency WHERE ts < ${messengerCutoff}`);
+    this.db.exec(`DELETE FROM protocol_outbox WHERE first_failure_at < ${messengerCutoff}`);
   }
 
   // --- Prepared statements (lazy-initialized) ---
@@ -1464,6 +1565,340 @@ export class DashboardDB {
 
   close(): void {
     this.db.close();
+  }
+}
+
+// --- Universal Messenger substrate stores (rc.9 plan PR-1) ---
+
+/**
+ * SQLite-backed `MessageIdempotencyStore` against the V12
+ * `message_idempotency` table in `DashboardDB`. Receiver-side dedup
+ * cache + sender-side "did we deliver this" cache, keyed by
+ * `(peer, protocol, message_id, direction)`.
+ *
+ * Constructed against an already-opened `DashboardDB` so all DKG
+ * persistence shares a single SQLite file (one WAL, one fsync, one
+ * pragma surface). Doesn't open the DB itself — the daemon's
+ * `lifecycle.ts` owns DB lifecycle and hands one in here in PR-2.
+ *
+ * Response caching policy lives in `RESPONSE_CACHE_BYTES` (256 KiB
+ * fixed limit, exported from `@origintrail-official/dkg-core`).
+ * Responses up to the limit are stored inline in `response_blob`;
+ * larger responses store `response_blob = NULL` with the actual
+ * size in `response_size` (mark-only). Duplicate receives whose
+ * original was mark-only surface as `RESPONSE_GONE` to the sender
+ * — see `RESPONSE_GONE_MARKER` for the canonical signal string.
+ */
+export class SqliteMessageIdempotencyStore implements MessageIdempotencyStore {
+  private readonly db: Database.Database;
+  private readonly clock: () => number;
+
+  /** @param clock injectable for deterministic tests. Defaults to `Date.now`. */
+  constructor(dashboard: DashboardDB, options: { clock?: () => number } = {}) {
+    this.db = dashboard.db;
+    this.clock = options.clock ?? (() => Date.now());
+  }
+
+  check(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    direction: MessageDirection,
+  ): IdempotencyCheckResult {
+    const row = this.db
+      .prepare(
+        `SELECT response_blob FROM message_idempotency
+         WHERE peer_id = ? AND protocol = ? AND message_id = ? AND direction = ?`,
+      )
+      .get(peer, protocol, messageId, direction) as
+      | { response_blob: Buffer | null }
+      | undefined;
+    if (!row) return { seen: false };
+    // better-sqlite3 returns Node Buffer for BLOB columns; convert to
+    // Uint8Array view (zero-copy) so the substrate stays Buffer-free.
+    if (row.response_blob === null) return { seen: true };
+    return {
+      seen: true,
+      cachedResponse: new Uint8Array(
+        row.response_blob.buffer,
+        row.response_blob.byteOffset,
+        row.response_blob.byteLength,
+      ),
+    };
+  }
+
+  record(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    direction: MessageDirection,
+    response?: Uint8Array,
+  ): void {
+    const responseSize = response?.length ?? 0;
+    // Mark-only when over the cache limit. Stores NULL blob + the
+    // actual size, so a future duplicate receive can surface
+    // `RESPONSE_GONE`. The 256 KiB cutoff is the rc.9 plan's locked
+    // design decision — no per-protocol/per-call knob.
+    const blob =
+      response !== undefined && response.length <= RESPONSE_CACHE_BYTES
+        ? Buffer.from(response.buffer, response.byteOffset, response.byteLength)
+        : null;
+    // Targeted ON CONFLICT — never the broader INSERT OR IGNORE which
+    // would silently swallow unrelated constraint violations (the
+    // Codex #534 lesson). Idempotent re-record on the same key is a
+    // no-op; any other constraint violation surfaces as a thrown
+    // SqliteError so the substrate's bug doesn't disguise itself as
+    // a normal duplicate.
+    this.db
+      .prepare(
+        `INSERT INTO message_idempotency
+           (peer_id, protocol, message_id, direction, response_blob, response_size, ts)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (peer_id, protocol, message_id, direction) DO NOTHING`,
+      )
+      .run(peer, protocol, messageId, direction, blob, responseSize, this.clock());
+  }
+
+  pruneOlderThan(tsMs: number): number {
+    const result = this.db
+      .prepare(`DELETE FROM message_idempotency WHERE ts < ?`)
+      .run(tsMs);
+    return result.changes;
+  }
+}
+
+/**
+ * SQLite-backed `ProtocolOutboxStore` against the V12
+ * `protocol_outbox` table. Sender-side durable retry queue, keyed
+ * by `(peer, protocol, message_id)`. The substrate's reliability
+ * floor: a daemon crash mid-retry doesn't lose the message — the
+ * next startup's `Messenger.processOutboxTick` picks up exactly
+ * where the crash left off (modulo the in-flight bytes that died
+ * with the process, which is documented as the "in-flight queue
+ * caveat" in CHANGELOG for rc.9).
+ *
+ * The backoff ladder + max-age are NOT stored in SQL — they live
+ * on the wrapping `ProtocolOutbox` in `packages/core`, and only
+ * the resulting `next_attempt_at` and `first_failure_at` timestamps
+ * land in the table. This keeps the schema independent of policy
+ * changes: bumping the ladder doesn't require a migration.
+ *
+ * Constructor takes a `maxAgeMs` so `dropExpired` can apply it
+ * directly in SQL (avoiding a full table read).
+ */
+export interface SqliteProtocolOutboxStoreOptions {
+  /**
+   * Max age (ms) from `firstFailureAt` before `dropExpired(now)`
+   * evicts an entry. Defaults to 24h. Mirrors the wrapping
+   * `ProtocolOutbox`'s `maxAgeMs` so both layers agree.
+   */
+  maxAgeMs?: number;
+  /**
+   * Function that returns the backoff (ms) to apply for an entry
+   * about to bump to `attempts`. The schema does NOT store the
+   * ladder; PR-2's `lifecycle.ts` wiring passes the wrapping
+   * `ProtocolOutbox`'s `backoffFor` method here so policy lives in
+   * one place. Defaults to a flat 5s backoff so the store works
+   * standalone in tests + before the wrapping outbox is wired.
+   */
+  backoffFor?: (attempts: number) => number;
+}
+
+export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
+  private readonly db: Database.Database;
+  private readonly maxAgeMs: number;
+  private readonly backoffFor: (attempts: number) => number;
+
+  constructor(dashboard: DashboardDB, options: SqliteProtocolOutboxStoreOptions = {}) {
+    this.db = dashboard.db;
+    this.maxAgeMs = options.maxAgeMs ?? 24 * 60 * 60 * 1000;
+    this.backoffFor = options.backoffFor ?? ((_attempts) => 5_000);
+  }
+
+  enqueue(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    payload: Uint8Array,
+    error: string,
+    now: number,
+  ): ProtocolOutboxEntry {
+    const existing = this.db
+      .prepare(
+        `SELECT * FROM protocol_outbox
+         WHERE peer_id = ? AND protocol = ? AND message_id = ?`,
+      )
+      .get(peer, protocol, messageId) as
+      | {
+          peer_id: string;
+          protocol: string;
+          message_id: string;
+          payload: Buffer;
+          attempts: number;
+          first_failure_at: number;
+          last_attempt_at: number;
+          next_attempt_at: number;
+          last_error: string | null;
+        }
+      | undefined;
+
+    if (existing) {
+      const newAttempts = existing.attempts + 1;
+      const nextAttemptAt = now + this.backoffFor(newAttempts);
+      this.db
+        .prepare(
+          `UPDATE protocol_outbox
+           SET attempts = ?, last_attempt_at = ?, next_attempt_at = ?, last_error = ?
+           WHERE peer_id = ? AND protocol = ? AND message_id = ?`,
+        )
+        .run(newAttempts, now, nextAttemptAt, error, peer, protocol, messageId);
+      return {
+        peer,
+        protocol,
+        messageId,
+        payload: new Uint8Array(
+          existing.payload.buffer,
+          existing.payload.byteOffset,
+          existing.payload.byteLength,
+        ),
+        attempts: newAttempts,
+        firstFailureAt: existing.first_failure_at,
+        lastAttemptAt: now,
+        nextAttemptAt,
+        lastError: error,
+      };
+    }
+
+    const attempts = 1;
+    const nextAttemptAt = now + this.backoffFor(attempts);
+    const blob = Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength);
+    this.db
+      .prepare(
+        `INSERT INTO protocol_outbox
+           (peer_id, protocol, message_id, payload, attempts,
+            first_failure_at, last_attempt_at, next_attempt_at, last_error)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(peer, protocol, messageId, blob, attempts, now, now, nextAttemptAt, error);
+    return {
+      peer,
+      protocol,
+      messageId,
+      payload,
+      attempts,
+      firstFailureAt: now,
+      lastAttemptAt: now,
+      nextAttemptAt,
+      lastError: error,
+    };
+  }
+
+  markDelivered(peer: string, protocol: string, messageId: string): boolean {
+    const result = this.db
+      .prepare(
+        `DELETE FROM protocol_outbox
+         WHERE peer_id = ? AND protocol = ? AND message_id = ?`,
+      )
+      .run(peer, protocol, messageId);
+    return result.changes > 0;
+  }
+
+  hasEntry(peer: string, protocol: string, messageId: string): boolean {
+    const row = this.db
+      .prepare(
+        `SELECT 1 FROM protocol_outbox
+         WHERE peer_id = ? AND protocol = ? AND message_id = ? LIMIT 1`,
+      )
+      .get(peer, protocol, messageId) as { 1: number } | undefined;
+    return row !== undefined;
+  }
+
+  pendingFor(peer: string): ProtocolOutboxEntry[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM protocol_outbox WHERE peer_id = ? ORDER BY first_failure_at ASC`,
+      )
+      .all(peer) as Array<{
+      peer_id: string;
+      protocol: string;
+      message_id: string;
+      payload: Buffer;
+      attempts: number;
+      first_failure_at: number;
+      last_attempt_at: number;
+      next_attempt_at: number;
+      last_error: string | null;
+    }>;
+    return rows.map(SqliteProtocolOutboxStore.rowToEntry);
+  }
+
+  due(now: number): ProtocolOutboxEntry[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM protocol_outbox WHERE next_attempt_at <= ?`,
+      )
+      .all(now) as Array<{
+      peer_id: string;
+      protocol: string;
+      message_id: string;
+      payload: Buffer;
+      attempts: number;
+      first_failure_at: number;
+      last_attempt_at: number;
+      next_attempt_at: number;
+      last_error: string | null;
+    }>;
+    return rows.map(SqliteProtocolOutboxStore.rowToEntry);
+  }
+
+  dropExpired(now: number): ProtocolOutboxEntry[] {
+    const cutoff = now - this.maxAgeMs;
+    const rows = this.db
+      .prepare(`SELECT * FROM protocol_outbox WHERE first_failure_at < ?`)
+      .all(cutoff) as Array<{
+      peer_id: string;
+      protocol: string;
+      message_id: string;
+      payload: Buffer;
+      attempts: number;
+      first_failure_at: number;
+      last_attempt_at: number;
+      next_attempt_at: number;
+      last_error: string | null;
+    }>;
+    this.db.prepare(`DELETE FROM protocol_outbox WHERE first_failure_at < ?`).run(cutoff);
+    return rows.map(SqliteProtocolOutboxStore.rowToEntry);
+  }
+
+  size(): number {
+    const row = this.db.prepare(`SELECT COUNT(*) as c FROM protocol_outbox`).get() as {
+      c: number;
+    };
+    return row.c;
+  }
+
+  private static rowToEntry(row: {
+    peer_id: string;
+    protocol: string;
+    message_id: string;
+    payload: Buffer;
+    attempts: number;
+    first_failure_at: number;
+    last_attempt_at: number;
+    next_attempt_at: number;
+    last_error: string | null;
+  }): ProtocolOutboxEntry {
+    return {
+      peer: row.peer_id,
+      protocol: row.protocol,
+      messageId: row.message_id,
+      payload: new Uint8Array(row.payload.buffer, row.payload.byteOffset, row.payload.byteLength),
+      attempts: row.attempts,
+      firstFailureAt: row.first_failure_at,
+      lastAttemptAt: row.last_attempt_at,
+      nextAttemptAt: row.next_attempt_at,
+      lastError: row.last_error ?? '',
+    };
   }
 }
 

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -1590,11 +1590,25 @@ export class DashboardDB {
 export class SqliteMessageIdempotencyStore implements MessageIdempotencyStore {
   private readonly db: Database.Database;
   private readonly clock: () => number;
+  private readonly checkStmt: Database.Statement;
+  private readonly recordStmt: Database.Statement;
+  private readonly pruneStmt: Database.Statement;
 
   /** @param clock injectable for deterministic tests. Defaults to `Date.now`. */
   constructor(dashboard: DashboardDB, options: { clock?: () => number } = {}) {
     this.db = dashboard.db;
     this.clock = options.clock ?? (() => Date.now());
+    this.checkStmt = this.db.prepare(
+      `SELECT response_blob FROM message_idempotency
+       WHERE peer_id = ? AND protocol = ? AND message_id = ? AND direction = ?`,
+    );
+    this.recordStmt = this.db.prepare(
+      `INSERT INTO message_idempotency
+         (peer_id, protocol, message_id, direction, response_blob, response_size, ts)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (peer_id, protocol, message_id, direction) DO NOTHING`,
+    );
+    this.pruneStmt = this.db.prepare(`DELETE FROM message_idempotency WHERE ts < ?`);
   }
 
   check(
@@ -1603,12 +1617,7 @@ export class SqliteMessageIdempotencyStore implements MessageIdempotencyStore {
     messageId: string,
     direction: MessageDirection,
   ): IdempotencyCheckResult {
-    const row = this.db
-      .prepare(
-        `SELECT response_blob FROM message_idempotency
-         WHERE peer_id = ? AND protocol = ? AND message_id = ? AND direction = ?`,
-      )
-      .get(peer, protocol, messageId, direction) as
+    const row = this.checkStmt.get(peer, protocol, messageId, direction) as
       | { response_blob: Buffer | null }
       | undefined;
     if (!row) return { seen: false };
@@ -1643,20 +1652,11 @@ export class SqliteMessageIdempotencyStore implements MessageIdempotencyStore {
     // no-op; any other constraint violation surfaces as a thrown
     // SqliteError so the substrate's bug doesn't disguise itself as
     // a normal duplicate.
-    this.db
-      .prepare(
-        `INSERT INTO message_idempotency
-           (peer_id, protocol, message_id, direction, response_blob, response_size, ts)
-         VALUES (?, ?, ?, ?, ?, ?, ?)
-         ON CONFLICT (peer_id, protocol, message_id, direction) DO NOTHING`,
-      )
-      .run(peer, protocol, messageId, direction, blob, responseSize, this.clock());
+    this.recordStmt.run(peer, protocol, messageId, direction, blob, responseSize, this.clock());
   }
 
   pruneOlderThan(tsMs: number): number {
-    const result = this.db
-      .prepare(`DELETE FROM message_idempotency WHERE ts < ?`)
-      .run(tsMs);
+    const result = this.pruneStmt.run(tsMs);
     return result.changes;
   }
 }
@@ -1702,9 +1702,55 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
   private readonly db: Database.Database;
   private maxAgeMs = 24 * 60 * 60 * 1000;
   private backoffFor: (attempts: number) => number = (_attempts) => 5_000;
+  private readonly selectEntryStmt: Database.Statement;
+  private readonly updateEntryStmt: Database.Statement;
+  private readonly insertEntryStmt: Database.Statement;
+  private readonly markDeliveredStmt: Database.Statement;
+  private readonly hasEntryStmt: Database.Statement;
+  private readonly pendingForStmt: Database.Statement;
+  private readonly dueStmt: Database.Statement;
+  private readonly selectExpiredStmt: Database.Statement;
+  private readonly deleteExpiredStmt: Database.Statement;
+  private readonly sizeStmt: Database.Statement;
 
   constructor(dashboard: DashboardDB, options: SqliteProtocolOutboxStoreOptions = {}) {
     this.db = dashboard.db;
+    this.selectEntryStmt = this.db.prepare(
+      `SELECT * FROM protocol_outbox
+       WHERE peer_id = ? AND protocol = ? AND message_id = ?`,
+    );
+    this.updateEntryStmt = this.db.prepare(
+      `UPDATE protocol_outbox
+       SET attempts = ?, last_attempt_at = ?, next_attempt_at = ?, last_error = ?
+       WHERE peer_id = ? AND protocol = ? AND message_id = ?`,
+    );
+    this.insertEntryStmt = this.db.prepare(
+      `INSERT INTO protocol_outbox
+         (peer_id, protocol, message_id, payload, attempts,
+          first_failure_at, last_attempt_at, next_attempt_at, last_error)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    this.markDeliveredStmt = this.db.prepare(
+      `DELETE FROM protocol_outbox
+       WHERE peer_id = ? AND protocol = ? AND message_id = ?`,
+    );
+    this.hasEntryStmt = this.db.prepare(
+      `SELECT 1 FROM protocol_outbox
+       WHERE peer_id = ? AND protocol = ? AND message_id = ? LIMIT 1`,
+    );
+    this.pendingForStmt = this.db.prepare(
+      `SELECT * FROM protocol_outbox WHERE peer_id = ? ORDER BY first_failure_at ASC`,
+    );
+    this.dueStmt = this.db.prepare(
+      `SELECT * FROM protocol_outbox WHERE next_attempt_at <= ?`,
+    );
+    this.selectExpiredStmt = this.db.prepare(
+      `SELECT * FROM protocol_outbox WHERE first_failure_at < ?`,
+    );
+    this.deleteExpiredStmt = this.db.prepare(
+      `DELETE FROM protocol_outbox WHERE first_failure_at < ?`,
+    );
+    this.sizeStmt = this.db.prepare(`SELECT COUNT(*) as c FROM protocol_outbox`);
     this.configurePolicy(options);
   }
 
@@ -1721,12 +1767,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
     error: string,
     now: number,
   ): ProtocolOutboxEntry {
-    const existing = this.db
-      .prepare(
-        `SELECT * FROM protocol_outbox
-         WHERE peer_id = ? AND protocol = ? AND message_id = ?`,
-      )
-      .get(peer, protocol, messageId) as
+    const existing = this.selectEntryStmt.get(peer, protocol, messageId) as
       | {
           peer_id: string;
           protocol: string;
@@ -1743,13 +1784,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
     if (existing) {
       const newAttempts = existing.attempts + 1;
       const nextAttemptAt = now + this.backoffFor(newAttempts);
-      this.db
-        .prepare(
-          `UPDATE protocol_outbox
-           SET attempts = ?, last_attempt_at = ?, next_attempt_at = ?, last_error = ?
-           WHERE peer_id = ? AND protocol = ? AND message_id = ?`,
-        )
-        .run(newAttempts, now, nextAttemptAt, error, peer, protocol, messageId);
+      this.updateEntryStmt.run(newAttempts, now, nextAttemptAt, error, peer, protocol, messageId);
       return {
         peer,
         protocol,
@@ -1766,14 +1801,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
     const attempts = 1;
     const nextAttemptAt = now + this.backoffFor(attempts);
     const blob = Buffer.from(payload);
-    this.db
-      .prepare(
-        `INSERT INTO protocol_outbox
-           (peer_id, protocol, message_id, payload, attempts,
-            first_failure_at, last_attempt_at, next_attempt_at, last_error)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(peer, protocol, messageId, blob, attempts, now, now, nextAttemptAt, error);
+    this.insertEntryStmt.run(peer, protocol, messageId, blob, attempts, now, now, nextAttemptAt, error);
     return {
       peer,
       protocol,
@@ -1788,31 +1816,17 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
   }
 
   markDelivered(peer: string, protocol: string, messageId: string): boolean {
-    const result = this.db
-      .prepare(
-        `DELETE FROM protocol_outbox
-         WHERE peer_id = ? AND protocol = ? AND message_id = ?`,
-      )
-      .run(peer, protocol, messageId);
+    const result = this.markDeliveredStmt.run(peer, protocol, messageId);
     return result.changes > 0;
   }
 
   hasEntry(peer: string, protocol: string, messageId: string): boolean {
-    const row = this.db
-      .prepare(
-        `SELECT 1 FROM protocol_outbox
-         WHERE peer_id = ? AND protocol = ? AND message_id = ? LIMIT 1`,
-      )
-      .get(peer, protocol, messageId) as { 1: number } | undefined;
+    const row = this.hasEntryStmt.get(peer, protocol, messageId) as { 1: number } | undefined;
     return row !== undefined;
   }
 
   pendingFor(peer: string): ProtocolOutboxEntry[] {
-    const rows = this.db
-      .prepare(
-        `SELECT * FROM protocol_outbox WHERE peer_id = ? ORDER BY first_failure_at ASC`,
-      )
-      .all(peer) as Array<{
+    const rows = this.pendingForStmt.all(peer) as Array<{
       peer_id: string;
       protocol: string;
       message_id: string;
@@ -1827,11 +1841,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
   }
 
   due(now: number): ProtocolOutboxEntry[] {
-    const rows = this.db
-      .prepare(
-        `SELECT * FROM protocol_outbox WHERE next_attempt_at <= ?`,
-      )
-      .all(now) as Array<{
+    const rows = this.dueStmt.all(now) as Array<{
       peer_id: string;
       protocol: string;
       message_id: string;
@@ -1847,9 +1857,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
 
   dropExpired(now: number): ProtocolOutboxEntry[] {
     const cutoff = now - this.maxAgeMs;
-    const rows = this.db
-      .prepare(`SELECT * FROM protocol_outbox WHERE first_failure_at < ?`)
-      .all(cutoff) as Array<{
+    const rows = this.selectExpiredStmt.all(cutoff) as Array<{
       peer_id: string;
       protocol: string;
       message_id: string;
@@ -1860,12 +1868,12 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
       next_attempt_at: number;
       last_error: string | null;
     }>;
-    this.db.prepare(`DELETE FROM protocol_outbox WHERE first_failure_at < ?`).run(cutoff);
+    this.deleteExpiredStmt.run(cutoff);
     return rows.map(SqliteProtocolOutboxStore.rowToEntry);
   }
 
   size(): number {
-    const row = this.db.prepare(`SELECT COUNT(*) as c FROM protocol_outbox`).get() as {
+    const row = this.sizeStmt.get() as {
       c: number;
     };
     return row.c;

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -86,7 +86,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(11);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(12);
 
     const cols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -843,7 +843,7 @@ describe('DashboardDB — V11 schema migration', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(11);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(12);
 
     const cols = (db.db.prepare('PRAGMA table_info(chat_messages)').all() as Array<{ name: string }>)
       .map((c) => c.name);

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RESPONSE_CACHE_BYTES } from '@origintrail-official/dkg-core';
+import {
+  DashboardDB,
+  SqliteMessageIdempotencyStore,
+  SqliteProtocolOutboxStore,
+} from '../src/db.js';
+
+const PEER_A = '12D3KooWMilesPlaceholder';
+const PEER_B = '12D3KooWLexPlaceholder';
+const PROTO = '/dkg/10.0.1/message';
+const MSG_1 = '00000000-0000-4000-8000-000000000001';
+const MSG_2 = '00000000-0000-4000-8000-000000000002';
+const PAYLOAD = new TextEncoder().encode('payload-bytes');
+
+let db: DashboardDB;
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'dkg-messenger-stores-test-'));
+  db = new DashboardDB({ dataDir: dir });
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('V12 migration', () => {
+  it('creates message_idempotency and protocol_outbox tables', () => {
+    const tables = (db.db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+      .all() as Array<{ name: string }>).map((t) => t.name);
+    expect(tables).toContain('message_idempotency');
+    expect(tables).toContain('protocol_outbox');
+  });
+
+  it('records user_version = 12 after migration', () => {
+    expect(db.db.pragma('user_version', { simple: true })).toBe(12);
+  });
+});
+
+describe('SqliteMessageIdempotencyStore', () => {
+  it('check returns { seen: false } for unrecorded triples', () => {
+    const store = new SqliteMessageIdempotencyStore(db);
+    expect(store.check(PEER_A, PROTO, MSG_1, 'in')).toEqual({ seen: false });
+  });
+
+  it('record + check round-trips a small response inline', () => {
+    const store = new SqliteMessageIdempotencyStore(db);
+    const resp = new TextEncoder().encode('ack');
+    store.record(PEER_A, PROTO, MSG_1, 'in', resp);
+    const result = store.check(PEER_A, PROTO, MSG_1, 'in');
+    expect(result.seen).toBe(true);
+    expect(result.seen && Array.from(result.cachedResponse ?? [])).toEqual(Array.from(resp));
+  });
+
+  it('stores mark-only (NULL blob) for responses larger than RESPONSE_CACHE_BYTES', () => {
+    const store = new SqliteMessageIdempotencyStore(db);
+    const oversize = new Uint8Array(RESPONSE_CACHE_BYTES + 1);
+    store.record(PEER_A, PROTO, MSG_1, 'in', oversize);
+    const row = db.db
+      .prepare(
+        `SELECT response_blob, response_size FROM message_idempotency
+         WHERE peer_id = ? AND protocol = ? AND message_id = ? AND direction = ?`,
+      )
+      .get(PEER_A, PROTO, MSG_1, 'in') as { response_blob: Buffer | null; response_size: number };
+    expect(row.response_blob).toBeNull();
+    expect(row.response_size).toBe(RESPONSE_CACHE_BYTES + 1);
+    expect(store.check(PEER_A, PROTO, MSG_1, 'in')).toEqual({ seen: true });
+  });
+
+  it('treats different directions as independent (Codex #534 lesson)', () => {
+    const store = new SqliteMessageIdempotencyStore(db);
+    store.record(PEER_A, PROTO, MSG_1, 'in');
+    expect(store.check(PEER_A, PROTO, MSG_1, 'in')).toEqual({ seen: true });
+    expect(store.check(PEER_A, PROTO, MSG_1, 'out')).toEqual({ seen: false });
+  });
+
+  it('treats different protocols as independent', () => {
+    const store = new SqliteMessageIdempotencyStore(db);
+    store.record(PEER_A, '/dkg/10.0.1/message', MSG_1, 'in');
+    expect(store.check(PEER_A, '/dkg/10.0.1/message', MSG_1, 'in')).toEqual({ seen: true });
+    expect(store.check(PEER_A, '/dkg/10.0.1/skill_request', MSG_1, 'in')).toEqual({ seen: false });
+  });
+
+  it('re-record on existing key is a no-op (ON CONFLICT DO NOTHING)', () => {
+    const store = new SqliteMessageIdempotencyStore(db);
+    store.record(PEER_A, PROTO, MSG_1, 'in', new TextEncoder().encode('first'));
+    // Second record with a different blob — first wins.
+    store.record(PEER_A, PROTO, MSG_1, 'in', new TextEncoder().encode('second'));
+    const result = store.check(PEER_A, PROTO, MSG_1, 'in');
+    expect(result.seen).toBe(true);
+    expect(
+      result.seen && new TextDecoder().decode(result.cachedResponse ?? new Uint8Array()),
+    ).toBe('first');
+  });
+
+  it('pruneOlderThan removes records older than the cutoff', () => {
+    let now = 1_000_000;
+    const store = new SqliteMessageIdempotencyStore(db, { clock: () => now });
+    store.record(PEER_A, PROTO, MSG_1, 'in');
+    now = 2_000_000;
+    store.record(PEER_A, PROTO, MSG_2, 'in');
+    const dropped = store.pruneOlderThan(1_500_000);
+    expect(dropped).toBe(1);
+    expect(store.check(PEER_A, PROTO, MSG_1, 'in')).toEqual({ seen: false });
+    expect(store.check(PEER_A, PROTO, MSG_2, 'in')).toEqual({ seen: true });
+  });
+
+  it('survives a re-open with data preserved (durability sanity)', () => {
+    const store = new SqliteMessageIdempotencyStore(db);
+    const resp = new TextEncoder().encode('persisted');
+    store.record(PEER_A, PROTO, MSG_1, 'in', resp);
+
+    db.close();
+    db = new DashboardDB({ dataDir: dir });
+    const reopened = new SqliteMessageIdempotencyStore(db);
+    const result = reopened.check(PEER_A, PROTO, MSG_1, 'in');
+    expect(result.seen).toBe(true);
+    expect(result.seen && new TextDecoder().decode(result.cachedResponse ?? new Uint8Array())).toBe(
+      'persisted',
+    );
+  });
+});
+
+describe('SqliteProtocolOutboxStore', () => {
+  it('enqueue creates a new entry with attempts=1', () => {
+    const store = new SqliteProtocolOutboxStore(db, { backoffFor: () => 5_000 });
+    const entry = store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'reset', 1_000_000);
+    expect(entry.attempts).toBe(1);
+    expect(entry.firstFailureAt).toBe(1_000_000);
+    expect(entry.nextAttemptAt).toBe(1_005_000);
+    expect(entry.lastError).toBe('reset');
+    expect(Array.from(entry.payload)).toEqual(Array.from(PAYLOAD));
+  });
+
+  it('enqueue bumps attempts and reschedules on repeat failure for the same key', () => {
+    const store = new SqliteProtocolOutboxStore(db, { backoffFor: (n) => n * 1000 });
+    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'first', 1_000_000);
+    const second = store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'second', 1_005_000);
+    expect(second.attempts).toBe(2);
+    expect(second.firstFailureAt).toBe(1_000_000);
+    expect(second.lastAttemptAt).toBe(1_005_000);
+    expect(second.nextAttemptAt).toBe(1_005_000 + 2000);
+    expect(second.lastError).toBe('second');
+  });
+
+  it('markDelivered removes the entry and returns true', () => {
+    const store = new SqliteProtocolOutboxStore(db);
+    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
+    expect(store.hasEntry(PEER_A, PROTO, MSG_1)).toBe(true);
+    expect(store.markDelivered(PEER_A, PROTO, MSG_1)).toBe(true);
+    expect(store.hasEntry(PEER_A, PROTO, MSG_1)).toBe(false);
+    expect(store.markDelivered(PEER_A, PROTO, MSG_1)).toBe(false);
+  });
+
+  it('pendingFor returns entries sorted by firstFailureAt ascending', () => {
+    const store = new SqliteProtocolOutboxStore(db);
+    store.enqueue(PEER_A, PROTO, MSG_2, PAYLOAD, 'e', 2000);
+    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
+    store.enqueue(PEER_B, PROTO, MSG_1, PAYLOAD, 'e', 500);
+    expect(store.pendingFor(PEER_A).map((e) => e.messageId)).toEqual([MSG_1, MSG_2]);
+    expect(store.pendingFor(PEER_B)).toHaveLength(1);
+  });
+
+  it('due returns entries with nextAttemptAt <= now', () => {
+    const store = new SqliteProtocolOutboxStore(db, { backoffFor: () => 5_000 });
+    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1_000_000);
+    expect(store.due(1_004_999)).toHaveLength(0);
+    expect(store.due(1_005_000)).toHaveLength(1);
+  });
+
+  it('dropExpired removes entries older than maxAgeMs and returns them', () => {
+    const store = new SqliteProtocolOutboxStore(db, {
+      maxAgeMs: 60_000,
+    });
+    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'old', 0);
+    store.enqueue(PEER_A, PROTO, MSG_2, PAYLOAD, 'new', 100_000);
+    const dropped = store.dropExpired(100_001);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].messageId).toBe(MSG_1);
+    expect(store.size()).toBe(1);
+  });
+
+  it('size reflects the row count', () => {
+    const store = new SqliteProtocolOutboxStore(db);
+    expect(store.size()).toBe(0);
+    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
+    expect(store.size()).toBe(1);
+    store.enqueue(PEER_B, PROTO, MSG_1, PAYLOAD, 'e', 1000);
+    expect(store.size()).toBe(2);
+  });
+
+  it('survives re-open with entries preserved (durability sanity)', () => {
+    const store = new SqliteProtocolOutboxStore(db);
+    // Use a recent timestamp — DashboardDB's constructor runs prune()
+    // which deletes protocol_outbox rows with first_failure_at older
+    // than 24h, so ancient test timestamps would get swept on reopen.
+    const now = Date.now();
+    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'crash-before-delivery', now);
+
+    db.close();
+    db = new DashboardDB({ dataDir: dir });
+    const reopened = new SqliteProtocolOutboxStore(db);
+    const pending = reopened.pendingFor(PEER_A);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].lastError).toBe('crash-before-delivery');
+    expect(Array.from(pending[0].payload)).toEqual(Array.from(PAYLOAD));
+  });
+});

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -58,6 +58,22 @@ describe('SqliteMessageIdempotencyStore', () => {
     expect(result.seen && Array.from(result.cachedResponse ?? [])).toEqual(Array.from(resp));
   });
 
+  it('snapshots cached responses on write and read', () => {
+    const store = new SqliteMessageIdempotencyStore(db);
+    const resp = new Uint8Array([1, 2, 3]);
+    store.record(PEER_A, PROTO, MSG_1, 'in', resp);
+
+    resp[0] = 9;
+    const first = store.check(PEER_A, PROTO, MSG_1, 'in');
+    expect(first.seen && Array.from(first.cachedResponse ?? [])).toEqual([1, 2, 3]);
+
+    if (first.seen && first.cachedResponse) {
+      first.cachedResponse[1] = 8;
+    }
+    const second = store.check(PEER_A, PROTO, MSG_1, 'in');
+    expect(second.seen && Array.from(second.cachedResponse ?? [])).toEqual([1, 2, 3]);
+  });
+
   it('stores mark-only (NULL blob) for responses larger than RESPONSE_CACHE_BYTES', () => {
     const store = new SqliteMessageIdempotencyStore(db);
     const oversize = new Uint8Array(RESPONSE_CACHE_BYTES + 1);
@@ -138,6 +154,31 @@ describe('SqliteProtocolOutboxStore', () => {
     expect(Array.from(entry.payload)).toEqual(Array.from(PAYLOAD));
   });
 
+  it('configurePolicy updates the SQLite store backoff and max age', () => {
+    const store = new SqliteProtocolOutboxStore(db);
+    store.configurePolicy({ backoffFor: () => 123, maxAgeMs: 60_000 });
+
+    const entry = store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'reset', 0);
+    expect(entry.nextAttemptAt).toBe(123);
+    expect(store.dropExpired(60_000)).toHaveLength(0);
+    expect(store.dropExpired(60_001)).toHaveLength(1);
+  });
+
+  it('snapshots payload bytes on write and read', () => {
+    const store = new SqliteProtocolOutboxStore(db, { backoffFor: () => 5_000 });
+    const payload = new Uint8Array([1, 2, 3]);
+    const entry = store.enqueue(PEER_A, PROTO, MSG_1, payload, 'reset', 1000);
+
+    payload[0] = 9;
+    entry.payload[1] = 8;
+
+    const pending = store.pendingFor(PEER_A);
+    expect(Array.from(pending[0].payload)).toEqual([1, 2, 3]);
+
+    pending[0].payload[2] = 7;
+    expect(Array.from(store.due(6000)[0].payload)).toEqual([1, 2, 3]);
+  });
+
   it('enqueue bumps attempts and reschedules on repeat failure for the same key', () => {
     const store = new SqliteProtocolOutboxStore(db, { backoffFor: (n) => n * 1000 });
     store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'first', 1_000_000);
@@ -197,11 +238,15 @@ describe('SqliteProtocolOutboxStore', () => {
 
   it('survives re-open with entries preserved (durability sanity)', () => {
     const store = new SqliteProtocolOutboxStore(db);
-    // Use a recent timestamp — DashboardDB's constructor runs prune()
-    // which deletes protocol_outbox rows with first_failure_at older
-    // than 24h, so ancient test timestamps would get swept on reopen.
-    const now = Date.now();
-    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'crash-before-delivery', now);
+    const oldEnoughForDefaultPolicy = Date.now() - 25 * 60 * 60 * 1000;
+    store.enqueue(
+      PEER_A,
+      PROTO,
+      MSG_1,
+      PAYLOAD,
+      'crash-before-delivery',
+      oldEnoughForDefaultPolicy,
+    );
 
     db.close();
     db = new DashboardDB({ dataDir: dir });

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -30,16 +30,40 @@ afterEach(() => {
 });
 
 describe('V12 migration', () => {
+  function sqliteNames(type: 'table' | 'index'): string[] {
+    return (db.db
+      .prepare('SELECT name FROM sqlite_master WHERE type = ?')
+      .all(type) as Array<{ name: string }>).map((row) => row.name);
+  }
+
   it('creates message_idempotency and protocol_outbox tables', () => {
-    const tables = (db.db
-      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
-      .all() as Array<{ name: string }>).map((t) => t.name);
+    const tables = sqliteNames('table');
     expect(tables).toContain('message_idempotency');
     expect(tables).toContain('protocol_outbox');
   });
 
   it('records user_version = 12 after migration', () => {
     expect(db.db.pragma('user_version', { simple: true })).toBe(12);
+  });
+
+  it('adds messenger tables and indexes when reopening an existing V11 database', () => {
+    db.db.exec(`
+      DROP TABLE IF EXISTS message_idempotency;
+      DROP TABLE IF EXISTS protocol_outbox;
+      PRAGMA user_version = 11;
+    `);
+    db.close();
+
+    db = new DashboardDB({ dataDir: dir });
+
+    expect(db.db.pragma('user_version', { simple: true })).toBe(12);
+    const tables = sqliteNames('table');
+    expect(tables).toContain('message_idempotency');
+    expect(tables).toContain('protocol_outbox');
+
+    const indexes = sqliteNames('index');
+    expect(indexes).toContain('idx_idem_ts');
+    expect(indexes).toContain('idx_outbox_next_attempt');
   });
 });
 
@@ -125,6 +149,25 @@ describe('SqliteMessageIdempotencyStore', () => {
     expect(dropped).toBe(1);
     expect(store.check(PEER_A, PROTO, MSG_1, 'in')).toEqual({ seen: false });
     expect(store.check(PEER_A, PROTO, MSG_2, 'in')).toEqual({ seen: true });
+  });
+
+  it('does not prepare SQL statements on the check/record/prune hot path', () => {
+    const store = new SqliteMessageIdempotencyStore(db);
+    const originalPrepare = db.db.prepare.bind(db.db);
+    let prepares = 0;
+    (db.db as any).prepare = ((sql: string) => {
+      prepares += 1;
+      return originalPrepare(sql);
+    }) as any;
+    try {
+      store.check(PEER_A, PROTO, MSG_1, 'in');
+      store.record(PEER_A, PROTO, MSG_1, 'in', new TextEncoder().encode('ack'));
+      store.check(PEER_A, PROTO, MSG_1, 'in');
+      store.pruneOlderThan(0);
+      expect(prepares).toBe(0);
+    } finally {
+      (db.db as any).prepare = originalPrepare;
+    }
   });
 
   it('survives a re-open with data preserved (durability sanity)', () => {
@@ -234,6 +277,28 @@ describe('SqliteProtocolOutboxStore', () => {
     expect(store.size()).toBe(1);
     store.enqueue(PEER_B, PROTO, MSG_1, PAYLOAD, 'e', 1000);
     expect(store.size()).toBe(2);
+  });
+
+  it('does not prepare SQL statements on the enqueue/query hot path', () => {
+    const store = new SqliteProtocolOutboxStore(db, { backoffFor: () => 5_000 });
+    const originalPrepare = db.db.prepare.bind(db.db);
+    let prepares = 0;
+    (db.db as any).prepare = ((sql: string) => {
+      prepares += 1;
+      return originalPrepare(sql);
+    }) as any;
+    try {
+      store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'e', 1000);
+      store.hasEntry(PEER_A, PROTO, MSG_1);
+      store.pendingFor(PEER_A);
+      store.due(6000);
+      store.size();
+      store.dropExpired(1000);
+      store.markDelivered(PEER_A, PROTO, MSG_1);
+      expect(prepares).toBe(0);
+    } finally {
+      (db.db as any).prepare = originalPrepare;
+    }
   });
 
   it('survives re-open with entries preserved (durability sanity)', () => {


### PR DESCRIPTION
## Summary

PR-1 of the Universal Messenger rc.9 plan. Lays the substrate primitives — `ReliableEnvelope` proto, `MessageIdempotencyStore` + `ProtocolOutboxStore` ports, `ProtocolOutbox` class, V12 SQLite migration + the two SQLite-backed store impls — that subsequent PRs wire every short DKG protocol through.

**Pure additive.** No existing caller changes behaviour. Chat continues to write to `chat_messages.message_id` (V11 dedup) until PR-3 cuts over to the substrate.

## What's in

**`packages/core`**
- `proto/reliable-envelope.ts` — protobuf `{ messageId, version, tsMs, payload }` outer wrapper. Mirrors the encode/decode shape of `message.ts`.
- `messenger-types.ts` — `MessageIdempotencyStore` + `ProtocolOutboxStore` port interfaces. `RESPONSE_CACHE_BYTES = 256 KiB` locked at the type layer; no per-call knob (rc.9 plan locked-in decision).
- `protocol-outbox.ts` — generic `ProtocolOutbox` class wrapping any `ProtocolOutboxStore` with the inflight-lock + `hasEntry` stale-snapshot guard (rc.9 #538 lesson lifted to the generic substrate). Plus `InMemoryProtocolOutboxStore` + `InMemoryMessageIdempotencyStore` reference impls.

**`packages/node-ui`**
- V12 migration: `message_idempotency` + `protocol_outbox` tables. Single `protocol` column partitions the namespace across every Messenger-routed protocol — no per-protocol storage needed.
- `SqliteMessageIdempotencyStore` + `SqliteProtocolOutboxStore` — daemon-side implementations of the port interfaces. Targeted `ON CONFLICT DO NOTHING` (Codex #534 lesson) on idempotency insert; `backoffFor` callback injected from the wrapping `ProtocolOutbox` so policy lives in one place.
- `DashboardDB.prune()` sweeps both new tables on a 24h TTL.

**Tests**
- `packages/core/test/proto/reliable-envelope.test.ts` (3 tests: small payload roundtrip, 32 KiB binary, empty payload)
- `packages/core/test/protocol-outbox.test.ts` (24 tests covering `enqueueFailure` / `markDelivered` / `hasEntry` / `tryBeginAttempt` / `dropExpired` plus the stale-snapshot guard contract every store impl must pass)
- `packages/node-ui/test/messenger-stores.test.ts` (18 tests covering the V12 migration, both SQLite store impls, and a durability sanity check across DB close/reopen)
- `db.test.ts` `user_version` assertions bumped 11 → 12.

**Docs**
- `docs/messenger.md` skeleton — architecture diagram, wire format, V12 schema, response caching policy, per-protocol coverage table (filled in by PR-3+), recovery primitives section (filled in by PR-4 + PR-5), SLO pointer (full def lives in `messenger-operator.md` skeleton from PR-7).

## What's NOT in (deferred to follow-up PRs)

- **PR-2** — wires the substrate into the daemon (`lifecycle.ts` instantiates the stores; `Messenger` class evolves to use them). `ackTransportFactory` route through Messenger is the HIGH RISK bit; explicit publishing-flow integration test required.
- **PR-3** — chat + skill cutover to `/dkg/10.0.1/*`. Deletes `message-outbox.ts`. V13 drops `idx_chat_msgid` but preserves `chat_messages.message_id` nullable for rollback safety.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core test` → 827 pass
- [x] `npx vitest run test/messenger-stores.test.ts test/db.test.ts` in node-ui → 64 pass
- [x] `pnpm --filter @origintrail-official/dkg build` clean (all downstream packages compile)
- [ ] Reviewer: verify the V12 migration is idempotent on an existing rc.9 node DB (pure additive, should be trivial; the existing chat-dedup index from V11 is untouched).

Made with [Cursor](https://cursor.com)