### PR TITLE
OT-RFC-38 LU-6 B2 — reconcile orphan host-mode .log files on startup

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -8863,10 +8863,21 @@ export class DKGAgent {
     }
     const defaults = SwmHostModeStore.defaultLimits();
     const { join } = await import('node:path');
+    const swmHostStartupCtx = createOperationContext('share');
     this.swmHostModeStore = new SwmHostModeStore({
       dataDir: join(this.config.dataDir, 'swm-host'),
       unregisteredLimits: hostModeCfg.unregistered ?? defaults.unregistered,
       registeredLimits: hostModeCfg.registered ?? defaults.registered,
+      // B2: surface the orphan-log reconcile report through the
+      // agent's log facade so operators can see exactly how many
+      // bytes were recovered after a crash.
+      onStartupReconcile: ({ orphanLogsRemoved, orphanBytesRemoved }) => {
+        this.log.warn(
+          swmHostStartupCtx,
+          `Host-mode startup reconcile reaped orphan logs: count=${orphanLogsRemoved} bytes=${orphanBytesRemoved} ` +
+          `(crashed appendFile→persistMeta windows produce these — they were unservable + unprunable until now)`,
+        );
+      },
     });
     await this.swmHostModeStore.init();
 

--- a/packages/agent/src/swm/host-mode-store.ts
+++ b/packages/agent/src/swm/host-mode-store.ts
@@ -134,6 +134,7 @@ export class SwmHostModeStore {
   private readonly metaCache = new Map<string, CgMetaState>();
   private readonly inflightWrites = new Map<string, Promise<void>>();
   private initialized = false;
+  private lastStartupReconcileReport: SwmHostModeStartupReconcileReport | undefined;
 
   constructor(options: SwmHostModeStoreOptions) {
     this.dataDir = options.dataDir;
@@ -151,6 +152,7 @@ export class SwmHostModeStore {
     if (this.initialized) return;
     await fs.mkdir(this.dataDir, { recursive: true });
     const report = await this.reconcileOrphanLogs();
+    this.lastStartupReconcileReport = report;
     this.initialized = true;
     if (this.onStartupReconcile && (report.orphanLogsRemoved > 0 || report.orphanBytesRemoved > 0)) {
       try {
@@ -162,12 +164,22 @@ export class SwmHostModeStore {
   }
 
   /**
-   * Test-only / operator helper: re-run the orphan-log sweep without
-   * re-initialising. Returns the totals for the current pass.
+   * Test-only / operator helper: get the orphan-log reconcile report
+   * the store actually applied. Codex PR #619 R2: on a first call
+   * before `init()` has captured anything, we lazily run init() and
+   * return the report it produced — NOT a second sweep, which would
+   * always come back empty after init's first pass already cleaned
+   * up.
    */
   async reconcileOrphanLogsNow(): Promise<SwmHostModeStartupReconcileReport> {
+    const wasInitialized = this.initialized;
     await this.init();
-    return this.reconcileOrphanLogs();
+    if (!wasInitialized && this.lastStartupReconcileReport) {
+      return this.lastStartupReconcileReport;
+    }
+    const report = await this.reconcileOrphanLogs();
+    this.lastStartupReconcileReport = report;
+    return report;
   }
 
   /**
@@ -194,12 +206,35 @@ export class SwmHostModeStore {
     } catch {
       return { orphanLogsRemoved: 0, orphanBytesRemoved: 0 };
     }
-    const metaKeys = new Set<string>();
+    // Codex PR #619 R2: only count a .meta as "healthy pairing
+    // candidate" if it parses as valid JSON with a contextGraphId.
+    // A crash mid-`writeFile(metaPath, ...)` can leave a truncated
+    // file; `loadMeta()` / `listKnownCgs()` already treat that as
+    // unusable, so the paired .log is still unservable + unprunable
+    // and must be reaped here too.
+    const validMetaKeys = new Set<string>();
+    const corruptMetaNames: string[] = [];
     const logFiles: { key: string; name: string }[] = [];
     for (const e of entries) {
       if (!e.isFile()) continue;
       if (e.name.endsWith('.meta')) {
-        metaKeys.add(e.name.slice(0, -'.meta'.length));
+        const metaPath = path.join(this.dataDir, e.name);
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(await fs.readFile(metaPath, 'utf-8'));
+        } catch {
+          corruptMetaNames.push(e.name);
+          continue;
+        }
+        if (
+          parsed && typeof parsed === 'object'
+          && typeof (parsed as { contextGraphId?: unknown }).contextGraphId === 'string'
+          && (parsed as { contextGraphId: string }).contextGraphId.length > 0
+        ) {
+          validMetaKeys.add(e.name.slice(0, -'.meta'.length));
+        } else {
+          corruptMetaNames.push(e.name);
+        }
       } else if (e.name.endsWith('.log')) {
         logFiles.push({ key: e.name.slice(0, -'.log'.length), name: e.name });
       }
@@ -207,7 +242,7 @@ export class SwmHostModeStore {
     let orphanLogsRemoved = 0;
     let orphanBytesRemoved = 0;
     for (const { key, name } of logFiles) {
-      if (metaKeys.has(key)) continue;
+      if (validMetaKeys.has(key)) continue;
       const fullPath = path.join(this.dataDir, name);
       try {
         const stat = await fs.stat(fullPath);
@@ -216,6 +251,20 @@ export class SwmHostModeStore {
         orphanLogsRemoved += 1;
       } catch {
         // best-effort; another process may have removed the file
+      }
+    }
+    // Also reap corrupt .meta files themselves so subsequent inits
+    // don't keep tripping over them. Their footprint is tiny (counted
+    // in orphanBytesRemoved for observability).
+    for (const name of corruptMetaNames) {
+      const fullPath = path.join(this.dataDir, name);
+      try {
+        const stat = await fs.stat(fullPath);
+        orphanBytesRemoved += stat.size;
+        await fs.rm(fullPath, { force: true });
+        orphanLogsRemoved += 1;
+      } catch {
+        // best-effort
       }
     }
     return { orphanLogsRemoved, orphanBytesRemoved };

--- a/packages/agent/src/swm/host-mode-store.ts
+++ b/packages/agent/src/swm/host-mode-store.ts
@@ -55,6 +55,27 @@ export interface SwmHostModeStoreOptions {
   registeredLimits: SwmHostModeStoreLimits;
   /** Clock override for tests. Defaults to `Date.now`. */
   now?: () => number;
+  /**
+   * Optional callback fired by `init()` after the orphan-log
+   * reconciliation pass. Receives the per-startup totals so the
+   * agent can surface them through its own logging facade. Pure
+   * observability — the store itself does not log.
+   */
+  onStartupReconcile?: (report: SwmHostModeStartupReconcileReport) => void;
+}
+
+/**
+ * Summary of the orphan-log sweep performed by `init()`. A `.log`
+ * file without a matching `.meta` cannot be served via catchup (no
+ * cleartext `contextGraphId` to dispatch on), pruned (the prune
+ * path keys off meta files), or reported in stats — those bytes are
+ * dead storage that accumulate after a crash between `appendFile`
+ * (durable) and `persistMeta` (durable) for a brand-new CG's first
+ * envelope. We delete orphans at init to recover the disk.
+ */
+export interface SwmHostModeStartupReconcileReport {
+  orphanLogsRemoved: number;
+  orphanBytesRemoved: number;
 }
 
 export interface SwmHostModeStats {
@@ -109,6 +130,7 @@ export class SwmHostModeStore {
   private readonly unregisteredLimits: SwmHostModeStoreLimits;
   private readonly registeredLimits: SwmHostModeStoreLimits;
   private readonly now: () => number;
+  private readonly onStartupReconcile?: (report: SwmHostModeStartupReconcileReport) => void;
   private readonly metaCache = new Map<string, CgMetaState>();
   private readonly inflightWrites = new Map<string, Promise<void>>();
   private initialized = false;
@@ -118,6 +140,7 @@ export class SwmHostModeStore {
     this.unregisteredLimits = options.unregisteredLimits ?? DEFAULT_UNREGISTERED_LIMITS;
     this.registeredLimits = options.registeredLimits ?? DEFAULT_REGISTERED_LIMITS;
     this.now = options.now ?? (() => Date.now());
+    this.onStartupReconcile = options.onStartupReconcile;
   }
 
   static defaultLimits(): { unregistered: SwmHostModeStoreLimits; registered: SwmHostModeStoreLimits } {
@@ -127,7 +150,75 @@ export class SwmHostModeStore {
   async init(): Promise<void> {
     if (this.initialized) return;
     await fs.mkdir(this.dataDir, { recursive: true });
+    const report = await this.reconcileOrphanLogs();
     this.initialized = true;
+    if (this.onStartupReconcile && (report.orphanLogsRemoved > 0 || report.orphanBytesRemoved > 0)) {
+      try {
+        this.onStartupReconcile(report);
+      } catch {
+        // observability callback must never break init
+      }
+    }
+  }
+
+  /**
+   * Test-only / operator helper: re-run the orphan-log sweep without
+   * re-initialising. Returns the totals for the current pass.
+   */
+  async reconcileOrphanLogsNow(): Promise<SwmHostModeStartupReconcileReport> {
+    await this.init();
+    return this.reconcileOrphanLogs();
+  }
+
+  /**
+   * Scan `dataDir` for `.log` files without a matching `.meta` and
+   * delete them. Orphans typically result from a crash between
+   * `appendFile` (durable) and `persistMeta` (durable) during the
+   * first envelope for a brand-new CG. Without meta we cannot:
+   *   - serve catchup (no cleartext contextGraphId to dispatch on)
+   *   - prune (the prune path keys off meta files)
+   *   - report in stats
+   * so the bytes are dead storage. Delete-at-init recovers the disk.
+   *
+   * `.meta` files without a matching `.log` are deliberately NOT
+   * removed: `markRegistered` writes a meta even for CGs that have
+   * never received an envelope, and a prune-to-empty leaves the meta
+   * behind. Both are harmless (zero-byte footprint) and the meta
+   * carries the cleartext `contextGraphId` we need for future
+   * append-time meta reconstruction.
+   */
+  private async reconcileOrphanLogs(): Promise<SwmHostModeStartupReconcileReport> {
+    let entries: Dirent[] = [];
+    try {
+      entries = await fs.readdir(this.dataDir, { withFileTypes: true });
+    } catch {
+      return { orphanLogsRemoved: 0, orphanBytesRemoved: 0 };
+    }
+    const metaKeys = new Set<string>();
+    const logFiles: { key: string; name: string }[] = [];
+    for (const e of entries) {
+      if (!e.isFile()) continue;
+      if (e.name.endsWith('.meta')) {
+        metaKeys.add(e.name.slice(0, -'.meta'.length));
+      } else if (e.name.endsWith('.log')) {
+        logFiles.push({ key: e.name.slice(0, -'.log'.length), name: e.name });
+      }
+    }
+    let orphanLogsRemoved = 0;
+    let orphanBytesRemoved = 0;
+    for (const { key, name } of logFiles) {
+      if (metaKeys.has(key)) continue;
+      const fullPath = path.join(this.dataDir, name);
+      try {
+        const stat = await fs.stat(fullPath);
+        orphanBytesRemoved += stat.size;
+        await fs.rm(fullPath, { force: true });
+        orphanLogsRemoved += 1;
+      } catch {
+        // best-effort; another process may have removed the file
+      }
+    }
+    return { orphanLogsRemoved, orphanBytesRemoved };
   }
 
   /**

--- a/packages/agent/test/swm/host-mode-store.test.ts
+++ b/packages/agent/test/swm/host-mode-store.test.ts
@@ -354,5 +354,73 @@ describe('SwmHostModeStore', () => {
       });
       await expect(store.init()).resolves.toBeUndefined();
     });
+
+    describe('B2 round-2: Codex feedback', () => {
+      it('reconcileOrphanLogsNow returns the init-time report on the first call (not {0,0} after init swept)', async () => {
+        // Codex PR #619 R2: prior behavior always returned {0,0} on
+        // the first invocation because init() had already run the
+        // reconcile sweep before reconcileOrphanLogsNow() got a
+        // chance, making the operator/helper API misleading.
+        const orphanKey = cgKey('curator/init-reaped');
+        await writeFile(path.join(dir, `${orphanKey}.log`), Buffer.from('garbage-bytes-12345'));
+        const store = new SwmHostModeStore({
+          dataDir: dir,
+          unregisteredLimits: limits,
+          registeredLimits: limits,
+        });
+        // No prior init() — the helper triggers it internally.
+        const report = await store.reconcileOrphanLogsNow();
+        expect(report.orphanLogsRemoved).toBe(1);
+        expect(report.orphanBytesRemoved).toBe(19);
+        // Second call goes through reconcileOrphanLogs again (no
+        // orphans left now).
+        const second = await store.reconcileOrphanLogsNow();
+        expect(second.orphanLogsRemoved).toBe(0);
+      });
+
+      it('reaps .log paired with a .meta that fails to parse as JSON (crashed mid-persist)', async () => {
+        // Codex PR #619 R2: a crash mid-`writeFile(metaPath, ...)`
+        // can leave a truncated/invalid .meta. `loadMeta()` and
+        // `listKnownCgs()` already treat that as unusable, so the
+        // matching .log is still unservable + unprunable. The
+        // reconcile pass must reap both.
+        const corruptKey = cgKey('curator/half-persisted');
+        await writeFile(path.join(dir, `${corruptKey}.meta`), Buffer.from('{"seqno":3,"reg'));
+        await writeFile(path.join(dir, `${corruptKey}.log`), Buffer.from('xxxxxxxxxx'));
+
+        let reportSeen: { orphanLogsRemoved: number; orphanBytesRemoved: number } | null = null;
+        const store = new SwmHostModeStore({
+          dataDir: dir,
+          unregisteredLimits: limits,
+          registeredLimits: limits,
+          onStartupReconcile: (r) => { reportSeen = r; },
+        });
+        await store.init();
+        expect(reportSeen).not.toBeNull();
+        expect(reportSeen!.orphanLogsRemoved).toBe(2);
+
+        const after = await readdir(dir);
+        expect(after).not.toContain(`${corruptKey}.log`);
+        expect(after).not.toContain(`${corruptKey}.meta`);
+      });
+
+      it('reaps .log paired with a .meta missing contextGraphId (parses as JSON but is unusable)', async () => {
+        const corruptKey = cgKey('curator/meta-missing-cgid');
+        await writeFile(
+          path.join(dir, `${corruptKey}.meta`),
+          Buffer.from('{"seqno":0,"registered":false}'),
+        );
+        await writeFile(path.join(dir, `${corruptKey}.log`), Buffer.from('zzzz'));
+        const store = new SwmHostModeStore({
+          dataDir: dir,
+          unregisteredLimits: limits,
+          registeredLimits: limits,
+        });
+        await store.init();
+        const after = await readdir(dir);
+        expect(after).not.toContain(`${corruptKey}.log`);
+        expect(after).not.toContain(`${corruptKey}.meta`);
+      });
+    });
   });
 });

--- a/packages/agent/test/swm/host-mode-store.test.ts
+++ b/packages/agent/test/swm/host-mode-store.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, readdir } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { SwmHostModeStore } from '../../src/swm/host-mode-store.js';
+
+function cgKey(contextGraphId: string): string {
+  return createHash('sha256').update(contextGraphId).digest('base64url');
+}
 
 describe('SwmHostModeStore', () => {
   let dir: string;
@@ -226,5 +231,128 @@ describe('SwmHostModeStore', () => {
     expect(stats.perCg['cg/meta-only']).toBeUndefined();
     expect(stats.perCg['cg/real-1']).toBeDefined();
     expect(stats.perCg['cg/real-2']).toBeDefined();
+  });
+
+  describe('B2: orphan .log reconcile on startup', () => {
+    const limits = { perCgByteCap: 1024 * 1024, ttlMs: 60_000 };
+
+    it('removes a .log file with no matching .meta on init', async () => {
+      // Simulate a crashed first-write: .log exists, .meta absent.
+      const orphanKey = cgKey('curator/crashed-cg');
+      const orphanLog = path.join(dir, `${orphanKey}.log`);
+      await writeFile(orphanLog, Buffer.from('orphan-bytes-pretending-to-be-frames'));
+      const before = await readdir(dir);
+      expect(before).toContain(`${orphanKey}.log`);
+
+      let reportSeen: { orphanLogsRemoved: number; orphanBytesRemoved: number } | null = null;
+      const store = new SwmHostModeStore({
+        dataDir: dir,
+        unregisteredLimits: limits,
+        registeredLimits: limits,
+        onStartupReconcile: (r) => { reportSeen = r; },
+      });
+      await store.init();
+
+      const after = await readdir(dir);
+      expect(after).not.toContain(`${orphanKey}.log`);
+      expect(reportSeen).toEqual({ orphanLogsRemoved: 1, orphanBytesRemoved: 36 });
+    });
+
+    it('preserves .meta without matching .log (markRegistered + never-written CG case)', async () => {
+      const store = new SwmHostModeStore({
+        dataDir: dir,
+        unregisteredLimits: limits,
+        registeredLimits: limits,
+      });
+      await store.init();
+      await store.markRegistered('curator/registered-but-empty');
+
+      const reincarnated = new SwmHostModeStore({
+        dataDir: dir,
+        unregisteredLimits: limits,
+        registeredLimits: limits,
+      });
+      const report = await reincarnated.reconcileOrphanLogsNow();
+      expect(report).toEqual({ orphanLogsRemoved: 0, orphanBytesRemoved: 0 });
+      expect(await reincarnated.isRegistered('curator/registered-but-empty')).toBe(true);
+    });
+
+    it('preserves .log files that have a matching .meta (normal case)', async () => {
+      const store = new SwmHostModeStore({
+        dataDir: dir,
+        unregisteredLimits: limits,
+        registeredLimits: limits,
+      });
+      await store.append('curator/healthy', new Uint8Array([0xa, 0xb]));
+
+      const reincarnated = new SwmHostModeStore({
+        dataDir: dir,
+        unregisteredLimits: limits,
+        registeredLimits: limits,
+      });
+      const report = await reincarnated.reconcileOrphanLogsNow();
+      expect(report.orphanLogsRemoved).toBe(0);
+      const entries = await reincarnated.iterate('curator/healthy', 0);
+      expect(entries).toHaveLength(1);
+    });
+
+    it('handles mixed dirs: removes orphan logs, leaves healthy pairs + lonely metas alone', async () => {
+      // Seed a healthy pair via the store, then plant an orphan log manually,
+      // then call init and verify only the orphan was removed.
+      const store = new SwmHostModeStore({
+        dataDir: dir,
+        unregisteredLimits: limits,
+        registeredLimits: limits,
+      });
+      await store.append('curator/healthy', new Uint8Array([0x42, 0x42]));
+      await store.markRegistered('curator/lonely-meta');
+
+      const orphanKey1 = cgKey('curator/orphan-1');
+      const orphanKey2 = cgKey('curator/orphan-2');
+      await writeFile(path.join(dir, `${orphanKey1}.log`), Buffer.from('garbage-1'));
+      await writeFile(path.join(dir, `${orphanKey2}.log`), Buffer.from('garbage-22'));
+
+      let reportSeen: { orphanLogsRemoved: number; orphanBytesRemoved: number } | null = null;
+      const reincarnated = new SwmHostModeStore({
+        dataDir: dir,
+        unregisteredLimits: limits,
+        registeredLimits: limits,
+        onStartupReconcile: (r) => { reportSeen = r; },
+      });
+      await reincarnated.init();
+      expect(reportSeen).toEqual({ orphanLogsRemoved: 2, orphanBytesRemoved: 9 + 10 });
+
+      const after = await readdir(dir);
+      expect(after).not.toContain(`${orphanKey1}.log`);
+      expect(after).not.toContain(`${orphanKey2}.log`);
+      // Healthy pair + lonely meta survive.
+      expect(after).toContain(`${cgKey('curator/healthy')}.log`);
+      expect(after).toContain(`${cgKey('curator/healthy')}.meta`);
+      expect(after).toContain(`${cgKey('curator/lonely-meta')}.meta`);
+    });
+
+    it('does not fire the reconcile callback when there are no orphans', async () => {
+      let callbackCount = 0;
+      const store = new SwmHostModeStore({
+        dataDir: dir,
+        unregisteredLimits: limits,
+        registeredLimits: limits,
+        onStartupReconcile: () => { callbackCount += 1; },
+      });
+      await store.init();
+      expect(callbackCount).toBe(0);
+    });
+
+    it('swallows callback errors so init never breaks on observability faults', async () => {
+      const orphanKey = cgKey('curator/will-be-reaped');
+      await writeFile(path.join(dir, `${orphanKey}.log`), Buffer.from('x'));
+      const store = new SwmHostModeStore({
+        dataDir: dir,
+        unregisteredLimits: limits,
+        registeredLimits: limits,
+        onStartupReconcile: () => { throw new Error('observability is wedged'); },
+      });
+      await expect(store.init()).resolves.toBeUndefined();
+    });
   });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       'test/e2e-dht-dial.test.ts',
       'test/generic-sql-source.test.ts',
       'test/query-min-trust-alias.test.ts',
+      'test/swm/host-mode-store.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## Summary

Closes a dead-storage accumulation that surfaced as the second item in Codex's PR #610 follow-ups list.

A crash between \`appendFile(.log)\` (durable) and \`persistMeta(.meta)\` (durable) for a brand-new CG's first envelope leaves a \`.log\` without a matching \`.meta\`. Pre-fix those bytes were:
- **unservable** — catchup needs the cleartext \`contextGraphId\` stored in \`.meta\` to dispatch on
- **unprunable** — the prune path enumerates \`.meta\` files
- **invisible to \`stats()\`**

They accumulated indefinitely. \`SwmHostModeStore.init()\` now sweeps the data dir and deletes orphan \`.log\` files. \`.meta\` without \`.log\` is preserved deliberately (markRegistered + prune-to-empty cases — harmless, zero-byte footprint).

Stacked on #610.

## Observability

New optional \`onStartupReconcile\` callback fires once per \`init()\` when orphans were reaped, with totals. The agent wires it to \`log.warn\` so operators see the recovery in node logs. Errors thrown by the callback are swallowed — init must never break on observability faults.

Also exposes \`reconcileOrphanLogsNow()\` for operator + test convenience.

## Test plan

- [x] 6 new \`host-mode-store.test.ts\` cases, all added to \`vitest.unit.config.ts\` (34 tests passing total)
- [x] .log without .meta is removed; report fires with byte total
- [x] .meta without .log is preserved (markRegistered + prune-empty)
- [x] normal pairs survive untouched
- [x] mixed dir: orphans gone, healthy pairs + lonely metas untouched
- [x] callback NOT fired when no orphans found
- [x] callback errors don't break init


Made with [Cursor](https://cursor.com)