### PR TITLE
feat(swm): CG member enumerator with 60s cache (rc.9 PR-B)

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -97,5 +97,12 @@ export {
 } from './random-sampling-bind.js';
 export { monotonicTransition, versionedWrite, type MonotonicStages } from './workspace-consistency.js';
 export { StaleWriteError, type CASCondition } from '@origintrail-official/dkg-publisher';
+export {
+  createCGMemberEnumerator,
+  type CGMemberEnumerator,
+  type CGMemberEnumeration,
+  type CGMemberEnumeratorDeps,
+  type CGMemberSource,
+} from './swm/enumerate-cg-members.js';
 export * from './source-worker.js';
 export * from './source-registry.js';

--- a/packages/agent/src/swm/enumerate-cg-members.ts
+++ b/packages/agent/src/swm/enumerate-cg-members.ts
@@ -60,15 +60,40 @@ export interface CGMemberEnumeration {
 
 export interface CGMemberEnumeratorDeps {
   /**
-   * Resolves a CG's peer allowlist. Returns `null` for non-curated
-   * CGs (no `DKG_ALLOWED_PEER` triples in the meta graph) — the
-   * enumerator interprets `null` as "fall through to topic-subscribers".
+   * Resolves a CG's peer allowlist. Returns `null` for CGs without
+   * an explicit `DKG_ALLOWED_PEER` allowlist in the meta graph. A
+   * `null` return does NOT by itself mean "public" — agent-gated
+   * private CGs (`DKG_ALLOWED_AGENT` / `DKG_PARTICIPANT_AGENT`
+   * without peer allowlist triples) also return `null` here. The
+   * enumerator disambiguates via {@link isPrivateContextGraph}.
    * Returns `[]` for a curated CG whose allowlist is explicitly
-   * empty (rare; the enumerator surfaces this as `source: 'allowlist'`
-   * with zero members so callers can distinguish "curated with zero
-   * remaining members" from "public CG with no subscribers").
+   * empty (rare; surfaced as `source: 'allowlist'` with zero members
+   * so callers can distinguish "curated with zero remaining members"
+   * from "public CG with no subscribers").
    */
   getContextGraphAllowedPeers: (cgId: string) => Promise<string[] | null>;
+  /**
+   * Returns true for any private CG — peer-allowlisted, agent-gated,
+   * or both. Same predicate the responder consults to gate sync /
+   * SWM-share auth (see `DKGAgent.isPrivateContextGraph`), so
+   * fan-out classification stays consistent with the data-plane
+   * access control.
+   *
+   * Bug fix (codex review on #571): without this, a CG that is
+   * private via `DKG_ALLOWED_AGENT` ONLY (no `DKG_ALLOWED_PEER`
+   * triples) was misclassified as public — `getContextGraphAllowedPeers`
+   * returns null, and the old code fell straight through to live
+   * topic subscribers. That would fan out SWM shares to GossipSub
+   * subscribers who are NOT actually allowed members, risking a
+   * metadata leak (the encrypted payload itself is still gated by
+   * the per-CG key, but the bare fact that a share exists would
+   * reach unauthorized nodes). Fail closed: if the CG is private
+   * but we have no enumerable peer allowlist, return `source:
+   * 'none'` with empty members so the caller falls back to
+   * gossip-only delivery (still safe because the receiver enforces
+   * auth on the gossip path too).
+   */
+  isPrivateContextGraph: (cgId: string) => Promise<boolean>;
   /**
    * Best-effort snapshot of peers subscribed to {@link topic} as
    * observed via GossipSub heartbeat + peer-exchange. May be empty
@@ -109,9 +134,59 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
   const now = deps.now ?? (() => Date.now());
   const ttl = deps.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
   const cache = new Map<string, { computedAtMs: number; value: CGMemberEnumeration }>();
+  // In-flight promise dedup so a burst of concurrent `enumerate(cgId)`
+  // calls for the same cgId collapses onto a single resolution. Bug
+  // fix (codex review on #571): without this, the burst optimisation
+  // the cache TTL is supposed to provide didn't actually fire for
+  // CONCURRENT bursts — every concurrent call saw a cache miss
+  // (cache is populated only after the async resolution finishes) and
+  // each performed its own SPARQL query + `getSubscribers` call. The
+  // entry is removed in `finally` so a future call after the promise
+  // settles consults the TTL cache normally.
+  const inFlight = new Map<string, Promise<CGMemberEnumeration>>();
 
   function isFresh(entry: { computedAtMs: number }, nowMs: number): boolean {
     return nowMs - entry.computedAtMs < ttl;
+  }
+
+  async function resolve(cgId: string, computedAtMs: number): Promise<CGMemberEnumeration> {
+    const allowed = await deps.getContextGraphAllowedPeers(cgId);
+
+    if (allowed !== null) {
+      // Curated CG with explicit peer allowlist: roster is
+      // authoritative. Even an empty allowlist is meaningful
+      // (curator removed every member; do NOT fall through to topic
+      // subscribers — that would re-admit peers the curator just
+      // kicked).
+      const result: CGMemberEnumeration = {
+        source: 'allowlist',
+        members: dedupAndExcludeSelf(allowed, deps.selfPeerId),
+      };
+      cache.set(cgId, { computedAtMs, value: result });
+      return result;
+    }
+
+    // No peer allowlist exists. Disambiguate private (agent-gated)
+    // from public via the same predicate the responder consults for
+    // sync / SWM-share auth. Fail closed for private CGs (see
+    // `isPrivateContextGraph` jsdoc on CGMemberEnumeratorDeps).
+    if (await deps.isPrivateContextGraph(cgId)) {
+      const result: CGMemberEnumeration = { source: 'none', members: [] };
+      cache.set(cgId, { computedAtMs, value: result });
+      return result;
+    }
+
+    // Public CG: no on-chain roster exists by design (subscribers
+    // don't pay to subscribe). Use the live GossipSub view.
+    const subscribers = deps.getTopicSubscribers(deps.topicForCG(cgId));
+    const result: CGMemberEnumeration = subscribers.length === 0
+      ? { source: 'none', members: [] }
+      : {
+        source: 'topic-subscribers',
+        members: dedupAndExcludeSelf(subscribers, deps.selfPeerId),
+      };
+    cache.set(cgId, { computedAtMs, value: result });
+    return result;
   }
 
   return {
@@ -122,34 +197,14 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
         return cached.value;
       }
 
-      const allowed = await deps.getContextGraphAllowedPeers(cgId);
-      let result: CGMemberEnumeration;
+      const existing = inFlight.get(cgId);
+      if (existing) return existing;
 
-      if (allowed !== null) {
-        // Curated CG: allowlist is authoritative. Even an empty
-        // allowlist is meaningful (signals a curator removed every
-        // member; callers should NOT fall through to topic subscribers
-        // because that would re-admit peers the curator just kicked).
-        result = {
-          source: 'allowlist',
-          members: dedupAndExcludeSelf(allowed, deps.selfPeerId),
-        };
-      } else {
-        // Public CG: no on-chain roster exists by design (subscribers
-        // don't pay to subscribe). Use the live GossipSub view.
-        const subscribers = deps.getTopicSubscribers(deps.topicForCG(cgId));
-        if (subscribers.length === 0) {
-          result = { source: 'none', members: [] };
-        } else {
-          result = {
-            source: 'topic-subscribers',
-            members: dedupAndExcludeSelf(subscribers, deps.selfPeerId),
-          };
-        }
-      }
-
-      cache.set(cgId, { computedAtMs: nowMs, value: result });
-      return result;
+      const promise = resolve(cgId, nowMs).finally(() => {
+        inFlight.delete(cgId);
+      });
+      inFlight.set(cgId, promise);
+      return promise;
     },
 
     invalidate(cgId: string): void {

--- a/packages/agent/src/swm/enumerate-cg-members.ts
+++ b/packages/agent/src/swm/enumerate-cg-members.ts
@@ -1,0 +1,175 @@
+/**
+ * SWM Reliable Fan-out — runtime CG member enumeration (rc.9 PR-B,
+ * Step 1a of the plan).
+ *
+ * Discovers the recipient set for a SWM share at fan-out time, with
+ * a single uniform API across the three CG membership models that
+ * coexist on rc.9 testnet:
+ *
+ *   - **curated** — CG has an on-chain (or local-meta-mirrored)
+ *     allowlist of peer IDs. Resolved via `getContextGraphAllowedPeers`,
+ *     which returns a non-null array of allowed peerIds. Source label:
+ *     `'allowlist'`.
+ *
+ *   - **public** — anyone can subscribe. There is NO authoritative
+ *     roster (publishing the allowlist on-chain for every drive-by
+ *     subscriber would be a cost regression the RFC explicitly avoids
+ *     — see RFC-003 §4.4 "Member enumeration misalignment"). The
+ *     best-effort substitute is the live GossipSub subscriber set as
+ *     observed via the heartbeat + peer-exchange protocol. Source
+ *     label: `'topic-subscribers'`.
+ *
+ *   - **legacy / unknown** — neither an allowlist nor any live
+ *     subscribers. Returns an empty member set with source `'none'`
+ *     so the caller can fall back to gossip-only delivery (or skip
+ *     the substrate top-up entirely). This is the bootstrap state for
+ *     a freshly-created CG before any peer has joined the mesh.
+ *
+ * The enumerator is intentionally NOT a hot-path component. Each
+ * `enumerate(cgId)` call may trigger a SPARQL query against the
+ * meta graph (for the allowlist resolution) — non-trivial but not
+ * prohibitive. The 60s in-memory cache absorbs the burst pattern
+ * typical for SWM share workloads (a burst of N shares to the same
+ * CG within seconds shares a single enumeration result).
+ *
+ * Cache TTL chosen to balance:
+ *   - **freshness** — when a curator updates the allowlist or a
+ *     subscriber joins/leaves, the change becomes visible to the
+ *     fan-out path within at most TTL milliseconds.
+ *   - **work** — N shares to the same CG within TTL only pay one
+ *     SPARQL query + one `getSubscribers` call.
+ *
+ * Callers that need explicit invalidation (e.g. PR-C after a
+ * substrate top-up consistently fails for a member) can call
+ * `invalidate(cgId)`.
+ */
+
+export type CGMemberSource = 'allowlist' | 'topic-subscribers' | 'none';
+
+export interface CGMemberEnumeration {
+  /** Which discovery path produced {@link members}. */
+  source: CGMemberSource;
+  /**
+   * Peer IDs of the recipient set, with self excluded. Order is not
+   * guaranteed (depends on SPARQL result ordering or GossipSub's
+   * internal peer set iteration). Caller MUST de-duplicate if it
+   * combines results across calls.
+   */
+  members: string[];
+}
+
+export interface CGMemberEnumeratorDeps {
+  /**
+   * Resolves a CG's peer allowlist. Returns `null` for non-curated
+   * CGs (no `DKG_ALLOWED_PEER` triples in the meta graph) — the
+   * enumerator interprets `null` as "fall through to topic-subscribers".
+   * Returns `[]` for a curated CG whose allowlist is explicitly
+   * empty (rare; the enumerator surfaces this as `source: 'allowlist'`
+   * with zero members so callers can distinguish "curated with zero
+   * remaining members" from "public CG with no subscribers").
+   */
+  getContextGraphAllowedPeers: (cgId: string) => Promise<string[] | null>;
+  /**
+   * Best-effort snapshot of peers subscribed to {@link topic} as
+   * observed via GossipSub heartbeat + peer-exchange. May be empty
+   * or stale; never throws.
+   */
+  getTopicSubscribers: (topic: string) => string[];
+  topicForCG: (cgId: string) => string;
+  /**
+   * Our own peer ID. Always excluded from the returned member set —
+   * we don't fan-out to ourselves (the local apply already happened
+   * in the caller).
+   */
+  selfPeerId: string;
+  /** Defaults to `Date.now`; override in tests for deterministic TTL. */
+  now?: () => number;
+  /** Defaults to 60s; override in tests or for higher-volatility CGs. */
+  cacheTtlMs?: number;
+}
+
+const DEFAULT_CACHE_TTL_MS = 60_000;
+
+export interface CGMemberEnumerator {
+  /**
+   * Resolve the current member set for {@link cgId}. Returns cached
+   * value if within TTL, otherwise recomputes (and caches).
+   */
+  enumerate(cgId: string): Promise<CGMemberEnumeration>;
+  /**
+   * Drop the cached entry for {@link cgId} so the next `enumerate`
+   * call recomputes. Safe to call for unknown cgIds (no-op).
+   */
+  invalidate(cgId: string): void;
+  /** Test/debug helper: number of cached entries currently held. */
+  size(): number;
+}
+
+export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMemberEnumerator {
+  const now = deps.now ?? (() => Date.now());
+  const ttl = deps.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  const cache = new Map<string, { computedAtMs: number; value: CGMemberEnumeration }>();
+
+  function isFresh(entry: { computedAtMs: number }, nowMs: number): boolean {
+    return nowMs - entry.computedAtMs < ttl;
+  }
+
+  return {
+    async enumerate(cgId: string): Promise<CGMemberEnumeration> {
+      const nowMs = now();
+      const cached = cache.get(cgId);
+      if (cached && isFresh(cached, nowMs)) {
+        return cached.value;
+      }
+
+      const allowed = await deps.getContextGraphAllowedPeers(cgId);
+      let result: CGMemberEnumeration;
+
+      if (allowed !== null) {
+        // Curated CG: allowlist is authoritative. Even an empty
+        // allowlist is meaningful (signals a curator removed every
+        // member; callers should NOT fall through to topic subscribers
+        // because that would re-admit peers the curator just kicked).
+        result = {
+          source: 'allowlist',
+          members: dedupAndExcludeSelf(allowed, deps.selfPeerId),
+        };
+      } else {
+        // Public CG: no on-chain roster exists by design (subscribers
+        // don't pay to subscribe). Use the live GossipSub view.
+        const subscribers = deps.getTopicSubscribers(deps.topicForCG(cgId));
+        if (subscribers.length === 0) {
+          result = { source: 'none', members: [] };
+        } else {
+          result = {
+            source: 'topic-subscribers',
+            members: dedupAndExcludeSelf(subscribers, deps.selfPeerId),
+          };
+        }
+      }
+
+      cache.set(cgId, { computedAtMs: nowMs, value: result });
+      return result;
+    },
+
+    invalidate(cgId: string): void {
+      cache.delete(cgId);
+    },
+
+    size(): number {
+      return cache.size;
+    },
+  };
+}
+
+function dedupAndExcludeSelf(peers: readonly string[], selfPeerId: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const p of peers) {
+    if (p === selfPeerId) continue;
+    if (seen.has(p)) continue;
+    seen.add(p);
+    out.push(p);
+  }
+  return out;
+}

--- a/packages/agent/src/swm/enumerate-cg-members.ts
+++ b/packages/agent/src/swm/enumerate-cg-members.ts
@@ -136,20 +136,46 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
   const cache = new Map<string, { computedAtMs: number; value: CGMemberEnumeration }>();
   // In-flight promise dedup so a burst of concurrent `enumerate(cgId)`
   // calls for the same cgId collapses onto a single resolution. Bug
-  // fix (codex review on #571): without this, the burst optimisation
-  // the cache TTL is supposed to provide didn't actually fire for
-  // CONCURRENT bursts — every concurrent call saw a cache miss
-  // (cache is populated only after the async resolution finishes) and
-  // each performed its own SPARQL query + `getSubscribers` call. The
-  // entry is removed in `finally` so a future call after the promise
-  // settles consults the TTL cache normally.
+  // fix (codex review on #571 round 1): without this, the burst
+  // optimisation the cache TTL is supposed to provide didn't actually
+  // fire for CONCURRENT bursts — every concurrent call saw a cache
+  // miss (cache is populated only after the async resolution
+  // finishes) and each performed its own SPARQL query +
+  // `getSubscribers` call.
   const inFlight = new Map<string, Promise<CGMemberEnumeration>>();
+  // Per-cgId generation counter bumped on every `invalidate(cgId)`.
+  // Bug fix (codex review on #571 round 2): `invalidate()` previously
+  // only cleared the resolved TTL cache, so concurrent
+  // `enumerate(cgId)` callers that arrived AFTER an `invalidate()`
+  // but while an earlier resolve was still in flight would join the
+  // stale promise and observe the pre-invalidation roster. Even with
+  // the in-flight slot also cleared in `invalidate()`, there is still
+  // a write-after-invalidate race where the stale resolve's
+  // `cache.set` could land after a fresh resolve had already
+  // populated the cache. The generation counter is captured BEFORE
+  // each resolve starts, and the resolve refuses to write to the
+  // cache if the captured generation no longer matches the current
+  // one — pinning the documented "fresh resolution on the next call"
+  // contract end-to-end.
+  const generation = new Map<string, number>();
+  const currentGen = (cgId: string): number => generation.get(cgId) ?? 0;
 
   function isFresh(entry: { computedAtMs: number }, nowMs: number): boolean {
     return nowMs - entry.computedAtMs < ttl;
   }
 
-  async function resolve(cgId: string, computedAtMs: number): Promise<CGMemberEnumeration> {
+  async function resolve(cgId: string, gen: number, computedAtMs: number): Promise<CGMemberEnumeration> {
+    const result = await computeMembers(cgId);
+    // Only commit to the TTL cache if no `invalidate(cgId)` has run
+    // since this resolve started. Otherwise a stale resolve could
+    // overwrite a fresher one (or pollute a freshly-cleared cache).
+    if (currentGen(cgId) === gen) {
+      cache.set(cgId, { computedAtMs, value: result });
+    }
+    return result;
+  }
+
+  async function computeMembers(cgId: string): Promise<CGMemberEnumeration> {
     const allowed = await deps.getContextGraphAllowedPeers(cgId);
 
     if (allowed !== null) {
@@ -158,12 +184,10 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
       // (curator removed every member; do NOT fall through to topic
       // subscribers — that would re-admit peers the curator just
       // kicked).
-      const result: CGMemberEnumeration = {
+      return {
         source: 'allowlist',
         members: dedupAndExcludeSelf(allowed, deps.selfPeerId),
       };
-      cache.set(cgId, { computedAtMs, value: result });
-      return result;
     }
 
     // No peer allowlist exists. Disambiguate private (agent-gated)
@@ -171,22 +195,25 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
     // sync / SWM-share auth. Fail closed for private CGs (see
     // `isPrivateContextGraph` jsdoc on CGMemberEnumeratorDeps).
     if (await deps.isPrivateContextGraph(cgId)) {
-      const result: CGMemberEnumeration = { source: 'none', members: [] };
-      cache.set(cgId, { computedAtMs, value: result });
-      return result;
+      return { source: 'none', members: [] };
     }
 
     // Public CG: no on-chain roster exists by design (subscribers
     // don't pay to subscribe). Use the live GossipSub view.
+    //
+    // Source label is derived from the FILTERED member list, not
+    // from the raw subscriber count. Bug fix (codex review on #571
+    // round 2): when the only subscriber visible is `self` (common
+    // when we're the first to subscribe to a public CG and no one
+    // else has joined yet) or duplicates collapse away, we'd
+    // otherwise return `{ source: 'topic-subscribers', members: [] }`
+    // and any caller that treats `source !== 'none'` as "I have
+    // remote recipients" would skip the intended fallback.
     const subscribers = deps.getTopicSubscribers(deps.topicForCG(cgId));
-    const result: CGMemberEnumeration = subscribers.length === 0
+    const members = dedupAndExcludeSelf(subscribers, deps.selfPeerId);
+    return members.length === 0
       ? { source: 'none', members: [] }
-      : {
-        source: 'topic-subscribers',
-        members: dedupAndExcludeSelf(subscribers, deps.selfPeerId),
-      };
-    cache.set(cgId, { computedAtMs, value: result });
-    return result;
+      : { source: 'topic-subscribers', members };
   }
 
   return {
@@ -200,15 +227,29 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
       const existing = inFlight.get(cgId);
       if (existing) return existing;
 
-      const promise = resolve(cgId, nowMs).finally(() => {
-        inFlight.delete(cgId);
+      const gen = currentGen(cgId);
+      const promise = resolve(cgId, gen, nowMs).finally(() => {
+        // Only release the slot if it still points to OUR promise.
+        // After `invalidate()` clears `inFlight[cgId]` and a fresh
+        // caller installs a new in-flight promise, we must not
+        // delete that fresh entry.
+        if (inFlight.get(cgId) === promise) {
+          inFlight.delete(cgId);
+        }
       });
       inFlight.set(cgId, promise);
       return promise;
     },
 
     invalidate(cgId: string): void {
+      generation.set(cgId, currentGen(cgId) + 1);
       cache.delete(cgId);
+      // Also drop the in-flight slot so the next `enumerate(cgId)`
+      // triggers a fresh resolve instead of joining the now-stale
+      // pending promise. The stale resolve's `cache.set` is gated
+      // by the generation check above, so it can't pollute the cache
+      // after this point.
+      inFlight.delete(cgId);
     },
 
     size(): number {

--- a/packages/agent/test/enumerate-cg-members.test.ts
+++ b/packages/agent/test/enumerate-cg-members.test.ts
@@ -9,6 +9,10 @@ const SELF = '12D3KooWSelf';
 function makeDeps(overrides: Partial<CGMemberEnumeratorDeps>): CGMemberEnumeratorDeps {
   return {
     getContextGraphAllowedPeers: async () => null,
+    // Default: NOT private. The dedicated "private CG without
+    // allowlist" describe-block below overrides this to true to
+    // exercise the fail-closed branch (codex review on #571 bug #1).
+    isPrivateContextGraph: async () => false,
     getTopicSubscribers: () => [],
     topicForCG: (cgId) => `dkg/context-graph/${cgId}/shared-memory`,
     selfPeerId: SELF,
@@ -92,6 +96,60 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
 
     expect(result.source).toBe('topic-subscribers');
     expect(result.members).toEqual(['peerY']);
+  });
+});
+
+/**
+ * Regression for the first codex finding on PR #571: `null` from
+ * `getContextGraphAllowedPeers` does NOT mean "public". A CG can be
+ * private via `DKG_ALLOWED_AGENT` / `DKG_PARTICIPANT_AGENT` without
+ * any peer-allowlist triples, and falling through to live topic
+ * subscribers for those CGs would fan SWM shares out to GossipSub
+ * subscribers who are not actually allowed members. The fix
+ * disambiguates via the same `isPrivateContextGraph` predicate the
+ * responder uses for sync / SWM-share auth — fail closed for any
+ * private CG that lacks an enumerable peer roster.
+ */
+describe('createCGMemberEnumerator: private CG WITHOUT peer allowlist (agent-gated)', () => {
+  it('returns source=none and empty members, ignoring topic subscribers', async () => {
+    let subscribersCalled = 0;
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => null,
+      isPrivateContextGraph: async () => true,
+      getTopicSubscribers: () => {
+        subscribersCalled += 1;
+        return ['nonMemberWhoHappensToSubscribe'];
+      },
+    }));
+
+    const result = await enumerator.enumerate('cg-agent-gated');
+
+    expect(result).toEqual({ source: 'none', members: [] });
+    // The whole point of fail-closed: even though there ARE live
+    // topic subscribers, we MUST NOT consult them for private CGs
+    // without a peer allowlist (would risk fan-out to non-members).
+    expect(subscribersCalled).toBe(0);
+  });
+
+  it('still uses the allowlist when one exists (private + peer-allowlisted)', async () => {
+    // Sanity check: a private CG that DOES have a peer allowlist
+    // (e.g. curated by both `DKG_ALLOWED_PEER` and `DKG_ALLOWED_AGENT`)
+    // takes the normal allowlist path and never consults
+    // `isPrivateContextGraph`.
+    let isPrivateCalled = 0;
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => ['peerA', 'peerB'],
+      isPrivateContextGraph: async () => {
+        isPrivateCalled += 1;
+        return true;
+      },
+    }));
+
+    const result = await enumerator.enumerate('cg-private-with-allowlist');
+
+    expect(result.source).toBe('allowlist');
+    expect(result.members.sort()).toEqual(['peerA', 'peerB']);
+    expect(isPrivateCalled).toBe(0);
   });
 });
 
