### PR TITLE
OT-RFC-38 LU-6 B3 — persist host-only designation across restart

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -8900,6 +8900,45 @@ export class DKGAgent {
       createOperationContext('system'),
       `SWM host-mode store initialized at ${join(this.config.dataDir, 'swm-host')} (role=${role})`,
     );
+
+    // OT-RFC-38 LU-6 B3 — restore persisted host-mode subscriptions
+    // BEFORE the chain-event poller starts. Chain events older than
+    // the poller's lookback window would otherwise be silently lost
+    // on restart, stranding CGs that the curator registered weeks
+    // ago. The chain-event path + beacons remain the primary
+    // mechanisms; this is the "we already knew about this CG before"
+    // shortcut that keeps the per-restart re-derivation cheap.
+    try {
+      const previouslySubscribed = await this.swmHostModeStore.listHostModeSubscribedCgs();
+      if (previouslySubscribed.length > 0) {
+        this.log.info(
+          createOperationContext('system'),
+          `Restoring ${previouslySubscribed.length} persisted host-mode subscription(s) from disk`,
+        );
+        for (const cgId of previouslySubscribed) {
+          // Re-engage the gossip handler directly; we trust the
+          // previous decision (the curated check ran when the
+          // subscription was first wired). The chain-anchored
+          // authority check on every envelope ingest still catches
+          // revocations even if curator state has changed since.
+          try {
+            this.wireSwmHostModeHandler(cgId);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            this.log.warn(
+              createOperationContext('system'),
+              `Failed to restore host-mode subscription for "${cgId}": ${msg}`,
+            );
+          }
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log.warn(
+        createOperationContext('system'),
+        `Failed to list persisted host-mode subscriptions: ${msg}`,
+      );
+    }
   }
 
   /**
@@ -9010,6 +9049,18 @@ export class DKGAgent {
     };
     this.swmHostModeHandlers.set(contextGraphId, handler);
     this.gossip.onMessage(swmTopic, handler);
+    // B3: persist the host-mode designation so a restart re-engages
+    // this handler before the chain-event poller catches up.
+    // Best-effort — never fail the wire on a persistence error.
+    if (this.swmHostModeStore) {
+      this.swmHostModeStore.markHostModeSubscribed(contextGraphId).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.log.debug(
+          createOperationContext('system'),
+          `Host-mode persistence (mark) failed for "${contextGraphId}": ${msg}`,
+        );
+      });
+    }
   }
 
   /**
@@ -9033,6 +9084,17 @@ export class DKGAgent {
     this.gossip.offMessage(swmTopic, handler);
     this.swmHostModeHandlers.delete(contextGraphId);
     this.swmHostModeSubscribed.delete(contextGraphId);
+    // B3: clear the persisted host-mode designation so a restart
+    // does NOT re-engage. Best-effort.
+    if (this.swmHostModeStore) {
+      this.swmHostModeStore.markHostModeUnsubscribed(contextGraphId).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.log.debug(
+          createOperationContext('system'),
+          `Host-mode persistence (unmark) failed for "${contextGraphId}": ${msg}`,
+        );
+      });
+    }
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -8923,6 +8923,14 @@ export class DKGAgent {
           // revocations even if curator state has changed since.
           try {
             this.wireSwmHostModeHandler(cgId);
+            // Codex PR #620 R2: also re-probe registration state.
+            // Without this, a host-only CG that was registered while
+            // the node was offline stays on the 1MiB / 6h pre-reg
+            // limits after restart and can prune valid ciphertext
+            // permanently — `GraphManager.listContextGraphs()` only
+            // sees local store graphs, so the periodic reconciler
+            // can't heal it later either.
+            await this.maybeMarkRegisteredForHostMode(cgId);
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             this.log.warn(
@@ -9051,16 +9059,12 @@ export class DKGAgent {
     this.gossip.onMessage(swmTopic, handler);
     // B3: persist the host-mode designation so a restart re-engages
     // this handler before the chain-event poller catches up.
-    // Best-effort — never fail the wire on a persistence error.
-    if (this.swmHostModeStore) {
-      this.swmHostModeStore.markHostModeSubscribed(contextGraphId).catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        this.log.debug(
-          createOperationContext('system'),
-          `Host-mode persistence (mark) failed for "${contextGraphId}": ${msg}`,
-        );
-      });
-    }
+    // Codex PR #620 R2: chain wire/unwire writes through a per-CG
+    // serialization queue so mark/unmark calls always land on disk
+    // in invocation order. Without this, back-to-back mark→unmark
+    // could write `true` after `false` and a restart would re-subscribe
+    // a torn-down CG. Still non-blocking at the wire level.
+    this.enqueueHostModePersistence(contextGraphId, true);
   }
 
   /**
@@ -9085,16 +9089,52 @@ export class DKGAgent {
     this.swmHostModeHandlers.delete(contextGraphId);
     this.swmHostModeSubscribed.delete(contextGraphId);
     // B3: clear the persisted host-mode designation so a restart
-    // does NOT re-engage. Best-effort.
-    if (this.swmHostModeStore) {
-      this.swmHostModeStore.markHostModeUnsubscribed(contextGraphId).catch((err: unknown) => {
+    // does NOT re-engage. Serialized via the per-CG persistence
+    // queue (see `enqueueHostModePersistence` for the ordering
+    // rationale).
+    this.enqueueHostModePersistence(contextGraphId, false);
+  }
+
+  /**
+   * Per-CG promise chain for host-mode mark/unmark writes. Codex
+   * PR #620 R2: prior fire-and-forget invocation made restart state
+   * nondeterministic — a stale mark() write could land AFTER a fresh
+   * unmark() and a subsequent restart would re-subscribe a CG that
+   * was already torn down.
+   *
+   * The chain serializes ALL writes for a given CG so they hit disk
+   * in invocation order. The wire/unwire callers stay synchronous;
+   * persistence is awaited only by the chain itself.
+   */
+  private readonly hostModePersistenceQueues = new Map<string, Promise<void>>();
+
+  private enqueueHostModePersistence(contextGraphId: string, subscribe: boolean): void {
+    if (!this.swmHostModeStore) return;
+    const store = this.swmHostModeStore;
+    const op = subscribe ? 'mark' : 'unmark';
+    const apply = async (): Promise<void> => {
+      try {
+        if (subscribe) {
+          await store.markHostModeSubscribed(contextGraphId);
+        } else {
+          await store.markHostModeUnsubscribed(contextGraphId);
+        }
+      } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         this.log.debug(
           createOperationContext('system'),
-          `Host-mode persistence (unmark) failed for "${contextGraphId}": ${msg}`,
+          `Host-mode persistence (${op}) failed for "${contextGraphId}": ${msg}`,
         );
-      });
-    }
+      }
+    };
+    const prev = this.hostModePersistenceQueues.get(contextGraphId) ?? Promise.resolve();
+    const next = prev.then(apply, apply);
+    this.hostModePersistenceQueues.set(contextGraphId, next);
+    void next.finally(() => {
+      if (this.hostModePersistenceQueues.get(contextGraphId) === next) {
+        this.hostModePersistenceQueues.delete(contextGraphId);
+      }
+    });
   }
 
   /**

--- a/packages/agent/src/swm/host-mode-store.ts
+++ b/packages/agent/src/swm/host-mode-store.ts
@@ -93,6 +93,22 @@ interface CgMetaState {
   seqno: number;
   registered: boolean;
   contextGraphId: string;
+  /**
+   * OT-RFC-38 LU-6 B3 — true when the agent has actively engaged
+   * host-mode for this CG (subscribed to its SWM gossip topic in
+   * opaque-ciphertext mode). Persisted so a restart can re-engage
+   * the gossip handler before the chain-event poller catches up
+   * (chain events outside the lookback window would otherwise be
+   * silently lost, stranding hosted CGs without an apply path).
+   *
+   * Distinct from `registered` (which tracks on-chain registration
+   * for limits + rate-limit purposes). A CG can be host-mode
+   * subscribed but unregistered (pre-registration auto-host via
+   * beacon) and vice-versa (registered but the curator revoked
+   * this core via off-protocol means — the next reconcile loop
+   * will clear `hostModeSubscribed`).
+   */
+  hostModeSubscribed?: boolean;
 }
 
 /**
@@ -208,6 +224,50 @@ export class SwmHostModeStore {
         if (limit !== undefined && out.length >= limit) break;
       }
       offset = payloadEnd;
+    }
+    return out;
+  }
+
+  /**
+   * OT-RFC-38 LU-6 B3 — record that the agent has engaged host-mode
+   * for this CG (subscribed to its SWM gossip topic in opaque-store
+   * mode). Persisted so a restart can re-engage the gossip handler
+   * before the chain-event poller catches up. Idempotent.
+   */
+  async markHostModeSubscribed(contextGraphId: string): Promise<void> {
+    await this.init();
+    const meta = await this.loadMeta(contextGraphId);
+    if (meta.hostModeSubscribed === true) return;
+    meta.hostModeSubscribed = true;
+    await this.persistMeta(contextGraphId, meta);
+  }
+
+  /**
+   * Inverse of {@link markHostModeSubscribed}. Called when the agent
+   * unwires the host-mode handler (promoted to member, curator
+   * revoked, operator explicitly disabled host-mode for this CG).
+   * Persisted so a restart does NOT re-engage.
+   */
+  async markHostModeUnsubscribed(contextGraphId: string): Promise<void> {
+    await this.init();
+    const meta = await this.loadMeta(contextGraphId);
+    if (meta.hostModeSubscribed !== true) return;
+    meta.hostModeSubscribed = false;
+    await this.persistMeta(contextGraphId, meta);
+  }
+
+  /**
+   * Returns the cleartext / wire ids of every CG marked
+   * `hostModeSubscribed: true` in its `.meta`. Used by the agent at
+   * startup to re-engage gossip handlers without waiting for the
+   * chain-event poller to re-derive them.
+   */
+  async listHostModeSubscribedCgs(): Promise<string[]> {
+    await this.init();
+    const out: string[] = [];
+    for (const { contextGraphId } of await this.listKnownCgs()) {
+      const meta = await this.loadMeta(contextGraphId).catch(() => null);
+      if (meta?.hostModeSubscribed === true) out.push(contextGraphId);
     }
     return out;
   }
