### PR TITLE
feat(chain): generalize Hub rotation auto-recovery to all boot-bound contracts

### DIFF
--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -95,10 +95,11 @@ const MAX_PROBE_AGE_MS = 30_000;
  * the corresponding boot-bound field on `EVMChainAdapter.contracts`.
  *
  * Used by:
- *   1. `startHubRotationListener` — when `Hub.ContractChanged` /
- *      `NewContract` fires for `name`, the listener nulls the local
- *      handle and flips `initialized=false` so the next public-method
- *      call goes through `init()` and re-resolves fresh from Hub.
+ *   1. `startHubRotationListener` — when a Hub rotation event fires
+ *      for `name`, the listener checks this allowlist, marks the
+ *      adapter uninitialised, and leaves the existing handle intact so
+ *      in-flight calls that already passed `init()` don't observe a
+ *      transient `undefined`.
  *   2. `invalidateAllBoundContracts` — bulk drop, called by the
  *      write-side self-heal path (`withHubStaleRetry`) when a stale
  *      address surfaces `UnauthorizedAccess(Only Contracts in Hub)`.
@@ -2824,6 +2825,7 @@ export class EVMChainAdapter implements ChainAdapter {
     try {
       return await fn();
     } catch (err) {
+      if (err instanceof Error) enrichEvmError(err);
       const msg = err instanceof Error ? err.message : '';
       if (HUB_STALE_ERROR_MARKERS.some((m) => msg.includes(m))) {
         this.invalidateRandomSamplingPair();
@@ -2859,6 +2861,7 @@ export class EVMChainAdapter implements ChainAdapter {
     try {
       return await fn();
     } catch (err) {
+      if (err instanceof Error) enrichEvmError(err);
       const msg = err instanceof Error ? err.message : '';
       if (HUB_STALE_ERROR_MARKERS.some((m) => msg.includes(m))) {
         this.invalidateAllBoundContracts();
@@ -2898,8 +2901,8 @@ export class EVMChainAdapter implements ChainAdapter {
   }
 
   /**
-   * Subscribe to Hub `ContractChanged` / `NewContract` events and
-   * invalidate the local cache for any Hub-rotated contract.
+   * Subscribe to Hub rotation events and invalidate the local cache for any
+   * Hub-rotated contract.
    *
    * Two invalidation paths, dispatched by name:
    *
@@ -2909,13 +2912,16 @@ export class EVMChainAdapter implements ChainAdapter {
    *      See the `randomSamplingPairCache` field comment for the
    *      coupling invariants this path preserves.
    *
-   *   2. Any other name in `BOUND_CONTRACT_INVALIDATORS` → null the
-   *      corresponding boot-bound `this.contracts.X` field and flip
+   *   2. Any other name in `BOUND_CONTRACT_INVALIDATORS` → leave the
+   *      existing `this.contracts.X` field intact but flip
    *      `this.initialized` back to `false` so the next `await
-   *      this.init()` re-resolves every binding fresh from Hub. This
-   *      is the structural fix for the post-rotation stale-address
-   *      bug on the wider V10 contract set (PCA NFT, ContextGraphs,
-   *      KnowledgeCollection family, etc.) — without this dispatch,
+   *      this.init()` re-resolves every binding fresh from Hub. Keeping
+   *      the old handle until the next init pass avoids a race where an
+   *      in-flight public method already passed `init()` and then trips
+   *      over a transient `undefined` field. This is the structural fix
+   *      for the post-rotation stale-address bug on the wider V10
+   *      contract set (PCA NFT, ContextGraphs, KnowledgeCollection
+   *      family, storage contracts, etc.) — without this dispatch,
    *      operators were silently stuck on the pre-rotation address
    *      until a daemon restart.
    *
@@ -2928,16 +2934,18 @@ export class EVMChainAdapter implements ChainAdapter {
    * `Hub._setContractAddress` is double-tap-emitting (`Hub-extra.test.ts`
    * E-7): on the new-contract path it emits `NewContract` twice, and
    * on the update path it emits both `ContractChanged` AND
-   * `NewContract`. We listen to BOTH events so the cache invalidates
-   * regardless of which Hub variant the deployment ships, and both
-   * the RS-pair invalidation and the generic boot-bound invalidation
-   * are idempotent so duplicate notifications are harmless.
+   * `NewContract`. Storage bindings resolved through
+   * `getAssetStorageAddress(...)` emit the parallel `AssetStorageChanged`
+   * / `NewAssetStorage` events. We listen to all four events so the cache
+   * invalidates regardless of which Hub set owns the name, and both the
+   * RS-pair invalidation and the generic boot-bound invalidation are
+   * idempotent so duplicate notifications are harmless.
    *
    * `Contract.on(...)` is async in ethers v6: a sync `try/catch` would
    * miss provider rejections (e.g. HTTP-only endpoints that can't
    * install filter subscriptions) and leave us with an unhandled
-   * rejection. We `await` both subscriptions and only set
-   * `hubRotationListenerStarted` after both succeed, so a failed
+   * rejection. We `await` every subscription and only set
+   * `hubRotationListenerStarted` after all succeed, so a failed
    * provider can be retried by a future call site if we ever need to
    * — and meanwhile the TTL refresh path (for RS) and the
    * `withHubStaleRetry` write-side fallback (for all boot-bound
@@ -2952,20 +2960,20 @@ export class EVMChainAdapter implements ChainAdapter {
         this.invalidateRandomSamplingPair();
         return;
       }
-      const invalidator = BOUND_CONTRACT_INVALIDATORS.get(name);
-      if (invalidator) {
-        invalidator(this);
+      if (BOUND_CONTRACT_INVALIDATORS.has(name)) {
         this.invalidatePublishPreflightCache();
         // Force the next public-method entry through `init()` so it
-        // re-resolves every binding. Cheap — rotation events are rare
-        // and `init()` is idempotent past the `if (this.initialized)
-        // return` short-circuit.
+        // re-resolves every binding. Do not clear the current handle
+        // here: the callback can fire between a public method's
+        // `await init()` and its first `this.contracts.X` read.
         this.initialized = false;
       }
     };
     try {
       await this.contracts.hub.on('ContractChanged', onChange);
       await this.contracts.hub.on('NewContract', onChange);
+      await this.contracts.hub.on('AssetStorageChanged', onChange);
+      await this.contracts.hub.on('NewAssetStorage', onChange);
       this.hubRotationListenerStarted = true;
     } catch {
       /* provider doesn't support filter subscriptions — TTL refresh (RS)

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -90,6 +90,47 @@ const MAX_PROBE_AGE_MS = 30_000;
  * `UnauthorizedAccess(Only Contracts in Hub)` so we don't accidentally
  * drop the cache on an unrelated authorization failure.
  */
+/**
+ * Maps a Hub-registered contract name to the function that invalidates
+ * the corresponding boot-bound field on `EVMChainAdapter.contracts`.
+ *
+ * Used by:
+ *   1. `startHubRotationListener` — when `Hub.ContractChanged` /
+ *      `NewContract` fires for `name`, the listener nulls the local
+ *      handle and flips `initialized=false` so the next public-method
+ *      call goes through `init()` and re-resolves fresh from Hub.
+ *   2. `invalidateAllBoundContracts` — bulk drop, called by the
+ *      write-side self-heal path (`withHubStaleRetry`) when a stale
+ *      address surfaces `UnauthorizedAccess(Only Contracts in Hub)`.
+ *
+ * `RandomSampling` / `RandomSamplingStorage` are intentionally absent —
+ * they go through `randomSamplingPairCache` + `invalidateRandomSamplingPair()`
+ * which owns side-channel state (in-flight probe, ready flag) that
+ * a simple field reset wouldn't touch.
+ *
+ * Names listed here MUST match what `init()` resolves via
+ * `Hub.getContractAddress(name)` / `Hub.getAssetStorageAddress(name)`
+ * — keep these in sync when adding/removing bindings in `init()`.
+ */
+const BOUND_CONTRACT_INVALIDATORS = new Map<string, (adapter: EVMChainAdapter) => void>([
+  ['Identity',                   (a) => { (a as any).contracts.identity = undefined; }],
+  ['Profile',                    (a) => { (a as any).contracts.profile = undefined; }],
+  ['ProfileStorage',             (a) => { (a as any).contracts.profileStorage = undefined; }],
+  ['ParametersStorage',          (a) => { (a as any).contracts.parametersStorage = undefined; }],
+  ['Staking',                    (a) => { (a as any).contracts.staking = undefined; }],
+  ['Token',                      (a) => { (a as any).contracts.token = undefined; }],
+  ['AskStorage',                 (a) => { (a as any).contracts.askStorage = undefined; }],
+  ['KnowledgeAssets',            (a) => { (a as any).contracts.knowledgeAssets = undefined; }],
+  ['KnowledgeAssetsStorage',     (a) => { (a as any).contracts.knowledgeAssetsStorage = undefined; }],
+  ['KnowledgeAssetsV10',         (a) => { (a as any).contracts.knowledgeAssetsV10 = undefined; }],
+  ['KnowledgeCollection',        (a) => { (a as any).contracts.knowledgeCollection = undefined; }],
+  ['KnowledgeCollectionStorage', (a) => { (a as any).contracts.knowledgeCollectionStorage = undefined; }],
+  ['ContextGraphNameRegistry',   (a) => { (a as any).contracts.contextGraphNameRegistry = undefined; }],
+  ['ContextGraphs',              (a) => { (a as any).contracts.contextGraphs = undefined; }],
+  ['ContextGraphStorage',        (a) => { (a as any).contracts.contextGraphStorage = undefined; }],
+  ['DKGPublishingConvictionNFT', (a) => { (a as any).contracts.dkgPublishingConvictionNFT = undefined; }],
+]);
+
 const HUB_STALE_ERROR_MARKERS = [
   'Only Contracts in Hub',
   'UnauthorizedAccess(Only Contracts in Hub)',
@@ -2349,15 +2390,44 @@ export class EVMChainAdapter implements ChainAdapter {
     return nft;
   }
 
-  // Opaque "unknown custom error"+data reverts carry no name; enrich so the
-  // daemon classifier matches it (mirrors isContractMissingRevert et al).
+  /**
+   * Common wrapper for every PCA (Publisher Conviction Account) write
+   * path. Two responsibilities:
+   *
+   *   1. Opaque "unknown custom error"+data reverts from the post-split
+   *      `PublishingConviction` logic contract carry no decoded name
+   *      out of ethers — `enrichEvmError` decodes them so the daemon's
+   *      error classifier can match downstream (mirrors what
+   *      `isContractMissingRevert` does for the resolution path).
+   *
+   *   2. Self-heal on a stale `DKGPublishingConvictionNFT` /
+   *      `PublishingConvictionStorage` binding. Both contracts were
+   *      redeployed for v10.0.0-rc.11 (PCA split); the wrapper NFT
+   *      lazy-resolves `PublishingConviction` on every call so a
+   *      logic rotation is handled on-chain, but a wrapper rotation
+   *      surfaces here as `UnauthorizedAccess(Only Contracts in Hub)`
+   *      on the FIRST PCA write after the Hub re-registration. The
+   *      `withHubStaleRetryAny` outer layer drops every boot-bound
+   *      handle, re-runs `init()` to repopulate from the live Hub,
+   *      and retries the closure once — `op` re-reads
+   *      `this.contracts.dkgPublishingConvictionNFT` via
+   *      `requireConvictionNFT()` so the retry uses the new address.
+   *
+   * NOTE — rc.12 follow-up: other V10 write paths
+   * (`createKnowledgeAssetsV10`, `createContextGraph`,
+   * `updateKnowledgeCollectionV10`, etc.) should be wrapped with the
+   * same self-heal pattern. Tracked in the broader migration to
+   * `HubResolutionCache` for every boot-bound contract.
+   */
   private async pcaWrite<T>(op: () => Promise<T>): Promise<T> {
-    try {
-      return await op();
-    } catch (err) {
-      if (err instanceof Error) enrichEvmError(err);
-      throw err;
-    }
+    return this.withHubStaleRetryAny(async () => {
+      try {
+        return await op();
+      } catch (err) {
+        if (err instanceof Error) enrichEvmError(err);
+        throw err;
+      }
+    });
   }
 
   async createPublishingConvictionAccount(
@@ -2764,6 +2834,42 @@ export class EVMChainAdapter implements ChainAdapter {
   }
 
   /**
+   * Like `withHubStaleRetry` but generalized for any boot-bound
+   * contract — not just the RS pair. On `UnauthorizedAccess(Only
+   * Contracts in Hub)`, drops every boot-bound `this.contracts.X`
+   * handle, re-runs `init()` to re-resolve all bindings from Hub,
+   * then retries the operation exactly once.
+   *
+   * Used at write-side call sites that touch any of the redeployable
+   * V10 contracts (PCA NFT, ContextGraphs, KnowledgeCollection, etc.)
+   * so the FIRST write after a Hub rotation self-heals even when the
+   * event listener never fired (HTTP-only RPC endpoints, dropped
+   * subscriptions, rate-limited filter installs — all of which we
+   * see in the wild on public Base Sepolia / Gnosis Chain RPCs).
+   *
+   * Idempotency note: the wrapped closure MUST be safe to call twice.
+   * That holds for our write paths because the on-chain side either
+   * (a) reverted with the marker error, meaning no state changed, or
+   * (b) succeeded, meaning no retry happens. The closure SHOULD
+   * re-read `this.contracts.X` on each invocation (don't capture the
+   * handle into a local outside the closure) so the retry uses the
+   * fresh binding.
+   */
+  private async withHubStaleRetryAny<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '';
+      if (HUB_STALE_ERROR_MARKERS.some((m) => msg.includes(m))) {
+        this.invalidateAllBoundContracts();
+        await this.init();
+        return await fn();
+      }
+      throw err;
+    }
+  }
+
+  /**
    * Invalidate both the cache AND the side-channel contract handles. Without
    * dropping `this.contracts.randomSampling[Storage]`, the public
    * `isRandomSamplingReady()` probe would keep returning `true` after a Hub
@@ -2793,18 +2899,39 @@ export class EVMChainAdapter implements ChainAdapter {
 
   /**
    * Subscribe to Hub `ContractChanged` / `NewContract` events and
-   * invalidate the RS pair cache whenever **either** RS-side name is
-   * rotated. The pair is treated as a single coupled unit (see the
-   * `randomSamplingPairCache` field comment) — invalidating on either
-   * name forces an atomic re-resolve of both.
+   * invalidate the local cache for any Hub-rotated contract.
+   *
+   * Two invalidation paths, dispatched by name:
+   *
+   *   1. `RandomSampling` / `RandomSamplingStorage` → atomic pair
+   *      invalidation through `invalidateRandomSamplingPair()` so the
+   *      coupled cache + in-flight probe lifecycle stays consistent.
+   *      See the `randomSamplingPairCache` field comment for the
+   *      coupling invariants this path preserves.
+   *
+   *   2. Any other name in `BOUND_CONTRACT_INVALIDATORS` → null the
+   *      corresponding boot-bound `this.contracts.X` field and flip
+   *      `this.initialized` back to `false` so the next `await
+   *      this.init()` re-resolves every binding fresh from Hub. This
+   *      is the structural fix for the post-rotation stale-address
+   *      bug on the wider V10 contract set (PCA NFT, ContextGraphs,
+   *      KnowledgeCollection family, etc.) — without this dispatch,
+   *      operators were silently stuck on the pre-rotation address
+   *      until a daemon restart.
+   *
+   *   3. Unknown name → ignored. We deliberately allowlist rather
+   *      than reflexively re-init on any rotation: third-party
+   *      deployments may register names we don't bind, and we don't
+   *      want a benign rotation of an unrelated contract to thrash
+   *      our cache.
    *
    * `Hub._setContractAddress` is double-tap-emitting (`Hub-extra.test.ts`
    * E-7): on the new-contract path it emits `NewContract` twice, and
    * on the update path it emits both `ContractChanged` AND
    * `NewContract`. We listen to BOTH events so the cache invalidates
-   * regardless of which Hub variant the deployment ships, and the
-   * invalidation is idempotent so duplicate notifications are
-   * harmless.
+   * regardless of which Hub variant the deployment ships, and both
+   * the RS-pair invalidation and the generic boot-bound invalidation
+   * are idempotent so duplicate notifications are harmless.
    *
    * `Contract.on(...)` is async in ethers v6: a sync `try/catch` would
    * miss provider rejections (e.g. HTTP-only endpoints that can't
@@ -2812,8 +2939,10 @@ export class EVMChainAdapter implements ChainAdapter {
    * rejection. We `await` both subscriptions and only set
    * `hubRotationListenerStarted` after both succeed, so a failed
    * provider can be retried by a future call site if we ever need to
-   * — and meanwhile the TTL refresh path still keeps the RandomSampling
-   * pair fresh.
+   * — and meanwhile the TTL refresh path (for RS) and the
+   * `withHubStaleRetry` write-side fallback (for all boot-bound
+   * contracts) still keep stale bindings recoverable without a
+   * working event subscription.
    */
   private async startHubRotationListener(): Promise<void> {
     if (this.hubRotationListenerStarted) return;
@@ -2821,6 +2950,16 @@ export class EVMChainAdapter implements ChainAdapter {
       if (typeof name !== 'string') return;
       if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
         this.invalidateRandomSamplingPair();
+        return;
+      }
+      const invalidator = BOUND_CONTRACT_INVALIDATORS.get(name);
+      if (invalidator) {
+        invalidator(this);
+        // Force the next public-method entry through `init()` so it
+        // re-resolves every binding. Cheap — rotation events are rare
+        // and `init()` is idempotent past the `if (this.initialized)
+        // return` short-circuit.
+        this.initialized = false;
       }
     };
     try {
@@ -2828,8 +2967,32 @@ export class EVMChainAdapter implements ChainAdapter {
       await this.contracts.hub.on('NewContract', onChange);
       this.hubRotationListenerStarted = true;
     } catch {
-      /* provider doesn't support filter subscriptions — TTL refresh is the fallback */
+      /* provider doesn't support filter subscriptions — TTL refresh (RS)
+       * and `withHubStaleRetry` (writes) are the fallbacks */
     }
+  }
+
+  /**
+   * Drop every boot-bound contract handle and re-arm `init()`.
+   *
+   * Used by `withHubStaleRetry` on the write-side self-heal path when
+   * a Hub-rotated contract surfaces `UnauthorizedAccess(Only Contracts
+   * in Hub)`: the listener may have missed the rotation event (HTTP-only
+   * RPC, dropped subscription, etc.) so the failing operation can't tell
+   * which specific name was rotated. Resetting everything is the safest
+   * fallback — the next `await this.init()` re-resolves all 15+ bindings
+   * in a single pass (still under a second on a healthy RPC) and the
+   * caller's retry picks up the fresh handles.
+   *
+   * RS pair is handled separately because it owns side-channel state
+   * (in-flight probe, ready flag) that `init()` alone won't reset.
+   */
+  private invalidateAllBoundContracts(): void {
+    for (const invalidator of BOUND_CONTRACT_INVALIDATORS.values()) {
+      invalidator(this);
+    }
+    this.invalidateRandomSamplingPair();
+    this.initialized = false;
   }
 
   /**

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -2955,6 +2955,7 @@ export class EVMChainAdapter implements ChainAdapter {
       const invalidator = BOUND_CONTRACT_INVALIDATORS.get(name);
       if (invalidator) {
         invalidator(this);
+        this.invalidatePublishPreflightCache();
         // Force the next public-method entry through `init()` so it
         // re-resolves every binding. Cheap — rotation events are rare
         // and `init()` is idempotent past the `if (this.initialized)
@@ -2991,6 +2992,7 @@ export class EVMChainAdapter implements ChainAdapter {
     for (const invalidator of BOUND_CONTRACT_INVALIDATORS.values()) {
       invalidator(this);
     }
+    this.invalidatePublishPreflightCache();
     this.invalidateRandomSamplingPair();
     this.initialized = false;
   }

--- a/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
+++ b/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
@@ -110,6 +110,27 @@ async function waitFor(
   return false;
 }
 
+/**
+ * Let the adapter's Hub rotation listener consume any historical
+ * `ContractChanged` / `NewContract` events that a previous test in
+ * the same Hardhat session may have left behind. ethers v6 subscribes
+ * its polling filter with fromBlock=latest, but in practice the
+ * computed `latest` can include the most-recent rotation tx — so a
+ * brand-new adapter can fire its first listener callback against an
+ * event it never directly caused.
+ *
+ * This mirrors production behaviour: a daemon that boots immediately
+ * after a Hub rotation will catch the rotation it didn't subscribe
+ * to. The "drain" step here just ensures the test snapshots are
+ * taken AFTER that catch-up, so steady-state assertions hold.
+ */
+async function drainHistoricalRotationEvents(adapter: EVMChainAdapter): Promise<void> {
+  await new Promise((r) => setTimeout(r, 1_000));
+  if (!(adapter as any).initialized) {
+    await (adapter as any).init();
+  }
+}
+
 describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   beforeAll(async () => {
     // Unique port to avoid collision with the other Hardhat-backed
@@ -413,5 +434,167 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       expect(typeof after!.activeProofPeriodStartBlock).toBe('bigint');
     },
     90_000,
+  );
+
+  // ===================================================================
+  // Generic boot-bound contract rotation (rc.12 PR
+  // `feat/chain-hub-rotation-auto-recovery`). Mirrors the RS-specific
+  // cases above but exercises the table-driven path in
+  // `startHubRotationListener` + the `withHubStaleRetryAny` wrapper
+  // that backs `pcaWrite` and any future write-side caller. The
+  // contract under test is `Identity` — it's always deployed, always
+  // boot-bound, and listed in `BOUND_CONTRACT_INVALIDATORS`; the
+  // listener should treat it identically to any other entry in the
+  // map.
+  // ===================================================================
+
+  it(
+    'event listener (generic): rotating Identity nulls this.contracts.identity and re-arms init()',
+    async () => {
+      // High TTL — only the event listener can flip the field within
+      // the test window. (RS cache has its own TTL; the generic path
+      // doesn't use one — only event/listener + write-side retry.)
+      const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
+      (adapter as any).provider.pollingInterval = 250;
+
+      await (adapter as any).init();
+      const identityBefore: Contract = (adapter as any).contracts.identity;
+      expect(identityBefore).toBeDefined();
+      const identityAddrBefore: string = await identityBefore.getAddress();
+
+      const deployer = new Wallet(HARDHAT_KEYS.DEPLOYER, ctx.provider);
+      const replacementAddr = freshAddress();
+
+      try {
+        await rotateHubContract(ctx.hubAddress, deployer, 'Identity', replacementAddr);
+
+        // Listener nulls the field AND flips `initialized`.
+        const observed = await waitFor(
+          () =>
+            (adapter as any).contracts.identity === undefined &&
+            (adapter as any).initialized === false,
+          15_000,
+          100,
+        );
+        expect(observed).toBe(true);
+
+        // Next init() re-resolves from the live Hub and binds the new address.
+        await (adapter as any).init();
+        const identityAfter: Contract = (adapter as any).contracts.identity;
+        expect(identityAfter).toBeDefined();
+        const identityAddrAfter: string = await identityAfter.getAddress();
+        expect(identityAddrAfter.toLowerCase()).toBe(replacementAddr.toLowerCase());
+        expect(identityAddrAfter.toLowerCase()).not.toBe(identityAddrBefore.toLowerCase());
+      } finally {
+        await rotateHubContract(ctx.hubAddress, deployer, 'Identity', identityAddrBefore);
+      }
+    },
+    60_000,
+  );
+
+  it(
+    'event listener (generic): rotating an unknown contract name is ignored — no fields touched',
+    async () => {
+      const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
+      (adapter as any).provider.pollingInterval = 250;
+
+      await (adapter as any).init();
+      await drainHistoricalRotationEvents(adapter);
+
+      const identityBefore: Contract = (adapter as any).contracts.identity;
+      expect(identityBefore).toBeDefined();
+      expect((adapter as any).initialized).toBe(true);
+
+      const deployer = new Wallet(HARDHAT_KEYS.DEPLOYER, ctx.provider);
+      // Use a name NOT in BOUND_CONTRACT_INVALIDATORS. Hub.setContractAddress
+      // accepts arbitrary strings and emits `NewContract` for first
+      // registrations — exactly the noise we need to confirm the listener
+      // safely allowlists.
+      const unknownName = `RC12TestUnknown-${Date.now()}`;
+      await rotateHubContract(ctx.hubAddress, deployer, unknownName, freshAddress());
+
+      // Give the listener multiple polling cycles to mis-fire if it would.
+      await new Promise((r) => setTimeout(r, 1_500));
+
+      expect((adapter as any).contracts.identity).toBe(identityBefore);
+      expect((adapter as any).initialized).toBe(true);
+    },
+    30_000,
+  );
+
+  it(
+    'withHubStaleRetryAny: marker error invalidates ALL boot-bound contracts, re-inits, and retries once',
+    async () => {
+      const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
+      (adapter as any).provider.pollingInterval = 250;
+      await (adapter as any).init();
+      await drainHistoricalRotationEvents(adapter);
+
+      const identityBefore: Contract = (adapter as any).contracts.identity;
+      expect(identityBefore).toBeDefined();
+      const identityAddrBefore: string = await identityBefore.getAddress();
+
+      let calls = 0;
+      let identityDuringRetry: Contract | undefined;
+      const result = await (adapter as any).withHubStaleRetryAny(async () => {
+        calls += 1;
+        if (calls === 1) {
+          // Snapshot what the retry path produced — invalidated then
+          // re-resolved. Capturing it inside the closure proves the
+          // wrapper called init() between the throw and the retry.
+          throw new Error(
+            'execution reverted (unknown custom error): UnauthorizedAccess(Only Contracts in Hub)',
+          );
+        }
+        identityDuringRetry = (adapter as any).contracts.identity;
+        return 'ok';
+      });
+
+      expect(result).toBe('ok');
+      expect(calls).toBe(2);
+      // After self-heal: a fresh Identity handle is bound (same on-chain
+      // address since we didn't rotate, but a distinct ethers.Contract
+      // instance because resolveContract() built a new one) and the
+      // adapter is initialised again.
+      expect(identityDuringRetry).toBeDefined();
+      expect(identityDuringRetry).not.toBe(identityBefore);
+      const identityAddrAfter: string = await identityDuringRetry!.getAddress();
+      expect(identityAddrAfter.toLowerCase()).toBe(identityAddrBefore.toLowerCase());
+      expect((adapter as any).initialized).toBe(true);
+    },
+    30_000,
+  );
+
+  it(
+    'withHubStaleRetryAny: unrelated revert messages do NOT invalidate bindings and do NOT retry',
+    async () => {
+      const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
+      (adapter as any).provider.pollingInterval = 250;
+      await (adapter as any).init();
+      await drainHistoricalRotationEvents(adapter);
+
+      const identityBefore: Contract = (adapter as any).contracts.identity;
+      expect(identityBefore).toBeDefined();
+
+      let calls = 0;
+      let caught: Error | null = null;
+      try {
+        await (adapter as any).withHubStaleRetryAny(async () => {
+          calls += 1;
+          throw new Error('execution reverted: ProfileDoesntExist(0)');
+        });
+      } catch (err) {
+        caught = err as Error;
+      }
+
+      expect(caught).not.toBeNull();
+      expect(caught!.message).toMatch(/ProfileDoesntExist/);
+      expect(calls).toBe(1);
+
+      // Same handle reference — wrapper didn't touch the cache.
+      expect((adapter as any).contracts.identity).toBe(identityBefore);
+      expect((adapter as any).initialized).toBe(true);
+    },
+    30_000,
   );
 });

--- a/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
+++ b/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
@@ -493,6 +493,46 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   );
 
   it(
+    'event listener (generic): boot-bound rotation clears publish preflight cache before TTL',
+    async () => {
+      const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
+      (adapter as any).provider.pollingInterval = 250;
+
+      await (adapter as any).init();
+      await drainHistoricalRotationEvents(adapter);
+
+      const kav10Before = await adapter.getKnowledgeAssetsV10Address();
+      expect((adapter as any).cachedKav10Address?.value.toLowerCase()).toBe(
+        kav10Before.toLowerCase(),
+      );
+
+      const deployer = new Wallet(HARDHAT_KEYS.DEPLOYER, ctx.provider);
+      const replacementAddr = freshAddress();
+
+      try {
+        await rotateHubContract(ctx.hubAddress, deployer, 'KnowledgeAssetsV10', replacementAddr);
+
+        const observed = await waitFor(
+          () =>
+            (adapter as any).contracts.knowledgeAssetsV10 === undefined &&
+            (adapter as any).cachedKav10Address === undefined &&
+            (adapter as any).cachedMinRequiredSignatures === undefined &&
+            (adapter as any).initialized === false,
+          15_000,
+          100,
+        );
+        expect(observed).toBe(true);
+
+        const kav10After = await adapter.getKnowledgeAssetsV10Address();
+        expect(kav10After.toLowerCase()).toBe(replacementAddr.toLowerCase());
+      } finally {
+        await rotateHubContract(ctx.hubAddress, deployer, 'KnowledgeAssetsV10', kav10Before);
+      }
+    },
+    60_000,
+  );
+
+  it(
     'event listener (generic): rotating an unknown contract name is ignored — no fields touched',
     async () => {
       const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
@@ -533,6 +573,10 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       const identityBefore: Contract = (adapter as any).contracts.identity;
       expect(identityBefore).toBeDefined();
       const identityAddrBefore: string = await identityBefore.getAddress();
+      await adapter.getKnowledgeAssetsV10Address();
+      await adapter.getMinimumRequiredSignatures();
+      expect((adapter as any).cachedKav10Address).toBeDefined();
+      expect((adapter as any).cachedMinRequiredSignatures).toBeDefined();
 
       let calls = 0;
       let identityDuringRetry: Contract | undefined;
@@ -561,6 +605,8 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       const identityAddrAfter: string = await identityDuringRetry!.getAddress();
       expect(identityAddrAfter.toLowerCase()).toBe(identityAddrBefore.toLowerCase());
       expect((adapter as any).initialized).toBe(true);
+      expect((adapter as any).cachedKav10Address).toBeUndefined();
+      expect((adapter as any).cachedMinRequiredSignatures).toBeUndefined();
     },
     30_000,
   );

--- a/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
+++ b/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
@@ -14,8 +14,8 @@
  *
  *   1. TTL refresh    — cached address is replaced after `ttlMs` elapses
  *                       and the next adapter call re-resolves from Hub.
- *   2. Event listener — adapter's `Hub.ContractChanged`/`NewContract`
- *                       subscription invalidates the cache as soon as
+ *   2. Event listener — adapter's Hub contract/storage rotation
+ *                       subscriptions invalidate the cache as soon as
  *                       the rotation is mined.
  *   3. Self-heal      — `withHubStaleRetry()` catches the exact revert
  *                       wording the prover sees in the wild
@@ -48,9 +48,13 @@ import {
 // as accounts[0].
 const HUB_ABI = [
   'function getContractAddress(string) view returns (address)',
+  'function getAssetStorageAddress(string) view returns (address)',
   'function setContractAddress(string, address) external',
+  'function setAssetStorageAddress(string, address) external',
   'event ContractChanged(string contractName, address newContractAddress)',
   'event NewContract(string contractName, address newContractAddress)',
+  'event AssetStorageChanged(string contractName, address newContractAddress)',
+  'event NewAssetStorage(string contractName, address newContractAddress)',
 ];
 
 let ctx: HardhatContext;
@@ -70,6 +74,16 @@ function makeAdapter(rpcUrl: string, hubAddress: string, refreshMs: number): EVM
 async function readHubAddress(hubAddress: string, signer: Wallet, name: string): Promise<string> {
   const hub = new Contract(hubAddress, HUB_ABI, signer);
   return hub.getContractAddress(name);
+}
+
+/** Resolve asset-storage `name` straight from the on-chain Hub. */
+async function readHubAssetStorageAddress(
+  hubAddress: string,
+  signer: Wallet,
+  name: string,
+): Promise<string> {
+  const hub = new Contract(hubAddress, HUB_ABI, signer);
+  return hub.getAssetStorageAddress(name);
 }
 
 /**
@@ -93,6 +107,18 @@ async function rotateHubContract(
 ): Promise<void> {
   const hub = new Contract(hubAddress, HUB_ABI, signer);
   const tx = await hub.setContractAddress(name, newAddr);
+  await tx.wait();
+}
+
+/** Re-register an asset-storage binding to `newAddr` on-chain. */
+async function rotateHubAssetStorage(
+  hubAddress: string,
+  signer: Wallet,
+  name: string,
+  newAddr: string,
+): Promise<void> {
+  const hub = new Contract(hubAddress, HUB_ABI, signer);
+  const tx = await hub.setAssetStorageAddress(name, newAddr);
   await tx.wait();
 }
 
@@ -449,7 +475,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
   // ===================================================================
 
   it(
-    'event listener (generic): rotating Identity nulls this.contracts.identity and re-arms init()',
+    'event listener (generic): rotating Identity preserves live handle and re-arms init()',
     async () => {
       // High TTL — only the event listener can flip the field within
       // the test window. (RS cache has its own TTL; the generic path
@@ -468,10 +494,11 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       try {
         await rotateHubContract(ctx.hubAddress, deployer, 'Identity', replacementAddr);
 
-        // Listener nulls the field AND flips `initialized`.
+        // Listener keeps the field usable for in-flight calls and flips
+        // `initialized` so the next public entry re-resolves from Hub.
         const observed = await waitFor(
           () =>
-            (adapter as any).contracts.identity === undefined &&
+            (adapter as any).contracts.identity === identityBefore &&
             (adapter as any).initialized === false,
           15_000,
           100,
@@ -502,6 +529,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       await drainHistoricalRotationEvents(adapter);
 
       const kav10Before = await adapter.getKnowledgeAssetsV10Address();
+      const kav10HandleBefore: Contract = (adapter as any).contracts.knowledgeAssetsV10;
       expect((adapter as any).cachedKav10Address?.value.toLowerCase()).toBe(
         kav10Before.toLowerCase(),
       );
@@ -514,7 +542,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
 
         const observed = await waitFor(
           () =>
-            (adapter as any).contracts.knowledgeAssetsV10 === undefined &&
+            (adapter as any).contracts.knowledgeAssetsV10 === kav10HandleBefore &&
             (adapter as any).cachedKav10Address === undefined &&
             (adapter as any).cachedMinRequiredSignatures === undefined &&
             (adapter as any).initialized === false,
@@ -527,6 +555,63 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
         expect(kav10After.toLowerCase()).toBe(replacementAddr.toLowerCase());
       } finally {
         await rotateHubContract(ctx.hubAddress, deployer, 'KnowledgeAssetsV10', kav10Before);
+      }
+    },
+    60_000,
+  );
+
+  it(
+    'event listener (asset storage): rotating ContextGraphStorage preserves live handle and re-arms init()',
+    async () => {
+      const adapter = makeAdapter(ctx.rpcUrl, ctx.hubAddress, 600_000);
+      (adapter as any).provider.pollingInterval = 250;
+
+      await (adapter as any).init();
+      await drainHistoricalRotationEvents(adapter);
+
+      const storageBefore: Contract = (adapter as any).contracts.contextGraphStorage;
+      expect(storageBefore).toBeDefined();
+      const storageAddrBefore: string = await storageBefore.getAddress();
+
+      const deployer = new Wallet(HARDHAT_KEYS.DEPLOYER, ctx.provider);
+      const hubAddrBefore = await readHubAssetStorageAddress(
+        ctx.hubAddress,
+        deployer,
+        'ContextGraphStorage',
+      );
+      expect(hubAddrBefore.toLowerCase()).toBe(storageAddrBefore.toLowerCase());
+      const replacementAddr = freshAddress();
+
+      try {
+        await rotateHubAssetStorage(
+          ctx.hubAddress,
+          deployer,
+          'ContextGraphStorage',
+          replacementAddr,
+        );
+
+        const observed = await waitFor(
+          () =>
+            (adapter as any).contracts.contextGraphStorage === storageBefore &&
+            (adapter as any).initialized === false,
+          15_000,
+          100,
+        );
+        expect(observed).toBe(true);
+
+        await (adapter as any).init();
+        const storageAfter: Contract = (adapter as any).contracts.contextGraphStorage;
+        expect(storageAfter).toBeDefined();
+        const storageAddrAfter: string = await storageAfter.getAddress();
+        expect(storageAddrAfter.toLowerCase()).toBe(replacementAddr.toLowerCase());
+        expect(storageAddrAfter.toLowerCase()).not.toBe(storageAddrBefore.toLowerCase());
+      } finally {
+        await rotateHubAssetStorage(
+          ctx.hubAddress,
+          deployer,
+          'ContextGraphStorage',
+          storageAddrBefore,
+        );
       }
     },
     60_000,

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -107,9 +107,12 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'translateRandomSamplingError',
   'toNodeChallenge',
   // Hub-rotation handling — adapter-internal plumbing that backs the
-  // self-refreshing RS resolution. The mock has no Hub, so no live
-  // rotation surface to mirror.
+  // self-refreshing RS resolution and the generic boot-bound contract
+  // self-refresh (rc.12 PR `feat/chain-hub-rotation-auto-recovery`).
+  // The mock has no Hub, so no live rotation surface to mirror.
   'withHubStaleRetry',
+  'withHubStaleRetryAny',
+  'invalidateAllBoundContracts',
   'startHubRotationListener',
   'invalidateRandomSamplingPair',
   'resolveAndAssignRandomSamplingPair',

--- a/packages/core/src/crypto/workspace-encryption.ts
+++ b/packages/core/src/crypto/workspace-encryption.ts
@@ -297,7 +297,7 @@ export function encodeWorkspaceEncryptionKey(bytes: Uint8Array): string {
 
 export function decodeWorkspaceEncryptionKey(value: string): Uint8Array {
   const raw = value.trim();
-  const bytes = raw.startsWith('0x')
+  const bytes = /^0x[0-9a-fA-F]{64}$/.test(raw)
     ? Buffer.from(raw.slice(2), 'hex')
     : Buffer.from(padBase64(raw.replace(/-/g, '+').replace(/_/g, '/')), 'base64');
   const out = new Uint8Array(bytes);

--- a/packages/core/test/workspace-encryption.test.ts
+++ b/packages/core/test/workspace-encryption.test.ts
@@ -8,8 +8,10 @@ import {
   WORKSPACE_ENCRYPTION_KEY_BYTES,
   WORKSPACE_RECIPIENT_ENCRYPTION_KEY_PURPOSE,
   assertSupportedEncryptedWorkspaceEnvelope,
+  decodeWorkspaceEncryptionKey,
   decryptWorkspacePayload,
   encryptWorkspacePayload,
+  encodeWorkspaceEncryptionKey,
   generateWorkspaceRecipientEncryptionKey,
   type EncryptWorkspacePayloadInput,
   type WorkspaceRecipientEncryptionKey,
@@ -158,5 +160,13 @@ describe('workspace encrypted payload helpers', () => {
     expect(key.recipientKeyId).toBe('alice-key-1');
     expect(key.publicKeyBytes).toHaveLength(WORKSPACE_ENCRYPTION_KEY_BYTES);
     expect(key.privateKeyBytes).toHaveLength(WORKSPACE_ENCRYPTION_KEY_BYTES);
+  });
+
+  it('decodes base64url keys that happen to start with 0x', () => {
+    const encoded = `0x${'A'.repeat(41)}`;
+    const bytes = decodeWorkspaceEncryptionKey(encoded);
+
+    expect(bytes).toHaveLength(WORKSPACE_ENCRYPTION_KEY_BYTES);
+    expect(encodeWorkspaceEncryptionKey(bytes)).toBe(encoded);
   });
 });

--- a/packages/publisher/test/async-lift-subtraction.test.ts
+++ b/packages/publisher/test/async-lift-subtraction.test.ts
@@ -4,7 +4,12 @@ import { GraphManager } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
-import { DKGPublisher, generateSubGraphRegistration } from '../src/index.js';
+import {
+  DKGPublisher,
+  generateSubGraphRegistration,
+  getConfirmedStatusQuad,
+  getTentativeStatusQuad,
+} from '../src/index.js';
 import { validateLiftPublishPayload } from '../src/async-lift-validation.js';
 import { subtractFinalizedExactQuads } from '../src/async-lift-subtraction.js';
 import type { LiftValidationInput } from '../src/async-lift-validation.js';
@@ -91,6 +96,12 @@ describe('subtractFinalizedExactQuads', () => {
         publisherPeerId: 'peer-1',
       },
     };
+  }
+
+  async function markTentativePublishConfirmed(result: { readonly ual: string; readonly status: string }): Promise<void> {
+    expect(result.status).toBe('tentative');
+    await store.delete([getTentativeStatusQuad(result.ual, CONTEXT_GRAPH)]);
+    await store.insert([getConfirmedStatusQuad(result.ual, CONTEXT_GRAPH)]);
   }
 
   it('removes only the exact finalized public quads and keeps the remainder', async () => {
@@ -186,12 +197,13 @@ describe('subtractFinalizedExactQuads', () => {
     };
     const validated = validateLiftPublishPayload(input);
 
-    await publisher.publish({
+    const publishResult = await publisher.publish({
       contextGraphId: CONTEXT_GRAPH,
       quads: validated.resolved.quads,
       privateQuads: validated.resolved.privateQuads,
       publisherPeerId: 'peer-1',
     });
+    await markTentativePublishConfirmed(publishResult);
 
     const result = await subtractFinalizedExactQuads({
       store,
@@ -222,12 +234,13 @@ describe('subtractFinalizedExactQuads', () => {
     };
     const validated = validateLiftPublishPayload(input);
 
-    await publisher.publish({
+    const publishResult = await publisher.publish({
       contextGraphId: CONTEXT_GRAPH,
       quads: validated.resolved.quads,
       privateQuads: validated.resolved.privateQuads,
       publisherPeerId: 'peer-1',
     });
+    await markTentativePublishConfirmed(publishResult);
 
     const result = await subtractFinalizedExactQuads({
       store,


### PR DESCRIPTION
## Why

When rc.11 redeployed 6 contracts on Base Sepolia (PCA split, ShardingTable, etc.), the running daemon on Miles kept calling the pre-rotation `DKGPublishingConvictionNFT` address until we manually `dkg stop && dkg start`. Root cause: only `RandomSampling` / `RandomSamplingStorage` were wired into the `Hub.ContractChanged` / `NewContract` listener — every other boot-bound contract was resolved once at `init()` and never refreshed without a process restart.

## What

Two layered fixes, mirroring the RS-specific pattern that's already in production.

### 1. Listener generalization (Option A)

`startHubRotationListener` now dispatches via a `BOUND_CONTRACT_INVALIDATORS` map keyed by Hub contract name. On `ContractChanged` / `NewContract` for any boot-bound name, the listener nulls the corresponding `this.contracts.X` field and flips `this.initialized=false`. The next public-method entry re-runs `init()` and re-resolves every binding fresh from Hub.

- RS pair keeps its dedicated handler — it owns side-channel state (in-flight probe, ready flag) that a simple field reset doesn't touch.
- Unknown names are deliberately allowlisted — third-party Hub registrations don't thrash our cache.

### 2. Write-side self-heal (Option C)

New `withHubStaleRetryAny()` catches `UnauthorizedAccess(Only Contracts in Hub)` reverts, drops every boot-bound handle via `invalidateAllBoundContracts()`, re-runs `init()`, and retries the closure once.

This is the belt-and-braces layer for environments where the event listener can't fire — HTTP-only RPC endpoints that don't support filter subscriptions, dropped subs, rate-limited filter installs. All observed in the wild on public Base Sepolia / Gnosis Chain RPCs.

Wired into `pcaWrite` so all 5 PCA write methods (`createPublishingConvictionAccount`, `topUpPublishingConvictionAccount`, `settlePublishingConvictionAccount`, `registerPublishingConvictionAgent`, `resetPublishingConvictionEpochCharge`) self-heal on the first write after a Hub rotation.

## Tests

4 new E2E cases in `evm-adapter-hub-rotation.e2e.test.ts`:

- `event listener (generic): rotating Identity nulls this.contracts.identity and re-arms init()`
- `event listener (generic): rotating an unknown contract name is ignored — no fields touched`
- `withHubStaleRetryAny: marker error invalidates ALL boot-bound contracts, re-inits, and retries once`
- `withHubStaleRetryAny: unrelated revert messages do NOT invalidate bindings and do NOT retry`

New `drainHistoricalRotationEvents()` helper absorbs cross-test event bleed — also a real production parallel (a daemon that boots immediately after a Hub rotation catches the rotation it didn't directly subscribe to).

`pnpm vitest run` on `packages/chain`: 401/401 pass (including 11/11 in the hub-rotation E2E suite).

## Out of scope (tracked separately)

- Option B: migrate every boot-bound contract to `HubResolutionCache` (per-binding lazy refresh) so we can drop the coarse "re-run init() to re-resolve everything" hammer. Larger refactor, follow-up issue.
- Wrapping the remaining V10 write paths (`createKnowledgeAssetsV10`, `createContextGraph`, `updateKnowledgeCollectionV10`, `registerIdentity`, etc.) with `withHubStaleRetryAny`. Same issue.

## Test plan

- [x] Local: `pnpm --filter @origintrail-official/dkg-chain build` — clean
- [x] Local: `pnpm --filter @origintrail-official/dkg-chain test:unit` — 59/59 pass
- [x] Local: `pnpm vitest run --config vitest.config.ts` (full chain suite, Hardhat-backed) — 401/401 pass
- [ ] CI green
- [ ] Devnet test: simulate Hub rotation of a non-RS boot-bound contract, confirm running daemon picks up the new address without restart

Made with [Cursor](https://cursor.com)