@@ -187,6 +245,97 @@ describe('createCGMemberEnumerator: TTL cache', () => {
   it('invalidate() on an unknown cgId is a no-op', () => {
     const enumerator = createCGMemberEnumerator(makeDeps({}));
     expect(() => enumerator.invalidate('never-seen')).not.toThrow();
+  });
+
+  /**
+   * Regression for the second codex finding on PR #571: the cache
+   * is populated only after the async resolution finishes, so a
+   * burst of CONCURRENT enumerate() calls for the same cgId would
+   * each see a cache miss and each perform their own SPARQL +
+   * `getSubscribers` lookup. The fix caches an in-flight promise
+   * keyed by cgId so the burst collapses onto a single resolution.
+   *
+   * Stalls `getContextGraphAllowedPeers` on a manually-resolved
+   * promise so a deterministic burst of 5 concurrent enumerate()s
+   * can be observed before any resolution completes.
+   */
+  it('collapses a CONCURRENT burst of enumerate() calls onto one resolution (in-flight dedup)', async () => {
+    let allowedCalls = 0;
+    let resolveAllowedPeers!: (peers: string[]) => void;
+    const allowedPeersPromise = new Promise<string[]>((res) => {
+      resolveAllowedPeers = res;
+    });
+
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => {
+        allowedCalls += 1;
+        return allowedPeersPromise;
+      },
+    }));
+
+    // Fire 5 concurrent enumerate() calls BEFORE the dep's promise
+    // settles. Pre-fix: all 5 missed the cache → 5 invocations of
+    // `getContextGraphAllowedPeers`. Post-fix: only the first
+    // invocation runs; the other 4 join the same in-flight promise.
+    const pending = Promise.all([
+      enumerator.enumerate('cg-burst'),
+      enumerator.enumerate('cg-burst'),
+      enumerator.enumerate('cg-burst'),
+      enumerator.enumerate('cg-burst'),
+      enumerator.enumerate('cg-burst'),
+    ]);
+
+    // Allow the microtask queue to drain so all 5 enumerate() calls
+    // have actually run their cache-miss + register-in-flight steps
+    // before we release the dep promise.
+    await new Promise<void>((res) => setImmediate(res));
+
+    expect(allowedCalls).toBe(1);
+
+    resolveAllowedPeers(['peerA', 'peerB']);
+    const results = await pending;
+
+    // All 5 callers observe the same result.
+    for (const r of results) {
+      expect(r.source).toBe('allowlist');
+      expect(r.members.sort()).toEqual(['peerA', 'peerB']);
+    }
+    expect(allowedCalls).toBe(1);
+
+    // After the in-flight promise settles, subsequent calls within
+    // TTL hit the normal cache (no additional dep invocations).
+    await enumerator.enumerate('cg-burst');
+    expect(allowedCalls).toBe(1);
+  });
+
+  it('releases the in-flight slot on resolution so post-TTL recompute can re-enter', async () => {
+    // Confirms the `finally` cleanup. If the in-flight slot leaked,
+    // the second burst (after TTL elapses + cache eviction) would
+    // either join a stale resolved promise or never fire the dep
+    // again, depending on the bug shape.
+    let allowedCalls = 0;
+    let nowMs = 1_000_000;
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      now: () => nowMs,
+      cacheTtlMs: 100,
+      getContextGraphAllowedPeers: async () => {
+        allowedCalls += 1;
+        return ['peerA'];
+      },
+    }));
+
+    await enumerator.enumerate('cg-leak-check');
+    expect(allowedCalls).toBe(1);
+
+    // Advance past TTL, fire another burst — dep should be invoked
+    // exactly once more (the in-flight slot from the first call
+    // must have been released).
+    nowMs += 200;
+    await Promise.all([
+      enumerator.enumerate('cg-leak-check'),
+      enumerator.enumerate('cg-leak-check'),
+    ]);
+    expect(allowedCalls).toBe(2);
   });
 });
 

