### PR TITLE
OT-RFC-38 LU-6 B1 — signed swm-host-catchup requests

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -9678,49 +9678,85 @@ export class DKGAgent {
       return { ok: false, reason: 'replayed catchup nonce' };
     }
 
-    // 3. chain-anchored authority
-    let chainParticipants: string[] | null = null;
+    // The authority sources below use UNION semantics: any source
+    // that recognises the requester EOA (or, as transport-layer
+    // fallback, the peer-id) is sufficient to accept. Codex PR #618
+    // R2 caught a fail-closed bug in the prior implementation where
+    // `chainParticipants` was treated as authoritative — if the
+    // chain returned a set that didn't include a legitimate
+    // delegatee or allowed-agent, we'd hard-deny without checking
+    // the locally-persisted allowlist. The current logic accepts
+    // on the first match across:
+    //   3a. on-chain participant agents
+    //   3b. beacon-pinned curator (pre-registration)
+    //   3c. locally-persisted agent-gate set (allowedAgent UNION
+    //       participantAgent from _meta + subscription cache)
+    //   3d. transport-layer allowedPeers (libp2p peer-id allowlist)
+    // Only if none accept do we deny.
+    const requesterLower = requesterEoa.toLowerCase();
+    let anyAuthoritySourceFound = false;
+
     try {
-      chainParticipants = await this.resolveOnChainParticipantAgents(req.contextGraphId);
-    } catch {
-      // Adapter probe failure is non-fatal; fall through to beacon/local checks.
-    }
-    if (chainParticipants !== null) {
-      const lowered = chainParticipants.map((a) => a.toLowerCase());
-      if (lowered.includes(requesterEoa.toLowerCase())) {
-        return { ok: true, recoveredSigner: requesterEoa };
+      const chainParticipants = await this.resolveOnChainParticipantAgents(req.contextGraphId);
+      if (chainParticipants !== null) {
+        anyAuthoritySourceFound = true;
+        if (chainParticipants.some((a) => a.toLowerCase() === requesterLower)) {
+          return { ok: true, recoveredSigner: requesterEoa };
+        }
       }
-      return { ok: false, reason: 'requester EOA not in on-chain participant set' };
-    }
-
-    // 4. pre-registration fallback — beacon-pinned curator
-    let beaconCurator: string | null = null;
-    try {
-      beaconCurator = await this.resolveBeaconPinnedCuratorEoa(req.contextGraphId);
     } catch {
-      // ignore; fall through to local allowlist
-    }
-    if (beaconCurator && beaconCurator.toLowerCase() === requesterEoa.toLowerCase()) {
-      return { ok: true, recoveredSigner: requesterEoa };
+      // Adapter probe failure is non-fatal; fall through to other sources.
     }
 
-    // 5. member-side local allowedPeers (transport-layer ACL); only
-    // gates when local meta exists (the host-only-core case is
-    // already handled by chain/beacon above).
+    try {
+      const beaconCurator = await this.resolveBeaconPinnedCuratorEoa(req.contextGraphId);
+      if (beaconCurator) {
+        anyAuthoritySourceFound = true;
+        if (beaconCurator.toLowerCase() === requesterLower) {
+          return { ok: true, recoveredSigner: requesterEoa };
+        }
+      }
+    } catch {
+      // Beacon cache miss is non-fatal.
+    }
+
+    // Locally-persisted agent gate: `getContextGraphAgentGateAddresses`
+    // unions `dkg:allowedAgent` + `dkg:participantAgent` from the CG's
+    // `_meta` graph and the in-memory subscription cache. On a member-
+    // side host this is the canonical allowlist + delegatee set;
+    // chain-derived sets often miss recently-approved delegatees that
+    // haven't been mirrored on chain yet.
+    try {
+      const agentGate = await this.getContextGraphAgentGateAddresses(req.contextGraphId);
+      if (agentGate !== null) {
+        anyAuthoritySourceFound = true;
+        if (agentGate.some((a) => a.toLowerCase() === requesterLower)) {
+          return { ok: true, recoveredSigner: requesterEoa };
+        }
+      }
+    } catch {
+      // Local-meta probe failure is non-fatal.
+    }
+
+    // Transport-layer ACL (libp2p peer-id allowlist). Only meaningful
+    // on nodes that have persisted the CG's `allowedPeers`; host-only
+    // cores never see it.
     try {
       const allowedPeers = await this.getContextGraphAllowedPeers(req.contextGraphId);
       if (allowedPeers !== null) {
+        anyAuthoritySourceFound = true;
         if (allowedPeers.includes(fromPeerId)) {
           return { ok: true, recoveredSigner: requesterEoa };
         }
-        return { ok: false, reason: 'peer not in context-graph allowedPeers' };
       }
     } catch {
-      // local-meta probe failure is non-fatal; the deny in step 6 still applies.
+      // local-meta probe failure is non-fatal; the deny below still applies.
     }
 
-    // 6. no authority source produced an accept → deny by default.
-    return { ok: false, reason: 'no authority source authorized requester EOA' };
+    const reason = anyAuthoritySourceFound
+      ? 'requester EOA not in any of: on-chain participants, beacon curator, local agent-gate, allowedPeers'
+      : 'no authority source available for context graph';
+    return { ok: false, reason };
   }
 
   /**
@@ -9769,12 +9805,15 @@ export class DKGAgent {
     // OT-RFC-38 LU-6 B1 — every catchup request is signed by the
     // requesting agent's chain EOA so the host can authenticate via
     // on-chain participant set without trusting the libp2p peer-id.
-    const requesterEoa = await this.getRegistrationTxSignerAddress();
-    if (!requesterEoa) {
-      const reason = 'no chain signer address available — cannot mint signed catchup request';
-      this.log.warn(ctx, `host-catchup ${reason} to=${remotePeerId} cg=${contextGraphId}`);
-      return { rounds: 0, fetched: 0, applied: 0, appliedTriples: 0, skipped: 0, nextSeqno: sinceSeqno, denied: reason };
-    }
+    //
+    // Codex PR #618 R2: we deliberately do NOT pre-compute the
+    // requester EOA from `getRegistrationTxSignerAddress()`. The
+    // chain adapter's tx-signer can differ from its message-signer
+    // (per the helper's own doc-comment), and binding the two
+    // independently produced "signer mismatch" rejections in every
+    // adapter except the EVM one. `mintSignedCatchupRequest` now
+    // recovers the actual signer from the signature itself and
+    // binds the digest to it — no caller-side lookup needed.
     if (typeof this.chain.signMessage !== 'function') {
       const reason = 'chain adapter does not implement signMessage — cannot mint signed catchup request';
       this.log.warn(ctx, `host-catchup ${reason} to=${remotePeerId} cg=${contextGraphId}`);
@@ -9793,7 +9832,12 @@ export class DKGAgent {
         sinceSeqno,
         maxEntries,
         maxBytes,
-        requesterEoa,
+        // requesterEoa intentionally omitted — the helper recovers
+        // the signer from the signature itself, which is the only
+        // way to guarantee the digest binds to the actual signing
+        // key (the chain adapter's tx-signer and message-signer can
+        // differ). See `MintSignedCatchupRequestInput.requesterEoa`
+        // doc comment for the full rationale.
         sign: async (digest) => {
           const { r, vs } = await this.chain.signMessage!(digest);
           const sig = ethers.Signature.from({ r: ethers.hexlify(r), yParityAndS: ethers.hexlify(vs) });

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -153,8 +153,14 @@ import {
   decodeSwmHostCatchupResponse,
   DEFAULT_MAX_BYTES as SWM_HOST_CATCHUP_DEFAULT_MAX_BYTES,
   DEFAULT_MAX_ENTRIES as SWM_HOST_CATCHUP_DEFAULT_MAX_ENTRIES,
+  SWM_HOST_CATCHUP_WIRE_VERSION,
   type SwmHostCatchupResponseEntry,
 } from './swm/host-catchup-wire.js';
+import {
+  CatchupReplayGuard,
+  mintSignedCatchupRequest,
+  verifySignedCatchupRequest,
+} from './swm/host-catchup-sign.js';
 import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
@@ -645,6 +651,14 @@ export class DKGAgent {
    * to identity / abuse history).
    */
   private readonly beaconCuratorByWireId = new Map<string, string>();
