### PR TITLE
feat: add multi-rpc failover

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -688,6 +688,7 @@ export interface DKGAgentConfig {
    */
   chainConfig?: {
     rpcUrl: string;
+    rpcUrls?: string[];
     hubAddress: string;
     adminPrivateKey?: string;
     operationalKeys: string[];

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -990,6 +990,7 @@ export class DKGAgent {
     } else if (config.chainConfig && opKeys?.length) {
       const evmConfigBase = {
         rpcUrl: config.chainConfig.rpcUrl,
+        rpcUrls: config.chainConfig.rpcUrls,
         privateKey: opKeys[0],
         additionalKeys: opKeys.slice(1),
         hubAddress: config.chainConfig.hubAddress,

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -179,6 +179,14 @@ function isRetryableRpcError(err: unknown): boolean {
     .test(msg);
 }
 
+function assertSuccessfulReceipt(receipt: ethers.TransactionReceipt, label: string): void {
+  if (receipt.status !== 0) return;
+  const err = new Error(`${label} tx ${receipt.hash} was mined but reverted (status=0)`);
+  (err as any).code = 'CALL_EXCEPTION';
+  (err as any).receipt = receipt;
+  throw err;
+}
+
 function isKnownTransactionError(err: unknown): boolean {
   const msg = errorMessage(err).toLowerCase();
   return msg.includes('already known')
@@ -688,7 +696,10 @@ export class EVMChainAdapter implements ChainAdapter {
     while (Date.now() < deadline) {
       try {
         const receipt = await this.getTransactionReceiptWithFailover(txHash);
-        if (receipt) return receipt;
+        if (receipt) {
+          assertSuccessfulReceipt(receipt, label);
+          return receipt;
+        }
       } catch (err) {
         if (!isRetryableRpcError(err)) throw err;
         lastError = err;

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -157,6 +157,7 @@ function isRetryableRpcError(err: unknown): boolean {
   const msg = errorMessage(err).toLowerCase();
 
   if (code === 'CALL_EXCEPTION' || code === 'INSUFFICIENT_FUNDS' || code === 'NONCE_EXPIRED'
+    || code === 'RPC_RECEIPT_LOOKUP_FAILED'
     || code === 'REPLACEMENT_UNDERPRICED' || code === 'TRANSACTION_REPLACED'
     || code === 'ACTION_REJECTED' || code === 'INVALID_ARGUMENT' || code === 'UNPREDICTABLE_GAS_LIMIT') {
     return false;
@@ -188,13 +189,16 @@ function assertSuccessfulReceipt(receipt: ethers.TransactionReceipt, label: stri
 }
 
 function isKnownTransactionError(err: unknown): boolean {
+  const code = errorCode(err);
   const msg = errorMessage(err).toLowerCase();
-  return msg.includes('already known')
+  return code === 'NONCE_EXPIRED'
+    || msg.includes('already known')
     || msg.includes('known transaction')
     || msg.includes('already imported')
     || msg.includes('transaction already in mempool')
     || msg.includes('already exists')
     || msg.includes('already have transaction')
+    || msg.includes('nonce too low')
     || msg.includes('duplicate transaction');
 }
 
@@ -574,16 +578,20 @@ export class EVMChainAdapter implements ChainAdapter {
       // EXCEPT the filter-spam class.
       console.error(`[chain] provider error (${providerContext}): ${formatProviderError(err)}`);
     };
-    try {
-      void Promise.resolve(this.primaryProvider.on('error', providerErrorHandler)).catch((err: unknown) => {
+    for (let i = 0; i < this.providers.length; i += 1) {
+      const provider = this.providers[i];
+      const listenerContext = `${providerContext}; rpc #${i + 1}`;
+      try {
+        void Promise.resolve(provider.on('error', providerErrorHandler)).catch((err: unknown) => {
+          console.error(
+            `[chain] provider error listener registration failed (${listenerContext}): ${formatProviderError(err)}`,
+          );
+        });
+      } catch (err) {
         console.error(
-          `[chain] provider error listener registration failed (${providerContext}): ${formatProviderError(err)}`,
+          `[chain] provider error listener registration failed (${listenerContext}): ${formatProviderError(err)}`,
         );
-      });
-    } catch (err) {
-      console.error(
-        `[chain] provider error listener registration failed (${providerContext}): ${formatProviderError(err)}`,
-      );
+      }
     }
     this.signer = new Wallet(config.privateKey, this.provider);
     this.signerPool = [this.signer];
@@ -667,6 +675,7 @@ export class EVMChainAdapter implements ChainAdapter {
 
   private async getTransactionReceiptWithFailover(txHash: string): Promise<ethers.TransactionReceipt | null> {
     let lastRetryable: unknown;
+    let sawNonErrorResponse = false;
     for (let i = 0; i < this.providers.length; i += 1) {
       const provider = this.providers[i];
       try {
@@ -675,14 +684,20 @@ export class EVMChainAdapter implements ChainAdapter {
           RPC_RECEIPT_ATTEMPT_TIMEOUT_MS,
           `receipt lookup via RPC #${i + 1}`,
         );
+        sawNonErrorResponse = true;
         if (receipt) return receipt;
       } catch (err) {
         if (!isRetryableRpcError(err)) throw err;
         lastRetryable = err;
       }
     }
-    if (lastRetryable && this.providers.length === 1) {
-      throw lastRetryable;
+    if (lastRetryable && !sawNonErrorResponse) {
+      const err = new Error(
+        `Receipt lookup for tx ${txHash} failed on all configured RPC endpoints: ${errorMessage(lastRetryable)}`,
+        { cause: lastRetryable },
+      );
+      (err as any).code = 'RPC_RECEIPT_LOOKUP_FAILED';
+      throw err;
     }
     return null;
   }
@@ -3005,7 +3020,11 @@ export class EVMChainAdapter implements ChainAdapter {
     return this.provider.getBlockNumber();
   }
 
-  getProvider(): JsonRpcProvider | FallbackProvider {
+  getProvider(): JsonRpcProvider {
+    return this.primaryProvider;
+  }
+
+  getReadProvider(): JsonRpcProvider | FallbackProvider {
     return this.provider;
   }
 

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -1,4 +1,4 @@
-import { ethers, JsonRpcProvider, Wallet, Contract, Interface } from 'ethers';
+import { ethers, JsonRpcProvider, FallbackProvider, Wallet, Contract, Interface } from 'ethers';
 import {
   createFilterErrorSilencer,
   formatProviderError,
@@ -81,6 +81,11 @@ const DURATION_PROBE_TIMEOUT_MS = 2000;
  * Codex round 8 on PR #369.
  */
 const MAX_PROBE_AGE_MS = 30_000;
+const RPC_READ_STALL_TIMEOUT_MS = 4_000;
+const RPC_BROADCAST_ATTEMPT_TIMEOUT_MS = 10_000;
+const RPC_RECEIPT_ATTEMPT_TIMEOUT_MS = 5_000;
+const RPC_RECEIPT_POLL_INTERVAL_MS = 2_000;
+const RPC_RECEIPT_TIMEOUT_MS = 180_000;
 
 /**
  * Substrings we treat as "the Hub no longer recognises this contract
@@ -94,6 +99,96 @@ const HUB_STALE_ERROR_MARKERS = [
   'Only Contracts in Hub',
   'UnauthorizedAccess(Only Contracts in Hub)',
 ];
+
+export function resolveRpcUrls(rpcUrl: string, rpcUrls?: string[]): string[] {
+  const out: string[] = [];
+  for (const candidate of [rpcUrl, ...(rpcUrls ?? [])]) {
+    const trimmed = typeof candidate === 'string' ? candidate.trim() : '';
+    if (!trimmed || out.includes(trimmed)) continue;
+    out.push(trimmed);
+  }
+  if (out.length === 0) {
+    throw new Error('EVMChainAdapter requires at least one RPC URL');
+  }
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const err = new Error(`${label} timed out after ${ms}ms`);
+      (err as any).code = 'TIMEOUT';
+      reject(err);
+    }, ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  }) as Promise<T>;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  try { return JSON.stringify(err); } catch { return String(err); }
+}
+
+function errorCode(err: unknown): string {
+  return String((err as any)?.code ?? (err as any)?.error?.code ?? '').toUpperCase();
+}
+
+function errorStatus(err: unknown): number | undefined {
+  const raw =
+    (err as any)?.status ??
+    (err as any)?.statusCode ??
+    (err as any)?.response?.status ??
+    (err as any)?.error?.status ??
+    (err as any)?.error?.statusCode;
+  return typeof raw === 'number' ? raw : undefined;
+}
+
+function isRetryableRpcError(err: unknown): boolean {
+  if (err instanceof Error) enrichEvmError(err);
+  const code = errorCode(err);
+  const status = errorStatus(err);
+  const msg = errorMessage(err).toLowerCase();
+
+  if (code === 'CALL_EXCEPTION' || code === 'INSUFFICIENT_FUNDS' || code === 'NONCE_EXPIRED'
+    || code === 'REPLACEMENT_UNDERPRICED' || code === 'TRANSACTION_REPLACED'
+    || code === 'ACTION_REJECTED' || code === 'INVALID_ARGUMENT' || code === 'UNPREDICTABLE_GAS_LIMIT') {
+    return false;
+  }
+  if (msg.includes('execution reverted') || msg.includes('call exception')
+    || msg.includes('insufficient funds') || msg.includes('invalid argument')
+    || msg.includes('nonce too low') || msg.includes('replacement transaction underpriced')
+    || msg.includes('intrinsic gas too low') || msg.includes('exceeds block gas limit')) {
+    return false;
+  }
+
+  if (status === 429 || (typeof status === 'number' && status >= 500)) return true;
+  if (code === 'TIMEOUT' || code === 'TIMEOUT_ERROR' || code === 'SERVER_ERROR'
+    || code === 'NETWORK_ERROR' || code === 'ECONNRESET' || code === 'ECONNREFUSED'
+    || code === 'ETIMEDOUT' || code === 'ENOTFOUND' || code === 'EAI_AGAIN'
+    || code === 'UNKNOWN_ERROR' || code === 'BAD_DATA') {
+    return true;
+  }
+  return /timeout|timed out|network|socket|reset|econnreset|econnrefused|etimedout|enotfound|eai_again|rate limit|too many requests|429|503|502|500|gateway|temporarily unavailable|fetch failed|connection/i
+    .test(msg);
+}
+
+function isKnownTransactionError(err: unknown): boolean {
+  const msg = errorMessage(err).toLowerCase();
+  return msg.includes('already known')
+    || msg.includes('known transaction')
+    || msg.includes('already imported')
+    || msg.includes('transaction already in mempool')
+    || msg.includes('already exists')
+    || msg.includes('already have transaction')
+    || msg.includes('duplicate transaction');
+}
 
 const require = createRequire(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -213,6 +308,7 @@ export function enrichEvmError(err: unknown): string | null {
 
 interface EVMAdapterBaseConfig {
   rpcUrl: string;
+  rpcUrls?: string[];
   /** Primary operational wallet key (used for identity registration, staking, etc.) */
   privateKey: string;
   /** Additional operational wallet keys for parallel transaction submission. */
@@ -299,7 +395,10 @@ export class EVMChainAdapter implements ChainAdapter {
   readonly chainType = 'evm' as const;
   readonly chainId: string;
 
-  private readonly provider: JsonRpcProvider;
+  private readonly provider: JsonRpcProvider | FallbackProvider;
+  private readonly primaryProvider: JsonRpcProvider;
+  private readonly providers: JsonRpcProvider[];
+  private readonly rpcUrls: string[];
   private readonly filterErrorSilencer: FilterErrorSilencer;
   /** Primary signer — used for identity/profile/staking operations. */
   private readonly signer: Wallet;
@@ -431,7 +530,21 @@ export class EVMChainAdapter implements ChainAdapter {
   }
 
   constructor(config: EVMAdapterConfig) {
-    this.provider = new JsonRpcProvider(config.rpcUrl, undefined, { cacheTimeout: -1 });
+    this.rpcUrls = resolveRpcUrls(config.rpcUrl, config.rpcUrls);
+    this.providers = this.rpcUrls.map((url) => new JsonRpcProvider(url, undefined, { cacheTimeout: -1 }));
+    this.primaryProvider = this.providers[0];
+    this.provider = this.providers.length === 1
+      ? this.primaryProvider
+      : new FallbackProvider(
+        this.providers.map((provider, index) => ({
+          provider,
+          priority: index + 1,
+          stallTimeout: RPC_READ_STALL_TIMEOUT_MS,
+          weight: 1,
+        })),
+        undefined,
+        { quorum: 1 },
+      );
     const providerContext = formatProviderContext(config);
     // PR-8: install the filter-not-found silencer. Without this, RPC
     // nodes that GC filters faster than ethers' polling cadence
@@ -454,7 +567,7 @@ export class EVMChainAdapter implements ChainAdapter {
       console.error(`[chain] provider error (${providerContext}): ${formatProviderError(err)}`);
     };
     try {
-      void Promise.resolve(this.provider.on('error', providerErrorHandler)).catch((err: unknown) => {
+      void Promise.resolve(this.primaryProvider.on('error', providerErrorHandler)).catch((err: unknown) => {
         console.error(
           `[chain] provider error listener registration failed (${providerContext}): ${formatProviderError(err)}`,
         );
@@ -515,6 +628,118 @@ export class EVMChainAdapter implements ChainAdapter {
   private findSignerByAddress(address: string): Wallet | undefined {
     const normalized = ethers.getAddress(address).toLowerCase();
     return this.signerPool.find((signer) => signer.address.toLowerCase() === normalized);
+  }
+
+  private async broadcastSignedTransactionWithFailover(
+    signedTx: string,
+    txHash: string,
+    label: string,
+  ): Promise<void> {
+    let lastRetryable: unknown;
+    for (let i = 0; i < this.providers.length; i += 1) {
+      const provider = this.providers[i];
+      try {
+        await withTimeout(
+          provider.broadcastTransaction(signedTx),
+          RPC_BROADCAST_ATTEMPT_TIMEOUT_MS,
+          `${label} broadcast via RPC #${i + 1}`,
+        );
+        return;
+      } catch (err) {
+        if (isKnownTransactionError(err)) return;
+        if (!isRetryableRpcError(err)) throw err;
+        lastRetryable = err;
+      }
+    }
+    throw new Error(
+      `${label} broadcast failed on all configured RPC endpoints for tx ${txHash}: ${errorMessage(lastRetryable)}`,
+      { cause: lastRetryable },
+    );
+  }
+
+  private async getTransactionReceiptWithFailover(txHash: string): Promise<ethers.TransactionReceipt | null> {
+    let lastRetryable: unknown;
+    for (let i = 0; i < this.providers.length; i += 1) {
+      const provider = this.providers[i];
+      try {
+        const receipt = await withTimeout(
+          provider.getTransactionReceipt(txHash),
+          RPC_RECEIPT_ATTEMPT_TIMEOUT_MS,
+          `receipt lookup via RPC #${i + 1}`,
+        );
+        if (receipt) return receipt;
+      } catch (err) {
+        if (!isRetryableRpcError(err)) throw err;
+        lastRetryable = err;
+      }
+    }
+    if (lastRetryable && this.providers.length === 1) {
+      throw lastRetryable;
+    }
+    return null;
+  }
+
+  private async waitForReceiptWithFailover(
+    txHash: string,
+    label: string,
+  ): Promise<ethers.TransactionReceipt> {
+    const deadline = Date.now() + RPC_RECEIPT_TIMEOUT_MS;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+      try {
+        const receipt = await this.getTransactionReceiptWithFailover(txHash);
+        if (receipt) return receipt;
+      } catch (err) {
+        if (!isRetryableRpcError(err)) throw err;
+        lastError = err;
+      }
+      await sleep(RPC_RECEIPT_POLL_INTERVAL_MS);
+    }
+    throw new Error(
+      `${label} tx ${txHash} was broadcast but no receipt was found within ${RPC_RECEIPT_TIMEOUT_MS}ms` +
+      (lastError ? ` (last RPC error: ${errorMessage(lastError)})` : ''),
+      { cause: lastError },
+    );
+  }
+
+  private async signPopulatedTransaction(
+    signer: Wallet,
+    populated: ethers.TransactionRequest,
+  ): Promise<{ signedTx: string; txHash: string }> {
+    const filled = await signer.populateTransaction(populated);
+    const signedTx = await signer.signTransaction(filled);
+    const txHash = ethers.Transaction.from(signedTx).hash ?? '0x';
+    return { signedTx, txHash };
+  }
+
+  private async sendSignedTransactionAndWait(
+    signedTx: string,
+    txHash: string,
+    label: string,
+  ): Promise<ethers.TransactionReceipt> {
+    await this.broadcastSignedTransactionWithFailover(signedTx, txHash, label);
+    return this.waitForReceiptWithFailover(txHash, label);
+  }
+
+  private async sendPopulatedTransaction(
+    signer: Wallet,
+    populated: ethers.TransactionRequest,
+    label: string,
+  ): Promise<ethers.TransactionReceipt> {
+    const { signedTx, txHash } = await this.signPopulatedTransaction(signer, populated);
+    return this.sendSignedTransactionAndWait(signedTx, txHash, label);
+  }
+
+  private async sendContractTransaction(
+    contract: Contract,
+    method: string,
+    args: readonly unknown[],
+    signer: Wallet,
+    label: string,
+  ): Promise<ethers.TransactionReceipt> {
+    const connected = contract.connect(signer) as any;
+    const populated = await connected[method].populateTransaction(...args);
+    return this.sendPopulatedTransaction(signer, populated, label);
   }
 
   /**
@@ -661,9 +886,13 @@ export class EVMChainAdapter implements ChainAdapter {
       );
     }
 
-    const profile = this.contracts.profile!.connect(this.adminSigner) as Contract;
-    const tx = await profile.addOperationalWallets(identityId, missing);
-    await tx.wait();
+    await this.sendContractTransaction(
+      this.contracts.profile!,
+      'addOperationalWallets',
+      [identityId, missing],
+      this.adminSigner,
+      'addOperationalWallets',
+    );
 
     for (const address of missing) {
       if (await this.hasOperationalPurpose(identityStorage, identityId, address)) {
@@ -697,8 +926,13 @@ export class EVMChainAdapter implements ChainAdapter {
     if (identityId === 0n) {
       throw new Error('setRelayCapable: signer has no on-chain profile (call ensureProfile first).');
     }
-    const tx = await this.contracts.profile.updateRelayCapable(identityId, relayCapable);
-    const receipt = await tx.wait();
+    const receipt = await this.sendContractTransaction(
+      this.contracts.profile,
+      'updateRelayCapable',
+      [identityId, relayCapable],
+      this.signer,
+      'updateRelayCapable',
+    );
     return {
       hash: receipt.hash,
       blockNumber: receipt.blockNumber,
@@ -896,14 +1130,13 @@ export class EVMChainAdapter implements ChainAdapter {
       }
       const nodeId = ethers.hexlify(ethers.randomBytes(32));
 
-      const tx = await this.contracts.profile!.createProfile(
-        this.adminSigner.address,
-        [],
-        nodeName,
-        nodeId,
-        0,
+      const receipt = await this.sendContractTransaction(
+        this.contracts.profile!,
+        'createProfile',
+        [this.adminSigner.address, [], nodeName, nodeId, 0],
+        this.signer,
+        'createProfile',
       );
-      const receipt = await tx.wait();
 
       for (const log of receipt.logs) {
         try {
@@ -947,13 +1180,23 @@ export class EVMChainAdapter implements ChainAdapter {
         if (stakingV10Addr === ethers.ZeroAddress) {
           throw new Error('StakingV10 not registered in Hub — V10 staking unavailable');
         }
-        const approveTx = await this.contracts.token.approve(stakingV10Addr, stakeAmount);
-        await approveTx.wait();
+        await this.sendContractTransaction(
+          this.contracts.token,
+          'approve',
+          [stakingV10Addr, stakeAmount],
+          this.signer,
+          'approve staking TRAC',
+        );
         // Wait an extra block for state propagation on public RPCs
         await new Promise(r => setTimeout(r, 2000));
 
-        const stakeTx = await stakingNFT.createConviction(identityId, stakeAmount, lockTier);
-        await stakeTx.wait();
+        await this.sendContractTransaction(
+          stakingNFT,
+          'createConviction',
+          [identityId, stakeAmount, lockTier],
+          this.signer,
+          'create staking conviction',
+        );
       } catch (err) {
         console.warn(
           `[ensureProfile] V10 staking failed for identity ${identityId} (profile exists, stake manually via DKGStakingConvictionNFT.createConviction): ` +
@@ -975,14 +1218,13 @@ export class EVMChainAdapter implements ChainAdapter {
     const nodeName = `node-${ethers.hexlify(ethers.randomBytes(4)).slice(2)}`;
     const nodeId = proof.publicKey.length > 0 ? proof.publicKey : ethers.randomBytes(32);
 
-    const tx = await this.contracts.profile!.createProfile(
-      this.adminSigner.address,
-      [],
-      nodeName,
-      nodeId,
-      0,
+    const receipt = await this.sendContractTransaction(
+      this.contracts.profile!,
+      'createProfile',
+      [this.adminSigner.address, [], nodeName, nodeId, 0],
+      this.signer,
+      'createProfile',
     );
-    const receipt = await tx.wait();
 
     for (const log of receipt.logs) {
       try {
@@ -1019,8 +1261,13 @@ export class EVMChainAdapter implements ChainAdapter {
     await this.init();
     this.requireV9();
 
-    const tx = await this.contracts.knowledgeAssets!.reserveUALRange(count);
-    const receipt = await tx.wait();
+    const receipt = await this.sendContractTransaction(
+      this.contracts.knowledgeAssets!,
+      'reserveUALRange',
+      [count],
+      this.signer,
+      'reserveUALRange',
+    );
 
     for (const log of receipt.logs) {
       try {
@@ -1054,8 +1301,13 @@ export class EVMChainAdapter implements ChainAdapter {
     if (this.contracts.token && params.tokenAmount > 0n) {
       const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, kaAddress);
       if (currentAllowance < params.tokenAmount) {
-        const approveTx = await this.contracts.token.approve(kaAddress, ethers.MaxUint256);
-        await approveTx.wait();
+        await this.sendContractTransaction(
+          this.contracts.token,
+          'approve',
+          [kaAddress, ethers.MaxUint256],
+          this.signer,
+          'approve KA TRAC',
+        );
       }
     }
 
@@ -1063,23 +1315,27 @@ export class EVMChainAdapter implements ChainAdapter {
     const rValues = params.receiverSignatures.map((s) => ethers.hexlify(s.r));
     const vsValues = params.receiverSignatures.map((s) => ethers.hexlify(s.vs));
 
-    const tx = await ka.batchMintKnowledgeAssets(
-      params.publisherNodeIdentityId,
-      ethers.hexlify(params.merkleRoot),
-      params.startKAId,
-      params.endKAId,
-      params.publicByteSize,
-      params.epochs,
-      params.tokenAmount,
-      ethers.ZeroAddress, // paymaster
-      ethers.hexlify(params.publisherSignature.r),
-      ethers.hexlify(params.publisherSignature.vs),
-      identityIds,
-      rValues,
-      vsValues,
+    const receipt = await this.sendContractTransaction(
+      ka,
+      'batchMintKnowledgeAssets',
+      [
+        params.publisherNodeIdentityId,
+        ethers.hexlify(params.merkleRoot),
+        params.startKAId,
+        params.endKAId,
+        params.publicByteSize,
+        params.epochs,
+        params.tokenAmount,
+        ethers.ZeroAddress, // paymaster
+        ethers.hexlify(params.publisherSignature.r),
+        ethers.hexlify(params.publisherSignature.vs),
+        identityIds,
+        rValues,
+        vsValues,
+      ],
+      this.signer,
+      'batchMintKnowledgeAssets',
     );
-
-    const receipt = await tx.wait();
 
     let batchId = 0n;
     for (const log of receipt.logs) {
@@ -1114,7 +1370,7 @@ export class EVMChainAdapter implements ChainAdapter {
     }
 
     try {
-      const receipt = await this.provider.getTransactionReceipt(txHash);
+      const receipt = await this.getTransactionReceiptWithFailover(txHash);
       if (!receipt || receipt.status !== 1) return { verified: false };
 
       let onChainMerkleRoot: Uint8Array | undefined;
@@ -1427,8 +1683,13 @@ export class EVMChainAdapter implements ChainAdapter {
     }
     const accessPolicy = params.accessPolicy ?? 0;
     const nameHash = ethers.keccak256(ethers.toUtf8Bytes(name));
-    const tx = await registry.claimName(nameHash, accessPolicy);
-    const receipt = await tx.wait();
+    const receipt = await this.sendContractTransaction(
+      registry,
+      'claimName',
+      [nameHash, accessPolicy],
+      this.signer,
+      'claim context graph name',
+    );
     if (!receipt) throw new Error('createContextGraph: no receipt');
     let contextGraphIdHex: string | undefined;
     for (const log of receipt.logs) {
@@ -1463,8 +1724,13 @@ export class EVMChainAdapter implements ChainAdapter {
     await this.init();
     const registry = this.contracts.contextGraphNameRegistry;
     if (!registry) throw new Error('revealContextGraphMetadata: ContextGraphNameRegistry not available');
-    const tx = await registry.revealMetadata(contextGraphId, name, description);
-    const receipt = await tx.wait();
+    const receipt = await this.sendContractTransaction(
+      registry,
+      'revealMetadata',
+      [contextGraphId, name, description],
+      this.signer,
+      'reveal context graph metadata',
+    );
     if (!receipt) throw new Error('revealContextGraphMetadata: no receipt');
     return { hash: receipt.hash, blockNumber: receipt.blockNumber, success: true };
   }
@@ -1515,20 +1781,25 @@ export class EVMChainAdapter implements ChainAdapter {
         'Pass both explicitly — e.g. { accessPolicy: 1, publishPolicy: 0 } for invite-only + curators-only.',
       );
     }
-    const tx = await this.contracts.contextGraphs.createContextGraph(
-      params.participantAgents ?? [],
-      params.metadataBatchId ?? 0n,
-      params.accessPolicy,
-      params.publishPolicy,
-      params.publishAuthority ?? ethers.ZeroAddress,
-      params.publishAuthorityAccountId ?? 0n,
-      // OT-RFC-38 / LU-6 Phase B — opt-in wire-id commitment. Default
-      // `bytes32(0)` opts out; the agent supplies a non-zero hash
-      // (typically `keccak256(bytes(cleartextId))`) to enable cores'
-      // chain-event-driven host-mode auto-subscribe path.
-      params.nameHash ?? ethers.ZeroHash,
+    const receipt = await this.sendContractTransaction(
+      this.contracts.contextGraphs,
+      'createContextGraph',
+      [
+        params.participantAgents ?? [],
+        params.metadataBatchId ?? 0n,
+        params.accessPolicy,
+        params.publishPolicy,
+        params.publishAuthority ?? ethers.ZeroAddress,
+        params.publishAuthorityAccountId ?? 0n,
+        // OT-RFC-38 / LU-6 Phase B — opt-in wire-id commitment. Default
+        // `bytes32(0)` opts out; the agent supplies a non-zero hash
+        // (typically `keccak256(bytes(cleartextId))`) to enable cores'
+        // chain-event-driven host-mode auto-subscribe path.
+        params.nameHash ?? ethers.ZeroHash,
+      ],
+      this.signer,
+      'create on-chain context graph',
     );
-    const receipt = await tx.wait();
 
     let contextGraphId: bigint | undefined;
     for (const log of receipt.logs) {
@@ -1567,11 +1838,13 @@ export class EVMChainAdapter implements ChainAdapter {
       throw new Error('ContextGraphs contract not deployed.');
     }
 
-    const tx = await this.contracts.contextGraphs.registerKnowledgeCollection(
-      params.contextGraphId,
-      params.batchId,
+    const receipt = await this.sendContractTransaction(
+      this.contracts.contextGraphs,
+      'registerKnowledgeCollection',
+      [params.contextGraphId, params.batchId],
+      this.signer,
+      'register knowledge collection',
     );
-    const receipt = await tx.wait();
 
     return {
       hash: receipt.hash,
@@ -1604,8 +1877,13 @@ export class EVMChainAdapter implements ChainAdapter {
       const token = this.contracts.token.connect(signer) as Contract;
       const currentAllowance: bigint = await token.allowance(signer.address, kaAddress);
       if (currentAllowance < params.tokenAmount) {
-        const approveTx = await token.approve(kaAddress, ethers.MaxUint256);
-        await approveTx.wait();
+        await this.sendContractTransaction(
+          token,
+          'approve',
+          [kaAddress, ethers.MaxUint256],
+          signer,
+          'approve context graph publish TRAC',
+        );
       }
     }
 
@@ -1700,7 +1978,7 @@ export class EVMChainAdapter implements ChainAdapter {
     await this.init();
 
     try {
-      const receipt = await this.provider.getTransactionReceipt(txHash);
+      const receipt = await this.getTransactionReceiptWithFailover(txHash);
       if (!receipt || receipt.status !== 1) return null;
 
       const v10 = this.contracts.knowledgeCollectionStorage
@@ -1843,8 +2121,13 @@ export class EVMChainAdapter implements ChainAdapter {
       const tokenWithSigner = this.contracts.token.connect(txSigner) as Contract;
       const currentAllowance = await tokenWithSigner.allowance(txSigner.address, kaAddress);
       if (currentAllowance < params.tokenAmount) {
-        const approveTx = await tokenWithSigner.approve(kaAddress, params.tokenAmount);
-        await approveTx.wait();
+        await this.sendContractTransaction(
+          tokenWithSigner,
+          'approve',
+          [kaAddress, params.tokenAmount],
+          txSigner,
+          'approve V10 publish TRAC',
+        );
       }
     }
 
@@ -1901,12 +2184,10 @@ export class EVMChainAdapter implements ChainAdapter {
     const populated = await (ka as any).publish.populateTransaction(
       publishParamsStruct,
     );
-    const filled = await txSigner.populateTransaction(populated);
-    const signedTx = await txSigner.signTransaction(filled);
+    const { signedTx, txHash: preBroadcastTxHash } = await this.signPopulatedTransaction(txSigner, populated);
     // Derive the pre-broadcast tx hash from the signed raw hex so WAL
     // consumers can log the exact identity of the tx about to hit the
     // wire. After broadcast completes, the receipt hash matches this.
-    const preBroadcastTxHash = ethers.Transaction.from(signedTx).hash ?? '0x';
     // Codex PR #241 iter-7: `await` the hook. `onBroadcast` is typed
     // as `Promise<void> | void`, so an async WAL writer (disk flush,
     // remote gossip) must run to completion BEFORE we proceed to
@@ -1924,9 +2205,7 @@ export class EVMChainAdapter implements ChainAdapter {
         `${hookErr instanceof Error ? hookErr.message : String(hookErr)}`,
       );
     }
-    const tx = await this.provider.broadcastTransaction(signedTx);
-
-    const receipt = await tx.wait();
+    const receipt = await this.sendSignedTransactionAndWait(signedTx, preBroadcastTxHash, 'V10 publish');
     if (!receipt) throw new Error('Transaction receipt is null');
 
     let kcId = 0n;
@@ -2239,8 +2518,13 @@ export class EVMChainAdapter implements ChainAdapter {
       const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
       const prevAllowance = await tokenWithSigner.allowance(signer.address, kav10Address);
       if (prevAllowance < newTokenAmount) {
-        const approveTx = await tokenWithSigner.approve(kav10Address, newTokenAmount);
-        await approveTx.wait();
+        await this.sendContractTransaction(
+          tokenWithSigner,
+          'approve',
+          [kav10Address, newTokenAmount],
+          signer,
+          'approve V10 update TRAC',
+        );
       }
     }
 
@@ -2254,9 +2538,7 @@ export class EVMChainAdapter implements ChainAdapter {
     // via `agentToAccountId(msg.sender)` for any positive
     // `deltaTokenAmount`.
     const populated = await (ka as any).update.populateTransaction(updateParams);
-    const filled = await signer.populateTransaction(populated);
-    const signedTx = await signer.signTransaction(filled);
-    const preBroadcastTxHash = ethers.Transaction.from(signedTx).hash ?? '0x';
+    const { signedTx, txHash: preBroadcastTxHash } = await this.signPopulatedTransaction(signer, populated);
     // Codex PR #241 iter-7: `await` so async WAL writes complete
     // before broadcast (see publish above for the full rationale).
     try {
@@ -2267,9 +2549,7 @@ export class EVMChainAdapter implements ChainAdapter {
         `${hookErr instanceof Error ? hookErr.message : String(hookErr)}`,
       );
     }
-    const tx = await this.provider.broadcastTransaction(signedTx);
-
-    const receipt = await tx.wait();
+    const receipt = await this.sendSignedTransactionAndWait(signedTx, preBroadcastTxHash, 'V10 update');
     if (!receipt) {
       throw new Error(
         `update broadcast succeeded (txHash=${preBroadcastTxHash}) but receipt was null ` +
@@ -2373,12 +2653,23 @@ export class EVMChainAdapter implements ChainAdapter {
       if (this.contracts.token) {
         const allowance: bigint = await this.contracts.token.allowance(this.signer.address, nftAddress);
         if (allowance < committedTRAC) {
-          await (await this.contracts.token.approve(nftAddress, ethers.MaxUint256)).wait();
+          await this.sendContractTransaction(
+            this.contracts.token,
+            'approve',
+            [nftAddress, ethers.MaxUint256],
+            this.signer,
+            'approve PCA TRAC',
+          );
         }
       }
 
-      const tx = await nft.createAccount(committedTRAC);
-      const receipt = await tx.wait();
+      const receipt = await this.sendContractTransaction(
+        nft,
+        'createAccount',
+        [committedTRAC],
+        this.signer,
+        'create publishing conviction account',
+      );
 
       // Post PR #650 split, `AccountCreated` is emitted by
       // `PublishingConviction` (logic), NOT by the wrapper. Parse via
@@ -2444,10 +2735,22 @@ export class EVMChainAdapter implements ChainAdapter {
       if (this.contracts.token) {
         const allowance: bigint = await this.contracts.token.allowance(this.signer.address, nftAddress);
         if (allowance < amount) {
-          await (await this.contracts.token.approve(nftAddress, ethers.MaxUint256)).wait();
+          await this.sendContractTransaction(
+            this.contracts.token,
+            'approve',
+            [nftAddress, ethers.MaxUint256],
+            this.signer,
+            'approve PCA top-up TRAC',
+          );
         }
       }
-      const receipt = await (await nft.topUp(accountId, amount)).wait();
+      const receipt = await this.sendContractTransaction(
+        nft,
+        'topUp',
+        [accountId, amount],
+        this.signer,
+        'top up publishing conviction account',
+      );
       return { hash: receipt.hash, blockNumber: receipt.blockNumber, success: receipt.status === 1 };
     });
   }
@@ -2456,7 +2759,13 @@ export class EVMChainAdapter implements ChainAdapter {
     await this.init();
     return this.pcaWrite(async () => {
       const nft = this.requireConvictionNFT();
-      const receipt = await (await nft.settle(accountId)).wait();
+      const receipt = await this.sendContractTransaction(
+        nft,
+        'settle',
+        [accountId],
+        this.signer,
+        'settle publishing conviction account',
+      );
       return { hash: receipt.hash, blockNumber: receipt.blockNumber, success: receipt.status === 1 };
     });
   }
@@ -2465,7 +2774,13 @@ export class EVMChainAdapter implements ChainAdapter {
     await this.init();
     return this.pcaWrite(async () => {
       const nft = this.requireConvictionNFT();
-      const receipt = await (await nft.registerAgent(accountId, agent)).wait();
+      const receipt = await this.sendContractTransaction(
+        nft,
+        'registerAgent',
+        [accountId, agent],
+        this.signer,
+        'register publishing conviction agent',
+      );
       return { hash: receipt.hash, blockNumber: receipt.blockNumber, success: receipt.status === 1 };
     });
   }
@@ -2474,7 +2789,13 @@ export class EVMChainAdapter implements ChainAdapter {
     await this.init();
     return this.pcaWrite(async () => {
       const nft = this.requireConvictionNFT();
-      const receipt = await (await nft.deregisterAgent(accountId, agent)).wait();
+      const receipt = await this.sendContractTransaction(
+        nft,
+        'deregisterAgent',
+        [accountId, agent],
+        this.signer,
+        'deregister publishing conviction agent',
+      );
       return { hash: receipt.hash, blockNumber: receipt.blockNumber, success: receipt.status === 1 };
     });
   }
@@ -2673,8 +2994,12 @@ export class EVMChainAdapter implements ChainAdapter {
     return this.provider.getBlockNumber();
   }
 
-  getProvider(): JsonRpcProvider {
+  getProvider(): JsonRpcProvider | FallbackProvider {
     return this.provider;
+  }
+
+  getRpcUrls(): string[] {
+    return [...this.rpcUrls];
   }
 
   async getContract(name: string): Promise<Contract> {
@@ -2889,8 +3214,13 @@ export class EVMChainAdapter implements ChainAdapter {
 
       let receipt: ethers.TransactionReceipt;
       try {
-        const tx = await rs.createChallenge();
-        receipt = await tx.wait();
+        receipt = await this.sendContractTransaction(
+          rs,
+          'createChallenge',
+          [],
+          this.signer,
+          'create random-sampling challenge',
+        );
       } catch (err) {
         this.translateRandomSamplingError(err);
       }
@@ -2955,8 +3285,13 @@ export class EVMChainAdapter implements ChainAdapter {
 
       let receipt: ethers.TransactionReceipt;
       try {
-        const tx = await rs.submitProof(leafHex, proofHex);
-        receipt = await tx.wait();
+        receipt = await this.sendContractTransaction(
+          rs,
+          'submitProof',
+          [leafHex, proofHex],
+          this.signer,
+          'submit random-sampling proof',
+        );
       } catch (err) {
         this.translateRandomSamplingError(err);
       }

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -1,6 +1,6 @@
 export * from './chain-adapter.js';
 export { MockChainAdapter, MOCK_DEFAULT_SIGNER } from './mock-adapter.js';
-export { EVMChainAdapter, type EVMAdapterConfig, decodeEvmError, enrichEvmError } from './evm-adapter.js';
+export { EVMChainAdapter, type EVMAdapterConfig, decodeEvmError, enrichEvmError, resolveRpcUrls } from './evm-adapter.js';
 export { NoChainAdapter } from './no-chain-adapter.js';
 export {
   HubResolutionCache,

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -106,6 +106,10 @@ export class MockChainAdapter implements ChainAdapter {
     return existing ?? 0n;
   }
 
+  getRpcUrls(): string[] {
+    return [];
+  }
+
   async ensureProfile(_options?: { nodeName?: string; stakeAmount?: bigint; lockTier?: number }): Promise<bigint> {
     const existing = await this.getIdentityId();
     if (existing > 0n) return existing;

--- a/packages/chain/test/evm-adapter-pca-enrich.test.ts
+++ b/packages/chain/test/evm-adapter-pca-enrich.test.ts
@@ -66,8 +66,15 @@ function opaqueCustomErrorRevert(dataHex: string): Error {
 function adapterWithFakeNft(nftOverrides: Record<string, unknown>): EVMChainAdapter {
   const a = new EVMChainAdapter(minimalConfig());
   (a as any).init = async () => undefined;
+  const connected: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(nftOverrides)) {
+    connected[name] = typeof value === 'function'
+      ? { populateTransaction: (...args: unknown[]) => (value as (...args: unknown[]) => unknown)(...args) }
+      : value;
+  }
   (a as any).contracts.dkgPublishingConvictionNFT = {
     getAddress: async () => NFT_ADDRESS,
+    connect: () => connected,
     ...nftOverrides,
   };
   // Leave contracts.token undefined so the allowance/approve branch in

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Interface, ethers } from 'ethers';
-import { decodeEvmError, enrichEvmError, EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+import { decodeEvmError, enrichEvmError, EVMChainAdapter, resolveRpcUrls, type EVMAdapterConfig } from '../src/evm-adapter.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const OTHER_PK = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b63b91100';
@@ -143,6 +143,115 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     const a = new EVMChainAdapter(minimalConfig());
     expect(a.getProvider()).toBeDefined();
     expect(typeof a.getProvider().getBlockNumber).toBe('function');
+  });
+
+  it('dedupes configured RPC URLs in priority order', () => {
+    expect(resolveRpcUrls('https://primary.example', [
+      'https://primary.example',
+      ' https://backup-a.example ',
+      'https://backup-b.example',
+      'https://backup-a.example',
+    ])).toEqual([
+      'https://primary.example',
+      'https://backup-a.example',
+      'https://backup-b.example',
+    ]);
+
+    const a = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://primary.example',
+      rpcUrls: ['https://primary.example', 'https://backup.example'],
+    }));
+    expect(a.getRpcUrls()).toEqual(['https://primary.example', 'https://backup.example']);
+  });
+
+  it('receipt lookup succeeds on backup when primary throws retryable provider error', async () => {
+    const a = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://primary.example',
+      rpcUrls: ['https://backup.example'],
+    }));
+    const receipt = { hash: '0xabc', blockNumber: 12, status: 1, logs: [] };
+    const primary = {
+      getTransactionReceipt: vi.fn(async () => {
+        const err = new Error('socket hang up');
+        (err as any).code = 'ECONNRESET';
+        throw err;
+      }),
+    };
+    const backup = { getTransactionReceipt: vi.fn(async () => receipt) };
+    (a as any).providers = [primary, backup];
+
+    await expect((a as any).getTransactionReceiptWithFailover('0xabc')).resolves.toBe(receipt);
+    expect(primary.getTransactionReceipt).toHaveBeenCalledTimes(1);
+    expect(backup.getTransactionReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fail over deterministic CALL_EXCEPTION errors', async () => {
+    const a = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://primary.example',
+      rpcUrls: ['https://backup.example'],
+    }));
+    const err = new Error('execution reverted');
+    (err as any).code = 'CALL_EXCEPTION';
+    const primary = { getTransactionReceipt: vi.fn(async () => { throw err; }) };
+    const backup = { getTransactionReceipt: vi.fn(async () => null) };
+    (a as any).providers = [primary, backup];
+
+    await expect((a as any).getTransactionReceiptWithFailover('0xabc')).rejects.toBe(err);
+    expect(backup.getTransactionReceipt).not.toHaveBeenCalled();
+  });
+
+  it('broadcasts the exact same signed raw transaction to backup after primary send failure', async () => {
+    const a = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://primary.example',
+      rpcUrls: ['https://backup.example'],
+    }));
+    const signedTx = '0x02f86c0180843b9aca0084773594008252089400000000000000000000000000000000000000018080c001a0' +
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const txHash = '0x' + '11'.repeat(32);
+    const receipt = { hash: txHash, blockNumber: 45, status: 1, logs: [] };
+    const primary = {
+      broadcastTransaction: vi.fn(async (_raw: string) => {
+        const err = new Error('429 too many requests');
+        (err as any).status = 429;
+        throw err;
+      }),
+      getTransactionReceipt: vi.fn(async () => null),
+    };
+    const backup = {
+      broadcastTransaction: vi.fn(async () => ({ hash: txHash })),
+      getTransactionReceipt: vi.fn(async () => receipt),
+    };
+    (a as any).providers = [primary, backup];
+
+    await expect((a as any).sendSignedTransactionAndWait(signedTx, txHash, 'unit write')).resolves.toBe(receipt);
+    expect(primary.broadcastTransaction).toHaveBeenCalledWith(signedTx);
+    expect(backup.broadcastTransaction).toHaveBeenCalledWith(signedTx);
+  });
+
+  it('treats already-known transaction responses as accepted and polls receipts', async () => {
+    const a = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://primary.example',
+      rpcUrls: ['https://backup.example'],
+    }));
+    const signedTx = '0xdeadbeef';
+    const txHash = '0x' + '22'.repeat(32);
+    const receipt = { hash: txHash, blockNumber: 46, status: 1, logs: [] };
+    const primary = {
+      broadcastTransaction: vi.fn(async () => {
+        throw new Error('already known');
+      }),
+      getTransactionReceipt: vi.fn(async () => receipt),
+    };
+    const backup = {
+      broadcastTransaction: vi.fn(async () => ({ hash: txHash })),
+      getTransactionReceipt: vi.fn(async () => receipt),
+    };
+    (a as any).providers = [primary, backup];
+
+    await expect((a as any).sendSignedTransactionAndWait(signedTx, txHash, 'unit write')).resolves.toBe(receipt);
+    expect(primary.broadcastTransaction).toHaveBeenCalledTimes(1);
+    expect(backup.broadcastTransaction).not.toHaveBeenCalled();
+    expect(primary.getTransactionReceipt).toHaveBeenCalledWith(txHash);
   });
 
   it('signMessage returns 32-byte r and vs (no contract init)', async () => {
@@ -745,4 +854,3 @@ describe('PR3 / RC11 — publish-preflight TTL cache', () => {
     expect(getNetwork).toHaveBeenCalledTimes(2);
   });
 });
-

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -254,6 +254,31 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(primary.getTransactionReceipt).toHaveBeenCalledWith(txHash);
   });
 
+  it('throws CALL_EXCEPTION when a mined write receipt reverted', async () => {
+    const a = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://primary.example',
+      rpcUrls: ['https://backup.example'],
+    }));
+    const signedTx = '0xdeadbeef';
+    const txHash = '0x' + '33'.repeat(32);
+    const receipt = { hash: txHash, blockNumber: 47, status: 0, logs: [] };
+    const primary = {
+      broadcastTransaction: vi.fn(async () => ({ hash: txHash })),
+      getTransactionReceipt: vi.fn(async () => receipt),
+    };
+    const backup = {
+      broadcastTransaction: vi.fn(async () => ({ hash: txHash })),
+      getTransactionReceipt: vi.fn(async () => receipt),
+    };
+    (a as any).providers = [primary, backup];
+
+    await expect((a as any).sendSignedTransactionAndWait(signedTx, txHash, 'unit write')).rejects.toMatchObject({
+      code: 'CALL_EXCEPTION',
+      receipt,
+    });
+    expect(backup.getTransactionReceipt).not.toHaveBeenCalled();
+  });
+
   it('signMessage returns 32-byte r and vs (no contract init)', async () => {
     const a = new EVMChainAdapter(minimalConfig());
     const digest = ethers.randomBytes(32);

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -143,6 +143,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     const a = new EVMChainAdapter(minimalConfig());
     expect(a.getProvider()).toBeDefined();
     expect(typeof a.getProvider().getBlockNumber).toBe('function');
+    expect(a.getReadProvider()).toBeDefined();
   });
 
   it('dedupes configured RPC URLs in priority order', () => {
@@ -181,6 +182,34 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     (a as any).providers = [primary, backup];
 
     await expect((a as any).getTransactionReceiptWithFailover('0xabc')).resolves.toBe(receipt);
+    expect(primary.getTransactionReceipt).toHaveBeenCalledTimes(1);
+    expect(backup.getTransactionReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails receipt lookup immediately when every RPC endpoint errors', async () => {
+    const a = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://primary.example',
+      rpcUrls: ['https://backup.example'],
+    }));
+    const primary = {
+      getTransactionReceipt: vi.fn(async () => {
+        const err = new Error('socket hang up');
+        (err as any).code = 'ECONNRESET';
+        throw err;
+      }),
+    };
+    const backup = {
+      getTransactionReceipt: vi.fn(async () => {
+        const err = new Error('502 bad gateway');
+        (err as any).status = 502;
+        throw err;
+      }),
+    };
+    (a as any).providers = [primary, backup];
+
+    await expect((a as any).getTransactionReceiptWithFailover('0xabc')).rejects.toMatchObject({
+      code: 'RPC_RECEIPT_LOOKUP_FAILED',
+    });
     expect(primary.getTransactionReceipt).toHaveBeenCalledTimes(1);
     expect(backup.getTransactionReceipt).toHaveBeenCalledTimes(1);
   });
@@ -239,6 +268,34 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     const primary = {
       broadcastTransaction: vi.fn(async () => {
         throw new Error('already known');
+      }),
+      getTransactionReceipt: vi.fn(async () => receipt),
+    };
+    const backup = {
+      broadcastTransaction: vi.fn(async () => ({ hash: txHash })),
+      getTransactionReceipt: vi.fn(async () => receipt),
+    };
+    (a as any).providers = [primary, backup];
+
+    await expect((a as any).sendSignedTransactionAndWait(signedTx, txHash, 'unit write')).resolves.toBe(receipt);
+    expect(primary.broadcastTransaction).toHaveBeenCalledTimes(1);
+    expect(backup.broadcastTransaction).not.toHaveBeenCalled();
+    expect(primary.getTransactionReceipt).toHaveBeenCalledWith(txHash);
+  });
+
+  it('treats nonce-too-low transaction responses as accepted and polls receipts', async () => {
+    const a = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://primary.example',
+      rpcUrls: ['https://backup.example'],
+    }));
+    const signedTx = '0xdeadbeef';
+    const txHash = '0x' + '44'.repeat(32);
+    const receipt = { hash: txHash, blockNumber: 48, status: 1, logs: [] };
+    const primary = {
+      broadcastTransaction: vi.fn(async () => {
+        const err = new Error('nonce too low');
+        (err as any).code = 'NONCE_EXPIRED';
+        throw err;
       }),
       getTransactionReceipt: vi.fn(async () => receipt),
     };

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -96,6 +96,13 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'init',
   'requireV9',
   'getBlockTimestamp',
+  'broadcastSignedTransactionWithFailover',
+  'getTransactionReceiptWithFailover',
+  'waitForReceiptWithFailover',
+  'signPopulatedTransaction',
+  'sendSignedTransactionAndWait',
+  'sendPopulatedTransaction',
+  'sendContractTransaction',
   'parseV10PublishReceipt',
   'parseV9PublishReceipt',
   // Random Sampling (Slice 1) — TS-private helpers that survive into

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -76,6 +76,7 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'getContract',            // resolves a Contract from the Hub — not applicable off-chain
   'getBlockNumber',         // the mock exposes its own block counter differently (advanceBlock)
   'getProvider',            // returns a JsonRpcProvider; mock has none
+  'getReadProvider',        // returns the EVM fallback read provider; mock has no RPC provider
   'getSignerAddress',       // mock exposes `signerAddress` as a field
   'getSignerAddresses',     // pool not applicable to mock
   'getAuthorizedPublisherAddress', // pool-specific signer selection; mock has one signerAddress

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -53,6 +53,12 @@ export interface DaemonStatusResponse {
   relayConnected: boolean;
   multiaddrs: string[];
   relay: RelayStatusResponse;
+  chain?: {
+    chainId: string | null;
+    rpcUrl?: string;
+    rpcUrls: string[];
+    hubAddress?: string;
+  } | null;
 }
 
 export class ApiClient {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -55,9 +55,9 @@ export interface DaemonStatusResponse {
   relay: RelayStatusResponse;
   chain?: {
     chainId: string | null;
-    rpcUrl?: string;
-    rpcUrls: string[];
-    hubAddress?: string;
+    configured: boolean;
+    rpcEndpointCount: number;
+    hubConfigured: boolean;
   } | null;
 }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@ import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { readFile, writeFile, unlink, appendFile } from 'node:fs/promises';
 import { ethers } from 'ethers';
+import { resolveRpcUrls } from '@origintrail-official/dkg-chain';
 import {
   dkgAuthTokenPath,
   FAUCET_WALLETS_PER_REQUEST,
@@ -78,6 +79,11 @@ import { registerIntegrationCommands } from './integrations/commands.js';
 type ActionOpts = Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 const VERIFY_COLLECTION_TIMEOUT_MIN_MS = 1_000;
 const VERIFY_COLLECTION_TIMEOUT_MAX_MS = 30 * 60 * 1000;
+const CLI_RPC_READ_STALL_TIMEOUT_MS = 4_000;
+const CLI_RPC_BROADCAST_TIMEOUT_MS = 10_000;
+const CLI_RPC_RECEIPT_ATTEMPT_TIMEOUT_MS = 5_000;
+const CLI_RPC_RECEIPT_POLL_INTERVAL_MS = 2_000;
+const CLI_RPC_RECEIPT_TIMEOUT_MS = 180_000;
 
 async function appendSupervisorLog(message: string): Promise<void> {
   await ensureDkgDir();
@@ -87,6 +93,144 @@ async function appendSupervisorLog(message: string): Promise<void> {
 function supervisorWarn(message: string): void {
   console.warn(message);
   void appendSupervisorLog(message).catch(() => {});
+}
+
+function cliSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function cliWithTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const err = new Error(`${label} timed out after ${ms}ms`);
+      (err as any).code = 'TIMEOUT';
+      reject(err);
+    }, ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  }) as Promise<T>;
+}
+
+function cliErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  try { return JSON.stringify(err); } catch { return String(err); }
+}
+
+function isCliKnownTransactionError(err: unknown): boolean {
+  const msg = cliErrorMessage(err).toLowerCase();
+  return msg.includes('already known')
+    || msg.includes('known transaction')
+    || msg.includes('already imported')
+    || msg.includes('transaction already in mempool')
+    || msg.includes('already exists')
+    || msg.includes('duplicate transaction');
+}
+
+function isCliRetryableRpcError(err: unknown): boolean {
+  const code = String((err as any)?.code ?? (err as any)?.error?.code ?? '').toUpperCase();
+  const status =
+    (err as any)?.status ??
+    (err as any)?.statusCode ??
+    (err as any)?.response?.status ??
+    (err as any)?.error?.status;
+  const msg = cliErrorMessage(err).toLowerCase();
+  if (code === 'CALL_EXCEPTION' || code === 'INSUFFICIENT_FUNDS' || code === 'NONCE_EXPIRED'
+    || code === 'REPLACEMENT_UNDERPRICED' || code === 'ACTION_REJECTED' || code === 'INVALID_ARGUMENT') {
+    return false;
+  }
+  if (msg.includes('execution reverted') || msg.includes('call exception')
+    || msg.includes('insufficient funds') || msg.includes('invalid argument')
+    || msg.includes('nonce too low') || msg.includes('replacement transaction underpriced')) {
+    return false;
+  }
+  if (status === 429 || (typeof status === 'number' && status >= 500)) return true;
+  if (code === 'TIMEOUT' || code === 'SERVER_ERROR' || code === 'NETWORK_ERROR'
+    || code === 'ECONNRESET' || code === 'ECONNREFUSED' || code === 'ETIMEDOUT'
+    || code === 'ENOTFOUND' || code === 'EAI_AGAIN' || code === 'UNKNOWN_ERROR') {
+    return true;
+  }
+  return /timeout|timed out|network|socket|reset|econnreset|econnrefused|etimedout|enotfound|rate limit|too many requests|429|503|502|500|gateway|temporarily unavailable|fetch failed|connection/i
+    .test(msg);
+}
+
+function createCliEvmProviders(rpcUrl: string, rpcUrls?: string[]): {
+  urls: string[];
+  providers: ethers.JsonRpcProvider[];
+  readProvider: ethers.JsonRpcProvider | ethers.FallbackProvider;
+} {
+  const urls = resolveRpcUrls(rpcUrl, rpcUrls);
+  const providers = urls.map((url) => new ethers.JsonRpcProvider(url, undefined, { cacheTimeout: -1 }));
+  const readProvider = providers.length === 1
+    ? providers[0]
+    : new ethers.FallbackProvider(
+      providers.map((provider, index) => ({
+        provider,
+        priority: index + 1,
+        stallTimeout: CLI_RPC_READ_STALL_TIMEOUT_MS,
+        weight: 1,
+      })),
+      undefined,
+      { quorum: 1 },
+    );
+  return { urls, providers, readProvider };
+}
+
+async function getCliReceiptWithFailover(
+  providers: ethers.JsonRpcProvider[],
+  txHash: string,
+): Promise<ethers.TransactionReceipt | null> {
+  for (let i = 0; i < providers.length; i += 1) {
+    try {
+      const receipt = await cliWithTimeout(
+        providers[i].getTransactionReceipt(txHash),
+        CLI_RPC_RECEIPT_ATTEMPT_TIMEOUT_MS,
+        `receipt lookup via RPC #${i + 1}`,
+      );
+      if (receipt) return receipt;
+    } catch (err) {
+      if (!isCliRetryableRpcError(err)) throw err;
+    }
+  }
+  return null;
+}
+
+async function sendCliRawTransactionWithFailover(
+  providers: ethers.JsonRpcProvider[],
+  signedTx: string,
+  txHash: string,
+): Promise<ethers.TransactionReceipt> {
+  let lastError: unknown;
+  for (let i = 0; i < providers.length; i += 1) {
+    try {
+      await cliWithTimeout(
+        providers[i].broadcastTransaction(signedTx),
+        CLI_RPC_BROADCAST_TIMEOUT_MS,
+        `broadcast via RPC #${i + 1}`,
+      );
+      lastError = undefined;
+      break;
+    } catch (err) {
+      if (isCliKnownTransactionError(err)) {
+        lastError = undefined;
+        break;
+      }
+      if (!isCliRetryableRpcError(err)) throw err;
+      lastError = err;
+    }
+  }
+  if (lastError) {
+    throw new Error(`Broadcast failed on all configured RPC endpoints: ${cliErrorMessage(lastError)}`, { cause: lastError });
+  }
+
+  const deadline = Date.now() + CLI_RPC_RECEIPT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const receipt = await getCliReceiptWithFailover(providers, txHash);
+    if (receipt) return receipt;
+    await cliSleep(CLI_RPC_RECEIPT_POLL_INTERVAL_MS);
+  }
+  throw new Error(`Transaction ${txHash} was broadcast but no receipt was found within ${CLI_RPC_RECEIPT_TIMEOUT_MS}ms`);
 }
 
 const STARTUP_BANNER = `
@@ -501,17 +645,21 @@ program
     // override even after `dkg init` re-prompts.
     const chainDefaults = resolveChainConfig(existing, network);
     const defaultRpcUrl = chainDefaults?.rpcUrl;
+    const defaultRpcUrls = chainDefaults?.rpcUrls?.join(', ') ?? '';
     const defaultHubAddress = chainDefaults?.hubAddress;
     const defaultChainId = chainDefaults?.chainId;
 
     console.log('\nBlockchain Configuration:');
     const rpcUrl = await ask('RPC URL', defaultRpcUrl);
+    const rpcUrlsInput = await ask('Backup RPC URLs (comma-separated, optional)', defaultRpcUrls);
+    const rpcUrls = rpcUrlsInput.split(',').map((s) => s.trim()).filter(Boolean);
     const hubAddress = await ask('Hub contract address', defaultHubAddress);
     const chainIdStr = await ask('Chain ID', defaultChainId);
 
     const chainSection = rpcUrl && hubAddress ? {
       type: 'evm' as const,
       rpcUrl,
+      ...(rpcUrls.length ? { rpcUrls } : {}),
       hubAddress,
       chainId: chainIdStr || undefined,
     } : undefined;
@@ -576,7 +724,7 @@ program
       // who only set rpcUrl still sees the inherited hub from the network.
       const effective = resolveChainConfig(config, network);
       console.log(`  chain:      ${effective?.rpcUrl && effective?.hubAddress
-        ? `${effective.rpcUrl} (hub: ${effective.hubAddress.slice(0, 10)}...)`
+        ? `${effective.rpcUrl}${effective.rpcUrls?.length ? ` (+${effective.rpcUrls.length} backups)` : ''} (hub: ${effective.hubAddress.slice(0, 10)}...)`
         : '(not configured)'}`);
     }
     if (network) {
@@ -3683,13 +3831,13 @@ program
       const tokenAddress = chainResolved?.tokenAddress;
       const chainId = chainResolved?.chainId ?? '(unknown)';
 
-      let provider: ethers.JsonRpcProvider | null = null;
+      let provider: ethers.JsonRpcProvider | ethers.FallbackProvider | null = null;
       let token: ethers.Contract | null = null;
       let tokenSymbol = 'TRAC';
 
       if (rpcUrl) {
         try {
-          provider = new ethers.JsonRpcProvider(rpcUrl);
+          provider = createCliEvmProviders(rpcUrl, chainResolved?.rpcUrls).readProvider;
           if (tokenAddress && tokenAddress !== ethers.ZeroAddress) {
             token = new ethers.Contract(tokenAddress, ['function balanceOf(address) view returns (uint256)', 'function symbol() view returns (string)'], provider);
             tokenSymbol = await token.symbol().catch(() => 'TRAC');
@@ -3740,6 +3888,7 @@ program
 
       console.log(`\n  Chain: ${chainId}`);
       if (rpcUrl) console.log(`  RPC:   ${rpcUrl}`);
+      if (chainResolved?.rpcUrls?.length) console.log(`  RPC backups: ${chainResolved.rpcUrls.join(', ')}`);
       console.log(`  File:  ~/.dkg/wallets.json`);
       console.log('\nFund these addresses with ETH (gas) and TRAC (staking/publishing).');
       if (opWallets.adminWallet) {
@@ -3785,17 +3934,17 @@ program
         process.exit(1);
       }
 
-      const provider = new ethers.JsonRpcProvider(rpcUrl);
-      const wallet = new ethers.Wallet(opWallets.wallets[0].privateKey, provider);
+      const { providers, readProvider } = createCliEvmProviders(rpcUrl, chainResolved?.rpcUrls);
+      const wallet = new ethers.Wallet(opWallets.wallets[0].privateKey, readProvider);
 
       const hub = new ethers.Contract(hubAddress, [
         'function getContractAddress(string) view returns (address)',
-      ], provider);
+      ], readProvider);
 
       const identityStorageAddr = await hub.getContractAddress('IdentityStorage');
       const identityStorage = new ethers.Contract(identityStorageAddr, [
         'function getIdentityId(address) view returns (uint72)',
-      ], provider);
+      ], readProvider);
 
       let identityId: bigint;
       if (opts.identity) {
@@ -3814,7 +3963,7 @@ program
       const profileStorageAddr = await hub.getContractAddress('ProfileStorage');
       const profileStorage = new ethers.Contract(profileStorageAddr, [
         'function getAsk(uint72) view returns (uint96)',
-      ], provider);
+      ], readProvider);
       const currentAsk = await profileStorage.getAsk(identityId);
 
       console.log(`  Identity:    ${identityId}`);
@@ -3832,10 +3981,13 @@ program
       ], wallet);
 
       console.log(`  Setting ask to ${amount} TRAC...`);
-      const tx = await profile.updateAsk(identityId, askWei);
-      console.log(`  TX: ${tx.hash}`);
-      const receipt = await tx.wait();
-      console.log(`  Confirmed in block ${receipt!.blockNumber}`);
+      const populated = await profile.updateAsk.populateTransaction(identityId, askWei);
+      const filled = await wallet.populateTransaction(populated);
+      const signedTx = await wallet.signTransaction(filled);
+      const txHash = ethers.Transaction.from(signedTx).hash ?? '0x';
+      console.log(`  TX: ${txHash}`);
+      const receipt = await sendCliRawTransactionWithFailover(providers, signedTx, txHash);
+      console.log(`  Confirmed in block ${receipt.blockNumber}`);
       console.log(`  New ask: ${amount} TRAC`);
     } catch (err) {
       if (hasErrorCode(err, 'CALL_EXCEPTION')) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -119,12 +119,15 @@ function cliErrorMessage(err: unknown): string {
 }
 
 function isCliKnownTransactionError(err: unknown): boolean {
+  const code = String((err as any)?.code ?? (err as any)?.error?.code ?? '').toUpperCase();
   const msg = cliErrorMessage(err).toLowerCase();
-  return msg.includes('already known')
+  return code === 'NONCE_EXPIRED'
+    || msg.includes('already known')
     || msg.includes('known transaction')
     || msg.includes('already imported')
     || msg.includes('transaction already in mempool')
     || msg.includes('already exists')
+    || msg.includes('nonce too low')
     || msg.includes('duplicate transaction');
 }
 
@@ -137,6 +140,7 @@ function isCliRetryableRpcError(err: unknown): boolean {
     (err as any)?.error?.status;
   const msg = cliErrorMessage(err).toLowerCase();
   if (code === 'CALL_EXCEPTION' || code === 'INSUFFICIENT_FUNDS' || code === 'NONCE_EXPIRED'
+    || code === 'RPC_RECEIPT_LOOKUP_FAILED'
     || code === 'REPLACEMENT_UNDERPRICED' || code === 'ACTION_REJECTED' || code === 'INVALID_ARGUMENT') {
     return false;
   }
@@ -181,6 +185,8 @@ async function getCliReceiptWithFailover(
   providers: ethers.JsonRpcProvider[],
   txHash: string,
 ): Promise<ethers.TransactionReceipt | null> {
+  let lastRetryable: unknown;
+  let sawNonErrorResponse = false;
   for (let i = 0; i < providers.length; i += 1) {
     try {
       const receipt = await cliWithTimeout(
@@ -188,10 +194,20 @@ async function getCliReceiptWithFailover(
         CLI_RPC_RECEIPT_ATTEMPT_TIMEOUT_MS,
         `receipt lookup via RPC #${i + 1}`,
       );
+      sawNonErrorResponse = true;
       if (receipt) return receipt;
     } catch (err) {
       if (!isCliRetryableRpcError(err)) throw err;
+      lastRetryable = err;
     }
+  }
+  if (lastRetryable && !sawNonErrorResponse) {
+    const err = new Error(
+      `Receipt lookup for transaction ${txHash} failed on all configured RPC endpoints: ${cliErrorMessage(lastRetryable)}`,
+      { cause: lastRetryable },
+    );
+    (err as any).code = 'RPC_RECEIPT_LOOKUP_FAILED';
+    throw err;
   }
   return null;
 }
@@ -662,15 +678,16 @@ program
 
     console.log('\nBlockchain Configuration:');
     const rpcUrl = await ask('RPC URL', defaultRpcUrl);
-    const rpcUrlsInput = await ask('Backup RPC URLs (comma-separated, optional)', defaultRpcUrls);
-    const rpcUrls = rpcUrlsInput.split(',').map((s) => s.trim()).filter(Boolean);
+    const rpcUrlsInput = await ask('Backup RPC URLs (comma-separated, optional; type "none" to clear)', defaultRpcUrls);
+    const clearRpcUrls = rpcUrlsInput.trim().toLowerCase() === 'none';
+    const rpcUrls = clearRpcUrls ? [] : rpcUrlsInput.split(',').map((s) => s.trim()).filter(Boolean);
     const hubAddress = await ask('Hub contract address', defaultHubAddress);
     const chainIdStr = await ask('Chain ID', defaultChainId);
 
     const chainSection = rpcUrl && hubAddress ? {
       type: 'evm' as const,
       rpcUrl,
-      ...(rpcUrls.length ? { rpcUrls } : {}),
+      ...(clearRpcUrls || rpcUrls.length ? { rpcUrls } : {}),
       hubAddress,
       chainId: chainIdStr || undefined,
     } : undefined;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -196,6 +196,14 @@ async function getCliReceiptWithFailover(
   return null;
 }
 
+function assertCliSuccessfulReceipt(receipt: ethers.TransactionReceipt, txHash: string): void {
+  if (receipt.status !== 0) return;
+  const err = new Error(`Transaction ${txHash} was mined but reverted (status=0)`);
+  (err as any).code = 'CALL_EXCEPTION';
+  (err as any).receipt = receipt;
+  throw err;
+}
+
 async function sendCliRawTransactionWithFailover(
   providers: ethers.JsonRpcProvider[],
   signedTx: string,
@@ -227,7 +235,10 @@ async function sendCliRawTransactionWithFailover(
   const deadline = Date.now() + CLI_RPC_RECEIPT_TIMEOUT_MS;
   while (Date.now() < deadline) {
     const receipt = await getCliReceiptWithFailover(providers, txHash);
-    if (receipt) return receipt;
+    if (receipt) {
+      assertCliSuccessfulReceipt(receipt, txHash);
+      return receipt;
+    }
     await cliSleep(CLI_RPC_RECEIPT_POLL_INTERVAL_MS);
   }
   throw new Error(`Transaction ${txHash} was broadcast but no receipt was found within ${CLI_RPC_RECEIPT_TIMEOUT_MS}ms`);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -127,6 +127,7 @@ export interface NetworkConfig {
   chain?: {
     type: 'evm';
     rpcUrl: string;
+    rpcUrls?: string[];
     hubAddress: string;
     tokenAddress?: string;
     chainId: string;
@@ -159,6 +160,8 @@ export interface ChainConfig {
   type: 'evm' | 'mock';
   /** JSON-RPC endpoint URL */
   rpcUrl: string;
+  /** Ordered JSON-RPC backup endpoints. `rpcUrl` remains the primary endpoint. */
+  rpcUrls?: string[];
   /** Hub contract address */
   hubAddress: string;
   /** Optional token contract address override. When omitted, resolve from Hub.Token. */
@@ -758,8 +761,19 @@ export function resolveChainConfig(
   const merged: Partial<ChainConfig> = {
     type: cfg?.type ?? net?.type ?? 'evm',
   };
-  const rpcUrl = cfg?.rpcUrl ?? net?.rpcUrl;
-  if (rpcUrl !== undefined) merged.rpcUrl = rpcUrl;
+  const primaryRpcUrl = cfg?.rpcUrl ?? net?.rpcUrl;
+  const backupRpcUrls = cfg?.rpcUrls ?? net?.rpcUrls ?? [];
+  const orderedRpcUrls: string[] = [];
+  for (const candidate of [primaryRpcUrl, ...backupRpcUrls]) {
+    if (typeof candidate !== 'string') continue;
+    const trimmed = candidate.trim();
+    if (!trimmed || orderedRpcUrls.includes(trimmed)) continue;
+    orderedRpcUrls.push(trimmed);
+  }
+  if (orderedRpcUrls[0] !== undefined) merged.rpcUrl = orderedRpcUrls[0];
+  if (orderedRpcUrls.length > 1 || cfg?.rpcUrls !== undefined || net?.rpcUrls !== undefined) {
+    merged.rpcUrls = orderedRpcUrls.slice(1);
+  }
   const hubAddress = cfg?.hubAddress ?? net?.hubAddress;
   if (hubAddress !== undefined) merged.hubAddress = hubAddress;
   const tokenAddress = cfg?.tokenAddress ?? net?.tokenAddress;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1004,6 +1004,7 @@ export async function runDaemonInner(
     // network supplies one of them; the agent expects rpcUrl + hubAddress.
     chainConfig: chainBase?.rpcUrl && chainBase?.hubAddress ? {
       rpcUrl: chainBase.rpcUrl,
+      rpcUrls: chainBase.rpcUrls,
       hubAddress: chainBase.hubAddress,
       ...(opWallets.adminWallet
         ? { adminPrivateKey: opWallets.adminWallet.privateKey }
@@ -1293,6 +1294,7 @@ export async function runDaemonInner(
   const publisherChainBase = chainBase?.rpcUrl && chainBase?.hubAddress
     ? {
         rpcUrl: chainBase.rpcUrl,
+        rpcUrls: chainBase.rpcUrls,
         hubAddress: chainBase.hubAddress,
         chainId: chainBase.chainId,
       }

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -356,8 +356,9 @@ function routeWithTimeout<T>(promise: Promise<T>, ms: number, label: string): Pr
   }) as Promise<T>;
 }
 
-async function probeRpcEndpoint(rpcUrl: string): Promise<{
-  rpcUrl: string;
+async function probeRpcEndpoint(rpcUrl: string, index: number): Promise<{
+  index: number;
+  role: 'primary' | 'backup';
   ok: boolean;
   latencyMs: number | null;
   blockNumber: number | null;
@@ -366,20 +367,24 @@ async function probeRpcEndpoint(rpcUrl: string): Promise<{
   const provider = new ethers.JsonRpcProvider(rpcUrl, undefined, { cacheTimeout: -1 });
   const start = Date.now();
   try {
-    const blockNumber = await routeWithTimeout(provider.getBlockNumber(), 3_000, `RPC health probe ${rpcUrl}`);
+    const blockNumber = await routeWithTimeout(provider.getBlockNumber(), 3_000, 'RPC health probe');
     return {
-      rpcUrl,
+      index,
+      role: index === 0 ? 'primary' : 'backup',
       ok: true,
       latencyMs: Date.now() - start,
       blockNumber,
     };
   } catch (err) {
     return {
-      rpcUrl,
+      index,
+      role: index === 0 ? 'primary' : 'backup',
       ok: false,
       latencyMs: null,
       blockNumber: null,
-      error: err instanceof Error ? err.message : String(err),
+      error: err instanceof Error && err.message.includes('timed out')
+        ? 'RPC health probe timed out'
+        : 'RPC health probe failed',
     };
   }
 }
@@ -561,6 +566,9 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     );
     const networkId = await computeNetworkId();
     const chainConf = resolveChainConfig(config, network);
+    const rpcEndpointCount = chainConf?.rpcUrl
+      ? resolveRpcUrls(chainConf.rpcUrl, chainConf.rpcUrls).length
+      : 0;
     const blockExplorerUrl =
       config.blockExplorerUrl ?? deriveBlockExplorerUrl(chainConf?.chainId);
     const identityId = agent.publisher.getIdentityId();
@@ -610,9 +618,9 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       chain: chainConf
         ? {
             chainId: chainConf.chainId ?? null,
-            rpcUrl: chainConf.rpcUrl,
-            rpcUrls: chainConf.rpcUrls ?? [],
-            hubAddress: chainConf.hubAddress,
+            configured: Boolean(chainConf.rpcUrl && chainConf.hubAddress),
+            rpcEndpointCount,
+            hubConfigured: Boolean(chainConf.hubAddress),
           }
         : null,
       updateAvailable:
@@ -884,8 +892,8 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     if (!rpcUrl) {
       return jsonResponse(res, 200, {
         ok: false,
-        rpcUrl: null,
-        rpcUrls: [],
+        configured: false,
+        rpcEndpointCount: 0,
         latencyMs: null,
         blockNumber: null,
         rpcs: [],
@@ -893,12 +901,12 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       });
     }
     const rpcUrls = resolveRpcUrls(rpcUrl, chain?.rpcUrls);
-    const rpcs = await Promise.all(rpcUrls.map((url) => probeRpcEndpoint(url)));
+    const rpcs = await Promise.all(rpcUrls.map((url, index) => probeRpcEndpoint(url, index)));
     const primary = rpcs[0];
     return jsonResponse(res, 200, {
       ok: primary?.ok ?? false,
-      rpcUrl,
-      rpcUrls: rpcUrls.slice(1),
+      configured: true,
+      rpcEndpointCount: rpcUrls.length,
       latencyMs: primary?.latencyMs ?? null,
       blockNumber: primary?.blockNumber ?? null,
       error: primary?.ok ? undefined : (primary?.error ?? "RPC health probe failed"),

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -55,7 +55,7 @@ const daemonRequire = createRequire(import.meta.url);
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
-import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { enrichEvmError, MockChainAdapter, resolveRpcUrls } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
@@ -346,6 +346,60 @@ interface RegistryCacheSnapshot {
 let registryCache: RegistryCacheSnapshot | null = null;
 let registryCacheInflight: Promise<RegistryCacheSnapshot> | null = null;
 
+function routeWithTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  }) as Promise<T>;
+}
+
+async function probeRpcEndpoint(rpcUrl: string): Promise<{
+  rpcUrl: string;
+  ok: boolean;
+  latencyMs: number | null;
+  blockNumber: number | null;
+  error?: string;
+}> {
+  const provider = new ethers.JsonRpcProvider(rpcUrl, undefined, { cacheTimeout: -1 });
+  const start = Date.now();
+  try {
+    const blockNumber = await routeWithTimeout(provider.getBlockNumber(), 3_000, `RPC health probe ${rpcUrl}`);
+    return {
+      rpcUrl,
+      ok: true,
+      latencyMs: Date.now() - start,
+      blockNumber,
+    };
+  } catch (err) {
+    return {
+      rpcUrl,
+      ok: false,
+      latencyMs: null,
+      blockNumber: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function createRouteEvmProvider(rpcUrl: string, rpcUrls?: string[]): ethers.JsonRpcProvider | ethers.FallbackProvider {
+  const providers = resolveRpcUrls(rpcUrl, rpcUrls)
+    .map((url) => new ethers.JsonRpcProvider(url, undefined, { cacheTimeout: -1 }));
+  if (providers.length === 1) return providers[0];
+  return new ethers.FallbackProvider(
+    providers.map((provider, index) => ({
+      provider,
+      priority: index + 1,
+      stallTimeout: 4_000,
+      weight: 1,
+    })),
+    undefined,
+    { quorum: 1 },
+  );
+}
+
 async function getRegistryCacheSnapshot(): Promise<RegistryCacheSnapshot> {
   const now = Date.now();
   if (registryCache && now - registryCache.fetchedAt < REGISTRY_CACHE_TTL_MS) {
@@ -553,6 +607,14 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       localAgentIntegrations,
       connectedLocalAgentIds: localAgentIntegrations.filter((integration) => integration.enabled).map((integration) => integration.id),
       autoUpdate: resolveAutoUpdateEnabled(config),
+      chain: chainConf
+        ? {
+            chainId: chainConf.chainId ?? null,
+            rpcUrl: chainConf.rpcUrl,
+            rpcUrls: chainConf.rpcUrls ?? [],
+            hubAddress: chainConf.hubAddress,
+          }
+        : null,
       updateAvailable:
         daemonState.lastUpdateCheck.checkedAt > 0 ? !daemonState.lastUpdateCheck.upToDate : null,
       latestCommit: daemonState.lastUpdateCheck.latestCommit || null,
@@ -581,6 +643,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         ? {
             chainId: chainConf.chainId ?? null,
             rpcUrl: chainConf.rpcUrl,
+            rpcUrls: chainConf.rpcUrls ?? [],
             hubAddress: chainConf.hubAddress,
           }
         : null,
@@ -748,11 +811,12 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         balances: [],
         chainId,
         rpcUrl: rpcUrl ?? null,
+        rpcUrls: chain?.rpcUrls ?? [],
         error: !rpcUrl || !hubAddress ? "Chain not configured" : "No wallets",
       });
     }
     try {
-      const provider = new ethers.JsonRpcProvider(rpcUrl);
+      const provider = createRouteEvmProvider(rpcUrl, chain?.rpcUrls);
       const tokenAddr = chain?.tokenAddress
         ?? (await new ethers.Contract(
           hubAddress,
@@ -793,6 +857,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         balances,
         chainId,
         rpcUrl,
+        rpcUrls: chain?.rpcUrls ?? [],
         symbol: tokenSymbol,
       });
     } catch (err: any) {
@@ -801,6 +866,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         balances: [],
         chainId,
         rpcUrl,
+        rpcUrls: chain?.rpcUrls ?? [],
         error: err.message,
       });
     }
@@ -819,31 +885,25 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       return jsonResponse(res, 200, {
         ok: false,
         rpcUrl: null,
+        rpcUrls: [],
         latencyMs: null,
         blockNumber: null,
+        rpcs: [],
         error: "Chain not configured",
       });
     }
-    try {
-      const provider = new ethers.JsonRpcProvider(rpcUrl);
-      const start = Date.now();
-      const blockNumber = await provider.getBlockNumber();
-      const latencyMs = Date.now() - start;
-      return jsonResponse(res, 200, {
-        ok: true,
-        rpcUrl,
-        latencyMs,
-        blockNumber,
-      });
-    } catch (err: any) {
-      return jsonResponse(res, 200, {
-        ok: false,
-        rpcUrl,
-        latencyMs: null,
-        blockNumber: null,
-        error: err.message,
-      });
-    }
+    const rpcUrls = resolveRpcUrls(rpcUrl, chain?.rpcUrls);
+    const rpcs = await Promise.all(rpcUrls.map((url) => probeRpcEndpoint(url)));
+    const primary = rpcs[0];
+    return jsonResponse(res, 200, {
+      ok: primary?.ok ?? false,
+      rpcUrl,
+      rpcUrls: rpcUrls.slice(1),
+      latencyMs: primary?.latencyMs ?? null,
+      blockNumber: primary?.blockNumber ?? null,
+      error: primary?.ok ? undefined : (primary?.error ?? "RPC health probe failed"),
+      rpcs,
+    });
   }
 
   // GET /api/identity — current on-chain identity status

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -903,13 +903,14 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     const rpcUrls = resolveRpcUrls(rpcUrl, chain?.rpcUrls);
     const rpcs = await Promise.all(rpcUrls.map((url, index) => probeRpcEndpoint(url, index)));
     const primary = rpcs[0];
+    const healthy = rpcs.find((rpc) => rpc.ok);
     return jsonResponse(res, 200, {
-      ok: primary?.ok ?? false,
+      ok: !!healthy,
       configured: true,
       rpcEndpointCount: rpcUrls.length,
-      latencyMs: primary?.latencyMs ?? null,
-      blockNumber: primary?.blockNumber ?? null,
-      error: primary?.ok ? undefined : (primary?.error ?? "RPC health probe failed"),
+      latencyMs: healthy?.latencyMs ?? null,
+      blockNumber: healthy?.blockNumber ?? null,
+      error: healthy ? undefined : (primary?.error ?? "RPC health probe failed"),
       rpcs,
     });
   }

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -34,6 +34,7 @@ export async function startPublisherRuntimeIfEnabled(args: {
   keypair: Ed25519Keypair;
   chainBase?: {
     rpcUrl: string;
+    rpcUrls?: string[];
     hubAddress: string;
     chainId?: string;
   };
@@ -76,6 +77,7 @@ interface PublisherRuntimeBaseArgs {
   store: TripleStore;
   chainBase?: {
     rpcUrl: string;
+    rpcUrls?: string[];
     hubAddress: string;
     chainId?: string;
   };
@@ -111,7 +113,7 @@ export async function createPublisherRuntime(args: {
   // finality but still functions).
   const merged = resolveChainConfig(args.config, network);
   const chainBase = merged?.rpcUrl && merged?.hubAddress
-    ? { rpcUrl: merged.rpcUrl, hubAddress: merged.hubAddress, chainId: merged.chainId }
+    ? { rpcUrl: merged.rpcUrl, rpcUrls: merged.rpcUrls, hubAddress: merged.hubAddress, chainId: merged.chainId }
     : undefined;
   return createPublisherRuntimeFromBase({
     dataDir: args.dataDir,
@@ -162,6 +164,7 @@ export async function createPublisherRuntimeFromAgent(args: {
   keypair: Ed25519Keypair;
   chainBase?: {
     rpcUrl: string;
+    rpcUrls?: string[];
     hubAddress: string;
     chainId?: string;
   };
@@ -201,6 +204,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
     const chain = args.chainBase
       ? new EVMChainAdapter({
           rpcUrl: args.chainBase.rpcUrl,
+          rpcUrls: args.chainBase.rpcUrls,
           privateKey: wallet.privateKey,
           hubAddress: args.chainBase.hubAddress,
           chainId: args.chainBase.chainId,

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -391,6 +391,15 @@ describe('resolveChainConfig (field-level merge)', () => {
     expect(merged?.rpcUrls).toEqual(['https://operator-backup.example/rpc']);
   });
 
+  it('preserves an explicit empty operator backup list instead of inheriting network backups', () => {
+    const merged = resolveChainConfig(
+      { chain: { rpcUrls: [] } },
+      { chain: fullNetworkChain },
+    );
+    expect(merged?.rpcUrl).toBe(fullNetworkChain.rpcUrl);
+    expect(merged?.rpcUrls).toEqual([]);
+  });
+
   it('strips rpcUrls under mock mode along with rpcUrl', () => {
     const merged = resolveChainConfig(
       {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -314,6 +314,7 @@ describe('resolveChainConfig (field-level merge)', () => {
   const fullNetworkChain = {
     type: 'evm' as const,
     rpcUrl: 'https://network.example/rpc',
+    rpcUrls: ['https://network-backup-1.example/rpc', 'https://network-backup-2.example/rpc'],
     hubAddress: '0xNETWORKHUB000000000000000000000000000000',
     chainId: 'base:84532',
   };
@@ -329,6 +330,7 @@ describe('resolveChainConfig (field-level merge)', () => {
     expect(merged).toEqual({
       type: 'evm',
       rpcUrl: fullNetworkChain.rpcUrl,
+      rpcUrls: fullNetworkChain.rpcUrls,
       hubAddress: fullNetworkChain.hubAddress,
       chainId: fullNetworkChain.chainId,
     });
@@ -341,6 +343,7 @@ describe('resolveChainConfig (field-level merge)', () => {
       { chain: fullNetworkChain },
     );
     expect(merged?.rpcUrl).toBe('https://my-private-rpc.example/abc');
+    expect(merged?.rpcUrls).toEqual(fullNetworkChain.rpcUrls);
     expect(merged?.hubAddress).toBe(fullNetworkChain.hubAddress);
     expect(merged?.chainId).toBe(fullNetworkChain.chainId);
     expect(merged?.type).toBe('evm');
@@ -353,7 +356,56 @@ describe('resolveChainConfig (field-level merge)', () => {
     );
     expect(merged?.hubAddress).toBe('0xOPERATORHUB0000000000000000000000000000');
     expect(merged?.rpcUrl).toBe(fullNetworkChain.rpcUrl);
+    expect(merged?.rpcUrls).toEqual(fullNetworkChain.rpcUrls);
     expect(merged?.chainId).toBe(fullNetworkChain.chainId);
+  });
+
+  it('dedupes primary + backups while preserving operator priority', () => {
+    const merged = resolveChainConfig(
+      {
+        chain: {
+          rpcUrl: 'https://operator.example/rpc',
+          rpcUrls: [
+            'https://operator.example/rpc',
+            ' https://backup-a.example/rpc ',
+            'https://backup-b.example/rpc',
+            'https://backup-a.example/rpc',
+          ],
+        },
+      },
+      { chain: fullNetworkChain },
+    );
+    expect(merged?.rpcUrl).toBe('https://operator.example/rpc');
+    expect(merged?.rpcUrls).toEqual([
+      'https://backup-a.example/rpc',
+      'https://backup-b.example/rpc',
+    ]);
+  });
+
+  it('uses operator backup list instead of network backups when set', () => {
+    const merged = resolveChainConfig(
+      { chain: { rpcUrls: ['https://operator-backup.example/rpc'] } },
+      { chain: fullNetworkChain },
+    );
+    expect(merged?.rpcUrl).toBe(fullNetworkChain.rpcUrl);
+    expect(merged?.rpcUrls).toEqual(['https://operator-backup.example/rpc']);
+  });
+
+  it('strips rpcUrls under mock mode along with rpcUrl', () => {
+    const merged = resolveChainConfig(
+      {
+        chain: {
+          type: 'mock',
+          rpcUrl: 'https://stale-rpc.example',
+          rpcUrls: ['https://stale-backup.example'],
+          hubAddress: '0xDEADBEEF00000000000000000000000000000000',
+        },
+      },
+      { chain: fullNetworkChain },
+    );
+    expect(merged?.type).toBe('mock');
+    expect(merged?.rpcUrl).toBeUndefined();
+    expect(merged?.rpcUrls).toBeUndefined();
   });
 
   it('merges tokenAddress with operator override precedence', () => {
@@ -377,6 +429,7 @@ describe('resolveChainConfig (field-level merge)', () => {
       null,
     );
     expect(merged?.rpcUrl).toBe('https://standalone.example/rpc');
+    expect(merged?.rpcUrls).toBeUndefined();
     expect(merged?.hubAddress).toBeUndefined();
     expect(merged?.chainId).toBeUndefined();
     // Callers (lifecycle, publisher-runner) MUST guard for the missing
@@ -397,6 +450,7 @@ describe('resolveChainConfig (field-level merge)', () => {
     expect(merged?.type).toBe('mock');
     expect(merged?.mockIdentityId).toBe('42');
     expect(merged?.rpcUrl).toBeUndefined();
+    expect(merged?.rpcUrls).toBeUndefined();
     expect(merged?.hubAddress).toBeUndefined();
     expect(merged?.chainId).toBeUndefined();
   });
@@ -449,6 +503,7 @@ describe('resolveChainConfig (field-level merge)', () => {
       mockIdentityId: '9',
     });
     expect(merged?.rpcUrl).toBeUndefined();
+    expect(merged?.rpcUrls).toBeUndefined();
     expect(merged?.hubAddress).toBeUndefined();
   });
 

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -143,12 +143,12 @@ describe('status route multi-RPC shape', () => {
     const res = await fetch(`${baseUrl}/api/chain/rpc-health`);
     const body: any = await res.json();
     expect(res.status).toBe(200);
-    expect(body.ok).toBe(false);
+    expect(body.ok).toBe(true);
     expect(body.configured).toBe(true);
     expect(body.rpcEndpointCount).toBe(2);
     expect(body).not.toHaveProperty('rpcUrl');
     expect(body).not.toHaveProperty('rpcUrls');
-    expect(body.blockNumber).toBeNull();
+    expect(body.blockNumber).toBe(456);
     expect(body.rpcs).toEqual([
       expect.objectContaining({
         index: 0,

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+
+const rpcState = vi.hoisted(() => ({
+  responses: new Map<string, number | Error | Promise<never>>(),
+}));
+
+vi.mock('ethers', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  class MockJsonRpcProvider {
+    readonly rpcUrl: string;
+    constructor(rpcUrl: string) {
+      this.rpcUrl = rpcUrl;
+    }
+    async getBlockNumber(): Promise<number> {
+      const response = rpcState.responses.get(this.rpcUrl);
+      if (response instanceof Error) throw response;
+      if (response && typeof (response as Promise<never>).then === 'function') {
+        return response as Promise<never>;
+      }
+      return typeof response === 'number' ? response : 123;
+    }
+  }
+  return {
+    ...actual,
+    ethers: {
+      ...actual.ethers,
+      JsonRpcProvider: MockJsonRpcProvider,
+    },
+  };
+});
+
+const { handleStatusRoutes } = await import('../src/daemon/routes/status.js');
+
+function makeCtx(path: string) {
+  const url = new URL(path, 'http://127.0.0.1');
+  return {
+    agent: {
+      peerId: '12D3KooStatusRouteTest',
+      multiaddrs: [],
+      node: {
+        libp2p: {
+          getConnections: () => [],
+        },
+      },
+      publisher: {
+        getIdentityId: () => 0n,
+      },
+    },
+    publisherControl: {},
+    publisherRuntime: null,
+    config: {
+      name: 'status-test',
+      nodeRole: 'edge',
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://primary.example/rpc',
+        rpcUrls: ['https://backup.example/rpc'],
+        hubAddress: '0x0000000000000000000000000000000000000001',
+        chainId: 'base:84532',
+      },
+    },
+    startedAt: Date.now() - 1000,
+    dashDb: {},
+    opWallets: { wallets: [] },
+    network: null,
+    tracker: {},
+    memoryManager: {},
+    bridgeAuthToken: undefined,
+    nodeVersion: 'test',
+    nodeCommit: 'abc123',
+    catchupTracker: { jobs: new Map(), latestByContextGraph: new Map() },
+    extractionRegistry: {},
+    fileStore: {},
+    extractionStatus: new Map(),
+    assertionImportLocks: new Map(),
+    vectorStore: {},
+    embeddingProvider: null,
+    validTokens: new Set(),
+    apiHost: '127.0.0.1',
+    apiPortRef: { value: 0 },
+    url,
+    path: url.pathname,
+    requestToken: undefined,
+    requestAgentAddress: 'did:dkg:agent:test',
+    emitMemoryGraphChanged: () => {},
+  };
+}
+
+describe('status route multi-RPC shape', () => {
+  let server: Server | undefined;
+  let baseUrl = '';
+
+  beforeEach(async () => {
+    rpcState.responses.clear();
+    server = createServer(async (req, res) => {
+      const requestPath = req.url ?? '/';
+      const ctx = { ...makeCtx(requestPath), req, res };
+      try {
+        await handleStatusRoutes(ctx as any);
+        if (!res.writableEnded) {
+          res.statusCode = 404;
+          res.end();
+        }
+      } catch (err: any) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: err?.message ?? String(err) }));
+      }
+    });
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('server did not bind');
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => server!.close((err) => (err ? reject(err) : resolve())));
+      server = undefined;
+    }
+  });
+
+  it('/api/status returns primary rpcUrl and backup rpcUrls', async () => {
+    const res = await fetch(`${baseUrl}/api/status`);
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.chain.rpcUrl).toBe('https://primary.example/rpc');
+    expect(body.chain.rpcUrls).toEqual(['https://backup.example/rpc']);
+  });
+
+  it('/api/chain/rpc-health preserves primary fields and adds per-endpoint probes', async () => {
+    rpcState.responses.set('https://primary.example/rpc', new Error('primary down'));
+    rpcState.responses.set('https://backup.example/rpc', 456);
+
+    const res = await fetch(`${baseUrl}/api/chain/rpc-health`);
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(false);
+    expect(body.rpcUrl).toBe('https://primary.example/rpc');
+    expect(body.rpcUrls).toEqual(['https://backup.example/rpc']);
+    expect(body.blockNumber).toBeNull();
+    expect(body.rpcs).toEqual([
+      expect.objectContaining({
+        rpcUrl: 'https://primary.example/rpc',
+        ok: false,
+        blockNumber: null,
+      }),
+      expect.objectContaining({
+        rpcUrl: 'https://backup.example/rpc',
+        ok: true,
+        blockNumber: 456,
+      }),
+    ]);
+  });
+});

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -121,15 +121,22 @@ describe('status route multi-RPC shape', () => {
     }
   });
 
-  it('/api/status returns primary rpcUrl and backup rpcUrls', async () => {
+  it('/api/status returns sanitized chain summary without raw RPC endpoints', async () => {
     const res = await fetch(`${baseUrl}/api/status`);
     const body: any = await res.json();
     expect(res.status).toBe(200);
-    expect(body.chain.rpcUrl).toBe('https://primary.example/rpc');
-    expect(body.chain.rpcUrls).toEqual(['https://backup.example/rpc']);
+    expect(body.chain).toEqual({
+      chainId: 'base:84532',
+      configured: true,
+      rpcEndpointCount: 2,
+      hubConfigured: true,
+    });
+    expect(body.chain).not.toHaveProperty('rpcUrl');
+    expect(body.chain).not.toHaveProperty('rpcUrls');
+    expect(body.chain).not.toHaveProperty('hubAddress');
   });
 
-  it('/api/chain/rpc-health preserves primary fields and adds per-endpoint probes', async () => {
+  it('/api/chain/rpc-health probes all endpoints without returning raw RPC URLs', async () => {
     rpcState.responses.set('https://primary.example/rpc', new Error('primary down'));
     rpcState.responses.set('https://backup.example/rpc', 456);
 
@@ -137,20 +144,28 @@ describe('status route multi-RPC shape', () => {
     const body: any = await res.json();
     expect(res.status).toBe(200);
     expect(body.ok).toBe(false);
-    expect(body.rpcUrl).toBe('https://primary.example/rpc');
-    expect(body.rpcUrls).toEqual(['https://backup.example/rpc']);
+    expect(body.configured).toBe(true);
+    expect(body.rpcEndpointCount).toBe(2);
+    expect(body).not.toHaveProperty('rpcUrl');
+    expect(body).not.toHaveProperty('rpcUrls');
     expect(body.blockNumber).toBeNull();
     expect(body.rpcs).toEqual([
       expect.objectContaining({
-        rpcUrl: 'https://primary.example/rpc',
+        index: 0,
+        role: 'primary',
         ok: false,
         blockNumber: null,
+        error: 'RPC health probe failed',
       }),
       expect.objectContaining({
-        rpcUrl: 'https://backup.example/rpc',
+        index: 1,
+        role: 'backup',
         ok: true,
         blockNumber: 456,
       }),
     ]);
+    for (const probe of body.rpcs) {
+      expect(probe).not.toHaveProperty('rpcUrl');
+    }
   });
 });

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
       ? ['test/daemon-http-behavior-extra.test.ts']
       : [
           'test/api-client.test.ts',
+          'test/config.test.ts',
+          'test/status-route-rpc.test.ts',
           'test/memory-graph-events.test.ts',
           'test/trust-endpoint-validation.test.ts',
           'test/daemon/plugin-loader.test.ts',

--- a/packages/core/src/crypto/workspace-encryption.ts
+++ b/packages/core/src/crypto/workspace-encryption.ts
@@ -297,7 +297,7 @@ export function encodeWorkspaceEncryptionKey(bytes: Uint8Array): string {
 
 export function decodeWorkspaceEncryptionKey(value: string): Uint8Array {
   const raw = value.trim();
-  const bytes = raw.startsWith('0x')
+  const bytes = /^0x[0-9a-fA-F]{64}$/.test(raw)
     ? Buffer.from(raw.slice(2), 'hex')
     : Buffer.from(padBase64(raw.replace(/-/g, '+').replace(/_/g, '/')), 'base64');
   const out = new Uint8Array(bytes);

--- a/packages/core/test/workspace-encryption.test.ts
+++ b/packages/core/test/workspace-encryption.test.ts
@@ -8,8 +8,10 @@ import {
   WORKSPACE_ENCRYPTION_KEY_BYTES,
   WORKSPACE_RECIPIENT_ENCRYPTION_KEY_PURPOSE,
   assertSupportedEncryptedWorkspaceEnvelope,
+  decodeWorkspaceEncryptionKey,
   decryptWorkspacePayload,
   encryptWorkspacePayload,
+  encodeWorkspaceEncryptionKey,
   generateWorkspaceRecipientEncryptionKey,
   type EncryptWorkspacePayloadInput,
   type WorkspaceRecipientEncryptionKey,
@@ -158,5 +160,13 @@ describe('workspace encrypted payload helpers', () => {
     expect(key.recipientKeyId).toBe('alice-key-1');
     expect(key.publicKeyBytes).toHaveLength(WORKSPACE_ENCRYPTION_KEY_BYTES);
     expect(key.privateKeyBytes).toHaveLength(WORKSPACE_ENCRYPTION_KEY_BYTES);
+  });
+
+  it('decodes base64url keys that happen to start with 0x', () => {
+    const encoded = `0x${'A'.repeat(41)}`;
+    const bytes = decodeWorkspaceEncryptionKey(encoded);
+
+    expect(bytes).toHaveLength(WORKSPACE_ENCRYPTION_KEY_BYTES);
+    expect(encodeWorkspaceEncryptionKey(bytes)).toBe(encoded);
   });
 });

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1827,7 +1827,22 @@ export const fetchWalletsBalances = () =>
     error?: string;
   }>('/api/wallets/balances');
 export const fetchRpcHealth = () =>
-  get<{ ok: boolean; rpcUrl: string | null; latencyMs: number | null; blockNumber: number | null; error?: string }>('/api/chain/rpc-health');
+  get<{
+    ok: boolean;
+    configured: boolean;
+    rpcEndpointCount: number;
+    latencyMs: number | null;
+    blockNumber: number | null;
+    error?: string;
+    rpcs: Array<{
+      index: number;
+      role: 'primary' | 'backup';
+      ok: boolean;
+      latencyMs: number | null;
+      blockNumber: number | null;
+      error?: string;
+    }>;
+  }>('/api/chain/rpc-health');
 
 // --- Node control ---
 export const shutdownNode = () =>

--- a/packages/publisher/test/async-lift-subtraction.test.ts
+++ b/packages/publisher/test/async-lift-subtraction.test.ts
@@ -4,7 +4,12 @@ import { GraphManager } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
-import { DKGPublisher, generateSubGraphRegistration } from '../src/index.js';
+import {
+  DKGPublisher,
+  generateSubGraphRegistration,
+  getConfirmedStatusQuad,
+  getTentativeStatusQuad,
+} from '../src/index.js';
 import { validateLiftPublishPayload } from '../src/async-lift-validation.js';
 import { subtractFinalizedExactQuads } from '../src/async-lift-subtraction.js';
 import type { LiftValidationInput } from '../src/async-lift-validation.js';
@@ -91,6 +96,12 @@ describe('subtractFinalizedExactQuads', () => {
         publisherPeerId: 'peer-1',
       },
     };
+  }
+
+  async function markTentativePublishConfirmed(result: { readonly ual: string; readonly status: string }): Promise<void> {
+    expect(result.status).toBe('tentative');
+    await store.delete([getTentativeStatusQuad(result.ual, CONTEXT_GRAPH)]);
+    await store.insert([getConfirmedStatusQuad(result.ual, CONTEXT_GRAPH)]);
   }
 
   it('removes only the exact finalized public quads and keeps the remainder', async () => {
@@ -186,12 +197,13 @@ describe('subtractFinalizedExactQuads', () => {
     };
     const validated = validateLiftPublishPayload(input);
 
-    await publisher.publish({
+    const publishResult = await publisher.publish({
       contextGraphId: CONTEXT_GRAPH,
       quads: validated.resolved.quads,
       privateQuads: validated.resolved.privateQuads,
       publisherPeerId: 'peer-1',
     });
+    await markTentativePublishConfirmed(publishResult);
 
     const result = await subtractFinalizedExactQuads({
       store,
@@ -222,12 +234,13 @@ describe('subtractFinalizedExactQuads', () => {
     };
     const validated = validateLiftPublishPayload(input);
 
-    await publisher.publish({
+    const publishResult = await publisher.publish({
       contextGraphId: CONTEXT_GRAPH,
       quads: validated.resolved.quads,
       privateQuads: validated.resolved.privateQuads,
       publisherPeerId: 'peer-1',
     });
+    await markTentativePublishConfirmed(publishResult);
 
     const result = await subtractFinalizedExactQuads({
       store,


### PR DESCRIPTION
## Summary

- add ordered `chain.rpcUrls` backup support across CLI config resolution, daemon lifecycle, publisher runner, and agent chain config plumbing
- add EVM provider failover: quorum-one read provider, sign-once raw transaction broadcast retries, receipt polling across all configured RPC endpoints, and deterministic-error stop conditions
- expose RPC backup visibility in status/wallet flows and add `/api/chain/rpc-health` per-endpoint health details

## Tests

- `pnpm --filter @origintrail-official/dkg-core build`
- `pnpm --filter @origintrail-official/dkg-storage build`
- `pnpm --filter @origintrail-official/dkg-chain build`
- `pnpm --filter @origintrail-official/dkg-publisher build`
- `pnpm --filter @origintrail-official/dkg-agent build`
- `pnpm --filter @origintrail-official/dkg build`
- `pnpm --filter @origintrail-official/dkg-chain exec vitest run --config vitest.unit.config.ts test/evm-adapter.unit.test.ts`
- `env DKG_HOME=/private/tmp/dkg-config-test pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/config.test.ts test/status-route-rpc.test.ts test/api-client.test.ts`

## Known issue observed

- `pnpm --filter @origintrail-official/dkg-publisher test` currently fails two existing tests in `test/async-lift-subtraction.test.ts`:
  - `removes finalized private IRI-object quads after store round-trip normalization`
  - `removes finalized private bare IRI-object quads after store round-trip normalization`

Those failures are in private-quad subtraction behavior and this PR does not touch `packages/publisher/src`.
