### PR TITLE
docs(adr): importer chunking contract + code-graph ontology convergence

### DIFF
--- a/docs/adr/0002-importer-chunking-contract.md
+++ b/docs/adr/0002-importer-chunking-contract.md
@@ -54,9 +54,15 @@ Concretely:
 
    ```
    POST /api/assertion/create   { name, subGraphName, contextGraphId }
-   POST /api/assertion/:name/write    { quads: [...] }     ── one or more times
-   POST /api/assertion/:name/promote  { entities: [...] }
+   POST /api/assertion/:name/write    { contextGraphId, subGraphName, quads: [...] }     ── one or more times
+   POST /api/assertion/:name/promote  { contextGraphId, subGraphName, entities: [...] }
    ```
+
+   `contextGraphId` (and the matching `subGraphName`) MUST be sent on every
+   write and promote, not only on create. The daemon validates them on each
+   call — importers that omit the field get HTTP 400 from the request
+   validator before any quads are processed. (The earlier draft of this
+   ADR showed only `quads`/`entities` in the body; that was wrong.)
 
    Each `write` body MUST stay under `MAX_BODY_BYTES`. Each `promote`
    `entities` array MUST stay under a comparable URI-count budget. Multiple

--- a/docs/adr/0002-importer-chunking-contract.md
+++ b/docs/adr/0002-importer-chunking-contract.md
@@ -124,10 +124,10 @@ assertions cannot afford to start over on slice 75 because the daemon
 restarted; it needs to know which slices have landed and which haven't.
 
 The canonical pattern is a small RDF manifest assertion that the importer
