### PR TITLE
fix(messenger): classify "All multiaddr dials failed" as recoverable

### DIFF
--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -79,6 +79,19 @@ export const DHT_WALK_RATE_LIMIT_MS = 5 * 60 * 1000;
 const DHT_WALK_TRIGGER_ERRORS = [
   'no valid addresses',
   'no_reservation',
+  // libp2p surfaces "All multiaddr dials failed" when every
+  // candidate address for the peer fails in a single dial attempt
+  // (instantaneous routing-table miss — typically peerStore briefly
+  // empty after restart, or every cached relay addr dead). This
+  // means the peer's addresses are stale on OUR side; a DHT walk is
+  // exactly the right recovery (re-resolve against the routing
+  // layer + identify cache + agent registry), not just a passive
+  // outbox backoff that would keep retrying the same dead address
+  // until TTL. Codex PR #567 review caught this — adding it to the
+  // classifier (PR #567 main change) made it recoverable, but
+  // without this list entry the retry path back-off-but-doesn't-
+  // re-resolve.
+  'all multiaddr dials failed',
 ];
 
 function shouldTriggerDhtWalk(errMsg: string): boolean {

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -581,6 +581,33 @@ describe('Messenger DHT-walk-on-stall recovery (rc.9 PR-5)', () => {
     expect(resolvePeer).toHaveBeenCalledTimes(1);
   });
 
+  // Regression for the May 2026 multi-node soak. libp2p surfaces
+  // "All multiaddr dials failed" when every candidate address for
+  // a peer fails in a single dial — peerStore briefly stale, all
+  // cached relay addrs dead, etc. PR #567's classifier change made
+  // this recoverable so the outbox queues it, but Codex review
+  // caught that without ALSO adding the string to
+  // `DHT_WALK_TRIGGER_ERRORS`, the outbox would just back off and
+  // retry the SAME dead addresses forever. This test asserts the
+  // string is wired through to the DHT-walk path the same way as
+  // `no valid addresses` / `NO_RESERVATION`.
+  it('treats "All multiaddr dials failed" as recoverable and triggers the DHT walk', async () => {
+    const { messenger, resolvePeer, advance } = makeStallSubstrate({
+      errorMessage: 'All multiaddr dials failed',
+    });
+
+    for (let i = 0; i < 5; i++) {
+      const result = await messenger.sendReliable(PEER_A, PROTO, new Uint8Array([1]), {
+        messageId: FIXED_MSG_ID,
+      });
+      expect(result.queued).toBe(true);
+      advance(1000);
+    }
+
+    expect(resolvePeer).toHaveBeenCalledTimes(1);
+    expect(resolvePeer).toHaveBeenCalledWith(PEER_A, { signal: expect.any(AbortSignal) });
+  });
+
   it('rate-limits resolvePeer per peer (no second walk within DHT_WALK_RATE_LIMIT_MS)', async () => {
     const { messenger, resolvePeer, advance } = makeStallSubstrate();
 

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -25,6 +25,20 @@ export function isRecoverableSendError(err: unknown): boolean {
     msg.includes('epipe') ||
     msg.includes('aborted') ||
     msg.includes('no valid addresses') ||
+    // libp2p dial exhaustion — every known multiaddr for the peer
+    // failed in one attempt. Surfaced by `transportManager.dial` and
+    // by `dialProtocol` after iterating every relay/transport
+    // candidate. Classifying as recoverable lets the substrate
+    // outbox queue + retry via PR-5's DHT-walk-on-stall, which
+    // re-resolves the peer's addresses against the routing layer.
+    //
+    // Without this, an instantaneous routing-table miss (peer's
+    // addresses momentarily absent from local libp2p peerStore)
+    // becomes a terminal application-level loss. The May 2026
+    // multi-node soak surfaced 50/57 of all sender-side hard fails
+    // in this class — making this single string the highest-impact
+    // gap-closer toward the 99.9% delivery SLO.
+    msg.includes('all multiaddr dials failed') ||
     msg.includes('no_reservation') ||
     msg.includes('no reservation') ||
     msg.includes('protocol selection failed') ||

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -22,6 +22,20 @@ describe('ProtocolRouter', () => {
       expect(isRecoverableSendError(new Error('no reservation for relay'))).toBe(true);
     });
 
+    // Regression for the May 2026 multi-node soak: libp2p surfaces
+    // "All multiaddr dials failed" when every candidate address for
+    // the peer fails in a single dial attempt (instantaneous
+    // routing-table miss). Pre-fix this was terminal; post-fix it
+    // queues so the substrate outbox + PR-5 DHT-walk-on-stall
+    // re-resolves the peer and retries.
+    it('returns true for libp2p multiaddr dial exhaustion (May 2026 soak)', () => {
+      expect(isRecoverableSendError(new Error('All multiaddr dials failed'))).toBe(true);
+      // Matches case-insensitively + within wrapping context (libp2p
+      // sometimes prefixes with the protocol id).
+      expect(isRecoverableSendError(new Error('dialProtocol(/dkg/10.0.1/message): All multiaddr dials failed'))).toBe(true);
+      expect(isRecoverableSendError(new Error('all multiaddr dials failed'))).toBe(true);
+    });
+
     it('returns false for non-recoverable errors', () => {
       expect(isRecoverableSendError(new Error('Read limit exceeded'))).toBe(false);
       expect(isRecoverableSendError(new Error('handler error'))).toBe(false);


### PR DESCRIPTION
## TL;DR

Single-line classifier widening in `isRecoverableSendError`. Adds `"all multiaddr dials failed"` to the recoverable-error list so the substrate outbox queues + retries these events instead of returning a terminal failure to the application.

Targets the dominant hard-fail class from the 2026-05-17 multi-node overnight soak: **50 of 57 (88%) of all sender-side non-queued losses across 6570 Miles-outbound messages were this single error string.**

## Why

The 10h soak (Miles → Lex, Hermes, Arx, Muy; full mesh; 1 msg / 15s per directed flow) produced:

| Hard-fail error                                            | Count | Substrate response   |
| ---------------------------------------------------------- | ----- | -------------------- |
| `"All multiaddr dials failed"`                             | **50** | NOT queued (terminal) |
| `"nonce" expected Uint8Array of length 24, got type=object` | 6     | NOT queued (terminal) |
| `"send timeout elapsed"`                                   | 1     | NOT queued (terminal) |

libp2p surfaces `"All multiaddr dials failed"` when every candidate address for the peer fails in a single dial attempt — typically an instantaneous routing-table miss where the peer's addresses are momentarily absent from the local libp2p peerStore. PR-5's DHT-walk-on-stall mechanism is designed exactly for this case (it re-resolves the peer's addresses against the routing layer when an outbox entry stalls), but the classifier never gave it a chance — the error was bubbling straight up to the application as terminal.

The 204 queued events in the same soak that *did* classify as recoverable (`"Remote closed connection during opening"`) achieved **100% outbox recovery** (204/204 ended up acked via the receiver's idempotency ledger), so we have high confidence the same path handles this newly-classified error correctly.

## What's changed

- `packages/core/src/protocol-router.ts`: 1 line added to `isRecoverableSendError`, with a docstring tying the change back to the soak finding.
- `packages/core/test/protocol-router.test.ts`: regression test covering the bare error, a wrapped form (`dialProtocol(...): All multiaddr dials failed`), and case-insensitivity.

## Projected impact

| Metric                                          | Pre-fix (last night) | Post-fix (next soak)              |
| ----------------------------------------------- | -------------------- | --------------------------------- |
| Truly-lost messages (no idempotency ack)        | 51 / 6570 (0.78%)    | ≈1 / 6570 (0.015%)                |
| End-to-end delivery rate                        | 99.22%               | ≈99.985%                          |
| Hard fails in `"All multiaddr dials failed"`   | 50                   | 0 (queued + recovered like the other 204) |

(The remaining ≈1 truly-lost is the one isolated `"send timeout elapsed"` event; the 6 cold-start nonce events are addressed by the companion PR.)

## Test plan

- [x] `packages/core/test/protocol-router.test.ts` — 36/36 green, includes new regression
- [ ] Re-run the multi-node overnight soak after merging into `soak/messenger-rc9-everything` and confirm `"All multiaddr dials failed"` events become queued+recovered instead of terminal
- [ ] Validate substrate outbox latency for newly-classified events is comparable to the 204 currently-recovered queued events (p50 10s, p95 20s, p99 28s last night)

## Coordination

- Targets `soak/messenger-rc9-everything` so it lands with PR #560 (long-lived per-peer stream pool) before the next mesh re-soak.
- PR #560 will dramatically reduce the *first-dial* frequency overall (per-peer streams stay warm), but the cold-peer first contact still goes through this dial path — so this PR remains defense-in-depth even after #560 lands.

Made with [Cursor](https://cursor.com)