### PR TITLE
fix(node-ui): restore context graph detail origins

### DIFF
--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback, useEffect } from 'react';
+import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { useFetch } from '../hooks.js';
 import { api } from '../api-wrapper.js';
 import { listParticipants } from '../api.js';
@@ -10,7 +10,7 @@ import { useAgents, AgentsContext } from '../hooks/useAgents.js';
 import { ActivityFeed } from '../components/ActivityFeed.js';
 import { SubGraphBar } from '../components/SubGraphBar.js';
 import { useTabsStore } from '../stores/tabs.js';
-import type { LayerView } from './project/helpers.js';
+import type { LayerView, LayerContentTab, SubGraphTab } from './project/helpers.js';
 import {
   ProjectHeaderStrip,
   LayerSwitcher,
@@ -29,6 +29,35 @@ interface ProjectViewProps {
   contextGraphId: string;
 }
 
+type MemoryLayerView = Extract<LayerView, 'wm' | 'swm' | 'vm'>;
+
+interface DetailOrigin {
+  activeLayer: LayerView;
+  activeSubGraph: string | null;
+  layerTabs: Record<MemoryLayerView, LayerContentTab>;
+  subGraphTabs: Record<string, SubGraphTab>;
+  scroll: { key: string; top: number };
+}
+
+const DEFAULT_LAYER_TABS: Record<MemoryLayerView, LayerContentTab> = {
+  wm: 'items',
+  swm: 'items',
+  vm: 'items',
+};
+
+function isMemoryLayerView(layer: LayerView): layer is MemoryLayerView {
+  return layer === 'wm' || layer === 'swm' || layer === 'vm';
+}
+
+function scrollSelector(key: string): string {
+  return `[data-cg-scroll-key="${key.replace(/"/g, '\\"')}"]`;
+}
+
+function scrollElementFor(key: string, fallback: HTMLElement | null): HTMLElement | null {
+  if (typeof document === 'undefined') return fallback;
+  return document.querySelector<HTMLElement>(scrollSelector(key)) ?? fallback;
+}
+
 export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const { data: cgData } = useFetch(api.fetchContextGraphs, [], 30_000);
   const [showImport, setShowImport] = useState(false);
@@ -41,9 +70,69 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // a sibling of `activeLayer`, not a filter over it: sub-graphs are a peer
   // axis to layers, and each axis gets its own first-class page.
   const [activeSubGraph, setActiveSubGraph] = useState<string | null>(null);
+  const [layerContentTabs, setLayerContentTabs] = useState<Record<MemoryLayerView, LayerContentTab>>(
+    DEFAULT_LAYER_TABS,
+  );
+  const [subGraphTabs, setSubGraphTabs] = useState<Record<string, SubGraphTab>>({});
+  const pageRef = useRef<HTMLElement | null>(null);
+  const detailOriginRef = useRef<DetailOrigin | null>(null);
+  const pendingScrollRestoreRef = useRef<DetailOrigin['scroll'] | null>(null);
   const profile = useProjectProfile(contextGraphId);
   const agentsData = useAgents(contextGraphId);
   const openTab = useTabsStore((s) => s.openTab);
+
+  const currentScrollKey = useCallback(() => {
+    if (activeSubGraph) {
+      return `subgraph:${activeSubGraph}:${subGraphTabs[activeSubGraph] ?? 'items'}`;
+    }
+    if (isMemoryLayerView(activeLayer)) {
+      return `layer:${activeLayer}:${layerContentTabs[activeLayer]}`;
+    }
+    return 'page';
+  }, [activeLayer, activeSubGraph, layerContentTabs, subGraphTabs]);
+
+  const captureDetailOrigin = useCallback((): DetailOrigin => {
+    const key = currentScrollKey();
+    const scrollEl = scrollElementFor(key, pageRef.current);
+    return {
+      activeLayer,
+      activeSubGraph,
+      layerTabs: { ...layerContentTabs },
+      subGraphTabs: { ...subGraphTabs },
+      scroll: { key, top: scrollEl?.scrollTop ?? 0 },
+    };
+  }, [activeLayer, activeSubGraph, currentScrollKey, layerContentTabs, subGraphTabs]);
+
+  const restoreScroll = useCallback((scroll: DetailOrigin['scroll']) => {
+    const restore = () => {
+      const scrollEl = scrollElementFor(scroll.key, pageRef.current);
+      if (scrollEl) scrollEl.scrollTop = scroll.top;
+    };
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(restore);
+    } else {
+      setTimeout(restore, 0);
+    }
+  }, []);
+
+  const openEntityDetail = useCallback((uri: string) => {
+    if (!selectedUri || !detailOriginRef.current) {
+      detailOriginRef.current = captureDetailOrigin();
+    }
+    setSelectedUri(uri);
+  }, [captureDetailOrigin, selectedUri]);
+
+  const clearDetailOrigin = useCallback(() => {
+    detailOriginRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    if (selectedUri) return;
+    const scroll = pendingScrollRestoreRef.current;
+    if (!scroll) return;
+    pendingScrollRestoreRef.current = null;
+    restoreScroll(scroll);
+  }, [selectedUri, activeLayer, activeSubGraph, layerContentTabs, subGraphTabs, restoreScroll]);
 
   // Cross-tab entity open — e.g. the agent profile page in another tab
   // fires a CustomEvent("v10:open-entity", { contextGraphId, entityUri })
@@ -55,11 +144,11 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
       if (!detail) return;
       if (detail.contextGraphId !== contextGraphId) return;
       if (typeof detail.entityUri !== 'string') return;
-      setSelectedUri(detail.entityUri);
+      openEntityDetail(detail.entityUri);
     };
     window.addEventListener('v10:open-entity', handler);
     return () => window.removeEventListener('v10:open-entity', handler);
