### PR TITLE
chore(evm): update Solady dependency

### DIFF
--- a/packages/evm-module/hardhat.node.config.ts
+++ b/packages/evm-module/hardhat.node.config.ts
@@ -44,7 +44,7 @@ const config: HardhatUserConfig = {
       gas: 15_000_000,
       gasMultiplier: 1,
       blockGasLimit: 30_000_000,
-      hardfork: 'shanghai',
+      hardfork: 'cancun',
       accounts: { count: 200 },
       throwOnTransactionFailures: true,
       throwOnCallFailures: true,
@@ -91,9 +91,9 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.20',
+        version: '0.8.26',
         settings: {
-          evmVersion: 'london',
+          evmVersion: 'cancun',
           optimizer: {
             enabled: true,
             runs: 200,

--- a/packages/evm-module/hardhat.node.config.ts
+++ b/packages/evm-module/hardhat.node.config.ts
@@ -44,7 +44,7 @@ const config: HardhatUserConfig = {
       gas: 15_000_000,
       gasMultiplier: 1,
       blockGasLimit: 30_000_000,
-      hardfork: 'cancun',
+      hardfork: 'shanghai',
       accounts: { count: 200 },
       throwOnTransactionFailures: true,
       throwOnCallFailures: true,
@@ -91,9 +91,9 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.26',
+        version: '0.8.20',
         settings: {
-          evmVersion: 'cancun',
+          evmVersion: 'london',
           optimizer: {
             enabled: true,
             runs: 200,

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -20,12 +20,12 @@
     "typechain": "hardhat typechain"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.1.0",
+    "@openzeppelin/contracts": "^5.6.1",
     "dotenv": "^16.4.7",
     "hardhat": "^2.22.17",
     "hardhat-deploy": "^0.12.4",
     "hardhat-deploy-ethers": "^0.4.2",
-    "solady": "^0.0.285",
+    "solady": "^0.1.26",
     "ts-node": "^10.9.1",
     "typescript": "^5.7.2"
   },

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -20,7 +20,7 @@
     "typechain": "hardhat typechain"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.6.1",
+    "@openzeppelin/contracts": "^5.1.0",
     "dotenv": "^16.4.7",
     "hardhat": "^2.22.17",
     "hardhat-deploy": "^0.12.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,8 +404,8 @@ importers:
   packages/evm-module:
     dependencies:
       '@openzeppelin/contracts':
-        specifier: ^5.1.0
-        version: 5.4.0
+        specifier: ^5.6.1
+        version: 5.6.1
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -419,8 +419,8 @@ importers:
         specifier: ^0.4.2
         version: 0.4.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(patch_hash=0d296aadcb2c28c2040ee89cecb4d10311c66f2e64ca77faf8151dbc4822dff9)(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@22.19.11)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)))(hardhat-deploy@0.12.4(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(patch_hash=0d296aadcb2c28c2040ee89cecb4d10311c66f2e64ca77faf8151dbc4822dff9)(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@22.19.11)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10))
       solady:
-        specifier: ^0.0.285
-        version: 0.0.285
+        specifier: ^0.1.26
+        version: 0.1.26
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
@@ -1622,8 +1622,8 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@openzeppelin/contracts@5.4.0':
-    resolution: {integrity: sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==}
+  '@openzeppelin/contracts@5.6.1':
+    resolution: {integrity: sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==}
 
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     resolution: {integrity: sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==}
@@ -5079,8 +5079,8 @@ packages:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
-  solady@0.0.285:
-    resolution: {integrity: sha512-MkY9KFFuhMeTkWU+4wIzBoEkGr1DXdMR98/zGB8S7efg9Wph9Z4d98RRu7c8pRpmRfrSPAYuMKkvauMCpWXStg==}
+  solady@0.1.26:
+    resolution: {integrity: sha512-dhGr/ptJFdea/1KE6xgqgwEdbMhUiSfRc6A+jLeltPe16zyt9qtED3PElIBVRnzEmUO5aZTjKVAr6SlqXBBcIw==}
 
   solc@0.8.26:
     resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
@@ -7160,7 +7160,7 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
 
-  '@openzeppelin/contracts@5.4.0': {}
+  '@openzeppelin/contracts@5.6.1': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     optional: true
@@ -11188,7 +11188,7 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
-  solady@0.0.285: {}
+  solady@0.1.26: {}
 
   solc@0.8.26(debug@4.4.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,8 +404,8 @@ importers:
   packages/evm-module:
     dependencies:
       '@openzeppelin/contracts':
-        specifier: ^5.6.1
-        version: 5.6.1
+        specifier: ^5.1.0
+        version: 5.4.0
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -1622,8 +1622,8 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@openzeppelin/contracts@5.6.1':
-    resolution: {integrity: sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==}
+  '@openzeppelin/contracts@5.4.0':
+    resolution: {integrity: sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==}
 
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     resolution: {integrity: sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==}
@@ -7160,7 +7160,7 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
 
-  '@openzeppelin/contracts@5.6.1': {}
+  '@openzeppelin/contracts@5.4.0': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     optional: true


### PR DESCRIPTION
## Summary

- Updates Solady to 0.1.26 from the #514 EVM dependency slice.
- Leaves `@openzeppelin/contracts` at the current 5.4.0 lockfile resolution.
- Keeps Hardhat on Solidity 0.8.20 with `evmVersion: "london"` and Hardhat network `shanghai`.

## Why OpenZeppelin stays out

OpenZeppelin 5.5.x/5.6.x pulls in Cancun-only `MCOPY` via `Bytes.sol`. Compiling those versions under `evmVersion: "london"` fails, while switching the whole config to `evmVersion: "cancun"` changes bytecode compatibility for every deploy target. That should be handled in a separate, explicit chain-compatibility PR.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @origintrail-official/dkg-evm-module run compile`
- `pnpm --filter @origintrail-official/dkg-evm-module run test:unit`
