### PR TITLE
feat(agent,cli): Messenger reliability substrate + lifecycle wiring (rc.9 PR-2)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -58,6 +58,8 @@ import {
   type SwmSenderKeyMessageMsg,
   type SwmSenderKeyPackageMsg,
   type WorkspaceRecipientEncryptionKey,
+  type MessageIdempotencyStore,
+  type ProtocolOutboxStore,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
@@ -956,6 +958,26 @@ export interface DKGAgentConfig {
   contextGraphSubscriptionStore?: ContextGraphSubscriptionStore;
   /** Durable local cache for nodes/agents known to be members of a context graph. */
   contextGraphMembershipStore?: ContextGraphMembershipStore;
+  /**
+   * Universal Messenger substrate stores (rc.9 plan PR-2). When
+   * supplied, the `Messenger` instance gets durable receiver-side
+   * idempotency + sender-side outbox semantics for every caller that
+   * switches to `messenger.sendReliable` (the migration starts in
+   * PR-3 with chat + skill). When omitted, the Messenger runs in
+   * legacy pass-through mode — backwards-compatible for callers
+   * still on `/dkg/10.0.0/*`.
+   *
+   * Production: `cli/src/daemon/lifecycle.ts` wires
+   * `SqliteMessageIdempotencyStore` + `SqliteProtocolOutboxStore`
+   * against the shared `DashboardDB`.
+   *
+   * Tests: pass `InMemoryMessageIdempotencyStore` +
+   * `InMemoryProtocolOutboxStore` from `@origintrail-official/dkg-core`.
+   */
+  messengerStores?: {
+    idempotencyStore: MessageIdempotencyStore;
+    outboxStore: ProtocolOutboxStore;
+  };
 }
 
 function normalizeAdapterPublisherAddress(value: unknown): string | undefined {
@@ -1207,6 +1229,15 @@ export class DKGAgent {
    */
   private readonly messageOutbox: MessageOutbox = new MessageOutbox();
   private messageOutboxTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Periodic tick driving `Messenger.processOutboxTick` for the
+   * Universal Messenger substrate outbox. Independent from
+   * `messageOutboxTimer` (chat-specific) so PR-3's deletion of the
+   * chat outbox doesn't accidentally take the substrate tick with
+   * it. Shares the cadence (`MESSAGE_OUTBOX_TICK_MS`) for operator
+   * visibility.
+   */
+  private messengerOutboxTimer: ReturnType<typeof setInterval> | null = null;
   private randomSamplingHandle: RandomSamplingHandle | null = null;
   private randomSamplingBindRetryTimer: ReturnType<typeof setInterval> | null = null;
   private randomSamplingBindRetryInFlight = false;
@@ -1680,7 +1711,10 @@ export class DKGAgent {
     });
     this.peerResolver = peerResolver;
     this.router = new ProtocolRouter(this.node, { peerResolver });
-    this.messenger = new Messenger({ router: this.router });
+    this.messenger = new Messenger({
+      router: this.router,
+      ...(this.config.messengerStores ?? {}),
+    });
     this.gossip = new GossipSubManager(this.node, this.eventBus);
     await this.loadSwmSenderKeyState();
     await this.rehydrateContextGraphSubscriptions();
@@ -2416,6 +2450,17 @@ export class DKGAgent {
           const message = err instanceof Error ? err.message : String(err);
           this.log.warn(ctx, `Opportunistic message-outbox retry on connect failed for ${remotePeer}: ${message}`);
         }
+        // Universal Messenger substrate (rc.9 PR-2): drain the
+        // generic outbox for this peer on the same connection:open
+        // signal. No-op until a caller migrates to
+        // `messenger.sendReliable` (PR-3 chat + skill, then C
+        // migrations).
+        try {
+          await this.messenger.processOutboxOnConnect(remotePeer);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.log.warn(ctx, `Opportunistic Messenger-outbox retry on connect failed for ${remotePeer}: ${message}`);
+        }
       })();
 
       const now = Date.now();
@@ -2553,6 +2598,29 @@ export class DKGAgent {
       });
     }, MESSAGE_OUTBOX_TICK_MS);
     if (this.messageOutboxTimer.unref) this.messageOutboxTimer.unref();
+
+    // Universal Messenger substrate retry tick (rc.9 PR-2). Shares
+    // the same cadence as the chat-specific tick so the operator
+    // sees a single "outbox tick" beat in their dashboard. No-op
+    // until a caller migrates to `messenger.sendReliable` (PR-3+);
+    // the substrate outbox is empty in pre-migration daemons.
+    this.messengerOutboxTimer = setInterval(() => {
+      const now = Date.now();
+      this.messenger.processOutboxTick(now).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        this.log.warn(ctx, `Messenger-outbox retry tick failed: ${message}`);
+      });
+      const dropped = this.messenger.dropExpiredOutbox(now);
+      for (const entry of dropped) {
+        this.log.warn(
+          ctx,
+          `Messenger-outbox dropped after ${entry.attempts} attempts: ` +
+            `peer=${entry.peer.slice(-8)} protocol=${entry.protocol} ` +
+            `msgId=${entry.messageId.slice(0, 8)} lastError="${entry.lastError}"`,
+        );
+      }
+    }, MESSAGE_OUTBOX_TICK_MS);
+    if (this.messengerOutboxTimer.unref) this.messengerOutboxTimer.unref();
 
     // Wire V10 Random Sampling prover. Edge nodes no-op. Core nodes with
     // transient identity/RPC startup failures retry in the background so
@@ -13913,6 +13981,10 @@ export class DKGAgent {
     if (this.messageOutboxTimer) {
       clearInterval(this.messageOutboxTimer);
       this.messageOutboxTimer = null;
+    }
+    if (this.messengerOutboxTimer) {
+      clearInterval(this.messengerOutboxTimer);
+      this.messengerOutboxTimer = null;
     }
     // Drop in-memory retry queue on shutdown; entries don't survive a
     // restart (the operator can re-fire via the redeliver-approval route

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2606,19 +2606,22 @@ export class DKGAgent {
     // the substrate outbox is empty in pre-migration daemons.
     this.messengerOutboxTimer = setInterval(() => {
       const now = Date.now();
-      this.messenger.processOutboxTick(now).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        this.log.warn(ctx, `Messenger-outbox retry tick failed: ${message}`);
-      });
-      const dropped = this.messenger.dropExpiredOutbox(now);
-      for (const entry of dropped) {
-        this.log.warn(
-          ctx,
-          `Messenger-outbox dropped after ${entry.attempts} attempts: ` +
-            `peer=${entry.peer.slice(-8)} protocol=${entry.protocol} ` +
-            `msgId=${entry.messageId.slice(0, 8)} lastError="${entry.lastError}"`,
-        );
-      }
+      this.messenger.processOutboxTick(now)
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          this.log.warn(ctx, `Messenger-outbox retry tick failed: ${message}`);
+        })
+        .finally(() => {
+          const dropped = this.messenger.dropExpiredOutbox(now);
+          for (const entry of dropped) {
+            this.log.warn(
+              ctx,
+              `Messenger-outbox dropped after ${entry.attempts} attempts: ` +
+                `peer=${entry.peer.slice(-8)} protocol=${entry.protocol} ` +
+                `msgId=${entry.messageId.slice(0, 8)} lastError="${entry.lastError}"`,
+            );
+          }
+        });
     }, MESSAGE_OUTBOX_TICK_MS);
     if (this.messengerOutboxTimer.unref) this.messengerOutboxTimer.unref();
 

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -1,39 +1,199 @@
-import type { ProtocolRouter } from '@origintrail-official/dkg-core';
+import { randomUUID } from 'node:crypto';
+import {
+  encodeReliableEnvelope,
+  decodeReliableEnvelope,
+  RELIABLE_ENVELOPE_VERSION,
+  RESPONSE_GONE_MARKER,
+  isRecoverableSendError,
+  ProtocolOutbox,
+  type MessageIdempotencyStore,
+  type ProtocolOutboxStore,
+  type ProtocolRouter,
+} from '@origintrail-official/dkg-core';
+
+/** Bytes payload the substrate uses to signal `RESPONSE_GONE` on the wire. */
+const RESPONSE_GONE_BYTES = new TextEncoder().encode(RESPONSE_GONE_MARKER);
 
 export interface MessengerDeps {
   router: ProtocolRouter;
+  /**
+   * Substrate idempotency store. Optional in PR-2 so existing tests +
+   * call sites that construct a bare-router Messenger keep working;
+   * mandatory once a caller migrates to the `/dkg/10.0.1/*` prefix
+   * (PR-3+). When omitted, `sendReliable` and `register` throw with a
+   * clear "no idempotency store" error so misconfiguration is loud.
+   */
+  idempotencyStore?: MessageIdempotencyStore;
+  /**
+   * Substrate sender-side outbox store. Same optionality rules as
+   * `idempotencyStore`. The Messenger wraps the store with a
+   * `ProtocolOutbox` internally (which owns the backoff ladder +
+   * inflight guard).
+   */
+  outboxStore?: ProtocolOutboxStore;
+  /**
+   * Override the default backoff ladder (5s → 2h, mirrors rc.8 chat
+   * outbox). Caller can pass a tighter / looser ladder per Messenger
+   * instance, but every protocol on the substrate shares the same
+   * ladder.
+   */
+  backoffs?: readonly number[];
+  /**
+   * Max age (ms) from `firstFailureAt` before an outbox entry is
+   * dropped. Defaults to 24h. Caller-supplied for tests; production
+   * keeps the default.
+   */
+  maxAgeMs?: number;
+  /**
+   * Injectable wall-clock. Tests can drive deterministic timestamps;
+   * production uses the default `Date.now`.
+   */
+  clock?: () => number;
 }
 
 export interface SendOpts {
   timeoutMs?: number;
 }
 
