### PR TITLE
fix(storage): stop encrypting private store triples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ packages/evm-module/deployments/hardhat_contracts.json
 packages/evm-module/deployments/localhost_contracts.json
 snapshots/_cache_phase1_neuroweb_epoch16.json
 .claude/
+.orchestrator/
+.worktrees/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -467,6 +467,11 @@ class SharedMemoryHandler {
   +contextGraphHasPrivateAccessPolicy()
   +getContextGraphAllowedPeers()
 }
+class PrivateContentStore {
+  +storePrivateTriples()
+  +getPrivateTriples()
+  +storePrivateTriplesForOperation()
+}
 class AsyncPublisher {
   +enqueue()
   +processNext()
@@ -500,6 +505,8 @@ EncryptedWorkspacePayload --> GossipEnvelope : nests as payload bytes
 GossipEnvelope --> SharedMemoryHandler : delivered on SWM topic
 SharedMemoryHandler --> ContextGraphAccessMetadata : reads access policy and gates
 SharedMemoryHandler --> SharedWorkingMemory : stores accepted writes
+PrivateContentStore --> WorkingMemory : stages async private lift payloads
+PrivateContentStore --> StorageAdapters : writes plaintext private RDF terms
 AsyncPublisher --> SharedWorkingMemory : reads source data
 AsyncPublisher --> VerifiedMemory : publishes
 ```
@@ -603,6 +610,16 @@ or metadata tampering fail closed. Open public graphs keep the legacy plaintext
 path for backward compatibility, while private graph integration rejects
 plaintext fallback.
 
+This encryption boundary is a transport boundary. `DKGAgent.share()`,
+`conditionalShare()`, and assertion promotion commit accepted quads to the local
+triple store as normal SWM rows, then replicate the `WorkspacePublishRequest`
+over GossipSub and/or the Universal Messenger substrate. For private or
+agent-gated context graphs, the request bytes are sender-key encrypted when the
+sender-key path is configured, or wrapped in `EncryptedWorkspacePayload` as the
+legacy encrypted workspace fallback. Receivers decrypt the wire payload first,
+run the same authorization and validation checks, and only then insert normal
+quads into the local `_shared_memory` graph.
+
 ```mermaid
 sequenceDiagram
   actor Writer as Local Writer
@@ -636,6 +653,69 @@ sequenceDiagram
     Gossip->>Handler: decode envelope or legacy raw payload
   end
 ```
+
+## Private and SWM Triple-Store Encryption Boundary
+
+Current repository state separates triple-store persistence from peer-to-peer
+message confidentiality. See
+[ADR 0004](./docs/adr/0004-private-store-plaintext-rdf.md) for the accepted
+decision to keep private-store RDF plaintext after message decryption.
+
+- **WM assertions** live in assertion named graphs such as
+  `did:dkg:context-graph:<cg>/assertion/<agent>/<name>`. `assertion.write`
+  inserts caller quads into that graph unchanged. `assertion.promote` filters
+  daemon-reserved metadata, partitions root entities, inserts the promoted quads
+  into `_shared_memory`, removes the promoted rows from the assertion graph, and
+  updates lifecycle metadata in `_meta`.
+- **SWM writes** from `/api/shared-memory/write`,
+  `/api/shared-memory/conditional-write`, and assertion promotion persist
+  normalized quads directly in `did:dkg:context-graph:<cg>/_shared_memory` or
+  the sub-graph equivalent. SWM operation metadata and ownership live in
+  `_shared_memory_meta`; the public snapshot store records the same public quads
+  for replay and catch-up. The store rows are not `enc:gcm:v1` envelopes.
+- **Private content** lives in `_private` graphs through `PrivateContentStore`.
+  `storePrivateTriples()` writes accepted RDF object terms unchanged into the
+  private graph: literals stay literals, IRI objects stay IRIs, and blank nodes
+  stay blank nodes. This is separate from Sender Key SWM and
+  `EncryptedWorkspacePayload`, which protect node-to-node messages before the
+  receiving node decrypts and stores the payload.
+  `storePrivateTriplesForOperation()` remains the async-lift staging path: it
+  stores a JSON literal payload in a private staging graph keyed by
+  `shareOperationId`, then the async publisher later moves those quads into
+  `_private`.
+- **Encrypted ACK staging** is a scoped publish-finalization exception, not the
+  #633 queryability surface. Curated/private publishes may ask core nodes that
+  are not context-graph members to ACK storage without seeing plaintext. In that
+  path `StorageACKHandler` stores a temporary base64 ciphertext blob under
+  `_shared_memory/staging-encrypted/<merkle-prefix>` and
+  `urn:dkg:swm:v10-publish-ciphertext`; those rows are opaque transport escrow,
+  not queryable KA triples.
+
+The removed triple-store-level encryption surface was narrow: the
+`PrivateContentStore` `enc:gcm:v1` literal seal, `DKG_PRIVATE_STORE_KEY*`
+at-rest encryption configuration, exported private-literal decrypt helper, and
+publisher exact-dedup decrypt call. Graph routing, private staging, ownership
+metadata, assertion lifecycle, SWM persistence, and publisher replay semantics
+remain intact. Do not remove the peer-to-peer encryption surfaces: Sender Key
+SWM, legacy `EncryptedWorkspacePayload`, or encrypted sender-key setup packages.
+The Universal Messenger `sendReliable` / `register` reliability substrate
+continues to carry those opaque application payload bytes on the wire. Encrypted
+ACK staging also stays out of the #633 fix; if that exception needs to move out
+of RDF storage later, handle it as a separate publish-finalization design.
+
+No automatic migration is planned for already-written `_private`
+`enc:gcm:v1` rows. They can remain as legacy data and may be overwritten or
+recaptured in devnet environments. The scoped fix is forward-looking: new private
+triple writes land as plaintext RDF terms so normal SPARQL filters work;
+legacy decrypt compatibility is not required for this test/devnet-phase data.
+Regression coverage should prove the generic private-store contract, not only
+the EPCIS symptom: private writes containing literal objects, IRI objects, blank
+nodes, and realistic query predicates must be visible as plaintext RDF terms in
+the raw `_private` graph and round-trip through `getPrivateTriples()` without a
+decrypt step. EPCIS fixture readback remains useful as manual/devnet validation,
+but the core automated regression can live at the storage or publisher layer.
+Replace the PR #644 repro narrative that documented literal filters as still
+broken; the new regression should assert the intended final contract instead.
 
 ## Source Worker Workflow
 

--- a/docs/adr/0004-private-store-plaintext-rdf.md
+++ b/docs/adr/0004-private-store-plaintext-rdf.md
@@ -1,0 +1,33 @@
+# ADR 0004 - Private store triples are plaintext RDF after message decryption
+
+- **Status**: Accepted
+- **Date**: 2026-05-26
+- **Related issues**: [#633](https://github.com/OriginTrail/dkg/issues/633),
+  [#644](https://github.com/OriginTrail/dkg/pull/644)
+
+## Context
+
+Private context graph data is protected by graph placement, access policy, and
+encrypted node-to-node transport, not by encrypting RDF terms inside the local
+triple store. When a node receives an encrypted SWM/private payload, it must
+decrypt the message at the transport/workspace boundary, validate the request,
+and insert normal plaintext RDF terms into `_private` or `_shared_memory` so
+SPARQL can query literals, IRIs, blank nodes, and filterable EPCIS-style fields.
+
+## Decision
+
+This replaces the `PrivateContentStore` `enc:gcm:v1` at-rest seal that encrypted
+private literal object terms and made object-value filters fail
+(OriginTrail/dkg#633). We will not migrate legacy encrypted `_private` rows; this
+is test/devnet-phase data and can remain as legacy state or be overwritten by
+recapture. The scoped fix removes private-store encryption/decryption and
+`DKG_PRIVATE_STORE_KEY*` configuration while preserving Sender Key SWM, legacy
+`EncryptedWorkspacePayload`, and other peer-message encryption.
+
+## Consequences
+
+Encrypted ACK staging is a separate publish-finalization exception: non-member
+core nodes may temporarily store opaque ciphertext bytes for storage ACK purposes
+under the staging path, because they are not allowed to see curated plaintext.
+That exception is out of scope for the #633 fix and should be revisited
+separately if ciphertext blob staging needs to move out of RDF storage.

--- a/packages/agent/test/e2e-security.test.ts
+++ b/packages/agent/test/e2e-security.test.ts
@@ -164,12 +164,10 @@ describe('Private triple confidentiality via GossipSub', () => {
   // "publisher A retains private triples locally while B only sees public"
   // removed: the test ran a RAW
   // `agentA.store.query(SELECT ?val WHERE { GRAPH <…/_private> { … } })`
-  // and asserted `bindings[0].val === '"top-secret-value"'` — it expected
-  // the on-disk private graph to contain plaintext. After the ST-2 fix
-  // (AES-GCM-SIV at rest) the private graph holds ciphertext
-  // (`"enc:gcm:v1:…"`) by design; authorised access is via the access
-  // protocol, not raw store reads. Coverage for the intended behaviour
-  // (cross-agent privacy + protocol-mediated access) is retained by
+  // and asserted `bindings[0].val === '"top-secret-value"'`. Plaintext local
+  // private rows are valid, but this e2e suite keeps its focus on the network
+  // privacy boundary: B must not receive or query A's private triples unless A
+  // grants access. Coverage for the intended behaviour is retained by
   // sibling tests "private triples published on A are NOT received by B
   // through GossipSub", "cross-agent SPARQL query does not return
   // private triples", and "publisher grants access and returns correct

--- a/packages/cli/test/repro-issue-633.test.ts
+++ b/packages/cli/test/repro-issue-633.test.ts
@@ -1,72 +1,144 @@
 /**
- * Regression test for OriginTrail/dkg#633
- * "EPCIS private queries cannot filter encrypted object values"
+ * Regression test for OriginTrail/dkg#633.
  *
- * History:
- *   - 2026-04-22 (PR #229 round-6 bot escalation, commit de341d88): the
- *     IRI half of `encryptLiteral` started AES-sealing every object
- *     term in `_private` — both literals and IRIs — under a single
- *     envelope with an internal `L|` / `I|` tag.
- *   - 2026-05-05 (PR #379): the round-6 squash landed on `main`, which
- *     silently broke every SPARQL filter against the private graph.
- *     The most visible victim was the EPCIS read path (#633).
- *   - This commit: reverts the IRI half of the seal in
- *     `PrivateContentStore.encryptLiteral`. IRI-position object terms
- *     now pass through plaintext, restoring SPARQL filterability for
- *     `eventType`, `bizStep`, `bizLocation`, `readPoint`, `disposition`.
- *     The literal half stays sealed (literals are the ST-2 finding),
- *     so `epc`, `action`, `eventTime` range filters still need a
- *     blind-index or in-app post-decrypt pass — tracked separately.
- *
- * Sets up an in-memory OxigraphStore wired to a real
- * ContextGraphManager + PrivateContentStore, writes one ObjectEvent
- * into the private graph the way the publisher does on capture, plus
- * the public anchor triple, then runs the SPARQL built by
- * `buildEpcisQuery()` and asserts the IRI-side is fixed and documents
- * the literal-side gap.
- *
- * Lives in `packages/cli/test` because cli is the only package that
- * already has BOTH `@origintrail-official/dkg-storage` and
- * `@origintrail-official/dkg-epcis` as workspace deps.
+ * Private payloads are encrypted between nodes, but once an authorised
+ * receiving node decrypts a payload it must insert normal plaintext RDF into
+ * its local private graph. The triple store must not wrap literals in a second
+ * `enc:gcm:v1` layer, because that breaks SPARQL filters and leaks ciphertext
+ * through query results.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
 import {
-  OxigraphStore,
   ContextGraphManager,
+  OxigraphStore,
   PrivateContentStore,
 } from '@origintrail-official/dkg-storage';
 import {
-  contextGraphSharedMemoryUri,
   contextGraphPrivateUri,
+  contextGraphSharedMemoryUri,
 } from '@origintrail-official/dkg-core';
 import { buildEpcisQuery } from '@origintrail-official/dkg-epcis';
 
 const CG = 'repro-633';
-const EVENT = 'urn:uuid:event-A';
-const EPC = 'urn:epc:id:sgtin:4012345.011111.1001';
-const SWM_GRAPH = contextGraphSharedMemoryUri(CG);
+const ROOT = 'urn:example:asset:123';
+const DETAIL = `${ROOT}/.well-known/genid/detail`;
 const PRIVATE_GRAPH = contextGraphPrivateUri(CG);
+const SWM_GRAPH = contextGraphSharedMemoryUri(CG);
+const EVENT = 'urn:uuid:repro-633-epcis-event';
+const EPC = 'urn:acme:bike:item:BIKE-2026-W18-0001';
 
-describe('OriginTrail/dkg#633 — EPCIS private queries cannot filter encrypted object values', () => {
-  let tempDir: string;
-  let store: OxigraphStore;
-  let gm: ContextGraphManager;
-  let ps: PrivateContentStore;
+describe('OriginTrail/dkg#633 — private graph stores plaintext RDF terms', () => {
+  it('keeps literals, IRIs, and blank nodes queryable in the raw private graph', async () => {
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
 
-  beforeEach(async () => {
-    tempDir = mkdtempSync(join(tmpdir(), 'repro-633-'));
-    process.env.DKG_PRIVATE_STORE_KEY_FILE = join(tempDir, 'private-store.key');
+    const quads = [
+      {
+        subject: ROOT,
+        predicate: 'http://example.com/ns/status',
+        object: '<http://example.com/status/Ready>',
+        graph: '',
+      },
+      {
+        subject: ROOT,
+        predicate: 'http://example.com/ns/temperature',
+        object: '"7.5"^^<http://www.w3.org/2001/XMLSchema#decimal>',
+        graph: '',
+      },
+      {
+        subject: ROOT,
+        predicate: 'http://example.com/ns/batch',
+        object: '"batch-42"',
+        graph: '',
+      },
+      {
+        subject: ROOT,
+        predicate: 'http://example.com/ns/detail',
+        object: '_:detail',
+        graph: '',
+      },
+      {
+        subject: DETAIL,
+        predicate: 'http://example.com/ns/note',
+        object: '"blank-node-shaped private data"',
+        graph: '',
+      },
+    ];
 
-    store = new OxigraphStore();
-    gm = new ContextGraphManager(store);
-    ps = new PrivateContentStore(store, gm);
+    await ps.storePrivateTriples(CG, ROOT, quads);
+    await ps.storePrivateTriples(
+      CG,
+      ROOT,
+      quads.filter((q) => q.object !== '_:detail'),
+    );
 
-    // 1) Public anchor — async-lift-publisher-impl.ts:142-147 emits this
-    // for every private root so EPCIS queries can locate the matching
-    // private payload at query time.
+    const raw = await store.query(`
+      SELECT ?p ?o WHERE {
+        GRAPH <${PRIVATE_GRAPH}> { <${ROOT}> ?p ?o . }
+      }
+      ORDER BY ?p ?o
+    `);
+    expect(raw.type).toBe('bindings');
+    if (raw.type !== 'bindings') return;
+
+    const rawObjects = raw.bindings.map((row) => row['o']);
+    expect(rawObjects.some((o) => o?.startsWith('"enc:gcm:v1:'))).toBe(false);
+    expect(rawObjects).toContain('http://example.com/status/Ready');
+    expect(rawObjects).toContain('"7.5"^^<http://www.w3.org/2001/XMLSchema#decimal>');
+    expect(rawObjects).toContain('"batch-42"');
+    expect(rawObjects.some((o) => o?.startsWith('_:'))).toBe(true);
+    expect(raw.bindings).toHaveLength(4);
+
+    const filteredLiteral = await store.query(`
+      SELECT ?s WHERE {
+        GRAPH <${PRIVATE_GRAPH}> {
+          ?s <http://example.com/ns/batch> "batch-42" .
+        }
+      }
+    `);
+    expect(filteredLiteral.type).toBe('bindings');
+    if (filteredLiteral.type !== 'bindings') return;
+    expect(filteredLiteral.bindings.map((row) => row['s'])).toEqual([ROOT]);
+
+    const filteredTypedLiteral = await store.query(`
+      SELECT ?s WHERE {
+        GRAPH <${PRIVATE_GRAPH}> {
+          ?s <http://example.com/ns/temperature> ?temperature .
+          FILTER(?temperature >= "7.0"^^<http://www.w3.org/2001/XMLSchema#decimal>)
+        }
+      }
+    `);
+    expect(filteredTypedLiteral.type).toBe('bindings');
+    if (filteredTypedLiteral.type !== 'bindings') return;
+    expect(filteredTypedLiteral.bindings.map((row) => row['s'])).toEqual([ROOT]);
+
+    const filteredIri = await store.query(`
+      SELECT ?s WHERE {
+        GRAPH <${PRIVATE_GRAPH}> {
+          ?s <http://example.com/ns/status> <http://example.com/status/Ready> .
+        }
+      }
+    `);
+    expect(filteredIri.type).toBe('bindings');
+    if (filteredIri.type !== 'bindings') return;
+    expect(filteredIri.bindings.map((row) => row['s'])).toEqual([ROOT]);
+
+    const roundTrippedObjects = (await ps.getPrivateTriples(CG, ROOT)).map(
+      (q) => q.object,
+    );
+    expect(roundTrippedObjects).toContain('<http://example.com/status/Ready>');
+    expect(roundTrippedObjects).toContain('"7.5"^^<http://www.w3.org/2001/XMLSchema#decimal>');
+    expect(roundTrippedObjects).toContain('"batch-42"');
+    expect(roundTrippedObjects).toContain('"blank-node-shaped private data"');
+    expect(roundTrippedObjects.some((o) => o.startsWith('_:'))).toBe(true);
+  });
+
+  it('keeps EPCIS private event filters working through buildEpcisQuery', async () => {
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
     await store.insert([
       {
         subject: EVENT,
@@ -75,11 +147,6 @@ describe('OriginTrail/dkg#633 — EPCIS private queries cannot filter encrypted 
         graph: SWM_GRAPH,
       },
     ]);
-
-    // 2) Private EPCIS event triples — same shape the publisher writes
-    // through PrivateContentStore.storePrivateTriples for a private
-    // ObjectEvent. Every `object` field gets AES-GCM sealed before the
-    // triplestore sees it (private-store.ts:550-581).
     await ps.storePrivateTriples(CG, EVENT, [
       {
         subject: EVENT,
@@ -90,13 +157,7 @@ describe('OriginTrail/dkg#633 — EPCIS private queries cannot filter encrypted 
       {
         subject: EVENT,
         predicate: 'https://gs1.github.io/EPCIS/eventTime',
-        object: '"2026-05-25T08:00:00.000Z"',
-        graph: '',
-      },
-      {
-        subject: EVENT,
-        predicate: 'https://gs1.github.io/EPCIS/bizStep',
-        object: '<https://ref.gs1.org/cbv/BizStep-shipping>',
+        object: '"2026-05-12T10:00:00.000Z"',
         graph: '',
       },
       {
@@ -107,109 +168,72 @@ describe('OriginTrail/dkg#633 — EPCIS private queries cannot filter encrypted 
       },
       {
         subject: EVENT,
+        predicate: 'https://gs1.github.io/EPCIS/bizStep',
+        object: '<https://ref.gs1.org/cbv/BizStep-inspecting>',
+        graph: '',
+      },
+      {
+        subject: EVENT,
+        predicate: 'https://gs1.github.io/EPCIS/disposition',
+        object: '<https://ref.gs1.org/cbv/Disp-in_progress>',
+        graph: '',
+      },
+      {
+        subject: EVENT,
         predicate: 'https://gs1.github.io/EPCIS/epcList',
         object: `"${EPC}"`,
         graph: '',
       },
+      {
+        subject: EVENT,
+        predicate: 'https://gs1.github.io/EPCIS/readPoint',
+        object: '<urn:acme:bike:station:FunctionalTest>',
+        graph: '',
+      },
+      {
+        subject: EVENT,
+        predicate: 'https://gs1.github.io/EPCIS/bizLocation',
+        object: '<urn:acme:bike:station:FunctionalTest>',
+        graph: '',
+      },
     ]);
-  });
 
-  afterEach(async () => {
-    await store.close();
-    rmSync(tempDir, { recursive: true, force: true });
-    delete process.env.DKG_PRIVATE_STORE_KEY_FILE;
-  });
-
-  it('[shape] post-revert: IRI-object terms pass through plaintext, literal-object terms stay sealed', async () => {
-    // Asserts the post-revert envelope shape: literals are still
-    // wrapped in `"enc:gcm:v1:..."`, but IRIs land in the store
-    // verbatim. This is the new contract — see the comment block on
-    // `PrivateContentStore.encryptLiteral`.
-    const raw = await store.query(`
-      SELECT ?p ?o WHERE {
-        GRAPH <${PRIVATE_GRAPH}> { <${EVENT}> ?p ?o . }
-      }
-    `);
-    expect(raw.type).toBe('bindings');
-    if (raw.type !== 'bindings') return;
-    expect(raw.bindings).toHaveLength(5);
-
-    const sealedByPredicate = Object.fromEntries(
-      raw.bindings.map((r) => [r['p'], r['o']?.startsWith('"enc:gcm:v1:')]),
-    );
-    expect(sealedByPredicate['http://www.w3.org/1999/02/22-rdf-syntax-ns#type']).toBe(false);
-    expect(sealedByPredicate['https://gs1.github.io/EPCIS/bizStep']).toBe(false);
-    expect(sealedByPredicate['https://gs1.github.io/EPCIS/eventTime']).toBe(true);
-    expect(sealedByPredicate['https://gs1.github.io/EPCIS/action']).toBe(true);
-    expect(sealedByPredicate['https://gs1.github.io/EPCIS/epcList']).toBe(true);
-  });
-
-  it('[shape] PrivateContentStore.getPrivateTriples returns N-Triples-form terms for both sealed and unsealed objects', async () => {
-    const quads = await ps.getPrivateTriples(CG, EVENT);
-    expect(quads).toHaveLength(5);
-    const byPred = Object.fromEntries(quads.map((q) => [q.predicate, q.object]));
-    expect(byPred['http://www.w3.org/1999/02/22-rdf-syntax-ns#type']).toBe(
-      '<https://gs1.github.io/EPCIS/ObjectEvent>',
-    );
-    expect(byPred['https://gs1.github.io/EPCIS/bizStep']).toBe(
-      '<https://ref.gs1.org/cbv/BizStep-shipping>',
-    );
-    expect(byPred['https://gs1.github.io/EPCIS/action']).toBe('"OBSERVE"');
-    expect(byPred['https://gs1.github.io/EPCIS/epcList']).toBe(`"${EPC}"`);
-  });
-
-  it('[#633 IRI fix] buildEpcisQuery with no filters returns the private event (was: 0 rows)', async () => {
-    const sparql = buildEpcisQuery({ finalized: false }, CG);
-    expect(sparql).toContain('STRSTARTS(STR(?eventType), "https://gs1.github.io/EPCIS/")');
-    const res = await store.query(sparql);
-    expect(res.type).toBe('bindings');
-    if (res.type !== 'bindings') return;
-    expect(res.bindings).toHaveLength(1);
-    expect(res.bindings[0]?.['event']).toBe(EVENT);
-    expect(res.bindings[0]?.['eventType']).toBe(
-      'https://gs1.github.io/EPCIS/ObjectEvent',
-    );
-  });
-
-  it('[#633 IRI fix] IRI-position object filters now match against the private branch', async () => {
-    const iriPositionCases: Array<[string, Parameters<typeof buildEpcisQuery>[0]]> = [
+    const cases: Array<[string, Parameters<typeof buildEpcisQuery>[0]]> = [
+      ['no filters', { finalized: false }],
       ['eventType=ObjectEvent', { finalized: false, eventType: 'ObjectEvent' }],
-      ['bizStep=shipping', { finalized: false, bizStep: 'shipping' }],
-    ];
-    for (const [label, params] of iriPositionCases) {
-      const sparql = buildEpcisQuery(params, CG);
-      const res = await store.query(sparql);
-      expect(res.type, label).toBe('bindings');
-      if (res.type !== 'bindings') continue;
-      expect(res.bindings, label).toHaveLength(1);
-    }
-  });
-
-  it('[#633 follow-up] literal-position object filters still return empty (literals stay sealed; needs blind-index work)', async () => {
-    // The literal half of the seal is intentionally retained — it
-    // addresses the original ST-2 audit finding ("private literal
-    // values must not land on disk in plaintext"). The trade-off is
-    // that SPARQL `FILTER(?epcList = "...")`-style matches against
-    // sealed literals still bind to ciphertext.
-    //
-    // The proper fix is either (a) a blind-index sidecar that lets
-    // SPARQL match without revealing plaintext, or (b) an in-app
-    // post-decrypt pass in the EPCIS handler. Both are out of scope
-    // for the IRI-seal revert. Tracked as a follow-up on #633.
-    const literalPositionCases: Array<[string, Parameters<typeof buildEpcisQuery>[0]]> = [
-      ['epc=' + EPC, { finalized: false, epc: EPC }],
       ['action=OBSERVE', { finalized: false, action: 'OBSERVE' }],
+      ['bizStep=inspecting', { finalized: false, bizStep: 'inspecting' }],
+      ['disposition=in_progress', { finalized: false, disposition: 'in_progress' }],
+      ['epc filter', { finalized: false, epc: EPC }],
       [
-        'eventTime range',
-        { finalized: false, from: '2026-05-25T00:00:00Z', to: '2026-05-26T00:00:00Z' },
+        'time range',
+        {
+          finalized: false,
+          from: '2026-05-12T09:59:00.000Z',
+          to: '2026-05-12T10:01:00.000Z',
+        },
+      ],
+      [
+        'readPoint=FunctionalTest',
+        {
+          finalized: false,
+          readPoint: 'urn:acme:bike:station:FunctionalTest',
+        },
+      ],
+      [
+        'bizLocation=FunctionalTest',
+        {
+          finalized: false,
+          bizLocation: 'urn:acme:bike:station:FunctionalTest',
+        },
       ],
     ];
-    for (const [label, params] of literalPositionCases) {
-      const sparql = buildEpcisQuery(params, CG);
-      const res = await store.query(sparql);
-      expect(res.type, label).toBe('bindings');
-      if (res.type !== 'bindings') continue;
-      expect(res.bindings, `${label} — currently empty pending follow-up`).toHaveLength(0);
+
+    for (const [label, params] of cases) {
+      const result = await store.query(buildEpcisQuery(params, CG));
+      expect(result.type, label).toBe('bindings');
+      if (result.type !== 'bindings') continue;
+      expect(result.bindings.map((row) => row['event']), label).toEqual([EVENT]);
     }
   });
 });

--- a/packages/publisher/src/async-lift-subtraction.ts
+++ b/packages/publisher/src/async-lift-subtraction.ts
@@ -1,6 +1,6 @@
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { assertSafeRdfTerm } from '@origintrail-official/dkg-core';
-import { GraphManager, decryptPrivateLiteral } from '@origintrail-official/dkg-storage';
+import { GraphManager } from '@origintrail-official/dkg-storage';
 import type { LiftResolvedPublishSlice } from './async-lift-publish-options.js';
 import type { LiftJobValidationMetadata, LiftRequest } from './lift-job.js';
 
@@ -18,21 +18,6 @@ export async function subtractFinalizedExactQuads(params: {
   request: LiftRequest;
   validation: LiftJobValidationMetadata;
   resolved: LiftResolvedPublishSlice;
-  /**
-   * Explicit encryption key used when sealing private literals (same
-   * value the caller's `PrivateContentStore` was constructed with).
-   *
-   * without
-   * this, the subtraction called `decryptPrivateLiteral` with no
-   * override and resolved ONLY the env/default key. A deployment that
-   * uses a non-default key therefore never matched any plaintext input
-   * against the on-disk envelope — every private quad reappeared as
-   * "unseen" and got republished. Callers (DKGPublisher) thread the
-   * same key they passed to `PrivateContentStore` here. `undefined`
-   * keeps the legacy env/default resolution so tests with no explicit
-   * key keep working.
-   */
-  privateStoreEncryptionKey?: Uint8Array | string;
 }): Promise<ExactQuadSubtractionResult> {
   if (params.request.transitionType !== 'CREATE') {
     return {
@@ -54,17 +39,10 @@ export async function subtractFinalizedExactQuads(params: {
     publicGraphUri(params.graphManager, params.request.contextGraphId, params.request.subGraphName),
     confirmedRoots,
   );
-  // Private quads land on disk as AES-GCM-SIV ciphertext (
-  // ST-2). The deterministic IV guarantees identical plaintexts produce
-  // identical ciphertexts, but the authoritative-key set still has to
-  // be in plaintext form so callers can match against the
-  // user-supplied (plaintext) input quads. Decrypt as we read.
   const authoritativePrivate = await loadAuthoritativeQuadKeys(
     params.store,
     privateGraphUri(params.graphManager, params.request.contextGraphId, params.request.subGraphName),
     confirmedRoots,
-    /* decryptObjects */ true,
-    params.privateStoreEncryptionKey,
   );
 
   const publicResult = subtractGraphExactMatches(params.resolved.quads, confirmedRoots, authoritativePublic);
@@ -155,8 +133,6 @@ async function loadAuthoritativeQuadKeys(
   store: TripleStore,
   graph: string,
   confirmedRoots: Set<string>,
-  decryptObjects = false,
-  encryptionKey?: Uint8Array | string,
 ): Promise<Set<string>> {
   if (confirmedRoots.size === 0) {
     return new Set();
@@ -183,19 +159,7 @@ async function loadAuthoritativeQuadKeys(
   }
 
   return new Set(
-    result.quads.map((quad) => {
-      // forward the store's explicit `encryptionKey` (when the caller
-      // supplied one) so the decrypt here uses the SAME key the
-      // backing `PrivateContentStore` sealed under. Without this,
-      // `decryptPrivateLiteral` silently falls back to env/default
-      // and never round-trips a non-default-key seal — causing
-      // subtraction to miss every authoritative private quad on a
-      // retry and republish duplicates.
-      const object = decryptObjects
-        ? decryptPrivateLiteral(quad.object, { encryptionKey })
-        : quad.object;
-      return toQuadKey({ ...quad, object, graph: '' });
-    }),
+    result.quads.map((quad) => toQuadKey({ ...quad, graph: '' })),
   );
 }
 
@@ -226,8 +190,19 @@ function safeObject(value: string): string {
   return term;
 }
 
+function normaliseObjectTermToNTriples(object: string): string {
+  if (
+    object.startsWith('"') ||
+    object.startsWith('<') ||
+    object.startsWith('_:')
+  ) {
+    return object;
+  }
+  return safeIri(object);
+}
+
 function toQuadKey(quad: Quad): string {
-  return `${quad.subject} ${quad.predicate} ${quad.object}`;
+  return `${quad.subject} ${quad.predicate} ${normaliseObjectTermToNTriples(quad.object)}`;
 }
 
 function stripTerm(value: string | undefined): string | undefined {

--- a/packages/publisher/test/async-lift-subtraction.test.ts
+++ b/packages/publisher/test/async-lift-subtraction.test.ts
@@ -180,6 +180,78 @@ describe('subtractFinalizedExactQuads', () => {
     expect(result.resolved.privateQuads).toBeUndefined();
   });
 
+  it('removes finalized private IRI-object quads after store round-trip normalization', async () => {
+    const input: LiftValidationInput = {
+      ...baseInput(),
+      resolved: {
+        ...baseInput().resolved,
+        privateQuads: [
+          {
+            subject: 'urn:local:/rihana',
+            predicate: 'http://schema.org/secretLink',
+            object: '<urn:secret:iri-object>',
+            graph: '',
+          },
+        ],
+      },
+    };
+    const validated = validateLiftPublishPayload(input);
+
+    await publisher.publish({
+      contextGraphId: CONTEXT_GRAPH,
+      quads: validated.resolved.quads,
+      privateQuads: validated.resolved.privateQuads,
+      publisherPeerId: 'peer-1',
+    });
+
+    const result = await subtractFinalizedExactQuads({
+      store,
+      graphManager,
+      request: input.request,
+      validation: validated.validation,
+      resolved: validated.resolved,
+    });
+
+    expect(result.alreadyPublishedPrivateCount).toBe(1);
+    expect(result.resolved.privateQuads).toBeUndefined();
+  });
+
+  it('removes finalized private bare IRI-object quads after store round-trip normalization', async () => {
+    const input: LiftValidationInput = {
+      ...baseInput(),
+      resolved: {
+        ...baseInput().resolved,
+        privateQuads: [
+          {
+            subject: 'urn:local:/rihana',
+            predicate: 'http://schema.org/secretBareLink',
+            object: 'urn:secret:bare-iri-object',
+            graph: '',
+          },
+        ],
+      },
+    };
+    const validated = validateLiftPublishPayload(input);
+
+    await publisher.publish({
+      contextGraphId: CONTEXT_GRAPH,
+      quads: validated.resolved.quads,
+      privateQuads: validated.resolved.privateQuads,
+      publisherPeerId: 'peer-1',
+    });
+
+    const result = await subtractFinalizedExactQuads({
+      store,
+      graphManager,
+      request: input.request,
+      validation: validated.validation,
+      resolved: validated.resolved,
+    });
+
+    expect(result.alreadyPublishedPrivateCount).toBe(1);
+    expect(result.resolved.privateQuads).toBeUndefined();
+  });
+
   it('does not subtract when the root is not confirmed even if the quad exists locally', async () => {
     const validated = validateLiftPublishPayload(baseInput());
     const dataGraph = graphManager.dataGraphUri(CONTEXT_GRAPH);

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -24,7 +24,7 @@ export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';
 export { BlazegraphStore } from './adapters/blazegraph.js';
 export { SparqlHttpStore, type SparqlHttpStoreOptions } from './adapters/sparql-http.js';
 export { ContextGraphManager, GraphManager } from './graph-manager.js';
-export { PrivateContentStore, decryptPrivateLiteral } from './private-store.js';
+export { PrivateContentStore } from './private-store.js';
 
 // Side-effect: register built-in adapters
 import './adapters/oxigraph.js';

--- a/packages/storage/src/private-store.ts
+++ b/packages/storage/src/private-store.ts
@@ -1,504 +1,38 @@
-import { assertSafeIri, escapeSparqlLiteral, isSafeIri } from '@origintrail-official/dkg-core';
-import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import {
+  assertSafeIri,
+  assertSafeRdfTerm,
+  escapeSparqlLiteral,
+  isSafeIri,
+} from '@origintrail-official/dkg-core';
 import type { TripleStore, Quad } from './triple-store.js';
 import type { ContextGraphManager } from './graph-manager.js';
 
 /**
- * Manages private (publisher-only) triples. These live in the same context
- * graph data graph as public triples, but are only stored on the publisher's
- * node. The meta graph records which KAs have private triples (via
- * privateMerkleRoot and privateTripleCount).
+ * Manages private triples stored on the local node. Peer-to-peer private
+ * payloads are encrypted before they arrive here; after a node decrypts and
+ * accepts the payload, RDF terms in the local private graph stay plaintext so
+ * normal SPARQL filters and graph reads keep working.
  */
-/** AES-GCM ciphertext envelope tag — distinguishes private literals
- *  from any other typed/plain literal that happens to look like
- *  base64. Versioned so the on-disk format can rotate without
- *  breaking existing data. */
-const ENC_PREFIX = 'enc:gcm:v1:';
-
-/** Encryption key resolution order:
- *   1. Explicit constructor `encryptionKey` (32 bytes, hex/base64/raw or
- *      shorter passphrase — short inputs are SHA-256-stretched so AES-256
- *      always sees a full 256-bit key).
- *   2. `DKG_PRIVATE_STORE_KEY` env var (same shape as #1).
- *   3. A **per-node persisted** key generated at first run and stored on
- *      disk with 0600 permissions. The path resolves in this order:
- *        a. `DKG_PRIVATE_STORE_KEY_FILE`
- *        b. `<DKG_HOME>/private-store.key`
- *        c. `<homedir()>/.dkg/private-store.key`
- *      If any directory in the chain is unwritable we fall through to
- *      step 4 rather than silently crashing.
- *   4. As a last resort a deterministic `sha256(DEFAULT_KEY_DOMAIN)` —
- *      which is NOT secret and has to be kept behind a loud warning
- *      for environments (e.g. read-only FS, sandboxed CI) where
- *      persisting a key is impossible. Operators who need guaranteed
- *      confidentiality even in those environments MUST configure
- *      `DKG_PRIVATE_STORE_KEY` explicitly or turn on strict mode via
- *      `DKG_PRIVATE_STORE_STRICT_KEY=1` (or `strictKey: true`), which
- *      turns step 4 into a hard error.
- *
- * behaviour: step 3 did not exist, so every node without an
- * explicit key shared `sha256(DEFAULT_KEY_DOMAIN)` — any attacker with
- * repo source could decrypt the stored "private" triples across the
- * whole fleet.
- */
-const DEFAULT_KEY_DOMAIN = 'dkg-v10/private-store/default-key/v1';
-const PERSISTED_KEY_FILENAME = 'private-store.key';
-let defaultKeyWarned = false;
-/**
- * Per-path cache of persisted keys. An earlier revision used a
- * single module-global `cachedPersistedKey: Buffer | null`, which
- * silently aliased multiple `PrivateContentStore` instances onto
- * the FIRST node's key whenever one process hosted several nodes
- * with different `DKG_HOME` / `DKG_PRIVATE_STORE_KEY_FILE` values
- * (test fixtures, multi-tenant daemons, simulation harnesses).
- * The second node would:
- *   1. call `resolvePersistedKeyPath()` → get its OWN path
- *   2. call `loadOrCreatePersistedKey()` → hit the module-global
- *      cache populated by node #1, return node #1's key
- *   3. read/write all private data under node #1's secret, breaking
- *      crypto isolation.
- * When the env later flipped back to the original path, cached key
- * still won and data became unreadable.
- *
- * Fix: key the cache by resolved file path. Each node's path maps
- * to its own key buffer. Writes to the same path still hit the
- * cache (the round-12-2 intra-process sharing property). Different
- * paths get different keys.
- *
- * The cache is still process-local, unbounded-by-design (the set
- * of paths a single process opens in its lifetime is inherently
- * bounded by the number of node instances it hosts — this is
- * thousands at most, not millions of entries). A hostile caller
- * that spins up a new path every call would still be bounded by
- * the filesystem's own limits long before the Map becomes a
- * memory issue.
- */
-let persistedKeyWarnedPaths: Set<string> = new Set();
-const persistedKeyByPath: Map<string, Buffer> = new Map();
-
-function strictKeyRequestedFromEnv(): boolean {
-  const v = (process.env.DKG_PRIVATE_STORE_STRICT_KEY ?? '').toLowerCase();
-  return v === '1' || v === 'true' || v === 'yes';
-}
-
-function resolvePersistedKeyPath(): string {
-  if (process.env.DKG_PRIVATE_STORE_KEY_FILE) {
-    return process.env.DKG_PRIVATE_STORE_KEY_FILE;
-  }
-  if (process.env.DKG_HOME) {
-    return join(process.env.DKG_HOME, PERSISTED_KEY_FILENAME);
-  }
-  return join(homedir(), '.dkg', PERSISTED_KEY_FILENAME);
-}
-
-/**
- * Load the per-node persisted key, generating it on first run.
- *
- * Returns `null` if we cannot read or create the key file (read-only
- * filesystem, unknown home directory, etc.) so the caller can fall
- * through to the deterministic last-resort key under a loud warning.
- *
- * Failure modes we deliberately tolerate:
- *   - file exists but is shorter than 32 bytes: treat as corrupt,
- *     regenerate (we never want a short AES-256 key).
- *   - dir doesn't exist: `mkdirSync(..., recursive: true)`.
- *   - write errors: fall through to last-resort key.
- *
- * The cached key is process-wide so multiple `PrivateContentStore`
- * instances on the same node share the same secret without re-reading
- * the file on every construction.
- */
-function loadOrCreatePersistedKey(): Buffer | null {
-  const path = resolvePersistedKeyPath();
-  // per-path cache, so two nodes in the same process with
-  // different key files each get THEIR OWN key.
-  const cached = persistedKeyByPath.get(path);
-  if (cached) return cached;
-
-  // private-store.ts:124). The
-  // previous logic had two correctness holes around persistent key
-  // loading:
-  //
-  //   1. If the key file existed but was SHORT (<32 bytes — truncated,
-  //      partial write, FS corruption), the `if (raw.length >= 32)`
-  //      branch silently fell through to the regenerate path below.
-  //      That auto-rotation re-keys the node in place AND overwrites
-  //      the original (possibly recoverable) bytes — every previously
-  //      encrypted private triple is silently stranded with no way for
-  //      the operator to notice.
-  //
-  //   2. The outer `try/catch` swallowed ALL errors (including
-  //      "permission denied", "file is a symlink to /dev/null", etc.)
-  //      and returned `null` so the caller fell back to the global
-  //      deterministic last-resort key. That's a different but related
-  //      stranding: future writes encrypt under last-resort, while
-  //      reads of pre-existing data still need the persisted key, and
-  //      neither side surfaces the problem.
-  //
-  // Fix: TREAT A NON-EMPTY-BUT-INVALID FILE AS A LOUD ERROR. Only
-  // generate a fresh key when the file is genuinely absent. If the
-  // file exists but is short, throw a clear `Error` so the operator
-  // sees the corruption signal at startup. The `DKG_PRIVATE_STORE_KEY`
-  // / `DKG_PRIVATE_STORE_KEY_FILE` env overrides remain available as
-  // an escape hatch for managed-secret deployments. An optional
-  // `DKG_PRIVATE_STORE_KEY_AUTO_RESET=1` lets the operator opt back
-  // into the old auto-regenerate behaviour after they've explicitly
-  // accepted the data-loss trade-off.
-  const fileExists = existsSync(path);
-  if (fileExists) {
-    let raw: Buffer;
-    try {
-      raw = readFileSync(path);
-    } catch (err) {
-      // Read failed entirely (permissions, symlink loop, etc.) —
-      // surface the OS error so the operator can fix it instead of
-      // silently re-keying the node.
-      throw new Error(
-        `[PrivateContentStore] Failed to read persistent private-store key file at ${path}: ` +
-          `${(err as Error).message}. Refusing to fall back to a fresh key (would silently strand existing private triples). ` +
-          'Fix the file, restore from backup, set DKG_PRIVATE_STORE_KEY / DKG_PRIVATE_STORE_KEY_FILE, ' +
-          'or set DKG_PRIVATE_STORE_KEY_AUTO_RESET=1 if you accept losing every previously encrypted private triple.',
-        { cause: err as Error },
-      );
-    }
-    if (raw.length >= 32) {
-      const key = Buffer.from(raw.subarray(0, 32));
-      persistedKeyByPath.set(path, key);
-      return key;
-    }
-    // File exists but is unusable. Loud error — see commentary above.
-    if (process.env.DKG_PRIVATE_STORE_KEY_AUTO_RESET === '1') {
-      console.warn(
-        `[PrivateContentStore] Persistent private-store key file at ${path} is corrupt ` +
-          `(length=${raw.length}, expected >= 32). DKG_PRIVATE_STORE_KEY_AUTO_RESET=1 is set, ` +
-          'so a FRESH key will be generated. Every previously encrypted private triple under the old ' +
-          'key is now PERMANENTLY UNRECOVERABLE.',
-      );
-      // Fall through to the generation path below.
-    } else {
-      throw new Error(
-        `[PrivateContentStore] Persistent private-store key file at ${path} is corrupt ` +
-          `(length=${raw.length}, expected >= 32 bytes for AES-256). ` +
-          'Refusing to auto-regenerate (would silently strand every previously encrypted private triple). ' +
-          'Restore the file from backup, set DKG_PRIVATE_STORE_KEY / DKG_PRIVATE_STORE_KEY_FILE to a known-good secret, ' +
-          'or set DKG_PRIVATE_STORE_KEY_AUTO_RESET=1 to accept losing every previously encrypted private triple ' +
-          'and regenerate a fresh key on next start.',
-      );
-    }
-  }
-
-  // First-run path: file is genuinely absent (or auto-reset opted-in).
-  try {
-    const dir = dirname(path);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
-    const fresh = randomBytes(32);
-    writeFileSync(path, fresh, { mode: 0o600 });
-    try { chmodSync(path, 0o600); } catch { /* non-POSIX FS */ }
-    if (!persistedKeyWarnedPaths.has(path)) {
-      persistedKeyWarnedPaths.add(path);
-      console.warn(
-        `[PrivateContentStore] Generated per-node private-store key at ${path}. ` +
-          'Back this file up alongside your node data; losing it makes existing ' +
-          'private triples unrecoverable. Override with DKG_PRIVATE_STORE_KEY ' +
-          'or DKG_PRIVATE_STORE_KEY_FILE to use a managed secret instead.',
-      );
-    }
-    persistedKeyByPath.set(path, fresh);
-    return fresh;
-  } catch {
-    // Generation failed (read-only FS, unknown home, etc.). Caller
-    // falls through to the deterministic last-resort key under a loud
-    // warning — same behaviour as before this change. We deliberately
-    // do NOT throw here because some test/dev environments cannot
-    // create the file at all and the operator already accepted the
-    // last-resort fallback in those topologies.
-    return null;
-  }
-}
-
-/** Test-only: drop any cached per-node key so a subsequent call
- *  re-reads from the (possibly-changed) persistence path. */
-export function __resetPrivateStoreKeyCacheForTests(): void {
-  persistedKeyByPath.clear();
-  defaultKeyWarned = false;
-  persistedKeyWarnedPaths = new Set();
-}
-
-/**
- * Decode a string-encoded key/passphrase into raw bytes.
- *
- * previously any non-hex string fell through to
- * `Buffer.from(s, 'base64')`, which silently interprets non-base64 input
- * as truncated garbage. Two callers passing the passphrases `"hunter2"`
- * and `"hunter2!"` would end up with the SAME key because both decode
- * to the same leading bytes under a permissive base64 reader.
- *
- * Resolution:
- *   - 64-char hex → decode as hex.
- *   - Canonical base64 (length multiple of 4, valid alphabet, length >=
- *     44 so the DECODED length is 32 or more) → decode as base64.
- *   - Everything else → treat as a UTF-8 passphrase and SHA-256-stretch.
- */
-function decodeKeyOrPassphrase(s: string): Buffer {
-  if (/^[0-9a-fA-F]{64}$/.test(s)) {
-    return Buffer.from(s, 'hex');
-  }
-  const looksLikeCanonicalBase64 =
-    s.length >= 44 &&
-    s.length % 4 === 0 &&
-    /^[A-Za-z0-9+/]+={0,2}$/.test(s);
-  if (looksLikeCanonicalBase64) {
-    try {
-      const buf = Buffer.from(s, 'base64');
-      if (buf.length >= 32) return buf;
-    } catch {
-      // fall through to passphrase path
-    }
-  }
-  return Buffer.from(s, 'utf8');
-}
-
-/**
- * Compute the deterministic legacy fallback key.
- *
- * nodes (no `DKG_PRIVATE_STORE_KEY` configured) all shared
- * `sha256(DEFAULT_KEY_DOMAIN)`. the rightly stopped using
- * that as the preferred key, but a straight flip would strand every
- * private triple written before the upgrade — the fresh per-node key
- * cannot decrypt ciphertext sealed under the deterministic key.
- *
- * keep the legacy key around as
- * a **decrypt-only** fallback so existing data remains readable after
- * upgrade. New writes always use the primary key. The legacy key is
- * never used to encrypt anything (the confidentiality regression that
- * ed is preserved — no one sharing a public constant for
- * fresh data). Once all legacy ciphertext has been re-encrypted or
- * deleted, operators can drop the fallback entirely by setting
- * `DKG_PRIVATE_STORE_STRICT_KEY=1` (which disables unconfigured-key
- * fallbacks altogether).
- */
-function computeLegacyDefaultDomainKey(): Buffer {
-  return createHash('sha256').update(DEFAULT_KEY_DOMAIN).digest();
-}
-
-/**
- * Try to decrypt an AES-GCM envelope against a primary key, falling
- * back to a list of legacy keys if the primary fails.
- *
- * AES-GCM authenticates every ciphertext with a 128-bit tag, so a
- * wrong key surfaces as a `decipher.final()` throw (Error: Unsupported
- * state or unable to authenticate data) — no silent plaintext
- * corruption. That lets us safely try keys in order and return the
- * first that authenticates.
- *
- * Returns `null` if NO key in the chain authenticates the ciphertext;
- * callers turn that into "leave the envelope visible so the operator
- * can detect the failure".
- */
-function tryDecryptWithKeyChain(
-  iv: Buffer,
-  tag: Buffer,
-  ct: Buffer,
-  primary: Buffer,
-  legacyKeys: readonly Buffer[],
-): string | null {
-  const chain = [primary, ...legacyKeys];
-  for (const key of chain) {
-    try {
-      const decipher = createDecipheriv('aes-256-gcm', key, iv);
-      decipher.setAuthTag(tag);
-      return Buffer.concat([decipher.update(ct), decipher.final()]).toString('utf8');
-    } catch {
-      // try next key
-    }
-  }
-  return null;
-}
-
-/**
- * Stateless mirror of {@link PrivateContentStore}'s seal — used by
- * pipelines that read private quads back from the underlying store via
- * raw SPARQL (and therefore see ciphertext envelopes) but want to
- * reason about plaintext semantics. Examples include the publisher's
- * `subtractFinalizedExactQuads`, which compares input plaintext quads
- * against on-disk authoritative quads for exact dedup. Without this,
- * the subtraction silently misses every private match because
- * `"plaintext"` never equals `"enc:gcm:v1:…"`.
- *
- * The helper resolves the same encryption key (DKG_PRIVATE_STORE_KEY
- * or the deterministic default-domain hash) so every consumer in the
- * process round-trips to identical bytes. Non-encrypted literals,
- * URIs, and blank nodes are returned unchanged.
- *
- * when the primary key can't
- * decrypt (typical on nodes just upgraded past r12-2 that still hold
- * private triples sealed under the legacy default-domain
- * key), fall back to the legacy `sha256(DEFAULT_KEY_DOMAIN)` key so
- * old data remains readable.
- */
-export function decryptPrivateLiteral(
-  serialized: string,
-  options: { encryptionKey?: Uint8Array | string } = {},
-): string {
-  if (!serialized.startsWith(`"${ENC_PREFIX}`)) return serialized;
-  const m = serialized.match(/^"enc:gcm:v1:([^"]+)"$/);
-  if (!m) return serialized;
-  const primary = resolveEncryptionKey(options.encryptionKey);
-  const legacyKeys = resolveLegacyDecryptionKeys(primary);
-  try {
-    const buf = Buffer.from(m[1], 'base64');
-    const iv = buf.subarray(0, 12);
-    const tag = buf.subarray(12, 28);
-    const ct = buf.subarray(28);
-    const plain = tryDecryptWithKeyChain(Buffer.from(iv), Buffer.from(tag), Buffer.from(ct), primary, legacyKeys);
-    if (plain === null) return serialized;
-    // Strip r6 type-tag prefix (`L|` literal / `I|` IRI). Legacy
-    // envelopes without the tag are returned verbatim for backwards
-    // compatibility — see `PrivateContentStore#decryptLiteral`.
-    if (plain.length >= 2 && plain[1] === '|') return plain.slice(2);
-    return plain;
-  } catch {
-    return serialized;
-  }
-}
-
-/**
- * Build the decrypt-only fallback-key list.
- *
- * Rules:
- *   - Always include `sha256(DEFAULT_KEY_DOMAIN)` unless it IS the
- *     primary (no point trying the same key twice — and that happens
- *     naturally on a read-only/sandbox node whose persisted-key
- *     creation failed and fell through to the legacy last-resort key
- *     anyway).
- *   - Never return an entry that would encrypt. This list is consumed
- *     by `tryDecryptWithKeyChain` only.
- */
-function resolveLegacyDecryptionKeys(primary: Buffer): Buffer[] {
-  const legacy = computeLegacyDefaultDomainKey();
-  if (primary.equals(legacy)) return [];
-  return [legacy];
-}
-
-function resolveEncryptionKey(
-  explicit?: Uint8Array | string,
-  options: { strictKey?: boolean } = {},
-): Buffer {
-  const fromExplicit = explicit ?? process.env.DKG_PRIVATE_STORE_KEY;
-  if (fromExplicit) {
-    const buf =
-      typeof fromExplicit === 'string'
-        ? decodeKeyOrPassphrase(fromExplicit)
-        : Buffer.from(fromExplicit);
-    if (buf.length !== 32) {
-      return createHash('sha256').update(buf).digest();
-    }
-    return buf;
-  }
-  // no key configured. If the caller (or the
-  // operator via DKG_PRIVATE_STORE_STRICT_KEY) has opted into strict
-  // mode, refuse to fall back to ANY unconfigured key — strict callers
-  // want a managed secret or nothing at all.
-  const strict = options.strictKey ?? strictKeyRequestedFromEnv();
-  if (strict) {
-    throw new Error(
-      'PrivateContentStore strict mode: DKG_PRIVATE_STORE_KEY is not set ' +
-        'and no encryptionKey was supplied. Refusing to fall back to an ' +
-        'auto-generated per-node key or the deterministic default — ' +
-        'configure a managed secret explicitly.',
-    );
-  }
-  // Preferred default: per-node persisted
-  // key. This gives every unconfigured node a unique secret so
-  // "private" triples are not cross-decryptable across the fleet.
-  const persisted = loadOrCreatePersistedKey();
-  if (persisted) return persisted;
-  // Last resort — persistence failed (read-only FS / CI sandbox / no
-  // HOME). Emit a LOUD warning so the operator can see the gap and
-  // either configure DKG_PRIVATE_STORE_KEY or make the key path
-  // writable. Private triples written under this key are NOT
-  // confidential against anyone with repo access.
-  if (!defaultKeyWarned) {
-    defaultKeyWarned = true;
-    console.warn(
-      '[PrivateContentStore] WARNING: DKG_PRIVATE_STORE_KEY is not set ' +
-        'and the per-node key file could not be created ' +
-        `(${resolvePersistedKeyPath()}). Falling back to a deterministic ` +
-        'default key derived from a public constant — private triples ' +
-        'encrypted under this key are NOT confidential against anyone ' +
-        'with access to this repository. Set DKG_PRIVATE_STORE_KEY to a ' +
-        'per-deployment secret, set DKG_PRIVATE_STORE_KEY_FILE to a ' +
-        'writable path, or set DKG_PRIVATE_STORE_STRICT_KEY=1 to turn ' +
-        'this fallback into an error.',
-    );
-  }
-  return createHash('sha256').update(DEFAULT_KEY_DOMAIN).digest();
-}
-
 export class PrivateContentStore {
   private readonly store: TripleStore;
   private readonly graphManager: ContextGraphManager;
   /** Tracks which rootEntities have private triples on this node. */
   private readonly privateEntities = new Map<string, Set<string>>();
-  /** AES-256-GCM key — used to seal literal objects of private quads
-   *  before they reach the underlying TripleStore (. */
-  private readonly encryptionKey: Buffer;
   /**
-   * dedup race). The
-   * read-then-insert sequence in {@link storePrivateTriples} would,
-   * under concurrent invocation for the same private graph, let two
-   * writers both observe an empty `existingPlainKeys`, then each
-   * insert their own ciphertext for the SAME `(s,p,o)` plaintext.
-   * Because {@link encryptLiteral} now uses a fresh random IV per
-   * call, the two ciphertexts are byte-distinct, so
-   * the underlying triple store happily keeps both — duplicating the
-   * private quad. This map serialises `storePrivateTriples` calls per
-   * `graphUri` so the read-and-insert pair is atomic from the caller's
-   * perspective. Different graphs still write in parallel.
+   * Serialises the read-existing + insert-missing sequence per private graph.
+   * Without this lock, concurrent replays can both observe an empty graph and
+   * insert duplicate rows before either insert becomes visible to the other.
    */
   private readonly perGraphWriteLocks = new Map<string, Promise<void>>();
 
-  constructor(
-    store: TripleStore,
-    graphManager: ContextGraphManager,
-    options: { encryptionKey?: Uint8Array | string; strictKey?: boolean } = {},
-  ) {
+  constructor(store: TripleStore, graphManager: ContextGraphManager) {
     this.store = store;
     this.graphManager = graphManager;
-    this.encryptionKey = resolveEncryptionKey(options.encryptionKey, {
-      strictKey: options.strictKey,
-    });
   }
 
   /**
-   * Run `fn` while holding an exclusive lock on `graphUri`. The lock
-   * is released when `fn` resolves OR rejects; queued waiters then
-   * fire in order.
-   *
-   * private-store.ts:491). The lock chain
-   * MUST decouple from the predecessor's success/failure: pre-r31-14
-   * the chain was `prev.then(() => next)` and `await prev` was
-   * outside the try/finally. If any prior writer rejected, `prev`
-   * was a rejected promise — every subsequent waiter inherited the
-   * rejection on `await prev` BEFORE entering the try{} that calls
-   * `release()`. That left `next` pending forever, the in-flight
-   * `chained` rejected, and the `perGraphWriteLocks` entry was never
-   * cleaned up because the cleanup also sat in the `finally`. Net
-   * effect: a single failed `storePrivateTriples()` permanently
-   * BRICKED that graph until process restart — every later writer
-   * for the same graph either threw on the rejected predecessor
-   * before doing anything OR enqueued behind a permanently-pending
-   * `next`.
-   *
-   * Fix: build the chain off `prev.catch(() => {})` so the queue is
-   * resilient to a predecessor's rejection. The lock is purely a
-   * mutex over `fn()`; the success/failure of the previous writer's
-   * own `fn()` is its caller's concern, not the queue's. Also
-   * `await safePrev` (the catch-wrapped variant) so the wait can
-   * never throw before we register the cleanup-on-finally.
+   * Run `fn` while holding an exclusive lock on `graphUri`. The lock is
+   * released when `fn` resolves or rejects; queued waiters then fire in order.
    */
   private async withGraphWriteLock<T>(
     graphUri: string,
@@ -507,9 +41,6 @@ export class PrivateContentStore {
     const prev = this.perGraphWriteLocks.get(graphUri) ?? Promise.resolve();
     let release!: () => void;
     const next = new Promise<void>((resolve) => { release = resolve; });
-    // Swallow predecessor rejections so the queue keeps draining.
-    // The previous writer's caller already saw (or chose to ignore)
-    // the rejection; the lock has no business re-throwing here.
     const safePrev = prev.catch(() => undefined);
     const chained = safePrev.then(() => next);
     this.perGraphWriteLocks.set(graphUri, chained);
@@ -525,113 +56,9 @@ export class PrivateContentStore {
   }
 
   /**
-   * AES-256-GCM seal — operates on the LEXICAL value portion of an
-   * RDF literal so the wire and at-rest formats remain valid N-Quads
-   * (a quoted string with no datatype/language). The wrapper preserves
-   * the original literal shape (language tag / datatype IRI) by
-   * embedding it in the plaintext payload before encryption.
-   *
-   * the previous implementation derived the IV as
-   * HMAC-SHA256(key, plaintext) truncated to 96 bits. That is NOT RFC
-   * 8452 AES-GCM-SIV; it is plain AES-GCM with a deterministic IV. Two
-   * identical plaintexts sealed under the same key produce identical
-   * 96-bit IVs, which is exactly the condition AES-GCM forbids — a
-   * single same-key same-nonce collision on two distinct plaintexts
-   * leaks H (the authentication subkey) and lets an attacker forge
-   * arbitrary tags. Even without two distinct plaintexts, determinism
-   * itself is a confidentiality leak: identical plaintexts become
-   * identical ciphertexts, which is visible at the storage layer.
-   *
-   * We now draw a fresh 96-bit random IV for every seal. The downstream
-   * dedup pipeline (async-lift `subtractFinalizedExactQuads`) already
-   * decrypts via {@link decryptPrivateLiteral} before comparing, so
-   * non-deterministic ciphertext does not break it.
-   */
-  private encryptLiteral(serialized: string): string {
-    // Blank nodes are node-local and carry no externally-meaningful
-    // identity, so sealing them would only break dedup — leave as-is.
-    if (serialized.startsWith('_:')) return serialized;
-    // IRI objects pass through unsealed. An earlier revision
-    // (de341d88, 2026-04-22, PR-229 round-6 bot review finding) wrapped
-    // both literals and IRIs in the same AES-GCM envelope with an
-    // internal `L|` / `I|` tag, on the theory that the on-disk N-Quads
-    // dump of a private graph would otherwise leak outgoing-edge target
-    // IRIs. That sealed-IRI behaviour broke every SPARQL filter against
-    // the `_private` graph — most visibly the EPCIS read path, which
-    // pattern-matches `?event a <ObjectEvent>` and friends in the
-    // object position (see https://github.com/OriginTrail/dkg/issues/633
-    // and `dkgv10-spec/scratchpad/private-store-iri-seal-blast-radius.md`).
-    // We now seal LITERAL object terms only, matching the original ST-2
-    // finding ("the literal value lands on disk in plaintext"). IRI
-    // confidentiality across `_private` is a separate concern that
-    // needs a blind-index design, not a SPARQL-killing envelope.
-    //
-    // Decrypt-side compatibility: `decryptLiteral` still strips the
-    // `L|` / `I|` prefix after decryption, so retroactive private
-    // triples sealed between 2026-05-05 (PR #379) and this commit
-    // remain readable via the safe API (`getPrivateTriples`).
-    if (!serialized.startsWith('"')) return serialized;
-    const plaintext = `L|${serialized}`;
-    const iv = randomBytes(12);
-    const cipher = createCipheriv('aes-256-gcm', this.encryptionKey, iv);
-    const ct = Buffer.concat([
-      cipher.update(plaintext, 'utf8'),
-      cipher.final(),
-    ]);
-    const authTag = cipher.getAuthTag();
-    const payload = Buffer.concat([iv, authTag, ct]).toString('base64');
-    return `"${ENC_PREFIX}${payload}"`;
-  }
-
-  private decryptLiteral(serialized: string): string {
-    if (!serialized.startsWith(`"${ENC_PREFIX}`)) return serialized;
-    const m = serialized.match(/^"enc:gcm:v1:([^"]+)"$/);
-    if (!m) return serialized;
-    try {
-      const buf = Buffer.from(m[1], 'base64');
-      const iv = buf.subarray(0, 12);
-      const tag = buf.subarray(12, 28);
-      const ct = buf.subarray(28);
-      // fall back to the legacy
-      // `sha256(DEFAULT_KEY_DOMAIN)` key when the primary key fails
-      // to authenticate. This is decrypt-only — `encryptLiteral`
-      // always uses `this.encryptionKey` — so a freshly-upgraded node
-      // whose private triples were sealed under the legacy
-      // deterministic key can still read them, while every new write
-      // goes to the unique per-node key.
-      const legacyKeys = resolveLegacyDecryptionKeys(this.encryptionKey);
-      const plain = tryDecryptWithKeyChain(
-        Buffer.from(iv),
-        Buffer.from(tag),
-        Buffer.from(ct),
-        this.encryptionKey,
-        legacyKeys,
-      );
-      if (plain === null) {
-        // Wrong key or corrupted ciphertext — leave the envelope
-        // visible so callers can detect the failure rather than
-        // silently dropping to "no result".
-        return serialized;
-      }
-      // Legacy (pre-r6) envelopes contained the literal bytes verbatim
-      // with no type tag. Detect them by the absence of the `L|` / `I|`
-      // prefix and return them unchanged so previously-written data
-      // stays readable after the seal-IRI upgrade.
-      if (plain.length < 2 || plain[1] !== '|') return plain;
-      return plain.slice(2);
-    } catch {
-      return serialized;
-    }
-  }
-
-  /**
-   * Read the set of already-present `(s, p, plaintextObject)` triples in
-   * `graphUri` whose `(s, p)` appears in `incoming`, decrypting the
-   * stored ciphertext objects so comparison is on plaintext identity.
-   *
-   * Scoping the SPARQL to only the `(s, p)` pairs the caller is about
-   * to write keeps this bounded: the naive "pull every private quad in
-   * the graph" variant would be O(|graph|) per insert.
+   * Read the set of already-present `(s, p, object)` triples in `graphUri`
+   * whose predicates appear in `incoming`. Scoping the SPARQL read keeps
+   * retries bounded without scanning every private quad in the graph.
    */
   private async collectExistingPlaintextKeys(
     graphUri: string,
@@ -645,48 +72,12 @@ export class PrivateContentStore {
     }
     if (subjects.size === 0 || predicates.size === 0) return new Set();
 
-    // — private-store.ts:553). The
-    // dedup query previously assumed every subject was an IRI and
-    // ran `assertSafeIri()` over each — but private RDF can legally
-    // contain blank-node subjects (`_:b0`) and `assertSafeIri()`
-    // throws on them. That throw escaped the surrounding try/catch
-    // (which only wraps `this.store.query(sparql)`, not the SPARQL
-    // construction), so a single blank-node-subject quad anywhere
-    // in the batch failed `storePrivateTriples()` outright instead
-    // of letting it fall back to the no-dedup path.
-    //
-    // Two complications govern the fix:
-    //   1. `assertSafeIri()` on `predicate` is FINE — RDF predicates
-    //      MUST be IRIs, never blank nodes. So we keep that strict.
-    //   2. Blank node IDENTITY is not stable across SPARQL queries
-    //      in the general case (a `_:b0` literal in a fresh query
-    //      may or may not bind to the same store-internal blank
-    //      node, depending on the implementation). So we cannot
-    //      rely on `VALUES ?s { _:b0 }` to dedup correctly even if
-    //      the parser accepted it. Instead, we OMIT the `?s VALUES`
-    //      pin entirely whenever ANY incoming subject is non-IRI
-    //      and rely on the predicate VALUES (always IRIs) +
-    //      post-filter to bound the working set. Predicate VALUES
-    //      alone is still a dramatic narrowing vs reading the
-    //      entire private graph; a private graph that uses the
-    //      same predicate for thousands of subjects already pays
-    //      that scan in `getPrivateTriples()`.
-    //   3. The post-filter still pre-computes the
-    //      `subject\u0001predicate\u0001plain` key BEFORE inserting
-    //      into the dedup set, so a blank-node subject in the
-    //      store still dedups against the SAME blank-node label in
-    //      the incoming batch — which is exactly the contract we
-    //      want for retry idempotency (the same caller writing the
-    //      same `_:b0` twice).
     let escapedPredicateVals: string;
     try {
       escapedPredicateVals = [...predicates]
         .map((p) => `<${assertSafeIri(p)}>`)
         .join(' ');
     } catch {
-      // Predicate that fails `assertSafeIri` is malformed RDF; bail
-      // to no-dedup rather than throwing out of an idempotency
-      // helper.
       return new Set();
     }
 
@@ -694,25 +85,10 @@ export class PrivateContentStore {
     try {
       escapedGraph = `<${assertSafeIri(graphUri)}>`;
     } catch {
-      // graphUri is constructed by the privateGraph() helper from
-      // contextGraphId + subGraphName — both already validated
-      // upstream — so this catch is purely defence-in-depth.
       return new Set();
     }
 
     const incomingSubjects = [...subjects];
-    // — private-store.ts:553) — note on
-    // detection. `assertSafeIri()` only rejects characters that would
-    // break SPARQL `<...>` framing; it accepts strings like `_:bn`
-    // because `_` and `:` aren't unsafe glyphs. That meant a previous
-    // attempt at this fix (gating on `assertSafeIri()` not throwing)
-    // still emitted invalid `<_:bn>` IRI tokens for blank-node
-    // subjects, the SPARQL parser rejected the query, and dedup
-    // silently fell back to no-op for ALL mixed batches — including
-    // the IRI subjects that should still have deduped. We now use the
-    // strict `isSafeIri()` check, which requires a `scheme:` prefix
-    // (and so reliably distinguishes IRIs from blank nodes / literals
-    // that happen to be character-safe).
     const allSubjectsSafe = incomingSubjects.every((s) => isSafeIri(s));
 
     let sparql: string;
@@ -730,9 +106,6 @@ export class PrivateContentStore {
         }
       `;
     } else {
-      // At least one blank-node (or otherwise non-IRI) subject.
-      // Drop the subject pin and rely on predicate narrowing +
-      // post-filter against `subjects` set membership.
       sparql = `
         SELECT ?s ?p ?o WHERE {
           GRAPH ${escapedGraph} {
@@ -742,24 +115,29 @@ export class PrivateContentStore {
         }
       `;
     }
+
     const keys = new Set<string>();
     try {
       const result = await this.store.query(sparql);
       if (result.type !== 'bindings') return keys;
       for (const row of result.bindings) {
         const subjectStr = row['s'];
-        if (subjectStr === undefined) continue;
-        // Post-filter for the blank-node fallback path: only
-        // dedup against subjects we are about to write. (For the
-        // strict-IRI path the SPARQL VALUES already enforces this.)
+        const predicateStr = row['p'];
+        const objectStr = row['o'];
+        if (
+          subjectStr === undefined ||
+          predicateStr === undefined ||
+          objectStr === undefined
+        ) {
+          continue;
+        }
         if (!allSubjectsSafe && !subjects.has(subjectStr)) continue;
-        const plain = this.decryptLiteral(row['o']);
-        keys.add(`${subjectStr}\u0001${row['p']}\u0001${plain}`);
+        const object = normaliseTermToNTriples(objectStr);
+        keys.add(`${subjectStr}\u0001${predicateStr}\u0001${object}`);
       }
     } catch {
-      // If the scoped read fails we fall back to no-dedup: worst case
-      // is the historical behaviour (duplicate ciphertexts) — never a
-      // confidentiality regression.
+      // If the scoped read fails we fall back to no-dedup: worst case is
+      // historical duplicate rows, not data loss.
     }
     return keys;
   }
@@ -778,7 +156,11 @@ export class PrivateContentStore {
     return subGraphName ? `${contextGraphId}\0${subGraphName}` : contextGraphId;
   }
 
-  private privateStagingGraph(contextGraphId: string, shareOperationId: string, subGraphName?: string): string {
+  private privateStagingGraph(
+    contextGraphId: string,
+    shareOperationId: string,
+    subGraphName?: string,
+  ): string {
     const parts = [contextGraphId, subGraphName ?? '_', shareOperationId]
       .map((part) => encodeURIComponent(part));
     return assertSafeIri(`urn:dkg:private-stage-graph:${parts.join(':')}`);
@@ -792,44 +174,17 @@ export class PrivateContentStore {
   ): Promise<void> {
     if (quads.length === 0) return;
 
-    // Defence-in-depth (ST-7): reject unsafe IRIs at the entry point. The
-    // other private-store operations (`getPrivateTriples`,
-    // `hasPrivateTriplesInStore`, `deletePrivateTriples`) all route
-    // `rootEntity` through `assertSafeIri` as they build SPARQL, so a
-    // string like `did:dkg:agent:evil> <http://attacker/` that slipped in
-    // here would land fine in the in-memory tracker and blow up only on
-    // the first downstream query. Asserting at write time gives callers
-    // an immediate, consistent error shape and keeps the tracker clean.
     assertSafeIri(rootEntity);
+    for (const q of quads) {
+      assertSafePrivateQuad(q);
+    }
 
     const graphUri = this.privateGraph(contextGraphId, subGraphName);
-    // ST-2: encrypt the literal `object` BEFORE handing the quad to
-    // the underlying TripleStore. URIs and blank nodes carry no
-    // payload and are passed through unchanged. The resulting
-    // on-disk N-Quads dump contains only ciphertext envelopes
-    // (`enc:gcm:v1:<base64>`); callers retrieve plaintext via
-    // `getPrivateTriples`, which reverses the seal.
-    //
-    // Because `encryptLiteral` uses a fresh random IV per call
-    // (deterministic IVs are forbidden for AES-GCM), a plain
-    // `insert()` would duplicate the quad on every retry / replay
-    // of the same private KA: the store dedups by byte-identical
-    // terms, but ciphertext is never byte-identical across writes.
-    // Dedup here by decrypting the set of existing ciphertext
-    // objects at each `(s, p)` position in this private graph and
-    // skipping any incoming plaintext that is already there. The
-    // comparison is on **plaintext** triple identity, which is the
-    // semantic we want; it preserves random-IV confidentiality
-    // while making the write idempotent.
-    //
-    // Hold a per-graph mutex for the whole "scan existing plaintext
-    // + insert
-    // missing quads" sequence so a second concurrent caller cannot
-    // observe an empty key set in parallel and wind up inserting a
-    // byte-distinct (random-IV) ciphertext for the same `(s,p,o)`
-    // plaintext.
     await this.withGraphWriteLock(graphUri, async () => {
-      const existingPlainKeys = await this.collectExistingPlaintextKeys(graphUri, quads);
+      const existingPlainKeys = await this.collectExistingPlaintextKeys(
+        graphUri,
+        quads,
+      );
       const toInsert: Quad[] = [];
       const seenInBatch = new Set<string>();
       for (const q of quads) {
@@ -839,7 +194,7 @@ export class PrivateContentStore {
         seenInBatch.add(key);
         toInsert.push({
           ...q,
-          object: this.encryptLiteral(q.object),
+          object: q.object,
           graph: graphUri,
         });
       }
@@ -937,14 +292,7 @@ export class PrivateContentStore {
     return result.bindings.map((row) => ({
       subject: row['s'],
       predicate: row['p'],
-      // Reverse the AES-GCM seal applied at write time so callers see
-      // the original literal value. Non-encrypted values (legacy data,
-      // URIs, blank nodes) flow through unchanged, then get normalised
-      // back to N-Triples form below so the `Quad.object` contract is
-      // stable across sealed vs unsealed values (post-IRI-seal-revert,
-      // freshly-stored IRI objects come back as bare strings from the
-      // SPARQL binding layer — see #633).
-      object: normaliseTermToNTriples(this.decryptLiteral(row['o'])),
+      object: normaliseTermToNTriples(row['o']),
       graph: graphUri,
     }));
   }
@@ -956,9 +304,8 @@ export class PrivateContentStore {
   }
 
   /**
-   * Checks the store directly for whether private triples exist.
-   * Useful when the in-memory tracker hasn't been populated (e.g., on a
-   * different instance than the one that originally stored the triples).
+   * Checks the store directly for whether private triples exist. Useful when
+   * the in-memory tracker has not been populated.
    */
   async hasPrivateTriplesInStore(
     contextGraphId: string,
@@ -974,8 +321,6 @@ export class PrivateContentStore {
     rootEntity: string,
     subGraphName?: string,
   ): Promise<void> {
-    // ST-7: assertSafeIri on the delete path so a malicious rootEntity
-    // cannot smuggle SPARQL-update tokens into `deleteBySubjectPrefix`.
     assertSafeIri(rootEntity);
     const graphUri = this.privateGraph(contextGraphId, subGraphName);
     await this.store.deleteBySubjectPrefix(graphUri, rootEntity);
@@ -1007,19 +352,35 @@ function parseLiteral(value: string | undefined): unknown {
   }
 }
 
+function assertSafePrivateQuad(q: Quad): void {
+  assertSafeSubjectOrObject(q.subject);
+  assertSafeIri(q.predicate);
+  assertSafeSubjectOrObject(q.object);
+}
+
+function assertSafeSubjectOrObject(term: string): void {
+  if (term.startsWith('_:')) {
+    assertSafeBlankNode(term);
+    return;
+  }
+  if (term.startsWith('"') || term.startsWith('<')) {
+    assertSafeRdfTerm(term);
+    return;
+  }
+  assertSafeIri(term);
+}
+
+function assertSafeBlankNode(term: string): void {
+  if (!/^_:[A-Za-z0-9][A-Za-z0-9_-]*$/.test(term)) {
+    throw new Error(`Unsafe blank node label: ${term.slice(0, 80)}`);
+  }
+}
+
 /**
- * Normalise an RDF term to the N-Triples lexical form the rest of the
- * codebase passes around (`<iri>`, `"literal"`, `_:bnode`). The triple
- * store adapters (`OxigraphStore`, `SparqlHttpStore`) emit IRI bindings
- * as BARE strings (e.g. `https://example.org/foo`), while literal
- * bindings come back already quoted. Before the IRI-seal revert, every
- * object that round-tripped through `decryptLiteral` was implicitly
- * normalised because the seal-payload embedded `I|<iri>` and decrypt
- * stripped the tag — IRIs always came out wrapped. With IRI objects now
- * stored in plaintext, `getPrivateTriples` needs to apply this
- * normalisation explicitly so its `Quad.object` contract stays stable
- * for consumers like `publisher/src/access-handler.ts` that interpolate
- * the value verbatim into an N-Quads string.
+ * Normalise an RDF term to the N-Triples lexical form the rest of the codebase
+ * passes around (`<iri>`, `"literal"`, `_:bnode`). The triple store adapters
+ * emit IRI bindings as bare strings, while literal and blank-node bindings
+ * already come back in their expected lexical forms.
  */
 function normaliseTermToNTriples(term: string): string {
   if (!term) return term;

--- a/packages/storage/test/private-store-extra.test.ts
+++ b/packages/storage/test/private-store-extra.test.ts
@@ -4,9 +4,9 @@
  *
  * Findings covered (see .test-audit/
  *
- *   ST-2  PROD-BUG — PrivateContentStore is documented as encrypted private
- *          storage but src/private-store.ts only remaps the graph URI. The
- *          literal value lands on disk in plaintext.
+ *   ST-2  PrivateContentStore stores accepted private RDF as plaintext terms
+ *          in the _private graph. Peer messages are encrypted before they
+ *          reach this store; local triple-store rows stay queryable.
  *
  *   ST-3  Named-graph isolation using REAL V10 URIs
  *          (contextGraphSharedMemoryUri / contextGraphVerifiedMemoryUri /
@@ -41,16 +41,9 @@ const CONTEXT_GRAPH = 'agent-registry';
 const ROOT = 'did:dkg:agent:QmSecretHolder';
 
 // =======================================================================
-// ST-2 — "encrypted private storage" is a lie.
+// ST-2 — Private graph RDF terms are plaintext and queryable.
 // =======================================================================
-describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
-  // PROD-BUG: PrivateContentStore does NOT encrypt. src/private-store.ts
-  // only remaps the quad's graph URI to the <cg>/_private named graph.
-  // The literal object is persisted verbatim by Oxigraph. Any operator
-  // with read access to the on-disk N-Quads file or the SPARQL endpoint
-  // can recover the plaintext. README claims otherwise — see
-  // . Leaving this test RED is the evidence.
-
+describe('PrivateContentStore — plaintext private RDF terms [ST-2]', () => {
   const SECRET = 'SECRET_PLAINTEXT_AAAA';
   let tempDir: string;
 
@@ -58,7 +51,7 @@ describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'dkg-private-store-'));
   });
 
-  it('on-disk N-Quads dump must not contain the plaintext literal', async () => {
+  it('on-disk N-Quads dump contains the plaintext literal, not a local encryption envelope', async () => {
     const persistPath = join(tempDir, 'store.nq');
     const store = new OxigraphStore(persistPath);
     const gm = new ContextGraphManager(store);
@@ -77,19 +70,14 @@ describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
 
     const onDisk = readFileSync(persistPath, 'utf-8');
     try {
-      expect(onDisk).not.toContain(SECRET);
+      expect(onDisk).toContain(SECRET);
+      expect(onDisk).not.toContain('enc:gcm:v1');
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
 
-  it('a second, unrelated SPARQL client must NOT see the plaintext literal', async () => {
-    // FIXED (ST-2): PrivateContentStore now seals the literal `object`
-    // with AES-256-GCM before handing the quad to the TripleStore. A
-    // raw SPARQL caller (no PrivateContentStore decrypt) sees only the
-    // `enc:gcm:v1:<base64>` envelope. PrivateContentStore.getPrivateTriples
-    // reverses the seal and returns the original literal — exercised
-    // by the "round-trip" assertion below.
+  it('a second raw SPARQL client sees the same plaintext RDF term', async () => {
     const store = new OxigraphStore();
     const gm = new ContextGraphManager(store);
     const ps = new PrivateContentStore(store, gm);
@@ -105,20 +93,15 @@ describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
     expect(raw.type).toBe('bindings');
     if (raw.type !== 'bindings') return;
     const rawObjects = raw.bindings.map((b) => b['o']);
-    // Raw SPARQL view: only the AES-GCM envelope is observable.
-    expect(rawObjects.join(' ')).not.toContain(SECRET);
-    expect(rawObjects.some((o) => o.startsWith('"enc:gcm:v1:'))).toBe(true);
+    expect(rawObjects).toContain(`"${SECRET}"`);
+    expect(rawObjects.some((o) => o.startsWith('"enc:gcm:v1:'))).toBe(false);
 
-    // Authorised path round-trips: getPrivateTriples decrypts.
-    const decrypted = await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT);
-    expect(decrypted.map((q) => q.object)).toContain(`"${SECRET}"`);
+    const roundTripped = await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT);
+    expect(roundTripped.map((q) => q.object)).toContain(`"${SECRET}"`);
   });
 
-  // Random IV is
-  // required, but
-  // the write path MUST stay idempotent on plaintext identity — otherwise
-  // every replay / retry of the same private KA stacks another
-  // ciphertext row and `getPrivateTriples` starts returning duplicates.
+  // The write path MUST stay idempotent on RDF term identity. Every replay /
+  // retry of the same private KA should keep one row per distinct quad.
   it('storePrivateTriples is idempotent on plaintext (no dup rows on replay)', async () => {
     const store = new OxigraphStore();
     const gm = new ContextGraphManager(store);
@@ -139,7 +122,7 @@ describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
     );
     expect(raw.type).toBe('bindings');
     if (raw.type !== 'bindings') return;
-    // Exactly two ciphertext rows survive, one per distinct (s,p,plaintext).
+    // Exactly two rows survive, one per distinct (s,p,o).
     expect(raw.bindings.length).toBe(2);
 
     const roundTripped = (await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT))
@@ -152,15 +135,9 @@ describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
   });
 
   it('concurrent storePrivateTriples for the same (s,p,o) cannot bypass dedup (read-then-insert race)', async () => {
-    // Pre-fix: `storePrivateTriples` snapshotted existing plaintext keys
-    // BEFORE inserting, with no mutual exclusion. Two concurrent writers
-    // for the same (s,p,o) plaintext would both observe an empty key
-    // set, then each insert their own random-IV ciphertext — and the
-    // store kept both because the underlying triple store dedups by
-    // byte-identical terms only. Post-fix: the per-graph mutex makes
-    // the read-and-insert pair atomic so only the FIRST writer's
-    // ciphertext lands; the SECOND sees the freshly inserted key and
-    // skips.
+    // The per-graph mutex makes the read-and-insert pair atomic so only
+    // the first writer inserts; later writers see the freshly inserted key
+    // and skip.
     const store = new OxigraphStore();
     const gm = new ContextGraphManager(store);
     const ps = new PrivateContentStore(store, gm);
@@ -187,9 +164,9 @@ describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
     if (raw.type !== 'bindings') return;
     expect(raw.bindings.length).toBe(1);
 
-    const decrypted = await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT);
-    expect(decrypted.length).toBe(1);
-    expect(decrypted[0].object).toBe(`"${SECRET}"`);
+    const roundTripped = await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT);
+    expect(roundTripped.length).toBe(1);
+    expect(roundTripped[0].object).toBe(`"${SECRET}"`);
   });
 
   // — private-store.ts:553). Pre-fix
@@ -216,7 +193,7 @@ describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
       ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, quads),
     ).resolves.not.toThrow();
 
-    // The two private rows actually landed (encrypted at rest).
+    // The two private rows actually landed.
     const privateGraph = contextGraphPrivateUri(CONTEXT_GRAPH);
     const raw = await store.query(
       `SELECT ?s ?p ?o WHERE { GRAPH <${privateGraph}> { ?s ?p ?o } }`,
@@ -852,5 +829,18 @@ describe('PrivateContentStore — SPARQL injection defence [ST-7]', () => {
         { subject: 'urn:safe:s', predicate: 'http://ex.org/p', object: '"v"', graph: '' },
       ]),
     ).rejects.toThrow(/Unsafe or empty IRI/);
+  });
+
+  it('storePrivateTriples rejects unsafe object RDF terms before adapter insertion', async () => {
+    await expect(
+      ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [
+        {
+          subject: ROOT,
+          predicate: 'http://ex.org/p',
+          object: '"x" <urn:graph> . <urn:evil> <http://ex.org/p> "y"',
+          graph: '',
+        },
+      ]),
+    ).rejects.toThrow(/Unsafe RDF term|Unsafe or empty IRI/);
   });
 });


### PR DESCRIPTION
## Summary
- remove local `PrivateContentStore` encryption/decryption and write accepted private RDF terms to `_private` as plaintext
- keep peer-message encryption surfaces out of scope and document the triple-store boundary in ADR 0004 / architecture notes
- update #633 regression coverage to assert literals, typed literals, IRIs, and blank nodes remain queryable without `enc:gcm:v1` envelopes

## Verification
- `pnpm --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-publisher --filter @origintrail-official/dkg run build`
- `pnpm --dir packages/cli exec vitest run test/repro-issue-633.test.ts`
- `pnpm --dir packages/storage exec vitest run test/private-store-extra.test.ts`
- `pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/async-lift-subtraction.test.ts` (run outside sandbox so Hardhat can bind localhost)
- Fresh 2-node DevNet EPCIS repro from PR #644 comment: 7 fixture captures returned plaintext query bodies, raw node1 `_private` graph had 98 private lines and 0 `enc:gcm:v1` rows

Fixes #633