-  }, [contextGraphId]);
+  }, [contextGraphId, openEntityDetail]);
 
   const openAgent = useCallback((uri: string) => {
     const slug = uri.startsWith('urn:dkg:agent:')
@@ -107,26 +196,44 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // (null) exits the page back to the current layer view, or overview if
   // we were already on one.
   const handleSelectSubGraph = useCallback((slug: string | null) => {
+    clearDetailOrigin();
     setActiveSubGraph(slug);
     setSelectedUri(null);
+  }, [clearDetailOrigin]);
+
+  const handleLayerSwitch = useCallback((layer: LayerView) => {
+    clearDetailOrigin();
+    setActiveLayer(layer);
+    setSelectedUri(null);
+    setActiveSubGraph(null);
+  }, [clearDetailOrigin]);
+
+  const handleLayerTabChange = useCallback((layer: MemoryLayerView, tab: LayerContentTab) => {
+    setLayerContentTabs(prev => prev[layer] === tab ? prev : { ...prev, [layer]: tab });
   }, []);
 
-  // Cross-sub-graph jump: when the user clicks an entity link that lives
-  // in a different sub-graph, switch pages and open the entity detail.
-  // Falls back to just opening the detail if the entity has no sub-graph
-  // origin (SWM/VM entities without WM presence).
+  const handleSubGraphTabChange = useCallback((slug: string, tab: SubGraphTab) => {
+    setSubGraphTabs(prev => prev[slug] === tab ? prev : { ...prev, [slug]: tab });
+  }, []);
+
+  // M2 keeps the user's origin stable: linked entities open in the detail
+  // pane, but the underlying layer/sub-graph page does not silently change
+  // until S5 adds breadcrumbs that can make that movement visible.
   const handleNavigate = useCallback((uri: string) => {
-    const target = rawMemory.entities.get(uri);
-    if (target && target.subGraphs.size > 0) {
-      // Prefer the active sub-graph if the entity lives in it (stay put);
-      // otherwise hop to the first sub-graph it belongs to.
-      if (!activeSubGraph || !target.subGraphs.has(activeSubGraph)) {
-        const next = target.subGraphs.values().next().value;
-        if (next && next !== 'meta') setActiveSubGraph(next);
-      }
-    }
-    setSelectedUri(uri);
-  }, [rawMemory.entities, activeSubGraph]);
+    openEntityDetail(uri);
+  }, [openEntityDetail]);
+
+  const handleDetailClose = useCallback(() => {
+    const origin = detailOriginRef.current;
+    detailOriginRef.current = null;
+    setSelectedUri(null);
+    if (!origin) return;
+    setActiveLayer(origin.activeLayer);
+    setActiveSubGraph(origin.activeSubGraph);
+    setLayerContentTabs(origin.layerTabs);
+    setSubGraphTabs(origin.subGraphTabs);
+    pendingScrollRestoreRef.current = origin.scroll;
+  }, []);
 
   const handleNodeClick = useCallback((node: any) => {
     if (node?.id) handleNavigate(node.id);
@@ -169,13 +276,13 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
       <LayerSwitcher
         active={activeLayer}
         counts={rawMemory.counts}
-        onSwitch={v => { setActiveLayer(v); setSelectedUri(null); setActiveSubGraph(null); }}
+        onSwitch={handleLayerSwitch}
         onShare={() => setShowShare(true)}
         onImport={() => setShowImport(true)}
         onRefresh={rawMemory.refresh}
       />
 
-      <main className="v10-memory-explorer-page" data-view={activePage}>
+      <main className="v10-memory-explorer-page" data-view={activePage} data-cg-scroll-key="page" ref={pageRef}>
       {/* Drilldown overlay */}
       {selectedEntity && (
         <KADetailView
@@ -183,7 +290,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           allEntities={rawMemory.entities}
           allTriples={rawMemory.graphTriples}
           onNavigate={handleNavigate}
-          onClose={() => setSelectedUri(null)}
+          onClose={handleDetailClose}
           contextGraphId={contextGraphId}
           onRefresh={rawMemory.refresh}
         />
@@ -205,6 +312,8 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             contextGraphId={contextGraphId}
             onNodeClick={handleNodeClick}
             onSelectEntity={handleNavigate}
+            activeTab={subGraphTabs[activeSubGraph] ?? 'items'}
+            onTabChange={tab => handleSubGraphTabChange(activeSubGraph, tab)}
           />
         </>
       )}
@@ -238,7 +347,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           />
           <MemoryStrip
             memory={rawMemory}
-            onSwitchLayer={setActiveLayer}
+            onSwitchLayer={handleLayerSwitch}
             onSelectEntity={handleNavigate}
             contextGraphId={contextGraphId}
             onNodeClick={handleNodeClick}
@@ -276,6 +385,8 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             onNodeClick={handleNodeClick}
             onSelectEntity={handleNavigate}
             contextGraphId={contextGraphId}
+            activeTab={layerContentTabs[activeLayer]}
+            onTabChange={tab => handleLayerTabChange(activeLayer, tab)}
           />
         </>
       )}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -35,6 +35,8 @@ interface DetailOrigin {
   activeLayer: LayerView;
   activeSubGraph: string | null;
   layerTabs: Record<MemoryLayerView, LayerContentTab>;
+  overviewExpandedLayer: MemoryLayerView | null;
+  overviewLayerTabs: Record<MemoryLayerView, LayerContentTab>;
   subGraphTabs: Record<string, SubGraphTab>;
   scroll: { key: string; top: number };
 }
@@ -73,6 +75,10 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const [layerContentTabs, setLayerContentTabs] = useState<Record<MemoryLayerView, LayerContentTab>>(
     DEFAULT_LAYER_TABS,
   );
+  const [overviewExpandedLayer, setOverviewExpandedLayer] = useState<MemoryLayerView | null>(null);
+  const [overviewLayerTabs, setOverviewLayerTabs] = useState<Record<MemoryLayerView, LayerContentTab>>(
+    DEFAULT_LAYER_TABS,
+  );
   const [subGraphTabs, setSubGraphTabs] = useState<Record<string, SubGraphTab>>({});
   const pageRef = useRef<HTMLElement | null>(null);
   const detailOriginRef = useRef<DetailOrigin | null>(null);
@@ -88,8 +94,11 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     if (isMemoryLayerView(activeLayer)) {
       return `layer:${activeLayer}:${layerContentTabs[activeLayer]}`;
     }
+    if (activeLayer === 'overview' && overviewExpandedLayer) {
+      return `layer:${overviewExpandedLayer}:${overviewLayerTabs[overviewExpandedLayer]}`;
+    }
     return 'page';
-  }, [activeLayer, activeSubGraph, layerContentTabs, subGraphTabs]);
+  }, [activeLayer, activeSubGraph, layerContentTabs, overviewExpandedLayer, overviewLayerTabs, subGraphTabs]);
 
   const captureDetailOrigin = useCallback((): DetailOrigin => {
     const key = currentScrollKey();
@@ -98,10 +107,20 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
       activeLayer,
       activeSubGraph,
       layerTabs: { ...layerContentTabs },
+      overviewExpandedLayer,
+      overviewLayerTabs: { ...overviewLayerTabs },
       subGraphTabs: { ...subGraphTabs },
       scroll: { key, top: scrollEl?.scrollTop ?? 0 },
     };
-  }, [activeLayer, activeSubGraph, currentScrollKey, layerContentTabs, subGraphTabs]);
+  }, [
+    activeLayer,
+    activeSubGraph,
+    currentScrollKey,
+    layerContentTabs,
+    overviewExpandedLayer,
+    overviewLayerTabs,
+    subGraphTabs,
+  ]);
 
   const restoreScroll = useCallback((scroll: DetailOrigin['scroll']) => {
     const restore = () => {
@@ -192,6 +211,12 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     [selectedUri, rawMemory.entities]
   );
 
+  useEffect(() => {
+    if (!selectedUri || selectedEntity || rawMemory.loading) return;
+    setSelectedUri(null);
+    clearDetailOrigin();
+  }, [selectedUri, selectedEntity, rawMemory.loading, clearDetailOrigin]);
+
   // Route a sub-graph chip click to the sub-graph page. Selecting "All"
   // (null) exits the page back to the current layer view, or overview if
   // we were already on one.
@@ -210,6 +235,10 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
 
   const handleLayerTabChange = useCallback((layer: MemoryLayerView, tab: LayerContentTab) => {
     setLayerContentTabs(prev => prev[layer] === tab ? prev : { ...prev, [layer]: tab });
+  }, []);
+
+  const handleOverviewLayerTabChange = useCallback((layer: MemoryLayerView, tab: LayerContentTab) => {
+    setOverviewLayerTabs(prev => prev[layer] === tab ? prev : { ...prev, [layer]: tab });
   }, []);
 
   const handleSubGraphTabChange = useCallback((slug: string, tab: SubGraphTab) => {
@@ -231,6 +260,8 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     setActiveLayer(origin.activeLayer);
     setActiveSubGraph(origin.activeSubGraph);
     setLayerContentTabs(origin.layerTabs);
+    setOverviewExpandedLayer(origin.overviewExpandedLayer);
+    setOverviewLayerTabs(origin.overviewLayerTabs);
     setSubGraphTabs(origin.subGraphTabs);
     pendingScrollRestoreRef.current = origin.scroll;
   }, []);
@@ -351,6 +382,10 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             onSelectEntity={handleNavigate}
             contextGraphId={contextGraphId}
             onNodeClick={handleNodeClick}
+            expandedLayer={overviewExpandedLayer}
+            onExpandedLayerChange={setOverviewExpandedLayer}
+            expandTabs={overviewLayerTabs}
+            onExpandTabChange={handleOverviewLayerTabChange}
           />
         </>
       )}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -49,13 +49,13 @@ function isMemoryLayerView(layer: LayerView): layer is MemoryLayerView {
   return layer === 'wm' || layer === 'swm' || layer === 'vm';
 }
 