+export interface SendReliableOpts {
+  /**
+   * Caller-supplied message id. Used by the receiver-side idempotency
+   * cache to dedupe duplicate deliveries and by the sender-side
+   * "did-I-already-deliver-this" cache. If omitted, the Messenger
+   * generates a UUID v4 — but callers that have their own correlation
+   * id (e.g. chat `messageId`, query `requestId`) should pass it so
+   * retries replayed across daemon restarts stay keyed consistently.
+   */
+  messageId?: string;
+  timeoutMs?: number;
+  /**
+   * Max age (ms) before an outbox entry for this `(peer, protocol,
+   * messageId)` is considered stale and dropped. Defaults to the
+   * Messenger's instance-level `maxAgeMs` (24h). Override for callers
+   * that want shorter expiry (e.g. ephemeral chat) or longer
+   * (e.g. join-approval).
+   */
+  maxAgeMs?: number;
+}
+
 /**
- * Single outbound P2P sending primitive.
+ * Result of `Messenger.sendReliable`. Three terminal shapes:
  *
- * Forwards the bytes to `ProtocolRouter.send`, which (since RFC 07 PR-3)
- * consults `PeerResolver` before dialing — populating the libp2p
- * peerStore with whatever multiaddrs the resolution order finds
- * (live conn → DHT → RFC 04 registry → agents-CG). Centralising every
- * outbound send through one entry point removes the "this code path
- * forgot to prime the relay route" defect class behind PR #448's
- * Laptop B invite failure.
+ *   - `{ delivered: true, response, attempts, messageId }` — wire
+ *     send + response read succeeded. `response` is the application
+ *     bytes the receiver's handler returned (envelope-unwrapped).
  *
- * Note: pre-PR-3 this class held its own `PeerResolver` ref and
- * resolved before delegating to the router. After PR-3 the router does
- * the same lookup, so doing it here too duplicated the DHT walk on
- * every cold send. Codex review on PR #497 caught the duplication;
- * the resolver dependency is now owned by `ProtocolRouter` alone.
+ *   - `{ delivered: false, queued: true, attempts, messageId, error }`
+ *     — wire send failed with a recoverable error; the substrate has
+ *     enqueued the envelope-wrapped bytes for background retry.
+ *     `attempts` tracks the total retry count so far (starts at 1 for
+ *     the first failure).
  *
- * See `dkgv10-spec/production_mainnet/07_IN_PROCESS_PEER_RESOLVER.md`.
+ *   - Thrown — non-recoverable error (encoding bug, unhandleable
+ *     protocol id, etc.) is rethrown to the caller. The substrate
+ *     does NOT enqueue these because retrying won't help.
+ *
+ * Late delivery (background retry succeeds AFTER `sendReliable`
+ * returned `{ queued: true }`) does not propagate back to the
+ * original caller — the original promise has already resolved. For
+ * chat that's fine (the UI notification path is independent). For
+ * request/response callers like `/query-remote`, the caller will
+ * need to poll or get notified through a separate channel; today
+ * the floor is just "we tried and queued, here's the messageId for
+ * follow-up".
+ */
+export type ReliableSendResult =
+  | {
+      delivered: true;
+      response: Uint8Array;
+      attempts: number;
+      messageId: string;
+    }
+  | {
+      delivered: false;
+      queued: true;
+      attempts: number;
+      messageId: string;
+      error: string;
+    };
+
+/** Handler signature for `Messenger.register`. */
+export type ReliableHandler = (
+  payload: Uint8Array,
+  peerId: string,
+) => Promise<Uint8Array>;
+
+/**
+ * The Universal Messenger substrate.
+ *
+ * Two surfaces:
+ *
+ *   1. **Legacy pass-through** (`sendToPeer`) — unchanged in PR-2 so
+ *      every existing `/dkg/10.0.0/*` caller continues to work
+ *      byte-identically. The substrate evolution does not break
+ *      backwards compatibility at the API layer; the protocol prefix
+ *      bump (PR-3+) is what opts a caller into the substrate path.
+ *
+ *   2. **Substrate** (`sendReliable` + `register` + retry tick) —
+ *      adds envelope-wrapping, sender-side idempotency cache,
+ *      durable outbox with backoff, receiver-side dedup. Used by any
+ *      caller on the `/dkg/10.0.1/*` prefix (PR-3 migrates chat +
+ *      skill first; subsequent PRs migrate the rest).
+ *
+ * Both surfaces share the same underlying `ProtocolRouter` — the
+ * substrate is a wrapper, not a replacement.
+ *
+ * Construction:
+ *
+ *   - PR-2 makes `idempotencyStore` + `outboxStore` optional so
+ *     existing test sites (`p2p-messenger.test.ts`) keep working
+ *     without store fixtures. When a caller invokes `sendReliable`
+ *     without stores wired, the method throws a typed
+ *     `MessengerNotConfiguredError` so misconfiguration surfaces
+ *     loudly rather than silently regressing reliability.
+ *
+ *   - PR-3 wires the SQLite-backed stores in `cli/src/daemon/
+ *     lifecycle.ts` so every chat send picks them up.
+ *
+ * See `docs/messenger.md` for the architecture overview and per-
+ * protocol coverage table.
  */
 export class Messenger {
   private readonly router: ProtocolRouter;
+  private readonly idempotencyStore?: MessageIdempotencyStore;
+  private readonly outbox?: ProtocolOutbox;
+  private readonly clock: () => number;
+
+  /**
+   * Application handlers registered via `register`. Stored separately
+   * from `router.handlers` so the envelope-decode + idempotency
+   * wrapper can route through the substrate before invoking the
+   * caller's handler.
+   */
+  private readonly handlers = new Map<string, ReliableHandler>();
 
   constructor(deps: MessengerDeps) {
     this.router = deps.router;
+    this.idempotencyStore = deps.idempotencyStore;
+    if (deps.outboxStore) {
+      this.outbox = new ProtocolOutbox(deps.outboxStore, {
+        backoffs: deps.backoffs,
+        maxAgeMs: deps.maxAgeMs,
+      });
+    }
+    this.clock = deps.clock ?? (() => Date.now());
   }
 
+  /**
+   * Legacy pass-through send. Returns the response bytes directly,
+   * matching the rc.8 API exactly so unmigrated callers keep
+   * working. No envelope, no idempotency, no outbox — pure
+   * `ProtocolRouter.send` delegation.
+   *
+   * PR-3+ migrates callers to `sendReliable` on a per-protocol
+   * basis; this method remains the floor until every short-message
+   * protocol has migrated.
+   */
   async sendToPeer(
     peerId: string,
     protocolId: string,
@@ -41,5 +201,327 @@ export class Messenger {
     opts: SendOpts = {},
   ): Promise<Uint8Array> {
     return this.router.send(peerId, protocolId, data, opts.timeoutMs);
+  }
+
+  /**
+   * Substrate send. Wraps `payload` in a `ReliableEnvelope`,
+   * consults the sender-side idempotency cache (so a retry of an
+   * already-delivered message returns the cached response without
+   * a wire round-trip), invokes `ProtocolRouter.send`, and on
+   * recoverable failure enqueues the envelope bytes for background
+   * retry.
+   *
+   * Returns a `ReliableSendResult` documenting the outcome — see
+   * the type's JSDoc for the three shapes.
+   *
+   * Throws `MessengerNotConfiguredError` if `idempotencyStore` or
+   * `outboxStore` was omitted at construction.
+   */
+  async sendReliable(
+    peerId: string,
+    protocolId: string,
+    payload: Uint8Array,
+    opts: SendReliableOpts = {},
+  ): Promise<ReliableSendResult> {
+    this.requireSubstrate('sendReliable');
+
+    const messageId = opts.messageId ?? randomUUID();
+    const idem = this.idempotencyStore!;
+    const outbox = this.outbox!;
+
+    // Sender-side dedup: if we previously delivered this exact
+    // `(peer, protocol, messageId)` (e.g. operator clicked send
+    // twice; same caller-supplied id replayed across a daemon
+    // restart with the in-flight outbox), return the cached
+    // response without a wire round-trip.
+    const sentBefore = idem.check(peerId, protocolId, messageId, 'out');
+    if (sentBefore.seen) {
+      return {
+        delivered: true,
+        // Mark-only original response surfaces as RESPONSE_GONE so
+        // the caller can decide whether to re-issue with a fresh
+        // messageId (chat: harmless; query: must re-issue).
+        response: sentBefore.cachedResponse ?? RESPONSE_GONE_BYTES,
+        attempts: 1,
+        messageId,
+      };
+    }
+
+    const envelope = encodeReliableEnvelope({
+      messageId,
+      version: RELIABLE_ENVELOPE_VERSION,
+      tsMs: this.clock(),
+      payload,
+    });
+
+    // Inflight guard (rc.9 #521 lesson lifted): two parallel
+    // attempters on the same `(peer, protocol, messageId)` can race
+    // when the periodic tick + an opportunistic-flush fire close
+    // together. Second attempter exits without dialing.
+    if (!outbox.tryBeginAttempt(peerId, protocolId, messageId)) {
+      // Another attempt is in flight. Return queued; the in-flight
+      // one will either deliver (writes to idempotency cache) or
+      // re-enqueue (updates outbox).
+      return {
+        delivered: false,
+        queued: true,
+        attempts: 1,
+        messageId,
+        error: 'send already in flight for this messageId',
+      };
+    }
+
+    try {
+      const response = await this.router.send(
+        peerId,
+        protocolId,
+        envelope,
+        opts.timeoutMs,
+      );
+      idem.record(peerId, protocolId, messageId, 'out', response);
+      outbox.markDelivered(peerId, protocolId, messageId);
+      return { delivered: true, response, attempts: 1, messageId };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      // Non-recoverable: rethrow. The caller sees the real error;
+      // the outbox stays out of it because retrying an encoding
+      // bug / unhandled protocol won't help.
+      if (!isRecoverableSendError(err)) {
+        throw err;
+      }
+      const entry = outbox.enqueueFailure(
+        peerId,
+        protocolId,
+        messageId,
+        envelope,
+        errMsg,
+        this.clock(),
+      );
+      return {
+        delivered: false,
+        queued: true,
+        attempts: entry.attempts,
+        messageId,
+        error: errMsg,
+      };
+    } finally {
+      outbox.endAttempt(peerId, protocolId, messageId);
+    }
+  }
+
+  /**
+   * Substrate receive registration. Wraps the caller's handler with:
+   *
+   *   1. `ReliableEnvelope` decode — extracts the application
+   *      payload bytes.
+   *
+   *   2. Receiver-side idempotency check — if we've already
+   *      processed `(peer, protocol, messageId, 'in')`, return the
+   *      cached response (or `RESPONSE_GONE` if the original was
+   *      too big to cache) WITHOUT re-invoking the application
+   *      handler. This absorbs both the multi-path race (PR-4) and
+   *      the sender-side stale-snapshot retry storm.
+   *
+   *   3. Application handler invocation with envelope-unwrapped
+   *      payload bytes.
+   *
+   *   4. Response record — the application's response bytes are
+   *      cached (inline up to 256 KiB, mark-only beyond) so a
+   *      duplicate receive returns the same bytes idempotently.
+   *
+   * The application handler signature `(payload, peerId) =>
+   * Promise<Uint8Array>` exactly matches what callers wrote before;
+   * the substrate is transparent to the inner handler logic.
+   *
+   * Throws `MessengerNotConfiguredError` if `idempotencyStore` was
+   * omitted at construction.
+   */
+  register(protocolId: string, handler: ReliableHandler): void {
+    this.requireSubstrate('register');
+    const idem = this.idempotencyStore!;
+    this.handlers.set(protocolId, handler);
+
+    this.router.register(protocolId, async (data, peerIdObj) => {
+      const peerKey = peerIdObj.toString();
+
+      let envelope: { messageId: string; payload: Uint8Array };
+      try {
+        const decoded = decodeReliableEnvelope(data);
+        envelope = { messageId: decoded.messageId, payload: decoded.payload };
+      } catch (err) {
+        // Bare bytes (no envelope) — this shouldn't happen on a
+        // /dkg/10.0.1/* protocol if both sides ran the substrate.
+        // Surface the bug rather than silently falling through to
+        // the raw handler, because mixing wrapped + bare frames on
+        // the same protocol prefix would corrupt the idempotency
+        // table (a "bare bytes" handler call would store the
+        // application response under a fabricated/missing messageId).
+        // Hard cutover on the protocol-prefix bump is the rc.9
+        // design decision — see docs/messenger.md.
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `[Messenger] failed to decode ReliableEnvelope on ${protocolId} from ${peerKey.slice(-8)}: ${msg}`,
+        );
+      }
+
+      const seen = idem.check(peerKey, protocolId, envelope.messageId, 'in');
+      if (seen.seen) {
+        // Duplicate. Return the cached response if any, else the
+        // RESPONSE_GONE sentinel so the sender's caller knows the
+        // original response was too big to cache.
+        return seen.cachedResponse ?? RESPONSE_GONE_BYTES;
+      }
+
+      const response = await handler(envelope.payload, peerKey);
+      idem.record(peerKey, protocolId, envelope.messageId, 'in', response);
+      return response;
+    });
+  }
+
+  /**
+   * Periodic-tick retry loop. The lifecycle.ts wiring (PR-3) calls
+   * this every ~5s. For each outbox entry whose `nextAttemptAt`
+   * passes `now`, attempts the wire send again using the
+   * already-encoded envelope bytes stored in the outbox.
+   *
+   * Inflight guard + stale-snapshot guard (`hasEntry` after
+   * `tryBeginAttempt`, rc.9 #538 lifted) protect against
+   * concurrent-retry duplicates and against re-sending an entry a
+   * sibling flush has already delivered.
+   *
+   * On non-recoverable error, the entry stays in the outbox until
+   * `dropExpired(now)` evicts it on age — recovering an encoding
+   * bug requires operator action (manual replay or shutdown).
+   */
+  async processOutboxTick(now: number): Promise<void> {
+    if (!this.outbox) return;
+    const due = this.outbox.due(now);
+    for (const entry of due) {
+      await this.retryOutboxEntry(entry);
+    }
+  }
+
+  /**
+   * Opportunistic-flush retry loop. The lifecycle.ts wiring (PR-3)
+   * calls this from a libp2p `connection:open` event for `peerId`:
+   * a reconnection is the signal we were waiting for, so attempt
+   * every pending entry for `peer` NOW even if `nextAttemptAt` is
+   * still in the future.
+   *
+   * Same guards as `processOutboxTick` — must check `hasEntry`
+   * after `tryBeginAttempt` to defend against the rc.9 #538 race.
+   */
+  async processOutboxOnConnect(peerId: string): Promise<void> {
+    if (!this.outbox) return;
+    const pending = this.outbox.pendingFor(peerId);
+    for (const entry of pending) {
+      await this.retryOutboxEntry(entry);
+    }
+  }
+
+  private async retryOutboxEntry(entry: {
+    peer: string;
+    protocol: string;
+    messageId: string;
+    payload: Uint8Array;
+  }): Promise<void> {
+    const outbox = this.outbox!;
+    if (!outbox.tryBeginAttempt(entry.peer, entry.protocol, entry.messageId)) {
+      return;
+    }
+    try {
+      // Stale-snapshot guard — between the moment `due`/`pendingFor`
+      // gave us the snapshot and the moment `tryBeginAttempt` won,
+      // a sibling flush may have completed delivery and called
+      // `markDelivered`. Re-check `hasEntry` and bail if gone.
+      // rc.9 PR #538 lesson, generalised.
+      if (!outbox.hasEntry(entry.peer, entry.protocol, entry.messageId)) {
+        return;
+      }
+      const response = await this.router.send(
+        entry.peer,
+        entry.protocol,
+        entry.payload,
+      );
+      this.idempotencyStore!.record(
+        entry.peer,
+        entry.protocol,
+        entry.messageId,
+        'out',
+        response,
+      );
+      outbox.markDelivered(entry.peer, entry.protocol, entry.messageId);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (isRecoverableSendError(err)) {
+        outbox.enqueueFailure(
+          entry.peer,
+          entry.protocol,
+          entry.messageId,
+          entry.payload,
+          errMsg,
+          this.clock(),
+        );
+      }
+      // Non-recoverable: leave the entry alone. `dropExpired` will
+      // age it out; an operator-facing diagnostic surface (PR-12)
+      // will surface stuck entries so a human can intervene.
+    } finally {
+      outbox.endAttempt(entry.peer, entry.protocol, entry.messageId);
+    }
+  }
+
+  /**
+   * Drop outbox entries past `maxAgeMs`. Returns the dropped
+   * entries so the caller (lifecycle.ts periodic tick) can log
+   * them. No-op if no outbox is wired.
+   */
+  dropExpiredOutbox(now: number): Array<{
+    peer: string;
+    protocol: string;
+    messageId: string;
+    attempts: number;
+    lastError: string;
+  }> {
+    if (!this.outbox) return [];
+    return this.outbox
+      .dropExpired(now)
+      .map(({ peer, protocol, messageId, attempts, lastError }) => ({
+        peer,
+        protocol,
+        messageId,
+        attempts,
+        lastError,
+      }));
+  }
+
+  /** Outbox size, for diagnostics. Zero when no outbox is wired. */
+  outboxSize(): number {
+    return this.outbox?.size() ?? 0;
+  }
+
+  private requireSubstrate(method: string): void {
+    if (!this.idempotencyStore || !this.outbox) {
+      throw new MessengerNotConfiguredError(method);
+    }
+  }
+}
+
+/**
+ * Thrown when a caller invokes `sendReliable` or `register` on a
+ * Messenger constructed without `idempotencyStore` + `outboxStore`.
+ * Loud-fail rather than silent-fallback because a misconfigured
+ * substrate would silently regress every reliability property the
+ * rc.9 plan is built around.
+ */
+export class MessengerNotConfiguredError extends Error {
+  constructor(method: string) {
+    super(
+      `[Messenger] ${method} requires idempotencyStore + outboxStore, ` +
+        `but the Messenger was constructed without them. Pass both at ` +
+        `construction (lifecycle.ts wires Sqlite-backed stores from the ` +
+        `DashboardDB; see docs/messenger.md).`,
+    );
+    this.name = 'MessengerNotConfiguredError';
   }
 }

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -89,6 +89,11 @@ export interface SendReliableOpts {
  *     `attempts` tracks the total retry count so far (starts at 1 for
  *     the first failure).
  *
+ *   - `{ delivered: false, queued: false, inFlight: true, ... }` —
+ *     another sender already owns the in-process attempt for this
+ *     `(peer, protocol, messageId)`. No durable outbox row necessarily
+ *     exists yet, so callers must not treat this as queued.
+ *
  *   - Thrown — non-recoverable error (encoding bug, unhandleable
  *     protocol id, etc.) is rethrown to the caller. The substrate
  *     does NOT enqueue these because retrying won't help.
@@ -113,6 +118,14 @@ export type ReliableSendResult =
       delivered: false;
       queued: true;
       attempts: number;
+      messageId: string;
+      error: string;
+    }
+  | {
+      delivered: false;
+      queued: false;
+      inFlight: true;
+      attempts: 0;
       messageId: string;
       error: string;
     };
