### PR TITLE
feat(swm): loud-fail gossip publish + redundant-apply counter (rc.9 PR-A)

### DIFF
--- a/docs/messenger-operator.md
+++ b/docs/messenger-operator.md
@@ -130,14 +130,83 @@ curl -s http://127.0.0.1:9200/api/slo \
       "queued": 14           // monotonic; "queued" = first send failed → outbox
     },
     "/dkg/10.0.1/storage-ack": { ... }
+  },
+  // rc.9 PR-A (SWM reliable fan-out, Step 0): two new sections,
+  // additive — soak tooling and operators that only parse `protocols`
+  // still work byte-identically.
+  "gossip": {
+    "publishFailures": {     // per-cgId count of `gossip.publish` errors
+      "did:dkg:context-graph:lex/playground": 3
+    },
+    // Counts evicted into here once the per-cgId tracking map crosses
+    // its hard cap (1024 distinct cgIds). Always 0 in normal
+    // deployments; non-zero only when failing publishes against
+    // thousands of distinct cgIds.
+    "publishFailuresOverflow": 0,
+    // Sticky boolean — true once the eviction path has fired. Means
+    // the per-cgId breakdown is partial; the grand total
+    // (sum(publishFailures) + publishFailuresOverflow) is still
+    // accurate.
+    "publishFailuresTruncated": false
+  },
+  "swm": {
+    "redundantApplies": {    // per-cgId redundant-apply count (RFC-003)
+      "did:dkg:context-graph:lex/playground": 5
+    },
+    // Sticky boolean — true once the receiver-side seenShareOps cap
+    // eviction had to trim a still-live (non-TTL-expired) entry. When
+    // true, `redundantApplies` is a lower bound for the operating
+    // window. Operators can raise `seenOpsMaxSize` (default 50_000)
+    // on the `SharedMemoryHandler` constructor for higher-throughput
+    // nodes.
+    "redundantAppliesLowerBound": false,
+    // Sum of per-cgId counters evicted into overflow once the per-cgId
+    // tracking map crosses its hard cap (default 1024 distinct cgIds).
+    // Non-zero only when a peer has been forcing duplicate applies
+    // against thousands of distinct cgIds.
+    "redundantAppliesOverflow": 0,
+    // Sticky boolean — true once the per-cgId cap eviction has fired.
+    // Means the `redundantApplies` breakdown is partial; the grand
+    // total is still `sum(redundantApplies) + redundantAppliesOverflow`.
+    "redundantAppliesTruncated": false
   }
 }
 ```
 
-Empty body `{ "protocols": {} }` means no substrate traffic has flowed
-since daemon start — either the node is idle, or every protocol it has
-exercised is still on `/dkg/10.0.0/*` and hasn't been migrated yet
-(no such protocol remains at rc.9 ship).
+Empty body with all-zero counters means no substrate traffic has
+flowed and no SWM share has either failed at gossip or been applied
+— typically a freshly restarted idle daemon.
+
+### `gossip` / `swm` reading guide
+
+- **`gossip.publishFailures[cgId] > 0`** → the local node committed a
+  share for `cgId` but `gossip.publish` threw. The share is NOT lost:
+  the local commit succeeded and `runSyncOnConnect` will catch
+  remote peers up on the next reconnect. A non-zero counter that
+  keeps growing without delivery progress is the signal to
+  investigate (mesh failure, no peers subscribed, etc.). The
+  per-failure WARN in `daemon.log` carries both `errorClass=` and
+  `error=` so distinct failure types stay greppable.
+- **`gossip.publishFailuresTruncated = true`** → operations against
+  >1024 distinct cgIds have failed since daemon start. The
+  `publishFailures` map drops the smallest counters into
+  `publishFailuresOverflow` to keep memory + response size bounded;
+  the grand total is still accurate.
+- **`swm.redundantApplies[cgId] > 0`** → a (cgId, shareOpId) was
+  re-delivered within the TTL window and applied a second time.
+  Pure measurement: behaviour is unchanged. Used to inform the rc10
+  dedup decision (RFC-003 Concern-2).
+- **`swm.redundantAppliesLowerBound = true`** → the receiver-side
+  `seenShareOps` cap eviction had to trim a still-live entry to
+  stay bounded. `redundantApplies` is now a lower bound for the
+  operating window. Tune the `SharedMemoryHandler` constructor's
+  `seenOpsMaxSize` upward for higher-throughput nodes.
+- **`swm.redundantAppliesTruncated = true`** → duplicate applies have
+  arrived against more than `redundantAppliesMaxCgs` (default 1024)
+  distinct cgIds, so the per-cgId breakdown is partial. The grand
+  total is still accurate via
+  `sum(redundantApplies) + redundantAppliesOverflow`. If `Truncated`
+  flips in normal operation (no hostile peer), raise the cap.
 
 ### Clock definition
 

--- a/docs/messenger.md
+++ b/docs/messenger.md
@@ -537,13 +537,52 @@ Authorization: Bearer <token from ~/.dkg/auth.token>
       "queued": 14           // monotonic counter; "queued" = first send failed → outbox
     },
     "/dkg/10.0.1/storage-ack": { ... }
+  },
+  // rc.9 PR-A (SWM reliable fan-out, Step 0): two new sections,
+  // additive — existing consumers that only parse `protocols` still
+  // work byte-identically.
+  "gossip": {
+    "publishFailures": {     // per-cgId count of `gossip.publish` errors
+      "did:dkg:context-graph:lex/playground": 3
+    },
+    // Counts evicted into here once the per-cgId tracking map crosses
+    // its hard cap (default 1024 distinct cgIds). Always 0 in normal
+    // deployments; non-zero only when failing publishes against
+    // thousands of distinct cgIds.
+    "publishFailuresOverflow": 0,
+    // Sticky boolean — true once the eviction path has fired. Means
+    // the per-cgId breakdown is partial; the grand total
+    // (sum(publishFailures) + publishFailuresOverflow) is still
+    // accurate.
+    "publishFailuresTruncated": false
+  },
+  "swm": {
+    "redundantApplies": {    // per-cgId redundant-apply count (RFC-003 Concern-2)
+      "did:dkg:context-graph:lex/playground": 5
+    },
+    // Sticky boolean — true once the seenShareOps cap eviction had to
+    // trim a still-live (non-TTL-expired) entry. When true,
+    // `redundantApplies` is a lower bound for the operating window.
+    // Operators can raise `seenOpsMaxSize` (default 50_000) for
+    // higher-throughput nodes.
+    "redundantAppliesLowerBound": false,
+    // Sum of per-cgId counters evicted into overflow once the per-cgId
+    // tracking map crosses its hard cap (default 1024 distinct cgIds).
+    // Always 0 in normal deployments; non-zero only when receiving
+    // duplicate applies against thousands of distinct cgIds.
+    "redundantAppliesOverflow": 0,
+    // Sticky boolean — true once the per-cgId cap eviction has fired.
+    // Means the `redundantApplies` breakdown is partial; the grand
+    // total is still `sum(redundantApplies) + redundantAppliesOverflow`.
+    "redundantAppliesTruncated": false
   }
 }
 ```
 
-Empty body `{ "protocols": {} }` means no substrate traffic has flowed
-since daemon start — either the node is idle, or every protocol it has
-exercised is still on `/dkg/10.0.0/*` and hasn't been migrated yet.
+Empty body `{ "protocols": {}, "gossip": {...}, "swm": {...} }` with
+all-zero counters means no substrate traffic has flowed and no SWM
+share has either failed at gossip or been applied — typically a freshly
+restarted idle daemon.
 
 ### Reading guide
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1203,6 +1203,28 @@ export class DKGAgent {
   private finalizationHandler?: FinalizationHandler;
   private readonly log = new Logger('DKGAgent');
 
+  /**
+   * Per-cgId count of SWM gossip publish failures. Populated by
+   * publishWorkspaceGossip's catch block (rc.9 PR-A / SWM reliable
+   * fan-out plan, Step 0). Exposed via /api/slo `gossip.publishFailures`.
+   * Process-lifetime in-memory only — no persistence; on daemon
+   * restart counters reset. Sufficient for soak measurement; if
+   * operators ever need cross-restart aggregation, escalate to a
+   * SQLite table.
+   *
+   * Codex PR #570 R5 caught that the map would grow unbounded for any
+   * caller that fails publishes against arbitrary cgIds. To prevent
+   * runaway memory + a permanently bloated /api/slo payload, we cap
+   * the per-cgId set at SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS. Overflow
+   * counters are summed into `swmGossipPublishFailuresOverflow` so the
+   * total stays accurate; a sticky `swmGossipPublishFailuresTruncated`
+   * flag tells operators that the per-cgId breakdown is partial.
+   */
+  private readonly swmGossipPublishFailures = new Map<string, number>();
+  private swmGossipPublishFailuresOverflow = 0;
+  private swmGossipPublishFailuresTruncated = false;
+  private static readonly SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS = 1024;
+
   private messageHandler: MessageHandler | null = null;
   private chainPoller: ChainEventPoller | null = null;
   private swmCleanupTimer: ReturnType<typeof setInterval> | null = null;