-maintains as it works (specified separately in
-[`packages/cli/skills/dkg-importer/SKILL.md`](../../packages/cli/skills/dkg-importer/SKILL.md)
-and implemented by `scripts/lib/manifest.mjs` in the same PR series as this
-ADR):
+maintains as it works. A follow-up implementation PR will ship the
+agent-readable importer manual and `scripts/lib/manifest.mjs` helper that
+turn this pattern into reusable code; this ADR only defines the contract the
+future artifacts must follow.
 
 ```
 <urn:dkg:import:my-corpus-2026-01-15>
@@ -150,10 +150,10 @@ partitions, and continues from there.
 
 **Will change** (in PRs that follow this ADR):
 
-- `packages/cli/skills/dkg-importer/SKILL.md` — agent-readable importer manual
+- Future `packages/cli/skills/dkg-importer/SKILL.md` — agent-readable importer manual
   that codifies the contract in §Decision with worked examples (TypeScript
   + Python) and an explicit "what to do on 413" recipe.
-- `scripts/lib/manifest.mjs` — small library that implements the manifest
+- Future `scripts/lib/manifest.mjs` — small library that implements the manifest
   pattern above against the daemon's own assertion API.
 - `packages/cli/src/daemon/routes/status.ts` — `/api/status` gains a
   non-binding `importLimits` block reflecting `MAX_BODY_BYTES`,

--- a/docs/adr/0002-importer-chunking-contract.md
+++ b/docs/adr/0002-importer-chunking-contract.md
@@ -1,0 +1,190 @@
+# ADR 0002 — Importer chunking contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-25
+- **Authors**: branarakic
+- **Related issues**: [#596](https://github.com/OriginTrail/dkg/issues/596), [#602](https://github.com/OriginTrail/dkg/pull/602)
+- **Related ADRs**: [0003 — Code-graph ontology convergence](./0003-code-graph-ontology-convergence.md)
+
+## Context
+
+PR [#602](https://github.com/OriginTrail/dkg/pull/602) introduced the "Graphify"
+codebase-import experiment, which converts every source file in a repository to
+RDF (per-file `code:File` triples, per-package `code:Package` triples,
+per-function `code:Function` triples, dependency edges, etc.) and tries to
+write the resulting graph into a DKG daemon's working memory in one shot.
+
+For a non-trivial repository the resulting graph is **1.7M quads spread over
+~74 assertions** (~150 MB of N-Quads). The push exposed several gaps in how
+the daemon's HTTP API expects callers to behave:
+
+1. **No per-request size guard before the daemon got swamped.** The daemon's
+   global limits (`MAX_BODY_BYTES = 10 MB`, `SMALL_BODY_BYTES = 256 KB`,
+   `MAX_UPLOAD_BYTES = 50 MB` — see
+   `packages/cli/src/daemon/http-utils.ts`) exist, but importers had no idea
+   what they were until they hit a 413. There was no machine-readable advert
+   of those limits in `/api/status`.
+
+2. **No agreed-upon chunk granularity.** Several existing importers in the
+   tree pick their own batch sizes — `dkg/.dkg/scripts/scan-code.mjs` uses
+   `CHUNK=5000` quads and `ROOT_CHUNK=1000` URIs per promote, but PR #602's
+   importer batched larger and slower; PR #602 originally tried a single
+   monolithic write, which is impossible by design.
+
+3. **No documented "what to do when 413 happens" pattern.** Importer authors
+   reach for retry-with-smaller-chunks the first time, but there's no
+   canonical shape.
+
+4. **Recurring confusion about whether the daemon should chunk for the
+   caller.** The natural temptation, after seeing a torn 1.7M-quad write,
+   is to add `/api/import/bulk` or to bump `MAX_BODY_BYTES` to 1 GB. Both
+   are wrong: the assertion-create/write/promote loop is _already_ the
+   chunked API. Hiding chunking behind the daemon also defeats the
+   resumability the importer needs anyway (a manifest of which slices
+   have landed; see §Manifest).
+
+## Decision
+
+**Clients chunk; the daemon publishes the limits clients chunk against.**
+
+Concretely:
+
+1. **The current per-call API contract IS the chunked contract.** Importers
+   write a large graph by calling, for each logical slice of triples:
+
+   ```
+   POST /api/assertion/create   { name, subGraphName, contextGraphId }
+   POST /api/assertion/:name/write    { quads: [...] }     ── one or more times
+   POST /api/assertion/:name/promote  { entities: [...] }
+   ```
+
+   Each `write` body MUST stay under `MAX_BODY_BYTES`. Each `promote`
+   `entities` array MUST stay under a comparable URI-count budget. Multiple
+   assertions can be created in parallel as long as the writes for a given
+   assertion stay sequential within that assertion's lifetime.
+
+2. **Pinned per-call budgets (the actual numbers).** Until per-network/
+   per-version values appear in `/api/status` (see §Consequences),
+   importers should use these constants verbatim. They are deliberately
+   conservative — well under the daemon's hard limits — so a single write
+   leaves margin for retries, header overhead, and JSON encoding bloat.
+
+   | Constant       | Value           | Rationale |
+   |---|---|---|
+   | `CHUNK`        | **5,000 quads** per `/api/assertion/:name/write` call | The 99th-percentile N-Quads quad serialises around 150-300 bytes (URIs + a small literal); 5,000 quads × ~250 B ≈ 1.25 MB, well under the 10 MB `MAX_BODY_BYTES`. Matches the value already in use by `.dkg/scripts/scan-code.mjs`. |
+   | `ROOT_CHUNK`   | **1,000 URIs** per `/api/assertion/:name/promote` call | Promote payloads are URI-array-only, so the body is bounded by URI count, not quad count. 1,000 URIs × ~120 B ≈ 120 KB, well under `SMALL_BODY_BYTES`. Also matches the scanner's existing pin. |
+   | Max concurrent writes per assertion | **1** | Sequential within an assertion — the daemon's WAL semantics don't support intra-assertion parallel writes today, and the `manifest` (§Manifest) tracks per-assertion state anyway. |
+   | Max concurrent assertions | **4** | Concurrency across assertions is safe; this keeps daemon CPU and memory bounded for laptop-class hosts. |
+
+3. **The daemon enforces the limits with HTTP 413 (`PayloadTooLargeError`,
+   already imported in every route group in `packages/cli/src/daemon/routes/`).**
+   Importers that exceed the budget MUST handle 413 the same way they handle
+   transient network errors: catch, halve the chunk size for the next
+   attempt, retry. Exponential backoff is fine; this rare path is not a
+   hot loop.
+
+4. **The daemon SHOULD publish its current per-call limits in `/api/status`.**
+   The status route (`packages/cli/src/daemon/routes/status.ts`) is the
+   canonical "ask the node what it can do" surface. A new top-level object
+   `importLimits: { maxQuadsPerWrite, maxBodyBytes, maxEntitiesPerPromote,
+   smallBodyBytes }` lets importers self-tune for nodes that have raised or
+   lowered the defaults. **This advertisement is non-binding** — the hard
+   413 enforcement remains in `http-utils.ts`; `/api/status` is a hint, not
+   a contract.
+
+5. **The daemon MUST NOT add a server-side "chunk this for me" endpoint
+   (`/api/assertion/bulk-write`, `/api/import/auto-chunk`, etc.).** Two
+   reasons:
+
+   - It would hide failure modes from the caller. Today a 413 surfaces
+     mid-write; the importer sees exactly which slice failed and which
+     have landed. A "send me the whole graph" endpoint would either buffer
+     in memory (defeating the size limit) or chunk inside the daemon
+     (duplicating client-side logic without the manifest the importer
+     needs anyway for resumability).
+
+   - It would erase the convergence with industry practice. Every
+     RDF-store HTTP API in current use (Apache Jena Fuseki, Stardog,
+     GraphDB, Blazegraph) draws the same line: server-side bulk import
+     is for _files on disk on the server_, not for HTTP-streaming
+     megabytes. Network-fed imports are client-chunked. This is the
+     "fetch the headers, then the body, in slices" pattern that every
+     megabyte-scale HTTP client follows.
+
+## Manifest
+
+Resumability is part of the chunking contract. An importer that writes 74
+assertions cannot afford to start over on slice 75 because the daemon
+restarted; it needs to know which slices have landed and which haven't.
+
+The canonical pattern is a small RDF manifest assertion that the importer
+maintains as it works (specified separately in
+[`packages/cli/skills/dkg-importer/SKILL.md`](../../packages/cli/skills/dkg-importer/SKILL.md)
+and implemented by `scripts/lib/manifest.mjs` in the same PR series as this
+ADR):
+
+```
+<urn:dkg:import:my-corpus-2026-01-15>
+    a                       <https://ontology.dkg.io/import#Import> ;
+    dkg:startedAt           "2026-01-15T09:00:00Z"^^xsd:dateTime ;
+    dkg:partition           <urn:dkg:import:my-corpus-2026-01-15#part-001>,
+                            <urn:dkg:import:my-corpus-2026-01-15#part-002>, ... .
+
+<urn:dkg:import:my-corpus-2026-01-15#part-001>
+    dkg:key                 "src/foo/bar.ts" ;
+    dkg:status              "done" .
+```
+
+The manifest itself follows the chunking contract — typically <100 partitions
+fit comfortably in one promote, so the manifest assertion is its own slice.
+On resume, the importer reads back the manifest, computes the set of pending
+partitions, and continues from there.
+
+## Consequences
+
+**Will change** (in PRs that follow this ADR):
+
+- `packages/cli/skills/dkg-importer/SKILL.md` — agent-readable importer manual
+  that codifies the contract in §Decision with worked examples (TypeScript
+  + Python) and an explicit "what to do on 413" recipe.
+- `scripts/lib/manifest.mjs` — small library that implements the manifest
+  pattern above against the daemon's own assertion API.
+- `packages/cli/src/daemon/routes/status.ts` — `/api/status` gains a
+  non-binding `importLimits` block reflecting `MAX_BODY_BYTES`,
+  `SMALL_BODY_BYTES`, and the pinned `CHUNK`/`ROOT_CHUNK` advisory values.
+  This is small and additive; it can land in any future PR without
+  disrupting existing clients.
+- `packages/cli/skills/dkg-node/SKILL.md` — adds a one-line cross-reference
+  to `dkg-importer/SKILL.md` from the "writing graphs" section, plus a
+  short HTTP-413 troubleshooting entry.
+- `dkg/.dkg/scripts/scan-code.mjs` (companion repo) — annotated to point
+  at this ADR so the existing pin matches the documented contract.
+
+**Will not change** (deliberately out of scope):
+
+- `MAX_BODY_BYTES`, `SMALL_BODY_BYTES`, `MAX_UPLOAD_BYTES` constants in
+  `packages/cli/src/daemon/http-utils.ts`. Tuning those is a separate
+  decision; this ADR is about the contract shape, not the numbers.
+- A server-side "bulk import" or "auto-chunk" endpoint. Forbidden per §5
+  above. If a future use case argues this is necessary, a separate ADR
+  must supersede this one.
+
+## Rejected alternatives
+
+- **"Just raise `MAX_BODY_BYTES` to 1 GB."** Doesn't solve resumability,
+  doesn't solve daemon-side memory pressure during the dump (Oxigraph
+  loads the request body into memory before parsing), and pushes the
+  failure mode from "413 on a 5 MB chunk" to "OOM on a 1 GB chunk".
+- **"Server-side chunking endpoint."** Forbidden per §5. Would require
+  duplicating manifest logic on both sides.
+- **"Per-network chunk values in `/api/status` are binding."** Tried in
+  draft. Rejected because some operators want to be able to bump the limit
+  for their own importers without forcing every client to re-read status.
+  Hard enforcement stays in HTTP code; `/api/status` is a hint.
+
+## References
+
+- HTTP 413 semantics — [RFC 9110 §15.5.14](https://www.rfc-editor.org/rfc/rfc9110#name-413-content-too-large)
+- Apache Jena Fuseki bulk-load — server-local files only, not HTTP-streamed
+- Stardog HTTP API — same pattern: server-side bulk for local files,
+  client-chunked for remote ingestion

--- a/docs/adr/0002-importer-chunking-contract.md
+++ b/docs/adr/0002-importer-chunking-contract.md
@@ -188,6 +188,41 @@ partitions, and continues from there.
   for their own importers without forcing every client to re-read status.
   Hard enforcement stays in HTTP code; `/api/status` is a hint.
 
+## Empirical motivation
+
+Quoted from an rc.10 import of this repository's Graphify output
+(26,960 nodes / 63,003 edges across 17 partitions), running on a
+sandbox daemon (port 9201, single worker, local SSD):
+
+- A hand-rolled importer written from `dkg-node/SKILL.md` alone needed
+  **~330 LOC** to land the graph: arg parsing, token resolution, wallet-
+  scoped CG id construction, partitioning, write batching, 413-driven
+  adaptive halving on `/promote`, 500-driven `entities: "all"` →
+  per-root batching on the 10 MB gossip cap, and a hand-rolled JSON
+  resume state file. Roughly half of that is cap-discovery ceremony.
+- The same workload using rc.10's existing `scripts/lib/dkg-daemon.mjs`
+  `DkgClient` cuts the importer to ~half the LOC because token, project
+  ensure, sub-graph ensure, and write batching are already handled.
+  Importer authors still hand-roll adaptive halving and the resume
+  manifest — those are the gaps PRs #642 and #643 close.
+- **Four of 17 partitions hit the 10 MB gossip cap** with
+  `entities: "all"` (24,599 KB, 11,993 KB, 10,788 KB, 20,686 KB). Each
+  failure required halve-and-retry. Total wall-clock spent in retry
+  cycles: **~15 minutes** on top of the legitimate write/promote work.
+  A documented contract (this ADR) plus a pinned `ROOT_CHUNK ≤ 1000`
+  default in the importer SKILL would have avoided all of it.
+- Write latency degrades roughly **200× from baseline** once cumulative
+  SWM grows past ~100k triples (5-7 ms/batch → 1.2 s/batch and worse),
+  because sync `/promote` shares a worker with write ingestion. That
+  cost is what motivates PR #643's async queue, not this ADR — but the
+  chunking discipline here is the prerequisite: without an agreed-upon
+  contract you can't move promote work to a background worker without
+  changing the importer's request shape.
+
+The full per-partition breakdown lives in the rc.10 test artifacts;
+this section keeps the headlines so the contract's "why these numbers"
+question has a concrete answer for reviewers.
+
 ## References
 
 - HTTP 413 semantics — [RFC 9110 §15.5.14](https://www.rfc-editor.org/rfc/rfc9110#name-413-content-too-large)

--- a/docs/adr/0003-code-graph-ontology-convergence.md
+++ b/docs/adr/0003-code-graph-ontology-convergence.md
@@ -41,30 +41,54 @@ which slice, and a sketch of how to reconcile already-emitted parallel URIs.
    urn:dkg:code:module:<moduleName>
    ```
 
