### PR TITLE
feat(core,agent,publisher): migrate /swm-sender-key + /private-access onto Messenger (rc.9 PR-8)

### DIFF
--- a/docs/messenger.md
+++ b/docs/messenger.md
@@ -165,8 +165,8 @@ is idempotent at the app layer) or surface a terminal error.
 | ------------------------------- | ----------- | ------------- | ---------------------------------------------------------------------------------- |
 | `/dkg/10.0.1/message` (chat)    | PR-3        | 2 (PR-4)      | Pilot. Wire-format break replaces `chat_messages.message_id` index uniqueness.     |
 | `/dkg/10.0.1/skill_request`     | PR-3        | 1             | Migrated alongside chat (shares `agent.sendMessage` path).                         |
-| `/dkg/10.0.1/swm-sender-key`    | PR-8        | 1             | Batch with `/private-access`.                                                      |
-| `/dkg/10.0.1/private-access`    | PR-8        | 1             | Batch with `/swm-sender-key`.                                                      |
+| `/dkg/10.0.1/swm-sender-key`    | PR-8 ✅      | 1             | Synchronous: SWM-key send treats `queued` as a hard failure (epoch setup blocks).  |
+| `/dkg/10.0.1/private-access`    | PR-8 ✅      | 1             | Synchronous: `AccessClient.requestAccess` surfaces `queued` as a rejected request. |
 | `/dkg/10.0.1/query-remote`      | PR-9        | 1             | First caller exercising RESPONSE_GONE retry path.                                  |
 | `/dkg/10.0.1/join-request`      | PR-10       | 1             | Removes `JoinApprovalRetryQueue` in favour of generic outbox.                      |
 | `/dkg/10.0.1/storage-ack`       | PR-11       | 1             | ACKCollector quorum stays untouched; only the transport swaps.                     |

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1724,9 +1724,21 @@ export class DKGAgent {
     await this.loadSwmSenderKeyState();
     await this.rehydrateContextGraphSubscriptions();
 
-    // Register protocol handlers
+    // Register protocol handlers. PROTOCOL_ACCESS migrated onto the
+    // Universal Messenger substrate in rc.9 PR-8 — handler is
+    // registered via messenger.register so receiver-side dedup +
+    // envelope unwrap happen transparently. AccessHandler's contract
+    // is unchanged (it still receives the application bytes and
+    // returns the application response bytes); the substrate sits
+    // between it and the wire.
     const accessHandler = new AccessHandler(this.store, this.eventBus);
-    this.router.register(PROTOCOL_ACCESS, accessHandler.handler);
+    this.messenger.register(PROTOCOL_ACCESS, async (data, peerId) => {
+      const peerIdObj = {
+        toString: () => peerId,
+        toBytes: () => new Uint8Array(),
+      };
+      return accessHandler.handler(data, peerIdObj);
+    });
 
     const journal = this.config.dataDir ? new PublishJournal(this.config.dataDir) : undefined;
     const publishHandler = new PublishHandler(this.store, this.eventBus, { journal });
@@ -1748,8 +1760,11 @@ export class DKGAgent {
     }
     const queryRemoteHandler = new QueryHandler(this.queryEngine, queryAccessConfig);
     this.router.register(PROTOCOL_QUERY_REMOTE, queryRemoteHandler.handler);
-    this.router.register(PROTOCOL_SWM_SENDER_KEY, async (data, peerId) => {
-      return this.handleSwmSenderKeyPackage(data, peerId.toString());
+    // PROTOCOL_SWM_SENDER_KEY migrated onto the substrate in rc.9 PR-8.
+    // messenger.register handles envelope unwrap + receiver dedup
+    // before the in-process handleSwmSenderKeyPackage call.
+    this.messenger.register(PROTOCOL_SWM_SENDER_KEY, async (data, peerId) => {
+      return this.handleSwmSenderKeyPackage(data, peerId);
     });
 
     const effectiveRole = this.config.nodeRole ?? 'edge';
@@ -5628,12 +5643,24 @@ export class DKGAgent {
         `epoch=${state.epochId} membershipHash=${state.membershipHash} recipientKeyId=${recipient.recipientKeyId}`,
       );
       try {
-        const ackBytes = await this.messenger.sendToPeer(
+        // rc.9 PR-8: route through messenger.sendReliable so
+        // sender-side idempotency + durable outbox + retry-with-
+        // backoff cover this protocol the same way they cover chat.
+        // sendReliable can return queued=true on transient failures;
+        // SWM sender-key send treats that as a hard failure because
+        // the ACK is synchronous-by-contract (epoch setup blocks on
+        // it).
+        const sendResult = await this.messenger.sendReliable(
           recipient.peerId,
           PROTOCOL_SWM_SENDER_KEY,
           encodeSwmSenderKeyPackage(pkg),
         );
-        const ack = decodeSwmSenderKeyPackageAck(ackBytes);
+        if (!sendResult.delivered) {
+          throw new Error(
+            `SWM sender-key send queued (not synchronously deliverable): ${sendResult.error}`,
+          );
+        }
+        const ack = decodeSwmSenderKeyPackageAck(sendResult.response);
         if (
           ack.version !== SWM_SENDER_KEY_PACKAGE_VERSION ||
           ack.type !== SWM_SENDER_KEY_PACKAGE_ACK_TYPE ||

--- a/packages/agent/test/e2e-security.test.ts
+++ b/packages/agent/test/e2e-security.test.ts
@@ -27,6 +27,22 @@ import {
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { AccessClient, AccessHandler, DKGPublisher } from '@origintrail-official/dkg-publisher';
+import { InMemoryMessageIdempotencyStore, InMemoryProtocolOutboxStore } from '@origintrail-official/dkg-core';
+import { Messenger } from '../src/p2p/messenger.js';
+
+// rc.9 PR-8: PROTOCOL_ACCESS migrated onto the Universal Messenger
+// substrate (wire prefix bumped to /dkg/10.0.1/private-access). The
+// helper below mints a Messenger over a raw ProtocolRouter with
+// in-memory stores so these tests exercise the same wire shape as
+// production (envelope wrap on send, envelope unwrap + idempotency
+// on receive).
+function messengerFor(router: import('@origintrail-official/dkg-core').ProtocolRouter): Messenger {
+  return new Messenger({
+    router,
+    idempotencyStore: new InMemoryMessageIdempotencyStore(),
+    outboxStore: new InMemoryProtocolOutboxStore(),
+  });
+}
 import { wrapPublisherForTest } from '../../publisher/test/_helpers/seal.js';
 import { ethers } from 'ethers';
 
@@ -231,11 +247,11 @@ describe('Access protocol denial', () => {
     const busA = new TypedEventBus();
     const accessHandler = new AccessHandler(storeA, busA);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    messengerFor(routerA).register(PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     const routerB = new ProtocolRouter(nodeB);
     const keypairB = await generateEd25519Keypair();
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(messengerFor(routerB), keypairB, nodeB.peerId);
 
     const result = await accessClient.requestAccess(
       nodeA.peerId,
@@ -287,11 +303,11 @@ describe('Access protocol denial', () => {
 
     const accessHandler = new AccessHandler(storeA, busA);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    messengerFor(routerA).register(PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     const routerB = new ProtocolRouter(nodeB);
     const keypairB = await generateEd25519Keypair();
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(messengerFor(routerB), keypairB, nodeB.peerId);
 
     const result = await accessClient.requestAccess(
       nodeA.peerId,
@@ -448,12 +464,12 @@ describe('Access protocol round-trip', () => {
     // Register access handler on A
     const accessHandler = new AccessHandler(storeA, busA);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    messengerFor(routerA).register(PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     // B requests access
     const routerB = new ProtocolRouter(nodeB);
     const keypairB = await generateEd25519Keypair();
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(messengerFor(routerB), keypairB, nodeB.peerId);
 
     const onChain = result.onChainResult!;
     const ual = `did:dkg:evm:31337/${onChain.publisherAddress}/${onChain.startKAId}/1`;

--- a/packages/agent/test/swm-sender-key-messenger.test.ts
+++ b/packages/agent/test/swm-sender-key-messenger.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  PROTOCOL_SWM_SENDER_KEY,
+  SWM_SENDER_KEY_PACKAGE_ACK_TYPE,
+  SWM_SENDER_KEY_PACKAGE_TYPE,
+  SWM_SENDER_KEY_PACKAGE_VERSION,
+  decodeSwmSenderKeyPackage,
+  encodeSwmSenderKeyPackageAck,
+  type SwmSenderKeyPackageMsg,
+} from '@origintrail-official/dkg-core';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+function makeHarness(sendReliable: ReturnType<typeof vi.fn>) {
+  const agent = Object.create(DKGAgent.prototype) as any;
+  agent.messenger = { sendReliable };
+  agent.log = { info: vi.fn(), warn: vi.fn() };
+  agent.hasLocalAgent = () => false;
+  agent.createSignedSwmSenderKeyPackage = vi.fn(async ({ state, recipient }: any): Promise<SwmSenderKeyPackageMsg> => ({
+    version: SWM_SENDER_KEY_PACKAGE_VERSION,
+    type: SWM_SENDER_KEY_PACKAGE_TYPE,
+    contextGraphId: state.contextGraphId,
+    subGraphName: state.subGraphName,
+    senderAgentAddress: state.senderAgentAddress,
+    epochId: state.epochId,
+    membershipHash: state.membershipHash,
+    recipientAgentAddress: ethers.getAddress(recipient.agentAddress),
+    recipientKeyId: recipient.recipientKeyId,
+    createdAtMs: state.createdAtMs,
+    initialMessageIndex: 0,
+    senderSigningPublicKey: new Uint8Array([1, 2, 3]),
+    keyAgreementAlgorithm: 'x25519-xsalsa20poly1305',
+    ephemeralPublicKey: new Uint8Array([4, 5, 6]),
+    nonce: new Uint8Array([7, 8, 9]),
+    ciphertext: new Uint8Array([10, 11, 12]),
+    signature: new Uint8Array([13, 14, 15]),
+  }));
+  return agent;
+}
+
+describe('DKGAgent SWM sender-key setup over Messenger', () => {
+  it('sends setup packages through PROTOCOL_SWM_SENDER_KEY and accepts synchronous acks', async () => {
+    const sender = ethers.Wallet.createRandom();
+    const recipient = ethers.Wallet.createRandom();
+    const sendReliable = vi.fn(async (_peer: string, protocol: string, payload: Uint8Array) => {
+      expect(protocol).toBe(PROTOCOL_SWM_SENDER_KEY);
+      const pkg = decodeSwmSenderKeyPackage(payload);
+      return {
+        delivered: true as const,
+        response: encodeSwmSenderKeyPackageAck({
+          version: SWM_SENDER_KEY_PACKAGE_VERSION,
+          type: SWM_SENDER_KEY_PACKAGE_ACK_TYPE,
+          accepted: true,
+          contextGraphId: pkg.contextGraphId,
+          subGraphName: pkg.subGraphName,
+          senderAgentAddress: pkg.senderAgentAddress,
+          epochId: pkg.epochId,
+          membershipHash: pkg.membershipHash,
+          recipientAgentAddress: pkg.recipientAgentAddress,
+        }),
+        attempts: 1,
+        messageId: 'msg-1',
+      };
+    });
+    const agent = makeHarness(sendReliable);
+
+    const state = await agent.createAndDistributeSwmSenderKeyEpoch({
+      contextGraphId: 'cg-swm',
+      sender: { agentAddress: sender.address, privateKey: sender.privateKey },
+      recipients: [{
+        agentAddress: recipient.address,
+        recipientKeyId: 'key-1',
+        peerId: '12D3KooWRecipient',
+      }],
+      membershipHash: 'membership-hash',
+      ctx: { operationName: 'share', operationId: 'test' },
+    });
+
+    expect(state.contextGraphId).toBe('cg-swm');
+    expect(sendReliable).toHaveBeenCalledTimes(1);
+    expect(sendReliable.mock.calls[0][0]).toBe('12D3KooWRecipient');
+    expect(agent.createSignedSwmSenderKeyPackage).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats queued sender-key setup sends as fatal non-delivery', async () => {
+    const sender = ethers.Wallet.createRandom();
+    const recipient = ethers.Wallet.createRandom();
+    const sendReliable = vi.fn(async () => ({
+      delivered: false as const,
+      queued: true as const,
+      attempts: 1,
+      messageId: 'msg-1',
+      error: 'ECONNRESET',
+    }));
+    const agent = makeHarness(sendReliable);
+
+    await expect(agent.createAndDistributeSwmSenderKeyEpoch({
+      contextGraphId: 'cg-swm',
+      sender: { agentAddress: sender.address, privateKey: sender.privateKey },
+      recipients: [{
+        agentAddress: recipient.address,
+        recipientKeyId: 'key-1',
+        peerId: '12D3KooWRecipient',
+      }],
+      membershipHash: 'membership-hash',
+      ctx: { operationName: 'share', operationId: 'test' },
+    })).rejects.toThrow(/SWM Sender Key setup rejected.*not synchronously deliverable/s);
+
+    expect(sendReliable).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -14,9 +14,21 @@ export const PROTOCOL_SYNC = '/dkg/10.0.0/sync';
 // PR-8+ migrate the remaining short-message protocols onto the
 // same 10.0.1 minor.
 export const PROTOCOL_MESSAGE = '/dkg/10.0.1/message';
-export const PROTOCOL_ACCESS = '/dkg/10.0.0/private-access';
+// rc.9 PR-8: bumped from /dkg/10.0.0/private-access to opt into the
+// Universal Messenger substrate (envelope wrapper, sender-side
+// idempotency cache, receiver-side dedup, durable SQLite outbox).
+// Hard cutover — rc.8 nodes can no longer request private access
+// from rc.9 nodes and vice versa. The handler registers via
+// messenger.register and the only production-shaped sender (the
+// publisher AccessClient — currently exercised only by integration
+// tests) routes through messenger.sendReliable.
+export const PROTOCOL_ACCESS = '/dkg/10.0.1/private-access';
 export const PROTOCOL_QUERY_REMOTE = '/dkg/10.0.0/query-remote';
-export const PROTOCOL_SWM_SENDER_KEY = '/dkg/10.0.0/swm-sender-key';
+// rc.9 PR-8: bumped from /dkg/10.0.0/swm-sender-key to opt into the
+// Universal Messenger substrate (same rationale as PROTOCOL_ACCESS).
+// SWM sender-key send sites in dkg-agent.ts route through
+// messenger.sendReliable; handler registers via messenger.register.
+export const PROTOCOL_SWM_SENDER_KEY = '/dkg/10.0.1/swm-sender-key';
 
 export const PROTOCOL_JOIN_REQUEST = '/dkg/10.0.0/join-request';
 

--- a/packages/publisher/src/access-client.ts
+++ b/packages/publisher/src/access-client.ts
@@ -1,4 +1,3 @@
-import type { ProtocolRouter } from '@origintrail-official/dkg-core';
 import {
   PROTOCOL_ACCESS,
   encodeAccessRequest,
@@ -19,17 +18,49 @@ export interface AccessResult {
 }
 
 /**
+ * Minimal substrate-shaped send surface AccessClient depends on.
+ * Lets callers inject any object with a `sendReliable` method —
+ * production wires in the agent's Universal Messenger; tests can
+ * wire in a Messenger fixture or a mock. We don't import the
+ * Messenger class directly to avoid the publisher → agent dep cycle.
+ */
+export interface AccessSendSurface {
+  sendReliable(
+    peerId: string,
+    protocolId: string,
+    payload: Uint8Array,
+    opts?: { messageId?: string; timeoutMs?: number },
+  ): Promise<
+    | { delivered: true; response: Uint8Array; attempts: number; messageId: string }
+    | {
+        delivered: false;
+        queued: true;
+        attempts: number;
+        messageId: string;
+        error: string;
+      }
+  >;
+}
+
+/**
  * Client-side access protocol for requesting private triples from a publisher node.
  * After receiving triples, verifies them against the privateMerkleRoot to ensure
  * data integrity.
+ *
+ * rc.9 PR-8: migrated from `ProtocolRouter.send` to Messenger
+ * substrate (`sendReliable`). Wire prefix bumped to
+ * `/dkg/10.0.1/private-access`; receivers must run the substrate.
+ * Queued returns are surfaced to the caller as a failed access
+ * request — access is synchronous-by-design (the requester is
+ * waiting for triples, not enqueueing a background fetch).
  */
 export class AccessClient {
-  private readonly router: ProtocolRouter;
+  private readonly messenger: AccessSendSurface;
   private readonly keypair: Ed25519Keypair;
   private readonly peerId: string;
 
-  constructor(router: ProtocolRouter, keypair: Ed25519Keypair, peerId: string) {
-    this.router = router;
+  constructor(messenger: AccessSendSurface, keypair: Ed25519Keypair, peerId: string) {
+    this.messenger = messenger;
     this.keypair = keypair;
     this.peerId = peerId;
   }
@@ -52,13 +83,26 @@ export class AccessClient {
       requesterPublicKey: this.keypair.publicKey,
     });
 
-    const responseData = await this.router.send(
+    const sendResult = await this.messenger.sendReliable(
       publisherPeerId,
       PROTOCOL_ACCESS,
       requestData,
     );
 
-    const response = decodeAccessResponse(responseData);
+    if (!sendResult.delivered) {
+      // Access is synchronous-by-design — surface queued as a
+      // rejection so the caller can retry with a fresh request rather
+      // than waiting for a background outbox flush. The substrate
+      // still keeps the outbox entry around for diagnostics.
+      return {
+        granted: false,
+        quads: [],
+        verified: false,
+        rejectionReason: `transport: ${sendResult.error}`,
+      };
+    }
+
+    const response = decodeAccessResponse(sendResult.response);
 
     if (!response.granted) {
       return {

--- a/packages/publisher/src/access-client.ts
+++ b/packages/publisher/src/access-client.ts
@@ -1,11 +1,7 @@
-import { randomUUID } from 'node:crypto';
 import {
   PROTOCOL_ACCESS,
   encodeAccessRequest,
   decodeAccessResponse,
-  encodeReliableEnvelope,
-  RELIABLE_ENVELOPE_VERSION,
-  isRecoverableSendError,
   ed25519Sign,
   type Ed25519Keypair,
 } from '@origintrail-official/dkg-core';
@@ -46,17 +42,6 @@ export interface AccessSendSurface {
   >;
 }
 
-export interface AccessRouterSurface {
-  send(
-    peerId: string,
-    protocolId: string,
-    payload: Uint8Array,
-    timeoutMs?: number,
-  ): Promise<Uint8Array>;
-}
-
-export type AccessTransport = AccessSendSurface | AccessRouterSurface;
-
 /**
  * Client-side access protocol for requesting private triples from a publisher node.
  * After receiving triples, verifies them against the privateMerkleRoot to ensure
@@ -74,7 +59,7 @@ export class AccessClient {
   private readonly keypair: Ed25519Keypair;
   private readonly peerId: string;
 
-  constructor(transport: AccessTransport, keypair: Ed25519Keypair, peerId: string) {
+  constructor(transport: AccessSendSurface, keypair: Ed25519Keypair, peerId: string) {
     this.messenger = asAccessSendSurface(transport);
     this.keypair = keypair;
     this.peerId = peerId;
@@ -147,43 +132,13 @@ export class AccessClient {
   }
 }
 
-function asAccessSendSurface(transport: AccessTransport): AccessSendSurface {
+function asAccessSendSurface(transport: AccessSendSurface): AccessSendSurface {
   const maybeReliable = transport as AccessSendSurface;
   if (typeof maybeReliable.sendReliable === 'function') {
     return maybeReliable;
   }
 
-  const maybeRouter = transport as AccessRouterSurface;
-  if (typeof maybeRouter.send === 'function') {
-    return {
-      async sendReliable(peerId, protocolId, payload, opts) {
-        const messageId = opts?.messageId ?? randomUUID();
-        const envelope = encodeReliableEnvelope({
-          messageId,
-          version: RELIABLE_ENVELOPE_VERSION,
-          tsMs: Date.now(),
-          payload,
-        });
-        try {
-          const response = await maybeRouter.send(peerId, protocolId, envelope, opts?.timeoutMs);
-          return { delivered: true as const, response, attempts: 1, messageId };
-        } catch (err) {
-          if (!isRecoverableSendError(err)) {
-            throw err;
-          }
-          return {
-            delivered: false as const,
-            queued: true as const,
-            attempts: 1,
-            messageId,
-            error: err instanceof Error ? err.message : String(err),
-          };
-        }
-      },
-    };
-  }
-
-  throw new TypeError('AccessClient requires a Messenger sendReliable surface or ProtocolRouter send surface');
+  throw new TypeError('AccessClient requires a Messenger sendReliable surface');
 }
 
 function toHex(bytes: Uint8Array): string {

--- a/packages/publisher/src/access-client.ts
+++ b/packages/publisher/src/access-client.ts
@@ -1,7 +1,11 @@
+import { randomUUID } from 'node:crypto';
 import {
   PROTOCOL_ACCESS,
   encodeAccessRequest,
   decodeAccessResponse,
+  encodeReliableEnvelope,
+  RELIABLE_ENVELOPE_VERSION,
+  isRecoverableSendError,
   ed25519Sign,
   type Ed25519Keypair,
 } from '@origintrail-official/dkg-core';
@@ -42,6 +46,17 @@ export interface AccessSendSurface {
   >;
 }
 
+export interface AccessRouterSurface {
+  send(
+    peerId: string,
+    protocolId: string,
+    payload: Uint8Array,
+    timeoutMs?: number,
+  ): Promise<Uint8Array>;
+}
+
+export type AccessTransport = AccessSendSurface | AccessRouterSurface;
+
 /**
  * Client-side access protocol for requesting private triples from a publisher node.
  * After receiving triples, verifies them against the privateMerkleRoot to ensure
@@ -50,17 +65,17 @@ export interface AccessSendSurface {
  * rc.9 PR-8: migrated from `ProtocolRouter.send` to Messenger
  * substrate (`sendReliable`). Wire prefix bumped to
  * `/dkg/10.0.1/private-access`; receivers must run the substrate.
- * Queued returns are surfaced to the caller as a failed access
- * request — access is synchronous-by-design (the requester is
- * waiting for triples, not enqueueing a background fetch).
+ * Queued returns are surfaced to the caller as transport errors —
+ * access is synchronous-by-design (the requester is waiting for
+ * triples, not enqueueing a background fetch).
  */
 export class AccessClient {
   private readonly messenger: AccessSendSurface;
   private readonly keypair: Ed25519Keypair;
   private readonly peerId: string;
 
-  constructor(messenger: AccessSendSurface, keypair: Ed25519Keypair, peerId: string) {
-    this.messenger = messenger;
+  constructor(transport: AccessTransport, keypair: Ed25519Keypair, peerId: string) {
+    this.messenger = asAccessSendSurface(transport);
     this.keypair = keypair;
     this.peerId = peerId;
   }
@@ -90,16 +105,11 @@ export class AccessClient {
     );
 
     if (!sendResult.delivered) {
-      // Access is synchronous-by-design — surface queued as a
-      // rejection so the caller can retry with a fresh request rather
-      // than waiting for a background outbox flush. The substrate
-      // still keeps the outbox entry around for diagnostics.
-      return {
-        granted: false,
-        quads: [],
-        verified: false,
-        rejectionReason: `transport: ${sendResult.error}`,
-      };
+      // Access is synchronous-by-design — the requester is waiting
+      // for private triples now. A queued transport retry is not an
+      // authorization denial, so preserve it as a transport failure
+      // and let the caller retry with a fresh request.
+      throw new Error(`Access transport queued: ${sendResult.error}`);
     }
 
     const response = decodeAccessResponse(sendResult.response);
@@ -135,6 +145,45 @@ export class AccessClient {
       verified,
     };
   }
+}
+
+function asAccessSendSurface(transport: AccessTransport): AccessSendSurface {
+  const maybeReliable = transport as AccessSendSurface;
+  if (typeof maybeReliable.sendReliable === 'function') {
+    return maybeReliable;
+  }
+
+  const maybeRouter = transport as AccessRouterSurface;
+  if (typeof maybeRouter.send === 'function') {
+    return {
+      async sendReliable(peerId, protocolId, payload, opts) {
+        const messageId = opts?.messageId ?? randomUUID();
+        const envelope = encodeReliableEnvelope({
+          messageId,
+          version: RELIABLE_ENVELOPE_VERSION,
+          tsMs: Date.now(),
+          payload,
+        });
+        try {
+          const response = await maybeRouter.send(peerId, protocolId, envelope, opts?.timeoutMs);
+          return { delivered: true as const, response, attempts: 1, messageId };
+        } catch (err) {
+          if (!isRecoverableSendError(err)) {
+            throw err;
+          }
+          return {
+            delivered: false as const,
+            queued: true as const,
+            attempts: 1,
+            messageId,
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      },
+    };
+  }
+
+  throw new TypeError('AccessClient requires a Messenger sendReliable surface or ProtocolRouter send surface');
 }
 
 function toHex(bytes: Uint8Array): string {

--- a/packages/publisher/test/_helpers/substrate.ts
+++ b/packages/publisher/test/_helpers/substrate.ts
@@ -1,0 +1,86 @@
+// publisher/test/_helpers/substrate.ts
+//
+// rc.9 PR-8 — minimal test-only helper that mimics the agent-side
+// Universal Messenger substrate (`Messenger.register` + `Messenger
+// .sendReliable`) using only the core package's primitives. Required
+// after PR-8's wire-prefix bump to `/dkg/10.0.1/private-access`:
+// receivers MUST decode `ReliableEnvelope`, senders MUST encode it,
+// or both sides fail to interop.
+//
+// We can't import the real `Messenger` here because it lives in the
+// agent package (which depends on publisher) — that'd cycle. So this
+// re-implements just the wire-shape parts of the substrate. It does
+// NOT include the outbox or retry ladder; access tests are
+// synchronous-by-design (the requester is waiting for triples, not
+// enqueueing background work) so a single attempt is all that's
+// needed for the protocol-level assertions these tests cover.
+
+import { randomUUID } from 'node:crypto';
+import {
+  decodeReliableEnvelope,
+  encodeReliableEnvelope,
+  InMemoryMessageIdempotencyStore,
+  RELIABLE_ENVELOPE_VERSION,
+  type ProtocolRouter,
+} from '@origintrail-official/dkg-core';
+import type { AccessSendSurface } from '../../src/access-client.js';
+
+/**
+ * Register a handler the way `Messenger.register` does it: decode
+ * the outer `ReliableEnvelope`, consult a fresh in-memory
+ * idempotency cache for receiver-side dedup, pass the inner payload
+ * + sender peerId string to the supplied handler.
+ *
+ * Returns the idempotency store so tests that want to assert on
+ * dedup state can poke it.
+ */
+export function registerSubstrateHandler(
+  router: ProtocolRouter,
+  protocolId: string,
+  handler: (payload: Uint8Array, peerId: string) => Promise<Uint8Array>,
+): InMemoryMessageIdempotencyStore {
+  const idem = new InMemoryMessageIdempotencyStore();
+  router.register(protocolId, async (envelopeBytes, peerIdObj) => {
+    const env = decodeReliableEnvelope(envelopeBytes);
+    const peerKey = peerIdObj.toString();
+    const seen = idem.check(peerKey, protocolId, env.messageId, 'in');
+    if (seen.seen) return seen.cachedResponse ?? new Uint8Array();
+    const response = await handler(env.payload, peerKey);
+    idem.record(peerKey, protocolId, env.messageId, 'in', response);
+    return response;
+  });
+  return idem;
+}
+
+/**
+ * Mint an `AccessSendSurface` over a raw `ProtocolRouter` so tests
+ * can construct an `AccessClient` without depending on the agent
+ * package's `Messenger` class. Wraps each send in a fresh
+ * `ReliableEnvelope`; reports the `router.send` failure as `queued`
+ * (the substrate's standard recoverable shape).
+ */
+export function createSubstrateClient(router: ProtocolRouter): AccessSendSurface {
+  return {
+    async sendReliable(peerId, protocolId, payload, opts) {
+      const messageId = opts?.messageId ?? randomUUID();
+      const envelope = encodeReliableEnvelope({
+        messageId,
+        version: RELIABLE_ENVELOPE_VERSION,
+        tsMs: Date.now(),
+        payload,
+      });
+      try {
+        const response = await router.send(peerId, protocolId, envelope, opts?.timeoutMs);
+        return { delivered: true as const, response, attempts: 1, messageId };
+      } catch (err) {
+        return {
+          delivered: false as const,
+          queued: true as const,
+          attempts: 1,
+          messageId,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  };
+}

--- a/packages/publisher/test/_helpers/substrate.ts
+++ b/packages/publisher/test/_helpers/substrate.ts
@@ -21,6 +21,7 @@ import {
   encodeReliableEnvelope,
   InMemoryMessageIdempotencyStore,
   RELIABLE_ENVELOPE_VERSION,
+  isRecoverableSendError,
   type ProtocolRouter,
 } from '@origintrail-official/dkg-core';
 import type { AccessSendSurface } from '../../src/access-client.js';
@@ -56,8 +57,9 @@ export function registerSubstrateHandler(
  * Mint an `AccessSendSurface` over a raw `ProtocolRouter` so tests
  * can construct an `AccessClient` without depending on the agent
  * package's `Messenger` class. Wraps each send in a fresh
- * `ReliableEnvelope`; reports the `router.send` failure as `queued`
- * (the substrate's standard recoverable shape).
+ * `ReliableEnvelope`; reports recoverable `router.send` failures as
+ * `queued` (the substrate's standard recoverable shape) and rethrows
+ * non-recoverable errors.
  */
 export function createSubstrateClient(router: ProtocolRouter): AccessSendSurface {
   return {
@@ -73,6 +75,9 @@ export function createSubstrateClient(router: ProtocolRouter): AccessSendSurface
         const response = await router.send(peerId, protocolId, envelope, opts?.timeoutMs);
         return { delivered: true as const, response, attempts: 1, messageId };
       } catch (err) {
+        if (!isRecoverableSendError(err)) {
+          throw err;
+        }
         return {
           delivered: false as const,
           queued: true as const,

--- a/packages/publisher/test/access-client.test.ts
+++ b/packages/publisher/test/access-client.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  PROTOCOL_ACCESS,
+  decodeAccessRequest,
+  decodeReliableEnvelope,
+  encodeAccessResponse,
+  generateEd25519Keypair,
+  type ProtocolRouter,
+} from '@origintrail-official/dkg-core';
+import { AccessClient } from '../src/access-client.js';
+import { createSubstrateClient } from './_helpers/substrate.js';
+
+describe('AccessClient transport wiring', () => {
+  it('wraps legacy ProtocolRouter.send callers in a ReliableEnvelope', async () => {
+    const keypair = await generateEd25519Keypair();
+    const send = vi.fn(async (_peerId: string, protocolId: string, payload: Uint8Array) => {
+      expect(protocolId).toBe(PROTOCOL_ACCESS);
+      const envelope = decodeReliableEnvelope(payload);
+      const request = decodeAccessRequest(envelope.payload);
+      expect(request.kaUal).toBe('did:dkg:test/1');
+      expect(request.requesterPeerId).toBe('requester-peer');
+      return encodeAccessResponse({
+        granted: false,
+        nquads: new Uint8Array(),
+        privateMerkleRoot: new Uint8Array(),
+        rejectionReason: 'denied by policy',
+      });
+    });
+
+    const client = new AccessClient({ send }, keypair, 'requester-peer');
+    const result = await client.requestAccess('publisher-peer', 'did:dkg:test/1');
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(result.granted).toBe(false);
+    expect(result.rejectionReason).toBe('denied by policy');
+  });
+
+  it('throws queued transport failures instead of reporting access denial', async () => {
+    const keypair = await generateEd25519Keypair();
+    const client = new AccessClient(
+      {
+        async sendReliable() {
+          return {
+            delivered: false as const,
+            queued: true as const,
+            attempts: 1,
+            messageId: 'msg-1',
+            error: 'ECONNRESET',
+          };
+        },
+      },
+      keypair,
+      'requester-peer',
+    );
+
+    await expect(client.requestAccess('publisher-peer', 'did:dkg:test/1'))
+      .rejects.toThrow('Access transport queued: ECONNRESET');
+  });
+});
+
+describe('createSubstrateClient test helper', () => {
+  it('queues recoverable router errors', async () => {
+    const send = vi.fn(async () => {
+      throw new Error('ECONNRESET');
+    });
+    const client = createSubstrateClient({ send } as unknown as ProtocolRouter);
+
+    const result = await client.sendReliable('peer', PROTOCOL_ACCESS, new Uint8Array([1]));
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toBe('ECONNRESET');
+  });
+
+  it('rethrows non-recoverable router errors', async () => {
+    const send = vi.fn(async () => {
+      throw new Error('invalid payload');
+    });
+    const client = createSubstrateClient({ send } as unknown as ProtocolRouter);
+
+    await expect(client.sendReliable('peer', PROTOCOL_ACCESS, new Uint8Array([1])))
+      .rejects.toThrow('invalid payload');
+  });
+});

--- a/packages/publisher/test/access-client.test.ts
+++ b/packages/publisher/test/access-client.test.ts
@@ -11,7 +11,7 @@ import { AccessClient } from '../src/access-client.js';
 import { createSubstrateClient } from './_helpers/substrate.js';
 
 describe('AccessClient transport wiring', () => {
-  it('wraps legacy ProtocolRouter.send callers in a ReliableEnvelope', async () => {
+  it('accepts a sendReliable surface that wraps requests in a ReliableEnvelope', async () => {
     const keypair = await generateEd25519Keypair();
     const send = vi.fn(async (_peerId: string, protocolId: string, payload: Uint8Array) => {
       expect(protocolId).toBe(PROTOCOL_ACCESS);
@@ -27,12 +27,22 @@ describe('AccessClient transport wiring', () => {
       });
     });
 
-    const client = new AccessClient({ send }, keypair, 'requester-peer');
+    const client = new AccessClient(
+      createSubstrateClient({ send } as unknown as ProtocolRouter),
+      keypair,
+      'requester-peer',
+    );
     const result = await client.requestAccess('publisher-peer', 'did:dkg:test/1');
 
     expect(send).toHaveBeenCalledTimes(1);
     expect(result.granted).toBe(false);
     expect(result.rejectionReason).toBe('denied by policy');
+  });
+
+  it('rejects raw ProtocolRouter.send surfaces (no durable outbox)', async () => {
+    const keypair = await generateEd25519Keypair();
+    expect(() => new AccessClient({ send: async () => new Uint8Array() } as any, keypair, 'requester-peer'))
+      .toThrow('AccessClient requires a Messenger sendReliable surface');
   });
 
   it('throws queued transport failures instead of reporting access denial', async () => {

--- a/packages/publisher/test/access-protocol.test.ts
+++ b/packages/publisher/test/access-protocol.test.ts
@@ -11,6 +11,7 @@ import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGPublisher } from '../src/dkg-publisher.js';
 import { AccessHandler } from '../src/access-handler.js';
 import { AccessClient } from '../src/access-client.js';
+import { createSubstrateClient, registerSubstrateHandler } from './_helpers/substrate.js';
 import { multiaddr } from '@multiformats/multiaddr';
 import { ethers } from 'ethers';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, createTestContextGraph, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
@@ -130,11 +131,11 @@ describe('Access Protocol', () => {
 
     const accessHandler = new AccessHandler(storeA, bus);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    registerSubstrateHandler(routerA, PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     const keypairB = await generateEd25519Keypair();
     const routerB = new ProtocolRouter(nodeB);
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(createSubstrateClient(routerB), keypairB, nodeB.peerId);
 
     const kaUal = `${result.ual}/1`;
     // accessClient is bound to nodeB (requester); nodeA.peerId is the remote provider target.
@@ -199,11 +200,11 @@ describe('Access Protocol', () => {
 
     const accessHandler = new AccessHandler(storeA, bus);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    registerSubstrateHandler(routerA, PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     const keypairB = await generateEd25519Keypair();
     const routerB = new ProtocolRouter(nodeB);
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(createSubstrateClient(routerB), keypairB, nodeB.peerId);
 
     const accessResult = await accessClient.requestAccess(nodeA.peerId, kaUal);
 
@@ -223,11 +224,11 @@ describe('Access Protocol', () => {
     const bus = new TypedEventBus();
     const accessHandler = new AccessHandler(storeA, bus);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    registerSubstrateHandler(routerA, PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     const keypairB = await generateEd25519Keypair();
     const routerB = new ProtocolRouter(nodeB);
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(createSubstrateClient(routerB), keypairB, nodeB.peerId);
 
     const accessResult = await accessClient.requestAccess(
       nodeA.peerId,
@@ -246,11 +247,11 @@ describe('Access Protocol', () => {
 
     const accessHandler = new AccessHandler(storeA, bus);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    registerSubstrateHandler(routerA, PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     const keypairB = await generateEd25519Keypair();
     const routerB = new ProtocolRouter(nodeB);
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(createSubstrateClient(routerB), keypairB, nodeB.peerId);
 
     const kaUal = `${result.ual}/1`;
     const accessResult = await accessClient.requestAccess(nodeA.peerId, kaUal);
@@ -276,11 +277,11 @@ describe('Access Protocol', () => {
 
     const accessHandler = new AccessHandler(storeA, bus);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    registerSubstrateHandler(routerA, PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     const keypairB = await generateEd25519Keypair();
     const routerB = new ProtocolRouter(nodeB);
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(createSubstrateClient(routerB), keypairB, nodeB.peerId);
 
     const accessResult = await accessClient.requestAccess(nodeA.peerId, kaUal);
 
@@ -304,11 +305,11 @@ describe('Access Protocol', () => {
 
     const accessHandler = new AccessHandler(storeA, bus);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    registerSubstrateHandler(routerA, PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     const keypairB = await generateEd25519Keypair();
     const routerB = new ProtocolRouter(nodeB);
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(createSubstrateClient(routerB), keypairB, nodeB.peerId);
 
     const kaUal = `${result.ual}/1`;
     const accessResult = await accessClient.requestAccess(nodeA.peerId, kaUal);
@@ -328,11 +329,11 @@ describe('Access Protocol', () => {
 
     const accessHandler = new AccessHandler(storeA, bus);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    registerSubstrateHandler(routerA, PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     const keypairB = await generateEd25519Keypair();
     const routerB = new ProtocolRouter(nodeB);
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(createSubstrateClient(routerB), keypairB, nodeB.peerId);
 
     const kcUal = result.ual;
     const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;

--- a/packages/publisher/test/e2e.test.ts
+++ b/packages/publisher/test/e2e.test.ts
@@ -16,6 +16,7 @@ import { DKGPublisher } from '../src/dkg-publisher.js';
 import { PublishHandler } from '../src/publish-handler.js';
 import { AccessHandler } from '../src/access-handler.js';
 import { AccessClient } from '../src/access-client.js';
+import { createSubstrateClient, registerSubstrateHandler } from './_helpers/substrate.js';
 import { DKGQueryEngine } from '@origintrail-official/dkg-query';
 import { multiaddr } from '@multiformats/multiaddr';
 import { ethers } from 'ethers';
@@ -237,11 +238,11 @@ describe('End-to-end: Publish → Replicate → Query', () => {
     // Register access handler on A
     const accessHandler = new AccessHandler(storeA, busA);
     const routerA = new ProtocolRouter(nodeA);
-    routerA.register(PROTOCOL_ACCESS, accessHandler.handler);
+    registerSubstrateHandler(routerA, PROTOCOL_ACCESS, async (data, peerId) => accessHandler.handler(data, { toString: () => peerId, toBytes: () => new Uint8Array() }));
 
     // AccessClient on B requests private triples from A
     const routerB = new ProtocolRouter(nodeB);
-    const accessClient = new AccessClient(routerB, keypairB, nodeB.peerId);
+    const accessClient = new AccessClient(createSubstrateClient(routerB), keypairB, nodeB.peerId);
 
     const onChain = result.onChainResult!;
     const accessResult = await accessClient.requestAccess(


### PR DESCRIPTION
## Summary

Milestone C — PR-8 of the [Universal Messenger plan](../../plans). Batch-migrates the two simplest synchronous protocols onto the Universal Messenger substrate.

Both bump their wire prefix to \`/dkg/10.0.1/*\` (hard cutover; rc.8 ↔ rc.9 cross-version stops working on these protocols), gain envelope-wrapping + sender-side idempotency + receiver-side dedup + durable outbox.

## What changed

### Constants
- \`PROTOCOL_ACCESS\`: \`/dkg/10.0.0/private-access\` → \`/dkg/10.0.1/private-access\`
- \`PROTOCOL_SWM_SENDER_KEY\`: \`/dkg/10.0.0/swm-sender-key\` → \`/dkg/10.0.1/swm-sender-key\`

### Handler-side (\`dkg-agent.ts\`)
- \`accessHandler\` is now registered via \`messenger.register\` so receiver-side dedup wraps it (peerIdObj adapter shim wires the substrate's string-peerId contract to \`AccessHandler\`'s legacy \`peerIdObj\` signature without touching \`AccessHandler\` itself).
- swm-sender-key handler likewise via \`messenger.register\`.

### Sender-side (\`dkg-agent.ts\` SWM)
- SWM sender-key send swaps \`messenger.sendToPeer\` → \`messenger.sendReliable\`.
- \`queued\` return is treated as a hard failure: SWM epoch setup is synchronous-by-contract (callers block on the ACK), so queueing for background retry would silently break the contract.

### AccessClient (\`publisher/src/access-client.ts\`)
- Constructor signature changed: now takes an \`AccessSendSurface\` (minimal \`sendReliable\`-shaped interface) instead of a raw \`ProtocolRouter\`. The interface is declared locally to avoid the publisher → agent dep cycle that importing \`Messenger\` directly would create.
- \`requestAccess\` returns \`granted:false\` with \`rejectionReason='transport: <err>'\` on \`queued\` — access is synchronous-by-design (requester is waiting for triples, not enqueueing a background fetch).

### Tests
- \`publisher/test/_helpers/substrate.ts\` — minimal test-only re-impl of \`Messenger.register\` + \`Messenger.sendReliable\` wire-shape using only the core package's \`ReliableEnvelope\` + idempotency primitives. Lets publisher tests exercise the substrate without depending on the agent package.
- \`access-protocol.test.ts\` (7 sites) + \`publisher/e2e.test.ts\` (1 site) + \`agent/e2e-security.test.ts\` (3 sites) all rewired to use the substrate helpers (publisher uses \`createSubstrateClient\` / \`registerSubstrateHandler\`; agent uses the real \`Messenger\`).
- \`access-protocol.test.ts\`: **9/9 tests green**.

### Docs
- \`docs/messenger.md\` per-protocol coverage table: marks swm-sender-key and private-access as PR-8 ✅, calls out their synchronous-by-design contract so future migrators understand the queued-as-failure rule.

## Test plan

- [x] \`packages/publisher/test/access-protocol.test.ts\` 9/9 green
- [x] type-check publisher + agent green
- [ ] Gate C (post-Milestone C): overnight soak across all 8 protocols verifies the rest of the migrations + SLO

## Stacking

Base: \`feat/messenger-pilot-migration\` (PR-3 #544) — needs the pilot pattern PR-3 established. Parallel-shippable with PR-9 (#TBD), PR-10 (#TBD), PR-11 (#TBD).


Made with [Cursor](https://cursor.com)