### PR TITLE
refactor(evm-module): apply CEI mint-last ordering on every ERC-721 mint path

### DIFF
--- a/packages/evm-module/contracts/DKGPublishingConvictionNFT.sol
+++ b/packages/evm-module/contracts/DKGPublishingConvictionNFT.sol
@@ -184,34 +184,45 @@ contract DKGPublishingConvictionNFT is INamed, IVersioned, HubDependent, IInitia
      * @notice Mint a new conviction-account NFT to the caller and
      *         transfer `committedTRAC` into the V10 vault.
      *
-     * @dev    Order of operations (mirrors the legacy v2.x semantics):
+     * @dev    CEI ordering with `_mint` last:
      *           1. Allocate `accountId` from the wrapper's mint counter.
-     *           2. Mint the ERC-721 to `msg.sender` (publisher).
-     *           3. Forward to `PublishingConviction.createAccount` which
+     *           2. Forward to `PublishingConviction.createAccount` which
      *              persists the `Account` record on PCS and emits
-     *              `AccountCreated`.
-     *           4. Pull TRAC from publisher to the V10 vault. The
+     *              `AccountCreated`. Logic-side parameter validation
+     *              runs here, BEFORE any funds move.
+     *           3. Pull TRAC from publisher to the V10 vault. The
      *              wrapper holds NO TRAC — this is a direct
      *              `transferFrom(publisher, ConvictionStakingStorage,
      *              committedTRAC)`.
+     *           4. `_mint(msg.sender, accountId)` LAST. The wrapper
+     *              never observes a half-built (NFT-without-Account
+     *              -or-funding) state.
      *