-   - `<pkgName>` and `<relPath>` MUST be `encodeURIComponent`'d per path
-     segment. A `relPath` of `src/a b.ts` becomes `src/a%20b.ts`. This
-     matches the helper's behaviour today and matches the
-     `must-be-percent-encoded` rule called out in the parent workspace's
-     `AGENTS.md` (§ "Query gotchas #4").
+   - **Encoding** — there are two producers in play and they encode
+     differently for historical reasons. New code MUST keep doing what
+     the existing producer in its slice does, **not** invent a third
+     convention:
+     - `scripts/lib/ontology.mjs` (`Code.uri.file`) — the monorepo
+       helper — runs `encodeURIComponent` on `<pkgName>` and on
+       `<relPath>` **as whole strings**. A `relPath` of `src/a b.ts`
+       becomes `src%2Fa%20b.ts` and the literal URI is
+       `urn:dkg:code:file:@origintrail-official%2Fdkg-storage/src%2Fa%20b.ts`.
+       This is what every monorepo importer (`import-code-graph.mjs`,
+       `seed-dkg-code-project.mjs`, `import-github.mjs`, `import-tasks.mjs`,
+       `import-decisions.mjs`) emits today.
+     - The parent workspace's `.dkg/scripts/scan-code.mjs` — which scans
+       arbitrary external GitHub repos — percent-encodes **each path
+       segment** and joins them with literal `/`. The parent workspace's
+       `AGENTS.md` (§ "Query gotchas #4") documents this. That convention
+       stays as well; both producers have months of WM/SWM/VM data behind
+       them.
+     - These two encodings cannot collide because the producers own
+       disjoint `<pkgName>` slices (see §2): the monorepo helper passes
+       the package.json `name` field (e.g. `@origintrail-official/dkg-storage`);
+       the parent scanner passes `<owner>/<name>` (e.g.
+       `OriginTrail/dkg`). No `<pkgName>` is valid in both spaces.
+     - If a future change unifies the encoding, that's a separate ADR
+       with a real migration plan; do not flip it in passing.
    - `<pkgName>` is **the source's natural package handle in the producer's
      scope**, not always a public npm name:
