### PR TITLE
feat(agent): DHT-walk-on-outbox-stall recovery primitive (rc.9 PR-5)

### DIFF
--- a/docs/messenger.md
+++ b/docs/messenger.md
@@ -183,9 +183,30 @@ is idempotent at the app layer) or surface a terminal error.
   (rc.9 #538).
 - **`parallelPaths`** _(PR-4)_ — `Messenger.sendToPeer` can race N
   candidate paths; receiver dedup absorbs duplicates.
-- **DHT walk on stall** _(PR-5)_ — outbox entry with ≥ 5 attempts of
-  "no valid addresses for peer" triggers a time-bounded, rate-limited
-  `libp2p.peerRouting.findPeer()`.
+- **DHT walk on stall** _(PR-5, shipped)_ — when an outbox entry hits
+  `OUTBOX_STALL_THRESHOLD` (5) attempts on an address-resolution
+  error (e.g. `"no valid addresses for peer"`, `"NO_RESERVATION"`),
+  the Messenger fires `libp2p.peerRouting.findPeer(pid)` in the
+  background via the injected `resolvePeer` hook. The walk
+  repopulates `peerStore` for the next retry; failures are logged
+  and never block backoff.
+
+  Two safety knobs:
+  - **`DHT_WALK_TIMEOUT_MS`** = 10 s — hard cap so a partitioned
+    network doesn't leave the walk spinning.
+  - **`DHT_WALK_RATE_LIMIT_MS`** = 5 min per peer — prevents the
+    retry tick from burning DHT bandwidth on still-fresh k-bucket
+    data.
+
+  Why the threshold = 5: the default backoff ladder (5s → 15s → 30s
+  → 60s → 5m → 30m → 2h) puts attempt 5 at the boundary between
+  fast sub-minute retries (likely transient blip) and multi-minute
+  retries (genuine reachability degradation — when a DHT walk earns
+  its cost).
+
+  Wiring lives in `cli/src/daemon/lifecycle.ts`'s `DKGAgent`
+  construction — the `Messenger` itself never imports libp2p, so the
+  substrate stays test-friendly.
 - **Gossip peer-hints** _(PR-6, conditional)_ — only ships if Gate B
   shows DHT walk insufficient.
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1714,6 +1714,17 @@ export class DKGAgent {
     this.messenger = new Messenger({
       router: this.router,
       ...(this.config.messengerStores ?? {}),
+      // Universal Messenger DHT-walk-on-stall recovery (rc.9 PR-5):
+      // when an outbox entry hits OUTBOX_STALL_THRESHOLD attempts on
+      // a "no valid addresses" error, the Messenger fires this hook
+      // in the background so kad-DHT repopulates peerStore for the
+      // next retry. Time-bounded + per-peer rate-limited inside the
+      // Messenger; failures are swallowed (logged only).
+      resolvePeer: async (peerId, { signal }) => {
+        const { peerIdFromString } = await import('@libp2p/peer-id');
+        const pid = peerIdFromString(peerId);
+        await this.node.libp2p.peerRouting.findPeer(pid, { signal });
+      },
     });
     this.gossip = new GossipSubManager(this.node, this.eventBus);
     await this.loadSwmSenderKeyState();

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1725,6 +1725,8 @@ export class DKGAgent {
         const pid = peerIdFromString(peerId);
         await this.node.libp2p.peerRouting.findPeer(pid, { signal });
       },
+      logInfo: (message) => this.log.info(createOperationContext('system'), message),
+      logWarn: (message) => this.log.warn(createOperationContext('system'), message),
     });
     this.gossip = new GossipSubManager(this.node, this.eventBus);
     await this.loadSwmSenderKeyState();

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -14,6 +14,59 @@ import {
 /** Bytes payload the substrate uses to signal `RESPONSE_GONE` on the wire. */
 const RESPONSE_GONE_BYTES = new TextEncoder().encode(RESPONSE_GONE_MARKER);
 
+/**
+ * Outbox-attempts threshold past which a stalled entry triggers a
+ * DHT-walk via the optional `resolvePeer` hook (rc.9 PR-5). Five was
+ * picked because the default backoff ladder (5s → 15s → 30s → 60s →
+ * 5m → 30m → 2h) puts attempt 5 at the boundary between the fast
+ * sub-minute retries (which should heal on transient relay blips)
+ * and the multi-minute retries (which means relay reachability is
+ * genuinely degraded, not just a transient — exactly when a DHT
+ * walk earns its cost).
+ */
+export const OUTBOX_STALL_THRESHOLD = 5;
+
+/**
+ * Max time the Messenger spends inside the optional `resolvePeer`
+ * hook before aborting via the `signal`. The hook is fire-and-
+ * forget so this never blocks user-visible latency; the timeout
+ * just bounds resource usage when the DHT walk would otherwise
+ * spin (e.g. fully partitioned network).
+ */
+export const DHT_WALK_TIMEOUT_MS = 10_000;
+
+/**
+ * Minimum interval between consecutive DHT walks for the same peer.
+ * Five minutes mirrors the 5m / 30m backoff layers on the outbox
+ * ladder — running a DHT walk more often than the entry itself
+ * retries would burn DHT bandwidth + amplify load with no upside
+ * (the prior walk's result is still fresh in libp2p's k-buckets).
+ */
+export const DHT_WALK_RATE_LIMIT_MS = 5 * 60 * 1000;
+
+/**
+ * Error-message substrings that indicate "the dialer couldn't find
+ * an address for the peer" — exactly the failure class the DHT walk
+ * is designed to heal. Match is case-insensitive `.includes` so we
+ * catch both libp2p's "The dial request has no valid addresses for
+ * peer" and the shorter "no valid addresses" + the relay-specific
+ * "NO_RESERVATION" surfaces from the soak data.
+ *
+ * Other recoverable errors (stream reset, ECONNRESET, etc.) don't
+ * trigger the walk because they don't mean address-resolution
+ * failed — they mean a known address went bad mid-flight, which a
+ * DHT walk doesn't help with.
+ */
+const DHT_WALK_TRIGGER_ERRORS = [
+  'no valid addresses',
+  'no_reservation',
+];
+
+function shouldTriggerDhtWalk(errMsg: string): boolean {
+  const lower = errMsg.toLowerCase();
+  return DHT_WALK_TRIGGER_ERRORS.some((needle) => lower.includes(needle));
+}
+
 export interface MessengerDeps {
   router: ProtocolRouter;
   /**
@@ -38,6 +91,26 @@ export interface MessengerDeps {
    * ladder.
    */
   backoffs?: readonly number[];
+  /**
+   * Optional address-resolver hook for the **DHT-walk-on-stall**
+   * recovery primitive (rc.9 PR-5). When provided, the Messenger
+   * fires `resolvePeer(peerId, { signal })` in the background after
+   * an outbox entry hits `OUTBOX_STALL_THRESHOLD` attempts with an
+   * address-resolution error (e.g. "no valid addresses for peer"),
+   * giving libp2p's kad-DHT a chance to repopulate `peerStore` for
+   * the next retry.
+   *
+   * Production wiring is `libp2p.peerRouting.findPeer(pid, { signal })`
+   * — done in `cli/src/daemon/lifecycle.ts`. The Messenger never
+   * imports libp2p itself; the hook keeps the substrate test-friendly
+   * and lets the agent layer own the libp2p object.
+   *
+   * The Messenger time-bounds the call (`DHT_WALK_TIMEOUT_MS`, 10s)
+   * and rate-limits per-peer (`DHT_WALK_RATE_LIMIT_MS`, 5 min) so
+   * callers don't need to manage either. Failures are logged but
+   * don't block backoff (the entry's `nextAttemptAt` is unaffected).
+   */
+  resolvePeer?: (peerId: string, opts: { signal: AbortSignal }) => Promise<void>;
   /**
    * Max age (ms) from `firstFailureAt` before an outbox entry is
    * dropped. Defaults to 24h. Caller-supplied for tests; production
@@ -163,6 +236,7 @@ export class Messenger {
   private readonly idempotencyStore?: MessageIdempotencyStore;
   private readonly outbox?: ProtocolOutbox;
   private readonly clock: () => number;
+  private readonly resolvePeer?: (peerId: string, opts: { signal: AbortSignal }) => Promise<void>;
 
   /**
    * Application handlers registered via `register`. Stored separately
@@ -171,6 +245,15 @@ export class Messenger {
    * caller's handler.
    */
   private readonly handlers = new Map<string, ReliableHandler>();
+
+  /**
+   * Per-peer wall-clock of the last DHT walk we kicked off via
+   * `resolvePeer`. Used to enforce {@link DHT_WALK_RATE_LIMIT_MS} so
+   * an outbox entry that keeps stalling doesn't fire findPeer once
+   * per retry tick (which would amplify DHT load + waste each walk
+   * on still-fresh peerStore data).
+   */
+  private readonly lastDhtWalkAt = new Map<string, number>();
 
   constructor(deps: MessengerDeps) {
     this.router = deps.router;
@@ -182,6 +265,7 @@ export class Messenger {
       });
     }
     this.clock = deps.clock ?? (() => Date.now());
+    this.resolvePeer = deps.resolvePeer;
   }
 
   /**
@@ -297,6 +381,7 @@ export class Messenger {
         errMsg,
         this.clock(),
       );
+      this.maybeScheduleDhtWalk(peerId, entry.attempts, errMsg);
       return {
         delivered: false,
         queued: true,
@@ -454,7 +539,7 @@ export class Messenger {
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       if (isRecoverableSendError(err)) {
-        outbox.enqueueFailure(
+        const updated = outbox.enqueueFailure(
           entry.peer,
           entry.protocol,
           entry.messageId,
@@ -462,6 +547,7 @@ export class Messenger {
           errMsg,
           this.clock(),
         );
+        this.maybeScheduleDhtWalk(entry.peer, updated.attempts, errMsg);
       }
       // Non-recoverable: leave the entry alone. `dropExpired` will
       // age it out; an operator-facing diagnostic surface (PR-12)
@@ -469,6 +555,57 @@ export class Messenger {
     } finally {
       outbox.endAttempt(entry.peer, entry.protocol, entry.messageId);
     }
+  }
+
+  /**
+   * DHT-walk-on-stall recovery primitive (rc.9 PR-5). Fire a
+   * `resolvePeer` call in the background when an outbox entry hits
+   * `OUTBOX_STALL_THRESHOLD` attempts on an address-resolution
+   * error, subject to per-peer rate-limiting.
+   *
+   * Fire-and-forget: never blocks the caller. The DHT walk's
+   * side-effect (populating `peerStore` for the peer) heals the
+   * next opportunistic-flush or periodic-tick retry, not the
+   * current one. This is intentional — the current retry has
+   * already failed; the walk is for the next attempt.
+   *
+   * Guards:
+   *   1. No-op when `resolvePeer` not wired.
+   *   2. No-op below `OUTBOX_STALL_THRESHOLD` attempts (don't
+   *      spend a DHT walk on a transient blip the backoff would
+   *      have healed anyway).
+   *   3. No-op for non-address-resolution errors (DHT walk
+   *      doesn't fix stream resets or NO_RESERVATION-after-handshake).
+   *   4. Per-peer rate limit (`DHT_WALK_RATE_LIMIT_MS`).
+   *   5. Time-bounded (`DHT_WALK_TIMEOUT_MS`) — failures logged,
+   *      never bubble.
+   */
+  private maybeScheduleDhtWalk(peerId: string, attempts: number, errMsg: string): void {
+    if (!this.resolvePeer) return;
+    if (attempts < OUTBOX_STALL_THRESHOLD) return;
+    if (!shouldTriggerDhtWalk(errMsg)) return;
+    const last = this.lastDhtWalkAt.get(peerId);
+    const now = this.clock();
+    if (last !== undefined && now - last < DHT_WALK_RATE_LIMIT_MS) return;
+
+    this.lastDhtWalkAt.set(peerId, now);
+    const signal = AbortSignal.timeout(DHT_WALK_TIMEOUT_MS);
+    // Fire-and-forget; never await. Any error swallowed + logged.
+    // The walk's value is its side-effect (peerStore population),
+    // not its return value, so we don't even need the resolved
+    // multiaddrs here.
+    void this.resolvePeer(peerId, { signal })
+      .then(() => {
+        console.warn(
+          `[Messenger] DHT walk completed for ${peerId.slice(-8)} after ${attempts} stalled outbox attempts — peerStore should now be primed`,
+        );
+      })
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[Messenger] DHT walk for ${peerId.slice(-8)} failed (attempts=${attempts}): ${msg}`,
+        );
+      });
   }
 
   /**

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -67,6 +67,10 @@ function shouldTriggerDhtWalk(errMsg: string): boolean {
   return DHT_WALK_TRIGGER_ERRORS.some((needle) => lower.includes(needle));
 }
 
+function isRecoverableMessengerSendError(err: unknown, errMsg: string): boolean {
+  return isRecoverableSendError(err) || shouldTriggerDhtWalk(errMsg);
+}
+
 export interface MessengerDeps {
   router: ProtocolRouter;
   /**
@@ -364,13 +368,14 @@ export class Messenger {
       );
       idem.record(peerId, protocolId, messageId, 'out', response);
       outbox.markDelivered(peerId, protocolId, messageId);
+      this.clearDhtWalkRateLimitIfDrained(peerId);
       return { delivered: true, response, attempts: 1, messageId };
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       // Non-recoverable: rethrow. The caller sees the real error;
       // the outbox stays out of it because retrying an encoding
       // bug / unhandled protocol won't help.
-      if (!isRecoverableSendError(err)) {
+      if (!isRecoverableMessengerSendError(err, errMsg)) {
         throw err;
       }
       const entry = outbox.enqueueFailure(
@@ -536,9 +541,10 @@ export class Messenger {
         response,
       );
       outbox.markDelivered(entry.peer, entry.protocol, entry.messageId);
+      this.clearDhtWalkRateLimitIfDrained(entry.peer);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      if (isRecoverableSendError(err)) {
+      if (isRecoverableMessengerSendError(err, errMsg)) {
         const updated = outbox.enqueueFailure(
           entry.peer,
           entry.protocol,
@@ -608,6 +614,12 @@ export class Messenger {
       });
   }
 
+  private clearDhtWalkRateLimitIfDrained(peerId: string): void {
+    if (!this.outbox || this.outbox.pendingFor(peerId).length === 0) {
+      this.lastDhtWalkAt.delete(peerId);
+    }
+  }
+
   /**
    * Drop outbox entries past `maxAgeMs`. Returns the dropped
    * entries so the caller (lifecycle.ts periodic tick) can log
@@ -621,8 +633,12 @@ export class Messenger {
     lastError: string;
   }> {
     if (!this.outbox) return [];
-    return this.outbox
-      .dropExpired(now)
+    const dropped = this.outbox.dropExpired(now);
+    const droppedPeers = new Set(dropped.map((entry) => entry.peer));
+    for (const peer of droppedPeers) {
+      this.clearDhtWalkRateLimitIfDrained(peer);
+    }
+    return dropped
       .map(({ peer, protocol, messageId, attempts, lastError }) => ({
         peer,
         protocol,

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -45,6 +45,14 @@ export const DHT_WALK_TIMEOUT_MS = 10_000;
 export const DHT_WALK_RATE_LIMIT_MS = 5 * 60 * 1000;
 
 /**
+ * Hard cap for the per-peer DHT-walk rate-limit map. The map is also
+ * time-pruned on every scheduling attempt, but this cap prevents a
+ * malicious or broken caller from retaining unbounded peer IDs inside
+ * one still-fresh rate-limit window.
+ */
+export const DHT_WALK_RATE_LIMIT_MAX_PEERS = 1024;
+
+/**
  * Error-message substrings that indicate "the dialer couldn't find
  * an address for the peer" — exactly the failure class the DHT walk
  * is designed to heal. Match is case-insensitive `.includes` so we
@@ -60,6 +68,7 @@ export const DHT_WALK_RATE_LIMIT_MS = 5 * 60 * 1000;
 const DHT_WALK_TRIGGER_ERRORS = [
   'no valid addresses',
   'no_reservation',
+  'no reservation',
 ];
 
 function shouldTriggerDhtWalk(errMsg: string): boolean {
@@ -115,6 +124,9 @@ export interface MessengerDeps {
    * don't block backoff (the entry's `nextAttemptAt` is unaffected).
    */
   resolvePeer?: (peerId: string, opts: { signal: AbortSignal }) => Promise<void>;
+  /** Optional structured logger callbacks for background DHT-walk diagnostics. */
+  logInfo?: (message: string) => void;
+  logWarn?: (message: string) => void;
   /**
    * Max age (ms) from `firstFailureAt` before an outbox entry is
    * dropped. Defaults to 24h. Caller-supplied for tests; production
@@ -241,6 +253,8 @@ export class Messenger {
   private readonly outbox?: ProtocolOutbox;
   private readonly clock: () => number;
   private readonly resolvePeer?: (peerId: string, opts: { signal: AbortSignal }) => Promise<void>;
+  private readonly logInfo: (message: string) => void;
+  private readonly logWarn: (message: string) => void;
 
   /**
    * Application handlers registered via `register`. Stored separately
@@ -270,6 +284,8 @@ export class Messenger {
     }
     this.clock = deps.clock ?? (() => Date.now());
     this.resolvePeer = deps.resolvePeer;
+    this.logInfo = deps.logInfo ?? (() => undefined);
+    this.logWarn = deps.logWarn ?? deps.logInfo ?? (() => undefined);
   }
 
   /**
@@ -581,7 +597,8 @@ export class Messenger {
    *      spend a DHT walk on a transient blip the backoff would
    *      have healed anyway).
    *   3. No-op for non-address-resolution errors (DHT walk
-   *      doesn't fix stream resets or NO_RESERVATION-after-handshake).
+   *      doesn't fix stream resets); address/reservation misses
+   *      such as "no valid addresses" and NO_RESERVATION do trigger.
    *   4. Per-peer rate limit (`DHT_WALK_RATE_LIMIT_MS`).
    *   5. Time-bounded (`DHT_WALK_TIMEOUT_MS`) — failures logged,
    *      never bubble.
@@ -590,10 +607,16 @@ export class Messenger {
     if (!this.resolvePeer) return;
     if (attempts < OUTBOX_STALL_THRESHOLD) return;
     if (!shouldTriggerDhtWalk(errMsg)) return;
-    const last = this.lastDhtWalkAt.get(peerId);
     const now = this.clock();
+    this.pruneDhtWalkRateLimit(now);
+    const last = this.lastDhtWalkAt.get(peerId);
     if (last !== undefined && now - last < DHT_WALK_RATE_LIMIT_MS) return;
 
+    while (this.lastDhtWalkAt.size >= DHT_WALK_RATE_LIMIT_MAX_PEERS) {
+      const oldest = this.lastDhtWalkAt.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.lastDhtWalkAt.delete(oldest);
+    }
     this.lastDhtWalkAt.set(peerId, now);
     const signal = AbortSignal.timeout(DHT_WALK_TIMEOUT_MS);
     // Fire-and-forget; never await. Any error swallowed + logged.
@@ -602,16 +625,24 @@ export class Messenger {
     // multiaddrs here.
     void this.resolvePeer(peerId, { signal })
       .then(() => {
-        console.warn(
+        this.logInfo(
           `[Messenger] DHT walk completed for ${peerId.slice(-8)} after ${attempts} stalled outbox attempts — peerStore should now be primed`,
         );
       })
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
-        console.warn(
+        this.logWarn(
           `[Messenger] DHT walk for ${peerId.slice(-8)} failed (attempts=${attempts}): ${msg}`,
         );
       });
+  }
+
+  private pruneDhtWalkRateLimit(now: number): void {
+    for (const [peer, ts] of this.lastDhtWalkAt) {
+      if (now - ts >= DHT_WALK_RATE_LIMIT_MS) {
+        this.lastDhtWalkAt.delete(peer);
+      }
+    }
   }
 
   private clearDhtWalkRateLimitIfDrained(peerId: string): void {

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -323,3 +323,209 @@ describe('Messenger construction guardrails', () => {
     expect(Array.from(out)).toEqual([0x77]);
   });
 });
+
+// rc.9 PR-5 — DHT walk on stalled outbox entry. When an entry hits
+// OUTBOX_STALL_THRESHOLD attempts on an address-resolution error,
+// the Messenger fires the optional `resolvePeer` hook in the
+// background. Per-peer rate-limited so a stuck peer doesn't burn DHT
+// bandwidth.
+describe('Messenger DHT-walk-on-stall recovery (rc.9 PR-5)', () => {
+  function makeStallSubstrate(opts: {
+    resolvePeer?: ReturnType<typeof vi.fn>;
+    backoffs?: readonly number[];
+    initialClock?: number;
+  } = {}) {
+    const router = makeRouter(async () => {
+      throw new Error('no valid addresses for peer');
+    });
+    const idempotencyStore = new InMemoryMessageIdempotencyStore();
+    const outboxStore = new InMemoryProtocolOutboxStore({
+      backoffs: opts.backoffs ?? [10],
+      maxAgeMs: 60_000,
+    });
+    let nowMs = opts.initialClock ?? 1_700_000_000_000;
+    const advance = (ms: number) => {
+      nowMs += ms;
+    };
+    const resolvePeer = opts.resolvePeer ?? vi.fn(async () => undefined);
+    const messenger = new Messenger({
+      router: router as unknown as ProtocolRouter,
+      idempotencyStore,
+      outboxStore,
+      backoffs: opts.backoffs ?? [10],
+      maxAgeMs: 60_000,
+      clock: () => nowMs,
+      resolvePeer,
+    });
+    return { messenger, router, outboxStore, resolvePeer, advance, now: () => nowMs };
+  }
+
+  it('does NOT fire resolvePeer below the stall threshold', async () => {
+    const { messenger, resolvePeer, advance } = makeStallSubstrate();
+
+    // 4 failures — one below OUTBOX_STALL_THRESHOLD (5).
+    for (let i = 0; i < 4; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+      advance(1000);
+    }
+
+    expect(resolvePeer).not.toHaveBeenCalled();
+  });
+
+  it('fires resolvePeer once when the stall threshold is hit', async () => {
+    const { messenger, resolvePeer, advance } = makeStallSubstrate();
+
+    // 5 failures — equals OUTBOX_STALL_THRESHOLD.
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+      advance(1000);
+    }
+
+    expect(resolvePeer).toHaveBeenCalledTimes(1);
+    expect(resolvePeer).toHaveBeenCalledWith(PEER_A, { signal: expect.any(AbortSignal) });
+  });
+
+  it('rate-limits resolvePeer per peer (no second walk within DHT_WALK_RATE_LIMIT_MS)', async () => {
+    const { messenger, resolvePeer, advance } = makeStallSubstrate();
+
+    // Climb past threshold once → fires walk #1.
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+      advance(1000);
+    }
+    expect(resolvePeer).toHaveBeenCalledTimes(1);
+
+    // 5 more failures within the rate-limit window — should NOT
+    // trigger another walk.
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+      advance(1000);
+    }
+    expect(resolvePeer).toHaveBeenCalledTimes(1);
+
+    // Cross the rate-limit boundary (default 5 min) → next failure
+    // fires walk #2.
+    advance(5 * 60 * 1000 + 1);
+    await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+      messageId: FIXED_MSG_ID,
+    });
+    expect(resolvePeer).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT fire resolvePeer for non-address-resolution errors (stream resets etc.)', async () => {
+    const router = makeRouter(async () => {
+      throw new Error('ECONNRESET: stream closed');
+    });
+    const idempotencyStore = new InMemoryMessageIdempotencyStore();
+    const outboxStore = new InMemoryProtocolOutboxStore({ backoffs: [10], maxAgeMs: 60_000 });
+    const resolvePeer = vi.fn(async () => undefined);
+    const messenger = new Messenger({
+      router: router as unknown as ProtocolRouter,
+      idempotencyStore,
+      outboxStore,
+      backoffs: [10],
+      maxAgeMs: 60_000,
+      resolvePeer,
+    });
+
+    // Even after many failures of a non-address-resolution error,
+    // the DHT walk shouldn't fire — it can't fix a stream reset.
+    for (let i = 0; i < 8; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+    }
+
+    expect(resolvePeer).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when resolvePeer is not wired (backwards compat)', async () => {
+    const router = makeRouter(async () => {
+      throw new Error('no valid addresses for peer');
+    });
+    const idempotencyStore = new InMemoryMessageIdempotencyStore();
+    const outboxStore = new InMemoryProtocolOutboxStore({ backoffs: [10], maxAgeMs: 60_000 });
+    const messenger = new Messenger({
+      router: router as unknown as ProtocolRouter,
+      idempotencyStore,
+      outboxStore,
+      backoffs: [10],
+      maxAgeMs: 60_000,
+      // resolvePeer omitted intentionally
+    });
+
+    // Just verifying no throw and outbox keeps growing as expected.
+    for (let i = 0; i < 7; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+    }
+    expect(outboxStore.size()).toBe(1);
+  });
+
+  it('rate-limits per-peer, not globally (different peers can each walk independently)', async () => {
+    const { messenger, resolvePeer, advance } = makeStallSubstrate();
+
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), { messageId: 'a' });
+      advance(100);
+    }
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_B, PROTO, new Uint8Array([1]), { messageId: 'b' });
+      advance(100);
+    }
+
+    // One walk per peer, even though both walks fall well within
+    // the rate-limit window.
+    expect(resolvePeer).toHaveBeenCalledTimes(2);
+    const peers = resolvePeer.mock.calls.map((c) => c[0]).sort();
+    expect(peers).toEqual([PEER_A, PEER_B].sort());
+  });
+
+  it('swallows resolvePeer rejections (failure must not bubble to caller)', async () => {
+    const resolvePeer = vi.fn(async () => {
+      throw new Error('DHT walk timed out');
+    });
+    const { messenger } = makeStallSubstrate({ resolvePeer });
+
+    // 5 failures → walk fires + rejects. The user-visible send result
+    // should still be the normal queued shape; no unhandled rejection.
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+    }
+    expect(resolvePeer).toHaveBeenCalledTimes(1);
+  });
+
+  it('also fires from the retry tick path (not only from sendReliable)', async () => {
+    // Bump entry to threshold-1 via direct sendReliable calls, then
+    // drive the rest via processOutboxTick so we exercise both
+    // enqueueFailure call sites.
+    const { messenger, resolvePeer, advance, outboxStore } = makeStallSubstrate();
+
+    // 4 sendReliable fails — attempts climbs to 4, threshold-1.
+    for (let i = 0; i < 4; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+      advance(1000);
+    }
+    expect(resolvePeer).not.toHaveBeenCalled();
+    expect(outboxStore.size()).toBe(1);
+
+    // One processOutboxTick → attempts climbs to 5 → walk fires.
+    advance(100);
+    await messenger.processOutboxTick(20_000_000_000_000); // far-future due check
+
+    expect(resolvePeer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -334,9 +334,10 @@ describe('Messenger DHT-walk-on-stall recovery (rc.9 PR-5)', () => {
     resolvePeer?: ReturnType<typeof vi.fn>;
     backoffs?: readonly number[];
     initialClock?: number;
+    errorMessage?: string;
   } = {}) {
     const router = makeRouter(async () => {
-      throw new Error('no valid addresses for peer');
+      throw new Error(opts.errorMessage ?? 'no valid addresses for peer');
     });
     const idempotencyStore = new InMemoryMessageIdempotencyStore();
     const outboxStore = new InMemoryProtocolOutboxStore({
@@ -387,6 +388,22 @@ describe('Messenger DHT-walk-on-stall recovery (rc.9 PR-5)', () => {
 
     expect(resolvePeer).toHaveBeenCalledTimes(1);
     expect(resolvePeer).toHaveBeenCalledWith(PEER_A, { signal: expect.any(AbortSignal) });
+  });
+
+  it('treats NO_RESERVATION as recoverable and triggers the DHT walk', async () => {
+    const { messenger, resolvePeer, advance } = makeStallSubstrate({
+      errorMessage: 'NO_RESERVATION',
+    });
+
+    for (let i = 0; i < 5; i++) {
+      const result = await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+      expect(result.queued).toBe(true);
+      advance(1000);
+    }
+
+    expect(resolvePeer).toHaveBeenCalledTimes(1);
   });
 
   it('rate-limits resolvePeer per peer (no second walk within DHT_WALK_RATE_LIMIT_MS)', async () => {
@@ -488,6 +505,30 @@ describe('Messenger DHT-walk-on-stall recovery (rc.9 PR-5)', () => {
     expect(resolvePeer).toHaveBeenCalledTimes(2);
     const peers = resolvePeer.mock.calls.map((c) => c[0]).sort();
     expect(peers).toEqual([PEER_A, PEER_B].sort());
+  });
+
+  it('clears the DHT-walk rate limit when a peer outbox expires empty', async () => {
+    const { messenger, resolvePeer, advance, now } = makeStallSubstrate();
+
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+      advance(1000);
+    }
+    expect(resolvePeer).toHaveBeenCalledTimes(1);
+
+    const dropped = messenger.dropExpiredOutbox(now() + 60_001);
+    expect(dropped).toHaveLength(1);
+    expect(messenger.outboxSize()).toBe(0);
+
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: '00000000-0000-4000-8000-000000000002',
+      });
+      advance(1000);
+    }
+    expect(resolvePeer).toHaveBeenCalledTimes(2);
   });
 
   it('swallows resolvePeer rejections (failure must not bubble to caller)', async () => {

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -9,7 +9,12 @@ import {
   type ProtocolRouter,
   type StreamHandler,
 } from '@origintrail-official/dkg-core';
-import { Messenger, MessengerNotConfiguredError } from '../src/p2p/messenger.js';
+import {
+  DHT_WALK_RATE_LIMIT_MAX_PEERS,
+  DHT_WALK_RATE_LIMIT_MS,
+  Messenger,
+  MessengerNotConfiguredError,
+} from '../src/p2p/messenger.js';
 
 const PEER_A = '12D3KooWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const PEER_B = '12D3KooWBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
@@ -332,6 +337,8 @@ describe('Messenger construction guardrails', () => {
 describe('Messenger DHT-walk-on-stall recovery (rc.9 PR-5)', () => {
   function makeStallSubstrate(opts: {
     resolvePeer?: ReturnType<typeof vi.fn>;
+    logInfo?: ReturnType<typeof vi.fn>;
+    logWarn?: ReturnType<typeof vi.fn>;
     backoffs?: readonly number[];
     initialClock?: number;
     errorMessage?: string;
@@ -357,6 +364,8 @@ describe('Messenger DHT-walk-on-stall recovery (rc.9 PR-5)', () => {
       maxAgeMs: 60_000,
       clock: () => nowMs,
       resolvePeer,
+      logInfo: opts.logInfo,
+      logWarn: opts.logWarn,
     });
     return { messenger, router, outboxStore, resolvePeer, advance, now: () => nowMs };
   }
@@ -430,11 +439,27 @@ describe('Messenger DHT-walk-on-stall recovery (rc.9 PR-5)', () => {
 
     // Cross the rate-limit boundary (default 5 min) → next failure
     // fires walk #2.
-    advance(5 * 60 * 1000 + 1);
+    advance(DHT_WALK_RATE_LIMIT_MS + 1);
     await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
       messageId: FIXED_MSG_ID,
     });
     expect(resolvePeer).toHaveBeenCalledTimes(2);
+  });
+
+  it('also treats spaced "no reservation" relay errors as DHT-walk triggers', async () => {
+    const { messenger, resolvePeer, advance } = makeStallSubstrate({
+      errorMessage: 'relay returned no reservation for peer',
+    });
+
+    for (let i = 0; i < 5; i++) {
+      const result = await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+      expect(result.queued).toBe(true);
+      advance(1000);
+    }
+
+    expect(resolvePeer).toHaveBeenCalledTimes(1);
   });
 
   it('does NOT fire resolvePeer for non-address-resolution errors (stream resets etc.)', async () => {
@@ -532,10 +557,11 @@ describe('Messenger DHT-walk-on-stall recovery (rc.9 PR-5)', () => {
   });
 
   it('swallows resolvePeer rejections (failure must not bubble to caller)', async () => {
+    const logWarn = vi.fn();
     const resolvePeer = vi.fn(async () => {
       throw new Error('DHT walk timed out');
     });
-    const { messenger } = makeStallSubstrate({ resolvePeer });
+    const { messenger } = makeStallSubstrate({ resolvePeer, logWarn });
 
     // 5 failures → walk fires + rejects. The user-visible send result
     // should still be the normal queued shape; no unhandled rejection.
@@ -545,6 +571,65 @@ describe('Messenger DHT-walk-on-stall recovery (rc.9 PR-5)', () => {
       });
     }
     expect(resolvePeer).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining('DHT walk timed out'));
+  });
+
+  it('logs completed DHT walks through the injected logger', async () => {
+    const logInfo = vi.fn();
+    const { messenger, resolvePeer } = makeStallSubstrate({ logInfo });
+
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+    }
+
+    expect(resolvePeer).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining('DHT walk completed'));
+  });
+
+  it('prunes stale DHT-walk rate-limit entries on the next scheduling attempt', async () => {
+    const { messenger, advance } = makeStallSubstrate();
+
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+      advance(1000);
+    }
+    const rateLimit = (messenger as unknown as { lastDhtWalkAt: Map<string, number> }).lastDhtWalkAt;
+    expect(rateLimit.has(PEER_A)).toBe(true);
+
+    advance(DHT_WALK_RATE_LIMIT_MS + 1);
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_B, PROTO, new Uint8Array([1]), {
+        messageId: '00000000-0000-4000-8000-000000000010',
+      });
+      advance(1000);
+    }
+
+    expect(rateLimit.has(PEER_A)).toBe(false);
+    expect(rateLimit.has(PEER_B)).toBe(true);
+  });
+
+  it('bounds the DHT-walk rate-limit cache', async () => {
+    const { messenger } = makeStallSubstrate();
+    const rateLimit = (messenger as unknown as { lastDhtWalkAt: Map<string, number> }).lastDhtWalkAt;
+    for (let i = 0; i < DHT_WALK_RATE_LIMIT_MAX_PEERS; i++) {
+      rateLimit.set(`peer-${i}`, 1_700_000_000_000);
+    }
+
+    for (let i = 0; i < 5; i++) {
+      await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+    }
+
+    expect(rateLimit.size).toBeLessThanOrEqual(DHT_WALK_RATE_LIMIT_MAX_PEERS);
+    expect(rateLimit.has('peer-0')).toBe(false);
+    expect(rateLimit.has(PEER_A)).toBe(true);
   });
 
   it('also fires from the retry tick path (not only from sendReliable)', async () => {

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -25,6 +25,8 @@ export function isRecoverableSendError(err: unknown): boolean {
     msg.includes('epipe') ||
     msg.includes('aborted') ||
     msg.includes('no valid addresses') ||
+    msg.includes('no_reservation') ||
+    msg.includes('no reservation') ||
     msg.includes('protocol selection failed') ||
     msg.includes('could not negotiate')
   );

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -18,6 +18,8 @@ describe('ProtocolRouter', () => {
       expect(isRecoverableSendError(new Error('EPIPE'))).toBe(true);
       expect(isRecoverableSendError(new Error('The operation was aborted'))).toBe(true);
       expect(isRecoverableSendError(new Error('no valid addresses'))).toBe(true);
+      expect(isRecoverableSendError(new Error('NO_RESERVATION'))).toBe(true);
+      expect(isRecoverableSendError(new Error('no reservation for relay'))).toBe(true);
     });
 
     it('returns false for non-recoverable errors', () => {


### PR DESCRIPTION
## Summary

Milestone B — PR-5 of the [Universal Messenger plan](../../plans). When an outbox entry hits \`OUTBOX_STALL_THRESHOLD\` (5) attempts on an address-resolution error, the Messenger fires \`libp2p.peerRouting.findPeer(pid)\` in the background. The DHT walk repopulates \`peerStore\` for the next retry — heals the dominant \"no valid addresses for peer\" tail surfaced in the May 2026 Miles↔Lex 8h soak.

## What changed

### Messenger
- New optional \`MessengerDeps.resolvePeer\` hook. Production wiring (\`lifecycle.ts\` → \`DKGAgent\` → \`Messenger\`) supplies \`libp2p.peerRouting.findPeer\`; the substrate itself never imports libp2p so unit tests stay clean.
- New constants: \`OUTBOX_STALL_THRESHOLD=5\`, \`DHT_WALK_TIMEOUT_MS=10s\`, \`DHT_WALK_RATE_LIMIT_MS=5 min/peer\`. All three picked to align with the default backoff ladder (5s → 2h) — threshold sits at the boundary between sub-minute transient retries and multi-minute genuine-degradation retries.
- \`shouldTriggerDhtWalk\` gates on error-message substrings: \`'no valid addresses'\`, \`'no_reservation'\`. Stream resets / ECONNRESET don't trigger (a DHT walk can't fix a torn-down stream).
- Per-peer \`lastDhtWalkAt\` Map enforces rate limit. Different peers walk independently.
- \`maybeScheduleDhtWalk\` is **fire-and-forget**: never await; rejections swallowed + logged so \`resolvePeer\` failures can't bubble into user-visible send results. Both \`sendReliable\` and \`retryOutboxEntry\` call it after \`enqueueFailure\`.

### DKGAgent
- Construction wires \`resolvePeer\` to the agent's libp2p instance (\`peerRouting.findPeer\`).

### Docs
- \`docs/messenger.md\` \"Recovery primitives\" DHT-walk section expanded with the timeout / rate-limit constants, the why-threshold-5 rationale, and the wiring note.

## Test plan

- [x] \`messenger-substrate.test.ts\` 25/25 green (17 existing + 8 new DHT-walk tests):
  - below-threshold → no walk
  - at-threshold → walk fires once
  - rate-limit: subsequent failures within 5min don't re-walk; crossing the boundary fires walk #2
  - non-address errors → no walk
  - \`resolvePeer\` omitted → no-op (backwards compat)
  - per-peer not global rate limit
  - \`resolvePeer\` rejection swallowed
  - retry-tick path also fires (not only sendReliable)
- [ ] Gate B (post-Milestone B merge): cross-laptop soak with peerStore wipe verifies DHT walk actually repopulates within 10s

## Stacking

Base: \`feat/messenger-substrate-class\` (PR-2 #543) — parallel with PR-4 (#545). Per the plan: _\"PR-4/5/7/12 don't strictly block on PR-3; they need PR-2's substrate but can ship in parallel with PR-3.\"_


Made with [Cursor](https://cursor.com)