@@ -6185,8 +6207,71 @@ export class DKGAgent {
     const wireMessage = await this.encodeWorkspaceGossipMessage(contextGraphId, message, resolvedSigner);
     try {
       await this.gossip.publish(topic, wireMessage);
-    } catch {
-      this.log.warn(ctx, `No peers subscribed to ${topic} yet`);
+    } catch (err) {
+      // rc.9 PR-A (SWM reliable fan-out plan, Step 0): replace the
+      // pre-rc.9 silent log.warn with a structured failure record so
+      // operators can see exactly which shares dropped. The local SWM
+      // commit already happened in the caller; on-connect-sync will
+      // catch remote peers up eventually. We intentionally do NOT
+      // re-throw — share() should still return success because the
+      // local commit succeeded — but the failure becomes observable
+      // via the new /api/slo `gossip.publishFailures` counter and the
+      // WARN log now carries the cgId + error class + error message
+      // for greppability (Codex PR #570 R6: previously the comment
+      // claimed "error class" but the implementation only logged
+      // err.message, collapsing distinct failure types).
+      this.recordSwmGossipPublishFailure(contextGraphId);
+      const errClass = err instanceof Error
+        ? (err.name && err.name !== 'Error' ? err.name : err.constructor.name)
+        : typeof err;
+      const errMessage = err instanceof Error ? err.message : String(err);
+      const count = this.swmGossipPublishFailures.get(contextGraphId) ?? 0;
+      this.log.warn(
+        ctx,
+        `Gossip publish FAILED for topic="${topic}" cgId=${contextGraphId} errorClass="${errClass}" error="${errMessage}" failureCountForCg=${count}`,
+      );
+    }
+  }
+
+  /**
+   * PR-A R5+R8: bookkeep a gossip-publish failure with a hard cap on
+   * the per-cgId tracking set. Once we cross
+   * SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS distinct cgIds, the entry
+   * with the GLOBAL smallest count is evicted into
+   * `swmGossipPublishFailuresOverflow` and a sticky
+   * `swmGossipPublishFailuresTruncated` flag is set so /api/slo can
+   * surface "the per-cgId breakdown is partial; total count is still
+   * accurate". This keeps the most-failing cgIds visible
+   * (operationally what operators care about) while bounding memory /
+   * response size.
+   *
+   * Codex PR #570 R8: the eviction comparison MUST include the
+   * just-incremented entry. Otherwise a stream of one-off failures
+   * against fresh cgIds (count=1 each) would each evict an existing
+   * HOT cgId (count>=2), even though the new entry is by definition
+   * the smallest. With this comparison, when the new entry IS the
+   * smallest, it's the one that gets evicted into overflow — leaving
+   * the existing hot spots intact, exactly what operators want.
+   */
+  private recordSwmGossipPublishFailure(contextGraphId: string): void {
+    const next = (this.swmGossipPublishFailures.get(contextGraphId) ?? 0) + 1;
+    this.swmGossipPublishFailures.set(contextGraphId, next);
+    if (this.swmGossipPublishFailures.size > DKGAgent.SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS) {
+      let smallestCg: string | null = null;
+      let smallestCount = Infinity;
+      for (const [cg, count] of this.swmGossipPublishFailures) {
+        if (count < smallestCount) {
+          smallestCount = count;
+          smallestCg = cg;
+        }
+      }
+      if (smallestCg !== null) {
+        this.swmGossipPublishFailures.delete(smallestCg);
+        this.swmGossipPublishFailuresOverflow += smallestCount;
+        if (!this.swmGossipPublishFailuresTruncated) {
+          this.swmGossipPublishFailuresTruncated = true;
+        }
+      }
     }
   }
 
