### PR TITLE
fix(swm): drop ghost subscribers from substrate fan-out (PR-J)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -9409,21 +9409,43 @@ export class DKGAgent {
         topicForCG: (cgId) => contextGraphWorkspaceTopic(cgId),
         getSelfPeerId: () => this.peerId,
         // PR-J liveness filter: drop GossipSub-advertised subscribers
-        // that we don't currently have a connection to. Bug fix for
-        // the 2026-05-18 Miles<->Lex soak where 3-of-4 enumerated
-        // public-CG subscribers were ghosts (peer-exchange residue),
-        // every substrate send queued, ackQuorum never completed.
-        // libp2p.getPeers() is cheap (returns the connected set, no
-        // I/O) so calling it on every enumeration miss is fine. If
-        // libp2p hasn't started yet (pre-start share()), getPeers()
-        // throws — match the getSelfPeerId thunk fallback by
-        // returning true (don't filter) so the enumeration still
-        // succeeds and falls through to gossip-only.
-        isPeerDialable: (peerId) => {
+        // we have no realistic chance of reaching via the send path.
+        // Bug fix for the 2026-05-18 Miles<->Lex soak where 3-of-4
+        // enumerated public-CG subscribers were ghosts (peer-exchange
+        // residue), every substrate send queued, ackQuorum never
+        // completed.
+        //
+        // **Reachability MUST match what `sendReliable` actually
+        // tries** (codex RED on #584 round 1). The router's send
+        // path consults libp2p.getConnections (live) AND
+        // libp2p.peerStore (cached addresses for dial). Filtering
+        // only on `getPeers()` would silently drop legitimate
+        // subscribers that we briefly disconnected from but still
+        // have addresses for. We OR-combine the two sources to
+        // mirror the send path: connected OR peerStore-known.
+        //
+        // Pre-start: if libp2p hasn't booted, `getPeers()` throws
+        // → caught → return false → all subscribers filtered out
+        // → source=none → publishWorkspaceGossip's gossip-only
+        // fallback kicks in (preserving the pre-start `share()`
+        // contract documented on the `getSelfPeerId` thunk). The
+        // pre-start GossipSub subscriber list is normally empty
+        // anyway since we haven't joined the mesh yet, so this
+        // path is rare in practice.
+        isPeerDialable: async (peerId) => {
           try {
-            return this.node.libp2p.getPeers().some((p) => p.toString() === peerId);
+            if (this.node.libp2p.getPeers().some((p) => p.toString() === peerId)) {
+              return true;
+            }
+            // peerStore.get throws on cold-cache miss — treat that
+            // as "we have no addressing info for this peer" =
+            // false. Any addresses present (direct OR circuit
+            // relay) count as dialable; the protocol router will
+            // make the final transport choice.
+            const peer = await this.node.libp2p.peerStore.get(peerId as unknown as Parameters<typeof this.node.libp2p.peerStore.get>[0]);
+            return (peer?.addresses?.length ?? 0) > 0;
           } catch {
-            return true;
+            return false;
           }
         },
       });

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -9400,6 +9400,57 @@ export class DKGAgent {
    *    bubble out of `enumerate()`, where the R1 try/catch in
    *    `publishWorkspaceGossip` rescues into the gossip-only path.
    */
+  /**
+   * Liveness predicate for the SUBSTRATE TARGET subset of an
+   * enumerated CG. Returns true iff `sendReliable` has a
+   * realistic chance of putting bytes on the wire to this peer.
+   *
+   * **Reachability MUST match what `sendReliable` actually tries**
+   * (codex RED #1 on #584). The router's send path consults
+   * `libp2p.getConnections` (live) AND `libp2p.peerStore` (cached
+   * addresses for dial). Filtering only on `getPeers()` would
+   * silently drop legitimate substrate targets that we briefly
+   * disconnected from but still have addresses for. We
+   * OR-combine the two sources to mirror the send path:
+   * connected OR peerStore-known.
+   *
+   * PeerId hygiene (codex RED #4 on #584 round 2):
+   * `libp2p.peerStore.get` requires a `PeerId` object, NOT a
+   * string. A type-cast call throws on the disconnected-but-
+   * known path in the real libp2p API, which would make this
+   * predicate return false for peers we DO have cached addresses
+   * for — dropping legitimate substrate targets. We parse with
+   * `peerIdFromString` first; on parse failure (malformed
+   * gossipsub entry) the catch returns false (safe drop).
+   *
+   * Pre-start: if libp2p hasn't booted, `getPeers()` throws →
+   * caught → return false → substrate target set is empty →
+   * substrate fan-out is a no-op (gossip still runs). The
+   * pre-start GossipSub subscriber list is normally empty anyway.
+   *
+   * Single source of truth: this method is consumed BOTH by the
+   * CG enumerator (filters topic-subscribers to populate
+   * `substrateEligibleMembers`) AND by `swmSubstrateTopUp` (re-
+   * filters watchdog missingPeers so the top-up doesn't keep
+   * blasting ghost peers that ackQuorum legitimately tracks but
+   * substrate can't reach). PR-J round 2 introduces the second
+   * use to close the watchdog leg of the same soak bug — without
+   * it, the queued counter would inflate once per 30s tick
+   * instead of once per share.
+   */
+  private async isPeerDialable(peerId: string): Promise<boolean> {
+    try {
+      if (this.node.libp2p.getPeers().some((p) => p.toString() === peerId)) {
+        return true;
+      }
+      const { peerIdFromString } = await import('@libp2p/peer-id');
+      const peer = await this.node.libp2p.peerStore.get(peerIdFromString(peerId));
+      return (peer?.addresses?.length ?? 0) > 0;
+    } catch {
+      return false;
+    }
+  }
+
   private getOrCreateCGMemberEnumerator(): CGMemberEnumerator {
     if (!this.cgMemberEnumerator) {
       this.cgMemberEnumerator = createCGMemberEnumerator({
@@ -9408,46 +9459,40 @@ export class DKGAgent {
         getTopicSubscribers: (topic) => this.gossip.getSubscribers(topic),
         topicForCG: (cgId) => contextGraphWorkspaceTopic(cgId),
         getSelfPeerId: () => this.peerId,
-        // PR-J liveness filter: drop GossipSub-advertised subscribers
-        // we have no realistic chance of reaching via the send path.
-        // Bug fix for the 2026-05-18 Miles<->Lex soak where 3-of-4
-        // enumerated public-CG subscribers were ghosts (peer-exchange
-        // residue), every substrate send queued, ackQuorum never
-        // completed.
+        // PR-J liveness filter: marks the substrate target subset
+        // (NOT `members`/`enumeratedMembers`) so the substrate
+        // fan-out doesn't waste sends on peers we have no
+        // addressing for. Bug fix for the 2026-05-18 Miles<->Lex
+        // soak where 3-of-4 enumerated public-CG subscribers were
+        // ghosts (peer-exchange residue) and every substrate send
+        // queued forever.
         //
         // **Reachability MUST match what `sendReliable` actually
-        // tries** (codex RED on #584 round 1). The router's send
-        // path consults libp2p.getConnections (live) AND
+        // tries** (codex RED #1 on #584 round 1). The router's
+        // send path consults libp2p.getConnections (live) AND
         // libp2p.peerStore (cached addresses for dial). Filtering
         // only on `getPeers()` would silently drop legitimate
-        // subscribers that we briefly disconnected from but still
-        // have addresses for. We OR-combine the two sources to
-        // mirror the send path: connected OR peerStore-known.
+        // substrate targets that we briefly disconnected from but
+        // still have addresses for. We OR-combine the two sources
+        // to mirror the send path: connected OR peerStore-known.
+        //
+        // PeerId hygiene (codex RED #4 on #584 round 2):
+        // libp2p.peerStore.get requires a `PeerId` object, NOT a
+        // string. The pre-fix cast threw on the disconnected-but-
+        // known path (real libp2p) and silently returned `false`,
+        // making the filter drop legitimate subscribers that
+        // SHOULD have been dialable. Parse with `peerIdFromString`
+        // first; on parse failure (malformed gossipsub entry)
+        // fall through to the catch → false → safe drop.
         //
         // Pre-start: if libp2p hasn't booted, `getPeers()` throws
-        // → caught → return false → all subscribers filtered out
-        // → source=none → publishWorkspaceGossip's gossip-only
-        // fallback kicks in (preserving the pre-start `share()`
-        // contract documented on the `getSelfPeerId` thunk). The
-        // pre-start GossipSub subscriber list is normally empty
-        // anyway since we haven't joined the mesh yet, so this
-        // path is rare in practice.
-        isPeerDialable: async (peerId) => {
-          try {
-            if (this.node.libp2p.getPeers().some((p) => p.toString() === peerId)) {
-              return true;
-            }
-            // peerStore.get throws on cold-cache miss — treat that
-            // as "we have no addressing info for this peer" =
-            // false. Any addresses present (direct OR circuit
-            // relay) count as dialable; the protocol router will
-            // make the final transport choice.
-            const peer = await this.node.libp2p.peerStore.get(peerId as unknown as Parameters<typeof this.node.libp2p.peerStore.get>[0]);
-            return (peer?.addresses?.length ?? 0) > 0;
-          } catch {
-            return false;
-          }
-        },
+        // → caught → return false → substrate target subset
+        // becomes empty for this CG → substrate fan-out is a
+        // no-op (gossip leg still runs). The pre-start GossipSub
+        // subscriber list is normally empty anyway since we
+        // haven't joined the mesh yet, so this path is rare in
+        // practice.
+        isPeerDialable: (peerId) => this.isPeerDialable(peerId),
       });
     }
     return this.cgMemberEnumerator;
@@ -9508,9 +9553,34 @@ export class DKGAgent {
     missingPeers: readonly string[];
   }): Promise<void> {
     const ctx = createOperationContext('share', shareOperationId);
+    // PR-J round 2: ackQuorum's `expectedMembers` is now the FULL
+    // enumerated set (gossip-eligible) per codex RED #3 on #584.
+    // `missingPeers` therefore includes peers ackQuorum tracks but
+    // substrate can't reach (ghost peer-exchange entries, or
+    // gossip-only-reachable peers without peerStore addresses).
+    // Re-apply the same dialability filter here so the watchdog
+    // top-up doesn't keep blasting wire sends that will queue
+    // forever — that would inflate the `swm.substrateFanout.queued`
+    // counter once per 30s tick for each ghost, recreating the
+    // soak bug at watchdog cadence instead of share cadence.
+    //
+    // Filtered-out peers remain in ackQuorum's expectedMembers and
+    // get reaped via deadlineHardMs if they never ack (a metric
+    // blip, not a wire-load regression — exactly the tradeoff
+    // codex called out as "noise we can't distinguish from
+    // legitimate churn" in the round-2 review).
+    const dialabilityChecks = await Promise.all(missingPeers.map((p) => this.isPeerDialable(p)));
+    const dialableMissingPeers = missingPeers.filter((_, idx) => dialabilityChecks[idx]);
+    if (dialableMissingPeers.length === 0) {
+      this.log.info(
+        ctx,
+        `SWM ack-quorum watchdog skipping substrate top-up for ${shareOperationId} (cg=${cgId}): no dialable peers among ${missingPeers.length} missing`,
+      );
+      return;
+    }
     this.log.info(
       ctx,
-      `SWM ack-quorum watchdog firing substrate top-up for ${shareOperationId} to ${missingPeers.length} peer(s) (cg=${cgId})`,
+      `SWM ack-quorum watchdog firing substrate top-up for ${shareOperationId} to ${dialableMissingPeers.length}/${missingPeers.length} dialable peer(s) (cg=${cgId})`,
     );
     // PR-H bug 1: route per-peer outcomes to the right ack-quorum
     // hook. Pre-PR-H ignored outcomes entirely except for
@@ -9550,7 +9620,7 @@ export class DKGAgent {
     //     publisher) would tighten this further; out of scope
     //     for this PR — see PR #582 comments / follow-up issue.
     let rearmCount = 0;
-    await Promise.allSettled(missingPeers.map(async (peerId: string) => {
+    await Promise.allSettled(dialableMissingPeers.map(async (peerId: string) => {
       try {
         const sendResult = await this.messenger.sendReliable(peerId, PROTOCOL_SWM_UPDATE, payload, {
           messageId: `swm-topup-${shareOperationId}-${peerId}`,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -6760,6 +6760,11 @@ export class DKGAgent {
     //      quorum target as gossip-side acks.
     if (plan.useSubstrate) {
       const baseBookkeeper = this.substrateFanoutBookkeeper();
+      // PR-J: capture per-peer outcomes for the optional detail
+      // line emitted when anything queues/fails/is rejected. Lets
+      // operators see WHICH peer is failing rather than just an
+      // aggregate "queued=4" with no way to attribute it.
+      const perPeerDetail: { peerId: string; outcome: string; error: string }[] = [];
       const substratePromise: Promise<void> = (async () => {
         try {
           const substrateResult = await executeSubstrateFanOut({
@@ -6778,6 +6783,18 @@ export class DKGAgent {
                 ) {
                   trackedQuorum.onAck(shareOperationId, record.peerId);
                 }
+                if (
+                  record.outcome === 'queued'
+                  || record.outcome === 'failed'
+                  || record.outcome === 'rejected'
+                  || record.outcome === 'retryable'
+                ) {
+                  perPeerDetail.push({
+                    peerId: record.peerId,
+                    outcome: record.outcome,
+                    error: record.error,
+                  });
+                }
                 baseBookkeeper.recordOutcome(cgId, record);
               },
             },
@@ -6793,6 +6810,19 @@ export class DKGAgent {
             + `inFlight=${substrateResult.inFlight} failed=${substrateResult.failed} `
             + `also_gossiped=${plan.useGossip}`,
           );
+          // PR-J per-peer detail. Logged at WARN so it surfaces in
+          // operator dashboards that filter by level (the aggregate
+          // INFO line is the steady-state observability; this is the
+          // "something's wrong, here's who" follow-up).
+          if (perPeerDetail.length > 0) {
+            const summary = perPeerDetail
+              .map((d) => `${d.peerId.slice(-12)}=${d.outcome}` + (d.error ? `(${d.error.slice(0, 80)})` : ''))
+              .join(' ');
+            this.log.warn(
+              ctx,
+              `SWM substrate fan-out non-delivered detail cgId=${contextGraphId} peers=[${summary}]`,
+            );
+          }
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
           this.log.warn(
@@ -9378,6 +9408,24 @@ export class DKGAgent {
         getTopicSubscribers: (topic) => this.gossip.getSubscribers(topic),
         topicForCG: (cgId) => contextGraphWorkspaceTopic(cgId),
         getSelfPeerId: () => this.peerId,
+        // PR-J liveness filter: drop GossipSub-advertised subscribers
+        // that we don't currently have a connection to. Bug fix for
+        // the 2026-05-18 Miles<->Lex soak where 3-of-4 enumerated
+        // public-CG subscribers were ghosts (peer-exchange residue),
+        // every substrate send queued, ackQuorum never completed.
+        // libp2p.getPeers() is cheap (returns the connected set, no
+        // I/O) so calling it on every enumeration miss is fine. If
+        // libp2p hasn't started yet (pre-start share()), getPeers()
+        // throws — match the getSelfPeerId thunk fallback by
+        // returning true (don't filter) so the enumeration still
+        // succeeds and falls through to gossip-only.
+        isPeerDialable: (peerId) => {
+          try {
+            return this.node.libp2p.getPeers().some((p) => p.toString() === peerId);
+          } catch {
+            return true;
+          }
+        },
       });
     }
     return this.cgMemberEnumerator;

--- a/packages/agent/src/swm/enumerate-cg-members.ts
+++ b/packages/agent/src/swm/enumerate-cg-members.ts
@@ -103,11 +103,12 @@ export interface CGMemberEnumeratorDeps {
   topicForCG: (cgId: string) => string;
   /**
    * Optional liveness filter for the `topic-subscribers` branch.
-   * Returns true iff the peer is currently dialable from this
-   * node (e.g. a live libp2p connection exists). Applied AFTER
-   * `dedupAndExcludeSelf` to drop ghost subscribers that
-   * GossipSub's peer-exchange / heartbeat still advertises but
-   * that have since gone offline (or were never reachable).
+   * Returns true iff the peer is reachable from this node — i.e.
+   * `sendReliable` has a realistic chance of putting bytes on the
+   * wire to them. Applied AFTER `dedupAndExcludeSelf` to drop
+   * ghost subscribers that GossipSub's peer-exchange / heartbeat
+   * still advertises but that have no addressing info anywhere
+   * in our local stack.
    *
    * Bug fix (PR-J, 2026-05-18): the 2026-05-18 soak between
    * Miles and Lex surfaced `enumerated=4 attempted=4 queued=4`
@@ -118,6 +119,22 @@ export interface CGMemberEnumeratorDeps {
    * outbox row, monotonically rising `queued` counter, no acks.
    * The filter drops those before substrate fan-out attempts.
    *
+   * **MUST match the reachability data the send path uses**, not
+   * just `libp2p.getPeers()` (live connections only). The send
+   * path also dials via peerStore-cached addresses, so a peer we
+   * briefly disconnected from but still know addresses for is
+   * dialable — filtering it out would silently drop a legitimate
+   * subscriber from substrate fan-out + ackQuorum's
+   * expectedMembers. The wiring in `DKGAgent` therefore returns
+   * true for `connected OR peerStore-has-addresses`. PR-J round
+   * 2 (codex feedback on #584).
+   *
+   * Async to accommodate libp2p's `peerStore.get` API (sync
+   * `getPeers()` alone is too narrow per the bug above). The
+   * enumerator awaits each peer in parallel — the dedup'd
+   * subscriber list is small (tens of peers typical), so the
+   * extra await batch is negligible.
+   *
    * Intentionally NOT applied to the `allowlist` branch: curated
    * CGs deliberately track ALL allowlisted peers (online or not)
    * so the watchdog can fire substrate top-up when a previously
@@ -126,12 +143,21 @@ export interface CGMemberEnumeratorDeps {
    * `topic-subscribers` offline subscribers are noise we can't
    * distinguish from churn, so we drop them.
    *
+   * Applied OUTSIDE the TTL cache (PR-J round 2, codex YELLOW on
+   * #584): the cache stores the unfiltered deduped subscriber
+   * snapshot (the expensive SPARQL + getSubscribers work), and
+   * the filter runs on EVERY `enumerate()` against the current
+   * connection state. A peer that briefly disconnects and
+   * reconnects within the 60s cache window is therefore eligible
+   * again on the very next call, not stranded for up to a
+   * minute.
+   *
    * Optional so existing tests / non-substrate callers that
    * construct an enumerator without a libp2p handle keep
    * working. When omitted, the filter is a no-op and pre-PR-J
    * behaviour is preserved.
    */
-  isPeerDialable?: (peerId: string) => boolean;
+  isPeerDialable?: (peerId: string) => boolean | Promise<boolean>;
   /**
    * Lazy accessor for our own peer ID. Always excluded from the
    * returned member set — we don't fan-out to ourselves (the local
@@ -251,28 +277,62 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
     // Public CG: no on-chain roster exists by design (subscribers
     // don't pay to subscribe). Use the live GossipSub view.
     //
-    // Source label is derived from the FILTERED member list, not
-    // from the raw subscriber count. Bug fix (codex review on #571
-    // round 2): when the only subscriber visible is `self` (common
-    // when we're the first to subscribe to a public CG and no one
-    // else has joined yet) or duplicates collapse away, we'd
-    // otherwise return `{ source: 'topic-subscribers', members: [] }`
-    // and any caller that treats `source !== 'none'` as "I have
-    // remote recipients" would skip the intended fallback.
+    // Source label is derived from the deduped member list. Bug
+    // fix (codex review on #571 round 2): when the only subscriber
+    // visible is `self` (common when we're the first to subscribe
+    // to a public CG and no one else has joined yet) or duplicates
+    // collapse away, we'd otherwise return `{ source:
+    // 'topic-subscribers', members: [] }` and any caller that
+    // treats `source !== 'none'` as "I have remote recipients"
+    // would skip the intended fallback.
     //
-    // PR-J (2026-05-18) adds a second filter pass: ghost peers
-    // that GossipSub still lists as subscribers but that we
-    // can't actually reach (no live connection) are dropped
-    // before reporting. See the `isPeerDialable` jsdoc on
-    // CGMemberEnumeratorDeps for the soak data this fixes.
+    // PR-J round 2: the `isPeerDialable` filter (added for the
+    // 2026-05-18 ghost-subscribers soak bug — see jsdoc) is
+    // intentionally NOT applied here. We cache the UNFILTERED
+    // deduped subscriber snapshot and let `enumerate()` apply
+    // the liveness filter on every call against current
+    // connection state. Reason: a peer that briefly disconnects
+    // shouldn't be stranded for up to 60s waiting for the cache
+    // to expire (codex YELLOW on #584). The expensive work the
+    // TTL was meant to amortise (SPARQL allowlist resolution,
+    // GossipSub subscriber snapshot) IS cached; only the cheap
+    // liveness check repeats.
     const subscribers = deps.getTopicSubscribers(deps.topicForCG(cgId));
-    const deduped = dedupAndExcludeSelf(subscribers, deps.getSelfPeerId());
-    const members = deps.isPeerDialable
-      ? deduped.filter(deps.isPeerDialable)
-      : deduped;
+    const members = dedupAndExcludeSelf(subscribers, deps.getSelfPeerId());
     return members.length === 0
       ? { source: 'none', members: [] }
       : { source: 'topic-subscribers', members };
+  }
+
+  /**
+   * Apply the `isPeerDialable` filter to a topic-subscribers
+   * result. No-op for other sources or when no filter is wired.
+   * Async to accommodate libp2p's `peerStore.get`. Empty filtered
+   * sets collapse to `source: 'none'` for the same reason the
+   * unfiltered self-only path does (callers gate substrate /
+   * ackQuorum on `source !== 'none'`).
+   *
+   * On predicate throw: treat as `false` (drop the peer). Less
+   * aggressive than crashing the whole enumeration — a single
+   * bad peerStore lookup shouldn't take down all SWM fan-out for
+   * this CG.
+   */
+  async function applyLivenessFilter(value: CGMemberEnumeration): Promise<CGMemberEnumeration> {
+    if (value.source !== 'topic-subscribers') return value;
+    if (!deps.isPeerDialable) return value;
+    const predicate = deps.isPeerDialable;
+    const checks = await Promise.all(value.members.map(async (peerId) => {
+      try {
+        return await predicate(peerId);
+      } catch {
+        return false;
+      }
+    }));
+    const filtered = value.members.filter((_, idx) => checks[idx]);
+    if (filtered.length === value.members.length) return value;
+    return filtered.length === 0
+      ? { source: 'none', members: [] }
+      : { source: 'topic-subscribers', members: filtered };
   }
 
   return {
@@ -280,11 +340,11 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
       const nowMs = now();
       const cached = cache.get(cgId);
       if (cached && isFresh(cached, nowMs)) {
-        return cached.value;
+        return applyLivenessFilter(cached.value);
       }
 
       const existing = inFlight.get(cgId);
-      if (existing) return existing;
+      if (existing) return applyLivenessFilter(await existing);
 
       const gen = currentGen(cgId);
       const promise = resolve(cgId, gen, nowMs).finally(() => {
@@ -297,7 +357,7 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
         }
       });
       inFlight.set(cgId, promise);
-      return promise;
+      return applyLivenessFilter(await promise);
     },
 
     invalidate(cgId: string): void {

--- a/packages/agent/src/swm/enumerate-cg-members.ts
+++ b/packages/agent/src/swm/enumerate-cg-members.ts
@@ -102,6 +102,37 @@ export interface CGMemberEnumeratorDeps {
   getTopicSubscribers: (topic: string) => string[];
   topicForCG: (cgId: string) => string;
   /**
+   * Optional liveness filter for the `topic-subscribers` branch.
+   * Returns true iff the peer is currently dialable from this
+   * node (e.g. a live libp2p connection exists). Applied AFTER
+   * `dedupAndExcludeSelf` to drop ghost subscribers that
+   * GossipSub's peer-exchange / heartbeat still advertises but
+   * that have since gone offline (or were never reachable).
+   *
+   * Bug fix (PR-J, 2026-05-18): the 2026-05-18 soak between
+   * Miles and Lex surfaced `enumerated=4 attempted=4 queued=4`
+   * every cycle on a public CG that had exactly one real
+   * subscriber (Lex). Three of the four enumerated peers were
+   * ghost entries in our local GossipSub mesh view — sendReliable
+   * to each hit `no valid addresses` (recoverable) → permanent
+   * outbox row, monotonically rising `queued` counter, no acks.
+   * The filter drops those before substrate fan-out attempts.
+   *
+   * Intentionally NOT applied to the `allowlist` branch: curated
+   * CGs deliberately track ALL allowlisted peers (online or not)
+   * so the watchdog can fire substrate top-up when a previously
+   * offline allowlistee reconnects. For `allowlist` the offline
+   * peer eventually recovers via `runSyncOnConnect`; for
+   * `topic-subscribers` offline subscribers are noise we can't
+   * distinguish from churn, so we drop them.
+   *
+   * Optional so existing tests / non-substrate callers that
+   * construct an enumerator without a libp2p handle keep
+   * working. When omitted, the filter is a no-op and pre-PR-J
+   * behaviour is preserved.
+   */
+  isPeerDialable?: (peerId: string) => boolean;
+  /**
    * Lazy accessor for our own peer ID. Always excluded from the
    * returned member set — we don't fan-out to ourselves (the local
    * apply already happened in the caller).
@@ -228,8 +259,17 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
     // otherwise return `{ source: 'topic-subscribers', members: [] }`
     // and any caller that treats `source !== 'none'` as "I have
     // remote recipients" would skip the intended fallback.
+    //
+    // PR-J (2026-05-18) adds a second filter pass: ghost peers
+    // that GossipSub still lists as subscribers but that we
+    // can't actually reach (no live connection) are dropped
+    // before reporting. See the `isPeerDialable` jsdoc on
+    // CGMemberEnumeratorDeps for the soak data this fixes.
     const subscribers = deps.getTopicSubscribers(deps.topicForCG(cgId));
-    const members = dedupAndExcludeSelf(subscribers, deps.getSelfPeerId());
+    const deduped = dedupAndExcludeSelf(subscribers, deps.getSelfPeerId());
+    const members = deps.isPeerDialable
+      ? deduped.filter(deps.isPeerDialable)
+      : deduped;
     return members.length === 0
       ? { source: 'none', members: [] }
       : { source: 'topic-subscribers', members };

--- a/packages/agent/src/swm/enumerate-cg-members.ts
+++ b/packages/agent/src/swm/enumerate-cg-members.ts
@@ -54,8 +54,40 @@ export interface CGMemberEnumeration {
    * guaranteed (depends on SPARQL result ordering or GossipSub's
    * internal peer set iteration). Caller MUST de-duplicate if it
    * combines results across calls.
+   *
+   * This is the FULL set — gossip-delivery-eligible AND
+   * ackQuorum-tracking-eligible. Substrate fan-out should consult
+   * {@link substrateEligibleMembers} instead (when set) so it
+   * doesn't waste sends on peers we have no addressing for. See
+   * the {@link CGMemberEnumeratorDeps.isPeerDialable} jsdoc for
+   * why the two sets diverge.
    */
   members: string[];
+  /**
+   * Subset of {@link members} that {@link CGMemberEnumeratorDeps.isPeerDialable}
+   * accepts — i.e. the peers the substrate fan-out is allowed to
+   * target. Undefined when no `isPeerDialable` predicate was
+   * wired (pre-PR-J behaviour: substrate targets the full set).
+   *
+   * Added in PR-J round 2 (codex feedback on #584 round 2): the
+   * round-1 / round-2-pre-fix design filtered `members` in place,
+   * which silently shrunk the ackQuorum's `expectedMembers` for
+   * gossip-only-large-public CGs and disabled the watchdog. The
+   * dual-field shape keeps `members` as the optimistic upper
+   * bound (gossip + ackQuorum) and `substrateEligibleMembers`
+   * as the dialable subset (substrate target only).
+   *
+   * For the soak bug this PR fixes: a CG with one real
+   * subscriber (Lex) and three ghost peer-exchange entries
+   * returns `members: [Lex, ghostA, ghostB, ghostC]` and
+   * `substrateEligibleMembers: [Lex]`. Substrate targets only
+   * Lex; ackQuorum still tracks all four (so a hypothetical
+   * gossip-reachable ghost could still ack). Ghosts that never
+   * ack reach the hard deadline and surface through
+   * `onDeadlineExpired` — a metric blip, not a wire-load
+   * regression.
+   */
+  substrateEligibleMembers?: string[];
 }
 
 export interface CGMemberEnumeratorDeps {
@@ -102,13 +134,11 @@ export interface CGMemberEnumeratorDeps {
   getTopicSubscribers: (topic: string) => string[];
   topicForCG: (cgId: string) => string;
   /**
-   * Optional liveness filter for the `topic-subscribers` branch.
+   * Optional liveness filter for the SUBSTRATE TARGET subset.
    * Returns true iff the peer is reachable from this node — i.e.
    * `sendReliable` has a realistic chance of putting bytes on the
-   * wire to them. Applied AFTER `dedupAndExcludeSelf` to drop
-   * ghost subscribers that GossipSub's peer-exchange / heartbeat
-   * still advertises but that have no addressing info anywhere
-   * in our local stack.
+   * wire to them. Populates {@link CGMemberEnumeration.substrateEligibleMembers}
+   * on the result; does NOT touch {@link CGMemberEnumeration.members}.
    *
    * Bug fix (PR-J, 2026-05-18): the 2026-05-18 soak between
    * Miles and Lex surfaced `enumerated=4 attempted=4 queued=4`
@@ -117,17 +147,17 @@ export interface CGMemberEnumeratorDeps {
    * ghost entries in our local GossipSub mesh view — sendReliable
    * to each hit `no valid addresses` (recoverable) → permanent
    * outbox row, monotonically rising `queued` counter, no acks.
-   * The filter drops those before substrate fan-out attempts.
+   * The filter drops those from the substrate target set before
+   * fan-out attempts.
    *
    * **MUST match the reachability data the send path uses**, not
    * just `libp2p.getPeers()` (live connections only). The send
    * path also dials via peerStore-cached addresses, so a peer we
    * briefly disconnected from but still know addresses for is
    * dialable — filtering it out would silently drop a legitimate
-   * subscriber from substrate fan-out + ackQuorum's
-   * expectedMembers. The wiring in `DKGAgent` therefore returns
-   * true for `connected OR peerStore-has-addresses`. PR-J round
-   * 2 (codex feedback on #584).
+   * subscriber from substrate fan-out. The wiring in `DKGAgent`
+   * therefore returns true for `connected OR peerStore-has-addresses`
+   * (codex RED #1 on #584 round 1).
    *
    * Async to accommodate libp2p's `peerStore.get` API (sync
    * `getPeers()` alone is too narrow per the bug above). The
@@ -143,8 +173,8 @@ export interface CGMemberEnumeratorDeps {
    * `topic-subscribers` offline subscribers are noise we can't
    * distinguish from churn, so we drop them.
    *
-   * Applied OUTSIDE the TTL cache (PR-J round 2, codex YELLOW on
-   * #584): the cache stores the unfiltered deduped subscriber
+   * Applied OUTSIDE the TTL cache (codex YELLOW on #584 round
+   * 1): the cache stores the unfiltered deduped subscriber
    * snapshot (the expensive SPARQL + getSubscribers work), and
    * the filter runs on EVERY `enumerate()` against the current
    * connection state. A peer that briefly disconnects and
@@ -152,10 +182,17 @@ export interface CGMemberEnumeratorDeps {
    * again on the very next call, not stranded for up to a
    * minute.
    *
+   * Does NOT shrink `members` (codex RED #3 on #584 round 2):
+   * the pre-round-2 design filtered `members` in place, which
+   * silently shrunk the ackQuorum's `expectedMembers` for
+   * gossip-only-large-public CGs and disabled the watchdog. The
+   * filter now populates a separate `substrateEligibleMembers`
+   * subset; `members` stays as the full gossip-eligible set.
+   *
    * Optional so existing tests / non-substrate callers that
    * construct an enumerator without a libp2p handle keep
-   * working. When omitted, the filter is a no-op and pre-PR-J
-   * behaviour is preserved.
+   * working. When omitted, `substrateEligibleMembers` stays
+   * undefined and pre-PR-J behaviour is preserved.
    */
   isPeerDialable?: (peerId: string) => boolean | Promise<boolean>;
   /**
@@ -287,16 +324,19 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
     // would skip the intended fallback.
     //
     // PR-J round 2: the `isPeerDialable` filter (added for the
-    // 2026-05-18 ghost-subscribers soak bug — see jsdoc) is
-    // intentionally NOT applied here. We cache the UNFILTERED
-    // deduped subscriber snapshot and let `enumerate()` apply
-    // the liveness filter on every call against current
-    // connection state. Reason: a peer that briefly disconnects
-    // shouldn't be stranded for up to 60s waiting for the cache
-    // to expire (codex YELLOW on #584). The expensive work the
-    // TTL was meant to amortise (SPARQL allowlist resolution,
-    // GossipSub subscriber snapshot) IS cached; only the cheap
-    // liveness check repeats.
+    // 2026-05-18 ghost-subscribers soak bug — see jsdoc) populates
+    // a SEPARATE `substrateEligibleMembers` field outside the
+    // cache (in `enumerate()`); `members` here stays as the full
+    // gossip-eligible set so ackQuorum keeps tracking everyone.
+    // Reasons:
+    //   - codex YELLOW on round 1: a transient disconnect
+    //     shouldn't strand a real subscriber for up to 60s.
+    //   - codex RED on round 2: filtering `members` in place would
+    //     shrink ackQuorum's expectedMembers and silently disable
+    //     the watchdog for gossip-only-large-public CGs.
+    // The expensive work the TTL was meant to amortise (SPARQL
+    // allowlist resolution, GossipSub subscriber snapshot) IS
+    // cached; only the cheap liveness check repeats.
     const subscribers = deps.getTopicSubscribers(deps.topicForCG(cgId));
     const members = dedupAndExcludeSelf(subscribers, deps.getSelfPeerId());
     return members.length === 0
@@ -305,19 +345,19 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
   }
 
   /**
-   * Apply the `isPeerDialable` filter to a topic-subscribers
-   * result. No-op for other sources or when no filter is wired.
-   * Async to accommodate libp2p's `peerStore.get`. Empty filtered
-   * sets collapse to `source: 'none'` for the same reason the
-   * unfiltered self-only path does (callers gate substrate /
-   * ackQuorum on `source !== 'none'`).
+   * Populate `substrateEligibleMembers` on a topic-subscribers
+   * result by awaiting `isPeerDialable` per-peer. No-op for
+   * other sources or when no filter is wired. Async to
+   * accommodate libp2p's `peerStore.get`. Throws caught + treated
+   * as "not dialable" — a single bad peerStore lookup shouldn't
+   * shrink the substrate target set across the whole CG.
    *
-   * On predicate throw: treat as `false` (drop the peer). Less
-   * aggressive than crashing the whole enumeration — a single
-   * bad peerStore lookup shouldn't take down all SWM fan-out for
-   * this CG.
+   * Returns the input unchanged when there's nothing to filter;
+   * otherwise returns a NEW object sharing the same `members`
+   * array (callers that mutate the result get the dual-field
+   * shape they expect).
    */
-  async function applyLivenessFilter(value: CGMemberEnumeration): Promise<CGMemberEnumeration> {
+  async function populateSubstrateEligibleMembers(value: CGMemberEnumeration): Promise<CGMemberEnumeration> {
     if (value.source !== 'topic-subscribers') return value;
     if (!deps.isPeerDialable) return value;
     const predicate = deps.isPeerDialable;
@@ -329,10 +369,11 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
       }
     }));
     const filtered = value.members.filter((_, idx) => checks[idx]);
-    if (filtered.length === value.members.length) return value;
-    return filtered.length === 0
-      ? { source: 'none', members: [] }
-      : { source: 'topic-subscribers', members: filtered };
+    return {
+      source: value.source,
+      members: value.members,
+      substrateEligibleMembers: filtered,
+    };
   }
 
   return {
@@ -340,11 +381,11 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
       const nowMs = now();
       const cached = cache.get(cgId);
       if (cached && isFresh(cached, nowMs)) {
-        return applyLivenessFilter(cached.value);
+        return populateSubstrateEligibleMembers(cached.value);
       }
 
       const existing = inFlight.get(cgId);
-      if (existing) return applyLivenessFilter(await existing);
+      if (existing) return populateSubstrateEligibleMembers(await existing);
 
       const gen = currentGen(cgId);
       const promise = resolve(cgId, gen, nowMs).finally(() => {
@@ -357,7 +398,7 @@ export function createCGMemberEnumerator(deps: CGMemberEnumeratorDeps): CGMember
         }
       });
       inFlight.set(cgId, promise);
-      return applyLivenessFilter(await promise);
+      return populateSubstrateEligibleMembers(await promise);
     },
 
     invalidate(cgId: string): void {

--- a/packages/agent/src/swm/substrate-fanout.ts
+++ b/packages/agent/src/swm/substrate-fanout.ts
@@ -96,6 +96,14 @@ export interface FanOutPlan {
    * `useSubstrate === false`. Already de-duplicated and
    * self-excluded by `CGMemberEnumerator`; this module does NOT
    * filter further.
+   *
+   * PR-J round 2 (codex RED #3 on #584): for `topic-subscribers`
+   * CGs this is the `CGMemberEnumeration.substrateEligibleMembers`
+   * subset when an `isPeerDialable` predicate was wired —
+   * potentially smaller than `enumeratedMembers`. For
+   * `allowlist` CGs the substrate target IS the full enumerated
+   * set (curated CGs deliberately track offline allowlistees so
+   * the watchdog can fire substrate top-up on reconnect).
    */
   substrateMembers: readonly string[];
   /**
@@ -189,6 +197,16 @@ export interface ChooseFanOutTierInput {
 export function chooseFanOutTier(input: ChooseFanOutTierInput): FanOutPlan {
   const { enumeration, maxSubstrateMembers } = input;
   const enumeratedCount = enumeration.members.length;
+  // PR-J round 2 (codex RED #3 on #584): substrate target may be
+  // a subset of `members` when the enumerator's `isPeerDialable`
+  // filter dropped ghost peer-exchange entries. `members` stays
+  // as the full gossip-eligible set (drives `enumeratedMembers`
+  // → SwmAckQuorum.expectedMembers); the substrate target uses
+  // the filtered subset when available. For curated
+  // (`allowlist`) CGs the enumerator never populates this field
+  // (we deliberately track offline allowlistees), so the
+  // fallback to `members` preserves curated semantics.
+  const substrateTarget = enumeration.substrateEligibleMembers ?? enumeration.members;
 
   switch (enumeration.source) {
     case 'allowlist':
@@ -205,7 +223,7 @@ export function chooseFanOutTier(input: ChooseFanOutTierInput): FanOutPlan {
         return {
           useSubstrate: true,
           useGossip: true,
-          substrateMembers: enumeration.members,
+          substrateMembers: substrateTarget,
           enumeratedMembers: enumeration.members,
           enumerationSource: 'topic-subscribers',
           enumeratedCount,

--- a/packages/agent/test/enumerate-cg-members.test.ts
+++ b/packages/agent/test/enumerate-cg-members.test.ts
@@ -129,6 +129,97 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
 
     expect(result).toEqual({ source: 'none', members: [] });
   });
+
+  /**
+   * PR-J (2026-05-18): drop GossipSub-advertised subscribers that
+   * we don't currently have a live connection to. Soak data: the
+   * 2026-05-18 Miles<->Lex run enumerated 4 subscribers on a CG
+   * with one real subscriber — three were ghosts in the local
+   * mesh view, every substrate send to them queued forever, and
+   * the ackQuorum's expectedMembers waited on acks that would
+   * never arrive.
+   */
+  describe('isPeerDialable filter (PR-J)', () => {
+    it('drops topic-subscribers that fail the dialable predicate', async () => {
+      const enumerator = createCGMemberEnumerator(makeDeps({
+        getContextGraphAllowedPeers: async () => null,
+        getTopicSubscribers: () => ['liveA', 'ghostB', 'liveC', 'ghostD'],
+        isPeerDialable: (peerId) => peerId.startsWith('live'),
+      }));
+
+      const result = await enumerator.enumerate('cg-public-ghosts');
+
+      expect(result.source).toBe('topic-subscribers');
+      expect(result.members.sort()).toEqual(['liveA', 'liveC']);
+    });
+
+    it('returns source=none when filter removes every subscriber', async () => {
+      const enumerator = createCGMemberEnumerator(makeDeps({
+        getContextGraphAllowedPeers: async () => null,
+        getTopicSubscribers: () => ['ghostA', 'ghostB'],
+        isPeerDialable: () => false,
+      }));
+
+      const result = await enumerator.enumerate('cg-public-all-ghosts');
+
+      expect(result).toEqual({ source: 'none', members: [] });
+    });
+
+    it('does NOT apply the filter to the allowlist branch', async () => {
+      // Curated CGs deliberately track offline allowlistees so the
+      // watchdog can fire substrate top-up when they reconnect.
+      // Filtering here would silently regress that behaviour.
+      let isPeerDialableCalled = 0;
+      const enumerator = createCGMemberEnumerator(makeDeps({
+        getContextGraphAllowedPeers: async () => ['peerA', 'peerB'],
+        isPeerDialable: () => {
+          isPeerDialableCalled += 1;
+          return false;
+        },
+      }));
+
+      const result = await enumerator.enumerate('cg-curated-with-offline');
+
+      expect(result.source).toBe('allowlist');
+      expect(result.members.sort()).toEqual(['peerA', 'peerB']);
+      expect(isPeerDialableCalled).toBe(0);
+    });
+
+    it('treats missing isPeerDialable as a no-op (pre-PR-J behaviour)', async () => {
+      const enumerator = createCGMemberEnumerator(makeDeps({
+        getContextGraphAllowedPeers: async () => null,
+        getTopicSubscribers: () => ['peerA', 'peerB'],
+        // Note: no isPeerDialable in deps. Compatibility with
+        // older callers that don't yet pass the filter.
+      }));
+
+      const result = await enumerator.enumerate('cg-public-no-filter');
+
+      expect(result.source).toBe('topic-subscribers');
+      expect(result.members.sort()).toEqual(['peerA', 'peerB']);
+    });
+
+    it('filter is applied AFTER dedupAndExcludeSelf', async () => {
+      // Self should never be passed to the filter; duplicates
+      // should be collapsed before the filter runs.
+      const seenByFilter: string[] = [];
+      const enumerator = createCGMemberEnumerator(makeDeps({
+        getContextGraphAllowedPeers: async () => null,
+        getTopicSubscribers: () => [SELF, 'peerA', 'peerA', SELF, 'peerB'],
+        isPeerDialable: (peerId) => {
+          seenByFilter.push(peerId);
+          return peerId !== 'peerB';
+        },
+      }));
+
+      const result = await enumerator.enumerate('cg-public-filter-order');
+
+      expect(result.source).toBe('topic-subscribers');
+      expect(result.members).toEqual(['peerA']);
+      // Filter never sees self or duplicates.
+      expect(seenByFilter.sort()).toEqual(['peerA', 'peerB']);
+    });
+  });
 });
 
 /**

--- a/packages/agent/test/enumerate-cg-members.test.ts
+++ b/packages/agent/test/enumerate-cg-members.test.ts
@@ -132,12 +132,18 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
 
   /**
    * PR-J (2026-05-18): drop GossipSub-advertised subscribers that
-   * we don't currently have a live connection to. Soak data: the
-   * 2026-05-18 Miles<->Lex run enumerated 4 subscribers on a CG
-   * with one real subscriber — three were ghosts in the local
-   * mesh view, every substrate send to them queued forever, and
-   * the ackQuorum's expectedMembers waited on acks that would
-   * never arrive.
+   * we have no realistic chance of reaching via the send path.
+   * Soak data: the 2026-05-18 Miles<->Lex run enumerated 4
+   * subscribers on a CG with one real subscriber — three were
+   * ghosts in the local mesh view, every substrate send to them
+   * queued forever, and the ackQuorum's expectedMembers waited on
+   * acks that would never arrive.
+   *
+   * Round 2 (codex feedback on #584): the filter is now async
+   * (the real predicate consults libp2p.peerStore.get for the
+   * non-connected branch) AND is applied OUTSIDE the TTL cache so
+   * a transient disconnect doesn't strand a real subscriber for
+   * up to 60s.
    */
   describe('isPeerDialable filter (PR-J)', () => {
     it('drops topic-subscribers that fail the dialable predicate', async () => {
@@ -151,6 +157,25 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
 
       expect(result.source).toBe('topic-subscribers');
       expect(result.members.sort()).toEqual(['liveA', 'liveC']);
+    });
+
+    it('supports an async (Promise-returning) predicate', async () => {
+      // The real wiring in DKGAgent is async (libp2p.peerStore.get
+      // is async). Predicate must be awaited per-peer; throws are
+      // caught and treated as "not dialable".
+      const enumerator = createCGMemberEnumerator(makeDeps({
+        getContextGraphAllowedPeers: async () => null,
+        getTopicSubscribers: () => ['liveA', 'ghostB', 'throwC', 'liveD'],
+        isPeerDialable: async (peerId) => {
+          if (peerId === 'throwC') throw new Error('peerStore cold cache miss');
+          return peerId.startsWith('live');
+        },
+      }));
+
+      const result = await enumerator.enumerate('cg-public-async');
+
+      expect(result.source).toBe('topic-subscribers');
+      expect(result.members.sort()).toEqual(['liveA', 'liveD']);
     });
 
     it('returns source=none when filter removes every subscriber', async () => {
@@ -189,8 +214,6 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
       const enumerator = createCGMemberEnumerator(makeDeps({
         getContextGraphAllowedPeers: async () => null,
         getTopicSubscribers: () => ['peerA', 'peerB'],
-        // Note: no isPeerDialable in deps. Compatibility with
-        // older callers that don't yet pass the filter.
       }));
 
       const result = await enumerator.enumerate('cg-public-no-filter');
@@ -200,8 +223,6 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
     });
 
     it('filter is applied AFTER dedupAndExcludeSelf', async () => {
-      // Self should never be passed to the filter; duplicates
-      // should be collapsed before the filter runs.
       const seenByFilter: string[] = [];
       const enumerator = createCGMemberEnumerator(makeDeps({
         getContextGraphAllowedPeers: async () => null,
@@ -216,8 +237,62 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
 
       expect(result.source).toBe('topic-subscribers');
       expect(result.members).toEqual(['peerA']);
-      // Filter never sees self or duplicates.
       expect(seenByFilter.sort()).toEqual(['peerA', 'peerB']);
+    });
+
+    /**
+     * Codex YELLOW regression on #584 round 1: the liveness filter
+     * is applied OUTSIDE the 60s TTL cache. A subscriber that
+     * goes from non-dialable → dialable → non-dialable across
+     * three successive calls must surface that exact pattern,
+     * even when the underlying subscriber snapshot is cached.
+     */
+    it('filter result reflects current state on every call (not cached)', async () => {
+      let isDialable = false;
+      const enumerator = createCGMemberEnumerator(makeDeps({
+        getContextGraphAllowedPeers: async () => null,
+        getTopicSubscribers: () => ['peerA'],
+        isPeerDialable: () => isDialable,
+      }));
+
+      const r1 = await enumerator.enumerate('cg-public-cache');
+      expect(r1.source).toBe('none');
+
+      isDialable = true;
+      const r2 = await enumerator.enumerate('cg-public-cache');
+      expect(r2.source).toBe('topic-subscribers');
+      expect(r2.members).toEqual(['peerA']);
+
+      isDialable = false;
+      const r3 = await enumerator.enumerate('cg-public-cache');
+      expect(r3.source).toBe('none');
+    });
+
+    it('cached subscriber snapshot is reused across calls (only filter re-runs)', async () => {
+      // Sanity check: the EXPENSIVE work (getSubscribers,
+      // getContextGraphAllowedPeers) is still cached. Only the
+      // cheap liveness filter is invalidated per-call. Verifies
+      // we didn't accidentally undo the TTL optimisation.
+      let getSubscribersCalls = 0;
+      let getAllowedCalls = 0;
+      const enumerator = createCGMemberEnumerator(makeDeps({
+        getContextGraphAllowedPeers: async () => {
+          getAllowedCalls += 1;
+          return null;
+        },
+        getTopicSubscribers: () => {
+          getSubscribersCalls += 1;
+          return ['peerA', 'peerB'];
+        },
+        isPeerDialable: () => true,
+      }));
+
+      await enumerator.enumerate('cg-public-cache-hit');
+      await enumerator.enumerate('cg-public-cache-hit');
+      await enumerator.enumerate('cg-public-cache-hit');
+
+      expect(getAllowedCalls).toBe(1);
+      expect(getSubscribersCalls).toBe(1);
     });
   });
 });

--- a/packages/agent/test/enumerate-cg-members.test.ts
+++ b/packages/agent/test/enumerate-cg-members.test.ts
@@ -131,22 +131,29 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
   });
 
   /**
-   * PR-J (2026-05-18): drop GossipSub-advertised subscribers that
-   * we have no realistic chance of reaching via the send path.
-   * Soak data: the 2026-05-18 Miles<->Lex run enumerated 4
+   * PR-J (2026-05-18): identify GossipSub-advertised subscribers
+   * that the substrate fan-out has no realistic chance of
+   * reaching, so substrate doesn't waste sends on them. Soak
+   * data: the 2026-05-18 Miles<->Lex run enumerated 4
    * subscribers on a CG with one real subscriber — three were
    * ghosts in the local mesh view, every substrate send to them
-   * queued forever, and the ackQuorum's expectedMembers waited on
-   * acks that would never arrive.
+   * queued forever, ackQuorum waited on acks that would never
+   * arrive.
    *
-   * Round 2 (codex feedback on #584): the filter is now async
-   * (the real predicate consults libp2p.peerStore.get for the
-   * non-connected branch) AND is applied OUTSIDE the TTL cache so
-   * a transient disconnect doesn't strand a real subscriber for
-   * up to 60s.
+   * Round 2 (codex feedback on #584):
+   *   - The filter is async (real wiring consults
+   *     libp2p.peerStore.get for the non-connected branch).
+   *   - It's applied OUTSIDE the TTL cache (codex YELLOW round
+   *     1) so a transient disconnect doesn't strand a real
+   *     subscriber for up to 60s.
+   *   - It populates a NEW `substrateEligibleMembers` field
+   *     instead of shrinking `members` in place (codex RED #3
+   *     round 2) — `members` stays as the full gossip-eligible
+   *     set so ackQuorum keeps tracking everyone, and only
+   *     substrate fan-out consults the filtered subset.
    */
   describe('isPeerDialable filter (PR-J)', () => {
-    it('drops topic-subscribers that fail the dialable predicate', async () => {
+    it('populates substrateEligibleMembers with the dialable subset, leaves members unfiltered', async () => {
       const enumerator = createCGMemberEnumerator(makeDeps({
         getContextGraphAllowedPeers: async () => null,
         getTopicSubscribers: () => ['liveA', 'ghostB', 'liveC', 'ghostD'],
@@ -156,13 +163,11 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
       const result = await enumerator.enumerate('cg-public-ghosts');
 
       expect(result.source).toBe('topic-subscribers');
-      expect(result.members.sort()).toEqual(['liveA', 'liveC']);
+      expect(result.members.sort()).toEqual(['ghostB', 'ghostD', 'liveA', 'liveC']);
+      expect(result.substrateEligibleMembers?.sort()).toEqual(['liveA', 'liveC']);
     });
 
     it('supports an async (Promise-returning) predicate', async () => {
-      // The real wiring in DKGAgent is async (libp2p.peerStore.get
-      // is async). Predicate must be awaited per-peer; throws are
-      // caught and treated as "not dialable".
       const enumerator = createCGMemberEnumerator(makeDeps({
         getContextGraphAllowedPeers: async () => null,
         getTopicSubscribers: () => ['liveA', 'ghostB', 'throwC', 'liveD'],
@@ -175,10 +180,19 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
       const result = await enumerator.enumerate('cg-public-async');
 
       expect(result.source).toBe('topic-subscribers');
-      expect(result.members.sort()).toEqual(['liveA', 'liveD']);
+      expect(result.members.length).toBe(4);
+      expect(result.substrateEligibleMembers?.sort()).toEqual(['liveA', 'liveD']);
     });
 
-    it('returns source=none when filter removes every subscriber', async () => {
+    /**
+     * Codex RED #3 (round 2): even when EVERY subscriber fails
+     * the dialability filter, `members` MUST stay populated so
+     * ackQuorum tracks all of them. The pre-round-2 design
+     * collapsed `source` to `'none'` and emptied `members` in
+     * this case, silently disabling the watchdog for shares
+     * fanning out to a gossip-only-reachable subscriber set.
+     */
+    it('keeps members populated and source=topic-subscribers even when nobody is dialable', async () => {
       const enumerator = createCGMemberEnumerator(makeDeps({
         getContextGraphAllowedPeers: async () => null,
         getTopicSubscribers: () => ['ghostA', 'ghostB'],
@@ -187,13 +201,12 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
 
       const result = await enumerator.enumerate('cg-public-all-ghosts');
 
-      expect(result).toEqual({ source: 'none', members: [] });
+      expect(result.source).toBe('topic-subscribers');
+      expect(result.members.sort()).toEqual(['ghostA', 'ghostB']);
+      expect(result.substrateEligibleMembers).toEqual([]);
     });
 
-    it('does NOT apply the filter to the allowlist branch', async () => {
-      // Curated CGs deliberately track offline allowlistees so the
-      // watchdog can fire substrate top-up when they reconnect.
-      // Filtering here would silently regress that behaviour.
+    it('does NOT populate substrateEligibleMembers for the allowlist branch', async () => {
       let isPeerDialableCalled = 0;
       const enumerator = createCGMemberEnumerator(makeDeps({
         getContextGraphAllowedPeers: async () => ['peerA', 'peerB'],
@@ -207,6 +220,7 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
 
       expect(result.source).toBe('allowlist');
       expect(result.members.sort()).toEqual(['peerA', 'peerB']);
+      expect(result.substrateEligibleMembers).toBeUndefined();
       expect(isPeerDialableCalled).toBe(0);
     });
 
@@ -220,6 +234,7 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
 
       expect(result.source).toBe('topic-subscribers');
       expect(result.members.sort()).toEqual(['peerA', 'peerB']);
+      expect(result.substrateEligibleMembers).toBeUndefined();
     });
 
     it('filter is applied AFTER dedupAndExcludeSelf', async () => {
@@ -236,15 +251,16 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
       const result = await enumerator.enumerate('cg-public-filter-order');
 
       expect(result.source).toBe('topic-subscribers');
-      expect(result.members).toEqual(['peerA']);
+      expect(result.members.sort()).toEqual(['peerA', 'peerB']);
+      expect(result.substrateEligibleMembers).toEqual(['peerA']);
       expect(seenByFilter.sort()).toEqual(['peerA', 'peerB']);
     });
 
     /**
-     * Codex YELLOW regression on #584 round 1: the liveness filter
-     * is applied OUTSIDE the 60s TTL cache. A subscriber that
-     * goes from non-dialable → dialable → non-dialable across
-     * three successive calls must surface that exact pattern,
+     * Codex YELLOW regression on #584 round 1: the liveness
+     * filter is applied OUTSIDE the 60s TTL cache. A subscriber
+     * that goes from non-dialable → dialable → non-dialable
+     * across three successive calls must surface that pattern,
      * even when the underlying subscriber snapshot is cached.
      */
     it('filter result reflects current state on every call (not cached)', async () => {
@@ -256,23 +272,19 @@ describe('createCGMemberEnumerator: public CG (topic-subscribers source)', () =>
       }));
 
       const r1 = await enumerator.enumerate('cg-public-cache');
-      expect(r1.source).toBe('none');
+      expect(r1.substrateEligibleMembers).toEqual([]);
+      expect(r1.members).toEqual(['peerA']);
 
       isDialable = true;
       const r2 = await enumerator.enumerate('cg-public-cache');
-      expect(r2.source).toBe('topic-subscribers');
-      expect(r2.members).toEqual(['peerA']);
+      expect(r2.substrateEligibleMembers).toEqual(['peerA']);
 
       isDialable = false;
       const r3 = await enumerator.enumerate('cg-public-cache');
-      expect(r3.source).toBe('none');
+      expect(r3.substrateEligibleMembers).toEqual([]);
     });
 
     it('cached subscriber snapshot is reused across calls (only filter re-runs)', async () => {
-      // Sanity check: the EXPENSIVE work (getSubscribers,
-      // getContextGraphAllowedPeers) is still cached. Only the
-      // cheap liveness filter is invalidated per-call. Verifies
-      // we didn't accidentally undo the TTL optimisation.
       let getSubscribersCalls = 0;
       let getAllowedCalls = 0;
       const enumerator = createCGMemberEnumerator(makeDeps({

--- a/packages/agent/test/swm-ack-quorum-integration.test.ts
+++ b/packages/agent/test/swm-ack-quorum-integration.test.ts
@@ -154,21 +154,37 @@ async function createAgent(name: string): Promise<DKGAgent> {
 }
 
 /**
- * Install a `node.libp2p` shim that reports EVERY peer-id as
+ * Install a `node.libp2p` shim that reports test peers as
  * dialable. Matches the pre-PR-J behaviour the integration tests
- * expect — they care about ack-quorum wiring, not reachability
- * filtering. The PR-J filter is exercised in
+ * expect — they care about ack-quorum / fan-out wiring, not
+ * reachability filtering. The PR-J filter is exercised in
  * `enumerate-cg-members.test.ts` where the predicate is the unit
  * under test.
  *
- * Stubs only the surfaces `DKGAgent.getOrCreateCGMemberEnumerator`'s
- * `isPeerDialable` consults: `getPeers()` (sync; we don't have a
- * fixed list so this returns empty and we lean on `peerStore.get`
- * returning a dialable record for everything).
+ * Why a lazy gossip read: PR-J round 2 (codex RED #4) routes the
+ * `isPeerDialable` predicate through `peerIdFromString` before
+ * `peerStore.get`. Short test peer IDs like `12D3KooWPeerA` are
+ * not valid Ed25519 base58 strings, so `peerIdFromString` would
+ * throw → catch → false → substrate target subset empties →
+ * the whole fan-out stops. We side-step by making `getPeers()`
+ * return whatever gossip.subscribers currently contains: the
+ * first branch of `isPeerDialable` (`getPeers().some(...)`)
+ * matches and short-circuits before peerStore is touched.
+ *
+ * For tests whose substrate fan-out targets peer IDs NOT in
+ * gossip.subscribers (e.g. watchdog-top-up tests with custom
+ * `missingPeers`), they can also push into
+ * `_extraDialablePeerIds` after install.
  */
-function installAllReachableLibp2pStub(agent: DKGAgent): void {
+function installAllReachableLibp2pStub(agent: DKGAgent): { extraDialablePeerIds: string[] } {
+  const extraDialablePeerIds: string[] = [];
   const stub = {
-    getPeers: (): Array<{ toString: () => string }> => [],
+    getPeers: (): Array<{ toString: () => string }> => {
+      const gossip = (agent as unknown as { gossip?: { subscribers?: string[] } }).gossip;
+      const fromGossip = gossip?.subscribers ?? [];
+      const all = [...fromGossip, ...extraDialablePeerIds];
+      return all.map((id) => ({ toString: () => id }));
+    },
     peerStore: {
       get: async (_peerId: unknown) => ({
         addresses: [{ multiaddr: { toString: () => '/ip4/127.0.0.1/tcp/0' } }],
@@ -180,6 +196,7 @@ function installAllReachableLibp2pStub(agent: DKGAgent): void {
     configurable: true,
     writable: true,
   });
+  return { extraDialablePeerIds };
 }
 
 describe('DKGAgent SwmAckQuorum integration (rc.9 PR-D)', () => {

--- a/packages/agent/test/swm-ack-quorum-integration.test.ts
+++ b/packages/agent/test/swm-ack-quorum-integration.test.ts
@@ -141,7 +141,45 @@ async function createAgent(name: string): Promise<DKGAgent> {
     value: SELF_PEER,
     configurable: true,
   });
+  // PR-J: CGMemberEnumerator now filters topic-subscribers
+  // through libp2p reachability (connected OR peerStore-known).
+  // These tests don't drive a real libp2p — without a stub the
+  // filter would strip every fake-peer subscriber and `track()`
+  // would never fire. Treat ALL test peers as dialable; the
+  // PR-J test that actually exercises the filter lives in
+  // `enumerate-cg-members.test.ts` where it can drive the
+  // predicate directly.
+  installAllReachableLibp2pStub(agent);
   return agent;
+}
+
+/**
+ * Install a `node.libp2p` shim that reports EVERY peer-id as
+ * dialable. Matches the pre-PR-J behaviour the integration tests
+ * expect — they care about ack-quorum wiring, not reachability
+ * filtering. The PR-J filter is exercised in
+ * `enumerate-cg-members.test.ts` where the predicate is the unit
+ * under test.
+ *
+ * Stubs only the surfaces `DKGAgent.getOrCreateCGMemberEnumerator`'s
+ * `isPeerDialable` consults: `getPeers()` (sync; we don't have a
+ * fixed list so this returns empty and we lean on `peerStore.get`
+ * returning a dialable record for everything).
+ */
+function installAllReachableLibp2pStub(agent: DKGAgent): void {
+  const stub = {
+    getPeers: (): Array<{ toString: () => string }> => [],
+    peerStore: {
+      get: async (_peerId: unknown) => ({
+        addresses: [{ multiaddr: { toString: () => '/ip4/127.0.0.1/tcp/0' } }],
+      }),
+    },
+  };
+  Object.defineProperty((agent as unknown as { node: { libp2p?: unknown } }).node, 'libp2p', {
+    value: stub,
+    configurable: true,
+    writable: true,
+  });
 }
 
 describe('DKGAgent SwmAckQuorum integration (rc.9 PR-D)', () => {

--- a/packages/agent/test/swm-substrate-fanout-integration.test.ts
+++ b/packages/agent/test/swm-substrate-fanout-integration.test.ts
@@ -118,7 +118,11 @@ async function createAgent(name: string): Promise<DKGAgent> {
 
 function installAllReachableLibp2pStub(agent: DKGAgent): void {
   const stub = {
-    getPeers: (): Array<{ toString: () => string }> => [],
+    getPeers: (): Array<{ toString: () => string }> => {
+      const gossip = (agent as unknown as { gossip?: { subscribers?: string[] } }).gossip;
+      const subs = gossip?.subscribers ?? [];
+      return subs.map((id) => ({ toString: () => id }));
+    },
     peerStore: {
       get: async (_peerId: unknown) => ({
         addresses: [{ multiaddr: { toString: () => '/ip4/127.0.0.1/tcp/0' } }],

--- a/packages/agent/test/swm-substrate-fanout-integration.test.ts
+++ b/packages/agent/test/swm-substrate-fanout-integration.test.ts
@@ -104,7 +104,32 @@ async function createAgent(name: string): Promise<DKGAgent> {
     value: SELF_PEER,
     configurable: true,
   });
+  // PR-J: the CGMemberEnumerator filters topic-subscribers
+  // through libp2p reachability. These tests don't drive a real
+  // libp2p, so without a stub the filter strips every fake
+  // subscriber and substrate fan-out has nobody to send to. The
+  // PR-J filter is exercised in `enumerate-cg-members.test.ts`
+  // where the predicate is the unit under test; here it's the
+  // ack-quorum + bookkeeper wiring that matters, so make
+  // EVERYTHING reachable.
+  installAllReachableLibp2pStub(agent);
   return agent;
+}
+
+function installAllReachableLibp2pStub(agent: DKGAgent): void {
+  const stub = {
+    getPeers: (): Array<{ toString: () => string }> => [],
+    peerStore: {
+      get: async (_peerId: unknown) => ({
+        addresses: [{ multiaddr: { toString: () => '/ip4/127.0.0.1/tcp/0' } }],
+      }),
+    },
+  };
+  Object.defineProperty((agent as unknown as { node: { libp2p?: unknown } }).node, 'libp2p', {
+    value: stub,
+    configurable: true,
+    writable: true,
+  });
 }
 
 describe('DKGAgent SWM substrate fan-out integration (rc.9 PR-C)', () => {


### PR DESCRIPTION
Recreates the PR (auto-closed when its base branch `feat/swm-ack-quorum-followups` was deleted on PR #582 squash-merge).

## What

PR-J (3 commits, post-rebase):

1. **drop ghost subscribers from substrate fan-out (PR-J)** — original round-1 fix. Added an optional `isPeerDialable` predicate to `CGMemberEnumerator` so substrate fan-out skips peers we have no addressing for. Bug-fix for the 2026-05-18 Miles<->Lex soak (3-of-4 enumerated public-CG subscribers were ghosts, every substrate send queued forever, ackQuorum never completed).

2. **PR-J round 2 — broaden reachability + apply filter outside TTL cache** — codex round-1 feedback. Async predicate (peerStore.get is async); filter runs on every call against current connection state (not cached for 60s).

3. **PR-J round 2.b — dual-field enumeration + peerIdFromString + watchdog filter** — codex round-2 feedback. Dual `members` (full gossip-eligible) + `substrateEligibleMembers` (filtered subset). `peerIdFromString` for peerStore.get. Watchdog top-up filters its missingPeers too.

## Tests

109/109 SWM tests pass. 61/61 additional `share()` tests pass.

## Outstanding codex feedback (deferred to follow-up)

To unblock the next soak run, two codex findings on the just-pushed round-2.b are deferred:

- Full outbox→quorum wiring (markDelivered observer surfacing response sentinels back to the publisher) — would tighten the `queued`/`inFlight` retry path. Currently the watchdog rearm + dialability filter gives bounded best-effort coverage.
- Any additional round-3 codex feedback on the dual-field shape.

Both will be addressed in a follow-up bugfix PR after we have soak data from the current fix.

Made with [Cursor](https://cursor.com)