@@ -171,6 +184,7 @@ export class Messenger {
    * caller's handler.
    */
   private readonly handlers = new Map<string, ReliableHandler>();
+  private readonly inboundInFlight = new Map<string, Promise<Uint8Array>>();
 
   constructor(deps: MessengerDeps) {
     this.router = deps.router;
@@ -259,13 +273,14 @@ export class Messenger {
     // when the periodic tick + an opportunistic-flush fire close
     // together. Second attempter exits without dialing.
     if (!outbox.tryBeginAttempt(peerId, protocolId, messageId)) {
-      // Another attempt is in flight. Return queued; the in-flight
-      // one will either deliver (writes to idempotency cache) or
-      // re-enqueue (updates outbox).
+      // Another attempt is in flight. This is not the same thing as
+      // durable queued: the winning attempt may still be on its first
+      // wire send and no outbox row may exist yet.
       return {
         delivered: false,
-        queued: true,
-        attempts: 1,
+        queued: false,
+        inFlight: true,
+        attempts: 0,
         messageId,
         error: 'send already in flight for this messageId',
       };
@@ -372,9 +387,23 @@ export class Messenger {
         return seen.cachedResponse ?? RESPONSE_GONE_BYTES;
       }
 
-      const response = await handler(envelope.payload, peerKey);
-      idem.record(peerKey, protocolId, envelope.messageId, 'in', response);
-      return response;
+      const inFlightKey = this.idempotencyKey(peerKey, protocolId, envelope.messageId, 'in');
+      const inFlight = this.inboundInFlight.get(inFlightKey);
+      if (inFlight) {
+        return inFlight;
+      }
+
+      const handled = (async () => {
+        const response = await handler(envelope.payload, peerKey);
+        idem.record(peerKey, protocolId, envelope.messageId, 'in', response);
+        return response;
+      })();
+      this.inboundInFlight.set(inFlightKey, handled);
+      try {
+        return await handled;
+      } finally {
+        this.inboundInFlight.delete(inFlightKey);
+      }
     });
   }
 
@@ -504,6 +533,15 @@ export class Messenger {
     if (!this.idempotencyStore || !this.outbox) {
       throw new MessengerNotConfiguredError(method);
     }
+  }
+
+  private idempotencyKey(
+    peer: string,
+    protocol: string,
+    messageId: string,
+    direction: 'in' | 'out',
+  ): string {
+    return `${peer}\x00${protocol}\x00${messageId}\x00${direction}`;
   }
 }
 

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -66,14 +66,6 @@ export interface SendReliableOpts {
    */
   messageId?: string;
   timeoutMs?: number;
-  /**
-   * Max age (ms) before an outbox entry for this `(peer, protocol,
-   * messageId)` is considered stale and dropped. Defaults to the
-   * Messenger's instance-level `maxAgeMs` (24h). Override for callers
-   * that want shorter expiry (e.g. ephemeral chat) or longer
-   * (e.g. join-approval).
-   */
-  maxAgeMs?: number;
 }
 
 /**
@@ -311,6 +303,7 @@ export class Messenger {
         envelope,
         errMsg,
         this.clock(),
+        { timeoutMs: opts.timeoutMs },
       );
       return {
         delivered: false,
@@ -453,6 +446,7 @@ export class Messenger {
     protocol: string;
     messageId: string;
     payload: Uint8Array;
+    timeoutMs?: number;
   }): Promise<void> {
     const outbox = this.outbox!;
     if (!outbox.tryBeginAttempt(entry.peer, entry.protocol, entry.messageId)) {
@@ -471,6 +465,7 @@ export class Messenger {
         entry.peer,
         entry.protocol,
         entry.payload,
+        entry.timeoutMs,
       );
       this.idempotencyStore!.record(
         entry.peer,
@@ -490,6 +485,7 @@ export class Messenger {
           entry.payload,
           errMsg,
           this.clock(),
+          { timeoutMs: entry.timeoutMs },
         );
       }
       // Non-recoverable: leave the entry alone. `dropExpired` will

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  InMemoryMessageIdempotencyStore,
+  InMemoryProtocolOutboxStore,
+  decodeReliableEnvelope,
+  encodeReliableEnvelope,
+  RELIABLE_ENVELOPE_VERSION,
+  RESPONSE_GONE_MARKER,
+  type ProtocolRouter,
+  type StreamHandler,
+} from '@origintrail-official/dkg-core';
+import { Messenger, MessengerNotConfiguredError } from '../src/p2p/messenger.js';
+
+const PEER_A = '12D3KooWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const PEER_B = '12D3KooWBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const PROTO = '/dkg/10.0.1/message';
+const FIXED_MSG_ID = '00000000-0000-4000-8000-000000000001';
+
+interface RouterDouble {
+  send: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  /** Inbound stream handler captured from `register` for tests that invoke it. */
+  inboundHandler?: StreamHandler;
+}
+
+function makeRouter(sendImpl?: () => Promise<Uint8Array>): RouterDouble {
+  const router: RouterDouble = {
+    send: vi.fn(sendImpl ?? (async () => new Uint8Array([0x10]))),
+    register: vi.fn((_protocol: string, handler: StreamHandler) => {
+      router.inboundHandler = handler;
+    }),
+  };
+  return router;
+}
+
+function makeSubstrate(overrides: { router?: RouterDouble } = {}) {
+  const router = overrides.router ?? makeRouter();
+  const idempotencyStore = new InMemoryMessageIdempotencyStore();
+  const outboxStore = new InMemoryProtocolOutboxStore({
+    backoffs: [10],
+    maxAgeMs: 60_000,
+  });
+  const clock = vi.fn(() => 1_700_000_000_000);
+  const messenger = new Messenger({
+    router: router as unknown as ProtocolRouter,
+    idempotencyStore,
+    outboxStore,
+    backoffs: [10],
+    maxAgeMs: 60_000,
+    clock,
+  });
+  return { messenger, router, idempotencyStore, outboxStore, clock };
+}
+
+describe('Messenger.sendReliable (happy path semantics)', () => {
+  it('envelope-wraps the payload before calling router.send', async () => {
+    const { messenger, router } = makeSubstrate();
+    const payload = new TextEncoder().encode('hello');
+
+    const result = await messenger.sendReliable(PEER_B, PROTO, payload, {
+      messageId: FIXED_MSG_ID,
+    });
+
+    expect(result).toMatchObject({
+      delivered: true,
+      messageId: FIXED_MSG_ID,
+      attempts: 1,
+    });
+    expect(router.send).toHaveBeenCalledTimes(1);
+    const [, , wireBytes] = router.send.mock.calls[0];
+    const decoded = decodeReliableEnvelope(wireBytes as Uint8Array);
+    expect(decoded.messageId).toBe(FIXED_MSG_ID);
+    expect(decoded.version).toBe(RELIABLE_ENVELOPE_VERSION);
+    expect(Array.from(decoded.payload)).toEqual(Array.from(payload));
+  });
+
+  it('returns the response bytes from the wire send', async () => {
+    const router = makeRouter(async () => new Uint8Array([0x42]));
+    const { messenger } = makeSubstrate({ router });
+    const result = await messenger.sendReliable(
+      PEER_A,
+      PROTO,
+      new Uint8Array([1]),
+      { messageId: FIXED_MSG_ID },
+    );
+    expect(result.delivered).toBe(true);
+    expect(result.delivered && Array.from(result.response)).toEqual([0x42]);
+  });
+
+  it('records the response in the idempotency store under direction=out', async () => {
+    const router = makeRouter(async () => new Uint8Array([0x42]));
+    const { messenger, idempotencyStore } = makeSubstrate({ router });
+    await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+    const check = idempotencyStore.check(PEER_A, PROTO, FIXED_MSG_ID, 'out');
+    expect(check.seen).toBe(true);
+    expect(check.seen && Array.from(check.cachedResponse ?? [])).toEqual([0x42]);
+  });
+
+  it('generates a UUID when no messageId is supplied', async () => {
+    const { messenger } = makeSubstrate();
+    const result = await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]));
+    expect(result.messageId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+});
+
+describe('Messenger.sendReliable (sender-side idempotency)', () => {
+  it('returns the cached response on a second send with the same messageId, no router call', async () => {
+    const router = makeRouter(async () => new Uint8Array([0x42]));
+    const { messenger } = makeSubstrate({ router });
+    await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+    expect(router.send).toHaveBeenCalledTimes(1);
+    const second = await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([2]), {
+      messageId: FIXED_MSG_ID,
+    });
+    expect(router.send).toHaveBeenCalledTimes(1);
+    expect(second.delivered).toBe(true);
+    expect(second.delivered && Array.from(second.response)).toEqual([0x42]);
+  });
+});
+
+describe('Messenger.sendReliable (failure / outbox)', () => {
+  it('queues on recoverable failure and reports queued=true with attempts=1', async () => {
+    const router = makeRouter(async () => {
+      throw new Error('no valid addresses for peer');
+    });
+    const { messenger, outboxStore } = makeSubstrate({ router });
+
+    const result = await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+
+    expect(result).toMatchObject({
+      delivered: false,
+      queued: true,
+      attempts: 1,
+      messageId: FIXED_MSG_ID,
+    });
+    expect(outboxStore.size()).toBe(1);
+    expect(outboxStore.hasEntry(PEER_A, PROTO, FIXED_MSG_ID)).toBe(true);
+  });
+
+  it('rethrows non-recoverable errors without enqueueing', async () => {
+    const router = makeRouter(async () => {
+      throw new Error('something unexpected exploded');
+    });
+    const { messenger, outboxStore } = makeSubstrate({ router });
+
+    await expect(
+      messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      }),
+    ).rejects.toThrow(/something unexpected/);
+    expect(outboxStore.size()).toBe(0);
+  });
+
+  it('releases the inflight slot even when the send rejects', async () => {
+    const router = makeRouter(async () => {
+      throw new Error('no valid addresses for peer');
+    });
+    const { messenger, outboxStore: _outboxStore } = makeSubstrate({ router });
+    void _outboxStore;
+    await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+    // A second sendReliable on the same key should be free to attempt
+    // (will queue again because router still throws).
+    const second = await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+    expect(second.queued).toBe(true);
+    expect(second.attempts).toBe(2);
+  });
+});
+
+describe('Messenger.register (receiver-side idempotency)', () => {
+  it('decodes the envelope and invokes the handler with the inner payload', async () => {
+    const { messenger, router } = makeSubstrate();
+    const handler = vi.fn(async (req: Uint8Array, _peer: string) => {
+      return new Uint8Array([...req, 0xff]);
+    });
+    messenger.register(PROTO, handler);
+    expect(router.register).toHaveBeenCalledWith(PROTO, expect.any(Function));
+
+    const envelope = encodeReliableEnvelope({
+      messageId: FIXED_MSG_ID,
+      version: RELIABLE_ENVELOPE_VERSION,
+      tsMs: 1,
+      payload: new Uint8Array([1, 2, 3]),
+    });
+    const peerIdObj = { toString: () => PEER_A, toBytes: () => new Uint8Array() };
+    const response = await router.inboundHandler!(envelope, peerIdObj);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    // protobufjs decodes `bytes` fields into Node Buffer (a Uint8Array
+    // subclass). Compare bytes-as-array rather than typed-array identity.
+    expect(Array.from(handler.mock.calls[0][0])).toEqual([1, 2, 3]);
+    expect(Array.from(response)).toEqual([1, 2, 3, 0xff]);
+  });
+
+  it('returns the cached response on a duplicate receive without invoking the handler', async () => {
+    const { messenger, router } = makeSubstrate();
+    const handler = vi.fn(async () => new Uint8Array([0xaa]));
+    messenger.register(PROTO, handler);
+
+    const envelope = encodeReliableEnvelope({
+      messageId: FIXED_MSG_ID,
+      version: RELIABLE_ENVELOPE_VERSION,
+      tsMs: 1,
+      payload: new Uint8Array([1]),
+    });
+    const peerIdObj = { toString: () => PEER_A, toBytes: () => new Uint8Array() };
+    const first = await router.inboundHandler!(envelope, peerIdObj);
+    const second = await router.inboundHandler!(envelope, peerIdObj);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(Array.from(first)).toEqual([0xaa]);
+    expect(Array.from(second)).toEqual([0xaa]);
+  });
+
+  it('returns RESPONSE_GONE bytes on a duplicate receive when the original response was too big to cache', async () => {
+    const { messenger, router, idempotencyStore } = makeSubstrate();
+    // Pre-record the idempotency entry as mark-only (response: undefined).
+    idempotencyStore.record(PEER_A, PROTO, FIXED_MSG_ID, 'in');
+    messenger.register(PROTO, async () => new Uint8Array([0xaa]));
+
+    const envelope = encodeReliableEnvelope({
+      messageId: FIXED_MSG_ID,
+      version: RELIABLE_ENVELOPE_VERSION,
+      tsMs: 1,
+      payload: new Uint8Array([1]),
+    });
+    const peerIdObj = { toString: () => PEER_A, toBytes: () => new Uint8Array() };
+    const response = await router.inboundHandler!(envelope, peerIdObj);
+
+    expect(new TextDecoder().decode(response)).toBe(RESPONSE_GONE_MARKER);
+  });
+
+  it('surfaces decode errors loudly (no silent bare-bytes fallback)', async () => {
+    const { messenger, router } = makeSubstrate();
+    messenger.register(PROTO, async () => new Uint8Array([0xaa]));
+    const garbage = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff]);
+    const peerIdObj = { toString: () => PEER_A, toBytes: () => new Uint8Array() };
+    await expect(router.inboundHandler!(garbage, peerIdObj)).rejects.toThrow(
+      /failed to decode ReliableEnvelope/,
+    );
+  });
+});
+
+describe('Messenger.processOutboxTick (retry loop semantics)', () => {
+  it('retries due entries via router.send and marks delivered on success', async () => {
+    let shouldFail = true;
+    const router = makeRouter(async () => {
+      if (shouldFail) throw new Error('no valid addresses for peer');
+      return new Uint8Array([0x42]);
+    });
+    const { messenger, outboxStore, clock } = makeSubstrate({ router });
+
+    // First attempt fails + enqueues.
+    await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+    expect(outboxStore.size()).toBe(1);
+
+    // Backoff is 10ms (configured in makeSubstrate); advance the
+    // injected clock and let router.send succeed this time.
+    shouldFail = false;
+    const due = outboxStore.due(clock() + 100);
+    expect(due).toHaveLength(1);
+
+    await messenger.processOutboxTick(clock() + 100);
+    expect(outboxStore.size()).toBe(0);
+  });
+
+  it('honours the stale-snapshot guard (rc.9 #538) — markDelivered in between aborts the retry', async () => {
+    // Surfaced via: first attempt fails + queues; we manually
+    // markDelivered before the next tick to simulate a sibling
+    // flush; tick must NOT re-send.
+    const router = makeRouter(async () => {
+      throw new Error('no valid addresses for peer');
+    });
+    const { messenger, outboxStore, clock } = makeSubstrate({ router });
+
+    await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+    expect(outboxStore.size()).toBe(1);
+    const sendCallsBefore = router.send.mock.calls.length;
+
+    // Sibling flush completes delivery — we model that as
+    // markDelivered without going through the wire.
+    outboxStore.markDelivered(PEER_A, PROTO, FIXED_MSG_ID);
+
+    await messenger.processOutboxTick(clock() + 100);
+    expect(router.send.mock.calls.length).toBe(sendCallsBefore);
+  });
+});
+
+describe('Messenger construction guardrails', () => {
+  it('throws MessengerNotConfiguredError when sendReliable is called without stores wired', async () => {
+    const router = makeRouter();
+    const messenger = new Messenger({ router: router as unknown as ProtocolRouter });
+    await expect(
+      messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1])),
+    ).rejects.toThrow(MessengerNotConfiguredError);
+  });
+
+  it('throws MessengerNotConfiguredError when register is called without stores wired', () => {
+    const router = makeRouter();
+    const messenger = new Messenger({ router: router as unknown as ProtocolRouter });
+    expect(() => messenger.register(PROTO, async () => new Uint8Array([0]))).toThrow(
+      MessengerNotConfiguredError,
+    );
+  });
+
+  it('keeps legacy sendToPeer working in a bare-router fixture (backwards compat for /dkg/10.0.0/* callers)', async () => {
+    const router = makeRouter(async () => new Uint8Array([0x77]));
+    const messenger = new Messenger({ router: router as unknown as ProtocolRouter });
+    const out = await messenger.sendToPeer(PEER_A, '/dkg/10.0.0/message', new Uint8Array([1]));
+    expect(Array.from(out)).toEqual([0x77]);
+  });
+});

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -143,6 +143,36 @@ describe('Messenger.sendReliable (failure / outbox)', () => {
     expect(outboxStore.hasEntry(PEER_A, PROTO, FIXED_MSG_ID)).toBe(true);
   });
 
