### PR TITLE
feat(core): ProtocolRouter.send gains parallelPaths option (rc.9 PR-4)

### DIFF
--- a/docs/messenger.md
+++ b/docs/messenger.md
@@ -181,8 +181,49 @@ is idempotent at the app layer) or surface a terminal error.
   reconnects, drain its `pendingFor(peer)` queue immediately rather
   than wait for backoff. Stale-snapshot-safe via `hasEntry` guard
   (rc.9 #538).
-- **`parallelPaths`** _(PR-4)_ — `Messenger.sendToPeer` can race N
-  candidate paths; receiver dedup absorbs duplicates.
+- **`parallelPaths`** _(PR-4, shipped)_ — `ProtocolRouter.send` races
+  up to N live connections in parallel via `Promise.any`-equivalent;
+  the first successful response wins, loser streams are aborted.
+  Caller passes `parallelPaths` through `SendOptions`:
+
+  ```ts
+  await router.send(peerId, '/dkg/10.0.1/X', payload, { parallelPaths: 3 });
+  ```
+
+  Two failure modes both fall through to the existing single-path
+  retry loop (so cold-peer behaviour is unchanged):
+  1. Fewer than 2 live connections — multi-path adds no value, skipped.
+  2. All N parallel attempts fail — single-path then runs with the full
+     resolver + dialProtocol + 3-retry budget.
+
+  **SAFETY invariant.** `parallelPaths > 1` is only safe for
+  protocols on the `/dkg/10.0.1/*` prefix (or later substrate
+  prefixes) where the receiver registers via `Messenger.register` and
+  dedupes by `messageId` server-side. Older `/dkg/10.0.0/*` callers
+  MUST keep `parallelPaths = 1` (the default) — without receiver
+  dedup, losing-path bytes that reach the receiver cause the
+  handler to fire twice. **This is a wire-version invariant, not a
+  runtime check** — the sender cannot inspect the receiver's
+  substrate version, the protocol-prefix string IS the contract.
+
+  Per-protocol defaults (set at the call site by each caller):
+
+  | Protocol             | Default `parallelPaths` | Reason                                                                 |
+  | -------------------- | ----------------------- | ---------------------------------------------------------------------- |
+  | chat (`/message`)    | 2                       | Latency-sensitive UX path; cheap to race 2 relays.                     |
+  | skill_request        | 1                       | Same wire prefix as chat; usually synchronous-blocking caller.         |
+  | swm-sender-key       | 1                       | Low frequency; latency tolerates single-path retries.                  |
+  | private-access       | 1                       | Same as swm-key.                                                       |
+  | query-remote         | 1                       | Large response; doubling bandwidth hurts more than it helps.           |
+  | join-request         | 1                       | Workflow-gated, not latency-critical.                                  |
+  | storage-ack          | 1                       | App-level ACKCollector already fans out N peers — 9x amplification.    |
+  | verify-proposal      | 1                       | Same shape as storage-ack.                                             |
+
+  Diversity strategy v1: take up to N candidates from the natural
+  connection list. In practice multi-reservation gives us one
+  connection per relay, so the natural list already provides path
+  diversity. Relay-grouped selection is a follow-up if Gate B data
+  shows duplicate-relay amplification matters.
 - **DHT walk on stall** _(PR-5)_ — outbox entry with ≥ 5 attempts of
   "no valid addresses for peer" triggers a time-bounded, rate-limited
   `libp2p.peerRouting.findPeer()`.

--- a/docs/messenger.md
+++ b/docs/messenger.md
@@ -163,7 +163,7 @@ is idempotent at the app layer) or surface a terminal error.
 
 | Protocol                        | Migrated in | parallelPaths | Notes                                                                              |
 | ------------------------------- | ----------- | ------------- | ---------------------------------------------------------------------------------- |
-| `/dkg/10.0.1/message` (chat)    | PR-3        | 2 (PR-4)      | Pilot. Wire-format break replaces `chat_messages.message_id` index uniqueness.     |
+| `/dkg/10.0.1/message` (chat)    | PR-3        | 1 (2 planned) | Pilot. Wire-format break replaces `chat_messages.message_id` index uniqueness.     |
 | `/dkg/10.0.1/skill_request`     | PR-3        | 1             | Migrated alongside chat (shares `agent.sendMessage` path).                         |
 | `/dkg/10.0.1/swm-sender-key`    | PR-8        | 1             | Batch with `/private-access`.                                                      |
 | `/dkg/10.0.1/private-access`    | PR-8        | 1             | Batch with `/swm-sender-key`.                                                      |
@@ -206,11 +206,13 @@ is idempotent at the app layer) or surface a terminal error.
   runtime check** — the sender cannot inspect the receiver's
   substrate version, the protocol-prefix string IS the contract.
 
-  Per-protocol defaults (set at the call site by each caller):
+  Per-protocol defaults (set at the call site by each caller). PR-4
+  ships the router primitive only; chat remains at the safe default
+  until its call site explicitly opts into `parallelPaths: 2`:
 
   | Protocol             | Default `parallelPaths` | Reason                                                                 |
   | -------------------- | ----------------------- | ---------------------------------------------------------------------- |
-  | chat (`/message`)    | 2                       | Latency-sensitive UX path; cheap to race 2 relays.                     |
+  | chat (`/message`)    | 1 (2 planned)           | Latency-sensitive UX path; opt-in happens where chat calls Messenger.  |
   | skill_request        | 1                       | Same wire prefix as chat; usually synchronous-blocking caller.         |
   | swm-sender-key       | 1                       | Low frequency; latency tolerates single-path retries.                  |
   | private-access       | 1                       | Same as swm-key.                                                       |

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -30,6 +30,43 @@ export function isRecoverableSendError(err: unknown): boolean {
   );
 }
 
