### PR TITLE
feat(cli,docs): --relay-preferred flag + operator-relay playbook (rc.9 PR-7)

### DIFF
--- a/docs/messenger-operator.md
+++ b/docs/messenger-operator.md
@@ -1,0 +1,89 @@
+# Universal Messenger — Operator Guide
+
+> Status: skeleton landed in rc.9 PR-7. Full `/api/slo` reference + dashboard reading guide land in PR-12. Cross-cutting coherence pass in PR-13.
+
+This is the operator-facing manual for running a DKG node on top of the Universal Messenger substrate. If you're trying to understand how the substrate works internally, read [`messenger.md`](./messenger.md). If you're adding a new protocol, read [`messenger-add-protocol.md`](./messenger-add-protocol.md).
+
+## What you actually need to know
+
+Most operators won't need any of this — the substrate is configured safely by default and the public testnet relay set is enough for reliable chat / skill / query traffic. The two surfaces you'll touch are:
+
+1. **`--relay-preferred`** (PR-7) — when you stand up your own relay infrastructure, point your node at it first.
+2. **`/api/slo`** (PR-12, coming) — per-protocol latency + delivery rate histograms exposed on localhost; the source-of-truth for "is messaging healthy".
+
+## `--relay-preferred` — using operator-controlled relays
+
+By default, every daemon reserves on the public testnet relay set (declared in `network/<env>.json#relays`). The public relays work well, but operators running their own infrastructure may want to prioritise relays they control — for capacity, geography, or operational independence.
+
+### CLI flag
+
+```bash
+dkg start \
+  --relay-preferred /ip4/203.0.113.10/tcp/4001/p2p/12D3KooWMyRelayOne... \
+  --relay-preferred /dns4/relay.example.com/tcp/4001/p2p/12D3KooWMyRelayTwo...
+```
+
+Repeatable. Each `--relay-preferred` adds one multiaddr; the order you pass them is the order libp2p attempts reservations. The public testnet relays remain configured as fallback — if your operator-relay disappears, the node keeps working through the public set.
+
+### Persistent config
+
+For a node you run continuously, write the same list into `~/.dkg/config.json`:
+
+```jsonc
+{
+  "name": "...",
+  "preferredRelays": [
+    "/ip4/203.0.113.10/tcp/4001/p2p/12D3KooWMyRelayOne...",
+    "/dns4/relay.example.com/tcp/4001/p2p/12D3KooWMyRelayTwo..."
+  ]
+  // ... other config
+}
+```
+
+CLI-flag entries take precedence over config entries; both are deduped (first-seen order) before being prepended to the network relay list.
+
+### Verifying
+
+After restart, the daemon logs:
+
+```
+Preferred relays (rc.9 PR-7): 2 operator-supplied multiaddr(s) prepended (sources: 2 from --relay-preferred, 0 from config.preferredRelays). Effective relayPeers count: 5.
+```
+
+You can also confirm via `/api/peer-info` (rc.9 #533) which reservations the libp2p stack is currently holding.
+
+## Relay-setup playbook (standing up your own relay)
+
+You'll get the most reliability lift from running 2-3 relays in geographically distinct regions. Each relay is a vanilla DKG node configured as a circuit-relay-v2 server. The full step-by-step lives in [`packages/cli/README.md`](../packages/cli/README.md#operator-relays-rc9-pr-7) — that's the authoritative playbook with infra recommendations, port-forwarding rules, and monitoring.
+
+In summary:
+
+1. **Provision a small cloud VM** (1 vCPU, 1 GiB RAM, 20 GiB disk is plenty for relay-only). Public IP + ports 4001/tcp open.
+2. **Install + init DKG** as you would for any other node.
+3. **Set `nodeRole: "core"` + `enableRelayServer: true`** in `config.json` so libp2p flips into relay-server mode (HOP streams + reservations).
+4. **Capture the relay's multiaddr** from the startup log: `/ip4/<public-ip>/tcp/4001/p2p/<peer-id>` — this is what you share with your other nodes' `--relay-preferred`.
+5. **Wire it up** on every node that should prefer your relay:
+
+   ```bash
+   dkg start --relay-preferred /ip4/<public-ip>/tcp/4001/p2p/<peer-id>
+   ```
+
+6. **Monitor** — the relay exposes the same `/api/peer-info` diagnostic, so a simple HTTP probe + a "reservations > 0" alert tells you if it's healthy.
+
+## What's coming
+
+- **`/api/slo`** (PR-12) — per-protocol p50/p95/p99 latency + delivered/queued counts. Localhost-only by default; this guide will explain how to read it and how to wire it into your dashboard via a reverse proxy.
+- **Cross-cutting coherence pass** (PR-13) — sequence diagrams polished into `messenger.md`, changelog notes, broken-link check.
+
+## Debugging a stuck outbox entry
+
+```bash
+sqlite3 ~/.dkg/dashboard.db "SELECT peer_id, protocol, message_id, attempts, last_error \
+  FROM protocol_outbox \
+  ORDER BY last_attempt_at DESC \
+  LIMIT 20;"
+```
+
+Or via the dashboard UI (`/ui/chat`) for chat-specific entries.
+
+If you see entries with `attempts >= 5` and `last_error LIKE '%no valid addresses%'`, the daemon is already retrying via the DHT-walk recovery primitive (PR-5) and the entry will heal as soon as the peer's reservations get re-discovered. If `attempts` keeps climbing past 10 with the same error, the peer may be genuinely unreachable — check your own internet connectivity (the soak data so far suggests "no valid addresses" tails are often correlated with sender-side network blips, not receiver-side outages).

--- a/docs/messenger-operator.md
+++ b/docs/messenger-operator.md
@@ -35,7 +35,7 @@ For a node you run continuously, write the same list into `~/.dkg/config.json`:
   "preferredRelays": [
     "/ip4/203.0.113.10/tcp/4001/p2p/12D3KooWMyRelayOne...",
     "/dns4/relay.example.com/tcp/4001/p2p/12D3KooWMyRelayTwo..."
-  ]
+  ],
   // ... other config
 }
 ```
@@ -60,7 +60,7 @@ In summary:
 
 1. **Provision a small cloud VM** (1 vCPU, 1 GiB RAM, 20 GiB disk is plenty for relay-only). Public IP + ports 4001/tcp open.
 2. **Install + init DKG** as you would for any other node.
-3. **Set `nodeRole: "core"` + `enableRelayServer: true`** in `config.json` so libp2p flips into relay-server mode (HOP streams + reservations).
+3. **Set `nodeRole: "core"`** in `config.json` so libp2p flips into relay-server mode (HOP streams + reservations).
 4. **Capture the relay's multiaddr** from the startup log: `/ip4/<public-ip>/tcp/4001/p2p/<peer-id>` — this is what you share with your other nodes' `--relay-preferred`.
 5. **Wire it up** on every node that should prefer your relay:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -102,6 +102,86 @@ To verify the live daemon's effective limit, look for the startup log line
 `[dkg-core] relay server: ulimit -n soft=<N> >= recommended <M>, ok` (or the
 WARN equivalent if the host needs tuning).
 
+## Operator relays (rc.9 PR-7)
+
+By default every daemon reserves on the public testnet relay set declared in
+`network/<env>.json#relays`. The public set is enough for reliable chat /
+skill / query traffic; operators who run their own relay infrastructure can
+prioritise their own relays via `--relay-preferred` (CLI) or the
+`preferredRelays` config field (persistent).
+
+### Standing up your own relay
+
+1. **Provision a small cloud VM.** 1 vCPU + 1 GiB RAM + 20 GiB disk is plenty
+   for a relay-only node. Public IP + ports `4001/tcp` open. AWS t4g.small,
+   Hetzner CPX11, GCP e2-micro all work.
+
+2. **Install + init DKG** as you would for any other node (see "Quick Start"
+   above).
+
+3. **Switch the role to relay-server.** Edit `~/.dkg/config.json`:
+
+   ```jsonc
+   {
+     "name": "my-relay-eu",
+     "nodeRole": "core",            // enables circuit-relay-v2 server
+     "enableRelayServer": true,
+     "relayServerCapacity": 1024,   // tune per the capacity table above
+     "announceAddresses": [
+       "/ip4/<your-public-ip>/tcp/4001"
+     ]
+   }
+   ```
+
+4. **Bump `ulimit -n`** per the table in "Required `ulimit -n`" above.
+
+5. **Start the daemon and capture the relay's multiaddr** from the startup
+   log. It will look like:
+
+   ```
+   /ip4/<public-ip>/tcp/4001/p2p/12D3KooWMyRelayPeerId...
+   ```
+
+   This is the string you share with your other nodes.
+
+6. **Wire it up on every node that should prefer your relay:**
+
+   ```bash
+   dkg start --relay-preferred /ip4/<public-ip>/tcp/4001/p2p/12D3KooW...
+   ```
+
+   Or persistently in each node's `~/.dkg/config.json`:
+
+   ```jsonc
+   {
+     "preferredRelays": [
+       "/ip4/203.0.113.10/tcp/4001/p2p/12D3KooWMyRelayEU...",
+       "/dns4/relay-us.example.com/tcp/4001/p2p/12D3KooWMyRelayUS..."
+     ]
+   }
+   ```
+
+### Recommended infrastructure
+
+- **2–3 relays in geographically distinct regions.** A two-relay topology
+  (EU + US) gives 100% uptime tolerance to single-region outages; three
+  (EU + US + APAC) lets you survive an entire cloud-provider failure.
+- **Restart policy.** systemd `Restart=always` (or the equivalent for your
+  init system). The local relay watchdog handles transient libp2p failures,
+  but a daemon crash needs OS-level restart.
+- **Monitoring.** Probe `/api/peer-info` (rc.9 #533) every 30s; alert on
+  `currentReservations.length == 0` for more than 5 minutes (means the
+  relay is technically running but holding no client reservations — usually
+  a port-forward / NAT issue).
+- **Backups.** A relay holds no application state — `~/.dkg` is reconstructible
+  from `dkg init`. The only persistent artifact you care about is the libp2p
+  peer key (`~/.dkg/key`); back it up if you want the same multiaddr after a
+  VM rebuild.
+
+See [`docs/messenger-operator.md`](../../docs/messenger-operator.md) for the
+full operator-side guide (debugging stuck outbox entries, reading `/api/slo`
+once it lands in rc.9 PR-12).
+
 ## Edge tuning
 
 ### Multi-reservation (NAT'd nodes)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -125,7 +125,6 @@ prioritise their own relays via `--relay-preferred` (CLI) or the
    {
      "name": "my-relay-eu",
      "nodeRole": "core",            // enables circuit-relay-v2 server
-     "enableRelayServer": true,
      "relayServerCapacity": 1024,   // tune per the capacity table above
      "announceAddresses": [
        "/ip4/<your-public-ip>/tcp/4001"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -656,6 +656,12 @@ program
   .command('start')
   .description('Start the DKG daemon')
   .option('-f, --foreground', 'Run in the foreground (don\'t daemonize)')
+  .option(
+    '--relay-preferred <multiaddr>',
+    'Operator-preferred relay multiaddr to prioritise over the network relay set (repeatable; rc.9 PR-7). Multiple uses prepend in CLI-declaration order. See docs/messenger-operator.md for the relay-setup playbook.',
+    (value: string, previous: string[] = []) => [...previous, value],
+    [] as string[],
+  )
   .action(async (opts: ActionOpts) => {
     if (!configExists()) {
       console.error('No config found. Run "dkg init" first.');
@@ -674,6 +680,22 @@ program
         allowRemoteBootstrap: false,
         repairLiveNodeUi: true,
       });
+    }
+
+    // rc.9 PR-7: forward --relay-preferred to the spawned daemon via
+    // env var. Comma-separated so the receiver can split + filter
+    // empty/duplicate entries in `lifecycle.ts`. Persistent config
+    // (`config.preferredRelays`) is a separate source — the daemon
+    // merges both lists with the env taking declaration order first.
+    const relayPreferredOpt = Array.isArray(opts.relayPreferred) ? (opts.relayPreferred as string[]) : [];
+    if (relayPreferredOpt.length > 0) {
+      const cleaned = relayPreferredOpt.map((s) => s.trim()).filter((s) => s.length > 0);
+      if (cleaned.length > 0) {
+        process.env.DKG_RELAY_PREFERRED = cleaned.join(',');
+        console.log(
+          `Preferring ${cleaned.length} operator relay(s) for this run (DKG_RELAY_PREFERRED env var set; see ~/.dkg/config.json#preferredRelays for persistence).`,
+        );
+      }
     }
 
     if (opts.foreground) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -207,7 +207,7 @@ async function runDaemonSupervisor(): Promise<void> {
   }
 }
 
-async function runForegroundSupervisor(): Promise<void> {
+async function runForegroundSupervisor(childEnv: NodeJS.ProcessEnv = process.env): Promise<void> {
   const maxCrashRestarts = 5;
   let crashRestartCount = 0;
   let currentChild: ReturnType<typeof spawn> | null = null;
@@ -228,7 +228,7 @@ async function runForegroundSupervisor(): Promise<void> {
       [...process.execArgv, resolveDaemonEntryPoint(), 'daemon-foreground-worker'],
       {
         stdio: 'inherit',
-        env: process.env,
+        env: childEnv,
       },
     );
 
@@ -684,22 +684,26 @@ program
 
     // rc.9 PR-7: forward --relay-preferred to the spawned daemon via
     // env var. Comma-separated so the receiver can split + filter
-    // empty/duplicate entries in `lifecycle.ts`. Persistent config
-    // (`config.preferredRelays`) is a separate source — the daemon
-    // merges both lists with the env taking declaration order first.
+    // empty/duplicate entries in `lifecycle.ts`. Build an explicit
+    // child env so an ambient DKG_RELAY_PREFERRED in the user's shell
+    // does not silently affect `dkg start` when the flag is omitted.
+    // Persistent config (`config.preferredRelays`) is a separate
+    // source — the daemon merges both lists with the env taking
+    // declaration order first.
     const relayPreferredOpt = Array.isArray(opts.relayPreferred) ? (opts.relayPreferred as string[]) : [];
-    if (relayPreferredOpt.length > 0) {
-      const cleaned = relayPreferredOpt.map((s) => s.trim()).filter((s) => s.length > 0);
-      if (cleaned.length > 0) {
-        process.env.DKG_RELAY_PREFERRED = cleaned.join(',');
-        console.log(
-          `Preferring ${cleaned.length} operator relay(s) for this run (DKG_RELAY_PREFERRED env var set; see ~/.dkg/config.json#preferredRelays for persistence).`,
-        );
-      }
+    const cleanedRelayPreferred = relayPreferredOpt.map((s) => s.trim()).filter((s) => s.length > 0);
+    const daemonEnv: NodeJS.ProcessEnv = { ...process.env };
+    if (cleanedRelayPreferred.length > 0) {
+      daemonEnv.DKG_RELAY_PREFERRED = cleanedRelayPreferred.join(',');
+      console.log(
+        `Preferring ${cleanedRelayPreferred.length} operator relay(s) for this run (DKG_RELAY_PREFERRED env var set; see ~/.dkg/config.json#preferredRelays for persistence).`,
+      );
+    } else {
+      delete daemonEnv.DKG_RELAY_PREFERRED;
     }
 
     if (opts.foreground) {
-      await runForegroundSupervisor();
+      await runForegroundSupervisor(daemonEnv);
       return;
     }
 
@@ -711,7 +715,7 @@ program
       {
         detached: true,
         stdio: ['ignore', 'ignore', 'ignore'],
-        env: process.env,
+        env: daemonEnv,
       },
     );
     child.unref();

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -282,6 +282,23 @@ export interface DkgConfig {
    * full rationale.
    */
   relayReservationCount?: number;
+  /**
+   * Operator-preferred relay multiaddrs that take priority over the
+   * network/<env>.json public relay set (rc.9 PR-7).
+   *
+   * When set, these multiaddrs are prepended to the active relayPeers
+   * list at daemon startup so libp2p attempts reservations on them
+   * first. The public testnet relays remain configured as fallback —
+   * if an operator-relay disappears, the node continues to function
+   * via the public set. Repeatable; populate from CLI via
+   * `dkg start --relay-preferred <multiaddr>` (sets env var
+   * `DKG_RELAY_PREFERRED` for the spawned daemon, comma-separated)
+   * or write into `~/.dkg/config.json` for persistence.
+   *
+   * See `docs/messenger-operator.md` for the relay-setup playbook
+   * (standing up a relay VM, sharing multiaddrs, monitoring).
+   */
+  preferredRelays?: string[];
   /** Public multiaddrs to announce (for VPS/cloud nodes where the public IP is not on the interface). */
   announceAddresses?: string[];
   /** Bootstrap peer multiaddrs to connect to on startup (for direct peer discovery without relay). */

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -375,7 +375,7 @@ export function resolveMemoryAgentAddress(agent: {
  */
 export function mergePreferredRelays(input: {
   envValue: string | undefined;
-  configPreferred: readonly string[] | undefined;
+  configPreferred: unknown;
   networkAndConfigRelays: readonly string[] | undefined;
 }): {
   relayPeers: string[];
@@ -387,7 +387,8 @@ export function mergePreferredRelays(input: {
     .split(',')
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
-  const configParsed = (input.configPreferred ?? []).filter(
+  const rawConfigPreferred = Array.isArray(input.configPreferred) ? input.configPreferred : [];
+  const configParsed = rawConfigPreferred.filter(
     (s): s is string => typeof s === 'string' && s.trim().length > 0,
   ).map((s) => s.trim());
 

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -351,6 +351,69 @@ export function resolveMemoryAgentAddress(agent: {
   return agent.getDefaultAgentAddress() ?? agent.peerId;
 }
 
+/**
+ * rc.9 PR-7 — operator-preferred-relay merge helper.
+ *
+ * Computes the effective `relayPeers` list for daemon startup by
+ * prepending operator-supplied multiaddrs (CLI flag + config field)
+ * onto the network/explicit relay set, while preserving the public
+ * relays as fallback. Exported as a pure function so the merge
+ * contract is unit-testable without booting the full daemon.
+ *
+ * Source precedence (declaration order, then dedupe first-seen):
+ *   1. `envValue` — comma-separated string from `DKG_RELAY_PREFERRED`
+ *      env var. Set by `dkg start --relay-preferred <ma>`.
+ *   2. `configPreferred` — array from `~/.dkg/config.json`
+ *      `preferredRelays` field.
+ *   3. `networkAndConfigRelays` — whatever `config.relay` /
+ *      `network.relays` produced upstream.
+ *
+ * Returned `relayPeers` is the de-duplicated concatenation, with
+ * operator-supplied multiaddrs ALWAYS appearing before public
+ * relays. Counts (`envCount`, `configCount`, `preferredCount`) are
+ * reported back for the operator-visible startup log line.
+ */
+export function mergePreferredRelays(input: {
+  envValue: string | undefined;
+  configPreferred: readonly string[] | undefined;
+  networkAndConfigRelays: readonly string[] | undefined;
+}): {
+  relayPeers: string[];
+  envCount: number;
+  configCount: number;
+  preferredCount: number;
+} {
+  const envParsed = (input.envValue ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const configParsed = (input.configPreferred ?? []).filter(
+    (s): s is string => typeof s === 'string' && s.trim().length > 0,
+  ).map((s) => s.trim());
+
+  const preferred = [...envParsed, ...configParsed];
+  const baseline = [...(input.networkAndConfigRelays ?? [])];
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  for (const ma of [...preferred, ...baseline]) {
+    if (seen.has(ma)) continue;
+    seen.add(ma);
+    merged.push(ma);
+  }
+
+  // Recompute the count of preferred multiaddrs that actually ended
+  // up in the result (some may be duplicated within the preferred
+  // list itself — first wins). This is what the log line wants.
+  const preferredInResult = merged.filter((ma) => preferred.includes(ma));
+
+  return {
+    relayPeers: merged,
+    envCount: envParsed.length,
+    configCount: configParsed.length,
+    preferredCount: preferredInResult.length,
+  };
+}
+
 export async function runDaemon(foreground: boolean): Promise<void> {
   await ensureDkgDir();
   const config = await loadConfig();
@@ -528,6 +591,24 @@ export async function runDaemonInner(
     relayPeers = network.relays;
     log(`Using relay(s) from network config (${network.networkName})`);
   }
+
+  // rc.9 PR-7 — operator-preferred relays. See `mergePreferredRelays`
+  // JSDoc for the merge semantics; this block is just the lifecycle
+  // call site + the operator-visible log line.
+  if (config.relay !== "none") {
+    const result = mergePreferredRelays({
+      envValue: process.env.DKG_RELAY_PREFERRED,
+      configPreferred: config.preferredRelays,
+      networkAndConfigRelays: relayPeers,
+    });
+    if (result.preferredCount > 0) {
+      relayPeers = result.relayPeers;
+      log(
+        `Preferred relays (rc.9 PR-7): ${result.preferredCount} operator-supplied multiaddr(s) prepended (sources: ${result.envCount} from --relay-preferred, ${result.configCount} from config.preferredRelays). Effective relayPeers count: ${relayPeers.length}.`,
+      );
+    }
+  }
+
   if (
     !relayPeers?.length &&
     !config.bootstrapPeers?.length &&

--- a/packages/cli/test/preferred-relays.test.ts
+++ b/packages/cli/test/preferred-relays.test.ts
@@ -130,9 +130,7 @@ describe('mergePreferredRelays (rc.9 PR-7)', () => {
       configPreferred: [
         RELAY_OP_A,
         '   ',
-        // @ts-expect-error — intentional defensive case
         null,
-        // @ts-expect-error — intentional defensive case
         42,
         RELAY_OP_B,
       ],
@@ -141,5 +139,17 @@ describe('mergePreferredRelays (rc.9 PR-7)', () => {
 
     expect(result.relayPeers).toEqual([RELAY_OP_A, RELAY_OP_B]);
     expect(result.configCount).toBe(2);
+  });
+
+  it('ignores malformed non-array configPreferred values defensively', () => {
+    const result = mergePreferredRelays({
+      envValue: undefined,
+      configPreferred: { preferredRelays: [RELAY_OP_A] },
+      networkAndConfigRelays: [RELAY_PUB_A],
+    });
+
+    expect(result.relayPeers).toEqual([RELAY_PUB_A]);
+    expect(result.configCount).toBe(0);
+    expect(result.preferredCount).toBe(0);
   });
 });

--- a/packages/cli/test/preferred-relays.test.ts
+++ b/packages/cli/test/preferred-relays.test.ts
@@ -1,0 +1,145 @@
+// preferred-relays.test.ts
+//
+// rc.9 PR-7 — unit tests for the operator-preferred-relay merge
+// helper. The lifecycle.ts call site is non-trivial to integration
+// test (it lives inside `runDaemonInner`'s full daemon boot), so we
+// pin the merge contract here.
+
+import { describe, it, expect } from 'vitest';
+import { mergePreferredRelays } from '../src/daemon/lifecycle.js';
+
+const RELAY_PUB_A = '/ip4/10.0.0.1/tcp/4001/p2p/12D3KooWPubA...';
+const RELAY_PUB_B = '/ip4/10.0.0.2/tcp/4001/p2p/12D3KooWPubB...';
+const RELAY_OP_A = '/ip4/203.0.113.10/tcp/4001/p2p/12D3KooWOpA...';
+const RELAY_OP_B = '/dns4/relay.example.com/tcp/4001/p2p/12D3KooWOpB...';
+
+describe('mergePreferredRelays (rc.9 PR-7)', () => {
+  it('returns the baseline unchanged when neither env nor config supplies preferreds', () => {
+    const result = mergePreferredRelays({
+      envValue: undefined,
+      configPreferred: undefined,
+      networkAndConfigRelays: [RELAY_PUB_A, RELAY_PUB_B],
+    });
+
+    expect(result.relayPeers).toEqual([RELAY_PUB_A, RELAY_PUB_B]);
+    expect(result.envCount).toBe(0);
+    expect(result.configCount).toBe(0);
+    expect(result.preferredCount).toBe(0);
+  });
+
+  it('prepends env-supplied preferreds before the baseline', () => {
+    const result = mergePreferredRelays({
+      envValue: RELAY_OP_A,
+      configPreferred: undefined,
+      networkAndConfigRelays: [RELAY_PUB_A, RELAY_PUB_B],
+    });
+
+    expect(result.relayPeers).toEqual([RELAY_OP_A, RELAY_PUB_A, RELAY_PUB_B]);
+    expect(result.envCount).toBe(1);
+    expect(result.preferredCount).toBe(1);
+  });
+
+  it('prepends config-supplied preferreds before the baseline', () => {
+    const result = mergePreferredRelays({
+      envValue: undefined,
+      configPreferred: [RELAY_OP_A, RELAY_OP_B],
+      networkAndConfigRelays: [RELAY_PUB_A],
+    });
+
+    expect(result.relayPeers).toEqual([RELAY_OP_A, RELAY_OP_B, RELAY_PUB_A]);
+    expect(result.configCount).toBe(2);
+    expect(result.preferredCount).toBe(2);
+  });
+
+  it('env entries take precedence over config entries in declaration order', () => {
+    const result = mergePreferredRelays({
+      envValue: RELAY_OP_B,
+      configPreferred: [RELAY_OP_A],
+      networkAndConfigRelays: [RELAY_PUB_A],
+    });
+
+    // env first (op-B), then config (op-A), then baseline.
+    expect(result.relayPeers).toEqual([RELAY_OP_B, RELAY_OP_A, RELAY_PUB_A]);
+    expect(result.envCount).toBe(1);
+    expect(result.configCount).toBe(1);
+  });
+
+  it('parses the env value as comma-separated list with trimmed entries', () => {
+    const result = mergePreferredRelays({
+      envValue: `  ${RELAY_OP_A}  ,  ${RELAY_OP_B}  `,
+      configPreferred: undefined,
+      networkAndConfigRelays: [RELAY_PUB_A],
+    });
+
+    expect(result.relayPeers).toEqual([RELAY_OP_A, RELAY_OP_B, RELAY_PUB_A]);
+    expect(result.envCount).toBe(2);
+  });
+
+  it('drops empty/whitespace-only env entries silently', () => {
+    const result = mergePreferredRelays({
+      envValue: `,,${RELAY_OP_A},   ,,`,
+      configPreferred: undefined,
+      networkAndConfigRelays: [],
+    });
+
+    expect(result.relayPeers).toEqual([RELAY_OP_A]);
+    expect(result.envCount).toBe(1);
+  });
+
+  it('dedupes when a preferred multiaddr already appears in the baseline (preferred wins position)', () => {
+    const result = mergePreferredRelays({
+      envValue: RELAY_PUB_A, // happens to match a baseline entry
+      configPreferred: undefined,
+      networkAndConfigRelays: [RELAY_PUB_A, RELAY_PUB_B],
+    });
+
+    // RELAY_PUB_A appears once, at position 0 (preferred slot).
+    expect(result.relayPeers).toEqual([RELAY_PUB_A, RELAY_PUB_B]);
+    expect(result.envCount).toBe(1);
+    expect(result.preferredCount).toBe(1);
+  });
+
+  it('dedupes duplicates WITHIN the preferred list (first wins)', () => {
+    const result = mergePreferredRelays({
+      envValue: `${RELAY_OP_A},${RELAY_OP_A}`,
+      configPreferred: [RELAY_OP_A],
+      networkAndConfigRelays: [RELAY_PUB_A],
+    });
+
+    expect(result.relayPeers).toEqual([RELAY_OP_A, RELAY_PUB_A]);
+    expect(result.envCount).toBe(2); // raw env count BEFORE dedupe
+    expect(result.configCount).toBe(1);
+    // preferredCount reflects what's in the result, not the raw inputs.
+    expect(result.preferredCount).toBe(1);
+  });
+
+  it('handles undefined baseline (no relays configured upstream)', () => {
+    const result = mergePreferredRelays({
+      envValue: RELAY_OP_A,
+      configPreferred: undefined,
+      networkAndConfigRelays: undefined,
+    });
+
+    expect(result.relayPeers).toEqual([RELAY_OP_A]);
+  });
+
+  it('filters non-string config entries defensively (config-source guard)', () => {
+    const result = mergePreferredRelays({
+      envValue: undefined,
+      // Simulate a malformed config (number/null bleed through json5 etc.)
+      configPreferred: [
+        RELAY_OP_A,
+        '   ',
+        // @ts-expect-error — intentional defensive case
+        null,
+        // @ts-expect-error — intentional defensive case
+        42,
+        RELAY_OP_B,
+      ],
+      networkAndConfigRelays: [],
+    });
+
+    expect(result.relayPeers).toEqual([RELAY_OP_A, RELAY_OP_B]);
+    expect(result.configCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Milestone B — PR-7 of the [Universal Messenger plan](../../plans). Lets operators prioritise their own relay infrastructure over the public testnet relay set, with the public set kept as fallback so a preferred relay can fail open without breaking the node.

## What changed

### CLI
\`dkg start --relay-preferred <multiaddr>\` (repeatable). Each invocation prepends a multiaddr; CLI declaration order is preserved through env-var → daemon spawn → lifecycle merge. Flag forwards via \`DKG_RELAY_PREFERRED\` env var (comma-separated) onto the spawned daemon process.

### Config
New \`preferredRelays?: string[]\` field on \`DkgConfig\`. Persistent alternative to the CLI flag; both sources merge with env taking declaration-order precedence over config.

### Lifecycle wiring
New exported \`mergePreferredRelays()\` pure helper computes the effective \`relayPeers\` list: dedupe (first-seen wins) of \`[env, config, baseline]\`. Returns counts for the operator-visible startup log line. Extracted as a pure function so the merge contract is testable without booting the full daemon.

Daemon startup logs:
> Preferred relays (rc.9 PR-7): N operator-supplied multiaddr(s) prepended (sources: X from --relay-preferred, Y from config.preferredRelays). Effective relayPeers count: Z.

### Docs
- **\`packages/cli/README.md\`** \"Operator relays (rc.9 PR-7)\" — full step-by-step playbook for standing up an operator-controlled relay (cloud VM sizing, port-forward, role flip, multiaddr capture, wiring on client nodes), plus recommended infrastructure (2-3 regions, restart policy, monitoring, backups).
- **\`docs/messenger-operator.md\`** — new file. Operator-facing guide covering \`--relay-preferred\` usage (CLI + config), debugging stuck outbox entries via SQLite, and placeholders for the \`/api/slo\` reference that lands in PR-12. Cross-links to \`cli/README.md\` for the playbook itself (single source of truth).

### Out of scope (operator-relay ops track)
Actually provisioning operator-controlled relays in distinct regions — that's an out-of-band infra workstream documented in the playbook.

## Test plan

- [x] \`cli/test/preferred-relays.test.ts\` 10/10 green:
  - Baseline-only (no preferreds) preserved unchanged
  - Env-only / config-only / both prepended
  - Env declaration order beats config when both supply preferreds
  - Env value parsed as trimmed comma-separated list
  - Empty/whitespace env entries dropped
  - Dedupe when preferred matches baseline (preferred wins position)
  - Dedupe within preferred list (first wins)
  - Undefined baseline handled
  - Defensive filter against non-string config entries
- [ ] Gate B (post-Milestone B merge): cross-laptop soak boot with \`--relay-preferred\` confirms libp2p attempts the operator relay first via \`/api/peer-info\`

## Stacking

Base: \`feat/messenger-substrate-class\` (PR-2 #543) — parallel with PR-4 (#545) + PR-5 (#546). Per the plan: _\"PR-4/5/7/12 don't strictly block on PR-3; they need PR-2's substrate but can ship in parallel with PR-3.\"_


Made with [Cursor](https://cursor.com)