### PR TITLE
fix(node-ui): stabilize swm graph coloring

### DIFF
--- a/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
+++ b/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
@@ -152,13 +152,16 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
   const [palette, setPalette] = useState<AgentPaletteEntry[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [resolvedContextGraphId, setResolvedContextGraphId] = useState<string | undefined>(undefined);
   const versionRef = useRef(0);
 
   useEffect(() => {
     if (!contextGraphId) {
+      versionRef.current += 1;
       setAttributions(new Map());
       setPalette([]);
       setLoading(false);
+      setResolvedContextGraphId(undefined);
       return;
     }
     const version = ++versionRef.current;
@@ -220,11 +223,13 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
         if (version !== versionRef.current) return;
         setAttributions(attrMap);
         setPalette(paletteEntries);
+        setResolvedContextGraphId(contextGraphId);
       } catch (err: any) {
         if (version !== versionRef.current) return;
         setError(err?.message ?? 'Failed to load SWM attributions');
         setAttributions(new Map());
         setPalette([]);
+        setResolvedContextGraphId(contextGraphId);
       } finally {
         if (version === versionRef.current) setLoading(false);
       }
@@ -252,5 +257,7 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
     return { nodeColors: nc, conflicts: confl };
   }, [attributions]);
 
-  return { attributions, palette, nodeColors, conflicts, loading, error };
+  const attributionPending = Boolean(contextGraphId && (loading || resolvedContextGraphId !== contextGraphId));
+
+  return { attributions, palette, nodeColors, conflicts, loading: attributionPending, error };
 }

--- a/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
+++ b/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
@@ -76,6 +76,7 @@ const AGENT_PALETTE = [
   '#0ea5e9', // sky
   '#d946ef', // fuchsia
 ];
+const ATTRIBUTION_QUERY_TIMEOUT_MS = 10_000;
 
 function bv(v: unknown): string | undefined {
   if (v == null) return undefined;
@@ -165,21 +166,38 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
       return;
     }
     const version = ++versionRef.current;
+    const controller = new AbortController();
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const isCurrent = () => !cancelled && version === versionRef.current;
+
     setLoading(true);
     setError(null);
 
     (async () => {
       try {
-        const res = await fetch('/api/query', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...authHeaders() },
-          body: JSON.stringify({
-            sparql: buildAttributionsQuery(contextGraphId),
-            contextGraphId,
-          }),
+        const timeout = new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            controller.abort();
+            reject(new Error(
+              `SWM attribution query timed out after ${Math.round(ATTRIBUTION_QUERY_TIMEOUT_MS / 1000)}s`,
+            ));
+          }, ATTRIBUTION_QUERY_TIMEOUT_MS);
         });
-        if (!res.ok) throw new Error(`SPARQL query failed: ${res.status}`);
-        const data = await res.json();
+        const request = (async () => {
+          const res = await fetch('/api/query', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeaders() },
+            signal: controller.signal,
+            body: JSON.stringify({
+              sparql: buildAttributionsQuery(contextGraphId),
+              contextGraphId,
+            }),
+          });
+          if (!res.ok) throw new Error(`SPARQL query failed: ${res.status}`);
+          return res.json();
+        })();
+        const data = await Promise.race([request, timeout]);
         const rows: any[] = data?.result?.bindings ?? [];
 
         const attrMap = new Map<string, AgentAttribution[]>();
@@ -220,20 +238,27 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
           }))
           .sort((a, b) => b.entityCount - a.entityCount);
 
-        if (version !== versionRef.current) return;
+        if (!isCurrent()) return;
         setAttributions(attrMap);
         setPalette(paletteEntries);
         setResolvedContextGraphId(contextGraphId);
       } catch (err: any) {
-        if (version !== versionRef.current) return;
+        if (!isCurrent()) return;
         setError(err?.message ?? 'Failed to load SWM attributions');
         setAttributions(new Map());
         setPalette([]);
         setResolvedContextGraphId(contextGraphId);
       } finally {
-        if (version === versionRef.current) setLoading(false);
+        if (timeoutId) clearTimeout(timeoutId);
+        if (isCurrent()) setLoading(false);
       }
     })();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      controller.abort();
