### PR TITLE
fix(cli): require explicit quads for batch verification

### DIFF
--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -57,7 +57,7 @@ const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, contextGraphDataUri, escapeDkgRdfLiteral } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, escapeDkgRdfLiteral } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri, type PublishOptions } from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
@@ -752,8 +752,8 @@ WHERE {
   // Body: {
   //   contextGraphId: string,
   //   expectedMerkleRoot: hex32 string ("0x" + 64 hex chars),
-  //   quads?: Quad[],            // if omitted, fetched from local SWM
-  //   subGraphName?: string,     // narrows the SWM source slice
+  //   quads: Quad[],             // exact plaintext quads for this batch
+  //   subGraphName?: string,
   //   privateRoots?: hex32[],    // optional per-KA private sub-roots
   //   batchId?: string,          // round-tripped into rejection record
   // }
@@ -784,74 +784,24 @@ WHERE {
       }
       privateRoots.push(hexToBytes32(ph));
     }
-    let quads: Array<{ subject: string; predicate: string; object: string; graph: string }> = [];
-    if (Array.isArray(parsed.quads)) {
-      quads = parsed.quads.map((q: any) => ({
+    if (!Array.isArray(parsed.quads)) {
+      return jsonResponse(res, 400, {
+        error:
+          `verify-batch requires explicit \`quads\` in the request body. ` +
+          `The daemon cannot safely reconstruct a single batch from the local ` +
+          `SWM/data graph because that graph can contain triples from other ` +
+          `batches in the same context graph.`,
+      });
+    }
+
+    const quads: Array<{ subject: string; predicate: string; object: string; graph: string }> = parsed.quads.map(
+      (q: any) => ({
         subject: String(q.subject),
         predicate: String(q.predicate),
         object: String(q.object),
         graph: String(q.graph ?? ''),
-      }));
-    } else {
-      // Codex PR #609: when the caller passes `batchId`, they are
-      // asking us to verify ONE specific batch — but the SWM /
-      // data-graph reconstruction below loads EVERY triple in the
-      // context graph. For a CG with more than one published batch
-      // (i.e. nearly every real CG after the second publish), this
-      // deterministically false-positives `root-mismatch` because we
-      // hash a superset of leaves against a single-batch expected
-      // root. The local triple store has no per-batch label on the
-      // SWM data, so we can't safely scope the read here without
-      // additional metadata. Fail explicitly so the caller passes
-      // `quads` directly (which they typically already have from the
-      // member-side LU-7 catch-up that produced the batch).
-      if (parsed.batchId !== undefined && parsed.batchId !== null && String(parsed.batchId).length > 0) {
-        return jsonResponse(res, 400, {
-          error:
-            `verify-batch with \`batchId\` requires explicit \`quads\` in the request body. ` +
-            `Reconstruction from local SWM / data graph would include triples from OTHER ` +
-            `batches in the same CG and deterministically report \`root-mismatch\` against ` +
-            `the single-batch \`expectedMerkleRoot\`. Supply the exact batch quads (typically ` +
-            `from the LU-7 catch-up response) or omit \`batchId\` if you really do want to ` +
-            `verify the entire CG against a single root.`,
-        });
-      }
-      // No batchId — caller wants to verify the entire CG against a
-      // single root (legacy / single-batch use). Reconstruct from
-      // local store as before:
-      //   1. _shared_memory (live SWM, before promote-to-VM)
-      //   2. CG data graph (post-publish — selection moves quads from
-      //      SWM into the named-graph as part of the seal step)
-      const swmGraphUri = contextGraphSharedMemoryUri(contextGraphId, subGraphName);
-      // Codex PR #609 R2 — when `subGraphName` is set and the batch has
-      // already been published (i.e. SWM is empty post-promote), the
-      // finalized triples live under the sub-graph-specific data graph,
-      // not the root CG graph. Use the same sub-graph-aware helper the
-      // publisher uses so the fallback path actually finds them.
-      const dataGraphUri = contextGraphDataUri(contextGraphId, subGraphName);
-      try {
-        const swmResult = await (agent as any).store.query(
-          `SELECT ?s ?p ?o WHERE { GRAPH <${swmGraphUri}> { ?s ?p ?o } }`,
-        );
-        if (swmResult?.type === 'bindings') {
-          for (const b of swmResult.bindings) {
-            quads.push({ subject: b['s'], predicate: b['p'], object: b['o'], graph: '' });
-          }
-        }
-        if (quads.length === 0) {
-          const dataResult = await (agent as any).store.query(
-            `SELECT ?s ?p ?o WHERE { GRAPH <${dataGraphUri}> { ?s ?p ?o } }`,
-          );
-          if (dataResult?.type === 'bindings') {
-            for (const b of dataResult.bindings) {
-              quads.push({ subject: b['s'], predicate: b['p'], object: b['o'], graph: '' });
-            }
-          }
-        }
-      } catch (err: any) {
-        return jsonResponse(res, 500, { error: `Failed to read local SWM/workspace: ${err?.message ?? err}` });
-      }
-    }
+      }),
+    );
 
     const { verifyBatch } = await import('@origintrail-official/dkg-agent');
     const verifyResult = verifyBatch({ quads, privateRoots, expectedRoot });

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -292,6 +292,22 @@ describe('daemon memory_graph_changed route emissions', () => {
     expect(emitMemoryGraphChanged).not.toHaveBeenCalled();
   });
 
