### PR TITLE
fix: land PR 637/638 follow-ups on rfc38 integration

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7742,16 +7742,16 @@ export class DKGAgent {
     // local store knows about), then chain access-policy fallback
     // for numeric on-chain ids (covers the C2 case where the target
     // is just the numeric `cgId` from the publish intent and the
-    // local store has no triple keyed by that id).
+    // local store has no triple keyed by that id). Numeric IDs are
+    // chain-owned; if chain truth is unavailable, return UNKNOWN and
+    // fail closed instead of silently publishing plaintext.
     const targetCgId = publishContextGraphId ?? contextGraphId;
-    const probeIsCurated = async (cgId: string): Promise<boolean> => {
+    const probeIsCurated = async (cgId: string): Promise<boolean | null> => {
       try {
         if (await this.isPrivateContextGraph(cgId)) return true;
       } catch { /* fall through to chain probe */ }
       const cached = this.onChainAccessPolicyCache.get(cgId);
       if (cached !== undefined) return cached === 1;
-      const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
-      if (typeof getAccessPolicy !== 'function') return false;
       let numericId: bigint;
       try {
         numericId = BigInt(cgId);
@@ -7759,21 +7759,32 @@ export class DKGAgent {
         return false;
       }
       if (numericId <= 0n) return false;
+      const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
+      if (typeof getAccessPolicy !== 'function') return null;
       try {
         const policy = await getAccessPolicy.call(this.chain, numericId);
         if (policy === 0 || policy === 1) {
           this.onChainAccessPolicyCache.set(cgId, policy);
           return policy === 1;
         }
+        return null;
       } catch (err) {
-        this.log.warn(ctx, `_resolveEncryptInlinePayload: chain.getContextGraphAccessPolicy(${cgId}) failed — treating as public: ${err instanceof Error ? err.message : String(err)}`);
+        this.log.warn(ctx, `_resolveEncryptInlinePayload: chain.getContextGraphAccessPolicy(${cgId}) failed — treating as UNKNOWN (fail-closed): ${err instanceof Error ? err.message : String(err)}`);
       }
-      return false;
+      return null;
     };
     const sourceIsCurated = await probeIsCurated(contextGraphId);
     const targetIsCurated = targetCgId === contextGraphId
       ? sourceIsCurated
       : await probeIsCurated(targetCgId);
+    if (targetIsCurated == null || (targetCgId !== contextGraphId && sourceIsCurated == null)) {
+      throw new Error(
+        `LU-5: publish access-policy is unknown — ` +
+        `source CG "${contextGraphId}" curated=${sourceIsCurated ?? 'unknown'}, ` +
+        `target CG "${targetCgId}" curated=${targetIsCurated ?? 'unknown'}. ` +
+        `Refusing to choose plaintext vs encrypted inline payload without chain-confirmed policy.`,
+      );
+    }
     if (targetCgId !== contextGraphId && sourceIsCurated !== targetIsCurated) {
       // Fail-closed: a remap publish that crosses the privacy
       // boundary in either direction is almost certainly an
@@ -17952,4 +17963,3 @@ export class DKGAgent {
   }
 
 }
-

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression coverage for LU-5 inline-payload encryption policy.
+ *
+ * Numeric context graph ids are chain-owned policy surfaces. If the
+ * daemon cannot read chain truth for one of them, publishing must fail
+ * closed instead of falling back to plaintext.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+function makeAgentLike(opts: {
+  isPrivate?: boolean;
+  accessPolicy?: 0 | 1;
+  accessPolicyError?: Error;
+  exposeAccessPolicy?: boolean;
+} = {}) {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+  const chain: Record<string, unknown> = {};
+  if (opts.exposeAccessPolicy !== false) {
+    chain.getContextGraphAccessPolicy = vi.fn(async () => {
+      if (opts.accessPolicyError) throw opts.accessPolicyError;
+      return opts.accessPolicy ?? 0;
+    });
+  }
+  return {
+    log,
+    chain,
+    onChainAccessPolicyCache: new Map<string, 0 | 1>(),
+    isPrivateContextGraph: vi.fn(async () => opts.isPrivate ?? false),
+  } as any;
+}
+
+async function resolveEncryptInlinePayload(
+  agentLike: any,
+  contextGraphId: string,
+  publishContextGraphId?: string,
+) {
+  return (DKGAgent.prototype as any)._resolveEncryptInlinePayload.call(
+    agentLike,
+    contextGraphId,
+    undefined,
+    undefined,
+    publishContextGraphId,
+  );
+}
+
+describe('DKGAgent._resolveEncryptInlinePayload policy lookup', () => {
+  it('keeps non-numeric local public CGs on the plaintext path', async () => {
+    const agentLike = makeAgentLike({ exposeAccessPolicy: false });
+
+    await expect(resolveEncryptInlinePayload(agentLike, 'local-public-cg')).resolves.toBeUndefined();
+  });
+
+  it('uses chain policy for numeric public CGs before choosing plaintext', async () => {
+    const agentLike = makeAgentLike({ accessPolicy: 0 });
+
+    await expect(resolveEncryptInlinePayload(agentLike, '42')).resolves.toBeUndefined();
+    expect(agentLike.chain.getContextGraphAccessPolicy).toHaveBeenCalledWith(42n);
+    expect(agentLike.onChainAccessPolicyCache.get('42')).toBe(0);
+  });
+
+  it('fails closed when numeric target CG policy lookup is unavailable', async () => {
+    const agentLike = makeAgentLike({
+      accessPolicyError: new Error('rpc unavailable'),
+    });
+
+    await expect(resolveEncryptInlinePayload(agentLike, '42')).rejects.toThrow(
+      /publish access-policy is unknown/,
+    );
+    expect(agentLike.log.warn).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('treating as UNKNOWN'),
+    );
+  });
+
+  it('fails closed when a remap target numeric CG policy cannot be resolved', async () => {
+    const agentLike = makeAgentLike({
+      accessPolicyError: new Error('rpc unavailable'),
+    });
+
+    await expect(resolveEncryptInlinePayload(agentLike, 'local-public-cg', '42')).rejects.toThrow(
+      /target CG "42" curated=unknown/,
+    );
+  });
+});

--- a/packages/agent/test/storage-ack-protocol-extra.test.ts
+++ b/packages/agent/test/storage-ack-protocol-extra.test.ts
@@ -1,16 +1,16 @@
 /**
  * Storage-ACK transport pin: ACK collection MUST ride the libp2p direct
- * protocol `/dkg/10.0.0/storage-ack` — NOT GossipSub.
+ * protocol `/dkg/10.0.1/storage-ack` — NOT GossipSub.
  *
  * Audit findings covered:
  *   A-9 (HIGH) — pins that the agent package uses
- *        `PROTOCOL_STORAGE_ACK = '/dkg/10.0.0/storage-ack'` for ACK wiring
+ *        `PROTOCOL_STORAGE_ACK = '/dkg/10.0.1/storage-ack'` for ACK wiring
  *        and NEVER publishes ACKs over GossipSub.
  *
  * This is a static-scan test (no real libp2p dial needed). Spying on the
  * real dial inside a hermetic vitest run adds environment flakiness with
  * no additional guarantee — if the constant, the router registration, or
- * the dial site diverges from `'/dkg/10.0.0/storage-ack'`, this test
+ * the dial site diverges from `'/dkg/10.0.1/storage-ack'`, this test
  * flips RED. See also ack-eip191-agent-extra.test.ts for the constant
  * pin.
  */
@@ -53,7 +53,7 @@ describe('A-9: storage-ack protocol id (libp2p) pin', () => {
 
   it('agent source never publishes ACKs on GossipSub', () => {
     // A false-positive here would be any call like
-    // `publish('/dkg/10.0.0/storage-ack', ...)` or
+    // `publish('/dkg/10.0.1/storage-ack', ...)` or
     // `gossipsub.publish('...storage-ack...', ...)` through the gossipsub
     // manager. We scan all .ts files in src and make sure we never see
     // GossipSub coupling with the storage-ack string.

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -57,7 +57,7 @@ const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, contextGraphDataUri, escapeDkgRdfLiteral } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, escapeDkgRdfLiteral } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri, type PublishOptions } from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
@@ -996,8 +996,8 @@ WHERE {
   // Body: {
   //   contextGraphId: string,
   //   expectedMerkleRoot: hex32 string ("0x" + 64 hex chars),
-  //   quads?: Quad[],            // if omitted, fetched from local SWM
-  //   subGraphName?: string,     // narrows the SWM source slice
+  //   quads: Quad[],             // exact plaintext quads for this batch
+  //   subGraphName?: string,
   //   privateRoots?: hex32[],    // optional per-KA private sub-roots
   //   batchId?: string,          // round-tripped into rejection record
   // }
@@ -1028,74 +1028,24 @@ WHERE {
       }
       privateRoots.push(hexToBytes32(ph));
     }
-    let quads: Array<{ subject: string; predicate: string; object: string; graph: string }> = [];
-    if (Array.isArray(parsed.quads)) {
-      quads = parsed.quads.map((q: any) => ({
+    if (!Array.isArray(parsed.quads)) {
+      return jsonResponse(res, 400, {
+        error:
+          `verify-batch requires explicit \`quads\` in the request body. ` +
+          `The daemon cannot safely reconstruct a single batch from the local ` +
+          `SWM/data graph because that graph can contain triples from other ` +
+          `batches in the same context graph.`,
+      });
+    }
+
+    const quads: Array<{ subject: string; predicate: string; object: string; graph: string }> = parsed.quads.map(
+      (q: any) => ({
         subject: String(q.subject),
         predicate: String(q.predicate),
         object: String(q.object),
         graph: String(q.graph ?? ''),
-      }));
-    } else {
-      // Codex PR #609: when the caller passes `batchId`, they are
-      // asking us to verify ONE specific batch — but the SWM /
-      // data-graph reconstruction below loads EVERY triple in the
-      // context graph. For a CG with more than one published batch
-      // (i.e. nearly every real CG after the second publish), this
-      // deterministically false-positives `root-mismatch` because we
-      // hash a superset of leaves against a single-batch expected
-      // root. The local triple store has no per-batch label on the
-      // SWM data, so we can't safely scope the read here without
-      // additional metadata. Fail explicitly so the caller passes
-      // `quads` directly (which they typically already have from the
-      // member-side LU-7 catch-up that produced the batch).
-      if (parsed.batchId !== undefined && parsed.batchId !== null && String(parsed.batchId).length > 0) {
-        return jsonResponse(res, 400, {
-          error:
-            `verify-batch with \`batchId\` requires explicit \`quads\` in the request body. ` +
-            `Reconstruction from local SWM / data graph would include triples from OTHER ` +
-            `batches in the same CG and deterministically report \`root-mismatch\` against ` +
-            `the single-batch \`expectedMerkleRoot\`. Supply the exact batch quads (typically ` +
-            `from the LU-7 catch-up response) or omit \`batchId\` if you really do want to ` +
-            `verify the entire CG against a single root.`,
-        });
-      }
-      // No batchId — caller wants to verify the entire CG against a
-      // single root (legacy / single-batch use). Reconstruct from
-      // local store as before:
-      //   1. _shared_memory (live SWM, before promote-to-VM)
-      //   2. CG data graph (post-publish — selection moves quads from
-      //      SWM into the named-graph as part of the seal step)
-      const swmGraphUri = contextGraphSharedMemoryUri(contextGraphId, subGraphName);
-      // Codex PR #609 R2 — when `subGraphName` is set and the batch has
-      // already been published (i.e. SWM is empty post-promote), the
-      // finalized triples live under the sub-graph-specific data graph,
-      // not the root CG graph. Use the same sub-graph-aware helper the
-      // publisher uses so the fallback path actually finds them.
-      const dataGraphUri = contextGraphDataUri(contextGraphId, subGraphName);
-      try {
-        const swmResult = await (agent as any).store.query(
-          `SELECT ?s ?p ?o WHERE { GRAPH <${swmGraphUri}> { ?s ?p ?o } }`,
-        );
-        if (swmResult?.type === 'bindings') {
-          for (const b of swmResult.bindings) {
-            quads.push({ subject: b['s'], predicate: b['p'], object: b['o'], graph: '' });
-          }
-        }
-        if (quads.length === 0) {
-          const dataResult = await (agent as any).store.query(
-            `SELECT ?s ?p ?o WHERE { GRAPH <${dataGraphUri}> { ?s ?p ?o } }`,
-          );
-          if (dataResult?.type === 'bindings') {
-            for (const b of dataResult.bindings) {
-              quads.push({ subject: b['s'], predicate: b['p'], object: b['o'], graph: '' });
-            }
-          }
-        }
-      } catch (err: any) {
-        return jsonResponse(res, 500, { error: `Failed to read local SWM/workspace: ${err?.message ?? err}` });
-      }
-    }
+      }),
+    );
 
     const { verifyBatch } = await import('@origintrail-official/dkg-agent');
     const verifyResult = verifyBatch({ quads, privateRoots, expectedRoot });

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -1004,7 +1004,10 @@ WHERE {
   //
   // Returns: { ok, expectedRoot, actualRoot, leafCount, reason? }
   if (req.method === "POST" && path === "/api/shared-memory/verify-batch") {
-    const body = await readBody(req, SMALL_BODY_BYTES);
+    // `quads` is now mandatory so the caller supplies the exact plaintext
+    // batch. Use the data-heavy endpoint limit rather than the small settings
+    // limit; otherwise valid batches over 256 KB cannot be verified.
+    const body = await readBody(req, MAX_BODY_BYTES);
     const parsed = safeParseJson(body, res);
     if (!parsed) return;
     const contextGraphId = parsed.contextGraphId;

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -308,6 +308,28 @@ describe('daemon memory_graph_changed route emissions', () => {
     expect(query).not.toHaveBeenCalled();
   });
 
+  it('accepts explicit verify-batch quads over the small request limit', async () => {
+    const largeLiteral = `"${'x'.repeat(270 * 1024)}"`;
+    const ctx = createContext('/api/shared-memory/verify-batch', {
+      contextGraphId: 'project-a',
+      expectedMerkleRoot: `0x${'11'.repeat(32)}`,
+      quads: [{
+        subject: 'urn:large-batch-root',
+        predicate: 'https://schema.org/text',
+        object: largeLiteral,
+        graph: 'urn:g',
+      }],
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(responseBody(ctx)).toMatchObject({
+      ok: false,
+      quadsConsidered: 1,
+    });
+  });
+
   it('threads callerAgentAddress into conditional shared-memory writes', async () => {
     const conditionalShare = vi.fn().mockResolvedValue({ shareOperationId: 'op-cas' });
     const ctx = createContext('/api/shared-memory/conditional-write', {

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -364,13 +364,14 @@ describe('daemon memory_graph_changed route emissions', () => {
         { subject: 'urn:root', predicate: 'urn:p2', object: 'urn:o2', graph: 'urn:g' },
       ],
     });
+    const getContextGraphOnChainId = vi.fn().mockResolvedValue('7');
     const ctx = createContext('/api/shared-memory/publish', {
       contextGraphId: 'project-a',
       subGraphName: 'notes',
       selection: ['urn:root'],
       clearAfter: false,
     }, {
-      agent: { publishFromSharedMemory } as unknown as RequestContext['agent'],
+      agent: { publishFromSharedMemory, getContextGraphOnChainId } as unknown as RequestContext['agent'],
       emitMemoryGraphChanged,
     });
 
@@ -413,7 +414,7 @@ describe('daemon memory_graph_changed route emissions', () => {
     await handleMemoryRoutes(ctx);
 
     expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
-    expect(getContextGraphOnChainId).not.toHaveBeenCalled();
+    expect(getContextGraphOnChainId).toHaveBeenCalledWith('project-a');
     expect(publishFromSharedMemory.mock.calls[0][2]).not.toHaveProperty('contextGraphId');
   });
 
@@ -424,12 +425,13 @@ describe('daemon memory_graph_changed route emissions', () => {
       kaManifest: [{ tokenId: 1n, rootEntity: 'urn:root' }],
       publicQuads: [{ subject: 'urn:root', predicate: 'urn:p', object: 'urn:o', graph: 'urn:g' }],
     });
+    const getContextGraphOnChainId = vi.fn().mockResolvedValue('7');
     const ctx = createContext('/api/shared-memory/publish', {
       contextGraphId: 'project-a',
       publishContextGraphId: '7',
       selection: ['urn:root'],
     }, {
-      agent: { publishFromSharedMemory } as unknown as RequestContext['agent'],
+      agent: { publishFromSharedMemory, getContextGraphOnChainId } as unknown as RequestContext['agent'],
     });
 
     await handleMemoryRoutes(ctx);

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -292,6 +292,22 @@ describe('daemon memory_graph_changed route emissions', () => {
     expect(emitMemoryGraphChanged).not.toHaveBeenCalled();
   });
 
+  it('rejects verify-batch without explicit batch quads before reading local graphs', async () => {
+    const query = vi.fn();
+    const ctx = createContext('/api/shared-memory/verify-batch', {
+      contextGraphId: 'project-a',
+      expectedMerkleRoot: `0x${'11'.repeat(32)}`,
+    }, {
+      agent: { store: { query } } as unknown as RequestContext['agent'],
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(400);
+    expect(responseBody(ctx).error).toMatch(/requires explicit `quads`/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
   it('threads callerAgentAddress into conditional shared-memory writes', async () => {
     const conditionalShare = vi.fn().mockResolvedValue({ shareOperationId: 'op-cas' });
     const ctx = createContext('/api/shared-memory/conditional-write', {

--- a/packages/core/src/proto/publish-intent.ts
+++ b/packages/core/src/proto/publish-intent.ts
@@ -21,7 +21,7 @@ const { Type, Field } = protobuf;
  * publisher is about to submit a chain TX and needs 3 core node StorageACKs.
  *
  * Core nodes that have the data in SWM verify the merkle root and respond
- * with a StorageACK via direct P2P stream `/dkg/10.0.0/storage-ack`.
+ * with a StorageACK via direct P2P stream `/dkg/10.0.1/storage-ack`.
  */
 
 export const PublishIntentSchema = new Type('PublishIntent')
@@ -52,8 +52,10 @@ export const PublishIntentSchema = new Type('PublishIntent')
   // they sign the V10 digest based on the publisher's claimed merkle root
   // and ciphertext byte size; member post-decrypt verification (LU-8)
   // catches any mismatch between the on-chain root and the actual
-  // plaintext. Field number 14 to keep the proto strictly additive — old
-  // senders never set it (default `false`), old receivers ignore it.
+  // plaintext. Field number 14 keeps the proto strictly additive for
+  // encoders, but encrypted payloads are only sent over the bumped
+  // `/dkg/10.0.1/storage-ack` protocol so pre-LU-5 receivers never parse
+  // ciphertext as plaintext.
   .add(new Field('isEncryptedPayload', 14, 'bool'));
 
 type Long = { low: number; high: number; unsigned: boolean };

--- a/packages/core/src/proto/storage-ack.ts
+++ b/packages/core/src/proto/storage-ack.ts
@@ -27,7 +27,7 @@ const { Type, Field } = protobuf;
  */
 
 /**
- * Declinable reasons a core node can return on `/dkg/10.0.0/storage-ack`
+ * Declinable reasons a core node can return on `/dkg/10.0.1/storage-ack`
  * instead of a signed ACK. These are situations where the core
  * legitimately cannot produce an ACK for THIS PEER right now — a
  * well-formed publish request that this specific core just can't

--- a/packages/node-ui/playwright.config.ts
+++ b/packages/node-ui/playwright.config.ts
@@ -5,6 +5,7 @@ import { dirname } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CI = !!process.env.CI;
 const PORT = 5173;
+const DEVNET_NODE = process.env.DEVNET_NODE || process.env.UI_NODE_ID || '1';
 
 export default defineConfig({
   testDir: './e2e/specs',
@@ -30,7 +31,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'pnpm dev:ui',
+    command: `cross-env DEVNET_NODE=${DEVNET_NODE} pnpm dev:ui`,
     cwd: __dirname,
     port: PORT,
     reuseExistingServer: !CI,

--- a/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
@@ -42,6 +42,7 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
   const [creating, setCreating] = useState(false);
   const [progress, setProgress] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [registrationWarning, setRegistrationWarning] = useState<string | null>(null);
   const [agentAddress, setAgentAddress] = useState<string | null>(null);
   // Phase 8: after CG + ontology + manifest publish, transition into a
   // wire-workspace step so the curator can populate their own workspace
@@ -72,7 +73,10 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
   };
 
   useEffect(() => {
-    if (open) loadAgentIdentity();
+    if (open) {
+      setRegistrationWarning(null);
+      loadAgentIdentity();
+    }
   }, [open]);
 
   if (!open) return null;
@@ -88,6 +92,7 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
 
     setCreating(true);
     setError(null);
+    setRegistrationWarning(null);
     setProgress('Registering context graph on the network…');
 
     const finalSlug = slugify(trimmedName);
@@ -137,14 +142,13 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
       // refresh and stranded the user with no obvious path forward.
       // The "retry from Settings" affordance below now picks up the
       // partial-success state via the refreshed list.
-      let registrationWarning: string | null = null;
       if (registerOnChain && result.registered === false) {
-        registrationWarning =
+        const registrationWarningMessage =
           `On-chain registration failed: ${result.registerError ?? 'unknown error'}. ` +
           `Project is created locally and usable for everything except Verified Memory publishing. ` +
           `Retry registration from the project's Settings when ready.`;
-        console.warn('[CreateProjectModal]', registrationWarning);
-        setProgress(registrationWarning);
+        console.warn('[CreateProjectModal]', registrationWarningMessage);
+        setRegistrationWarning(registrationWarningMessage);
       }
 
       // Phase 7: install the chosen ontology into meta/project-ontology so
@@ -234,6 +238,7 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
   function handleWireDone() {
     setWiredCgId(null);
     setWiredProjectName('');
+    setRegistrationWarning(null);
     setName('');
     setDescription('');
     onClose();
@@ -250,6 +255,11 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
             </div>
           </div>
           <div className="v10-modal-body">
+            {registrationWarning && (
+              <div className="v10-modal-warning">
+                {registrationWarning}
+              </div>
+            )}
             <WireWorkspacePanel
               contextGraphId={wiredCgId}
               projectName={wiredProjectName}
@@ -276,6 +286,12 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
           {error && (
             <div className="v10-modal-error">
               {error}
+            </div>
+          )}
+
+          {registrationWarning && (
+            <div className="v10-modal-warning">
+              {registrationWarning}
             </div>
           )}
 

--- a/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
@@ -104,6 +104,8 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
     const cgId = `${agentAddress}/${finalSlug}`;
 
     try {
+      const slowTimer = setTimeout(() => setProgress('On-chain registration in progress — this can take up to 30s…'), 5000);
+
       // OT-RFC-38 LU-6: project creation is LOCAL-ONLY (no chain
       // interaction, no gas). On-chain registration is deferred to
       // the first VM publish, which is what the user actually opts

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -3360,6 +3360,17 @@ p { font-size: 13px; color: var(--text-secondary); line-height: 1.6; }
   line-height: 1.5;
 }
 
+.v10-modal-warning {
+  padding: 10px 14px;
+  background: var(--amber-dim);
+  border: 1px solid rgba(245, 158, 11, 0.25);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 12px;
+  color: var(--text-warning);
+  line-height: 1.5;
+}
+
 .v10-modal-tip {
   padding: 12px 14px;
   background: var(--bg-surface);

--- a/packages/node-ui/test/create-project-modal.test.ts
+++ b/packages/node-ui/test/create-project-modal.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+const createContextGraphMock = vi.fn();
+const fetchContextGraphsMock = vi.fn();
+const fetchCurrentAgentMock = vi.fn();
+const installOntologyMock = vi.fn();
+const publishProjectManifestMock = vi.fn();
+
+vi.mock('../src/ui/api.js', async () => {
+  const actual = await vi.importActual<any>('../src/ui/api.js');
+  return {
+    ...actual,
+    createContextGraph: createContextGraphMock,
+    fetchContextGraphs: fetchContextGraphsMock,
+    fetchCurrentAgent: fetchCurrentAgentMock,
+  };
+});
+
+vi.mock('../src/ui/lib/ontologyInstall.js', () => ({
+  installOntology: installOntologyMock,
+  listStarters: () => [{
+    slug: 'coding-project',
+    displayName: 'Coding Project',
+    description: 'Default coding starter',
+  }],
+}));
+
+vi.mock('../src/ui/lib/projectManifest.js', () => ({
+  publishProjectManifest: publishProjectManifestMock,
+}));
+
+vi.mock('../src/ui/components/Workspace/WireWorkspacePanel.js', () => ({
+  WireWorkspacePanel: ({ contextGraphId, projectName }: { contextGraphId: string; projectName: string }) =>
+    React.createElement('div', { 'data-testid': 'wire-workspace' }, `${projectName}:${contextGraphId}`),
+}));
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  valueSetter?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('CreateProjectModal partial registration flow', () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+  const agentAddress = '0x00000000000000000000000000000000000000a1';
+  const cgId = `${agentAddress}/partial-registration`;
+
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fetchCurrentAgentMock.mockResolvedValue({
+      agentAddress,
+      agentDid: `did:dkg:agent:${agentAddress}`,
+      name: 'Local Agent',
+      peerId: 'peer-local',
+    });
+    createContextGraphMock.mockResolvedValue({
+      created: cgId,
+      registered: false,
+      registerError: 'rpc unavailable',
+    });
+    fetchContextGraphsMock.mockResolvedValue({
+      contextGraphs: [{ id: cgId, name: 'Partial Registration' }],
+    });
+    installOntologyMock.mockResolvedValue(undefined);
+    publishProjectManifestMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    container?.remove();
+    root = null;
+    container = null;
+    vi.restoreAllMocks();
+  });
+
+  async function renderModal() {
+    const { CreateProjectModal } = await import('../src/ui/components/Modals/CreateProjectModal.js');
+    const { useProjectsStore } = await import('../src/ui/stores/projects.js');
+    const { useTabsStore } = await import('../src/ui/stores/tabs.js');
+    const { useJourneyStore } = await import('../src/ui/stores/journey.js');
+    act(() => {
+      useProjectsStore.setState({ contextGraphs: [], loading: false, activeProjectId: null });
+      useTabsStore.setState({
+        tabs: [{ id: 'dashboard', label: 'Dashboard', closable: false }],
+        activeTabId: 'dashboard',
+      });
+      useJourneyStore.setState({ stage: 0 });
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(React.createElement(CreateProjectModal, { open: true, onClose: vi.fn() }));
+    });
+    await flush();
+    return { useProjectsStore };
+  }
+
+  it('keeps a locally-created project active and visible when on-chain registration fails', async () => {
+    const { useProjectsStore } = await renderModal();
+    const nameInput = container!.querySelector('input[type="text"]') as HTMLInputElement | null;
+    const registerCheckbox = container!.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+    expect(nameInput).toBeTruthy();
+    expect(registerCheckbox).toBeTruthy();
+
+    await act(async () => {
+      setInputValue(nameInput!, 'Partial Registration');
+      registerCheckbox!.click();
+    });
+    await flush();
+
+    const createButton = Array
+      .from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent === 'Create Context Graph') as HTMLButtonElement | undefined;
+    expect(createButton).toBeTruthy();
+    await act(async () => {
+      createButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+    await flush();
+
+    expect(createContextGraphMock).toHaveBeenCalledWith(
+      cgId,
+      'Partial Registration',
+      undefined,
+      expect.objectContaining({ register: true }),
+    );
+    expect(useProjectsStore.getState().activeProjectId).toBe(cgId);
+    expect(container!.querySelector('[data-testid="wire-workspace"]')).toBeTruthy();
+    expect(container!.textContent).toContain('On-chain registration failed: rpc unavailable');
+  });
+});

--- a/packages/node-ui/vite.config.ts
+++ b/packages/node-ui/vite.config.ts
@@ -21,12 +21,17 @@ function readDkgConfig() {
   const devnetNodeNum = process.env.DEVNET_NODE || process.env.UI_NODE_ID;
   if (devnetNodeNum) {
     const devnetDir = resolve(__dirname, '../../.devnet', `node${devnetNodeNum}`);
-    if (existsSync(join(devnetDir, 'api.port'))) {
-      const port = parseInt(readFileSync(join(devnetDir, 'api.port'), 'utf-8').trim(), 10) || 9201;
-      const token = readTokenFile(join(devnetDir, 'auth.token'));
-      console.log(`[vite] Using devnet node${devnetNodeNum} on port ${port}`);
-      return { port, token };
+    const portFile = join(devnetDir, 'api.port');
+    if (!existsSync(portFile)) {
+      throw new Error(
+        `[vite] DEVNET_NODE/UI_NODE_ID requested devnet node${devnetNodeNum}, ` +
+        `but ${portFile} does not exist. Start that devnet node or unset the env var to use ~/.dkg.`,
+      );
     }
+    const port = parseInt(readFileSync(portFile, 'utf-8').trim(), 10) || 9201;
+    const token = readTokenFile(join(devnetDir, 'auth.token'));
+    console.log(`[vite] Using devnet node${devnetNodeNum} on port ${port}`);
+    return { port, token };
   }
 
   // Fall back to ~/.dkg (testnet / production node)

--- a/packages/node-ui/vite.config.ts
+++ b/packages/node-ui/vite.config.ts
@@ -12,20 +12,21 @@ function readTokenFile(path: string): string {
 }
 
 function readDkgConfig() {
-  // Devnet takes priority over ~/.dkg. By default we target node1 (matches
-  // pre-LU-5 behaviour). The `scripts/devnet.sh ui start` wrapper already
-  // exports DEVNET_NODE=$UI_NODE_ID, so set UI_NODE_ID=5 before invoking
-  // the script (or set DEVNET_NODE directly when running `pnpm dev:ui`
-  // standalone) to point the UI at a different daemon — required to test
-  // the edge-curator flow from the UI without hand-rolling curl against
-  // the edge node's daemon port.
-  const devnetNodeNum = process.env.DEVNET_NODE || '1';
-  const devnetDir = resolve(__dirname, '../../.devnet', `node${devnetNodeNum}`);
-  if (existsSync(join(devnetDir, 'api.port'))) {
-    const port = parseInt(readFileSync(join(devnetDir, 'api.port'), 'utf-8').trim(), 10) || 9201;
-    const token = readTokenFile(join(devnetDir, 'auth.token'));
-    console.log(`[vite] Using devnet node${devnetNodeNum} on port ${port}`);
-    return { port, token };
+  // Devnet takes priority over ~/.dkg only when explicitly requested.
+  // `scripts/devnet.sh ui start` exports DEVNET_NODE=$UI_NODE_ID, so
+  // operators can still point at node5 by setting UI_NODE_ID=5 before
+  // invoking the wrapper (or DEVNET_NODE directly for `pnpm dev:ui`).
+  // Without that explicit opt-in, stale `.devnet/node1` files must not
+  // shadow the real local node in ~/.dkg.
+  const devnetNodeNum = process.env.DEVNET_NODE || process.env.UI_NODE_ID;
+  if (devnetNodeNum) {
+    const devnetDir = resolve(__dirname, '../../.devnet', `node${devnetNodeNum}`);
+    if (existsSync(join(devnetDir, 'api.port'))) {
+      const port = parseInt(readFileSync(join(devnetDir, 'api.port'), 'utf-8').trim(), 10) || 9201;
+      const token = readTokenFile(join(devnetDir, 'auth.token'));
+      console.log(`[vite] Using devnet node${devnetNodeNum} on port ${port}`);
+      return { port, token };
+    }
   }
 
   // Fall back to ~/.dkg (testnet / production node)

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -49,7 +49,7 @@ function sanitizeDeclineField(value: string, maxChars: number): string {
  *
  * Flow:
  * 1. Broadcast PublishIntent via GossipSub (finalization topic)
- * 2. Concurrently dial each known core node on /dkg/10.0.0/storage-ack
+ * 2. Concurrently dial each known core node on PROTOCOL_STORAGE_ACK
  * 3. First 3 valid ACKs win; verify each signature via ecrecover
  */
 export class ACKCollector {
@@ -112,6 +112,10 @@ export class ACKCollector {
     }
 
     // P2P intent includes staging quads so core nodes can verify inline.
+    // Encrypted inline payloads are gated by this collector's exclusive
+    // use of PROTOCOL_STORAGE_ACK (`/dkg/10.0.1/storage-ack`): pre-LU-5
+    // cores that only speak `/dkg/10.0.0/storage-ack` never receive field
+    // 14 ciphertext and therefore cannot misparse it as plaintext.
     // `contextGraphId` on the wire is the TARGET numeric id peers will sign
     // the ACK against. `swmGraphId` (optional) is the SOURCE graph where
     // data lives in SWM — only set when the publisher is remapping a named

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -23,7 +23,7 @@ export type ReceiverSignatureProvider = (
 ) => Promise<ReceiverSignature[]>;
 
 /**
- * V10 core node ACK signature collected via /dkg/10.0.0/storage-ack.
+ * V10 core node ACK signature collected via /dkg/10.0.1/storage-ack.
  * Spec §9.0.3: ACK = EIP-191(computePublishACKDigest(chainId, kav10Address,
  *   contextGraphId, merkleRoot, kaCount, byteSize, epochs, tokenAmount))
  */

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -185,7 +185,7 @@ export class StorageACKHandler {
   }
 
   /**
-   * Protocol stream handler for `/dkg/10.0.0/storage-ack`.
+   * Protocol stream handler for `/dkg/10.0.1/storage-ack`.
    * Receives PublishIntent, returns StorageACK.
    */
   handler = async (data: Uint8Array, _peerId: PeerId): Promise<Uint8Array> => {

--- a/scripts/devnet-test-rfc38-lu8.sh
+++ b/scripts/devnet-test-rfc38-lu8.sh
@@ -48,6 +48,16 @@ api_call() {
   curl "${curl_args[@]}"
 }
 
+api_call_with_status() {
+  local node="$1" method="$2" path="$3" data="${4:-}"
+  local port; port=$(node_port "$node")
+  local token; token=$(node_token "$node")
+  local -a curl_args=(-sS --max-time 120 -X "$method" -H "Authorization: Bearer $token" -H 'Content-Type: application/json')
+  [ -n "$data" ] && curl_args+=(-d "$data")
+  curl_args+=(-w $'\n%{http_code}' "http://127.0.0.1:${port}${path}")
+  curl "${curl_args[@]}"
+}
+
 parse_json() {
   printf '%s' "$1" | node -e "
     let d=''; process.stdin.on('data',c=>d+=c);
@@ -133,14 +143,17 @@ log "================================================================"
 # hashes a superset of leaves against a single-batch expected root. Keep the
 # route strict: callers must pass the exact plaintext quads they are verifying.
 log "Curator calls verify-batch without quads; endpoint should reject the ambiguous request..."
-VERIFY_MISSING_QUADS=$(api_call "$CURATOR_NODE" POST /api/shared-memory/verify-batch "$(cat <<EOF
+VERIFY_MISSING_QUADS_WITH_STATUS=$(api_call_with_status "$CURATOR_NODE" POST /api/shared-memory/verify-batch "$(cat <<EOF
 { "contextGraphId": "$PUB_CG", "expectedMerkleRoot": "$MERKLE_ROOT" }
 EOF
 )")
+VERIFY_MISSING_QUADS_STATUS=$(printf '%s\n' "$VERIFY_MISSING_QUADS_WITH_STATUS" | tail -n 1)
+VERIFY_MISSING_QUADS=$(printf '%s\n' "$VERIFY_MISSING_QUADS_WITH_STATUS" | sed '$d')
 log "verify-batch missing-quads response: $VERIFY_MISSING_QUADS"
+[ "$VERIFY_MISSING_QUADS_STATUS" = "400" ] || fail "verify-batch missing-quads status=$VERIFY_MISSING_QUADS_STATUS (expected 400): $VERIFY_MISSING_QUADS"
 MISSING_QUADS_ERROR=$(parse_json "$VERIFY_MISSING_QUADS" '.error')
 if printf '%s' "$MISSING_QUADS_ERROR" | grep -q 'requires explicit `quads`'; then
-  log "✓ Scenario 1: verify-batch rejects omitted quads before ambiguous reconstruction"
+  log "✓ Scenario 1: verify-batch rejects omitted quads with HTTP 400 before ambiguous reconstruction"
 else
   fail "verify-batch missing-quads response did not mention explicit quads requirement: $VERIFY_MISSING_QUADS"
 fi

--- a/scripts/devnet-test-rfc38-lu8.sh
+++ b/scripts/devnet-test-rfc38-lu8.sh
@@ -5,10 +5,10 @@
 #
 # Scenarios:
 #
-#   1. HAPPY PATH — Curator publishes a public CG batch. Member fetches
-#      the on-chain merkleRoot via the chain API, calls
-#      POST /api/shared-memory/verify-batch with the local SWM quads
-#      → must return ok=true.
+#   1. REQUEST VALIDATION — verify-batch without explicit quads is
+#      rejected because local graph reconstruction is not batch-scoped.
+#      The happy path then calls verify-batch with exact caller-supplied
+#      plaintext quads and must return ok=true.
 #
 #   2. ROOT-MISMATCH — Member calls verify-batch with a forged set of
 #      quads (adds an injected triple) but the real expectedRoot.
@@ -120,37 +120,34 @@ log "✓ published txHash=$TX_HASH merkleRoot=$MERKLE_ROOT"
 sleep 5
 
 # ===========================================================================
-# SCENARIO 1 — Happy path on the member side.
+# SCENARIO 1 — Request validation + happy path on the member side.
 # ===========================================================================
 
 log ""
 log "================================================================"
-log "  SCENARIO 1: verify-batch HAPPY PATH (member, public CG)"
+log "  SCENARIO 1: verify-batch REQUEST VALIDATION + HAPPY PATH"
 log "================================================================"
 
-# The published quads on the curator side live in the CG's named data
-# graph after seal (the publisher moves them out of SWM). The verify-
-# batch endpoint falls back to the data graph if SWM is empty.
-log "Curator calls verify-batch against its own local data (after publish, plaintext lives in the CG data graph)..."
-VERIFY_OK=$(api_call "$CURATOR_NODE" POST /api/shared-memory/verify-batch "$(cat <<EOF
+# The daemon cannot safely infer a single published batch from a whole
+# context graph. Once a CG has multiple batches, local graph reconstruction
+# hashes a superset of leaves against a single-batch expected root. Keep the
+# route strict: callers must pass the exact plaintext quads they are verifying.
+log "Curator calls verify-batch without quads; endpoint should reject the ambiguous request..."
+VERIFY_MISSING_QUADS=$(api_call "$CURATOR_NODE" POST /api/shared-memory/verify-batch "$(cat <<EOF
 { "contextGraphId": "$PUB_CG", "expectedMerkleRoot": "$MERKLE_ROOT" }
 EOF
 )")
-log "verify-batch happy: $VERIFY_OK"
-OK_FLAG=$(parse_json "$VERIFY_OK" '.ok')
-QUADS_CONSIDERED=$(parse_json "$VERIFY_OK" '.quadsConsidered')
-if [ "$OK_FLAG" = "true" ]; then
-  log "✓ Scenario 1: verify-batch returned ok=true ($QUADS_CONSIDERED quads considered)"
+log "verify-batch missing-quads response: $VERIFY_MISSING_QUADS"
+MISSING_QUADS_ERROR=$(parse_json "$VERIFY_MISSING_QUADS" '.error')
+if printf '%s' "$MISSING_QUADS_ERROR" | grep -q 'requires explicit `quads`'; then
+  log "✓ Scenario 1: verify-batch rejects omitted quads before ambiguous reconstruction"
 else
-  warn "verify-batch returned ok=$OK_FLAG ($QUADS_CONSIDERED quads considered)"
-  warn "  The actual published root for KC #$KC_ID was $MERKLE_ROOT"
-  warn "  recomputed: $(parse_json "$VERIFY_OK" '.actualRoot')"
+  fail "verify-batch missing-quads response did not mention explicit quads requirement: $VERIFY_MISSING_QUADS"
 fi
 
-# Bonus: also exercise the explicit-quads path (caller-supplied
-# plaintext). This is the path a member uses after catchup once they've
-# decrypted ciphertext, and is the only path that's truly key-holder-
-# independent for the verifier API.
+# Exercise the explicit-quads path (caller-supplied plaintext). This is the
+# path a member uses after catchup once they've decrypted ciphertext, and is
+# the only path that's batch-scoped for the verifier API.
 log "Calling verify-batch with explicit caller-supplied quads (member-side simulation)..."
 EXPLICIT_QUADS=$(node -e "
   const quads = [];


### PR DESCRIPTION
Summary: lands only the missing PR #637/#638 follow-up fixes on integration/rfc38-mainnet-ready without merging either branch wholesale. Includes #638 verify-batch explicit quads requirement and LU-8 script assertion, #637 DEVNET_NODE Playwright pin, fail-closed numeric CG access-policy handling, node UI registration warning, Vite devnet opt-in, storage ACK /dkg/10.0.1 docs/tests, and protocol comment cleanups. Tests: pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/memory-graph-events.test.ts; bash -n scripts/devnet-test-rfc38-lu8.sh; pnpm exec vitest run test/encrypt-inline-policy.test.ts test/storage-ack-protocol-extra.test.ts from packages/agent with Hardhat listener escalation; pnpm --filter @origintrail-official/dkg-node-ui build. Static checks: no verify-batch contextGraphDataUri fallback; Playwright starts pnpm dev:ui with DEVNET_NODE; Vite uses .devnet only when DEVNET_NODE or UI_NODE_ID is set.