-function scrollSelector(key: string): string {
-  return `[data-cg-scroll-key="${key.replace(/"/g, '\\"')}"]`;
-}
-
 function scrollElementFor(key: string, fallback: HTMLElement | null): HTMLElement | null {
   if (typeof document === 'undefined') return fallback;
-  return document.querySelector<HTMLElement>(scrollSelector(key)) ?? fallback;
+  const elements = document.querySelectorAll<HTMLElement>('[data-cg-scroll-key]');
+  for (const element of elements) {
+    if (element.dataset.cgScrollKey === key) return element;
+  }
+  return fallback;
 }
 
 export function ProjectView({ contextGraphId }: ProjectViewProps) {

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -94,14 +94,11 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     if (isMemoryLayerView(activeLayer)) {
       return `layer:${activeLayer}:${layerContentTabs[activeLayer]}`;
     }
-    if (activeLayer === 'overview' && overviewExpandedLayer) {
-      return `layer:${overviewExpandedLayer}:${overviewLayerTabs[overviewExpandedLayer]}`;
-    }
     return 'page';
-  }, [activeLayer, activeSubGraph, layerContentTabs, overviewExpandedLayer, overviewLayerTabs, subGraphTabs]);
+  }, [activeLayer, activeSubGraph, layerContentTabs, subGraphTabs]);
 