-     - For DKG monorepo packages: the workspace package name without scope
-       — e.g. `dkg-storage`, `dkg-agent`, `dkg-cli`.
+     - For DKG monorepo packages: the scoped package.json `name` field —
+       e.g. `@origintrail-official/dkg-storage`,
+       `@origintrail-official/dkg-agent`,
+       `@origintrail-official/dkg-cli`. This matches what the existing
+       monorepo importers pass; using a hand-rolled unscoped form would
+       create a parallel `dkg-storage` namespace and fragment the graph.
      - For external GitHub repos scanned by the parent workspace's
-       `scan-code.mjs`: `<owner>/<name>` (slash kept as-is — that's the only
-       case `<pkgName>` contains a literal slash). The parent scanner has
-       been emitting this pattern for months; it stays.
-     - For loose source trees with no package metadata: a slug derived from
-       the directory name.
+       `scan-code.mjs`: `<owner>/<name>` (slash kept as-is — that's the
+       only case `<pkgName>` contains a literal slash). The parent
+       scanner has been emitting this pattern for months; it stays.
+     - For loose source trees with no package metadata: a slug derived
+       from the directory name.
 
 2. **One producer owns one slice.** Each tool MUST stay inside its declared
    scope so the URIs don't collide:
 
-   | Producer | Owns | Reads from |
-   |---|---|---|
-   | `scripts/lib/ontology.mjs` consumers in this worktree | DKG monorepo `urn:dkg:code:*` triples (`<pkgName>` is the workspace name) | Other producers via SPARQL — joins are by URI |
-   | Parent workspace's `scan-code.mjs` | External-repo `urn:dkg:code:*` triples (`<pkgName>` is `<owner>/<name>`) | Other producers via SPARQL — joins are by URI |
-   | Future Graphify-style importers | A producer-specific sub-graph; URIs MUST follow the canonical shape above (no `graphify:*` namespace) | Other producers via SPARQL — joins are by URI |
+   | Producer | Owns | `<pkgName>` shape | Reads from |
+   |---|---|---|---|
+   | `scripts/lib/ontology.mjs` consumers in this worktree | DKG monorepo `urn:dkg:code:*` triples | scoped package.json name (`@origintrail-official/dkg-storage`) | Other producers via SPARQL — joins are by URI |
+   | Parent workspace's `scan-code.mjs` | External-repo `urn:dkg:code:*` triples | `<owner>/<name>` (slash kept literal) | Other producers via SPARQL — joins are by URI |
+   | Future Graphify-style importers | A producer-specific sub-graph; URIs MUST follow the canonical shape above (no `graphify:*` namespace) | Whatever fits the producer's scope; pick one and stick to it | Other producers via SPARQL — joins are by URI |
 
 3. **The `graphify:*` URI namespace is deprecated.** Importers that
    currently emit `graphify:file:<hash>` MUST switch to
