### PR TITLE
Reframe Context Graph query catalogue

### DIFF
--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -204,7 +204,7 @@ function vmSparql(cgId: string) {
   // We exclude:
   //   • `_shared_memory*`        — belongs to SWM
   //   • `assertion/*`            — belongs to WM
-  //   • `_meta`, `/meta/*`, `_private`, `_rules`, any `_verified_memory_meta`
+  //   • `_meta`, `/meta`, `/meta/*`, `_private`, `_rules`, any `_verified_memory_meta`
   //     — bookkeeping graphs, not user data.
   return `SELECT ?s ?p ?o ?g WHERE {
     GRAPH ?g { ?s ?p ?o }
@@ -214,6 +214,7 @@ function vmSparql(cgId: string) {
       !CONTAINS(STR(?g), "/_shared_memory") &&
       !CONTAINS(STR(?g), "_verified_memory_meta") &&
       !STRENDS(STR(?g), "/_meta") &&
+      STR(?g) != "${cgUri}/meta" &&
       !CONTAINS(STR(?g), "/meta/") &&
       !CONTAINS(STR(?g), "/_private") &&
       !CONTAINS(STR(?g), "/_rules")

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -204,7 +204,7 @@ function vmSparql(cgId: string) {
   // We exclude:
   //   • `_shared_memory*`        — belongs to SWM
   //   • `assertion/*`            — belongs to WM
-  //   • `_meta`, `_private`, `_rules`, any `_verified_memory_meta`
+  //   • `_meta`, `/meta/*`, `_private`, `_rules`, any `_verified_memory_meta`
   //     — bookkeeping graphs, not user data.
   return `SELECT ?s ?p ?o ?g WHERE {
     GRAPH ?g { ?s ?p ?o }
@@ -214,6 +214,7 @@ function vmSparql(cgId: string) {
       !CONTAINS(STR(?g), "/_shared_memory") &&
       !CONTAINS(STR(?g), "_verified_memory_meta") &&
       !STRENDS(STR(?g), "/_meta") &&
+      !CONTAINS(STR(?g), "/meta/") &&
       !CONTAINS(STR(?g), "/_private") &&
       !CONTAINS(STR(?g), "/_rules")
     )

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -2979,14 +2979,16 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-mlv-query-input:focus { border-color: var(--border-strong); }
 .v10-cg-query-view {
-  width: min(100%, 1180px);
-  max-width: 1180px;
+  width: 100%;
+  max-width: none;
+  box-sizing: border-box;
+  padding: 12px 16px 16px;
   gap: 16px;
 }
 .v10-memory-explorer-page .v10-cg-query-view {
   display: flex;
   flex-direction: column;
-  overflow: auto;
+  overflow: visible;
 }
 .v10-cg-query-zone {
   border: 1px solid var(--border-subtle);
@@ -3027,43 +3029,6 @@ button:focus:not(:focus-visible) { outline: none; }
   text-transform: uppercase;
   color: var(--text-tertiary);
 }
-.v10-cg-query-scope {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  align-items: flex-end;
-}
-.v10-cg-query-scope-label {
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
-  color: var(--text-tertiary);
-}
-.v10-cg-query-scope-control {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  padding: 3px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 6px;
-  background: var(--bg-surface);
-}
-.v10-cg-query-scope-control button {
-  min-height: 28px;
-  padding: 0 10px;
-  border: 0;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-tertiary);
-  font-size: 11px;
-  font-weight: 600;
-}
-.v10-cg-query-scope-control button:hover,
-.v10-cg-query-scope-control button.active {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
 .v10-cg-query-catalog-groups {
   display: flex;
   flex-direction: column;
@@ -3091,17 +3056,6 @@ button:focus:not(:focus-visible) { outline: none; }
   font-size: 11px;
   line-height: 1.45;
   color: var(--text-tertiary);
-}
-.v10-cg-query-scope-badge {
-  flex: 0 0 auto;
-  padding: 3px 7px;
-  border: 1px solid color-mix(in srgb, var(--sg-color, #38bdf8) 42%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--sg-color, #38bdf8) 12%, transparent);
-  color: var(--text-secondary);
-  font-size: 10px;
-  font-weight: 700;
-  line-height: 1.3;
 }
 .v10-cg-query-list {
   display: grid;
@@ -3279,9 +3233,6 @@ button:focus:not(:focus-visible) { outline: none; }
 @media (max-width: 900px) {
   .v10-vm-search-header { flex-direction: column; align-items: stretch; }
   .v10-cg-query-zone-header { flex-direction: column; align-items: stretch; }
-  .v10-cg-query-scope { align-items: stretch; }
-  .v10-cg-query-scope-control { width: 100%; }
-  .v10-cg-query-scope-control button { flex: 1 1 0; }
   .v10-vm-search-controls,
   .v10-mlv-query-bar,
   .v10-cg-query-editor { grid-template-columns: 1fr; display: flex; flex-direction: column; }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -2922,8 +2922,8 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-memory-layer-view { max-width: 1000px; min-width: 0; }
 .v10-mlv-header { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
 .v10-mlv-icon { font-size: 20px; }
-.v10-mlv-title { font-size: 16px; font-weight: 600; color: var(--text-primary); margin-bottom: 2px; }
-.v10-mlv-desc { font-size: 12px; color: var(--text-secondary); }
+.v10-mlv-title { font-size: 16px; line-height: 1.25; font-weight: 600; color: var(--text-primary); margin: 0 0 2px; }
+.v10-mlv-desc { font-size: 12px; line-height: 1.4; color: var(--text-secondary); margin: 0; }
 .v10-vm-search-panel {
   border: 1px solid var(--border-default);
   border-radius: 10px;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -3032,19 +3032,23 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-cg-query-catalog-groups {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 4px;
 }
 .v10-cg-query-catalog-group {
-  padding: 12px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--bg-surface) 78%, transparent);
+  padding: 10px 0 14px 12px;
+  border-left: 2px solid color-mix(in srgb, var(--sg-color, #38bdf8) 45%, var(--border-subtle));
+  background: transparent;
+}
+.v10-cg-query-catalog-group + .v10-cg-query-catalog-group {
+  margin-top: 6px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-subtle);
 }
 .v10-cg-query-catalog-group-header {
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 12px;
 }
 .v10-cg-query-catalog-title-row {
   display: flex;
@@ -3080,8 +3084,8 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-cg-query-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
 }
 .v10-cg-query-chip {
   min-height: 54px;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -3184,8 +3184,8 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-mlv-empty p { font-size: 12px; color: var(--text-tertiary); }
 .v10-mlv-table-wrap { overflow-x: auto; border: 1px solid var(--border-default); border-radius: 8px; }
 .v10-cg-query-results {
-  flex: 0 0 auto;
-  min-height: 160px;
+  flex: 1 1 auto;
+  min-height: 220px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -3202,8 +3202,9 @@ button:focus:not(:focus-visible) { outline: none; }
   justify-content: center;
 }
 .v10-cg-query-results .v10-mlv-table-wrap {
-  flex: 0 0 auto;
-  max-height: 260px;
+  flex: 1 1 auto;
+  min-height: 180px;
+  max-height: min(56vh, 720px);
   overflow: auto;
 }
 .v10-mlv-table { width: 100%; border-collapse: collapse; font-size: 12px; }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -2978,11 +2978,170 @@ button:focus:not(:focus-visible) { outline: none; }
   color: var(--text-primary);
 }
 .v10-mlv-query-input:focus { border-color: var(--border-strong); }
-.v10-cg-query-view { max-width: 1180px; }
+.v10-cg-query-view {
+  width: min(100%, 1180px);
+  max-width: 1180px;
+  gap: 16px;
+}
 .v10-memory-explorer-page .v10-cg-query-view {
   display: flex;
   flex-direction: column;
   overflow: auto;
+}
+.v10-cg-query-zone {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  padding: 14px 16px;
+}
+.v10-cg-query-zone-editor {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+.v10-cg-query-zone-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 10px;
+}
+.v10-cg-query-zone-header h3 {
+  margin: 2px 0 4px;
+  font-size: 15px;
+  line-height: 1.3;
+  color: var(--text-primary);
+}
+.v10-cg-query-zone-header p {
+  margin: 0;
+  max-width: 680px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+.v10-cg-query-eyebrow {
+  display: block;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.v10-cg-query-scope {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  align-items: flex-end;
+}
+.v10-cg-query-scope-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.v10-cg-query-scope-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-surface);
+}
+.v10-cg-query-scope-control button {
+  min-height: 28px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 600;
+}
+.v10-cg-query-scope-control button:hover,
+.v10-cg-query-scope-control button.active {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.v10-cg-query-catalog-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.v10-cg-query-catalog-group {
+  padding: 9px 0;
+  border-top: 1px solid var(--border-subtle);
+}
+.v10-cg-query-catalog-group:first-child { border-top: 0; padding-top: 0; }
+.v10-cg-query-catalog-group:last-child { padding-bottom: 0; }
+.v10-cg-query-catalog-group-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.v10-cg-query-catalog-group-header h4 {
+  margin: 0 0 2px;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.v10-cg-query-catalog-group-header p {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
+}
+.v10-cg-query-scope-badge {
+  flex: 0 0 auto;
+  padding: 3px 7px;
+  border: 1px solid color-mix(in srgb, var(--sg-color, #38bdf8) 42%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--sg-color, #38bdf8) 12%, transparent);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.3;
+}
+.v10-cg-query-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 8px;
+}
+.v10-cg-query-chip {
+  min-height: 54px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+  text-align: left;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+}
+.v10-cg-query-chip:hover,
+.v10-cg-query-chip.active {
+  border-color: color-mix(in srgb, var(--sg-color, #38bdf8) 52%, var(--border-strong));
+  color: var(--text-primary);
+}
+.v10-cg-query-chip-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: inherit;
+}
+.v10-cg-query-chip-desc {
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--text-tertiary);
+}
+.v10-cg-query-error-detail {
+  display: block;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
 }
 .v10-cg-query-editor {
   display: grid;
@@ -3008,15 +3167,6 @@ button:focus:not(:focus-visible) { outline: none; }
   display: flex;
   flex-direction: column;
   gap: 8px;
-}
-.v10-cg-query-catalog {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
-  padding: 8px 0 14px;
-  margin-bottom: 14px;
-  border-bottom: 1px solid var(--border-subtle);
 }
 .v10-mlv-run-btn {
   padding: 8px 16px;
@@ -3080,22 +3230,26 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-mlv-empty p { font-size: 12px; color: var(--text-tertiary); }
 .v10-mlv-table-wrap { overflow-x: auto; border: 1px solid var(--border-default); border-radius: 8px; }
 .v10-cg-query-results {
-  flex: 1 1 auto;
-  min-height: 180px;
+  flex: 0 0 auto;
+  min-height: 160px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
+.v10-cg-query-results .v10-empty-state {
+  flex: 0 0 auto;
+  min-height: 160px;
+}
 .v10-cg-query-results .v10-mlv-empty {
-  flex: 1 1 auto;
-  min-height: 180px;
+  flex: 0 0 auto;
+  min-height: 160px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 .v10-cg-query-results .v10-mlv-table-wrap {
-  flex: 1 1 auto;
-  min-height: 0;
+  flex: 0 0 auto;
+  max-height: 260px;
   overflow: auto;
 }
 .v10-mlv-table { width: 100%; border-collapse: collapse; font-size: 12px; }
@@ -3124,6 +3278,10 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-mlv-table tr:hover td { background: var(--bg-hover); }
 @media (max-width: 900px) {
   .v10-vm-search-header { flex-direction: column; align-items: stretch; }
+  .v10-cg-query-zone-header { flex-direction: column; align-items: stretch; }
+  .v10-cg-query-scope { align-items: stretch; }
+  .v10-cg-query-scope-control { width: 100%; }
+  .v10-cg-query-scope-control button { flex: 1 1 0; }
   .v10-vm-search-controls,
   .v10-mlv-query-bar,
   .v10-cg-query-editor { grid-template-columns: 1fr; display: flex; flex-direction: column; }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -2994,7 +2994,7 @@ button:focus:not(:focus-visible) { outline: none; }
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel);
-  padding: 14px 16px;
+  padding: 16px;
 }
 .v10-cg-query-zone-editor {
   flex: 0 0 auto;
@@ -3006,7 +3006,7 @@ button:focus:not(:focus-visible) { outline: none; }
   justify-content: space-between;
   gap: 16px;
   align-items: flex-start;
-  margin-bottom: 10px;
+  margin-bottom: 14px;
 }
 .v10-cg-query-zone-header h3 {
   margin: 2px 0 4px;
@@ -3032,22 +3032,43 @@ button:focus:not(:focus-visible) { outline: none; }
 .v10-cg-query-catalog-groups {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: 12px;
 }
 .v10-cg-query-catalog-group {
-  padding: 9px 0;
-  border-top: 1px solid var(--border-subtle);
+  padding: 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-surface) 78%, transparent);
 }
-.v10-cg-query-catalog-group:first-child { border-top: 0; padding-top: 0; }
-.v10-cg-query-catalog-group:last-child { padding-bottom: 0; }
 .v10-cg-query-catalog-group-header {
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  margin-bottom: 6px;
+  margin-bottom: 10px;
+}
+.v10-cg-query-catalog-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.v10-cg-query-catalog-kind {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 2px 7px;
+  border: 1px solid color-mix(in srgb, var(--sg-color) 38%, var(--border-subtle));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--sg-color) 12%, var(--bg-surface));
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: uppercase;
 }
 .v10-cg-query-catalog-group-header h4 {
-  margin: 0 0 2px;
+  margin: 0;
   font-size: 13px;
   color: var(--text-primary);
 }
@@ -3086,6 +3107,10 @@ button:focus:not(:focus-visible) { outline: none; }
   color: inherit;
 }
 .v10-cg-query-chip-desc {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
   font-size: 11px;
   line-height: 1.35;
   color: var(--text-tertiary);

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1589,8 +1589,8 @@ LIMIT 1000`;
 
 const CONTEXT_GRAPH_QUERY_SUBGRAPH = '__context_graph';
 const USER_QUERY_CATALOG_SLUG = 'ui-saved-queries';
-const USER_QUERY_CATALOG_NAME = 'Saved queries';
-const USER_QUERY_CATALOG_DESCRIPTION = 'Queries saved from the Query Catalogue.';
+const USER_QUERY_CATALOG_NAME = 'Profile-saved queries';
+const USER_QUERY_CATALOG_DESCRIPTION = 'Queries saved from this page for this Context Graph profile.';
 const PROFILE_NS = 'http://dkg.io/ontology/profile/';
 const SCHEMA_NS = 'http://schema.org/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
@@ -1629,7 +1629,7 @@ function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
     subGraph,
     catalogSlug,
     catalogName,
-    catalogDescription: 'Built-in queries for available non-private graphs in this Context Graph.',
+    catalogDescription: 'Included with the Node UI for common Context Graph inspections.',
     catalogRank,
     resultColumn: '',
     ...query,
@@ -1639,7 +1639,7 @@ function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
     slug: catalogSlug,
     subGraph,
     name: catalogName,
-    description: 'Built-in queries for available non-private graphs in this Context Graph.',
+    description: 'Included with the Node UI for common Context Graph inspections.',
     rank: catalogRank,
     queries: [
       withQueryDefaults({
@@ -1791,9 +1791,17 @@ function queryCatalogueScope(catalog: QueryCatalog): 'context' | 'subgraph' {
 }
 
 function queryCatalogueGroupLabel(catalog: QueryCatalog, scope: 'context' | 'subgraph', subGraphLabel?: string): string {
-  if (isBuiltInQueryCatalog(catalog)) return 'Built-in context queries';
+  if (isBuiltInQueryCatalog(catalog)) return 'Built-in presets';
+  if (catalog.subGraph === CONTEXT_GRAPH_QUERY_SUBGRAPH && catalog.slug === USER_QUERY_CATALOG_SLUG) {
+    return USER_QUERY_CATALOG_NAME;
+  }
   if (scope === 'context') return catalog.name;
   return `${subGraphLabel ?? catalog.subGraph}: ${catalog.name}`;
+}
+
+function queryCatalogueGroupKind(catalog: QueryCatalog, scope: 'context' | 'subgraph'): string {
+  if (isBuiltInQueryCatalog(catalog)) return 'Built in';
+  return scope === 'context' ? 'Saved' : 'Subgraph';
 }
 
 function queryErrorMessage(error: string | null): ReactNode {
@@ -1955,7 +1963,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
         <div>
           <h2 className="v10-mlv-title">Query Catalogue</h2>
           <p className="v10-mlv-desc">
-            Profile-backed reusable SPARQL queries for this Context Graph. Save queries here, then load them back into the editor.
+            Reusable SPARQL for this Context Graph. Use built-in presets or save useful queries to this node profile.
           </p>
         </div>
       </div>
@@ -1963,9 +1971,9 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
       <section className="v10-cg-query-zone v10-cg-query-zone-catalog" aria-labelledby="query-catalogue-saved-title">
         <div className="v10-cg-query-zone-header">
           <div>
-            <span className="v10-cg-query-eyebrow">Saved Queries</span>
-            <h3 id="query-catalogue-saved-title">Reusable query catalogue</h3>
-            <p>Built-in queries and saved profile queries. Save creates a reusable context-level query in this node profile.</p>
+            <span className="v10-cg-query-eyebrow">Query Library</span>
+            <h3 id="query-catalogue-saved-title">Choose a query</h3>
+            <p>Selecting a query loads it into the editor below.</p>
           </div>
         </div>
 
@@ -1998,6 +2006,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
               const binding = scope === 'context' ? undefined : profile?.forSubGraph(catalog.subGraph);
               const color = binding?.color ?? '#38bdf8';
               const label = queryCatalogueGroupLabel(catalog, scope, binding?.displayName);
+              const kind = queryCatalogueGroupKind(catalog, scope);
               return (
                 <div
                   key={`${catalog.subGraph}|${catalog.slug}`}
@@ -2006,7 +2015,10 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
                 >
                   <div className="v10-cg-query-catalog-group-header">
                     <div>
-                      <h4>{label}</h4>
+                      <div className="v10-cg-query-catalog-title-row">
+                        <span className="v10-cg-query-catalog-kind">{kind}</span>
+                        <h4>{label}</h4>
+                      </div>
                       {catalog.description && <p>{catalog.description}</p>}
                     </div>
                   </div>
@@ -2039,7 +2051,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
             inline
             tone="query"
             icon="?"
-            title="No saved profile queries yet."
+            title="No profile-saved queries yet."
             description="Use Save after editing SPARQL to add a reusable context-level query to this catalogue."
           />
         )}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1589,8 +1589,8 @@ LIMIT 1000`;
 
 const CONTEXT_GRAPH_QUERY_SUBGRAPH = '__context_graph';
 const USER_QUERY_CATALOG_SLUG = 'ui-saved-queries';
-const USER_QUERY_CATALOG_NAME = 'Profile-saved queries';
-const USER_QUERY_CATALOG_DESCRIPTION = 'Queries saved from this page for this Context Graph profile.';
+const USER_QUERY_CATALOG_NAME = 'Saved queries';
+const USER_QUERY_CATALOG_DESCRIPTION = 'User-created SPARQL saved in this node profile for this Context Graph.';
 const PROFILE_NS = 'http://dkg.io/ontology/profile/';
 const SCHEMA_NS = 'http://schema.org/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
@@ -1629,7 +1629,7 @@ function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
     subGraph,
     catalogSlug,
     catalogName,
-    catalogDescription: 'Included with the Node UI for common Context Graph inspections.',
+    catalogDescription: 'Ready-made SPARQL included with the Node UI for common Context Graph checks.',
     catalogRank,
     resultColumn: '',
     ...query,
@@ -1639,7 +1639,7 @@ function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
     slug: catalogSlug,
     subGraph,
     name: catalogName,
-    description: 'Included with the Node UI for common Context Graph inspections.',
+    description: 'Ready-made SPARQL included with the Node UI for common Context Graph checks.',
     rank: catalogRank,
     queries: [
       withQueryDefaults({
@@ -1799,8 +1799,18 @@ function queryCatalogueGroupLabel(catalog: QueryCatalog, scope: 'context' | 'sub
   return `${subGraphLabel ?? catalog.subGraph}: ${catalog.name}`;
 }
 
+function queryCatalogueGroupDescription(catalog: QueryCatalog): string {
+  if (isBuiltInQueryCatalog(catalog)) {
+    return 'UI-provided SPARQL for common Context Graph checks.';
+  }
+  if (catalog.subGraph === CONTEXT_GRAPH_QUERY_SUBGRAPH && catalog.slug === USER_QUERY_CATALOG_SLUG) {
+    return USER_QUERY_CATALOG_DESCRIPTION;
+  }
+  return catalog.description ?? '';
+}
+
 function queryCatalogueGroupKind(catalog: QueryCatalog, scope: 'context' | 'subgraph'): string {
-  if (isBuiltInQueryCatalog(catalog)) return 'Built in';
+  if (isBuiltInQueryCatalog(catalog)) return 'Preset';
   return scope === 'context' ? 'Saved' : 'Subgraph';
 }
 
@@ -1963,7 +1973,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
         <div>
           <h2 className="v10-mlv-title">Query Catalogue</h2>
           <p className="v10-mlv-desc">
-            Reusable SPARQL for this Context Graph. Use built-in presets or save useful queries to this node profile.
+            Reusable SPARQL for this Context Graph. Use UI presets or save queries for people and local agents to reuse.
           </p>
         </div>
       </div>
@@ -1973,7 +1983,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
           <div>
             <span className="v10-cg-query-eyebrow">Query Library</span>
             <h3 id="query-catalogue-saved-title">Choose a query</h3>
-            <p>Selecting a query loads it into the editor below.</p>
+            <p>Load a preset or saved query into the editor below.</p>
           </div>
         </div>
 
@@ -1983,8 +1993,8 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
             inline
             tone="query"
             icon="?"
-            title="Loading saved query catalogue..."
-            description="Built-in queries are available while profile-backed saved queries load."
+            title="Loading saved queries..."
+            description="Built-in presets are available while saved queries load from this node profile."
           />
         )}
 
@@ -2006,6 +2016,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
               const binding = scope === 'context' ? undefined : profile?.forSubGraph(catalog.subGraph);
               const color = binding?.color ?? '#38bdf8';
               const label = queryCatalogueGroupLabel(catalog, scope, binding?.displayName);
+              const description = queryCatalogueGroupDescription(catalog);
               const kind = queryCatalogueGroupKind(catalog, scope);
               return (
                 <div
@@ -2019,18 +2030,21 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
                         <span className="v10-cg-query-catalog-kind">{kind}</span>
                         <h4>{label}</h4>
                       </div>
-                      {catalog.description && <p>{catalog.description}</p>}
+                      {description && <p>{description}</p>}
                     </div>
                   </div>
                   <div className="v10-cg-query-list">
                     {catalog.queries.map((q) => {
                       const key = `${q.subGraph}|${q.catalogSlug}|${q.slug}`;
                       const isActive = activeCatalogQueryKey === key && activeQuery === q.sparql;
+                      const chipLabel = q.description ? `${q.name}. ${q.description}` : q.name;
                       return (
                         <button
                           key={key}
                           type="button"
                           className={`v10-cg-query-chip${isActive ? ' active' : ''}`}
+                          title={chipLabel}
+                          aria-label={`Load query: ${chipLabel}`}
                           onClick={() => runCatalogQuery(key, q.sparql)}
                         >
                           <span className="v10-cg-query-chip-title">{q.name}</span>
@@ -2051,8 +2065,8 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
             inline
             tone="query"
             icon="?"
-            title="No profile-saved queries yet."
-            description="Use Save after editing SPARQL to add a reusable context-level query to this catalogue."
+            title="No saved queries yet."
+            description="Use Save after editing SPARQL to keep a reusable query for this Context Graph."
           />
         )}
       </section>

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1590,13 +1590,12 @@ LIMIT 1000`;
 const CONTEXT_GRAPH_QUERY_SUBGRAPH = '__context_graph';
 const USER_QUERY_CATALOG_SLUG = 'ui-saved-queries';
 const USER_QUERY_CATALOG_NAME = 'Saved queries';
-const USER_QUERY_CATALOG_DESCRIPTION = 'Queries saved from the Query tab.';
+const USER_QUERY_CATALOG_DESCRIPTION = 'Queries saved from the Query Catalogue.';
 const PROFILE_NS = 'http://dkg.io/ontology/profile/';
 const SCHEMA_NS = 'http://schema.org/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 type SavedCatalogQuery = QueryCatalog['queries'][number];
-type QueryCatalogueScope = 'all' | 'context' | 'subgraphs';
 
 function sparqlString(value: string): string {
   return JSON.stringify(value);
@@ -1791,6 +1790,12 @@ function queryCatalogueScope(catalog: QueryCatalog): 'context' | 'subgraph' {
   return catalog.subGraph === CONTEXT_GRAPH_QUERY_SUBGRAPH ? 'context' : 'subgraph';
 }
 
+function queryCatalogueGroupLabel(catalog: QueryCatalog, scope: 'context' | 'subgraph', subGraphLabel?: string): string {
+  if (isBuiltInQueryCatalog(catalog)) return 'Built-in context queries';
+  if (scope === 'context') return 'Saved profile queries';
+  return `${subGraphLabel ?? catalog.subGraph}: ${catalog.name}`;
+}
+
 function queryErrorMessage(error: string | null): ReactNode {
   return (
     <>
@@ -1806,7 +1811,6 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
   const [draftQuery, setDraftQuery] = useState(defaultQuery);
   const [activeQuery, setActiveQuery] = useState(defaultQuery);
   const [activeCatalogQueryKey, setActiveCatalogQueryKey] = useState<string | null>(null);
-  const [catalogueScope, setCatalogueScope] = useState<QueryCatalogueScope>('all');
   const [localSavedCatalogs, setLocalSavedCatalogs] = useState<QueryCatalog[]>([]);
   const [saveOpen, setSaveOpen] = useState(false);
   const [saveName, setSaveName] = useState('');
@@ -1824,7 +1828,6 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
     setDraftQuery(defaultQuery);
     setActiveQuery(defaultQuery);
     setActiveCatalogQueryKey(null);
-    setCatalogueScope('all');
     setLocalSavedCatalogs([]);
     setSaveOpen(false);
     setSaveName('');
@@ -1844,45 +1847,10 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
     [data],
   );
 
-  const visibleQueryCatalogs = useMemo(
-    () => queryCatalogs.filter((catalog) => {
-      const scope = queryCatalogueScope(catalog);
-      if (catalogueScope === 'context') return scope === 'context';
-      if (catalogueScope === 'subgraphs') return scope === 'subgraph';
-      return true;
-    }),
-    [catalogueScope, queryCatalogs],
+  const hasSavedProfileQueries = useMemo(
+    () => queryCatalogs.some(catalog => !isBuiltInQueryCatalog(catalog) && catalog.queries.length > 0),
+    [queryCatalogs],
   );
-
-  const hasSavedQueriesForSelectedScope = useMemo(
-    () => queryCatalogs.some((catalog) => {
-      if (isBuiltInQueryCatalog(catalog) || catalog.queries.length === 0) return false;
-      const scope = queryCatalogueScope(catalog);
-      if (catalogueScope === 'context') return scope === 'context';
-      if (catalogueScope === 'subgraphs') return scope === 'subgraph';
-      return true;
-    }),
-    [catalogueScope, queryCatalogs],
-  );
-
-  const savedQueryEmptyCopy = useMemo(() => {
-    if (catalogueScope === 'context') {
-      return {
-        title: 'No saved context queries yet.',
-        description: 'Use Save after editing SPARQL to add a reusable context-level query.',
-      };
-    }
-    if (catalogueScope === 'subgraphs') {
-      return {
-        title: 'No saved subgraph queries yet.',
-        description: 'Subgraph-specific saved queries appear when profile metadata includes a subgraph catalogue.',
-      };
-    }
-    return {
-      title: 'No saved profile queries yet.',
-      description: 'Use Save after editing SPARQL to add a reusable query to this catalogue.',
-    };
-  }, [catalogueScope]);
 
   const columns = useMemo(() => {
     const out: string[] = [];
@@ -1898,6 +1866,8 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
     const next = draftQuery.trim();
     if (!next) return;
     setActiveCatalogQueryKey(null);
+    setSaveMessage(null);
+    setSaveError(null);
     if (next === activeQuery) {
       refresh();
       return;
@@ -1908,6 +1878,8 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
   const resetQuery = useCallback(() => {
     setDraftQuery(defaultQuery);
     setActiveCatalogQueryKey(null);
+    setSaveMessage(null);
+    setSaveError(null);
     if (activeQuery === defaultQuery) refresh();
     else setActiveQuery(defaultQuery);
   }, [activeQuery, defaultQuery, refresh]);
@@ -1917,6 +1889,8 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
     if (!next) return;
     setActiveCatalogQueryKey(key);
     setDraftQuery(next);
+    setSaveMessage(null);
+    setSaveError(null);
     if (activeQuery === next) {
       refresh();
       return;
@@ -1956,14 +1930,13 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
       setLocalSavedCatalogs(prev => appendSavedQueryCatalog(prev, query));
       const key = `${query.subGraph}|${query.catalogSlug}|${query.slug}`;
       setActiveCatalogQueryKey(key);
-      setCatalogueScope('context');
       setDraftQuery(query.sparql);
       if (activeQuery === query.sparql) refresh();
       else setActiveQuery(query.sparql);
       setSaveName('');
       setSaveDescription('');
       setSaveOpen(false);
-      setSaveMessage('Saved to catalog.');
+      setSaveMessage('Saved to catalogue.');
     } catch (err: any) {
       setSaveError(err?.message ?? 'Failed to save query.');
     } finally {
@@ -1988,27 +1961,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
           <div>
             <span className="v10-cg-query-eyebrow">Saved Queries</span>
             <h3 id="query-catalogue-saved-title">Reusable query catalogue</h3>
-            <p>Named, described SPARQL saved in this node profile to run again.</p>
-          </div>
-          <div className="v10-cg-query-scope">
-            <span className="v10-cg-query-scope-label">Catalogue scope</span>
-            <div className="v10-cg-query-scope-control" role="group" aria-label="Catalogue scope">
-              {([
-                ['all', 'All'],
-                ['context', 'Context graph'],
-                ['subgraphs', 'Subgraphs'],
-              ] as Array<[QueryCatalogueScope, string]>).map(([scope, label]) => (
-                <button
-                  key={scope}
-                  type="button"
-                  className={catalogueScope === scope ? 'active' : ''}
-                  aria-pressed={catalogueScope === scope}
-                  onClick={() => setCatalogueScope(scope)}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
+            <p>Built-in queries and saved profile queries. Save creates a reusable context-level query in this node profile.</p>
           </div>
         </div>
 
@@ -2034,21 +1987,21 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
           />
         )}
 
-        {visibleQueryCatalogs.length === 0 && !profile?.loading && !profile?.error ? (
+        {queryCatalogs.length === 0 && !profile?.loading && !profile?.error ? (
           <EmptyState
             compact
             tone="query"
             icon="?"
-            title={catalogueScope === 'subgraphs' ? 'No subgraph saved queries yet.' : 'No saved queries yet.'}
+            title="No saved queries yet."
             description="Saved queries will appear here once a profile or agent adds them."
           />
-        ) : visibleQueryCatalogs.length > 0 ? (
+        ) : queryCatalogs.length > 0 ? (
           <div className="v10-cg-query-catalog-groups">
-            {visibleQueryCatalogs.map((catalog) => {
+            {queryCatalogs.map((catalog) => {
               const scope = queryCatalogueScope(catalog);
               const binding = scope === 'context' ? undefined : profile?.forSubGraph(catalog.subGraph);
               const color = binding?.color ?? '#38bdf8';
-              const label = scope === 'context' ? catalog.name : `${binding?.displayName ?? catalog.subGraph}: ${catalog.name}`;
+              const label = queryCatalogueGroupLabel(catalog, scope, binding?.displayName);
               return (
                 <div
                   key={`${catalog.subGraph}|${catalog.slug}`}
@@ -2056,7 +2009,6 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
                   style={{ '--sg-color': color } as React.CSSProperties}
                 >
                   <div className="v10-cg-query-catalog-group-header">
-                    <span className="v10-cg-query-scope-badge">{scope === 'context' ? 'Context graph' : 'Subgraph'}</span>
                     <div>
                       <h4>{label}</h4>
                       {catalog.description && <p>{catalog.description}</p>}
@@ -2085,14 +2037,14 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
           </div>
         ) : null}
 
-        {!profile?.loading && !profile?.error && visibleQueryCatalogs.length > 0 && !hasSavedQueriesForSelectedScope && (
+        {!profile?.loading && !profile?.error && queryCatalogs.length > 0 && !hasSavedProfileQueries && (
           <EmptyState
             compact
             inline
             tone="query"
             icon="?"
-            title={savedQueryEmptyCopy.title}
-            description={savedQueryEmptyCopy.description}
+            title="No saved profile queries yet."
+            description="Use Save after editing SPARQL to add a reusable context-level query to this catalogue."
           />
         )}
       </section>

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1824,8 +1824,8 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
     [builtInCatalog, localSavedCatalogs, profile?.queryCatalogs],
   );
   const renderedQueryCatalogs = useMemo(
-    () => (profile?.loading || profile?.error ? [builtInCatalog] : queryCatalogs),
-    [builtInCatalog, profile?.error, profile?.loading, queryCatalogs],
+    () => (profile?.loading || profile?.error ? [builtInCatalog, ...localSavedCatalogs] : queryCatalogs),
+    [builtInCatalog, localSavedCatalogs, profile?.error, profile?.loading, queryCatalogs],
   );
 
   useEffect(() => {

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1596,6 +1596,7 @@ const SCHEMA_NS = 'http://schema.org/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 type SavedCatalogQuery = QueryCatalog['queries'][number];
+type QueryCatalogueScope = 'all' | 'context' | 'subgraphs';
 
 function sparqlString(value: string): string {
   return JSON.stringify(value);
@@ -1615,7 +1616,7 @@ function contextGraphQueryFilter(contextGraphId: string): string {
 
 function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
   const catalogSlug = 'whole-context-graph';
-  const catalogName = 'Whole graph';
+  const catalogName = 'Context graph';
   const catalogRank = -100;
   const subGraph = CONTEXT_GRAPH_QUERY_SUBGRAPH;
   const withQueryDefaults = (query: {
@@ -1629,7 +1630,7 @@ function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
     subGraph,
     catalogSlug,
     catalogName,
-    catalogDescription: 'Built-in queries for the full context graph.',
+    catalogDescription: 'Built-in queries for every public graph in this Context Graph.',
     catalogRank,
     resultColumn: '',
     ...query,
@@ -1639,7 +1640,7 @@ function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
     slug: catalogSlug,
     subGraph,
     name: catalogName,
-    description: 'Built-in queries for the full context graph.',
+    description: 'Built-in queries for every public graph in this Context Graph.',
     rank: catalogRank,
     queries: [
       withQueryDefaults({
@@ -1782,12 +1783,30 @@ function shortenBindingValue(value: string): string {
   return `${value.slice(0, 110)}...${value.slice(-24)}`;
 }
 
+function isBuiltInQueryCatalog(catalog: QueryCatalog): boolean {
+  return catalog.subGraph === CONTEXT_GRAPH_QUERY_SUBGRAPH && catalog.slug === 'whole-context-graph';
+}
+
+function queryCatalogueScope(catalog: QueryCatalog): 'context' | 'subgraph' {
+  return catalog.subGraph === CONTEXT_GRAPH_QUERY_SUBGRAPH ? 'context' : 'subgraph';
+}
+
+function queryErrorMessage(error: string | null): ReactNode {
+  return (
+    <>
+      <span>Check the SPARQL syntax or try again after the node recovers.</span>
+      {error && <span className="v10-cg-query-error-detail">{error}</span>}
+    </>
+  );
+}
+
 export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: string }) {
   const profile = useProjectProfileContext();
   const defaultQuery = useMemo(() => contextGraphQueryTemplate(contextGraphId), [contextGraphId]);
   const [draftQuery, setDraftQuery] = useState(defaultQuery);
   const [activeQuery, setActiveQuery] = useState(defaultQuery);
   const [activeCatalogQueryKey, setActiveCatalogQueryKey] = useState<string | null>(null);
+  const [catalogueScope, setCatalogueScope] = useState<QueryCatalogueScope>('all');
   const [localSavedCatalogs, setLocalSavedCatalogs] = useState<QueryCatalog[]>([]);
   const [saveOpen, setSaveOpen] = useState(false);
   const [saveName, setSaveName] = useState('');
@@ -1805,6 +1824,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
     setDraftQuery(defaultQuery);
     setActiveQuery(defaultQuery);
     setActiveCatalogQueryKey(null);
+    setCatalogueScope('all');
     setLocalSavedCatalogs([]);
     setSaveOpen(false);
     setSaveName('');
@@ -1822,6 +1842,21 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
   const rows = useMemo(
     () => (data as any)?.result?.bindings ?? (data as any)?.results?.bindings ?? [],
     [data],
+  );
+
+  const visibleQueryCatalogs = useMemo(
+    () => queryCatalogs.filter((catalog) => {
+      const scope = queryCatalogueScope(catalog);
+      if (catalogueScope === 'context') return scope === 'context';
+      if (catalogueScope === 'subgraphs') return scope === 'subgraph';
+      return true;
+    }),
+    [catalogueScope, queryCatalogs],
+  );
+
+  const hasTeamSavedQueries = useMemo(
+    () => queryCatalogs.some(catalog => !isBuiltInQueryCatalog(catalog) && catalog.queries.length > 0),
+    [queryCatalogs],
   );
 
   const columns = useMemo(() => {
@@ -1915,52 +1950,140 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
       <div className="v10-mlv-header">
         <span className="v10-mlv-icon">⟐</span>
         <div>
-          <h2 className="v10-mlv-title">Context Graph Query</h2>
-          <p className="v10-mlv-desc">Run SPARQL against the full context graph, across sub-graphs and memory layers.</p>
+          <h2 className="v10-mlv-title">Query Catalogue</h2>
+          <p className="v10-mlv-desc">
+            Reusable SPARQL queries for this Context Graph. People and agents can save queries here, then load them back into the editor.
+          </p>
         </div>
       </div>
 
-      <div className="v10-cg-query-catalog">
-        <span className="v10-subgraph-savedqueries-label">Query catalog</span>
-        {queryCatalogs.map((catalog) => {
-          const isBuiltIn = catalog.subGraph === CONTEXT_GRAPH_QUERY_SUBGRAPH;
-          const binding = isBuiltIn ? undefined : profile?.forSubGraph(catalog.subGraph);
-          const color = binding?.color ?? '#38bdf8';
-          const label = isBuiltIn ? catalog.name : `${binding?.displayName ?? catalog.subGraph}: ${catalog.name}`;
-          return (
-            <React.Fragment key={`${catalog.subGraph}|${catalog.slug}`}>
-              <span
-                className="v10-subgraph-savedqueries-label"
-                title={catalog.description || label}
-                style={{ marginLeft: 8, opacity: 0.8 }}
-              >
-                {label}
-              </span>
-              {catalog.queries.map((q) => {
-                const key = `${q.subGraph}|${q.catalogSlug}|${q.slug}`;
-                const isActive = activeCatalogQueryKey === key && activeQuery === q.sparql;
-                return (
-                  <button
-                    key={key}
-                    type="button"
-                    className={`v10-subgraph-savedquery${isActive ? ' active' : ''}`}
-                    onClick={() => runCatalogQuery(key, q.sparql)}
-                    title={q.description || q.name}
-                    style={{ '--sg-color': color } as React.CSSProperties}
-                  >
-                    <span className="v10-subgraph-savedquery-glyph">{isActive ? '✓' : '◎'}</span>
-                    {q.name}
-                  </button>
-                );
-              })}
-            </React.Fragment>
-          );
-        })}
-      </div>
+      <section className="v10-cg-query-zone v10-cg-query-zone-catalog" aria-labelledby="query-catalogue-saved-title">
+        <div className="v10-cg-query-zone-header">
+          <div>
+            <span className="v10-cg-query-eyebrow">Saved Queries</span>
+            <h3 id="query-catalogue-saved-title">Reusable query catalogue</h3>
+            <p>Named, described SPARQL saved for people and agents to run again.</p>
+          </div>
+          <div className="v10-cg-query-scope">
+            <span className="v10-cg-query-scope-label">Catalogue scope</span>
+            <div className="v10-cg-query-scope-control" role="group" aria-label="Catalogue scope">
+              {([
+                ['all', 'All'],
+                ['context', 'Context graph'],
+                ['subgraphs', 'Subgraphs'],
+              ] as Array<[QueryCatalogueScope, string]>).map(([scope, label]) => (
+                <button
+                  key={scope}
+                  type="button"
+                  className={catalogueScope === scope ? 'active' : ''}
+                  aria-pressed={catalogueScope === scope}
+                  onClick={() => setCatalogueScope(scope)}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {profile?.loading && (
+          <EmptyState
+            compact
+            inline
+            tone="query"
+            icon="?"
+            title="Loading saved query catalogue..."
+            description="Built-in queries are available while profile-backed saved queries load."
+          />
+        )}
+
+        {profile?.error && (
+          <EmptyState
+            compact
+            inline
+            tone="danger"
+            icon="!"
+            title="Saved query catalogue unavailable"
+            description={profile.error}
+          />
+        )}
+
+        {visibleQueryCatalogs.length === 0 && !profile?.loading && !profile?.error ? (
+          <EmptyState
+            compact
+            tone="query"
+            icon="?"
+            title={catalogueScope === 'subgraphs' ? 'No subgraph saved queries yet.' : 'No saved queries yet.'}
+            description="Saved queries will appear here once a profile or agent adds them."
+          />
+        ) : visibleQueryCatalogs.length > 0 ? (
+          <div className="v10-cg-query-catalog-groups">
+            {visibleQueryCatalogs.map((catalog) => {
+              const scope = queryCatalogueScope(catalog);
+              const binding = scope === 'context' ? undefined : profile?.forSubGraph(catalog.subGraph);
+              const color = binding?.color ?? '#38bdf8';
+              const label = scope === 'context' ? catalog.name : `${binding?.displayName ?? catalog.subGraph}: ${catalog.name}`;
+              return (
+                <div
+                  key={`${catalog.subGraph}|${catalog.slug}`}
+                  className="v10-cg-query-catalog-group"
+                  style={{ '--sg-color': color } as React.CSSProperties}
+                >
+                  <div className="v10-cg-query-catalog-group-header">
+                    <span className="v10-cg-query-scope-badge">{scope === 'context' ? 'Context graph' : 'Subgraph'}</span>
+                    <div>
+                      <h4>{label}</h4>
+                      {catalog.description && <p>{catalog.description}</p>}
+                    </div>
+                  </div>
+                  <div className="v10-cg-query-list">
+                    {catalog.queries.map((q) => {
+                      const key = `${q.subGraph}|${q.catalogSlug}|${q.slug}`;
+                      const isActive = activeCatalogQueryKey === key && activeQuery === q.sparql;
+                      return (
+                        <button
+                          key={key}
+                          type="button"
+                          className={`v10-cg-query-chip${isActive ? ' active' : ''}`}
+                          onClick={() => runCatalogQuery(key, q.sparql)}
+                        >
+                          <span className="v10-cg-query-chip-title">{q.name}</span>
+                          {q.description && <span className="v10-cg-query-chip-desc">{q.description}</span>}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+
+        {!profile?.loading && !profile?.error && !hasTeamSavedQueries && catalogueScope !== 'subgraphs' && (
+          <EmptyState
+            compact
+            inline
+            tone="query"
+            icon="?"
+            title="No team-saved queries yet."
+            description="Use Save after editing SPARQL to add a reusable query to this catalogue."
+          />
+        )}
+      </section>
+
+      <section className="v10-cg-query-zone v10-cg-query-zone-editor" aria-labelledby="query-catalogue-editor-title">
+        <div className="v10-cg-query-zone-header">
+          <div>
+            <span className="v10-cg-query-eyebrow">Ad-hoc SPARQL</span>
+            <h3 id="query-catalogue-editor-title">Editor and results</h3>
+            <p>Run a one-off query against this Context Graph, or save it when it should become reusable.</p>
+          </div>
+        </div>
 
       <div className="v10-cg-query-editor">
         <textarea
           className="v10-cg-query-textarea"
+          aria-label="SPARQL editor"
           value={draftQuery}
           onChange={(e) => {
             setDraftQuery(e.target.value);
@@ -2021,8 +2144,8 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
             compact
             tone="danger"
             icon="!"
-            title="Query failed"
-            description={error}
+            title="Query could not run."
+            description={queryErrorMessage(error)}
           />
         )}
 
@@ -2065,6 +2188,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
           </div>
         )}
       </div>
+      </section>
     </div>
   );
 }

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1987,15 +1987,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
           />
         )}
 
-        {queryCatalogs.length === 0 && !profile?.loading && !profile?.error ? (
-          <EmptyState
-            compact
-            tone="query"
-            icon="?"
-            title="No saved queries yet."
-            description="Saved queries will appear here once a profile or agent adds them."
-          />
-        ) : queryCatalogs.length > 0 ? (
+        {!profile?.loading && !profile?.error && (
           <div className="v10-cg-query-catalog-groups">
             {queryCatalogs.map((catalog) => {
               const scope = queryCatalogueScope(catalog);
@@ -2035,7 +2027,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
               );
             })}
           </div>
-        ) : null}
+        )}
 
         {!profile?.loading && !profile?.error && queryCatalogs.length > 0 && !hasSavedProfileQueries && (
           <EmptyState

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1769,6 +1769,39 @@ function appendSavedQueryCatalog(catalogs: QueryCatalog[], query: SavedCatalogQu
   ];
 }
 
+function mergeQueryCatalogs(catalogs: QueryCatalog[]): QueryCatalog[] {
+  const byCatalog = new Map<string, QueryCatalog>();
+
+  for (const catalog of catalogs) {
+    const catalogKey = `${catalog.subGraph}|${catalog.slug}`;
+    const existing = byCatalog.get(catalogKey);
+    if (!existing) {
+      byCatalog.set(catalogKey, {
+        ...catalog,
+        queries: [...catalog.queries],
+      });
+      continue;
+    }
+
+    const byQuery = new Map(existing.queries.map(query => [
+      `${query.subGraph}|${query.catalogSlug}|${query.slug}`,
+      query,
+    ]));
+    for (const query of catalog.queries) {
+      const queryKey = `${query.subGraph}|${query.catalogSlug}|${query.slug}`;
+      if (!byQuery.has(queryKey)) byQuery.set(queryKey, query);
+    }
+    existing.queries = Array.from(byQuery.values())
+      .sort((a, b) => a.rank - b.rank || a.name.localeCompare(b.name));
+  }
+
+  return Array.from(byCatalog.values()).sort((a, b) =>
+    a.subGraph.localeCompare(b.subGraph)
+    || a.rank - b.rank
+    || a.name.localeCompare(b.name),
+  );
+}
+
 function bindingValue(v: unknown): string {
   if (v == null) return '';
   if (typeof v === 'string') return v;
@@ -1838,11 +1871,11 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const builtInCatalog = useMemo(() => contextGraphBuiltInCatalog(contextGraphId), [contextGraphId]);
   const queryCatalogs = useMemo(
-    () => [builtInCatalog, ...localSavedCatalogs, ...(profile?.queryCatalogs ?? [])],
+    () => mergeQueryCatalogs([builtInCatalog, ...localSavedCatalogs, ...(profile?.queryCatalogs ?? [])]),
     [builtInCatalog, localSavedCatalogs, profile?.queryCatalogs],
   );
   const renderedQueryCatalogs = useMemo(
-    () => (profile?.loading || profile?.error ? [builtInCatalog, ...localSavedCatalogs] : queryCatalogs),
+    () => (profile?.loading || profile?.error ? mergeQueryCatalogs([builtInCatalog, ...localSavedCatalogs]) : queryCatalogs),
     [builtInCatalog, localSavedCatalogs, profile?.error, profile?.loading, queryCatalogs],
   );
 

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1792,7 +1792,7 @@ function queryCatalogueScope(catalog: QueryCatalog): 'context' | 'subgraph' {
 
 function queryCatalogueGroupLabel(catalog: QueryCatalog, scope: 'context' | 'subgraph', subGraphLabel?: string): string {
   if (isBuiltInQueryCatalog(catalog)) return 'Built-in context queries';
-  if (scope === 'context') return 'Saved profile queries';
+  if (scope === 'context') return catalog.name;
   return `${subGraphLabel ?? catalog.subGraph}: ${catalog.name}`;
 }
 

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1630,7 +1630,7 @@ function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
     subGraph,
     catalogSlug,
     catalogName,
-    catalogDescription: 'Built-in queries for every public graph in this Context Graph.',
+    catalogDescription: 'Built-in queries for available non-private graphs in this Context Graph.',
     catalogRank,
     resultColumn: '',
     ...query,
@@ -1640,13 +1640,13 @@ function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
     slug: catalogSlug,
     subGraph,
     name: catalogName,
-    description: 'Built-in queries for every public graph in this Context Graph.',
+    description: 'Built-in queries for available non-private graphs in this Context Graph.',
     rank: catalogRank,
     queries: [
       withQueryDefaults({
         slug: 'all-triples',
         name: 'All triples',
-        description: 'Show triples across every public graph in this context graph.',
+        description: 'Show triples across available non-private graphs in this context graph.',
         sparql: contextGraphQueryTemplate(contextGraphId),
         resultColumn: 'o',
         rank: 1,
@@ -1654,7 +1654,7 @@ function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
       withQueryDefaults({
         slug: 'graphs',
         name: 'Graphs',
-        description: 'List public named graphs and triple counts.',
+        description: 'List available non-private named graphs and triple counts.',
         sparql: `SELECT ?g (COUNT(*) AS ?triples) WHERE {
   GRAPH ?g { ?s ?p ?o }
   ${contextGraphQueryFilter(contextGraphId)}
@@ -1854,10 +1854,35 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
     [catalogueScope, queryCatalogs],
   );
 
-  const hasTeamSavedQueries = useMemo(
-    () => queryCatalogs.some(catalog => !isBuiltInQueryCatalog(catalog) && catalog.queries.length > 0),
-    [queryCatalogs],
+  const hasSavedQueriesForSelectedScope = useMemo(
+    () => queryCatalogs.some((catalog) => {
+      if (isBuiltInQueryCatalog(catalog) || catalog.queries.length === 0) return false;
+      const scope = queryCatalogueScope(catalog);
+      if (catalogueScope === 'context') return scope === 'context';
+      if (catalogueScope === 'subgraphs') return scope === 'subgraph';
+      return true;
+    }),
+    [catalogueScope, queryCatalogs],
   );
+
+  const savedQueryEmptyCopy = useMemo(() => {
+    if (catalogueScope === 'context') {
+      return {
+        title: 'No saved context queries yet.',
+        description: 'Use Save after editing SPARQL to add a reusable context-level query.',
+      };
+    }
+    if (catalogueScope === 'subgraphs') {
+      return {
+        title: 'No saved subgraph queries yet.',
+        description: 'Subgraph-specific saved queries appear when profile metadata includes a subgraph catalogue.',
+      };
+    }
+    return {
+      title: 'No saved profile queries yet.',
+      description: 'Use Save after editing SPARQL to add a reusable query to this catalogue.',
+    };
+  }, [catalogueScope]);
 
   const columns = useMemo(() => {
     const out: string[] = [];
@@ -1931,6 +1956,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
       setLocalSavedCatalogs(prev => appendSavedQueryCatalog(prev, query));
       const key = `${query.subGraph}|${query.catalogSlug}|${query.slug}`;
       setActiveCatalogQueryKey(key);
+      setCatalogueScope('context');
       setDraftQuery(query.sparql);
       if (activeQuery === query.sparql) refresh();
       else setActiveQuery(query.sparql);
@@ -2059,14 +2085,14 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
           </div>
         ) : null}
 
-        {!profile?.loading && !profile?.error && !hasTeamSavedQueries && catalogueScope !== 'subgraphs' && (
+        {!profile?.loading && !profile?.error && visibleQueryCatalogs.length > 0 && !hasSavedQueriesForSelectedScope && (
           <EmptyState
             compact
             inline
             tone="query"
             icon="?"
-            title="No saved profile queries yet."
-            description="Use Save after editing SPARQL to add a reusable query to this catalogue."
+            title={savedQueryEmptyCopy.title}
+            description={savedQueryEmptyCopy.description}
           />
         )}
       </section>

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1823,6 +1823,10 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
     () => [builtInCatalog, ...localSavedCatalogs, ...(profile?.queryCatalogs ?? [])],
     [builtInCatalog, localSavedCatalogs, profile?.queryCatalogs],
   );
+  const renderedQueryCatalogs = useMemo(
+    () => (profile?.loading || profile?.error ? [builtInCatalog] : queryCatalogs),
+    [builtInCatalog, profile?.error, profile?.loading, queryCatalogs],
+  );
 
   useEffect(() => {
     setDraftQuery(defaultQuery);
@@ -1987,9 +1991,9 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
           />
         )}
 
-        {!profile?.loading && !profile?.error && (
+        {renderedQueryCatalogs.length > 0 && (
           <div className="v10-cg-query-catalog-groups">
-            {queryCatalogs.map((catalog) => {
+            {renderedQueryCatalogs.map((catalog) => {
               const scope = queryCatalogueScope(catalog);
               const binding = scope === 'context' ? undefined : profile?.forSubGraph(catalog.subGraph);
               const color = binding?.color ?? '#38bdf8';

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1794,7 +1794,7 @@ function queryCatalogueScope(catalog: QueryCatalog): 'context' | 'subgraph' {
 function queryErrorMessage(error: string | null): ReactNode {
   return (
     <>
-      <span>Check the SPARQL syntax or try again after the node recovers.</span>
+      <span>Review the query or node response details, then try again.</span>
       {error && <span className="v10-cg-query-error-detail">{error}</span>}
     </>
   );
@@ -1952,7 +1952,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
         <div>
           <h2 className="v10-mlv-title">Query Catalogue</h2>
           <p className="v10-mlv-desc">
-            Reusable SPARQL queries for this Context Graph. People and agents can save queries here, then load them back into the editor.
+            Profile-backed reusable SPARQL queries for this Context Graph. Save queries here, then load them back into the editor.
           </p>
         </div>
       </div>
@@ -1962,7 +1962,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
           <div>
             <span className="v10-cg-query-eyebrow">Saved Queries</span>
             <h3 id="query-catalogue-saved-title">Reusable query catalogue</h3>
-            <p>Named, described SPARQL saved for people and agents to run again.</p>
+            <p>Named, described SPARQL saved in this node profile to run again.</p>
           </div>
           <div className="v10-cg-query-scope">
             <span className="v10-cg-query-scope-label">Catalogue scope</span>
@@ -2065,7 +2065,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
             inline
             tone="query"
             icon="?"
-            title="No team-saved queries yet."
+            title="No saved profile queries yet."
             description="Use Save after editing SPARQL to add a reusable query to this catalogue."
           />
         )}

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -283,6 +283,47 @@ describe('ContextGraphQueryView', () => {
     await act(async () => { root.unmount(); });
   });
 
+  it('keeps local saves visible while profile queries are loading', async () => {
+    const { container, root } = await renderWithProfile(profile({ loading: true }));
+
+    await waitForText(container, 'Loading saved query catalogue...');
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await act(async () => {
+      setFieldValue(textarea, 'SELECT ?entity WHERE { ?entity ?p ?o } LIMIT 5');
+    });
+
+    const saveButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Save');
+    expect(saveButton).toBeTruthy();
+
+    await act(async () => {
+      saveButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const nameInput = container.querySelector('input[placeholder="Query name"]') as HTMLInputElement;
+    const descriptionInput = container.querySelector('input[placeholder="Optional"]') as HTMLInputElement;
+    await act(async () => {
+      setFieldValue(nameInput, 'Loading-safe query');
+      setFieldValue(descriptionInput, 'Visible before profile data returns.');
+    });
+
+    const submitButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Save query');
+    expect(submitButton).toBeTruthy();
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await waitForText(container, 'Saved to catalogue.');
+    expect(container.textContent).toContain('All triples');
+    expect(container.textContent).toContain('Loading-safe query');
+    expect(container.textContent).toContain('Visible before profile data returns.');
+
+    await act(async () => { root.unmount(); });
+  });
+
   it('renders query failures as a friendly EmptyState', async () => {
     apiMocks.executeQuery.mockRejectedValueOnce(new Error('HTTP 500'));
     const { container, root } = await renderWithProfile(profile());

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -261,7 +261,28 @@ describe('ContextGraphQueryView', () => {
   });
 
   it('saves the draft query into the local catalogue', async () => {
-    const { container, root } = await renderWithProfile(profile());
+    const { container, root } = await renderWithProfile(profile({
+      queryCatalogs: [{
+        slug: 'ui-saved-queries',
+        subGraph: '__context_graph',
+        name: 'Saved queries',
+        description: 'User-created SPARQL saved in this node profile for this Context Graph.',
+        rank: 50,
+        queries: [{
+          slug: 'existing-query',
+          subGraph: '__context_graph',
+          catalogSlug: 'ui-saved-queries',
+          catalogName: 'Saved queries',
+          catalogDescription: 'User-created SPARQL saved in this node profile for this Context Graph.',
+          catalogRank: 50,
+          name: 'Existing saved query',
+          description: 'Already persisted.',
+          sparql: 'SELECT ?type WHERE { GRAPH ?g { ?s a ?type } }',
+          resultColumn: 'type',
+          rank: 1,
+        }],
+      }],
+    }));
 
     await waitForText(container, 'Query Catalogue');
 
@@ -295,7 +316,10 @@ describe('ContextGraphQueryView', () => {
 
     await waitForText(container, 'Saved to catalogue.');
     expect(apiMocks.writeProfileQueryCatalog).toHaveBeenCalledWith('cg-test', expect.any(Array));
-    expect(container.textContent).toContain('Saved queries');
+    const savedHeadings = Array.from(container.querySelectorAll('h4'))
+      .filter(heading => heading.textContent === 'Saved queries');
+    expect(savedHeadings).toHaveLength(1);
+    expect(container.textContent).toContain('Existing saved query');
     expect(container.textContent).toContain('Reusable triples');
     expect(container.textContent).toContain('A reusable triples query.');
 

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -131,6 +131,25 @@ describe('ContextGraphQueryView', () => {
   it('groups saved queries and loads the selected query into the editor', async () => {
     const savedProfile = profile({
       queryCatalogs: [{
+        slug: 'personal',
+        subGraph: '__context_graph',
+        name: 'Personal research',
+        description: 'Context-level profile queries.',
+        rank: 1,
+        queries: [{
+          slug: 'entity-counts',
+          subGraph: '__context_graph',
+          catalogSlug: 'personal',
+          catalogName: 'Personal research',
+          catalogDescription: 'Context-level profile queries.',
+          catalogRank: 1,
+          name: 'Entity counts',
+          description: 'Count reusable context entities.',
+          sparql: 'SELECT (COUNT(?s) AS ?count) WHERE { GRAPH ?g { ?s ?p ?o } }',
+          resultColumn: 'count',
+          rank: 1,
+        }],
+      }, {
         slug: 'research',
         subGraph: 'docs',
         name: 'Document research',
@@ -153,6 +172,9 @@ describe('ContextGraphQueryView', () => {
     });
     const { container, root } = await renderWithProfile(savedProfile);
 
+    await waitForText(container, 'Personal research');
+    expect(container.textContent).toContain('Context-level profile queries.');
+    expect(container.textContent).not.toContain('Saved profile queries');
     await waitForText(container, 'Documents: Document research');
     expect(container.textContent).toContain('Queries for document-backed entities.');
     expect(container.textContent).toContain('List markdown-backed document entities.');

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -120,15 +120,18 @@ describe('ContextGraphQueryView', () => {
       .filter(Boolean);
 
     expect(container.querySelector('h2.v10-mlv-title')?.textContent).toBe('Query Catalogue');
-    expect(container.querySelector('#query-catalogue-saved-title')?.textContent).toBe('Reusable query catalogue');
+    expect(container.querySelector('#query-catalogue-saved-title')?.textContent).toBe('Choose a query');
     expect(container.querySelector('#query-catalogue-editor-title')?.textContent).toBe('Editor and results');
     expect(container.querySelector('textarea')).toBeTruthy();
     expect(buttonLabels.some(label => label?.startsWith('All triples'))).toBe(true);
     expect(buttonLabels.some(label => label?.startsWith('Graphs'))).toBe(true);
     expect(buttonLabels.some(label => label?.startsWith('Types'))).toBe(true);
     expect(buttonLabels).toEqual(expect.arrayContaining(['Run', 'Save', 'Reset']));
-    expect(container.textContent).toContain('Profile-backed reusable SPARQL queries for this Context Graph');
+    expect(container.textContent).toContain('Reusable SPARQL for this Context Graph');
+    expect(container.textContent).toContain('Selecting a query loads it into the editor below.');
+    expect(container.textContent).toContain('Built-in presets');
     expect(container.textContent).not.toContain('Catalogue scope');
+    expect(container.textContent).not.toContain('Built-in context queries');
 
     await act(async () => { root.unmount(); });
   });
@@ -180,7 +183,10 @@ describe('ContextGraphQueryView', () => {
     await waitForText(container, 'Personal research');
     expect(container.textContent).toContain('Context-level profile queries.');
     expect(container.textContent).not.toContain('Saved profile queries');
+    expect(container.textContent).toContain('Built in');
+    expect(container.textContent).toContain('Saved');
     await waitForText(container, 'Documents: Document research');
+    expect(container.textContent).toContain('Subgraph');
     expect(container.textContent).toContain('Queries for document-backed entities.');
     expect(container.textContent).toContain('List markdown-backed document entities.');
 
@@ -203,14 +209,14 @@ describe('ContextGraphQueryView', () => {
 
     await waitForText(container, 'Loading saved query catalogue...');
     expect(container.textContent).toContain('All triples');
-    expect(container.textContent).not.toContain('No saved profile queries yet.');
+    expect(container.textContent).not.toContain('No profile-saved queries yet.');
 
     await act(async () => { root.unmount(); });
     document.body.innerHTML = '';
 
     const emptyRender = await renderWithProfile(profile());
     const { container: emptyContainer, root: emptyRoot } = emptyRender;
-    expect(emptyContainer.textContent).toContain('No saved profile queries yet.');
+    expect(emptyContainer.textContent).toContain('No profile-saved queries yet.');
 
     await act(async () => { emptyRoot.unmount(); });
   });
@@ -222,7 +228,7 @@ describe('ContextGraphQueryView', () => {
 
     expect(container.textContent).toContain('Profile query failed');
     expect(container.textContent).toContain('All triples');
-    expect(container.textContent).not.toContain('No saved profile queries yet.');
+    expect(container.textContent).not.toContain('No profile-saved queries yet.');
 
     await act(async () => { root.unmount(); });
   });
@@ -262,6 +268,7 @@ describe('ContextGraphQueryView', () => {
 
     await waitForText(container, 'Saved to catalogue.');
     expect(apiMocks.writeProfileQueryCatalog).toHaveBeenCalledWith('cg-test', expect.any(Array));
+    expect(container.textContent).toContain('Profile-saved queries');
     expect(container.textContent).toContain('Reusable triples');
     expect(container.textContent).toContain('A reusable triples query.');
 

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -115,13 +115,13 @@ describe('ContextGraphQueryView', () => {
 
     await waitForText(container, 'Query Catalogue');
 
-    expect(container.textContent).toContain('Reusable SPARQL queries for this Context Graph');
+    expect(container.textContent).toContain('Profile-backed reusable SPARQL queries for this Context Graph');
     expect(container.textContent).toContain('Saved Queries');
     expect(container.textContent).toContain('Reusable query catalogue');
     expect(container.textContent).toContain('Catalogue scope');
     expect(container.textContent).toContain('Ad-hoc SPARQL');
     expect(container.textContent).toContain('Editor and results');
-    expect(container.textContent).toContain('No team-saved queries yet.');
+    expect(container.textContent).toContain('No saved profile queries yet.');
 
     await act(async () => { root.unmount(); });
   });
@@ -210,7 +210,7 @@ describe('ContextGraphQueryView', () => {
     await waitForText(container, 'Saved query catalogue unavailable');
 
     expect(container.textContent).toContain('Profile query failed');
-    expect(container.textContent).not.toContain('No team-saved queries yet.');
+    expect(container.textContent).not.toContain('No saved profile queries yet.');
 
     await act(async () => { root.unmount(); });
   });
@@ -262,7 +262,7 @@ describe('ContextGraphQueryView', () => {
 
     await waitForText(container, 'Query could not run.');
 
-    expect(container.textContent).toContain('Check the SPARQL syntax or try again after the node recovers.');
+    expect(container.textContent).toContain('Review the query or node response details, then try again.');
     expect(container.textContent).toContain('HTTP 500');
 
     await act(async () => { root.unmount(); });

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -128,7 +128,7 @@ describe('ContextGraphQueryView', () => {
     expect(buttonLabels.some(label => label?.startsWith('Types'))).toBe(true);
     expect(buttonLabels).toEqual(expect.arrayContaining(['Run', 'Save', 'Reset']));
     expect(container.textContent).toContain('Reusable SPARQL for this Context Graph');
-    expect(container.textContent).toContain('Selecting a query loads it into the editor below.');
+    expect(container.textContent).toContain('Load a preset or saved query into the editor below.');
     expect(container.textContent).toContain('Built-in presets');
     expect(container.textContent).not.toContain('Catalogue scope');
     expect(container.textContent).not.toContain('Built-in context queries');
@@ -139,22 +139,41 @@ describe('ContextGraphQueryView', () => {
   it('groups saved queries and loads the selected query into the editor', async () => {
     const savedProfile = profile({
       queryCatalogs: [{
-        slug: 'personal',
+        slug: 'ui-saved-queries',
         subGraph: '__context_graph',
-        name: 'Personal research',
-        description: 'Context-level profile queries.',
+        name: 'Old saved-query title',
+        description: 'Queries saved from the Query tab.',
         rank: 1,
         queries: [{
           slug: 'entity-counts',
           subGraph: '__context_graph',
-          catalogSlug: 'personal',
-          catalogName: 'Personal research',
-          catalogDescription: 'Context-level profile queries.',
+          catalogSlug: 'ui-saved-queries',
+          catalogName: 'Old saved-query title',
+          catalogDescription: 'Queries saved from the Query tab.',
           catalogRank: 1,
           name: 'Entity counts',
-          description: 'Count reusable context entities.',
+          description: 'Count reusable context entities with a long enough description to need a tooltip.',
           sparql: 'SELECT (COUNT(?s) AS ?count) WHERE { GRAPH ?g { ?s ?p ?o } }',
           resultColumn: 'count',
+          rank: 1,
+        }],
+      }, {
+        slug: 'personal',
+        subGraph: '__context_graph',
+        name: 'Personal research',
+        description: 'Custom context-level query set.',
+        rank: 2,
+        queries: [{
+          slug: 'named-entities',
+          subGraph: '__context_graph',
+          catalogSlug: 'personal',
+          catalogName: 'Personal research',
+          catalogDescription: 'Custom context-level query set.',
+          catalogRank: 2,
+          name: 'Named entities',
+          description: 'Find entities that have names.',
+          sparql: 'SELECT ?s ?name WHERE { GRAPH ?g { ?s <http://schema.org/name> ?name } }',
+          resultColumn: 's',
           rank: 1,
         }],
       }, {
@@ -180,15 +199,23 @@ describe('ContextGraphQueryView', () => {
     });
     const { container, root } = await renderWithProfile(savedProfile);
 
-    await waitForText(container, 'Personal research');
-    expect(container.textContent).toContain('Context-level profile queries.');
-    expect(container.textContent).not.toContain('Saved profile queries');
-    expect(container.textContent).toContain('Built in');
+    await waitForText(container, 'Saved queries');
+    expect(container.textContent).toContain('User-created SPARQL saved in this node profile for this Context Graph.');
+    expect(container.textContent).not.toContain('Queries saved from the Query tab.');
+    expect(container.textContent).not.toContain('Profile-saved queries');
+    expect(container.textContent).toContain('Personal research');
+    expect(container.textContent).toContain('Custom context-level query set.');
+    expect(container.textContent).toContain('Preset');
     expect(container.textContent).toContain('Saved');
     await waitForText(container, 'Documents: Document research');
     expect(container.textContent).toContain('Subgraph');
     expect(container.textContent).toContain('Queries for document-backed entities.');
     expect(container.textContent).toContain('List markdown-backed document entities.');
+
+    const entityCountsButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('Entity counts'));
+    expect(entityCountsButton?.getAttribute('title')).toBe('Entity counts. Count reusable context entities with a long enough description to need a tooltip.');
+    expect(entityCountsButton?.getAttribute('aria-label')).toBe('Load query: Entity counts. Count reusable context entities with a long enough description to need a tooltip.');
 
     const findButton = Array.from(container.querySelectorAll('button'))
       .find(button => button.textContent?.includes('Find documents'));
@@ -207,16 +234,16 @@ describe('ContextGraphQueryView', () => {
   it('shows profile loading and saved-query empty catalogue states', async () => {
     const { container, root } = await renderWithProfile(profile({ loading: true }));
 
-    await waitForText(container, 'Loading saved query catalogue...');
+    await waitForText(container, 'Loading saved queries...');
     expect(container.textContent).toContain('All triples');
-    expect(container.textContent).not.toContain('No profile-saved queries yet.');
+    expect(container.textContent).not.toContain('No saved queries yet.');
 
     await act(async () => { root.unmount(); });
     document.body.innerHTML = '';
 
     const emptyRender = await renderWithProfile(profile());
     const { container: emptyContainer, root: emptyRoot } = emptyRender;
-    expect(emptyContainer.textContent).toContain('No profile-saved queries yet.');
+    expect(emptyContainer.textContent).toContain('No saved queries yet.');
 
     await act(async () => { emptyRoot.unmount(); });
   });
@@ -228,7 +255,7 @@ describe('ContextGraphQueryView', () => {
 
     expect(container.textContent).toContain('Profile query failed');
     expect(container.textContent).toContain('All triples');
-    expect(container.textContent).not.toContain('No profile-saved queries yet.');
+    expect(container.textContent).not.toContain('No saved queries yet.');
 
     await act(async () => { root.unmount(); });
   });
@@ -268,7 +295,7 @@ describe('ContextGraphQueryView', () => {
 
     await waitForText(container, 'Saved to catalogue.');
     expect(apiMocks.writeProfileQueryCatalog).toHaveBeenCalledWith('cg-test', expect.any(Array));
-    expect(container.textContent).toContain('Profile-saved queries');
+    expect(container.textContent).toContain('Saved queries');
     expect(container.textContent).toContain('Reusable triples');
     expect(container.textContent).toContain('A reusable triples query.');
 
@@ -293,7 +320,7 @@ describe('ContextGraphQueryView', () => {
   it('keeps local saves visible while profile queries are loading', async () => {
     const { container, root } = await renderWithProfile(profile({ loading: true }));
 
-    await waitForText(container, 'Loading saved query catalogue...');
+    await waitForText(container, 'Loading saved queries...');
 
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
     await act(async () => {

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -121,6 +121,7 @@ describe('ContextGraphQueryView', () => {
     expect(container.textContent).toContain('Catalogue scope');
     expect(container.textContent).toContain('Ad-hoc SPARQL');
     expect(container.textContent).toContain('Editor and results');
+    expect(container.textContent).toContain('available non-private graphs in this Context Graph');
     expect(container.textContent).toContain('No saved profile queries yet.');
 
     await act(async () => { root.unmount(); });
@@ -165,6 +166,17 @@ describe('ContextGraphQueryView', () => {
 
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
     expect(textarea.value).toContain('schema.org/name');
+
+    const contextButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Context graph');
+    expect(contextButton).toBeTruthy();
+
+    await act(async () => {
+      contextButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(contextButton!.getAttribute('aria-pressed')).toBe('true');
+    expect(container.textContent).toContain('No saved context queries yet.');
 
     await act(async () => { root.unmount(); });
   });
@@ -225,6 +237,14 @@ describe('ContextGraphQueryView', () => {
       setFieldValue(textarea, 'SELECT ?s WHERE { ?s ?p ?o } LIMIT 10');
     });
 
+    const subgraphButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Subgraphs');
+    expect(subgraphButton).toBeTruthy();
+    await act(async () => {
+      subgraphButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(subgraphButton!.getAttribute('aria-pressed')).toBe('true');
+
     const saveButton = Array.from(container.querySelectorAll('button'))
       .find(button => button.textContent === 'Save');
     expect(saveButton).toBeTruthy();
@@ -252,6 +272,9 @@ describe('ContextGraphQueryView', () => {
     expect(apiMocks.writeProfileQueryCatalog).toHaveBeenCalledWith('cg-test', expect.any(Array));
     expect(container.textContent).toContain('Reusable triples');
     expect(container.textContent).toContain('A reusable triples query.');
+    const contextButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Context graph');
+    expect(contextButton?.getAttribute('aria-pressed')).toBe('true');
 
     await act(async () => { root.unmount(); });
   });

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectProfile } from '../src/ui/hooks/useProjectProfile.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const apiMocks = vi.hoisted(() => ({
+  executeQuery: vi.fn(),
+  writeProfileQueryCatalog: vi.fn(),
+}));
+
+vi.mock('../src/ui/api.js', () => ({
+  listJoinRequests: vi.fn(async () => ({ requests: [] })),
+  approveJoinRequest: vi.fn(),
+  rejectJoinRequest: vi.fn(),
+  listParticipants: vi.fn(async () => ({ allowedAgents: [] })),
+  listAssertions: vi.fn(),
+  promoteAssertion: vi.fn(),
+  publishSharedMemory: vi.fn(),
+  executeQuery: apiMocks.executeQuery,
+  writeProfileQueryCatalog: apiMocks.writeProfileQueryCatalog,
+  fetchSubGraphs: vi.fn(async () => ({ subGraphs: [] })),
+}));
+
+const {
+  ContextGraphQueryView,
+} = await import('../src/ui/views/project/components.js');
+
+const {
+  ProjectProfileContext,
+} = await import('../src/ui/hooks/useProjectProfile.js');
+
+function profile(overrides: Partial<ProjectProfile> = {}): ProjectProfile {
+  return {
+    contextGraphId: 'cg-test',
+    displayName: 'Test graph',
+    primaryColor: '#a855f7',
+    accentColor: '#22c55e',
+    subGraphs: [],
+    typeBindings: [],
+    views: [],
+    filterChips: [],
+    queryCatalogs: [],
+    savedQueries: [],
+    loading: false,
+    error: undefined,
+    forSubGraph: (slug: string) => ({
+      slug,
+      displayName: slug === 'docs' ? 'Documents' : slug,
+      color: '#38bdf8',
+      rank: 1,
+    }),
+    forType: () => undefined,
+    view: () => undefined,
+    chipsFor: () => [],
+    savedQueryCatalogsFor: () => [],
+    savedQueriesFor: () => [],
+    ...overrides,
+  };
+}
+
+async function renderWithProfile(value: ProjectProfile): Promise<{
+  container: HTMLDivElement;
+  root: Root;
+}> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      React.createElement(ProjectProfileContext.Provider, { value },
+        React.createElement(ContextGraphQueryView, { contextGraphId: 'cg-test' }),
+      ),
+    );
+  });
+
+  return { container, root };
+}
+
+async function waitForText(container: HTMLElement, text: string): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < 1000) {
+    if ((container.textContent ?? '').includes(text)) return;
+    await act(async () => { await Promise.resolve(); });
+  }
+  throw new Error(`Timed out waiting for text: ${text}`);
+}
+
+function setFieldValue(field: HTMLInputElement | HTMLTextAreaElement, value: string): void {
+  const proto = field instanceof HTMLTextAreaElement
+    ? HTMLTextAreaElement.prototype
+    : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+  setter?.call(field, value);
+  field.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('ContextGraphQueryView', () => {
+  beforeEach(() => {
+    apiMocks.executeQuery.mockResolvedValue({ result: { bindings: [] } });
+    apiMocks.writeProfileQueryCatalog.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('frames the page as a catalogue first and editor second', async () => {
+    const { container, root } = await renderWithProfile(profile());
+
+    await waitForText(container, 'Query Catalogue');
+
+    expect(container.textContent).toContain('Reusable SPARQL queries for this Context Graph');
+    expect(container.textContent).toContain('Saved Queries');
+    expect(container.textContent).toContain('Reusable query catalogue');
+    expect(container.textContent).toContain('Catalogue scope');
+    expect(container.textContent).toContain('Ad-hoc SPARQL');
+    expect(container.textContent).toContain('Editor and results');
+    expect(container.textContent).toContain('No team-saved queries yet.');
+
+    await act(async () => { root.unmount(); });
+  });
+
+  it('groups saved queries and loads the selected query into the editor', async () => {
+    const savedProfile = profile({
+      queryCatalogs: [{
+        slug: 'research',
+        subGraph: 'docs',
+        name: 'Document research',
+        description: 'Queries for document-backed entities.',
+        rank: 1,
+        queries: [{
+          slug: 'find-documents',
+          subGraph: 'docs',
+          catalogSlug: 'research',
+          catalogName: 'Document research',
+          catalogDescription: 'Queries for document-backed entities.',
+          catalogRank: 1,
+          name: 'Find documents',
+          description: 'List markdown-backed document entities.',
+          sparql: 'SELECT ?doc WHERE { GRAPH ?g { ?doc <http://schema.org/name> ?name } } LIMIT 5',
+          resultColumn: 'doc',
+          rank: 1,
+        }],
+      }],
+    });
+    const { container, root } = await renderWithProfile(savedProfile);
+
+    await waitForText(container, 'Documents: Document research');
+    expect(container.textContent).toContain('Queries for document-backed entities.');
+    expect(container.textContent).toContain('List markdown-backed document entities.');
+
+    const findButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('Find documents'));
+    expect(findButton).toBeTruthy();
+
+    await act(async () => {
+      findButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea.value).toContain('schema.org/name');
+
+    await act(async () => { root.unmount(); });
+  });
+
+  it('shows profile loading and subgraph-empty catalogue states', async () => {
+    const { container, root } = await renderWithProfile(profile({ loading: true }));
+
+    await waitForText(container, 'Loading saved query catalogue...');
+
+    const subgraphButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Subgraphs');
+    expect(subgraphButton).toBeTruthy();
+    expect(subgraphButton!.getAttribute('aria-pressed')).toBe('false');
+
+    await act(async () => {
+      subgraphButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(subgraphButton!.getAttribute('aria-pressed')).toBe('true');
+    expect(container.textContent).not.toContain('No subgraph saved queries yet.');
+
+    await act(async () => { root.unmount(); });
+    document.body.innerHTML = '';
+
+    const emptyRender = await renderWithProfile(profile());
+    const emptySubgraphButton = Array.from(emptyRender.container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Subgraphs');
+    expect(emptySubgraphButton).toBeTruthy();
+
+    await act(async () => {
+      emptySubgraphButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const { container: emptyContainer, root: emptyRoot } = emptyRender;
+    expect(emptyContainer.textContent).toContain('No subgraph saved queries yet.');
+
+    await act(async () => { emptyRoot.unmount(); });
+  });
+
+  it('shows profile errors without also implying an empty catalogue', async () => {
+    const { container, root } = await renderWithProfile(profile({ error: 'Profile query failed' }));
+
+    await waitForText(container, 'Saved query catalogue unavailable');
+
+    expect(container.textContent).toContain('Profile query failed');
+    expect(container.textContent).not.toContain('No team-saved queries yet.');
+
+    await act(async () => { root.unmount(); });
+  });
+
+  it('saves the draft query into the local catalogue', async () => {
+    const { container, root } = await renderWithProfile(profile());
+
+    await waitForText(container, 'Query Catalogue');
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await act(async () => {
+      setFieldValue(textarea, 'SELECT ?s WHERE { ?s ?p ?o } LIMIT 10');
+    });
+
+    const saveButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Save');
+    expect(saveButton).toBeTruthy();
+
+    await act(async () => {
+      saveButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const nameInput = container.querySelector('input[placeholder="Query name"]') as HTMLInputElement;
+    const descriptionInput = container.querySelector('input[placeholder="Optional"]') as HTMLInputElement;
+    await act(async () => {
+      setFieldValue(nameInput, 'Reusable triples');
+      setFieldValue(descriptionInput, 'A reusable triples query.');
+    });
+
+    const submitButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Save query');
+    expect(submitButton).toBeTruthy();
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await waitForText(container, 'Saved to catalog.');
+    expect(apiMocks.writeProfileQueryCatalog).toHaveBeenCalledWith('cg-test', expect.any(Array));
+    expect(container.textContent).toContain('Reusable triples');
+    expect(container.textContent).toContain('A reusable triples query.');
+
+    await act(async () => { root.unmount(); });
+  });
+
+  it('renders query failures as a friendly EmptyState', async () => {
+    apiMocks.executeQuery.mockRejectedValueOnce(new Error('HTTP 500'));
+    const { container, root } = await renderWithProfile(profile());
+
+    await waitForText(container, 'Query could not run.');
+
+    expect(container.textContent).toContain('Check the SPARQL syntax or try again after the node recovers.');
+    expect(container.textContent).toContain('HTTP 500');
+
+    await act(async () => { root.unmount(); });
+  });
+});

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -115,15 +115,20 @@ describe('ContextGraphQueryView', () => {
 
     await waitForText(container, 'Query Catalogue');
 
+    const buttonLabels = Array.from(container.querySelectorAll('button'))
+      .map(button => button.textContent?.trim())
+      .filter(Boolean);
+
+    expect(container.querySelector('h2.v10-mlv-title')?.textContent).toBe('Query Catalogue');
+    expect(container.querySelector('#query-catalogue-saved-title')?.textContent).toBe('Reusable query catalogue');
+    expect(container.querySelector('#query-catalogue-editor-title')?.textContent).toBe('Editor and results');
+    expect(container.querySelector('textarea')).toBeTruthy();
+    expect(buttonLabels.some(label => label?.startsWith('All triples'))).toBe(true);
+    expect(buttonLabels.some(label => label?.startsWith('Graphs'))).toBe(true);
+    expect(buttonLabels.some(label => label?.startsWith('Types'))).toBe(true);
+    expect(buttonLabels).toEqual(expect.arrayContaining(['Run', 'Save', 'Reset']));
     expect(container.textContent).toContain('Profile-backed reusable SPARQL queries for this Context Graph');
-    expect(container.textContent).toContain('Saved Queries');
-    expect(container.textContent).toContain('Reusable query catalogue');
-    expect(container.textContent).toContain('Save creates a reusable context-level query');
     expect(container.textContent).not.toContain('Catalogue scope');
-    expect(container.textContent).toContain('Ad-hoc SPARQL');
-    expect(container.textContent).toContain('Editor and results');
-    expect(container.textContent).toContain('available non-private graphs in this Context Graph');
-    expect(container.textContent).toContain('No saved profile queries yet.');
 
     await act(async () => { root.unmount(); });
   });

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -118,7 +118,8 @@ describe('ContextGraphQueryView', () => {
     expect(container.textContent).toContain('Profile-backed reusable SPARQL queries for this Context Graph');
     expect(container.textContent).toContain('Saved Queries');
     expect(container.textContent).toContain('Reusable query catalogue');
-    expect(container.textContent).toContain('Catalogue scope');
+    expect(container.textContent).toContain('Save creates a reusable context-level query');
+    expect(container.textContent).not.toContain('Catalogue scope');
     expect(container.textContent).toContain('Ad-hoc SPARQL');
     expect(container.textContent).toContain('Editor and results');
     expect(container.textContent).toContain('available non-private graphs in this Context Graph');
@@ -167,51 +168,21 @@ describe('ContextGraphQueryView', () => {
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
     expect(textarea.value).toContain('schema.org/name');
 
-    const contextButton = Array.from(container.querySelectorAll('button'))
-      .find(button => button.textContent === 'Context graph');
-    expect(contextButton).toBeTruthy();
-
-    await act(async () => {
-      contextButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    expect(contextButton!.getAttribute('aria-pressed')).toBe('true');
-    expect(container.textContent).toContain('No saved context queries yet.');
-
     await act(async () => { root.unmount(); });
   });
 
-  it('shows profile loading and subgraph-empty catalogue states', async () => {
+  it('shows profile loading and saved-query empty catalogue states', async () => {
     const { container, root } = await renderWithProfile(profile({ loading: true }));
 
     await waitForText(container, 'Loading saved query catalogue...');
-
-    const subgraphButton = Array.from(container.querySelectorAll('button'))
-      .find(button => button.textContent === 'Subgraphs');
-    expect(subgraphButton).toBeTruthy();
-    expect(subgraphButton!.getAttribute('aria-pressed')).toBe('false');
-
-    await act(async () => {
-      subgraphButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    expect(subgraphButton!.getAttribute('aria-pressed')).toBe('true');
-    expect(container.textContent).not.toContain('No subgraph saved queries yet.');
+    expect(container.textContent).not.toContain('No saved profile queries yet.');
 
     await act(async () => { root.unmount(); });
     document.body.innerHTML = '';
 
     const emptyRender = await renderWithProfile(profile());
-    const emptySubgraphButton = Array.from(emptyRender.container.querySelectorAll('button'))
-      .find(button => button.textContent === 'Subgraphs');
-    expect(emptySubgraphButton).toBeTruthy();
-
-    await act(async () => {
-      emptySubgraphButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
     const { container: emptyContainer, root: emptyRoot } = emptyRender;
-    expect(emptyContainer.textContent).toContain('No subgraph saved queries yet.');
+    expect(emptyContainer.textContent).toContain('No saved profile queries yet.');
 
     await act(async () => { emptyRoot.unmount(); });
   });
@@ -237,14 +208,6 @@ describe('ContextGraphQueryView', () => {
       setFieldValue(textarea, 'SELECT ?s WHERE { ?s ?p ?o } LIMIT 10');
     });
 
-    const subgraphButton = Array.from(container.querySelectorAll('button'))
-      .find(button => button.textContent === 'Subgraphs');
-    expect(subgraphButton).toBeTruthy();
-    await act(async () => {
-      subgraphButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(subgraphButton!.getAttribute('aria-pressed')).toBe('true');
-
     const saveButton = Array.from(container.querySelectorAll('button'))
       .find(button => button.textContent === 'Save');
     expect(saveButton).toBeTruthy();
@@ -268,13 +231,25 @@ describe('ContextGraphQueryView', () => {
       submitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    await waitForText(container, 'Saved to catalog.');
+    await waitForText(container, 'Saved to catalogue.');
     expect(apiMocks.writeProfileQueryCatalog).toHaveBeenCalledWith('cg-test', expect.any(Array));
     expect(container.textContent).toContain('Reusable triples');
     expect(container.textContent).toContain('A reusable triples query.');
-    const contextButton = Array.from(container.querySelectorAll('button'))
-      .find(button => button.textContent === 'Context graph');
-    expect(contextButton?.getAttribute('aria-pressed')).toBe('true');
+
+    apiMocks.executeQuery.mockRejectedValueOnce(new Error('HTTP 400'));
+    await act(async () => {
+      setFieldValue(textarea, 'SELECT ?broken WHERE { ?broken ?p }');
+    });
+    const runButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Run');
+    expect(runButton).toBeTruthy();
+
+    await act(async () => {
+      runButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await waitForText(container, 'Query could not run.');
+    expect(container.textContent).not.toContain('Saved to catalogue.');
 
     await act(async () => { root.unmount(); });
   });

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -202,6 +202,7 @@ describe('ContextGraphQueryView', () => {
     const { container, root } = await renderWithProfile(profile({ loading: true }));
 
     await waitForText(container, 'Loading saved query catalogue...');
+    expect(container.textContent).toContain('All triples');
     expect(container.textContent).not.toContain('No saved profile queries yet.');
 
     await act(async () => { root.unmount(); });
@@ -220,6 +221,7 @@ describe('ContextGraphQueryView', () => {
     await waitForText(container, 'Saved query catalogue unavailable');
 
     expect(container.textContent).toContain('Profile query failed');
+    expect(container.textContent).toContain('All triples');
     expect(container.textContent).not.toContain('No saved profile queries yet.');
 
     await act(async () => { root.unmount(); });

--- a/packages/node-ui/test/use-memory-entities-counts.test.ts
+++ b/packages/node-ui/test/use-memory-entities-counts.test.ts
@@ -121,5 +121,10 @@ describe('useMemoryEntities canonical layer counts', () => {
     expect(el.getAttribute('data-current-layers')).toContain('urn:test:promoted:shared');
     expect(el.getAttribute('data-current-layers')).toContain('urn:test:full-pipeline:verified');
     expect(el.getAttribute('data-current-layers')).not.toContain('urn:test:object-only');
+
+    const vmRequest = vi.mocked(fetch).mock.calls
+      .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { sparql?: string })
+      .find(body => body.sparql?.includes('_verified_memory_meta'));
+    expect(vmRequest?.sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
   });
 });

--- a/packages/node-ui/test/use-memory-entities-counts.test.ts
+++ b/packages/node-ui/test/use-memory-entities-counts.test.ts
@@ -125,6 +125,7 @@ describe('useMemoryEntities canonical layer counts', () => {
     const vmRequest = vi.mocked(fetch).mock.calls
       .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { sparql?: string })
       .find(body => body.sparql?.includes('_verified_memory_meta'));
+    expect(vmRequest?.sparql).toContain('STR(?g) != "did:dkg:context-graph:cg-counts/meta"');
     expect(vmRequest?.sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
   });
 });


### PR DESCRIPTION
## Summary

- Reframes the Context Graph Query Catalogue as a reusable saved-query catalogue first, with grouped context-graph and subgraph query sections plus a visible scope selector.
- Separates reusable saved queries from the ad-hoc SPARQL editor/results area and adds friendly loading, empty, unavailable, and query-error states using the shared S9 EmptyState pattern.
- Adds focused coverage for catalogue intro/grouping, saved-query loading, loading/error/empty states, save flow, and accessible scope selection.

## Related

- Context Graph UX plan PR 2.4 / S6: Query Catalogue reframe.
- Follows S1/S2/N8 tab IA and S9/M5 shared EmptyState/StatStrip primitives.
- Leaves S3 Subgraph Explorer, S7/N2/N4 graph viewport/rail work, VM metadata/publish flow, and activity-feed breadth out of scope.

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/views/project/components.tsx` | Reworks Query Catalogue IA, catalogue grouping/scope filtering, friendly states, and editor separation. |
| `packages/node-ui/src/ui/styles.css` | Adds catalogue/editor zone layout, query chips, scope segmented control, and responsive behavior. |
| `packages/node-ui/test/context-graph-query-catalog.test.ts` | Adds focused S6 regression coverage. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/context-graph-query-catalog.test.ts test/use-project-profile.test.ts test/context-graph-empty-stat-components.test.ts test/context-graph-ia-overview.test.ts test/project-view-navigation.test.ts test/ui-api-pure.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui`
- [x] `git diff --check`
- [x] Mock-backed local dev-server browser visual QA with screenshots at desktop and constrained widths for catalogue grouping, scope filtering, editor/results separation, successful query output, and friendly query-error state.
- [x] Local Codex PR review: 4 rounds; final round returned no actionable comments.