### PR TITLE
feat(core,agent,cli): migrate /storage-ack + /verify-proposal onto Messenger (rc.9 PR-11)

### DIFF
--- a/docs/messenger.md
+++ b/docs/messenger.md
@@ -169,8 +169,8 @@ is idempotent at the app layer) or surface a terminal error.
 | `/dkg/10.0.1/private-access`    | PR-8        | 1             | Batch with `/swm-sender-key`.                                                      |
 | `/dkg/10.0.1/query-remote`      | PR-9        | 1             | First caller exercising RESPONSE_GONE retry path.                                  |
 | `/dkg/10.0.1/join-request`      | PR-10       | 1             | Removes `JoinApprovalRetryQueue` in favour of generic outbox.                      |
-| `/dkg/10.0.1/storage-ack`       | PR-11       | 1             | ACKCollector quorum stays untouched; only the transport swaps.                     |
-| `/dkg/10.0.1/verify-proposal`   | PR-11       | 1             | Same shape as storage-ack.                                                         |
+| `/dkg/10.0.1/storage-ack`       | PR-11 ✅     | **1**         | App-level quorum (`ACKCollector`) untouched; transport sendP2P → `messenger.sendReliable`. `parallelPaths=1` (transport-side; app already fans out to N core peers — `parallelPaths>1` would 9x the wire load for no SLO win). Substrate `queued` returns surface as a per-peer throw, picked up by `ACKCollector`'s `MAX_RETRIES=3` loop. |
+| `/dkg/10.0.1/verify-proposal`   | PR-11 ✅     | **1**         | Same shape + same rationale as `/storage-ack` — app-level quorum (`VerifyCollector`) untouched; only the transport swaps. `parallelPaths=1` for the same amplification reason. |
 
 ## Recovery primitives
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1896,6 +1896,10 @@ export class DKGAgent {
                 if (storageACKFailoverInFlight) return;
                 storageACKFailoverInFlight = true;
                 storageACKProtocolRegistered = false;
+                // rc.9 PR-11: messenger.register stored the handler
+                // in the substrate's wrapper which delegates to
+                // router.register under the hood (see Messenger.register
+                // implementation), so router.unregister still removes it.
                 this.router.unregister(PROTOCOL_STORAGE_ACK);
                 this.log.warn(
                   attemptCtx,
@@ -1931,7 +1935,14 @@ export class DKGAgent {
                 );
               },
             }, this.eventBus);
-            this.router.register(PROTOCOL_STORAGE_ACK, ackHandler.handler);
+            // rc.9 PR-11: migrated onto the Universal Messenger
+            // substrate (wire prefix /dkg/10.0.1/storage-ack).
+            // messenger.register handles envelope decode + receiver
+            // dedup; ackHandler's signature stays the same.
+            this.messenger.register(PROTOCOL_STORAGE_ACK, async (data, peerIdStr) => {
+              const peerId = { toString: () => peerIdStr, toBytes: () => new Uint8Array() };
+              return ackHandler.handler(data, peerId);
+            });
             storageACKProtocolRegistered = true;
             this.clearStorageACKRegistrationRetry();
             this.log.info(
@@ -2024,7 +2035,13 @@ export class DKGAgent {
           return onChainId ? BigInt(onChainId) : null;
         },
       });
-      this.router.register(PROTOCOL_VERIFY_PROPOSAL, verifyHandler.handler);
+      // rc.9 PR-11: migrated onto the Universal Messenger substrate
+      // (wire prefix /dkg/10.0.1/verify-proposal). messenger.register
+      // wraps the handler with envelope decode + receiver dedup.
+      this.messenger.register(PROTOCOL_VERIFY_PROPOSAL, async (data, peerIdStr) => {
+        const peerId = { toString: () => peerIdStr, toBytes: () => new Uint8Array() };
+        return verifyHandler.handler(data, peerId);
+      });
       this.log.info(ctx, 'Registered VERIFY proposal handler');
     }
 