+    };
   }, [contextGraphId]);
 
   const { nodeColors, conflicts } = useMemo(() => {

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -378,6 +378,8 @@ export function LayerGraphPanel({
     () => buildLayerGraphOptions(layer, layer === 'swm' ? swmAttr.nodeColors : undefined),
     [layer, swmAttr.nodeColors],
   );
+  const graphKey = `${contextGraphId ?? 'context'}:${layer}`;
+  const swmAttributionPending = layer === 'swm' && Boolean(contextGraphId) && swmAttr.loading;
 
   if (uniqueTriples.length === 0) {
     return (
@@ -387,10 +389,19 @@ export function LayerGraphPanel({
     );
   }
 
+  if (swmAttributionPending) {
+    return (
+      <div className="v10-graph-view v10-graph-view-fill">
+        <span className="v10-graph-placeholder">Loading Shared Working Memory attribution...</span>
+      </div>
+    );
+  }
+
   return (
     <div className="v10-graph-view v10-graph-view-fill" style={{ position: 'relative' }}>
       <Suspense fallback={<span className="v10-graph-placeholder">Loading graph...</span>}>
         <RdfGraph
+          key={graphKey}
           data={uniqueTriples}
           format="triples"
           options={graphOptions}

--- a/packages/node-ui/test/layer-graph-panel.test.ts
+++ b/packages/node-ui/test/layer-graph-panel.test.ts
@@ -69,6 +69,7 @@ describe('LayerGraphPanel graph lifecycle', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -152,9 +153,48 @@ describe('LayerGraphPanel graph lifecycle', () => {
     expect(graph.getAttribute('data-default-color')).toBe('#f59e0b');
   });
 
+  it('releases the SWM graph if attribution lookup stalls', async () => {
+    vi.useFakeTimers();
+    let requestSignal: AbortSignal | undefined;
+    vi.stubGlobal('fetch', vi.fn((_url, init?: RequestInit) => {
+      requestSignal = init?.signal as AbortSignal | undefined;
+      return new Promise(() => {});
+    }));
+    const { LayerGraphPanel } = await import('../src/ui/views/project/components.js');
+
+    await act(async () => {
+      root.render(React.createElement(LayerGraphPanel, {
+        layer: 'swm',
+        triples,
+        contextGraphId: 'cg-1',
+      }));
+    });
+
+    expect(container.textContent).toContain('Loading Shared Working Memory attribution...');
+    expect(container.querySelector('[data-testid="rdf-graph"]')).toBeNull();
+    expect(requestSignal?.aborted).toBe(false);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+    vi.useRealTimers();
+
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
+    });
+
+    const graph = container.querySelector('[data-testid="rdf-graph"]') as HTMLElement;
+    expect(requestSignal?.aborted).toBe(true);
+    expect(graph.getAttribute('data-default-color')).toBe('#f59e0b');
+    expect(JSON.parse(graph.getAttribute('data-node-colors') ?? '{}')).toEqual({});
+  });
+
   it('invalidates in-flight attribution when the hook is disabled', async () => {
     const resolvers: Array<(response: any) => void> = [];
-    vi.stubGlobal('fetch', vi.fn(() => new Promise((resolve) => {
+    const signals: AbortSignal[] = [];
+    vi.stubGlobal('fetch', vi.fn((_url, init?: RequestInit) => new Promise((resolve) => {
+      if (init?.signal) signals.push(init.signal as AbortSignal);
       resolvers.push(resolve);
     })));
     const { LayerGraphPanel } = await import('../src/ui/views/project/components.js');
@@ -178,6 +218,7 @@ describe('LayerGraphPanel graph lifecycle', () => {
     await waitForAssertion(() => {
       expect(container.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
     });
+    expect(signals[0]?.aborted).toBe(true);
 
     await act(async () => {
       resolvers[0]!({

--- a/packages/node-ui/test/layer-graph-panel.test.ts
+++ b/packages/node-ui/test/layer-graph-panel.test.ts
@@ -1,0 +1,264 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+const graphState = vi.hoisted(() => ({
+  mounts: [] as string[],
+  unmounts: [] as string[],
+}));
+
+vi.mock('@origintrail-official/dkg-graph-viz/react', async () => {
+  const React = await import('react');
+  return {
+    RdfGraph(props: any) {
+      const defaultColor = props.options?.style?.defaultNodeColor ?? '';
+      React.useEffect(() => {
+        graphState.mounts.push(defaultColor);
+        return () => {
+          graphState.unmounts.push(defaultColor);
+        };
+      }, [defaultColor]);
+
+      return React.createElement('div', {
+        'data-testid': 'rdf-graph',
+        'data-default-color': defaultColor,
+        'data-node-colors': JSON.stringify(props.options?.style?.nodeColors ?? {}),
+      });
+    },
+  };
+});
+
+const triples = [{
+  subject: 'urn:test:root',
+  predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+  object: 'http://schema.org/Thing',
+}];
+
+async function waitForAssertion(assertion: () => void): Promise<void> {
+  const started = Date.now();
+  let lastError: unknown;
+  while (Date.now() - started < 1000) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      lastError = err;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+  }
+  throw lastError;
+}
+
+describe('LayerGraphPanel graph lifecycle', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    graphState.mounts.length = 0;
+    graphState.unmounts.length = 0;
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('waits for SWM attribution colors before first graph paint', async () => {
+    let resolveFetch!: (response: any) => void;
+    vi.stubGlobal('fetch', vi.fn(() => new Promise((resolve) => {
+      resolveFetch = resolve;
+    })));
+
+    const { LayerGraphPanel } = await import('../src/ui/views/project/components.js');
+
+    await act(async () => {
+      root.render(React.createElement(LayerGraphPanel, {
+        layer: 'swm',
+        triples,
+        contextGraphId: 'cg-1',
+      }));
+    });
+
+    expect(container.textContent).toContain('Loading Shared Working Memory attribution...');
+    expect(container.querySelector('[data-testid="rdf-graph"]')).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFetch({
+        ok: true,
+        json: async () => ({
+          result: {
+            bindings: [{
+              op: { value: 'urn:test:op' },
+              root: { value: 'urn:test:root' },
+              agent: { value: 'did:dkg:agent:alice' },
+              publishedAt: { value: '2026-05-22T00:00:00.000Z' },
+              g: { value: 'did:dkg:context-graph:cg-1/_shared_memory_meta' },
+            }],
+          },
+        }),
+      });
+    });
+
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
+    });
+
+    const graph = container.querySelector('[data-testid="rdf-graph"]') as HTMLElement;
+    const nodeColors = JSON.parse(graph.getAttribute('data-node-colors') ?? '{}');
+    expect(nodeColors['urn:test:root']).toBeTruthy();
+    expect(container.textContent).not.toContain('Loading Shared Working Memory attribution...');
+  });
+
+  it('releases the SWM graph after attribution lookup fails', async () => {
+    let resolveFetch!: (response: any) => void;
+    vi.stubGlobal('fetch', vi.fn(() => new Promise((resolve) => {
+      resolveFetch = resolve;
+    })));
+    const { LayerGraphPanel } = await import('../src/ui/views/project/components.js');
+
+    await act(async () => {
+      root.render(React.createElement(LayerGraphPanel, {
+        layer: 'swm',
+        triples,
+        contextGraphId: 'cg-1',
+      }));
+    });
+
+    expect(container.querySelector('[data-testid="rdf-graph"]')).toBeNull();
+
+    await act(async () => {
+      resolveFetch({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      });
+    });
+
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
+    });
+
+    const graph = container.querySelector('[data-testid="rdf-graph"]') as HTMLElement;
+    expect(graph.getAttribute('data-default-color')).toBe('#f59e0b');
+  });
+
+  it('invalidates in-flight attribution when the hook is disabled', async () => {
+    const resolvers: Array<(response: any) => void> = [];
+    vi.stubGlobal('fetch', vi.fn(() => new Promise((resolve) => {
+      resolvers.push(resolve);
+    })));
+    const { LayerGraphPanel } = await import('../src/ui/views/project/components.js');
+
+    await act(async () => {
+      root.render(React.createElement(LayerGraphPanel, {
+        layer: 'swm',
+        triples,
+        contextGraphId: 'cg-1',
+      }));
+    });
+    expect(container.querySelector('[data-testid="rdf-graph"]')).toBeNull();
+
+    await act(async () => {
+      root.render(React.createElement(LayerGraphPanel, {
+        layer: 'wm',
+        triples,
+        contextGraphId: 'cg-1',
+      }));
+    });
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
+    });
+
+    await act(async () => {
+      resolvers[0]!({
+        ok: true,
+        json: async () => ({
+          result: {
+            bindings: [{
+              op: { value: 'urn:test:op' },
+              root: { value: 'urn:test:root' },
+              agent: { value: 'did:dkg:agent:alice' },
+              publishedAt: { value: '2026-05-22T00:00:00.000Z' },
+              g: { value: 'did:dkg:context-graph:cg-1/_shared_memory_meta' },
+            }],
+          },
+        }),
+      });
+    });
+
+    graphState.mounts.length = 0;
+    graphState.unmounts.length = 0;
+
+    await act(async () => {
+      root.render(React.createElement(LayerGraphPanel, {
+        layer: 'swm',
+        triples,
+        contextGraphId: 'cg-1',
+      }));
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain('Loading Shared Working Memory attribution...');
+    expect(container.querySelector('[data-testid="rdf-graph"]')).toBeNull();
+    expect(graphState.mounts).toEqual([]);
+
+    await act(async () => {
+      resolvers[1]!({
+        ok: true,
+        json: async () => ({
+          result: {
+            bindings: [{
+              op: { value: 'urn:test:op-2' },
+              root: { value: 'urn:test:root' },
+              agent: { value: 'did:dkg:agent:bob' },
+              publishedAt: { value: '2026-05-22T00:01:00.000Z' },
+              g: { value: 'did:dkg:context-graph:cg-1/_shared_memory_meta' },
+            }],
+          },
+        }),
+      });
+    });
+
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
+    });
+  });
+
+  it('remounts the graph when the active layer changes', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const { LayerGraphPanel } = await import('../src/ui/views/project/components.js');
+
+    await act(async () => {
+      root.render(React.createElement(LayerGraphPanel, {
+        layer: 'wm',
+        triples,
+      }));
+    });
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
+    });
+
+    await act(async () => {
+      root.render(React.createElement(LayerGraphPanel, {
+        layer: 'swm',
+        triples,
+      }));
+    });
+    await waitForAssertion(() => {
+      expect(graphState.mounts).toHaveLength(2);
+    });
+
+    expect(graphState.mounts).toEqual(['#64748b', '#f59e0b']);
+    expect(graphState.unmounts).toEqual(['#64748b']);
+  });
+});


### PR DESCRIPTION
## Summary

- Remount Context Graph layer graphs per context/layer identity so stale `RdfGraph` styling cannot carry across WM/SWM/VM switches.
- Gate the SWM graph until attribution lookup resolves or fails, preventing a first paint with missing `nodeColors`.
- Invalidate in-flight SWM attribution requests when the hook is disabled, so leaving and returning to SWM cannot unlock a stale render.

## Related

- Follow-up to #598
- First-wave Context Graph UX rollout PR 1.3 / M3
- Parallel to #599

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/views/project/components.tsx` | Keys layer graph instances and shows an SWM attribution loading placeholder before graph render. |
| `packages/node-ui/src/ui/hooks/useSwmAttributions.ts` | Tracks resolved context graph id and invalidates stale in-flight attribution requests. |
| `packages/node-ui/test/layer-graph-panel.test.ts` | Covers SWM first-paint gating, attribution failure fallback, in-flight invalidation, and graph remounting. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/layer-graph-panel.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/layer-graph-panel.test.ts test/ui-compat.test.ts test/use-memory-entities-live-updates.test.ts test/use-memory-entities-partial.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui`
- [x] `git diff --check`
- [x] Browser boot smoke at `http://localhost:9200/ui/` with no console errors.
- [x] Populated-node browser graph check on `Hello World`: WM and SWM graph canvases render nonblank; WM→SWM→WM keeps WM slate and does not carry amber back into WM.
- [x] Local PR review: 2 rounds, final result had no actionable comments.

Note: multi-agent attribution quality remains out of scope for M3 and is still gated for N3/G-Q15.
