### PR TITLE
feat(publisher): structured StorageACK declines instead of stream resets

### DIFF
--- a/packages/core/src/proto/index.ts
+++ b/packages/core/src/proto/index.ts
@@ -87,8 +87,11 @@ export {
 
 export {
   type StorageACKMsg,
+  type StorageACKDeclineCode,
+  STORAGE_ACK_DECLINE_CODES,
   encodeStorageACK,
   decodeStorageACK,
+  isStorageACKDecline,
 } from './storage-ack.js';
 
 export {

--- a/packages/core/src/proto/index.ts
+++ b/packages/core/src/proto/index.ts
@@ -89,9 +89,11 @@ export {
   type StorageACKMsg,
   type StorageACKDeclineCode,
   STORAGE_ACK_DECLINE_CODES,
+  TRANSIENT_STORAGE_ACK_DECLINE_CODES,
   encodeStorageACK,
   decodeStorageACK,
   isStorageACKDecline,
+  isTransientStorageACKDeclineCode,
 } from './storage-ack.js';
 
 export {

--- a/packages/core/src/proto/storage-ack.ts
+++ b/packages/core/src/proto/storage-ack.ts
@@ -29,20 +29,34 @@ const { Type, Field } = protobuf;
 /**
  * Declinable reasons a core node can return on `/dkg/10.0.0/storage-ack`
  * instead of a signed ACK. These are situations where the core
- * legitimately cannot produce an ACK (its SWM is missing or stale
- * relative to the publisher's payload, or its operational signer was
- * just rotated off-chain) — distinct from a malformed-request error
- * that should still close the libp2p stream.
+ * legitimately cannot produce an ACK for THIS PEER right now — a
+ * well-formed publish request that this specific core just can't
+ * satisfy.
  *
- * The publisher treats declines as **permanent for this request** (no
- * retry against the same peer), reports the per-peer decline reason in
- * the final error if quorum fails, and tries the remaining peers in
- * parallel.
+ * Codes split into two classes that the publisher treats differently:
+ *
+ * - **Transient** ({@link TRANSIENT_STORAGE_ACK_DECLINE_CODES}):
+ *   the local condition is expected to clear on its own (e.g. SWM is
+ *   catching up via gossip). The publisher retries the same peer with
+ *   the existing transport backoff before giving up — keeps quorum
+ *   reachable when replication is just slightly behind the publish.
+ *
+ * - **Permanent** (every other code):
+ *   the condition will not change on a fast retry (e.g. the operational
+ *   signer was rotated off-chain). The publisher deselects this peer
+ *   for THIS request and moves on to others; the reason is surfaced
+ *   in the final error if quorum still fails.
+ *
+ * Malformed-request errors are NOT declines and do NOT belong here.
+ * The handler keeps `throw`ing on those so the publisher sees them as
+ * stream errors with the original message and surfaces them to the
+ * caller immediately rather than fanning out to every core looking
+ * for a different answer.
  *
  * String values are part of the wire format: they are populated into
  * `StorageACK.declineCode` and surfaced in publisher logs / error
  * messages. Keep them stable across releases. Adding a new code is a
- * non-breaking change (older publishers will see it as the catch-all
+ * non-breaking change (older publishers see it as the catch-all
  * "unknown decline" path); renaming or removing one IS breaking.
  */
 export const STORAGE_ACK_DECLINE_CODES = {
@@ -52,12 +66,31 @@ export const STORAGE_ACK_DECLINE_CODES = {
   MERKLE_MISMATCH_IN_SWM: 'MERKLE_MISMATCH_IN_SWM',
   /** Operational signer was just removed / rotated off-chain. */
   SIGNER_NOT_REGISTERED: 'SIGNER_NOT_REGISTERED',
-  /** CG id is non-numeric or non-positive (publisher remap mistake). */
-  CG_ID_INVALID: 'CG_ID_INVALID',
 } as const;
 
 export type StorageACKDeclineCode =
   (typeof STORAGE_ACK_DECLINE_CODES)[keyof typeof STORAGE_ACK_DECLINE_CODES];
+
+/**
+ * Decline codes whose root cause is expected to clear on its own
+ * (typically SWM replication catching up via gossip). The publisher
+ * retries these against the same peer through the normal transport
+ * backoff before giving up, so a peer that would have ACKed seconds
+ * later still contributes to quorum.
+ *
+ * Membership of this set is part of the protocol contract between
+ * publisher and core — promoting / demoting a code is a behavior
+ * change, not a wire change.
+ */
+export const TRANSIENT_STORAGE_ACK_DECLINE_CODES: ReadonlySet<string> = new Set<string>([
+  STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
+  STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM,
+]);
+
+/** True iff `code` names a decline the publisher should retry rather than treat as permanent. */
+export function isTransientStorageACKDeclineCode(code: string | undefined): boolean {
+  return typeof code === 'string' && TRANSIENT_STORAGE_ACK_DECLINE_CODES.has(code);
+}
 
 /**
  * Wire schema. Fields 1–5 are the original ACK shape; fields 6–7 carry

--- a/packages/core/src/proto/storage-ack.ts
+++ b/packages/core/src/proto/storage-ack.ts
@@ -29,10 +29,10 @@ const { Type, Field } = protobuf;
 /**
  * Declinable reasons a core node can return on `/dkg/10.0.0/storage-ack`
  * instead of a signed ACK. These are situations where the core
- * legitimately cannot produce an ACK (it doesn't host the CG, its SWM
- * is missing or stale relative to the publisher's payload, or its
- * operational signer was just rotated off-chain) — distinct from a
- * malformed-request error that should still close the libp2p stream.
+ * legitimately cannot produce an ACK (its SWM is missing or stale
+ * relative to the publisher's payload, or its operational signer was
+ * just rotated off-chain) — distinct from a malformed-request error
+ * that should still close the libp2p stream.
  *
  * The publisher treats declines as **permanent for this request** (no
  * retry against the same peer), reports the per-peer decline reason in
@@ -46,8 +46,6 @@ const { Type, Field } = protobuf;
  * "unknown decline" path); renaming or removing one IS breaking.
  */
 export const STORAGE_ACK_DECLINE_CODES = {
-  /** Core does not host the requested CG (no `<contextGraphsServed>`). */
-  NOT_HOSTED: 'NOT_HOSTED',
   /** SWM CONSTRUCT returned no quads for the request. */
   NO_DATA_IN_SWM: 'NO_DATA_IN_SWM',
   /** SWM has data but its merkle root does not match the publisher's. */

--- a/packages/core/src/proto/storage-ack.ts
+++ b/packages/core/src/proto/storage-ack.ts
@@ -26,12 +26,57 @@ const { Type, Field } = protobuf;
  * byte-for-byte.
  */
 
+/**
+ * Declinable reasons a core node can return on `/dkg/10.0.0/storage-ack`
+ * instead of a signed ACK. These are situations where the core
+ * legitimately cannot produce an ACK (it doesn't host the CG, its SWM
+ * is missing or stale relative to the publisher's payload, or its
+ * operational signer was just rotated off-chain) — distinct from a
+ * malformed-request error that should still close the libp2p stream.
+ *
+ * The publisher treats declines as **permanent for this request** (no
+ * retry against the same peer), reports the per-peer decline reason in
+ * the final error if quorum fails, and tries the remaining peers in
+ * parallel.
+ *
+ * String values are part of the wire format: they are populated into
+ * `StorageACK.declineCode` and surfaced in publisher logs / error
+ * messages. Keep them stable across releases. Adding a new code is a
+ * non-breaking change (older publishers will see it as the catch-all
+ * "unknown decline" path); renaming or removing one IS breaking.
+ */
+export const STORAGE_ACK_DECLINE_CODES = {
+  /** Core does not host the requested CG (no `<contextGraphsServed>`). */
+  NOT_HOSTED: 'NOT_HOSTED',
+  /** SWM CONSTRUCT returned no quads for the request. */
+  NO_DATA_IN_SWM: 'NO_DATA_IN_SWM',
+  /** SWM has data but its merkle root does not match the publisher's. */
+  MERKLE_MISMATCH_IN_SWM: 'MERKLE_MISMATCH_IN_SWM',
+  /** Operational signer was just removed / rotated off-chain. */
+  SIGNER_NOT_REGISTERED: 'SIGNER_NOT_REGISTERED',
+  /** CG id is non-numeric or non-positive (publisher remap mistake). */
+  CG_ID_INVALID: 'CG_ID_INVALID',
+} as const;
+
+export type StorageACKDeclineCode =
+  (typeof STORAGE_ACK_DECLINE_CODES)[keyof typeof STORAGE_ACK_DECLINE_CODES];
+
+/**
+ * Wire schema. Fields 1–5 are the original ACK shape; fields 6–7 carry
+ * a decline payload. Two optional strings (rather than a `oneof`) keep
+ * the change strictly additive: old encoders never set the new fields,
+ * old decoders silently ignore them, so cross-version traffic is
+ * unchanged. New decoders inspect `declineCode` first — when it is
+ * non-empty the message is a decline and the ACK fields are unset.
+ */
 export const StorageACKSchema = new Type('StorageACK')
   .add(new Field('merkleRoot', 1, 'bytes'))
   .add(new Field('coreNodeSignatureR', 2, 'bytes'))
   .add(new Field('coreNodeSignatureVS', 3, 'bytes'))
   .add(new Field('contextGraphId', 4, 'string'))
-  .add(new Field('nodeIdentityId', 5, 'uint64'));
+  .add(new Field('nodeIdentityId', 5, 'uint64'))
+  .add(new Field('declineCode', 6, 'string'))
+  .add(new Field('declineMessage', 7, 'string'));
 
 type Long = { low: number; high: number; unsigned: boolean };
 
@@ -41,6 +86,31 @@ export interface StorageACKMsg {
   coreNodeSignatureVS: Uint8Array;
   contextGraphId: string;
   nodeIdentityId: number | Long;
+  /**
+   * When non-empty, this message is a decline rather than a signed ACK
+   * — see {@link STORAGE_ACK_DECLINE_CODES}. Old senders never set this
+   * field; old receivers ignore it. New receivers MUST check this
+   * before treating the message as an ACK (signature/merkleRoot are
+   * unset on declines).
+   */
+  declineCode?: string;
+  /**
+   * Human-readable reason that accompanies `declineCode`. Surfaced into
+   * publisher logs and the final `storage_ack_insufficient` error so
+   * operators can diagnose hosting / replication issues without having
+   * to ssh into individual cores.
+   */
+  declineMessage?: string;
+}
+
+/**
+ * Convenience: returns true iff the message is a decline (i.e.
+ * `declineCode` is set to a non-empty string). Keeps callers from
+ * having to remember the empty-string-as-undefined idiom that
+ * protobufjs uses for unset string fields.
+ */
+export function isStorageACKDecline(msg: StorageACKMsg): boolean {
+  return typeof msg.declineCode === 'string' && msg.declineCode.length > 0;
 }
 
 export function encodeStorageACK(msg: StorageACKMsg): Uint8Array {

--- a/packages/core/test/v10-proto.test.ts
+++ b/packages/core/test/v10-proto.test.ts
@@ -161,23 +161,28 @@ describe('StorageACKMsg', () => {
   });
 
   it('a new decoder reading bytes from an old encoder still yields a valid ACK (forward compat)', () => {
-    // Pre-decline shape — a fixed byte sequence stands in for what an
-    // older release would have written. We synthesise it with the
-    // current encoder by leaving the new decline fields unset; the
-    // length-prefixed wire format guarantees an old encoder produces
-    // the same bytes (proto3 default-skipping is consistent across
-    // protobufjs versions in this repo).
-    const oldShape: StorageACKMsg = {
-      merkleRoot: new Uint8Array(32).fill(0xa5),
-      coreNodeSignatureR: new Uint8Array(32).fill(0x11),
-      coreNodeSignatureVS: new Uint8Array(32).fill(0x22),
-      contextGraphId: 'cg-100',
-      nodeIdentityId: 7,
-    };
-    const wire = encodeStorageACK(oldShape);
+    // Literal pre-decline wire shape from the old 5-field schema:
+    // 1=merkleRoot, 2=signatureR, 3=signatureVS, 4=contextGraphId,
+    // 5=nodeIdentityId. Keeping this as bytes catches regressions where
+    // the new schema stops decoding historical ACK payloads even though
+    // the current encoder still omits unset decline fields.
+    const wire = Uint8Array.from([
+      0x0a, 0x20,
+      ...new Array(32).fill(0xa5),
+      0x12, 0x20,
+      ...new Array(32).fill(0x11),
+      0x1a, 0x20,
+      ...new Array(32).fill(0x22),
+      0x22, 0x06,
+      0x63, 0x67, 0x2d, 0x31, 0x30, 0x30,
+      0x28, 0x07,
+    ]);
     const decoded = decodeStorageACK(wire);
     expect(decoded.contextGraphId).toBe('cg-100');
     expect(Number(decoded.nodeIdentityId)).toBe(7);
+    expect(new Uint8Array(decoded.merkleRoot)).toEqual(new Uint8Array(32).fill(0xa5));
+    expect(new Uint8Array(decoded.coreNodeSignatureR)).toEqual(new Uint8Array(32).fill(0x11));
+    expect(new Uint8Array(decoded.coreNodeSignatureVS)).toEqual(new Uint8Array(32).fill(0x22));
     expect(decoded.declineCode == null || decoded.declineCode === '').toBe(true);
   });
 });

--- a/packages/core/test/v10-proto.test.ts
+++ b/packages/core/test/v10-proto.test.ts
@@ -130,6 +130,56 @@ describe('StorageACKMsg', () => {
   it('deterministic encoding', () => {
     expect(encodeStorageACK(ack)).toEqual(encodeStorageACK(ack));
   });
+
+  it('decodes an old ACK (no decline fields) without populating declineCode', async () => {
+    const decoded = decodeStorageACK(encodeStorageACK(ack));
+    expect(decoded.declineCode == null || decoded.declineCode === '').toBe(true);
+    expect(decoded.declineMessage == null || decoded.declineMessage === '').toBe(true);
+    const { isStorageACKDecline } = await import('../src/proto/storage-ack.js');
+    expect(isStorageACKDecline(decoded)).toBe(false);
+  });
+
+  it('decline-only message: empty ACK fields + populated decline code/message round-trip', async () => {
+    const { STORAGE_ACK_DECLINE_CODES, isStorageACKDecline } = await import('../src/proto/storage-ack.js');
+    const decline: StorageACKMsg = {
+      merkleRoot: new Uint8Array(0),
+      coreNodeSignatureR: new Uint8Array(0),
+      coreNodeSignatureVS: new Uint8Array(0),
+      contextGraphId: '15',
+      nodeIdentityId: 0,
+      declineCode: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
+      declineMessage:
+        'No data found in SWM graph did:dkg:context-graph:15/_shared_memory for entities: urn:a, urn:b',
+    };
+    const decoded = decodeStorageACK(encodeStorageACK(decline));
+    expect(decoded.declineCode).toBe('NO_DATA_IN_SWM');
+    expect(decoded.declineMessage).toContain('No data found in SWM graph');
+    expect(decoded.contextGraphId).toBe('15');
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(new Uint8Array(decoded.merkleRoot).length).toBe(0);
+    expect(new Uint8Array(decoded.coreNodeSignatureR).length).toBe(0);
+  });
+
+  it('a new decoder reading bytes from an old encoder still yields a valid ACK (forward compat)', () => {
+    // Pre-decline shape — a fixed byte sequence stands in for what an
+    // older release would have written. We synthesise it with the
+    // current encoder by leaving the new decline fields unset; the
+    // length-prefixed wire format guarantees an old encoder produces
+    // the same bytes (proto3 default-skipping is consistent across
+    // protobufjs versions in this repo).
+    const oldShape: StorageACKMsg = {
+      merkleRoot: new Uint8Array(32).fill(0xa5),
+      coreNodeSignatureR: new Uint8Array(32).fill(0x11),
+      coreNodeSignatureVS: new Uint8Array(32).fill(0x22),
+      contextGraphId: 'cg-100',
+      nodeIdentityId: 7,
+    };
+    const wire = encodeStorageACK(oldShape);
+    const decoded = decodeStorageACK(wire);
+    expect(decoded.contextGraphId).toBe('cg-100');
+    expect(Number(decoded.nodeIdentityId)).toBe(7);
+    expect(decoded.declineCode == null || decoded.declineCode === '').toBe(true);
+  });
 });
 
 // ── SwmShareAck (rc.9 PR-D) ───────────────────────────────────────────

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -268,6 +268,20 @@ export class ACKCollector {
             log(`[ACKCollector] Retry ${attempt + 1}/${MAX_RETRIES} for ${peerId.slice(-8)}: ${msg}`);
             await new Promise(r => setTimeout(r, (attempt + 1) * 1000));
           } else {
+            // Terminal transport failure on the final attempt. If this
+            // peer transient-declined on an earlier attempt the
+            // `declines` map still holds that stale code — overwrite
+            // it with the actual terminal reason so the aggregated
+            // `storage_ack_insufficient` diagnostic reflects the last
+            // observed outcome (the codex review on PR #559 caught
+            // the original "stale decline shadows the real failure"
+            // path here).
+            if (declines.has(peerId)) {
+              declines.set(peerId, {
+                code: 'TRANSPORT_ERROR',
+                message: sanitizeDeclineField(msg, MAX_DECLINE_MESSAGE_CHARS),
+              });
+            }
             log(`[ACKCollector] Failed to get ACK from ${peerId.slice(-8)} after ${MAX_RETRIES} attempts: ${msg}`);
           }
         }

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -4,6 +4,7 @@ import {
   decodeStorageACK,
   computePublishACKDigest,
   isStorageACKDecline,
+  isTransientStorageACKDeclineCode,
   type PublishIntentMsg,
   type StorageACKMsg,
 } from '@origintrail-official/dkg-core';
@@ -193,7 +194,30 @@ export class ACKCollector {
               ack.declineMessage ?? '',
               MAX_DECLINE_MESSAGE_CHARS,
             );
+            // Record the latest decline reason so it surfaces in the
+            // final `storage_ack_insufficient` error. Overwriting any
+            // prior entry is intentional — operators care most about
+            // why the peer ultimately could not ACK.
             declines.set(peerId, { code, message: declineMessage });
+
+            // Transient declines (SWM replication catching up via
+            // gossip) can resolve on a retry, so re-send through the
+            // same backoff as transport errors instead of permanently
+            // deselecting the peer. Codex review on PR #559 flagged
+            // the "every decline is permanent" path as a regression:
+            // a core that would have ACKed seconds later was being
+            // removed from the quorum pool the moment its SWM trailed
+            // the publish by even one gossip cycle.
+            if (isTransientStorageACKDeclineCode(code) && attempt < MAX_RETRIES - 1) {
+              log(
+                `[ACKCollector] Transient decline from ${peerId.slice(-8)}: ${code}` +
+                (declineMessage ? ` — ${declineMessage}` : '') +
+                ` (retry ${attempt + 1}/${MAX_RETRIES})`,
+              );
+              await new Promise(r => setTimeout(r, (attempt + 1) * 1000));
+              continue;
+            }
+
             log(
               `[ACKCollector] Decline from ${peerId.slice(-8)}: ${code}` +
               (declineMessage ? ` — ${declineMessage}` : ''),
@@ -223,6 +247,12 @@ export class ACKCollector {
               return null;
             }
           }
+
+          // Clear any prior transient-decline record now that this peer
+          // has produced a valid ACK on a later retry — otherwise the
+          // stale decline would still appear in `storage_ack_insufficient`
+          // if quorum fails for unrelated reasons.
+          declines.delete(peerId);
 
           log(`[ACKCollector] Valid ACK from ${peerId.slice(-8)} (identity=${identityId}, signer=${recoveredAddress.slice(0, 10)}...)`);
 

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -149,14 +149,26 @@ export class ACKCollector {
     const collected: CollectedACK[] = [];
     const seenPeers = new Set<string>();
     const seenIdentityIds = new Set<bigint>();
-    // Per-peer typed declines from new core nodes — see PR#557.
-    // Declines are permanent for THIS request; the publisher records the
-    // reason, skips retries against the declining peer, and surfaces all
-    // collected reasons in the final `storage_ack_insufficient` message
-    // when quorum can't be reached. Old cores that pre-date the typed
-    // wire shape continue to throw / reset and follow the legacy retry
-    // path below — declines are strictly additive.
+    // Per-peer typed declines from core nodes that ran the StorageACK
+    // handler against the request and decided they cannot sign. The
+    // publisher records the reason, skips retries against the declining
+    // peer, and surfaces all collected reasons in the final
+    // `storage_ack_insufficient` message when quorum can't be reached.
+    // Cores that pre-date the typed wire shape continue to throw / reset
+    // and follow the legacy retry path below — declines are strictly
+    // additive on the wire.
     const declines = new Map<string, { code: string; message: string }>();
+
+    const formatDeclineDetail = (): string => {
+      if (declines.size === 0) return '';
+      const formatted = [...declines.entries()]
+        .map(([peer, { code, message }]) => {
+          const tag = `${peer.slice(-8)}→${code}`;
+          return message ? `${tag} (${message})` : tag;
+        })
+        .join('; ');
+      return ` Declines: ${formatted}.`;
+    };
 
     const requestACK = async (peerId: string): Promise<CollectedACK | null> => {
       for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
@@ -222,44 +234,65 @@ export class ACKCollector {
     let quorumResolve: (() => void) | undefined;
     const quorumPromise = new Promise<void>(resolve => { quorumResolve = resolve; });
 
+    // Fast-fail on impossible quorum (Codex Review on PR#559): once
+    // declines + max-retries-failures bring the still-pending pool too
+    // low to ever reach `REQUIRED_ACKS`, surface the
+    // `storage_ack_insufficient` error immediately rather than waiting
+    // out the full ACK_TIMEOUT_MS for a hung peer that — by that point
+    // — couldn't change the outcome anyway. The check is conservative
+    // (counts a still-pending peer as a potential ACK), so we never
+    // fail-fast a quorum that's still attainable.
+    let peersSettled = 0;
+    let impossibleReject: ((reason: Error) => void) | undefined;
+    const impossiblePromise = new Promise<never>((_, reject) => { impossibleReject = reject; });
+
+    const settlePeer = () => {
+      peersSettled += 1;
+      if (collected.length >= REQUIRED_ACKS) return;
+      const stillPending = corePeers.length - peersSettled;
+      if (collected.length + stillPending < REQUIRED_ACKS) {
+        impossibleReject?.(new Error(
+          `storage_ack_insufficient: got ${collected.length}/${REQUIRED_ACKS} valid ACKs after ` +
+          `${peersSettled}/${corePeers.length} core peer(s) settled — quorum no longer reachable.${formatDeclineDetail()}`,
+        ));
+      }
+    };
+
     await Promise.race([
       (async () => {
         const promises = corePeers.map(async (peerId) => {
-          if (collected.length >= REQUIRED_ACKS) return;
-          const ack = await requestACK(peerId);
-          if (ack && !seenPeers.has(ack.peerId) && !seenIdentityIds.has(ack.nodeIdentityId)) {
-            seenPeers.add(ack.peerId);
-            seenIdentityIds.add(ack.nodeIdentityId);
-            collected.push(ack);
-            if (collected.length >= REQUIRED_ACKS) {
-              quorumResolve?.();
-              return;
+          if (collected.length >= REQUIRED_ACKS) {
+            settlePeer();
+            return;
+          }
+          try {
+            const ack = await requestACK(peerId);
+            if (ack && !seenPeers.has(ack.peerId) && !seenIdentityIds.has(ack.nodeIdentityId)) {
+              seenPeers.add(ack.peerId);
+              seenIdentityIds.add(ack.nodeIdentityId);
+              collected.push(ack);
+              if (collected.length >= REQUIRED_ACKS) {
+                quorumResolve?.();
+              }
             }
+          } finally {
+            settlePeer();
           }
         });
         await Promise.race([Promise.allSettled(promises), quorumPromise]);
       })(),
+      impossiblePromise,
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`storage_ack_timeout: only ${collected.length}/${REQUIRED_ACKS} ACKs received within ${ACK_TIMEOUT_MS}ms`)),
+        setTimeout(() => reject(new Error(`storage_ack_timeout: only ${collected.length}/${REQUIRED_ACKS} ACKs received within ${ACK_TIMEOUT_MS}ms.${formatDeclineDetail()}`)),
           ACK_TIMEOUT_MS,
         ),
       ),
     ]);
 
     if (collected.length < REQUIRED_ACKS) {
-      let detail = '';
-      if (declines.size > 0) {
-        const formatted = [...declines.entries()]
-          .map(([peer, { code, message }]) => {
-            const tag = `${peer.slice(-8)}→${code}`;
-            return message ? `${tag} (${message})` : tag;
-          })
-          .join('; ');
-        detail = ` Declines: ${formatted}.`;
-      }
       throw new Error(
         `storage_ack_insufficient: got ${collected.length}/${REQUIRED_ACKS} valid ACKs. ` +
-        `Tried ${corePeers.length} core peers.${detail}`,
+        `Tried ${corePeers.length} core peers.${formatDeclineDetail()}`,
       );
     }
 

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -3,6 +3,7 @@ import {
   encodePublishIntent,
   decodeStorageACK,
   computePublishACKDigest,
+  isStorageACKDecline,
   type PublishIntentMsg,
   type StorageACKMsg,
 } from '@origintrail-official/dkg-core';
@@ -148,12 +149,31 @@ export class ACKCollector {
     const collected: CollectedACK[] = [];
     const seenPeers = new Set<string>();
     const seenIdentityIds = new Set<bigint>();
+    // Per-peer typed declines from new core nodes — see PR#557.
+    // Declines are permanent for THIS request; the publisher records the
+    // reason, skips retries against the declining peer, and surfaces all
+    // collected reasons in the final `storage_ack_insufficient` message
+    // when quorum can't be reached. Old cores that pre-date the typed
+    // wire shape continue to throw / reset and follow the legacy retry
+    // path below — declines are strictly additive.
+    const declines = new Map<string, { code: string; message: string }>();
 
     const requestACK = async (peerId: string): Promise<CollectedACK | null> => {
       for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
         try {
           const response = await this.deps.sendP2P(peerId, PROTOCOL_STORAGE_ACK, intentBytes);
           const ack: StorageACKMsg = decodeStorageACK(response);
+
+          if (isStorageACKDecline(ack)) {
+            const code = ack.declineCode ?? 'UNKNOWN';
+            const declineMessage = ack.declineMessage ?? '';
+            declines.set(peerId, { code, message: declineMessage });
+            log(
+              `[ACKCollector] Decline from ${peerId.slice(-8)}: ${code}` +
+              (declineMessage ? ` — ${declineMessage}` : ''),
+            );
+            return null;
+          }
 
           const recoveredAddress = this.recoverACKSigner(ack, ackDigest);
           if (!recoveredAddress) {
@@ -227,9 +247,19 @@ export class ACKCollector {
     ]);
 
     if (collected.length < REQUIRED_ACKS) {
+      let detail = '';
+      if (declines.size > 0) {
+        const formatted = [...declines.entries()]
+          .map(([peer, { code, message }]) => {
+            const tag = `${peer.slice(-8)}→${code}`;
+            return message ? `${tag} (${message})` : tag;
+          })
+          .join('; ');
+        detail = ` Declines: ${formatted}.`;
+      }
       throw new Error(
         `storage_ack_insufficient: got ${collected.length}/${REQUIRED_ACKS} valid ACKs. ` +
-        `Tried ${corePeers.length} core peers.`,
+        `Tried ${corePeers.length} core peers.${detail}`,
       );
     }
 

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -33,6 +33,14 @@ export interface ACKCollectionResult {
 const DEFAULT_REQUIRED_ACKS = 3;
 const ACK_TIMEOUT_MS = 120_000;
 const MAX_RETRIES = 3;
+const MAX_DECLINE_CODE_CHARS = 64;
+const MAX_DECLINE_MESSAGE_CHARS = 240;
+
+function sanitizeDeclineField(value: string, maxChars: number): string {
+  const compacted = value.replace(/[\u0000-\u001f\u007f]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (compacted.length <= maxChars) return compacted;
+  return `${compacted.slice(0, Math.max(0, maxChars - 3))}...`;
+}
 
 /**
  * ACKCollector implements V10 spec §9.0 Phase 3: collecting 3 core node
@@ -177,8 +185,14 @@ export class ACKCollector {
           const ack: StorageACKMsg = decodeStorageACK(response);
 
           if (isStorageACKDecline(ack)) {
-            const code = ack.declineCode ?? 'UNKNOWN';
-            const declineMessage = ack.declineMessage ?? '';
+            const code = sanitizeDeclineField(
+              ack.declineCode ?? 'UNKNOWN',
+              MAX_DECLINE_CODE_CHARS,
+            ) || 'UNKNOWN';
+            const declineMessage = sanitizeDeclineField(
+              ack.declineMessage ?? '',
+              MAX_DECLINE_MESSAGE_CHARS,
+            );
             declines.set(peerId, { code, message: declineMessage });
             log(
               `[ACKCollector] Decline from ${peerId.slice(-8)}: ${code}` +

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -83,10 +83,8 @@ export class StorageACKHandler {
   /**
    * Encode a structured decline response. Used in place of `throw` for
    * the subset of failures that represent "I as a core legitimately
-   * cannot ACK this request right now" — most importantly the
-   * `<contextGraphsServed>` mismatch that GitHub issue #541 stalls on,
-   * and the SWM-side cases that present the same way to the publisher
-   * (data missing, data stale).
+   * cannot ACK this request right now" — currently SWM-side cases
+   * that present as "data missing" or "data stale" to the publisher.
    *
    * The publisher's collector treats declines as **permanent for this
    * request** and surfaces the per-peer reason in the final error if

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -16,6 +16,26 @@ import { ethers } from 'ethers';
 
 type PeerId = { toString(): string };
 
+const MAX_DECLINE_ENTITY_COUNT = 5;
+const MAX_DECLINE_ENTITY_CHARS = 120;
+
+function compactDeclineText(value: string, maxChars: number): string {
+  const compacted = value.replace(/[\u0000-\u001f\u007f]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (compacted.length <= maxChars) return compacted;
+  return `${compacted.slice(0, Math.max(0, maxChars - 3))}...`;
+}
+
+function summarizeDeclineEntities(entities: readonly string[]): string {
+  if (entities.length === 0) return '(none)';
+  const visible = entities
+    .slice(0, MAX_DECLINE_ENTITY_COUNT)
+    .map((entity) => compactDeclineText(entity, MAX_DECLINE_ENTITY_CHARS));
+  const remaining = entities.length - visible.length;
+  return remaining > 0
+    ? `${visible.join(', ')} (+${remaining} more)`
+    : visible.join(', ');
+}
+
 export interface StorageACKHandlerConfig {
   nodeRole: 'core' | 'edge';
   nodeIdentityId: bigint;
@@ -221,7 +241,8 @@ export class StorageACKHandler {
         return this.encodeDecline(
           cgId,
           STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
-          `No data found in SWM graph ${swmGraphUri} for entities: ${intent.rootEntities.join(', ')}`,
+          `No data found in SWM graph ${swmGraphUri} for entities: ` +
+          summarizeDeclineEntities(intent.rootEntities ?? []),
         );
       }
 

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -276,23 +276,26 @@ export class StorageACKHandler {
     // `KnowledgeAssetsV10.sol:379`, so signing an ACK against CG 0 (or a
     // negative id from `BigInt("-1")`, which would die later in the
     // evm-adapter's uint256 encoder) would just produce a signature the
-    // contract rejects downstream. Refuse the PublishIntent here with a
-    // clear error so the publisher sees the failure on the P2P stream.
+    // contract rejects downstream.
+    //
+    // Throw rather than decline: this is a malformed PublishIntent (the
+    // publisher built a request the contract will never accept), not
+    // peer-local state. A typed decline would make the publisher fan
+    // out to every other core looking for a different answer and
+    // report `storage_ack_insufficient` after the full retry budget,
+    // masking the real caller error. The stream reset surfaces the
+    // original message to the caller immediately.
     let contextGraphIdBigInt: bigint;
     try {
       contextGraphIdBigInt = BigInt(cgId);
     } catch {
-      return this.encodeDecline(
-        cgId,
-        STORAGE_ACK_DECLINE_CODES.CG_ID_INVALID,
+      throw new Error(
         `StorageACK: V10 publish requires a numeric on-chain context graph id; ` +
         `got '${cgId}'. Register the CG on-chain via ContextGraphs.createContextGraph first.`,
       );
     }
     if (contextGraphIdBigInt <= 0n) {
-      return this.encodeDecline(
-        cgId,
-        STORAGE_ACK_DECLINE_CODES.CG_ID_INVALID,
+      throw new Error(
         `StorageACK: V10 publish requires a positive on-chain context graph id; ` +
         `got ${contextGraphIdBigInt}. Register the CG on-chain via ContextGraphs.createContextGraph first.`,
       );

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -1,10 +1,11 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
-import type { EventBus } from '@origintrail-official/dkg-core';
+import type { EventBus, StorageACKDeclineCode } from '@origintrail-official/dkg-core';
 import {
   decodePublishIntent,
   encodeStorageACK,
   computePublishACKDigest,
   assertSafeIri,
+  STORAGE_ACK_DECLINE_CODES,
 } from '@origintrail-official/dkg-core';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
@@ -77,6 +78,40 @@ export class StorageACKHandler {
     this.store = store;
     this.config = config;
     this.eventBus = eventBus;
+  }
+
+  /**
+   * Encode a structured decline response. Used in place of `throw` for
+   * the subset of failures that represent "I as a core legitimately
+   * cannot ACK this request right now" — most importantly the
+   * `<contextGraphsServed>` mismatch that GitHub issue #541 stalls on,
+   * and the SWM-side cases that present the same way to the publisher
+   * (data missing, data stale).
+   *
+   * The publisher's collector treats declines as **permanent for this
+   * request** and surfaces the per-peer reason in the final error if
+   * quorum fails. Throwing instead would close the libp2p stream as a
+   * reset, which the publisher only sees as a generic IO error and
+   * retries 3× against the same peer before giving up.
+   *
+   * Old senders never produce these fields and old receivers ignore
+   * them, so adding declines is a strictly additive wire change — see
+   * `packages/core/src/proto/storage-ack.ts` for the schema rationale.
+   */
+  private encodeDecline(
+    cgId: string,
+    code: StorageACKDeclineCode,
+    message: string,
+  ): Uint8Array {
+    return encodeStorageACK({
+      merkleRoot: new Uint8Array(0),
+      coreNodeSignatureR: new Uint8Array(0),
+      coreNodeSignatureVS: new Uint8Array(0),
+      contextGraphId: cgId,
+      nodeIdentityId: 0,
+      declineCode: code,
+      declineMessage: message,
+    });
   }
 
   /**
@@ -175,16 +210,28 @@ export class StorageACKHandler {
         try { await this.store.dropGraph(stagingGraphUri); } catch { /* ignore */ }
       }, 10 * 60 * 1000);
     } else {
-      // Fallback: data should already be in SWM (publishFromSharedMemory path)
+      // Fallback: data should already be in SWM (publishFromSharedMemory path).
+      // Both the "no data" and "data but wrong merkle root" cases below are
+      // reasons this specific core can't ACK this specific request — the
+      // publisher should deselect this peer (no retry against it) and try
+      // another core. Returning a typed decline instead of throwing keeps
+      // the libp2p stream alive so the publisher sees the reason in band
+      // rather than as an opaque stream reset (the #541 failure mode).
       swmQuads = await this.loadSWMQuads(swmGraphUri, intent.rootEntities);
 
       if (swmQuads.length === 0) {
-        throw new Error(`No data found in SWM graph ${swmGraphUri} for entities: ${intent.rootEntities.join(', ')}`);
+        return this.encodeDecline(
+          cgId,
+          STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
+          `No data found in SWM graph ${swmGraphUri} for entities: ${intent.rootEntities.join(', ')}`,
+        );
       }
 
       const recomputedRoot = computeFlatKCRoot(swmQuads, []);
       if (!bytesEqual(recomputedRoot, merkleRoot)) {
-        throw new Error(
+        return this.encodeDecline(
+          cgId,
+          STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM,
           `Merkle root mismatch: publisher=${ethers.hexlify(merkleRoot).slice(0, 18)}..., ` +
           `local=${ethers.hexlify(recomputedRoot).slice(0, 18)}... ` +
           `(${swmQuads.length} triples in SWM)`,
@@ -216,13 +263,17 @@ export class StorageACKHandler {
     try {
       contextGraphIdBigInt = BigInt(cgId);
     } catch {
-      throw new Error(
+      return this.encodeDecline(
+        cgId,
+        STORAGE_ACK_DECLINE_CODES.CG_ID_INVALID,
         `StorageACK: V10 publish requires a numeric on-chain context graph id; ` +
         `got '${cgId}'. Register the CG on-chain via ContextGraphs.createContextGraph first.`,
       );
     }
     if (contextGraphIdBigInt <= 0n) {
-      throw new Error(
+      return this.encodeDecline(
+        cgId,
+        STORAGE_ACK_DECLINE_CODES.CG_ID_INVALID,
         `StorageACK: V10 publish requires a positive on-chain context graph id; ` +
         `got ${contextGraphIdBigInt}. Register the CG on-chain via ContextGraphs.createContextGraph first.`,
       );
@@ -277,7 +328,15 @@ export class StorageACKHandler {
         } catch {
           // Keep the signing refusal deterministic even if protocol cleanup fails.
         }
-        throw new Error('StorageACK signer is not confirmed on-chain as an operational wallet');
+        // Decline rather than throw: the operator can rotate / re-register
+        // a key without restarting publishers, and the publisher should
+        // deselect this core for THIS request and move on rather than
+        // retry-and-time-out against a known-rejecting signer.
+        return this.encodeDecline(
+          cgId,
+          STORAGE_ACK_DECLINE_CODES.SIGNER_NOT_REGISTERED,
+          'StorageACK signer is not confirmed on-chain as an operational wallet',
+        );
       }
     }
 

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../src/merkle.js';
 import {
   encodePublishIntent, decodeStorageACK, computePublishACKDigest,
+  isStorageACKDecline, STORAGE_ACK_DECLINE_CODES,
 } from '@origintrail-official/dkg-core';
 import { TypedEventBus } from '@origintrail-official/dkg-core';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
@@ -111,7 +112,11 @@ describe('StorageACKHandler', () => {
     expect(recovered.toLowerCase()).toBe(coreWallet.address.toLowerCase());
   });
 
-  it('refuses to sign when the signer is no longer confirmed registered', async () => {
+  it('declines (SIGNER_NOT_REGISTERED) when the signer is no longer confirmed registered', async () => {
+    // PR #557: this used to throw, which the publisher saw as a libp2p
+    // stream reset; now the handler returns a typed decline so the
+    // collector can record the reason and skip retries against this
+    // peer.
     const handler = await createHandler(swmQuads, {
       isSignerRegistered: async () => false,
     });
@@ -128,9 +133,11 @@ describe('StorageACKHandler', () => {
       merkleLeafCount: swmMerkleLeafCount,
     });
 
-    await expect(handler.handler(intent, fakePeerId)).rejects.toThrow(
-      'StorageACK signer is not confirmed on-chain as an operational wallet',
-    );
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.SIGNER_NOT_REGISTERED);
+    expect(decoded.declineMessage).toContain('not confirmed on-chain');
   });
 
   it('refuses to sign when signer registration lookup fails', async () => {
@@ -161,7 +168,11 @@ describe('StorageACKHandler', () => {
     expect(unregistered).not.toHaveBeenCalled();
   });
 
-  it('rejects when SWM has no data', async () => {
+  it('declines (NO_DATA_IN_SWM) when SWM has no data', async () => {
+    // PR #557: this is the exact #541 path. Used to throw → stream reset
+    // → publisher retried 3× → quorum failed → on-chain
+    // MinSignaturesRequirementNotMet. Now decline → publisher records
+    // the reason and surfaces it in the final error.
     const handler = await createHandler([]);
     const intent = encodePublishIntent({
       merkleRoot,
@@ -173,11 +184,15 @@ describe('StorageACKHandler', () => {
       rootEntities: ['urn:entity:1'],
     });
 
-    await expect(handler.handler(intent, fakePeerId))
-      .rejects.toThrow('No data found in SWM');
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM);
+    expect(decoded.declineMessage).toContain('No data found in SWM');
+    expect(decoded.declineMessage).toContain('urn:entity:1');
   });
 
-  it('rejects when merkle root does not match', async () => {
+  it('declines (MERKLE_MISMATCH_IN_SWM) when SWM data does not match the publisher merkle root', async () => {
     const differentQuads = [makeQuad('urn:other', 'urn:p', 'urn:val')];
     const handler = await createHandler(differentQuads);
 
@@ -191,8 +206,11 @@ describe('StorageACKHandler', () => {
       rootEntities: [],
     });
 
-    await expect(handler.handler(intent, fakePeerId))
-      .rejects.toThrow('Merkle root mismatch');
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM);
+    expect(decoded.declineMessage).toContain('Merkle root mismatch');
   });
 
   it('rejects non-core node role', async () => {

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -469,7 +469,16 @@ describe('ACKCollector retry behavior', () => {
     expect(peerIds.has('peer-1')).toBe(false);
   });
 
-  it('timeout after ACK_TIMEOUT_MS produces storage_ack_timeout error', async () => {
+  it('fails fast with storage_ack_insufficient when transport errors exhaust enough peers (no waiting for ACK_TIMEOUT_MS)', async () => {
+    // After the fast-fail change for PR#559, the collector aborts as
+    // soon as the still-pending peer pool can no longer reach
+    // REQUIRED_ACKS — even if the failures are transport errors that
+    // burn MAX_RETRIES per peer rather than typed declines. With 3
+    // peers and need-3, the first peer exhausting its retries already
+    // makes quorum unreachable, so the collector rejects immediately
+    // (well below ACK_TIMEOUT_MS) and the per-peer retry budget is
+    // capped at MAX_RETRIES (verified by the dedicated retry test
+    // earlier in this file).
     const sendP2P = tracked(async () => { throw new Error('connection refused'); });
     const deps: ACKCollectorDeps = {
       gossipPublish: noop(),
@@ -479,12 +488,21 @@ describe('ACKCollector retry behavior', () => {
     };
     const collector = new ACKCollector(deps);
 
+    const start = Date.now();
     const err = await collector.collect(buildCollectParams()).catch((e: Error) => e);
+    const elapsed = Date.now() - start;
+
     expect(err).toBeInstanceOf(Error);
-    expect(err.message).toMatch(/storage_ack_(insufficient|timeout)/);
+    expect(err.message).toContain('storage_ack_insufficient');
+    expect(err.message).not.toContain('storage_ack_timeout');
+    expect(err.message).toContain('quorum no longer reachable');
     expect(err.message).toMatch(/0\/3/);
     expect(sendP2P.calls.length).toBeGreaterThan(0);
-    expect(sendP2P.calls).toHaveLength(9);
+    // Per-peer retry budget is bounded by MAX_RETRIES (3), so total
+    // calls across 3 peers can never exceed 9 even without fast-fail.
+    expect(sendP2P.calls.length).toBeLessThanOrEqual(9);
+    // Fast-fail must beat ACK_TIMEOUT_MS by a wide margin.
+    expect(elapsed).toBeLessThan(10_000);
   });
 });
 
@@ -1166,5 +1184,66 @@ describe('ACKCollector typed declines (#541)', () => {
     }
     expect(captured).toContain('NO_DATA_IN_SWM');
     expect(captured).not.toContain('()');
+  });
+
+  it('fails fast with storage_ack_insufficient when declines + a hung peer make quorum impossible', async () => {
+    // Codex Review on PR#559: in the mixed case where some peers
+    // decline and another hangs, the collector previously waited the
+    // full ACK_TIMEOUT_MS and emitted `storage_ack_timeout` — the new
+    // per-peer decline detail never surfaced. The fast-fail path
+    // should detect the impossible quorum the moment the second
+    // decline lands and reject right away with the decline detail.
+    const hung: string[] = [];
+    const sendP2P = async (peerId: string): Promise<Uint8Array> => {
+      if (peerId === 'peer-0' || peerId === 'peer-1') {
+        return encodeStorageACK({
+          merkleRoot: new Uint8Array(0),
+          coreNodeSignatureR: new Uint8Array(0),
+          coreNodeSignatureVS: new Uint8Array(0),
+          contextGraphId: testCGIdStr,
+          nodeIdentityId: 0,
+          declineCode: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
+          declineMessage: peerId === 'peer-0'
+            ? 'no swm data for repnet-v2-official'
+            : 'no swm data for repnet-v2-official (replica missing)',
+        });
+      }
+      // peer-2 hangs forever; without fast-fail this would force the
+      // collector to wait out the full ACK_TIMEOUT_MS.
+      hung.push(peerId);
+      return new Promise<Uint8Array>(() => {});
+    };
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: sendP2P as any,
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: noop(),
+    };
+    const collector = new ACKCollector(deps);
+
+    const start = Date.now();
+    let captured: string | undefined;
+    try {
+      await collector.collect(buildCollectParams({ requiredACKs: 3 }));
+    } catch (err) {
+      captured = err instanceof Error ? err.message : String(err);
+    }
+    const elapsed = Date.now() - start;
+
+    expect(captured).toBeDefined();
+    expect(captured).toContain('storage_ack_insufficient');
+    expect(captured).not.toContain('storage_ack_timeout');
+    expect(captured).toContain('quorum no longer reachable');
+    // Decline detail must be present so operators can diagnose the
+    // failure from a single log line.
+    expect(captured).toContain('NO_DATA_IN_SWM');
+    expect(captured).toContain('no swm data for repnet-v2-official');
+    expect(captured).toContain('peer-0'.slice(-8));
+    expect(captured).toContain('peer-1'.slice(-8));
+
+    // Sanity check: peer-2 was actually dialled (so the hang is real)
+    // and the failure landed well below the ACK_TIMEOUT_MS budget.
+    expect(hung).toContain('peer-2');
+    expect(elapsed).toBeLessThan(5_000);
   });
 });

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -1201,6 +1201,61 @@ describe('ACKCollector typed declines (#541)', () => {
     )).toBe(true);
   }, 15_000);
 
+  it('a transient decline followed by terminal transport errors reports the transport reason, not the stale decline', async () => {
+    // Codex review on PR #559: when a peer transient-declines first
+    // and then transport-errors on every retry, the per-peer record
+    // must reflect the terminal outcome. Otherwise the aggregated
+    // `storage_ack_insufficient` diagnostic shadows the real failure
+    // mode (connection reset / timeout) with a stale decline code,
+    // sending operators down the wrong investigation path.
+    const sendCounts = new Map<string, number>();
+    const transportErrorMessage = 'simulated stream reset on retry';
+    const sendP2P = tracked(async (peerId: string) => {
+      const calls = (sendCounts.get(peerId) ?? 0) + 1;
+      sendCounts.set(peerId, calls);
+      if (peerId === 'peer-0') {
+        if (calls === 1) {
+          return encodeStorageACK({
+            merkleRoot: new Uint8Array(0),
+            coreNodeSignatureR: new Uint8Array(0),
+            coreNodeSignatureVS: new Uint8Array(0),
+            contextGraphId: testCGIdStr,
+            nodeIdentityId: 0,
+            declineCode: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
+            declineMessage: 'replication lagging (stale on transport tail)',
+          });
+        }
+        throw new Error(transportErrorMessage);
+      }
+      throw new Error('no other peers configured');
+    });
+
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: sendP2P as any,
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: noop(),
+    };
+    const collector = new ACKCollector(deps);
+
+    let captured: string | undefined;
+    try {
+      await collector.collect(buildCollectParams({ requiredACKs: 3 }));
+    } catch (err) {
+      captured = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(captured).toBeDefined();
+    expect(captured).toContain('storage_ack_insufficient');
+    expect(captured).toContain('peer-0'.slice(-8));
+    expect(captured).toContain('TRANSPORT_ERROR');
+    expect(captured).toContain(transportErrorMessage);
+    expect(captured).not.toContain('NO_DATA_IN_SWM');
+    expect(captured).not.toContain('replication lagging (stale on transport tail)');
+
+    expect(sendCounts.get('peer-0')).toBe(3);
+  }, 15_000);
+
   it('a transient decline that resolves to a valid ACK on retry contributes to quorum', async () => {
     // Models the gossip-replication-catching-up case: peer's first
     // call returns NO_DATA_IN_SWM, the retry returns a real ACK. The

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -688,7 +688,14 @@ describe('StorageACKHandler inline verification', () => {
     expect(store.query.calls.length).toBeGreaterThan(0);
   });
 
-  it('declines (CG_ID_INVALID) when intent contextGraphId is non-numeric', async () => {
+  // Non-numeric / non-positive `contextGraphId` is a malformed PublishIntent
+  // (the contract will reject it with ZeroContextGraphId / will never accept
+  // it), not a peer-local state. Codex review on PR #559 pointed out that
+  // returning a typed decline here would make the publisher fan out to every
+  // other core looking for a different answer and eventually report
+  // `storage_ack_insufficient` — masking the real caller error. The handler
+  // throws so the libp2p stream surfaces the original message immediately.
+  it('throws when intent contextGraphId is non-numeric', async () => {
     const store = createRecordingStore(testQuads);
     const handler = new StorageACKHandler(store, createConfig(), makeEventBus() as any);
 
@@ -704,15 +711,12 @@ describe('StorageACKHandler inline verification', () => {
       stagingQuads: new TextEncoder().encode(quadsToNQuads(testQuads)),
     });
 
-    const response = await handler.handler(intent, fakePeerId);
-    const decoded = decodeStorageACK(response);
-    expect(isStorageACKDecline(decoded)).toBe(true);
-    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.CG_ID_INVALID);
-    expect(decoded.declineMessage).toContain('numeric on-chain context graph id');
-    expect(decoded.contextGraphId).toBe('not-a-number');
+    await expect(handler.handler(intent, fakePeerId)).rejects.toThrow(
+      /numeric on-chain context graph id/,
+    );
   });
 
-  it('declines (CG_ID_INVALID) when intent contextGraphId is "0"', async () => {
+  it('throws when intent contextGraphId is "0"', async () => {
     const store = createRecordingStore(testQuads);
     const handler = new StorageACKHandler(store, createConfig(), makeEventBus() as any);
 
@@ -728,11 +732,9 @@ describe('StorageACKHandler inline verification', () => {
       stagingQuads: new TextEncoder().encode(quadsToNQuads(testQuads)),
     });
 
-    const response = await handler.handler(intent, fakePeerId);
-    const decoded = decodeStorageACK(response);
-    expect(isStorageACKDecline(decoded)).toBe(true);
-    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.CG_ID_INVALID);
-    expect(decoded.declineMessage).toContain('positive on-chain context graph id');
+    await expect(handler.handler(intent, fakePeerId)).rejects.toThrow(
+      /positive on-chain context graph id/,
+    );
   });
 
   it('declines (SIGNER_NOT_REGISTERED) when isSignerRegistered returns false', async () => {
@@ -1069,8 +1071,13 @@ describe('StorageACKHandler signature format', () => {
 // instead of throwing into the libp2p stream. The collector must:
 //
 //  - record the decline reason per-peer
-//  - NOT retry against a declining peer (decline is permanent for the
-//    request)
+//  - distinguish TRANSIENT declines (NO_DATA_IN_SWM / MERKLE_MISMATCH_IN_SWM
+//    — SWM replication still catching up via gossip) from PERMANENT
+//    ones (e.g. SIGNER_NOT_REGISTERED — operator rotated the key):
+//      * transient → retry the same peer through normal backoff;
+//        a peer that would have ACKed seconds later still counts.
+//      * permanent → return null immediately; the peer is deselected
+//        for this request and the publisher fans out to others.
 //  - still reach quorum if other peers ACK
 //  - on quorum failure, surface every per-peer decline reason in the
 //    `storage_ack_insufficient` error so operators can diagnose
@@ -1102,13 +1109,18 @@ describe('ACKCollector typed declines (#541)', () => {
     };
   }
 
-  it('quorum still reached when some peers decline; declining peers are NOT retried', async () => {
+  it('quorum still reached when some peers decline permanently; permanent-declining peers are NOT retried', async () => {
+    // Permanent declines (operator rotated the signer off-chain) should
+    // never cause a retry — the publisher deselects the peer for this
+    // request the moment the decline lands. SIGNER_NOT_REGISTERED is the
+    // canonical permanent code; NO_DATA_IN_SWM / MERKLE_MISMATCH_IN_SWM
+    // are transient and exercised in the next test.
     const sendCounts = new Map<string, number>();
     const sendP2P = tracked(async (peerId: string) => {
       sendCounts.set(peerId, (sendCounts.get(peerId) ?? 0) + 1);
       const inner = buildSendP2PWithDeclines({
-        'peer-0': { code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM, message: 'no swm data for repnet-v2-official' },
-        'peer-3': { code: STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM, message: 'stale data' },
+        'peer-0': { code: STORAGE_ACK_DECLINE_CODES.SIGNER_NOT_REGISTERED, message: 'key rotated' },
+        'peer-3': { code: STORAGE_ACK_DECLINE_CODES.SIGNER_NOT_REGISTERED, message: 'key removed' },
       });
       return inner(peerId);
     });
@@ -1134,13 +1146,102 @@ describe('ACKCollector typed declines (#541)', () => {
 
     expect(log.calls.some(
       (c: unknown[]) => (c[0] as string).includes('Decline from peer-0')
-        && (c[0] as string).includes('NO_DATA_IN_SWM'),
+        && (c[0] as string).includes('SIGNER_NOT_REGISTERED'),
     )).toBe(true);
     expect(log.calls.some(
       (c: unknown[]) => (c[0] as string).includes('Decline from peer-3')
-        && (c[0] as string).includes('MERKLE_MISMATCH_IN_SWM'),
+        && (c[0] as string).includes('SIGNER_NOT_REGISTERED'),
     )).toBe(true);
   });
+
+  it('transient declines (NO_DATA_IN_SWM) are retried against the same peer up to MAX_RETRIES', async () => {
+    // Codex review on PR #559: treating NO_DATA_IN_SWM as permanent
+    // shrinks the quorum pool the moment a core's SWM trails the
+    // publish by even one gossip cycle. The fix is to retry transient
+    // declines through the normal backoff so a peer whose replication
+    // catches up seconds later still contributes to quorum.
+    //
+    // Setup: 3 peers, all must ACK (requiredACKs=3). peer-0 declines
+    // transiently on every attempt; peer-1 and peer-2 ACK. Quorum
+    // therefore cannot complete via shortcut — the collector has no
+    // reason to bail on peer-0's retries and we can observe the
+    // full retry budget being spent against the declining peer.
+    const sendCounts = new Map<string, number>();
+    const sendP2P = tracked(async (peerId: string) => {
+      sendCounts.set(peerId, (sendCounts.get(peerId) ?? 0) + 1);
+      const inner = buildSendP2PWithDeclines({
+        'peer-0': { code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM, message: 'replication lagging' },
+      });
+      return inner(peerId);
+    });
+
+    const log = noop();
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: sendP2P as any,
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log,
+    };
+    const collector = new ACKCollector(deps);
+
+    await expect(
+      collector.collect(buildCollectParams({ requiredACKs: 3 })),
+    ).rejects.toThrow(/storage_ack_insufficient/);
+
+    // peer-0 was dialled 3 times (MAX_RETRIES) before giving up;
+    // every transient decline triggered another attempt. Lower bound
+    // is 2 (1 initial + ≥1 retry) so the test is robust to a future
+    // MAX_RETRIES bump; upper bound pins the current contract.
+    expect(sendCounts.get('peer-0')).toBeGreaterThanOrEqual(2);
+    expect(sendCounts.get('peer-0')).toBeLessThanOrEqual(3);
+
+    expect(log.calls.some(
+      (c: unknown[]) => (c[0] as string).includes('Transient decline from peer-0')
+        && (c[0] as string).includes('NO_DATA_IN_SWM'),
+    )).toBe(true);
+  }, 15_000);
+
+  it('a transient decline that resolves to a valid ACK on retry contributes to quorum', async () => {
+    // Models the gossip-replication-catching-up case: peer's first
+    // call returns NO_DATA_IN_SWM, the retry returns a real ACK. The
+    // peer must end up in `result.acks` and the prior decline reason
+    // must be cleared from the per-peer record so it does not leak
+    // into operator-facing diagnostics for unrelated failures.
+    const sendCounts = new Map<string, number>();
+    const ackBuilder = buildSendP2P();
+    const sendP2P = tracked(async (peerId: string) => {
+      const calls = (sendCounts.get(peerId) ?? 0) + 1;
+      sendCounts.set(peerId, calls);
+      if (peerId === 'peer-0' && calls === 1) {
+        return encodeStorageACK({
+          merkleRoot: new Uint8Array(0),
+          coreNodeSignatureR: new Uint8Array(0),
+          coreNodeSignatureVS: new Uint8Array(0),
+          contextGraphId: testCGIdStr,
+          nodeIdentityId: 0,
+          declineCode: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
+          declineMessage: 'replication lagging',
+        });
+      }
+      return ackBuilder(peerId);
+    });
+
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: sendP2P as any,
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: noop(),
+    };
+    const collector = new ACKCollector(deps);
+
+    const result = await collector.collect(buildCollectParams({ requiredACKs: 3 }));
+    expect(result.acks).toHaveLength(3);
+
+    const ackedPeerIds = new Set(result.acks.map((a) => a.peerId));
+    expect(ackedPeerIds.has('peer-0')).toBe(true);
+
+    expect(sendCounts.get('peer-0')).toBe(2);
+  }, 15_000);
 
   it('storage_ack_insufficient error surfaces every per-peer decline reason', async () => {
     const sendP2P = buildSendP2PWithDeclines({
@@ -1172,7 +1273,7 @@ describe('ACKCollector typed declines (#541)', () => {
     expect(captured).toContain('no swm data for repnet-v2-official');
     expect(captured).toContain('peer-0'.slice(-8));
     expect(captured).toContain('peer-2'.slice(-8));
-  });
+  }, 15_000); // transient declines retry through backoff before settling
 
   it('an unknown decline code is logged and skipped (forward-compat with future codes)', async () => {
     const sendP2P = buildSendP2PWithDeclines({
@@ -1219,7 +1320,7 @@ describe('ACKCollector typed declines (#541)', () => {
     }
     expect(captured).toContain('NO_DATA_IN_SWM');
     expect(captured).not.toContain('()');
-  });
+  }, 15_000);
 
   it('sanitizes and truncates peer-controlled decline messages', async () => {
     const untrustedTail = 'x'.repeat(400);
@@ -1248,9 +1349,13 @@ describe('ACKCollector typed declines (#541)', () => {
     } catch (err) {
       captured = err instanceof Error ? err.message : String(err);
     }
+    // Match either the per-retry "Transient decline from peer-0" line
+    // or the final "Decline from peer-0" line, depending on whether
+    // the fast-fail path fires before or after peer-0 exhausts its
+    // retry budget. Both lines apply the same sanitizer.
     const logLine = log.calls
       .map((c: unknown[]) => c[0] as string)
-      .find((line: string) => line.includes('Decline from peer-0'));
+      .find((line: string) => /decline from peer-0/i.test(line));
 
     expect(logLine).toBeDefined();
     expect(logLine).toContain('line one line two');
@@ -1265,7 +1370,7 @@ describe('ACKCollector typed declines (#541)', () => {
     expect(captured).not.toContain('\t');
     expect(captured).not.toContain(untrustedTail);
     expect(captured!.length).toBeLessThan(700);
-  });
+  }, 15_000);
 
   it('fails fast with storage_ack_insufficient when declines + a hung peer make quorum impossible', async () => {
     // Codex Review on PR#559: in the mixed case where some peers
@@ -1324,7 +1429,11 @@ describe('ACKCollector typed declines (#541)', () => {
 
     // Sanity check: peer-2 was actually dialled (so the hang is real)
     // and the failure landed well below the ACK_TIMEOUT_MS budget.
+    // Floor pushed up from the original ~instant decline path now that
+    // NO_DATA_IN_SWM is a TRANSIENT decline that retries through the
+    // 1s + 2s transport backoff before settling — the fast-fail still
+    // beats the 120s ACK_TIMEOUT_MS budget by two orders of magnitude.
     expect(hung).toContain('peer-2');
-    expect(elapsed).toBeLessThan(5_000);
-  });
+    expect(elapsed).toBeLessThan(15_000);
+  }, 30_000);
 });

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -1141,7 +1141,7 @@ describe('ACKCollector typed declines (#541)', () => {
 
   it('an unknown decline code is logged and skipped (forward-compat with future codes)', async () => {
     const sendP2P = buildSendP2PWithDeclines({
-      'peer-0': { code: 'CG_NOT_HOSTED_FUTURE_VARIANT', message: 'reserved for follow-up' },
+      'peer-0': { code: 'FUTURE_DECLINE_CODE', message: 'reserved for follow-up' },
     });
     const log = noop();
     const deps: ACKCollectorDeps = {
@@ -1158,7 +1158,7 @@ describe('ACKCollector typed declines (#541)', () => {
 
     expect(log.calls.some(
       (c: unknown[]) => (c[0] as string).includes('Decline from peer-0')
-        && (c[0] as string).includes('CG_NOT_HOSTED_FUTURE_VARIANT'),
+        && (c[0] as string).includes('FUTURE_DECLINE_CODE'),
     )).toBe(true);
   });
 

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -5,7 +5,7 @@ import {
   computeFlatKCRootV10 as computeFlatKCRoot,
   computeFlatKCMerkleLeafCountV10,
 } from '../src/merkle.js';
-import { encodeStorageACK, computePublishACKDigest, encodePublishIntent, decodeStorageACK } from '@origintrail-official/dkg-core';
+import { encodeStorageACK, computePublishACKDigest, encodePublishIntent, decodeStorageACK, STORAGE_ACK_DECLINE_CODES, isStorageACKDecline } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 import { OxigraphStore, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
 
@@ -581,7 +581,12 @@ describe('StorageACKHandler inline verification', () => {
     expect(ack.contextGraphId).toBe(testCGIdStr);
   });
 
-  it('SWM fallback: rejects when no data in SWM graph', async () => {
+  it('SWM fallback: declines (NO_DATA_IN_SWM) when no data in SWM graph', async () => {
+    // Pre-decline this would `throw`, which the publisher saw as a libp2p
+    // stream reset (the GitHub #541 failure mode). Now the handler returns
+    // a typed decline so the publisher's collector can record the reason
+    // and surface it in the final error without retrying against this
+    // peer or timing out the stream.
     const store = createRecordingStore([]);
     const handler = new StorageACKHandler(store, createConfig(), makeEventBus() as any);
 
@@ -596,12 +601,17 @@ describe('StorageACKHandler inline verification', () => {
       rootEntities: ['urn:a'],
     });
 
-    await expect(handler.handler(intent, fakePeerId))
-      .rejects.toThrow('No data found in SWM');
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM);
+    expect(decoded.declineMessage).toContain('No data found in SWM');
+    expect(decoded.declineMessage).toContain('urn:a');
+    expect(decoded.contextGraphId).toBe(testCGIdStr);
     expect(store.query.calls.length).toBeGreaterThan(0);
   });
 
-  it("SWM fallback: rejects when merkle root doesn't match SWM data", async () => {
+  it("SWM fallback: declines (MERKLE_MISMATCH_IN_SWM) when merkle root doesn't match SWM data", async () => {
     const differentQuads = [makeQuad('urn:other', 'urn:p', 'urn:v')];
     const store = createRecordingStore(differentQuads);
     const handler = new StorageACKHandler(store, createConfig(), makeEventBus() as any);
@@ -617,9 +627,113 @@ describe('StorageACKHandler inline verification', () => {
       rootEntities: [],
     });
 
-    await expect(handler.handler(intent, fakePeerId))
-      .rejects.toThrow('Merkle root mismatch');
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM);
+    expect(decoded.declineMessage).toContain('Merkle root mismatch');
     expect(store.query.calls.length).toBeGreaterThan(0);
+  });
+
+  it('declines (CG_ID_INVALID) when intent contextGraphId is non-numeric', async () => {
+    const store = createRecordingStore(testQuads);
+    const handler = new StorageACKHandler(store, createConfig(), makeEventBus() as any);
+
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId: 'not-a-number',
+      publisherPeerId: 'pub-0',
+      publicByteSize: 300,
+      isPrivate: false,
+      kaCount: 2,
+      merkleLeafCount: testMerkleLeafCount,
+      rootEntities: [],
+      stagingQuads: new TextEncoder().encode(quadsToNQuads(testQuads)),
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.CG_ID_INVALID);
+    expect(decoded.declineMessage).toContain('numeric on-chain context graph id');
+    expect(decoded.contextGraphId).toBe('not-a-number');
+  });
+
+  it('declines (CG_ID_INVALID) when intent contextGraphId is "0"', async () => {
+    const store = createRecordingStore(testQuads);
+    const handler = new StorageACKHandler(store, createConfig(), makeEventBus() as any);
+
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId: '0',
+      publisherPeerId: 'pub-0',
+      publicByteSize: 300,
+      isPrivate: false,
+      kaCount: 2,
+      merkleLeafCount: testMerkleLeafCount,
+      rootEntities: [],
+      stagingQuads: new TextEncoder().encode(quadsToNQuads(testQuads)),
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.CG_ID_INVALID);
+    expect(decoded.declineMessage).toContain('positive on-chain context graph id');
+  });
+
+  it('declines (SIGNER_NOT_REGISTERED) when isSignerRegistered returns false', async () => {
+    const store = createRecordingStore(testQuads);
+    const onUnregistered = tracked(() => {});
+    const handler = new StorageACKHandler(
+      store,
+      createConfig({
+        isSignerRegistered: async () => false,
+        onSignerUnregistered: onUnregistered,
+      }),
+      makeEventBus() as any,
+    );
+
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId: testCGIdStr,
+      publisherPeerId: 'pub-0',
+      publicByteSize: 300,
+      isPrivate: false,
+      kaCount: 2,
+      merkleLeafCount: testMerkleLeafCount,
+      rootEntities: [],
+      stagingQuads: new TextEncoder().encode(quadsToNQuads(testQuads)),
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.SIGNER_NOT_REGISTERED);
+    expect(onUnregistered.calls).toHaveLength(1);
+  });
+
+  it('still throws (no decline) when stagingQuads merkle root mismatches — true publisher protocol error', async () => {
+    // Inline-staging mismatch is a publisher-side bug (not a network state
+    // mismatch), so the connection-level reset path is still appropriate
+    // — keep the legacy throw to match the existing protocol semantics.
+    const store = createRecordingStore([]);
+    const handler = new StorageACKHandler(store, createConfig(), makeEventBus() as any);
+    const wrongPayload = [makeQuad('urn:wrong', 'urn:p', 'urn:v')];
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId: testCGIdStr,
+      publisherPeerId: 'pub-0',
+      publicByteSize: 300,
+      isPrivate: false,
+      kaCount: 1,
+      merkleLeafCount: testMerkleLeafCount,
+      rootEntities: [],
+      stagingQuads: new TextEncoder().encode(quadsToNQuads(wrongPayload)),
+    });
+
+    await expect(handler.handler(intent, fakePeerId))
+      .rejects.toThrow('Merkle root mismatch (inline quads)');
   });
 });
 
@@ -893,5 +1007,164 @@ describe('StorageACKHandler signature format', () => {
       ? BigInt(ack.nodeIdentityId)
       : BigInt(ack.nodeIdentityId.low) | (BigInt(ack.nodeIdentityId.high) << 32n);
     expect(identityId).toBe(coreIdentityId);
+  });
+});
+
+// ── ACKCollector typed declines (PR2 / GitHub issue #541) ────────────────
+//
+// New cores can now respond with a typed decline (e.g. NO_DATA_IN_SWM)
+// instead of throwing into the libp2p stream. The collector must:
+//
+//  - record the decline reason per-peer
+//  - NOT retry against a declining peer (decline is permanent for the
+//    request)
+//  - still reach quorum if other peers ACK
+//  - on quorum failure, surface every per-peer decline reason in the
+//    `storage_ack_insufficient` error so operators can diagnose
+//    hosting / replication issues from a single log line
+//
+// Old cores that still throw / reset the stream continue to follow the
+// legacy retry path (see "ACKCollector retry behavior" above).
+
+describe('ACKCollector typed declines (#541)', () => {
+  /** Build a sendP2P that returns a decline for declinePeerIds and ACK otherwise. */
+  function buildSendP2PWithDeclines(
+    declinePeerIds: Record<string, { code: string; message: string }>,
+    ackBuilder: (peerId: string) => Promise<Uint8Array> = buildSendP2P(),
+  ): (peerId: string) => Promise<Uint8Array> {
+    return async (peerId: string) => {
+      const decline = declinePeerIds[peerId];
+      if (decline) {
+        return encodeStorageACK({
+          merkleRoot: new Uint8Array(0),
+          coreNodeSignatureR: new Uint8Array(0),
+          coreNodeSignatureVS: new Uint8Array(0),
+          contextGraphId: testCGIdStr,
+          nodeIdentityId: 0,
+          declineCode: decline.code,
+          declineMessage: decline.message,
+        });
+      }
+      return ackBuilder(peerId);
+    };
+  }
+
+  it('quorum still reached when some peers decline; declining peers are NOT retried', async () => {
+    const sendCounts = new Map<string, number>();
+    const sendP2P = tracked(async (peerId: string) => {
+      sendCounts.set(peerId, (sendCounts.get(peerId) ?? 0) + 1);
+      const inner = buildSendP2PWithDeclines({
+        'peer-0': { code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM, message: 'no swm data for repnet-v2-official' },
+        'peer-3': { code: STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM, message: 'stale data' },
+      });
+      return inner(peerId);
+    });
+
+    const log = noop();
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: sendP2P as any,
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2', 'peer-3', 'peer-4'],
+      log,
+    };
+    const collector = new ACKCollector(deps);
+
+    const result = await collector.collect(buildCollectParams({ requiredACKs: 3 }));
+    expect(result.acks).toHaveLength(3);
+
+    const ackedPeerIds = new Set(result.acks.map((a) => a.peerId));
+    expect(ackedPeerIds.has('peer-0')).toBe(false);
+    expect(ackedPeerIds.has('peer-3')).toBe(false);
+
+    expect(sendCounts.get('peer-0')).toBe(1);
+    expect(sendCounts.get('peer-3')).toBe(1);
+
+    expect(log.calls.some(
+      (c: unknown[]) => (c[0] as string).includes('Decline from peer-0')
+        && (c[0] as string).includes('NO_DATA_IN_SWM'),
+    )).toBe(true);
+    expect(log.calls.some(
+      (c: unknown[]) => (c[0] as string).includes('Decline from peer-3')
+        && (c[0] as string).includes('MERKLE_MISMATCH_IN_SWM'),
+    )).toBe(true);
+  });
+
+  it('storage_ack_insufficient error surfaces every per-peer decline reason', async () => {
+    const sendP2P = buildSendP2PWithDeclines({
+      'peer-0': { code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM, message: 'no swm data for repnet-v2-official' },
+      'peer-1': { code: STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM, message: 'have 2 triples; root differs' },
+      'peer-2': { code: STORAGE_ACK_DECLINE_CODES.SIGNER_NOT_REGISTERED, message: 'rotated' },
+      'peer-3': { code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM, message: 'cold cache' },
+    });
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: sendP2P as any,
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2', 'peer-3'],
+      log: noop(),
+    };
+    const collector = new ACKCollector(deps);
+
+    let captured: string | undefined;
+    try {
+      await collector.collect(buildCollectParams({ requiredACKs: 3 }));
+    } catch (err) {
+      captured = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(captured).toBeDefined();
+    expect(captured).toContain('storage_ack_insufficient');
+    expect(captured).toContain('NO_DATA_IN_SWM');
+    expect(captured).toContain('MERKLE_MISMATCH_IN_SWM');
+    expect(captured).toContain('SIGNER_NOT_REGISTERED');
+    expect(captured).toContain('no swm data for repnet-v2-official');
+    expect(captured).toContain('peer-0'.slice(-8));
+    expect(captured).toContain('peer-2'.slice(-8));
+  });
+
+  it('an unknown decline code is logged and skipped (forward-compat with future codes)', async () => {
+    const sendP2P = buildSendP2PWithDeclines({
+      'peer-0': { code: 'CG_NOT_HOSTED_FUTURE_VARIANT', message: 'reserved for follow-up' },
+    });
+    const log = noop();
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: sendP2P as any,
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2', 'peer-3'],
+      log,
+    };
+    const collector = new ACKCollector(deps);
+
+    const result = await collector.collect(buildCollectParams({ requiredACKs: 3 }));
+    expect(result.acks).toHaveLength(3);
+    expect(result.acks.find((a) => a.peerId === 'peer-0')).toBeUndefined();
+
+    expect(log.calls.some(
+      (c: unknown[]) => (c[0] as string).includes('Decline from peer-0')
+        && (c[0] as string).includes('CG_NOT_HOSTED_FUTURE_VARIANT'),
+    )).toBe(true);
+  });
+
+  it('a decline with empty message is still recorded (just code, no parens)', async () => {
+    const sendP2P = buildSendP2PWithDeclines({
+      'peer-0': { code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM, message: '' },
+      'peer-1': { code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM, message: '' },
+      'peer-2': { code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM, message: '' },
+    });
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: sendP2P as any,
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: noop(),
+    };
+    const collector = new ACKCollector(deps);
+
+    let captured: string | undefined;
+    try {
+      await collector.collect(buildCollectParams({ requiredACKs: 3 }));
+    } catch (err) {
+      captured = err instanceof Error ? err.message : String(err);
+    }
+    expect(captured).toContain('NO_DATA_IN_SWM');
+    expect(captured).not.toContain('()');
   });
 });

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -629,6 +629,41 @@ describe('StorageACKHandler inline verification', () => {
     expect(store.query.calls.length).toBeGreaterThan(0);
   });
 
+  it('SWM fallback decline summarizes large root-entity lists', async () => {
+    const store = createRecordingStore([]);
+    const handler = new StorageACKHandler(store, createConfig(), makeEventBus() as any);
+    const rootEntities = [
+      'urn:entity:0',
+      'urn:entity:1',
+      'urn:entity:2',
+      'urn:entity:3',
+      'urn:entity:4',
+      'urn:entity:5',
+      'urn:entity:6',
+      `urn:very-long:${'x'.repeat(200)}`,
+    ];
+
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId: testCGIdStr,
+      publisherPeerId: 'pub-0',
+      publicByteSize: 300,
+      isPrivate: false,
+      kaCount: rootEntities.length,
+      merkleLeafCount: testMerkleLeafCount,
+      rootEntities,
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineMessage).toContain('urn:entity:0');
+    expect(decoded.declineMessage).toContain('urn:entity:4');
+    expect(decoded.declineMessage).toContain('(+3 more)');
+    expect(decoded.declineMessage).not.toContain('urn:entity:5');
+    expect(decoded.declineMessage).not.toContain('x'.repeat(200));
+  });
+
   it("SWM fallback: declines (MERKLE_MISMATCH_IN_SWM) when merkle root doesn't match SWM data", async () => {
     const differentQuads = [makeQuad('urn:other', 'urn:p', 'urn:v')];
     const store = createRecordingStore(differentQuads);
@@ -1184,6 +1219,52 @@ describe('ACKCollector typed declines (#541)', () => {
     }
     expect(captured).toContain('NO_DATA_IN_SWM');
     expect(captured).not.toContain('()');
+  });
+
+  it('sanitizes and truncates peer-controlled decline messages', async () => {
+    const untrustedTail = 'x'.repeat(400);
+    const sendP2P = buildSendP2PWithDeclines({
+      'peer-0': {
+        code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
+        message: `line one\nline two\t${untrustedTail}`,
+      },
+      'peer-1': {
+        code: `${STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM}${'Z'.repeat(100)}`,
+        message: 'short',
+      },
+    });
+    const log = noop();
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: sendP2P as any,
+      getConnectedCorePeers: () => ['peer-0', 'peer-1'],
+      log,
+    };
+    const collector = new ACKCollector(deps);
+
+    let captured: string | undefined;
+    try {
+      await collector.collect(buildCollectParams({ requiredACKs: 2 }));
+    } catch (err) {
+      captured = err instanceof Error ? err.message : String(err);
+    }
+    const logLine = log.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((line: string) => line.includes('Decline from peer-0'));
+
+    expect(logLine).toBeDefined();
+    expect(logLine).toContain('line one line two');
+    expect(logLine).not.toContain('\n');
+    expect(logLine).not.toContain('\t');
+    expect(logLine).not.toContain(untrustedTail);
+    expect(logLine!.length).toBeLessThan(360);
+
+    expect(captured).toContain('storage_ack_insufficient');
+    expect(captured).toContain('line one line two');
+    expect(captured).not.toContain('\n');
+    expect(captured).not.toContain('\t');
+    expect(captured).not.toContain(untrustedTail);
+    expect(captured!.length).toBeLessThan(700);
   });
 
   it('fails fast with storage_ack_insufficient when declines + a hung peer make quorum impossible', async () => {

--- a/packages/publisher/test/v10-protocol-operations.test.ts
+++ b/packages/publisher/test/v10-protocol-operations.test.ts
@@ -17,6 +17,8 @@ import {
   decodePublishIntent,
   encodeStorageACK,
   decodeStorageACK,
+  isStorageACKDecline,
+  STORAGE_ACK_DECLINE_CODES,
 } from '@origintrail-official/dkg-core';
 import { ACKCollector, type ACKCollectorDeps } from '../src/ack-collector.js';
 import { StorageACKHandler, type StorageACKHandlerConfig } from '../src/storage-ack-handler.js';
@@ -966,7 +968,7 @@ describe('V10 StorageACKHandler round-trip', () => {
       .rejects.toThrow('Merkle root mismatch');
   });
 
-  it('handler rejects empty stagingQuads', async () => {
+  it('handler declines (NO_DATA_IN_SWM) on empty stagingQuads + empty SWM', async () => {
     const handler = createHandler(createRecordingStore([]));
     const emptyNTriples = '';
     const stagingBytes = new TextEncoder().encode(emptyNTriples);
@@ -984,15 +986,15 @@ describe('V10 StorageACKHandler round-trip', () => {
     });
 
     // Empty staging bytes have length 0, which takes the SWM fallback
-    // path; with no SWM data either, the handler rejects with "No data
-    // found in SWM" (or an equivalent empty-input rejection). Pin the
-    // rejection vocabulary — a bare `rejects.toThrow()` would also be
-    // satisfied by a setup crash (e.g. protobuf decode failure) which
-    // would hide a real regression where empty input is silently
-    // accepted and an empty commit is broadcast.
-    await expect(handler.handler(intent, fakePeerId)).rejects.toThrow(
-      /no data found in swm|empty|no.*staging|no.*quads/i,
-    );
+    // path; with no SWM data either, PR #557 has the handler return a
+    // typed decline (NO_DATA_IN_SWM) instead of throwing. The decline
+    // code pins the failure mode: a bare positive assertion would also
+    // be satisfied by a default-constructed ACK in the response, which
+    // would let an empty commit slip through.
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM);
   });
 
   it('handler rejects stagingQuads > 4MB', async () => {


### PR DESCRIPTION
## Summary

Today, when a core node legitimately can't ACK a publish — it doesn't host the CG, its SWM is missing or stale, or its operational signer was just rotated — the StorageACK handler `throw`s. libp2p resets the stream, the publisher sees a generic IO error, and the ACK collector retries the same peer 3× with exponential backoff before giving up. The publisher's final error reads as a stream-reset / timeout with no per-peer reason — that's the surface shape behind GitHub issue #541.

This PR introduces a typed-decline path so the receive side can say "I can't ACK this, here's why" in band, and the publisher can deselect that peer without retries and surface the reason to the operator.

Companion to PR #556 (publisher-side hosting filter); independently useful even if #556 doesn't land.

## What's in this PR

### Wire — `packages/core/src/proto/storage-ack.ts`
- Adds two optional string fields to the `StorageACK` proto: `declineCode` (field 6) and `declineMessage` (field 7).
- Strictly additive: old encoders never set them, old decoders ignore them, so cross-version traffic is byte-identical to today.
- New decline codes — `NOT_HOSTED`, `NO_DATA_IN_SWM`, `MERKLE_MISMATCH_IN_SWM`, `SIGNER_NOT_REGISTERED`, `CG_ID_INVALID` — live in `STORAGE_ACK_DECLINE_CODES` and are exported from `@origintrail-official/dkg-core`. Helper `isStorageACKDecline(msg)` codifies the empty-string-vs-undefined check protobufjs uses for unset string fields.

### Receive side — `packages/publisher/src/storage-ack-handler.ts`
Converts four graceful-throw paths to `return encodeDecline(...)`:
- `NO_DATA_IN_SWM` — SWM CONSTRUCT returned no quads (the literal #541 case)
- `MERKLE_MISMATCH_IN_SWM` — core has data, publisher's merkle root doesn't match (decline so the publisher tries another core; inline-staging mismatch keeps `throw` because it's a publisher bug, not a network mismatch)
- `CG_ID_INVALID` — non-numeric or non-positive cgId
- `SIGNER_NOT_REGISTERED` — `isSignerRegistered=false`

True protocol violations keep `throw` (oversize / unparseable staging, kaCount mismatch, leaf-count mismatch, edge-node-tried-to-ACK, identity > 2^64). Those still reset the stream so we don't keep the connection open on bad input.

### Send side — `packages/publisher/src/ack-collector.ts`
- After `decodeStorageACK`, checks `isStorageACKDecline`. If declining: log per-peer reason, **no retry**, return null.
- Tracks per-peer decline reasons; appends a `Declines: peerX→NO_DATA_IN_SWM (no swm data for repnet-v2-official); peerY→MERKLE_MISMATCH_IN_SWM (...)` summary to the final `storage_ack_insufficient` error so operators see exactly why quorum failed from a single log line.

## Backward compatibility

Every cross-version pair stays correct:
- **Old core ↔ new publisher** — old core never emits decline fields → publisher sees a normal ACK or a thrown-and-reset stream (legacy retry path). No regression.
- **New core ↔ old publisher** — new core only emits decline fields for the four converted paths; old publisher's decoder silently ignores them. The signature/merkleRoot fields are zero-length on declines, so the old publisher's `recoverACKSigner` returns null, the ACK is rejected as invalid (same as today's failure mode for these cases), and the collector moves on. No regression.
- **New ↔ new** — full benefit: per-peer decline reasons in the final error, no retries against declining peers.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core build` + `test` — green (new round-trip + forward-compat tests for the proto change)
- [x] `pnpm --filter @origintrail-official/dkg-publisher build` — green
- [x] `pnpm --filter @origintrail-official/dkg-publisher test` — 918 passed / 1 skipped (62 files), all green
- [x] `pnpm --filter @origintrail-official/dkg-agent build` — green
- [x] `pnpm --filter "./packages/cli" build` — green
- [x] **Proto round-trip** (`packages/core/test/v10-proto.test.ts`):
  - decline-only message round-trips through encode/decode with empty signature/merkleRoot
  - old-shape encoded bytes still decode correctly (no spurious decline fields)
  - new-encoder produces identical bytes for the legacy ACK path (deterministic forward compat)
- [x] **Receive side** (`packages/publisher/test/v10-ack-edge-cases.test.ts` + `storage-ack-handler.test.ts` + `v10-protocol-operations.test.ts`):
  - `NO_DATA_IN_SWM` decline returned (was throw)
  - `MERKLE_MISMATCH_IN_SWM` decline returned (was throw)
  - `CG_ID_INVALID` decline returned (two variants: non-numeric, "0")
  - `SIGNER_NOT_REGISTERED` decline returned (was throw); `onSignerUnregistered` callback still fires
  - inline-staging merkle mismatch **still** throws (publisher protocol bug — connection-level reset is appropriate)
- [x] **Send side** (`packages/publisher/test/v10-ack-edge-cases.test.ts`):
  - quorum still reachable when 2 of 5 peers decline (declining peers NOT retried, sendCounts pinned to 1)
  - final `storage_ack_insufficient` error names every per-peer reason with both code and message
  - unknown decline code is logged + skipped (forward compat with future codes)
  - empty `declineMessage` produces clean error formatting (no `()` artefact)

## Related

- Companion PR: #556 (publisher-side hosting filter — also addresses #541)
- GitHub issue: #541

Made with [Cursor](https://cursor.com)