@@ -11009,7 +11026,19 @@ export class DKGAgent {
 
     // 5. Collect M-of-N approvals
     const collector = new VerifyCollector({
-      sendP2P: async (peerId: string, protocol: string, data: Uint8Array) => this.messenger.sendToPeer(peerId, protocol, data),
+      // rc.9 PR-11: route through messenger.sendReliable so
+      // /dkg/10.0.1/verify-proposal gets envelope wrap + sender-side
+      // idempotency. App-level fan-out via VerifyCollector is
+      // unchanged; queued is treated as a per-peer failure (caller
+      // moves on to the next peer; substrate keeps the queued entry
+      // in the outbox for diagnostics).
+      sendP2P: async (peerId: string, protocol: string, data: Uint8Array) => {
+        const sendResult = await this.messenger.sendReliable(peerId, protocol, data);
+        if (!sendResult.delivered) {
+          throw new Error(`substrate queued (transport): ${sendResult.error}`);
+        }
+        return sendResult.response;
+      },
       getParticipantPeers: (cgId?: string) => {
         const allPeers = this.node.libp2p.getPeers().map(p => p.toString()).filter(id => id !== this.peerId);
         // TODO: Filter by on-chain participant set once getContextGraphParticipants() is available.
@@ -13910,8 +13939,17 @@ export class DKGAgent {
       gossipPublish: async (topic: string, data: Uint8Array) => {
         await this.gossip.publish(topic, data);
       },
+      // rc.9 PR-11: ACKCollector now routes through messenger.send
+      // Reliable so /dkg/10.0.1/storage-ack gets envelope wrap +
+      // sender-side idempotency. ACKCollector's own MAX_RETRIES=3 loop
+      // sits on top; queued counts as a per-peer failure that the
+      // collector handles via its existing retry-then-skip path.
       sendP2P: async (peerId: string, protocol: string, data: Uint8Array) => {
-        return this.messenger.sendToPeer(peerId, protocol, data);
+        const sendResult = await this.messenger.sendReliable(peerId, protocol, data);
+        if (!sendResult.delivered) {
+          throw new Error(`substrate queued (transport): ${sendResult.error}`);
+        }
+        return sendResult.response;
       },
       getConnectedCorePeers: () => {
         const peers = this.node.libp2p.getPeers();

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -88,6 +88,7 @@ import {
   type SharedMemoryPublicSnapshotStorageConfig, type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import {
   DKGQueryEngine, QueryHandler,
@@ -115,6 +116,18 @@ type PreSignedAuthorAttestation = {
   address: string;
   signature: { r: Uint8Array; vs: Uint8Array };
 };
+
+function stableReliableRequestMessageId(peerId: string, protocol: string, data: Uint8Array): string {
+  const hash = createHash('sha256');
+  hash.update('dkg-agent:reliable-request');
+  hash.update('\0');
+  hash.update(protocol);
+  hash.update('\0');
+  hash.update(peerId);
+  hash.update('\0');
+  hash.update(data);
+  return `request-${hash.digest('hex')}`;
+}
 
 type LocalSwmSenderKeySendState = {
   contextGraphId: string;
@@ -1938,10 +1951,10 @@ export class DKGAgent {
             // rc.9 PR-11: migrated onto the Universal Messenger
             // substrate (wire prefix /dkg/10.0.1/storage-ack).
             // messenger.register handles envelope decode + receiver
-            // dedup; ackHandler's signature stays the same.
+            // dedup; the publisher handler receives the peer id string
+            // emitted by the substrate.
             this.messenger.register(PROTOCOL_STORAGE_ACK, async (data, peerIdStr) => {
-              const peerId = { toString: () => peerIdStr, toBytes: () => new Uint8Array() };
-              return ackHandler.handler(data, peerId);
+              return ackHandler.handler(data, peerIdStr);
             });
             storageACKProtocolRegistered = true;
             this.clearStorageACKRegistrationRetry();
@@ -2039,8 +2052,7 @@ export class DKGAgent {
       // (wire prefix /dkg/10.0.1/verify-proposal). messenger.register
       // wraps the handler with envelope decode + receiver dedup.
       this.messenger.register(PROTOCOL_VERIFY_PROPOSAL, async (data, peerIdStr) => {
-        const peerId = { toString: () => peerIdStr, toBytes: () => new Uint8Array() };
-        return verifyHandler.handler(data, peerId);
+        return verifyHandler.handler(data, peerIdStr);
       });
       this.log.info(ctx, 'Registered VERIFY proposal handler');
     }
@@ -11031,9 +11043,12 @@ export class DKGAgent {
       // idempotency. App-level fan-out via VerifyCollector is
       // unchanged; queued is treated as a per-peer failure (caller
       // moves on to the next peer; substrate keeps the queued entry
-      // in the outbox for diagnostics).
+      // in the outbox for diagnostics). Use a stable per-peer request id
+      // so collector retries converge on the same outbox/idempotency row.
       sendP2P: async (peerId: string, protocol: string, data: Uint8Array) => {
-        const sendResult = await this.messenger.sendReliable(peerId, protocol, data);
+        const sendResult = await this.messenger.sendReliable(peerId, protocol, data, {
+          messageId: stableReliableRequestMessageId(peerId, protocol, data),
+        });
         if (!sendResult.delivered) {
           throw new Error(`substrate queued (transport): ${sendResult.error}`);
         }
@@ -13943,9 +13958,12 @@ export class DKGAgent {
       // Reliable so /dkg/10.0.1/storage-ack gets envelope wrap +
       // sender-side idempotency. ACKCollector's own MAX_RETRIES=3 loop
       // sits on top; queued counts as a per-peer failure that the
-      // collector handles via its existing retry-then-skip path.
+      // collector handles via its existing retry-then-skip path. Use a
+      // stable per-peer request id so retries update the same outbox row.
       sendP2P: async (peerId: string, protocol: string, data: Uint8Array) => {
-        const sendResult = await this.messenger.sendReliable(peerId, protocol, data);
+        const sendResult = await this.messenger.sendReliable(peerId, protocol, data, {
+          messageId: stableReliableRequestMessageId(peerId, protocol, data),
+        });
         if (!sendResult.delivered) {
           throw new Error(`substrate queued (transport): ${sendResult.error}`);
         }

--- a/packages/agent/test/ack-eip191-agent-extra.test.ts
+++ b/packages/agent/test/ack-eip191-agent-extra.test.ts
@@ -157,8 +157,9 @@ describe('A-10: 6-field ACK digest + EIP-191 signing (agent identity)', () => {
 describe('A-10 / A-12: storage-ack libp2p protocol id is pinned', () => {
   // If the constant shifts, ACK collectors and handlers will disagree and
   // ACK collection silently times out. See also storage-ack-protocol-extra.
-  it(`is exactly "/dkg/10.0.0/storage-ack"`, () => {
-    expect(PROTOCOL_STORAGE_ACK).toBe('/dkg/10.0.0/storage-ack');
+  // rc.9 PR-11: pin bumped to the substrate-versioned prefix.
+  it(`is exactly "/dkg/10.0.1/storage-ack"`, () => {
+    expect(PROTOCOL_STORAGE_ACK).toBe('/dkg/10.0.1/storage-ack');
   });
 });
 

--- a/packages/agent/test/storage-ack-protocol-extra.test.ts
+++ b/packages/agent/test/storage-ack-protocol-extra.test.ts
@@ -36,15 +36,18 @@ function walk(dir: string, acc: string[] = []): string[] {
 
 describe('A-9: storage-ack protocol id (libp2p) pin', () => {
   it('constant is the exact spec string', () => {
-    expect(PROTOCOL_STORAGE_ACK).toBe('/dkg/10.0.0/storage-ack');
+    // rc.9 PR-11: bumped to /dkg/10.0.1/* hard cutover (Universal
+    // Messenger substrate; receiver dedup + envelope wrap mandatory).
+    expect(PROTOCOL_STORAGE_ACK).toBe('/dkg/10.0.1/storage-ack');
   });
 
-  it('`dkg-agent.ts` registers PROTOCOL_STORAGE_ACK on the protocol router', () => {
+  it('`dkg-agent.ts` registers PROTOCOL_STORAGE_ACK on the messenger substrate', () => {
     const src = readFileSync(DKG_AGENT_FILE, 'utf8');
-    // Must import the constant and use it with router.register.
     expect(src).toMatch(/PROTOCOL_STORAGE_ACK/);
-    // The registration call — `this.router.register(PROTOCOL_STORAGE_ACK, ...)`
-    const registerRE = /router\.register\s*\(\s*PROTOCOL_STORAGE_ACK\s*,/;
+    // rc.9 PR-11: registration moved from `router.register` to
+    // `messenger.register` (substrate auto-wraps with envelope
+    // decode + receiver-side dedup). Pin against the new shape.
+    const registerRE = /messenger\.register\s*\(\s*PROTOCOL_STORAGE_ACK\s*,/;
     expect(src).toMatch(registerRE);
   });
 

--- a/packages/agent/test/storage-ack-protocol-extra.test.ts
+++ b/packages/agent/test/storage-ack-protocol-extra.test.ts
@@ -23,6 +23,7 @@ import { PROTOCOL_STORAGE_ACK } from '@origintrail-official/dkg-core';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const AGENT_SRC = resolve(__dirname, '..', 'src');
 const DKG_AGENT_FILE = join(AGENT_SRC, 'dkg-agent.ts');
+const CLI_LIFECYCLE_FILE = resolve(__dirname, '..', '..', 'cli', 'src', 'daemon', 'lifecycle.ts');
 
 function walk(dir: string, acc: string[] = []): string[] {
   for (const name of readdirSync(dir)) {
@@ -49,6 +50,26 @@ describe('A-9: storage-ack protocol id (libp2p) pin', () => {
     // decode + receiver-side dedup). Pin against the new shape.
     const registerRE = /messenger\.register\s*\(\s*PROTOCOL_STORAGE_ACK\s*,/;
     expect(src).toMatch(registerRE);
+  });
+
+  it('messenger handler registrations pass the real peer id string, not a partial PeerId object', () => {
+    const src = readFileSync(DKG_AGENT_FILE, 'utf8');
+    expect(src).not.toMatch(/toBytes:\s*\(\)\s*=>\s*new Uint8Array/);
+    expect(src).toMatch(/ackHandler\.handler\(data,\s*peerIdStr\)/);
+    expect(src).toMatch(/verifyHandler\.handler\(data,\s*peerIdStr\)/);
+  });
+
+  it('ACK and VERIFY reliable requests use stable retry message ids', () => {
+    const agentSrc = readFileSync(DKG_AGENT_FILE, 'utf8');
+    const lifecycleSrc = readFileSync(CLI_LIFECYCLE_FILE, 'utf8');
+    const agentMessageIds = agentSrc.match(
+      /messageId:\s*stableReliableRequestMessageId\(peerId,\s*protocol,\s*data\)/g,
+    ) ?? [];
+
+    expect(agentMessageIds).toHaveLength(2);
+    expect(lifecycleSrc).toMatch(
+      /messageId:\s*stableReliableRequestMessageId\(peerId,\s*protocol,\s*data\)/,
+    );
   });
 
   it('agent source never publishes ACKs on GossipSub', () => {

--- a/packages/agent/test/storage-ack-protocol-extra.test.ts
+++ b/packages/agent/test/storage-ack-protocol-extra.test.ts
@@ -14,16 +14,68 @@
  * flips RED. See also ack-eip191-agent-extra.test.ts for the constant
  * pin.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { PROTOCOL_STORAGE_ACK } from '@origintrail-official/dkg-core';
+import {
+  InMemoryMessageIdempotencyStore,
+  InMemoryProtocolOutboxStore,
+  PROTOCOL_STORAGE_ACK,
+  PROTOCOL_VERIFY_PROPOSAL,
+  RELIABLE_ENVELOPE_VERSION,
+  TypedEventBus,
+  decodeStorageACK,
+  decodeVerifyApproval,
+  encodePublishIntent,
+  encodeReliableEnvelope,
+  encodeVerifyProposal,
+  type ProtocolRouter,
+  type StreamHandler,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  StorageACKHandler,
+  type StorageACKHandlerConfig,
+} from '../../publisher/src/storage-ack-handler.js';
+import { VerifyProposalHandler } from '../../publisher/src/verify-proposal-handler.js';
+import {
+  computeFlatKCRootV10 as computeFlatKCRoot,
+  computeFlatKCMerkleLeafCountV10,
+} from '../../publisher/src/merkle.js';
+import { ethers } from 'ethers';
+import { Messenger } from '../src/p2p/messenger.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const AGENT_SRC = resolve(__dirname, '..', 'src');
 const DKG_AGENT_FILE = join(AGENT_SRC, 'dkg-agent.ts');
 const CLI_LIFECYCLE_FILE = resolve(__dirname, '..', '..', 'cli', 'src', 'daemon', 'lifecycle.ts');
+
+interface RouterDouble {
+  send: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  inboundHandlers: Map<string, StreamHandler>;
+}
+
+function makeMessengerDouble() {
+  const router: RouterDouble = {
+    send: vi.fn(),
+    inboundHandlers: new Map(),
+    register: vi.fn((protocol: string, handler: StreamHandler) => {
+      router.inboundHandlers.set(protocol, handler);
+    }),
+  };
+  const messenger = new Messenger({
+    router: router as unknown as ProtocolRouter,
+    idempotencyStore: new InMemoryMessageIdempotencyStore(),
+    outboxStore: new InMemoryProtocolOutboxStore(),
+  });
+  return { messenger, router };
+}
+
+function q(subject: string, predicate: string, object: string, graph: string): Quad {
+  return { subject, predicate, object, graph };
+}
 
 function walk(dir: string, acc: string[] = []): string[] {
   for (const name of readdirSync(dir)) {
@@ -70,6 +122,91 @@ describe('A-9: storage-ack protocol id (libp2p) pin', () => {
     expect(lifecycleSrc).toMatch(
       /messageId:\s*stableReliableRequestMessageId\(peerId,\s*protocol,\s*data\)/,
     );
+  });
+
+  it('drives StorageACK and VerifyProposal handlers through Messenger reliable envelopes', async () => {
+    const contextGraphId = '42';
+    const swmGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory`;
+    const quads = [
+      q('urn:entity:1', 'urn:p:name', '"Entity One"', swmGraph),
+      q('urn:entity:1', 'urn:p:type', 'urn:type:Thing', swmGraph),
+    ];
+    const merkleRoot = computeFlatKCRoot(quads, []);
+    const merkleLeafCount = computeFlatKCMerkleLeafCountV10(quads, []);
+    const store = new OxigraphStore();
+    await store.insert(quads);
+
+    const coreWallet = ethers.Wallet.createRandom();
+    const ackConfig: StorageACKHandlerConfig = {
+      nodeRole: 'core',
+      nodeIdentityId: 7n,
+      signerWallet: coreWallet,
+      contextGraphSharedMemoryUri: (cgId: string) =>
+        `did:dkg:context-graph:${cgId}/_shared_memory`,
+      chainId: 31337n,
+      kav10Address: '0x000000000000000000000000000000000000c10a',
+    };
+    const ackHandler = new StorageACKHandler(
+      store as any,
+      ackConfig,
+      new TypedEventBus() as any,
+    );
+    const verifyHandler = new VerifyProposalHandler({
+      store: store as any,
+      agentPrivateKey: coreWallet.privateKey,
+      agentAddress: coreWallet.address,
+      getBatchMerkleRoot: async () => merkleRoot,
+      getContextGraphIdOnChain: async () => 42n,
+    });
+    const { messenger, router } = makeMessengerDouble();
+    messenger.register(PROTOCOL_STORAGE_ACK, ackHandler.handler);
+    messenger.register(PROTOCOL_VERIFY_PROPOSAL, verifyHandler.handler);
+
+    const intentBytes = encodePublishIntent({
+      merkleRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-peer',
+      publicByteSize: 123,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:entity:1'],
+      epochs: 1,
+      tokenAmountStr: '1000',
+      merkleLeafCount,
+    });
+    const ackEnvelope = encodeReliableEnvelope({
+      messageId: '00000000-0000-4000-8000-000000000555',
+      version: RELIABLE_ENVELOPE_VERSION,
+      tsMs: Date.now(),
+      payload: intentBytes,
+    });
+    const ackBytes = await router.inboundHandlers.get(PROTOCOL_STORAGE_ACK)!(
+      ackEnvelope,
+      { toString: () => 'publisher-peer', toBytes: () => new Uint8Array() },
+    );
+    const ack = decodeStorageACK(ackBytes);
+    expect(Number(ack.nodeIdentityId)).toBe(7);
+
+    const proposalId = crypto.getRandomValues(new Uint8Array(16));
+    const proposalEnvelope = encodeReliableEnvelope({
+      messageId: '00000000-0000-4000-8000-000000000556',
+      version: RELIABLE_ENVELOPE_VERSION,
+      tsMs: Date.now(),
+      payload: encodeVerifyProposal({
+        proposalId,
+        contextGraphId,
+        batchId: 1,
+        merkleRoot,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    });
+    const verifyBytes = await router.inboundHandlers.get(PROTOCOL_VERIFY_PROPOSAL)!(
+      proposalEnvelope,
+      { toString: () => 'publisher-peer', toBytes: () => new Uint8Array() },
+    );
+    const approval = decodeVerifyApproval(verifyBytes);
+    expect(approval.approverAddress).toBe(coreWallet.address);
+    expect(Array.from(approval.proposalId)).toEqual(Array.from(proposalId));
   });
 
   it('agent source never publishes ACKs on GossipSub', () => {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -809,8 +809,18 @@ export async function runDaemonInner(
           // integration test covering ACK quorum collection + the
           // ackTransportFactory hot path before the prefix bump
           // lands.
+          // rc.9 PR-11: /storage-ack + /verify-proposal migrated to
+          // /dkg/10.0.1/* and now route through messenger.sendReliable
+          // (envelope wrap + sender-side idempotency + durable
+          // outbox). queued surfaces as a thrown transport error so
+          // ACKCollector's MAX_RETRIES loop + per-peer skip semantics
+          // kick in unchanged.
           sendP2P: async (peerId: string, protocol: string, data: Uint8Array) => {
-            return agent.messenger.sendToPeer(peerId, protocol, data);
+            const sendResult = await agent.messenger.sendReliable(peerId, protocol, data);
+            if (!sendResult.delivered) {
+              throw new Error(`substrate queued (transport): ${sendResult.error}`);
+            }
+            return sendResult.response;
           },
           getConnectedCorePeers: () => {
             const allPeers = agent.node.libp2p

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -51,6 +51,18 @@ const daemonRequire = createRequire(import.meta.url);
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
+
+function stableReliableRequestMessageId(peerId: string, protocol: string, data: Uint8Array): string {
+  const hash = createHash('sha256');
+  hash.update('dkg-cli:ack-transport');
+  hash.update('\0');
+  hash.update(protocol);
+  hash.update('\0');
+  hash.update(peerId);
+  hash.update('\0');
+  hash.update(data);
+  return `request-${hash.digest('hex')}`;
+}
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
@@ -814,9 +826,12 @@ export async function runDaemonInner(
           // (envelope wrap + sender-side idempotency + durable
           // outbox). queued surfaces as a thrown transport error so
           // ACKCollector's MAX_RETRIES loop + per-peer skip semantics
-          // kick in unchanged.
+          // kick in unchanged. A stable per-peer request id keeps retry
+          // attempts on the same outbox/idempotency entry.
           sendP2P: async (peerId: string, protocol: string, data: Uint8Array) => {
-            const sendResult = await agent.messenger.sendReliable(peerId, protocol, data);
+            const sendResult = await agent.messenger.sendReliable(peerId, protocol, data, {
+              messageId: stableReliableRequestMessageId(peerId, protocol, data),
+            });
             if (!sendResult.delivered) {
               throw new Error(`substrate queued (transport): ${sendResult.error}`);
             }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -20,9 +20,17 @@ export const PROTOCOL_SWM_SENDER_KEY = '/dkg/10.0.0/swm-sender-key';
 
 export const PROTOCOL_JOIN_REQUEST = '/dkg/10.0.0/join-request';
 
-export const PROTOCOL_VERIFY_PROPOSAL = '/dkg/10.0.0/verify-proposal';
+// rc.9 PR-11: bumped from /dkg/10.0.0/* to opt into the Universal
+// Messenger substrate. ACKCollector + VerifyCollector keep their
+// existing app-level fan-out + quorum semantics; substrate gives
+// them envelope-versioned wire + receiver-side dedup + sender
+// idempotency under the hood. Default `parallelPaths` for these two
+// is intentionally **1** (the app already fans out; parallelPaths>1
+// would 9x amplify the wire load with no SLO win — see plan PR-4
+// runtime guard + PR-11 rationale).
+export const PROTOCOL_VERIFY_PROPOSAL = '/dkg/10.0.1/verify-proposal';
 export const PROTOCOL_VERIFY_APPROVAL = '/dkg/10.0.0/verify-approval';
-export const PROTOCOL_STORAGE_ACK = '/dkg/10.0.0/storage-ack';
+export const PROTOCOL_STORAGE_ACK = '/dkg/10.0.1/storage-ack';
 
 export const DHT_PROTOCOL = '/dkg/kad/1.0.0';
 

--- a/packages/core/test/v10-constants.test.ts
+++ b/packages/core/test/v10-constants.test.ts
@@ -47,21 +47,30 @@ import {
 } from '../src/constants.js';
 
 describe('V10 protocol stream IDs', () => {
-  it('uses /dkg/10.0.0/ version prefix', () => {
+  // rc.9 plan: protocols on /dkg/10.0.1/* are migrated onto the
+  // Universal Messenger substrate (envelope wrap + receiver dedup +
+  // durable outbox). PR-3 migrated /message (chat + skill); PR-11
+  // migrated /storage-ack + /verify-proposal. Other protocols
+  // migrate on their own PRs (PR-8/9/10) — assertions for those
+  // belong in those PRs' test updates.
+  it('legacy + not-yet-migrated protocols on the /dkg/10.0.0/ prefix', () => {
     expect(PROTOCOL_PUBLISH).toBe('/dkg/10.0.0/publish');
     expect(PROTOCOL_QUERY).toBe('/dkg/10.0.0/query');
     expect(PROTOCOL_DISCOVER).toBe('/dkg/10.0.0/discover');
     expect(PROTOCOL_SYNC).toBe('/dkg/10.0.0/sync');
-    expect(PROTOCOL_MESSAGE).toBe('/dkg/10.0.0/message');
     expect(PROTOCOL_ACCESS).toBe('/dkg/10.0.0/private-access');
     expect(PROTOCOL_QUERY_REMOTE).toBe('/dkg/10.0.0/query-remote');
     expect(PROTOCOL_SWM_SENDER_KEY).toBe('/dkg/10.0.0/swm-sender-key');
   });
 
-  it('defines new VERIFY and ACK protocols', () => {
-    expect(PROTOCOL_VERIFY_PROPOSAL).toBe('/dkg/10.0.0/verify-proposal');
+  // PR-3 migrated /message. PR-11 migrates /storage-ack and
+  // /verify-proposal. /verify-approval stays on /dkg/10.0.0/ because
+  // it's an async follow-up signal, not a synchronous request.
+  it('substrate-migrated protocols use /dkg/10.0.1/ prefix', () => {
+    expect(PROTOCOL_MESSAGE).toBe('/dkg/10.0.1/message');
+    expect(PROTOCOL_VERIFY_PROPOSAL).toBe('/dkg/10.0.1/verify-proposal');
     expect(PROTOCOL_VERIFY_APPROVAL).toBe('/dkg/10.0.0/verify-approval');
-    expect(PROTOCOL_STORAGE_ACK).toBe('/dkg/10.0.0/storage-ack');
+    expect(PROTOCOL_STORAGE_ACK).toBe('/dkg/10.0.1/storage-ack');
   });
 
   it('DHT protocol is unchanged', () => {

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -13,8 +13,6 @@ import {
 import { parseSimpleNQuads } from './publish-handler.js';
 import { ethers } from 'ethers';
 
-type PeerId = { toString(): string };
-
 export interface StorageACKHandlerConfig {
   nodeRole: 'core' | 'edge';
   nodeIdentityId: bigint;
@@ -83,7 +81,7 @@ export class StorageACKHandler {
    * Protocol stream handler for `/dkg/10.0.0/storage-ack`.
    * Receives PublishIntent, returns StorageACK.
    */
-  handler = async (data: Uint8Array, _peerId: PeerId): Promise<Uint8Array> => {
+  handler = async (data: Uint8Array, _peerId: string): Promise<Uint8Array> => {
     if (this.config.nodeRole !== 'core') {
       throw new Error('Only core nodes can issue StorageACKs');
     }

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -13,6 +13,12 @@ import {
 import { parseSimpleNQuads } from './publish-handler.js';
 import { ethers } from 'ethers';
 
+type PeerIdLike = string | { toString(): string };
+
+function normalizePeerId(peerId: PeerIdLike): string {
+  return typeof peerId === 'string' ? peerId : peerId.toString();
+}
+
 export interface StorageACKHandlerConfig {
   nodeRole: 'core' | 'edge';
   nodeIdentityId: bigint;
@@ -78,10 +84,11 @@ export class StorageACKHandler {
   }
 
   /**
-   * Protocol stream handler for `/dkg/10.0.0/storage-ack`.
+   * Protocol stream handler for `/dkg/10.0.1/storage-ack`.
    * Receives PublishIntent, returns StorageACK.
    */
-  handler = async (data: Uint8Array, _peerId: string): Promise<Uint8Array> => {
+  handler = async (data: Uint8Array, peerId: PeerIdLike): Promise<Uint8Array> => {
+    void normalizePeerId(peerId);
     if (this.config.nodeRole !== 'core') {
       throw new Error('Only core nodes can issue StorageACKs');
     }

--- a/packages/publisher/src/verify-proposal-handler.ts
+++ b/packages/publisher/src/verify-proposal-handler.ts
@@ -9,7 +9,7 @@ import {
 import { ethers } from 'ethers';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 
-type StreamHandler = (data: Uint8Array, peerId: { toString(): string }) => Promise<Uint8Array>;
+type StreamHandler = (data: Uint8Array, peerId: string) => Promise<Uint8Array>;
 
 export interface VerifyProposalHandlerDeps {
   store: TripleStore;
@@ -36,8 +36,8 @@ export class VerifyProposalHandler {
   }
 
   get handler(): StreamHandler {
-    return async (data: Uint8Array, peerId: { toString(): string }) => {
-      return this.handleProposal(data, peerId.toString());
+    return async (data: Uint8Array, peerId: string) => {
+      return this.handleProposal(data, peerId);
     };
   }
 

--- a/packages/publisher/src/verify-proposal-handler.ts
+++ b/packages/publisher/src/verify-proposal-handler.ts
@@ -9,7 +9,12 @@ import {
 import { ethers } from 'ethers';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 
-type StreamHandler = (data: Uint8Array, peerId: string) => Promise<Uint8Array>;
+type PeerIdLike = string | { toString(): string };
+type StreamHandler = (data: Uint8Array, peerId: PeerIdLike) => Promise<Uint8Array>;
+
+function normalizePeerId(peerId: PeerIdLike): string {
+  return typeof peerId === 'string' ? peerId : peerId.toString();
+}
 
 export interface VerifyProposalHandlerDeps {
   store: TripleStore;
@@ -36,8 +41,8 @@ export class VerifyProposalHandler {
   }
 
   get handler(): StreamHandler {
-    return async (data: Uint8Array, peerId: string) => {
-      return this.handleProposal(data, peerId);
+    return async (data: Uint8Array, peerId: PeerIdLike) => {
+      return this.handleProposal(data, normalizePeerId(peerId));
     };
   }
 

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -37,7 +37,7 @@ describe('StorageACKHandler', () => {
 
   const coreWallet = ethers.Wallet.createRandom();
   const coreIdentityId = 42n;
-  const fakePeerId = { toString: () => 'publisher-peer' };
+  const fakePeerId = 'publisher-peer';
 
   async function createHandler(
     storeQuads: Quad[],

--- a/packages/publisher/test/storage-ack-roster-and-verify-mofn-extra.test.ts
+++ b/packages/publisher/test/storage-ack-roster-and-verify-mofn-extra.test.ts
@@ -290,7 +290,7 @@ describe('P-9: StorageACKHandler nodeRole guard (edge nodes cannot issue ACKs)',
       merkleLeafCount: 1,
     });
 
-    await expect(handler.handler(intent, { toString: () => 'peer-1' })).rejects.toThrow(
+    await expect(handler.handler(intent, 'peer-1')).rejects.toThrow(
       /core nodes can issue StorageACKs/i,
     );
   });
@@ -354,7 +354,7 @@ describe('P-9: StorageACKHandler roster gap — core-flagged node signs with ANY
         merkleLeafCount: rosterTestLeafCount,
       });
 
-      const responseBytes = await handler.handler(intent, { toString: () => 'rogue' });
+      const responseBytes = await handler.handler(intent, 'rogue');
       // If the handler had a proper roster check, we'd never reach
       // here — the call would throw. It doesn't, so we assert the
       // fact directly: ACK is produced and signed by a wallet the

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -493,7 +493,7 @@ describe('ACKCollector retry behavior', () => {
 describe('StorageACKHandler inline verification', () => {
   const coreWallet = ethers.Wallet.createRandom();
   const coreIdentityId = 42n;
-  const fakePeerId = { toString: () => 'publisher-peer' };
+  const fakePeerId = 'publisher-peer';
 
   function createConfig(overrides: Partial<StorageACKHandlerConfig> = {}): StorageACKHandlerConfig {
     return {
@@ -627,7 +627,7 @@ describe('StorageACKHandler inline verification', () => {
 
 describe('StorageACKHandler security', () => {
   const coreWallet = ethers.Wallet.createRandom();
-  const fakePeerId = { toString: () => 'publisher-peer' };
+  const fakePeerId = 'publisher-peer';
 
   function createConfig(overrides: Partial<StorageACKHandlerConfig> = {}): StorageACKHandlerConfig {
     return {
@@ -759,7 +759,7 @@ describe('StorageACKHandler security', () => {
 describe('StorageACKHandler signature format', () => {
   const coreWallet = ethers.Wallet.createRandom();
   const coreIdentityId = 99n;
-  const fakePeerId = { toString: () => 'publisher-peer' };
+  const fakePeerId = 'publisher-peer';
 
   function createConfig(): StorageACKHandlerConfig {
     return {

--- a/packages/publisher/test/v10-protocol-operations.test.ts
+++ b/packages/publisher/test/v10-protocol-operations.test.ts
@@ -685,7 +685,7 @@ describe('V10 ACK Edge Cases', () => {
       merkleLeafCount: singleEntityLeafCount,
     });
 
-    await expect(handler.handler(intent, { toString: () => 'peer' }))
+    await expect(handler.handler(intent, 'peer'))
       .rejects.toThrow('exceeds');
   });
 });
@@ -792,7 +792,7 @@ describe('V10 StorageACKHandler round-trip', () => {
   const contextGraphId = '42';
   const cgIdBigInt = 42n;
   const coreWallet = ethers.Wallet.createRandom();
-  const fakePeerId = { toString: () => 'requester-peer' };
+  const fakePeerId = 'requester-peer';
 
   const testQuads: Quad[] = [
     makeQuad('urn:entity:1', 'urn:p:name', '"Entity One"'),

--- a/packages/publisher/test/v10-publish-e2e.test.ts
+++ b/packages/publisher/test/v10-publish-e2e.test.ts
@@ -126,8 +126,7 @@ describe('V10 Publish E2E', () => {
       sendP2P: async (peerId, _protocol, data) => {
         const idx = parseInt(peerId.replace('core-', ''), 10);
         const handler = handlers[idx];
-        const fakePeerId = { toString: () => peerId };
-        return handler.handler(data, fakePeerId);
+        return handler.handler(data, peerId);
       },
       getConnectedCorePeers: () => ['core-0', 'core-1', 'core-2'],
       log: () => {},

--- a/packages/publisher/test/v10-remap-wire.test.ts
+++ b/packages/publisher/test/v10-remap-wire.test.ts
@@ -328,7 +328,7 @@ describe('V10 remap wire (PublishIntent.swmGraphId + subGraphName)', () => {
       merkleLeafCount,
     });
 
-    const response = await handler.handler(intent, { toString: () => 'publisher-peer-0' });
+    const response = await handler.handler(intent, 'publisher-peer-0');
     const ack = decodeStorageACK(response);
 
     // 1. Handler looked up SWM under the SOURCE graph + sub-graph, NOT the

--- a/packages/publisher/test/verify-proposal-handler.test.ts
+++ b/packages/publisher/test/verify-proposal-handler.test.ts
@@ -31,7 +31,7 @@ function makeProposalBytes(overrides?: Record<string, unknown>): Uint8Array {
   });
 }
 
-const peerId = { toString: () => '12D3KooWTest' };
+const peerId = '12D3KooWTest';
 
 describe('VerifyProposalHandler', () => {
   it('returns a signed approval for a valid proposal', async () => {


### PR DESCRIPTION
## Summary

Milestone C — PR-11. Batch-migrates the two ACK-quorum protocols onto the Universal Messenger substrate. App-level fan-out (\`ACKCollector\` + \`VerifyCollector\`) stays untouched; only the transport swaps.

## What changed

### Constants
- \`PROTOCOL_STORAGE_ACK\`: \`/dkg/10.0.0/storage-ack\` → \`/dkg/10.0.1/storage-ack\`
- \`PROTOCOL_VERIFY_PROPOSAL\`: \`/dkg/10.0.0/verify-proposal\` → \`/dkg/10.0.1/verify-proposal\`
- \`PROTOCOL_VERIFY_APPROVAL\` stays on \`/dkg/10.0.0/\` (async follow-up signal — no synchronous request/response, doesn't need the substrate).

### Handler-side (\`dkg-agent.ts\`)
- Both handlers register via \`messenger.register\`; envelope decode + receiver-side dedup wrap them transparently (peerIdObj adapter shim).
- \`router.unregister(PROTOCOL_STORAGE_ACK)\` on signer-failover still works because \`messenger.register\` delegates to \`router.register\` under the hood.

### Sender-side (3 sites)
- **agent** \`VerifyCollector.sendP2P\`: now routes through \`messenger.sendReliable\`; \`queued\` surfaces as a per-peer throw that \`VerifyCollector\` handles via its existing per-peer skip semantics.
- **agent** \`ACKCollector.sendP2P\` (same pattern); \`ACKCollector\`'s \`MAX_RETRIES=3\` loop sits on top.
- **cli** \`lifecycle.ts ackTransportFactory.sendP2P\`: same pattern (the inline comment that flagged THIS as the PR-11 hot path is now satisfied).

### \`parallelPaths=1\` rationale (transport-side)
The app already fans out to N core peers in parallel. \`parallelPaths>1\` would amplify the wire load **9x** (N × parallelPaths) with no SLO win — see PR-4's runtime guard + plan PR-4/PR-11 spec. Documented inline in \`docs/messenger.md\` per-protocol table.

### Tests
- \`storage-ack-protocol-extra.test.ts\`: A-9 pin updated to \`/dkg/10.0.1/storage-ack\` + \`messenger.register\` regex.
- \`ack-eip191-agent-extra.test.ts\`: A-10/A-12 pin updated to \`/dkg/10.0.1/storage-ack\`.
- \`v10-constants.test.ts\`: split into "legacy + not-yet-migrated" vs "substrate-migrated" assertions so each protocol PR can claim its row without thrashing the others. PR-11 claims \`storage-ack\` + \`verify-proposal\`; PR-3's \`PROTOCOL_MESSAGE\` row also fixed (was a leftover failure from PR-3).
- Full agent test suite (excluding pre-existing flakes): **461/461 green across 52 test files**.
- \`packages/publisher/test/ack-collector.test.ts\`: 5/5 green (uses injected sendP2P mocks).
- \`packages/publisher/test/storage-ack-roster-and-verify-mofn-extra.test.ts\`: 6/6 green.

### Docs
- \`docs/messenger.md\` per-protocol table: \`/storage-ack\` and \`/verify-proposal\` marked PR-11 ✅ with the parallelPaths=1 amplification rationale.

## Test plan

- [x] agent suite 461/461 green
- [x] publisher ack tests 11/11 green
- [x] core constants tests 69/69 green
- [x] type-check core + agent + cli green
- [ ] Gate C (post-Milestone C): overnight soak across all 8 protocols verifies the rest of the migrations + SLO.

## Stacking

Base: \`feat/messenger-pilot-migration\` (PR-3 #544). Parallel-shippable with PR-8 (#550), PR-9 (#551), PR-10 (#554), PR-12 (#TBD).


Made with [Cursor](https://cursor.com)