-  const captureDetailOrigin = useCallback((): DetailOrigin => {
-    const key = currentScrollKey();
+  const captureDetailOrigin = useCallback((originScrollKey?: string): DetailOrigin => {
+    const key = originScrollKey ?? currentScrollKey();
     const scrollEl = scrollElementFor(key, pageRef.current);
     return {
       activeLayer,
@@ -134,9 +131,9 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     }
   }, []);
 
-  const openEntityDetail = useCallback((uri: string) => {
+  const openEntityDetail = useCallback((uri: string, originScrollKey?: string) => {
     if (!selectedUri || !detailOriginRef.current) {
-      detailOriginRef.current = captureDetailOrigin();
+      detailOriginRef.current = captureDetailOrigin(originScrollKey);
     }
     setSelectedUri(uri);
   }, [captureDetailOrigin, selectedUri]);
@@ -248,8 +245,8 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // M2 keeps the user's origin stable: linked entities open in the detail
   // pane, but the underlying layer/sub-graph page does not silently change
   // until S5 adds breadcrumbs that can make that movement visible.
-  const handleNavigate = useCallback((uri: string) => {
-    openEntityDetail(uri);
+  const handleNavigate = useCallback((uri: string, originScrollKey?: string) => {
+    openEntityDetail(uri, originScrollKey);
   }, [openEntityDetail]);
 
   const handleDetailClose = useCallback(() => {
@@ -269,6 +266,21 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const handleNodeClick = useCallback((node: any) => {
     if (node?.id) handleNavigate(node.id);
   }, [handleNavigate]);
+
+  const handleOverviewActivityNavigate = useCallback((uri: string) => {
+    handleNavigate(uri, 'page');
+  }, [handleNavigate]);
+
+  const handleOverviewStripNavigate = useCallback((uri: string) => {
+    const key = overviewExpandedLayer
+      ? `layer:${overviewExpandedLayer}:${overviewLayerTabs[overviewExpandedLayer]}`
+      : 'page';
+    handleNavigate(uri, key);
+  }, [handleNavigate, overviewExpandedLayer, overviewLayerTabs]);
+
+  const handleOverviewStripNodeClick = useCallback((node: any) => {
+    if (node?.id) handleOverviewStripNavigate(node.id);
+  }, [handleOverviewStripNavigate]);
 
   if (!cg) {
     return (
@@ -369,7 +381,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           )}
           <ActivityFeed
             entities={rawMemory.entityList}
-            onSelectEntity={handleNavigate}
+            onSelectEntity={handleOverviewActivityNavigate}
             title="Recent activity"
             limit={40}
             includeUndated={false}
@@ -379,9 +391,9 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           <MemoryStrip
             memory={rawMemory}
             onSwitchLayer={handleLayerSwitch}
-            onSelectEntity={handleNavigate}
+            onSelectEntity={handleOverviewStripNavigate}
             contextGraphId={contextGraphId}
-            onNodeClick={handleNodeClick}
+            onNodeClick={handleOverviewStripNodeClick}
             expandedLayer={overviewExpandedLayer}
             onExpandedLayerChange={setOverviewExpandedLayer}
             expandTabs={overviewLayerTabs}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1054,7 +1054,7 @@ export function LayerContent({
       </div>
 
       {activeTab === 'items' && (
-        <div className="v10-layer-expand-body entities-tab">
+        <div className="v10-layer-expand-body entities-tab" data-cg-scroll-key={`layer:${layer}:items`}>
           {layer === 'vm' && !isInitialVerifiedMemoryLoad && !isVerifiedMemoryUnavailable && (
             <VerifiedMemoryHeroBanner
               entities={entities}
@@ -1103,12 +1103,17 @@ export function LayerContent({
 
       {activeTab === 'assertions' && layer !== 'vm' && (
         <div className="v10-layer-expand-body full-width">
-          <AssertionsList contextGraphId={contextGraphId} layer={layer} onComplete={memory.refresh} />
+          <AssertionsList
+            contextGraphId={contextGraphId}
+            layer={layer}
+            onComplete={memory.refresh}
+            scrollKey={`layer:${layer}:assertions`}
+          />
         </div>
       )}
 
       {activeTab === 'graph' && (
-        <div className="v10-layer-expand-body full-width">
+        <div className="v10-layer-expand-body full-width" data-cg-scroll-key={`layer:${layer}:graph`}>
           <LayerGraphPanel
             layer={layer}
             triples={layerTriples}
@@ -1120,7 +1125,11 @@ export function LayerContent({
 
       {activeTab === 'docs' && (
         <div className="v10-layer-expand-body full-width">
-          <DocumentsList entities={entities} contextGraphId={contextGraphId} />
+          <DocumentsList
+            entities={entities}
+            contextGraphId={contextGraphId}
+            scrollKey={`layer:${layer}:docs`}
+          />
         </div>
       )}
     </>
@@ -1686,10 +1695,11 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
 
 // Small helper: compute unique triples for a given layer slice of memory.
 
-export function AssertionsList({ contextGraphId, layer, onComplete }: {
+export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }: {
   contextGraphId: string;
   layer: 'wm' | 'swm';
   onComplete: () => void;
+  scrollKey?: string;
 }) {
   const { data: assertions, loading, refresh } = useFetch(
     () => listAssertions(contextGraphId, layer),
@@ -1747,19 +1757,29 @@ export function AssertionsList({ contextGraphId, layer, onComplete }: {
     }
   }, [assertions, contextGraphId, layer, refresh, onComplete]);
 
+  const scrollRootStyle = { flex: 1, overflow: 'auto' } as const;
+
   if (loading) {
-    return <div className="v10-layer-state">Loading assertions...</div>;
+    return (
+      <div style={scrollRootStyle} data-cg-scroll-key={scrollKey}>
+        <div className="v10-layer-state">Loading assertions...</div>
+      </div>
+    );
   }
 
   if (!assertions?.length) {
-    return <div className="v10-layer-state">No assertions in this layer</div>;
+    return (
+      <div style={scrollRootStyle} data-cg-scroll-key={scrollKey}>
+        <div className="v10-layer-state">No assertions in this layer</div>
+      </div>
+    );
   }
 
   const actionLabel = layer === 'wm' ? 'Promote → Shared' : 'Publish to VM';
   const actionAllLabel = layer === 'wm' ? 'Promote All → Shared' : 'Publish all to Verified Memory';
 
   return (
-    <div style={{ flex: 1, overflow: 'auto' }}>
+    <div style={scrollRootStyle} data-cg-scroll-key={scrollKey}>
       <div style={{ padding: '8px 16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid var(--border-subtle)' }}>
         <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{assertions.length} assertion{assertions.length !== 1 ? 's' : ''}</span>
         <button
@@ -1798,14 +1818,23 @@ export function AssertionsList({ contextGraphId, layer, onComplete }: {
 
 // ─── Full Layer Detail View (WM / SWM / VM) ─────────────────
 
-export function LayerDetailView({ layer, memory, onNodeClick, onSelectEntity, contextGraphId }: {
+export function LayerDetailView({
+  layer,
+  memory,
+  onNodeClick,
+  onSelectEntity,
+  contextGraphId,
+  activeTab,
+  onTabChange,
+}: {
   layer: 'wm' | 'swm' | 'vm';
   memory: ReturnType<typeof useMemoryEntities>;
   onNodeClick: (node: any) => void;
   onSelectEntity: (uri: string) => void;
   contextGraphId: string;
+  activeTab: LayerContentTab;
+  onTabChange: (tab: LayerContentTab) => void;
 }) {
-  const [contentTab, setContentTab] = useState<LayerContentTab>('items');
   const config = LAYER_CONFIG[layer];
 
   const entities = useMemo(
@@ -1832,8 +1861,8 @@ export function LayerDetailView({ layer, memory, onNodeClick, onSelectEntity, co
           layerTriples={layerTriples}
           contextGraphId={contextGraphId}
           memory={memory}
-          activeTab={contentTab}
-          onTabChange={setContentTab}
+          activeTab={activeTab}
+          onTabChange={onTabChange}
           onSelectEntity={onSelectEntity}
           onNodeClick={onNodeClick}
         />
@@ -1845,7 +1874,15 @@ export function LayerDetailView({ layer, memory, onNodeClick, onSelectEntity, co
 // ─── Documents List ──────────────────────────────────────────
 
 
-export function DocumentsList({ entities, contextGraphId }: { entities: MemoryEntity[]; contextGraphId?: string }) {
+export function DocumentsList({
+  entities,
+  contextGraphId,
+  scrollKey,
+}: {
+  entities: MemoryEntity[];
+  contextGraphId?: string;
+  scrollKey?: string;
+}) {
   const openTab = useTabsStore(s => s.openTab);
 
   const docs = useMemo(() => {
@@ -1881,14 +1918,14 @@ export function DocumentsList({ entities, contextGraphId }: { entities: MemoryEn
 
   if (docs.length === 0) {
     return (
-      <div className="v10-docs-placeholder" style={{ flex: 1 }}>
+      <div className="v10-docs-placeholder" style={{ flex: 1 }} data-cg-scroll-key={scrollKey}>
         No documents in this layer. Import a file to get started.
       </div>
     );
   }
 
   return (
-    <div className="v10-layer-detail-content">
+    <div className="v10-layer-detail-content" data-cg-scroll-key={scrollKey}>
       <div className="v10-items-list">
         {docs.map(e => {
           const contentType = e.properties.get(SOURCE_CONTENT_TYPE)?.[0] ?? '';
@@ -2221,7 +2258,7 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
   return (
     <div className="v10-ka-detail">
       <div className="v10-ka-header">
-        <button className="v10-ka-back" onClick={onClose}>← Back to Project</button>
+        <button className="v10-ka-back" onClick={onClose}>← Back to Context Graph</button>
         <div className="v10-ka-header-left">
           <div className="v10-ka-label">Knowledge Asset</div>
           <div className="v10-ka-name">
@@ -2824,10 +2861,12 @@ export function SubGraphTimeline({
   items,
   color,
   onSelectEntity,
+  scrollKey,
 }: {
   items: Array<{ entity: MemoryEntity; date: Date }>;
   color: string;
   onSelectEntity: (uri: string) => void;
+  scrollKey?: string;
 }) {
   const profile = useProjectProfileContext();
   const agents = useAgentsContext();
@@ -2844,14 +2883,14 @@ export function SubGraphTimeline({
 
   if (items.length === 0) {
     return (
-      <div className="v10-subgraph-timeline-empty">
+      <div className="v10-subgraph-timeline-empty" data-cg-scroll-key={scrollKey}>
         No entities in this sub-graph have a timeline value (check the profile's <code>timelinePredicate</code> and the underlying data).
       </div>
     );
   }
 
   return (
-    <div className="v10-subgraph-timeline">
+    <div className="v10-subgraph-timeline" data-cg-scroll-key={scrollKey}>
       {grouped.map(([bucket, rows]) => (
         <div key={bucket} className="v10-subgraph-timeline-bucket">
           <div className="v10-subgraph-timeline-bucket-head">
@@ -2905,12 +2944,16 @@ export function SubGraphDetailView({
   contextGraphId,
   onNodeClick,
   onSelectEntity,
+  activeTab,
+  onTabChange,
 }: {
   slug: string;
   rawMemory: ReturnType<typeof useMemoryEntities>;
   contextGraphId: string;
   onNodeClick: (node: any) => void;
   onSelectEntity: (uri: string) => void;
+  activeTab?: SubGraphTab;
+  onTabChange?: (tab: SubGraphTab) => void;
 }) {
   const profile = useProjectProfileContext();
   const binding = profile?.forSubGraph(slug);
@@ -2918,7 +2961,9 @@ export function SubGraphDetailView({
   const queryCatalogs = profile?.savedQueryCatalogsFor(slug) ?? [];
   const timelinePredicate = binding?.timelinePredicate;
 
-  const [activeTab, setActiveTab] = useState<SubGraphTab>('items');
+  const [localActiveTab, setLocalActiveTab] = useState<SubGraphTab>('items');
+  const selectedTab = activeTab ?? localActiveTab;
+  const setSelectedTab = onTabChange ?? setLocalActiveTab;
   // Default to newest-first for any sub-graph that defines a timeline
   // predicate (chat, github, tasks, decisions). Sub-graphs with no time
   // signal (code, meta) fall back to the legacy "richest entity first"
@@ -3129,11 +3174,14 @@ export function SubGraphDetailView({
   // `tasks` would linger when the user jumps to `decisions` and silently
   // zero out the list.
   useEffect(() => {
-    setActiveTab('items');
     setEnabledLayers(new Set<TrustLevel>(['working', 'shared', 'verified']));
     setChipState(new Map());
     clearQuery();
   }, [slug, clearQuery]);
+
+  useEffect(() => {
+    if (!activeTab) setLocalActiveTab('items');
+  }, [slug, activeTab]);
 
   const hasAnyFilter = enabledLayers.size < 3 || chipState.size > 0 || !!queryResults;
   const resetFilters = () => {
@@ -3239,35 +3287,35 @@ export function SubGraphDetailView({
       <div className="v10-layer-detail-body">
         <div className="v10-layer-expand-tabs">
           <button
-            className={`v10-layer-expand-tab ${activeTab === 'items' ? 'active' : ''}`}
-            onClick={() => setActiveTab('items')}
+            className={`v10-layer-expand-tab ${selectedTab === 'items' ? 'active' : ''}`}
+            onClick={() => setSelectedTab('items')}
           >
             Entities ({filteredEntities.length}{filteredEntities.length !== scopedEntities.length ? ` / ${scopedEntities.length}` : ''})
           </button>
           <button
-            className={`v10-layer-expand-tab ${activeTab === 'graph' ? 'active' : ''}`}
-            onClick={() => setActiveTab('graph')}
+            className={`v10-layer-expand-tab ${selectedTab === 'graph' ? 'active' : ''}`}
+            onClick={() => setSelectedTab('graph')}
           >
             Graph
           </button>
           {timelinePredicate && (
             <button
-              className={`v10-layer-expand-tab ${activeTab === 'timeline' ? 'active' : ''}`}
-              onClick={() => setActiveTab('timeline')}
+              className={`v10-layer-expand-tab ${selectedTab === 'timeline' ? 'active' : ''}`}
+              onClick={() => setSelectedTab('timeline')}
             >
               Timeline
             </button>
           )}
           <button
-            className={`v10-layer-expand-tab ${activeTab === 'docs' ? 'active' : ''}`}
-            onClick={() => setActiveTab('docs')}
+            className={`v10-layer-expand-tab ${selectedTab === 'docs' ? 'active' : ''}`}
+            onClick={() => setSelectedTab('docs')}
           >
             Documents
           </button>
         </div>
 
-        {activeTab === 'items' && (
-          <div className="v10-layer-expand-body entities-tab">
+        {selectedTab === 'items' && (
+          <div className="v10-layer-expand-body entities-tab" data-cg-scroll-key={`subgraph:${slug}:items`}>
             <EntityList
               entities={sortedEntities}
               layerKey="wm"
@@ -3300,8 +3348,8 @@ export function SubGraphDetailView({
           </div>
         )}
 
-        {activeTab === 'graph' && (
-          <div className="v10-layer-expand-body full-width">
+        {selectedTab === 'graph' && (
+          <div className="v10-layer-expand-body full-width" data-cg-scroll-key={`subgraph:${slug}:graph`}>
             <LayerGraphPanel
               layer="wm"
               triples={filteredTriples}
@@ -3311,21 +3359,23 @@ export function SubGraphDetailView({
           </div>
         )}
 
-        {activeTab === 'timeline' && timelinePredicate && (
+        {selectedTab === 'timeline' && timelinePredicate && (
           <div className="v10-layer-expand-body full-width">
             <SubGraphTimeline
               items={timelineItems}
               color={color}
               onSelectEntity={onSelectEntity}
+              scrollKey={`subgraph:${slug}:timeline`}
             />
           </div>
         )}
 
-        {activeTab === 'docs' && (
+        {selectedTab === 'docs' && (
           <div className="v10-layer-expand-body full-width">
             <DocumentsList
               entities={filteredEntities}
               contextGraphId={contextGraphId}
+              scrollKey={`subgraph:${slug}:docs`}
             />
           </div>
         )}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -501,15 +501,37 @@ export function VerifiedGraphLegend({ anchors }: { anchors: PublishAnchor[] }) {
 
 // ─── Memory Strip (expandable layer rows) ────────────────────
 
-export function MemoryStrip({ memory, onSwitchLayer, onSelectEntity, contextGraphId, onNodeClick }: {
+type MemoryStripLayer = 'wm' | 'swm' | 'vm';
+
+export function MemoryStrip({
+  memory,
+  onSwitchLayer,
+  onSelectEntity,
+  contextGraphId,
+  onNodeClick,
+  expandedLayer,
+  onExpandedLayerChange,
+  expandTabs,
+  onExpandTabChange,
+}: {
   memory: ReturnType<typeof useMemoryEntities>;
   onSwitchLayer: (layer: LayerView) => void;
   onSelectEntity: (uri: string) => void;
   contextGraphId: string;
   onNodeClick?: (node: any) => void;
+  expandedLayer?: MemoryStripLayer | null;
+  onExpandedLayerChange?: (layer: MemoryStripLayer | null) => void;
+  expandTabs?: Record<MemoryStripLayer, LayerContentTab>;
+  onExpandTabChange?: (layer: MemoryStripLayer, tab: LayerContentTab) => void;
 }) {
-  const [expanded, setExpanded] = useState<string | null>(null);
-  const [expandTab, setExpandTab] = useState<Record<string, string>>({ wm: 'items', swm: 'items', vm: 'items' });
+  const [localExpanded, setLocalExpanded] = useState<MemoryStripLayer | null>(null);
+  const [localExpandTabs, setLocalExpandTabs] = useState<Record<MemoryStripLayer, LayerContentTab>>({
+    wm: 'items',
+    swm: 'items',
+    vm: 'items',
+  });
+  const expanded = expandedLayer !== undefined ? expandedLayer : localExpanded;
+  const activeExpandTabs = expandTabs ?? localExpandTabs;
   const profile = useProjectProfileContext();
 
   const layerEntities = useMemo(() => {
@@ -534,12 +556,19 @@ export function MemoryStrip({ memory, onSwitchLayer, onSelectEntity, contextGrap
     return { wm, swm, vm };
   }, [memory.allTriples]);
 
-  const toggleExpand = (layer: string) => {
-    setExpanded(prev => prev === layer ? null : layer);
+  const toggleExpand = (layer: MemoryStripLayer) => {
+    const next = expanded === layer ? null : layer;
+    if (onExpandedLayerChange) onExpandedLayerChange(next);
+    else setLocalExpanded(next);
+  };
+
+  const handleExpandTab = (layer: MemoryStripLayer, tab: LayerContentTab) => {
+    if (onExpandTabChange) onExpandTabChange(layer, tab);
+    else setLocalExpandTabs(prev => ({ ...prev, [layer]: tab }));
   };
 
   const layers: Array<{
-    key: string;
+    key: MemoryStripLayer;
     label: string;
     color: string;
     icon: string;
@@ -556,7 +585,7 @@ export function MemoryStrip({ memory, onSwitchLayer, onSelectEntity, contextGrap
     <div className="v10-memory-strip">
       {layers.map(layer => {
         const isExpanded = expanded === layer.key;
-        const activeTab = expandTab[layer.key] ?? 'items';
+        const activeTab = activeExpandTabs[layer.key] ?? 'items';
         return (
           <React.Fragment key={layer.key}>
             <div
@@ -596,9 +625,7 @@ export function MemoryStrip({ memory, onSwitchLayer, onSelectEntity, contextGrap
                   contextGraphId={contextGraphId}
                   memory={memory}
                   activeTab={activeTab as LayerContentTab}
-                  onTabChange={tab =>
-                    setExpandTab(prev => ({ ...prev, [layer.key]: tab }))
-                  }
+                  onTabChange={tab => handleExpandTab(layer.key, tab)}
                   onSelectEntity={onSelectEntity}
                   onNodeClick={onNodeClick}
                   onSwitchLayer={() => onSwitchLayer(layer.viewLayer)}
@@ -2962,7 +2989,8 @@ export function SubGraphDetailView({
   const timelinePredicate = binding?.timelinePredicate;
 
   const [localActiveTab, setLocalActiveTab] = useState<SubGraphTab>('items');
-  const selectedTab = activeTab ?? localActiveTab;
+  const rawSelectedTab = activeTab ?? localActiveTab;
+  const selectedTab = rawSelectedTab === 'timeline' && !timelinePredicate ? 'items' : rawSelectedTab;
   const setSelectedTab = onTabChange ?? setLocalActiveTab;
   // Default to newest-first for any sub-graph that defines a timeline
   // predicate (chat, github, tasks, decisions). Sub-graphs with no time
@@ -3182,6 +3210,10 @@ export function SubGraphDetailView({
   useEffect(() => {
     if (!activeTab) setLocalActiveTab('items');
   }, [slug, activeTab]);
+
+  useEffect(() => {
+    if (rawSelectedTab !== selectedTab) setSelectedTab(selectedTab);
+  }, [rawSelectedTab, selectedTab, setSelectedTab]);
 
   const hasAnyFilter = enabledLayers.size < 3 || chipState.size > 0 || !!queryResults;
   const resetFilters = () => {

--- a/packages/node-ui/test/ka-detail-label.test.ts
+++ b/packages/node-ui/test/ka-detail-label.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { KADetailView } from '../src/ui/views/project/components.js';
+import { ProjectProfileContext, type ProjectProfile } from '../src/ui/hooks/useProjectProfile.js';
+import { AgentsContext, type AgentsData } from '../src/ui/hooks/useAgents.js';
+import type { MemoryEntity } from '../src/ui/hooks/useMemoryEntities.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const profile: ProjectProfile = {
+  contextGraphId: 'cg-test',
+  displayName: 'Context Graph Test',
+  primaryColor: '#64748b',
+  accentColor: '#22c55e',
+  subGraphs: [],
+  typeBindings: [],
+  views: [],
+  filterChips: [],
+  queryCatalogs: [],
+  savedQueries: [],
+  loading: false,
+  forSubGraph: () => undefined,
+  forType: typeIri => ({
+    typeIri,
+    label: typeIri.split(/[/#]/).pop() ?? typeIri,
+    color: '#64748b',
+  }),
+  view: () => undefined,
+  chipsFor: () => [],
+  savedQueryCatalogsFor: () => [],
+  savedQueriesFor: () => [],
+};
+
+const agents: AgentsData = {
+  agents: new Map(),
+  list: [],
+  loading: false,
+  get: () => undefined,
+  openAgent: vi.fn(),
+};
+
+const entity: MemoryEntity = {
+  uri: 'urn:entity:working',
+  label: 'Working entity',
+  types: ['http://schema.org/Thing'],
+  trustLevel: 'working',
+  layers: new Set(['working']),
+  subGraphs: new Set(),
+  properties: new Map(),
+  connections: [],
+};
+
+function query(selector: string): HTMLElement {
+  const el = document.querySelector<HTMLElement>(selector);
+  if (!el) throw new Error(`Missing element ${selector}`);
+  return el;
+}
+
+describe('KADetailView navigation label', () => {
+  let root: Root;
+
+  beforeEach(async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    const container = query('#root');
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  it('renders Back to Context Graph and calls onClose', async () => {
+    const onClose = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(AgentsContext.Provider, { value: agents },
+            React.createElement(KADetailView, {
+              entity,
+              allEntities: new Map([[entity.uri, entity]]),
+              allTriples: [],
+              onNavigate: vi.fn(),
+              onClose,
+              contextGraphId: 'cg-test',
+              onRefresh: vi.fn(),
+            }))),
+      );
+    });
+
+    const back = query('.v10-ka-back');
+    expect(back.textContent).toContain('Back to Context Graph');
+    expect(back.textContent).not.toContain('Back to Project');
+
+    await act(async () => {
+      back.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -7,8 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
-const memory = {
-  entities: new Map([
+function createEntities() {
+  return new Map([
     ['urn:entity:working', {
       uri: 'urn:entity:working',
       label: 'Working entity',
@@ -39,7 +39,11 @@ const memory = {
       properties: new Map(),
       connections: [],
     }],
-  ]),
+  ]);
+}
+
+const memory = {
+  entities: createEntities(),
   entityList: [] as any[],
   allTriples: [],
   graphTriples: [],
@@ -50,7 +54,12 @@ const memory = {
   partial: false,
   refresh: vi.fn(),
 };
-memory.entityList = [...memory.entities.values()];
+
+function resetMemory() {
+  memory.entities = createEntities();
+  memory.entityList = [...memory.entities.values()];
+}
+resetMemory();
 
 const profile = {
   primaryColor: '#64748b',
@@ -142,7 +151,37 @@ vi.mock('../src/ui/views/project/components.js', () => ({
         React.createElement('button', { 'data-testid': 'open-subgraph-entity', onClick: () => onSelectEntity('urn:entity:demo') }, 'Open demo entity'))),
   ProjectOverviewCard: () => React.createElement('div', {}, 'Overview'),
   PendingJoinRequestsBar: () => null,
-  MemoryStrip: () => null,
+  MemoryStrip: ({ expandedLayer, onExpandedLayerChange, expandTabs, onExpandTabChange, onSelectEntity }: {
+    expandedLayer: 'wm' | 'swm' | 'vm' | null;
+    onExpandedLayerChange: (layer: 'wm' | 'swm' | 'vm' | null) => void;
+    expandTabs: Record<'wm' | 'swm' | 'vm', string>;
+    onExpandTabChange: (layer: 'wm' | 'swm' | 'vm', tab: string) => void;
+    onSelectEntity: (uri: string) => void;
+  }) => {
+    const activeTab = expandedLayer ? expandTabs[expandedLayer] : 'items';
+    return React.createElement('section', {
+      'data-testid': 'memory-strip',
+      'data-expanded': expandedLayer ?? '',
+      'data-tab': activeTab,
+    },
+      React.createElement('button', {
+        'data-testid': 'expand-strip-swm',
+        onClick: () => onExpandedLayerChange(expandedLayer === 'swm' ? null : 'swm'),
+      }, 'Expand SWM'),
+      expandedLayer && React.createElement(React.Fragment, {},
+        React.createElement('button', {
+          'data-testid': 'strip-tab-graph',
+          onClick: () => onExpandTabChange(expandedLayer, 'graph'),
+        }, 'Graph'),
+        React.createElement('div', {
+          'data-testid': 'strip-scroll',
+          'data-cg-scroll-key': `layer:${expandedLayer}:${activeTab}`,
+        },
+          React.createElement('button', {
+            'data-testid': 'open-strip-entity',
+            onClick: () => onSelectEntity('urn:entity:working'),
+          }, 'Open strip entity'))));
+  },
   SubGraphOverviewGrid: () => null,
   ContextGraphQueryView: () => null,
   LayerDetailView: ({ layer, activeTab, onTabChange, onSelectEntity }: {
@@ -184,6 +223,7 @@ describe('ProjectView entity detail navigation', () => {
   let originalRaf: typeof window.requestAnimationFrame;
 
   beforeEach(async () => {
+    resetMemory();
     document.body.innerHTML = '<div id="root"></div>';
     originalRaf = window.requestAnimationFrame;
     Object.defineProperty(window, 'requestAnimationFrame', {
@@ -232,6 +272,25 @@ describe('ProjectView entity detail navigation', () => {
     expect(query('layer-scroll').scrollTop).toBe(86);
   });
 
+  it('restores overview strip expansion, subtab, and scroll when entity detail closes', async () => {
+    await click('expand-strip-swm');
+    await click('strip-tab-graph');
+
+    const scroller = query('strip-scroll');
+    scroller.scrollTop = 64;
+
+    await click('open-strip-entity');
+    expect(query('entity-detail').dataset.entity).toBe('urn:entity:working');
+
+    await click('detail-back');
+    await flush();
+
+    expect(query('active-layer').dataset.layer).toBe('overview');
+    expect(query('memory-strip').dataset.expanded).toBe('swm');
+    expect(query('memory-strip').dataset.tab).toBe('graph');
+    expect(query('strip-scroll').scrollTop).toBe(64);
+  });
+
   it('keeps the originating subgraph stable while following cross-subgraph entity links', async () => {
     await click('select-subgraph-demo');
     await click('subgraph-tab-graph');
@@ -245,6 +304,32 @@ describe('ProjectView entity detail navigation', () => {
     await click('open-related-entity');
     expect(query('entity-detail').dataset.entity).toBe('urn:entity:other');
     expect(query('active-subgraph').textContent).toBe('demo');
+
+    await click('detail-back');
+    await flush();
+
+    expect(query('subgraph-detail').dataset.slug).toBe('demo');
+    expect(query('subgraph-detail').dataset.tab).toBe('graph');
+  });
+
+  it('clears stale detail origin when the selected entity disappears', async () => {
+    await click('switch-swm');
+    await click('open-layer-entity');
+    expect(query('entity-detail').dataset.entity).toBe('urn:entity:working');
+
+    await act(async () => {
+      memory.entities = new Map([...memory.entities].filter(([uri]) => uri !== 'urn:entity:working'));
+      memory.entityList = [...memory.entities.values()];
+      root.render(React.createElement(ProjectView, { contextGraphId: 'cg-test' }));
+    });
+    await flush();
+
+    expect(document.querySelector('[data-testid="entity-detail"]')).toBeNull();
+
+    await click('select-subgraph-demo');
+    await click('subgraph-tab-graph');
+    await click('open-subgraph-entity');
+    expect(query('entity-detail').dataset.entity).toBe('urn:entity:demo');
 
     await click('detail-back');
     await flush();

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -1,0 +1,256 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const memory = {
+  entities: new Map([
+    ['urn:entity:working', {
+      uri: 'urn:entity:working',
+      label: 'Working entity',
+      types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    }],
+    ['urn:entity:demo', {
+      uri: 'urn:entity:demo',
+      label: 'Demo entity',
+      types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [{ predicate: 'related', targetUri: 'urn:entity:other', targetLabel: 'Other entity' }],
+    }],
+    ['urn:entity:other', {
+      uri: 'urn:entity:other',
+      label: 'Other entity',
+      types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['other']),
+      properties: new Map(),
+      connections: [],
+    }],
+  ]),
+  entityList: [] as any[],
+  allTriples: [],
+  graphTriples: [],
+  trustMap: new Map(),
+  counts: { wm: 2, swm: 0, vm: 0, total: 2 },
+  loading: false,
+  error: null,
+  partial: false,
+  refresh: vi.fn(),
+};
+memory.entityList = [...memory.entities.values()];
+
+const profile = {
+  primaryColor: '#64748b',
+  forSubGraph: (slug: string) => ({ slug, displayName: slug, color: '#38bdf8', icon: '#', description: '' }),
+};
+
+const agentsData = {
+  agents: new Map(),
+  list: [],
+  loading: false,
+  get: () => undefined,
+  openAgent: vi.fn(),
+};
+
+vi.mock('../src/ui/api-wrapper.js', () => ({
+  api: {
+    fetchContextGraphs: vi.fn(async () => ({
+      contextGraphs: [{ id: 'cg-test', name: 'Context Graph Test' }],
+    })),
+  },
+}));
+
+vi.mock('../src/ui/api.js', () => ({
+  listParticipants: vi.fn(async () => ({ allowedAgents: [] })),
+}));
+
+vi.mock('../src/ui/hooks/useMemoryEntities.js', () => ({
+  useMemoryEntities: () => memory,
+}));
+
+vi.mock('../src/ui/hooks/useProjectProfile.js', () => ({
+  ProjectProfileContext: React.createContext(profile),
+  useProjectProfile: () => profile,
+}));
+
+vi.mock('../src/ui/hooks/useAgents.js', () => ({
+  AgentsContext: React.createContext(agentsData),
+  useAgents: () => agentsData,
+}));
+
+vi.mock('../src/ui/stores/tabs.js', () => ({
+  useTabsStore: () => vi.fn(),
+}));
+
+vi.mock('../src/ui/components/Modals/ImportFilesModal.js', () => ({
+  ImportFilesModal: () => null,
+}));
+
+vi.mock('../src/ui/components/Modals/ShareProjectModal.js', () => ({
+  ShareProjectModal: () => null,
+}));
+
+vi.mock('../src/ui/components/ActivityFeed.js', () => ({
+  ActivityFeed: ({ onSelectEntity }: { onSelectEntity: (uri: string) => void }) =>
+    React.createElement('button', {
+      'data-testid': 'open-activity-entity',
+      onClick: () => onSelectEntity('urn:entity:working'),
+    }, 'Open activity entity'),
+}));
+
+vi.mock('../src/ui/components/SubGraphBar.js', () => ({
+  SubGraphBar: ({ selected, onSelect }: { selected: string | null; onSelect: (slug: string | null) => void }) =>
+    React.createElement('div', { 'data-testid': 'subgraph-bar', 'data-selected': selected ?? '' },
+      React.createElement('button', { 'data-testid': 'select-subgraph-demo', onClick: () => onSelect('demo') }, 'demo'),
+      React.createElement('button', { 'data-testid': 'clear-subgraph', onClick: () => onSelect(null) }, 'all')),
+}));
+
+vi.mock('../src/ui/views/project/components.js', () => ({
+  ProjectHeaderStrip: ({ activeSubGraph }: { activeSubGraph: any }) =>
+    React.createElement('div', { 'data-testid': 'active-subgraph' }, activeSubGraph?.slug ?? 'none'),
+  LayerSwitcher: ({ active, onSwitch }: { active: string; onSwitch: (layer: string) => void }) =>
+    React.createElement('div', { 'data-testid': 'active-layer', 'data-layer': active },
+      React.createElement('button', { 'data-testid': 'switch-wm', onClick: () => onSwitch('wm') }, 'WM'),
+      React.createElement('button', { 'data-testid': 'switch-swm', onClick: () => onSwitch('swm') }, 'SWM')),
+  KADetailView: ({ entity, onNavigate, onClose }: { entity: any; onNavigate: (uri: string) => void; onClose: () => void }) =>
+    React.createElement('section', { 'data-testid': 'entity-detail', 'data-entity': entity.uri },
+      React.createElement('div', {}, entity.label),
+      React.createElement('button', { 'data-testid': 'open-related-entity', onClick: () => onNavigate('urn:entity:other') }, 'Open related'),
+      React.createElement('button', { 'data-testid': 'detail-back', onClick: onClose }, 'Back to Context Graph')),
+  SubGraphDetailView: ({ slug, activeTab = 'items', onTabChange, onSelectEntity }: {
+    slug: string;
+    activeTab?: string;
+    onTabChange: (tab: string) => void;
+    onSelectEntity: (uri: string) => void;
+  }) =>
+    React.createElement('section', { 'data-testid': 'subgraph-detail', 'data-slug': slug, 'data-tab': activeTab },
+      React.createElement('button', { 'data-testid': 'subgraph-tab-graph', onClick: () => onTabChange('graph') }, 'Graph'),
+      React.createElement('div', { 'data-testid': 'subgraph-scroll', 'data-cg-scroll-key': `subgraph:${slug}:${activeTab}` },
+        React.createElement('button', { 'data-testid': 'open-subgraph-entity', onClick: () => onSelectEntity('urn:entity:demo') }, 'Open demo entity'))),
+  ProjectOverviewCard: () => React.createElement('div', {}, 'Overview'),
+  PendingJoinRequestsBar: () => null,
+  MemoryStrip: () => null,
+  SubGraphOverviewGrid: () => null,
+  ContextGraphQueryView: () => null,
+  LayerDetailView: ({ layer, activeTab, onTabChange, onSelectEntity }: {
+    layer: string;
+    activeTab: string;
+    onTabChange: (tab: string) => void;
+    onSelectEntity: (uri: string) => void;
+  }) =>
+    React.createElement('section', { 'data-testid': 'layer-detail', 'data-layer': layer, 'data-tab': activeTab },
+      React.createElement('button', { 'data-testid': 'layer-tab-graph', onClick: () => onTabChange('graph') }, 'Graph'),
+      React.createElement('div', { 'data-testid': 'layer-scroll', 'data-cg-scroll-key': `layer:${layer}:${activeTab}` },
+        React.createElement('button', { 'data-testid': 'open-layer-entity', onClick: () => onSelectEntity('urn:entity:working') }, 'Open layer entity'))),
+  ProvenanceBar: () => null,
+}));
+
+const { ProjectView } = await import('../src/ui/views/ProjectView.js');
+
+function query(testId: string): HTMLElement {
+  const el = document.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+  if (!el) throw new Error(`Missing test element ${testId}`);
+  return el;
+}
+
+async function click(testId: string): Promise<void> {
+  await act(async () => {
+    query(testId).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+}
+
+describe('ProjectView entity detail navigation', () => {
+  let root: Root;
+  let originalRaf: typeof window.requestAnimationFrame;
+
+  beforeEach(async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    originalRaf = window.requestAnimationFrame;
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: (cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      },
+    });
+    const container = document.getElementById('root');
+    if (!container) throw new Error('Missing root');
+    root = createRoot(container);
+    await act(async () => {
+      root.render(React.createElement(ProjectView, { contextGraphId: 'cg-test' }));
+    });
+    await flush();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: originalRaf,
+    });
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  it('restores layer, subtab, and scroll when entity detail closes', async () => {
+    await click('switch-swm');
+    await click('layer-tab-graph');
+
+    const scroller = query('layer-scroll');
+    scroller.scrollTop = 86;
+
+    await click('open-layer-entity');
+    expect(query('entity-detail').dataset.entity).toBe('urn:entity:working');
+
+    await click('detail-back');
+    await flush();
+
+    expect(query('active-layer').dataset.layer).toBe('swm');
+    expect(query('layer-detail').dataset.tab).toBe('graph');
+    expect(query('layer-scroll').scrollTop).toBe(86);
+  });
+
+  it('keeps the originating subgraph stable while following cross-subgraph entity links', async () => {
+    await click('select-subgraph-demo');
+    await click('subgraph-tab-graph');
+    expect(query('active-subgraph').textContent).toBe('demo');
+    expect(query('subgraph-detail').dataset.tab).toBe('graph');
+
+    await click('open-subgraph-entity');
+    expect(query('entity-detail').dataset.entity).toBe('urn:entity:demo');
+    expect(query('active-subgraph').textContent).toBe('demo');
+
+    await click('open-related-entity');
+    expect(query('entity-detail').dataset.entity).toBe('urn:entity:other');
+    expect(query('active-subgraph').textContent).toBe('demo');
+
+    await click('detail-back');
+    await flush();
+
+    expect(query('subgraph-detail').dataset.slug).toBe('demo');
+    expect(query('subgraph-detail').dataset.tab).toBe('graph');
+  });
+
+});

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -205,6 +205,12 @@ function query(testId: string): HTMLElement {
   return el;
 }
 
+function scrollRoot(key: string): HTMLElement {
+  const el = document.querySelector<HTMLElement>(`[data-cg-scroll-key="${key}"]`);
+  if (!el) throw new Error(`Missing scroll root ${key}`);
+  return el;
+}
+
 async function click(testId: string): Promise<void> {
   await act(async () => {
     query(testId).dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -289,6 +295,29 @@ describe('ProjectView entity detail navigation', () => {
     expect(query('memory-strip').dataset.expanded).toBe('swm');
     expect(query('memory-strip').dataset.tab).toBe('graph');
     expect(query('strip-scroll').scrollTop).toBe(64);
+  });
+
+  it('restores page scroll when overview activity opens while the strip is expanded', async () => {
+    await click('expand-strip-swm');
+    await click('strip-tab-graph');
+
+    const pageScroller = scrollRoot('page');
+    const stripScroller = query('strip-scroll');
+    pageScroller.scrollTop = 140;
+    stripScroller.scrollTop = 32;
+
+    await click('open-activity-entity');
+    expect(query('entity-detail').dataset.entity).toBe('urn:entity:working');
+
+    pageScroller.scrollTop = 0;
+
+    await click('detail-back');
+    await flush();
+
+    expect(query('active-layer').dataset.layer).toBe('overview');
+    expect(query('memory-strip').dataset.expanded).toBe('swm');
+    expect(query('memory-strip').dataset.tab).toBe('graph');
+    expect(scrollRoot('page').scrollTop).toBe(140);
   });
 
   it('keeps the originating subgraph stable while following cross-subgraph entity links', async () => {

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProjectProfileContext, type ProjectProfile } from '../src/ui/hooks/useProjectProfile.js';
+import { SubGraphDetailView } from '../src/ui/views/project/components.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@origintrail-official/dkg-graph-viz/react', async () => {
+  const React = await import('react');
+  return {
+    RdfGraph() {
+      return React.createElement('div', { 'data-testid': 'rdf-graph' });
+    },
+  };
+});
+
+const entity = {
+  uri: 'urn:entity:demo',
+  label: 'Demo entity',
+  types: [],
+  trustLevel: 'working',
+  layers: new Set(['working']),
+  subGraphs: new Set(['demo']),
+  properties: new Map(),
+  connections: [],
+};
+
+const rawMemory = {
+  entities: new Map([[entity.uri, entity]]),
+  entityList: [entity],
+  allTriples: [],
+  graphTriples: [],
+  trustMap: new Map(),
+  counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+  loading: false,
+  error: null,
+  partial: false,
+  refresh: vi.fn(),
+} as any;
+
+const profile: ProjectProfile = {
+  contextGraphId: 'cg-test',
+  displayName: 'Context Graph Test',
+  primaryColor: '#64748b',
+  accentColor: '#38bdf8',
+  subGraphs: [],
+  typeBindings: [],
+  views: [],
+  filterChips: [],
+  queryCatalogs: [],
+  savedQueries: [],
+  loading: false,
+  forSubGraph: (slug: string) => ({
+    slug,
+    displayName: slug,
+    color: '#38bdf8',
+    icon: '#',
+    rank: 0,
+  }),
+  forType: () => undefined,
+  view: () => undefined,
+  chipsFor: () => [],
+  savedQueryCatalogsFor: () => [],
+  savedQueriesFor: () => [],
+};
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('SubGraphDetailView tabs', () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement;
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+      root = null;
+    }
+    container.remove();
+  });
+
+  it('clamps an unsupported controlled timeline tab back to entities', async () => {
+    const onTabChange = vi.fn();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'timeline',
+            onTabChange,
+          })),
+      );
+    });
+    await flush();
+
+    expect(onTabChange).toHaveBeenCalledWith('items');
+    expect(container.querySelector('[data-cg-scroll-key="subgraph:demo:items"]')).toBeTruthy();
+    expect(container.querySelector('[data-cg-scroll-key="subgraph:demo:timeline"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Capture the Context Graph route/tab/scroll origin before entity drill-in and restore it when the detail view closes.
- Keep cross-subgraph entity links inside the detail route instead of silently switching the underlying subgraph page.
- Control layer and subgraph tabs from `ProjectView`, with stable scroll keys on the actual scroll roots used by restoration.
- Rename the detail back action to "Back to Context Graph" for M2 terminology alignment.

## Related

- Follow-up to #598
- Context Graph UX rollout PR 1.2 / M2

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/views/ProjectView.tsx` | Adds origin snapshot/restore handling, controlled layer/subgraph tab state, and detail close routing. |
| `packages/node-ui/src/ui/views/project/components.tsx` | Exposes controlled tabs, moves scroll keys onto stable scroll containers, and updates detail back copy. |
| `packages/node-ui/test/project-view-navigation.test.ts` | Covers origin restoration and cross-subgraph detail navigation behavior. |
| `packages/node-ui/test/ka-detail-label.test.ts` | Covers the rendered detail back-label copy. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/project-view-navigation.test.ts test/ka-detail-label.test.ts test/ui-compat.test.ts test/use-memory-entities-live-updates.test.ts test/use-memory-entities-partial.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui`
- [x] `git diff --check`
- [x] In-app browser boot smoke at `http://localhost:5176/ui/` with no console errors or warnings.
- [x] Local PR review: 4 rounds, final result had no actionable comments.

Note: the local dev node had zero context graphs, so the full live drill-in/back walkthrough still needs a populated-node manual pass.