@@ -13502,6 +13587,81 @@ export class DKGAgent {
    */
   getMessengerSloStats(): Record<string, SloProtocolStats> {
     return this.messenger.getSloStats();
+  }
+
+  /**
+   * Snapshot of SWM gossip publish health (rc.9 PR-A).
+   *
+   * - `publishFailures` — per-cgId count of failed `gossip.publish`
+   *   calls. Pre-rc.9 these were silently swallowed; now they're
+   *   observable. A non-zero counter is operator-visible signal that
+   *   some shares went out-of-band only (local commit succeeded;
+   *   catch-up will run via `runSyncOnConnect` on the next peer
+   *   reconnect).
+   * - `publishFailuresOverflow` — sum of counters that were evicted
+   *   when the per-cgId tracking set crossed
+   *   `SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS`. Always 0 in normal
+   *   deployments; non-zero only when a caller has been failing
+   *   publishes against thousands of distinct cgIds.
+   * - `publishFailuresTruncated` — sticky boolean, true once the
+   *   eviction path has fired. Surfaced via Codex PR #570 R5 so
+   *   operators see that the per-cgId breakdown is partial even
+   *   though the grand total (`sum(publishFailures) +
+   *   publishFailuresOverflow`) is still accurate.
+   */
+  getSwmGossipStats(): {
+    publishFailures: Record<string, number>;
+    publishFailuresOverflow: number;
+    publishFailuresTruncated: boolean;
+  } {
+    return {
+      publishFailures: Object.fromEntries(this.swmGossipPublishFailures),
+      publishFailuresOverflow: this.swmGossipPublishFailuresOverflow,
+      publishFailuresTruncated: this.swmGossipPublishFailuresTruncated,
+    };
+  }
+
+  /**
+   * Snapshot of receiver-side SWM apply metrics (rc.9 PR-A).
+   *
+   * - `redundantApplies` — per-cgId count of times
+   *   `SharedMemoryHandler.handle()` saw a (cgId, shareOpId) it had
+   *   already processed within the TTL window AND both deliveries
+   *   actually applied to the store. Used to inform the rc10
+   *   decision on whether to add explicit receiver-side dedup
+   *   (Concern-2 in the SWM reliable fan-out plan).
+   * - `redundantAppliesLowerBound` — sticky boolean, true once the
+   *   seenShareOps cap eviction had to trim a still-live entry.
+   *   Surfaced via Codex PR #570 R3 so operators can detect that
+   *   the metric has become a lower bound (configured cap too small
+   *   for current throughput).
+   * - `redundantAppliesOverflow` — sum of per-cgId counters evicted
+   *   into the overflow bucket when the per-cgId map crossed the
+   *   `redundantAppliesMaxCgs` cap. Surfaced via Codex PR #570 R9.
+   * - `redundantAppliesTruncated` — sticky boolean, true once R9
+   *   eviction has fired. Means the per-cgId breakdown is partial;
+   *   the grand total is still `sum(redundantApplies) +
+   *   redundantAppliesOverflow`.
+   *
+   * Returns the empty / pristine snapshot if the SharedMemoryHandler
+   * has not yet been initialised (no SWM share has ever been received
+   * locally).
+   */
+  getSwmHandlerStats(): {
+    redundantApplies: Record<string, number>;
+    redundantAppliesLowerBound: boolean;
+    redundantAppliesOverflow: number;
+    redundantAppliesTruncated: boolean;
+  } {
+    if (!this.sharedMemoryHandler) {
+      return {
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+      };
+    }
+    return this.sharedMemoryHandler.getStats();
   }
 
   async getPeerDiagnostics(peerId: string): Promise<PeerDiagnostics> {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -6220,15 +6220,28 @@ export class DKGAgent {
       // for greppability (Codex PR #570 R6: previously the comment
       // claimed "error class" but the implementation only logged
       // err.message, collapsing distinct failure types).
-      this.recordSwmGossipPublishFailure(contextGraphId);
+      // Codex PR #570 R12: source the running failure count from
+      // `recordSwmGossipPublishFailure`'s return value, not by
+      // re-reading the map. Pre-fix, when the just-incremented
+      // entry was itself the smallest and got evicted into the
+      // overflow bucket on the very same call, the subsequent
+      // map.get() returned 0 (or an older count for a recycled
+      // cgId), producing misleading `failureCountForCg=0` log lines
+      // for a cgId that had just failed. We now log the actual
+      // post-increment count, and flag the overflow case explicitly
+      // so operators can see why the per-cgId breakdown in
+      // /api/slo's `gossip.publishFailures` may not show this cgId.
+      const { failureCountForCg, evictedToOverflow } = this.recordSwmGossipPublishFailure(contextGraphId);
       const errClass = err instanceof Error
         ? (err.name && err.name !== 'Error' ? err.name : err.constructor.name)
         : typeof err;
       const errMessage = err instanceof Error ? err.message : String(err);
-      const count = this.swmGossipPublishFailures.get(contextGraphId) ?? 0;
+      const overflowSuffix = evictedToOverflow
+        ? ' (evicted to overflow bucket; per-cgId breakdown truncated)'
+        : '';
       this.log.warn(
         ctx,
-        `Gossip publish FAILED for topic="${topic}" cgId=${contextGraphId} errorClass="${errClass}" error="${errMessage}" failureCountForCg=${count}`,
+        `Gossip publish FAILED for topic="${topic}" cgId=${contextGraphId} errorClass="${errClass}" error="${errMessage}" failureCountForCg=${failureCountForCg}${overflowSuffix}`,
       );
     }
   }
@@ -6252,10 +6265,20 @@ export class DKGAgent {
    * the smallest. With this comparison, when the new entry IS the
    * smallest, it's the one that gets evicted into overflow — leaving
    * the existing hot spots intact, exactly what operators want.
+   *
+   * Codex PR #570 R12: returns the post-increment count and an
+   * `evictedToOverflow` flag so the caller's WARN log accurately
+   * reflects what just happened without having to re-read the map
+   * (which is stale if THIS cgId was the one evicted into the
+   * overflow bucket on the same call).
    */
-  private recordSwmGossipPublishFailure(contextGraphId: string): void {
+  private recordSwmGossipPublishFailure(contextGraphId: string): {
+    failureCountForCg: number;
+    evictedToOverflow: boolean;
+  } {
     const next = (this.swmGossipPublishFailures.get(contextGraphId) ?? 0) + 1;
     this.swmGossipPublishFailures.set(contextGraphId, next);
+    let evictedToOverflow = false;
     if (this.swmGossipPublishFailures.size > DKGAgent.SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS) {
       let smallestCg: string | null = null;
       let smallestCount = Infinity;
@@ -6271,8 +6294,12 @@ export class DKGAgent {
         if (!this.swmGossipPublishFailuresTruncated) {
           this.swmGossipPublishFailuresTruncated = true;
         }
+        if (smallestCg === contextGraphId) {
+          evictedToOverflow = true;
+        }
       }
     }
+    return { failureCountForCg: next, evictedToOverflow };
   }
 
   async publishAsync(

--- a/packages/agent/test/swm-gossip-publish-failure.test.ts
+++ b/packages/agent/test/swm-gossip-publish-failure.test.ts
@@ -129,7 +129,7 @@ describe('DKGAgent SWM gossip publish failure (rc.9 PR-A)', () => {
 
     const internals = agent as unknown as {
       swmGossipPublishFailures: Map<string, number>;
-      recordSwmGossipPublishFailure: (cgId: string) => void;
+      recordSwmGossipPublishFailure: (cgId: string) => { failureCountForCg: number; evictedToOverflow: boolean };
     };
     const Cls = (agent.constructor as unknown as { SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS: number });
     const cap = Cls.SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS;
@@ -171,7 +171,7 @@ describe('DKGAgent SWM gossip publish failure (rc.9 PR-A)', () => {
 
     const internals = agent as unknown as {
       swmGossipPublishFailures: Map<string, number>;
-      recordSwmGossipPublishFailure: (cgId: string) => void;
+      recordSwmGossipPublishFailure: (cgId: string) => { failureCountForCg: number; evictedToOverflow: boolean };
     };
     const Cls = (agent.constructor as unknown as { SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS: number });
     const cap = Cls.SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS;
@@ -226,6 +226,76 @@ describe('DKGAgent SWM gossip publish failure (rc.9 PR-A)', () => {
     expect(warn).toBeDefined();
     expect(warn!.message).toContain('errorClass="NoPeersSubscribedError"');
     expect(warn!.message).toContain('error="no peers subscribed to');
+  });
+
+  // PR-A R12 regression: when the per-cgId tracking map is at the
+  // cap AND the just-incremented entry is the one evicted into the
+  // overflow bucket on the same call, the WARN log must still
+  // report the actual post-increment count (≥1), not the stale 0
+  // returned by re-reading the map after eviction. The log line
+  // also flags the overflow case so operators can see why this
+  // cgId won't show up in /api/slo's per-cgId breakdown.
+  it('WARN log reports accurate failureCountForCg even when the entry is evicted to overflow (R12)', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmGossipFailureR12Overflow',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const gossip = new TypedThrowingGossip();
+    (agent as unknown as { gossip: TypedThrowingGossip }).gossip = gossip;
+    Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
+      value: { toString: () => '12D3KooWPublisherR12' },
+      configurable: true,
+    });
+
+    const internals = agent as unknown as {
+      swmGossipPublishFailures: Map<string, number>;
+      recordSwmGossipPublishFailure: (cgId: string) => { failureCountForCg: number; evictedToOverflow: boolean };
+    };
+    const Cls = (agent.constructor as unknown as { SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS: number });
+    const cap = Cls.SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS;
+
+    // Saturate the cap with hot cgIds (count >= 2 each) so the
+    // smallest entry after the next single bump will be the new one.
+    for (let pass = 0; pass < 2; pass++) {
+      for (let i = 0; i < cap; i++) {
+        internals.recordSwmGossipPublishFailure(`cg-hot-${i}`);
+      }
+    }
+
+    const captured: Array<{ message: string }> = [];
+    const originalWarn = (agent as unknown as { log: { warn: (ctx: unknown, msg: string) => void } }).log.warn.bind(
+      (agent as unknown as { log: { warn: (ctx: unknown, msg: string) => void } }).log,
+    );
+    (agent as unknown as { log: { warn: (ctx: unknown, msg: string) => void } }).log.warn = (ctx, message) => {
+      captured.push({ message });
+      originalWarn(ctx, message);
+    };
+
+    // This share will go through publishWorkspaceGossip, which fails
+    // and calls recordSwmGossipPublishFailure for a brand-new cgId
+    // (count=1) — guaranteed to be the smallest and thus the one
+    // evicted into overflow. Pre-R12, the WARN log re-read the map
+    // after eviction and printed failureCountForCg=0.
+    const newCg = 'swm-pub-fail-cg-overflow-new';
+    await agent.share(newCg, [{
+      subject: 'urn:test:overflow',
+      predicate: 'http://schema.org/name',
+      object: '"will overflow"',
+      graph: '',
+    }]);
+
+    const warn = captured.find((c) => /Gossip publish FAILED/.test(c.message) && new RegExp(`cgId=${newCg}\\b`).test(c.message));
+    expect(warn).toBeDefined();
+    expect(warn!.message).toContain('failureCountForCg=1');
+    expect(warn!.message).not.toContain('failureCountForCg=0');
+    expect(warn!.message).toContain('evicted to overflow bucket');
+
+    const stats = agent.getSwmGossipStats();
+    expect(stats.publishFailuresTruncated).toBe(true);
+    // The new cgId itself should NOT appear in the per-cgId map
+    // (it was evicted into overflow on the very same call).
+    expect(stats.publishFailures[newCg]).toBeUndefined();
+    expect(stats.publishFailuresOverflow).toBeGreaterThanOrEqual(1);
   });
 
   it('initialises receiver-side handler stats as empty even before any share is received', async () => {

--- a/packages/agent/test/swm-gossip-publish-failure.test.ts
+++ b/packages/agent/test/swm-gossip-publish-failure.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent } from '../src/index.js';
+
+class ThrowingGossip {
+  publishAttempts: Array<{ topic: string; bytes: number }> = [];
+
+  subscribe(_topic: string): void {}
+  unsubscribe(_topic: string): void {}
+  onMessage(_topic: string, _handler: (topic: string, data: Uint8Array, from?: string) => void | Promise<void>): void {}
+
+  async publish(topic: string, data: Uint8Array): Promise<void> {
+    this.publishAttempts.push({ topic, bytes: data.byteLength });
+    throw new Error(`simulated mesh failure for ${topic}`);
+  }
+}
+
+// PR-A R6 regression: throws a named, non-generic error class so the
+// WARN line can record both the class name and the message. Pre-fix
+// the catch block only logged err.message, collapsing distinct types
+// like `NoPeersSubscribedError` into the same log shape.
+class NoPeersSubscribedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NoPeersSubscribedError';
+  }
+}
+
+class TypedThrowingGossip {
+  publishAttempts: Array<{ topic: string; bytes: number }> = [];
+  subscribe(_topic: string): void {}
+  unsubscribe(_topic: string): void {}
+  onMessage(_topic: string, _handler: (topic: string, data: Uint8Array, from?: string) => void | Promise<void>): void {}
+  async publish(topic: string, data: Uint8Array): Promise<void> {
+    this.publishAttempts.push({ topic, bytes: data.byteLength });
+    throw new NoPeersSubscribedError(`no peers subscribed to ${topic}`);
+  }
+}
+
+describe('DKGAgent SWM gossip publish failure (rc.9 PR-A)', () => {
+  it('reports zero publish failures before any share has been attempted', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmGossipFailureZero',
+      chainAdapter: new MockChainAdapter(),
+    });
+
+    expect(agent.getSwmGossipStats()).toEqual({
+      publishFailures: {},
+      publishFailuresOverflow: 0,
+      publishFailuresTruncated: false,
+    });
+  });
+
+  it('bumps the per-cgId failure counter when gossip.publish throws, and share() still succeeds', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmGossipFailureBump',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const gossip = new ThrowingGossip();
+    (agent as unknown as { gossip: ThrowingGossip }).gossip = gossip;
+    Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
+      value: { toString: () => '12D3KooWPublisherLoudFail' },
+      configurable: true,
+    });
+
+    const contextGraphId = 'swm-pub-fail-cg-a';
+
+    const result = await agent.share(contextGraphId, [{
+      subject: 'urn:test:loud-fail',
+      predicate: 'http://schema.org/name',
+      object: '"local commit succeeded"',
+      graph: '',
+    }]);
+
+    expect(typeof result.shareOperationId).toBe('string');
+    expect(result.shareOperationId.length).toBeGreaterThan(0);
+
+    expect(gossip.publishAttempts).toHaveLength(1);
+    expect(gossip.publishAttempts[0]?.topic).toMatch(/shared-memory$/);
+
+    expect(agent.getSwmGossipStats()).toEqual({
+      publishFailures: { [contextGraphId]: 1 },
+      publishFailuresOverflow: 0,
+      publishFailuresTruncated: false,
+    });
+  });
+
+  it('isolates the counter per cgId and accumulates across calls', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmGossipFailureMulti',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const gossip = new ThrowingGossip();
+    (agent as unknown as { gossip: ThrowingGossip }).gossip = gossip;
+    Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
+      value: { toString: () => '12D3KooWPublisherMulti' },
+      configurable: true,
+    });
+
+    const cgA = 'swm-pub-fail-cg-multi-a';
+    const cgB = 'swm-pub-fail-cg-multi-b';
+
+    await agent.share(cgA, [{ subject: 'urn:t:1', predicate: 'http://schema.org/name', object: '"A1"', graph: '' }]);
+    await agent.share(cgA, [{ subject: 'urn:t:2', predicate: 'http://schema.org/name', object: '"A2"', graph: '' }]);
+    await agent.share(cgB, [{ subject: 'urn:t:3', predicate: 'http://schema.org/name', object: '"B1"', graph: '' }]);
+
+    expect(agent.getSwmGossipStats()).toEqual({
+      publishFailures: { [cgA]: 2, [cgB]: 1 },
+      publishFailuresOverflow: 0,
+      publishFailuresTruncated: false,
+    });
+  });
+
+  // PR-A R8 regression: once the cap is hit, a brand-new cgId with
+  // count=1 MUST evict itself into overflow (not push out an existing
+  // hot cgId). The pre-R8 eviction always protected the just-
+  // incremented entry, so a stream of one-off failures could
+  // displace hot cgIds. Post-fix, the comparison is global — the
+  // smallest count wins eviction, even if that's the new entry.
+  it('hot cgId survives a stream of one-off failures against fresh cgIds (R8)', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmGossipFailureR8Hot',
+      chainAdapter: new MockChainAdapter(),
+    });
+    Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
+      value: { toString: () => '12D3KooWPublisherR8' },
+      configurable: true,
+    });
+
+    const internals = agent as unknown as {
+      swmGossipPublishFailures: Map<string, number>;
+      recordSwmGossipPublishFailure: (cgId: string) => void;
+    };
+    const Cls = (agent.constructor as unknown as { SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS: number });
+    const cap = Cls.SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS;
+
+    for (let i = 0; i < 10; i++) {
+      internals.recordSwmGossipPublishFailure('cg-hot');
+    }
+    for (let i = 0; i < cap; i++) {
+      internals.recordSwmGossipPublishFailure(`cg-cold-${i}`);
+    }
+    for (let i = 0; i < 50; i++) {
+      internals.recordSwmGossipPublishFailure(`cg-oneoff-${i}`);
+    }
+
+    const stats = agent.getSwmGossipStats();
+    expect(stats.publishFailuresTruncated).toBe(true);
+    expect(stats.publishFailures['cg-hot']).toBe(10);
+    expect(Object.keys(stats.publishFailures).length).toBeLessThanOrEqual(cap);
+  });
+
+  // PR-A R5 regression: failures against thousands of distinct cgIds
+  // must not unboundedly grow the per-cgId map (and the /api/slo
+  // payload). When we cross SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS the
+  // smallest counter is evicted into `publishFailuresOverflow` and
+  // the sticky `publishFailuresTruncated` flag flips. Test exercises
+  // the eviction path by failing publishes against more cgIds than
+  // the cap, with one "hot" cgId that should survive eviction.
+  it('caps the per-cgId map + spills overflow + flips truncated flag (R5)', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmGossipFailureCap',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const gossip = new ThrowingGossip();
+    (agent as unknown as { gossip: ThrowingGossip }).gossip = gossip;
+    Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
+      value: { toString: () => '12D3KooWPublisherCap' },
+      configurable: true,
+    });
+
+    const internals = agent as unknown as {
+      swmGossipPublishFailures: Map<string, number>;
+      recordSwmGossipPublishFailure: (cgId: string) => void;
+    };
+    const Cls = (agent.constructor as unknown as { SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS: number });
+    const cap = Cls.SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS;
+
+    for (let i = 0; i < 5; i++) {
+      internals.recordSwmGossipPublishFailure('cg-hot');
+    }
+    for (let i = 0; i < cap; i++) {
+      internals.recordSwmGossipPublishFailure(`cg-cold-${i}`);
+    }
+
+    const stats = agent.getSwmGossipStats();
+    expect(stats.publishFailuresTruncated).toBe(true);
+    expect(stats.publishFailuresOverflow).toBeGreaterThan(0);
+    expect(stats.publishFailures['cg-hot']).toBe(5);
+    expect(Object.keys(stats.publishFailures).length).toBeLessThanOrEqual(cap);
+  });
+
+  // PR-A R6 regression: the WARN line includes the error CLASS, not
+  // just err.message. Pre-fix the comment claimed "error class" but
+  // the code only logged err.message, so a NoPeersSubscribedError and
+  // a generic transport error looked identical in daemon.log.
+  it('WARN log carries the error class name distinct from the error message (R6)', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmGossipFailureErrClass',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const gossip = new TypedThrowingGossip();
+    (agent as unknown as { gossip: TypedThrowingGossip }).gossip = gossip;
+    Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
+      value: { toString: () => '12D3KooWPublisherTyped' },
+      configurable: true,
+    });
+
+    const captured: Array<{ ctx: unknown; message: string }> = [];
+    const originalWarn = (agent as unknown as { log: { warn: (ctx: unknown, msg: string) => void } }).log.warn.bind(
+      (agent as unknown as { log: { warn: (ctx: unknown, msg: string) => void } }).log,
+    );
+    (agent as unknown as { log: { warn: (ctx: unknown, msg: string) => void } }).log.warn = (ctx, message) => {
+      captured.push({ ctx, message });
+      originalWarn(ctx, message);
+    };
+
+    await agent.share('swm-pub-fail-cg-err-class', [{
+      subject: 'urn:test:err-class',
+      predicate: 'http://schema.org/name',
+      object: '"typed failure"',
+      graph: '',
+    }]);
+
+    const warn = captured.find((c) => /Gossip publish FAILED/.test(c.message));
+    expect(warn).toBeDefined();
+    expect(warn!.message).toContain('errorClass="NoPeersSubscribedError"');
+    expect(warn!.message).toContain('error="no peers subscribed to');
+  });
+
+  it('initialises receiver-side handler stats as empty even before any share is received', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmHandlerStatsEmpty',
+      chainAdapter: new MockChainAdapter(),
+    });
+
+    expect(agent.getSwmHandlerStats()).toEqual({
+      redundantApplies: {},
+      redundantAppliesLowerBound: false,
+      redundantAppliesOverflow: 0,
+      redundantAppliesTruncated: false,
+    });
+  });
+});

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -627,10 +627,7 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
   // in front. The agent.getMessengerSloStats() call itself is cheap
   // (≤ 8 protocols × ≤ 1k samples sort) so no rate limit is needed.
   if (req.method === "GET" && path === "/api/slo") {
-    const protocols = agent.getMessengerSloStats();
-    const gossip = agent.getSwmGossipStats();
-    const swm = agent.getSwmHandlerStats();
-    return jsonResponse(res, 200, { protocols, gossip, swm });
+    return jsonResponse(res, 200, buildSloPayload(agent));
   }
 
   // GET /api/skills
