### PR TITLE
rc.9 PR-D: SwmAckQuorum overlay for SWM gossip-path reliability

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -164,6 +164,7 @@ import {
 import {
   chooseFanOutTier,
   executeSubstrateFanOut,
+  classifySendResult,
   FANOUT_RESPONSE_REJECTED,
   FANOUT_RESPONSE_RETRYABLE,
   type FanOutBookkeeper,
@@ -6673,22 +6674,31 @@ export class DKGAgent {
       };
     }
 
-    // rc.9 PR-D wiring (rebased onto PR-G's G2 detach): register
-    // the SwmAckQuorum tracker BEFORE substrate + gossip fire so
-    // a fast receiver's PROTOCOL_SWM_SHARE_ACK arrival lands
-    // against a known shareOperationId. (Pre-D5 the track call
-    // ran AFTER substrate + gossip completed, racing the ack
-    // path; PR-G's G2 detach made that race even tighter since
-    // share() now returns BEFORE substrate finishes. Tracking
-    // up-front side-steps both — the quorum record is alive the
-    // moment any wire packet leaves this method.)
+    // rc.9 PR-D codex follow-up #D5 (rebased onto PR-G's G2
+    // detach): register the SwmAckQuorum tracker BEFORE
+    // substrate + gossip fire so a fast receiver's
+    // PROTOCOL_SWM_SHARE_ACK arrival lands against a known
+    // shareOperationId.
     //
-    // We pipe substrate-delivered peers into the quorum via the
-    // bookkeeper shim (not via the deprecated `preAckedFromSubstrate`
-    // init field), so the quorum counts both transports in one
-    // number. Each substrate `delivered` outcome calls
-    // `quorum.onAck()` exactly like a gossip-applied receiver's
-    // SwmShareAck would.
+    // Pre-D5 the track call ran AFTER `Promise.all([substrate,
+    // gossip])`, so a fast receiver could:
+    //   1. apply the gossip payload,
+    //   2. send PROTOCOL_SWM_SHARE_ACK back to us,
+    //   3. our handler runs `swmAckQuorum.onAck(opId, peer)`,
+    //   4. but the record doesn't exist yet → ack DROPPED,
+    //   5. quorum stays short → spurious watchdog top-up fires.
+    //
+    // PR-G's G2 detach made that race even tighter since
+    // share() now returns BEFORE substrate finishes. Tracking
+    // up-front side-steps both — the quorum record is alive
+    // the moment any wire packet leaves this method.
+    //
+    // We track with `preAckedFromSubstrate: []` and pipe
+    // substrate-delivered peers into the quorum via the
+    // bookkeeper instead — they go through `onAck()` exactly
+    // like gossip-applied receivers do, so the quorum
+    // arithmetic is identical regardless of which transport
+    // delivered first.
     //
     // Three preconditions for tracking:
     //   1. Caller supplied a shareOperationId (`share()` does;
@@ -6698,7 +6708,7 @@ export class DKGAgent {
     //      no-gossip / substrate-only plan would already cover
     //      quorum via PR-C's substrate counters.
     //   3. We have at least one expected member to wait for.
-    //      (rc.9 PR-D codex #D3 keys this off
+    //      (PR-D #D3 keys this off
     //      `plan.enumeratedMembers.length`, NOT
     //      `substrateMembers.length`, so the gossip-only
     //      "public CG above the substrate cap" branch is
@@ -6726,8 +6736,8 @@ export class DKGAgent {
     // feeds per-peer outcomes through the bookkeeper as each
     // send completes. The bookkeeper does double duty:
     //   1. Bump per-(cgId, outcome) counters for /api/slo.
-    //   2. (PR-D) Feed substrate-`delivered` peers into the
-    //      quorum via onAck so they count toward the same
+    //   2. (PR-D #D5) Feed substrate-`delivered` peers into
+    //      the quorum via onAck so they count toward the same
     //      quorum target as gossip-side acks.
     if (plan.useSubstrate) {
       const baseBookkeeper = this.substrateFanoutBookkeeper();
@@ -9180,6 +9190,25 @@ export class DKGAgent {
   }
 
   /**
+   * Test-only inspector for SwmAckQuorum's tracked-record
+   * snapshot, exposed so integration tests can assert on the
+   * `acked` / `expectedMembers` after driving ack arrivals
+   * through `handleSwmShareAck`. Returns `undefined` for
+   * unknown shareOperationIds (matches the underlying
+   * component's `inspect()` contract — once a record completes
+   * quorum or expires, it's reaped). Not part of the public
+   * API surface; the production caller talks to the quorum
+   * directly via `getOrCreateSwmAckQuorum()`.
+   */
+  getSwmAckQuorumRecordSnapshotForTests(shareOperationId: string): {
+    acked: readonly string[];
+    expectedMembers: readonly string[];
+    ackPct: number;
+  } | undefined {
+    return this.swmAckQuorum?.inspect(shareOperationId);
+  }
+
+  /**
    * Best-effort send of `PROTOCOL_SWM_SHARE_ACK` to the share's
    * publisher peer after a successful gossip-path apply.
    * Extracted into a named method so the receiver contract can
@@ -9353,34 +9382,83 @@ export class DKGAgent {
    * tail-latency the rest. Failures get swallowed — the substrate's
    * own outbox handles retry.
    */
+  /**
+   * Watchdog-driven substrate top-up for SwmAckQuorum.
+   * Extracted into a named method (mirrors PR-C's
+   * `handleSwmUpdate` / PR-D's `handleSwmShareAck` shape) so
+   * the per-outcome classification contract from rc.9 PR-D
+   * codex follow-up #D6 can be unit-tested in isolation
+   * without driving real-time watchdog ticks.
+   *
+   * Per-peer outcomes (classified via the SAME
+   * `classifySendResult` the main fan-out uses):
+   *   - `delivered` → call `swmAckQuorum.onAck` so the peer
+   *     counts toward quorum. PROTOCOL_SWM_UPDATE does NOT
+   *     emit `PROTOCOL_SWM_SHARE_ACK` (acks ride the gossip
+   *     applier path only), so without this call a successful
+   *     top-up never moves the peer into `acked` and the
+   *     share stays `pending` until `deadlineHardMs` even
+   *     after the actual delivery succeeded.
+   *   - `retryable` (0x02 sentinel) → no-op; next watchdog
+   *     tick fires another top-up, giving upstream state more
+   *     time to converge.
+   *   - `rejected` (0x01 sentinel) → no-op; receiver
+   *     permanently rejected the share, retrying won't help.
+   *     (Pre-PR-D receivers that fell back to the throw path
+   *     instead of the sentinel surface this as `failed`
+   *     here — also a no-op for the same reason.)
+   *   - `queued` / `inFlight` / `failed` → no-op; the
+   *     substrate outbox owns retry for these.
+   */
+  private async swmSubstrateTopUp({
+    shareOperationId, cgId, payload, missingPeers,
+  }: {
+    shareOperationId: string;
+    cgId: string;
+    payload: Uint8Array;
+    missingPeers: readonly string[];
+  }): Promise<void> {
+    const ctx = createOperationContext('share', shareOperationId);
+    this.log.info(
+      ctx,
+      `SWM ack-quorum watchdog firing substrate top-up for ${shareOperationId} to ${missingPeers.length} peer(s) (cg=${cgId})`,
+    );
+    await Promise.allSettled(missingPeers.map(async (peerId: string) => {
+      try {
+        const sendResult = await this.messenger.sendReliable(peerId, PROTOCOL_SWM_UPDATE, payload, {
+          messageId: `swm-topup-${shareOperationId}-${peerId}`,
+          timeoutMs: DKGAgent.SWM_SUBSTRATE_FANOUT_TIMEOUT_MS,
+        });
+        const classified = classifySendResult(peerId, sendResult);
+        if (classified.outcome === 'delivered') {
+          this.swmAckQuorum?.onAck(shareOperationId, peerId);
+        }
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        this.log.warn(ctx, `SWM top-up to ${peerId} failed: ${reason}`);
+      }
+    }));
+  }
+
+  /**
+   * Test-only view onto {@link swmSubstrateTopUp} for the
+   * PR-D codex follow-up #D6 regression. Bypasses the
+   * watchdog's setInterval so tests can pin the per-outcome
+   * classification → onAck wiring without real-time flake.
+   */
+  async invokeSwmSubstrateTopUpForTests(args: {
+    shareOperationId: string;
+    cgId: string;
+    payload: Uint8Array;
+    missingPeers: readonly string[];
+  }): Promise<void> {
+    return this.swmSubstrateTopUp(args);
+  }
+
   private getOrCreateSwmAckQuorum(): SwmAckQuorum {
     if (!this.swmAckQuorum) {
       this.swmAckQuorum = createSwmAckQuorum({
-        substrateTopUp: async ({
-          shareOperationId, cgId, payload, missingPeers,
-        }: {
-          shareOperationId: string;
-          cgId: string;
-          payload: Uint8Array;
-          missingPeers: readonly string[];
-        }) => {
-          const ctx = createOperationContext('share', shareOperationId);
-          this.log.info(
-            ctx,
-            `SWM ack-quorum watchdog firing substrate top-up for ${shareOperationId} to ${missingPeers.length} peer(s) (cg=${cgId})`,
-          );
-          await Promise.allSettled(missingPeers.map(async (peerId: string) => {
-            try {
-              await this.messenger.sendReliable(peerId, PROTOCOL_SWM_UPDATE, payload, {
-                messageId: `swm-topup-${shareOperationId}-${peerId}`,
-                timeoutMs: DKGAgent.SWM_SUBSTRATE_FANOUT_TIMEOUT_MS,
-              });
-            } catch (err) {
-              const reason = err instanceof Error ? err.message : String(err);
-              this.log.warn(ctx, `SWM top-up to ${peerId} failed: ${reason}`);
-            }
-          }));
-        },
+        substrateTopUp: (args) => this.swmSubstrateTopUp(args),
         observers: {
           onQuorumCompleted: (e: {
             shareOperationId: string; cgId: string; ackedCount: number; expectedCount: number; ackPct: number;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2,7 +2,7 @@ import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
   PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
-  PROTOCOL_SWM_SENDER_KEY, PROTOCOL_SWM_UPDATE, PROTOCOL_MESSAGE,
+  PROTOCOL_SWM_SENDER_KEY, PROTOCOL_SWM_UPDATE, PROTOCOL_SWM_SHARE_ACK, PROTOCOL_MESSAGE,
   contextGraphPublishTopic, contextGraphWorkspaceTopic, contextGraphAppTopic, contextGraphUpdateTopic, contextGraphFinalizationTopic,
   contextGraphDataGraphUri, contextGraphMetaGraphUri, contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
   contextGraphSharedMemoryUri,
@@ -46,6 +46,8 @@ import {
   encodeSwmSenderKeyMessage,
   encodeSwmSenderKeyPackage,
   encodeSwmSenderKeyPackageAck,
+  encodeSwmShareAck,
+  decodeSwmShareAck,
   encryptSwmSenderKeyMessage,
   encryptSwmSenderKeyPackage,
   generateEd25519Keypair,
@@ -167,6 +169,10 @@ import {
   type FanOutPeerRecord,
   type FanOutPlan,
 } from './swm/substrate-fanout.js';
+import {
+  createSwmAckQuorum,
+  type SwmAckQuorum,
+} from './swm/ack-quorum.js';
 import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
@@ -1383,6 +1389,25 @@ export class DKGAgent {
    */
   private cgMemberEnumerator?: CGMemberEnumerator;
 
+  /**
+   * Lazy SwmAckQuorum — single instance per agent. Tracks
+   * outstanding SWM shares to compute per-share delivery quorum
+   * across the gossip + substrate hybrid (rc.9 PR-D, RFC-003
+   * §4.2 + §5). Substrate-acked peers from PR-C's
+   * `executeSubstrateFanOut` pre-populate the `acked` set so the
+   * gossip-side `PROTOCOL_SWM_SHARE_ACK` arrivals fill in the
+   * remaining gap. See {@link getOrCreateSwmAckQuorum}.
+   */
+  private swmAckQuorum?: SwmAckQuorum;
+  private swmAckQuorumTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Period at which `SwmAckQuorum.tick()` runs. Picked to match
+   * RFC-003 §5.2 ("watchdog tick: 5s") — a finer cadence buys
+   * nothing useful (watchdogMs is 30s by default, deadlineHardMs
+   * is 5min, so 5s is already 6x and 60x resolution respectively).
+   */
+  private static readonly SWM_ACK_QUORUM_TICK_MS = 5_000;
+
   private messageHandler: MessageHandler | null = null;
   private chainPoller: ChainEventPoller | null = null;
   private swmCleanupTimer: ReturnType<typeof setInterval> | null = null;
@@ -2005,6 +2030,37 @@ export class DKGAgent {
       PROTOCOL_SWM_UPDATE,
       (response) => !(response.byteLength === 1 && response[0] === 0x01),
     );
+
+    // rc.9 PR-D: gossip-applied share acks. Receiver-only —
+    // senders don't read the response (returns empty Uint8Array
+    // as a no-op ACK at the wire level). The handler simply
+    // funnels arrivals into SwmAckQuorum.onAck which is the
+    // source of truth for delivery quorum tracking. Decoupled
+    // from the substrate path entirely: PROTOCOL_SWM_UPDATE's
+    // own response is the substrate-side ack and is consumed by
+    // PR-C's classifySendResult — it does NOT route through
+    // SwmAckQuorum.onAck (the substrate-delivered peers are
+    // pre-populated into the `acked` set at track time instead,
+    // which is structurally identical and avoids a second
+    // round-trip per peer).
+    this.messenger.register(PROTOCOL_SWM_SHARE_ACK, async (data, fromPeerId) => {
+      try {
+        const ack = decodeSwmShareAck(data);
+        const ackPeerId = ack.ackPeerId || fromPeerId;
+        this.getOrCreateSwmAckQuorum().onAck(ack.shareOperationId, ackPeerId);
+      } catch (err) {
+        // Malformed ack bytes from a buggy or hostile peer.
+        // Swallow — the worst case is the share's watchdog
+        // eventually fires substrate top-up (which is what would
+        // have happened anyway without the ack arrival).
+        const reason = err instanceof Error ? err.message : String(err);
+        this.log.warn(
+          createOperationContext('share'),
+          `SWM share ack decode failed from ${fromPeerId}: ${reason}`,
+        );
+      }
+      return new Uint8Array();
+    });
 
     const effectiveRole = this.config.nodeRole ?? 'edge';
     const ackSignerCandidates = this.getACKSignerCandidateWallets(ctx);
@@ -6537,6 +6593,22 @@ export class DKGAgent {
     message: Uint8Array,
     ctx: OperationContext,
     resolvedSigner?: (AgentKeyRecord & { privateKey: string }) | null,
+    /**
+     * Publisher-minted unique share ID. When provided, this share
+     * is registered with `SwmAckQuorum` after fan-out so the
+     * watchdog can fire substrate top-up if gossip-side acks
+     * don't reach quorum within `watchdogMs`. Omitted by
+     * callers that aren't tracking per-share delivery (legacy
+     * code paths and tests); the share still publishes
+     * identically — only the quorum tracking is skipped.
+     *
+     * The cheapest way to keep backward compat with the existing
+     * three call sites: ONLY `share()` provides this for now.
+     * `liftToShared` / `sharedMemoryCAS` can add it in a
+     * follow-up if/when soak shows their share types benefit
+     * from quorum tracking too.
+     */
+    shareOperationId?: string,
   ): Promise<void> {
     const topic = contextGraphWorkspaceTopic(contextGraphId);
     const wireMessage = await this.encodeWorkspaceGossipMessage(contextGraphId, message, resolvedSigner);
@@ -6599,30 +6671,56 @@ export class DKGAgent {
       };
     }
 
-    // rc.9 PR-G codex follow-up #G2: detach substrate fan-out
-    // from the foreground share() path. We await ONLY the gossip
-    // publish (fast — a single topic emit), and let the substrate
-    // leg complete in the background. Without this, one slow /
-    // offline allowlisted peer could hold share() open for up to
-    // SWM_SUBSTRATE_FANOUT_TIMEOUT_MS (15s), regressing the
-    // pre-rc.9 gossip-only path's "share returns in tens of ms"
-    // contract.
+    // rc.9 PR-D wiring (rebased onto PR-G's G2 detach): register
+    // the SwmAckQuorum tracker BEFORE substrate + gossip fire so
+    // a fast receiver's PROTOCOL_SWM_SHARE_ACK arrival lands
+    // against a known shareOperationId. (Pre-D5 the track call
+    // ran AFTER substrate + gossip completed, racing the ack
+    // path; PR-G's G2 detach made that race even tighter since
+    // share() now returns BEFORE substrate finishes. Tracking
+    // up-front side-steps both — the quorum record is alive the
+    // moment any wire packet leaves this method.)
     //
-    // Background substrate keeps everything observability-wise:
-    //   - executeSubstrateFanOut still uses Promise.allSettled
-    //     internally, so per-peer outcomes still feed the
-    //     bookkeeper as each send completes.
-    //   - The INFO summary log fires from .then() once all peers
-    //     have responded (or timed out).
-    //   - A defensive .catch() guards against any escaped error
-    //     (should not fire — allSettled never rejects — but cheap
-    //     insurance against future refactors).
-    //   - The promise is registered into
-    //     `this.inFlightSubstrateFanOuts` so tests can drain via
-    //     `awaitInFlightSubstrateFanOuts()`. .finally() removes
-    //     each promise on completion to keep the Set bounded by
-    //     concurrency rather than cumulative shares.
+    // We pipe substrate-delivered peers into the quorum via the
+    // bookkeeper shim (not via the deprecated `preAckedFromSubstrate`
+    // init field), so the quorum counts both transports in one
+    // number. Each substrate `delivered` outcome calls
+    // `quorum.onAck()` exactly like a gossip-applied receiver's
+    // SwmShareAck would.
+    //
+    // Three preconditions for tracking:
+    //   1. Caller supplied a shareOperationId (`share()` does;
+    //      legacy callers don't).
+    //   2. The plan ran a gossip leg — SwmShareAck only covers
+    //      gossip-applied receivers.
+    //   3. We have at least one expected member to wait for.
+    const ackQuorumActive = !!shareOperationId
+      && plan.useGossip
+      && plan.substrateMembers.length > 0;
+    let trackedQuorum: SwmAckQuorum | null = null;
+    if (ackQuorumActive && shareOperationId) {
+      trackedQuorum = this.getOrCreateSwmAckQuorum();
+      trackedQuorum.track({
+        shareOperationId,
+        cgId: contextGraphId,
+        expectedMembers: plan.substrateMembers,
+        preAckedFromSubstrate: [],
+        payload: wireMessage,
+        enumerationSource: plan.enumerationSource,
+      });
+    }
+
+    // rc.9 PR-G #G2: substrate fan-out is detached from the
+    // share() critical path — share() awaits only the gossip
+    // publish (fast). Substrate runs in the background and
+    // feeds per-peer outcomes through the bookkeeper as each
+    // send completes. The bookkeeper does double duty:
+    //   1. Bump per-(cgId, outcome) counters for /api/slo.
+    //   2. (PR-D) Feed substrate-`delivered` peers into the
+    //      quorum via onAck so they count toward the same
+    //      quorum target as gossip-side acks.
     if (plan.useSubstrate) {
+      const baseBookkeeper = this.substrateFanoutBookkeeper();
       const substratePromise: Promise<void> = (async () => {
         try {
           const substrateResult = await executeSubstrateFanOut({
@@ -6632,7 +6730,18 @@ export class DKGAgent {
             members: plan.substrateMembers,
             sendTimeoutMs: DKGAgent.SWM_SUBSTRATE_FANOUT_TIMEOUT_MS,
             substrate: this.messenger,
-            bookkeeper: this.substrateFanoutBookkeeper(),
+            bookkeeper: {
+              recordOutcome: (cgId, record) => {
+                if (
+                  trackedQuorum
+                  && shareOperationId
+                  && record.outcome === 'delivered'
+                ) {
+                  trackedQuorum.onAck(shareOperationId, record.peerId);
+                }
+                baseBookkeeper.recordOutcome(cgId, record);
+              },
+            },
           });
           this.log.info(
             ctx,
@@ -7200,7 +7309,10 @@ export class DKGAgent {
       });
     }
     if (!opts?.localOnly) {
-      await this.publishWorkspaceGossip(contextGraphId, message, ctx, gossipSigner);
+      // rc.9 PR-D: pass shareOperationId so publishWorkspaceGossip
+      // can register the share with SwmAckQuorum and the watchdog
+      // can fire substrate top-up if gossip-side acks miss quorum.
+      await this.publishWorkspaceGossip(contextGraphId, message, ctx, gossipSigner, shareOperationId);
     }
     return { shareOperationId };
   }
@@ -7235,7 +7347,7 @@ export class DKGAgent {
       });
     }
     if (!opts?.localOnly) {
-      await this.publishWorkspaceGossip(contextGraphId, message, ctx, gossipSigner);
+      await this.publishWorkspaceGossip(contextGraphId, message, ctx, gossipSigner, shareOperationId);
     }
     return { shareOperationId };
   }
@@ -8977,8 +9089,71 @@ export class DKGAgent {
     this.gossip.subscribe(swmTopic);
     this.gossip.onMessage(swmTopic, async (_topic, data, from) => {
       const wh = this.getOrCreateSharedMemoryHandler();
-      await wh.handle(data, from);
+      const outcome = await wh.handle(data, from);
+      // rc.9 PR-D: emit SwmShareAck on gossip-applied shares so
+      // the publisher's SwmAckQuorum can compute per-share
+      // delivery quorum. Substrate-applied shares (via
+      // PROTOCOL_SWM_UPDATE → handleSwmUpdate) DO NOT emit a
+      // separate ack — the substrate response is itself the ack
+      // signal at the substrate layer (consumed by PR-C's
+      // classifySendResult / pre-acked set passed to
+      // SwmAckQuorum.track). Doing both would double-count
+      // delivery to peers reachable via both transports.
+      //
+      // Best-effort throughout: missing metadata fields, failed
+      // sendReliable, throws — all swallowed. The publisher's
+      // watchdog will fire substrate top-up if the ack count
+      // doesn't reach quorum, which makes the ack channel an
+      // opportunistic fast-path rather than a correctness
+      // requirement.
+      if (!outcome.applied) return;
+      this.maybeEmitSwmShareAck(outcome).catch(() => { /* swallowed; logged inside */ });
     });
+  }
+
+  /**
+   * Best-effort send of `PROTOCOL_SWM_SHARE_ACK` to the share's
+   * publisher peer after a successful gossip-path apply.
+   * Extracted into a named method so the receiver contract can
+   * be unit-tested in isolation without spinning up a real
+   * GossipSub subscription.
+   *
+   * Self-acks are filtered: if the publisher peerId equals our
+   * own (we both published AND happened to receive our own
+   * gossip back via the mesh — rare but possible), we skip the
+   * send because the publisher-side track() already counts the
+   * local apply via the substrate pre-acked set / never enters
+   * the watchdog branch.
+   */
+  private async maybeEmitSwmShareAck(outcome: {
+    applied: true;
+    cgId?: string;
+    shareOperationId?: string;
+    publisherPeerId?: string;
+  }): Promise<void> {
+    const { shareOperationId, publisherPeerId } = outcome;
+    if (!shareOperationId || !publisherPeerId) return;
+    let selfPeerId: string;
+    try {
+      selfPeerId = this.peerId;
+    } catch {
+      return;
+    }
+    if (publisherPeerId === selfPeerId) return;
+
+    const ackBytes = encodeSwmShareAck({ shareOperationId, ackPeerId: selfPeerId });
+    try {
+      await this.messenger.sendReliable(publisherPeerId, PROTOCOL_SWM_SHARE_ACK, ackBytes, {
+        messageId: `swm-share-ack-${shareOperationId}-${selfPeerId}`,
+        timeoutMs: DKGAgent.SWM_SUBSTRATE_FANOUT_TIMEOUT_MS,
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      this.log.warn(
+        createOperationContext('share', shareOperationId),
+        `SWM share ack to ${publisherPeerId} failed: ${reason}`,
+      );
+    }
   }
 
   /**
@@ -9073,6 +9248,96 @@ export class DKGAgent {
       });
     }
     return this.cgMemberEnumerator;
+  }
+
+  /**
+   * Lazy single-instance SwmAckQuorum (rc.9 PR-D). Constructs on
+   * first share through `publishWorkspaceGossip` and lives for
+   * the agent's lifetime. The 5s tick is wired here too — kept
+   * inside the lazy constructor so an agent that never shares
+   * pays no timer overhead.
+   *
+   * `substrateTopUp` callback is implemented inline against
+   * `messenger.sendReliable(PROTOCOL_SWM_UPDATE, ...)` so the
+   * watchdog re-fires through the exact same protocol PR-C's
+   * substrate fan-out uses — receivers (`handleSwmUpdate`) are
+   * idempotent on (cgId, shareOperationId), so a top-up arriving
+   * for a peer that already got the gossip-leg is dedup'd
+   * server-side via `seenShareOps`. Top-up uses Promise.allSettled
+   * (mirrors `executeSubstrateFanOut`) so one slow peer doesn't
+   * tail-latency the rest. Failures get swallowed — the substrate's
+   * own outbox handles retry.
+   */
+  private getOrCreateSwmAckQuorum(): SwmAckQuorum {
+    if (!this.swmAckQuorum) {
+      this.swmAckQuorum = createSwmAckQuorum({
+        substrateTopUp: async ({
+          shareOperationId, cgId, payload, missingPeers,
+        }: {
+          shareOperationId: string;
+          cgId: string;
+          payload: Uint8Array;
+          missingPeers: readonly string[];
+        }) => {
+          const ctx = createOperationContext('share', shareOperationId);
+          this.log.info(
+            ctx,
+            `SWM ack-quorum watchdog firing substrate top-up for ${shareOperationId} to ${missingPeers.length} peer(s) (cg=${cgId})`,
+          );
+          await Promise.allSettled(missingPeers.map(async (peerId: string) => {
+            try {
+              await this.messenger.sendReliable(peerId, PROTOCOL_SWM_UPDATE, payload, {
+                messageId: `swm-topup-${shareOperationId}-${peerId}`,
+                timeoutMs: DKGAgent.SWM_SUBSTRATE_FANOUT_TIMEOUT_MS,
+              });
+            } catch (err) {
+              const reason = err instanceof Error ? err.message : String(err);
+              this.log.warn(ctx, `SWM top-up to ${peerId} failed: ${reason}`);
+            }
+          }));
+        },
+        observers: {
+          onQuorumCompleted: (e: {
+            shareOperationId: string; cgId: string; ackedCount: number; expectedCount: number; ackPct: number;
+          }) => {
+            this.log.debug(
+              createOperationContext('share', e.shareOperationId),
+              `SWM share quorum reached cg=${e.cgId} acked=${e.ackedCount}/${e.expectedCount} (${(e.ackPct * 100).toFixed(1)}%)`,
+            );
+          },
+          onWatchdogFired: (e: {
+            shareOperationId: string; cgId: string; missingCount: number; expectedCount: number;
+          }) => {
+            this.log.warn(
+              createOperationContext('share', e.shareOperationId),
+              `SWM share watchdog fired cg=${e.cgId} missing=${e.missingCount}/${e.expectedCount}`,
+            );
+          },
+          onDeadlineExpired: (e: {
+            shareOperationId: string; cgId: string; ackedCount: number; expectedCount: number; ackPct: number;
+          }) => {
+            this.log.warn(
+              createOperationContext('share', e.shareOperationId),
+              `SWM share deadline expired cg=${e.cgId} acked=${e.ackedCount}/${e.expectedCount} (${(e.ackPct * 100).toFixed(1)}%) — offline peers will recover via runSyncOnConnect`,
+            );
+          },
+        },
+      });
+      this.swmAckQuorumTimer = setInterval(() => {
+        try {
+          this.swmAckQuorum?.tick();
+        } catch (err) {
+          // Defensive — tick() should not throw, but if some
+          // future observer/callback path breaks the contract we'd
+          // rather drop one tick than crash the daemon's tick loop.
+          const reason = err instanceof Error ? err.message : String(err);
+          this.log.warn(createOperationContext('system'), `SWM ack-quorum tick failed: ${reason}`);
+        }
+      }, DKGAgent.SWM_ACK_QUORUM_TICK_MS);
+      const t = this.swmAckQuorumTimer as { unref?: () => void };
+      if (typeof t.unref === 'function') t.unref();
+    }
+    return this.swmAckQuorum;
   }
 
   /**
@@ -9237,6 +9502,44 @@ export class DKGAgent {
       },
       truncated: this.swmSubstrateFanoutTruncated,
     };
+  }
+
+  /**
+   * Snapshot of the SwmAckQuorum counters for /api/slo (rc.9
+   * PR-D). Returns pristine zeroes when the quorum tracker hasn't
+   * been lazy-constructed yet (no shares have been published, or
+   * none of them met the tracking preconditions in
+   * `publishWorkspaceGossip`). Safe to call from a fresh daemon.
+   *
+   * Counter semantics (cumulative since process start, except
+   * `pending` which is an instantaneous gauge):
+   *   - tracked          — every successful `track()` call
+   *   - completed        — records that reached quorumThreshold
+   *   - watchdogFired    — records where the watchdog fired
+   *                        substrate top-up (at most once per
+   *                        record)
+   *   - deadlineExpired  — records reaped at deadlineHardMs
+   *                        without reaching quorum
+   *   - pending          — currently tracked (not yet completed
+   *                        or expired)
+   *
+   * A healthy soak surfaces: `completed >> watchdogFired >>
+   * deadlineExpired`. A spike in `deadlineExpired` is the
+   * operator alarm — those peers will recover via
+   * `runSyncOnConnect` but the share's per-recipient delivery
+   * window blew past the 5min budget.
+   */
+  getSwmAckQuorumStats(): {
+    tracked: number;
+    completed: number;
+    watchdogFired: number;
+    deadlineExpired: number;
+    pending: number;
+  } {
+    if (!this.swmAckQuorum) {
+      return { tracked: 0, completed: 0, watchdogFired: 0, deadlineExpired: 0, pending: 0 };
+    }
+    return this.swmAckQuorum.stats();
   }
 
   private updateHandler?: UpdateHandler;
@@ -14862,6 +15165,10 @@ export class DKGAgent {
     if (this.messengerOutboxTimer) {
       clearInterval(this.messengerOutboxTimer);
       this.messengerOutboxTimer = null;
+    }
+    if (this.swmAckQuorumTimer) {
+      clearInterval(this.swmAckQuorumTimer);
+      this.swmAckQuorumTimer = null;
     }
     // rc.9 PR-10: joinApprovalRetryTimer + joinApprovalRetryQueue
     // deleted; substrate outbox owns retry state and drains itself

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2043,24 +2043,7 @@ export class DKGAgent {
     // pre-populated into the `acked` set at track time instead,
     // which is structurally identical and avoids a second
     // round-trip per peer).
-    this.messenger.register(PROTOCOL_SWM_SHARE_ACK, async (data, fromPeerId) => {
-      try {
-        const ack = decodeSwmShareAck(data);
-        const ackPeerId = ack.ackPeerId || fromPeerId;
-        this.getOrCreateSwmAckQuorum().onAck(ack.shareOperationId, ackPeerId);
-      } catch (err) {
-        // Malformed ack bytes from a buggy or hostile peer.
-        // Swallow — the worst case is the share's watchdog
-        // eventually fires substrate top-up (which is what would
-        // have happened anyway without the ack arrival).
-        const reason = err instanceof Error ? err.message : String(err);
-        this.log.warn(
-          createOperationContext('share'),
-          `SWM share ack decode failed from ${fromPeerId}: ${reason}`,
-        );
-      }
-      return new Uint8Array();
-    });
+    this.messenger.register(PROTOCOL_SWM_SHARE_ACK, (data, fromPeerId) => this.handleSwmShareAck(data, fromPeerId));
 
     const effectiveRole = this.config.nodeRole ?? 'edge';
     const ackSignerCandidates = this.getACKSignerCandidateWallets(ctx);
@@ -6666,6 +6649,7 @@ export class DKGAgent {
         useSubstrate: false,
         useGossip: true,
         substrateMembers: [],
+        enumeratedMembers: [],
         enumerationSource: 'none',
         enumeratedCount: 0,
       };
@@ -6692,18 +6676,26 @@ export class DKGAgent {
     //   1. Caller supplied a shareOperationId (`share()` does;
     //      legacy callers don't).
     //   2. The plan ran a gossip leg — SwmShareAck only covers
-    //      gossip-applied receivers.
+    //      gossip-applied receivers. A hypothetical future
+    //      no-gossip / substrate-only plan would already cover
+    //      quorum via PR-C's substrate counters.
     //   3. We have at least one expected member to wait for.
+    //      (rc.9 PR-D codex #D3 keys this off
+    //      `plan.enumeratedMembers.length`, NOT
+    //      `substrateMembers.length`, so the gossip-only
+    //      "public CG above the substrate cap" branch is
+    //      covered too — that's the dominant use case for
+    //      ack-driven reliability.)
     const ackQuorumActive = !!shareOperationId
       && plan.useGossip
-      && plan.substrateMembers.length > 0;
+      && plan.enumeratedMembers.length > 0;
     let trackedQuorum: SwmAckQuorum | null = null;
     if (ackQuorumActive && shareOperationId) {
       trackedQuorum = this.getOrCreateSwmAckQuorum();
       trackedQuorum.track({
         shareOperationId,
         cgId: contextGraphId,
-        expectedMembers: plan.substrateMembers,
+        expectedMembers: plan.enumeratedMembers,
         preAckedFromSubstrate: [],
         payload: wireMessage,
         enumerationSource: plan.enumerationSource,
@@ -9112,6 +9104,63 @@ export class DKGAgent {
   }
 
   /**
+   * Receiver handler for `PROTOCOL_SWM_SHARE_ACK`. Extracted into
+   * a named method (mirrors `handleSwmUpdate`'s shape) so the
+   * spoof-rejection contract from PR-D codex follow-up #D2 can
+   * be unit-tested in isolation without spinning up a real
+   * Messenger registration. Always returns `new Uint8Array()`
+   * at the wire level — senders don't read the response (acks
+   * use fire-and-forget `sendToPeer` per #D1).
+   */
+  private async handleSwmShareAck(data: Uint8Array, fromPeerId: string): Promise<Uint8Array> {
+    try {
+      const ack = decodeSwmShareAck(data);
+      // rc.9 PR-D codex follow-up #D2: authoritative ack identity
+      // is the libp2p-authenticated `fromPeerId`, NOT the
+      // self-asserted `ack.ackPeerId` in the protobuf body.
+      // Pre-D2 we trusted the body, which let any peer that had
+      // learned a `shareOperationId` spoof acks on behalf of
+      // other expected members — suppressing watchdog top-up
+      // for those members and degrading delivery quorum
+      // reliability. The body's `ackPeerId` is kept on the wire
+      // for forward-compat with a possible future relayed-ack
+      // path (where `fromPeerId` would be a relay node, not the
+      // original receiver), but in the current direct-Messenger
+      // world we reject any non-empty mismatch as either a
+      // misconfiguration or a spoof attempt.
+      if (ack.ackPeerId && ack.ackPeerId !== fromPeerId) {
+        this.log.warn(
+          createOperationContext('share', ack.shareOperationId),
+          `SWM share ack body/transport peerId mismatch — body=${ack.ackPeerId} transport=${fromPeerId} — dropping (potential spoof)`,
+        );
+        return new Uint8Array();
+      }
+      this.getOrCreateSwmAckQuorum().onAck(ack.shareOperationId, fromPeerId);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      this.log.warn(
+        createOperationContext('share'),
+        `SWM share ack decode failed from ${fromPeerId}: ${reason}`,
+      );
+    }
+    return new Uint8Array();
+  }
+
+  /**
+   * Test-only view onto {@link handleSwmShareAck} for the PR-D
+   * codex follow-up #D2 regression. Production traffic invokes
+   * the same handler via the `messenger.register()` callback
+   * registered in {@link initialize}; tests need the same
+   * arrow-function shape without having to intercept the
+   * register call (which happens before the test can install
+   * its messenger stub). Not part of the public API; method
+   * exists purely to make the spoof-rejection contract testable.
+   */
+  async getOrCreateSwmShareAckHandlerForTests(): Promise<(data: Uint8Array, from: string) => Promise<Uint8Array>> {
+    return (data, from) => this.handleSwmShareAck(data, from);
+  }
+
+  /**
    * Best-effort send of `PROTOCOL_SWM_SHARE_ACK` to the share's
    * publisher peer after a successful gossip-path apply.
    * Extracted into a named method so the receiver contract can
@@ -9142,16 +9191,33 @@ export class DKGAgent {
     if (publisherPeerId === selfPeerId) return;
 
     const ackBytes = encodeSwmShareAck({ shareOperationId, ackPeerId: selfPeerId });
+    // rc.9 PR-D codex follow-up #D1: use fire-and-forget
+    // `sendToPeer` instead of durable `sendReliable`. Pre-D1
+    // the ack went through the substrate outbox — but
+    // PROTOCOL_SWM_SHARE_ACK is a new rc.9-PR-D-only protocol,
+    // and during a rolling upgrade the publisher peer may not
+    // have it registered yet. A `sendReliable` to an
+    // unsupported protocol enqueues into the outbox and retries
+    // forever on protocol negotiation, accumulating a permanent
+    // queued row per received share. By contrast `sendToPeer`
+    // just delegates to `ProtocolRouter.send`: one network
+    // attempt, no envelope, no idempotency cache, no outbox row.
+    // On any failure (peer offline, protocol unsupported,
+    // stream reset) we WARN and drop — that's the right
+    // semantic anyway since acks are pure observability: a
+    // missed ack just means the watchdog will eventually fire
+    // substrate top-up, which the receiver dedups via
+    // `seenShareOps`. Losing an ack is recoverable; persisting
+    // a doomed retry forever is not.
     try {
-      await this.messenger.sendReliable(publisherPeerId, PROTOCOL_SWM_SHARE_ACK, ackBytes, {
-        messageId: `swm-share-ack-${shareOperationId}-${selfPeerId}`,
+      await this.messenger.sendToPeer(publisherPeerId, PROTOCOL_SWM_SHARE_ACK, ackBytes, {
         timeoutMs: DKGAgent.SWM_SUBSTRATE_FANOUT_TIMEOUT_MS,
       });
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       this.log.warn(
         createOperationContext('share', shareOperationId),
-        `SWM share ack to ${publisherPeerId} failed: ${reason}`,
+        `SWM share ack to ${publisherPeerId} failed (best-effort, watchdog will retry the share if quorum slips): ${reason}`,
       );
     }
   }

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -165,6 +165,7 @@ import {
   chooseFanOutTier,
   executeSubstrateFanOut,
   FANOUT_RESPONSE_REJECTED,
+  FANOUT_RESPONSE_RETRYABLE,
   type FanOutBookkeeper,
   type FanOutPeerRecord,
   type FanOutPlan,
@@ -1318,12 +1319,20 @@ export class DKGAgent {
    */
   private readonly swmSubstrateFanoutDelivered = new Map<string, number>();
   private readonly swmSubstrateFanoutRejected = new Map<string, number>();
+  /**
+   * rc.9 PR-D (codex follow-up from PR-G #G1): per-cgId count
+   * of substrate sends that returned the FANOUT_RESPONSE_RETRYABLE
+   * sentinel. NOT counted as delivered; SwmAckQuorum's watchdog
+   * fires substrate top-up.
+   */
+  private readonly swmSubstrateFanoutRetryable = new Map<string, number>();
   private readonly swmSubstrateFanoutQueued = new Map<string, number>();
   private readonly swmSubstrateFanoutInFlight = new Map<string, number>();
   private readonly swmSubstrateFanoutFailed = new Map<string, number>();
   private swmSubstrateFanoutOverflow = {
     delivered: 0,
     rejected: 0,
+    retryable: 0,
     queued: 0,
     inFlight: 0,
     failed: 0,
@@ -2026,9 +2035,15 @@ export class DKGAgent {
     // NOT bump for these responses. The application-level
     // truth (delivered vs rejected) lives in
     // `swm.substrateFanout.{delivered,rejected}`.
+    // rc.9 PR-D (codex follow-up from PR-G #G1): exclude BOTH
+    // the 0x01 (permanent) AND 0x02 (transient) sentinels from
+    // the protocol-level `delivered` count — neither maps to an
+    // application-level successful apply. The application-side
+    // truth (delivered / rejected / retryable) lives in
+    // `swm.substrateFanout.*`.
     this.messenger.setResponseDeliveredClassifier(
       PROTOCOL_SWM_UPDATE,
-      (response) => !(response.byteLength === 1 && response[0] === 0x01),
+      (response) => !(response.byteLength === 1 && (response[0] === 0x01 || response[0] === 0x02)),
     );
 
     // rc.9 PR-D: gossip-applied share acks. Receiver-only —
@@ -6154,22 +6169,25 @@ export class DKGAgent {
       return new Uint8Array();
     }
     if (outcome.retryable) {
-      // Throwing here is what tells the substrate outbox to keep
-      // the share queued. The router aborts the stream which the
-      // sender sees as a stream-reset error — `isRecoverableSendError`
-      // matches "reset"/"closed" substrings and enqueues into the
-      // outbox. `handle()` already logged the specific rejection
-      // at WARN/ERROR; the throw message just gives operators the
-      // hint when they grep for "swm apply" in receiver logs.
-      //
-      // (Codex flagged this as PR-G #G1 — the abort string
-      // matching is fragile. The proper fix is a wire sentinel
-      // PLUS a watchdog that reschedules retryable peers when
-      // libp2p drops the abort. That fix lands in PR-D where
-      // the watchdog exists; PR-G keeps the throw path so the
-      // outbox is still the safety net on transports where the
-      // abort happens to match.)
-      throw new Error(`SWM apply transient rejection from ${fromPeerId}: ${outcome.reason}`);
+      // rc.9 PR-D (codex follow-up from PR-G #G1): return the
+      // 0x02 sentinel instead of throwing. Pre-PR-D this branch
+      // threw, hoping libp2p would surface the handler abort as
+      // a recoverable stream-reset so `isRecoverableSendError`
+      // would re-queue into the outbox. That hope was fragile:
+      // the non-pooled ProtocolRouter aborts with the literal
+      // string "handler error", which doesn't match
+      // reset/closed/timeout — the share got DROPPED instead of
+      // queued. The sentinel sidesteps the abort path entirely:
+      // wire layer succeeds, sender's `classifySendResult`
+      // re-buckets 0x02 into the `retryable` outcome, the peer
+      // is NOT added to the pre-acked set, and SwmAckQuorum's
+      // watchdog fires substrate top-up at watchdogMs — giving
+      // upstream state time to converge before the retry.
+      this.log.info(
+        createOperationContext('share'),
+        `SWM substrate receiver transient rejection from ${fromPeerId} (PR-D watchdog will retry): ${outcome.reason}`,
+      );
+      return FANOUT_RESPONSE_RETRYABLE;
     }
     // Permanent rejection: signal via the 1-byte sentinel so the
     // sender records `rejected` (not `delivered`) and stops here.
@@ -6741,6 +6759,7 @@ export class DKGAgent {
             + `enumerated=${plan.enumeratedCount} `
             + `attempted=${substrateResult.attempted} `
             + `delivered=${substrateResult.delivered} rejected=${substrateResult.rejected} `
+            + `retryable=${substrateResult.retryable} `
             + `queued=${substrateResult.queued} `
             + `inFlight=${substrateResult.inFlight} failed=${substrateResult.failed} `
             + `also_gossiped=${plan.useGossip}`,
@@ -9444,6 +9463,7 @@ export class DKGAgent {
     switch (outcome) {
       case 'delivered': return this.swmSubstrateFanoutDelivered;
       case 'rejected':  return this.swmSubstrateFanoutRejected;
+      case 'retryable': return this.swmSubstrateFanoutRetryable;
       case 'queued':    return this.swmSubstrateFanoutQueued;
       case 'inFlight':  return this.swmSubstrateFanoutInFlight;
       case 'failed':    return this.swmSubstrateFanoutFailed;
@@ -9453,6 +9473,7 @@ export class DKGAgent {
   private substrateFanoutTotalForCg(cgId: string): number {
     return (this.swmSubstrateFanoutDelivered.get(cgId) ?? 0)
       + (this.swmSubstrateFanoutRejected.get(cgId) ?? 0)
+      + (this.swmSubstrateFanoutRetryable.get(cgId) ?? 0)
       + (this.swmSubstrateFanoutQueued.get(cgId) ?? 0)
       + (this.swmSubstrateFanoutInFlight.get(cgId) ?? 0)
       + (this.swmSubstrateFanoutFailed.get(cgId) ?? 0);
@@ -9479,6 +9500,7 @@ export class DKGAgent {
     const distinctCgIds = new Set<string>([
       ...this.swmSubstrateFanoutDelivered.keys(),
       ...this.swmSubstrateFanoutRejected.keys(),
+      ...this.swmSubstrateFanoutRetryable.keys(),
       ...this.swmSubstrateFanoutQueued.keys(),
       ...this.swmSubstrateFanoutInFlight.keys(),
       ...this.swmSubstrateFanoutFailed.keys(),
@@ -9498,11 +9520,13 @@ export class DKGAgent {
 
     this.swmSubstrateFanoutOverflow.delivered += this.swmSubstrateFanoutDelivered.get(smallestCg) ?? 0;
     this.swmSubstrateFanoutOverflow.rejected  += this.swmSubstrateFanoutRejected.get(smallestCg) ?? 0;
+    this.swmSubstrateFanoutOverflow.retryable += this.swmSubstrateFanoutRetryable.get(smallestCg) ?? 0;
     this.swmSubstrateFanoutOverflow.queued    += this.swmSubstrateFanoutQueued.get(smallestCg) ?? 0;
     this.swmSubstrateFanoutOverflow.inFlight  += this.swmSubstrateFanoutInFlight.get(smallestCg) ?? 0;
     this.swmSubstrateFanoutOverflow.failed    += this.swmSubstrateFanoutFailed.get(smallestCg) ?? 0;
     this.swmSubstrateFanoutDelivered.delete(smallestCg);
     this.swmSubstrateFanoutRejected.delete(smallestCg);
+    this.swmSubstrateFanoutRetryable.delete(smallestCg);
     this.swmSubstrateFanoutQueued.delete(smallestCg);
     this.swmSubstrateFanoutInFlight.delete(smallestCg);
     this.swmSubstrateFanoutFailed.delete(smallestCg);
@@ -9547,21 +9571,24 @@ export class DKGAgent {
   getSwmSubstrateFanoutStats(): {
     delivered: Record<string, number>;
     rejected: Record<string, number>;
+    retryable: Record<string, number>;
     queued: Record<string, number>;
     inFlight: Record<string, number>;
     failed: Record<string, number>;
-    overflow: { delivered: number; rejected: number; queued: number; inFlight: number; failed: number };
+    overflow: { delivered: number; rejected: number; retryable: number; queued: number; inFlight: number; failed: number };
     truncated: boolean;
   } {
     return {
       delivered: Object.fromEntries(this.swmSubstrateFanoutDelivered),
       rejected: Object.fromEntries(this.swmSubstrateFanoutRejected),
+      retryable: Object.fromEntries(this.swmSubstrateFanoutRetryable),
       queued: Object.fromEntries(this.swmSubstrateFanoutQueued),
       inFlight: Object.fromEntries(this.swmSubstrateFanoutInFlight),
       failed: Object.fromEntries(this.swmSubstrateFanoutFailed),
       overflow: {
         delivered: this.swmSubstrateFanoutOverflow.delivered,
         rejected: this.swmSubstrateFanoutOverflow.rejected,
+        retryable: this.swmSubstrateFanoutOverflow.retryable,
         queued: this.swmSubstrateFanoutOverflow.queued,
         inFlight: this.swmSubstrateFanoutOverflow.inFlight,
         failed: this.swmSubstrateFanoutOverflow.failed,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -108,6 +108,7 @@ export {
   chooseFanOutTier,
   executeSubstrateFanOut,
   FANOUT_RESPONSE_REJECTED,
+  FANOUT_RESPONSE_RETRYABLE,
   type ChooseFanOutTierInput,
   type FanOutPlan,
   type FanOutOutcome,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -106,6 +106,7 @@ export {
 } from './swm/enumerate-cg-members.js';
 export {
   chooseFanOutTier,
+  classifySendResult,
   executeSubstrateFanOut,
   FANOUT_RESPONSE_REJECTED,
   FANOUT_RESPONSE_RETRYABLE,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -117,5 +117,15 @@ export {
   type ExecuteSubstrateFanOutInput,
   type ExecuteSubstrateFanOutResult,
 } from './swm/substrate-fanout.js';
+export {
+  createSwmAckQuorum,
+  type SwmAckQuorum,
+  type SwmAckQuorumDeps,
+  type SwmAckQuorumObservers,
+  type SwmAckQuorumStats,
+  type SubstrateTopUp,
+  type TrackInput,
+  type TrackedRecordSnapshot,
+} from './swm/ack-quorum.js';
 export * from './source-worker.js';
 export * from './source-registry.js';

--- a/packages/agent/src/swm/ack-quorum.ts
+++ b/packages/agent/src/swm/ack-quorum.ts
@@ -1,0 +1,417 @@
+/**
+ * SWM ack-quorum overlay (rc.9 PR-D, RFC-003 §4.2 + §5).
+ *
+ * Sits beside `executeSubstrateFanOut` (PR-C) and the
+ * `publishWorkspaceGossip` egress point. Closes the per-recipient
+ * visibility gap that PR-C left open for the gossip path: substrate
+ * fan-out gets per-peer confirmation for free (each
+ * `messenger.sendReliable` returns a `delivered` flag), but the
+ * gossip leg of every share is fire-and-forget. For curated CGs
+ * (PR-C codex R2 made gossip the universal baseline) and for
+ * public CGs with members above `maxSubstrateMembers`, this
+ * component is what surfaces "who got the share" at the protocol
+ * level.
+ *
+ * Design choices, in order of importance:
+ *
+ *   1. **Substrate-acked peers pre-populate the `acked` set.**
+ *      A share that goes out via gossip + substrate ends up with
+ *      the substrate-delivered peers already counted as acked,
+ *      so the gossip-side `SwmShareAck` arrivals only fill in the
+ *      gossip-only-delivery-path subset of expectedMembers. This
+ *      gives one unified per-share quorum number that's not
+ *      double-counted across the two transports.
+ *
+ *   2. **No own timer.** The component exposes `tick(nowMs)` and
+ *      the caller (DKGAgent) wires it to a `setInterval`. Keeps
+ *      this module clock-pure for testing — every state
+ *      transition is deterministic on `track` / `onAck` / `tick`
+ *      inputs.
+ *
+ *   3. **Watchdog fires once per record.** The first `tick`
+ *      after `startedAtMs + watchdogMs` AND quorum-not-yet-met
+ *      dispatches the substrate top-up. Subsequent ticks before
+ *      deadline don't re-fire — if the top-up succeeded the acks
+ *      will land and complete quorum; if it failed, repeating it
+ *      every 5s would just amplify the wire-load for no benefit
+ *      (the substrate's own outbox has the retry budget). PR-G
+ *      may revisit if soak data shows the once-only policy
+ *      drops too many shares.
+ *
+ *   4. **Deadline reaps records.** At `startedAtMs + deadlineHardMs`,
+ *      a record is dropped from tracking regardless of ack state.
+ *      Offline peers fall through to `runSyncOnConnect` (the
+ *      catch-up safety net that PR-E migrated onto the reliable
+ *      substrate). Bounds in-memory state size per share: a record
+ *      lives for at most `deadlineHardMs` (default 5 minutes).
+ *
+ *   5. **In-memory only in PR-D.** No SQLite journal. A daemon
+ *      crash mid-share loses the tracking state but NOT the share
+ *      itself — the gossip publish already went out, the
+ *      substrate sends already enqueued into the outbox. The
+ *      worst case post-restart is "we don't run the watchdog
+ *      top-up for shares that were in flight at crash time" —
+ *      `runSyncOnConnect` covers those receivers when they next
+ *      connect. Persistent journaling is RFC §5.2 future work
+ *      (likely PR-G or PR-H), gated on whether the soak shows
+ *      crash-loss is a material reliability hit.
+ *
+ *   6. **Caller owns ack-emission policy.** This component does
+ *      NOT send `SwmShareAck` itself — the receiver-side wiring
+ *      in `SharedMemoryHandler` is what calls
+ *      `messenger.sendReliable(authorPeer, PROTOCOL_SWM_SHARE_ACK, ...)`
+ *      after a successful gossip apply. Decoupled because the
+ *      receiver doesn't have an `SwmAckQuorum` instance — it's a
+ *      sender-side concept.
+ */
+
+import type { CGMemberEnumeration } from './enumerate-cg-members.js';
+
+/**
+ * Top-up callback. Invoked when the watchdog fires (gossip-only
+ * delivery quorum not met within `watchdogMs`). The component
+ * supplies the SAME wire bytes the original share fanned out with,
+ * plus the residual peer set (`expectedMembers \ acked`), and the
+ * caller is expected to fan those out via the substrate exactly
+ * like PR-C's `executeSubstrateFanOut`.
+ *
+ * MUST not throw — implementations should swallow + log so a
+ * misbehaving top-up dispatch doesn't crash the periodic tick.
+ * (We swallow internally too, as a belt-and-braces.)
+ */
+export type SubstrateTopUp = (input: {
+  shareOperationId: string;
+  cgId: string;
+  payload: Uint8Array;
+  missingPeers: readonly string[];
+}) => void | Promise<void>;
+
+/** Optional observability hooks. All callbacks are best-effort and must not throw. */
+export interface SwmAckQuorumObservers {
+  onQuorumCompleted?: (input: {
+    shareOperationId: string;
+    cgId: string;
+    ackedCount: number;
+    expectedCount: number;
+    ackPct: number;
+  }) => void;
+  onWatchdogFired?: (input: {
+    shareOperationId: string;
+    cgId: string;
+    missingCount: number;
+    expectedCount: number;
+  }) => void;
+  onDeadlineExpired?: (input: {
+    shareOperationId: string;
+    cgId: string;
+    ackedCount: number;
+    expectedCount: number;
+    ackPct: number;
+  }) => void;
+}
+
+export interface SwmAckQuorumDeps {
+  substrateTopUp: SubstrateTopUp;
+  observers?: SwmAckQuorumObservers;
+  /** Defaults to `Date.now`; override in tests for deterministic timing. */
+  now?: () => number;
+}
+
+/**
+ * Input to {@link SwmAckQuorum.track}. The caller (DKGAgent's
+ * `publishWorkspaceGossip`) bundles everything the component
+ * needs to drive a single share to completion or deadline.
+ */
+export interface TrackInput {
+  shareOperationId: string;
+  cgId: string;
+  /**
+   * The full enumerated recipient set for the gossip leg. The
+   * component does NOT mutate this set; it lives as the
+   * authoritative denominator for the quorum calculation. Empty
+   * sets are rejected (`track` is a no-op) — there's nothing to
+   * wait for.
+   */
+  expectedMembers: readonly string[];
+  /**
+   * Peers the substrate fan-out (PR-C) already delivered to. These
+   * are pre-populated into the `acked` set so the gossip-side
+   * acks only need to cover the gap. Empty when the plan was
+   * gossip-only (public CG above `maxSubstrateMembers`, or
+   * `source: 'none'`).
+   */
+  preAckedFromSubstrate?: readonly string[];
+  /**
+   * The wire bytes that went out via gossip. Held in the tracking
+   * record so the watchdog can pass them to {@link SubstrateTopUp}
+   * verbatim — receivers are idempotent on (shareOperationId,
+   * payload), so a top-up with the same payload as the original
+   * gossip is the explicit design.
+   */
+  payload: Uint8Array;
+  /**
+   * Fraction of `expectedMembers` that must ack before the share
+   * is considered "complete" and the record removed. Default
+   * 0.9 per RFC-003 §5.1. Clamped to [0, 1] on track.
+   */
+  quorumThreshold?: number;
+  /**
+   * Milliseconds after `track()` before the watchdog fires
+   * substrate top-up for non-acked peers. Default 30_000 per
+   * RFC-003 §5.2.
+   */
+  watchdogMs?: number;
+  /**
+   * Hard cap on a record's tracking lifetime. After this elapses,
+   * the record is reaped regardless of ack state and offline peers
+   * fall through to `runSyncOnConnect`. Default 5 * 60_000 per
+   * RFC-003 §5.2.
+   */
+  deadlineHardMs?: number;
+  /**
+   * Enumeration source that produced `expectedMembers`. Surfaced
+   * on the observer callbacks so /api/slo can break down
+   * completion / watchdog / deadline counts by allowlist vs
+   * topic-subscribers vs none. Mirrors PR-C's
+   * `FanOutPlan.enumerationSource`.
+   */
+  enumerationSource: CGMemberEnumeration['source'];
+}
+
+/** Snapshot returned by {@link SwmAckQuorum.stats}. */
+export interface SwmAckQuorumStats {
+  /** Total `track()` calls since construction (cumulative). */
+  tracked: number;
+  /** Records that reached quorum (cumulative). */
+  completed: number;
+  /** Watchdog dispatch count (cumulative — at most one per record). */
+  watchdogFired: number;
+  /** Records reaped at `deadlineHardMs` without reaching quorum (cumulative). */
+  deadlineExpired: number;
+  /** Currently-tracked record count (gauge — instantaneous). */
+  pending: number;
+}
+
+/**
+ * In-memory ack-quorum tracker. Construct ONE per `DKGAgent` and
+ * route every gossip-fanned-out share through it. Pure — `now()`
+ * is the only injectable side, and {@link tick} is the only entry
+ * that advances time-driven state.
+ */
+export interface SwmAckQuorum {
+  track(input: TrackInput): void;
+  onAck(shareOperationId: string, fromPeerId: string): void;
+  tick(nowMs?: number): void;
+  stats(): SwmAckQuorumStats;
+  /** Test/debug helper: snapshot a single record by id (or undefined if not tracked). */
+  inspect(shareOperationId: string): TrackedRecordSnapshot | undefined;
+}
+
+/** Read-only snapshot returned by {@link SwmAckQuorum.inspect}. */
+export interface TrackedRecordSnapshot {
+  shareOperationId: string;
+  cgId: string;
+  expectedMembers: readonly string[];
+  acked: readonly string[];
+  ackPct: number;
+  watchdogFired: boolean;
+  startedAtMs: number;
+  watchdogMs: number;
+  deadlineHardMs: number;
+  enumerationSource: CGMemberEnumeration['source'];
+}
+
+const DEFAULT_QUORUM_THRESHOLD = 0.9;
+const DEFAULT_WATCHDOG_MS = 30_000;
+const DEFAULT_DEADLINE_HARD_MS = 5 * 60_000;
+
+interface TrackedRecord {
+  shareOperationId: string;
+  cgId: string;
+  expectedMembers: Set<string>;
+  acked: Set<string>;
+  payload: Uint8Array;
+  quorumThreshold: number;
+  watchdogMs: number;
+  deadlineHardMs: number;
+  startedAtMs: number;
+  watchdogFired: boolean;
+  enumerationSource: CGMemberEnumeration['source'];
+}
+
+export function createSwmAckQuorum(deps: SwmAckQuorumDeps): SwmAckQuorum {
+  const now = deps.now ?? (() => Date.now());
+  const observers = deps.observers ?? {};
+  const records = new Map<string, TrackedRecord>();
+
+  let trackedCount = 0;
+  let completedCount = 0;
+  let watchdogFiredCount = 0;
+  let deadlineExpiredCount = 0;
+
+  function ackPctOf(record: TrackedRecord): number {
+    if (record.expectedMembers.size === 0) return 1;
+    return record.acked.size / record.expectedMembers.size;
+  }
+
+  /**
+   * Mark a record complete + invoke the observer + delete it from
+   * the tracking map. Idempotent on `shareOperationId` (the
+   * `records.delete` is the gate).
+   */
+  function completeRecord(record: TrackedRecord): void {
+    if (!records.delete(record.shareOperationId)) return;
+    completedCount += 1;
+    safeInvoke(() => observers.onQuorumCompleted?.({
+      shareOperationId: record.shareOperationId,
+      cgId: record.cgId,
+      ackedCount: record.acked.size,
+      expectedCount: record.expectedMembers.size,
+      ackPct: ackPctOf(record),
+    }));
+  }
+
+  function expireRecord(record: TrackedRecord): void {
+    if (!records.delete(record.shareOperationId)) return;
+    deadlineExpiredCount += 1;
+    safeInvoke(() => observers.onDeadlineExpired?.({
+      shareOperationId: record.shareOperationId,
+      cgId: record.cgId,
+      ackedCount: record.acked.size,
+      expectedCount: record.expectedMembers.size,
+      ackPct: ackPctOf(record),
+    }));
+  }
+
+  function fireWatchdog(record: TrackedRecord): void {
+    record.watchdogFired = true;
+    watchdogFiredCount += 1;
+    const missingPeers: string[] = [];
+    for (const peer of record.expectedMembers) {
+      if (!record.acked.has(peer)) missingPeers.push(peer);
+    }
+    safeInvoke(() => observers.onWatchdogFired?.({
+      shareOperationId: record.shareOperationId,
+      cgId: record.cgId,
+      missingCount: missingPeers.length,
+      expectedCount: record.expectedMembers.size,
+    }));
+    safeInvoke(() => {
+      const r = deps.substrateTopUp({
+        shareOperationId: record.shareOperationId,
+        cgId: record.cgId,
+        payload: record.payload,
+        missingPeers,
+      });
+      if (r && typeof (r as Promise<void>).catch === 'function') {
+        (r as Promise<void>).catch(() => { /* swallowed; caller logs */ });
+      }
+    });
+  }
+
+  return {
+    track(input: TrackInput): void {
+      if (input.expectedMembers.length === 0) return;
+      if (records.has(input.shareOperationId)) return;
+
+      const threshold = clamp01(input.quorumThreshold ?? DEFAULT_QUORUM_THRESHOLD);
+      const expectedMembers = new Set(input.expectedMembers);
+      const acked = new Set<string>();
+      for (const p of input.preAckedFromSubstrate ?? []) {
+        if (expectedMembers.has(p)) acked.add(p);
+      }
+
+      const record: TrackedRecord = {
+        shareOperationId: input.shareOperationId,
+        cgId: input.cgId,
+        expectedMembers,
+        acked,
+        payload: input.payload,
+        quorumThreshold: threshold,
+        watchdogMs: Math.max(0, input.watchdogMs ?? DEFAULT_WATCHDOG_MS),
+        deadlineHardMs: Math.max(0, input.deadlineHardMs ?? DEFAULT_DEADLINE_HARD_MS),
+        startedAtMs: now(),
+        watchdogFired: false,
+        enumerationSource: input.enumerationSource,
+      };
+      records.set(record.shareOperationId, record);
+      trackedCount += 1;
+
+      if (ackPctOf(record) >= record.quorumThreshold) {
+        completeRecord(record);
+      }
+    },
+
+    onAck(shareOperationId: string, fromPeerId: string): void {
+      const record = records.get(shareOperationId);
+      if (!record) return;
+      if (!record.expectedMembers.has(fromPeerId)) return;
+      if (record.acked.has(fromPeerId)) return;
+      record.acked.add(fromPeerId);
+
+      if (ackPctOf(record) >= record.quorumThreshold) {
+        completeRecord(record);
+      }
+    },
+
+    tick(nowMs?: number): void {
+      const t = nowMs ?? now();
+      for (const record of [...records.values()]) {
+        const age = t - record.startedAtMs;
+        if (age >= record.deadlineHardMs) {
+          expireRecord(record);
+          continue;
+        }
+        if (!record.watchdogFired && age >= record.watchdogMs) {
+          if (ackPctOf(record) < record.quorumThreshold) {
+            fireWatchdog(record);
+          }
+        }
+      }
+    },
+
+    stats(): SwmAckQuorumStats {
+      return {
+        tracked: trackedCount,
+        completed: completedCount,
+        watchdogFired: watchdogFiredCount,
+        deadlineExpired: deadlineExpiredCount,
+        pending: records.size,
+      };
+    },
+
+    inspect(shareOperationId: string): TrackedRecordSnapshot | undefined {
+      const record = records.get(shareOperationId);
+      if (!record) return undefined;
+      return {
+        shareOperationId: record.shareOperationId,
+        cgId: record.cgId,
+        expectedMembers: [...record.expectedMembers],
+        acked: [...record.acked],
+        ackPct: ackPctOf(record),
+        watchdogFired: record.watchdogFired,
+        startedAtMs: record.startedAtMs,
+        watchdogMs: record.watchdogMs,
+        deadlineHardMs: record.deadlineHardMs,
+        enumerationSource: record.enumerationSource,
+      };
+    },
+  };
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_QUORUM_THRESHOLD;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function safeInvoke(fn: () => void): void {
+  try {
+    fn();
+  } catch {
+    // observers/top-up callbacks are best-effort; never let them
+    // crash the periodic tick — operator metrics matter more than
+    // strict propagation.
+  }
+}

--- a/packages/agent/src/swm/substrate-fanout.ts
+++ b/packages/agent/src/swm/substrate-fanout.ts
@@ -253,6 +253,32 @@ export type FanOutOutcome =
   // codex R6 caught that bundling them overstated end-to-end
   // success in `/api/slo`'s `swm.substrateFanout.delivered`.
   | 'rejected'
+  // rc.9 PR-D (codex follow-up from PR-G #G1, deferred here so
+  // it lands together with the watchdog that actually
+  // reschedules retryable peers): `messenger.sendReliable`
+  // returned `delivered: true` but the receiver's response was
+  // the {@link FANOUT_RESPONSE_RETRYABLE} sentinel — the
+  // receiver saw a TRANSIENT rejection (CAS pre-condition not
+  // yet met; upstream writes pending). The sender does NOT
+  // count this as delivered; SwmAckQuorum's watchdog handles
+  // the actual re-send by leaving the peer out of the pre-acked
+  // set so it falls through to the expectedMembers∖acked window
+  // and substrate top-up fires at watchdogMs.
+  //
+  // Pre-PR-D the receiver THREW on retryable rejections, hoping
+  // libp2p would surface the handler-abort as a recoverable
+  // stream-reset that `isRecoverableSendError()` would re-queue
+  // into the outbox. That hope was fragile: the non-pooled
+  // ProtocolRouter aborts with the literal string `"handler
+  // error"`, which matches none of the recoverable substrings,
+  // so the share got DROPPED instead of queued. The sentinel
+  // is deterministic — receiver returns the byte at the wire
+  // layer, sender's classifier re-buckets it into 'retryable',
+  // SwmAckQuorum's watchdog fires top-up. NOTE the throw path
+  // remains in handleSwmUpdate as the fallback when PR-D's
+  // watchdog is disabled (test seam / config flag), so the
+  // pre-PR-D behaviour is recoverable.
+  | 'retryable'
   // `messenger.sendReliable` returned `delivered: false, queued:
   // true`. Persisted into the durable substrate outbox; will be
   // retried by `Messenger.processOutboxTick` and on the next
@@ -296,6 +322,23 @@ export type FanOutOutcome =
  *     further runs on a normal response).
  */
 export const FANOUT_RESPONSE_REJECTED: Uint8Array = new Uint8Array([0x01]);
+
+/**
+ * rc.9 PR-D (codex follow-up from PR-G #G1, deferred here so
+ * it lands together with the SwmAckQuorum watchdog). Wire
+ * sentinel returned by the substrate receiver for TRANSIENT
+ * rejections — the receiver couldn't apply the share right
+ * now (CAS pre-condition not yet met) but the same wire bytes
+ * might apply successfully on retry once upstream state
+ * converges.
+ *
+ * Older substrate senders (pre-PR-D) treat 0x02 identically to
+ * 0x01 — opaque non-empty byte → `delivered: true` in their
+ * classifier. Slight metric overcount during rolling rc.9 PR-C
+ * → PR-D upgrades; no behavioural regression since receivers
+ * still dedup via `seenShareOps` (PR-A).
+ */
+export const FANOUT_RESPONSE_RETRYABLE: Uint8Array = new Uint8Array([0x02]);
 
 /**
  * Per-peer record handed to {@link FanOutBookkeeper.recordOutcome}.
@@ -359,6 +402,13 @@ export interface ExecuteSubstrateFanOutResult {
   delivered: number;
   /** Permanent receiver-side rejections — sender drops, NOT counted as delivered (PR-C codex R6). */
   rejected: number;
+  /**
+   * Transient receiver-side rejections — sender does NOT count
+   * as delivered; SwmAckQuorum's watchdog (PR-D) fires substrate
+   * top-up at watchdogMs so upstream state has time to converge
+   * before retry (codex follow-up from PR-G #G1, landed here).
+   */
+  retryable: number;
   queued: number;
   inFlight: number;
   failed: number;
@@ -385,6 +435,7 @@ export async function executeSubstrateFanOut(
     attempted: members.length,
     delivered: 0,
     rejected: 0,
+    retryable: 0,
     queued: 0,
     inFlight: 0,
     failed: 0,
@@ -412,6 +463,9 @@ export async function executeSubstrateFanOut(
         break;
       case 'rejected':
         result.rejected += 1;
+        break;
+      case 'retryable':
+        result.retryable += 1;
         break;
       case 'queued':
         result.queued += 1;
@@ -446,6 +500,18 @@ function classifySendResult(peerId: string, sendResult: ReliableSendResult): Fan
         attempts: sendResult.attempts,
         messageId: sendResult.messageId,
         error: 'receiver returned FANOUT_RESPONSE_REJECTED sentinel (permanent rejection)',
+      };
+    }
+    // rc.9 PR-D (codex follow-up from PR-G #G1): the 0x02
+    // sentinel means TRANSIENT rejection — SwmAckQuorum's
+    // watchdog will fire substrate top-up at watchdogMs.
+    if (isRetryableSentinel(sendResult.response)) {
+      return {
+        peerId,
+        outcome: 'retryable',
+        attempts: sendResult.attempts,
+        messageId: sendResult.messageId,
+        error: 'receiver returned FANOUT_RESPONSE_RETRYABLE sentinel (transient rejection)',
       };
     }
     return {
@@ -500,4 +566,8 @@ function classifySendResult(peerId: string, sendResult: ReliableSendResult): Fan
  */
 function isRejectionSentinel(response: Uint8Array | undefined): boolean {
   return response !== undefined && response.byteLength === 1 && response[0] === 0x01;
+}
+
+function isRetryableSentinel(response: Uint8Array | undefined): boolean {
+  return response !== undefined && response.byteLength === 1 && response[0] === 0x02;
 }

--- a/packages/agent/src/swm/substrate-fanout.ts
+++ b/packages/agent/src/swm/substrate-fanout.ts
@@ -483,7 +483,17 @@ export async function executeSubstrateFanOut(
   return result;
 }
 
-function classifySendResult(peerId: string, sendResult: ReliableSendResult): FanOutPeerRecord {
+/**
+ * Map a `ReliableSendResult` (the messenger's send-time outcome)
+ * onto the application-level {@link FanOutOutcome}. Exported so
+ * the watchdog/top-up path (rc.9 PR-D #D6) can reuse the EXACT
+ * same classification rules as the main fan-out — keeping
+ * sentinel handling (`FANOUT_RESPONSE_REJECTED`,
+ * `FANOUT_RESPONSE_RETRYABLE`), queued/inFlight policy, and
+ * error-string conventions in a single place. Pure function;
+ * no I/O.
+ */
+export function classifySendResult(peerId: string, sendResult: ReliableSendResult): FanOutPeerRecord {
   if (sendResult.delivered) {
     // PR-C codex R6: receivers signal permanent rejection (peer
     // not in allowlist, bad signature, validation failure) with

--- a/packages/agent/src/swm/substrate-fanout.ts
+++ b/packages/agent/src/swm/substrate-fanout.ts
@@ -99,6 +99,23 @@ export interface FanOutPlan {
    */
   substrateMembers: readonly string[];
   /**
+   * Full enumerated recipient set, regardless of whether the
+   * substrate leg actually targets each peer. Equals
+   * `substrateMembers` when `useSubstrate === true`. When
+   * `useSubstrate === false` for a public CG above
+   * `maxSubstrateMembers`, this still carries every subscriber
+   * the enumerator returned — so PR-D's `SwmAckQuorum` can track
+   * the full expected delivery set for large public CGs (where
+   * gossip is the ONLY transport and ack feedback is the only
+   * way to know who actually got the share).
+   *
+   * Added in rc.9 PR-D codex follow-up #D3. Pre-D3 the
+   * `SwmAckQuorum` track gate keyed off `substrateMembers.length
+   * > 0`, which silently disabled the watchdog for the entire
+   * gossip-only-because-too-many-subscribers branch.
+   */
+  enumeratedMembers: readonly string[];
+  /**
    * The {@link CGMemberEnumeration.source} that drove the
    * decision. Surfaced for observability (log lines / per-tier
    * metric breakdown / soak postmortem).
@@ -179,6 +196,7 @@ export function chooseFanOutTier(input: ChooseFanOutTierInput): FanOutPlan {
         useSubstrate: true,
         useGossip: true,
         substrateMembers: enumeration.members,
+        enumeratedMembers: enumeration.members,
         enumerationSource: 'allowlist',
         enumeratedCount,
       };
@@ -188,14 +206,21 @@ export function chooseFanOutTier(input: ChooseFanOutTierInput): FanOutPlan {
           useSubstrate: true,
           useGossip: true,
           substrateMembers: enumeration.members,
+          enumeratedMembers: enumeration.members,
           enumerationSource: 'topic-subscribers',
           enumeratedCount,
         };
       }
+      // rc.9 PR-D codex follow-up #D3: keep the full subscriber
+      // list on `enumeratedMembers` even when we drop substrate.
+      // SwmAckQuorum needs it to track expected delivery for
+      // large public CGs (gossip-only) — pre-D3 the watchdog
+      // was silently disabled here.
       return {
         useSubstrate: false,
         useGossip: true,
         substrateMembers: [],
+        enumeratedMembers: enumeration.members,
         enumerationSource: 'topic-subscribers',
         enumeratedCount,
       };
@@ -204,6 +229,7 @@ export function chooseFanOutTier(input: ChooseFanOutTierInput): FanOutPlan {
         useSubstrate: false,
         useGossip: true,
         substrateMembers: [],
+        enumeratedMembers: [],
         enumerationSource: 'none',
         enumeratedCount,
       };

--- a/packages/agent/test/swm-ack-quorum-integration.test.ts
+++ b/packages/agent/test/swm-ack-quorum-integration.test.ts
@@ -1,0 +1,315 @@
+/**
+ * rc.9 PR-D integration test for the SwmAckQuorum wiring inside
+ * DKGAgent. The component itself is covered by
+ * `swm-ack-quorum.test.ts`; this file pins the AGENT-side wiring:
+ *
+ *   1. `share()` registers tracking when preconditions hold
+ *      (shareOperationId set, gossip leg active, substrateMembers
+ *      non-empty).
+ *   2. PROTOCOL_SWM_SHARE_ACK arrivals route into
+ *      `swmAckQuorum.onAck()` and count toward quorum.
+ *   3. Pre-acked substrate peers (PR-C delivered set) feed
+ *      `preAckedFromSubstrate` so a hybrid share that already met
+ *      quorum via substrate doesn't fight a watchdog race.
+ *   4. The gossip-applied path of `SharedMemoryHandler.handle()`
+ *      emits a SwmShareAck back to the publisher.
+ *   5. `getSwmAckQuorumStats()` returns pristine zeroes before any
+ *      share, and reflects the right counters after.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  PROTOCOL_SWM_UPDATE,
+  PROTOCOL_SWM_SHARE_ACK,
+  encodeSwmShareAck,
+} from '@origintrail-official/dkg-core';
+import { DKGAgent } from '../src/index.js';
+import type { ReliableSendResult } from '../src/p2p/messenger.js';
+
+const SELF_PEER = '12D3KooWSelfPubD';
+
+class CapturingGossip {
+  publishes: Array<{ topic: string; bytes: number }> = [];
+  subscribers: string[] = [];
+
+  subscribe(_topic: string): void {}
+  unsubscribe(_topic: string): void {}
+  onMessage(_topic: string, _handler: (topic: string, data: Uint8Array, from?: string) => void | Promise<void>): void {}
+  async publish(topic: string, data: Uint8Array): Promise<void> {
+    this.publishes.push({ topic, bytes: data.byteLength });
+  }
+  getSubscribers(_topic: string): string[] {
+    return [...this.subscribers];
+  }
+}
+
+interface SendReliableCall {
+  peerId: string;
+  protocolId: string;
+  bytes: number;
+  messageId?: string;
+}
+
+/**
+ * Stub `messenger.sendReliable` with two extras over the PR-C
+ * integration helper:
+ *   - Capture `messageId` (we assert top-up uses the documented
+ *     `swm-topup-` prefix).
+ *   - Default to a successful delivery if the lookup returns
+ *     undefined, so ack-quorum top-up calls don't blow up just
+ *     because the test only configured the initial fan-out
+ *     responses.
+ */
+function stubMessengerSendReliable(
+  results: Map<string, ReliableSendResult> | ((peerId: string, protocolId: string, messageId?: string) => ReliableSendResult | Error),
+): { calls: SendReliableCall[]; install: (agent: DKGAgent) => void } {
+  const calls: SendReliableCall[] = [];
+  const lookup = typeof results === 'function'
+    ? results
+    : (peerId: string): ReliableSendResult | Error => {
+      const r = results.get(peerId);
+      if (!r) {
+        return {
+          delivered: true,
+          response: new Uint8Array(),
+          attempts: 1,
+          messageId: 'stub-default-ok',
+        };
+      }
+      return r;
+    };
+  const install = (agent: DKGAgent): void => {
+    const stub = {
+      sendReliable: async (
+        peerId: string,
+        protocolId: string,
+        payload: Uint8Array,
+        opts?: { messageId?: string },
+      ): Promise<ReliableSendResult> => {
+        calls.push({ peerId, protocolId, bytes: payload.byteLength, messageId: opts?.messageId });
+        const out = lookup(peerId, protocolId, opts?.messageId);
+        if (out instanceof Error) throw out;
+        return out;
+      },
+    };
+    (agent as unknown as { messenger: typeof stub }).messenger = stub;
+  };
+  return { calls, install };
+}
+
+async function createAgent(name: string): Promise<DKGAgent> {
+  const agent = await DKGAgent.create({
+    name: `${name}-${Math.random().toString(36).slice(2)}`,
+    chainAdapter: new MockChainAdapter(),
+  });
+  Object.defineProperty((agent as unknown as { node: object }).node, 'peerId', {
+    value: SELF_PEER,
+    configurable: true,
+  });
+  return agent;
+}
+
+describe('DKGAgent SwmAckQuorum integration (rc.9 PR-D)', () => {
+  let createdAgents: DKGAgent[] = [];
+
+  beforeAll(() => {
+    createdAgents = [];
+  });
+
+  afterAll(async () => {
+    // Stop each created agent so the 5s ack-quorum tick + any
+    // other intervals it owns are cleared. The timers use
+    // `.unref()` so they wouldn't block process exit, but
+    // stopping is the documented contract.
+    await Promise.allSettled(createdAgents.map(async (a) => {
+      const maybeStop = a as unknown as { stop?: () => Promise<void> };
+      if (typeof maybeStop.stop === 'function') {
+        try { await maybeStop.stop(); } catch { /* test-shape stub agent */ }
+      }
+    }));
+  });
+
+  function register(agent: DKGAgent): DKGAgent {
+    createdAgents.push(agent);
+    return agent;
+  }
+
+  it('cold-start: getSwmAckQuorumStats returns pristine zeroes', async () => {
+    const agent = register(await createAgent('AckQuorumCold'));
+    expect(agent.getSwmAckQuorumStats()).toEqual({
+      tracked: 0,
+      completed: 0,
+      watchdogFired: 0,
+      deadlineExpired: 0,
+      pending: 0,
+    });
+  });
+
+  it('share() registers tracking after fan-out, substrate-delivered peers pre-ack', async () => {
+    const agent = register(await createAgent('AckQuorumTrack'));
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWPeerA', '12D3KooWPeerB', '12D3KooWPeerC'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { install } = stubMessengerSendReliable(new Map([
+      ['12D3KooWPeerA', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mA' }],
+      ['12D3KooWPeerB', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mB' }],
+      ['12D3KooWPeerC', {
+        delivered: false, queued: true, attempts: 1, messageId: 'mC',
+        error: 'transient', nextAttemptAtMs: Date.now() + 1000,
+      }],
+    ]));
+    install(agent);
+
+    await agent.share('cg-ackquorum-track', [{
+      subject: 'urn:test:track', predicate: 'http://schema.org/name', object: '"hi"', graph: '',
+    }]);
+
+    const stats = agent.getSwmAckQuorumStats();
+    expect(stats.tracked).toBe(1);
+    expect(stats.pending).toBe(1);
+    expect(stats.completed).toBe(0);
+  });
+
+  it('substrate-only-delivery reaches quorum at track time (no gossip ack needed)', async () => {
+    const agent = register(await createAgent('AckQuorumAllSubstrate'));
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWPeerX', '12D3KooWPeerY'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { install } = stubMessengerSendReliable(new Map([
+      ['12D3KooWPeerX', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mX' }],
+      ['12D3KooWPeerY', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mY' }],
+    ]));
+    install(agent);
+
+    await agent.share('cg-ackquorum-all-substrate', [{
+      subject: 'urn:test:all', predicate: 'http://schema.org/name', object: '"all"', graph: '',
+    }]);
+
+    const stats = agent.getSwmAckQuorumStats();
+    expect(stats.tracked).toBe(1);
+    expect(stats.completed).toBe(1);
+    expect(stats.pending).toBe(0);
+    expect(stats.watchdogFired).toBe(0);
+  });
+
+  it('PROTOCOL_SWM_SHARE_ACK arrival increments acked count + completes quorum when threshold met', async () => {
+    const agent = register(await createAgent('AckQuorumAckArrival'));
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWPeer1', '12D3KooWPeer2', '12D3KooWPeer3'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { install } = stubMessengerSendReliable((_peerId, _proto, _msg) => ({
+      delivered: false, queued: true, attempts: 1, messageId: 'queued-' + Math.random().toString(36).slice(2),
+      error: 'transient', nextAttemptAtMs: Date.now() + 1000,
+    }));
+    install(agent);
+
+    await agent.share('cg-ackquorum-arrivals', [{
+      subject: 'urn:test:arr', predicate: 'http://schema.org/name', object: '"arr"', graph: '',
+    }]);
+
+    let stats = agent.getSwmAckQuorumStats();
+    expect(stats.tracked).toBe(1);
+    expect(stats.completed).toBe(0);
+    expect(stats.pending).toBe(1);
+
+    const messengerRegistrations = (agent as unknown as {
+      messenger: { register?: (proto: string, handler: (data: Uint8Array, from: string) => Promise<Uint8Array>) => void };
+    }).messenger;
+    // The stub doesn't have `register` — the production register
+    // already ran in DKGAgent.create() against the real Messenger
+    // (which got swapped out by stubMessengerSendReliable above).
+    // For this test we invoke the PR-D-added ack handler directly
+    // via the same code path it would be invoked from, by reaching
+    // into the quorum tracker.
+    void messengerRegistrations;
+    const quorum = (agent as unknown as {
+      getOrCreateSwmAckQuorum: () => { onAck: (op: string, peer: string) => void; stats: () => { tracked: number; completed: number; watchdogFired: number; deadlineExpired: number; pending: number } };
+    }).getOrCreateSwmAckQuorum();
+
+    // Look up the tracked record's shareOperationId by inspecting
+    // the only tracked record. We do this through the existing
+    // public `inspect()` API on the component once we have its
+    // id — but we don't have the id yet, so use the test-only
+    // stats `tracked === 1` invariant to confirm there's exactly
+    // one.
+    // For a deterministic test, we know `share()` returned the
+    // shareOperationId, so let's redo this with that.
+
+    expect(quorum.stats().pending).toBe(1);
+  });
+
+  it('share() returns shareOperationId — ack arrivals for it complete quorum', async () => {
+    const agent = register(await createAgent('AckQuorumWithId'));
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWPeerQ1', '12D3KooWPeerQ2', '12D3KooWPeerQ3', '12D3KooWPeerQ4'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { install } = stubMessengerSendReliable(() => ({
+      delivered: false, queued: true, attempts: 1, messageId: 'q-' + Math.random().toString(36).slice(2),
+      error: 'transient', nextAttemptAtMs: Date.now() + 1000,
+    }));
+    install(agent);
+
+    const { shareOperationId } = await agent.share('cg-ackquorum-byid', [{
+      subject: 'urn:test:byid', predicate: 'http://schema.org/name', object: '"byid"', graph: '',
+    }]);
+    expect(typeof shareOperationId).toBe('string');
+
+    const quorum = (agent as unknown as {
+      getOrCreateSwmAckQuorum: () => {
+        onAck: (op: string, peer: string) => void;
+        stats: () => { tracked: number; completed: number; watchdogFired: number; deadlineExpired: number; pending: number };
+        inspect: (op: string) => { acked: readonly string[]; expectedMembers: readonly string[]; ackPct: number } | undefined;
+      };
+    }).getOrCreateSwmAckQuorum();
+
+    expect(quorum.inspect(shareOperationId)?.expectedMembers.sort())
+      .toEqual(['12D3KooWPeerQ1', '12D3KooWPeerQ2', '12D3KooWPeerQ3', '12D3KooWPeerQ4']);
+
+    quorum.onAck(shareOperationId, '12D3KooWPeerQ1');
+    quorum.onAck(shareOperationId, '12D3KooWPeerQ2');
+    quorum.onAck(shareOperationId, '12D3KooWPeerQ3');
+    expect(quorum.stats().completed).toBe(0);
+
+    quorum.onAck(shareOperationId, '12D3KooWPeerQ4');
+    expect(quorum.stats().completed).toBe(1);
+    expect(quorum.inspect(shareOperationId)).toBeUndefined();
+  });
+
+  it('legacy callers (no shareOperationId on publishWorkspaceGossip) do not register tracking', async () => {
+    const agent = register(await createAgent('AckQuorumLegacy'));
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWLegacyPeer'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { install } = stubMessengerSendReliable(new Map([
+      ['12D3KooWLegacyPeer', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'mL' }],
+    ]));
+    install(agent);
+
+    const internals = agent as unknown as {
+      publishWorkspaceGossip: (cgId: string, msg: Uint8Array, ctx: unknown, signer: unknown) => Promise<void>;
+    };
+    const dummyMessage = new TextEncoder().encode('not-a-real-wire-message');
+    await internals.publishWorkspaceGossip('cg-legacy-caller', dummyMessage, { operationId: 'test' }, null);
+
+    const stats = agent.getSwmAckQuorumStats();
+    expect(stats.tracked).toBe(0);
+    expect(stats.pending).toBe(0);
+  });
+
+  it('SwmShareAck wire shape: handler accepts the same bytes encodeSwmShareAck produces', () => {
+    const bytes = encodeSwmShareAck({
+      shareOperationId: 'op-roundtrip',
+      ackPeerId: '12D3KooWAckRoundtrip',
+    });
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.byteLength).toBeGreaterThan(0);
+    expect(PROTOCOL_SWM_SHARE_ACK).toBe('/dkg/10.0.1/swm-share-ack');
+    expect(PROTOCOL_SWM_UPDATE).toBe('/dkg/10.0.1/swm-update');
+  });
+});

--- a/packages/agent/test/swm-ack-quorum-integration.test.ts
+++ b/packages/agent/test/swm-ack-quorum-integration.test.ts
@@ -92,6 +92,27 @@ function stubMessengerSendReliable(
         if (out instanceof Error) throw out;
         return out;
       },
+      // rc.9 PR-D codex follow-up #D1: ack emission uses
+      // fire-and-forget `sendToPeer` instead of durable
+      // `sendReliable`. We capture into the same `calls` array
+      // so existing assertions see both kinds of sends; the
+      // `protocolId` discriminates (acks go to
+      // PROTOCOL_SWM_SHARE_ACK). No outbox, no retry — one
+      // network attempt, opaque response.
+      sendToPeer: async (
+        peerId: string,
+        protocolId: string,
+        payload: Uint8Array,
+      ): Promise<Uint8Array> => {
+        calls.push({ peerId, protocolId, bytes: payload.byteLength });
+        return new Uint8Array();
+      },
+      // PR-D registers PROTOCOL_SWM_SHARE_ACK and PR-C registers
+      // a deliveredResponseClassifier — stub these as no-ops so
+      // DKGAgent's constructor / wiring code doesn't crash when
+      // it reaches into the stubbed messenger.
+      register: (_proto: string, _handler: (data: Uint8Array, from: string) => Promise<Uint8Array>): void => {},
+      setResponseDeliveredClassifier: (_proto: string, _fn: (r: Uint8Array) => boolean): void => {},
     };
     (agent as unknown as { messenger: typeof stub }).messenger = stub;
   };
@@ -311,5 +332,184 @@ describe('DKGAgent SwmAckQuorum integration (rc.9 PR-D)', () => {
     expect(bytes.byteLength).toBeGreaterThan(0);
     expect(PROTOCOL_SWM_SHARE_ACK).toBe('/dkg/10.0.1/swm-share-ack');
     expect(PROTOCOL_SWM_UPDATE).toBe('/dkg/10.0.1/swm-update');
+  });
+
+  /**
+   * rc.9 PR-D codex follow-up #D1: ack emission MUST use
+   * fire-and-forget `sendToPeer`, NOT durable `sendReliable`.
+   * Pre-D1 a publisher peer on a build without
+   * PROTOCOL_SWM_SHARE_ACK registered would leave a permanently-
+   * queued outbox row per received share, retrying protocol
+   * negotiation forever. This test pins the call surface: the
+   * ack handler exercised here calls `messenger.sendToPeer`,
+   * not `messenger.sendReliable`.
+   */
+  it('PR-D #D1: ack emission uses sendToPeer (fire-and-forget), not sendReliable (durable)', async () => {
+    const agent = register(await createAgent('AckQuorumD1FireForget'));
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWPublisher'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { calls, install } = stubMessengerSendReliable(new Map([
+      ['12D3KooWPublisher', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'm-pub' }],
+    ]));
+    install(agent);
+
+    // Invoke the ack emit path directly with a synthetic
+    // apply-true outcome — bypasses the gossip mesh dance and
+    // pins the messenger call shape.
+    const emit = (agent as unknown as {
+      maybeEmitSwmShareAck: (o: { applied: true; cgId?: string; shareOperationId?: string; publisherPeerId?: string }) => Promise<void>;
+    }).maybeEmitSwmShareAck.bind(agent);
+
+    await emit({
+      applied: true,
+      cgId: 'cg-d1',
+      shareOperationId: 'op-d1-fire-forget',
+      publisherPeerId: '12D3KooWPublisher',
+    });
+
+    const ackCalls = calls.filter((c) => c.protocolId === PROTOCOL_SWM_SHARE_ACK);
+    expect(ackCalls).toHaveLength(1);
+    expect(ackCalls[0]?.peerId).toBe('12D3KooWPublisher');
+    // sendToPeer doesn't expose a messageId option (fire-and-
+    // forget; no outbox row to key off). The stub leaves
+    // messageId undefined for sendToPeer calls.
+    expect(ackCalls[0]?.messageId).toBeUndefined();
+  });
+
+  /**
+   * rc.9 PR-D codex follow-up #D2: the ack handler MUST trust
+   * the libp2p-authenticated `fromPeerId`, NOT the
+   * self-asserted `ack.ackPeerId` in the protobuf body. Pre-D2
+   * any peer that learned a `shareOperationId` could spoof
+   * acks on behalf of other expected members, suppressing
+   * watchdog top-up for those members.
+   *
+   * This test exercises the handler with a body that claims
+   * peerB acked while the transport identity is peerA, and
+   * asserts:
+   *   1. The spoof attempt is dropped (the quorum's `acked` set
+   *      gains no entry).
+   *   2. Body == transport → the ack lands as expected.
+   */
+  it('PR-D #D2: ack handler rejects body/transport peerId mismatch (anti-spoof)', async () => {
+    const agent = register(await createAgent('AckQuorumD2AntiSpoof'));
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWPeerA', '12D3KooWPeerB', '12D3KooWPeerC'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { install } = stubMessengerSendReliable(() => ({
+      delivered: false, queued: true, attempts: 1, messageId: 'q-' + Math.random().toString(36).slice(2),
+      error: 'transient', nextAttemptAtMs: Date.now() + 1000,
+    }));
+    install(agent);
+
+    const { shareOperationId } = await agent.share('cg-d2-antispoof', [{
+      subject: 'urn:test:d2', predicate: 'http://schema.org/name', object: '"d2"', graph: '',
+    }]);
+
+    const quorum = (agent as unknown as {
+      getOrCreateSwmAckQuorum: () => {
+        onAck: (op: string, peer: string) => void;
+        inspect: (op: string) => { acked: readonly string[]; expectedMembers: readonly string[] } | undefined;
+      };
+    }).getOrCreateSwmAckQuorum();
+
+    expect(quorum.inspect(shareOperationId)?.acked).toEqual([]);
+
+    // Find the PROTOCOL_SWM_SHARE_ACK handler. We can't intercept
+    // the stub's register call (PR-D registers BEFORE the stub
+    // is installed), so reach into the real Messenger via the
+    // production-side getter that DKGAgent exposes. Test goes
+    // through the SAME handler in src/dkg-agent.ts that
+    // production traffic hits — that's the whole point.
+    const ackHandler = await agent.getOrCreateSwmShareAckHandlerForTests();
+
+    // Spoof attempt: body claims peerB, transport says peerA.
+    // Expected: ack DROPPED, acked set unchanged.
+    const spoofBytes = encodeSwmShareAck({
+      shareOperationId,
+      ackPeerId: '12D3KooWPeerB',
+    });
+    await ackHandler(spoofBytes, '12D3KooWPeerA');
+    expect(quorum.inspect(shareOperationId)?.acked).toEqual([]);
+
+    // Honest ack: body matches transport. Expected: lands.
+    const honestBytes = encodeSwmShareAck({
+      shareOperationId,
+      ackPeerId: '12D3KooWPeerA',
+    });
+    await ackHandler(honestBytes, '12D3KooWPeerA');
+    expect(quorum.inspect(shareOperationId)?.acked).toEqual(['12D3KooWPeerA']);
+
+    // Empty body ackPeerId is also accepted — back-compat with
+    // a future relayed-ack path where the body field might be
+    // omitted intentionally.
+    const emptyBodyBytes = encodeSwmShareAck({
+      shareOperationId,
+      ackPeerId: '',
+    });
+    await ackHandler(emptyBodyBytes, '12D3KooWPeerC');
+    const after = quorum.inspect(shareOperationId)?.acked ?? [];
+    expect([...after].sort()).toEqual(['12D3KooWPeerA', '12D3KooWPeerC']);
+  });
+
+  /**
+   * rc.9 PR-D codex follow-up #D3: the ack-quorum tracker MUST
+   * also run for the gossip-only-because-too-many-subscribers
+   * branch (public CG above the substrate cap). Pre-D3 the
+   * track gate required `plan.substrateMembers.length > 0`,
+   * which this branch intentionally empties — so the watchdog
+   * was silently disabled for the dominant use case for
+   * ack-driven reliability.
+   *
+   * Easiest deterministic exercise: temporarily clamp the
+   * substrate-members cap to 1 so a CG with 3 subscribers
+   * trips the gossip-only branch. Then assert that
+   * `getOrCreateSwmAckQuorum().inspect(...).expectedMembers`
+   * includes all 3 — not 0.
+   */
+  it('PR-D #D3: gossip-only-large-public CGs DO get tracked (watchdog covers them)', async () => {
+    const agent = register(await createAgent('AckQuorumD3LargePublic'));
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWBig1', '12D3KooWBig2', '12D3KooWBig3'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    // Clamp the substrate cap so 3 subscribers trip the
+    // gossip-only branch.
+    (agent as unknown as { swmSubstrateMaxMembers: number }).swmSubstrateMaxMembers = 1;
+
+    const { calls, install } = stubMessengerSendReliable(new Map());
+    install(agent);
+
+    const { shareOperationId } = await agent.share('cg-d3-large-public', [{
+      subject: 'urn:test:d3', predicate: 'http://schema.org/name', object: '"d3"', graph: '',
+    }]);
+
+    // Substrate must NOT have been used (above the clamp).
+    const updateCalls = calls.filter((c) => c.protocolId === PROTOCOL_SWM_UPDATE);
+    expect(updateCalls).toEqual([]);
+
+    // Pre-D3: this would have been undefined (track was
+    // skipped because substrateMembers.length === 0).
+    // Post-D3: enumeratedMembers carries the full subscriber
+    // list and track() runs against it.
+    const quorum = (agent as unknown as {
+      getOrCreateSwmAckQuorum: () => {
+        inspect: (op: string) => { expectedMembers: readonly string[]; acked: readonly string[] } | undefined;
+      };
+    }).getOrCreateSwmAckQuorum();
+
+    const record = quorum.inspect(shareOperationId);
+    expect(record).toBeDefined();
+    expect([...(record?.expectedMembers ?? [])].sort()).toEqual([
+      '12D3KooWBig1',
+      '12D3KooWBig2',
+      '12D3KooWBig3',
+    ]);
+    // No substrate sends → no pre-acked peers; everyone is
+    // pending until a SwmShareAck arrives (or watchdog fires).
+    expect(record?.acked).toEqual([]);
   });
 });

--- a/packages/agent/test/swm-ack-quorum-integration.test.ts
+++ b/packages/agent/test/swm-ack-quorum-integration.test.ts
@@ -45,6 +45,18 @@ class CapturingGossip {
 }
 
 interface SendReliableCall {
+  /**
+   * Which messenger method was invoked. rc.9 PR-D codex
+   * follow-up #D8: pre-D8 we only tracked `messageId` and
+   * relied on it being `undefined` to infer "this was a
+   * `sendToPeer` call, not `sendReliable`" — but the
+   * production `maybeEmitSwmShareAck` doesn't pass
+   * `opts.messageId` to `sendReliable` either, so a
+   * regression that re-routed acks back through `sendReliable`
+   * would have passed the test. Tracking the method name
+   * explicitly fixes the assertion's signal-to-noise.
+   */
+  method: 'sendReliable' | 'sendToPeer';
   peerId: string;
   protocolId: string;
   bytes: number;
@@ -87,7 +99,7 @@ function stubMessengerSendReliable(
         payload: Uint8Array,
         opts?: { messageId?: string },
       ): Promise<ReliableSendResult> => {
-        calls.push({ peerId, protocolId, bytes: payload.byteLength, messageId: opts?.messageId });
+        calls.push({ method: 'sendReliable', peerId, protocolId, bytes: payload.byteLength, messageId: opts?.messageId });
         const out = lookup(peerId, protocolId, opts?.messageId);
         if (out instanceof Error) throw out;
         return out;
@@ -95,16 +107,17 @@ function stubMessengerSendReliable(
       // rc.9 PR-D codex follow-up #D1: ack emission uses
       // fire-and-forget `sendToPeer` instead of durable
       // `sendReliable`. We capture into the same `calls` array
-      // so existing assertions see both kinds of sends; the
-      // `protocolId` discriminates (acks go to
-      // PROTOCOL_SWM_SHARE_ACK). No outbox, no retry — one
-      // network attempt, opaque response.
+      // (with `method: 'sendToPeer'`) so assertions can
+      // distinguish the two surfaces — the `protocolId` alone
+      // is not enough since the production `sendReliable` and
+      // `sendToPeer` paths both have undefined `messageId` when
+      // the caller doesn't pass `opts.messageId` (codex #D8).
       sendToPeer: async (
         peerId: string,
         protocolId: string,
         payload: Uint8Array,
       ): Promise<Uint8Array> => {
-        calls.push({ peerId, protocolId, bytes: payload.byteLength });
+        calls.push({ method: 'sendToPeer', peerId, protocolId, bytes: payload.byteLength });
         return new Uint8Array();
       },
       // PR-D registers PROTOCOL_SWM_SHARE_ACK and PR-C registers
@@ -216,6 +229,16 @@ describe('DKGAgent SwmAckQuorum integration (rc.9 PR-D)', () => {
     expect(stats.watchdogFired).toBe(0);
   });
 
+  /**
+   * rc.9 PR-D codex follow-up #D7: drive a real
+   * `PROTOCOL_SWM_SHARE_ACK` arrival through the production
+   * handler and assert that it lands in the quorum's `acked`
+   * set, then reaches the `completed` count once the threshold
+   * is met. The pre-D7 version of this test only asserted
+   * "one share is pending" — a regression in
+   * `handleSwmShareAck()` (e.g. failing to call onAck, or
+   * dropping ACKs silently) would not have been caught.
+   */
   it('PROTOCOL_SWM_SHARE_ACK arrival increments acked count + completes quorum when threshold met', async () => {
     const agent = register(await createAgent('AckQuorumAckArrival'));
     const gossip = new CapturingGossip();
@@ -228,39 +251,42 @@ describe('DKGAgent SwmAckQuorum integration (rc.9 PR-D)', () => {
     }));
     install(agent);
 
-    await agent.share('cg-ackquorum-arrivals', [{
+    const { shareOperationId } = await agent.share('cg-ackquorum-arrivals', [{
       subject: 'urn:test:arr', predicate: 'http://schema.org/name', object: '"arr"', graph: '',
     }]);
+    expect(typeof shareOperationId).toBe('string');
 
-    let stats = agent.getSwmAckQuorumStats();
-    expect(stats.tracked).toBe(1);
-    expect(stats.completed).toBe(0);
-    expect(stats.pending).toBe(1);
+    const stats0 = agent.getSwmAckQuorumStats();
+    expect(stats0.tracked).toBe(1);
+    expect(stats0.completed).toBe(0);
+    expect(stats0.pending).toBe(1);
 
-    const messengerRegistrations = (agent as unknown as {
-      messenger: { register?: (proto: string, handler: (data: Uint8Array, from: string) => Promise<Uint8Array>) => void };
-    }).messenger;
-    // The stub doesn't have `register` — the production register
-    // already ran in DKGAgent.create() against the real Messenger
-    // (which got swapped out by stubMessengerSendReliable above).
-    // For this test we invoke the PR-D-added ack handler directly
-    // via the same code path it would be invoked from, by reaching
-    // into the quorum tracker.
-    void messengerRegistrations;
-    const quorum = (agent as unknown as {
-      getOrCreateSwmAckQuorum: () => { onAck: (op: string, peer: string) => void; stats: () => { tracked: number; completed: number; watchdogFired: number; deadlineExpired: number; pending: number } };
-    }).getOrCreateSwmAckQuorum();
+    // Drive the real handler with three real-shape ACK bytes —
+    // exactly the same code path that a libp2p arrival would
+    // hit. We get the handler via the same test-only getter
+    // production registration uses; this test exercises
+    // handleSwmShareAck → SwmAckQuorum.onAck without bypassing
+    // anything.
+    const ackHandler = await agent.getOrCreateSwmShareAckHandlerForTests();
+    const inspect = agent.getSwmAckQuorumRecordSnapshotForTests(shareOperationId);
+    expect(inspect?.acked).toEqual([]);
+    expect([...(inspect?.expectedMembers ?? [])].sort()).toEqual([
+      '12D3KooWPeer1', '12D3KooWPeer2', '12D3KooWPeer3',
+    ]);
 
-    // Look up the tracked record's shareOperationId by inspecting
-    // the only tracked record. We do this through the existing
-    // public `inspect()` API on the component once we have its
-    // id — but we don't have the id yet, so use the test-only
-    // stats `tracked === 1` invariant to confirm there's exactly
-    // one.
-    // For a deterministic test, we know `share()` returned the
-    // shareOperationId, so let's redo this with that.
+    await ackHandler(encodeSwmShareAck({ shareOperationId, ackPeerId: '12D3KooWPeer1' }), '12D3KooWPeer1');
+    expect(agent.getSwmAckQuorumStats().completed).toBe(0);
+    expect(agent.getSwmAckQuorumRecordSnapshotForTests(shareOperationId)?.acked).toEqual(['12D3KooWPeer1']);
 
-    expect(quorum.stats().pending).toBe(1);
+    await ackHandler(encodeSwmShareAck({ shareOperationId, ackPeerId: '12D3KooWPeer2' }), '12D3KooWPeer2');
+    expect(agent.getSwmAckQuorumStats().completed).toBe(0);
+
+    await ackHandler(encodeSwmShareAck({ shareOperationId, ackPeerId: '12D3KooWPeer3' }), '12D3KooWPeer3');
+    // 3/3 acked → quorum complete (default quorumPct is 1.0 in
+    // the test config; the record is reaped on completion so
+    // inspect() returns undefined).
+    expect(agent.getSwmAckQuorumStats().completed).toBe(1);
+    expect(agent.getSwmAckQuorumRecordSnapshotForTests(shareOperationId)).toBeUndefined();
   });
 
   it('share() returns shareOperationId — ack arrivals for it complete quorum', async () => {
@@ -372,10 +398,22 @@ describe('DKGAgent SwmAckQuorum integration (rc.9 PR-D)', () => {
     const ackCalls = calls.filter((c) => c.protocolId === PROTOCOL_SWM_SHARE_ACK);
     expect(ackCalls).toHaveLength(1);
     expect(ackCalls[0]?.peerId).toBe('12D3KooWPublisher');
-    // sendToPeer doesn't expose a messageId option (fire-and-
-    // forget; no outbox row to key off). The stub leaves
-    // messageId undefined for sendToPeer calls.
-    expect(ackCalls[0]?.messageId).toBeUndefined();
+    // rc.9 PR-D codex #D8: assert the METHOD explicitly. The
+    // pre-D8 assertion checked `messageId === undefined` which
+    // would have passed even if the implementation regressed
+    // back to `sendReliable(peer, proto, payload, { timeoutMs })`
+    // (no opts.messageId → still undefined). Tracking the
+    // method name makes the assertion actually pin the
+    // fire-and-forget contract.
+    expect(ackCalls[0]?.method).toBe('sendToPeer');
+
+    // Additional defense in depth: zero sendReliable calls
+    // hit PROTOCOL_SWM_SHARE_ACK. Catches the regression
+    // where a future change might call BOTH for some reason.
+    const reliableAckCalls = calls.filter(
+      (c) => c.protocolId === PROTOCOL_SWM_SHARE_ACK && c.method === 'sendReliable',
+    );
+    expect(reliableAckCalls).toEqual([]);
   });
 
   /**
@@ -453,6 +491,133 @@ describe('DKGAgent SwmAckQuorum integration (rc.9 PR-D)', () => {
     await ackHandler(emptyBodyBytes, '12D3KooWPeerC');
     const after = quorum.inspect(shareOperationId)?.acked ?? [];
     expect([...after].sort()).toEqual(['12D3KooWPeerA', '12D3KooWPeerC']);
+  });
+
+  /**
+   * rc.9 PR-D codex follow-up #D5: the quorum tracker MUST
+   * register the share BEFORE substrate + gossip publish so a
+   * fast receiver's ack lands against a known shareOperationId
+   * instead of getting dropped because the record doesn't
+   * exist yet. Pre-D5 the order was:
+   *   1. Promise.all([substrate, gossip])    ← waits for both
+   *   2. quorum.track(...)                   ← registers AFTER
+   * A fast receiver could ack between #1 finishing and #2
+   * starting; the handler's `quorum.onAck()` would no-op
+   * because the shareOperationId wasn't tracked yet, causing
+   * undercounted quorum and spurious watchdog top-up.
+   *
+   * Easiest exercise: intercept the gossip publish so it spies
+   * on whether the quorum record exists at publish time, then
+   * assert the record was tracked BEFORE the publish call.
+   */
+  it('PR-D #D5: quorum record is registered BEFORE gossip publish (no pre-track ack drop race)', async () => {
+    const agent = register(await createAgent('AckQuorumD5RaceFix'));
+    let recordExistedAtPublishTime: boolean | null = null;
+    let capturedShareOperationId: string | null = null;
+    const spyingGossip = new CapturingGossip();
+    spyingGossip.subscribers = ['12D3KooWPeerRace1', '12D3KooWPeerRace2'];
+    const originalPublish = spyingGossip.publish.bind(spyingGossip);
+    spyingGossip.publish = async (topic: string, data: Uint8Array): Promise<void> => {
+      // Inspect the agent's quorum state right when gossip
+      // publish is about to fire. By this point the production
+      // code MUST have already called quorum.track() — pre-D5
+      // it hadn't.
+      const stats = agent.getSwmAckQuorumStats();
+      recordExistedAtPublishTime = stats.tracked === 1 && stats.pending === 1;
+      await originalPublish(topic, data);
+    };
+    (agent as unknown as { gossip: CapturingGossip }).gossip = spyingGossip;
+
+    const { install } = stubMessengerSendReliable(() => ({
+      delivered: false, queued: true, attempts: 1, messageId: 'q-' + Math.random().toString(36).slice(2),
+      error: 'transient', nextAttemptAtMs: Date.now() + 1000,
+    }));
+    install(agent);
+
+    const { shareOperationId } = await agent.share('cg-d5-race-fix', [{
+      subject: 'urn:test:d5', predicate: 'http://schema.org/name', object: '"d5"', graph: '',
+    }]);
+    capturedShareOperationId = shareOperationId;
+
+    expect(recordExistedAtPublishTime).toBe(true);
+    expect(agent.getSwmAckQuorumRecordSnapshotForTests(capturedShareOperationId)).toBeDefined();
+  });
+
+  /**
+   * rc.9 PR-D codex follow-up #D6: substrate top-up MUST honour
+   * the `ReliableSendResult` it gets back from sendReliable —
+   * a successful top-up needs to pipe through onAck so the
+   * peer counts toward quorum. Pre-D6 the result was awaited
+   * and discarded, so a peer the watchdog successfully topped
+   * up via substrate would STAY pending until deadlineHardMs
+   * (since PROTOCOL_SWM_UPDATE doesn't emit SwmShareAck).
+   *
+   * Direct exercise of the substrateTopUp callback baked into
+   * the lazily-constructed SwmAckQuorum, with a stub messenger
+   * that returns each outcome shape so we can pin the
+   * classification → onAck wiring for each one.
+   */
+  it('PR-D #D6: substrate top-up "delivered" outcomes route through onAck (peer counts toward quorum)', async () => {
+    const agent = register(await createAgent('AckQuorumD6TopUpOnAck'));
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWTopUpA', '12D3KooWTopUpB', '12D3KooWTopUpC'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    // Initial fan-out: all peers go to the outbox (queued).
+    // Watchdog then fires; top-up gets distinct outcomes per
+    // peer to pin the per-outcome wiring.
+    const { calls, install } = stubMessengerSendReliable((peerId, _proto, _msgId) => {
+      const isTopUp = _msgId?.startsWith('swm-topup-');
+      if (!isTopUp) {
+        return { delivered: false, queued: true, attempts: 1, messageId: 'q-init', error: 'transient', nextAttemptAtMs: Date.now() + 1000 };
+      }
+      if (peerId === '12D3KooWTopUpA') {
+        // empty response → delivered → onAck
+        return { delivered: true, response: new Uint8Array(), attempts: 1, messageId: _msgId! };
+      }
+      if (peerId === '12D3KooWTopUpB') {
+        // 0x02 retryable → no onAck; next watchdog tick retries
+        return { delivered: true, response: new Uint8Array([0x02]), attempts: 1, messageId: _msgId! };
+      }
+      // 0x01 rejected → no onAck (permanent)
+      return { delivered: true, response: new Uint8Array([0x01]), attempts: 1, messageId: _msgId! };
+    });
+    install(agent);
+
+    const { shareOperationId } = await agent.share('cg-d6-topup', [{
+      subject: 'urn:test:d6', predicate: 'http://schema.org/name', object: '"d6"', graph: '',
+    }]);
+
+    // Pre-watchdog: all 3 peers still pending.
+    const before = agent.getSwmAckQuorumRecordSnapshotForTests(shareOperationId);
+    expect(before?.acked).toEqual([]);
+
+    // Drive the substrateTopUp path directly via the test-only
+    // helper. Bypasses the watchdog's setInterval (so the test
+    // isn't real-time-flaky) and hits the EXACT method the
+    // watchdog wires into createSwmAckQuorum's
+    // `substrateTopUp` dep.
+    await agent.invokeSwmSubstrateTopUpForTests({
+      shareOperationId,
+      cgId: 'cg-d6-topup',
+      payload: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+      missingPeers: ['12D3KooWTopUpA', '12D3KooWTopUpB', '12D3KooWTopUpC'],
+    });
+
+    // After top-up: A got `delivered` → routed through onAck;
+    // B got 0x02 retryable → NOT onAck'd (will retry next
+    // tick); C got 0x01 rejected → NOT onAck'd (permanent).
+    const after = agent.getSwmAckQuorumRecordSnapshotForTests(shareOperationId);
+    expect(after?.acked).toEqual(['12D3KooWTopUpA']);
+
+    // Sanity: the top-up actually invoked sendReliable for all
+    // three peers (with the documented swm-topup- prefix).
+    const topUpCalls = calls.filter((c) => c.messageId?.startsWith('swm-topup-'));
+    expect(topUpCalls.map((c) => c.peerId).sort()).toEqual([
+      '12D3KooWTopUpA',
+      '12D3KooWTopUpB',
+      '12D3KooWTopUpC',
+    ]);
   });
 
   /**

--- a/packages/agent/test/swm-ack-quorum.test.ts
+++ b/packages/agent/test/swm-ack-quorum.test.ts
@@ -1,0 +1,547 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createSwmAckQuorum,
+  type SwmAckQuorum,
+  type SubstrateTopUp,
+  type SwmAckQuorumObservers,
+} from '../src/swm/ack-quorum.js';
+
+const PAYLOAD = new TextEncoder().encode('share-bytes');
+
+interface TopUpCall {
+  shareOperationId: string;
+  cgId: string;
+  missingPeers: readonly string[];
+}
+
+function makeTopUp(): { calls: TopUpCall[]; fn: SubstrateTopUp } {
+  const calls: TopUpCall[] = [];
+  const fn: SubstrateTopUp = (input) => {
+    calls.push({
+      shareOperationId: input.shareOperationId,
+      cgId: input.cgId,
+      missingPeers: [...input.missingPeers],
+    });
+  };
+  return { calls, fn };
+}
+
+function makeQuorum(opts: {
+  now?: () => number;
+  topUp?: SubstrateTopUp;
+  observers?: SwmAckQuorumObservers;
+} = {}): SwmAckQuorum {
+  return createSwmAckQuorum({
+    substrateTopUp: opts.topUp ?? (() => {}),
+    now: opts.now,
+    observers: opts.observers,
+  });
+}
+
+describe('createSwmAckQuorum: track + onAck happy path', () => {
+  it('reaches quorum when 100% of expected members ack', () => {
+    const q = makeQuorum();
+    q.track({
+      shareOperationId: 'op-1',
+      cgId: 'cg-1',
+      expectedMembers: ['p1', 'p2', 'p3'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      quorumThreshold: 0.9,
+    });
+
+    expect(q.stats().pending).toBe(1);
+    q.onAck('op-1', 'p1');
+    expect(q.stats().pending).toBe(1);
+    q.onAck('op-1', 'p2');
+    expect(q.stats().pending).toBe(1);
+    q.onAck('op-1', 'p3');
+
+    expect(q.stats().pending).toBe(0);
+    expect(q.stats().completed).toBe(1);
+    expect(q.stats().tracked).toBe(1);
+    expect(q.inspect('op-1')).toBeUndefined();
+  });
+
+  it('reaches quorum at exactly the threshold (0.9 of 10 = 9 acks)', () => {
+    const q = makeQuorum();
+    q.track({
+      shareOperationId: 'op-th',
+      cgId: 'cg-th',
+      expectedMembers: ['p1','p2','p3','p4','p5','p6','p7','p8','p9','p10'],
+      payload: PAYLOAD,
+      enumerationSource: 'topic-subscribers',
+      quorumThreshold: 0.9,
+    });
+
+    for (let i = 1; i <= 8; i++) q.onAck('op-th', `p${i}`);
+    expect(q.stats().completed).toBe(0);
+    expect(q.inspect('op-th')?.ackPct).toBeCloseTo(0.8);
+
+    q.onAck('op-th', 'p9');
+    expect(q.stats().completed).toBe(1);
+    expect(q.inspect('op-th')).toBeUndefined();
+  });
+
+  it('pre-acked substrate peers count toward the quorum at track time', () => {
+    const q = makeQuorum();
+    q.track({
+      shareOperationId: 'op-pre',
+      cgId: 'cg-pre',
+      expectedMembers: ['p1', 'p2', 'p3', 'p4', 'p5'],
+      preAckedFromSubstrate: ['p1', 'p2', 'p3', 'p4'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      quorumThreshold: 0.9,
+    });
+
+    expect(q.inspect('op-pre')?.acked.sort()).toEqual(['p1','p2','p3','p4']);
+    expect(q.inspect('op-pre')?.ackPct).toBeCloseTo(0.8);
+
+    q.onAck('op-pre', 'p5');
+    expect(q.stats().completed).toBe(1);
+  });
+
+  it('pre-completes at track time if substrate alone meets the threshold', () => {
+    const observers: SwmAckQuorumObservers = {
+      onQuorumCompleted: vi.fn(),
+    };
+    const q = makeQuorum({ observers });
+    q.track({
+      shareOperationId: 'op-substrate-only',
+      cgId: 'cg-curated',
+      expectedMembers: ['p1', 'p2', 'p3'],
+      preAckedFromSubstrate: ['p1', 'p2', 'p3'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      quorumThreshold: 0.9,
+    });
+
+    expect(q.stats().tracked).toBe(1);
+    expect(q.stats().completed).toBe(1);
+    expect(q.stats().pending).toBe(0);
+    expect(observers.onQuorumCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('substrate pre-acks outside expectedMembers are filtered out', () => {
+    const q = makeQuorum();
+    q.track({
+      shareOperationId: 'op-filter',
+      cgId: 'cg-filter',
+      expectedMembers: ['p1', 'p2'],
+      preAckedFromSubstrate: ['p1', 'pNotInRoster', 'p2'],
+      payload: PAYLOAD,
+      enumerationSource: 'topic-subscribers',
+      quorumThreshold: 1.0,
+    });
+
+    expect(q.inspect('op-filter')).toBeUndefined();
+    expect(q.stats().completed).toBe(1);
+  });
+});
+
+describe('createSwmAckQuorum: track idempotency / edge cases', () => {
+  it('empty expectedMembers is a no-op (nothing to wait for)', () => {
+    const q = makeQuorum();
+    q.track({
+      shareOperationId: 'op-empty',
+      cgId: 'cg-empty',
+      expectedMembers: [],
+      payload: PAYLOAD,
+      enumerationSource: 'none',
+    });
+
+    expect(q.stats().tracked).toBe(0);
+    expect(q.stats().completed).toBe(0);
+    expect(q.stats().pending).toBe(0);
+  });
+
+  it('duplicate track for the same shareOperationId is ignored', () => {
+    const q = makeQuorum();
+    q.track({
+      shareOperationId: 'op-dup',
+      cgId: 'cg-dup',
+      expectedMembers: ['p1', 'p2'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+    });
+    q.track({
+      shareOperationId: 'op-dup',
+      cgId: 'cg-dup',
+      expectedMembers: ['pOther'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+    });
+
+    expect(q.stats().tracked).toBe(1);
+    expect(q.inspect('op-dup')?.expectedMembers.sort()).toEqual(['p1', 'p2']);
+  });
+
+  it('clamps quorumThreshold to [0, 1]', () => {
+    const q = makeQuorum();
+
+    q.track({
+      shareOperationId: 'op-low',
+      cgId: 'cg',
+      expectedMembers: ['p1'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      quorumThreshold: -5,
+    });
+    expect(q.stats().completed).toBe(1);
+
+    q.track({
+      shareOperationId: 'op-high',
+      cgId: 'cg',
+      expectedMembers: ['p1', 'p2'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      quorumThreshold: 99,
+    });
+    q.onAck('op-high', 'p1');
+    expect(q.stats().completed).toBe(1);
+    q.onAck('op-high', 'p2');
+    expect(q.stats().completed).toBe(2);
+  });
+
+  it('falls back to default threshold for non-finite values (NaN)', () => {
+    const q = makeQuorum();
+    q.track({
+      shareOperationId: 'op-nan',
+      cgId: 'cg',
+      expectedMembers: ['p1','p2','p3','p4','p5','p6','p7','p8','p9','p10'],
+      payload: PAYLOAD,
+      enumerationSource: 'topic-subscribers',
+      quorumThreshold: Number.NaN,
+    });
+
+    for (let i = 1; i <= 8; i++) q.onAck('op-nan', `p${i}`);
+    expect(q.stats().completed).toBe(0);
+
+    q.onAck('op-nan', 'p9');
+    expect(q.stats().completed).toBe(1);
+  });
+});
+
+describe('createSwmAckQuorum: onAck filtering / dedup', () => {
+  it('onAck for unknown shareOperationId is a no-op (stale ack arriving after deadline)', () => {
+    const q = makeQuorum();
+    q.onAck('op-never-tracked', 'p1');
+    expect(q.stats().completed).toBe(0);
+    expect(q.stats().pending).toBe(0);
+  });
+
+  it('onAck from a peer NOT in expectedMembers is dropped', () => {
+    const q = makeQuorum();
+    q.track({
+      shareOperationId: 'op-stranger',
+      cgId: 'cg',
+      expectedMembers: ['p1', 'p2'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      quorumThreshold: 1.0,
+    });
+
+    q.onAck('op-stranger', 'pStranger');
+    expect(q.inspect('op-stranger')?.acked).toEqual([]);
+
+    q.onAck('op-stranger', 'p1');
+    q.onAck('op-stranger', 'p2');
+    expect(q.stats().completed).toBe(1);
+  });
+
+  it('duplicate onAck from the same peer is idempotent', () => {
+    const q = makeQuorum();
+    q.track({
+      shareOperationId: 'op-dup-ack',
+      cgId: 'cg',
+      expectedMembers: ['p1', 'p2', 'p3'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      quorumThreshold: 1.0,
+    });
+
+    q.onAck('op-dup-ack', 'p1');
+    q.onAck('op-dup-ack', 'p1');
+    q.onAck('op-dup-ack', 'p1');
+    expect(q.inspect('op-dup-ack')?.acked).toEqual(['p1']);
+    expect(q.stats().completed).toBe(0);
+  });
+});
+
+describe('createSwmAckQuorum: tick + watchdog + deadline', () => {
+  it('tick before watchdogMs does NOT fire top-up', () => {
+    let nowMs = 1_000_000;
+    const { calls, fn } = makeTopUp();
+    const q = makeQuorum({ now: () => nowMs, topUp: fn });
+
+    q.track({
+      shareOperationId: 'op-early',
+      cgId: 'cg',
+      expectedMembers: ['p1', 'p2', 'p3', 'p4'],
+      payload: PAYLOAD,
+      enumerationSource: 'topic-subscribers',
+      watchdogMs: 30_000,
+      deadlineHardMs: 5 * 60_000,
+    });
+
+    nowMs += 25_000;
+    q.tick();
+
+    expect(calls).toEqual([]);
+    expect(q.stats().watchdogFired).toBe(0);
+    expect(q.inspect('op-early')?.watchdogFired).toBe(false);
+  });
+
+  it('tick AT watchdogMs (and quorum not met) fires top-up exactly once with missing peers', () => {
+    let nowMs = 1_000_000;
+    const { calls, fn } = makeTopUp();
+    const onWatchdogFired = vi.fn();
+    const q = makeQuorum({
+      now: () => nowMs,
+      topUp: fn,
+      observers: { onWatchdogFired },
+    });
+
+    q.track({
+      shareOperationId: 'op-watch',
+      cgId: 'cg-watch',
+      expectedMembers: ['p1', 'p2', 'p3', 'p4'],
+      payload: PAYLOAD,
+      enumerationSource: 'topic-subscribers',
+      watchdogMs: 30_000,
+      deadlineHardMs: 5 * 60_000,
+    });
+
+    q.onAck('op-watch', 'p1');
+    q.onAck('op-watch', 'p2');
+
+    nowMs += 30_000;
+    q.tick();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      shareOperationId: 'op-watch',
+      cgId: 'cg-watch',
+      missingPeers: expect.arrayContaining(['p3', 'p4']),
+    });
+    expect(calls[0]!.missingPeers).toHaveLength(2);
+
+    expect(q.stats().watchdogFired).toBe(1);
+    expect(onWatchdogFired).toHaveBeenCalledOnce();
+    expect(onWatchdogFired).toHaveBeenCalledWith({
+      shareOperationId: 'op-watch',
+      cgId: 'cg-watch',
+      missingCount: 2,
+      expectedCount: 4,
+    });
+
+    // Subsequent ticks before deadline must NOT re-fire.
+    nowMs += 30_000;
+    q.tick();
+    nowMs += 60_000;
+    q.tick();
+    expect(calls).toHaveLength(1);
+    expect(q.stats().watchdogFired).toBe(1);
+  });
+
+  it('watchdog does NOT fire if quorum was met before watchdogMs elapsed', () => {
+    let nowMs = 1_000_000;
+    const { calls, fn } = makeTopUp();
+    const q = makeQuorum({ now: () => nowMs, topUp: fn });
+
+    q.track({
+      shareOperationId: 'op-quick',
+      cgId: 'cg',
+      expectedMembers: ['p1', 'p2', 'p3', 'p4'],
+      payload: PAYLOAD,
+      enumerationSource: 'topic-subscribers',
+      watchdogMs: 30_000,
+      deadlineHardMs: 5 * 60_000,
+      quorumThreshold: 0.5,
+    });
+
+    q.onAck('op-quick', 'p1');
+    q.onAck('op-quick', 'p2');
+    expect(q.stats().completed).toBe(1);
+
+    nowMs += 60_000;
+    q.tick();
+
+    expect(calls).toEqual([]);
+    expect(q.stats().watchdogFired).toBe(0);
+  });
+
+  it('tick at deadlineHardMs reaps the record and fires onDeadlineExpired', () => {
+    let nowMs = 1_000_000;
+    const { calls, fn } = makeTopUp();
+    const onDeadlineExpired = vi.fn();
+    const q = makeQuorum({
+      now: () => nowMs,
+      topUp: fn,
+      observers: { onDeadlineExpired },
+    });
+
+    q.track({
+      shareOperationId: 'op-dead',
+      cgId: 'cg-dead',
+      expectedMembers: ['p1', 'p2', 'p3'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      watchdogMs: 30_000,
+      deadlineHardMs: 5 * 60_000,
+    });
+
+    q.onAck('op-dead', 'p1');
+
+    nowMs += 30_000;
+    q.tick();
+    expect(calls).toHaveLength(1);
+
+    nowMs += 5 * 60_000;
+    q.tick();
+
+    expect(q.stats().deadlineExpired).toBe(1);
+    expect(q.stats().pending).toBe(0);
+    expect(q.inspect('op-dead')).toBeUndefined();
+    expect(onDeadlineExpired).toHaveBeenCalledWith({
+      shareOperationId: 'op-dead',
+      cgId: 'cg-dead',
+      ackedCount: 1,
+      expectedCount: 3,
+      ackPct: 1 / 3,
+    });
+  });
+
+  it('multiple records advance independently in a single tick', () => {
+    let nowMs = 1_000_000;
+    const { calls, fn } = makeTopUp();
+    const q = makeQuorum({ now: () => nowMs, topUp: fn });
+
+    q.track({
+      shareOperationId: 'op-a',
+      cgId: 'cg-a',
+      expectedMembers: ['pA1', 'pA2'],
+      payload: PAYLOAD,
+      enumerationSource: 'topic-subscribers',
+      watchdogMs: 30_000,
+      deadlineHardMs: 5 * 60_000,
+    });
+
+    nowMs += 10_000;
+    q.track({
+      shareOperationId: 'op-b',
+      cgId: 'cg-b',
+      expectedMembers: ['pB1', 'pB2', 'pB3'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      watchdogMs: 30_000,
+      deadlineHardMs: 5 * 60_000,
+    });
+
+    q.onAck('op-b', 'pB1');
+    q.onAck('op-b', 'pB2');
+    q.onAck('op-b', 'pB3');
+
+    nowMs += 20_000;
+    q.tick();
+
+    expect(q.stats().completed).toBe(1);
+    expect(q.stats().watchdogFired).toBe(1);
+    const aTopUps = calls.filter(c => c.shareOperationId === 'op-a');
+    const bTopUps = calls.filter(c => c.shareOperationId === 'op-b');
+    expect(aTopUps).toHaveLength(1);
+    expect(bTopUps).toHaveLength(0);
+  });
+});
+
+describe('createSwmAckQuorum: error isolation', () => {
+  it('throwing observer does not crash the tick', () => {
+    let nowMs = 1_000_000;
+    const q = makeQuorum({
+      now: () => nowMs,
+      topUp: () => {},
+      observers: {
+        onWatchdogFired: () => { throw new Error('observer boom'); },
+        onDeadlineExpired: () => { throw new Error('observer boom'); },
+        onQuorumCompleted: () => { throw new Error('observer boom'); },
+      },
+    });
+
+    q.track({
+      shareOperationId: 'op-throw',
+      cgId: 'cg',
+      expectedMembers: ['p1', 'p2'],
+      payload: PAYLOAD,
+      enumerationSource: 'topic-subscribers',
+      watchdogMs: 30_000,
+      deadlineHardMs: 5 * 60_000,
+    });
+
+    nowMs += 30_000;
+    expect(() => q.tick()).not.toThrow();
+    expect(q.stats().watchdogFired).toBe(1);
+
+    nowMs += 5 * 60_000;
+    expect(() => q.tick()).not.toThrow();
+    expect(q.stats().deadlineExpired).toBe(1);
+
+    q.track({
+      shareOperationId: 'op-throw-2',
+      cgId: 'cg',
+      expectedMembers: ['p1'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      quorumThreshold: 1.0,
+    });
+    expect(() => q.onAck('op-throw-2', 'p1')).not.toThrow();
+    expect(q.stats().completed).toBe(1);
+  });
+
+  it('throwing substrateTopUp does not crash the tick OR mark the record dropped', () => {
+    let nowMs = 1_000_000;
+    const q = makeQuorum({
+      now: () => nowMs,
+      topUp: () => { throw new Error('top-up boom'); },
+    });
+
+    q.track({
+      shareOperationId: 'op-tu-throw',
+      cgId: 'cg',
+      expectedMembers: ['p1', 'p2'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      watchdogMs: 30_000,
+      deadlineHardMs: 5 * 60_000,
+    });
+
+    nowMs += 30_000;
+    expect(() => q.tick()).not.toThrow();
+    expect(q.stats().watchdogFired).toBe(1);
+    expect(q.inspect('op-tu-throw')?.watchdogFired).toBe(true);
+  });
+
+  it('async substrateTopUp rejection is swallowed', async () => {
+    let nowMs = 1_000_000;
+    const q = makeQuorum({
+      now: () => nowMs,
+      topUp: async () => { throw new Error('async top-up boom'); },
+    });
+
+    q.track({
+      shareOperationId: 'op-tu-async',
+      cgId: 'cg',
+      expectedMembers: ['p1'],
+      payload: PAYLOAD,
+      enumerationSource: 'allowlist',
+      quorumThreshold: 1.0,
+      watchdogMs: 30_000,
+      deadlineHardMs: 5 * 60_000,
+    });
+
+    nowMs += 30_000;
+    q.tick();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(q.stats().watchdogFired).toBe(1);
+  });
+});

--- a/packages/agent/test/swm-substrate-fanout-integration.test.ts
+++ b/packages/agent/test/swm-substrate-fanout-integration.test.ts
@@ -22,7 +22,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { DKGAgent } from '../src/index.js';
+import { DKGAgent, FANOUT_RESPONSE_RETRYABLE } from '../src/index.js';
 import type { ReliableSendResult } from '../src/p2p/messenger.js';
 
 const SELF_PEER = '12D3KooWSelfPubC';
@@ -115,10 +115,11 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
     expect(stats).toEqual({
       delivered: {},
       rejected: {},
+      retryable: {},
       queued: {},
       inFlight: {},
       failed: {},
-      overflow: { delivered: 0, rejected: 0, queued: 0, inFlight: 0, failed: 0 },
+      overflow: { delivered: 0, rejected: 0, retryable: 0, queued: 0, inFlight: 0, failed: 0 },
       truncated: false,
     });
   });
@@ -148,10 +149,11 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
     expect(agent.getSwmSubstrateFanoutStats()).toEqual({
       delivered: {},
       rejected: {},
+      retryable: {},
       queued: {},
       inFlight: {},
       failed: {},
-      overflow: { delivered: 0, rejected: 0, queued: 0, inFlight: 0, failed: 0 },
+      overflow: { delivered: 0, rejected: 0, retryable: 0, queued: 0, inFlight: 0, failed: 0 },
       truncated: false,
     });
   });
@@ -214,7 +216,7 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
     expect(stats.queued).toEqual({ 'cg-public-mixed': 1 });
     expect(stats.inFlight).toEqual({});
     expect(stats.failed).toEqual({ 'cg-public-mixed': 1 });
-    expect(stats.overflow).toEqual({ delivered: 0, rejected: 0, queued: 0, inFlight: 0, failed: 0 });
+    expect(stats.overflow).toEqual({ delivered: 0, rejected: 0, retryable: 0, queued: 0, inFlight: 0, failed: 0 });
     expect(stats.truncated).toBe(false);
   });
 
@@ -364,10 +366,11 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
     expect(agent.getSwmSubstrateFanoutStats()).toEqual({
       delivered: {},
       rejected: {},
+      retryable: {},
       queued: {},
       inFlight: {},
       failed: {},
-      overflow: { delivered: 0, rejected: 0, queued: 0, inFlight: 0, failed: 0 },
+      overflow: { delivered: 0, rejected: 0, retryable: 0, queued: 0, inFlight: 0, failed: 0 },
       truncated: false,
     });
   });
@@ -418,11 +421,12 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
    *      Uint8Array), sender drops the share. Matches the
    *      pre-PR-C gossip behaviour for permanent rejections
    *      (bad signature, peer not in allowlist, CAS-not-met).
-   *   - `applied: false, retryable: true`        → THROW, so
-   *      sendReliable reports failure and the substrate
-   *      outbox keeps the share queued for retry. Dominant
-   *      production case: sender key package for the epoch
-   *      hasn't arrived yet.
+   *   - `applied: false, retryable: true`        → returns
+   *      the `FANOUT_RESPONSE_RETRYABLE` (0x02) sentinel (rc.9
+   *      PR-D, codex follow-up from PR-G #G1). Sender's
+   *      classifier re-buckets into 'retryable'; the peer is
+   *      NOT pre-added to the SwmAckQuorum acked set, so the
+   *      watchdog fires substrate top-up at watchdogMs.
    *
    * We exercise the private `handleSwmUpdate` method directly
    * by stubbing `getOrCreateSharedMemoryHandler` to return a
@@ -480,7 +484,7 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
       expect(response[0]).toBe(0x01);
     });
 
-    it('retryable rejection (retryable: true) → THROWS so substrate outbox keeps the share queued', async () => {
+    it('retryable rejection (retryable: true) → returns FANOUT_RESPONSE_RETRYABLE sentinel (PR-D, codex from PR-G #G1)', async () => {
       const agent = await createAgent('R3Receiver-Retryable');
       installStubHandler(agent, async () => ({
         applied: false,
@@ -488,9 +492,9 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
         retryable: true,
       }));
 
-      await expect(
-        invokeReceiver(agent, new Uint8Array([7, 8, 9]), '12D3KooWPeerR3c'),
-      ).rejects.toThrow(/transient rejection from 12D3KooWPeerR3c.*epoch 42/);
+      const response = await invokeReceiver(agent, new Uint8Array([7, 8, 9]), '12D3KooWPeerR3c');
+      expect(response).toBeInstanceOf(Uint8Array);
+      expect(response).toEqual(FANOUT_RESPONSE_RETRYABLE);
     });
   });
 
@@ -688,5 +692,44 @@ describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {
     // is correctly removing completed fan-outs.
     expect(agent.inFlightSubstrateFanOutCount()).toBe(0);
     expect(agent.getSwmSubstrateFanoutStats().delivered).toEqual({ 'cg-g2-cleanup': 5 });
+  });
+
+  /**
+   * rc.9 PR-D (codex follow-up from PR-G #G1) end-to-end: the
+   * substrate's per-(cgId, outcome) counter MUST surface a
+   * `retryable` bucket when the receiver returns the 0x02
+   * sentinel, separately from `delivered` AND from `rejected`.
+   * Pre-PR-D the receiver threw on retryable rejections — and
+   * that throw relied on libp2p's handler-abort surfacing as
+   * recoverable, which it did not. The 0x02 sentinel sidesteps
+   * the abort entirely: receiver returns the byte, sender
+   * classifies it as `retryable`, and SwmAckQuorum's watchdog
+   * schedules the actual re-send.
+   */
+  it('PR-D end-to-end (codex from PR-G #G1): 0x02 retryable sentinel moves counter into the retryable bucket', async () => {
+    const agent = await createAgent('SubstrateFanoutRetryablePRD');
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWApplied', '12D3KooWRetryable'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    const { install } = stubMessengerSendReliable(new Map([
+      ['12D3KooWApplied', { delivered: true, response: new Uint8Array(), attempts: 1, messageId: 'm-applied' }],
+      ['12D3KooWRetryable', { delivered: true, response: new Uint8Array([0x02]), attempts: 1, messageId: 'm-retryable' }],
+    ]));
+    install(agent);
+
+    await agent.share('cg-prd-retryable', [{
+      subject: 'urn:test:prd-retry', predicate: 'http://schema.org/name', object: '"prd"', graph: '',
+    }]);
+    // PR-G #G2: substrate fan-out is detached from share(); drain
+    // in-flight before asserting on the counters.
+    await agent.awaitInFlightSubstrateFanOuts();
+
+    const stats = agent.getSwmSubstrateFanoutStats();
+    expect(stats.delivered).toEqual({ 'cg-prd-retryable': 1 });
+    expect(stats.retryable).toEqual({ 'cg-prd-retryable': 1 });
+    expect(stats.rejected).toEqual({});
+    expect(stats.queued).toEqual({});
+    expect(stats.failed).toEqual({});
   });
 });

--- a/packages/agent/test/swm-substrate-fanout.test.ts
+++ b/packages/agent/test/swm-substrate-fanout.test.ts
@@ -162,6 +162,59 @@ describe('chooseFanOutTier', () => {
       expect(plan.enumeratedCount).toBe(0);
     });
   });
+
+  /**
+   * rc.9 PR-D codex follow-up #D3: `enumeratedMembers` carries
+   * the full recipient set regardless of whether the substrate
+   * leg is active, so PR-D's `SwmAckQuorum` can track the full
+   * expected delivery for the gossip-only-because-too-many-
+   * subscribers branch (which is the dominant use case for
+   * large public CGs). Pre-D3 the only available field was
+   * `substrateMembers`, which the gossip-only branch
+   * intentionally empties — silently disabling watchdog.
+   */
+  describe('enumeratedMembers (PR-D #D3 regression)', () => {
+    it('curated CG: enumeratedMembers equals substrateMembers (full allowlist)', () => {
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('allowlist', ['peerA', 'peerB']),
+        maxSubstrateMembers: 100,
+      });
+      expect(plan.substrateMembers).toEqual(['peerA', 'peerB']);
+      expect(plan.enumeratedMembers).toEqual(['peerA', 'peerB']);
+    });
+
+    it('public CG below threshold: enumeratedMembers equals substrateMembers', () => {
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('topic-subscribers', ['peerA', 'peerB']),
+        maxSubstrateMembers: 100,
+      });
+      expect(plan.substrateMembers).toEqual(['peerA', 'peerB']);
+      expect(plan.enumeratedMembers).toEqual(['peerA', 'peerB']);
+    });
+
+    it('public CG above threshold (gossip-only): enumeratedMembers KEEPS all subscribers, substrateMembers is empty', () => {
+      const members = Array.from({ length: 150 }, (_, i) => `peer${i}`);
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('topic-subscribers', members),
+        maxSubstrateMembers: 100,
+      });
+      expect(plan.useSubstrate).toBe(false);
+      expect(plan.substrateMembers).toEqual([]);
+      // Pre-D3 this was lost; SwmAckQuorum needs it to track
+      // delivery against the full subscriber set.
+      expect(plan.enumeratedMembers).toEqual(members);
+      expect(plan.enumeratedMembers.length).toBe(150);
+    });
+
+    it('source=none: both substrateMembers and enumeratedMembers are empty', () => {
+      const plan = chooseFanOutTier({
+        enumeration: enumeration('none', []),
+        maxSubstrateMembers: 100,
+      });
+      expect(plan.substrateMembers).toEqual([]);
+      expect(plan.enumeratedMembers).toEqual([]);
+    });
+  });
 });
 
 describe('executeSubstrateFanOut', () => {

--- a/packages/agent/test/swm-substrate-fanout.test.ts
+++ b/packages/agent/test/swm-substrate-fanout.test.ts
@@ -242,7 +242,7 @@ describe('executeSubstrateFanOut', () => {
       bookkeeper: bk,
     });
 
-    expect(result).toEqual({ attempted: 0, delivered: 0, rejected: 0, queued: 0, inFlight: 0, failed: 0 });
+    expect(result).toEqual({ attempted: 0, delivered: 0, rejected: 0, retryable: 0, queued: 0, inFlight: 0, failed: 0 });
     expect(calls).toEqual([]);
   });
 
@@ -343,7 +343,7 @@ describe('executeSubstrateFanOut', () => {
       bookkeeper: bk,
     });
 
-    expect(result).toEqual({ attempted: 4, delivered: 3, rejected: 0, queued: 0, inFlight: 0, failed: 1 });
+    expect(result).toEqual({ attempted: 4, delivered: 3, rejected: 0, retryable: 0, queued: 0, inFlight: 0, failed: 1 });
     expect(calls).toHaveLength(4);
   });
 

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -992,6 +992,18 @@ export function buildSloPayload(agent: {
     overflow: { delivered: number; rejected: number; queued: number; inFlight: number; failed: number };
     truncated: boolean;
   };
+  /**
+   * rc.9 PR-D addition. Optional for the same reason
+   * getSwmSubstrateFanoutStats is — test doubles don't need to
+   * stub a tracker they aren't exercising.
+   */
+  getSwmAckQuorumStats?: () => {
+    tracked: number;
+    completed: number;
+    watchdogFired: number;
+    deadlineExpired: number;
+    pending: number;
+  };
 }): {
   protocols: Record<string, unknown>;
   gossip: {
@@ -1018,16 +1030,30 @@ export function buildSloPayload(agent: {
       overflow: { delivered: number; rejected: number; queued: number; inFlight: number; failed: number };
       truncated: boolean;
     };
+    /**
+     * rc.9 PR-D: ack-quorum overlay counters. Same opt-out
+     * mechanic as `substrateFanout` — present iff the agent
+     * exposes `getSwmAckQuorumStats()`.
+     */
+    shareAckQuorum?: {
+      tracked: number;
+      completed: number;
+      watchdogFired: number;
+      deadlineExpired: number;
+      pending: number;
+    };
   };
 } {
   const swmHandler = agent.getSwmHandlerStats();
   const substrateFanout = agent.getSwmSubstrateFanoutStats?.();
+  const shareAckQuorum = agent.getSwmAckQuorumStats?.();
   return {
     protocols: agent.getMessengerSloStats(),
     gossip: agent.getSwmGossipStats(),
     swm: {
       ...swmHandler,
       ...(substrateFanout !== undefined ? { substrateFanout } : {}),
+      ...(shareAckQuorum !== undefined ? { shareAckQuorum } : {}),
     },
   };
 }

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -986,10 +986,23 @@ export function buildSloPayload(agent: {
   getSwmSubstrateFanoutStats?: () => {
     delivered: Record<string, number>;
     rejected: Record<string, number>;
+    /**
+     * rc.9 PR-D (codex follow-up from PR-G #G1): transient
+     * receiver-side rejections. Optional on the interface for
+     * back-compat with pre-PR-D test doubles.
+     */
+    retryable?: Record<string, number>;
     queued: Record<string, number>;
     inFlight: Record<string, number>;
     failed: Record<string, number>;
-    overflow: { delivered: number; rejected: number; queued: number; inFlight: number; failed: number };
+    overflow: {
+      delivered: number;
+      rejected: number;
+      retryable?: number;
+      queued: number;
+      inFlight: number;
+      failed: number;
+    };
     truncated: boolean;
   };
   /**
@@ -1024,10 +1037,18 @@ export function buildSloPayload(agent: {
     substrateFanout?: {
       delivered: Record<string, number>;
       rejected: Record<string, number>;
+      retryable?: Record<string, number>;
       queued: Record<string, number>;
       inFlight: Record<string, number>;
       failed: Record<string, number>;
-      overflow: { delivered: number; rejected: number; queued: number; inFlight: number; failed: number };
+      overflow: {
+        delivered: number;
+        rejected: number;
+        retryable?: number;
+        queued: number;
+        inFlight: number;
+        failed: number;
+      };
       truncated: boolean;
     };
     /**

--- a/packages/cli/test/api-slo-route.test.ts
+++ b/packages/cli/test/api-slo-route.test.ts
@@ -278,6 +278,49 @@ describe('/api/slo wire format (rc.9 PR-A / Codex PR #570 R10)', () => {
     expect((body as { swm: Record<string, unknown> }).swm.shareAckQuorum).toBeUndefined();
   });
 
+  /**
+   * rc.9 PR-D (codex follow-up from PR-G #G1): agents that ship
+   * the `retryable` outcome bucket (transient receiver-side
+   * rejections — CAS pre-condition not yet met, etc.) must
+   * see it surface end-to-end on `/api/slo`. Operators rely
+   * on this to distinguish "share dropped permanently" from
+   * "share will retry shortly via watchdog top-up", which
+   * have very different incident-response implications.
+   */
+  it('substrateFanout — retryable bucket (PR-D, codex from PR-G #G1) flows through end-to-end', async () => {
+    const agent: FakeAgent = {
+      getMessengerSloStats: () => ({}),
+      getSwmGossipStats: () => ({
+        publishFailures: {},
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      }),
+      getSwmHandlerStats: () => ({
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+      }),
+      getSwmSubstrateFanoutStats: () => ({
+        delivered: { 'did:dkg:context-graph:curated': 10 },
+        rejected: {},
+        retryable: { 'did:dkg:context-graph:curated': 3 },
+        queued: {},
+        inFlight: {},
+        failed: {},
+        overflow: { delivered: 0, rejected: 0, retryable: 7, queued: 0, inFlight: 0, failed: 0 },
+        truncated: false,
+      }),
+    };
+    ({ server, port } = await startSloServer(agent));
+
+    const { status, body } = await get(port, '/api/slo');
+    expect(status).toBe(200);
+    const substrateFanout = (body as { swm: { substrateFanout: Record<string, unknown> } }).swm.substrateFanout;
+    expect(substrateFanout.retryable).toEqual({ 'did:dkg:context-graph:curated': 3 });
+    expect((substrateFanout.overflow as Record<string, number>).retryable).toBe(7);
+  });
+
   it('substrateFanout — absent when the agent omits getSwmSubstrateFanoutStats (back-compat with PR-A-only doubles)', async () => {
     const agent: FakeAgent = {
       getMessengerSloStats: () => ({}),

--- a/packages/cli/test/api-slo-route.test.ts
+++ b/packages/cli/test/api-slo-route.test.ts
@@ -201,6 +201,83 @@ describe('/api/slo wire format (rc.9 PR-A / Codex PR #570 R10)', () => {
     });
   });
 
+  /**
+   * rc.9 PR-D wire-format regression: when the agent exposes
+   * `getSwmAckQuorumStats()`, /api/slo MUST surface it under
+   * `swm.shareAckQuorum`. Mirrors the PR-C pattern so test doubles
+   * can opt-out and production agents always supply it.
+   */
+  it('shareAckQuorum — when provided, nested under swm with all five counters', async () => {
+    const agent: FakeAgent = {
+      getMessengerSloStats: () => ({}),
+      getSwmGossipStats: () => ({
+        publishFailures: {},
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      }),
+      getSwmHandlerStats: () => ({
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+      }),
+      getSwmAckQuorumStats: () => ({
+        tracked: 1024,
+        completed: 998,
+        watchdogFired: 21,
+        deadlineExpired: 5,
+        pending: 7,
+      }),
+    };
+    ({ server, port } = await startSloServer(agent));
+
+    const { status, body } = await get(port, '/api/slo');
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      protocols: {},
+      gossip: {
+        publishFailures: {},
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      },
+      swm: {
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+        shareAckQuorum: {
+          tracked: 1024,
+          completed: 998,
+          watchdogFired: 21,
+          deadlineExpired: 5,
+          pending: 7,
+        },
+      },
+    });
+  });
+
+  it('shareAckQuorum — absent when the agent omits getSwmAckQuorumStats (back-compat with pre-PR-D doubles)', async () => {
+    const agent: FakeAgent = {
+      getMessengerSloStats: () => ({}),
+      getSwmGossipStats: () => ({
+        publishFailures: {},
+        publishFailuresOverflow: 0,
+        publishFailuresTruncated: false,
+      }),
+      getSwmHandlerStats: () => ({
+        redundantApplies: {},
+        redundantAppliesLowerBound: false,
+        redundantAppliesOverflow: 0,
+        redundantAppliesTruncated: false,
+      }),
+    };
+    ({ server, port } = await startSloServer(agent));
+
+    const { status, body } = await get(port, '/api/slo');
+    expect(status).toBe(200);
+    expect((body as { swm: Record<string, unknown> }).swm.shareAckQuorum).toBeUndefined();
+  });
+
   it('substrateFanout — absent when the agent omits getSwmSubstrateFanoutStats (back-compat with PR-A-only doubles)', async () => {
     const agent: FakeAgent = {
       getMessengerSloStats: () => ({}),

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -61,6 +61,20 @@ export const PROTOCOL_SWM_SENDER_KEY = '/dkg/10.0.1/swm-sender-key';
 // or below `DKG_SWM_SUBSTRATE_MAX_MEMBERS`. See RFC-003 §6 for the
 // full transport policy.
 export const PROTOCOL_SWM_UPDATE = '/dkg/10.0.1/swm-update';
+// rc.9 PR-D (SWM reliable fan-out plan, Step 1b): NEW protocol — no
+// rc.8 predecessor. Per-recipient acknowledgement that the receiver
+// successfully applied a SWM share via the GOSSIP path. Receivers
+// emit this on every gossip-applied share to the share's author peer
+// (extracted from the gossip envelope signature); senders track ack
+// arrivals against the enumerated `expectedMembers` set in
+// `SwmAckQuorum` to compute per-share delivery quorum. Substrate-
+// delivered shares (PROTOCOL_SWM_UPDATE) ACK via the substrate
+// response itself and DO NOT emit a separate SwmShareAck to avoid
+// double counting. The watchdog runs substrate top-up over the
+// long-tail non-acked peers (`expectedMembers \ acked`) and gives
+// up at the deadline, falling back to runSyncOnConnect for offline
+// peers. See RFC-003 §4.2 + §5.2 for the full ack-quorum policy.
+export const PROTOCOL_SWM_SHARE_ACK = '/dkg/10.0.1/swm-share-ack';
 
 // rc.9 PR-10: bumped from /dkg/10.0.0/join-request to opt into the
 // Universal Messenger substrate. The in-memory JoinApprovalRetryQueue

--- a/packages/core/src/proto/index.ts
+++ b/packages/core/src/proto/index.ts
@@ -92,6 +92,12 @@ export {
 } from './storage-ack.js';
 
 export {
+  type SwmShareAckMsg,
+  encodeSwmShareAck,
+  decodeSwmShareAck,
+} from './swm-share-ack.js';
+
+export {
   type GossipEnvelopeMsg,
   GOSSIP_ENVELOPE_VERSION,
   GOSSIP_TYPE_WORKSPACE_PUBLISH,

--- a/packages/core/src/proto/swm-share-ack.ts
+++ b/packages/core/src/proto/swm-share-ack.ts
@@ -1,0 +1,76 @@
+/**
+ * SWM share ack (RFC-003 §4.2, rc.9 PR-D).
+ *
+ * Single-message protobuf carried by `PROTOCOL_SWM_SHARE_ACK`. The
+ * receiver emits one of these to the share author after a
+ * gossip-delivered share applies successfully (SharedMemoryHandler
+ * returns `applied: true`). The sender's `SwmAckQuorum` accumulates
+ * these per `shareOperationId` to compute delivery quorum and decide
+ * whether to fire the substrate top-up watchdog.
+ *
+ * Substrate-delivered shares (`PROTOCOL_SWM_UPDATE`) DO NOT emit a
+ * separate SwmShareAck — the substrate response (empty Uint8Array
+ * for applied / FANOUT_RESPONSE_REJECTED sentinel for permanent
+ * rejection) is itself the ack signal at the substrate layer. This
+ * keeps the receiver out of the business of figuring out whether the
+ * ack would be redundant with what the substrate already carried.
+ *
+ * Wire shape kept deliberately minimal — no signature, no
+ * timestamp, no nonce. The author peerId is the receiver of the
+ * ack message (transport identifies the sender, the sender identifies
+ * itself in the body for restart-survival), and the
+ * `shareOperationId` is opaque random bytes minted by the original
+ * publisher (so it's already unguessable by random peers). Future
+ * extensions (PR-G or beyond) MAY add fields without bumping the
+ * protocol version as long as the wire bytes stay protobuf-decodable
+ * by older senders — that's how protobuf field-number compatibility
+ * works.
+ *
+ * Field semantics:
+ *
+ *   - `shareOperationId` — the publisher-minted unique ID for the
+ *     original share, exactly as it appears in
+ *     `WorkspacePublishRequest.shareOperationId` on the gossip path.
+ *     The sender's `SwmAckQuorum` keys its pending-share map on this
+ *     value; arrival of an ack for an unknown ID is dropped (likely a
+ *     stale ack arriving after the share's deadlineHardMs expired and
+ *     the record was reaped).
+ *   - `ackPeerId` — the libp2p peerId of the receiver as a string
+ *     (matches `node.peerId.toString()`). Carried in the body rather
+ *     than relying on the transport-level `fromPeerId` because the
+ *     latter is the immediate connection's peer, which after future
+ *     relay/forwarder work may NOT equal the actual applier. We always
+ *     trust the body value here; a forged ackPeerId would let a
+ *     malicious peer claim delivery on someone else's behalf, but the
+ *     blast radius is limited to "watchdog top-up doesn't fire for
+ *     that peer" — the share itself is still subject to the per-CG
+ *     auth checks on the receiver side, and the long-tail top-up
+ *     would retry via substrate anyway if the actual delivery did
+ *     fail. Better authentication (signing the ack with the receiver's
+ *     agent key) is a PR-G-or-later addition.
+ *
+ * @internal
+ */
+
+import protobuf from 'protobufjs';
+
+const { Type, Field } = protobuf;
+
+export const SwmShareAckSchema = new Type('SwmShareAck')
+  .add(new Field('shareOperationId', 1, 'string'))
+  .add(new Field('ackPeerId', 2, 'string'));
+
+export interface SwmShareAckMsg {
+  shareOperationId: string;
+  ackPeerId: string;
+}
+
+export function encodeSwmShareAck(msg: SwmShareAckMsg): Uint8Array {
+  return SwmShareAckSchema.encode(
+    SwmShareAckSchema.create(msg),
+  ).finish();
+}
+
+export function decodeSwmShareAck(buf: Uint8Array): SwmShareAckMsg {
+  return SwmShareAckSchema.decode(buf) as unknown as SwmShareAckMsg;
+}

--- a/packages/core/src/proto/swm-share-ack.ts
+++ b/packages/core/src/proto/swm-share-ack.ts
@@ -36,18 +36,26 @@
  *     stale ack arriving after the share's deadlineHardMs expired and
  *     the record was reaped).
  *   - `ackPeerId` — the libp2p peerId of the receiver as a string
- *     (matches `node.peerId.toString()`). Carried in the body rather
- *     than relying on the transport-level `fromPeerId` because the
- *     latter is the immediate connection's peer, which after future
- *     relay/forwarder work may NOT equal the actual applier. We always
- *     trust the body value here; a forged ackPeerId would let a
- *     malicious peer claim delivery on someone else's behalf, but the
- *     blast radius is limited to "watchdog top-up doesn't fire for
- *     that peer" — the share itself is still subject to the per-CG
- *     auth checks on the receiver side, and the long-tail top-up
- *     would retry via substrate anyway if the actual delivery did
- *     fail. Better authentication (signing the ack with the receiver's
- *     agent key) is a PR-G-or-later addition.
+ *     (matches `node.peerId.toString()`). In the rc.9 PR-D
+ *     direct-Messenger world this field is REDUNDANT with the
+ *     transport-authenticated `fromPeerId` that libp2p hands
+ *     `messenger.register()` handlers. The current receiver
+ *     (`DKGAgent.handleSwmShareAck`, PR-D codex follow-up #D2)
+ *     treats `fromPeerId` as authoritative and DROPS the ack on
+ *     any non-empty body/transport mismatch as a likely spoof
+ *     attempt (pre-D2 we trusted the body, which let any peer
+ *     that learned a `shareOperationId` claim delivery on
+ *     someone else's behalf and suppress watchdog top-up for
+ *     them). Empty `ackPeerId` is still accepted — it's the
+ *     forward-compat slot for a future relayed-ack path where
+ *     `fromPeerId` would be a relay node and the body would
+ *     carry the original receiver identity (signed with that
+ *     receiver's agent key, since at that point the transport
+ *     guarantee no longer covers identity end-to-end). That
+ *     relay path is NOT supported today; senders SHOULD set
+ *     `ackPeerId = receiver.peerId.toString()` for symmetry
+ *     with `fromPeerId`, but receivers will reject any other
+ *     non-empty value.
  *
  * @internal
  */

--- a/packages/core/test/v10-constants.test.ts
+++ b/packages/core/test/v10-constants.test.ts
@@ -9,6 +9,7 @@ import {
   PROTOCOL_QUERY_REMOTE,
   PROTOCOL_SWM_SENDER_KEY,
   PROTOCOL_SWM_UPDATE,
+  PROTOCOL_SWM_SHARE_ACK,
   PROTOCOL_VERIFY_PROPOSAL,
   PROTOCOL_VERIFY_APPROVAL,
   PROTOCOL_STORAGE_ACK,
@@ -70,6 +71,7 @@ describe('V10 protocol stream IDs', () => {
     expect(PROTOCOL_QUERY_REMOTE).toBe('/dkg/10.0.1/query-remote');
     expect(PROTOCOL_SWM_SENDER_KEY).toBe('/dkg/10.0.1/swm-sender-key');
     expect(PROTOCOL_SWM_UPDATE).toBe('/dkg/10.0.1/swm-update');
+    expect(PROTOCOL_SWM_SHARE_ACK).toBe('/dkg/10.0.1/swm-share-ack');
     expect(PROTOCOL_VERIFY_PROPOSAL).toBe('/dkg/10.0.1/verify-proposal');
     expect(PROTOCOL_VERIFY_APPROVAL).toBe('/dkg/10.0.0/verify-approval');
     expect(PROTOCOL_STORAGE_ACK).toBe('/dkg/10.0.1/storage-ack');

--- a/packages/core/test/v10-proto.test.ts
+++ b/packages/core/test/v10-proto.test.ts
@@ -6,12 +6,15 @@ import {
   decodeVerifyApproval,
   encodeStorageACK,
   decodeStorageACK,
+  encodeSwmShareAck,
+  decodeSwmShareAck,
   encodeGossipEnvelope,
   decodeGossipEnvelope,
   computeGossipSigningPayload,
   type VerifyProposalMsg,
   type VerifyApprovalMsg,
   type StorageACKMsg,
+  type SwmShareAckMsg,
   type GossipEnvelopeMsg,
 } from '../src/index.js';
 
@@ -126,6 +129,39 @@ describe('StorageACKMsg', () => {
 
   it('deterministic encoding', () => {
     expect(encodeStorageACK(ack)).toEqual(encodeStorageACK(ack));
+  });
+});
+
+// ── SwmShareAck (rc.9 PR-D) ───────────────────────────────────────────
+
+describe('SwmShareAckMsg', () => {
+  const ack: SwmShareAckMsg = {
+    shareOperationId: 'op-01HXYZABCDEFGHJKMNPQRSTVWX',
+    ackPeerId: '12D3KooWPeerAck',
+  };
+
+  it('encode → decode round-trip preserves both fields', () => {
+    const encoded = encodeSwmShareAck(ack);
+    expect(encoded).toBeInstanceOf(Uint8Array);
+    expect(encoded.length).toBeGreaterThan(0);
+
+    const decoded = decodeSwmShareAck(encoded);
+    expect(decoded.shareOperationId).toBe(ack.shareOperationId);
+    expect(decoded.ackPeerId).toBe(ack.ackPeerId);
+  });
+
+  it('deterministic encoding', () => {
+    expect(encodeSwmShareAck(ack)).toEqual(encodeSwmShareAck(ack));
+  });
+
+  it('handles long peerIds and operation IDs', () => {
+    const long: SwmShareAckMsg = {
+      shareOperationId: 'op-' + 'x'.repeat(200),
+      ackPeerId: '12D3KooW' + 'y'.repeat(200),
+    };
+    const decoded = decodeSwmShareAck(encodeSwmShareAck(long));
+    expect(decoded.shareOperationId).toBe(long.shareOperationId);
+    expect(decoded.ackPeerId).toBe(long.ackPeerId);
   });
 });
 

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -75,12 +75,43 @@ export type WorkspaceSenderKeyDecryptor = (
  *     converged would likely succeed; the substrate caller
  *     SHOULD keep the share queued so it gets re-attempted.
  *
- * Gossip callers ignore the outcome — gossip is best-effort and
- * its only "retry" is sync-on-reconnect, which doesn't consult
- * this signal. The new substrate fan-out receiver consumes it.
+ * Gossip callers consume the `applied: true` variant — rc.9 PR-D
+ * (SWM ack-quorum overlay) reads `cgId`, `shareOperationId` and
+ * `publisherPeerId` to address the `PROTOCOL_SWM_SHARE_ACK`
+ * message back to the original publisher. Substrate callers
+ * consume `applied + retryable` to decide whether to ACK / throw /
+ * return the rejection sentinel. The substrate path DOES NOT
+ * emit a PROTOCOL_SWM_SHARE_ACK — the substrate response is
+ * itself the ack signal at the substrate layer; the metadata
+ * fields are populated regardless so a future receiver
+ * (e.g. a sync-emitted apply) could choose its own ack policy.
+ *
+ * The metadata fields are optional because two early-return paths
+ * (missing contextGraphId / pre-decode of the publish request)
+ * applied successfully in a prior shape can't surface them
+ * reliably; if a caller can't extract them from the outcome it
+ * MUST fall back to NOT emitting an ack (silent best-effort, same
+ * as pre-PR-D gossip behaviour).
  */
 export type SharedMemoryApplyOutcome =
-  | { applied: true }
+  | {
+      applied: true;
+      /** Context graph the share applied into. Set on the apply path. */
+      cgId?: string;
+      /**
+       * Publisher-minted unique ID for the original share. Same
+       * value the sender keyed its `SwmAckQuorum` record on.
+       * Optional only because legacy callers shouldn't be forced
+       * to consume it; the apply path always sets it when known.
+       */
+      shareOperationId?: string;
+      /**
+       * libp2p peerId of the publisher (`request.publisherPeerId`,
+       * which the apply path enforces equals `fromPeerId`).
+       * Caller addresses the PROTOCOL_SWM_SHARE_ACK to this peer.
+       */
+      publisherPeerId?: string;
+    }
   | { applied: false; reason: string; retryable: boolean };
 
 /**
@@ -956,7 +987,12 @@ export class SharedMemoryHandler {
           source: 'gossip',
           counts: { triples: quads.length },
         });
-        return { applied: true };
+        return {
+          applied: true,
+          cgId: contextGraphId,
+          shareOperationId,
+          publisherPeerId,
+        };
       }
       // `applied === false` from the withWriteLocks closure. PR-C
       // codex R4: validation rejection is deterministic (retry

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -879,7 +879,7 @@ describe('SharedMemoryHandler.handle outcome (rc.9 PR-C codex R3)', () => {
     handler = new SharedMemoryHandler(store, new TypedEventBus(), {});
   });
 
-  it('successful apply returns { applied: true }', async () => {
+  it('successful apply returns { applied: true } with metadata for PR-D ack-quorum tracking', async () => {
     const nquads = `<${ENTITY}> <http://schema.org/name> "Applied" <${DATA_GRAPH}> .`;
     const msg = encodeWorkspacePublishRequest({
       contextGraphId: CONTEXT_GRAPH,
@@ -891,7 +891,18 @@ describe('SharedMemoryHandler.handle outcome (rc.9 PR-C codex R3)', () => {
     });
 
     const outcome = await handler.handle(msg, '12D3KooWPeerR3');
-    expect(outcome).toEqual({ applied: true });
+    // PR-D extended the applied: true variant to carry cgId,
+    // shareOperationId, and publisherPeerId so the gossip
+    // subscriber can address SwmShareAck back to the publisher
+    // (RFC-003 §4.2). Backward-compat: legacy callers using just
+    // `outcome.applied` still see `true`; only assertions with
+    // strict equality need the new fields.
+    expect(outcome).toEqual({
+      applied: true,
+      cgId: CONTEXT_GRAPH,
+      shareOperationId: 'op-applied',
+      publisherPeerId: '12D3KooWPeerR3',
+    });
   });
 
   it('permanent rejection (publisherPeerId / fromPeerId mismatch) returns { applied: false, retryable: false }', async () => {


### PR DESCRIPTION
## Summary

Implements RFC-003 §4.2 + §5: per-share ack-quorum overlay that closes the per-recipient visibility gap PR-C left open for the gossip leg of SWM share fan-out. Adds:

- New `PROTOCOL_SWM_SHARE_ACK = '/dkg/10.0.1/swm-share-ack'` (single-message ack from receiver to publisher after a gossip-applied SWM share).
- `SwmAckQuorum` in-memory tracker (`packages/agent/src/swm/ack-quorum.ts`) — defaults match RFC-003 §5.1-5.2: quorum=0.9, watchdog=30s, deadline=5min, 5s tick cadence.
- Sender wiring in `DKGAgent.publishWorkspaceGossip` — registers each gossipable share with `track()`, pre-populates the `acked` set with PR-C substrate-delivered peers so hybrid shares converge in one quorum number instead of double-counting.
- Receiver wiring on the gossip subscriber path — emits `SwmShareAck` after successful apply. Substrate path (`handleSwmUpdate`, PR-C) deliberately does NOT emit one, so peers reachable via both transports get exactly one ack signal.
- Watchdog top-up via `messenger.sendReliable(PROTOCOL_SWM_UPDATE)` to non-acked peers; receiver idempotency (PR-A `seenShareOps`) absorbs the redundant delivery cleanly if both legs arrive.
- `/api/slo` extension: `swm.shareAckQuorum: { tracked, completed, watchdogFired, deadlineExpired, pending }`.

## Sequencing notes

- **Base branch shows PR-C's commits too.** This PR is stacked on `feat/swm-substrate-fanout` (PR #576). When PR-C merges into `soak/messenger-rc9-everything`, GitHub auto-rebases this diff to just the three PR-D commits.
- **PR-D is in-memory only.** SQLite journaling for crash-survival (RFC §5.2 future work) is deliberately deferred — a daemon crash mid-share loses the tracking state but not the share itself (gossip already published, substrate already enqueued). `runSyncOnConnect` covers the worst case. Promotion to a journaled tracker is gated on whether the soak postmortem shows crash-loss matters.
- **Large public CGs above the substrate cap stay untracked in PR-D.** `plan.substrateMembers` is empty by design in that tier; tracking the full topic-subscriber set would need a separate re-enumeration. Deferred to a follow-up if soak shows it matters.

## Commit structure

1. `feat(core): PROTOCOL_SWM_SHARE_ACK constant + SwmShareAck protobuf` — wire shape scaffolding.
2. `feat(agent): SwmAckQuorum tracker for SWM share delivery quorum` — pure in-memory component + 20 unit tests covering quorum thresholds, pre-acked peers, watchdog timing, deadline, error isolation.
3. `feat(agent,cli,publisher): wire SwmAckQuorum into DKGAgent + /api/slo` — sender + receiver wiring, `/api/slo` extension, 7 integration tests + workspace-handler outcome shape update.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core exec vitest run test/v10-constants.test.ts test/v10-proto.test.ts` — 55/55 pass
- [x] `pnpm --filter @origintrail-official/dkg-agent exec vitest run test/swm-*.test.ts test/messenger-substrate.test.ts test/enumerate-cg-members.test.ts` — 137/137 pass
- [x] `pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/workspace*.test.ts test/security-regressions.test.ts test/phase-sequences.test.ts` — 122/122 pass
- [x] `pnpm --filter @origintrail-official/dkg exec vitest run test/api-slo-route.test.ts` — 7/7 pass
- [x] Typecheck clean across core, publisher, agent, cli
- [ ] Reviewer to confirm the wire-format documentation in `swm-share-ack.ts` matches the security trade-offs you want (body-carried `ackPeerId` vs transport-derived; no signature in v1)
- [ ] Reviewer to confirm liftToShared can defer ack-quorum tracking to a follow-up (only `share()` + `sharedMemoryCAS()` plumb shareOperationId in PR-D)
- [ ] PR-F soak postmortem will validate: `completed >> watchdogFired >> deadlineExpired`, and overall `>=99.9%` delivery vs `/api/slo` `swm.substrateFanout.delivered` + `shareAckQuorum.completed`

## Follow-ups (out of scope, tracked separately)

- **PR-G**: any post-merge Codex bugfixes from PR-C/PR-D batched into one branch
- **PR-F**: 12-24h multi-node soak (#572 prep already open) once PR-D lands
- **Future** (post-rc9): SQLite journal for SwmAckQuorum, liftToShared tracking, gossip suppression on confirmed-substrate peers, signed acks


Made with [Cursor](https://cursor.com)