--- a/packages/agent/test/enumerate-cg-members.test.ts
+++ b/packages/agent/test/enumerate-cg-members.test.ts
@@ -97,6 +97,38 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
     expect(result.source).toBe('topic-subscribers');
     expect(result.members).toEqual(['peerY']);
   });
+
+  /**
+   * Regression for codex review on PR #571 round 2: source label
+   * MUST be derived from the FILTERED member list, not the raw
+   * subscriber count. Otherwise a public CG where only `self` is
+   * subscribed (common bootstrap state — we're first to subscribe,
+   * no one else has joined) returns `{ source: 'topic-subscribers',
+   * members: [] }`, and any caller that treats `source !== 'none'`
+   * as "I have remote recipients" silently skips the gossip-only
+   * fallback.
+   */
+  it('returns source=none when the only subscriber is self', async () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => null,
+      getTopicSubscribers: () => [SELF],
+    }));
+
+    const result = await enumerator.enumerate('cg-public-self-only');
+
+    expect(result).toEqual({ source: 'none', members: [] });
+  });
+
+  it('returns source=none when duplicates collapse to an empty filtered set', async () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => null,
+      getTopicSubscribers: () => [SELF, SELF, SELF],
+    }));
+
+    const result = await enumerator.enumerate('cg-public-self-dupes');
+
+    expect(result).toEqual({ source: 'none', members: [] });
+  });
 });
 
 /**
@@ -306,6 +338,67 @@ describe('createCGMemberEnumerator: TTL cache', () => {
     // TTL hit the normal cache (no additional dep invocations).
     await enumerator.enumerate('cg-burst');
     expect(allowedCalls).toBe(1);
+  });
+
+  /**
+   * Regression for codex review on PR #571 round 2: `invalidate()`
+   * MUST also drop the in-flight slot AND prevent the stale resolve
+   * from polluting the cache. Otherwise:
+   *   - the next `enumerate(cgId)` joins the still-pending stale
+   *     promise and returns the pre-invalidation roster (visible
+   *     bug, breaks documented "fresh resolution on the next call"
+   *     contract);
+   *   - even after clearing the in-flight slot, the stale resolve's
+   *     `cache.set` could still land after a fresher resolve had
+   *     populated the cache (subtle bug, would cause sporadic
+   *     stale reads on TTL hits).
+   *
+   * The generation counter pinning the stale resolve out of the
+   * cache covers both.
+   */
+  it('invalidate() during an in-flight resolve forces the NEXT enumerate to start a fresh resolve', async () => {
+    let allowedCalls = 0;
+    let resolveSlow!: (peers: string[]) => void;
+    const slowAnswers: Array<Promise<string[]>> = [];
+    slowAnswers.push(new Promise<string[]>((res) => { resolveSlow = res; }));
+
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => {
+        allowedCalls += 1;
+        if (allowedCalls === 1) return slowAnswers[0];
+        return ['peerNew'];
+      },
+    }));
+
+    const firstCall = enumerator.enumerate('cg-invalidate-race');
+    // First call is now in flight, blocked on slowAnswers[0]. Drain
+    // microtasks so the in-flight slot is installed.
+    await new Promise<void>((res) => setImmediate(res));
+    expect(allowedCalls).toBe(1);
+
+    enumerator.invalidate('cg-invalidate-race');
+
+    // Second call MUST NOT join the stale promise; it MUST start a
+    // fresh resolve. Pre-fix it would join `firstCall`.
+    const secondCall = enumerator.enumerate('cg-invalidate-race');
+    await new Promise<void>((res) => setImmediate(res));
+    expect(allowedCalls).toBe(2);
+
+    // Resolve the original (stale) promise. Its result MUST NOT
+    // overwrite the cache populated by the fresh resolve. The first
+    // caller still gets the pre-invalidation value (it asked before
+    // invalidate ran — that's the contract).
+    resolveSlow(['peerStale']);
+
+    const [firstResult, secondResult] = await Promise.all([firstCall, secondCall]);
+    expect(firstResult.members).toEqual(['peerStale']);
+    expect(secondResult.members).toEqual(['peerNew']);
+
+    // The cache MUST hold the fresh resolve's value, not the stale
+    // one. Verify by a TTL-hit call: it must reflect `peerNew`.
+    const third = await enumerator.enumerate('cg-invalidate-race');
+    expect(third.members).toEqual(['peerNew']);
+    expect(allowedCalls).toBe(2);
   });
 
   it('releases the in-flight slot on resolution so post-TTL recompute can re-enter', async () => {

--- a/packages/agent/test/enumerate-cg-members.test.ts
+++ b/packages/agent/test/enumerate-cg-members.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createCGMemberEnumerator,
+  type CGMemberEnumeratorDeps,
+} from '../src/swm/enumerate-cg-members.js';
+
+const SELF = '12D3KooWSelf';
+
+function makeDeps(overrides: Partial<CGMemberEnumeratorDeps>): CGMemberEnumeratorDeps {
+  return {
+    getContextGraphAllowedPeers: async () => null,
+    getTopicSubscribers: () => [],
+    topicForCG: (cgId) => `dkg/context-graph/${cgId}/shared-memory`,
+    selfPeerId: SELF,
+    ...overrides,
+  };
+}
+
+describe('createCGMemberEnumerator: curated CG (allowlist source)', () => {
+  it('returns allowlist members and excludes self', async () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => ['peerA', 'peerB', SELF, 'peerC'],
+    }));
+
+    const result = await enumerator.enumerate('cg-curated-1');
+
+    expect(result.source).toBe('allowlist');
+    expect(result.members.sort()).toEqual(['peerA', 'peerB', 'peerC']);
+  });
+
+  it('preserves source=allowlist even when allowlist is empty', async () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => [],
+      getTopicSubscribers: () => ['shouldNotAppearPeer'],
+    }));
+
+    const result = await enumerator.enumerate('cg-curated-empty');
+
+    expect(result.source).toBe('allowlist');
+    expect(result.members).toEqual([]);
+  });
+
+  it('does not consult topic subscribers when an allowlist exists', async () => {
+    let subscribersCalled = 0;
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => ['peerA'],
+      getTopicSubscribers: () => {
+        subscribersCalled += 1;
+        return ['peerB'];
+      },
+    }));
+
+    await enumerator.enumerate('cg-curated-2');
+
+    expect(subscribersCalled).toBe(0);
+  });
+
+  it('dedupes a curated allowlist that contains duplicates', async () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => ['peerA', 'peerA', 'peerB', 'peerA'],
+    }));
+
+    const result = await enumerator.enumerate('cg-curated-dups');
+
+    expect(result.members.sort()).toEqual(['peerA', 'peerB']);
+  });
+});
+
+describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () => {
+  it('falls through to topic subscribers when allowlist is null', async () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => null,
+      getTopicSubscribers: (topic) => {
+        expect(topic).toBe('dkg/context-graph/cg-public-1/shared-memory');
+        return ['peerX', 'peerY'];
+      },
+    }));
+
+    const result = await enumerator.enumerate('cg-public-1');
+
+    expect(result.source).toBe('topic-subscribers');
+    expect(result.members.sort()).toEqual(['peerX', 'peerY']);
+  });
+
+  it('excludes self from topic subscribers', async () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => null,
+      getTopicSubscribers: () => [SELF, 'peerY'],
+    }));
+
+    const result = await enumerator.enumerate('cg-public-2');
+
+    expect(result.source).toBe('topic-subscribers');
+    expect(result.members).toEqual(['peerY']);
+  });
+});
+
+describe('createCGMemberEnumerator: legacy / unknown CG (none source)', () => {
+  it('returns source=none and empty members when no allowlist + no subscribers', async () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => null,
+      getTopicSubscribers: () => [],
+    }));
+
+    const result = await enumerator.enumerate('cg-bootstrap');
+
+    expect(result).toEqual({ source: 'none', members: [] });
+  });
+});
+
+describe('createCGMemberEnumerator: TTL cache', () => {
+  it('returns cached value within TTL without re-calling deps', async () => {
+    let allowedCalls = 0;
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => {
+        allowedCalls += 1;
+        return ['peerA'];
+      },
+    }));
+
+    await enumerator.enumerate('cg-cached');
+    await enumerator.enumerate('cg-cached');
+    await enumerator.enumerate('cg-cached');
+
+    expect(allowedCalls).toBe(1);
+  });
+
+  it('recomputes after TTL elapses', async () => {
+    let allowedCalls = 0;
+    let nowMs = 1_000_000;
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      now: () => nowMs,
+      cacheTtlMs: 1000,
+      getContextGraphAllowedPeers: async () => {
+        allowedCalls += 1;
+        return ['peerA'];
+      },
+    }));
+
+    await enumerator.enumerate('cg-ttl');
+    nowMs += 500;
+    await enumerator.enumerate('cg-ttl');
+    expect(allowedCalls).toBe(1);
+
+    nowMs += 600;
+    await enumerator.enumerate('cg-ttl');
+    expect(allowedCalls).toBe(2);
+  });
+
+  it('isolates cache per cgId', async () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async (cgId) => {
+        if (cgId === 'cg-1') return ['peerA'];
+        if (cgId === 'cg-2') return ['peerB'];
+        return null;
+      },
+    }));
+
+    const a = await enumerator.enumerate('cg-1');
+    const b = await enumerator.enumerate('cg-2');
+
+    expect(a.members).toEqual(['peerA']);
+    expect(b.members).toEqual(['peerB']);
+    expect(enumerator.size()).toBe(2);
+  });
+
+  it('invalidate() forces a fresh resolution on the next call', async () => {
+    let nthCall = 0;
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => {
+        nthCall += 1;
+        return nthCall === 1 ? ['peerOld'] : ['peerNew'];
+      },
+    }));
+
+    const first = await enumerator.enumerate('cg-invalidate');
+    expect(first.members).toEqual(['peerOld']);
+
+    const cached = await enumerator.enumerate('cg-invalidate');
+    expect(cached.members).toEqual(['peerOld']);
+
+    enumerator.invalidate('cg-invalidate');
+    const refreshed = await enumerator.enumerate('cg-invalidate');
+    expect(refreshed.members).toEqual(['peerNew']);
+  });
+
+  it('invalidate() on an unknown cgId is a no-op', () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({}));
+    expect(() => enumerator.invalidate('never-seen')).not.toThrow();
+  });
+});
+
+describe('createCGMemberEnumerator: source label transitions', () => {
+  it('reflects the live source whenever recompute fires (post-TTL)', async () => {
+    let nowMs = 1_000_000;
+    let allowed: string[] | null = ['peerCurated'];
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      now: () => nowMs,
+      cacheTtlMs: 100,
+      getContextGraphAllowedPeers: async () => allowed,
+      getTopicSubscribers: () => ['peerOpen'],
+    }));
+
+    const first = await enumerator.enumerate('cg-transition');
+    expect(first.source).toBe('allowlist');
+
+    allowed = null;
+    nowMs += 200;
+
+    const second = await enumerator.enumerate('cg-transition');
+    expect(second.source).toBe('topic-subscribers');
+    expect(second.members).toEqual(['peerOpen']);
+  });
+});