+  it('reports inFlight instead of queued when a duplicate send races the active attempt', async () => {
+    let release!: (value: Uint8Array) => void;
+    const router = makeRouter(
+      () => new Promise<Uint8Array>((resolve) => {
+        release = resolve;
+      }),
+    );
+    const { messenger, outboxStore } = makeSubstrate({ router });
+
+    const first = messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+    expect(router.send).toHaveBeenCalledTimes(1);
+
+    const second = await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+    expect(second).toMatchObject({
+      delivered: false,
+      queued: false,
+      inFlight: true,
+      attempts: 0,
+      messageId: FIXED_MSG_ID,
+    });
+    expect(outboxStore.size()).toBe(0);
+
+    release(new Uint8Array([0x55]));
+    await expect(first).resolves.toMatchObject({ delivered: true, messageId: FIXED_MSG_ID });
+  });
+
   it('rethrows non-recoverable errors without enqueueing', async () => {
     const router = makeRouter(async () => {
       throw new Error('something unexpected exploded');
@@ -219,6 +249,36 @@ describe('Messenger.register (receiver-side idempotency)', () => {
     expect(handler).toHaveBeenCalledTimes(1);
     expect(Array.from(first)).toEqual([0xaa]);
     expect(Array.from(second)).toEqual([0xaa]);
+  });
+
+  it('coalesces concurrent duplicate receives while the first handler is still running', async () => {
+    const { messenger, router } = makeSubstrate();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const handler = vi.fn(async () => {
+      await gate;
+      return new Uint8Array([0xab]);
+    });
+    messenger.register(PROTO, handler);
+
+    const envelope = encodeReliableEnvelope({
+      messageId: FIXED_MSG_ID,
+      version: RELIABLE_ENVELOPE_VERSION,
+      tsMs: 1,
+      payload: new Uint8Array([1]),
+    });
+    const peerIdObj = { toString: () => PEER_A, toBytes: () => new Uint8Array() };
+    const first = router.inboundHandler!(envelope, peerIdObj);
+    const second = router.inboundHandler!(envelope, peerIdObj);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    release();
+    const [firstResponse, secondResponse] = await Promise.all([first, second]);
+    expect(Array.from(firstResponse)).toEqual([0xab]);
+    expect(Array.from(secondResponse)).toEqual([0xab]);
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
   it('returns RESPONSE_GONE bytes on a duplicate receive when the original response was too big to cache', async () => {

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -143,6 +143,21 @@ describe('Messenger.sendReliable (failure / outbox)', () => {
     expect(outboxStore.hasEntry(PEER_A, PROTO, FIXED_MSG_ID)).toBe(true);
   });
 
+  it('persists timeoutMs with queued entries for background retries', async () => {
+    const router = makeRouter(async () => {
+      throw new Error('no valid addresses for peer');
+    });
+    const { messenger, outboxStore } = makeSubstrate({ router });
+
+    await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+      timeoutMs: 1234,
+    });
+
+    const [entry] = outboxStore.pendingFor(PEER_A);
+    expect(entry.timeoutMs).toBe(1234);
+  });
+
   it('reports inFlight instead of queued when a duplicate send races the active attempt', async () => {
     let release!: (value: Uint8Array) => void;
     const router = makeRouter(
@@ -322,6 +337,7 @@ describe('Messenger.processOutboxTick (retry loop semantics)', () => {
     // First attempt fails + enqueues.
     await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
       messageId: FIXED_MSG_ID,
+      timeoutMs: 4321,
     });
     expect(outboxStore.size()).toBe(1);
 
@@ -332,6 +348,7 @@ describe('Messenger.processOutboxTick (retry loop semantics)', () => {
     expect(due).toHaveLength(1);
 
     await messenger.processOutboxTick(clock() + 100);
+    expect(router.send.mock.calls[1][3]).toBe(4321);
     expect(outboxStore.size()).toBe(0);
   });
 

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -63,6 +63,8 @@ import {
   ChatMemoryManager,
   LogPushWorker,
   LlmClient,
+  SqliteMessageIdempotencyStore,
+  SqliteProtocolOutboxStore,
   type MetricsSource,
 } from "@origintrail-official/dkg-node-ui";
 import {
@@ -552,6 +554,15 @@ export async function runDaemonInner(
 
   const dashDb = new DashboardDB({ dataDir: dkgDir() });
 
+  // Universal Messenger substrate stores (rc.9 PR-2). Wired into the
+  // DKGAgent's Messenger so any caller that opts into
+  // `messenger.sendReliable` gets durable receiver-side idempotency
+  // + sender-side outbox retries against the shared DashboardDB.
+  // No caller exercises this path until PR-3 (chat + skill migration);
+  // wiring early keeps Milestone A trivially deployable + soak-testable.
+  const messengerIdempotencyStore = new SqliteMessageIdempotencyStore(dashDb);
+  const messengerOutboxStore = new SqliteProtocolOutboxStore(dashDb);
+
   const agent = await DKGAgent.create({
     name: config.name,
     framework: "DKG",
@@ -634,6 +645,10 @@ export async function runDaemonInner(
       delete: async (contextGraphId, principalType, principalId) => {
         dashDb.deleteContextGraphMember(contextGraphId, principalType, principalId);
       },
+    },
+    messengerStores: {
+      idempotencyStore: messengerIdempotencyStore,
+      outboxStore: messengerOutboxStore,
     },
   });
 
@@ -777,8 +792,25 @@ export async function runDaemonInner(
           gossipPublish: async (topic: string, data: Uint8Array) => {
             await agent.gossip.publish(topic, data);
           },
+          // Route storage-ack + verify-proposal outbound sends through
+          // the Messenger rather than directly through ProtocolRouter
+          // (rc.9 PR-2 wiring). Today this is semantically identical
+          // to the prior `agent.router.send` path — `/dkg/10.0.0/*`
+          // protocols travel `Messenger.sendToPeer` (legacy pass-
+          // through) → `ProtocolRouter.send`. The wiring matters at
+          // Milestone C PR-11 when `/storage-ack` + `/verify-proposal`
+          // migrate to `/dkg/10.0.1/*` and start using
+          // `messenger.sendReliable`, picking up the substrate's
+          // durable outbox + sender-side idempotency without
+          // touching this factory again.
+          //
+          // HIGH RISK gate (rc.9 plan): Milestone C migration of
+          // these protocols MUST include an explicit publishing-flow
+          // integration test covering ACK quorum collection + the
+          // ackTransportFactory hot path before the prefix bump
+          // lands.
           sendP2P: async (peerId: string, protocol: string, data: Uint8Array) => {
-            return agent.router.send(peerId, protocol, data);
+            return agent.messenger.sendToPeer(peerId, protocol, data);
           },
           getConnectedCorePeers: () => {
             const allPeers = agent.node.libp2p

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -53,7 +53,7 @@ const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
@@ -561,7 +561,16 @@ export async function runDaemonInner(
   // No caller exercises this path until PR-3 (chat + skill migration);
   // wiring early keeps Milestone A trivially deployable + soak-testable.
   const messengerIdempotencyStore = new SqliteMessageIdempotencyStore(dashDb);
-  const messengerOutboxStore = new SqliteProtocolOutboxStore(dashDb);
+  const messengerOutboxStore = new SqliteProtocolOutboxStore(dashDb, {
+    maxAgeMs: DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS,
+    backoffFor: (attempts) => {
+      const idx = Math.min(
+        Math.max(attempts - 1, 0),
+        DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS.length - 1,
+      );
+      return DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS[idx];
+    },
+  });
 
   const agent = await DKGAgent.create({
     name: config.name,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,8 @@ export {
   ProtocolRouter,
   type ProtocolRouterOptions,
   DEFAULT_MAX_READ_BYTES,
+  DEFAULT_SEND_TIMEOUT_MS,
+  isRecoverableSendError,
 } from './protocol-router.js';
 export { GossipSubManager, type GossipMessageHandler } from './gossipsub-manager.js';
 export { PeerDiscoveryManager } from './discovery.js';

--- a/packages/core/src/messenger-types.ts
+++ b/packages/core/src/messenger-types.ts
@@ -162,11 +162,16 @@ export interface ProtocolOutboxEntry {
   protocol: string;
   messageId: string;
   payload: Uint8Array;
+  timeoutMs?: number;
   attempts: number;
   firstFailureAt: number;
   lastAttemptAt: number;
   nextAttemptAt: number;
   lastError: string;
+}
+
+export interface ProtocolOutboxEnqueueOptions {
+  timeoutMs?: number;
 }
 
 export interface ProtocolOutboxStore {
@@ -186,6 +191,7 @@ export interface ProtocolOutboxStore {
     payload: Uint8Array,
     error: string,
     now: number,
+    options?: ProtocolOutboxEnqueueOptions,
   ): ProtocolOutboxEntry;
 
   /**

--- a/packages/core/src/protocol-outbox.ts
+++ b/packages/core/src/protocol-outbox.ts
@@ -32,6 +32,7 @@ import type {
   MessageDirection,
   MessageIdempotencyStore,
   ProtocolOutboxEntry,
+  ProtocolOutboxEnqueueOptions,
   ProtocolOutboxStore,
 } from './messenger-types.js';
 import { RESPONSE_CACHE_BYTES } from './messenger-types.js';
@@ -155,8 +156,9 @@ export class ProtocolOutbox {
     payload: Uint8Array,
     error: string,
     now: number,
+    options?: ProtocolOutboxEnqueueOptions,
   ): ProtocolOutboxEntry {
-    return this.store.enqueue(peer, protocol, messageId, payload, error, now);
+    return this.store.enqueue(peer, protocol, messageId, payload, error, now, options);
   }
 
   /**
@@ -250,6 +252,7 @@ export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
     payload: Uint8Array,
     error: string,
     now: number,
+    options: ProtocolOutboxEnqueueOptions = {},
   ): ProtocolOutboxEntry {
     const key = InMemoryProtocolOutboxStore.key(peer, protocol, messageId);
     const existing = this.entries.get(key);
@@ -258,6 +261,7 @@ export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
       existing.lastAttemptAt = now;
       existing.nextAttemptAt = now + this.backoffFor(existing.attempts);
       existing.lastError = error;
+      existing.timeoutMs = options.timeoutMs ?? existing.timeoutMs;
       return { ...existing };
     }
     const entry: ProtocolOutboxEntry = {
@@ -265,6 +269,7 @@ export class InMemoryProtocolOutboxStore implements ProtocolOutboxStore {
       protocol,
       messageId,
       payload,
+      timeoutMs: options.timeoutMs,
       attempts: 1,
       firstFailureAt: now,
       lastAttemptAt: now,

--- a/packages/core/test/protocol-outbox.test.ts
+++ b/packages/core/test/protocol-outbox.test.ts
@@ -62,6 +62,22 @@ describe('ProtocolOutbox.enqueueFailure', () => {
     outbox.enqueueFailure(PEER_A, PROTO, MSG_2, PAYLOAD, 'b', 1000);
     expect(outbox.size()).toBe(2);
   });
+
+  it('preserves per-message timeout metadata on queued entries', () => {
+    const { outbox } = fixture();
+    const entry = outbox.enqueueFailure(
+      PEER_A,
+      PROTO,
+      MSG_1,
+      PAYLOAD,
+      'reset',
+      1000,
+      { timeoutMs: 1234 },
+    );
+
+    expect(entry.timeoutMs).toBe(1234);
+    expect(outbox.due(Number.MAX_SAFE_INTEGER)[0].timeoutMs).toBe(1234);
+  });
 });
 
 describe('ProtocolOutbox.markDelivered + hasEntry', () => {

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -9,7 +9,7 @@ import {
   type ProtocolOutboxStore,
 } from '@origintrail-official/dkg-core';
 
-const SCHEMA_VERSION = 12;
+const SCHEMA_VERSION = 13;
 const DEFAULT_RETENTION_DAYS = 90;
 
 export interface DashboardDBOptions {
@@ -413,10 +413,10 @@ export class DashboardDB {
       //     queue sizes (~tens of entries per peer).
       //
       // No data migration: pure additive. The chat-specific
-      // `idx_chat_msgid` from V11 stays in place — PR-3 will drop
-      // it (V13) once chat migrates onto the substrate and
+      // `idx_chat_msgid` from V11 stays in place — a later migration
+      // will drop it once chat migrates onto the substrate and
       // `message_id` is enforced via `message_idempotency` instead.
-      // V13 will also preserve `chat_messages.message_id` as
+      // That migration will also preserve `chat_messages.message_id` as
       // nullable + unwritten for rollback safety.
       this.db.exec(`
         CREATE TABLE IF NOT EXISTS message_idempotency (
@@ -436,6 +436,7 @@ export class DashboardDB {
           protocol TEXT NOT NULL,
           message_id TEXT NOT NULL,
           payload BLOB NOT NULL,
+          timeout_ms INTEGER,
           attempts INTEGER NOT NULL DEFAULT 0,
           first_failure_at INTEGER NOT NULL,
           last_attempt_at INTEGER NOT NULL,
@@ -446,6 +447,17 @@ export class DashboardDB {
         CREATE INDEX IF NOT EXISTS idx_outbox_next_attempt
           ON protocol_outbox(next_attempt_at);
       `);
+
+    }
+
+    if (version < 13) {
+      const outboxCols = new Set(
+        (this.db.prepare('PRAGMA table_info(protocol_outbox)').all() as Array<{ name: string }>)
+          .map((c) => c.name),
+      );
+      if (outboxCols.size > 0 && !outboxCols.has('timeout_ms')) {
+        this.db.exec(`ALTER TABLE protocol_outbox ADD COLUMN timeout_ms INTEGER;`);
+      }
     }
 
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
@@ -1722,6 +1734,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
     payload: Uint8Array,
     error: string,
     now: number,
+    options: { timeoutMs?: number } = {},
   ): ProtocolOutboxEntry {
     const existing = this.db
       .prepare(
@@ -1734,6 +1747,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
           protocol: string;
           message_id: string;
           payload: Buffer;
+          timeout_ms: number | null;
           attempts: number;
           first_failure_at: number;
           last_attempt_at: number;
@@ -1745,13 +1759,14 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
     if (existing) {
       const newAttempts = existing.attempts + 1;
       const nextAttemptAt = now + this.backoffFor(newAttempts);
+      const timeoutMs = options.timeoutMs ?? existing.timeout_ms ?? undefined;
       this.db
         .prepare(
           `UPDATE protocol_outbox
-           SET attempts = ?, last_attempt_at = ?, next_attempt_at = ?, last_error = ?
+           SET attempts = ?, last_attempt_at = ?, next_attempt_at = ?, last_error = ?, timeout_ms = ?
            WHERE peer_id = ? AND protocol = ? AND message_id = ?`,
         )
-        .run(newAttempts, now, nextAttemptAt, error, peer, protocol, messageId);
+        .run(newAttempts, now, nextAttemptAt, error, timeoutMs ?? null, peer, protocol, messageId);
       return {
         peer,
         protocol,
@@ -1761,6 +1776,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
           existing.payload.byteOffset,
           existing.payload.byteLength,
         ),
+        timeoutMs,
         attempts: newAttempts,
         firstFailureAt: existing.first_failure_at,
         lastAttemptAt: now,
@@ -1775,16 +1791,17 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
     this.db
       .prepare(
         `INSERT INTO protocol_outbox
-           (peer_id, protocol, message_id, payload, attempts,
+           (peer_id, protocol, message_id, payload, timeout_ms, attempts,
             first_failure_at, last_attempt_at, next_attempt_at, last_error)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(peer, protocol, messageId, blob, attempts, now, now, nextAttemptAt, error);
+      .run(peer, protocol, messageId, blob, options.timeoutMs ?? null, attempts, now, now, nextAttemptAt, error);
     return {
       peer,
       protocol,
       messageId,
       payload,
+      timeoutMs: options.timeoutMs,
       attempts,
       firstFailureAt: now,
       lastAttemptAt: now,
@@ -1823,6 +1840,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
       protocol: string;
       message_id: string;
       payload: Buffer;
+      timeout_ms: number | null;
       attempts: number;
       first_failure_at: number;
       last_attempt_at: number;
@@ -1842,6 +1860,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
       protocol: string;
       message_id: string;
       payload: Buffer;
+      timeout_ms: number | null;
       attempts: number;
       first_failure_at: number;
       last_attempt_at: number;
@@ -1860,6 +1879,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
       protocol: string;
       message_id: string;
       payload: Buffer;
+      timeout_ms: number | null;
       attempts: number;
       first_failure_at: number;
       last_attempt_at: number;
@@ -1882,6 +1902,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
     protocol: string;
     message_id: string;
     payload: Buffer;
+    timeout_ms: number | null;
     attempts: number;
     first_failure_at: number;
     last_attempt_at: number;
@@ -1893,6 +1914,7 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
       protocol: row.protocol,
       messageId: row.message_id,
       payload: new Uint8Array(row.payload.buffer, row.payload.byteOffset, row.payload.byteLength),
+      timeoutMs: row.timeout_ms ?? undefined,
       attempts: row.attempts,
       firstFailureAt: row.first_failure_at,
       lastAttemptAt: row.last_attempt_at,

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -1,4 +1,9 @@
-export { DashboardDB } from './db.js';
+export {
+  DashboardDB,
+  SqliteMessageIdempotencyStore,
+  SqliteProtocolOutboxStore,
+  type SqliteProtocolOutboxStoreOptions,
+} from './db.js';
 export type {
   DashboardDBOptions,
   MetricSnapshotRow,

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
 });
 
-describe('V12 migration', () => {
+describe('V13 migration', () => {
   it('creates message_idempotency and protocol_outbox tables', () => {
     const tables = (db.db
       .prepare("SELECT name FROM sqlite_master WHERE type='table'")
@@ -38,8 +38,38 @@ describe('V12 migration', () => {
     expect(tables).toContain('protocol_outbox');
   });
 
-  it('records user_version = 12 after migration', () => {
-    expect(db.db.pragma('user_version', { simple: true })).toBe(12);
+  it('records user_version = 13 after migration', () => {
+    expect(db.db.pragma('user_version', { simple: true })).toBe(13);
+  });
+
+  it('adds timeout_ms when reopening an existing V12 protocol_outbox table', () => {
+    db.db.exec(`
+      DROP TABLE protocol_outbox;
+      CREATE TABLE protocol_outbox (
+        peer_id TEXT NOT NULL,
+        protocol TEXT NOT NULL,
+        message_id TEXT NOT NULL,
+        payload BLOB NOT NULL,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        first_failure_at INTEGER NOT NULL,
+        last_attempt_at INTEGER NOT NULL,
+        next_attempt_at INTEGER NOT NULL,
+        last_error TEXT,
+        PRIMARY KEY (peer_id, protocol, message_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_outbox_next_attempt
+        ON protocol_outbox(next_attempt_at);
+      PRAGMA user_version = 12;
+    `);
+    db.close();
+
+    db = new DashboardDB({ dataDir: dir });
+
+    const cols = (db.db
+      .prepare('PRAGMA table_info(protocol_outbox)')
+      .all() as Array<{ name: string }>).map((col) => col.name);
+    expect(cols).toContain('timeout_ms');
+    expect(db.db.pragma('user_version', { simple: true })).toBe(13);
   });
 });
 
@@ -130,8 +160,11 @@ describe('SqliteMessageIdempotencyStore', () => {
 describe('SqliteProtocolOutboxStore', () => {
   it('enqueue creates a new entry with attempts=1', () => {
     const store = new SqliteProtocolOutboxStore(db, { backoffFor: () => 5_000 });
-    const entry = store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'reset', 1_000_000);
+    const entry = store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'reset', 1_000_000, {
+      timeoutMs: 1234,
+    });
     expect(entry.attempts).toBe(1);
+    expect(entry.timeoutMs).toBe(1234);
     expect(entry.firstFailureAt).toBe(1_000_000);
     expect(entry.nextAttemptAt).toBe(1_005_000);
     expect(entry.lastError).toBe('reset');
@@ -140,9 +173,12 @@ describe('SqliteProtocolOutboxStore', () => {
 
   it('enqueue bumps attempts and reschedules on repeat failure for the same key', () => {
     const store = new SqliteProtocolOutboxStore(db, { backoffFor: (n) => n * 1000 });
-    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'first', 1_000_000);
+    store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'first', 1_000_000, {
+      timeoutMs: 1234,
+    });
     const second = store.enqueue(PEER_A, PROTO, MSG_1, PAYLOAD, 'second', 1_005_000);
     expect(second.attempts).toBe(2);
+    expect(second.timeoutMs).toBe(1234);
     expect(second.firstFailureAt).toBe(1_000_000);
     expect(second.lastAttemptAt).toBe(1_005_000);
     expect(second.nextAttemptAt).toBe(1_005_000 + 2000);
@@ -209,6 +245,7 @@ describe('SqliteProtocolOutboxStore', () => {
     const pending = reopened.pendingFor(PEER_A);
     expect(pending).toHaveLength(1);
     expect(pending[0].lastError).toBe('crash-before-delivery');
+    expect(pending[0].timeoutMs).toBeUndefined();
     expect(Array.from(pending[0].payload)).toEqual(Array.from(PAYLOAD));
   });
 });


### PR DESCRIPTION
## Summary

Milestone A, PR-2 of the [Universal Messenger plan](../../tree/feat/messenger-substrate-primitives/docs/messenger.md). Stacks on top of #542 (PR-1).

Evolves the agent-layer `Messenger` so any caller can opt into durable reliability (sender outbox + receiver-side idempotency + a universal `ReliableEnvelope` wire wrapper) **while keeping the legacy `sendToPeer` path bitwise-compatible** for `/dkg/10.0.0/*` protocols that haven't migrated yet.

Once this lands, every caller migration (PR-3 onward) is a tiny diff — no transport rewiring, just swap `router.send` for `messenger.sendReliable` and pick a `/dkg/10.0.1/*` prefix.

## What's in the PR

**`packages/agent/src/p2p/messenger.ts` (substantially rewritten)**

- Constructor now accepts optional `MessageIdempotencyStore` + `ProtocolOutboxStore` (from PR-1).
- **`sendReliable(peerId, protocolId, payload, opts)`** — wraps payload in `ReliableEnvelope`, dedups by `messageId` on the sender (returns cached response or `RESPONSE_GONE`), enqueues to outbox on `isRecoverableSendError`, surfaces hard failures eagerly.
- **`register(protocolId, handler)`** — installs a receiver that decodes the envelope, gates on `idempotencyStore.check()`, caches the response (≤ `RESPONSE_CACHE_BYTES`) or marks `RESPONSE_GONE`, de-dups duplicate inbound streams.
- **`processOutboxTick(now)` / `processOutboxOnConnect(peer)` / `dropExpiredOutbox(now)`** — drive the retry loop.
- **`MessengerNotConfiguredError`** — thrown if `sendReliable`/`register` is called without stores wired. Fails loud; never silent.
- Existing `sendToPeer` path is unchanged — `/dkg/10.0.0/*` callers are unaffected.

**`packages/agent/src/dkg-agent.ts`**

- `DKGAgentConfig.messengerStores?: { idempotencyStore, outboxStore }`.
- Constructor passes them through to `new Messenger({...})`.
- New `messengerOutboxTimer` running at the same cadence as the chat-specific tick (decoupled deliberately — PR-3 deletes the chat outbox without touching the substrate tick).
- Piggy-back call to `messenger.processOutboxOnConnect(peer)` inside the existing `connection:open` handler.
- Dropped-after-expiry entries are logged with `peer/protocol/msgId/lastError`.

**`packages/cli/src/daemon/lifecycle.ts`**

- Instantiates `SqliteMessageIdempotencyStore` + `SqliteProtocolOutboxStore` (from PR-1) against the shared `DashboardDB` and passes them to `DKGAgent.create`.
- Routes `ackTransportFactory.sendP2P` through `messenger.sendToPeer` — semantically identical today, matters at PR-11 when `/storage-ack` + `/verify-proposal` migrate to `/dkg/10.0.1/*` and start using `sendReliable` without further factory edits.

**`packages/core/src/index.ts`**

- Exports `isRecoverableSendError` so Messenger reuses the same error classification as `ProtocolRouter` (no duplicate regex lists).

**`packages/node-ui/src/index.ts`**

- Exports the new SQLite store classes from #542.

**`packages/agent/test/messenger-substrate.test.ts` (new, 17 tests)**

Covers happy path, sender + receiver idempotency, outbox enqueue on recoverable failures, stale-snapshot guard during retries, `RESPONSE_GONE` for oversize responses, and the `MessengerNotConfiguredError` guardrail.

## Risk

**HIGH RISK** per the plan: `ackTransportFactory.sendP2P` is the publishing-flow hot path. This PR routes it through `messenger.sendToPeer` which is pass-through to `ProtocolRouter.send` — identical semantics today. The real migration risk lives at PR-11 (`/storage-ack` + `/verify-proposal` onto `sendReliable`), which the plan gates with a publishing-flow integration test.

To mitigate today: kept the legacy `sendToPeer` path bit-for-bit unchanged so any caller still on `/dkg/10.0.0/*` (which is everyone, until PR-3) sees identical wire behaviour.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core build` — clean
- [x] `pnpm --filter @origintrail-official/dkg-node-ui build` — clean
- [x] `pnpm --filter @origintrail-official/dkg-agent build` — clean
- [x] `pnpm --filter @origintrail-official/dkg build` — clean
- [x] `packages/core` test suite — 827/827 ✅
- [x] `packages/node-ui` test suite — 637 pass / 38 skip ✅
- [x] `packages/agent` test suite — 605/606 ✅ (one unrelated pre-existing failure in `swm-snapshot-sync.test.ts`, no changes from this branch)
- [x] New `messenger-substrate.test.ts` — 17/17 ✅
- [ ] Reviewer to sanity-check the `connection:open` + `outbox-tick` integration on a live daemon before PR-3 lands

## Plan position

- Milestone A → **PR-2** ← you are here
- Next: **PR-3** — pilot migration of `/dkg/10.0.0/message` (chat) + `/dkg/10.0.0/skill` to `/dkg/10.0.1/message` + `/dkg/10.0.1/skill`, delete `message-outbox.ts`, V13 migration drops `idx_chat_msgid` (keeps column nullable for rollback).
- Then **Gate A**: cross-laptop chat+skill soak Miles ↔ Lex (1-2h, 5min cadence).

Stacked on #542 (Milestone A PR-1). Base is `feat/messenger-substrate-primitives` and not `main` to keep the diff reviewable; will retarget to `integration/messenger-v1` once #542 merges into it.


Made with [Cursor](https://cursor.com)