-     *         The TRAC pull is intentionally LAST so a logic-side
-     *         revert (e.g. parameter validation) does not move funds.
-     *         A failed `transferFrom` reverts the whole tx — atomic,
-     *         the NFT is never minted without TRAC backing it.
+     *         `_mint` (not `_safeMint`) is intentional: contract
+     *         publishers without `IERC721Receiver` (DAO treasuries,
+     *         relayer/factory wrappers, etc.) are part of the
+     *         supported caller set.
+     *
+     *         The forward-before-pull order means a logic-side revert
+     *         does not move funds. The whole tx reverts atomically on
+     *         any failure path — the NFT is never minted without TRAC
+     *         backing it and a recorded `Account` row.
      */
     function createAccount(uint96 committedTRAC) external returns (uint256 accountId) {
         if (committedTRAC == 0) revert InvalidAmount();
 
         accountId = _nextAccountId++;
 
-        _mint(msg.sender, accountId);
-
         _publishingConviction().createAccount(msg.sender, accountId, committedTRAC);
 
+        // Direct publisher -> CSS vault transfer. Contract never holds TRAC.
+        // The TRAC sits in escrow against this account's billing windows and
+        // is accounted to the staker pool lazily via active/passive sinks.
         if (!tokenContract.transferFrom(msg.sender, stakingStorageAddress, committedTRAC)) {
             revert TokenTransferFailed();
         }
+
+        _mint(msg.sender, accountId);
     }
 
     /**

--- a/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
+++ b/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
@@ -374,8 +374,13 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
         _convictionMultiplier(lockTier);
 
         tokenId = ++nextTokenId;
-        _mint(msg.sender, tokenId);
+        // CEI ordering: settle CSS state and pull TRAC FIRST, then `_mint`
+        // last so the wrapper never observes a half-built (NFT-without-
+        // position) state. `_mint` (not `_safeMint`) is intentional:
+        // contract callers without `IERC721Receiver` are part of the
+        // supported caller set (multisigs, treasuries, AA wallets, etc.).
         stakingV10.stake(msg.sender, tokenId, identityId, amount, lockTier);
+        _mint(msg.sender, tokenId);
 
         emit PositionCreated(msg.sender, tokenId, identityId, amount, lockTier);
     }
@@ -393,14 +398,21 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
     ///      here (and the CSS-level `PositionReplaced` with the full reward
     ///      stat continuity).
     ///
-    ///      Mint-before-forward ordering: we mint `newTokenId` BEFORE the
-    ///      StakingV10 call so that CSS's `createNewPositionFromExisting`
-    ///      can assert the new slot is empty (`positions[newTokenId].identityId == 0`)
-    ///      — there's no NFT collision because the ERC-721 tokenId space
-    ///      and the CSS position space are the same namespace.
-    ///      Burn-after-forward: we burn `oldTokenId` AFTER CSS has moved
-    ///      the position across, so a mid-call revert leaves BOTH NFT and
-    ///      position state intact at the old tokenId.
+    ///      CEI ordering — state changes first, NFT mint last:
+    ///        1. `stakingV10.relock` — drives CSS's `createNewPositionFromExisting`
+    ///           which itself asserts the new slot is empty
+    ///           (`positions[newTokenId].identityId == 0`). That assertion is
+    ///           a CSS-state check, not an NFT-existence check, so the new
+    ///           NFT does NOT need to exist yet.
+    ///        2. `_burn(oldTokenId)` — removes the old NFT after CSS has
+    ///           moved the position. A mid-call revert leaves BOTH NFT and
+    ///           position state intact at the old tokenId.
+    ///        3. `_mint(msg.sender, newTokenId)` — last, so the wrapper
+    ///           never observes a half-built burn-mint state. `_mint`
+    ///           (not `_safeMint`) is intentional: contract callers
+    ///           without `IERC721Receiver` are part of the supported
+    ///           caller set, including any contract holding an existing
+    ///           position from a prior `_mint`-era relock.
     function relock(uint256 oldTokenId, uint40 newLockTier) external returns (uint256 newTokenId) {
         if (ownerOf(oldTokenId) != msg.sender) revert NotPositionOwner();
         // Fail-fast on unregistered tiers (e.g. 2, 4, 7). Tier 0 is valid:
@@ -412,9 +424,9 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
         _convictionMultiplier(newLockTier);
 
         newTokenId = ++nextTokenId;
-        _mint(msg.sender, newTokenId);
         stakingV10.relock(msg.sender, oldTokenId, newTokenId, newLockTier);
         _burn(oldTokenId);
+        _mint(msg.sender, newTokenId);
 
         emit PositionRelocked(oldTokenId, newTokenId, newLockTier);
     }
@@ -513,8 +525,9 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
         _convictionMultiplier(lockTier);
 
         tokenId = ++nextTokenId;
-        _mint(msg.sender, tokenId);
+        // CEI ordering: settle CSS state first; mint after.
         stakingV10.selfConvertToNFT(msg.sender, tokenId, identityId, lockTier);
+        _mint(msg.sender, tokenId);
 
         emit ConvertedFromV8(msg.sender, tokenId, identityId, lockTier, false);
     }
@@ -579,8 +592,16 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
     ) internal returns (uint256 tokenId) {
         _convictionMultiplier(lockTier);
         tokenId = ++nextTokenId;
-        _mint(delegator, tokenId);
+        // CEI ordering: settle CSS state first; mint to `delegator` after.
+        // `_mint` (not `_safeMint`) so the rescue still completes even
+        // when a V8 contract delegator does not implement
+        // `IERC721Receiver`. The alternative — a `_safeMint` revert —
+        // would leave that delegator's TRAC stuck in V8 with no
+        // automated migration path, which is worse than landing the
+        // V10 NFT at the same contract address that already held the
+        // V8 delegation.
         stakingV10.adminConvertToNFT(delegator, tokenId, identityId, lockTier);
+        _mint(delegator, tokenId);
         emit ConvertedFromV8(delegator, tokenId, identityId, lockTier, true);
     }
 

--- a/packages/evm-module/contracts/storage/ContextGraphStorage.sol
+++ b/packages/evm-module/contracts/storage/ContextGraphStorage.sol
@@ -229,8 +229,13 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
 
         contextGraphId = ++_contextGraphCounter;
 
-        _mint(owner_, contextGraphId);
-
+        // CEI ordering: populate ALL CG state below first; `_mint` happens
+        // last so the wrapper never observes a half-built (NFT-without-
+        // metadata-or-participants) state. `_mint` (not `_safeMint`) is
+        // intentional: `owner_` is forwarded from `ContextGraphs.create
+        // ContextGraph` as the upstream `msg.sender`, and contract owners
+        // without `IERC721Receiver` (DAO timelocks, custom multisigs,
+        // factory wrappers) are part of the supported caller set.
         KnowledgeAssetsLib.ContextGraph storage cg = _contextGraphs[contextGraphId];
         cg.metadataBatchId = metadataBatchId;
         cg.active = true;
@@ -261,6 +266,8 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
         if (nameHash != bytes32(0)) {
             _contextGraphNameHash[contextGraphId] = nameHash;
         }
+
+        _mint(owner_, contextGraphId);
 
         emit ContextGraphCreated(
             contextGraphId,


### PR DESCRIPTION
## Summary

Supersedes #663. Reorders every ERC-721 mint site so `_mint` is the **last** state-changing call in the function. Pure ordering change — no `_safeMint`, no public-selector change, no event change, no public-API break.

Sites reordered (every ERC-721 mint in the live contract surface):

| File | Function |
| --- | --- |
| `DKGStakingConvictionNFT.sol` | `createConviction` |
| `DKGStakingConvictionNFT.sol` | `relock` |
| `DKGStakingConvictionNFT.sol` | `selfMigrateV8` |
| `DKGStakingConvictionNFT.sol` | `_adminMigrateV8Single` |
| `DKGPublishingConvictionNFT.sol` | `createAccount` |
| `storage/ContextGraphStorage.sol` | `createContextGraph` |

## Why CEI mint-last

- The wrapper never observes a half-built (NFT-without-position / NFT-without-`Account` / NFT-without-CG) state during execution. Any future external interaction added after the mint sees a fully-consistent post-state by construction.
- `relock` additionally moves `_burn(oldTokenId)` to before the new `_mint(newTokenId)`, so the burn-mint pair is atomic and a mid-call revert leaves BOTH the NFT and the CSS position intact at the old tokenId.

## Why NOT \`_safeMint\` (deliberate non-fix of Aderyn L-17)

Aderyn L-17 flags these six sites and recommends `_safeMint` to prevent NFTs from being silently locked when the recipient is a contract that does not implement `IERC721Receiver`. Adopting `_safeMint` would, however, break a real and intended caller set:

- Older Gnosis Safe variants (`< 1.3.0`, or `>= 1.3.0` deployed without the default fallback handler).
- Custom DAO timelocks / non-Safe multisigs without an ERC721-receiver mixin.
- Factory / strategy / yield-wrapper contracts that self-stake / self-publish / self-create-CGs.

#663 ([review thread](https://github.com/OriginTrail/dkg/pull/663#pullrequestreview-)) flagged this as a 🔴 public-API break across `DKGStakingConvictionNFT.*`, `DKGPublishingConvictionNFT.createAccount`, and `ContextGraphStorage.createContextGraph`. Recipients in every site are caller-controlled (`msg.sender` on five sites; admin-supplied V8 delegator on `_adminMigrateV8Single`), so the "silent lock" risk L-17 warns about is a callsite concern that callers manage themselves.

Each site has an inline NatSpec comment explaining why `_safeMint` is rejected. Aderyn L-17 will continue to flag these six sites as informational findings; the static-analysis CI lane is `continue-on-error: true` and explicitly informational (lane name: "Tornado: static analysis (informational)"), so CI stays green.

## NatSpec changes

The \`relock\` doc comment is rewritten to:
- spell out the new burn-before-mint order, and
- correct a stale claim that the old `_mint(newTokenId)` had to precede the `StakingV10.relock` forward. CSS's `createNewPositionFromExisting` asserts `positions[newTokenId].identityId == 0`, which is a CSS-state check, not an NFT-existence check — the new NFT does not need to exist yet, so the forward runs first.

## Test plan

- [x] `hardhat compile` — clean.
- [x] All 278 unit tests across `DKGStakingConvictionNFT`, `DKGPublishingConvictionNFT*`, `ContextGraphStorage`, `ContextGraphs` pass. No tests required updates — every test mints to an EOA, and the reordering is invisible to EOA callers.
- [ ] CI (compile, full unit/integration suite, Slither, Aderyn, solhint).

## Out of scope (intentional)

- ERC-1155 `_mint` in `tokens/ERC1155Delta.sol`, `storage/KnowledgeCollectionStorage.sol`, ERC-20 `_mint` in `Token.sol` — different standards, different safe-receive semantics.
- `archive/KnowledgeAssetsStorage.sol` — archived V9 surface, excluded from the static-analysis filter.

## Notes for reviewer

The diff is intentionally minimal — only the order of three or four lines per site changes, plus updated NatSpec on `relock` / `createAccount`. The protocol's external surface (function signatures, events, error selectors) is unchanged.

Made with Cursor


Made with [Cursor](https://cursor.com)