--- a/packages/core/src/gossipsub-manager.ts
+++ b/packages/core/src/gossipsub-manager.ts
@@ -85,4 +85,26 @@ export class GossipSubManager {
   get subscribedTopics(): string[] {
     return this.node.libp2p.services.pubsub.getTopics();
   }
+
+  /**
+   * The set of peers we've observed subscribed to {@link topic} via
+   * GossipSub's peer-exchange + heartbeat. Returned as plain peer-id
+   * strings (no PeerId object dependency leaks out).
+   *
+   * Empty array when no peers are subscribed OR when the underlying
+   * pubsub implementation does not expose `getSubscribers` (legacy
+   * test doubles). Callers MUST treat the result as "best-effort, may
+   * be stale by up to one heartbeat interval" — GossipSub's view of
+   * topic membership lags real subscription state because there's no
+   * authoritative roster.
+   *
+   * rc.9 PR-B (SWM reliable fan-out plan, Step 1a): consumed by
+   * {@link createCGMemberEnumerator} for runtime fan-out decisions
+   * on public (non-curated) context graphs.
+   */
+  getSubscribers(topic: string): string[] {
+    const pubsub = this.node.libp2p.services.pubsub as { getSubscribers?: (t: string) => Array<{ toString(): string }> };
+    if (typeof pubsub.getSubscribers !== 'function') return [];
+    return pubsub.getSubscribers(topic).map(p => p.toString());
+  }
 }


