### PR TITLE
fix(node-ui): fill context graph route panel

### DIFF
--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -2974,7 +2974,7 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-memory-explorer-page .v10-cg-query-view {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: auto;
 }
 .v10-cg-query-editor {
   display: grid;
@@ -3073,7 +3073,7 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-mlv-table-wrap { overflow-x: auto; border: 1px solid var(--border-default); border-radius: 8px; }
 .v10-cg-query-results {
   flex: 1 1 auto;
-  min-height: 0;
+  min-height: 180px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -3906,7 +3906,10 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   flex-direction: column;
   overflow: hidden;
 }
-.v10-memory-explorer-page[data-view="overview"] {
+.v10-memory-explorer-page[data-view="overview"],
+.v10-memory-explorer-page[data-view="query"],
+.v10-memory-explorer-page[data-view="entity"],
+.v10-memory-explorer-page[data-view="subgraph"] {
   overflow: auto;
 }
 .v10-memory-explorer-page > .v10-layer-detail,
@@ -3925,6 +3928,10 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   display: flex;
   align-items: center;
   justify-content: center;
+}
+.v10-memory-explorer-page[data-view="entity"] > .v10-ka-detail,
+.v10-memory-explorer-page[data-view="subgraph"] > .v10-layer-detail {
+  min-height: 420px;
 }
 
 /* ── Trust Summary ── */

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -2971,6 +2971,11 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-mlv-query-input:focus { border-color: var(--border-strong); }
 .v10-cg-query-view { max-width: 1180px; }
+.v10-memory-explorer-page .v10-cg-query-view {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
 .v10-cg-query-editor {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -3066,6 +3071,25 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-mlv-empty { padding: 32px 0; text-align: center; }
 .v10-mlv-empty p { font-size: 12px; color: var(--text-tertiary); }
 .v10-mlv-table-wrap { overflow-x: auto; border: 1px solid var(--border-default); border-radius: 8px; }
+.v10-cg-query-results {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.v10-cg-query-results .v10-mlv-empty {
+  flex: 1 1 auto;
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.v10-cg-query-results .v10-mlv-table-wrap {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
 .v10-mlv-table { width: 100%; border-collapse: collapse; font-size: 12px; }
 .v10-mlv-table thead { background: var(--bg-elevated); }
 .v10-mlv-table th {
@@ -3874,6 +3898,34 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   display: flex; flex-direction: column; height: 100%; min-height: 0;
   max-width: none; margin: -24px -28px; overflow: hidden;
 }
+.v10-memory-explorer-page {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.v10-memory-explorer-page[data-view="overview"] {
+  overflow: auto;
+}
+.v10-memory-explorer-page > .v10-layer-detail,
+.v10-memory-explorer-page > .v10-ka-detail,
+.v10-memory-explorer-page > .v10-sgov,
+.v10-memory-explorer-page > .v10-memory-layer-view {
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+}
+.v10-memory-explorer-page > .v10-sgov-empty,
+.v10-memory-explorer-page > .v10-sgov-loading {
+  flex: 1 1 auto;
+  min-height: 220px;
+  margin: 0 12px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 
 /* ── Trust Summary ── */
 .v10-trust-summary { padding: 8px 16px; border-bottom: 1px solid var(--border-subtle); flex-shrink: 0; }
@@ -3908,6 +3960,7 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
 .v10-subgraph-bar {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
   gap: 8px;
   flex-wrap: wrap;
   padding: 8px 12px;
@@ -4629,6 +4682,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   overflow-y: auto;
 }
 .v10-entity-list.empty {
+  flex: 1 1 auto;
   display: flex; align-items: center; justify-content: center;
   padding: 32px 16px;
 }
@@ -4965,6 +5019,17 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-docs-placeholder {
   flex: 1; display: flex; align-items: center; justify-content: center;
   color: var(--text-ghost); font-size: 12px;
+}
+.v10-layer-state {
+  flex: 1 1 auto;
+  min-height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  color: var(--text-ghost);
+  font-size: 12px;
+  text-align: center;
 }
 .v10-items-list { padding: 0; }
 
@@ -5612,6 +5677,9 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   font-size: 12px; color: var(--text-tertiary); font-style: italic;
   padding: 8px 0;
 }
+.v10-overview-activity.v10-activity-feed-empty {
+  min-height: 140px;
+}
 .v10-activity-feed-bucket { display: flex; flex-direction: column; gap: 4px; }
 .v10-activity-feed-bucket-head {
   display: flex; align-items: center; gap: 8px;
@@ -6100,6 +6168,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 /* ── Persistent project header strip ── */
 .v10-project-strip {
   display: flex; align-items: center; gap: 10px;
+  flex-shrink: 0;
   padding: 8px 16px;
   border-bottom: 1px solid var(--border-subtle);
   background: linear-gradient(

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -143,6 +143,11 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // Active sub-graph binding (for the breadcrumb strip) — stays in scope
   // across sub-graph / layer / overview routes.
   const activeSubGraphBinding = activeSubGraph ? profile.forSubGraph(activeSubGraph) : null;
+  const activePage = selectedEntity
+    ? 'entity'
+    : activeSubGraph
+      ? 'subgraph'
+      : activeLayer;
 
   return (
     <ProjectProfileContext.Provider value={profile}>
@@ -170,8 +175,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
         onRefresh={rawMemory.refresh}
       />
 
-
-
+      <main className="v10-memory-explorer-page" data-view={activePage}>
       {/* Drilldown overlay */}
       {selectedEntity && (
         <KADetailView
@@ -230,6 +234,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             limit={40}
             includeUndated={false}
             emptyHint="Once agents start proposing decisions or tasks they'll show up here as a live feed."
+            className="v10-overview-activity"
           />
           <MemoryStrip
             memory={rawMemory}
@@ -274,6 +279,8 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           />
         </>
       )}
+
+      </main>
 
       {/* Provenance Bar */}
       <ProvenanceBar memory={rawMemory} />

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1578,43 +1578,45 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
       {saveMessage && <p className="v10-mlv-status" style={{ color: 'var(--accent-green)' }}>{saveMessage}</p>}
       {saveError && <p className="v10-mlv-status" style={{ color: 'var(--accent-red)' }}>{saveError}</p>}
 
-      {loading && <p className="v10-mlv-status">Loading...</p>}
-      {error && <p className="v10-mlv-status" style={{ color: 'var(--accent-red)' }}>Error: {error}</p>}
+      <div className="v10-cg-query-results">
+        {loading && <p className="v10-mlv-status">Loading...</p>}
+        {error && <p className="v10-mlv-status" style={{ color: 'var(--accent-red)' }}>Error: {error}</p>}
 
-      {!loading && !error && rows.length === 0 && (
-        <div className="v10-mlv-empty">
-          <p>No results for this query.</p>
-        </div>
-      )}
+        {!loading && !error && rows.length === 0 && (
+          <div className="v10-mlv-empty">
+            <p>No results for this query.</p>
+          </div>
+        )}
 
-      {!loading && !error && rows.length > 0 && (
-        <div className="v10-mlv-table-wrap">
-          <div className="v10-mlv-result-count">{rows.length} result{rows.length === 1 ? '' : 's'}</div>
-          <table className="v10-mlv-table">
-            <thead>
-              <tr>
-                {columns.map((column) => (
-                  <th key={column}>{column}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row: Record<string, unknown>, index: number) => (
-                <tr key={index}>
-                  {columns.map((column) => {
-                    const value = bindingValue(row[column]);
-                    return (
-                      <td key={column} className="v10-mlv-cell" title={value}>
-                        {shortenBindingValue(value)}
-                      </td>
-                    );
-                  })}
+        {!loading && !error && rows.length > 0 && (
+          <div className="v10-mlv-table-wrap">
+            <div className="v10-mlv-result-count">{rows.length} result{rows.length === 1 ? '' : 's'}</div>
+            <table className="v10-mlv-table">
+              <thead>
+                <tr>
+                  {columns.map((column) => (
+                    <th key={column}>{column}</th>
+                  ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+              </thead>
+              <tbody>
+                {rows.map((row: Record<string, unknown>, index: number) => (
+                  <tr key={index}>
+                    {columns.map((column) => {
+                      const value = bindingValue(row[column]);
+                      return (
+                        <td key={column} className="v10-mlv-cell" title={value}>
+                          {shortenBindingValue(value)}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -1683,11 +1685,11 @@ export function AssertionsList({ contextGraphId, layer, onComplete }: {
   }, [assertions, contextGraphId, layer, refresh, onComplete]);
 
   if (loading) {
-    return <div style={{ padding: 24, textAlign: 'center', color: 'var(--text-ghost)', fontSize: 12 }}>Loading assertions...</div>;
+    return <div className="v10-layer-state">Loading assertions...</div>;
   }
 
   if (!assertions?.length) {
-    return <div style={{ padding: 24, textAlign: 'center', color: 'var(--text-ghost)', fontSize: 12 }}>No assertions in this layer</div>;
+    return <div className="v10-layer-state">No assertions in this layer</div>;
   }
 
   const actionLabel = layer === 'wm' ? 'Promote → Shared' : 'Publish to VM';


### PR DESCRIPTION
## Summary

- Implements PR 1.1 / M7 from the Context Graph UX/UI rollout by giving `ProjectView` one bounded route-page flex shell between persistent project chrome and the provenance bar.
- Keeps the project strip, layer switcher, and provenance bar pinned while Overview, graph overview, query, layer views, sub-graph views, and entity detail own the remaining panel space.
- Contains sparse states and query/table results inside their page regions so loading/empty content no longer floats above unused panel space.

## Related

- Context Graph UX/UI redesign rollout: M7 pages fill panel / flex shell.
- No GitHub issue linked.

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/views/ProjectView.tsx` | Wraps routed Context Graph content in `.v10-memory-explorer-page` and tags the active route for layout styling. |
| `packages/node-ui/src/ui/views/project/components.tsx` | Gives query results and assertion loading/empty states bounded route regions. |
| `packages/node-ui/src/ui/styles.css` | Adds the flex-shell contract, centered in-panel empty/loading states, query result overflow containment, and fixed chrome sizing. |

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @origintrail-official/dkg-core run build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build`
- [x] `pnpm --filter @origintrail-official/dkg-graph-viz run build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/ui-compat.test.ts test/use-memory-entities-live-updates.test.ts test/use-memory-entities-partial.test.ts`
- [x] `git diff --check`
- [x] Live-node Vite/Playwright walkthrough against `Hello World`: Overview, WM, Graph Overview empty state, Query, VM, and 900x700 responsive sizing all stayed within the panel with persistent chrome.
- [x] Local PR review with GPT 5.5 xhigh reviewer: no actionable findings.

Known non-blocking note: full `pnpm --filter @origintrail-official/dkg-node-ui test` ran 36 files / 678 passing tests / 38 skipped tests, with one unrelated timeout in `test/openclaw-bridge.test.ts` outside the touched files.