@@ -409,6 +469,7 @@ export class SwmHostModeStore {
       seqno: Math.max(parsed?.seqno ?? 0, logSeqno),
       registered: parsed?.registered ?? false,
       contextGraphId,
+      ...(parsed?.hostModeSubscribed === true ? { hostModeSubscribed: true } : {}),
     };
     // If the log says more than the meta does, persist the
     // reconciled cursor so subsequent cold loads don't have to

--- a/packages/agent/test/swm/host-mode-store.test.ts
+++ b/packages/agent/test/swm/host-mode-store.test.ts
@@ -227,4 +227,57 @@ describe('SwmHostModeStore', () => {
     expect(stats.perCg['cg/real-1']).toBeDefined();
     expect(stats.perCg['cg/real-2']).toBeDefined();
   });
+
+  describe('B3: host-mode designation persistence', () => {
+    const limits = { perCgByteCap: 1024 * 1024, ttlMs: 60_000 };
+
+    it('persists hostModeSubscribed across new store instances', async () => {
+      const first = new SwmHostModeStore({ dataDir: dir, unregisteredLimits: limits, registeredLimits: limits });
+      await first.markHostModeSubscribed('curator/cg-host');
+
+      const second = new SwmHostModeStore({ dataDir: dir, unregisteredLimits: limits, registeredLimits: limits });
+      const restored = await second.listHostModeSubscribedCgs();
+      expect(restored).toEqual(['curator/cg-host']);
+    });
+
+    it('listHostModeSubscribedCgs returns only flagged CGs', async () => {
+      const store = new SwmHostModeStore({ dataDir: dir, unregisteredLimits: limits, registeredLimits: limits });
+      await store.markHostModeSubscribed('curator/cg-a');
+      await store.markRegistered('curator/cg-b'); // registered but never subscribed
+      await store.append('curator/cg-c', new Uint8Array([1])); // ciphertext but no host-mode flag
+
+      const restored = await store.listHostModeSubscribedCgs();
+      expect(restored).toEqual(['curator/cg-a']);
+    });
+
+    it('markHostModeUnsubscribed clears the flag (unwire path)', async () => {
+      const store = new SwmHostModeStore({ dataDir: dir, unregisteredLimits: limits, registeredLimits: limits });
+      await store.markHostModeSubscribed('curator/cg-x');
+      expect(await store.listHostModeSubscribedCgs()).toContain('curator/cg-x');
+      await store.markHostModeUnsubscribed('curator/cg-x');
+      expect(await store.listHostModeSubscribedCgs()).not.toContain('curator/cg-x');
+    });
+
+    it('preserves hostModeSubscribed alongside append-driven seqno updates', async () => {
+      const first = new SwmHostModeStore({ dataDir: dir, unregisteredLimits: limits, registeredLimits: limits });
+      await first.markHostModeSubscribed('curator/cg-active');
+      await first.append('curator/cg-active', new Uint8Array([1, 2, 3]));
+      await first.append('curator/cg-active', new Uint8Array([4, 5, 6]));
+
+      const second = new SwmHostModeStore({ dataDir: dir, unregisteredLimits: limits, registeredLimits: limits });
+      expect(await second.listHostModeSubscribedCgs()).toEqual(['curator/cg-active']);
+      // Seqno bookkeeping also survives — append picks up at 3.
+      const s3 = await second.append('curator/cg-active', new Uint8Array([7]));
+      expect(s3).toBe(3);
+    });
+
+    it('mark + unmark are idempotent', async () => {
+      const store = new SwmHostModeStore({ dataDir: dir, unregisteredLimits: limits, registeredLimits: limits });
+      await store.markHostModeSubscribed('curator/cg-1');
+      await store.markHostModeSubscribed('curator/cg-1');
+      await store.markHostModeUnsubscribed('curator/cg-1');
+      await store.markHostModeUnsubscribed('curator/cg-1');
+      expect(await store.listHostModeSubscribedCgs()).toEqual([]);
+    });
+  });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       'test/e2e-dht-dial.test.ts',
       'test/generic-sql-source.test.ts',
       'test/query-min-trust-alias.test.ts',
