### PR TITLE
feat(agent,daemon): wire async-promote queue + 5 HTTP routes (PR 2/4)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -84,8 +84,11 @@ import {
   validateLiftPublishPayload,
   subtractFinalizedExactQuads,
   TripleStoreAsyncLiftPublisher,
+  TripleStoreAsyncPromoteQueue,
   FileWorkspacePublicSnapshotStore,
   parseWorkspacePublicSnapshotNQuads,
+  type AsyncPromoteQueue, type AsyncPromoteQueueConfig,
+  type PromoteJob, type PromoteListFilter,
   type PublishOptions, type PublishResult, type PhaseCallback, type KAMetadata, type CASCondition,
   type CollectedACK, type LiftAuthorityProof, type LiftTransitionType,
   type LiftRequest, type LiftRequestAuthorSeal,
@@ -360,6 +363,23 @@ export class DKGAgent {
   readonly queryEngine: DKGQueryEngine;
   readonly discovery: DiscoveryClient;
   readonly profileManager: ProfileManager;
+  /**
+   * Lazily-constructed WM→SWM async-promote queue (see
+   * `docs/specs/SPEC_ASYNC_PROMOTE_QUEUE.md`). Routes call into it via
+   * `agent.assertion.promoteAsync(...)`. PR #3 will wire an in-process
+   * worker loop that periodically calls `claimNext` + `succeed`/`fail`;
+   * for now, only the public enqueue/inspect surface is reachable. We
+   * stash the impl as `private` and expose it via the `promoteQueue`
+   * getter so the worker (a daemon-side concern) and tests can drive
+   * the queue directly without going through the assertion subsurface.
+   */
+  private _promoteQueue?: AsyncPromoteQueue;
+  /**
+   * Override for tests / future operator config. When set before
+   * `promoteQueue` is first accessed, the queue is constructed with
+   * these overrides folded into the defaults.
+   */
+  private _promoteQueueConfig?: Partial<AsyncPromoteQueueConfig>;
   gossip!: GossipSubManager;
   router!: ProtocolRouter;
   messenger!: Messenger;
@@ -17980,7 +18000,72 @@ export class DKGAgent {
           events: [...eventMap.values()],
         };
       },
+
+      // ── Async promote (RFC: docs/specs/SPEC_ASYNC_PROMOTE_QUEUE.md) ──
+      //
+      // These five methods are thin pass-throughs to the queue. The
+      // worker that actually drains the queue lives in the daemon (PR
+      // #3); on this surface we only enqueue, inspect, cancel, and
+      // recover. No memoryGraphChanged event is emitted at enqueue time
+      // — emission happens when the worker reports success.
+      async promoteAsync(
+        contextGraphId: string,
+        name: string,
+        opts?: { entities?: readonly string[] | 'all'; subGraphName?: string },
+      ): Promise<{ jobId: string }> {
+        const jobId = await agent.promoteQueue.enqueue({
+          contextGraphId,
+          assertionName: name,
+          subGraphName: opts?.subGraphName,
+          entities: opts?.entities ?? 'all',
+        });
+        return { jobId };
+      },
+      async getPromoteAsyncStatus(jobId: string): Promise<PromoteJob | null> {
+        return agent.promoteQueue.getStatus(jobId);
+      },
+      async listPromoteAsyncJobs(filter?: PromoteListFilter): Promise<PromoteJob[]> {
+        return agent.promoteQueue.list(filter);
+      },
+      async cancelPromoteAsync(jobId: string): Promise<void> {
+        return agent.promoteQueue.cancel(jobId);
+      },
+      async recoverPromoteAsync(jobId: string): Promise<void> {
+        return agent.promoteQueue.recover(jobId);
+      },
     };
+  }
+
+  /**
+   * Lazily-constructed async-promote queue. First access materialises
+   * the `TripleStoreAsyncPromoteQueue` against `this.store`; subsequent
+   * accesses return the same instance. The queue's control graph
+   * (`urn:dkg:promote-queue:control-plane`) lives in the same triple
+   * store as everything else, so it survives daemon restarts.
+   *
+   * Exposed publicly so PR #3's worker loop can drive the worker-side
+   * surface (`claimNext` / `heartbeat` / `succeed` / `fail` /
+   * `recordCommitMarker` / `recoverOnStartup`) without the assertion
+   * subsurface having to leak those methods to user-facing callers.
+   */
+  get promoteQueue(): AsyncPromoteQueue {
+    if (!this._promoteQueue) {
+      this._promoteQueue = new TripleStoreAsyncPromoteQueue(this.store, this._promoteQueueConfig ?? {});
+    }
+    return this._promoteQueue;
+  }
+
+  /**
+   * Override the promote-queue config (e.g. inject deterministic
+   * `now`/`idGenerator` for tests, or tune `maxRetries`/`leaseMs` from
+   * daemon config). Must be called BEFORE the first `promoteQueue`
+   * access; throws otherwise so the override doesn't silently no-op.
+   */
+  configurePromoteQueue(config: Partial<AsyncPromoteQueueConfig>): void {
+    if (this._promoteQueue) {
+      throw new Error('configurePromoteQueue must be called before the queue is first accessed');
+    }
+    this._promoteQueueConfig = config;
   }
 
 }

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -407,6 +407,29 @@ function validateContentHash(hash: string): boolean {
   return /^(?:sha256:|keccak256:)?[0-9a-f]{64}$/i.test(hash);
 }
 
+function validatePromoteJobId(jobId: string): { valid: true } | { valid: false; reason: string } {
+  if (!jobId) return { valid: false, reason: "jobId is required" };
+  if (jobId.length > 256) return { valid: false, reason: "jobId is too long" };
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(jobId)) {
+    return {
+      valid: false,
+      reason: "jobId may only contain letters, numbers, '.', '_', ':', and '-'",
+    };
+  }
+  return { valid: true };
+}
+
+function decodePromoteJobId(encoded: string, res: ServerResponse): string | null {
+  const jobId = safeDecodeURIComponent(encoded, res);
+  if (jobId === null) return null;
+  const validation = validatePromoteJobId(jobId);
+  if (!validation.valid) {
+    jsonResponse(res, 400, { error: `Invalid promote jobId: ${validation.reason}` });
+    return null;
+  }
+  return jobId;
+}
+
 function parseImportedAssertionUri(
   assertionUri: string,
   contextGraphId: string,
@@ -1447,7 +1470,7 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
         { entities: entities ?? "all", subGraphName },
       );
       const job = await agent.assertion.getPromoteAsyncStatus(result.jobId);
