### PR TITLE
fix(node-ui): rebuild verifiable memory panel

### DIFF
--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -3,6 +3,8 @@ import { authHeaders } from '../api.js';
 import { useMemoryGraphEvents } from './useNodeEvents.js';
 
 export type TrustLevel = 'working' | 'shared' | 'verified';
+export type MemoryLayerKey = 'wm' | 'swm' | 'vm';
+export type MemoryLayerStatus = 'loading' | 'ok' | 'error';
 
 export interface MemoryEntity {
   uri: string;
@@ -40,6 +42,8 @@ export interface MemoryData {
   /** True when some (but not all) layer queries failed — counts are
    *  incomplete but not absent. `error` stays null in this case. */
   partial: boolean;
+  /** Per-layer query status so UI can distinguish a VM miss from WM/SWM failures. */
+  layerStatus: Record<MemoryLayerKey, MemoryLayerStatus>;
   refresh: () => void;
 }
 
@@ -174,6 +178,18 @@ function subGraphOf(gUri: string, cgId: string): string | undefined {
 
 interface LayerResult { triples: Triple[]; ok: boolean }
 
+const LOADING_LAYER_STATUS: Record<MemoryLayerKey, MemoryLayerStatus> = {
+  wm: 'loading',
+  swm: 'loading',
+  vm: 'loading',
+};
+
+const ERROR_LAYER_STATUS: Record<MemoryLayerKey, MemoryLayerStatus> = {
+  wm: 'error',
+  swm: 'error',
+  vm: 'error',
+};
+
 async function queryLayer(
   sparql: string,
   contextGraphId: string,
@@ -300,6 +316,9 @@ export function useMemoryEntities(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [partial, setPartial] = useState(false);
+  const [layerStatus, setLayerStatus] = useState<Record<MemoryLayerKey, MemoryLayerStatus>>(
+    LOADING_LAYER_STATUS,
+  );
   const versionRef = useRef(0);
 
   const fetchAll = useCallback(async () => {
@@ -308,6 +327,7 @@ export function useMemoryEntities(
     setLoading(true);
     setError(null);
     setPartial(false);
+    setLayerStatus(LOADING_LAYER_STATUS);
 
     try {
       // queryLayer never throws — it returns { triples, ok }. We keep
@@ -328,6 +348,11 @@ export function useMemoryEntities(
       ];
 
       setLayeredTriples(all);
+      setLayerStatus({
+        wm: wmR.ok ? 'ok' : 'error',
+        swm: swmR.ok ? 'ok' : 'error',
+        vm: vmR.ok ? 'ok' : 'error',
+      });
       const failed = [wmR, swmR, vmR].filter(r => !r.ok).length;
       // `partial` is computed UNCONDITIONALLY for every caller — it was
       // previously dead unless a caller opted in, making truncated
@@ -340,6 +365,7 @@ export function useMemoryEntities(
     } catch (err: any) {
       if (version === versionRef.current) {
         setError(err.message ?? 'Failed to load memory data');
+        setLayerStatus(ERROR_LAYER_STATUS);
       }
     } finally {
       if (version === versionRef.current) setLoading(false);
@@ -400,6 +426,7 @@ export function useMemoryEntities(
     loading,
     error,
     partial,
+    layerStatus,
     refresh: fetchAll,
   };
 }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -4019,71 +4019,89 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
 
 /* ── Verified Memory Hero Banner ── */
 .v10-vm-hero {
+  --v10-vm-accent: #86efac;
+  --v10-vm-accent-strong: var(--layer-verified);
+  --v10-vm-border: color-mix(in srgb, var(--v10-vm-accent-strong) 28%, var(--border-default));
+  --v10-vm-surface: color-mix(in srgb, var(--v10-vm-accent-strong) 8%, var(--bg-surface));
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 14px 16px;
+  gap: 14px;
+  padding: 16px;
   margin-bottom: 10px;
   /* Banner sits above the scrollable EntityList inside a fixed-height
      (70vh) flex-column. Without flex-shrink:0 it competes with the list
      for vertical space and squeezes the list below the visible region,
      which makes scrolling the list impossible. */
   flex-shrink: 0;
-  background: linear-gradient(135deg,
-    rgba(34,197,94,0.14) 0%,
-    rgba(59,130,246,0.10) 50%,
-    rgba(168,85,247,0.10) 100%);
-  border: 1px solid rgba(34,197,94,0.35);
-  border-radius: 12px;
-  box-shadow: 0 0 0 1px rgba(34,197,94,0.15) inset,
-              0 8px 30px -10px rgba(34,197,94,0.25);
+  background: color-mix(in srgb, var(--v10-vm-accent-strong) 5%, var(--bg-panel));
+  border: 1px solid var(--v10-vm-border);
+  border-radius: 10px;
+  box-shadow: none;
 }
 .v10-vm-hero-title {
   display: flex;
-  align-items: center;
-  gap: 10px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.v10-vm-hero-heading {
+  display: flex;
+  flex: 1 1 220px;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
 }
 .v10-vm-hero-badge {
   display: inline-flex;
   align-items: center;
-  padding: 3px 10px;
+  flex: 0 0 auto;
+  padding: 4px 10px;
   border-radius: 999px;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
-  background: rgba(34,197,94,0.22);
-  color: #86efac;
-  border: 1px solid rgba(34,197,94,0.45);
-  letter-spacing: 0.05em;
+  background: rgba(34,197,94,0.16);
+  color: var(--v10-vm-accent);
+  border: 1px solid var(--v10-vm-border);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 .v10-vm-hero-headline {
-  font-size: 13px;
-  color: var(--text-secondary, #cbd5e1);
-  font-weight: 500;
+  font-size: 14px;
+  line-height: 1.35;
+  color: var(--text-primary, #f8fafc);
+  font-weight: 650;
+}
+.v10-vm-hero-context {
+  max-width: 100%;
+  font-size: 12px;
+  line-height: 1.35;
+  color: var(--text-tertiary, #94a3b8);
+  overflow-wrap: anywhere;
 }
 .v10-vm-hero-stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 12px;
 }
 .v10-vm-hero-stat {
-  padding: 8px 12px;
-  background: rgba(0,0,0,0.22);
-  border: 1px solid rgba(255,255,255,0.06);
+  padding: 12px 14px;
+  background: var(--v10-vm-surface);
+  border: 1px solid var(--v10-vm-border);
   border-radius: 8px;
 }
 .v10-vm-hero-stat-val {
-  font-size: 20px;
+  font-size: 24px;
   font-weight: 700;
   color: var(--text-primary, #f8fafc);
   font-family: var(--font-mono, ui-monospace);
   line-height: 1.1;
 }
 .v10-vm-hero-stat-lbl {
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: 11px;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
   color: var(--text-tertiary, #94a3b8);
-  margin-top: 3px;
+  margin-top: 6px;
 }
 .v10-vm-hero-strip {
   display: flex;
@@ -4094,12 +4112,12 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 10px;
+  padding: 5px 10px;
   font-size: 11px;
   font-weight: 600;
   color: var(--text-secondary, #cbd5e1);
-  background: rgba(0,0,0,0.25);
-  border: 1px solid rgba(255,255,255,0.08);
+  background: var(--v10-vm-surface);
+  border: 1px solid var(--v10-vm-border);
   border-radius: 999px;
 }
 .v10-vm-hero-chip-dot {
@@ -4107,6 +4125,53 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   height: 6px;
   border-radius: 999px;
   box-shadow: 0 0 6px currentColor;
+}
+body.light .v10-vm-hero {
+  --v10-vm-accent: #166534;
+  --v10-vm-accent-strong: #16a34a;
+}
+.v10-vm-hero-empty {
+  gap: 16px;
+}
+.v10-vm-empty-state {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  background: var(--v10-vm-surface);
+  border: 1px solid var(--v10-vm-border);
+  border-radius: 8px;
+}
+.v10-vm-empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  color: var(--v10-vm-accent);
+  background: rgba(34,197,94,0.14);
+  border: 1px solid var(--v10-vm-border);
+  font-size: 15px;
+  line-height: 1;
+}
+.v10-vm-empty-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+.v10-vm-empty-title {
+  font-size: 14px;
+  line-height: 1.35;
+  font-weight: 650;
+  color: var(--text-primary, #f8fafc);
+}
+.v10-vm-empty-text {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-secondary, #cbd5e1);
 }
 
 /* ── VM graph legend (floating overlay) ──

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1021,7 +1021,8 @@ export function LayerContent({
   const config = LAYER_CONFIG[layer];
   const itemsLabel = layer === 'vm' ? 'Knowledge Assets' : 'Entities';
   const isInitialVerifiedMemoryLoad = layer === 'vm' && memory.loading && entities.length === 0;
-  const isEmptyVerifiedMemory = layer === 'vm' && !memory.loading && entities.length === 0;
+  const isVerifiedMemoryUnavailable = layer === 'vm' && !memory.loading && memory.partial && entities.length === 0;
+  const isEmptyVerifiedMemory = layer === 'vm' && !memory.loading && !memory.partial && entities.length === 0;
 
   const handleTab = (tab: LayerContentTab) => (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1053,7 +1054,7 @@ export function LayerContent({
 
       {activeTab === 'items' && (
         <div className="v10-layer-expand-body entities-tab">
-          {layer === 'vm' && !isInitialVerifiedMemoryLoad && (
+          {layer === 'vm' && !isInitialVerifiedMemoryLoad && !isVerifiedMemoryUnavailable && (
             <VerifiedMemoryHeroBanner
               entities={entities}
               tripleCount={tripleCount}
@@ -1065,7 +1066,16 @@ export function LayerContent({
               <div className="v10-canvas-empty">
                 <div className="v10-canvas-empty-icon">◉</div>
                 <div className="v10-canvas-empty-text">
-                  Loading Verifiable Memory...
+                  Loading Verified Memory...
+                </div>
+              </div>
+            </div>
+          ) : isVerifiedMemoryUnavailable ? (
+            <div className="v10-layer-widgets-strip empty">
+              <div className="v10-canvas-empty">
+                <div className="v10-canvas-empty-icon">◉</div>
+                <div className="v10-canvas-empty-text">
+                  Verified Memory status unavailable.
                 </div>
               </div>
             </div>
@@ -1134,7 +1144,7 @@ export function VerifiedMemoryHeroBanner({ entities, tripleCount, contextGraphId
     return (
       <div className="v10-vm-hero v10-vm-hero-empty">
         <div className="v10-vm-hero-title">
-          <span className="v10-vm-hero-badge">◉ Verifiable Memory</span>
+          <span className="v10-vm-hero-badge">◉ Verified Memory</span>
           <div className="v10-vm-hero-heading">
             <span className="v10-vm-hero-headline">Nothing published yet</span>
             <span className="v10-vm-hero-context" title={contextGraphId}>
@@ -1158,7 +1168,7 @@ export function VerifiedMemoryHeroBanner({ entities, tripleCount, contextGraphId
   return (
     <div className="v10-vm-hero">
       <div className="v10-vm-hero-title">
-        <span className="v10-vm-hero-badge">◉ Verifiable Memory</span>
+        <span className="v10-vm-hero-badge">◉ Verified Memory</span>
         <div className="v10-vm-hero-heading">
           <span className="v10-vm-hero-headline">On-chain anchored · cryptographically signed</span>
           <span className="v10-vm-hero-context" title={contextGraphId}>

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1020,9 +1020,10 @@ export function LayerContent({
 }) {
   const config = LAYER_CONFIG[layer];
   const itemsLabel = layer === 'vm' ? 'Knowledge Assets' : 'Entities';
-  const isInitialVerifiedMemoryLoad = layer === 'vm' && memory.loading && entities.length === 0;
-  const isVerifiedMemoryUnavailable = layer === 'vm' && !memory.loading && memory.partial && entities.length === 0;
-  const isEmptyVerifiedMemory = layer === 'vm' && !memory.loading && !memory.partial && entities.length === 0;
+  const vmLayerStatus = memory.layerStatus?.vm ?? (memory.loading ? 'loading' : memory.error ? 'error' : 'ok');
+  const isInitialVerifiedMemoryLoad = layer === 'vm' && vmLayerStatus === 'loading' && entities.length === 0;
+  const isVerifiedMemoryUnavailable = layer === 'vm' && vmLayerStatus === 'error' && entities.length === 0;
+  const isEmptyVerifiedMemory = layer === 'vm' && vmLayerStatus === 'ok' && entities.length === 0;
 
   const handleTab = (tab: LayerContentTab) => (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1020,6 +1020,8 @@ export function LayerContent({
 }) {
   const config = LAYER_CONFIG[layer];
   const itemsLabel = layer === 'vm' ? 'Knowledge Assets' : 'Entities';
+  const isInitialVerifiedMemoryLoad = layer === 'vm' && memory.loading && entities.length === 0;
+  const isEmptyVerifiedMemory = layer === 'vm' && !memory.loading && entities.length === 0;
 
   const handleTab = (tab: LayerContentTab) => (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1051,26 +1053,39 @@ export function LayerContent({
 
       {activeTab === 'items' && (
         <div className="v10-layer-expand-body entities-tab">
-          {layer === 'vm' && (
+          {layer === 'vm' && !isInitialVerifiedMemoryLoad && (
             <VerifiedMemoryHeroBanner
               entities={entities}
               tripleCount={tripleCount}
               contextGraphId={contextGraphId}
             />
           )}
-          <LayerWidgetStrip
-            layer={layer}
-            entities={entities}
-            tripleCount={tripleCount}
-            contextGraphId={contextGraphId}
-            onComplete={memory.refresh}
-          />
-          <EntityList
-            entities={entities}
-            layerKey={layer}
-            layerIcon={config.icon}
-            onSelectEntity={onSelectEntity}
-          />
+          {isInitialVerifiedMemoryLoad ? (
+            <div className="v10-layer-widgets-strip empty">
+              <div className="v10-canvas-empty">
+                <div className="v10-canvas-empty-icon">◉</div>
+                <div className="v10-canvas-empty-text">
+                  Loading Verifiable Memory...
+                </div>
+              </div>
+            </div>
+          ) : !isEmptyVerifiedMemory && (
+            <>
+              <LayerWidgetStrip
+                layer={layer}
+                entities={entities}
+                tripleCount={tripleCount}
+                contextGraphId={contextGraphId}
+                onComplete={memory.refresh}
+              />
+              <EntityList
+                entities={entities}
+                layerKey={layer}
+                layerIcon={config.icon}
+                onSelectEntity={onSelectEntity}
+              />
+            </>
+          )}
           {footer}
         </div>
       )}
@@ -1115,11 +1130,41 @@ export function VerifiedMemoryHeroBanner({ entities, tripleCount, contextGraphId
   for (const e of entities) for (const t of e.types) typeSet.add(t);
   const typeCount = typeSet.size;
 
+  if (totalAssets === 0) {
+    return (
+      <div className="v10-vm-hero v10-vm-hero-empty">
+        <div className="v10-vm-hero-title">
+          <span className="v10-vm-hero-badge">◉ Verifiable Memory</span>
+          <div className="v10-vm-hero-heading">
+            <span className="v10-vm-hero-headline">Nothing published yet</span>
+            <span className="v10-vm-hero-context" title={contextGraphId}>
+              Context Graph: {contextGraphId}
+            </span>
+          </div>
+        </div>
+        <div className="v10-vm-empty-state">
+          <div className="v10-vm-empty-icon">◉</div>
+          <div className="v10-vm-empty-copy">
+            <div className="v10-vm-empty-title">No Knowledge Assets yet.</div>
+            <div className="v10-vm-empty-text">
+              Publish entities from Shared Working Memory to verify them on-chain.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="v10-vm-hero">
       <div className="v10-vm-hero-title">
-        <span className="v10-vm-hero-badge">◉ Verified</span>
-        <span className="v10-vm-hero-headline">On-chain anchored · cryptographically signed</span>
+        <span className="v10-vm-hero-badge">◉ Verifiable Memory</span>
+        <div className="v10-vm-hero-heading">
+          <span className="v10-vm-hero-headline">On-chain anchored · cryptographically signed</span>
+          <span className="v10-vm-hero-context" title={contextGraphId}>
+            Context Graph: {contextGraphId}
+          </span>
+        </div>
       </div>
       <div className="v10-vm-hero-stats">
         <div className="v10-vm-hero-stat">
@@ -1133,10 +1178,6 @@ export function VerifiedMemoryHeroBanner({ entities, tripleCount, contextGraphId
         <div className="v10-vm-hero-stat">
           <div className="v10-vm-hero-stat-val">{typeCount}</div>
           <div className="v10-vm-hero-stat-lbl">Entity Types</div>
-        </div>
-        <div className="v10-vm-hero-stat">
-          <div className="v10-vm-hero-stat-val" title={contextGraphId}>{contextGraphId.slice(0, 10)}…</div>
-          <div className="v10-vm-hero-stat-lbl">Context Graph</div>
         </div>
       </div>
       <div className="v10-vm-hero-strip">

--- a/packages/node-ui/test/use-memory-entities-partial.test.ts
+++ b/packages/node-ui/test/use-memory-entities-partial.test.ts
@@ -34,6 +34,9 @@ function Probe({ id }: { id: string }) {
     'data-loading': String(m.loading),
     'data-error': String(m.error),
     'data-partial': String(m.partial),
+    'data-wm-status': m.layerStatus.wm,
+    'data-swm-status': m.layerStatus.swm,
+    'data-vm-status': m.layerStatus.vm,
     'data-wm': String(m.counts.wm),
     'data-vm': String(m.counts.vm),
     'data-total': String(m.counts.total),
@@ -95,6 +98,9 @@ describe('useMemoryEntities — partial layer failure', () => {
     // One layer (SWM) failed → partial, NOT a hard error.
     expect(el.getAttribute('data-error')).toBe('null');
     expect(el.getAttribute('data-partial')).toBe('true');
+    expect(el.getAttribute('data-wm-status')).toBe('ok');
+    expect(el.getAttribute('data-swm-status')).toBe('error');
+    expect(el.getAttribute('data-vm-status')).toBe('ok');
     // WM + VM still populated despite SWM's 500.
     expect(el.getAttribute('data-wm')).toBe('2');
     expect(el.getAttribute('data-vm')).toBe('1');

--- a/packages/node-ui/test/vm-hero-banner.test.ts
+++ b/packages/node-ui/test/vm-hero-banner.test.ts
@@ -84,6 +84,7 @@ describe('VerifiedMemoryHeroBanner', () => {
     });
 
     expect(container.querySelector('.v10-vm-empty-state')).toBeTruthy();
+    expect(container.textContent).toContain('Verified Memory');
     expect(container.textContent).toContain('Nothing published yet');
     expect(container.textContent).toContain('No Knowledge Assets yet.');
     expect(container.textContent).toContain('Publish entities from Shared Working Memory');
@@ -141,6 +142,39 @@ describe('VerifiedMemoryHeroBanner', () => {
     expect(container.querySelector('.v10-vm-empty-state')).toBeTruthy();
     expect(container.querySelector('.v10-layer-widgets-strip')).toBeNull();
     expect(container.querySelector('.v10-entity-list')).toBeNull();
+    expect(container.textContent).toContain('View full layer');
+
+    await unmount();
+  });
+
+  it('suppresses the empty VM hero while memory layer loading is partial', async () => {
+    const { container, unmount } = await renderLayerContent({
+      layer: 'vm',
+      entities: [],
+      tripleCount: 0,
+      layerTriples: [],
+      contextGraphId: 'cg-partial',
+      memory: {
+        entities: new Map(),
+        entityList: [],
+        allTriples: [],
+        graphTriples: [],
+        trustMap: new Map(),
+        counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+        loading: false,
+        error: null,
+        partial: true,
+        refresh: () => {},
+      } as any,
+      activeTab: 'items',
+      onTabChange: () => {},
+      onSelectEntity: () => {},
+      footer: React.createElement('button', null, 'View full layer'),
+    });
+
+    expect(container.querySelector('.v10-vm-empty-state')).toBeNull();
+    expect(container.textContent).not.toContain('Nothing published yet');
+    expect(container.textContent).toContain('Verified Memory status unavailable.');
     expect(container.textContent).toContain('View full layer');
 
     await unmount();

--- a/packages/node-ui/test/vm-hero-banner.test.ts
+++ b/packages/node-ui/test/vm-hero-banner.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LayerContent, VerifiedMemoryHeroBanner } from '../src/ui/views/project/components.js';
+import type { MemoryEntity } from '../src/ui/hooks/useMemoryEntities.js';
+
+function memoryEntity(uri: string, types: string[]): MemoryEntity {
+  return {
+    uri,
+    label: uri,
+    types,
+    trustLevel: 'verified',
+    layers: new Set(['verified']),
+    subGraphs: new Set(['public']),
+    properties: new Map(),
+    connections: [],
+  };
+}
+
+async function renderVmHero(props: {
+  entities: MemoryEntity[];
+  tripleCount: number;
+  contextGraphId: string;
+}): Promise<{ container: HTMLDivElement; unmount: () => Promise<void> }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(React.createElement(VerifiedMemoryHeroBanner, props));
+  });
+
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+async function renderLayerContent(props: React.ComponentProps<typeof LayerContent>): Promise<{
+  container: HTMLDivElement;
+  unmount: () => Promise<void>;
+}> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(React.createElement(LayerContent, props));
+  });
+
+  return {
+    container,
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe('VerifiedMemoryHeroBanner', () => {
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('shows a purposeful empty VM state instead of a zero-stat hero', async () => {
+    const { container, unmount } = await renderVmHero({
+      entities: [],
+      tripleCount: 0,
+      contextGraphId: 'cg-empty',
+    });
+
+    expect(container.querySelector('.v10-vm-empty-state')).toBeTruthy();
+    expect(container.textContent).toContain('Nothing published yet');
+    expect(container.textContent).toContain('No Knowledge Assets yet.');
+    expect(container.textContent).toContain('Publish entities from Shared Working Memory');
+    expect(container.querySelectorAll('.v10-vm-hero-stat')).toHaveLength(0);
+
+    await unmount();
+  });
+
+  it('keeps populated stats numeric and moves the context graph id out of the stat row', async () => {
+    const { container, unmount } = await renderVmHero({
+      entities: [
+        memoryEntity('asset-1', ['http://schema.org/Thing']),
+        memoryEntity('asset-2', ['http://schema.org/Thing', 'http://schema.org/CreativeWork']),
+      ],
+      tripleCount: 1234,
+      contextGraphId: 'cg-populated',
+    });
+
+    const statValues = Array.from(container.querySelectorAll('.v10-vm-hero-stat-val'))
+      .map((node) => node.textContent);
+
+    expect(statValues).toEqual(['2', (1234).toLocaleString(), '2']);
+    expect(container.querySelector('.v10-vm-hero-context')?.textContent).toContain('cg-populated');
+    expect(statValues.some((value) => value?.includes('cg-populated'))).toBe(false);
+    expect(container.querySelector('.v10-vm-empty-state')).toBeNull();
+
+    await unmount();
+  });
+
+  it('uses only the VM empty hero while preserving the caller footer', async () => {
+    const { container, unmount } = await renderLayerContent({
+      layer: 'vm',
+      entities: [],
+      tripleCount: 0,
+      layerTriples: [],
+      contextGraphId: 'cg-empty',
+      memory: {
+        entities: new Map(),
+        entityList: [],
+        allTriples: [],
+        graphTriples: [],
+        trustMap: new Map(),
+        counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+        loading: false,
+        error: null,
+        partial: false,
+        refresh: () => {},
+      } as any,
+      activeTab: 'items',
+      onTabChange: () => {},
+      onSelectEntity: () => {},
+      footer: React.createElement('button', null, 'View full layer'),
+    });
+
+    expect(container.querySelector('.v10-vm-empty-state')).toBeTruthy();
+    expect(container.querySelector('.v10-layer-widgets-strip')).toBeNull();
+    expect(container.querySelector('.v10-entity-list')).toBeNull();
+    expect(container.textContent).toContain('View full layer');
+
+    await unmount();
+  });
+});

--- a/packages/node-ui/test/vm-hero-banner.test.ts
+++ b/packages/node-ui/test/vm-hero-banner.test.ts
@@ -131,6 +131,7 @@ describe('VerifiedMemoryHeroBanner', () => {
         loading: false,
         error: null,
         partial: false,
+        layerStatus: { wm: 'ok', swm: 'ok', vm: 'ok' },
         refresh: () => {},
       } as any,
       activeTab: 'items',
@@ -147,7 +148,7 @@ describe('VerifiedMemoryHeroBanner', () => {
     await unmount();
   });
 
-  it('suppresses the empty VM hero while memory layer loading is partial', async () => {
+  it('keeps the empty VM hero when another layer is partial but VM loaded successfully', async () => {
     const { container, unmount } = await renderLayerContent({
       layer: 'vm',
       entities: [],
@@ -164,6 +165,41 @@ describe('VerifiedMemoryHeroBanner', () => {
         loading: false,
         error: null,
         partial: true,
+        layerStatus: { wm: 'error', swm: 'ok', vm: 'ok' },
+        refresh: () => {},
+      } as any,
+      activeTab: 'items',
+      onTabChange: () => {},
+      onSelectEntity: () => {},
+      footer: React.createElement('button', null, 'View full layer'),
+    });
+
+    expect(container.querySelector('.v10-vm-empty-state')).toBeTruthy();
+    expect(container.textContent).toContain('Nothing published yet');
+    expect(container.textContent).not.toContain('Verified Memory status unavailable.');
+    expect(container.textContent).toContain('View full layer');
+
+    await unmount();
+  });
+
+  it('suppresses the empty VM hero when the VM layer failed to load', async () => {
+    const { container, unmount } = await renderLayerContent({
+      layer: 'vm',
+      entities: [],
+      tripleCount: 0,
+      layerTriples: [],
+      contextGraphId: 'cg-vm-error',
+      memory: {
+        entities: new Map(),
+        entityList: [],
+        allTriples: [],
+        graphTriples: [],
+        trustMap: new Map(),
+        counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+        loading: false,
+        error: null,
+        partial: false,
+        layerStatus: { wm: 'error', swm: 'error', vm: 'error' },
         refresh: () => {},
       } as any,
       activeTab: 'items',


### PR DESCRIPTION
## Summary
- Rebuilds the Verifiable Memory hero so the stat row contains numeric stats only and the Context Graph id moves into subtitle metadata.
- Adds a purposeful empty-VM state for zero Knowledge Assets and suppresses the duplicate generic layer/list empty widgets while preserving caller footers.
- Replaces the mismatched green-glow/stat/chip styling with one restrained, theme-aware border/surface treatment and adds focused component/integration coverage.

## Scope / Gates
- Covers first-wave PR 1.6 / M4 only.
- Does not add S10 VM metadata, trust-level breakdowns, chain/token fields, provenance, or publish-flow assumptions.
- G-Q14/Q16 remains a narrow populated-VM re-check once a node with published VM Knowledge Assets is available; the empty-state/craft fix is fully verifiable now.

## Verification
- `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/vm-hero-banner.test.ts`
- `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/vm-hero-banner.test.ts test/ui-compat.test.ts test/use-memory-entities-live-updates.test.ts test/use-memory-entities-partial.test.ts`
- `pnpm --filter @origintrail-official/dkg-node-ui run build`
- `pnpm --filter @origintrail-official/dkg-node-ui run build:ui`
- `git diff --check`
- Branch-local Vite browser smoke at `http://localhost:5176/ui/` with token injected from node-served UI: `Hello World` VM empty state rendered, no duplicate generic empty widgets, no console/page/API errors.
- `900x500` resize probe: VM hero had no internal text overflow.
- Light-theme contrast spot-check after theme-aware surface fix: badge ~6.2:1, headline/title ~15.6:1, context ~4.6:1, body ~8.5:1.

## Local Review
- Temporary local reviewers completed three rounds using `.codex/review-prompt.md` and `.codex/review-schema.json`.
- Fixed valid findings: empty-VM branch preserved footer, LayerContent empty-VM behavior gained coverage, and VM hero styling became light-theme safe.
- Final review round returned `{comments:[]}`.