### PR TITLE
fix(node-ui): improve context graph contrast

### DIFF
--- a/packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx
@@ -263,7 +263,7 @@ export function ImportFilesModal({ open, onClose, contextGraphId, contextGraphNa
                         {r.status === 'success' ? '✓' : r.status === 'skipped' ? '–' : '✗'}
                       </span>
                       <span className="v10-import-file-name">{r.fileName}</span>
-                      <span className="v10-import-file-size" style={r.status === 'error' ? { color: 'var(--accent-red)' } : undefined}>
+                      <span className="v10-import-file-size" style={r.status === 'error' ? { color: 'var(--text-danger)' } : undefined}>
                         {r.status === 'success' && r.triplesWritten != null ? `${r.triplesWritten} triples` :
                          r.status === 'skipped' ? 'stored (no extraction)' :
                          r.error ?? 'failed'}

--- a/packages/node-ui/src/ui/components/Modals/ShareProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/ShareProjectModal.tsx
@@ -254,7 +254,7 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
               {pendingRequests.length > 0 && (
                 <span style={{
                   position: 'absolute', top: 4, right: 4,
-                  background: 'var(--accent-red, #ef4444)', color: '#fff',
+                  background: 'var(--accent-red, #ef4444)', color: 'var(--text-on-accent)',
                   borderRadius: 999, fontSize: 9, fontWeight: 700,
                   padding: '1px 5px', minWidth: 16, textAlign: 'center',
                 }}>
@@ -402,7 +402,7 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
                       onClick={() => handleApprove(req.agentAddress)}
                       disabled={processingRequest === req.agentAddress}
                       style={{
-                        background: 'rgba(34, 197, 94, 0.15)', color: 'var(--accent-green, #22c55e)',
+                        background: 'rgba(34, 197, 94, 0.15)', color: 'var(--text-success)',
                         border: '1px solid rgba(34, 197, 94, 0.3)', cursor: 'pointer',
                         borderRadius: 4, fontSize: 10, padding: '4px 10px', fontWeight: 600,
                       }}
@@ -413,7 +413,7 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
                       onClick={() => handleReject(req.agentAddress)}
                       disabled={processingRequest === req.agentAddress}
                       style={{
-                        background: 'rgba(239, 68, 68, 0.1)', color: 'var(--accent-red, #ef4444)',
+                        background: 'rgba(239, 68, 68, 0.1)', color: 'var(--text-danger)',
                         border: '1px solid rgba(239, 68, 68, 0.2)', cursor: 'pointer',
                         borderRadius: 4, fontSize: 10, padding: '4px 10px', fontWeight: 600,
                       }}
@@ -425,7 +425,7 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
               ))}
 
               {agentError && (
-                <div style={{ fontSize: 10, color: 'var(--accent-red, #ef4444)', marginTop: 4 }}>{agentError}</div>
+                <div style={{ fontSize: 10, color: 'var(--text-danger)', marginTop: 4 }}>{agentError}</div>
               )}
             </div>
           )}

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -43,9 +43,13 @@
   --accent-blue: #3b82f6;
 
   /* Semantic foregrounds (theme-aware) */
+  --text-success: #86efac;
+  --text-warning: #fbbf24;
+  --text-info: #7dd3fc;
   --text-danger: #fca5a5;
   --text-danger-hover: #fecaca;
   --text-link: #60a5fa;
+  --text-on-accent: #111111;
 
   /* Layer identity */
   --layer-working: #64748b;
