### PR TITLE
feat(messenger): long-lived per-peer stream pool (/dkg/10.0.2/message)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2107,6 +2107,41 @@ export class DKGAgent {
       this.eventBus,
     );
 
+    // Long-lived stream pooling for the chat protocol — opt-in via
+    // env. When `DKG_POOLED_MESSAGES=1`, ProtocolRouter wraps the
+    // chat protocol (`/dkg/10.0.1/message`) with a per-peer pooled
+    // wire variant (`/dkg/10.0.2/message`) that re-uses a single
+    // bidirectional yamux substream + framed multiplexing across
+    // every send to the same peer. Backward-compatible: peers that
+    // don't advertise the pooled wire variant fall back to one-shot
+    // automatically via multistream-select.
+    //
+    // Designed for the May 2026 multi-node soak finding: circuit-
+    // relay-v2 connections were being torn down between every send
+    // (200–365 ms per re-dial), dominating the latency tail (p95
+    // ~8.5s, p99 ~9.6s). Long-lived streams keep both the substream
+    // and the underlying relay connection warm via periodic PING
+    // frames. See packages/core/src/message-stream-pool.ts.
+    if (process.env.DKG_POOLED_MESSAGES === '1') {
+      this.router.enablePooling(PROTOCOL_MESSAGE, {
+        // Conservative keepalive: 10s is fast enough to keep
+        // relay-v2 reservations alive (default reservation TTL is
+        // far longer) and slow enough to add <0.1Hz of background
+        // traffic per peer.
+        keepaliveIntervalMs: 10_000,
+        // 5 min idle close: a peer the local node hasn't messaged in
+        // 5 min probably isn't going to message again soon; closing
+        // the stream releases the relay reservation slot, and the
+        // next send re-opens cheaply.
+        idleTimeoutMs: 5 * 60_000,
+      });
+      this.log.info(
+        ctx,
+        '[messenger] pooled wire variant /dkg/10.0.2/message enabled for ' +
+          'chat protocol (long-lived per-peer streams).',
+      );
+    }
+
     // Wire up pending chat handler
     if (this._pendingChatHandler) {
       this.messageHandler.onChat(this._pendingChatHandler);
@@ -13928,6 +13963,15 @@ export class DKGAgent {
     if (this.randomSamplingHandle) {
       try { await this.randomSamplingHandle.stop(); } catch { /* swallow on shutdown */ }
       this.randomSamplingHandle = null;
+    }
+    // Tear down any pooled wire-protocol overlays before libp2p
+    // stops so per-peer streams close gracefully rather than via
+    // libp2p teardown (which would surface as recoverable resets
+    // and trigger spurious outbox retries on the very last cycle).
+    try {
+      await this.router.closePooling();
+    } catch {
+      // best-effort; libp2p teardown below will close residual streams
     }
     await this.node.stop();
     if (this.syncVerifyWorker) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,10 +53,33 @@ export {
 export {
   ProtocolRouter,
   type ProtocolRouterOptions,
+  type SendOptions,
   DEFAULT_MAX_READ_BYTES,
   DEFAULT_SEND_TIMEOUT_MS,
   isRecoverableSendError,
+  isProtocolUnsupportedError,
 } from './protocol-router.js';
+export {
+  MessageStreamPool,
+  POOLED_MESSAGE_PROTOCOL,
+  DEFAULT_KEEPALIVE_MS,
+  DEFAULT_IDLE_TIMEOUT_MS,
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  PooledStreamResetError,
+  type MessageStreamPoolOptions,
+  type PooledStreamHandler,
+  type PerPeerStats,
+  type PoolNode,
+} from './message-stream-pool.js';
+export {
+  FrameType,
+  encodeFrame,
+  encodeVarint,
+  tryDecodeVarint,
+  decodeFrames,
+  DEFAULT_MAX_FRAME_BYTES,
+  type DecodedFrame,
+} from './message-frame.js';
 export { GossipSubManager, type GossipMessageHandler } from './gossipsub-manager.js';
 export { PeerDiscoveryManager } from './discovery.js';
 export {

--- a/packages/core/src/message-frame.ts
+++ b/packages/core/src/message-frame.ts
@@ -100,22 +100,44 @@ export function encodeVarint(value: number): Uint8Array {
  * `{ value, bytesRead }` on success or `null` if the buffer doesn't
  * yet contain the full varint (caller should buffer more bytes and
  * retry). Throws on overlong / out-of-range encodings.
+ *
+ * Implementation note: accumulates arithmetically rather than via
+ * `<<` shifts because the 5th byte of a varint contributes bits
+ * 28..34 to the result. JavaScript's bitwise operators are 32-bit
+ * signed-coerce, so `(byte & 0x7f) << 28` truncates bits 31..34
+ * and would let a 5-byte varint with payload > 2^32-1 wrap to a
+ * smaller value instead of throwing as the docstring promises.
+ * Codex PR #560 review caught the regression. We use `Math.pow(2,
+ * shift) * payload` to stay in IEEE 754 double space (lossless up
+ * to 2^53) and explicitly reject values >= 2^32 on the 5th byte.
  */
 export function tryDecodeVarint(
   buf: Uint8Array,
   offset = 0,
 ): { value: number; bytesRead: number } | null {
   let value = 0;
-  let shift = 0;
   for (let i = 0; i < MAX_VARINT_BYTES; i++) {
     if (offset + i >= buf.length) return null;
     const byte = buf[offset + i]!;
-    value |= (byte & 0x7f) << shift;
-    if ((byte & 0x80) === 0) {
-      // For JS bitwise ops, values > 2^31 - 1 sign-extend; coerce to unsigned.
-      return { value: value >>> 0, bytesRead: i + 1 };
+    const payload = byte & 0x7f;
+    // On the 5th byte (i === 4) the payload contributes bits 28..34.
+    // Only the low 4 bits (0..15) are representable inside a 32-bit
+    // unsigned integer; anything larger is an out-of-range encoding.
+    if (i === 4 && payload > 0x0f) {
+      throw new RangeError('tryDecodeVarint: varint exceeds 32-bit range');
     }
-    shift += 7;
+    value += payload * Math.pow(2, 7 * i);
+    if ((byte & 0x80) === 0) {
+      // Defensive: ensure we never return a value outside the
+      // documented 0..2^32-1 range, even on legal 5-byte encodings
+      // whose high bits sum to just under the cap. The check above
+      // already covers this in practice, but the bound makes the
+      // post-condition explicit.
+      if (value > 0xffffffff) {
+        throw new RangeError('tryDecodeVarint: varint exceeds 32-bit range');
+      }
+      return { value, bytesRead: i + 1 };
+    }
   }
   throw new RangeError('tryDecodeVarint: varint exceeds 5 bytes');
 }

--- a/packages/core/src/message-frame.ts
+++ b/packages/core/src/message-frame.ts
@@ -1,0 +1,219 @@
+/**
+ * Wire framing for `/dkg/10.0.2/message` and any future long-lived
+ * messenger transport. Each frame is:
+ *
+ *   <uvarint frame-length><frame-body>
+ *
+ * Where `frame-body` is:
+ *
+ *   <uvarint frame-type><payload bytes>
+ *
+ * Frame types:
+ *
+ *   * 0x01 REQUEST  — application payload (sender → receiver)
+ *   * 0x02 RESPONSE — application payload (receiver → sender)
+ *   * 0x03 ERROR    — UTF-8 error string (receiver → sender, terminal for that request)
+ *   * 0x04 PING     — keepalive probe, no payload
+ *   * 0x05 PONG     — keepalive acknowledgement, no payload
+ *
+ * Design constraints:
+ *
+ *   * **Variable-length integer (uvarint)** — Protobuf-compatible
+ *     varint encoding for both `frame-length` and `frame-type`. Lets
+ *     control frames (PING/PONG, type+1 byte length=1) cost 2 bytes
+ *     while keeping the door open for future >127 frame types
+ *     without a wire break.
+ *
+ *   * **No request id at the wire level (yet).** The pool serialises
+ *     requests per stream — at most one request in-flight per
+ *     `(peer, protocol)` pair. The next RESPONSE/ERROR frame the
+ *     reader sees IS the answer to the most recent REQUEST. Adding
+ *     request ids costs ~3 bytes/frame and adds dispatcher
+ *     complexity that the chat-rate workload doesn't need; if a
+ *     future caller pipelines, we can introduce a `0x06 REQUEST_V2`
+ *     frame type with an embedded id without breaking 0x01 readers.
+ *
+ *   * **Bounded frame size.** The decoder rejects any frame whose
+ *     declared length exceeds the configured cap (default 10 MiB,
+ *     matching {@link DEFAULT_MAX_READ_BYTES} in `protocol-router.ts`).
+ *     A malicious or buggy peer cannot pin our memory by claiming a
+ *     huge frame; the limit triggers a stream-level abort.
+ *
+ *   * **Streaming decode.** The decoder is an async generator that
+ *     consumes bytes incrementally from any `AsyncIterable<Uint8Array>`
+ *     source (libp2p `Stream` works directly). It yields each frame
+ *     as soon as the full body has arrived; partial-frame state is
+ *     held in an internal buffer.
+ *
+ * No external dependencies — varint impl is inline (~25 LoC).
+ */
+
+/**
+ * Wire-level frame type discriminator. Values are stable as part of
+ * the `/dkg/10.0.2/*` wire format; never renumber.
+ */
+export enum FrameType {
+  REQUEST = 0x01,
+  RESPONSE = 0x02,
+  ERROR = 0x03,
+  PING = 0x04,
+  PONG = 0x05,
+}
+
+/**
+ * A single decoded wire frame. `payload` is the raw bytes after the
+ * type byte; for ERROR frames it's the UTF-8-encoded error message,
+ * for PING/PONG it's a zero-length view.
+ */
+export interface DecodedFrame {
+  type: FrameType;
+  payload: Uint8Array;
+}
+
+/** Default per-frame max length, matching the protocol-router cap. */
+export const DEFAULT_MAX_FRAME_BYTES = 10 * 1024 * 1024;
+
+/** Maximum bytes a uvarint length prefix may consume (5 bytes covers 0..2^35). */
+const MAX_VARINT_BYTES = 5;
+
+/**
+ * Encode a non-negative integer as a uvarint (LEB128 / Protobuf).
+ * Returns the encoded bytes; throws on negative or >= 2^32 input.
+ * Exported for tests.
+ */
+export function encodeVarint(value: number): Uint8Array {
+  if (!Number.isInteger(value) || value < 0 || value > 0xffffffff) {
+    throw new RangeError(`encodeVarint: out of range (${value})`);
+  }
+  const out: number[] = [];
+  let v = value;
+  while (v >= 0x80) {
+    out.push((v & 0x7f) | 0x80);
+    v >>>= 7;
+  }
+  out.push(v & 0x7f);
+  return new Uint8Array(out);
+}
+
+/**
+ * Try to decode a uvarint from `buf` starting at `offset`. Returns
+ * `{ value, bytesRead }` on success or `null` if the buffer doesn't
+ * yet contain the full varint (caller should buffer more bytes and
+ * retry). Throws on overlong / out-of-range encodings.
+ */
+export function tryDecodeVarint(
+  buf: Uint8Array,
+  offset = 0,
+): { value: number; bytesRead: number } | null {
+  let value = 0;
+  let shift = 0;
+  for (let i = 0; i < MAX_VARINT_BYTES; i++) {
+    if (offset + i >= buf.length) return null;
+    const byte = buf[offset + i]!;
+    value |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) {
+      // For JS bitwise ops, values > 2^31 - 1 sign-extend; coerce to unsigned.
+      return { value: value >>> 0, bytesRead: i + 1 };
+    }
+    shift += 7;
+  }
+  throw new RangeError('tryDecodeVarint: varint exceeds 5 bytes');
+}
+
+/**
+ * Encode a frame as `<uvarint body-length><uvarint frame-type><payload bytes>`.
+ *
+ * The body-length covers both the type varint and the payload, so a
+ * reader can `read N bytes` after the length prefix and recover the
+ * entire frame as one blob — useful when the stream's underlying
+ * `for await` chunks don't align with frame boundaries.
+ */
+export function encodeFrame(type: FrameType, payload: Uint8Array = new Uint8Array(0)): Uint8Array {
+  const typeBytes = encodeVarint(type);
+  const bodyLength = typeBytes.length + payload.length;
+  const lengthBytes = encodeVarint(bodyLength);
+  const out = new Uint8Array(lengthBytes.length + bodyLength);
+  out.set(lengthBytes, 0);
+  out.set(typeBytes, lengthBytes.length);
+  out.set(payload, lengthBytes.length + typeBytes.length);
+  return out;
+}
+
+/**
+ * Streaming frame decoder. Consumes bytes from `source` and yields
+ * each fully-arrived `DecodedFrame`. Stops when the source is
+ * exhausted (graceful close) — a partial frame at EOF is treated as
+ * a protocol error and throws.
+ *
+ * @param source Any async byte stream (libp2p `Stream` works directly).
+ * @param maxFrameBytes Reject frames larger than this. Default 10 MiB.
+ */
+export async function* decodeFrames(
+  source: AsyncIterable<Uint8Array>,
+  maxFrameBytes: number = DEFAULT_MAX_FRAME_BYTES,
+): AsyncGenerator<DecodedFrame, void, void> {
+  let buf = new Uint8Array(0);
+
+  // Read more bytes from the source into `buf`. Returns true when a
+  // new chunk arrived, false on EOF.
+  const sourceIterator = source[Symbol.asyncIterator]();
+
+  async function readMore(): Promise<boolean> {
+    const next = await sourceIterator.next();
+    if (next.done) return false;
+    const chunk = next.value instanceof Uint8Array
+      ? next.value
+      : new Uint8Array((next.value as { subarray: () => Uint8Array }).subarray());
+    if (chunk.length === 0) {
+      // Empty chunk — keep reading. Some libp2p stream impls emit
+      // them at backpressure boundaries.
+      return readMore();
+    }
+    const merged = new Uint8Array(buf.length + chunk.length);
+    merged.set(buf, 0);
+    merged.set(chunk, buf.length);
+    buf = merged;
+    return true;
+  }
+
+  while (true) {
+    let lengthHeader: { value: number; bytesRead: number } | null = null;
+    while (lengthHeader === null) {
+      lengthHeader = tryDecodeVarint(buf, 0);
+      if (lengthHeader !== null) break;
+      const got = await readMore();
+      if (!got) {
+        if (buf.length === 0) return; // clean EOF
+        throw new Error('decodeFrames: stream ended mid-length-prefix');
+      }
+    }
+    const bodyLength = lengthHeader.value;
+    if (bodyLength > maxFrameBytes) {
+      throw new Error(
+        `decodeFrames: frame length ${bodyLength} exceeds cap ${maxFrameBytes}`,
+      );
+    }
+    while (buf.length < lengthHeader.bytesRead + bodyLength) {
+      const got = await readMore();
+      if (!got) {
+        throw new Error('decodeFrames: stream ended mid-frame-body');
+      }
+    }
+    const bodyStart = lengthHeader.bytesRead;
+    const bodyEnd = bodyStart + bodyLength;
+    const typeHeader = tryDecodeVarint(buf, bodyStart);
+    if (typeHeader === null) {
+      throw new Error('decodeFrames: malformed frame (empty body)');
+    }
+    if (typeHeader.bytesRead > bodyLength) {
+      throw new Error('decodeFrames: frame body too short for type prefix');
+    }
+    const payloadStart = bodyStart + typeHeader.bytesRead;
+    const payload = buf.slice(payloadStart, bodyEnd);
+
+    yield { type: typeHeader.value as FrameType, payload };
+
+    // Compact buf: drop everything we just consumed.
+    buf = buf.length === bodyEnd ? new Uint8Array(0) : buf.slice(bodyEnd);
+  }
+}

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -177,6 +177,13 @@ interface PendingRequest {
   signal?: AbortSignal;
   enqueuedAt: number;
   abortListener?: () => void;
+  /**
+   * Per-call response timeout in ms, or `undefined` to use the
+   * pool-wide default. Threaded from `send()`'s `opts.timeoutMs` so
+   * callers asking for a larger budget than the pool default aren't
+   * silently capped at 20s (Codex PR #560 round-2 review).
+   */
+  perRequestTimeoutMs?: number;
 }
 
 interface PerPeerState {
@@ -298,7 +305,7 @@ export class MessageStreamPool {
   send(
     peerIdStr: string,
     payload: Uint8Array,
-    opts: { signal?: AbortSignal } = {},
+    opts: { signal?: AbortSignal; timeoutMs?: number } = {},
   ): Promise<Uint8Array> {
     if (this.closed) {
       return Promise.reject(new PooledStreamResetError('pool closed'));
@@ -311,6 +318,15 @@ export class MessageStreamPool {
         reject,
         signal: opts.signal,
         enqueuedAt: this.clock(),
+        // If the caller supplied a per-call timeout, honor it
+        // regardless of the pool-wide default. Otherwise fall back
+        // to the pool's `requestTimeoutMs` at schedule time. Codex
+        // PR #560 round-2 caught: previously `router.send(...,
+        // { timeoutMs: 60_000 })` was silently capped at 20s.
+        perRequestTimeoutMs:
+          typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0
+            ? opts.timeoutMs
+            : undefined,
       };
       // Track every outstanding request so `close()` can reject any
       // that haven't reached an installed state yet (dial still in
@@ -334,11 +350,31 @@ export class MessageStreamPool {
     // exactly once regardless of which path resolves the request.
     this.wrapTerminal(req);
 
+    // Pre-dial abort fast-path. Codex PR #560 round-2 review caught
+    // this: if the caller's signal is already aborted by the time
+    // dispatchSend runs, we MUST reject before doing any work — not
+    // attempt the dial, not queue the request, not write on the
+    // wire. Otherwise the request silently outlives the caller's
+    // cancel budget.
+    if (req.signal?.aborted) {
+      req.reject(new Error('request aborted'));
+      return;
+    }
+
     let state: PerPeerState;
     try {
       state = await this.getOrOpenPeer(peerIdStr, req.signal);
     } catch (err) {
       req.reject(this.toResetError(err, 'open failed'));
+      return;
+    }
+
+    // Re-check after the await — the signal may have aborted while
+    // `getOrOpenPeer` was resolving the peer + dialing. Without this
+    // second checkpoint, an abort that fires mid-dial gets ignored
+    // and the request still hits the wire. Codex PR #560 round-2.
+    if (req.signal?.aborted) {
+      req.reject(new Error('request aborted'));
       return;
     }
 
@@ -671,7 +707,12 @@ export class MessageStreamPool {
   }
 
   private scheduleRequestTimeout(state: PerPeerState, req: PendingRequest): void {
-    if (this.requestTimeoutMs <= 0) return;
+    // Per-call timeout takes precedence over the pool-wide default;
+    // both 0 and negative disable the timer. Codex PR #560 round-2:
+    // previously the per-call value was silently capped at the
+    // pool's `requestTimeoutMs` (default 20s).
+    const effective = req.perRequestTimeoutMs ?? this.requestTimeoutMs;
+    if (effective <= 0) return;
     const t = setTimeout(() => {
       if (state.inFlight !== req) return;
       // Treat as recoverable so the substrate outbox retries.
@@ -680,7 +721,7 @@ export class MessageStreamPool {
       req.reject(err);
       // Trigger a teardown — a stalled stream is unlikely to recover.
       this.handleReaderEnd(state, err).catch(() => undefined);
-    }, this.requestTimeoutMs);
+    }, effective);
     if (typeof (t as unknown as { unref?: () => void }).unref === 'function') {
       (t as unknown as { unref: () => void }).unref();
     }

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -370,18 +370,44 @@ export class MessageStreamPool {
       return;
     }
 
+    // Race the shared open against this caller's signal. Codex PR
+    // #560 round 4: `getOrOpenPeer` is shared infrastructure that
+    // doesn't observe per-caller cancellation (otherwise one caller's
+    // timeout would abort the dial for everyone). To let an aborting
+    // caller reject IMMEDIATELY without waiting for the dial to
+    // complete, we race the open against an abort-signal-driven
+    // promise. The dial itself continues for the other waiters.
     let state: PerPeerState;
     try {
-      state = await this.getOrOpenPeer(peerIdStr, req.signal);
+      const openPromise = this.getOrOpenPeer(peerIdStr, req.signal);
+      if (req.signal) {
+        const abortPromise = new Promise<never>((_, rej) => {
+          if (req.signal!.aborted) {
+            rej(new Error('request aborted'));
+            return;
+          }
+          const onAbort = (): void => rej(new Error('request aborted'));
+          req.signal!.addEventListener('abort', onAbort, { once: true });
+        });
+        state = await Promise.race([openPromise, abortPromise]);
+      } else {
+        state = await openPromise;
+      }
     } catch (err) {
-      req.reject(this.toResetError(err, 'open failed'));
+      // Caller-abort surfaces here as 'request aborted'; pass through
+      // verbatim. Dial / prime failures surface as the underlying
+      // error wrapped in a PooledStreamResetError.
+      if (err instanceof Error && err.message === 'request aborted') {
+        req.reject(err);
+      } else {
+        req.reject(this.toResetError(err, 'open failed'));
+      }
       return;
     }
 
-    // Re-check after the await — the signal may have aborted while
-    // `getOrOpenPeer` was resolving the peer + dialing. Without this
-    // second checkpoint, an abort that fires mid-dial gets ignored
-    // and the request still hits the wire. Codex PR #560 round-2.
+    // Belt-and-suspenders: re-check after the await — covers the
+    // race where the signal aborts between `Promise.race` resolving
+    // (with the open) and this line running.
     if (req.signal?.aborted) {
       req.reject(new Error('request aborted'));
       return;
@@ -567,8 +593,23 @@ export class MessageStreamPool {
 
   private async getOrOpenPeer(
     peerIdStr: string,
-    signal?: AbortSignal,
+    _signal?: AbortSignal,
   ): Promise<PerPeerState> {
+    // NOTE: `_signal` is intentionally NOT propagated into the
+    // dial. Codex PR #560 round-4 caught that openLocks shares one
+    // in-flight open across every concurrent caller — and the FIRST
+    // caller's signal was the one driving cancellation. If caller A
+    // timed out while caller B was still willing to wait, B's dial
+    // inherited A's abort and failed even though B's budget was
+    // intact.
+    //
+    // Each caller's individual signal is honored by `dispatchSend`'s
+    // post-open abort listener — see round-2 fix. The shared open
+    // itself runs to completion regardless of any one caller, with
+    // the dial's natural transport timeout providing the upper
+    // bound. Callers whose signal aborts while waiting on the
+    // shared open are rejected in `dispatchSend`'s post-await
+    // abort checkpoint.
     const existing = this.peers.get(peerIdStr);
     if (existing && !existing.closed) return existing;
     const pending = this.openLocks.get(peerIdStr);
@@ -595,7 +636,9 @@ export class MessageStreamPool {
       // peerStore so the dial CAN reach a routable address).
       if (this.primePeer) {
         try {
-          await this.primePeer(peerIdStr, { signal });
+          // No caller-bound signal — the shared open is infra,
+          // not per-caller. See top-of-method comment.
+          await this.primePeer(peerIdStr, {});
         } catch {
           // primePeer never gates the dial — the existing
           // identify-cache path may still resolve.
@@ -604,8 +647,23 @@ export class MessageStreamPool {
       const peerId = await this.resolvePeerId(peerIdStr);
       const stream = await this.node.libp2p.dialProtocol(peerId, this.protocolId, {
         runOnLimitedConnection: true,
-        signal,
       });
+      // Race-with-close guard. Codex PR #560 round-4 caught: while
+      // `dialProtocol` was awaiting, `pool.close()` may have run.
+      // `installState` after close would re-create per-peer state
+      // (with timers) AFTER shutdown, leaving a stream alive past
+      // `closePooling()`. Close the just-opened stream instead.
+      if (this.closed) {
+        try {
+          // Use abort here — close() during shutdown is an error
+          // path for the would-be caller, not a graceful peer
+          // teardown.
+          stream.abort(new Error('pool closed during dial'));
+        } catch {
+          // already torn down
+        }
+        throw new PooledStreamResetError('pool closed');
+      }
       return this.installState(peerIdStr, stream);
     })();
 
@@ -614,7 +672,13 @@ export class MessageStreamPool {
       const state = await opening;
       return state;
     } finally {
-      this.openLocks.delete(peerIdStr);
+      // Only delete if we're still the registered open — close()
+      // already cleared the map and a new caller might have
+      // registered a fresh open in the interim. Idempotent delete
+      // is safe regardless.
+      if (this.openLocks.get(peerIdStr) === opening) {
+        this.openLocks.delete(peerIdStr);
+      }
     }
   }
 

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -1,0 +1,828 @@
+/**
+ * Long-lived per-peer stream pool for the `/dkg/10.0.2/message`
+ * substrate transport.
+ *
+ * Problem this fixes
+ * ------------------
+ *
+ * The `/dkg/10.0.1/message` transport opens a fresh request-response
+ * stream per send: dial → multistream-select → write → half-close →
+ * read response → close. On circuit-relay-v2 connections (which are
+ * the majority of our edge↔edge traffic because all edges are NAT-
+ * behind), the underlying connection itself is one-shot: it closes
+ * shortly after the single stream tears down. The next send pays the
+ * full circuit-relay + multistream-select handshake again.
+ *
+ * The May 2026 multi-node soak data (LEX→{MILES,ARX,HERMES} 24h, 4
+ * peers, /dkg/10.0.1/message via circuit-relay-v2) showed:
+ *
+ *   * p50 send-latency: ~900 ms
+ *   * p95: ~8.5 s
+ *   * p99: ~9.6 s
+ *
+ * Daemon-log inspection during the soak showed circuit-relay
+ * connections opening for 200–365 ms and closing immediately after
+ * each send. PR #537's `getConnections` reuse walk worked correctly
+ * but rarely found anything to reuse — the connection was already
+ * torn down by the time the next send fired.
+ *
+ * What this changes
+ * -----------------
+ *
+ * Each `(localNode, peerId)` pair holds at most ONE outbound stream
+ * for `/dkg/10.0.2/message`. The stream stays open across many
+ * request/response cycles via:
+ *
+ *   * **Framed multiplexing.** Every send writes a REQUEST frame
+ *     ({@link FrameType}); the response arrives as a RESPONSE or
+ *     ERROR frame. Requests serialise per stream (one in-flight at
+ *     a time) — additional sends queue behind the current one.
+ *     Pipelining is a future addition; chat-rate traffic (~1
+ *     msg/15s) doesn't need it.
+ *
+ *   * **Keepalive pings.** A periodic PING frame (default 10s)
+ *     keeps both the stream AND the underlying circuit-relay
+ *     connection alive between application messages. The receiver
+ *     echoes PONG; the relay forwards bytes either way, which keeps
+ *     the relay's reservation alive too.
+ *
+ *   * **Idle close.** If a stream sees no activity (no app sends,
+ *     no inbound frames) for `idleTimeoutMs`, the pool closes it
+ *     gracefully. The next send re-opens. This bounds the cost of
+ *     a peer the local node hasn't talked to in a while.
+ *
+ *   * **Reset recovery.** On stream error (transport reset, peer
+ *     closed, abort) the pool rejects every in-flight + queued
+ *     request for that peer with a recoverable error code so the
+ *     substrate's `MessageOutbox` re-enqueues them. The next send
+ *     opens a fresh stream.
+ *
+ * Wire format: see {@link FrameType} and {@link encodeFrame} in
+ * `message-frame.ts`.
+ *
+ * Compatibility
+ * -------------
+ *
+ * Peers without the pool registered will fail multistream-select on
+ * `/dkg/10.0.2/message` and the dialer falls back to
+ * `/dkg/10.0.1/message` (one-shot). The pool advertises only
+ * `/dkg/10.0.2/message` on the wire; cross-version negotiation lives
+ * at the {@link ProtocolRouter} layer, which can be configured to
+ * try the pooled wire protocol first and fall through to one-shot.
+ */
+
+import type { Stream } from '@libp2p/interface';
+import {
+  DEFAULT_MAX_FRAME_BYTES,
+  FrameType,
+  decodeFrames,
+  encodeFrame,
+  type DecodedFrame,
+} from './message-frame.js';
+import type { DKGNode } from './node.js';
+
+/** Protocol id for the pooled, framed transport. */
+export const POOLED_MESSAGE_PROTOCOL = '/dkg/10.0.2/message';
+
+/** Default keepalive ping interval — 10 s. */
+export const DEFAULT_KEEPALIVE_MS = 10_000;
+
+/** Default idle timeout — 5 min of no activity. */
+export const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Default per-request response timeout — matches one-shot path. */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
+
+/**
+ * Subset of {@link DKGNode} we depend on. Defined structurally so
+ * tests can pass a stub without re-implementing the full DKGNode
+ * surface.
+ */
+export interface PoolNode {
+  libp2p: {
+    dialProtocol: (
+      peerId: unknown,
+      protocols: string | string[],
+      options?: { runOnLimitedConnection?: boolean; signal?: AbortSignal },
+    ) => Promise<Stream>;
+    handle: (
+      protocolId: string,
+      handler: (stream: Stream, connection: { remotePeer: { toString: () => string } }) => void,
+      opts?: { runOnLimitedConnection?: boolean },
+    ) => void;
+    unhandle: (protocolId: string) => void;
+  };
+}
+
+/** Application-level handler signature — identical to ProtocolRouter's. */
+export type PooledStreamHandler = (
+  requestData: Uint8Array,
+  peerId: { toString: () => string },
+) => Promise<Uint8Array>;
+
+export interface MessageStreamPoolOptions {
+  /** Wire protocol id. Default {@link POOLED_MESSAGE_PROTOCOL}. */
+  protocolId?: string;
+  /** Per-request timeout. Default {@link DEFAULT_REQUEST_TIMEOUT_MS}. */
+  requestTimeoutMs?: number;
+  /** Keepalive ping interval. Default {@link DEFAULT_KEEPALIVE_MS}. Set 0 to disable. */
+  keepaliveIntervalMs?: number;
+  /** Idle close threshold. Default {@link DEFAULT_IDLE_TIMEOUT_MS}. Set 0 to disable. */
+  idleTimeoutMs?: number;
+  /** Max bytes per frame. Default {@link DEFAULT_MAX_FRAME_BYTES}. */
+  maxFrameBytes?: number;
+  /**
+   * Injectable wall-clock + timers for tests. Production uses
+   * `Date.now` + `setTimeout`/`setInterval`.
+   */
+  clock?: () => number;
+  /**
+   * Inject `peerIdFromString`. Default lazy-imports `@libp2p/peer-id`.
+   * Tests pass a stub so the pool stays decoupled from libp2p
+   * internals.
+   */
+  peerIdFromString?: (s: string) => unknown;
+}
+
+interface PendingRequest {
+  payload: Uint8Array;
+  resolve: (response: Uint8Array) => void;
+  reject: (err: Error) => void;
+  signal?: AbortSignal;
+  enqueuedAt: number;
+  abortListener?: () => void;
+}
+
+interface PerPeerState {
+  peerIdStr: string;
+  stream: Stream;
+  /** The currently-in-flight request (writer wrote, awaiting response frame). */
+  inFlight: PendingRequest | null;
+  /** Sends queued behind the in-flight request, FIFO order. */
+  queue: PendingRequest[];
+  /** Reader loop promise — resolves when the stream's frame source ends. */
+  readerDone: Promise<void>;
+  /** Wall-clock of the most recent inbound or outbound frame. */
+  lastActivityAt: number;
+  /** Keepalive timer; null if disabled. */
+  keepaliveTimer: ReturnType<typeof setInterval> | null;
+  /** Idle close watchdog timer; null if disabled. */
+  idleTimer: ReturnType<typeof setTimeout> | null;
+  /** True after `closePeer` has run; reject any further sends. */
+  closed: boolean;
+  /** Diagnostics. */
+  framesSent: number;
+  framesReceived: number;
+  bytesSent: number;
+  bytesReceived: number;
+}
+
+/** Stats per peer, returned by {@link MessageStreamPool.stats}. */
+export interface PerPeerStats {
+  peerIdStr: string;
+  inFlight: boolean;
+  queueDepth: number;
+  framesSent: number;
+  framesReceived: number;
+  bytesSent: number;
+  bytesReceived: number;
+  ageMs: number;
+  lastActivityAgoMs: number;
+}
+
+/**
+ * Error returned to callers whose request was rejected by stream
+ * teardown / pool close. The message intentionally matches one of
+ * the substrings in `isRecoverableSendError` so the substrate
+ * outbox treats it as retryable.
+ */
+export class PooledStreamResetError extends Error {
+  constructor(detail: string) {
+    super(`pooled stream reset: ${detail}`);
+    this.name = 'PooledStreamResetError';
+  }
+}
+
+/**
+ * Per-peer long-lived stream pool. Construct one per local node;
+ * call {@link send} for outbound requests, {@link registerHandler}
+ * to wire the inbound side.
+ */
+export class MessageStreamPool {
+  private readonly node: PoolNode;
+  private readonly protocolId: string;
+  private readonly requestTimeoutMs: number;
+  private readonly keepaliveIntervalMs: number;
+  private readonly idleTimeoutMs: number;
+  private readonly maxFrameBytes: number;
+  private readonly clock: () => number;
+  private readonly peerIdFromStringOverride?: (s: string) => unknown;
+  private peerIdFromString?: (s: string) => unknown;
+  private inboundHandler: PooledStreamHandler | null = null;
+  private inboundRegistered = false;
+  private closed = false;
+  private readonly peers = new Map<string, PerPeerState>();
+  /**
+   * Records the wall-clock when each per-peer state was created, so
+   * `stats()` can report stream age separately from last-activity.
+   */
+  private readonly peerOpenedAt = new Map<string, number>();
+  /**
+   * Lazy lock so multiple concurrent sends for the same peer don't
+   * race to open a stream. First send-without-state grabs the lock,
+   * others await it.
+   */
+  private readonly openLocks = new Map<string, Promise<PerPeerState>>();
+  /**
+   * Every pending request — both queued and in-flight, across all
+   * peers, plus requests whose dial is still in progress. `close()`
+   * rejects every entry in this set so a caller's promise never
+   * hangs through a pool shutdown.
+   */
+  private readonly outstanding = new Set<PendingRequest>();
+
+  constructor(node: PoolNode, options: MessageStreamPoolOptions = {}) {
+    this.node = node;
+    this.protocolId = options.protocolId ?? POOLED_MESSAGE_PROTOCOL;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.keepaliveIntervalMs = options.keepaliveIntervalMs ?? DEFAULT_KEEPALIVE_MS;
+    this.idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+    this.maxFrameBytes = options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES;
+    this.clock = options.clock ?? (() => Date.now());
+    this.peerIdFromStringOverride = options.peerIdFromString;
+  }
+
+  /** Protocol id this pool advertises on the wire. */
+  get pooledProtocolId(): string {
+    return this.protocolId;
+  }
+
+  /**
+   * Send `payload` to `peerIdStr` over the pooled stream, returning
+   * the application response bytes. Lazily opens the stream on first
+   * call per peer; subsequent calls reuse the held stream.
+   *
+   * Serialised per peer — multiple concurrent calls for the same
+   * peer are dispatched in arrival order, one in-flight at a time.
+   * Throws {@link PooledStreamResetError} when stream teardown
+   * affected this request (recoverable; substrate outbox will retry).
+   */
+  send(
+    peerIdStr: string,
+    payload: Uint8Array,
+    opts: { signal?: AbortSignal } = {},
+  ): Promise<Uint8Array> {
+    if (this.closed) {
+      return Promise.reject(new PooledStreamResetError('pool closed'));
+    }
+
+    return new Promise<Uint8Array>((resolve, reject) => {
+      const req: PendingRequest = {
+        payload,
+        resolve,
+        reject,
+        signal: opts.signal,
+        enqueuedAt: this.clock(),
+      };
+      // Track every outstanding request so `close()` can reject any
+      // that haven't reached an installed state yet (dial still in
+      // flight). Without this, a close() racing a first-contact dial
+      // would leave the caller's promise hung forever.
+      this.outstanding.add(req);
+
+      void this.dispatchSend(peerIdStr, req);
+    });
+  }
+
+  /**
+   * Walk the dial → enqueue → pump path for a single request. Any
+   * error short-circuits to `req.reject`; success leaves the request
+   * pending until the reader resolves it. Always removes the request
+   * from `outstanding` on the first terminal action (resolved or
+   * rejected) — see {@link wrapTerminal}.
+   */
+  private async dispatchSend(peerIdStr: string, req: PendingRequest): Promise<void> {
+    // Wrap resolve/reject so the outstanding-set is cleaned up
+    // exactly once regardless of which path resolves the request.
+    this.wrapTerminal(req);
+
+    let state: PerPeerState;
+    try {
+      state = await this.getOrOpenPeer(peerIdStr, req.signal);
+    } catch (err) {
+      req.reject(this.toResetError(err, 'open failed'));
+      return;
+    }
+
+    if (this.closed || state.closed) {
+      req.reject(new PooledStreamResetError('pool closed'));
+      return;
+    }
+
+    if (req.signal) {
+      const onAbort = (): void => {
+        // Caller cancelled. If still queued, splice out and reject.
+        // If in-flight, leave the request entry in place — the
+        // reader will resolve/reject when the response arrives or
+        // the stream tears down. Don't tear down the stream just
+        // because one caller cancelled.
+        if (state.inFlight === req) {
+          req.reject(new Error('request aborted'));
+          return;
+        }
+        const idx = state.queue.indexOf(req);
+        if (idx !== -1) {
+          state.queue.splice(idx, 1);
+          req.reject(new Error('request aborted'));
+        }
+      };
+      req.signal.addEventListener('abort', onAbort, { once: true });
+      req.abortListener = onAbort;
+    }
+
+    state.queue.push(req);
+    try {
+      await this.maybePumpNext(state);
+    } catch (err) {
+      // maybePumpNext routes write failures through req.reject; this
+      // catch is defensive against unexpected throws (shouldn't fire).
+      req.reject(this.toResetError(err, 'pump failed'));
+    }
+  }
+
+  /**
+   * Replace `req.resolve` / `req.reject` with shims that also remove
+   * the request from {@link outstanding} on first terminal action.
+   * Idempotent — only the first call to resolve OR reject does the
+   * cleanup; subsequent calls are no-ops.
+   */
+  private wrapTerminal(req: PendingRequest): void {
+    const origResolve = req.resolve;
+    const origReject = req.reject;
+    let settled = false;
+    const cleanup = (): void => {
+      if (settled) return;
+      settled = true;
+      this.outstanding.delete(req);
+    };
+    req.resolve = (v) => {
+      cleanup();
+      origResolve(v);
+    };
+    req.reject = (e) => {
+      cleanup();
+      origReject(e);
+    };
+  }
+
+  /**
+   * Register the inbound handler for pooled streams. Called once at
+   * daemon setup; idempotent re-registration overwrites the handler
+   * but does NOT re-register the libp2p handle (which is also
+   * idempotent on the libp2p side — `handle()` overwrites).
+   */
+  registerHandler(handler: PooledStreamHandler): void {
+    this.inboundHandler = handler;
+    if (this.inboundRegistered) return;
+    this.inboundRegistered = true;
+    this.node.libp2p.handle(
+      this.protocolId,
+      (stream, connection) => {
+        this.handleInboundStream(stream, connection.remotePeer.toString()).catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error(
+            `[MessageStreamPool] inbound stream error on ${this.protocolId}:`,
+            err instanceof Error ? err.message : err,
+          );
+        });
+      },
+      { runOnLimitedConnection: true },
+    );
+  }
+
+  /** Diagnostics: number of peers with an active stream. */
+  size(): number {
+    return this.peers.size;
+  }
+
+  /** Diagnostics: per-peer state snapshot. */
+  stats(peerIdStr: string): PerPeerStats | undefined {
+    const state = this.peers.get(peerIdStr);
+    if (!state) return undefined;
+    const now = this.clock();
+    const openedAt = this.peerOpenedAt.get(peerIdStr) ?? now;
+    return {
+      peerIdStr,
+      inFlight: state.inFlight !== null,
+      queueDepth: state.queue.length,
+      framesSent: state.framesSent,
+      framesReceived: state.framesReceived,
+      bytesSent: state.bytesSent,
+      bytesReceived: state.bytesReceived,
+      ageMs: now - openedAt,
+      lastActivityAgoMs: now - state.lastActivityAt,
+    };
+  }
+
+  /**
+   * Close every pooled stream and reject all pending requests.
+   * Safe to call multiple times. After close, further `send()` calls
+   * throw {@link PooledStreamResetError}.
+   */
+  async close(): Promise<void> {
+    this.closed = true;
+    if (this.inboundRegistered) {
+      try {
+        this.node.libp2p.unhandle(this.protocolId);
+      } catch {
+        // libp2p may already have torn down; ignore.
+      }
+      this.inboundRegistered = false;
+    }
+    const peers = [...this.peers.values()];
+    for (const state of peers) {
+      await this.closePeer(state, 'pool closed');
+    }
+    // Reject any remaining outstanding requests — covers the
+    // "dial still in flight when close fires" race + any request
+    // that wasn't installed in a peer state yet.
+    const stragglers = [...this.outstanding];
+    this.outstanding.clear();
+    for (const req of stragglers) {
+      try {
+        req.reject(new PooledStreamResetError('pool closed'));
+      } catch {
+        // already settled
+      }
+    }
+    this.peers.clear();
+    this.peerOpenedAt.clear();
+    this.openLocks.clear();
+  }
+
+  // ---------------------------------------------------------------
+  // internals
+  // ---------------------------------------------------------------
+
+  private async getOrOpenPeer(
+    peerIdStr: string,
+    signal?: AbortSignal,
+  ): Promise<PerPeerState> {
+    const existing = this.peers.get(peerIdStr);
+    if (existing && !existing.closed) return existing;
+    const pending = this.openLocks.get(peerIdStr);
+    if (pending) return pending;
+
+    const opening = (async (): Promise<PerPeerState> => {
+      const peerId = await this.resolvePeerId(peerIdStr);
+      const stream = await this.node.libp2p.dialProtocol(peerId, this.protocolId, {
+        runOnLimitedConnection: true,
+        signal,
+      });
+      return this.installState(peerIdStr, stream);
+    })();
+
+    this.openLocks.set(peerIdStr, opening);
+    try {
+      const state = await opening;
+      return state;
+    } finally {
+      this.openLocks.delete(peerIdStr);
+    }
+  }
+
+  private async resolvePeerId(peerIdStr: string): Promise<unknown> {
+    if (this.peerIdFromStringOverride) return this.peerIdFromStringOverride(peerIdStr);
+    if (!this.peerIdFromString) {
+      const mod = await import('@libp2p/peer-id');
+      this.peerIdFromString = mod.peerIdFromString;
+    }
+    return this.peerIdFromString(peerIdStr);
+  }
+
+  private installState(peerIdStr: string, stream: Stream): PerPeerState {
+    const now = this.clock();
+    const state: PerPeerState = {
+      peerIdStr,
+      stream,
+      inFlight: null,
+      queue: [],
+      readerDone: Promise.resolve(),
+      lastActivityAt: now,
+      keepaliveTimer: null,
+      idleTimer: null,
+      closed: false,
+      framesSent: 0,
+      framesReceived: 0,
+      bytesSent: 0,
+      bytesReceived: 0,
+    };
+    this.peers.set(peerIdStr, state);
+    this.peerOpenedAt.set(peerIdStr, now);
+
+    state.readerDone = (async () => {
+      try {
+        await this.runReader(state);
+        // Clean EOF: peer closed its write side. Treat as a recoverable
+        // reset so any in-flight/queued request rejects via the outbox
+        // retry path rather than hanging forever waiting for a
+        // response that will never arrive.
+        if (!state.closed) {
+          await this.handleReaderEnd(state, new PooledStreamResetError('peer closed stream'));
+        }
+      } catch (err) {
+        if (!state.closed) {
+          await this.handleReaderEnd(
+            state,
+            err instanceof Error ? err : new Error(String(err)),
+          );
+        }
+      }
+    })();
+
+    if (this.keepaliveIntervalMs > 0) {
+      state.keepaliveTimer = setInterval(() => {
+        this.sendControlFrame(state, FrameType.PING).catch(() => undefined);
+      }, this.keepaliveIntervalMs);
+      // Allow process to exit even when keepalive is running.
+      if (typeof (state.keepaliveTimer as unknown as { unref?: () => void }).unref === 'function') {
+        (state.keepaliveTimer as unknown as { unref: () => void }).unref();
+      }
+    }
+    this.armIdleTimer(state);
+
+    return state;
+  }
+
+  private armIdleTimer(state: PerPeerState): void {
+    if (this.idleTimeoutMs <= 0) return;
+    if (state.idleTimer) clearTimeout(state.idleTimer);
+    state.idleTimer = setTimeout(() => {
+      if (state.closed) return;
+      if (state.inFlight !== null || state.queue.length > 0) {
+        // Still active — re-arm.
+        this.armIdleTimer(state);
+        return;
+      }
+      this.closePeer(state, 'idle timeout').catch(() => undefined);
+    }, this.idleTimeoutMs);
+    if (typeof (state.idleTimer as unknown as { unref?: () => void }).unref === 'function') {
+      (state.idleTimer as unknown as { unref: () => void }).unref();
+    }
+  }
+
+  private async maybePumpNext(state: PerPeerState): Promise<void> {
+    if (state.closed) return;
+    if (state.inFlight !== null) return;
+    const next = state.queue.shift();
+    if (!next) return;
+    state.inFlight = next;
+    const frame = encodeFrame(FrameType.REQUEST, next.payload);
+    try {
+      state.stream.send(frame);
+      state.framesSent += 1;
+      state.bytesSent += frame.length;
+      state.lastActivityAt = this.clock();
+      this.armIdleTimer(state);
+      this.scheduleRequestTimeout(state, next);
+    } catch (err) {
+      // Failed to write — tear down stream, reject this request +
+      // every queued one.
+      state.inFlight = null;
+      next.reject(this.toResetError(err, 'write failed'));
+      await this.handleReaderEnd(state, this.toResetError(err, 'write failed'));
+    }
+  }
+
+  private scheduleRequestTimeout(state: PerPeerState, req: PendingRequest): void {
+    if (this.requestTimeoutMs <= 0) return;
+    const t = setTimeout(() => {
+      if (state.inFlight !== req) return;
+      // Treat as recoverable so the substrate outbox retries.
+      const err = new PooledStreamResetError('request timeout');
+      state.inFlight = null;
+      req.reject(err);
+      // Trigger a teardown — a stalled stream is unlikely to recover.
+      this.handleReaderEnd(state, err).catch(() => undefined);
+    }, this.requestTimeoutMs);
+    if (typeof (t as unknown as { unref?: () => void }).unref === 'function') {
+      (t as unknown as { unref: () => void }).unref();
+    }
+  }
+
+  private async sendControlFrame(state: PerPeerState, type: FrameType): Promise<void> {
+    if (state.closed) return;
+    try {
+      const frame = encodeFrame(type);
+      state.stream.send(frame);
+      state.framesSent += 1;
+      state.bytesSent += frame.length;
+      state.lastActivityAt = this.clock();
+    } catch (err) {
+      await this.handleReaderEnd(state, this.toResetError(err, 'control frame write failed'));
+    }
+  }
+
+  private async runReader(state: PerPeerState): Promise<void> {
+    for await (const frame of decodeFrames(
+      state.stream as unknown as AsyncIterable<Uint8Array>,
+      this.maxFrameBytes,
+    )) {
+      state.framesReceived += 1;
+      state.bytesReceived += frame.payload.length + 2; // approximate; framing overhead
+      state.lastActivityAt = this.clock();
+      this.armIdleTimer(state);
+      await this.dispatchInboundFrame(state, frame);
+    }
+  }
+
+  private async dispatchInboundFrame(state: PerPeerState, frame: DecodedFrame): Promise<void> {
+    switch (frame.type) {
+      case FrameType.RESPONSE: {
+        const req = state.inFlight;
+        if (!req) {
+          // Spurious response (no matching request). Likely indicates
+          // a peer bug; log and ignore — alternative would be tear
+          // down which is more disruptive.
+          // eslint-disable-next-line no-console
+          console.warn(`[MessageStreamPool] orphan RESPONSE from ${state.peerIdStr.slice(-8)}`);
+          return;
+        }
+        state.inFlight = null;
+        if (req.abortListener && req.signal) {
+          req.signal.removeEventListener('abort', req.abortListener);
+        }
+        req.resolve(frame.payload);
+        // Pump next queued request, if any.
+        await this.maybePumpNext(state);
+        return;
+      }
+      case FrameType.ERROR: {
+        const req = state.inFlight;
+        const msg = new TextDecoder().decode(frame.payload);
+        if (!req) {
+          // eslint-disable-next-line no-console
+          console.warn(`[MessageStreamPool] orphan ERROR from ${state.peerIdStr.slice(-8)}: ${msg}`);
+          return;
+        }
+        state.inFlight = null;
+        if (req.abortListener && req.signal) {
+          req.signal.removeEventListener('abort', req.abortListener);
+        }
+        // App errors are NOT pool-level resets; surface as a plain
+        // Error so the caller can decide whether to retry / surface.
+        req.reject(new Error(msg || 'remote handler error'));
+        await this.maybePumpNext(state);
+        return;
+      }
+      case FrameType.PING:
+        await this.sendControlFrame(state, FrameType.PONG);
+        return;
+      case FrameType.PONG:
+        // Keepalive ack — nothing to do.
+        return;
+      case FrameType.REQUEST: {
+        // The sender side of a pool receives REQUEST frames only via
+        // the inbound stream installed by `registerHandler`. If we
+        // see a REQUEST on an outbound stream, the peer is misusing
+        // the wire — tear down.
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[MessageStreamPool] unexpected REQUEST on outbound stream from ${state.peerIdStr.slice(-8)}`,
+        );
+        await this.handleReaderEnd(
+          state,
+          new PooledStreamResetError('peer sent REQUEST on outbound stream'),
+        );
+        return;
+      }
+      default:
+        // Unknown frame type — log and continue. Future wire
+        // additions should pass through cleanly.
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[MessageStreamPool] unknown frame type ${frame.type} from ${state.peerIdStr.slice(-8)}`,
+        );
+    }
+  }
+
+  private async handleInboundStream(stream: Stream, remotePeerStr: string): Promise<void> {
+    const handler = this.inboundHandler;
+    if (!handler) {
+      // No application handler registered yet — reject the stream
+      // cleanly so the dialer surfaces a typed error.
+      try {
+        stream.abort(new Error('pooled handler not registered'));
+      } catch {
+        // already torn down
+      }
+      return;
+    }
+
+    const peerIdLike = {
+      toString: () => remotePeerStr,
+    };
+
+    try {
+      for await (const frame of decodeFrames(
+        stream as unknown as AsyncIterable<Uint8Array>,
+        this.maxFrameBytes,
+      )) {
+        if (frame.type === FrameType.PING) {
+          try {
+            stream.send(encodeFrame(FrameType.PONG));
+          } catch {
+            return;
+          }
+          continue;
+        }
+        if (frame.type === FrameType.PONG) {
+          continue;
+        }
+        if (frame.type !== FrameType.REQUEST) {
+          // Unexpected on the inbound side; ignore non-request frame
+          // types but keep the stream alive (forward-compat).
+          continue;
+        }
+        // Invoke the application handler. ANY error becomes an ERROR
+        // frame back to the caller; we don't propagate handler
+        // exceptions to the stream level (which would tear the
+        // whole pooled stream down and affect other in-flight
+        // requests on this same peer).
+        let response: Uint8Array;
+        try {
+          response = await handler(frame.payload, peerIdLike);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          try {
+            stream.send(encodeFrame(FrameType.ERROR, new TextEncoder().encode(msg)));
+          } catch {
+            // Stream gone; bail.
+            return;
+          }
+          continue;
+        }
+        try {
+          stream.send(encodeFrame(FrameType.RESPONSE, response));
+        } catch {
+          // Stream torn down; reader loop will exit on next iter.
+          return;
+        }
+      }
+    } catch (err) {
+      // Reader-side decode error or transport error — abort and let
+      // the dialer reconnect.
+      try {
+        stream.abort(err instanceof Error ? err : new Error('reader error'));
+      } catch {
+        // already torn down
+      }
+    }
+  }
+
+  private async handleReaderEnd(state: PerPeerState, err: Error): Promise<void> {
+    if (state.closed) return;
+    state.closed = true;
+    if (state.keepaliveTimer) clearInterval(state.keepaliveTimer);
+    if (state.idleTimer) clearTimeout(state.idleTimer);
+    state.keepaliveTimer = null;
+    state.idleTimer = null;
+
+    const wrapped =
+      err instanceof PooledStreamResetError ? err : this.toResetError(err, 'stream ended');
+
+    const pending: PendingRequest[] = [];
+    if (state.inFlight) pending.push(state.inFlight);
+    pending.push(...state.queue);
+    state.inFlight = null;
+    state.queue = [];
+    for (const req of pending) {
+      if (req.abortListener && req.signal) {
+        req.signal.removeEventListener('abort', req.abortListener);
+      }
+      req.reject(wrapped);
+    }
+
+    try {
+      state.stream.abort(wrapped);
+    } catch {
+      // already torn down
+    }
+
+    if (this.peers.get(state.peerIdStr) === state) {
+      this.peers.delete(state.peerIdStr);
+      this.peerOpenedAt.delete(state.peerIdStr);
+    }
+  }
+
+  private async closePeer(state: PerPeerState, reason: string): Promise<void> {
+    if (state.closed) return;
+    await this.handleReaderEnd(state, new PooledStreamResetError(reason));
+  }
+
+  private toResetError(err: unknown, fallback: string): PooledStreamResetError {
+    if (err instanceof PooledStreamResetError) return err;
+    if (err instanceof Error) return new PooledStreamResetError(err.message);
+    return new PooledStreamResetError(fallback);
+  }
+}

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -142,6 +142,32 @@ export interface MessageStreamPoolOptions {
    * internals.
    */
   peerIdFromString?: (s: string) => unknown;
+  /**
+   * Address-resolution hook called BEFORE `dialProtocol` on the
+   * first stream open per peer. Critical for cold-peer first
+   * contact: libp2p's peerStore may be empty/stale for a peer we
+   * haven't recently talked to, and `dialProtocol` returns
+   * "no valid addresses for peer" without ever consulting the DHT
+   * / agent registry / RFC 04 routing.
+   *
+   * The wrapping `ProtocolRouter` always primes via `peerResolver`
+   * on the one-shot path (RFC 07 §3.2 — see `protocol-router.ts`
+   * for the rationale + grep gate). Threading the same hook here
+   * keeps the pooled path on parity: the pool's first dial pays
+   * the same priming cost as the one-shot first dial, no more, no
+   * less.
+   *
+   * Codex PR #560 review: without this, enabling pooling
+   * regressed first-contact delivery to cold peers — the failure
+   * mode the soak postmortem was built around.
+   *
+   * Failure-tolerant by contract: any throw from `primePeer` is
+   * swallowed (the dial itself surfaces a real transport error if
+   * the peer is genuinely unreachable). Per-step timeout is owned
+   * by the caller — pass an `AbortSignal` tied to the overall
+   * send budget.
+   */
+  primePeer?: (peerIdStr: string, opts: { signal?: AbortSignal }) => Promise<void>;
 }
 
 interface PendingRequest {
@@ -218,6 +244,7 @@ export class MessageStreamPool {
   private readonly clock: () => number;
   private readonly peerIdFromStringOverride?: (s: string) => unknown;
   private peerIdFromString?: (s: string) => unknown;
+  private readonly primePeer?: (peerIdStr: string, opts: { signal?: AbortSignal }) => Promise<void>;
   private inboundHandler: PooledStreamHandler | null = null;
   private inboundRegistered = false;
   private closed = false;
@@ -250,6 +277,7 @@ export class MessageStreamPool {
     this.maxFrameBytes = options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES;
     this.clock = options.clock ?? (() => Date.now());
     this.peerIdFromStringOverride = options.peerIdFromString;
+    this.primePeer = options.primePeer;
   }
 
   /** Protocol id this pool advertises on the wire. */
@@ -321,13 +349,35 @@ export class MessageStreamPool {
 
     if (req.signal) {
       const onAbort = (): void => {
-        // Caller cancelled. If still queued, splice out and reject.
-        // If in-flight, leave the request entry in place — the
-        // reader will resolve/reject when the response arrives or
-        // the stream tears down. Don't tear down the stream just
-        // because one caller cancelled.
+        // Caller cancelled. Three cases:
+        //
+        //   1. Request still queued — splice out, reject the caller's
+        //      promise. The stream and other peers are unaffected.
+        //
+        //   2. Request in-flight — we cannot let `state.inFlight` stay
+        //      pointed at the cancelled request: the remote will
+        //      eventually send a response frame for THIS request, and
+        //      since the pool serialises (one in-flight at a time)
+        //      every later send queues behind it, waiting forever for
+        //      a response that's already been delivered to nobody.
+        //      Codex PR #560 round-1 review caught this — one cancel
+        //      poisons every subsequent send to the same peer.
+        //
+        //      Fix: treat in-flight cancel as a stream reset. Reject
+        //      every pending request with a recoverable error so the
+        //      substrate outbox retries them on a fresh stream, then
+        //      tear down state via the standard reader-end path.
+        //      The next send opens a clean stream.
+        //
+        //   3. Request neither queued nor in-flight (dispatchSend not
+        //      yet awaited / already settled). No-op — `wrapTerminal`
+        //      ensures resolve/reject is idempotent.
         if (state.inFlight === req) {
           req.reject(new Error('request aborted'));
+          this.handleReaderEnd(
+            state,
+            new PooledStreamResetError('in-flight request aborted'),
+          ).catch(() => undefined);
           return;
         }
         const idx = state.queue.indexOf(req);
@@ -474,6 +524,32 @@ export class MessageStreamPool {
     if (pending) return pending;
 
     const opening = (async (): Promise<PerPeerState> => {
+      // Cold-peer priming. The pool dials the wire variant directly
+      // via `dialProtocol`, which consults libp2p's peerStore for
+      // addresses. If peerStore is empty / stale (the soak-
+      // postmortem Window D shape — first contact after a node
+      // restart, or after a long quiet), the dial returns
+      // "no valid addresses for peer" and the pool fails the open
+      // without ever asking the DHT / agent registry / RFC 04
+      // routing surface where the peer might be findable.
+      //
+      // The wrapping `ProtocolRouter` always primes via
+      // `peerResolver.resolve` before its one-shot dial — see RFC
+      // 07 §3.2. Without the same priming here, enabling pooling
+      // would regress first-contact delivery to cold peers.
+      //
+      // Best-effort: any throw is swallowed (the dial below
+      // surfaces a real transport error if the peer is genuinely
+      // unreachable; the prime hook's only job is to populate
+      // peerStore so the dial CAN reach a routable address).
+      if (this.primePeer) {
+        try {
+          await this.primePeer(peerIdStr, { signal });
+        } catch {
+          // primePeer never gates the dial — the existing
+          // identify-cache path may still resolve.
+        }
+      }
       const peerId = await this.resolvePeerId(peerIdStr);
       const stream = await this.node.libp2p.dialProtocol(peerId, this.protocolId, {
         runOnLimitedConnection: true,

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -915,6 +915,15 @@ export class MessageStreamPool {
       return;
     }
 
+    // Track whether we exited via clean EOF or an error path so the
+    // finally block knows which teardown to use. Codex PR #560
+    // round-5: previously the `for await` loop simply returned on
+    // remote-side EOF and we never closed our local half. That
+    // leaked half-open substream state until the underlying
+    // connection died (and circuit-relay reservations along with
+    // it). The finally now guarantees the local side is released
+    // on every exit path.
+    let cleanEof = true;
     try {
       for await (const frame of decodeFrames(
         stream as unknown as AsyncIterable<Uint8Array>,
@@ -962,12 +971,26 @@ export class MessageStreamPool {
         }
       }
     } catch (err) {
+      cleanEof = false;
       // Reader-side decode error or transport error — abort and let
       // the dialer reconnect.
       try {
         stream.abort(err instanceof Error ? err : new Error('reader error'));
       } catch {
         // already torn down
+      }
+    } finally {
+      // Clean EOF: remote half-closed gracefully. Close our local
+      // write side too so the substream releases cleanly. Without
+      // this, the local half stays open until the underlying
+      // connection dies, leaking inbound stream slots and (on
+      // circuit-relay-v2) relay reservations.
+      if (cleanEof) {
+        try {
+          await stream.close();
+        } catch {
+          // already torn down
+        }
       }
     }
   }

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -114,10 +114,19 @@ export interface PoolNode {
   };
 }
 
-/** Application-level handler signature — identical to ProtocolRouter's. */
+/**
+ * Application-level handler signature for inbound pooled traffic.
+ * `peerId` is whatever libp2p hands us as `connection.remotePeer`
+ * — in production this is a full `PeerId` with `toMultihash()`,
+ * `toBytes()`, `equals()`, etc.; in tests it can be any object
+ * with at least `toString()`. The router wraps this into the same
+ * shape the one-shot path provides before passing to application
+ * handlers, so calling `peerId.toBytes()` from a handler works on
+ * both wire variants (Codex PR #560 round-3).
+ */
 export type PooledStreamHandler = (
   requestData: Uint8Array,
-  peerId: { toString: () => string },
+  peerId: unknown,
 ) => Promise<Uint8Array>;
 
 export interface MessageStreamPoolOptions {
@@ -474,7 +483,13 @@ export class MessageStreamPool {
     this.node.libp2p.handle(
       this.protocolId,
       (stream, connection) => {
-        this.handleInboundStream(stream, connection.remotePeer.toString()).catch((err) => {
+        // Pass the WHOLE `remotePeer` object through (not just its
+        // string form) so application handlers can call methods
+        // like `.toBytes()` / `.toMultihash()` exactly as they do
+        // on the one-shot path. Codex PR #560 round-3 caught this:
+        // previously only `.toString()` was threaded, which meant
+        // pooled traffic broke handlers that worked on one-shot.
+        this.handleInboundStream(stream, connection.remotePeer).catch((err) => {
           // eslint-disable-next-line no-console
           console.error(
             `[MessageStreamPool] inbound stream error on ${this.protocolId}:`,
@@ -823,7 +838,7 @@ export class MessageStreamPool {
     }
   }
 
-  private async handleInboundStream(stream: Stream, remotePeerStr: string): Promise<void> {
+  private async handleInboundStream(stream: Stream, remotePeer: unknown): Promise<void> {
     const handler = this.inboundHandler;
     if (!handler) {
       // No application handler registered yet — reject the stream
@@ -835,10 +850,6 @@ export class MessageStreamPool {
       }
       return;
     }
-
-    const peerIdLike = {
-      toString: () => remotePeerStr,
-    };
 
     try {
       for await (const frame of decodeFrames(
@@ -868,7 +879,7 @@ export class MessageStreamPool {
         // requests on this same peer).
         let response: Uint8Array;
         try {
-          response = await handler(frame.payload, peerIdLike);
+          response = await handler(frame.payload, remotePeer);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           try {
@@ -897,7 +908,34 @@ export class MessageStreamPool {
     }
   }
 
-  private async handleReaderEnd(state: PerPeerState, err: Error): Promise<void> {
+  /**
+   * Tear down per-peer state. `graceful` controls how we signal the
+   * tear-down to the remote:
+   *
+   *   * `graceful: true` (idle expiry / pool close / unregister) —
+   *     use `stream.close()` to send a FIN. The remote reader sees
+   *     EOF (clean half-close), not RST_STREAM. This matters during
+   *     intentional shutdown: a RST surfaces on the remote as a
+   *     stream reset, which the remote messenger's substrate (or
+   *     ours, on a peer-initiated graceful close) may interpret as
+   *     a transport failure worth re-enqueuing — even though the
+   *     last delivery was complete. Codex PR #560 round-3 caught
+   *     this.
+   *
+   *   * `graceful: false` (transport error, reader threw, write
+   *     failure) — use `stream.abort()` to send RST_STREAM. The
+   *     remote sees the error and acts on it (retry / dial fresh).
+   *
+   * Pending requests are rejected with `PooledStreamResetError`
+   * in BOTH cases. The receiver-side dedup-by-messageId from PR
+   * #534 catches any duplicate retries the substrate generates on
+   * graceful shutdown.
+   */
+  private async handleReaderEnd(
+    state: PerPeerState,
+    err: Error,
+    opts: { graceful?: boolean } = {},
+  ): Promise<void> {
     if (state.closed) return;
     state.closed = true;
     if (state.keepaliveTimer) clearInterval(state.keepaliveTimer);
@@ -921,7 +959,13 @@ export class MessageStreamPool {
     }
 
     try {
-      state.stream.abort(wrapped);
+      if (opts.graceful) {
+        // Best-effort FIN — close() is async, errors during teardown
+        // don't matter (the stream is going away regardless).
+        await state.stream.close();
+      } else {
+        state.stream.abort(wrapped);
+      }
     } catch {
       // already torn down
     }
@@ -934,7 +978,9 @@ export class MessageStreamPool {
 
   private async closePeer(state: PerPeerState, reason: string): Promise<void> {
     if (state.closed) return;
-    await this.handleReaderEnd(state, new PooledStreamResetError(reason));
+    // Graceful — caller invoked this intentionally (idle expiry,
+    // pool close, unregister). Codex PR #560 round-3 fix.
+    await this.handleReaderEnd(state, new PooledStreamResetError(reason), { graceful: true });
   }
 
   private toResetError(err: unknown, fallback: string): PooledStreamResetError {

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -189,6 +189,26 @@ export class ProtocolRouter {
       return;
     }
     const wireProtocolId = options.protocolId ?? POOLED_MESSAGE_PROTOCOL;
+    // Wire-id collision guard. Codex PR #560 round-3 review caught
+    // that every pool defaults to the same `/dkg/10.0.2/message`
+    // wire id. If a SECOND logical protocol opts in without an
+    // explicit `options.protocolId`, its `libp2p.handle()` would
+    // overwrite the first pool's inbound handler — and inbound
+    // traffic for the first logical protocol would silently
+    // dispatch to the wrong application handler.
+    //
+    // We refuse to install a duplicate wire handler. The caller
+    // must supply a distinct `options.protocolId` for the second
+    // pool (no auto-derived suffix — wire ids are part of the
+    // protocol contract, ad-hoc names would break peer interop).
+    const claimedBy = this.logicalByWire.get(wireProtocolId);
+    if (claimedBy && claimedBy !== logicalProtocolId) {
+      throw new Error(
+        `enablePooling: wire protocol ${wireProtocolId} is already claimed by ` +
+          `logical protocol ${claimedBy}. Pass options.protocolId to use a ` +
+          `distinct wire id for ${logicalProtocolId}.`,
+      );
+    }
     // Thread the router's `peerResolver` into the pool unless the
     // caller already supplied a `primePeer` hook. Without this, the
     // pool would skip resolver priming and regress first-contact
@@ -242,15 +262,29 @@ export class ProtocolRouter {
       if (!handler) {
         throw new Error(`no application handler for ${logicalProtocolId}`);
       }
-      // Wrap the libp2p-shape peerId object into the same shape the
-      // one-shot path uses (`toString` only; toBytes optional).
+      // Wrap into the exact same `{ toString, toBytes }` shape the
+      // one-shot register() path passes to application handlers
+      // (see `register()` ~30 lines below). The pool now threads
+      // the REAL `connection.remotePeer` through, so on production
+      // traffic this exposes `.toMultihash().bytes` just like
+      // one-shot. Tests can pass minimal peer-like objects with
+      // only `.toString()` and the wrap still works (toBytes()
+      // surfaces a typed error rather than silently corrupting).
+      // Codex PR #560 round-3.
+      const remote = peerId as {
+        toString: () => string;
+        toMultihash?: () => { bytes: Uint8Array };
+        toBytes?: () => Uint8Array;
+      };
       const wrappedPeerId = {
-        toString: () => peerId.toString(),
+        toString: () => remote.toString(),
         toBytes: () => {
-          // We don't need bytes for substrate dispatch; pass through
-          // when available, else throw to surface unexpected use.
-          const maybe = peerId as { toBytes?: () => Uint8Array };
-          if (maybe.toBytes) return maybe.toBytes();
+          if (typeof remote.toMultihash === 'function') {
+            return remote.toMultihash().bytes;
+          }
+          if (typeof remote.toBytes === 'function') {
+            return remote.toBytes();
+          }
           throw new Error('peerId.toBytes not available on pooled handler');
         },
       };

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -2,6 +2,12 @@ import type { Stream } from '@libp2p/interface';
 import type { StreamHandler as DKGStreamHandler } from './types.js';
 import type { DKGNode } from './node.js';
 import type { PeerResolver } from './network/peer-resolver.js';
+import {
+  MessageStreamPool,
+  POOLED_MESSAGE_PROTOCOL,
+  PooledStreamResetError,
+  type MessageStreamPoolOptions,
+} from './message-stream-pool.js';
 
 /** Default max bytes readAll will buffer before aborting (10 MB). */
 export const DEFAULT_MAX_READ_BYTES = 10 * 1024 * 1024;
@@ -109,11 +115,168 @@ export class ProtocolRouter {
    */
   private warnedMissingResolver = false;
   readonly maxReadBytes: number;
+  /**
+   * Per-logical-protocol pooled-transport overlay. When a caller
+   * invokes `router.enablePooling(logicalProtocolId)`, the router
+   * tries the pooled `/dkg/10.0.2/*` wire variant first via
+   * `dialProtocol([pooledId, logicalId])`, and reuses a long-lived
+   * stream per peer. Receivers that don't advertise the pooled wire
+   * variant fall back to the one-shot path within the same `send()`
+   * call (libp2p multistream-select picks the best mutual).
+   *
+   * Stored by LOGICAL protocol id (what the caller passes to
+   * `send`/`register`); the value holds the wire variant + the pool
+   * instance.
+   */
+  private readonly pooledByLogical = new Map<string, PooledOverlay>();
+  /**
+   * Reverse map from WIRE protocol id back to the logical id, so
+   * the inbound handler the pool dispatches to can resolve the
+   * application handler registered under the logical id.
+   */
+  private readonly logicalByWire = new Map<string, string>();
+  /**
+   * Per-peer wire-variant memo. Once a peer has been seen on a
+   * specific wire variant for a given logical protocol, subsequent
+   * sends skip the dial-with-protocol-list overhead by going
+   * directly through the pool (if pooled) or the one-shot path
+   * (otherwise). Cleared on stream reset for the pooled side; the
+   * one-shot side has no memo to clear because every send re-dials
+   * anyway.
+   */
+  private readonly peerWireVariant = new Map<string, Map<string, 'pooled' | 'one-shot'>>();
 
   constructor(node: DKGNode, options?: ProtocolRouterOptions) {
     this.node = node;
     this.peerResolver = options?.peerResolver;
     this.maxReadBytes = options?.maxReadBytes ?? DEFAULT_MAX_READ_BYTES;
+  }
+
+  /**
+   * Opt a logical protocol into the pooled transport overlay. After
+   * this call:
+   *
+   *   * `send(peer, logicalId, data)` first attempts the pooled wire
+   *     variant `/dkg/10.0.2/message` (or the caller-supplied
+   *     `pooledProtocolId`). On multistream-select fallback to the
+   *     logical id, the one-shot path runs unchanged. The wire
+   *     variant chosen per peer is memoized so subsequent sends
+   *     skip the negotiation.
+   *
+   *   * `register(logicalId, handler)` ALSO registers `handler` on
+   *     the pooled wire variant via the pool's inbound handler, so
+   *     peers using the pooled wire reach the same application
+   *     code.
+   *
+   * Calling this method is idempotent; second + later calls update
+   * the per-pool options (handler is re-registered).
+   *
+   * `enablePooling` MUST be called BEFORE `register(logicalId,
+   * handler)` for the pool's inbound handler to pick up the
+   * registration. Re-ordering would silently leave the pooled wire
+   * variant unhandled.
+   */
+  enablePooling(
+    logicalProtocolId: string,
+    options: Partial<MessageStreamPoolOptions> = {},
+  ): void {
+    const existing = this.pooledByLogical.get(logicalProtocolId);
+    if (existing) {
+      // Idempotent — caller might be re-enabling with different
+      // options after a hot-reload; honor the latest config by
+      // tearing down + reopening (no-op for tests that re-construct).
+      // For now, just keep the existing pool and ignore subsequent
+      // calls; callers are expected to enable once at startup.
+      return;
+    }
+    const wireProtocolId = options.protocolId ?? POOLED_MESSAGE_PROTOCOL;
+    const pool = new MessageStreamPool(
+      // The node shape required by the pool overlaps with DKGNode but
+      // is narrower; pass the node directly (DKGNode satisfies the
+      // structural subset PoolNode requires).
+      this.node as unknown as Parameters<typeof MessageStreamPool['prototype']['send']>[0] extends never
+        ? never
+        : ConstructorParameters<typeof MessageStreamPool>[0],
+      {
+        ...options,
+        protocolId: wireProtocolId,
+        maxFrameBytes: options.maxFrameBytes ?? this.maxReadBytes,
+      },
+    );
+    this.pooledByLogical.set(logicalProtocolId, {
+      pool,
+      wireProtocolId,
+      logicalProtocolId,
+    });
+    this.logicalByWire.set(wireProtocolId, logicalProtocolId);
+    // If a handler is already registered for the logical id, wire it
+    // through the pool's inbound side right away.
+    const handler = this.handlers.get(logicalProtocolId);
+    if (handler) {
+      this.installPoolInboundHandler(logicalProtocolId, pool);
+    }
+  }
+
+  private installPoolInboundHandler(
+    logicalProtocolId: string,
+    pool: MessageStreamPool,
+  ): void {
+    pool.registerHandler(async (requestData, peerId) => {
+      const handler = this.handlers.get(logicalProtocolId);
+      if (!handler) {
+        throw new Error(`no application handler for ${logicalProtocolId}`);
+      }
+      // Wrap the libp2p-shape peerId object into the same shape the
+      // one-shot path uses (`toString` only; toBytes optional).
+      const wrappedPeerId = {
+        toString: () => peerId.toString(),
+        toBytes: () => {
+          // We don't need bytes for substrate dispatch; pass through
+          // when available, else throw to surface unexpected use.
+          const maybe = peerId as { toBytes?: () => Uint8Array };
+          if (maybe.toBytes) return maybe.toBytes();
+          throw new Error('peerId.toBytes not available on pooled handler');
+        },
+      };
+      return handler(requestData, wrappedPeerId);
+    });
+  }
+
+  /**
+   * Diagnostics: snapshot of every pooled overlay (logical id, wire
+   * id, peers-with-live-streams). Empty when no protocols are
+   * pooled.
+   */
+  pooledStatus(): Array<{
+    logicalProtocolId: string;
+    wireProtocolId: string;
+    livePeers: number;
+  }> {
+    return [...this.pooledByLogical.values()].map((overlay) => ({
+      logicalProtocolId: overlay.logicalProtocolId,
+      wireProtocolId: overlay.wireProtocolId,
+      livePeers: overlay.pool.size(),
+    }));
+  }
+
+  /**
+   * Tear down every pooled overlay. Idempotent. The router itself
+   * remains usable for one-shot sends after this — pooling is opt-in
+   * and reversible. Tests call this in `afterEach`; production
+   * daemons call it during shutdown.
+   */
+  async closePooling(): Promise<void> {
+    const overlays = [...this.pooledByLogical.values()];
+    this.pooledByLogical.clear();
+    this.logicalByWire.clear();
+    this.peerWireVariant.clear();
+    for (const overlay of overlays) {
+      try {
+        await overlay.pool.close();
+      } catch {
+        // ignore — best-effort shutdown
+      }
+    }
   }
 
   register(protocolId: string, handler: DKGStreamHandler): void {
@@ -140,11 +303,25 @@ export class ProtocolRouter {
         }
       }
     }, { runOnLimitedConnection: true });
+
+    // If pooling was enabled for this protocol BEFORE the handler
+    // arrived, wire the pool's inbound handler now. (The
+    // `enablePooling` path also calls this once when the handler
+    // already exists — together they cover both orderings.)
+    const overlay = this.pooledByLogical.get(protocolId);
+    if (overlay) {
+      this.installPoolInboundHandler(protocolId, overlay.pool);
+    }
   }
 
   unregister(protocolId: string): void {
     this.handlers.delete(protocolId);
     this.node.libp2p.unhandle(protocolId);
+    // If we had a pooled overlay for this logical protocol, leave
+    // it in place — the pool's libp2p.handle was already
+    // unregistered by `closePooling` if that path was used; bare
+    // `unregister` is a per-handler operation that doesn't touch
+    // the pool.
   }
 
   async send(
@@ -157,6 +334,47 @@ export class ProtocolRouter {
       typeof timeoutMsOrOpts === 'number' ? { timeoutMs: timeoutMsOrOpts } : timeoutMsOrOpts;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
     const parallelPaths = Math.max(1, Math.floor(opts.parallelPaths ?? 1));
+
+    // Pooled overlay short-circuit. When `enablePooling(protocolId)`
+    // has been called for this logical protocol AND the peer hasn't
+    // been pinned to the one-shot wire variant by a prior fallback,
+    // route through the pool. The pool handles its own retry, dial,
+    // keepalive, and idle-close semantics, so on success we return
+    // directly. On failure that classifies as "peer doesn't speak
+    // the pooled wire" (multistream-select negotiate / protocol
+    // unsupported), we memoize the peer as one-shot and fall through
+    // to the existing one-shot path below — same `send()` call, no
+    // user-visible retry. Any OTHER pool error (transient transport,
+    // recoverable reset) is bubbled directly to the caller so the
+    // substrate outbox can retry; without bubbling we'd convert a
+    // genuine transport failure into a phantom one-shot fallback and
+    // mask the underlying issue.
+    const overlay = this.pooledByLogical.get(protocolId);
+    if (overlay && this.peerWireVariantFor(peerIdStr, protocolId) !== 'one-shot') {
+      try {
+        const response = await overlay.pool.send(peerIdStr, data, {
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+        this.memoizePeerWire(peerIdStr, protocolId, 'pooled');
+        return response;
+      } catch (err) {
+        if (isProtocolUnsupportedError(err)) {
+          // Peer doesn't advertise the pooled wire variant. Pin to
+          // one-shot for future sends; fall through to existing
+          // single-path / multi-path logic below.
+          this.memoizePeerWire(peerIdStr, protocolId, 'one-shot');
+        } else if (err instanceof PooledStreamResetError) {
+          // Pool-level reset: don't fall through (would silently
+          // double-send on a stream that the pool will re-open on
+          // the next call). Surface the recoverable error to the
+          // caller so the substrate retries through the pool path
+          // next attempt.
+          throw err;
+        } else {
+          throw err;
+        }
+      }
+    }
 
     const libp2p = this.node.libp2p;
     const { peerIdFromString } = await import('@libp2p/peer-id');
@@ -814,6 +1032,74 @@ async function readAll(
   }
   return concat(chunks);
 }
+
+/**
+ * Per-(peer, logical-protocol) wire variant memo. Persists across
+ * sends to skip redundant negotiation on subsequent calls.
+ */
+interface PooledOverlay {
+  pool: MessageStreamPool;
+  wireProtocolId: string;
+  logicalProtocolId: string;
+}
+
+/**
+ * Returns true if `err` looks like a multistream-select / protocol-
+ * negotiation failure that justifies falling back to a different
+ * wire variant. Conservative — only fall back on errors that
+ * specifically mean "the peer doesn't speak this protocol", not on
+ * transient transport errors that should retry on the same wire.
+ *
+ * Exported for tests.
+ */
+export function isProtocolUnsupportedError(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  // PooledStreamResetError wraps the underlying message verbatim
+  // ("pooled stream reset: <inner>"), so the substrings below
+  // match through the wrapper.
+  return (
+    msg.includes('protocol selection failed') ||
+    msg.includes('could not negotiate') ||
+    msg.includes('unsupported protocol') ||
+    msg.includes('protocol mismatch')
+  );
+}
+
+// Helpers attached to ProtocolRouter via prototype assignment after
+// the class. Implemented this way to keep the class body readable
+// (avoids interleaving the helpers with the long `send` method).
+declare module './protocol-router.js' {
+  interface ProtocolRouter {
+    peerWireVariantFor(peerIdStr: string, logicalProtocolId: string): 'pooled' | 'one-shot' | undefined;
+    memoizePeerWire(peerIdStr: string, logicalProtocolId: string, variant: 'pooled' | 'one-shot'): void;
+  }
+}
+
+ProtocolRouter.prototype.peerWireVariantFor = function (
+  this: ProtocolRouter,
+  peerIdStr: string,
+  logicalProtocolId: string,
+): 'pooled' | 'one-shot' | undefined {
+  const map = (this as unknown as { peerWireVariant: Map<string, Map<string, 'pooled' | 'one-shot'>> })
+    .peerWireVariant;
+  return map.get(peerIdStr)?.get(logicalProtocolId);
+};
+
+ProtocolRouter.prototype.memoizePeerWire = function (
+  this: ProtocolRouter,
+  peerIdStr: string,
+  logicalProtocolId: string,
+  variant: 'pooled' | 'one-shot',
+): void {
+  const map = (this as unknown as { peerWireVariant: Map<string, Map<string, 'pooled' | 'one-shot'>> })
+    .peerWireVariant;
+  let inner = map.get(peerIdStr);
+  if (!inner) {
+    inner = new Map();
+    map.set(peerIdStr, inner);
+  }
+  inner.set(logicalProtocolId, variant);
+};
 
 function concat(arrays: Uint8Array[]): Uint8Array {
   if (arrays.length === 0) return new Uint8Array(0);

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -417,20 +417,30 @@ export class ProtocolRouter {
     // substrate outbox can retry; without bubbling we'd convert a
     // genuine transport failure into a phantom one-shot fallback and
     // mask the underlying issue.
+    // Overall wall-clock budget guard. Codex PR #560 round-4 caught
+    // that the pool branch and the one-shot fallback each got a
+    // FRESH `timeoutMs` budget — a slow pool failure followed by a
+    // slow one-shot retry could blow the API contract by ~2x. We
+    // now stamp the start, share a single AbortSignal across both
+    // branches, and compute a remaining-budget that the one-shot
+    // fallback honors. The shared signal aborts BOTH the pool
+    // attempt and any one-shot retry as soon as the overall budget
+    // is exhausted.
+    const overallStartedAt = Date.now();
+    const overallDeadline = AbortSignal.timeout(timeoutMs);
+
     const overlay = this.pooledByLogical.get(protocolId);
     const memoizedVariant = this.peerWireVariantFor(peerIdStr, protocolId);
     if (overlay && memoizedVariant !== 'one-shot') {
       try {
+        const remainingForPool = Math.max(0, timeoutMs - (Date.now() - overallStartedAt));
         const response = await overlay.pool.send(peerIdStr, data, {
-          signal: AbortSignal.timeout(timeoutMs),
-          // Thread the router's per-call timeout into the pool's
-          // own request timer so a caller asking for, say, 60s
-          // isn't silently capped at the pool's 20s default. The
-          // pool's signal-abort path covers the wall-clock budget;
-          // the request-timer is the in-pool fallback when the
-          // signal isn't observed (e.g. mid-write). Codex PR #560
-          // round 2.
-          timeoutMs,
+          // Share the OVERALL deadline so a fall-through to one-shot
+          // doesn't get a fresh budget. Codex PR #560 round 4.
+          signal: overallDeadline,
+          // Thread the remaining wall-clock into the pool's own
+          // request timer so it lines up with the shared deadline.
+          timeoutMs: remainingForPool,
         });
         this.memoizePeerWire(peerIdStr, protocolId, 'pooled');
         return response;
@@ -468,13 +478,26 @@ export class ProtocolRouter {
       }
     }
 
+    // One-shot path: reuse the OVERALL wall-clock budget rather
+    // than starting a fresh timer. If the pool branch already
+    // consumed most of `timeoutMs`, the one-shot retry inherits the
+    // remainder — and `overallDeadline` aborts mid-attempt the
+    // moment the total budget is exhausted. Codex PR #560 round 4.
+    const remainingMs = Math.max(0, timeoutMs - (Date.now() - overallStartedAt));
+    if (remainingMs === 0) {
+      throw new Error(
+        `send timeout: pooled fallback exhausted the ${timeoutMs}ms budget before one-shot attempt`,
+      );
+    }
     const libp2p = this.node.libp2p;
     const { peerIdFromString } = await import('@libp2p/peer-id');
     const peerId = peerIdFromString(peerIdStr);
-    const startedAt = Date.now();
+    const startedAt = overallStartedAt;
 
     if (parallelPaths > 1) {
-      const multipathSignal = AbortSignal.timeout(timeoutMs);
+      // Reuse the overall budget rather than starting a fresh one
+      // — see comment above. Codex PR #560 round 4.
+      const multipathSignal = overallDeadline;
       // Multi-path pre-attempt — race up to N live connections.
       // Returns the response on a winning path, or null if there
       // weren't enough live candidates (or all candidates failed).

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -390,6 +390,14 @@ export class ProtocolRouter {
       this.logicalByWire.delete(overlay.pool.pooledProtocolId);
       overlay.pool.close().catch(() => undefined);
     }
+    // Clear any per-peer wire-variant memos for this logical
+    // protocol. Codex PR #560 round-5 caught: without this, a peer
+    // pinned to 'one-shot' for protocol X would stay pinned across
+    // unregister + re-register + re-enable-pooling cycles, never
+    // renegotiating the pooled wire variant until process restart.
+    for (const [_peerId, inner] of this.peerWireVariant) {
+      inner.delete(protocolId);
+    }
   }
 
   async send(
@@ -746,7 +754,25 @@ export class ProtocolRouter {
         }
         if (!isRecoverableSendError(err) || attempt >= 2) throw err;
         const backoff = (attempt + 1) * 500;
-        await new Promise(r => setTimeout(r, backoff));
+        // Make the backoff abortable so the overall deadline is
+        // honored. Codex PR #560 round-5 caught: if the pool burned
+        // most of `timeoutMs`, the one-shot retry's fixed 500/1000ms
+        // sleep would still push past the deadline before the next
+        // attempt could fail loudly. Now: if `overallDeadline` fires
+        // during the backoff, we throw immediately rather than
+        // continuing into another attempt that's already over budget.
+        await new Promise<void>((resolve, reject) => {
+          const t = setTimeout(resolve, backoff);
+          const onAbort = (): void => {
+            clearTimeout(t);
+            reject(new Error(`send timeout: backoff aborted by overall deadline (${timeoutMs}ms)`));
+          };
+          if (overallDeadline.aborted) {
+            onAbort();
+            return;
+          }
+          overallDeadline.addEventListener('abort', onAbort, { once: true });
+        });
       }
     }
     throw lastErr;

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -5,7 +5,6 @@ import type { PeerResolver } from './network/peer-resolver.js';
 import {
   MessageStreamPool,
   POOLED_MESSAGE_PROTOCOL,
-  PooledStreamResetError,
   type MessageStreamPoolOptions,
 } from './message-stream-pool.js';
 
@@ -190,6 +189,22 @@ export class ProtocolRouter {
       return;
     }
     const wireProtocolId = options.protocolId ?? POOLED_MESSAGE_PROTOCOL;
+    // Thread the router's `peerResolver` into the pool unless the
+    // caller already supplied a `primePeer` hook. Without this, the
+    // pool would skip resolver priming and regress first-contact
+    // delivery to cold peers (Codex PR #560 review). The router's
+    // own one-shot path already primes per RFC 07 §3.2; this just
+    // keeps the pooled path on parity.
+    const peerResolver = this.peerResolver;
+    const primePeer =
+      options.primePeer ??
+      (peerResolver
+        ? async (peerIdStr: string, opts: { signal?: AbortSignal }) => {
+            await peerResolver
+              .resolve(peerIdStr, { signal: opts.signal })
+              .catch(() => undefined);
+          }
+        : undefined);
     const pool = new MessageStreamPool(
       // The node shape required by the pool overlaps with DKGNode but
       // is narrower; pass the node directly (DKGNode satisfies the
@@ -201,6 +216,7 @@ export class ProtocolRouter {
         ...options,
         protocolId: wireProtocolId,
         maxFrameBytes: options.maxFrameBytes ?? this.maxReadBytes,
+        primePeer,
       },
     );
     this.pooledByLogical.set(logicalProtocolId, {
@@ -350,7 +366,8 @@ export class ProtocolRouter {
     // genuine transport failure into a phantom one-shot fallback and
     // mask the underlying issue.
     const overlay = this.pooledByLogical.get(protocolId);
-    if (overlay && this.peerWireVariantFor(peerIdStr, protocolId) !== 'one-shot') {
+    const memoizedVariant = this.peerWireVariantFor(peerIdStr, protocolId);
+    if (overlay && memoizedVariant !== 'one-shot') {
       try {
         const response = await overlay.pool.send(peerIdStr, data, {
           signal: AbortSignal.timeout(timeoutMs),
@@ -359,19 +376,34 @@ export class ProtocolRouter {
         return response;
       } catch (err) {
         if (isProtocolUnsupportedError(err)) {
-          // Peer doesn't advertise the pooled wire variant. Pin to
-          // one-shot for future sends; fall through to existing
-          // single-path / multi-path logic below.
+          // Definitive: peer doesn't advertise the pooled wire
+          // variant. Pin to one-shot for future sends; fall through
+          // to existing single-path / multi-path logic below.
           this.memoizePeerWire(peerIdStr, protocolId, 'one-shot');
-        } else if (err instanceof PooledStreamResetError) {
-          // Pool-level reset: don't fall through (would silently
-          // double-send on a stream that the pool will re-open on
-          // the next call). Surface the recoverable error to the
-          // caller so the substrate retries through the pool path
-          // next attempt.
+        } else if (memoizedVariant === 'pooled') {
+          // Peer is KNOWN to speak the pooled wire (we've delivered
+          // on it before). This is a transient failure on the held
+          // stream — the pool has already torn down state and will
+          // reopen on the next call. Bubble the recoverable error
+          // so the substrate's outbox retries on the pooled wire
+          // rather than silently switching to one-shot (which would
+          // pay a fresh dial cost when the next pooled retry would
+          // succeed). Codex PR #560 round 1.
           throw err;
         } else {
-          throw err;
+          // First contact + non-protocol error (no valid addresses,
+          // dial timeout, ECONNRESET, etc.). Without this fallback,
+          // enabling pooling would regress first-contact delivery
+          // versus the one-shot path: one-shot has the full
+          // resolver-re-prime + 3x retry budget INTERNAL to a
+          // single send, while the pool has just one dial attempt.
+          // Codex PR #560 round 1 caught this.
+          //
+          // Fall through to one-shot WITHOUT memoizing — next send
+          // retries the pool, and if it succeeds we transition to
+          // pooled steady-state. We only memoize on a definitive
+          // negotiation outcome (success → pooled, unsupported →
+          // one-shot).
         }
       }
     }

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -333,11 +333,29 @@ export class ProtocolRouter {
   unregister(protocolId: string): void {
     this.handlers.delete(protocolId);
     this.node.libp2p.unhandle(protocolId);
-    // If we had a pooled overlay for this logical protocol, leave
-    // it in place — the pool's libp2p.handle was already
-    // unregistered by `closePooling` if that path was used; bare
-    // `unregister` is a per-handler operation that doesn't touch
-    // the pool.
+    // If a pooled overlay is attached to this logical protocol, tear
+    // it down too. Codex PR #560 round-2: leaving the overlay alive
+    // means the `/dkg/10.0.2/...` wire handler stays advertised on
+    // libp2p, and any peer that already memoized this side as
+    // "pooled" will keep dialing the wire variant — but the inbound
+    // handler is gone, so each dial answers "no application
+    // handler" instead of cleanly falling back. The pool's
+    // `close()` `unhandle`s its wire protocol AND rejects every
+    // outstanding request with a recoverable error (substrate
+    // outbox retries → next dial sees protocol-unsupported → memo
+    // flips to one-shot → fallback path runs).
+    //
+    // Fire-and-forget the async close: `unregister` is sync by
+    // contract, and the close is idempotent + safe even if the
+    // pool tears down before its handlers detach from libp2p.
+    // Errors are swallowed (a teardown failure here doesn't block
+    // re-registration).
+    const overlay = this.pooledByLogical.get(protocolId);
+    if (overlay) {
+      this.pooledByLogical.delete(protocolId);
+      this.logicalByWire.delete(overlay.pool.pooledProtocolId);
+      overlay.pool.close().catch(() => undefined);
+    }
   }
 
   async send(
@@ -371,6 +389,14 @@ export class ProtocolRouter {
       try {
         const response = await overlay.pool.send(peerIdStr, data, {
           signal: AbortSignal.timeout(timeoutMs),
+          // Thread the router's per-call timeout into the pool's
+          // own request timer so a caller asking for, say, 60s
+          // isn't silently capped at the pool's 20s default. The
+          // pool's signal-abort path covers the wall-clock budget;
+          // the request-timer is the in-pool fallback when the
+          // signal isn't observed (e.g. mid-write). Codex PR #560
+          // round 2.
+          timeoutMs,
         });
         this.memoizePeerWire(peerIdStr, protocolId, 'pooled');
         return response;

--- a/packages/core/test/message-frame.test.ts
+++ b/packages/core/test/message-frame.test.ts
@@ -46,6 +46,31 @@ describe('encodeVarint / tryDecodeVarint', () => {
     expect(() => tryDecodeVarint(overlong, 0)).toThrow(/exceeds 5 bytes/);
   });
 
+  it('rejects 5-byte varints whose high bits would exceed 32-bit range (Codex #560 round 1)', () => {
+    // 5-byte varint with the 5th byte payload = 0x10 (decimal 16):
+    // value = 0 + 0*7 + 0*14 + 0*21 + 16*2^28 = 0x100000000 = 2^32.
+    // 32-bit unsigned only supports 0..2^32-1, so this MUST throw
+    // rather than silently wrapping (the old `<<` impl truncated
+    // the high bits and returned a much smaller value, letting a
+    // malicious frame-length prefix desynchronise the decoder).
+    const bytes = new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x10]);
+    expect(() => tryDecodeVarint(bytes, 0)).toThrow(/exceeds 32-bit range/);
+
+    // 5-byte varint with the 5th byte payload = 0x7f (the MAX
+    // possible 7-bit payload). This is way beyond 2^32; must also
+    // throw.
+    const bytesMax = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x7f]);
+    expect(() => tryDecodeVarint(bytesMax, 0)).toThrow(/exceeds 32-bit range/);
+  });
+
+  it('accepts the largest valid 5-byte varint (2^32 - 1)', () => {
+    // 4 high-bit continuation bytes of 0xff + final byte 0x0f.
+    // value = 0x7f + 0x7f<<7 + 0x7f<<14 + 0x7f<<21 + 0x0f<<28
+    //       = 0x0fffffff + 0xf0000000 = 0xffffffff = 4294967295
+    const bytes = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x0f]);
+    expect(tryDecodeVarint(bytes, 0)).toEqual({ value: 0xffffffff, bytesRead: 5 });
+  });
+
   it('throws on out-of-range input to encodeVarint', () => {
     expect(() => encodeVarint(-1)).toThrow(RangeError);
     expect(() => encodeVarint(1.5)).toThrow(RangeError);

--- a/packages/core/test/message-frame.test.ts
+++ b/packages/core/test/message-frame.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FrameType,
+  encodeFrame,
+  encodeVarint,
+  tryDecodeVarint,
+  decodeFrames,
+  DEFAULT_MAX_FRAME_BYTES,
+} from '../src/message-frame.js';
+
+describe('encodeVarint / tryDecodeVarint', () => {
+  it('round-trips small values in one byte', () => {
+    for (const v of [0, 1, 5, 0x7f]) {
+      const buf = encodeVarint(v);
+      expect(buf.length).toBe(1);
+      const dec = tryDecodeVarint(buf, 0);
+      expect(dec).toEqual({ value: v, bytesRead: 1 });
+    }
+  });
+
+  it('round-trips two-byte values', () => {
+    for (const v of [0x80, 0x3fff, 1234]) {
+      const buf = encodeVarint(v);
+      expect(buf.length).toBe(2);
+      const dec = tryDecodeVarint(buf, 0);
+      expect(dec).toEqual({ value: v, bytesRead: 2 });
+    }
+  });
+
+  it('round-trips multi-byte values up to 2^32-1', () => {
+    for (const v of [0x1fffff, 0xffffffff]) {
+      const buf = encodeVarint(v);
+      const dec = tryDecodeVarint(buf, 0);
+      expect(dec).toEqual({ value: v, bytesRead: buf.length });
+    }
+  });
+
+  it('returns null when the buffer ends mid-varint', () => {
+    // 0x80 continuation byte with nothing after it — partial varint.
+    expect(tryDecodeVarint(new Uint8Array([0x80]), 0)).toBeNull();
+    expect(tryDecodeVarint(new Uint8Array([]), 0)).toBeNull();
+  });
+
+  it('throws on overlong varint', () => {
+    const overlong = new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x80, 0x01]);
+    expect(() => tryDecodeVarint(overlong, 0)).toThrow(/exceeds 5 bytes/);
+  });
+
+  it('throws on out-of-range input to encodeVarint', () => {
+    expect(() => encodeVarint(-1)).toThrow(RangeError);
+    expect(() => encodeVarint(1.5)).toThrow(RangeError);
+    expect(() => encodeVarint(0xffffffff + 1)).toThrow(RangeError);
+  });
+});
+
+describe('encodeFrame', () => {
+  it('encodes PING as 2 bytes (length=1, type=0x04, no payload)', () => {
+    const f = encodeFrame(FrameType.PING);
+    expect(Array.from(f)).toEqual([0x01, FrameType.PING]);
+  });
+
+  it('encodes a REQUEST frame with payload', () => {
+    const payload = new TextEncoder().encode('hi');
+    const f = encodeFrame(FrameType.REQUEST, payload);
+    // body = type(1) + 'hi'(2) = 3 bytes; length-prefix = 0x03
+    expect(Array.from(f)).toEqual([0x03, FrameType.REQUEST, 0x68, 0x69]);
+  });
+
+  it('handles a large payload without throwing', () => {
+    const payload = new Uint8Array(200_000);
+    payload.fill(0xab);
+    const f = encodeFrame(FrameType.RESPONSE, payload);
+    // length-prefix uses 3 bytes for 200_001
+    expect(f.length).toBe(3 + 1 + 200_000);
+  });
+});
+
+async function* arrAsAsync<T>(arr: T[]): AsyncGenerator<T, void, void> {
+  for (const v of arr) yield v;
+}
+
+describe('decodeFrames', () => {
+  it('decodes a sequence of frames from one contiguous buffer', async () => {
+    const reqA = encodeFrame(FrameType.REQUEST, new TextEncoder().encode('A'));
+    const reqB = encodeFrame(FrameType.REQUEST, new TextEncoder().encode('BB'));
+    const ping = encodeFrame(FrameType.PING);
+    const merged = new Uint8Array(reqA.length + reqB.length + ping.length);
+    merged.set(reqA, 0);
+    merged.set(reqB, reqA.length);
+    merged.set(ping, reqA.length + reqB.length);
+
+    const frames = [];
+    for await (const f of decodeFrames(arrAsAsync([merged]))) {
+      frames.push(f);
+    }
+    expect(frames.map((f) => f.type)).toEqual([
+      FrameType.REQUEST,
+      FrameType.REQUEST,
+      FrameType.PING,
+    ]);
+    expect(new TextDecoder().decode(frames[0].payload)).toBe('A');
+    expect(new TextDecoder().decode(frames[1].payload)).toBe('BB');
+    expect(frames[2].payload.length).toBe(0);
+  });
+
+  it('decodes frames split across chunk boundaries (mid-length, mid-body)', async () => {
+    const payload = new Uint8Array(200);
+    payload.fill(0x42);
+    const frame = encodeFrame(FrameType.RESPONSE, payload);
+
+    // Split into 1-byte chunks to stress every boundary.
+    const chunks: Uint8Array[] = [];
+    for (let i = 0; i < frame.length; i++) {
+      chunks.push(frame.slice(i, i + 1));
+    }
+    const frames = [];
+    for await (const f of decodeFrames(arrAsAsync(chunks))) {
+      frames.push(f);
+    }
+    expect(frames.length).toBe(1);
+    expect(frames[0].type).toBe(FrameType.RESPONSE);
+    expect(frames[0].payload.length).toBe(200);
+    expect(frames[0].payload[0]).toBe(0x42);
+  });
+
+  it('handles empty chunks emitted at backpressure boundaries', async () => {
+    const f = encodeFrame(FrameType.PONG);
+    const chunks: Uint8Array[] = [
+      new Uint8Array(0),
+      f.slice(0, 1),
+      new Uint8Array(0),
+      f.slice(1),
+    ];
+    const frames = [];
+    for await (const x of decodeFrames(arrAsAsync(chunks))) {
+      frames.push(x);
+    }
+    expect(frames.length).toBe(1);
+    expect(frames[0].type).toBe(FrameType.PONG);
+  });
+
+  it('throws when a frame body exceeds the configured cap', async () => {
+    // Length prefix says 10 bytes but we cap at 4.
+    const length = encodeVarint(10);
+    const stub = new Uint8Array(length.length + 10);
+    stub.set(length, 0);
+    await expect(async () => {
+      const frames = [];
+      for await (const f of decodeFrames(arrAsAsync([stub]), 4)) frames.push(f);
+    }).rejects.toThrow(/exceeds cap/);
+  });
+
+  it('throws when stream ends mid-frame', async () => {
+    // Promise length=5, deliver only 3 bytes total.
+    const partial = new Uint8Array([0x05, 0x01, 0xaa]);
+    await expect(async () => {
+      const frames = [];
+      for await (const f of decodeFrames(arrAsAsync([partial]))) frames.push(f);
+    }).rejects.toThrow(/ended mid-frame/);
+  });
+
+  it('returns cleanly on EOF before any frame bytes', async () => {
+    const frames = [];
+    for await (const f of decodeFrames(arrAsAsync<Uint8Array>([]))) frames.push(f);
+    expect(frames).toEqual([]);
+  });
+
+  it('default cap is 10 MiB', () => {
+    expect(DEFAULT_MAX_FRAME_BYTES).toBe(10 * 1024 * 1024);
+  });
+});

--- a/packages/core/test/message-stream-pool.test.ts
+++ b/packages/core/test/message-stream-pool.test.ts
@@ -688,6 +688,43 @@ describe('MessageStreamPool', () => {
     await pool.close();
   });
 
+  it('inbound stream closes local half on remote clean EOF (Codex #560 round 5)', async () => {
+    let stubHandle:
+      | ((stream: unknown, conn: { remotePeer: unknown }) => void)
+      | null = null;
+    const pool = new MessageStreamPool(
+      {
+        libp2p: {
+          dialProtocol: () => { throw new Error('not used'); },
+          handle: (
+            _p: string,
+            h: (stream: unknown, conn: { remotePeer: unknown }) => void,
+          ) => { stubHandle = h; },
+          unhandle: () => undefined,
+        },
+      } as unknown as PoolNode,
+      { keepaliveIntervalMs: 0, idleTimeoutMs: 0 },
+    );
+    pool.registerHandler(async () => new TextEncoder().encode('ack'));
+    expect(stubHandle).not.toBeNull();
+
+    const inboundStream = new FakeStream();
+    stubHandle!(inboundStream as unknown, { remotePeer: { toString: () => PEER_A } });
+    await flush();
+    // Remote closes its write side cleanly — no frames, just EOF.
+    inboundStream.endRemote();
+    // Let the handler's for-await loop exit + finally run.
+    await flush();
+    await flush();
+    await flush();
+    // Local half should now be closed — without the round-5 fix
+    // it stayed 'open'.
+    expect(inboundStream.writeStatus).toBe('closed');
+    expect(inboundStream.abortReason).toBeNull(); // ← graceful, not abort
+
+    await pool.close();
+  });
+
   it('inbound handler receives the full remotePeer object (real PeerId parity, Codex #560 round 3)', async () => {
     let stubHandle:
       | ((stream: unknown, conn: { remotePeer: unknown }) => void)

--- a/packages/core/test/message-stream-pool.test.ts
+++ b/packages/core/test/message-stream-pool.test.ts
@@ -1,0 +1,556 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  MessageStreamPool,
+  POOLED_MESSAGE_PROTOCOL,
+  PooledStreamResetError,
+  type PoolNode,
+  type PooledStreamHandler,
+} from '../src/message-stream-pool.js';
+import {
+  FrameType,
+  encodeFrame,
+  decodeFrames,
+} from '../src/message-frame.js';
+
+/**
+ * A pairable in-memory libp2p stream stub. Reads block on an async
+ * queue; writes either go to a sibling stream's read queue (via
+ * {@link pair}) or are buffered for inspection.
+ */
+class FakeStream {
+  writeStatus: 'open' | 'closing' | 'closed' = 'open';
+  readonly sent: Uint8Array[] = [];
+  private readBuf: Uint8Array[] = [];
+  private waiters: Array<(v: IteratorResult<Uint8Array>) => void> = [];
+  private ended = false;
+  private peer: FakeStream | null = null;
+  abortReason: Error | null = null;
+
+  send(data: Uint8Array): void {
+    if (this.writeStatus !== 'open') throw new Error('stream closed for write');
+    const copy = new Uint8Array(data);
+    this.sent.push(copy);
+    if (this.peer) {
+      this.peer.feed(copy);
+    }
+  }
+
+  feed(data: Uint8Array): void {
+    if (this.ended) return;
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ value: data, done: false });
+    } else {
+      this.readBuf.push(data);
+    }
+  }
+
+  endRemote(): void {
+    this.ended = true;
+    while (this.waiters.length) {
+      const w = this.waiters.shift()!;
+      w({ value: undefined as unknown as Uint8Array, done: true });
+    }
+  }
+
+  abort(err: Error): void {
+    this.abortReason = err;
+    this.writeStatus = 'closed';
+    this.endRemote();
+    if (this.peer) {
+      this.peer.endRemote();
+    }
+  }
+
+  async close(): Promise<void> {
+    this.writeStatus = 'closed';
+  }
+
+  pair(other: FakeStream): void {
+    this.peer = other;
+    other.peer = this;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+    return {
+      next: () => {
+        if (this.readBuf.length > 0) {
+          return Promise.resolve({ value: this.readBuf.shift()!, done: false });
+        }
+        if (this.ended) {
+          return Promise.resolve({ value: undefined as unknown as Uint8Array, done: true });
+        }
+        return new Promise((resolve) => {
+          this.waiters.push(resolve);
+        });
+      },
+    };
+  }
+}
+
+interface FakeNodeState {
+  /** Recorded dial attempts per peer (count). */
+  dials: Map<string, number>;
+  /** Streams the node returned from its most recent dialProtocol per peer. */
+  streams: Map<string, FakeStream>;
+  /** Registered inbound handler for the protocol, if any. */
+  inboundHandler: ((stream: FakeStream, peerStr: string) => void) | null;
+  /** Inbound side's stream (the receiving fake). */
+  inboundStreams: Map<string, FakeStream>;
+}
+
+interface FakeNode extends PoolNode {
+  state: FakeNodeState;
+  // Manually drive a remote dial: the test acts as the peer dialling
+  // INTO this node. Returns the stream the node's handler is reading
+  // from (so the test can write requests into it).
+  simulateInboundDial(remotePeerStr: string): { remoteWrites: FakeStream; localReads: FakeStream };
+}
+
+function makeFakeNode(opts: {
+  /**
+   * Optional override: when the pool dials a peer, the test wants to
+   * control what stream comes back. By default, the node creates a
+   * paired stream and returns one side; the test gets the other via
+   * `state.streams.get(peerIdStr)` (the side the node returned to
+   * the pool's caller).
+   *
+   * Returning `null` simulates a dial failure (test passes the
+   * thrown error in).
+   */
+  onDial?: (peerIdStr: string) => Promise<FakeStream | null>;
+} = {}): FakeNode {
+  const state: FakeNodeState = {
+    dials: new Map(),
+    streams: new Map(),
+    inboundHandler: null,
+    inboundStreams: new Map(),
+  };
+  const node: FakeNode = {
+    state,
+    libp2p: {
+      dialProtocol: async (peerId, _protocols, _options) => {
+        const peerIdStr =
+          typeof peerId === 'string' ? peerId : (peerId as { toString: () => string }).toString();
+        state.dials.set(peerIdStr, (state.dials.get(peerIdStr) ?? 0) + 1);
+        if (opts.onDial) {
+          const s = await opts.onDial(peerIdStr);
+          if (s === null) throw new Error('dial rejected');
+          state.streams.set(peerIdStr, s);
+          return s as unknown as import('@libp2p/interface').Stream;
+        }
+        const stream = new FakeStream();
+        state.streams.set(peerIdStr, stream);
+        return stream as unknown as import('@libp2p/interface').Stream;
+      },
+      handle: (_protocolId, handler, _opts) => {
+        state.inboundHandler = (s, peerStr) =>
+          handler(s as unknown as import('@libp2p/interface').Stream, {
+            remotePeer: { toString: () => peerStr },
+          });
+      },
+      unhandle: () => {
+        state.inboundHandler = null;
+      },
+    },
+    simulateInboundDial(remotePeerStr: string) {
+      // remoteWrites — what the dialer (the peer) writes into.
+      // localReads — what the node reads from.
+      // They're paired so writing into one feeds the other's read.
+      const localReads = new FakeStream();
+      const remoteWrites = new FakeStream();
+      // Pair them: writing to remoteWrites feeds localReads; writing
+      // to localReads feeds remoteWrites.
+      remoteWrites.pair(localReads);
+      state.inboundStreams.set(remotePeerStr, localReads);
+      if (state.inboundHandler) {
+        state.inboundHandler(localReads, remotePeerStr);
+      }
+      return { remoteWrites, localReads };
+    },
+  };
+  return node;
+}
+
+const PEER_A = '12D3KooWPeerA0000000000000000000000000000000000000000aaaa';
+const PEER_B = '12D3KooWPeerB0000000000000000000000000000000000000000bbbb';
+
+/**
+ * Drain the microtask queue. We don't know exactly how many awaits
+ * the dial+install chain costs (resolvePeerId + dialProtocol +
+ * installState + dispatchSend), so flush generously.
+ */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 30; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('MessageStreamPool', () => {
+  // Skip libp2p's peerIdFromString import in tests via stub.
+  const stubPeerIdFromString = (s: string): unknown => ({ toString: () => s });
+
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('opens one stream per peer and reuses it across sends', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const sendPromise1 = pool.send(PEER_A, new TextEncoder().encode('hello'));
+    // Wait a tick for the dial + stream wire-up.
+    await flush();
+    await flush();
+
+    const dialedStream = node.state.streams.get(PEER_A)!;
+    expect(dialedStream).toBeDefined();
+    // First REQUEST frame should be in `sent`.
+    expect(dialedStream.sent.length).toBeGreaterThanOrEqual(1);
+
+    // Simulate response from peer.
+    dialedStream.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('world')));
+    const resp1 = await sendPromise1;
+    expect(new TextDecoder().decode(resp1)).toBe('world');
+
+    // Second send should NOT open a new stream.
+    const sendPromise2 = pool.send(PEER_A, new TextEncoder().encode('hello2'));
+    await flush();
+    await flush();
+    expect(node.state.dials.get(PEER_A)).toBe(1);
+    dialedStream.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('world2')));
+    const resp2 = await sendPromise2;
+    expect(new TextDecoder().decode(resp2)).toBe('world2');
+
+    await pool.close();
+  });
+
+  it('serialises in-flight sends per peer (FIFO)', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const a = pool.send(PEER_A, new TextEncoder().encode('a'));
+    const b = pool.send(PEER_A, new TextEncoder().encode('b'));
+    const c = pool.send(PEER_A, new TextEncoder().encode('c'));
+
+    // Let the pool drain its work.
+    await flush();
+    await flush();
+
+    const s = node.state.streams.get(PEER_A)!;
+    // Only ONE REQUEST should be written so far (serial).
+    let requestFrames = 0;
+    for (const w of s.sent) {
+      const ft = w[1];
+      if (ft === FrameType.REQUEST) requestFrames += 1;
+    }
+    expect(requestFrames).toBe(1);
+
+    // Answer first; second should now go out.
+    s.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('A')));
+    expect(new TextDecoder().decode(await a)).toBe('A');
+
+    // After the response, the next REQUEST should have been pumped.
+    await flush();
+    await flush();
+    requestFrames = 0;
+    for (const w of s.sent) {
+      const ft = w[1];
+      if (ft === FrameType.REQUEST) requestFrames += 1;
+    }
+    expect(requestFrames).toBe(2);
+
+    s.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('B')));
+    expect(new TextDecoder().decode(await b)).toBe('B');
+
+    await flush();
+    await flush();
+    s.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('C')));
+    expect(new TextDecoder().decode(await c)).toBe('C');
+
+    await pool.close();
+  });
+
+  it('opens separate streams per peer (no cross-contamination)', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const a = pool.send(PEER_A, new TextEncoder().encode('to-A'));
+    const b = pool.send(PEER_B, new TextEncoder().encode('to-B'));
+
+    await flush();
+    await flush();
+
+    expect(node.state.dials.get(PEER_A)).toBe(1);
+    expect(node.state.dials.get(PEER_B)).toBe(1);
+
+    const sA = node.state.streams.get(PEER_A)!;
+    const sB = node.state.streams.get(PEER_B)!;
+
+    sA.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('respA')));
+    sB.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('respB')));
+
+    expect(new TextDecoder().decode(await a)).toBe('respA');
+    expect(new TextDecoder().decode(await b)).toBe('respB');
+
+    await pool.close();
+  });
+
+  it('rejects pending sends on stream reset (recoverable)', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await flush();
+    await flush();
+    const stream = node.state.streams.get(PEER_A)!;
+    stream.abort(new Error('peer reset'));
+    await expect(pSend).rejects.toBeInstanceOf(PooledStreamResetError);
+  });
+
+  it('reopens stream on next send after reset', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const a = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await flush();
+    await flush();
+    const first = node.state.streams.get(PEER_A)!;
+    first.abort(new Error('peer reset'));
+    await expect(a).rejects.toBeInstanceOf(PooledStreamResetError);
+
+    // Allow the teardown to propagate.
+    await flush();
+    await flush();
+
+    const b = pool.send(PEER_A, new TextEncoder().encode('hi2'));
+    await flush();
+    await flush();
+    expect(node.state.dials.get(PEER_A)).toBe(2);
+    const second = node.state.streams.get(PEER_A)!;
+    expect(second).not.toBe(first);
+    second.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')));
+    expect(new TextDecoder().decode(await b)).toBe('ok');
+
+    await pool.close();
+  });
+
+  it('responds to PING with PONG on outbound stream', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    // Force-open a stream by sending a dummy.
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('warm'));
+    await flush();
+    await flush();
+    const s = node.state.streams.get(PEER_A)!;
+    // Server sends PING; pool should respond PONG.
+    s.feed(encodeFrame(FrameType.PING));
+    await flush();
+    await flush();
+    // Among s.sent, find a PONG frame.
+    const sawPong = s.sent.some((buf) => buf[1] === FrameType.PONG);
+    expect(sawPong).toBe(true);
+    // The original send is still pending — answer it so the test
+    // doesn't hang on cleanup.
+    s.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')));
+    await pSend;
+    await pool.close();
+  });
+
+  it('keepalive timer emits PING frames after the configured interval', async () => {
+    vi.useFakeTimers();
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 5000,
+      idleTimeoutMs: 0,
+    });
+
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('warm'));
+    // Give the dial a real-timer microtask window to settle.
+    await vi.advanceTimersByTimeAsync(0);
+    const s = node.state.streams.get(PEER_A)!;
+    s.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')));
+    await pSend;
+    expect(s.sent.some((b) => b[1] === FrameType.PING)).toBe(false);
+
+    // Advance past one keepalive interval.
+    await vi.advanceTimersByTimeAsync(5500);
+    expect(s.sent.some((b) => b[1] === FrameType.PING)).toBe(true);
+
+    await pool.close();
+    vi.useRealTimers();
+  });
+
+  it('idle timeout closes the stream when inactive', async () => {
+    vi.useFakeTimers();
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 3000,
+    });
+
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await vi.advanceTimersByTimeAsync(0);
+    const s = node.state.streams.get(PEER_A)!;
+    s.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')));
+    await pSend;
+    // Pool stats present.
+    expect(pool.stats(PEER_A)).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(3500);
+    // After idle timeout, the per-peer state should be gone.
+    expect(pool.stats(PEER_A)).toBeUndefined();
+
+    await pool.close();
+    vi.useRealTimers();
+  });
+
+  it('inbound handler answers framed requests', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const handler: PooledStreamHandler = async (req) => {
+      return new TextEncoder().encode(`echo:${new TextDecoder().decode(req)}`);
+    };
+    pool.registerHandler(handler);
+
+    // Simulate the remote peer dialling into us.
+    const { remoteWrites } = node.simulateInboundDial(PEER_B);
+    // Send a REQUEST frame from the "remote" side.
+    remoteWrites.send(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('ping')));
+
+    // The handler will respond on the localReads side; we set up the
+    // pair so feeding remoteWrites goes to localReads. We read what
+    // the handler wrote BACK by inspecting remoteWrites.sent (which
+    // is paired with localReads, so writes from localReads-side
+    // appear in remoteWrites's read buffer / sent... wait, our
+    // FakeStream pair semantics are: each side's `send` feeds the
+    // peer's read queue. The remoteWrites side's reads = what the
+    // handler wrote.
+
+    // Wait for handler dispatch.
+    let response: { type: FrameType; payload: Uint8Array } | undefined;
+    const expectedFrame = encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('echo:ping'));
+    void expectedFrame;
+    for (let i = 0; i < 50; i++) {
+      // Drain anything the remote side received from the handler.
+      // remoteWrites is the dialer side; reads come from its async
+      // iterator. Use a probe iterator.
+      const buf: Uint8Array[] = [];
+      // Pull whatever is currently buffered.
+      // Since FakeStream's iterator awaits new data, we peek by
+      // resolving microtasks.
+      await flush();
+      await flush();
+      // Combine accumulated reads from remoteWrites:
+      const accum = (remoteWrites as unknown as { readBuf: Uint8Array[] }).readBuf;
+      if (accum.length > 0) {
+        buf.push(...accum);
+        for await (const f of decodeFrames(
+          (async function* () {
+            for (const c of buf) yield c;
+          })(),
+        )) {
+          response = f;
+          break;
+        }
+        break;
+      }
+    }
+    expect(response).toBeDefined();
+    expect(response!.type).toBe(FrameType.RESPONSE);
+    expect(new TextDecoder().decode(response!.payload)).toBe('echo:ping');
+
+    await pool.close();
+  });
+
+  it('inbound handler errors surface as ERROR frame, not stream teardown', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const handler: PooledStreamHandler = async () => {
+      throw new Error('boom');
+    };
+    pool.registerHandler(handler);
+
+    const { remoteWrites } = node.simulateInboundDial(PEER_B);
+    remoteWrites.send(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('?')));
+    // Drain.
+    let response: { type: FrameType; payload: Uint8Array } | undefined;
+    for (let i = 0; i < 50; i++) {
+      await flush();
+      const accum = (remoteWrites as unknown as { readBuf: Uint8Array[] }).readBuf;
+      if (accum.length > 0) {
+        for await (const f of decodeFrames(
+          (async function* () {
+            for (const c of accum) yield c;
+          })(),
+        )) {
+          response = f;
+          break;
+        }
+        break;
+      }
+    }
+    expect(response).toBeDefined();
+    expect(response!.type).toBe(FrameType.ERROR);
+    expect(new TextDecoder().decode(response!.payload)).toBe('boom');
+
+    await pool.close();
+  });
+
+  it('close() rejects pending sends and prevents new sends', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await flush();
+    await flush();
+    await pool.close();
+    await expect(pSend).rejects.toBeInstanceOf(PooledStreamResetError);
+    await expect(pool.send(PEER_A, new Uint8Array([0]))).rejects.toBeInstanceOf(PooledStreamResetError);
+  });
+
+  it('POOLED_MESSAGE_PROTOCOL is the wire-version-bump constant', () => {
+    expect(POOLED_MESSAGE_PROTOCOL).toBe('/dkg/10.0.2/message');
+  });
+});

--- a/packages/core/test/message-stream-pool.test.ts
+++ b/packages/core/test/message-stream-pool.test.ts
@@ -688,6 +688,105 @@ describe('MessageStreamPool', () => {
     await pool.close();
   });
 
+  it('inbound handler receives the full remotePeer object (real PeerId parity, Codex #560 round 3)', async () => {
+    let stubHandle:
+      | ((stream: unknown, conn: { remotePeer: unknown }) => void)
+      | null = null;
+    const pool = new MessageStreamPool(
+      {
+        libp2p: {
+          dialProtocol: () => { throw new Error('not used'); },
+          handle: (
+            _p: string,
+            h: (stream: unknown, conn: { remotePeer: unknown }) => void,
+          ) => {
+            stubHandle = h;
+          },
+          unhandle: () => undefined,
+        },
+      } as unknown as PoolNode,
+      { keepaliveIntervalMs: 0, idleTimeoutMs: 0 },
+    );
+    let handlerReceivedPeer: unknown = null;
+    pool.registerHandler(async (_data, peerId) => {
+      handlerReceivedPeer = peerId;
+      return new TextEncoder().encode('ack');
+    });
+    expect(stubHandle).not.toBeNull();
+
+    // Drive an inbound REQUEST through the libp2p.handle callback.
+    const inboundStream = new FakeStream();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    const productionLikePeer = {
+      toString: () => PEER_A,
+      toBytes: () => new Uint8Array([0x12, 0x34, 0x56]),
+      toMultihash: () => ({ bytes: new Uint8Array([0xde, 0xad, 0xbe, 0xef]) }),
+      equals: (_other: unknown) => false,
+    };
+    stubHandle!(inboundStream as unknown, { remotePeer: productionLikePeer });
+    await flush();
+    await flush();
+
+    // The handler must receive the EXACT remotePeer object — not a
+    // hollow `{ toString }` shim. This is what gives ProtocolRouter's
+    // wrapper access to `.toMultihash().bytes` for one-shot parity.
+    expect(handlerReceivedPeer).toBe(productionLikePeer);
+    const asPeer = handlerReceivedPeer as { toBytes: () => Uint8Array };
+    expect(Array.from(asPeer.toBytes())).toEqual([0x12, 0x34, 0x56]);
+
+    inboundStream.endRemote();
+    await pool.close();
+  });
+
+  it('graceful close uses stream.close() not stream.abort() (Codex #560 round 3)', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await flush();
+    const stream = node.state.streams.get(PEER_A)!;
+    expect(stream).toBeDefined();
+    // Complete the request normally so close() finds clean state.
+    stream.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')));
+    expect(new TextDecoder().decode(await pSend)).toBe('ok');
+
+    // Now close. This is an intentional teardown — must use FIN
+    // (stream.close()), not RST_STREAM (stream.abort()). Remote
+    // sees clean EOF; their messenger substrate does NOT re-enqueue
+    // anything as a transport error.
+    const closeStatusBefore = stream.writeStatus;
+    await pool.close();
+    expect(stream.writeStatus).toBe('closed');
+    expect(stream.abortReason).toBeNull(); // ← key assertion: NO abort
+    expect(closeStatusBefore).toBe('open');
+  });
+
+  it('error teardown still uses stream.abort() (graceful path is opt-in only)', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await flush();
+    const stream = node.state.streams.get(PEER_A)!;
+    expect(stream).toBeDefined();
+
+    // Simulate a transport-level reset from the remote: feed a
+    // malformed frame so the reader's decoder throws.
+    stream.feed(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
+    await flush();
+    await flush();
+    // The send should have rejected (recoverable).
+    await expect(pSend).rejects.toBeInstanceOf(PooledStreamResetError);
+    // Error path MUST abort (RST_STREAM), not gracefully close.
+    expect(stream.abortReason).not.toBeNull();
+  });
+
   it('honors caller-supplied timeoutMs above the pool default (Codex #560 round 2)', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/test/message-stream-pool.test.ts
+++ b/packages/core/test/message-stream-pool.test.ts
@@ -639,4 +639,89 @@ describe('MessageStreamPool', () => {
 
     await pool.close();
   });
+
+  it('rejects immediately if signal already aborted before send() (Codex #560 round 2)', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const ac = new AbortController();
+    ac.abort();
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('preborn'), { signal: ac.signal });
+    await expect(pSend).rejects.toThrow(/aborted/);
+    // Critically: no dial was attempted (we MUST NOT hit the wire
+    // for a request that was cancelled before it was even sent).
+    expect(node.state.dials.get(PEER_A) ?? 0).toBe(0);
+
+    await pool.close();
+  });
+
+  it('rejects if signal aborts mid-dial, without writing to the wire (Codex #560 round 2)', async () => {
+    let resolveDial: ((s: FakeStream) => void) | null = null;
+    const dialPromise = new Promise<FakeStream>((r) => {
+      resolveDial = r;
+    });
+    const node = makeFakeNode({
+      onDial: () => dialPromise,
+    });
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const ac = new AbortController();
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('inflight'), { signal: ac.signal });
+    await flush();
+    // Dial in flight, not yet resolved. Abort now.
+    ac.abort();
+    // Let the dial resolve AFTER abort.
+    const stream = new FakeStream();
+    resolveDial!(stream);
+    await expect(pSend).rejects.toThrow(/aborted/);
+    // The request must NOT have written to the stream.
+    expect(stream.sent.length).toBe(0);
+
+    await pool.close();
+  });
+
+  it('honors caller-supplied timeoutMs above the pool default (Codex #560 round 2)', async () => {
+    vi.useFakeTimers();
+    try {
+      const node = makeFakeNode();
+      const pool = new MessageStreamPool(node, {
+        peerIdFromString: stubPeerIdFromString,
+        keepaliveIntervalMs: 0,
+        idleTimeoutMs: 0,
+        requestTimeoutMs: 1000,
+      });
+
+      // Caller asks for 5x the pool default — must NOT be capped.
+      const pSend = pool.send(PEER_A, new TextEncoder().encode('long'), {
+        timeoutMs: 5000,
+      });
+      // Pump open + write paths.
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // At T=1500ms (past pool default), the request must still be pending.
+      await vi.advanceTimersByTimeAsync(1500);
+      let settled = false;
+      pSend.then(() => { settled = true; }, () => { settled = true; });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(settled).toBe(false);
+
+      // At T=5000ms (caller's budget), the request must reject with
+      // the pool's recoverable timeout error.
+      await vi.advanceTimersByTimeAsync(3600);
+      await expect(pSend).rejects.toBeInstanceOf(PooledStreamResetError);
+
+      await pool.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/core/test/message-stream-pool.test.ts
+++ b/packages/core/test/message-stream-pool.test.ts
@@ -787,6 +787,65 @@ describe('MessageStreamPool', () => {
     expect(stream.abortReason).not.toBeNull();
   });
 
+  it('one caller cancelling does not abort a shared open for another caller (Codex #560 round 4)', async () => {
+    // Hold the dial in flight so two concurrent callers serialize
+    // on the same `openLocks` promise.
+    let resolveDial: ((s: FakeStream) => void) | null = null;
+    const dialPromise = new Promise<FakeStream>((r) => { resolveDial = r; });
+    const node = makeFakeNode({ onDial: () => dialPromise });
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const acA = new AbortController();
+    const sendA = pool.send(PEER_A, new TextEncoder().encode('a'), { signal: acA.signal });
+    const sendB = pool.send(PEER_A, new TextEncoder().encode('b'));
+    await flush();
+    // Both share the same in-flight dial. A aborts.
+    acA.abort();
+    await expect(sendA).rejects.toThrow(/aborted/);
+    // Now the dial completes — B's request MUST still go through.
+    const stream = new FakeStream();
+    resolveDial!(stream);
+    await flush();
+    await flush();
+    // Only B should be in-flight on the stream now.
+    stream.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('b-ok')));
+    expect(new TextDecoder().decode(await sendB)).toBe('b-ok');
+    // Exactly ONE dial attempt was made (the shared open).
+    expect(node.state.dials.get(PEER_A)).toBe(1);
+
+    await pool.close();
+  });
+
+  it('close() during in-flight dial closes the resulting stream rather than installing it (Codex #560 round 4)', async () => {
+    let resolveDial: ((s: FakeStream) => void) | null = null;
+    const dialPromise = new Promise<FakeStream>((r) => { resolveDial = r; });
+    const node = makeFakeNode({ onDial: () => dialPromise });
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await flush();
+    // close() runs WHILE the dial is in flight.
+    const closing = pool.close();
+    // Now resolve the dial — pool must NOT install the stream.
+    const lateStream = new FakeStream();
+    resolveDial!(lateStream);
+    await closing;
+    await expect(pSend).rejects.toBeInstanceOf(PooledStreamResetError);
+    // No peer state was registered post-close.
+    expect(pool.size()).toBe(0);
+    // The late stream was aborted by the pool (no leaked alive stream).
+    await flush();
+    expect(lateStream.abortReason).not.toBeNull();
+  });
+
   it('honors caller-supplied timeoutMs above the pool default (Codex #560 round 2)', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/test/message-stream-pool.test.ts
+++ b/packages/core/test/message-stream-pool.test.ts
@@ -553,4 +553,90 @@ describe('MessageStreamPool', () => {
   it('POOLED_MESSAGE_PROTOCOL is the wire-version-bump constant', () => {
     expect(POOLED_MESSAGE_PROTOCOL).toBe('/dkg/10.0.2/message');
   });
+
+  it('aborting an in-flight request tears down the stream so the pool does not stall (Codex #560 round 1)', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    // Start a send that we will abort.
+    const ac = new AbortController();
+    const cancelled = pool.send(PEER_A, new TextEncoder().encode('first'), { signal: ac.signal });
+    await flush();
+    const firstStream = node.state.streams.get(PEER_A)!;
+    expect(firstStream).toBeDefined();
+    // Cancel mid-flight (no response fed yet).
+    ac.abort();
+    await expect(cancelled).rejects.toThrow(/aborted/);
+
+    // After cancel, the pool should have torn down state — next send
+    // opens a fresh stream rather than queuing behind the dead in-flight.
+    await flush();
+    const next = pool.send(PEER_A, new TextEncoder().encode('second'));
+    await flush();
+    expect(node.state.dials.get(PEER_A)).toBe(2);
+    const secondStream = node.state.streams.get(PEER_A)!;
+    expect(secondStream).not.toBe(firstStream);
+    secondStream.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')));
+    expect(new TextDecoder().decode(await next)).toBe('ok');
+
+    await pool.close();
+  });
+
+  it('runs primePeer before dialProtocol on first contact (Codex #560 round 1)', async () => {
+    let primed = false;
+    let dialed = false;
+    const node = makeFakeNode({
+      onDial: async () => {
+        // Dial must run AFTER prime — assert ordering by spying.
+        expect(primed).toBe(true);
+        dialed = true;
+        return new FakeStream();
+      },
+    });
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      primePeer: async () => {
+        primed = true;
+      },
+    });
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await flush();
+    expect(primed).toBe(true);
+    expect(dialed).toBe(true);
+
+    node.state.streams.get(PEER_A)!.feed(
+      encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')),
+    );
+    expect(new TextDecoder().decode(await pSend)).toBe('ok');
+
+    await pool.close();
+  });
+
+  it('primePeer failures are swallowed; dial still attempted', async () => {
+    const node = makeFakeNode();
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      primePeer: async () => {
+        throw new Error('DHT timeout');
+      },
+    });
+    const pSend = pool.send(PEER_A, new TextEncoder().encode('hi'));
+    await flush();
+    // Dial happened despite the prime throwing.
+    expect(node.state.dials.get(PEER_A)).toBe(1);
+    node.state.streams.get(PEER_A)!.feed(
+      encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')),
+    );
+    expect(new TextDecoder().decode(await pSend)).toBe('ok');
+
+    await pool.close();
+  });
 });

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -382,6 +382,32 @@ describe('ProtocolRouter pooled overlay', () => {
     await fixture.router.closePooling();
   });
 
+  it('throws when a second logical claims an already-used wire id (Codex #560 round 3)', () => {
+    const fixture = makeRouterFixture();
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+    // Second logical, default wire id (collides with first pool).
+    expect(() =>
+      fixture.router.enablePooling('/dkg/10.0.1/some-other-logical', {
+        keepaliveIntervalMs: 0,
+        idleTimeoutMs: 0,
+        peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+      }),
+    ).toThrow(/already claimed by/);
+    // Passing a DISTINCT wire id works.
+    expect(() =>
+      fixture.router.enablePooling('/dkg/10.0.1/some-other-logical', {
+        protocolId: '/dkg/10.0.3/some-other-wire',
+        keepaliveIntervalMs: 0,
+        idleTimeoutMs: 0,
+        peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+      }),
+    ).not.toThrow();
+  });
+
   it('unregister(logicalId) tears down the pooled wire handler (Codex #560 round 2)', async () => {
     const unhandleCalls: string[] = [];
     const fixture = makeRouterFixture({

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -278,7 +278,7 @@ describe('ProtocolRouter pooled overlay', () => {
     expect(fixture.router.pooledStatus()).toEqual([]);
   });
 
-  it('closePooling tears down peer state', async () => {
+  it('closePooling tears down peer state (live peer count drops to zero)', async () => {
     const fixture = makeRouterFixture();
     fixture.router.enablePooling('/dkg/10.0.1/message', {
       keepaliveIntervalMs: 0,
@@ -286,32 +286,41 @@ describe('ProtocolRouter pooled overlay', () => {
       peerIdFromString: (s) => ({ toString: () => s }) as unknown,
     });
 
+    // Open a stream + complete one request so the peer is fully
+    // established (we can then assert closePooling() drops it).
     const pSend = fixture.router.send(
       PEER_NEW,
       '/dkg/10.0.1/message',
       new TextEncoder().encode('a'),
     );
     await flush();
+    fixture.streamsByCall[0]!.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('ok')));
+    expect(new TextDecoder().decode(await pSend)).toBe('ok');
     expect(fixture.router.pooledStatus()[0].livePeers).toBe(1);
+
     await fixture.router.closePooling();
     expect(fixture.router.pooledStatus()).toEqual([]);
-    await expect(pSend).rejects.toThrow();
   });
 
-  it('pool-level transient errors do not silently fall back', async () => {
+  it('first-contact transient pool error falls through to one-shot (Codex #560 round 1)', async () => {
     let pooledCalls = 0;
     let logicalCalls = 0;
     const fixture = makeRouterFixture({
       onDial: async (_peer, protocols) => {
         if (protocols === POOLED_MESSAGE_PROTOCOL) {
           pooledCalls += 1;
-          // Simulate a transient transport error, NOT a protocol
-          // negotiation failure. Per design this should bubble up
-          // to the caller, not fall back to one-shot.
-          throw new Error('ECONNRESET');
+          // Cold-peer-class failure: no addresses in peerStore. Not
+          // a protocol-negotiation error; without fallback, enabling
+          // pooling would regress first-contact delivery.
+          throw new Error('The dial request has no valid addresses for peer');
         }
         logicalCalls += 1;
-        return new FakeStream();
+        const s = new FakeStream();
+        queueMicrotask(() => {
+          s.feed(new TextEncoder().encode('one-shot-resp'));
+          s.endRemote();
+        });
+        return s;
       },
     });
     fixture.router.enablePooling('/dkg/10.0.1/message', {
@@ -320,15 +329,92 @@ describe('ProtocolRouter pooled overlay', () => {
       peerIdFromString: (s) => ({ toString: () => s }) as unknown,
     });
 
+    const resp = await fixture.router.send(
+      PEER_NEW,
+      '/dkg/10.0.1/message',
+      new TextEncoder().encode('x'),
+    );
+    expect(new TextDecoder().decode(resp)).toBe('one-shot-resp');
+    expect(pooledCalls).toBe(1);
+    expect(logicalCalls).toBe(1);
+    // Crucially we do NOT memoize as one-shot — the failure was
+    // transient, not a definitive protocol-unsupported signal — so
+    // the next send retries the pool.
+    expect(fixture.router.peerWireVariantFor(PEER_NEW, '/dkg/10.0.1/message')).toBeUndefined();
+
+    await fixture.router.closePooling();
+  });
+
+  it('established pooled peer transient errors still bubble (no spurious wire switch)', async () => {
+    // Use a manual peer-wire memo so we can simulate "we already
+    // know this peer is pooled-capable" without the round-trip
+    // setup.
+    const fixture = makeRouterFixture({
+      onDial: async (_peer, protocols) => {
+        if (protocols === POOLED_MESSAGE_PROTOCOL) {
+          throw new Error('ECONNRESET');
+        }
+        return new FakeStream();
+      },
+    });
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+    // Manually mark the peer as pooled-capable.
+    fixture.router.memoizePeerWire(PEER_NEW, '/dkg/10.0.1/message', 'pooled');
+
     await expect(
       fixture.router.send(PEER_NEW, '/dkg/10.0.1/message', new TextEncoder().encode('x')),
     ).rejects.toThrow();
-    // Pool attempted, but we did NOT call into the one-shot path —
-    // surface to caller so substrate retries on the same wire.
-    expect(pooledCalls).toBe(1);
-    expect(logicalCalls).toBe(0);
+    // Wire memo is preserved — next outbox retry stays on pooled.
+    expect(fixture.router.peerWireVariantFor(PEER_NEW, '/dkg/10.0.1/message')).toBe('pooled');
 
     await fixture.router.closePooling();
+  });
+
+  it('primes peerResolver before pool dial (cold-peer recovery, Codex #560 round 1)', async () => {
+    const resolveCalls: string[] = [];
+    const peerResolver = {
+      resolve: async (peerIdStr: string) => {
+        resolveCalls.push(peerIdStr);
+        return [];
+      },
+    } as unknown as import('../src/network/peer-resolver.js').PeerResolver;
+    let dialCalls = 0;
+    const node = {
+      libp2p: {
+        dialProtocol: async () => {
+          dialCalls += 1;
+          // Assert the resolver ran BEFORE the dial.
+          expect(resolveCalls.length).toBeGreaterThan(0);
+          const s = new FakeStream();
+          return s as unknown as import('@libp2p/interface').Stream;
+        },
+        handle: () => undefined,
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+    const { ProtocolRouter } = await import('../src/protocol-router.js');
+    const router = new ProtocolRouter(node, { peerResolver });
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+    // Avoid awaiting the send — the FakeStream never responds, so
+    // the test's job is just to verify the prime → dial ordering
+    // happened. Swallow the eventual rejection so it doesn't leak
+    // as an unhandled promise.
+    const pSend = router.send(PEER_NEW, '/dkg/10.0.1/message', new TextEncoder().encode('a'));
+    pSend.catch(() => undefined);
+    await flush();
+    expect(resolveCalls).toEqual([PEER_NEW]);
+    expect(dialCalls).toBe(1);
+    await router.closePooling();
   });
 });
 

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ProtocolRouter,
+  isProtocolUnsupportedError,
+  POOLED_MESSAGE_PROTOCOL,
+} from '../src/index.js';
+import type { DKGNode } from '../src/node.js';
+import {
+  FrameType,
+  encodeFrame,
+  decodeFrames,
+} from '../src/message-frame.js';
+
+/**
+ * Pool-enabled `ProtocolRouter` integration tests. These verify the
+ * router-level negotiation: pool-first attempt, fall back to one-shot
+ * on multistream-select failure, peer-variant memoization, and
+ * end-to-end framed round-trip via the pool's inbound handler.
+ *
+ * The libp2p stub is intentionally narrower than the one in
+ * `protocol-router.test.ts` — we only need dialProtocol + handle +
+ * unhandle.
+ */
+
+/**
+ * Valid base58btc peer IDs — needed because the router's one-shot
+ * fallback path calls the real `peerIdFromString` from
+ * `@libp2p/peer-id`. The pooled path uses an injectable
+ * `peerIdFromString` stub, but the fallback escapes that boundary.
+ */
+const PEER_NEW = '12D3KooWBzj7Hg2cKCdsKL6QcjC5UbLztKTvzCZQHaT4P4ZyJEAA';
+const PEER_OLD = '12D3KooWGRUkpYzqu7w17X8YBaPDB6c7TuD3KSGmZSEpCpVjMx9V';
+
+class FakeStream {
+  writeStatus: 'open' | 'closing' | 'closed' = 'open';
+  readonly sent: Uint8Array[] = [];
+  private readBuf: Uint8Array[] = [];
+  private waiters: Array<(v: IteratorResult<Uint8Array>) => void> = [];
+  private ended = false;
+
+  send(data: Uint8Array): void {
+    if (this.writeStatus !== 'open') throw new Error('closed');
+    this.sent.push(new Uint8Array(data));
+  }
+
+  feed(data: Uint8Array): void {
+    if (this.ended) return;
+    const w = this.waiters.shift();
+    if (w) w({ value: data, done: false });
+    else this.readBuf.push(data);
+  }
+
+  endRemote(): void {
+    this.ended = true;
+    while (this.waiters.length) {
+      this.waiters.shift()!({ value: undefined as unknown as Uint8Array, done: true });
+    }
+  }
+
+  abort(_err: Error): void {
+    this.writeStatus = 'closed';
+    this.endRemote();
+  }
+
+  async close(): Promise<void> {
+    this.writeStatus = 'closed';
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+    return {
+      next: () => {
+        if (this.readBuf.length > 0) {
+          return Promise.resolve({ value: this.readBuf.shift()!, done: false });
+        }
+        if (this.ended) {
+          return Promise.resolve({ value: undefined as unknown as Uint8Array, done: true });
+        }
+        return new Promise((resolve) => this.waiters.push(resolve));
+      },
+    };
+  }
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 30; i++) await Promise.resolve();
+}
+
+interface RouterFixture {
+  router: ProtocolRouter;
+  dialedProtocols: Array<{ peer: string; protocols: string | string[] }>;
+  streamsByCall: FakeStream[];
+}
+
+function makeRouterFixture(opts: {
+  /**
+   * Decides how dialProtocol resolves for each (peer, protocols)
+   * tuple. Default: returns a fresh FakeStream for every protocol.
+   * Tests can pass a custom function to simulate fallback (e.g.
+   * throw on pooled protocol, succeed on logical).
+   */
+  onDial?: (peerStr: string, protocols: string | string[]) => Promise<FakeStream>;
+} = {}): RouterFixture {
+  const dialed: Array<{ peer: string; protocols: string | string[] }> = [];
+  const streamsByCall: FakeStream[] = [];
+  const node = {
+    libp2p: {
+      dialProtocol: async (peerId: unknown, protocols: string | string[], _options: unknown) => {
+        const peerStr = (peerId as { toString: () => string }).toString();
+        dialed.push({ peer: peerStr, protocols });
+        const stream = opts.onDial
+          ? await opts.onDial(peerStr, protocols)
+          : new FakeStream();
+        streamsByCall.push(stream);
+        return stream as unknown as import('@libp2p/interface').Stream;
+      },
+      handle: () => undefined,
+      unhandle: () => undefined,
+      getConnections: () => [],
+      peerStore: { get: async () => ({ addresses: [] }) },
+    },
+  } as unknown as DKGNode;
+  const router = new ProtocolRouter(node);
+  return { router, dialedProtocols: dialed, streamsByCall };
+}
+
+describe('ProtocolRouter pooled overlay', () => {
+  it('routes pooled-protocol sends through the pool when enabled', async () => {
+    const fixture = makeRouterFixture({
+      onDial: async (_peer, protocols) => {
+        // Pool dials with the pooled wire protocol only.
+        expect(protocols).toBe(POOLED_MESSAGE_PROTOCOL);
+        return new FakeStream();
+      },
+    });
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    const sendPromise = fixture.router.send(
+      PEER_NEW,
+      '/dkg/10.0.1/message',
+      new TextEncoder().encode('hello'),
+    );
+    await flush();
+    const stream = fixture.streamsByCall[0]!;
+    // First write should be a framed REQUEST.
+    expect(stream.sent.length).toBeGreaterThanOrEqual(1);
+    const firstFrame = stream.sent[0];
+    expect(firstFrame[1]).toBe(FrameType.REQUEST);
+
+    // Feed a framed RESPONSE.
+    stream.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('world')));
+    const resp = await sendPromise;
+    expect(new TextDecoder().decode(resp)).toBe('world');
+
+    // Pool status reflects one live peer.
+    const status = fixture.router.pooledStatus();
+    expect(status).toHaveLength(1);
+    expect(status[0].logicalProtocolId).toBe('/dkg/10.0.1/message');
+    expect(status[0].wireProtocolId).toBe(POOLED_MESSAGE_PROTOCOL);
+    expect(status[0].livePeers).toBe(1);
+
+    await fixture.router.closePooling();
+  });
+
+  it('reuses the pooled stream across multiple sends to the same peer', async () => {
+    const fixture = makeRouterFixture();
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    const p1 = fixture.router.send(PEER_NEW, '/dkg/10.0.1/message', new TextEncoder().encode('a'));
+    await flush();
+    const stream = fixture.streamsByCall[0]!;
+    stream.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('A')));
+    expect(new TextDecoder().decode(await p1)).toBe('A');
+
+    const p2 = fixture.router.send(PEER_NEW, '/dkg/10.0.1/message', new TextEncoder().encode('b'));
+    await flush();
+    // No second dial.
+    expect(fixture.dialedProtocols.length).toBe(1);
+    stream.feed(encodeFrame(FrameType.RESPONSE, new TextEncoder().encode('B')));
+    expect(new TextDecoder().decode(await p2)).toBe('B');
+
+    await fixture.router.closePooling();
+  });
+
+  it('falls back to one-shot when peer rejects pooled protocol', async () => {
+    let dialCallNo = 0;
+    const fixture = makeRouterFixture({
+      onDial: async (_peer, protocols) => {
+        dialCallNo += 1;
+        if (protocols === POOLED_MESSAGE_PROTOCOL) {
+          throw new Error('protocol selection failed - unsupported');
+        }
+        // One-shot dial — return a stream that closes after one
+        // response.
+        const s = new FakeStream();
+        // Simulate the receiver immediately responding to one-shot
+        // (raw bytes, no framing).
+        queueMicrotask(() => {
+          s.feed(new TextEncoder().encode('one-shot-resp'));
+          s.endRemote();
+        });
+        return s;
+      },
+    });
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    const resp = await fixture.router.send(
+      PEER_OLD,
+      '/dkg/10.0.1/message',
+      new TextEncoder().encode('x'),
+    );
+    expect(new TextDecoder().decode(resp)).toBe('one-shot-resp');
+    // Two dials: one pooled (rejected), then one one-shot.
+    expect(dialCallNo).toBe(2);
+
+    // Verify the peer is memoized as one-shot for subsequent sends.
+    expect(fixture.router.peerWireVariantFor(PEER_OLD, '/dkg/10.0.1/message')).toBe('one-shot');
+
+    await fixture.router.closePooling();
+  });
+
+  it('memoized one-shot peers skip the pooled attempt entirely', async () => {
+    let pooledDials = 0;
+    let oneShotDials = 0;
+    const fixture = makeRouterFixture({
+      onDial: async (_peer, protocols) => {
+        if (protocols === POOLED_MESSAGE_PROTOCOL) {
+          pooledDials += 1;
+          throw new Error('could not negotiate');
+        }
+        oneShotDials += 1;
+        const s = new FakeStream();
+        queueMicrotask(() => {
+          s.feed(new TextEncoder().encode('os'));
+          s.endRemote();
+        });
+        return s;
+      },
+    });
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    await fixture.router.send(PEER_OLD, '/dkg/10.0.1/message', new TextEncoder().encode('1'));
+    await fixture.router.send(PEER_OLD, '/dkg/10.0.1/message', new TextEncoder().encode('2'));
+
+    // Pooled attempted only ONCE — second send skipped it via memo.
+    expect(pooledDials).toBe(1);
+    expect(oneShotDials).toBe(2);
+
+    await fixture.router.closePooling();
+  });
+
+  it('isProtocolUnsupportedError matches multistream-select failure shapes', () => {
+    expect(isProtocolUnsupportedError(new Error('protocol selection failed: foo'))).toBe(true);
+    expect(isProtocolUnsupportedError(new Error('Could not negotiate /dkg/10.0.2/message'))).toBe(true);
+    expect(isProtocolUnsupportedError(new Error('Unsupported protocol'))).toBe(true);
+    expect(isProtocolUnsupportedError(new Error('Protocol mismatch'))).toBe(true);
+    expect(isProtocolUnsupportedError(new Error('ECONNRESET'))).toBe(false);
+    expect(isProtocolUnsupportedError(new Error('no valid addresses'))).toBe(false);
+  });
+
+  it('pooledStatus is empty when pooling not enabled', () => {
+    const fixture = makeRouterFixture();
+    expect(fixture.router.pooledStatus()).toEqual([]);
+  });
+
+  it('closePooling tears down peer state', async () => {
+    const fixture = makeRouterFixture();
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    const pSend = fixture.router.send(
+      PEER_NEW,
+      '/dkg/10.0.1/message',
+      new TextEncoder().encode('a'),
+    );
+    await flush();
+    expect(fixture.router.pooledStatus()[0].livePeers).toBe(1);
+    await fixture.router.closePooling();
+    expect(fixture.router.pooledStatus()).toEqual([]);
+    await expect(pSend).rejects.toThrow();
+  });
+
+  it('pool-level transient errors do not silently fall back', async () => {
+    let pooledCalls = 0;
+    let logicalCalls = 0;
+    const fixture = makeRouterFixture({
+      onDial: async (_peer, protocols) => {
+        if (protocols === POOLED_MESSAGE_PROTOCOL) {
+          pooledCalls += 1;
+          // Simulate a transient transport error, NOT a protocol
+          // negotiation failure. Per design this should bubble up
+          // to the caller, not fall back to one-shot.
+          throw new Error('ECONNRESET');
+        }
+        logicalCalls += 1;
+        return new FakeStream();
+      },
+    });
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    await expect(
+      fixture.router.send(PEER_NEW, '/dkg/10.0.1/message', new TextEncoder().encode('x')),
+    ).rejects.toThrow();
+    // Pool attempted, but we did NOT call into the one-shot path —
+    // surface to caller so substrate retries on the same wire.
+    expect(pooledCalls).toBe(1);
+    expect(logicalCalls).toBe(0);
+
+    await fixture.router.closePooling();
+  });
+});
+
+describe('ProtocolRouter pooled inbound handler', () => {
+  it('forwards framed REQUESTs to the registered application handler', async () => {
+    // For inbound, we need to invoke the libp2p handle callback ourselves.
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    const node = {
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          // Only capture the POOLED protocol handler; one-shot handlers
+          // for the logical id also call libp2p.handle but we don't
+          // exercise them in this test.
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node);
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+    router.register('/dkg/10.0.1/message', async (req, _peer) => {
+      return new TextEncoder().encode(`echo:${new TextDecoder().decode(req)}`);
+    });
+
+    expect(inboundHandler).toBeDefined();
+
+    // Simulate an inbound stream: feed REQUEST, expect RESPONSE.
+    const inboundStream = new FakeStream();
+    const probeStream = new FakeStream();
+    const remotePeerStr = PEER_NEW;
+    // Wire up so writes from the inbound side appear in the probe stream's
+    // read buffer. Easiest: re-use FakeStream's sent buffer to inspect.
+    void probeStream; // placeholder for clarity
+    // Kick the handler.
+    inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => remotePeerStr,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    // Feed a REQUEST frame.
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    await flush();
+    // The handler should have written a RESPONSE frame.
+    expect(inboundStream.sent.length).toBeGreaterThanOrEqual(1);
+    const parsed: { type: FrameType; payload: Uint8Array }[] = [];
+    for await (const f of decodeFrames(
+      (async function* () {
+        for (const c of inboundStream.sent) yield c;
+      })(),
+    )) {
+      parsed.push(f);
+    }
+    expect(parsed.length).toBe(1);
+    expect(parsed[0].type).toBe(FrameType.RESPONSE);
+    expect(new TextDecoder().decode(parsed[0].payload)).toBe('echo:hi');
+
+    await router.closePooling();
+  });
+});

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -99,6 +99,12 @@ function makeRouterFixture(opts: {
    * throw on pooled protocol, succeed on logical).
    */
   onDial?: (peerStr: string, protocols: string | string[]) => Promise<FakeStream>;
+  /**
+   * Spy hook for `libp2p.unhandle(protocolId)`. Tests can use it to
+   * assert that both logical and pooled wire handlers are released
+   * (Codex PR #560 round-2 unregister leak).
+   */
+  onUnhandle?: (protocolId: string) => void;
 } = {}): RouterFixture {
   const dialed: Array<{ peer: string; protocols: string | string[] }> = [];
   const streamsByCall: FakeStream[] = [];
@@ -114,7 +120,9 @@ function makeRouterFixture(opts: {
         return stream as unknown as import('@libp2p/interface').Stream;
       },
       handle: () => undefined,
-      unhandle: () => undefined,
+      unhandle: (protocolId: string) => {
+        if (opts.onUnhandle) opts.onUnhandle(protocolId);
+      },
       getConnections: () => [],
       peerStore: { get: async () => ({ addresses: [] }) },
     },
@@ -372,6 +380,30 @@ describe('ProtocolRouter pooled overlay', () => {
     expect(fixture.router.peerWireVariantFor(PEER_NEW, '/dkg/10.0.1/message')).toBe('pooled');
 
     await fixture.router.closePooling();
+  });
+
+  it('unregister(logicalId) tears down the pooled wire handler (Codex #560 round 2)', async () => {
+    const unhandleCalls: string[] = [];
+    const fixture = makeRouterFixture({
+      onUnhandle: (protocolId) => {
+        unhandleCalls.push(protocolId);
+      },
+    });
+    fixture.router.register('/dkg/10.0.1/message', async () => new Uint8Array([0xaa]));
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    fixture.router.unregister('/dkg/10.0.1/message');
+    await flush();
+
+    // Both the logical AND the wire protocol must have been unhandled.
+    expect(unhandleCalls).toContain('/dkg/10.0.1/message');
+    expect(unhandleCalls).toContain(POOLED_MESSAGE_PROTOCOL);
+    // Overlay is fully detached — pooledStatus reports it gone.
+    expect(fixture.router.pooledStatus()).toEqual([]);
   });
 
   it('primes peerResolver before pool dial (cold-peer recovery, Codex #560 round 1)', async () => {

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -451,6 +451,60 @@ describe('ProtocolRouter pooled overlay', () => {
     ).not.toThrow();
   });
 
+  it('unregister(logicalId) clears peerWireVariant memos for that logical (Codex #560 round 5)', () => {
+    const fixture = makeRouterFixture();
+    fixture.router.register('/dkg/10.0.1/message', async () => new Uint8Array());
+    fixture.router.register('/dkg/other/1.0.0', async () => new Uint8Array());
+    fixture.router.memoizePeerWire(PEER_NEW, '/dkg/10.0.1/message', 'one-shot');
+    fixture.router.memoizePeerWire(PEER_NEW, '/dkg/other/1.0.0', 'pooled');
+    expect(fixture.router.peerWireVariantFor(PEER_NEW, '/dkg/10.0.1/message')).toBe('one-shot');
+    expect(fixture.router.peerWireVariantFor(PEER_NEW, '/dkg/other/1.0.0')).toBe('pooled');
+
+    fixture.router.unregister('/dkg/10.0.1/message');
+    // Memos for the unregistered logical must be cleared.
+    expect(fixture.router.peerWireVariantFor(PEER_NEW, '/dkg/10.0.1/message')).toBeUndefined();
+    // Memos for OTHER logicals are preserved.
+    expect(fixture.router.peerWireVariantFor(PEER_NEW, '/dkg/other/1.0.0')).toBe('pooled');
+  });
+
+  it('one-shot backoff respects the overall deadline (Codex #560 round 5)', async () => {
+    let oneShotAttempts = 0;
+    const fixture = makeRouterFixture({
+      onDial: async (_peer, protocols) => {
+        if (protocols === POOLED_MESSAGE_PROTOCOL) {
+          // Pool burns ~half the overall budget then fails recoverably.
+          await new Promise((r) => setTimeout(r, 200));
+          throw new Error('no valid addresses');
+        }
+        oneShotAttempts += 1;
+        // One-shot always fails recoverably — would normally retry
+        // with 500ms backoff, then 1000ms.
+        throw new Error('stream reset');
+      },
+    });
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    const started = Date.now();
+    await expect(
+      fixture.router.send(PEER_NEW, '/dkg/10.0.1/message', new TextEncoder().encode('x'), {
+        timeoutMs: 400,
+      }),
+    ).rejects.toThrow();
+    const elapsed = Date.now() - started;
+    // Total elapsed must respect the 400ms budget — the bug shape
+    // would let one-shot's 500ms backoff push us to ~900ms.
+    expect(elapsed).toBeLessThan(650);
+    // The first one-shot attempt should have run; the SECOND
+    // attempt's backoff aborts on overall deadline.
+    expect(oneShotAttempts).toBeGreaterThanOrEqual(1);
+
+    await fixture.router.closePooling();
+  });
+
   it('unregister(logicalId) tears down the pooled wire handler (Codex #560 round 2)', async () => {
     const unhandleCalls: string[] = [];
     const fixture = makeRouterFixture({

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -382,6 +382,49 @@ describe('ProtocolRouter pooled overlay', () => {
     await fixture.router.closePooling();
   });
 
+  it('overall send timeoutMs is shared across pool + one-shot fallback (Codex #560 round 4)', async () => {
+    // Slow pool failure → fall-through to one-shot. Total elapsed
+    // wall-clock MUST stay under `timeoutMs`, not 2x.
+    const fixture = makeRouterFixture({
+      onDial: async (_peer, protocols) => {
+        if (protocols === POOLED_MESSAGE_PROTOCOL) {
+          // Simulate a slow pool failure that consumes ~half the
+          // overall budget.
+          await new Promise((r) => setTimeout(r, 150));
+          throw new Error('no valid addresses');
+        }
+        // One-shot succeeds quickly.
+        const s = new FakeStream();
+        queueMicrotask(() => {
+          s.feed(new TextEncoder().encode('shot-resp'));
+          s.endRemote();
+        });
+        return s;
+      },
+    });
+    fixture.router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    const started = Date.now();
+    const resp = await fixture.router.send(
+      PEER_NEW,
+      '/dkg/10.0.1/message',
+      new TextEncoder().encode('x'),
+      { timeoutMs: 500 },
+    );
+    const elapsed = Date.now() - started;
+    expect(new TextDecoder().decode(resp)).toBe('shot-resp');
+    // Total wall-clock MUST be well under 2 * timeoutMs (the bug
+    // shape) — we allow some headroom for the one-shot path's own
+    // retry budget but cap at 750ms to fail loudly on a regression.
+    expect(elapsed).toBeLessThan(750);
+
+    await fixture.router.closePooling();
+  });
+
   it('throws when a second logical claims an already-used wire id (Codex #560 round 3)', () => {
     const fixture = makeRouterFixture();
     fixture.router.enablePooling('/dkg/10.0.1/message', {


### PR DESCRIPTION
## TL;DR

Adds a long-lived bidirectional yamux substream per `(localNode, peerId)` pair for a new wire variant `/dkg/10.0.2/message`. Messages are multiplexed over the held stream with length-prefixed framing; periodic PINGs keep both the substream and the underlying circuit-relay-v2 connection alive between application messages. Opt-in via `DKG_POOLED_MESSAGES=1`; multistream-select handles fallback to the existing one-shot `/dkg/10.0.1/message` automatically.

Targets the latency tail observed in the May 2026 multi-node soak: **p50 ~900ms, p95 ~8.5s, p99 ~9.6s** on relay-v2 chat traffic. Daemon-log inspection during that soak showed circuit-relay connections opening for 200–365ms and closing immediately per send — the one-shot stream pattern was paying a full handshake every cycle. PR #537's `getConnections` reuse walk was correct but rarely had anything to reuse because the connection died with the stream.

## What's changed

### New: `MessageStreamPool` (`packages/core/src/message-stream-pool.ts`)

Lazy per-peer stream with:
- **Framed multiplexing** (REQUEST / RESPONSE / ERROR / PING / PONG)
- **Serial in-flight** — at most one request awaiting a response; siblings FIFO-queue behind it. Chat-rate workload (1 msg / 15s) doesn't need pipelining; if a future caller does, the wire format already reserves space for a `REQUEST_V2` frame with an embedded request-id.
- **Keepalive** — periodic PING (default 10s) keeps the stream + relay reservation warm.
- **Idle close** — 5 min no-activity → graceful close; next send re-opens.
- **Reset recovery** — stream errors reject every pending request with a `PooledStreamResetError` whose message matches `isRecoverableSendError`, so the substrate's `MessageOutbox` re-enqueues automatically. Next send opens a fresh stream.

### New: framing codec (`packages/core/src/message-frame.ts`)

uvarint length-prefixed frames, type byte, payload. Streaming decoder consumes any `AsyncIterable<Uint8Array>` (works directly with libp2p `Stream`). Bounded frame size (default 10 MiB, matches `DEFAULT_MAX_READ_BYTES`).

### Modified: `ProtocolRouter`

- `enablePooling(logicalProtocolId, opts?)` — opt-in per logical protocol. Wire variant is `/dkg/10.0.2/message` by default; configurable.
- `send()` checks for a pooled overlay first; on `protocol selection failed` / `could not negotiate` / `unsupported protocol` / `protocol mismatch` it memoizes the peer as one-shot and falls through to the existing single-path retry loop **within the same `send()` call**. Transient errors (ECONNRESET, etc.) bubble so the substrate retries on the same wire next attempt — we don't silently swap wires under load.
- `pooledStatus()` + `closePooling()` for diagnostics + lifecycle.
- One-shot path completely unchanged; pooling is purely additive.

### Modified: `DKGAgent`

Env-gated `router.enablePooling(PROTOCOL_MESSAGE, …)` right after `MessageHandler` construction; `router.closePooling()` in `agent.stop()` before `node.stop()` so per-peer streams close gracefully and don't trigger a spurious final outbox retry.

## Wire compatibility

* `10.0.1`-only peer × `10.0.2`-capable peer: multistream-select picks `/dkg/10.0.1/message`; one-shot path runs end-to-end. After the first dial, the router memoizes the peer as one-shot so subsequent sends don't pay the negotiation cost.
* `10.0.2`-capable × `10.0.2`-capable: pooled path; subsequent sends reuse the stream.
* No change to the `ReliableEnvelope`, idempotency cache, durable outbox, or application handlers — pooling is transparent to `Messenger.sendReliable` / `Messenger.register` callers.

## How to test

Lex and Miles (both sides need to upgrade for the optimization to kick in; one-sided is fallback path):

\`\`\`bash
git fetch origin feat/longlived-message-streams
git checkout feat/longlived-message-streams
pnpm install
pnpm -r build
dkg stop
DKG_POOLED_MESSAGES=1 DKG_NO_BLUE_GREEN=1 dkg start
dkg status
\`\`\`

Daemon log should show:

\`\`\`
[messenger] pooled wire variant /dkg/10.0.2/message enabled for chat protocol (long-lived per-peer streams).
\`\`\`

Then re-run the LEX↔MILES↔HERMES↔ARX soak. Expect:
- p50 latency to drop from ~900ms → ~300-500ms (single round-trip cost; no dial)
- p99 to drop substantially (the worst cases were "have to re-dial everything") if both ends speak `/dkg/10.0.2/message`
- `/api/peer-info` connection churn to drop — connections stay warm

## Tests (38 new, all green)

| File | Tests | Coverage |
|------|-------|----------|
| `message-frame.test.ts` | 16 | varint round-trip, multi-chunk decode, frame-size cap, malformed-stream rejection |
| `message-stream-pool.test.ts` | 13 | stream reuse, FIFO serialisation, per-peer isolation, reset → recoverable rejection, automatic reopen, PING→PONG, keepalive emission on schedule, idle-timeout, inbound dispatch, handler-error → ERROR-frame, close() rejects pending |
| `protocol-router-pool.test.ts` | 9 | pooled overlay routing, multi-send reuse, multistream-select fallback, peer-wire memoization, transient errors bubble, closePooling teardown, inbound integration |

Existing tests: `packages/core` 876/877 (one pre-existing unrelated `PROTOCOL_ACCESS` constant test failure on this branch), `messenger-substrate.test.ts` + `p2p-messenger.test.ts` + `dkg-agent-diagnostics.test.ts` all 52/52 green.

## Coordination notes for Miles

* This is a **wire-format change**; the libp2p multistream-select fallback covers cross-version traffic so deployment is safe to roll one node at a time.
* The env gate (`DKG_POOLED_MESSAGES=1`) defaults to **off** so merging + restarting without setting the env gives identical behaviour to today's substrate. The flag is the only thing that flips on the new wire variant.
* Both sides need the flag for the latency win to actually show up — Lex-only is fallback path. We'll need a coordinated restart with the flag set to validate the improvement on the multi-node soak.
* The pool's diagnostics (`router.pooledStatus()`) aren't exposed via HTTP/MCP yet — wire one of these as a follow-up if you want live observability during the soak. For now we can compare per-protocol SLO histograms before vs after.

## Follow-ups (out of scope)

* Roll pooling out to the other substrate protocols (`private-access`, `query-remote`, `swm-sender-key`, `storage-ack`, `verify-proposal`, `join-request`). Chat is the highest-traffic protocol so the biggest win lands here; incremental rollout lets us measure each protocol's response.
* Pipelining (multi in-flight per stream) for `/query-remote` where the receiver's handler is slow.
* Per-wire-variant SLO histogram so operators can directly compare pooled vs one-shot.
* Once the new variant has soaked at least 24h on Miles/Hermes/Arx without anomalies, flip the default to enabled and deprecate the env gate.


Made with [Cursor](https://cursor.com)