### PR TITLE
chore(release): v10.0.0-rc.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the DKG V9 node are documented here. The format is based 
 
 ## [Unreleased]
 
+## [10.0.0-rc.11] - 2026-05-26
+
 ### Added — Node release visible on the libp2p wire
 
 - **`DKGNodeConfig.nodeVersion` → libp2p `nodeInfo.userAgent`** (`packages/core/src/types.ts`, `packages/core/src/node.ts`, `packages/agent/src/dkg-agent-types.ts`, `packages/agent/src/dkg-agent.ts`, `packages/cli/src/daemon/lifecycle.ts`, `packages/agent/test/dkg-agent-diagnostics.test.ts`): the daemon now sets `nodeInfo.userAgent` at `createLibp2p()` time to `dkg/<semver>` (read from the running CLI's `package.json`). libp2p's identify protocol ships that string in its `agentVersion` PB field, and every remote peer stores it under `Peer.metadata.AgentVersion`. Closes the version-on-the-wire gap that surfaced during the v10.0.0-rc.10 rollout: before this change `/api/peer-info` could tell operators *which* protocols a peer spoke but not *which DKG release* they were running, leaving "did the network pick up the upgrade?" answerable only by SSHing into each Core node. `getPeerDiagnostics()` now surfaces the decoded string as `peerStore.nodeVersion` (kept distinct from libp2p's `AgentVersion` wire name because in the DKG context "agent" already means `DKGAgent`). Pre-rc.11 peers fall through to libp2p's `js-libp2p/<version>` default — itself a useful "peer hasn't adopted the version-advertisement convention yet" signal. `peerStore.protocolVersion` (libp2p's `ProtocolVersion`, default `ipfs/0.1.0`) is exposed alongside under its libp2p name since it's truly libp2p's protocol version, unrelated to DKG. Lets a single Core node answer "what's every peer's DKG version?" by iterating `/api/agents` → `/api/peer-info?peerId=…` and reading `peerStore.nodeVersion`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "description": "ElizaOS plugin adapter \u2014 turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "description": "Hermes Agent adapter \u2014 connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "description": "DKG V9 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bump root + 17 workspace packages from `10.0.0-rc.10` to `10.0.0-rc.11`, and promote the CHANGELOG `[Unreleased]` block to the dated `[10.0.0-rc.11] - 2026-05-26` section.

Merge me, then tag `v10.0.0-rc.11` on the resulting merge commit:

```sh
git fetch ghorigin main
git checkout main
git pull --ff-only ghorigin main
git tag -s v10.0.0-rc.11 -m "DKG v10.0.0 rc.11"
git push ghorigin v10.0.0-rc.11
```

`release.yml` will fire on the tag push and produce the GitHub Release (binaries + SBOM + attestations). npm publish will be done manually this round (npm-publish environment not configured) — see [RELEASE_PROCESS.md §5](./RELEASE_PROCESS.md) and the agent-supplied manual-publish steps in the parent chat.

## Release contents

All 14 outstanding `branarakic` rc.11 PRs landed on `main` via the integration branch in #680. Highlights:

**Core-stability hardening** (rc.10 deadlock workstream): #655 hard shutdown timeout, #669 AbortSignal plumbing, #670 filter-error silencer, #664 supervisor liveness probe, #668 AutoNAT boot probe, #661 core relay prereq check, #662 relay metrics in /api/status, #666 `dkg migrate-to-npm`, #657 + #659 (auto-update controls).

**ERC-721 mint ordering**: #681 CEI mint-last at every mint site (superseded #663's `_safeMint` proposal, which was rejected as a public-API break for older Gnosis Safes / DAO timelocks / strategy wrappers; #681 keeps `_mint`, reorders so `_mint` is last state-changing call, `relock` moves `_burn` before `_mint`).

**Async-promote queue stack**: #660 + #665 + #667 (worker-readiness gate, worker supervisor, e2e tests).

**Honest ACK + tentative-VM cleanup**: #671 (delete self-signed ACK fallback, delete tentative-VM concept) + #672 (typed errors, LU-6 runbook, provenance telemetry).

**Test infra**: #673 (rc.11 test infrastructure fixes).

## Verification (run on integration branch before this bump)

- `pnpm install --frozen-lockfile` + `pnpm check:npm-metadata` clean
- `pnpm -r build` clean
- `pnpm --filter @origintrail-official/dkg test:unit` — **403/403 PASS**
- `pnpm --filter @origintrail-official/dkg-chain test:unit` — **59/59 PASS**
- EVM contract tests (`DKGStakingConvictionNFT`, `DKGPublishingConvictionNFT*`, `ContextGraphStorage`, `ContextGraphs`) — **278/278 PASS**
- `devnet-test-rc11-promote-crash-recovery.sh` — GREEN
- `devnet-test-rc11-shutdown-mid-publish.sh` — GREEN (549ms shutdown, 0 `[shutdown-timeout]` lines)
- `devnet-test-rfc38-all.sh` — 10/11 PASS (1 fail = pre-existing documented LU-6 cores-only gap, not a regression)
- `devnet-test.sh` — 343/347 PASS (4 fails tracked in #676 as stale test expectations against #671's seal contract + V10 auto-registration; daemon is correct, tests need refresh in rc.12)

## Test plan after merge

- [ ] Tag `v10.0.0-rc.11` lands on the merge commit
- [ ] `release.yml` GitHub Release publishes with the 3 MarkItDown binaries + SBOM + attestations
- [ ] Manual `npm publish` posts all 15 publishable packages at `10.0.0-rc.11` with the `latest` + `rc` dist-tags
- [ ] `npm view @origintrail-official/dkg version` returns `10.0.0-rc.11`
- [ ] One canary node `dkg update 10.0.0-rc.11 --allow-prerelease` succeeds and runs healthy for 30 min

Made with [Cursor](https://cursor.com)