+  /**
+   * OT-RFC-38 / LU-6 — replay-defence cache for signed
+   * `swm-host-catchup` requests. Tracks recent (requesterEoa, nonce)
+   * pairs so a request lifted off the wire can't be replayed against
+   * the same responder while the freshness window is still open.
+   * See {@link CatchupReplayGuard}.
+   */
+  private readonly catchupReplayGuard = new CatchupReplayGuard();
   /**
    * OT-RFC-38 / LU-6 Phase B — periodic beacon re-announce timer
    * (curators only). See {@link beaconRegistry} jsdoc.
@@ -9481,7 +9495,7 @@ export class DKGAgent {
     const ctx = createOperationContext('share');
     if (!this.swmHostModeStore) {
       return encodeSwmHostCatchupResponse({
-        version: 1,
+        version: SWM_HOST_CATCHUP_WIRE_VERSION,
         contextGraphId: '',
         nextSeqno: 0,
         truncated: false,
@@ -9495,7 +9509,7 @@ export class DKGAgent {
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       return encodeSwmHostCatchupResponse({
-        version: 1,
+        version: SWM_HOST_CATCHUP_WIRE_VERSION,
         contextGraphId: '',
         nextSeqno: 0,
         truncated: false,
@@ -9503,41 +9517,27 @@ export class DKGAgent {
         entries: [],
       });
     }
-    // Codex PR #610 round-2 #6 (partial mitigation): when the local
-    // node has explicit peer-allowlist meta for this CG (the member-
-    // side case), require the requesting peer to be in it. Pre-fix,
-    // any connected peer that knew or guessed a `contextGraphId`
-    // could pull stored envelopes; ciphertext is useless without
-    // the chain key but the activity metadata (existence, timing,
-    // volume) still leaked. We DON'T yet authenticate the host-only-
-    // core case (no local allowlist, chain-only authority) — that
-    // needs a signed catchup-request wire change and is tracked as
-    // a separate post-launch follow-up. For now host-only cores
-    // still serve openly, mitigated by per-peer rate limiting on
-    // the wire and the fact that ciphertext leaks no useful data
-    // without the curator-issued chain key.
-    try {
-      const allowedPeers = await this.getContextGraphAllowedPeers(req.contextGraphId);
-      if (allowedPeers !== null && !allowedPeers.includes(fromPeerId)) {
-        this.log.info(
-          ctx,
-          `host-catchup denied cg=${req.contextGraphId} from=${fromPeerId}: peer not in allowedPeers (len=${allowedPeers.length})`,
-        );
-        return encodeSwmHostCatchupResponse({
-          version: 1,
-          contextGraphId: req.contextGraphId,
-          nextSeqno: req.sinceSeqno,
-          truncated: false,
-          denied: 'peer not in context-graph allowlist',
-          entries: [],
-        });
-      }
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      this.log.debug(ctx, `host-catchup peer-allowlist probe failed cg=${req.contextGraphId}: ${reason}`);
-      // Fall through — local-allowlist read failure is non-fatal
-      // (host-only cores hit this path) and the iterate call below
-      // still gates on the existence of the CG in the host store.
+
+    // OT-RFC-38 LU-6 B1: signature + freshness + replay-defence +
+    // chain-anchored authorization. Pre-B1 the handler treated the
+    // libp2p peer-id as an authority token, which leaked metadata
+    // (existence/timing/volume of curated CGs) to any connected peer
+    // that knew or guessed the wire id — see comment block below at
+    // the authorization branch for the threat-model rationale.
+    const authResult = await this.authorizeSwmHostCatchupRequest(req, fromPeerId, Date.now());
+    if (!authResult.ok) {
+      this.log.info(
+        ctx,
+        `host-catchup denied cg=${req.contextGraphId} from=${fromPeerId} requesterEoa=${req.requesterEoa}: ${authResult.reason}`,
+      );
+      return encodeSwmHostCatchupResponse({
+        version: SWM_HOST_CATCHUP_WIRE_VERSION,
+        contextGraphId: req.contextGraphId,
+        nextSeqno: req.sinceSeqno,
+        truncated: false,
+        denied: authResult.reason,
+        entries: [],
+      });
     }
 
     const maxEntries = req.maxEntries ?? SWM_HOST_CATCHUP_DEFAULT_MAX_ENTRIES;
@@ -9549,7 +9549,7 @@ export class DKGAgent {
       const reason = err instanceof Error ? err.message : String(err);
       this.log.warn(ctx, `host-catchup iterate failed cg=${req.contextGraphId} from=${fromPeerId}: ${reason}`);
       return encodeSwmHostCatchupResponse({
-        version: 1,
+        version: SWM_HOST_CATCHUP_WIRE_VERSION,
         contextGraphId: req.contextGraphId,
         nextSeqno: req.sinceSeqno,
         truncated: false,
@@ -9600,7 +9600,7 @@ export class DKGAgent {
       // can't fit in the response (would otherwise loop because
       // `nextSeqno` stays equal to `sinceSeqno` when entries=0).
       return encodeSwmHostCatchupResponse({
-        version: 1,
+        version: SWM_HOST_CATCHUP_WIRE_VERSION,
         contextGraphId: req.contextGraphId,
         nextSeqno: req.sinceSeqno,
         truncated: true,
@@ -9614,12 +9614,113 @@ export class DKGAgent {
       `host-catchup served cg=${req.contextGraphId} from=${fromPeerId} sinceSeqno=${req.sinceSeqno} entries=${entries.length} bytes=${runningBytes} truncated=${truncatedByEntries || truncatedByBytes}`,
     );
     return encodeSwmHostCatchupResponse({
-      version: 1,
+      version: SWM_HOST_CATCHUP_WIRE_VERSION,
       contextGraphId: req.contextGraphId,
       nextSeqno,
       truncated: truncatedByEntries || truncatedByBytes,
       entries,
     });
+  }
+
+  /**
+   * OT-RFC-38 LU-6 B1 — authorize a signed `swm-host-catchup` request.
+   *
+   * Layered checks (deny-by-default):
+   *   1. Signature recovery + freshness (issuedAtMs within window).
+   *   2. Replay-nonce uniqueness (per-responder LRU).
+   *   3. Chain-anchored: `requesterEoa ∈ participantAgents` for the CG.
+   *      Definitive when chain context is available — the on-chain
+   *      participant set IS the curated access policy.
+   *   4. Pre-registration fallback: `requesterEoa == beaconCurator`.
+   *      Curators can always catch up themselves before paying gas to
+   *      register, mirroring `ingestSwmHostModeEnvelope`.
+   *   5. Member-side allowlist fallback: when the local node has
+   *      explicit peer-allowlist meta (member CG context, not host-only
+   *      core), require `fromPeerId ∈ allowedPeers`. Defence in depth
+   *      against a signed-but-out-of-band requester.
+   *   6. Otherwise: DENY. The previous behaviour ("serve openly when
+   *      no authority source available") was the metadata-leak vector
+   *      Codex flagged on PR #610 round-2 #6.
+   *
+   * Returns `{ ok: true, recoveredSigner }` on accept or
+   * `{ ok: false, reason }` with a wire-suitable string.
+   */
+  private async authorizeSwmHostCatchupRequest(
+    req: ReturnType<typeof decodeSwmHostCatchupRequest>,
+    fromPeerId: string,
+    nowMs: number,
+  ): Promise<{ ok: true; recoveredSigner: string } | { ok: false; reason: string }> {
+    // 1. signature + freshness. `verifySignedCatchupRequest` re-runs
+    //    `computeCatchupRequestDigest` over the same numerical fields
+    //    the client signed; pass defined defaults for the optional
+    //    `maxEntries`/`maxBytes` so the encoded uint256 layout matches.
+    const verify = verifySignedCatchupRequest(
+      {
+        version: req.version,
+        contextGraphId: req.contextGraphId,
+        sinceSeqno: req.sinceSeqno,
+        maxEntries: req.maxEntries ?? 0,
+        maxBytes: req.maxBytes ?? 0,
+        requesterEoa: req.requesterEoa,
+        issuedAtMs: req.issuedAtMs,
+        nonce: req.nonce,
+        sig: req.sig,
+      },
+      nowMs,
+    );
+    if (!verify.ok || !verify.recoveredSigner) {
+      return { ok: false, reason: verify.reason ?? 'signature verification failed' };
+    }
+    const requesterEoa = verify.recoveredSigner;
+
+    // 2. replay-defence
+    if (!this.catchupReplayGuard.recordIfFresh(requesterEoa, req.nonce, req.issuedAtMs, nowMs)) {
+      return { ok: false, reason: 'replayed catchup nonce' };
+    }
+
+    // 3. chain-anchored authority
+    let chainParticipants: string[] | null = null;
+    try {
+      chainParticipants = await this.resolveOnChainParticipantAgents(req.contextGraphId);
+    } catch {
+      // Adapter probe failure is non-fatal; fall through to beacon/local checks.
+    }
+    if (chainParticipants !== null) {
+      const lowered = chainParticipants.map((a) => a.toLowerCase());
+      if (lowered.includes(requesterEoa.toLowerCase())) {
+        return { ok: true, recoveredSigner: requesterEoa };
+      }
+      return { ok: false, reason: 'requester EOA not in on-chain participant set' };
+    }
+
+    // 4. pre-registration fallback — beacon-pinned curator
+    let beaconCurator: string | null = null;
+    try {
+      beaconCurator = await this.resolveBeaconPinnedCuratorEoa(req.contextGraphId);
+    } catch {
+      // ignore; fall through to local allowlist
+    }
+    if (beaconCurator && beaconCurator.toLowerCase() === requesterEoa.toLowerCase()) {
+      return { ok: true, recoveredSigner: requesterEoa };
+    }
+
+    // 5. member-side local allowedPeers (transport-layer ACL); only
+    // gates when local meta exists (the host-only-core case is
+    // already handled by chain/beacon above).
+    try {
+      const allowedPeers = await this.getContextGraphAllowedPeers(req.contextGraphId);
+      if (allowedPeers !== null) {
+        if (allowedPeers.includes(fromPeerId)) {
+          return { ok: true, recoveredSigner: requesterEoa };
+        }
+        return { ok: false, reason: 'peer not in context-graph allowedPeers' };
+      }
+    } catch {
+      // local-meta probe failure is non-fatal; the deny in step 6 still applies.
+    }
+
+    // 6. no authority source produced an accept → deny by default.
+    return { ok: false, reason: 'no authority source authorized requester EOA' };
   }
 
   /**
@@ -9664,6 +9765,21 @@ export class DKGAgent {
     let sinceSeqno = options?.sinceSeqno ?? 0;
     const maxRounds = Math.max(1, options?.maxRounds ?? 8);
     const maxEntries = options?.maxEntriesPerRound ?? SWM_HOST_CATCHUP_DEFAULT_MAX_ENTRIES;
+    const maxBytes = SWM_HOST_CATCHUP_DEFAULT_MAX_BYTES;
+    // OT-RFC-38 LU-6 B1 — every catchup request is signed by the
+    // requesting agent's chain EOA so the host can authenticate via
+    // on-chain participant set without trusting the libp2p peer-id.
+    const requesterEoa = await this.getRegistrationTxSignerAddress();
+    if (!requesterEoa) {
+      const reason = 'no chain signer address available — cannot mint signed catchup request';
+      this.log.warn(ctx, `host-catchup ${reason} to=${remotePeerId} cg=${contextGraphId}`);
+      return { rounds: 0, fetched: 0, applied: 0, appliedTriples: 0, skipped: 0, nextSeqno: sinceSeqno, denied: reason };
+    }
+    if (typeof this.chain.signMessage !== 'function') {
+      const reason = 'chain adapter does not implement signMessage — cannot mint signed catchup request';
+      this.log.warn(ctx, `host-catchup ${reason} to=${remotePeerId} cg=${contextGraphId}`);
+      return { rounds: 0, fetched: 0, applied: 0, appliedTriples: 0, skipped: 0, nextSeqno: sinceSeqno, denied: reason };
+    }
     let rounds = 0;
     let fetched = 0;
     let applied = 0;
@@ -9672,11 +9788,28 @@ export class DKGAgent {
     let lastDenied: string | undefined;
     while (rounds < maxRounds) {
       rounds += 1;
-      const reqBytes = encodeSwmHostCatchupRequest({
-        version: 1,
+      const signedReq = await mintSignedCatchupRequest({
         contextGraphId,
         sinceSeqno,
         maxEntries,
+        maxBytes,
+        requesterEoa,
+        sign: async (digest) => {
+          const { r, vs } = await this.chain.signMessage!(digest);
+          const sig = ethers.Signature.from({ r: ethers.hexlify(r), yParityAndS: ethers.hexlify(vs) });
+          return sig.serialized;
+        },
+      });
+      const reqBytes = encodeSwmHostCatchupRequest({
+        version: SWM_HOST_CATCHUP_WIRE_VERSION,
+        contextGraphId,
+        sinceSeqno,
+        maxEntries,
+        maxBytes,
+        requesterEoa: signedReq.requesterEoa,
+        issuedAtMs: signedReq.issuedAtMs,
+        nonce: signedReq.nonce,
+        sig: signedReq.sig,
       });
       let sendResult;
       try {

--- a/packages/agent/src/swm/host-catchup-sign.ts
+++ b/packages/agent/src/swm/host-catchup-sign.ts
@@ -1,0 +1,327 @@
+/**
+ * OT-RFC-38 LU-6 — Signed `swm-host-catchup` request authentication.
+ *
+ * Closes the metadata-leak vector flagged by Codex on PR #610: pre-fix,
+ * any peer that knew or guessed a `contextGraphId` could pull stored
+ * envelopes from a host-only core. Ciphertext is useless without the
+ * curator-issued chain key, but the activity metadata (existence,
+ * timing, volume per peer) still leaked. The local `allowedPeers`
+ * mitigation only covers member-side nodes that have the CG's peer
+ * allowlist persisted — host-only cores never have that list and
+ * fell through to unauthenticated serving.
+ *
+ * This module adds an EIP-191 signature on every catchup request,
+ * letting the responder verify the requester's chain-EOA identity
+ * regardless of transport peer-id. The agent then cross-references
+ * the recovered EOA against the on-chain participant set (or, for
+ * pre-registration CGs, the beacon-pinned curator EOA) — the same
+ * authority sources the SWM ingest path already uses.
+ *
+ * Wire layout for the signed digest (packed binary, 228 bytes):
+ *
+ *   version             : uint256              (32)   — wire version
+ *   contextGraphIdHash  : keccak256(utf8 id)   (32)   — binds to CG
+ *   sinceSeqno          : uint256              (32)
+ *   maxEntries          : uint256              (32)   — 0 means unset
+ *   maxBytes            : uint256              (32)
+ *   requesterEoa        : address              (20)
+ *   issuedAtMs          : uint256              (32)   — wall clock
+ *   nonce               : bytes16              (16)   — replay-defence
+ *
+ * The digest is `keccak256(packed)`, signed via EIP-191 personal-sign
+ * so the same chain adapter that signs beacons + attestations works
+ * verbatim. We use packed bytes rather than JSON to avoid canonical-
+ * isation surprises across runtimes — the verifier hand-computes the
+ * same buffer and recovers the signer.
+ *
+ * Freshness: the responder enforces `|now - issuedAtMs| <=
+ * CATCHUP_REQUEST_MAX_AGE_MS` (5 min). Combined with the per-server
+ * nonce LRU, this bounds replay to a small wall-clock window even if
+ * an attacker exfiltrates a valid request from the wire.
+ */
+
+import { keccak256 } from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+
+/**
+ * Maximum wall-clock skew between the client's `issuedAtMs` and the
+ * responder's local time. 5 minutes matches the SWM envelope freshness
+ * window (`workspace-handler.ts`) so operators tune one knob.
+ */
+export const CATCHUP_REQUEST_MAX_AGE_MS = 5 * 60 * 1000;
+
+/**
+ * Soft cap on the per-responder nonce-replay set. Tuned for 1 req/peer/sec
+ * sustained across ~16 concurrent peers over the freshness window
+ * (16 * 60 * 5 ≈ 5K). Going above this evicts oldest-first; freshness
+ * still bounds replay once a nonce drops out, so the cap is a memory
+ * guard, not a security guarantee.
+ */
+export const CATCHUP_REPLAY_NONCE_LRU_MAX = 8 * 1024;
+
+export interface SignedCatchupRequestFields {
+  version: number;
+  contextGraphId: string;
+  sinceSeqno: number;
+  maxEntries: number;
+  maxBytes: number;
+  requesterEoa: string;
+  issuedAtMs: number;
+  /** 0x-prefixed lowercase 32-hex-char string (16 bytes). */
+  nonce: string;
+}
+
+export interface SignedCatchupRequest extends SignedCatchupRequestFields {
+  /** 65-byte EIP-191 personal-sign signature, 0x-prefixed hex. */
+  sig: string;
+}
+
+export interface VerifyCatchupRequestResult {
+  ok: boolean;
+  /** Recovered EVM address. Lowercase when ok=true. */
+  recoveredSigner?: string;
+  reason?: string;
+}
+
+/**
+ * Compute the digest the requester signs. Layout matches the doc-
+ * comment at the top of this file. Verifier MUST hand-compute the
+ * same buffer — JSON canonicalisation is deliberately out of scope.
+ *
+ * `req.contextGraphId` is hashed (`keccak256(utf8(...))`) on both
+ * sides so the digest binds to a canonical 32-byte identifier
+ * regardless of whether the wire form is cleartext, hash, or numeric.
+ * This keeps the wire `contextGraphId` field compatible with the
+ * existing host-mode store keying (sha256 over whatever string the
+ * member passed) — the wire id and the signed id need not be the
+ * same shape, only the latter needs to be canonical.
+ */
+export function computeCatchupRequestDigest(req: SignedCatchupRequestFields): Uint8Array {
+  if (typeof req.contextGraphId !== 'string' || req.contextGraphId.length === 0) {
+    throw new Error('contextGraphId must be a non-empty string');
+  }
+  validateAddress(req.requesterEoa, 'requesterEoa');
+  validateNonce16(req.nonce);
+
+  const contextGraphIdHash = keccak256(new TextEncoder().encode(req.contextGraphId));
+
+  // 32 (version) + 32 (cgIdHash) + 32 (sinceSeqno) + 32 (maxEntries)
+  // + 32 (maxBytes) + 20 (requesterEoa) + 32 (issuedAtMs) + 16 (nonce)
+  // = 228 bytes
+  const packed = new Uint8Array(228);
+  let off = 0;
+  packed.set(uint256ToBytes(req.version), off); off += 32;
+  packed.set(contextGraphIdHash, off); off += 32;
+  packed.set(uint256ToBytes(req.sinceSeqno), off); off += 32;
+  packed.set(uint256ToBytes(req.maxEntries), off); off += 32;
+  packed.set(uint256ToBytes(req.maxBytes), off); off += 32;
+  packed.set(addressToBytes(req.requesterEoa), off); off += 20;
+  packed.set(uint256ToBytes(req.issuedAtMs), off); off += 32;
+  packed.set(hexTo16Bytes(req.nonce), off); off += 16;
+  return keccak256(packed);
+}
+
+export interface MintSignedCatchupRequestInput {
+  /** Wire `contextGraphId` (cleartext, hash, or numeric form — keccak'd into the digest). */
+  contextGraphId: string;
+  sinceSeqno: number;
+  maxEntries: number;
+  maxBytes: number;
+  requesterEoa: string;
+  /** Unix epoch ms. Defaults to Date.now(). */
+  issuedAtMs?: number;
+  /** Hex-encoded 16-byte nonce. Auto-generated if omitted. */
+  nonce?: string;
+  /**
+   * Wallet-agnostic signer. Returns EIP-191 personal-sign signature
+   * (65-byte 0x-prefixed hex) over the supplied digest. Same shape
+   * as `mintCgDiscoveryBeacon` so callers can pass the same lambda
+   * (chain adapter's signMessage).
+   */
+  sign: (digest: Uint8Array) => Promise<string>;
+  /** Wire version to mint at. Defaults to 2 (current). */
+  version?: number;
+}
+
+export async function mintSignedCatchupRequest(
+  input: MintSignedCatchupRequestInput,
+): Promise<SignedCatchupRequest> {
+  const version = input.version ?? 2;
+  const issuedAtMs = input.issuedAtMs ?? Date.now();
+  const nonce = input.nonce ?? randomNonceHex();
+  const fields: SignedCatchupRequestFields = {
+    version,
+    contextGraphId: input.contextGraphId,
+    sinceSeqno: input.sinceSeqno,
+    maxEntries: input.maxEntries,
+    maxBytes: input.maxBytes,
+    requesterEoa: input.requesterEoa.toLowerCase(),
+    issuedAtMs,
+    nonce: nonce.toLowerCase(),
+  };
+  const digest = computeCatchupRequestDigest(fields);
+  const sig = await input.sign(digest);
+  return { ...fields, sig };
+}
+
+/**
+ * Verify a received signed catchup request. Checks:
+ *   1. Freshness: |nowMs - issuedAtMs| <= CATCHUP_REQUEST_MAX_AGE_MS.
+ *   2. Signature: EIP-191 recovers exactly `req.requesterEoa`.
+ *
+ * Does NOT check authorization (participant-set membership) — that's
+ * the caller's job because it depends on chain reads + local meta
+ * the verifier doesn't see. Does NOT check replay-nonce uniqueness —
+ * that's a separate stateful check, see {@link CatchupReplayGuard}.
+ */
+export function verifySignedCatchupRequest(
+  req: SignedCatchupRequest,
+  nowMs: number,
+): VerifyCatchupRequestResult {
+  if (!Number.isFinite(req.issuedAtMs) || req.issuedAtMs < 0) {
+    return { ok: false, reason: `issuedAtMs must be a non-negative number, got ${req.issuedAtMs}` };
+  }
+  const ageMs = Math.abs(nowMs - req.issuedAtMs);
+  if (ageMs > CATCHUP_REQUEST_MAX_AGE_MS) {
+    return { ok: false, reason: `request age ${ageMs}ms > ${CATCHUP_REQUEST_MAX_AGE_MS}ms max` };
+  }
+
+  let digest: Uint8Array;
+  try {
+    digest = computeCatchupRequestDigest(req);
+  } catch (err) {
+    return { ok: false, reason: `digest computation failed: ${(err as Error)?.message ?? err}` };
+  }
+
+  let recovered: string;
+  try {
+    recovered = ethers.verifyMessage(digest, req.sig).toLowerCase();
+  } catch (err: unknown) {
+    return { ok: false, reason: `signature recovery failed: ${(err as Error)?.message ?? err}` };
+  }
+
+  if (recovered !== req.requesterEoa) {
+    return { ok: false, reason: `signer mismatch: recovered ${recovered}, claimed ${req.requesterEoa}` };
+  }
+
+  return { ok: true, recoveredSigner: recovered };
+}
+
+/**
+ * Per-responder replay-defence cache for catchup-request nonces.
+ * Reject any (requesterEoa, nonce) seen within the freshness window.
+ * Once a nonce ages out (LRU eviction), the freshness check is the
+ * only line of defence — that's acceptable because the issuedAtMs is
+ * inside the signed digest, so the attacker can't refresh it without
+ * the signer's private key.
+ */
+export class CatchupReplayGuard {
+  private readonly seen = new Map<string, number>(); // key -> issuedAtMs
+  private readonly maxEntries: number;
+
+  constructor(maxEntries = CATCHUP_REPLAY_NONCE_LRU_MAX) {
+    this.maxEntries = maxEntries;
+  }
+
+  /**
+   * Returns true iff the (requesterEoa, nonce) pair is fresh — i.e.
+   * not seen before. False return = the pair was a replay and the
+   * caller should reject the request. Mutates internal state on
+   * accept (recording the nonce).
+   */
+  recordIfFresh(requesterEoa: string, nonce: string, issuedAtMs: number, nowMs: number): boolean {
+    this.evictStale(nowMs);
+    const key = `${requesterEoa.toLowerCase()}:${nonce.toLowerCase()}`;
+    if (this.seen.has(key)) return false;
+    if (this.seen.size >= this.maxEntries) {
+      // Map iteration order is insertion order; oldest first.
+      const oldestKey = this.seen.keys().next().value;
+      if (oldestKey !== undefined) this.seen.delete(oldestKey);
+    }
+    this.seen.set(key, issuedAtMs);
+    return true;
+  }
+
+  size(): number {
+    return this.seen.size;
+  }
+
+  private evictStale(nowMs: number): void {
+    const threshold = nowMs - CATCHUP_REQUEST_MAX_AGE_MS;
+    for (const [key, issuedAtMs] of this.seen) {
+      if (issuedAtMs < threshold) {
+        this.seen.delete(key);
+      } else {
+        // Insertion order = ascending issuedAtMs (approximately),
+        // so first non-stale entry means rest are also fresh.
+        break;
+      }
+    }
+  }
+}
+
+function randomNonceHex(): string {
+  const bytes = new Uint8Array(16);
+  // Node + browser both expose crypto.getRandomValues; the agent
+  // ships against Node ≥18 which has it on globalThis.crypto.
+  const c = (globalThis as { crypto?: { getRandomValues?: (b: Uint8Array) => Uint8Array } }).crypto;
+  if (c?.getRandomValues) {
+    c.getRandomValues(bytes);
+  } else {
+    // Fallback for legacy embeddings without crypto on globalThis.
+    // Math.random is NOT cryptographically secure, but the nonce is
+    // belt-and-braces (signature already binds the request); use it
+    // only when no secure RNG is available.
+    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  let out = '0x';
+  for (const b of bytes) out += b.toString(16).padStart(2, '0');
+  return out;
+}
+
+function uint256ToBytes(n: number): Uint8Array {
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(`uint256 input must be a non-negative finite number, got ${n}`);
+  }
+  const out = new Uint8Array(32);
+  let value = BigInt(Math.floor(n));
+  for (let i = 31; i >= 0 && value > 0n; i--) {
+    out[i] = Number(value & 0xffn);
+    value >>= 8n;
+  }
+  return out;
+}
+
+function hexTo16Bytes(hex: string): Uint8Array {
+  validateNonce16(hex);
+  return hexToBytes(hex, 16);
+}
+
+function addressToBytes(addr: string): Uint8Array {
+  validateAddress(addr, 'address');
+  return hexToBytes(addr, 20);
+}
+
+function hexToBytes(hex: string, expectedLen: number): Uint8Array {
+  const stripped = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (stripped.length !== expectedLen * 2) {
+    throw new Error(`expected ${expectedLen}-byte hex, got ${stripped.length / 2}`);
+  }
+  const out = new Uint8Array(expectedLen);
+  for (let i = 0; i < expectedLen; i++) {
+    out[i] = parseInt(stripped.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function validateAddress(hex: string, field: string): void {
+  if (typeof hex !== 'string' || !/^0x[0-9a-fA-F]{40}$/.test(hex)) {
+    throw new Error(`${field} must be 0x + 40 hex chars (20 bytes), got ${hex}`);
+  }
+}
+
+function validateNonce16(hex: string): void {
+  if (typeof hex !== 'string' || !/^0x[0-9a-fA-F]{32}$/.test(hex)) {
+    throw new Error(`nonce must be 0x + 32 hex chars (16 bytes), got ${hex}`);
+  }
+}

--- a/packages/agent/src/swm/host-catchup-sign.ts
+++ b/packages/agent/src/swm/host-catchup-sign.ts
@@ -127,7 +127,22 @@ export interface MintSignedCatchupRequestInput {
   sinceSeqno: number;
   maxEntries: number;
   maxBytes: number;
-  requesterEoa: string;
+  /**
+   * Optional. If provided, MUST match the address recovered from
+   * `sign(digest)`; otherwise the mint throws. If omitted, the
+   * helper computes the digest with a placeholder zero address,
+   * recovers the signer from the signature, then re-computes the
+   * digest binding to that recovered address.
+   *
+   * Codex PR #618 round-2: callers used to advertise the chain
+   * tx-signer address here (`getRegistrationTxSignerAddress`), but
+   * `sign` is wired to `chain.signMessage` which CAN sign with a
+   * different key (per its own helper comment). The receiver's
+   * verify step then rejected every request as "signer mismatch".
+   * Letting the helper recover the truth from the signature itself
+   * removes that whole class of mis-binding.
+   */
+  requesterEoa?: string;
   /** Unix epoch ms. Defaults to Date.now(). */
   issuedAtMs?: number;
   /** Hex-encoded 16-byte nonce. Auto-generated if omitted. */
@@ -143,25 +158,58 @@ export interface MintSignedCatchupRequestInput {
   version?: number;
 }
 
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
 export async function mintSignedCatchupRequest(
   input: MintSignedCatchupRequestInput,
 ): Promise<SignedCatchupRequest> {
   const version = input.version ?? 2;
   const issuedAtMs = input.issuedAtMs ?? Date.now();
   const nonce = input.nonce ?? randomNonceHex();
-  const fields: SignedCatchupRequestFields = {
+
+  // Two-pass to bind the digest to the actual signer:
+  // 1. Compute digest with claimed-or-placeholder address.
+  // 2. Sign it. Recover the address from the signature.
+  // 3. If claim was provided: require match (fail closed).
+  //    If not: re-build the request bound to the recovered
+  //    address and sign that.
+  const claimedEoa = input.requesterEoa?.toLowerCase();
+  const probeFields: SignedCatchupRequestFields = {
     version,
     contextGraphId: input.contextGraphId,
     sinceSeqno: input.sinceSeqno,
     maxEntries: input.maxEntries,
     maxBytes: input.maxBytes,
-    requesterEoa: input.requesterEoa.toLowerCase(),
+    requesterEoa: claimedEoa ?? ZERO_ADDRESS,
     issuedAtMs,
     nonce: nonce.toLowerCase(),
   };
-  const digest = computeCatchupRequestDigest(fields);
-  const sig = await input.sign(digest);
-  return { ...fields, sig };
+
+  if (claimedEoa) {
+    // Caller asserts the signer address. Sign + verify recovery matches.
+    const digest = computeCatchupRequestDigest(probeFields);
+    const sig = await input.sign(digest);
+    const recovered = ethers.verifyMessage(digest, sig).toLowerCase();
+    if (recovered !== claimedEoa) {
+      throw new Error(
+        `mintSignedCatchupRequest: requesterEoa=${claimedEoa} does not match signature signer ${recovered}. ` +
+          'Drop the explicit requesterEoa and let the helper bind to the actual signer, ' +
+          'or pass the chain.signMessage()-paired EOA.',
+      );
+    }
+    return { ...probeFields, sig };
+  }
+
+  // Discovery mode: sign a placeholder digest, recover the signer,
+  // then sign the FINAL digest with the bound address. Two sigs, but
+  // only the second one is ever sent over the wire.
+  const probeDigest = computeCatchupRequestDigest(probeFields);
+  const probeSig = await input.sign(probeDigest);
+  const recovered = ethers.verifyMessage(probeDigest, probeSig).toLowerCase();
+  const finalFields: SignedCatchupRequestFields = { ...probeFields, requesterEoa: recovered };
+  const finalDigest = computeCatchupRequestDigest(finalFields);
+  const finalSig = await input.sign(finalDigest);
+  return { ...finalFields, sig: finalSig };
 }
 
 /**

--- a/packages/agent/src/swm/host-catchup-wire.ts
+++ b/packages/agent/src/swm/host-catchup-wire.ts
@@ -16,18 +16,28 @@
  * the wire schema visible in tests and devnet logs and avoids
  * adding another protobuf descriptor to the build.
  *
- * Request schema:
+ * **Version 2 (current)** — closes the metadata-leak vector Codex
+ * flagged on PR #610: every request is now signed by the requester's
+ * chain EOA so the responder can authenticate without trusting the
+ * libp2p peer-id. See `host-catchup-sign.ts` for the digest layout
+ * and replay-defence reasoning.
+ *
+ * Request schema (v2):
  *   {
- *     version: 1,
- *     contextGraphId: string,
+ *     version: 2,
+ *     contextGraphId: string,             // keccak256 wire-id hex (0x + 64 chars)
  *     sinceSeqno: number (0 means "all entries"),
  *     maxEntries?: number (default DEFAULT_MAX_ENTRIES, hard-capped at MAX_MAX_ENTRIES),
- *     maxBytes?: number   (default DEFAULT_MAX_BYTES, hard-capped at MAX_MAX_BYTES)
+ *     maxBytes?: number   (default DEFAULT_MAX_BYTES, hard-capped at MAX_MAX_BYTES),
+ *     requesterEoa: string,               // 0x + 40 hex chars, lowercased
+ *     issuedAtMs: number,                 // unix epoch ms; freshness window enforced
+ *     nonce: string,                      // 0x + 32 hex chars; replay-defence
+ *     sig: string                         // 0x + 130 hex chars; EIP-191 personal-sign
  *   }
  *
  * Response schema:
  *   {
- *     version: 1,
+ *     version: 2,
  *     contextGraphId: string,
  *     nextSeqno: number,    // largest seqno returned, or sinceSeqno when empty
  *     truncated: boolean,   // true if more entries exist beyond what we returned
@@ -37,14 +47,19 @@
  *
  * Denial vs empty:
  *   - `denied` is set when the responder is unwilling/unable to serve
- *     (CG unknown, requester not authorised, host mode disabled). The
- *     requester treats this as a terminal failure for this peer.
+ *     (CG unknown, requester not authorised, host mode disabled, signature
+ *     invalid). The requester treats this as a terminal failure for this peer.
  *   - `entries.length === 0` with `denied` unset is a *valid empty*
  *     response — the requester is up-to-date relative to this host,
  *     or the host has nothing for that CG.
+ *
+ * Backward compatibility: v1 (unsigned) requests are NOT accepted by
+ * v2 responders. This is a deliberate hard cutover — the unsigned
+ * variant was vulnerable to metadata leakage and the LU-6 stack has
+ * not shipped yet, so there is no on-the-wire legacy to preserve.
  */
 
-export const SWM_HOST_CATCHUP_WIRE_VERSION = 1;
+export const SWM_HOST_CATCHUP_WIRE_VERSION = 2;
 
 export const DEFAULT_MAX_ENTRIES = 256;
 export const MAX_MAX_ENTRIES = 1024;
@@ -57,6 +72,14 @@ export interface SwmHostCatchupRequest {
   sinceSeqno: number;
   maxEntries?: number;
   maxBytes?: number;
+  /** 0x-prefixed lowercase 20-byte hex — requester's chain EOA. */
+  requesterEoa: string;
+  /** Unix epoch ms when the request was minted. */
+  issuedAtMs: number;
+  /** 0x-prefixed lowercase 16-byte hex — replay nonce. */
+  nonce: string;
+  /** 0x-prefixed 65-byte hex — EIP-191 personal-sign by `requesterEoa`. */
+  sig: string;
 }
 
 export interface SwmHostCatchupResponseEntry {
@@ -81,12 +104,31 @@ export function encodeSwmHostCatchupRequest(req: SwmHostCatchupRequest): Uint8Ar
   if (!req.contextGraphId) {
     throw new Error('contextGraphId is required');
   }
+  if (req.version !== SWM_HOST_CATCHUP_WIRE_VERSION) {
+    throw new Error(`unsupported wire version ${req.version}, expected ${SWM_HOST_CATCHUP_WIRE_VERSION}`);
+  }
+  if (!isHex(req.requesterEoa, 40)) {
+    throw new Error('requesterEoa must be 0x + 40 hex chars (20 bytes)');
+  }
+  if (!isHex(req.nonce, 32)) {
+    throw new Error('nonce must be 0x + 32 hex chars (16 bytes)');
+  }
+  if (!isHex(req.sig, 130)) {
+    throw new Error('sig must be 0x + 130 hex chars (65 bytes)');
+  }
+  if (!Number.isFinite(req.issuedAtMs) || req.issuedAtMs < 0) {
+    throw new Error('issuedAtMs must be a finite non-negative number');
+  }
   const normalized: SwmHostCatchupRequest = {
     version: SWM_HOST_CATCHUP_WIRE_VERSION,
     contextGraphId: req.contextGraphId,
     sinceSeqno: Math.floor(req.sinceSeqno),
     ...(req.maxEntries !== undefined ? { maxEntries: clamp(req.maxEntries, 1, MAX_MAX_ENTRIES) } : {}),
     ...(req.maxBytes !== undefined ? { maxBytes: clamp(req.maxBytes, 1, MAX_MAX_BYTES) } : {}),
+    requesterEoa: req.requesterEoa.toLowerCase(),
+    issuedAtMs: Math.floor(req.issuedAtMs),
+    nonce: req.nonce.toLowerCase(),
+    sig: req.sig,
   };
   return new TextEncoder().encode(JSON.stringify(normalized));
 }
@@ -103,12 +145,28 @@ export function decodeSwmHostCatchupRequest(bytes: Uint8Array): SwmHostCatchupRe
   if (typeof parsed.sinceSeqno !== 'number' || !Number.isFinite(parsed.sinceSeqno) || parsed.sinceSeqno < 0) {
     throw new Error('SwmHostCatchup request has invalid sinceSeqno');
   }
+  if (typeof parsed.requesterEoa !== 'string' || !isHex(parsed.requesterEoa, 40)) {
+    throw new Error('SwmHostCatchup request missing or malformed requesterEoa');
+  }
+  if (typeof parsed.issuedAtMs !== 'number' || !Number.isFinite(parsed.issuedAtMs) || parsed.issuedAtMs < 0) {
+    throw new Error('SwmHostCatchup request has invalid issuedAtMs');
+  }
+  if (typeof parsed.nonce !== 'string' || !isHex(parsed.nonce, 32)) {
+    throw new Error('SwmHostCatchup request missing or malformed nonce');
+  }
+  if (typeof parsed.sig !== 'string' || !isHex(parsed.sig, 130)) {
+    throw new Error('SwmHostCatchup request missing or malformed sig');
+  }
   return {
     version: SWM_HOST_CATCHUP_WIRE_VERSION,
     contextGraphId: parsed.contextGraphId,
     sinceSeqno: Math.floor(parsed.sinceSeqno),
     ...(parsed.maxEntries !== undefined ? { maxEntries: clamp(parsed.maxEntries, 1, MAX_MAX_ENTRIES) } : {}),
     ...(parsed.maxBytes !== undefined ? { maxBytes: clamp(parsed.maxBytes, 1, MAX_MAX_BYTES) } : {}),
+    requesterEoa: parsed.requesterEoa.toLowerCase(),
+    issuedAtMs: Math.floor(parsed.issuedAtMs),
+    nonce: parsed.nonce.toLowerCase(),
+    sig: parsed.sig,
   };
 }
 
@@ -151,6 +209,12 @@ export function decodeSwmHostCatchupResponse(bytes: Uint8Array): SwmHostCatchupR
     ...(typeof parsed.denied === 'string' ? { denied: parsed.denied } : {}),
     entries: entries as SwmHostCatchupResponseEntry[],
   };
+}
+
+function isHex(value: string, expectedLen: number): boolean {
+  if (typeof value !== 'string') return false;
+  const stripped = value.startsWith('0x') ? value.slice(2) : value;
+  return stripped.length === expectedLen && /^[0-9a-fA-F]+$/.test(stripped);
 }
 
 function clamp(value: number, lo: number, hi: number): number {

--- a/packages/agent/test/swm/host-catchup-sign.test.ts
+++ b/packages/agent/test/swm/host-catchup-sign.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  computeCatchupRequestDigest,
+  mintSignedCatchupRequest,
+  verifySignedCatchupRequest,
+  CatchupReplayGuard,
+  CATCHUP_REQUEST_MAX_AGE_MS,
+} from '../../src/swm/host-catchup-sign.js';
+
+const FIXED_NOW = 1_700_000_000_000;
+
+async function mintWith(wallet: ethers.Wallet, overrides: Partial<{ contextGraphId: string; sinceSeqno: number; nonce: string; issuedAtMs: number }> = {}) {
+  return mintSignedCatchupRequest({
+    contextGraphId: overrides.contextGraphId ?? 'curator/cg-1',
+    sinceSeqno: overrides.sinceSeqno ?? 0,
+    maxEntries: 32,
+    maxBytes: 64 * 1024,
+    requesterEoa: wallet.address,
+    issuedAtMs: overrides.issuedAtMs ?? FIXED_NOW,
+    nonce: overrides.nonce,
+    sign: async (digest) => wallet.signMessage(digest),
+  });
+}
+
+describe('host-catchup-sign (B1: signed catchup requests)', () => {
+  describe('mint + verify roundtrip', () => {
+    it('accepts a well-formed signature within the freshness window', async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const req = await mintWith(wallet);
+      const result = verifySignedCatchupRequest(req, FIXED_NOW + 1000);
+      expect(result.ok).toBe(true);
+      expect(result.recoveredSigner).toBe(wallet.address.toLowerCase());
+    });
+
+    it('rejects a tampered contextGraphId (digest no longer matches)', async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const req = await mintWith(wallet);
+      const tampered = { ...req, contextGraphId: 'attacker/owned-cg' };
+      const result = verifySignedCatchupRequest(tampered, FIXED_NOW);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toMatch(/signer mismatch/i);
+    });
+
+    it('rejects a tampered sinceSeqno (digest no longer matches)', async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const req = await mintWith(wallet, { sinceSeqno: 5 });
+      const tampered = { ...req, sinceSeqno: 999 };
+      const result = verifySignedCatchupRequest(tampered, FIXED_NOW);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toMatch(/signer mismatch/i);
+    });
+
+    it('rejects a request signed by a different wallet than requesterEoa claims', async () => {
+      const a = ethers.Wallet.createRandom();
+      const b = ethers.Wallet.createRandom();
+      const req = await mintWith(a);
+      const swapped = { ...req, requesterEoa: b.address.toLowerCase() };
+      const result = verifySignedCatchupRequest(swapped, FIXED_NOW);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toMatch(/signer mismatch/i);
+    });
+  });
+
+  describe('freshness window', () => {
+    it('rejects requests older than CATCHUP_REQUEST_MAX_AGE_MS', async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const req = await mintWith(wallet, { issuedAtMs: FIXED_NOW });
+      const stale = verifySignedCatchupRequest(req, FIXED_NOW + CATCHUP_REQUEST_MAX_AGE_MS + 1);
+      expect(stale.ok).toBe(false);
+      expect(stale.reason).toMatch(/age/i);
+    });
+
+    it('rejects requests with future-skewed timestamps beyond the window', async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const req = await mintWith(wallet, { issuedAtMs: FIXED_NOW + CATCHUP_REQUEST_MAX_AGE_MS + 2000 });
+      const future = verifySignedCatchupRequest(req, FIXED_NOW);
+      expect(future.ok).toBe(false);
+      expect(future.reason).toMatch(/age/i);
+    });
+
+    it('accepts requests just inside the window boundary', async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const req = await mintWith(wallet, { issuedAtMs: FIXED_NOW });
+      const justInside = verifySignedCatchupRequest(req, FIXED_NOW + CATCHUP_REQUEST_MAX_AGE_MS - 1);
+      expect(justInside.ok).toBe(true);
+    });
+  });
+
+  describe('digest binding', () => {
+    it('binds to maxEntries (so digest changes when client lies about caps)', () => {
+      const base = {
+        version: 2,
+        contextGraphId: 'cg/x',
+        sinceSeqno: 0,
+        maxEntries: 32,
+        maxBytes: 64 * 1024,
+        requesterEoa: '0x' + 'a'.repeat(40),
+        issuedAtMs: FIXED_NOW,
+        nonce: '0x' + '00'.repeat(16),
+      };
+      const d1 = computeCatchupRequestDigest(base);
+      const d2 = computeCatchupRequestDigest({ ...base, maxEntries: 999 });
+      expect(Buffer.from(d1).toString('hex')).not.toBe(Buffer.from(d2).toString('hex'));
+    });
+
+    it('binds to nonce (so replay-defence can rely on it being signed)', () => {
+      const base = {
+        version: 2,
+        contextGraphId: 'cg/x',
+        sinceSeqno: 0,
+        maxEntries: 32,
+        maxBytes: 64 * 1024,
+        requesterEoa: '0x' + 'a'.repeat(40),
+        issuedAtMs: FIXED_NOW,
+        nonce: '0x' + '00'.repeat(16),
+      };
+      const d1 = computeCatchupRequestDigest(base);
+      const d2 = computeCatchupRequestDigest({ ...base, nonce: '0x' + 'ff'.repeat(16) });
+      expect(Buffer.from(d1).toString('hex')).not.toBe(Buffer.from(d2).toString('hex'));
+    });
+  });
+
+  describe('CatchupReplayGuard', () => {
+    it('admits a fresh (eoa, nonce) pair', () => {
+      const guard = new CatchupReplayGuard();
+      expect(guard.recordIfFresh('0xabc', '0xnonce1', FIXED_NOW, FIXED_NOW)).toBe(true);
+    });
+
+    it('rejects a replay of the same (eoa, nonce) pair within the window', () => {
+      const guard = new CatchupReplayGuard();
+      guard.recordIfFresh('0xabc', '0xnonce1', FIXED_NOW, FIXED_NOW);
+      expect(guard.recordIfFresh('0xabc', '0xnonce1', FIXED_NOW, FIXED_NOW + 1000)).toBe(false);
+    });
+
+    it('distinguishes by EOA (same nonce, different wallet → fresh)', () => {
+      const guard = new CatchupReplayGuard();
+      guard.recordIfFresh('0xabc', '0xnonce1', FIXED_NOW, FIXED_NOW);
+      expect(guard.recordIfFresh('0xdef', '0xnonce1', FIXED_NOW, FIXED_NOW + 1000)).toBe(true);
+    });
+
+    it('evicts stale entries once they age beyond the freshness window', () => {
+      const guard = new CatchupReplayGuard();
+      guard.recordIfFresh('0xabc', '0xnonce1', FIXED_NOW, FIXED_NOW);
+      // Advance wall-clock past freshness window and probe with a new
+      // entry (which triggers eviction). The old nonce should now be
+      // re-admittable.
+      guard.recordIfFresh('0xabc', '0xnonce2', FIXED_NOW + CATCHUP_REQUEST_MAX_AGE_MS + 1000, FIXED_NOW + CATCHUP_REQUEST_MAX_AGE_MS + 1000);
+      // Both old nonces have aged out; reusing nonce1 is now fresh because
+      // the freshness check would also reject it independently. Confirm
+      // the guard's internal book-keeping evicted it (size shrunk).
+      // size = 1 (only nonce2 remains)
+      expect(guard.size()).toBe(1);
+    });
+
+    it('caps memory: evicts oldest first when over the LRU max', () => {
+      const guard = new CatchupReplayGuard(3);
+      guard.recordIfFresh('0xa', '0xn1', FIXED_NOW, FIXED_NOW);
+      guard.recordIfFresh('0xa', '0xn2', FIXED_NOW + 100, FIXED_NOW + 100);
+      guard.recordIfFresh('0xa', '0xn3', FIXED_NOW + 200, FIXED_NOW + 200);
+      guard.recordIfFresh('0xa', '0xn4', FIXED_NOW + 300, FIXED_NOW + 300);
+      // n1 should be evicted; nonces n2..n4 should still reject as replays.
+      expect(guard.recordIfFresh('0xa', '0xn1', FIXED_NOW, FIXED_NOW + 300)).toBe(true);
+      expect(guard.recordIfFresh('0xa', '0xn4', FIXED_NOW + 300, FIXED_NOW + 400)).toBe(false);
+    });
+  });
+});

