### PR TITLE
Codex/openclaw query catalog save main

### DIFF
--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -79,6 +79,7 @@ type QueryCatalogToolItem = {
   name: string;
   description?: string;
   sparql: string;
+  resultColumn?: string;
   rank: number;
   catalogSlug: string;
   catalogName: string;
@@ -182,6 +183,7 @@ function normalizeQueryCatalogItems(response: Record<string, unknown>): QueryCat
         name: stripRdfTerm(r.name) || slug,
         description: r.description !== undefined ? stripRdfTerm(r.description) : undefined,
         sparql,
+        resultColumn: r.resultColumn !== undefined ? stripRdfTerm(r.resultColumn) : undefined,
         rank: Number.parseInt(stripRdfTerm(r.rank) || '99', 10) || 99,
         catalogSlug,
         catalogName: stripRdfTerm(r.catalogName) || 'Queries',
@@ -2958,7 +2960,7 @@ export class DkgNodePlugin {
         description:
           'Run a saved SPARQL query from a context graph profile query catalog by slug or exact display name. ' +
           'Call dkg_query_catalog_list first if the selector is ambiguous. Executes the saved SPARQL against ' +
-          'the same context graph using the standard DKG query route.',
+          'the same context graph and saved sub-graph scope using the standard DKG query route.',
         parameters: {
           type: 'object',
           properties: {
@@ -3888,7 +3890,10 @@ export class DkgNodePlugin {
       }
 
       const savedQuery = matches[0];
-      const result = await this.client.query(savedQuery.sparql, { contextGraphId });
+      const queryOpts = savedQuery.subGraph && savedQuery.subGraph !== CONTEXT_GRAPH_QUERY_SUBGRAPH
+        ? { contextGraphId, subGraphName: savedQuery.subGraph }
+        : { contextGraphId };
+      const result = await this.client.query(savedQuery.sparql, queryOpts);
       return this.json({
         contextGraphId,
         savedQuery,

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -72,7 +72,7 @@ const USER_QUERY_CATALOG_DESCRIPTION = 'Queries saved from the Query tab.';
 const PROFILE_NS = 'http://dkg.io/ontology/profile/';
 const SCHEMA_NS = 'http://schema.org/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
-const XSD_INT = 'http://www.w3.org/2001/XMLSchema#int';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
 type QueryCatalogToolItem = {
   slug: string;
@@ -222,7 +222,7 @@ function queryCatalogLiteral(value: string): string {
 }
 
 function queryCatalogIntLiteral(value: number): string {
-  return `"${value}"^^<${XSD_INT}>`;
+  return `"${value}"^^<${XSD_INTEGER}>`;
 }
 
 function optionalString(value: unknown): string | undefined {

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -65,6 +65,15 @@ function isValidEthAddressString(value: string | undefined): boolean {
   return typeof value === 'string' && ETH_ADDR_RE_LC.test(value.trim().toLowerCase());
 }
 
+const CONTEXT_GRAPH_QUERY_SUBGRAPH = '__context_graph';
+const USER_QUERY_CATALOG_SLUG = 'ui-saved-queries';
+const USER_QUERY_CATALOG_NAME = 'Saved queries';
+const USER_QUERY_CATALOG_DESCRIPTION = 'Queries saved from the Query tab.';
+const PROFILE_NS = 'http://dkg.io/ontology/profile/';
+const SCHEMA_NS = 'http://schema.org/';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const XSD_INT = 'http://www.w3.org/2001/XMLSchema#int';
+
 type QueryCatalogToolItem = {
   slug: string;
   name: string;
@@ -76,6 +85,13 @@ type QueryCatalogToolItem = {
   catalogDescription?: string;
   catalogRank: number;
   subGraph: string;
+};
+
+type QueryCatalogWriteQuad = {
+  subject: string;
+  predicate: string;
+  object: string;
+  graph: string;
 };
 
 function stripRdfTerm(value: unknown): string {
@@ -181,6 +197,108 @@ function normalizeQueryCatalogItems(response: Record<string, unknown>): QueryCat
       || a.rank - b.rank
       || a.name.localeCompare(b.name),
     );
+}
+
+function queryCatalogSlug(value: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+  return slug || 'saved-query';
+}
+
+function queryCatalogProfileUri(contextGraphId: string, kind: 'catalog' | 'query', slug: string): string {
+  return `urn:dkg:profile:${encodeURIComponent(contextGraphId)}:${kind}:${encodeURIComponent(slug)}`;
+}
+
+function queryCatalogLiteral(value: string): string {
+  return JSON.stringify(value);
+}
+
+function queryCatalogIntLiteral(value: number): string {
+  return `"${value}"^^<${XSD_INT}>`;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function readOnlySparqlOperation(sparql: string): string | null {
+  const normalized = sparql
+    .split(/\r?\n/)
+    .filter((line) => !line.trimStart().startsWith('#'))
+    .join('\n')
+    .trim();
+  const match = normalized.match(/^(?:(?:PREFIX\s+\S+\s*<[^>]+>|BASE\s+<[^>]+>)\s*)*(SELECT|ASK|CONSTRUCT|DESCRIBE)\b/i);
+  return match?.[1]?.toUpperCase() ?? null;
+}
+
+function buildQueryCatalogSaveWrite(input: {
+  contextGraphId: string;
+  name: string;
+  description?: string;
+  sparql: string;
+  subGraph: string;
+  catalogSlug: string;
+  catalogName: string;
+  catalogDescription?: string;
+  resultColumn?: string;
+  rank: number;
+  catalogRank: number;
+}): {
+  savedQuery: QueryCatalogToolItem & {
+    queryUri: string;
+    catalogUri: string;
+    resultColumn?: string;
+  };
+  quads: QueryCatalogWriteQuad[];
+} {
+  const slug = `${queryCatalogSlug(input.name)}-${input.rank.toString(36)}`;
+  const catalogUri = queryCatalogProfileUri(input.contextGraphId, 'catalog', input.catalogSlug);
+  const queryUri = queryCatalogProfileUri(input.contextGraphId, 'query', slug);
+  const quads: QueryCatalogWriteQuad[] = [
+    { subject: catalogUri, predicate: RDF_TYPE, object: `${PROFILE_NS}QueryCatalog`, graph: '' },
+    { subject: catalogUri, predicate: `${PROFILE_NS}forSubGraph`, object: queryCatalogLiteral(input.subGraph), graph: '' },
+    { subject: catalogUri, predicate: `${PROFILE_NS}displayName`, object: queryCatalogLiteral(input.catalogName), graph: '' },
+    { subject: catalogUri, predicate: `${PROFILE_NS}rank`, object: queryCatalogIntLiteral(input.catalogRank), graph: '' },
+    { subject: queryUri, predicate: RDF_TYPE, object: `${PROFILE_NS}SavedQuery`, graph: '' },
+    { subject: queryUri, predicate: `${PROFILE_NS}forSubGraph`, object: queryCatalogLiteral(input.subGraph), graph: '' },
+    { subject: queryUri, predicate: `${PROFILE_NS}inCatalog`, object: catalogUri, graph: '' },
+    { subject: queryUri, predicate: `${PROFILE_NS}displayName`, object: queryCatalogLiteral(input.name), graph: '' },
+    { subject: queryUri, predicate: `${PROFILE_NS}sparqlQuery`, object: queryCatalogLiteral(input.sparql), graph: '' },
+    { subject: queryUri, predicate: `${PROFILE_NS}rank`, object: queryCatalogIntLiteral(input.rank), graph: '' },
+  ];
+  if (input.catalogDescription) {
+    quads.push({ subject: catalogUri, predicate: `${SCHEMA_NS}description`, object: queryCatalogLiteral(input.catalogDescription), graph: '' });
+  }
+  if (input.description) {
+    quads.push({ subject: queryUri, predicate: `${SCHEMA_NS}description`, object: queryCatalogLiteral(input.description), graph: '' });
+  }
+  if (input.resultColumn) {
+    quads.push({ subject: queryUri, predicate: `${PROFILE_NS}resultColumn`, object: queryCatalogLiteral(input.resultColumn), graph: '' });
+  }
+  return {
+    savedQuery: {
+      slug,
+      name: input.name,
+      description: input.description,
+      sparql: input.sparql,
+      rank: input.rank,
+      catalogSlug: input.catalogSlug,
+      catalogName: input.catalogName,
+      catalogDescription: input.catalogDescription,
+      catalogRank: input.catalogRank,
+      subGraph: input.subGraph,
+      queryUri,
+      catalogUri,
+      resultColumn: input.resultColumn,
+    },
+    quads,
+  };
 }
 
 const OPENCLAW_LOCAL_AGENT_CAPABILITIES = {
@@ -2858,6 +2976,57 @@ export class DkgNodePlugin {
         execute: async (_toolCallId, args) => this.handleQueryCatalogRun(args),
       },
       {
+        name: 'dkg_query_catalog_save',
+        description:
+          'Save a read-only SPARQL query into a context graph profile query catalog. Use only when the user ' +
+          'explicitly asks to save a query and you have the query text. Defaults to the UI "Saved queries" ' +
+          'catalog for whole-context-graph queries.',
+        parameters: {
+          type: 'object',
+          properties: {
+            context_graph_id: {
+              type: 'string',
+              description: 'Context graph/project ID whose profile query catalog should receive the saved query.',
+            },
+            name: {
+              type: 'string',
+              description: 'Human-readable saved query name.',
+            },
+            sparql: {
+              type: 'string',
+              description: 'Read-only SPARQL query text. Must start with SELECT, ASK, CONSTRUCT, or DESCRIBE after optional PREFIX/BASE declarations.',
+            },
+            description: {
+              type: 'string',
+              description: 'Optional short description of what the saved query returns.',
+            },
+            sub_graph: {
+              type: 'string',
+              description:
+                'Optional profile sub-graph scope. Defaults to "__context_graph", the whole-context-graph query surface.',
+            },
+            catalog_slug: {
+              type: 'string',
+              description: 'Optional catalog slug. Defaults to "ui-saved-queries".',
+            },
+            catalog_name: {
+              type: 'string',
+              description: 'Optional catalog display name. Defaults to "Saved queries".',
+            },
+            catalog_description: {
+              type: 'string',
+              description: 'Optional catalog description. Defaults to the UI saved-query catalog description.',
+            },
+            result_column: {
+              type: 'string',
+              description: 'Optional SELECT variable name, without "?", that identifies entity URI results for UI entity-list rendering.',
+            },
+          },
+          required: ['context_graph_id', 'name', 'sparql'],
+        },
+        execute: async (_toolCallId, args) => this.handleQueryCatalogSave(args),
+      },
+      {
         name: 'dkg_find_agents',
         description:
           'List DKG agents known to this node — combines the local registry (this node + cached peers from the ' +
@@ -3724,6 +3893,55 @@ export class DkgNodePlugin {
         contextGraphId,
         savedQuery,
         result,
+      });
+    } catch (err: any) {
+      return this.daemonError(err);
+    }
+  }
+
+  private async handleQueryCatalogSave(args: Record<string, unknown>): Promise<OpenClawToolResult> {
+    try {
+      const contextGraphId = String(args.context_graph_id ?? '').trim();
+      const name = String(args.name ?? '').trim();
+      const sparql = String(args.sparql ?? '').trim();
+      if (!contextGraphId) return this.error('"context_graph_id" is required.');
+      if (!name) return this.error('"name" is required.');
+      if (!sparql) return this.error('"sparql" is required.');
+
+      const operation = readOnlySparqlOperation(sparql);
+      if (!operation) {
+        return this.error(
+          '"sparql" must be a read-only query starting with SELECT, ASK, CONSTRUCT, or DESCRIBE ' +
+            'after optional PREFIX/BASE declarations.',
+        );
+      }
+
+      const description = optionalString(args.description);
+      const subGraph = optionalString(args.sub_graph) ?? CONTEXT_GRAPH_QUERY_SUBGRAPH;
+      const catalogSlug = queryCatalogSlug(optionalString(args.catalog_slug) ?? USER_QUERY_CATALOG_SLUG);
+      const catalogName = optionalString(args.catalog_name) ?? USER_QUERY_CATALOG_NAME;
+      const catalogDescription = optionalString(args.catalog_description) ?? USER_QUERY_CATALOG_DESCRIPTION;
+      const resultColumn = optionalString(args.result_column)?.replace(/^\?/, '');
+      const rank = Date.now();
+      const { savedQuery, quads } = buildQueryCatalogSaveWrite({
+        contextGraphId,
+        name,
+        description,
+        sparql,
+        subGraph,
+        catalogSlug,
+        catalogName,
+        catalogDescription,
+        resultColumn,
+        rank,
+        catalogRank: 50,
+      });
+      const write = await this.client.writeQueryCatalog(contextGraphId, quads);
+      return this.json({
+        contextGraphId,
+        operation,
+        savedQuery,
+        write,
       });
     } catch (err: any) {
       return this.daemonError(err);

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -342,6 +342,19 @@ export class DkgDaemonClient {
     return this.post('/api/profile/query-catalog/read', { contextGraphId });
   }
 
+  /**
+   * Append profile query catalog triples for a context graph.
+   *
+   * The daemon ignores caller-supplied graph names and writes into the
+   * context graph's local `meta/query-catalog` profile graph.
+   */
+  async writeQueryCatalog(
+    contextGraphId: string,
+    quads: Array<{ subject: string; predicate: string; object: string; graph?: string }>,
+  ): Promise<Record<string, unknown>> {
+    return this.post('/api/profile/query-catalog/write', { contextGraphId, quads });
+  }
+
   // ---------------------------------------------------------------------------
   // Shared memory write (SWM layer — NOT used by v1 chat-turn / memory paths)
   // ---------------------------------------------------------------------------

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -131,6 +131,32 @@ describe('DkgNodePlugin', () => {
     });
   });
 
+  it('saves query catalog timestamp ranks as unbounded integer literals', async () => {
+    const rank = 1_714_000_000_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(rank);
+    const writeQueryCatalog = vi.fn(async () => ({ written: true }));
+    const plugin = new DkgNodePlugin();
+    (plugin as any).client = { writeQueryCatalog };
+
+    try {
+      const result = await (plugin as any).handleQueryCatalogSave({
+        context_graph_id: 'cg-1',
+        name: 'Orders',
+        sparql: 'SELECT ?s WHERE { ?s ?p ?o }',
+      });
+
+      const savedQuery = (result.details as any).savedQuery;
+      const quads = writeQueryCatalog.mock.calls[0][1];
+      const rankQuad = quads.find((q: any) =>
+        q.subject === savedQuery.queryUri && q.predicate === 'http://dkg.io/ontology/profile/rank'
+      );
+
+      expect(rankQuad?.object).toBe(`"${rank}"^^<http://www.w3.org/2001/XMLSchema#integer>`);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it('bootstraps resolver state even when slot is owned by another plugin (R10.2)', async () => {
     // Pre-fix: when memory slot was owned by a different plugin, the
     // resolver bootstrap (`memoryResolverApi = api` + `refreshMemoryResolverState`)

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -67,6 +67,70 @@ describe('DkgNodePlugin', () => {
     });
   });
 
+  it('round-trips query catalog resultColumn metadata in list output', async () => {
+    const plugin = new DkgNodePlugin();
+    (plugin as any).client = {
+      readQueryCatalog: vi.fn(async () => ({
+        result: {
+          type: 'bindings',
+          bindings: [
+            {
+              q: 'urn:dkg:profile:cg-1:query:orders',
+              catalog: 'urn:dkg:profile:cg-1:catalog:saved',
+              name: '"Orders"',
+              sparql: '"SELECT ?uri WHERE { ?uri ?p ?o }"',
+              resultColumn: '"uri"',
+              subGraph: '"__context_graph"',
+            },
+          ],
+        },
+      })),
+    };
+
+    const result = await (plugin as any).handleQueryCatalogList({ context_graph_id: 'cg-1' });
+
+    expect((result.details as any).items[0]).toMatchObject({
+      slug: 'orders',
+      name: 'Orders',
+      resultColumn: 'uri',
+      subGraph: '__context_graph',
+    });
+  });
+
+  it('runs saved query catalog entries against their saved sub-graph scope', async () => {
+    const query = vi.fn(async () => ({ result: { bindings: [] } }));
+    const plugin = new DkgNodePlugin();
+    (plugin as any).client = {
+      readQueryCatalog: vi.fn(async () => ({
+        result: {
+          type: 'bindings',
+          bindings: [
+            {
+              q: 'urn:dkg:profile:cg-1:query:orders',
+              catalog: 'urn:dkg:profile:cg-1:catalog:saved',
+              name: '"Orders"',
+              sparql: '"SELECT ?s WHERE { ?s ?p ?o }"',
+              resultColumn: '"s"',
+              subGraph: '"production"',
+            },
+          ],
+        },
+      })),
+      query,
+    };
+
+    const result = await (plugin as any).handleQueryCatalogRun({ context_graph_id: 'cg-1', query: 'orders' });
+
+    expect(query).toHaveBeenCalledWith('SELECT ?s WHERE { ?s ?p ?o }', {
+      contextGraphId: 'cg-1',
+      subGraphName: 'production',
+    });
+    expect((result.details as any).savedQuery).toMatchObject({
+      resultColumn: 's',
+      subGraph: 'production',
+    });
+  });
+
   it('bootstraps resolver state even when slot is owned by another plugin (R10.2)', async () => {
     // Pre-fix: when memory slot was owned by a different plugin, the
     // resolver bootstrap (`memoryResolverApi = api` + `refreshMemoryResolverState`)

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -138,6 +138,7 @@ Drop to HTTP when the operation isn't in the table — participant self-service 
 | `dkg_query` | `POST /api/query` | Read-only SPARQL across assertions in a CG. Pass `view` (`working-memory` / `shared-working-memory` / `verified-memory`) to pick the layer — when `view` is set, `context_graph_id` is required; for WM reads, optional `agent_address` targets another agent's WM (defaults to this node). Omit `view` for a legacy cross-graph data-path query. |
 | `dkg_query_catalog_list` | `POST /api/profile/query-catalog/read` | List saved SPARQL queries declared in the project profile query catalog |
 | `dkg_query_catalog_run` | `POST /api/profile/query-catalog/read` + `POST /api/query` | Run a saved catalog query by slug or exact display name |
+| `dkg_query_catalog_save` | `POST /api/profile/query-catalog/write` | Save a read-only SPARQL query into the project profile query catalog |
 | `dkg_find_agents` | `GET /api/agents` | Discover other agents (best-effort P2P) |
 | `dkg_send_message` | `POST /api/chat` | Send a direct message (best-effort P2P) |
 | `dkg_read_messages` | `GET /api/messages` | Read inbound messages |
@@ -150,7 +151,7 @@ P2P tools fail gracefully when the peer is offline. `dkg_publish` (fresh quads +
 - **Participant self-service join/sign flow** — see §6.
 - **Conditional writes** (`POST /api/shared-memory/conditional-write`) — see §5 SWM.
 - **Async publisher job queue** (`/api/publisher/*`) — see §8.
-- **Query catalog writes** (`POST /api/profile/query-catalog/write`) — see §5 "Saved Query Catalog".
+- **Raw query catalog writes** (`POST /api/profile/query-catalog/write`) when not using `dkg_query_catalog_save` — see §5 "Saved Query Catalog".
 - **Raw file retrieval** (`GET /api/file/{fileHash}`) — see §7.
 - **Endorse / verify / update** (`POST /api/endorse`, `/verify`, `/update`) — see §5 VM.
 - **SSE event stream** (`GET /api/events`) — see §8.
@@ -274,10 +275,15 @@ Use this decision order:
    `dkg_query_catalog_run` with the selected `context_graph_id` and the saved
    query slug or exact display name. If the name is ambiguous, list first and
    ask/choose by slug.
-7. If no query catalog tool is available, use `dkg_query` against the profile
+7. If the user asks to save the current/query/SPARQL, call
+   `dkg_query_catalog_save` with the selected `context_graph_id`, a concise
+   `name`, optional `description`, and the exact read-only SPARQL text. If the
+   SPARQL text is not present in the user message or turn context, ask for it;
+   do not invent a query and save it as if it came from the user.
+8. If no query catalog tool is available, use `dkg_query` against the profile
    graph (`did:dkg:context-graph:<id>/meta/query-catalog`) to read saved
    queries, then run the selected `prof:sparqlQuery` with `dkg_query`.
-8. Only write or change query catalog entries when the user explicitly asks to
+9. Only write or change query catalog entries when the user explicitly asks to
    save/update catalog queries.
 
 OpenClaw tool path:
@@ -285,6 +291,10 @@ OpenClaw tool path:
 - `dkg_query_catalog_list` input: `{ "context_graph_id": "<contextGraphId>" }`
 - `dkg_query_catalog_run` input:
   `{ "context_graph_id": "<contextGraphId>", "query": "<slug-or-exact-name>" }`
+- `dkg_query_catalog_save` input:
+  `{ "context_graph_id": "<contextGraphId>", "name": "<display-name>", "sparql": "<read-only-sparql>", "description"?: "...", "result_column"?: "uri" }`
+  Optional advanced fields: `sub_graph` (defaults to `__context_graph`),
+  `catalog_slug`, `catalog_name`, and `catalog_description`.
 
 CLI fallback:
 
@@ -303,8 +313,9 @@ HTTP fallback:
   Body: `{ "contextGraphId": "<contextGraphId>", "quads": [...] }`
   The daemon stores these triples in
   `did:dkg:context-graph:<contextGraphId>/meta/query-catalog` regardless of
-  the incoming quad `graph` field. This route appends profile triples; prefer
-  a new saved-query URI for new saved queries and avoid overwriting unrelated
+  the incoming quad `graph` field. Prefer `dkg_query_catalog_save` for normal
+  user-requested saves. Raw writes append profile triples; prefer a new
+  saved-query URI for new saved queries and avoid overwriting unrelated
   catalog/profile metadata.
 
 Profile RDF shape for writes:

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3840,6 +3840,7 @@ type QueryCatalogItem = {
   name: string;
   description?: string;
   sparql: string;
+  resultColumn?: string;
   rank: number;
   catalogSlug: string;
   catalogName: string;
@@ -3847,6 +3848,8 @@ type QueryCatalogItem = {
   catalogRank: number;
   subGraph: string;
 };
+
+const CONTEXT_GRAPH_QUERY_SUBGRAPH = '__context_graph';
 
 async function loadSavedQueriesForCatalog(contextGraphId: string): Promise<QueryCatalogItem[]> {
   const client = await ApiClient.connect();
@@ -3863,6 +3866,7 @@ async function loadSavedQueriesForCatalog(contextGraphId: string): Promise<Query
         name: stripQuotes(String(row.name ?? slug)),
         description: row.description ? stripQuotes(String(row.description)) : undefined,
         sparql: stripQuotes(String(row.sparql ?? '')),
+        resultColumn: row.resultColumn ? stripQuotes(String(row.resultColumn)) : undefined,
         rank: Number.parseInt(stripQuotes(String(row.rank ?? '99')), 10) || 99,
         catalogSlug,
         catalogName: stripQuotes(String(row.catalogName ?? 'Queries')),
@@ -3924,6 +3928,7 @@ queryCatalogCmd
         console.log(`  Name:        ${item.name}`);
         console.log(`  Catalog:     ${item.catalogName} (${item.catalogSlug})`);
         console.log(`  Sub-graph:   ${item.subGraph}`);
+        if (item.resultColumn) console.log(`  Result col:  ${item.resultColumn}`);
         if (item.description) console.log(`  Description: ${item.description}`);
         console.log('');
       }
@@ -3945,7 +3950,13 @@ queryCatalogCmd
         process.exit(1);
       }
       const client = await ApiClient.connect();
-      const result = await client.query(match.sparql, contextGraphId);
+      const result = await client.query(
+        match.sparql,
+        contextGraphId,
+        match.subGraph && match.subGraph !== CONTEXT_GRAPH_QUERY_SUBGRAPH
+          ? { subGraphName: match.subGraph }
+          : undefined,
+      );
       console.log(`Running saved query: ${match.name}`);
       console.log(`Slug: ${match.slug}\n`);
       console.log(JSON.stringify(result.result, null, 2));

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -510,7 +510,7 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
     const graph = `did:dkg:context-graph:${contextGraphId}/meta/query-catalog`;
     const query = `PREFIX prof: <http://dkg.io/ontology/profile/>
 PREFIX schema: <http://schema.org/>
-SELECT ?q ?subGraph ?catalog ?name ?description ?sparql ?rank ?catalogName ?catalogDescription ?catalogRank
+SELECT ?q ?subGraph ?catalog ?name ?description ?sparql ?resultColumn ?rank ?catalogName ?catalogDescription ?catalogRank
 WHERE {
   GRAPH <${graph}> {
     ?q a prof:SavedQuery ;
@@ -519,6 +519,7 @@ WHERE {
     OPTIONAL { ?q prof:inCatalog ?catalog }
     OPTIONAL { ?q prof:displayName ?name }
     OPTIONAL { ?q schema:description ?description }
+    OPTIONAL { ?q prof:resultColumn ?resultColumn }
     OPTIONAL { ?q prof:rank ?rank }
     OPTIONAL { ?catalog prof:displayName ?catalogName }
     OPTIONAL { ?catalog schema:description ?catalogDescription }

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -72,11 +72,15 @@ const GRAPH_ICON = (
 interface MemoryLayerViewProps {
   layer: MemoryLayer;
   contextGraphId: string;
+  externalQuery?: string;
+  externalQueryKey?: string;
+  queryPresetOptions?: Array<{ label: string; query: string }>;
 }
 
-export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps) {
+export function MemoryLayerView({ layer, contextGraphId, externalQuery, externalQueryKey, queryPresetOptions }: MemoryLayerViewProps) {
   const meta = LAYER_META[layer];
   const [viewMode, setViewMode] = useState<ViewMode>('graph');
+  const [selectedPresetLabel, setSelectedPresetLabel] = useState('');
   const [draftQuery, setDraftQuery] = useState('');
   const [activeQuery, setActiveQuery] = useState('');
   const [draftSearch, setDraftSearch] = useState('');
@@ -91,6 +95,7 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
   React.useEffect(() => {
     if (prevLayerRef.current !== layer) {
       prevLayerRef.current = layer;
+      setSelectedPresetLabel('');
       setShowAdvancedQuery(layer !== 'vm');
       setDraftQuery('');
       setActiveQuery('');
@@ -102,6 +107,13 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
       setAppliedLimit(50);
     }
   }, [layer]);
+
+  React.useEffect(() => {
+    if (externalQuery === undefined) return;
+    setSelectedPresetLabel('');
+    setDraftQuery(externalQuery);
+    setActiveQuery(externalQuery);
+  }, [externalQuery, externalQueryKey]);
 
   const defaultSparql = useMemo(() => {
     if (layer === 'wm') {
@@ -248,14 +260,34 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
 
       {(layer !== 'vm' || showAdvancedQuery) && (
         <div className="v10-mlv-query-bar">
-          <input
-            type="text"
-            className="v10-mlv-query-input"
-            placeholder="Custom SPARQL query..."
-            value={draftQuery}
-            onChange={(e) => setDraftQuery(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') runQuery(); }}
-          />
+          {queryPresetOptions?.length ? (
+            <select
+              className="v10-vm-search-select"
+              value={selectedPresetLabel}
+              onChange={(e) => {
+                const nextLabel = e.target.value;
+                setSelectedPresetLabel(nextLabel);
+                const preset = queryPresetOptions.find((option) => option.label === nextLabel);
+                const nextQuery = preset?.query ?? '';
+                setDraftQuery(nextQuery);
+                setActiveQuery(nextQuery);
+              }}
+            >
+              <option value="">Select common query...</option>
+              {queryPresetOptions.map((option) => (
+                <option key={option.label} value={option.label}>{option.label}</option>
+              ))}
+            </select>
+          ) : (
+            <input
+              type="text"
+              className="v10-mlv-query-input"
+              placeholder="Custom SPARQL query..."
+              value={draftQuery}
+              onChange={(e) => setDraftQuery(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') runQuery(); }}
+            />
+          )}
           <button className="v10-mlv-run-btn" onClick={runQuery}>
             Run
           </button>

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1165,7 +1165,7 @@ const USER_QUERY_CATALOG_DESCRIPTION = 'Queries saved from the Query tab.';
 const PROFILE_NS = 'http://dkg.io/ontology/profile/';
 const SCHEMA_NS = 'http://schema.org/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
-const XSD_INT = 'http://www.w3.org/2001/XMLSchema#int';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 type SavedCatalogQuery = QueryCatalog['queries'][number];
 
 function sparqlString(value: string): string {
@@ -1273,7 +1273,7 @@ function literal(value: string): string {
 }
 
 function intLiteral(value: number): string {
-  return `"${value}"^^<${XSD_INT}>`;
+  return `"${value}"^^<${XSD_INTEGER}>`;
 }
 
 function buildSavedQueryWrite(contextGraphId: string, name: string, description: string, sparql: string): {


### PR DESCRIPTION
## Summary

Adds OpenClaw support for saving read-only SPARQL queries into a context graph query catalog, and lets `MemoryLayerView` consume externally supplied queries/preset options.

Also updates Base Sepolia test deployment references and adds the deployment artifact.

## Changes

- Added `dkg_query_catalog_save` to `adapter-openclaw`.
- Added daemon client support for `/api/profile/query-catalog/write`.
- Documented saved-query behavior in `packages/cli/skills/dkg-node/SKILL.md`.
- Added optional `externalQuery`, `externalQueryKey`, and `queryPresetOptions` props to `MemoryLayerView`.
- Updated Base Sepolia test Hub address references.
- Added `base_sepolia_test_contracts.json`.

## Validation

- `pnpm --filter @origintrail-official/dkg-core build`
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw build`
- `pnpm --filter @origintrail-official/dkg-node-ui build`
- `git diff --check HEAD`