### PR TITLE
fix(rs): unblock random-sampling on integration — T2 + T6 + T8 devnet-sweep triage

### DIFF
--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -621,6 +621,19 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
      *      check, not here.
      */
     function _isCGEligible(uint256 contextGraphId) internal view returns (bool) {
+        // RFC-39 Phase B (deferred): curated CG random sampling requires a
+        // ciphertext-aware prover. The contract-side picker (steps 2/3 below)
+        // is already wired to draw against `getCiphertextChunkCount`, but the
+        // off-chain prover at `packages/random-sampling/src/prover.ts` still
+        // queries `getMerkleLeafCount` and proves against plaintext leaves.
+        // Until the prover ciphertext path lands, curated CGs are skipped at
+        // CG-level eligibility so the picker never returns a curated KC and
+        // every draw stays decidable against the existing plaintext leaves.
+        //
+        // Re-enabling curated random sampling is a single-line revert here +
+        // the unskip in `RandomSampling-curated.test.ts`, contingent on the
+        // prover ciphertext path being green.
+        if (contextGraphStorage.getIsCurated(contextGraphId)) return false;
         return contextGraphStorage.isContextGraphActive(contextGraphId);
     }
 

--- a/packages/evm-module/test/unit/RandomSampling-curated.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling-curated.test.ts
@@ -35,7 +35,21 @@ import {
  * `previewChallengeForSeed` helper so the curated branch is testable
  * without a full proof-period dance.
  */
-describe('@unit RandomSampling — RFC-39 curated picker', () => {
+// RFC-39 Phase B (deferred): curated CG random sampling is gated at the
+// `_isCGEligible` level until the off-chain prover (`packages/random-sampling
+// /src/prover.ts`) learns to fetch `getCiphertextChunkCount` /
+// `getCiphertextChunksRoot` and build the proof against the ciphertext
+// chunks on disk. Today the prover still queries `getMerkleLeafCount` and
+// proves against plaintext leaves, so any draw the contract picker resolved
+// to a curated KC produced `V10ProofLeafCountMismatchError` for every
+// proving period (devnet sweep confirmed this on every core node).
+//
+// Until the prover lands its ciphertext path, the contract picker treats
+// curated CGs as ineligible. The picker code in steps 2/3 of
+// `_pickWeightedChallenge` retains the curated branches so the unskip is a
+// one-line revert in `RandomSampling._isCGEligible` + removing the
+// `.skip` below.
+describe.skip('@unit RandomSampling — RFC-39 curated picker [Phase B deferred]', () => {
   const CURATED_POLICY = 0;
   const OPEN_POLICY = 1;
   const TEST_KC_BYTE_SIZE = 128n;

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -982,16 +982,19 @@ describe('@unit RandomSampling', () => {
     // -----------------------------------------------------------------------
     // Test 2 — Edge: only-curated-CG-holds-value scenario.
     //
-    // RFC-39 Phase A.5 behaviour change: curated CGs are NO LONGER excluded
-    // at the CG-eligibility level. Instead, KCs inside a curated CG must
-    // each carry a `(ciphertextChunksRoot, ciphertextChunkCount)` commitment
-    // to participate in the curated draw. Without a commitment, every KC
-    // is skipped during step 2 of the picker — MAX_KC_RETRIES are exhausted
-    // and the call reverts with `NoEligibleKnowledgeCollection` (not the
-    // pre-RFC-39 `NoEligibleContextGraph`). The CG-level slot still resolves;
-    // it's the KC-level slot that has no candidates.
+    // RFC-39 Phase B (deferred): the curated-CG eligibility branch in
+    // `_isCGEligible` is currently a hard skip until the off-chain prover
+    // learns to fetch `getCiphertextChunkCount` + `getCiphertextChunksRoot`
+    // and build proofs against ciphertext chunks. With curated CGs filtered
+    // at the CG-level, the only-curated scenario falls through to
+    // `adjustedTotal == 0` on the first attempt and reverts
+    // `NoEligibleContextGraph` (the pre-RFC-39 behaviour). When the prover
+    // ciphertext path lands and the eligibility filter is removed, this
+    // test should be flipped back to expect `NoEligibleKnowledgeCollection`
+    // — see the corresponding `describe.skip` in
+    // `RandomSampling-curated.test.ts`.
     // -----------------------------------------------------------------------
-    it('reverts NoEligibleKnowledgeCollection when only curated CGs hold value and none have a ciphertext commitment', async () => {
+    it('reverts NoEligibleContextGraph when only curated CGs hold value (Phase B picker skip)', async () => {
       const curatedCgId = await createCG(CURATED_POLICY);
       const endEpoch = (await Chronos.getCurrentEpoch()) + 5n;
       await createKC(curatedCgId, endEpoch);
@@ -1002,7 +1005,7 @@ describe('@unit RandomSampling', () => {
         RandomSampling.previewChallengeForSeed(testSeed(0), currentEpoch),
       ).to.be.revertedWithCustomError(
         RandomSampling,
-        'NoEligibleKnowledgeCollection',
+        'NoEligibleContextGraph',
       );
     });
 

--- a/packages/random-sampling/src/kc-extractor.ts
+++ b/packages/random-sampling/src/kc-extractor.ts
@@ -3,6 +3,8 @@ import {
   contextGraphDataUri,
   contextGraphMetaUri,
   hashTripleV10,
+  TRUST_LEVEL_PREDICATE,
+  LEGACY_TRUST_LEVEL_PREDICATE,
 } from '@origintrail-official/dkg-core';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 
@@ -11,6 +13,23 @@ const XSD = 'http://www.w3.org/2001/XMLSchema#';
 const ONTOLOGY_GRAPH = 'did:dkg:context-graph:ontology';
 const CONTEXT_GRAPH_ON_CHAIN_ID = 'https://dkg.network/ontology#ContextGraphOnChainId';
 const CG_URI_PREFIX = 'did:dkg:context-graph:';
+
+/**
+ * Predicates that are stamped onto the data graph by the daemon AFTER a
+ * KC has been published (verify-quorum's `dkg:trustLevel` write being the
+ * canonical case). These are NOT part of the KC's commit-time leaf set
+ * and must be excluded from extraction so the recomputed leaf set stays
+ * bit-identical with the publisher's `merkleLeafCount`. Without this
+ * filter, every single-node publish (which falls into
+ * `stampBatchTrustLevel(..., SelfAttested)` because no remote ACK
+ * lands) corrupts the prover with `V10ProofLeafCountMismatchError`.
+ * The publisher already refuses user-authored trustLevel triples via
+ * `assertNoUserAuthoredTrustLevelQuads`, so excluding them here is safe.
+ */
+const POST_PUBLISH_PREDICATES_TO_SKIP: ReadonlySet<string> = new Set([
+  TRUST_LEVEL_PREDICATE,
+  LEGACY_TRUST_LEVEL_PREDICATE,
+]);
 
 /**
  * Quads pulled from the local triple store, post-publish, in the same
@@ -230,6 +249,7 @@ export async function extractV10KCFromStore(
     );
     if (result.type === 'quads') {
       for (const q of result.quads) {
+        if (POST_PUBLISH_PREDICATES_TO_SKIP.has(q.predicate)) continue;
         triples.push({ subject: q.subject, predicate: q.predicate, object: q.object });
       }
     }

--- a/packages/random-sampling/src/prover.ts
+++ b/packages/random-sampling/src/prover.ts
@@ -394,11 +394,18 @@ export class RandomSamplingProver {
     } catch (err) {
       const reason = mapBuilderError(err);
       if (reason) {
+        const e = err as any;
         this.log.error('rs.tick.data-corrupted', {
           kcId: kcId.toString(),
           cgId: cgId.toString(),
           reason,
           err: (err as Error).name,
+          ...(typeof e?.computedLeafCount === 'number' ? { computedLeafCount: e.computedLeafCount } : {}),
+          ...(typeof e?.expectedLeafCount === 'number' ? { expectedLeafCount: e.expectedLeafCount } : {}),
+          ...(typeof e?.chunkId === 'number' ? { chunkId: e.chunkId } : {}),
+          ...(typeof e?.leafCount === 'number' ? { leafCount: e.leafCount } : {}),
+          extractedLeafCount: leaves.length,
+          chainExpectedLeafCount: Number(expectedLeafCount),
         });
         await this.wal.append(
           makeWalEntry(periodKey, 'failed', {

--- a/packages/random-sampling/test/kc-extractor.test.ts
+++ b/packages/random-sampling/test/kc-extractor.test.ts
@@ -197,6 +197,57 @@ describe('extractV10KCFromStore — happy path / publisher round-trip parity', (
     expect(quads[0].graph).toBe(contextGraphDataUri(fixture.cgName!, fixture.cgId.toString()));
   });
 
+  // Regression: T2 (devnet-sweep triage). The daemon's verify-quorum
+  // path stamps `dkg:trustLevel = "N"` onto the dataGraph AFTER the
+  // publisher has computed `merkleLeafCount` and registered it on-chain
+  // (see `dkg-agent.stampTrustLevel` / `stampBatchTrustLevel`). For
+  // single-node publishes (no remote ACK lands) this happens within
+  // seconds of publish, polluting the dataGraph with one extra triple
+  // per root subject. Without the post-publish predicate skip, the
+  // extractor recomputes `merkleLeafCount + 1` and the prover dies with
+  // `V10ProofLeafCountMismatchError` for every challenge period.
+  it('skips post-publish dkg:trustLevel stamps so leaf count stays bit-identical with merkleLeafCount', async () => {
+    const fixture: KCFixture = {
+      cgId: 11n,
+      kcId: 17n,
+      ual: 'did:dkg:hardhat:31337/0xpub/17',
+      rootEntities: ['urn:entity:trust-target'],
+      publicTriples: [
+        { subject: 'urn:entity:trust-target', predicate: 'urn:p:k', object: '"v"' },
+      ],
+    };
+    await seedKC(store, fixture);
+
+    const cgName = `cg-${fixture.cgId.toString()}`;
+    const dataGraph = contextGraphDataUri(cgName, fixture.cgId.toString());
+    const TRUST_LEVEL_PREDICATE = 'http://dkg.io/ontology/trustLevel';
+    const LEGACY_TRUST_LEVEL_PREDICATE = 'https://dkg.network/ontology#trustLevel';
+    await store.insert([
+      {
+        subject: 'urn:entity:trust-target',
+        predicate: TRUST_LEVEL_PREDICATE,
+        object: '"0"',
+        graph: dataGraph,
+      },
+      {
+        subject: 'urn:entity:trust-target',
+        predicate: LEGACY_TRUST_LEVEL_PREDICATE,
+        object: '"0"',
+        graph: dataGraph,
+      },
+    ]);
+
+    const result = await extractV10KCFromStore(store, fixture.cgId, fixture.kcId);
+
+    expect(result.triples).toHaveLength(fixture.publicTriples.length);
+    expect(result.triples.map((t) => t.predicate)).not.toContain(TRUST_LEVEL_PREDICATE);
+    expect(result.triples.map((t) => t.predicate)).not.toContain(LEGACY_TRUST_LEVEL_PREDICATE);
+    expect(result.leaves).toHaveLength(fixture.publicTriples.length);
+
+    const fixtureLeaves = fixture.publicTriples.map((t) => hashTripleV10(t.subject, t.predicate, t.object));
+    expect(new V10MerkleTree(result.leaves).root).toEqual(new V10MerkleTree(fixtureLeaves).root);
+  });
+
   it('round-trips through buildV10ProofMaterial (extractor leaves accept on-chain commitment)', async () => {
     const fixture: KCFixture = {
       cgId: 1n,

--- a/scripts/_devnet-full-sweep.sh
+++ b/scripts/_devnet-full-sweep.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Internal sweep — runs every devnet-test script not already covered by
+# devnet-test-rfc38-all.sh, plus the non-RFC-38 baseline harnesses.
+# Aggregates pass/fail and writes per-script logs for triage.
+#
+# Prerequisite: devnet running (./scripts/devnet.sh start).
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/scripts"
+RESULTS_DIR="${RESULTS_DIR:-$REPO_ROOT/.devnet/full-sweep/$(date +%s)}"
+mkdir -p "$RESULTS_DIR"
+
+# Order matters for the stateful ones: revocation / unclean-restart mutate
+# the devnet in ways subsequent scripts have to tolerate. Random-sampling
+# and soak run last so a single chain advance doesn't poison the in-flight
+# challenges of the cheaper scripts.
+SCRIPTS=(
+  "rfc38-curator-offline-midbatch"
+  "rfc38-revocation"
+  "rfc38-prereg-bytecap-stress"
+  "rfc38-unclean-restart"
+  "publish"
+  "sharing"
+  "invite-flow"
+  "cli-invite"
+  "reject-flow"
+  "random-sampling"
+)
+
+# soak-rs is intentionally NOT in the default list — it's 30+ minutes and
+# only meaningful as a separate long-running test. Add SOAK=1 to include.
+if [ "${SOAK:-0}" = "1" ]; then
+  SCRIPTS+=("soak-rs")
+fi
+
+declare -a RESULTS
+
+START_TS=$(date +%s)
+echo "[sweep] Run started at $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+echo "[sweep] Results dir: $RESULTS_DIR"
+echo ""
+
+for id in "${SCRIPTS[@]}"; do
+  # Two naming conventions in scripts/: devnet-test-* and devnet-soak-*
+  if [ "$id" = "soak-rs" ]; then
+    script="devnet-soak-rs.sh"
+  else
+    script="devnet-test-${id}.sh"
+  fi
+
+  echo "================================================================"
+  echo "[sweep] Running $id ($script)"
+  echo "================================================================"
+
+  if [ ! -x "$SCRIPTS_DIR/$script" ]; then
+    echo "[sweep] MISSING: $script"
+    RESULTS+=("$id:MISSING")
+    continue
+  fi
+
+  LOGFILE="$RESULTS_DIR/${id}.log"
+  if ( cd "$REPO_ROOT" && "$SCRIPTS_DIR/$script" ) > "$LOGFILE" 2>&1; then
+    echo "[sweep] PASS: $id"
+    RESULTS+=("$id:PASS")
+  else
+    EC=$?
+    echo "[sweep] FAIL: $id (exit=$EC)"
+    echo "[sweep]   last 15 lines:"
+    tail -n 15 "$LOGFILE" | sed 's/^/    /'
+    RESULTS+=("$id:FAIL:$EC")
+  fi
+
+  # Short settle between scripts so chain mining, gossip, and replication
+  # have headroom — same logic as devnet-test-rfc38-all.sh.
+  sleep 8
+done
+
+END_TS=$(date +%s)
+ELAPSED=$((END_TS - START_TS))
+
+echo ""
+echo "================================================================"
+echo "[sweep] FULL SWEEP SUMMARY (${ELAPSED}s wall)"
+echo "================================================================"
+FAILS=0
+for r in "${RESULTS[@]}"; do
+  printf '  %-40s %s\n' "${r%%:*}" "${r#*:}"
+  case "$r" in
+    *:PASS) ;;
+    *) FAILS=$((FAILS + 1)) ;;
+  esac
+done
+echo ""
+if [ "$FAILS" -eq 0 ]; then
+  echo "[sweep] ALL PASS (${#RESULTS[@]} scripts, ${ELAPSED}s)"
+  exit 0
+else
+  echo "[sweep] $FAILS / ${#RESULTS[@]} scripts FAILED"
+  exit $((FAILS > 99 ? 99 : FAILS))
+fi

--- a/scripts/devnet-test-cli-invite.sh
+++ b/scripts/devnet-test-cli-invite.sh
@@ -22,9 +22,12 @@ PORT3=$((PORT1 + 2))
 HOME1="$DEVNET_DIR/node1"
 HOME2="$DEVNET_DIR/node2"
 HOME3="$DEVNET_DIR/node3"
-ADDR1="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-ADDR2="0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
-ADDR3="0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+# Derive each node's primary agent address from its running daemon. Hard-
+# coding Anvil-default wallets (the original `0xf39Fd6...` / `0x709979...`
+# / `0x3C44Cd...`) breaks the moment devnet derives its wallets from a
+# mnemonic that's not the Hardhat default. Discovering at runtime makes
+# this script reusable against any devnet topology — same pattern as the
+# RFC-38 scripts (e.g. `devnet-test-rfc38-revocation.sh:107-109`).
 
 PASS=0
 FAIL=0
@@ -52,25 +55,47 @@ cli_node() {
   DKG_HOME="$home" DKG_API_PORT=$port $CLI "$@" 2>&1
 }
 
+# Discover each node's primary agent address from its running daemon.
+# Match the `/api/agent/identity` discovery pattern used by every
+# RFC-38 devnet script (see header note above ADDR comment).
+addr_of() {
+  api "$1" GET /api/agent/identity | python3 -c "import sys, json; print(json.load(sys.stdin).get('agentAddress',''))"
+}
+ADDR1=$(addr_of "$PORT1")
+ADDR2=$(addr_of "$PORT2")
+ADDR3=$(addr_of "$PORT3")
+if [ -z "$ADDR1" ] || [ -z "$ADDR2" ] || [ -z "$ADDR3" ]; then
+  echo "FATAL: Could not derive agent addresses from /api/agent/identity (got: '$ADDR1' '$ADDR2' '$ADDR3'). Is devnet running?" >&2
+  exit 1
+fi
+echo "Discovered agent addresses: Node1=$ADDR1  Node2=$ADDR2  Node3=$ADDR3"
+
 # ──────────────────────────────────────────────────────────
 h "PART 1: CLI Flow — Node 1 creates, Node 2 joins"
 # ──────────────────────────────────────────────────────────
 
 echo "1a. Node 1: Create curated project via CLI (bare slug auto-namespace)"
-CREATE_OUT=$(cli_node $PORT1 context-graph create cli-test-project --name "CLI Test Project" --access-policy 1)
+# Suffix the slug with a wall-clock stamp so re-runs against a long-lived
+# devnet don't trip the "already exists" guard. Matches the convention
+# used by every other devnet-test-rfc38-*.sh script.
+SLUG="cli-test-project-$(date +%s)"
+CREATE_OUT=$(cli_node $PORT1 context-graph create "$SLUG" --name "CLI Test Project" --access-policy 1)
 echo "$CREATE_OUT"
 CG_ID=$(echo "$CREATE_OUT" | grep "ID:" | head -1 | sed 's/.*ID:[ ]*//')
-if echo "$CG_ID" | grep -q "$ADDR1/cli-test-project"; then
+# Case-insensitive match — the CLI prints checksummed addresses
+# (`0xAa…Bb…`) while `/api/agent/identity` returns lowercase. Strict
+# `grep -q` would always miss.
+if echo "$CG_ID" | grep -qi "$ADDR1/$SLUG"; then
   pass "Auto-namespaced CG ID: $CG_ID"
 else
-  fail "Expected $ADDR1/cli-test-project, got: $CG_ID"
+  fail "Expected $ADDR1/$SLUG, got: $CG_ID"
 fi
 
 echo ""
 echo "1b. Node 1: List agents (should have creator auto-added)"
 AGENTS_OUT=$(cli_node $PORT1 context-graph agents "$CG_ID")
 echo "$AGENTS_OUT"
-if echo "$AGENTS_OUT" | grep -q "Allowed agents" && echo "$AGENTS_OUT" | grep -q "$ADDR1"; then
+if echo "$AGENTS_OUT" | grep -q "Allowed agents" && echo "$AGENTS_OUT" | grep -qi "$ADDR1"; then
   pass "Creator is in allowlist"
 else
   fail "Creator not in allowlist: $AGENTS_OUT"
@@ -101,7 +126,7 @@ GOT_REQUEST=0
 for i in $(seq 1 5); do
   sleep 2
   REQUESTS_OUT=$(cli_node $PORT1 context-graph join-requests "$CG_ID")
-  if echo "$REQUESTS_OUT" | grep -q "$ADDR2"; then
+  if echo "$REQUESTS_OUT" | grep -qi "$ADDR2"; then
     GOT_REQUEST=1
     break
   fi
@@ -170,7 +195,7 @@ echo ""
 echo "1j. Verify Node 3 removed"
 AGENTS_POST_REMOVE=$(cli_node $PORT1 context-graph agents "$CG_ID")
 echo "$AGENTS_POST_REMOVE"
-if echo "$AGENTS_POST_REMOVE" | grep -q "^  $ADDR3"; then
+if echo "$AGENTS_POST_REMOVE" | grep -qi "^  $ADDR3"; then
   fail "Node 3 still in allowlist after removal"
 else
   pass "Node 3 no longer in allowlist"
@@ -180,21 +205,34 @@ fi
 h "PART 2: API Flow (simulating UI) — Node 1 creates, Node 3 joins"
 # ──────────────────────────────────────────────────────────
 
-UI_CG_ID="$ADDR1/ui-test-project"
+UI_SLUG="ui-test-project-$(date +%s)"
+UI_CG_ID="$ADDR1/$UI_SLUG"
 
 echo "2a. Node 1: Create curated project via API (like UI would)"
 CREATE_API=$(api $PORT1 POST "/api/context-graph/create" -d "{\"id\":\"$UI_CG_ID\",\"name\":\"UI Test Project\",\"accessPolicy\":1,\"allowedAgents\":[\"$ADDR1\"]}")
 echo "$CREATE_API" | python3 -m json.tool 2>/dev/null || echo "$CREATE_API"
-if echo "$CREATE_API" | grep -q "ui-test-project"; then
+if echo "$CREATE_API" | grep -q "$UI_SLUG"; then
   pass "API: Project created with clean slug (no timestamp suffix)"
 else
   fail "API: Project creation failed: $CREATE_API"
 fi
 
 echo ""
-echo "2b. Node 3: Send join request via API"
+echo "2b. Node 3: Send join request via API (sign on N3 + forward to N1)"
 sleep 3
-JOIN_API=$(api $PORT3 POST "/api/context-graph/$(python3 -c "import urllib.parse; print(urllib.parse.quote('$UI_CG_ID', safe=''))")/sign-join" -d '{}')
+# PR #448 split sign-only from forward to avoid double-emit. UI/CLI chain
+# `/sign-join` → `/request-join`; replicate the same two-step call here.
+UI_ENC_ID=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$UI_CG_ID', safe=''))")
+SIGN_API=$(api $PORT3 POST "/api/context-graph/$UI_ENC_ID/sign-join" -d '{}')
+DELEGATION=$(echo "$SIGN_API" | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin).get('delegation',{})))")
+if [ -z "$DELEGATION" ] || [ "$DELEGATION" = "{}" ]; then
+  fail "API: sign-join did not return a delegation: $SIGN_API"
+  JOIN_API="$SIGN_API"
+else
+  # Forward over P2P with N1's peer id so the curator can authenticate the round-trip.
+  JOIN_API=$(api $PORT3 POST "/api/context-graph/$UI_ENC_ID/request-join" \
+    -d "{\"delegation\":$DELEGATION,\"curatorPeerId\":\"$PEER1\"}")
+fi
 echo "$JOIN_API" | python3 -m json.tool 2>/dev/null || echo "$JOIN_API"
 if echo "$JOIN_API" | grep -q '"ok"'; then
   pass "API: Join request sent from Node 3"
@@ -203,12 +241,19 @@ else
 fi
 
 echo ""
-echo "2c. Node 1: List join requests via API"
-sleep 2
+echo "2c. Node 1: List join requests via API (poll up to 15s for gossip)"
 ENC_ID=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$UI_CG_ID', safe=''))")
-REQUESTS_API=$(api $PORT1 GET "/api/context-graph/$ENC_ID/join-requests")
+GOT_API_REQUEST=0
+for i in $(seq 1 5); do
+  sleep 3
+  REQUESTS_API=$(api $PORT1 GET "/api/context-graph/$ENC_ID/join-requests")
+  if echo "$REQUESTS_API" | grep -qi "$ADDR3\|pending"; then
+    GOT_API_REQUEST=1
+    break
+  fi
+done
 echo "$REQUESTS_API" | python3 -m json.tool 2>/dev/null || echo "$REQUESTS_API"
-if echo "$REQUESTS_API" | grep -qi "$ADDR3\|pending"; then
+if [ "$GOT_API_REQUEST" -eq 1 ]; then
   pass "API: Join request from Node 3 visible"
 else
   fail "API: No join request found: $REQUESTS_API"
@@ -261,8 +306,8 @@ fi
 echo ""
 echo "3c. Both projects visible in context-graph list"
 LIST_OUT=$(cli_node $PORT1 context-graph list)
-CLI_PROJ=$(echo "$LIST_OUT" | grep -c "cli-test-project" || true)
-UI_PROJ=$(echo "$LIST_OUT" | grep -c "ui-test-project" || true)
+CLI_PROJ=$(echo "$LIST_OUT" | grep -c "$SLUG" || true)
+UI_PROJ=$(echo "$LIST_OUT" | grep -c "$UI_SLUG" || true)
 if [ "$CLI_PROJ" -ge 1 ] && [ "$UI_PROJ" -ge 1 ]; then
   pass "Both projects visible in list"
 else
@@ -274,7 +319,7 @@ h "PART 4: Edge cases"
 # ──────────────────────────────────────────────────────────
 
 echo "4a. Duplicate create should fail (409)"
-DUP_OUT=$(cli_node $PORT1 context-graph create cli-test-project --name "Duplicate" --access-policy 1 2>&1 || true)
+DUP_OUT=$(cli_node $PORT1 context-graph create "$SLUG" --name "Duplicate" --access-policy 1 2>&1 || true)
 echo "$DUP_OUT"
 if echo "$DUP_OUT" | grep -qi "already exists\|409\|conflict"; then
   pass "Duplicate create rejected"

--- a/scripts/devnet-test-publish.sh
+++ b/scripts/devnet-test-publish.sh
@@ -83,90 +83,54 @@ done
 
 log "Preconditions OK (hardhat pid=$HARDHAT_PID, node $NODE_NUM pid=$NODE_PID, api :$API_PORT)"
 
-# --- 2. Create V10 context graph ---------------------------------------------
+# --- 2. Create + register V10 context graph via the daemon -------------------
+#
+# Previous revision called `ContextGraphs.createContextGraph(...)` directly
+# from a hardhat signer. That mints an on-chain CG owned by a wallet the
+# daemon does not control, so the subsequent `dkg context-graph register
+# <id>` call (run against that numeric id) creates a SECOND on-chain CG
+# under the daemon's wallet rather than binding the existing one. The
+# publish then targets the orphan and fails with "not registered on-chain".
+#
+# The publish flow expects the daemon to OWN the CG it publishes to (the
+# author signature on the finalized assertion has to chain back to the
+# on-chain CG curator/creator). So we just use the daemon's own CLI:
+#   1. `context-graph create <slug>` creates a local CG name.
+#   2. `context-graph register <slug>` mints the on-chain CG under the
+#      daemon's EOA and binds the local name to the numeric id.
+# The RDF data graph URI is `did:dkg:context-graph:<slug>` (the publisher
+# resolves the slug → on-chain id internally before computing leaves).
+#
+# Slug is timestamped so reruns within the same devnet session don't
+# collide with prior CGs.
 
-log "Creating fresh V10 context graph via ContextGraphs.createContextGraph..."
+CG_SLUG="v10-publish-smoke-$(date +%s)"
+log "Creating local CG '$CG_SLUG' via daemon CLI..."
+# `context-graph create` auto-namespaces bare slugs to
+# `{agentAddress}/{slug}` (see cli.ts → contextGraphCmd.command('create')).
+# Capture the post-namespacing id from the "ID:" line so register and
+# publish use the fully-qualified form the daemon registry actually
+# stores.
+CREATE_OUT=$(DKG_HOME="$NODE_DIR" node "$CLI_JS" context-graph create "$CG_SLUG" \
+  --name "V10 publishDirect smoke" \
+  --description "Auto-created by scripts/devnet-test-publish.sh") \
+  || fail "context-graph create failed"
+CG_FQ_ID=$(printf '%s\n' "$CREATE_OUT" | sed -nE 's/^[[:space:]]*ID:[[:space:]]+(.+)$/\1/p' | head -n1)
+[ -n "$CG_FQ_ID" ] || fail "could not parse CG id from create output:\n$CREATE_OUT"
+log "Local CG id = $CG_FQ_ID"
 
-CG_ID=$(
-  cd "$REPO_ROOT/packages/evm-module" && \
-  RPC_URL="http://127.0.0.1:${HARDHAT_PORT}" \
-  CONTRACTS_JSON="$CONTRACTS_JSON" \
-  ABI_DIR="$EVM_ABI_DIR" \
-  node -e '
-const { ethers } = require("ethers");
-const fs = require("fs");
-const path = require("path");
-
-(async () => {
-  const rpc = process.env.RPC_URL;
-  const contractsPath = process.env.CONTRACTS_JSON;
-  const abiDir = process.env.ABI_DIR;
-
-  const provider = new ethers.JsonRpcProvider(rpc);
-  const deployer = await provider.getSigner(0);
-
-  const contracts = JSON.parse(fs.readFileSync(contractsPath, "utf8")).contracts;
-  const cgAddr        = contracts.ContextGraphs?.evmAddress;
-  const cgStorageAddr = contracts.ContextGraphStorage?.evmAddress;
-  if (!cgAddr)        throw new Error("ContextGraphs not deployed");
-  if (!cgStorageAddr) throw new Error("ContextGraphStorage not deployed");
-
-  const loadAbi = (name) => JSON.parse(fs.readFileSync(path.join(abiDir, name + ".json"), "utf8"));
-  const cgAbi        = loadAbi("ContextGraphs");
-  const cgStorageAbi = loadAbi("ContextGraphStorage");
-
-  const cg        = new ethers.Contract(cgAddr, cgAbi, deployer);
-  const cgStorage = new ethers.Contract(cgStorageAddr, cgStorageAbi, provider);
-
-  // Open policy: no participantAgents (open contribution), no metadata,
-  // no curator/PCA. Per SPEC_CG_MEMORY_MODEL the contract no longer takes
-  // hostingNodes or per-CG requiredSignatures — hosting + ACK quorum are
-  // network-level concerns (sharding table + parametersStorage.minimumRequiredSignatures()).
-  const args = [
-    [],                     // address[] participantAgents (open — no curator list)
-    0,                      // uint256 metadataBatchId  (none)
-    0,                      // uint8 accessPolicy       (0 = public/discoverable)
-    1,                      // uint8 publishPolicy      (1 = open)
-    ethers.ZeroAddress,     // address publishAuthority  (open rejects non-zero)
-    0,                      // uint256 publishAuthorityAccountId (open rejects non-zero)
-  ];
-
-  // Preview cgId via staticCall, fall back to event parsing if needed.
-  let previewId = null;
-  try {
-    previewId = await cg.createContextGraph.staticCall(...args);
-    console.error("staticCall preview: cgId=" + previewId);
-  } catch (e) {
-    console.error("staticCall preview failed: " + (e?.shortMessage || e?.message || e));
-  }
-
-  const tx = await cg.createContextGraph(...args);
-  const receipt = await tx.wait();
-
-  let cgId = previewId;
-  if (cgId == null) {
-    const topic = cgStorage.interface.getEvent("ContextGraphCreated").topicHash;
-    for (const lg of receipt.logs) {
-      if (lg.address.toLowerCase() !== cgStorageAddr.toLowerCase()) continue;
-      if (lg.topics[0] !== topic) continue;
-      const parsed = cgStorage.interface.parseLog(lg);
-      cgId = parsed.args.contextGraphId;
-      break;
-    }
-    if (cgId == null) throw new Error("ContextGraphCreated event not found on receipt");
-  }
-
-  console.error("createContextGraph tx=" + receipt.hash + " cgId=" + cgId);
-  console.log(cgId.toString());
-})().catch(e => {
-  console.error("[create-cg] " + (e?.shortMessage || e?.message || String(e)));
-  process.exit(1);
-});
-'
-) || fail "context graph creation failed"
-
-[ -n "$CG_ID" ] || fail "empty CG_ID captured"
-log "Created V10 context graph id=$CG_ID"
+log "Registering '$CG_FQ_ID' on-chain via daemon CLI..."
+REG_OUT=$(DKG_HOME="$NODE_DIR" node "$CLI_JS" context-graph register "$CG_FQ_ID") \
+  || fail "context-graph register failed (CG=$CG_FQ_ID)"
+CG_ONCHAIN_ID=$(printf '%s\n' "$REG_OUT" | sed -nE 's/.*On-chain:[[:space:]]+([0-9]+).*/\1/p' | head -n1)
+[ -n "$CG_ONCHAIN_ID" ] || fail "could not parse on-chain id from register output:\n$REG_OUT"
+# The slug is what `dkg publish` and the data-graph URI both consume;
+# CG_ONCHAIN_ID is only used in the post-publish KCS verification at
+# step 6 (kcsAddr.getKnowledgeCollectionMetadata takes a numeric KC id,
+# but the publish receipt gives us batchId directly so CG_ONCHAIN_ID is
+# only kept for logging / debug context).
+CG_ID="$CG_FQ_ID"
+log "CG ready: id=$CG_ID on-chain=$CG_ONCHAIN_ID"
 
 # --- 3. Build RDF fixture -----------------------------------------------------
 
@@ -181,7 +145,6 @@ log "Wrote RDF fixture to $TMP_RDF (subject=$SUBJECT)"
 
 # --- 4. CLI publish -----------------------------------------------------------
 
-# Remember where the daemon log currently ends so we can scan only new lines.
 if [ -s "$DAEMON_LOG" ]; then
   BASELINE_LINES=$(wc -l < "$DAEMON_LOG" | tr -d ' ')
 else


### PR DESCRIPTION
## Summary

Closes the three concrete devnet-sweep regressions surfaced during the
`integration/rfc38-mainnet-ready` readiness pass. The remaining sweep
failures (T1/T3 sender-key reliability, T4/T5/T7-a catchup-runner deny
hang, T7-b WM-isolation suspicion) are pre-existing reliability gaps,
not regressions from this integration cut — they ship as documented
followups in `TESTNET_RESET.md` rather than gate the testnet release.

| ID | Where it broke | Fix in this PR |
|----|----------------|----------------|
| **T2** (curated) | PR #630 wired `RandomSampling.sol` to draw against `getCiphertextChunkCount` for curated CGs, but the off-chain prover still extracts plaintext leaves via `getMerkleLeafCount` → `V10ProofLeafCountMismatchError` every period | Defer curated CG random sampling to RFC-39 Phase B by filtering curated CGs at `_isCGEligible`. Single-line revert when the prover's ciphertext path lands |
| **T2** (public) | `dkg-agent.stampTrustLevel` writes `dkg:trustLevel = "N"` to the dataGraph AFTER the publisher records `merkleLeafCount` on-chain. Extractor then sees N+1 leaves vs chain's N | Skip both canonical and legacy `dkg:trustLevel` predicates during KC leaf extraction (publisher already refuses user-authored `trustLevel` triples, so excluding them on read is safe by construction) |
| **T6** | `devnet-test-cli-invite.sh` hardcoded Anvil default addresses + omitted the second step of the API join flow | Dynamic agent discovery via `/api/agent/identity`, case-insensitive address match, timestamped slugs, correct `/sign-join` → `/request-join` two-step |
| **T8** | `devnet-test-publish.sh` minted the on-chain CG directly from a hardhat signer the daemon didn't own, so the daemon's later `register` call created an orphan CG and publish failed with "not registered on-chain" | Switch to the natural daemon-side flow (`context-graph create` → `context-graph register` → `publish`) so the CG is owned by the daemon's wallet from the start |

## Commits (split for review)

1. `4967a16f fix(evm-module): defer curated CG random sampling to RFC-39 Phase B` — `RandomSampling.sol._isCGEligible` skip + two test updates (`.skip` the curated suite, flip the only-curated-CG edge case to expect `NoEligibleContextGraph`)
2. `4a6e0370 fix(random-sampling): skip post-publish dkg:trustLevel stamps in KC leaf extraction` — `kc-extractor.ts` allow-list + regression test
3. `3655c68e chore(prover): expand rs.tick.data-corrupted diagnostics` — `prover.ts` log fields (this is the diagnostic that pinned down the trustLevel bug; preserved for testnet debugging)
4. `e5ae3395 test(devnet): fix publish + cli-invite scripts (T6 + T8) and add full-sweep harness` — `scripts/devnet-test-{publish,cli-invite}.sh` + new `scripts/_devnet-full-sweep.sh`

## Devnet smoke (single-node publish + random-sampling)

```
[v10-publish-test] Published KC id=1 tx=0xeaf4857fdfcd55f9...
                   verified readable via KCS
[rs.tick.submitted]    {"kcId":"1","cgId":"7","chunkId":"0",
                        "txHash":"0x6081..."}
[rs.tick.already-solved]  {"epoch":"1","periodStart":"600"}
[rs.tick.submitted]    {"kcId":"1","cgId":"7","chunkId":"0",
                        "txHash":"0xcf5a..."}
```

Proofs land on-chain every period for the publisher; non-hosting nodes
correctly emit `[rs.tick.kc-not-synced]` instead of the previous
`data-corrupted`.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-random-sampling test --run` → 48/48 pass (includes new regression test for the trustLevel skip)
- [x] `./scripts/devnet-test-publish.sh` → green
- [x] `./scripts/devnet-test-cli-invite.sh` → 21/21 assertions pass
- [x] `./scripts/devnet-test-random-sampling.sh` → proofs landing on-chain
- [ ] Full `./scripts/_devnet-full-sweep.sh` — in progress at PR creation; remaining sweep failures expected to map only to documented pre-existing reliability gaps

## Followups (NOT in this PR)

Tracked in `TESTNET_RESET.md`:

- **T1/T3** sender-key `setup-send` reliability (revocation + unclean-restart timeouts) — pre-existing
- **T4/T5** + **T7-a** catchup-runner doesn't terminate when all peers deny a sync request — pre-existing
- **T7-b** possible WM-isolation breach in `sharing` — needs investigation
- **T2 curated**: re-enable when PR #617 (LU-11 ciphertext commitment) + ciphertext-aware prover lands — single-line revert + test unskip noted in code comments
- **trustLevel post-publish injection (architectural)**: move the stamp to a separate `_trust` graph so the extractor allow-list is no longer needed

Made with [Cursor](https://cursor.com)