### PR TITLE
fix: rc.11 follow-up — address 11 unaddressed Codex findings from the #680 integration sweep

### DIFF
--- a/packages/chain/src/filter-error-silencer.ts
+++ b/packages/chain/src/filter-error-silencer.ts
@@ -123,8 +123,16 @@ export function formatProviderError(err: unknown): string {
 }
 
 function safeJson(value: unknown): string {
+  // Codex (#670#discussion_r3301775310): ethers error payloads commonly
+  // contain `bigint` fields (e.g. transaction values, chain ids), which
+  // `JSON.stringify` rejects with a TypeError. The previous fallback
+  // returned `"[object Object]"`, discarding the structured diagnostics
+  // this path is trying to preserve. Stringify bigints in a replacer so
+  // the serialized form survives the round-trip.
   try {
-    return JSON.stringify(value);
+    return JSON.stringify(value, (_key, v) =>
+      typeof v === 'bigint' ? v.toString() : v,
+    );
   } catch {
     return String(value);
   }

--- a/packages/chain/test/filter-error-silencer.test.ts
+++ b/packages/chain/test/filter-error-silencer.test.ts
@@ -121,6 +121,37 @@ describe('formatProviderError', () => {
     expect(formatted).toContain('"code":-32000');
     expect(formatted).toContain('eth_getFilterChanges');
   });
+
+  it('Codex #670 — preserves bigint payload fields instead of falling back to "[object Object]"', () => {
+    // Codex (#670#discussion_r3301775310): ethers error payloads commonly
+    // carry `bigint` fields (transaction values, chain ids, gas) inside
+    // the nested `info.error` / `data` blocks. The previous `JSON.stringify`
+    // call threw on these and the catch-fallback returned `String(value)`,
+    // which yields `"[object Object]"` for typical error objects —
+    // discarding the structured diagnostics this path is trying to
+    // preserve. The serializer now stringifies bigints in a replacer.
+    const err = Object.assign(new Error('insufficient funds for gas'), {
+      code: 'CALL_EXCEPTION',
+      info: {
+        error: {
+          code: -32000,
+          message: 'insufficient funds',
+          data: {
+            value: 12345678901234567890n,
+            chainId: 84532n,
+            gasLimit: 5_000_000n,
+          },
+        },
+      },
+    });
+    const formatted = formatProviderError(err);
+    expect(formatted).not.toContain('[object Object]');
+    expect(formatted).toContain('insufficient funds for gas');
+    expect(formatted).toContain('CALL_EXCEPTION');
+    expect(formatted).toContain('"value":"12345678901234567890"');
+    expect(formatted).toContain('"chainId":"84532"');
+    expect(formatted).toContain('"gasLimit":"5000000"');
+  });
 });
 
 describe('createFilterErrorSilencer', () => {

--- a/packages/chain/vitest.unit.config.ts
+++ b/packages/chain/vitest.unit.config.ts
@@ -11,9 +11,16 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Codex (#670#discussion_r3301775307): a hardcoded include list silently
+    // drops new `*.unit.test.ts` files added later. The original list missed
+    // `hub-resolution-cache.unit.test.ts` which had existed for several
+    // sprints. Use a glob so unit coverage stays auto-discovered. The
+    // explicit `filter-error-silencer.test.ts` entry is preserved because
+    // that file is pure-logic and does not follow the `.unit.test.ts`
+    // naming convention.
     include: [
+      'test/**/*.unit.test.ts',
       'test/filter-error-silencer.test.ts',
-      'test/evm-adapter.unit.test.ts',
     ],
     exclude: ['**/node_modules/**', '**/dist/**'],
     testTimeout: 30_000,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4059,6 +4059,7 @@ program
       renderPlan,
       findDkgMonorepoRootFromCwd,
       resolveMigrationDkgHome,
+      selectMigrationDkgHome,
     } = await import('./migrate-to-npm.js');
     const detectedRepoRoot = repoDir();
     const cwdRepoRoot = findDkgMonorepoRootFromCwd(process.cwd());
@@ -4073,21 +4074,33 @@ program
       console.log('No active git-checkout marker detected at this location (repoDir() === null).');
       console.log(`Continuing from ${repoRoot} so a partial migration can still repair config pins.`);
     }
-    // Codex review (3302171976): base the home on the LIVE CLI's install
-    // mode (detectedRepoRoot !== null) rather than the structural markers
-    // at repoRoot. The structural markers stay true after the load-bearing
-    // package.json rename, so a rerun from a partially-migrated checkout
-    // would otherwise still target ~/.dkg-dev while the standalone CLI
-    // already reads ~/.dkg.
-    const dkgHomeNow = resolveMigrationDkgHome({
+    // Codex review (3302171976 → #666#discussion_r3302712591): probe BOTH
+    // the monorepo-candidate home (~/.dkg-dev) and the standalone home
+    // (~/.dkg) for a live daemon before picking which one the migration
+    // targets. The previous code derived the home purely from the LIVE
+    // CLI's install mode via `repoDir()`, which is the WRONG signal when
+    // an operator runs a globally installed `dkg` from inside an
+    // unmigrated git checkout — `repoDir()` is null but the local daemon
+    // still writes to ~/.dkg-dev.
+    const homeSelection = await selectMigrationDkgHome({
+      repoRoot,
       detectedRepoRoot,
       homeDir: homedir(),
+      readPidFromHome,
+      isProcessRunning,
     });
+    if (homeSelection.recoveredGlobalCliInCheckout) {
+      console.log(
+        `Detected a live daemon at ${homeSelection.dkgHome} even though the running CLI is in standalone install-mode. ` +
+          `Using ${homeSelection.dkgHome} for migration so the orphan-state blocker and autoUpdate.source pin target the right config.`,
+      );
+    }
+    const dkgHomeNow = homeSelection.dkgHome;
+    const pid = homeSelection.pid;
     const dkgHomePostMigration = resolveMigrationDkgHome({
       detectedRepoRoot: null,
       homeDir: homedir(),
     });
-    const pid = await readPidFromHome(dkgHomeNow);
     const daemonAlive = pid !== null && isProcessRunning(pid);
     const currentAutoUpdateSource = await readAutoUpdateSourceFromHome(dkgHomeNow);
     const backupSuffix = new Date()

--- a/packages/cli/src/daemon/core-prereq-check.ts
+++ b/packages/cli/src/daemon/core-prereq-check.ts
@@ -259,7 +259,17 @@ function classifyIPv6(ipRaw: string): AddrClassification {
   const ip = ipRaw.toLowerCase();
   if (ip === '::') return 'reserved';
   if (ip === '::1') return 'loopback';
-  if (ip.startsWith('2001:db8:') || ip === '2001:db8::') return 'unknown';
+  // Codex #661 (discussion_r3302752877): bare-string `startsWith('2001:db8:')`
+  // misses valid zero-padded spellings like `2001:0db8::1`. Normalize by
+  // parsing the first two hextets numerically before comparing, so any
+  // documentation address inside `2001:db8::/32` (RFC 3849) is caught
+  // regardless of textual form.
+  const hextets = ip.split('::')[0]?.split(':') ?? [];
+  if (hextets.length >= 2) {
+    const h0 = parseInt(hextets[0], 16);
+    const h1 = parseInt(hextets[1], 16);
+    if (h0 === 0x2001 && h1 === 0x0db8) return 'unknown';
+  }
   if (/^fe[89ab][0-9a-f]?:/.test(ip)) return 'linkLocal';
   if (/^f[cd][0-9a-f]{2}:/.test(ip)) return 'ulaIpv6';
   if (/^ff[0-9a-f]{2}:/.test(ip)) return 'multicast';
@@ -306,7 +316,12 @@ function isPublicAnnounceAddress(
  *   - single-label (no dot)          → not a fully-qualified domain name
  */
 function isReservedDnsName(name: string): boolean {
-  const lower = name.toLowerCase();
+  // Codex #661 (discussion_r3302752890): FQDNs may carry a trailing root
+  // dot (e.g. `localhost.`, `relay.test.`, `svc.cluster.local.`); without
+  // stripping it the `.local`/`.test` suffix checks miss and a reserved
+  // name leaks through as a usable DNS host that would rescue a degraded
+  // listener.
+  const lower = name.toLowerCase().replace(/\.$/, '');
   if (lower === 'localhost') return true;
   if (lower.endsWith('.localhost')) return true;
   if (lower.endsWith('.local')) return true;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1274,6 +1274,18 @@ export async function runDaemonInner(
             process.exit(1);
             return;
           }
+        } else if (prereq.indeterminate) {
+          // Codex (#661#discussion_r3302752893): the DNS-rescue / warn-only
+          // path previously fell into the unconditional `OK` branch below
+          // and hid the indeterminate verdict the checker had just
+          // computed. Surface the reasons so operators see why the prereq
+          // sweep neither passed strictly nor failed; the lifecycle
+          // continues to boot since this is a soft rescue.
+          log(
+            `[CORE-PREREQ] INDETERMINATE: ${prereq.publicListenAddresses.length} ` +
+              `public-class listen address${prereq.publicListenAddresses.length === 1 ? '' : 'es'} bound. ` +
+              `reasons: ${prereq.reasons.join('; ')}.`,
+          );
         } else {
           log(
             `[CORE-PREREQ] OK: ${prereq.publicListenAddresses.length} ` +

--- a/packages/cli/src/daemon/nat-status.ts
+++ b/packages/cli/src/daemon/nat-status.ts
@@ -249,11 +249,11 @@ export function startNatStatusWatcher(opts: StartNatWatcherOpts): { stop(): void
   // external reach), the previous logic marked `private` as DEFINITIVE
   // — disabling the soft timeout and locking the verdict until a later
   // address-update event happened (which may never come on a stable
-  // private-only host). Treat the FIRST non-public reclassification the
-  // same as the initial bound-address snapshot: report it via the cache
-  // for `/api/status` observability, but DO NOT mark it definitive. Only
-  // the soft-timeout or a SUBSEQUENT non-public event escalates to
-  // definitive.
+  // private-only host). Treat the FIRST non-public, non-unknown
+  // reclassification the same as the initial bound-address snapshot:
+  // report it via the cache for `/api/status` observability, but DO NOT
+  // mark it definitive. Only the soft-timeout or a SUBSEQUENT non-public
+  // event escalates to definitive.
   let sawAnyEventReclassify = false;
 
   const reclassify = (cause: 'event' | 'soft-timeout' | 'initial'): NatStatus => {
@@ -278,7 +278,7 @@ export function startNatStatusWatcher(opts: StartNatWatcherOpts): { stop(): void
       }
       return next;
     }
-    if (cause === 'event') {
+    if (cause === 'event' && next !== 'unknown') {
       sawAnyEventReclassify = true;
     }
     if (next !== 'unknown') {

--- a/packages/cli/src/daemon/nat-status.ts
+++ b/packages/cli/src/daemon/nat-status.ts
@@ -242,6 +242,20 @@ export function startNatStatusWatcher(opts: StartNatWatcherOpts): { stop(): void
   let softTimer: ReturnType<typeof setTimeout> | null = null;
   let sawDefinitiveClassification = false;
 
+  // Codex (#668#discussion_r3302734688): the very first `self:peer:update`
+  // also fires for the initial post-listen peer record AutoNAT publishes
+  // when the daemon binds. If that record contains only RFC1918/CGNAT
+  // multiaddrs (common during a cold boot before AutoNAT has verified
+  // external reach), the previous logic marked `private` as DEFINITIVE
+  // — disabling the soft timeout and locking the verdict until a later
+  // address-update event happened (which may never come on a stable
+  // private-only host). Treat the FIRST non-public reclassification the
+  // same as the initial bound-address snapshot: report it via the cache
+  // for `/api/status` observability, but DO NOT mark it definitive. Only
+  // the soft-timeout or a SUBSEQUENT non-public event escalates to
+  // definitive.
+  let sawAnyEventReclassify = false;
+
   const reclassify = (cause: 'event' | 'soft-timeout' | 'initial'): NatStatus => {
     if (stopped) return cachedNatStatus;
     const addrs = opts.node.getMultiaddrs().map((ma) => ma.toString());
@@ -251,6 +265,21 @@ export function startNatStatusWatcher(opts: StartNatWatcherOpts): { stop(): void
       // AutoNAT has not necessarily updated the peer record yet, so do not
       // turn RFC1918/CGNAT binds into a definitive private verdict here.
       return cachedNatStatus;
+    }
+    if (cause === 'event' && next === 'private' && !sawAnyEventReclassify) {
+      // First post-listen `self:peer:update` is still effectively the
+      // bound-address baseline — AutoNAT may not have published a
+      // verified external address yet. See Codex #668 note above.
+      sawAnyEventReclassify = true;
+      const previous = cachedNatStatus;
+      if (next !== previous) {
+        cachedNatStatus = next;
+        opts.onClassification?.(next, previous);
+      }
+      return next;
+    }
+    if (cause === 'event') {
+      sawAnyEventReclassify = true;
     }
     if (next !== 'unknown') {
       sawDefinitiveClassification = true;

--- a/packages/cli/src/daemon/supervisor-liveness.ts
+++ b/packages/cli/src/daemon/supervisor-liveness.ts
@@ -218,6 +218,7 @@ export function startLivenessWatcher(opts: LivenessWatcherOpts): { stop(): void 
         if (inShutdown) {
           if (shutdownObservedAt === null) {
             shutdownObservedAt = Date.now();
+            consecutiveFailures = 0;
           }
           const elapsedMs = Date.now() - shutdownObservedAt;
           // Within the grace window OR the operator opted out of the
@@ -225,6 +226,7 @@ export function startLivenessWatcher(opts: LivenessWatcherOpts): { stop(): void 
           // counting so the worker's own graceful teardown can complete
           // without supervisor interference.
           if (shutdownGraceMs < 0 || elapsedMs < shutdownGraceMs) {
+            consecutiveFailures = 0;
             return;
           }
           // Grace window exceeded: fall through and count this as a real

--- a/packages/cli/src/daemon/supervisor-liveness.ts
+++ b/packages/cli/src/daemon/supervisor-liveness.ts
@@ -131,18 +131,34 @@ export interface LivenessWatcherOpts {
   /**
    * Optional graceful-shutdown detector. Called on every failed probe BEFORE
    * the consecutive-failure counter is incremented. If it returns truthy, the
-   * watcher disarms — the worker is in the slow tail of an intentional
-   * shutdown (e.g. `agent.stop()` / DB close after `server.close()`), and
-   * SIGKILLing now would skip the rest of teardown.
+   * watcher enters a bounded shutdown-grace window — failed probes during
+   * this window do not count toward the SIGKILL threshold so we don't
+   * SIGKILL the worker mid-teardown (e.g. `agent.stop()` / DB close after
+   * `server.close()`).
    *
    * The supervisor wires this to `existsSync(apiPortFile) === false`: the
    * worker's `shutdown()` removes `api.port` BEFORE the slow awaits, so its
    * absence is the "graceful shutdown initiated" signal the watcher needs.
-   * Without this check, a slow cleanup tail (or future `SHUTDOWN_HARD_TIMEOUT_MS`
-   * bump above ~2.5 min) would race with `consecutiveFailuresToKill * intervalMs`
-   * and SIGKILL the worker mid-teardown.
+   *
+   * Codex (#664#discussion_r3302432762): the previous implementation
+   * PERMANENTLY disarmed the watcher on the first shutdown observation.
+   * If a later teardown step hung (DB close, network shutdown, …), the
+   * supervisor could no longer SIGKILL or respawn the worker. The fix:
+   * keep probing during shutdown, but only fire SIGKILL after a bounded
+   * grace window (`shutdownGraceMs`) so the worker's own
+   * SHUTDOWN_HARD_TIMEOUT_MS gets first crack at force-exiting itself.
    */
   isShuttingDown?: () => boolean | Promise<boolean>;
+  /**
+   * Maximum time to wait after the worker enters graceful shutdown before
+   * the watcher resumes counting failures toward `consecutiveFailuresToKill`.
+   * Default is 2× `SHUTDOWN_HARD_TIMEOUT_MS` (30s) — comfortably longer than
+   * the daemon's own self-force-exit deadline so a healthy graceful shutdown
+   * finishes inside the window; only a wedged teardown reaches the SIGKILL
+   * path. Set to a negative value to disable the bounded fallback (legacy
+   * "disarm forever" behavior).
+   */
+  shutdownGraceMs?: number;
 }
 
 /**
@@ -161,10 +177,17 @@ export function startLivenessWatcher(opts: LivenessWatcherOpts): { stop(): void 
   const threshold = opts.consecutiveFailuresToKill ?? LIVENESS_CONSECUTIVE_FAILURES_TO_KILL;
   const probe = opts.probe ?? probeWorkerAlive;
   const host = opts.host ?? '127.0.0.1';
+  // Default to 2× the worker's own hard-shutdown deadline; if the worker's
+  // self-force-exit fires first the watcher never needs to kill anyway.
+  const shutdownGraceMs = opts.shutdownGraceMs ?? 2 * 15_000;
 
   let consecutiveFailures = 0;
   let probing = false;
   let stopped = false;
+  // Codex #664: track WHEN graceful shutdown was first observed so we can
+  // re-arm the SIGKILL path after `shutdownGraceMs` expires. `null` means
+  // we are not in graceful-shutdown mode yet.
+  let shutdownObservedAt: number | null = null;
 
   const tick = async () => {
     if (stopped || probing) return;
@@ -174,28 +197,45 @@ export function startLivenessWatcher(opts: LivenessWatcherOpts): { stop(): void 
       if (stopped) return;
       if (alive) {
         consecutiveFailures = 0;
+        // A successful probe AFTER shutdown was observed means the worker
+        // re-bound the listener (extremely unlikely on the shutdown path)
+        // or the file-based detector lied. Re-arm the watcher.
+        shutdownObservedAt = null;
         return;
       }
-      // Probe failed. Before counting it toward the SIGKILL threshold,
-      // ask the supervisor whether the worker is in a graceful shutdown
-      // (api.port file absent — see `LivenessWatcherOpts.isShuttingDown`).
-      // If so, disarm the watcher: SIGKILLing now would bypass `agent.stop()`,
-      // DB close, and pid cleanup, leaving local state dirty.
+      // Probe failed. Before counting toward the SIGKILL threshold, check
+      // graceful-shutdown state. We DO NOT permanently disarm here — see
+      // Codex #664#discussion_r3302432762: a watcher that stays disarmed
+      // for the whole shutdown tail can never recover the process if a
+      // later await hangs (DB close, network shutdown, …).
       if (opts.isShuttingDown) {
+        let inShutdown = false;
         try {
-          if (await opts.isShuttingDown()) {
-            stopped = true;
-            return;
-          }
+          inShutdown = !!(await opts.isShuttingDown());
         } catch {
           /* shutdown detector errors shouldn't unconditionally arm the SIGKILL path; treat as "still alive" and keep counting failures. */
+        }
+        if (inShutdown) {
+          if (shutdownObservedAt === null) {
+            shutdownObservedAt = Date.now();
+          }
+          const elapsedMs = Date.now() - shutdownObservedAt;
+          // Within the grace window OR the operator opted out of the
+          // bounded fallback (`shutdownGraceMs < 0`): suppress failure
+          // counting so the worker's own graceful teardown can complete
+          // without supervisor interference.
+          if (shutdownGraceMs < 0 || elapsedMs < shutdownGraceMs) {
+            return;
+          }
+          // Grace window exceeded: fall through and count this as a real
+          // failure so a wedged teardown still gets SIGKILLed + respawned.
+        } else {
+          shutdownObservedAt = null;
         }
       }
       consecutiveFailures += 1;
       opts.onFailure?.(consecutiveFailures);
       if (consecutiveFailures >= threshold) {
-        // Reset BEFORE firing the kill — otherwise a slow respawn would
-        // hit the threshold again before the new worker's listener binds.
         consecutiveFailures = 0;
         opts.onUnresponsive();
       }

--- a/packages/cli/src/daemon/worker/async-promote-worker.ts
+++ b/packages/cli/src/daemon/worker/async-promote-worker.ts
@@ -112,6 +112,13 @@ export interface PromoteWorkerCounters {
   succeeded: number;
   failedTerminal: number;
   failedRetrying: number;
+  /**
+   * Codex #665: jobs whose promote ran successfully but whose post-promote
+   * bookkeeping (commit-marker write / queue.succeed) failed mid-flight.
+   * These remain in `running` state until next startup recovery; operators
+   * MUST inspect SWM/VM before any explicit `/recover`.
+   */
+  partialPromoteAmbiguity: number;
   /** Number of `runJob` invocations that started (regardless of outcome). */
   attempted: number;
   /** Set when shuttingDown was hit mid-job; ops can correlate with abandoned counts at next startup. */
@@ -198,7 +205,14 @@ export async function runPromoteJob(
     log: (msg: string) => void;
     emitMemoryGraphChanged?: (event: PromoteMemoryGraphChangedEvent) => void;
   },
-): Promise<{ outcome: 'succeeded' | 'failed_retrying' | 'failed_terminal'; error?: ClassifiedPromoteError }> {
+): Promise<{
+  outcome:
+    | 'succeeded'
+    | 'failed_retrying'
+    | 'failed_terminal'
+    | 'partial_promote_ambiguity';
+  error?: ClassifiedPromoteError;
+}> {
   const { job, queue, runPromote, now, heartbeatIntervalMs, log, emitMemoryGraphChanged } = args;
   if (!job.lease) {
     throw new Error(`runPromoteJob requires a job with an active lease (jobId=${job.jobId})`);
@@ -259,11 +273,48 @@ export async function runPromoteJob(
     // `assertionPromote` returns. We can't observe the internal phases
     // (WM clean / lifecycle stamp / gossip), so only stamp the recovery
     // gate the queue actually consumes.
-    await queue.recordCommitMarker(job.jobId, claimToken, 'swmInserted');
-    await queue.succeed(job.jobId, claimToken, {
-      promotedCount: result.promotedCount,
-      succeededAt: now(),
-    });
+    //
+    // Codex (#665#discussion_r3302646439): `assertion.promote()` has
+    // ALREADY mutated SWM / gossiped data at this point. If either of
+    // the next two writes throws (store hiccup, lost lease, transient
+    // FS error, …), we MUST NOT let the outer worker catch park this
+    // job as a normal `failed` row — that would expose it to
+    // `/promote-async/{jobId}/recover`, which blindly re-queues
+    // `failed` jobs. Re-running an already-completed promote risks
+    // duplicate WM/SWM writes and re-gossip. Instead, return the
+    // dedicated `partial_promote_ambiguity` outcome so the supervisor
+    // leaves the job in `running` state; on next daemon boot the lease
+    // will have expired and `recoverOnStartup()` will correctly route
+    // it into the "abandoned partial promote" bucket (promoteStarted
+    // = true, swmInserted = false → operator action required).
+    try {
+      await queue.recordCommitMarker(job.jobId, claimToken, 'swmInserted');
+      await queue.succeed(job.jobId, claimToken, {
+        promotedCount: result.promotedCount,
+        succeededAt: now(),
+      });
+    } catch (bookkeepingErr: unknown) {
+      const message =
+        bookkeepingErr instanceof Error
+          ? bookkeepingErr.message
+          : String(bookkeepingErr);
+      log(
+        `PARTIAL-PROMOTE-AMBIGUITY: jobId=${job.jobId} ` +
+          `assertion.promote() returned successfully (promotedCount=${result.promotedCount}) ` +
+          `but post-promote bookkeeping failed: ${message}. ` +
+          `Leaving job in 'running' state; recoverOnStartup() will pick this up ` +
+          `on next boot as abandoned partial promote. ` +
+          `Operator action: inspect SWM/VM for the assertion before any /recover.`,
+      );
+      return {
+        outcome: 'partial_promote_ambiguity',
+        error: {
+          retryable: false,
+          classification: 'fatal',
+          message: `partial-promote ambiguity (post-promote bookkeeping failed): ${message}`,
+        },
+      };
+    }
 
     if (result.promotedCount > 0 && emitMemoryGraphChanged) {
       try {
@@ -320,7 +371,14 @@ export function createPromoteWorkerSupervisor(config: PromoteWorkerConfig): Prom
   let counters: PromoteWorkerCounters = freshCounters();
 
   function freshCounters(): PromoteWorkerCounters {
-    return { succeeded: 0, failedTerminal: 0, failedRetrying: 0, attempted: 0, interruptedAtShutdown: 0 };
+    return {
+      succeeded: 0,
+      failedTerminal: 0,
+      failedRetrying: 0,
+      partialPromoteAmbiguity: 0,
+      attempted: 0,
+      interruptedAtShutdown: 0,
+    };
   }
 
   async function tickSlot(slot: WorkerSlot): Promise<boolean> {
@@ -365,6 +423,9 @@ export function createPromoteWorkerSupervisor(config: PromoteWorkerConfig): Prom
             break;
           case 'failed_terminal':
             counters.failedTerminal += 1;
+            break;
+          case 'partial_promote_ambiguity':
+            counters.partialPromoteAmbiguity += 1;
             break;
         }
       } catch (err: unknown) {

--- a/packages/cli/src/daemon/worker/async-promote-worker.ts
+++ b/packages/cli/src/daemon/worker/async-promote-worker.ts
@@ -128,6 +128,7 @@ export interface PromoteWorkerCounters {
 export type ClassifiedPromoteError = {
   classification: PromoteFailureClassification;
   retryable: boolean;
+  message?: string;
 };
 
 /**
@@ -440,12 +441,13 @@ export function createPromoteWorkerSupervisor(config: PromoteWorkerConfig): Prom
               recordedAt: now(),
             });
           } catch (failErr: unknown) {
+            const failMessage = failErr instanceof Error ? failErr.message : String(failErr);
             if (failErr instanceof PromoteJobLeaseError) {
-              log(`Lease lost while parking crashed job ${claimed.jobId}: ${failErr.message}`);
+              log(`Lease lost while parking crashed job ${claimed.jobId}: ${failMessage}`);
             } else {
               log(
                 `Failed to park crashed job ${claimed.jobId}; next startup recovery must reconcile it: ` +
-                  `${failErr instanceof Error ? failErr.message : String(failErr)}`,
+                  `${failMessage}`,
               );
             }
           }

--- a/packages/cli/src/migrate-to-npm.ts
+++ b/packages/cli/src/migrate-to-npm.ts
@@ -597,42 +597,41 @@ export function selectMigrationDkgHome(opts: {
   configExists?: boolean;
 }): Promise<MigrationHomeSelection> {
   return (async () => {
-    const monorepoCandidate = resolveMigrationDkgHome({
-      detectedRepoRoot: opts.repoRoot,
-      homeDir: opts.homeDir,
-      env: opts.env,
-      configExists: opts.configExists,
-    });
-    const standaloneCandidate = resolveMigrationDkgHome({
-      detectedRepoRoot: null,
-      homeDir: opts.homeDir,
-      env: opts.env,
-      configExists: opts.configExists,
-    });
-    const monorepoPid =
-      monorepoCandidate !== standaloneCandidate
-        ? await opts.readPidFromHome(monorepoCandidate)
-        : null;
-    const standalonePid = await opts.readPidFromHome(standaloneCandidate);
-    const monorepoAlive =
-      monorepoPid !== null && opts.isProcessRunning(monorepoPid);
-    const standaloneAlive =
-      standalonePid !== null && opts.isProcessRunning(standalonePid);
+    const monorepoCandidate = join(opts.homeDir, '.dkg-dev');
+    const standaloneCandidate = join(opts.homeDir, '.dkg');
+    const candidates: string[] = [];
+    const addCandidate = (candidate: string | undefined): void => {
+      if (candidate && !candidates.includes(candidate)) candidates.push(candidate);
+    };
+    addCandidate(opts.env?.DKG_HOME);
+    addCandidate(monorepoCandidate);
+    addCandidate(standaloneCandidate);
 
-    if (monorepoAlive) {
+    const live: Array<{ dkgHome: string; pid: number }> = [];
+    for (const dkgHome of candidates) {
+      const pid = await opts.readPidFromHome(dkgHome);
+      if (pid !== null && opts.isProcessRunning(pid)) {
+        live.push({ dkgHome, pid });
+      }
+    }
+
+    if (live.length > 1) {
+      const detail = live.map((entry) => `${entry.dkgHome} (pid ${entry.pid})`).join(', ');
+      throw new Error(
+        `Multiple live DKG daemons detected while selecting migration home: ${detail}. ` +
+          `Stop all but the daemon you intend to migrate, then rerun dkg migrate-to-npm.`,
+      );
+    }
+
+    if (live.length === 1) {
+      const selected = live[0]!;
       return {
-        dkgHome: monorepoCandidate,
-        pid: monorepoPid,
+        dkgHome: selected.dkgHome,
+        pid: selected.pid,
         recoveredGlobalCliInCheckout:
           opts.detectedRepoRoot === null &&
+          selected.dkgHome === monorepoCandidate &&
           monorepoCandidate !== standaloneCandidate,
-      };
-    }
-    if (standaloneAlive) {
-      return {
-        dkgHome: standaloneCandidate,
-        pid: standalonePid,
-        recoveredGlobalCliInCheckout: false,
       };
     }
     const fallback = resolveMigrationDkgHome({

--- a/packages/cli/src/migrate-to-npm.ts
+++ b/packages/cli/src/migrate-to-npm.ts
@@ -547,3 +547,104 @@ export function resolveMigrationDkgHome(opts: {
     configExists: opts.configExists,
   });
 }
+
+/**
+ * Result of `selectMigrationDkgHome()` — the home the migration should
+ * read/write from, the pid found there (if any), and whether the
+ * monorepo-candidate had a live daemon despite the executing CLI being
+ * in standalone install-mode (operator messaging hint).
+ */
+export interface MigrationHomeSelection {
+  dkgHome: string;
+  pid: number | null;
+  /**
+   * True when a live daemon was found at the monorepo-candidate home
+   * AND the executing CLI is itself in standalone install-mode. This
+   * is the global-CLI-in-checkout case from Codex
+   * #666#discussion_r3302712591 — operators need an explicit log line
+   * so they aren't surprised by the home selection.
+   */
+  recoveredGlobalCliInCheckout: boolean;
+}
+
+/**
+ * Pick the DKG home the migration should target by probing BOTH the
+ * monorepo-mode home (`~/.dkg-dev`) and the standalone home (`~/.dkg`)
+ * for an active daemon. Falls back to `resolveMigrationDkgHome()` when
+ * neither home has a running daemon (greenfield migration).
+ *
+ * Codex (#666#discussion_r3302712591): the previous logic derived the
+ * home purely from the LIVE CLI's install mode via `repoDir()`. When
+ * an operator runs a globally installed `dkg` (standalone CLI →
+ * `repoDir() === null`) from inside an unmigrated git checkout, that
+ * call resolved to `~/.dkg` and missed the live daemon running out of
+ * `~/.dkg-dev`. The migration then wrote `autoUpdate.source` into the
+ * wrong config and bypassed the orphan-state blocker.
+ *
+ * `repoRoot` is the structural checkout (`findDkgMonorepoRootFromCwd`)
+ * — used to compute the monorepo-candidate home regardless of how the
+ * live CLI sees its own install mode. `detectedRepoRoot` is the LIVE
+ * CLI's `repoDir()` — used purely to set `recoveredGlobalCliInCheckout`
+ * so callers can log the divergence.
+ */
+export function selectMigrationDkgHome(opts: {
+  repoRoot: string;
+  detectedRepoRoot: string | null;
+  homeDir: string;
+  readPidFromHome: (dkgHome: string) => Promise<number | null> | number | null;
+  isProcessRunning: (pid: number) => boolean;
+  env?: Pick<NodeJS.ProcessEnv, 'DKG_HOME'>;
+  configExists?: boolean;
+}): Promise<MigrationHomeSelection> {
+  return (async () => {
+    const monorepoCandidate = resolveMigrationDkgHome({
+      detectedRepoRoot: opts.repoRoot,
+      homeDir: opts.homeDir,
+      env: opts.env,
+      configExists: opts.configExists,
+    });
+    const standaloneCandidate = resolveMigrationDkgHome({
+      detectedRepoRoot: null,
+      homeDir: opts.homeDir,
+      env: opts.env,
+      configExists: opts.configExists,
+    });
+    const monorepoPid =
+      monorepoCandidate !== standaloneCandidate
+        ? await opts.readPidFromHome(monorepoCandidate)
+        : null;
+    const standalonePid = await opts.readPidFromHome(standaloneCandidate);
+    const monorepoAlive =
+      monorepoPid !== null && opts.isProcessRunning(monorepoPid);
+    const standaloneAlive =
+      standalonePid !== null && opts.isProcessRunning(standalonePid);
+
+    if (monorepoAlive) {
+      return {
+        dkgHome: monorepoCandidate,
+        pid: monorepoPid,
+        recoveredGlobalCliInCheckout:
+          opts.detectedRepoRoot === null &&
+          monorepoCandidate !== standaloneCandidate,
+      };
+    }
+    if (standaloneAlive) {
+      return {
+        dkgHome: standaloneCandidate,
+        pid: standalonePid,
+        recoveredGlobalCliInCheckout: false,
+      };
+    }
+    const fallback = resolveMigrationDkgHome({
+      detectedRepoRoot: opts.detectedRepoRoot,
+      homeDir: opts.homeDir,
+      env: opts.env,
+      configExists: opts.configExists,
+    });
+    return {
+      dkgHome: fallback,
+      pid: await opts.readPidFromHome(fallback),
+      recoveredGlobalCliInCheckout: false,
+    };
+  })();
+}

--- a/packages/cli/test/async-promote-worker.test.ts
+++ b/packages/cli/test/async-promote-worker.test.ts
@@ -211,14 +211,21 @@ describe('runPromoteJob', () => {
     expect(result.outcome).toBe('partial_promote_ambiguity');
     expect(result.error?.classification).toBe('fatal');
     expect(result.error?.retryable).toBe(false);
-    // Job remains in `running` state — NOT `failed` — so /recover cannot
-    // re-promote it.
+    // Job remains in `running` state until lease expiry — NOT immediately
+    // `failed` — so /recover cannot re-promote it during the unsafe window.
     const final = await queue.getStatus(job.jobId);
     expect(final?.state).toBe('running');
     expect(final?.commitMarker?.promoteStarted).toBe(true);
     expect(final?.commitMarker?.swmInserted).toBe(false);
     // The loud log line operators need to see.
     expect(logs.some((l) => l.includes('PARTIAL-PROMOTE-AMBIGUITY'))).toBe(true);
+
+    now += 6 * 60 * 1000;
+    await queue.claimNext('worker-after-lease-expiry');
+    const reconciled = await queue.getStatus(job.jobId);
+    expect(reconciled?.state).toBe('failed');
+    expect(reconciled?.reason).toContain('partial promote ambiguity');
+    await expect(queue.recover(job.jobId)).rejects.toThrow(/Cannot recover job job-1: partial promote ambiguity/);
   });
 
   it('emits memoryGraphChanged on successful promote with >0 triples', async () => {

--- a/packages/cli/test/async-promote-worker.test.ts
+++ b/packages/cli/test/async-promote-worker.test.ts
@@ -171,6 +171,56 @@ describe('runPromoteJob', () => {
     expect(final?.result?.promotedCount).toBe(42);
   });
 
+  it('Codex #665 — post-promote bookkeeping failure returns partial_promote_ambiguity and leaves job running', async () => {
+    // Codex (#665#discussion_r3302646439): if `assertion.promote()` has
+    // already returned successfully and the next `recordCommitMarker
+    // ('swmInserted')` or `queue.succeed()` write fails (store hiccup,
+    // lost lease, transient FS error, …), the previous behavior let the
+    // outer worker catch park the job as `failed` with retryable=false.
+    // Re-running through `/promote-async/{jobId}/recover` would then
+    // promote already-promoted data — duplicate WM/SWM writes + re-gossip.
+    //
+    // The fix returns `partial_promote_ambiguity` and DOES NOT call
+    // queue.fail(). The job stays in `running` state until the lease
+    // expires; recoverOnStartup() then routes it into the abandoned
+    // partial-promote bucket on next daemon boot.
+    const job = await enqueueAndClaim();
+    const failingQueue: AsyncPromoteQueue = {
+      ...queue,
+      recordCommitMarker: async (jobId, claimToken, step) => {
+        if (step === 'swmInserted') {
+          throw new Error('simulated store hiccup');
+        }
+        return queue.recordCommitMarker(jobId, claimToken, step);
+      },
+    } as AsyncPromoteQueue;
+
+    const result = await runPromoteJob({
+      job,
+      queue: failingQueue,
+      workerId: 'worker-test',
+      runPromote: async (_request, markPromoteStarted) => {
+        await markPromoteStarted();
+        return { promotedCount: 99 };
+      },
+      now: () => now,
+      heartbeatIntervalMs: 0,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.outcome).toBe('partial_promote_ambiguity');
+    expect(result.error?.classification).toBe('fatal');
+    expect(result.error?.retryable).toBe(false);
+    // Job remains in `running` state — NOT `failed` — so /recover cannot
+    // re-promote it.
+    const final = await queue.getStatus(job.jobId);
+    expect(final?.state).toBe('running');
+    expect(final?.commitMarker?.promoteStarted).toBe(true);
+    expect(final?.commitMarker?.swmInserted).toBe(false);
+    // The loud log line operators need to see.
+    expect(logs.some((l) => l.includes('PARTIAL-PROMOTE-AMBIGUITY'))).toBe(true);
+  });
+
   it('emits memoryGraphChanged on successful promote with >0 triples', async () => {
     const events: any[] = [];
     const job = await enqueueAndClaim();

--- a/packages/cli/test/core-prereq-check.test.ts
+++ b/packages/cli/test/core-prereq-check.test.ts
@@ -89,6 +89,8 @@ describe('classifyMultiaddr — per-class smoke tests', () => {
     ['/ip6/ff02::1/tcp/4001',         'multicast'],
     ['/ip6/2606:4700:4700::1111/tcp/4001', 'public'],
     ['/ip6/2001:db8::1/tcp/4001',     'unknown'],  // RFC 3849 documentation range
+    ['/ip6/2001:0db8::1/tcp/4001',    'unknown'],  // Codex #661 regression — zero-padded
+    ['/ip6/2001:0db8:0000:0000::1/tcp/4001', 'unknown'],  // Codex #661 regression — fully expanded
     ['/dns4/example.com/tcp/4001',    'dns'],
     ['/dns6/example.com/tcp/4001',    'dns'],
     ['/dns/example.com/tcp/4001',     'dns'],
@@ -245,6 +247,27 @@ describe('checkCoreRelayPrereqs — 7 canonical cases from the plan', () => {
     expect(result.indeterminate).toBe(true);
     expect(result.nonRoutableAddresses[0].class).toBe('rfc1918');
     expect(result.reasons.some((r) => r.includes('DNS hostname'))).toBe(true);
+  });
+
+  it('Codex #661 — reserved DNS announce WITH trailing root dot is not a rescue', () => {
+    // Codex (#661#discussion_r3302752890): `isReservedDnsName()` previously
+    // missed FQDNs with a trailing root dot, so `localhost.`, `relay.test.`,
+    // `svc.cluster.local.` could rescue a degraded RFC1918 listener even
+    // though they are reserved by RFC 6761 and not externally dialable.
+    for (const announce of [
+      '/dnsaddr/localhost.',
+      '/dns4/relay.test.',
+      '/dns/svc.cluster.local.',
+    ]) {
+      const result = checkCoreRelayPrereqs({
+        listenAddresses: ['/ip4/192.168.1.1/tcp/4001'],
+        hostInterfaces: [RFC1918_IFACE],
+        announceAddresses: [announce],
+        nodeRole: 'core',
+      });
+      // No rescue: looksDegraded stays true, no `indeterminate` warn-only escape.
+      expect(result.looksDegraded).toBe(true);
+    }
   });
 
   it('literal public announce can rescue an unresolved wildcard pre-start listener', () => {

--- a/packages/cli/test/migrate-to-npm.test.ts
+++ b/packages/cli/test/migrate-to-npm.test.ts
@@ -685,6 +685,32 @@ describe('selectMigrationDkgHome — Codex #666 probe-both-homes', () => {
     expect(result.recoveredGlobalCliInCheckout).toBe(true);
   });
 
+  it('probes ~/.dkg-dev even when standalone ~/.dkg config exists', async () => {
+    const result = await selectMigrationDkgHome({
+      repoRoot: '/home/op/dkg-v9',
+      detectedRepoRoot: null,
+      homeDir: '/home/op',
+      configExists: true,
+      readPidFromHome: async (home) =>
+        home === '/home/op/.dkg-dev' ? 4343 : null,
+      isProcessRunning: (pid) => pid === 4343,
+    });
+    expect(result.dkgHome).toBe('/home/op/.dkg-dev');
+    expect(result.pid).toBe(4343);
+    expect(result.recoveredGlobalCliInCheckout).toBe(true);
+  });
+
+  it('refuses ambiguous migration when both monorepo and standalone daemons are alive', async () => {
+    await expect(selectMigrationDkgHome({
+      repoRoot: '/home/op/dkg-v9',
+      detectedRepoRoot: null,
+      homeDir: '/home/op',
+      readPidFromHome: async (home) =>
+        home === '/home/op/.dkg-dev' ? 4242 : home === '/home/op/.dkg' ? 6666 : null,
+      isProcessRunning: () => true,
+    })).rejects.toThrow(/Multiple live DKG daemons detected/);
+  });
+
   it('greenfield (no daemons): falls back to install-mode resolution', async () => {
     const standalone = await selectMigrationDkgHome({
       repoRoot: '/home/op/dkg-v9',

--- a/packages/cli/test/migrate-to-npm.test.ts
+++ b/packages/cli/test/migrate-to-npm.test.ts
@@ -24,6 +24,7 @@ import {
   renderPlan,
   findDkgMonorepoRootFromCwd,
   resolveMigrationDkgHome,
+  selectMigrationDkgHome,
   type ApplyPlanIo,
   type MigrationPlan,
 } from '../src/migrate-to-npm.js';
@@ -656,5 +657,92 @@ describe('resolveMigrationDkgHome — partial-migration home selection', () => {
       configExists: true,
     });
     expect(home).toBe('/home/op/.dkg');
+  });
+});
+
+describe('selectMigrationDkgHome — Codex #666 probe-both-homes', () => {
+  // Codex (#666#discussion_r3302712591): when a globally-installed `dkg`
+  // CLI (standalone install-mode) is run from inside an unmigrated git
+  // checkout, `repoDir() === null`, but the local daemon is still
+  // writing to ~/.dkg-dev. The previous code derived the home purely
+  // from the executing CLI's install mode and missed the live daemon,
+  // so the orphan-state blocker silently skipped and `autoUpdate.source`
+  // landed in the wrong config.
+  const noopReadPid = async (_h: string) => null;
+  const noopRunning = (_pid: number) => false;
+
+  it('global CLI in unmigrated checkout: picks ~/.dkg-dev when a daemon is alive there', async () => {
+    const result = await selectMigrationDkgHome({
+      repoRoot: '/home/op/dkg-v9',
+      detectedRepoRoot: null,
+      homeDir: '/home/op',
+      readPidFromHome: async (home) =>
+        home === '/home/op/.dkg-dev' ? 4242 : null,
+      isProcessRunning: (pid) => pid === 4242,
+    });
+    expect(result.dkgHome).toBe('/home/op/.dkg-dev');
+    expect(result.pid).toBe(4242);
+    expect(result.recoveredGlobalCliInCheckout).toBe(true);
+  });
+
+  it('greenfield (no daemons): falls back to install-mode resolution', async () => {
+    const standalone = await selectMigrationDkgHome({
+      repoRoot: '/home/op/dkg-v9',
+      detectedRepoRoot: null,
+      homeDir: '/home/op',
+      readPidFromHome: noopReadPid,
+      isProcessRunning: noopRunning,
+    });
+    expect(standalone.dkgHome).toBe('/home/op/.dkg');
+    expect(standalone.pid).toBeNull();
+    expect(standalone.recoveredGlobalCliInCheckout).toBe(false);
+
+    const monorepo = await selectMigrationDkgHome({
+      repoRoot: '/home/op/dkg-v9',
+      detectedRepoRoot: '/home/op/dkg-v9',
+      homeDir: '/home/op',
+      readPidFromHome: noopReadPid,
+      isProcessRunning: noopRunning,
+    });
+    expect(monorepo.dkgHome).toBe('/home/op/.dkg-dev');
+  });
+
+  it('monorepo CLI matches monorepo daemon: no flag, no recovery message', async () => {
+    const result = await selectMigrationDkgHome({
+      repoRoot: '/home/op/dkg-v9',
+      detectedRepoRoot: '/home/op/dkg-v9',
+      homeDir: '/home/op',
+      readPidFromHome: async (home) =>
+        home === '/home/op/.dkg-dev' ? 5555 : null,
+      isProcessRunning: () => true,
+    });
+    expect(result.dkgHome).toBe('/home/op/.dkg-dev');
+    expect(result.recoveredGlobalCliInCheckout).toBe(false);
+  });
+
+  it('standalone daemon present + standalone CLI: picks ~/.dkg, no recovery message', async () => {
+    const result = await selectMigrationDkgHome({
+      repoRoot: '/home/op/dkg-v9',
+      detectedRepoRoot: null,
+      homeDir: '/home/op',
+      readPidFromHome: async (home) =>
+        home === '/home/op/.dkg' ? 6666 : null,
+      isProcessRunning: () => true,
+    });
+    expect(result.dkgHome).toBe('/home/op/.dkg');
+    expect(result.recoveredGlobalCliInCheckout).toBe(false);
+  });
+
+  it('dead pid in ~/.dkg-dev: not picked, falls through to install-mode resolution', async () => {
+    const result = await selectMigrationDkgHome({
+      repoRoot: '/home/op/dkg-v9',
+      detectedRepoRoot: null,
+      homeDir: '/home/op',
+      readPidFromHome: async (home) =>
+        home === '/home/op/.dkg-dev' ? 99999 : null,
+      isProcessRunning: () => false,
+    });
+    expect(result.dkgHome).toBe('/home/op/.dkg');
+    expect(result.recoveredGlobalCliInCheckout).toBe(false);
   });
 });

--- a/packages/cli/test/nat-status.test.ts
+++ b/packages/cli/test/nat-status.test.ts
@@ -205,6 +205,54 @@ describe('startNatStatusWatcher — soft-timeout', () => {
     w.stop();
   });
 
+  it('Codex #668 — first event-driven `private` reclassification is not yet definitive (soft timeout still arms)', async () => {
+    // Codex (#668#discussion_r3302734688): the very first
+    // `self:peer:update` after listen also fires for the initial
+    // post-listen peer record AutoNAT publishes. If that record contains
+    // only private-class addresses (cold boot before AutoNAT verifies
+    // external reach), the previous logic marked `private` as DEFINITIVE
+    // immediately — disabling the soft timeout and locking the verdict.
+    // The fix: treat the FIRST non-public event-driven reclassification
+    // the same as the initial bound-address snapshot.
+    const node = makeFakeNode([]);
+    const onClass = vi.fn();
+    const w = startNatStatusWatcher({ node, onClassification: onClass, softTimeoutMs: 1_000 });
+    // Simulate AutoNAT's first post-listen update with only private addresses.
+    node.setAddrs(['/ip4/192.168.1.5/tcp/4001']);
+    node.emit();
+    // The status DOES update (so /api/status surfaces the current state),
+    // but it MUST NOT be definitive — the soft timeout must still fire
+    // for a downstream consumer to receive a non-stale verdict.
+    expect(onClass).toHaveBeenCalledWith('private', 'unknown');
+    // Now AutoNAT verifies an external address and reclassifies to public:
+    // the soft timeout did its job because the first private event did not
+    // mark `sawDefinitiveClassification`.
+    node.setAddrs(['/ip4/8.8.8.8/tcp/4001']);
+    node.emit();
+    expect(onClass).toHaveBeenLastCalledWith('public', 'private');
+    w.stop();
+  });
+
+  it('Codex #668 — second event-driven `private` reclassification IS definitive', async () => {
+    // Sanity check the inverse: once an event has fired, a subsequent
+    // private classification is treated as the real verdict — we don't
+    // permanently suppress the private branch.
+    const node = makeFakeNode([]);
+    const onClass = vi.fn();
+    const w = startNatStatusWatcher({ node, onClassification: onClass, softTimeoutMs: 1_000 });
+    // First event arrives with public addresses, marks definitive public.
+    node.setAddrs(['/ip4/8.8.8.8/tcp/4001']);
+    node.emit();
+    expect(onClass).toHaveBeenLastCalledWith('public', 'unknown');
+    // Second event flips to private (e.g. external uplink dropped). This
+    // is now treated as a definitive transition; the soft timeout would
+    // not need to fire again.
+    node.setAddrs(['/ip4/192.168.1.5/tcp/4001']);
+    node.emit();
+    expect(onClass).toHaveBeenLastCalledWith('private', 'public');
+    w.stop();
+  });
+
   it('softTimeoutMs=0 disables the soft-timeout entirely', async () => {
     const node = makeFakeNode([]);
     const onClass = vi.fn();

--- a/packages/cli/test/nat-status.test.ts
+++ b/packages/cli/test/nat-status.test.ts
@@ -205,6 +205,26 @@ describe('startNatStatusWatcher — soft-timeout', () => {
     w.stop();
   });
 
+  it('Codex review — unknown first event does not consume the first private baseline', async () => {
+    const node = makeFakeNode([]);
+    const onClass = vi.fn();
+    const w = startNatStatusWatcher({ node, onClassification: onClass, softTimeoutMs: 1_000 });
+
+    node.emit();
+    expect(onClass).toHaveBeenCalledTimes(0);
+
+    node.setAddrs(['/ip4/192.168.1.5/tcp/4001']);
+    node.emit();
+    expect(onClass).toHaveBeenCalledTimes(1);
+    expect(onClass).toHaveBeenLastCalledWith('private', 'unknown');
+
+    node.setAddrs(['/ip4/8.8.8.8/tcp/4001']);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onClass).toHaveBeenCalledTimes(2);
+    expect(onClass).toHaveBeenLastCalledWith('public', 'private');
+    w.stop();
+  });
+
   it('Codex #668 — first event-driven `private` reclassification is not yet definitive (soft timeout still arms)', async () => {
     // Codex (#668#discussion_r3302734688): the very first
     // `self:peer:update` after listen also fires for the initial

--- a/packages/cli/test/supervisor-liveness.test.ts
+++ b/packages/cli/test/supervisor-liveness.test.ts
@@ -255,12 +255,17 @@ describe('startLivenessWatcher', () => {
     watcher.stop();
   });
 
-  it('disarms (no SIGKILL, no failure increment) when isShuttingDown returns true', async () => {
+  it('suppresses SIGKILL during the shutdown grace window when isShuttingDown returns true', async () => {
     // Regression: PR #664 originally counted every failed probe toward the
     // SIGKILL threshold, so a slow shutdown tail (server.close() runs early
     // → probe fails → 5 × 30s later we SIGKILL) bypassed agent.stop() / DB
     // close. The supervisor wires `isShuttingDown` to "api.port file gone"
     // because the worker's shutdown() removes it before the slow awaits.
+    //
+    // Codex #664 follow-up: the watcher no longer disarms PERMANENTLY —
+    // it enters a bounded grace window during which failures are
+    // suppressed. The "still armed after the window" case is covered in
+    // the dedicated `re-arms SIGKILL after shutdownGraceMs elapses` test.
     const probe = vi.fn().mockResolvedValue(false);
     const onUnresponsive = vi.fn();
     const onFailure = vi.fn();
@@ -273,6 +278,8 @@ describe('startLivenessWatcher', () => {
       isShuttingDown,
       intervalMs: 1000,
       consecutiveFailuresToKill: 1,
+      // Long enough that 5s of ticks stays inside the window.
+      shutdownGraceMs: 60_000,
     });
 
     await advanceTicks(5, 1000);
@@ -341,6 +348,60 @@ describe('startLivenessWatcher', () => {
 
     await advanceTicks(5, 1000);
     expect(isShuttingDown).not.toHaveBeenCalled();
+    watcher.stop();
+  });
+
+  it('Codex #664 — re-arms SIGKILL after shutdownGraceMs elapses', async () => {
+    // Codex (#664#discussion_r3302432762): the previous implementation
+    // PERMANENTLY disarmed the watcher on the first shutdown observation.
+    // If a later teardown step hung, the supervisor could never SIGKILL
+    // or respawn the worker. The fix: keep probing during shutdown, but
+    // resume counting failures after a bounded grace window so wedged
+    // teardowns still get force-killed.
+    const probe = vi.fn().mockResolvedValue(false);
+    const onUnresponsive = vi.fn();
+    const isShuttingDown = vi.fn().mockReturnValue(true);
+    const watcher = startLivenessWatcher({
+      port: 1234,
+      probe,
+      onUnresponsive,
+      isShuttingDown,
+      intervalMs: 1000,
+      consecutiveFailuresToKill: 2,
+      shutdownGraceMs: 5000,
+    });
+
+    // Within grace window: no SIGKILL even though probes are failing.
+    await advanceTicks(4, 1000);
+    expect(onUnresponsive).not.toHaveBeenCalled();
+
+    // After grace window expires, consecutive failures start counting
+    // again; with threshold=2 the watcher trips on the next 2 failed
+    // probes.
+    await advanceTicks(3, 1000);
+    expect(onUnresponsive).toHaveBeenCalledTimes(1);
+    watcher.stop();
+  });
+
+  it('Codex #664 — shutdownGraceMs<0 preserves legacy disarm-forever behavior', async () => {
+    // Operators who explicitly want the rc.11-and-earlier "never SIGKILL
+    // during graceful shutdown" semantic can opt back in with a negative
+    // grace value.
+    const probe = vi.fn().mockResolvedValue(false);
+    const onUnresponsive = vi.fn();
+    const isShuttingDown = vi.fn().mockReturnValue(true);
+    const watcher = startLivenessWatcher({
+      port: 1234,
+      probe,
+      onUnresponsive,
+      isShuttingDown,
+      intervalMs: 1000,
+      consecutiveFailuresToKill: 1,
+      shutdownGraceMs: -1,
+    });
+
+    await advanceTicks(20, 1000);
+    expect(onUnresponsive).not.toHaveBeenCalled();
     watcher.stop();
   });
 });

--- a/packages/cli/test/supervisor-liveness.test.ts
+++ b/packages/cli/test/supervisor-liveness.test.ts
@@ -383,6 +383,35 @@ describe('startLivenessWatcher', () => {
     watcher.stop();
   });
 
+  it('resets stale failure count when entering shutdown grace', async () => {
+    const probe = vi.fn().mockResolvedValue(false);
+    const onUnresponsive = vi.fn();
+    const onFailure = vi.fn();
+    let shuttingDown = false;
+    const watcher = startLivenessWatcher({
+      port: 1234,
+      probe,
+      onUnresponsive,
+      onFailure,
+      isShuttingDown: () => shuttingDown,
+      intervalMs: 1000,
+      consecutiveFailuresToKill: 3,
+      shutdownGraceMs: 3000,
+    });
+
+    await advanceTicks(2, 1000);
+    expect(onFailure).toHaveBeenCalledTimes(2);
+    shuttingDown = true;
+    await advanceTicks(3, 1000);
+    expect(onUnresponsive).not.toHaveBeenCalled();
+
+    await advanceTicks(2, 1000);
+    expect(onUnresponsive).not.toHaveBeenCalled();
+    await advanceTicks(1, 1000);
+    expect(onUnresponsive).toHaveBeenCalledTimes(1);
+    watcher.stop();
+  });
+
   it('Codex #664 — shutdownGraceMs<0 preserves legacy disarm-forever behavior', async () => {
     // Operators who explicitly want the rc.11-and-earlier "never SIGKILL
     // during graceful shutdown" semantic can opt back in with a negative

--- a/packages/core/src/crypto/workspace-encryption.ts
+++ b/packages/core/src/crypto/workspace-encryption.ts
@@ -297,7 +297,7 @@ export function encodeWorkspaceEncryptionKey(bytes: Uint8Array): string {
 
 export function decodeWorkspaceEncryptionKey(value: string): Uint8Array {
   const raw = value.trim();
-  const bytes = raw.startsWith('0x')
+  const bytes = /^0x[0-9a-fA-F]{64}$/.test(raw)
     ? Buffer.from(raw.slice(2), 'hex')
     : Buffer.from(padBase64(raw.replace(/-/g, '+').replace(/_/g, '/')), 'base64');
   const out = new Uint8Array(bytes);

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -351,19 +351,30 @@ export class ProtocolRouter {
 
     const limit = this.maxReadBytes;
     libp2p.handle(protocolId, async (stream: Stream, connection) => {
+      // Codex (#669#discussion_r3302188320): cache the stopSignal once at
+      // handler entry and reuse it for every step of the inbound lifecycle.
+      // The previous code re-read `this.node.stopSignal` three times — at
+      // the initial read, in the catch-path abort check, and (implicitly)
+      // for `stream.close()` (which didn't pass it at all). If `DKGNode.stop()`
+      // fires AFTER the request has been read but before the response path
+      // finishes, the controller is cleared in `finally`, so the catch-path
+      // can see `undefined` and misclassify the shutdown as a real handler
+      // error. By caching once we make the whole handler consistently
+      // abortable, and `stream.close({ signal })` participates in shutdown.
+      const stopSignal = this.node.stopSignal;
       try {
-        const requestData = await readAllWithSignal(stream, limit, this.node.stopSignal);
+        const requestData = await readAllWithSignal(stream, limit, stopSignal);
         const peerId = {
           toString: () => connection.remotePeer.toString(),
           toBytes: () => connection.remotePeer.toMultihash().bytes,
         };
         const responseData = await handler(requestData, peerId);
         stream.send(responseData);
-        await stream.close();
+        await stream.close(stopSignal ? { signal: stopSignal } : undefined);
       } catch (err) {
-        if (this.node.stopSignal?.aborted) {
+        if (stopSignal?.aborted) {
           try {
-            stream.abort(asAbortError(this.node.stopSignal.reason));
+            stream.abort(asAbortError(stopSignal.reason));
           } catch {
             // stream already closed
           }

--- a/packages/core/test/workspace-encryption.test.ts
+++ b/packages/core/test/workspace-encryption.test.ts
@@ -8,8 +8,10 @@ import {
   WORKSPACE_ENCRYPTION_KEY_BYTES,
   WORKSPACE_RECIPIENT_ENCRYPTION_KEY_PURPOSE,
   assertSupportedEncryptedWorkspaceEnvelope,
+  decodeWorkspaceEncryptionKey,
   decryptWorkspacePayload,
   encryptWorkspacePayload,
+  encodeWorkspaceEncryptionKey,
   generateWorkspaceRecipientEncryptionKey,
   type EncryptWorkspacePayloadInput,
   type WorkspaceRecipientEncryptionKey,
@@ -158,5 +160,13 @@ describe('workspace encrypted payload helpers', () => {
     expect(key.recipientKeyId).toBe('alice-key-1');
     expect(key.publicKeyBytes).toHaveLength(WORKSPACE_ENCRYPTION_KEY_BYTES);
     expect(key.privateKeyBytes).toHaveLength(WORKSPACE_ENCRYPTION_KEY_BYTES);
+  });
+
+  it('decodes base64url keys that happen to start with 0x', () => {
+    const encoded = `0x${'A'.repeat(41)}`;
+    const bytes = decodeWorkspaceEncryptionKey(encoded);
+
+    expect(bytes).toHaveLength(WORKSPACE_ENCRYPTION_KEY_BYTES);
+    expect(encodeWorkspaceEncryptionKey(bytes)).toBe(encoded);
   });
 });

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -169,6 +169,11 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
           `Cannot recover job in state '${job.state}'. Only 'failed' jobs can be recovered.`,
         );
       }
+      if (this.requiresManualInspection(job)) {
+        throw new Error(
+          `Cannot recover job ${jobId}: ${job.reason ?? job.attempt.lastError?.message ?? 'manual inspection required'}`,
+        );
+      }
       await this.assertNoActiveConflict(job.request, job.jobId);
       const recovered: PromoteJob = {
         jobId: job.jobId,
@@ -600,6 +605,15 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
       },
     };
     await this.writeJob(abandonedJob);
+  }
+
+  private requiresManualInspection(job: PromoteJob): boolean {
+    const reason = (job.reason ?? '').toLowerCase();
+    const lastError = (job.attempt.lastError?.message ?? '').toLowerCase();
+    return reason.includes('partial promote ambiguity')
+      || lastError.includes('partial promote ambiguity')
+      || reason.includes('legacy promote job')
+      || lastError.includes('legacy promote job');
   }
 
   private async activeUniquenessKeys(state: PromoteJobState): Promise<Set<string>> {

--- a/packages/publisher/test/async-lift-subtraction.test.ts
+++ b/packages/publisher/test/async-lift-subtraction.test.ts
@@ -4,7 +4,12 @@ import { GraphManager } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
-import { DKGPublisher, generateSubGraphRegistration } from '../src/index.js';
+import {
+  DKGPublisher,
+  generateSubGraphRegistration,
+  getConfirmedStatusQuad,
+  getTentativeStatusQuad,
+} from '../src/index.js';
 import { validateLiftPublishPayload } from '../src/async-lift-validation.js';
 import { subtractFinalizedExactQuads } from '../src/async-lift-subtraction.js';
 import type { LiftValidationInput } from '../src/async-lift-validation.js';
@@ -91,6 +96,12 @@ describe('subtractFinalizedExactQuads', () => {
         publisherPeerId: 'peer-1',
       },
     };
+  }
+
+  async function markTentativePublishConfirmed(result: { readonly ual: string; readonly status: string }): Promise<void> {
+    expect(result.status).toBe('tentative');
+    await store.delete([getTentativeStatusQuad(result.ual, CONTEXT_GRAPH)]);
+    await store.insert([getConfirmedStatusQuad(result.ual, CONTEXT_GRAPH)]);
   }
 
   it('removes only the exact finalized public quads and keeps the remainder', async () => {
@@ -186,12 +197,13 @@ describe('subtractFinalizedExactQuads', () => {
     };
     const validated = validateLiftPublishPayload(input);
 
-    await publisher.publish({
+    const publishResult = await publisher.publish({
       contextGraphId: CONTEXT_GRAPH,
       quads: validated.resolved.quads,
       privateQuads: validated.resolved.privateQuads,
       publisherPeerId: 'peer-1',
     });
+    await markTentativePublishConfirmed(publishResult);
 
     const result = await subtractFinalizedExactQuads({
       store,
@@ -222,12 +234,13 @@ describe('subtractFinalizedExactQuads', () => {
     };
     const validated = validateLiftPublishPayload(input);
 
-    await publisher.publish({
+    const publishResult = await publisher.publish({
       contextGraphId: CONTEXT_GRAPH,
       quads: validated.resolved.quads,
       privateQuads: validated.resolved.privateQuads,
       publisherPeerId: 'peer-1',
     });
+    await markTentativePublishConfirmed(publishResult);
 
     const result = await subtractFinalizedExactQuads({
       store,

--- a/packages/publisher/test/async-promote-queue.test.ts
+++ b/packages/publisher/test/async-promote-queue.test.ts
@@ -591,6 +591,7 @@ describe('TripleStoreAsyncPromoteQueue', () => {
     expect(job?.state).toBe('failed');
     expect(job?.reason).toMatch(/partial promote ambiguity/i);
     expect(job?.lease).toBeUndefined();
+    await expect(queue.recover(jobId)).rejects.toThrow(/Cannot recover job .*partial promote ambiguity/i);
   });
 
   it('26. recoverOnStartup() reclaims expired running jobs when promote never started', async () => {
@@ -647,6 +648,7 @@ describe('TripleStoreAsyncPromoteQueue', () => {
     expect(job?.lease).toBeUndefined();
     expect(job?.reason).toMatch(/legacy promote job/i);
     expect(job?.attempt.lastError?.message).toMatch(/formatVersion=0/);
+    await expect(queue.recover(jobId)).rejects.toThrow(/Cannot recover job .*legacy promote job/i);
   });
 
   it('26c. recoverOnStartup() RECLAIMS v2 running jobs with promoteStarted=false', async () => {

--- a/scripts/devnet-test-rc11-promote-crash-recovery.sh
+++ b/scripts/devnet-test-rc11-promote-crash-recovery.sh
@@ -102,7 +102,13 @@ fail() { echo "[rc11-promote-crash] FAIL: $*" >&2; exit 1; }
 node_dir()    { echo "$DEVNET_DIR/node$1"; }
 node_token()  { tail -1 "$(node_dir "$1")/auth.token" 2>/dev/null | tr -d '\r\n'; }
 node_port()   { echo $((API_PORT_BASE + $1 - 1)); }
+# devnet.pid is the outer foreground supervisor; daemon.pid is the inner
+# `daemon-foreground-worker` that actually runs the libp2p node and async-promote
+# worker. Codex (#673#discussion_r3302023868) flagged that killing only the
+# supervisor leaves the worker alive, so the API port + SQLite store stays open
+# and the "restart" path doesn't reflect a real crash. We now kill BOTH.
 node_pidfile(){ echo "$(node_dir "$1")/devnet.pid"; }
+node_daemon_pidfile(){ echo "$(node_dir "$1")/daemon.pid"; }
 
 api_call() {
   local node="$1" method="$2" path="$3" data="${4:-}"
@@ -203,10 +209,14 @@ while [ "$(date +%s)" -lt "$RACE_DEADLINE" ]; do
       break
       ;;
     succeeded)
+      # Codex (#673#discussion_r3302023872): the crash/restart scenario was
+      # never exercised on this path. Exit non-zero so callers can
+      # distinguish an inconclusive run from a pass — this script asserts
+      # crash-recovery behavior, not happy-path completion.
       warn "job drained before kill could land (state=succeeded). Worker faster than poll loop — rerun for a reliable crash window."
       log "  raw status: $STATUS"
-      log "RESULT: INCONCLUSIVE (worker finished before kill)"
-      exit 0
+      log "RESULT: INCONCLUSIVE (worker finished before kill — crash-recovery path not exercised)"
+      exit 2
       ;;
     failed)
       fail "job in state=failed before any kill — pre-existing recovery condition? raw status: $STATUS"
@@ -230,25 +240,41 @@ fi
 # graceful-shutdown path drain the worker, defeating the test.
 # ---------------------------------------------------------------------------
 
-PIDFILE=$(node_pidfile "$CURATOR_NODE")
-[ -f "$PIDFILE" ] || fail "expected pidfile at $PIDFILE — node may not be running"
-DAEMON_PID=$(cat "$PIDFILE")
+SUPERVISOR_PIDFILE=$(node_pidfile "$CURATOR_NODE")
+WORKER_PIDFILE=$(node_daemon_pidfile "$CURATOR_NODE")
+[ -f "$SUPERVISOR_PIDFILE" ] || fail "expected pidfile at $SUPERVISOR_PIDFILE — node may not be running"
+SUPERVISOR_PID=$(cat "$SUPERVISOR_PIDFILE")
+# Codex (#673#discussion_r3302023868): SIGKILL on the supervisor alone leaves
+# `daemon-foreground-worker` alive and holding the API port + SQLite store
+# open, so the restart isn't a real crash. Kill both the supervisor and the
+# worker (whichever pidfiles are present).
+WORKER_PID=""
+if [ -f "$WORKER_PIDFILE" ]; then
+  WORKER_PID=$(cat "$WORKER_PIDFILE")
+fi
 log ""
-log "SIGKILL daemon (pid=$DAEMON_PID) — bypassing graceful-shutdown to reproduce a hard crash..."
-kill -9 "$DAEMON_PID" 2>/dev/null || warn "kill -9 returned non-zero; pid may already be gone"
+log "SIGKILL daemon (supervisor pid=$SUPERVISOR_PID, worker pid=${WORKER_PID:-<none>}) — bypassing graceful-shutdown to reproduce a hard crash..."
+[ -n "$WORKER_PID" ] && { kill -9 "$WORKER_PID" 2>/dev/null || warn "kill -9 $WORKER_PID returned non-zero; pid may already be gone"; }
+kill -9 "$SUPERVISOR_PID" 2>/dev/null || warn "kill -9 $SUPERVISOR_PID returned non-zero; pid may already be gone"
 
-# Wait for the process to actually disappear so the restart doesn't race
-# the dying process.
+# Wait for both processes to actually disappear so the restart doesn't race
+# a dying process holding the API port.
 for _ in 1 2 3 4 5 6 7 8 9 10; do
-  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+  supervisor_alive=0; worker_alive=0
+  kill -0 "$SUPERVISOR_PID" 2>/dev/null && supervisor_alive=1
+  [ -n "$WORKER_PID" ] && kill -0 "$WORKER_PID" 2>/dev/null && worker_alive=1
+  if [ "$supervisor_alive" -eq 0 ] && [ "$worker_alive" -eq 0 ]; then
     break
   fi
   sleep 0.5
 done
-if kill -0 "$DAEMON_PID" 2>/dev/null; then
-  fail "daemon pid $DAEMON_PID still alive 5s after SIGKILL — kernel did not reap"
+if kill -0 "$SUPERVISOR_PID" 2>/dev/null; then
+  fail "supervisor pid $SUPERVISOR_PID still alive 5s after SIGKILL — kernel did not reap"
 fi
-log "✓ daemon dead"
+if [ -n "$WORKER_PID" ] && kill -0 "$WORKER_PID" 2>/dev/null; then
+  fail "worker pid $WORKER_PID still alive 5s after SIGKILL — kernel did not reap"
+fi
+log "✓ supervisor + worker dead"
 
 # ---------------------------------------------------------------------------
 # Stage 4: Restart the node. Lifecycle wires queue.recoverOnStartup()

--- a/scripts/devnet-test-rc11-shutdown-mid-publish.sh
+++ b/scripts/devnet-test-rc11-shutdown-mid-publish.sh
@@ -157,13 +157,25 @@ for i in $(seq 1 $CONCURRENCY); do
     ")
     api_call "$LOAD_NODE" POST /api/shared-memory/write "$QUADS" \
       > "$TMP_OUT_DIR/write-$i.json" 2>&1 || true
-    api_call "$LOAD_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{ "contextGraphId": "$CG_ID",
-  "selection": { "kind": "sparql",
-                 "query": "SELECT ?s ?p ?o WHERE { ?s ?p ?o FILTER STRSTARTS(STR(?s), 'urn:rc11-shutdown/${STAMP}/pub${i}/') }" },
-  "kaSelection": { "kind": "all" } }
-EOF
-)" > "$TMP_OUT_DIR/publish-$i.json" 2>&1 || true
+    # Codex (#673#discussion_r3302023873): `/api/shared-memory/publish`
+    # accepts `selection: "all"` or a root-entity string array — NOT a
+    # SPARQL-shaped object. Pass the 8 generated root entities directly so
+    # each background pipeline drives a real StorageACK round trip.
+    ROOT_ENTITIES=$(node -e "
+      const roots = [];
+      for (let j = 0; j < 8; j++) {
+        roots.push('urn:rc11-shutdown/${STAMP}/pub${i}/item' + j);
+      }
+      console.log(JSON.stringify({
+        contextGraphId: '$CG_ID',
+        selection: roots,
+      }));
+    ")
+    PUBLISH_OUT=$(api_call "$LOAD_NODE" POST /api/shared-memory/publish "$ROOT_ENTITIES" 2>&1) || PUBLISH_RC=$? && PUBLISH_RC=${PUBLISH_RC:-0}
+    echo "$PUBLISH_OUT" > "$TMP_OUT_DIR/publish-$i.json"
+    if [ "$PUBLISH_RC" -ne 0 ]; then
+      echo "[publish-$i] api_call exit=$PUBLISH_RC" >> "$TMP_OUT_DIR/publish-$i.json"
+    fi
   ) &
   PUBLISH_PIDS+=($!)
 done


### PR DESCRIPTION
## Summary

Follow-up to the rc.11 integration PR (#680). Closes the highest-severity Codex review findings that the rc.11 cut deferred so they could be addressed in a single reviewable PR after merge instead of holding the release.

**9 critical 🔴 findings** + 2 medium 🟡 findings, across 7 source files and 6 test files. All addressed with regression test coverage where the surface is unit-testable.

PRs whose findings are addressed here:

| PR | Finding | File |
|---|---|---|
| #661 | IPv6 zero-padded `2001:0db8::` slips past TEST-NET-2 check (🔴) | `core-prereq-check.ts:262` |
| #661 | `isReservedDnsName` trailing-root-dot bypass (🟡) | `core-prereq-check.ts:309` |
| #661 | `lifecycle.ts` hides `prereq.indeterminate` verdict (🟡) | `lifecycle.ts:1276` |
| #664 | Watchdog disarm via `api.port` deletion is permanent (🔴) | `supervisor-liveness.ts` |
| #665 | `swmInserted` marker write failure → re-promote risk (🔴) | `async-promote-worker.ts:262` |
| #666 | `dkgHomeNow` derives from CLI install mode, not target checkout (🔴) | `cli.ts:4082` / `migrate-to-npm.ts` |
| #668 | First `self:peer:update` locks in `private` before AutoNAT verifies (🔴) | `nat-status.ts:273` |
| #669 | `stopSignal` not cached at handler entry; `stream.close()` not abortable (🔴) | `protocol-router.ts:355` |
| #670 | `vitest.unit.config.ts` hardcoded include drops new unit tests (🟡) | `chain/vitest.unit.config.ts` |
| #670 | `JSON.stringify` throws on bigint in ethers payloads (🟡) | `filter-error-silencer.ts:127` |
| #673 | SIGKILL hits supervisor pid only; daemon worker survives (🔴) | `devnet-test-rc11-promote-crash-recovery.sh:238` |
| #673 | `exit 0` on false-green path (worker drained before kill) (🔴) | `devnet-test-rc11-promote-crash-recovery.sh:209` |
| #673 | SPARQL `selection` shape rejected by `/api/shared-memory/publish` (🔴) | `devnet-test-rc11-shutdown-mid-publish.sh:162` |

Each commit references the specific Codex `discussion_r*` ID it addresses.

## Notable design decisions

- **#664 watchdog disarm**: replaced "disarm forever" with a bounded `shutdownGraceMs` (default 30s = 2× `SHUTDOWN_HARD_TIMEOUT_MS`). Graceful shutdown gets the full window; wedged teardowns still get SIGKILLed. `shutdownGraceMs < 0` preserves the legacy "never SIGKILL during graceful shutdown" semantic for operators who explicitly want it.

- **#665 swmInserted marker**: introduces a new `partial_promote_ambiguity` outcome that does NOT call `queue.fail()` — the job stays in `running` state, and `recoverOnStartup()` correctly routes it into the "abandoned partial promote" bucket on next boot. This prevents `/promote-async/{jobId}/recover` from blindly re-running an already-completed promote. A loud `PARTIAL-PROMOTE-AMBIGUITY: jobId=…` log surfaces the condition for operator alerting.

- **#666 dkgHomeNow**: extracted `selectMigrationDkgHome()` that probes BOTH `~/.dkg-dev` and `~/.dkg` for a live daemon. Falls back to install-mode-based resolution only when neither home has a running daemon (greenfield migration). Surfaces `recoveredGlobalCliInCheckout` so the CLI logs an explicit line when it overrides the install-mode default.

- **#668 NAT-status**: only the FIRST event-driven non-public reclassification is treated as the bound-address baseline (same as the initial snapshot). Once an event has fired once, subsequent `private` events are treated as real verdicts — we don't permanently suppress legitimate transitions.

## Findings NOT in this PR (parked for #676 rc.12 backlog)

The remaining 7 medium 🟡 findings are tracked in #676 (rc.12 follow-ups):

- #662 `/api/status` HEAD path / duplicate `RelayStatusResponse` shape (HEAD path actually ADDRESSED on main, only the duplicate shape remains)
- #665 supervisor stop() race with start() resolution
- #665 `PromoteCommitMarker.promoteStarted` source-compat (internal type)
- #667 `heartbeatIntervalMs` vs actual queue lease (partial guard exists for default lease)
- #668 third independent address classifier in `nat-status.ts:107` (engineering hygiene)
- #671 `hardhat-harness.ts:432` quorum=1 weakens ACK validation
- #672 `evm-adapter.ts:390` 1h TTL caches mutable reads (`invalidatePublishPreflightCache()` exists as explicit-flush hook)

Findings actually ALREADY ADDRESSED on `main` (verified by file-level inspection during triage):

- #662 status.ts HEAD fast-path (line 494 returns early before relay walk) ✅
- #667 `/promote-async` 503-gate when `enabled: false` (assertion.ts:533) ✅
- #667 SKILL.md `state` query param docs match `searchParams.get()` ✅
- #671 verified-memory root graph restored by `a63c8669` (in main via #680) ✅
- #663 (entire PR) — reverted and superseded by #681 in the integration branch ✅

Closing redundant PRs that #680 folded in (no commits ahead of main):

- #665 (async-promote worker supervisor) — closed
- #667 (async-promote queue config + e2e) — closed
- #672 (typed errors + RPC caching + LU-6 runbook + provenance) — closed

## Verification

- `pnpm --filter '@origintrail-official/dkg' test:unit` — **416/416 passing** (up from 403; +13 new regression cases)
- `pnpm --filter '@origintrail-official/dkg-chain' test:unit` — **68/68 passing** (up from 59; +8 newly-discovered `hub-resolution-cache` + 1 new bigint case)
- `pnpm --filter '@origintrail-official/dkg-core' exec vitest run test/protocol-router-abort.test.ts test/protocol-router.test.ts test/protocol-router-pool.test.ts` — **70/70 passing**
- `pnpm -r build` clean
- `bash -n scripts/devnet-test-rc11-*.sh` — syntax OK

## Test plan

- [x] Build clean (`pnpm -r build`)
- [x] Touched-package unit tests green (416 CLI, 68 chain, 70 core protocol-router)
- [x] New regression cases for every fix where the surface is unit-testable (IPv6, trailing-dot DNS, indeterminate branch, watchdog re-arm + legacy opt-out, partial-promote-ambiguity, probe-both-homes, NAT first-event-not-definitive, bigint serializer)
- [ ] Re-run the rc11-targeted devnet scenarios on a fresh devnet to confirm the script fixes
- [ ] CI green

Made with [Cursor](https://cursor.com)