### PR TITLE
feat(node-ui): peer-axis Network tab — one card per libp2p peer

### DIFF
--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -93,6 +93,36 @@ interface AgentInfo {
   latencyMs?: number;
 }
 
+// One row from `/api/connections.connections` — a single libp2p
+// connection. A peer can appear multiple times when reachable via both
+// a direct and a relay transport simultaneously; `buildPeers` collapses
+// those to one card per peerId.
+export interface ConnectionRow {
+  peerId: string;
+  remoteAddr?: string;
+  transport: 'direct' | 'relayed';
+  direction?: string;
+  openedAt?: number | null;
+  durationMs?: number | null;
+}
+
+// Peer-axis model for the Network tab. One per libp2p peerId. Agents
+// hosted by the peer (0..N) attach as a list and surface inside the
+// card as chips. `name` is the peer's (node's) name — same value across
+// every agent on this peer — sampled from any one of them since the
+// `/api/connections` endpoint doesn't expose it.
+export interface PeerInfo {
+  peerId: string;
+  name?: string;
+  transport: 'direct' | 'relayed';
+  hasDirect: boolean;
+  hasRelay: boolean;
+  openedAt: number | null;
+  connected: boolean;
+  lastSeen?: number;
+  agents: AgentInfo[];
+}
+
 interface LocalAgentSessionSummary {
   sessionId: string;
   integrationId: string;
@@ -111,6 +141,122 @@ let localMessageId = 0;
 
 function shortPeerId(peerId: string): string {
   return peerId.length > 12 ? peerId.slice(-8) : peerId;
+}
+
+// Compact chip label for an agentUri. agentUris are typically
+// colon-separated (e.g. `did:dkg:agent:0x…`); take the last segment so
+// the most-specific identifier shows, trimmed to 10 chars. Falls back
+// to the URI's last 8 chars if there's no colon. The full URI is
+// surfaced via `title` on the chip so the truncated tail isn't lossy.
+export function shortAgentUri(uri: string): string {
+  if (!uri) return '';
+  const colonIdx = uri.lastIndexOf(':');
+  const tail = colonIdx >= 0 ? uri.slice(colonIdx + 1) : uri;
+  return tail.length > 10 ? tail.slice(-10) : tail || uri.slice(-8);
+}
+
+// Group raw connections + agents into the peer-axis model the Network
+// tab renders. Frontend-only — no backend changes needed; the `name`
+// field travels with every agent record (it's the peer's/node's name,
+// identical across agents on the same peer), so we sample it from any
+// agent on the peer.
+//
+// Rules:
+//   * Connected peers come from `/api/connections.connections` grouped
+//     by peerId. Per-connection records — a peer reachable via direct +
+//     relay shows up twice and is collapsed here. Any-direct-wins for
+//     the displayed transport; `hasDirect`/`hasRelay` flags carry the
+//     raw signal for the badge tooltip.
+//   * Recently-seen peers are the peers in `/api/agents` (filtered to
+//     non-self upstream) whose peerId isn't currently connected and
+//     whose latest `lastSeen` across their agents is within
+//     `recentlySeenWindowMs` (default 24h). Sorted by `lastSeen` desc.
+//   * Summary counts derive from the de-duped peer set, not the raw
+//     connection rows.
+export function buildPeers(
+  connections: ConnectionRow[],
+  agents: AgentInfo[],
+  now: number,
+  recentlySeenWindowMs: number = 24 * 60 * 60 * 1000,
+): {
+  connected: PeerInfo[];
+  recentlySeen: PeerInfo[];
+  directCount: number;
+  relayedCount: number;
+} {
+  // peerId → AgentInfo[] (preserves all agents per peer for the chip list).
+  const agentsByPeer = new Map<string, AgentInfo[]>();
+  for (const a of agents) {
+    if (!a.peerId) continue;
+    const list = agentsByPeer.get(a.peerId) ?? [];
+    list.push(a);
+    agentsByPeer.set(a.peerId, list);
+  }
+
+  // peerId → { hasDirect, hasRelay, openedAt (earliest) }.
+  const connByPeer = new Map<string, {
+    hasDirect: boolean;
+    hasRelay: boolean;
+    openedAt: number | null;
+  }>();
+  for (const c of connections) {
+    if (!c.peerId) continue;
+    const prev = connByPeer.get(c.peerId) ?? { hasDirect: false, hasRelay: false, openedAt: null };
+    const hasDirect = prev.hasDirect || c.transport === 'direct';
+    const hasRelay = prev.hasRelay || c.transport === 'relayed';
+    const openedAt = c.openedAt != null
+      ? (prev.openedAt != null ? Math.min(prev.openedAt, c.openedAt) : c.openedAt)
+      : prev.openedAt;
+    connByPeer.set(c.peerId, { hasDirect, hasRelay, openedAt });
+  }
+
+  const pickName = (peerAgents: AgentInfo[]): string | undefined =>
+    peerAgents.find((a) => a.name)?.name;
+  const pickLastSeen = (peerAgents: AgentInfo[]): number | undefined =>
+    peerAgents.reduce<number | undefined>(
+      (acc, a) => (a.lastSeen != null && (acc == null || a.lastSeen > acc) ? a.lastSeen : acc),
+      undefined,
+    );
+
+  const connected: PeerInfo[] = [];
+  for (const [peerId, c] of connByPeer) {
+    const peerAgents = agentsByPeer.get(peerId) ?? [];
+    connected.push({
+      peerId,
+      name: pickName(peerAgents),
+      transport: c.hasDirect ? 'direct' : 'relayed',
+      hasDirect: c.hasDirect,
+      hasRelay: c.hasRelay,
+      openedAt: c.openedAt,
+      connected: true,
+      lastSeen: pickLastSeen(peerAgents),
+      agents: peerAgents,
+    });
+  }
+
+  const recentlySeen: PeerInfo[] = [];
+  for (const [peerId, peerAgents] of agentsByPeer) {
+    if (connByPeer.has(peerId)) continue;
+    const lastSeen = pickLastSeen(peerAgents);
+    if (lastSeen == null || now - lastSeen > recentlySeenWindowMs) continue;
+    recentlySeen.push({
+      peerId,
+      name: pickName(peerAgents),
+      // Transport is not meaningful for a peer we aren't connected to;
+      // mark `direct` arbitrarily so the type stays narrow.
+      transport: 'direct',
+      hasDirect: false,
+      hasRelay: false,
+      openedAt: null,
+      connected: false,
+      lastSeen,
+      agents: peerAgents,
+    });
+  }
+  recentlySeen.sort((a, b) => (b.lastSeen ?? 0) - (a.lastSeen ?? 0));
+
+  const directCount = connected.filter((p) => p.transport === 'direct').length;
+  return { connected, recentlySeen, directCount, relayedCount: connected.length - directCount };
 }
 
 function formatDuration(ms: number): string {
@@ -1689,32 +1835,82 @@ export function ConnectedAgentsTab(props: {
   );
 }
 
-function NetworkPeerCard({ agent }: { agent: AgentInfo }) {
-  const statusClass = networkPeerCardStatusClass(agent);
+// Per-peer card: header + meta + agents-as-chips. Nodes are
+// infrastructure; agents live on them. Up to 3 chips inline, with a
+// "+N more" button that expands inline (card grows vertically).
+function NetworkPeerCard({ peer }: { peer: PeerInfo }) {
+  const [expanded, setExpanded] = useState(false);
+  const CHIP_BUDGET = 3;
+  const statusClass: 'connected' | 'offline' = peer.connected ? 'connected' : 'offline';
+  const displayName = peer.name?.trim() || shortPeerId(peer.peerId);
+  const visibleAgents = expanded ? peer.agents : peer.agents.slice(0, CHIP_BUDGET);
+  const hiddenCount = peer.agents.length - visibleAgents.length;
+  const transportLabel = peer.connected ? peer.transport : 'Disconnected';
+  // Any-direct-wins means a peer reachable on direct + relay is
+  // labelled "direct" — surface the raw availability in the tooltip
+  // so the relay path isn't completely hidden.
+  const transportTitle =
+    peer.connected && peer.hasDirect && peer.hasRelay
+      ? 'Direct + relay paths active — direct shown'
+      : undefined;
   return (
-    <div className={`v10-agent-card ${statusClass}`}>
+    <div className={`v10-agent-card v10-peer-card ${statusClass}`}>
       <div className="v10-agent-card-header">
         <span className={`v10-agent-card-dot ${statusClass}`} />
-        <span className="v10-agent-card-name">{agent.name}</span>
-        <span className="v10-agent-card-badge">
-          {agent.connectionStatus === 'connected'
-            ? (agent.connectionTransport ?? 'direct')
-            : 'Disconnected'}
+        <span className="v10-peer-card-name">{displayName}</span>
+        <span className="v10-agent-card-badge" title={transportTitle}>
+          {transportLabel}
         </span>
       </div>
-      <div className="v10-agent-card-meta">
-        <span>{agent.nodeRole ?? 'core'}</span>
-        <span title={agent.peerId}>{shortPeerId(agent.peerId)}</span>
-        {agent.latencyMs != null && <span>{agent.latencyMs}ms</span>}
-        {agent.lastSeen != null && <span>{formatDuration(Date.now() - agent.lastSeen)} ago</span>}
+      <div className="v10-peer-card-meta">
+        <span title={peer.peerId}>{shortPeerId(peer.peerId)}</span>
+        {peer.connected && peer.openedAt != null && (
+          <span>up {formatDuration(Date.now() - peer.openedAt)}</span>
+        )}
+        {!peer.connected && peer.lastSeen != null && (
+          <span>{formatDuration(Date.now() - peer.lastSeen)} ago</span>
+        )}
+        {peer.agents.length > 0 && (
+          <span>{peer.agents.length} agent{peer.agents.length === 1 ? '' : 's'}</span>
+        )}
       </div>
+      {peer.agents.length > 0 && (
+        <ul
+          className="v10-peer-card-chips"
+          aria-label={`Agents on ${displayName}`}
+        >
+          {visibleAgents.map((a, idx) => (
+            <li
+              key={a.agentUri || `${peer.peerId}:${idx}`}
+              className="v10-agent-chip"
+              title={a.agentUri || ''}
+            >
+              <span className="v10-agent-chip-label">
+                {shortAgentUri(a.agentUri) || shortPeerId(a.peerId)}
+              </span>
+            </li>
+          ))}
+          {peer.agents.length > CHIP_BUDGET && (
+            <li>
+              <button
+                type="button"
+                className="v10-agent-chip v10-agent-chip-more"
+                aria-expanded={expanded}
+                onClick={() => setExpanded((e) => !e)}
+              >
+                {expanded ? '− less' : `+${peer.agents.length - CHIP_BUDGET} more`}
+              </button>
+            </li>
+          )}
+        </ul>
+      )}
     </div>
   );
 }
 
 function NetworkPeerGroup(props: {
   label: string;
-  peers: AgentInfo[];
+  peers: PeerInfo[];
   expanded: boolean;
   onToggle: () => void;
   emptyMessage: string;
@@ -1741,13 +1937,10 @@ function NetworkPeerGroup(props: {
           {peers.length === 0 ? (
             <div className="v10-agent-empty-state">{emptyMessage}</div>
           ) : (
-            // Key on the same identity used for dedupe upstream
-            // (agentUri, falling back to peerId). After the BNlko fix,
-            // distinct agents sharing a peerId now render as separate
-            // cards — keying on peerId alone would collide and cause
-            // React to reuse the wrong card across re-renders.
-            peers.map((agent) => (
-              <NetworkPeerCard key={agent.agentUri || agent.peerId} agent={agent} />
+            // One card per libp2p peerId — keying on peerId is now
+            // safe and intended (the previous agent-axis dedup is gone).
+            peers.map((peer) => (
+              <NetworkPeerCard key={peer.peerId} peer={peer} />
             ))
           )}
         </div>
@@ -1759,134 +1952,51 @@ function NetworkPeerGroup(props: {
 function NetworkTab(props: {
   peerAgents: AgentInfo[];
   /**
-   * Raw libp2p connection counts from `/api/connections`. Used to drive
-   * the empty-state and to surface a transitional message when libp2p
-   * has connections but `/api/agents` has not emitted records yet — the
-   * deduped peerAgents list can otherwise show "0 connected / No
-   * network peers detected yet" even though the node is connected.
+   * `/api/connections` totals + per-connection rows. Both are needed:
+   *   - `total` drives the empty-state (libp2p has connections but
+   *     `/api/agents` hasn't emitted records yet).
+   *   - `rows` is the source of truth for the peer axis — grouped by
+   *     peerId inside `buildPeers` to derive one card per peer.
+   * Per-connection records may include the same peerId twice when a
+   * peer is reachable via both direct + relay simultaneously;
+   * `buildPeers` collapses those.
    */
-  connections: { total: number; direct: number; relayed: number };
+  connections: { total: number; direct: number; relayed: number; rows: ConnectionRow[] };
   loading: boolean;
   onRefresh: () => void;
 }) {
   const { peerAgents, connections, loading, onRefresh } = props;
   const [connectedExpanded, setConnectedExpanded] = useState(true);
-  const [disconnectedExpanded, setDisconnectedExpanded] = useState(false);
+  const [recentlySeenExpanded, setRecentlySeenExpanded] = useState(false);
 
-  // The /api/agents feed can report the same agent under multiple records
-  // (e.g. once via a direct transport, once via a relay). Collapse to one
-  // entry per agent. Dedupe on `agentUri` — a stable per-agent identifier
-  // — rather than `peerId`, since a remote node may advertise multiple
-  // distinct agents on the same peer (different `agentUri` values), and
-  // those are NOT duplicates. Fall back to `peerId` only when `agentUri`
-  // is missing so older records still collapse instead of multiplying.
-  //
-  // Tie-break order when collapsing records for the same agent:
-  //   1. Prefer a connected record over a disconnected one.
-  //   2. Among connected records, prefer DIRECT over relayed — direct is
-  //      the better transport, so an agent that has any direct connection
-  //      should be reported as direct (not arbitrarily classed as relayed
-  //      because the relay record arrived more recently in the feed).
-  //   3. Otherwise prefer the more-recently-seen record so latency/status
-  //      reflect current state.
-  // With this rule, direct + relayed = total unique connected agents and
-  // the top summary count agrees with the section counts.
-  const transportRank = (peer: AgentInfo): number =>
-    (peer.connectionTransport ?? 'direct') === 'direct' ? 1 : 0;
-  const dedupeKey = (peer: AgentInfo): string => peer.agentUri || peer.peerId;
-  const uniquePeers = Array.from(
-    peerAgents.reduce<Map<string, AgentInfo>>((acc, peer) => {
-      const key = dedupeKey(peer);
-      const prev = acc.get(key);
-      if (!prev) {
-        acc.set(key, peer);
-        return acc;
-      }
-      const peerConnected = peer.connectionStatus === 'connected';
-      const prevConnected = prev.connectionStatus === 'connected';
-      if (peerConnected !== prevConnected) {
-        // Status disagrees → use the freshest available signal. The rule
-        // has shaken out across several Codex rounds:
-        //   CGaLH: don't naively prefer "connected" — a stale connected
-        //          row after a peer drops keeps the UI wrong.
-        //   CG3Lw: don't `?? 0` missing timestamps either — an older
-        //          timestamped connected row would beat a newer
-        //          un-timestamped disconnect.
-        //   CHMS1: don't fall through to feed-order on missing-timestamp
-        //          ties either — `/api/agents` doesn't sort by recency,
-        //          so an upstream ordering change can silently flip the
-        //          panel back. Prefer the timestamped row when only one
-        //          side has it; when neither has a timestamp, prefer
-        //          the disconnected reading so a stale connected row
-        //          can't mask a fresh disconnect.
-        const peerHasTs = typeof peer.lastSeen === 'number';
-        const prevHasTs = typeof prev.lastSeen === 'number';
-        if (peerHasTs && prevHasTs) {
-          // Both timestamped — pure numeric freshness; tie goes to peer
-          // (later in feed by construction, deterministic within the
-          // same numeric bucket).
-          if (peer.lastSeen! >= prev.lastSeen!) acc.set(key, peer);
-        } else if (peerHasTs) {
-          // Only peer has a timestamp — take it.
-          acc.set(key, peer);
-        } else if (prevHasTs) {
-          // Only prev has a timestamp — keep prev (no-op).
-        } else {
-          // Neither has a timestamp — bias toward disconnected to keep
-          // stale connected rows from masking a real disconnect.
-          if (!peerConnected) acc.set(key, peer);
-        }
-        return acc;
-      }
-      // Same status — prefer DIRECT transport (the better channel),
-      // then most recent.
-      const peerRank = transportRank(peer);
-      const prevRank = transportRank(prev);
-      if (peerRank !== prevRank) {
-        if (peerRank > prevRank) acc.set(key, peer);
-        return acc;
-      }
-      if ((peer.lastSeen ?? 0) >= (prev.lastSeen ?? 0)) {
-        acc.set(key, peer);
-      }
-      return acc;
-    }, new Map()).values(),
+  // Peer-axis derivation — one card per libp2p peerId. Replaces the
+  // earlier agent-axis dedupe tower (which existed to merge same-agent
+  // records across transports; that's no longer needed once peerId is
+  // the grouping key). Recently-seen list filters disconnected peers
+  // to the last 24h, sorted by lastSeen desc.
+  const { connected, recentlySeen, directCount, relayedCount } = buildPeers(
+    connections.rows,
+    peerAgents,
+    Date.now(),
   );
-  const connectedPeers = uniquePeers.filter((a) => a.connectionStatus === 'connected');
-  const disconnectedPeers = uniquePeers.filter((a) => a.connectionStatus !== 'connected');
-  // Derive the top-summary counts from the same deduped list the user is
-  // looking at, instead of pulling raw libp2p connection counts from
-  // /api/connections. /api/connections counts *connections* (so a peer
-  // reachable on direct + relayed transports counts twice), which is
-  // technically correct but confusing when the visible list says
-  // otherwise. Showing *peer* counts here keeps the top summary and the
-  // section counts consistent.
-  const directCount = connectedPeers.filter((a) => (a.connectionTransport ?? 'direct') === 'direct').length;
-  const relayedCount = connectedPeers.length - directCount;
 
   return (
     <div className="v10-agent-scroll-tab">
       <div className="v10-agents-summary">
         <span className="v10-agents-stat">
-          {/* Dot reflects actual libp2p connectivity. If raw connections
-              report any peer up, light the dot — otherwise the panel can
-              briefly show a stale "disconnected" indicator while /api/agents
-              is still catching up. */}
-          <span className={`v10-agents-stat-dot ${connectedPeers.length > 0 || connections.total > 0 ? 'connected' : 'known'}`} />
-          {/* "Connected" qualifier matches the Connected section header below
-              — without it, "0 peers" reads as "no peers known" when there
-              might be hundreds of disconnected peers in the section underneath. */}
-          {connectedPeers.length} connected
+          {/* Dot reflects libp2p connectivity. Light it if either
+              `/api/connections` reports peers OR our derived count is
+              non-zero — so a brief skew between the two endpoints
+              doesn't briefly show "disconnected" while data is in flight. */}
+          <span className={`v10-agents-stat-dot ${connected.length > 0 || connections.total > 0 ? 'connected' : 'known'}`} />
+          <span title="Unique libp2p peers connected to this node — matches the count in the header.">
+            {connected.length} peer{connected.length === 1 ? '' : 's'}
+          </span>
         </span>
-        {/*
-          The counts here reflect the *preferred transport per peer*, not
-          raw transport-channel counts. A peer reachable through both
-          transports is collapsed to its DIRECT record by the dedupe rule
-          above, so it shows under `direct` even if a relay path is also
-          active. The title surfaces this so "0 relayed" doesn't read as
-          "no relay paths in use" — for raw libp2p transport diagnostics
-          the /api/connections counters are still the source of truth.
-        */}
+        {/* Any-direct-wins per peer: a peer reachable on direct + relay
+            simultaneously is bucketed as direct. The transport tooltip
+            on each card surfaces the raw availability so the relay path
+            isn't completely hidden. */}
         <span
           className="v10-agents-stat"
           title="Preferred transport per peer (peers reachable via direct + relay are bucketed under direct)"
@@ -1899,33 +2009,33 @@ function NetworkTab(props: {
       </div>
 
       {loading && <p className="v10-agents-loading">Loading peers...</p>}
-      {peerAgents.length === 0 && !loading && connections.total === 0 && (
+      {!loading && connected.length === 0 && recentlySeen.length === 0 && connections.total === 0 && (
         <div className="v10-agent-empty-state">No network peers detected yet.</div>
       )}
-      {peerAgents.length === 0 && !loading && connections.total > 0 && (
-        // libp2p reports connections but /api/agents hasn't emitted records
-        // for them yet (slow probe, or remote peers have no agent
-        // metadata). Surface that so the panel doesn't read as "no peers"
-        // when the node is actually connected.
+      {!loading && connected.length === 0 && connections.total > 0 && (
+        // libp2p reports connections but we haven't yet derived peers
+        // from the row data — surface the raw count so the panel
+        // doesn't read as "no peers" when the node IS actually
+        // connected.
         <div className="v10-agent-empty-state">
-          Connected to {connections.total} peer{connections.total === 1 ? '' : 's'} (agent metadata syncing…).
+          Connected to {connections.total} peer{connections.total === 1 ? '' : 's'} (peer metadata syncing…).
         </div>
       )}
-      {peerAgents.length > 0 && (
+      {(connected.length > 0 || recentlySeen.length > 0) && (
         <>
           <NetworkPeerGroup
             label="Connected"
-            peers={connectedPeers}
+            peers={connected}
             expanded={connectedExpanded}
             onToggle={() => setConnectedExpanded((p) => !p)}
             emptyMessage="No peers currently connected."
           />
           <NetworkPeerGroup
-            label="Disconnected"
-            peers={disconnectedPeers}
-            expanded={disconnectedExpanded}
-            onToggle={() => setDisconnectedExpanded((p) => !p)}
-            emptyMessage="All known peers are connected."
+            label="Recently seen"
+            peers={recentlySeen}
+            expanded={recentlySeenExpanded}
+            onToggle={() => setRecentlySeenExpanded((p) => !p)}
+            emptyMessage="No peers seen in the last 24 hours."
           />
         </>
       )}
@@ -1975,7 +2085,7 @@ export function PanelRight() {
 
   const [memorySessions, setMemorySessions] = useState<MemorySession[]>([]);
   const [peerAgents, setPeerAgents] = useState<AgentInfo[]>([]);
-  const [connections, setConnections] = useState<{ total: number; direct: number; relayed: number }>({ total: 0, direct: 0, relayed: 0 });
+  const [connections, setConnections] = useState<{ total: number; direct: number; relayed: number; rows: ConnectionRow[] }>({ total: 0, direct: 0, relayed: 0, rows: [] });
   const [peerLoading, setPeerLoading] = useState(true);
   const [currentAgent, setCurrentAgent] = useState<AgentIdentity | null>(null);
 
@@ -2234,7 +2344,7 @@ export function PanelRight() {
     try {
       const [agentData, connData] = await Promise.all([
         fetchAgents().catch(() => ({ agents: [] })),
-        fetchConnections().catch(() => ({ total: 0, direct: 0, relayed: 0 })),
+        fetchConnections().catch(() => ({ total: 0, direct: 0, relayed: 0, connections: [] })),
       ]);
       const agents = (agentData.agents ?? []).filter((agent: AgentInfo) => agent.connectionStatus !== 'self');
       setPeerAgents(agents);
@@ -2242,6 +2352,9 @@ export function PanelRight() {
         total: connData.total ?? 0,
         direct: connData.direct ?? 0,
         relayed: connData.relayed ?? 0,
+        // Per-connection rows are the source of truth for the peer
+        // axis — grouped by peerId inside NetworkTab's `buildPeers`.
+        rows: Array.isArray(connData.connections) ? connData.connections : [],
       });
     } catch {
       // ignore

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -241,18 +241,26 @@ export function buildPeers(
   // `/api/agents`, the agents endpoint can still report `connectionStatus:
   // "connected"` for a peer that isn't in `connByPeer`. Synthesize an entry
   // from the agent record so the peer doesn't vanish during the transient
-  // gap. Transport comes from the agent's own hint.
+  // gap. Transport rolls up with the same any-direct-wins rule used for
+  // real connection rows — today the daemon emits a single transport per
+  // peerId (it's a peerId-keyed lookup at agent-chat.ts:551,556), so this
+  // is defense-in-depth against any future change.
   for (const [peerId, peerAgents] of agentsByPeer) {
     if (connectedPeerIds.has(peerId)) continue;
-    const connectedAgent = peerAgents.find((a) => a.connectionStatus === 'connected');
-    if (!connectedAgent) continue;
-    const isRelayed = connectedAgent.connectionTransport === 'relayed';
+    const connectedAgents = peerAgents.filter((a) => a.connectionStatus === 'connected');
+    if (connectedAgents.length === 0) continue;
+    const hasDirect = connectedAgents.some((a) => a.connectionTransport === 'direct');
+    const hasRelay = connectedAgents.some((a) => a.connectionTransport === 'relayed');
+    // Any-direct-wins on the displayed transport. Default to 'direct' when
+    // neither flag is set (e.g. an agent reporting `connectionTransport: null`
+    // — we have no signal, so don't downgrade the badge to relayed).
+    const transport: 'direct' | 'relayed' = hasRelay && !hasDirect ? 'relayed' : 'direct';
     connected.push({
       peerId,
       name: pickName(peerAgents),
-      transport: isRelayed ? 'relayed' : 'direct',
-      hasDirect: !isRelayed,
-      hasRelay: isRelayed,
+      transport,
+      hasDirect,
+      hasRelay,
       openedAt: null,
       connected: true,
       lastSeen: pickLastSeen(peerAgents),

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -167,17 +167,16 @@ export function shortAgentUri(uri: string): string {
 //     relay shows up twice and is collapsed here. Any-direct-wins for
 //     the displayed transport; `hasDirect`/`hasRelay` flags carry the
 //     raw signal for the badge tooltip.
-//   * Recently-seen peers are the peers in `/api/agents` (filtered to
+//   * Recently-seen peers are every peer in `/api/agents` (filtered to
 //     non-self upstream) whose peerId isn't currently connected and
-//     whose latest `lastSeen` across their agents is within
-//     `recentlySeenWindowMs` (default 24h). Sorted by `lastSeen` desc.
+//     that has any `lastSeen` timestamp across its agents. Sorted by
+//     `lastSeen` desc — no window cap (operators want long-term
+//     visibility into previously-discovered peers).
 //   * Summary counts derive from the de-duped peer set, not the raw
 //     connection rows.
 export function buildPeers(
   connections: ConnectionRow[],
   agents: AgentInfo[],
-  now: number,
-  recentlySeenWindowMs: number = 24 * 60 * 60 * 1000,
 ): {
   connected: PeerInfo[];
   recentlySeen: PeerInfo[];
@@ -266,7 +265,7 @@ export function buildPeers(
   for (const [peerId, peerAgents] of agentsByPeer) {
     if (connectedPeerIds.has(peerId)) continue;
     const lastSeen = pickLastSeen(peerAgents);
-    if (lastSeen == null || now - lastSeen > recentlySeenWindowMs) continue;
+    if (lastSeen == null) continue;
     recentlySeen.push({
       peerId,
       name: pickName(peerAgents),
@@ -2002,12 +2001,11 @@ function NetworkTab(props: {
   // Peer-axis derivation — one card per libp2p peerId. Replaces the
   // earlier agent-axis dedupe tower (which existed to merge same-agent
   // records across transports; that's no longer needed once peerId is
-  // the grouping key). Recently-seen list filters disconnected peers
-  // to the last 24h, sorted by lastSeen desc.
+  // the grouping key). Recently-seen list is uncapped, sorted by
+  // lastSeen desc.
   const { connected, recentlySeen, directCount, relayedCount } = buildPeers(
     connections.rows,
     peerAgents,
-    Date.now(),
   );
 
   return (
@@ -2065,7 +2063,7 @@ function NetworkTab(props: {
             peers={recentlySeen}
             expanded={recentlySeenExpanded}
             onToggle={() => setRecentlySeenExpanded((p) => !p)}
-            emptyMessage="No peers seen in the last 24 hours."
+            emptyMessage="No previously-seen peers."
           />
         </>
       )}

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
+import React, { useState, useRef, useCallback, useEffect, useId, useLayoutEffect, useMemo } from 'react';
 import { useJourneyStore } from '../../stores/journey.js';
 import { useProjectsStore, type ContextGraph } from '../../stores/projects.js';
 import {
@@ -1840,11 +1840,11 @@ export function ConnectedAgentsTab(props: {
 // "+N more" button that expands inline (card grows vertically).
 function NetworkPeerCard({ peer }: { peer: PeerInfo }) {
   const [expanded, setExpanded] = useState(false);
+  const chipsId = useId();
   const CHIP_BUDGET = 3;
   const statusClass: 'connected' | 'offline' = peer.connected ? 'connected' : 'offline';
   const displayName = peer.name?.trim() || shortPeerId(peer.peerId);
   const visibleAgents = expanded ? peer.agents : peer.agents.slice(0, CHIP_BUDGET);
-  const hiddenCount = peer.agents.length - visibleAgents.length;
   const transportLabel = peer.connected ? peer.transport : 'Disconnected';
   // Any-direct-wins means a peer reachable on direct + relay is
   // labelled "direct" — surface the raw availability in the tooltip
@@ -1876,16 +1876,17 @@ function NetworkPeerCard({ peer }: { peer: PeerInfo }) {
       </div>
       {peer.agents.length > 0 && (
         <ul
+          id={chipsId}
           className="v10-peer-card-chips"
           aria-label={`Agents on ${displayName}`}
         >
           {visibleAgents.map((a, idx) => (
             <li
               key={a.agentUri || `${peer.peerId}:${idx}`}
-              className="v10-agent-chip"
+              className="v10-peer-chip"
               title={a.agentUri || ''}
             >
-              <span className="v10-agent-chip-label">
+              <span className="v10-peer-chip-label">
                 {shortAgentUri(a.agentUri) || shortPeerId(a.peerId)}
               </span>
             </li>
@@ -1894,11 +1895,12 @@ function NetworkPeerCard({ peer }: { peer: PeerInfo }) {
             <li>
               <button
                 type="button"
-                className="v10-agent-chip v10-agent-chip-more"
+                className="v10-peer-chip-more"
                 aria-expanded={expanded}
+                aria-controls={chipsId}
                 onClick={() => setExpanded((e) => !e)}
               >
-                {expanded ? '− less' : `+${peer.agents.length - CHIP_BUDGET} more`}
+                {expanded ? 'Show less' : `+${peer.agents.length - CHIP_BUDGET} more`}
               </button>
             </li>
           )}

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -219,6 +219,9 @@ export function buildPeers(
     );
 
   const connected: PeerInfo[] = [];
+  const connectedPeerIds = new Set<string>();
+  // Phase 1a: peers from `/api/connections.connections[]` (the authoritative
+  // signal — comes straight from libp2p `getConnections()`).
   for (const [peerId, c] of connByPeer) {
     const peerAgents = agentsByPeer.get(peerId) ?? [];
     connected.push({
@@ -232,11 +235,36 @@ export function buildPeers(
       lastSeen: pickLastSeen(peerAgents),
       agents: peerAgents,
     });
+    connectedPeerIds.add(peerId);
+  }
+  // Phase 1b: graceful-degradation fallback. If `/api/connections` errors,
+  // returns an older shape without a `connections[]` array, or briefly lags
+  // `/api/agents`, the agents endpoint can still report `connectionStatus:
+  // "connected"` for a peer that isn't in `connByPeer`. Synthesize an entry
+  // from the agent record so the peer doesn't vanish during the transient
+  // gap. Transport comes from the agent's own hint.
+  for (const [peerId, peerAgents] of agentsByPeer) {
+    if (connectedPeerIds.has(peerId)) continue;
+    const connectedAgent = peerAgents.find((a) => a.connectionStatus === 'connected');
+    if (!connectedAgent) continue;
+    const isRelayed = connectedAgent.connectionTransport === 'relayed';
+    connected.push({
+      peerId,
+      name: pickName(peerAgents),
+      transport: isRelayed ? 'relayed' : 'direct',
+      hasDirect: !isRelayed,
+      hasRelay: isRelayed,
+      openedAt: null,
+      connected: true,
+      lastSeen: pickLastSeen(peerAgents),
+      agents: peerAgents,
+    });
+    connectedPeerIds.add(peerId);
   }
 
   const recentlySeen: PeerInfo[] = [];
   for (const [peerId, peerAgents] of agentsByPeer) {
-    if (connByPeer.has(peerId)) continue;
+    if (connectedPeerIds.has(peerId)) continue;
     const lastSeen = pickLastSeen(peerAgents);
     if (lastSeen == null || now - lastSeen > recentlySeenWindowMs) continue;
     recentlySeen.push({

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -991,6 +991,56 @@ button:focus:not(:focus-visible) { outline: none; }
   flex-wrap: wrap;
 }
 
+/* Peer-axis Network-tab card — extends .v10-agent-card. The peer's
+   name reads as a primary identifier (own line treatment via
+   .v10-peer-card-name). Meta line uses the same mono treatment as
+   .v10-agent-card-meta. */
+.v10-peer-card-name {
+  font-size: 12px; font-weight: 600; color: var(--text-primary);
+  flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.v10-peer-card-meta {
+  display: flex; gap: 8px; margin-top: 4px;
+  font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono);
+  flex-wrap: wrap;
+}
+/* Agents-as-chips inside each peer card. flex-wrap handles long lists
+   gracefully; the +N more button toggles inline expansion (card grows
+   vertically). */
+.v10-peer-card-chips {
+  list-style: none; padding: 0; margin: 6px 0 0;
+  display: flex; flex-wrap: wrap; gap: 4px;
+}
+.v10-agent-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  max-width: 140px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  font-size: 10px;
+  line-height: 16px;
+  color: var(--text-secondary);
+}
+.v10-agent-chip-label {
+  font-family: var(--font-mono);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* "+N more" / "− less" toggle button. Sits in the same chip row;
+   reuses the chip surface so layout stays predictable. */
+.v10-agent-chip-more {
+  cursor: pointer;
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-family: inherit;
+}
+.v10-agent-chip-more:hover { color: var(--text-primary); }
+.v10-agent-chip-more:focus-visible {
+  outline: 1px solid var(--accent-blue);
+  outline-offset: 1px;
+}
+
 .v10-local-agent-list {
   display: flex;
   flex-direction: column;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -993,8 +993,9 @@ button:focus:not(:focus-visible) { outline: none; }
 
 /* Peer-axis Network-tab card — extends .v10-agent-card. The peer's
    name reads as a primary identifier (own line treatment via
-   .v10-peer-card-name). Meta line uses the same mono treatment as
-   .v10-agent-card-meta. */
+   .v10-peer-card-name). Meta line: --text-secondary (identifying state,
+   not decoration); we intentionally diverge from .v10-agent-card-meta's
+   legacy tertiary here for AA on bg-elevated. */
 .v10-peer-card-name {
   font-size: 12px; font-weight: 600; color: var(--text-primary);
   flex: 1; min-width: 0;
@@ -1002,43 +1003,60 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-peer-card-meta {
   display: flex; gap: 8px; margin-top: 4px;
-  font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono);
+  font-size: 10px; color: var(--text-secondary); font-family: var(--font-mono);
   flex-wrap: wrap;
 }
+/* Override the legacy badge color to --text-secondary on peer cards
+   (the badge carries identifying state — `direct` / `relayed` — not
+   decoration; tertiary on bg-elevated is borderline AA). Scoped so the
+   legacy Agents-tab cards keep their existing token. */
+.v10-peer-card .v10-agent-card-badge { color: var(--text-secondary); }
 /* Agents-as-chips inside each peer card. flex-wrap handles long lists
    gracefully; the +N more button toggles inline expansion (card grows
-   vertically). */
+   vertically). Class is .v10-peer-chip (NOT .v10-agent-chip) — the
+   latter is the attribution-pill component (~styles.css:5451) and the
+   namespaces would collide. */
 .v10-peer-card-chips {
   list-style: none; padding: 0; margin: 6px 0 0;
   display: flex; flex-wrap: wrap; gap: 4px;
 }
-.v10-agent-chip {
+.v10-peer-chip {
   display: inline-flex; align-items: center; gap: 4px;
   max-width: 140px;
-  padding: 1px 6px;
-  border-radius: 10px;
+  min-width: 0;
+  padding: 2px 7px;
+  border-radius: 999px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-subtle);
-  font-size: 10px;
-  line-height: 16px;
   color: var(--text-secondary);
-}
-.v10-agent-chip-label {
   font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.4;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-/* "+N more" / "− less" toggle button. Sits in the same chip row;
-   reuses the chip surface so layout stays predictable. */
-.v10-agent-chip-more {
-  cursor: pointer;
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
-  font-family: inherit;
+.v10-peer-chip-label {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.v10-agent-chip-more:hover { color: var(--text-primary); }
-.v10-agent-chip-more:focus-visible {
-  outline: 1px solid var(--accent-blue);
-  outline-offset: 1px;
+/* "+N more" / "Show less" toggle button. Shares the chip-pill geometry
+   so it sits in the same row; one-tier-stronger border + transparent
+   background distinguish it as interactive. No scoped :focus-visible —
+   the global focus ring (styles.css:167) is the convention. */
+.v10-peer-chip-more {
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.v10-peer-chip-more:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
 }
 
 .v10-local-agent-list {

--- a/packages/node-ui/test/panel-right.component.test.ts
+++ b/packages/node-ui/test/panel-right.component.test.ts
@@ -77,7 +77,16 @@ describe('PanelRight component', () => {
       peerId: 'peer-2',
       connectionStatus: 'connected',
     }] });
-    fetchConnectionsMock.mockResolvedValue({ total: 1, direct: 1, relayed: 0 });
+    // The peer-axis NetworkTab derives connected peers from
+    // `connections.connections[]`; totals alone aren't enough.
+    fetchConnectionsMock.mockResolvedValue({
+      total: 1,
+      direct: 1,
+      relayed: 0,
+      connections: [
+        { peerId: 'peer-2', transport: 'direct', direction: 'outbound', openedAt: Date.now() - 60_000, durationMs: 60_000 },
+      ],
+    });
     fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [{
       id: 'openclaw',
       name: 'OpenClaw',

--- a/packages/node-ui/test/panel-right.logic.test.ts
+++ b/packages/node-ui/test/panel-right.logic.test.ts
@@ -936,6 +936,76 @@ describe('buildPeers', () => {
     expect(result.recentlySeen[0].peerId).toBe('peer-b');
   });
 
+  it('falls back to agent.connectionStatus when /api/connections is empty (transient lag / error)', () => {
+    // Simulates `/api/connections` returning `{ rows: [] }` (endpoint error
+    // or older daemon shape) while `/api/agents` still reports the peer as
+    // connected via the `connectionStatus` field.
+    const agents = [
+      agent({
+        agentUri: 'did:dkg:agent:a',
+        peerId: 'peer-lag',
+        connectionStatus: 'connected',
+        connectionTransport: 'direct',
+        lastSeen: NOW - 30_000,
+      }),
+    ];
+    const result = buildPeers([], agents, NOW);
+
+    expect(result.connected).toHaveLength(1);
+    expect(result.connected[0].peerId).toBe('peer-lag');
+    expect(result.connected[0].transport).toBe('direct');
+    expect(result.connected[0].hasDirect).toBe(true);
+    expect(result.connected[0].hasRelay).toBe(false);
+    expect(result.recentlySeen).toHaveLength(0);
+    expect(result.directCount).toBe(1);
+  });
+
+  it('agent-based fallback honours connectionTransport: "relayed"', () => {
+    const agents = [
+      agent({
+        peerId: 'peer-relay-only',
+        connectionStatus: 'connected',
+        connectionTransport: 'relayed',
+        lastSeen: NOW - 10_000,
+      }),
+    ];
+    const result = buildPeers([], agents, NOW);
+
+    expect(result.connected).toHaveLength(1);
+    expect(result.connected[0].transport).toBe('relayed');
+    expect(result.connected[0].hasDirect).toBe(false);
+    expect(result.connected[0].hasRelay).toBe(true);
+    expect(result.relayedCount).toBe(1);
+  });
+
+  it('does not double-count: connByPeer wins when both sources agree the peer is connected', () => {
+    const connections = [conn({ peerId: 'peer-a', transport: 'direct' })];
+    const agents = [
+      agent({ peerId: 'peer-a', connectionStatus: 'connected', connectionTransport: 'direct' }),
+    ];
+    const result = buildPeers(connections, agents, NOW);
+
+    expect(result.connected).toHaveLength(1);
+    expect(result.connected[0].peerId).toBe('peer-a');
+    // openedAt comes from the connection row, not the synthesized fallback (which is null)
+    expect(result.connected[0].openedAt).not.toBeNull();
+  });
+
+  it('agent-based fallback does NOT promote disconnected agents to connected', () => {
+    const agents = [
+      agent({
+        peerId: 'peer-x',
+        connectionStatus: 'disconnected',
+        lastSeen: NOW - 1 * HOUR,
+      }),
+    ];
+    const result = buildPeers([], agents, NOW);
+
+    expect(result.connected).toHaveLength(0);
+    expect(result.recentlySeen).toHaveLength(1);
+    expect(result.recentlySeen[0].peerId).toBe('peer-x');
+  });
+
   it('honours a custom recentlySeenWindowMs', () => {
     const agents = [agent({ peerId: 'peer-x', lastSeen: NOW - 2 * HOUR })];
     // 1-hour window — peer is too old.

--- a/packages/node-ui/test/panel-right.logic.test.ts
+++ b/packages/node-ui/test/panel-right.logic.test.ts
@@ -8,6 +8,8 @@ let formatLocalTimestamp: any;
 let getLocalAgentConversationStateKey: any;
 let markLocalAgentIntegrationDisconnected: any;
 let networkPeerCardStatusClass: any;
+let buildPeers: any;
+let shortAgentUri: any;
 let normalizeMessageContent: any;
 let resolveConnectedAgentsTabState: any;
 let resolveLocalAgentSelectionState: any;
@@ -44,6 +46,8 @@ beforeAll(async () => {
   getLocalAgentConversationStateKey = panelRight.getLocalAgentConversationStateKey;
   markLocalAgentIntegrationDisconnected = panelRight.markLocalAgentIntegrationDisconnected;
   networkPeerCardStatusClass = panelRight.networkPeerCardStatusClass;
+  buildPeers = panelRight.buildPeers;
+  shortAgentUri = panelRight.shortAgentUri;
   normalizeMessageContent = panelRight.normalizeMessageContent;
   resolveConnectedAgentsTabState = panelRight.resolveConnectedAgentsTabState;
   resolveLocalAgentSelectionState = panelRight.resolveLocalAgentSelectionState;
@@ -715,5 +719,230 @@ describe('ConnectedAgentsTab rendering', () => {
     expect(markup).toContain('Hermes provider restore failed: backup file missing');
     // The "Ready to connect" Connect button is still enabled — user can retry.
     expect(markup).toContain('Connect Hermes');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPeers — peer-axis aggregation for the Network tab.
+//
+// These tests exercise the pure function that joins `/api/connections`
+// with `/api/agents` into the `PeerInfo[]` model the Network tab renders.
+// The aggregation is frontend-only and the function takes `now` as an
+// argument, so the tests are fully deterministic.
+// ---------------------------------------------------------------------------
+
+const HOUR = 60 * 60 * 1000;
+const NOW = 1_700_000_000_000;
+
+function agent(overrides: Record<string, unknown> = {}) {
+  return {
+    agentUri: 'did:dkg:agent:abc',
+    name: 'node-alpha',
+    peerId: 'peer-a',
+    ...overrides,
+  } as any;
+}
+
+function conn(overrides: Record<string, unknown> = {}) {
+  return {
+    peerId: 'peer-a',
+    transport: 'direct',
+    direction: 'outbound',
+    openedAt: NOW - 5 * 60_000,
+    durationMs: 5 * 60_000,
+    ...overrides,
+  } as any;
+}
+
+describe('shortAgentUri', () => {
+  it('returns the last colon-separated segment when short enough', () => {
+    expect(shortAgentUri('did:dkg:agent:abc')).toBe('abc');
+  });
+
+  it('trims to the last 10 chars when the tail is long', () => {
+    expect(shortAgentUri('did:dkg:agent:abcdefghijklmnop')).toBe('ghijklmnop');
+  });
+
+  it('falls back to the last 8 chars of the full URI when there is no colon', () => {
+    // No colon: tail = full URI; if ≤ 10 chars, returned as-is.
+    expect(shortAgentUri('shorturi')).toBe('shorturi');
+  });
+
+  it('returns "" for empty input', () => {
+    expect(shortAgentUri('')).toBe('');
+  });
+});
+
+describe('buildPeers', () => {
+  it('collapses direct + relay rows for the same peer into one card (any-direct-wins)', () => {
+    const connections = [
+      conn({ peerId: 'peer-a', transport: 'direct', openedAt: NOW - 60_000 }),
+      conn({ peerId: 'peer-a', transport: 'relayed', openedAt: NOW - 30_000 }),
+    ];
+    const agents = [agent({ peerId: 'peer-a' })];
+    const result = buildPeers(connections, agents, NOW);
+
+    expect(result.connected).toHaveLength(1);
+    const p = result.connected[0];
+    expect(p.peerId).toBe('peer-a');
+    expect(p.transport).toBe('direct');
+    expect(p.hasDirect).toBe(true);
+    expect(p.hasRelay).toBe(true);
+    // earliest openedAt wins
+    expect(p.openedAt).toBe(NOW - 60_000);
+    expect(result.directCount).toBe(1);
+    expect(result.relayedCount).toBe(0);
+  });
+
+  it('counts relay-only peers as relayed', () => {
+    const connections = [conn({ peerId: 'peer-r', transport: 'relayed' })];
+    const result = buildPeers(connections, [], NOW);
+
+    expect(result.connected).toHaveLength(1);
+    expect(result.connected[0].transport).toBe('relayed');
+    expect(result.connected[0].hasDirect).toBe(false);
+    expect(result.connected[0].hasRelay).toBe(true);
+    expect(result.directCount).toBe(0);
+    expect(result.relayedCount).toBe(1);
+  });
+
+  it('samples the peer name from any agent on the peer and lists all agents', () => {
+    const connections = [conn({ peerId: 'peer-a' })];
+    const agents = [
+      agent({ agentUri: 'did:dkg:agent:one', peerId: 'peer-a', name: 'node-alpha' }),
+      agent({ agentUri: 'did:dkg:agent:two', peerId: 'peer-a', name: 'node-alpha' }),
+      agent({ agentUri: 'did:dkg:agent:three', peerId: 'peer-a', name: 'node-alpha' }),
+    ];
+    const result = buildPeers(connections, agents, NOW);
+
+    expect(result.connected).toHaveLength(1);
+    expect(result.connected[0].name).toBe('node-alpha');
+    expect(result.connected[0].agents).toHaveLength(3);
+    expect(result.connected[0].agents.map((a: any) => a.agentUri)).toEqual([
+      'did:dkg:agent:one',
+      'did:dkg:agent:two',
+      'did:dkg:agent:three',
+    ]);
+  });
+
+  it('renders a relay-only / bootstrap peer (no agents) as a peerId-only card', () => {
+    const connections = [conn({ peerId: 'peer-bootstrap', transport: 'relayed' })];
+    const result = buildPeers(connections, [], NOW);
+
+    expect(result.connected).toHaveLength(1);
+    expect(result.connected[0].peerId).toBe('peer-bootstrap');
+    expect(result.connected[0].name).toBeUndefined();
+    expect(result.connected[0].agents).toEqual([]);
+  });
+
+  it('includes a peer in "Recently seen" when lastSeen is within the 24h window', () => {
+    const agents = [
+      agent({ peerId: 'peer-gone', lastSeen: NOW - 23 * HOUR }),
+    ];
+    const result = buildPeers([], agents, NOW);
+
+    expect(result.connected).toHaveLength(0);
+    expect(result.recentlySeen).toHaveLength(1);
+    expect(result.recentlySeen[0].peerId).toBe('peer-gone');
+    expect(result.recentlySeen[0].connected).toBe(false);
+    expect(result.recentlySeen[0].lastSeen).toBe(NOW - 23 * HOUR);
+  });
+
+  it('excludes a peer from "Recently seen" once it is older than 24h', () => {
+    const agents = [agent({ peerId: 'peer-stale', lastSeen: NOW - 25 * HOUR })];
+    const result = buildPeers([], agents, NOW);
+
+    expect(result.recentlySeen).toHaveLength(0);
+  });
+
+  it('excludes a peer from "Recently seen" when lastSeen is missing', () => {
+    const agents = [agent({ peerId: 'peer-no-ts', lastSeen: undefined })];
+    const result = buildPeers([], agents, NOW);
+
+    expect(result.recentlySeen).toHaveLength(0);
+  });
+
+  it('sorts "Recently seen" by lastSeen descending (most recent first)', () => {
+    const agents = [
+      agent({ peerId: 'peer-old', lastSeen: NOW - 10 * HOUR }),
+      agent({ peerId: 'peer-fresh', lastSeen: NOW - 1 * HOUR }),
+      agent({ peerId: 'peer-mid', lastSeen: NOW - 5 * HOUR }),
+    ];
+    const result = buildPeers([], agents, NOW);
+
+    expect(result.recentlySeen.map((p: any) => p.peerId)).toEqual([
+      'peer-fresh',
+      'peer-mid',
+      'peer-old',
+    ]);
+  });
+
+  it('does not include a peer in "Recently seen" if it is currently connected', () => {
+    const connections = [conn({ peerId: 'peer-a' })];
+    const agents = [agent({ peerId: 'peer-a', lastSeen: NOW - 2 * HOUR })];
+    const result = buildPeers(connections, agents, NOW);
+
+    expect(result.connected).toHaveLength(1);
+    expect(result.recentlySeen).toHaveLength(0);
+  });
+
+  it('takes the latest lastSeen across the peer\'s agents', () => {
+    const agents = [
+      agent({ agentUri: 'did:dkg:agent:one', peerId: 'peer-multi', lastSeen: NOW - 10 * HOUR }),
+      agent({ agentUri: 'did:dkg:agent:two', peerId: 'peer-multi', lastSeen: NOW - 2 * HOUR }),
+    ];
+    const result = buildPeers([], agents, NOW);
+
+    expect(result.recentlySeen).toHaveLength(1);
+    expect(result.recentlySeen[0].lastSeen).toBe(NOW - 2 * HOUR);
+  });
+
+  it('produces directCount + relayedCount that sum to connected.length', () => {
+    const connections = [
+      conn({ peerId: 'peer-d1', transport: 'direct' }),
+      conn({ peerId: 'peer-d2', transport: 'direct' }),
+      conn({ peerId: 'peer-r1', transport: 'relayed' }),
+      // peer-mixed has both — counts as direct (any-direct-wins)
+      conn({ peerId: 'peer-mixed', transport: 'direct' }),
+      conn({ peerId: 'peer-mixed', transport: 'relayed' }),
+    ];
+    const result = buildPeers(connections, [], NOW);
+
+    expect(result.connected).toHaveLength(4);
+    expect(result.directCount).toBe(3);
+    expect(result.relayedCount).toBe(1);
+    expect(result.directCount + result.relayedCount).toBe(result.connected.length);
+  });
+
+  it('ignores connection rows without a peerId', () => {
+    const connections = [
+      conn({ peerId: '' }),
+      conn({ peerId: 'peer-a' }),
+    ];
+    const result = buildPeers(connections, [], NOW);
+
+    expect(result.connected).toHaveLength(1);
+    expect(result.connected[0].peerId).toBe('peer-a');
+  });
+
+  it('ignores agent rows without a peerId', () => {
+    const agents = [
+      agent({ peerId: '', lastSeen: NOW - 1 * HOUR }),
+      agent({ peerId: 'peer-b', lastSeen: NOW - 1 * HOUR }),
+    ];
+    const result = buildPeers([], agents, NOW);
+
+    expect(result.recentlySeen).toHaveLength(1);
+    expect(result.recentlySeen[0].peerId).toBe('peer-b');
+  });
+
+  it('honours a custom recentlySeenWindowMs', () => {
+    const agents = [agent({ peerId: 'peer-x', lastSeen: NOW - 2 * HOUR })];
+    // 1-hour window — peer is too old.
+    const tight = buildPeers([], agents, NOW, 1 * HOUR);
+    expect(tight.recentlySeen).toHaveLength(0);
+    // 3-hour window — peer fits.
+    const loose = buildPeers([], agents, NOW, 3 * HOUR);
+    expect(loose.recentlySeen).toHaveLength(1);
   });
 });

--- a/packages/node-ui/test/panel-right.logic.test.ts
+++ b/packages/node-ui/test/panel-right.logic.test.ts
@@ -987,6 +987,56 @@ describe('buildPeers', () => {
     expect(result.connected[0].openedAt).not.toBeNull();
   });
 
+  it('agent-based fallback applies any-direct-wins when transports disagree across the peer\'s agents', () => {
+    // Defense-in-depth: the daemon today emits the same transport for every
+    // agent on a peer (peerId-keyed lookup), but the rollup must not depend
+    // on iteration order if that ever changes.
+    const agents = [
+      agent({
+        agentUri: 'did:dkg:agent:relayed-first',
+        peerId: 'peer-mixed',
+        connectionStatus: 'connected',
+        connectionTransport: 'relayed',
+        lastSeen: NOW - 1000,
+      }),
+      agent({
+        agentUri: 'did:dkg:agent:direct-second',
+        peerId: 'peer-mixed',
+        connectionStatus: 'connected',
+        connectionTransport: 'direct',
+        lastSeen: NOW - 500,
+      }),
+    ];
+    const result = buildPeers([], agents);
+
+    expect(result.connected).toHaveLength(1);
+    // Direct wins even though the relayed record comes first in the feed.
+    expect(result.connected[0].transport).toBe('direct');
+    expect(result.connected[0].hasDirect).toBe(true);
+    expect(result.connected[0].hasRelay).toBe(true);
+    expect(result.directCount).toBe(1);
+  });
+
+  it('agent-based fallback handles null connectionTransport without downgrading to relayed', () => {
+    // An agent reporting `connectionStatus: "connected"` but no transport
+    // info: don't classify as relayed; default to 'direct' and leave both
+    // hasDirect/hasRelay false so the tooltip stays silent.
+    const agents = [
+      agent({
+        peerId: 'peer-null-transport',
+        connectionStatus: 'connected',
+        connectionTransport: null,
+        lastSeen: NOW - 1000,
+      }),
+    ];
+    const result = buildPeers([], agents);
+
+    expect(result.connected).toHaveLength(1);
+    expect(result.connected[0].transport).toBe('direct');
+    expect(result.connected[0].hasDirect).toBe(false);
+    expect(result.connected[0].hasRelay).toBe(false);
+  });
+
   it('agent-based fallback does NOT promote disconnected agents to connected', () => {
     const agents = [
       agent({

--- a/packages/node-ui/test/panel-right.logic.test.ts
+++ b/packages/node-ui/test/panel-right.logic.test.ts
@@ -780,7 +780,7 @@ describe('buildPeers', () => {
       conn({ peerId: 'peer-a', transport: 'relayed', openedAt: NOW - 30_000 }),
     ];
     const agents = [agent({ peerId: 'peer-a' })];
-    const result = buildPeers(connections, agents, NOW);
+    const result = buildPeers(connections, agents);
 
     expect(result.connected).toHaveLength(1);
     const p = result.connected[0];
@@ -796,7 +796,7 @@ describe('buildPeers', () => {
 
   it('counts relay-only peers as relayed', () => {
     const connections = [conn({ peerId: 'peer-r', transport: 'relayed' })];
-    const result = buildPeers(connections, [], NOW);
+    const result = buildPeers(connections, []);
 
     expect(result.connected).toHaveLength(1);
     expect(result.connected[0].transport).toBe('relayed');
@@ -813,7 +813,7 @@ describe('buildPeers', () => {
       agent({ agentUri: 'did:dkg:agent:two', peerId: 'peer-a', name: 'node-alpha' }),
       agent({ agentUri: 'did:dkg:agent:three', peerId: 'peer-a', name: 'node-alpha' }),
     ];
-    const result = buildPeers(connections, agents, NOW);
+    const result = buildPeers(connections, agents);
 
     expect(result.connected).toHaveLength(1);
     expect(result.connected[0].name).toBe('node-alpha');
@@ -827,7 +827,7 @@ describe('buildPeers', () => {
 
   it('renders a relay-only / bootstrap peer (no agents) as a peerId-only card', () => {
     const connections = [conn({ peerId: 'peer-bootstrap', transport: 'relayed' })];
-    const result = buildPeers(connections, [], NOW);
+    const result = buildPeers(connections, []);
 
     expect(result.connected).toHaveLength(1);
     expect(result.connected[0].peerId).toBe('peer-bootstrap');
@@ -835,29 +835,25 @@ describe('buildPeers', () => {
     expect(result.connected[0].agents).toEqual([]);
   });
 
-  it('includes a peer in "Recently seen" when lastSeen is within the 24h window', () => {
+  it('includes any disconnected peer with a lastSeen timestamp in "Recently seen" (no time cap)', () => {
     const agents = [
-      agent({ peerId: 'peer-gone', lastSeen: NOW - 23 * HOUR }),
+      // Old (10 days) — still shown; operators want long-term visibility.
+      agent({ peerId: 'peer-ancient', lastSeen: NOW - 240 * HOUR }),
+      // Recent (23h).
+      agent({ peerId: 'peer-recent', lastSeen: NOW - 23 * HOUR }),
     ];
-    const result = buildPeers([], agents, NOW);
+    const result = buildPeers([], agents);
 
     expect(result.connected).toHaveLength(0);
-    expect(result.recentlySeen).toHaveLength(1);
-    expect(result.recentlySeen[0].peerId).toBe('peer-gone');
-    expect(result.recentlySeen[0].connected).toBe(false);
-    expect(result.recentlySeen[0].lastSeen).toBe(NOW - 23 * HOUR);
-  });
-
-  it('excludes a peer from "Recently seen" once it is older than 24h', () => {
-    const agents = [agent({ peerId: 'peer-stale', lastSeen: NOW - 25 * HOUR })];
-    const result = buildPeers([], agents, NOW);
-
-    expect(result.recentlySeen).toHaveLength(0);
+    expect(result.recentlySeen.map((p: any) => p.peerId)).toEqual(['peer-recent', 'peer-ancient']);
+    expect(result.recentlySeen.every((p: any) => p.connected === false)).toBe(true);
   });
 
   it('excludes a peer from "Recently seen" when lastSeen is missing', () => {
+    // No timestamp means we can't sort it; drop it (without a timestamp
+    // it would always render at the bottom regardless of true freshness).
     const agents = [agent({ peerId: 'peer-no-ts', lastSeen: undefined })];
-    const result = buildPeers([], agents, NOW);
+    const result = buildPeers([], agents);
 
     expect(result.recentlySeen).toHaveLength(0);
   });
@@ -868,7 +864,7 @@ describe('buildPeers', () => {
       agent({ peerId: 'peer-fresh', lastSeen: NOW - 1 * HOUR }),
       agent({ peerId: 'peer-mid', lastSeen: NOW - 5 * HOUR }),
     ];
-    const result = buildPeers([], agents, NOW);
+    const result = buildPeers([], agents);
 
     expect(result.recentlySeen.map((p: any) => p.peerId)).toEqual([
       'peer-fresh',
@@ -880,7 +876,7 @@ describe('buildPeers', () => {
   it('does not include a peer in "Recently seen" if it is currently connected', () => {
     const connections = [conn({ peerId: 'peer-a' })];
     const agents = [agent({ peerId: 'peer-a', lastSeen: NOW - 2 * HOUR })];
-    const result = buildPeers(connections, agents, NOW);
+    const result = buildPeers(connections, agents);
 
     expect(result.connected).toHaveLength(1);
     expect(result.recentlySeen).toHaveLength(0);
@@ -891,7 +887,7 @@ describe('buildPeers', () => {
       agent({ agentUri: 'did:dkg:agent:one', peerId: 'peer-multi', lastSeen: NOW - 10 * HOUR }),
       agent({ agentUri: 'did:dkg:agent:two', peerId: 'peer-multi', lastSeen: NOW - 2 * HOUR }),
     ];
-    const result = buildPeers([], agents, NOW);
+    const result = buildPeers([], agents);
 
     expect(result.recentlySeen).toHaveLength(1);
     expect(result.recentlySeen[0].lastSeen).toBe(NOW - 2 * HOUR);
@@ -906,7 +902,7 @@ describe('buildPeers', () => {
       conn({ peerId: 'peer-mixed', transport: 'direct' }),
       conn({ peerId: 'peer-mixed', transport: 'relayed' }),
     ];
-    const result = buildPeers(connections, [], NOW);
+    const result = buildPeers(connections, []);
 
     expect(result.connected).toHaveLength(4);
     expect(result.directCount).toBe(3);
@@ -919,7 +915,7 @@ describe('buildPeers', () => {
       conn({ peerId: '' }),
       conn({ peerId: 'peer-a' }),
     ];
-    const result = buildPeers(connections, [], NOW);
+    const result = buildPeers(connections, []);
 
     expect(result.connected).toHaveLength(1);
     expect(result.connected[0].peerId).toBe('peer-a');
@@ -930,7 +926,7 @@ describe('buildPeers', () => {
       agent({ peerId: '', lastSeen: NOW - 1 * HOUR }),
       agent({ peerId: 'peer-b', lastSeen: NOW - 1 * HOUR }),
     ];
-    const result = buildPeers([], agents, NOW);
+    const result = buildPeers([], agents);
 
     expect(result.recentlySeen).toHaveLength(1);
     expect(result.recentlySeen[0].peerId).toBe('peer-b');
@@ -949,7 +945,7 @@ describe('buildPeers', () => {
         lastSeen: NOW - 30_000,
       }),
     ];
-    const result = buildPeers([], agents, NOW);
+    const result = buildPeers([], agents);
 
     expect(result.connected).toHaveLength(1);
     expect(result.connected[0].peerId).toBe('peer-lag');
@@ -969,7 +965,7 @@ describe('buildPeers', () => {
         lastSeen: NOW - 10_000,
       }),
     ];
-    const result = buildPeers([], agents, NOW);
+    const result = buildPeers([], agents);
 
     expect(result.connected).toHaveLength(1);
     expect(result.connected[0].transport).toBe('relayed');
@@ -983,7 +979,7 @@ describe('buildPeers', () => {
     const agents = [
       agent({ peerId: 'peer-a', connectionStatus: 'connected', connectionTransport: 'direct' }),
     ];
-    const result = buildPeers(connections, agents, NOW);
+    const result = buildPeers(connections, agents);
 
     expect(result.connected).toHaveLength(1);
     expect(result.connected[0].peerId).toBe('peer-a');
@@ -999,20 +995,10 @@ describe('buildPeers', () => {
         lastSeen: NOW - 1 * HOUR,
       }),
     ];
-    const result = buildPeers([], agents, NOW);
+    const result = buildPeers([], agents);
 
     expect(result.connected).toHaveLength(0);
     expect(result.recentlySeen).toHaveLength(1);
     expect(result.recentlySeen[0].peerId).toBe('peer-x');
-  });
-
-  it('honours a custom recentlySeenWindowMs', () => {
-    const agents = [agent({ peerId: 'peer-x', lastSeen: NOW - 2 * HOUR })];
-    // 1-hour window — peer is too old.
-    const tight = buildPeers([], agents, NOW, 1 * HOUR);
-    expect(tight.recentlySeen).toHaveLength(0);
-    // 3-hour window — peer fits.
-    const loose = buildPeers([], agents, NOW, 3 * HOUR);
-    expect(loose.recentlySeen).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- Right-panel **Network tab** now groups by libp2p **peer** instead of agent. One card per peerId; hosted agents render as compact chips (label = short `agentUri` tail, full URI on hover). Three chips inline, then a "+N more" toggle expands the rest in place.
- Header peer count and Network tab count now agree (both peer-axis).
- "Disconnected" → **"Recently seen"** — peers with `lastSeen` within the last 24 h, sorted by `lastSeen` desc.
- Direct + relay rows for the same peerId collapse to one card with **any-direct-wins**; a tooltip on the transport badge surfaces "Direct + relay paths active" when both are present.

### Why

Today the tab counts unique agents (deduped by `agentUri || peerId`) while the top-right header counts libp2p peers (`getPeers().length`). On a multi-agent node these disagree by design and surface as the "11 peers vs 25 connected" mismatch + apparent duplicates in the list. Nodes are infrastructure; agents live on them — switching the tab to a peer-axis model makes the two views consistent and adds an at-a-glance read of "which peer is running how many agents."

### Approach

Frontend-only. `name` already travels with every `/api/agents` record (same value across agents on a peer), so the join `{peerId, name}` is sampled client-side instead of growing the `/api/connections` payload. The dedupe-by-agentUri state machine in `NetworkTab` is gone — peer-axis collapses are structurally simpler.

New pure helper `buildPeers(connections, agents, now, recentlySeenWindowMs?)` is exported for tests.

## Test plan

- [x] `pnpm -F @origintrail-official/dkg-node-ui exec tsc --noEmit` — clean
- [x] `pnpm -F @origintrail-official/dkg-node-ui exec vitest run --no-file-parallelism` — 666 / 666 (38 skipped) across 36 files
- [x] `panel-right.logic.test.ts` — 14 new `buildPeers` cases + 4 `shortAgentUri` cases (any-direct-wins, 24 h window in/out, sort by lastSeen, custom window, name sampling, relay-only bootstrap peer with no agents, empty-peerId guards)
- [x] `panel-right.component.test.ts` — fixture extended with the `connections[]` array required by the new model
- [ ] Manual against a live multi-agent node: header N == tab N; multi-agent peer renders one card with chips; `+N more` reveals the rest inline; disconnect a peer → moves to "Recently seen" with `Xm ago`; narrow panel to ~280 px (chips wrap, peerId truncates); dark + light themes AA

🤖 Generated with [Claude Code](https://claude.com/claude-code)