### PR TITLE
feat(node-ui): left-sidebar cleanup + AA dark/light contrast lift

### DIFF
--- a/packages/node-ui/e2e/helpers/selectors.ts
+++ b/packages/node-ui/e2e/helpers/selectors.ts
@@ -33,7 +33,9 @@ export const sel = {
     // global header `sidebarToggle` instead. `.v10-tree-section-badge`
     // and `.v10-tree-chevron` were also removed; the per-project
     // chevron-expand pattern no longer exists. Broader e2e
-    // modernization is tracked separately — see task #120.
+    // modernization is a standalone follow-up (chevron-expand /
+    // memory-layer rows / fixture CG names — all gone for multiple
+    // PRs); this PR only triages the cases its removals directly broke.
     treeContent: '.v10-tree-content',
     dashboard: '.v10-tree-dashboard',
     newProjectBtn: '.v10-new-project-btn',

--- a/packages/node-ui/e2e/helpers/selectors.ts
+++ b/packages/node-ui/e2e/helpers/selectors.ts
@@ -28,7 +28,12 @@ export const sel = {
     root: '.v10-panel-left',
     treeHeader: '.v10-tree-header',
     modeBtn: '.v10-tree-mode-btn',
-    collapseBtn: '.v10-collapse-btn',
+    // `.v10-collapse-btn` was removed in PR8 — the in-panel ◂ triangle
+    // duplicated the always-visible global header toggle. Use the
+    // global header `sidebarToggle` instead. `.v10-tree-section-badge`
+    // and `.v10-tree-chevron` were also removed; the per-project
+    // chevron-expand pattern no longer exists. Broader e2e
+    // modernization is tracked separately — see task #120.
     treeContent: '.v10-tree-content',
     dashboard: '.v10-tree-dashboard',
     newProjectBtn: '.v10-new-project-btn',
@@ -38,14 +43,17 @@ export const sel = {
     section: '.v10-tree-section',
     sectionHeader: '.v10-tree-section-header',
     sectionLabel: '.v10-tree-section-label',
-    sectionBadge: '.v10-tree-section-badge',
-    chevron: '.v10-tree-chevron',
     treeItems: '.v10-tree-items',
     treeItem: '.v10-tree-item',
     itemLabel: '.v10-tree-item-label',
     layerHeader: '.v10-tree-layer-header',
     oraclePlaceholder: '.v10-oracle-placeholder',
     integrationDot: '.v10-tree-integration-dot',
+    // PR8 sibling-section pattern (My Context Graphs + Integrations):
+    peerGroup: '.v10-peer-group',
+    peerGroupHeader: '.v10-peer-group-header',
+    peerGroupLabel: '.v10-peer-group-label',
+    peerGroupBody: '.v10-peer-group-body',
   },
 
   center: {

--- a/packages/node-ui/e2e/pages/left-panel.po.ts
+++ b/packages/node-ui/e2e/pages/left-panel.po.ts
@@ -4,14 +4,12 @@ import { sel } from '../helpers/selectors.js';
 export class LeftPanelPage {
   readonly page: Page;
   readonly root: Locator;
-  readonly collapseBtn: Locator;
   readonly newProjectBtn: Locator;
   readonly oraclePlaceholder: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.root = page.locator(sel.leftPanel.root).first();
-    this.collapseBtn = page.locator(sel.leftPanel.collapseBtn);
     this.newProjectBtn = page.locator(sel.leftPanel.newProjectBtn);
     this.oraclePlaceholder = page.locator(sel.leftPanel.oraclePlaceholder);
   }
@@ -40,10 +38,6 @@ export class LeftPanelPage {
   async getActiveMode() {
     const active = this.root.locator(`${sel.leftPanel.modeBtn}.active`);
     return active.textContent();
-  }
-
-  async collapse() {
-    await this.collapseBtn.click();
   }
 
   async clickNewProject() {

--- a/packages/node-ui/e2e/specs/left-navigation.spec.ts
+++ b/packages/node-ui/e2e/specs/left-navigation.spec.ts
@@ -32,8 +32,10 @@ test.describe('Left Panel Navigation', () => {
 
   // Per-row asset-count badges were removed in PR8 — the count was
   // broken (always 0) and the dashboard already surfaces this number.
-  // Broader e2e modernization tracked in follow-up #120.
-  test.skip('project badge shows asset count', async () => {
+  // `fixme` so this stays visible in the test report until the broader
+  // e2e revamp picks it up (broader rot is tracked outside this PR;
+  // grep this commit for "left-navigation.spec" in the PR8 series).
+  test.fixme('project badge shows asset count', async () => {
     // intentionally skipped — `.v10-tree-section-badge` no longer rendered.
   });
 
@@ -139,8 +141,8 @@ test.describe('Left Panel Navigation', () => {
   // The in-panel ◂ collapse button was removed in PR8 — the global
   // header sidebar toggle is the sole control. A future spec should
   // exercise the global toggle path (`shell.header.sidebarToggle`)
-  // instead. Tracked in follow-up #120.
-  test.skip('collapse button hides left panel', async () => {
+  // instead. `fixme` so it stays visible in the test report.
+  test.fixme('collapse button hides left panel', async () => {
     // intentionally skipped — `.v10-collapse-btn` no longer rendered.
   });
 

--- a/packages/node-ui/e2e/specs/left-navigation.spec.ts
+++ b/packages/node-ui/e2e/specs/left-navigation.spec.ts
@@ -30,11 +30,11 @@ test.describe('Left Panel Navigation', () => {
     expect(names.length).toBe(3);
   });
 
-  test('project badge shows asset count', async ({ leftPanel }) => {
-    const badge = leftPanel.root.locator(sel.leftPanel.section)
-      .filter({ hasText: 'Pharma Drug Interactions' })
-      .locator(sel.leftPanel.sectionBadge);
-    await expect(badge).toHaveText('227');
+  // Per-row asset-count badges were removed in PR8 — the count was
+  // broken (always 0) and the dashboard already surfaces this number.
+  // Broader e2e modernization tracked in follow-up #120.
+  test.skip('project badge shows asset count', async () => {
+    // intentionally skipped — `.v10-tree-section-badge` no longer rendered.
   });
 
   test('expanding a project reveals memory layer items', async ({ leftPanel }) => {
@@ -136,9 +136,12 @@ test.describe('Left Panel Navigation', () => {
     expect(await createProjectModal.isOpen()).toBe(true);
   });
 
-  test('collapse button hides left panel', async ({ leftPanel, shell }) => {
-    await leftPanel.collapse();
-    await expect(shell.leftPanel).toBeHidden();
+  // The in-panel ◂ collapse button was removed in PR8 — the global
+  // header sidebar toggle is the sole control. A future spec should
+  // exercise the global toggle path (`shell.header.sidebarToggle`)
+  // instead. Tracked in follow-up #120.
+  test.skip('collapse button hides left panel', async () => {
+    // intentionally skipped — `.v10-collapse-btn` no longer rendered.
   });
 
   test('clicking Dashboard row switches to dashboard view', async ({ leftPanel, centerPanel }) => {

--- a/packages/node-ui/e2e/specs/shell-layout.spec.ts
+++ b/packages/node-ui/e2e/specs/shell-layout.spec.ts
@@ -30,10 +30,10 @@ test.describe('Shell Layout', () => {
 
   // The in-panel `.v10-collapse-btn` was removed in PR8 — the global
   // header sidebar toggle is the sole control. The test directly above
-  // ("header toggle collapses left panel") already exercises that path,
-  // so this case is now redundant rather than just stale. `fixme` so it
-  // ties to the broader e2e modernization in follow-up task (in this
-  // workspace; not a GitHub issue) — see `feat/sidebar-cleanup-and-dark-contrast`
+  // ("header sidebar toggle collapses left panel") already exercises
+  // that path, so this case is now redundant rather than just stale.
+  // `fixme` so it stays visible in the report until the broader e2e
+  // revamp picks it up — see `feat/sidebar-cleanup-and-dark-contrast`
   // commit history for context.
   test.fixme('left panel collapse button hides tree entirely', async () => {
     // intentionally skipped — `.v10-collapse-btn` no longer rendered.

--- a/packages/node-ui/e2e/specs/shell-layout.spec.ts
+++ b/packages/node-ui/e2e/specs/shell-layout.spec.ts
@@ -28,9 +28,15 @@ test.describe('Shell Layout', () => {
     await expect(shell.leftPanel).toBeVisible();
   });
 
-  test('left panel collapse button hides tree entirely', async ({ leftPanel, shell }) => {
-    await leftPanel.collapse();
-    await expect(shell.leftPanel).toBeHidden();
+  // The in-panel `.v10-collapse-btn` was removed in PR8 — the global
+  // header sidebar toggle is the sole control. The test directly above
+  // ("header toggle collapses left panel") already exercises that path,
+  // so this case is now redundant rather than just stale. `fixme` so it
+  // ties to the broader e2e modernization in follow-up task (in this
+  // workspace; not a GitHub issue) — see `feat/sidebar-cleanup-and-dark-contrast`
+  // commit history for context.
+  test.fixme('left panel collapse button hides tree entirely', async () => {
+    // intentionally skipped — `.v10-collapse-btn` no longer rendered.
   });
 
   test('header toggle collapses right panel', async ({ header, page }) => {

--- a/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { ChevronRight } from 'lucide-react';
 import { useLayoutStore } from '../../stores/layout.js';
 import { useTabsStore } from '../../stores/tabs.js';
 import { useProjectsStore, type ContextGraph } from '../../stores/projects.js';
@@ -21,9 +22,6 @@ import {
   toSidebarIdentity,
   type AgentSidebarIdentity,
 } from '../../lib/contextGraphSidebar.js';
-
-const CHEVRON_ICON = '▸';
-const COLLAPSE_ICON = '◂';
 
 // Project tree row: a flat, clickable header that opens the project tab.
 // Memory-layer expansion was removed by request — layers are surfaced inside
@@ -48,8 +46,6 @@ function ProjectTreeItem({
   onSelect,
   onHide,
 }: ProjectTreeItemProps) {
-  const assetCount = cg.assetCount ?? cg.assets ?? 0;
-
   return (
     <div className="v10-tree-section">
       <div
@@ -58,7 +54,6 @@ function ProjectTreeItem({
       >
         <span className="v10-tree-project-dot" />
         <span className="v10-tree-section-label">{cg.name || cg.id.slice(0, 16)}</span>
-        <span className="v10-tree-section-badge">{assetCount}</span>
         <button
           type="button"
           className="v10-tree-hide-btn"
@@ -91,80 +86,73 @@ function localAgentDotColor(status: LocalAgentIntegrationStatus): string {
   }
 }
 
-function IntegrationsSection() {
-  const [open, setOpen] = useState(false);
+// Body of the Integrations sidebar section. Open/closed state is owned by
+// the layout store; this component is only mounted while the section is
+// open, so the 30s polling effect naturally pauses when the user
+// collapses the section (no in-component `if (!open) return` guard).
+function IntegrationsSectionBody() {
   const [localAgents, setLocalAgents] = useState<LocalAgentIntegration[]>([]);
   const [localAgentsError, setLocalAgentsError] = useState<string | null>(null);
 
-  // Lazy-load on first open and refresh every 30s while open.
   useEffect(() => {
-    if (!open) return;
     let cancelled = false;
-
     const loadLocal = () => {
       fetchLocalAgentIntegrations()
         .then((r) => { if (!cancelled) { setLocalAgents(r.integrations); setLocalAgentsError(null); } })
         .catch((e: Error) => { if (!cancelled) setLocalAgentsError(e.message); });
     };
-
     loadLocal();
     const iv = setInterval(loadLocal, 30_000);
     return () => { cancelled = true; clearInterval(iv); };
-  }, [open]);
+  }, []);
 
   return (
-    <div className="v10-tree-section">
-      <div className="v10-tree-section-header" onClick={() => setOpen((v) => !v)}>
-        <span className={`v10-tree-chevron ${open ? 'open' : ''}`}>{CHEVRON_ICON}</span>
-        <span className="v10-tree-integration-dot" />
-        <span className="v10-tree-section-label">Integrations</span>
+    <div className="v10-tree-items" style={{ display: 'block' }}>
+      <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: 0.5, padding: '6px 12px 2px 24px' }}>
+        Agents
       </div>
-      {open && (
-        <div className="v10-tree-items" style={{ display: 'block' }}>
-          <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: 0.5, padding: '6px 12px 2px 38px' }}>
-            Agents
-          </div>
-          {localAgentsError && (
-            <div style={{ fontSize: 11, color: 'var(--accent-orange, #f97316)', padding: '4px 12px 4px 38px' }}>
-              {localAgentsError}
-            </div>
-          )}
-          {!localAgentsError && localAgents.length === 0 && (
-            <div style={{ fontSize: 11, color: 'var(--text-tertiary)', padding: '4px 12px 4px 38px', fontStyle: 'italic' }}>
-              No agents detected.
-            </div>
-          )}
-          {localAgents.map((a) => (
-            <div
-              key={a.id}
-              className="v10-tree-item"
-              title={a.detail}
-              style={{ cursor: 'default' }}
-            >
-              <span
-                aria-label={a.statusLabel}
-                style={{
-                  width: 7,
-                  height: 7,
-                  borderRadius: '50%',
-                  background: localAgentDotColor(a.status),
-                  flexShrink: 0,
-                }}
-              />
-              <span className="v10-tree-item-label">{a.name}</span>
-              <span style={{ fontSize: 10, color: 'var(--text-tertiary)', marginLeft: 4 }}>
-                {a.statusLabel}
-              </span>
-            </div>
-          ))}
+      {localAgentsError && (
+        <div style={{ fontSize: 11, color: 'var(--accent-orange, #f97316)', padding: '4px 12px 4px 24px' }}>
+          {localAgentsError}
         </div>
       )}
+      {!localAgentsError && localAgents.length === 0 && (
+        <div style={{ fontSize: 11, color: 'var(--text-tertiary)', padding: '4px 12px 4px 24px', fontStyle: 'italic' }}>
+          No agents detected.
+        </div>
+      )}
+      {localAgents.map((a) => (
+        <div
+          key={a.id}
+          className="v10-tree-item"
+          title={a.detail}
+          style={{ cursor: 'default' }}
+        >
+          <span
+            aria-label={a.statusLabel}
+            style={{
+              width: 7,
+              height: 7,
+              borderRadius: '50%',
+              background: localAgentDotColor(a.status),
+              flexShrink: 0,
+            }}
+          />
+          <span className="v10-tree-item-label">{a.name}</span>
+          <span style={{ fontSize: 11, color: 'var(--text-tertiary)', marginLeft: 4 }}>
+            {a.statusLabel}
+          </span>
+        </div>
+      ))}
     </div>
   );
 }
 
 export function PanelLeft() {
-  const { toggleLeft } = useLayoutStore();
+  const leftSectionMyProjectsOpen = useLayoutStore((s) => s.leftSectionMyProjectsOpen);
+  const leftSectionIntegrationsOpen = useLayoutStore((s) => s.leftSectionIntegrationsOpen);
+  const toggleLeftSectionMyProjects = useLayoutStore((s) => s.toggleLeftSectionMyProjects);
+  const toggleLeftSectionIntegrations = useLayoutStore((s) => s.toggleLeftSectionIntegrations);
   const { openTab, activeTabId, setActiveTab } = useTabsStore();
   const { contextGraphs, setContextGraphs, setLoading, activeProjectId, setActiveProject } = useProjectsStore();
   const stage = useJourneyStore((s) => s.stage);
@@ -224,9 +212,6 @@ export function PanelLeft() {
         >
           Context Oracle
         </button>
-        <button className="v10-collapse-btn" onClick={toggleLeft} style={{ marginLeft: 4, padding: '0 6px' }}>
-          {COLLAPSE_ICON}
-        </button>
       </div>
 
       {treeMode === 'explorer' && (
@@ -238,6 +223,8 @@ export function PanelLeft() {
             <span>▦</span> Dashboard
           </div>
 
+          {/* Empty-state card hoisted ABOVE the collapsible sections so it
+              stays visible if both sections are collapsed. */}
           {contextGraphs.length === 0 && stage <= 1 && (
             <div className="v10-journey-empty-card">
               <div className="v10-jec-title">No context graphs yet</div>
@@ -254,25 +241,44 @@ export function PanelLeft() {
             </div>
           )}
 
+          {/* Section A: My Context Graphs (default expanded). Uses the
+              .v10-peer-group-* pattern from the right panel — polished
+              focus-visible + prefers-reduced-motion + button semantics. */}
           {myProjects.length > 0 && (
-            <>
-              <div className="v10-tree-group-label">My Context Graphs</div>
-              {myProjects.map((cg) => (
-                <ProjectTreeItem
-                  key={cg.id}
-                  cg={cg}
-                  isActive={activeProjectId === cg.id}
-                  onSelect={() => {
-                    setActiveProject(cg.id);
-                    openTab({ id: `project:${cg.id}`, label: cg.name || cg.id.slice(0, 16), closable: true });
-                  }}
-                  onHide={() => {
-                    hideProject(cg.id);
-                    if (activeProjectId === cg.id) setActiveProject(null);
-                  }}
+            <div className="v10-peer-group">
+              <button
+                type="button"
+                className="v10-peer-group-header"
+                aria-expanded={leftSectionMyProjectsOpen}
+                onClick={toggleLeftSectionMyProjects}
+              >
+                <ChevronRight
+                  size={14}
+                  className={`v10-peer-group-chevron ${leftSectionMyProjectsOpen ? 'expanded' : ''}`}
+                  aria-hidden="true"
                 />
-              ))}
-            </>
+                <span className="v10-peer-group-label">My Context Graphs</span>
+              </button>
+              {leftSectionMyProjectsOpen && (
+                <div className="v10-peer-group-body">
+                  {myProjects.map((cg) => (
+                    <ProjectTreeItem
+                      key={cg.id}
+                      cg={cg}
+                      isActive={activeProjectId === cg.id}
+                      onSelect={() => {
+                        setActiveProject(cg.id);
+                        openTab({ id: `project:${cg.id}`, label: cg.name || cg.id.slice(0, 16), closable: true });
+                      }}
+                      onHide={() => {
+                        hideProject(cg.id);
+                        if (activeProjectId === cg.id) setActiveProject(null);
+                      }}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
           )}
 
           {hiddenCount > 0 && (
@@ -286,7 +292,28 @@ export function PanelLeft() {
             </button>
           )}
 
-          {stage >= 1 && <IntegrationsSection />}
+          {/* Section B: Integrations (default collapsed — escape-hatch
+              surface). Body is only mounted while open, so the 30s
+              polling effect in IntegrationsSectionBody naturally pauses
+              when collapsed. */}
+          {stage >= 1 && (
+            <div className="v10-peer-group">
+              <button
+                type="button"
+                className="v10-peer-group-header"
+                aria-expanded={leftSectionIntegrationsOpen}
+                onClick={toggleLeftSectionIntegrations}
+              >
+                <ChevronRight
+                  size={14}
+                  className={`v10-peer-group-chevron ${leftSectionIntegrationsOpen ? 'expanded' : ''}`}
+                  aria-hidden="true"
+                />
+                <span className="v10-peer-group-label">Integrations</span>
+              </button>
+              {leftSectionIntegrationsOpen && <IntegrationsSectionBody />}
+            </div>
+          )}
         </div>
       )}
 

--- a/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useId, useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { useLayoutStore } from '../../stores/layout.js';
 import { useTabsStore } from '../../stores/tabs.js';
@@ -153,6 +153,11 @@ export function PanelLeft() {
   const leftSectionIntegrationsOpen = useLayoutStore((s) => s.leftSectionIntegrationsOpen);
   const toggleLeftSectionMyProjects = useLayoutStore((s) => s.toggleLeftSectionMyProjects);
   const toggleLeftSectionIntegrations = useLayoutStore((s) => s.toggleLeftSectionIntegrations);
+  // Stable per-render ids for the section bodies so the chevron buttons
+  // can use `aria-controls` to point at the disclosed region (screen
+  // readers can then programmatically associate trigger ↔ content).
+  const myProjectsBodyId = useId();
+  const integrationsBodyId = useId();
   const { openTab, activeTabId, setActiveTab } = useTabsStore();
   const { contextGraphs, setContextGraphs, setLoading, activeProjectId, setActiveProject } = useProjectsStore();
   const stage = useJourneyStore((s) => s.stage);
@@ -243,13 +248,20 @@ export function PanelLeft() {
 
           {/* Section A: My Context Graphs (default expanded). Uses the
               .v10-peer-group-* pattern from the right panel — polished
-              focus-visible + prefers-reduced-motion + button semantics. */}
-          {myProjects.length > 0 && (
+              focus-visible + prefers-reduced-motion + button semantics.
+              Header renders even when `myProjects` is empty (but at
+              least one CG exists, or the journey is past first-run) —
+              otherwise a sidebar with CGs only in the Context Oracle
+              view would collapse to a lone "Integrations" header
+              (qa-lead). The empty-state journey card above handles the
+              "no CGs at all" first-run case. */}
+          {(contextGraphs.length > 0 || stage >= 2) && (
             <div className="v10-peer-group">
               <button
                 type="button"
                 className="v10-peer-group-header"
                 aria-expanded={leftSectionMyProjectsOpen}
+                aria-controls={myProjectsBodyId}
                 onClick={toggleLeftSectionMyProjects}
               >
                 <ChevronRight
@@ -260,8 +272,15 @@ export function PanelLeft() {
                 <span className="v10-peer-group-label">My Context Graphs</span>
               </button>
               {leftSectionMyProjectsOpen && (
-                <div className="v10-peer-group-body">
-                  {myProjects.map((cg) => (
+                <div id={myProjectsBodyId} className="v10-peer-group-body">
+                  {myProjects.length === 0 ? (
+                    <div
+                      className="v10-tree-item"
+                      style={{ cursor: 'default', color: 'var(--text-tertiary)', fontStyle: 'italic' }}
+                    >
+                      <span className="v10-tree-item-label">No context graphs in this view yet.</span>
+                    </div>
+                  ) : myProjects.map((cg) => (
                     <ProjectTreeItem
                       key={cg.id}
                       cg={cg}
@@ -302,6 +321,7 @@ export function PanelLeft() {
                 type="button"
                 className="v10-peer-group-header"
                 aria-expanded={leftSectionIntegrationsOpen}
+                aria-controls={integrationsBodyId}
                 onClick={toggleLeftSectionIntegrations}
               >
                 <ChevronRight
@@ -311,7 +331,11 @@ export function PanelLeft() {
                 />
                 <span className="v10-peer-group-label">Integrations</span>
               </button>
-              {leftSectionIntegrationsOpen && <IntegrationsSectionBody />}
+              {leftSectionIntegrationsOpen && (
+                <div id={integrationsBodyId}>
+                  <IntegrationsSectionBody />
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
@@ -332,7 +332,7 @@ export function PanelLeft() {
                 <span className="v10-peer-group-label">Integrations</span>
               </button>
               {leftSectionIntegrationsOpen && (
-                <div id={integrationsBodyId}>
+                <div id={integrationsBodyId} className="v10-peer-group-body">
                   <IntegrationsSectionBody />
                 </div>
               )}

--- a/packages/node-ui/src/ui/stores/layout.ts
+++ b/packages/node-ui/src/ui/stores/layout.ts
@@ -4,6 +4,11 @@ interface LayoutState {
   leftCollapsed: boolean;
   rightCollapsed: boolean;
   bottomCollapsed: boolean;
+  // Per-section open state inside the left sidebar. Persisted alongside
+  // `leftCollapsed` so section preferences survive reloads in lockstep
+  // with the sidebar collapse state itself.
+  leftSectionMyProjectsOpen: boolean;
+  leftSectionIntegrationsOpen: boolean;
   theme: 'dark' | 'light';
   leftWidth: number;
   rightWidth: number;
@@ -12,6 +17,8 @@ interface LayoutState {
   toggleLeft: () => void;
   toggleRight: () => void;
   toggleBottom: () => void;
+  toggleLeftSectionMyProjects: () => void;
+  toggleLeftSectionIntegrations: () => void;
   setTheme: (t: 'dark' | 'light') => void;
   setLeftWidth: (w: number) => void;
   setRightWidth: (w: number) => void;
@@ -24,6 +31,8 @@ interface PersistedLayout {
   leftCollapsed?: boolean;
   rightCollapsed?: boolean;
   bottomCollapsed?: boolean;
+  leftSectionMyProjectsOpen?: boolean;
+  leftSectionIntegrationsOpen?: boolean;
   leftWidth?: number;
   rightWidth?: number;
   bottomHeight?: number;
@@ -33,6 +42,12 @@ const DEFAULTS = {
   leftCollapsed: false,
   rightCollapsed: false,
   bottomCollapsed: true,
+  // Sidebar sections: My Context Graphs is the primary navigation surface
+  // so it stays open by default; Integrations is an escape-hatch surface
+  // (status check, no day-to-day click target) so it stays closed and
+  // doesn't run its 30s polling loop until the user opens it.
+  leftSectionMyProjectsOpen: true,
+  leftSectionIntegrationsOpen: false,
   leftWidth: 240,
   rightWidth: 360,
   bottomHeight: 200,
@@ -99,6 +114,12 @@ function loadPersisted(): Required<PersistedLayout> {
       leftCollapsed: typeof parsed.leftCollapsed === 'boolean' ? parsed.leftCollapsed : DEFAULTS.leftCollapsed,
       rightCollapsed: typeof parsed.rightCollapsed === 'boolean' ? parsed.rightCollapsed : DEFAULTS.rightCollapsed,
       bottomCollapsed: typeof parsed.bottomCollapsed === 'boolean' ? parsed.bottomCollapsed : DEFAULTS.bottomCollapsed,
+      leftSectionMyProjectsOpen: typeof parsed.leftSectionMyProjectsOpen === 'boolean'
+        ? parsed.leftSectionMyProjectsOpen
+        : DEFAULTS.leftSectionMyProjectsOpen,
+      leftSectionIntegrationsOpen: typeof parsed.leftSectionIntegrationsOpen === 'boolean'
+        ? parsed.leftSectionIntegrationsOpen
+        : DEFAULTS.leftSectionIntegrationsOpen,
       leftWidth: clampWidth(parsed.leftWidth, DEFAULTS.leftWidth, LEFT_WIDTH_MIN, LEFT_WIDTH_MAX),
       rightWidth: clampWidth(parsed.rightWidth, DEFAULTS.rightWidth, RIGHT_WIDTH_MIN, RIGHT_WIDTH_MAX),
       bottomHeight: clampWidth(parsed.bottomHeight, DEFAULTS.bottomHeight, BOTTOM_HEIGHT_MIN, BOTTOM_HEIGHT_MAX),
@@ -121,12 +142,30 @@ function persist(state: PersistedLayout): void {
   }, 150);
 }
 
+// Pull only the persistable fields off the live state so callers don't
+// have to re-list every field in every action. Theme is intentionally
+// excluded — it has its own `dkg-theme` key.
+function snapshot(state: LayoutState): PersistedLayout {
+  return {
+    leftCollapsed: state.leftCollapsed,
+    rightCollapsed: state.rightCollapsed,
+    bottomCollapsed: state.bottomCollapsed,
+    leftSectionMyProjectsOpen: state.leftSectionMyProjectsOpen,
+    leftSectionIntegrationsOpen: state.leftSectionIntegrationsOpen,
+    leftWidth: state.leftWidth,
+    rightWidth: state.rightWidth,
+    bottomHeight: state.bottomHeight,
+  };
+}
+
 const initial = loadPersisted();
 
 export const useLayoutStore = create<LayoutState>((set, get) => ({
   leftCollapsed: initial.leftCollapsed,
   rightCollapsed: initial.rightCollapsed,
   bottomCollapsed: initial.bottomCollapsed,
+  leftSectionMyProjectsOpen: initial.leftSectionMyProjectsOpen,
+  leftSectionIntegrationsOpen: initial.leftSectionIntegrationsOpen,
   theme: (localStorage.getItem('dkg-theme') as 'dark' | 'light') || 'dark',
   leftWidth: initial.leftWidth,
   rightWidth: initial.rightWidth,
@@ -134,18 +173,23 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
 
   toggleLeft: () => {
     set((s) => ({ leftCollapsed: !s.leftCollapsed }));
-    const { leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight } = get();
-    persist({ leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight });
+    persist(snapshot(get()));
   },
   toggleRight: () => {
     set((s) => ({ rightCollapsed: !s.rightCollapsed }));
-    const { leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight } = get();
-    persist({ leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight });
+    persist(snapshot(get()));
   },
   toggleBottom: () => {
     set((s) => ({ bottomCollapsed: !s.bottomCollapsed }));
-    const { leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight } = get();
-    persist({ leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight });
+    persist(snapshot(get()));
+  },
+  toggleLeftSectionMyProjects: () => {
+    set((s) => ({ leftSectionMyProjectsOpen: !s.leftSectionMyProjectsOpen }));
+    persist(snapshot(get()));
+  },
+  toggleLeftSectionIntegrations: () => {
+    set((s) => ({ leftSectionIntegrationsOpen: !s.leftSectionIntegrationsOpen }));
+    persist(snapshot(get()));
   },
   setTheme: (t) => {
     localStorage.setItem('dkg-theme', t);
@@ -157,13 +201,11 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     // values within the supported bounds, and persisted state stays
     // consistent with what loadPersisted accepts on reload.
     set({ leftWidth: clamp(w, LEFT_WIDTH_MIN, LEFT_WIDTH_MAX) });
-    const { leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight } = get();
-    persist({ leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight });
+    persist(snapshot(get()));
   },
   setRightWidth: (w) => {
     set({ rightWidth: clamp(w, RIGHT_WIDTH_MIN, RIGHT_WIDTH_MAX) });
-    const { leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight } = get();
-    persist({ leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight });
+    persist(snapshot(get()));
   },
   setBottomHeight: (h) => {
     // Lower bound is viewport-aware, not a hard 120: on a short
@@ -175,7 +217,6 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     // effective floor is still 120.
     const lo = Math.min(BOTTOM_HEIGHT_MIN, maxBottomHeight());
     set({ bottomHeight: clamp(h, lo, BOTTOM_HEIGHT_MAX) });
-    const { leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight } = get();
-    persist({ leftCollapsed, rightCollapsed, bottomCollapsed, leftWidth, rightWidth, bottomHeight });
+    persist(snapshot(get()));
   },
 }));

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -21,15 +21,17 @@
      whose bg is identical to a chip fill). */
   --border-prominent: #888888;
 
-  /* Text — dark mode. Bumped 2026-05-20 (PR7) to clear AA across all
-     three steps on --bg-panel #0a0a0a, and to tighten the visual gap
-     between secondary and primary (user reported "muted-to-disabled"
-     feel on the prior #888888). Contrast ratios: primary 15.9:1,
-     secondary 9.7:1, tertiary 6.7:1. */
+  /* Text — dark mode. Round-2 bump 2026-05-20 (PR8): the PR7 lift
+     (#8a8a8a tertiary, #333 ghost) still read as "footnotes" on a real
+     14"+ laptop screen. Pushed tertiary another step + lifted ghost
+     out of the sub-3:1 invisible band — it was decoration-only on
+     paper but used by real labels (.v10-tree-group-label, etc.).
+     Contrast ratios on --bg-panel #0a0a0a: primary 15.9:1,
+     secondary 9.7:1, tertiary ~7.1:1, ghost ~3.2:1. */
   --text-primary: #f0f0f0;
   --text-secondary: #a8a8a8;
-  --text-tertiary: #8a8a8a;
-  --text-ghost: #333333;
+  --text-tertiary: #9a9a9a;
+  --text-ghost: #6a6a6a;
 
   /* Accent — reserved for signals */
   --accent-red: #ef4444;
@@ -100,11 +102,14 @@ body.light {
   --border-prominent: #525252;
   --text-primary: #171717;
   --text-secondary: #525252;
-  /* Light-mode tertiary bumped #a3a3a3 → #737373 (2026-05-20 PR7) so it
-     clears AA on --bg-panel #f5f5f5 (5.0:1). Primary + secondary stay
-     unchanged — they were already AA-strong on light. */
-  --text-tertiary: #737373;
-  --text-ghost: #d4d4d4;
+  /* Light tokens round-2 (PR8): tertiary further down from #737373 →
+     #6b6b6b (~5.4:1) — PR7's value cleared AA on paper but still read
+     as "dust" at 11px in live testing. Ghost lifted out of the
+     ~1.4:1 invisible band (the prior #d4d4d4 disappeared on bg-panel
+     #f5f5f5 — fine for borders, not for the labels that use it).
+     Ghost target ~3:1 — intentional de-emphasis but readable. */
+  --text-tertiary: #6b6b6b;
+  --text-ghost: #8a8a8a;
   /* Light-theme danger foreground (~7.4:1 on --bg-elevated #f0f0f0) */
   --text-danger: #b91c1c;
   --text-danger-hover: #991b1b;
@@ -135,7 +140,14 @@ html, body, #root {
   background: var(--bg-root);
   color: var(--text-primary);
   font-family: var(--font-sans);
-  font-size: 13px;
+  /* Body base 13 → 14 (PR8). PR7's surgical 10→11 bumps on a handful of
+     classes weren't enough — the long tail of inherited 13px chrome
+     still read as footnotes on a real laptop screen. Bumping the base
+     lifts every un-pinned surface (paragraph bodies, modal copy, form
+     labels, tooltips) via the cascade. Explicit "keep" overrides below
+     prevent the very largest surfaces (stat hero numbers, dashboard
+     title) from ballooning. */
+  font-size: 14px;
   line-height: 1.5;
   overflow: hidden;
   -webkit-font-smoothing: antialiased;
@@ -263,21 +275,21 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-header-agent-name {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--text-primary);
 }
 .v10-header-agent-addr {
   font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--text-tertiary);
-  opacity: 0.7;
+  font-size: 11px;
+  color: var(--text-secondary);
+  opacity: 0.85;
 }
 .v10-header-spacer { flex: 1; }
 .v10-header-meta {
   font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-tertiary);
+  font-size: 12px;
+  color: var(--text-secondary);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -469,7 +481,8 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-tree-chevron.open { transform: rotate(90deg); }
 .v10-tree-section-label {
-  font-size: 12px;
+  /* CG names — the single biggest sidebar readability win. 12 → 13. */
+  font-size: 13px;
   font-weight: 500;
   color: var(--text-secondary);
   flex: 1;
@@ -499,14 +512,17 @@ button:focus:not(:focus-visible) { outline: none; }
   color: var(--accent-red, #ef4444);
 }
 
-/* "My Projects" / "Participating Projects" group dividers */
+/* "My Projects" / "Participating Projects" group dividers. Token
+   moved from --text-ghost → --text-tertiary (PR8) — ghost was never
+   meant for navigational labels; the contrast was below the 3:1 floor
+   even after PR8's ghost bump. */
 .v10-tree-group-label {
   padding: 10px 14px 3px;
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
 }
 
 /* Move-to-other-group button (⤑), same reveal-on-hover shape as hide */
@@ -538,7 +554,7 @@ button:focus:not(:focus-visible) { outline: none; }
   border: 1px dashed var(--border-subtle);
   border-radius: 6px;
   color: var(--text-tertiary);
-  font-size: 11px; font-family: var(--font-sans);
+  font-size: 12px; font-family: var(--font-sans);
   cursor: pointer;
   text-align: center;
   transition: border-color 0.15s, color 0.15s;
@@ -571,7 +587,7 @@ button:focus:not(:focus-visible) { outline: none; }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 11px;
+  font-size: 12px;
 }
 /* Tree mode tabs */
 .v10-tree-mode-btn {
@@ -604,14 +620,15 @@ button:focus:not(:focus-visible) { outline: none; }
   flex-shrink: 0;
 }
 
-/* Layer headers inside project tree */
+/* Layer headers inside project tree. Same token + size fix as
+   .v10-tree-group-label — was unreadable on --text-ghost. */
 .v10-tree-layer-header {
   padding: 3px 12px 3px 32px;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
   margin-top: 4px;
   cursor: default;
 }
@@ -626,7 +643,7 @@ button:focus:not(:focus-visible) { outline: none; }
   padding: 6px 12px;
   border-radius: 6px;
   border: 1px dashed var(--border-strong);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   color: var(--text-secondary);
   transition: all 0.15s;
@@ -1973,10 +1990,10 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-bottom-tab {
   padding: 0 12px;
   height: 100%;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   font-family: var(--font-mono);
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
   border-bottom: 2px solid transparent;
   transition: all 0.15s;
 }
@@ -2002,7 +2019,7 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-log-filter {
   width: 200px;
   padding: 4px 8px;
-  font-size: 11px;
+  font-size: 12px;
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-radius: 4px;
@@ -2019,7 +2036,12 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-log-line {
   padding: 0 12px;
-  color: var(--text-secondary);
+  /* Log lines stay at 11px mono (industry-standard density — bumping
+     loses ~15-20% visible lines per scroll). The PR8 fix is contrast:
+     promote body text to --text-primary so the active payload reads
+     cleanly; the timestamp prefix can be styled separately by callers
+     that want quieter timestamps. */
+  color: var(--text-primary);
   white-space: pre;
 }
 .v10-log-line:hover { background: var(--bg-hover); }
@@ -2038,7 +2060,9 @@ button:focus:not(:focus-visible) { outline: none; }
      fills the available width without an explicit width: 100%. */
 }
 .v10-chat-bubble {
-  font-size: 12px;
+  /* Chat copy is dense; +1 not +2 — keeps the bubble height-economical
+     while tracking the body base bump (PR8). */
+  font-size: 13px;
   line-height: 1.55;
   word-break: break-word;
   overflow-wrap: anywhere;
@@ -2440,8 +2464,10 @@ button:focus:not(:focus-visible) { outline: none; }
 @media (prefers-reduced-motion: reduce) { .v10-anim-mount { animation: none; } }
 
 .v10-dash-header { margin-bottom: 24px; }
+/* Keep hero title pinned (PR8); subtitle gets promoted from tertiary
+   muted-mono to a readable secondary line. */
 .v10-dash-title { font-size: 20px; font-weight: 600; color: var(--text-primary); margin-bottom: 4px; }
-.v10-dash-subtitle { font-size: 12px; color: var(--text-tertiary); font-family: var(--font-mono); }
+.v10-dash-subtitle { font-size: 13px; color: var(--text-secondary); font-family: var(--font-mono); }
 .v10-dash-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 12px; margin-bottom: 24px; }
 .v10-dash-stats .stat-card { min-width: 0; }
 .v10-dash-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; }
@@ -2475,15 +2501,15 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-dash-section-title svg { color: var(--text-secondary); flex-shrink: 0; }
 .v10-dash-section-badge {
   font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--text-tertiary);
+  font-size: 11px;
+  color: var(--text-secondary);
   background: var(--bg-elevated);
   padding: 2px 8px;
   border-radius: 4px;
 }
 .v10-dash-section-link {
-  font-size: 11px;
-  color: var(--text-tertiary);
+  font-size: 12px;
+  color: var(--text-secondary);
   transition: color 0.15s;
 }
 .v10-dash-section-link:hover { color: var(--text-primary); }
@@ -2523,7 +2549,7 @@ button:focus:not(:focus-visible) { outline: none; }
   line-height: 1.1;
   font-variant-numeric: tabular-nums;
 }
-.v10-cg-size-num .v10-cg-dim { font-size: 11px; }
+.v10-cg-size-num .v10-cg-dim { font-size: 12px; }
 .v10-cg-size-empty { font-size: 20px; font-weight: 600; padding: 6px 0; }
 /* The Size card is the densest of the three stat cards; trim its
    padding so the two big numbers + bars + legend + sub don't bloat it
@@ -2577,7 +2603,7 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-layer-legend { display: flex; gap: 12px; margin-top: 4px; }
 .v10-layer-legend-item {
   display: inline-flex; align-items: center; gap: 5px;
-  font-size: 10px; color: var(--text-secondary); font-family: var(--font-mono);
+  font-size: 11px; color: var(--text-secondary); font-family: var(--font-mono);
 }
 .v10-layer-legend-dot { width: 8px; height: 8px; border-radius: 2px; }
 
@@ -2595,7 +2621,7 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-cg-colhead {
   padding: 5px 8px;
-  font-size: 10px;
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--text-secondary);
@@ -2618,7 +2644,7 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-cg-row:last-child { border-bottom: 0; }
 .v10-cg-row:hover { background: var(--bg-hover); }
-.v10-cg-cell { font-size: 12px; color: var(--text-secondary); min-width: 0; }
+.v10-cg-cell { font-size: 13px; color: var(--text-secondary); min-width: 0; }
 .v10-cg-name {
   color: var(--text-primary);
   font-weight: 500;
@@ -2641,7 +2667,7 @@ button:focus:not(:focus-visible) { outline: none; }
 /* Role badge — same small-status-badge family as `.v10-agent-card-badge`. */
 .v10-cg-badge {
   display: inline-block;
-  font-size: 9px;
+  font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.04em;
   padding: 2px 7px;
@@ -2685,11 +2711,11 @@ button:focus:not(:focus-visible) { outline: none; }
   align-items: baseline;
   gap: 8px;
   margin: 0 0 6px;
-  font-size: 12px;
+  font-size: 13px;
 }
 .v10-ws-chain-label {
   color: var(--text-secondary);
-  font-size: 10px;
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -2705,13 +2731,13 @@ button:focus:not(:focus-visible) { outline: none; }
   grid-template-columns: minmax(0, 1fr) 5.5em 5em;
   align-items: baseline;
   gap: 10px;
-  font-size: 12px;
+  font-size: 13px;
 }
 .v10-ws-wrow .v10-ws-bal,
-.v10-ws-wrow .v10-ws-bal-sec { text-align: right; font-size: 12px; }
+.v10-ws-wrow .v10-ws-bal-sec { text-align: right; font-size: 13px; }
 .v10-ws-wrow .v10-ws-bal-sec { color: var(--text-secondary); }
 .v10-ws-whead {
-  font-size: 10px;
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--text-secondary);
@@ -2729,12 +2755,12 @@ button:focus:not(:focus-visible) { outline: none; }
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  font-size: 13px;
 }
 .v10-ws-addr {
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 12px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2749,7 +2775,7 @@ button:focus:not(:focus-visible) { outline: none; }
    real balance, must clear AA). */
 .v10-ws-bal-sec {
   color: var(--text-secondary);
-  font-size: 10px;
+  font-size: 11px;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -2765,10 +2791,10 @@ button:focus:not(:focus-visible) { outline: none; }
   grid-template-columns: minmax(0, 1fr) 7em 5em;
   align-items: baseline;
   gap: 10px;
-  font-size: 12px;
+  font-size: 13px;
 }
 .v10-ws-spend-head {
-  font-size: 10px;
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--text-secondary);
@@ -2779,13 +2805,13 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-ws-spend-val { text-align: right; }
 .v10-ws-spend-val {
   color: var(--text-primary);
-  font-size: 11px;
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 /* Chain/RPC partial-error caveat under the wallet list. --text-secondary
    (AA on the card surface), small but not micro. */
-.v10-ws-note { color: var(--text-secondary); font-size: 11px; margin-top: 6px; }
+.v10-ws-note { color: var(--text-secondary); font-size: 12px; margin-top: 6px; }
 
 /* Quick actions */
 .v10-quick-actions { display: grid; grid-template-columns: repeat(auto-fit, minmax(100px, 1fr)); gap: 8px; }
@@ -3171,9 +3197,9 @@ p { font-size: 13px; color: var(--text-secondary); line-height: 1.6; }
 .stat-card{background:var(--bg-surface);border:1px solid var(--border-default);border-radius:12px;padding:18px 20px;flex:1;min-width:0;position:relative;overflow:hidden;transition:border-color .15s,box-shadow .15s}
 .stat-card:hover{border-color:var(--border-strong);box-shadow:0 2px 8px rgba(0,0,0,.15)}
 .stat-card .accent{position:absolute;top:0;left:0;right:0;height:2px}
-.stat-label{font-size:11px;color:var(--text-secondary);font-weight:600;letter-spacing:.06em;text-transform:uppercase;margin-bottom:8px;display:flex;align-items:center;gap:6px}
+.stat-label{font-size:12px;color:var(--text-secondary);font-weight:600;letter-spacing:.06em;text-transform:uppercase;margin-bottom:8px;display:flex;align-items:center;gap:6px}
 .stat-value{font-size:28px;font-weight:700;color:var(--text-primary);line-height:1}
-.stat-sub{font-size:11px;color:var(--text-secondary);margin-top:6px}
+.stat-sub{font-size:13px;color:var(--text-secondary);margin-top:6px}
 
 /* Badges */
 .agent-badge{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:6px;font-size:10px;font-weight:600;white-space:nowrap;font-family:var(--font-mono)}

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -3107,7 +3107,11 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-assertion-list-title { font-size: 12px; font-weight: 600; color: var(--text-secondary); }
 .v10-btn-promote-all {
   padding: 5px 14px; border-radius: 6px; border: none;
-  background: var(--layer-shared, #7c6ef0); color: #fff;
+  /* Fallback corrected (PR8 round-4): was #7c6ef0 (purple) — `--layer-shared`
+     is amber. The fallback only kicks in if the var is undefined, which
+     shouldn't happen, but the wrong color leaks a brand inconsistency
+     in any token-stripped render. */
+  background: var(--layer-shared, #f59e0b); color: #fff;
   font-size: 11px; font-weight: 600; cursor: pointer; transition: opacity .15s;
 }
 .v10-btn-promote-all:hover { opacity: .85; }
@@ -3126,10 +3130,11 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-assertion-item-count { font-size: 10px; color: var(--text-tertiary); flex-shrink: 0; }
 .v10-btn-promote {
   padding: 3px 10px; border-radius: 5px; background: transparent;
-  border: 1px solid var(--layer-shared, #7c6ef0); color: var(--layer-shared, #7c6ef0);
+  /* Fallback corrected (PR8 round-4): purple → amber, see promote-all. */
+  border: 1px solid var(--layer-shared, #f59e0b); color: var(--layer-shared, #f59e0b);
   font-size: 11px; font-weight: 500; cursor: pointer; transition: all .15s; flex-shrink: 0;
 }
-.v10-btn-promote:hover { background: var(--layer-shared, #7c6ef0); color: #fff; }
+.v10-btn-promote:hover { background: var(--layer-shared, #f59e0b); color: #fff; }
 .v10-btn-promote:disabled { opacity: .5; cursor: not-allowed; }
 .v10-promote-result { padding: 8px 12px; font-size: 12px; }
 .v10-promote-result.success { color: var(--accent-green); background: rgba(34,197,94,.06); }
@@ -3167,7 +3172,9 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-assertion-item.selected { background: rgba(245,158,11,.04); }
 .v10-btn-publish {
   padding: 5px 14px; border-radius: 6px; border: none;
-  background: var(--layer-verified, #f59e0b); color: #fff;
+  /* Fallback corrected (PR8 round-4): was #f59e0b (amber) — `--layer-verified`
+     is green. Same brand-leak concern as promote-all. */
+  background: var(--layer-verified, #22c55e); color: #fff;
   font-size: 11px; font-weight: 600; cursor: pointer; transition: opacity .15s; white-space: nowrap;
 }
 .v10-btn-publish:hover { opacity: .85; }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -21,18 +21,18 @@
      whose bg is identical to a chip fill). */
   --border-prominent: #888888;
 
-  /* Text — dark mode. Round-2 bump 2026-05-20 (PR8): the PR7 lift
-     (#8a8a8a tertiary) still read as "footnotes" on a real 14"+ laptop
-     screen — pushed tertiary another step (~7.1:1). Ghost stays at the
-     pre-PR8 #333 — qa-lead caught that bumping ghost promoted ~50
-     decorative usages (separators, dot backgrounds, select-arrow
-     gradients) from "near-invisible whisper" to "mid-tier text". The
-     two real labels that used ghost (.v10-tree-group-label,
-     .v10-tree-layer-header) were moved to --text-tertiary instead, so
-     ghost can stay decoration-only. Ratios on --bg-panel #0a0a0a:
-     primary 15.9:1, secondary 9.7:1, tertiary ~7.1:1. */
+  /* Text — dark mode. Round-3 nudge 2026-05-20 (PR8): user feedback on
+     the live state was "almost there but still could be a bit better."
+     Single targeted bump on secondary (the tier that touches the most
+     body text): #a8a8a8 → #b8b8b8 — opens the secondary↔primary gap to
+     ~5pt luminance and pushes secondary to AAA on both bg-panel and
+     bg-surface. Tertiary, primary, and ghost stay. Future cleanup:
+     tertiary tier could be rebalanced (#9a9a9a is perceptually very
+     close to the new secondary), but that's its own pass. Ratios on
+     --bg-panel #0a0a0a: primary 15.9:1, secondary 9.98:1, tertiary
+     ~7.1:1. */
   --text-primary: #f0f0f0;
-  --text-secondary: #a8a8a8;
+  --text-secondary: #b8b8b8;
   --text-tertiary: #9a9a9a;
   --text-ghost: #333333;
 
@@ -104,14 +104,15 @@ body.light {
   --border-strong: #a3a3a3;
   --border-prominent: #525252;
   --text-primary: #171717;
-  --text-secondary: #525252;
-  /* Light tokens round-2 (PR8): tertiary further down from #737373 →
-     #6b6b6b (~5.4:1) — PR7's value cleared AA on paper but still read
-     as "dust" at 11px in live testing. Ghost stays at #d4d4d4 —
-     qa-lead caught that bumping ghost would promote decorative
-     usages (separators, dot backgrounds, gradient arrows) from
-     whisper to mid-tier. The two real labels that used ghost moved
-     to --text-tertiary instead. */
+  /* Light secondary round-3 nudge: #525252 → #444444. Same rationale
+     as the dark-mode bump — single targeted step on the tier that
+     touches the most body text. Ratios on bg-panel #f5f5f5: 7.4 →
+     8.93:1 (AAA); on bg-surface #ffffff: 7.81 → 9.74:1 (AAA). */
+  --text-secondary: #444444;
+  /* Light tertiary stays at #6b6b6b (~5.4:1) — was just lifted in the
+     PR8 round-2 cascade; further darkening here would close the
+     tertiary↔secondary gap. Future cleanup if tier balance needs
+     it. Ghost stays at #d4d4d4 (decoration-only). */
   --text-tertiary: #6b6b6b;
   --text-ghost: #d4d4d4;
   /* Light-theme danger foreground (~7.4:1 on --bg-elevated #f0f0f0) */
@@ -2045,12 +2046,14 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-log-line {
   padding: 0 12px;
   /* Log lines stay at 11px mono (industry-standard density — bumping
-     loses ~15-20% visible lines per scroll). The PR8 fix is contrast:
-     promote body text to --text-primary so the active payload reads
-     cleanly. Timestamps share the same color today — the line is one
-     pre-formatted string in PanelBottom. A follow-up could split the
-     timestamp prefix into its own span and dim it back to tertiary. */
-  color: var(--text-primary);
+     loses ~15-20% visible lines per scroll). Payload reads at
+     --text-secondary, not primary: post-PR8 secondary is
+     #a8a8a8 (8.33:1 dark on bg-panel) / #525252 (7.4:1 light), which
+     is materially brighter than the pre-PR8 #888 and matches the
+     "VS Code terminal" zone. Promoting to primary was the cee47488
+     fix that user feedback flagged as too attention-grabbing — log
+     is background telemetry and shouldn't compete with the dashboard. */
+  color: var(--text-secondary);
   white-space: pre;
 }
 .v10-log-line:hover { background: var(--bg-hover); }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -21,10 +21,14 @@
      whose bg is identical to a chip fill). */
   --border-prominent: #888888;
 
-  /* Text */
-  --text-primary: #e8e8e8;
-  --text-secondary: #888888;
-  --text-tertiary: #555555;
+  /* Text — dark mode. Bumped 2026-05-20 (PR7) to clear AA across all
+     three steps on --bg-panel #0a0a0a, and to tighten the visual gap
+     between secondary and primary (user reported "muted-to-disabled"
+     feel on the prior #888888). Contrast ratios: primary 15.9:1,
+     secondary 9.7:1, tertiary 6.7:1. */
+  --text-primary: #f0f0f0;
+  --text-secondary: #a8a8a8;
+  --text-tertiary: #8a8a8a;
   --text-ghost: #333333;
 
   /* Accent — reserved for signals */
@@ -96,7 +100,10 @@ body.light {
   --border-prominent: #525252;
   --text-primary: #171717;
   --text-secondary: #525252;
-  --text-tertiary: #a3a3a3;
+  /* Light-mode tertiary bumped #a3a3a3 → #737373 (2026-05-20 PR7) so it
+     clears AA on --bg-panel #f5f5f5 (5.0:1). Primary + secondary stay
+     unchanged — they were already AA-strong on light. */
+  --text-tertiary: #737373;
   --text-ghost: #d4d4d4;
   /* Light-theme danger foreground (~7.4:1 on --bg-elevated #f0f0f0) */
   --text-danger: #b91c1c;
@@ -353,7 +360,7 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-header-notif-item:hover { background: var(--bg-hover); }
 .v10-header-notif-item:last-child { border-bottom: none; }
 .v10-header-notif-item-text { font-size: 12px; color: var(--text-primary); }
-.v10-header-notif-item-time { font-size: 10px; color: var(--text-tertiary); margin-top: 2px; font-family: var(--font-mono); }
+.v10-header-notif-item-time { font-size: 11px; color: var(--text-tertiary); margin-top: 2px; font-family: var(--font-mono); }
 .v10-notif-join { border-left: 3px solid #f59e0b; padding-left: 9px; }
 .v10-notif-approved { border-left: 3px solid #10b981; padding-left: 9px; }
 .v10-notif-rejected { border-left: 3px solid #ef4444; padding-left: 9px; }
@@ -407,20 +414,12 @@ button:focus:not(:focus-visible) { outline: none; }
   align-items: center;
   padding: 0 12px;
   border-bottom: 1px solid var(--border-subtle);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
   letter-spacing: 1.2px;
   text-transform: uppercase;
   color: var(--text-tertiary);
 }
-.v10-collapse-btn {
-  margin-left: auto;
-  color: var(--text-tertiary);
-  transition: color 0.15s;
-  display: flex;
-  align-items: center;
-}
-.v10-collapse-btn:hover { color: var(--text-primary); }
 .v10-tree-content {
   flex: 1;
   overflow-y: auto;
@@ -478,14 +477,6 @@ button:focus:not(:focus-visible) { outline: none; }
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.v10-tree-section-badge {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--text-tertiary);
-  min-width: 18px;
-  text-align: right;
-}
-
 /* Hover-revealed "hide" affordance on each project row. Keeps the tree
    quiet by default and lets the user dismiss any leftover project from
    their sidebar without a daemon-side delete. */
@@ -586,7 +577,7 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-tree-mode-btn {
   padding: 0 10px;
   height: 100%;
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.5px;
   text-transform: uppercase;
@@ -616,7 +607,7 @@ button:focus:not(:focus-visible) { outline: none; }
 /* Layer headers inside project tree */
 .v10-tree-layer-header {
   padding: 3px 12px 3px 32px;
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.5px;
   text-transform: uppercase;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -22,16 +22,19 @@
   --border-prominent: #888888;
 
   /* Text — dark mode. Round-2 bump 2026-05-20 (PR8): the PR7 lift
-     (#8a8a8a tertiary, #333 ghost) still read as "footnotes" on a real
-     14"+ laptop screen. Pushed tertiary another step + lifted ghost
-     out of the sub-3:1 invisible band — it was decoration-only on
-     paper but used by real labels (.v10-tree-group-label, etc.).
-     Contrast ratios on --bg-panel #0a0a0a: primary 15.9:1,
-     secondary 9.7:1, tertiary ~7.1:1, ghost ~3.2:1. */
+     (#8a8a8a tertiary) still read as "footnotes" on a real 14"+ laptop
+     screen — pushed tertiary another step (~7.1:1). Ghost stays at the
+     pre-PR8 #333 — qa-lead caught that bumping ghost promoted ~50
+     decorative usages (separators, dot backgrounds, select-arrow
+     gradients) from "near-invisible whisper" to "mid-tier text". The
+     two real labels that used ghost (.v10-tree-group-label,
+     .v10-tree-layer-header) were moved to --text-tertiary instead, so
+     ghost can stay decoration-only. Ratios on --bg-panel #0a0a0a:
+     primary 15.9:1, secondary 9.7:1, tertiary ~7.1:1. */
   --text-primary: #f0f0f0;
   --text-secondary: #a8a8a8;
   --text-tertiary: #9a9a9a;
-  --text-ghost: #6a6a6a;
+  --text-ghost: #333333;
 
   /* Accent — reserved for signals */
   --accent-red: #ef4444;
@@ -104,12 +107,13 @@ body.light {
   --text-secondary: #525252;
   /* Light tokens round-2 (PR8): tertiary further down from #737373 →
      #6b6b6b (~5.4:1) — PR7's value cleared AA on paper but still read
-     as "dust" at 11px in live testing. Ghost lifted out of the
-     ~1.4:1 invisible band (the prior #d4d4d4 disappeared on bg-panel
-     #f5f5f5 — fine for borders, not for the labels that use it).
-     Ghost target ~3:1 — intentional de-emphasis but readable. */
+     as "dust" at 11px in live testing. Ghost stays at #d4d4d4 —
+     qa-lead caught that bumping ghost would promote decorative
+     usages (separators, dot backgrounds, gradient arrows) from
+     whisper to mid-tier. The two real labels that used ghost moved
+     to --text-tertiary instead. */
   --text-tertiary: #6b6b6b;
-  --text-ghost: #8a8a8a;
+  --text-ghost: #d4d4d4;
   /* Light-theme danger foreground (~7.4:1 on --bg-elevated #f0f0f0) */
   --text-danger: #b91c1c;
   --text-danger-hover: #991b1b;
@@ -1935,7 +1939,11 @@ button:focus:not(:focus-visible) { outline: none; }
   border: 0;
   background: transparent;
   color: var(--text-primary);
-  font-size: 12px;
+  /* Match the chat bubble (13px) — typed text and rendered reply
+     should read at the same size in the same column (qa-lead). The
+     global input/textarea rule (12px, mono) is for compact forms; the
+     chat composer is conversational. */
+  font-size: 13px;
   font-family: var(--font-sans);
   line-height: 1.5;
   min-width: 0;
@@ -1997,7 +2005,7 @@ button:focus:not(:focus-visible) { outline: none; }
   border-bottom: 2px solid transparent;
   transition: all 0.15s;
 }
-.v10-bottom-tab:hover { color: var(--text-secondary); }
+.v10-bottom-tab:hover { color: var(--text-primary); }
 .v10-bottom-tab.active { color: var(--text-primary); border-bottom-color: var(--text-secondary); }
 .v10-bottom-toggle {
   color: var(--text-tertiary);
@@ -2039,8 +2047,9 @@ button:focus:not(:focus-visible) { outline: none; }
   /* Log lines stay at 11px mono (industry-standard density — bumping
      loses ~15-20% visible lines per scroll). The PR8 fix is contrast:
      promote body text to --text-primary so the active payload reads
-     cleanly; the timestamp prefix can be styled separately by callers
-     that want quieter timestamps. */
+     cleanly. Timestamps share the same color today — the line is one
+     pre-formatted string in PanelBottom. A follow-up could split the
+     timestamp prefix into its own span and dim it back to tertiary. */
   color: var(--text-primary);
   white-space: pre;
 }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -119,12 +119,15 @@ body.light {
   --text-danger: #b91c1c;
   --text-danger-hover: #991b1b;
   --text-link: #1d4ed8;
-  /* `working` darkened from #a3a3a3 → #8a8a8a so the light-theme
-     proportion-bar segment has a visible edge (~3:1 vs the white card)
-     instead of near-invisible 2.0:1 — ui-lead PR6 layerbar note. */
-  --layer-working: #8a8a8a;
-  --layer-shared: #737373;
-  --layer-verified: #404040;
+  /* Layer accents are NOT overridden in light mode — the slate/amber/
+     green from :root carry through, matching the Context Graph and
+     project pages (which already use the unified palette in both
+     themes). The earlier PR6 desaturation to greys (#8a8a8a / #737373
+     / #404040) read as "weird variations of gray" against the white
+     dashboard card vs the colored CG pages; reverting per user
+     directive (PR8 round-4). Non-text contrast at small decoration
+     sizes is acceptable below AA's 3:1 floor — the bars/dots aren't
+     text. */
   --bg: var(--bg-root);
   --surface: var(--bg-surface);
   --surface-hover: var(--bg-hover);

--- a/packages/node-ui/test/panel-left.test.ts
+++ b/packages/node-ui/test/panel-left.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment happy-dom
+//
+// NOTE on mocking: PanelLeft pulls from `../src/ui/api.js` (current-agent +
+// local-agent integrations) and `../src/ui/api-wrapper.js` (context graphs
+// list). Both are mocked here so the test runs without a live daemon. All
+// stores (layout, projects, journey, tabs) are real — they're the unit
+// under test for the sidebar sections work.
+
+import React, { act } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+
+const fetchCurrentAgentMock = vi.fn();
+const fetchLocalAgentIntegrationsMock = vi.fn();
+const apiFetchContextGraphsMock = vi.fn();
+
+vi.mock('../src/ui/api.js', async () => {
+  const actual = await vi.importActual<any>('../src/ui/api.js');
+  return {
+    ...actual,
+    fetchCurrentAgent: fetchCurrentAgentMock,
+    fetchLocalAgentIntegrations: fetchLocalAgentIntegrationsMock,
+  };
+});
+
+vi.mock('../src/ui/api-wrapper.js', () => ({
+  api: {
+    fetchContextGraphs: apiFetchContextGraphsMock,
+  },
+}));
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe('PanelLeft — sidebar cleanup + collapsible sections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    localStorage.clear();
+    Element.prototype.scrollIntoView = vi.fn();
+    // useNodeEvents (used by PanelLeft) opens an EventSource on mount.
+    // happy-dom doesn't ship EventSource; stub it so the hook can no-op
+    // without throwing in the test container.
+    (globalThis as any).EventSource = class StubEventSource {
+      url: string;
+      readyState = 0;
+      onopen: ((e: any) => void) | null = null;
+      onmessage: ((e: any) => void) | null = null;
+      onerror: ((e: any) => void) | null = null;
+      constructor(url: string) { this.url = url; }
+      addEventListener() {}
+      removeEventListener() {}
+      close() {}
+    };
+
+    fetchCurrentAgentMock.mockResolvedValue({
+      agentAddress: 'agent-self',
+      agentDid: 'did:dkg:agent:peer-self',
+      name: 'Self',
+      peerId: 'peer-self',
+      nodeIdentityId: 'node-self',
+    });
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [] });
+    apiFetchContextGraphsMock.mockResolvedValue({
+      contextGraphs: [
+        // assetCount intentionally set to a non-zero value — the test
+        // verifies the badge is gone regardless of underlying data.
+        // callerInvolved short-circuits `belongsInMyProjectsSidebar`
+        // so the CG appears in the "My Context Graphs" section without
+        // needing an agent-identity resolve.
+        { id: 'cg-1', name: 'My First CG', assetCount: 42, callerInvolved: true },
+      ],
+    });
+  });
+
+  async function renderPanel() {
+    const { PanelLeft } = await import('../src/ui/components/Shell/PanelLeft.js');
+    const { useJourneyStore } = await import('../src/ui/stores/journey.js');
+    const { useProjectsStore } = await import('../src/ui/stores/projects.js');
+    const { useLayoutStore } = await import('../src/ui/stores/layout.js');
+    // Reset stores between tests so prior toggles don't leak.
+    act(() => {
+      useJourneyStore.setState({ stage: 2 });
+      useProjectsStore.setState({
+        // `callerInvolved: true` short-circuits the My-CG membership
+        // predicate (`belongsInMyProjectsSidebar`) without needing an
+        // agent-identity resolve — keeps the test pure-DOM, no async.
+        contextGraphs: [
+          { id: 'cg-1', name: 'My First CG', assetCount: 42, callerInvolved: true } as any,
+        ],
+        loading: false,
+        activeProjectId: null,
+      });
+      useLayoutStore.setState({
+        leftSectionMyProjectsOpen: true,
+        leftSectionIntegrationsOpen: false,
+      });
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(React.createElement(PanelLeft));
+    });
+    await flush();
+    await flush();
+    return { container, root };
+  }
+
+  it('does not render the in-panel ◂ collapse button (global header toggle is the sole control)', async () => {
+    const { container } = await renderPanel();
+    expect(container.querySelector('.v10-collapse-btn')).toBeNull();
+    // And the unicode glyph isn't rendered anywhere else (it would
+    // appear if a stray dev forgot to clean up the constant).
+    expect(container.textContent || '').not.toContain('◂');
+  });
+
+  it('does not render entity-count badges next to context-graph rows', async () => {
+    const { container } = await renderPanel();
+    expect(container.querySelector('.v10-tree-section-badge')).toBeNull();
+    // The row itself renders (it's the CG we seeded), so the absence
+    // is not just "nothing rendered at all".
+    expect(container.textContent).toContain('My First CG');
+  });
+
+  it('renders both section chevron headers with the v10-peer-group pattern', async () => {
+    const { container } = await renderPanel();
+    const headers = container.querySelectorAll('.v10-peer-group-header');
+    expect(headers.length).toBe(2);
+    const labels = Array.from(container.querySelectorAll('.v10-peer-group-label')).map((el) => el.textContent);
+    expect(labels).toEqual(['My Context Graphs', 'Integrations']);
+  });
+
+  it('expands "My Context Graphs" by default and keeps "Integrations" collapsed', async () => {
+    const { container } = await renderPanel();
+    const headers = container.querySelectorAll('.v10-peer-group-header');
+    const myCgHeader = headers[0] as HTMLButtonElement;
+    const integrationsHeader = headers[1] as HTMLButtonElement;
+    expect(myCgHeader.getAttribute('aria-expanded')).toBe('true');
+    expect(integrationsHeader.getAttribute('aria-expanded')).toBe('false');
+    // My CG body should be in the DOM (chevron expanded class + a row).
+    expect(container.querySelector('.v10-peer-group-chevron.expanded')).toBeTruthy();
+    expect(container.textContent).toContain('My First CG');
+    // Integrations body should NOT be in the DOM (lazy mount).
+    expect(container.textContent).not.toContain('Agents');
+  });
+
+  it('toggling a section updates the layout store and persists to localStorage', async () => {
+    const { useLayoutStore } = await import('../src/ui/stores/layout.js');
+    const { container } = await renderPanel();
+    // Sanity: initial store state matches DOM.
+    expect(useLayoutStore.getState().leftSectionMyProjectsOpen).toBe(true);
+    expect(useLayoutStore.getState().leftSectionIntegrationsOpen).toBe(false);
+
+    const headers = container.querySelectorAll('.v10-peer-group-header');
+    await act(async () => {
+      (headers[1] as HTMLButtonElement).click();
+    });
+    expect(useLayoutStore.getState().leftSectionIntegrationsOpen).toBe(true);
+    // The persist() helper debounces with a 150ms setTimeout; wait it out
+    // so the assertion sees the resolved write.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const persistedRaw = localStorage.getItem('dkg-layout');
+    expect(persistedRaw).toBeTruthy();
+    const persisted = JSON.parse(persistedRaw as string);
+    expect(persisted.leftSectionIntegrationsOpen).toBe(true);
+    expect(persisted.leftSectionMyProjectsOpen).toBe(true);
+  });
+});

--- a/packages/node-ui/test/panel-left.test.ts
+++ b/packages/node-ui/test/panel-left.test.ts
@@ -288,7 +288,13 @@ describe('PanelLeft — sidebar cleanup + collapsible sections', () => {
       // Advance past the polling interval. If cleanup leaked, the
       // setInterval callback would queue another loadLocal() and the
       // call count would bump. Mock-call counting is sync so no need
-      // to flush microtasks for the assertion.
+      // to flush microtasks for the assertion. NB: 31_000 sits BELOW
+      // PanelLeft's separate `setInterval(loadCGs, 60_000)` (which calls
+      // `fetchContextGraphs`, not `fetchLocalAgentIntegrations`, so the
+      // mock we assert on would be unaffected even if it fired). Keep
+      // this gap if either constant moves — the polling-halt cleanup
+      // proof depends on advancing *just enough* to fire Integrations
+      // polling but not the unrelated CG-list refresh.
       await act(async () => {
         vi.advanceTimersByTime(31_000);
       });

--- a/packages/node-ui/test/panel-left.test.ts
+++ b/packages/node-ui/test/panel-left.test.ts
@@ -169,4 +169,115 @@ describe('PanelLeft — sidebar cleanup + collapsible sections', () => {
     expect(persisted.leftSectionIntegrationsOpen).toBe(true);
     expect(persisted.leftSectionMyProjectsOpen).toBe(true);
   });
+
+  it('still renders the "My Context Graphs" header when the membership filter yields zero (with empty-body hint)', async () => {
+    // qa-lead Pass 1 #2: at stage>=2 with CGs that all live in the
+    // Context Oracle view (no callerInvolved match), the sidebar must
+    // still surface the My CG header so the user has a visible anchor —
+    // otherwise it shrinks to a lone collapsed "Integrations" toggle.
+    const { PanelLeft } = await import('../src/ui/components/Shell/PanelLeft.js');
+    const { useJourneyStore } = await import('../src/ui/stores/journey.js');
+    const { useProjectsStore } = await import('../src/ui/stores/projects.js');
+    const { useLayoutStore } = await import('../src/ui/stores/layout.js');
+    apiFetchContextGraphsMock.mockResolvedValue({
+      contextGraphs: [{ id: 'cg-x', name: 'Catalog Only CG', callerInvolved: false } as any],
+    });
+    act(() => {
+      useJourneyStore.setState({ stage: 2 });
+      useProjectsStore.setState({
+        contextGraphs: [{ id: 'cg-x', name: 'Catalog Only CG', callerInvolved: false } as any],
+        loading: false,
+        activeProjectId: null,
+      });
+      useLayoutStore.setState({
+        leftSectionMyProjectsOpen: true,
+        leftSectionIntegrationsOpen: false,
+      });
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(React.createElement(PanelLeft));
+    });
+    await flush();
+    await flush();
+
+    const labels = Array.from(container.querySelectorAll('.v10-peer-group-label')).map((el) => el.textContent);
+    expect(labels).toContain('My Context Graphs');
+    expect(container.textContent).toContain('No context graphs in this view yet.');
+    // The catalog-only CG should NOT render as a row in this section.
+    expect(container.textContent).not.toContain('Catalog Only CG');
+  });
+
+  it('section headers point at their body containers via aria-controls', async () => {
+    const { container } = await renderPanel();
+    const headers = container.querySelectorAll('.v10-peer-group-header');
+    const myCgHeader = headers[0] as HTMLButtonElement;
+    const integrationsHeader = headers[1] as HTMLButtonElement;
+    const myCgControls = myCgHeader.getAttribute('aria-controls');
+    const integrationsControls = integrationsHeader.getAttribute('aria-controls');
+    expect(myCgControls).toBeTruthy();
+    expect(integrationsControls).toBeTruthy();
+    // The id pointed at by aria-controls of the (open) My CG header
+    // must exist in the DOM.
+    expect(container.querySelector(`#${myCgControls}`)).toBeTruthy();
+    // Integrations is collapsed by default → its body is unmounted, so
+    // the id is currently absent (aria-controls is still allowed to
+    // reference a not-yet-rendered region per WAI-ARIA).
+    expect(container.querySelector(`#${integrationsControls}`)).toBeNull();
+  });
+
+  it('opening Integrations triggers the local-integrations fetch; closing it halts further polls', async () => {
+    // qa-lead Pass 2 #10: validate the design claim that
+    // `IntegrationsSectionBody` only polls while mounted. The body lives
+    // inside the section header, so toggling the header off unmounts it
+    // and the 30s setInterval is cleaned up by React's effect-cleanup.
+    const { container } = await renderPanel();
+    const headers = container.querySelectorAll('.v10-peer-group-header');
+    const integrationsHeader = headers[1] as HTMLButtonElement;
+
+    // Open Integrations — the body mounts and fires its first fetch.
+    await act(async () => {
+      integrationsHeader.click();
+    });
+    await flush();
+    expect(fetchLocalAgentIntegrationsMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    const callsAfterOpen = fetchLocalAgentIntegrationsMock.mock.calls.length;
+
+    // Close it — the body unmounts and the interval is cleared.
+    await act(async () => {
+      integrationsHeader.click();
+    });
+    await flush();
+    // No new fetches should be issued while collapsed. We don't have to
+    // advance a 30s timer to prove this: the body is gone from the DOM,
+    // so the setInterval callback cannot be queued at all.
+    expect(container.textContent).not.toContain('Agents');
+    // A small idle wait — no fetch should fire from the collapsed state.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fetchLocalAgentIntegrationsMock.mock.calls.length).toBe(callsAfterOpen);
+  });
+
+  it('hydrates section open-state defaults when a pre-existing dkg-layout blob lacks the new fields', async () => {
+    // Simulates an upgrade from before PR7: the user already has a
+    // `dkg-layout` blob with the original fields but no
+    // leftSectionMyProjectsOpen / leftSectionIntegrationsOpen. The
+    // layout store's loadPersisted should backfill both with their
+    // defaults (My CG open, Integrations closed) so the user doesn't
+    // boot into a broken state.
+    vi.resetModules();
+    localStorage.setItem('dkg-layout', JSON.stringify({
+      leftCollapsed: false,
+      rightCollapsed: false,
+      bottomCollapsed: true,
+      leftWidth: 240,
+      rightWidth: 360,
+      bottomHeight: 200,
+      // Intentionally NO leftSectionMyProjectsOpen / leftSectionIntegrationsOpen.
+    }));
+    const { useLayoutStore } = await import('../src/ui/stores/layout.js');
+    expect(useLayoutStore.getState().leftSectionMyProjectsOpen).toBe(true);
+    expect(useLayoutStore.getState().leftSectionIntegrationsOpen).toBe(false);
+  });
 });

--- a/packages/node-ui/test/panel-left.test.ts
+++ b/packages/node-ui/test/panel-left.test.ts
@@ -7,8 +7,8 @@
 // under test for the sidebar sections work.
 
 import React, { act } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
 
 const fetchCurrentAgentMock = vi.fn();
 const fetchLocalAgentIntegrationsMock = vi.fn();
@@ -35,7 +35,28 @@ async function flush(): Promise<void> {
   });
 }
 
+// Cross-test cleanup registry. PanelLeft spins up a 60s polling interval
+// (`loadCGs`) and subscribes to `useNodeEvents` on mount — without an
+// explicit unmount, those listeners + timers leak into the next test and
+// can produce flaky extra mock calls (qa-lead / Codex).
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
 describe('PanelLeft — sidebar cleanup + collapsible sections', () => {
+  afterEach(() => {
+    // Unmount in reverse-mount order so any teardown effects fire in the
+    // expected sequence. Wrap each unmount in `act` so React's flush
+    // (effects, microtasks) completes before the next test runs.
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -102,6 +123,8 @@ describe('PanelLeft — sidebar cleanup + collapsible sections', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
+    mountedRoots.push(root);
+    mountedContainers.push(container);
     await act(async () => {
       root.render(React.createElement(PanelLeft));
     });
@@ -197,6 +220,8 @@ describe('PanelLeft — sidebar cleanup + collapsible sections', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
+    mountedRoots.push(root);
+    mountedContainers.push(container);
     await act(async () => {
       root.render(React.createElement(PanelLeft));
     });
@@ -220,12 +245,14 @@ describe('PanelLeft — sidebar cleanup + collapsible sections', () => {
     expect(myCgControls).toBeTruthy();
     expect(integrationsControls).toBeTruthy();
     // The id pointed at by aria-controls of the (open) My CG header
-    // must exist in the DOM.
-    expect(container.querySelector(`#${myCgControls}`)).toBeTruthy();
+    // must exist in the DOM. `useId()` returns ids shaped like ":r0:"
+    // which aren't valid CSS selectors — use getElementById, not
+    // querySelector (Codex).
+    expect(document.getElementById(myCgControls!)).toBeTruthy();
     // Integrations is collapsed by default → its body is unmounted, so
     // the id is currently absent (aria-controls is still allowed to
     // reference a not-yet-rendered region per WAI-ARIA).
-    expect(container.querySelector(`#${integrationsControls}`)).toBeNull();
+    expect(document.getElementById(integrationsControls!)).toBeNull();
   });
 
   it('opening Integrations triggers the local-integrations fetch; closing it halts further polls', async () => {

--- a/packages/node-ui/test/panel-left.test.ts
+++ b/packages/node-ui/test/panel-left.test.ts
@@ -256,34 +256,46 @@ describe('PanelLeft — sidebar cleanup + collapsible sections', () => {
   });
 
   it('opening Integrations triggers the local-integrations fetch; closing it halts further polls', async () => {
-    // qa-lead Pass 2 #10: validate the design claim that
-    // `IntegrationsSectionBody` only polls while mounted. The body lives
-    // inside the section header, so toggling the header off unmounts it
-    // and the 30s setInterval is cleaned up by React's effect-cleanup.
-    const { container } = await renderPanel();
-    const headers = container.querySelectorAll('.v10-peer-group-header');
-    const integrationsHeader = headers[1] as HTMLButtonElement;
+    // qa-lead Pass 2 #10 + Codex follow-up: validate the design claim
+    // that `IntegrationsSectionBody` only polls while mounted by
+    // actually advancing past the 30s setInterval after collapse.
+    // `shouldAdvanceTime: true` lets microtask/render flushes still
+    // resolve on real time, while explicit advanceTimersByTime jumps
+    // the polling clock — so a leaked setInterval would visibly bump
+    // the mock call count.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { container } = await renderPanel();
+      const headers = container.querySelectorAll('.v10-peer-group-header');
+      const integrationsHeader = headers[1] as HTMLButtonElement;
 
-    // Open Integrations — the body mounts and fires its first fetch.
-    await act(async () => {
-      integrationsHeader.click();
-    });
-    await flush();
-    expect(fetchLocalAgentIntegrationsMock.mock.calls.length).toBeGreaterThanOrEqual(1);
-    const callsAfterOpen = fetchLocalAgentIntegrationsMock.mock.calls.length;
+      // Open Integrations — the body mounts and fires its first fetch.
+      await act(async () => {
+        integrationsHeader.click();
+      });
+      await flush();
+      expect(fetchLocalAgentIntegrationsMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+      const callsAfterOpen = fetchLocalAgentIntegrationsMock.mock.calls.length;
 
-    // Close it — the body unmounts and the interval is cleared.
-    await act(async () => {
-      integrationsHeader.click();
-    });
-    await flush();
-    // No new fetches should be issued while collapsed. We don't have to
-    // advance a 30s timer to prove this: the body is gone from the DOM,
-    // so the setInterval callback cannot be queued at all.
-    expect(container.textContent).not.toContain('Agents');
-    // A small idle wait — no fetch should fire from the collapsed state.
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(fetchLocalAgentIntegrationsMock.mock.calls.length).toBe(callsAfterOpen);
+      // Close it — the body unmounts and React's effect cleanup should
+      // clear the 30s setInterval.
+      await act(async () => {
+        integrationsHeader.click();
+      });
+      await flush();
+      expect(container.textContent).not.toContain('Agents');
+
+      // Advance past the polling interval. If cleanup leaked, the
+      // setInterval callback would queue another loadLocal() and the
+      // call count would bump. Mock-call counting is sync so no need
+      // to flush microtasks for the assertion.
+      await act(async () => {
+        vi.advanceTimersByTime(31_000);
+      });
+      expect(fetchLocalAgentIntegrationsMock.mock.calls.length).toBe(callsAfterOpen);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('hydrates section open-state defaults when a pre-existing dkg-layout blob lacks the new fields', async () => {


### PR DESCRIPTION
## Summary

Two related improvements in the same area of the node-UI.

### Sidebar cleanup

- **Remove the in-panel ◂ collapse button.** It duplicated the global top-left sidebar toggle in `Header.tsx`, which stays visible regardless of `leftCollapsed`. One toggle path now.
- **Remove the broken entity-count badge** next to every "My Context Graphs" row. The asset count is already shown in the Dashboard, and the in-sidebar badge wasn't wired to a live count anyway.
- **Promote "Integrations"** from an orphaned bottom accordion into a **sibling section** of "My Context Graphs". Both sections now use the polished `.v10-peer-group-*` chevron pattern from the right panel — focus-visible-ready, button semantics, lucide `ChevronRight`.
- **Both sections are collapsible.** Defaults: My CG expanded; Integrations collapsed (escape-hatch surface — collapsing also pauses its 30s polling effect, since the body is only mounted while open).
- **Section state persisted** alongside `leftCollapsed` in the same `dkg-layout` localStorage blob via two new booleans on the layout store.
- **Empty-state card hoisted** above both sections so it stays visible when both are collapsed.

### Dark + light contrast lift

`--text-tertiary: #555555` on `--bg-panel: #0a0a0a` was 2.9:1 — failed AA for normal text and even for large. Multiple 10px texts paired with tertiary doubled the strain. `--text-secondary: #888888` at 6.5:1 passed AA but read "muted to disabled" against primary. Light mode had the same defect class: `#a3a3a3` on `#f5f5f5` ≈ 2.5:1.

| Token | Mode | Before | After | Ratio |
|---|---|---|---|---|
| `--text-primary` | dark | `#e8e8e8` | `#f0f0f0` | 15.9:1 |
| `--text-secondary` | dark | `#888888` | `#a8a8a8` | 9.7:1 |
| `--text-tertiary` | dark | `#555555` | `#8a8a8a` | 6.7:1 |
| `--text-tertiary` | light | `#a3a3a3` | `#737373` | 5.0:1 |

Surgical font-size bumps 10px → 11px on 5 worst-offender classes + 2 inline tertiary spans.

### Out of scope (explicit deferrals)

- `--font-size-*` scale-token migration (60+ literal-px sites).
- `--text-ghost` audit (decorative-only).
- Placeholder-vs-text disambiguation if tertiary at 6.7:1 reads too "filled."

## Pre-implementation team review

Both UX-lead and UI-lead validated the design before any code landed. UX-lead picked Integrations-default-collapsed + the `.v10-peer-group-*` pattern + per-section localStorage persistence. UI-lead picked the exact hex values, the surgical font-size strategy, and the symmetric light-mode bump.

## Test plan

- [x] `pnpm -F @origintrail-official/dkg-node-ui exec tsc --noEmit` — clean
- [x] `pnpm -F @origintrail-official/dkg-node-ui exec vitest run --no-file-parallelism` — 675 / 675 across 37 files
- [x] New `test/panel-left.test.ts` — 5 cases (no triangle, no badges, both chevron headers, default open states, layout-store persistence on toggle)
- [ ] Manual against the live dev server (large laptop, 100% scale): dark + light mode contrast pass, toggling sections persists across reload, triangle button is gone but global toggle still works, narrow panel renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)