### PR TITLE
fix(node-ui): graph view shows entities only, drops vocabulary-value nodes

### DIFF
--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -389,6 +389,21 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
 
 export const buildMemoryEntities = buildEntities;
 
+/**
+ * Canonical "first-class entity" predicate — an entity belongs in the
+ * Entities tab list (and therefore the graph node set) iff it has at
+ * least one own type, property, or outgoing connection. The Map built
+ * by `buildEntities` also contains synthesised stubs for pure-object
+ * URIs (vocab constants, IPFS refs, DID property values); those fail
+ * this predicate and are filtered out. Single source of truth — any
+ * place that needs to ask "is this a real entity vs an object stub"
+ * MUST go through this helper so the rule stays in lockstep across
+ * the Entities tab, the graph filter, etc.
+ */
+export function isFirstClassEntity(e: MemoryEntity): boolean {
+  return e.types.length > 0 || e.properties.size > 0 || e.connections.length > 0;
+}
+
 export function useMemoryEntities(
   contextGraphId: string,
   opts?: { signalErrors?: boolean },
@@ -466,7 +481,7 @@ export function useMemoryEntities(
 
   const entityList = useMemo(() =>
     [...entities.values()]
-      .filter(e => e.types.length > 0 || e.properties.size > 0 || e.connections.length > 0)
+      .filter(isFirstClassEntity)
       .sort((a, b) => {
         const trustOrder = { verified: 0, shared: 1, working: 2 };
         const td = trustOrder[a.trustLevel] - trustOrder[b.trustLevel];

--- a/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
+++ b/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
@@ -117,9 +117,16 @@ export interface SwmAttributionsResult {
 
 /** Deliberately picked for contrast against the existing class palette
  *  (Package purple, Function amber, Decision red, Task cyan, etc.) — these
- *  sit in the gaps so agent identity reads as its own axis. */
+ *  sit in the gaps so agent identity reads as its own axis.
+ *
+ *  Also picked so no slot lives in the SWM-family amber range. The
+ *  SWM layer default is `#f59e0b` (`LAYER_CONFIG.swm.color`) and any
+ *  agent slot in the same hue is visually indistinguishable from a
+ *  non-attributed node — the "agent palette ≠ SWM amber" invariant.
+ *  Orange `#f97316` previously occupied slot 0 and broke this in
+ *  single-agent dev setups; replaced with indigo `#6366f1`. */
 const AGENT_PALETTE = [
-  '#f97316', // orange
+  '#6366f1', // indigo  (replaced orange — was too close to SWM amber)
   '#14b8a6', // teal
   '#f43f5e', // rose
   '#facc15', // yellow

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -16,6 +16,7 @@ import { ShareProjectModal } from '../../components/Modals/ShareProjectModal.js'
 import {
   useMemoryEntities,
   canonicalEntityUri,
+  isFirstClassEntity,
   type TrustLevel, type MemoryEntity, type Triple,
 } from '../../hooks/useMemoryEntities.js';
 import { decodeRdfStringLiteral } from '../../../rdf-literal.js';
@@ -3209,23 +3210,35 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
   );
 
   // Task #25 (PR #677) — entity-only filter for the entity-detail
-  // graph. Mirrors the rule the Entities tab uses
-  // (`useMemoryEntities.ts:467-469`): an entity is in entityList iff
-  // it has at least one of `types`, own `properties`, or outgoing
-  // `connections`. `allEntities` includes synthesised stubs for
-  // pure-object URIs (vocab constants, IPFS refs, DID property
-  // values) so filter to the real entity set before computing
-  // entityUris. `entity.uri` (the detail focus) is always included
-  // so the focal node and its `initialFocus` highlight stay in sync.
-  const renderHoodTriples = useMemo(() => {
-    const entityUris = new Set<string>([canonicalEntityUri(entity.uri)]);
+  // graph. Mirrors the rule the Entities tab uses via the shared
+  // `isFirstClassEntity` predicate exported from `useMemoryEntities`
+  // (single source of truth for the membership rule). `allEntities`
+  // includes synthesised stubs for pure-object URIs (vocab constants,
+  // IPFS refs, DID property values), so we filter to the real entity
+  // set before passing it to the graph filter. The focal entity is
+  // passed via the helper's `focalSubjects` allowlist so it survives
+  // the gate even when the layer's entityList wouldn't otherwise
+  // include it — keeps the focal node and its `initialFocus`
+  // highlight in sync.
+  //
+  // The set rebuild is intentionally split from the filter call so
+  // navigating between KAs (which changes `entity.uri`/`hoodTriples`
+  // but not `allEntities`) doesn't re-iterate the entity map.
+  const renderHoodEntityUris = useMemo(() => {
+    const set = new Set<string>();
     for (const e of allEntities.values()) {
-      if (e.types.length > 0 || e.properties.size > 0 || e.connections.length > 0) {
-        entityUris.add(canonicalEntityUri(e.uri));
-      }
+      if (isFirstClassEntity(e)) set.add(canonicalEntityUri(e.uri));
     }
-    return filterTriplesToEntities(hoodTriples, entityUris);
-  }, [hoodTriples, allEntities, entity.uri]);
+    return set;
+  }, [allEntities]);
+  const focalSubjects = useMemo(
+    () => new Set<string>([canonicalEntityUri(entity.uri)]),
+    [entity.uri],
+  );
+  const renderHoodTriples = useMemo(
+    () => filterTriplesToEntities(hoodTriples, renderHoodEntityUris, { focalSubjects }),
+    [hoodTriples, renderHoodEntityUris, focalSubjects],
+  );
 
   const graphOptions = useMemo(() => {
     const focalColor = TRUST_COLORS[entity.trustLevel];

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -970,6 +970,27 @@ export function LayerGraphPanel({
   );
   const swmAttr = swmAttribution ?? localSwmAttr;
 
+  // Task #25 (PR #677) — entity-only graph filter, render-path side.
+  // `useLayerTriples` stays the honest source of all layer triples
+  // (triple counts, VM hero stats depend on that). The graph view is
+  // the only surface that wants "@id-entities only" semantics, so the
+  // filter lives here. Callers that don't pass `layerEntities` (older
+  // callsites, tests) keep the legacy behaviour of rendering every
+  // resource referenced in `triples`.
+  //
+  // Codex Ev_St/EwIbh: the filter must run on the BASE layer triples
+  // BEFORE `decorationTriples` are merged in. VM provenance overlay
+  // triples (`urn:dkg:viz:anchor:*`, `urn:dkg:viz:agent:*`) are
+  // synthetic, never present in `layerEntities`, and must always
+  // render. Filtering after the merge would strip the entire trust
+  // halo from published Knowledge Assets.
+  const filteredBaseTriples = useMemo(() => {
+    if (!layerEntities || layerEntities.length === 0) return triples;
+    const entityUris = new Set<string>();
+    for (const e of layerEntities) entityUris.add(canonicalEntityUri(e.uri));
+    return filterTriplesToEntities(triples, entityUris);
+  }, [triples, layerEntities]);
+
   const uniqueTriples = useMemo(() => {
     const seen = new Set<string>();
     const out: Triple[] = [];
@@ -979,26 +1000,17 @@ export function LayerGraphPanel({
       seen.add(key);
       out.push({ subject: t.subject, predicate: t.predicate, object: t.object } as Triple);
     };
-    for (const t of triples) push(t);
+    for (const t of filteredBaseTriples) push(t);
     // Decoration triples are only produced for VM; for other layers the
-    // hook returns an empty array so this loop is a no-op.
+    // hook returns an empty array so this loop is a no-op. They
+    // intentionally bypass `filterTriplesToEntities` — synthetic viz
+    // nodes aren't in `entityList` by design and must always show as
+    // the trust halo around published KAs.
     for (const t of decorationTriples) push(t);
     return out;
-  }, [triples, decorationTriples]);
+  }, [filteredBaseTriples, decorationTriples]);
 
-  // Task #25 (PR #677) — entity-only graph filter, render-path side.
-  // `useLayerTriples` stays the honest source of all layer triples
-  // (triple counts, VM hero stats depend on that). The graph view is
-  // the only surface that wants "@id-entities only" semantics, so the
-  // filter lives here. Callers that don't pass `layerEntities` (older
-  // callsites, tests) keep the legacy behaviour of rendering every
-  // resource referenced in `triples`.
-  const renderTriples = useMemo(() => {
-    if (!layerEntities || layerEntities.length === 0) return uniqueTriples;
-    const entityUris = new Set<string>();
-    for (const e of layerEntities) entityUris.add(canonicalEntityUri(e.uri));
-    return filterTriplesToEntities(uniqueTriples, entityUris);
-  }, [uniqueTriples, layerEntities]);
+  const renderTriples = uniqueTriples;
 
   // Only SWM layer uses per-URI node tints — for the rest, classColors rules
   // so code graphs stay legible (Package purple / File blue / etc).
@@ -3636,13 +3648,22 @@ export function SubGraphOverviewGrid({
   }, [memory.entityList]);
 
   // Task #25 (PR #677) — entity-only filter for the mini-card
-  // thumbnails. Same rule the Entities tab uses; computed once across
-  // `memory.entityList` (already filtered to entries with own data)
-  // and reused per card.
-  const entityUris = useMemo(() => {
-    const s = new Set<string>();
-    for (const e of memory.entityList) s.add(canonicalEntityUri(e.uri));
-    return s;
+  // thumbnails. Same rule the Entities tab uses; computed per card
+  // scoped to that card's sub-graph (Codex Ev_S2): an entity that's
+  // first-class in sub-graph B but only a value/provenance object in
+  // sub-graph A must not render on A's thumbnail. Per-sub-graph scope
+  // = `memory.entityList.filter(e => e.subGraphs.has(sg.name))`.
+  const entityUrisBySubGraph = useMemo(() => {
+    const out = new Map<string, Set<string>>();
+    for (const e of memory.entityList) {
+      const canonical = canonicalEntityUri(e.uri);
+      for (const sg of e.subGraphs) {
+        let s = out.get(sg);
+        if (!s) { s = new Set(); out.set(sg, s); }
+        s.add(canonical);
+      }
+    }
+    return out;
   }, [memory.entityList]);
 
   // Merge registered sub-graphs (minus `meta`) with profile bindings so
@@ -3653,6 +3674,7 @@ export function SubGraphOverviewGrid({
       .map(sg => {
         const binding = profile?.forSubGraph(sg.name) ?? {};
         const rawTriples = triplesBySubGraph.get(sg.name) ?? [];
+        const cardEntityUris = entityUrisBySubGraph.get(sg.name) ?? new Set<string>();
         return {
           slug: sg.name,
           icon: binding.icon ?? '•',
@@ -3662,12 +3684,12 @@ export function SubGraphOverviewGrid({
           rank: binding.rank ?? 99,
           entityCount: sg.entityCount,
           tripleCount: sg.tripleCount,
-          triples: filterTriplesToEntities(rawTriples, entityUris),
+          triples: filterTriplesToEntities(rawTriples, cardEntityUris),
           layerCounts: layerCountsBySubGraph.get(sg.name) ?? { wm: 0, swm: 0, vm: 0 },
         };
       })
       .sort((a, b) => a.rank - b.rank);
-  }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph, entityUris]);
+  }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph]);
 
   if (loading && cards.length === 0) {
     return (

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3196,6 +3196,25 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
     [entity.uri, allTriples]
   );
 
+  // Task #25 (PR #677) — entity-only filter for the entity-detail
+  // graph. Mirrors the rule the Entities tab uses
+  // (`useMemoryEntities.ts:467-469`): an entity is in entityList iff
+  // it has at least one of `types`, own `properties`, or outgoing
+  // `connections`. `allEntities` includes synthesised stubs for
+  // pure-object URIs (vocab constants, IPFS refs, DID property
+  // values) so filter to the real entity set before computing
+  // entityUris. `entity.uri` (the detail focus) is always included
+  // so the focal node and its `initialFocus` highlight stay in sync.
+  const renderHoodTriples = useMemo(() => {
+    const entityUris = new Set<string>([canonicalEntityUri(entity.uri)]);
+    for (const e of allEntities.values()) {
+      if (e.types.length > 0 || e.properties.size > 0 || e.connections.length > 0) {
+        entityUris.add(canonicalEntityUri(e.uri));
+      }
+    }
+    return filterTriplesToEntities(hoodTriples, entityUris);
+  }, [hoodTriples, allEntities, entity.uri]);
+
   const graphOptions = useMemo(() => ({
     labelMode: 'humanized' as const,
     renderer: '2d' as const,
@@ -3362,11 +3381,11 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
               tone={layerBadge}
               className="v10-ka-graph-shell"
               renderGraph={(expanded) => (
-                hoodTriples.length > 0 ? (
+                renderHoodTriples.length > 0 ? (
                   <Suspense fallback={<span className="v10-graph-placeholder">Loading graph...</span>}>
                     <RdfGraph
                       key={`${entity.uri}:${expanded ? 'expanded' : 'inline'}`}
-                      data={hoodTriples}
+                      data={renderHoodTriples}
                       format="triples"
                       options={graphOptions}
                       viewConfig={entityViewConfig}
@@ -3616,6 +3635,16 @@ export function SubGraphOverviewGrid({
     return out;
   }, [memory.entityList]);
 
+  // Task #25 (PR #677) — entity-only filter for the mini-card
+  // thumbnails. Same rule the Entities tab uses; computed once across
+  // `memory.entityList` (already filtered to entries with own data)
+  // and reused per card.
+  const entityUris = useMemo(() => {
+    const s = new Set<string>();
+    for (const e of memory.entityList) s.add(canonicalEntityUri(e.uri));
+    return s;
+  }, [memory.entityList]);
+
   // Merge registered sub-graphs (minus `meta`) with profile bindings so
   // icon/color/label/rank all flow from the single source of truth.
   const cards = useMemo(() => {
@@ -3623,6 +3652,7 @@ export function SubGraphOverviewGrid({
       .filter(sg => sg.name !== 'meta')
       .map(sg => {
         const binding = profile?.forSubGraph(sg.name) ?? {};
+        const rawTriples = triplesBySubGraph.get(sg.name) ?? [];
         return {
           slug: sg.name,
           icon: binding.icon ?? '•',
@@ -3632,12 +3662,12 @@ export function SubGraphOverviewGrid({
           rank: binding.rank ?? 99,
           entityCount: sg.entityCount,
           tripleCount: sg.tripleCount,
-          triples: triplesBySubGraph.get(sg.name) ?? [],
+          triples: filterTriplesToEntities(rawTriples, entityUris),
           layerCounts: layerCountsBySubGraph.get(sg.name) ?? { wm: 0, swm: 0, vm: 0 },
         };
       })
       .sort((a, b) => a.rank - b.rank);
-  }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph]);
+  }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph, entityUris]);
 
   if (loading && cards.length === 0) {
     return (

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -56,7 +56,7 @@ import {
   SOURCE_CONTENT_TYPE, MARKDOWN_FORM, SOURCE_FILE, DKG_SIZE,
   entityAuthorUri, transitionAgentUri, transitionAtISO,
   shortType, shortPred, entityMeta,
-  buildLayerGraphOptions, getDescription, neighborhoodTriples,
+  buildLayerGraphOptions, getDescription, neighborhoodTriples, neutraliseBuiltinNamespaces,
   matchesSearch, humanizeLabel, layerNoun, useLayerTriples,
   filterTriplesToEntities,
   entityTimestamp, formatRelativeTime, formatTimelineBucket, formatTrailTimestamp,
@@ -3227,19 +3227,23 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
     return filterTriplesToEntities(hoodTriples, entityUris);
   }, [hoodTriples, allEntities, entity.uri]);
 
-  const graphOptions = useMemo(() => ({
-    labelMode: 'humanized' as const,
-    renderer: '2d' as const,
-    labels: memoryGraphLabels({ minZoomForLabels: 0.2 }),
-    style: {
-      defaultNodeColor: TRUST_COLORS[entity.trustLevel],
-      defaultEdgeColor: '#475569',
-      edgeWidth: 1.0,
-      fontSize: 11,
-    },
-    hexagon: { baseSize: 7, minSize: 4, maxSize: 10, scaleWithDegree: true },
-    focus: { maxNodes: 500, hops: 999 },
-  }), [entity.trustLevel]);
+  const graphOptions = useMemo(() => {
+    const focalColor = TRUST_COLORS[entity.trustLevel];
+    return {
+      labelMode: 'humanized' as const,
+      renderer: '2d' as const,
+      labels: memoryGraphLabels({ minZoomForLabels: 0.2 }),
+      style: {
+        namespaceColors: neutraliseBuiltinNamespaces(focalColor),
+        defaultNodeColor: focalColor,
+        defaultEdgeColor: '#475569',
+        edgeWidth: 1.0,
+        fontSize: 11,
+      },
+      hexagon: { baseSize: 7, minSize: 4, maxSize: 10, scaleWithDegree: true },
+      focus: { maxNodes: 500, hops: 999 },
+    };
+  }, [entity.trustLevel]);
 
   // ViewConfig makes the opened entity visually focal (bigger hexagon)
   // and drives the `<CenterOnEntity>` child to pan the camera to it
@@ -3682,7 +3686,14 @@ export function SubGraphOverviewGrid({
           displayName: binding.displayName ?? sg.name,
           description: binding.description,
           rank: binding.rank ?? 99,
-          entityCount: sg.entityCount,
+          // Use the client-canonicalised entity set size (the same one we
+          // use for the filter and that the Entities tab renders) so the
+          // mini-card count matches the detail page. The server-reported
+          // `sg.entityCount` is a liberal COUNT(DISTINCT ?s) per named
+          // graph and can include subjects that fail our entityList
+          // membership rule. Fall back to the server count if we have no
+          // client set for this sub-graph (e.g. nothing yet hydrated).
+          entityCount: cardEntityUris.size > 0 ? cardEntityUris.size : sg.entityCount,
           tripleCount: sg.tripleCount,
           triples: filterTriplesToEntities(rawTriples, cardEntityUris),
           layerCounts: layerCountsBySubGraph.get(sg.name) ?? { wm: 0, swm: 0, vm: 0 },
@@ -3758,6 +3769,7 @@ export function SubGraphMiniCard({
     style: {
       classColors: CODE_CLASS_COLORS,
       predicateColors: CODE_PREDICATE_COLORS,
+      namespaceColors: neutraliseBuiltinNamespaces(card.color),
       defaultNodeColor: card.color,
       defaultEdgeColor: '#475569',
       edgeWidth: 1.0,

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -15,6 +15,7 @@ import { ImportFilesModal } from '../../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../../components/Modals/ShareProjectModal.js';
 import {
   useMemoryEntities,
+  canonicalEntityUri,
   type TrustLevel, type MemoryEntity, type Triple,
 } from '../../hooks/useMemoryEntities.js';
 import { decodeRdfStringLiteral } from '../../../rdf-literal.js';
@@ -57,6 +58,7 @@ import {
   shortType, shortPred, entityMeta,
   buildLayerGraphOptions, getDescription, neighborhoodTriples,
   matchesSearch, humanizeLabel, layerNoun, useLayerTriples,
+  filterTriplesToEntities,
   entityTimestamp, formatRelativeTime, formatTimelineBucket, formatTrailTimestamp,
   type LayerView, type LayerContentTab, type KAPane,
   type SubGraphTab, type SubGraphEntitySort,
@@ -887,6 +889,7 @@ export function LayerGraphPanel({
   title: titleOverride,
   scopeEntities,
   swmAttribution,
+  layerEntities,
 }: {
   layer: 'wm' | 'swm' | 'vm';
   triples: Triple[];
@@ -914,6 +917,17 @@ export function LayerGraphPanel({
    * `EntityDetailView`, tests).
    */
   swmAttribution?: SwmAttributionsResult;
+  /**
+   * Task #25 (PR #677) — the layer's `entityList` (entities whose
+   * canonical layer matches this panel's `layer`). When supplied,
+   * the panel filters object-side resources against entity membership
+   * via `filterTriplesToEntities` so pure-object URIs (vocabulary
+   * constants, `ipfs://` file refs, `did:` identity refs, blank-node
+   * compound-property anchors) don't render as canvas nodes. Omit
+   * (or pass an empty array) to preserve the legacy behaviour where
+   * the panel renders every resource referenced in `triples`.
+   */
+  layerEntities?: ReadonlyArray<MemoryEntity>;
 }) {
   const { title: layerTitle } = LAYER_CONFIG[layer];
   const title = titleOverride ?? layerTitle;
@@ -972,6 +986,20 @@ export function LayerGraphPanel({
     return out;
   }, [triples, decorationTriples]);
 
+  // Task #25 (PR #677) — entity-only graph filter, render-path side.
+  // `useLayerTriples` stays the honest source of all layer triples
+  // (triple counts, VM hero stats depend on that). The graph view is
+  // the only surface that wants "@id-entities only" semantics, so the
+  // filter lives here. Callers that don't pass `layerEntities` (older
+  // callsites, tests) keep the legacy behaviour of rendering every
+  // resource referenced in `triples`.
+  const renderTriples = useMemo(() => {
+    if (!layerEntities || layerEntities.length === 0) return uniqueTriples;
+    const entityUris = new Set<string>();
+    for (const e of layerEntities) entityUris.add(canonicalEntityUri(e.uri));
+    return filterTriplesToEntities(uniqueTriples, entityUris);
+  }, [uniqueTriples, layerEntities]);
+
   // Only SWM layer uses per-URI node tints — for the rest, classColors rules
   // so code graphs stay legible (Package purple / File blue / etc).
   const graphOptions = useMemo(
@@ -979,8 +1007,8 @@ export function LayerGraphPanel({
     [layer, swmAttr.nodeColors],
   );
   const { canvasTriples, singletonItems } = useMemo(
-    () => splitGraphTriplesForShelf(uniqueTriples),
-    [uniqueTriples],
+    () => splitGraphTriplesForShelf(renderTriples),
+    [renderTriples],
   );
 
   // Union `singletonItems` (URIs that are *subjects* of triples but have
@@ -1865,6 +1893,7 @@ export function LayerContent({
             onNodeClick={onNodeClick}
             contextGraphId={contextGraphId}
             swmAttribution={layer === 'swm' ? swmAttribution : undefined}
+            layerEntities={entities}
           />
         </div>
       )}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4496,6 +4496,7 @@ export function SubGraphDetailView({
               scopeLabel={`Subgraph graph: ${title} entities and entity-to-entity triples from loaded subgraph data.`}
               trustLegendActiveLayer={singleLayer}
               scopeEntities={graphPanelScopeEntities}
+              layerEntities={graphPanelEntities}
             />
           </div>
         )}

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -378,17 +378,18 @@ export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, la
   return useMemo(() => {
     const seen = new Set<string>();
     const out: Triple[] = [];
-    // Task #25 — first-class entity = URI that appears as a *subject*
-    // in this layer's triples. `buildEntities` synthesises a record
-    // for every URI mentioned including pure objects (so vocabulary
-    // URIs like `https://ref.gs1.org/cbv/BizStep-packing` end up in
-    // `memory.entities`), making the entity map useless for the
-    // "is this a real entity?" check. Scan once for the subject set.
-    const subjectsInLayer = new Set<string>();
-    for (const t of memory.allTriples) {
-      if (t.layer !== targetLayer) continue;
-      subjectsInLayer.add(canonicalEntityUri(t.subject));
-    }
+    // Task #25 — first-class entity = same membership rule the
+    // Entities tab uses (`useMemoryEntities.ts:467-469`): an entity is
+    // in `entityList` iff it has at least one of `types`, own
+    // `properties`, or outgoing `connections`. Pure-object URIs
+    // (`cbv:BizStep-packing`, `ipfs://Qm...` as `sourceFile` target,
+    // `did:...` as `wasAttributedTo` target) get a synthetic record
+    // from `buildEntities` but no own data — so they're not in
+    // `entityList` and not first-class entities. Mirror that
+    // membership rule here so the Graph view and the Entities tab
+    // stay in lockstep — single source of truth, no two-rule drift.
+    const entityUris = new Set<string>();
+    for (const e of memory.entityList) entityUris.add(canonicalEntityUri(e.uri));
     for (const t of memory.allTriples) {
       if (t.layer !== targetLayer) continue;
       // Skip residual triples for a subject that has been promoted past
@@ -418,24 +419,22 @@ export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, la
       // triples (`rdf:type`, labels, `schema:name`, etc.) have a
       // non-resource object so this check no-ops; they always pass.
       //
-      // Task #25 — also drop resource→resource edges whose object is
-      // a **vocabulary value URI** (never appears as a subject in
-      // this layer): e.g. `<entity> epcis:bizstep <bizstep:packing>`
-      // would render `bizstep:packing` as a phantom canvas node
-      // tinted by `defaultNodeColor` while typed entities used
-      // `classColors` — the source of the user-reported "random
-      // different-coloured nodes" on the WM Graph. The graph should
-      // only show first-class entities until N1 ships an
-      // entity/+triples toggle. `rdf:type` is exempt — class IRIs
-      // never appear as subjects but the downstream
-      // `splitGraphTriplesForShelf` rdf:type guard ensures they
-      // don't become canvas nodes, and we need the triple itself
-      // for `classColors`.
+      // Task #25 — additionally drop resource→resource edges whose
+      // object isn't in the layer's `entityList` (same membership
+      // rule as the Entities tab). Covers all the cases that
+      // produced "random different-coloured nodes" on the WM Graph:
+      // vocabulary constants (`cbv:BizStep-packing`), IPFS file
+      // refs as `sourceFile` targets, DID identifiers as
+      // `wasAttributedTo` targets, blank-node compound-property
+      // anchors. `rdf:type` is exempt — class IRIs aren't entities
+      // but the triple is needed for `classColors`, and the
+      // downstream `splitGraphTriplesForShelf` rdf:type guard
+      // already prevents the class IRI from becoming a canvas node.
       if (isResourceObject(t.object)) {
         const canonicalObject = canonicalEntityUri(t.object);
         const objectEntity = memory.entities.get(canonicalObject);
         if (objectEntity && objectEntity.trustLevel !== targetLayer) continue;
-        if (!isRdfType(t.predicate) && !subjectsInLayer.has(canonicalObject)) continue;
+        if (!isRdfType(t.predicate) && !entityUris.has(canonicalObject)) continue;
       }
       const key = `${t.subject}|${t.predicate}|${t.object}`;
       if (seen.has(key)) continue;
@@ -443,7 +442,7 @@ export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, la
       out.push(t);
     }
     return out;
-  }, [memory.allTriples, memory.entities, targetLayer]);
+  }, [memory.allTriples, memory.entities, memory.entityList, targetLayer]);
 }
 
 // ─── Assertions List (WM/SWM named graphs) ──────────────────

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -242,6 +242,22 @@ export const CODE_PREDICATE_COLORS: Record<string, string> = {
   [VIZ_PRED_CONSENSUS]: '#22c55e',     // green (consensus literal edge)
 };
 
+// Built-in graph-viz auto-tints (schema.org → purple, prov → blue, etc) that
+// would otherwise override our layer default for any node with a matching
+// rdf:type. We neutralise them by mapping each to `defaultNodeColor` so the
+// layer color wins for non-attribution nodes. SWM agent attribution still
+// works because per-URI `nodeColors` sits ABOVE namespaceColors in the
+// style-engine priority stack. Future coloring rework can drop a richer
+// taxonomy in here without touching the rest of the wiring.
+export function neutraliseBuiltinNamespaces(defaultColor: string): Record<string, string> {
+  return {
+    'https://schema.org/': defaultColor,
+    'http://www.w3.org/ns/prov#': defaultColor,
+    'http://xmlns.com/foaf/0.1/': defaultColor,
+    'http://purl.org/dc/terms/': defaultColor,
+  };
+}
+
 export function buildLayerGraphOptions(
   layer: 'wm' | 'swm' | 'vm',
   nodeColors?: Record<string, string>,
@@ -259,6 +275,7 @@ export function buildLayerGraphOptions(
     style: {
       classColors: CODE_CLASS_COLORS,
       predicateColors: CODE_PREDICATE_COLORS,
+      namespaceColors: neutraliseBuiltinNamespaces(color),
       // Per-URI node tints (SWM attribution uses this to paint root KAs by
       // their proposing agent). Omitted for layers that don't use it, so
       // the style engine keeps falling back to classColors.
@@ -313,7 +330,12 @@ export function neighborhoodTriples(entityUri: string, allTriples: Triple[], hop
     if (frontier.size === 0) break;
   }
 
-  return allTriples.filter(t => visited.has(t.subject) || visited.has(t.object));
+  // Strict containment: both endpoints must be inside the N-hop ball.
+  // Using `||` here pulls in dangling edges from frontier nodes to nodes
+  // (N+1) hops away — those targets then render as nodes that look
+  // disconnected from the focal entity. AND keeps the rendered subgraph
+  // truly bounded by `hops`.
+  return allTriples.filter(t => visited.has(t.subject) && visited.has(t.object));
 }
 
 export function matchesSearch(e: MemoryEntity, q: string): boolean {

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -454,9 +454,27 @@ function isRdfType(predicate: string): boolean {
 export function filterTriplesToEntities(
   triples: Triple[],
   entityUris: ReadonlySet<string>,
+  options?: { focalSubjects?: ReadonlySet<string> },
 ): Triple[] {
   const out: Triple[] = [];
+  const focal = options?.focalSubjects;
   for (const t of triples) {
+    // Subject-side check (Codex EwIbn): keep only triples whose subject
+    // is a real entity per the entityList membership rule. In practice
+    // every subject of a triple is in entityList (it has at least one
+    // type/property/connection), but a scoped entityUris (per-sub-graph,
+    // KADetailView with allEntities filtered down, etc.) can have
+    // subjects that aren't in the scope. Drop those. Callers can pass
+    // `focalSubjects` to exempt subjects that must always render (e.g.
+    // KADetailView's focal entity).
+    const subjectCanonical = canonicalEntityUri(t.subject);
+    if (!entityUris.has(subjectCanonical) && !focal?.has(subjectCanonical)) continue;
+    // Object-side check (the original gate): drop resource→resource
+    // edges where the object isn't a known entity. `rdf:type` is exempt
+    // because class IRIs aren't entities but the triple is needed for
+    // `classColors`; the downstream `splitGraphTriplesForShelf`
+    // `rdf:type` guard prevents the class IRI from becoming a canvas
+    // node anyway.
     if (isResourceObject(t.object)) {
       if (!isRdfType(t.predicate) && !entityUris.has(canonicalEntityUri(t.object))) continue;
     }

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -361,6 +361,61 @@ function isResourceObject(value: string): boolean {
   return /^[A-Za-z][A-Za-z0-9+.-]*:/.test(trimmed);
 }
 
+export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, layer: 'wm' | 'swm' | 'vm'): Triple[] {
+  const targetLayer = LAYER_CONFIG[layer].trustLevel;
+  return useMemo(() => {
+    const seen = new Set<string>();
+    const out: Triple[] = [];
+    for (const t of memory.allTriples) {
+      if (t.layer !== targetLayer) continue;
+      // Skip residual triples for a subject that has been promoted past
+      // this layer: post-promote the daemon currently leaves the WM
+      // `/assertion/<addr>/<name>` graphs on disk, so a promoted entity's
+      // WM triples keep coming back from `wmSparql` even though the
+      // entity has logically moved to SWM. The entity's canonical layer
+      // is `trustLevel` (its highest layer); a triple whose subject has
+      // moved past `targetLayer` would otherwise be counted on the
+      // prior layer's tally. Triples whose subject has no entity record
+      // (literal orphans / class IRIs that only ever appear as objects)
+      // pass through unfiltered.
+      //
+      // R2-1 fix: `entities.get` is keyed by the canonical (trimmed,
+      // unwrapped) URI per `buildEntities`. The daemon sometimes ships
+      // subjects wrapped (`<urn:...>`) — looking them up raw misses the
+      // entity record, silently bypasses this filter, and the phantom
+      // triple returns. Canonicalise first.
+      const subjectEntity = memory.entities.get(canonicalEntityUri(t.subject));
+      if (subjectEntity && subjectEntity.trustLevel !== targetLayer) continue;
+      // Issue-A fix (object-side, asymmetric C17 form): a WM triple
+      // `wm-entity-A relatesTo swm-entity-B` (B promoted to SWM) has
+      // a WM subject but its object has moved past WM. The triple is
+      // residue — counting it on WM would inflate the count and
+      // would leak the promoted-entity URI as an object in any
+      // downstream rendering. Drop resource→resource edges whose
+      // object has been promoted past the requested layer.
+      // Literal-valued triples (labels, names, etc.) have a
+      // non-resource object so this check no-ops; they always pass.
+      //
+      // This stays in `useLayerTriples` because it's a per-LAYER
+      // correctness rule (a triple shouldn't be tallied on a layer
+      // where neither endpoint canonically lives). Entity-filtering
+      // for the graph view happens downstream in `LayerGraphPanel`
+      // via `filterTriplesToEntities` — `useLayerTriples` is the
+      // honest layer source for triple counts and VM hero stats.
+      if (isResourceObject(t.object)) {
+        const canonicalObject = canonicalEntityUri(t.object);
+        const objectEntity = memory.entities.get(canonicalObject);
+        if (objectEntity && objectEntity.trustLevel !== targetLayer) continue;
+      }
+      const key = `${t.subject}|${t.predicate}|${t.object}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(t);
+    }
+    return out;
+  }, [memory.allTriples, memory.entities, targetLayer]);
+}
+
 const RDF_TYPE_URI = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 function isRdfType(predicate: string): boolean {
   // Match the wrapped/unwrapped + whitespace tolerance used elsewhere
@@ -373,76 +428,41 @@ function isRdfType(predicate: string): boolean {
   return unwrapped === RDF_TYPE_URI;
 }
 
-export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, layer: 'wm' | 'swm' | 'vm'): Triple[] {
-  const targetLayer = LAYER_CONFIG[layer].trustLevel;
-  return useMemo(() => {
-    const seen = new Set<string>();
-    const out: Triple[] = [];
-    // Task #25 — first-class entity = same membership rule the
-    // Entities tab uses (`useMemoryEntities.ts:467-469`): an entity is
-    // in `entityList` iff it has at least one of `types`, own
-    // `properties`, or outgoing `connections`. Pure-object URIs
-    // (`cbv:BizStep-packing`, `ipfs://Qm...` as `sourceFile` target,
-    // `did:...` as `wasAttributedTo` target) get a synthetic record
-    // from `buildEntities` but no own data — so they're not in
-    // `entityList` and not first-class entities. Mirror that
-    // membership rule here so the Graph view and the Entities tab
-    // stay in lockstep — single source of truth, no two-rule drift.
-    const entityUris = new Set<string>();
-    for (const e of memory.entityList) entityUris.add(canonicalEntityUri(e.uri));
-    for (const t of memory.allTriples) {
-      if (t.layer !== targetLayer) continue;
-      // Skip residual triples for a subject that has been promoted past
-      // this layer: post-promote the daemon currently leaves the WM
-      // `/assertion/<addr>/<name>` graphs on disk, so a promoted entity's
-      // WM triples keep coming back from `wmSparql` even though the
-      // entity has logically moved to SWM. The entity's canonical layer
-      // is `trustLevel` (its highest layer); a triple whose subject has
-      // moved past `targetLayer` would otherwise render as a phantom
-      // node on the prior-layer Graph view. Triples whose subject has
-      // no entity record (literal orphans / class IRIs that only ever
-      // appear as objects) pass through unfiltered.
-      //
-      // R2-1 fix: `entities.get` is keyed by the canonical (trimmed,
-      // unwrapped) URI per `buildEntities`. The daemon sometimes ships
-      // subjects wrapped (`<urn:...>`) — looking them up raw misses the
-      // entity record, silently bypasses this filter, and the phantom
-      // node returns. Canonicalise first.
-      const subjectEntity = memory.entities.get(canonicalEntityUri(t.subject));
-      if (subjectEntity && subjectEntity.trustLevel !== targetLayer) continue;
-      // Issue-A fix (object-side, asymmetric C17 form): a WM triple
-      // `wm-entity-A relatesTo swm-entity-B` (B promoted to SWM)
-      // passes the subject check but `RdfGraph` would render BOTH
-      // endpoints as canvas nodes — the promoted-entity URI leaks in
-      // as an object node. Drop resource→resource edges whose object
-      // has been promoted past the requested layer. Literal-valued
-      // triples (`rdf:type`, labels, `schema:name`, etc.) have a
-      // non-resource object so this check no-ops; they always pass.
-      //
-      // Task #25 — additionally drop resource→resource edges whose
-      // object isn't in the layer's `entityList` (same membership
-      // rule as the Entities tab). Covers all the cases that
-      // produced "random different-coloured nodes" on the WM Graph:
-      // vocabulary constants (`cbv:BizStep-packing`), IPFS file
-      // refs as `sourceFile` targets, DID identifiers as
-      // `wasAttributedTo` targets, blank-node compound-property
-      // anchors. `rdf:type` is exempt — class IRIs aren't entities
-      // but the triple is needed for `classColors`, and the
-      // downstream `splitGraphTriplesForShelf` rdf:type guard
-      // already prevents the class IRI from becoming a canvas node.
-      if (isResourceObject(t.object)) {
-        const canonicalObject = canonicalEntityUri(t.object);
-        const objectEntity = memory.entities.get(canonicalObject);
-        if (objectEntity && objectEntity.trustLevel !== targetLayer) continue;
-        if (!isRdfType(t.predicate) && !entityUris.has(canonicalObject)) continue;
-      }
-      const key = `${t.subject}|${t.predicate}|${t.object}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push(t);
+/**
+ * Task #25 — graph-render-side entity filter. Used by `LayerGraphPanel`
+ * just before `RdfGraph`. Drops resource→resource edges whose object
+ * isn't in the layer's `entityList` membership (same rule the Entities
+ * tab uses: `e.types.length > 0 || e.properties.size > 0 || e.connections.length > 0`).
+ * Pure-object URIs — vocabulary constants (`cbv:BizStep-packing`),
+ * IPFS file refs (`ipfs://...`), DID identity refs (`did:...`),
+ * blank-node compound-property anchors — drop uniformly. If the
+ * object IS a first-class entity in the layer (e.g. a DID with its
+ * own rdf:type), the edge is kept.
+ *
+ * Lives in `helpers.ts` (not `components.tsx`) so it stays pure and
+ * unit-testable without rendering. `rdf:type` is exempt: class IRIs
+ * aren't entities but the triple is needed for `classColors`, and
+ * the downstream `splitGraphTriplesForShelf` rdf:type guard already
+ * prevents the class IRI from becoming a canvas node.
+ *
+ * `entityUris` is the set of canonical URIs of entities in the
+ * **layer's** entityList — i.e. callers should pass
+ * `memory.entityList.filter(e => e.trustLevel === layer.trustLevel)`
+ * mapped to canonical URIs. (`LayerGraphPanel` already has the layer
+ * to do that filtering with.)
+ */
+export function filterTriplesToEntities(
+  triples: Triple[],
+  entityUris: ReadonlySet<string>,
+): Triple[] {
+  const out: Triple[] = [];
+  for (const t of triples) {
+    if (isResourceObject(t.object)) {
+      if (!isRdfType(t.predicate) && !entityUris.has(canonicalEntityUri(t.object))) continue;
     }
-    return out;
-  }, [memory.allTriples, memory.entities, memory.entityList, targetLayer]);
+    out.push(t);
+  }
+  return out;
 }
 
 // ─── Assertions List (WM/SWM named graphs) ──────────────────

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -361,11 +361,34 @@ function isResourceObject(value: string): boolean {
   return /^[A-Za-z][A-Za-z0-9+.-]*:/.test(trimmed);
 }
 
+const RDF_TYPE_URI = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+function isRdfType(predicate: string): boolean {
+  // Match the wrapped/unwrapped + whitespace tolerance used elsewhere
+  // (see `splitGraphTriplesForShelf::graphNodeKey`); raw equality
+  // would let a `<rdf:type>` predicate slip past this guard.
+  const trimmed = predicate.trim();
+  const unwrapped = trimmed.startsWith('<') && trimmed.endsWith('>')
+    ? trimmed.slice(1, -1)
+    : trimmed;
+  return unwrapped === RDF_TYPE_URI;
+}
+
 export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, layer: 'wm' | 'swm' | 'vm'): Triple[] {
   const targetLayer = LAYER_CONFIG[layer].trustLevel;
   return useMemo(() => {
     const seen = new Set<string>();
     const out: Triple[] = [];
+    // Task #25 — first-class entity = URI that appears as a *subject*
+    // in this layer's triples. `buildEntities` synthesises a record
+    // for every URI mentioned including pure objects (so vocabulary
+    // URIs like `https://ref.gs1.org/cbv/BizStep-packing` end up in
+    // `memory.entities`), making the entity map useless for the
+    // "is this a real entity?" check. Scan once for the subject set.
+    const subjectsInLayer = new Set<string>();
+    for (const t of memory.allTriples) {
+      if (t.layer !== targetLayer) continue;
+      subjectsInLayer.add(canonicalEntityUri(t.subject));
+    }
     for (const t of memory.allTriples) {
       if (t.layer !== targetLayer) continue;
       // Skip residual triples for a subject that has been promoted past
@@ -394,9 +417,25 @@ export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, la
       // has been promoted past the requested layer. Literal-valued
       // triples (`rdf:type`, labels, `schema:name`, etc.) have a
       // non-resource object so this check no-ops; they always pass.
+      //
+      // Task #25 — also drop resource→resource edges whose object is
+      // a **vocabulary value URI** (never appears as a subject in
+      // this layer): e.g. `<entity> epcis:bizstep <bizstep:packing>`
+      // would render `bizstep:packing` as a phantom canvas node
+      // tinted by `defaultNodeColor` while typed entities used
+      // `classColors` — the source of the user-reported "random
+      // different-coloured nodes" on the WM Graph. The graph should
+      // only show first-class entities until N1 ships an
+      // entity/+triples toggle. `rdf:type` is exempt — class IRIs
+      // never appear as subjects but the downstream
+      // `splitGraphTriplesForShelf` rdf:type guard ensures they
+      // don't become canvas nodes, and we need the triple itself
+      // for `classColors`.
       if (isResourceObject(t.object)) {
-        const objectEntity = memory.entities.get(canonicalEntityUri(t.object));
+        const canonicalObject = canonicalEntityUri(t.object);
+        const objectEntity = memory.entities.get(canonicalObject);
         if (objectEntity && objectEntity.trustLevel !== targetLayer) continue;
+        if (!isRdfType(t.predicate) && !subjectsInLayer.has(canonicalObject)) continue;
       }
       const key = `${t.subject}|${t.predicate}|${t.object}`;
       if (seen.has(key)) continue;

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -311,6 +311,17 @@ export function getDescription(e: MemoryEntity): string | null {
   return null;
 }
 
+/**
+ * Returns the strict N-hop neighbourhood around `entityUri`: every triple
+ * whose subject AND object both sit inside the visited set after `hops`
+ * BFS expansions from the focal entity. Edges that would dangle from a
+ * frontier node to a node (N+1) hops out are deliberately excluded —
+ * otherwise rendering pulls in nodes that have no visible path back to
+ * the focal entity, producing visually disconnected components in the
+ * detail graph. If you need the loose "edge cut" semantics (frontier
+ * node ↔ outside node), don't reuse this — define a separate helper
+ * with clear name + JSDoc so the two semantics stay distinguishable.
+ */
 export function neighborhoodTriples(entityUri: string, allTriples: Triple[], hops: number = 2): Triple[] {
   const visited = new Set<string>([entityUri]);
   let frontier = new Set<string>([entityUri]);
@@ -330,11 +341,6 @@ export function neighborhoodTriples(entityUri: string, allTriples: Triple[], hop
     if (frontier.size === 0) break;
   }
 
-  // Strict containment: both endpoints must be inside the N-hop ball.
-  // Using `||` here pulls in dangling edges from frontier nodes to nodes
-  // (N+1) hops away — those targets then render as nodes that look
-  // disconnected from the focal entity. AND keeps the rendered subgraph
-  // truly bounded by `hops`.
   return allTriples.filter(t => visited.has(t.subject) && visited.has(t.object));
 }
 

--- a/packages/node-ui/test/filter-triples-to-entities.test.ts
+++ b/packages/node-ui/test/filter-triples-to-entities.test.ts
@@ -101,4 +101,53 @@ describe('filterTriplesToEntities — graph-render entity filter', () => {
     const result = filterTriplesToEntities(triples, new Set(['urn:e:event', 'urn:e:other-entity']));
     expect(result.map(t => t.object)).toEqual(['<urn:e:other-entity>']);
   });
+
+  it('drops triples whose subject is not in entityUris (subject-side gate)', () => {
+    // PR #677 Codex EwIbn — without the subject check, a non-entity
+    // subject (synthesised stub or filtered-out URI) whose object
+    // happens to be a real entity would still emit a phantom edge.
+    const triples: Triple[] = [
+      { subject: 'urn:e:non-entity-stub', predicate: 'http://schema.org/about', object: 'urn:e:real-entity' },
+      { subject: 'urn:e:real-entity', predicate: 'http://schema.org/name', object: '"Real"' },
+    ];
+    const result = filterTriplesToEntities(triples, new Set(['urn:e:real-entity']));
+    // The phantom edge from the stub is dropped; the real entity's
+    // own literal property survives.
+    expect(result).toHaveLength(1);
+    expect(result[0].subject).toBe('urn:e:real-entity');
+  });
+
+  it('keeps triples whose subject is only in focalSubjects (KADetailView focal exemption)', () => {
+    // `focalSubjects` allowlists the entity-detail focus so it
+    // survives the subject-side gate even when the layer's
+    // `entityList` wouldn't otherwise include it (e.g. cross-layer
+    // navigation where the focal entity lives in a different layer).
+    const triples: Triple[] = [
+      { subject: 'urn:e:focal', predicate: 'http://schema.org/name', object: '"Focal"' },
+      { subject: 'urn:e:focal', predicate: 'http://schema.org/about', object: 'urn:e:neighbor' },
+    ];
+    const result = filterTriplesToEntities(
+      triples,
+      new Set(['urn:e:neighbor']),
+      { focalSubjects: new Set(['urn:e:focal']) },
+    );
+    expect(result).toHaveLength(2);
+    expect(result.map(t => t.subject)).toEqual(['urn:e:focal', 'urn:e:focal']);
+  });
+
+  it('focalSubjects without entityUris membership still drops object-side non-entities', () => {
+    // Focal exemption only bypasses the subject-side gate. The
+    // object side still has to be a real entity (or an rdf:type
+    // target) — otherwise focusing on a focal would silently re-
+    // introduce vocab-value nodes via the focal's properties.
+    const triples: Triple[] = [
+      { subject: 'urn:e:focal', predicate: 'https://ref.gs1.org/cbv/bizStep', object: 'https://ref.gs1.org/cbv/BizStep-packing' },
+    ];
+    const result = filterTriplesToEntities(
+      triples,
+      new Set<string>(),
+      { focalSubjects: new Set(['urn:e:focal']) },
+    );
+    expect(result).toHaveLength(0);
+  });
 });

--- a/packages/node-ui/test/filter-triples-to-entities.test.ts
+++ b/packages/node-ui/test/filter-triples-to-entities.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { filterTriplesToEntities } from '../src/ui/views/project/helpers.js';
+import type { Triple } from '../src/ui/hooks/useMemoryEntities.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+// Task #25 (PR #677) — the graph-render-side entity filter. Lives in
+// `LayerGraphPanel` not `useLayerTriples` because triple counts and
+// the VM hero stats want the honest raw triple list. Mirrors the
+// `entityList` membership rule the Entities tab uses
+// (`useMemoryEntities.ts:467-469`): entity iff has at least one of
+// `types` / own `properties` / outgoing `connections`. Pure-object
+// URIs (vocabulary constants, `ipfs://` file refs, `did:` identity
+// refs, blank-node compound-property anchors) drop uniformly.
+describe('filterTriplesToEntities — graph-render entity filter', () => {
+  it('keeps entity→entity edges when both endpoints are in entityUris', () => {
+    const triples: Triple[] = [
+      { subject: 'urn:e:event', predicate: 'http://schema.org/about', object: 'urn:e:other-entity' },
+    ];
+    const result = filterTriplesToEntities(triples, new Set(['urn:e:event', 'urn:e:other-entity']));
+    expect(result.map(t => t.object)).toEqual(['urn:e:other-entity']);
+  });
+
+  it('drops vocabulary-constant objects (`cbv:BizStep-packing` not in entityUris)', () => {
+    const triples: Triple[] = [
+      { subject: 'urn:e:event', predicate: 'http://schema.org/about', object: 'urn:e:other-entity' },
+      { subject: 'urn:e:event', predicate: 'https://ref.gs1.org/cbv/bizStep', object: 'https://ref.gs1.org/cbv/BizStep-packing' },
+    ];
+    const result = filterTriplesToEntities(triples, new Set(['urn:e:event', 'urn:e:other-entity']));
+    const objects = result.map(t => t.object);
+    expect(objects).not.toContain('https://ref.gs1.org/cbv/BizStep-packing');
+    expect(objects).toContain('urn:e:other-entity');
+  });
+
+  it('drops `ipfs://` file-ref objects (not in entityUris — they are property values)', () => {
+    const triples: Triple[] = [
+      { subject: 'urn:e:doc', predicate: 'http://dkg.io/ontology/sourceFile', object: 'ipfs://QmExampleCidHash' },
+    ];
+    const result = filterTriplesToEntities(triples, new Set(['urn:e:doc']));
+    expect(result).toHaveLength(0);
+  });
+
+  it('drops `did:` identity-ref objects when used purely as a property value', () => {
+    const triples: Triple[] = [
+      { subject: 'urn:e:doc', predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: 'did:dkg:agent:0xabc123' },
+    ];
+    const result = filterTriplesToEntities(triples, new Set(['urn:e:doc']));
+    expect(result).toHaveLength(0);
+  });
+
+  it('keeps `did:` objects when the DID is in entityUris (real agent entity)', () => {
+    // When a DID has its own data in the layer (rdf:type / properties)
+    // it IS in entityList and the edge to it is kept. Mirrors the
+    // Entities tab.
+    const triples: Triple[] = [
+      { subject: 'urn:e:doc', predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: 'did:dkg:agent:alice' },
+    ];
+    const result = filterTriplesToEntities(triples, new Set(['urn:e:doc', 'did:dkg:agent:alice']));
+    expect(result.map(t => t.object)).toEqual(['did:dkg:agent:alice']);
+  });
+
+  it('keeps blank-node objects only when they appear in entityUris', () => {
+    const triples: Triple[] = [
+      { subject: 'urn:e:event', predicate: 'http://schema.org/location', object: '_:loc-anon' },
+      { subject: 'urn:e:event', predicate: 'http://schema.org/contributor', object: '_:loc-named' },
+    ];
+    const result = filterTriplesToEntities(triples, new Set(['urn:e:event', '_:loc-named']));
+    const objects = result.map(t => t.object);
+    expect(objects).not.toContain('_:loc-anon');
+    expect(objects).toContain('_:loc-named');
+  });
+
+  it('exempts rdf:type triples regardless of object membership (classColors needs them)', () => {
+    // The downstream `splitGraphTriplesForShelf` rdf:type guard
+    // prevents the class IRI from becoming a canvas node; we just
+    // need the triple to feed `classColors`.
+    const triples: Triple[] = [
+      { subject: 'urn:e:typed', predicate: RDF_TYPE, object: 'http://schema.org/Thing' },
+    ];
+    const result = filterTriplesToEntities(triples, new Set(['urn:e:typed']));
+    expect(result.map(t => t.object)).toEqual(['http://schema.org/Thing']);
+  });
+
+  it('keeps literal objects (not resources — never go through the membership check)', () => {
+    const triples: Triple[] = [
+      { subject: 'urn:e:event', predicate: 'http://schema.org/name', object: '"E"' },
+      { subject: 'urn:e:event', predicate: 'http://schema.org/startDate', object: '"2026-05-26"' },
+    ];
+    const result = filterTriplesToEntities(triples, new Set(['urn:e:event']));
+    expect(result).toHaveLength(2);
+  });
+
+  it('canonicalises wrapped <urn:...> objects before the membership lookup', () => {
+    // The daemon ships some bindings wrapped; `entityUris` is built
+    // from canonical entity URIs. Without canonicalising in the
+    // filter, wrapped object URIs would miss the membership match
+    // and drop legitimate edges.
+    const triples: Triple[] = [
+      { subject: 'urn:e:event', predicate: 'http://schema.org/about', object: '<urn:e:other-entity>' },
+    ];
+    const result = filterTriplesToEntities(triples, new Set(['urn:e:event', 'urn:e:other-entity']));
+    expect(result.map(t => t.object)).toEqual(['<urn:e:other-entity>']);
+  });
+});

--- a/packages/node-ui/test/use-layer-triples.test.ts
+++ b/packages/node-ui/test/use-layer-triples.test.ts
@@ -12,9 +12,18 @@ const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
 function memoryFor(triples: LayeredTriple[]): MemoryData {
   const entities = buildMemoryEntities(triples);
+  // Mirror the real `useMemoryEntities` filter at src/ui/hooks/
+  // useMemoryEntities.ts:467-469 — the entity-tab membership rule that
+  // `useLayerTriples` now consults. Without applying it here the test
+  // shim would list every synthesised entity stub (including pure
+  // object URIs like `cbv:BizStep-packing`), defeating the purpose
+  // of the filter under test.
+  const entityList = [...entities.values()].filter(e =>
+    e.types.length > 0 || e.properties.size > 0 || e.connections.length > 0,
+  );
   return {
     entities,
-    entityList: [...entities.values()],
+    entityList,
     allTriples: triples,
     graphTriples: [],
     trustMap: new Map(),
@@ -204,13 +213,16 @@ describe('useLayerTriples — promoted-entity residue filter (P1)', () => {
   });
 });
 
-// Task #25 — the Graph view should only render nodes for first-class
-// entities. Pre-fix, resource objects with no subject record in the
-// layer (vocabulary-value URIs like `bizstep:packing`) leaked through
-// and rendered as canvas nodes, falling back to `defaultNodeColor`
-// while typed entities used `classColors` — so the user saw "random
-// different-coloured nodes" along the edge of the WM graph.
-describe('useLayerTriples — vocabulary-value object filter (#25)', () => {
+// Task #25 — the Graph view filters resource→resource edges using the
+// same `entityList` membership rule the Entities tab uses
+// (`useMemoryEntities.ts:467-469`): an entity has at least one of
+// `types`, own `properties`, or outgoing `connections`. URIs that
+// appear only as objects with no own data (vocabulary constants like
+// `cbv:BizStep-packing`, `ipfs://` file refs, `did:` identity refs,
+// blank-node compound-property anchors) are property values, not
+// entities, and are dropped from the graph. Single source of truth
+// across the Graph view and the Entities tab — no two-rule drift.
+describe('useLayerTriples — entityList membership filter (#25)', () => {
   let root: Root;
   let container: HTMLDivElement;
 
@@ -225,48 +237,78 @@ describe('useLayerTriples — vocabulary-value object filter (#25)', () => {
     container.remove();
   });
 
-  it('drops resource→resource edges whose object is a vocabulary value (never a subject in the layer)', () => {
-    // `urn:e:event` is a typed entity (Event). It has two object-side
-    // resources: `urn:e:other-entity` (a real entity, appears as a
-    // subject) and `https://ref.gs1.org/cbv/BizStep-packing` (a
-    // vocabulary value with no subject-side triples — only used as
-    // an object). The vocabulary edge should be dropped; the
-    // entity-to-entity edge stays.
+  it('drops vocabulary-constant objects (`cbv:BizStep-packing` — no own data)', () => {
+    // `urn:e:event` is a typed entity (Event). Its two object-side
+    // resources: `urn:e:other-entity` is also a real entity (has its
+    // own rdf:type triple), `https://ref.gs1.org/cbv/BizStep-packing`
+    // is a vocabulary constant with no own data. Entity-to-entity
+    // edge stays; entity-to-vocabulary edge is dropped.
     const triples: LayeredTriple[] = [
       { subject: 'urn:e:event',        predicate: RDF_TYPE, object: 'http://schema.org/Event', layer: 'working' },
       { subject: 'urn:e:other-entity', predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
-      // Entity-to-entity edge — must survive.
       { subject: 'urn:e:event', predicate: 'http://schema.org/about', object: 'urn:e:other-entity', layer: 'working' },
-      // Entity-to-vocabulary edge — must be dropped (would render
-      // `BizStep-packing` as a phantom canvas node).
       { subject: 'urn:e:event', predicate: 'https://ref.gs1.org/cbv/bizStep', object: 'https://ref.gs1.org/cbv/BizStep-packing', layer: 'working' },
-      // Literal subject-local triple — must always pass.
       { subject: 'urn:e:event', predicate: 'http://schema.org/name', object: '"E"', layer: 'working' },
     ];
     const memory = memoryFor(triples);
-    expect(memory.entities.get('urn:e:event')).toBeDefined();
-    expect(memory.entities.get('urn:e:other-entity')).toBeDefined();
-    // `buildEntities` creates a record for every URI mentioned even
-    // as a pure object, so the vocabulary URI does end up in the
-    // map. The filter scans the layer's subjects directly instead.
-
     act(() => {
       root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
     });
-
     const probe = container.querySelector('#probe')!;
     const objects = (probe.getAttribute('data-objects') ?? '').split('|');
-    // The vocabulary URI never appears as a triple object after filtering.
     expect(objects).not.toContain('https://ref.gs1.org/cbv/BizStep-packing');
-    // The real entity edge survives.
     expect(objects).toContain('urn:e:other-entity');
-    // rdf:type is exempt — the class URI is allowed as an object
-    // (the downstream shelf-split rdf:type guard prevents it from
-    // becoming a canvas node).
+    // rdf:type still passes — class IRI exemption for `classColors`.
     expect(objects).toContain('http://schema.org/Event');
   });
 
-  it('keeps rdf:type triples whose object is a class IRI (no subject-side appearance)', () => {
+  it('drops `ipfs://` file-ref objects (sourceFile property value, no own data)', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:doc', predicate: RDF_TYPE, object: 'http://schema.org/CreativeWork', layer: 'working' },
+      { subject: 'urn:e:doc', predicate: 'http://dkg.io/ontology/sourceFile', object: 'ipfs://QmExampleCidHash', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    act(() => {
+      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
+    });
+    const probe = container.querySelector('#probe')!;
+    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
+    expect(objects).not.toContain('ipfs://QmExampleCidHash');
+  });
+
+  it('drops `did:` identity-ref objects (wasAttributedTo property value, no own data)', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:doc', predicate: RDF_TYPE, object: 'http://schema.org/CreativeWork', layer: 'working' },
+      { subject: 'urn:e:doc', predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: 'did:dkg:agent:0xabc123', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    act(() => {
+      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
+    });
+    const probe = container.querySelector('#probe')!;
+    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
+    expect(objects).not.toContain('did:dkg:agent:0xabc123');
+  });
+
+  it('keeps `did:` objects when the DID has its own data in the layer (real agent entity)', () => {
+    // When a DID is a first-class entity (has its own rdf:type or
+    // properties), it IS in entityList and the edge to it stays.
+    // Mirrors how the Entities tab would list it.
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:doc',          predicate: RDF_TYPE, object: 'http://schema.org/CreativeWork', layer: 'working' },
+      { subject: 'did:dkg:agent:alice', predicate: RDF_TYPE, object: 'http://schema.org/Person', layer: 'working' },
+      { subject: 'urn:e:doc', predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: 'did:dkg:agent:alice', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    act(() => {
+      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
+    });
+    const probe = container.querySelector('#probe')!;
+    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
+    expect(objects).toContain('did:dkg:agent:alice');
+  });
+
+  it('keeps rdf:type triples whose object is a class IRI (exemption for `classColors`)', () => {
     const triples: LayeredTriple[] = [
       { subject: 'urn:e:typed', predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
     ];
@@ -280,9 +322,6 @@ describe('useLayerTriples — vocabulary-value object filter (#25)', () => {
   });
 
   it('still drops cross-layer resource-to-resource edges (Issue A behaviour preserved)', () => {
-    // Regression: the new vocabulary filter must not weaken the
-    // existing Issue-A check that drops edges to entities promoted
-    // past the layer.
     const triples: LayeredTriple[] = [
       { subject: 'urn:e:wm-a',        predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
       { subject: 'urn:e:promoted-b',  predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'shared' },

--- a/packages/node-ui/test/use-layer-triples.test.ts
+++ b/packages/node-ui/test/use-layer-triples.test.ts
@@ -30,7 +30,12 @@ function memoryFor(triples: LayeredTriple[]): MemoryData {
 function ProbeLayerTriples({ memory, layer }: { memory: MemoryData; layer: 'wm' | 'swm' | 'vm' }) {
   const triples = useLayerTriples(memory as any, layer);
   const subjects = triples.map((t: Triple) => t.subject).join('|');
-  return React.createElement('div', { id: 'probe', 'data-subjects': subjects });
+  const objects = triples.map((t: Triple) => t.object).join('|');
+  return React.createElement('div', {
+    id: 'probe',
+    'data-subjects': subjects,
+    'data-objects': objects,
+  });
 }
 
 describe('useLayerTriples — promoted-entity residue filter (P1)', () => {
@@ -196,5 +201,99 @@ describe('useLayerTriples — promoted-entity residue filter (P1)', () => {
 
     // No triple at all whose subject is the leaked promoted entity.
     expect(subjects).not.toContain('urn:e:promoted-b');
+  });
+});
+
+// Task #25 — the Graph view should only render nodes for first-class
+// entities. Pre-fix, resource objects with no subject record in the
+// layer (vocabulary-value URIs like `bizstep:packing`) leaked through
+// and rendered as canvas nodes, falling back to `defaultNodeColor`
+// while typed entities used `classColors` — so the user saw "random
+// different-coloured nodes" along the edge of the WM graph.
+describe('useLayerTriples — vocabulary-value object filter (#25)', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('drops resource→resource edges whose object is a vocabulary value (never a subject in the layer)', () => {
+    // `urn:e:event` is a typed entity (Event). It has two object-side
+    // resources: `urn:e:other-entity` (a real entity, appears as a
+    // subject) and `https://ref.gs1.org/cbv/BizStep-packing` (a
+    // vocabulary value with no subject-side triples — only used as
+    // an object). The vocabulary edge should be dropped; the
+    // entity-to-entity edge stays.
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:event',        predicate: RDF_TYPE, object: 'http://schema.org/Event', layer: 'working' },
+      { subject: 'urn:e:other-entity', predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
+      // Entity-to-entity edge — must survive.
+      { subject: 'urn:e:event', predicate: 'http://schema.org/about', object: 'urn:e:other-entity', layer: 'working' },
+      // Entity-to-vocabulary edge — must be dropped (would render
+      // `BizStep-packing` as a phantom canvas node).
+      { subject: 'urn:e:event', predicate: 'https://ref.gs1.org/cbv/bizStep', object: 'https://ref.gs1.org/cbv/BizStep-packing', layer: 'working' },
+      // Literal subject-local triple — must always pass.
+      { subject: 'urn:e:event', predicate: 'http://schema.org/name', object: '"E"', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    expect(memory.entities.get('urn:e:event')).toBeDefined();
+    expect(memory.entities.get('urn:e:other-entity')).toBeDefined();
+    // `buildEntities` creates a record for every URI mentioned even
+    // as a pure object, so the vocabulary URI does end up in the
+    // map. The filter scans the layer's subjects directly instead.
+
+    act(() => {
+      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
+    });
+
+    const probe = container.querySelector('#probe')!;
+    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
+    // The vocabulary URI never appears as a triple object after filtering.
+    expect(objects).not.toContain('https://ref.gs1.org/cbv/BizStep-packing');
+    // The real entity edge survives.
+    expect(objects).toContain('urn:e:other-entity');
+    // rdf:type is exempt — the class URI is allowed as an object
+    // (the downstream shelf-split rdf:type guard prevents it from
+    // becoming a canvas node).
+    expect(objects).toContain('http://schema.org/Event');
+  });
+
+  it('keeps rdf:type triples whose object is a class IRI (no subject-side appearance)', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:typed', predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    act(() => {
+      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
+    });
+    const probe = container.querySelector('#probe')!;
+    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
+    expect(objects).toContain('http://schema.org/Thing');
+  });
+
+  it('still drops cross-layer resource-to-resource edges (Issue A behaviour preserved)', () => {
+    // Regression: the new vocabulary filter must not weaken the
+    // existing Issue-A check that drops edges to entities promoted
+    // past the layer.
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:wm-a',        predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
+      { subject: 'urn:e:promoted-b',  predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'shared' },
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/knows', object: 'urn:e:promoted-b', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    act(() => {
+      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
+    });
+    const probe = container.querySelector('#probe')!;
+    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
+    expect(objects).not.toContain('urn:e:promoted-b');
   });
 });

--- a/packages/node-ui/test/use-layer-triples.test.ts
+++ b/packages/node-ui/test/use-layer-triples.test.ts
@@ -12,18 +12,9 @@ const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
 function memoryFor(triples: LayeredTriple[]): MemoryData {
   const entities = buildMemoryEntities(triples);
-  // Mirror the real `useMemoryEntities` filter at src/ui/hooks/
-  // useMemoryEntities.ts:467-469 — the entity-tab membership rule that
-  // `useLayerTriples` now consults. Without applying it here the test
-  // shim would list every synthesised entity stub (including pure
-  // object URIs like `cbv:BizStep-packing`), defeating the purpose
-  // of the filter under test.
-  const entityList = [...entities.values()].filter(e =>
-    e.types.length > 0 || e.properties.size > 0 || e.connections.length > 0,
-  );
   return {
     entities,
-    entityList,
+    entityList: [...entities.values()],
     allTriples: triples,
     graphTriples: [],
     trustMap: new Map(),
@@ -39,12 +30,7 @@ function memoryFor(triples: LayeredTriple[]): MemoryData {
 function ProbeLayerTriples({ memory, layer }: { memory: MemoryData; layer: 'wm' | 'swm' | 'vm' }) {
   const triples = useLayerTriples(memory as any, layer);
   const subjects = triples.map((t: Triple) => t.subject).join('|');
-  const objects = triples.map((t: Triple) => t.object).join('|');
-  return React.createElement('div', {
-    id: 'probe',
-    'data-subjects': subjects,
-    'data-objects': objects,
-  });
+  return React.createElement('div', { id: 'probe', 'data-subjects': subjects });
 }
 
 describe('useLayerTriples — promoted-entity residue filter (P1)', () => {
@@ -210,129 +196,5 @@ describe('useLayerTriples — promoted-entity residue filter (P1)', () => {
 
     // No triple at all whose subject is the leaked promoted entity.
     expect(subjects).not.toContain('urn:e:promoted-b');
-  });
-});
-
-// Task #25 — the Graph view filters resource→resource edges using the
-// same `entityList` membership rule the Entities tab uses
-// (`useMemoryEntities.ts:467-469`): an entity has at least one of
-// `types`, own `properties`, or outgoing `connections`. URIs that
-// appear only as objects with no own data (vocabulary constants like
-// `cbv:BizStep-packing`, `ipfs://` file refs, `did:` identity refs,
-// blank-node compound-property anchors) are property values, not
-// entities, and are dropped from the graph. Single source of truth
-// across the Graph view and the Entities tab — no two-rule drift.
-describe('useLayerTriples — entityList membership filter (#25)', () => {
-  let root: Root;
-  let container: HTMLDivElement;
-
-  beforeEach(() => {
-    container = document.createElement('div');
-    document.body.appendChild(container);
-    root = createRoot(container);
-  });
-
-  afterEach(() => {
-    act(() => root.unmount());
-    container.remove();
-  });
-
-  it('drops vocabulary-constant objects (`cbv:BizStep-packing` — no own data)', () => {
-    // `urn:e:event` is a typed entity (Event). Its two object-side
-    // resources: `urn:e:other-entity` is also a real entity (has its
-    // own rdf:type triple), `https://ref.gs1.org/cbv/BizStep-packing`
-    // is a vocabulary constant with no own data. Entity-to-entity
-    // edge stays; entity-to-vocabulary edge is dropped.
-    const triples: LayeredTriple[] = [
-      { subject: 'urn:e:event',        predicate: RDF_TYPE, object: 'http://schema.org/Event', layer: 'working' },
-      { subject: 'urn:e:other-entity', predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
-      { subject: 'urn:e:event', predicate: 'http://schema.org/about', object: 'urn:e:other-entity', layer: 'working' },
-      { subject: 'urn:e:event', predicate: 'https://ref.gs1.org/cbv/bizStep', object: 'https://ref.gs1.org/cbv/BizStep-packing', layer: 'working' },
-      { subject: 'urn:e:event', predicate: 'http://schema.org/name', object: '"E"', layer: 'working' },
-    ];
-    const memory = memoryFor(triples);
-    act(() => {
-      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
-    });
-    const probe = container.querySelector('#probe')!;
-    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
-    expect(objects).not.toContain('https://ref.gs1.org/cbv/BizStep-packing');
-    expect(objects).toContain('urn:e:other-entity');
-    // rdf:type still passes — class IRI exemption for `classColors`.
-    expect(objects).toContain('http://schema.org/Event');
-  });
-
-  it('drops `ipfs://` file-ref objects (sourceFile property value, no own data)', () => {
-    const triples: LayeredTriple[] = [
-      { subject: 'urn:e:doc', predicate: RDF_TYPE, object: 'http://schema.org/CreativeWork', layer: 'working' },
-      { subject: 'urn:e:doc', predicate: 'http://dkg.io/ontology/sourceFile', object: 'ipfs://QmExampleCidHash', layer: 'working' },
-    ];
-    const memory = memoryFor(triples);
-    act(() => {
-      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
-    });
-    const probe = container.querySelector('#probe')!;
-    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
-    expect(objects).not.toContain('ipfs://QmExampleCidHash');
-  });
-
-  it('drops `did:` identity-ref objects (wasAttributedTo property value, no own data)', () => {
-    const triples: LayeredTriple[] = [
-      { subject: 'urn:e:doc', predicate: RDF_TYPE, object: 'http://schema.org/CreativeWork', layer: 'working' },
-      { subject: 'urn:e:doc', predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: 'did:dkg:agent:0xabc123', layer: 'working' },
-    ];
-    const memory = memoryFor(triples);
-    act(() => {
-      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
-    });
-    const probe = container.querySelector('#probe')!;
-    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
-    expect(objects).not.toContain('did:dkg:agent:0xabc123');
-  });
-
-  it('keeps `did:` objects when the DID has its own data in the layer (real agent entity)', () => {
-    // When a DID is a first-class entity (has its own rdf:type or
-    // properties), it IS in entityList and the edge to it stays.
-    // Mirrors how the Entities tab would list it.
-    const triples: LayeredTriple[] = [
-      { subject: 'urn:e:doc',          predicate: RDF_TYPE, object: 'http://schema.org/CreativeWork', layer: 'working' },
-      { subject: 'did:dkg:agent:alice', predicate: RDF_TYPE, object: 'http://schema.org/Person', layer: 'working' },
-      { subject: 'urn:e:doc', predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: 'did:dkg:agent:alice', layer: 'working' },
-    ];
-    const memory = memoryFor(triples);
-    act(() => {
-      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
-    });
-    const probe = container.querySelector('#probe')!;
-    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
-    expect(objects).toContain('did:dkg:agent:alice');
-  });
-
-  it('keeps rdf:type triples whose object is a class IRI (exemption for `classColors`)', () => {
-    const triples: LayeredTriple[] = [
-      { subject: 'urn:e:typed', predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
-    ];
-    const memory = memoryFor(triples);
-    act(() => {
-      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
-    });
-    const probe = container.querySelector('#probe')!;
-    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
-    expect(objects).toContain('http://schema.org/Thing');
-  });
-
-  it('still drops cross-layer resource-to-resource edges (Issue A behaviour preserved)', () => {
-    const triples: LayeredTriple[] = [
-      { subject: 'urn:e:wm-a',        predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
-      { subject: 'urn:e:promoted-b',  predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'shared' },
-      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/knows', object: 'urn:e:promoted-b', layer: 'working' },
-    ];
-    const memory = memoryFor(triples);
-    act(() => {
-      root.render(React.createElement(ProbeLayerTriples, { memory, layer: 'wm' }));
-    });
-    const probe = container.querySelector('#probe')!;
-    const objects = (probe.getAttribute('data-objects') ?? '').split('|');
-    expect(objects).not.toContain('urn:e:promoted-b');
   });
 });


### PR DESCRIPTION
## Summary

- WM/SWM/VM Graph views were rendering canvas nodes for resource objects that aren't first-class entities — vocabulary value URIs like `https://ref.gs1.org/cbv/BizStep-packing` from `epcis:bizStep` triples. They had no `rdf:type` triple so they fell back to `defaultNodeColor` while typed entities used `classColors`, producing the user-reported "random different-coloured nodes" along the edge of a WM graph (Image 27 post-#656 merge).
- `useLayerTriples` now drops resource→resource edges whose object never appears as a subject in the same layer. `rdf:type` is exempt — class IRIs feed `classColors` and are already kept off-canvas by the downstream `splitGraphTriplesForShelf` rdf:type guard.
- Temporary fix: until N1 ships an entity / +triples toggle, the Graph view stays entity-only. Once a colour-by-sub-graph binding (N3) lands, tinting normalisation comes for free because every remaining node is an entity with a known sub-graph membership.

## Related

- Sibling/parallel PR to #656 (per user direction)
- Follow-up to the post-#656 merge user-feedback bug (Image 27)
- Tracking task: #25

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/views/project/helpers.ts` | Add `RDF_TYPE_URI` + `isRdfType` helper; precompute the layer's subject set in `useLayerTriples`; drop resource→resource edges whose object isn't a subject in the layer (rdf:type exempt). Existing Issue-A cross-layer leak check preserved. |
| `packages/node-ui/test/use-layer-triples.test.ts` | Add `data-objects` to the probe component; new describe block `vocabulary-value object filter (#25)` with 3 cases — vocab-value drop, rdf:type class-IRI exemption, Issue-A regression preserved. |

## Test plan

- [x] `pnpm exec tsc --noEmit -p tsconfig.json` (node-ui) — clean
- [x] `pnpm exec vitest run test/use-layer-triples.test.ts` — 8/8 pass (5 existing + 3 new)
- [x] `pnpm exec vitest run test/{use-layer-triples,layer-graph-panel,subgraph-detail-view,vm-hero-banner,context-graph-empty-stat-components,graph-label-predicates}.test.ts` — 41/41 pass
- [x] `pnpm build:ui` — green
- [ ] Manual: dev node + WM Graph tab on a project with epcis-style data, confirm vocabulary nodes (`bizstep:*`) no longer appear