@@ -106,9 +130,13 @@ written once per known-aliased URI:
     owl:sameAs <urn:dkg:code:file:dkg-agent/src/dkg-agent.ts> .
 ```
 
-In SPARQL, joins across the legacy and canonical URIs become trivial:
+In SPARQL, joins across the legacy and canonical URIs become trivial
+(the `PREFIX owl:` declaration is required by standard SPARQL parsers
+when using the `owl:` short form):
 
 ```sparql
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
 SELECT ?file ?path WHERE {
   ?file owl:sameAs* ?canonical .
   ?canonical <http://dkg.io/ontology/code/path> ?path .
@@ -134,8 +162,8 @@ a single ROOT_CHUNK = 1000 URIs).
   any graphs that have already been promoted with the legacy URIs.
 - The parent workspace's `.dkg/scripts/scan-code.mjs` — scheduled for a
   documentation pass that points at this ADR. No URI-shape change is
-  required; the existing `<owner>/<name>/<relPath>` shape is already
-  canonical within its scope (external-repo scanning).
+  required; the existing `<owner>/<name>/<per-segment-encoded-relPath>`
+  shape is already canonical within its scope (external-repo scanning).
 - Any new code-graph importer — MUST import class/property IRIs from
   `scripts/lib/ontology.mjs` and MUST follow the URI shape above.
 