+/**
+ * Per-call options for {@link ProtocolRouter.send}. Replaces the prior
+ * `timeoutMs: number` 4th-arg shape; the number form is still accepted
+ * for backwards compat with the rc.8 call sites (rc.9 PR-4).
+ */
+export interface SendOptions {
+  /** Overall send timeout (resolver + dial + write + read). Default {@link DEFAULT_SEND_TIMEOUT_MS}. */
+  timeoutMs?: number;
+  /**
+   * Race up to N parallel `newStream` attempts across the peer's live
+   * connections (different relay paths where the natural connection
+   * list provides them). First successful response wins; loser
+   * streams are aborted as soon as the winner is settled.
+   *
+   * Defaults to **1** (existing single-path behaviour preserved).
+   *
+   * **SAFETY — this is a wire-version invariant, NOT a runtime check.**
+   * `parallelPaths > 1` is only safe for protocols on the
+   * `/dkg/10.0.1/*` prefix (or later substrate-managed prefixes)
+   * where the receiver registers via `Messenger.register` and
+   * dedupes duplicates server-side. Passing `parallelPaths > 1` for
+   * a `/dkg/10.0.0/*` protocol can cause the receiver's handler to
+   * run multiple times for the same logical request — every caller
+   * MUST satisfy this prefix invariant before enabling > 1. The
+   * sender cannot inspect the receiver's substrate version; the
+   * protocol-prefix string IS the contract (see docs/messenger.md
+   * "Versioning" and the rc.9 plan PR-4 invariant note).
+   *
+   * When fewer than 2 live connections exist for the peer, the
+   * multi-path attempt is skipped and `send` falls through to the
+   * existing single-path resolver + dialProtocol retry loop. So
+   * passing a high `parallelPaths` on a cold peer is harmless —
+   * there's just one path available, single-path runs.
+   */
+  parallelPaths?: number;
+}
+
 export interface ProtocolRouterOptions {
   maxReadBytes?: number;
   /**
@@ -112,13 +149,49 @@ export class ProtocolRouter {
     peerIdStr: string,
     protocolId: string,
     data: Uint8Array,
-    timeoutMs = DEFAULT_SEND_TIMEOUT_MS,
+    timeoutMsOrOpts: number | SendOptions = DEFAULT_SEND_TIMEOUT_MS,
   ): Promise<Uint8Array> {
+    const opts: SendOptions =
+      typeof timeoutMsOrOpts === 'number' ? { timeoutMs: timeoutMsOrOpts } : timeoutMsOrOpts;
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
+    const parallelPaths = Math.max(1, Math.floor(opts.parallelPaths ?? 1));
+
     const libp2p = this.node.libp2p;
     const { peerIdFromString } = await import('@libp2p/peer-id');
     const peerId = peerIdFromString(peerIdStr);
     const signal = AbortSignal.timeout(timeoutMs);
     const startedAt = Date.now();
+
+    if (parallelPaths > 1) {
+      // Multi-path pre-attempt — race up to N live connections.
+      // Returns the response on a winning path, or null if there
+      // weren't enough live candidates (or all candidates failed).
+      // On null we fall through to the single-path retry loop below
+      // so cold peers + total-multipath-failure both keep the rc.8
+      // semantics intact.
+      const multipathResult = await raceMultiPath({
+        getConnections: () =>
+          rawGetConnectionsFor(libp2p, peerId),
+        protocolId,
+        data,
+        parallelPaths,
+        signal,
+        maxReadBytes: this.maxReadBytes,
+      });
+      if (multipathResult !== null) {
+        const totalDurationMs = Date.now() - startedAt;
+        if (totalDurationMs > 100) {
+          console.warn(
+            `[ProtocolRouter] send ${protocolId} to ${peerIdStr} via multi-path (${multipathResult.attemptedPaths} paths): total=${totalDurationMs}ms`,
+          );
+        }
+        return multipathResult.response;
+      }
+      // All multi-path candidates failed (or fewer than 2 existed) —
+      // fall through to the single-path retry loop. The single-path
+      // does resolver-prime + dialProtocol with the full 3x retry
+      // budget, so we get cold-peer recovery for free.
+    }
 
     if (!this.peerResolver && !this.warnedMissingResolver) {
       // Codex PR #497 round 5: structural enforcement (CI grep gate)
@@ -542,6 +615,178 @@ export async function tryReuseExistingConnection(
     }
   }
   return null;
+}
+
+/**
+ * Internal helper: walk libp2p's raw connection table and return the
+ * subset whose `remotePeer` matches `peerId`. Used by both the
+ * single-path fast-reuse (`tryReuseExistingConnection`) and the
+ * multi-path racer (`raceMultiPath`). Matches the Window D fix's
+ * "raw walk not peerId-keyed lookup" rationale documented above.
+ */
+function rawGetConnectionsFor(
+  libp2p: { getConnections: () => ReadonlyArray<unknown> },
+  peerId: unknown,
+): ReadonlyArray<ReusableConnection> {
+  try {
+    const all = libp2p.getConnections() as ReadonlyArray<
+      ReusableConnection & {
+        remotePeer?: { equals?: (other: unknown) => boolean };
+      }
+    >;
+    return all.filter((c) => {
+      try {
+        return c.remotePeer?.equals?.(peerId) === true;
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Multi-path send result returned by {@link raceMultiPath}. `null`
+ * when the racer didn't run (fewer than 2 live candidates) or every
+ * candidate failed — caller falls through to single-path.
+ */
+export interface MultiPathResult {
+  response: Uint8Array;
+  /** How many paths were started before the winner settled. Surfaced for diagnostics. */
+  attemptedPaths: number;
+}
+
+/**
+ * Race up to `parallelPaths` parallel `newStream` attempts across the
+ * peer's live connections (one stream per connection). First success
+ * wins; loser streams are aborted as soon as the winner is settled.
+ *
+ * Diversity strategy (rc.9 PR-4 v1): take up to N connections from
+ * the natural connection list, no relay-grouping yet. In practice
+ * multi-reservation gives us one connection per relay, so the
+ * natural list already provides path diversity. Relay-grouped
+ * selection is a follow-up if Gate B shows duplicate-relay
+ * amplification matters.
+ *
+ * Returns `null` (not `throw`) on every failure mode so the caller
+ * can fall through to single-path within the same logical `send()`
+ * call. Throwing here would short-circuit the cold-peer recovery
+ * path that the single-path resolver + retry loop is built for.
+ *
+ * SAFETY: caller is responsible for the `/dkg/10.0.1/*` prefix
+ * invariant (see {@link SendOptions.parallelPaths}). The receiver
+ * MUST run `Messenger.register` to dedupe duplicates; without that,
+ * losing-path bytes reaching the receiver cause double-handler
+ * invocation. This function does not (and cannot) check.
+ */
+export async function raceMultiPath(args: {
+  getConnections: () => ReadonlyArray<ReusableConnection>;
+  protocolId: string;
+  data: Uint8Array;
+  parallelPaths: number;
+  signal: AbortSignal;
+  maxReadBytes: number;
+}): Promise<MultiPathResult | null> {
+  const { protocolId, data, parallelPaths, signal, maxReadBytes } = args;
+  const candidates = args.getConnections().filter((c) => !c.status || c.status === 'open');
+  if (candidates.length < 2) {
+    // Single (or zero) live candidates — multi-path adds no value;
+    // the single-path code already handles "one live connection" via
+    // its fast-reuse logic. Fall through.
+    return null;
+  }
+
+  const picked = candidates.slice(0, parallelPaths);
+  const streams: Array<{ stream: import('@libp2p/interface').Stream; aborted: boolean } | null> =
+    picked.map(() => null);
+
+  const attempts = picked.map(async (conn, idx): Promise<Uint8Array> => {
+    const stream = await conn.newStream(protocolId, {
+      runOnLimitedConnection: true,
+      signal,
+    });
+    streams[idx] = { stream, aborted: false };
+    if (stream.writeStatus === 'closed' || stream.writeStatus === 'closing') {
+      try {
+        stream.abort(new Error('multipath: stream returned in closed state'));
+      } catch {
+        // already torn down
+      }
+      throw new Error('multipath: stream returned in closed state');
+    }
+    stream.send(data);
+    await stream.close({ signal });
+    return await readAll(stream, maxReadBytes);
+  });
+
+  // Surface a winner via Promise.any (first FULFILLED wins; if all
+  // reject, AggregateError surfaces and we return null). Loser
+  // streams are aborted in the finally block below, AFTER they
+  // resolve naturally — aborting an in-flight newStream from
+  // outside libp2p is racy, so we let each attempt complete and
+  // abort the stream it produced.
+  const losers: Promise<unknown>[] = attempts.map((p) => p.catch(() => undefined));
+
+  let winnerResponse: Uint8Array | null = null;
+  let winnerIdx = -1;
+  try {
+    // Promise.any-equivalent that also gives us the winning index.
+    winnerResponse = await new Promise<Uint8Array>((resolve, reject) => {
+      let rejected = 0;
+      const errs: unknown[] = [];
+      attempts.forEach((p, i) => {
+        p.then((res) => {
+          if (winnerIdx === -1) {
+            winnerIdx = i;
+            resolve(res);
+          }
+        }).catch((err) => {
+          errs.push(err);
+          rejected += 1;
+          if (rejected === attempts.length) {
+            reject(new AggregateError(errs, 'multipath: all paths failed'));
+          }
+        });
+      });
+    });
+  } catch {
+    // All N attempts failed — return null so caller falls through
+    // to single-path. Wait for any in-flight stream open to settle
+    // so we can clean up.
+    await Promise.allSettled(losers);
+    for (const s of streams) {
+      if (s && !s.aborted) {
+        try {
+          s.stream.abort(new Error('multipath: all paths failed'));
+        } catch {
+          /* already torn down */
+        }
+      }
+    }
+    return null;
+  }
+
+  // Abort losers — schedule the aborts but don't block on them; the
+  // winner's response is already in hand and the receiver's dedup
+  // will absorb any in-flight loser bytes.
+  for (let i = 0; i < streams.length; i++) {
+    if (i === winnerIdx) continue;
+    const settled = losers[i];
+    void settled.then(() => {
+      const s = streams[i];
+      if (s && !s.aborted) {
+        s.aborted = true;
+        try {
+          s.stream.abort(new Error('multipath: loser path'));
+        } catch {
+          /* already torn down */
+        }
+      }
+    });
+  }
+
+  return { response: winnerResponse, attemptedPaths: picked.length };
 }
 
 async function readAll(

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -159,10 +159,10 @@ export class ProtocolRouter {
     const libp2p = this.node.libp2p;
     const { peerIdFromString } = await import('@libp2p/peer-id');
     const peerId = peerIdFromString(peerIdStr);
-    const signal = AbortSignal.timeout(timeoutMs);
     const startedAt = Date.now();
 
     if (parallelPaths > 1) {
+      const multipathSignal = AbortSignal.timeout(timeoutMs);
       // Multi-path pre-attempt — race up to N live connections.
       // Returns the response on a winning path, or null if there
       // weren't enough live candidates (or all candidates failed).
@@ -175,7 +175,7 @@ export class ProtocolRouter {
         protocolId,
         data,
         parallelPaths,
-        signal,
+        signal: multipathSignal,
         maxReadBytes: this.maxReadBytes,
       });
       if (multipathResult !== null) {
@@ -230,6 +230,12 @@ export class ProtocolRouter {
     const triedConnections = new WeakSet<ReusableConnection>();
     let lastErr: unknown;
     for (let attempt = 0; attempt < 3; attempt++) {
+      const remaining = timeoutMs - (Date.now() - startedAt);
+      if (remaining <= 0) {
+        lastErr = new Error('send timeout elapsed');
+        throw lastErr;
+      }
+      const attemptSignal = AbortSignal.timeout(remaining);
       // Track which connection (if any) the fast path picked this
       // attempt so the catch block can blacklist it on failure
       // without needing to inspect stream/connection internals from
@@ -331,7 +337,7 @@ export class ProtocolRouter {
             }
           },
           protocolId,
-          signal,
+          attemptSignal,
           {
             // Probe peerStore for non-circuit (direct) addresses; the
             // fast path uses this to gate whether reusing a LIMITED
@@ -356,9 +362,8 @@ export class ProtocolRouter {
         pickedConnection = fastResult?.connection ?? null;
 
         if (this.peerResolver && !fastStream) {
-          const remaining = Math.max(0, timeoutMs - (Date.now() - startedAt));
           await this.peerResolver
-            .resolve(peerIdStr, { signal, perStepTimeoutMs: remaining })
+            .resolve(peerIdStr, { signal: attemptSignal, perStepTimeoutMs: remaining })
             .catch(() => undefined);
         }
 
@@ -367,7 +372,7 @@ export class ProtocolRouter {
           fastStream ??
           (await libp2p.dialProtocol(peerId, protocolId, {
             runOnLimitedConnection: true,
-            signal,
+            signal: attemptSignal,
           }));
         const dialDurationMs = Date.now() - dialStartedAt;
 
@@ -378,7 +383,7 @@ export class ProtocolRouter {
 
         const sendStartedAt = Date.now();
         stream.send(data);
-        await stream.close({ signal });
+        await stream.close({ signal: attemptSignal });
         const sendDurationMs = Date.now() - sendStartedAt;
 
         const readStartedAt = Date.now();
@@ -700,6 +705,26 @@ export async function raceMultiPath(args: {
   const picked = candidates.slice(0, parallelPaths);
   const streams: Array<{ stream: import('@libp2p/interface').Stream; aborted: boolean } | null> =
     picked.map(() => null);
+  let winnerIdx = -1;
+
+  const abortPath = (idx: number, reason: Error): void => {
+    const s = streams[idx];
+    if (!s || s.aborted) return;
+    s.aborted = true;
+    try {
+      s.stream.abort(reason);
+    } catch {
+      /* already torn down */
+    }
+  };
+
+  const abortLosers = (winningIdx: number): void => {
+    for (let i = 0; i < streams.length; i++) {
+      if (i !== winningIdx) {
+        abortPath(i, new Error('multipath: loser path'));
+      }
+    }
+  };
 
   const attempts = picked.map(async (conn, idx): Promise<Uint8Array> => {
     const stream = await conn.newStream(protocolId, {
@@ -707,6 +732,10 @@ export async function raceMultiPath(args: {
       signal,
     });
     streams[idx] = { stream, aborted: false };
+    if (winnerIdx !== -1 && winnerIdx !== idx) {
+      abortPath(idx, new Error('multipath: late loser path'));
+      throw new Error('multipath: loser path');
+    }
     if (stream.writeStatus === 'closed' || stream.writeStatus === 'closing') {
       try {
         stream.abort(new Error('multipath: stream returned in closed state'));
@@ -720,16 +749,7 @@ export async function raceMultiPath(args: {
     return await readAll(stream, maxReadBytes);
   });
 
-  // Surface a winner via Promise.any (first FULFILLED wins; if all
-  // reject, AggregateError surfaces and we return null). Loser
-  // streams are aborted in the finally block below, AFTER they
-  // resolve naturally — aborting an in-flight newStream from
-  // outside libp2p is racy, so we let each attempt complete and
-  // abort the stream it produced.
-  const losers: Promise<unknown>[] = attempts.map((p) => p.catch(() => undefined));
-
   let winnerResponse: Uint8Array | null = null;
-  let winnerIdx = -1;
   try {
     // Promise.any-equivalent that also gives us the winning index.
     winnerResponse = await new Promise<Uint8Array>((resolve, reject) => {
@@ -739,7 +759,10 @@ export async function raceMultiPath(args: {
         p.then((res) => {
           if (winnerIdx === -1) {
             winnerIdx = i;
+            abortLosers(i);
             resolve(res);
+          } else if (winnerIdx !== i) {
+            abortPath(i, new Error('multipath: loser path'));
           }
         }).catch((err) => {
           errs.push(err);
@@ -752,11 +775,11 @@ export async function raceMultiPath(args: {
     });
   } catch {
     // All N attempts failed — return null so caller falls through
-    // to single-path. Wait for any in-flight stream open to settle
-    // so we can clean up.
-    await Promise.allSettled(losers);
+    // to single-path. At this point every attempt rejected, so any
+    // streams that opened can be aborted synchronously.
     for (const s of streams) {
       if (s && !s.aborted) {
+        s.aborted = true;
         try {
           s.stream.abort(new Error('multipath: all paths failed'));
         } catch {
@@ -765,25 +788,6 @@ export async function raceMultiPath(args: {
       }
     }
     return null;
-  }
-
-  // Abort losers — schedule the aborts but don't block on them; the
-  // winner's response is already in hand and the receiver's dedup
-  // will absorb any in-flight loser bytes.
-  for (let i = 0; i < streams.length; i++) {
-    if (i === winnerIdx) continue;
-    const settled = losers[i];
-    void settled.then(() => {
-      const s = streams[i];
-      if (s && !s.aborted) {
-        s.aborted = true;
-        try {
-          s.stream.abort(new Error('multipath: loser path'));
-        } catch {
-          /* already torn down */
-        }
-      }
-    });
   }
 
   return { response: winnerResponse, attemptedPaths: picked.length };

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -161,14 +161,18 @@ export class ProtocolRouter {
     const peerId = peerIdFromString(peerIdStr);
     const startedAt = Date.now();
 
-    if (parallelPaths > 1) {
-      const multipathSignal = AbortSignal.timeout(timeoutMs);
+    if (parallelPaths > 1 && timeoutMs > 1) {
+      const multipathBudgetMs = Math.max(1, Math.min(timeoutMs - 1, Math.ceil(timeoutMs / 3)));
+      const multipathSignal = AbortSignal.timeout(multipathBudgetMs);
       // Multi-path pre-attempt — race up to N live connections.
       // Returns the response on a winning path, or null if there
       // weren't enough live candidates (or all candidates failed).
       // On null we fall through to the single-path retry loop below
       // so cold peers + total-multipath-failure both keep the rc.8
-      // semantics intact.
+      // semantics intact. The pre-attempt gets only an initial slice
+      // of the caller's timeout so a wedged set of live connections
+      // cannot consume the whole budget before resolver+dial fallback
+      // has a chance to run.
       const multipathResult = await raceMultiPath({
         getConnections: () =>
           rawGetConnectionsFor(libp2p, peerId),
@@ -706,6 +710,8 @@ export async function raceMultiPath(args: {
   const streams: Array<{ stream: import('@libp2p/interface').Stream; aborted: boolean } | null> =
     picked.map(() => null);
   let winnerIdx = -1;
+  const winnerController = new AbortController();
+  const raceSignal = abortSignalAny([signal, winnerController.signal]);
 
   const abortPath = (idx: number, reason: Error): void => {
     const s = streams[idx];
@@ -729,7 +735,7 @@ export async function raceMultiPath(args: {
   const attempts = picked.map(async (conn, idx): Promise<Uint8Array> => {
     const stream = await conn.newStream(protocolId, {
       runOnLimitedConnection: true,
-      signal,
+      signal: raceSignal,
     });
     streams[idx] = { stream, aborted: false };
     if (winnerIdx !== -1 && winnerIdx !== idx) {
@@ -745,7 +751,7 @@ export async function raceMultiPath(args: {
       throw new Error('multipath: stream returned in closed state');
     }
     stream.send(data);
-    await stream.close({ signal });
+    await stream.close({ signal: raceSignal });
     return await readAll(stream, maxReadBytes);
   });
 
@@ -760,6 +766,9 @@ export async function raceMultiPath(args: {
           if (winnerIdx === -1) {
             winnerIdx = i;
             abortLosers(i);
+            if (!winnerController.signal.aborted) {
+              winnerController.abort(new Error('multipath: winner settled'));
+            }
             resolve(res);
           } else if (winnerIdx !== i) {
             abortPath(i, new Error('multipath: loser path'));
@@ -777,6 +786,9 @@ export async function raceMultiPath(args: {
     // All N attempts failed — return null so caller falls through
     // to single-path. At this point every attempt rejected, so any
     // streams that opened can be aborted synchronously.
+    if (!winnerController.signal.aborted) {
+      winnerController.abort(new Error('multipath: all paths failed'));
+    }
     for (const s of streams) {
       if (s && !s.aborted) {
         s.aborted = true;
@@ -791,6 +803,28 @@ export async function raceMultiPath(args: {
   }
 
   return { response: winnerResponse, attemptedPaths: picked.length };
+}
+
+function abortSignalAny(signals: AbortSignal[]): AbortSignal {
+  const any = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;
+  if (typeof any === 'function') {
+    return any(signals);
+  }
+
+  const controller = new AbortController();
+  const abortFrom = (signal: AbortSignal): void => {
+    if (!controller.signal.aborted) {
+      controller.abort(signal.reason ?? new Error('aborted'));
+    }
+  };
+  for (const signal of signals) {
+    if (signal.aborted) {
+      abortFrom(signal);
+      break;
+    }
+    signal.addEventListener('abort', () => abortFrom(signal), { once: true });
+  }
+  return controller.signal;
 }
 
 async function readAll(

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -899,4 +899,329 @@ describe('ProtocolRouter', () => {
       expect(result).toBeNull();
     });
   });
+
+  // rc.9 PR-4 — multi-path parallel send. ProtocolRouter.send(parallelPaths > 1)
+  // races up to N live connections via Promise.any-equivalent; the
+  // first successful response wins, losers are aborted. Safe by the
+  // /dkg/10.0.1/* prefix invariant (receiver dedupes via
+  // Messenger.register). When fewer than 2 live connections exist or
+  // all parallel attempts fail, falls through to the single-path
+  // resolver + dialProtocol retry loop. See SendOptions JSDoc.
+  describe('send() multi-path parallel race (rc.9 PR-4)', () => {
+    const FAKE_PEER_ID = '12D3KooWBzj7Hg2cKCdsKL6QcjC5UbLztKTvzCZQHaT4P4ZyJEAA';
+
+    function makeWorkingStream(response: Uint8Array, delayMs = 0) {
+      let returned = false;
+      return {
+        writeStatus: 'open' as const,
+        send: () => undefined,
+        close: async () => undefined,
+        abort: () => undefined,
+        async *[Symbol.asyncIterator]() {
+          if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+          if (!returned) {
+            returned = true;
+            yield response;
+          }
+        },
+      };
+    }
+
+    function makeConn(opts: {
+      label: string;
+      onNewStream: () => Promise<unknown>;
+    }) {
+      return {
+        status: 'open' as const,
+        label: opts.label,
+        remotePeer: {
+          equals: (other: unknown) => String(other) === FAKE_PEER_ID,
+          toString: () => FAKE_PEER_ID,
+        },
+        newStream: opts.onNewStream,
+      };
+    }
+
+    function makeRouter(opts: {
+      connections: ReadonlyArray<ReturnType<typeof makeConn>>;
+      onDial?: () => void;
+    }): ProtocolRouter {
+      const node = {
+        libp2p: {
+          getConnections: () => opts.connections,
+          dialProtocol: async () => {
+            opts.onDial?.();
+            throw new Error('dialProtocol should not be reached when multi-path wins');
+          },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      return new ProtocolRouter(node, { peerResolver });
+    }
+
+    it('parallelPaths=1 (default) preserves the single-path code — no multi-path race', async () => {
+      let aDials = 0;
+      let bDials = 0;
+      const connA = makeConn({
+        label: 'A',
+        onNewStream: async () => {
+          aDials += 1;
+          return makeWorkingStream(new Uint8Array([0xAA])) as any;
+        },
+      });
+      const connB = makeConn({
+        label: 'B',
+        onNewStream: async () => {
+          bDials += 1;
+          return makeWorkingStream(new Uint8Array([0xBB])) as any;
+        },
+      });
+      const router = makeRouter({ connections: [connA, connB] });
+
+      const result = await router.send(FAKE_PEER_ID, '/dkg/10.0.1/test', new Uint8Array([1]));
+
+      // Single-path takes the first live connection only.
+      expect(result).toEqual(new Uint8Array([0xAA]));
+      expect(aDials).toBe(1);
+      expect(bDials).toBe(0);
+    });
+
+    it('parallelPaths>1 with N>=2 live connections opens N parallel streams', async () => {
+      let aDials = 0;
+      let bDials = 0;
+      let cDials = 0;
+      const connA = makeConn({
+        label: 'A',
+        onNewStream: async () => {
+          aDials += 1;
+          // Slow-A so B wins; this verifies the winner-selection
+          // path; A's stream gets aborted as a loser.
+          return makeWorkingStream(new Uint8Array([0xAA]), 100) as any;
+        },
+      });
+      const connB = makeConn({
+        label: 'B',
+        onNewStream: async () => {
+          bDials += 1;
+          return makeWorkingStream(new Uint8Array([0xBB])) as any;
+        },
+      });
+      const connC = makeConn({
+        label: 'C',
+        onNewStream: async () => {
+          cDials += 1;
+          return makeWorkingStream(new Uint8Array([0xCC]), 200) as any;
+        },
+      });
+      const router = makeRouter({ connections: [connA, connB, connC] });
+
+      const result = await router.send(FAKE_PEER_ID, '/dkg/10.0.1/test', new Uint8Array([1]), {
+        parallelPaths: 3,
+      });
+
+      // Fast-B wins; we returned its bytes. Slow-A and Slow-C were
+      // also issued (race kicked off all 3 in parallel).
+      expect(result).toEqual(new Uint8Array([0xBB]));
+      expect(aDials).toBe(1);
+      expect(bDials).toBe(1);
+      expect(cDials).toBe(1);
+    });
+
+    it('parallelPaths>1 with only 1 live connection skips the race (multi-path adds no value)', async () => {
+      let aDials = 0;
+      const connA = makeConn({
+        label: 'A',
+        onNewStream: async () => {
+          aDials += 1;
+          return makeWorkingStream(new Uint8Array([0xAA])) as any;
+        },
+      });
+      const router = makeRouter({ connections: [connA] });
+
+      const result = await router.send(FAKE_PEER_ID, '/dkg/10.0.1/test', new Uint8Array([1]), {
+        parallelPaths: 3,
+      });
+
+      expect(result).toEqual(new Uint8Array([0xAA]));
+      // Exactly one newStream — multi-path fell through to single-path
+      // (which then hit the fast-reuse on connA).
+      expect(aDials).toBe(1);
+    });
+
+    it('parallelPaths>1 falls through to single-path when ALL parallel attempts fail', async () => {
+      let aDials = 0;
+      let bDials = 0;
+      let dialCalls = 0;
+      const connA = makeConn({
+        label: 'A-dead',
+        onNewStream: async () => {
+          aDials += 1;
+          throw new Error('A: stream returned in closed state');
+        },
+      });
+      const connB = makeConn({
+        label: 'B-dead',
+        onNewStream: async () => {
+          bDials += 1;
+          throw new Error('B: stream returned in closed state');
+        },
+      });
+      const node = {
+        libp2p: {
+          getConnections: () => [connA, connB],
+          dialProtocol: async () => {
+            dialCalls += 1;
+            return makeWorkingStream(new Uint8Array([0xCC])) as any;
+          },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      const router = new ProtocolRouter(node, { peerResolver });
+
+      const result = await router.send(FAKE_PEER_ID, '/dkg/10.0.1/test', new Uint8Array([1]), {
+        parallelPaths: 2,
+      });
+
+      // All multi-path attempts failed → fell through to single-path
+      // → fast-reuse hits A and B which throw, so dialProtocol takes
+      // over and succeeds.
+      expect(result).toEqual(new Uint8Array([0xCC]));
+      // Each conn dialed at least once during multi-path; single-path
+      // may try them again via fast-reuse before falling to dial.
+      expect(aDials).toBeGreaterThanOrEqual(1);
+      expect(bDials).toBeGreaterThanOrEqual(1);
+      expect(dialCalls).toBeGreaterThanOrEqual(1);
+    });
+
+    it('parallelPaths>1 accepts the number-form timeoutMs still working via opts.timeoutMs', async () => {
+      // Backwards-compat smoke: passing a number as the 4th arg
+      // still works (rc.8 call sites untouched).
+      let dials = 0;
+      const node = {
+        libp2p: {
+          getConnections: () => [],
+          dialProtocol: async () => {
+            dials += 1;
+            return makeWorkingStream(new Uint8Array([0xDD])) as any;
+          },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      const router = new ProtocolRouter(node, { peerResolver });
+
+      const result = await router.send(FAKE_PEER_ID, '/dkg/10.0.1/test', new Uint8Array([1]), 5000);
+      expect(result).toEqual(new Uint8Array([0xDD]));
+      expect(dials).toBe(1);
+    });
+  });
+
+  // Direct unit tests on raceMultiPath itself — independent of
+  // ProtocolRouter.send so future refactors that change how send()
+  // wires the racer still exercise the race semantics directly.
+  describe('raceMultiPath: race semantics (rc.9 PR-4)', () => {
+    it('returns null when fewer than 2 live candidates exist', async () => {
+      const { raceMultiPath } = await import('../src/protocol-router.js');
+      const conn = {
+        status: 'open',
+        newStream: async () => ({ writeStatus: 'open' } as any),
+      };
+      const result = await raceMultiPath({
+        getConnections: () => [conn] as any[],
+        protocolId: '/test/1.0.0',
+        data: new Uint8Array([1]),
+        parallelPaths: 3,
+        signal: AbortSignal.timeout(1000),
+        maxReadBytes: 1024,
+      });
+      expect(result).toBeNull();
+    });
+
+    it('returns the first fulfilled response and reports the count of attempted paths', async () => {
+      const { raceMultiPath } = await import('../src/protocol-router.js');
+      const conns = [
+        { status: 'open', newStream: async () => ({
+          writeStatus: 'open', send: () => undefined, close: async () => undefined, abort: () => undefined,
+          async *[Symbol.asyncIterator]() { await new Promise((r) => setTimeout(r, 50)); yield new Uint8Array([0xAA]); },
+        } as any) },
+        { status: 'open', newStream: async () => ({
+          writeStatus: 'open', send: () => undefined, close: async () => undefined, abort: () => undefined,
+          async *[Symbol.asyncIterator]() { yield new Uint8Array([0xBB]); },
+        } as any) },
+      ];
+      const result = await raceMultiPath({
+        getConnections: () => conns as any[],
+        protocolId: '/test/1.0.0',
+        data: new Uint8Array([1]),
+        parallelPaths: 2,
+        signal: AbortSignal.timeout(1000),
+        maxReadBytes: 1024,
+      });
+      expect(result?.response).toEqual(new Uint8Array([0xBB]));
+      expect(result?.attemptedPaths).toBe(2);
+    });
+
+    it('returns null when every parallel attempt fails (AggregateError swallowed)', async () => {
+      const { raceMultiPath } = await import('../src/protocol-router.js');
+      const conns = [
+        { status: 'open', newStream: async () => { throw new Error('A-dead'); } },
+        { status: 'open', newStream: async () => { throw new Error('B-dead'); } },
+      ];
+      const result = await raceMultiPath({
+        getConnections: () => conns as any[],
+        protocolId: '/test/1.0.0',
+        data: new Uint8Array([1]),
+        parallelPaths: 2,
+        signal: AbortSignal.timeout(1000),
+        maxReadBytes: 1024,
+      });
+      expect(result).toBeNull();
+    });
+
+    it('aborts the loser stream after the winner settles', async () => {
+      const { raceMultiPath } = await import('../src/protocol-router.js');
+      let loserAborted = false;
+      const winnerStream: any = {
+        writeStatus: 'open',
+        send: () => undefined,
+        close: async () => undefined,
+        abort: () => undefined,
+        async *[Symbol.asyncIterator]() { yield new Uint8Array([0xCC]); },
+      };
+      const loserStream: any = {
+        writeStatus: 'open',
+        send: () => undefined,
+        close: async () => undefined,
+        abort: () => { loserAborted = true; },
+        async *[Symbol.asyncIterator]() {
+          await new Promise((r) => setTimeout(r, 100));
+          yield new Uint8Array([0xDD]);
+        },
+      };
+      const conns = [
+        { status: 'open', newStream: async () => winnerStream },
+        { status: 'open', newStream: async () => loserStream },
+      ];
+      const result = await raceMultiPath({
+        getConnections: () => conns as any[],
+        protocolId: '/test/1.0.0',
+        data: new Uint8Array([1]),
+        parallelPaths: 2,
+        signal: AbortSignal.timeout(1000),
+        maxReadBytes: 1024,
+      });
+      expect(result?.response).toEqual(new Uint8Array([0xCC]));
+      // Let the loser settle so the post-winner abort scheduler runs.
+      await new Promise((r) => setTimeout(r, 150));
+      expect(loserAborted).toBe(true);
+    });
+  });
 });

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -929,7 +929,10 @@ describe('ProtocolRouter', () => {
 
     function makeConn(opts: {
       label: string;
-      onNewStream: () => Promise<unknown>;
+      onNewStream: (
+        protocols?: string,
+        options?: { runOnLimitedConnection?: boolean; signal?: AbortSignal },
+      ) => Promise<unknown>;
     }) {
       return {
         status: 'open' as const,
@@ -1055,10 +1058,13 @@ describe('ProtocolRouter', () => {
       let aDials = 0;
       let bDials = 0;
       let dialCalls = 0;
+      let multipathSignal: AbortSignal | undefined;
+      let fallbackSignal: AbortSignal | undefined;
       const connA = makeConn({
         label: 'A-dead',
-        onNewStream: async () => {
+        onNewStream: async (_protocols, options) => {
           aDials += 1;
+          multipathSignal ??= options?.signal;
           throw new Error('A: stream returned in closed state');
         },
       });
@@ -1072,8 +1078,9 @@ describe('ProtocolRouter', () => {
       const node = {
         libp2p: {
           getConnections: () => [connA, connB],
-          dialProtocol: async () => {
+          dialProtocol: async (_peer: unknown, _protocol: string, options?: { signal?: AbortSignal }) => {
             dialCalls += 1;
+            fallbackSignal = options?.signal;
             return makeWorkingStream(new Uint8Array([0xCC])) as any;
           },
           handle: () => undefined,
@@ -1097,6 +1104,9 @@ describe('ProtocolRouter', () => {
       expect(aDials).toBeGreaterThanOrEqual(1);
       expect(bDials).toBeGreaterThanOrEqual(1);
       expect(dialCalls).toBeGreaterThanOrEqual(1);
+      expect(fallbackSignal).toBeDefined();
+      expect(fallbackSignal).not.toBe(multipathSignal);
+      expect(fallbackSignal?.aborted).toBe(false);
     });
 
     it('parallelPaths>1 accepts the number-form timeoutMs still working via opts.timeoutMs', async () => {
@@ -1219,9 +1229,50 @@ describe('ProtocolRouter', () => {
         maxReadBytes: 1024,
       });
       expect(result?.response).toEqual(new Uint8Array([0xCC]));
-      // Let the loser settle so the post-winner abort scheduler runs.
-      await new Promise((r) => setTimeout(r, 150));
       expect(loserAborted).toBe(true);
+    });
+
+    it('aborts a late loser stream immediately after newStream returns', async () => {
+      const { raceMultiPath } = await import('../src/protocol-router.js');
+      let lateLoserAborted = false;
+      let lateLoserSent = false;
+      const winnerStream: any = {
+        writeStatus: 'open',
+        send: () => undefined,
+        close: async () => undefined,
+        abort: () => undefined,
+        async *[Symbol.asyncIterator]() { yield new Uint8Array([0xCC]); },
+      };
+      const lateLoserStream: any = {
+        writeStatus: 'open',
+        send: () => { lateLoserSent = true; },
+        close: async () => undefined,
+        abort: () => { lateLoserAborted = true; },
+        async *[Symbol.asyncIterator]() { yield new Uint8Array([0xDD]); },
+      };
+      const conns = [
+        { status: 'open', newStream: async () => winnerStream },
+        {
+          status: 'open',
+          newStream: async () => {
+            await new Promise((r) => setTimeout(r, 25));
+            return lateLoserStream;
+          },
+        },
+      ];
+      const result = await raceMultiPath({
+        getConnections: () => conns as any[],
+        protocolId: '/test/1.0.0',
+        data: new Uint8Array([1]),
+        parallelPaths: 2,
+        signal: AbortSignal.timeout(1000),
+        maxReadBytes: 1024,
+      });
+      expect(result?.response).toEqual(new Uint8Array([0xCC]));
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(lateLoserAborted).toBe(true);
+      expect(lateLoserSent).toBe(false);
     });
   });
 });

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -1109,6 +1109,47 @@ describe('ProtocolRouter', () => {
       expect(fallbackSignal?.aborted).toBe(false);
     });
 
+    it('bounds the multi-path pre-attempt so fallback keeps time budget', async () => {
+      let newStreamCalls = 0;
+      let dialCalls = 0;
+      const stalledConn = (label: string) => makeConn({
+        label,
+        onNewStream: async (_protocols, options) => {
+          newStreamCalls += 1;
+          if (newStreamCalls <= 2) {
+            await new Promise((_resolve, reject) => {
+              options?.signal?.addEventListener('abort', () => reject(new Error('stalled multipath aborted')), {
+                once: true,
+              });
+            });
+          }
+          throw new Error('stream returned in closed state');
+        },
+      });
+      const node = {
+        libp2p: {
+          getConnections: () => [stalledConn('A-stalled'), stalledConn('B-stalled')],
+          dialProtocol: async () => {
+            dialCalls += 1;
+            return makeWorkingStream(new Uint8Array([0xCE])) as any;
+          },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      const router = new ProtocolRouter(node, { peerResolver });
+
+      const result = await router.send(FAKE_PEER_ID, '/dkg/10.0.1/test', new Uint8Array([1]), {
+        parallelPaths: 2,
+        timeoutMs: 120,
+      });
+
+      expect(result).toEqual(new Uint8Array([0xCE]));
+      expect(dialCalls).toBe(1);
+    });
+
     it('parallelPaths>1 accepts the number-form timeoutMs still working via opts.timeoutMs', async () => {
       // Backwards-compat smoke: passing a number as the 4th arg
       // still works (rc.8 call sites untouched).
@@ -1273,6 +1314,44 @@ describe('ProtocolRouter', () => {
       await new Promise((r) => setTimeout(r, 50));
       expect(lateLoserAborted).toBe(true);
       expect(lateLoserSent).toBe(false);
+    });
+
+    it('aborts pending loser newStream attempts when a winner settles', async () => {
+      const { raceMultiPath } = await import('../src/protocol-router.js');
+      let pendingLoserAborted = false;
+      const winnerStream: any = {
+        writeStatus: 'open',
+        send: () => undefined,
+        close: async () => undefined,
+        abort: () => undefined,
+        async *[Symbol.asyncIterator]() { yield new Uint8Array([0xCC]); },
+      };
+      const conns = [
+        { status: 'open', newStream: async () => winnerStream },
+        {
+          status: 'open',
+          newStream: async (_protocols: string, options?: { signal?: AbortSignal }) => {
+            await new Promise((_resolve, reject) => {
+              options?.signal?.addEventListener('abort', () => {
+                pendingLoserAborted = true;
+                reject(new Error('pending loser aborted'));
+              }, { once: true });
+            });
+          },
+        },
+      ];
+      const result = await raceMultiPath({
+        getConnections: () => conns as any[],
+        protocolId: '/test/1.0.0',
+        data: new Uint8Array([1]),
+        parallelPaths: 2,
+        signal: AbortSignal.timeout(1000),
+        maxReadBytes: 1024,
+      });
+      expect(result?.response).toEqual(new Uint8Array([0xCC]));
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(pendingLoserAborted).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Milestone B — PR-4 of the [Universal Messenger plan](../../plans). Multi-path parallel send for substrate-managed protocols.

Race up to N live connections to the same peer in parallel; first successful response wins; loser streams are aborted. Receiver-side dedup (\`Messenger.register\`, rc.9 PR-2) absorbs duplicates idempotently.

## What changed

### API
- New \`SendOptions\` interface; \`ProtocolRouter.send\` 4th arg now accepts either the legacy \`timeoutMs: number\` OR \`SendOptions\`. Backwards-compatible — every existing rc.8 / rc.9 PR-1..3 call site keeps working unchanged.
- \`SendOptions.parallelPaths\` defaults to **1** (single-path behaviour preserved). Values > 1 enable the multi-path racer.

### Safety invariant — wire-version, NOT runtime
- \`parallelPaths > 1\` is ONLY safe for \`/dkg/10.0.1/*\` protocols where the receiver registers via \`Messenger.register\` and dedupes by \`messageId\`. Older \`/dkg/10.0.0/*\` callers MUST keep \`parallelPaths=1\` or duplicate handler invocations corrupt state.
- The sender cannot inspect the receiver's substrate version; **the protocol-prefix string IS the contract**. Documented in \`SendOptions\` JSDoc + \`docs/messenger.md\` "Recovery primitives" section.

### Implementation
- \`raceMultiPath()\` helper does the parallel \`newStream\` + Promise.any-equivalent (so we can track the winning index for loser-abort).
- **Two fall-through paths preserved**:
  1. Fewer than 2 live candidates → return \`null\`, single-path takes over (cold peer keeps the resolver + dialProtocol retry budget).
  2. All N parallel attempts fail → \`AggregateError\` swallowed, return \`null\`, single-path takes over (full 3-retry budget still applies).
- **Diversity v1**: take up to N from the natural connection list. With multi-reservation this naturally gives one connection per relay; relay-grouped selection is a follow-up if Gate B shows duplicate-relay amplification matters.
- **Loser streams aborted after the winner settles** (scheduled, not blocked-on). The receiver's idempotency cache absorbs any in-flight loser bytes that already crossed the wire.

### Tests (+9, 25 → 34 total)
- \`send(parallelPaths=1)\` preserves single-path semantics — only first connection's stream opened.
- \`send(parallelPaths=3)\` with 3 live conns opens all 3 in parallel; fastest wins.
- \`send(parallelPaths=3)\` with 1 live conn falls through to single-path.
- \`send(parallelPaths=2)\` with all dead conns falls through to single-path → \`dialProtocol\` → success.
- Backwards-compat smoke: 4th arg as number still works.
- Direct \`raceMultiPath\` unit tests: null on <2 candidates, null on all-failed AggregateError, loser abort fires after winner settled.

### Docs
- \`docs/messenger.md\` "Recovery primitives" \`parallelPaths\` section expanded with usage example, fall-through behaviour, the wire-version invariant, per-protocol defaults table, and the v1 diversity strategy.

## Test plan

- [x] \`packages/core\` test suite green (34/34)
- [x] Backwards-compat: existing call sites untouched (no migration churn)
- [ ] Gate B (post-Milestone B merge): cross-laptop soak with relay kill verifies multi-path actually heals "kill one relay mid-send" without bumping retry attempts

## Stacking

Base: \`feat/messenger-substrate-class\` (PR-2 #543) — needs PR-2's substrate, doesn't strictly need PR-3 (chat migration). Per the plan: _\"PR-4/5/7/12 don't strictly block on PR-3; they need PR-2's substrate but can ship in parallel with PR-3.\"_


Made with [Cursor](https://cursor.com)