-      return jsonResponse(res, 202, {
+      return jsonResponse(res, 200, {
         jobId: result.jobId,
         state: job?.state ?? "queued",
         enqueuedAt: job?.enqueuedAt,
@@ -1480,16 +1503,17 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     path === "/api/assertion/promote-async"
   ) {
     const stateParam = url.searchParams.get("state");
-    const stateFilter: PromoteJobState[] | undefined = stateParam
-      ? stateParam.split(",").map((s) => s.trim()).filter((s): s is PromoteJobState =>
-          (PROMOTE_JOB_STATES as readonly string[]).includes(s),
-        )
-      : undefined;
-    if (stateParam && (!stateFilter || stateFilter.length === 0)) {
+    const requestedStates = stateParam ? stateParam.split(",").map((s) => s.trim()) : undefined;
+    if (
+      requestedStates &&
+      (requestedStates.length === 0 ||
+        requestedStates.some((s) => !(PROMOTE_JOB_STATES as readonly string[]).includes(s)))
+    ) {
       return jsonResponse(res, 400, {
         error: `Invalid state filter: ${stateParam}. Allowed: ${PROMOTE_JOB_STATES.join(",")}`,
       });
     }
+    const stateFilter = requestedStates as PromoteJobState[] | undefined;
     const contextGraphId = url.searchParams.get("contextGraphId") ?? undefined;
     const limitParam = url.searchParams.get("limit");
     const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
@@ -1512,10 +1536,7 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     path.startsWith("/api/assertion/promote-async/") &&
     !path.endsWith("/recover")
   ) {
-    const jobId = safeDecodeURIComponent(
-      path.slice("/api/assertion/promote-async/".length),
-      res,
-    );
+    const jobId = decodePromoteJobId(path.slice("/api/assertion/promote-async/".length), res);
     if (jobId === null) return;
     const job = await agent.assertion.getPromoteAsyncStatus(jobId);
     if (!job) {
@@ -1529,10 +1550,7 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     req.method === "DELETE" &&
     path.startsWith("/api/assertion/promote-async/")
   ) {
-    const jobId = safeDecodeURIComponent(
-      path.slice("/api/assertion/promote-async/".length),
-      res,
-    );
+    const jobId = decodePromoteJobId(path.slice("/api/assertion/promote-async/".length), res);
     if (jobId === null) return;
     try {
       await agent.assertion.cancelPromoteAsync(jobId);
@@ -1556,7 +1574,7 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     path.startsWith("/api/assertion/promote-async/") &&
     path.endsWith("/recover")
   ) {
-    const jobId = safeDecodeURIComponent(
+    const jobId = decodePromoteJobId(
       path.slice("/api/assertion/promote-async/".length, -"/recover".length),
       res,
     );

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -58,7 +58,7 @@ const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, escapeDkgRdfLiteral, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, assertionLifecycleUri } from '@origintrail-official/dkg-core';
-import { findReservedSubjectPrefix, isSkolemizedUri, PROMOTE_JOB_STATES, PromoteJobConflictError, type PromoteJobState, type PublishOptions } from '@origintrail-official/dkg-publisher';
+import { findReservedSubjectPrefix, isSkolemizedUri, PROMOTE_JOB_STATES, PromoteJobConflictError, type PromoteJob, type PromoteJobState, type PublishOptions } from '@origintrail-official/dkg-publisher';
 import { validatePreSignedAuthorAttestation } from './memory.js';
 import {
   DashboardDB,
@@ -428,6 +428,116 @@ function decodePromoteJobId(encoded: string, res: ServerResponse): string | null
     return null;
   }
   return jobId;
+}
+
+// ── Async-promote wire schema (RFC §3.2 + §3.3) ──────────────────────────────
+//
+// The internal `PromoteJob` shape persisted by the queue carries
+// implementation details the HTTP contract is not allowed to leak:
+//   - `lease.claimToken` (opaque worker-side capability),
+//   - `lease.workerId` / heartbeat metadata,
+//   - numeric epoch timestamps,
+//   - `commitMarker` (internal idempotency bookkeeping).
+//
+// `PromoteJobView` is the documented public shape per RFC §3.2; ISO-8601
+// timestamps, a flat top level for assertion identity, and a stable
+// `lastError.code` enum mapped from the queue's failure classification.
+// The list (§3.3) and status (§3.2) endpoints share `promoteJobToView()`
+// so both surfaces stay in lockstep.
+
+export interface PromoteJobErrorView {
+  code: string;
+  message: string;
+  retryable: boolean;
+}
+
+export interface PromoteJobView {
+  jobId: string;
+  state: PromoteJobState;
+  contextGraphId: string;
+  assertionName: string;
+  subGraphName?: string;
+  entities: readonly string[] | 'all';
+  enqueuedAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  entitiesPromoted?: number;
+  attempts: number;
+  maxAttempts: number;
+  nextRetryAt?: string;
+  lastError?: PromoteJobErrorView;
+  reason?: string;
+}
+
+function isoFromEpochMs(ms: number | undefined): string | undefined {
+  if (ms === undefined || ms === null) return undefined;
+  if (!Number.isFinite(ms)) return undefined;
+  return new Date(ms).toISOString();
+}
+
+export function promoteJobToView(job: PromoteJob): PromoteJobView {
+  // `startedAt` reflects the current attempt's lease acquisition; while
+  // running the lease is present, after success/failure the queue clears
+  // it so the field naturally goes away. `finishedAt` is sourced from
+  // the terminal-state evidence the queue already records:
+  // `result.succeededAt` for success and `attempt.lastError.recordedAt`
+  // for failed / failed_retrying. Cancelled jobs (no lastError, no
+  // result) fall back to `updatedAt` because that's the only durable
+  // timestamp for that transition.
+  const startedAt = isoFromEpochMs(job.lease?.acquiredAt);
+  let finishedAt: string | undefined;
+  if (job.state === 'succeeded') {
+    finishedAt = isoFromEpochMs(job.result?.succeededAt) ?? isoFromEpochMs(job.updatedAt);
+  } else if (job.state === 'failed' || job.state === 'failed_retrying') {
+    finishedAt =
+      isoFromEpochMs(job.attempt.lastError?.recordedAt) ?? isoFromEpochMs(job.updatedAt);
+  }
+
+  const lastError: PromoteJobErrorView | undefined = job.attempt.lastError
+    ? {
+        code: job.attempt.lastError.classification,
+        message: job.attempt.lastError.message,
+        retryable: job.attempt.lastError.retryable,
+      }
+    : undefined;
+
+  const view: PromoteJobView = {
+    jobId: job.jobId,
+    state: job.state,
+    contextGraphId: job.request.contextGraphId,
+    assertionName: job.request.assertionName,
+    entities: job.request.entities,
+    enqueuedAt: new Date(job.enqueuedAt).toISOString(),
+    updatedAt: new Date(job.updatedAt).toISOString(),
+    attempts: job.attempt.count,
+    maxAttempts: job.attempt.maxRetries,
+  };
+  if (job.request.subGraphName !== undefined) view.subGraphName = job.request.subGraphName;
+  if (startedAt !== undefined) view.startedAt = startedAt;
+  if (finishedAt !== undefined) view.finishedAt = finishedAt;
+  if (job.result?.promotedCount !== undefined) view.entitiesPromoted = job.result.promotedCount;
+  const nextRetryAt = isoFromEpochMs(job.attempt.nextRetryAt);
+  if (nextRetryAt !== undefined) view.nextRetryAt = nextRetryAt;
+  if (lastError !== undefined) view.lastError = lastError;
+  if (job.reason !== undefined) view.reason = job.reason;
+  return view;
+}
+
+// Helper used by the five `/promote-async` routes below to refuse work
+// when no worker is actually draining the queue (RFC §3.1 — the
+// implementation plan parks the supervisor in a follow-up PR; until then
+// `daemonState.promoteWorkerAvailable` stays `false` and we return 503
+// rather than silently accept jobs that would sit in `queued` forever).
+function asyncPromoteUnavailable(res: ServerResponse): boolean {
+  if (daemonState.promoteWorkerAvailable) return false;
+  const reason = daemonState.promoteWorkerUnavailableReason;
+  jsonResponse(res, 503, {
+    error:
+      `async-promote worker is not available` +
+      (reason ? `: ${reason}` : ''),
+  });
+  return true;
 }
 
 function parseImportedAssertionUri(
@@ -1456,6 +1566,7 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
       return jsonResponse(res, 400, {
         error: `Invalid assertion name: ${nameVal.reason}`,
       });
+    if (asyncPromoteUnavailable(res)) return;
     const body = await readBody(req, SMALL_BODY_BYTES);
     const parsed = safeParseJson(body, res);
     if (!parsed) return;
@@ -1500,6 +1611,7 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     req.method === "GET" &&
     path === "/api/assertion/promote-async"
   ) {
+    if (asyncPromoteUnavailable(res)) return;
     const stateParam = url.searchParams.get("state");
     const requestedStates = stateParam ? stateParam.split(",").map((s) => s.trim()) : undefined;
     if (
@@ -1530,7 +1642,7 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
       contextGraphId,
       limit,
     });
-    return jsonResponse(res, 200, { jobs });
+    return jsonResponse(res, 200, { jobs: jobs.map(promoteJobToView) });
   }
 
   // GET /api/assertion/promote-async/:jobId
@@ -1539,13 +1651,14 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     path.startsWith("/api/assertion/promote-async/") &&
     !path.endsWith("/recover")
   ) {
+    if (asyncPromoteUnavailable(res)) return;
     const jobId = decodePromoteJobId(path.slice("/api/assertion/promote-async/".length), res);
     if (jobId === null) return;
     const job = await agent.assertion.getPromoteAsyncStatus(jobId);
     if (!job) {
       return jsonResponse(res, 404, { error: `Promote job not found: ${jobId}` });
     }
-    return jsonResponse(res, 200, job);
+    return jsonResponse(res, 200, promoteJobToView(job));
   }
 
   // DELETE /api/assertion/promote-async/:jobId   — cancel a queued/failed_retrying job

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -58,7 +58,7 @@ const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, escapeDkgRdfLiteral, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, assertionLifecycleUri } from '@origintrail-official/dkg-core';
-import { findReservedSubjectPrefix, isSkolemizedUri, type PublishOptions } from '@origintrail-official/dkg-publisher';
+import { findReservedSubjectPrefix, isSkolemizedUri, PROMOTE_JOB_STATES, PromoteJobConflictError, type PromoteJobState, type PublishOptions } from '@origintrail-official/dkg-publisher';
 import { validatePreSignedAuthorAttestation } from './memory.js';
 import {
   DashboardDB,
@@ -1400,6 +1400,177 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
         err.message?.includes("Unsafe")
       ) {
         return jsonResponse(res, 400, { error: err.message });
+      }
+      throw err;
+    }
+  }
+
+  // ── Async-promote queue (RFC: docs/specs/SPEC_ASYNC_PROMOTE_QUEUE.md) ──
+  //
+  // Five routes that mirror the sync /promote contract but enqueue work
+  // for an in-process worker (PR #3) instead of running it inline. All
+  // routes share the SMALL_BODY_BYTES cap from sync /promote — see
+  // RFC §3.1.
+  //
+  // The list/status/cancel/recover routes are unambiguous because the
+  // jobId lives in the path; the enqueue route uses `/promote-async`
+  // as the trailing segment so it doesn't conflict with assertion
+  // names containing the word "promote".
+
+  // POST /api/assertion/:name/promote-async  { contextGraphId, entities?, subGraphName? }
+  if (
+    req.method === "POST" &&
+    path.startsWith("/api/assertion/") &&
+    path.endsWith("/promote-async")
+  ) {
+    const assertionName = safeDecodeURIComponent(
+      path.slice("/api/assertion/".length, -"/promote-async".length),
+      res,
+    );
+    if (assertionName === null) return;
+    const nameVal = validateAssertionName(assertionName);
+    if (!nameVal.valid)
+      return jsonResponse(res, 400, {
+        error: `Invalid assertion name: ${nameVal.reason}`,
+      });
+    const body = await readBody(req, SMALL_BODY_BYTES);
+    const parsed = safeParseJson(body, res);
+    if (!parsed) return;
+    const { contextGraphId, entities, subGraphName } = parsed;
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
+    if (!validateEntities(entities, res)) return;
+    if (!validateOptionalSubGraphName(subGraphName, res)) return;
+    try {
+      const result = await agent.assertion.promoteAsync(
+        contextGraphId,
+        assertionName,
+        { entities: entities ?? "all", subGraphName },
+      );
+      const job = await agent.assertion.getPromoteAsyncStatus(result.jobId);
+      return jsonResponse(res, 202, {
+        jobId: result.jobId,
+        state: job?.state ?? "queued",
+        enqueuedAt: job?.enqueuedAt,
+      });
+    } catch (err: any) {
+      if (err instanceof PromoteJobConflictError) {
+        return jsonResponse(res, 409, {
+          error: err.message,
+          existingJobId: err.existingJobId,
+        });
+      }
+      if (
+        err.message?.includes("required") ||
+        err.message?.includes("Invalid") ||
+        err.message?.includes("must be")
+      ) {
+        return jsonResponse(res, 400, { error: err.message });
+      }
+      throw err;
+    }
+  }
+
+  // GET /api/assertion/promote-async  ?contextGraphId=<cg>&state=queued,running,...&limit=<n>
+  // List jobs filtered by contextGraphId / state. Must come BEFORE the
+  // `/:jobId` route below because Node URL routing here is by `startsWith`
+  // + `endsWith` rather than a real router; an exact-prefix GET to the
+  // collection URL would otherwise be claimed by the per-job handler.
+  if (
+    req.method === "GET" &&
+    path === "/api/assertion/promote-async"
+  ) {
+    const stateParam = url.searchParams.get("state");
+    const stateFilter: PromoteJobState[] | undefined = stateParam
+      ? stateParam.split(",").map((s) => s.trim()).filter((s): s is PromoteJobState =>
+          (PROMOTE_JOB_STATES as readonly string[]).includes(s),
+        )
+      : undefined;
+    if (stateParam && (!stateFilter || stateFilter.length === 0)) {
+      return jsonResponse(res, 400, {
+        error: `Invalid state filter: ${stateParam}. Allowed: ${PROMOTE_JOB_STATES.join(",")}`,
+      });
+    }
+    const contextGraphId = url.searchParams.get("contextGraphId") ?? undefined;
+    const limitParam = url.searchParams.get("limit");
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+    if (limit !== undefined && (!Number.isFinite(limit) || limit <= 0 || limit > 1000)) {
+      return jsonResponse(res, 400, {
+        error: "limit must be a positive integer ≤ 1000",
+      });
+    }
+    const jobs = await agent.assertion.listPromoteAsyncJobs({
+      state: stateFilter,
+      contextGraphId,
+      limit,
+    });
+    return jsonResponse(res, 200, { jobs });
+  }
+
+  // GET /api/assertion/promote-async/:jobId
+  if (
+    req.method === "GET" &&
+    path.startsWith("/api/assertion/promote-async/") &&
+    !path.endsWith("/recover")
+  ) {
+    const jobId = safeDecodeURIComponent(
+      path.slice("/api/assertion/promote-async/".length),
+      res,
+    );
+    if (jobId === null) return;
+    const job = await agent.assertion.getPromoteAsyncStatus(jobId);
+    if (!job) {
+      return jsonResponse(res, 404, { error: `Promote job not found: ${jobId}` });
+    }
+    return jsonResponse(res, 200, job);
+  }
+
+  // DELETE /api/assertion/promote-async/:jobId   — cancel a queued/failed_retrying job
+  if (
+    req.method === "DELETE" &&
+    path.startsWith("/api/assertion/promote-async/")
+  ) {
+    const jobId = safeDecodeURIComponent(
+      path.slice("/api/assertion/promote-async/".length),
+      res,
+    );
+    if (jobId === null) return;
+    try {
+      await agent.assertion.cancelPromoteAsync(jobId);
+      const job = await agent.assertion.getPromoteAsyncStatus(jobId);
+      return jsonResponse(res, 200, { jobId, state: job?.state ?? "failed" });
+    } catch (err: any) {
+      if (err.message?.includes("not found")) {
+        return jsonResponse(res, 404, { error: err.message });
+      }
+      // "Cannot cancel job in state 'running'" etc.
+      if (err.message?.includes("Cannot cancel")) {
+        return jsonResponse(res, 409, { error: err.message });
+      }
+      throw err;
+    }
+  }
+
+  // POST /api/assertion/promote-async/:jobId/recover   — requeue a terminal-failed job
+  if (
+    req.method === "POST" &&
+    path.startsWith("/api/assertion/promote-async/") &&
+    path.endsWith("/recover")
+  ) {
+    const jobId = safeDecodeURIComponent(
+      path.slice("/api/assertion/promote-async/".length, -"/recover".length),
+      res,
+    );
+    if (jobId === null) return;
+    try {
+      await agent.assertion.recoverPromoteAsync(jobId);
+      const job = await agent.assertion.getPromoteAsyncStatus(jobId);
+      return jsonResponse(res, 200, { jobId, state: job?.state ?? "queued" });
+    } catch (err: any) {
+      if (err.message?.includes("not found")) {
+        return jsonResponse(res, 404, { error: err.message });
+      }
+      if (err.message?.includes("Cannot recover")) {
+        return jsonResponse(res, 409, { error: err.message });
       }
       throw err;
     }

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -1469,11 +1469,9 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
         assertionName,
         { entities: entities ?? "all", subGraphName },
       );
-      const job = await agent.assertion.getPromoteAsyncStatus(result.jobId);
       return jsonResponse(res, 200, {
         jobId: result.jobId,
-        state: job?.state ?? "queued",
-        enqueuedAt: job?.enqueuedAt,
+        state: "queued",
       });
     } catch (err: any) {
       if (err instanceof PromoteJobConflictError) {
@@ -1516,7 +1514,12 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     const stateFilter = requestedStates as PromoteJobState[] | undefined;
     const contextGraphId = url.searchParams.get("contextGraphId") ?? undefined;
     const limitParam = url.searchParams.get("limit");
-    const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+    if (limitParam !== null && !/^[1-9]\d*$/.test(limitParam)) {
+      return jsonResponse(res, 400, {
+        error: "limit must be a positive integer ≤ 1000",
+      });
+    }
+    const limit = limitParam !== null ? Number.parseInt(limitParam, 10) : undefined;
     if (limit !== undefined && (!Number.isFinite(limit) || limit <= 0 || limit > 1000)) {
       return jsonResponse(res, 400, {
         error: "limit must be a positive integer ≤ 1000",

--- a/packages/cli/src/daemon/state.ts
+++ b/packages/cli/src/daemon/state.ts
@@ -43,6 +43,22 @@ export const daemonState: {
   standaloneCache: boolean | null;
   /** CORS allowlist, set by `runDaemonInner`, read in `handleRequest`. */
   moduleCorsAllowed: CorsAllowlist;
+  /**
+   * Whether the async-promote queue worker is currently able to drain
+   * queued jobs. Defaults to `false` so that until something explicitly
+   * starts a worker (the supervisor lands in a follow-up PR — see
+   * `docs/specs/SPEC_ASYNC_PROMOTE_QUEUE_IMPLEMENTATION_PLAN.md`), the
+   * `/promote-async` routes return `503` rather than silently accepting
+   * jobs that would sit in `queued` forever.
+   */
+  promoteWorkerAvailable: boolean;
+  /**
+   * Optional reason surfaced alongside the `503` when
+   * `promoteWorkerAvailable` is `false`. Set by the worker supervisor
+   * when startup fails (so operators see why jobs can't run), and left
+   * `null` in this PR because no supervisor exists yet.
+   */
+  promoteWorkerUnavailableReason: string | null;
   /** OpenClaw bridge health cache. Mutated from both `openclaw.ts`
    *  (read) and `handle-request.ts` (write after each /send round
    *  trip), so it lives here rather than inside openclaw.ts. */
@@ -58,6 +74,8 @@ export const daemonState: {
   },
   standaloneCache: null,
   moduleCorsAllowed: '*',
+  promoteWorkerAvailable: false,
+  promoteWorkerUnavailableReason: null,
   openClawBridgeHealth: null,
 };
 

--- a/packages/cli/test/promote-async-routes.test.ts
+++ b/packages/cli/test/promote-async-routes.test.ts
@@ -173,7 +173,7 @@ describe('promote-async daemon routes', () => {
     expect(r.status).toBe(200);
     expect(r.body.jobId).toBe('job-1');
     expect(r.body.state).toBe('queued');
-    expect(r.body.enqueuedAt).toBeTypeOf('number');
+    expect(r.body.enqueuedAt).toBeUndefined();
   });
 
   it('POST /:name/promote-async returns 409 with existingJobId on duplicate enqueue', async () => {
@@ -312,6 +312,13 @@ describe('promote-async daemon routes', () => {
   it('GET /promote-async?limit=abc returns 400', async () => {
     await startRoutes(makeAgent());
     const r = await get('/api/assertion/promote-async?limit=abc');
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/positive integer/);
+  });
+
+  it('GET /promote-async?limit=10foo returns 400 instead of coercing', async () => {
+    await startRoutes(makeAgent());
+    const r = await get('/api/assertion/promote-async?limit=10foo');
     expect(r.status).toBe(400);
     expect(r.body.error).toMatch(/positive integer/);
   });

--- a/packages/cli/test/promote-async-routes.test.ts
+++ b/packages/cli/test/promote-async-routes.test.ts
@@ -27,6 +27,7 @@ import {
   type PromoteListFilter,
 } from '@origintrail-official/dkg-publisher';
 import { handleAssertionRoutes } from '../src/daemon/routes/assertion.js';
+import { daemonState } from '../src/daemon/state.js';
 
 describe('promote-async daemon routes', () => {
   let server: Server | undefined;
@@ -44,6 +45,11 @@ describe('promote-async daemon routes', () => {
       idGenerator: () => `job-${++idCounter}`,
       backoff: () => 60_000,
     });
+    // The supervisor that flips this on lives in a follow-up PR; for
+    // the wire-contract tests we pretend the worker is already up.
+    // Individual tests can flip it back off to exercise the 503 path.
+    daemonState.promoteWorkerAvailable = true;
+    daemonState.promoteWorkerUnavailableReason = null;
   });
 
   afterEach(async () => {
@@ -53,6 +59,8 @@ describe('promote-async daemon routes', () => {
       });
       server = undefined;
     }
+    daemonState.promoteWorkerAvailable = false;
+    daemonState.promoteWorkerUnavailableReason = null;
   });
 
   function makeAgent() {
@@ -160,6 +168,55 @@ describe('promote-async daemon routes', () => {
   }
 
   // ---------------------------------------------------------------------------
+  // Worker-availability gate (RFC §3.1 / Codex PR #660 review id=3302072808)
+  //
+  // The async-promote routes go public in this PR but the supervisor that
+  // drains the queue ships in a follow-up PR. Until `promoteWorkerAvailable`
+  // flips to true, every enqueue / list / status call must return 503 with
+  // a reason — silently accepting jobs that would sit `queued` forever is
+  // exactly the "silent black hole" the reviewer flagged.
+  // ---------------------------------------------------------------------------
+
+  it('POST /:name/promote-async returns 503 when the worker is unavailable', async () => {
+    daemonState.promoteWorkerAvailable = false;
+    daemonState.promoteWorkerUnavailableReason = null;
+    await startRoutes(makeAgent());
+    const r = await post('/api/assertion/x/promote-async', {
+      contextGraphId: 'cg',
+      entities: 'all',
+    });
+    expect(r.status).toBe(503);
+    expect(r.body.error).toMatch(/async-promote worker is not available/i);
+  });
+
+  it('POST /:name/promote-async surfaces the unavailability reason when set', async () => {
+    daemonState.promoteWorkerAvailable = false;
+    daemonState.promoteWorkerUnavailableReason = 'supervisor crashed during recoverOnStartup';
+    await startRoutes(makeAgent());
+    const r = await post('/api/assertion/x/promote-async', { contextGraphId: 'cg' });
+    expect(r.status).toBe(503);
+    expect(r.body.error).toContain('supervisor crashed during recoverOnStartup');
+  });
+
+  it('GET /promote-async returns 503 when the worker is unavailable', async () => {
+    daemonState.promoteWorkerAvailable = false;
+    daemonState.promoteWorkerUnavailableReason = null;
+    await startRoutes(makeAgent());
+    const r = await get('/api/assertion/promote-async');
+    expect(r.status).toBe(503);
+    expect(r.body.error).toMatch(/async-promote worker is not available/i);
+  });
+
+  it('GET /promote-async/:jobId returns 503 when the worker is unavailable', async () => {
+    daemonState.promoteWorkerAvailable = false;
+    daemonState.promoteWorkerUnavailableReason = null;
+    await startRoutes(makeAgent());
+    const r = await get('/api/assertion/promote-async/anything');
+    expect(r.status).toBe(503);
+    expect(r.body.error).toMatch(/async-promote worker is not available/i);
+  });
+
+  // ---------------------------------------------------------------------------
   // POST /api/assertion/:name/promote-async
   // ---------------------------------------------------------------------------
 
@@ -225,18 +282,48 @@ describe('promote-async daemon routes', () => {
   // GET /api/assertion/promote-async/:jobId
   // ---------------------------------------------------------------------------
 
-  it('GET /promote-async/:jobId returns the full job', async () => {
+  it('GET /promote-async/:jobId returns the documented wire schema (RFC §3.2)', async () => {
     await startRoutes(makeAgent());
     const enq = await post('/api/assertion/single/promote-async', {
       contextGraphId: 'cg',
+      subGraphName: 'sg',
       entities: 'all',
     });
     const r = await get(`/api/assertion/promote-async/${enq.body.jobId}`);
     expect(r.status).toBe(200);
     expect(r.body.jobId).toBe(enq.body.jobId);
     expect(r.body.state).toBe('queued');
-    expect(r.body.request.contextGraphId).toBe('cg');
-    expect(r.body.attempt.maxRetries).toBeGreaterThan(0);
+    // Flat assertion identity at the top level, not nested under `request`.
+    expect(r.body.contextGraphId).toBe('cg');
+    expect(r.body.assertionName).toBe('single');
+    expect(r.body.subGraphName).toBe('sg');
+    expect(r.body.entities).toBe('all');
+    expect(r.body.attempts).toBe(0);
+    expect(r.body.maxAttempts).toBeGreaterThan(0);
+    // ISO-8601 timestamps, not raw epoch ms.
+    expect(typeof r.body.enqueuedAt).toBe('string');
+    expect(new Date(r.body.enqueuedAt).toISOString()).toBe(r.body.enqueuedAt);
+    expect(typeof r.body.updatedAt).toBe('string');
+  });
+
+  it('GET /promote-async/:jobId never leaks the internal queue shape (claimToken, request, attempt, commitMarker)', async () => {
+    await startRoutes(makeAgent());
+    const enq = await post('/api/assertion/internals/promote-async', {
+      contextGraphId: 'cg',
+      entities: 'all',
+    });
+    // Force the job into `running` so the queue assigns a lease + claim
+    // token; the wire shape must still hide both.
+    await queue.claimNext('test-worker');
+    const r = await get(`/api/assertion/promote-async/${enq.body.jobId}`);
+    expect(r.status).toBe(200);
+    expect(r.body.state).toBe('running');
+    expect(r.body).not.toHaveProperty('request');
+    expect(r.body).not.toHaveProperty('attempt');
+    expect(r.body).not.toHaveProperty('lease');
+    expect(r.body).not.toHaveProperty('commitMarker');
+    expect(JSON.stringify(r.body)).not.toContain('claimToken');
+    expect(JSON.stringify(r.body)).not.toContain('workerId');
   });
 
   it('GET /promote-async/:jobId returns 404 for unknown job', async () => {
@@ -277,7 +364,7 @@ describe('promote-async daemon routes', () => {
     const r = await get('/api/assertion/promote-async?contextGraphId=cg-1');
     expect(r.status).toBe(200);
     expect(r.body.jobs).toHaveLength(2);
-    expect(r.body.jobs.every((j: PromoteJob) => j.request.contextGraphId === 'cg-1')).toBe(true);
+    expect(r.body.jobs.every((j: { contextGraphId: string }) => j.contextGraphId === 'cg-1')).toBe(true);
   });
 
   it('GET /promote-async?state=queued filters by state', async () => {

--- a/packages/cli/test/promote-async-routes.test.ts
+++ b/packages/cli/test/promote-async-routes.test.ts
@@ -163,14 +163,14 @@ describe('promote-async daemon routes', () => {
   // POST /api/assertion/:name/promote-async
   // ---------------------------------------------------------------------------
 
-  it('POST /:name/promote-async returns 202 with jobId on success', async () => {
+  it('POST /:name/promote-async returns 200 with jobId on success', async () => {
     await startRoutes(makeAgent());
     const r = await post('/api/assertion/my-assertion/promote-async', {
       contextGraphId: 'graphify',
       subGraphName: 'code',
       entities: 'all',
     });
-    expect(r.status).toBe(202);
+    expect(r.status).toBe(200);
     expect(r.body.jobId).toBe('job-1');
     expect(r.body.state).toBe('queued');
     expect(r.body.enqueuedAt).toBeTypeOf('number');
@@ -183,7 +183,7 @@ describe('promote-async daemon routes', () => {
       subGraphName: 'sub',
       entities: 'all',
     });
-    expect(first.status).toBe(202);
+    expect(first.status).toBe(200);
     const second = await post('/api/assertion/dup/promote-async', {
       contextGraphId: 'cg',
       subGraphName: 'sub',
@@ -216,7 +216,7 @@ describe('promote-async daemon routes', () => {
       contextGraphId: 'cg',
       entities: ['urn:dkg:entity:a', 'urn:dkg:entity:b'],
     });
-    expect(r.status).toBe(202);
+    expect(r.status).toBe(200);
     const job = await queue.getStatus(r.body.jobId);
     expect(job?.request.entities).toEqual(['urn:dkg:entity:a', 'urn:dkg:entity:b']);
   });
@@ -244,6 +244,13 @@ describe('promote-async daemon routes', () => {
     const r = await get('/api/assertion/promote-async/non-existent');
     expect(r.status).toBe(404);
     expect(r.body.error).toMatch(/not found/i);
+  });
+
+  it('GET /promote-async/:jobId rejects unsafe path values before queue lookup', async () => {
+    await startRoutes(makeAgent());
+    const r = await get('/api/assertion/promote-async/job%3Ebad');
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/Invalid promote jobId/);
   });
 
   // ---------------------------------------------------------------------------
@@ -295,6 +302,13 @@ describe('promote-async daemon routes', () => {
     expect(r.body.error).toMatch(/Invalid state filter/);
   });
 
+  it('GET /promote-async?state=queued,garbage rejects the whole filter', async () => {
+    await startRoutes(makeAgent());
+    const r = await get('/api/assertion/promote-async?state=queued,garbage');
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/Invalid state filter/);
+  });
+
   it('GET /promote-async?limit=abc returns 400', async () => {
     await startRoutes(makeAgent());
     const r = await get('/api/assertion/promote-async?limit=abc');
@@ -331,6 +345,13 @@ describe('promote-async daemon routes', () => {
     expect(r.status).toBe(404);
   });
 
+  it('DELETE /promote-async/:jobId rejects unsafe path values before queue lookup', async () => {
+    await startRoutes(makeAgent());
+    const r = await del('/api/assertion/promote-async/job%20bad');
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/Invalid promote jobId/);
+  });
+
   // ---------------------------------------------------------------------------
   // POST /api/assertion/promote-async/:jobId/recover
   // ---------------------------------------------------------------------------
@@ -358,6 +379,13 @@ describe('promote-async daemon routes', () => {
     await startRoutes(makeAgent());
     const r = await post('/api/assertion/promote-async/non-existent/recover', {});
     expect(r.status).toBe(404);
+  });
+
+  it('POST /promote-async/:jobId/recover rejects unsafe path values before queue lookup', async () => {
+    await startRoutes(makeAgent());
+    const r = await post('/api/assertion/promote-async/job%3Ebad/recover', {});
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/Invalid promote jobId/);
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/cli/test/promote-async-routes.test.ts
+++ b/packages/cli/test/promote-async-routes.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Async-promote queue HTTP routes.
+ *
+ * Five new routes added by PR #2 of the async-promote-queue series:
+ *
+ *   POST   /api/assertion/:name/promote-async
+ *   GET    /api/assertion/promote-async
+ *   GET    /api/assertion/promote-async/:jobId
+ *   DELETE /api/assertion/promote-async/:jobId
+ *   POST   /api/assertion/promote-async/:jobId/recover
+ *
+ * Pattern mirrors `import-artifact-routes.test.ts`: spin up a real HTTP
+ * server with `handleAssertionRoutes`, hand it a minimal mock agent
+ * whose `assertion` subsurface delegates to a real
+ * `TripleStoreAsyncPromoteQueue` backed by `OxigraphStore`. This means
+ * we test the wire contract AND the queue invariants end-to-end without
+ * needing hardhat.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  TripleStoreAsyncPromoteQueue,
+  type AsyncPromoteQueue,
+  type PromoteJob,
+  type PromoteListFilter,
+} from '@origintrail-official/dkg-publisher';
+import { handleAssertionRoutes } from '../src/daemon/routes/assertion.js';
+
+describe('promote-async daemon routes', () => {
+  let server: Server | undefined;
+  let baseUrl: string;
+  let now: number;
+  let idCounter: number;
+  let queue: AsyncPromoteQueue;
+
+  beforeEach(() => {
+    now = 1_700_000_000_000;
+    idCounter = 0;
+    const store = new OxigraphStore();
+    queue = new TripleStoreAsyncPromoteQueue(store, {
+      now: () => now,
+      idGenerator: () => `job-${++idCounter}`,
+      backoff: () => 60_000,
+    });
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server!.close((err) => (err ? reject(err) : resolve()));
+      });
+      server = undefined;
+    }
+  });
+
+  function makeAgent() {
+    return {
+      assertion: {
+        async promoteAsync(
+          contextGraphId: string,
+          name: string,
+          opts?: { entities?: readonly string[] | 'all'; subGraphName?: string },
+        ): Promise<{ jobId: string }> {
+          const jobId = await queue.enqueue({
+            contextGraphId,
+            assertionName: name,
+            subGraphName: opts?.subGraphName,
+            entities: opts?.entities ?? 'all',
+          });
+          return { jobId };
+        },
+        async getPromoteAsyncStatus(jobId: string): Promise<PromoteJob | null> {
+          return queue.getStatus(jobId);
+        },
+        async listPromoteAsyncJobs(filter?: PromoteListFilter): Promise<PromoteJob[]> {
+          return queue.list(filter);
+        },
+        async cancelPromoteAsync(jobId: string): Promise<void> {
+          return queue.cancel(jobId);
+        },
+        async recoverPromoteAsync(jobId: string): Promise<void> {
+          return queue.recover(jobId);
+        },
+      },
+    };
+  }
+
+  async function startRoutes(agent: ReturnType<typeof makeAgent>) {
+    server = createServer(async (req, res) => {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      try {
+        await handleAssertionRoutes({
+          req,
+          res,
+          agent,
+          publisherControl: {},
+          publisherRuntime: null,
+          config: {},
+          startedAt: Date.now(),
+          dashDb: {},
+          opWallets: {},
+          network: {},
+          tracker: {},
+          memoryManager: {},
+          bridgeAuthToken: undefined,
+          nodeVersion: 'test',
+          nodeCommit: 'test',
+          catchupTracker: { jobs: new Map(), latestByContextGraph: new Map() },
+          extractionRegistry: {},
+          fileStore: {},
+          extractionStatus: new Map(),
+          assertionImportLocks: new Map(),
+          vectorStore: {},
+          embeddingProvider: null,
+          validTokens: new Set(),
+          apiHost: '127.0.0.1',
+          apiPortRef: { value: 0 },
+          url,
+          path: url.pathname,
+          requestToken: undefined,
+          requestAgentAddress: 'did:dkg:agent:test',
+          emitMemoryGraphChanged: () => {},
+        } as any);
+        if (!res.writableEnded) {
+          res.statusCode = 404;
+          res.end();
+        }
+      } catch (err: any) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: `Unhandled: ${err?.message ?? err}` }));
+      }
+    });
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+    const addr = server!.address();
+    if (!addr || typeof addr === 'string') throw new Error('server did not bind');
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  }
+
+  async function post(path: string, body?: Record<string, unknown>) {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    const json = await res.json().catch(() => null);
+    return { status: res.status, body: json };
+  }
+  async function get(path: string) {
+    const res = await fetch(`${baseUrl}${path}`);
+    const json = await res.json().catch(() => null);
+    return { status: res.status, body: json };
+  }
+  async function del(path: string) {
+    const res = await fetch(`${baseUrl}${path}`, { method: 'DELETE' });
+    const json = await res.json().catch(() => null);
+    return { status: res.status, body: json };
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /api/assertion/:name/promote-async
+  // ---------------------------------------------------------------------------
+
+  it('POST /:name/promote-async returns 202 with jobId on success', async () => {
+    await startRoutes(makeAgent());
+    const r = await post('/api/assertion/my-assertion/promote-async', {
+      contextGraphId: 'graphify',
+      subGraphName: 'code',
+      entities: 'all',
+    });
+    expect(r.status).toBe(202);
+    expect(r.body.jobId).toBe('job-1');
+    expect(r.body.state).toBe('queued');
+    expect(r.body.enqueuedAt).toBeTypeOf('number');
+  });
+
+  it('POST /:name/promote-async returns 409 with existingJobId on duplicate enqueue', async () => {
+    await startRoutes(makeAgent());
+    const first = await post('/api/assertion/dup/promote-async', {
+      contextGraphId: 'cg',
+      subGraphName: 'sub',
+      entities: 'all',
+    });
+    expect(first.status).toBe(202);
+    const second = await post('/api/assertion/dup/promote-async', {
+      contextGraphId: 'cg',
+      subGraphName: 'sub',
+      entities: 'all',
+    });
+    expect(second.status).toBe(409);
+    expect(second.body.existingJobId).toBe(first.body.jobId);
+    expect(second.body.error).toMatch(/already active/i);
+  });
+
+  it('POST /:name/promote-async returns 400 on missing contextGraphId', async () => {
+    await startRoutes(makeAgent());
+    const r = await post('/api/assertion/x/promote-async', { entities: 'all' });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/contextGraphId/);
+  });
+
+  it('POST /:name/promote-async returns 400 on invalid assertion name', async () => {
+    await startRoutes(makeAgent());
+    const r = await post('/api/assertion/..%2Fbad/promote-async', {
+      contextGraphId: 'cg',
+    });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/Invalid assertion name/);
+  });
+
+  it('POST /:name/promote-async accepts an explicit entities list', async () => {
+    await startRoutes(makeAgent());
+    const r = await post('/api/assertion/list/promote-async', {
+      contextGraphId: 'cg',
+      entities: ['urn:dkg:entity:a', 'urn:dkg:entity:b'],
+    });
+    expect(r.status).toBe(202);
+    const job = await queue.getStatus(r.body.jobId);
+    expect(job?.request.entities).toEqual(['urn:dkg:entity:a', 'urn:dkg:entity:b']);
+  });
+
+  // ---------------------------------------------------------------------------
+  // GET /api/assertion/promote-async/:jobId
+  // ---------------------------------------------------------------------------
+
+  it('GET /promote-async/:jobId returns the full job', async () => {
+    await startRoutes(makeAgent());
+    const enq = await post('/api/assertion/single/promote-async', {
+      contextGraphId: 'cg',
+      entities: 'all',
+    });
+    const r = await get(`/api/assertion/promote-async/${enq.body.jobId}`);
+    expect(r.status).toBe(200);
+    expect(r.body.jobId).toBe(enq.body.jobId);
+    expect(r.body.state).toBe('queued');
+    expect(r.body.request.contextGraphId).toBe('cg');
+    expect(r.body.attempt.maxRetries).toBeGreaterThan(0);
+  });
+
+  it('GET /promote-async/:jobId returns 404 for unknown job', async () => {
+    await startRoutes(makeAgent());
+    const r = await get('/api/assertion/promote-async/non-existent');
+    expect(r.status).toBe(404);
+    expect(r.body.error).toMatch(/not found/i);
+  });
+
+  // ---------------------------------------------------------------------------
+  // GET /api/assertion/promote-async (list)
+  // ---------------------------------------------------------------------------
+
+  it('GET /promote-async lists all jobs', async () => {
+    await startRoutes(makeAgent());
+    await post('/api/assertion/a/promote-async', { contextGraphId: 'cg-1' });
+    await post('/api/assertion/b/promote-async', { contextGraphId: 'cg-2' });
+    await post('/api/assertion/c/promote-async', { contextGraphId: 'cg-1' });
+
+    const r = await get('/api/assertion/promote-async');
+    expect(r.status).toBe(200);
+    expect(r.body.jobs).toHaveLength(3);
+  });
+
+  it('GET /promote-async?contextGraphId=cg scopes by CG', async () => {
+    await startRoutes(makeAgent());
+    await post('/api/assertion/a/promote-async', { contextGraphId: 'cg-1' });
+    await post('/api/assertion/b/promote-async', { contextGraphId: 'cg-2' });
+    await post('/api/assertion/c/promote-async', { contextGraphId: 'cg-1' });
+
+    const r = await get('/api/assertion/promote-async?contextGraphId=cg-1');
+    expect(r.status).toBe(200);
+    expect(r.body.jobs).toHaveLength(2);
+    expect(r.body.jobs.every((j: PromoteJob) => j.request.contextGraphId === 'cg-1')).toBe(true);
+  });
+
+  it('GET /promote-async?state=queued filters by state', async () => {
+    await startRoutes(makeAgent());
+    const a = await post('/api/assertion/a/promote-async', { contextGraphId: 'cg' });
+    const b = await post('/api/assertion/b/promote-async', { contextGraphId: 'cg' });
+    await del(`/api/assertion/promote-async/${a.body.jobId}`);
+
+    const queued = await get('/api/assertion/promote-async?state=queued');
+    expect(queued.body.jobs).toHaveLength(1);
+    expect(queued.body.jobs[0].jobId).toBe(b.body.jobId);
+
+    const failed = await get('/api/assertion/promote-async?state=failed');
+    expect(failed.body.jobs).toHaveLength(1);
+    expect(failed.body.jobs[0].jobId).toBe(a.body.jobId);
+  });
+
+  it('GET /promote-async?state=garbage returns 400', async () => {
+    await startRoutes(makeAgent());
+    const r = await get('/api/assertion/promote-async?state=garbage');
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/Invalid state filter/);
+  });
+
+  it('GET /promote-async?limit=abc returns 400', async () => {
+    await startRoutes(makeAgent());
+    const r = await get('/api/assertion/promote-async?limit=abc');
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/positive integer/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // DELETE /api/assertion/promote-async/:jobId
+  // ---------------------------------------------------------------------------
+
+  it('DELETE /promote-async/:jobId cancels a queued job', async () => {
+    await startRoutes(makeAgent());
+    const enq = await post('/api/assertion/cancel-me/promote-async', { contextGraphId: 'cg' });
+    const r = await del(`/api/assertion/promote-async/${enq.body.jobId}`);
+    expect(r.status).toBe(200);
+    expect(r.body.state).toBe('failed');
+    const job = await queue.getStatus(enq.body.jobId);
+    expect(job?.reason).toBe('cancelled');
+  });
+
+  it('DELETE /promote-async/:jobId returns 409 for running job', async () => {
+    await startRoutes(makeAgent());
+    const enq = await post('/api/assertion/running/promote-async', { contextGraphId: 'cg' });
+    await queue.claimNext('test-worker');
+    const r = await del(`/api/assertion/promote-async/${enq.body.jobId}`);
+    expect(r.status).toBe(409);
+    expect(r.body.error).toMatch(/Cannot cancel.*running/);
+  });
+
+  it('DELETE /promote-async/:jobId returns 404 for unknown job', async () => {
+    await startRoutes(makeAgent());
+    const r = await del('/api/assertion/promote-async/non-existent');
+    expect(r.status).toBe(404);
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /api/assertion/promote-async/:jobId/recover
+  // ---------------------------------------------------------------------------
+
+  it('POST /promote-async/:jobId/recover requeues a failed job', async () => {
+    await startRoutes(makeAgent());
+    const enq = await post('/api/assertion/recoverable/promote-async', { contextGraphId: 'cg' });
+    await del(`/api/assertion/promote-async/${enq.body.jobId}`);
+    expect((await queue.getStatus(enq.body.jobId))?.state).toBe('failed');
+
+    const r = await post(`/api/assertion/promote-async/${enq.body.jobId}/recover`, {});
+    expect(r.status).toBe(200);
+    expect(r.body.state).toBe('queued');
+  });
+
+  it('POST /promote-async/:jobId/recover returns 409 for non-failed job', async () => {
+    await startRoutes(makeAgent());
+    const enq = await post('/api/assertion/queued/promote-async', { contextGraphId: 'cg' });
+    const r = await post(`/api/assertion/promote-async/${enq.body.jobId}/recover`, {});
+    expect(r.status).toBe(409);
+    expect(r.body.error).toMatch(/Cannot recover/);
+  });
+
+  it('POST /promote-async/:jobId/recover returns 404 for unknown job', async () => {
+    await startRoutes(makeAgent());
+    const r = await post('/api/assertion/promote-async/non-existent/recover', {});
+    expect(r.status).toBe(404);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Routing precedence — the list route (`/promote-async`) must not be
+  // claimed by the per-job route (`/promote-async/:jobId`).
+  // ---------------------------------------------------------------------------
+
+  it('GET /promote-async (no jobId) hits the list route, not the per-job route', async () => {
+    await startRoutes(makeAgent());
+    await post('/api/assertion/x/promote-async', { contextGraphId: 'cg' });
+    const r = await get('/api/assertion/promote-async');
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.body.jobs)).toBe(true);
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   test: {
     include: runsDaemonHttpBehavior
       ? ['test/daemon-http-behavior-extra.test.ts']
-      : ['test/api-client.test.ts', 'test/memory-graph-events.test.ts', 'test/trust-endpoint-validation.test.ts', 'test/daemon/plugin-loader.test.ts', 'test/daemon/routes/plugins.test.ts', 'test/auth.test.ts'],
+      : ['test/api-client.test.ts', 'test/memory-graph-events.test.ts', 'test/trust-endpoint-validation.test.ts', 'test/daemon/plugin-loader.test.ts', 'test/daemon/routes/plugins.test.ts', 'test/auth.test.ts', 'test/promote-async-routes.test.ts'],
     testTimeout: runsDaemonHttpBehavior ? 120_000 : 60_000,
     globalSetup: runsDaemonHttpBehavior ? ['../chain/test/hardhat-global-setup.ts'] : [],
     env: runsDaemonHttpBehavior ? { HARDHAT_PORT: '9548' } : undefined,

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -104,6 +104,7 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
 
     const now = this.now();
     const jobId = this.idGenerator();
+    this.validateJobId(jobId);
     const job: PromoteJob = {
       jobId,
       request: this.normalizeRequest(request),
@@ -413,6 +414,18 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
           throw new Error('entities array must contain non-empty strings');
         }
       }
+    }
+  }
+
+  private validateJobId(jobId: string): void {
+    if (!jobId || typeof jobId !== 'string') {
+      throw new Error('idGenerator must return a non-empty string jobId');
+    }
+    if (jobId.length > 256) {
+      throw new Error('idGenerator returned a jobId that is too long');
+    }
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(jobId)) {
+      throw new Error("idGenerator returned an unsafe jobId; allowed characters are letters, numbers, '.', '_', ':', and '-'");
     }
   }
 


### PR DESCRIPTION
> **Stacked on [#657](https://github.com/OriginTrail/dkg/pull/657).** Review #657 first; this PR's base will be re-targeted to `main` after #657 merges. The diff against `main` is +1,633/-2 across 4 files; the diff against #657's branch is +633/-2 across 4 files.

## What

PR 2 of the async-promote-queue series. Builds on PR #657 (the `TripleStoreAsyncPromoteQueue` library) by exposing the queue to user code via two layers:

### 1. Agent surface (`packages/agent/src/dkg-agent.ts`, +85)

- **Lazy `agent.promoteQueue` accessor** — single shared `TripleStoreAsyncPromoteQueue` instance, constructed on first use against `agent.store`. The control graph (`urn:dkg:promote-queue:control-plane`) lives in the same triple store as everything else, so the queue survives daemon restarts.
- **5 new methods on `agent.assertion`:**
  - `promoteAsync(cgId, name, opts) → { jobId }`
  - `getPromoteAsyncStatus(jobId) → PromoteJob | null`
  - `listPromoteAsyncJobs(filter?) → PromoteJob[]`
  - `cancelPromoteAsync(jobId)`
  - `recoverPromoteAsync(jobId)`
- **`agent.configurePromoteQueue(config)`** for tests / future daemon config plumbing — must be called before first access.

The worker-side surface (`claimNext` / `heartbeat` / `succeed` / `fail` / `recordCommitMarker` / `recoverOnStartup`) is deliberately NOT exposed on `agent.assertion`. PR #3's worker reaches in via `agent.promoteQueue` directly so user-facing callers can't accidentally drive the lifecycle.

### 2. HTTP routes (`packages/cli/src/daemon/routes/assertion.ts`, +173)

| Method | Path | Behaviour | Errors |
|---|---|---|---|
| `POST` | `/api/assertion/:name/promote-async` | Enqueue → 202 `{ jobId, state, enqueuedAt }` | 400 invalid args, 409 + `existingJobId` on duplicate (uniqueness conflict) |
| `GET` | `/api/assertion/promote-async` | List, scoped by `?contextGraphId`, `?state=queued,running,...`, `?limit=` | 400 garbage filter |
| `GET` | `/api/assertion/promote-async/:jobId` | Single job | 404 if missing |
| `DELETE` | `/api/assertion/promote-async/:jobId` | Cancel queued/failed_retrying | 409 if running, 404 if missing |
| `POST` | `/api/assertion/promote-async/:jobId/recover` | Requeue failed | 409 if not failed, 404 if missing |

All share the `SMALL_BODY_BYTES` (256 KB) cap, per RFC §3.1.

**Routing precedence** in the linear `startsWith`/`endsWith` dispatch:
- The collection `GET /promote-async` is checked BEFORE the per-job `GET /promote-async/:jobId` so the list route isn't claimed by the per-job handler.
- The per-job `GET` filters out `/recover`-suffixed paths so the recover `POST` keeps its place.
- All `/promote-async` routes are checked AFTER the existing sync `/promote` route to keep that contract untouched.

### 3. Tests (`packages/cli/test/promote-async-routes.test.ts`, +375)

Mirrors `import-artifact-routes.test.ts` pattern: real HTTP server, real `TripleStoreAsyncPromoteQueue` backed by `OxigraphStore`, mock agent whose `assertion` subsurface delegates to the queue. Tests exercise the wire contract AND the queue invariants end-to-end:

- ✅ happy path enqueue + 202 response
- ✅ duplicate enqueue returns 409 with `existingJobId`
- ✅ missing/invalid params return 400
- ✅ explicit `entities` array round-trips
- ✅ GET status, list (incl. `?contextGraphId` / `?state` / `?limit`)
- ✅ 400 on garbage filter values
- ✅ DELETE happy path + 409 on running job + 404 on missing
- ✅ POST `.../recover` happy path + 409 + 404
- ✅ routing precedence assertion (list vs per-job)

All 19 pass:

```
✓ test/promote-async-routes.test.ts (19 tests) 1547ms
```

## Verification

```bash
# PR #1 queue tests (still green — no regression from new wiring)
cd packages/publisher && pnpm exec vitest --config vitest.unit.config.ts run test/async-promote-queue.test.ts
# → 32 passed

# PR #2 route tests
cd packages/cli && pnpm exec vitest --config vitest.unit.config.ts run test/promote-async-routes.test.ts
# → 19 passed

# tsc clean across the dependency chain (chain → core → node-ui → publisher → agent → cli)
pnpm -r build  # all green
```

## What's still NOT in this PR (and why)

- **No worker loop.** Until PR #3 lands, jobs sit in `queued` and never transition to `running`. The HTTP routes still work for inspecting/cancelling/recovering — this lets us validate the agent surface against real test clients before adding the live worker.
- **No `memoryGraphChanged` events.** Enqueueing isn't a memory change; that event will be emitted from the worker (PR #3) when a job hits `succeeded`.
- **No `importLimits.promoteWorkerConcurrency` on `/api/status`.** Comes with PR #4.

## Stacked review order

`PR #657 → PR #658 (this) → PR #3 → PR #4`. Each builds on the previous; each is reviewable as-is.

Made with [Cursor](https://cursor.com)