@@ -951,4 +948,51 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
       throw err;
     }
   }
+}
+
+/**
+ * Build the `/api/slo` response payload. Extracted out of the inline
+ * route block so the public wire shape is testable in isolation
+ * (rc.9 PR-A / Codex PR #570 R10) — production route + regression
+ * test share the exact same code path, so a future drift in any
+ * field name / nesting can't slip past CI.
+ *
+ * Cold-start safety: when `sharedMemoryHandler` has never been
+ * instantiated (no SWM share has ever been received), the agent's
+ * `getSwmHandlerStats()` returns its pristine snapshot rather than
+ * throwing — `buildSloPayload` is safe to call against a fresh
+ * daemon.
+ */
+export function buildSloPayload(agent: {
+  getMessengerSloStats: () => Record<string, unknown>;
+  getSwmGossipStats: () => {
+    publishFailures: Record<string, number>;
+    publishFailuresOverflow: number;
+    publishFailuresTruncated: boolean;
+  };
+  getSwmHandlerStats: () => {
+    redundantApplies: Record<string, number>;
+    redundantAppliesLowerBound: boolean;
+    redundantAppliesOverflow: number;
+    redundantAppliesTruncated: boolean;
+  };
+}): {
+  protocols: Record<string, unknown>;
+  gossip: {
+    publishFailures: Record<string, number>;
+    publishFailuresOverflow: number;
+    publishFailuresTruncated: boolean;
+  };
+  swm: {
+    redundantApplies: Record<string, number>;
+    redundantAppliesLowerBound: boolean;
+    redundantAppliesOverflow: number;
+    redundantAppliesTruncated: boolean;
+  };
+} {
+  return {
+    protocols: agent.getMessengerSloStats(),
+    gossip: agent.getSwmGossipStats(),
+    swm: agent.getSwmHandlerStats(),
+  };
 }

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -610,6 +610,13 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
   // monotonic delivered / queued counters. Source of truth for the
   // ship-gate overnight soak.
   //
+  // rc.9 PR-A (SWM reliable fan-out plan, Step 0) extended the
+  // response shape with two new top-level sections — `gossip` for
+  // SWM gossip publish failures (pre-rc.9 silently swallowed) and
+  // `swm` for receiver-side redundant-apply measurement (informs
+  // rc10 Concern-2 dedup decision). Both are additive; existing
+  // consumers that parse `protocols` keep working.
+  //
   // SECURITY: this endpoint is reachable only from localhost via the
   // daemon's bind address (the daemon binds /api/* to 127.0.0.1 by
   // default — see packages/cli/src/daemon/lifecycle.ts). Per-protocol
@@ -620,8 +627,10 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
   // in front. The agent.getMessengerSloStats() call itself is cheap
   // (≤ 8 protocols × ≤ 1k samples sort) so no rate limit is needed.
   if (req.method === "GET" && path === "/api/slo") {
-    const stats = agent.getMessengerSloStats();
-    return jsonResponse(res, 200, { protocols: stats });
+    const protocols = agent.getMessengerSloStats();
+    const gossip = agent.getSwmGossipStats();
+    const swm = agent.getSwmHandlerStats();
+    return jsonResponse(res, 200, { protocols, gossip, swm });
   }
 
   // GET /api/skills