--- a/docs/adr/0003-code-graph-ontology-convergence.md
+++ b/docs/adr/0003-code-graph-ontology-convergence.md
@@ -1,0 +1,177 @@
+# ADR 0003 — Code-graph ontology convergence
+
+- **Status**: Accepted
+- **Date**: 2026-05-25
+- **Authors**: branarakic
+- **Related issues**: [#596](https://github.com/OriginTrail/dkg/issues/596), [#602](https://github.com/OriginTrail/dkg/pull/602)
+- **Related ADRs**: [0002 — Importer chunking contract](./0002-importer-chunking-contract.md)
+
+## Context
+
+Three things in the tree (and one in the next-door tree at
+`/Users/aleatoric/dev/.dkg/scripts/scan-code.mjs`) currently produce RDF
+triples about source files, packages, classes, and functions:
+
+| Producer | URI shape | Scope |
+|---|---|---|
+| `scripts/lib/ontology.mjs` (`Code.uri.file`) | `urn:dkg:code:file:<pkgName>/<relPath>` | DKG monorepo packages |
+| The parent workspace's `scan-code.mjs` | `urn:dkg:code:file:<owner>/<name>/<relPath>` | Arbitrary external GitHub repos (also occasionally used against this monorepo with `owner=OriginTrail name=dkg`) |
+| PR [#602](https://github.com/OriginTrail/dkg/pull/602) Graphify importer | `graphify:file:<hash>` and similar | The repository the experiment was run against |
+| Any future ad-hoc importer | (unknown — drift risk) | (unknown) |
+
+This is fine for a single producer working in isolation. It fragments the
+graph the moment two producers describe the same file: queries don't join,
+the UI shows two nodes for `packages/storage/src/adapters/oxigraph.ts`, and
+`dkg_memory_search` returns duplicates.
+
+The Graphify experiment in PR #602 made this concrete by emitting `graphify:*`
+URIs for ~30k files that the parent scanner had already indexed under
+`urn:dkg:code:*`. Neither side knew about the other.
+
+We need a canonical shape, documented expectations for which producer owns
+which slice, and a sketch of how to reconcile already-emitted parallel URIs.
+
+## Decision
+
+1. **Canonical URI shapes for the `code:*` ontology** (defined in `scripts/lib/ontology.mjs`):
+
+   ```
+   urn:dkg:code:package:<pkgName>
+   urn:dkg:code:file:<pkgName>/<relPath>
+   urn:dkg:code:module:<moduleName>
+   ```
+
+   - `<pkgName>` and `<relPath>` MUST be `encodeURIComponent`'d per path
+     segment. A `relPath` of `src/a b.ts` becomes `src/a%20b.ts`. This
+     matches the helper's behaviour today and matches the
+     `must-be-percent-encoded` rule called out in the parent workspace's
+     `AGENTS.md` (§ "Query gotchas #4").
+   - `<pkgName>` is **the source's natural package handle in the producer's
+     scope**, not always a public npm name:
+     - For DKG monorepo packages: the workspace package name without scope
+       — e.g. `dkg-storage`, `dkg-agent`, `dkg-cli`.
+     - For external GitHub repos scanned by the parent workspace's
+       `scan-code.mjs`: `<owner>/<name>` (slash kept as-is — that's the only
+       case `<pkgName>` contains a literal slash). The parent scanner has
+       been emitting this pattern for months; it stays.
+     - For loose source trees with no package metadata: a slug derived from
+       the directory name.
+
+2. **One producer owns one slice.** Each tool MUST stay inside its declared
+   scope so the URIs don't collide:
+
+   | Producer | Owns | Reads from |
+   |---|---|---|
+   | `scripts/lib/ontology.mjs` consumers in this worktree | DKG monorepo `urn:dkg:code:*` triples (`<pkgName>` is the workspace name) | Other producers via SPARQL — joins are by URI |
+   | Parent workspace's `scan-code.mjs` | External-repo `urn:dkg:code:*` triples (`<pkgName>` is `<owner>/<name>`) | Other producers via SPARQL — joins are by URI |
+   | Future Graphify-style importers | A producer-specific sub-graph; URIs MUST follow the canonical shape above (no `graphify:*` namespace) | Other producers via SPARQL — joins are by URI |
+
+3. **The `graphify:*` URI namespace is deprecated.** Importers that
+   currently emit `graphify:file:<hash>` MUST switch to
+   `urn:dkg:code:file:<pkgName>/<relPath>` (using the producer's declared
+   `<pkgName>` scope). For graphs that have already been promoted to
+   SWM/VM with `graphify:*` URIs, a one-shot reconciliation assertion
+   maps the legacy URIs forward (see §Reconciliation).
+
+4. **`<relPath>` is the path relative to the package root, not the repo
+   root.** A monorepo file at `packages/storage/src/adapters/oxigraph.ts`
+   has `<pkgName>=dkg-storage` and `<relPath>=src/adapters/oxigraph.ts`. The
+   parent's scanner (which runs against external repos one repo at a time)
+   has no concept of "package root", so its `<relPath>` is the repo-root-
+   relative path — but its `<pkgName>=<owner>/<name>` is also repo-rooted,
+   so the produced URI is unambiguous.
+
+5. **The `code:` ontology stays exactly as defined today** —
+   `scripts/lib/ontology.mjs` is the canonical source of truth for class
+   IRIs (`code:Package`, `code:File`, `code:Function`, `code:Class`,
+   `code:Interface`, `code:TypeAlias`, `code:Enum`, `code:ExternalModule`)
+   and property IRIs (`code:path`, `code:package`, `code:imports`,
+   `code:exports`, `code:contains`, etc.). New producers MUST import these
+   constants rather than redeclaring them.
+
+## Reconciliation
+
+Existing graphs that promoted `graphify:*` URIs to SWM/VM need a
+machine-readable bridge so downstream queries can find the canonical node
+either way. The pattern is a small `owl:sameAs` reconciliation assertion,
+written once per known-aliased URI:
+
+```turtle
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+<graphify:file:7f3a9c1e>
+    owl:sameAs <urn:dkg:code:file:dkg-storage/src/adapters/oxigraph.ts> .
+
+<graphify:file:b2d4e8f0>
+    owl:sameAs <urn:dkg:code:file:dkg-agent/src/dkg-agent.ts> .
+```
+
+In SPARQL, joins across the legacy and canonical URIs become trivial:
+
+```sparql
+SELECT ?file ?path WHERE {
+  ?file owl:sameAs* ?canonical .
+  ?canonical <http://dkg.io/ontology/code/path> ?path .
+}
+```
+
+Authoring the reconciliation assertion is the responsibility of whichever
+agent operated the deprecated importer. The assertion can be promoted
+through the standard `assertion/create + write + promote` flow (within
+the chunking budgets from ADR 0002 — one reconciliation typically fits in
+a single ROOT_CHUNK = 1000 URIs).
+
+## Consequences
+
+**Will change** (in PRs that follow this ADR):
+
+- `packages/cli/skills/dkg-importer/SKILL.md` (created in the same PR series
+  as this ADR) — the agent-readable importer manual cites this ADR for the
+  canonical URI shape and the "no `graphify:*` URIs in new code" rule.
+- The Graphify experiment (PR #602) — its importer migrates from
+  `graphify:*` URIs to `urn:dkg:code:*` URIs in a follow-up PR. The
+  experiment authors author a one-shot `owl:sameAs` reconciliation for
+  any graphs that have already been promoted with the legacy URIs.
+- The parent workspace's `.dkg/scripts/scan-code.mjs` — scheduled for a
+  documentation pass that points at this ADR. No URI-shape change is
+  required; the existing `<owner>/<name>/<relPath>` shape is already
+  canonical within its scope (external-repo scanning).
+- Any new code-graph importer — MUST import class/property IRIs from
+  `scripts/lib/ontology.mjs` and MUST follow the URI shape above.
+
+**Will not change**:
+
+- Existing `urn:dkg:code:*` URIs in WM/SWM/VM produced by either
+  `scripts/lib/ontology.mjs` consumers or the parent scanner. They are
+  already canonical.
+- The `code:*` class hierarchy or property IRIs.
+- The decision about how to encode language-specific concepts (Solidity
+  contracts, Python type hints, etc.) — those continue to evolve through
+  the existing `Code.T.*` definitions in `scripts/lib/ontology.mjs`.
+
+## Rejected alternatives
+
+- **"Two parallel canonical namespaces, `urn:dkg:code:*` and
+  `urn:dkg:scanned-code:*`."** Would solve the producer-scope question by
+  giving each producer its own namespace, but at the cost of breaking
+  every existing query. Existing consumers (the parent scanner has been
+  emitting `urn:dkg:code:*` for months and other tooling joins against it)
+  would have to be migrated. Not worth the churn.
+- **"Hash-based URIs (`urn:dkg:code:file:sha256:<digest>`)."** Producer-
+  independent, but loses human readability ("which file is
+  `sha256:7f3a…`?") and forces clients to maintain hash → path indexes
+  outside the graph. Considered for derived-artefact identity later but
+  not for the canonical URI.
+- **"Each producer maintains its own private URI space and joins through
+  an indirection."** That's exactly the `owl:sameAs` reconciliation pattern
+  above, applied universally. Without a canonical shape it leads to N²
+  bridges between producers. The canonical-with-one-bridge approach is
+  strictly better than N² bridges.
+
+## References
+
+- W3C OWL 2 reference for `owl:sameAs` — [https://www.w3.org/TR/owl2-syntax/#Individual_Equality](https://www.w3.org/TR/owl2-syntax/#Individual_Equality)
+- The percent-encoding requirement is mirrored in the parent workspace's
+  `AGENTS.md` § "Query gotchas (4)".
+- `scripts/lib/ontology.mjs` — canonical definitions of the `code:*` ontology
+  (classes, properties, URI helpers).

--- a/docs/adr/0003-code-graph-ontology-convergence.md
+++ b/docs/adr/0003-code-graph-ontology-convergence.md
@@ -99,11 +99,15 @@ which slice, and a sketch of how to reconcile already-emitted parallel URIs.
 
 4. **`<relPath>` is the path relative to the package root, not the repo
    root.** A monorepo file at `packages/storage/src/adapters/oxigraph.ts`
-   has `<pkgName>=dkg-storage` and `<relPath>=src/adapters/oxigraph.ts`. The
-   parent's scanner (which runs against external repos one repo at a time)
-   has no concept of "package root", so its `<relPath>` is the repo-root-
-   relative path — but its `<pkgName>=<owner>/<name>` is also repo-rooted,
-   so the produced URI is unambiguous.
+   has `<pkgName>=@origintrail-official/dkg-storage` (the scoped name
+   from that package's `package.json`) and
+   `<relPath>=src/adapters/oxigraph.ts`. The scope-prefixed handle is
+   what `Code.uri.package`/`Code.uri.file` emit today, so the example
+   here matches what the helper produces — no parallel namespace. The
+   parent's scanner (which runs against external repos one repo at a
+   time) has no concept of "package root", so its `<relPath>` is the
+   repo-root-relative path — but its `<pkgName>=<owner>/<name>` is also
+   repo-rooted, so the produced URI is unambiguous.
 
 5. **The `code:` ontology stays exactly as defined today** —
    `scripts/lib/ontology.mjs` is the canonical source of truth for class
@@ -124,22 +128,37 @@ written once per known-aliased URI:
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 
 <graphify:file:7f3a9c1e>
-    owl:sameAs <urn:dkg:code:file:dkg-storage/src/adapters/oxigraph.ts> .
+    owl:sameAs <urn:dkg:code:file:%40origintrail-official/dkg-storage/src/adapters/oxigraph.ts> .
 
 <graphify:file:b2d4e8f0>
-    owl:sameAs <urn:dkg:code:file:dkg-agent/src/dkg-agent.ts> .
+    owl:sameAs <urn:dkg:code:file:%40origintrail-official/dkg-agent/src/dkg-agent.ts> .
 ```
 
-In SPARQL, joins across the legacy and canonical URIs become trivial
-(the `PREFIX owl:` declaration is required by standard SPARQL parsers
-when using the `owl:` short form):
+The canonical URIs above match the shape `Code.uri.file()` already
+emits — note the `%40` (percent-encoded `@`) in the scoped package
+name, applied per `scripts/lib/ontology.mjs`. Using the unscoped
+`dkg-storage`/`dkg-agent` form here would re-introduce the parallel
+namespace this ADR is trying to eliminate.
+
+In SPARQL, joins across the legacy and canonical URIs become trivial.
+Two things to note:
+
+- The `PREFIX owl:` declaration is required by standard SPARQL parsers
+  when using the `owl:` short form (Codex flagged the earlier draft
+  for shipping the property path without it).
+- DKG sub-graph data is stored in named graphs (see [AGENTS.md §Query
+  gotchas](../../AGENTS.md)); a query against the default graph returns
+  zero rows. Wrap the pattern in `GRAPH ?g { ... }` so the example is
+  executable against the real `code` sub-graph.
 
 ```sparql
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT ?file ?path WHERE {
-  ?file owl:sameAs* ?canonical .
-  ?canonical <http://dkg.io/ontology/code/path> ?path .
+  GRAPH ?g {
+    ?file owl:sameAs* ?canonical .
+    ?canonical <http://dkg.io/ontology/code/path> ?path .
+  }
 }
 ```
 

--- a/docs/adr/0003-code-graph-ontology-convergence.md
+++ b/docs/adr/0003-code-graph-ontology-convergence.md
@@ -8,8 +8,8 @@
 
 ## Context
 
-Three things in the tree (and one in the next-door tree at
-`/Users/aleatoric/dev/.dkg/scripts/scan-code.mjs`) currently produce RDF
+Three things in this repository (and the shared workspace scanner that lives
+outside the repo at `.dkg/scripts/scan-code.mjs`) currently produce RDF
 triples about source files, packages, classes, and functions:
 
 | Producer | URI shape | Scope |
@@ -172,9 +172,9 @@ a single ROOT_CHUNK = 1000 URIs).
 
 **Will change** (in PRs that follow this ADR):
 
-- `packages/cli/skills/dkg-importer/SKILL.md` (created in the same PR series
-  as this ADR) — the agent-readable importer manual cites this ADR for the
-  canonical URI shape and the "no `graphify:*` URIs in new code" rule.
+- Future `packages/cli/skills/dkg-importer/SKILL.md` — the agent-readable
+  importer manual will cite this ADR for the canonical URI shape and the
+  "no `graphify:*` URIs in new code" rule.
 - The Graphify experiment (PR #602) — its importer migrates from
   `graphify:*` URIs to `urn:dkg:code:*` URIs in a follow-up PR. The
   experiment authors author a one-shot `owl:sameAs` reconciliation for


### PR DESCRIPTION
## Summary

Two ADRs to close out the architectural questions surfaced by the Graphify experiment (PR #602):

- **ADR 0002 — Importer chunking contract**: Clients chunk, daemon publishes the limits. Pins `CHUNK=5000` quads/write + `ROOT_CHUNK=1000` URIs/promote as the de-facto budgets importers should use. Documents HTTP 413 as a normal recoverable error, and explicitly rejects a server-side \`/api/import/bulk\` endpoint (would hide failure modes, duplicate manifest logic, defeat resumability).

- **ADR 0003 — Code-graph ontology convergence**: Canonical URI shapes for \`urn:dkg:code:{package,file,module}:*\` + producer-scope rules so monorepo scans, external-repo scans, and future importers don't fragment the graph. Deprecates the \`graphify:*\` namespace introduced in PR #602 in favour of \`urn:dkg:code:*\` + \`owl:sameAs\` reconciliation for graphs that have already promoted the legacy URIs.

Both ADRs cite the canonical helpers in \`scripts/lib/ontology.mjs\` and cross-reference each other. They unblock the importer SKILL.md and manifest library in a follow-up PR.

## Test plan

- [x] ADRs read coherently end-to-end; cross-references resolve to existing files in the tree
- [x] URI patterns match the existing scanner output (\`urn:dkg:code:file:<pkgName>/<relPath>\` with per-segment percent-encoding)
- [ ] Reviewer to confirm: rejected alternatives in ADR 0002 (server-side bulk endpoint, raising MAX_BODY_BYTES) are the right rejections for our team

Related: #596, #636 (bug report), #640 (WM persistence fix).

Made with [Cursor](https://cursor.com)

## Update — round 3 (2026-05-25): empirical motivation

Adds a short **Empirical motivation** subsection to ADR 0002 with concrete numbers from importing this repository's Graphify output (26,960 nodes / 63,003 edges) on rc.10:

- A hand-rolled importer written from `dkg-node/SKILL.md` alone needed **~330 LOC**, roughly half of which is cap-discovery ceremony (413 halving, 500-gossip switch to per-root batching, hand-rolled wallet-scoped CG ids, hand-rolled JSON resume state).
- Using rc.10's existing `scripts/lib/dkg-daemon.mjs` `DkgClient` cuts the importer to ~half the LOC; the gaps that remain are the ones PR #642 and PR #643 close.
- **Four of 17 partitions exceeded the 10 MB gossip cap** with `entities: "all"`. Total wall-clock spent in halve-and-retry: **~15 minutes** on top of legitimate write/promote work.
- Write latency degrades ~**200× from baseline** once cumulative SWM grows past ~100k triples; that's PR #643's motivation but presupposes this ADR's chunking discipline.

Full per-partition data lives in the rc.10 test artifacts; this ADR keeps the headline numbers so reviewers see "why these constants" up front.

Also addresses the two remaining round-3 codex line comments inline: portable scanner reference (replaces the author-local absolute path) and dead-link cleanup for the `dkg-importer/SKILL.md` / `manifest.mjs` references (now framed as future implementation work, since they ship in the dependent PR #642).
