### PR TITLE
feat(node-ui): rebuild context graph overview IA

### DIFF
--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -9,6 +9,7 @@ import { useLayoutStore, maxBottomHeight } from './stores/layout.js';
 import { useAgentsStore } from './stores/agents.js';
 import { useTabsStore } from './stores/tabs.js';
 import { api } from './api-wrapper.js';
+import { CONTEXT_GRAPH_PRIMER_TAB } from './lib/contextGraphPrimer.js';
 
 function useLiveStatus() {
   const setNodeStatus = useAgentsStore((s) => s.setNodeStatus);
@@ -230,12 +231,6 @@ function AppShell() {
 const NetworkDebugPage = React.lazy(() =>
   import('./pages/Network.js').then((m) => ({ default: m.NetworkPage }))
 );
-
-const CONTEXT_GRAPH_PRIMER_TAB = {
-  id: 'context-graph-primer',
-  label: 'What is a Context Graph?',
-  closable: true,
-};
 
 function ContextGraphPrimerRoute() {
   const openTab = useTabsStore((s) => s.openTab);

--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -231,16 +231,25 @@ const NetworkDebugPage = React.lazy(() =>
   import('./pages/Network.js').then((m) => ({ default: m.NetworkPage }))
 );
 
-function ContextGraphPrimerRoute() {
-  const openTab = useTabsStore((s) => s.openTab);
+const CONTEXT_GRAPH_PRIMER_TAB = {
+  id: 'context-graph-primer',
+  label: 'What is a Context Graph?',
+  closable: true,
+};
 
-  useEffect(() => {
-    openTab({
-      id: 'context-graph-primer',
-      label: 'What is a Context Graph?',
-      closable: true,
-    });
-  }, [openTab]);
+function activateContextGraphPrimerTab() {
+  const { tabs, activeTabId } = useTabsStore.getState();
+  const hasPrimerTab = tabs.some(tab => tab.id === CONTEXT_GRAPH_PRIMER_TAB.id);
+  if (hasPrimerTab && activeTabId === CONTEXT_GRAPH_PRIMER_TAB.id) return;
+
+  useTabsStore.setState({
+    tabs: hasPrimerTab ? tabs : [...tabs, CONTEXT_GRAPH_PRIMER_TAB],
+    activeTabId: CONTEXT_GRAPH_PRIMER_TAB.id,
+  });
+}
+
+function ContextGraphPrimerRoute() {
+  activateContextGraphPrimerTab();
 
   return <AppShell />;
 }

--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -7,6 +7,7 @@ import { PanelBottom } from './components/Shell/PanelBottom.js';
 import { PanelRight } from './components/Shell/PanelRight.js';
 import { useLayoutStore, maxBottomHeight } from './stores/layout.js';
 import { useAgentsStore } from './stores/agents.js';
+import { useTabsStore } from './stores/tabs.js';
 import { api } from './api-wrapper.js';
 
 function useLiveStatus() {
@@ -230,6 +231,20 @@ const NetworkDebugPage = React.lazy(() =>
   import('./pages/Network.js').then((m) => ({ default: m.NetworkPage }))
 );
 
+function ContextGraphPrimerRoute() {
+  const openTab = useTabsStore((s) => s.openTab);
+
+  useEffect(() => {
+    openTab({
+      id: 'context-graph-primer',
+      label: 'What is a Context Graph?',
+      closable: true,
+    });
+  }, [openTab]);
+
+  return <AppShell />;
+}
+
 export function App() {
   return (
     <Routes>
@@ -238,6 +253,7 @@ export function App() {
           <NetworkDebugPage />
         </React.Suspense>
       } />
+      <Route path="/context-graph-primer" element={<ContextGraphPrimerRoute />} />
       <Route path="/agent" element={<Navigate to="/" replace />} />
       <Route path="/explorer" element={<Navigate to="/" replace />} />
       <Route path="/settings" element={<Navigate to="/" replace />} />

--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -251,7 +251,7 @@ function activateContextGraphPrimerTab() {
 function ContextGraphPrimerRoute() {
   activateContextGraphPrimerTab();
 
-  return <AppShell />;
+  return <Navigate to="/" replace />;
 }
 
 export function App() {

--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { Header } from './components/Shell/Header.js';
 import { PanelLeft } from './components/Shell/PanelLeft.js';
@@ -237,19 +237,12 @@ const CONTEXT_GRAPH_PRIMER_TAB = {
   closable: true,
 };
 
-function activateContextGraphPrimerTab() {
-  const { tabs, activeTabId } = useTabsStore.getState();
-  const hasPrimerTab = tabs.some(tab => tab.id === CONTEXT_GRAPH_PRIMER_TAB.id);
-  if (hasPrimerTab && activeTabId === CONTEXT_GRAPH_PRIMER_TAB.id) return;
-
-  useTabsStore.setState({
-    tabs: hasPrimerTab ? tabs : [...tabs, CONTEXT_GRAPH_PRIMER_TAB],
-    activeTabId: CONTEXT_GRAPH_PRIMER_TAB.id,
-  });
-}
-
 function ContextGraphPrimerRoute() {
-  activateContextGraphPrimerTab();
+  const openTab = useTabsStore((s) => s.openTab);
+
+  useLayoutEffect(() => {
+    openTab(CONTEXT_GRAPH_PRIMER_TAB);
+  }, [openTab]);
 
   return <Navigate to="/" replace />;
 }

--- a/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
@@ -290,11 +290,11 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
             <div className="v10-form-radio-group">
               <label className="v10-form-radio">
                 <input type="radio" checked={publishPolicy === 'curator-only'} readOnly disabled />
-                Curator only — only the curator can publish to Verified Memory
+                Curator only — only the curator can publish to Verifiable Memory
               </label>
               <label className="v10-form-radio">
                 <input type="radio" checked={publishPolicy === 'open'} readOnly disabled />
-                Open — any collaborator can publish to Verified Memory
+                Open — any collaborator can publish to Verifiable Memory
               </label>
             </div>
           </div>

--- a/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
@@ -7,6 +7,7 @@ import { MemoryLayerView } from '../../views/MemoryLayerView.js';
 import { MemoryStackView } from '../../views/MemoryStackView.js';
 import { authHeaders, fileUrl } from '../../api.js';
 import { DOC_TAB_PREFIX, decodeDocTabId } from '../../lib/doc-tab-id.js';
+import { CONTEXT_GRAPH_PRIMER_TAB_ID } from '../../lib/contextGraphPrimer.js';
 import { MarkdownMessage } from '../chat/MarkdownMessage.js';
 
 const CLOSE_ICON = (
@@ -297,7 +298,7 @@ function ViewContainer() {
 
   if (activeTabId === 'memory-stack') return <MemoryStackView />;
 
-  if (activeTabId === 'context-graph-primer') return <ContextGraphPrimerView />;
+  if (activeTabId === CONTEXT_GRAPH_PRIMER_TAB_ID) return <ContextGraphPrimerView />;
 
   if (activeTabId.startsWith('project:')) {
     const cgId = activeTabId.slice('project:'.length);

--- a/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
@@ -2,6 +2,7 @@ import React, { Suspense, useState, useEffect } from 'react';
 import { useTabsStore } from '../../stores/tabs.js';
 import { DashboardView } from '../../views/DashboardView.js';
 import { ProjectView } from '../../views/ProjectView.js';
+import { ContextGraphPrimerView } from '../../views/ContextGraphPrimerView.js';
 import { MemoryLayerView } from '../../views/MemoryLayerView.js';
 import { MemoryStackView } from '../../views/MemoryStackView.js';
 import { authHeaders, fileUrl } from '../../api.js';
@@ -295,6 +296,8 @@ function ViewContainer() {
   }
 
   if (activeTabId === 'memory-stack') return <MemoryStackView />;
+
+  if (activeTabId === 'context-graph-primer') return <ContextGraphPrimerView />;
 
   if (activeTabId.startsWith('project:')) {
     const cgId = activeTabId.slice('project:'.length);

--- a/packages/node-ui/src/ui/genui/components.tsx
+++ b/packages/node-ui/src/ui/genui/components.tsx
@@ -282,7 +282,7 @@ export const VerifiedProvenancePanelImpl: React.FC<RenderProps<{
     <div className="v10-genui-vm-panel-head">
       <div className="v10-genui-vm-badge">
         <span className="v10-genui-vm-badge-dot" />
-        Verified Memory
+        Verifiable Memory
       </div>
       <div className="v10-genui-vm-title">On-chain provenance</div>
     </div>

--- a/packages/node-ui/src/ui/genui/registry.tsx
+++ b/packages/node-ui/src/ui/genui/registry.tsx
@@ -209,7 +209,7 @@ const TaskCard = defineComponent({
 const VerifiedProvenancePanel = defineComponent({
   name: 'VerifiedProvenancePanel',
   description:
-    'The Verified Memory hero block. Use at the top of any entity in the VM layer. Surfaces on-chain anchor (tx hash, block), consensus (signing agents with reputation), knowledge-asset identity (UAL, content hash, TRAC locked, NFT token id), and finalisation timeline.',
+    'The Verifiable Memory hero block. Use at the top of any entity in the VM layer. Surfaces on-chain anchor (tx hash, block), consensus (signing agents with reputation), knowledge-asset identity (UAL, content hash, TRAC locked, NFT token id), and finalisation timeline.',
   props: z.object({
     onChain: z
       .object({
@@ -279,7 +279,7 @@ export const genuiLibrary = createLibrary({
     { name: 'Code domain', components: ['PackageCard', 'FileCard'] },
     { name: 'GitHub domain', components: ['PRCard'] },
     { name: 'Decisions & tasks', components: ['DecisionCard', 'TaskCard'] },
-    { name: 'Verified memory', components: ['VerifiedProvenancePanel'] },
+    { name: 'Verifiable memory', components: ['VerifiedProvenancePanel'] },
   ],
 });
 
@@ -297,7 +297,7 @@ export function getGenuiLibraryPrompt(): string {
         'Always wrap the response in the EntityDetail root element.',
       additionalRules: [
         'Prefer specialised cards (PackageCard, PRCard, DecisionCard, TaskCard, FileCard) when the rdf:type matches.',
-        'Include VerifiedProvenancePanel at the very top if the entity appears in verified memory or has on-chain / signature triples.',
+        'Include VerifiedProvenancePanel at the very top if the entity appears in verifiable memory or has on-chain / signature triples.',
         'Keep the tree compact: aim for 3–8 top-level blocks.',
         'Do not invent triple data — only use values present in the provided triples.',
       ],

--- a/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
+++ b/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
@@ -15,7 +15,7 @@ let state: CurrentAgentState = {
   loading: true,
   error: null,
 };
-let inFlight: Promise<void> | null = null;
+let inFlight: { authKey: string; promise: Promise<void> } | null = null;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let generation = 0;
 let stateAuthKey = '';
@@ -52,22 +52,25 @@ function setState(next: CurrentAgentState) {
 }
 
 function loadCurrentAgent() {
-  if (inFlight) return inFlight;
-
   const loadGeneration = generation;
   const loadAuthKey = currentAuthKey();
+  if (inFlight?.authKey === loadAuthKey) return inFlight.promise;
+
   if (loadAuthKey !== stateAuthKey) {
     resetStateForAuthKey(loadAuthKey);
     emit();
   } else {
     setState({ ...state, loading: true, error: null });
   }
-  inFlight = api.fetchCurrentAgent()
+  const promise = api.fetchCurrentAgent()
     .then((data) => {
       if (loadGeneration !== generation) return;
       if (loadAuthKey !== currentAuthKey()) {
-        resetStateForAuthKey(currentAuthKey());
-        emit();
+        const authKey = currentAuthKey();
+        if (stateAuthKey !== authKey) {
+          resetStateForAuthKey(authKey);
+          emit();
+        }
         return;
       }
       setState({ data, loading: false, error: null });
@@ -75,8 +78,11 @@ function loadCurrentAgent() {
     .catch((error) => {
       if (loadGeneration !== generation) return;
       if (loadAuthKey !== currentAuthKey()) {
-        resetStateForAuthKey(currentAuthKey());
-        emit();
+        const authKey = currentAuthKey();
+        if (stateAuthKey !== authKey) {
+          resetStateForAuthKey(authKey);
+          emit();
+        }
         return;
       }
       setState({
@@ -86,10 +92,12 @@ function loadCurrentAgent() {
       });
     })
     .finally(() => {
-      if (loadGeneration === generation) inFlight = null;
+      if (loadGeneration === generation && inFlight?.promise === promise) inFlight = null;
     });
 
-  return inFlight;
+  inFlight = { authKey: loadAuthKey, promise };
+
+  return promise;
 }
 
 function startPolling() {

--- a/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
+++ b/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
@@ -12,7 +12,7 @@ const POLL_MS = 60_000;
 
 let state: CurrentAgentState = {
   data: null,
-  loading: false,
+  loading: true,
   error: null,
 };
 let inFlight: Promise<void> | null = null;
@@ -70,7 +70,7 @@ function stopPollingIfIdle() {
   inFlight = null;
   state = {
     data: null,
-    loading: false,
+    loading: true,
     error: null,
   };
 }

--- a/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
+++ b/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
@@ -101,8 +101,8 @@ function loadCurrentAgent() {
 }
 
 function startPolling() {
-  if (pollTimer) return;
   void loadCurrentAgent();
+  if (pollTimer) return;
   pollTimer = setInterval(() => {
     void loadCurrentAgent();
   }, POLL_MS);

--- a/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
+++ b/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
@@ -18,7 +18,29 @@ let state: CurrentAgentState = {
 let inFlight: Promise<void> | null = null;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let generation = 0;
+let stateAuthKey = '';
 const listeners = new Set<() => void>();
+
+function currentAuthKey() {
+  if (typeof window === 'undefined') return '';
+  const token = (window as any).__DKG_TOKEN__;
+  return token ? `Bearer ${token}` : '';
+}
+
+function resetStateForAuthKey(authKey: string) {
+  stateAuthKey = authKey;
+  state = {
+    data: null,
+    loading: true,
+    error: null,
+  };
+}
+
+function snapshotForCurrentAuth() {
+  const authKey = currentAuthKey();
+  if (authKey !== stateAuthKey) resetStateForAuthKey(authKey);
+  return state;
+}
 
 function emit() {
   for (const listener of listeners) listener();
@@ -33,16 +55,32 @@ function loadCurrentAgent() {
   if (inFlight) return inFlight;
 
   const loadGeneration = generation;
-  setState({ ...state, loading: true, error: null });
+  const loadAuthKey = currentAuthKey();
+  if (loadAuthKey !== stateAuthKey) {
+    resetStateForAuthKey(loadAuthKey);
+    emit();
+  } else {
+    setState({ ...state, loading: true, error: null });
+  }
   inFlight = api.fetchCurrentAgent()
     .then((data) => {
       if (loadGeneration !== generation) return;
+      if (loadAuthKey !== currentAuthKey()) {
+        resetStateForAuthKey(currentAuthKey());
+        emit();
+        return;
+      }
       setState({ data, loading: false, error: null });
     })
     .catch((error) => {
       if (loadGeneration !== generation) return;
+      if (loadAuthKey !== currentAuthKey()) {
+        resetStateForAuthKey(currentAuthKey());
+        emit();
+        return;
+      }
       setState({
-        data: null,
+        data: state.data,
         loading: false,
         error: error instanceof Error ? error.message : 'Failed to load current agent',
       });
@@ -73,15 +111,16 @@ function stopPollingIfIdle() {
     loading: true,
     error: null,
   };
+  stateAuthKey = currentAuthKey();
 }
 
 export function useCurrentAgent() {
-  const [snapshot, setSnapshot] = useState(state);
+  const [snapshot, setSnapshot] = useState(snapshotForCurrentAuth);
 
   useEffect(() => {
-    const listener = () => setSnapshot(state);
+    const listener = () => setSnapshot(snapshotForCurrentAuth());
     listeners.add(listener);
-    setSnapshot(state);
+    setSnapshot(snapshotForCurrentAuth());
     startPolling();
 
     return () => {

--- a/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
+++ b/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
@@ -17,6 +17,7 @@ let state: CurrentAgentState = {
 };
 let inFlight: Promise<void> | null = null;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
+let generation = 0;
 const listeners = new Set<() => void>();
 
 function emit() {
@@ -31,12 +32,15 @@ function setState(next: CurrentAgentState) {
 function loadCurrentAgent() {
   if (inFlight) return inFlight;
 
+  const loadGeneration = generation;
   setState({ ...state, loading: true, error: null });
   inFlight = api.fetchCurrentAgent()
     .then((data) => {
+      if (loadGeneration !== generation) return;
       setState({ data, loading: false, error: null });
     })
     .catch((error) => {
+      if (loadGeneration !== generation) return;
       setState({
         data: state.data,
         loading: false,
@@ -44,7 +48,7 @@ function loadCurrentAgent() {
       });
     })
     .finally(() => {
-      inFlight = null;
+      if (loadGeneration === generation) inFlight = null;
     });
 
   return inFlight;
@@ -62,6 +66,13 @@ function stopPollingIfIdle() {
   if (listeners.size > 0 || !pollTimer) return;
   clearInterval(pollTimer);
   pollTimer = null;
+  generation += 1;
+  inFlight = null;
+  state = {
+    data: null,
+    loading: false,
+    error: null,
+  };
 }
 
 export function useCurrentAgent() {

--- a/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
+++ b/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
@@ -67,10 +67,12 @@ function loadCurrentAgent() {
       if (loadGeneration !== generation) return;
       if (loadAuthKey !== currentAuthKey()) {
         const authKey = currentAuthKey();
+        const shouldLoadCurrentAuth = stateAuthKey !== authKey || state.loading;
         if (stateAuthKey !== authKey) {
           resetStateForAuthKey(authKey);
           emit();
         }
+        if (shouldLoadCurrentAuth) void loadCurrentAgent();
         return;
       }
       setState({ data, loading: false, error: null });
@@ -79,10 +81,12 @@ function loadCurrentAgent() {
       if (loadGeneration !== generation) return;
       if (loadAuthKey !== currentAuthKey()) {
         const authKey = currentAuthKey();
+        const shouldLoadCurrentAuth = stateAuthKey !== authKey || state.loading;
         if (stateAuthKey !== authKey) {
           resetStateForAuthKey(authKey);
           emit();
         }
+        if (shouldLoadCurrentAuth) void loadCurrentAgent();
         return;
       }
       setState({

--- a/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
+++ b/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api-wrapper.js';
+import type { AgentIdentity } from '../api.js';
+
+type CurrentAgentState = {
+  data: AgentIdentity | null;
+  loading: boolean;
+  error: string | null;
+};
+
+const POLL_MS = 60_000;
+
+let state: CurrentAgentState = {
+  data: null,
+  loading: false,
+  error: null,
+};
+let inFlight: Promise<void> | null = null;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+function setState(next: CurrentAgentState) {
+  state = next;
+  emit();
+}
+
+function loadCurrentAgent() {
+  if (inFlight) return inFlight;
+
+  setState({ ...state, loading: true, error: null });
+  inFlight = api.fetchCurrentAgent()
+    .then((data) => {
+      setState({ data, loading: false, error: null });
+    })
+    .catch((error) => {
+      setState({
+        data: state.data,
+        loading: false,
+        error: error instanceof Error ? error.message : 'Failed to load current agent',
+      });
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+
+  return inFlight;
+}
+
+function startPolling() {
+  if (pollTimer) return;
+  void loadCurrentAgent();
+  pollTimer = setInterval(() => {
+    void loadCurrentAgent();
+  }, POLL_MS);
+}
+
+function stopPollingIfIdle() {
+  if (listeners.size > 0 || !pollTimer) return;
+  clearInterval(pollTimer);
+  pollTimer = null;
+}
+
+export function useCurrentAgent() {
+  const [snapshot, setSnapshot] = useState(state);
+
+  useEffect(() => {
+    const listener = () => setSnapshot(state);
+    listeners.add(listener);
+    setSnapshot(state);
+    startPolling();
+
+    return () => {
+      listeners.delete(listener);
+      stopPollingIfIdle();
+    };
+  }, []);
+
+  return snapshot;
+}

--- a/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
+++ b/packages/node-ui/src/ui/hooks/useCurrentAgent.ts
@@ -42,7 +42,7 @@ function loadCurrentAgent() {
     .catch((error) => {
       if (loadGeneration !== generation) return;
       setState({
-        data: state.data,
+        data: null,
         loading: false,
         error: error instanceof Error ? error.message : 'Failed to load current agent',
       });

--- a/packages/node-ui/src/ui/lib/contextGraphPrimer.ts
+++ b/packages/node-ui/src/ui/lib/contextGraphPrimer.ts
@@ -1,0 +1,7 @@
+export const CONTEXT_GRAPH_PRIMER_TAB_ID = 'context-graph-primer';
+
+export const CONTEXT_GRAPH_PRIMER_TAB = {
+  id: CONTEXT_GRAPH_PRIMER_TAB_ID,
+  label: 'What is a Context Graph?',
+  closable: true,
+};

--- a/packages/node-ui/src/ui/mocks/data.ts
+++ b/packages/node-ui/src/ui/mocks/data.ts
@@ -129,7 +129,7 @@ export const MOCK_WALLETS = {
 
 export const MOCK_NOTIFICATIONS = {
   notifications: [
-    { id: 1, ts: Date.now() - 60000, type: 'publish', title: 'Publish complete', message: 'warfarin-aspirin-001 published to Verified Memory', source: null, peer: null, read: 0, meta: null },
+    { id: 1, ts: Date.now() - 60000, type: 'publish', title: 'Publish complete', message: 'warfarin-aspirin-001 published to Verifiable Memory', source: null, peer: null, read: 0, meta: null },
     { id: 2, ts: Date.now() - 300000, type: 'agent', title: 'Agent connected', message: 'research-agent joined Pharma Drug Interactions', source: null, peer: 'QmResearch456', read: 0, meta: null },
     { id: 3, ts: Date.now() - 900000, type: 'sync', title: 'Sync complete', message: '12 new triples synced from data-curator', source: null, peer: 'QmCurator789', read: 1, meta: null },
   ],
@@ -146,7 +146,7 @@ export const MOCK_NODE_LOG = {
     '[2026-04-11 10:30:15] INFO  Agent research-agent connected via libp2p',
     '[2026-04-11 10:31:00] INFO  Publish operation started: warfarin-aspirin-001',
     '[2026-04-11 10:31:12] INFO  Triple store updated: +34 triples',
-    '[2026-04-11 10:31:15] INFO  Publish complete: warfarin-aspirin-001 → Verified Memory',
+    '[2026-04-11 10:31:15] INFO  Publish complete: warfarin-aspirin-001 → Verifiable Memory',
     '[2026-04-11 10:32:00] DEBUG SPARQL query executed in 23ms (42 results)',
     '[2026-04-11 10:33:00] INFO  Gossip: received 3 proposals from data-curator',
     '[2026-04-11 10:34:00] INFO  SWM cleanup: 0 expired triples removed',
@@ -168,7 +168,7 @@ export const MOCK_SESSIONS = {
       session: 'sess-def456',
       messages: [
         { author: 'user', text: 'Summarize the latest climate data for Arctic ice', ts: '2026-04-10T14:00:00Z' },
-        { author: 'assistant', text: 'Based on the latest projections in the verified memory...', ts: '2026-04-10T14:00:03Z' },
+        { author: 'assistant', text: 'Based on the latest projections in the verifiable memory...', ts: '2026-04-10T14:00:03Z' },
       ],
     },
   ],

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -5427,23 +5427,6 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-layer-action-btn.promote:hover { background: rgba(245,158,11,0.15); }
 .v10-layer-detail-content { flex: 1; overflow: auto; }
 
-@media (max-width: 1500px) {
-  .v10-layer-action-btn {
-    min-width: 30px;
-    padding-left: 9px;
-    padding-right: 9px;
-  }
-}
-
-@media (max-width: 920px) {
-  .v10-layer-action-btn {
-    min-width: 28px;
-    width: 28px;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
 /* ── Content tabs (inside layer views) ── */
 .v10-content-tabs {
   flex-shrink: 0; display: flex; align-items: center;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -4583,6 +4583,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   flex-shrink: 0; display: flex; align-items: center;
   border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel);
   padding: 0 4px; height: 36px; min-height: 36px; gap: 0;
+  flex-wrap: nowrap;
 }
 .v10-layer-switch-btn {
   height: 100%; padding: 0 14px; display: flex; align-items: center; gap: 6px;
@@ -4591,21 +4592,86 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   border-bottom: 2px solid transparent; transition: all 0.15s; white-space: nowrap;
   font-family: var(--font-sans);
 }
+.v10-layer-switch-label { display: inline; }
+.v10-layer-switch-label-compact { display: none; }
 .v10-layer-switch-btn:hover { color: var(--text-secondary); background: var(--bg-hover); }
 .v10-layer-switch-btn.active { color: var(--text-primary); }
 .v10-layer-switch-btn.active[data-layer="overview"] { border-bottom-color: var(--text-secondary); }
+.v10-layer-switch-btn.active[data-layer="graph-overview"] { border-bottom-color: #38bdf8; }
 .v10-layer-switch-btn.active[data-layer="query"] { border-bottom-color: #38bdf8; }
 .v10-layer-switch-btn.active[data-layer="wm"] { border-bottom-color: #64748b; }
 .v10-layer-switch-btn.active[data-layer="swm"] { border-bottom-color: #f59e0b; }
 .v10-layer-switch-btn.active[data-layer="vm"] { border-bottom-color: #22c55e; }
 .v10-layer-switch-icon { font-size: 11px; }
+.v10-layer-switch-separator {
+  flex: 0 0 auto;
+  width: 1px;
+  height: 18px;
+  margin: 0 6px;
+  background: var(--border-subtle);
+}
 .v10-layer-switch-count {
   font-family: var(--font-mono); font-size: 9px; padding: 1px 5px;
   border-radius: 3px; background: var(--bg-elevated); color: var(--text-tertiary);
 }
 .v10-layer-switch-btn.active .v10-layer-switch-count { color: var(--text-tertiary); }
-.v10-layer-switcher-spacer { flex: 1; }
-.v10-layer-switcher-actions { display: flex; align-items: center; gap: 4px; padding-right: 4px; }
+.v10-layer-switcher-spacer { flex: 1; min-width: 6px; }
+.v10-layer-switcher-actions { display: flex; align-items: center; gap: 4px; padding-right: 4px; flex: 0 0 auto; }
+.v10-layer-more {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  flex: 0 0 auto;
+}
+.v10-layer-more-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 40;
+  min-width: 178px;
+  padding: 4px;
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.32);
+}
+.v10-layer-more-item {
+  width: 100%;
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+.v10-layer-more-item:hover,
+.v10-layer-more-item.active {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.v10-layer-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+}
+.v10-layer-action-icon {
+  flex: 0 0 auto;
+  line-height: 1;
+}
+.v10-layer-action-label {
+  line-height: 1;
+}
 
 /* Shared Context Graph empty/stat patterns */
 .v10-empty-state {
@@ -4785,9 +4851,10 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 
 /* ── Project Overview Card ── */
-.v10-po { flex-shrink: 0; padding: 14px 16px; border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel); }
-.v10-po-top { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 12px; }
+.v10-po { flex-shrink: 0; padding: 16px; border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel); }
+.v10-po-top { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 14px; }
 .v10-po-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--text-primary); flex-shrink: 0; margin-top: 4px; }
+.v10-po-heading { flex: 1 1 auto; min-width: 0; }
 .v10-po-title { font-size: 15px; font-weight: 600; color: var(--text-primary); }
 .v10-po-desc { font-size: 11px; color: var(--text-tertiary); margin-top: 2px; line-height: 1.5; }
 .v10-po-stat-strip { margin-bottom: 12px; }
@@ -4796,7 +4863,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-po-stat-val { font-size: 20px; font-weight: 700; color: var(--text-primary); font-family: var(--font-mono); }
 .v10-po-stat-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-tertiary); font-weight: 600; }
 .v10-po-participants { margin-bottom: 12px; }
-.v10-po-participants-label { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-tertiary); margin-bottom: 6px; }
+.v10-po-participants-label { font-size: 9px; font-weight: 700; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 6px; }
 .v10-po-participants-list { display: flex; flex-wrap: wrap; gap: 6px; }
 .v10-po-participant {
   display: inline-flex; align-items: center; gap: 5px;
@@ -4814,6 +4881,228 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-po-progress-legend { display: flex; gap: 14px; margin-top: 6px; font-size: 9px; font-family: var(--font-mono); color: var(--text-tertiary); }
 .v10-po-legend-item { display: flex; align-items: center; gap: 4px; }
 .v10-po-legend-dot { width: 6px; height: 6px; border-radius: 50%; }
+.v10-po-badges {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+  max-width: 45%;
+}
+.v10-po-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 9px;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.v10-po-badge.curator,
+.v10-po-badge.public {
+  border-color: rgba(34, 197, 94, 0.38);
+  background: rgba(34, 197, 94, 0.11);
+  color: var(--text-success);
+}
+.v10-po-badge.participant,
+.v10-po-badge.curated {
+  border-color: rgba(245, 158, 11, 0.4);
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--text-warning);
+}
+.v10-po-badge.viewer,
+.v10-po-badge.unknown {
+  color: var(--text-tertiary);
+}
+.v10-po-pipeline {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 4px 0 12px;
+}
+.v10-po-pipeline-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.v10-po-section-title {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 700;
+}
+.v10-po-section-desc {
+  max-width: 760px;
+  margin-top: 3px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.v10-po-primer-link {
+  flex: 0 0 auto;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 700;
+  min-height: 30px;
+  padding: 0 12px;
+}
+.v10-po-primer-link:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+.v10-po-pipeline-track {
+  display: flex;
+  width: 100%;
+  height: 7px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--bg-elevated);
+}
+.v10-po-pipeline-seg {
+  min-width: 0;
+}
+.v10-po-pipeline-empty {
+  width: 100%;
+  background: var(--border-subtle);
+}
+.v10-po-pipeline-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+.v10-po-pipeline-step {
+  --po-layer-color: var(--border-strong);
+  min-width: 0;
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--po-layer-color) 28%, var(--border-default));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--po-layer-color) 6%, var(--bg-surface));
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  text-align: left;
+}
+.v10-po-pipeline-step:hover {
+  border-color: color-mix(in srgb, var(--po-layer-color) 48%, var(--border-strong));
+  background: color-mix(in srgb, var(--po-layer-color) 10%, var(--bg-hover));
+}
+.v10-po-pipeline-step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--po-layer-color) 20%, transparent);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+}
+.v10-po-pipeline-step-copy {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+.v10-po-pipeline-step-label {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+}
+.v10-po-pipeline-step-desc {
+  color: var(--text-tertiary);
+  font-size: 11px;
+  line-height: 1.3;
+}
+.v10-po-pipeline-step-count {
+  flex: 0 0 auto;
+  max-width: 42%;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+@media (max-width: 1500px) {
+  .v10-layer-switch-label-full { display: none; }
+  .v10-layer-switch-label-compact { display: inline; }
+  .v10-layer-action-label { display: none; }
+  .v10-layer-action-btn {
+    min-width: 30px;
+    padding-left: 9px;
+    padding-right: 9px;
+  }
+}
+
+@media (max-width: 1320px) {
+  .v10-layer-switch-label-full { display: none; }
+  .v10-layer-switch-label-compact { display: inline; }
+}
+
+@media (max-width: 1180px) {
+  .v10-layer-switch-btn { padding: 0 9px; gap: 5px; font-size: 11px; }
+  .v10-layer-switch-count { display: none; }
+  .v10-layer-switch-separator { margin: 0 4px; }
+}
+
+@media (max-width: 920px) {
+  .v10-layer-switcher { padding: 0 2px; }
+  .v10-layer-switch-btn {
+    width: 30px;
+    min-width: 30px;
+    padding: 0;
+    justify-content: center;
+    gap: 0;
+  }
+  .v10-layer-switch-label { display: none; }
+  .v10-layer-switch-separator { margin: 0 2px; }
+  .v10-layer-switcher-spacer { flex: 0 0 2px; min-width: 2px; }
+  .v10-layer-switcher-actions { gap: 2px; padding-right: 2px; }
+  .v10-layer-action-btn {
+    min-width: 28px;
+    width: 28px;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .v10-po-top,
+  .v10-po-pipeline-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .v10-po-badges {
+    max-width: none;
+    justify-content: flex-start;
+  }
+  .v10-po-pipeline-steps {
+    grid-template-columns: 1fr;
+  }
+  .v10-po-primer-link {
+    align-self: flex-start;
+  }
+}
 
 /* ── Memory Strip ── */
 .v10-memory-strip { flex-shrink: 0; border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel); }
@@ -5137,6 +5426,23 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-layer-action-btn.promote { background: rgba(245,158,11,0.08); color: var(--text-warning); border-color: rgba(245,158,11,0.25); }
 .v10-layer-action-btn.promote:hover { background: rgba(245,158,11,0.15); }
 .v10-layer-detail-content { flex: 1; overflow: auto; }
+
+@media (max-width: 1500px) {
+  .v10-layer-action-btn {
+    min-width: 30px;
+    padding-left: 9px;
+    padding-right: 9px;
+  }
+}
+
+@media (max-width: 920px) {
+  .v10-layer-action-btn {
+    min-width: 28px;
+    width: 28px;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
 
 /* ── Content tabs (inside layer views) ── */
 .v10-content-tabs {
@@ -6478,4 +6784,109 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   margin-left: auto;
   max-width: 560px;
   padding-left: 12px;
+}
+
+/* Context Graph primer */
+.v10-primer-view {
+  height: 100%;
+  overflow: auto;
+  padding: 28px 32px;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+}
+.v10-primer-header {
+  max-width: 860px;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.v10-primer-kicker {
+  margin: 0 0 8px;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.v10-primer-header h1 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 26px;
+  font-weight: 750;
+  line-height: 1.2;
+}
+.v10-primer-header p {
+  max-width: 720px;
+  margin: 10px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.6;
+}
+.v10-primer-pipeline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 32px minmax(0, 1fr) 32px minmax(0, 1fr);
+  align-items: center;
+  max-width: 980px;
+  gap: 10px;
+  padding: 22px 0;
+}
+.v10-primer-pipeline span:not(.connector) {
+  min-width: 0;
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 700;
+  text-align: center;
+}
+.v10-primer-pipeline .wm {
+  border-color: rgba(100, 116, 139, 0.48);
+  background: rgba(100, 116, 139, 0.12);
+}
+.v10-primer-pipeline .swm {
+  border-color: rgba(245, 158, 11, 0.45);
+  background: rgba(245, 158, 11, 0.12);
+}
+.v10-primer-pipeline .vm {
+  border-color: rgba(34, 197, 94, 0.42);
+  background: rgba(34, 197, 94, 0.11);
+}
+.v10-primer-pipeline .connector {
+  height: 1px;
+  background: var(--border-strong);
+}
+.v10-primer-sections {
+  max-width: 860px;
+  display: flex;
+  flex-direction: column;
+}
+.v10-primer-section {
+  padding: 18px 0;
+  border-top: 1px solid var(--border-subtle);
+}
+.v10-primer-section:first-child {
+  border-top: 0;
+}
+.v10-primer-section h2 {
+  margin: 0 0 6px;
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 750;
+}
+.v10-primer-section p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+@media (max-width: 760px) {
+  .v10-primer-view { padding: 22px 18px; }
+  .v10-primer-pipeline {
+    grid-template-columns: 1fr;
+  }
+  .v10-primer-pipeline .connector {
+    width: 1px;
+    height: 18px;
+    justify-self: center;
+  }
 }

--- a/packages/node-ui/src/ui/views/ContextGraphPrimerView.tsx
+++ b/packages/node-ui/src/ui/views/ContextGraphPrimerView.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+const primerSections = [
+  {
+    title: 'Memory layers',
+    body: 'Working Memory is private staging, Shared Working Memory is the collaborative review layer, and Verifiable Memory is the published on-chain layer. Counts show where entities live now.',
+  },
+  {
+    title: 'Subgraphs',
+    body: 'Subgraphs organize the same Context Graph by topic or source. They cut across memory layers, so a subgraph can contain Working, Shared Working, and Verifiable Memory at the same time.',
+  },
+  {
+    title: 'Entities and Knowledge Assets',
+    body: 'Working Memory and Shared Working Memory contain entities. Once an entity is published to Verifiable Memory, it becomes a Knowledge Asset with on-chain provenance.',
+  },
+  {
+    title: 'Assertions',
+    body: 'Assertions are batches of triples that explain how entities entered or moved through the Context Graph. They are useful for reviewing provenance and lifecycle state.',
+  },
+  {
+    title: 'Roles',
+    body: 'A curator controls access and publication policy. A participant can collaborate inside the Context Graph according to that policy.',
+  },
+];
+
+export function ContextGraphPrimerView() {
+  return (
+    <div className="v10-primer-view">
+      <header className="v10-primer-header">
+        <p className="v10-primer-kicker">Context Graph Primer</p>
+        <h1>What is a Context Graph?</h1>
+        <p>
+          A Context Graph is a shared knowledge workspace where agents stage,
+          review, organize, and publish structured memory.
+        </p>
+      </header>
+
+      <section className="v10-primer-pipeline" aria-label="Context Graph pipeline">
+        <span className="wm">Working Memory</span>
+        <span className="connector" aria-hidden="true" />
+        <span className="swm">Shared Working Memory</span>
+        <span className="connector" aria-hidden="true" />
+        <span className="vm">Verifiable Memory</span>
+      </section>
+
+      <div className="v10-primer-sections">
+        {primerSections.map(section => (
+          <section key={section.title} className="v10-primer-section">
+            <h2>{section.title}</h2>
+            <p>{section.body}</p>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/views/ContextGraphPrimerView.tsx
+++ b/packages/node-ui/src/ui/views/ContextGraphPrimerView.tsx
@@ -11,7 +11,7 @@ const primerSections = [
   },
   {
     title: 'Entities and Knowledge Assets',
-    body: 'Working Memory and Shared Working Memory contain entities. Once an entity is published to Verifiable Memory, it becomes a Knowledge Asset with on-chain provenance.',
+    body: 'Working Memory and Shared Working Memory contain entities. When published, an assertion/triple bundle is anchored as a Knowledge Asset in Verifiable Memory, giving included entities on-chain provenance.',
   },
   {
     title: 'Assertions',

--- a/packages/node-ui/src/ui/views/DashboardView.tsx
+++ b/packages/node-ui/src/ui/views/DashboardView.tsx
@@ -30,8 +30,8 @@ const LAYERS = [
     desc: 'Private agent drafts — free, self-attested, persists locally.' },
   { key: 'swm', label: 'Shared Working Memory', short: 'SWM', color: 'var(--layer-shared)',
     desc: 'Team proposals — free, gossip-replicated across context-graph peers.' },
-  { key: 'vm', label: 'Verified Memory', short: 'VM', color: 'var(--layer-verified)',
-    desc: 'On-chain knowledge — permanent, verified, requires TRAC to publish.' },
+  { key: 'vm', label: 'Verifiable Memory', short: 'VM', color: 'var(--layer-verified)',
+    desc: 'On-chain knowledge — permanent, verifiable, requires TRAC to publish.' },
 ] as const;
 
 interface LayerCounts { wm: number; swm: number; vm: number; total: number }
@@ -679,7 +679,7 @@ export function DashboardView() {
             {agg.hasCgs
               ? (agg.sizePartial
                   ? 'Some context graphs could not report size; total is partial.'
-                  : 'Totals across all your context graphs, summed over Working, Shared Working & Verified Memory. Knowledge Assets are entities that have been published to Verified Memory.')
+                  : 'Totals across all your context graphs, summed over Working, Shared Working & Verifiable Memory. Knowledge Assets are entities that have been published to Verifiable Memory.')
               : 'No context graphs yet.'}
           </div>
         </StatCard>
@@ -814,7 +814,7 @@ export function DashboardView() {
           <div className="v10-ws-spend">
             <div className="v10-ws-spend-head">
               <span>Period</span>
-              <span title="Publishes to Verified Memory that spent TRAC on-chain. Free SWM/local/testnet publishes are not counted (they don't burn TRAC).">Publishes to VM</span>
+              <span title="Publishes to Verifiable Memory that spent TRAC on-chain. Free SWM/local/testnet publishes are not counted (they don't burn TRAC).">Publishes to VM</span>
               {/* economics totalTrac is always TRAC-denominated, independent
                   of the node wallet token symbol — label it literally. */}
               <span>TRAC</span>

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -18,7 +18,7 @@ type ViewMode = 'table' | 'graph';
 const LAYER_META: Record<MemoryLayer, { label: string; color: string; icon: string; description: string }> = {
   wm: { label: 'Working Memory', color: 'var(--layer-working)', icon: '◇', description: 'Private agent drafts. Fast local storage.' },
   swm: { label: 'Shared Working Memory', color: 'var(--layer-shared)', icon: '◈', description: 'Shared proposals with collaborators. TTL-bounded.' },
-  vm: { label: 'Verified Memory', color: 'var(--layer-verified)', icon: '◉', description: 'Endorsed, published, on-chain knowledge.' },
+  vm: { label: 'Verifiable Memory', color: 'var(--layer-verified)', icon: '◉', description: 'Endorsed, published, on-chain knowledge.' },
 };
 
 const GRAPH_OPTIONS = {
@@ -202,7 +202,7 @@ export function MemoryLayerView({ layer, contextGraphId, externalQuery, external
         <div className="v10-vm-search-panel">
           <div className="v10-vm-search-header">
             <div>
-              <div className="v10-vm-search-title">Search Verified Memory</div>
+              <div className="v10-vm-search-title">Search Verifiable Memory</div>
               <div className="v10-vm-search-desc">
                 Search published triples by subject, predicate, object, or across all fields.
               </div>
@@ -220,7 +220,7 @@ export function MemoryLayerView({ layer, contextGraphId, externalQuery, external
             <input
               type="text"
               className="v10-mlv-query-input"
-              placeholder="Search verified memory..."
+              placeholder="Search verifiable memory..."
               value={draftSearch}
               onChange={(e) => setDraftSearch(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter') runVerifiedSearch(); }}
@@ -575,7 +575,7 @@ function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: string;
     return (
       <div className="v10-publish-panel">
         <div className="v10-publish-panel-header">
-          <span className="v10-publish-panel-title">Publish to Verified Memory</span>
+          <span className="v10-publish-panel-title">Publish to Verifiable Memory</span>
         </div>
         <div className="v10-publish-panel-empty">
           No data in Shared Working Memory yet. Promote assertions from Working Memory first.
@@ -638,7 +638,7 @@ function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: string;
 
       {publishResult && (
         <div className="v10-publish-result-card success">
-          <div className="v10-publish-result-title">Published to Verified Memory</div>
+          <div className="v10-publish-result-title">Published to Verifiable Memory</div>
           <div className="v10-publish-result-details">
             <div><span className="v10-publish-result-label">Knowledge Collection:</span> {publishResult.kcId}</div>
             <div><span className="v10-publish-result-label">Status:</span> {publishResult.status}</div>

--- a/packages/node-ui/src/ui/views/MemoryStackView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryStackView.tsx
@@ -3,7 +3,7 @@
  * every project the user is in.
  *
  * Each visible, non-hidden project becomes a row with three cards:
- * Working / Shared / Verified Memory. Each card shows the layer's
+ * Working / Shared / Verifiable Memory. Each card shows the layer's
  * entity + triple counts for that project, a short preview of the
  * newest entities, and a button that deep-links into the project's
  * layer tab (reusing the existing `wm:` / `swm:` / `vm:` tab ids).
@@ -31,7 +31,7 @@ const LAYERS: Array<{
 }> = [
   { key: 'working',  title: 'Working Memory',        short: 'WM',  icon: '◇', color: '#64748b', desc: 'Private agent drafts', tabPrefix: 'wm' },
   { key: 'shared',   title: 'Shared Working Memory', short: 'SWM', icon: '◈', color: '#f59e0b', desc: 'Team proposals',       tabPrefix: 'swm' },
-  { key: 'verified', title: 'Verified Memory',       short: 'VM',  icon: '◉', color: '#22c55e', desc: 'On-chain knowledge',   tabPrefix: 'vm' },
+  { key: 'verified', title: 'Verifiable Memory',     short: 'VM',  icon: '◉', color: '#22c55e', desc: 'On-chain knowledge',   tabPrefix: 'vm' },
 ];
 
 const TS_PREDS = [

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -9,6 +9,7 @@ import { useAgents, AgentsContext } from '../hooks/useAgents.js';
 import { useCurrentAgent } from '../hooks/useCurrentAgent.js';
 import { ActivityFeed } from '../components/ActivityFeed.js';
 import { SubGraphBar } from '../components/SubGraphBar.js';
+import { CONTEXT_GRAPH_PRIMER_TAB } from '../lib/contextGraphPrimer.js';
 import { useTabsStore } from '../stores/tabs.js';
 import type { LayerView, LayerContentTab, SubGraphTab } from './project/helpers.js';
 import {
@@ -276,11 +277,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   }, [handleNavigate]);
 
   const handleOpenPrimer = useCallback(() => {
-    openTab({
-      id: 'context-graph-primer',
-      label: 'What is a Context Graph?',
-      closable: true,
-    });
+    openTab(CONTEXT_GRAPH_PRIMER_TAB);
   }, [openTab]);
 
   if (!cg) {

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { useFetch } from '../hooks.js';
 import { api } from '../api-wrapper.js';
-import { listParticipants } from '../api.js';
 import { ImportFilesModal } from '../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../components/Modals/ShareProjectModal.js';
 import { useMemoryEntities } from '../hooks/useMemoryEntities.js';
@@ -189,7 +188,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const refreshParticipants = useCallback(() => {
     if (cg?.id) {
       setParticipantsStatus('loading');
-      listParticipants(cg.id)
+      api.listParticipants(cg.id)
         .then(data => {
           setParticipants(data.allowedAgents);
           setParticipantsStatus('ok');

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -30,6 +30,11 @@ interface ProjectViewProps {
 
 type MemoryLayerView = Extract<LayerView, 'wm' | 'swm' | 'vm'>;
 type ParticipantsStatus = 'loading' | 'ok' | 'error';
+type ParticipantsState = {
+  contextGraphId: string | null;
+  list: string[];
+  status: ParticipantsStatus;
+};
 
 interface DetailOrigin {
   activeLayer: LayerView;
@@ -64,8 +69,11 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const [showShare, setShowShare] = useState(false);
   const [activeLayer, setActiveLayer] = useState<LayerView>('overview');
   const [selectedUri, setSelectedUri] = useState<string | null>(null);
-  const [participants, setParticipants] = useState<string[]>([]);
-  const [participantsStatus, setParticipantsStatus] = useState<ParticipantsStatus>('loading');
+  const [participantsState, setParticipantsState] = useState<ParticipantsState>({
+    contextGraphId: null,
+    list: [],
+    status: 'loading',
+  });
   // Active sub-graph *page* — when set, the middle pane renders the sub-graph
   // detail view instead of the overview / layer views. This is structurally
   // a sibling of `activeLayer`, not a filter over it: sub-graphs are a peer
@@ -78,6 +86,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const pageRef = useRef<HTMLElement | null>(null);
   const detailOriginRef = useRef<DetailOrigin | null>(null);
   const pendingScrollRestoreRef = useRef<DetailOrigin['scroll'] | null>(null);
+  const participantsRequestRef = useRef(0);
   const profile = useProjectProfile(contextGraphId);
   const agentsData = useAgents(contextGraphId);
   const openTab = useTabsStore((s) => s.openTab);
@@ -186,18 +195,20 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const rawMemory = useMemoryEntities(contextGraphId);
 
   const refreshParticipants = useCallback(() => {
-    if (cg?.id) {
-      setParticipantsStatus('loading');
-      api.listParticipants(cg.id)
-        .then(data => {
-          setParticipants(data.allowedAgents);
-          setParticipantsStatus('ok');
-        })
-        .catch(() => {
-          setParticipants([]);
-          setParticipantsStatus('error');
-        });
-    }
+    const targetId = cg?.id;
+    if (!targetId) return;
+    const requestId = participantsRequestRef.current + 1;
+    participantsRequestRef.current = requestId;
+    setParticipantsState({ contextGraphId: targetId, list: [], status: 'loading' });
+    api.listParticipants(targetId)
+      .then(data => {
+        if (participantsRequestRef.current !== requestId) return;
+        setParticipantsState({ contextGraphId: targetId, list: data.allowedAgents, status: 'ok' });
+      })
+      .catch(() => {
+        if (participantsRequestRef.current !== requestId) return;
+        setParticipantsState({ contextGraphId: targetId, list: [], status: 'error' });
+      });
   }, [cg?.id]);
 
   useEffect(() => { refreshParticipants(); }, [refreshParticipants]);
@@ -288,6 +299,12 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     : activeSubGraph
       ? 'subgraph'
       : activeLayer;
+  const participantsForCurrentGraph = participantsState.contextGraphId === cg.id
+    ? participantsState.list
+    : [];
+  const participantsStatusForCurrentGraph = participantsState.contextGraphId === cg.id
+    ? participantsState.status
+    : 'loading';
 
   return (
     <ProjectProfileContext.Provider value={profile}>
@@ -357,8 +374,8 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           <ProjectOverviewCard
             cg={cg}
             memory={rawMemory}
-            participants={participants}
-            participantsStatus={participantsStatus}
+            participants={participantsForCurrentGraph}
+            participantsStatus={participantsStatusForCurrentGraph}
             currentAgent={currentAgent ?? null}
             currentAgentStatus={currentAgentLoading ? 'loading' : currentAgentError ? 'error' : 'ok'}
             onSwitchLayer={handleLayerSwitch}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -261,13 +261,6 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
       label: 'What is a Context Graph?',
       closable: true,
     });
-    if (typeof window !== 'undefined') {
-      const base = window.location.pathname.startsWith('/ui') ? '/ui' : '';
-      const target = `${base}/context-graph-primer`;
-      if (window.location.pathname !== target) {
-        window.history.pushState(null, '', target);
-      }
-    }
   }, [openTab]);
 
   if (!cg) {

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -18,7 +18,6 @@ import {
   SubGraphDetailView,
   ProjectOverviewCard,
   PendingJoinRequestsBar,
-  MemoryStrip,
   SubGraphOverviewGrid,
   ContextGraphQueryView,
   LayerDetailView,
@@ -35,8 +34,6 @@ interface DetailOrigin {
   activeLayer: LayerView;
   activeSubGraph: string | null;
   layerTabs: Record<MemoryLayerView, LayerContentTab>;
-  overviewExpandedLayer: MemoryLayerView | null;
-  overviewLayerTabs: Record<MemoryLayerView, LayerContentTab>;
   subGraphTabs: Record<string, SubGraphTab>;
   scroll: { key: string; top: number };
 }
@@ -75,10 +72,6 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const [layerContentTabs, setLayerContentTabs] = useState<Record<MemoryLayerView, LayerContentTab>>(
     DEFAULT_LAYER_TABS,
   );
-  const [overviewExpandedLayer, setOverviewExpandedLayer] = useState<MemoryLayerView | null>(null);
-  const [overviewLayerTabs, setOverviewLayerTabs] = useState<Record<MemoryLayerView, LayerContentTab>>(
-    DEFAULT_LAYER_TABS,
-  );
   const [subGraphTabs, setSubGraphTabs] = useState<Record<string, SubGraphTab>>({});
   const pageRef = useRef<HTMLElement | null>(null);
   const detailOriginRef = useRef<DetailOrigin | null>(null);
@@ -86,6 +79,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const profile = useProjectProfile(contextGraphId);
   const agentsData = useAgents(contextGraphId);
   const openTab = useTabsStore((s) => s.openTab);
+  const { data: currentAgent } = useFetch(api.fetchCurrentAgent, [], 60_000);
 
   const currentScrollKey = useCallback(() => {
     if (activeSubGraph) {
@@ -104,8 +98,6 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
       activeLayer,
       activeSubGraph,
       layerTabs: { ...layerContentTabs },
-      overviewExpandedLayer,
-      overviewLayerTabs: { ...overviewLayerTabs },
       subGraphTabs: { ...subGraphTabs },
       scroll: { key, top: scrollEl?.scrollTop ?? 0 },
     };
@@ -114,8 +106,6 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     activeSubGraph,
     currentScrollKey,
     layerContentTabs,
-    overviewExpandedLayer,
-    overviewLayerTabs,
     subGraphTabs,
   ]);
 
@@ -234,10 +224,6 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     setLayerContentTabs(prev => prev[layer] === tab ? prev : { ...prev, [layer]: tab });
   }, []);
 
-  const handleOverviewLayerTabChange = useCallback((layer: MemoryLayerView, tab: LayerContentTab) => {
-    setOverviewLayerTabs(prev => prev[layer] === tab ? prev : { ...prev, [layer]: tab });
-  }, []);
-
   const handleSubGraphTabChange = useCallback((slug: string, tab: SubGraphTab) => {
     setSubGraphTabs(prev => prev[slug] === tab ? prev : { ...prev, [slug]: tab });
   }, []);
@@ -257,8 +243,6 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     setActiveLayer(origin.activeLayer);
     setActiveSubGraph(origin.activeSubGraph);
     setLayerContentTabs(origin.layerTabs);
-    setOverviewExpandedLayer(origin.overviewExpandedLayer);
-    setOverviewLayerTabs(origin.overviewLayerTabs);
     setSubGraphTabs(origin.subGraphTabs);
     pendingScrollRestoreRef.current = origin.scroll;
   }, []);
@@ -271,16 +255,20 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     handleNavigate(uri, 'page');
   }, [handleNavigate]);
 
-  const handleOverviewStripNavigate = useCallback((uri: string) => {
-    const key = overviewExpandedLayer
-      ? `layer:${overviewExpandedLayer}:${overviewLayerTabs[overviewExpandedLayer]}`
-      : 'page';
-    handleNavigate(uri, key);
-  }, [handleNavigate, overviewExpandedLayer, overviewLayerTabs]);
-
-  const handleOverviewStripNodeClick = useCallback((node: any) => {
-    if (node?.id) handleOverviewStripNavigate(node.id);
-  }, [handleOverviewStripNavigate]);
+  const handleOpenPrimer = useCallback(() => {
+    openTab({
+      id: 'context-graph-primer',
+      label: 'What is a Context Graph?',
+      closable: true,
+    });
+    if (typeof window !== 'undefined') {
+      const base = window.location.pathname.startsWith('/ui') ? '/ui' : '';
+      const target = `${base}/context-graph-primer`;
+      if (window.location.pathname !== target) {
+        window.history.pushState(null, '', target);
+      }
+    }
+  }, [openTab]);
 
   if (!cg) {
     return (
@@ -364,15 +352,15 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
       {/* Overview View */}
       {!activeSubGraph && activeLayer === 'overview' && !selectedEntity && (
         <>
-          <ProjectOverviewCard cg={cg} memory={rawMemory} participants={participants} />
-          <PendingJoinRequestsBar contextGraphId={contextGraphId} onParticipantsChanged={refreshParticipants} />
-          <SubGraphBar
-            contextGraphId={contextGraphId}
-            profile={profile}
-            selected={activeSubGraph}
-            entities={rawMemory.entityList}
-            onSelect={handleSelectSubGraph}
+          <ProjectOverviewCard
+            cg={cg}
+            memory={rawMemory}
+            participants={participants}
+            currentAgent={currentAgent ?? null}
+            onSwitchLayer={handleLayerSwitch}
+            onOpenPrimer={handleOpenPrimer}
           />
+          <PendingJoinRequestsBar contextGraphId={contextGraphId} onParticipantsChanged={refreshParticipants} />
           {rawMemory.loading && (
             <div className="v10-me-loading"><div className="v10-me-loading-text">Loading memory...</div></div>
           )}
@@ -388,21 +376,10 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             emptyHint="Once agents start proposing decisions or tasks they'll show up here as a live feed."
             className="v10-overview-activity"
           />
-          <MemoryStrip
-            memory={rawMemory}
-            onSwitchLayer={handleLayerSwitch}
-            onSelectEntity={handleOverviewStripNavigate}
-            contextGraphId={contextGraphId}
-            onNodeClick={handleOverviewStripNodeClick}
-            expandedLayer={overviewExpandedLayer}
-            onExpandedLayerChange={setOverviewExpandedLayer}
-            expandTabs={overviewLayerTabs}
-            onExpandTabChange={handleOverviewLayerTabChange}
-          />
         </>
       )}
 
-      {/* Graph Overview — one mini graph per sub-graph, side-by-side */}
+      {/* Subgraphs — one mini graph per sub-graph, side-by-side */}
       {!activeSubGraph && activeLayer === 'graph-overview' && !selectedEntity && (
         <SubGraphOverviewGrid
           contextGraphId={contextGraphId}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -82,7 +82,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const profile = useProjectProfile(contextGraphId);
   const agentsData = useAgents(contextGraphId);
   const openTab = useTabsStore((s) => s.openTab);
-  const { data: currentAgent } = useCurrentAgent();
+  const { data: currentAgent, loading: currentAgentLoading, error: currentAgentError } = useCurrentAgent();
 
   const currentScrollKey = useCallback(() => {
     if (activeSubGraph) {
@@ -361,6 +361,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             participants={participants}
             participantsStatus={participantsStatus}
             currentAgent={currentAgent ?? null}
+            currentAgentStatus={currentAgentLoading ? 'loading' : currentAgentError ? 'error' : 'ok'}
             onSwitchLayer={handleLayerSwitch}
             onOpenPrimer={handleOpenPrimer}
           />

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -7,6 +7,7 @@ import { ShareProjectModal } from '../components/Modals/ShareProjectModal.js';
 import { useMemoryEntities } from '../hooks/useMemoryEntities.js';
 import { useProjectProfile, ProjectProfileContext } from '../hooks/useProjectProfile.js';
 import { useAgents, AgentsContext } from '../hooks/useAgents.js';
+import { useCurrentAgent } from '../hooks/useCurrentAgent.js';
 import { ActivityFeed } from '../components/ActivityFeed.js';
 import { SubGraphBar } from '../components/SubGraphBar.js';
 import { useTabsStore } from '../stores/tabs.js';
@@ -29,6 +30,7 @@ interface ProjectViewProps {
 }
 
 type MemoryLayerView = Extract<LayerView, 'wm' | 'swm' | 'vm'>;
+type ParticipantsStatus = 'loading' | 'ok' | 'error';
 
 interface DetailOrigin {
   activeLayer: LayerView;
@@ -64,6 +66,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const [activeLayer, setActiveLayer] = useState<LayerView>('overview');
   const [selectedUri, setSelectedUri] = useState<string | null>(null);
   const [participants, setParticipants] = useState<string[]>([]);
+  const [participantsStatus, setParticipantsStatus] = useState<ParticipantsStatus>('loading');
   // Active sub-graph *page* — when set, the middle pane renders the sub-graph
   // detail view instead of the overview / layer views. This is structurally
   // a sibling of `activeLayer`, not a filter over it: sub-graphs are a peer
@@ -79,7 +82,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const profile = useProjectProfile(contextGraphId);
   const agentsData = useAgents(contextGraphId);
   const openTab = useTabsStore((s) => s.openTab);
-  const { data: currentAgent } = useFetch(api.fetchCurrentAgent, [], 60_000);
+  const { data: currentAgent } = useCurrentAgent();
 
   const currentScrollKey = useCallback(() => {
     if (activeSubGraph) {
@@ -185,9 +188,16 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
 
   const refreshParticipants = useCallback(() => {
     if (cg?.id) {
+      setParticipantsStatus('loading');
       listParticipants(cg.id)
-        .then(data => setParticipants(data.allowedAgents))
-        .catch(() => setParticipants([]));
+        .then(data => {
+          setParticipants(data.allowedAgents);
+          setParticipantsStatus('ok');
+        })
+        .catch(() => {
+          setParticipants([]);
+          setParticipantsStatus('error');
+        });
     }
   }, [cg?.id]);
 
@@ -349,6 +359,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             cg={cg}
             memory={rawMemory}
             participants={participants}
+            participantsStatus={participantsStatus}
             currentAgent={currentAgent ?? null}
             onSwitchLayer={handleLayerSwitch}
             onOpenPrimer={handleOpenPrimer}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -266,9 +266,14 @@ type OverviewRoleState = {
   title: string;
   tone: 'curator' | 'participant' | 'viewer' | 'unknown';
 };
+type OverviewAgentStatus = 'loading' | 'ok' | 'error';
 type OverviewParticipantsStatus = 'loading' | 'ok' | 'error';
 
-function overviewRoleState(cg: any, currentAgent: Pick<AgentIdentity, 'agentDid'> | null): OverviewRoleState {
+function overviewRoleState(
+  cg: any,
+  currentAgent: Pick<AgentIdentity, 'agentDid'> | null,
+  currentAgentStatus: OverviewAgentStatus,
+): OverviewRoleState {
   const curator = typeof cg?.curator === 'string' ? cg.curator.trim() : '';
   const agentDid = currentAgent?.agentDid?.trim() ?? '';
   if (curator && agentDid && canonicalAgentDid(curator) === canonicalAgentDid(agentDid)) {
@@ -279,6 +284,20 @@ function overviewRoleState(cg: any, currentAgent: Pick<AgentIdentity, 'agentDid'
     };
   }
   if (cg?.callerInvolved === true) {
+    if (curator && !agentDid && currentAgentStatus === 'loading') {
+      return {
+        label: 'Role checking',
+        title: 'This agent is involved in this Context Graph; curator status is still loading.',
+        tone: 'unknown',
+      };
+    }
+    if (curator && !agentDid && currentAgentStatus === 'error') {
+      return {
+        label: 'Role unknown',
+        title: 'This agent is involved in this Context Graph, but curator status could not be confirmed.',
+        tone: 'unknown',
+      };
+    }
     return {
       label: 'Joined',
       title: 'This agent is involved in this Context Graph; curator status is shown only when identity metadata confirms it.',
@@ -376,6 +395,7 @@ export function ProjectOverviewCard({
   participants,
   participantsStatus = 'ok',
   currentAgent,
+  currentAgentStatus = 'ok',
   onSwitchLayer,
   onOpenPrimer,
 }: {
@@ -384,12 +404,13 @@ export function ProjectOverviewCard({
   participants: string[];
   participantsStatus?: OverviewParticipantsStatus;
   currentAgent?: Pick<AgentIdentity, 'agentDid'> | null;
+  currentAgentStatus?: OverviewAgentStatus;
   onSwitchLayer?: (layer: LayerView) => void;
   onOpenPrimer?: () => void;
 }) {
   const { wm: working, swm: shared, vm: verified } = memory.counts;
   const layerSum = working + shared + verified;
-  const role = overviewRoleState(cg, currentAgent ?? null);
+  const role = overviewRoleState(cg, currentAgent ?? null, currentAgentStatus);
   const access = overviewAccessState(cg?.accessPolicy);
   const accessAgentStat = overviewAccessAgentStat(cg, participants, participantsStatus);
   const statusHint = memory.loading

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -281,14 +281,22 @@ type OverviewRoleState = {
 };
 type OverviewAgentStatus = 'loading' | 'ok' | 'error';
 type OverviewParticipantsStatus = 'loading' | 'ok' | 'error';
+type OverviewAgentIdentity = Pick<AgentIdentity, 'agentDid'> & Partial<Pick<AgentIdentity, 'agentAddress'>>;
 
 function overviewRoleState(
   cg: any,
-  currentAgent: Pick<AgentIdentity, 'agentDid'> | null,
+  currentAgent: OverviewAgentIdentity | null,
   currentAgentStatus: OverviewAgentStatus,
+  participants: string[],
+  participantsStatus: OverviewParticipantsStatus,
 ): OverviewRoleState {
   const curator = typeof cg?.curator === 'string' ? cg.curator.trim() : '';
   const agentDid = currentAgent?.agentDid?.trim() ?? '';
+  const agentIds = new Set(
+    [currentAgent?.agentDid, currentAgent?.agentAddress]
+      .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+      .map(canonicalAgentDid),
+  );
   if (curator && agentDid && canonicalAgentDid(curator) === canonicalAgentDid(agentDid)) {
     return {
       label: 'Curator',
@@ -322,6 +330,17 @@ function overviewRoleState(
       label: 'Not joined',
       title: 'This agent is not listed as curator or participant for this Context Graph.',
       tone: 'viewer',
+    };
+  }
+  const isListedParticipant = participantsStatus === 'ok' && participants
+    .map(participant => participant.trim())
+    .filter(Boolean)
+    .some(participant => agentIds.has(canonicalAgentDid(participant)));
+  if (isListedParticipant) {
+    return {
+      label: 'Joined',
+      title: 'This agent is listed as a participant for this Context Graph.',
+      tone: 'participant',
     };
   }
   return {
@@ -416,14 +435,14 @@ export function ProjectOverviewCard({
   memory: ReturnType<typeof useMemoryEntities>;
   participants: string[];
   participantsStatus?: OverviewParticipantsStatus;
-  currentAgent?: Pick<AgentIdentity, 'agentDid'> | null;
+  currentAgent?: OverviewAgentIdentity | null;
   currentAgentStatus?: OverviewAgentStatus;
   onSwitchLayer?: (layer: LayerView) => void;
   onOpenPrimer?: () => void;
 }) {
   const { wm: working, swm: shared, vm: verified } = memory.counts;
   const layerSum = working + shared + verified;
-  const role = overviewRoleState(cg, currentAgent ?? null, currentAgentStatus);
+  const role = overviewRoleState(cg, currentAgent ?? null, currentAgentStatus, participants, participantsStatus);
   const access = overviewAccessState(cg?.accessPolicy);
   const isPublicAccess = normalizeAccessPolicy(cg?.accessPolicy) === 'public';
   const accessAgentStat = overviewAccessAgentStat(cg, participants, participantsStatus);

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -5,7 +5,7 @@ import { api } from '../../api-wrapper.js';
 import { encodeDocTabId, resolveDocRef } from '../../lib/doc-tab-id.js';
 import {
   listJoinRequests, approveJoinRequest, rejectJoinRequest,
-  listParticipants, listAssertions, promoteAssertion,
+  listAssertions, promoteAssertion,
   publishSharedMemory, executeQuery,
   writeProfileQueryCatalog,
   fetchSubGraphs,
@@ -425,6 +425,7 @@ export function ProjectOverviewCard({
   const layerSum = working + shared + verified;
   const role = overviewRoleState(cg, currentAgent ?? null, currentAgentStatus);
   const access = overviewAccessState(cg?.accessPolicy);
+  const isPublicAccess = normalizeAccessPolicy(cg?.accessPolicy) === 'public';
   const accessAgentStat = overviewAccessAgentStat(cg, participants, participantsStatus);
   const layerStatuses = Object.values(memory.layerStatus ?? {});
   const unavailableLayerCount = layerStatuses.filter(status => status === 'error').length;
@@ -445,6 +446,7 @@ export function ProjectOverviewCard({
       label: 'Working Memory',
       desc: 'Private staging area',
       count: working,
+      status: memory.layerStatus?.wm ?? 'ok',
       color: '#64748b',
     },
     {
@@ -452,6 +454,7 @@ export function ProjectOverviewCard({
       label: 'Shared Working Memory',
       desc: 'Collaborative review',
       count: shared,
+      status: memory.layerStatus?.swm ?? 'ok',
       color: '#f59e0b',
     },
     {
@@ -459,9 +462,11 @@ export function ProjectOverviewCard({
       label: 'Verifiable Memory',
       desc: 'Published on-chain',
       count: verified,
+      status: memory.layerStatus?.vm ?? 'ok',
       color: '#22c55e',
     },
   ];
+  const pipelineHasUnavailableLayer = pipeline.some(item => item.status === 'error');
 
   return (
     <div className="v10-po">
@@ -496,7 +501,7 @@ export function ProjectOverviewCard({
           )}
         </div>
         <div className="v10-po-pipeline-track" aria-hidden="true">
-          {layerSum > 0
+          {!pipelineHasUnavailableLayer && layerSum > 0
             ? pipeline.map(item => {
               const width = item.count > 0 ? (item.count / layerSum) * 100 : 0;
               return (
@@ -524,7 +529,7 @@ export function ProjectOverviewCard({
                 <span className="v10-po-pipeline-step-desc">{item.desc}</span>
               </span>
               <span className="v10-po-pipeline-step-count">
-                {allLayerCountsUnavailable
+                {item.status === 'error'
                   ? 'Unavailable'
                   : `${item.count.toLocaleString()} ${layerNoun(item.key, item.count)}`}
               </span>
@@ -534,7 +539,9 @@ export function ProjectOverviewCard({
       </div>
       {participants.length > 0 && (
         <div className="v10-po-participants">
-          <div className="v10-po-participants-label">Allowlisted participants</div>
+          <div className="v10-po-participants-label">
+            {isPublicAccess ? 'Known participants' : 'Allowlisted participants'}
+          </div>
           <div className="v10-po-participants-list">
             {participants.map(addr => (
               <span key={addr} className="v10-po-participant" title={addr}>

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -266,6 +266,7 @@ type OverviewRoleState = {
   title: string;
   tone: 'curator' | 'participant' | 'viewer' | 'unknown';
 };
+type OverviewParticipantsStatus = 'loading' | 'ok' | 'error';
 
 function overviewRoleState(cg: any, currentAgent: Pick<AgentIdentity, 'agentDid'> | null): OverviewRoleState {
   const curator = typeof cg?.curator === 'string' ? cg.curator.trim() : '';
@@ -298,7 +299,11 @@ function overviewRoleState(cg: any, currentAgent: Pick<AgentIdentity, 'agentDid'
   };
 }
 
-function overviewAccessAgentStat(cg: any, participants: string[]) {
+function overviewAccessAgentStat(
+  cg: any,
+  participants: string[],
+  participantsStatus: OverviewParticipantsStatus,
+) {
   const policy = normalizeAccessPolicy(cg?.accessPolicy);
   if (policy === 'public') {
     return {
@@ -306,6 +311,22 @@ function overviewAccessAgentStat(cg: any, participants: string[]) {
       value: 'Open',
       label: 'Public access',
       hint: 'Public Context Graphs do not have an authoritative allowlist count.',
+    };
+  }
+  if (participantsStatus === 'loading') {
+    return {
+      id: 'participants',
+      value: '...',
+      label: 'Agents with access',
+      hint: 'Participant list is loading.',
+    };
+  }
+  if (participantsStatus === 'error') {
+    return {
+      id: 'participants',
+      value: 'Unavailable',
+      label: 'Agents with access',
+      hint: 'Participant list unavailable; access count is unknown.',
     };
   }
 
@@ -353,6 +374,7 @@ export function ProjectOverviewCard({
   cg,
   memory,
   participants,
+  participantsStatus = 'ok',
   currentAgent,
   onSwitchLayer,
   onOpenPrimer,
@@ -360,6 +382,7 @@ export function ProjectOverviewCard({
   cg: any;
   memory: ReturnType<typeof useMemoryEntities>;
   participants: string[];
+  participantsStatus?: OverviewParticipantsStatus;
   currentAgent?: Pick<AgentIdentity, 'agentDid'> | null;
   onSwitchLayer?: (layer: LayerView) => void;
   onOpenPrimer?: () => void;
@@ -368,7 +391,7 @@ export function ProjectOverviewCard({
   const layerSum = working + shared + verified;
   const role = overviewRoleState(cg, currentAgent ?? null);
   const access = overviewAccessState(cg?.accessPolicy);
-  const accessAgentStat = overviewAccessAgentStat(cg, participants);
+  const accessAgentStat = overviewAccessAgentStat(cg, participants, participantsStatus);
   const statusHint = memory.loading
     ? 'Loading memory layers...'
     : memory.partial

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -413,13 +413,19 @@ export function ProjectOverviewCard({
   const role = overviewRoleState(cg, currentAgent ?? null, currentAgentStatus);
   const access = overviewAccessState(cg?.accessPolicy);
   const accessAgentStat = overviewAccessAgentStat(cg, participants, participantsStatus);
+  const layerStatuses = Object.values(memory.layerStatus ?? {});
+  const unavailableLayerCount = layerStatuses.filter(status => status === 'error').length;
+  const allLayerCountsUnavailable =
+    !memory.loading && layerStatuses.length === 3 && unavailableLayerCount === 3;
+  const hasUnavailableLayer = !memory.loading && unavailableLayerCount > 0;
   const statusHint = memory.loading
     ? 'Loading memory layers...'
-    : memory.partial
-      ? 'One or more layer counts are currently a lower bound.'
-      : memory.error
+    : allLayerCountsUnavailable || memory.error
         ? 'Live memory counts are unavailable.'
-        : 'Canonical current-layer entity counts.';
+        : memory.partial || hasUnavailableLayer
+          ? 'One or more layer counts are currently a lower bound.'
+          : 'Canonical current-layer entity counts.';
+  const totalEntitiesValue = allLayerCountsUnavailable ? 'Unavailable' : layerSum.toLocaleString();
   const pipeline = [
     {
       key: 'wm' as const,
@@ -460,7 +466,7 @@ export function ProjectOverviewCard({
       <StatStrip
         className="v10-po-stat-strip"
         items={[
-          { id: 'total', value: layerSum.toLocaleString(), label: 'Total entities', hint: statusHint },
+          { id: 'total', value: totalEntitiesValue, label: 'Total entities', hint: statusHint },
           accessAgentStat,
         ]}
       />
@@ -505,7 +511,9 @@ export function ProjectOverviewCard({
                 <span className="v10-po-pipeline-step-desc">{item.desc}</span>
               </span>
               <span className="v10-po-pipeline-step-count">
-                {item.count.toLocaleString()} {layerNoun(item.key, item.count)}
+                {allLayerCountsUnavailable
+                  ? 'Unavailable'
+                  : `${item.count.toLocaleString()} ${layerNoun(item.key, item.count)}`}
               </span>
             </button>
           ))}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -9,7 +9,7 @@ import {
   publishSharedMemory, executeQuery,
   writeProfileQueryCatalog,
   fetchSubGraphs,
-  type PendingJoinRequest, type PublishResult, type SubGraphInfo,
+  type AgentIdentity, type PendingJoinRequest, type PublishResult, type SubGraphInfo,
 } from '../../api.js';
 import { ImportFilesModal } from '../../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../../components/Modals/ShareProjectModal.js';
@@ -31,6 +31,7 @@ import { VerifiedIdentityBanner } from '../../components/VerifiedIdentityBanner.
 import { SubGraphBar } from '../../components/SubGraphBar.js';
 import { GenUIEntityPanel } from '../../genui/index.js';
 import { memoryGraphLabels } from '../../lib/memoryLabels.js';
+import { canonicalAgentDid, normalizeAccessPolicy } from '../../lib/contextGraphSidebar.js';
 import { useTabsStore } from '../../stores/tabs.js';
 import {
   useVerifiedMemoryAnchors,
@@ -71,58 +72,120 @@ export function LayerSwitcher({ active, counts, onSwitch, onShare, onImport, onR
   onImport: () => void;
   onRefresh: () => void;
 }) {
+  const [moreOpen, setMoreOpen] = useState(false);
+  const switchTo = (layer: LayerView) => {
+    setMoreOpen(false);
+    onSwitch(layer);
+  };
+
   return (
     <div className="v10-layer-switcher">
       <button
         className={`v10-layer-switch-btn ${active === 'overview' ? 'active' : ''}`}
         data-layer="overview"
-        onClick={() => onSwitch('overview')}
+        aria-label="Overview"
+        title="Overview"
+        onClick={() => switchTo('overview')}
       >
-        <span className="v10-layer-switch-icon">◎</span> Overview
+        <span className="v10-layer-switch-icon">◎</span>
+        <span className="v10-layer-switch-label">Overview</span>
       </button>
-      <button
-        className={`v10-layer-switch-btn ${active === 'graph-overview' ? 'active' : ''}`}
-        data-layer="graph-overview"
-        onClick={() => onSwitch('graph-overview')}
-      >
-        <span className="v10-layer-switch-icon">⌬</span> Graph Overview
-      </button>
-      <button
-        className={`v10-layer-switch-btn ${active === 'query' ? 'active' : ''}`}
-        data-layer="query"
-        onClick={() => onSwitch('query')}
-      >
-        <span className="v10-layer-switch-icon">⟐</span> Query
-      </button>
+      <span className="v10-layer-switch-separator" aria-hidden="true" />
       <button
         className={`v10-layer-switch-btn ${active === 'wm' ? 'active' : ''}`}
         data-layer="wm"
-        onClick={() => onSwitch('wm')}
+        aria-label="Working Memory"
+        title="Working Memory"
+        onClick={() => switchTo('wm')}
       >
-        <span className="v10-layer-switch-icon" style={{ color: '#64748b' }}>◇</span> Working Memory
+        <span className="v10-layer-switch-icon" style={{ color: '#64748b' }}>◇</span>
+        <span className="v10-layer-switch-label v10-layer-switch-label-full">Working Memory</span>
+        <span className="v10-layer-switch-label v10-layer-switch-label-compact">WM</span>
         {counts.wm > 0 && <span className="v10-layer-switch-count">{counts.wm}</span>}
       </button>
       <button
         className={`v10-layer-switch-btn ${active === 'swm' ? 'active' : ''}`}
         data-layer="swm"
-        onClick={() => onSwitch('swm')}
+        aria-label="Shared Working Memory"
+        title="Shared Working Memory"
+        onClick={() => switchTo('swm')}
       >
-        <span className="v10-layer-switch-icon" style={{ color: '#f59e0b' }}>◈</span> Shared Memory
+        <span className="v10-layer-switch-icon" style={{ color: '#f59e0b' }}>◈</span>
+        <span className="v10-layer-switch-label v10-layer-switch-label-full">Shared Working Memory</span>
+        <span className="v10-layer-switch-label v10-layer-switch-label-compact">SWM</span>
         {counts.swm > 0 && <span className="v10-layer-switch-count">{counts.swm}</span>}
       </button>
       <button
         className={`v10-layer-switch-btn ${active === 'vm' ? 'active' : ''}`}
         data-layer="vm"
-        onClick={() => onSwitch('vm')}
+        aria-label="Verifiable Memory"
+        title="Verifiable Memory"
+        onClick={() => switchTo('vm')}
       >
-        <span className="v10-layer-switch-icon" style={{ color: '#22c55e' }}>◉</span> Verified Memory
+        <span className="v10-layer-switch-icon" style={{ color: '#22c55e' }}>◉</span>
+        <span className="v10-layer-switch-label v10-layer-switch-label-full">Verifiable Memory</span>
+        <span className="v10-layer-switch-label v10-layer-switch-label-compact">VM</span>
         {counts.vm > 0 && <span className="v10-layer-switch-count">{counts.vm}</span>}
       </button>
+      <span className="v10-layer-switch-separator" aria-hidden="true" />
+      <button
+        className={`v10-layer-switch-btn ${active === 'graph-overview' ? 'active' : ''}`}
+        data-layer="graph-overview"
+        aria-label="Subgraphs"
+        title="Subgraphs"
+        onClick={() => switchTo('graph-overview')}
+      >
+        <span className="v10-layer-switch-icon">⌬</span>
+        <span className="v10-layer-switch-label">Subgraphs</span>
+      </button>
+      <div
+        className="v10-layer-more"
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+            setMoreOpen(false);
+          }
+        }}
+      >
+        <button
+          type="button"
+          className={`v10-layer-switch-btn v10-layer-more-btn ${active === 'query' ? 'active' : ''}`}
+          data-layer="query"
+          aria-haspopup="menu"
+          aria-expanded={moreOpen}
+          aria-label="More Context Graph views"
+          title="More Context Graph views"
+          onClick={() => setMoreOpen(open => !open)}
+        >
+          <span className="v10-layer-switch-icon">⋯</span>
+          <span className="v10-layer-switch-label">More</span>
+        </button>
+        {moreOpen && (
+          <div className="v10-layer-more-menu" role="menu">
+            <button
+              type="button"
+              role="menuitem"
+              className={`v10-layer-more-item ${active === 'query' ? 'active' : ''}`}
+              onClick={() => switchTo('query')}
+            >
+              <span className="v10-layer-switch-icon">⟐</span>
+              Query Catalogue
+            </button>
+          </div>
+        )}
+      </div>
       <div className="v10-layer-switcher-spacer" />
       <div className="v10-layer-switcher-actions">
-        <button className="v10-layer-action-btn" onClick={onShare}>⤴ Share</button>
-        <button className="v10-layer-action-btn" onClick={onImport}>↑ Import</button>
-        <button className="v10-layer-action-btn" onClick={onRefresh}>↻</button>
+        <button className="v10-layer-action-btn" onClick={onShare} aria-label="Share Context Graph">
+          <span className="v10-layer-action-icon">⤴</span>
+          <span className="v10-layer-action-label">Share</span>
+        </button>
+        <button className="v10-layer-action-btn" onClick={onImport} aria-label="Import into Context Graph">
+          <span className="v10-layer-action-icon">↑</span>
+          <span className="v10-layer-action-label">Import</span>
+        </button>
+        <button className="v10-layer-action-btn" onClick={onRefresh} aria-label="Refresh Context Graph data">
+          <span className="v10-layer-action-icon">↻</span>
+        </button>
       </div>
     </div>
   );
@@ -198,39 +261,186 @@ export function ProjectHeaderStrip({
 
 // ─── Project Overview Card ───────────────────────────────────
 
-export function ProjectOverviewCard({ cg, memory, participants }: {
+type OverviewRoleState = {
+  label: string;
+  title: string;
+  tone: 'curator' | 'participant' | 'viewer' | 'unknown';
+};
+
+function overviewRoleState(cg: any, currentAgent: Pick<AgentIdentity, 'agentDid'> | null): OverviewRoleState {
+  const curator = typeof cg?.curator === 'string' ? cg.curator.trim() : '';
+  const agentDid = currentAgent?.agentDid?.trim() ?? '';
+  if (curator && agentDid && canonicalAgentDid(curator) === canonicalAgentDid(agentDid)) {
+    return {
+      label: 'Curator',
+      title: 'This agent is the curator for this Context Graph.',
+      tone: 'curator',
+    };
+  }
+  if (cg?.callerInvolved === true && agentDid && curator) {
+    return {
+      label: 'Participant',
+      title: 'This agent is listed as a participant in this Context Graph.',
+      tone: 'participant',
+    };
+  }
+  if (cg?.callerInvolved === false) {
+    return {
+      label: 'Not joined',
+      title: 'This agent is not listed as curator or participant for this Context Graph.',
+      tone: 'viewer',
+    };
+  }
+  return {
+    label: 'Role unknown',
+    title: 'The node did not provide enough role metadata for this Context Graph.',
+    tone: 'unknown',
+  };
+}
+
+function overviewAccessState(raw?: string): { label: string; title: string; tone: 'public' | 'curated' | 'unknown' } {
+  const policy = normalizeAccessPolicy(raw);
+  if (policy === 'public') {
+    return {
+      label: 'Public',
+      title: 'Public Context Graph.',
+      tone: 'public',
+    };
+  }
+  if (policy === 'private') {
+    return {
+      label: 'Curated',
+      title: 'Curated Context Graph with access controlled by the curator.',
+      tone: 'curated',
+    };
+  }
+  return {
+    label: 'Access unknown',
+    title: 'The node did not provide an access policy for this Context Graph.',
+    tone: 'unknown',
+  };
+}
+
+export function ProjectOverviewCard({
+  cg,
+  memory,
+  participants,
+  currentAgent,
+  onSwitchLayer,
+  onOpenPrimer,
+}: {
   cg: any;
   memory: ReturnType<typeof useMemoryEntities>;
   participants: string[];
+  currentAgent?: Pick<AgentIdentity, 'agentDid'> | null;
+  onSwitchLayer?: (layer: LayerView) => void;
+  onOpenPrimer?: () => void;
 }) {
   const { wm: working, swm: shared, vm: verified } = memory.counts;
   const layerSum = working + shared + verified;
-  const pctVm = layerSum > 0 ? Math.round((verified / layerSum) * 100) : 0;
-  const pctSwm = layerSum > 0 ? Math.round((shared / layerSum) * 100) : 0;
-  const pctWm = layerSum > 0 ? Math.max(0, 100 - pctVm - pctSwm) : 0;
+  const role = overviewRoleState(cg, currentAgent ?? null);
+  const access = overviewAccessState(cg?.accessPolicy);
+  const statusHint = memory.loading
+    ? 'Loading memory layers...'
+    : memory.partial
+      ? 'One or more layer counts are currently a lower bound.'
+      : memory.error
+        ? 'Live memory counts are unavailable.'
+        : 'Canonical current-layer entity counts.';
+  const pipeline = [
+    {
+      key: 'wm' as const,
+      label: 'Working Memory',
+      desc: 'Private staging area',
+      count: working,
+      color: '#64748b',
+    },
+    {
+      key: 'swm' as const,
+      label: 'Shared Working Memory',
+      desc: 'Collaborative review',
+      count: shared,
+      color: '#f59e0b',
+    },
+    {
+      key: 'vm' as const,
+      label: 'Verifiable Memory',
+      desc: 'Published on-chain',
+      count: verified,
+      color: '#22c55e',
+    },
+  ];
 
   return (
     <div className="v10-po">
       <div className="v10-po-top">
         <span className="v10-po-dot" />
-        <div>
+        <div className="v10-po-heading">
           <div className="v10-po-title">{cg.name || cg.id}</div>
           {cg.description && <div className="v10-po-desc">{cg.description}</div>}
+        </div>
+        <div className="v10-po-badges">
+          <span className={`v10-po-badge ${role.tone}`} title={role.title}>{role.label}</span>
+          <span className={`v10-po-badge ${access.tone}`} title={access.title}>{access.label}</span>
         </div>
       </div>
       <StatStrip
         className="v10-po-stat-strip"
         items={[
-          { id: 'total', value: layerSum, label: 'Entities total' },
-          { id: 'wm', value: working, label: 'in Working' },
-          { id: 'swm', value: shared, label: 'in Shared' },
-          { id: 'vm', value: verified, label: 'in Verified' },
-          { id: 'participants', value: participants.length, label: 'participants' },
+          { id: 'total', value: layerSum.toLocaleString(), label: 'Total entities', hint: statusHint },
+          { id: 'participants', value: participants.length.toLocaleString(), label: 'Allowlisted agents' },
         ]}
       />
+      <div className="v10-po-pipeline" aria-label="Knowledge Pipeline">
+        <div className="v10-po-pipeline-head">
+          <div>
+            <div className="v10-po-section-title">Knowledge Pipeline</div>
+            <div className="v10-po-section-desc">Entities move from private staging to shared review and, when published, become Knowledge Assets.</div>
+          </div>
+          {onOpenPrimer && (
+            <button type="button" className="v10-po-primer-link" onClick={onOpenPrimer}>
+              What is a Context Graph?
+            </button>
+          )}
+        </div>
+        <div className="v10-po-pipeline-track" aria-hidden="true">
+          {layerSum > 0
+            ? pipeline.map(item => {
+              const width = item.count > 0 ? (item.count / layerSum) * 100 : 0;
+              return (
+                <span
+                  key={item.key}
+                  className={`v10-po-pipeline-seg ${item.key}`}
+                  style={{ width: `${width}%`, background: item.color }}
+                />
+              );
+            })
+            : <span className="v10-po-pipeline-empty" />}
+        </div>
+        <div className="v10-po-pipeline-steps">
+          {pipeline.map((item, index) => (
+            <button
+              key={item.key}
+              type="button"
+              className={`v10-po-pipeline-step ${item.key}`}
+              onClick={() => onSwitchLayer?.(item.key)}
+              style={{ '--po-layer-color': item.color } as React.CSSProperties}
+            >
+              <span className="v10-po-pipeline-step-index">{index + 1}</span>
+              <span className="v10-po-pipeline-step-copy">
+                <span className="v10-po-pipeline-step-label">{item.label}</span>
+                <span className="v10-po-pipeline-step-desc">{item.desc}</span>
+              </span>
+              <span className="v10-po-pipeline-step-count">
+                {item.count.toLocaleString()} {layerNoun(item.key, item.count)}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
       {participants.length > 0 && (
         <div className="v10-po-participants">
-          <div className="v10-po-participants-label">Participants</div>
+          <div className="v10-po-participants-label">Allowlisted participants</div>
           <div className="v10-po-participants-list">
             {participants.map(addr => (
               <span key={addr} className="v10-po-participant" title={addr}>
@@ -238,24 +448,6 @@ export function ProjectOverviewCard({ cg, memory, participants }: {
                 {addr.slice(0, 6)}…{addr.slice(-4)}
               </span>
             ))}
-          </div>
-        </div>
-      )}
-      {layerSum > 0 && (
-        <div className="v10-po-progress">
-          <div className="v10-po-progress-label">
-            <span>Knowledge Progress</span>
-            <span style={{ color: 'var(--text-success)', fontWeight: 600 }}>{pctVm}% verified</span>
-          </div>
-          <div className="v10-po-progress-bar">
-            {pctVm > 0 && <div className="v10-po-progress-seg vm" style={{ width: `${pctVm}%` }} />}
-            {pctSwm > 0 && <div className="v10-po-progress-seg swm" style={{ width: `${pctSwm}%` }} />}
-            {pctWm > 0 && <div className="v10-po-progress-seg wm" style={{ width: `${pctWm}%` }} />}
-          </div>
-          <div className="v10-po-progress-legend">
-            <span className="v10-po-legend-item"><span className="v10-po-legend-dot" style={{ background: '#22c55e' }} />Verified ({verified})</span>
-            <span className="v10-po-legend-item"><span className="v10-po-legend-dot" style={{ background: '#f59e0b' }} />Shared ({shared})</span>
-            <span className="v10-po-legend-item"><span className="v10-po-legend-dot" style={{ background: '#64748b' }} />Working ({working})</span>
           </div>
         </div>
       )}
@@ -471,7 +663,7 @@ export function SwmAttributionLegend({ palette, conflicts }: { palette: AgentPal
   );
 }
 
-// ─── Verified Memory graph legend (floating overlay) ─────────
+// ─── Verifiable Memory graph legend (floating overlay) ─────────
 // Lives in the top-right of the VM graph view. Explains the two new glyphs
 // (gold anchor, lavender agent) introduced by `useVerifiedMemoryAnchors`
 // so viewers can decode the graph at a glance. Also doubles as an anchor
@@ -494,7 +686,7 @@ export function VerifiedGraphLegend({ anchors }: { anchors: PublishAnchor[] }) {
   })();
 
   return (
-    <div className="v10-vm-legend" aria-label="Verified Memory legend">
+    <div className="v10-vm-legend" aria-label="Verifiable Memory legend">
       <div className="v10-vm-legend-row v10-vm-legend-head">
         <span>VM provenance layer</span>
         <span className="v10-vm-legend-count">{anchors.length} anchor{anchors.length === 1 ? '' : 's'}</span>
@@ -597,8 +789,8 @@ export function MemoryStrip({
     viewLayer: LayerView;
   }> = [
     { key: 'wm', label: 'Working Memory', color: '#64748b', icon: '◇', entities: layerEntities.wm, count: memory.counts.wm, promoteLabel: 'Promote All → Shared', viewLayer: 'wm' },
-    { key: 'swm', label: 'Shared Working Memory', color: '#f59e0b', icon: '◈', entities: layerEntities.swm, count: memory.counts.swm, promoteLabel: 'Publish to Verified Memory', viewLayer: 'swm' },
-    { key: 'vm', label: 'Verified Memory', color: '#22c55e', icon: '◉', entities: layerEntities.vm, count: memory.counts.vm, promoteLabel: null, viewLayer: 'vm' },
+    { key: 'swm', label: 'Shared Working Memory', color: '#f59e0b', icon: '◈', entities: layerEntities.swm, count: memory.counts.swm, promoteLabel: 'Publish to Verifiable Memory', viewLayer: 'swm' },
+    { key: 'vm', label: 'Verifiable Memory', color: '#22c55e', icon: '◉', entities: layerEntities.vm, count: memory.counts.vm, promoteLabel: null, viewLayer: 'vm' },
   ];
 
   return (
@@ -837,7 +1029,7 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
         setResult(`Promoted ${promoted} triple${promoted !== 1 ? 's' : ''} to Shared Memory`);
       } else {
         await publishSharedMemory(contextGraphId);
-        setResult('Published to Verified Memory');
+        setResult('Published to Verifiable Memory');
       }
       onComplete?.();
     } catch (err: any) {
@@ -849,13 +1041,13 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
 
   if (count === 0) return null;
   const color = isWm ? '#f59e0b' : '#22c55e';
-  const target = isWm ? 'Shared Working Memory' : 'Verified Memory';
+  const target = isWm ? 'Shared Working Memory' : 'Verifiable Memory';
   const noun = layerNoun(layer, count).toLowerCase();
 
   return (
     <GenWidget title={isWm ? 'Promote' : 'Publish'} footnote={`Moves ${noun} from this layer to ${target}.`}>
       <div className="v10-decision-context" style={{ marginBottom: 10 }}>
-        {count} {noun} in this layer can be {isWm ? 'promoted to Shared Working Memory for collaborative review' : 'published to Verified Memory on-chain'}.
+        {count} {noun} in this layer can be {isWm ? 'promoted to Shared Working Memory for collaborative review' : 'published to Verifiable Memory on-chain'}.
       </div>
       {result && <div style={{ fontSize: 11, color: 'var(--text-success)', marginBottom: 8 }}>✓ {result}</div>}
       {error && <div style={{ fontSize: 11, color: 'var(--text-danger)', marginBottom: 8 }}>✕ {error}</div>}
@@ -868,7 +1060,7 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
           disabled={busy}
           onClick={handleAction}
         >
-          {busy ? '...' : (isWm ? '✓ Promote All → Shared' : '◉ Publish to Verified Memory')}
+          {busy ? '...' : (isWm ? '✓ Promote All → Shared' : '◉ Publish to Verifiable Memory')}
         </button>
       </div>
     </GenWidget>
@@ -1116,7 +1308,7 @@ export function LayerContent({
                 compact
                 tone="vm"
                 icon={LAYER_CONFIG.vm.icon}
-                title="Loading Verified Memory..."
+                title="Loading Verifiable Memory..."
                 description="Knowledge Assets are being read from the verified layer."
               />
             </div>
@@ -1126,7 +1318,7 @@ export function LayerContent({
                 compact
                 tone="vm"
                 icon={LAYER_CONFIG.vm.icon}
-                title="Verified Memory status unavailable."
+                title="Verifiable Memory status unavailable."
                 description="This node could not read the verified layer right now."
               />
             </div>
@@ -1187,7 +1379,7 @@ export function LayerContent({
   );
 }
 
-// ─── Verified Memory Hero Banner ──────────────────────────────
+// ─── Verifiable Memory Hero Banner ──────────────────────────────
 // Sits at the top of the VM tab's "Knowledge Assets" view. Pulls together
 // the DKG "secret sauce" into a compact visual: anchoring, consensus,
 // agent identity — the verifiability elements that justify the VM's cost.
@@ -1205,7 +1397,7 @@ export function VerifiedMemoryHeroBanner({ entities, tripleCount, contextGraphId
     return (
       <div className="v10-vm-hero v10-vm-hero-empty">
         <div className="v10-vm-hero-title">
-          <span className="v10-vm-hero-badge">◉ Verified Memory</span>
+          <span className="v10-vm-hero-badge">◉ Verifiable Memory</span>
           <div className="v10-vm-hero-heading">
             <span className="v10-vm-hero-headline">Nothing published yet</span>
             <span className="v10-vm-hero-context" title={contextGraphId}>
@@ -1228,7 +1420,7 @@ export function VerifiedMemoryHeroBanner({ entities, tripleCount, contextGraphId
   return (
     <div className="v10-vm-hero">
       <div className="v10-vm-hero-title">
-        <span className="v10-vm-hero-badge">◉ Verified Memory</span>
+        <span className="v10-vm-hero-badge">◉ Verifiable Memory</span>
         <div className="v10-vm-hero-heading">
           <span className="v10-vm-hero-headline">On-chain anchored · cryptographically signed</span>
           <span className="v10-vm-hero-context" title={contextGraphId}>
@@ -1784,7 +1976,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
         setResult(`Promoted ${res.promotedCount} triples to Shared Memory`);
       } else {
         await publishSharedMemory(contextGraphId);
-        setResult('Published to Verified Memory');
+        setResult('Published to Verifiable Memory');
       }
       refresh();
       onComplete();
@@ -1810,7 +2002,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
         setResult(`Promoted ${total} triples across ${assertions.length} assertion${assertions.length !== 1 ? 's' : ''}`);
       } else {
         await publishSharedMemory(contextGraphId);
-        setResult('Published all to Verified Memory');
+        setResult('Published all to Verifiable Memory');
       }
       refresh();
       onComplete();
@@ -1854,7 +2046,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
   }
 
   const actionLabel = layer === 'wm' ? 'Promote → Shared' : 'Publish to VM';
-  const actionAllLabel = layer === 'wm' ? 'Promote All → Shared' : 'Publish all to Verified Memory';
+  const actionAllLabel = layer === 'wm' ? 'Promote All → Shared' : 'Publish all to Verifiable Memory';
 
   return (
     <div style={scrollRootStyle} data-cg-scroll-key={scrollKey}>
@@ -2280,7 +2472,7 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
   const authorUri = entityAuthorUri(entity);
   const author = authorUri ? agents?.get(authorUri) ?? null : null;
   const layerBadge = entity.trustLevel === 'verified' ? 'vm' : entity.trustLevel === 'shared' ? 'swm' : 'wm';
-  const layerLabel = entity.trustLevel === 'verified' ? 'Verified Memory' : entity.trustLevel === 'shared' ? 'Shared Working Memory' : 'Working Memory';
+  const layerLabel = entity.trustLevel === 'verified' ? 'Verifiable Memory' : entity.trustLevel === 'shared' ? 'Shared Working Memory' : 'Working Memory';
   const detailNoun = layerNoun(entity.trustLevel, 1);
 
   const incoming = useMemo(() => {
@@ -2566,7 +2758,7 @@ export function ProvenanceTrail({ entity }: { entity: MemoryEntity }) {
       {entity.trustLevel === 'verified' && (
         <TrailEvent
           toneClass="verified"
-          title="Published to Verified Memory"
+          title="Published to Verifiable Memory"
           actionWord="Published"
           agent={published.agent}
           agentUri={published.uri}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -280,8 +280,8 @@ function overviewRoleState(cg: any, currentAgent: Pick<AgentIdentity, 'agentDid'
   }
   if (cg?.callerInvolved === true) {
     return {
-      label: 'Participant',
-      title: 'This agent is listed as a member of this Context Graph.',
+      label: 'Joined',
+      title: 'This agent is involved in this Context Graph; curator status is shown only when identity metadata confirms it.',
       tone: 'participant',
     };
   }

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -277,10 +277,10 @@ function overviewRoleState(cg: any, currentAgent: Pick<AgentIdentity, 'agentDid'
       tone: 'curator',
     };
   }
-  if (cg?.callerInvolved === true && agentDid && curator) {
+  if (cg?.callerInvolved === true) {
     return {
       label: 'Participant',
-      title: 'This agent is listed as a participant in this Context Graph.',
+      title: 'This agent is listed as a member of this Context Graph.',
       tone: 'participant',
     };
   }
@@ -295,6 +295,34 @@ function overviewRoleState(cg: any, currentAgent: Pick<AgentIdentity, 'agentDid'
     label: 'Role unknown',
     title: 'The node did not provide enough role metadata for this Context Graph.',
     tone: 'unknown',
+  };
+}
+
+function overviewAccessAgentStat(cg: any, participants: string[]) {
+  const policy = normalizeAccessPolicy(cg?.accessPolicy);
+  if (policy === 'public') {
+    return {
+      id: 'participants',
+      value: 'Open',
+      label: 'Public access',
+      hint: 'Public Context Graphs do not have an authoritative allowlist count.',
+    };
+  }
+
+  const agents = new Set(
+    participants
+      .map(agent => agent.trim())
+      .filter(Boolean)
+      .map(canonicalAgentDid),
+  );
+  const curator = typeof cg?.curator === 'string' ? cg.curator.trim() : '';
+  if (curator) agents.add(canonicalAgentDid(curator));
+
+  return {
+    id: 'participants',
+    value: agents.size.toLocaleString(),
+    label: 'Agents with access',
+    hint: 'Includes the curator plus allowlisted participants reported by the node.',
   };
 }
 
@@ -340,6 +368,7 @@ export function ProjectOverviewCard({
   const layerSum = working + shared + verified;
   const role = overviewRoleState(cg, currentAgent ?? null);
   const access = overviewAccessState(cg?.accessPolicy);
+  const accessAgentStat = overviewAccessAgentStat(cg, participants);
   const statusHint = memory.loading
     ? 'Loading memory layers...'
     : memory.partial
@@ -388,14 +417,14 @@ export function ProjectOverviewCard({
         className="v10-po-stat-strip"
         items={[
           { id: 'total', value: layerSum.toLocaleString(), label: 'Total entities', hint: statusHint },
-          { id: 'participants', value: participants.length.toLocaleString(), label: 'Allowlisted agents' },
+          accessAgentStat,
         ]}
       />
       <div className="v10-po-pipeline" aria-label="Knowledge Pipeline">
         <div className="v10-po-pipeline-head">
           <div>
             <div className="v10-po-section-title">Knowledge Pipeline</div>
-            <div className="v10-po-section-desc">Entities move from private staging to shared review and, when published, become Knowledge Assets.</div>
+            <div className="v10-po-section-desc">Entities move from private staging to shared review; published assertion bundles become Knowledge Assets with on-chain provenance.</div>
           </div>
           {onOpenPrimer && (
             <button type="button" className="v10-po-primer-link" onClick={onOpenPrimer}>

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback, useEffect, lazy, Suspense } from 'react';
+import React, { useMemo, useState, useCallback, useEffect, useRef, lazy, Suspense } from 'react';
 import type { ReactNode } from 'react';
 import { useFetch } from '../../hooks.js';
 import { api } from '../../api-wrapper.js';
@@ -73,10 +73,22 @@ export function LayerSwitcher({ active, counts, onSwitch, onShare, onImport, onR
   onRefresh: () => void;
 }) {
   const [moreOpen, setMoreOpen] = useState(false);
+  const moreRef = useRef<HTMLDivElement | null>(null);
   const switchTo = (layer: LayerView) => {
     setMoreOpen(false);
     onSwitch(layer);
   };
+
+  useEffect(() => {
+    if (!moreOpen) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (target && moreRef.current?.contains(target)) return;
+      setMoreOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [moreOpen]);
 
   return (
     <div className="v10-layer-switcher">
@@ -139,6 +151,7 @@ export function LayerSwitcher({ active, counts, onSwitch, onShare, onImport, onR
         <span className="v10-layer-switch-label">Subgraphs</span>
       </button>
       <div
+        ref={moreRef}
         className="v10-layer-more"
         onBlur={(event) => {
           if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -163,7 +163,7 @@ export const LAYER_CONFIG: Record<'wm' | 'swm' | 'vm', {
   vm: {
     icon: '◉',
     color: '#22c55e',
-    title: 'Verified Memory',
+    title: 'Verifiable Memory',
     desc: 'Endorsed, published, on-chain knowledge',
     trustLabel: 'Verified',
     trustLevel: 'verified',
@@ -227,7 +227,7 @@ export function buildLayerGraphOptions(
   nodeColors?: Record<string, string>,
 ) {
   const { color } = LAYER_CONFIG[layer];
-  // VM ("Verified Memory") is the DKG hero view — we deliberately juice it:
+  // VM ("Verifiable Memory") is the DKG hero view — we deliberately juice it:
   // thicker & brighter edges, bigger hub/leaf spread, higher gradient so every
   // node reads as a "trust gem". WM/SWM stay quieter so VM clearly wins the
   // eye. This is the visual equivalent of "this knowledge is anchored on-chain".

--- a/packages/node-ui/test/app-primer-route.test.ts
+++ b/packages/node-ui/test/app-primer-route.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTabsStore } from '../src/ui/stores/tabs.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../src/ui/api-wrapper.js', () => ({
+  api: {
+    fetchStatus: vi.fn(async () => ({ synced: true, peers: 0 })),
+  },
+}));
+
+vi.mock('../src/ui/api.js', () => ({
+  authHeaders: () => ({}),
+  fileUrl: () => '',
+}));
+
+vi.mock('../src/ui/components/Shell/Header.js', () => ({
+  Header: () => React.createElement('header', { 'data-testid': 'header' }),
+}));
+
+vi.mock('../src/ui/components/Shell/PanelLeft.js', () => ({
+  PanelLeft: () => React.createElement('aside', { 'data-testid': 'left-panel' }),
+}));
+
+vi.mock('../src/ui/components/Shell/PanelBottom.js', () => ({
+  PanelBottom: () => React.createElement('footer', { 'data-testid': 'bottom-panel' }),
+}));
+
+vi.mock('../src/ui/components/Shell/PanelRight.js', () => ({
+  PanelRight: () => React.createElement('aside', { 'data-testid': 'right-panel' }),
+}));
+
+vi.mock('../src/ui/views/DashboardView.js', () => ({
+  DashboardView: () => {
+    throw new Error('Dashboard should not mount before primer route activation');
+  },
+}));
+
+vi.mock('../src/ui/views/ProjectView.js', () => ({
+  ProjectView: () => React.createElement('div', { 'data-testid': 'project-view' }),
+}));
+
+vi.mock('../src/ui/views/MemoryLayerView.js', () => ({
+  MemoryLayerView: () => React.createElement('div', { 'data-testid': 'memory-layer-view' }),
+}));
+
+vi.mock('../src/ui/views/MemoryStackView.js', () => ({
+  MemoryStackView: () => React.createElement('div', { 'data-testid': 'memory-stack-view' }),
+}));
+
+vi.mock('../src/ui/views/ContextGraphPrimerView.js', () => ({
+  ContextGraphPrimerView: () => React.createElement('div', { 'data-testid': 'primer-view' }, 'Primer'),
+}));
+
+const { App } = await import('../src/ui/App.js');
+
+describe('Context Graph primer route', () => {
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>';
+    useTabsStore.setState({
+      tabs: [{ id: 'dashboard', label: 'Dashboard', closable: false }],
+      activeTabId: 'dashboard',
+    });
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root!.unmount();
+      });
+    }
+    root = null;
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  it('activates the primer tab before the shell renders the dashboard', async () => {
+    const container = document.getElementById('root');
+    if (!container) throw new Error('Missing root');
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(
+          MemoryRouter,
+          { initialEntries: ['/context-graph-primer'] },
+          React.createElement(App),
+        ),
+      );
+    });
+
+    expect(document.querySelector('[data-testid="primer-view"]')).toBeTruthy();
+    expect(useTabsStore.getState().activeTabId).toBe('context-graph-primer');
+    expect(useTabsStore.getState().tabs.some(tab => tab.id === 'context-graph-primer')).toBe(true);
+  });
+});

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LayerSwitcher, ProjectOverviewCard } from '../src/ui/views/project/components.js';
+import { ContextGraphPrimerView } from '../src/ui/views/ContextGraphPrimerView.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const baseMemory = {
+  entities: new Map(),
+  entityList: [],
+  allTriples: [],
+  graphTriples: [],
+  trustMap: new Map(),
+  counts: { wm: 4, swm: 2, vm: 1, total: 7 },
+  loading: false,
+  error: null,
+  partial: false,
+  layerStatus: { wm: 'ok', swm: 'ok', vm: 'ok' },
+  refresh: vi.fn(),
+} as any;
+
+async function render(element: React.ReactElement): Promise<{ container: HTMLDivElement; root: Root }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(element);
+  });
+  return { container, root };
+}
+
+describe('Context Graph IA and Overview', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  it('orders and labels the Context Graph view switcher according to the pipeline IA', async () => {
+    const onSwitch = vi.fn();
+    const { container, root } = await render(
+      React.createElement(LayerSwitcher, {
+        active: 'overview',
+        counts: baseMemory.counts,
+        onSwitch,
+        onShare: vi.fn(),
+        onImport: vi.fn(),
+        onRefresh: vi.fn(),
+      }),
+    );
+
+    const topLevelLabels = Array.from(container.querySelectorAll('.v10-layer-switcher > button, .v10-layer-more > button'))
+      .map(button => button.getAttribute('aria-label'));
+
+    expect(topLevelLabels).toEqual([
+      'Overview',
+      'Working Memory',
+      'Shared Working Memory',
+      'Verifiable Memory',
+      'Subgraphs',
+      'More Context Graph views',
+    ]);
+    expect(container.textContent).not.toContain('Graph Overview');
+    expect(container.textContent).not.toContain('Shared Memory4');
+    expect(container.textContent).not.toContain('Verified Memory');
+
+    const more = container.querySelector<HTMLButtonElement>('.v10-layer-more-btn');
+    expect(more).toBeTruthy();
+    await act(async () => {
+      more!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('Query Catalogue');
+    const query = container.querySelector<HTMLButtonElement>('.v10-layer-more-item');
+    await act(async () => {
+      query!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onSwitch).toHaveBeenCalledWith('query');
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders Overview as a summary with one clickable Knowledge Pipeline', async () => {
+    const onSwitchLayer = vi.fn();
+    const onOpenPrimer = vi.fn();
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-test',
+          name: 'UI Rework',
+          description: 'Context Graph UI test',
+          accessPolicy: 'private',
+          curator: 'did:dkg:agent:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+          callerInvolved: true,
+        },
+        memory: baseMemory,
+        participants: ['0x1234567890abcdef', '0xabcdef1234567890'],
+        currentAgent: { agentDid: 'did:dkg:agent:0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD' },
+        onSwitchLayer,
+        onOpenPrimer,
+      }),
+    );
+
+    expect(container.textContent).toContain('Curator');
+    expect(container.textContent).toContain('Curated');
+    expect(container.textContent).toContain('Knowledge Pipeline');
+    expect(container.querySelector('.v10-memory-strip')).toBeNull();
+    expect(container.querySelectorAll('.v10-po-pipeline-step')).toHaveLength(3);
+
+    const labels = Array.from(container.querySelectorAll('.v10-po-pipeline-step-label'))
+      .map(node => node.textContent);
+    expect(labels).toEqual(['Working Memory', 'Shared Working Memory', 'Verifiable Memory']);
+
+    const steps = Array.from(container.querySelectorAll<HTMLButtonElement>('.v10-po-pipeline-step'));
+    for (const step of steps) {
+      await act(async () => {
+        step.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    }
+    expect(onSwitchLayer.mock.calls.map(call => call[0])).toEqual(['wm', 'swm', 'vm']);
+
+    const primer = container.querySelector<HTMLButtonElement>('.v10-po-primer-link');
+    await act(async () => {
+      primer!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onOpenPrimer).toHaveBeenCalledTimes(1);
+
+    await act(async () => root.unmount());
+  });
+
+  it('keeps Overview role/access badges honest when metadata is incomplete', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-public', name: 'Public Graph', accessPolicy: 'public' },
+        memory: baseMemory,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    expect(container.textContent).toContain('Role unknown');
+    expect(container.textContent).toContain('Public');
+
+    await act(async () => root.unmount());
+  });
+
+  it('does not downgrade an unresolved curator role to participant before identity is available', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-member',
+          name: 'Member Graph',
+          accessPolicy: 'private',
+          curator: 'did:dkg:agent:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+          callerInvolved: true,
+        },
+        memory: baseMemory,
+        participants: [],
+        currentAgent: null,
+      }),
+    );
+
+    expect(container.textContent).toContain('Role unknown');
+    expect(container.textContent).not.toContain('Participant');
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders the linked Context Graph primer with the required concepts', async () => {
+    const { container, root } = await render(React.createElement(ContextGraphPrimerView));
+
+    for (const text of [
+      'What is a Context Graph?',
+      'Memory layers',
+      'Subgraphs',
+      'Entities and Knowledge Assets',
+      'Assertions',
+      'Roles',
+      'Working Memory',
+      'Shared Working Memory',
+      'Verifiable Memory',
+    ]) {
+      expect(container.textContent).toContain(text);
+    }
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -152,7 +152,7 @@ describe('Context Graph IA and Overview', () => {
     await act(async () => root.unmount());
   });
 
-  it('uses caller involvement as the joined-role fallback when curator identity is unresolved', async () => {
+  it('keeps curator-owned membership role neutral while current-agent identity is loading', async () => {
     const { container, root } = await render(
       React.createElement(ProjectOverviewCard, {
         cg: {
@@ -165,6 +165,52 @@ describe('Context Graph IA and Overview', () => {
         memory: baseMemory,
         participants: [],
         currentAgent: null,
+        currentAgentStatus: 'loading',
+      }),
+    );
+
+    expect(container.textContent).toContain('Role checking');
+    expect(container.textContent).not.toContain('Joined');
+
+    await act(async () => root.unmount());
+  });
+
+  it('does not show joined for curator-owned graphs when current-agent lookup fails', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-member-error',
+          name: 'Member Graph',
+          accessPolicy: 'private',
+          curator: 'did:dkg:agent:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+          callerInvolved: true,
+        },
+        memory: baseMemory,
+        participants: [],
+        currentAgent: null,
+        currentAgentStatus: 'error',
+      }),
+    );
+
+    expect(container.textContent).toContain('Role unknown');
+    expect(container.textContent).not.toContain('Joined');
+
+    await act(async () => root.unmount());
+  });
+
+  it('uses caller involvement as the joined-role fallback when curator metadata is absent', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-member-no-curator',
+          name: 'Member Graph',
+          accessPolicy: 'private',
+          callerInvolved: true,
+        },
+        memory: baseMemory,
+        participants: [],
+        currentAgent: null,
+        currentAgentStatus: 'ok',
       }),
     );
 

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -185,9 +185,12 @@ describe('Context Graph IA and Overview', () => {
       'Working Memory',
       'Shared Working Memory',
       'Verifiable Memory',
+      'assertion/triple bundle is anchored as a Knowledge Asset',
+      'included entities on-chain provenance',
     ]) {
       expect(container.textContent).toContain(text);
     }
+    expect(container.textContent).not.toContain('entity is published to Verifiable Memory, it becomes a Knowledge Asset');
 
     await act(async () => root.unmount());
   });

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -86,6 +86,32 @@ describe('Context Graph IA and Overview', () => {
     await act(async () => root.unmount());
   });
 
+  it('closes the More menu on outside pointer input', async () => {
+    const { container, root } = await render(
+      React.createElement(LayerSwitcher, {
+        active: 'overview',
+        counts: baseMemory.counts,
+        onSwitch: vi.fn(),
+        onShare: vi.fn(),
+        onImport: vi.fn(),
+        onRefresh: vi.fn(),
+      }),
+    );
+
+    const more = container.querySelector<HTMLButtonElement>('.v10-layer-more-btn');
+    await act(async () => {
+      more!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.textContent).toContain('Query Catalogue');
+
+    await act(async () => {
+      document.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    });
+    expect(container.textContent).not.toContain('Query Catalogue');
+
+    await act(async () => root.unmount());
+  });
+
   it('renders Overview as a summary with one clickable Knowledge Pipeline', async () => {
     const onSwitchLayer = vi.fn();
     const onOpenPrimer = vi.fn();

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -168,7 +168,7 @@ describe('Context Graph IA and Overview', () => {
       }),
     );
 
-    expect(container.textContent).toContain('Participant');
+    expect(container.textContent).toContain('Joined');
     expect(container.textContent).not.toContain('Role unknown');
 
     await act(async () => root.unmount());

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -109,7 +109,9 @@ describe('Context Graph IA and Overview', () => {
 
     expect(container.textContent).toContain('Curator');
     expect(container.textContent).toContain('Curated');
+    expect(container.textContent).toContain('Agents with access');
     expect(container.textContent).toContain('Knowledge Pipeline');
+    expect(container.textContent).toContain('published assertion bundles become Knowledge Assets');
     expect(container.querySelector('.v10-memory-strip')).toBeNull();
     expect(container.querySelectorAll('.v10-po-pipeline-step')).toHaveLength(3);
 
@@ -150,7 +152,7 @@ describe('Context Graph IA and Overview', () => {
     await act(async () => root.unmount());
   });
 
-  it('does not downgrade an unresolved curator role to participant before identity is available', async () => {
+  it('uses caller involvement as the joined-role fallback when curator identity is unresolved', async () => {
     const { container, root } = await render(
       React.createElement(ProjectOverviewCard, {
         cg: {
@@ -166,8 +168,30 @@ describe('Context Graph IA and Overview', () => {
       }),
     );
 
-    expect(container.textContent).toContain('Role unknown');
-    expect(container.textContent).not.toContain('Participant');
+    expect(container.textContent).toContain('Participant');
+    expect(container.textContent).not.toContain('Role unknown');
+
+    await act(async () => root.unmount());
+  });
+
+  it('summarizes public access without pretending the allowlist is an exact count', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-public-open',
+          name: 'Open Graph',
+          accessPolicy: 'public',
+          callerInvolved: true,
+        },
+        memory: baseMemory,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    expect(container.textContent).toContain('Public access');
+    expect(container.textContent).toContain('Open');
+    expect(container.textContent).not.toContain('Allowlisted agents');
 
     await act(async () => root.unmount());
   });

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -196,6 +196,30 @@ describe('Context Graph IA and Overview', () => {
     await act(async () => root.unmount());
   });
 
+  it('does not turn participant fetch failures into exact access counts', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-private-error',
+          name: 'Private Graph',
+          accessPolicy: 'private',
+          curator: 'did:dkg:agent:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+          callerInvolved: true,
+        },
+        memory: baseMemory,
+        participants: [],
+        participantsStatus: 'error',
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    expect(container.textContent).toContain('Agents with access');
+    expect(container.textContent).toContain('Unavailable');
+    expect(container.textContent).not.toContain('Allowlisted agents');
+
+    await act(async () => root.unmount());
+  });
+
   it('renders the linked Context Graph primer with the required concepts', async () => {
     const { container, root } = await render(React.createElement(ContextGraphPrimerView));
 

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -268,6 +268,27 @@ describe('Context Graph IA and Overview', () => {
     await act(async () => root.unmount());
   });
 
+  it('labels public graph participant lists as known, not allowlisted', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-public-participants',
+          name: 'Open Graph',
+          accessPolicy: 'public',
+          callerInvolved: true,
+        },
+        memory: baseMemory,
+        participants: ['0x1234567890abcdef'],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    expect(container.textContent).toContain('Known participants');
+    expect(container.textContent).not.toContain('Allowlisted participants');
+
+    await act(async () => root.unmount());
+  });
+
   it('does not present all-layer query failures as authoritative zero counts', async () => {
     const outageMemory = {
       ...baseMemory,
@@ -293,6 +314,37 @@ describe('Context Graph IA and Overview', () => {
     expect(container.textContent).toContain('Unavailable');
     expect(container.textContent).toContain('Live memory counts are unavailable.');
     expect(container.textContent).not.toContain('Canonical current-layer entity counts.');
+
+    await act(async () => root.unmount());
+  });
+
+  it('does not fold failed layer counts into pipeline percentages', async () => {
+    const partialOutageMemory = {
+      ...baseMemory,
+      counts: { wm: 4, swm: 2, vm: 0, total: 6 },
+      layerStatus: { wm: 'ok', swm: 'ok', vm: 'error' },
+      partial: true,
+      error: null,
+    };
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-partial-outage',
+          name: 'Partial Outage Graph',
+          accessPolicy: 'private',
+          callerInvolved: false,
+        },
+        memory: partialOutageMemory,
+        participants: [],
+        currentAgent: null,
+      }),
+    );
+
+    expect(container.textContent).toContain('One or more layer counts are currently a lower bound.');
+    expect(container.querySelector('.v10-po-pipeline-step.vm .v10-po-pipeline-step-count')?.textContent)
+      .toBe('Unavailable');
+    expect(container.querySelectorAll('.v10-po-pipeline-seg')).toHaveLength(0);
+    expect(container.querySelector('.v10-po-pipeline-empty')).toBeTruthy();
 
     await act(async () => root.unmount());
   });

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -246,6 +246,57 @@ describe('Context Graph IA and Overview', () => {
     await act(async () => root.unmount());
   });
 
+  it('uses participant membership as the joined-role fallback for older daemons', async () => {
+    const agentAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-member-legacy',
+          name: 'Member Graph',
+          accessPolicy: 'private',
+        },
+        memory: baseMemory,
+        participants: [agentAddress],
+        currentAgent: {
+          agentDid: `did:dkg:agent:${agentAddress}`,
+          agentAddress,
+        },
+        currentAgentStatus: 'ok',
+      }),
+    );
+
+    expect(container.textContent).toContain('Joined');
+    expect(container.textContent).not.toContain('Role unknown');
+
+    await act(async () => root.unmount());
+  });
+
+  it('does not use stale participant membership while participants are loading', async () => {
+    const agentAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-member-loading',
+          name: 'Member Graph',
+          accessPolicy: 'private',
+        },
+        memory: baseMemory,
+        participants: [agentAddress],
+        participantsStatus: 'loading',
+        currentAgent: {
+          agentDid: `did:dkg:agent:${agentAddress}`,
+          agentAddress,
+        },
+        currentAgentStatus: 'ok',
+      }),
+    );
+
+    expect(container.textContent).toContain('Role unknown');
+    expect(container.textContent).not.toContain('Joined');
+
+    await act(async () => root.unmount());
+  });
+
   it('summarizes public access without pretending the allowlist is an exact count', async () => {
     const { container, root } = await render(
       React.createElement(ProjectOverviewCard, {

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -242,6 +242,35 @@ describe('Context Graph IA and Overview', () => {
     await act(async () => root.unmount());
   });
 
+  it('does not present all-layer query failures as authoritative zero counts', async () => {
+    const outageMemory = {
+      ...baseMemory,
+      counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+      layerStatus: { wm: 'error', swm: 'error', vm: 'error' },
+      partial: false,
+      error: null,
+    };
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-outage',
+          name: 'Outage Graph',
+          accessPolicy: 'private',
+          callerInvolved: false,
+        },
+        memory: outageMemory,
+        participants: [],
+        currentAgent: null,
+      }),
+    );
+
+    expect(container.textContent).toContain('Unavailable');
+    expect(container.textContent).toContain('Live memory counts are unavailable.');
+    expect(container.textContent).not.toContain('Canonical current-layer entity counts.');
+
+    await act(async () => root.unmount());
+  });
+
   it('does not turn participant fetch failures into exact access counts', async () => {
     const { container, root } = await render(
       React.createElement(ProjectOverviewCard, {

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -79,6 +79,10 @@ vi.mock('../src/ui/api-wrapper.js', () => ({
     fetchContextGraphs: vi.fn(async () => ({
       contextGraphs: [{ id: 'cg-test', name: 'Context Graph Test' }],
     })),
+    fetchCurrentAgent: vi.fn(async () => ({
+      agentDid: 'did:dkg:agent:0xabc',
+      peerId: 'peer-1',
+    })),
   },
 }));
 
@@ -133,7 +137,8 @@ vi.mock('../src/ui/views/project/components.js', () => ({
   LayerSwitcher: ({ active, onSwitch }: { active: string; onSwitch: (layer: string) => void }) =>
     React.createElement('div', { 'data-testid': 'active-layer', 'data-layer': active },
       React.createElement('button', { 'data-testid': 'switch-wm', onClick: () => onSwitch('wm') }, 'WM'),
-      React.createElement('button', { 'data-testid': 'switch-swm', onClick: () => onSwitch('swm') }, 'SWM')),
+      React.createElement('button', { 'data-testid': 'switch-swm', onClick: () => onSwitch('swm') }, 'SWM'),
+      React.createElement('button', { 'data-testid': 'switch-subgraphs', onClick: () => onSwitch('graph-overview') }, 'Subgraphs')),
   KADetailView: ({ entity, onNavigate, onClose }: { entity: any; onNavigate: (uri: string) => void; onClose: () => void }) =>
     React.createElement('section', { 'data-testid': 'entity-detail', 'data-entity': entity.uri },
       React.createElement('div', {}, entity.label),
@@ -182,7 +187,11 @@ vi.mock('../src/ui/views/project/components.js', () => ({
             onClick: () => onSelectEntity('urn:entity:working'),
           }, 'Open strip entity'))));
   },
-  SubGraphOverviewGrid: () => null,
+  SubGraphOverviewGrid: ({ onSelectSubGraph }: { onSelectSubGraph: (slug: string) => void }) =>
+    React.createElement('button', {
+      'data-testid': 'select-subgraph-demo',
+      onClick: () => onSelectSubGraph('demo'),
+    }, 'Open demo subgraph'),
   ContextGraphQueryView: () => null,
   LayerDetailView: ({ layer, activeTab, onTabChange, onSelectEntity }: {
     layer: string;
@@ -278,33 +287,9 @@ describe('ProjectView entity detail navigation', () => {
     expect(query('layer-scroll').scrollTop).toBe(86);
   });
 
-  it('restores overview strip expansion, subtab, and scroll when entity detail closes', async () => {
-    await click('expand-strip-swm');
-    await click('strip-tab-graph');
-
-    const scroller = query('strip-scroll');
-    scroller.scrollTop = 64;
-
-    await click('open-strip-entity');
-    expect(query('entity-detail').dataset.entity).toBe('urn:entity:working');
-
-    await click('detail-back');
-    await flush();
-
-    expect(query('active-layer').dataset.layer).toBe('overview');
-    expect(query('memory-strip').dataset.expanded).toBe('swm');
-    expect(query('memory-strip').dataset.tab).toBe('graph');
-    expect(query('strip-scroll').scrollTop).toBe(64);
-  });
-
-  it('restores page scroll when overview activity opens while the strip is expanded', async () => {
-    await click('expand-strip-swm');
-    await click('strip-tab-graph');
-
+  it('restores page scroll when overview activity opens an entity detail', async () => {
     const pageScroller = scrollRoot('page');
-    const stripScroller = query('strip-scroll');
     pageScroller.scrollTop = 140;
-    stripScroller.scrollTop = 32;
 
     await click('open-activity-entity');
     expect(query('entity-detail').dataset.entity).toBe('urn:entity:working');
@@ -315,12 +300,11 @@ describe('ProjectView entity detail navigation', () => {
     await flush();
 
     expect(query('active-layer').dataset.layer).toBe('overview');
-    expect(query('memory-strip').dataset.expanded).toBe('swm');
-    expect(query('memory-strip').dataset.tab).toBe('graph');
     expect(scrollRoot('page').scrollTop).toBe(140);
   });
 
   it('keeps the originating subgraph stable while following cross-subgraph entity links', async () => {
+    await click('switch-subgraphs');
     await click('select-subgraph-demo');
     await click('subgraph-tab-graph');
     expect(query('active-subgraph').textContent).toBe('demo');

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -87,6 +87,7 @@ vi.mock('../src/ui/api-wrapper.js', () => ({
       agentDid: 'did:dkg:agent:0xabc',
       peerId: 'peer-1',
     })),
+    listParticipants: vi.fn(async () => ({ allowedAgents: [] })),
   },
 }));
 

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -78,17 +78,14 @@ const tabsStoreMock = vi.hoisted(() => ({
   openTab: vi.fn(),
 }));
 
+const apiWrapperMock = vi.hoisted(() => ({
+  fetchContextGraphs: vi.fn(),
+  fetchCurrentAgent: vi.fn(),
+  listParticipants: vi.fn(),
+}));
+
 vi.mock('../src/ui/api-wrapper.js', () => ({
-  api: {
-    fetchContextGraphs: vi.fn(async () => ({
-      contextGraphs: [{ id: 'cg-test', name: 'Context Graph Test' }],
-    })),
-    fetchCurrentAgent: vi.fn(async () => ({
-      agentDid: 'did:dkg:agent:0xabc',
-      peerId: 'peer-1',
-    })),
-    listParticipants: vi.fn(async () => ({ allowedAgents: [] })),
-  },
+  api: apiWrapperMock,
 }));
 
 vi.mock('../src/ui/api.js', () => ({
@@ -162,8 +159,16 @@ vi.mock('../src/ui/views/project/components.js', () => ({
       React.createElement('button', { 'data-testid': 'subgraph-tab-graph', onClick: () => onTabChange('graph') }, 'Graph'),
       React.createElement('div', { 'data-testid': 'subgraph-scroll', 'data-cg-scroll-key': `subgraph:${slug}:${activeTab}` },
         React.createElement('button', { 'data-testid': 'open-subgraph-entity', onClick: () => onSelectEntity('urn:entity:demo') }, 'Open demo entity'))),
-  ProjectOverviewCard: ({ onOpenPrimer }: { onOpenPrimer: () => void }) =>
-    React.createElement('div', {},
+  ProjectOverviewCard: ({ onOpenPrimer, participants, participantsStatus }: {
+    onOpenPrimer: () => void;
+    participants: string[];
+    participantsStatus: string;
+  }) =>
+    React.createElement('div', {
+      'data-testid': 'overview-card',
+      'data-participants': participants.join(','),
+      'data-participants-status': participantsStatus,
+    },
       'Overview',
       React.createElement('button', { 'data-testid': 'open-primer', onClick: onOpenPrimer }, 'What is a Context Graph?')),
   PendingJoinRequestsBar: () => null,
@@ -250,6 +255,14 @@ describe('ProjectView entity detail navigation', () => {
 
   beforeEach(async () => {
     resetMemory();
+    apiWrapperMock.fetchContextGraphs.mockResolvedValue({
+      contextGraphs: [{ id: 'cg-test', name: 'Context Graph Test' }],
+    });
+    apiWrapperMock.fetchCurrentAgent.mockResolvedValue({
+      agentDid: 'did:dkg:agent:0xabc',
+      peerId: 'peer-1',
+    });
+    apiWrapperMock.listParticipants.mockResolvedValue({ allowedAgents: [] });
     document.body.innerHTML = '<div id="root"></div>';
     originalRaf = window.requestAnimationFrame;
     Object.defineProperty(window, 'requestAnimationFrame', {
@@ -327,6 +340,42 @@ describe('ProjectView entity detail navigation', () => {
     expect(pushStateSpy).not.toHaveBeenCalled();
 
     pushStateSpy.mockRestore();
+  });
+
+  it('does not pass participants loaded for another context graph into Overview', async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.innerHTML = '<div id="root"></div>';
+    const container = document.getElementById('root');
+    if (!container) throw new Error('Missing root');
+    root = createRoot(container);
+
+    apiWrapperMock.fetchContextGraphs.mockResolvedValue({
+      contextGraphs: [
+        { id: 'cg-test', name: 'Context Graph Test' },
+        { id: 'cg-next', name: 'Next Context Graph' },
+      ],
+    });
+    apiWrapperMock.listParticipants.mockReset();
+    apiWrapperMock.listParticipants
+      .mockResolvedValueOnce({ allowedAgents: ['0xabc'] })
+      .mockImplementation(() => new Promise(() => {}));
+
+    await act(async () => {
+      root.render(React.createElement(ProjectView, { contextGraphId: 'cg-test' }));
+    });
+    await flush();
+    expect(query('overview-card').dataset.participants).toBe('0xabc');
+    expect(query('overview-card').dataset.participantsStatus).toBe('ok');
+
+    await act(async () => {
+      root.render(React.createElement(ProjectView, { contextGraphId: 'cg-next' }));
+    });
+    await flush();
+
+    expect(query('overview-card').dataset.participants).toBe('');
+    expect(query('overview-card').dataset.participantsStatus).toBe('loading');
   });
 
   it('keeps the originating subgraph stable while following cross-subgraph entity links', async () => {

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -74,6 +74,10 @@ const agentsData = {
   openAgent: vi.fn(),
 };
 
+const tabsStoreMock = vi.hoisted(() => ({
+  openTab: vi.fn(),
+}));
+
 vi.mock('../src/ui/api-wrapper.js', () => ({
   api: {
     fetchContextGraphs: vi.fn(async () => ({
@@ -105,7 +109,10 @@ vi.mock('../src/ui/hooks/useAgents.js', () => ({
 }));
 
 vi.mock('../src/ui/stores/tabs.js', () => ({
-  useTabsStore: () => vi.fn(),
+  useTabsStore: (selector?: (state: { openTab: typeof tabsStoreMock.openTab }) => unknown) => {
+    const state = { openTab: tabsStoreMock.openTab };
+    return selector ? selector(state) : state;
+  },
 }));
 
 vi.mock('../src/ui/components/Modals/ImportFilesModal.js', () => ({
@@ -154,7 +161,10 @@ vi.mock('../src/ui/views/project/components.js', () => ({
       React.createElement('button', { 'data-testid': 'subgraph-tab-graph', onClick: () => onTabChange('graph') }, 'Graph'),
       React.createElement('div', { 'data-testid': 'subgraph-scroll', 'data-cg-scroll-key': `subgraph:${slug}:${activeTab}` },
         React.createElement('button', { 'data-testid': 'open-subgraph-entity', onClick: () => onSelectEntity('urn:entity:demo') }, 'Open demo entity'))),
-  ProjectOverviewCard: () => React.createElement('div', {}, 'Overview'),
+  ProjectOverviewCard: ({ onOpenPrimer }: { onOpenPrimer: () => void }) =>
+    React.createElement('div', {},
+      'Overview',
+      React.createElement('button', { 'data-testid': 'open-primer', onClick: onOpenPrimer }, 'What is a Context Graph?')),
   PendingJoinRequestsBar: () => null,
   MemoryStrip: ({ expandedLayer, onExpandedLayerChange, expandTabs, onExpandTabChange, onSelectEntity }: {
     expandedLayer: 'wm' | 'swm' | 'vm' | null;
@@ -301,6 +311,21 @@ describe('ProjectView entity detail navigation', () => {
 
     expect(query('active-layer').dataset.layer).toBe('overview');
     expect(scrollRoot('page').scrollTop).toBe(140);
+  });
+
+  it('opens the primer as a tab without mutating browser history', async () => {
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+
+    await click('open-primer');
+
+    expect(tabsStoreMock.openTab).toHaveBeenCalledWith({
+      id: 'context-graph-primer',
+      label: 'What is a Context Graph?',
+      closable: true,
+    });
+    expect(pushStateSpy).not.toHaveBeenCalled();
+
+    pushStateSpy.mockRestore();
   });
 
   it('keeps the originating subgraph stable while following cross-subgraph entity links', async () => {

--- a/packages/node-ui/test/use-current-agent.test.ts
+++ b/packages/node-ui/test/use-current-agent.test.ts
@@ -153,4 +153,48 @@ describe('useCurrentAgent', () => {
 
     await act(async () => root.unmount());
   });
+
+  it('loads immediately for a new consumer after auth changes while polling is active', async () => {
+    fetchCurrentAgentMock.mockResolvedValueOnce({
+      agentDid: 'did:dkg:agent:0xold',
+      agentAddress: '0xold',
+      name: 'Old agent',
+      framework: 'DKG',
+      peerId: 'peer-old',
+      nodeIdentityId: '0',
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await Promise.resolve();
+    });
+    expect(fetchCurrentAgentMock).toHaveBeenCalledTimes(1);
+
+    fetchCurrentAgentMock.mockResolvedValueOnce({
+      agentDid: 'did:dkg:agent:0xnew',
+      agentAddress: '0xnew',
+      name: 'New agent',
+      framework: 'DKG',
+      peerId: 'peer-new',
+      nodeIdentityId: '0',
+    });
+
+    (window as any).__DKG_TOKEN__ = 'token-new';
+    await act(async () => {
+      root.render(React.createElement(React.Fragment, {},
+        React.createElement(Probe),
+        React.createElement(Probe),
+      ));
+      await Promise.resolve();
+    });
+
+    expect(fetchCurrentAgentMock).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('[data-agent-did="did:dkg:agent:0xnew"]')).toBeTruthy();
+
+    await act(async () => root.unmount());
+  });
 });

--- a/packages/node-ui/test/use-current-agent.test.ts
+++ b/packages/node-ui/test/use-current-agent.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchCurrentAgentMock = vi.fn();
+
+vi.mock('../src/ui/api-wrapper.js', () => ({
+  api: {
+    fetchCurrentAgent: () => fetchCurrentAgentMock(),
+  },
+}));
+
+const { useCurrentAgent } = await import('../src/ui/hooks/useCurrentAgent.js');
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function Probe() {
+  const currentAgent = useCurrentAgent();
+  return React.createElement('div', {
+    'data-agent-did': currentAgent.data?.agentDid ?? '',
+    'data-loading': String(currentAgent.loading),
+    'data-error': currentAgent.error ?? '',
+  });
+}
+
+describe('useCurrentAgent', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    fetchCurrentAgentMock.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('clears cached identity when a refresh fails', async () => {
+    fetchCurrentAgentMock.mockResolvedValueOnce({
+      agentDid: 'did:dkg:agent:0xold',
+      agentAddress: '0xold',
+      name: 'Old agent',
+      framework: 'DKG',
+      peerId: 'peer-old',
+      nodeIdentityId: '0',
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await Promise.resolve();
+    });
+    expect(container.firstElementChild?.getAttribute('data-agent-did')).toBe('did:dkg:agent:0xold');
+
+    fetchCurrentAgentMock.mockRejectedValueOnce(new Error('auth failed'));
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(container.firstElementChild?.getAttribute('data-agent-did')).toBe('');
+    expect(container.firstElementChild?.getAttribute('data-loading')).toBe('false');
+    expect(container.firstElementChild?.getAttribute('data-error')).toBe('auth failed');
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/node-ui/test/use-current-agent.test.ts
+++ b/packages/node-ui/test/use-current-agent.test.ts
@@ -16,6 +16,16 @@ const { useCurrentAgent } = await import('../src/ui/hooks/useCurrentAgent.js');
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function Probe() {
   const currentAgent = useCurrentAgent();
   return React.createElement('div', {
@@ -79,6 +89,67 @@ describe('useCurrentAgent', () => {
     expect(container.firstElementChild?.getAttribute('data-agent-did')).toBe('');
     expect(container.firstElementChild?.getAttribute('data-loading')).toBe('false');
     expect(container.firstElementChild?.getAttribute('data-error')).toBe('auth failed');
+
+    await act(async () => root.unmount());
+  });
+
+  it('starts a new identity fetch when auth changes during a pending load', async () => {
+    const oldLoad = deferred<any>();
+    const newLoad = deferred<any>();
+    fetchCurrentAgentMock
+      .mockReturnValueOnce(oldLoad.promise)
+      .mockReturnValueOnce(newLoad.promise);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await Promise.resolve();
+    });
+    expect(fetchCurrentAgentMock).toHaveBeenCalledTimes(1);
+
+    (window as any).__DKG_TOKEN__ = 'token-new';
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(fetchCurrentAgentMock).toHaveBeenCalledTimes(2);
+    expect(container.firstElementChild?.getAttribute('data-agent-did')).toBe('');
+    expect(container.firstElementChild?.getAttribute('data-loading')).toBe('true');
+
+    await act(async () => {
+      newLoad.resolve({
+        agentDid: 'did:dkg:agent:0xnew',
+        agentAddress: '0xnew',
+        name: 'New agent',
+        framework: 'DKG',
+        peerId: 'peer-new',
+        nodeIdentityId: '0',
+      });
+      await newLoad.promise;
+      await Promise.resolve();
+    });
+
+    expect(container.firstElementChild?.getAttribute('data-agent-did')).toBe('did:dkg:agent:0xnew');
+    expect(container.firstElementChild?.getAttribute('data-loading')).toBe('false');
+
+    await act(async () => {
+      oldLoad.resolve({
+        agentDid: 'did:dkg:agent:0xold',
+        agentAddress: '0xold',
+        name: 'Old agent',
+        framework: 'DKG',
+        peerId: 'peer-old',
+        nodeIdentityId: '0',
+      });
+      await oldLoad.promise;
+      await Promise.resolve();
+    });
+    expect(container.firstElementChild?.getAttribute('data-agent-did')).toBe('did:dkg:agent:0xnew');
+    expect(container.firstElementChild?.getAttribute('data-loading')).toBe('false');
 
     await act(async () => root.unmount());
   });

--- a/packages/node-ui/test/use-current-agent.test.ts
+++ b/packages/node-ui/test/use-current-agent.test.ts
@@ -28,16 +28,18 @@ function Probe() {
 describe('useCurrentAgent', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
+    (window as any).__DKG_TOKEN__ = 'token-old';
     fetchCurrentAgentMock.mockReset();
     vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    delete (window as any).__DKG_TOKEN__;
     document.body.innerHTML = '';
   });
 
-  it('clears cached identity when a refresh fails', async () => {
+  it('preserves identity on transient failure but clears it when auth changes', async () => {
     fetchCurrentAgentMock.mockResolvedValueOnce({
       agentDid: 'did:dkg:agent:0xold',
       agentAddress: '0xold',
@@ -57,6 +59,17 @@ describe('useCurrentAgent', () => {
     });
     expect(container.firstElementChild?.getAttribute('data-agent-did')).toBe('did:dkg:agent:0xold');
 
+    fetchCurrentAgentMock.mockRejectedValueOnce(new Error('temporary failure'));
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(container.firstElementChild?.getAttribute('data-agent-did')).toBe('did:dkg:agent:0xold');
+    expect(container.firstElementChild?.getAttribute('data-loading')).toBe('false');
+    expect(container.firstElementChild?.getAttribute('data-error')).toBe('temporary failure');
+
+    (window as any).__DKG_TOKEN__ = 'token-new';
     fetchCurrentAgentMock.mockRejectedValueOnce(new Error('auth failed'));
     await act(async () => {
       vi.advanceTimersByTime(60_000);

--- a/packages/node-ui/test/use-current-agent.test.ts
+++ b/packages/node-ui/test/use-current-agent.test.ts
@@ -154,6 +154,60 @@ describe('useCurrentAgent', () => {
     await act(async () => root.unmount());
   });
 
+  it('starts a replacement load when a pending request detects auth changed', async () => {
+    const oldLoad = deferred<any>();
+    const newLoad = deferred<any>();
+    fetchCurrentAgentMock
+      .mockReturnValueOnce(oldLoad.promise)
+      .mockReturnValueOnce(newLoad.promise);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(Probe));
+      await Promise.resolve();
+    });
+    expect(fetchCurrentAgentMock).toHaveBeenCalledTimes(1);
+
+    (window as any).__DKG_TOKEN__ = 'token-new';
+    await act(async () => {
+      oldLoad.resolve({
+        agentDid: 'did:dkg:agent:0xold',
+        agentAddress: '0xold',
+        name: 'Old agent',
+        framework: 'DKG',
+        peerId: 'peer-old',
+        nodeIdentityId: '0',
+      });
+      await oldLoad.promise;
+      await Promise.resolve();
+    });
+
+    expect(fetchCurrentAgentMock).toHaveBeenCalledTimes(2);
+    expect(container.firstElementChild?.getAttribute('data-agent-did')).toBe('');
+    expect(container.firstElementChild?.getAttribute('data-loading')).toBe('true');
+
+    await act(async () => {
+      newLoad.resolve({
+        agentDid: 'did:dkg:agent:0xnew',
+        agentAddress: '0xnew',
+        name: 'New agent',
+        framework: 'DKG',
+        peerId: 'peer-new',
+        nodeIdentityId: '0',
+      });
+      await newLoad.promise;
+      await Promise.resolve();
+    });
+
+    expect(container.firstElementChild?.getAttribute('data-agent-did')).toBe('did:dkg:agent:0xnew');
+    expect(container.firstElementChild?.getAttribute('data-loading')).toBe('false');
+
+    await act(async () => root.unmount());
+  });
+
   it('loads immediately for a new consumer after auth changes while polling is active', async () => {
     fetchCurrentAgentMock.mockResolvedValueOnce({
       agentDid: 'did:dkg:agent:0xold',

--- a/packages/node-ui/test/vm-hero-banner.test.ts
+++ b/packages/node-ui/test/vm-hero-banner.test.ts
@@ -84,7 +84,7 @@ describe('VerifiedMemoryHeroBanner', () => {
     });
 
     expect(container.querySelector('.v10-vm-empty-state')).toBeTruthy();
-    expect(container.textContent).toContain('Verified Memory');
+    expect(container.textContent).toContain('Verifiable Memory');
     expect(container.textContent).toContain('Nothing published yet');
     expect(container.textContent).toContain('No Knowledge Assets yet.');
     expect(container.textContent).toContain('Publish entities from Shared Working Memory');
@@ -176,7 +176,7 @@ describe('VerifiedMemoryHeroBanner', () => {
 
     expect(container.querySelector('.v10-vm-empty-state')).toBeTruthy();
     expect(container.textContent).toContain('Nothing published yet');
-    expect(container.textContent).not.toContain('Verified Memory status unavailable.');
+    expect(container.textContent).not.toContain('Verifiable Memory status unavailable.');
     expect(container.textContent).toContain('View full layer');
 
     await unmount();
@@ -210,7 +210,7 @@ describe('VerifiedMemoryHeroBanner', () => {
 
     expect(container.querySelector('.v10-vm-empty-state')).toBeNull();
     expect(container.textContent).not.toContain('Nothing published yet');
-    expect(container.textContent).toContain('Verified Memory status unavailable.');
+    expect(container.textContent).toContain('Verifiable Memory status unavailable.');
     expect(container.textContent).toContain('View full layer');
 
     await unmount();


### PR DESCRIPTION
## Summary

- Implements PR 2.3 / S1 + S2 + N8 from the Context Graph UX plan: the view switcher now follows the pipeline IA, with memory layers grouped before Subgraphs and Query Catalogue in More.
- Rebuilds the Context Graph Overview as a summary-only surface with role/access badges, shared `StatStrip` stats, one Knowledge Pipeline, and links into WM/SWM/VM instead of embedding duplicate layer pages.
- Adds the linked Context Graph primer, including a direct `/ui/context-graph-primer` restore path, and completes the user-facing `Verifiable Memory` terminology sweep across adjacent node UI memory surfaces.

## Related

- Follow-up to #612
- Implements planned items S1, S2, and N8 from `agent-docs/context-graph-implementation-plan.md`

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/views/project/components.tsx` | Reorders the Context Graph switcher, adds Overview role/access badges and Knowledge Pipeline, and keeps role labels conservative when identity is unavailable. |
| `packages/node-ui/src/ui/views/ProjectView.tsx` | Removes the Overview MemoryStrip duplication, wires current-agent identity, layer navigation, and primer opening. |
| `packages/node-ui/src/ui/views/ContextGraphPrimerView.tsx` | Adds the N8 primer surface for layers, subgraphs, entities vs Knowledge Assets, assertions, and roles. |
| `packages/node-ui/src/ui/App.tsx` / `components/Shell/PanelCenter.tsx` | Registers and renders the primer as a direct-restorable center tab. |
| `packages/node-ui/src/ui/styles.css` | Adds Overview, primer, switcher grouping, More menu, and responsive compact-label styles. |
| `packages/node-ui/src/ui/views/DashboardView.tsx`, `MemoryLayerView.tsx`, `MemoryStackView.tsx`, `genui/*`, `mocks/data.ts`, `CreateProjectModal.tsx`, `views/project/helpers.ts` | Aligns visible VM copy to the canonical `Verifiable Memory` term. |
| `packages/node-ui/test/context-graph-ia-overview.test.ts`, `project-view-navigation.test.ts`, `vm-hero-banner.test.ts` | Adds IA/Overview/primer coverage and updates existing mocks/expectations. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/context-graph-ia-overview.test.ts test/project-view-navigation.test.ts test/vm-hero-banner.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/context-graph-ia-overview.test.ts test/project-view-navigation.test.ts test/context-graph-empty-stat-components.test.ts test/use-memory-entities-counts.test.ts test/use-memory-entities-labels.test.ts test/context-graph-contrast.test.ts test/subgraph-detail-view.test.ts test/use-my-context-graphs.test.ts test/contextGraphSidebar.test.ts test/vm-hero-banner.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-graph-viz --filter @origintrail-official/dkg-node-ui run build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui` (existing large chunk warnings only)
- [x] `git diff --check` (CRLF warnings only)
- [x] Dev-server visual QA through a local mock-data proxy at `http://127.0.0.1:5181/ui/`: screenshots at 1440x900, 1280x800, and 900x700 confirmed one-row navigation, no horizontal overflow, no visible `Graph Overview`, no Overview MemoryStrip duplication, visible Knowledge Pipeline, and the primer entry point.
- [x] Browser route smoke confirmed direct `/ui/context-graph-primer` restore and Overview primer-link URL encoding.
- [x] Local PR reviewer ran three rounds; valid findings were fixed and the final round returned `{comments:[]}`.