### PR TITLE
feat(node-ui): add shared context graph empty states

### DIFF
--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -24,7 +24,7 @@ import {
 } from '../hooks/useProjectActivity.js';
 import { useAgentsContext } from '../hooks/useAgents.js';
 import { useProjectProfileContext } from '../hooks/useProjectProfile.js';
-import { EmptyState } from '../views/project/primitives.js';
+import { EmptyState } from './ContextGraphPrimitives.js';
 import { AgentChip } from './AgentChip.js';
 
 const LAYER_COLOR: Record<TrustLevel, string> = {

--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -24,6 +24,7 @@ import {
 } from '../hooks/useProjectActivity.js';
 import { useAgentsContext } from '../hooks/useAgents.js';
 import { useProjectProfileContext } from '../hooks/useProjectProfile.js';
+import { EmptyState } from '../views/project/primitives.js';
 import { AgentChip } from './AgentChip.js';
 
 const LAYER_COLOR: Record<TrustLevel, string> = {
@@ -83,9 +84,11 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
     return (
       <div className={`v10-activity-feed v10-activity-feed-empty ${className}`}>
         {title && <div className="v10-activity-feed-title">{title}</div>}
-        <div className="v10-activity-feed-empty-body">
-          {emptyHint ?? 'No activity with a timestamp yet.'}
-        </div>
+        <EmptyState
+          compact
+          title={emptyHint ?? 'No activity with a timestamp yet.'}
+          className="v10-activity-feed-empty-state"
+        />
       </div>
     );
   }

--- a/packages/node-ui/src/ui/components/ContextGraphPrimitives.tsx
+++ b/packages/node-ui/src/ui/components/ContextGraphPrimitives.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import type { ReactNode } from 'react';
-import { LAYER_CONFIG } from './helpers.js';
 
-export type EmptyStateTone = 'neutral' | 'wm' | 'swm' | 'vm' | 'danger' | 'query';
+type ContextGraphLayer = 'wm' | 'swm' | 'vm';
+
+export type EmptyStateTone = 'neutral' | ContextGraphLayer | 'danger' | 'query';
 
 type EmptyStateAction = {
   label: string;
@@ -12,14 +13,14 @@ type EmptyStateAction = {
 
 const EMPTY_STATE_ACCENTS: Record<EmptyStateTone, string> = {
   neutral: 'var(--border-strong)',
-  wm: LAYER_CONFIG.wm.color,
-  swm: LAYER_CONFIG.swm.color,
-  vm: LAYER_CONFIG.vm.color,
+  wm: 'var(--layer-working, #64748b)',
+  swm: 'var(--layer-shared, #f59e0b)',
+  vm: 'var(--layer-verified, #22c55e)',
   danger: 'var(--text-danger)',
   query: '#38bdf8',
 };
 
-export function toneForLayer(layer: 'wm' | 'swm' | 'vm'): EmptyStateTone {
+export function toneForLayer(layer: ContextGraphLayer): EmptyStateTone {
   return layer;
 }
 
@@ -94,12 +95,12 @@ export function StatStrip({
   className = '',
 }: {
   items: StatStripItem[];
-  layer?: 'wm' | 'swm' | 'vm';
+  layer?: ContextGraphLayer;
   compact?: boolean;
   className?: string;
 }) {
   const style = layer
-    ? ({ '--v10-stat-accent': LAYER_CONFIG[layer].color } as React.CSSProperties)
+    ? ({ '--v10-stat-accent': EMPTY_STATE_ACCENTS[layer] } as React.CSSProperties)
     : undefined;
 
   return (

--- a/packages/node-ui/src/ui/components/ContextGraphPrimitives.tsx
+++ b/packages/node-ui/src/ui/components/ContextGraphPrimitives.tsx
@@ -58,7 +58,7 @@ export function EmptyState({
       data-tone={tone}
       style={style}
     >
-      {icon && <div className="v10-empty-state-icon">{icon}</div>}
+      {icon && <div className="v10-empty-state-icon" aria-hidden="true">{icon}</div>}
       <div className="v10-empty-state-copy">
         <div className="v10-empty-state-title">{title}</div>
         {description && <div className="v10-empty-state-desc">{description}</div>}
@@ -111,8 +111,8 @@ export function StatStrip({
     >
       {items.map((item, index) => (
         <div key={item.id ?? index} className="v10-stat-strip-cell">
-          <span className="v10-stat-strip-value">{item.value}</span>
           <span className="v10-stat-strip-label">{item.label}</span>
+          <span className="v10-stat-strip-value">{item.value}</span>
           {item.hint && <span className="v10-stat-strip-hint">{item.hint}</span>}
         </div>
       ))}

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -4148,9 +4148,10 @@ body.light .v10-vm-hero {
 .v10-vm-hero-empty {
   gap: 16px;
 }
-.v10-vm-empty-state {
+.v10-empty-state.v10-vm-empty-state {
   display: flex;
   align-items: flex-start;
+  justify-content: flex-start;
   gap: 12px;
   padding: 16px;
   background: var(--v10-vm-surface);
@@ -5928,7 +5929,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   text-transform: uppercase; letter-spacing: 0.06em;
   color: var(--text-tertiary);
 }
-.v10-activity-feed-empty-state { min-height: 96px; }
+.v10-empty-state.v10-activity-feed-empty-state { min-height: 96px; }
 .v10-overview-activity.v10-activity-feed-empty {
   min-height: 140px;
 }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -4145,6 +4145,9 @@ body.light .v10-vm-hero {
   --v10-vm-accent: #166534;
   --v10-vm-accent-strong: #16a34a;
 }
+.v10-layer-expand-body.entities-tab > .v10-vm-hero {
+  margin: 16px 16px 10px;
+}
 .v10-vm-hero-empty {
   gap: 16px;
 }
@@ -4873,6 +4876,10 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-layer-expand-body.full-width > * {
   flex: 1 1 auto; min-height: 0;
   width: 100%;
+}
+.v10-layer-empty-shell {
+  padding: 16px;
+  box-sizing: border-box;
 }
 /* Entities tab body is a single block-level scroll region. We deliberately
    opt out of the parent's flex-column layout here: with flex, each child

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -3928,14 +3928,10 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   min-height: 0;
   width: 100%;
 }
-.v10-memory-explorer-page > .v10-sgov-empty,
-.v10-memory-explorer-page > .v10-sgov-loading {
+.v10-memory-explorer-page > .v10-sgov-state {
   flex: 1 1 auto;
   min-height: 220px;
   margin: 0 12px 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 .v10-memory-explorer-page[data-view="entity"] > .v10-ka-detail,
 .v10-memory-explorer-page[data-view="subgraph"] > .v10-layer-detail {
@@ -4110,6 +4106,17 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   text-transform: uppercase;
   color: var(--text-tertiary, #94a3b8);
   margin-top: 6px;
+}
+.v10-vm-hero-stats .v10-stat-strip-cell {
+  background: var(--v10-vm-surface);
+  border-color: var(--v10-vm-border);
+}
+.v10-vm-hero-stats .v10-stat-strip-value {
+  font-size: 24px;
+}
+.v10-vm-hero-stats .v10-stat-strip-label {
+  font-size: 11px;
+  letter-spacing: 0.07em;
 }
 .v10-vm-hero-strip {
   display: flex;
@@ -4596,12 +4603,184 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-layer-switcher-spacer { flex: 1; }
 .v10-layer-switcher-actions { display: flex; align-items: center; gap: 4px; padding-right: 4px; }
 
+/* Shared Context Graph empty/stat patterns */
+.v10-empty-state {
+  --v10-empty-accent: var(--border-strong);
+  flex: 1 1 auto;
+  min-height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 24px;
+  border: 1px solid color-mix(in srgb, var(--v10-empty-accent) 28%, var(--border-default));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--v10-empty-accent) 7%, var(--bg-surface));
+  color: var(--text-secondary);
+  text-align: left;
+}
+.v10-empty-state.compact {
+  min-height: 118px;
+  padding: 18px;
+}
+.v10-empty-state.inline {
+  flex: 0 0 auto;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  justify-content: flex-start;
+  gap: 6px;
+}
+.v10-empty-state-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  color: var(--v10-empty-accent);
+  background: color-mix(in srgb, var(--v10-empty-accent) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--v10-empty-accent) 34%, var(--border-default));
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+}
+.v10-empty-state.inline .v10-empty-state-icon {
+  width: 18px;
+  height: 18px;
+  font-size: 10px;
+  background: transparent;
+}
+.v10-empty-state-copy {
+  display: flex;
+  min-width: 0;
+  max-width: 560px;
+  flex-direction: column;
+  gap: 5px;
+}
+.v10-empty-state.inline .v10-empty-state-copy { max-width: none; }
+.v10-empty-state-title {
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.35;
+}
+.v10-empty-state.inline .v10-empty-state-title {
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 500;
+}
+.v10-empty-state-desc {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.v10-empty-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+.v10-empty-state-action {
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 650;
+  cursor: pointer;
+}
+.v10-empty-state-action.primary {
+  border-color: color-mix(in srgb, var(--v10-empty-accent) 55%, var(--border-default));
+  background: color-mix(in srgb, var(--v10-empty-accent) 18%, var(--bg-elevated));
+  color: var(--text-primary);
+}
+.v10-empty-state-action:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+.v10-stat-strip {
+  --v10-stat-accent: var(--border-strong);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+  gap: 10px;
+  min-width: 0;
+}
+.v10-stat-strip-cell {
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--v10-stat-accent) 18%, var(--border-default));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--v10-stat-accent) 5%, var(--bg-surface));
+}
+.v10-stat-strip-value {
+  display: block;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+.v10-stat-strip-label {
+  display: block;
+  margin-top: 5px;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+.v10-stat-strip-hint {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+}
+.v10-stat-strip.compact {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--v10-stat-accent) 16%, var(--border-default));
+  border-radius: 8px;
+  background: var(--bg-surface);
+}
+.v10-stat-strip.compact .v10-stat-strip-cell {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  border-radius: 0;
+  background: transparent;
+}
+.v10-stat-strip.compact .v10-stat-strip-cell:last-child { border-bottom: 0; }
+.v10-stat-strip.compact .v10-stat-strip-value {
+  order: 2;
+  font-size: 13px;
+}
+.v10-stat-strip.compact .v10-stat-strip-label {
+  order: 1;
+  margin-top: 0;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
 /* ── Project Overview Card ── */
 .v10-po { flex-shrink: 0; padding: 14px 16px; border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel); }
 .v10-po-top { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 12px; }
 .v10-po-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--text-primary); flex-shrink: 0; margin-top: 4px; }
 .v10-po-title { font-size: 15px; font-weight: 600; color: var(--text-primary); }
 .v10-po-desc { font-size: 11px; color: var(--text-tertiary); margin-top: 2px; line-height: 1.5; }
+.v10-po-stat-strip { margin-bottom: 12px; }
 .v10-po-stats { display: flex; gap: 20px; margin-bottom: 12px; flex-wrap: wrap; }
 .v10-po-stat { display: flex; flex-direction: column; align-items: center; gap: 1px; min-width: 50px; }
 .v10-po-stat-val { font-size: 20px; font-weight: 700; color: var(--text-primary); font-family: var(--font-mono); }
@@ -5191,11 +5370,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-sgov-title { font-size: 13px; font-weight: 600; color: var(--text-primary); letter-spacing: 0.02em; }
 .v10-sgov-sub { font-size: 11px; color: var(--text-tertiary); font-family: var(--font-mono); }
-.v10-sgov-loading, .v10-sgov-empty {
-  padding: 32px; text-align: center; font-size: 12px; color: var(--text-tertiary);
-  border: 1px dashed var(--border-default); border-radius: 12px;
-  background: var(--surface-1, rgba(255,255,255,0.02));
-}
+.v10-sgov-state { margin: 0 12px 12px; }
 /* The grid auto-fills: 3-up on wide screens, 2-up around 1100px, single column
    under 720px. Each cell has a stable minimum height so the mini graphs get
    room to breathe regardless of triple density. */
@@ -5753,10 +5928,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   text-transform: uppercase; letter-spacing: 0.06em;
   color: var(--text-tertiary);
 }
-.v10-activity-feed-empty-body {
-  font-size: 12px; color: var(--text-tertiary); font-style: italic;
-  padding: 8px 0;
-}
+.v10-activity-feed-empty-state { min-height: 96px; }
 .v10-overview-activity.v10-activity-feed-empty {
   min-height: 140px;
 }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -4712,6 +4712,8 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   min-width: 0;
 }
 .v10-stat-strip-cell {
+  display: flex;
+  flex-direction: column;
   min-width: 0;
   padding: 10px 12px;
   border: 1px solid color-mix(in srgb, var(--v10-stat-accent) 18%, var(--border-default));
@@ -4720,6 +4722,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-stat-strip-value {
   display: block;
+  order: 1;
   color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 18px;
@@ -4729,6 +4732,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-stat-strip-label {
   display: block;
+  order: 2;
   margin-top: 5px;
   color: var(--text-tertiary);
   font-size: 10px;
@@ -4739,6 +4743,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-stat-strip-hint {
   display: block;
+  order: 3;
   margin-top: 4px;
   color: var(--text-secondary);
   font-size: 11px;
@@ -4755,6 +4760,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-stat-strip.compact .v10-stat-strip-cell {
   display: flex;
+  flex-direction: row;
   align-items: center;
   justify-content: space-between;
   gap: 10px;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -5371,7 +5371,10 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-sgov-title { font-size: 13px; font-weight: 600; color: var(--text-primary); letter-spacing: 0.02em; }
 .v10-sgov-sub { font-size: 11px; color: var(--text-tertiary); font-family: var(--font-mono); }
-.v10-sgov-state { margin: 0 12px 12px; }
+.v10-empty-state.v10-sgov-state {
+  min-height: 220px;
+  margin: 0 12px 12px;
+}
 /* The grid auto-fills: 3-up on wide screens, 2-up around 1100px, single column
    under 720px. Each cell has a stable minimum height so the mini graphs get
    room to breathe regardless of triple density. */

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -57,7 +57,7 @@ import {
   type LayerView, type LayerContentTab, type KAPane,
   type SubGraphTab, type SubGraphEntitySort,
 } from './helpers.js';
-import { EmptyState, StatStrip, toneForLayer } from './primitives.js';
+import { EmptyState, StatStrip, toneForLayer } from '../../components/ContextGraphPrimitives.js';
 
 export const RdfGraph = lazy(() =>
   import('@origintrail-official/dkg-graph-viz/react').then(m => ({ default: m.RdfGraph }))

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -57,6 +57,7 @@ import {
   type LayerView, type LayerContentTab, type KAPane,
   type SubGraphTab, type SubGraphEntitySort,
 } from './helpers.js';
+import { EmptyState, StatStrip, toneForLayer } from './primitives.js';
 
 export const RdfGraph = lazy(() =>
   import('@origintrail-official/dkg-graph-viz/react').then(m => ({ default: m.RdfGraph }))
@@ -217,13 +218,16 @@ export function ProjectOverviewCard({ cg, memory, participants }: {
           {cg.description && <div className="v10-po-desc">{cg.description}</div>}
         </div>
       </div>
-      <div className="v10-po-stats">
-        <div className="v10-po-stat"><span className="v10-po-stat-val">{layerSum}</span><span className="v10-po-stat-label">Entities total</span></div>
-        <div className="v10-po-stat"><span className="v10-po-stat-val">{working}</span><span className="v10-po-stat-label">in Working</span></div>
-        <div className="v10-po-stat"><span className="v10-po-stat-val">{shared}</span><span className="v10-po-stat-label">in Shared</span></div>
-        <div className="v10-po-stat"><span className="v10-po-stat-val">{verified}</span><span className="v10-po-stat-label">in Verified</span></div>
-        <div className="v10-po-stat"><span className="v10-po-stat-val">{participants.length}</span><span className="v10-po-stat-label">participants</span></div>
-      </div>
+      <StatStrip
+        className="v10-po-stat-strip"
+        items={[
+          { id: 'total', value: layerSum, label: 'Entities total' },
+          { id: 'wm', value: working, label: 'in Working' },
+          { id: 'swm', value: shared, label: 'in Shared' },
+          { id: 'vm', value: verified, label: 'in Verified' },
+          { id: 'participants', value: participants.length, label: 'participants' },
+        ]}
+      />
       {participants.length > 0 && (
         <div className="v10-po-participants">
           <div className="v10-po-participants-label">Participants</div>
@@ -387,7 +391,13 @@ export function LayerGraphPanel({
   if (uniqueTriples.length === 0) {
     return (
       <div className="v10-graph-view v10-graph-view-fill">
-        <span className="v10-graph-placeholder">No triples in {title}</span>
+        <EmptyState
+          compact
+          tone={toneForLayer(layer)}
+          icon={LAYER_CONFIG[layer].icon}
+          title={`No triples in ${title}`}
+          description="The graph will appear when this layer has connected triples."
+        />
       </div>
     );
   }
@@ -395,7 +405,13 @@ export function LayerGraphPanel({
   if (swmAttributionPending) {
     return (
       <div className="v10-graph-view v10-graph-view-fill">
-        <span className="v10-graph-placeholder">Loading Shared Working Memory attribution...</span>
+        <EmptyState
+          compact
+          tone="swm"
+          icon={LAYER_CONFIG.swm.icon}
+          title="Loading Shared Working Memory attribution..."
+          description="Agent colors are being prepared before the graph renders."
+        />
       </div>
     );
   }
@@ -603,7 +619,12 @@ export function MemoryStrip({
               <div className="v10-layer-items">
                 <span className="v10-layer-chevron">▸</span>
                 {layer.entities.length === 0 && (
-                  <span style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>No {layerNoun(layer.key, 2).toLowerCase()} yet</span>
+                  <EmptyState
+                    inline
+                    tone={toneForLayer(layer.key)}
+                    icon={layer.icon}
+                    title={`No ${layerNoun(layer.key, 2).toLowerCase()} yet`}
+                  />
                 )}
                 {layer.entities.slice(0, 6).map(e => {
                   const { icon } = entityMeta(e, profile);
@@ -746,14 +767,14 @@ export function TypeBreakdownWidget({ entities }: { entities: MemoryEntity[] }) 
 
   return (
     <GenWidget title="Entity Types">
-      <div className="v10-layer-summary">
-        {breakdown.map(([type, { icon, count }]) => (
-          <div key={type} className="v10-layer-summary-stat">
-            <span className="v10-layer-summary-label">{icon} {type}</span>
-            <span className="v10-layer-summary-value">{count}</span>
-          </div>
-        ))}
-      </div>
+      <StatStrip
+        compact
+        items={breakdown.map(([type, { icon, count }]) => ({
+          id: type,
+          label: `${icon} ${type}`,
+          value: count,
+        }))}
+      />
     </GenWidget>
   );
 }
@@ -773,41 +794,19 @@ export function LayerStatsWidget({ entities, entityCount, triples, layer }: {
     [entities]
   );
   const avgConns = entities.length > 0 ? (totalConns / entities.length).toFixed(1) : '0';
-  const layerConfig = {
-    wm: { icon: '◇', color: '#64748b' },
-    swm: { icon: '◈', color: '#f59e0b' },
-    vm: { icon: '◉', color: '#22c55e' },
-  }[layer];
-
   return (
     <GenWidget title="Layer Stats">
-      <div className="v10-layer-summary">
-        <div className="v10-layer-summary-stat">
-          <span className="v10-layer-summary-label">{layerNoun(layer, entityCount)}</span>
-          <span className="v10-layer-summary-value">{entityCount}</span>
-        </div>
-        <div className="v10-layer-summary-stat">
-          <span className="v10-layer-summary-label">Triples</span>
-          <span className="v10-layer-summary-value">{triples}</span>
-        </div>
-        <div className="v10-layer-summary-stat">
-          <span className="v10-layer-summary-label">Connections</span>
-          <span className="v10-layer-summary-value">{totalConns}</span>
-        </div>
-        <div className="v10-layer-summary-stat">
-          <span className="v10-layer-summary-label">Avg. connections / entity</span>
-          <span className="v10-layer-summary-value">{avgConns}</span>
-        </div>
-        {docCount > 0 && (
-          <div className="v10-layer-summary-stat">
-            <span className="v10-layer-summary-label">📄 Documents</span>
-            <span className="v10-layer-summary-value">{docCount}</span>
-          </div>
-        )}
-        <div className="v10-layer-summary-bar">
-          <div className="v10-layer-summary-bar-fill" style={{ width: '100%', background: layerConfig.color }} />
-        </div>
-      </div>
+      <StatStrip
+        compact
+        layer={layer}
+        items={[
+          { id: 'entities', label: layerNoun(layer, entityCount), value: entityCount },
+          { id: 'triples', label: 'Triples', value: triples },
+          { id: 'connections', label: 'Connections', value: totalConns },
+          { id: 'avg', label: 'Avg. connections / entity', value: avgConns },
+          ...(docCount > 0 ? [{ id: 'documents', label: 'Documents', value: docCount }] : []),
+        ]}
+      />
     </GenWidget>
   );
 }
@@ -889,12 +888,19 @@ export function LayerWidgetStrip({ layer, entities, entityCount, tripleCount, co
   if (entityCount === 0) {
     return (
       <div className="v10-layer-widgets-strip empty">
-        <div className="v10-canvas-empty">
-          <div className="v10-canvas-empty-icon">⬡</div>
-          <div className="v10-canvas-empty-text">
-            Import data or chat with agents to populate this layer.
-          </div>
-        </div>
+        <EmptyState
+          compact
+          tone={toneForLayer(layer)}
+          icon={LAYER_CONFIG[layer].icon}
+          title={`No ${layerNoun(layer, 2).toLowerCase()} yet`}
+          description={
+            layer === 'wm'
+              ? 'Import data or chat with agents to populate Working Memory.'
+              : layer === 'swm'
+                ? 'Promote entities from Working Memory to share them with the team.'
+                : 'Publish entities from Shared Working Memory to verify them on-chain.'
+          }
+        />
       </div>
     );
   }
@@ -963,7 +969,13 @@ export function EntityList({
   if (entities.length === 0) {
     return (
       <div className="v10-entity-list empty">
-        <div className="v10-entity-list-empty">No {layerNoun(layerKey, 2).toLowerCase()} in this layer yet.</div>
+        <EmptyState
+          compact
+          tone={toneForLayer(layerKey)}
+          icon={layerIcon}
+          title={`No ${layerNoun(layerKey, 2).toLowerCase()} yet`}
+          description={`This view will fill when matching ${layerNoun(layerKey, 2).toLowerCase()} are available.`}
+        />
       </div>
     );
   }
@@ -1100,21 +1112,23 @@ export function LayerContent({
           )}
           {isInitialVerifiedMemoryLoad ? (
             <div className="v10-layer-widgets-strip empty">
-              <div className="v10-canvas-empty">
-                <div className="v10-canvas-empty-icon">◉</div>
-                <div className="v10-canvas-empty-text">
-                  Loading Verified Memory...
-                </div>
-              </div>
+              <EmptyState
+                compact
+                tone="vm"
+                icon={LAYER_CONFIG.vm.icon}
+                title="Loading Verified Memory..."
+                description="Knowledge Assets are being read from the verified layer."
+              />
             </div>
           ) : isVerifiedMemoryUnavailable ? (
             <div className="v10-layer-widgets-strip empty">
-              <div className="v10-canvas-empty">
-                <div className="v10-canvas-empty-icon">◉</div>
-                <div className="v10-canvas-empty-text">
-                  Verified Memory status unavailable.
-                </div>
-              </div>
+              <EmptyState
+                compact
+                tone="vm"
+                icon={LAYER_CONFIG.vm.icon}
+                title="Verified Memory status unavailable."
+                description="This node could not read the verified layer right now."
+              />
             </div>
           ) : !isEmptyVerifiedMemory && (
             <>
@@ -1199,15 +1213,14 @@ export function VerifiedMemoryHeroBanner({ entities, tripleCount, contextGraphId
             </span>
           </div>
         </div>
-        <div className="v10-vm-empty-state">
-          <div className="v10-vm-empty-icon">◉</div>
-          <div className="v10-vm-empty-copy">
-            <div className="v10-vm-empty-title">No Knowledge Assets yet.</div>
-            <div className="v10-vm-empty-text">
-              Publish entities from Shared Working Memory to verify them on-chain.
-            </div>
-          </div>
-        </div>
+        <EmptyState
+          compact
+          className="v10-vm-empty-state"
+          tone="vm"
+          icon={LAYER_CONFIG.vm.icon}
+          title="No Knowledge Assets yet."
+          description="Publish entities from Shared Working Memory to verify them on-chain."
+        />
       </div>
     );
   }
@@ -1223,20 +1236,15 @@ export function VerifiedMemoryHeroBanner({ entities, tripleCount, contextGraphId
           </span>
         </div>
       </div>
-      <div className="v10-vm-hero-stats">
-        <div className="v10-vm-hero-stat">
-          <div className="v10-vm-hero-stat-val">{totalAssets}</div>
-          <div className="v10-vm-hero-stat-lbl">Knowledge Assets</div>
-        </div>
-        <div className="v10-vm-hero-stat">
-          <div className="v10-vm-hero-stat-val">{tripleCount.toLocaleString()}</div>
-          <div className="v10-vm-hero-stat-lbl">Verified Triples</div>
-        </div>
-        <div className="v10-vm-hero-stat">
-          <div className="v10-vm-hero-stat-val">{typeCount}</div>
-          <div className="v10-vm-hero-stat-lbl">Entity Types</div>
-        </div>
-      </div>
+      <StatStrip
+        className="v10-vm-hero-stats"
+        layer="vm"
+        items={[
+          { id: 'assets', value: totalAssets, label: 'Knowledge Assets' },
+          { id: 'triples', value: tripleCount.toLocaleString(), label: 'Verified Triples' },
+          { id: 'types', value: typeCount, label: 'Entity Types' },
+        ]}
+      />
       <div className="v10-vm-hero-strip">
         <div className="v10-vm-hero-chip" title="Multi-agent endorsement">
           <span className="v10-vm-hero-chip-dot" style={{ background: '#22c55e' }} />
@@ -1688,13 +1696,32 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
       {saveError && <p className="v10-mlv-status" style={{ color: 'var(--text-danger)' }}>{saveError}</p>}
 
       <div className="v10-cg-query-results">
-        {loading && <p className="v10-mlv-status">Loading...</p>}
-        {error && <p className="v10-mlv-status" style={{ color: 'var(--text-danger)' }}>Error: {error}</p>}
+        {loading && (
+          <EmptyState
+            compact
+            tone="query"
+            icon="?"
+            title="Loading query results..."
+          />
+        )}
+        {error && (
+          <EmptyState
+            compact
+            tone="danger"
+            icon="!"
+            title="Query failed"
+            description={error}
+          />
+        )}
 
         {!loading && !error && rows.length === 0 && (
-          <div className="v10-mlv-empty">
-            <p>No results for this query.</p>
-          </div>
+          <EmptyState
+            compact
+            tone="query"
+            icon="?"
+            title="No results for this query."
+            description="Adjust the query or run a saved query against this Context Graph."
+          />
         )}
 
         {!loading && !error && rows.length > 0 && (
@@ -1799,7 +1826,12 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
   if (loading) {
     return (
       <div style={scrollRootStyle} data-cg-scroll-key={scrollKey}>
-        <div className="v10-layer-state">Loading assertions...</div>
+        <EmptyState
+          compact
+          tone={toneForLayer(layer)}
+          icon={LAYER_CONFIG[layer].icon}
+          title="Loading assertions..."
+        />
       </div>
     );
   }
@@ -1807,7 +1839,16 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
   if (!assertions?.length) {
     return (
       <div style={scrollRootStyle} data-cg-scroll-key={scrollKey}>
-        <div className="v10-layer-state">No assertions in this layer</div>
+        <EmptyState
+          tone={toneForLayer(layer)}
+          icon={LAYER_CONFIG[layer].icon}
+          title={layer === 'swm'
+            ? 'No Shared Working Memory assertions listed yet.'
+            : 'No Working Memory assertions yet.'}
+          description={layer === 'swm'
+            ? 'Promoted assertion contents are available as Shared Working Memory entities. The assertion list will populate once promoted assertions are exposed by the node.'
+            : 'Create or import data to stage assertions in Working Memory.'}
+        />
       </div>
     );
   }
@@ -1956,7 +1997,11 @@ export function DocumentsList({
   if (docs.length === 0) {
     return (
       <div className="v10-docs-placeholder" style={{ flex: 1 }} data-cg-scroll-key={scrollKey}>
-        No documents in this layer. Import a file to get started.
+        <EmptyState
+          compact
+          title="No documents in this layer yet."
+          description="Import a file to add document-backed entities."
+        />
       </div>
     );
   }
@@ -2698,14 +2743,22 @@ export function SubGraphOverviewGrid({
 
   if (loading && cards.length === 0) {
     return (
-      <div className="v10-sgov-loading">Loading sub-graphs…</div>
+      <EmptyState
+        compact
+        icon="#"
+        title="Loading sub-graphs..."
+        className="v10-sgov-state"
+      />
     );
   }
   if (cards.length === 0) {
     return (
-      <div className="v10-sgov-empty">
-        No sub-graphs registered on this project yet.
-      </div>
+      <EmptyState
+        icon="#"
+        title="No sub-graphs registered yet."
+        description="This Context Graph currently only has the root memory view."
+        className="v10-sgov-state"
+      />
     );
   }
 
@@ -2912,7 +2965,11 @@ export function SubGraphTimeline({
   if (items.length === 0) {
     return (
       <div className="v10-subgraph-timeline-empty" data-cg-scroll-key={scrollKey}>
-        No entities in this sub-graph have a timeline value (check the profile's <code>timelinePredicate</code> and the underlying data).
+        <EmptyState
+          compact
+          title="No timeline values yet."
+          description="Entities in this sub-graph do not currently expose the configured timeline field."
+        />
       </div>
     );
   }

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -390,7 +390,7 @@ export function LayerGraphPanel({
 
   if (uniqueTriples.length === 0) {
     return (
-      <div className="v10-graph-view v10-graph-view-fill">
+      <div className="v10-graph-view v10-graph-view-fill v10-layer-empty-shell">
         <EmptyState
           compact
           tone={toneForLayer(layer)}
@@ -404,7 +404,7 @@ export function LayerGraphPanel({
 
   if (swmAttributionPending) {
     return (
-      <div className="v10-graph-view v10-graph-view-fill">
+      <div className="v10-graph-view v10-graph-view-fill v10-layer-empty-shell">
         <EmptyState
           compact
           tone="swm"
@@ -1825,7 +1825,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
 
   if (loading) {
     return (
-      <div style={scrollRootStyle} data-cg-scroll-key={scrollKey}>
+      <div className="v10-layer-empty-shell" style={scrollRootStyle} data-cg-scroll-key={scrollKey}>
         <EmptyState
           compact
           tone={toneForLayer(layer)}
@@ -1838,7 +1838,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
 
   if (!assertions?.length) {
     return (
-      <div style={scrollRootStyle} data-cg-scroll-key={scrollKey}>
+      <div className="v10-layer-empty-shell" style={scrollRootStyle} data-cg-scroll-key={scrollKey}>
         <EmptyState
           tone={toneForLayer(layer)}
           icon={LAYER_CONFIG[layer].icon}
@@ -1996,7 +1996,7 @@ export function DocumentsList({
 
   if (docs.length === 0) {
     return (
-      <div className="v10-docs-placeholder" style={{ flex: 1 }} data-cg-scroll-key={scrollKey}>
+      <div className="v10-docs-placeholder v10-layer-empty-shell" style={{ flex: 1 }} data-cg-scroll-key={scrollKey}>
         <EmptyState
           compact
           title="No documents in this layer yet."

--- a/packages/node-ui/src/ui/views/project/primitives.tsx
+++ b/packages/node-ui/src/ui/views/project/primitives.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { LAYER_CONFIG } from './helpers.js';
+
+export type EmptyStateTone = 'neutral' | 'wm' | 'swm' | 'vm' | 'danger' | 'query';
+
+type EmptyStateAction = {
+  label: string;
+  onClick: () => void;
+  variant?: 'primary' | 'secondary';
+};
+
+const EMPTY_STATE_ACCENTS: Record<EmptyStateTone, string> = {
+  neutral: 'var(--border-strong)',
+  wm: LAYER_CONFIG.wm.color,
+  swm: LAYER_CONFIG.swm.color,
+  vm: LAYER_CONFIG.vm.color,
+  danger: 'var(--text-danger)',
+  query: '#38bdf8',
+};
+
+export function toneForLayer(layer: 'wm' | 'swm' | 'vm'): EmptyStateTone {
+  return layer;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  actions = [],
+  tone = 'neutral',
+  compact = false,
+  inline = false,
+  className = '',
+}: {
+  icon?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: EmptyStateAction[];
+  tone?: EmptyStateTone;
+  compact?: boolean;
+  inline?: boolean;
+  className?: string;
+}) {
+  const style = {
+    '--v10-empty-accent': EMPTY_STATE_ACCENTS[tone],
+  } as React.CSSProperties;
+
+  return (
+    <div
+      className={[
+        'v10-empty-state',
+        compact ? 'compact' : '',
+        inline ? 'inline' : '',
+        className,
+      ].filter(Boolean).join(' ')}
+      data-tone={tone}
+      style={style}
+    >
+      {icon && <div className="v10-empty-state-icon">{icon}</div>}
+      <div className="v10-empty-state-copy">
+        <div className="v10-empty-state-title">{title}</div>
+        {description && <div className="v10-empty-state-desc">{description}</div>}
+        {actions.length > 0 && (
+          <div className="v10-empty-state-actions">
+            {actions.map(action => (
+              <button
+                key={action.label}
+                type="button"
+                className={`v10-empty-state-action ${action.variant ?? 'secondary'}`}
+                onClick={action.onClick}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export type StatStripItem = {
+  id?: string;
+  label: ReactNode;
+  value: ReactNode;
+  hint?: ReactNode;
+};
+
+export function StatStrip({
+  items,
+  layer,
+  compact = false,
+  className = '',
+}: {
+  items: StatStripItem[];
+  layer?: 'wm' | 'swm' | 'vm';
+  compact?: boolean;
+  className?: string;
+}) {
+  const style = layer
+    ? ({ '--v10-stat-accent': LAYER_CONFIG[layer].color } as React.CSSProperties)
+    : undefined;
+
+  return (
+    <div
+      className={['v10-stat-strip', compact ? 'compact' : '', className].filter(Boolean).join(' ')}
+      data-layer={layer}
+      style={style}
+    >
+      {items.map((item, index) => (
+        <div key={item.id ?? index} className="v10-stat-strip-cell">
+          <span className="v10-stat-strip-value">{item.value}</span>
+          <span className="v10-stat-strip-label">{item.label}</span>
+          {item.hint && <span className="v10-stat-strip-hint">{item.hint}</span>}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/node-ui/test/context-graph-contrast.test.ts
+++ b/packages/node-ui/test/context-graph-contrast.test.ts
@@ -95,6 +95,9 @@ describe('Context Graph contrast tokens', () => {
       '.v10-gen-widget-footnote',
       '.v10-evidence-title',
       '.v10-canvas-empty',
+      '.v10-empty-state-title',
+      '.v10-empty-state-desc',
+      '.v10-stat-strip-label',
       '.v10-entity-list-sort-select',
     ];
 

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -1,0 +1,193 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiMocks = vi.hoisted(() => ({
+  listAssertions: vi.fn(),
+  promoteAssertion: vi.fn(),
+  publishSharedMemory: vi.fn(),
+}));
+
+vi.mock('../src/ui/api.js', () => ({
+  listJoinRequests: vi.fn(async () => ({ requests: [] })),
+  approveJoinRequest: vi.fn(),
+  rejectJoinRequest: vi.fn(),
+  listParticipants: vi.fn(async () => ({ allowedAgents: [] })),
+  listAssertions: apiMocks.listAssertions,
+  promoteAssertion: apiMocks.promoteAssertion,
+  publishSharedMemory: apiMocks.publishSharedMemory,
+  executeQuery: vi.fn(),
+  writeProfileQueryCatalog: vi.fn(),
+  fetchSubGraphs: vi.fn(async () => ({ subGraphs: [] })),
+}));
+
+const {
+  EmptyState,
+  StatStrip,
+} = await import('../src/ui/views/project/primitives.js');
+
+const {
+  AssertionsList,
+} = await import('../src/ui/views/project/components.js');
+
+const {
+  ActivityFeed,
+} = await import('../src/ui/components/ActivityFeed.js');
+
+async function render(node: React.ReactElement): Promise<{
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => Promise<void>;
+}> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(node);
+  });
+
+  return {
+    container,
+    root,
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+async function waitForText(container: HTMLElement, text: string): Promise<void> {
+  const started = Date.now();
+  let last = '';
+  while (Date.now() - started < 1000) {
+    last = container.textContent ?? '';
+    if (last.includes(text)) return;
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+  }
+  throw new Error(`Timed out waiting for text "${text}" in "${last}"`);
+}
+
+describe('Context Graph shared empty/stat patterns', () => {
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders EmptyState without requiring an action', async () => {
+    const { container, unmount } = await render(
+      React.createElement(EmptyState, {
+        icon: 'i',
+        title: 'No entities yet',
+        description: 'Import data to populate this layer.',
+        tone: 'wm',
+      }),
+    );
+
+    expect(container.querySelector('.v10-empty-state')).toBeTruthy();
+    expect(container.querySelector('.v10-empty-state-action')).toBeNull();
+    expect(container.textContent).toContain('No entities yet');
+    expect(container.textContent).toContain('Import data to populate this layer.');
+
+    await unmount();
+  });
+
+  it('renders StatStrip cells with layer tone and labelled values', async () => {
+    const { container, unmount } = await render(
+      React.createElement(StatStrip, {
+        layer: 'vm',
+        items: [
+          { id: 'assets', value: 2, label: 'Knowledge Assets' },
+          { id: 'triples', value: '1,234', label: 'Verified Triples' },
+        ],
+      }),
+    );
+
+    expect(container.querySelector('.v10-stat-strip')?.getAttribute('data-layer')).toBe('vm');
+    expect(Array.from(container.querySelectorAll('.v10-stat-strip-value')).map(el => el.textContent))
+      .toEqual(['2', '1,234']);
+    expect(container.textContent).toContain('Knowledge Assets');
+    expect(container.textContent).toContain('Verified Triples');
+
+    await unmount();
+  });
+
+  it('uses the shared empty pattern for empty activity feeds', async () => {
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: [],
+        onSelectEntity: vi.fn(),
+        emptyHint: 'No recent updates yet.',
+      }),
+    );
+
+    expect(container.querySelector('.v10-activity-feed-empty .v10-empty-state')).toBeTruthy();
+    expect(container.textContent).toContain('No recent updates yet.');
+
+    await unmount();
+  });
+
+  it('shows the explained interim empty state for SWM assertions', async () => {
+    apiMocks.listAssertions.mockResolvedValueOnce([]);
+    const { container, unmount } = await render(
+      React.createElement(AssertionsList, {
+        contextGraphId: 'cg-test',
+        layer: 'swm',
+        onComplete: vi.fn(),
+      }),
+    );
+
+    await waitForText(container, 'No Shared Working Memory assertions listed yet.');
+    expect(container.textContent).toContain('Promoted assertion contents are available as Shared Working Memory entities.');
+    expect(container.textContent).not.toContain('No assertions in this layer');
+
+    await unmount();
+  });
+
+  it('keeps WM assertions empty copy separate from the SWM backend-gated copy', async () => {
+    apiMocks.listAssertions.mockResolvedValueOnce([]);
+    const { container, unmount } = await render(
+      React.createElement(AssertionsList, {
+        contextGraphId: 'cg-test',
+        layer: 'wm',
+        onComplete: vi.fn(),
+      }),
+    );
+
+    await waitForText(container, 'No Working Memory assertions yet.');
+    expect(container.textContent).toContain('Create or import data to stage assertions in Working Memory.');
+    expect(container.textContent).not.toContain('Promoted assertion contents are available');
+
+    await unmount();
+  });
+
+  it('renders assertion rows when SWM assertions become listable', async () => {
+    apiMocks.listAssertions.mockResolvedValueOnce([
+      { name: 'turn-anno-test', tripleCount: 3 },
+    ]);
+    const { container, unmount } = await render(
+      React.createElement(AssertionsList, {
+        contextGraphId: 'cg-test',
+        layer: 'swm',
+        onComplete: vi.fn(),
+      }),
+    );
+
+    await waitForText(container, 'turn-anno-test');
+    expect(container.textContent).toContain('3 triples');
+    expect(container.textContent).not.toContain('No Shared Working Memory assertions listed yet.');
+
+    await unmount();
+  });
+});

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -30,6 +30,8 @@ const {
 
 const {
   AssertionsList,
+  LayerGraphPanel,
+  VerifiedMemoryHeroBanner,
 } = await import('../src/ui/views/project/components.js');
 
 const {
@@ -169,8 +171,36 @@ describe('Context Graph shared empty/stat patterns', () => {
     );
 
     await waitForText(container, 'No Shared Working Memory assertions listed yet.');
+    expect(container.querySelector('.v10-layer-empty-shell .v10-empty-state')).toBeTruthy();
     expect(container.textContent).toContain('Promoted assertion contents are available as Shared Working Memory entities.');
     expect(container.textContent).not.toContain('No assertions in this layer');
+
+    await unmount();
+  });
+
+  it('keeps graph and VM empty states inside the shared content gutter', async () => {
+    const { container, unmount } = await render(
+      React.createElement(React.Fragment, null,
+        React.createElement(LayerGraphPanel, {
+          layer: 'wm',
+          triples: [],
+          onNodeClick: vi.fn(),
+          contextGraphId: 'cg-test',
+        }),
+        React.createElement('div', { className: 'v10-layer-expand-body entities-tab' },
+          React.createElement(VerifiedMemoryHeroBanner, {
+            entities: [],
+            tripleCount: 0,
+            contextGraphId: 'cg-test',
+          }),
+        ),
+      ),
+    );
+
+    expect(container.querySelector('.v10-graph-view.v10-layer-empty-shell .v10-empty-state')).toBeTruthy();
+    expect(container.querySelector('.v10-layer-expand-body.entities-tab > .v10-vm-hero')).toBeTruthy();
+    expect(container.textContent).toContain('No triples in Working Memory');
+    expect(container.textContent).toContain('No Knowledge Assets yet.');
 
     await unmount();
   });

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -26,7 +26,7 @@ vi.mock('../src/ui/api.js', () => ({
 const {
   EmptyState,
   StatStrip,
-} = await import('../src/ui/views/project/primitives.js');
+} = await import('../src/ui/components/ContextGraphPrimitives.js');
 
 const {
   AssertionsList,

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -96,6 +96,7 @@ describe('Context Graph shared empty/stat patterns', () => {
     );
 
     expect(container.querySelector('.v10-empty-state')).toBeTruthy();
+    expect(container.querySelector('.v10-empty-state-icon')?.getAttribute('aria-hidden')).toBe('true');
     expect(container.querySelector('.v10-empty-state-action')).toBeNull();
     expect(container.textContent).toContain('No entities yet');
     expect(container.textContent).toContain('Import data to populate this layer.');
@@ -119,6 +120,25 @@ describe('Context Graph shared empty/stat patterns', () => {
       .toEqual(['2', '1,234']);
     expect(container.textContent).toContain('Knowledge Assets');
     expect(container.textContent).toContain('Verified Triples');
+
+    await unmount();
+  });
+
+  it('keeps compact StatStrip labels before values in DOM reading order', async () => {
+    const { container, unmount } = await render(
+      React.createElement(StatStrip, {
+        compact: true,
+        items: [
+          { id: 'entities', value: 12, label: 'Entities' },
+        ],
+      }),
+    );
+
+    const cell = container.querySelector('.v10-stat-strip-cell');
+    expect(cell?.children[0]?.className).toBe('v10-stat-strip-label');
+    expect(cell?.children[0]?.textContent).toBe('Entities');
+    expect(cell?.children[1]?.className).toBe('v10-stat-strip-value');
+    expect(cell?.children[1]?.textContent).toBe('12');
 
     await unmount();
   });

--- a/packages/node-ui/test/vm-hero-banner.test.ts
+++ b/packages/node-ui/test/vm-hero-banner.test.ts
@@ -103,7 +103,7 @@ describe('VerifiedMemoryHeroBanner', () => {
       contextGraphId: 'cg-populated',
     });
 
-    const statValues = Array.from(container.querySelectorAll('.v10-vm-hero-stat-val'))
+    const statValues = Array.from(container.querySelectorAll('.v10-vm-hero-stats .v10-stat-strip-value'))
       .map((node) => node.textContent);
 
     expect(statValues).toEqual(['2', (1234).toLocaleString(), '2']);


### PR DESCRIPTION
﻿## Summary

- Adds shared Context Graph `EmptyState` and `StatStrip` primitives for S9, with layer-aware tone support and reusable styling.
- Replaces ad hoc empty/status panels and stats across Overview, layer views, graph/loading states, documents, VM hero, activity feed, query, assertions, and sub-graph overview where safe for this PR scope.
- Implements the M5 interim Shared Working Memory Assertions empty state without changing the backend list path, so real rows still render when `listAssertions(cg, 'swm')` returns data.

## Related

- Follow-up to #611.
- Context Graph UX rollout PR 2.2: S9 + M5 from `agent-docs/context-graph-implementation-plan.md` section 7.3.
- Leaves `G-BACKEND-M5` population behavior for a later backend-gated change.

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/views/project/primitives.tsx` | Adds shared `EmptyState`, `StatStrip`, and layer tone helpers. |
| `packages/node-ui/src/ui/views/project/components.tsx` | Refits Context Graph empty states, status panels, stat rows, and SWM Assertions interim copy. |
| `packages/node-ui/src/ui/components/ActivityFeed.tsx` | Uses the shared empty-state pattern for empty activity feeds. |
| `packages/node-ui/src/ui/styles.css` | Adds shared empty/stat styling and removes old double-wrapper treatments where replaced. |
| `packages/node-ui/test/context-graph-empty-stat-components.test.ts` | Covers shared primitives and WM/SWM Assertions empty/list behavior. |
| `packages/node-ui/test/context-graph-contrast.test.ts` | Adds shared empty/stat text selectors to contrast coverage. |
| `packages/node-ui/test/vm-hero-banner.test.ts` | Updates VM hero stat assertions for the shared `StatStrip`. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/context-graph-empty-stat-components.test.ts test/vm-hero-banner.test.ts test/layer-graph-panel.test.ts test/context-graph-contrast.test.ts test/use-memory-entities-counts.test.ts test/ka-detail-label.test.ts test/project-view-navigation.test.ts test/ui-compat.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui`
- [x] `git diff --check`
- [x] Playwright smoke against `http://127.0.0.1:5178/ui/`: Context Graph Overview showed the shared `StatStrip`, empty activity used shared `EmptyState`, and Shared Memory > Assertions showed the M5 interim empty state.
- [x] Local PR review from `pr-diff.patch`: round 1 found two styling fidelity issues; round 2 returned `{"comments":[]}`.

Note: the local dev node emitted repeated API 500 console errors during browser smoke due its local data/API state. The UI still booted and the PR-specific Context Graph states rendered; this is not caused by this UI-only change.