--- a/packages/cli/test/api-slo-route.test.ts
+++ b/packages/cli/test/api-slo-route.test.ts
@@ -1,0 +1,178 @@
+// /api/slo route-level wire-format regression test.
+//
+// rc.9 PR-A added two new top-level sections (`gossip`, `swm`) to
+// the `/api/slo` response. Codex review on PR #570 R10 caught that
+// the PR only exercised the internal getters/handlers; the public
+// HTTP wire shape was untested, making it easy to silently break
+// later — especially the cold-start case where `sharedMemoryHandler`
+// is still undefined and the receiver-side stats getter must return
+// the pristine snapshot.
+//
+// We pin the wire shape by exercising the production `buildSloPayload`
+// helper (which the live route also calls) through a real HTTP
+// roundtrip via `jsonResponse`. If the route's bundling shape, the
+// helper's field names, or any of the three getters' return shape
+// changes, this test fails — protecting soak tooling + operators
+// from a silent breaking change.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { jsonResponse } from '../src/daemon/http-utils.js';
+import { buildSloPayload } from '../src/daemon/routes/agent-chat.js';
+
+type FakeAgent = Parameters<typeof buildSloPayload>[0];
+
+async function startSloServer(agent: FakeAgent): Promise<{ server: Server; port: number }> {
+  const server = createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/api/slo') {
+      return jsonResponse(res, 200, buildSloPayload(agent));
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address();
+  if (typeof addr === 'string' || addr === null) throw new Error('server addr unavailable');
+  return { server, port: addr.port };
+}
+
+async function get(port: number, path: string): Promise<{ status: number; body: unknown }> {
+  const response = await fetch(`http://127.0.0.1:${port}${path}`);
+  const text = await response.text();
+  return { status: response.status, body: text.length > 0 ? JSON.parse(text) : null };
+}
+
+describe('/api/slo wire format (rc.9 PR-A / Codex PR #570 R10)', () => {
+  let server: Server | null = null;
+  let port = 0;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => server!.close((err) => (err ? reject(err) : resolve())));
+      server = null;
+    }
+  });
+
+  it('pristine cold-start payload — all three sections present, all empty/zero', async () => {
+    const agent: FakeAgent = {
+      getMessengerSloStats: () => ({}),
+      getSwmGossipStats: () => ({
+        publishFailures: {},
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      }),
+      getSwmHandlerStats: () => ({
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+      }),
+    };
+    ({ server, port } = await startSloServer(agent));
+
+    const { status, body } = await get(port, '/api/slo');
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      protocols: {},
+      gossip: {
+        publishFailures: {},
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      },
+      swm: {
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+      },
+    });
+  });
+
+  it('populated payload — every field flows through end-to-end', async () => {
+    const agent: FakeAgent = {
+      getMessengerSloStats: () => ({
+        '/dkg/10.0.1/message': {
+          samples: 847,
+          p50Ms: 42,
+          p95Ms: 380,
+          p99Ms: 1240,
+          delivered: 1602,
+          queued: 14,
+        },
+      }),
+      getSwmGossipStats: () => ({
+        publishFailures: { 'did:dkg:context-graph:lex/playground': 3 },
+        publishFailuresOverflow: 7,
+        publishFailuresTruncated: true,
+      }),
+      getSwmHandlerStats: () => ({
+        redundantApplies: { 'did:dkg:context-graph:lex/playground': 5 },
+        redundantAppliesLowerBound: true,
+        redundantAppliesOverflow: 11,
+        redundantAppliesTruncated: true,
+      }),
+    };
+    ({ server, port } = await startSloServer(agent));
+
+    const { status, body } = await get(port, '/api/slo');
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      protocols: {
+        '/dkg/10.0.1/message': {
+          samples: 847,
+          p50Ms: 42,
+          p95Ms: 380,
+          p99Ms: 1240,
+          delivered: 1602,
+          queued: 14,
+        },
+      },
+      gossip: {
+        publishFailures: { 'did:dkg:context-graph:lex/playground': 3 },
+        publishFailuresOverflow: 7,
+        publishFailuresTruncated: true,
+      },
+      swm: {
+        redundantApplies: { 'did:dkg:context-graph:lex/playground': 5 },
+        redundantAppliesLowerBound: true,
+        redundantAppliesOverflow: 11,
+        redundantAppliesTruncated: true,
+      },
+    });
+  });
+
+  it('partial / mid-life payload — gossip populated, swm pristine', async () => {
+    const agent: FakeAgent = {
+      getMessengerSloStats: () => ({}),
+      getSwmGossipStats: () => ({
+        publishFailures: { 'cg-with-failures': 1 },
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      }),
+      getSwmHandlerStats: () => ({
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+      }),
+    };
+    ({ server, port } = await startSloServer(agent));
+
+    const { status, body } = await get(port, '/api/slo');
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      protocols: {},
+      gossip: {
+        publishFailures: { 'cg-with-failures': 1 },
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      },
+      swm: {
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+      },
+    });
+  });
+});

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -66,6 +66,57 @@ export class SharedMemoryHandler {
   private readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
   private readonly log = new Logger('SharedMemoryHandler');
 
+  /**
+   * Per-(cgId|shareOperationId) timestamp of the most recent legitimate
+   * delivery. Used purely for measurement of the redundant-apply rate
+   * surfaced via /api/slo `swm.redundantApplies`. Bumped (without
+   * blocking the apply) whenever we see a `(cgId, shareOperationId)`
+   * we already processed within the TTL window.
+   *
+   * Lives here rather than in DKGAgent because once Step 1a / 1b of the
+   * SWM reliable fan-out plan land, the gossip and substrate delivery
+   * paths both terminate at `SharedMemoryHandler.handle()` — this is
+   * the natural place to count duplicates that result from the two-
+   * path race (gossip arrives, then substrate top-up fires before
+   * receiver ack catches up to author).
+   *
+   * Bounded LRU: when size exceeds SEEN_OPS_MAX_SIZE, the oldest entries
+   * are evicted in batches. Insertion order is JS-Map-iteration order,
+   * so eviction is O(batch_size).
+   */
+  private readonly seenShareOps = new Map<string, number>();
+  private readonly redundantApplyCounts = new Map<string, number>();
+  /**
+   * Sum of redundant-apply counts evicted into the overflow bucket
+   * when `redundantApplyCounts.size` exceeds `redundantAppliesMaxCgs`.
+   * Always 0 in normal deployments; non-zero only when redundant
+   * applies arrive against thousands of distinct cgIds (typically a
+   * buggy or hostile peer). Surfaces via `getStats()` so /api/slo
+   * stays bounded.
+   *
+   * Codex PR #570 R9 caught the unbounded growth.
+   */
+  private redundantApplyCountsOverflow = 0;
+  /** Sticky truncated flag for `redundantApplyCounts` (R9). */
+  private redundantApplyCountsTruncated = false;
+  private readonly seenOpsTtlMs: number;
+  private readonly seenOpsMaxSize: number;
+  private readonly seenOpsEvictBatch: number;
+  private readonly redundantAppliesMaxCgs: number;
+  /**
+   * Becomes true the first time the cap eviction had to trim a
+   * non-expired entry (i.e., the TTL window stopped being accurate
+   * because throughput outran the cap). Surfaced via `getStats()` so
+   * `/api/slo` operators can see that `redundantApplies` is a lower
+   * bound rather than an exact count. Codex review on PR #570
+   * caught the silent undercount.
+   */
+  private seenOpsCapEvictedLiveEntries = false;
+  private static readonly DEFAULT_SEEN_OPS_TTL_MS = 10 * 60 * 1000;
+  private static readonly DEFAULT_SEEN_OPS_MAX_SIZE = 50_000;
+  private static readonly DEFAULT_SEEN_OPS_EVICT_BATCH = 5_000;
+  private static readonly DEFAULT_REDUNDANT_APPLIES_MAX_CGS = 1024;
+
   constructor(
     store: TripleStore,
     eventBus: EventBus,
@@ -79,6 +130,27 @@ export class SharedMemoryHandler {
       workspaceSenderKeyDecryptor?: WorkspaceSenderKeyDecryptor;
       now?: () => number;
       publicSnapshotStore?: WorkspacePublicSnapshotStore;
+      /**
+       * Override the seen-share-op TTL (default 10 min). Lower values
+       * are useful in tests / very-low-RAM deployments. Codex review
+       * #570 R3 surfaced that the cap-based eviction was potentially
+       * silently trimming live entries above ~83 unique ops/sec; the
+       * configurable knobs let operators tune for their throughput.
+       */
+      seenOpsTtlMs?: number;
+      /** Override the seen-share-op map capacity (default 50_000). */
+      seenOpsMaxSize?: number;
+      /** Override the seen-share-op eviction batch size (default 5_000). */
+      seenOpsEvictBatch?: number;
+      /**
+       * Override the per-cgId `redundantApplyCounts` map capacity
+       * (default 1024). Codex PR #570 R9: the per-cgId redundant-apply
+       * counter map was unbounded — a buggy/hostile peer could grow
+       * memory + /api/slo payload by forcing one duplicate on many
+       * fresh cgIds. Beyond this cap, the smallest counter is evicted
+       * into an overflow bucket so the grand total stays accurate.
+       */
+      redundantAppliesMaxCgs?: number;
     },
   ) {
     this.store = store;
@@ -93,6 +165,177 @@ export class SharedMemoryHandler {
     this.workspaceSenderKeyDecryptor = options?.workspaceSenderKeyDecryptor;
     this.now = options?.now ?? (() => Date.now());
     this.publicSnapshotStore = options?.publicSnapshotStore;
+    this.seenOpsTtlMs = options?.seenOpsTtlMs ?? SharedMemoryHandler.DEFAULT_SEEN_OPS_TTL_MS;
+    this.seenOpsMaxSize = options?.seenOpsMaxSize ?? SharedMemoryHandler.DEFAULT_SEEN_OPS_MAX_SIZE;
+    this.seenOpsEvictBatch = options?.seenOpsEvictBatch ?? SharedMemoryHandler.DEFAULT_SEEN_OPS_EVICT_BATCH;
+    this.redundantAppliesMaxCgs =
+      options?.redundantAppliesMaxCgs ?? SharedMemoryHandler.DEFAULT_REDUNDANT_APPLIES_MAX_CGS;
+  }
+
+  /**
+   * Bump the redundant-apply counter when a (cgId, shareOpId) pair
+   * is observed a second time within the TTL window. Idempotent on
+   * repeat observations within TTL (counter increments each repeat).
+   *
+   * Codex review on PR #570 surfaced four correctness issues that
+   * this fixed shape addresses:
+   *
+   *   R1: callers must only invoke this AFTER the delivery has
+   *       passed allowlist + sub-graph validation + CAS + actual
+   *       write — counting rejected deliveries would skew the
+   *       /api/slo `swm.redundantApplies` gauge that informs the
+   *       rc10 dedup decision. Call site is now inside the
+   *       `if (applied)` block in `handle()`.
+   *
+   *   R2: eviction is true LRU, not just least-recently-inserted.
+   *       `Map#set(existingKey, …)` updates the value but leaves
+   *       iteration order untouched, so a hot key inserted long
+   *       ago could still be evicted when the map crosses
+   *       seenOpsMaxSize. We now `delete(key)` before
+   *       re-inserting on a hit, which moves the key to the end of
+   *       iteration order so eviction takes the genuinely oldest
+   *       entries.
+   *
+   *   R3: eviction prunes TTL-expired entries first, then falls
+   *       back to cap-based batch eviction only if everything is
+   *       still live. Pre-fix, at ~83 unique ops/sec the cap was
+   *       hit before TTL expiry, so live entries got dropped and
+   *       `redundantApplies` undercounted exactly when the metric
+   *       was meant to inform the rc10 dedup decision. When the
+   *       fallback path DOES have to trim live entries (e.g.,
+   *       configured cap too small for the throughput), we set a
+   *       sticky flag so operators see `redundantAppliesLowerBound`
+   *       on the `/api/slo` snapshot.
+   *
+   *   R4: see workspace.test.ts — the regression test now drives
+   *       the map past the configured cap so the LRU refresh +
+   *       prune-expired-first paths are exercised, not just the
+   *       insertion-order assertion.
+   */
+  private recordSeenShareOp(
+    cgId: string,
+    shareOperationId: string,
+    ctx: import('@origintrail-official/dkg-core').OperationContext,
+  ): void {
+    const key = `${cgId}|${shareOperationId}`;
+    const nowMs = this.now();
+    const previousAt = this.seenShareOps.get(key);
+    if (previousAt !== undefined) {
+      if (nowMs - previousAt < this.seenOpsTtlMs) {
+        const next = (this.redundantApplyCounts.get(cgId) ?? 0) + 1;
+        this.redundantApplyCounts.set(cgId, next);
+        this.enforceRedundantApplyCountsCap();
+        this.log.debug(ctx, `SWM redundant apply (cgId=${cgId} op=${shareOperationId} count=${next})`);
+      }
+      // PR-A R2: refresh the LRU position. `Map#set(existingKey, v)`
+      // alone does NOT move the key to the end of iteration order;
+      // we must delete first so the subsequent set re-inserts at the
+      // tail. Without this, a hot key inserted at t=0 keeps the same
+      // position even after a t=now access and eventually gets
+      // evicted as if it were cold.
+      this.seenShareOps.delete(key);
+    }
+    this.seenShareOps.set(key, nowMs);
+    if (this.seenShareOps.size > this.seenOpsMaxSize) {
+      // PR-A R3 Phase 1: prune TTL-expired entries first. Iteration
+      // order is LRU (oldest first thanks to the delete+set in R2),
+      // so we can sweep from the front and bail at the first live
+      // entry — O(actually-expired), not O(n).
+      for (const [k, ts] of this.seenShareOps) {
+        if (nowMs - ts < this.seenOpsTtlMs) break;
+        this.seenShareOps.delete(k);
+      }
+      // PR-A R3 Phase 2: if the map is STILL over the cap after
+      // pruning expired, it means throughput has outrun the
+      // configured cap and we must trim still-live entries to stay
+      // bounded. This makes redundantApplies a lower bound rather
+      // than exact — surface that to operators via the sticky
+      // `seenOpsCapEvictedLiveEntries` flag (exposed through
+      // getStats()) so `/api/slo` can flag it.
+      if (this.seenShareOps.size > this.seenOpsMaxSize) {
+        let evicted = 0;
+        for (const k of this.seenShareOps.keys()) {
+          if (evicted >= this.seenOpsEvictBatch) break;
+          this.seenShareOps.delete(k);
+          evicted += 1;
+        }
+        if (!this.seenOpsCapEvictedLiveEntries) {
+          this.seenOpsCapEvictedLiveEntries = true;
+          this.log.warn(
+            ctx,
+            `SWM seenShareOps cap eviction trimmed ${evicted} live (non-TTL-expired) entries — redundantApplies is now a lower bound. Consider raising seenOpsMaxSize (current=${this.seenOpsMaxSize}).`,
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * PR-A R9: bound the per-cgId redundant-apply counter map. The
+   * receiver-side `redundantApplyCounts` would otherwise grow O(distinct
+   * cgIds ever observed) — a buggy or hostile peer could force one
+   * duplicate apply on many fresh cgIds and inflate both process
+   * memory and the /api/slo response payload indefinitely. Mirrors
+   * the swmGossipPublishFailures cap on the sender side.
+   *
+   * Eviction picks the GLOBAL smallest counter (including the
+   * just-incremented one) — so when the new entry IS the smallest,
+   * it gets evicted into the overflow bucket and the existing hot
+   * cgIds stay intact (Codex PR #570 R8 lifted here too).
+   */
+  private enforceRedundantApplyCountsCap(): void {
+    if (this.redundantApplyCounts.size <= this.redundantAppliesMaxCgs) return;
+    let smallestCg: string | null = null;
+    let smallestCount = Infinity;
+    for (const [cg, count] of this.redundantApplyCounts) {
+      if (count < smallestCount) {
+        smallestCount = count;
+        smallestCg = cg;
+      }
+    }
+    if (smallestCg !== null) {
+      this.redundantApplyCounts.delete(smallestCg);
+      this.redundantApplyCountsOverflow += smallestCount;
+      if (!this.redundantApplyCountsTruncated) {
+        this.redundantApplyCountsTruncated = true;
+      }
+    }
+  }
+
+  /**
+   * Snapshot of receiver-side SWM metrics for /api/slo. rc.9 PR-A.
+   *
+   * - `redundantApplies`: per-cgId counts of redundant applies (same
+   *   `shareOpId` delivered twice within the TTL window AND both
+   *   deliveries actually applied to the store). Counter increments
+   *   each additional delivery beyond the first.
+   * - `redundantAppliesLowerBound`: sticky boolean set to true the
+   *   moment cap-based eviction had to trim a still-live (non-TTL-
+   *   expired) entry from `seenShareOps`. Once true, the
+   *   `redundantApplies` figures are a lower bound for the operating
+   *   window — surfaces via Codex PR #570 R3 so operators can spot
+   *   the configured `seenOpsMaxSize` no longer fits their throughput.
+   * - `redundantAppliesOverflow`: sum of counters evicted into
+   *   overflow when `redundantApplyCounts.size` crossed
+   *   `redundantAppliesMaxCgs`. Surfaces via Codex PR #570 R9 so the
+   *   grand total stays accurate even when the per-cgId breakdown
+   *   gets truncated.
+   * - `redundantAppliesTruncated`: sticky boolean, true once R9
+   *   eviction has fired. Means the per-cgId breakdown is partial;
+   *   total is still `sum(redundantApplies) + redundantAppliesOverflow`.
+   */
+  getStats(): {
+    redundantApplies: Record<string, number>;
+    redundantAppliesLowerBound: boolean;
+    redundantAppliesOverflow: number;
+    redundantAppliesTruncated: boolean;
+  } {
+    return {
+      redundantApplies: Object.fromEntries(this.redundantApplyCounts),
+      redundantAppliesLowerBound: this.seenOpsCapEvictedLiveEntries,
+      redundantAppliesOverflow: this.redundantApplyCountsOverflow,
+      redundantAppliesTruncated: this.redundantApplyCountsTruncated,
+    };
   }
 
   private async withWriteLocks<T>(keys: string[], fn: () => Promise<T>): Promise<T> {
@@ -271,6 +514,13 @@ export class SharedMemoryHandler {
         return;
       }
 
+      // PR-A R1 NOTE: the redundant-apply counter is bumped AFTER the
+      // write succeeds (inside `if (applied)` below), not here. Counting
+      // pre-validation deliveries would let bogus / replay-rejected /
+      // CAS-rejected messages skew the `/api/slo` `redundantApplies`
+      // gauge that the rc10 dedup decision relies on. Codex review on
+      // PR #570 caught the earlier shape.
+
       // Enforce peer allowlist for curated CGs
       if (allowedPeers !== null && !allowedPeers.includes(fromPeerId)) {
         this.log.warn(ctx, `SWM write rejected: peer "${fromPeerId}" not in allowlist for context graph "${contextGraphId}"`);
@@ -439,6 +689,12 @@ export class SharedMemoryHandler {
 
       onPhase?.('store', 'end');
       if (applied) {
+        // PR-A R1: only record the observation after the apply actually
+        // succeeded — passing allowlist + sub-graph validation + CAS +
+        // the durable store insert. Recording earlier would let
+        // rejected duplicate deliveries count as "redundant applies"
+        // and skew the `/api/slo` metric.
+        this.recordSeenShareOp(contextGraphId, shareOperationId, ctx);
         this.log.info(ctx, `Stored SWM write ${shareOperationId} (${quads.length} quads)`);
         this.eventBus.emit(DKGEvent.MEMORY_GRAPH_CHANGED, {
           contextGraphId,

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -46,6 +46,31 @@ export type WorkspaceSenderKeyDecryptor = (
 ) => Promise<Uint8Array>;
 
 /**
+ * Unambiguous composite key for `seenShareOps`.
+ *
+ * **Why not `${cgId}|${shareOperationId}` (rc.9 PR-A codex follow-up
+ * #11)**: both `cgId` and `shareOperationId` are wire-supplied by
+ * the publishing peer, neither is structurally constrained to
+ * exclude `|`. A peer can therefore craft two distinct logical
+ * pairs that hash to the SAME composite-string key
+ * (`cgId="a|b" + op="c"` and `cgId="a" + op="b|c"` both produce
+ * `"a|b|c"`), letting them collide `redundantApplies` accounting:
+ * a legitimate apply on one pair could appear to be a "redundant"
+ * re-delivery of the other. The metric is operator-facing, so the
+ * skew is bounded but it would still let a hostile peer poison the
+ * counter for unrelated tenants.
+ *
+ * `JSON.stringify([cgId, shareOperationId])` is structurally
+ * unambiguous: array delimiters + quote-escaping make every
+ * (cgId, op) pair produce a unique key. The performance cost
+ * (one `JSON.stringify` per apply) is negligible — this runs only
+ * on legitimate deliveries that already passed validation.
+ */
+function seenShareOpKey(cgId: string, shareOperationId: string): string {
+  return JSON.stringify([cgId, shareOperationId]);
+}
+
+/**
  * Handles incoming shared memory topic messages (GossipSub).
  * Validates the request, stores public triples into SWM graph
  * and metadata into SWM meta graph. No chain, no UAL.
@@ -67,8 +92,10 @@ export class SharedMemoryHandler {
   private readonly log = new Logger('SharedMemoryHandler');
 
   /**
-   * Per-(cgId|shareOperationId) timestamp of the most recent legitimate
-   * delivery. Used purely for measurement of the redundant-apply rate
+   * Per-(cgId, shareOperationId) timestamp of the most recent legitimate
+   * delivery, keyed via {@link seenShareOpKey} so neither field can be
+   * crafted to collide with another pair (rc.9 PR-A codex follow-up
+   * #11). Used purely for measurement of the redundant-apply rate
    * surfaced via /api/slo `swm.redundantApplies`. Bumped (without
    * blocking the apply) whenever we see a `(cgId, shareOperationId)`
    * we already processed within the TTL window.
@@ -217,7 +244,7 @@ export class SharedMemoryHandler {
     shareOperationId: string,
     ctx: import('@origintrail-official/dkg-core').OperationContext,
   ): void {
-    const key = `${cgId}|${shareOperationId}`;
+    const key = seenShareOpKey(cgId, shareOperationId);
     const nowMs = this.now();
     const previousAt = this.seenShareOps.get(key);
     if (previousAt !== undefined) {

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -862,6 +862,353 @@ describe('SharedMemoryHandler', () => {
   });
 });
 
+describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
+  let store: OxigraphStore;
+  let handler: SharedMemoryHandler;
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {});
+  });
+
+  it('returns zero counts initially', () => {
+    expect(handler.getStats()).toEqual({ redundantApplies: {}, redundantAppliesLowerBound: false, redundantAppliesOverflow: 0, redundantAppliesTruncated: false });
+  });
+
+  it('does not count first delivery of a (cgId, shareOpId) pair', async () => {
+    const nquads = `<${ENTITY}> <http://schema.org/name> "First" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      shareOperationId: 'first-only',
+      timestampMs: Date.now(),
+    });
+
+    await handler.handle(msg, '12D3KooWPeer');
+
+    expect(handler.getStats()).toEqual({ redundantApplies: {}, redundantAppliesLowerBound: false, redundantAppliesOverflow: 0, redundantAppliesTruncated: false });
+  });
+
+  it('counts each subsequent delivery of the same (cgId, shareOpId) within TTL', async () => {
+    const nquads = `<${ENTITY}> <http://schema.org/name> "Twice" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      shareOperationId: 'dup-op',
+      timestampMs: Date.now(),
+    });
+
+    await handler.handle(msg, '12D3KooWPeer');
+    await handler.handle(msg, '12D3KooWPeer');
+    await handler.handle(msg, '12D3KooWPeer');
+
+    expect(handler.getStats()).toEqual({
+      redundantApplies: { [CONTEXT_GRAPH]: 2 },
+      redundantAppliesLowerBound: false,
+      redundantAppliesOverflow: 0,
+      redundantAppliesTruncated: false,
+    });
+  });
+
+  it('isolates counts per cgId', async () => {
+    const otherCg = `${CONTEXT_GRAPH}-second`;
+    const otherDataGraph = `did:dkg:context-graph:${otherCg}`;
+
+    const msgA = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(`<${ENTITY}> <http://schema.org/name> "A" <${DATA_GRAPH}> .`),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      shareOperationId: 'op-a',
+      timestampMs: Date.now(),
+    });
+    const msgB = encodeWorkspacePublishRequest({
+      contextGraphId: otherCg,
+      nquads: new TextEncoder().encode(`<${ENTITY}> <http://schema.org/name> "B" <${otherDataGraph}> .`),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      shareOperationId: 'op-b',
+      timestampMs: Date.now(),
+    });
+
+    await handler.handle(msgA, '12D3KooWPeer');
+    await handler.handle(msgA, '12D3KooWPeer');
+    await handler.handle(msgB, '12D3KooWPeer');
+    await handler.handle(msgB, '12D3KooWPeer');
+    await handler.handle(msgB, '12D3KooWPeer');
+
+    expect(handler.getStats()).toEqual({
+      redundantApplies: {
+        [CONTEXT_GRAPH]: 1,
+        [otherCg]: 2,
+      },
+      redundantAppliesLowerBound: false,
+      redundantAppliesOverflow: 0,
+      redundantAppliesTruncated: false,
+    });
+  });
+
+  it('does not count if same shareOpId is delivered but TTL has elapsed', async () => {
+    let nowMs = 1_000_000;
+    const handlerWithClock = new SharedMemoryHandler(store, new TypedEventBus(), {
+      now: () => nowMs,
+    });
+
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(`<${ENTITY}> <http://schema.org/name> "TTL" <${DATA_GRAPH}> .`),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      shareOperationId: 'op-ttl',
+      timestampMs: nowMs,
+    });
+
+    await handlerWithClock.handle(msg, '12D3KooWPeer');
+    nowMs += 10 * 60 * 1000 + 1;
+    await handlerWithClock.handle(msg, '12D3KooWPeer');
+
+    expect(handlerWithClock.getStats()).toEqual({ redundantApplies: {}, redundantAppliesLowerBound: false, redundantAppliesOverflow: 0, redundantAppliesTruncated: false });
+  });
+
+  it('still applies the second delivery (no behavior change — measurement only)', async () => {
+    const nquads = `<${ENTITY}> <http://schema.org/name> "Applied" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      shareOperationId: 'op-applied-twice',
+      timestampMs: Date.now(),
+    });
+
+    await handler.handle(msg, '12D3KooWPeer');
+    await handler.handle(msg, '12D3KooWPeer');
+
+    const gm = new GraphManager(store);
+    await gm.ensureContextGraph(CONTEXT_GRAPH);
+    const wsGraph = gm.workspaceGraphUri(CONTEXT_GRAPH);
+    const result = await store.query(
+      `SELECT ?o WHERE { GRAPH <${wsGraph}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      expect(result.bindings.length).toBe(1);
+      expect(result.bindings[0]['o']).toBe('"Applied"');
+    }
+    expect(handler.getStats()).toEqual({
+      redundantApplies: { [CONTEXT_GRAPH]: 1 },
+      redundantAppliesLowerBound: false,
+      redundantAppliesOverflow: 0,
+      redundantAppliesTruncated: false,
+    });
+  });
+
+  // PR-A R1 regression: a delivery that fails validation (here:
+  // invalid subGraphName — caught by `validateSubGraphName` before the
+  // write lock) MUST NOT bump `redundantApplies`. Pre-fix the counter
+  // was incremented at the top of `handle()` before any validation,
+  // so a steady stream of rejected duplicate messages would silently
+  // inflate the /api/slo metric the rc10 dedup decision is based on.
+  // Codex review on PR #570 caught the early-bump.
+  it('does NOT count a duplicated rejected delivery (R1: rejected messages skipped)', async () => {
+    const nquads = `<${ENTITY}> <http://schema.org/name> "Bad" <${DATA_GRAPH}> .`;
+    const badMsg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      shareOperationId: 'op-rejected',
+      timestampMs: Date.now(),
+      // Invalid sub-graph name — `validateSubGraphName` rejects, so
+      // `handle()` returns BEFORE the write lock and BEFORE
+      // recordSeenShareOp is invoked.
+      subGraphName: '../illegal',
+    });
+
+    await handler.handle(badMsg, '12D3KooWPeer');
+    await handler.handle(badMsg, '12D3KooWPeer');
+    await handler.handle(badMsg, '12D3KooWPeer');
+
+    expect(handler.getStats()).toEqual({ redundantApplies: {}, redundantAppliesLowerBound: false, redundantAppliesOverflow: 0, redundantAppliesTruncated: false });
+  });
+
+  it('does NOT count a duplicated delivery whose publisherPeerId disagrees with the sender (R1: rejected messages skipped)', async () => {
+    const nquads = `<${ENTITY}> <http://schema.org/name> "Spoofed" <${DATA_GRAPH}> .`;
+    const spoofedMsg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      // Claims to be from Peer-A but `handle()` receives it from
+      // Peer-Other → rejected at the publisherPeerId check.
+      publisherPeerId: '12D3KooWPeer-A',
+      shareOperationId: 'op-spoofed',
+      timestampMs: Date.now(),
+    });
+
+    await handler.handle(spoofedMsg, '12D3KooWPeer-Other');
+    await handler.handle(spoofedMsg, '12D3KooWPeer-Other');
+
+    expect(handler.getStats()).toEqual({ redundantApplies: {}, redundantAppliesLowerBound: false, redundantAppliesOverflow: 0, redundantAppliesTruncated: false });
+  });
+
+  // PR-A R2 + R4 regression: the seenShareOps map is true LRU AND
+  // the cap-based eviction is exercised. Pre-R2, `Map#set(existing,…)`
+  // didn't move the key in iteration order, so a hot key inserted at
+  // t=0 would be evicted as if cold. Pre-R4 the regression test only
+  // checked insertion order without crossing the cap, so removing the
+  // `delete(key)` fix would still let the test pass.
+  //
+  // This test drives the map past `seenOpsMaxSize` (configured tiny
+  // here, default is 50_000) so the eviction path actually runs and
+  // we can assert the hot key survives. Uses an injected fixed clock
+  // so the TTL prune-first phase doesn't bail anything out for us.
+  it('LRU refresh + cap eviction: a re-observed key survives an actual eviction batch (R2 + R4)', () => {
+    let nowMs = 1_000_000;
+    const handlerForLru = new SharedMemoryHandler(store, new TypedEventBus(), {
+      now: () => nowMs,
+      seenOpsMaxSize: 10,
+      seenOpsEvictBatch: 5,
+      seenOpsTtlMs: 10 * 60 * 1000,
+    });
+    const internals = handlerForLru as unknown as {
+      seenShareOps: Map<string, number>;
+      recordSeenShareOp: (cgId: string, opId: string, ctx: unknown) => void;
+    };
+    const ctx = {} as any;
+
+    internals.recordSeenShareOp('cg', 'hot', ctx);
+    for (let i = 0; i < 8; i++) {
+      internals.recordSeenShareOp('cg', `cold-${i}`, ctx);
+    }
+    internals.recordSeenShareOp('cg', 'hot', ctx);
+    internals.recordSeenShareOp('cg', 'cold-9', ctx);
+    internals.recordSeenShareOp('cg', 'cold-10', ctx);
+
+    const remaining = [...internals.seenShareOps.keys()];
+    expect(remaining).toContain('cg|hot');
+    expect(remaining.length).toBeLessThanOrEqual(10);
+    expect(remaining).not.toContain('cg|cold-0');
+    expect(remaining).not.toContain('cg|cold-1');
+  });
+
+  // PR-A R3 regression: when the map fills the cap, the FIRST eviction
+  // pass prunes TTL-expired entries — only if that's not enough does
+  // cap-based batch eviction kick in. Pre-fix, cap eviction trimmed
+  // live entries even when TTL-expired entries were sitting right
+  // there waiting to be removed, silently shrinking the measurement
+  // window. This test inserts entries at t=0, advances the clock past
+  // TTL, then inserts more — and asserts the t=0 entries are pruned
+  // by the TTL-first sweep before any live entries get touched.
+  it('cap eviction prunes TTL-expired entries first (R3)', () => {
+    let nowMs = 1_000_000;
+    const handlerForTtl = new SharedMemoryHandler(store, new TypedEventBus(), {
+      now: () => nowMs,
+      seenOpsMaxSize: 5,
+      seenOpsEvictBatch: 5,
+      seenOpsTtlMs: 1_000,
+    });
+    const internals = handlerForTtl as unknown as {
+      seenShareOps: Map<string, number>;
+      seenOpsCapEvictedLiveEntries: boolean;
+      recordSeenShareOp: (cgId: string, opId: string, ctx: unknown) => void;
+    };
+    const ctx = {} as any;
+
+    for (let i = 0; i < 5; i++) {
+      internals.recordSeenShareOp('cg', `expired-${i}`, ctx);
+    }
+    nowMs += 2_000;
+    internals.recordSeenShareOp('cg', 'live-0', ctx);
+    internals.recordSeenShareOp('cg', 'live-1', ctx);
+
+    const remaining = [...internals.seenShareOps.keys()];
+    expect(remaining).toContain('cg|live-0');
+    expect(remaining).toContain('cg|live-1');
+    for (let i = 0; i < 5; i++) {
+      expect(remaining).not.toContain(`cg|expired-${i}`);
+    }
+    expect(internals.seenOpsCapEvictedLiveEntries).toBe(false);
+    expect(handlerForTtl.getStats().redundantAppliesLowerBound).toBe(false);
+  });
+
+  // PR-A R9 regression: the per-cgId `redundantApplyCounts` map must
+  // be bounded. Pre-fix, a hostile peer could force one duplicate
+  // apply on many fresh cgIds and grow process memory + /api/slo
+  // payload unboundedly. Fix: cap at `redundantAppliesMaxCgs` (default
+  // 1024), evict smallest-count entries into an overflow bucket, flip
+  // a sticky truncated flag. R8 lifted: the eviction comparison is
+  // GLOBAL — when the new entry IS the smallest, it gets evicted
+  // (not pushing out an existing hot cgId).
+  it('caps redundantApplyCounts and protects hot cgIds against one-off bumps (R8 + R9)', () => {
+    let nowMs = 1_000_000;
+    const handlerForR9 = new SharedMemoryHandler(store, new TypedEventBus(), {
+      now: () => nowMs,
+      redundantAppliesMaxCgs: 4,
+      seenOpsTtlMs: 60 * 60 * 1000,
+    });
+    const internals = handlerForR9 as unknown as {
+      recordSeenShareOp: (cgId: string, opId: string, ctx: unknown) => void;
+      enforceRedundantApplyCountsCap: () => void;
+      redundantApplyCounts: Map<string, number>;
+    };
+    const ctx = {} as any;
+
+    for (let i = 0; i < 5; i++) {
+      internals.recordSeenShareOp('cg-hot', 'op-shared', ctx);
+      internals.recordSeenShareOp('cg-hot', 'op-shared', ctx);
+    }
+    const hotCountBeforeEviction = internals.redundantApplyCounts.get('cg-hot');
+    expect(hotCountBeforeEviction).toBeGreaterThanOrEqual(5);
+
+    for (let i = 0; i < 20; i++) {
+      const opId = `op-cold-${i}`;
+      internals.recordSeenShareOp(`cg-cold-${i}`, opId, ctx);
+      internals.recordSeenShareOp(`cg-cold-${i}`, opId, ctx);
+    }
+
+    const stats = handlerForR9.getStats();
+    expect(stats.redundantAppliesTruncated).toBe(true);
+    expect(stats.redundantAppliesOverflow).toBeGreaterThan(0);
+    expect(stats.redundantApplies['cg-hot']).toBe(hotCountBeforeEviction);
+    expect(Object.keys(stats.redundantApplies).length).toBeLessThanOrEqual(4);
+  });
+
+  // PR-A R3 regression: when throughput outruns even the prune-expired
+  // path (everything is still live AND we're over the cap), cap-based
+  // eviction MUST trim live entries to stay bounded. The sticky
+  // `redundantAppliesLowerBound` flag flips so operators see the
+  // /api/slo metric has become a lower bound for the operating window.
+  it('cap eviction sets the lower-bound flag when forced to trim live entries (R3)', () => {
+    let nowMs = 1_000_000;
+    const handlerForLowerBound = new SharedMemoryHandler(store, new TypedEventBus(), {
+      now: () => nowMs,
+      seenOpsMaxSize: 5,
+      seenOpsEvictBatch: 3,
+      seenOpsTtlMs: 60 * 60 * 1000,
+    });
+    const internals = handlerForLowerBound as unknown as {
+      seenShareOps: Map<string, number>;
+      seenOpsCapEvictedLiveEntries: boolean;
+      recordSeenShareOp: (cgId: string, opId: string, ctx: unknown) => void;
+    };
+    const ctx = {} as any;
+
+    expect(handlerForLowerBound.getStats().redundantAppliesLowerBound).toBe(false);
+
+    for (let i = 0; i < 10; i++) {
+      nowMs += 1;
+      internals.recordSeenShareOp('cg', `live-${i}`, ctx);
+    }
+
+    expect(internals.seenOpsCapEvictedLiveEntries).toBe(true);
+    expect(handlerForLowerBound.getStats().redundantAppliesLowerBound).toBe(true);
+  });
+});
+
 describe('SharedMemoryHandler: CAS gossip enforcement', () => {
   let store: OxigraphStore;
   let handler: SharedMemoryHandler;

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -1088,11 +1088,14 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
     internals.recordSeenShareOp('cg', 'cold-9', ctx);
     internals.recordSeenShareOp('cg', 'cold-10', ctx);
 
+    // PR-A R11: keys are `JSON.stringify([cgId, shareOperationId])`,
+    // not the legacy `${cgId}|${shareOperationId}` (which was
+    // ambiguous when either field contained `|`).
     const remaining = [...internals.seenShareOps.keys()];
-    expect(remaining).toContain('cg|hot');
+    expect(remaining).toContain(JSON.stringify(['cg', 'hot']));
     expect(remaining.length).toBeLessThanOrEqual(10);
-    expect(remaining).not.toContain('cg|cold-0');
-    expect(remaining).not.toContain('cg|cold-1');
+    expect(remaining).not.toContain(JSON.stringify(['cg', 'cold-0']));
+    expect(remaining).not.toContain(JSON.stringify(['cg', 'cold-1']));
   });
 
   // PR-A R3 regression: when the map fills the cap, the FIRST eviction
@@ -1125,11 +1128,12 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
     internals.recordSeenShareOp('cg', 'live-0', ctx);
     internals.recordSeenShareOp('cg', 'live-1', ctx);
 
+    // PR-A R11: keys are `JSON.stringify([cgId, shareOperationId])`.
     const remaining = [...internals.seenShareOps.keys()];
-    expect(remaining).toContain('cg|live-0');
-    expect(remaining).toContain('cg|live-1');
+    expect(remaining).toContain(JSON.stringify(['cg', 'live-0']));
+    expect(remaining).toContain(JSON.stringify(['cg', 'live-1']));
     for (let i = 0; i < 5; i++) {
-      expect(remaining).not.toContain(`cg|expired-${i}`);
+      expect(remaining).not.toContain(JSON.stringify(['cg', `expired-${i}`]));
     }
     expect(internals.seenOpsCapEvictedLiveEntries).toBe(false);
     expect(handlerForTtl.getStats().redundantAppliesLowerBound).toBe(false);
@@ -1206,6 +1210,48 @@ describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
 
     expect(internals.seenOpsCapEvictedLiveEntries).toBe(true);
     expect(handlerForLowerBound.getStats().redundantAppliesLowerBound).toBe(true);
+  });
+
+  // PR-A R11 regression: prior to the fix, the composite key was
+  // `${cgId}|${shareOperationId}`, which collided whenever either
+  // field contained `|` (both wire-supplied — a hostile peer could
+  // craft them). Two structurally distinct (cgId, op) pairs that
+  // hash to the same string would corrupt `redundantApplies`
+  // accounting: a legitimate first-delivery on one pair would look
+  // like a "redundant" re-delivery of the other and bump the
+  // operator-facing counter under the wrong cgId. The fix uses
+  // `JSON.stringify([cgId, op])`, which is unambiguous (array
+  // delimiters + JSON quote-escaping). This test exercises the
+  // canonical aliasing pair and asserts that the legitimate first
+  // delivery on the second pair is NOT counted as redundant.
+  it('avoids (cgId, shareOpId) composite-key aliasing across pipe-containing values (R11)', () => {
+    let nowMs = 1_000_000;
+    const handlerForR11 = new SharedMemoryHandler(store, new TypedEventBus(), {
+      now: () => nowMs,
+      seenOpsTtlMs: 60 * 60 * 1000,
+    });
+    const internals = handlerForR11 as unknown as {
+      recordSeenShareOp: (cgId: string, opId: string, ctx: unknown) => void;
+    };
+    const ctx = {} as any;
+
+    // Legacy `${cgId}|${shareOperationId}` would produce the same
+    // string `"a|b|c"` for both of these distinct logical pairs:
+    internals.recordSeenShareOp('a|b', 'c', ctx);
+    internals.recordSeenShareOp('a', 'b|c', ctx);
+
+    // Neither call is a redundant apply: the keys must be distinct.
+    const stats = handlerForR11.getStats();
+    expect(stats.redundantApplies).toEqual({});
+    expect(stats.redundantAppliesLowerBound).toBe(false);
+    expect(stats.redundantAppliesOverflow).toBe(0);
+    expect(stats.redundantAppliesTruncated).toBe(false);
+
+    // Now genuinely re-deliver the second pair and assert it IS
+    // counted under the correct cgId (and not under "a|b").
+    internals.recordSeenShareOp('a', 'b|c', ctx);
+    const stats2 = handlerForR11.getStats();
+    expect(stats2.redundantApplies).toEqual({ a: 1 });
   });
 });
 


### PR DESCRIPTION
## Summary

Step 0 of the [SWM Reliable Fan-out RFC (RFC-003)](https://github.com/OriginTrail/dkgv10-spec/pull/110). **Pure observability — no behavior change for the happy path.** Establishes the metrics surface that the later PRs (B / C / D) hang their telemetry off of.

**Why now:** the May-17 soak postmortem surfaced that `publishWorkspaceGossip` swallowed every `gossip.publish` failure as a silent `log.warn("No peers subscribed to {topic} yet")`. The "No peers" framing was misleading — the catch fired on **any** publish error including legitimate mesh failures — and the silent absorption meant entire share streams could disappear without any operator-visible signal. PR-A makes the failure mode observable without changing the contract of `share()` (local commit still succeeds; `runSyncOnConnect` still catches remote peers up).

## What changed

### Loud-fail `publishWorkspaceGossip`  ([`packages/agent/src/dkg-agent.ts`](https://github.com/OriginTrail/dkg/blob/feat/swm-observability-loud-fail/packages/agent/src/dkg-agent.ts))
- Replaces silent `log.warn` with a structured WARN that carries the topic, cgId, error class, and per-cgId failure count
- Bumps the new `swmGossipPublishFailures: Map<cgId, count>`
- Does **NOT** re-throw — `share()` still resolves successfully when the local commit succeeded but gossip failed. Catch-up is delegated to `runSyncOnConnect`, exactly like today

### Receiver-side redundant-apply counter ([`packages/publisher/src/workspace-handler.ts`](https://github.com/OriginTrail/dkg/blob/feat/swm-observability-loud-fail/packages/publisher/src/workspace-handler.ts))
- Bounded (50k entry, 10min TTL, amortised LRU eviction) `seenShareOps` map keyed by \`${cgId}|${shareOpId}\`
- On every legitimate delivery (post-publisher-verification, pre-allowlist), bumps `redundantApplyCounts.get(cgId)` when the pair has been seen within the TTL window
- Apply path is unchanged — the second delivery still applies just like today. **Counter is observation only.** Deliberately defers Concern-2 (real receiver-side dedup) to rc10 pending soak data on whether the redundant-apply rate is actually problematic in practice

### `/api/slo` response shape ([`packages/cli/src/daemon/routes/agent-chat.ts`](https://github.com/OriginTrail/dkg/blob/feat/swm-observability-loud-fail/packages/cli/src/daemon/routes/agent-chat.ts))
- Extended **additively** from \`{protocols}\` to \`{protocols, gossip, swm}\`
- \`gossip.publishFailures: Record<cgId, count>\` from \`agent.getSwmGossipStats()\`
- \`swm.redundantApplies: Record<cgId, count>\` from \`agent.getSwmHandlerStats()\`
- Existing consumers that parse \`protocols\` keep working

### New public getters on \`DKGAgent\`
- \`getSwmGossipStats()\` — surface for the publish-failure counter
- \`getSwmHandlerStats()\` — passthrough to handler.getStats(); returns empty object if handler hasn't initialised

## Tests

- \`packages/agent/test/swm-gossip-publish-failure.test.ts\` (**NEW**, 4 tests):
  - empty counters before any share
  - gossip throw → counter bumps, share() still resolves, attempt logged
  - isolated per-cgId accumulation across multiple shares
  - empty handler stats before any inbound delivery
- \`packages/publisher/test/workspace.test.ts\` (**+6 tests** in new describe block):
  - empty initially
  - first delivery → 0
  - three deliveries → 2 (each repeat counts)
  - per-cgId isolation
  - TTL expiry: same op delivered >10min later does not count
  - second delivery still applies (no behavior change)

## Test plan

- [x] \`pnpm --filter @origintrail-official/dkg-publisher test --run test/workspace.test.ts\` — 53/53
- [x] \`pnpm --filter @origintrail-official/dkg-agent test --run test/swm-gossip-publish-failure.test.ts\` — 4/4
- [x] \`pnpm --filter @origintrail-official/dkg-agent test --run test/swm-gossip-signing.test.ts\` — 6/6 (regression check)
- [x] All packages build clean (core / publisher / agent / cli)
- [ ] CI passes
- [ ] Operator canary: hit \`/api/slo\` on an rc9 daemon, confirm response includes \`gossip\` and \`swm\` sections

## Why this enables PR-F

PR-F (the multi-node SWM soak that validates ≥99.9% delivery) needs ground-truth observability:
- \`gossip.publishFailures\` answers "did we even try to send it?"
- \`swm.redundantApplies\` answers "how often does gossip + future-substrate-top-up race?"
- \`protocols\` (already present) answers "did substrate sends ack?"

Without PR-A's surface, PR-F can only measure end-to-end delivery via inbox sampling — opaque on the cause of any gaps.

## Behavior change summary

| Surface                          | Before                                       | After                                                                              |
| -------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------- |
| \`share()\` return on gossip fail | resolves (silent log.warn)                   | resolves (same — but WARN now structured + counter bumped)                         |
| \`/api/slo\` shape               | \`{protocols}\`                              | \`{protocols, gossip, swm}\` (additive)                                            |
| \`SharedMemoryHandler.handle\`   | apply once, second arrival reapplies silently | apply once, second arrival reapplies + bumps observability counter                 |
| WARN log on publish fail         | \`"No peers subscribed to {topic} yet"\`       | \`"Gossip publish FAILED topic=... cgId=... error=... failureCountForCg=..."\` |

## Part of the SWM reliable fan-out plan

See [RFC-003 in dkgv10-spec PR #110](https://github.com/OriginTrail/dkgv10-spec/pull/110). PR sequence:
- **PR-A** (this PR) — Loud-fail gossip + redundant-apply counter
- **PR-E** (#569) — Sync protocol migration  
- PR-B — Membership enumerator
- PR-C — Small-tier substrate fan-out
- PR-D — Ack-quorum overlay
- PR-F — Multi-node SWM soak validation

Made with [Cursor](https://cursor.com)