### PR TITLE
N6 — broaden activity feed (imports + promotions)

### DIFF
--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -17,10 +17,11 @@
 import React from 'react';
 import type { MemoryEntity, TrustLevel } from '../hooks/useMemoryEntities.js';
 import {
-  useProjectActivity,
+  useProjectActivityEvents,
   bucketActivity,
   relativeTime,
   type ActivityItem,
+  type PromotionAttribution,
 } from '../hooks/useProjectActivity.js';
 import { useAgentsContext } from '../hooks/useAgents.js';
 import { useProjectProfileContext } from '../hooks/useProjectProfile.js';
@@ -51,6 +52,14 @@ export interface ActivityFeedProps {
    * feed sets this to false.
    */
   includeUndated?: boolean;
+  /**
+   * N6 part 2 — when supplied, SWM promotion events are interleaved
+   * into the feed as `'promoted'` rows. The Overview wires this to
+   * `useSwmAttributions(...)` so a CG full of imported + promoted
+   * entities reads as a real timeline. AgentProfileView omits this
+   * (the per-agent typed-activity slice doesn't want promotion noise).
+   */
+  swmAttributions?: Map<string, PromotionAttribution[]>;
   title?: React.ReactNode;
   onSelectEntity: (uri: string) => void;
   /** Optional click handler for author chips (navigate to agent profile). */
@@ -67,14 +76,18 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   subGraph,
   limit,
   includeUndated = true,
+  swmAttributions,
   title,
   onSelectEntity,
   onOpenAgent,
   emptyHint,
   className = '',
 }) => {
-  const items = useProjectActivity(entities, {
-    agentUri, typeIri, subGraph, limit, includeUndated,
+  // useProjectActivityEvents reduces to plain useProjectActivity when
+  // swmAttributions is undefined, so existing callers (AgentProfileView)
+  // get identical behaviour without passing the new prop.
+  const items = useProjectActivityEvents(entities, {
+    agentUri, typeIri, subGraph, limit, includeUndated, swmAttributions,
   });
   const buckets = React.useMemo(() => bucketActivity(items), [items]);
   const agents = useAgentsContext();
@@ -134,17 +147,32 @@ function ActivityRow({
   onOpenAgent?: (uri: string) => void;
 }) {
   const author = item.authorUri ? agents?.get(item.authorUri) : null;
-  // For `'added'` events the entity has no typed-activity kind, so we
-  // fall back to a neutral "Added" presentation rather than peering
-  // into a non-existent type binding (N6 — entity imports now surface
-  // as activity rows, not just decisions / tasks / PRs / commits).
-  const isAdded = item.event === 'added';
-  const typeBinding = !isAdded && item.kindUri ? profile?.forType(item.kindUri) : null;
-  const typeLabel = isAdded
-    ? 'Added'
-    : (typeBinding?.label ?? (item.kindUri ? item.kindUri.split(/[#/]/).pop() : null) ?? 'Entity');
-  const typeIcon = isAdded ? '+' : (typeBinding?.icon ?? '◆');
-  const typeColor = typeBinding?.color ?? (isAdded ? '#64748b' : '#a855f7');
+  // Event-specific presentation (N6). `'typed'` keeps the historical
+  // type-binding-driven look (Decision green check, Task cyan, etc.).
+  // `'added'` is a neutral import treatment. `'promoted'` (and the
+  // forthcoming `'published'`) are stage transitions, coloured to the
+  // *target* layer they advanced into so the row reads as "moved to
+  // Shared Working Memory".
+  const isTyped = item.event === 'typed';
+  const typeBinding = isTyped && item.kindUri ? profile?.forType(item.kindUri) : null;
+  const typeLabel = ((): string => {
+    if (item.event === 'added') return 'Added';
+    if (item.event === 'promoted') return 'Promoted to Shared Working Memory';
+    if (item.event === 'published') return 'Published to Verifiable Memory';
+    return typeBinding?.label ?? (item.kindUri ? item.kindUri.split(/[#/]/).pop() : null) ?? 'Entity';
+  })();
+  const typeIcon = ((): string => {
+    if (item.event === 'added') return '+';
+    if (item.event === 'promoted') return '⇡';
+    if (item.event === 'published') return '◉';
+    return typeBinding?.icon ?? '◆';
+  })();
+  const typeColor = ((): string => {
+    if (item.event === 'promoted') return LAYER_COLOR.shared;
+    if (item.event === 'published') return LAYER_COLOR.verified;
+    if (item.event === 'added') return '#64748b';
+    return typeBinding?.color ?? '#a855f7';
+  })();
   const layerColor = LAYER_COLOR[item.layer];
 
   // Surface status when the entity has one — decisions.status / tasks.status /

--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -134,12 +134,17 @@ function ActivityRow({
   onOpenAgent?: (uri: string) => void;
 }) {
   const author = item.authorUri ? agents?.get(item.authorUri) : null;
-  const typeBinding = profile?.forType(item.kindUri);
-  const typeLabel = typeBinding?.label
-    ?? item.kindUri.split(/[#/]/).pop()
-    ?? 'Entity';
-  const typeIcon = typeBinding?.icon ?? '◆';
-  const typeColor = typeBinding?.color ?? '#a855f7';
+  // For `'added'` events the entity has no typed-activity kind, so we
+  // fall back to a neutral "Added" presentation rather than peering
+  // into a non-existent type binding (N6 — entity imports now surface
+  // as activity rows, not just decisions / tasks / PRs / commits).
+  const isAdded = item.event === 'added';
+  const typeBinding = !isAdded && item.kindUri ? profile?.forType(item.kindUri) : null;
+  const typeLabel = isAdded
+    ? 'Added'
+    : (typeBinding?.label ?? (item.kindUri ? item.kindUri.split(/[#/]/).pop() : null) ?? 'Entity');
+  const typeIcon = isAdded ? '+' : (typeBinding?.icon ?? '◆');
+  const typeColor = typeBinding?.color ?? (isAdded ? '#64748b' : '#a855f7');
   const layerColor = LAYER_COLOR[item.layer];
 
   // Surface status when the entity has one — decisions.status / tasks.status /

--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -21,7 +21,7 @@ import {
   bucketActivity,
   relativeTime,
   type ActivityItem,
-  type PromotionAttribution,
+  type PromotionAttribution as ActivityFeedEvent,
 } from '../hooks/useProjectActivity.js';
 import { useAgentsContext } from '../hooks/useAgents.js';
 import { useProjectProfileContext } from '../hooks/useProjectProfile.js';
@@ -55,11 +55,13 @@ export interface ActivityFeedProps {
   /**
    * N6 part 2 — when supplied, SWM promotion events are interleaved
    * into the feed as `'promoted'` rows. The Overview wires this to
-   * `useSwmAttributions(...)` so a CG full of imported + promoted
-   * entities reads as a real timeline. AgentProfileView omits this
-   * (the per-agent typed-activity slice doesn't want promotion noise).
+   * `useSwmAttributions(...).events` (raw per-operation event log)
+   * so re-promotions surface as distinct rows. AgentProfileView omits
+   * this (the per-agent typed-activity slice doesn't want promotion
+   * noise). Codex Code2 (PR #656) — switched from the deduped
+   * `attributions` map to the raw event list.
    */
-  swmAttributions?: Map<string, PromotionAttribution[]>;
+  swmEvents?: ReadonlyArray<ActivityFeedEvent>;
   title?: React.ReactNode;
   onSelectEntity: (uri: string) => void;
   /** Optional click handler for author chips (navigate to agent profile). */
@@ -76,7 +78,7 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   subGraph,
   limit,
   includeUndated = true,
-  swmAttributions,
+  swmEvents,
   title,
   onSelectEntity,
   onOpenAgent,
@@ -84,10 +86,10 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   className = '',
 }) => {
   // useProjectActivityEvents reduces to plain useProjectActivity when
-  // swmAttributions is undefined, so existing callers (AgentProfileView)
+  // swmEvents is undefined, so existing callers (AgentProfileView)
   // get identical behaviour without passing the new prop.
   const items = useProjectActivityEvents(entities, {
-    agentUri, typeIri, subGraph, limit, includeUndated, swmAttributions,
+    agentUri, typeIri, subGraph, limit, includeUndated, swmEvents,
   });
   const buckets = React.useMemo(() => bucketActivity(items), [items]);
   const agents = useAgentsContext();
@@ -118,7 +120,7 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
           <div className="v10-activity-feed-items">
             {bucket.items.map(item => (
               <ActivityRow
-                key={item.entity.uri}
+                key={item.id}
                 item={item}
                 agents={agents}
                 profile={profile}
@@ -191,13 +193,13 @@ function ActivityRow({
     return parts.join('\n');
   })();
 
-  return (
-    <button
-      type="button"
-      className="v10-activity-feed-row"
-      onClick={() => onSelectEntity(item.entity.uri)}
-      title={tooltip}
-    >
+  // Codex Code3 (PR #656) — stub promotion rows for roots that aren't
+  // in `rawMemory.entities` are non-clickable. The detail navigation
+  // would otherwise resolve `selectedEntity` to null and clear the
+  // selection on the next render. Render as static text instead of
+  // an interactive button; the event still appears in the timeline.
+  const rowBody = (
+    <>
       <span
         className="v10-activity-feed-layer"
         style={{ color: layerColor }}
@@ -231,6 +233,29 @@ function ActivityRow({
       <span className="v10-activity-feed-time" title={item.at ? item.at.toLocaleString() : 'no timestamp'}>
         {relativeTime(item.at)}
       </span>
+    </>
+  );
+
+  if (!item.clickable) {
+    return (
+      <div
+        className="v10-activity-feed-row v10-activity-feed-row-static"
+        title={tooltip}
+        aria-disabled="true"
+      >
+        {rowBody}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className="v10-activity-feed-row"
+      onClick={() => onSelectEntity(item.entity.uri)}
+      title={tooltip}
+    >
+      {rowBody}
     </button>
   );
 }

--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -177,15 +177,26 @@ function ActivityRow({
 
   // Surface status when the entity has one — decisions.status / tasks.status /
   // github.state — because "rejected" / "blocked" / "merged" is often the
-  // most useful scan-while-browsing signal.
-  const status = findStatus(item.entity);
+  // most useful scan-while-browsing signal. Only meaningful on `'typed'`
+  // rows; `'promoted'` / `'added'` / `'published'` describe the transition
+  // itself and the status would read confusingly next to "Promoted to …".
+  const status = isTyped ? findStatus(item.entity) : null;
+  // Event-aware tooltip — promote/publish rows read better as
+  // "Promoted to Shared Working Memory · Foo" than just "Foo".
+  const tooltip = (() => {
+    const parts: string[] = [];
+    if (item.event !== 'typed') parts.push(typeLabel);
+    parts.push(item.entity.label);
+    if (item.at) parts.push(item.at.toISOString());
+    return parts.join('\n');
+  })();
 
   return (
     <button
       type="button"
       className="v10-activity-feed-row"
       onClick={() => onSelectEntity(item.entity.uri)}
-      title={item.at ? `${item.entity.label}\n${item.at.toISOString()}` : item.entity.label}
+      title={tooltip}
     >
       <span
         className="v10-activity-feed-layer"

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -90,7 +90,7 @@ function shortPredicate(uri: string): string {
   return s.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/_/g, ' ');
 }
 
-function uriTail(uri: string): string {
+export function uriTail(uri: string): string {
   const hash = uri.lastIndexOf('#');
   const slash = uri.lastIndexOf('/');
   const colon = uri.lastIndexOf(':');

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -36,7 +36,7 @@
  *                    entity-list pass below).
  */
 import { useMemo } from 'react';
-import { canonicalEntityUri, type MemoryEntity, type TrustLevel } from './useMemoryEntities.js';
+import { canonicalEntityUri, uriTail, type MemoryEntity, type TrustLevel } from './useMemoryEntities.js';
 
 // Priority order — first predicate that has a parseable value wins.
 const TIMESTAMP_PREDICATES = [
@@ -470,10 +470,13 @@ export function buildPromotionEvents(
 function syntheticEntityStub(uri: string): MemoryEntity {
   // URI-tail label so the row reads ("promoted <tail>") even when
   // the underlying entity hasn't loaded into `entitiesByUri` yet.
-  const tail = uri.split(/[#/]/).filter(Boolean).pop() ?? uri;
+  // R2-Local-2 (PR #656) — reuse `uriTail` from `useMemoryEntities`
+  // so stub labels match the rest of the surface; the previous
+  // `[#/]` split collapsed canonical `urn:dkg:thing:...` URIs to
+  // the entire URN.
   return {
     uri,
-    label: tail,
+    label: uriTail(uri),
     types: [],
     trustLevel: 'shared',
     layers: new Set(['shared']),

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -133,13 +133,23 @@ function parseDateLike(s: string): Date | null {
  * reconcile the wrong row on updates. The id is event-discriminated
  * + tied to either the operation URI (for transition events) or the
  * entity URI (for entity-derived events), plus the row's timestamp.
+ *
+ * Codex Code4 (PR #656) — promotion rows additionally include the
+ * `rootUri` so a single `WorkspaceOperation` that promotes several
+ * roots produces a distinct id per root (one op URI + multiple roots
+ * at the same timestamp would otherwise collide on `${event}|${opUri}|${ts}`).
  */
 export function buildActivityId(
   event: ActivityEvent,
   subjectUri: string,
   at: Date | null,
+  rootUri?: string,
 ): string {
-  return `${event}|${subjectUri}|${at ? at.toISOString() : 'no-ts'}`;
+  const ts = at ? at.toISOString() : 'no-ts';
+  if (rootUri && rootUri !== subjectUri) {
+    return `${event}|${subjectUri}|${rootUri}|${ts}`;
+  }
+  return `${event}|${subjectUri}|${ts}`;
 }
 
 /**
@@ -405,10 +415,12 @@ export function buildPromotionEvents(
     const entity = entitiesByUri.get(evt.rootUri);
     const resolved = entity != null;
     out.push({
-      // Per-op id (Code1) — keys off the operation URI so two
-      // re-promotions of the same (root, agent) produce two distinct
-      // keys (different opUri) and React reconciles them correctly.
-      id: buildActivityId('promoted', evt.opUri, at),
+      // Per-op id (Code1 + Code4) — keys off the operation URI plus
+      // the root URI so (a) two re-promotions of the same (root, agent)
+      // with different `opUri`s reconcile as distinct rows, and (b) a
+      // single `WorkspaceOperation` that promotes multiple roots
+      // produces a distinct id per root (the opUri alone would collide).
+      id: buildActivityId('promoted', evt.opUri, at, evt.rootUri),
       // When the entity isn't in `entitiesByUri` (data race, or a
       // promotion of a root that was already published past SWM
       // before this hook ran), synthesise a stub so the row still

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -36,7 +36,7 @@
  *                    entity-list pass below).
  */
 import { useMemo } from 'react';
-import type { MemoryEntity, TrustLevel } from './useMemoryEntities.js';
+import { canonicalEntityUri, type MemoryEntity, type TrustLevel } from './useMemoryEntities.js';
 
 // Priority order — first predicate that has a parseable value wins.
 const TIMESTAMP_PREDICATES = [
@@ -412,20 +412,31 @@ export function buildPromotionEvents(
     if (subGraph && evt.subGraph !== subGraph) continue;
     const at = parseDateLike(evt.publishedAt);
     if (!at) continue;
-    const entity = entitiesByUri.get(evt.rootUri);
+    // Local-1 (PR #656) — `evt.rootUri` is the raw SPARQL binding
+    // value and can be wrapped (`<urn:...>`), while `entitiesByUri`
+    // is keyed by canonical URIs (the same canonicalisation
+    // `buildEntities` applies). Without this step every promotion of
+    // a wrapped-URI root would fall through to the stub branch and
+    // render as a non-clickable static row, even though the entity
+    // is loaded. Same C8 / R2-1 pattern as the earlier #639 fixes.
+    const canonicalRoot = canonicalEntityUri(evt.rootUri);
+    const entity = entitiesByUri.get(canonicalRoot);
     const resolved = entity != null;
     out.push({
       // Per-op id (Code1 + Code4) — keys off the operation URI plus
-      // the root URI so (a) two re-promotions of the same (root, agent)
-      // with different `opUri`s reconcile as distinct rows, and (b) a
-      // single `WorkspaceOperation` that promotes multiple roots
-      // produces a distinct id per root (the opUri alone would collide).
-      id: buildActivityId('promoted', evt.opUri, at, evt.rootUri),
+      // the (canonical) root URI so (a) two re-promotions of the
+      // same (root, agent) with different `opUri`s reconcile as
+      // distinct rows, and (b) a single `WorkspaceOperation` that
+      // promotes multiple roots produces a distinct id per root
+      // (the opUri alone would collide). Use the canonical form so
+      // a wrapped + unwrapped event for the same root don't render
+      // as two rows.
+      id: buildActivityId('promoted', evt.opUri, at, canonicalRoot),
       // When the entity isn't in `entitiesByUri` (data race, or a
       // promotion of a root that was already published past SWM
       // before this hook ran), synthesise a stub so the row still
       // renders cleanly. A URI-tail label is good enough for the row.
-      entity: entity ?? syntheticEntityStub(evt.rootUri),
+      entity: entity ?? syntheticEntityStub(canonicalRoot),
       at,
       // Author on a `'promoted'` row is the *promoter* (the agent
       // who moved this entity into SWM), not the original `prov:

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -15,6 +15,25 @@
  *
  * This is intentionally client-side: every memory triple is already in
  * the hook's cache, and the feed is a pure derivation. No extra SPARQL.
+ *
+ * **N6 — event classification.** Originally the feed allowlisted a small
+ * set of "interesting" types (Decision / Task / PR / Issue / Commit) and
+ * silently dropped every other entity, so a Context Graph full of
+ * imported knowledge displayed "No activity yet" even when many entities
+ * had been imported with `dcterms:created` timestamps. The feed now
+ * surfaces every entity with a parseable timestamp and tags each item
+ * with an `event` discriminator so the renderer can adapt the icon,
+ * copy and per-row chrome:
+ *
+ *   - `'typed'`   — entity matches one of the historical ACTIVITY_TYPES
+ *                    (preserved verbatim so AgentProfileView and the
+ *                    existing decision/task/PR feed shape unchanged).
+ *   - `'added'`   — pure import: the entity has a timestamp but isn't
+ *                    one of the typed-activity kinds.
+ *   - `'promoted'` / `'published'` — reserved for later commits in this
+ *                    series; surfaced from `_shared_memory_meta`
+ *                    WorkspaceOperation records (not derived from the
+ *                    entity-list pass below).
  */
 import { useMemo } from 'react';
 import type { MemoryEntity, TrustLevel } from './useMemoryEntities.js';
@@ -31,7 +50,12 @@ const TIMESTAMP_PREDICATES = [
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const PROV_WAS_ATTRIBUTED_TO = 'http://www.w3.org/ns/prov#wasAttributedTo';
 
-/** Entity types that make sense on the activity feed. */
+/**
+ * Entity types that surface as "typed" activity rows (the original feed
+ * shape — decision proposed, task done, PR merged, etc.). Imported
+ * entities whose `rdf:type` is not in this set become `'added'` rows
+ * instead (see `event` on `ActivityItem`).
+ */
 const ACTIVITY_TYPES = new Set([
   'http://dkg.io/ontology/decisions/Decision',
   'http://dkg.io/ontology/tasks/Task',
@@ -39,6 +63,17 @@ const ACTIVITY_TYPES = new Set([
   'http://dkg.io/ontology/github/Issue',
   'http://dkg.io/ontology/github/Commit',
 ]);
+
+/**
+ * Discriminator on every activity item. Drives the row icon / copy.
+ * `'typed'` preserves the legacy decision/task/PR feed shape; `'added'`
+ * is the N6 broadening — any entity with a timestamp that isn't one of
+ * the historical typed activities. `'promoted'` / `'published'` are
+ * threaded through in later commits in this series and originate from
+ * `_shared_memory_meta` WorkspaceOperation records, not the
+ * entity-list pass.
+ */
+export type ActivityEvent = 'added' | 'typed' | 'promoted' | 'published';
 
 export interface ActivityItem {
   entity: MemoryEntity;
@@ -51,12 +86,19 @@ export interface ActivityItem {
    */
   at: Date | null;
   authorUri: string | null;
-  /** Primary rdf:type of the entity (first match from ACTIVITY_TYPES). */
-  kindUri: string;
+  /**
+   * Primary rdf:type of the entity (first match from ACTIVITY_TYPES),
+   * or `null` for `'added'` rows whose entity doesn't have one of the
+   * historical typed-activity kinds. Renderers should fall back to a
+   * neutral "added" treatment when this is `null`.
+   */
+  kindUri: string | null;
   /** Which sub-graph this activity lives in. */
   subGraph: string | null;
   /** Trust layer — drives the coloured dot in the feed. */
   layer: TrustLevel;
+  /** N6 event-kind discriminator — see `ActivityEvent`. */
+  event: ActivityEvent;
 }
 
 function parseDateLike(s: string): Date | null {
@@ -134,14 +176,26 @@ export function useProjectActivity(
     const out: ActivityItem[] = [];
     for (const e of entityList) {
       const kindUri = primaryActivityType(e);
-      if (!kindUri) continue;
+      // typeIri filter pins the feed to a specific typed-activity kind
+      // (used by AgentProfileView's per-type stat chips). When set, the
+      // entity must have that exact `kindUri` — `'added'` rows are
+      // dropped from the slice. Without `typeIri` we keep both `typed`
+      // and `added` items.
       if (typeIri && kindUri !== typeIri) continue;
       const at = timestampOf(e);
-      if (!at && !includeUndated) continue;
+      // No-timestamp + includeUndated: only surface entities with a
+      // recognised type so the Undated bucket on AgentProfileView
+      // stays focused on authored work, not every random untyped
+      // entity in the project.
+      if (!at) {
+        if (!includeUndated) continue;
+        if (!kindUri) continue;
+      }
       const author = authorOf(e);
       if (agentUri && author !== agentUri) continue;
       const sg = primarySubGraph(e);
       if (subGraph && sg !== subGraph) continue;
+      const event: ActivityEvent = kindUri ? 'typed' : 'added';
       out.push({
         entity: e,
         at,
@@ -149,6 +203,7 @@ export function useProjectActivity(
         kindUri,
         subGraph: sg,
         layer: e.trustLevel,
+        event,
       });
     }
     // Dated items newest-first; undated items go last, ordered by label

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -76,6 +76,15 @@ const ACTIVITY_TYPES = new Set([
 export type ActivityEvent = 'added' | 'typed' | 'promoted' | 'published';
 
 export interface ActivityItem {
+  /**
+   * Stable per-event identifier — `${event}|${opUri ?? entity.uri}|${atIso}`.
+   * Same entity URI can produce several rows in one feed (`added` +
+   * `promoted` for an entity that was both imported and promoted, or
+   * two `promoted` rows for two distinct promoters / re-promotions),
+   * so keying React's list by `entity.uri` would collide and
+   * reconcile the wrong row on updates. Renderers MUST key off `id`.
+   */
+  id: string;
   entity: MemoryEntity;
   /**
    * Primary activity timestamp — `null` means the entity is relevant
@@ -99,12 +108,38 @@ export interface ActivityItem {
   layer: TrustLevel;
   /** N6 event-kind discriminator — see `ActivityEvent`. */
   event: ActivityEvent;
+  /**
+   * Whether the row should navigate when clicked. `false` for stub
+   * promotion rows whose underlying root isn't in `rawMemory.entities`
+   * — `ProjectView.openEntityDetail` would clear the selection
+   * immediately because `selectedEntity` resolves to `null`, so we
+   * render those rows as static text (the event still appears in the
+   * timeline; only the navigation is suppressed). Defaults to `true`.
+   */
+  clickable: boolean;
 }
 
 function parseDateLike(s: string): Date | null {
   const stripped = s.replace(/^"|"$/g, '').replace(/^"(.+)"(?:@\w+|\^\^.+)?$/, '$1');
   const d = new Date(stripped);
   return Number.isFinite(d.getTime()) ? d : null;
+}
+
+/**
+ * Stable per-event id (Code1 fix). The same entity URI can appear in
+ * several rows (`added` from an import + `promoted` from a WM→SWM
+ * transition + a second `promoted` from a re-promotion by a different
+ * agent), so keying React's list by `entity.uri` would collide and
+ * reconcile the wrong row on updates. The id is event-discriminated
+ * + tied to either the operation URI (for transition events) or the
+ * entity URI (for entity-derived events), plus the row's timestamp.
+ */
+export function buildActivityId(
+  event: ActivityEvent,
+  subjectUri: string,
+  at: Date | null,
+): string {
+  return `${event}|${subjectUri}|${at ? at.toISOString() : 'no-ts'}`;
 }
 
 /**
@@ -196,7 +231,13 @@ export function useProjectActivity(
       const sg = primarySubGraph(e);
       if (subGraph && sg !== subGraph) continue;
       const event: ActivityEvent = kindUri ? 'typed' : 'added';
+      // Per-event id (Code1) — typed/added rows have at most one of
+      // each event-kind per entity, so `${event}|${uri}|${atIso}` is
+      // stable across re-renders even if the same URI later gains a
+      // `'promoted'` row from the joiner.
+      const id = buildActivityId(event, e.uri, at);
       out.push({
+        id,
         entity: e,
         at,
         authorUri: author,
@@ -204,6 +245,10 @@ export function useProjectActivity(
         subGraph: sg,
         layer: e.trustLevel,
         event,
+        // Entity-derived rows always have a resolvable entity in
+        // `rawMemory` (we iterated `entityList` to get here), so they
+        // can always navigate.
+        clickable: true,
       });
     }
     // Dated items newest-first; undated items go last, ordered by label
@@ -273,33 +318,51 @@ export function bucketActivity(items: ActivityItem[], now: Date = new Date()): A
 
 // ─── Promotion events (N6 part 2) ────────────────────────────────
 //
-// `useSwmAttributions` already queries the project's `_shared_memory_meta`
-// partitions and produces a `Map<rootUri, AgentAttribution[]>` carrying
-// `(agent, opUri, publishedAt, subGraph)` per (root, agent) pair. We
-// re-use that data here — no new SPARQL — and project each attribution
-// into a `'promoted'` activity row so the Overview feed shows who
-// promoted what when. Each `AgentAttribution` becomes one row; an
-// entity promoted by two distinct agents produces two rows (which
-// reads as the conflict signal the SWM legend already badges).
+// `useSwmAttributions` queries `_shared_memory_meta` for every
+// `dkg:WorkspaceOperation` row and exposes them in two shapes:
+//
+//   1. `attributions: Map<rootUri, AgentAttribution[]>` — deduplicated
+//      by `(root, agent)`. The SWM-graph legend wants this (one
+//      colour-slot per promoter regardless of how often they re-promoted).
+//
+//   2. `events: WorkspaceOperationEvent[]` — raw per-operation rows,
+//      no dedup. Re-promotions of the same `(root, agent)` produce
+//      two rows. This is the substrate the activity feed needs: every
+//      promotion is its own event in the timeline.
+//
+// Codex Code2 (PR #656) caught us wiring the deduped map into the
+// activity feed — that silently dropped re-promotions and could show
+// outdated timestamps. The joiner below now consumes the raw event
+// list. No new SPARQL — same `useSwmAttributions` query, two
+// projections.
 //
 // Kept as a small pure helper that takes data + an entity lookup so
 // the joiner is testable without a network query — the React hook
 // below just wires the live `useSwmAttributions` result in.
 
 /**
- * Minimal shape of a SWM agent-attribution entry, mirrored from
- * `useSwmAttributions.AgentAttribution`. Re-declared here as a
+ * Raw per-operation event shape, mirrored from
+ * `useSwmAttributions.WorkspaceOperationEvent`. Re-declared here as a
  * structural subset so this file doesn't have to import the SWM hook
  * type and can be exercised by tests with plain object literals.
+ *
+ * @deprecated Use `WorkspaceOperationEvent` directly when consuming
+ *   the live hook — this alias is retained for symmetry with the
+ *   pre-Code2 `PromotionAttribution` callers but is now a strict
+ *   superset (`rootUri` is required).
  */
 export interface PromotionAttribution {
   agent: string;
   opUri: string;
   publishedAt: string;
   subGraph?: string;
+  /** The root entity URI this promotion event applies to. Was
+   *  implicit in the previous Map key; now explicit so the row can
+   *  also surface multiple roots from one op id. */
+  rootUri: string;
 }
 
-export interface AppendPromotionEventsOptions {
+export interface BuildPromotionEventsOptions {
   /** Per-URI entity lookup. Used to recover entity label + trustLevel
    *  for the promoted root. URIs that don't resolve still produce a row
    *  with a `null`-ish entity stub so the feed never silently drops a
@@ -316,50 +379,61 @@ export interface AppendPromotionEventsOptions {
 }
 
 /**
- * Pure helper — turns a SWM attribution map into a flat list of
- * `'promoted'` activity items, ready to merge with the entity-derived
- * feed. Skips rows whose timestamp can't be parsed (the meta graph
- * encodes them as ISO strings — failures are not expected in practice
- * but we'd rather drop than render an "Invalid Date" row).
+ * Pure helper — turns a raw `_shared_memory_meta` event list into a
+ * flat list of `'promoted'` activity items, ready to merge with the
+ * entity-derived feed. Skips rows whose timestamp can't be parsed
+ * (the meta graph encodes them as ISO strings — failures are not
+ * expected in practice but we'd rather drop than render an "Invalid
+ * Date" row).
+ *
+ * Stub rows (root not in `entitiesByUri`) are emitted as
+ * `clickable: false` so the row stays in the timeline but doesn't
+ * navigate to a detail view that would immediately clear itself
+ * (Codex Code3, PR #656).
  */
 export function buildPromotionEvents(
-  attributions: Map<string, PromotionAttribution[]>,
-  opts: AppendPromotionEventsOptions,
+  events: ReadonlyArray<PromotionAttribution>,
+  opts: BuildPromotionEventsOptions,
 ): ActivityItem[] {
   const { entitiesByUri, agentUri, subGraph, limit = 200 } = opts;
   const out: ActivityItem[] = [];
-  for (const [rootUri, attrs] of attributions) {
-    const entity = entitiesByUri.get(rootUri);
-    for (const attr of attrs) {
-      if (agentUri && attr.agent !== agentUri) continue;
-      if (subGraph && attr.subGraph !== subGraph) continue;
-      const at = parseDateLike(attr.publishedAt);
-      if (!at) continue;
-      out.push({
-        // When the entity isn't in `entitiesByUri` (data race, or a
-        // promotion of a root that was already published past SWM
-        // before this hook ran), synthesise a stub so the row still
-        // renders cleanly. `humanizeLabel` would be ideal here but
-        // pulling that dep would couple this file to project helpers;
-        // a URI-tail label is good enough for the Overview row.
-        entity: entity ?? syntheticEntityStub(rootUri),
-        at,
-        // Author on a `'promoted'` row is the *promoter* (the agent
-        // who moved this entity into SWM), not the original `prov:
-        // wasAttributedTo` author. Different events, different agents.
-        authorUri: attr.agent,
-        // Promotion is intentionally not a "typed activity" — clears
-        // the `typeIri` filter contract: typed-only callers won't see
-        // promotion rows. Renderer leans on `event === 'promoted'`.
-        kindUri: null,
-        subGraph: attr.subGraph ?? null,
-        // Trust layer is `shared` by construction — the entity has
-        // just landed in SWM. Even if the entity object isn't loaded
-        // yet, the row is about the SWM transition.
-        layer: 'shared',
-        event: 'promoted',
-      });
-    }
+  for (const evt of events) {
+    if (agentUri && evt.agent !== agentUri) continue;
+    if (subGraph && evt.subGraph !== subGraph) continue;
+    const at = parseDateLike(evt.publishedAt);
+    if (!at) continue;
+    const entity = entitiesByUri.get(evt.rootUri);
+    const resolved = entity != null;
+    out.push({
+      // Per-op id (Code1) — keys off the operation URI so two
+      // re-promotions of the same (root, agent) produce two distinct
+      // keys (different opUri) and React reconciles them correctly.
+      id: buildActivityId('promoted', evt.opUri, at),
+      // When the entity isn't in `entitiesByUri` (data race, or a
+      // promotion of a root that was already published past SWM
+      // before this hook ran), synthesise a stub so the row still
+      // renders cleanly. A URI-tail label is good enough for the row.
+      entity: entity ?? syntheticEntityStub(evt.rootUri),
+      at,
+      // Author on a `'promoted'` row is the *promoter* (the agent
+      // who moved this entity into SWM), not the original `prov:
+      // wasAttributedTo` author. Different events, different agents.
+      authorUri: evt.agent,
+      // Promotion is intentionally not a "typed activity" — clears
+      // the `typeIri` filter contract: typed-only callers won't see
+      // promotion rows. Renderer leans on `event === 'promoted'`.
+      kindUri: null,
+      subGraph: evt.subGraph ?? null,
+      // Trust layer is `shared` by construction — the entity has
+      // just landed in SWM. Even if the entity object isn't loaded
+      // yet, the row is about the SWM transition.
+      layer: 'shared',
+      event: 'promoted',
+      // Code3 — stub rows can't navigate to a detail view that
+      // ProjectView would immediately clear. Render them as static
+      // text instead of an interactive button.
+      clickable: resolved,
+    });
   }
   out.sort((a, b) => {
     if (a.at && b.at) return b.at.getTime() - a.at.getTime();
@@ -387,9 +461,14 @@ function syntheticEntityStub(uri: string): MemoryEntity {
 }
 
 export interface UseProjectActivityEventsOptions extends UseProjectActivityOptions {
-  /** SWM attribution map from `useSwmAttributions`. When omitted the
-   *  joiner reduces to plain `useProjectActivity(entities, opts)`. */
-  swmAttributions?: Map<string, PromotionAttribution[]>;
+  /**
+   * Raw per-operation event log from `useSwmAttributions.events`.
+   * When omitted (or empty) the joiner reduces to plain
+   * `useProjectActivity(entities, opts)`. Code2 (PR #656) — we now
+   * consume the raw event list, not the deduped attribution map, so
+   * re-promotions surface as distinct rows.
+   */
+  swmEvents?: ReadonlyArray<PromotionAttribution>;
 }
 
 /**
@@ -397,23 +476,23 @@ export interface UseProjectActivityEventsOptions extends UseProjectActivityOptio
  * Existing callers (AgentProfileView) keep using `useProjectActivity`
  * directly when they don't want promotion rows polluting a per-agent
  * typed-activity slice. The Overview "Recent activity" feed swaps to
- * this one and feeds in the live `useSwmAttributions` result.
+ * this one and feeds in the live `useSwmAttributions().events` result.
  */
 export function useProjectActivityEvents(
   entityList: MemoryEntity[],
   opts: UseProjectActivityEventsOptions = {},
 ): ActivityItem[] {
-  const { swmAttributions, ...baseOpts } = opts;
+  const { swmEvents, ...baseOpts } = opts;
   const base = useProjectActivity(entityList, baseOpts);
   return useMemo(() => {
     // typeIri pins the feed to a typed-activity kind (Decision/Task/
     // PR/etc.) — promotion rows have no `kindUri` so they're dropped
     // wholesale, matching how the same filter drops `'added'` rows.
     if (opts.typeIri) return base;
-    if (!swmAttributions || swmAttributions.size === 0) return base;
+    if (!swmEvents || swmEvents.length === 0) return base;
     const entitiesByUri = new Map<string, MemoryEntity>();
     for (const e of entityList) entitiesByUri.set(e.uri, e);
-    const promotions = buildPromotionEvents(swmAttributions, {
+    const promotions = buildPromotionEvents(swmEvents, {
       entitiesByUri,
       agentUri: baseOpts.agentUri,
       subGraph: baseOpts.subGraph,
@@ -429,7 +508,7 @@ export function useProjectActivityEvents(
     });
     const cap = baseOpts.limit ?? 200;
     return merged.slice(0, cap);
-  }, [base, swmAttributions, entityList, baseOpts.agentUri, baseOpts.subGraph, baseOpts.limit, opts.typeIri]);
+  }, [base, swmEvents, entityList, baseOpts.agentUri, baseOpts.subGraph, baseOpts.limit, opts.typeIri]);
 }
 
 /** "2h ago" / "3d ago" / "Apr 18" — compact relative-time label. */

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -271,6 +271,167 @@ export function bucketActivity(items: ActivityItem[], now: Date = new Date()): A
   return order.map(k => buckets[k]);
 }
 
+// ─── Promotion events (N6 part 2) ────────────────────────────────
+//
+// `useSwmAttributions` already queries the project's `_shared_memory_meta`
+// partitions and produces a `Map<rootUri, AgentAttribution[]>` carrying
+// `(agent, opUri, publishedAt, subGraph)` per (root, agent) pair. We
+// re-use that data here — no new SPARQL — and project each attribution
+// into a `'promoted'` activity row so the Overview feed shows who
+// promoted what when. Each `AgentAttribution` becomes one row; an
+// entity promoted by two distinct agents produces two rows (which
+// reads as the conflict signal the SWM legend already badges).
+//
+// Kept as a small pure helper that takes data + an entity lookup so
+// the joiner is testable without a network query — the React hook
+// below just wires the live `useSwmAttributions` result in.
+
+/**
+ * Minimal shape of a SWM agent-attribution entry, mirrored from
+ * `useSwmAttributions.AgentAttribution`. Re-declared here as a
+ * structural subset so this file doesn't have to import the SWM hook
+ * type and can be exercised by tests with plain object literals.
+ */
+export interface PromotionAttribution {
+  agent: string;
+  opUri: string;
+  publishedAt: string;
+  subGraph?: string;
+}
+
+export interface AppendPromotionEventsOptions {
+  /** Per-URI entity lookup. Used to recover entity label + trustLevel
+   *  for the promoted root. URIs that don't resolve still produce a row
+   *  with a `null`-ish entity stub so the feed never silently drops a
+   *  promotion just because the root URI hasn't loaded yet. */
+  entitiesByUri: Map<string, MemoryEntity>;
+  /** Optional: filter to a single agent (the promoter). */
+  agentUri?: string;
+  /** Optional: filter to a single sub-graph slug. */
+  subGraph?: string;
+  /** Cap on rows returned. Promotion rows are interleaved with
+   *  entity-derived rows by the joiner hook below; the joiner enforces
+   *  the *combined* cap, not a per-stream cap. */
+  limit?: number;
+}
+
+/**
+ * Pure helper — turns a SWM attribution map into a flat list of
+ * `'promoted'` activity items, ready to merge with the entity-derived
+ * feed. Skips rows whose timestamp can't be parsed (the meta graph
+ * encodes them as ISO strings — failures are not expected in practice
+ * but we'd rather drop than render an "Invalid Date" row).
+ */
+export function buildPromotionEvents(
+  attributions: Map<string, PromotionAttribution[]>,
+  opts: AppendPromotionEventsOptions,
+): ActivityItem[] {
+  const { entitiesByUri, agentUri, subGraph, limit = 200 } = opts;
+  const out: ActivityItem[] = [];
+  for (const [rootUri, attrs] of attributions) {
+    const entity = entitiesByUri.get(rootUri);
+    for (const attr of attrs) {
+      if (agentUri && attr.agent !== agentUri) continue;
+      if (subGraph && attr.subGraph !== subGraph) continue;
+      const at = parseDateLike(attr.publishedAt);
+      if (!at) continue;
+      out.push({
+        // When the entity isn't in `entitiesByUri` (data race, or a
+        // promotion of a root that was already published past SWM
+        // before this hook ran), synthesise a stub so the row still
+        // renders cleanly. `humanizeLabel` would be ideal here but
+        // pulling that dep would couple this file to project helpers;
+        // a URI-tail label is good enough for the Overview row.
+        entity: entity ?? syntheticEntityStub(rootUri),
+        at,
+        // Author on a `'promoted'` row is the *promoter* (the agent
+        // who moved this entity into SWM), not the original `prov:
+        // wasAttributedTo` author. Different events, different agents.
+        authorUri: attr.agent,
+        // Promotion is intentionally not a "typed activity" — clears
+        // the `typeIri` filter contract: typed-only callers won't see
+        // promotion rows. Renderer leans on `event === 'promoted'`.
+        kindUri: null,
+        subGraph: attr.subGraph ?? null,
+        // Trust layer is `shared` by construction — the entity has
+        // just landed in SWM. Even if the entity object isn't loaded
+        // yet, the row is about the SWM transition.
+        layer: 'shared',
+        event: 'promoted',
+      });
+    }
+  }
+  out.sort((a, b) => {
+    if (a.at && b.at) return b.at.getTime() - a.at.getTime();
+    if (a.at && !b.at) return -1;
+    if (!a.at && b.at) return 1;
+    return a.entity.label.localeCompare(b.entity.label);
+  });
+  return out.slice(0, limit);
+}
+
+function syntheticEntityStub(uri: string): MemoryEntity {
+  // URI-tail label so the row reads ("promoted <tail>") even when
+  // the underlying entity hasn't loaded into `entitiesByUri` yet.
+  const tail = uri.split(/[#/]/).filter(Boolean).pop() ?? uri;
+  return {
+    uri,
+    label: tail,
+    types: [],
+    trustLevel: 'shared',
+    layers: new Set(['shared']),
+    subGraphs: new Set(),
+    properties: new Map(),
+    connections: [],
+  };
+}
+
+export interface UseProjectActivityEventsOptions extends UseProjectActivityOptions {
+  /** SWM attribution map from `useSwmAttributions`. When omitted the
+   *  joiner reduces to plain `useProjectActivity(entities, opts)`. */
+  swmAttributions?: Map<string, PromotionAttribution[]>;
+}
+
+/**
+ * Joiner hook — `useProjectActivity` plus the SWM promotion stream.
+ * Existing callers (AgentProfileView) keep using `useProjectActivity`
+ * directly when they don't want promotion rows polluting a per-agent
+ * typed-activity slice. The Overview "Recent activity" feed swaps to
+ * this one and feeds in the live `useSwmAttributions` result.
+ */
+export function useProjectActivityEvents(
+  entityList: MemoryEntity[],
+  opts: UseProjectActivityEventsOptions = {},
+): ActivityItem[] {
+  const { swmAttributions, ...baseOpts } = opts;
+  const base = useProjectActivity(entityList, baseOpts);
+  return useMemo(() => {
+    // typeIri pins the feed to a typed-activity kind (Decision/Task/
+    // PR/etc.) — promotion rows have no `kindUri` so they're dropped
+    // wholesale, matching how the same filter drops `'added'` rows.
+    if (opts.typeIri) return base;
+    if (!swmAttributions || swmAttributions.size === 0) return base;
+    const entitiesByUri = new Map<string, MemoryEntity>();
+    for (const e of entityList) entitiesByUri.set(e.uri, e);
+    const promotions = buildPromotionEvents(swmAttributions, {
+      entitiesByUri,
+      agentUri: baseOpts.agentUri,
+      subGraph: baseOpts.subGraph,
+      // No per-stream limit — apply the combined cap below.
+      limit: Number.POSITIVE_INFINITY,
+    });
+    const merged = [...base, ...promotions];
+    merged.sort((a, b) => {
+      if (a.at && b.at) return b.at.getTime() - a.at.getTime();
+      if (a.at && !b.at) return -1;
+      if (!a.at && b.at) return 1;
+      return a.entity.label.localeCompare(b.entity.label);
+    });
+    const cap = baseOpts.limit ?? 200;
+    return merged.slice(0, cap);
+  }, [base, swmAttributions, entityList, baseOpts.agentUri, baseOpts.subGraph, baseOpts.limit, opts.typeIri]);
+}
+
 /** "2h ago" / "3d ago" / "Apr 18" — compact relative-time label. */
 export function relativeTime(d: Date | null, now: Date = new Date()): string {
   if (!d) return '—';

--- a/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
+++ b/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
@@ -152,7 +152,7 @@ function subGraphFromMetaGraphUri(gUri: string, cgId: string): string | undefine
   return seg;
 }
 
-function buildAttributionsQuery(cgId: string): string {
+export function buildAttributionsQuery(cgId: string): string {
   const cgUri = `did:dkg:context-graph:${cgId}`;
   return `PREFIX dkg: <http://dkg.io/ontology/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
@@ -167,7 +167,7 @@ SELECT ?op ?root ?agent ?publishedAt ?g WHERE {
     STRSTARTS(STR(?g), "${cgUri}") &&
     CONTAINS(STR(?g), "_shared_memory_meta")
   )
-} ORDER BY ?publishedAt LIMIT 5000`;
+} ORDER BY DESC(?publishedAt) LIMIT 5000`;
 }
 
 /** Stable hash → palette index so a given agent always keeps the same
@@ -232,7 +232,16 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
           return res.json();
         })();
         const data = await Promise.race([request, timeout]);
-        const rows: any[] = data?.result?.bindings ?? [];
+        // Codex Code5 (PR #656) — the SPARQL query orders DESC and
+        // caps at 5000 so a project with more than 5000 promotion ops
+        // returns the *newest* 5000 (the activity feed needs recent
+        // events). The downstream legend dedup is order-sensitive
+        // (first-seen wins), so we reverse here to ASC before folding
+        // — keeps the legend semantics (oldest promotion wins per
+        // (root, agent)) identical to the pre-DESC behaviour for
+        // projects with <5000 ops, and stays meaningful for larger ones.
+        const rawRows: any[] = data?.result?.bindings ?? [];
+        const rows = rawRows.slice().reverse();
 
         const attrMap = new Map<string, AgentAttribution[]>();
         const agentTotals = new Map<string, Set<string>>();

--- a/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
+++ b/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
@@ -96,9 +96,12 @@ export interface SwmAttributionsResult {
    * Raw, undeduplicated per-operation event list. One entry per SPARQL
    * binding so re-promotions (same agent promoting the same root again
    * with a different op id / timestamp) are preserved. Sorted by
-   * `publishedAt` ASC — chronological order matches the source query's
-   * ORDER BY clause. Used by the project activity feed to surface every
-   * promotion as its own row.
+   * `publishedAt` ASC. R2-Local-3 (PR #656) — the source query is now
+   * `ORDER BY DESC` + `LIMIT 5000` (Code5; keeps the newest 5000 ops
+   * within the cap), but the hook reverses client-side before exposing
+   * this array so the legend dedup's first-seen-wins semantics still
+   * pick the oldest promotion per `(root, agent)`. The activity-feed
+   * consumer re-sorts newest-first, so it's order-agnostic on input.
    */
   events: WorkspaceOperationEvent[];
   /** Stable colour + label per agent, for legends and per-URI tinting. */

--- a/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
+++ b/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
@@ -40,6 +40,28 @@ export interface AgentAttribution {
   subGraph?: string;
 }
 
+/**
+ * Raw `dkg:WorkspaceOperation` row from `_shared_memory_meta`, *not*
+ * deduplicated by `(root, agent)`. One entry per SPARQL binding —
+ * preserves re-promotions (same agent promoting the same root twice
+ * with different op ids / timestamps) and is the substrate the activity
+ * feed needs for an accurate timeline.
+ *
+ * Codex Code2 (PR #656) caught the bug: the deduped `attributions` map
+ * is fine for the SWM-graph legend (where collapsing repeated
+ * promotions to a single agent per root is what you want) but wrong
+ * for the activity feed, where each promotion should be its own event.
+ * We compute both shapes from the same SPARQL response so callers pick
+ * the shape that matches their semantics.
+ */
+export interface WorkspaceOperationEvent {
+  opUri: string;
+  rootUri: string;
+  agent: string;
+  publishedAt: string;
+  subGraph?: string;
+}
+
 export interface AgentPaletteEntry {
   agent: string;
   color: string;
@@ -50,8 +72,18 @@ export interface AgentPaletteEntry {
 
 export interface SwmAttributionsResult {
   /** Attribution map keyed by entity URI. Callers pass these into the
-   *  graph engine via a derived `nodeColors` record. */
+   *  graph engine via a derived `nodeColors` record. Deduplicated by
+   *  `(root, agent)` — at most one entry per pair. */
   attributions: Map<string, AgentAttribution[]>;
+  /**
+   * Raw, undeduplicated per-operation event list. One entry per SPARQL
+   * binding so re-promotions (same agent promoting the same root again
+   * with a different op id / timestamp) are preserved. Sorted by
+   * `publishedAt` ASC — chronological order matches the source query's
+   * ORDER BY clause. Used by the project activity feed to surface every
+   * promotion as its own row.
+   */
+  events: WorkspaceOperationEvent[];
   /** Stable colour + label per agent, for legends and per-URI tinting. */
   palette: AgentPaletteEntry[];
   /** Per-URI override map ready to drop into RdfGraph's `style.nodeColors`. */
@@ -150,6 +182,7 @@ function paletteIndex(agent: string): number {
 
 export function useSwmAttributions(contextGraphId: string | undefined): SwmAttributionsResult {
   const [attributions, setAttributions] = useState<Map<string, AgentAttribution[]>>(new Map());
+  const [events, setEvents] = useState<WorkspaceOperationEvent[]>([]);
   const [palette, setPalette] = useState<AgentPaletteEntry[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -160,6 +193,7 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
     if (!contextGraphId) {
       versionRef.current += 1;
       setAttributions(new Map());
+      setEvents([]);
       setPalette([]);
       setLoading(false);
       setResolvedContextGraphId(undefined);
@@ -202,6 +236,10 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
 
         const attrMap = new Map<string, AgentAttribution[]>();
         const agentTotals = new Map<string, Set<string>>();
+        // Raw per-op event log (no dedup) — separate from `attrMap`
+        // because the activity feed needs every promotion as its own
+        // row, while the legend wants one entry per `(root, agent)`.
+        const eventLog: WorkspaceOperationEvent[] = [];
 
         for (const row of rows) {
           const op = bv(row.op);
@@ -212,6 +250,10 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
           if (!op || !root || !agentRaw || !ts) continue;
           const agent = canonicaliseAgent(agentRaw);
           const subGraph = g ? subGraphFromMetaGraphUri(g, contextGraphId) : undefined;
+
+          // Raw event always recorded — preserves re-promotions
+          // (same `(root, agent)` with a different `opUri` or `ts`).
+          eventLog.push({ opUri: op, rootUri: root, agent, publishedAt: ts, subGraph });
 
           const entry: AgentAttribution = { agent, opUri: op, publishedAt: ts, subGraph };
           const list = attrMap.get(root);
@@ -240,12 +282,14 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
 
         if (!isCurrent()) return;
         setAttributions(attrMap);
+        setEvents(eventLog);
         setPalette(paletteEntries);
         setResolvedContextGraphId(contextGraphId);
       } catch (err: any) {
         if (!isCurrent()) return;
         setError(err?.message ?? 'Failed to load SWM attributions');
         setAttributions(new Map());
+        setEvents([]);
         setPalette([]);
         setResolvedContextGraphId(contextGraphId);
       } finally {
@@ -284,5 +328,5 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
 
   const attributionPending = Boolean(contextGraphId && (loading || resolvedContextGraphId !== contextGraphId));
 
-  return { attributions, palette, nodeColors, conflicts, loading: attributionPending, error };
+  return { attributions, events, palette, nodeColors, conflicts, loading: attributionPending, error };
 }

--- a/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
+++ b/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
@@ -71,6 +71,23 @@ export interface AgentPaletteEntry {
 }
 
 export interface SwmAttributionsResult {
+  /**
+   * Context graph id whose SPARQL response produced the rest of the
+   * fields in this result. `undefined` until the first query for the
+   * current `contextGraphId` resolves; lags behind the caller's
+   * `contextGraphId` during a project switch — the in-flight result is
+   * still for the *previous* graph until the new query lands.
+   *
+   * Codex Code7 (PR #656) — exposing this lets page-level consumers
+   * (e.g. `ProjectView` feeding the Overview activity feed) gate
+   * downstream rendering on `resultContextGraphId === contextGraphId`
+   * so users don't briefly see promotion rows from the previous
+   * project after switching context graphs. The SWM graph internally
+   * doesn't gate (momentary stale tints are less misleading than
+   * stale activity-feed rows, and it re-renders cleanly once the new
+   * attribution lands).
+   */
+  resultContextGraphId: string | undefined;
   /** Attribution map keyed by entity URI. Callers pass these into the
    *  graph engine via a derived `nodeColors` record. Deduplicated by
    *  `(root, agent)` — at most one entry per pair. */
@@ -337,5 +354,14 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
 
   const attributionPending = Boolean(contextGraphId && (loading || resolvedContextGraphId !== contextGraphId));
 
-  return { attributions, events, palette, nodeColors, conflicts, loading: attributionPending, error };
+  return {
+    resultContextGraphId: resolvedContextGraphId,
+    attributions,
+    events,
+    palette,
+    nodeColors,
+    conflicts,
+    loading: attributionPending,
+    error,
+  };
 }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6878,6 +6878,15 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   border-top: 1px solid var(--border-subtle);
   border-radius: 0;
 }
+/* Local-2 (PR #656) — non-clickable stub rows for promotion events
+ * whose root isn't loaded in `rawMemory.entities`. Same row shell so
+ * the timeline stays visually coherent, but the affordance is honest:
+ * default cursor, no hover surface, slight opacity to read as inert. */
+.v10-activity-feed-row-static {
+  cursor: default;
+  opacity: 0.7;
+}
+.v10-activity-feed-row-static:hover { background: none; }
 .v10-activity-feed-layer {
   font-size: 14px; line-height: 1;
   justify-self: center;

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -467,7 +467,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             title="Recent activity"
             limit={40}
             includeUndated={false}
-            emptyHint="Once agents start proposing decisions or tasks they'll show up here as a live feed."
+            emptyHint="Once you import knowledge or agents start proposing decisions or tasks they'll show up here as a live feed."
             className="v10-overview-activity"
           />
         </>

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -238,7 +238,18 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // SWM graph's agent-tint legend; we re-use its `attributions` map
   // here rather than re-querying `_shared_memory_meta`. Hook is
   // already in production for the SWM Graph subtab so it's cached.
-  const swmAttributionsResult = useSwmAttributions(contextGraphId);
+  //
+  // Local-3 (PR #656) — gate the hoist on a view that actually
+  // consumes the result. Pre-fix the page-level call fired
+  // unconditionally for every active view (graph-overview, query,
+  // WM/VM detail, sub-graph pages — none of which read it), running
+  // a 5000-row SPARQL for nothing. Active consumers today are
+  // (a) the Overview activity feed and (b) the SWM-tab layer graph.
+  // The hook already short-circuits cleanly on `undefined` (state
+  // resets, no fetch).
+  const swmAttributionNeeded =
+    !activeSubGraph && !selectedUri && (activeLayer === 'overview' || activeLayer === 'swm');
+  const swmAttributionsResult = useSwmAttributions(swmAttributionNeeded ? contextGraphId : undefined);
   // Codex Code7 (PR #656) — the hook returns its previous-graph
   // result during the transition window between context-graph switch
   // and the new SPARQL resolving. Gate `events` on the result being

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -470,7 +470,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           )}
           <ActivityFeed
             entities={rawMemory.entityList}
-            swmAttributions={swmAttributionsResult.attributions}
+            swmEvents={swmAttributionsResult.events}
             onSelectEntity={handleOverviewActivityNavigate}
             title="Recent activity"
             limit={40}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -239,6 +239,16 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // here rather than re-querying `_shared_memory_meta`. Hook is
   // already in production for the SWM Graph subtab so it's cached.
   const swmAttributionsResult = useSwmAttributions(contextGraphId);
+  // Codex Code7 (PR #656) — the hook returns its previous-graph
+  // result during the transition window between context-graph switch
+  // and the new SPARQL resolving. Gate `events` on the result being
+  // for the *current* graph so the Overview doesn't briefly show
+  // promotion rows from the previous project. The SWM graph itself
+  // tolerates the momentary stale tint (it re-renders cleanly once
+  // the new attribution lands), so we don't gate there.
+  const overviewSwmEvents = swmAttributionsResult.resultContextGraphId === contextGraphId
+    ? swmAttributionsResult.events
+    : undefined;
 
   const refreshParticipants = useCallback(() => {
     const targetId = cg?.id;
@@ -470,7 +480,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           )}
           <ActivityFeed
             entities={rawMemory.entityList}
-            swmEvents={swmAttributionsResult.events}
+            swmEvents={overviewSwmEvents}
             onSelectEntity={handleOverviewActivityNavigate}
             title="Recent activity"
             limit={40}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -514,6 +514,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             contextGraphId={contextGraphId}
             activeTab={layerContentTabs[activeLayer]}
             onTabChange={tab => handleLayerTabChange(activeLayer, tab)}
+            swmAttribution={swmAttributionsResult}
           />
         </>
       )}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -12,6 +12,7 @@ import {
 import { useProjectProfile, ProjectProfileContext } from '../hooks/useProjectProfile.js';
 import { useAgents, AgentsContext } from '../hooks/useAgents.js';
 import { useCurrentAgent } from '../hooks/useCurrentAgent.js';
+import { useSwmAttributions } from '../hooks/useSwmAttributions.js';
 import { ActivityFeed } from '../components/ActivityFeed.js';
 import { SubGraphBar } from '../components/SubGraphBar.js';
 import { CONTEXT_GRAPH_PRIMER_TAB } from '../lib/contextGraphPrimer.js';
@@ -232,6 +233,12 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   );
 
   const rawMemory = useMemoryEntities(contextGraphId);
+  // N6 part 2 — feed promotion (WM→SWM) events into the Overview
+  // ActivityFeed. `useSwmAttributions` is the existing source for the
+  // SWM graph's agent-tint legend; we re-use its `attributions` map
+  // here rather than re-querying `_shared_memory_meta`. Hook is
+  // already in production for the SWM Graph subtab so it's cached.
+  const swmAttributionsResult = useSwmAttributions(contextGraphId);
 
   const refreshParticipants = useCallback(() => {
     const targetId = cg?.id;
@@ -463,6 +470,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           )}
           <ActivityFeed
             entities={rawMemory.entityList}
+            swmAttributions={swmAttributionsResult.attributions}
             onSelectEntity={handleOverviewActivityNavigate}
             title="Recent activity"
             limit={40}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -17,7 +17,7 @@ import { ActivityFeed } from '../components/ActivityFeed.js';
 import { SubGraphBar } from '../components/SubGraphBar.js';
 import { CONTEXT_GRAPH_PRIMER_TAB } from '../lib/contextGraphPrimer.js';
 import { useTabsStore } from '../stores/tabs.js';
-import type { LayerView, LayerContentTab, SubGraphTab } from './project/helpers.js';
+import { shouldFetchSwmAttribution, type LayerView, type LayerContentTab, type SubGraphTab } from './project/helpers.js';
 import {
   ProjectHeaderStrip,
   LayerSwitcher,
@@ -247,8 +247,16 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // (a) the Overview activity feed and (b) the SWM-tab layer graph.
   // The hook already short-circuits cleanly on `undefined` (state
   // resets, no fetch).
-  const swmAttributionNeeded =
-    !activeSubGraph && !selectedUri && (activeLayer === 'overview' || activeLayer === 'swm');
+  //
+  // R2-Local-1 (PR #656) — do NOT gate on `selectedUri`. Opening
+  // an entity detail overlays the same view; toggling `undefined`
+  // here would clear the hook's cached events, then on detail-close
+  // re-fetch the 5000-row SPARQL — during the re-fetch the Code7
+  // discriminator (`resultContextGraphId !== contextGraphId`) would
+  // suppress `overviewSwmEvents`, making promotion rows visibly
+  // flicker out on every detail round-trip. Sub-graph navigation is
+  // a real route change so we still gate on `!activeSubGraph`.
+  const swmAttributionNeeded = shouldFetchSwmAttribution({ activeLayer, activeSubGraph });
   const swmAttributionsResult = useSwmAttributions(swmAttributionNeeded ? contextGraphId : undefined);
   // Codex Code7 (PR #656) — the hook returns its previous-graph
   // result during the transition window between context-graph switch

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -44,6 +44,7 @@ import {
 import {
   useSwmAttributions,
   type AgentPaletteEntry,
+  type SwmAttributionsResult,
 } from '../../hooks/useSwmAttributions.js';
 import {
   TRUST_COLORS, TYPE_LABELS,
@@ -885,6 +886,7 @@ export function LayerGraphPanel({
   trustLegendActiveLayer,
   title: titleOverride,
   scopeEntities,
+  swmAttribution,
 }: {
   layer: 'wm' | 'swm' | 'vm';
   triples: Triple[];
@@ -901,6 +903,17 @@ export function LayerGraphPanel({
   // sub-graph filter). Without this, those entities silently disappear
   // from the Graph tab even though the Entities tab shows them.
   scopeEntities?: ReadonlyArray<{ uri: string; label: string }>;
+  /**
+   * Codex Code6 (PR #656) — when the parent already calls
+   * `useSwmAttributions` (e.g. `ProjectView` shares one result between
+   * the Overview activity feed and the SWM graph), it can pass that
+   * result in here to suppress the internal hook call. Without this,
+   * the SPARQL fires twice on every SWM-tab render. When omitted, the
+   * panel falls back to the local hook (the long-standing behaviour
+   * preserved for all other callsites — `SubGraphDetailView`,
+   * `EntityDetailView`, tests).
+   */
+  swmAttribution?: SwmAttributionsResult;
 }) {
   const { title: layerTitle } = LAYER_CONFIG[layer];
   const title = titleOverride ?? layerTitle;
@@ -932,7 +945,16 @@ export function LayerGraphPanel({
   // promoted it, so the graph reads as "who proposed what". Also surfaces
   // conflict nodes (multi-agent disagreement) and an agent palette for the
   // legend. No-op on WM / VM.
-  const swmAttr = useSwmAttributions(layer === 'swm' && contextGraphId ? contextGraphId : undefined);
+  //
+  // Codex Code6 (PR #656) — when the parent passes `swmAttribution`
+  // it has already paid for the SPARQL (e.g. `ProjectView` shares the
+  // result with the Overview activity feed). Skip the internal hook's
+  // network call by passing `undefined`, then read from the prop. The
+  // hook still runs (rules of hooks) but short-circuits to empty state.
+  const localSwmAttr = useSwmAttributions(
+    layer === 'swm' && contextGraphId && !swmAttribution ? contextGraphId : undefined,
+  );
+  const swmAttr = swmAttribution ?? localSwmAttr;
 
   const uniqueTriples = useMemo(() => {
     const seen = new Set<string>();
@@ -1176,6 +1198,7 @@ export function MemoryStrip({
   onExpandedLayerChange,
   expandTabs,
   onExpandTabChange,
+  swmAttribution,
 }: {
   memory: ReturnType<typeof useMemoryEntities>;
   onSwitchLayer: (layer: LayerView) => void;
@@ -1186,6 +1209,9 @@ export function MemoryStrip({
   onExpandedLayerChange?: (layer: MemoryStripLayer | null) => void;
   expandTabs?: Record<MemoryStripLayer, LayerContentTab>;
   onExpandTabChange?: (layer: MemoryStripLayer, tab: LayerContentTab) => void;
+  /** Codex Code6 (PR #656) — pass-through of the parent's shared
+   *  SWM attribution result. */
+  swmAttribution?: SwmAttributionsResult;
 }) {
   const [localExpanded, setLocalExpanded] = useState<MemoryStripLayer | null>(null);
   const [localExpandTabs, setLocalExpandTabs] = useState<Record<MemoryStripLayer, LayerContentTab>>({
@@ -1304,6 +1330,7 @@ export function MemoryStrip({
                   onSelectEntity={onSelectEntity}
                   onNodeClick={onNodeClick}
                   onSwitchLayer={() => onSwitchLayer(layer.viewLayer)}
+                  swmAttribution={layer.key === 'swm' ? swmAttribution : undefined}
                 />
               )}
             </div>
@@ -1326,6 +1353,7 @@ export function MemoryStripExpanded({
   onSelectEntity,
   onNodeClick,
   onSwitchLayer,
+  swmAttribution,
 }: {
   layerKey: 'wm' | 'swm' | 'vm';
   entities: MemoryEntity[];
@@ -1337,6 +1365,10 @@ export function MemoryStripExpanded({
   onSelectEntity: (uri: string) => void;
   onNodeClick?: (node: any) => void;
   onSwitchLayer: () => void;
+  /** Codex Code6 (PR #656) — pass-through of the parent's shared
+   *  SWM attribution result so the SWM-tab graph reuses the network
+   *  call ProjectView already made for the Overview feed. */
+  swmAttribution?: SwmAttributionsResult;
 }) {
   const layerTriples = useLayerTriples(memory, layerKey);
   // No wrapper here: `LayerGraphPanel` already injects `trustLayer:
@@ -1356,6 +1388,7 @@ export function MemoryStripExpanded({
       onTabChange={onTabChange}
       onSelectEntity={onSelectEntity}
       onNodeClick={onNodeClick}
+      swmAttribution={swmAttribution}
       footer={
         <div className="v10-layer-expand-footer">
           <button
@@ -1707,6 +1740,7 @@ export function LayerContent({
   onSelectEntity,
   onNodeClick,
   footer,
+  swmAttribution,
 }: {
   layer: 'wm' | 'swm' | 'vm';
   entities: MemoryEntity[];
@@ -1719,6 +1753,11 @@ export function LayerContent({
   onSelectEntity: (uri: string) => void;
   onNodeClick?: (node: any) => void;
   footer?: React.ReactNode;
+  /** Codex Code6 (PR #656) — optional shared SWM attribution result
+   *  hoisted from a common parent (`ProjectView`). Passes straight
+   *  through to `LayerGraphPanel` to avoid a duplicate SPARQL query
+   *  when the same data is already loaded for the Overview feed. */
+  swmAttribution?: SwmAttributionsResult;
 }) {
   const config = LAYER_CONFIG[layer];
   const itemsLabel = layerNoun(layer, 2);
@@ -1825,6 +1864,7 @@ export function LayerContent({
             triples={layerTriples}
             onNodeClick={onNodeClick}
             contextGraphId={contextGraphId}
+            swmAttribution={layer === 'swm' ? swmAttribution : undefined}
           />
         </div>
       )}
@@ -2716,6 +2756,7 @@ export function LayerDetailView({
   contextGraphId,
   activeTab,
   onTabChange,
+  swmAttribution,
 }: {
   layer: 'wm' | 'swm' | 'vm';
   memory: ReturnType<typeof useMemoryEntities>;
@@ -2724,6 +2765,9 @@ export function LayerDetailView({
   contextGraphId: string;
   activeTab: LayerContentTab;
   onTabChange: (tab: LayerContentTab) => void;
+  /** Codex Code6 (PR #656) — pass-through of the parent's shared
+   *  SWM attribution result. */
+  swmAttribution?: SwmAttributionsResult;
 }) {
   const config = LAYER_CONFIG[layer];
   // No wrapper here: `LayerGraphPanel` already injects `trustLayer:
@@ -2758,6 +2802,7 @@ export function LayerDetailView({
           onTabChange={onTabChange}
           onSelectEntity={onSelectEntity}
           onNodeClick={onNodeClick}
+          swmAttribution={swmAttribution}
         />
       </div>
     </div>

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -14,6 +14,25 @@ import { memoryGraphLabels } from '../../lib/memoryLabels.js';
 
 export type LayerView = 'overview' | 'graph-overview' | 'query' | 'wm' | 'swm' | 'vm';
 export type LayerContentTab = 'items' | 'assertions' | 'graph' | 'docs';
+
+/**
+ * Whether the SWM attribution SPARQL is worth firing for the current
+ * `ProjectView` route state. True only on views that actually consume
+ * the result — the Overview activity feed and the SWM-layer graph.
+ *
+ * Notably *not* gated on `selectedUri`: opening an entity detail
+ * overlays the same view, and toggling the hook to `undefined` on
+ * detail-open would clear its cached events and force a re-fetch on
+ * detail-close, making promotion rows on the Overview visibly flicker
+ * out during every detail round-trip (R2-Local-1, PR #656).
+ */
+export function shouldFetchSwmAttribution(args: {
+  activeLayer: LayerView;
+  activeSubGraph: string | null;
+}): boolean {
+  if (args.activeSubGraph) return false;
+  return args.activeLayer === 'overview' || args.activeLayer === 'swm';
+}
 export const TRUST_COLORS: Record<TrustLevel, string> = {
   verified: '#22c55e',
   shared: '#f59e0b',

--- a/packages/node-ui/test/project-helpers.test.ts
+++ b/packages/node-ui/test/project-helpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { shouldFetchSwmAttribution } from '../src/ui/views/project/helpers.js';
+
+// R2-Local-1 (PR #656) — pins the predicate that ProjectView uses to
+// decide whether to feed `useSwmAttributions` a real `contextGraphId`
+// or `undefined`. Critical that opening an entity detail does NOT
+// flip the predicate to `false` — the hook would clear its cached
+// events and force a 5000-row re-fetch on detail-close, making the
+// Overview activity feed visibly flicker.
+describe('shouldFetchSwmAttribution — ProjectView gate predicate', () => {
+  it('is true on the Overview tab (activity feed consumer)', () => {
+    expect(shouldFetchSwmAttribution({ activeLayer: 'overview', activeSubGraph: null })).toBe(true);
+  });
+
+  it('is true on the SWM tab (layer graph consumer)', () => {
+    expect(shouldFetchSwmAttribution({ activeLayer: 'swm', activeSubGraph: null })).toBe(true);
+  });
+
+  it('is false on WM / VM / graph-overview / query (no consumer)', () => {
+    expect(shouldFetchSwmAttribution({ activeLayer: 'wm', activeSubGraph: null })).toBe(false);
+    expect(shouldFetchSwmAttribution({ activeLayer: 'vm', activeSubGraph: null })).toBe(false);
+    expect(shouldFetchSwmAttribution({ activeLayer: 'graph-overview', activeSubGraph: null })).toBe(false);
+    expect(shouldFetchSwmAttribution({ activeLayer: 'query', activeSubGraph: null })).toBe(false);
+  });
+
+  it('is false while a sub-graph page is active (real route change)', () => {
+    expect(shouldFetchSwmAttribution({ activeLayer: 'overview', activeSubGraph: 'docs' })).toBe(false);
+    expect(shouldFetchSwmAttribution({ activeLayer: 'swm', activeSubGraph: 'docs' })).toBe(false);
+  });
+
+  // The flicker bug — opening an entity detail overlay must keep the
+  // gate `true` on consumer views so the hook's cached events stay
+  // populated through the detail-open/close round-trip. The predicate
+  // intentionally takes no `selectedUri` arg; this test pins that
+  // omission as an invariant rather than an oversight.
+  it('round-tripping a flicker scenario (Overview → detail → Overview) keeps the gate true (R2-Local-1)', () => {
+    // The caller passes `{ activeLayer, activeSubGraph }` only; the
+    // detail overlay is orthogonal to both. So the predicate cannot
+    // observe a transient `selectedUri` and therefore cannot flip.
+    const overview = { activeLayer: 'overview' as const, activeSubGraph: null };
+    expect(shouldFetchSwmAttribution(overview)).toBe(true);
+    // Simulated detail-open: same args, same answer.
+    expect(shouldFetchSwmAttribution(overview)).toBe(true);
+    // Simulated detail-close: same args, same answer.
+    expect(shouldFetchSwmAttribution(overview)).toBe(true);
+  });
+});

--- a/packages/node-ui/test/use-project-activity.test.ts
+++ b/packages/node-ui/test/use-project-activity.test.ts
@@ -233,3 +233,209 @@ describe('useProjectActivity — N6 event classification', () => {
     expect(items[0].author).toBe('did:dkg:agent:alice');
   });
 });
+
+// ─── N6 part 2 — promotion events ───────────────────────────────
+
+import {
+  useProjectActivityEvents,
+  buildPromotionEvents,
+  type PromotionAttribution,
+} from '../src/ui/hooks/useProjectActivity.js';
+
+function ProbeEvents({
+  entities,
+  opts,
+}: {
+  entities: MemoryEntity[];
+  opts?: Parameters<typeof useProjectActivityEvents>[1];
+}) {
+  const items = useProjectActivityEvents(entities, opts);
+  const dump: CapturedItem[] = items.map(toCaptured);
+  return React.createElement('div', {
+    id: 'probe',
+    'data-items': JSON.stringify(dump),
+  });
+}
+
+describe('useProjectActivityEvents — promotion events (N6 part 2)', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  // The headline win: a CG with a promoted entity surfaces the promote
+  // as a `'promoted'` activity row on the Overview, attributed to the
+  // promoter (not the original author), and tagged to the SWM layer.
+  it('surfaces a SWM promotion as a `promoted` row attributed to the promoter', () => {
+    // The promoted entity exists in the entity list as an `'added'` row
+    // (it has dcterms:created from import); the promote layers on top.
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:doc:promoted', predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+      { subject: 'urn:doc:promoted', predicate: DC_CREATED, object: '"2026-05-20T08:00:00Z"', layer: 'working' },
+      { subject: 'urn:doc:promoted', predicate: PROV_AUTHOR, object: 'did:dkg:agent:alice', layer: 'working' },
+    ];
+    const attributions = new Map<string, PromotionAttribution[]>([
+      ['urn:doc:promoted', [{
+        agent: 'did:dkg:agent:bob',
+        opUri: 'urn:dkg:share:op-1',
+        publishedAt: '2026-05-22T10:00:00Z',
+      }]],
+    ]);
+    act(() => {
+      root.render(React.createElement(ProbeEvents, {
+        entities: entitiesFrom(triples),
+        opts: { swmAttributions: attributions },
+      }));
+    });
+    const items = readItems(container);
+    // Promoted is newer than added (May 22 vs May 20) → first row.
+    expect(items.map(i => i.event)).toEqual(['promoted', 'added']);
+    expect(items[0].author).toBe('did:dkg:agent:bob');
+    expect(items[0].uri).toBe('urn:doc:promoted');
+    expect(items[0].kindUri).toBe(null);
+    // `'added'` row keeps its original-author attribution.
+    expect(items[1].author).toBe('did:dkg:agent:alice');
+  });
+
+  // Two distinct agents promoting the same root → two `'promoted'`
+  // rows (mirrors the SWM-graph conflict signal — different events,
+  // different rows, the timeline shows both promotions).
+  it('emits one row per (root, agent) when two agents promoted the same entity', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:contested', predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+    ];
+    const attributions = new Map<string, PromotionAttribution[]>([
+      ['urn:e:contested', [
+        { agent: 'did:dkg:agent:alice', opUri: 'urn:dkg:share:op-a', publishedAt: '2026-05-22T10:00:00Z' },
+        { agent: 'did:dkg:agent:bob',   opUri: 'urn:dkg:share:op-b', publishedAt: '2026-05-23T10:00:00Z' },
+      ]],
+    ]);
+    act(() => {
+      root.render(React.createElement(ProbeEvents, {
+        entities: entitiesFrom(triples),
+        opts: { swmAttributions: attributions },
+      }));
+    });
+    const items = readItems(container).filter(i => i.event === 'promoted');
+    expect(items).toHaveLength(2);
+    expect(items.map(i => i.author).sort()).toEqual(['did:dkg:agent:alice', 'did:dkg:agent:bob']);
+  });
+
+  // A promotion of a root that isn't (yet) in the entity list still
+  // produces a row — we synthesise an entity stub so the timeline
+  // never silently drops a transition.
+  it('still emits a row when the promoted root is missing from entitiesByUri', () => {
+    const triples: LayeredTriple[] = [];
+    const attributions = new Map<string, PromotionAttribution[]>([
+      ['urn:dkg:thing:orphan-root', [{
+        agent: 'did:dkg:agent:bob',
+        opUri: 'urn:dkg:share:op-1',
+        publishedAt: '2026-05-22T10:00:00Z',
+      }]],
+    ]);
+    act(() => {
+      root.render(React.createElement(ProbeEvents, {
+        entities: entitiesFrom(triples),
+        opts: { swmAttributions: attributions },
+      }));
+    });
+    const items = readItems(container);
+    expect(items).toHaveLength(1);
+    expect(items[0].event).toBe('promoted');
+    expect(items[0].uri).toBe('urn:dkg:thing:orphan-root');
+  });
+
+  // The agentUri filter narrows promotions to a single promoter; this
+  // is how AgentProfileView would surface "what did Bob promote".
+  it('agentUri filter applies to promotion rows (promoter, not original author)', () => {
+    const triples: LayeredTriple[] = [];
+    const attributions = new Map<string, PromotionAttribution[]>([
+      ['urn:e:1', [{ agent: 'did:dkg:agent:alice', opUri: 'urn:op:1', publishedAt: '2026-05-22T10:00:00Z' }]],
+      ['urn:e:2', [{ agent: 'did:dkg:agent:bob',   opUri: 'urn:op:2', publishedAt: '2026-05-23T10:00:00Z' }]],
+    ]);
+    act(() => {
+      root.render(React.createElement(ProbeEvents, {
+        entities: entitiesFrom(triples),
+        opts: { swmAttributions: attributions, agentUri: 'did:dkg:agent:bob' },
+      }));
+    });
+    const items = readItems(container);
+    expect(items.map(i => i.uri)).toEqual(['urn:e:2']);
+    expect(items[0].author).toBe('did:dkg:agent:bob');
+  });
+
+  // typeIri pins the feed to a typed-activity kind — promotion rows
+  // are not typed and so must be dropped wholesale, mirroring how the
+  // same filter drops `'added'` rows.
+  it('typeIri filter drops promotion rows entirely', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:decision:1', predicate: RDF_TYPE, object: TYPE_DECISION, layer: 'working' },
+      { subject: 'urn:decision:1', predicate: DC_CREATED, object: '"2026-05-20T08:00:00Z"', layer: 'working' },
+    ];
+    const attributions = new Map<string, PromotionAttribution[]>([
+      ['urn:e:promoted', [{ agent: 'did:dkg:agent:bob', opUri: 'urn:op:1', publishedAt: '2026-05-22T10:00:00Z' }]],
+    ]);
+    act(() => {
+      root.render(React.createElement(ProbeEvents, {
+        entities: entitiesFrom(triples),
+        opts: { swmAttributions: attributions, typeIri: TYPE_DECISION },
+      }));
+    });
+    const items = readItems(container);
+    expect(items.map(i => i.event)).toEqual(['typed']);
+  });
+
+  // Omitting swmAttributions → joiner reduces to the entity-derived
+  // feed only. Keeps the AgentProfileView path noise-free.
+  it('without swmAttributions returns the same items as useProjectActivity', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:doc:1', predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+      { subject: 'urn:doc:1', predicate: DC_CREATED, object: '"2026-05-22T08:00:00Z"', layer: 'working' },
+    ];
+    act(() => {
+      root.render(React.createElement(ProbeEvents, {
+        entities: entitiesFrom(triples),
+        opts: {},
+      }));
+    });
+    const items = readItems(container);
+    expect(items.map(i => i.event)).toEqual(['added']);
+  });
+});
+
+// Pure-helper tests — `buildPromotionEvents` is a standalone joiner so
+// callers can compose other event streams (later: VM publishes) without
+// the React hook plumbing.
+describe('buildPromotionEvents — pure joiner', () => {
+  it('drops rows with unparseable timestamps rather than emitting Invalid Date', () => {
+    const items = buildPromotionEvents(
+      new Map([['urn:e:1', [{
+        agent: 'did:dkg:agent:bob',
+        opUri: 'urn:op:1',
+        publishedAt: 'not-a-date',
+      }]]]),
+      { entitiesByUri: new Map() },
+    );
+    expect(items).toHaveLength(0);
+  });
+
+  it('sorts newest-first when fed an out-of-order map', () => {
+    const items = buildPromotionEvents(
+      new Map([
+        ['urn:e:older', [{ agent: 'did:dkg:agent:alice', opUri: 'urn:op:a', publishedAt: '2026-05-20T00:00:00Z' }]],
+        ['urn:e:newer', [{ agent: 'did:dkg:agent:bob',   opUri: 'urn:op:b', publishedAt: '2026-05-22T00:00:00Z' }]],
+      ]),
+      { entitiesByUri: new Map() },
+    );
+    expect(items.map(i => i.entity.uri)).toEqual(['urn:e:newer', 'urn:e:older']);
+  });
+});

--- a/packages/node-ui/test/use-project-activity.test.ts
+++ b/packages/node-ui/test/use-project-activity.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import {
   useProjectActivity,
+  buildActivityId,
   type ActivityItem,
   type ActivityEvent,
 } from '../src/ui/hooks/useProjectActivity.js';
@@ -470,5 +471,55 @@ describe('buildPromotionEvents — pure joiner', () => {
       { entitiesByUri: new Map() },
     );
     expect(items.map(i => i.entity.uri)).toEqual(['urn:e:newer', 'urn:e:older']);
+  });
+
+  // Codex Code4 (PR #656) — a single `WorkspaceOperation` that
+  // promotes multiple roots produces one event per root in the raw
+  // event log. The id keyed off `opUri` + `at` alone would collide
+  // between those rows, so `buildActivityId` now includes `rootUri`
+  // for promotion events. Without this fix React reconciliation would
+  // treat both as the same list child and one would silently disappear.
+  it('emits distinct ids for two roots promoted by the same workspace operation (Code4)', () => {
+    const items = buildPromotionEvents(
+      [
+        { rootUri: 'urn:e:root-a', agent: 'did:dkg:agent:bob', opUri: 'urn:op:multi', publishedAt: '2026-05-22T10:00:00Z' },
+        { rootUri: 'urn:e:root-b', agent: 'did:dkg:agent:bob', opUri: 'urn:op:multi', publishedAt: '2026-05-22T10:00:00Z' },
+      ],
+      { entitiesByUri: new Map() },
+    );
+    expect(items).toHaveLength(2);
+    expect(items[0].id).not.toEqual(items[1].id);
+    const uris = items.map(i => i.entity.uri).sort();
+    expect(uris).toEqual(['urn:e:root-a', 'urn:e:root-b']);
+  });
+});
+
+// `buildActivityId` is a pure helper exported alongside the joiner.
+// These unit tests pin its contract — id stability across renders,
+// per-event discrimination (Code1), and per-root distinctness for
+// promotion events (Code4).
+describe('buildActivityId — id contract', () => {
+  it('returns the same id for the same (event, subject, at) tuple', () => {
+    const at = new Date('2026-05-22T10:00:00Z');
+    expect(buildActivityId('added', 'urn:e:1', at)).toBe(buildActivityId('added', 'urn:e:1', at));
+  });
+
+  it('produces distinct ids for the same subject with different event kinds (Code1)', () => {
+    const at = new Date('2026-05-22T10:00:00Z');
+    expect(buildActivityId('added', 'urn:e:1', at)).not.toBe(buildActivityId('promoted', 'urn:e:1', at));
+  });
+
+  it('produces distinct ids for two roots from the same op + timestamp (Code4)', () => {
+    const at = new Date('2026-05-22T10:00:00Z');
+    const idA = buildActivityId('promoted', 'urn:op:multi', at, 'urn:e:root-a');
+    const idB = buildActivityId('promoted', 'urn:op:multi', at, 'urn:e:root-b');
+    expect(idA).not.toBe(idB);
+  });
+
+  it('omits the rootUri segment when it equals the subjectUri (entity-derived rows)', () => {
+    const at = new Date('2026-05-22T10:00:00Z');
+    const withRoot = buildActivityId('added', 'urn:e:1', at, 'urn:e:1');
+    const withoutRoot = buildActivityId('added', 'urn:e:1', at);
+    expect(withRoot).toBe(withoutRoot);
   });
 });

--- a/packages/node-ui/test/use-project-activity.test.ts
+++ b/packages/node-ui/test/use-project-activity.test.ts
@@ -1,0 +1,235 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  useProjectActivity,
+  type ActivityItem,
+  type ActivityEvent,
+} from '../src/ui/hooks/useProjectActivity.js';
+import {
+  buildMemoryEntities,
+  type LayeredTriple,
+  type MemoryEntity,
+} from '../src/ui/hooks/useMemoryEntities.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const DC_CREATED = 'http://purl.org/dc/terms/created';
+const PROV_AUTHOR = 'http://www.w3.org/ns/prov#wasAttributedTo';
+const TYPE_DECISION = 'http://dkg.io/ontology/decisions/Decision';
+const TYPE_TASK = 'http://dkg.io/ontology/tasks/Task';
+const SCHEMA_NAME = 'http://schema.org/name';
+
+interface CapturedItem {
+  uri: string;
+  event: ActivityEvent;
+  kindUri: string | null;
+  at: string | null;
+  author: string | null;
+}
+
+function Probe({
+  entities,
+  opts,
+}: {
+  entities: MemoryEntity[];
+  opts?: Parameters<typeof useProjectActivity>[1];
+}) {
+  const items = useProjectActivity(entities, opts);
+  const dump: CapturedItem[] = items.map(toCaptured);
+  return React.createElement('div', {
+    id: 'probe',
+    'data-items': JSON.stringify(dump),
+  });
+}
+
+function toCaptured(item: ActivityItem): CapturedItem {
+  return {
+    uri: item.entity.uri,
+    event: item.event,
+    kindUri: item.kindUri,
+    at: item.at?.toISOString() ?? null,
+    author: item.authorUri,
+  };
+}
+
+function entitiesFrom(triples: LayeredTriple[]): MemoryEntity[] {
+  return [...buildMemoryEntities(triples).values()];
+}
+
+function readItems(container: HTMLElement): CapturedItem[] {
+  const probe = container.querySelector('#probe');
+  if (!probe) return [];
+  try {
+    return JSON.parse(probe.getAttribute('data-items') ?? '[]');
+  } catch {
+    return [];
+  }
+}
+
+describe('useProjectActivity — N6 event classification', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  // The whole point of N6: an imported entity (timestamp + non-typed
+  // rdf:type) used to be silently dropped by the ACTIVITY_TYPES gate,
+  // so a CG full of imported knowledge read "No activity yet" on the
+  // Overview. It must now surface as an 'added' row.
+  it('surfaces an imported entity as an `added` activity row even without a typed activity kind', () => {
+    const triples: LayeredTriple[] = [
+      // An imported document — has dcterms:created but is not a
+      // Decision/Task/PR/Issue/Commit, so the original feed dropped it.
+      { subject: 'urn:doc:1', predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+      { subject: 'urn:doc:1', predicate: SCHEMA_NAME, object: '"Imported Doc"', layer: 'working' },
+      { subject: 'urn:doc:1', predicate: DC_CREATED, object: '"2026-05-20T10:00:00Z"', layer: 'working' },
+    ];
+    act(() => {
+      root.render(React.createElement(Probe, { entities: entitiesFrom(triples) }));
+    });
+    const items = readItems(container);
+    expect(items).toHaveLength(1);
+    expect(items[0].event).toBe('added');
+    expect(items[0].kindUri).toBe(null);
+    expect(items[0].uri).toBe('urn:doc:1');
+    expect(items[0].at).toBe('2026-05-20T10:00:00.000Z');
+  });
+
+  // The historical decision/task/PR/issue/commit shape must keep
+  // producing `typed` rows — AgentProfileView and the existing feed
+  // empty-state would regress otherwise.
+  it('preserves `typed` rows for entities matching ACTIVITY_TYPES', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:decision:1', predicate: RDF_TYPE, object: TYPE_DECISION, layer: 'working' },
+      { subject: 'urn:decision:1', predicate: SCHEMA_NAME, object: '"Pick a name"', layer: 'working' },
+      { subject: 'urn:decision:1', predicate: DC_CREATED, object: '"2026-05-21T10:00:00Z"', layer: 'working' },
+    ];
+    act(() => {
+      root.render(React.createElement(Probe, { entities: entitiesFrom(triples) }));
+    });
+    const items = readItems(container);
+    expect(items).toHaveLength(1);
+    expect(items[0].event).toBe('typed');
+    expect(items[0].kindUri).toBe(TYPE_DECISION);
+  });
+
+  // Mixed feed: typed rows AND added rows interleave, sorted by
+  // timestamp newest-first.
+  it('interleaves `typed` and `added` rows under one sort axis (newest-first)', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:doc:older',  predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+      { subject: 'urn:doc:older',  predicate: DC_CREATED, object: '"2026-05-20T08:00:00Z"', layer: 'working' },
+      { subject: 'urn:task:newer', predicate: RDF_TYPE, object: TYPE_TASK, layer: 'working' },
+      { subject: 'urn:task:newer', predicate: DC_CREATED, object: '"2026-05-22T08:00:00Z"', layer: 'working' },
+    ];
+    act(() => {
+      root.render(React.createElement(Probe, { entities: entitiesFrom(triples) }));
+    });
+    const items = readItems(container);
+    expect(items.map(i => i.uri)).toEqual(['urn:task:newer', 'urn:doc:older']);
+    expect(items[0].event).toBe('typed');
+    expect(items[1].event).toBe('added');
+  });
+
+  // includeUndated:false (the Overview "recent activity" path) must
+  // still drop entities with no timestamp — N6's broadening is not a
+  // license to swamp the recent feed with un-dated imports.
+  it('with includeUndated:false drops entities with no timestamp (Overview path)', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:doc:no-date', predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+      { subject: 'urn:doc:no-date', predicate: SCHEMA_NAME, object: '"Undated"', layer: 'working' },
+      { subject: 'urn:doc:dated',   predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+      { subject: 'urn:doc:dated',   predicate: DC_CREATED, object: '"2026-05-22T08:00:00Z"', layer: 'working' },
+    ];
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: entitiesFrom(triples),
+        opts: { includeUndated: false },
+      }));
+    });
+    const items = readItems(container);
+    expect(items.map(i => i.uri)).toEqual(['urn:doc:dated']);
+  });
+
+  // includeUndated:true (default) used to require an entity to match
+  // ACTIVITY_TYPES to enter the Undated bucket — that gate is still
+  // wanted there, since the bucket is for "authored work I can't sort
+  // temporally", not "every random entity in the project".
+  it('with includeUndated:true keeps only typed entities when timestamp is missing', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:doc:no-date',  predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+      { subject: 'urn:doc:no-date',  predicate: SCHEMA_NAME, object: '"Untyped undated"', layer: 'working' },
+      { subject: 'urn:task:no-date', predicate: RDF_TYPE, object: TYPE_TASK, layer: 'working' },
+      { subject: 'urn:task:no-date', predicate: SCHEMA_NAME, object: '"Typed undated"', layer: 'working' },
+    ];
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: entitiesFrom(triples),
+        opts: { includeUndated: true },
+      }));
+    });
+    const items = readItems(container);
+    // Only the typed entity. The plain Article without a timestamp
+    // doesn't surface — otherwise the feed would balloon to every
+    // untyped entity ever imported.
+    expect(items.map(i => i.uri)).toEqual(['urn:task:no-date']);
+    expect(items[0].event).toBe('typed');
+  });
+
+  // typeIri filter must keep behaving as today — AgentProfileView's
+  // per-type stat chips select by IRI and expect a single-kind slice.
+  it('typeIri filter drops `added` rows and pins to the requested typed kind', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:doc:1',      predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+      { subject: 'urn:doc:1',      predicate: DC_CREATED, object: '"2026-05-20T08:00:00Z"', layer: 'working' },
+      { subject: 'urn:decision:1', predicate: RDF_TYPE, object: TYPE_DECISION, layer: 'working' },
+      { subject: 'urn:decision:1', predicate: DC_CREATED, object: '"2026-05-21T08:00:00Z"', layer: 'working' },
+      { subject: 'urn:task:1',     predicate: RDF_TYPE, object: TYPE_TASK, layer: 'working' },
+      { subject: 'urn:task:1',     predicate: DC_CREATED, object: '"2026-05-22T08:00:00Z"', layer: 'working' },
+    ];
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: entitiesFrom(triples),
+        opts: { typeIri: TYPE_DECISION },
+      }));
+    });
+    const items = readItems(container);
+    expect(items.map(i => i.uri)).toEqual(['urn:decision:1']);
+    expect(items[0].event).toBe('typed');
+  });
+
+  // agentUri filter respects author attribution on added rows too —
+  // an import attributed to alice@example should pass `agentUri=alice`.
+  it('agentUri filter applies to both `typed` and `added` rows', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:doc:1', predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+      { subject: 'urn:doc:1', predicate: DC_CREATED, object: '"2026-05-20T08:00:00Z"', layer: 'working' },
+      { subject: 'urn:doc:1', predicate: PROV_AUTHOR, object: 'did:dkg:agent:alice', layer: 'working' },
+      { subject: 'urn:doc:2', predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+      { subject: 'urn:doc:2', predicate: DC_CREATED, object: '"2026-05-21T08:00:00Z"', layer: 'working' },
+      { subject: 'urn:doc:2', predicate: PROV_AUTHOR, object: 'did:dkg:agent:bob', layer: 'working' },
+    ];
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: entitiesFrom(triples),
+        opts: { agentUri: 'did:dkg:agent:alice' },
+      }));
+    });
+    const items = readItems(container);
+    expect(items.map(i => i.uri)).toEqual(['urn:doc:1']);
+    expect(items[0].author).toBe('did:dkg:agent:alice');
+  });
+});

--- a/packages/node-ui/test/use-project-activity.test.ts
+++ b/packages/node-ui/test/use-project-activity.test.ts
@@ -24,11 +24,13 @@ const TYPE_TASK = 'http://dkg.io/ontology/tasks/Task';
 const SCHEMA_NAME = 'http://schema.org/name';
 
 interface CapturedItem {
+  id: string;
   uri: string;
   event: ActivityEvent;
   kindUri: string | null;
   at: string | null;
   author: string | null;
+  clickable: boolean;
 }
 
 function Probe({
@@ -48,11 +50,13 @@ function Probe({
 
 function toCaptured(item: ActivityItem): CapturedItem {
   return {
+    id: item.id,
     uri: item.entity.uri,
     event: item.event,
     kindUri: item.kindUri,
     at: item.at?.toISOString() ?? null,
     author: item.authorUri,
+    clickable: item.clickable,
   };
 }
 
@@ -283,17 +287,16 @@ describe('useProjectActivityEvents — promotion events (N6 part 2)', () => {
       { subject: 'urn:doc:promoted', predicate: DC_CREATED, object: '"2026-05-20T08:00:00Z"', layer: 'working' },
       { subject: 'urn:doc:promoted', predicate: PROV_AUTHOR, object: 'did:dkg:agent:alice', layer: 'working' },
     ];
-    const attributions = new Map<string, PromotionAttribution[]>([
-      ['urn:doc:promoted', [{
-        agent: 'did:dkg:agent:bob',
-        opUri: 'urn:dkg:share:op-1',
-        publishedAt: '2026-05-22T10:00:00Z',
-      }]],
-    ]);
+    const events: PromotionAttribution[] = [{
+      rootUri: 'urn:doc:promoted',
+      agent: 'did:dkg:agent:bob',
+      opUri: 'urn:dkg:share:op-1',
+      publishedAt: '2026-05-22T10:00:00Z',
+    }];
     act(() => {
       root.render(React.createElement(ProbeEvents, {
         entities: entitiesFrom(triples),
-        opts: { swmAttributions: attributions },
+        opts: { swmEvents: events },
       }));
     });
     const items = readItems(container);
@@ -302,8 +305,13 @@ describe('useProjectActivityEvents — promotion events (N6 part 2)', () => {
     expect(items[0].author).toBe('did:dkg:agent:bob');
     expect(items[0].uri).toBe('urn:doc:promoted');
     expect(items[0].kindUri).toBe(null);
+    expect(items[0].clickable).toBe(true);
     // `'added'` row keeps its original-author attribution.
     expect(items[1].author).toBe('did:dkg:agent:alice');
+    expect(items[1].clickable).toBe(true);
+    // Code1 — every row has a stable per-event id; the promoted row
+    // and the added row (same entity URI) have distinct ids.
+    expect(items[0].id).not.toEqual(items[1].id);
   });
 
   // Two distinct agents promoting the same root → two `'promoted'`
@@ -313,59 +321,83 @@ describe('useProjectActivityEvents — promotion events (N6 part 2)', () => {
     const triples: LayeredTriple[] = [
       { subject: 'urn:e:contested', predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
     ];
-    const attributions = new Map<string, PromotionAttribution[]>([
-      ['urn:e:contested', [
-        { agent: 'did:dkg:agent:alice', opUri: 'urn:dkg:share:op-a', publishedAt: '2026-05-22T10:00:00Z' },
-        { agent: 'did:dkg:agent:bob',   opUri: 'urn:dkg:share:op-b', publishedAt: '2026-05-23T10:00:00Z' },
-      ]],
-    ]);
+    const events: PromotionAttribution[] = [
+      { rootUri: 'urn:e:contested', agent: 'did:dkg:agent:alice', opUri: 'urn:dkg:share:op-a', publishedAt: '2026-05-22T10:00:00Z' },
+      { rootUri: 'urn:e:contested', agent: 'did:dkg:agent:bob',   opUri: 'urn:dkg:share:op-b', publishedAt: '2026-05-23T10:00:00Z' },
+    ];
     act(() => {
       root.render(React.createElement(ProbeEvents, {
         entities: entitiesFrom(triples),
-        opts: { swmAttributions: attributions },
+        opts: { swmEvents: events },
       }));
     });
     const items = readItems(container).filter(i => i.event === 'promoted');
     expect(items).toHaveLength(2);
     expect(items.map(i => i.author).sort()).toEqual(['did:dkg:agent:alice', 'did:dkg:agent:bob']);
+    // Code1 — two promotion rows for the same root have distinct ids.
+    expect(items[0].id).not.toEqual(items[1].id);
   });
 
-  // A promotion of a root that isn't (yet) in the entity list still
-  // produces a row — we synthesise an entity stub so the timeline
-  // never silently drops a transition.
-  it('still emits a row when the promoted root is missing from entitiesByUri', () => {
-    const triples: LayeredTriple[] = [];
-    const attributions = new Map<string, PromotionAttribution[]>([
-      ['urn:dkg:thing:orphan-root', [{
-        agent: 'did:dkg:agent:bob',
-        opUri: 'urn:dkg:share:op-1',
-        publishedAt: '2026-05-22T10:00:00Z',
-      }]],
-    ]);
+  // Codex Code2 regression — the same `(root, agent)` is promoted
+  // twice (different op id / timestamp). The previous wiring fed the
+  // deduped `attributions` map and silently lost the second event.
+  // The joiner now consumes the raw per-op event list and renders both.
+  it('emits two rows for re-promotion of the same (root, agent) — different op ids (Code2)', () => {
+    const events: PromotionAttribution[] = [
+      { rootUri: 'urn:e:repromoted', agent: 'did:dkg:agent:bob', opUri: 'urn:dkg:share:op-first',  publishedAt: '2026-05-22T10:00:00Z' },
+      { rootUri: 'urn:e:repromoted', agent: 'did:dkg:agent:bob', opUri: 'urn:dkg:share:op-second', publishedAt: '2026-05-24T10:00:00Z' },
+    ];
     act(() => {
       root.render(React.createElement(ProbeEvents, {
-        entities: entitiesFrom(triples),
-        opts: { swmAttributions: attributions },
+        entities: entitiesFrom([]),
+        opts: { swmEvents: events },
+      }));
+    });
+    const items = readItems(container).filter(i => i.event === 'promoted');
+    expect(items).toHaveLength(2);
+    // Distinct ids per event keep React's reconciliation honest.
+    expect(items[0].id).not.toEqual(items[1].id);
+    // Newest first.
+    expect(items[0].at).toBe('2026-05-24T10:00:00.000Z');
+    expect(items[1].at).toBe('2026-05-22T10:00:00.000Z');
+  });
+
+  // Codex Code3 — a promotion of a root that isn't in `entitiesByUri`
+  // still emits a row (the timeline doesn't drop transitions silently),
+  // but the row is marked `clickable: false` so the renderer can render
+  // it as static text rather than navigating to a detail view that
+  // ProjectView would immediately clear.
+  it('emits a non-clickable stub row when the promoted root is missing from entitiesByUri (Code3)', () => {
+    const events: PromotionAttribution[] = [{
+      rootUri: 'urn:dkg:thing:orphan-root',
+      agent: 'did:dkg:agent:bob',
+      opUri: 'urn:dkg:share:op-1',
+      publishedAt: '2026-05-22T10:00:00Z',
+    }];
+    act(() => {
+      root.render(React.createElement(ProbeEvents, {
+        entities: entitiesFrom([]),
+        opts: { swmEvents: events },
       }));
     });
     const items = readItems(container);
     expect(items).toHaveLength(1);
     expect(items[0].event).toBe('promoted');
     expect(items[0].uri).toBe('urn:dkg:thing:orphan-root');
+    expect(items[0].clickable).toBe(false);
   });
 
   // The agentUri filter narrows promotions to a single promoter; this
   // is how AgentProfileView would surface "what did Bob promote".
   it('agentUri filter applies to promotion rows (promoter, not original author)', () => {
-    const triples: LayeredTriple[] = [];
-    const attributions = new Map<string, PromotionAttribution[]>([
-      ['urn:e:1', [{ agent: 'did:dkg:agent:alice', opUri: 'urn:op:1', publishedAt: '2026-05-22T10:00:00Z' }]],
-      ['urn:e:2', [{ agent: 'did:dkg:agent:bob',   opUri: 'urn:op:2', publishedAt: '2026-05-23T10:00:00Z' }]],
-    ]);
+    const events: PromotionAttribution[] = [
+      { rootUri: 'urn:e:1', agent: 'did:dkg:agent:alice', opUri: 'urn:op:1', publishedAt: '2026-05-22T10:00:00Z' },
+      { rootUri: 'urn:e:2', agent: 'did:dkg:agent:bob',   opUri: 'urn:op:2', publishedAt: '2026-05-23T10:00:00Z' },
+    ];
     act(() => {
       root.render(React.createElement(ProbeEvents, {
-        entities: entitiesFrom(triples),
-        opts: { swmAttributions: attributions, agentUri: 'did:dkg:agent:bob' },
+        entities: entitiesFrom([]),
+        opts: { swmEvents: events, agentUri: 'did:dkg:agent:bob' },
       }));
     });
     const items = readItems(container);
@@ -381,22 +413,22 @@ describe('useProjectActivityEvents — promotion events (N6 part 2)', () => {
       { subject: 'urn:decision:1', predicate: RDF_TYPE, object: TYPE_DECISION, layer: 'working' },
       { subject: 'urn:decision:1', predicate: DC_CREATED, object: '"2026-05-20T08:00:00Z"', layer: 'working' },
     ];
-    const attributions = new Map<string, PromotionAttribution[]>([
-      ['urn:e:promoted', [{ agent: 'did:dkg:agent:bob', opUri: 'urn:op:1', publishedAt: '2026-05-22T10:00:00Z' }]],
-    ]);
+    const events: PromotionAttribution[] = [
+      { rootUri: 'urn:e:promoted', agent: 'did:dkg:agent:bob', opUri: 'urn:op:1', publishedAt: '2026-05-22T10:00:00Z' },
+    ];
     act(() => {
       root.render(React.createElement(ProbeEvents, {
         entities: entitiesFrom(triples),
-        opts: { swmAttributions: attributions, typeIri: TYPE_DECISION },
+        opts: { swmEvents: events, typeIri: TYPE_DECISION },
       }));
     });
     const items = readItems(container);
     expect(items.map(i => i.event)).toEqual(['typed']);
   });
 
-  // Omitting swmAttributions → joiner reduces to the entity-derived
+  // Omitting swmEvents → joiner reduces to the entity-derived
   // feed only. Keeps the AgentProfileView path noise-free.
-  it('without swmAttributions returns the same items as useProjectActivity', () => {
+  it('without swmEvents returns the same items as useProjectActivity', () => {
     const triples: LayeredTriple[] = [
       { subject: 'urn:doc:1', predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
       { subject: 'urn:doc:1', predicate: DC_CREATED, object: '"2026-05-22T08:00:00Z"', layer: 'working' },
@@ -418,22 +450,23 @@ describe('useProjectActivityEvents — promotion events (N6 part 2)', () => {
 describe('buildPromotionEvents — pure joiner', () => {
   it('drops rows with unparseable timestamps rather than emitting Invalid Date', () => {
     const items = buildPromotionEvents(
-      new Map([['urn:e:1', [{
+      [{
+        rootUri: 'urn:e:1',
         agent: 'did:dkg:agent:bob',
         opUri: 'urn:op:1',
         publishedAt: 'not-a-date',
-      }]]]),
+      }],
       { entitiesByUri: new Map() },
     );
     expect(items).toHaveLength(0);
   });
 
-  it('sorts newest-first when fed an out-of-order map', () => {
+  it('sorts newest-first when fed an out-of-order array', () => {
     const items = buildPromotionEvents(
-      new Map([
-        ['urn:e:older', [{ agent: 'did:dkg:agent:alice', opUri: 'urn:op:a', publishedAt: '2026-05-20T00:00:00Z' }]],
-        ['urn:e:newer', [{ agent: 'did:dkg:agent:bob',   opUri: 'urn:op:b', publishedAt: '2026-05-22T00:00:00Z' }]],
-      ]),
+      [
+        { rootUri: 'urn:e:older', agent: 'did:dkg:agent:alice', opUri: 'urn:op:a', publishedAt: '2026-05-20T00:00:00Z' },
+        { rootUri: 'urn:e:newer', agent: 'did:dkg:agent:bob',   opUri: 'urn:op:b', publishedAt: '2026-05-22T00:00:00Z' },
+      ],
       { entitiesByUri: new Map() },
     );
     expect(items.map(i => i.entity.uri)).toEqual(['urn:e:newer', 'urn:e:older']);

--- a/packages/node-ui/test/use-project-activity.test.ts
+++ b/packages/node-ui/test/use-project-activity.test.ts
@@ -492,6 +492,45 @@ describe('buildPromotionEvents — pure joiner', () => {
     const uris = items.map(i => i.entity.uri).sort();
     expect(uris).toEqual(['urn:e:root-a', 'urn:e:root-b']);
   });
+
+  // Local-1 (PR #656) — the daemon sometimes ships wrapped
+  // (`<urn:...>`) bindings in `_shared_memory_meta` rows, while
+  // `entitiesByUri` is canonicalised (`buildEntities` strips the
+  // angle brackets). Without canonicalising on lookup, every
+  // wrapped-URI promotion would fall through to the stub branch
+  // and render as a non-clickable static row, even when the
+  // entity is loaded. Same C8 / R2-1 canonicalisation pattern as
+  // the earlier #639 fixes.
+  it('resolves wrapped <urn:...> rootUri to a canonical entity, keeping the row clickable (Local-1)', () => {
+    const canonical = 'urn:e:wrapped';
+    const entity: MemoryEntity = {
+      uri: canonical,
+      label: 'Wrapped Entity',
+      types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(),
+      properties: new Map(),
+      connections: [],
+    };
+    const items = buildPromotionEvents(
+      [{
+        rootUri: `<${canonical}>`,
+        agent: 'did:dkg:agent:bob',
+        opUri: 'urn:op:wrapped',
+        publishedAt: '2026-05-22T10:00:00Z',
+      }],
+      { entitiesByUri: new Map([[canonical, entity]]) },
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].clickable).toBe(true);
+    expect(items[0].entity.uri).toBe(canonical);
+    // Stable id keys off canonical so a mixed wrapped/unwrapped feed
+    // for the same root doesn't render two rows.
+    expect(items[0].id).toBe(
+      buildActivityId('promoted', 'urn:op:wrapped', new Date('2026-05-22T10:00:00Z'), canonical),
+    );
+  });
 });
 
 // `buildActivityId` is a pure helper exported alongside the joiner.

--- a/packages/node-ui/test/use-swm-attributions.test.ts
+++ b/packages/node-ui/test/use-swm-attributions.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { buildAttributionsQuery } from '../src/ui/hooks/useSwmAttributions.js';
+
+describe('useSwmAttributions — SPARQL query shape', () => {
+  // Codex Code5 (PR #656) — the query MUST order DESC + LIMIT 5000.
+  // ASC + LIMIT 5000 keeps the oldest 5000 promotions, so once a
+  // project crosses 5000 ops the activity feed silently loses every
+  // recent promotion. DESC + LIMIT 5000 returns the most recent
+  // window — the activity feed is the load-bearing consumer.
+  it('orders by ?publishedAt DESC so the newest promotions are kept inside LIMIT 5000', () => {
+    const q = buildAttributionsQuery('cg-1');
+    expect(q).toContain('ORDER BY DESC(?publishedAt)');
+    expect(q).toContain('LIMIT 5000');
+    // Guard against accidentally regressing to plain ASC by leaving
+    // the new DESC and the old `ORDER BY ?publishedAt` both present.
+    expect(q).not.toMatch(/ORDER BY \?publishedAt\s+LIMIT/);
+  });
+});

--- a/packages/node-ui/test/use-swm-attributions.test.ts
+++ b/packages/node-ui/test/use-swm-attributions.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from 'vitest';
-import { buildAttributionsQuery } from '../src/ui/hooks/useSwmAttributions.js';
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  buildAttributionsQuery,
+  useSwmAttributions,
+  type SwmAttributionsResult,
+} from '../src/ui/hooks/useSwmAttributions.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe('useSwmAttributions — SPARQL query shape', () => {
   // Codex Code5 (PR #656) — the query MUST order DESC + LIMIT 5000.
@@ -14,5 +24,104 @@ describe('useSwmAttributions — SPARQL query shape', () => {
     // Guard against accidentally regressing to plain ASC by leaving
     // the new DESC and the old `ORDER BY ?publishedAt` both present.
     expect(q).not.toMatch(/ORDER BY \?publishedAt\s+LIMIT/);
+  });
+});
+
+// Codex Code7 (PR #656) — the hook returns its previous-graph result
+// during the transition window between context-graph switch and the
+// new SPARQL resolving, so callers that key off the result without a
+// discriminator (e.g. feeding `events` into the Overview activity
+// feed) can briefly show rows from the prior project. The hook now
+// exposes `resultContextGraphId` so consumers can gate on it.
+describe('useSwmAttributions — stale-on-switch protection', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let originalFetch: typeof globalThis.fetch | undefined;
+  // Deferred-promise queue per contextGraphId so the test can drive
+  // when each fetch resolves.
+  let pending: Map<string, { resolve: (rows: any[]) => void }>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    pending = new Map();
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (_url: any, init?: any) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      const cgId: string = body.contextGraphId;
+      const p = new Promise<any[]>((resolve) => {
+        pending.set(cgId, { resolve });
+      });
+      const rows = await p;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ result: { bindings: rows } }),
+      } as any;
+    }) as any;
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  async function flushMicrotasks() {
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+  }
+
+  function rowsFor(cgId: string) {
+    return [{
+      op:          `"urn:op:${cgId}"`,
+      root:        `"urn:e:${cgId}"`,
+      agent:       `"did:dkg:agent:0x${cgId.padEnd(40, '0')}"`,
+      publishedAt: `"2026-05-22T10:00:00Z"`,
+      g:           `"did:dkg:context-graph:${cgId}/_shared_memory_meta"`,
+    }];
+  }
+
+  it('lags resultContextGraphId behind the prop during a context-graph switch (Code7)', async () => {
+    let latest: SwmAttributionsResult | null = null;
+    function Probe({ id }: { id: string }) {
+      latest = useSwmAttributions(id);
+      return null;
+    }
+
+    // Initial render for cg-A.
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-A' }));
+    });
+    await flushMicrotasks();
+    expect(latest!.resultContextGraphId).toBeUndefined();
+    expect(latest!.events).toHaveLength(0);
+
+    // Resolve cg-A's fetch.
+    pending.get('cg-A')!.resolve(rowsFor('cg-A'));
+    await flushMicrotasks();
+    expect(latest!.resultContextGraphId).toBe('cg-A');
+    expect(latest!.events).toHaveLength(1);
+    expect(latest!.events[0].rootUri).toBe('urn:e:cg-A');
+
+    // Switch to cg-B. The hook still holds cg-A's events until the
+    // new SPARQL lands — that's the pre-existing behaviour. The fix
+    // is the discriminator: callers can detect the mismatch and
+    // suppress downstream rendering until it clears.
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-B' }));
+    });
+    await flushMicrotasks();
+    // Before cg-B's fetch resolves, the result still describes cg-A.
+    // A consumer that gates on `resultContextGraphId === currentId`
+    // would now suppress these events (they're for the wrong graph).
+    expect(latest!.resultContextGraphId).toBe('cg-A');
+
+    // Resolve cg-B; the discriminator catches up.
+    pending.get('cg-B')!.resolve(rowsFor('cg-B'));
+    await flushMicrotasks();
+    expect(latest!.resultContextGraphId).toBe('cg-B');
+    expect(latest!.events).toHaveLength(1);
+    expect(latest!.events[0].rootUri).toBe('urn:e:cg-B');
   });
 });


### PR DESCRIPTION
## Summary

Implements **N6 — Activity feed breadth** (plan §5). The Recent Activity feed on the Context Graph Overview previously allowlisted a small set of "interesting" rdf:types (Decision / Task / PR / Issue / Commit) and silently dropped every other entity, so a Context Graph full of imported knowledge read "No activity yet" even when many entities had `dcterms:created` timestamps from the import pipeline.

After this PR the feed surfaces:

- **`added` events** — every imported entity with a parseable timestamp (e.g. `dcterms:created`), regardless of `rdf:type`. Renders as a neutral "Added" row with a `+` glyph in slate.
- **`promoted` events** — WM→SWM transitions, joined from `useSwmAttributions`'s existing `_shared_memory_meta` query. Renders as "Promoted to Shared Working Memory" with a `⇡` glyph in SWM amber. One row per (root, agent) pair so two distinct promoters of the same root produce two rows (mirrors the SWM-graph conflict signal).
- **`typed` events** — preserved verbatim from the previous shape (Decision proposed / Task done / PR merged / etc.). AgentProfileView's per-type stat-chip slices are bit-for-bit identical.
- **`published` events** — renderer ready (◉ glyph + VM green + "Published to Verifiable Memory" copy), data path **deferred to a follow-up** — see Deferred below.

## Related work

- Plan §5 N6.
- Reuses existing data sources: `useSwmAttributions` (already in production for the SWM Graph subtab agent-tint legend). No new SPARQL.
- Built on top of S2 (Overview rebuild) ✅ merged.

## Files changed

| File | Change |
|------|--------|
| `packages/node-ui/src/ui/hooks/useProjectActivity.ts` | `ActivityItem` gains an `event: 'added' \| 'typed' \| 'promoted' \| 'published'` discriminator; `kindUri` becomes nullable. New pure `buildPromotionEvents()` helper. New `useProjectActivityEvents()` joiner hook composes the base feed with the promotion stream. |
| `packages/node-ui/src/ui/components/ActivityFeed.tsx` | Renderer branches on `event`: each event kind has its own icon, copy and accent. New optional `swmAttributions` prop forwards into the joiner hook; absence reduces to the legacy `useProjectActivity` behaviour so existing consumers don't regress. Status pill is now only surfaced on `'typed'` rows. Tooltip is event-aware. |
| `packages/node-ui/src/ui/views/ProjectView.tsx` | Calls `useSwmAttributions(contextGraphId)` once at the top level and threads `attributions` into the Overview's `<ActivityFeed swmAttributions={...} />`. The hook is already cached by the SWM Graph subtab so this is a freebie subscriber. Empty-state copy nudged to mention imports. |
| `packages/node-ui/test/use-project-activity.test.ts` | New file. 15 unit tests across two suites — `useProjectActivity` (event classification + filter contracts) and `useProjectActivityEvents` / `buildPromotionEvents` (joiner + pure-helper). |

## Test plan

- [x] `tsc --noEmit` clean against node-ui (worktree + after each commit).
- [x] Focused vitest passes: `use-project-activity.test.ts` (15 tests, all green), plus regression-adjacent files `subgraph-detail-view`, `layer-graph-panel`, `project-view-navigation`, `agent-tab-menu` (49 tests across 5 files).
- [x] Every regression test verified to fail when the corresponding implementation is reverted (genuine assertions, not no-op).
- [x] Vite `pnpm build:ui` clean — confirms the browser bundle still produces.
- [ ] CI to validate the full suite (some local files require `better-sqlite3` native bindings that the worktree's `pnpm install --ignore-scripts` skipped — those run cleanly in CI's native-install path).

### Visual QA recipe (recommended for ux-lead's pass)

This branch's UI surface lands cleanly when served from the worktree's freshly-built `dist-ui/` via the dev-daemon bypass invocation (not the globally-installed `dkg` CLI, which serves a stale npm-published bundle):

```bash
cd C:/Projects/dkg-v9-cg-takeover
pnpm install                                            # first time only
pnpm --filter @origintrail-official/dkg-node-ui build:full
# (also build dkg-cli if your local copy isn't built yet)
DKG_NO_BLUE_GREEN=1 node packages/cli/dist/cli.js start --foreground
# → http://127.0.0.1:9200/ui
```

Then walk:
- **Empty CG** → Overview "Recent activity" empty state with broadened copy ("Once you import knowledge…").
- **CG with imported files (no decisions/tasks)** → `Added <Foo>` rows on the Overview.
- **CG with a promoted entity** → `Promoted to Shared Working Memory <Foo>` row attributed to the promoter, interleaved with the entity's prior `Added` row in newest-first order.
- **AgentProfileView per-type stat-chip click** → typed-only slice unchanged (no `Added` rows leaking in).

## Deferred follow-up

- **`'published'` (SWM→VM) row data path.** The renderer is wired and ready — see commit 3's body. Surfacing the events distinctly from `'promoted'` requires either a curator-only `_meta`-graph query (`dkg:AssertionPublished` events live there but `_meta` is not replicated between peers) or a trustLevel cross-reference heuristic on the replicated `WorkspaceOperation` records (which feed both `useSwmAttributions` and `useVerifiedMemoryAnchors` from the same SPARQL projection). Both are larger than this PR's scope and want a design call from ux-lead on whether two rows per op ("Promoted X" + "Published X") or one merged transition row reads better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
