### PR TITLE
chore(agent): demote stale-target SWM sender-key rejections to DEBUG

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -148,6 +148,37 @@ export class SyncAccessDeniedError extends Error {
   }
 }
 
+/**
+ * Thrown by `acceptSwmSenderKeyPackage` when an inbound sender-key
+ * setup package is targeted at a `recipientKeyId` we don't host as an
+ * active local X25519 private key. This is the routine, benign outcome
+ * when a sender fans the bootstrap out across every cached snapshot of
+ * our agent's public encryption keys (e.g. registry observations from
+ * before a rotation): one bootstrap per stale fingerprint lands here,
+ * only the bootstrap that targets the currently active key passes.
+ *
+ * Distinct from a generic `Error` so the receive handler can route this
+ * outcome to DEBUG (silenced from `daemon.log`) while leaving genuine
+ * security/protocol failures (signature mismatch, gate violation,
+ * non-local recipient, revoked-key targeting) at WARN. See PR
+ * `chore/swm-sender-key-stale-noise` for the operator-noise context.
+ *
+ * The thrown message is preserved verbatim from the original WARN so
+ * any external log scrapers that grepped for the legacy string keep
+ * matching: `No local X25519 private key for DKG agent <addr> key <id>`.
+ */
+export class StaleSenderKeyTargetError extends Error {
+  readonly code = 'StaleSenderKeyTarget';
+  readonly recipientAgentAddress: string;
+  readonly recipientKeyId: string;
+  constructor(recipientAgentAddress: string, recipientKeyId: string) {
+    super(`No local X25519 private key for DKG agent ${recipientAgentAddress} key ${recipientKeyId}`);
+    this.name = 'StaleSenderKeyTargetError';
+    this.recipientAgentAddress = recipientAgentAddress;
+    this.recipientKeyId = recipientKeyId;
+  }
+}
+
 // ── Publish surface ─────────────────────────────────────────────────
 
 export interface CclPublishedResultEntry {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -5827,7 +5827,25 @@ export class DKGAgent {
       // revoke flow want to see the latter explicitly. Use the same
       // localAgents map the active-only filter does so the diagnostic
       // matches the gate exactly.
-      const record = this.localAgents.get(recipientAgentAddress);
+      //
+      // Codex round 2 on PR #654: a `Map.get(checksum)` here can miss
+      // a record that's stored under a differently-cased Map key than
+      // its own `record.agentAddress` field (legacy persisted state,
+      // older fixtures, or any path that lowercased on persist while
+      // keeping the EIP-55 form on the record itself). The miss falls
+      // through to `StaleSenderKeyTargetError`, which demotes a real
+      // revoked-or-known-key failure to DEBUG and silences operator
+      // visibility. Mirror the case-insensitive scan already used by
+      // `hasLocalAgent` (just above) and `getLocalWorkspaceRecipient
+      // PrivateKeys` so this branch sees the record whenever the
+      // existence-gate above did.
+      let record: AgentKeyRecord | undefined;
+      for (const candidate of this.localAgents.values()) {
+        if (candidate.agentAddress.toLowerCase() === recipientAgentAddress.toLowerCase()) {
+          record = candidate;
+          break;
+        }
+      }
       const activeEntry = record?.workspaceEncryptionKeys.find(
         (entry) => entry.encryptionKeyId === pkg.recipientKeyId && !entry.revokedAt,
       );

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -5828,6 +5828,12 @@ export class DKGAgent {
       // localAgents map the active-only filter does so the diagnostic
       // matches the gate exactly.
       const record = this.localAgents.get(recipientAgentAddress);
+      const activeEntry = record?.workspaceEncryptionKeys.find(
+        (entry) => entry.encryptionKeyId === pkg.recipientKeyId && !entry.revokedAt,
+      );
+      if (activeEntry) {
+        throw new Error(`No local X25519 private key for DKG agent ${recipientAgentAddress} key ${pkg.recipientKeyId}`);
+      }
       const revokedEntry = record?.workspaceEncryptionKeys.find(
         (entry) => entry.encryptionKeyId === pkg.recipientKeyId && entry.revokedAt,
       );

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -247,6 +247,7 @@ import {
 import {
   ContextGraphNotFoundError,
   InvalidContentError,
+  StaleSenderKeyTargetError,
   SyncAccessDeniedError,
   type PreSignedAuthorAttestation,
   type LocalSwmSenderKeySendState,
@@ -5739,12 +5740,30 @@ export class DKGAgent {
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       if (pkg) {
-        this.log.warn(
-          ctx,
+        // A sender-key setup may legitimately be fanned out across every
+        // cached snapshot of our agent's public encryption keys. Each
+        // bootstrap that targets a fingerprint we don't host as an
+        // active local key throws `StaleSenderKeyTargetError` and is
+        // not actionable for the operator — the matching bootstrap that
+        // hits our active key is logged at INFO via
+        // `SWM sender-key setup receive accepted`. Logging every stale
+        // attempt at WARN swamps `daemon.log` (5 WARNs per peer per
+        // session was routine on testnet edge nodes) without surfacing
+        // anything operators need to act on, so this branch is demoted
+        // to DEBUG. WARN is reserved for failure modes that DO require
+        // intervention: signature mismatch, agent-gate violation,
+        // recipient not local, and revoked-key targeting (the
+        // last of which throws a generic `Error` with the explicit
+        // `was revoked at` message above and therefore stays at WARN).
+        const message =
           `SWM sender-key setup receive rejected: senderAgent=${pkg.senderAgentAddress} recipientAgent=${pkg.recipientAgentAddress} ` +
           `fromPeer=${fromPeerId} contextGraph=${pkg.contextGraphId}${pkg.subGraphName ? `/${pkg.subGraphName}` : ''} ` +
-          `epoch=${pkg.epochId} membershipHash=${pkg.membershipHash} reason=${reason}`,
-        );
+          `epoch=${pkg.epochId} membershipHash=${pkg.membershipHash} reason=${reason}`;
+        if (err instanceof StaleSenderKeyTargetError) {
+          this.log.debug(ctx, message);
+        } else {
+          this.log.warn(ctx, message);
+        }
       }
       return encodeSwmSenderKeyPackageAck({
         version: SWM_SENDER_KEY_PACKAGE_VERSION,
@@ -5820,7 +5839,7 @@ export class DKGAgent {
           'against an active key.',
         );
       }
-      throw new Error(`No local X25519 private key for DKG agent ${recipientAgentAddress} key ${pkg.recipientKeyId}`);
+      throw new StaleSenderKeyTargetError(recipientAgentAddress, pkg.recipientKeyId);
     }
 
     const secret = await decryptSwmSenderKeyPackage({ package: pkg, recipientKey: localKey });

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -92,6 +92,7 @@ export {
 export {
   ContextGraphNotFoundError,
   InvalidContentError,
+  StaleSenderKeyTargetError,
   type DKGAgentConfig,
   type ContextGraphSub,
   type PublishOpts,

--- a/packages/agent/test/swm-sender-key-stale-target.test.ts
+++ b/packages/agent/test/swm-sender-key-stale-target.test.ts
@@ -238,6 +238,37 @@ describe('acceptSwmSenderKeyPackage: stale-target throw type', () => {
     );
     await expect(accept).rejects.not.toBeInstanceOf(StaleSenderKeyTargetError);
   });
+
+  it('does NOT misclassify a revoked-key target as stale when localAgents is keyed under a different case', async () => {
+    // Codex round 2 regression on PR #654: `hasLocalAgent` does a
+    // case-insensitive scan over `localAgents.values()`, but the
+    // inner record lookup in the `!localKey` diagnostic branch was
+    // doing exact-string `Map.get(checksum)`. If the keystore is
+    // keyed under a different case than the record's own
+    // `agentAddress` field (legacy persisted state, older fixtures,
+    // any path that lowercases on save while keeping EIP-55 on the
+    // record itself), `record` becomes `undefined`, the
+    // active/revoked discriminators silently fail, and the bootstrap
+    // falls through to `StaleSenderKeyTargetError` — demoting a real
+    // revoked-key targeting to DEBUG. Pin the case-insensitive scan.
+    const { internals, recipient, senderWallet } = await bootAgentForStaleTargetTest();
+    const activeKeyId = recipient.workspaceEncryptionKeys[0].encryptionKeyId;
+    recipient.workspaceEncryptionKeys[0].revokedAt = new Date().toISOString();
+    internals.localAgents.delete(recipient.agentAddress);
+    internals.localAgents.set(recipient.agentAddress.toLowerCase(), recipient);
+
+    const pkg = await buildSignedPackage({
+      senderWallet,
+      recipientAgentAddress: recipient.agentAddress,
+      recipientKeyId: activeKeyId,
+    });
+    const accept = internals.acceptSwmSenderKeyPackage(pkg, FROM_PEER_ID, {
+      operationId: 'test-op',
+      operationName: 'share',
+    });
+    await expect(accept).rejects.toThrow(/was revoked at/);
+    await expect(accept).rejects.not.toBeInstanceOf(StaleSenderKeyTargetError);
+  });
 });
 
 describe('handleSwmSenderKeyPackage: log-level routing', () => {
@@ -337,5 +368,35 @@ describe('handleSwmSenderKeyPackage: log-level routing', () => {
     expect(rejectEntries[0].message).toContain(
       `reason=No local X25519 private key for DKG agent ${recipient.agentAddress} key ${activeKeyId}`,
     );
+  });
+
+  it('routes a revoked-key target to WARN even when localAgents is keyed under a different case', async () => {
+    // Operator-facing pin for Codex round 2: same case-mismatch as
+    // the accept-path regression above, but verified end-to-end
+    // through `handleSwmSenderKeyPackage` so a future refactor that
+    // re-introduces the exact-key Map.get() trips both halves.
+    const { internals, recipient, senderWallet } = await bootAgentForStaleTargetTest();
+    const activeKeyId = recipient.workspaceEncryptionKeys[0].encryptionKeyId;
+    recipient.workspaceEncryptionKeys[0].revokedAt = new Date().toISOString();
+    internals.localAgents.delete(recipient.agentAddress);
+    internals.localAgents.set(recipient.agentAddress.toLowerCase(), recipient);
+
+    const pkg = await buildSignedPackage({
+      senderWallet,
+      recipientAgentAddress: recipient.agentAddress,
+      recipientKeyId: activeKeyId,
+    });
+    const bytes = encodeSwmSenderKeyPackage(pkg);
+
+    const sink = captureLoggerSink();
+    detachSink = sink.detach;
+    await internals.handleSwmSenderKeyPackage(bytes, FROM_PEER_ID);
+
+    const rejectEntries = sink.entries.filter((e) =>
+      e.message.startsWith('SWM sender-key setup receive rejected'),
+    );
+    expect(rejectEntries).toHaveLength(1);
+    expect(rejectEntries[0].level).toBe('warn');
+    expect(rejectEntries[0].message).toContain('was revoked at');
   });
 });

--- a/packages/agent/test/swm-sender-key-stale-target.test.ts
+++ b/packages/agent/test/swm-sender-key-stale-target.test.ts
@@ -217,6 +217,27 @@ describe('acceptSwmSenderKeyPackage: stale-target throw type', () => {
     await expect(accept).rejects.toBeInstanceOf(Error);
     await expect(accept).rejects.not.toBeInstanceOf(StaleSenderKeyTargetError);
   });
+
+  it('does NOT throw StaleSenderKeyTargetError when the active key exists but local private material is missing', async () => {
+    const { internals, recipient, senderWallet } = await bootAgentForStaleTargetTest();
+    const activeKeyId = recipient.workspaceEncryptionKeys[0].encryptionKeyId;
+    delete recipient.workspaceEncryptionKeys[0].privateEncryptionKey;
+    delete recipient.privateEncryptionKey;
+    const pkg = await buildSignedPackage({
+      senderWallet,
+      recipientAgentAddress: recipient.agentAddress,
+      recipientKeyId: activeKeyId,
+    });
+
+    const accept = internals.acceptSwmSenderKeyPackage(pkg, FROM_PEER_ID, {
+      operationId: 'test-op',
+      operationName: 'share',
+    });
+    await expect(accept).rejects.toThrow(
+      `No local X25519 private key for DKG agent ${recipient.agentAddress} key ${activeKeyId}`,
+    );
+    await expect(accept).rejects.not.toBeInstanceOf(StaleSenderKeyTargetError);
+  });
 });
 
 describe('handleSwmSenderKeyPackage: log-level routing', () => {
@@ -290,5 +311,31 @@ describe('handleSwmSenderKeyPackage: log-level routing', () => {
     expect(rejectEntries).toHaveLength(1);
     expect(rejectEntries[0].level).toBe('warn');
     expect(rejectEntries[0].message).toContain('is not local to this node');
+  });
+
+  it('routes a missing local private key for a known active fingerprint to WARN', async () => {
+    const { internals, recipient, senderWallet } = await bootAgentForStaleTargetTest();
+    const activeKeyId = recipient.workspaceEncryptionKeys[0].encryptionKeyId;
+    delete recipient.workspaceEncryptionKeys[0].privateEncryptionKey;
+    delete recipient.privateEncryptionKey;
+    const pkg = await buildSignedPackage({
+      senderWallet,
+      recipientAgentAddress: recipient.agentAddress,
+      recipientKeyId: activeKeyId,
+    });
+    const bytes = encodeSwmSenderKeyPackage(pkg);
+
+    const sink = captureLoggerSink();
+    detachSink = sink.detach;
+    await internals.handleSwmSenderKeyPackage(bytes, FROM_PEER_ID);
+
+    const rejectEntries = sink.entries.filter((e) =>
+      e.message.startsWith('SWM sender-key setup receive rejected'),
+    );
+    expect(rejectEntries).toHaveLength(1);
+    expect(rejectEntries[0].level).toBe('warn');
+    expect(rejectEntries[0].message).toContain(
+      `reason=No local X25519 private key for DKG agent ${recipient.agentAddress} key ${activeKeyId}`,
+    );
   });
 });

--- a/packages/agent/test/swm-sender-key-stale-target.test.ts
+++ b/packages/agent/test/swm-sender-key-stale-target.test.ts
@@ -1,0 +1,294 @@
+// Operator-noise reduction for the SWM sender-key receive path.
+//
+// On testnet edge-node logs we observed up to 5 WARN lines per peer
+// per session of the form:
+//
+//   SWM sender-key setup receive rejected: ... reason=No local
+//     X25519 private key for DKG agent <addr> key <keyId>
+//
+// Each WARN was a single bootstrap attempt where the sender targeted
+// a *stale* X25519 fingerprint of our agent (e.g. cached from a
+// registry observation taken before our last rotation). The sender
+// fans the bootstrap out across every cached fingerprint it knows of;
+// only the one that matches our currently active key passes (logged
+// at INFO via `SWM sender-key setup receive accepted`). The rejected
+// attempts are not actionable and clutter `daemon.log`.
+//
+// The fix throws a typed `StaleSenderKeyTargetError` for that exact
+// outcome so the receive handler can route it to DEBUG. Genuine
+// failure modes (signature mismatch, agent-gate violation, recipient
+// not local, revoked-key targeting) keep throwing generic `Error`s
+// and stay at WARN.
+//
+// These tests pin both halves of the invariant: the typed error is
+// what's actually thrown for the stale-key case, and the receive
+// handler routes it to DEBUG (no WARN sink entry) while still routing
+// other failures to WARN.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  Logger,
+  computeSwmSenderKeyPackageAAD,
+  encodeSwmSenderKeyPackage,
+  encryptSwmSenderKeyPackage,
+  generateEd25519Keypair,
+  generateSwmSenderChainKey,
+  generateSwmSenderEpochId,
+  generateWorkspaceRecipientEncryptionKey,
+  type OperationContext,
+} from '@origintrail-official/dkg-core';
+import type { SwmSenderKeyPackageMsg } from '@origintrail-official/dkg-core';
+import {
+  DKGAgent,
+  StaleSenderKeyTargetError,
+  agentFromPrivateKey,
+  type AgentKeyRecord,
+} from '../src/index.js';
+
+interface DKGAgentInternals {
+  localAgents: Map<string, AgentKeyRecord>;
+  // Both private — we reach in via this view to drive them in tests.
+  acceptSwmSenderKeyPackage(
+    pkg: SwmSenderKeyPackageMsg,
+    fromPeerId: string,
+    ctx: OperationContext,
+  ): Promise<void>;
+  handleSwmSenderKeyPackage(data: Uint8Array, fromPeerId: string): Promise<Uint8Array>;
+  // Exposed for the `agentGate` mock so we don't have to spin up a
+  // full context graph + membership snapshot just to drive the
+  // sender-key bootstrap path.
+  getContextGraphAgentGateAddresses(contextGraphId: string): Promise<string[] | null>;
+}
+
+interface CapturedLog {
+  level: string;
+  message: string;
+}
+
+const TEST_CONTEXT_GRAPH_ID = 'agent-test-cg/swm-stale-target';
+const FROM_PEER_ID = '12D3KooWStaleTargetTestPeer';
+
+async function buildSignedPackage(input: {
+  senderWallet: ethers.HDNodeWallet;
+  recipientAgentAddress: string;
+  recipientKeyId: string;
+}): Promise<SwmSenderKeyPackageMsg> {
+  const signingKp = await generateEd25519Keypair();
+  const chainKey = generateSwmSenderChainKey();
+  // The recipient pubkey is only used by the sender as the second leg
+  // of the X25519 ECDH that derives the package setup key. We never
+  // exercise the decrypt path in these tests (the throw fires before
+  // it), so a freshly-minted ephemeral pubkey is sufficient — its
+  // only contract is "32-byte X25519 public key bytes".
+  const ephemeralRecipientPub = generateWorkspaceRecipientEncryptionKey(
+    `did:dkg:agent:${input.recipientAgentAddress}`,
+    input.recipientKeyId,
+  ).publicKeyBytes!;
+
+  const pkg = await encryptSwmSenderKeyPackage({
+    contextGraphId: TEST_CONTEXT_GRAPH_ID,
+    senderAgentAddress: input.senderWallet.address,
+    epochId: generateSwmSenderEpochId(),
+    membershipHash: 'sha256:stale-target-test',
+    recipientAgentAddress: input.recipientAgentAddress,
+    recipientKeyId: input.recipientKeyId,
+    createdAtMs: Date.now(),
+    initialMessageIndex: 0,
+    chainKey,
+    senderSigningPublicKey: signingKp.publicKey,
+    recipientPublicKey: ephemeralRecipientPub,
+  });
+  const aad = computeSwmSenderKeyPackageAAD(pkg);
+  pkg.signature = ethers.getBytes(await input.senderWallet.signMessage(aad));
+  return pkg;
+}
+
+async function bootAgentForStaleTargetTest(): Promise<{
+  agent: DKGAgent;
+  internals: DKGAgentInternals;
+  recipient: AgentKeyRecord;
+  senderWallet: ethers.HDNodeWallet;
+}> {
+  const agent = await DKGAgent.create({
+    name: 'StaleTargetTest',
+    chainAdapter: new MockChainAdapter(),
+  });
+  const internals = agent as unknown as DKGAgentInternals;
+  const recipient = agentFromPrivateKey(
+    ethers.Wallet.createRandom().privateKey,
+    'recipient',
+  );
+  internals.localAgents.set(recipient.agentAddress, recipient);
+  const senderWallet = ethers.Wallet.createRandom();
+  // Stub the agent-gate lookup. The real implementation reads it
+  // from the context graph's RDF membership; for the receive-handler
+  // log-routing test we just need both addresses to look "allowed",
+  // which is exactly what the bootstrap would observe in production
+  // after the chain-side join completed.
+  internals.getContextGraphAgentGateAddresses = async () => [
+    senderWallet.address,
+    recipient.agentAddress,
+  ];
+  return { agent, internals, recipient, senderWallet };
+}
+
+function captureLoggerSink(): {
+  entries: CapturedLog[];
+  detach: () => void;
+} {
+  const entries: CapturedLog[] = [];
+  Logger.setSink((entry) => entries.push({ level: entry.level, message: entry.message }));
+  return {
+    entries,
+    detach: () => Logger.setSink(null),
+  };
+}
+
+describe('StaleSenderKeyTargetError (typed error class)', () => {
+  // Pinning the message format so any operator alerting that grepped
+  // the legacy WARN string (`No local X25519 private key for DKG agent
+  // <addr> key <keyId>`) keeps matching after the demotion. If you
+  // intentionally restructure this string, update operator playbooks
+  // that rely on it before flipping this expectation.
+  it('preserves the legacy human-readable message format', () => {
+    const err = new StaleSenderKeyTargetError(
+      '0xC541F50f734E01d10dAF1bC1aEc3891fb3eA372E',
+      'did:dkg:agent:0xc541f50f734e01d10daf1bc1aec3891fb3ea372e#x25519-deadbeef',
+    );
+    expect(err.message).toBe(
+      'No local X25519 private key for DKG agent 0xC541F50f734E01d10dAF1bC1aEc3891fb3eA372E ' +
+        'key did:dkg:agent:0xc541f50f734e01d10daf1bc1aec3891fb3ea372e#x25519-deadbeef',
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('StaleSenderKeyTargetError');
+    expect(err.code).toBe('StaleSenderKeyTarget');
+    expect(err.recipientAgentAddress).toBe('0xC541F50f734E01d10dAF1bC1aEc3891fb3eA372E');
+    expect(err.recipientKeyId).toBe(
+      'did:dkg:agent:0xc541f50f734e01d10daf1bc1aec3891fb3ea372e#x25519-deadbeef',
+    );
+  });
+});
+
+describe('acceptSwmSenderKeyPackage: stale-target throw type', () => {
+  // Verifies the THROW side of the contract: when the targeted
+  // `recipientKeyId` isn't an active local key, `acceptSwmSenderKey
+  // Package` throws `StaleSenderKeyTargetError` (not generic `Error`).
+  // This anchors the type so the receive handler can rely on
+  // `instanceof StaleSenderKeyTargetError` for log routing.
+
+  it('throws StaleSenderKeyTargetError for a fingerprint we do not host', async () => {
+    const { internals, recipient, senderWallet } = await bootAgentForStaleTargetTest();
+    const stalePkg = await buildSignedPackage({
+      senderWallet,
+      recipientAgentAddress: recipient.agentAddress,
+      recipientKeyId:
+        `did:dkg:agent:${recipient.agentAddress.toLowerCase()}#x25519-deadbeefdeadbeefdeadbeefdeadbeef`,
+    });
+
+    await expect(
+      internals.acceptSwmSenderKeyPackage(stalePkg, FROM_PEER_ID, {
+        operationId: 'test-op',
+        operationName: 'share',
+      }),
+    ).rejects.toBeInstanceOf(StaleSenderKeyTargetError);
+  });
+
+  it('does NOT throw StaleSenderKeyTargetError for an active key (decrypt failure path)', async () => {
+    const { internals, recipient, senderWallet } = await bootAgentForStaleTargetTest();
+    // Use the recipient's actual active key id, but keep the random
+    // ephemeral recipient pubkey from `buildSignedPackage` — that
+    // mismatch will fail inside `decryptSwmSenderKeyPackage` AFTER
+    // the localKey lookup succeeds. The point: a generic `Error`
+    // surfaces, not `StaleSenderKeyTargetError`, so the receive
+    // handler keeps WARN-routing real protocol failures.
+    const activeKeyId = recipient.workspaceEncryptionKeys[0].encryptionKeyId;
+    const pkg = await buildSignedPackage({
+      senderWallet,
+      recipientAgentAddress: recipient.agentAddress,
+      recipientKeyId: activeKeyId,
+    });
+
+    const accept = internals.acceptSwmSenderKeyPackage(pkg, FROM_PEER_ID, {
+      operationId: 'test-op',
+      operationName: 'share',
+    });
+    await expect(accept).rejects.toBeInstanceOf(Error);
+    await expect(accept).rejects.not.toBeInstanceOf(StaleSenderKeyTargetError);
+  });
+});
+
+describe('handleSwmSenderKeyPackage: log-level routing', () => {
+  // The OPERATOR-FACING half: with the typed error wired, the receive
+  // handler must dispatch DEBUG for the stale case and WARN for
+  // anything else. We assert on the Logger sink (see
+  // packages/core/src/logger.ts — `debug()` is sink-only and never
+  // reaches stdout/stderr; `warn()` writes both). This is what
+  // demotes the line from `daemon.log` while keeping it
+  // troubleshootable via the dashboard DB sink at debug level.
+
+  let detachSink: (() => void) | null = null;
+  afterEach(() => {
+    detachSink?.();
+    detachSink = null;
+  });
+
+  it('routes a stale-key rejection to DEBUG (no WARN entry in the sink)', async () => {
+    const { internals, recipient, senderWallet } = await bootAgentForStaleTargetTest();
+    const stalePkg = await buildSignedPackage({
+      senderWallet,
+      recipientAgentAddress: recipient.agentAddress,
+      recipientKeyId:
+        `did:dkg:agent:${recipient.agentAddress.toLowerCase()}#x25519-cafef00dcafef00dcafef00dcafef00d`,
+    });
+    const bytes = encodeSwmSenderKeyPackage(stalePkg);
+
+    const sink = captureLoggerSink();
+    detachSink = sink.detach;
+    await internals.handleSwmSenderKeyPackage(bytes, FROM_PEER_ID);
+
+    const rejectEntries = sink.entries.filter((e) =>
+      e.message.startsWith('SWM sender-key setup receive rejected'),
+    );
+    expect(rejectEntries).toHaveLength(1);
+    expect(rejectEntries[0].level).toBe('debug');
+    expect(rejectEntries[0].message).toContain(
+      `reason=No local X25519 private key for DKG agent ${recipient.agentAddress}`,
+    );
+
+    const warnRejects = sink.entries.filter(
+      (e) => e.level === 'warn' && e.message.includes('SWM sender-key setup receive rejected'),
+    );
+    expect(warnRejects).toEqual([]);
+  });
+
+  it('routes a non-stale failure (recipient not local) to WARN', async () => {
+    // Same setup, but we drop the recipient from `localAgents` AFTER
+    // the agent-gate stub still allows it. That makes
+    // `hasLocalAgent(recipientAgentAddress)` return false and
+    // `acceptSwmSenderKeyPackage` throws a plain `Error` ("Recipient
+    // agent <addr> is not local to this node") — which must stay at
+    // WARN so operators see real misconfigurations.
+    const { internals, recipient, senderWallet } = await bootAgentForStaleTargetTest();
+    const activeKeyId = recipient.workspaceEncryptionKeys[0].encryptionKeyId;
+    const pkg = await buildSignedPackage({
+      senderWallet,
+      recipientAgentAddress: recipient.agentAddress,
+      recipientKeyId: activeKeyId,
+    });
+    const bytes = encodeSwmSenderKeyPackage(pkg);
+    internals.localAgents.delete(recipient.agentAddress);
+
+    const sink = captureLoggerSink();
+    detachSink = sink.detach;
+    await internals.handleSwmSenderKeyPackage(bytes, FROM_PEER_ID);
+
+    const rejectEntries = sink.entries.filter((e) =>
+      e.message.startsWith('SWM sender-key setup receive rejected'),
+    );
+    expect(rejectEntries).toHaveLength(1);
+    expect(rejectEntries[0].level).toBe('warn');
+    expect(rejectEntries[0].message).toContain('is not local to this node');
+  });
+});


### PR DESCRIPTION
## Why

On testnet edge-node logs we see up to 5 WARN lines per peer per session of the form:

```
SWM sender-key setup receive rejected: senderAgent=<peer> recipientAgent=<us>
  reason=No local X25519 private key for DKG agent <addr> key <keyId>
```

Each WARN is a single bootstrap attempt where the sender targeted a *stale* X25519 fingerprint of our agent (cached from a registry observation taken before our last rotation, or during a key-rollout window where multiple snapshots were live). The sender fans the bootstrap out across every cached fingerprint it knows of; only the one that matches our currently active key passes — that one is logged at INFO via `SWM sender-key setup receive accepted`. The rejected attempts are not actionable.

We confirmed this is happening in practice while validating dzudza on the local testnet: 5 WARNs in a 14-second window, each citing a different `#x25519-...` fingerprint, yet the SWM channel itself was healthy (75 data + 349 meta triples synced 3 minutes later, both nodes seeing decrypted content) — i.e. the noise is purely informational and clutters `daemon.log` for operators chasing real issues.

## What changes

- New `StaleSenderKeyTargetError` (`packages/agent/src/dkg-agent-types.ts`) — typed error, exported from the agent index.
- `acceptSwmSenderKeyPackage` throws `StaleSenderKeyTargetError` (instead of generic `Error`) for the "no active local X25519 key matches `recipientKeyId`" case. The legacy human-readable message is preserved verbatim so any operator alerting that grepped the old string keeps matching.
- `handleSwmSenderKeyPackage` routes the throw via `instanceof StaleSenderKeyTargetError` — DEBUG (sink-only, never reaches stdout/stderr per `packages/core/src/logger.ts`) for stale targets, WARN for everything else.

WARN remains for genuine, operator-actionable failures:

| Failure mode                       | Throw                                  | Log level |
|------------------------------------|----------------------------------------|-----------|
| Signature recovery mismatch        | `Error("Sender Key setup signature ...")` | **WARN** |
| Sender outside agent gate          | `Error("Sender agent X is not allowed ...")` | **WARN** |
| Recipient outside agent gate       | `Error("Recipient agent X is not allowed ...")` | **WARN** |
| Recipient not local                | `Error("Recipient agent X is not local ...")` | **WARN** |
| Recipient targeted a **revoked** key  | `Error("Recipient key X ... was revoked at ...")` | **WARN** |
| Recipient targeted a **stale** key (this PR)  | `StaleSenderKeyTargetError`     | **DEBUG** |

## Tests

`packages/agent/test/swm-sender-key-stale-target.test.ts` — 5 cases, all green:

- `StaleSenderKeyTargetError` preserves the legacy human-readable message format (anchor for external scrapers).
- `acceptSwmSenderKeyPackage` throws `StaleSenderKeyTargetError` (`instanceof`, not just any `Error`) for an unknown `recipientKeyId`.
- `acceptSwmSenderKeyPackage` does **not** throw `StaleSenderKeyTargetError` when the `recipientKeyId` is active but the package fails for an unrelated reason — anchors the discriminator so a future refactor can't accidentally over-broadly demote real protocol failures.
- `handleSwmSenderKeyPackage` routes the stale-target throw to a DEBUG sink entry with **no** WARN — verified via `Logger.setSink` capturing levels.
- `handleSwmSenderKeyPackage` still routes "recipient not local" to WARN — anchors operator visibility for real misconfigurations.

```
$ pnpm exec vitest run test/swm-sender-key-stale-target.test.ts test/agent-rotate-encryption-key.test.ts
 Test Files  2 passed (2)
      Tests  22 passed (22)
```

## Out of scope

Pre-existing `tsc` errors on `packages/agent` (ChainAdapter API drift, ONTOLOGY constant churn, `dkg-publisher` re-exports) are unchanged by this PR. Verified by stash-checking `origin/main` against the same compile invocation: identical error set, only line numbers shift by the new exports we add.

## Test plan

- [x] New unit tests pass locally (5/5).
- [x] Adjacent unit tests (`agent-rotate-encryption-key.test.ts`, the closest existing coverage of this area) still pass (17/17).
- [x] Lint/format: package has no lint script; no new `tsc` errors introduced (compared to `origin/main` baseline).
- [ ] CI green.
- [ ] Optional follow-up after merge: spot-check a fresh devnet `daemon.log` for absence of the demoted WARN line during a re-bootstrap.


Made with [Cursor](https://cursor.com)