+      'test/swm/host-mode-store.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## Summary

Pre-fix, host-only cores re-derived their hosting set on every restart from two sources only:
- chain \`ContextGraphCreated\` events (within poller lookback)
- curator-broadcast discovery beacons (5-min cadence)

CGs registered before the lookback window AND whose curator was offline during the post-restart re-announce tick were silently lost — the gossip handler never rewired and incoming envelopes went to /dev/null.

This PR persists the host-mode designation in the per-CG \`.meta\` file (next to \`seqno\` / \`registered\`) and restores it at startup BEFORE the chain-event poller starts. Chain events + beacons remain the primary derivation; restoration is the \"we already knew about this CG\" shortcut.

Stacked on #610.

## Store API additions

- \`markHostModeSubscribed(cgId)\` — wire path persists the flag
- \`markHostModeUnsubscribed(cgId)\` — unwire path clears it
- \`listHostModeSubscribedCgs()\` — startup enumerates restorable
- \`CgMetaState.hostModeSubscribed?: boolean\` — new optional field (existing CGs read as undefined → treated as not-subscribed)

## Agent wiring

- \`wireSwmHostModeHandler()\` calls \`markHostModeSubscribed\` after subscribing (best-effort; persistence failure never fails the wire)
- \`unwireSwmHostModeHandler()\` calls \`markHostModeUnsubscribed\`
- \`setupSwmHostMode()\` restores persisted subscriptions after store init, calling \`wireSwmHostModeHandler\` directly (skipping the curated-check gate — we trust the previous decision; the chain-anchored envelope-ingest authority check still catches revocations)

## Test plan

- [x] 5 new \`host-mode-store.test.ts\` cases, added to \`vitest.unit.config.ts\` (33 tests passing)
- [x] persists hostModeSubscribed across new store instances
- [x] listHostModeSubscribedCgs returns only flagged CGs
- [x] unmark clears the flag (unwire path)
- [x] survives interleaved append-driven seqno updates
- [x] mark/unmark are idempotent


Made with [Cursor](https://cursor.com)