### PR TITLE
fix: address PR 608 follow-up feedback

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7387,16 +7387,16 @@ export class DKGAgent {
     // local store knows about), then chain access-policy fallback
     // for numeric on-chain ids (covers the C2 case where the target
     // is just the numeric `cgId` from the publish intent and the
-    // local store has no triple keyed by that id).
+    // local store has no triple keyed by that id). Numeric IDs are
+    // chain-owned; if chain truth is unavailable, return UNKNOWN and
+    // fail closed instead of silently publishing plaintext.
     const targetCgId = publishContextGraphId ?? contextGraphId;
-    const probeIsCurated = async (cgId: string): Promise<boolean> => {
+    const probeIsCurated = async (cgId: string): Promise<boolean | null> => {
       try {
         if (await this.isPrivateContextGraph(cgId)) return true;
       } catch { /* fall through to chain probe */ }
       const cached = this.onChainAccessPolicyCache.get(cgId);
       if (cached !== undefined) return cached === 1;
-      const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
-      if (typeof getAccessPolicy !== 'function') return false;
       let numericId: bigint;
       try {
         numericId = BigInt(cgId);
@@ -7404,21 +7404,32 @@ export class DKGAgent {
         return false;
       }
       if (numericId <= 0n) return false;
+      const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
+      if (typeof getAccessPolicy !== 'function') return null;
       try {
         const policy = await getAccessPolicy.call(this.chain, numericId);
         if (policy === 0 || policy === 1) {
           this.onChainAccessPolicyCache.set(cgId, policy);
           return policy === 1;
         }
+        return null;
       } catch (err) {
-        this.log.warn(ctx, `_resolveEncryptInlinePayload: chain.getContextGraphAccessPolicy(${cgId}) failed — treating as public: ${err instanceof Error ? err.message : String(err)}`);
+        this.log.warn(ctx, `_resolveEncryptInlinePayload: chain.getContextGraphAccessPolicy(${cgId}) failed — treating as UNKNOWN (fail-closed): ${err instanceof Error ? err.message : String(err)}`);
       }
-      return false;
+      return null;
     };
     const sourceIsCurated = await probeIsCurated(contextGraphId);
     const targetIsCurated = targetCgId === contextGraphId
       ? sourceIsCurated
       : await probeIsCurated(targetCgId);
+    if (targetIsCurated == null || (targetCgId !== contextGraphId && sourceIsCurated == null)) {
+      throw new Error(
+        `LU-5: publish access-policy is unknown — ` +
+        `source CG "${contextGraphId}" curated=${sourceIsCurated ?? 'unknown'}, ` +
+        `target CG "${targetCgId}" curated=${targetIsCurated ?? 'unknown'}. ` +
+        `Refusing to choose plaintext vs encrypted inline payload without chain-confirmed policy.`,
+      );
+    }
     if (targetCgId !== contextGraphId && sourceIsCurated !== targetIsCurated) {
       // Fail-closed: a remap publish that crosses the privacy
       // boundary in either direction is almost certainly an
@@ -15493,4 +15504,3 @@ export class DKGAgent {
   }
 
 }
-

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression coverage for LU-5 inline-payload encryption policy.
+ *
+ * Numeric context graph ids are chain-owned policy surfaces. If the
+ * daemon cannot read chain truth for one of them, publishing must fail
+ * closed instead of falling back to plaintext.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+function makeAgentLike(opts: {
+  isPrivate?: boolean;
+  accessPolicy?: 0 | 1;
+  accessPolicyError?: Error;
+  exposeAccessPolicy?: boolean;
+} = {}) {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+  const chain: Record<string, unknown> = {};
+  if (opts.exposeAccessPolicy !== false) {
+    chain.getContextGraphAccessPolicy = vi.fn(async () => {
+      if (opts.accessPolicyError) throw opts.accessPolicyError;
+      return opts.accessPolicy ?? 0;
+    });
+  }
+  return {
+    log,
+    chain,
+    onChainAccessPolicyCache: new Map<string, 0 | 1>(),
+    isPrivateContextGraph: vi.fn(async () => opts.isPrivate ?? false),
+  } as any;
+}
+
+async function resolveEncryptInlinePayload(
+  agentLike: any,
+  contextGraphId: string,
+  publishContextGraphId?: string,
+) {
+  return (DKGAgent.prototype as any)._resolveEncryptInlinePayload.call(
+    agentLike,
+    contextGraphId,
+    undefined,
+    undefined,
+    publishContextGraphId,
+  );
+}
+
+describe('DKGAgent._resolveEncryptInlinePayload policy lookup', () => {
+  it('keeps non-numeric local public CGs on the plaintext path', async () => {
+    const agentLike = makeAgentLike({ exposeAccessPolicy: false });
+
+    await expect(resolveEncryptInlinePayload(agentLike, 'local-public-cg')).resolves.toBeUndefined();
+  });
+
+  it('uses chain policy for numeric public CGs before choosing plaintext', async () => {
+    const agentLike = makeAgentLike({ accessPolicy: 0 });
+
+    await expect(resolveEncryptInlinePayload(agentLike, '42')).resolves.toBeUndefined();
+    expect(agentLike.chain.getContextGraphAccessPolicy).toHaveBeenCalledWith(42n);
+    expect(agentLike.onChainAccessPolicyCache.get('42')).toBe(0);
+  });
+
+  it('fails closed when numeric target CG policy lookup is unavailable', async () => {
+    const agentLike = makeAgentLike({
+      accessPolicyError: new Error('rpc unavailable'),
+    });
+
+    await expect(resolveEncryptInlinePayload(agentLike, '42')).rejects.toThrow(
+      /publish access-policy is unknown/,
+    );
+    expect(agentLike.log.warn).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('treating as UNKNOWN'),
+    );
+  });
+
+  it('fails closed when a remap target numeric CG policy cannot be resolved', async () => {
+    const agentLike = makeAgentLike({
+      accessPolicyError: new Error('rpc unavailable'),
+    });
+
+    await expect(resolveEncryptInlinePayload(agentLike, 'local-public-cg', '42')).rejects.toThrow(
+      /target CG "42" curated=unknown/,
+    );
+  });
+});

--- a/packages/agent/test/storage-ack-protocol-extra.test.ts
+++ b/packages/agent/test/storage-ack-protocol-extra.test.ts
@@ -1,16 +1,16 @@
 /**
  * Storage-ACK transport pin: ACK collection MUST ride the libp2p direct
- * protocol `/dkg/10.0.0/storage-ack` — NOT GossipSub.
+ * protocol `/dkg/10.0.1/storage-ack` — NOT GossipSub.
  *
  * Audit findings covered:
  *   A-9 (HIGH) — pins that the agent package uses
- *        `PROTOCOL_STORAGE_ACK = '/dkg/10.0.0/storage-ack'` for ACK wiring
+ *        `PROTOCOL_STORAGE_ACK = '/dkg/10.0.1/storage-ack'` for ACK wiring
  *        and NEVER publishes ACKs over GossipSub.
  *
  * This is a static-scan test (no real libp2p dial needed). Spying on the
  * real dial inside a hermetic vitest run adds environment flakiness with
  * no additional guarantee — if the constant, the router registration, or
- * the dial site diverges from `'/dkg/10.0.0/storage-ack'`, this test
+ * the dial site diverges from `'/dkg/10.0.1/storage-ack'`, this test
  * flips RED. See also ack-eip191-agent-extra.test.ts for the constant
  * pin.
  */
@@ -53,7 +53,7 @@ describe('A-9: storage-ack protocol id (libp2p) pin', () => {
 
   it('agent source never publishes ACKs on GossipSub', () => {
     // A false-positive here would be any call like
-    // `publish('/dkg/10.0.0/storage-ack', ...)` or
+    // `publish('/dkg/10.0.1/storage-ack', ...)` or
     // `gossipsub.publish('...storage-ack...', ...)` through the gossipsub
     // manager. We scan all .ts files in src and make sure we never see
     // GossipSub coupling with the storage-ack string.

--- a/packages/core/src/proto/publish-intent.ts
+++ b/packages/core/src/proto/publish-intent.ts
@@ -21,7 +21,7 @@ const { Type, Field } = protobuf;
  * publisher is about to submit a chain TX and needs 3 core node StorageACKs.
  *
  * Core nodes that have the data in SWM verify the merkle root and respond
- * with a StorageACK via direct P2P stream `/dkg/10.0.0/storage-ack`.
+ * with a StorageACK via direct P2P stream `/dkg/10.0.1/storage-ack`.
  */
 
 export const PublishIntentSchema = new Type('PublishIntent')
@@ -52,8 +52,10 @@ export const PublishIntentSchema = new Type('PublishIntent')
   // they sign the V10 digest based on the publisher's claimed merkle root
   // and ciphertext byte size; member post-decrypt verification (LU-8)
   // catches any mismatch between the on-chain root and the actual
-  // plaintext. Field number 14 to keep the proto strictly additive — old
-  // senders never set it (default `false`), old receivers ignore it.
+  // plaintext. Field number 14 keeps the proto strictly additive for
+  // encoders, but encrypted payloads are only sent over the bumped
+  // `/dkg/10.0.1/storage-ack` protocol so pre-LU-5 receivers never parse
+  // ciphertext as plaintext.
   .add(new Field('isEncryptedPayload', 14, 'bool'));
 
 type Long = { low: number; high: number; unsigned: boolean };

--- a/packages/core/src/proto/storage-ack.ts
+++ b/packages/core/src/proto/storage-ack.ts
@@ -27,7 +27,7 @@ const { Type, Field } = protobuf;
  */
 
 /**
- * Declinable reasons a core node can return on `/dkg/10.0.0/storage-ack`
+ * Declinable reasons a core node can return on `/dkg/10.0.1/storage-ack`
  * instead of a signed ACK. These are situations where the core
  * legitimately cannot produce an ACK for THIS PEER right now — a
  * well-formed publish request that this specific core just can't

--- a/packages/node-ui/playwright.config.ts
+++ b/packages/node-ui/playwright.config.ts
@@ -5,6 +5,7 @@ import { dirname } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CI = !!process.env.CI;
 const PORT = 5173;
+const DEVNET_NODE = process.env.DEVNET_NODE || process.env.UI_NODE_ID || '1';
 
 export default defineConfig({
   testDir: './e2e/specs',
@@ -30,7 +31,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'pnpm dev:ui',
+    command: `cross-env DEVNET_NODE=${DEVNET_NODE} pnpm dev:ui`,
     cwd: __dirname,
     port: PORT,
     reuseExistingServer: !CI,

--- a/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
@@ -42,6 +42,7 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
   const [creating, setCreating] = useState(false);
   const [progress, setProgress] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [registrationWarning, setRegistrationWarning] = useState<string | null>(null);
   const [agentAddress, setAgentAddress] = useState<string | null>(null);
   // Phase 8: after CG + ontology + manifest publish, transition into a
   // wire-workspace step so the curator can populate their own workspace
@@ -72,7 +73,10 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
   };
 
   useEffect(() => {
-    if (open) loadAgentIdentity();
+    if (open) {
+      setRegistrationWarning(null);
+      loadAgentIdentity();
+    }
   }, [open]);
 
   if (!open) return null;
@@ -88,6 +92,7 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
 
     setCreating(true);
     setError(null);
+    setRegistrationWarning(null);
     setProgress('Registering context graph on the network…');
 
     const finalSlug = slugify(trimmedName);
@@ -128,14 +133,13 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
       // refresh and stranded the user with no obvious path forward.
       // The "retry from Settings" affordance below now picks up the
       // partial-success state via the refreshed list.
-      let registrationWarning: string | null = null;
       if (registerOnChain && result.registered === false) {
-        registrationWarning =
+        const registrationWarningMessage =
           `On-chain registration failed: ${result.registerError ?? 'unknown error'}. ` +
           `Project is created locally and usable for everything except Verified Memory publishing. ` +
           `Retry registration from the project's Settings when ready.`;
-        console.warn('[CreateProjectModal]', registrationWarning);
-        setProgress(registrationWarning);
+        console.warn('[CreateProjectModal]', registrationWarningMessage);
+        setRegistrationWarning(registrationWarningMessage);
       }
 
       // Phase 7: install the chosen ontology into meta/project-ontology so
@@ -225,6 +229,7 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
   function handleWireDone() {
     setWiredCgId(null);
     setWiredProjectName('');
+    setRegistrationWarning(null);
     setName('');
     setDescription('');
     onClose();
@@ -241,6 +246,11 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
             </div>
           </div>
           <div className="v10-modal-body">
+            {registrationWarning && (
+              <div className="v10-modal-warning">
+                {registrationWarning}
+              </div>
+            )}
             <WireWorkspacePanel
               contextGraphId={wiredCgId}
               projectName={wiredProjectName}
@@ -267,6 +277,12 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
           {error && (
             <div className="v10-modal-error">
               {error}
+            </div>
+          )}
+
+          {registrationWarning && (
+            <div className="v10-modal-warning">
+              {registrationWarning}
             </div>
           )}
 

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -3360,6 +3360,17 @@ p { font-size: 13px; color: var(--text-secondary); line-height: 1.6; }
   line-height: 1.5;
 }
 
+.v10-modal-warning {
+  padding: 10px 14px;
+  background: var(--amber-dim);
+  border: 1px solid rgba(245, 158, 11, 0.25);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 12px;
+  color: var(--text-warning);
+  line-height: 1.5;
+}
+
 .v10-modal-tip {
   padding: 12px 14px;
   background: var(--bg-surface);

--- a/packages/node-ui/vite.config.ts
+++ b/packages/node-ui/vite.config.ts
@@ -12,20 +12,21 @@ function readTokenFile(path: string): string {
 }
 
 function readDkgConfig() {
-  // Devnet takes priority over ~/.dkg. By default we target node1 (matches
-  // pre-LU-5 behaviour). The `scripts/devnet.sh ui start` wrapper already
-  // exports DEVNET_NODE=$UI_NODE_ID, so set UI_NODE_ID=5 before invoking
-  // the script (or set DEVNET_NODE directly when running `pnpm dev:ui`
-  // standalone) to point the UI at a different daemon — required to test
-  // the edge-curator flow from the UI without hand-rolling curl against
-  // the edge node's daemon port.
-  const devnetNodeNum = process.env.DEVNET_NODE || '1';
-  const devnetDir = resolve(__dirname, '../../.devnet', `node${devnetNodeNum}`);
-  if (existsSync(join(devnetDir, 'api.port'))) {
-    const port = parseInt(readFileSync(join(devnetDir, 'api.port'), 'utf-8').trim(), 10) || 9201;
-    const token = readTokenFile(join(devnetDir, 'auth.token'));
-    console.log(`[vite] Using devnet node${devnetNodeNum} on port ${port}`);
-    return { port, token };
+  // Devnet takes priority over ~/.dkg only when explicitly requested.
+  // `scripts/devnet.sh ui start` exports DEVNET_NODE=$UI_NODE_ID, so
+  // operators can still point at node5 by setting UI_NODE_ID=5 before
+  // invoking the wrapper (or DEVNET_NODE directly for `pnpm dev:ui`).
+  // Without that explicit opt-in, stale `.devnet/node1` files must not
+  // shadow the real local node in ~/.dkg.
+  const devnetNodeNum = process.env.DEVNET_NODE || process.env.UI_NODE_ID;
+  if (devnetNodeNum) {
+    const devnetDir = resolve(__dirname, '../../.devnet', `node${devnetNodeNum}`);
+    if (existsSync(join(devnetDir, 'api.port'))) {
+      const port = parseInt(readFileSync(join(devnetDir, 'api.port'), 'utf-8').trim(), 10) || 9201;
+      const token = readTokenFile(join(devnetDir, 'auth.token'));
+      console.log(`[vite] Using devnet node${devnetNodeNum} on port ${port}`);
+      return { port, token };
+    }
   }
 
   // Fall back to ~/.dkg (testnet / production node)

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -49,7 +49,7 @@ function sanitizeDeclineField(value: string, maxChars: number): string {
  *
  * Flow:
  * 1. Broadcast PublishIntent via GossipSub (finalization topic)
- * 2. Concurrently dial each known core node on /dkg/10.0.0/storage-ack
+ * 2. Concurrently dial each known core node on PROTOCOL_STORAGE_ACK
  * 3. First 3 valid ACKs win; verify each signature via ecrecover
  */
 export class ACKCollector {
@@ -112,6 +112,10 @@ export class ACKCollector {
     }
 
     // P2P intent includes staging quads so core nodes can verify inline.
+    // Encrypted inline payloads are gated by this collector's exclusive
+    // use of PROTOCOL_STORAGE_ACK (`/dkg/10.0.1/storage-ack`): pre-LU-5
+    // cores that only speak `/dkg/10.0.0/storage-ack` never receive field
+    // 14 ciphertext and therefore cannot misparse it as plaintext.
     // `contextGraphId` on the wire is the TARGET numeric id peers will sign
     // the ACK against. `swmGraphId` (optional) is the SOURCE graph where
     // data lives in SWM — only set when the publisher is remapping a named

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -23,7 +23,7 @@ export type ReceiverSignatureProvider = (
 ) => Promise<ReceiverSignature[]>;
 
 /**
- * V10 core node ACK signature collected via /dkg/10.0.0/storage-ack.
+ * V10 core node ACK signature collected via /dkg/10.0.1/storage-ack.
  * Spec §9.0.3: ACK = EIP-191(computePublishACKDigest(chainId, kav10Address,
  *   contextGraphId, merkleRoot, kaCount, byteSize, epochs, tokenAmount))
  */

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -185,7 +185,7 @@ export class StorageACKHandler {
   }
 
   /**
-   * Protocol stream handler for `/dkg/10.0.0/storage-ack`.
+   * Protocol stream handler for `/dkg/10.0.1/storage-ack`.
    * Receives PublishIntent, returns StorageACK.
    */
   handler = async (data: Uint8Array, _peerId: PeerId): Promise<Uint8Array> => {


### PR DESCRIPTION
Follow-up to #608.\n\nSummary:\n- fail closed when numeric/on-chain CG access policy cannot be resolved for LU-5 inline encryption\n- keep on-chain registration partial-success warnings visible in the create-project flow\n- make node-ui devnet config opt-in instead of defaulting to stale .devnet/node1\n- clarify the 10.0.1 storage-ack protocol gate for encrypted inline payloads\n\nVerification:\n- pnpm --filter @origintrail-official/dkg-core build\n- pnpm --filter @origintrail-official/dkg-chain build\n- pnpm --filter @origintrail-official/dkg-storage build\n- pnpm --filter @origintrail-official/dkg-query build\n- pnpm --filter @origintrail-official/dkg-random-sampling build\n- pnpm --filter @origintrail-official/dkg-publisher build\n- pnpm --filter @origintrail-official/dkg-agent build\n- pnpm --filter @origintrail-official/dkg-node-ui build\n- pnpm --dir packages/agent exec vitest run --testNamePattern 'DKGAgent\._resolveEncryptInlinePayload policy lookup|storage-ack protocol id' --reporter dot\n- pnpm --dir packages/publisher exec vitest run --testNamePattern 'isEncryptedPayload' --reporter dot