--- a/packages/agent/test/swm/host-catchup-sign.test.ts
+++ b/packages/agent/test/swm/host-catchup-sign.test.ts
@@ -62,6 +62,40 @@ describe('host-catchup-sign (B1: signed catchup requests)', () => {
     });
   });
 
+  describe('B1 round-2: requesterEoa derivation from signer', () => {
+    it('discovery mode (no requesterEoa supplied) binds digest to recovered signer', async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const req = await mintSignedCatchupRequest({
+        contextGraphId: 'cg/x',
+        sinceSeqno: 0,
+        maxEntries: 32,
+        maxBytes: 64 * 1024,
+        // requesterEoa intentionally omitted
+        issuedAtMs: FIXED_NOW,
+        sign: async (digest) => wallet.signMessage(digest),
+      });
+      expect(req.requesterEoa).toBe(wallet.address.toLowerCase());
+      const result = verifySignedCatchupRequest(req, FIXED_NOW + 1000);
+      expect(result.ok).toBe(true);
+    });
+
+    it('throws when caller claims a requesterEoa that does not match the actual signer', async () => {
+      const signing = ethers.Wallet.createRandom();
+      const wrongClaim = ethers.Wallet.createRandom();
+      await expect(
+        mintSignedCatchupRequest({
+          contextGraphId: 'cg/x',
+          sinceSeqno: 0,
+          maxEntries: 32,
+          maxBytes: 64 * 1024,
+          requesterEoa: wrongClaim.address,
+          issuedAtMs: FIXED_NOW,
+          sign: async (digest) => signing.signMessage(digest),
+        }),
+      ).rejects.toThrow(/does not match signature signer/i);
+    });
+  });
+
   describe('freshness window', () => {
     it('rejects requests older than CATCHUP_REQUEST_MAX_AGE_MS', async () => {
       const wallet = ethers.Wallet.createRandom();

--- a/packages/agent/test/swm/host-catchup-wire.test.ts
+++ b/packages/agent/test/swm/host-catchup-wire.test.ts
@@ -1,10 +1,30 @@
 import { describe, it, expect } from 'vitest';
+import { ethers } from 'ethers';
 import {
   encodeSwmHostCatchupRequest,
   encodeSwmHostCatchupResponse,
+  decodeSwmHostCatchupRequest,
   decodeSwmHostCatchupResponse,
   SWM_HOST_CATCHUP_WIRE_VERSION,
 } from '../../src/swm/host-catchup-wire.js';
+import {
+  computeCatchupRequestDigest,
+  mintSignedCatchupRequest,
+} from '../../src/swm/host-catchup-sign.js';
+
+const SIG_FILLER = '0x' + 'aa'.repeat(65); // shape-valid 65-byte hex (won't verify, but encode/decode only)
+const NONCE_FILLER = '0x' + '00'.repeat(16);
+
+async function buildSignedRequestWith(wallet: ethers.Wallet, opts: { sinceSeqno?: number; cgId?: string } = {}) {
+  return mintSignedCatchupRequest({
+    contextGraphId: opts.cgId ?? 'curator/cg-1',
+    sinceSeqno: opts.sinceSeqno ?? 0,
+    maxEntries: 32,
+    maxBytes: 64 * 1024,
+    requesterEoa: wallet.address,
+    sign: async (digest) => wallet.signMessage(digest),
+  });
+}
 
 describe('SwmHostCatchup wire (PR #610 round-2 Codex follow-ups)', () => {
   describe('decode: nextSeqno validation (#9)', () => {
@@ -66,24 +86,113 @@ describe('SwmHostCatchup wire (PR #610 round-2 Codex follow-ups)', () => {
     });
 
     it('rejects Infinity nextSeqno', () => {
-      const malformed = new TextEncoder().encode(`{"version":1,"contextGraphId":"c/g","nextSeqno":1e999,"truncated":false,"entries":[]}`);
+      const malformed = new TextEncoder().encode(`{"version":${SWM_HOST_CATCHUP_WIRE_VERSION},"contextGraphId":"c/g","nextSeqno":1e999,"truncated":false,"entries":[]}`);
       expect(() => decodeSwmHostCatchupResponse(malformed)).toThrow(/invalid nextSeqno/i);
     });
   });
 
-  describe('request encode/decode roundtrip', () => {
-    it('encodes a well-formed request', () => {
+  describe('request encode/decode roundtrip (B1: signed requests)', () => {
+    it('encodes and decodes a well-formed signed request', async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const signed = await buildSignedRequestWith(wallet);
       const wire = encodeSwmHostCatchupRequest({
         version: SWM_HOST_CATCHUP_WIRE_VERSION,
         contextGraphId: 'curator/cg-1',
         sinceSeqno: 0,
         maxEntries: 32,
+        maxBytes: 64 * 1024,
+        requesterEoa: signed.requesterEoa,
+        issuedAtMs: signed.issuedAtMs,
+        nonce: signed.nonce,
+        sig: signed.sig,
       });
       expect(wire.byteLength).toBeGreaterThan(0);
-      // The body is JSON; should be parseable.
-      const parsed = JSON.parse(new TextDecoder().decode(wire));
-      expect(parsed.contextGraphId).toBe('curator/cg-1');
-      expect(parsed.sinceSeqno).toBe(0);
+      const decoded = decodeSwmHostCatchupRequest(wire);
+      expect(decoded.contextGraphId).toBe('curator/cg-1');
+      expect(decoded.sinceSeqno).toBe(0);
+      expect(decoded.requesterEoa).toBe(wallet.address.toLowerCase());
+      expect(decoded.sig).toBe(signed.sig);
+    });
+
+    it('rejects request missing requesterEoa', () => {
+      const malformed = new TextEncoder().encode(JSON.stringify({
+        version: SWM_HOST_CATCHUP_WIRE_VERSION,
+        contextGraphId: 'curator/cg-1',
+        sinceSeqno: 0,
+        issuedAtMs: Date.now(),
+        nonce: NONCE_FILLER,
+        sig: SIG_FILLER,
+      }));
+      expect(() => decodeSwmHostCatchupRequest(malformed)).toThrow(/requesterEoa/);
+    });
+
+    it('rejects request with malformed sig (wrong length)', () => {
+      const malformed = new TextEncoder().encode(JSON.stringify({
+        version: SWM_HOST_CATCHUP_WIRE_VERSION,
+        contextGraphId: 'curator/cg-1',
+        sinceSeqno: 0,
+        requesterEoa: '0x' + 'a'.repeat(40),
+        issuedAtMs: Date.now(),
+        nonce: NONCE_FILLER,
+        sig: '0xdeadbeef',
+      }));
+      expect(() => decodeSwmHostCatchupRequest(malformed)).toThrow(/sig/);
+    });
+
+    it('rejects request with malformed nonce (wrong length)', () => {
+      const malformed = new TextEncoder().encode(JSON.stringify({
+        version: SWM_HOST_CATCHUP_WIRE_VERSION,
+        contextGraphId: 'curator/cg-1',
+        sinceSeqno: 0,
+        requesterEoa: '0x' + 'a'.repeat(40),
+        issuedAtMs: Date.now(),
+        nonce: '0xdead',
+        sig: SIG_FILLER,
+      }));
+      expect(() => decodeSwmHostCatchupRequest(malformed)).toThrow(/nonce/);
+    });
+
+    it('rejects v1 (legacy unsigned) requests — hard cutover', () => {
+      const v1 = new TextEncoder().encode(JSON.stringify({
+        version: 1,
+        contextGraphId: 'curator/cg-1',
+        sinceSeqno: 0,
+      }));
+      expect(() => decodeSwmHostCatchupRequest(v1)).toThrow(/version/i);
+    });
+  });
+
+  describe('digest determinism', () => {
+    it('produces identical digests for identical fields across runs', () => {
+      const fields = {
+        version: 2,
+        contextGraphId: 'curator/cg-determinism',
+        sinceSeqno: 7,
+        maxEntries: 32,
+        maxBytes: 64 * 1024,
+        requesterEoa: '0x' + 'a'.repeat(40),
+        issuedAtMs: 1_700_000_000_000,
+        nonce: '0x' + '01'.repeat(16),
+      };
+      const d1 = computeCatchupRequestDigest(fields);
+      const d2 = computeCatchupRequestDigest(fields);
+      expect(Buffer.from(d1).toString('hex')).toBe(Buffer.from(d2).toString('hex'));
+    });
+
+    it('produces different digests when contextGraphId differs', () => {
+      const base = {
+        version: 2,
+        contextGraphId: 'curator/cg-a',
+        sinceSeqno: 0,
+        maxEntries: 32,
+        maxBytes: 64 * 1024,
+        requesterEoa: '0x' + 'a'.repeat(40),
+        issuedAtMs: 1_700_000_000_000,
+        nonce: '0x' + '01'.repeat(16),
+      };
+      const d1 = computeCatchupRequestDigest(base);
+      const d2 = computeCatchupRequestDigest({ ...base, contextGraphId: 'curator/cg-b' });
+      expect(Buffer.from(d1).toString('hex')).not.toBe(Buffer.from(d2).toString('hex'));
     });
   });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
       'test/e2e-dht-dial.test.ts',
       'test/generic-sql-source.test.ts',
       'test/query-min-trust-alias.test.ts',
+      'test/swm/host-catchup-sign.test.ts',
+      'test/swm/host-catchup-wire.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## Summary

Closes the metadata-leak vector Codex flagged on PR #610 round-2 #6: the previous host-catchup wire let any peer that knew or guessed a `contextGraphId` pull stored envelopes from a host-only core. The local `allowedPeers` mitigation only covered member-side nodes — host-only cores have no local allowlist and fell through to unauthenticated serving.

Stacked on #610 (which is itself stacked on #609 → #608 → #595).

## Wire change (v1 → v2, hard cutover)

- `SwmHostCatchupRequest` now carries `requesterEoa`, `issuedAtMs`, `nonce`, and `sig`.
- `sig` is EIP-191 personal-sign over a 228-byte packed digest binding `version + keccak256(cgId) + sinceSeqno + maxEntries + maxBytes + requesterEoa + issuedAtMs + nonce`.
- New `swm/host-catchup-sign.ts` — digest layout, mint + verify, and a per-responder `CatchupReplayGuard`.
- No back-compat: LU-6 hasn't shipped yet so there is no on-the-wire legacy to preserve.

## Responder authorization (layered, deny-by-default)

\`authorizeSwmHostCatchupRequest\` runs:
1. Signature recovery + freshness (5 min, matches the SWM envelope window).
2. Replay-nonce uniqueness.
3. **Chain-anchored**: \`requesterEoa ∈ participantAgents\` (definitive when chain context is available).
4. **Pre-registration fallback**: \`requesterEoa == beacon-pinned curator\` (curator can always catch up themselves before paying gas).
5. **Member-side**: \`allowedPeers\` peer-id check (defence in depth when local meta is present).
6. Otherwise DENY — replaces the previous \"serve openly when no authority source available\" behaviour.

## Requester

\`catchupSwmFromHost\` mints a signed request per round via \`chain.signMessage\`. Fails closed when no chain signer is wired (returns \`{ denied: 'no chain signer...' }\` rather than sending unsigned).

## Test plan

- [x] 14 \`host-catchup-sign.test.ts\` cases: mint/verify roundtrip, tampered fields, freshness boundary, digest binding, replay-guard LRU
- [x] 6 new \`host-catchup-wire.test.ts\` cases: signed wire encode/decode, malformed sig/nonce, hard v1 rejection, digest determinism
- [x] All cases added to \`vitest.unit.config.ts\` allowlist (44 tests passing)
- [ ] Devnet validation — covered once #610 + this branch merge

## Out of scope (follow-ups)

- B2 (PR follow-up): orphaned \`.log\` reconcile on host-mode-store startup
- B3 (PR follow-up): host-only designation persistence across restart
- C-series: end-to-end devnet scenarios (member revocation, curator-offline mid-batch, unclean restart, pre-reg stress)

Made with [Cursor](https://cursor.com)