### PR TITLE
feat(evm-module): Profile.recreateProfile — testnet recovery for profiles orphaned by ProfileStorage redeploy

### DIFF
--- a/packages/evm-module/abi/Profile.json
+++ b/packages/evm-module/abi/Profile.json
@@ -76,6 +76,27 @@
   {
     "inputs": [
       {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "bytes",
+        "name": "expected",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "provided",
+        "type": "bytes"
+      }
+    ],
+    "name": "NodeIdShardingMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "string",
         "name": "nodeName",
         "type": "string"
@@ -142,6 +163,17 @@
       }
     ],
     "name": "OperatorFeeOutOfRange",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      }
+    ],
+    "name": "ProfileAlreadyExists",
     "type": "error"
   },
   {
@@ -370,6 +402,34 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "operationalWallet",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "nodeName",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "nodeId",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint16",
+        "name": "initialOperatorFee",
+        "type": "uint16"
+      }
+    ],
+    "name": "recreateProfile",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bool",
         "name": "_status",
         "type": "bool"
@@ -378,6 +438,19 @@
     "name": "setStatus",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "shardingTableStorage",
+    "outputs": [
+      {
+        "internalType": "contract ShardingTableStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/evm-module/contracts/Profile.sol
+++ b/packages/evm-module/contracts/Profile.sol
@@ -24,7 +24,12 @@ contract Profile is INamed, IVersioned, ContractStatus, IInitializable {
     // Network State Registry (RFC 04 v0.3 / Issue #461). Multiaddrs were
     // briefly added on a prior revision but are not stored on Profile —
     // they live in per-round attestation KCs instead (RFC 04 §5.2).
-    string private constant _VERSION = "1.2.0";
+    // Bumped 1.2.0 -> 1.3.0: adds recreateProfile, an admin-only recovery
+    // entry point that re-attaches a Profile to an existing identityId
+    // (testnet ProfileStorage-redeploy recovery). The id is reused so the
+    // surviving staking/conviction/sharding state stays addressable. See
+    // docs/adr/0001-recreate-profile-admin-only.md.
+    string private constant _VERSION = "1.3.0";
 
     Ask public askContract;
     Identity public identityContract;
@@ -119,6 +124,43 @@ contract Profile is INamed, IVersioned, ContractStatus, IInitializable {
         }
         uint72 identityId = id.createIdentity(msg.sender, adminWallet);
         id.addOperationalWallets(identityId, operationalWallets);
+
+        ps.createProfile(identityId, nodeName, nodeId, initialOperatorFee);
+    }
+
+    // recreate-profile-recovery 0001 — re-attach a Profile to an Identity
+    // that survived a ProfileStorage redeploy. Admin-only (ADR 0001):
+    // unlike genesis createProfile, the supplied identityId may already
+    // carry third-party delegated stake, so an operational key must not
+    // be able to re-price the operator fee. The identityId is reused — no
+    // new identity is minted — so id-keyed staking/conviction/sharding
+    // state stays addressable.
+    function recreateProfile(
+        uint72 identityId,
+        string calldata nodeName,
+        bytes calldata nodeId,
+        uint16 initialOperatorFee
+    ) external onlyWhitelisted onlyAdmin(identityId) {
+        ProfileStorage ps = profileStorage;
+
+        if (ps.profileExists(identityId)) {
+            revert ProfileLib.ProfileAlreadyExists(identityId);
+        }
+        if (bytes(nodeName).length == 0) {
+            revert ProfileLib.EmptyNodeName();
+        }
+        if (ps.isNameTaken(nodeName)) {
+            revert ProfileLib.NodeNameAlreadyExists(nodeName);
+        }
+        if (nodeId.length == 0) {
+            revert ProfileLib.EmptyNodeId();
+        }
+        if (ps.nodeIdsList(nodeId)) {
+            revert ProfileLib.NodeIdAlreadyExists(nodeId);
+        }
+        if (initialOperatorFee > parametersStorage.maxOperatorFee()) {
+            revert ProfileLib.OperatorFeeOutOfRange(initialOperatorFee);
+        }
 
         ps.createProfile(identityId, nodeName, nodeId, initialOperatorFee);
     }

--- a/packages/evm-module/contracts/Profile.sol
+++ b/packages/evm-module/contracts/Profile.sol
@@ -190,6 +190,16 @@ contract Profile is INamed, IVersioned, ContractStatus, IInitializable {
         }
 
         ps.createProfile(identityId, nodeName, nodeId, initialOperatorFee);
+
+        // ShardingTable survived a ProfileStorage-only redeploy: if this
+        // node is already in the ring, Ask's active-set / pricing
+        // aggregates (recomputed from ProfileStorage.getAsk per ring node)
+        // are stale until something recomputes. Trigger it now so the
+        // recovered node's contribution is consistent. Genesis
+        // createProfile has no ring entry, so it never needs this.
+        if (sts.nodeExists(identityId)) {
+            askContract.recalculateActiveSet();
+        }
     }
 
     function addOperationalWallets(

--- a/packages/evm-module/contracts/Profile.sol
+++ b/packages/evm-module/contracts/Profile.sol
@@ -129,18 +129,25 @@ contract Profile is INamed, IVersioned, ContractStatus, IInitializable {
     }
 
     // recreate-profile-recovery 0001 — re-attach a Profile to an Identity
-    // that survived a ProfileStorage redeploy. Admin-only (ADR 0001):
-    // unlike genesis createProfile, the supplied identityId may already
-    // carry third-party delegated stake, so an operational key must not
-    // be able to re-price the operator fee. The identityId is reused — no
-    // new identity is minted — so id-keyed staking/conviction/sharding
-    // state stays addressable.
+    // that survived a ProfileStorage redeploy. The caller passes the node
+    // operational wallet (operators know this; the numeric identityId is
+    // internal and often unknown), and the contract resolves the id via
+    // IdentityStorage. Admin-only (ADR 0001): unlike genesis createProfile,
+    // the resolved identityId may already carry third-party delegated
+    // stake, so an operational key must not be able to re-price the
+    // operator fee — _checkAdmin enforces the admin key after resolution
+    // (a zero/unknown wallet resolves to id 0, which has no admin and
+    // reverts). The identityId is reused — no new identity is minted — so
+    // id-keyed staking/conviction/sharding state stays addressable.
     function recreateProfile(
-        uint72 identityId,
+        address operationalWallet,
         string calldata nodeName,
         bytes calldata nodeId,
         uint16 initialOperatorFee
-    ) external onlyWhitelisted onlyAdmin(identityId) {
+    ) external onlyWhitelisted {
+        uint72 identityId = identityStorage.getIdentityId(operationalWallet);
+        _checkAdmin(identityId);
+
         ProfileStorage ps = profileStorage;
 
         if (ps.profileExists(identityId)) {

--- a/packages/evm-module/contracts/Profile.sol
+++ b/packages/evm-module/contracts/Profile.sol
@@ -10,6 +10,8 @@ import {ProfileStorage} from "./storage/ProfileStorage.sol";
 import {WhitelistStorage} from "./storage/WhitelistStorage.sol";
 import {Chronos} from "./storage/Chronos.sol";
 import {ConvictionStakingStorage} from "./storage/ConvictionStakingStorage.sol";
+import {ShardingTableStorage} from "./storage/ShardingTableStorage.sol";
+import {ShardingTableLib} from "./libraries/ShardingTableLib.sol";
 import {ContractStatus} from "./abstract/ContractStatus.sol";
 import {IInitializable} from "./interfaces/IInitializable.sol";
 import {INamed} from "./interfaces/INamed.sol";
@@ -44,6 +46,9 @@ contract Profile is INamed, IVersioned, ContractStatus, IInitializable {
     // Profile reads `isOperatorFeeClaimedForEpoch` in `updateOperatorFee`
     // to gate fee changes on prior-epoch fee claims being fully settled.
     ConvictionStakingStorage public convictionStakingStorage;
+    // recreate-profile-recovery 0001 — read-only: recreateProfile checks the
+    // recovered nodeId against any surviving sharding-table entry.
+    ShardingTableStorage public shardingTableStorage;
 
     // solhint-disable-next-line no-empty-blocks
     constructor(address hubAddress) ContractStatus(hubAddress) {}
@@ -77,6 +82,7 @@ contract Profile is INamed, IVersioned, ContractStatus, IInitializable {
         whitelistStorage = WhitelistStorage(hub.getContractAddress("WhitelistStorage"));
         chronos = Chronos(hub.getContractAddress("Chronos"));
         convictionStakingStorage = ConvictionStakingStorage(hub.getContractAddress("ConvictionStakingStorage"));
+        shardingTableStorage = ShardingTableStorage(hub.getContractAddress("ShardingTableStorage"));
     }
 
     function name() external pure virtual override returns (string memory) {
@@ -147,6 +153,20 @@ contract Profile is INamed, IVersioned, ContractStatus, IInitializable {
     ) external onlyWhitelisted {
         uint72 identityId = identityStorage.getIdentityId(operationalWallet);
         _checkAdmin(identityId);
+
+        // ShardingTableStorage survived the ProfileStorage redeploy and
+        // caches nodeId per identityId. If this node is still in the ring,
+        // the recovered nodeId MUST match the surviving entry — otherwise
+        // ProfileStorage and the sharding table would disagree about the
+        // same identityId (consumers would see a stale ring node). Read-only:
+        // ring state is not rewritten here (out of scope — ADR 0001).
+        ShardingTableStorage sts = shardingTableStorage;
+        if (sts.nodeExists(identityId)) {
+            bytes memory ringNodeId = sts.getNode(identityId).nodeId;
+            if (keccak256(nodeId) != keccak256(ringNodeId)) {
+                revert ProfileLib.NodeIdShardingMismatch(identityId, ringNodeId, nodeId);
+            }
+        }
 
         ProfileStorage ps = profileStorage;
 

--- a/packages/evm-module/contracts/libraries/ProfileLib.sol
+++ b/packages/evm-module/contracts/libraries/ProfileLib.sol
@@ -34,6 +34,7 @@ library ProfileLib {
     error NoOperatorFees(uint72 identityId);
     error ProfileDoesntExist(uint72 identityId);
     error ProfileAlreadyExists(uint72 identityId);
+    error NodeIdShardingMismatch(uint72 identityId, bytes expected, bytes provided);
     error NoPendingNodeAsk();
     error NoPendingOperatorFee();
     error InvalidOperatorFee();

--- a/packages/evm-module/contracts/libraries/ProfileLib.sol
+++ b/packages/evm-module/contracts/libraries/ProfileLib.sol
@@ -33,6 +33,7 @@ library ProfileLib {
     error AskUpdateOnCooldown(uint72 identityId, uint256 cooldownEnd);
     error NoOperatorFees(uint72 identityId);
     error ProfileDoesntExist(uint72 identityId);
+    error ProfileAlreadyExists(uint72 identityId);
     error NoPendingNodeAsk();
     error NoPendingOperatorFee();
     error InvalidOperatorFee();

--- a/packages/evm-module/deploy/active/025_deploy_profile.ts
+++ b/packages/evm-module/deploy/active/025_deploy_profile.ts
@@ -16,6 +16,10 @@ func.dependencies = [
   'ParametersStorage',
   'ProfileStorage',
   'WhitelistStorage',
+  // recreate-profile-recovery 0001 — recreateProfile reads
+  // ShardingTableStorage to keep the recovered nodeId consistent with any
+  // surviving sharding-table entry for the same identityId.
+  'ShardingTableStorage',
   'Ask',
   // D13 — Profile.initialize() reads `isOperatorFeeClaimedForEpoch` via CSS
   // after the DelegatorsInfo redirect. V6/V8 DelegatorsInfo migrators

--- a/packages/evm-module/docs/adr/0001-recreate-profile-admin-only.md
+++ b/packages/evm-module/docs/adr/0001-recreate-profile-admin-only.md
@@ -54,3 +54,26 @@ recover their nodes with a single transaction.
 - If testnet whitelisting is enabled, the bricked identities' **Admin**
   wallets must be whitelisted before recovery — the genesis flow
   whitelisted the Operational caller instead.
+- **Sharding-table consistency (enforced).** `ShardingTableStorage`
+  survives a ProfileStorage-only redeploy and caches `nodeId` per
+  `identityId`. `recreateProfile` therefore *reverts* (`NodeIdShardingMismatch`)
+  if the node is still in the ring (`nodeExists(identityId)`) and the
+  supplied `nodeId` differs from the surviving ring entry. This is a
+  **read-only** check — recovery deliberately does **not** rewrite ring
+  state (out of scope; would touch ShardingTable). Honest recovery (same
+  node, same `nodeId`) is unaffected; only a divergent `nodeId` is refused.
+
+## Known limitations
+
+- **Operator-fee history is not recoverable.** The pre-redeploy operator-fee
+  schedule was Profile-resident and is gone. `recreateProfile` seeds a
+  single fresh fee at recovery time (like genesis `createProfile`). For any
+  **unclaimed pre-recovery epochs**, `StakingV10._claim` resolves the
+  historical split via `getOperatorFeePercentageByTimestampReverse`, which
+  now falls back to the new recovery-time fee — i.e. recovery can
+  retroactively change reward splits for those epochs. This is **accepted
+  as a known testnet limitation**: the data is unrecoverable on-chain, and
+  a real (mainnet) event of this kind would be handled by a state
+  migration, not this recovery path. Operationally: settle/claim all
+  pre-recovery epochs before recovering, or accept reward drift for
+  unclaimed ones.

--- a/packages/evm-module/docs/adr/0001-recreate-profile-admin-only.md
+++ b/packages/evm-module/docs/adr/0001-recreate-profile-admin-only.md
@@ -1,0 +1,45 @@
+# ADR 0001 — recreateProfile is admin-only
+
+- Status: Accepted
+- Scope: `packages/evm-module` · `Profile.recreateProfile`
+- Related: PRD "Recreate Profile for an existing Identity (testnet recovery)"
+
+## Context
+
+After a testnet `ProfileStorage` redeploy, some nodes have an on-chain
+`Identity` but no `Profile`. `recreateProfile` re-attaches a `Profile`
+to such an `Identity`, reusing the existing `identityId` so that the
+surviving `identityId`-keyed staking, conviction and sharding state
+stays addressable.
+
+Genesis `createProfile` is whitelist-gated and called by an
+**Operational** key on a brand-new identity with zero stake. `Recreate`
+is different: it acts on an `identityId` that may already carry
+third-party delegated stake, and it sets the initial operator fee.
+
+## Decision
+
+`recreateProfile` is gated `onlyWhitelisted onlyAdmin(identityId)`.
+
+- The caller must hold the supplied identity's **Admin** key. This both
+  authorizes the caller and proves the `Identity` exists.
+- The signature takes `identityId` explicitly because Admin keys have no
+  reverse lookup, mirroring other admin-gated, id-parameterised profile
+  mutations (`updateOperatorFee`, `addOperationalWallets`).
+- The existing whitelist gate is preserved.
+
+## Rationale
+
+An Operational ("hot") key must not be able to set the operator fee on a
+stake-bearing node. A compromised hot key could otherwise re-price the
+node's operator fee against its delegators. Restricting recovery to the
+Admin key removes that vector while still letting honest operators
+recover their nodes with a single transaction.
+
+## Consequences
+
+- Operators must control each bricked Identity's original Admin key to
+  recover (operationally verified, off-chain).
+- If testnet whitelisting is enabled, the bricked identities' **Admin**
+  wallets must be whitelisted before recovery — the genesis flow
+  whitelisted the Operational caller instead.

--- a/packages/evm-module/docs/adr/0001-recreate-profile-admin-only.md
+++ b/packages/evm-module/docs/adr/0001-recreate-profile-admin-only.md
@@ -19,14 +19,25 @@ third-party delegated stake, and it sets the initial operator fee.
 
 ## Decision
 
-`recreateProfile` is gated `onlyWhitelisted onlyAdmin(identityId)`.
+`recreateProfile(address operationalWallet, …)` is gated `onlyWhitelisted`
+and resolves + enforces the admin check in-body:
 
-- The caller must hold the supplied identity's **Admin** key. This both
-  authorizes the caller and proves the `Identity` exists.
-- The signature takes `identityId` explicitly because Admin keys have no
-  reverse lookup, mirroring other admin-gated, id-parameterised profile
-  mutations (`updateOperatorFee`, `addOperationalWallets`).
+- The caller passes the node's **Operational wallet** — operators know this
+  (it is the node's running key); the numeric `identityId` is internal and
+  often unknown. The contract resolves
+  `identityId = IdentityStorage.getIdentityId(operationalWallet)`.
+- It then calls `_checkAdmin(identityId)`: `msg.sender` must hold that
+  identity's **Admin** key. Authorization is the Admin key, exactly as
+  before — the operational wallet is only an *identifier*, never the
+  authorizer. A zero/unknown wallet resolves to `id 0` (no admin) and
+  reverts, which also proves the `Identity` exists.
 - The existing whitelist gate is preserved.
+
+(Original draft took `uint72 identityId` directly, gated
+`onlyAdmin(identityId)`. Changed to the operational-wallet form for
+operator ergonomics — admins rarely know the numeric id — without
+weakening authorization: the admin key is still enforced, just after
+in-body resolution rather than via the modifier.)
 
 ## Rationale
 

--- a/packages/evm-module/test/integration/Profile.test.ts
+++ b/packages/evm-module/test/integration/Profile.test.ts
@@ -1172,7 +1172,7 @@ describe('@integration Profile recreate preserves id-keyed state', () => {
     await expect(
       profile
         .connect(admin)
-        .recreateProfile(identityId, 'Recover Node', nodeId, 1000),
+        .recreateProfile(operational.address, 'Recover Node', nodeId, 1000),
     ).to.not.be.reverted;
 
     // Profile restored under the SAME id; no new identity minted; the

--- a/packages/evm-module/test/integration/Profile.test.ts
+++ b/packages/evm-module/test/integration/Profile.test.ts
@@ -24,6 +24,8 @@ import {
   ParametersStorage,
   DelegatorsInfo,
   ShardingTable,
+  ConvictionStakingStorage,
+  IdentityStorage,
 } from '../../typechain';
 import { createKnowledgeCollection } from '../helpers/kc-helpers';
 import { createProfile } from '../helpers/profile-helpers';
@@ -1096,5 +1098,96 @@ describe('Profile Contract', () => {
         ).to.be.revertedWithCustomError(Profile, 'InvalidOperatorFee');
       });
     });
+  });
+});
+
+/* ───────── recreate-profile-recovery 0001 — id-keyed state ───────── */
+
+describe('@integration Profile recreate preserves id-keyed state', () => {
+  const fixtureRecreate = deployments.createFixture(async () => {
+    await hre.deployments.fixture(['Profile']);
+    const signers = await hre.ethers.getSigners();
+    const contracts = {
+      hub: await hre.ethers.getContract<Hub>('Hub'),
+      profile: await hre.ethers.getContract<Profile>('Profile'),
+      profileStorage:
+        await hre.ethers.getContract<ProfileStorage>('ProfileStorage'),
+      identityStorage:
+        await hre.ethers.getContract<IdentityStorage>('IdentityStorage'),
+      stakingStorage:
+        await hre.ethers.getContract<StakingStorage>('StakingStorage'),
+      convictionStakingStorage:
+        await hre.ethers.getContract<ConvictionStakingStorage>(
+          'ConvictionStakingStorage',
+        ),
+    };
+    await contracts.hub.setContractAddress('HubOwner', signers[0].address);
+    return { ...contracts, signers };
+  });
+
+  it('staking/conviction state pre-seeded under a bricked identityId survives recreate', async () => {
+    const {
+      profile,
+      profileStorage,
+      identityStorage,
+      stakingStorage,
+      convictionStakingStorage,
+      signers,
+    } = await fixtureRecreate();
+
+    const operational = signers[0];
+    const admin = signers[1];
+    const nodeId =
+      '0x07f38512786964d9e70453371e7c98975d284100d44bd68dab67fe00b525cb66';
+
+    // Mint identity 1 + profile, then wipe ONLY the profile — the testnet
+    // ProfileStorage-redeploy state: Identity + id-keyed state survive.
+    await profile
+      .connect(operational)
+      .createProfile(admin.address, [], 'Recover Node', nodeId, 1000);
+    const identityId = await identityStorage.getIdentityId(
+      operational.address,
+    );
+
+    const seededStake = hre.ethers.parseEther('12345');
+    const seededOperatorFee = hre.ethers.parseEther('67');
+    await stakingStorage
+      .connect(signers[0])
+      .setNodeStake(identityId, seededStake);
+    await convictionStakingStorage
+      .connect(signers[0])
+      .setOperatorFeeBalance(identityId, seededOperatorFee);
+
+    await profileStorage.connect(signers[0]).deleteProfile(identityId);
+    expect(await profileStorage.profileExists(identityId)).to.equal(false);
+    expect(await stakingStorage.getNodeStake(identityId)).to.equal(
+      seededStake,
+    );
+    expect(
+      await convictionStakingStorage.getOperatorFeeBalance(identityId),
+    ).to.equal(seededOperatorFee);
+
+    const lastIdBefore = await identityStorage.lastIdentityId();
+
+    await expect(
+      profile
+        .connect(admin)
+        .recreateProfile(identityId, 'Recover Node', nodeId, 1000),
+    ).to.not.be.reverted;
+
+    // Profile restored under the SAME id; no new identity minted; the
+    // pre-seeded id-keyed state is still addressable and unchanged.
+    expect(await profileStorage.profileExists(identityId)).to.equal(true);
+    expect(await profileStorage.getNodeId(identityId)).to.equal(nodeId);
+    expect(await identityStorage.lastIdentityId()).to.equal(lastIdBefore);
+    expect(
+      await identityStorage.getIdentityId(operational.address),
+    ).to.equal(identityId);
+    expect(await stakingStorage.getNodeStake(identityId)).to.equal(
+      seededStake,
+    );
+    expect(
+      await convictionStakingStorage.getOperatorFeeBalance(identityId),
+    ).to.equal(seededOperatorFee);
   });
 });

--- a/packages/evm-module/test/integration/Profile.test.ts
+++ b/packages/evm-module/test/integration/Profile.test.ts
@@ -26,6 +26,7 @@ import {
   ShardingTable,
   ConvictionStakingStorage,
   IdentityStorage,
+  ShardingTableStorage,
 } from '../../typechain';
 import { createKnowledgeCollection } from '../helpers/kc-helpers';
 import { createProfile } from '../helpers/profile-helpers';
@@ -1120,6 +1121,11 @@ describe('@integration Profile recreate preserves id-keyed state', () => {
         await hre.ethers.getContract<ConvictionStakingStorage>(
           'ConvictionStakingStorage',
         ),
+      askStorage: await hre.ethers.getContract<AskStorage>('AskStorage'),
+      shardingTableStorage:
+        await hre.ethers.getContract<ShardingTableStorage>(
+          'ShardingTableStorage',
+        ),
     };
     await contracts.hub.setContractAddress('HubOwner', signers[0].address);
     return { ...contracts, signers };
@@ -1130,7 +1136,6 @@ describe('@integration Profile recreate preserves id-keyed state', () => {
       profile,
       profileStorage,
       identityStorage,
-      stakingStorage,
       convictionStakingStorage,
       signers,
     } = await fixtureRecreate();
@@ -1149,20 +1154,21 @@ describe('@integration Profile recreate preserves id-keyed state', () => {
       operational.address,
     );
 
-    const seededStake = hre.ethers.parseEther('12345');
     const seededOperatorFee = hre.ethers.parseEther('67');
-    await stakingStorage
-      .connect(signers[0])
-      .setNodeStake(identityId, seededStake);
+    // Canonical V10 stake is ConvictionStakingStorage.nodeStakeV10 (read by
+    // Ask/ShardingTable/StakingV10). V8 StakingStorage.getNodeStake is
+    // unmaintained post-migration. No public nodeStakeV10 setter exists, so
+    // assert it is invariant across recreate (recreate writes only
+    // ProfileStorage, never CSS) alongside a non-zero operator-fee balance
+    // (a real CSS setter) to prove id-keyed CSS state survives.
     await convictionStakingStorage
       .connect(signers[0])
       .setOperatorFeeBalance(identityId, seededOperatorFee);
+    const stakeV10Before =
+      await convictionStakingStorage.getNodeStakeV10(identityId);
 
     await profileStorage.connect(signers[0]).deleteProfile(identityId);
     expect(await profileStorage.profileExists(identityId)).to.equal(false);
-    expect(await stakingStorage.getNodeStake(identityId)).to.equal(
-      seededStake,
-    );
     expect(
       await convictionStakingStorage.getOperatorFeeBalance(identityId),
     ).to.equal(seededOperatorFee);
@@ -1183,11 +1189,79 @@ describe('@integration Profile recreate preserves id-keyed state', () => {
     expect(
       await identityStorage.getIdentityId(operational.address),
     ).to.equal(identityId);
-    expect(await stakingStorage.getNodeStake(identityId)).to.equal(
-      seededStake,
-    );
+    expect(
+      await convictionStakingStorage.getNodeStakeV10(identityId),
+    ).to.equal(stakeV10Before);
     expect(
       await convictionStakingStorage.getOperatorFeeBalance(identityId),
     ).to.equal(seededOperatorFee);
+  });
+
+  it('recomputes the Ask active set when the recovered node is in the sharding table', async () => {
+    const {
+      profile,
+      profileStorage,
+      identityStorage,
+      askStorage,
+      shardingTableStorage,
+      signers,
+    } = await fixtureRecreate();
+    const operational = signers[0];
+    const admin = signers[1];
+    const nodeId =
+      '0x07f38512786964d9e70453371e7c98975d284100d44bd68dab67fe00b525cb66';
+
+    await profile
+      .connect(operational)
+      .createProfile(admin.address, [], 'Recover Node', nodeId, 1000);
+    const identityId = await identityStorage.getIdentityId(
+      operational.address,
+    );
+    await profileStorage.connect(signers[0]).deleteProfile(identityId);
+
+    // Node still in the ring; AskStorage carries a stale aggregate.
+    await shardingTableStorage
+      .connect(signers[0])
+      .createNodeObject(1, nodeId, identityId, 1);
+    await askStorage.connect(signers[0]).setTotalActiveStake(777n);
+    expect(await askStorage.prevTotalActiveStake()).to.equal(0n);
+
+    await profile
+      .connect(admin)
+      .recreateProfile(operational.address, 'Recover Node', nodeId, 1000);
+
+    // recalculateActiveSet ran: it copies totalActiveStake -> prev first.
+    expect(await askStorage.prevTotalActiveStake()).to.equal(777n);
+  });
+
+  it('does not recompute the Ask active set when the recovered node is not in the sharding table', async () => {
+    const {
+      profile,
+      profileStorage,
+      identityStorage,
+      askStorage,
+      signers,
+    } = await fixtureRecreate();
+    const operational = signers[0];
+    const admin = signers[1];
+    const nodeId =
+      '0x07f38512786964d9e70453371e7c98975d284100d44bd68dab67fe00b525cb66';
+
+    await profile
+      .connect(operational)
+      .createProfile(admin.address, [], 'Recover Node', nodeId, 1000);
+    const identityId = await identityStorage.getIdentityId(
+      operational.address,
+    );
+    await profileStorage.connect(signers[0]).deleteProfile(identityId);
+
+    await askStorage.connect(signers[0]).setTotalActiveStake(777n);
+
+    await profile
+      .connect(admin)
+      .recreateProfile(operational.address, 'Recover Node', nodeId, 1000);
+
+    // Node not in the ring → guard skips recalc → prev stays 0.
+    expect(await askStorage.prevTotalActiveStake()).to.equal(0n);
   });
 });

--- a/packages/evm-module/test/unit/Profile.test.ts
+++ b/packages/evm-module/test/unit/Profile.test.ts
@@ -9,6 +9,7 @@ import {
   ParametersStorage,
   Profile,
   ProfileStorage,
+  ShardingTableStorage,
   StakingStorage,
   Token,
   WhitelistStorage,
@@ -24,6 +25,7 @@ type ProfileFixture = {
   WhitelistStorage: WhitelistStorage;
   Token: Token;
   StakingStorage: StakingStorage;
+  ShardingTableStorage: ShardingTableStorage;
 };
 
 describe('@unit Profile contract', function () {
@@ -36,6 +38,7 @@ describe('@unit Profile contract', function () {
   let WhitelistStorage: WhitelistStorage;
   let Token: Token;
   let StakingStorage: StakingStorage;
+  let ShardingTableStorage: ShardingTableStorage;
 
   const nodeId1 =
     '0x07f38512786964d9e70453371e7c98975d284100d44bd68dab67fe00b525cb66';
@@ -55,6 +58,10 @@ describe('@unit Profile contract', function () {
     Token = await hre.ethers.getContract<Token>('Token');
     StakingStorage =
       await hre.ethers.getContract<StakingStorage>('StakingStorage');
+    ShardingTableStorage =
+      await hre.ethers.getContract<ShardingTableStorage>(
+        'ShardingTableStorage',
+      );
     accounts = await hre.ethers.getSigners();
     Hub = await hre.ethers.getContract<Hub>('Hub');
     await Hub.setContractAddress('HubOwner', accounts[0].address);
@@ -69,6 +76,7 @@ describe('@unit Profile contract', function () {
       WhitelistStorage,
       Token,
       StakingStorage,
+      ShardingTableStorage,
     };
   }
 
@@ -83,6 +91,7 @@ describe('@unit Profile contract', function () {
       WhitelistStorage,
       Token,
       StakingStorage,
+      ShardingTableStorage,
     } = await loadFixture(deployProfileFixture));
   });
 
@@ -490,6 +499,39 @@ describe('@unit Profile contract', function () {
           1000,
         ),
       ).to.be.revertedWithCustomError(Profile, 'OnlyProfileAdminFunction');
+    });
+
+    it('reverts when the supplied nodeId diverges from a surviving sharding-table entry', async () => {
+      await seedBrickedIdentity();
+      // Node still in the sharding ring under its ORIGINAL nodeId — the
+      // testnet state (ShardingTableStorage survived; ProfileStorage did not).
+      await ShardingTableStorage.createNodeObject(1, nodeId1, identityId1, 1);
+      const differentNodeId =
+        '0x17f38512786964d9e70453371e7c98975d284100d44bd68dab67fe00b525cb66';
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          accounts[0].address,
+          'Node 1',
+          differentNodeId,
+          1000,
+        ),
+      ).to.be.revertedWithCustomError(Profile, 'NodeIdShardingMismatch');
+    });
+
+    it('succeeds when the supplied nodeId matches the surviving sharding-table entry', async () => {
+      await seedBrickedIdentity();
+      await ShardingTableStorage.createNodeObject(1, nodeId1, identityId1, 1);
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          accounts[0].address,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.not.be.reverted;
+      expect(await ProfileStorage.profileExists(identityId1)).to.equal(true);
     });
 
     it('reverts EmptyNodeName for an empty node name', async () => {

--- a/packages/evm-module/test/unit/Profile.test.ts
+++ b/packages/evm-module/test/unit/Profile.test.ts
@@ -388,6 +388,208 @@ describe('@unit Profile contract', function () {
         identityId1,
       );
     });
+
+    it('reverts ProfileAlreadyExists when the Identity still has a Profile', async () => {
+      await Profile.createProfile(
+        accounts[1].address,
+        [],
+        'Node 1',
+        nodeId1,
+        1000,
+      );
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          identityId1,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      )
+        .to.be.revertedWithCustomError(Profile, 'ProfileAlreadyExists')
+        .withArgs(identityId1);
+    });
+
+    it('reverts when caller is an operational key (not admin) of the Identity', async () => {
+      await seedBrickedIdentity();
+
+      // accounts[0] is the operational key minted by createProfile.
+      await expect(
+        Profile.connect(accounts[0]).recreateProfile(
+          identityId1,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.be.revertedWithCustomError(Profile, 'OnlyProfileAdminFunction');
+    });
+
+    it('reverts when caller holds no admin key for the identityId', async () => {
+      await seedBrickedIdentity();
+
+      await expect(
+        Profile.connect(accounts[5]).recreateProfile(
+          identityId1,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.be.revertedWithCustomError(Profile, 'OnlyProfileAdminFunction');
+    });
+
+    it('reverts EmptyNodeName for an empty node name', async () => {
+      await seedBrickedIdentity();
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          identityId1,
+          '',
+          nodeId1,
+          1000,
+        ),
+      ).to.be.revertedWithCustomError(Profile, 'EmptyNodeName');
+    });
+
+    it('reverts EmptyNodeId for an empty node id', async () => {
+      await seedBrickedIdentity();
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          identityId1,
+          'Node 1',
+          '0x',
+          1000,
+        ),
+      ).to.be.revertedWithCustomError(Profile, 'EmptyNodeId');
+    });
+
+    it('reverts NodeIdAlreadyExists when the node id is taken by another node', async () => {
+      await seedBrickedIdentity();
+      await Profile.connect(accounts[3]).createProfile(
+        accounts[4].address,
+        [],
+        'Node 2',
+        nodeId1,
+        1000,
+      );
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          identityId1,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.be.revertedWithCustomError(Profile, 'NodeIdAlreadyExists');
+    });
+
+    it('reverts NodeNameAlreadyExists when the node name is taken', async () => {
+      await seedBrickedIdentity();
+
+      // isNameTaken has no on-chain setter (pre-existing protocol
+      // behavior), so flip the storage slot directly to exercise the
+      // verbatim createProfile name-uniqueness guard.
+      const nameTakenSlot = hre.ethers.keccak256(
+        hre.ethers.solidityPacked(['string', 'uint256'], ['Node 1', 2]),
+      );
+      await hre.network.provider.send('hardhat_setStorageAt', [
+        await ProfileStorage.getAddress(),
+        nameTakenSlot,
+        hre.ethers.zeroPadValue('0x01', 32),
+      ]);
+      expect(await ProfileStorage.isNameTaken('Node 1')).to.equal(true);
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          identityId1,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.be.revertedWithCustomError(Profile, 'NodeNameAlreadyExists');
+    });
+
+    it('accepts initialOperatorFee equal to the max and rejects above it', async () => {
+      await seedBrickedIdentity();
+      const maxFee = await ParametersStorage.maxOperatorFee();
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          identityId1,
+          'Node 1',
+          nodeId1,
+          maxFee,
+        ),
+      ).to.not.be.reverted;
+    });
+
+    it('reverts OperatorFeeOutOfRange when initialOperatorFee exceeds the max', async () => {
+      await seedBrickedIdentity();
+      const maxFee = await ParametersStorage.maxOperatorFee();
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          identityId1,
+          'Node 1',
+          nodeId1,
+          maxFee + 1n,
+        ),
+      ).to.be.revertedWithCustomError(Profile, 'OperatorFeeOutOfRange');
+    });
+
+    it('is gated by the whitelist: reverts when enabled and admin not whitelisted', async () => {
+      await seedBrickedIdentity();
+      await WhitelistStorage.enableWhitelist();
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          identityId1,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.be.revertedWithCustomError(
+        Profile,
+        'OnlyWhitelistedAddressesFunction',
+      );
+    });
+
+    it('whitelist enabled and admin whitelisted -> succeeds', async () => {
+      await seedBrickedIdentity();
+      await WhitelistStorage.enableWhitelist();
+      await WhitelistStorage.whitelistAddress(accounts[1].address);
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          identityId1,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.not.be.reverted;
+    });
+
+    it('regression: a brand-new wallet can still createProfile after a recovery', async () => {
+      await seedBrickedIdentity();
+      await Profile.connect(accounts[1]).recreateProfile(
+        identityId1,
+        'Node 1',
+        nodeId1,
+        1000,
+      );
+
+      const nodeId2 =
+        '0x17f38512786964d9e70453371e7c98975d284100d44bd68dab67fe00b525cb66';
+      await expect(
+        Profile.connect(accounts[3]).createProfile(
+          accounts[4].address,
+          [],
+          'Node 2',
+          nodeId2,
+          1000,
+        ),
+      ).to.not.be.reverted;
+    });
   });
 
   // =====================================================================

--- a/packages/evm-module/test/unit/Profile.test.ts
+++ b/packages/evm-module/test/unit/Profile.test.ts
@@ -580,31 +580,12 @@ describe('@unit Profile contract', function () {
       ).to.be.revertedWithCustomError(Profile, 'NodeIdAlreadyExists');
     });
 
-    it('reverts NodeNameAlreadyExists when the node name is taken', async () => {
-      await seedBrickedIdentity();
-
-      // isNameTaken has no on-chain setter (pre-existing protocol
-      // behavior), so flip the storage slot directly to exercise the
-      // verbatim createProfile name-uniqueness guard.
-      const nameTakenSlot = hre.ethers.keccak256(
-        hre.ethers.solidityPacked(['string', 'uint256'], ['Node 1', 2]),
-      );
-      await hre.network.provider.send('hardhat_setStorageAt', [
-        await ProfileStorage.getAddress(),
-        nameTakenSlot,
-        hre.ethers.zeroPadValue('0x01', 32),
-      ]);
-      expect(await ProfileStorage.isNameTaken('Node 1')).to.equal(true);
-
-      await expect(
-        Profile.connect(accounts[1]).recreateProfile(
-          accounts[0].address,
-          'Node 1',
-          nodeId1,
-          1000,
-        ),
-      ).to.be.revertedWithCustomError(Profile, 'NodeNameAlreadyExists');
-    });
+    // NOTE: a `NodeNameAlreadyExists` recreate test was removed here — it
+    // asserted an unreachable revert. `ProfileStorage.isNameTaken` is never
+    // written by any contract path, so the name-uniqueness guard (copied
+    // verbatim from createProfile) cannot fire in production; the old test
+    // only "passed" by faking it via a hardcoded storage slot. The dead
+    // mapping itself is tracked as separate pre-existing cleanup.
 
     it('accepts initialOperatorFee equal to the max and rejects above it', async () => {
       await seedBrickedIdentity();

--- a/packages/evm-module/test/unit/Profile.test.ts
+++ b/packages/evm-module/test/unit/Profile.test.ts
@@ -90,8 +90,8 @@ describe('@unit Profile contract', function () {
     expect(await Profile.name()).to.equal('Profile');
   });
 
-  it('The contract is version "1.2.0"', async () => {
-    expect(await Profile.version()).to.equal('1.2.0');
+  it('The contract is version "1.3.0"', async () => {
+    expect(await Profile.version()).to.equal('1.3.0');
   });
 
   it('Create a profile with valid inputs, expect to pass', async () => {
@@ -324,6 +324,70 @@ describe('@unit Profile contract', function () {
       Profile,
       'OnlyWhitelistedAddressesFunction',
     );
+  });
+
+  // =====================================================================
+  // recreate-profile-recovery 0001 — re-attach a Profile to an existing
+  // Identity (testnet ProfileStorage-redeploy recovery). Admin-only; the
+  // identityId is reused so surviving staking/conviction/sharding state
+  // stays addressable. See docs/adr/0001-recreate-profile-admin-only.md.
+  // =====================================================================
+
+  describe('recreateProfile (testnet recovery)', () => {
+    // createProfile mints identity 1 (operational = accounts[0],
+    // admin = accounts[1]) then we wipe only the Profile — mirroring the
+    // testnet state where the Identity survived a ProfileStorage redeploy.
+    async function seedBrickedIdentity() {
+      await Profile.createProfile(
+        accounts[1].address,
+        [],
+        'Node 1',
+        nodeId1,
+        1000,
+      );
+      await ProfileStorage.deleteProfile(identityId1);
+    }
+
+    it('admin recreates the Profile under the same identityId', async () => {
+      await seedBrickedIdentity();
+      expect(await ProfileStorage.profileExists(identityId1)).to.equal(false);
+
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          identityId1,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.not.be.reverted;
+
+      expect(await ProfileStorage.profileExists(identityId1)).to.equal(true);
+      expect(await ProfileStorage.getNodeId(identityId1)).to.equal(nodeId1);
+      expect(await ProfileStorage.getName(identityId1)).to.equal('Node 1');
+    });
+
+    it('does not mint a new identity (id counter and resolved id unchanged)', async () => {
+      await seedBrickedIdentity();
+      const lastIdBefore = await IdentityStorage.lastIdentityId();
+      const resolvedBefore = await IdentityStorage.getIdentityId(
+        accounts[0].address,
+      );
+
+      await Profile.connect(accounts[1]).recreateProfile(
+        identityId1,
+        'Node 1',
+        nodeId1,
+        1000,
+      );
+
+      expect(await IdentityStorage.lastIdentityId()).to.equal(lastIdBefore);
+      expect(await IdentityStorage.getIdentityId(accounts[0].address)).to.equal(
+        resolvedBefore,
+      );
+      expect(await IdentityStorage.getIdentityId(accounts[0].address)).to.equal(
+        identityId1,
+      );
+    });
   });
 
   // =====================================================================

--- a/packages/evm-module/test/unit/Profile.test.ts
+++ b/packages/evm-module/test/unit/Profile.test.ts
@@ -348,13 +348,32 @@ describe('@unit Profile contract', function () {
       await ProfileStorage.deleteProfile(identityId1);
     }
 
+    it('admin recreates by supplying the node operational wallet, not the numeric id', async () => {
+      await seedBrickedIdentity();
+      // accounts[0] is the operational wallet minted by createProfile;
+      // accounts[1] is the admin. The admin recovers WITHOUT knowing the
+      // numeric identityId — it passes the node operational wallet and the
+      // contract resolves the id (admin auth still enforced).
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          accounts[0].address,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.not.be.reverted;
+
+      expect(await ProfileStorage.profileExists(identityId1)).to.equal(true);
+      expect(await ProfileStorage.getNodeId(identityId1)).to.equal(nodeId1);
+    });
+
     it('admin recreates the Profile under the same identityId', async () => {
       await seedBrickedIdentity();
       expect(await ProfileStorage.profileExists(identityId1)).to.equal(false);
 
       await expect(
         Profile.connect(accounts[1]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           'Node 1',
           nodeId1,
           1000,
@@ -374,7 +393,7 @@ describe('@unit Profile contract', function () {
       );
 
       await Profile.connect(accounts[1]).recreateProfile(
-        identityId1,
+        accounts[0].address,
         'Node 1',
         nodeId1,
         1000,
@@ -400,7 +419,7 @@ describe('@unit Profile contract', function () {
 
       await expect(
         Profile.connect(accounts[1]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           'Node 1',
           nodeId1,
           1000,
@@ -416,7 +435,7 @@ describe('@unit Profile contract', function () {
       // accounts[0] is the operational key minted by createProfile.
       await expect(
         Profile.connect(accounts[0]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           'Node 1',
           nodeId1,
           1000,
@@ -429,7 +448,43 @@ describe('@unit Profile contract', function () {
 
       await expect(
         Profile.connect(accounts[5]).recreateProfile(
-          identityId1,
+          accounts[0].address,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.be.revertedWithCustomError(Profile, 'OnlyProfileAdminFunction');
+    });
+
+    it('reverts when the operational wallet has no identity (resolves to id 0)', async () => {
+      await seedBrickedIdentity();
+      // accounts[6] has no identity → getIdentityId == 0 → _checkAdmin(0)
+      // reverts (id 0 is never assigned, has no admin key).
+      await expect(
+        Profile.connect(accounts[1]).recreateProfile(
+          accounts[6].address,
+          'Node 1',
+          nodeId1,
+          1000,
+        ),
+      ).to.be.revertedWithCustomError(Profile, 'OnlyProfileAdminFunction');
+    });
+
+    it('reverts when caller admins a different identity than the operational wallet resolves to', async () => {
+      await seedBrickedIdentity();
+      // identity 2: operational = accounts[3], admin = accounts[4].
+      await Profile.connect(accounts[3]).createProfile(
+        accounts[4].address,
+        [],
+        'Node 2',
+        '0x17f38512786964d9e70453371e7c98975d284100d44bd68dab67fe00b525cb66',
+        1000,
+      );
+      // admin of identity 2 passes identity 1's operational wallet →
+      // resolves to id 1 → _checkAdmin(1) for the wrong admin reverts.
+      await expect(
+        Profile.connect(accounts[4]).recreateProfile(
+          accounts[0].address,
           'Node 1',
           nodeId1,
           1000,
@@ -442,7 +497,7 @@ describe('@unit Profile contract', function () {
 
       await expect(
         Profile.connect(accounts[1]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           '',
           nodeId1,
           1000,
@@ -455,7 +510,7 @@ describe('@unit Profile contract', function () {
 
       await expect(
         Profile.connect(accounts[1]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           'Node 1',
           '0x',
           1000,
@@ -475,7 +530,7 @@ describe('@unit Profile contract', function () {
 
       await expect(
         Profile.connect(accounts[1]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           'Node 1',
           nodeId1,
           1000,
@@ -501,7 +556,7 @@ describe('@unit Profile contract', function () {
 
       await expect(
         Profile.connect(accounts[1]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           'Node 1',
           nodeId1,
           1000,
@@ -515,7 +570,7 @@ describe('@unit Profile contract', function () {
 
       await expect(
         Profile.connect(accounts[1]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           'Node 1',
           nodeId1,
           maxFee,
@@ -529,7 +584,7 @@ describe('@unit Profile contract', function () {
 
       await expect(
         Profile.connect(accounts[1]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           'Node 1',
           nodeId1,
           maxFee + 1n,
@@ -543,7 +598,7 @@ describe('@unit Profile contract', function () {
 
       await expect(
         Profile.connect(accounts[1]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           'Node 1',
           nodeId1,
           1000,
@@ -561,7 +616,7 @@ describe('@unit Profile contract', function () {
 
       await expect(
         Profile.connect(accounts[1]).recreateProfile(
-          identityId1,
+          accounts[0].address,
           'Node 1',
           nodeId1,
           1000,
@@ -572,7 +627,7 @@ describe('@unit Profile contract', function () {
     it('regression: a brand-new wallet can still createProfile after a recovery', async () => {
       await seedBrickedIdentity();
       await Profile.connect(accounts[1]).recreateProfile(
-        identityId1,
+        accounts[0].address,
         'Node 1',
         nodeId1,
         1000,


### PR DESCRIPTION
## Problem

After a testnet **ProfileStorage** redeploy (IdentityStorage kept), every existing node has an on-chain **Identity** but no **Profile** — silently bricked. No on-chain path attaches a Profile to an existing `identityId`. TS-only fix impossible.

## Root cause

`identityId` is the cross-contract foreign key (IdentityStorage ↔ ProfileStorage ↔ Staking ↔ ConvictionStaking ↔ ShardingTable). `lastIdentityId` lives in IdentityStorage, **not** ProfileStorage — a ProfileStorage-only redeploy wipes `profiles[]` but leaves identity + id counter + sharding/staking state intact.

## Solution (testnet, Option A)

`Profile.recreateProfile(address operationalWallet, string nodeName, bytes nodeId, uint16 initialOperatorFee)`:

- Resolves `identityId = IdentityStorage.getIdentityId(operationalWallet)`, then `_checkAdmin(identityId)` (admin-only per `docs/adr/0001`; zero/unknown wallet → id 0 → reverts, also proves identity exists).
- Reuses the resolved `identityId`; never calls `Identity.createIdentity` (would orphan id-keyed staking/conviction/sharding state).
- **Sharding consistency:** if still in `ShardingTableStorage` (`nodeExists`), supplied `nodeId` must equal the surviving ring entry, else reverts `NodeIdShardingMismatch` (read-only — no ring writes).
- **Ask consistency:** if still in the sharding table, triggers `askContract.recalculateActiveSet()` so the recovered node's stale pre-redeploy active-set/pricing contribution is recomputed (mirrors `updateAsk`; genesis `createProfile` has no ring entry so never needs it).
- New errors `ProfileAlreadyExists`, `NodeIdShardingMismatch`; createProfile validations preserved; parity (ask=0, relayCapable=false, reuses `ProfileCreated`). `_VERSION` 1.2.0 → 1.3.0. Logic-redeploy only; `ShardingTableStorage` added to deploy deps (read-only).

## CI Codex review — status

**Round 1:** 🔴 ABI not regenerated → **Fixed**. 🔴 Sharding divergence → **Fixed** (`NodeIdShardingMismatch`). 🔴 Operator-fee retroactive → **Accepted known limitation** (ADR 0001).

**Round 2 (after close/reopen — the “30,979-line / over cap” skip was a stale GitHub merge-ref vs. a 119-commit-ahead `main`, not the real ~700-line diff):** 🔴 fee re-flag → standing decision. 🟡 brittle `isNameTaken` slot test → **Removed** (asserted unreachable behavior; `isNameTaken` is written by no contract path — dead mapping tracked as separate cleanup).

**Round 3:** 🔴 fee re-flag (3rd) → **standing decision**; “carry forward last fee” is impossible (schedule unrecoverable on-chain). 🔴 Ask active-set stale after recovery → **Fixed** (guarded `recalculateActiveSet`). 🟡 dead `isNameTaken` guard in recreate → deferred to the separate holistic cleanup (removing only here would diverge from `createProfile`). 🟡 integration test seeded V8 `StakingStorage` not V10 → **Fixed** (now asserts canonical `ConvictionStakingStorage.getNodeStakeV10` invariance + non-zero operator-fee balance; V8 seed/asserts dropped).

## Verification (this branch)

- `hardhat compile` clean.
- Profile **unit + integration: 49 passing / 0 failing** (1 pending = pre-existing obsolete V8 skip). Includes sharding-mismatch/-match, Ask-recompute (in-ring + not-in-ring), and CSS-V10 FK-preservation tests.
- solhint/eslint **not configured for `packages/evm-module`** (`turbo lint` skips it) — stated, not claimed.
- Full-repo regression deferred to CI (change internal to `Profile.recreateProfile`).

## Operator preconditions (not code — verify before testnet recovery)

1. If `WhitelistStorage.whitelistingEnabled()` is true, whitelist the bricked identities' **admin** wallets first (default disabled).
2. Operators must hold each bricked identity's **original admin key** and pass one of its operational wallet addresses.
3. **Settle/claim all pre-recovery epochs before recovering**, or accept reward drift for unclaimed ones (ADR 0001 “Known limitations”).
4. Each recovered operator must still call `updateAsk` to set a real ask post-recovery (recreate seeds ask=0; the recompute only clears the stale ring contribution).

## Out of scope

ProfileStorage batch-import/snapshot migration (mainnet Option C); IdentityStorage/staking/sharding-table *writes*; mainnet migration tooling; node-name → admin anti-squatting; the dead `isNameTaken` mapping cleanup (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
