### PR TITLE
feat(swm): PROTOCOL_SWM_UPDATE substrate fan-out + tier-switch (rc.9 PR-C)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1937,19 +1937,29 @@ export class DKGAgent {
     // peer): the second arrival just bumps `swm.redundantApplies`
     // for that cgId. No separate dedup machinery needed here.
     //
-    // The handler returns an empty Uint8Array because SWM apply
-    // is fire-and-forget (no application response). The
-    // substrate's send-side idempotency cache will return that
-    // empty response verbatim for any duplicate within its
-    // window, which is harmless. PR-D will replace the empty
-    // response with a structured ACK message (SwmShareAck) so the
-    // sender's quorum tracker can upgrade queued → delivered
-    // after receiver-side application succeeds.
-    this.messenger.register(PROTOCOL_SWM_UPDATE, async (data, peerId) => {
-      const wh = this.getOrCreateSharedMemoryHandler();
-      await wh.handle(data, peerId);
-      return new Uint8Array();
-    });
+    // PR-C codex R3 (receiver ACK semantics): the substrate
+    // response distinguishes three outcomes returned by
+    // `handle()`:
+    //   - `applied: true`         → empty Uint8Array ACK (success).
+    //   - `applied: false, retryable: false` → empty Uint8Array
+    //       (permanent rejection; nothing more for the sender to
+    //       do — bad signature, peer not in allowlist, CAS
+    //       conditions don't hold, etc. The sender drops the
+    //       share, matching pre-PR-C gossip semantics where the
+    //       same rejection would silently fall on the floor).
+    //   - `applied: false, retryable: true`  → THROW from the
+    //       handler so `messenger.sendReliable` reports the send
+    //       as failed and the substrate outbox keeps the share
+    //       queued for retry. Dominant production case: sender
+    //       key package for the current epoch hasn't arrived
+    //       yet; once it does, the same wire bytes apply on the
+    //       next retry.
+    // PR-D will replace the empty response with a structured ACK
+    // message (SwmShareAck) carrying the outcome explicitly, so
+    // the sender's quorum tracker can upgrade queued → delivered
+    // after receiver-side application succeeds (rather than the
+    // current proxy through substrate-level wire delivery).
+    this.messenger.register(PROTOCOL_SWM_UPDATE, async (data, peerId) => this.handleSwmUpdate(data, peerId));
 
     const effectiveRole = this.config.nodeRole ?? 'edge';
     const ackSignerCandidates = this.getACKSignerCandidateWallets(ctx);
@@ -6021,6 +6031,42 @@ export class DKGAgent {
     const signature = await new ethers.Wallet(input.senderPrivateKey)
       .signMessage(computeSwmSenderKeyPackageAAD(pkg));
     return { ...pkg, signature: ethers.getBytes(signature) };
+  }
+
+  /**
+   * `PROTOCOL_SWM_UPDATE` substrate receiver. Routes substrate-
+   * delivered SWM share bytes through `SharedMemoryHandler.handle()`
+   * (the same in-process apply path the gossip subscription
+   * drives) and maps the outcome to a substrate response:
+   *
+   *   - `applied: true` or permanent rejection → empty Uint8Array
+   *     (ACK; sender drops the share, matches gossip semantics
+   *     for the rejected case).
+   *   - retryable rejection → THROW so `messenger.sendReliable`
+   *     reports a failed send and the substrate outbox keeps the
+   *     share queued for retry. Dominant case: sender key package
+   *     for the current epoch hasn't arrived yet (workspaceSender
+   *     KeyDecryptor missing in the local handler, or the
+   *     decryptor itself rejects). Once the sender key arrives
+   *     the same wire bytes apply cleanly on the next attempt.
+   *
+   * Extracted into a named method so the receiver contract can
+   * be unit-tested in isolation without spinning up a real
+   * Messenger registration.
+   */
+  private async handleSwmUpdate(data: Uint8Array, fromPeerId: string): Promise<Uint8Array> {
+    const wh = this.getOrCreateSharedMemoryHandler();
+    const outcome = await wh.handle(data, fromPeerId);
+    if (!outcome.applied && outcome.retryable) {
+      // Throwing here is what tells the substrate outbox to keep
+      // the share queued. `handle()` already logged the specific
+      // rejection at WARN/ERROR; the throw message just surfaces
+      // it through the substrate's failure path so /api/slo's
+      // `protocols['/dkg/10.0.1/swm-update']` queued counts make
+      // sense at a glance.
+      throw new Error(`SWM apply transient rejection from ${fromPeerId}: ${outcome.reason}`);
+    }
+    return new Uint8Array();
   }
 
   private async handleSwmSenderKeyPackage(data: Uint8Array, fromPeerId: string): Promise<Uint8Array> {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2,7 +2,7 @@ import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
   PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
-  PROTOCOL_SWM_SENDER_KEY, PROTOCOL_MESSAGE,
+  PROTOCOL_SWM_SENDER_KEY, PROTOCOL_SWM_UPDATE, PROTOCOL_MESSAGE,
   contextGraphPublishTopic, contextGraphWorkspaceTopic, contextGraphAppTopic, contextGraphUpdateTopic, contextGraphFinalizationTopic,
   contextGraphDataGraphUri, contextGraphMetaGraphUri, contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
   contextGraphSharedMemoryUri,
@@ -155,6 +155,16 @@ import { SyncVerifyWorker } from './sync-verify-worker.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
+import {
+  createCGMemberEnumerator,
+  type CGMemberEnumerator,
+} from './swm/enumerate-cg-members.js';
+import {
+  chooseFanOutTier,
+  executeSubstrateFanOut,
+  type FanOutBookkeeper,
+  type FanOutPeerRecord,
+} from './swm/substrate-fanout.js';
 import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
@@ -1272,6 +1282,72 @@ export class DKGAgent {
   private swmGossipPublishFailuresTruncated = false;
   private static readonly SWM_GOSSIP_FAILURE_MAX_TRACKED_CGS = 1024;
 
+  /**
+   * Per-cgId, per-outcome counters for substrate-fan-out SWM
+   * shares (rc.9 PR-C / SWM reliable fan-out plan, Step 3).
+   * Populated by the {@link FanOutBookkeeper} the agent passes to
+   * `executeSubstrateFanOut` inside `publishWorkspaceGossip`.
+   * Same overflow-cap shape as `swmGossipPublishFailures` (Codex
+   * PR #570 R5/R8): the per-cgId map is hard-capped at
+   * {@link SWM_SUBSTRATE_FANOUT_MAX_TRACKED_CGS}; once exceeded,
+   * the cgId with the GLOBAL smallest total (delivered + queued +
+   * inFlight + failed) gets evicted into
+   * {@link swmSubstrateFanoutOverflow} so the grand total stays
+   * accurate. A sticky {@link swmSubstrateFanoutTruncated} flag
+   * tells `/api/slo` consumers that the per-cgId breakdown is
+   * partial.
+   *
+   * `delivered` is the only "good" outcome — `queued` means the
+   * substrate accepted the entry into the durable outbox (will
+   * retry; not a delivery confirmation), `inFlight` means another
+   * sender already owns the attempt, `failed` is the
+   * unrecoverable case. PR-D will add an ACK / watchdog that
+   * upgrades `queued → delivered` after the receiver confirms.
+   */
+  private readonly swmSubstrateFanoutDelivered = new Map<string, number>();
+  private readonly swmSubstrateFanoutQueued = new Map<string, number>();
+  private readonly swmSubstrateFanoutInFlight = new Map<string, number>();
+  private readonly swmSubstrateFanoutFailed = new Map<string, number>();
+  private swmSubstrateFanoutOverflow = {
+    delivered: 0,
+    queued: 0,
+    inFlight: 0,
+    failed: 0,
+  };
+  private swmSubstrateFanoutTruncated = false;
+  private static readonly SWM_SUBSTRATE_FANOUT_MAX_TRACKED_CGS = 1024;
+  /**
+   * Member-count cap above which public CGs fall back to gossip-
+   * only delivery (substrate fan-out is N-round-trips, so cost
+   * grows linearly in members; gossip cost is independent of N).
+   * Configurable via `DKG_SWM_SUBSTRATE_MAX_MEMBERS` env so soak
+   * runs can sweep the parameter without rebuilding. Curated CGs
+   * (`source: 'allowlist'`) are NOT truncated by this cap — see
+   * `chooseFanOutTier` jsdoc for the rationale.
+   */
+  private readonly swmSubstrateMaxMembers: number = (() => {
+    const raw = process.env.DKG_SWM_SUBSTRATE_MAX_MEMBERS;
+    if (!raw) return 100;
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 0) return 100;
+    return n;
+  })();
+  /**
+   * Per-send substrate timeout for SWM update fan-out. Matches the
+   * 15s reliability SLO the messenger targets for chat. Kept as a
+   * named constant so the soak script can correlate /api/slo
+   * `protocols['/dkg/10.0.1/swm-update']` p99 latency against the
+   * timeout budget.
+   */
+  private static readonly SWM_SUBSTRATE_FANOUT_TIMEOUT_MS = 15_000;
+
+  /**
+   * Lazy CGMemberEnumerator — single instance per agent. Holds the
+   * 60s membership cache shared across every share to the same
+   * cgId within a window. See {@link getOrCreateCGMemberEnumerator}.
+   */
+  private cgMemberEnumerator?: CGMemberEnumerator;
+
   private messageHandler: MessageHandler | null = null;
   private chainPoller: ChainEventPoller | null = null;
   private swmCleanupTimer: ReturnType<typeof setInterval> | null = null;
@@ -1846,6 +1922,32 @@ export class DKGAgent {
     // before the in-process handleSwmSenderKeyPackage call.
     this.messenger.register(PROTOCOL_SWM_SENDER_KEY, async (data, peerId) => {
       return this.handleSwmSenderKeyPackage(data, peerId);
+    });
+
+    // rc.9 PR-C (SWM reliable fan-out plan, Step 3): NEW protocol
+    // for point-to-point SWM share delivery as an alternative to
+    // GossipSub's best-effort mesh. The wire bytes are the same
+    // encoded workspace gossip message the gossip subscription
+    // delivers (see `encodeWorkspaceGossipMessage` in publisher),
+    // so we route them through the exact same in-process apply
+    // path — `SharedMemoryHandler.handle()`. That means PR-A's
+    // `seenShareOps` / `redundantApplies` accounting transparently
+    // covers double-delivery (gossip + substrate to the same
+    // peer): the second arrival just bumps `swm.redundantApplies`
+    // for that cgId. No separate dedup machinery needed here.
+    //
+    // The handler returns an empty Uint8Array because SWM apply
+    // is fire-and-forget (no application response). The
+    // substrate's send-side idempotency cache will return that
+    // empty response verbatim for any duplicate within its
+    // window, which is harmless. PR-D will replace the empty
+    // response with a structured ACK message (SwmShareAck) so the
+    // sender's quorum tracker can upgrade queued → delivered
+    // after receiver-side application succeeds.
+    this.messenger.register(PROTOCOL_SWM_UPDATE, async (data, peerId) => {
+      const wh = this.getOrCreateSharedMemoryHandler();
+      await wh.handle(data, peerId);
+      return new Uint8Array();
     });
 
     const effectiveRole = this.config.nodeRole ?? 'edge';
@@ -6319,6 +6421,88 @@ export class DKGAgent {
   ): Promise<void> {
     const topic = contextGraphWorkspaceTopic(contextGraphId);
     const wireMessage = await this.encodeWorkspaceGossipMessage(contextGraphId, message, resolvedSigner);
+
+    // rc.9 PR-C (SWM reliable fan-out plan, Step 3): tier-switch
+    // between substrate fan-out (point-to-point reliable via
+    // /dkg/10.0.1/swm-update) and GossipSub mesh based on CG
+    // membership shape. See `chooseFanOutTier` jsdoc + RFC-003 §6
+    // for the full policy. Both legs run when the policy says so
+    // — receiver-side dedup via SharedMemoryHandler's seenShareOps
+    // (PR-A) absorbs the resulting double-delivery cleanly and
+    // PR-A's `swm.redundantApplies` gauge makes it observable.
+    //
+    // Enumeration cost: at most one SPARQL query + one
+    // getSubscribers() call per CG per 60s window (enumerator
+    // caches). Independent of share rate.
+    //
+    // Errors are intentionally NOT re-thrown — share() in the
+    // caller already committed locally; transport failures here
+    // become observable via /api/slo (gossip.publishFailures +
+    // swm.substrateFanout) and the next sync-on-reconnect is the
+    // ultimate safety net.
+    const enumeration = await this.getOrCreateCGMemberEnumerator().enumerate(contextGraphId);
+    const plan = chooseFanOutTier({
+      enumeration,
+      maxSubstrateMembers: this.swmSubstrateMaxMembers,
+    });
+
+    // Substrate fan-out runs first (and in parallel with gossip
+    // when both legs are active) so the parallel send latency
+    // overlaps with the gossip publish round-trip.
+    const substratePromise = plan.useSubstrate
+      ? executeSubstrateFanOut({
+        contextGraphId,
+        protocolId: PROTOCOL_SWM_UPDATE,
+        payload: wireMessage,
+        members: plan.substrateMembers,
+        sendTimeoutMs: DKGAgent.SWM_SUBSTRATE_FANOUT_TIMEOUT_MS,
+        substrate: this.messenger,
+        bookkeeper: this.substrateFanoutBookkeeper(),
+      })
+      : Promise.resolve(null);
+
+    const gossipPromise = plan.useGossip
+      ? this.publishViaGossip(contextGraphId, topic, wireMessage, ctx)
+      : Promise.resolve();
+
+    const [substrateResult] = await Promise.all([substratePromise, gossipPromise]);
+
+    if (substrateResult !== null) {
+      this.log.info(
+        ctx,
+        `SWM substrate fan-out cgId=${contextGraphId} source=${plan.enumerationSource} `
+        + `enumerated=${plan.enumeratedCount} `
+        + `attempted=${substrateResult.attempted} `
+        + `delivered=${substrateResult.delivered} queued=${substrateResult.queued} `
+        + `inFlight=${substrateResult.inFlight} failed=${substrateResult.failed} `
+        + `also_gossiped=${plan.useGossip}`,
+      );
+    } else if (plan.enumerationSource === 'topic-subscribers' && plan.enumeratedCount > this.swmSubstrateMaxMembers) {
+      // Public CG above the threshold: gossip-only. Surface the
+      // gate trip at INFO so soak postmortems can correlate share
+      // delivery against transport choice without grepping for
+      // a separate decision log.
+      this.log.info(
+        ctx,
+        `SWM gossip-only (public CG above substrate cap) cgId=${contextGraphId} `
+        + `enumerated=${plan.enumeratedCount} cap=${this.swmSubstrateMaxMembers}`,
+      );
+    }
+  }
+
+  /**
+   * Pre-rc.9-PR-C body of `publishWorkspaceGossip` — the
+   * GossipSub publish + loud-fail counter from PR-A. Extracted
+   * into a named helper so the tier-switch above can call it
+   * conditionally (alongside or instead of the substrate fan-out
+   * leg) without duplicating the failure-bookkeeping logic.
+   */
+  private async publishViaGossip(
+    contextGraphId: string,
+    topic: string,
+    wireMessage: Uint8Array,
+    ctx: OperationContext,
+  ): Promise<void> {
     try {
       await this.gossip.publish(topic, wireMessage);
     } catch (err) {
@@ -8661,6 +8845,173 @@ export class DKGAgent {
       });
     }
     return this.sharedMemoryHandler;
+  }
+
+  /**
+   * Lazy single-instance CGMemberEnumerator. The enumerator owns
+   * a 60s membership cache so a burst of N shares to the same CG
+   * within the window pays one SPARQL query + one
+   * `getSubscribers` call total, not N.
+   *
+   * Deps are bound here to:
+   *  - `getContextGraphAllowedPeers` — the same accessor
+   *    `authorizePrivateSyncRequest` uses; returns null for CGs
+   *    with no `DKG_ALLOWED_PEER` allowlist triples (curated by
+   *    peer-allowlist returns the array; agent-gated returns
+   *    null, then `isPrivateContextGraph` discriminates).
+   *  - `isPrivateContextGraph` — closes the agent-gated-CG
+   *    misclassification hole (codex review on #571 bug #1): a CG
+   *    private via `DKG_ALLOWED_AGENT` without `DKG_ALLOWED_PEER`
+   *    falls into `source: 'none'` (fail closed) instead of
+   *    falling through to live topic subscribers.
+   *  - `getTopicSubscribers` — wrapping `GossipSubManager`'s
+   *    PR-B-added subscriber-snapshot accessor (best-effort, may
+   *    lag by one heartbeat interval; documented in
+   *    GossipSubManager.getSubscribers).
+   *  - `selfPeerId` — never fan out to ourselves; the local apply
+   *    already happened in the caller of `publishWorkspaceGossip`.
+   */
+  private getOrCreateCGMemberEnumerator(): CGMemberEnumerator {
+    if (!this.cgMemberEnumerator) {
+      this.cgMemberEnumerator = createCGMemberEnumerator({
+        getContextGraphAllowedPeers: (cgId) => this.getContextGraphAllowedPeers(cgId),
+        isPrivateContextGraph: (cgId) => this.isPrivateContextGraph(cgId),
+        getTopicSubscribers: (topic) => this.gossip.getSubscribers(topic),
+        topicForCG: (cgId) => contextGraphWorkspaceTopic(cgId),
+        selfPeerId: this.peerId,
+      });
+    }
+    return this.cgMemberEnumerator;
+  }
+
+  /**
+   * {@link FanOutBookkeeper} implementation backed by the four
+   * per-cgId outcome maps + the overflow buckets. Mirrors the
+   * Codex PR #570 R5/R8 shape from `recordSwmGossipPublishFailure`:
+   * once the per-cgId map crosses
+   * `SWM_SUBSTRATE_FANOUT_MAX_TRACKED_CGS`, the cgId with the
+   * GLOBAL smallest TOTAL count (summed across all four outcome
+   * maps) is evicted into the appropriate overflow bucket, so the
+   * grand total stays accurate and the hot cgIds stay visible.
+   *
+   * Returned as a single object literal (not a class) so the
+   * tier-switch in `publishWorkspaceGossip` can pass it inline
+   * to `executeSubstrateFanOut` without extra plumbing.
+   */
+  private substrateFanoutBookkeeper(): FanOutBookkeeper {
+    return {
+      recordOutcome: (cgId: string, record: FanOutPeerRecord) => {
+        this.recordSwmSubstrateFanoutOutcome(cgId, record);
+      },
+    };
+  }
+
+  /**
+   * Increment the per-(cgId, outcome) substrate counter and apply
+   * the overflow-cap eviction policy. Returns the post-increment
+   * count for the caller's WARN log on `failed` outcomes (parity
+   * with `recordSwmGossipPublishFailure`'s R12-fix shape).
+   */
+  private recordSwmSubstrateFanoutOutcome(cgId: string, record: FanOutPeerRecord): void {
+    const targetMap = this.substrateFanoutMapFor(record.outcome);
+    targetMap.set(cgId, (targetMap.get(cgId) ?? 0) + 1);
+    this.maybeEvictSubstrateFanoutCgId(cgId);
+  }
+
+  private substrateFanoutMapFor(outcome: FanOutPeerRecord['outcome']): Map<string, number> {
+    switch (outcome) {
+      case 'delivered': return this.swmSubstrateFanoutDelivered;
+      case 'queued':    return this.swmSubstrateFanoutQueued;
+      case 'inFlight':  return this.swmSubstrateFanoutInFlight;
+      case 'failed':    return this.swmSubstrateFanoutFailed;
+    }
+  }
+
+  private substrateFanoutTotalForCg(cgId: string): number {
+    return (this.swmSubstrateFanoutDelivered.get(cgId) ?? 0)
+      + (this.swmSubstrateFanoutQueued.get(cgId) ?? 0)
+      + (this.swmSubstrateFanoutInFlight.get(cgId) ?? 0)
+      + (this.swmSubstrateFanoutFailed.get(cgId) ?? 0);
+  }
+
+  /**
+   * If the per-cgId tracking set is at or above
+   * `SWM_SUBSTRATE_FANOUT_MAX_TRACKED_CGS`, find the cgId with
+   * the smallest TOTAL count (summed across all four outcome
+   * maps), drain its four per-outcome counts into the overflow
+   * buckets, and delete it from the four maps. Setting the
+   * sticky `swmSubstrateFanoutTruncated` flag tells operators
+   * the per-cgId breakdown on /api/slo is partial.
+   *
+   * Eviction key = TOTAL across outcomes (not any single map),
+   * because the operator-facing definition of "hot cgId" is "lots
+   * of substrate activity", regardless of how it broke down. A
+   * cgId with 100 delivers is hotter than a cgId with 5 failed,
+   * even though `failed` is the more alarming outcome.
+   */
+  private maybeEvictSubstrateFanoutCgId(_justBumped: string): void {
+    // Use any of the four maps to count distinct tracked cgIds —
+    // they're populated together via `substrateFanoutTotalForCg`.
+    const distinctCgIds = new Set<string>([
+      ...this.swmSubstrateFanoutDelivered.keys(),
+      ...this.swmSubstrateFanoutQueued.keys(),
+      ...this.swmSubstrateFanoutInFlight.keys(),
+      ...this.swmSubstrateFanoutFailed.keys(),
+    ]);
+    if (distinctCgIds.size <= DKGAgent.SWM_SUBSTRATE_FANOUT_MAX_TRACKED_CGS) return;
+
+    let smallestCg: string | null = null;
+    let smallestTotal = Infinity;
+    for (const cg of distinctCgIds) {
+      const total = this.substrateFanoutTotalForCg(cg);
+      if (total < smallestTotal) {
+        smallestTotal = total;
+        smallestCg = cg;
+      }
+    }
+    if (smallestCg === null) return;
+
+    this.swmSubstrateFanoutOverflow.delivered += this.swmSubstrateFanoutDelivered.get(smallestCg) ?? 0;
+    this.swmSubstrateFanoutOverflow.queued    += this.swmSubstrateFanoutQueued.get(smallestCg) ?? 0;
+    this.swmSubstrateFanoutOverflow.inFlight  += this.swmSubstrateFanoutInFlight.get(smallestCg) ?? 0;
+    this.swmSubstrateFanoutOverflow.failed    += this.swmSubstrateFanoutFailed.get(smallestCg) ?? 0;
+    this.swmSubstrateFanoutDelivered.delete(smallestCg);
+    this.swmSubstrateFanoutQueued.delete(smallestCg);
+    this.swmSubstrateFanoutInFlight.delete(smallestCg);
+    this.swmSubstrateFanoutFailed.delete(smallestCg);
+    this.swmSubstrateFanoutTruncated = true;
+  }
+
+  /**
+   * Snapshot of the substrate fan-out counters for /api/slo.
+   * Same surface shape as `getSwmGossipStats()` / `getSwmHandlerStats()`
+   * — pure read, safe to call from a fresh daemon (returns
+   * pristine zeroes when no shares have fanned out yet). Pre-
+   * serializing into `Record<string, number>` happens via
+   * `Object.fromEntries` consistent with the existing /api/slo
+   * shape.
+   */
+  getSwmSubstrateFanoutStats(): {
+    delivered: Record<string, number>;
+    queued: Record<string, number>;
+    inFlight: Record<string, number>;
+    failed: Record<string, number>;
+    overflow: { delivered: number; queued: number; inFlight: number; failed: number };
+    truncated: boolean;
+  } {
+    return {
+      delivered: Object.fromEntries(this.swmSubstrateFanoutDelivered),
+      queued: Object.fromEntries(this.swmSubstrateFanoutQueued),
+      inFlight: Object.fromEntries(this.swmSubstrateFanoutInFlight),
+      failed: Object.fromEntries(this.swmSubstrateFanoutFailed),
+      overflow: {
+        delivered: this.swmSubstrateFanoutOverflow.delivered,
+        queued: this.swmSubstrateFanoutOverflow.queued,
+        inFlight: this.swmSubstrateFanoutOverflow.inFlight,
+        failed: this.swmSubstrateFanoutOverflow.failed,
+      },
+      truncated: this.swmSubstrateFanoutTruncated,
+    };
   }
 
   private updateHandler?: UpdateHandler;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -162,6 +162,7 @@ import {
 import {
   chooseFanOutTier,
   executeSubstrateFanOut,
+  FANOUT_RESPONSE_REJECTED,
   type FanOutBookkeeper,
   type FanOutPeerRecord,
   type FanOutPlan,
@@ -1298,19 +1299,25 @@ export class DKGAgent {
    * tells `/api/slo` consumers that the per-cgId breakdown is
    * partial.
    *
-   * `delivered` is the only "good" outcome — `queued` means the
-   * substrate accepted the entry into the durable outbox (will
-   * retry; not a delivery confirmation), `inFlight` means another
-   * sender already owns the attempt, `failed` is the
-   * unrecoverable case. PR-D will add an ACK / watchdog that
+   * `delivered` is the only "good" outcome — `rejected` means
+   * the receiver explicitly dropped the share for a permanent
+   * reason (peer not in allowlist, bad signature, validation
+   * failed; PR-C codex R6 split this out from `delivered` so
+   * the metric doesn't overstate end-to-end success), `queued`
+   * means the substrate accepted the entry into the durable
+   * outbox (will retry; not a delivery confirmation), `inFlight`
+   * means another sender already owns the attempt, `failed` is
+   * the unrecoverable case. PR-D will add an ACK / watchdog that
    * upgrades `queued → delivered` after the receiver confirms.
    */
   private readonly swmSubstrateFanoutDelivered = new Map<string, number>();
+  private readonly swmSubstrateFanoutRejected = new Map<string, number>();
   private readonly swmSubstrateFanoutQueued = new Map<string, number>();
   private readonly swmSubstrateFanoutInFlight = new Map<string, number>();
   private readonly swmSubstrateFanoutFailed = new Map<string, number>();
   private swmSubstrateFanoutOverflow = {
     delivered: 0,
+    rejected: 0,
     queued: 0,
     inFlight: 0,
     failed: 0,
@@ -6037,18 +6044,27 @@ export class DKGAgent {
    * `PROTOCOL_SWM_UPDATE` substrate receiver. Routes substrate-
    * delivered SWM share bytes through `SharedMemoryHandler.handle()`
    * (the same in-process apply path the gossip subscription
-   * drives) and maps the outcome to a substrate response:
+   * drives) and maps the {@link SharedMemoryApplyOutcome} to a
+   * substrate response:
    *
-   *   - `applied: true` or permanent rejection → empty Uint8Array
-   *     (ACK; sender drops the share, matches gossip semantics
-   *     for the rejected case).
-   *   - retryable rejection → THROW so `messenger.sendReliable`
-   *     reports a failed send and the substrate outbox keeps the
-   *     share queued for retry. Dominant case: sender key package
-   *     for the current epoch hasn't arrived yet (workspaceSender
-   *     KeyDecryptor missing in the local handler, or the
-   *     decryptor itself rejects). Once the sender key arrives
-   *     the same wire bytes apply cleanly on the next attempt.
+   *   - `applied: true`                          → empty Uint8Array
+   *      (ACK; sender records `delivered`).
+   *   - `applied: false, retryable: true`        → THROW so
+   *      `messenger.sendReliable` reports a stream error,
+   *      `isRecoverableSendError` classifies it as recoverable
+   *      (the libp2p stream-reset signature contains "closed" /
+   *      "reset"), and the substrate outbox keeps the share
+   *      queued for retry. Dominant case: sender key package
+   *      for the current epoch hasn't arrived yet — once it
+   *      does, the SAME wire bytes apply cleanly on retry.
+   *   - `applied: false, retryable: false`       → return
+   *      {@link FANOUT_RESPONSE_REJECTED} (1-byte sentinel
+   *      `0x01`). The sender's `classifySendResult` recognises
+   *      the sentinel and records the outcome as `rejected`,
+   *      NOT `delivered` (codex R6 on PR #576). The share is
+   *      dropped — retrying the same wire bytes would produce
+   *      the same permanent rejection (bad signature, peer not
+   *      in allowlist, validation failed, malformed protobuf).
    *
    * Extracted into a named method so the receiver contract can
    * be unit-tested in isolation without spinning up a real
@@ -6057,16 +6073,28 @@ export class DKGAgent {
   private async handleSwmUpdate(data: Uint8Array, fromPeerId: string): Promise<Uint8Array> {
     const wh = this.getOrCreateSharedMemoryHandler();
     const outcome = await wh.handle(data, fromPeerId);
-    if (!outcome.applied && outcome.retryable) {
+    if (outcome.applied) {
+      return new Uint8Array();
+    }
+    if (outcome.retryable) {
       // Throwing here is what tells the substrate outbox to keep
-      // the share queued. `handle()` already logged the specific
-      // rejection at WARN/ERROR; the throw message just surfaces
-      // it through the substrate's failure path so /api/slo's
-      // `protocols['/dkg/10.0.1/swm-update']` queued counts make
-      // sense at a glance.
+      // the share queued. The router aborts the stream which the
+      // sender sees as a stream-reset error — `isRecoverableSendError`
+      // matches "reset"/"closed" substrings and enqueues into the
+      // outbox. `handle()` already logged the specific rejection
+      // at WARN/ERROR; the throw message just gives operators the
+      // hint when they grep for "swm apply" in receiver logs.
       throw new Error(`SWM apply transient rejection from ${fromPeerId}: ${outcome.reason}`);
     }
-    return new Uint8Array();
+    // Permanent rejection: signal via the 1-byte sentinel so the
+    // sender records `rejected` (not `delivered`) and stops here.
+    // PR-D will replace this with a structured `SwmShareAck`
+    // protobuf carrying outcome + reason on the wire.
+    this.log.warn(
+      createOperationContext('share'),
+      `SWM substrate receiver dropping share from ${fromPeerId} (permanent rejection): ${outcome.reason}`,
+    );
+    return FANOUT_RESPONSE_REJECTED;
   }
 
   private async handleSwmSenderKeyPackage(data: Uint8Array, fromPeerId: string): Promise<Uint8Array> {
@@ -6554,7 +6582,8 @@ export class DKGAgent {
         `SWM substrate fan-out cgId=${contextGraphId} source=${plan.enumerationSource} `
         + `enumerated=${plan.enumeratedCount} `
         + `attempted=${substrateResult.attempted} `
-        + `delivered=${substrateResult.delivered} queued=${substrateResult.queued} `
+        + `delivered=${substrateResult.delivered} rejected=${substrateResult.rejected} `
+        + `queued=${substrateResult.queued} `
         + `inFlight=${substrateResult.inFlight} failed=${substrateResult.failed} `
         + `also_gossiped=${plan.useGossip}`,
       );
@@ -9002,6 +9031,7 @@ export class DKGAgent {
   private substrateFanoutMapFor(outcome: FanOutPeerRecord['outcome']): Map<string, number> {
     switch (outcome) {
       case 'delivered': return this.swmSubstrateFanoutDelivered;
+      case 'rejected':  return this.swmSubstrateFanoutRejected;
       case 'queued':    return this.swmSubstrateFanoutQueued;
       case 'inFlight':  return this.swmSubstrateFanoutInFlight;
       case 'failed':    return this.swmSubstrateFanoutFailed;
@@ -9010,6 +9040,7 @@ export class DKGAgent {
 
   private substrateFanoutTotalForCg(cgId: string): number {
     return (this.swmSubstrateFanoutDelivered.get(cgId) ?? 0)
+      + (this.swmSubstrateFanoutRejected.get(cgId) ?? 0)
       + (this.swmSubstrateFanoutQueued.get(cgId) ?? 0)
       + (this.swmSubstrateFanoutInFlight.get(cgId) ?? 0)
       + (this.swmSubstrateFanoutFailed.get(cgId) ?? 0);
@@ -9031,10 +9062,11 @@ export class DKGAgent {
    * even though `failed` is the more alarming outcome.
    */
   private maybeEvictSubstrateFanoutCgId(_justBumped: string): void {
-    // Use any of the four maps to count distinct tracked cgIds —
+    // Use any of the five maps to count distinct tracked cgIds —
     // they're populated together via `substrateFanoutTotalForCg`.
     const distinctCgIds = new Set<string>([
       ...this.swmSubstrateFanoutDelivered.keys(),
+      ...this.swmSubstrateFanoutRejected.keys(),
       ...this.swmSubstrateFanoutQueued.keys(),
       ...this.swmSubstrateFanoutInFlight.keys(),
       ...this.swmSubstrateFanoutFailed.keys(),
@@ -9053,10 +9085,12 @@ export class DKGAgent {
     if (smallestCg === null) return;
 
     this.swmSubstrateFanoutOverflow.delivered += this.swmSubstrateFanoutDelivered.get(smallestCg) ?? 0;
+    this.swmSubstrateFanoutOverflow.rejected  += this.swmSubstrateFanoutRejected.get(smallestCg) ?? 0;
     this.swmSubstrateFanoutOverflow.queued    += this.swmSubstrateFanoutQueued.get(smallestCg) ?? 0;
     this.swmSubstrateFanoutOverflow.inFlight  += this.swmSubstrateFanoutInFlight.get(smallestCg) ?? 0;
     this.swmSubstrateFanoutOverflow.failed    += this.swmSubstrateFanoutFailed.get(smallestCg) ?? 0;
     this.swmSubstrateFanoutDelivered.delete(smallestCg);
+    this.swmSubstrateFanoutRejected.delete(smallestCg);
     this.swmSubstrateFanoutQueued.delete(smallestCg);
     this.swmSubstrateFanoutInFlight.delete(smallestCg);
     this.swmSubstrateFanoutFailed.delete(smallestCg);
@@ -9074,19 +9108,22 @@ export class DKGAgent {
    */
   getSwmSubstrateFanoutStats(): {
     delivered: Record<string, number>;
+    rejected: Record<string, number>;
     queued: Record<string, number>;
     inFlight: Record<string, number>;
     failed: Record<string, number>;
-    overflow: { delivered: number; queued: number; inFlight: number; failed: number };
+    overflow: { delivered: number; rejected: number; queued: number; inFlight: number; failed: number };
     truncated: boolean;
   } {
     return {
       delivered: Object.fromEntries(this.swmSubstrateFanoutDelivered),
+      rejected: Object.fromEntries(this.swmSubstrateFanoutRejected),
       queued: Object.fromEntries(this.swmSubstrateFanoutQueued),
       inFlight: Object.fromEntries(this.swmSubstrateFanoutInFlight),
       failed: Object.fromEntries(this.swmSubstrateFanoutFailed),
       overflow: {
         delivered: this.swmSubstrateFanoutOverflow.delivered,
+        rejected: this.swmSubstrateFanoutOverflow.rejected,
         queued: this.swmSubstrateFanoutOverflow.queued,
         inFlight: this.swmSubstrateFanoutOverflow.inFlight,
         failed: this.swmSubstrateFanoutOverflow.failed,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1967,6 +1967,17 @@ export class DKGAgent {
     // after receiver-side application succeeds (rather than the
     // current proxy through substrate-level wire delivery).
     this.messenger.register(PROTOCOL_SWM_UPDATE, async (data, peerId) => this.handleSwmUpdate(data, peerId));
+    // PR-C codex R7: tell Messenger that the 1-byte rejection
+    // sentinel is an APP-LEVEL rejection — Messenger's
+    // protocol-level `delivered` counter + latency histogram
+    // (`/api/slo`'s `protocols['/dkg/10.0.1/swm-update']`) should
+    // NOT bump for these responses. The application-level
+    // truth (delivered vs rejected) lives in
+    // `swm.substrateFanout.{delivered,rejected}`.
+    this.messenger.setResponseDeliveredClassifier(
+      PROTOCOL_SWM_UPDATE,
+      (response) => !(response.byteLength === 1 && response[0] === 0x01),
+    );
 
     const effectiveRole = this.config.nodeRole ?? 'edge';
     const ackSignerCandidates = this.getACKSignerCandidateWallets(ctx);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -164,6 +164,7 @@ import {
   executeSubstrateFanOut,
   type FanOutBookkeeper,
   type FanOutPeerRecord,
+  type FanOutPlan,
 } from './swm/substrate-fanout.js';
 import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
@@ -6440,11 +6441,45 @@ export class DKGAgent {
     // become observable via /api/slo (gossip.publishFailures +
     // swm.substrateFanout) and the next sync-on-reconnect is the
     // ultimate safety net.
-    const enumeration = await this.getOrCreateCGMemberEnumerator().enumerate(contextGraphId);
-    const plan = chooseFanOutTier({
-      enumeration,
-      maxSubstrateMembers: this.swmSubstrateMaxMembers,
-    });
+    //
+    // PR-C Codex R1 (planning-throw safety): `enumerate()` calls
+    // `getContextGraphAllowedPeers()` + `isPrivateContextGraph()`
+    // which both run SPARQL queries against `this.store`. A
+    // triple-store query failure (worker timeout, transient
+    // backend hiccup, corrupt graph) would otherwise bubble out
+    // of `publishWorkspaceGossip` and reject `share()` AFTER the
+    // local commit already succeeded — silently changing the
+    // pre-PR-C "share() never re-throws on transport failure"
+    // contract. Wrap planning in the same swallow-and-log shell
+    // as the gossip publish: on throw, fall back to a gossip-only
+    // plan (exactly the pre-PR-C behaviour for this share). The
+    // next share to the same cgId pays the SPARQL retry; the
+    // 60s enumeration cache means a one-off blip is recovered on
+    // the next call.
+    let plan: FanOutPlan;
+    try {
+      const enumeration = await this.getOrCreateCGMemberEnumerator().enumerate(contextGraphId);
+      plan = chooseFanOutTier({
+        enumeration,
+        maxSubstrateMembers: this.swmSubstrateMaxMembers,
+      });
+    } catch (err) {
+      const errClass = err instanceof Error
+        ? (err.name && err.name !== 'Error' ? err.name : err.constructor.name)
+        : typeof err;
+      const errMessage = err instanceof Error ? err.message : String(err);
+      this.log.warn(
+        ctx,
+        `SWM fan-out planning FAILED for cgId=${contextGraphId} errorClass="${errClass}" error="${errMessage}" — falling back to gossip-only (pre-PR-C behaviour)`,
+      );
+      plan = {
+        useSubstrate: false,
+        useGossip: true,
+        substrateMembers: [],
+        enumerationSource: 'none',
+        enumeratedCount: 0,
+      };
+    }
 
     // Substrate fan-out runs first (and in parallel with gossip
     // when both legs are active) so the parallel send latency

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -8989,8 +8989,14 @@ export class DKGAgent {
    *    PR-B-added subscriber-snapshot accessor (best-effort, may
    *    lag by one heartbeat interval; documented in
    *    GossipSubManager.getSubscribers).
-   *  - `selfPeerId` — never fan out to ourselves; the local apply
+   *  - `getSelfPeerId` — never fan out to ourselves; the local apply
    *    already happened in the caller of `publishWorkspaceGossip`.
+   *    Passed as a thunk (not the resolved string) because
+   *    `this.peerId` throws `DKGNode not started` before libp2p has
+   *    booted — eagerly capturing it here would break pre-start
+   *    `share()` callers (PR-C codex R8). The thunk lets any throw
+   *    bubble out of `enumerate()`, where the R1 try/catch in
+   *    `publishWorkspaceGossip` rescues into the gossip-only path.
    */
   private getOrCreateCGMemberEnumerator(): CGMemberEnumerator {
     if (!this.cgMemberEnumerator) {
@@ -8999,7 +9005,7 @@ export class DKGAgent {
         isPrivateContextGraph: (cgId) => this.isPrivateContextGraph(cgId),
         getTopicSubscribers: (topic) => this.gossip.getSubscribers(topic),
         topicForCG: (cgId) => contextGraphWorkspaceTopic(cgId),
-        selfPeerId: this.peerId,
+        getSelfPeerId: () => this.peerId,
       });
     }
     return this.cgMemberEnumerator;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -104,5 +104,17 @@ export {
   type CGMemberEnumeratorDeps,
   type CGMemberSource,
 } from './swm/enumerate-cg-members.js';
+export {
+  chooseFanOutTier,
+  executeSubstrateFanOut,
+  type ChooseFanOutTierInput,
+  type FanOutPlan,
+  type FanOutOutcome,
+  type FanOutPeerRecord,
+  type FanOutBookkeeper,
+  type FanOutSubstrate,
+  type ExecuteSubstrateFanOutInput,
+  type ExecuteSubstrateFanOutResult,
+} from './swm/substrate-fanout.js';
 export * from './source-worker.js';
 export * from './source-registry.js';

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -107,6 +107,7 @@ export {
 export {
   chooseFanOutTier,
   executeSubstrateFanOut,
+  FANOUT_RESPONSE_REJECTED,
   type ChooseFanOutTierInput,
   type FanOutPlan,
   type FanOutOutcome,

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -377,6 +377,30 @@ export class Messenger {
    */
   private readonly lastDhtWalkAt = new Map<string, number>();
 
+  /**
+   * Per-protocol classifier that decides whether a successful wire
+   * response should count as `delivered` in the protocol-level SLO
+   * counters/histogram. Returning `false` skips the delivered bump
+   * (and the latency sample) for THAT response — the caller still
+   * sees the response bytes verbatim and the outbox still removes
+   * the entry; only the metric is adjusted.
+   *
+   * Added in rc.9 PR-C codex R7: SWM's substrate receiver
+   * (`handleSwmUpdate`) signals permanent application-level
+   * rejections (peer not in allowlist, bad signature, validation
+   * failure) with a 1-byte `FANOUT_RESPONSE_REJECTED` sentinel
+   * response. Without this hook, `protocols['/dkg/10.0.1/swm-update']`
+   * would record those rejections as `delivered`, overstating
+   * apply success at the protocol layer. Other protocols don't
+   * register a classifier — every response counts as delivered
+   * (backward-compatible default).
+   *
+   * The classifier is called once per response (success path,
+   * background retry success, sender-side dedup hit) — it must
+   * be pure (no side effects) and cheap (microseconds).
+   */
+  private readonly deliveredResponseClassifiers = new Map<string, (response: Uint8Array) => boolean>();
+
   constructor(deps: MessengerDeps & { sloWindowSamples?: number }) {
     this.router = deps.router;
     this.idempotencyStore = deps.idempotencyStore;
@@ -389,6 +413,39 @@ export class Messenger {
     this.clock = deps.clock ?? (() => Date.now());
     this.sloWindowSamples = deps.sloWindowSamples ?? DEFAULT_SLO_WINDOW_SAMPLES;
     this.resolvePeer = deps.resolvePeer;
+  }
+
+  /**
+   * Register a per-protocol filter that decides whether a wire
+   * response should count toward the protocol-level `delivered`
+   * SLO counter. See {@link deliveredResponseClassifiers} for the
+   * full design rationale. Calling this with `protocolId` that
+   * already has a classifier overwrites it — last-write-wins.
+   *
+   * Typical use: PR-C SWM substrate fan-out registers
+   *   `setResponseDeliveredClassifier(PROTOCOL_SWM_UPDATE, (resp) =>
+   *      !(resp.byteLength === 1 && resp[0] === 0x01))`
+   * so the 1-byte rejection sentinel is excluded from `delivered`.
+   */
+  setResponseDeliveredClassifier(
+    protocolId: string,
+    classifier: (response: Uint8Array) => boolean,
+  ): void {
+    this.deliveredResponseClassifiers.set(protocolId, classifier);
+  }
+
+  private shouldCountResponseAsDelivered(protocolId: string, response: Uint8Array): boolean {
+    const classifier = this.deliveredResponseClassifiers.get(protocolId);
+    if (classifier === undefined) return true;
+    try {
+      return classifier(response);
+    } catch {
+      // Classifier bug — fail open (count as delivered) so a
+      // classifier crash doesn't make every send look like a
+      // rejection. The SWM-specific bucket will record the truth
+      // even if the protocol-level metric is slightly off.
+      return true;
+    }
   }
 
   /**
@@ -423,14 +480,34 @@ export class Messenger {
   }
 
   /**
-   * Record a successful delivery for the SLO histogram. Called from
+   * Record a wire-level response for the SLO histogram. Called from
    * `sendReliable` on synchronous success + from `retryOutboxEntry`
    * on background retry success. Idempotent on the (protocol, peer,
    * messageId) key — second call is a no-op because firstAttemptAt
    * was already cleared.
+   *
+   * PR-C codex R7: consults the per-protocol
+   * `deliveredResponseClassifiers` to decide whether the response
+   * counts as an application-level delivery. Non-applied responses
+   * (e.g. SWM's `FANOUT_RESPONSE_REJECTED` sentinel) clean up
+   * `firstAttemptAt` (no leak) but skip the `delivered` counter
+   * AND the latency histogram sample — operators reading the
+   * protocol-level metric see apply-level truth.
    */
-  private noteDeliveredForSlo(protocolId: string, peerId: string, messageId: string): void {
+  private noteDeliveredForSlo(
+    protocolId: string,
+    peerId: string,
+    messageId: string,
+    response: Uint8Array,
+  ): void {
     const k = sloKey(protocolId, peerId, messageId);
+    if (!this.shouldCountResponseAsDelivered(protocolId, response)) {
+      // App-level rejection (e.g. SWM rejection sentinel).
+      // Bookkeeping cleanup only; SLO bucket stays accurate to
+      // its "apply-level delivered" meaning.
+      this.firstAttemptAt.delete(k);
+      return;
+    }
     const startedAt = this.firstAttemptAt.get(k);
     if (startedAt == null) {
       this.bumpCounter(protocolId, 'delivered');
@@ -524,14 +601,23 @@ export class Messenger {
       // didn't actually deliver this call; the original delivery
       // already counted. Still bump the delivered counter so
       // operators see traffic.
-      this.bumpCounter(protocolId, 'delivered');
+      //
+      // PR-C codex R7: but only if the per-protocol classifier
+      // says the cached response counts as delivered. If the
+      // cached response is e.g. SWM's rejection sentinel, we
+      // shouldn't bump delivered on a dedup re-hit either — the
+      // protocol-level metric stays accurate to "applied".
+      const cached = sentBefore.cachedResponse ?? RESPONSE_GONE_BYTES;
+      if (this.shouldCountResponseAsDelivered(protocolId, cached)) {
+        this.bumpCounter(protocolId, 'delivered');
+      }
       this.firstAttemptAt.delete(sloK);
       return {
         delivered: true,
         // Mark-only original response surfaces as RESPONSE_GONE so
         // the caller can decide whether to re-issue with a fresh
         // messageId (chat: harmless; query: must re-issue).
-        response: sentBefore.cachedResponse ?? RESPONSE_GONE_BYTES,
+        response: cached,
         attempts: 1,
         messageId,
       };
@@ -571,7 +657,7 @@ export class Messenger {
       );
       idem.record(peerId, protocolId, messageId, 'out', response);
       outbox.markDelivered(peerId, protocolId, messageId);
-      this.noteDeliveredForSlo(protocolId, peerId, messageId);
+      this.noteDeliveredForSlo(protocolId, peerId, messageId, response);
       this.clearDhtWalkRateLimitIfDrained(peerId);
       return { delivered: true, response, attempts: 1, messageId };
     } catch (err) {
@@ -761,7 +847,7 @@ export class Messenger {
         response,
       );
       outbox.markDelivered(entry.peer, entry.protocol, entry.messageId);
-      this.noteDeliveredForSlo(entry.protocol, entry.peer, entry.messageId);
+      this.noteDeliveredForSlo(entry.protocol, entry.peer, entry.messageId, response);
       this.clearDhtWalkRateLimitIfDrained(entry.peer);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);

--- a/packages/agent/src/swm/enumerate-cg-members.ts
+++ b/packages/agent/src/swm/enumerate-cg-members.ts
@@ -102,11 +102,30 @@ export interface CGMemberEnumeratorDeps {
   getTopicSubscribers: (topic: string) => string[];
   topicForCG: (cgId: string) => string;
   /**
-   * Our own peer ID. Always excluded from the returned member set —
-   * we don't fan-out to ourselves (the local apply already happened
-   * in the caller).
+   * Lazy accessor for our own peer ID. Always excluded from the
+   * returned member set — we don't fan-out to ourselves (the local
+   * apply already happened in the caller).
+   *
+   * Resolved as a thunk (not a captured string) because the canonical
+   * accessor on `DKGAgent` is `this.node.peerId`, which throws
+   * `DKGNode not started` if libp2p hasn't booted yet. Eagerly
+   * capturing it at enumerator construction time would break the
+   * pre-start `share()` contract: callers that construct an agent
+   * and call `share()` before `start()` (e.g. test harnesses, or
+   * production code that queues writes before the node finishes
+   * booting) would crash inside the fan-out planner even when the
+   * share would otherwise take the gossip-only path. With a thunk,
+   * any throw bubbles out of `enumerate()` and gets caught by the
+   * try/catch in `DKGAgent.publishWorkspaceGossip` (PR-C codex R1
+   * fallback), which falls back to gossip-only and preserves the
+   * contract.
+   *
+   * The thunk is called fresh on every `computeMembers` invocation
+   * (cache misses) — peer ID is immutable once the node is started,
+   * so there's no correctness issue if it's read across multiple
+   * resolves with the same node.
    */
-  selfPeerId: string;
+  getSelfPeerId: () => string;
   /** Defaults to `Date.now`; override in tests for deterministic TTL. */
   now?: () => number;
   /** Defaults to 60s; override in tests or for higher-volatility CGs. */
@@ -186,7 +205,7 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
       // kicked).
       return {
         source: 'allowlist',
-        members: dedupAndExcludeSelf(allowed, deps.selfPeerId),
+        members: dedupAndExcludeSelf(allowed, deps.getSelfPeerId()),
       };
     }
 
@@ -210,7 +229,7 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
     // and any caller that treats `source !== 'none'` as "I have
     // remote recipients" would skip the intended fallback.
     const subscribers = deps.getTopicSubscribers(deps.topicForCG(cgId));
-    const members = dedupAndExcludeSelf(subscribers, deps.selfPeerId);
+    const members = dedupAndExcludeSelf(subscribers, deps.getSelfPeerId());
     return members.length === 0
       ? { source: 'none', members: [] }
       : { source: 'topic-subscribers', members };

--- a/packages/agent/src/swm/substrate-fanout.ts
+++ b/packages/agent/src/swm/substrate-fanout.ts
@@ -7,11 +7,21 @@
  * Owns three concerns:
  *
  *   1. **Tier decision** — given a `CGMemberEnumeration`, decide
- *      which transports to use:
- *        - `{ useSubstrate: true,  useGossip: false }` — curated
- *          CG (`source: 'allowlist'`); the on-chain roster is
- *          authoritative, gossip would just duplicate the wire
- *          load with no reliability gain.
+ *      which transports to use. As of the PR-C codex review (R2)
+ *      gossip is the UNIVERSAL baseline: it always runs. Substrate
+ *      decides whether to *also* run, adding a per-known-peer
+ *      reliability upgrade for peers we have a roster for:
+ *        - `{ useSubstrate: true,  useGossip: true }` — curated
+ *          CG (`source: 'allowlist'`); roster is authoritative,
+ *          but we still gossip because during a rolling rc.8/rc.9
+ *          upgrade some allowlisted peers won't yet support
+ *          `/dkg/10.0.1/swm-update` — substrate-only would silently
+ *          stop delivering to those peers (libp2p
+ *          protocol-negotiation error → sendReliable queues/retries
+ *          forever, never reaches the receiver). Gossip is the
+ *          cross-version safety net; PR-D will use per-peer ACK
+ *          feedback to opportunistically suppress the gossip leg
+ *          for peers that have confirmed substrate support.
  *        - `{ useSubstrate: true,  useGossip: true  }` — public CG
  *          (`source: 'topic-subscribers'`) at or below
  *          `maxSubstrateMembers`. Gossip remains the canonical
@@ -123,11 +133,13 @@ export interface ChooseFanOutTierInput {
  * to call N times per share if the caller wants (only enumeration
  * cost dominates, and the enumerator has its own 60s cache).
  *
- * Decision matrix (see RFC-003 §6 for the full rationale):
+ * Decision matrix (see RFC-003 §6 + this module's header for the
+ * full rationale). After PR-C codex R2, gossip is always on; the
+ * substrate is an additive per-known-peer reliability layer.
  *
  *   | source              | members vs cap       | substrate | gossip |
  *   |---------------------|----------------------|-----------|--------|
- *   | allowlist           | (any size)           | YES       | NO     |
+ *   | allowlist           | (any size)           | YES       | YES    |
  *   | topic-subscribers   | <= maxSubstrateMembers | YES     | YES    |
  *   | topic-subscribers   | >  maxSubstrateMembers | NO      | YES    |
  *   | none                | (always empty)       | NO        | YES    |
@@ -142,6 +154,20 @@ export interface ChooseFanOutTierInput {
  * peers on the next tick (and the soak postmortem will surface
  * the throughput cost so we can decide whether to add batching
  * or sharding for rc.10).
+ *
+ * Why curated CGs ALSO publish to gossip (PR-C codex R2): rolling
+ * rc.8 → rc.9 upgrades mean some allowlisted peers may not yet
+ * speak `/dkg/10.0.1/swm-update`. Substrate-only delivery would
+ * silently hit libp2p protocol-negotiation errors, sendReliable
+ * would queue/retry forever, and the peer would stop receiving
+ * SWM updates entirely until it upgraded. The gossip leg is a
+ * cross-version safety net. Cost: one extra gossip publish per
+ * share — negligible on small curated rosters, and receiver-side
+ * dedup (`SharedMemoryHandler.seenShareOps`, PR-A) absorbs the
+ * resulting double-delivery cleanly. PR-D will use per-peer ACK
+ * feedback to opportunistically suppress the gossip leg for peers
+ * confirmed to support substrate, recovering the wire-load saving
+ * once a CG's roster is fully on rc.9+.
  */
 export function chooseFanOutTier(input: ChooseFanOutTierInput): FanOutPlan {
   const { enumeration, maxSubstrateMembers } = input;
@@ -151,7 +177,7 @@ export function chooseFanOutTier(input: ChooseFanOutTierInput): FanOutPlan {
     case 'allowlist':
       return {
         useSubstrate: true,
-        useGossip: false,
+        useGossip: true,
         substrateMembers: enumeration.members,
         enumerationSource: 'allowlist',
         enumeratedCount,

--- a/packages/agent/src/swm/substrate-fanout.ts
+++ b/packages/agent/src/swm/substrate-fanout.ts
@@ -1,0 +1,383 @@
+/**
+ * SWM Reliable Fan-out — substrate fan-out policy + execution
+ * (rc.9 PR-C, Step 3 of the plan).
+ *
+ * Sits between `publishWorkspaceGossip` (the SWM share egress
+ * point) and the GossipSub mesh / Universal Messenger substrate.
+ * Owns three concerns:
+ *
+ *   1. **Tier decision** — given a `CGMemberEnumeration`, decide
+ *      which transports to use:
+ *        - `{ useSubstrate: true,  useGossip: false }` — curated
+ *          CG (`source: 'allowlist'`); the on-chain roster is
+ *          authoritative, gossip would just duplicate the wire
+ *          load with no reliability gain.
+ *        - `{ useSubstrate: true,  useGossip: true  }` — public CG
+ *          (`source: 'topic-subscribers'`) at or below
+ *          `maxSubstrateMembers`. Gossip remains the canonical
+ *          transport (catches latecomer subscribers we don't yet
+ *          see in the subscriber view); substrate is a top-up that
+ *          raises per-known-peer reliability into the same window
+ *          chat enjoys.
+ *        - `{ useSubstrate: false, useGossip: true  }` — public CG
+ *          above the threshold (substrate fan-out scales
+ *          poorly above ~100 peers — N round-trips per share), or
+ *          `source: 'none'` (bootstrap state or agent-gated
+ *          private CG without an enumerable peer roster — see
+ *          `enumerate-cg-members.ts` for why the latter fails
+ *          closed).
+ *
+ *      NB: this module is intentionally PURE — it does not consult
+ *      `process.env`. The caller (`DKGAgent`) reads
+ *      `DKG_SWM_SUBSTRATE_MAX_MEMBERS` at construction time and
+ *      passes the result in via `maxSubstrateMembers`.
+ *
+ *   2. **Fan-out execution** — for the chosen substrate set, fire
+ *      `messenger.sendReliable` in PARALLEL via `Promise.allSettled`
+ *      so one slow peer doesn't tail-latency the whole share. Each
+ *      per-peer outcome is classified as `delivered` /
+ *      `inFlight` / `queued` / `failed` and tallied into the
+ *      bookkeeping callback the caller provides.
+ *
+ *      Why parallel and not sequential? A curated CG with 50
+ *      members would otherwise pay 50 × p99 latency in the worst
+ *      case. Parallel fan-out caps the wall-clock at p99 of the
+ *      slowest single send.
+ *
+ *      Why `allSettled` and not `all`? `all` short-circuits on
+ *      first reject — but `messenger.sendReliable` doesn't reject
+ *      on transient failures (it returns `delivered: false,
+ *      queued: true` and persists into the outbox). A synchronous
+ *      throw here is the unrecoverable case (e.g. invalid peerId
+ *      shape) where the failure is local-side, not network-side,
+ *      and we want to record it but keep fanning out to the rest.
+ *
+ *   3. **Receiver-side coupling** — none, by design. The substrate
+ *      handler registered on `PROTOCOL_SWM_UPDATE` hands the wire
+ *      bytes straight to `SharedMemoryHandler.handle()`, the exact
+ *      same in-process apply path the gossip subscription drives.
+ *      That means PR-A's `seenShareOps`/`redundantApplies` accounting
+ *      automatically covers double-delivery (gossip + substrate of
+ *      the same share to the same peer) — the second arrival just
+ *      bumps `swm.redundantApplies` for that cgId. No new dedup
+ *      machinery needed at this layer.
+ *
+ * Watchdog / ACK / outstanding-table is PR-D, NOT here. PR-C is
+ * "send it and tally what happened"; PR-D adds "and if nobody
+ * acked, top up after N seconds".
+ */
+
+import type { ReliableSendResult } from '../p2p/messenger.js';
+import type { CGMemberEnumeration } from './enumerate-cg-members.js';
+
+/**
+ * Per-call decision: which transports to use for ONE share.
+ *
+ * `useSubstrate` and `useGossip` are independent booleans so the
+ * caller can write a single `if`/`if` block instead of a switch on
+ * three named tiers; the four meaningful combinations are
+ * captured exactly by the 2-bit product.
+ */
+export interface FanOutPlan {
+  useSubstrate: boolean;
+  useGossip: boolean;
+  /**
+   * Recipient set for the substrate leg. Empty array iff
+   * `useSubstrate === false`. Already de-duplicated and
+   * self-excluded by `CGMemberEnumerator`; this module does NOT
+   * filter further.
+   */
+  substrateMembers: readonly string[];
+  /**
+   * The {@link CGMemberEnumeration.source} that drove the
+   * decision. Surfaced for observability (log lines / per-tier
+   * metric breakdown / soak postmortem).
+   */
+  enumerationSource: CGMemberEnumeration['source'];
+  /**
+   * Pre-truncation member count (before `maxSubstrateMembers`
+   * gate kicked in). Equals `substrateMembers.length` when
+   * `useSubstrate === true`. When `useSubstrate === false` for a
+   * public CG that exceeded the threshold, this is the count
+   * that tripped the gate. Used by the caller's WARN log so
+   * operators can see "gossip-only because 137 > 100".
+   */
+  enumeratedCount: number;
+}
+
+/** Decision input — kept narrow so the policy is easy to test. */
+export interface ChooseFanOutTierInput {
+  enumeration: CGMemberEnumeration;
+  /**
+   * Maximum number of members we'll substrate-fan-out to. Above
+   * this, public CGs fall back to gossip-only (substrate cost
+   * grows linearly in members; gossip cost is independent of N).
+   * Curated CGs are NOT truncated by this — see {@link chooseFanOutTier}
+   * jsdoc for why.
+   */
+  maxSubstrateMembers: number;
+}
+
+/**
+ * Pure tier-decision function. No I/O, no clock, no globals — safe
+ * to call N times per share if the caller wants (only enumeration
+ * cost dominates, and the enumerator has its own 60s cache).
+ *
+ * Decision matrix (see RFC-003 §6 for the full rationale):
+ *
+ *   | source              | members vs cap       | substrate | gossip |
+ *   |---------------------|----------------------|-----------|--------|
+ *   | allowlist           | (any size)           | YES       | NO     |
+ *   | topic-subscribers   | <= maxSubstrateMembers | YES     | YES    |
+ *   | topic-subscribers   | >  maxSubstrateMembers | NO      | YES    |
+ *   | none                | (always empty)       | NO        | YES    |
+ *
+ * Why not truncate large curated CGs to the first
+ * `maxSubstrateMembers`? A curated CG above the threshold is rare
+ * (testnet curated CGs we've seen are <20 members), but the
+ * delivery semantics matter more than the threshold cost: dropping
+ * a substrate target because we're over budget would silently
+ * regress reliability for the dropped peers. If a curated CG ever
+ * does grow that large, PR-D's ACK + watchdog will catch missed
+ * peers on the next tick (and the soak postmortem will surface
+ * the throughput cost so we can decide whether to add batching
+ * or sharding for rc.10).
+ */
+export function chooseFanOutTier(input: ChooseFanOutTierInput): FanOutPlan {
+  const { enumeration, maxSubstrateMembers } = input;
+  const enumeratedCount = enumeration.members.length;
+
+  switch (enumeration.source) {
+    case 'allowlist':
+      return {
+        useSubstrate: true,
+        useGossip: false,
+        substrateMembers: enumeration.members,
+        enumerationSource: 'allowlist',
+        enumeratedCount,
+      };
+    case 'topic-subscribers':
+      if (enumeratedCount <= maxSubstrateMembers) {
+        return {
+          useSubstrate: true,
+          useGossip: true,
+          substrateMembers: enumeration.members,
+          enumerationSource: 'topic-subscribers',
+          enumeratedCount,
+        };
+      }
+      return {
+        useSubstrate: false,
+        useGossip: true,
+        substrateMembers: [],
+        enumerationSource: 'topic-subscribers',
+        enumeratedCount,
+      };
+    case 'none':
+      return {
+        useSubstrate: false,
+        useGossip: true,
+        substrateMembers: [],
+        enumerationSource: 'none',
+        enumeratedCount,
+      };
+  }
+}
+
+/** Per-peer substrate fan-out outcome, the bookkeeping vocabulary. */
+export type FanOutOutcome =
+  // `messenger.sendReliable` returned `delivered: true`. Wire ack
+  // received within the timeout; payload is in the receiver's
+  // SharedMemoryHandler. No follow-up needed.
+  | 'delivered'
+  // `messenger.sendReliable` returned `delivered: false, queued:
+  // true`. Persisted into the durable substrate outbox; will be
+  // retried by `Messenger.processOutboxTick` and on the next
+  // reconnect. From this layer's POV, treat as a soft failure
+  // (it's NOT a delivery confirmation) but DON'T re-fan out —
+  // would just enqueue another row for the same logical share.
+  | 'queued'
+  // `messenger.sendReliable` returned the rare `inFlight: true`
+  // (another sender already owns the in-process attempt for this
+  // peer × protocol × messageId). Effectively a no-op for THIS
+  // call; the other sender's outcome is what counts. Surfaced as
+  // its own bucket because it shouldn't be lumped with "failed"
+  // (no actual failure) or "delivered" (no actual delivery from
+  // OUR call).
+  | 'inFlight'
+  // Synchronous throw OR `delivered: false, queued: false`.
+  // Unrecoverable from this layer — usually a programming bug
+  // (invalid peerId shape) or a substrate misconfiguration. The
+  // share won't reach this peer via substrate. Gossip may still
+  // cover it if `useGossip: true`; otherwise the next sync-on-
+  // reconnect is the safety net.
+  | 'failed';
+
+/**
+ * Per-peer record handed to {@link FanOutBookkeeper.recordOutcome}.
+ * Includes the substrate-returned `attempts` and `messageId` so
+ * the caller can correlate against the substrate outbox /
+ * `/api/slo`'s `protocols['/dkg/10.0.1/swm-update']` histogram if
+ * needed (debug-only; the per-cgId aggregate counters are the
+ * production observability surface).
+ */
+export interface FanOutPeerRecord {
+  peerId: string;
+  outcome: FanOutOutcome;
+  attempts: number;
+  /** Substrate-assigned messageId; empty string for synchronous-throw failures. */
+  messageId: string;
+  /** Failure / queued reason string from the substrate; empty for delivered/inFlight. */
+  error: string;
+}
+
+/**
+ * Caller-side observability hook. The agent's implementation
+ * increments per-(cgId, outcome) counters with the same overflow
+ * cap pattern PR-A established for `swmGossipPublishFailures`.
+ * Kept as an interface so the policy module stays unit-testable
+ * with a tiny in-memory stub.
+ */
+export interface FanOutBookkeeper {
+  recordOutcome(cgId: string, record: FanOutPeerRecord): void;
+}
+
+/**
+ * Substrate dependency narrowed to the single method this module
+ * needs. Lets the test suite supply a mock without dragging in
+ * the full Messenger surface.
+ */
+export interface FanOutSubstrate {
+  sendReliable(
+    peerId: string,
+    protocolId: string,
+    payload: Uint8Array,
+    opts?: { timeoutMs?: number },
+  ): Promise<ReliableSendResult>;
+}
+
+export interface ExecuteSubstrateFanOutInput {
+  contextGraphId: string;
+  protocolId: string;
+  /** Wire bytes — same encoded workspace gossip message the gossip path publishes. */
+  payload: Uint8Array;
+  members: readonly string[];
+  /** Per-send timeout passed to `messenger.sendReliable`. */
+  sendTimeoutMs: number;
+  substrate: FanOutSubstrate;
+  bookkeeper: FanOutBookkeeper;
+}
+
+export interface ExecuteSubstrateFanOutResult {
+  /** Total number of substrate sends attempted (== members.length, kept for the WARN log). */
+  attempted: number;
+  /** Per-outcome counts, summed across all peers. */
+  delivered: number;
+  queued: number;
+  inFlight: number;
+  failed: number;
+}
+
+/**
+ * Fire `members.length` parallel substrate sends, classify each
+ * outcome, hand it to the bookkeeper, and return aggregate
+ * counts. Never throws — synchronous throws from `sendReliable`
+ * are caught and counted as `failed`.
+ *
+ * Parallel execution is intentional (see module-level jsdoc); the
+ * receiver's `SharedMemoryHandler.handle()` uses
+ * `withWriteLocks([sharedMemoryGraphUri])` so concurrent arrivals
+ * for the same CG are serialised at the apply layer — no risk of
+ * interleaved partial writes from fan-out parallelism on the
+ * sender side.
+ */
+export async function executeSubstrateFanOut(
+  input: ExecuteSubstrateFanOutInput,
+): Promise<ExecuteSubstrateFanOutResult> {
+  const { contextGraphId, protocolId, payload, members, sendTimeoutMs, substrate, bookkeeper } = input;
+  const result: ExecuteSubstrateFanOutResult = {
+    attempted: members.length,
+    delivered: 0,
+    queued: 0,
+    inFlight: 0,
+    failed: 0,
+  };
+
+  if (members.length === 0) return result;
+
+  await Promise.allSettled(members.map(async (peerId) => {
+    let record: FanOutPeerRecord;
+    try {
+      const sendResult = await substrate.sendReliable(peerId, protocolId, payload, { timeoutMs: sendTimeoutMs });
+      record = classifySendResult(peerId, sendResult);
+    } catch (err) {
+      record = {
+        peerId,
+        outcome: 'failed',
+        attempts: 0,
+        messageId: '',
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+    switch (record.outcome) {
+      case 'delivered':
+        result.delivered += 1;
+        break;
+      case 'queued':
+        result.queued += 1;
+        break;
+      case 'inFlight':
+        result.inFlight += 1;
+        break;
+      case 'failed':
+        result.failed += 1;
+        break;
+    }
+    bookkeeper.recordOutcome(contextGraphId, record);
+  }));
+
+  return result;
+}
+
+function classifySendResult(peerId: string, sendResult: ReliableSendResult): FanOutPeerRecord {
+  if (sendResult.delivered) {
+    return {
+      peerId,
+      outcome: 'delivered',
+      attempts: sendResult.attempts,
+      messageId: sendResult.messageId,
+      error: '',
+    };
+  }
+  // delivered: false. Three sub-cases via the discriminator.
+  if ('inFlight' in sendResult && sendResult.inFlight === true) {
+    return {
+      peerId,
+      outcome: 'inFlight',
+      attempts: sendResult.attempts,
+      messageId: sendResult.messageId,
+      error: sendResult.error,
+    };
+  }
+  if ('queued' in sendResult && sendResult.queued === true) {
+    return {
+      peerId,
+      outcome: 'queued',
+      attempts: sendResult.attempts,
+      messageId: sendResult.messageId,
+      error: sendResult.error,
+    };
+  }
+  // Defensive — the ReliableSendResult union currently only has
+  // three variants (delivered / queued / inFlight). If a fourth
+  // variant is ever added without updating this site, classify
+  // it as `failed` so the substrate fan-out doesn't silently
+  // double-count or lose track.
+  return {
+    peerId,
+    outcome: 'failed',
+    attempts: 0,
+    messageId: '',
+    error: 'unrecognised ReliableSendResult variant',
+  };
+}

--- a/packages/agent/src/swm/substrate-fanout.ts
+++ b/packages/agent/src/swm/substrate-fanout.ts
@@ -212,10 +212,21 @@ export function chooseFanOutTier(input: ChooseFanOutTierInput): FanOutPlan {
 
 /** Per-peer substrate fan-out outcome, the bookkeeping vocabulary. */
 export type FanOutOutcome =
-  // `messenger.sendReliable` returned `delivered: true`. Wire ack
-  // received within the timeout; payload is in the receiver's
-  // SharedMemoryHandler. No follow-up needed.
+  // `messenger.sendReliable` returned `delivered: true` AND the
+  // receiver's response was the empty Uint8Array (the
+  // applied-OK ACK from `DKGAgent.handleSwmUpdate`). Payload is
+  // in the receiver's SharedMemoryHandler. No follow-up needed.
   | 'delivered'
+  // `messenger.sendReliable` returned `delivered: true` but the
+  // receiver's response was the {@link FANOUT_RESPONSE_REJECTED}
+  // sentinel — the receiver explicitly rejected the share for
+  // a permanent reason (peer not in allowlist, bad agent
+  // signature, validation failure). The sender drops the share
+  // — retrying the same wire bytes would produce the same
+  // rejection. Counted separately from `delivered` because PR-C
+  // codex R6 caught that bundling them overstated end-to-end
+  // success in `/api/slo`'s `swm.substrateFanout.delivered`.
+  | 'rejected'
   // `messenger.sendReliable` returned `delivered: false, queued:
   // true`. Persisted into the durable substrate outbox; will be
   // retried by `Messenger.processOutboxTick` and on the next
@@ -238,6 +249,27 @@ export type FanOutOutcome =
   // cover it if `useGossip: true`; otherwise the next sync-on-
   // reconnect is the safety net.
   | 'failed';
+
+/**
+ * Wire sentinel returned by the substrate receiver
+ * (`DKGAgent.handleSwmUpdate`) for permanent rejections that
+ * the sender should drop without counting as delivered (peer
+ * not in CG allowlist, bad agent signature, validation
+ * rejection). Single-byte `0x01` chosen because:
+ *
+ *   - Distinguishable from the empty-Uint8Array applied-OK
+ *     response (length 0 vs length 1).
+ *   - Forward-compatible with PR-D's planned `SwmShareAck`:
+ *     PR-D will replace this with a structured protobuf
+ *     payload, but the 1-byte sentinel pins the
+ *     "delivered ≠ applied" semantic for the rc.9 release line.
+ *   - Older substrate senders that don't recognise the sentinel
+ *     treat the 1-byte response as a successful `delivered`
+ *     (slight metric overcount but no behavioural regression —
+ *     they continue to drop the share locally because nothing
+ *     further runs on a normal response).
+ */
+export const FANOUT_RESPONSE_REJECTED: Uint8Array = new Uint8Array([0x01]);
 
 /**
  * Per-peer record handed to {@link FanOutBookkeeper.recordOutcome}.
@@ -299,6 +331,8 @@ export interface ExecuteSubstrateFanOutResult {
   attempted: number;
   /** Per-outcome counts, summed across all peers. */
   delivered: number;
+  /** Permanent receiver-side rejections — sender drops, NOT counted as delivered (PR-C codex R6). */
+  rejected: number;
   queued: number;
   inFlight: number;
   failed: number;
@@ -324,6 +358,7 @@ export async function executeSubstrateFanOut(
   const result: ExecuteSubstrateFanOutResult = {
     attempted: members.length,
     delivered: 0,
+    rejected: 0,
     queued: 0,
     inFlight: 0,
     failed: 0,
@@ -349,6 +384,9 @@ export async function executeSubstrateFanOut(
       case 'delivered':
         result.delivered += 1;
         break;
+      case 'rejected':
+        result.rejected += 1;
+        break;
       case 'queued':
         result.queued += 1;
         break;
@@ -367,6 +405,23 @@ export async function executeSubstrateFanOut(
 
 function classifySendResult(peerId: string, sendResult: ReliableSendResult): FanOutPeerRecord {
   if (sendResult.delivered) {
+    // PR-C codex R6: receivers signal permanent rejection (peer
+    // not in allowlist, bad signature, validation failure) with
+    // the single-byte FANOUT_RESPONSE_REJECTED sentinel response.
+    // The substrate's `delivered: true` just means "got a normal
+    // reply" — we have to peek at the payload to distinguish
+    // "applied OK" from "explicitly dropped". Empty response =
+    // applied (the historical default and PR-D's planned upgrade
+    // path).
+    if (isRejectionSentinel(sendResult.response)) {
+      return {
+        peerId,
+        outcome: 'rejected',
+        attempts: sendResult.attempts,
+        messageId: sendResult.messageId,
+        error: 'receiver returned FANOUT_RESPONSE_REJECTED sentinel (permanent rejection)',
+      };
+    }
     return {
       peerId,
       outcome: 'delivered',
@@ -406,4 +461,17 @@ function classifySendResult(peerId: string, sendResult: ReliableSendResult): Fan
     messageId: '',
     error: 'unrecognised ReliableSendResult variant',
   };
+}
+
+/**
+ * Does the substrate response equal {@link FANOUT_RESPONSE_REJECTED}?
+ *
+ * Direct `===` doesn't work because the response Uint8Array is
+ * reconstructed by the substrate (decode path); we compare bytes
+ * instead. Tight 1-byte check — anything else (empty for applied
+ * OK, or future structured PR-D `SwmShareAck` payloads) is
+ * treated as `delivered`.
+ */
+function isRejectionSentinel(response: Uint8Array | undefined): boolean {
+  return response !== undefined && response.byteLength === 1 && response[0] === 0x01;
 }

--- a/packages/agent/test/enumerate-cg-members.test.ts
+++ b/packages/agent/test/enumerate-cg-members.test.ts
@@ -15,7 +15,7 @@ function makeDeps(overrides: Partial<CGMemberEnumeratorDeps>): CGMemberEnumerato
     isPrivateContextGraph: async () => false,
     getTopicSubscribers: () => [],
     topicForCG: (cgId) => `dkg/context-graph/${cgId}/shared-memory`,
-    selfPeerId: SELF,
+    getSelfPeerId: () => SELF,
     ...overrides,
   };
 }
@@ -452,5 +452,68 @@ describe('createCGMemberEnumerator: source label transitions', () => {
     const second = await enumerator.enumerate('cg-transition');
     expect(second.source).toBe('topic-subscribers');
     expect(second.members).toEqual(['peerOpen']);
+  });
+});
+
+/**
+ * PR-C codex R8: `getSelfPeerId` is a thunk (not a captured
+ * string) so that any throw inside the canonical accessor
+ * (`DKGAgent.peerId` → `DKGNode.peerId` → throws `DKGNode not
+ * started` before libp2p boots) doesn't fire at enumerator
+ * construction time. Construction MUST be safe even when the
+ * thunk would throw — only the actual `enumerate()` call should
+ * exercise it, where the throw bubbles into
+ * `publishWorkspaceGossip`'s R1 try/catch (gossip-only fallback).
+ */
+describe('createCGMemberEnumerator: getSelfPeerId thunk (PR-C codex R8)', () => {
+  it('construction does NOT call getSelfPeerId — pre-start agents are safe to wire up', () => {
+    let calls = 0;
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getSelfPeerId: () => {
+        calls += 1;
+        throw new Error('DKGNode not started');
+      },
+    }));
+
+    expect(calls).toBe(0);
+    expect(enumerator.size()).toBe(0);
+  });
+
+  it('throw inside getSelfPeerId propagates out of enumerate() so callers can rescue', async () => {
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      getContextGraphAllowedPeers: async () => ['peerA'],
+      getSelfPeerId: () => {
+        throw new Error('DKGNode not started');
+      },
+    }));
+
+    await expect(enumerator.enumerate('cg-thunk-throws')).rejects.toThrow(/not started/);
+  });
+
+  it('thunk is called fresh on each cache-miss resolve (allows peerId to become available between calls)', async () => {
+    let nowMs = 1_000_000;
+    const peerIdSnapshots: (string | null)[] = [];
+    let currentPeerId: string | null = null;
+    const enumerator = createCGMemberEnumerator(makeDeps({
+      now: () => nowMs,
+      cacheTtlMs: 100,
+      getContextGraphAllowedPeers: async () => ['peerA', SELF, 'peerB'],
+      getSelfPeerId: () => {
+        peerIdSnapshots.push(currentPeerId);
+        if (currentPeerId === null) {
+          throw new Error('DKGNode not started');
+        }
+        return currentPeerId;
+      },
+    }));
+
+    await expect(enumerator.enumerate('cg-late-start')).rejects.toThrow(/not started/);
+    expect(peerIdSnapshots).toEqual([null]);
+
+    currentPeerId = SELF;
+    nowMs += 200;
+    const result = await enumerator.enumerate('cg-late-start');
+    expect(peerIdSnapshots).toEqual([null, SELF]);
+    expect(result.members.sort()).toEqual(['peerA', 'peerB']);
   });
 });

--- a/packages/agent/test/messenger-substrate.test.ts
+++ b/packages/agent/test/messenger-substrate.test.ts
@@ -475,6 +475,121 @@ describe('Messenger.getSloStats (SLO histogram)', () => {
     expect(messenger.getSloStats()).toEqual({});
   });
 
+  /**
+   * PR-C codex R7: per-protocol classifier hook lets the protocol
+   * owner exclude application-level rejection responses from the
+   * protocol-level `delivered` counter + latency histogram. SWM
+   * uses this for its 1-byte rejection sentinel so
+   * `protocols['/dkg/10.0.1/swm-update'].delivered` stays accurate
+   * to apply-level truth.
+   *
+   * These tests exercise the hook directly against a stock
+   * Messenger (no SWM-specific code involved) so the primitive
+   * stays reusable for future protocols.
+   */
+  describe('setResponseDeliveredClassifier (PR-C codex R7)', () => {
+    const REJECTION_SENTINEL = new Uint8Array([0x01]);
+
+    it('default behaviour (no classifier registered): every response counts as delivered', async () => {
+      const router = makeRouter(async () => REJECTION_SENTINEL);
+      const { messenger } = makeSubstrate({ router });
+      await messenger.sendReliable(PEER_B, PROTO, new Uint8Array([1]), {
+        messageId: 'm-default-' + '0'.repeat(26),
+      });
+
+      const stats = messenger.getSloStats();
+      expect(stats[PROTO].delivered).toBe(1);
+      expect(stats[PROTO].samples).toBe(1);
+    });
+
+    it('classifier returning false for a response skips delivered bump AND latency sample', async () => {
+      const router = makeRouter(async () => REJECTION_SENTINEL);
+      const { messenger, clock } = makeSubstrate({ router });
+      messenger.setResponseDeliveredClassifier(
+        PROTO,
+        (resp) => !(resp.byteLength === 1 && resp[0] === 0x01),
+      );
+
+      clock.mockImplementation(() => 1_700_000_000_000);
+      const p = messenger.sendReliable(PEER_B, PROTO, new Uint8Array([1]), {
+        messageId: 'm-rej-' + '0'.repeat(30),
+      });
+      clock.mockImplementation(() => 1_700_000_000_500);
+      const result = await p;
+
+      // Caller still sees a successful response with the sentinel
+      // bytes — only the metric is adjusted.
+      expect(result.delivered).toBe(true);
+      expect(Array.from(result.response ?? [])).toEqual([0x01]);
+
+      const stats = messenger.getSloStats();
+      // No SLO entry at all because nothing successfully delivered
+      // — getSloStats only emits keys for protocols with traffic.
+      expect(stats[PROTO]).toBeUndefined();
+    });
+
+    it('classifier returning true keeps the delivered bump (apply-OK response)', async () => {
+      const router = makeRouter(async () => new Uint8Array());
+      const { messenger } = makeSubstrate({ router });
+      messenger.setResponseDeliveredClassifier(
+        PROTO,
+        (resp) => !(resp.byteLength === 1 && resp[0] === 0x01),
+      );
+
+      await messenger.sendReliable(PEER_B, PROTO, new Uint8Array([1]), {
+        messageId: 'm-ok-' + '0'.repeat(31),
+      });
+
+      const stats = messenger.getSloStats();
+      expect(stats[PROTO].delivered).toBe(1);
+    });
+
+    it('mix of applied + rejected responses bumps delivered only for applied', async () => {
+      let respondWith = new Uint8Array();
+      const router = makeRouter(async () => respondWith);
+      const { messenger } = makeSubstrate({ router });
+      messenger.setResponseDeliveredClassifier(
+        PROTO,
+        (resp) => !(resp.byteLength === 1 && resp[0] === 0x01),
+      );
+
+      // First: apply OK → counts as delivered.
+      respondWith = new Uint8Array();
+      await messenger.sendReliable(PEER_B, PROTO, new Uint8Array([1]), {
+        messageId: 'm-r7-ok-' + '0'.repeat(28),
+      });
+      // Second: rejected → does NOT count as delivered.
+      respondWith = REJECTION_SENTINEL;
+      await messenger.sendReliable(PEER_B, PROTO, new Uint8Array([2]), {
+        messageId: 'm-r7-rej-' + '0'.repeat(27),
+      });
+      // Third: apply OK → counts as delivered.
+      respondWith = new Uint8Array();
+      await messenger.sendReliable(PEER_B, PROTO, new Uint8Array([3]), {
+        messageId: 'm-r7-ok2-' + '0'.repeat(27),
+      });
+
+      const stats = messenger.getSloStats();
+      expect(stats[PROTO].delivered).toBe(2);
+      expect(stats[PROTO].samples).toBe(2);
+    });
+
+    it('classifier crash fails open (counts as delivered) so a classifier bug does not hide real traffic', async () => {
+      const router = makeRouter(async () => REJECTION_SENTINEL);
+      const { messenger } = makeSubstrate({ router });
+      messenger.setResponseDeliveredClassifier(PROTO, () => {
+        throw new Error('classifier bug');
+      });
+
+      await messenger.sendReliable(PEER_B, PROTO, new Uint8Array([1]), {
+        messageId: 'm-r7-bug-' + '0'.repeat(27),
+      });
+
+      const stats = messenger.getSloStats();
+      expect(stats[PROTO].delivered).toBe(1);
+    });
+  });
+
   it('per-protocol stats are isolated', async () => {
     const { messenger, clock } = makeSubstrate();
     const PROTO_B = '/dkg/10.0.1/private-access';

--- a/packages/agent/test/swm-agent-gate-access.test.ts
+++ b/packages/agent/test/swm-agent-gate-access.test.ts
@@ -38,6 +38,12 @@ class FakeGossip {
   onMessage(): void {}
 
   async publish(): Promise<void> {}
+
+  // rc.9 PR-C: tier-switch in publishWorkspaceGossip consults
+  // GossipSubManager.getSubscribers. Empty roster keeps the
+  // agent-gate-access flow on the gossip-only branch (no
+  // substrate fan-out picks up the encoded share bytes here).
+  getSubscribers(_topic: string): string[] { return []; }
 }
 
 async function flushAsync(): Promise<void> {

--- a/packages/agent/test/swm-gossip-publish-failure.test.ts
+++ b/packages/agent/test/swm-gossip-publish-failure.test.ts
@@ -13,6 +13,15 @@ class ThrowingGossip {
     this.publishAttempts.push({ topic, bytes: data.byteLength });
     throw new Error(`simulated mesh failure for ${topic}`);
   }
+
+  // rc.9 PR-C: the tier-switch in publishWorkspaceGossip consults
+  // GossipSubManager.getSubscribers via the CGMemberEnumerator.
+  // Returning [] keeps these PR-A regression tests focused on the
+  // gossip-failure path: no topic subscribers + no allowlist =>
+  // `source: 'none'` => `useSubstrate: false, useGossip: true`,
+  // so the share takes the gossip-only branch and exercises the
+  // PR-A counter exactly like it did before PR-C.
+  getSubscribers(_topic: string): string[] { return []; }
 }
 
 // PR-A R6 regression: throws a named, non-generic error class so the
@@ -35,6 +44,7 @@ class TypedThrowingGossip {
     this.publishAttempts.push({ topic, bytes: data.byteLength });
     throw new NoPeersSubscribedError(`no peers subscribed to ${topic}`);
   }
+  getSubscribers(_topic: string): string[] { return []; }
 }
 
 describe('DKGAgent SWM gossip publish failure (rc.9 PR-A)', () => {

--- a/packages/agent/test/swm-gossip-signing.test.ts
+++ b/packages/agent/test/swm-gossip-signing.test.ts
@@ -41,6 +41,12 @@ class CapturingGossip {
   async publish(topic: string, data: Uint8Array): Promise<void> {
     this.messages.push({ topic, data });
   }
+
+  // rc.9 PR-C: tier-switch in publishWorkspaceGossip consults
+  // GossipSubManager.getSubscribers. Empty roster keeps these
+  // tests focused on the gossip-signing path (no substrate
+  // fan-out competes for the encoded message bytes).
+  getSubscribers(_topic: string): string[] { return []; }
 }
 
 async function insertAgentGate(

--- a/packages/agent/test/swm-substrate-fanout-integration.test.ts
+++ b/packages/agent/test/swm-substrate-fanout-integration.test.ts
@@ -1,0 +1,273 @@
+/**
+ * rc.9 PR-C integration test for the substrate fan-out + tier-
+ * switch wiring INSIDE DKGAgent (the pure decision + executor
+ * logic is covered by `swm-substrate-fanout.test.ts`).
+ *
+ * The agent's `publishWorkspaceGossip` now consults the
+ * CGMemberEnumerator + the tier-switch + (conditionally) the
+ * substrate fan-out path. Each share goes through three
+ * conceptually independent surfaces:
+ *
+ *   1. Enumeration: which transport(s) we'll use
+ *   2. Substrate fan-out: per-(cgId, outcome) counters
+ *   3. Gossip publish: PR-A's loud-fail counter (already
+ *      regression-tested in `swm-gossip-publish-failure.test.ts`)
+ *
+ * The wire-format of `/api/slo` for #2 is regression-tested in
+ * `packages/cli/test/api-slo-route.test.ts`. What's left to pin
+ * is the AGENT-side wiring: that the tier decision actually
+ * flows to the substrate vs gossip path based on enumeration,
+ * and that the per-outcome counters update accordingly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent } from '../src/index.js';
+import type { ReliableSendResult } from '../src/p2p/messenger.js';
+
+const SELF_PEER = '12D3KooWSelfPubC';
+
+class CapturingGossip {
+  publishes: Array<{ topic: string; bytes: number }> = [];
+  /** Static roster returned by `getSubscribers` — adjust per-test. */
+  subscribers: string[] = [];
+
+  subscribe(_topic: string): void {}
+  unsubscribe(_topic: string): void {}
+  onMessage(_topic: string, _handler: (topic: string, data: Uint8Array, from?: string) => void | Promise<void>): void {}
+
+  async publish(topic: string, data: Uint8Array): Promise<void> {
+    this.publishes.push({ topic, bytes: data.byteLength });
+  }
+
+  getSubscribers(_topic: string): string[] {
+    return [...this.subscribers];
+  }
+}
+
+/**
+ * Narrow stub of Messenger.sendReliable. We don't exercise the
+ * envelope wrap / outbox path here — that's covered by the
+ * messenger's own tests; we just confirm the agent invokes
+ * sendReliable per-substrate-member and that the result is
+ * counted into the right per-outcome bucket.
+ *
+ * `DKGAgent.create()` does NOT initialise `this.messenger` — that
+ * happens inside `start()`, which we don't call in this test
+ * suite (it would require a real libp2p node). So we install a
+ * narrow stub object whose only contract is `sendReliable`; the
+ * substrate-fanout module is typed against `FanOutSubstrate`
+ * which has only that one method.
+ */
+function stubMessengerSendReliable(
+  results: Map<string, ReliableSendResult> | ((peerId: string) => ReliableSendResult | Error),
+): { calls: Array<{ peerId: string; protocolId: string; bytes: number }>; install: (agent: DKGAgent) => void } {
+  const calls: Array<{ peerId: string; protocolId: string; bytes: number }> = [];
+  const lookup = typeof results === 'function'
+    ? results
+    : (peerId: string): ReliableSendResult | Error => {
+      const r = results.get(peerId);
+      if (!r) return new Error(`stubMessengerSendReliable: no result configured for peerId=${peerId}`);
+      return r;
+    };
+  const install = (agent: DKGAgent): void => {
+    const stub = {
+      sendReliable: async (
+        peerId: string,
+        protocolId: string,
+        payload: Uint8Array,
+      ): Promise<ReliableSendResult> => {
+        calls.push({ peerId, protocolId, bytes: payload.byteLength });
+        const out = lookup(peerId);
+        if (out instanceof Error) throw out;
+        return out;
+      },
+    };
+    (agent as unknown as { messenger: typeof stub }).messenger = stub;
+  };
+  return { calls, install };
+}
+
+async function createAgent(name: string): Promise<DKGAgent> {
+  const agent = await DKGAgent.create({
+    name: `${name}-${Math.random().toString(36).slice(2)}`,
+    chainAdapter: new MockChainAdapter(),
+  });
+  // DKGNode.peerId is a getter that delegates into the live libp2p
+  // node; without `start()` it throws. Pin it to a deterministic
+  // string for the substrate-fanout self-exclusion check (the
+  // CGMemberEnumerator captures `selfPeerId: this.peerId` once at
+  // agent constructor time).
+  Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
+    value: SELF_PEER,
+    configurable: true,
+  });
+  return agent;
+}
+
+describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
+  it('reports zero substrate-fanout counters before any share', async () => {
+    const agent = await createAgent('SubstrateFanoutZero');
+    const stats = agent.getSwmSubstrateFanoutStats();
+
+    expect(stats).toEqual({
+      delivered: {},
+      queued: {},
+      inFlight: {},
+      failed: {},
+      overflow: { delivered: 0, queued: 0, inFlight: 0, failed: 0 },
+      truncated: false,
+    });
+  });
+
+  /**
+   * Public CG with no live subscribers + no allowlist =>
+   * `source: 'none'` => gossip-only path. No substrate sends,
+   * no per-outcome counters move, gossip publish fires exactly
+   * once. This is the PR-A pre-PR-C behavior (verifies PR-C
+   * didn't regress the gossip-only branch).
+   */
+  it('source=none takes gossip-only branch and does NOT call sendReliable', async () => {
+    const agent = await createAgent('SubstrateFanoutNone');
+    const gossip = new CapturingGossip();
+    gossip.subscribers = [];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+    const { calls, install } = stubMessengerSendReliable(new Map());
+    install(agent);
+
+    await agent.share('cg-no-roster', [{
+      subject: 'urn:test:none', predicate: 'http://schema.org/name', object: '"hi"', graph: '',
+    }]);
+
+    expect(gossip.publishes).toHaveLength(1);
+    expect(gossip.publishes[0]?.topic).toMatch(/shared-memory$/);
+    expect(calls).toEqual([]);
+    expect(agent.getSwmSubstrateFanoutStats()).toEqual({
+      delivered: {},
+      queued: {},
+      inFlight: {},
+      failed: {},
+      overflow: { delivered: 0, queued: 0, inFlight: 0, failed: 0 },
+      truncated: false,
+    });
+  });
+
+  /**
+   * Public CG with live subscribers <= cap (default 100) =>
+   * `source: 'topic-subscribers'` => substrate fan-out RUNS in
+   * parallel with gossip publish. Each substrate send is counted
+   * by outcome. `delivered` for the success, `queued` for the
+   * one that the messenger persisted for retry, `failed` for the
+   * synchronous-throw classification path.
+   */
+  it('source=topic-subscribers fans out via substrate AND publishes via gossip, counters reflect mixed outcomes', async () => {
+    const agent = await createAgent('SubstrateFanoutPublic');
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWPeerA', '12D3KooWPeerB', '12D3KooWPeerC'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { calls, install } = stubMessengerSendReliable((peerId): ReliableSendResult | Error => {
+      switch (peerId) {
+        case '12D3KooWPeerA':
+          return { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mA' };
+        case '12D3KooWPeerB':
+          return {
+            delivered: false, queued: true, attempts: 2, messageId: 'mB',
+            error: 'transient', nextAttemptAtMs: Date.now() + 1000,
+          };
+        case '12D3KooWPeerC':
+          return new Error('peerC connection refused');
+        default:
+          return new Error(`unexpected peerId=${peerId}`);
+      }
+    });
+    install(agent);
+
+    await agent.share('cg-public-mixed', [{
+      subject: 'urn:test:mixed', predicate: 'http://schema.org/name', object: '"mixed"', graph: '',
+    }]);
+
+    // Gossip publish should have fired exactly once for the topic.
+    expect(gossip.publishes).toHaveLength(1);
+    expect(gossip.publishes[0]?.topic).toMatch(/shared-memory$/);
+
+    // Substrate fan-out should have hit all three subscribers
+    // (self is excluded by the enumerator, and self isn't in
+    // this fixture's subscriber list anyway).
+    expect(calls).toHaveLength(3);
+    expect(calls.every(c => c.protocolId === '/dkg/10.0.1/swm-update')).toBe(true);
+    // All three sends carry the same wire bytes as the gossip
+    // publish — same `encodeWorkspaceGossipMessage` output.
+    expect(calls.every(c => c.bytes === gossip.publishes[0]?.bytes)).toBe(true);
+
+    const stats = agent.getSwmSubstrateFanoutStats();
+    expect(stats.delivered).toEqual({ 'cg-public-mixed': 1 });
+    expect(stats.queued).toEqual({ 'cg-public-mixed': 1 });
+    expect(stats.inFlight).toEqual({});
+    expect(stats.failed).toEqual({ 'cg-public-mixed': 1 });
+    expect(stats.overflow).toEqual({ delivered: 0, queued: 0, inFlight: 0, failed: 0 });
+    expect(stats.truncated).toBe(false);
+  });
+
+  /**
+   * Self should be excluded from the substrate fan-out roster.
+   * If our own peerId appears in the GossipSub subscribers list
+   * (which it does after we subscribe to our own CG), substrate
+   * fan-out MUST skip it — we already applied the share locally
+   * in the caller, and sending it to ourselves over the
+   * messenger would be wasted work + a redundantApplies bump.
+   */
+  it('excludes self from substrate fan-out even when self is a topic subscriber', async () => {
+    const agent = await createAgent('SubstrateFanoutSelfExclude');
+    const gossip = new CapturingGossip();
+    // CGMemberEnumerator filters self out via the `selfPeerId` dep,
+    // which is wired to `this.peerId` (set above to SELF_PEER).
+    gossip.subscribers = [SELF_PEER, '12D3KooWPeerOther'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { calls, install } = stubMessengerSendReliable(new Map([
+      ['12D3KooWPeerOther', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mO' }],
+    ]));
+    install(agent);
+
+    await agent.share('cg-self-exclude', [{
+      subject: 'urn:test:se', predicate: 'http://schema.org/name', object: '"self"', graph: '',
+    }]);
+
+    expect(calls.map(c => c.peerId)).toEqual(['12D3KooWPeerOther']);
+    expect(agent.getSwmSubstrateFanoutStats().delivered).toEqual({ 'cg-self-exclude': 1 });
+  });
+
+  /**
+   * Counters MUST isolate per cgId so operator-facing /api/slo
+   * shows which CGs are healthy vs which are dragging the
+   * delivery rate down.
+   */
+  it('per-cgId outcome counters are isolated across multiple shares to different CGs', async () => {
+    const agent = await createAgent('SubstrateFanoutIsolation');
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWPeerOnly'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { install } = stubMessengerSendReliable(new Map([
+      ['12D3KooWPeerOnly', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mOK' }],
+    ]));
+    install(agent);
+
+    await agent.share('cg-iso-1', [{
+      subject: 'urn:test:i1', predicate: 'http://schema.org/name', object: '"a"', graph: '',
+    }]);
+    await agent.share('cg-iso-2', [{
+      subject: 'urn:test:i2', predicate: 'http://schema.org/name', object: '"b"', graph: '',
+    }]);
+    await agent.share('cg-iso-1', [{
+      subject: 'urn:test:i1b', predicate: 'http://schema.org/name', object: '"c"', graph: '',
+    }]);
+
+    const stats = agent.getSwmSubstrateFanoutStats();
+    expect(stats.delivered).toEqual({
+      'cg-iso-1': 2,
+      'cg-iso-2': 1,
+    });
+  });
+});

--- a/packages/agent/test/swm-substrate-fanout-integration.test.ts
+++ b/packages/agent/test/swm-substrate-fanout-integration.test.ts
@@ -96,8 +96,10 @@ async function createAgent(name: string): Promise<DKGAgent> {
   // DKGNode.peerId is a getter that delegates into the live libp2p
   // node; without `start()` it throws. Pin it to a deterministic
   // string for the substrate-fanout self-exclusion check (the
-  // CGMemberEnumerator captures `selfPeerId: this.peerId` once at
-  // agent constructor time).
+  // CGMemberEnumerator reads `this.peerId` lazily on each resolve
+  // via the `getSelfPeerId` thunk — PR-C codex R8). Most tests rely
+  // on this stub; the dedicated R8 test below removes it to verify
+  // the pre-start `share()` contract.
   Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
     value: SELF_PEER,
     configurable: true,
@@ -222,8 +224,9 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
   it('excludes self from substrate fan-out even when self is a topic subscriber', async () => {
     const agent = await createAgent('SubstrateFanoutSelfExclude');
     const gossip = new CapturingGossip();
-    // CGMemberEnumerator filters self out via the `selfPeerId` dep,
-    // which is wired to `this.peerId` (set above to SELF_PEER).
+    // CGMemberEnumerator filters self out via the `getSelfPeerId`
+    // thunk, which is wired to `() => this.peerId` (set above to
+    // SELF_PEER).
     gossip.subscribers = [SELF_PEER, '12D3KooWPeerOther'];
     (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
 

--- a/packages/agent/test/swm-substrate-fanout-integration.test.ts
+++ b/packages/agent/test/swm-substrate-fanout-integration.test.ts
@@ -391,4 +391,84 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
       'cg-iso-2': 1,
     });
   });
+
+  /**
+   * PR-C codex R3 regression: the substrate receiver
+   * (`handleSwmUpdate`) MUST map `SharedMemoryHandler.handle()`
+   * outcomes to substrate responses so the sender's
+   * `sendReliable` reports realistic delivery semantics:
+   *
+   *   - `applied: true`                          → ACK (empty
+   *      Uint8Array), sender records delivered.
+   *   - `applied: false, retryable: false`       → ACK (empty
+   *      Uint8Array), sender drops the share. Matches the
+   *      pre-PR-C gossip behaviour for permanent rejections
+   *      (bad signature, peer not in allowlist, CAS-not-met).
+   *   - `applied: false, retryable: true`        → THROW, so
+   *      sendReliable reports failure and the substrate
+   *      outbox keeps the share queued for retry. Dominant
+   *      production case: sender key package for the epoch
+   *      hasn't arrived yet.
+   *
+   * We exercise the private `handleSwmUpdate` method directly
+   * by stubbing `getOrCreateSharedMemoryHandler` to return a
+   * handler whose `handle()` we control per test case. This
+   * pins the response-mapping contract without spinning up a
+   * real Messenger registration.
+   */
+  describe('codex R3: substrate receiver maps handle() outcomes to substrate responses', () => {
+    function installStubHandler(
+      agent: DKGAgent,
+      handle: (data: Uint8Array, peerId: string) => Promise<
+        | { applied: true }
+        | { applied: false; reason: string; retryable: boolean }
+      >,
+    ): void {
+      const stubHandler = { handle };
+      (agent as unknown as {
+        getOrCreateSharedMemoryHandler(): { handle: typeof handle };
+      }).getOrCreateSharedMemoryHandler = () => stubHandler;
+    }
+
+    function invokeReceiver(agent: DKGAgent, data: Uint8Array, peerId: string): Promise<Uint8Array> {
+      return (agent as unknown as {
+        handleSwmUpdate(data: Uint8Array, peerId: string): Promise<Uint8Array>;
+      }).handleSwmUpdate(data, peerId);
+    }
+
+    it('applied: true → empty Uint8Array ACK', async () => {
+      const agent = await createAgent('R3Receiver-Applied');
+      installStubHandler(agent, async () => ({ applied: true }));
+
+      const response = await invokeReceiver(agent, new Uint8Array([1, 2, 3]), '12D3KooWPeerR3a');
+      expect(response).toBeInstanceOf(Uint8Array);
+      expect(response.byteLength).toBe(0);
+    });
+
+    it('permanent rejection (retryable: false) → empty Uint8Array ACK (drop semantics, matches gossip)', async () => {
+      const agent = await createAgent('R3Receiver-Permanent');
+      installStubHandler(agent, async () => ({
+        applied: false,
+        reason: 'peer "12D3KooWPeerR3b" not in allowlist',
+        retryable: false,
+      }));
+
+      const response = await invokeReceiver(agent, new Uint8Array([4, 5, 6]), '12D3KooWPeerR3b');
+      expect(response).toBeInstanceOf(Uint8Array);
+      expect(response.byteLength).toBe(0);
+    });
+
+    it('retryable rejection (retryable: true) → THROWS so substrate outbox keeps the share queued', async () => {
+      const agent = await createAgent('R3Receiver-Retryable');
+      installStubHandler(agent, async () => ({
+        applied: false,
+        reason: 'simulated decryptor throw: sender key package for epoch 42 not yet arrived',
+        retryable: true,
+      }));
+
+      await expect(
+        invokeReceiver(agent, new Uint8Array([7, 8, 9]), '12D3KooWPeerR3c'),
+      ).rejects.toThrow(/transient rejection from 12D3KooWPeerR3c.*epoch 42/);
+    });
+  });
 });

--- a/packages/agent/test/swm-substrate-fanout-integration.test.ts
+++ b/packages/agent/test/swm-substrate-fanout-integration.test.ts
@@ -112,10 +112,11 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
 
     expect(stats).toEqual({
       delivered: {},
+      rejected: {},
       queued: {},
       inFlight: {},
       failed: {},
-      overflow: { delivered: 0, queued: 0, inFlight: 0, failed: 0 },
+      overflow: { delivered: 0, rejected: 0, queued: 0, inFlight: 0, failed: 0 },
       truncated: false,
     });
   });
@@ -144,10 +145,11 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
     expect(calls).toEqual([]);
     expect(agent.getSwmSubstrateFanoutStats()).toEqual({
       delivered: {},
+      rejected: {},
       queued: {},
       inFlight: {},
       failed: {},
-      overflow: { delivered: 0, queued: 0, inFlight: 0, failed: 0 },
+      overflow: { delivered: 0, rejected: 0, queued: 0, inFlight: 0, failed: 0 },
       truncated: false,
     });
   });
@@ -205,7 +207,7 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
     expect(stats.queued).toEqual({ 'cg-public-mixed': 1 });
     expect(stats.inFlight).toEqual({});
     expect(stats.failed).toEqual({ 'cg-public-mixed': 1 });
-    expect(stats.overflow).toEqual({ delivered: 0, queued: 0, inFlight: 0, failed: 0 });
+    expect(stats.overflow).toEqual({ delivered: 0, rejected: 0, queued: 0, inFlight: 0, failed: 0 });
     expect(stats.truncated).toBe(false);
   });
 
@@ -351,10 +353,11 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
     expect(calls).toEqual([]);
     expect(agent.getSwmSubstrateFanoutStats()).toEqual({
       delivered: {},
+      rejected: {},
       queued: {},
       inFlight: {},
       failed: {},
-      overflow: { delivered: 0, queued: 0, inFlight: 0, failed: 0 },
+      overflow: { delivered: 0, rejected: 0, queued: 0, inFlight: 0, failed: 0 },
       truncated: false,
     });
   });
@@ -445,7 +448,14 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
       expect(response.byteLength).toBe(0);
     });
 
-    it('permanent rejection (retryable: false) → empty Uint8Array ACK (drop semantics, matches gossip)', async () => {
+    it('permanent rejection (retryable: false) → FANOUT_RESPONSE_REJECTED sentinel (codex R6: distinguishable from delivered)', async () => {
+      // Codex R6: returning an empty Uint8Array on permanent
+      // rejection let the sender count it as `delivered` even
+      // though the receiver explicitly dropped the share. The
+      // 1-byte sentinel `0x01` lets `classifySendResult` bucket
+      // it as `rejected` instead, so /api/slo's
+      // `swm.substrateFanout.delivered` only counts shares the
+      // receiver actually applied.
       const agent = await createAgent('R3Receiver-Permanent');
       installStubHandler(agent, async () => ({
         applied: false,
@@ -455,7 +465,8 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
 
       const response = await invokeReceiver(agent, new Uint8Array([4, 5, 6]), '12D3KooWPeerR3b');
       expect(response).toBeInstanceOf(Uint8Array);
-      expect(response.byteLength).toBe(0);
+      expect(response.byteLength).toBe(1);
+      expect(response[0]).toBe(0x01);
     });
 
     it('retryable rejection (retryable: true) → THROWS so substrate outbox keeps the share queued', async () => {
@@ -470,5 +481,38 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
         invokeReceiver(agent, new Uint8Array([7, 8, 9]), '12D3KooWPeerR3c'),
       ).rejects.toThrow(/transient rejection from 12D3KooWPeerR3c.*epoch 42/);
     });
+  });
+
+  /**
+   * PR-C codex R6 end-to-end: the substrate's per-(cgId,
+   * outcome) counter MUST distinguish `delivered` from
+   * `rejected`. We stub the messenger so one peer's
+   * sendReliable returns the rejection sentinel and another
+   * returns an empty (applied) response, and verify the
+   * counters split correctly. This pins the receiver →
+   * classifier → bookkeeper → getSwmSubstrateFanoutStats
+   * pipeline that /api/slo reads.
+   */
+  it('codex R6 end-to-end: rejection sentinel response moves counter from delivered to rejected', async () => {
+    const agent = await createAgent('SubstrateFanoutRejected');
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWApplied', '12D3KooWRejected'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { install } = stubMessengerSendReliable(new Map([
+      ['12D3KooWApplied', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'm-applied' }],
+      ['12D3KooWRejected', { delivered: true, response: new Uint8Array([0x01]), attempts: 1, messageId: 'm-rejected' }],
+    ]));
+    install(agent);
+
+    await agent.share('cg-r6-mixed', [{
+      subject: 'urn:test:r6', predicate: 'http://schema.org/name', object: '"split"', graph: '',
+    }]);
+
+    const stats = agent.getSwmSubstrateFanoutStats();
+    expect(stats.delivered).toEqual({ 'cg-r6-mixed': 1 });
+    expect(stats.rejected).toEqual({ 'cg-r6-mixed': 1 });
+    expect(stats.queued).toEqual({});
+    expect(stats.failed).toEqual({});
   });
 });

--- a/packages/agent/test/swm-substrate-fanout-integration.test.ts
+++ b/packages/agent/test/swm-substrate-fanout-integration.test.ts
@@ -239,6 +239,127 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
   });
 
   /**
+   * PR-C codex R2 regression: curated CGs MUST publish via gossip
+   * in addition to substrate fan-out, as a cross-version safety
+   * net for rolling rc.8 → rc.9 upgrades. If we ever silently
+   * regress to substrate-only here, any allowlisted peer still
+   * on rc.8 (no `/dkg/10.0.1/swm-update` handler) would
+   * permanently stop receiving SWM updates from this node.
+   *
+   * Pure policy is regressed in `swm-substrate-fanout.test.ts`;
+   * this integration test additionally pins the WIRE behaviour
+   * through the agent — both `gossip.publish` AND
+   * `messenger.sendReliable` fire for every allowlist-source
+   * share, with per-cgId counters reflecting the substrate leg.
+   */
+  it('codex R2: curated CG fans out via substrate AND publishes via gossip', async () => {
+    const agent = await createAgent('SubstrateFanoutCuratedR2');
+    const gossip = new CapturingGossip();
+    // Curated enumerator returns 'allowlist' source — gossip
+    // subscriber view is irrelevant for the allowlist branch
+    // (we never call getSubscribers in that case).
+    gossip.subscribers = [];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { calls, install } = stubMessengerSendReliable(new Map([
+      ['12D3KooWAllowedA', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mA' }],
+      ['12D3KooWAllowedB', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mB' }],
+    ]));
+    install(agent);
+
+    // Inject a curated-source enumeration without setting up
+    // real allowlist triples — the integration target here is
+    // the tier-switch wiring, not the SPARQL plumbing (covered
+    // by enumerate-cg-members.test.ts).
+    const enumerator = (agent as unknown as {
+      getOrCreateCGMemberEnumerator(): { enumerate: (cg: string) => Promise<unknown> };
+    }).getOrCreateCGMemberEnumerator();
+    enumerator.enumerate = async () => ({
+      source: 'allowlist',
+      members: ['12D3KooWAllowedA', '12D3KooWAllowedB'],
+    });
+
+    await agent.share('cg-curated-r2', [{
+      subject: 'urn:test:r2', predicate: 'http://schema.org/name', object: '"curated"', graph: '',
+    }]);
+
+    // BOTH legs must have fired. Gossip publish once on the
+    // workspace topic; substrate sendReliable once per
+    // allowlisted peer.
+    expect(gossip.publishes).toHaveLength(1);
+    expect(gossip.publishes[0]?.topic).toMatch(/shared-memory$/);
+
+    expect(calls).toHaveLength(2);
+    expect(calls.map(c => c.peerId).sort()).toEqual(['12D3KooWAllowedA', '12D3KooWAllowedB']);
+    expect(calls.every(c => c.protocolId === '/dkg/10.0.1/swm-update')).toBe(true);
+
+    expect(agent.getSwmSubstrateFanoutStats().delivered).toEqual({ 'cg-curated-r2': 2 });
+  });
+
+  /**
+   * PR-C codex R1 regression: enumeration calls SPARQL through
+   * `this.store`. A triple-store query failure (worker timeout,
+   * transient backend hiccup, corrupt graph) MUST NOT reject
+   * `share()` after the local commit already succeeded. The
+   * agent wraps `enumerate()` + `chooseFanOutTier()` in a
+   * try/catch and falls back to gossip-only on throw (the
+   * pre-PR-C behaviour for this share).
+   *
+   * We trigger the throw by overriding `enumerate` on the lazy
+   * enumerator instance — that's the call site whose SPARQL
+   * helpers raise in production.
+   */
+  it('codex R1: enumeration throw falls back to gossip-only, share() succeeds, no substrate sends', async () => {
+    const agent = await createAgent('SubstrateFanoutPlanningThrow');
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWPeerWouldHaveGottenSubstrate'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    // Substrate stub: assert it's NEVER called on the throw path
+    // — the fallback plan is `useSubstrate: false`.
+    const { calls, install } = stubMessengerSendReliable(new Map());
+    install(agent);
+
+    // Force the lazy enumerator to throw on enumerate() — same
+    // shape `getContextGraphAllowedPeers()` would produce if
+    // `this.store.query()` raised.
+    const enumerator = (agent as unknown as {
+      getOrCreateCGMemberEnumerator(): { enumerate: (cg: string) => Promise<unknown> };
+    }).getOrCreateCGMemberEnumerator();
+    enumerator.enumerate = async () => {
+      throw new Error('simulated SPARQL worker timeout');
+    };
+
+    // share() MUST resolve cleanly — local commit already
+    // succeeded, transport plan fell back to gossip-only.
+    const result = await agent.share('cg-planning-throw', [{
+      subject: 'urn:test:planning-throw',
+      predicate: 'http://schema.org/name',
+      object: '"local commit must survive enumeration throw"',
+      graph: '',
+    }]);
+    expect(typeof result.shareOperationId).toBe('string');
+    expect(result.shareOperationId.length).toBeGreaterThan(0);
+
+    // Gossip publish DID run (the fallback plan keeps it on).
+    expect(gossip.publishes).toHaveLength(1);
+    expect(gossip.publishes[0]?.topic).toMatch(/shared-memory$/);
+
+    // Substrate fan-out did NOT run — fallback plan has
+    // useSubstrate: false, so no per-peer sends and no counter
+    // movement.
+    expect(calls).toEqual([]);
+    expect(agent.getSwmSubstrateFanoutStats()).toEqual({
+      delivered: {},
+      queued: {},
+      inFlight: {},
+      failed: {},
+      overflow: { delivered: 0, queued: 0, inFlight: 0, failed: 0 },
+      truncated: false,
+    });
+  });
+
+  /**
    * Counters MUST isolate per cgId so operator-facing /api/slo
    * shows which CGs are healthy vs which are dragging the
    * delivery rate down.

--- a/packages/agent/test/swm-substrate-fanout.test.ts
+++ b/packages/agent/test/swm-substrate-fanout.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect } from 'vitest';
+import {
+  chooseFanOutTier,
+  executeSubstrateFanOut,
+  type FanOutBookkeeper,
+  type FanOutPeerRecord,
+  type FanOutSubstrate,
+} from '../src/swm/substrate-fanout.js';
+import type { CGMemberEnumeration } from '../src/swm/enumerate-cg-members.js';
+import type { ReliableSendResult } from '../src/p2p/messenger.js';
+
+function makeBookkeeper(): { calls: Array<{ cgId: string; record: FanOutPeerRecord }>; bk: FanOutBookkeeper } {
+  const calls: Array<{ cgId: string; record: FanOutPeerRecord }> = [];
+  return {
+    calls,
+    bk: {
+      recordOutcome(cgId, record) { calls.push({ cgId, record }); },
+    },
+  };
+}
+
+function enumeration(source: CGMemberEnumeration['source'], members: string[]): CGMemberEnumeration {
+  return { source, members };
+}
+
+describe('chooseFanOutTier', () => {
+  /**
+   * Curated CGs are the headline win for substrate fan-out:
+   * authoritative roster, every member is by definition allowed
+   * to receive the share, so substrate-only is both reliable
+   * (point-to-point ack within the messenger SLO) AND saves the
+   * gossip wire load. We deliberately do NOT truncate curated
+   * CGs even when they exceed `maxSubstrateMembers` — see the
+   * `chooseFanOutTier` jsdoc for why dropping substrate targets
+   * silently regresses curated reliability.
+   */
+  describe('curated CG (source = allowlist)', () => {
+    it('substrate-only for any curated CG, even at or above the threshold', () => {
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('allowlist', ['peerA', 'peerB', 'peerC']),
+        maxSubstrateMembers: 100,
+      });
+
+      expect(plan.useSubstrate).toBe(true);
+      expect(plan.useGossip).toBe(false);
+      expect(plan.substrateMembers).toEqual(['peerA', 'peerB', 'peerC']);
+      expect(plan.enumerationSource).toBe('allowlist');
+      expect(plan.enumeratedCount).toBe(3);
+    });
+
+    it('does NOT truncate curated members above the threshold', () => {
+      const members = Array.from({ length: 250 }, (_, i) => `peer${i}`);
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('allowlist', members),
+        maxSubstrateMembers: 100,
+      });
+
+      expect(plan.useSubstrate).toBe(true);
+      expect(plan.useGossip).toBe(false);
+      expect(plan.substrateMembers).toEqual(members);
+      expect(plan.enumeratedCount).toBe(250);
+    });
+
+    it('handles the curated-with-empty-allowlist edge case (curator kicked everyone)', () => {
+      // CGMemberEnumerator returns `{ source: 'allowlist', members: [] }`
+      // for a curated CG with an explicitly empty allowlist (NOT to be
+      // re-admitted via gossip subscribers). Substrate fan-out has
+      // nobody to send to; gossip remains OFF. Caller's local apply
+      // already happened; nothing more to do.
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('allowlist', []),
+        maxSubstrateMembers: 100,
+      });
+
+      expect(plan.useSubstrate).toBe(true);
+      expect(plan.useGossip).toBe(false);
+      expect(plan.substrateMembers).toEqual([]);
+    });
+  });
+
+  /**
+   * Public CGs use the gossip topic as the canonical transport
+   * (catches latecomer subscribers we don't see yet), with
+   * substrate as a top-up for the known subscriber set when small
+   * enough to be affordable.
+   */
+  describe('public CG (source = topic-subscribers)', () => {
+    it('substrate + gossip for public CG at or below the threshold', () => {
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('topic-subscribers', ['peerA', 'peerB']),
+        maxSubstrateMembers: 100,
+      });
+
+      expect(plan.useSubstrate).toBe(true);
+      expect(plan.useGossip).toBe(true);
+      expect(plan.substrateMembers).toEqual(['peerA', 'peerB']);
+      expect(plan.enumerationSource).toBe('topic-subscribers');
+      expect(plan.enumeratedCount).toBe(2);
+    });
+
+    it('substrate + gossip exactly AT the threshold (boundary)', () => {
+      const members = Array.from({ length: 100 }, (_, i) => `peer${i}`);
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('topic-subscribers', members),
+        maxSubstrateMembers: 100,
+      });
+
+      expect(plan.useSubstrate).toBe(true);
+      expect(plan.substrateMembers).toEqual(members);
+    });
+
+    it('gossip-only for public CG above the threshold', () => {
+      const members = Array.from({ length: 101 }, (_, i) => `peer${i}`);
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('topic-subscribers', members),
+        maxSubstrateMembers: 100,
+      });
+
+      expect(plan.useSubstrate).toBe(false);
+      expect(plan.useGossip).toBe(true);
+      expect(plan.substrateMembers).toEqual([]);
+      // `enumeratedCount` preserves the pre-truncation count so
+      // the caller's WARN log can show "gossip-only because
+      // 101 > 100".
+      expect(plan.enumeratedCount).toBe(101);
+    });
+  });
+
+  /**
+   * `none` covers two distinct semantic cases collapsed into the
+   * same wire behaviour (gossip-only): legacy/bootstrap CGs with
+   * no live subscribers yet, AND agent-gated private CGs without
+   * an enumerable peer allowlist (which fail closed in
+   * CGMemberEnumerator, see enumerate-cg-members.ts bug fix #1).
+   * Both end up here for the same reason — we have no roster to
+   * substrate-fan-out to. Gossip is safe in both: receiver-side
+   * auth gate (`isPrivateContextGraph`) drops payloads at the
+   * apply layer for private CGs, and the SWM payload is encrypted
+   * with the per-CG key anyway.
+   */
+  describe('legacy / agent-gated CG (source = none)', () => {
+    it('gossip-only with empty substrate set', () => {
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('none', []),
+        maxSubstrateMembers: 100,
+      });
+
+      expect(plan.useSubstrate).toBe(false);
+      expect(plan.useGossip).toBe(true);
+      expect(plan.substrateMembers).toEqual([]);
+      expect(plan.enumeratedCount).toBe(0);
+    });
+  });
+});
+
+describe('executeSubstrateFanOut', () => {
+  const PROTOCOL = '/dkg/10.0.1/swm-update';
+
+  function fakeSubstrate(per: (peerId: string) => ReliableSendResult | Error): FanOutSubstrate {
+    return {
+      async sendReliable(peerId: string) {
+        const out = per(peerId);
+        if (out instanceof Error) throw out;
+        return out;
+      },
+    };
+  }
+
+  it('returns zero counts and skips the bookkeeper when members is empty', async () => {
+    const { calls, bk } = makeBookkeeper();
+    const result = await executeSubstrateFanOut({
+      contextGraphId: 'cg-empty',
+      protocolId: PROTOCOL,
+      payload: new Uint8Array([1]),
+      members: [],
+      sendTimeoutMs: 5000,
+      substrate: fakeSubstrate(() => ({ delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mid' })),
+      bookkeeper: bk,
+    });
+
+    expect(result).toEqual({ attempted: 0, delivered: 0, queued: 0, inFlight: 0, failed: 0 });
+    expect(calls).toEqual([]);
+  });
+
+  it('classifies delivered / queued / inFlight / failed across a mixed fan-out', async () => {
+    const { calls, bk } = makeBookkeeper();
+    const result = await executeSubstrateFanOut({
+      contextGraphId: 'cg-mixed',
+      protocolId: PROTOCOL,
+      payload: new Uint8Array([1, 2, 3]),
+      members: ['peerOK', 'peerQueued', 'peerInFlight', 'peerSyncThrow', 'peerHardFail'],
+      sendTimeoutMs: 5000,
+      substrate: fakeSubstrate((peerId): ReliableSendResult | Error => {
+        switch (peerId) {
+          case 'peerOK':
+            return { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'm-ok' };
+          case 'peerQueued':
+            return {
+              delivered: false,
+              queued: true,
+              attempts: 2,
+              messageId: 'm-q',
+              error: 'transient backoff',
+              nextAttemptAtMs: 12345,
+            };
+          case 'peerInFlight':
+            return {
+              delivered: false,
+              queued: false,
+              inFlight: true,
+              attempts: 0,
+              messageId: 'm-if',
+              error: 'already in flight',
+            };
+          case 'peerSyncThrow':
+            return new Error('invalid peerId format');
+          case 'peerHardFail':
+            // A future variant of ReliableSendResult would also land
+            // in `failed` via the defensive classifier branch — but
+            // exercising the unrecoverable case via the
+            // `inFlight: false, queued: false` shape is impossible
+            // today because the union doesn't admit that combo.
+            // Synchronous throw is the production-shaped "failed".
+            return new Error('messenger gone');
+          default:
+            throw new Error('unreachable');
+        }
+      }),
+      bookkeeper: bk,
+    });
+
+    expect(result.attempted).toBe(5);
+    expect(result.delivered).toBe(1);
+    expect(result.queued).toBe(1);
+    expect(result.inFlight).toBe(1);
+    expect(result.failed).toBe(2);
+
+    expect(calls).toHaveLength(5);
+    const byPeer = new Map(calls.map(c => [c.record.peerId, c.record]));
+    expect(byPeer.get('peerOK')).toEqual({
+      peerId: 'peerOK', outcome: 'delivered', attempts: 1, messageId: 'm-ok', error: '',
+    });
+    expect(byPeer.get('peerQueued')).toEqual({
+      peerId: 'peerQueued', outcome: 'queued', attempts: 2, messageId: 'm-q', error: 'transient backoff',
+    });
+    expect(byPeer.get('peerInFlight')).toEqual({
+      peerId: 'peerInFlight', outcome: 'inFlight', attempts: 0, messageId: 'm-if', error: 'already in flight',
+    });
+    expect(byPeer.get('peerSyncThrow')).toEqual({
+      peerId: 'peerSyncThrow', outcome: 'failed', attempts: 0, messageId: '', error: 'invalid peerId format',
+    });
+    expect(byPeer.get('peerHardFail')).toEqual({
+      peerId: 'peerHardFail', outcome: 'failed', attempts: 0, messageId: '', error: 'messenger gone',
+    });
+
+    // Every record was associated with the right cgId.
+    expect(calls.every(c => c.cgId === 'cg-mixed')).toBe(true);
+  });
+
+  /**
+   * A synchronous throw from sendReliable for one peer MUST NOT
+   * abort the fan-out — the other peers must still get their
+   * sends. This is what `Promise.allSettled` buys us over
+   * `Promise.all` (see substrate-fanout.ts jsdoc), and the
+   * try/catch inside the per-peer task makes it explicit.
+   */
+  it('one peer throwing synchronously does not abort the rest', async () => {
+    const { calls, bk } = makeBookkeeper();
+    const result = await executeSubstrateFanOut({
+      contextGraphId: 'cg-isolation',
+      protocolId: PROTOCOL,
+      payload: new Uint8Array([9]),
+      members: ['ok1', 'boom', 'ok2', 'ok3'],
+      sendTimeoutMs: 5000,
+      substrate: fakeSubstrate((peerId): ReliableSendResult | Error => {
+        if (peerId === 'boom') return new Error('intentional');
+        return { delivered: true, response: new Uint8Array(), attempts: 1, messageId: `m-${peerId}` };
+      }),
+      bookkeeper: bk,
+    });
+
+    expect(result).toEqual({ attempted: 4, delivered: 3, queued: 0, inFlight: 0, failed: 1 });
+    expect(calls).toHaveLength(4);
+  });
+
+  /**
+   * Sends MUST run in parallel — sequential execution would
+   * pay (sum of per-peer latencies) wall-clock and tail-latency
+   * the entire share through the slowest single peer. We assert
+   * this by stalling each send on a manually-resolved promise
+   * for ~20ms and verifying the total wall-clock is closer to
+   * one stall than to N stalls.
+   *
+   * Uses a small absolute budget (rather than fake timers) so
+   * this also exercises the real Promise.allSettled scheduling.
+   */
+  it('fires sends in PARALLEL, not sequentially', async () => {
+    const { bk } = makeBookkeeper();
+    const PER_PEER_STALL_MS = 20;
+    const MEMBERS = 8;
+
+    const t0 = Date.now();
+    const result = await executeSubstrateFanOut({
+      contextGraphId: 'cg-parallel',
+      protocolId: PROTOCOL,
+      payload: new Uint8Array([0]),
+      members: Array.from({ length: MEMBERS }, (_, i) => `peer${i}`),
+      sendTimeoutMs: 5000,
+      substrate: {
+        async sendReliable(peerId): Promise<ReliableSendResult> {
+          await new Promise<void>((res) => setTimeout(res, PER_PEER_STALL_MS));
+          return { delivered: true, response: new Uint8Array(), attempts: 1, messageId: `m-${peerId}` };
+        },
+      },
+      bookkeeper: bk,
+    });
+    const elapsed = Date.now() - t0;
+
+    expect(result.delivered).toBe(MEMBERS);
+    // Sequential would be ~MEMBERS * PER_PEER_STALL_MS = ~160ms.
+    // Parallel should be ~PER_PEER_STALL_MS = ~20ms. Loose bound
+    // (3x the per-peer stall) to avoid CI flakes from scheduler
+    // jitter on heavily loaded runners; still leaves plenty of
+    // margin to detect a regression to sequential execution.
+    expect(elapsed).toBeLessThan(PER_PEER_STALL_MS * 3);
+    expect(elapsed).toBeLessThan(MEMBERS * PER_PEER_STALL_MS / 2);
+  });
+});

--- a/packages/agent/test/swm-substrate-fanout.test.ts
+++ b/packages/agent/test/swm-substrate-fanout.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   chooseFanOutTier,
   executeSubstrateFanOut,
+  FANOUT_RESPONSE_REJECTED,
   type FanOutBookkeeper,
   type FanOutPeerRecord,
   type FanOutSubstrate,
@@ -188,7 +189,7 @@ describe('executeSubstrateFanOut', () => {
       bookkeeper: bk,
     });
 
-    expect(result).toEqual({ attempted: 0, delivered: 0, queued: 0, inFlight: 0, failed: 0 });
+    expect(result).toEqual({ attempted: 0, delivered: 0, rejected: 0, queued: 0, inFlight: 0, failed: 0 });
     expect(calls).toEqual([]);
   });
 
@@ -289,8 +290,55 @@ describe('executeSubstrateFanOut', () => {
       bookkeeper: bk,
     });
 
-    expect(result).toEqual({ attempted: 4, delivered: 3, queued: 0, inFlight: 0, failed: 1 });
+    expect(result).toEqual({ attempted: 4, delivered: 3, rejected: 0, queued: 0, inFlight: 0, failed: 1 });
     expect(calls).toHaveLength(4);
+  });
+
+  /**
+   * PR-C codex R6: the receiver signals a permanent rejection
+   * (peer not in allowlist, bad signature, validation failure)
+   * by returning the {@link FANOUT_RESPONSE_REJECTED} sentinel
+   * (`Uint8Array([0x01])`). `classifySendResult` MUST recognise
+   * this and bucket the outcome as `rejected`, NOT `delivered`
+   * — otherwise `/api/slo` overstates end-to-end success.
+   *
+   * Forward-compatible: any other response shape (empty or
+   * future PR-D `SwmShareAck` payloads) continues to classify
+   * as `delivered`.
+   */
+  it('rejection sentinel response classifies as rejected, not delivered (codex R6)', async () => {
+    const { calls, bk } = makeBookkeeper();
+    const result = await executeSubstrateFanOut({
+      contextGraphId: 'cg-rejected',
+      protocolId: PROTOCOL,
+      payload: new Uint8Array([1]),
+      members: ['peerApplied', 'peerRejected', 'peerLongResponse'],
+      sendTimeoutMs: 5000,
+      substrate: fakeSubstrate((peerId): ReliableSendResult => {
+        switch (peerId) {
+          case 'peerApplied':
+            return { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'm-ok' };
+          case 'peerRejected':
+            return { delivered: true, response: FANOUT_RESPONSE_REJECTED, attempts: 1, messageId: 'm-rej' };
+          case 'peerLongResponse':
+            return { delivered: true, response: new Uint8Array([0x01, 0x02]), attempts: 1, messageId: 'm-future' };
+          default:
+            throw new Error('unreachable');
+        }
+      }),
+      bookkeeper: bk,
+    });
+
+    expect(result.attempted).toBe(3);
+    expect(result.delivered).toBe(2);
+    expect(result.rejected).toBe(1);
+    expect(result.queued).toBe(0);
+    expect(result.failed).toBe(0);
+
+    const byPeer = new Map(calls.map(c => [c.record.peerId, c.record]));
+    expect(byPeer.get('peerApplied')?.outcome).toBe('delivered');
+    expect(byPeer.get('peerRejected')?.outcome).toBe('rejected');
+    expect(byPeer.get('peerLongResponse')?.outcome).toBe('delivered');
   });
 
   /**

--- a/packages/agent/test/swm-substrate-fanout.test.ts
+++ b/packages/agent/test/swm-substrate-fanout.test.ts
@@ -25,24 +25,31 @@ function enumeration(source: CGMemberEnumeration['source'], members: string[]): 
 
 describe('chooseFanOutTier', () => {
   /**
-   * Curated CGs are the headline win for substrate fan-out:
-   * authoritative roster, every member is by definition allowed
-   * to receive the share, so substrate-only is both reliable
-   * (point-to-point ack within the messenger SLO) AND saves the
-   * gossip wire load. We deliberately do NOT truncate curated
-   * CGs even when they exceed `maxSubstrateMembers` — see the
-   * `chooseFanOutTier` jsdoc for why dropping substrate targets
-   * silently regresses curated reliability.
+   * Curated CGs get substrate fan-out for per-known-peer
+   * reliability AND gossip as a cross-version safety net (PR-C
+   * codex R2 fix): during a rolling rc.8 → rc.9 upgrade some
+   * allowlisted peers may not yet support
+   * `/dkg/10.0.1/swm-update`. Substrate-only delivery would
+   * silently hit libp2p protocol-negotiation errors and the
+   * non-upgraded peer would stop receiving SWM updates entirely
+   * until it upgraded. Gossip keeps the delivery path open in the
+   * meantime; receiver-side dedup absorbs the double-arrival
+   * cleanly. PR-D will use ACK feedback to opportunistically
+   * suppress gossip for peers confirmed to support substrate. We
+   * still do NOT truncate curated CGs even when they exceed
+   * `maxSubstrateMembers` — see `chooseFanOutTier` jsdoc for why
+   * dropping substrate targets silently regresses curated
+   * reliability.
    */
   describe('curated CG (source = allowlist)', () => {
-    it('substrate-only for any curated CG, even at or above the threshold', () => {
+    it('substrate + gossip for any curated CG (cross-version safety net, codex R2)', () => {
       const plan = chooseFanOutTier({
         enumeration: enumeration('allowlist', ['peerA', 'peerB', 'peerC']),
         maxSubstrateMembers: 100,
       });
 
       expect(plan.useSubstrate).toBe(true);
-      expect(plan.useGossip).toBe(false);
+      expect(plan.useGossip).toBe(true);
       expect(plan.substrateMembers).toEqual(['peerA', 'peerB', 'peerC']);
       expect(plan.enumerationSource).toBe('allowlist');
       expect(plan.enumeratedCount).toBe(3);
@@ -56,24 +63,27 @@ describe('chooseFanOutTier', () => {
       });
 
       expect(plan.useSubstrate).toBe(true);
-      expect(plan.useGossip).toBe(false);
+      expect(plan.useGossip).toBe(true);
       expect(plan.substrateMembers).toEqual(members);
       expect(plan.enumeratedCount).toBe(250);
     });
 
     it('handles the curated-with-empty-allowlist edge case (curator kicked everyone)', () => {
       // CGMemberEnumerator returns `{ source: 'allowlist', members: [] }`
-      // for a curated CG with an explicitly empty allowlist (NOT to be
-      // re-admitted via gossip subscribers). Substrate fan-out has
-      // nobody to send to; gossip remains OFF. Caller's local apply
-      // already happened; nothing more to do.
+      // for a curated CG with an explicitly empty allowlist (no peer
+      // remains authorised). Substrate fan-out has nobody to send to;
+      // gossip still runs (cross-version safety net is unconditional
+      // for allowlist source) but with no remote peers in the
+      // subscriber set there is effectively nobody to receive it
+      // either — both legs are no-ops at the wire level. Caller's
+      // local apply already happened; nothing more to do.
       const plan = chooseFanOutTier({
         enumeration: enumeration('allowlist', []),
         maxSubstrateMembers: 100,
       });
 
       expect(plan.useSubstrate).toBe(true);
-      expect(plan.useGossip).toBe(false);
+      expect(plan.useGossip).toBe(true);
       expect(plan.substrateMembers).toEqual([]);
     });
   });

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -976,6 +976,21 @@ export function buildSloPayload(agent: {
     redundantAppliesOverflow: number;
     redundantAppliesTruncated: boolean;
   };
+  /**
+   * rc.9 PR-C addition. Optional on the interface so a hypothetical
+   * test double that only exercises the gossip + receiver sides
+   * doesn't have to stub it. Implementations that omit it simply
+   * leave `swm.substrateFanout` off the response — soak scripts
+   * check for its presence before referencing fields.
+   */
+  getSwmSubstrateFanoutStats?: () => {
+    delivered: Record<string, number>;
+    queued: Record<string, number>;
+    inFlight: Record<string, number>;
+    failed: Record<string, number>;
+    overflow: { delivered: number; queued: number; inFlight: number; failed: number };
+    truncated: boolean;
+  };
 }): {
   protocols: Record<string, unknown>;
   gossip: {
@@ -988,11 +1003,29 @@ export function buildSloPayload(agent: {
     redundantAppliesLowerBound: boolean;
     redundantAppliesOverflow: number;
     redundantAppliesTruncated: boolean;
+    /**
+     * rc.9 PR-C: substrate fan-out per-outcome counters. Present
+     * iff the agent exposes `getSwmSubstrateFanoutStats()` (every
+     * production agent does; opt-out is for test doubles).
+     */
+    substrateFanout?: {
+      delivered: Record<string, number>;
+      queued: Record<string, number>;
+      inFlight: Record<string, number>;
+      failed: Record<string, number>;
+      overflow: { delivered: number; queued: number; inFlight: number; failed: number };
+      truncated: boolean;
+    };
   };
 } {
+  const swmHandler = agent.getSwmHandlerStats();
+  const substrateFanout = agent.getSwmSubstrateFanoutStats?.();
   return {
     protocols: agent.getMessengerSloStats(),
     gossip: agent.getSwmGossipStats(),
-    swm: agent.getSwmHandlerStats(),
+    swm: {
+      ...swmHandler,
+      ...(substrateFanout !== undefined ? { substrateFanout } : {}),
+    },
   };
 }

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -985,10 +985,11 @@ export function buildSloPayload(agent: {
    */
   getSwmSubstrateFanoutStats?: () => {
     delivered: Record<string, number>;
+    rejected: Record<string, number>;
     queued: Record<string, number>;
     inFlight: Record<string, number>;
     failed: Record<string, number>;
-    overflow: { delivered: number; queued: number; inFlight: number; failed: number };
+    overflow: { delivered: number; rejected: number; queued: number; inFlight: number; failed: number };
     truncated: boolean;
   };
 }): {
@@ -1010,10 +1011,11 @@ export function buildSloPayload(agent: {
      */
     substrateFanout?: {
       delivered: Record<string, number>;
+      rejected: Record<string, number>;
       queued: Record<string, number>;
       inFlight: Record<string, number>;
       failed: Record<string, number>;
-      overflow: { delivered: number; queued: number; inFlight: number; failed: number };
+      overflow: { delivered: number; rejected: number; queued: number; inFlight: number; failed: number };
       truncated: boolean;
     };
   };

--- a/packages/cli/test/api-slo-route.test.ts
+++ b/packages/cli/test/api-slo-route.test.ts
@@ -141,6 +141,87 @@ describe('/api/slo wire format (rc.9 PR-A / Codex PR #570 R10)', () => {
     });
   });
 
+  /**
+   * rc.9 PR-C wire-format regression: when the agent exposes
+   * `getSwmSubstrateFanoutStats()`, /api/slo MUST surface it under
+   * `swm.substrateFanout`. The interface marks the getter optional
+   * so test doubles can omit it; the agent's production
+   * implementation always provides it.
+   */
+  it('substrateFanout — when provided, nested under swm with all four outcome maps + overflow', async () => {
+    const agent: FakeAgent = {
+      getMessengerSloStats: () => ({}),
+      getSwmGossipStats: () => ({
+        publishFailures: {},
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      }),
+      getSwmHandlerStats: () => ({
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+      }),
+      getSwmSubstrateFanoutStats: () => ({
+        delivered: { 'did:dkg:context-graph:lex/curated': 47 },
+        queued: { 'did:dkg:context-graph:lex/curated': 2 },
+        inFlight: {},
+        failed: { 'did:dkg:context-graph:bigpublic': 1 },
+        overflow: { delivered: 12, queued: 3, inFlight: 0, failed: 5 },
+        truncated: true,
+      }),
+    };
+    ({ server, port } = await startSloServer(agent));
+
+    const { status, body } = await get(port, '/api/slo');
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      protocols: {},
+      gossip: {
+        publishFailures: {},
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      },
+      swm: {
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+        substrateFanout: {
+          delivered: { 'did:dkg:context-graph:lex/curated': 47 },
+          queued: { 'did:dkg:context-graph:lex/curated': 2 },
+          inFlight: {},
+          failed: { 'did:dkg:context-graph:bigpublic': 1 },
+          overflow: { delivered: 12, queued: 3, inFlight: 0, failed: 5 },
+          truncated: true,
+        },
+      },
+    });
+  });
+
+  it('substrateFanout — absent when the agent omits getSwmSubstrateFanoutStats (back-compat with PR-A-only doubles)', async () => {
+    const agent: FakeAgent = {
+      getMessengerSloStats: () => ({}),
+      getSwmGossipStats: () => ({
+        publishFailures: {},
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      }),
+      getSwmHandlerStats: () => ({
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+      }),
+    };
+    ({ server, port } = await startSloServer(agent));
+
+    const { status, body } = await get(port, '/api/slo');
+    expect(status).toBe(200);
+    // Stricter than toEqual w/ partial — assert the key is genuinely absent.
+    expect((body as { swm: Record<string, unknown> }).swm.substrateFanout).toBeUndefined();
+  });
+
   it('partial / mid-life payload — gossip populated, swm pristine', async () => {
     const agent: FakeAgent = {
       getMessengerSloStats: () => ({}),

--- a/packages/cli/test/api-slo-route.test.ts
+++ b/packages/cli/test/api-slo-route.test.ts
@@ -164,10 +164,11 @@ describe('/api/slo wire format (rc.9 PR-A / Codex PR #570 R10)', () => {
       }),
       getSwmSubstrateFanoutStats: () => ({
         delivered: { 'did:dkg:context-graph:lex/curated': 47 },
+        rejected: { 'did:dkg:context-graph:lex/curated': 4 },
         queued: { 'did:dkg:context-graph:lex/curated': 2 },
         inFlight: {},
         failed: { 'did:dkg:context-graph:bigpublic': 1 },
-        overflow: { delivered: 12, queued: 3, inFlight: 0, failed: 5 },
+        overflow: { delivered: 12, rejected: 2, queued: 3, inFlight: 0, failed: 5 },
         truncated: true,
       }),
     };
@@ -189,10 +190,11 @@ describe('/api/slo wire format (rc.9 PR-A / Codex PR #570 R10)', () => {
         redundantAppliesTruncated: false,
         substrateFanout: {
           delivered: { 'did:dkg:context-graph:lex/curated': 47 },
+          rejected: { 'did:dkg:context-graph:lex/curated': 4 },
           queued: { 'did:dkg:context-graph:lex/curated': 2 },
           inFlight: {},
           failed: { 'did:dkg:context-graph:bigpublic': 1 },
-          overflow: { delivered: 12, queued: 3, inFlight: 0, failed: 5 },
+          overflow: { delivered: 12, rejected: 2, queued: 3, inFlight: 0, failed: 5 },
           truncated: true,
         },
       },

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -48,6 +48,19 @@ export const PROTOCOL_QUERY_REMOTE = '/dkg/10.0.1/query-remote';
 // SWM sender-key send sites in dkg-agent.ts route through
 // messenger.sendReliable; handler registers via messenger.register.
 export const PROTOCOL_SWM_SENDER_KEY = '/dkg/10.0.1/swm-sender-key';
+// rc.9 PR-C (SWM reliable fan-out plan, Step 3): NEW protocol — no
+// rc.8 predecessor. Carries the same workspace-gossip wire bytes
+// (produced by `encodeWorkspaceGossipMessage`) point-to-point over
+// the reliable messenger substrate, as a deterministic alternative
+// to GossipSub's best-effort mesh. The receiver handler hands the
+// bytes directly to `SharedMemoryHandler.handle()` — same in-process
+// apply path that the gossip subscription drives, so dedup and
+// metrics behave identically. Activated by the tier-switch in
+// `publishWorkspaceGossip` for any CG whose `CGMemberEnumerator`
+// returns `source: 'allowlist'`, and as a top-up for public CGs at
+// or below `DKG_SWM_SUBSTRATE_MAX_MEMBERS`. See RFC-003 §6 for the
+// full transport policy.
+export const PROTOCOL_SWM_UPDATE = '/dkg/10.0.1/swm-update';
 
 // rc.9 PR-10: bumped from /dkg/10.0.0/join-request to opt into the
 // Universal Messenger substrate. The in-memory JoinApprovalRetryQueue

--- a/packages/core/test/v10-constants.test.ts
+++ b/packages/core/test/v10-constants.test.ts
@@ -8,6 +8,7 @@ import {
   PROTOCOL_ACCESS,
   PROTOCOL_QUERY_REMOTE,
   PROTOCOL_SWM_SENDER_KEY,
+  PROTOCOL_SWM_UPDATE,
   PROTOCOL_VERIFY_PROPOSAL,
   PROTOCOL_VERIFY_APPROVAL,
   PROTOCOL_STORAGE_ACK,
@@ -68,6 +69,7 @@ describe('V10 protocol stream IDs', () => {
     expect(PROTOCOL_ACCESS).toBe('/dkg/10.0.1/private-access');
     expect(PROTOCOL_QUERY_REMOTE).toBe('/dkg/10.0.1/query-remote');
     expect(PROTOCOL_SWM_SENDER_KEY).toBe('/dkg/10.0.1/swm-sender-key');
+    expect(PROTOCOL_SWM_UPDATE).toBe('/dkg/10.0.1/swm-update');
     expect(PROTOCOL_VERIFY_PROPOSAL).toBe('/dkg/10.0.1/verify-proposal');
     expect(PROTOCOL_VERIFY_APPROVAL).toBe('/dkg/10.0.0/verify-approval');
     expect(PROTOCOL_STORAGE_ACK).toBe('/dkg/10.0.1/storage-ack');

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -46,6 +46,44 @@ export type WorkspaceSenderKeyDecryptor = (
 ) => Promise<Uint8Array>;
 
 /**
+ * Outcome of one `SharedMemoryHandler.handle()` invocation. Added
+ * in rc.9 PR-C (codex R3) so the new substrate fan-out receiver
+ * (`PROTOCOL_SWM_UPDATE`) can distinguish "share applied
+ * locally" from "receiver dropped the share for a stated reason"
+ * — without it, the substrate ACKs every delivery as successful
+ * even when the receiver silently `return;`-rejected (sender key
+ * package hasn't arrived yet, peer not in allowlist, etc.) and
+ * the sender's `sendReliable` records a `delivered` count that
+ * misrepresents end-to-end success.
+ *
+ * The `retryable` flag tells the substrate caller whether the
+ * rejection is something a future delivery attempt could
+ * resolve:
+ *
+ *   - `retryable: false` — permanent rejection. Bad signature,
+ *     peer not in allowlist, CAS conditions don't hold, payload
+ *     malformed. A retry with the SAME payload won't apply
+ *     either; the sender should NOT queue the share for retry
+ *     (drop it). The pre-PR-C gossip behaviour was identical:
+ *     drop silently, rely on sync-on-reconnect as the safety
+ *     net.
+ *   - `retryable: true` — transient rejection. Most commonly
+ *     this is an UNEXPECTED throw caught by the outer try/catch
+ *     in `handle()` (sender key state for the current epoch
+ *     hasn't arrived yet, decryptor temporarily unavailable,
+ *     triple-store hiccup). A retry once the local state has
+ *     converged would likely succeed; the substrate caller
+ *     SHOULD keep the share queued so it gets re-attempted.
+ *
+ * Gossip callers ignore the outcome — gossip is best-effort and
+ * its only "retry" is sync-on-reconnect, which doesn't consult
+ * this signal. The new substrate fan-out receiver consumes it.
+ */
+export type SharedMemoryApplyOutcome =
+  | { applied: true }
+  | { applied: false; reason: string; retryable: boolean };
+
+/**
  * Unambiguous composite key for `seenShareOps`.
  *
  * **Why not `${cgId}|${shareOperationId}` (rc.9 PR-A codex follow-up
@@ -437,10 +475,34 @@ export class SharedMemoryHandler {
   }
 
   /**
-   * Handler for GossipSub shared memory topic: (data, fromPeerId) => void.
-   * Validates, stores to SWM + SWM meta, updates sharedMemoryOwnedEntities.
+   * Handler for SWM share delivery. Originally introduced as the
+   * GossipSub shared-memory topic callback; as of rc.9 PR-C it
+   * ALSO services the substrate fan-out path (`PROTOCOL_SWM_UPDATE`).
+   *
+   * Validates, stores to SWM + SWM meta, updates
+   * sharedMemoryOwnedEntities, returns a {@link SharedMemoryApplyOutcome}
+   * the caller can use to decide whether to ACK / retry / drop.
+   *
+   * Codex review on PR #576 (R3) flagged that the previous
+   * `Promise<void>` signature made every substrate delivery look
+   * `delivered: true` from the sender's POV, even when this
+   * function silently `return;`-rejected the share (sender key
+   * package hasn't arrived yet, peer not in allowlist, etc.).
+   * The structured return restores end-to-end semantics: the
+   * caller learns whether the apply succeeded, and if not,
+   * whether a retry with the same payload could plausibly help
+   * (`retryable: true` for thrown errors like missing sender key
+   * state; `retryable: false` for permanent rejections like bad
+   * signatures).
+   *
+   * Existing gossip callers (gossip.onMessage(swmTopic, …))
+   * remain unchanged in BEHAVIOUR — they discard the return,
+   * matching pre-PR-C "fire-and-forget, sync-on-reconnect is the
+   * safety net" semantics. The new PR-C substrate receiver
+   * inspects the outcome and throws on `retryable: true` so the
+   * substrate's outbox keeps the share queued for retry.
    */
-  async handle(data: Uint8Array, fromPeerId: string, onPhase?: PhaseCallback): Promise<void> {
+  async handle(data: Uint8Array, fromPeerId: string, onPhase?: PhaseCallback): Promise<SharedMemoryApplyOutcome> {
     let ctx = createOperationContext('share');
     try {
       onPhase?.('decode', 'start');
@@ -449,8 +511,9 @@ export class SharedMemoryHandler {
       let request = decoded.request;
       let contextGraphId = request?.contextGraphId ?? decoded.senderKeyMessage?.contextGraphId ?? envelope?.contextGraphId;
       if (!contextGraphId) {
-        this.log.warn(ctx, 'SWM write rejected: missing context graph id');
-        return;
+        const reason = 'missing context graph id';
+        this.log.warn(ctx, `SWM write rejected: ${reason}`);
+        return { applied: false, reason, retryable: false };
       }
 
       const agentGateAddresses = await this.getContextGraphAgentGateAddresses(contextGraphId);
@@ -458,69 +521,96 @@ export class SharedMemoryHandler {
       const hasPrivateAccessPolicy = await this.contextGraphHasPrivateAccessPolicy(contextGraphId);
 
       if (hasPrivateAccessPolicy && agentGateAddresses === null && allowedPeers === null) {
-        this.log.warn(ctx, `SWM write rejected: private context graph "${contextGraphId}" has no gossip allowlist`);
-        return;
+        const reason = `private context graph "${contextGraphId}" has no gossip allowlist`;
+        this.log.warn(ctx, `SWM write rejected: ${reason}`);
+        return { applied: false, reason, retryable: false };
       }
 
       if (hasPrivateAccessPolicy && agentGateAddresses === null) {
-        this.log.warn(ctx, `SWM write rejected: private context graph "${contextGraphId}" requires DKG agent encryption recipients`);
-        return;
+        const reason = `private context graph "${contextGraphId}" requires DKG agent encryption recipients`;
+        this.log.warn(ctx, `SWM write rejected: ${reason}`);
+        return { applied: false, reason, retryable: false };
       }
 
       if (agentGateAddresses !== null) {
         const verified = await this.verifyAgentEnvelope(envelope, signedPayload, contextGraphId, agentGateAddresses, ctx);
-        if (!verified) return;
+        if (!verified) {
+          // verifyAgentEnvelope already logged the specific reason
+          // at WARN. Treated as permanent: a bad signature won't
+          // become good on retry.
+          return { applied: false, reason: 'agent envelope verification failed', retryable: false };
+        }
       }
 
       const requiresEncryptedPayload = hasPrivateAccessPolicy || agentGateAddresses !== null;
       if (requiresEncryptedPayload && !decoded.encryptedPayload && !decoded.senderKeyMessage) {
-        this.log.warn(ctx, `SWM write rejected: Sender Key encrypted workspace payload required for private or agent-gated context graph "${contextGraphId}"`);
-        return;
+        const reason = `Sender Key encrypted workspace payload required for private or agent-gated context graph "${contextGraphId}"`;
+        this.log.warn(ctx, `SWM write rejected: ${reason}`);
+        return { applied: false, reason, retryable: false };
       }
 
       if (decoded.senderKeyMessage) {
         if (!requiresEncryptedPayload) {
-          this.log.warn(ctx, `SWM write rejected: Sender Key payload is only supported for private or agent-gated context graph "${contextGraphId}"`);
-          return;
+          const reason = `Sender Key payload is only supported for private or agent-gated context graph "${contextGraphId}"`;
+          this.log.warn(ctx, `SWM write rejected: ${reason}`);
+          return { applied: false, reason, retryable: false };
         }
         if (!this.workspaceSenderKeyDecryptor) {
-          this.log.warn(ctx, `SWM write rejected: no local Sender Key state decryptor for context graph "${contextGraphId}"`);
-          return;
+          const reason = `no local Sender Key state decryptor for context graph "${contextGraphId}"`;
+          this.log.warn(ctx, `SWM write rejected: ${reason}`);
+          // Receiver-side init order: this branch fires when the
+          // SharedMemoryHandler exists but workspaceSenderKeyDecryptor
+          // was not wired by the agent. Marking retryable so the
+          // sender's substrate outbox keeps the share queued
+          // across a daemon restart that re-wires the decryptor.
+          return { applied: false, reason, retryable: true };
         }
         if (decoded.senderKeyMessage.contextGraphId !== contextGraphId) {
-          this.log.warn(ctx, `SWM write rejected: Sender Key contextGraphId "${decoded.senderKeyMessage.contextGraphId}" does not match envelope "${contextGraphId}"`);
-          return;
+          const reason = `Sender Key contextGraphId "${decoded.senderKeyMessage.contextGraphId}" does not match envelope "${contextGraphId}"`;
+          this.log.warn(ctx, `SWM write rejected: ${reason}`);
+          return { applied: false, reason, retryable: false };
         }
+        // workspaceSenderKeyDecryptor THROWS when the sender key
+        // package hasn't arrived yet (or epoch state is missing).
+        // That throw falls through to the outer catch below and
+        // is classified as `retryable: true` — once the sender
+        // key package arrives, the same wire bytes apply cleanly.
         const plaintext = await this.workspaceSenderKeyDecryptor(decoded.senderKeyMessage, contextGraphId, ctx);
         request = decodeWorkspacePublishRequest(plaintext);
         if (request.contextGraphId !== contextGraphId) {
-          this.log.warn(ctx, `SWM write rejected: Sender Key decrypted payload contextGraphId "${request.contextGraphId}" does not match envelope "${contextGraphId}"`);
-          return;
+          const reason = `Sender Key decrypted payload contextGraphId "${request.contextGraphId}" does not match envelope "${contextGraphId}"`;
+          this.log.warn(ctx, `SWM write rejected: ${reason}`);
+          return { applied: false, reason, retryable: false };
         }
       } else if (decoded.encryptedPayload) {
         if (!requiresEncryptedPayload) {
-          this.log.warn(ctx, `SWM write rejected: encrypted workspace payload is only supported for private or agent-gated context graph "${contextGraphId}"`);
-          return;
+          const reason = `encrypted workspace payload is only supported for private or agent-gated context graph "${contextGraphId}"`;
+          this.log.warn(ctx, `SWM write rejected: ${reason}`);
+          return { applied: false, reason, retryable: false };
         }
         if (this.workspaceSenderKeyDecryptor) {
-          this.log.warn(ctx, `SWM write rejected: legacy encrypted workspace payload is not accepted for Sender Key protected context graph "${contextGraphId}"`);
-          return;
+          const reason = `legacy encrypted workspace payload is not accepted for Sender Key protected context graph "${contextGraphId}"`;
+          this.log.warn(ctx, `SWM write rejected: ${reason}`);
+          return { applied: false, reason, retryable: false };
         }
         if (decoded.encryptedPayload.contextGraphId !== contextGraphId) {
-          this.log.warn(ctx, `SWM write rejected: encrypted contextGraphId "${decoded.encryptedPayload.contextGraphId}" does not match envelope "${contextGraphId}"`);
-          return;
+          const reason = `encrypted contextGraphId "${decoded.encryptedPayload.contextGraphId}" does not match envelope "${contextGraphId}"`;
+          this.log.warn(ctx, `SWM write rejected: ${reason}`);
+          return { applied: false, reason, retryable: false };
         }
         const plaintext = await this.decryptEncryptedWorkspacePayload(decoded.encryptedPayload, contextGraphId);
         request = decodeWorkspacePublishRequest(plaintext);
         if (request.contextGraphId !== contextGraphId) {
-          this.log.warn(ctx, `SWM write rejected: decrypted payload contextGraphId "${request.contextGraphId}" does not match envelope "${contextGraphId}"`);
-          return;
+          const reason = `decrypted payload contextGraphId "${request.contextGraphId}" does not match envelope "${contextGraphId}"`;
+          this.log.warn(ctx, `SWM write rejected: ${reason}`);
+          return { applied: false, reason, retryable: false };
         }
       }
 
       if (!request) {
-        this.log.warn(ctx, `SWM write rejected: no workspace publish request for context graph "${contextGraphId}"`);
-        return;
+        const reason = `no workspace publish request for context graph "${contextGraphId}"`;
+        this.log.warn(ctx, `SWM write rejected: ${reason}`);
+        return { applied: false, reason, retryable: false };
       }
 
       if (request.operationId) {
@@ -532,13 +622,15 @@ export class SharedMemoryHandler {
       this.log.info(ctx, `SWM write from ${fromPeerId} for context graph ${contextGraphId}${sgLabel} op=${shareOperationId}`);
 
       if (!shareOperationId) {
-        this.log.warn(ctx, `SWM write rejected: missing shareOperationId for context graph "${contextGraphId}"`);
-        return;
+        const reason = `missing shareOperationId for context graph "${contextGraphId}"`;
+        this.log.warn(ctx, `SWM write rejected: ${reason}`);
+        return { applied: false, reason, retryable: false };
       }
 
       if (publisherPeerId !== fromPeerId) {
-        this.log.warn(ctx, `SWM write rejected: payload publisherPeerId "${publisherPeerId}" does not match sender "${fromPeerId}"`);
-        return;
+        const reason = `payload publisherPeerId "${publisherPeerId}" does not match sender "${fromPeerId}"`;
+        this.log.warn(ctx, `SWM write rejected: ${reason}`);
+        return { applied: false, reason, retryable: false };
       }
 
       // PR-A R1 NOTE: the redundant-apply counter is bumped AFTER the
@@ -550,15 +642,17 @@ export class SharedMemoryHandler {
 
       // Enforce peer allowlist for curated CGs
       if (allowedPeers !== null && !allowedPeers.includes(fromPeerId)) {
-        this.log.warn(ctx, `SWM write rejected: peer "${fromPeerId}" not in allowlist for context graph "${contextGraphId}"`);
-        return;
+        const reason = `peer "${fromPeerId}" not in allowlist for context graph "${contextGraphId}"`;
+        this.log.warn(ctx, `SWM write rejected: ${reason}`);
+        return { applied: false, reason, retryable: false };
       }
 
       if (subGraphName) {
         const v = validateSubGraphName(subGraphName);
         if (!v.valid) {
-          this.log.warn(ctx, `SWM write rejected: invalid subGraphName "${subGraphName}": ${v.reason}`);
-          return;
+          const reason = `invalid subGraphName "${subGraphName}": ${v.reason}`;
+          this.log.warn(ctx, `SWM write rejected: ${reason}`);
+          return { applied: false, reason, retryable: false };
         }
       }
 
@@ -731,9 +825,30 @@ export class SharedMemoryHandler {
           source: 'gossip',
           counts: { triples: quads.length },
         });
+        return { applied: true };
       }
+      // `applied === false` from the withWriteLocks closure: either
+      // validation rejected the payload or CAS pre-conditions
+      // didn't hold against current SWM state. Both are permanent
+      // for this exact wire bytes: retrying the SAME payload would
+      // produce the same outcome (validation is deterministic; CAS
+      // checks current state, which the sender can re-evaluate by
+      // issuing a fresh share with updated conditions).
+      return { applied: false, reason: 'validation or CAS conditions rejected by withWriteLocks closure', retryable: false };
     } catch (err) {
-      this.log.error(ctx, `SWM handle failed: ${err instanceof Error ? err.message : String(err)}`);
+      // PR-C codex R3: classify the catch path as `retryable: true`.
+      // The dominant production case here is `workspaceSenderKeyDecryptor`
+      // rejecting because the corresponding sender key package
+      // hasn't arrived for the epoch yet — once it does, the same
+      // wire bytes apply cleanly on the next attempt. Generic
+      // triple-store hiccups (`store.insert` worker timeouts,
+      // transient backend errors) similarly recover on retry.
+      // Genuinely permanent throws (malformed protobuf inside the
+      // try, etc.) will eventually exhaust the substrate outbox's
+      // retry budget and get dropped without operator action.
+      const reason = err instanceof Error ? err.message : String(err);
+      this.log.error(ctx, `SWM handle failed: ${reason}`);
+      return { applied: false, reason, retryable: true };
     }
   }
 

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -504,9 +504,34 @@ export class SharedMemoryHandler {
    */
   async handle(data: Uint8Array, fromPeerId: string, onPhase?: PhaseCallback): Promise<SharedMemoryApplyOutcome> {
     let ctx = createOperationContext('share');
+    // PR-C codex R5 (dropped review comment): protobuf decode
+    // failures are DETERMINISTIC — retrying the same wire bytes
+    // can't make a malformed envelope parse. Short-circuit
+    // decode errors as `retryable: false` so the substrate
+    // outbox drops them on the first attempt instead of burning
+    // the retry budget on log noise. The remaining body of
+    // `handle()` runs under the inner try whose catch defaults
+    // to `retryable: true` (dominated by I/O paths — sender
+    // key decryptor throws, store hiccups — see the catch
+    // block for details).
+    let decoded: WorkspaceGossipDecodeResult;
     try {
       onPhase?.('decode', 'start');
-      const decoded = this.decodeWorkspaceGossipMessage(data);
+      decoded = this.decodeWorkspaceGossipMessage(data);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      this.log.warn(ctx, `SWM write rejected: protobuf decode failed: ${reason}`);
+      return { applied: false, reason: `protobuf decode failed: ${reason}`, retryable: false };
+    }
+    // PR-C codex R4 (dropped review comment): inside the inner
+    // try, `withWriteLocks` returns false for TWO distinct
+    // reasons — validation rejection (deterministic, payload
+    // can never apply) and CAS-not-met (TRANSIENT when SWM
+    // writes arrive out of order). Hoisted here so the closure
+    // can signal which branch fired; the post-closure code
+    // maps `cas` → retryable and `validation` → permanent.
+    let withWriteLocksRejection: 'validation' | 'cas' | undefined;
+    try {
       const { envelope, signedPayload } = decoded;
       let request = decoded.request;
       let contextGraphId = request?.contextGraphId ?? decoded.senderKeyMessage?.contextGraphId ?? envelope?.contextGraphId;
@@ -721,6 +746,7 @@ export class SharedMemoryHandler {
         );
         if (!validation.valid) {
           this.log.warn(ctx, `SWM validation rejected: ${validation.errors.join('; ')}`);
+          withWriteLocksRejection = 'validation';
           return false;
         }
         onPhase?.('validate', 'end');
@@ -734,6 +760,7 @@ export class SharedMemoryHandler {
             // replays missed writes on reconnect, converging replicas eventually.
             // Accepting stale-CAS writes would silently corrupt local state.
             this.log.info(ctx, `Skipping SWM write ${shareOperationId} — remote CAS conditions not met`);
+            withWriteLocksRejection = 'cas';
             return false;
           }
         }
@@ -827,14 +854,26 @@ export class SharedMemoryHandler {
         });
         return { applied: true };
       }
-      // `applied === false` from the withWriteLocks closure: either
-      // validation rejected the payload or CAS pre-conditions
-      // didn't hold against current SWM state. Both are permanent
-      // for this exact wire bytes: retrying the SAME payload would
-      // produce the same outcome (validation is deterministic; CAS
-      // checks current state, which the sender can re-evaluate by
-      // issuing a fresh share with updated conditions).
-      return { applied: false, reason: 'validation or CAS conditions rejected by withWriteLocks closure', retryable: false };
+      // `applied === false` from the withWriteLocks closure. PR-C
+      // codex R4: validation rejection is deterministic (retry
+      // produces the same outcome), but CAS-not-met is
+      // TRANSIENT — the missed write upstream might still arrive
+      // via gossip and bring local state up to where the CAS
+      // condition would pass. Keep retrying so the sender's
+      // outbox doesn't drop a payload that would apply after
+      // out-of-order delivery converges.
+      if (withWriteLocksRejection === 'cas') {
+        return {
+          applied: false,
+          reason: 'CAS pre-conditions not met against current SWM state (transient: may apply after upstream writes converge)',
+          retryable: true,
+        };
+      }
+      return {
+        applied: false,
+        reason: 'validation rejected payload (permanent: triple structure or manifest does not pass validatePublishRequest)',
+        retryable: false,
+      };
     } catch (err) {
       // PR-C codex R3: classify the catch path as `retryable: true`.
       // The dominant production case here is `workspaceSenderKeyDecryptor`

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -912,6 +912,58 @@ describe('SharedMemoryHandler.handle outcome (rc.9 PR-C codex R3)', () => {
     expect(outcome.reason).toContain('does not match sender');
   });
 
+  it('retryable rejection (CAS pre-condition not met) returns { applied: false, retryable: true } — codex R4', async () => {
+    // Codex R4 (dropped review comment): CAS-not-met is
+    // TRANSIENT when SWM writes arrive out of order. The
+    // missed upstream write might still land via gossip and
+    // bring local state up to where the CAS condition would
+    // pass; the substrate outbox must keep this share queued.
+    //
+    // Setup: empty store. Send a publish with a CAS condition
+    // expecting "recruiting" on a subject/predicate that
+    // doesn't exist locally → enforceCASConditions returns
+    // false → withWriteLocks closure returns false with
+    // withWriteLocksRejection = 'cas' → outcome should be
+    // retryable.
+    const nquads = `<${ENTITY}> <http://schema.org/name> "CASRetry" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeerR4',
+      shareOperationId: 'op-cas-retryable',
+      timestampMs: Date.now(),
+      casConditions: [{
+        subject: ENTITY,
+        predicate: 'http://example.org/status',
+        expectedValue: '"recruiting"',
+        expectAbsent: false,
+      }],
+    });
+
+    const outcome = await handler.handle(msg, '12D3KooWPeerR4');
+    expect(outcome.applied).toBe(false);
+    if (outcome.applied) throw new Error('unreachable');
+    expect(outcome.retryable).toBe(true);
+    expect(outcome.reason).toMatch(/CAS/);
+  });
+
+  it('permanent rejection (malformed protobuf wire bytes) returns { applied: false, retryable: false } — codex R5', async () => {
+    // Codex R5 (dropped review comment): decode failures are
+    // DETERMINISTIC — retrying the same bytes can't make a
+    // malformed envelope parse. The top-level decode try in
+    // handle() short-circuits these as `retryable: false` so
+    // the substrate outbox drops on first attempt instead of
+    // burning retry budget on log noise.
+    const garbage = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+
+    const outcome = await handler.handle(garbage, '12D3KooWPeerR5');
+    expect(outcome.applied).toBe(false);
+    if (outcome.applied) throw new Error('unreachable');
+    expect(outcome.retryable).toBe(false);
+    expect(outcome.reason).toMatch(/decode/i);
+  });
+
   it('retryable rejection (unexpected throw during apply) returns { applied: false, retryable: true }', async () => {
     // Dominant production case for `retryable: true`: the
     // sender key package for the current epoch hasn't arrived

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -862,6 +862,100 @@ describe('SharedMemoryHandler', () => {
   });
 });
 
+/**
+ * rc.9 PR-C codex R3: `handle()` returns a `SharedMemoryApplyOutcome`
+ * so the new substrate-fanout receiver can distinguish "applied
+ * locally" from "silently rejected" without log-scraping. Gossip
+ * callers ignore the return (unchanged behaviour); substrate
+ * callers throw on `retryable: true` so `sendReliable` keeps the
+ * share queued for retry.
+ */
+describe('SharedMemoryHandler.handle outcome (rc.9 PR-C codex R3)', () => {
+  let store: OxigraphStore;
+  let handler: SharedMemoryHandler;
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {});
+  });
+
+  it('successful apply returns { applied: true }', async () => {
+    const nquads = `<${ENTITY}> <http://schema.org/name> "Applied" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeerR3',
+      shareOperationId: 'op-applied',
+      timestampMs: Date.now(),
+    });
+
+    const outcome = await handler.handle(msg, '12D3KooWPeerR3');
+    expect(outcome).toEqual({ applied: true });
+  });
+
+  it('permanent rejection (publisherPeerId / fromPeerId mismatch) returns { applied: false, retryable: false }', async () => {
+    const nquads = `<${ENTITY}> <http://schema.org/name> "PubMismatch" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWClaimedPublisher',
+      shareOperationId: 'op-pub-mismatch',
+      timestampMs: Date.now(),
+    });
+
+    const outcome = await handler.handle(msg, '12D3KooWActualSender');
+    expect(outcome.applied).toBe(false);
+    if (outcome.applied) throw new Error('unreachable');
+    expect(outcome.retryable).toBe(false);
+    expect(outcome.reason).toContain('does not match sender');
+  });
+
+  it('retryable rejection (unexpected throw during apply) returns { applied: false, retryable: true }', async () => {
+    // Dominant production case for `retryable: true`: the
+    // sender key package for the current epoch hasn't arrived
+    // yet, so `workspaceSenderKeyDecryptor` rejects with an
+    // Error. The outer catch in `handle()` MUST classify any
+    // such thrown error as retryable so the substrate outbox
+    // keeps the share queued for retry — once the sender key
+    // package arrives, the SAME wire bytes apply cleanly.
+    //
+    // Setting up a real agent-gated CG + sender-key state is
+    // heavyweight here; instead we install a store proxy that
+    // throws inside the handle()'s try-block (a triple-store
+    // hiccup has identical semantics — caught by the same
+    // outer catch and classified by the same rule). Any
+    // unexpected throw → `retryable: true`.
+    const throwingStore = new Proxy(store, {
+      get(target, prop, receiver) {
+        if (prop === 'insert') {
+          return () => Promise.reject(new Error('simulated triple-store worker hiccup'));
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    const throwingHandler = new SharedMemoryHandler(throwingStore, new TypedEventBus(), {});
+
+    const nquads = `<${ENTITY}> <http://schema.org/name> "WillThrow" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeerR3',
+      shareOperationId: 'op-retryable',
+      timestampMs: Date.now(),
+    });
+
+    const outcome = await throwingHandler.handle(msg, '12D3KooWPeerR3');
+    expect(outcome.applied).toBe(false);
+    if (outcome.applied) throw new Error('unreachable');
+    expect(outcome.retryable).toBe(true);
+    expect(typeof outcome.reason).toBe('string');
+    expect(outcome.reason.length).toBeGreaterThan(0);
+  });
+});
+
 describe('SharedMemoryHandler: redundant-apply counter (rc.9 PR-A)', () => {
   let store: OxigraphStore;
   let handler: SharedMemoryHandler;


### PR DESCRIPTION
## Summary

Step 3 of the SWM Reliable Fan-out plan ([RFC-003](https://github.com/OriginTrail/dkgv10-spec/pull/110)). With PR-A (#570) and PR-B (#571) merged, this PR finally wires the substrate fan-out path the plan was building toward — a deterministic alternative to GossipSub's best-effort mesh for SWM share delivery.

- **New protocol** \`/dkg/10.0.1/swm-update\` carries the same wire bytes \`encodeWorkspaceGossipMessage\` produces, point-to-point over the Universal Messenger substrate. Receiver routes straight into \`SharedMemoryHandler.handle()\` — PR-A's \`seenShareOps\` / \`redundantApplies\` dedup transparently covers double-delivery (gossip + substrate).
- **Tier-switch** in \`publishWorkspaceGossip\` consults the PR-B \`CGMemberEnumerator\` then a pure \`chooseFanOutTier()\` decision:

  | \`source\`            | members vs cap         | substrate | gossip |
  |---------------------|------------------------|-----------|--------|
  | \`allowlist\`         | (any size)             | YES       | NO     |
  | \`topic-subscribers\` | \`<= maxSubstrateMembers\` | YES       | YES    |
  | \`topic-subscribers\` | \`>  maxSubstrateMembers\` | NO        | YES    |
  | \`none\`              | (always empty)         | NO        | YES    |

  Threshold: \`DKG_SWM_SUBSTRATE_MAX_MEMBERS\` env (default 100), so the PR-F soak can sweep without rebuilding.
- **Parallel execution** via \`Promise.allSettled\` — one slow peer doesn't tail-latency the share; per-peer outcomes classified as \`delivered\` / \`queued\` / \`inFlight\` / \`failed\` and tallied per-cgId.
- **\`/api/slo\`** extended with \`swm.substrateFanout\`: per-(cgId, outcome) maps + overflow + sticky \`truncated\` flag, same shape as PR-A's gossip counters. Getter optional on \`buildSloPayload\` for back-compat with PR-A-only test doubles.

## Why curated CGs are NOT cap-truncated

A curated CG above the threshold (rare on testnet today — most are <20 peers) shouldn't have substrate targets silently dropped: that would regress reliability for the dropped peers. If a curated CG ever does grow huge, PR-D's ACK + watchdog will catch missed peers on the next tick, and the soak postmortem will surface the throughput cost so we can decide whether rc.10 needs batching or sharding.

## Files

- \`packages/core/src/constants.ts\` (+13) — \`PROTOCOL_SWM_UPDATE = '/dkg/10.0.1/swm-update'\`
- \`packages/agent/src/swm/substrate-fanout.ts\` (NEW, +371) — pure tier-decision + parallel executor
- \`packages/agent/src/dkg-agent.ts\` (+353) — receiver \`messenger.register\` for \`PROTOCOL_SWM_UPDATE\`, lazy \`CGMemberEnumerator\`, four per-outcome maps with overflow-cap eviction, refactor of \`publishWorkspaceGossip\` to tier-switch + parallel substrate/gossip
- \`packages/agent/src/index.ts\` (+12) — re-export the new public types
- \`packages/cli/src/daemon/routes/agent-chat.ts\` (+35) — \`buildSloPayload\` extension under \`swm.substrateFanout\`

## Tests (100 across affected suites)

| Suite | Count | What |
|-------|-------|------|
| \`swm-substrate-fanout.test.ts\` (NEW) | 11 | Pure tier-matrix + executor (parallel fan-out, mixed-outcome classification, sync-throw isolation between peers) |
| \`swm-substrate-fanout-integration.test.ts\` (NEW) | 5 | DKGAgent wiring — gossip-only branch, mixed substrate+gossip, self-exclusion, per-cgId isolation |
| \`api-slo-route.test.ts\` (extended) | +2 | Wire-format regression for \`swm.substrateFanout\` (present-when-provided + back-compat absent) |
| \`v10-constants.test.ts\` (extended) | +1 | \`PROTOCOL_SWM_UPDATE\` on \`/dkg/10.0.1/\` |
| \`swm-gossip-publish-failure\` / \`swm-gossip-signing\` / \`swm-agent-gate-access\` | unchanged behavior | Stub \`Gossip\` classes gained \`getSubscribers(): string[]\` to match production \`GossipSubManager\` (PR-B addition) |

All 100 pass locally; targeted \`vitest run\` output included in the linked PR conversation.

## Test plan

- [ ] CI green
- [ ] Code review (looking for: tier-decision boundary correctness, overflow-cap eviction semantics, receiver-handler return-value back-compat)
- [ ] Manual smoke on a 2-node testnet: create a curated CG with 2 peers, share, verify \`/api/slo\`'s \`swm.substrateFanout.delivered\` increments and (because curated → no gossip) \`gossip.publishFailures\` stays at 0
- [ ] PR-D follow-up: ACK protocol upgrades \`queued → delivered\` once receiver confirms apply

## Related

- RFC-003 — dkgv10-spec PR #110
- PR-A (#570) MERGED — loud-fail gossip + redundantApplies
- PR-B (#571) MERGED — \`CGMemberEnumerator\`
- PR-E (#569) MERGED — \`PROTOCOL_SYNC\` migration
- PR-D — UP NEXT — \`PROTOCOL_SWM_SHARE_ACK\` + \`SwmAckQuorum\` watchdog + queued→delivered upgrade
- PR-F (#572) — soak script, awaiting human review; depends on PR-C + PR-D landing for substrate path coverage

Made with [Cursor](https://cursor.com)