### PR TITLE
feat(mcp-dkg): add inject-session-context hook to restore turn-URI linkage

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,11 +1,16 @@
 {
   "version": 1,
-  "_comment": "DKG chat-capture + inbox-injection hooks. capture-chat.mjs auto-promotes operator-Cursor conversation turns into the project's chat sub-graph (workspace bound). inject-inbox.mjs (Phase 1.5 of the agent debug chat RFC) auto-prepends unread agent-to-agent peer messages to the operator's next prompt so the Cursor agent always sees the inbox without the operator having to ask. Both fail open: hook errors never block the operator's chat. capture-chat.mjs is the legacy hook; inject-inbox.mjs is the new one. They share the same daemon-config loading conventions (DKG_HOME/config.json preferred, falling back to a cwd walk for .dkg/config.yaml).",
+  "_comment": "DKG chat-capture + context-injection hooks. capture-chat.mjs auto-promotes operator-Cursor conversation turns into the project's chat sub-graph (workspace bound). inject-session-context.mjs prepends <dkg-session-context> to every prompt with sessionId + nextTurnIndex + predicted turn URI so the agent can author annotations carrying graph edges back to the chat:Turn that capture-chat writes after the response (restores the V9 forSession linkage that #381 + R3 capture-chat reduction retired). inject-inbox.mjs (Phase 1.5 of the agent debug chat RFC) auto-prepends unread agent-to-agent peer messages. All three fail open: hook errors never block the operator's chat.",
   "hooks": {
     "beforeSubmitPrompt": [
       {
-        "_comment": "capture-chat runs first so it stashes the operator's ORIGINAL prompt for later afterAgentResponse capture, before inject-inbox potentially prepends an inbox block via updated_input.",
+        "_comment": "capture-chat MUST run first so it stashes the operator's ORIGINAL prompt for later afterAgentResponse capture, before any other hook mutates updated_input. It also persists session state (turnIndex), which inject-session-context reads.",
         "command": "node packages/mcp-dkg/hooks/capture-chat.mjs beforeSubmitPrompt",
+        "failClosed": false
+      },
+      {
+        "_comment": "inject-session-context reads the state file capture-chat just wrote and prepends a <dkg-session-context> block. Runs before inject-inbox so the final prompt order is: <dkg-inbox-notice> (most urgent) / <dkg-session-context> (administrative metadata) / <operator prompt>.",
+        "command": "node packages/mcp-dkg/hooks/inject-session-context.mjs",
         "failClosed": false
       },
       {

--- a/.cursor/rules/dkg-annotate.mdc
+++ b/.cursor/rules/dkg-annotate.mdc
@@ -1,0 +1,166 @@
+---
+description: Annotate every substantive chat turn into the DKG project's sub-graphs via the V10 MCP tools (assertion_create → write → promote) so shared project memory grows organically and stays navigable, with every annotation linked back to its chat:Turn by the predicted turn URI.
+alwaysApply: true
+---
+
+# DKG annotation protocol (V10)
+
+This repository is bound to a DKG V10 context graph (`dkg-code-project`). Use the `dkg` MCP server to keep the graph rich and convergent. The full canonical instructions live in [`AGENTS.md`](mdc:AGENTS.md); this file is the Cursor-specific mirror.
+
+## Session context — read this every turn
+
+Your incoming prompt is prefixed with a block injected by [`packages/mcp-dkg/hooks/inject-session-context.mjs`](mdc:packages/mcp-dkg/hooks/inject-session-context.mjs):
+
+```
+<dkg-session-context>
+  <session-id>{sessionKey}</session-id>
+  <next-turn-index>{N}</next-turn-index>
+  <turn-uri>urn:dkg:chat:session:{sessionKey}#turn:{N}</turn-uri>
+  <agent-uri>{your agent URI}</agent-uri>
+</dkg-session-context>
+```
+
+**Parse it once and hold `<turn-uri>` + `<agent-uri>` in working memory.** The capture hook at [`packages/mcp-dkg/hooks/capture-chat.mjs`](mdc:packages/mcp-dkg/hooks/capture-chat.mjs) will write `chat:Turn` at exactly this URI after your response, so any `<turn-uri> chat:proposes <X>` edge you author during the turn JOINs cleanly once the post-response write lands.
+
+If the block is missing, fall back: annotations still stand on `dcterms:created` + `prov:wasAttributedTo` even without the turn-URI edge.
+
+(V9 sourced the session id from a session-start `additionalContext` payload. That path is retired in V10 — use the `<dkg-session-context>` block instead.)
+
+Hook ordering is documented in the installed [`.cursor/hooks.json`](mdc:.cursor/hooks.json) — capture-chat runs first (stashes prompt + writes state file with `pendingTurnIndex`), inject-session-context runs second (reads state, prepends block), inject-inbox runs third (prepends its own notice on top). Don't re-order without understanding the dependencies.
+
+## After every substantive turn
+
+Author one per-turn assertion. **Over-eagerness is not a failure mode; under-coverage is.** Skip only one-line acknowledgements.
+
+The V9 sugared `dkg_annotate_turn` is **gone** — V10 uses an explicit three-step write:
+
+```js
+dkg_assertion_create({ name: `turn-anno-${sessionKey}-${N}`, subGraphName: "decisions" });
+dkg_assertion_write({
+  name: `turn-anno-${sessionKey}-${N}`,
+  subGraphName: "decisions",
+  quads: [
+    // For each topic / Decision / Finding / Task / Question / code-ref:
+    //   <entity> rdf:type <type>
+    //   <entity> rdfs:label "label"
+    //   <entity> dcterms:created "<iso ts>"^^xsd:dateTime
+    //   <entity> prov:wasAttributedTo <agent-uri>
+    //   <turn-uri> chat:proposes <entity>    // the linking edge
+    // And for each file touched:
+    //   <turn-uri> chat:mentions <file-uri>
+    //   <file-uri> code:touchedInTurnBy <agent-uri>
+  ],
+});
+dkg_assertion_promote({
+  name: `turn-anno-${sessionKey}-${N}`,
+  entities: [turnUri, ...everyMintedRootUri], // see Query gotcha (3) below
+});
+```
+
+**Object encoding rule**: `dkg_assertion_write`'s `object` field is EITHER a bare URI OR a literal wrapped in double quotes. Literals without quotes fail on embedded spaces.
+
+## Look-before-mint (the convergence rule)
+
+Before minting any new `urn:dkg:<type>:<slug>` URI:
+
+1. Compute the normalised slug: `lowercase → ASCII-fold → strip stopwords (the/a/an/of/for/and/or/to/in/on/with) → hyphenate → ≤60 chars`.
+2. Call `dkg_memory_search` with the **unnormalised label**.
+3. If any returned hit's normalised slug matches yours, **REUSE** that URI (prefer VM > SWM > WM hits).
+4. Otherwise mint fresh per §URI patterns below.
+
+**Never fabricate URIs** outside this protocol.
+
+## Sub-graph routing
+
+| Entity type | Sub-graph |
+|---|---|
+| `chat:Turn` (hook-owned, do NOT write) | `chat` |
+| Topic / mentions on a turn | `chat` |
+| `Finding`, `Decision`, `Question` | `decisions` |
+| `Task` | `tasks` |
+| `code:File` / `code:Package` / `code:Repository` | `code` |
+| `urn:dkg:github:repo|pr|issue:*` | `github` |
+| `Concept`, agent profile, ontology refs | `meta` |
+
+If a turn produces entities for multiple sub-graphs, create one assertion per sub-graph (suffix the name: `turn-anno-<sessionKey>-<N>-decisions`, `-code`).
+
+## URI patterns
+
+```
+urn:dkg:concept:<slug>                       free-text concept (skos:Concept)
+urn:dkg:topic:<slug>                         broad topical bucket
+urn:dkg:question:<slug>                      open question
+urn:dkg:finding:<slug>                       preserved claim/observation
+urn:dkg:decision:<slug>                      architectural decision
+urn:dkg:task:<slug>                          work item
+urn:dkg:agent:<slug>                         agent identity
+urn:dkg:github:repo:<owner>/<name>           GitHub repository
+urn:dkg:github:pr:<owner>/<name>/<num>       GitHub PR
+urn:dkg:github:issue:<owner>/<name>/<num>    GitHub issue
+urn:dkg:code:repo:<owner>/<name>             scanner-owned repo node
+urn:dkg:code:file:<owner>/<name>/<relpath>   scanner-owned file node
+urn:dkg:code:package:<owner>/<name>/<pkg>    scanner-owned package node
+```
+
+## Code graph: two layers
+
+**Layer 1** — `.dkg/scripts/scan-code.mjs` (operator-installed) owns `code:File`/`code:Package` triples. Run `node .dkg/scripts/scan-code.mjs <repo>` or `--all` when fresh structural data is needed; the daily launchd template at `.dkg/scripts/com.dkg.scan-code.plist` covers steady state.
+
+**Layer 2** — you, on every turn that touches a file. Emit in the per-turn assertion (subGraphName `code`):
+
+- `<turn-uri> chat:mentions <file-uri>` for every file touched.
+- `<file-uri> code:touchedInTurnBy <agent-uri>` for non-trivial touches (skip incidental Reads).
+- `<file-uri> dcterms:modified "<iso ts>"^^xsd:dateTime` for Edit/Write.
+- Optional `<file-uri> schema:description "<one line on why>"`.
+
+File URI MUST match the scanner pattern. `dkg_memory_search` the path first — if it's in the graph, reuse the URI. If not, mint per the pattern and the next scan reconciles.
+
+## V10 MCP tool surface (cheat sheet)
+
+The authoritative reference is [`packages/cli/skills/dkg-node/SKILL.md`](mdc:packages/cli/skills/dkg-node/SKILL.md). Quick map:
+
+**Read**: `dkg_memory_search` (was `dkg_search`), `dkg_query` (was `dkg_sparql`), `dkg_get_entity`, `dkg_list_context_graphs` (was `dkg_list_projects`), `dkg_sub_graph_list` (was `dkg_list_subgraphs`), `dkg_list_activity`, `dkg_get_agent`, `dkg_assertion_query`, `dkg_assertion_history`, `dkg_status`.
+
+**Write (auto-promoted via `autoShare: true`)**: `dkg_assertion_create` + `dkg_assertion_write` + `dkg_assertion_promote`, `dkg_assertion_discard`, `dkg_share` (direct SWM), `dkg_sub_graph_create`.
+
+**Inter-agent**: `dkg_send_message`, `dkg_check_inbox` / `dkg_read_messages`, `dkg_subscribe`.
+
+**HUMAN-GATED**: `dkg_shared_memory_publish` (SWM → VM, on-chain, costs TRAC). Don't call without explicit operator instruction.
+
+**Retired (do not call)**: `dkg_annotate_turn`, `dkg_propose_decision`, `dkg_add_task`, `dkg_comment`, `dkg_request_vm_publish`, `dkg_set_session_privacy`, `dkg_get_chat`, `dkg_get_ontology`, `dkg_search`, `dkg_sparql`, `dkg_list_projects`, `dkg_list_subgraphs`.
+
+## Query gotchas
+
+Things that consistently bite agents writing SPARQL via `dkg_query`:
+
+**(1) Wrap patterns in `GRAPH ?g { ... }`.** Sub-graph data lives in named graphs, not the default graph. `SELECT ?s WHERE { ?s a code:File }` returns 0 rows; `SELECT ?s WHERE { GRAPH ?g { ?s a code:File } }` returns the real count.
+
+**(2) `view` + `subGraphName` are mutually exclusive in V10.** The daemon returns HTTP 400 if you pass both. Two workarounds:
+- Scoped query: omit `view`, pass `subGraphName: "<name>"` (legacy data-path query — works fine).
+- Cross-subgraph view: pass `view: "shared-working-memory"` alone, then filter in SPARQL via `GRAPH <did:dkg:context-graph:<cg>/<sub>/_shared_memory> { ... }`.
+
+**(3) `dkg_assertion_promote` needs an explicit array via MCP.** The MCP rejects `entities: "all"` (must be array) and the daemon REST rejects empty arrays. Pass the explicit list of every root URI you minted — the turn URI plus every Decision/Finding/Task/file URI. Missing entries stay in WM, invisible to peers.
+
+**(4) `code:` URI segments are percent-encoded.** Files like `gnosis+base wallets.zip` or `@scope/pkg` would break IRI parsing. The scanner applies `encodeURIComponent` per path segment. When constructing a file URI by hand, do the same: `urn:dkg:code:file:<owner>/<name>/${pathSegments.map(encodeURIComponent).join('/')}`.
+
+## Things to NOT do
+
+- **Don't fabricate URIs.** Look-before-mint or skip the edge.
+- **Don't skip turns to "save tokens".** A three-step annotation is cheap. Coverage wins.
+- **Don't publish to VM via MCP.** `dkg_shared_memory_publish` is operator-gated.
+- **Don't normalise slugs in your `dkg_memory_search` query.** Pass the unnormalised label.
+- **Don't try to compute the turn URI yourself.** The `<dkg-session-context>` block gives it to you. Reading capture-chat's session state files is brittle and unnecessary.
+- **Don't write `chat:Turn` entities yourself.** The capture hook owns them. You write annotations that LINK to them.
+- **Don't call any V9-retired tool** (`dkg_annotate_turn`, `dkg_search`, `dkg_sparql`, etc.) — they no longer exist.
+
+## Per-turn cheat sheet
+
+```
+1. Read <dkg-session-context> → grab <turn-uri>, <agent-uri>.
+2. dkg_memory_search "<label>" → reuse or mint URIs.
+3. dkg_assertion_create({ name: turn-anno-<sessionKey>-<N>, subGraphName: <route> }).
+4. dkg_assertion_write({ name, quads: [topics, mentions, durable artifacts, code-refs] }).
+5. dkg_assertion_promote({ name, entities: [<turn-uri>, ...every-minted-root-uri] }).
+```
+
+That's it. The graph grows; teammates' agents see your work via auto-recall; humans ratify on-chain when worthwhile.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,93 +1,243 @@
 # Agent Instructions
 
-This repository is bound to a **DKG context graph** (`dkg-code-project`) used for shared project memory across all AI coding agents working on it. Cursor, Claude Code, and any other MCP-aware agent should follow the same protocol so the graph converges rather than fragments.
+This repository is bound to a **DKG V10 context graph** (`dkg-code-project`) used for shared project memory across every AI coding agent working in it. Cursor, Claude Code, Codex CLI, Continue, and any other MCP-aware agent must follow the same protocol so the graph converges rather than fragments.
 
-For Cursor-specific session-start guidance the same content lives in [`.cursor/rules/dkg-annotate.mdc`](.cursor/rules/dkg-annotate.mdc) with `alwaysApply: true`. This file is the canonical instructions and is read by Claude Code, Continue, OpenAI Codex CLI, and any other tool that honours `AGENTS.md`.
+For Cursor-specific session-start guidance the same content lives in [`.cursor/rules/dkg-annotate.mdc`](.cursor/rules/dkg-annotate.mdc) with `alwaysApply: true`. **This file is canonical for AGENTS.md-honouring tools.**
 
-## What this graph is
+The authoritative reference for the V10 MCP tool surface is [`packages/cli/skills/dkg-node/SKILL.md`](packages/cli/skills/dkg-node/SKILL.md). Read it once per session — that's the source of truth for every `dkg_*` tool listed below.
 
-- **Subgraphs**: `chat`, `tasks`, `decisions`, `code`, `github`, `meta` — each a distinct slice of project memory.
-- **Capture hook** at `packages/mcp-dkg/hooks/capture-chat.mjs` writes every chat turn into `chat` and gossips it to all subscribed nodes within ~5s. Wired via `.cursor/hooks.json` and `~/.claude/settings.json`.
-- **MCP server** at `packages/mcp-dkg` exposes ~14 read+write+annotation tools to any MCP-aware agent.
-- **Project ontology** lives at `meta/project-ontology` — fetch via `dkg_get_ontology`. The formal Turtle/OWL artifact + a markdown agent guide.
+## 1. What this graph is
 
-## The annotation protocol
+- **Sub-graphs**: `chat`, `tasks`, `decisions`, `code`, `github`, `meta` — each a distinct slice of project memory.
+- **Capture hook** at `packages/mcp-dkg/hooks/capture-chat.mjs` writes every chat turn into `chat` as a `chat:Turn` entity with deterministic URI `urn:dkg:chat:session:<sessionKey>#turn:<idx>`. Auto-promoted to SWM when `autoShare: true`.
+- **Session-context hook** at `packages/mcp-dkg/hooks/inject-session-context.mjs` prepends a `<dkg-session-context>` block to every operator prompt. This is how you, the agent, know the URI of THIS turn so annotations can link back to it.
+- **Code-graph scanner** at `.dkg/scripts/scan-code.mjs` (operator-installed) walks `git ls-files` of any target repo and writes `code:File` / `code:Package` triples into the `code` sub-graph. Idempotent (rolling per-repo assertion).
+- **MCP server** at `packages/mcp-dkg` exposes the V10 tool surface — see §6. The V9 sugared annotation tools (`dkg_annotate_turn`, `dkg_propose_decision`, `dkg_add_task`, `dkg_comment`, `dkg_request_vm_publish`, `dkg_set_session_privacy`, `dkg_get_chat`, `dkg_get_ontology`) are **retired**.
 
-After **every substantive turn** (anything that reasoned, proposed, examined, or referenced something — basically every turn that wasn't a one-line acknowledgement), call **`dkg_annotate_turn`** exactly once. The shared chat sub-graph is project memory, not a "DKG-relevant search index" — over-eagerness is not a failure mode; under-coverage is.
+## 2. Session context injection — read this first every turn
 
-**Always pass `forSession`.** The session ID is in the `additionalContext` injected at session start ("Your current session ID: `<id>`"). The tool queues the annotation as a pending entity; the capture hook applies it to your actual turn URI when it writes the next `chat:Turn` for the session. Race-free regardless of timing — works whether you call it during your response composition (before the hook fires) or after. Don't try to predict your own turn URI; it doesn't exist yet at the moment you call this tool.
+On every turn, your incoming prompt is prefixed by a structured block:
 
-Minimum viable annotation:
-
-```jsonc
-dkg_annotate_turn({
-  forSession: "<session id from additionalContext>",
-  topics:   [<2-3 short topic strings>],   // chat:topic literals
-  mentions: [<URIs found via dkg_search>], // chat:mentions edges
-})
+```
+<dkg-session-context>
+  <session-id>{sessionKey}</session-id>
+  <next-turn-index>{N}</next-turn-index>
+  <turn-uri>urn:dkg:chat:session:{sessionKey}#turn:{N}</turn-uri>
+  <agent-uri>{your agent URI}</agent-uri>
+</dkg-session-context>
 ```
 
-Add when the turn warrants:
+**Parse this block once at the start of every turn and hold `<turn-uri>` + `<agent-uri>` in working memory.** They are the two identifiers you need to write graph-edged annotations.
 
-- `examines` — entities the turn analysed in detail (vs just citing in passing)
-- `concludes` — `:Finding` entities the turn produced (claims worth preserving)
-- `asks` — `:Question` entities left open
-- `proposedDecisions` — sugar over `dkg_propose_decision`; freshly mints a Decision and links via `chat:proposes`
-- `proposedTasks` — sugar over `dkg_add_task`
-- `comments` — sugar over `dkg_comment` (against any existing entity)
-- `vmPublishRequests` — sugar over `dkg_request_vm_publish` (writes a marker; **never** publishes on-chain)
+The capture hook will write the actual `chat:Turn` entity at exactly this `<turn-uri>` after your response is captured, so any `<turn-uri> chat:proposes <X>` edge you author during the turn JOINs cleanly once the post-response write lands.
 
-## Look-before-mint protocol (the convergence rule)
+If the block is missing (degraded hook, fresh tool, etc.), fall back: annotations still stand on their own provenance via `dcterms:created` + `prov:wasAttributedTo` even without the turn-URI edge.
 
-This is the single most important rule. It's how parallel agents converge on the same URIs instead of fragmenting the graph.
+(V9 sourced the session id from a session-start `additionalContext` payload — "Your current session ID: `<id>`". That injection path is retired in V10; use the `<dkg-session-context>` block instead.)
+
+## 3. The annotation protocol
+
+**After every substantive turn** — anything that reasoned, proposed, examined, or referenced something, i.e. every turn that wasn't a one-line acknowledgement — author a per-turn annotation assertion. **Over-eagerness is not a failure mode; under-coverage is.** The shared chat sub-graph is project memory, not a "DKG-relevant search index".
+
+The canonical V10 write flow is three explicit MCP calls. One assertion per turn holds all of that turn's structured entities; promotion happens once at the end.
+
+### 3.1 Look-before-mint (the convergence rule)
 
 Before minting any new `urn:dkg:<type>:<slug>` URI:
 
 1. Compute the **normalised slug**: lowercase → ASCII-fold → strip stopwords (`the/a/an/of/for/and/or/to/in/on/with`) → hyphenate → ≤60 chars.
-2. Call `dkg_search` with the **unnormalised label** (the daemon does its own fuzzy match).
-3. If any returned entity's normalised slug matches yours → **REUSE** that URI.
-4. Otherwise mint `urn:dkg:<type>:<slug>` per the patterns below.
+2. Call `dkg_memory_search` with the **unnormalised label** (the daemon does its own fuzzy match across WM/SWM/VM layers).
+3. If any returned hit's normalised slug matches yours → **REUSE** that URI. Prefer hits in higher layers (VM > SWM > WM) when multiple match.
+4. Otherwise mint `urn:dkg:<type>:<slug>` per the patterns in §5.
 
-**Never fabricate URIs** for entities you didn't discover via `dkg_search`. If unsure, prefer minting fresh and let humans (or the future `dkg_propose_same_as` reconciliation flow) merge duplicates via `owl:sameAs`.
+**Never fabricate URIs** for entities you didn't discover via `dkg_memory_search` or freshly mint via this protocol. If unsure, prefer minting fresh and let humans (or future `owl:sameAs` reconciliation) merge duplicates.
 
-## URI patterns
+### 3.2 Per-turn assertion shape
+
+Build one assertion named `turn-anno-<sessionKey>-<N>` (matches `/^[a-z0-9-]+$/` once sanitised). Put every entity the turn produced into it. Promote once at the end.
+
+```js
+// Step 1 — stage the assertion (WM)
+dkg_assertion_create({
+  contextGraphId,                          // omit to default to .dkg/config.yaml
+  name: `turn-anno-${sessionKey}-${N}`,
+  subGraphName: "decisions",               // see §4 for routing
+});
+
+// Step 2 — write quads. Each entity gets:
+//   - rdf:type + rdfs:label
+//   - dcterms:created + prov:wasAttributedTo (provenance)
+//   - chat:proposes / chat:examines / chat:mentions edge from <turn-uri>
+dkg_assertion_write({
+  contextGraphId,
+  name: `turn-anno-${sessionKey}-${N}`,
+  subGraphName: "decisions",
+  quads: [
+    // a Finding
+    { subject: "urn:dkg:finding:swm-sync-acks-needed",
+      predicate: "rdf:type",
+      object: "http://dkg.io/ontology/findings/Finding" },
+    { subject: "urn:dkg:finding:swm-sync-acks-needed",
+      predicate: "rdfs:label",
+      object: `"SWM sync needs explicit acks under burst load"` },
+    { subject: "urn:dkg:finding:swm-sync-acks-needed",
+      predicate: "http://purl.org/dc/terms/created",
+      object: `"${new Date().toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime>` },
+    { subject: "urn:dkg:finding:swm-sync-acks-needed",
+      predicate: "http://www.w3.org/ns/prov#wasAttributedTo",
+      object: agentUri },
+    // the linking edge — restores V9 forSession behaviour
+    { subject: turnUri,
+      predicate: "http://dkg.io/ontology/chat/proposes",
+      object: "urn:dkg:finding:swm-sync-acks-needed" },
+  ],
+});
+
+// Step 3 — promote WM → SWM so teammates see it.
+// IMPORTANT: the MCP wrapper rejects entities:"all" (Zod expects array)
+// and the daemon REST also rejects empty arrays. Pass the explicit list
+// of root subject URIs you minted (turn URI + every Decision/Finding/Task
+// URI). Forgetting an entity here means it stays in WM, invisible to peers.
+dkg_assertion_promote({
+  projectId,                              // MCP uses projectId, not contextGraphId
+  name: `turn-anno-${sessionKey}-${N}`,
+  subGraphName: "decisions",
+  entities: [
+    turnUri,
+    "urn:dkg:finding:swm-sync-acks-needed",
+    // ...every other root URI
+  ],
+});
+```
+
+**Object encoding rule** (the #1 mistake): in `dkg_assertion_write`, the `object` field is EITHER a bare URI OR a literal wrapped in double quotes. A literal without surrounding quotes gets parsed as a URI and fails on embedded spaces. Typed literals use the `"<value>"^^<datatype>` form.
+
+### 3.3 What goes in each per-turn assertion (the over-eagerness sweet spot)
+
+For every substantive turn, the per-turn assertion should typically contain at least:
+
+- `<turn-uri> chat:topic "<short label>"` — 2-3 topic literals for what the turn was about.
+- `<turn-uri> chat:mentions <X>` — edges to every entity URI the turn referenced (via `dkg_memory_search` reuse or fresh mint).
+- For any **durable artifact** produced — `Finding`, `Decision`, `Task`, `Question` — full triples per §3.2 plus the linking `chat:proposes` edge.
+- For any **file touched** — see §7 "Code-graph annotations".
+
+Skip the assertion entirely for one-line acknowledgements ("ok", "thanks", "done") — that's the only failure mode of over-eagerness.
+
+## 4. Sub-graph routing
+
+Pick `subGraphName` based on the entity type. The scanner and capture hook auto-create `code` and `chat`; the others must be registered once via `dkg_sub_graph_create` (a one-time bootstrap — see [`docs`](docs) or the workspace setup history).
+
+| Entity type | Sub-graph |
+|---|---|
+| `chat:Turn` (hook-owned, do NOT write) | `chat` |
+| Topic / mentions annotations on a turn | `chat` |
+| `Finding`, `Decision`, `Question` | `decisions` |
+| `Task` | `tasks` |
+| `urn:dkg:code:file:*` / `urn:dkg:code:package:*` / `urn:dkg:code:repo:*` | `code` |
+| `urn:dkg:github:repo|pr|issue:*` | `github` |
+| `Concept`, agent profile, ontology refs | `meta` |
+
+Multiple sub-graphs per turn are fine — create one assertion per sub-graph. The `turn-anno-<sessionKey>-<N>` name can be suffixed (`-decisions`, `-code`) to avoid collisions.
+
+## 5. URI patterns
 
 ```
-urn:dkg:concept:<slug>              free-text concept (skos:Concept)
-urn:dkg:topic:<slug>                broad topical bucket
-urn:dkg:question:<slug>             open question
-urn:dkg:finding:<slug>              preserved claim/observation
-urn:dkg:decision:<slug>             architectural decision (coding-project)
-urn:dkg:task:<slug>                 work item (coding-project)
-urn:dkg:agent:<slug>                agent identity (usually <framework>-<operator>)
-urn:dkg:github:repo:<owner>/<name>  GitHub repository
-urn:dkg:github:pr:<owner>/<name>/<num>
-urn:dkg:code:file:<pkg>/<path>
-urn:dkg:code:package:<name>
+urn:dkg:concept:<slug>                       free-text concept (skos:Concept)
+urn:dkg:topic:<slug>                         broad topical bucket
+urn:dkg:question:<slug>                      open question
+urn:dkg:finding:<slug>                       preserved claim/observation
+urn:dkg:decision:<slug>                      architectural decision
+urn:dkg:task:<slug>                          work item
+urn:dkg:agent:<slug>                         agent identity (e.g. cursor-aleatoric)
+urn:dkg:github:repo:<owner>/<name>           GitHub repository
+urn:dkg:github:pr:<owner>/<name>/<num>       GitHub PR
+urn:dkg:github:issue:<owner>/<name>/<num>    GitHub issue
+urn:dkg:code:repo:<owner>/<name>             scanner-owned repo node
+urn:dkg:code:file:<owner>/<name>/<relpath>   scanner-owned file node
+urn:dkg:code:package:<owner>/<name>/<pkg>    scanner-owned package node
+urn:dkg:chat:session:<key>                   capture-hook-owned session
+urn:dkg:chat:session:<key>#turn:<idx>        capture-hook-owned turn (== <turn-uri>)
 ```
 
-## Tool reference
+## 6. Tool reference (V10)
 
-Read tools (read-only, no side effects):
+The full schema lives in each tool's MCP descriptor; this is the working map.
 
-- `dkg_list_projects` — list every CG this node knows about
-- `dkg_list_subgraphs` — show counts per sub-graph in a project
-- `dkg_sparql` — arbitrary SELECT/CONSTRUCT/ASK; layer ∈ {wm, swm, union, vm}
-- `dkg_get_entity` — describe one entity + 1-hop neighbourhood
-- `dkg_search` — keyword search across labels + body text (use this in look-before-mint)
-- `dkg_list_activity` — recent activity feed (decisions, tasks, turns) with attribution
-- `dkg_get_agent` — agent profile + authored counts
-- `dkg_get_chat` — captured turns filterable by session/agent/keyword/time
-- `dkg_get_ontology` — the project's ontology + agent guide (call once per session)
+**Read tools (no side effects):**
 
-Write tools (auto-promoted to SWM; humans gate VM):
+- `dkg_memory_search` — keyword search across WM/SWM/VM with trust-weighted ranking. **Use this in look-before-mint.** (V9: `dkg_search`.)
+- `dkg_query` — arbitrary SPARQL SELECT/ASK/CONSTRUCT. Pass `view` to pick the memory tier; pair with `contextGraphId` and `subGraphName` to narrow. **`view` and `subGraphName` are mutually exclusive in V10** — see §7b for the workaround. **Always wrap patterns in `GRAPH ?g { ... }`** or you'll get zero rows from sub-graph-routed data. (V9: `dkg_sparql`.)
+- `dkg_get_entity` — describe one URI + its 1-hop inbound neighbourhood.
+- `dkg_list_context_graphs` — every CG this node knows about. (V9: `dkg_list_projects`.)
+- `dkg_sub_graph_list` — sub-graphs in a CG. (V9: `dkg_list_subgraphs`.)
+- `dkg_list_activity` — recent activity feed across sub-graphs; filter by `agentUri`, `sinceIso`, `view`.
+- `dkg_get_agent` — agent profile + authored counts.
+- `dkg_assertion_query` — dump every quad in a single assertion (not SPARQL).
+- `dkg_assertion_history` — read an assertion's lifecycle descriptor.
+- `dkg_status`, `dkg_peer_info`, `dkg_wallet_balances` — node ops.
 
-- `dkg_annotate_turn` — **the main per-turn surface**; batches everything below
-- `dkg_propose_decision`, `dkg_add_task`, `dkg_comment`, `dkg_request_vm_publish`, `dkg_set_session_privacy` — the underlying primitives, available standalone for explicit "file a decision" / "open a task" requests
+**Write tools (auto-promoted to SWM when `autoShare: true`):**
 
-## Agent-to-agent debug chat
+- `dkg_assertion_create` — stage a new WM assertion.
+- `dkg_assertion_write` — append RDF quads to it.
+- `dkg_assertion_promote` — WM → SWM. See §7b(3) for the explicit-array requirement.
+- `dkg_assertion_discard` — drop a WM assertion.
+- `dkg_share` — direct SWM write (skips WM staging). Prefer the assertion flow for durable work; use `dkg_share` for quick team-visible notes.
+- `dkg_sub_graph_create` — register a new sub-graph in a CG.
 
-This repository's DKG nodes can be paired with each other. When they are, agents working on the same problem from different nodes can exchange encrypted libp2p messages — invaluable for debugging network features where neither agent has the whole picture on their own. Phase 1 ships two MCP tools:
+**Inter-agent (best-effort P2P) — see §8:**
+
+- `dkg_send_message`, `dkg_check_inbox` / `dkg_read_messages`, `dkg_subscribe`.
+
+**HUMAN-GATED — do not call without explicit operator instruction:**
+
+- `dkg_shared_memory_publish` — SWM → VM (on-chain, costs TRAC). The V9 marker tool `dkg_request_vm_publish` is gone; there is no agent-side "request review" shortcut.
+
+**Retired (do not call — they no longer exist):**
+
+- `dkg_annotate_turn`, `dkg_propose_decision`, `dkg_add_task`, `dkg_comment`, `dkg_request_vm_publish`, `dkg_set_session_privacy`, `dkg_get_chat`, `dkg_get_ontology`, `dkg_search`, `dkg_sparql`, `dkg_list_projects`, `dkg_list_subgraphs`.
+
+## 7. Code-graph annotations
+
+The `code` sub-graph has two layers:
+
+**Layer 1 — Structural skeleton (scanner-owned, do not author yourself):** `.dkg/scripts/scan-code.mjs` walks `git ls-files` and writes `code:File`, `code:Package`, `code:Repository` triples. Run it whenever the operator asks for a fresh scan, or rely on the launchd template at `.dkg/scripts/com.dkg.scan-code.plist` if it's been installed. Run scan invocations: `node .dkg/scripts/scan-code.mjs <repo>` or `--all`.
+
+**Layer 2 — Runtime context (yours to author):** when a turn touches a file (Read/Edit/Write or substantive reference), include in your per-turn assertion:
+
+- `<turn-uri> chat:mentions <file-uri>` — every file touched.
+- `<file-uri> code:touchedInTurnBy <agent-uri>` — for non-trivial touches (skip incidental Reads).
+- `<file-uri> dcterms:modified "<iso-ts>"^^xsd:dateTime` — for Edit/Write only.
+- `<file-uri> schema:description "<one line on why>"` — optional, but useful.
+
+**The file URI MUST match the scanner's shape**: `urn:dkg:code:file:<owner>/<name>/<relpath>`. Run `dkg_memory_search` for the path before minting — if the scanner has indexed the repo, the URI exists; reuse it.
+
+**Self-healing**: if `dkg_memory_search` for a file URI returns nothing, the containing repo hasn't been scanned. Either run `node .dkg/scripts/scan-code.mjs <repo-path>` once (if the daemon is up and you have shell access), or just mint the URI directly using the scanner's pattern — the next scan will reconcile.
+
+## 7b. Query gotchas (learned the hard way)
+
+Things that consistently bite agents writing SPARQL via `dkg_query` against this CG:
+
+**(1) Sub-graph data lives in named graphs, not the default graph.** A query like `SELECT ?s WHERE { ?s a code:File }` returns ZERO rows even though there are thousands of `code:File` entities. Wrap every triple pattern in `GRAPH ?g { ... }`:
+
+```sparql
+SELECT ?s WHERE { GRAPH ?g { ?s a <http://dkg.io/ontology/code/File> } }
+```
+
+This applies to every sub-graph other than the bare CG default — `chat`, `code`, `decisions`, `tasks`, `github`, `meta` all live in named graphs (e.g. `did:dkg:context-graph:<cg>/code/_shared_memory`).
+
+**(2) `subGraphName` is incompatible with `view: "shared-working-memory"` in V10.** The daemon returns HTTP 400 `"subGraphName cannot be combined with view-based routing. Sub-graph scoping within views is deferred to V10.x."` Two workarounds:
+
+- For scoped queries: **omit `view`** entirely and pass `subGraphName: "<name>"` — that's the legacy data-path query and it routes correctly.
+- For cross-subgraph views: pass `view: "shared-working-memory"` without `subGraphName`, then filter by named graph in your SPARQL: `GRAPH <did:dkg:context-graph:<cg>/code/_shared_memory> { ?s ?p ?o }`.
+
+**(3) `dkg_assertion_promote` requires an explicit array of root URIs via MCP.** The MCP wrapper rejects `entities: "all"` (Zod expects array) and the daemon REST rejects empty arrays with `"entities" must be "all" or a non-empty array of non-empty strings`. Pass the explicit list of every root subject URI you minted (turn URI + every `Decision`/`Finding`/`Task`/`Question`/file URI). Anything not listed stays in WM, invisible to peers. (The shell scanner can hit the daemon REST directly with `entities: "all"`; only the MCP-side has the array constraint.)
+
+**(4) Path segments in `code:` URIs are percent-encoded.** Files with spaces, parens, `+`, `@`, etc. would otherwise produce IRIs that Oxigraph rejects with `Invalid IRI code point`. The scanner encodes each path segment with `encodeURIComponent` and joins with `/`. So `@origintrail-official/dkg-core` becomes `%40origintrail-official/dkg-core` inside the URI. When minting a file URI by hand, apply the same encoding.
+
+## 8. Agent-to-agent debug chat
+
+This repository's DKG nodes can be paired with each other. When they are, agents working on the same problem from different nodes can exchange encrypted libp2p messages — invaluable for debugging network features where neither agent has the whole picture on their own. The MCP ships two tools for this:
 
 - **`dkg_check_inbox`** — read unread peer messages from this node's local SQLite history.
 - **`dkg_send_message`** — send an encrypted chat to another agent on the network.
@@ -116,30 +266,36 @@ For any other error (peer not found, timeout, network), retry once before bother
 - **Don't loop** — if you send a message and the response comes back asking another question, surface it to the operator before auto-replying. Phase 1 is operator-in-the-loop by design; Phase 3 (autonomous bridge) is a future RFC.
 - **Don't conflate chat with the `chat` sub-graph.** The `chat` sub-graph (captured by `capture-chat.mjs`) is the operator's conversation with you; `dkg_send_message` is *your* conversation with another agent. They're separate channels for now.
 
-## Universal Messenger (v10.0.0-rc.9)
+## 9. Universal Messenger (v10.0.0-rc.9)
 
 DKG's short peer-to-peer protocols (chat, skill request, query-remote, swm-sender-key, private-access, join-request, storage-ack, verify-proposal) all route through a single reliability substrate called the **Universal Messenger**. Architecture: [`docs/messenger.md`](./docs/messenger.md). Operator-facing surfaces: [`docs/messenger-operator.md`](./docs/messenger-operator.md). Migration recipe for a hypothetical 9th protocol: [`docs/messenger-add-protocol.md`](./docs/messenger-add-protocol.md).
 
 **Convergence rule for agents working on this codebase**: route any new short-message protocol through `Messenger.sendReliable` and register handlers via `Messenger.register` — never `ProtocolRouter.send` / `ProtocolRouter.register` directly. The substrate gives you sender-side durable retry (SQLite outbox surviving daemon restart), receiver-side dedup keyed by `messageId`, sender-side response cache, stale-snapshot-safe retries, opportunistic flush on `connection:open`, DHT-walk-on-stall, and observability via `/api/slo`. Bypassing it loses every one of those properties. The migration recipe lives at `docs/messenger-add-protocol.md` and includes the worked example from PR-3 (chat).
 
-## Things to NOT do
+## 10. Things to NOT do
 
-- **Don't fabricate URIs.** Every URI in `mentions` must come from `dkg_search` or be freshly minted via the look-before-mint protocol.
-- **Don't skip turns to "save tokens".** One annotation call per turn is cheap (~few hundred ms). Coverage wins.
-- **Don't publish to VM via MCP.** That's `dkg_request_vm_publish` (marker for human review), not `/api/shared-memory/publish`. The agent is never the gating actor for on-chain commitment.
-- **Don't normalise slugs in your `dkg_search` query.** Pass the unnormalised label so the daemon's fuzzy match has the most signal; only normalise when comparing for reuse-vs-mint.
-- **Don't call `ProtocolRouter.send` directly for new short-message protocols.** Use `Messenger.sendReliable` (see Universal Messenger section above).
+- **Don't fabricate URIs.** Every URI in `chat:mentions` (or any other edge) must come from `dkg_memory_search` or be freshly minted via look-before-mint.
+- **Don't skip turns to "save tokens".** A three-step annotation per turn is ~few hundred ms. Coverage wins.
+- **Don't publish to VM via MCP.** `dkg_shared_memory_publish` mints on-chain and costs TRAC. Operator-gated only.
+- **Don't normalise slugs in your `dkg_memory_search` query.** Pass the unnormalised label; the daemon's fuzzy match wants the most signal. Normalise only when comparing for reuse-vs-mint.
+- **Don't try to compute the turn URI yourself.** The `<dkg-session-context>` block already gives it to you. Computing it from session state files is brittle and the rule is "use what the hook injected".
+- **Don't write the `chat:Turn` entity yourself.** The capture hook owns it. Your job is to write annotations that LINK to it, not duplicate it.
+- **Don't call `ProtocolRouter.send` directly for new short-message protocols.** Use `Messenger.sendReliable` (see §9 Universal Messenger).
+- **Don't call any V9-retired tool** listed in §6 — they no longer exist on the MCP surface; calling them will error.
 
-## Cheat sheet
+## 11. Cheat sheet (per substantive turn)
 
 ```
-After every substantive turn:
-1. dkg_search "<some label from the turn>" → reuse-or-mint URIs
-2. dkg_annotate_turn({
-     topics: [...], mentions: [...],
-     examines?, concludes?, asks?,
-     proposedDecisions?, proposedTasks?, comments?
-   })
+1. Read <dkg-session-context> from the incoming prompt → grab <turn-uri>, <agent-uri>.
+2. dkg_memory_search "<unnormalised label from the turn>" → reuse-or-mint URIs.
+3. dkg_assertion_create({ name: `turn-anno-${sessionKey}-${N}`, subGraphName: <route per §4> }).
+4. dkg_assertion_write({ name, quads: [
+     // topic + mentions on <turn-uri>
+     // every Decision/Finding/Task/Question with provenance triples
+     // <turn-uri> chat:proposes <each durable artifact>
+     // every file touched: <turn-uri> chat:mentions <file-uri>, code:touchedInTurnBy, dcterms:modified
+   ]}).
+5. dkg_assertion_promote({ name, entities: [<turn-uri>, ...every-minted-root-uri] }).
 ```
 
-That's it. The graph grows; teammates' agents see your work in seconds; humans ratify on-chain when worthwhile.
+That's it. The graph grows; teammates' agents see your work in seconds via auto-recall; humans ratify on-chain via `dkg_shared_memory_publish` when worthwhile.

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -133,6 +133,16 @@ export interface McpDkgAssets {
   packageDir: string;
   distEntry: string;       // <pkg>/dist/index.js
   captureScript: string;   // <pkg>/hooks/capture-chat.mjs
+  /**
+   * Absolute path to `<pkg>/hooks/inject-session-context.mjs`. Used
+   * by `buildManifestInstallContext` to populate the
+   * `{{injectSessionContextScriptPath}}` placeholder in the Cursor
+   * + Claude Code hook templates so installs done via the daemon's
+   * `/manifest/plan-install` and `/manifest/install` routes wire the
+   * inject-session-context hook the same way the MCP CLI's
+   * `dkg-mcp join` flow does. See Codex PR #589 finding 3.
+   */
+  injectSessionContextScript: string;
   source: 'node-resolution' | 'repo-fallback';
 }
 export function resolveMcpDkgAssets(): McpDkgAssets {
@@ -141,8 +151,9 @@ export function resolveMcpDkgAssets(): McpDkgAssets {
     const packageDir = dirname(pkgJsonPath);
     const distEntry = resolve(packageDir, 'dist', 'index.js');
     const captureScript = resolve(packageDir, 'hooks', 'capture-chat.mjs');
-    if (existsSync(distEntry) && existsSync(captureScript)) {
-      return { packageDir, distEntry, captureScript, source: 'node-resolution' };
+    const injectSessionContextScript = resolve(packageDir, 'hooks', 'inject-session-context.mjs');
+    if (existsSync(distEntry) && existsSync(captureScript) && existsSync(injectSessionContextScript)) {
+      return { packageDir, distEntry, captureScript, injectSessionContextScript, source: 'node-resolution' };
     }
     // Resolution worked but assets are missing (e.g. a pruned install).
     // Fall through to repo-layout path so checkouts still work.
@@ -161,8 +172,9 @@ export function resolveMcpDkgAssets(): McpDkgAssets {
   const packageDir = resolve(repoRoot, 'packages', 'mcp-dkg');
   const distEntry = resolve(packageDir, 'dist', 'index.js');
   const captureScript = resolve(packageDir, 'hooks', 'capture-chat.mjs');
-  if (existsSync(distEntry) && existsSync(captureScript)) {
-    return { packageDir, distEntry, captureScript, source: 'repo-fallback' };
+  const injectSessionContextScript = resolve(packageDir, 'hooks', 'inject-session-context.mjs');
+  if (existsSync(distEntry) && existsSync(captureScript) && existsSync(injectSessionContextScript)) {
+    return { packageDir, distEntry, captureScript, injectSessionContextScript, source: 'repo-fallback' };
   }
   throw new Error(
     `resolveMcpDkgAssets: could not locate @origintrail-official/dkg-mcp. ` +
@@ -505,6 +517,7 @@ export function buildManifestInstallContext(
       // entry so this being stale is fine.
       mcpDkgSrcAbsPath: resolve(mcpDkgAssets.packageDir, 'src', 'index.ts'),
       captureScriptPath: mcpDkgAssets.captureScript,
+      injectSessionContextScriptPath: mcpDkgAssets.injectSessionContextScript,
       tools,
       agentNickname: rawNickname,
       // Cryptographic agent URI derived from the daemon's wallet (the

--- a/packages/mcp-dkg/hooks/capture-chat.mjs
+++ b/packages/mcp-dkg/hooks/capture-chat.mjs
@@ -500,8 +500,25 @@ async function handleBeforeSubmitPrompt(cfg, payload) {
   };
   state.pendingPrompt = extractText(payload) ?? '';
   state.pendingPromptAt = new Date().toISOString();
+  // Reserve a UNIQUE turn slot for this prompt. `maxAssignedTurnIndex`
+  // is monotonic — it advances on every beforeSubmitPrompt and is
+  // never rolled back, even when a previous afterAgentResponse write
+  // fails. That's the contract `inject-session-context.mjs` relies on
+  // to predict a turn URI that capture-chat will write to exactly
+  // once: if turn N+1's write fails, the slot is ABANDONED (graph
+  // gap) and the next prompt is assigned slot N+2, so annotations
+  // emitted against #turn:N+1 can never be silently re-attributed to
+  // a later, content-different turn. See Codex PR #589 finding 1.
+  //
+  // Back-compat: older state files lack `maxAssignedTurnIndex`; the
+  // Math.max() seed keeps numbering monotonic across the upgrade.
+  state.maxAssignedTurnIndex = Math.max(
+    state.maxAssignedTurnIndex ?? 0,
+    state.turnIndex ?? 0,
+  ) + 1;
+  state.pendingTurnIndex = state.maxAssignedTurnIndex;
   saveSessionState(sessionKey, state);
-  log(`queued prompt (${state.pendingPrompt.length} chars) for session ${sessionKey}`);
+  log(`queued prompt (${state.pendingPrompt.length} chars) for session ${sessionKey} as turn #${state.pendingTurnIndex}`);
 }
 
 async function handleAfterAgentResponse(cfg, payload) {
@@ -513,11 +530,15 @@ async function handleAfterAgentResponse(cfg, payload) {
     turnIndex: 0,
     pendingPrompt: null,
   };
-  // Compute the next index *without* committing it yet. We only advance
-  // state.turnIndex (and clear pendingPrompt) after writeTriples()
-  // succeeds — otherwise a transient daemon/network error would silently
-  // burn a turn slot and shift numbering for every subsequent turn.
-  const idx = state.turnIndex + 1;
+  // Consume the slot reserved by handleBeforeSubmitPrompt. This is
+  // unique per prompt by construction (see the comment there). Older
+  // state files written before the maxAssignedTurnIndex contract was
+  // introduced won't have `pendingTurnIndex`; fall back to the legacy
+  // turnIndex+1 calc so an in-flight upgrade doesn't lose a turn.
+  // We DON'T advance state.turnIndex yet — only after writeTriples()
+  // succeeds — so reads of state.turnIndex elsewhere still reflect
+  // "last successfully committed turn".
+  const idx = state.pendingTurnIndex ?? (state.turnIndex + 1);
   const turn = turnUri(sessionKey, idx);
   const now = new Date().toISOString();
   const userText = state.pendingPrompt ?? '';
@@ -573,6 +594,7 @@ async function handleAfterAgentResponse(cfg, payload) {
     writeOk = true;
     state.turnIndex = idx;
     state.pendingPrompt = null;
+    state.pendingTurnIndex = null;
     if (bootstrapSession) state.sessionWritten = true;
     if (await shouldPromote(cfg, state)) {
       // Promote both the session and the individual turn so the team
@@ -584,9 +606,21 @@ async function handleAfterAgentResponse(cfg, payload) {
     }
     log(`wrote turn #${idx} for session ${sessionKey}${bootstrapSession ? ' (bootstrapped session)' : ''}`);
   } catch (err) {
-    // Leave state.turnIndex + state.pendingPrompt untouched so the next
-    // afterAgentResponse retries the same slot with the same prompt.
-    log(`turn write failed (turn #${idx} not committed; will retry next event): ${err?.message ?? err}`);
+    // Slot idx is ABANDONED — `maxAssignedTurnIndex` was already
+    // advanced past it in handleBeforeSubmitPrompt, so the NEXT
+    // beforeSubmitPrompt reserves a strictly greater
+    // pendingTurnIndex and #turn:${idx} can never be re-used for a
+    // different prompt. Annotations the agent emitted against
+    // #turn:${idx} during the failed exchange become dangling
+    // references (a chat:Turn that was never persisted), which graph
+    // consumers can recover; the prior "retry the same slot with the
+    // next prompt" behaviour silently misattributed those
+    // annotations to whichever turn next wrote to the slot. See
+    // Codex PR #589 finding 1. We deliberately do NOT clear
+    // pendingPrompt / pendingTurnIndex here so post-mortem logs and
+    // future "show me uncommitted turns" tooling can still see what
+    // was lost.
+    log(`turn write failed (turn #${idx} abandoned; slot will not be reused): ${err?.message ?? err}`);
   }
 
   state.lastEventAt = now;

--- a/packages/mcp-dkg/hooks/capture-chat.mjs
+++ b/packages/mcp-dkg/hooks/capture-chat.mjs
@@ -322,6 +322,19 @@ export function extractSessionKey(payload) {
   return sanitiseSlug(anonSessionKey());
 }
 
+// Generate a fresh anon-session suffix. Uses `crypto.randomBytes`
+// (CSPRNG) rather than `Math.random` so the session key is hard to
+// predict — the anon-session id is used as both a filesystem path
+// segment and a chat:Session URI fragment, so weak entropy is a
+// (minor) attack surface for anyone with read access to the user's
+// state dir or graph. CodeQL flagged the pre-existing `Math.random`
+// path as reachable from inject-session-context.mjs via the
+// `extractSessionKey` re-export added in PR #589 round 3; this is
+// the fix at the source.
+function freshAnonKey() {
+  return `anon-${Date.now().toString(36)}-${crypto.randomBytes(6).toString('hex')}`;
+}
+
 function anonSessionKey() {
   try {
     const stateDir = path.join(os.homedir(), '.dkg', 'hook-state');
@@ -331,11 +344,11 @@ function anonSessionKey() {
       const buf = fs.readFileSync(idxFile, 'utf-8').trim();
       if (buf) return buf;
     }
-    const fresh = `anon-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    const fresh = freshAnonKey();
     fs.writeFileSync(idxFile, fresh, 'utf-8');
     return fresh;
   } catch {
-    return `anon-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    return freshAnonKey();
   }
 }
 

--- a/packages/mcp-dkg/hooks/inject-inbox.mjs
+++ b/packages/mcp-dkg/hooks/inject-inbox.mjs
@@ -310,9 +310,33 @@ async function readStdinJson() {
  * prompt entirely. We now look at `rawPayload` too, and `main()`
  * fails CLOSED on prompt extraction (returns `{}` rather than
  * overwriting the operator's input).
+ *
+ * Codex PR #589 round 3 raised a related concern: when multiple
+ * beforeSubmitPrompt hooks chain (capture-chat → inject-session-
+ * context → inject-inbox), if Cursor passes each downstream hook
+ * the UPSTREAM hook's `updated_input` value, this hook used to
+ * ignore it — silently overwriting any prepended block (e.g. the
+ * `<dkg-session-context>` block inject-session-context emits) with
+ * its own `<dkg-inbox-notice>` + ORIGINAL prompt. Cursor's docs
+ * don't explicitly specify how `updated_input` composes across
+ * sequential hooks (and a known Cursor bug
+ * <https://forum.cursor.com/t/.../158883> strips `updated_input`
+ * for beforeSubmitPrompt entirely on some versions), so we can't
+ * test this end-to-end against Cursor itself. We DEFENSIVELY prefer
+ * `payload.updated_input` when it's present: if Cursor's protocol
+ * passes upstream values through, the chain composes correctly; if
+ * not (or if the field is stripped), nothing changes vs. before.
  */
 export function extractPrompt(payload) {
   if (!payload || typeof payload !== 'object') return '';
+  // Defensive: an upstream beforeSubmitPrompt hook may have already
+  // emitted `updated_input`. If Cursor's hook executor surfaces that
+  // to downstream hooks (the unspecified composition case), treat it
+  // as the canonical prompt — this preserves any prepended block
+  // such as <dkg-session-context>.
+  if (typeof payload.updated_input === 'string' && payload.updated_input.trim()) {
+    return payload.updated_input;
+  }
   if (typeof payload.rawPayload === 'string' && payload.rawPayload.trim()) {
     return payload.rawPayload;
   }

--- a/packages/mcp-dkg/hooks/inject-session-context.mjs
+++ b/packages/mcp-dkg/hooks/inject-session-context.mjs
@@ -77,6 +77,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const LOG_FILE = process.env.DKG_SESSION_CTX_LOG ?? '/tmp/dkg-inject-session-context.log';
 const STATE_DIR = path.join(os.homedir(), '.cache', 'dkg-mcp', 'sessions');
@@ -284,11 +285,15 @@ async function main() {
 }
 
 // Self-execute only when invoked directly (avoids running during
-// import from a future unit test).
+// import from a future unit test). Mirrors the Windows-safe pattern
+// used by inject-inbox.mjs / capture-chat.mjs: `fileURLToPath` round-
+// trips the module URL into a real filesystem path so the equality
+// check works on Windows too (where `new URL("file://" + path)` would
+// otherwise mangle drive-letter paths and silently disable the hook).
 const isMainModule = (() => {
   try {
     if (!process.argv[1]) return false;
-    return import.meta.url === new URL(`file://${path.resolve(process.argv[1])}`).href;
+    return fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
   } catch {
     return false;
   }

--- a/packages/mcp-dkg/hooks/inject-session-context.mjs
+++ b/packages/mcp-dkg/hooks/inject-session-context.mjs
@@ -78,16 +78,21 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-// Lockstep contract: reuse capture-chat's `extractText` so the two
-// hooks recognise the SAME set of prompt-bearing payload shapes. If
-// capture-chat persists a turn for some shape, this hook must inject
-// a session-context block for that shape too — otherwise annotations
-// authored during the turn are orphaned (no `chat:Turn` exists for
-// the predicted URI). capture-chat exports the helper for exactly
-// this reason; this is a same-directory sibling import, no side
-// effects at import time (capture-chat's `main()` runs only under
-// its own `isMainModule` guard).
-import { extractText as captureExtractText } from './capture-chat.mjs';
+// Lockstep contract: reuse capture-chat's helpers verbatim so the
+// two hooks recognise the SAME payload shapes, derive the SAME
+// session keys, and predict / write the SAME turn URIs. Any drift
+// here silently orphans annotations (capture-chat persists a turn
+// the agent can't link back to, or vice versa). capture-chat
+// already exports these for exactly this purpose; same-directory
+// sibling import is safe (capture-chat's `main()` runs only under
+// its own `isMainModule` guard, so importing it has no side
+// effects). See Codex PR #589 finding 2.
+import {
+  extractText as captureExtractText,
+  extractSessionKey as captureExtractSessionKey,
+  sanitiseSlug as captureSanitiseSlug,
+  pick as capturePick,
+} from './capture-chat.mjs';
 
 const LOG_FILE = process.env.DKG_SESSION_CTX_LOG ?? '/tmp/dkg-inject-session-context.log';
 const STATE_DIR = path.join(os.homedir(), '.cache', 'dkg-mcp', 'sessions');
@@ -100,55 +105,14 @@ function log(msg) {
   }
 }
 
-// Generic deep-search for the first matching key. Same pattern as
-// sibling hooks; lets us tolerate field-name drift across Cursor /
-// Claude Code / future tools without per-tool branching.
-function pick(obj, candidates, depth = 0) {
-  if (depth > 4 || obj == null || typeof obj !== 'object') return undefined;
-  for (const c of candidates) {
-    if (Object.prototype.hasOwnProperty.call(obj, c)) {
-      const v = obj[c];
-      if (typeof v === 'string' && v.trim()) return v;
-      if (typeof v === 'number' || typeof v === 'boolean') return String(v);
-    }
-  }
-  for (const v of Object.values(obj)) {
-    if (v && typeof v === 'object') {
-      const nested = pick(v, candidates, depth + 1);
-      if (nested !== undefined) return nested;
-    }
-  }
-  return undefined;
-}
-
-export function sanitiseSlug(s) {
-  return String(s).replace(/[^A-Za-z0-9._-]+/g, '-').slice(0, 80);
-}
-
-// Mirror capture-chat.mjs `extractSessionKey` so both hooks compute
-// the same `sessionKey` for the same payload — any drift here would
-// silently produce a turn URI the capture hook never writes.
-export function extractSessionKey(payload) {
-  const id = pick(payload, [
-    'conversation_id', 'session_id', 'thread_id', 'chat_id',
-    'conversationId', 'sessionId', 'threadId', 'chatId', 'convId', 'id',
-  ]);
-  if (id) return sanitiseSlug(id);
-  // Anon-session fallback identical to capture-chat.mjs: read the
-  // per-process index file. capture-chat's `anonSessionKey()` writes
-  // it; we only read.
-  try {
-    const stateDir = path.join(os.homedir(), '.dkg', 'hook-state');
-    const idxFile = path.join(stateDir, `anon-session-${process.ppid || process.pid}.txt`);
-    if (fs.existsSync(idxFile)) {
-      const buf = fs.readFileSync(idxFile, 'utf-8').trim();
-      if (buf) return sanitiseSlug(buf);
-    }
-  } catch {
-    /* fall through */
-  }
-  return null;
-}
+// Re-export the capture-chat helpers under our own names so existing
+// tests (and any future ones) that import `pick` / `sanitiseSlug` /
+// `extractSessionKey` from this module continue to resolve. By
+// re-exporting (rather than re-implementing) we get drift-proof
+// lockstep with capture-chat by construction.
+export const pick = capturePick;
+export const sanitiseSlug = captureSanitiseSlug;
+export const extractSessionKey = captureExtractSessionKey;
 
 export function extractPrompt(payload) {
   if (!payload || typeof payload !== 'object') return '';
@@ -223,23 +187,34 @@ function loadAgentUri() {
   }
 }
 
-// Read-only consumer of capture-chat's session state. We never write
-// this file — capture-chat owns the writes; we only need `turnIndex`
-// to predict the next turn URI.
-function loadTurnIndex(sessionKey) {
+// Read-only consumer of capture-chat's session state. capture-chat
+// owns the writes; we only need the slot it reserved for THIS prompt
+// (in its `beforeSubmitPrompt` handler, which runs before us).
+//
+// Returns the index capture-chat will write turn-URI to, or `null`
+// if we can't determine it (caller treats `null` as "skip injection"
+// — better to lose a session-context block on one turn than predict
+// a URI capture-chat doesn't honour).
+//
+// `pendingTurnIndex` is the canonical value: it's reserved fresh in
+// every beforeSubmitPrompt via `maxAssignedTurnIndex`, so it's
+// guaranteed unique across the session's lifetime, even when a
+// previous afterAgentResponse write failed (Codex PR #589 finding 1).
+// `turnIndex + 1` is the legacy back-compat fallback for state files
+// written by capture-chat versions that predate `pendingTurnIndex`.
+function loadPendingTurnIndex(sessionKey) {
   try {
     const raw = fs.readFileSync(path.join(STATE_DIR, `${sessionKey}.json`), 'utf-8');
     const state = JSON.parse(raw);
-    return typeof state.turnIndex === 'number' ? state.turnIndex : 0;
+    if (typeof state.pendingTurnIndex === 'number') return state.pendingTurnIndex;
+    if (typeof state.turnIndex === 'number') return state.turnIndex + 1;
+    return 1;
   } catch {
-    // Missing state file → first turn of a fresh session. capture-chat
-    // creates the state file in its own beforeSubmitPrompt handler, which
-    // runs BEFORE this hook per .cursor/hooks.json ordering, so this
-    // branch only fires when (a) it's literally turn 1, or (b)
-    // capture-chat errored out on this turn (in which case fail-open is
-    // the right move — emit nextTurnIndex=1 and the capture hook will
-    // self-heal on its next successful event).
-    return 0;
+    // Missing state file → either turn 1 of a fresh session OR
+    // capture-chat errored out before writing state. Returning `null`
+    // makes main() fall back to skipping injection rather than
+    // predicting a URI that may collide.
+    return null;
   }
 }
 
@@ -287,8 +262,16 @@ async function main() {
     return;
   }
 
-  const turnIndex = loadTurnIndex(sessionKey);
-  const nextTurnIndex = turnIndex + 1;
+  const nextTurnIndex = loadPendingTurnIndex(sessionKey);
+  // No state file (capture-chat ran before us but errored out, or
+  // never ran at all on this hook ordering) → skip injection. Better
+  // to lose a session-context block on one turn than predict a URI
+  // capture-chat doesn't honour.
+  if (nextTurnIndex == null) {
+    log(`skipping injection: no capture-chat session state for ${sessionKey}`);
+    process.stdout.write('{}\n');
+    return;
+  }
   // Mirror capture-chat.mjs `turnUri(slug, idx)`. For sanitised slugs
   // encodeURIComponent is a no-op, but we keep it for byte-alignment
   // with the producer of the URI we're predicting.

--- a/packages/mcp-dkg/hooks/inject-session-context.mjs
+++ b/packages/mcp-dkg/hooks/inject-session-context.mjs
@@ -78,6 +78,16 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+// Lockstep contract: reuse capture-chat's `extractText` so the two
+// hooks recognise the SAME set of prompt-bearing payload shapes. If
+// capture-chat persists a turn for some shape, this hook must inject
+// a session-context block for that shape too — otherwise annotations
+// authored during the turn are orphaned (no `chat:Turn` exists for
+// the predicted URI). capture-chat exports the helper for exactly
+// this reason; this is a same-directory sibling import, no side
+// effects at import time (capture-chat's `main()` runs only under
+// its own `isMainModule` guard).
+import { extractText as captureExtractText } from './capture-chat.mjs';
 
 const LOG_FILE = process.env.DKG_SESSION_CTX_LOG ?? '/tmp/dkg-inject-session-context.log';
 const STATE_DIR = path.join(os.homedir(), '.cache', 'dkg-mcp', 'sessions');
@@ -142,12 +152,20 @@ export function extractSessionKey(payload) {
 
 export function extractPrompt(payload) {
   if (!payload || typeof payload !== 'object') return '';
+  // `readStdinJson` wraps non-JSON stdin in `{ rawPayload: <text> }`
+  // so the operator's prompt is recoverable even when Cursor sends
+  // a plain string. Honour that envelope before delegating to the
+  // shared key-extraction helper.
   if (typeof payload.rawPayload === 'string' && payload.rawPayload.trim()) {
     return payload.rawPayload;
   }
-  return pick(payload, [
-    'prompt', 'input', 'text', 'message', 'content', 'user_input',
-  ]) ?? '';
+  // Delegate to capture-chat's `extractText` so the user-prompt
+  // candidate list (`prompt`, `userPrompt`, `user_prompt`, `request`,
+  // `input`, …) stays in exact sync. Any future Cursor / Claude /
+  // Aider payload-shape change captured there flows through here for
+  // free, eliminating the orphan-annotation drift Codex flagged on
+  // PR #589.
+  return captureExtractText(payload);
 }
 
 function findWorkspaceConfig(start) {

--- a/packages/mcp-dkg/hooks/inject-session-context.mjs
+++ b/packages/mcp-dkg/hooks/inject-session-context.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * inject-session-context.mjs
+ *
+ * Cursor `beforeSubmitPrompt` + Claude Code `UserPromptSubmit` hook
+ * that prepends a `<dkg-session-context>` block to every prompt so
+ * the agent can author structured annotations (Decision / Finding /
+ * Task / Question / code-ref) carrying a proper graph edge back to
+ * the `chat:Turn` capture-chat.mjs will write after the response.
+ *
+ * Why this hook exists (the gap it closes)
+ * ----------------------------------------
+ * The V9 prompt-injection sub-system (`sessionStart` additionalContext
+ * with "Your session ID: <id>") was retired in the V10 MCP consolidation
+ * (#381) and the subsequent R3 capture-chat reduction (commit 0e7abdf9).
+ * Without it, the agent has no reliable input carrying its own `conversation_id`,
+ * so it cannot compute the predictable URI
+ *
+ *   urn:dkg:chat:session:<sessionKey>#turn:<idx>
+ *
+ * that capture-chat.mjs writes deterministically after the response.
+ * Annotations written during the turn end up orphaned (no graph edge
+ * back to the Turn that produced them). This hook restores that input
+ * via the `updated_input` channel (the only V10-supported prompt
+ * injection mechanism), so annotations can include edges like
+ *
+ *   <turn-uri> chat:proposes  <finding-uri>
+ *   <turn-uri> chat:mentions  <file-uri>
+ *
+ * and the capture-chat write that lands after the response completes
+ * the JOIN.
+ *
+ * Hook ordering (.cursor/hooks.json)
+ * ----------------------------------
+ *   1. capture-chat.mjs (beforeSubmitPrompt) — stashes the ORIGINAL
+ *      prompt before any hook mutates it, and persists session state
+ *      (turnIndex, pendingPrompt).
+ *   2. inject-session-context.mjs (this hook) — reads the persisted
+ *      state, computes next-turn index, prepends the block.
+ *   3. inject-inbox.mjs — prepends inbox notice if unread peer
+ *      messages exist. Sees prompt-with-session-context as its input
+ *      and prepends ABOVE it, producing final order:
+ *         <dkg-inbox-notice>      (most urgent)
+ *         <dkg-session-context>   (administrative metadata)
+ *         <operator prompt>       (the actual ask)
+ *
+ * Output contract
+ * ---------------
+ *   { updated_input: "<dkg-session-context>...\n\n<operator prompt>" }
+ * or `{}` on any failure (fail-open per hook convention).
+ *
+ * Security model
+ * --------------
+ * Both injected fields come from the local trust boundary:
+ *   - `sessionKey` is Cursor's `conversation_id` from the hook payload
+ *     (a value Cursor itself mints; never peer-controlled).
+ *   - `nextTurnIndex` comes from `~/.cache/dkg-mcp/sessions/<sessionKey>.json`,
+ *     which only capture-chat.mjs writes on this machine.
+ *   - `agentUri` is read from `.dkg/config.yaml` (local).
+ *
+ * No peer-controlled data is inlined. Same posture as inject-inbox.mjs,
+ * which explicitly forbids peer text in the prompt; we route around
+ * that constraint by injecting only locally-controlled identifiers.
+ *
+ * Design principles (mirror capture-chat.mjs / inject-inbox.mjs)
+ * -------------------------------------------------------------
+ *   1. FAIL OPEN. Any error → `{}` on stdout (no modification). The
+ *      hook must never block the operator's prompt.
+ *   2. FAIL CLOSED on prompt extraction. If we cannot identify the
+ *      operator's prompt, we must NOT emit `updated_input` (would
+ *      silently REPLACE the prompt with just our block).
+ *   3. NO NEW CONFIG SURFACE. Reads `.dkg/config.yaml` walking
+ *      upward from cwd for `agent.uri`.
+ *   4. STDLIB ONLY. No npm imports.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const LOG_FILE = process.env.DKG_SESSION_CTX_LOG ?? '/tmp/dkg-inject-session-context.log';
+const STATE_DIR = path.join(os.homedir(), '.cache', 'dkg-mcp', 'sessions');
+
+function log(msg) {
+  try {
+    fs.appendFileSync(LOG_FILE, `${new Date().toISOString()} ${msg}\n`);
+  } catch {
+    /* never crash the hook just because we can't log */
+  }
+}
+
+// Generic deep-search for the first matching key. Same pattern as
+// sibling hooks; lets us tolerate field-name drift across Cursor /
+// Claude Code / future tools without per-tool branching.
+function pick(obj, candidates, depth = 0) {
+  if (depth > 4 || obj == null || typeof obj !== 'object') return undefined;
+  for (const c of candidates) {
+    if (Object.prototype.hasOwnProperty.call(obj, c)) {
+      const v = obj[c];
+      if (typeof v === 'string' && v.trim()) return v;
+      if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+    }
+  }
+  for (const v of Object.values(obj)) {
+    if (v && typeof v === 'object') {
+      const nested = pick(v, candidates, depth + 1);
+      if (nested !== undefined) return nested;
+    }
+  }
+  return undefined;
+}
+
+export function sanitiseSlug(s) {
+  return String(s).replace(/[^A-Za-z0-9._-]+/g, '-').slice(0, 80);
+}
+
+// Mirror capture-chat.mjs `extractSessionKey` so both hooks compute
+// the same `sessionKey` for the same payload — any drift here would
+// silently produce a turn URI the capture hook never writes.
+export function extractSessionKey(payload) {
+  const id = pick(payload, [
+    'conversation_id', 'session_id', 'thread_id', 'chat_id',
+    'conversationId', 'sessionId', 'threadId', 'chatId', 'convId', 'id',
+  ]);
+  if (id) return sanitiseSlug(id);
+  // Anon-session fallback identical to capture-chat.mjs: read the
+  // per-process index file. capture-chat's `anonSessionKey()` writes
+  // it; we only read.
+  try {
+    const stateDir = path.join(os.homedir(), '.dkg', 'hook-state');
+    const idxFile = path.join(stateDir, `anon-session-${process.ppid || process.pid}.txt`);
+    if (fs.existsSync(idxFile)) {
+      const buf = fs.readFileSync(idxFile, 'utf-8').trim();
+      if (buf) return sanitiseSlug(buf);
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+export function extractPrompt(payload) {
+  if (!payload || typeof payload !== 'object') return '';
+  if (typeof payload.rawPayload === 'string' && payload.rawPayload.trim()) {
+    return payload.rawPayload;
+  }
+  return pick(payload, [
+    'prompt', 'input', 'text', 'message', 'content', 'user_input',
+  ]) ?? '';
+}
+
+function findWorkspaceConfig(start) {
+  let dir = path.resolve(start);
+  const root = path.parse(dir).root;
+  while (true) {
+    const candidate = path.join(dir, '.dkg', 'config.yaml');
+    if (fs.existsSync(candidate)) return candidate;
+    if (dir === root) return null;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// Read the single `agent.uri` field from the workspace YAML. We deliberately
+// don't reuse the full parsers from sibling hooks — they each carry their own
+// stripped-down parser for the same reason: stdlib-only + small footprint.
+export function parseAgentUri(yamlText) {
+  const lines = yamlText.split('\n');
+  let inAgent = false;
+  let agentIndent = -1;
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/#.*$/, '').replace(/\s+$/, '');
+    if (!line.trim()) continue;
+    const indent = line.match(/^ */)[0].length;
+    if (!inAgent && /^agent\s*:\s*$/.test(line.trim())) {
+      inAgent = true;
+      agentIndent = indent;
+      continue;
+    }
+    if (inAgent && indent <= agentIndent) {
+      // dedented out of the `agent:` block before finding `uri`
+      inAgent = false;
+    }
+    if (inAgent) {
+      const m = line.trim().match(/^uri\s*:\s*(.*)$/);
+      if (m) return m[1].replace(/^["']|["']$/g, '').trim();
+    }
+  }
+  return null;
+}
+
+function loadAgentUri() {
+  const fromEnv = process.env.DKG_AGENT_URI?.trim();
+  if (fromEnv) return fromEnv;
+  const cwd = process.env.DKG_WORKSPACE ?? process.cwd();
+  const cfgPath = findWorkspaceConfig(cwd);
+  if (!cfgPath) return null;
+  try {
+    return parseAgentUri(fs.readFileSync(cfgPath, 'utf-8'));
+  } catch (err) {
+    log(`agent.uri parse failed: ${err?.message ?? err}`);
+    return null;
+  }
+}
+
+// Read-only consumer of capture-chat's session state. We never write
+// this file — capture-chat owns the writes; we only need `turnIndex`
+// to predict the next turn URI.
+function loadTurnIndex(sessionKey) {
+  try {
+    const raw = fs.readFileSync(path.join(STATE_DIR, `${sessionKey}.json`), 'utf-8');
+    const state = JSON.parse(raw);
+    return typeof state.turnIndex === 'number' ? state.turnIndex : 0;
+  } catch {
+    // Missing state file → first turn of a fresh session. capture-chat
+    // creates the state file in its own beforeSubmitPrompt handler, which
+    // runs BEFORE this hook per .cursor/hooks.json ordering, so this
+    // branch only fires when (a) it's literally turn 1, or (b)
+    // capture-chat errored out on this turn (in which case fail-open is
+    // the right move — emit nextTurnIndex=1 and the capture hook will
+    // self-heal on its next successful event).
+    return 0;
+  }
+}
+
+async function readStdinJson() {
+  if (process.stdin.isTTY) return {};
+  try {
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    const text = Buffer.concat(chunks).toString('utf-8').trim();
+    if (!text) return {};
+    try { return JSON.parse(text); }
+    catch { return { rawPayload: text }; }
+  } catch (err) {
+    log(`stdin read failed: ${err?.message ?? err}`);
+    return {};
+  }
+}
+
+export function renderBlock({ sessionKey, nextTurnIndex, turnUri, agentUri }) {
+  // Wrapping tags make this a structured notice the agent's prompt
+  // parser sees as metadata, not free text. Four fields keep the
+  // prompt-budget hit minimal.
+  return [
+    '<dkg-session-context>',
+    `  <session-id>${sessionKey}</session-id>`,
+    `  <next-turn-index>${nextTurnIndex}</next-turn-index>`,
+    `  <turn-uri>${turnUri}</turn-uri>`,
+    `  <agent-uri>${agentUri ?? '(unknown)'}</agent-uri>`,
+    '</dkg-session-context>',
+  ].join('\n');
+}
+
+async function main() {
+  const payload = await readStdinJson();
+  const sessionKey = extractSessionKey(payload);
+  const userPrompt = extractPrompt(payload);
+
+  // FAIL CLOSED on missing inputs. If sessionKey is null we cannot
+  // build a useful turn URI. If userPrompt is empty, emitting
+  // updated_input would silently REPLACE the operator's prompt with
+  // just our block — see the same guard in inject-inbox.mjs.
+  if (!sessionKey || !userPrompt) {
+    log(`skipping injection: sessionKey=${!!sessionKey} prompt=${!!userPrompt}`);
+    process.stdout.write('{}\n');
+    return;
+  }
+
+  const turnIndex = loadTurnIndex(sessionKey);
+  const nextTurnIndex = turnIndex + 1;
+  // Mirror capture-chat.mjs `turnUri(slug, idx)`. For sanitised slugs
+  // encodeURIComponent is a no-op, but we keep it for byte-alignment
+  // with the producer of the URI we're predicting.
+  const turnUri = `urn:dkg:chat:session:${encodeURIComponent(sessionKey)}#turn:${nextTurnIndex}`;
+  const agentUri = loadAgentUri();
+
+  const block = renderBlock({ sessionKey, nextTurnIndex, turnUri, agentUri });
+  const updatedInput = `${block}\n\n${userPrompt}`;
+
+  process.stdout.write(JSON.stringify({ updated_input: updatedInput }) + '\n');
+  log(`injected: session=${sessionKey} nextTurn=${nextTurnIndex} agent=${agentUri ?? '(none)'} promptLen=${userPrompt.length}`);
+}
+
+// Self-execute only when invoked directly (avoids running during
+// import from a future unit test).
+const isMainModule = (() => {
+  try {
+    if (!process.argv[1]) return false;
+    return import.meta.url === new URL(`file://${path.resolve(process.argv[1])}`).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMainModule) {
+  main().catch((err) => {
+    log(`unexpected error: ${err?.stack ?? err?.message ?? err}`);
+    process.stdout.write('{}\n');
+  });
+}

--- a/packages/mcp-dkg/hooks/inject-session-context.mjs
+++ b/packages/mcp-dkg/hooks/inject-session-context.mjs
@@ -116,6 +116,17 @@ export const extractSessionKey = captureExtractSessionKey;
 
 export function extractPrompt(payload) {
   if (!payload || typeof payload !== 'object') return '';
+  // Defensive: an upstream beforeSubmitPrompt hook may have already
+  // emitted `updated_input`. Cursor's docs don't specify how the
+  // field composes across sequential hooks, but if it IS surfaced
+  // to downstream hooks we want to treat it as the canonical prompt
+  // rather than going back to the original `prompt` field — that
+  // would silently overwrite any earlier prepended block. Mirrors
+  // the matching guard in inject-inbox.mjs. See Codex PR #589
+  // round 3 finding on hook composition.
+  if (typeof payload.updated_input === 'string' && payload.updated_input.trim()) {
+    return payload.updated_input;
+  }
   // `readStdinJson` wraps non-JSON stdin in `{ rawPayload: <text> }`
   // so the operator's prompt is recoverable even when Cursor sends
   // a plain string. Honour that envelope before delegating to the

--- a/packages/mcp-dkg/src/cli/index.ts
+++ b/packages/mcp-dkg/src/cli/index.ts
@@ -437,6 +437,7 @@ async function cmdJoin(args: string[]): Promise<number> {
     mcpDkgPackageDir: path.resolve(HERE, '..', '..'),
     mcpDkgSrcAbsPath: path.resolve(HERE, '..', '..', 'src', 'index.ts'),
     captureScriptPath: path.resolve(HERE, '..', '..', 'hooks', 'capture-chat.mjs'),
+    injectSessionContextScriptPath: path.resolve(HERE, '..', '..', 'hooks', 'inject-session-context.mjs'),
     homedir: os.homedir(),
   };
   const plan = planInstall(ctx);

--- a/packages/mcp-dkg/src/manifest/install.ts
+++ b/packages/mcp-dkg/src/manifest/install.ts
@@ -83,6 +83,8 @@ export interface InstallContext {
   mcpDkgSrcAbsPath: string;
   /** Absolute path to the capture-chat.mjs hook script. */
   captureScriptPath: string;
+  /** Absolute path to the inject-session-context.mjs hook script. */
+  injectSessionContextScriptPath: string;
   /** Override $HOME for tests; defaults to os.homedir(). */
   homedir?: string;
 }
@@ -156,6 +158,7 @@ function buildSubstitutionValues(
     mcpDkgPackageDir: ctx.mcpDkgPackageDir,
     mcpDkgSrcAbsPath: ctx.mcpDkgSrcAbsPath,
     captureScriptPath: ctx.captureScriptPath,
+    injectSessionContextScriptPath: ctx.injectSessionContextScriptPath,
     network: ctx.manifest.network,
   };
 }

--- a/packages/mcp-dkg/src/manifest/schema.ts
+++ b/packages/mcp-dkg/src/manifest/schema.ts
@@ -87,6 +87,7 @@ export const MANIFEST_PLACEHOLDERS = [
   'mcpDkgPackageDir',   // absolute path to packages/mcp-dkg — used to run `pnpm --dir … exec tsx src/index.ts` on the TS source (dist/ is gitignored)
   'mcpDkgSrcAbsPath',   // absolute path to packages/mcp-dkg/src/index.ts — passed to tsx so we don't depend on CWD
   'captureScriptPath',  // absolute path to packages/mcp-dkg/hooks/capture-chat.mjs
+  'injectSessionContextScriptPath',  // absolute path to packages/mcp-dkg/hooks/inject-session-context.mjs
   'network',            // testnet / mainnet / devnet
 ] as const;
 

--- a/packages/mcp-dkg/src/manifest/templates.ts
+++ b/packages/mcp-dkg/src/manifest/templates.ts
@@ -39,6 +39,8 @@
  *                           NOT shipped in the published tarball; kept for
  *                           legacy templates and `tsx`-based dev flows)
  *   {{captureScriptPath}}   absolute path to @origintrail-official/dkg-mcp/hooks/capture-chat.mjs
+ *   {{injectSessionContextScriptPath}}
+ *                           absolute path to @origintrail-official/dkg-mcp/hooks/inject-session-context.mjs
  *   {{network}}             testnet / mainnet / devnet
  */
 
@@ -80,9 +82,24 @@ export const CURSOR_HOOKS_TEMPLATE = JSON.stringify(
       ],
       beforeSubmitPrompt: [
         {
+          // capture-chat MUST run first — it stashes the operator's ORIGINAL prompt
+          // for later afterAgentResponse capture and persists session state
+          // (turnIndex), which inject-session-context reads on the next line.
           command:
             'DKG_WORKSPACE={{sh:workspaceAbsPath}} DKG_API={{sh:daemonApiUrl}} DKG_AGENT_URI={{sh:agentUri}} ' +
             'node {{sh:captureScriptPath}} beforeSubmitPrompt',
+          failClosed: false,
+        },
+        {
+          // inject-session-context prepends <dkg-session-context> to the prompt
+          // with sessionId + nextTurnIndex + predicted turn URI so the agent
+          // can author annotations carrying graph edges back to the chat:Turn
+          // capture-chat writes after the response. Restores the V9 forSession
+          // linkage that the V10 MCP consolidation (#381) + R3 capture-chat
+          // reduction (0e7abdf9) retired.
+          command:
+            'DKG_WORKSPACE={{sh:workspaceAbsPath}} DKG_AGENT_URI={{sh:agentUri}} ' +
+            'node {{sh:injectSessionContextScriptPath}}',
           failClosed: false,
         },
       ],
@@ -125,10 +142,21 @@ export const CLAUDE_HOOKS_TEMPLATE = JSON.stringify(
         {
           hooks: [
             {
+              // capture-chat MUST run first — see the matching Cursor hook
+              // for the rationale (stash prompt + persist turnIndex).
               type: 'command',
               command:
                 'DKG_WORKSPACE={{sh:workspaceAbsPath}} DKG_CAPTURE_TOOL=claude-code DKG_API={{sh:daemonApiUrl}} ' +
                 'DKG_AGENT_URI={{sh:agentUri}} node {{sh:captureScriptPath}} UserPromptSubmit',
+            },
+            {
+              // inject-session-context — see the matching Cursor hook for
+              // the rationale (restores the V9 forSession linkage that the
+              // V10 MCP consolidation retired).
+              type: 'command',
+              command:
+                'DKG_WORKSPACE={{sh:workspaceAbsPath}} DKG_CAPTURE_TOOL=claude-code ' +
+                'DKG_AGENT_URI={{sh:agentUri}} node {{sh:injectSessionContextScriptPath}}',
             },
           ],
         },

--- a/packages/mcp-dkg/test/inject-inbox-hook.test.ts
+++ b/packages/mcp-dkg/test/inject-inbox-hook.test.ts
@@ -78,6 +78,51 @@ describe('inject-inbox.mjs renderNotice — SECURITY', () => {
   });
 });
 
+describe('inject-inbox.mjs extractPrompt — HOOK COMPOSITION', () => {
+  // Codex PR #589 round 3 finding: if Cursor passes an upstream
+  // beforeSubmitPrompt hook's `updated_input` to downstream hooks
+  // (composition semantics aren't documented), the old extractor
+  // ignored it and went back to the original `prompt` field —
+  // silently overwriting any prepended block (e.g. the
+  // <dkg-session-context> emitted by inject-session-context.mjs).
+  // These tests pin the new defensive behaviour.
+
+  it('prefers payload.updated_input over the original prompt field when both are present', () => {
+    const upstreamBlock =
+      '<dkg-session-context>\n' +
+      '  <session-id>abc-123</session-id>\n' +
+      '  <next-turn-index>5</next-turn-index>\n' +
+      '  <turn-uri>urn:dkg:chat:session:abc-123#turn:5</turn-uri>\n' +
+      '  <agent-uri>urn:dkg:agent:0xdef</agent-uri>\n' +
+      '</dkg-session-context>\n\n' +
+      'what is the meaning of life?';
+    const composed = extractPrompt({
+      prompt: 'what is the meaning of life?',
+      updated_input: upstreamBlock,
+      conversation_id: 'abc-123',
+    });
+    expect(composed).toBe(upstreamBlock);
+    expect(composed).toContain('<dkg-session-context>');
+    expect(composed).toContain('what is the meaning of life?');
+  });
+
+  it('falls back to the original prompt when updated_input is absent', () => {
+    expect(extractPrompt({ prompt: 'plain prompt' })).toBe('plain prompt');
+  });
+
+  it('ignores updated_input when empty or whitespace-only', () => {
+    expect(extractPrompt({ prompt: 'p', updated_input: '' })).toBe('p');
+    expect(extractPrompt({ prompt: 'p', updated_input: '   \n  ' })).toBe('p');
+  });
+
+  it('ignores updated_input when it is not a string', () => {
+    // Hardening: if a future Cursor schema makes updated_input an
+    // object (matching preToolUse's shape), don't treat it as a
+    // string prompt.
+    expect(extractPrompt({ prompt: 'p', updated_input: { command: 'x' } as any })).toBe('p');
+  });
+});
+
 describe('inject-inbox.mjs daemonIdentityHash — STATE KEYING', () => {
   it('is deterministic for identical inputs', () => {
     const cfg = { api: 'http://localhost:9200', source: '/some/.dkg/config.yaml' };

--- a/packages/mcp-dkg/test/inject-session-context-hook.test.ts
+++ b/packages/mcp-dkg/test/inject-session-context-hook.test.ts
@@ -130,6 +130,31 @@ describe('inject-session-context.mjs — LOCKSTEP with capture-chat.mjs', () => 
       expect(extractPrompt({})).toBe('');
     });
   });
+
+  describe('hook composition: defensive updated_input extraction', () => {
+    // Codex PR #589 round 3: if a different upstream hook (or
+    // ourselves on a re-entry) has already emitted `updated_input`
+    // and Cursor surfaces it to this hook, we want to preserve it.
+    // Mirrors the matching defensive guard in inject-inbox.mjs.
+
+    it('prefers payload.updated_input over the original prompt when present', () => {
+      const upstreamBlock = '<dkg-inbox-notice>peer count</dkg-inbox-notice>\n\noriginal prompt';
+      expect(extractPrompt({
+        prompt: 'original prompt',
+        updated_input: upstreamBlock,
+      })).toBe(upstreamBlock);
+    });
+
+    it('falls back to the original prompt when updated_input is absent / empty', () => {
+      expect(extractPrompt({ prompt: 'p' })).toBe('p');
+      expect(extractPrompt({ prompt: 'p', updated_input: '' })).toBe('p');
+      expect(extractPrompt({ prompt: 'p', updated_input: '   ' })).toBe('p');
+    });
+
+    it('ignores updated_input when it is not a string', () => {
+      expect(extractPrompt({ prompt: 'p', updated_input: { command: 'x' } } as any)).toBe('p');
+    });
+  });
 });
 
 describe('inject-session-context.mjs — renderBlock', () => {

--- a/packages/mcp-dkg/test/inject-session-context-hook.test.ts
+++ b/packages/mcp-dkg/test/inject-session-context-hook.test.ts
@@ -1,0 +1,299 @@
+// inject-session-context-hook.test.ts
+//
+// Lockstep regression tests for the `<dkg-session-context>` injector.
+// Addresses Codex PR #589 finding 2: the hook reimplements helpers
+// that capture-chat owns, and any silent drift orphans annotations.
+//
+// These tests import BOTH `inject-session-context.mjs` and the
+// reference helpers from `capture-chat.mjs` directly, then assert
+// byte-for-byte agreement on representative payloads. If a future
+// edit accidentally diverges one side from the other, this suite
+// fails loudly instead of allowing the prod hooks to silently mint
+// turn URIs that capture-chat never writes.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ESM doesn't define `__dirname`; resolve it from `import.meta.url`
+// for the subprocess test below.
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+// @ts-expect-error - importing .mjs hook for its pure-function exports
+import {
+  extractPrompt,
+  extractSessionKey,
+  sanitiseSlug,
+  pick,
+  renderBlock,
+  parseAgentUri,
+} from '../hooks/inject-session-context.mjs';
+// @ts-expect-error - importing .mjs hook for its pure-function exports
+import {
+  extractText as captureExtractText,
+  extractSessionKey as captureExtractSessionKey,
+  sanitiseSlug as captureSanitiseSlug,
+  pick as capturePick,
+} from '../hooks/capture-chat.mjs';
+
+describe('inject-session-context.mjs — LOCKSTEP with capture-chat.mjs', () => {
+  it('re-exports the SAME `pick` reference as capture-chat (not a copy)', () => {
+    // `===` here is the strongest possible lockstep guarantee:
+    // there's only one implementation, so no drift is even
+    // representable.
+    expect(pick).toBe(capturePick);
+  });
+
+  it('re-exports the SAME `sanitiseSlug` reference as capture-chat', () => {
+    expect(sanitiseSlug).toBe(captureSanitiseSlug);
+  });
+
+  it('re-exports the SAME `extractSessionKey` reference as capture-chat', () => {
+    expect(extractSessionKey).toBe(captureExtractSessionKey);
+  });
+
+  // Functional cross-checks — even if someone broke the re-export
+  // contract above, these would catch agreement-on-representative-
+  // payloads drift (exactly the failure mode Codex flagged).
+  describe('extractSessionKey agreement', () => {
+    const payloads = [
+      // Cursor 3.1.15 snake_case
+      { name: 'conversation_id snake', payload: { conversation_id: 'abc-123', prompt: 'p' } },
+      { name: 'session_id snake', payload: { session_id: 'def-456' } },
+      // Cursor / Claude camelCase
+      { name: 'conversationId camel', payload: { conversationId: 'ghi-789' } },
+      { name: 'sessionId camel', payload: { sessionId: 'jkl-012' } },
+      // Short aliases other frameworks use
+      { name: 'convId short', payload: { convId: 'mno' } },
+      { name: 'id bare', payload: { id: 'pqr' } },
+      // Nested payloads (the deep-search behaviour of `pick`)
+      { name: 'nested conversation_id', payload: { meta: { conversation_id: 'stu' } } },
+      // ID with non-slug-safe chars — both sides must normalise the
+      // same way.
+      { name: 'colons + slashes', payload: { conversation_id: 'urn:dkg:agent:0xABC/cursor-1' } },
+      { name: 'whitespace + unicode', payload: { session_id: 'session — round 2' } },
+    ];
+
+    it.each(payloads)('agrees with capture-chat on $name', ({ payload }) => {
+      expect(extractSessionKey(payload)).toBe(captureExtractSessionKey(payload));
+    });
+
+    it('agrees on the anon-session fallback path (both write/read the same per-process file)', () => {
+      // The anon-session fallback path in capture-chat writes a file
+      // under ~/.dkg/hook-state if no id is present. Two consecutive
+      // calls — one through each export — must produce the SAME
+      // synthesised key because the second call reads the file the
+      // first one wrote. (Both exports point at the same function
+      // reference, so this is checking that the underlying file
+      // protocol stays consistent.)
+      const stateDir = path.join(os.homedir(), '.dkg', 'hook-state');
+      const idxFile = path.join(stateDir, `anon-session-${process.ppid || process.pid}.txt`);
+      // Clear any leftover state from previous test runs.
+      try { fs.unlinkSync(idxFile); } catch { /* ok if absent */ }
+      const k1 = extractSessionKey({});
+      const k2 = captureExtractSessionKey({});
+      expect(k1).toBe(k2);
+      expect(k1).toMatch(/^anon-/);
+    });
+  });
+
+  describe('extractPrompt agreement on user-prompt payload shapes', () => {
+    // Codex finding 2 (round 1) was specifically about these keys
+    // — they MUST all extract through both modules. capture-chat's
+    // `extractText` is the canonical list; inject-session-context's
+    // `extractPrompt` delegates to it (after the rawPayload short-
+    // circuit).
+    const keys = ['prompt', 'userPrompt', 'user_prompt', 'request', 'input', 'text', 'message', 'content'];
+    it.each(keys)('extracts %s via both helpers', (key) => {
+      const payload = { [key]: 'sentinel value' };
+      expect(extractPrompt(payload)).toBe('sentinel value');
+      expect(captureExtractText(payload)).toBe('sentinel value');
+    });
+
+    it('honours the rawPayload short-circuit even when capture-chat would not', () => {
+      // capture-chat doesn't recognise `rawPayload` — that wrapper
+      // is specific to inject-session-context's readStdinJson, which
+      // wraps non-JSON stdin so the operator's prompt remains
+      // recoverable. We deliberately diverge here, and the test
+      // pins that divergence so it doesn't get "fixed" by accident.
+      const payload = { rawPayload: 'raw text' };
+      expect(extractPrompt(payload)).toBe('raw text');
+      expect(captureExtractText(payload)).toBe('');
+    });
+
+    it('returns empty string for non-objects and missing keys', () => {
+      expect(extractPrompt(null)).toBe('');
+      expect(extractPrompt(undefined)).toBe('');
+      expect(extractPrompt('string')).toBe('');
+      expect(extractPrompt({})).toBe('');
+    });
+  });
+});
+
+describe('inject-session-context.mjs — renderBlock', () => {
+  it('produces a structured XML-shaped notice the agent can parse as metadata', () => {
+    const block = renderBlock({
+      sessionKey: 'abc-123',
+      nextTurnIndex: 5,
+      turnUri: 'urn:dkg:chat:session:abc-123#turn:5',
+      agentUri: 'urn:dkg:agent:0xdef',
+    });
+    expect(block).toMatch(/^<dkg-session-context>/);
+    expect(block).toMatch(/<\/dkg-session-context>$/);
+    expect(block).toContain('<session-id>abc-123</session-id>');
+    expect(block).toContain('<next-turn-index>5</next-turn-index>');
+    expect(block).toContain('<turn-uri>urn:dkg:chat:session:abc-123#turn:5</turn-uri>');
+    expect(block).toContain('<agent-uri>urn:dkg:agent:0xdef</agent-uri>');
+  });
+
+  it('falls back to (unknown) when agentUri is null/undefined', () => {
+    const block = renderBlock({
+      sessionKey: 'a', nextTurnIndex: 1, turnUri: 'urn:t', agentUri: null,
+    });
+    expect(block).toContain('<agent-uri>(unknown)</agent-uri>');
+  });
+});
+
+describe('inject-session-context.mjs — parseAgentUri', () => {
+  it('parses agent.uri from a minimal .dkg/config.yaml', () => {
+    const yaml = [
+      'contextGraph: foo',
+      'agent:',
+      '  uri: urn:dkg:agent:0xabc',
+      '  nickname: "Test Laptop"',
+    ].join('\n');
+    expect(parseAgentUri(yaml)).toBe('urn:dkg:agent:0xabc');
+  });
+
+  it('ignores commented-out uri lines', () => {
+    const yaml = [
+      'agent:',
+      '  # uri: urn:dkg:agent:wrong',
+      '  uri: urn:dkg:agent:right',
+    ].join('\n');
+    expect(parseAgentUri(yaml)).toBe('urn:dkg:agent:right');
+  });
+
+  it('returns null when agent block has no uri field', () => {
+    const yaml = 'agent:\n  nickname: foo\n';
+    expect(parseAgentUri(yaml)).toBe(null);
+  });
+
+  it('returns null when there is no agent block', () => {
+    expect(parseAgentUri('contextGraph: foo\n')).toBe(null);
+  });
+});
+
+describe('inject-session-context.mjs — turn-URI prediction via state file', () => {
+  // Black-box test of the hook's state-file consumption. We
+  // construct a state file that mirrors what capture-chat would
+  // write, run the hook as a subprocess, and assert it emits
+  // `<turn-uri>` matching the slot capture-chat reserved.
+  //
+  // This is the regression that fails if PR #589 finding 1's bug
+  // is reintroduced: a state file with `pendingTurnIndex=7` and
+  // `turnIndex=3` must produce `#turn:7`, NOT `#turn:4`.
+
+  const STATE_DIR = path.join(os.homedir(), '.cache', 'dkg-mcp', 'sessions');
+  const sessionKey = 'inject-test-session';
+  const stateFile = path.join(STATE_DIR, `${sessionKey}.json`);
+  const hookPath = path.resolve(HERE, '..', 'hooks', 'inject-session-context.mjs');
+  let savedState: string | null = null;
+
+  beforeEach(() => {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+    if (fs.existsSync(stateFile)) {
+      savedState = fs.readFileSync(stateFile, 'utf-8');
+    }
+  });
+
+  afterEach(() => {
+    if (savedState != null) {
+      fs.writeFileSync(stateFile, savedState);
+      savedState = null;
+    } else {
+      try { fs.unlinkSync(stateFile); } catch { /* ok */ }
+    }
+  });
+
+  async function runHook(payload: object): Promise<{ stdout: string; output: any }> {
+    const { spawn } = await import('node:child_process');
+    return await new Promise((resolveFn, rejectFn) => {
+      const proc = spawn('node', [hookPath], { stdio: ['pipe', 'pipe', 'pipe'] });
+      let stdout = '';
+      proc.stdout.on('data', (c) => { stdout += c; });
+      proc.on('close', () => {
+        try {
+          resolveFn({ stdout, output: JSON.parse(stdout.trim() || '{}') });
+        } catch (e) { rejectFn(e); }
+      });
+      proc.on('error', rejectFn);
+      proc.stdin.write(JSON.stringify(payload));
+      proc.stdin.end();
+    });
+  }
+
+  it('uses state.pendingTurnIndex when present (the post-PR #589 contract)', async () => {
+    // Simulate capture-chat reserving turn 7 after several
+    // previous turns; the failed-retry scenario is what advances
+    // pendingTurnIndex past turnIndex.
+    fs.writeFileSync(stateFile, JSON.stringify({
+      sessionKey,
+      sessionUri: `urn:dkg:chat:session:${sessionKey}`,
+      startedAt: new Date().toISOString(),
+      turnIndex: 3,
+      pendingTurnIndex: 7,
+      maxAssignedTurnIndex: 7,
+      pendingPrompt: 'whatever',
+    }));
+    const { output } = await runHook({ session_id: sessionKey, prompt: 'hi' });
+    expect(output.updated_input).toContain(`<turn-uri>urn:dkg:chat:session:${sessionKey}#turn:7</turn-uri>`);
+    expect(output.updated_input).toContain('<next-turn-index>7</next-turn-index>');
+  });
+
+  it('falls back to turnIndex+1 for legacy state files written before the contract existed', async () => {
+    // Old capture-chat writes don't include pendingTurnIndex. The
+    // hook must not break for in-flight upgrades.
+    fs.writeFileSync(stateFile, JSON.stringify({
+      sessionKey,
+      sessionUri: `urn:dkg:chat:session:${sessionKey}`,
+      startedAt: new Date().toISOString(),
+      turnIndex: 4,
+      pendingPrompt: 'whatever',
+    }));
+    const { output } = await runHook({ session_id: sessionKey, prompt: 'hi' });
+    expect(output.updated_input).toContain(`<turn-uri>urn:dkg:chat:session:${sessionKey}#turn:5</turn-uri>`);
+  });
+
+  it('skips injection when no state file exists (fail-closed)', async () => {
+    try { fs.unlinkSync(stateFile); } catch { /* ok */ }
+    const { output } = await runHook({ session_id: sessionKey, prompt: 'hi' });
+    expect(output).toEqual({});
+  });
+
+  it('does NOT reuse the same predicted URI after a simulated failed-turn-write retry', async () => {
+    // The scenario PR #589 finding 1 calls out:
+    // 1. Prompt P1 reserves turn 5 (state.pendingTurnIndex = 5).
+    // 2. capture-chat's afterAgentResponse for P1 fails. State
+    //    after capture-chat's failure handler: turnIndex unchanged
+    //    at 4, maxAssignedTurnIndex stays at 5 (the failed slot is
+    //    abandoned, not retried).
+    // 3. Prompt P2 reserves turn 6 (maxAssignedTurnIndex advances to 6).
+    // Verify inject-session-context predicts the FRESH slot 6, not
+    // the orphaned slot 5.
+    fs.writeFileSync(stateFile, JSON.stringify({
+      sessionKey,
+      sessionUri: `urn:dkg:chat:session:${sessionKey}`,
+      startedAt: new Date().toISOString(),
+      turnIndex: 4,
+      pendingTurnIndex: 6, // capture-chat reserved a NEW slot after P1's failure
+      maxAssignedTurnIndex: 6,
+      pendingPrompt: 'P2',
+    }));
+    const { output } = await runHook({ session_id: sessionKey, prompt: 'P2' });
+    expect(output.updated_input).toContain('#turn:6</turn-uri>');
+    expect(output.updated_input).not.toContain('#turn:5</turn-uri>');
+  });
+});


### PR DESCRIPTION
## Summary

- New `beforeSubmitPrompt` hook `packages/mcp-dkg/hooks/inject-session-context.mjs` that prepends a `<dkg-session-context>` block to every operator prompt, carrying `<session-id>`, `<next-turn-index>`, the deterministic `<turn-uri>`, and the operator's `<agent-uri>`.
- One-entry diff in `.cursor/hooks.json` wiring the new hook between `capture-chat` (must run first to persist turn state) and `inject-inbox` (must run last so its notice sits on top).
- Closes the V10 gap created when #381 + the R3 capture-chat reduction (0e7abdf9) retired the V9 `sessionStart` additionalContext channel — agents can again author graph edges back to the `chat:Turn` capture-chat writes after each response.

## Why

The V10 MCP consolidation deliberately retired the V9 prompt-injection sub-system and the "sugared" annotation tools (`dkg_annotate_turn`, `dkg_propose_decision`, `dkg_add_task`, …). The new canonical write flow is the explicit three-step `dkg_assertion_create` → `dkg_assertion_write` → `dkg_assertion_promote`. That's the right surface — but it left a real gap: an agent had no input carrying its own `conversation_id`, so it could not compute the predictable URI

```
urn:dkg:chat:session:<sessionKey>#turn:<idx>
```

that `capture-chat.mjs` writes deterministically after each response. Any annotation an agent authored during the turn (Findings, Decisions, Tasks, `chat:topic`, `chat:mentions`) ended up orphaned: no graph edge back to the Turn that produced it. The chat sub-graph stopped functioning as project memory because you couldn't traverse from a Turn to "what was decided / found / proposed in this turn".

## What

This hook restores the missing input via the only V10-supported channel — `updated_input`:

```
<dkg-session-context>
  <session-id>{sessionKey}</session-id>
  <next-turn-index>{N}</next-turn-index>
  <turn-uri>urn:dkg:chat:session:{sessionKey}#turn:{N}</turn-uri>
  <agent-uri>{agentUri}</agent-uri>
</dkg-session-context>
```

The agent reads `<turn-uri>` once and can now author:

```
<turn-uri> chat:proposes  <finding-uri>
<turn-uri> chat:mentions  <file-uri>
```

`capture-chat` afterAgentResponse writes the actual `chat:Turn` entity at exactly this URI, so the join is clean.

### Hook ordering (`.cursor/hooks.json`)

1. `capture-chat` (`beforeSubmitPrompt`) — stashes the operator's ORIGINAL prompt for later `afterAgentResponse` capture, and persists session state (turnIndex) to `~/.cache/dkg-mcp/sessions/<sessionKey>.json`.
2. `inject-session-context` (this PR) — reads the state file, computes `nextTurnIndex`, prepends the block.
3. `inject-inbox` — prepends its `<dkg-inbox-notice>` on top, producing final prompt order:
   - `<dkg-inbox-notice>` (most urgent)
   - `<dkg-session-context>` (administrative metadata)
   - operator prompt

### Security model

Mirrors `inject-inbox.mjs`. Every injected field comes from the local trust boundary:

- `sessionKey` is Cursor's `conversation_id` from the hook payload (Cursor mints it; never peer-controlled).
- `nextTurnIndex` comes from `~/.cache/dkg-mcp/sessions/<sessionKey>.json`, which only `capture-chat.mjs` writes on this machine.
- `agentUri` is read from `.dkg/config.yaml` (local).

No peer-controlled text is inlined into the prompt.

### Fail-open

Per existing hook convention. Any failure → `{}` on stdout (no prompt modification). Errors are appended to `/tmp/dkg-inject-session-context.log`. The one exception is fail-closed-on-prompt-extraction: if the operator's prompt can't be identified in the payload, we skip injection rather than risk silently replacing the prompt with just our block.

## Test plan

- [x] **Standalone unit invocation**: piped a synthetic Cursor `beforeSubmitPrompt` payload into the hook, confirmed it returns `{ updated_input: "<dkg-session-context>...\n\n<prompt>" }` with the right session/turn URI and `<agent-uri>` derived from `.dkg/config.yaml`.
- [x] **End-to-end annotation flow with the daemon up**: with the hook wired, agent computed `<turn-uri>`, called `dkg_memory_search` for look-before-mint, then `dkg_assertion_create` + `_write` + `_promote` to file 4 Findings + 4 `chat:proposes` edges in the `decisions` sub-graph. Verified via SPARQL (with the obligatory `GRAPH ?g { ... }` wrapper) that all 5 root entities landed in SWM and that `<turn-uri> chat:proposes ?finding` returned all 4 expected URIs.
- [ ] Reviewer: please verify on a fresh Cursor session (hooks are cached at session start — open a new chat after merging + pulling). The first agent reply should reference the session/turn URI it parsed from the injected block.
- [ ] Reviewer: please confirm `/tmp/dkg-inject-session-context.log` shows one `injected: session=… nextTurn=…` line per substantive operator prompt.

## Notes

- The hook is intentionally STDLIB-only (no npm imports), matching the existing `inject-inbox.mjs` posture.
- File mode is `100755` to match `inject-inbox.mjs` (the hooks aren't *invoked* as executables — Cursor spawns them via `node …` — but the convention is consistent).
- Follow-up (out of scope for this PR): the workspace-side AGENTS.md / cursor rule / scanner that exercise this hook downstream are tracked separately and can land in a subsequent PR if the team wants the documentation surface in this repo.

Made with [Cursor](https://cursor.com)