@@ -116,9 +120,13 @@ body.light {
   --text-tertiary: #6b6b6b;
   --text-ghost: #d4d4d4;
   /* Light-theme danger foreground (~7.4:1 on --bg-elevated #f0f0f0) */
+  --text-success: #166534;
+  --text-warning: #92400e;
+  --text-info: #1d4ed8;
   --text-danger: #b91c1c;
   --text-danger-hover: #991b1b;
   --text-link: #1d4ed8;
+  --text-on-accent: #111111;
   /* Layer accents are NOT overridden in light mode — the slate/amber/
      green from :root carry through, matching the Context Graph and
      project pages (which already use the unified palette in both
@@ -1120,27 +1128,27 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-local-agent-badge.chat_ready,
 .v10-local-agent-status-pill.chat_ready {
-  color: var(--accent-green);
+  color: var(--text-success);
   border-color: color-mix(in srgb, var(--accent-green) 35%, var(--border-subtle));
 }
 .v10-local-agent-badge.connecting,
 .v10-local-agent-status-pill.connecting {
-  color: var(--accent-blue);
+  color: var(--text-info);
   border-color: color-mix(in srgb, var(--accent-blue) 35%, var(--border-subtle));
 }
 .v10-local-agent-badge.bridge_offline,
 .v10-local-agent-status-pill.bridge_offline {
-  color: #f59e0b;
+  color: var(--text-warning);
   border-color: color-mix(in srgb, #f59e0b 35%, var(--border-subtle));
 }
 .v10-local-agent-badge.degraded,
 .v10-local-agent-status-pill.degraded {
-  color: #f59e0b;
+  color: var(--text-warning);
   border-color: color-mix(in srgb, #f59e0b 35%, var(--border-subtle));
 }
 .v10-local-agent-badge.available,
 .v10-local-agent-status-pill.available {
-  color: var(--accent-blue);
+  color: var(--text-info);
   border-color: color-mix(in srgb, var(--accent-blue) 35%, var(--border-subtle));
 }
 .v10-local-agent-detail {
@@ -3028,12 +3036,12 @@ button:focus:not(:focus-visible) { outline: none; }
   border: 1px solid rgba(56, 189, 248, 0.35);
   font-size: 12px;
   font-weight: 500;
-  color: #7dd3fc;
+  color: var(--text-info);
   transition: all 0.15s;
 }
 .v10-mlv-save-btn:hover {
   border-color: rgba(56, 189, 248, 0.65);
-  color: #bae6fd;
+  color: var(--text-link);
 }
 .v10-cg-query-save-panel {
   display: grid;
@@ -3135,7 +3143,7 @@ button:focus:not(:focus-visible) { outline: none; }
      is amber. The fallback only kicks in if the var is undefined, which
      shouldn't happen, but the wrong color leaks a brand inconsistency
      in any token-stripped render. */
-  background: var(--layer-shared, #f59e0b); color: #fff;
+  background: var(--layer-shared, #f59e0b); color: var(--text-on-accent);
   font-size: 11px; font-weight: 600; cursor: pointer; transition: opacity .15s;
 }
 .v10-btn-promote-all:hover { opacity: .85; }
@@ -3155,14 +3163,14 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-btn-promote {
   padding: 3px 10px; border-radius: 5px; background: transparent;
   /* Fallback corrected (PR8 round-4): purple → amber, see promote-all. */
-  border: 1px solid var(--layer-shared, #f59e0b); color: var(--layer-shared, #f59e0b);
+  border: 1px solid var(--layer-shared, #f59e0b); color: var(--text-warning);
   font-size: 11px; font-weight: 500; cursor: pointer; transition: all .15s; flex-shrink: 0;
 }
-.v10-btn-promote:hover { background: var(--layer-shared, #f59e0b); color: #fff; }
+.v10-btn-promote:hover { background: var(--layer-shared, #f59e0b); color: var(--text-on-accent); }
 .v10-btn-promote:disabled { opacity: .5; cursor: not-allowed; }
 .v10-promote-result { padding: 8px 12px; font-size: 12px; }
-.v10-promote-result.success { color: var(--accent-green); background: rgba(34,197,94,.06); }
-.v10-promote-result.error { color: var(--accent-red); background: rgba(239,68,68,.06); }
+.v10-promote-result.success { color: var(--text-success); background: rgba(34,197,94,.06); }
+.v10-promote-result.error { color: var(--text-danger); background: rgba(239,68,68,.06); }
 
 /* ── Publish Panel (SWM → VM) ── */
 .v10-publish-panel {
@@ -3198,7 +3206,7 @@ button:focus:not(:focus-visible) { outline: none; }
   padding: 5px 14px; border-radius: 6px; border: none;
   /* Fallback corrected (PR8 round-4): was #f59e0b (amber) — `--layer-verified`
      is green. Same brand-leak concern as promote-all. */
-  background: var(--layer-verified, #22c55e); color: #fff;
+  background: var(--layer-verified, #22c55e); color: var(--text-on-accent);
   font-size: 11px; font-weight: 600; cursor: pointer; transition: opacity .15s; white-space: nowrap;
 }
 .v10-btn-publish:hover { opacity: .85; }
@@ -3208,8 +3216,8 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-publish-result-card:first-of-type { margin-top: 12px; }
 .v10-publish-result-card.success { background: rgba(34,197,94,.06); border: 1px solid rgba(34,197,94,.2); }
-.v10-publish-result-card.error { background: rgba(239,68,68,.06); border: 1px solid rgba(239,68,68,.2); color: var(--accent-red); }
-.v10-publish-result-title { font-weight: 600; color: var(--accent-green); margin-bottom: 8px; }
+.v10-publish-result-card.error { background: rgba(239,68,68,.06); border: 1px solid rgba(239,68,68,.2); color: var(--text-danger); }
+.v10-publish-result-title { font-weight: 600; color: var(--text-success); margin-bottom: 8px; }
 .v10-publish-result-details { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: var(--text-secondary); }
 .v10-publish-result-label { font-weight: 600; color: var(--text-primary); margin-right: 4px; }
 .v10-publish-result-tx { font-family: var(--font-mono); font-size: 11px; }
@@ -3348,7 +3356,7 @@ p { font-size: 13px; color: var(--text-secondary); line-height: 1.6; }
   border-radius: 8px;
   margin-bottom: 16px;
   font-size: 12px;
-  color: var(--accent-red);
+  color: var(--text-danger);
   line-height: 1.5;
 }
 
@@ -3382,7 +3390,7 @@ p { font-size: 13px; color: var(--text-secondary); line-height: 1.6; }
 .v10-file-preview-error {
   margin: 16px 24px; padding: 14px; border-radius: 8px;
   background: rgba(239, 68, 68, 0.06); border: 1px solid rgba(239, 68, 68, 0.2);
-  color: var(--accent-red); font-size: 12px;
+  color: var(--text-danger); font-size: 12px;
 }
 .v10-file-preview-meta {
   display: flex; flex-wrap: wrap; gap: 6px; padding: 10px 24px;
@@ -3482,7 +3490,7 @@ p { font-size: 13px; color: var(--text-secondary); line-height: 1.6; }
 }
 .v10-form-radio-desc {
   font-size: 11px;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
   margin-left: 22px;
   margin-top: -4px;
 }
@@ -3541,7 +3549,7 @@ p { font-size: 13px; color: var(--text-secondary); line-height: 1.6; }
   font-weight: 600;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
   margin-bottom: 4px;
 }
 
@@ -3577,7 +3585,7 @@ body.light .v10-modal-btn.primary { background: #1a1a1a; color: #ffffff; border-
 }
 .v10-import-dropzone-hint {
   font-size: 11px;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
 }
 .v10-import-file-list {
   border: 1px solid var(--border-subtle);
@@ -3604,11 +3612,11 @@ body.light .v10-modal-btn.primary { background: #1a1a1a; color: #ffffff; border-
   flex-shrink: 0;
 }
 .v10-import-file-name { flex: 1; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.v10-import-file-size { font-family: var(--font-mono); font-size: 10px; color: var(--text-ghost); flex-shrink: 0; }
+.v10-import-file-size { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); flex-shrink: 0; }
 .v10-import-file-remove {
   background: none;
   border: none;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
   cursor: pointer;
   font-size: 14px;
   padding: 0 2px;
@@ -3662,12 +3670,12 @@ body.light .v10-modal-btn.primary { background: #1a1a1a; color: #ffffff; border-
 .v10-import-result.success {
   background: rgba(34, 197, 94, 0.08);
   border: 1px solid rgba(34, 197, 94, 0.25);
-  color: var(--accent-green, #22c55e);
+  color: var(--text-success);
 }
 .v10-import-result.error {
   background: rgba(239, 68, 68, 0.08);
   border: 1px solid rgba(239, 68, 68, 0.25);
-  color: var(--accent-red);
+  color: var(--text-danger);
 }
 
 /* Light overrides for import UI */
@@ -3951,9 +3959,9 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
 /* ── Trust Badges ── */
 .v10-trust-badge { display: inline-flex; align-items: center; gap: 3px; padding: 1px 6px; border-radius: 4px; font-size: 9px; font-weight: 600; letter-spacing: 0.3px; white-space: nowrap; }
 .v10-trust-badge-icon { font-size: 10px; }
-.v10-trust-badge.trust-verified { background: rgba(34, 197, 94, 0.12); color: #22c55e; }
-.v10-trust-badge.trust-shared { background: rgba(245, 158, 11, 0.12); color: #f59e0b; }
-.v10-trust-badge.trust-working { background: rgba(100, 116, 139, 0.12); color: #94a3b8; }
+.v10-trust-badge.trust-verified { background: rgba(34, 197, 94, 0.12); color: var(--text-success); }
+.v10-trust-badge.trust-shared { background: rgba(245, 158, 11, 0.12); color: var(--text-warning); }
+.v10-trust-badge.trust-working { background: rgba(100, 116, 139, 0.12); color: var(--text-tertiary); }
 .v10-trust-ring { font-size: 14px; line-height: 1; }
 .v10-trust-ring.trust-verified { color: #22c55e; }
 .v10-trust-ring.trust-shared { color: #f59e0b; }
@@ -4451,7 +4459,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-dd-graph { height: 260px; flex-shrink: 0; position: relative; border-bottom: 1px solid var(--border-subtle); background: var(--bg-surface); }
 .v10-dd-graph-info {
   position: absolute; bottom: 8px; left: 10px; font-size: 10px; font-family: var(--font-mono);
-  color: var(--text-ghost); pointer-events: none;
+  color: var(--text-tertiary); pointer-events: none;
 }
 
 .v10-dd-card { flex: 1; overflow-y: auto; padding: 0; }
@@ -4461,10 +4469,10 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-dd-type-row { display: flex; align-items: center; gap: 8px; margin-top: 4px; }
 .v10-dd-type { font-size: 11px; font-family: var(--font-mono); color: var(--text-tertiary); }
 .v10-dd-desc { font-size: 12px; color: var(--text-secondary); line-height: 1.6; padding: 0 16px 12px; border-bottom: 1px solid var(--border-subtle); margin: 0; }
-.v10-dd-uri { font-size: 10px; color: var(--text-ghost); padding: 8px 16px; word-break: break-all; border-bottom: 1px solid var(--border-subtle); }
+.v10-dd-uri { font-size: 10px; color: var(--text-tertiary); padding: 8px 16px; word-break: break-all; border-bottom: 1px solid var(--border-subtle); }
 
 .v10-dd-section { padding: 10px 16px; border-bottom: 1px solid var(--border-subtle); }
-.v10-dd-section-title { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-ghost); margin: 0 0 8px; }
+.v10-dd-section-title { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-tertiary); margin: 0 0 8px; }
 .v10-dd-prop { display: flex; flex-direction: column; gap: 1px; margin-bottom: 6px; }
 .v10-dd-prop-key { font-size: 10px; font-weight: 600; color: var(--text-tertiary); text-transform: capitalize; }
 .v10-dd-prop-val { font-size: 12px; color: var(--text-primary); word-break: break-word; line-height: 1.4; }
@@ -4477,7 +4485,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-dd-conn-pred { color: var(--text-tertiary); text-transform: capitalize; flex-shrink: 0; }
 .v10-dd-conn-arrow { color: var(--text-ghost); flex-shrink: 0; }
 .v10-dd-conn-target { color: var(--text-primary); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.v10-dd-conn-date { font-size: 10px; font-family: var(--font-mono); color: var(--text-ghost); margin-left: auto; flex-shrink: 0; }
+.v10-dd-conn-date { font-size: 10px; font-family: var(--font-mono); color: var(--text-tertiary); margin-left: auto; flex-shrink: 0; }
 .v10-dd-conn-sim { font-size: 10px; font-family: var(--font-mono); color: #6366f1; margin-left: auto; flex-shrink: 0; }
 .v10-dd-source-link {
   font-size: 11px; color: #6366f1; text-decoration: none;
@@ -4514,17 +4522,17 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-ph-stats { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 10px; }
 .v10-ph-stat { display: flex; flex-direction: column; align-items: center; gap: 1px; min-width: 56px; }
 .v10-ph-stat-val { font-size: 18px; font-weight: 700; color: var(--text-primary); font-family: var(--font-mono); }
-.v10-ph-stat-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-ghost); font-weight: 600; }
+.v10-ph-stat-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-tertiary); font-weight: 600; }
 
 .v10-ph-agents { display: flex; flex-direction: column; gap: 6px; }
-.v10-ph-agents-label { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-ghost); }
+.v10-ph-agents-label { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-tertiary); }
 .v10-ph-agents-list { display: flex; flex-wrap: wrap; gap: 6px; }
 .v10-ph-agent-chip {
   display: inline-flex; align-items: center; gap: 4px;
   padding: 3px 10px; border-radius: 12px; font-size: 11px; font-weight: 600;
   background: var(--bg-surface); border: 1px solid var(--border-default); color: var(--text-primary);
 }
-.v10-ph-agent-tool { font-size: 9px; font-weight: 500; color: var(--text-ghost); background: var(--bg-elevated); padding: 0 5px; border-radius: 3px; }
+.v10-ph-agent-tool { font-size: 9px; font-weight: 500; color: var(--text-tertiary); background: var(--bg-elevated); padding: 0 5px; border-radius: 3px; }
 
 .v10-ph-join-requests { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border-subtle); }
 .v10-ph-join-badge {
@@ -4540,15 +4548,15 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-ph-join-info { display: flex; flex-direction: column; gap: 1px; }
 .v10-ph-join-name { font-size: 11px; font-weight: 600; color: var(--text-primary); }
-.v10-ph-join-addr { font-size: 9px; font-family: var(--font-mono); color: var(--text-ghost); }
+.v10-ph-join-addr { font-size: 9px; font-family: var(--font-mono); color: var(--text-tertiary); }
 .v10-ph-join-actions { display: flex; gap: 4px; }
 .v10-ph-join-btn {
   border: none; border-radius: 6px; font-size: 10px; font-weight: 600; cursor: pointer;
   padding: 4px 10px; transition: background 0.15s;
 }
-.v10-ph-join-btn.approve { background: #22c55e22; color: #22c55e; border: 1px solid #22c55e44; }
+.v10-ph-join-btn.approve { background: #22c55e22; color: var(--text-success); border: 1px solid #22c55e44; }
 .v10-ph-join-btn.approve:hover { background: #22c55e44; }
-.v10-ph-join-btn.reject { background: #ef444422; color: #ef4444; border: 1px solid #ef444444; padding: 4px 8px; }
+.v10-ph-join-btn.reject { background: #ef444422; color: var(--text-danger); border: 1px solid #ef444444; padding: 4px 8px; }
 .v10-ph-join-btn.reject:hover { background: #ef444444; }
 .v10-ph-join-btn:disabled { opacity: 0.5; cursor: default; }
 
@@ -4582,7 +4590,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-layer-switch-icon { font-size: 11px; }
 .v10-layer-switch-count {
   font-family: var(--font-mono); font-size: 9px; padding: 1px 5px;
-  border-radius: 3px; background: var(--bg-elevated); color: var(--text-ghost);
+  border-radius: 3px; background: var(--bg-elevated); color: var(--text-tertiary);
 }
 .v10-layer-switch-btn.active .v10-layer-switch-count { color: var(--text-tertiary); }
 .v10-layer-switcher-spacer { flex: 1; }
@@ -4597,9 +4605,9 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-po-stats { display: flex; gap: 20px; margin-bottom: 12px; flex-wrap: wrap; }
 .v10-po-stat { display: flex; flex-direction: column; align-items: center; gap: 1px; min-width: 50px; }
 .v10-po-stat-val { font-size: 20px; font-weight: 700; color: var(--text-primary); font-family: var(--font-mono); }
-.v10-po-stat-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-ghost); font-weight: 600; }
+.v10-po-stat-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-tertiary); font-weight: 600; }
 .v10-po-participants { margin-bottom: 12px; }
-.v10-po-participants-label { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-ghost); margin-bottom: 6px; }
+.v10-po-participants-label { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-tertiary); margin-bottom: 6px; }
 .v10-po-participants-list { display: flex; flex-wrap: wrap; gap: 6px; }
 .v10-po-participant {
   display: inline-flex; align-items: center; gap: 5px;
@@ -4614,7 +4622,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-po-progress-seg.wm { background: #64748b; }
 .v10-po-progress-seg.swm { background: #f59e0b; }
 .v10-po-progress-seg.vm { background: #22c55e; }
-.v10-po-progress-legend { display: flex; gap: 14px; margin-top: 6px; font-size: 9px; font-family: var(--font-mono); color: var(--text-ghost); }
+.v10-po-progress-legend { display: flex; gap: 14px; margin-top: 6px; font-size: 9px; font-family: var(--font-mono); color: var(--text-tertiary); }
 .v10-po-legend-item { display: flex; align-items: center; gap: 4px; }
 .v10-po-legend-dot { width: 6px; height: 6px; border-radius: 50%; }
 
@@ -4632,7 +4640,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-layer-label:hover { background: var(--bg-hover); }
 .v10-layer-abbr { font-family: var(--font-sans); font-size: 12px; font-weight: 600; white-space: nowrap; }
-.v10-layer-count { font-family: var(--font-mono); font-size: 10px; color: var(--text-ghost); margin-left: auto; }
+.v10-layer-count { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); margin-left: auto; }
 .v10-layer-items {
   flex: 1; display: flex; align-items: center; gap: 6px;
   padding: 5px 10px; overflow-x: auto; min-width: 0;
@@ -4647,7 +4655,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-layer-chip:hover { border-color: var(--border-strong); background: var(--bg-elevated); }
 .v10-chip-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
 .v10-chip-text { color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; }
-.v10-chip-meta { font-family: var(--font-mono); font-size: 9px; color: var(--text-ghost); flex-shrink: 0; }
+.v10-chip-meta { font-family: var(--font-mono); font-size: 9px; color: var(--text-tertiary); flex-shrink: 0; }
 @keyframes v10-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
 .v10-chip-activity { animation: v10-pulse 2s ease-in-out infinite; }
 .v10-memory-layer.wm { background: rgba(100,116,139,0.03); }
@@ -4759,7 +4767,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   padding: 32px 16px;
 }
 .v10-entity-list-empty {
-  color: var(--text-ghost); font-size: 12px; font-style: italic;
+  color: var(--text-tertiary); font-size: 12px; font-style: italic;
 }
 .v10-entity-list-header {
   position: sticky; top: 0; z-index: 1;
@@ -4767,7 +4775,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   padding: 8px 16px;
   background: var(--bg-root);
   border-bottom: 1px solid var(--border-subtle);
-  font-size: 11px; color: var(--text-ghost);
+  font-size: 11px; color: var(--text-tertiary);
 }
 .v10-entity-list-count { font-weight: 600; color: var(--text-secondary); font-family: var(--font-mono); }
 .v10-entity-list-hint { font-style: italic; font-size: 10px; flex: 1; padding: 0 12px; }
@@ -4785,7 +4793,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-entity-list-sort {
   display: inline-flex; align-items: center; gap: 6px;
-  font-size: 11px; color: var(--text-ghost); font-style: normal;
+  font-size: 11px; color: var(--text-tertiary); font-style: normal;
 }
 .v10-entity-list-sort-label { text-transform: uppercase; letter-spacing: 0.04em; }
 .v10-entity-list-sort-select {
@@ -4797,8 +4805,8 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   padding: 3px 22px 3px 8px;
   font-size: 11px; font-family: var(--font-mono);
   cursor: pointer;
-  background-image: linear-gradient(45deg, transparent 50%, var(--text-ghost) 50%),
-                    linear-gradient(135deg, var(--text-ghost) 50%, transparent 50%);
+  background-image: linear-gradient(45deg, transparent 50%, var(--text-tertiary) 50%),
+                    linear-gradient(135deg, var(--text-tertiary) 50%, transparent 50%);
   background-position: calc(100% - 11px) 50%, calc(100% - 7px) 50%;
   background-size: 4px 4px, 4px 4px;
   background-repeat: no-repeat;
@@ -4838,7 +4846,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   line-height: 1.4;
 }
 .v10-entity-card-triples {
-  font-family: var(--font-mono); font-size: 10px; color: var(--text-ghost);
+  font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary);
 }
 .v10-layer-expand-tabs {
   display: flex; align-items: center; gap: 2px;
@@ -4874,9 +4882,9 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   transition: all 0.15s; background: none; cursor: pointer; font-family: var(--font-sans);
 }
 .v10-layer-expand-footer-btn:hover { color: var(--text-primary); border-color: var(--border-strong); }
-.v10-layer-expand-footer-btn.promote { color: #f59e0b; border-color: rgba(245,158,11,0.25); }
+.v10-layer-expand-footer-btn.promote { color: var(--text-warning); border-color: rgba(245,158,11,0.25); }
 .v10-layer-expand-footer-btn.promote:hover { background: rgba(245,158,11,0.08); }
-.v10-layer-expand-footer-btn.publish { color: #22c55e; border-color: rgba(34,197,94,0.25); }
+.v10-layer-expand-footer-btn.publish { color: var(--text-success); border-color: rgba(34,197,94,0.25); }
 .v10-layer-expand-footer-btn.publish:hover { background: rgba(34,197,94,0.08); }
 
 /* ── Item rows (shared by strip and layer views) ── */
@@ -4889,19 +4897,19 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-item-icon { font-size: 14px; width: 22px; text-align: center; flex-shrink: 0; color: var(--text-tertiary); }
 .v10-item-info { flex: 1; min-width: 0; }
 .v10-item-name { font-size: 12px; font-weight: 600; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.v10-item-ual { font-size: 9px; color: var(--text-ghost); font-family: var(--font-mono); margin-top: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v10-item-ual { font-size: 9px; color: var(--text-tertiary); font-family: var(--font-mono); margin-top: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .v10-item-meta-row { display: flex; gap: 8px; margin-top: 1px; }
 .v10-item-type { font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono); }
-.v10-item-count { font-size: 10px; color: var(--text-ghost); font-family: var(--font-mono); }
-.v10-item-owner { display: flex; align-items: center; gap: 4px; font-size: 10px; color: var(--text-ghost); font-family: var(--font-mono); flex-shrink: 0; margin-right: 6px; }
+.v10-item-count { font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono); }
+.v10-item-owner { display: flex; align-items: center; gap: 4px; font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono); flex-shrink: 0; margin-right: 6px; }
 .v10-item-owner-dot { width: 5px; height: 5px; border-radius: 50%; }
 .v10-trust-badge {
   display: inline-flex; align-items: center; gap: 3px; padding: 2px 7px;
   border-radius: 4px; font-size: 9px; font-weight: 600; letter-spacing: 0.3px; flex-shrink: 0;
 }
-.v10-trust-badge.vm { background: rgba(34,197,94,0.12); color: #22c55e; }
-.v10-trust-badge.swm { background: rgba(245,158,11,0.12); color: #f59e0b; }
-.v10-trust-badge.wm { background: rgba(100,116,139,0.12); color: #94a3b8; }
+.v10-trust-badge.vm { background: rgba(34,197,94,0.12); color: var(--text-success); }
+.v10-trust-badge.swm { background: rgba(245,158,11,0.12); color: var(--text-warning); }
+.v10-trust-badge.wm { background: rgba(100,116,139,0.12); color: var(--text-tertiary); }
 .v10-item-promote-btn {
   padding: 3px 10px; border-radius: 5px; font-size: 10px; font-weight: 600;
   border: 1px solid var(--border-default); color: var(--text-tertiary);
@@ -4931,9 +4939,9 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   background: none; cursor: pointer; font-family: var(--font-sans);
 }
 .v10-layer-action-btn:hover { border-color: var(--border-strong); color: var(--text-primary); }
-.v10-layer-action-btn.primary { background: rgba(34,197,94,0.08); color: #22c55e; border-color: rgba(34,197,94,0.3); }
+.v10-layer-action-btn.primary { background: rgba(34,197,94,0.08); color: var(--text-success); border-color: rgba(34,197,94,0.3); }
 .v10-layer-action-btn.primary:hover { background: rgba(34,197,94,0.15); }
-.v10-layer-action-btn.promote { background: rgba(245,158,11,0.08); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
+.v10-layer-action-btn.promote { background: rgba(245,158,11,0.08); color: var(--text-warning); border-color: rgba(245,158,11,0.25); }
 .v10-layer-action-btn.promote:hover { background: rgba(245,158,11,0.15); }
 .v10-layer-detail-content { flex: 1; overflow: auto; }
 
@@ -4983,12 +4991,12 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-gen-widget-agent { display: flex; align-items: center; gap: 4px; font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono); }
 .v10-gen-widget-agent-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--accent-blue); }
 .v10-gen-widget-dismiss {
-  font-size: 14px; color: var(--text-ghost); padding: 2px 4px; border-radius: 3px;
+  font-size: 14px; color: var(--text-tertiary); padding: 2px 4px; border-radius: 3px;
   transition: all 0.15s; cursor: pointer; border: none; background: none;
 }
 .v10-gen-widget-dismiss:hover { color: var(--text-secondary); background: var(--bg-hover); }
 .v10-gen-widget-body { padding: 14px; }
-.v10-gen-widget-footnote { padding: 10px 14px; border-top: 1px solid var(--border-subtle); font-size: 10px; color: var(--text-ghost); line-height: 1.5; }
+.v10-gen-widget-footnote { padding: 10px 14px; border-top: 1px solid var(--border-subtle); font-size: 10px; color: var(--text-tertiary); line-height: 1.5; }
 .v10-gen-widget.dissolved { opacity: 0.3; filter: blur(1px); pointer-events: none; max-height: 40px; overflow: hidden; transition: all 0.5s; }
 
 /* Layer summary widget */
@@ -5010,7 +5018,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   padding: 10px 12px; border-radius: 6px; background: var(--bg-elevated);
   border: 1px solid var(--border-subtle); margin-bottom: 14px;
 }
-.v10-evidence-title { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-ghost); margin-bottom: 6px; }
+.v10-evidence-title { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-tertiary); margin-bottom: 6px; }
 .v10-evidence-item { display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--text-tertiary); padding: 2px 0; }
 .v10-evidence-dot { width: 4px; height: 4px; border-radius: 50%; background: var(--text-ghost); flex-shrink: 0; }
 .v10-decision-actions { display: flex; gap: 8px; }
@@ -5018,9 +5026,9 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   flex: 1; height: 32px; border-radius: 6px; font-size: 11px; font-weight: 600;
   display: flex; align-items: center; justify-content: center; transition: all 0.15s; cursor: pointer;
 }
-.v10-decision-btn.approve { background: rgba(34,197,94,0.1); color: var(--accent-green); border: 1px solid rgba(34,197,94,0.3); }
+.v10-decision-btn.approve { background: rgba(34,197,94,0.1); color: var(--text-success); border: 1px solid rgba(34,197,94,0.3); }
 .v10-decision-btn.approve:hover { background: rgba(34,197,94,0.2); }
-.v10-decision-btn.revise { background: rgba(245,158,11,0.08); color: var(--accent-amber); border: 1px solid rgba(245,158,11,0.25); }
+.v10-decision-btn.revise { background: rgba(245,158,11,0.08); color: var(--text-warning); border: 1px solid rgba(245,158,11,0.25); }
 .v10-decision-btn.revise:hover { background: rgba(245,158,11,0.15); }
 .v10-decision-btn.discuss { background: var(--bg-elevated); color: var(--text-secondary); border: 1px solid var(--border-default); }
 .v10-decision-btn.discuss:hover { background: var(--bg-hover); color: var(--text-primary); }
@@ -5032,12 +5040,12 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   font-weight: 700;
   letter-spacing: 0.3px;
   background: linear-gradient(180deg, #22c55e 0%, #16a34a 100%);
-  color: #ffffff;
+  color: var(--text-on-accent);
   border: 1px solid #15803d;
   box-shadow:
     inset 0 1px 0 rgba(255,255,255,0.18),
     0 2px 8px rgba(34,197,94,0.35);
-  text-shadow: 0 1px 0 rgba(0,0,0,0.15);
+  text-shadow: none;
   gap: 6px;
 }
 .v10-decision-btn.primary-cta.publish-vm:hover:not(:disabled) {
@@ -5061,7 +5069,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 /* Canvas empty state */
 .v10-canvas-empty {
   flex: 1; display: flex; flex-direction: column; align-items: center;
-  justify-content: center; text-align: center; color: var(--text-ghost); gap: 8px;
+  justify-content: center; text-align: center; color: var(--text-tertiary); gap: 8px;
   min-height: 120px;
 }
 .v10-canvas-empty-icon { font-size: 28px; opacity: 0.3; }
@@ -5071,7 +5079,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-provenance-bar {
   flex-shrink: 0; padding: 6px 14px; border-top: 1px solid var(--border-subtle);
   background: var(--bg-panel); display: flex; align-items: center; gap: 8px;
-  font-size: 10px; color: var(--text-ghost); font-family: var(--font-mono);
+  font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono);
 }
 .v10-provenance-bar-dot { width: 4px; height: 4px; border-radius: 50%; background: #22c55e; }
 
@@ -5086,11 +5094,11 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   flex: 1 1 auto; min-height: 0; width: 100%;
 }
 .v10-graph-placeholder {
-  color: var(--text-ghost); font-size: 12px; font-family: var(--font-mono);
+  color: var(--text-tertiary); font-size: 12px; font-family: var(--font-mono);
 }
 .v10-docs-placeholder {
   flex: 1; display: flex; align-items: center; justify-content: center;
-  color: var(--text-ghost); font-size: 12px;
+  color: var(--text-tertiary); font-size: 12px;
 }
 .v10-layer-state {
   flex: 1 1 auto;
@@ -5099,7 +5107,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   align-items: center;
   justify-content: center;
   padding: 24px;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
   font-size: 12px;
   text-align: center;
 }
@@ -5120,18 +5128,18 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-ka-header-left { display: flex; flex-direction: column; gap: 2px; }
 .v10-ka-label { font-size: 10px; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.5px; }
 .v10-ka-name { font-size: 15px; font-weight: 600; color: var(--text-primary); display: flex; align-items: center; gap: 8px; }
-.v10-ka-ual { font-size: 10px; color: var(--text-ghost); font-family: var(--font-mono); margin-top: 2px; }
+.v10-ka-ual { font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono); margin-top: 2px; }
 .v10-ka-split { display: flex; flex: 1; min-height: 0; overflow: hidden; }
 .v10-ka-left { flex: 1; min-width: 0; overflow-y: auto; padding: 16px 20px; border-right: 1px solid var(--border-subtle); }
 .v10-ka-right { width: 300px; flex-shrink: 0; overflow-y: auto; padding: 16px; }
 .v10-ka-section { margin-bottom: 16px; }
 .v10-ka-section-title {
   font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;
-  color: var(--text-ghost); margin-bottom: 8px;
+  color: var(--text-tertiary); margin-bottom: 8px;
 }
 .v10-ka-desc { font-size: 12px; color: var(--text-secondary); line-height: 1.7; }
 .v10-ka-desc p { margin-bottom: 8px; }
-.v10-ka-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; font-size: 10px; font-family: var(--font-mono); color: var(--text-ghost); }
+.v10-ka-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; font-size: 10px; font-family: var(--font-mono); color: var(--text-tertiary); }
 .v10-ka-meta-item { display: flex; align-items: center; gap: 4px; }
 .v10-ka-prop { display: flex; gap: 8px; padding: 4px 0; font-size: 11px; border-bottom: 1px solid var(--border-subtle); }
 .v10-ka-prop:last-child { border-bottom: none; }
@@ -5143,13 +5151,13 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   font-family: var(--font-sans); font-size: 11px; transition: background 0.1s;
 }
 .v10-ka-conn:hover { background: var(--bg-hover); }
-.v10-ka-conn-pred { color: var(--text-ghost); font-family: var(--font-mono); font-size: 10px; min-width: 80px; }
+.v10-ka-conn-pred { color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; min-width: 80px; }
 .v10-ka-conn-arrow { color: var(--text-ghost); }
 .v10-ka-conn-target { color: var(--text-secondary); font-weight: 500; }
 .v10-ka-triples-table { width: 100%; border-collapse: collapse; font-size: 10px; font-family: var(--font-mono); }
 .v10-ka-triples-table th {
   padding: 6px 8px; text-align: left; font-size: 9px; font-weight: 600;
-  text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-ghost);
+  text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-tertiary);
   border-bottom: 1px solid var(--border-default); background: var(--bg-elevated);
 }
 .v10-ka-triples-table td {
@@ -5167,9 +5175,9 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-ka-event-dot.created { border-color: var(--layer-working); background: rgba(100,116,139,0.15); }
 .v10-ka-event-dot.shared { border-color: var(--layer-shared); background: rgba(245,158,11,0.15); }
 .v10-ka-event-dot.verified { border-color: var(--layer-verified); background: rgba(34,197,94,0.15); }
-.v10-ka-event-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 2px; }
+.v10-ka-event-header { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; margin-bottom: 2px; }
 .v10-ka-event-title { font-size: 11px; font-weight: 600; color: var(--text-primary); }
-.v10-ka-event-time { font-family: var(--font-mono); font-size: 9px; color: var(--text-ghost); }
+.v10-ka-event-time { font-family: var(--font-mono); font-size: 9px; color: var(--text-tertiary); white-space: nowrap; margin-left: auto; }
 .v10-ka-event-desc { font-size: 10px; color: var(--text-tertiary); line-height: 1.5; }
 
 /* ── Sub-graph Overview (Graph Overview tab) ──
@@ -5273,7 +5281,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-minipyr.compact { flex-direction: row; align-items: center; gap: 6px; }
 .v10-minipyr-empty {
-  font-size: 10px; color: var(--text-ghost); font-style: italic;
+  font-size: 10px; color: var(--text-tertiary); font-style: italic;
 }
 .v10-minipyr-bar {
   display: flex; height: 6px; width: 100%;
@@ -5346,7 +5354,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-subgraph-savedqueries-label {
   font-size: 10px; font-weight: 700; text-transform: uppercase;
-  letter-spacing: 0.08em; color: var(--text-ghost);
+  letter-spacing: 0.08em; color: var(--text-tertiary);
   margin-right: 4px;
 }
 .v10-subgraph-savedquery {
@@ -5371,7 +5379,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   font-size: 10px; color: var(--sg-color, #a855f7);
 }
 .v10-subgraph-savedquery-error {
-  color: var(--accent-red, #ef4444); font-size: 11px;
+  color: var(--text-danger); font-size: 11px;
 }
 .v10-subgraph-savedquery-count {
   margin-left: auto;
@@ -5391,7 +5399,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-subgraph-filter-label {
   font-size: 10px; font-weight: 700; text-transform: uppercase;
-  letter-spacing: 0.08em; color: var(--text-ghost);
+  letter-spacing: 0.08em; color: var(--text-tertiary);
   min-width: 62px;
 }
 .v10-subgraph-filter-chips { display: flex; gap: 5px; flex-wrap: wrap; }
@@ -5420,7 +5428,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   padding: 2px 8px;
   background: none;
   border: 1px solid transparent;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
   font-size: 10px; font-family: var(--font-sans);
   cursor: pointer;
   border-radius: 10px;
@@ -5461,7 +5469,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-subgraph-timeline-bucket-count {
   margin-left: auto;
-  font-size: 10px; color: var(--text-ghost);
+  font-size: 10px; color: var(--text-tertiary);
   font-variant-numeric: tabular-nums;
 }
 .v10-subgraph-timeline-items {
@@ -5489,7 +5497,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .v10-subgraph-timeline-item-date {
-  font-family: var(--font-mono); font-size: 10px; color: var(--text-ghost);
+  font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary);
   font-variant-numeric: tabular-nums;
 }
 
@@ -5510,26 +5518,26 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   display: inline-block;
 }
 .v10-subgraph-chip-badge.tone-warn {
-  background: rgba(245,158,11,0.15); color: #f59e0b;
+  background: rgba(245,158,11,0.15); color: var(--text-warning);
 }
 .v10-subgraph-chip-badge.tone-warn .v10-subgraph-chip-badge-dot {
   background: #f59e0b; box-shadow: 0 0 4px rgba(245,158,11,0.6);
 }
 .v10-subgraph-chip-badge.tone-danger {
-  background: rgba(239,68,68,0.15); color: #ef4444;
+  background: rgba(239,68,68,0.15); color: var(--text-danger);
 }
 .v10-subgraph-chip-badge.tone-danger .v10-subgraph-chip-badge-dot {
   background: #ef4444; box-shadow: 0 0 4px rgba(239,68,68,0.6);
   animation: v10-pulse-red 2s infinite;
 }
 .v10-subgraph-chip-badge.tone-info {
-  background: rgba(59,130,246,0.15); color: #3b82f6;
+  background: rgba(59,130,246,0.15); color: var(--text-info);
 }
 .v10-subgraph-chip-badge.tone-info .v10-subgraph-chip-badge-dot {
   background: #3b82f6;
 }
 .v10-subgraph-chip-badge.tone-muted {
-  background: rgba(100,116,139,0.15); color: #64748b;
+  background: rgba(100,116,139,0.15); color: var(--text-tertiary);
 }
 .v10-subgraph-chip-badge.tone-muted .v10-subgraph-chip-badge-dot {
   background: #64748b;
@@ -5622,7 +5630,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   margin-top: 8px; padding: 6px 8px;
   background: rgba(239,68,68,0.12);
   border-radius: 4px;
-  color: #ef4444; font-size: 11px;
+  color: var(--text-danger); font-size: 11px;
   font-family: var(--font-mono);
 }
 .v10-ka-verify-ok {
@@ -5765,7 +5773,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-activity-feed-bucket-count {
   margin-left: auto;
-  font-family: var(--font-mono); font-size: 10px; color: var(--text-ghost);
+  font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary);
 }
 .v10-activity-feed-items { display: flex; flex-direction: column; }
 
@@ -5799,12 +5807,12 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   border-radius: 10px;
   font-size: 10px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.04em;
-  color: var(--type-color, #a855f7);
+  color: var(--text-secondary);
   background: color-mix(in srgb, var(--type-color, #a855f7) 12%, transparent);
   border: 1px solid color-mix(in srgb, var(--type-color, #a855f7) 30%, var(--border-subtle));
   white-space: nowrap;
 }
-.v10-activity-feed-type-icon { font-size: 11px; }
+.v10-activity-feed-type-icon { font-size: 11px; color: var(--type-color, #a855f7); }
 .v10-activity-feed-title-text {
   font-size: 12px; font-weight: 600;
   color: var(--text-primary);
@@ -5820,13 +5828,13 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   color: var(--text-secondary);
   background: var(--bg-elevated);
 }
-.v10-activity-feed-status.status-good  { color: #22c55e; border-color: rgba(34,197,94,0.35); background: rgba(34,197,94,0.08); }
-.v10-activity-feed-status.status-warn  { color: #f59e0b; border-color: rgba(245,158,11,0.35); background: rgba(245,158,11,0.08); }
-.v10-activity-feed-status.status-bad   { color: #ef4444; border-color: rgba(239,68,68,0.35); background: rgba(239,68,68,0.08); }
+.v10-activity-feed-status.status-good  { color: var(--text-success); border-color: rgba(34,197,94,0.35); background: rgba(34,197,94,0.08); }
+.v10-activity-feed-status.status-warn  { color: var(--text-warning); border-color: rgba(245,158,11,0.35); background: rgba(245,158,11,0.08); }
+.v10-activity-feed-status.status-bad   { color: var(--text-danger); border-color: rgba(239,68,68,0.35); background: rgba(239,68,68,0.08); }
 .v10-activity-feed-author { display: inline-flex; }
 .v10-activity-feed-time {
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
   white-space: nowrap;
   min-width: 54px; text-align: right;
 }
@@ -6150,7 +6158,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   text-transform: uppercase; letter-spacing: 0.08em;
   padding: 2px 7px;
   border-radius: 10px;
-  color: #22c55e;
+  color: var(--text-success);
   background: rgba(34,197,94,0.12);
   border: 1px solid rgba(34,197,94,0.35);
 }
@@ -6164,7 +6172,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-vm-identity-lbl {
   font-size: 9px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.08em;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
   min-width: 56px;
 }
 .v10-vm-identity-val {
@@ -6183,7 +6191,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   font-size: 10px;
 }
 .v10-vm-identity-opid {
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
   font-size: 10px;
 }
 .v10-vm-identity-copy {
@@ -6191,7 +6199,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   background: none;
   border: 1px solid var(--border-subtle);
   border-radius: 4px;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
   font-size: 10px;
   cursor: pointer;
   font-family: var(--font-sans);
@@ -6216,12 +6224,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   text-transform: uppercase;
   letter-spacing: 0.06em;
   font-weight: 700;
-  color: var(--text-ghost);
-}
-.v10-ka-event-attribution-when {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
 }
 
 /* Author block in the KA detail header (prominent "Proposed by …" card) */
@@ -6234,7 +6237,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-ka-header-author-label {
   font-size: 9px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.08em;
-  color: var(--text-ghost);
+  color: var(--text-tertiary);
 }
 
 /* ── Persistent project header strip ── */
@@ -6277,6 +6280,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-project-strip-sg {
   display: inline-flex; align-items: center; gap: 5px;
   font-size: 12px; font-weight: 600;
+  color: var(--text-secondary);
 }
 .v10-project-strip-sg-icon { font-size: 13px; line-height: 1; }
 .v10-project-strip-desc {

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -168,11 +168,13 @@ export function ProjectHeaderStrip({
       {activeSubGraph ? (
         <>
           <span className="v10-project-strip-sep">›</span>
-          <span
-            className="v10-project-strip-sg"
-            style={{ color: activeSubGraph.color }}
-          >
-            <span className="v10-project-strip-sg-icon">{activeSubGraph.icon ?? '•'}</span>
+          <span className="v10-project-strip-sg">
+            <span
+              className="v10-project-strip-sg-icon"
+              style={{ color: activeSubGraph.color }}
+            >
+              {activeSubGraph.icon ?? '•'}
+            </span>
             {activeSubGraph.displayName ?? activeSubGraph.slug}
           </span>
           {activeSubGraph.description && (
@@ -238,7 +240,7 @@ export function ProjectOverviewCard({ cg, memory, participants }: {
         <div className="v10-po-progress">
           <div className="v10-po-progress-label">
             <span>Knowledge Progress</span>
-            <span style={{ color: '#22c55e', fontWeight: 600 }}>{pctVm}% verified</span>
+            <span style={{ color: 'var(--text-success)', fontWeight: 600 }}>{pctVm}% verified</span>
           </div>
           <div className="v10-po-progress-bar">
             {pctVm > 0 && <div className="v10-po-progress-seg vm" style={{ width: `${pctVm}%` }} />}
@@ -290,7 +292,7 @@ export function PendingJoinRequestsBar({ contextGraphId, onParticipantsChanged }
 
   return (
     <div className="v10-ph-join-requests" style={{ margin: '0 16px 8px', padding: '8px 12px', borderRadius: 8, background: 'var(--bg-surface)', border: '1px solid #f59e0b44' }}>
-      <span style={{ fontSize: 9, fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: '0.8px', color: 'var(--text-ghost)', marginBottom: 6, display: 'block' }}>
+      <span style={{ fontSize: 9, fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: '0.8px', color: 'var(--text-tertiary)', marginBottom: 6, display: 'block' }}>
         Pending Join Requests <span className="v10-ph-join-badge">{requests.length}</span>
       </span>
       <div className="v10-ph-join-list">
@@ -592,14 +594,14 @@ export function MemoryStrip({
               className={`v10-memory-layer ${layer.key} ${isExpanded ? 'expanded' : ''}`}
               onClick={() => toggleExpand(layer.key)}
             >
-              <div className="v10-layer-label" style={{ color: layer.color }}>
+              <div className="v10-layer-label">
                 <span className="v10-layer-abbr">{layer.label}</span>
                 <span className="v10-layer-count">{layer.entities.length}</span>
               </div>
               <div className="v10-layer-items">
                 <span className="v10-layer-chevron">▸</span>
                 {layer.entities.length === 0 && (
-                  <span style={{ fontSize: 11, color: 'var(--text-ghost)', fontStyle: 'italic' }}>No assets yet</span>
+                  <span style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>No assets yet</span>
                 )}
                 {layer.entities.slice(0, 6).map(e => {
                   const { icon } = entityMeta(e, profile);
@@ -852,13 +854,13 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
       <div className="v10-decision-context" style={{ marginBottom: 10 }}>
         {count} asset{count !== 1 ? 's' : ''} in this layer can be {isWm ? 'promoted to Shared Memory for collaborative review' : 'published to Verified Memory on-chain'}.
       </div>
-      {result && <div style={{ fontSize: 11, color: 'var(--accent-green)', marginBottom: 8 }}>✓ {result}</div>}
-      {error && <div style={{ fontSize: 11, color: 'var(--accent-red)', marginBottom: 8 }}>✕ {error}</div>}
+      {result && <div style={{ fontSize: 11, color: 'var(--text-success)', marginBottom: 8 }}>✓ {result}</div>}
+      {error && <div style={{ fontSize: 11, color: 'var(--text-danger)', marginBottom: 8 }}>✕ {error}</div>}
       <div className="v10-decision-actions">
         <button
           className={isWm ? 'v10-decision-btn approve' : 'v10-decision-btn primary-cta publish-vm'}
           style={isWm
-            ? { borderColor: `${color}50`, color, background: `${color}15`, opacity: busy ? 0.5 : 1 }
+            ? { borderColor: `${color}50`, color: 'var(--text-warning)', background: `${color}15`, opacity: busy ? 0.5 : 1 }
             : { opacity: busy ? 0.5 : 1 }}
           disabled={busy}
           onClick={handleAction}
@@ -1674,12 +1676,12 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
         </form>
       )}
 
-      {saveMessage && <p className="v10-mlv-status" style={{ color: 'var(--accent-green)' }}>{saveMessage}</p>}
-      {saveError && <p className="v10-mlv-status" style={{ color: 'var(--accent-red)' }}>{saveError}</p>}
+      {saveMessage && <p className="v10-mlv-status" style={{ color: 'var(--text-success)' }}>{saveMessage}</p>}
+      {saveError && <p className="v10-mlv-status" style={{ color: 'var(--text-danger)' }}>{saveError}</p>}
 
       <div className="v10-cg-query-results">
         {loading && <p className="v10-mlv-status">Loading...</p>}
-        {error && <p className="v10-mlv-status" style={{ color: 'var(--accent-red)' }}>Error: {error}</p>}
+        {error && <p className="v10-mlv-status" style={{ color: 'var(--text-danger)' }}>Error: {error}</p>}
 
         {!loading && !error && rows.length === 0 && (
           <div className="v10-mlv-empty">
@@ -1818,8 +1820,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
           {busy === '__all__' ? '...' : actionAllLabel}
         </button>
       </div>
-      {result && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--accent-green)' }}>✓ {result}</div>}
-      {error && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--accent-red)' }}>✕ {error}</div>}
+      {result && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--text-success)' }}>✓ {result}</div>}
+      {error && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--text-danger)' }}>✕ {error}</div>}
       {assertions.map(a => (
         <div key={a.name} className="v10-item-row">
           <span className="v10-item-icon">▤</span>
@@ -2408,7 +2410,7 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
                   ))}
                 </tbody>
               </table>
-              <div style={{ fontSize: 10, color: 'var(--text-ghost)', fontFamily: 'var(--font-mono)', padding: '6px 8px' }}>
+              <div style={{ fontSize: 10, color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)', padding: '6px 8px' }}>
                 {Math.min(entityTriples.length, 50)} of {entityTriples.length} triples shown
               </div>
             </div>
@@ -2563,12 +2565,12 @@ export function TrailEvent({
       <div className={`v10-ka-event-dot ${toneClass}`} />
       <div className="v10-ka-event-header">
         <span className="v10-ka-event-title">{title}</span>
+        {when && <time className="v10-ka-event-time" dateTime={at ?? undefined}>{when}</time>}
       </div>
       {(agent || agentUri) && (
         <div className="v10-ka-event-attribution">
           <span className="v10-ka-event-attribution-prefix">{actionWord} by</span>
           <AgentChip agent={agent ?? undefined} fallbackUri={agentUri ?? undefined} size="sm" />
-          {when && <span className="v10-ka-event-attribution-when">{when}</span>}
         </div>
       )}
     </div>

--- a/packages/node-ui/test/context-graph-contrast.test.ts
+++ b/packages/node-ui/test/context-graph-contrast.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(resolve(here, '../src/ui/styles.css'), 'utf8');
+
+function ruleFor(selector: string): string {
+  const match = new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{`).exec(css);
+  if (!match) throw new Error(`Missing selector ${selector}`);
+  const open = css.indexOf('{', match.index);
+  const close = css.indexOf('}', open);
+  return css.slice(open + 1, close);
+}
+
+function blockFor(selector: string): string {
+  return ruleFor(selector);
+}
+
+function customProperties(selector: string): Record<string, string> {
+  const block = blockFor(selector);
+  return Object.fromEntries(
+    [...block.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/gi)].map(([, key, value]) => [key, value.trim()]),
+  );
+}
+
+const rootVars = customProperties(':root');
+const lightVars = { ...rootVars, ...customProperties('body.light') };
+
+function declaration(rule: string, property: string): string {
+  const match = new RegExp(`(?:^|;)\\s*${property}\\s*:\\s*([^;]+);?`).exec(rule);
+  if (!match) throw new Error(`Missing ${property} declaration in ${rule}`);
+  return match[1].trim();
+}
+
+function resolveColor(value: string, vars = lightVars): string {
+  const varMatch = /var\((--[a-z0-9-]+)(?:,\s*([^)]+))?\)/i.exec(value);
+  if (varMatch) {
+    return resolveColor(vars[varMatch[1]] ?? varMatch[2], vars);
+  }
+  const hexMatch = /#[0-9a-f]{3,6}/i.exec(value);
+  if (!hexMatch) throw new Error(`Cannot resolve color ${value}`);
+  return hexMatch[0];
+}
+
+function rgb(hex: string): [number, number, number] {
+  const raw = hex.slice(1);
+  const full = raw.length === 3 ? raw.split('').map(ch => ch + ch).join('') : raw;
+  return [0, 2, 4].map(offset => parseInt(full.slice(offset, offset + 2), 16) / 255) as [number, number, number];
+}
+
+function luminance(hex: string): number {
+  const [r, g, b] = rgb(hex).map(channel => (
+    channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  ));
+  return (0.2126 * r) + (0.7152 * g) + (0.0722 * b);
+}
+
+function contrast(foreground: string, background: string): number {
+  const a = luminance(resolveColor(foreground));
+  const b = luminance(resolveColor(background));
+  const lighter = Math.max(a, b);
+  const darker = Math.min(a, b);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function foregroundFor(selector: string): string {
+  return resolveColor(declaration(ruleFor(selector), 'color'));
+}
+
+describe('Context Graph contrast tokens', () => {
+  it('keeps readable Context Graph text off the decoration-only ghost token', () => {
+    const readableSelectors = [
+      '.v10-layer-switch-count',
+      '.v10-po-stat-label',
+      '.v10-po-progress-legend',
+      '.v10-entity-list-empty',
+      '.v10-entity-list-header',
+      '.v10-entity-card-triples',
+      '.v10-item-ual',
+      '.v10-item-count',
+      '.v10-graph-placeholder',
+      '.v10-docs-placeholder',
+      '.v10-provenance-bar',
+      '.v10-ka-ual',
+      '.v10-ka-section-title',
+      '.v10-ka-meta',
+      '.v10-ka-conn-pred',
+      '.v10-ka-triples-table th',
+      '.v10-ka-event-time',
+      '.v10-activity-feed-bucket-count',
+      '.v10-activity-feed-time',
+      '.v10-vm-identity-lbl',
+      '.v10-gen-widget-footnote',
+      '.v10-evidence-title',
+      '.v10-canvas-empty',
+      '.v10-entity-list-sort-select',
+    ];
+
+    for (const selector of readableSelectors) {
+      expect(ruleFor(selector), selector).not.toContain('color: var(--text-ghost)');
+    }
+  });
+
+  it('keeps the trust palette tokens unchanged by the contrast sweep', () => {
+    expect(css).toContain('--layer-working: #64748b;');
+    expect(css).toContain('--layer-shared: #f59e0b;');
+    expect(css).toContain('--layer-verified: #22c55e;');
+  });
+
+  it('uses light-theme semantic foregrounds with AA contrast for status and action text', () => {
+    const selectorsOnSurface = [
+      '.v10-mlv-save-btn',
+      '.v10-btn-promote',
+      '.v10-trust-badge.trust-verified',
+      '.v10-trust-badge.trust-shared',
+      '.v10-trust-badge.trust-working',
+      '.v10-trust-badge.vm',
+      '.v10-trust-badge.swm',
+      '.v10-trust-badge.wm',
+      '.v10-layer-expand-footer-btn.promote',
+      '.v10-layer-expand-footer-btn.publish',
+      '.v10-layer-action-btn.primary',
+      '.v10-layer-action-btn.promote',
+      '.v10-decision-btn.approve',
+      '.v10-decision-btn.revise',
+      '.v10-subgraph-chip-badge.tone-warn',
+      '.v10-subgraph-chip-badge.tone-danger',
+      '.v10-subgraph-chip-badge.tone-info',
+      '.v10-subgraph-chip-badge.tone-muted',
+      '.v10-activity-feed-type',
+      '.v10-activity-feed-status.status-good',
+      '.v10-activity-feed-status.status-warn',
+      '.v10-activity-feed-status.status-bad',
+      '.v10-ph-join-btn.approve',
+      '.v10-ph-join-btn.reject',
+    ];
+
+    for (const selector of selectorsOnSurface) {
+      expect(contrast(foregroundFor(selector), lightVars['--bg-surface']), selector).toBeGreaterThanOrEqual(4.5);
+    }
+
+    expect(contrast(foregroundFor('.v10-btn-promote-all'), lightVars['--layer-shared'])).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(foregroundFor('.v10-btn-publish'), lightVars['--layer-verified'])).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(foregroundFor('.v10-decision-btn.primary-cta.publish-vm'), '#22c55e')).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(foregroundFor('.v10-decision-btn.primary-cta.publish-vm'), '#16a34a')).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/packages/node-ui/test/ka-detail-label.test.ts
+++ b/packages/node-ui/test/ka-detail-label.test.ts
@@ -4,7 +4,7 @@ import React from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { KADetailView } from '../src/ui/views/project/components.js';
+import { KADetailView, TrailEvent } from '../src/ui/views/project/components.js';
 import { ProjectProfileContext, type ProjectProfile } from '../src/ui/hooks/useProjectProfile.js';
 import { AgentsContext, type AgentsData } from '../src/ui/hooks/useAgents.js';
 import type { MemoryEntity } from '../src/ui/hooks/useMemoryEntities.js';
@@ -104,5 +104,42 @@ describe('KADetailView navigation label', () => {
     });
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders provenance timestamps in the event header without requiring an agent', async () => {
+    const at = '2026-05-23T12:34:00.000Z';
+
+    await act(async () => {
+      root.render(React.createElement(TrailEvent, {
+        toneClass: 'created',
+        title: 'Created in Working Memory',
+        actionWord: 'Created',
+        agent: null,
+        agentUri: null,
+        at,
+      }));
+    });
+
+    const timestamp = query('.v10-ka-event-time') as HTMLTimeElement;
+    expect(timestamp.tagName).toBe('TIME');
+    expect(timestamp.dateTime).toBe(at);
+    expect(timestamp.textContent).toContain('2026');
+    expect(document.querySelector('.v10-ka-event-attribution')).toBeNull();
+  });
+
+  it('omits provenance timestamp chrome when a lifecycle step has no timestamp', async () => {
+    await act(async () => {
+      root.render(React.createElement(TrailEvent, {
+        toneClass: 'shared',
+        title: 'Promoted to Shared Working Memory',
+        actionWord: 'Promoted',
+        agent: null,
+        agentUri: null,
+        at: null,
+      }));
+    });
+
+    expect(document.querySelector('.v10-ka-event-time')).toBeNull();
+    expect(query('.v10-ka-event-title').textContent).toContain('Promoted to Shared Working Memory');
   });
 });


### PR DESCRIPTION
## Summary

- Improves Context Graph contrast by moving readable labels, badges, statuses, and action text onto theme-aware semantic foreground tokens while preserving raw layer/profile colors for glyphs, swatches, borders, fills, and graph identity.
- Renders Provenance Trail lifecycle timestamps as right-aligned header `<time>` elements, including when no attribution agent is available, and omits timestamp chrome when timestamp data is absent.
- Keeps this PR scoped to M8 plus the S13 timestamp-rendering half; the S13 VM transaction-link half remains deferred to the later S10/VM metadata PR.

## Related

- Follow-up to #598, #599, #600, and #601 in the Context Graph UX rollout.
- Implements PR 1.5 / M8 + S13 timestamp-rendering half from `agent-docs/context-graph-implementation-plan.md`.

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/styles.css` | Adds semantic foreground tokens and raises readable Context Graph text/status selectors off ghost or raw accent foregrounds. |
| `packages/node-ui/src/ui/views/project/components.tsx` | Keeps dynamic/layer colors decorative, applies semantic status text, and moves Provenance Trail timestamps into the event header. |
| `packages/node-ui/src/ui/components/Modals/ShareProjectModal.tsx` | Uses semantic foregrounds for request status/action text. |
| `packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx` | Uses semantic danger foreground for import errors. |
| `packages/node-ui/test/context-graph-contrast.test.ts` | Adds static coverage for readable ghost-token usage and light-theme AA contrast on affected selectors. |
| `packages/node-ui/test/ka-detail-label.test.ts` | Covers Provenance Trail timestamp present/absent rendering. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/ka-detail-label.test.ts test/context-graph-contrast.test.ts test/vm-hero-banner.test.ts test/ui-compat.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui`
- [x] `git diff --check`
- [x] In-app browser smoke at `http://localhost:5175/ui/`: opened a sample Context Graph in light mode and confirmed Context Graph chrome rendered with no warning/error browser logs.
- [x] Local PR review from `pr-diff.patch`: no actionable findings remain.