+  it('rejects verify-batch without explicit batch quads before reading local graphs', async () => {
+    const query = vi.fn();
+    const ctx = createContext('/api/shared-memory/verify-batch', {
+      contextGraphId: 'project-a',
+      expectedMerkleRoot: `0x${'11'.repeat(32)}`,
+    }, {
+      agent: { store: { query } } as unknown as RequestContext['agent'],
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(400);
+    expect(responseBody(ctx).error).toMatch(/requires explicit `quads`/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
   it('threads callerAgentAddress into conditional shared-memory writes', async () => {
     const conditionalShare = vi.fn().mockResolvedValue({ shareOperationId: 'op-cas' });
     const ctx = createContext('/api/shared-memory/conditional-write', {

--- a/scripts/devnet-test-rfc38-lu8.sh
+++ b/scripts/devnet-test-rfc38-lu8.sh
@@ -48,6 +48,16 @@ api_call() {
   curl "${curl_args[@]}"
 }
 
+api_call_with_status() {
+  local node="$1" method="$2" path="$3" data="${4:-}"
+  local port; port=$(node_port "$node")
+  local token; token=$(node_token "$node")
+  local -a curl_args=(-sS --max-time 120 -X "$method" -H "Authorization: Bearer $token" -H 'Content-Type: application/json')
+  [ -n "$data" ] && curl_args+=(-d "$data")
+  curl_args+=(-w $'\n%{http_code}' "http://127.0.0.1:${port}${path}")
+  curl "${curl_args[@]}"
+}
+
 parse_json() {
   printf '%s' "$1" | node -e "
     let d=''; process.stdin.on('data',c=>d+=c);
@@ -133,14 +143,17 @@ log "================================================================"
 # hashes a superset of leaves against a single-batch expected root. Keep the
 # route strict: callers must pass the exact plaintext quads they are verifying.
 log "Curator calls verify-batch without quads; endpoint should reject the ambiguous request..."
-VERIFY_MISSING_QUADS=$(api_call "$CURATOR_NODE" POST /api/shared-memory/verify-batch "$(cat <<EOF
+VERIFY_MISSING_QUADS_WITH_STATUS=$(api_call_with_status "$CURATOR_NODE" POST /api/shared-memory/verify-batch "$(cat <<EOF
 { "contextGraphId": "$PUB_CG", "expectedMerkleRoot": "$MERKLE_ROOT" }
 EOF
 )")
+VERIFY_MISSING_QUADS_STATUS=$(printf '%s\n' "$VERIFY_MISSING_QUADS_WITH_STATUS" | tail -n 1)
+VERIFY_MISSING_QUADS=$(printf '%s\n' "$VERIFY_MISSING_QUADS_WITH_STATUS" | sed '$d')
 log "verify-batch missing-quads response: $VERIFY_MISSING_QUADS"
+[ "$VERIFY_MISSING_QUADS_STATUS" = "400" ] || fail "verify-batch missing-quads status=$VERIFY_MISSING_QUADS_STATUS (expected 400): $VERIFY_MISSING_QUADS"
 MISSING_QUADS_ERROR=$(parse_json "$VERIFY_MISSING_QUADS" '.error')
 if printf '%s' "$MISSING_QUADS_ERROR" | grep -q 'requires explicit `quads`'; then
-  log "✓ Scenario 1: verify-batch rejects omitted quads before ambiguous reconstruction"
+  log "✓ Scenario 1: verify-batch rejects omitted quads with HTTP 400 before ambiguous reconstruction"
 else
   fail "verify-batch missing-quads response did not mention explicit quads requirement: $VERIFY_MISSING_QUADS"
 fi

--- a/scripts/devnet-test-rfc38-lu8.sh
+++ b/scripts/devnet-test-rfc38-lu8.sh
@@ -5,10 +5,10 @@
 #
 # Scenarios:
 #
-#   1. HAPPY PATH — Curator publishes a public CG batch. Member fetches
-#      the on-chain merkleRoot via the chain API, calls
-#      POST /api/shared-memory/verify-batch with the local SWM quads
-#      → must return ok=true.
+#   1. REQUEST VALIDATION — verify-batch without explicit quads is
+#      rejected because local graph reconstruction is not batch-scoped.
+#      The happy path then calls verify-batch with exact caller-supplied
+#      plaintext quads and must return ok=true.
 #
 #   2. ROOT-MISMATCH — Member calls verify-batch with a forged set of
 #      quads (adds an injected triple) but the real expectedRoot.
@@ -120,37 +120,34 @@ log "✓ published txHash=$TX_HASH merkleRoot=$MERKLE_ROOT"
 sleep 5
 
 # ===========================================================================
-# SCENARIO 1 — Happy path on the member side.
+# SCENARIO 1 — Request validation + happy path on the member side.
 # ===========================================================================
 
 log ""
 log "================================================================"
-log "  SCENARIO 1: verify-batch HAPPY PATH (member, public CG)"
+log "  SCENARIO 1: verify-batch REQUEST VALIDATION + HAPPY PATH"
 log "================================================================"
 
-# The published quads on the curator side live in the CG's named data
-# graph after seal (the publisher moves them out of SWM). The verify-
-# batch endpoint falls back to the data graph if SWM is empty.
-log "Curator calls verify-batch against its own local data (after publish, plaintext lives in the CG data graph)..."
-VERIFY_OK=$(api_call "$CURATOR_NODE" POST /api/shared-memory/verify-batch "$(cat <<EOF
+# The daemon cannot safely infer a single published batch from a whole
+# context graph. Once a CG has multiple batches, local graph reconstruction
+# hashes a superset of leaves against a single-batch expected root. Keep the
+# route strict: callers must pass the exact plaintext quads they are verifying.
+log "Curator calls verify-batch without quads; endpoint should reject the ambiguous request..."
+VERIFY_MISSING_QUADS=$(api_call "$CURATOR_NODE" POST /api/shared-memory/verify-batch "$(cat <<EOF
 { "contextGraphId": "$PUB_CG", "expectedMerkleRoot": "$MERKLE_ROOT" }
 EOF
 )")
-log "verify-batch happy: $VERIFY_OK"
-OK_FLAG=$(parse_json "$VERIFY_OK" '.ok')
-QUADS_CONSIDERED=$(parse_json "$VERIFY_OK" '.quadsConsidered')
-if [ "$OK_FLAG" = "true" ]; then
-  log "✓ Scenario 1: verify-batch returned ok=true ($QUADS_CONSIDERED quads considered)"
+log "verify-batch missing-quads response: $VERIFY_MISSING_QUADS"
+MISSING_QUADS_ERROR=$(parse_json "$VERIFY_MISSING_QUADS" '.error')
+if printf '%s' "$MISSING_QUADS_ERROR" | grep -q 'requires explicit `quads`'; then
+  log "✓ Scenario 1: verify-batch rejects omitted quads before ambiguous reconstruction"
 else
-  warn "verify-batch returned ok=$OK_FLAG ($QUADS_CONSIDERED quads considered)"
-  warn "  The actual published root for KC #$KC_ID was $MERKLE_ROOT"
-  warn "  recomputed: $(parse_json "$VERIFY_OK" '.actualRoot')"
+  fail "verify-batch missing-quads response did not mention explicit quads requirement: $VERIFY_MISSING_QUADS"
 fi
 
-# Bonus: also exercise the explicit-quads path (caller-supplied
-# plaintext). This is the path a member uses after catchup once they've
-# decrypted ciphertext, and is the only path that's truly key-holder-
-# independent for the verifier API.
+# Exercise the explicit-quads path (caller-supplied plaintext). This is the
+# path a member uses after catchup once they've decrypted ciphertext, and is
+# the only path that's batch-scoped for the verifier API.
 log "Calling verify-batch with explicit caller-supplied quads (member-side simulation)..."
 EXPLICIT_QUADS=$(node -e "
   const quads = [];


### PR DESCRIPTION
## Summary
- require /api/shared-memory/verify-batch callers to pass explicit batch quads instead of reconstructing from the whole local graph
- add a route-level regression test that proves omitted quads are rejected before local graph reads
- update the LU-8 devnet harness to expect the validation error, then continue through the explicit-quads happy path

## Verification
- pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/memory-graph-events.test.ts --reporter dot
- pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts --reporter dot (requires local bind permission; passed with escalated sandbox)
- git diff --check

## Notes
- PR #609 review threads for attestation membership and unknown KC 404 handling were already addressed in the merged R2 commit; this follow-up fixes the remaining unscoped verify-batch fallback.
- A local CLI tsc --noEmit run is still blocked by existing workspace setup/type drift unrelated to this patch: stale/missing workspace package declarations for EPCIS and missing local @iarna/toml install.