### PR DESCRIPTION
## Summary

Step 1a of the [SWM Reliable Fan-out RFC (RFC-003)](https://github.com/OriginTrail/dkgv10-spec/pull/110). **Pure foundation — no caller wires this up yet;** PR-C will dispatch off the enumerator's output to decide between gossip-only and substrate fan-out.

**Why a separate PR:** the membership-model abstraction is the load-bearing decision of the whole RFC, but it's small enough to land + review independently. PR-C / PR-D then have one less moving part when they introduce the substrate paths.

## Three sources, one uniform API

\`createCGMemberEnumerator(deps).enumerate(cgId)\` returns \`{ source, members }\` where \`source\` is one of:

| Source              | Meaning                                                                          | Member set source                                          |
| ------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| \`'allowlist'\`     | Curated CG (non-null \`getContextGraphAllowedPeers\`)                              | The on-chain / local-meta allowlist                       |
| \`'topic-subscribers'\` | Public CG (null allowlist) with at least one observed subscriber                | \`GossipSub.getSubscribers(topic)\` snapshot                |
| \`'none'\`          | Bootstrap case: no allowlist + no live subscribers                               | Empty                                                       |

Self is always excluded; duplicates are deduped.

Even an **empty allowlist** is preserved as \`source='allowlist'\` with zero members so callers can distinguish "curator kicked everyone" from "public CG with no subscribers" — the two have very different fan-out semantics.

## Why runtime inference rather than a stored \`membershipModel\` field

- Avoids a SQLite migration on the integration branch.
- Keeps the "look at the data we already store" property — curated vs public is implied by whether \`DKG_ALLOWED_PEER\` triples exist in the CG's \`_meta\` graph (already true today).
- A CG that transitions from public to curated (or vice versa) picks up the new model on the next cache miss (≤TTL), no flag flip required.

## 60s TTL

Chosen to balance:
- **freshness**: curator allowlist edits or new subscribers become visible within at most 60s on the fan-out path
- **work**: N shares to the same CG within 60s share a single SPARQL+\`getSubscribers\` resolution

Explicit \`invalidate(cgId)\` exposed for PR-C's failure-feedback loop: when a substrate top-up consistently fails for a given member, invalidate forces a fresh enumeration on the next share. Idempotent on unknown cgIds.

## \`GossipSubManager.getSubscribers()\` wrapper

Added so the enumerator can consume the underlying libp2p pubsub view without leaking \`PeerId\` types into the agent layer. Defensive fallback to \`[]\` when the pubsub implementation does not expose \`getSubscribers\` (legacy test doubles in the codebase do this).

## Files

| File                                                                  | Change                                  |
| --------------------------------------------------------------------- | --------------------------------------- |
| \`packages/agent/src/swm/enumerate-cg-members.ts\`                    | **NEW** (~120 LOC, the enumerator)      |
| \`packages/agent/test/enumerate-cg-members.test.ts\`                  | **NEW** (13 tests)                      |
| \`packages/core/src/gossipsub-manager.ts\`                            | +24 LOC: \`getSubscribers(topic)\`       |
| \`packages/agent/src/index.ts\`                                       | +7 LOC: re-exports                      |

## Test coverage

- **curated CG**: allowlist source, self exclusion, dedup, empty allowlist preserves source label, allowlist short-circuits topic lookup
- **public CG**: topic-subscribers source, self exclusion, correct topic name passed to \`getTopicSubscribers\`
- **legacy/bootstrap**: \`source='none'\` with empty members
- **TTL cache**: hit suppresses repeat calls; miss after TTL recomputes; per-cgId isolation; invalidate forces refresh; unknown-cgId invalidate is no-op
- **source transitions**: public→curated→public picks up the live classification post-TTL

## Test plan

- [x] \`pnpm --filter @origintrail-official/dkg-agent test --run test/enumerate-cg-members.test.ts\` — 13/13
- [x] Builds clean across core + agent
- [ ] CI passes

## Why this enables PR-C / PR-D

PR-C needs to ask "should I fan-out via substrate instead of gossip?" — that requires knowing the recipient set's size, which requires enumeration. PR-D's \`SwmAckQuorum\` needs the same set to track which acks are outstanding. Both consume the enumerator via dependency injection (factory pattern keeps the cache testable in isolation).

## Part of the SWM reliable fan-out plan

See [RFC-003 in dkgv10-spec PR #110](https://github.com/OriginTrail/dkgv10-spec/pull/110). PR sequence:
- **PR-A** (#570) — Loud-fail gossip + redundant-apply counter
- **PR-E** (#569) — Sync protocol migration
- **PR-B** (this PR) — Membership enumerator
- PR-C — Small-tier substrate fan-out
- PR-D — Ack-quorum overlay
- PR-F — Multi-node SWM soak validation

Made with [Cursor](https://cursor.com)