### PR TITLE
feat(node-ui): N6 polish bundle — lifecycle events, quieter empty state, agent attribution

### DIFF
--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -72,6 +72,18 @@ export interface ActivityFeedProps {
    * AgentProfileView omits this; it stays on `swmEvents` for now.
    */
   lifecycleEvents?: ReadonlyArray<AssertionLifecycleEvent>;
+  /**
+   * PR #694 Comment 8 — when set, the lifecycle SPARQL failed for
+   * the current context graph. Surface a quiet inline error indicator
+   * in place of (or above) the empty hint so the consumer can
+   * distinguish "no local activity yet" from "the activity stream
+   * couldn't load". The hook clears `events` on failure but our
+   * Comment 3 fix advances `resultContextGraphId` to the current
+   * cgId in the catch path so consumers can no longer detect failure
+   * by `events.length === 0` alone — this prop is the explicit
+   * signal. Only the Overview supplies it; other callers omit.
+   */
+  lifecycleError?: string | null;
   title?: React.ReactNode;
   onSelectEntity: (uri: string) => void;
   /** Optional click handler for author chips (navigate to agent profile). */
@@ -80,6 +92,14 @@ export interface ActivityFeedProps {
   emptyHint?: React.ReactNode;
   className?: string;
 }
+
+// Mirror of `useProjectActivityEvents`'s default cap so the title-
+// badge "saturation indicator" stays in sync with the joiner's cap
+// without needing the joiner to return a `total` count alongside the
+// items. PR #694 Comment 9 — the badge previously rendered the
+// post-slice count, implying a project had exactly `limit` items
+// when it actually had more.
+const DEFAULT_ITEM_LIMIT = 200;
 
 export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   entities,
@@ -90,6 +110,7 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   includeUndated = true,
   swmEvents,
   lifecycleEvents,
+  lifecycleError,
   title,
   onSelectEntity,
   onOpenAgent,
@@ -107,6 +128,16 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   const agents = useAgentsContext();
   const profile = useProjectProfileContext();
 
+  // PR #694 Comment 9 — render `${limit}+` when the feed is at-cap
+  // so the user can tell "saturated" apart from "this project happens
+  // to have exactly `limit` items". The joiner's default cap is
+  // `DEFAULT_ITEM_LIMIT` (200) when the caller passes no `limit`.
+  // Cheapest correct fix that doesn't change the joiner's API.
+  const effectiveLimit = limit ?? DEFAULT_ITEM_LIMIT;
+  const titleCount = items.length >= effectiveLimit
+    ? `${effectiveLimit}+`
+    : String(items.length);
+
   // N6 polish (item 3) — title row gets a total-feed count badge
   // mirroring the per-bucket chip; we render the same row in both
   // the empty and populated branches so the heading stays anchored
@@ -114,9 +145,30 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   const titleRow = title ? (
     <div className="v10-activity-feed-title">
       <span className="v10-activity-feed-title-label">{title}</span>
-      <span className="v10-activity-feed-title-count">{items.length}</span>
+      <span className="v10-activity-feed-title-count">{titleCount}</span>
     </div>
   ) : null;
+
+  // PR #694 Comment 8 — when the lifecycle SPARQL errored, surface
+  // an honest indicator instead of degrading to a normal empty feed.
+  // Quieter than the prior `EmptyState` primitive (same tertiary
+  // family as the empty hint) so we don't shout, but still
+  // distinguishable from the silent empty case.
+  if (lifecycleError) {
+    return (
+      <div className={`v10-activity-feed v10-activity-feed-empty ${className}`}>
+        {titleRow}
+        <div
+          className="v10-activity-feed-error"
+          role="status"
+          aria-live="polite"
+          title={lifecycleError}
+        >
+          Couldn't load recent activity. Retrying…
+        </div>
+      </div>
+    );
+  }
 
   if (items.length === 0) {
     // N6 polish (item 2) — the centered bold `EmptyState` primitive

--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -120,23 +120,22 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   // useProjectActivityEvents reduces to plain useProjectActivity when
   // both swmEvents and lifecycleEvents are undefined, so existing
   // callers (AgentProfileView) get identical behaviour without
-  // passing the new props.
-  const items = useProjectActivityEvents(entities, {
+  // passing the new props. Returns `{ items, hasMore }` — `hasMore`
+  // is the pre-slice honest signal for the title saturation badge
+  // (PR #694 Comment 13).
+  const { items, hasMore } = useProjectActivityEvents(entities, {
     agentUri, typeIri, subGraph, limit, includeUndated, swmEvents, lifecycleEvents,
   });
   const buckets = React.useMemo(() => bucketActivity(items), [items]);
   const agents = useAgentsContext();
   const profile = useProjectProfileContext();
 
-  // PR #694 Comment 9 — render `${limit}+` when the feed is at-cap
-  // so the user can tell "saturated" apart from "this project happens
-  // to have exactly `limit` items". The joiner's default cap is
-  // `DEFAULT_ITEM_LIMIT` (200) when the caller passes no `limit`.
-  // Cheapest correct fix that doesn't change the joiner's API.
+  // PR #694 Comment 13 — render `${effectiveLimit}+` only when the
+  // joiner reports rows were dropped. Boundary case: a project with
+  // exactly `effectiveLimit` rows shows the exact count, not the
+  // saturation indicator (the prior `>=` heuristic overstated here).
   const effectiveLimit = limit ?? DEFAULT_ITEM_LIMIT;
-  const titleCount = items.length >= effectiveLimit
-    ? `${effectiveLimit}+`
-    : String(items.length);
+  const titleCount = hasMore ? `${effectiveLimit}+` : String(items.length);
 
   // N6 polish (item 3) — title row gets a total-feed count badge
   // mirroring the per-bucket chip; we render the same row in both
@@ -149,37 +148,41 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
     </div>
   ) : null;
 
-  // PR #694 Comment 8 — when the lifecycle SPARQL errored, surface
-  // an honest indicator instead of degrading to a normal empty feed.
-  // Quieter than the prior `EmptyState` primitive (same tertiary
-  // family as the empty hint) so we don't shout, but still
-  // distinguishable from the silent empty case.
-  if (lifecycleError) {
-    return (
-      <div className={`v10-activity-feed v10-activity-feed-empty ${className}`}>
-        {titleRow}
-        <div
-          className="v10-activity-feed-error"
-          role="status"
-          aria-live="polite"
-          title={lifecycleError}
-        >
-          Couldn't load recent activity. Retrying…
-        </div>
-      </div>
-    );
-  }
+  // PR #694 Comment 8 + 11 — when the lifecycle SPARQL errored,
+  // render a quiet inline error indicator. Comment 11 narrowed the
+  // Comment 8 fix: the indicator renders INLINE (above buckets,
+  // below the title), so typed Decision/Task/PR rows from the BASE
+  // entity-list path still render when present — a lifecycle
+  // failure shouldn't blank the whole feed. Only when `items.length
+  // === 0` does the indicator replace the empty hint. Copy is
+  // "Couldn't load recent activity." (qa-lead tweak — dropped
+  // "Retrying…" because the hook only re-fetches on cgId change,
+  // not on a timer).
+  const errorBanner = lifecycleError ? (
+    <div
+      className="v10-activity-feed-error"
+      role="status"
+      aria-live="polite"
+      title={lifecycleError}
+    >
+      Couldn't load recent activity.
+    </div>
+  ) : null;
 
   if (items.length === 0) {
     // N6 polish (item 2) — the centered bold `EmptyState` primitive
     // read as a load-bearing message; quieter inline tertiary text
     // recedes so the rest of the Overview stays the focal area.
+    // The error banner takes precedence over the empty hint here so
+    // the user doesn't see two contradictory states (Comment 8).
     return (
       <div className={`v10-activity-feed v10-activity-feed-empty ${className}`}>
         {titleRow}
-        <div className="v10-activity-feed-empty-hint">
-          {emptyHint ?? 'No activity with a timestamp yet.'}
-        </div>
+        {errorBanner ?? (
+          <div className="v10-activity-feed-empty-hint">
+            {emptyHint ?? 'No activity with a timestamp yet.'}
+          </div>
+        )}
       </div>
     );
   }
@@ -187,6 +190,7 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   return (
     <div className={`v10-activity-feed ${className}`}>
       {titleRow}
+      {errorBanner}
       {buckets.map(bucket => (
         <div key={bucket.key} className="v10-activity-feed-bucket">
           <div className="v10-activity-feed-bucket-head">

--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -23,9 +23,9 @@ import {
   type ActivityItem,
   type PromotionAttribution as ActivityFeedEvent,
 } from '../hooks/useProjectActivity.js';
+import type { AssertionLifecycleEvent } from '../hooks/useAssertionLifecycleEvents.js';
 import { useAgentsContext } from '../hooks/useAgents.js';
 import { useProjectProfileContext } from '../hooks/useProjectProfile.js';
-import { EmptyState } from './ContextGraphPrimitives.js';
 import { AgentChip } from './AgentChip.js';
 
 const LAYER_COLOR: Record<TrustLevel, string> = {
@@ -62,6 +62,16 @@ export interface ActivityFeedProps {
    * `attributions` map to the raw event list.
    */
   swmEvents?: ReadonlyArray<ActivityFeedEvent>;
+  /**
+   * N6 polish (task #23) — bundle-keyed lifecycle events from
+   * `useAssertionLifecycleEvents`. When supplied, this is the
+   * authoritative source for `'added'` (from `dkg:AssertionCreated`)
+   * and `'promoted'` (from `dkg:AssertionPromoted`) rows. The
+   * entity-list `dcterms:created` rows and `swmEvents` promotions
+   * are suppressed so we don't render the same transition twice.
+   * AgentProfileView omits this; it stays on `swmEvents` for now.
+   */
+  lifecycleEvents?: ReadonlyArray<AssertionLifecycleEvent>;
   title?: React.ReactNode;
   onSelectEntity: (uri: string) => void;
   /** Optional click handler for author chips (navigate to agent profile). */
@@ -79,6 +89,7 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   limit,
   includeUndated = true,
   swmEvents,
+  lifecycleEvents,
   title,
   onSelectEntity,
   onOpenAgent,
@@ -86,31 +97,44 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   className = '',
 }) => {
   // useProjectActivityEvents reduces to plain useProjectActivity when
-  // swmEvents is undefined, so existing callers (AgentProfileView)
-  // get identical behaviour without passing the new prop.
+  // both swmEvents and lifecycleEvents are undefined, so existing
+  // callers (AgentProfileView) get identical behaviour without
+  // passing the new props.
   const items = useProjectActivityEvents(entities, {
-    agentUri, typeIri, subGraph, limit, includeUndated, swmEvents,
+    agentUri, typeIri, subGraph, limit, includeUndated, swmEvents, lifecycleEvents,
   });
   const buckets = React.useMemo(() => bucketActivity(items), [items]);
   const agents = useAgentsContext();
   const profile = useProjectProfileContext();
 
+  // N6 polish (item 3) — title row gets a total-feed count badge
+  // mirroring the per-bucket chip; we render the same row in both
+  // the empty and populated branches so the heading stays anchored
+  // (showing "0" rather than vanishing into the empty state).
+  const titleRow = title ? (
+    <div className="v10-activity-feed-title">
+      <span className="v10-activity-feed-title-label">{title}</span>
+      <span className="v10-activity-feed-title-count">{items.length}</span>
+    </div>
+  ) : null;
+
   if (items.length === 0) {
+    // N6 polish (item 2) — the centered bold `EmptyState` primitive
+    // read as a load-bearing message; quieter inline tertiary text
+    // recedes so the rest of the Overview stays the focal area.
     return (
       <div className={`v10-activity-feed v10-activity-feed-empty ${className}`}>
-        {title && <div className="v10-activity-feed-title">{title}</div>}
-        <EmptyState
-          compact
-          title={emptyHint ?? 'No activity with a timestamp yet.'}
-          className="v10-activity-feed-empty-state"
-        />
+        {titleRow}
+        <div className="v10-activity-feed-empty-hint">
+          {emptyHint ?? 'No activity with a timestamp yet.'}
+        </div>
       </div>
     );
   }
 
   return (
     <div className={`v10-activity-feed ${className}`}>
-      {title && <div className="v10-activity-feed-title">{title}</div>}
+      {titleRow}
       {buckets.map(bucket => (
         <div key={bucket.key} className="v10-activity-feed-bucket">
           <div className="v10-activity-feed-bucket-head">
@@ -159,8 +183,17 @@ function ActivityRow({
   const typeBinding = isTyped && item.kindUri ? profile?.forType(item.kindUri) : null;
   const typeLabel = ((): string => {
     if (item.event === 'added') return 'Added';
-    if (item.event === 'promoted') return 'Promoted to Shared Working Memory';
-    if (item.event === 'published') return 'Published to Verifiable Memory';
+    if (item.event === 'promoted') {
+      // Promote rows from `dkg:AssertionPromoted` carry the per-bundle
+      // root-entity count; surface it inline so a single row reads as
+      // "one promote action of N entities" instead of needing N
+      // separate rows. Hidden when missing (legacy WorkspaceOperation
+      // fallback rows) or zero.
+      return item.entityCount != null && item.entityCount > 0
+        ? `Promoted to SWM · ${item.entityCount} ${item.entityCount === 1 ? 'entity' : 'entities'}`
+        : 'Promoted to SWM';
+    }
+    if (item.event === 'published') return 'Published to VM';
     return typeBinding?.label ?? (item.kindUri ? item.kindUri.split(/[#/]/).pop() : null) ?? 'Entity';
   })();
   const typeIcon = ((): string => {

--- a/packages/node-ui/src/ui/components/AgentChip.tsx
+++ b/packages/node-ui/src/ui/components/AgentChip.tsx
@@ -48,6 +48,21 @@ function initials(name: string): string {
   return (parts[0][0] + (parts[1][0] ?? '')).toUpperCase();
 }
 
+/**
+ * N6 polish (item 4) — when we fall back to a raw identifier (no
+ * resolved agent profile available), truncate so libp2p peer ids
+ * (`12D3K…b9a3`) and eth addresses (`0xaaaa…bbbb`) don't blow the
+ * pill layout. Pattern matches plan S13 (`agent-docs/context-graph-
+ * implementation-plan.md`): head 6 + ellipsis + tail 4. Short
+ * identifiers (<= head+tail+1) render unchanged so we never insert
+ * an ellipsis that hides nothing.
+ */
+function truncateFallbackId(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length <= 11) return trimmed;
+  return `${trimmed.slice(0, 6)}…${trimmed.slice(-4)}`;
+}
+
 export const AgentChip: React.FC<AgentChipProps> = ({
   agent,
   fallbackUri,
@@ -65,7 +80,11 @@ export const AgentChip: React.FC<AgentChipProps> = ({
   const resolvedOpen = onOpenAgent ?? ctxAgents?.openAgent;
 
   const uri  = agent?.uri ?? fallbackUri!;
-  const name = agent?.name ?? (fallbackUri?.split(':').pop() ?? 'unknown');
+  // N6 polish (item 4) — only truncate the FALLBACK path. Resolved
+  // agents already have a human-readable `name`; truncating that
+  // would hide useful display info.
+  const name = agent?.name
+    ?? (fallbackUri ? truncateFallbackId(fallbackUri.split(':').pop() ?? fallbackUri) : 'unknown');
   const kind = agent?.kind ?? 'ai';
   const framework = agent?.framework;
   const glyph = framedGlyph(framework, kind);

--- a/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
+++ b/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
@@ -81,11 +81,23 @@ export function buildLifecycleEventsQuery(cgId: string): string {
   const metaGraph = `did:dkg:context-graph:${cgId}/_meta`;
   // Created events use `prov:generated` (the activity produced the
   // assertion); promoted events use `prov:used` (the activity acted
-  // on an existing assertion). UNION-bind ?assertion to the right
-  // predicate per kind. Aggregate the count of `dkg:rootEntity`
-  // bindings into ?entityCount — created events never have any
+  // on an existing assertion). Bind both as OPTIONAL and COALESCE
+  // into a single `?assertion` — the prior UNION-with-inner-FILTER
+  // shape silently returned zero rows in production (the FILTER on
+  // `?type` inside the UNION branch did not interact correctly with
+  // the outer `?event a ?type` binding once an event carried multiple
+  // `rdf:type` triples — every emitted event has both
+  // `rdf:type prov:Activity` AND `rdf:type dkg:Assertion{Created,
+  // Promoted}`). Pulling the type filter OUT of the UNION (or, as
+  // here, using OPTIONAL + COALESCE without UNION at all) restores
+  // the row stream. Pinned by `use-assertion-lifecycle-events.test.ts`
+  // against the actual `oxigraph` daemon shape.
+  //
+  // Aggregate the count of `dkg:rootEntity` bindings into
+  // `?entityCount` — created events never have any
   // (`generateAssertionCreatedMetadata` does not emit them) so they
-  // group to 0 cleanly; promoted events report one row per bundle.
+  // group to 0 cleanly; the consumer normalises 0 → undefined.
+  // Promoted events report one row per bundle.
   //
   // PR #694 review fix — the lifecycle metadata writers
   // (`generateAssertionCreatedMetadata` / `…PromotedMetadata`) do
@@ -103,9 +115,10 @@ SELECT ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph (COUNT(?root) AS
     ?event a ?type ;
            prov:startedAtTime ?ts ;
            prov:wasAssociatedWith ?agent .
-    { ?event prov:generated ?assertion . FILTER(?type = dkg:AssertionCreated) }
-    UNION
-    { ?event prov:used ?assertion . FILTER(?type = dkg:AssertionPromoted) }
+    FILTER(?type IN (dkg:AssertionCreated, dkg:AssertionPromoted))
+    OPTIONAL { ?event prov:generated ?gen }
+    OPTIONAL { ?event prov:used ?used }
+    BIND(COALESCE(?gen, ?used) AS ?assertion)
     ?assertion dkg:assertionName ?name .
     OPTIONAL { ?assertion dkg:assertionGraph ?assertionGraph }
     OPTIONAL { ?event dkg:rootEntity ?root }

--- a/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
+++ b/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
@@ -173,12 +173,25 @@ export function useAssertionLifecycleEvents(
 
   useEffect(() => {
     if (!contextGraphId) {
-      setEvents([]);
+      // PR #694 Comment 20 — when the caller gates the hook off (e.g.
+      // user switched away from Overview), STOP fetching but preserve
+      // the last successful result so returning to the gated state
+      // doesn't render an empty feed during the re-fetch window. The
+      // `resultContextGraphId === contextGraphId` discriminator in
+      // consumers still correctly identifies "stale prev-project
+      // result" when the user later switches to a different cgId,
+      // because that new cgId will trigger a fresh fetch.
       setLoading(false);
+      return;
+    }
+    // Stale cache from a DIFFERENT cgId — clear so the consumer's
+    // discriminator doesn't accidentally accept prev-project events
+    // during the new fetch window. Compared via the ref so this
+    // effect can stay keyed only on `contextGraphId`.
+    if (lastRequestedCg.current != null && lastRequestedCg.current !== contextGraphId) {
+      setEvents([]);
       setError(null);
       setResultContextGraphId(undefined);
-      lastRequestedCg.current = undefined;
-      return;
     }
     let cancelled = false;
     const controller = new AbortController();

--- a/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
+++ b/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
@@ -1,0 +1,234 @@
+/**
+ * useAssertionLifecycleEvents — assertion-lifecycle activity source.
+ *
+ * Queries the project's `_meta` graph for `dkg:AssertionCreated` and
+ * `dkg:AssertionPromoted` events emitted by `generateAssertionCreatedMetadata`
+ * / `generateAssertionPromotedMetadata` (`packages/publisher/src/metadata.ts`).
+ *
+ * Why this exists separately from `useSwmAttributions`:
+ *
+ *   - `useSwmAttributions` is the source-of-truth for the SWM graph's
+ *     per-agent attribution coloring + legend. It queries
+ *     `dkg:WorkspaceOperation` records in `_shared_memory_meta` which
+ *     are keyed on `publisherPeerId` (a libp2p peer id, `12D3…`).
+ *
+ *   - The assertion-lifecycle events emitted by the daemon are keyed
+ *     natively on the DKG agent identity (`did:dkg:agent:0x…`) — the
+ *     same identity space the rest of the UI resolves agent profiles
+ *     against. Sourcing the activity feed from these events removes
+ *     the "raw peer-id in author column" gap that PR #656 testing
+ *     surfaced without needing a peer→agent reverse index.
+ *
+ * Two record classes returned in one stream so the activity feed
+ * does a single SPARQL round-trip per project:
+ *
+ *   - `'created'` — agent created a new WM assertion bundle.
+ *   - `'promoted'` — agent promoted an existing assertion WM→SWM.
+ *
+ * `'published'` (SWM→VM) is intentionally out of scope here — it lives
+ * with `dkg:AssertionPublished` (when emitted) and the N6 publishes
+ * fold-in tracked in the implementation plan.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { authHeaders } from '../api.js';
+
+export type AssertionLifecycleKind = 'created' | 'promoted';
+
+export interface AssertionLifecycleEvent {
+  /** Stable per-event identifier (`prov:Activity` URI). */
+  eventUri: string;
+  /** Event class: which lifecycle transition this row represents. */
+  kind: AssertionLifecycleKind;
+  /** The assertion entity URI the event was generated for. */
+  assertionUri: string;
+  /** Human-readable assertion name (`dkg:assertionName` literal). */
+  assertionName: string;
+  /** DKG agent identity URI (`did:dkg:agent:0x…`) — agent-identity-keyed. */
+  agentUri: string;
+  /** ISO timestamp of the event. */
+  publishedAt: string;
+  /** Sub-graph slug if the assertion is sub-graph-scoped. */
+  subGraph?: string;
+  /**
+   * Number of root entities included in a `'promoted'` bundle —
+   * `count(?event dkg:rootEntity ?root)`. Undefined for `'created'`
+   * (the metadata writer doesn't emit `dkg:rootEntity` on creation,
+   * see `generateAssertionCreatedMetadata` in
+   * `packages/publisher/src/metadata.ts`).
+   */
+  entityCount?: number;
+}
+
+export interface AssertionLifecycleEventsResult {
+  /**
+   * Context graph id whose SPARQL response produced `events`. Lags
+   * behind the caller's `contextGraphId` during a project switch — the
+   * in-flight result is still for the *previous* graph until the new
+   * query lands. Same gate pattern as `useSwmAttributions`.
+   */
+  resultContextGraphId: string | undefined;
+  /** Sorted newest-first. Empty when the query hasn't returned yet. */
+  events: AssertionLifecycleEvent[];
+  loading: boolean;
+  error: string | null;
+}
+
+const QUERY_TIMEOUT_MS = 10_000;
+const DKG = 'http://dkg.io/ontology/';
+
+export function buildLifecycleEventsQuery(cgId: string): string {
+  const metaGraph = `did:dkg:context-graph:${cgId}/_meta`;
+  // Created events use `prov:generated` (the activity produced the
+  // assertion); promoted events use `prov:used` (the activity acted
+  // on an existing assertion). UNION-bind ?assertion to the right
+  // predicate per kind. Aggregate the count of `dkg:rootEntity`
+  // bindings into ?entityCount — created events never have any
+  // (`generateAssertionCreatedMetadata` does not emit them) so they
+  // group to 0 cleanly; promoted events report one row per bundle.
+  return `PREFIX dkg: <${DKG}>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+SELECT ?event ?type ?assertion ?name ?agent ?ts ?subGraph (COUNT(?root) AS ?entityCount) WHERE {
+  GRAPH <${metaGraph}> {
+    ?event a ?type ;
+           prov:startedAtTime ?ts ;
+           prov:wasAssociatedWith ?agent .
+    { ?event prov:generated ?assertion . FILTER(?type = dkg:AssertionCreated) }
+    UNION
+    { ?event prov:used ?assertion . FILTER(?type = dkg:AssertionPromoted) }
+    ?assertion dkg:assertionName ?name .
+    OPTIONAL { ?assertion dkg:subGraphName ?subGraph }
+    OPTIONAL { ?event dkg:rootEntity ?root }
+  }
+} GROUP BY ?event ?type ?assertion ?name ?agent ?ts ?subGraph
+  ORDER BY DESC(?ts) LIMIT 5000`;
+}
+
+function bv(v: unknown): string | undefined {
+  if (v == null) return undefined;
+  if (typeof v === 'string') {
+    return v.startsWith('"')
+      ? v.replace(/^"/, '').replace(/"(\^\^<[^>]*>)?$/, '')
+      : v;
+  }
+  if (typeof v === 'object' && v !== null && 'value' in (v as any)) {
+    return String((v as any).value);
+  }
+  return String(v);
+}
+
+function kindForType(typeUri: string | undefined): AssertionLifecycleKind | null {
+  if (typeUri === `${DKG}AssertionCreated`) return 'created';
+  if (typeUri === `${DKG}AssertionPromoted`) return 'promoted';
+  return null;
+}
+
+export function useAssertionLifecycleEvents(
+  contextGraphId: string | undefined,
+): AssertionLifecycleEventsResult {
+  const [events, setEvents] = useState<AssertionLifecycleEvent[]>([]);
+  const [loading, setLoading] = useState<boolean>(Boolean(contextGraphId));
+  const [error, setError] = useState<string | null>(null);
+  const [resultContextGraphId, setResultContextGraphId] = useState<string | undefined>(undefined);
+  const lastRequestedCg = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!contextGraphId) {
+      setEvents([]);
+      setLoading(false);
+      setError(null);
+      setResultContextGraphId(undefined);
+      lastRequestedCg.current = undefined;
+      return;
+    }
+    let cancelled = false;
+    const controller = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    lastRequestedCg.current = contextGraphId;
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const timeout = new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            controller.abort();
+            reject(new Error(
+              `Assertion-lifecycle query timed out after ${Math.round(QUERY_TIMEOUT_MS / 1000)}s`,
+            ));
+          }, QUERY_TIMEOUT_MS);
+        });
+        const request = (async () => {
+          const res = await fetch('/api/query', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeaders() },
+            signal: controller.signal,
+            body: JSON.stringify({
+              sparql: buildLifecycleEventsQuery(contextGraphId),
+              contextGraphId,
+            }),
+          });
+          if (!res.ok) throw new Error(`SPARQL query failed: ${res.status}`);
+          return res.json();
+        })();
+        const data = await Promise.race([request, timeout]);
+        if (cancelled || lastRequestedCg.current !== contextGraphId) return;
+        const rows: any[] = data?.result?.bindings ?? [];
+        const out: AssertionLifecycleEvent[] = [];
+        for (const row of rows) {
+          const eventUri = bv(row.event);
+          const typeUri = bv(row.type);
+          const assertionUri = bv(row.assertion);
+          const assertionName = bv(row.name);
+          const agentUri = bv(row.agent);
+          const ts = bv(row.ts);
+          if (!eventUri || !assertionUri || !agentUri || !ts) continue;
+          const kind = kindForType(typeUri);
+          if (!kind) continue;
+          // entityCount is only meaningful on promoted rows. The
+          // GROUP BY produces a numeric literal (often typed as
+          // xsd:integer); `bv()` strips the type tag, leaving a
+          // bare digit string. Missing/zero on created rows.
+          let entityCount: number | undefined;
+          if (kind === 'promoted') {
+            const raw = bv(row.entityCount);
+            const n = raw != null ? Number(raw) : NaN;
+            if (Number.isFinite(n) && n >= 0) entityCount = n;
+          }
+          out.push({
+            eventUri,
+            kind,
+            assertionUri,
+            assertionName: assertionName ?? '',
+            agentUri,
+            publishedAt: ts,
+            subGraph: bv(row.subGraph),
+            entityCount,
+          });
+        }
+        setEvents(out);
+        setResultContextGraphId(contextGraphId);
+        setError(null);
+      } catch (err) {
+        if (cancelled || (err as any)?.name === 'AbortError') return;
+        setError((err as Error).message ?? String(err));
+        setEvents([]);
+      } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [contextGraphId]);
+
+  return useMemo(
+    () => ({ resultContextGraphId, events, loading, error }),
+    [resultContextGraphId, events, loading, error],
+  );
+}

--- a/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
+++ b/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
@@ -86,9 +86,19 @@ export function buildLifecycleEventsQuery(cgId: string): string {
   // bindings into ?entityCount — created events never have any
   // (`generateAssertionCreatedMetadata` does not emit them) so they
   // group to 0 cleanly; promoted events report one row per bundle.
+  //
+  // PR #694 review fix — the lifecycle metadata writers
+  // (`generateAssertionCreatedMetadata` / `…PromotedMetadata`) do
+  // NOT emit `dkg:subGraphName` on the assertion subject (only
+  // `generateShareMetadata` does, and that's the WorkspaceOperation
+  // source we collapsed away from). They DO emit
+  // `dkg:assertionGraph` — a stable triple set on creation
+  // (`metadata.ts:632`). Project the assertion-graph URI and parse
+  // the sub-graph slug client-side; the URI is shaped per
+  // `contextGraphAssertionUri` in `packages/core/src/constants.ts`.
   return `PREFIX dkg: <${DKG}>
 PREFIX prov: <http://www.w3.org/ns/prov#>
-SELECT ?event ?type ?assertion ?name ?agent ?ts ?subGraph (COUNT(?root) AS ?entityCount) WHERE {
+SELECT ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph (COUNT(?root) AS ?entityCount) WHERE {
   GRAPH <${metaGraph}> {
     ?event a ?type ;
            prov:startedAtTime ?ts ;
@@ -97,11 +107,40 @@ SELECT ?event ?type ?assertion ?name ?agent ?ts ?subGraph (COUNT(?root) AS ?enti
     UNION
     { ?event prov:used ?assertion . FILTER(?type = dkg:AssertionPromoted) }
     ?assertion dkg:assertionName ?name .
-    OPTIONAL { ?assertion dkg:subGraphName ?subGraph }
+    OPTIONAL { ?assertion dkg:assertionGraph ?assertionGraph }
     OPTIONAL { ?event dkg:rootEntity ?root }
   }
-} GROUP BY ?event ?type ?assertion ?name ?agent ?ts ?subGraph
+} GROUP BY ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph
   ORDER BY DESC(?ts) LIMIT 5000`;
+}
+
+/**
+ * Parse a sub-graph slug out of a `dkg:assertionGraph` URI. Mirror of
+ * `contextGraphAssertionUri` in `packages/core/src/constants.ts`:
+ *
+ *   root-bucket : `did:dkg:context-graph:<cgId>/assertion/<agent>/<name>`
+ *   sub-graph   : `did:dkg:context-graph:<cgId>/<subGraphName>/assertion/<agent>/<name>`
+ *
+ * Returns the slug when present, `undefined` for root-bucket
+ * assertions or any URI that doesn't match the expected shape (the
+ * latter shouldn't happen in practice — `dkg:assertionGraph` is set
+ * by the writer — but the parse stays defensive so a malformed URI
+ * just suppresses the sub-graph filter rather than throwing).
+ */
+export function subGraphFromAssertionGraphUri(
+  assertionGraphUri: string,
+  contextGraphId: string,
+): string | undefined {
+  const prefix = `did:dkg:context-graph:${contextGraphId}/`;
+  if (!assertionGraphUri.startsWith(prefix)) return undefined;
+  const tail = assertionGraphUri.slice(prefix.length);
+  const segments = tail.split('/');
+  // Root-bucket: tail starts with `assertion/…` (no sub-graph segment).
+  if (segments[0] === 'assertion') return undefined;
+  // Sub-graph: `<subGraphName>/assertion/…`. Require the assertion
+  // segment to actually be there so we don't misparse stray URIs.
+  if (segments.length >= 2 && segments[1] === 'assertion') return segments[0];
+  return undefined;
 }
 
 function bv(v: unknown): string | undefined {
@@ -196,6 +235,14 @@ export function useAssertionLifecycleEvents(
             const n = raw != null ? Number(raw) : NaN;
             if (Number.isFinite(n) && n >= 0) entityCount = n;
           }
+          // PR #694 review fix — derive the sub-graph slug from
+          // `dkg:assertionGraph` (which writers DO emit) instead of
+          // `dkg:subGraphName` (which the lifecycle writers don't).
+          // Falls back to undefined for root-bucket assertions.
+          const assertionGraphUri = bv(row.assertionGraph);
+          const subGraph = assertionGraphUri
+            ? subGraphFromAssertionGraphUri(assertionGraphUri, contextGraphId)
+            : undefined;
           out.push({
             eventUri,
             kind,
@@ -203,7 +250,7 @@ export function useAssertionLifecycleEvents(
             assertionName: assertionName ?? '',
             agentUri,
             publishedAt: ts,
-            subGraph: bv(row.subGraph),
+            subGraph,
             entityCount,
           });
         }
@@ -214,6 +261,15 @@ export function useAssertionLifecycleEvents(
         if (cancelled || (err as any)?.name === 'AbortError') return;
         setError((err as Error).message ?? String(err));
         setEvents([]);
+        // PR #694 review fix — advance `resultContextGraphId` on
+        // failure so consumers gating on
+        // `resultContextGraphId === contextGraphId` (the Code7 pattern
+        // shared with `useSwmAttributions`) can distinguish "still
+        // loading the new graph" from "the new graph errored and
+        // that's the answer for this graph". Without this, an early
+        // failure keeps consumers stuck in the previous-graph state
+        // until the hook re-runs.
+        setResultContextGraphId(contextGraphId);
       } finally {
         if (timeoutId) clearTimeout(timeoutId);
         if (!cancelled) setLoading(false);

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -598,6 +598,21 @@ export interface UseProjectActivityEventsOptions extends UseProjectActivityOptio
 }
 
 /**
+ * Joiner hook return shape — `items` plus the explicit `hasMore`
+ * signal so consumers can render an honest "saturated" indicator
+ * (e.g. ActivityFeed's title badge `${limit}+`). PR #694 Comment 13
+ * — the previous `items.length >= effectiveLimit` heuristic
+ * overstated at the boundary (a project with exactly `limit` rows
+ * would render `${limit}+` even though no rows were dropped).
+ * `hasMore` is computed pre-slice in the joiner, so callers don't
+ * have to guess.
+ */
+export interface ProjectActivityEventsResult {
+  items: ActivityItem[];
+  hasMore: boolean;
+}
+
+/**
  * Joiner hook — `useProjectActivity` plus the SWM promotion stream.
  * Existing callers (AgentProfileView) keep using `useProjectActivity`
  * directly when they don't want promotion rows polluting a per-agent
@@ -608,14 +623,19 @@ export interface UseProjectActivityEventsOptions extends UseProjectActivityOptio
 export function useProjectActivityEvents(
   entityList: MemoryEntity[],
   opts: UseProjectActivityEventsOptions = {},
-): ActivityItem[] {
+): ProjectActivityEventsResult {
   const { swmEvents, lifecycleEvents, ...baseOpts } = opts;
   const base = useProjectActivity(entityList, baseOpts);
   return useMemo(() => {
+    const cap = baseOpts.limit ?? 200;
     // typeIri pins the feed to a typed-activity kind (Decision/Task/
     // PR/etc.) — promotion rows have no `kindUri` so they're dropped
     // wholesale, matching how the same filter drops `'added'` rows.
-    if (opts.typeIri) return base;
+    // `base` is already capped by `useProjectActivity` at `cap`, so
+    // we can't recover an honest `hasMore` for this path without
+    // re-running the entity scan; report `false` (the typed slice
+    // doesn't surface a saturation badge today).
+    if (opts.typeIri) return { items: base, hasMore: false };
     // PR #694 review fix — presence-keyed, not size-keyed. The
     // `lifecycleEvents` prop is the contract: when supplied (even
     // as an empty array because the project has no AssertionCreated
@@ -628,7 +648,10 @@ export function useProjectActivityEvents(
     // Overview shape mid-project as soon as the first assertion
     // landed.
     const useLifecycle = lifecycleEvents != null;
-    if (!useLifecycle && (!swmEvents || swmEvents.length === 0)) return base;
+    if (!useLifecycle && (!swmEvents || swmEvents.length === 0)) {
+      // Same caveat as the typed path: `base` is already capped.
+      return { items: base, hasMore: false };
+    }
 
     // When the lifecycle stream is supplied it is the authoritative
     // source for `'added'` and `'promoted'` rows — drop those event
@@ -639,8 +662,6 @@ export function useProjectActivityEvents(
     const baseFiltered = useLifecycle
       ? base.filter(item => item.event !== 'added')
       : base;
-
-    const cap = baseOpts.limit ?? 200;
 
     let promotions: ActivityItem[];
     if (useLifecycle) {
@@ -668,7 +689,12 @@ export function useProjectActivityEvents(
       if (!a.at && b.at) return 1;
       return a.entity.label.localeCompare(b.entity.label);
     });
-    return merged.slice(0, cap);
+    // PR #694 Comment 13 — compute `hasMore` BEFORE the slice so
+    // the consumer can render `${cap}+` only when rows were
+    // actually dropped. A project with exactly `cap` rows now
+    // renders the exact count, not the saturation indicator.
+    const hasMore = merged.length > cap;
+    return { items: merged.slice(0, cap), hasMore };
   }, [base, swmEvents, lifecycleEvents, entityList, baseOpts.agentUri, baseOpts.subGraph, baseOpts.limit, opts.typeIri]);
 }
 

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -37,6 +37,7 @@
  */
 import { useMemo } from 'react';
 import { canonicalEntityUri, uriTail, type MemoryEntity, type TrustLevel } from './useMemoryEntities.js';
+import type { AssertionLifecycleEvent } from './useAssertionLifecycleEvents.js';
 
 // Priority order — first predicate that has a parseable value wins.
 const TIMESTAMP_PREDICATES = [
@@ -85,6 +86,14 @@ export interface ActivityItem {
    * reconcile the wrong row on updates. Renderers MUST key off `id`.
    */
   id: string;
+  /**
+   * N6 polish — number of root entities included in a promoted
+   * assertion bundle. Sourced from `dkg:rootEntity` triples emitted
+   * by `generateAssertionPromotedMetadata`. Undefined for non-
+   * lifecycle rows and for created rows (the creator metadata does
+   * not emit `dkg:rootEntity`).
+   */
+  entityCount?: number;
   entity: MemoryEntity;
   /**
    * Primary activity timestamp — `null` means the entity is relevant
@@ -486,6 +495,77 @@ function syntheticEntityStub(uri: string): MemoryEntity {
   };
 }
 
+// N6 polish (task #23) — bundle-keyed activity rows sourced from
+// `dkg:AssertionCreated` / `dkg:AssertionPromoted` events
+// (`useAssertionLifecycleEvents`). One row per event (a single
+// promote action with N root entities renders as ONE row, not N),
+// agent-DID-keyed for clean attribution (no `12D3…` peer ids in
+// the author column).
+//
+// Rows are intentionally non-interactive in this PR: clicking lands
+// on an assertion-detail view that S4 will introduce; until then
+// surfacing the entity-detail click would resolve to nothing useful.
+// Renderer reads `clickable: false` and emits a static row.
+export interface BuildLifecycleActivityRowsOptions {
+  agentUri?: string;
+  subGraph?: string;
+  limit?: number;
+}
+
+export function buildLifecycleActivityRows(
+  events: ReadonlyArray<AssertionLifecycleEvent>,
+  opts: BuildLifecycleActivityRowsOptions = {},
+): ActivityItem[] {
+  const { agentUri, subGraph, limit = 200 } = opts;
+  const out: ActivityItem[] = [];
+  for (const evt of events) {
+    if (agentUri && evt.agentUri !== agentUri) continue;
+    if (subGraph && evt.subGraph !== subGraph) continue;
+    const at = parseDateLike(evt.publishedAt);
+    if (!at) continue;
+    const event: ActivityEvent = evt.kind === 'promoted' ? 'promoted' : 'added';
+    const layer: TrustLevel = evt.kind === 'promoted' ? 'shared' : 'working';
+    // The assertion bundle URI is the "subject" the row is about.
+    // We carry it as the entity URI so React keys + tooltip share a
+    // stable identity even before S4's assertion-detail view exists.
+    const canonicalAssertion = canonicalEntityUri(evt.assertionUri);
+    out.push({
+      id: buildActivityId(event, evt.eventUri, at, canonicalAssertion),
+      entity: {
+        uri: canonicalAssertion,
+        label: evt.assertionName || uriTail(canonicalAssertion),
+        types: [],
+        trustLevel: layer,
+        layers: new Set([layer]),
+        subGraphs: evt.subGraph ? new Set([evt.subGraph]) : new Set(),
+        properties: new Map(),
+        connections: [],
+      },
+      at,
+      authorUri: evt.agentUri,
+      kindUri: null,
+      subGraph: evt.subGraph ?? null,
+      layer,
+      event,
+      // Per-bundle root count from `dkg:AssertionPromoted`; undefined
+      // for created rows (creator metadata doesn't emit `dkg:rootEntity`).
+      entityCount: evt.entityCount,
+      // Pre-S4: no assertion-detail surface yet. Rows render as
+      // static text instead of navigating to a `selectedEntity` that
+      // ProjectView would immediately clear (same shape as Code3
+      // stub-row handling on PR #656).
+      clickable: false,
+    });
+  }
+  out.sort((a, b) => {
+    if (a.at && b.at) return b.at.getTime() - a.at.getTime();
+    if (a.at && !b.at) return -1;
+    if (!a.at && b.at) return 1;
+    return a.entity.label.localeCompare(b.entity.label);
+  });
+  return out.slice(0, limit);
+}
+
 export interface UseProjectActivityEventsOptions extends UseProjectActivityOptions {
   /**
    * Raw per-operation event log from `useSwmAttributions.events`.
@@ -493,8 +573,28 @@ export interface UseProjectActivityEventsOptions extends UseProjectActivityOptio
    * `useProjectActivity(entities, opts)`. Code2 (PR #656) — we now
    * consume the raw event list, not the deduped attribution map, so
    * re-promotions surface as distinct rows.
+   *
+   * N6 polish (task #23) — superseded by `lifecycleEvents` on the
+   * Overview feed (which prefers the agent-DID-keyed lifecycle
+   * source). Kept on the option for AgentProfileView and other
+   * legacy callers that still want the peer-id-keyed SWM stream.
+   * When BOTH are supplied, `lifecycleEvents` wins for created+promoted
+   * rows and `swmEvents`-derived promotion rows are dropped so we
+   * don't render the same WM→SWM transition twice.
    */
   swmEvents?: ReadonlyArray<PromotionAttribution>;
+  /**
+   * N6 polish (task #23) — bundle-keyed lifecycle events from
+   * `useAssertionLifecycleEvents`. One row per `dkg:AssertionCreated`
+   * / `dkg:AssertionPromoted` event, with the per-bundle root-entity
+   * count surfaced inline so a single promote of N entities reads as
+   * ONE row. Agent attribution is DID-keyed (no `12D3…` peer ids).
+   * When supplied, this is the source of `'added'` (from created)
+   * and `'promoted'` rows on the feed; the legacy entity-list
+   * `dcterms:created` and `swmEvents` promotion rows are suppressed
+   * to avoid double-counting the same transition.
+   */
+  lifecycleEvents?: ReadonlyArray<AssertionLifecycleEvent>;
 }
 
 /**
@@ -502,39 +602,63 @@ export interface UseProjectActivityEventsOptions extends UseProjectActivityOptio
  * Existing callers (AgentProfileView) keep using `useProjectActivity`
  * directly when they don't want promotion rows polluting a per-agent
  * typed-activity slice. The Overview "Recent activity" feed swaps to
- * this one and feeds in the live `useSwmAttributions().events` result.
+ * this one and feeds in the live `useAssertionLifecycleEvents().events`
+ * result (preferred) or `useSwmAttributions().events` (legacy).
  */
 export function useProjectActivityEvents(
   entityList: MemoryEntity[],
   opts: UseProjectActivityEventsOptions = {},
 ): ActivityItem[] {
-  const { swmEvents, ...baseOpts } = opts;
+  const { swmEvents, lifecycleEvents, ...baseOpts } = opts;
   const base = useProjectActivity(entityList, baseOpts);
   return useMemo(() => {
     // typeIri pins the feed to a typed-activity kind (Decision/Task/
     // PR/etc.) — promotion rows have no `kindUri` so they're dropped
     // wholesale, matching how the same filter drops `'added'` rows.
     if (opts.typeIri) return base;
-    if (!swmEvents || swmEvents.length === 0) return base;
-    const entitiesByUri = new Map<string, MemoryEntity>();
-    for (const e of entityList) entitiesByUri.set(e.uri, e);
-    const promotions = buildPromotionEvents(swmEvents, {
-      entitiesByUri,
-      agentUri: baseOpts.agentUri,
-      subGraph: baseOpts.subGraph,
-      // No per-stream limit — apply the combined cap below.
-      limit: Number.POSITIVE_INFINITY,
-    });
-    const merged = [...base, ...promotions];
+    const useLifecycle = lifecycleEvents && lifecycleEvents.length > 0;
+    if (!useLifecycle && (!swmEvents || swmEvents.length === 0)) return base;
+
+    // When the lifecycle stream is supplied it is the authoritative
+    // source for `'added'` and `'promoted'` rows — drop those event
+    // kinds from `base` so an entity that was both imported (with a
+    // `dcterms:created` triple) and recorded by `dkg:AssertionCreated`
+    // doesn't show up twice. Other event kinds in `base` (typed
+    // activity, etc.) pass through.
+    const baseFiltered = useLifecycle
+      ? base.filter(item => item.event !== 'added')
+      : base;
+
+    const cap = baseOpts.limit ?? 200;
+
+    let promotions: ActivityItem[];
+    if (useLifecycle) {
+      promotions = buildLifecycleActivityRows(lifecycleEvents!, {
+        agentUri: baseOpts.agentUri,
+        subGraph: baseOpts.subGraph,
+        limit: Number.POSITIVE_INFINITY,
+      });
+    } else {
+      const entitiesByUri = new Map<string, MemoryEntity>();
+      for (const e of entityList) entitiesByUri.set(e.uri, e);
+      promotions = buildPromotionEvents(swmEvents!, {
+        entitiesByUri,
+        agentUri: baseOpts.agentUri,
+        subGraph: baseOpts.subGraph,
+        // No per-stream limit — apply the combined cap below.
+        limit: Number.POSITIVE_INFINITY,
+      });
+    }
+
+    const merged = [...baseFiltered, ...promotions];
     merged.sort((a, b) => {
       if (a.at && b.at) return b.at.getTime() - a.at.getTime();
       if (a.at && !b.at) return -1;
       if (!a.at && b.at) return 1;
       return a.entity.label.localeCompare(b.entity.label);
     });
-    const cap = baseOpts.limit ?? 200;
     return merged.slice(0, cap);
-  }, [base, swmEvents, entityList, baseOpts.agentUri, baseOpts.subGraph, baseOpts.limit, opts.typeIri]);
+  }, [base, swmEvents, lifecycleEvents, entityList, baseOpts.agentUri, baseOpts.subGraph, baseOpts.limit, opts.typeIri]);
 }
 
 /** "2h ago" / "3d ago" / "Apr 18" — compact relative-time label. */

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -594,7 +594,15 @@ export function buildLifecycleActivityRows(
   return out.slice(0, limit);
 }
 
-export interface UseProjectActivityEventsOptions extends UseProjectActivityOptions {
+// PR #694 Comment 17 — `excludeEvents` is base-only. The joiner
+// applies it internally for the Comment 14 fix (push `'added'`
+// suppression down into base when lifecycle is the source) but
+// doesn't filter `promotions` against it, so exposing it on the
+// joiner's public option type would create a "filters base but not
+// joined rows" inconsistency. Omit it from the joiner-facing
+// options; callers who need a real cross-source filter should
+// surface a follow-up.
+export interface UseProjectActivityEventsOptions extends Omit<UseProjectActivityOptions, 'excludeEvents'> {
   /**
    * Raw per-operation event log from `useSwmAttributions.events`.
    * When omitted (or empty) the joiner reduces to plain
@@ -658,9 +666,11 @@ export function useProjectActivityEvents(
   // operates on the post-filter set, so typed Decision/Task/PR rows
   // can't be silently dropped by a flood of imports ranking above them.
   const useLifecycle = lifecycleEvents != null;
-  const baseExcludeEvents = useLifecycle
-    ? (baseOpts.excludeEvents ? [...baseOpts.excludeEvents, 'added' as const] : ['added' as const])
-    : baseOpts.excludeEvents;
+  // `excludeEvents` isn't on `UseProjectActivityEventsOptions` (Comment
+  // 17 — base-only), so callers can't pass it through; we set it here
+  // for the Comment 14 fix (push `'added'` suppression into base when
+  // lifecycle is the source).
+  const baseExcludeEvents = useLifecycle ? ['added' as const] : undefined;
   const baseResult = useProjectActivity(entityList, { ...baseOpts, excludeEvents: baseExcludeEvents });
   return useMemo(() => {
     const cap = baseOpts.limit ?? 200;

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -213,20 +213,47 @@ export interface UseProjectActivityOptions {
    * project-home "recent" feed where we strictly want temporal data.
    */
   includeUndated?: boolean;
+  /**
+   * Skip rows whose `event` is in this set during the row loop —
+   * BEFORE sort+slice. The joiner sets this to `['added']` when the
+   * lifecycle source is supplying its own bundle-level created rows,
+   * so a flood of imports doesn't push older typed Decision/Task/PR
+   * rows out of the `limit` window before the joiner gets to suppress
+   * the imports (PR #694 Comment 14 — silent data loss).
+   */
+  excludeEvents?: ReadonlyArray<ActivityEvent>;
+}
+
+/**
+ * Base hook return shape — `items` plus an explicit `hasMore` signal
+ * so the joiner (and indirectly the ActivityFeed saturation badge)
+ * can render an honest "more than `limit` rows existed" indicator on
+ * non-lifecycle paths too (PR #694 Comment 15). `hasMore` is computed
+ * from the post-filter, pre-slice count — surfaces overflow even
+ * when `excludeEvents` was active.
+ */
+export interface ProjectActivityResult {
+  items: ActivityItem[];
+  hasMore: boolean;
 }
 
 export function useProjectActivity(
   entityList: MemoryEntity[],
   opts: UseProjectActivityOptions = {},
-): ActivityItem[] {
+): ProjectActivityResult {
   const {
     limit = 200,
     agentUri,
     typeIri,
     subGraph,
     includeUndated = true,
+    excludeEvents,
   } = opts;
+  const excludeKey = excludeEvents ? [...excludeEvents].sort().join(',') : '';
   return useMemo(() => {
+    const excludeSet = excludeEvents && excludeEvents.length > 0
+      ? new Set<ActivityEvent>(excludeEvents)
+      : null;
     const out: ActivityItem[] = [];
     for (const e of entityList) {
       const kindUri = primaryActivityType(e);
@@ -250,6 +277,7 @@ export function useProjectActivity(
       const sg = primarySubGraph(e);
       if (subGraph && sg !== subGraph) continue;
       const event: ActivityEvent = kindUri ? 'typed' : 'added';
+      if (excludeSet && excludeSet.has(event)) continue;
       // Per-event id (Code1) — typed/added rows have at most one of
       // each event-kind per entity, so `${event}|${uri}|${atIso}` is
       // stable across re-renders even if the same URI later gains a
@@ -278,8 +306,8 @@ export function useProjectActivity(
       if (!a.at && b.at) return 1;
       return a.entity.label.localeCompare(b.entity.label);
     });
-    return out.slice(0, limit);
-  }, [entityList, limit, agentUri, typeIri, subGraph, includeUndated]);
+    return { items: out.slice(0, limit), hasMore: out.length > limit };
+  }, [entityList, limit, agentUri, typeIri, subGraph, includeUndated, excludeKey]);
 }
 
 /** Bucket items into "Today / Yesterday / Earlier this week / <month>" groups. */
@@ -625,43 +653,29 @@ export function useProjectActivityEvents(
   opts: UseProjectActivityEventsOptions = {},
 ): ProjectActivityEventsResult {
   const { swmEvents, lifecycleEvents, ...baseOpts } = opts;
-  const base = useProjectActivity(entityList, baseOpts);
+  // PR #694 Comment 14 — push the `'added'` suppression DOWN into base
+  // when lifecycle is supplied. Filtering at source means base's slice
+  // operates on the post-filter set, so typed Decision/Task/PR rows
+  // can't be silently dropped by a flood of imports ranking above them.
+  const useLifecycle = lifecycleEvents != null;
+  const baseExcludeEvents = useLifecycle
+    ? (baseOpts.excludeEvents ? [...baseOpts.excludeEvents, 'added' as const] : ['added' as const])
+    : baseOpts.excludeEvents;
+  const baseResult = useProjectActivity(entityList, { ...baseOpts, excludeEvents: baseExcludeEvents });
   return useMemo(() => {
     const cap = baseOpts.limit ?? 200;
     // typeIri pins the feed to a typed-activity kind (Decision/Task/
     // PR/etc.) — promotion rows have no `kindUri` so they're dropped
     // wholesale, matching how the same filter drops `'added'` rows.
-    // `base` is already capped by `useProjectActivity` at `cap`, so
-    // we can't recover an honest `hasMore` for this path without
-    // re-running the entity scan; report `false` (the typed slice
-    // doesn't surface a saturation badge today).
-    if (opts.typeIri) return { items: base, hasMore: false };
-    // PR #694 review fix — presence-keyed, not size-keyed. The
-    // `lifecycleEvents` prop is the contract: when supplied (even
-    // as an empty array because the project has no AssertionCreated
-    // / AssertionPromoted records yet) it is the authoritative
-    // source for `'added'` + `'promoted'` rows, so the joiner
-    // suppresses the legacy `dcterms:created`-derived rows from
-    // `base` and emits zero promotion rows. The previous
-    // size-keyed test silently fell back to the legacy path when
-    // a project had no lifecycle events yet — changing the
-    // Overview shape mid-project as soon as the first assertion
-    // landed.
-    const useLifecycle = lifecycleEvents != null;
+    // PR #694 Comment 15 — `hasMore` from base is now honest (computed
+    // from the post-filter, pre-slice count) so we can propagate it
+    // instead of hard-coding `false`.
+    if (opts.typeIri) return { items: baseResult.items, hasMore: baseResult.hasMore };
     if (!useLifecycle && (!swmEvents || swmEvents.length === 0)) {
-      // Same caveat as the typed path: `base` is already capped.
-      return { items: base, hasMore: false };
+      // Legacy path (no lifecycle, no SWM) — base is the only source;
+      // its `hasMore` is the honest signal.
+      return { items: baseResult.items, hasMore: baseResult.hasMore };
     }
-
-    // When the lifecycle stream is supplied it is the authoritative
-    // source for `'added'` and `'promoted'` rows — drop those event
-    // kinds from `base` so an entity that was both imported (with a
-    // `dcterms:created` triple) and recorded by `dkg:AssertionCreated`
-    // doesn't show up twice. Other event kinds in `base` (typed
-    // activity, etc.) pass through.
-    const baseFiltered = useLifecycle
-      ? base.filter(item => item.event !== 'added')
-      : base;
 
     let promotions: ActivityItem[];
     if (useLifecycle) {
@@ -682,20 +696,20 @@ export function useProjectActivityEvents(
       });
     }
 
-    const merged = [...baseFiltered, ...promotions];
+    const merged = [...baseResult.items, ...promotions];
     merged.sort((a, b) => {
       if (a.at && b.at) return b.at.getTime() - a.at.getTime();
       if (a.at && !b.at) return -1;
       if (!a.at && b.at) return 1;
       return a.entity.label.localeCompare(b.entity.label);
     });
-    // PR #694 Comment 13 — compute `hasMore` BEFORE the slice so
-    // the consumer can render `${cap}+` only when rows were
-    // actually dropped. A project with exactly `cap` rows now
-    // renders the exact count, not the saturation indicator.
-    const hasMore = merged.length > cap;
+    // Combined overflow: either base overflowed its own cap (some
+    // typed/added rows didn't fit) OR the merge with promotions
+    // overflowed (cap is shared across all streams). Either means
+    // there's more activity than the badge total represents.
+    const hasMore = baseResult.hasMore || merged.length > cap;
     return { items: merged.slice(0, cap), hasMore };
-  }, [base, swmEvents, lifecycleEvents, entityList, baseOpts.agentUri, baseOpts.subGraph, baseOpts.limit, opts.typeIri]);
+  }, [baseResult, swmEvents, lifecycleEvents, useLifecycle, entityList, baseOpts.agentUri, baseOpts.subGraph, baseOpts.limit, opts.typeIri]);
 }
 
 /** "2h ago" / "3d ago" / "Apr 18" — compact relative-time label. */

--- a/packages/node-ui/src/ui/hooks/useProjectActivity.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectActivity.ts
@@ -616,7 +616,18 @@ export function useProjectActivityEvents(
     // PR/etc.) — promotion rows have no `kindUri` so they're dropped
     // wholesale, matching how the same filter drops `'added'` rows.
     if (opts.typeIri) return base;
-    const useLifecycle = lifecycleEvents && lifecycleEvents.length > 0;
+    // PR #694 review fix — presence-keyed, not size-keyed. The
+    // `lifecycleEvents` prop is the contract: when supplied (even
+    // as an empty array because the project has no AssertionCreated
+    // / AssertionPromoted records yet) it is the authoritative
+    // source for `'added'` + `'promoted'` rows, so the joiner
+    // suppresses the legacy `dcterms:created`-derived rows from
+    // `base` and emits zero promotion rows. The previous
+    // size-keyed test silently fell back to the legacy path when
+    // a project had no lifecycle events yet — changing the
+    // Overview shape mid-project as soon as the first assertion
+    // landed.
+    const useLifecycle = lifecycleEvents != null;
     if (!useLifecycle && (!swmEvents || swmEvents.length === 0)) return base;
 
     // When the lifecycle stream is supplied it is the authoritative

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6859,6 +6859,16 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   font-size: 12px; font-weight: 400; line-height: 1.5;
   color: var(--text-tertiary);
 }
+.v10-activity-feed-error {
+  /* PR #694 Comment 8 — distinguishable from `.v10-activity-feed-empty-hint`
+   * so the user can tell "couldn't load" apart from "no activity
+   * yet", but still quieter than the loud `EmptyState` primitive. */
+  margin-top: 8px;
+  padding: 6px 8px;
+  border-left: 2px solid var(--accent-warn, #f59e0b);
+  font-size: 12px; font-weight: 400; line-height: 1.5;
+  color: var(--text-tertiary);
+}
 .v10-activity-feed-bucket { display: flex; flex-direction: column; gap: 4px; }
 .v10-activity-feed-bucket-head {
   display: flex; align-items: center; gap: 8px;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6833,13 +6833,31 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   background: rgba(255, 255, 255, 0.015);
 }
 .v10-activity-feed-title {
+  display: flex; align-items: baseline; gap: 8px;
   font-size: 12px; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.06em;
   color: var(--text-tertiary);
 }
-.v10-empty-state.v10-activity-feed-empty-state { min-height: 96px; }
+.v10-activity-feed-title-label { flex: 0 1 auto; }
+.v10-activity-feed-title-count {
+  /* N6 polish (item 3) — total-feed count next to the heading.
+   * Same mono+tertiary treatment as `.v10-activity-feed-bucket-count`
+   * so the two read as the same kind of signal at different scopes. */
+  font-family: var(--font-mono); font-weight: 400;
+  font-size: 10px; letter-spacing: 0;
+  text-transform: none;
+  color: var(--text-tertiary);
+}
 .v10-overview-activity.v10-activity-feed-empty {
   min-height: 140px;
+}
+.v10-activity-feed-empty-hint {
+  /* N6 polish (item 2) — quieter than the prior centered/bold
+   * EmptyState primitive; recedes so the rest of the Overview
+   * stays the focal area. */
+  margin-top: 8px;
+  font-size: 12px; font-weight: 400; line-height: 1.5;
+  color: var(--text-tertiary);
 }
 .v10-activity-feed-bucket { display: flex; flex-direction: column; gap: 4px; }
 .v10-activity-feed-bucket-head {

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6936,7 +6936,14 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
 }
 .v10-activity-feed-type-icon { font-size: 11px; color: var(--type-color, #a855f7); }
 .v10-activity-feed-title-text {
-  font-size: 12px; font-weight: 600;
+  /* Entity / assertion name in each row (e.g.
+   * "pharmaceutical-derived-product-metadata"). Was `600` to
+   * compensate for the `.v10-activity-feed-row-static` opacity dim;
+   * with the dim gone (prior commit), `600` over-emphasised the row
+   * body relative to the surrounding chrome (`RECENT ACTIVITY · 7`
+   * title, `TODAY` bucket label, agent chips). Dropped one notch
+   * to `500` to bring it inline with the chrome's body weight. */
+  font-size: 12px; font-weight: 500;
   color: var(--text-primary);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   min-width: 0;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6906,13 +6906,17 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   border-top: 1px solid var(--border-subtle);
   border-radius: 0;
 }
-/* Local-2 (PR #656) — non-clickable stub rows for promotion events
- * whose root isn't loaded in `rawMemory.entities`. Same row shell so
- * the timeline stays visually coherent, but the affordance is honest:
- * default cursor, no hover surface, slight opacity to read as inert. */
+/* Non-clickable rows — both PR #656-era stub rows (promotion of a
+ * root not in `rawMemory.entities`) and the lifecycle rows that are
+ * non-interactive by design (PR #694 Comment 12 (A) — assertion
+ * click-through lands in the S4 PR). Disabledness is signalled by
+ * `cursor: default` + `aria-disabled="true"` + the missing hover
+ * surface; the prior `opacity: 0.7` was redundant and dimmed the
+ * bulk of the feed once lifecycle rows became the dominant
+ * non-clickable kind, making the whole feed read muted vs the rest
+ * of the Overview chrome. */
 .v10-activity-feed-row-static {
   cursor: default;
-  opacity: 0.7;
 }
 .v10-activity-feed-row-static:hover { background: none; }
 .v10-activity-feed-layer {

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -13,6 +13,7 @@ import { useProjectProfile, ProjectProfileContext } from '../hooks/useProjectPro
 import { useAgents, AgentsContext } from '../hooks/useAgents.js';
 import { useCurrentAgent } from '../hooks/useCurrentAgent.js';
 import { useSwmAttributions } from '../hooks/useSwmAttributions.js';
+import { useAssertionLifecycleEvents } from '../hooks/useAssertionLifecycleEvents.js';
 import { ActivityFeed } from '../components/ActivityFeed.js';
 import { SubGraphBar } from '../components/SubGraphBar.js';
 import { CONTEXT_GRAPH_PRIMER_TAB } from '../lib/contextGraphPrimer.js';
@@ -269,6 +270,19 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     ? swmAttributionsResult.events
     : undefined;
 
+  // N6 polish (task #23) — bundle-keyed lifecycle events feed the
+  // Overview activity feed. Gated on the Overview tab only (the SWM
+  // graph doesn't consume this stream; SWM attribution coloring
+  // stays on `useSwmAttributions` which is the legend's source of
+  // truth). Same `resultContextGraphId` guard as the SWM stream so
+  // a project switch doesn't briefly show stale rows.
+  const lifecycleEventsResult = useAssertionLifecycleEvents(
+    !activeSubGraph && activeLayer === 'overview' ? contextGraphId : undefined,
+  );
+  const overviewLifecycleEvents = lifecycleEventsResult.resultContextGraphId === contextGraphId
+    ? lifecycleEventsResult.events
+    : undefined;
+
   const refreshParticipants = useCallback(() => {
     const targetId = cg?.id;
     if (!targetId) return;
@@ -499,12 +513,12 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           )}
           <ActivityFeed
             entities={rawMemory.entityList}
-            swmEvents={overviewSwmEvents}
+            lifecycleEvents={overviewLifecycleEvents}
             onSelectEntity={handleOverviewActivityNavigate}
             title="Recent activity"
             limit={40}
             includeUndated={false}
-            emptyHint="Once you import knowledge or agents start proposing decisions or tasks they'll show up here as a live feed."
+            emptyHint="Once knowledge starts being added and managed in this context graph, activities will show up here as a live feed."
             className="v10-overview-activity"
           />
         </>

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -234,48 +234,20 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   );
 
   const rawMemory = useMemoryEntities(contextGraphId);
-  // N6 part 2 — feed promotion (WM→SWM) events into the Overview
-  // ActivityFeed. `useSwmAttributions` is the existing source for the
-  // SWM graph's agent-tint legend; we re-use its `attributions` map
-  // here rather than re-querying `_shared_memory_meta`. Hook is
-  // already in production for the SWM Graph subtab so it's cached.
-  //
-  // Local-3 (PR #656) — gate the hoist on a view that actually
-  // consumes the result. Pre-fix the page-level call fired
-  // unconditionally for every active view (graph-overview, query,
-  // WM/VM detail, sub-graph pages — none of which read it), running
-  // a 5000-row SPARQL for nothing. Active consumers today are
-  // (a) the Overview activity feed and (b) the SWM-tab layer graph.
-  // The hook already short-circuits cleanly on `undefined` (state
-  // resets, no fetch).
-  //
-  // R2-Local-1 (PR #656) — do NOT gate on `selectedUri`. Opening
-  // an entity detail overlays the same view; toggling `undefined`
-  // here would clear the hook's cached events, then on detail-close
-  // re-fetch the 5000-row SPARQL — during the re-fetch the Code7
-  // discriminator (`resultContextGraphId !== contextGraphId`) would
-  // suppress `overviewSwmEvents`, making promotion rows visibly
-  // flicker out on every detail round-trip. Sub-graph navigation is
-  // a real route change so we still gate on `!activeSubGraph`.
+  // SWM attribution drives the SWM graph's agent-tint legend (its
+  // sole remaining consumer). PR #694 review — the Overview no
+  // longer reads this stream (lifecycle source replaced it), so the
+  // gate is `'swm'`-only now (see `shouldFetchSwmAttribution`); the
+  // 5k-row SPARQL no longer fires on Overview renders.
   const swmAttributionNeeded = shouldFetchSwmAttribution({ activeLayer, activeSubGraph });
   const swmAttributionsResult = useSwmAttributions(swmAttributionNeeded ? contextGraphId : undefined);
-  // Codex Code7 (PR #656) — the hook returns its previous-graph
-  // result during the transition window between context-graph switch
-  // and the new SPARQL resolving. Gate `events` on the result being
-  // for the *current* graph so the Overview doesn't briefly show
-  // promotion rows from the previous project. The SWM graph itself
-  // tolerates the momentary stale tint (it re-renders cleanly once
-  // the new attribution lands), so we don't gate there.
-  const overviewSwmEvents = swmAttributionsResult.resultContextGraphId === contextGraphId
-    ? swmAttributionsResult.events
-    : undefined;
 
   // N6 polish (task #23) — bundle-keyed lifecycle events feed the
   // Overview activity feed. Gated on the Overview tab only (the SWM
   // graph doesn't consume this stream; SWM attribution coloring
   // stays on `useSwmAttributions` which is the legend's source of
-  // truth). Same `resultContextGraphId` guard as the SWM stream so
-  // a project switch doesn't briefly show stale rows.
+  // truth). Same `resultContextGraphId` discriminator as the SWM
+  // stream so a project switch doesn't briefly show stale rows.
   const lifecycleEventsResult = useAssertionLifecycleEvents(
     !activeSubGraph && activeLayer === 'overview' ? contextGraphId : undefined,
   );

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -243,17 +243,18 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const swmAttributionsResult = useSwmAttributions(swmAttributionNeeded ? contextGraphId : undefined);
 
   // N6 polish (task #23) — bundle-keyed lifecycle events feed the
-  // Overview activity feed. The hook fires for the current
-  // `contextGraphId` regardless of active tab (PR #694 Comment 16) so
-  // the last successful lifecycle result stays cached across tab
-  // switches — gating the HOOK on `overviewIsActive` reset the cache
-  // every time the user left Overview, so returning rendered an
-  // empty feed briefly until the 5k-row SPARQL re-resolved. The
-  // consumer-side ternary below still hides events off-Overview.
-  // The SWM graph attribution coloring stays on `useSwmAttributions`
+  // Overview activity feed. Gated to Overview only (PR #694 Comment
+  // 20 — we don't fire the 5k-row SPARQL on WM/SWM/VM/Query tabs
+  // where nothing consumes it). The hook now PRESERVES its last
+  // successful result when the gate flips off (PR #694 Comment 16),
+  // so returning to Overview shows the cached events immediately
+  // while a background refresh runs — no empty-feed flicker. SWM
+  // graph attribution coloring stays on `useSwmAttributions`
   // (separate source of truth for the legend).
   const overviewIsActive = !activeSubGraph && activeLayer === 'overview';
-  const lifecycleEventsResult = useAssertionLifecycleEvents(contextGraphId);
+  const lifecycleEventsResult = useAssertionLifecycleEvents(
+    overviewIsActive ? contextGraphId : undefined,
+  );
   // PR #694 review fix (Comment 6) — when the Overview is the
   // active consumer, pass `[]` during the transition window (cold
   // load, project switch, or post-leave-and-return) instead of

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -243,15 +243,17 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const swmAttributionsResult = useSwmAttributions(swmAttributionNeeded ? contextGraphId : undefined);
 
   // N6 polish (task #23) — bundle-keyed lifecycle events feed the
-  // Overview activity feed. Gated on the Overview tab only (the SWM
-  // graph doesn't consume this stream; SWM attribution coloring
-  // stays on `useSwmAttributions` which is the legend's source of
-  // truth). Same `resultContextGraphId` discriminator as the SWM
-  // stream so a project switch doesn't briefly show stale rows.
+  // Overview activity feed. The hook fires for the current
+  // `contextGraphId` regardless of active tab (PR #694 Comment 16) so
+  // the last successful lifecycle result stays cached across tab
+  // switches — gating the HOOK on `overviewIsActive` reset the cache
+  // every time the user left Overview, so returning rendered an
+  // empty feed briefly until the 5k-row SPARQL re-resolved. The
+  // consumer-side ternary below still hides events off-Overview.
+  // The SWM graph attribution coloring stays on `useSwmAttributions`
+  // (separate source of truth for the legend).
   const overviewIsActive = !activeSubGraph && activeLayer === 'overview';
-  const lifecycleEventsResult = useAssertionLifecycleEvents(
-    overviewIsActive ? contextGraphId : undefined,
-  );
+  const lifecycleEventsResult = useAssertionLifecycleEvents(contextGraphId);
   // PR #694 review fix (Comment 6) — when the Overview is the
   // active consumer, pass `[]` during the transition window (cold
   // load, project switch, or post-leave-and-return) instead of

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -248,11 +248,26 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // stays on `useSwmAttributions` which is the legend's source of
   // truth). Same `resultContextGraphId` discriminator as the SWM
   // stream so a project switch doesn't briefly show stale rows.
+  const overviewIsActive = !activeSubGraph && activeLayer === 'overview';
   const lifecycleEventsResult = useAssertionLifecycleEvents(
-    !activeSubGraph && activeLayer === 'overview' ? contextGraphId : undefined,
+    overviewIsActive ? contextGraphId : undefined,
   );
-  const overviewLifecycleEvents = lifecycleEventsResult.resultContextGraphId === contextGraphId
-    ? lifecycleEventsResult.events
+  // PR #694 review fix (Comment 6) — when the Overview is the
+  // active consumer, pass `[]` during the transition window (cold
+  // load, project switch, or post-leave-and-return) instead of
+  // `undefined`. The joiner contract is presence-keyed: `[]` opts
+  // INTO the lifecycle source (legacy `dcterms:created`-derived
+  // `'added'` rows are suppressed); `undefined` falls back to the
+  // legacy path. Passing `undefined` mid-transition let legacy
+  // rows render briefly before the fetch resolved, then flipped
+  // to lifecycle rows — exactly the shape-change Comment 4 was
+  // meant to prevent. Empty briefly is better than wrong-shape
+  // briefly. Off-Overview we still pass `undefined` so other
+  // callers (none today; future surfaces) get the legacy path.
+  const overviewLifecycleEvents = overviewIsActive
+    ? (lifecycleEventsResult.resultContextGraphId === contextGraphId
+        ? lifecycleEventsResult.events
+        : [])
     : undefined;
 
   const refreshParticipants = useCallback(() => {

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -269,6 +269,17 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
         ? lifecycleEventsResult.events
         : [])
     : undefined;
+  // PR #694 Comment 8 — plumb the lifecycle error so the feed can
+  // distinguish "loaded with zero rows" from "the query failed".
+  // After the Comment 3 fix, `resultContextGraphId` advances in
+  // both success and catch paths, so consumers can't infer failure
+  // from the events array alone. Only surface the error to the
+  // Overview consumer; off-Overview the prop stays undefined so
+  // legacy callers don't grow an error pathway they don't use.
+  const overviewLifecycleError = overviewIsActive
+    && lifecycleEventsResult.resultContextGraphId === contextGraphId
+    ? lifecycleEventsResult.error
+    : null;
 
   const refreshParticipants = useCallback(() => {
     const targetId = cg?.id;
@@ -501,6 +512,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           <ActivityFeed
             entities={rawMemory.entityList}
             lifecycleEvents={overviewLifecycleEvents}
+            lifecycleError={overviewLifecycleError}
             onSelectEntity={handleOverviewActivityNavigate}
             title="Recent activity"
             limit={40}

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -17,21 +17,32 @@ export type LayerContentTab = 'items' | 'assertions' | 'graph' | 'docs';
 
 /**
  * Whether the SWM attribution SPARQL is worth firing for the current
- * `ProjectView` route state. True only on views that actually consume
- * the result — the Overview activity feed and the SWM-layer graph.
+ * `ProjectView` route state. True only when the SWM-layer graph (the
+ * sole remaining consumer) is the active view.
+ *
+ * PR #694 review fix — the Overview was previously included here too
+ * because the activity feed read `useSwmAttributions(...).events`
+ * (the WorkspaceOperation source). After the lifecycle-source
+ * switch in task #23 (`useAssertionLifecycleEvents`) the Overview
+ * no longer consumes this stream; firing the 5k-row SWM SPARQL on
+ * every Overview render was pure waste. Trade-off: the SWM tab now
+ * incurs the cold-start fetch on click instead of being pre-warmed
+ * by Overview navigation. Bounded by the 10s query timeout and the
+ * tab has its own loading state, so the cold-start window is
+ * acceptable.
  *
  * Notably *not* gated on `selectedUri`: opening an entity detail
  * overlays the same view, and toggling the hook to `undefined` on
  * detail-open would clear its cached events and force a re-fetch on
- * detail-close, making promotion rows on the Overview visibly flicker
- * out during every detail round-trip (R2-Local-1, PR #656).
+ * detail-close, making the SWM graph's agent tints flicker out
+ * during every detail round-trip (R2-Local-1, PR #656).
  */
 export function shouldFetchSwmAttribution(args: {
   activeLayer: LayerView;
   activeSubGraph: string | null;
 }): boolean {
   if (args.activeSubGraph) return false;
-  return args.activeLayer === 'overview' || args.activeLayer === 'swm';
+  return args.activeLayer === 'swm';
 }
 export const TRUST_COLORS: Record<TrustLevel, string> = {
   verified: '#22c55e',

--- a/packages/node-ui/test/agent-chip.test.ts
+++ b/packages/node-ui/test/agent-chip.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+//
+// N6 polish (task #23) — AgentChip falls back to the URI tail when no
+// resolved agent profile is available. Pre-fix, the full peer id
+// (`12D3KooW…b9a3`, ~52 chars) or eth address (`0xaaaa…bbbb`, 42 chars)
+// blew the pill layout. The fix truncates the FALLBACK identifier
+// only — resolved agents keep their full human-readable `name`.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { AgentChip } from '../src/ui/components/AgentChip.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('AgentChip — fallback id truncation', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function nameOf(): string {
+    return container.querySelector('.v10-agent-chip-name')?.textContent ?? '';
+  }
+
+  it('truncates a long libp2p peer id to head6+ellipsis+tail4', () => {
+    const peer = '12D3KooWAbcdefghijklmnopqrstuvwxyz1234567890b9a3';
+    act(() => {
+      root.render(React.createElement(AgentChip, {
+        agent: null,
+        fallbackUri: peer,
+      }));
+    });
+    expect(nameOf()).toBe('12D3Ko…b9a3');
+  });
+
+  it('truncates a long 0x… eth address to head6+ellipsis+tail4', () => {
+    const addr = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb';
+    act(() => {
+      root.render(React.createElement(AgentChip, {
+        agent: null,
+        fallbackUri: addr,
+      }));
+    });
+    expect(nameOf()).toBe('0xaaaa…bbbb');
+  });
+
+  it('uses the colon-split tail when the fallback URI is namespaced (did:...)', () => {
+    // The split-on-colon keeps the existing behaviour, then truncation
+    // applies to the tail. `did:dkg:agent:0xaaaaaa…bbbb` → tail is
+    // the 42-char eth address, truncated to head6+…+tail4.
+    const did = 'did:dkg:agent:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb';
+    act(() => {
+      root.render(React.createElement(AgentChip, {
+        agent: null,
+        fallbackUri: did,
+      }));
+    });
+    expect(nameOf()).toBe('0xaaaa…bbbb');
+  });
+
+  it('does NOT truncate when the fallback id is already short', () => {
+    act(() => {
+      root.render(React.createElement(AgentChip, {
+        agent: null,
+        fallbackUri: 'urn:agent:bob',
+      }));
+    });
+    // tail-after-colon-split = 'bob', length 3 → no ellipsis.
+    expect(nameOf()).toBe('bob');
+  });
+
+  it('uses the resolved agent name unchanged (truncation only on the fallback path)', () => {
+    act(() => {
+      root.render(React.createElement(AgentChip, {
+        agent: {
+          uri: 'did:dkg:agent:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb',
+          name: 'Alice Researcher',
+          kind: 'human',
+        } as any,
+      }));
+    });
+    expect(nameOf()).toBe('Alice Researcher');
+  });
+});

--- a/packages/node-ui/test/build-lifecycle-activity-rows.test.ts
+++ b/packages/node-ui/test/build-lifecycle-activity-rows.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { buildLifecycleActivityRows } from '../src/ui/hooks/useProjectActivity.js';
+import type { AssertionLifecycleEvent } from '../src/ui/hooks/useAssertionLifecycleEvents.js';
+
+// N6 polish (task #23) — `buildLifecycleActivityRows` converts
+// agent-DID-keyed lifecycle events into rows the activity feed
+// renders. One row per event, agent attribution on `authorUri`,
+// per-bundle root count on `entityCount` (promoted only).
+describe('buildLifecycleActivityRows', () => {
+  const baseCreated: AssertionLifecycleEvent = {
+    eventUri: 'urn:evt:create-1',
+    kind: 'created',
+    assertionUri: 'urn:assert:doc-1',
+    assertionName: 'doc-1',
+    agentUri: 'did:dkg:agent:alice',
+    publishedAt: '2026-05-20T10:00:00Z',
+  };
+  const basePromoted: AssertionLifecycleEvent = {
+    eventUri: 'urn:evt:promote-1',
+    kind: 'promoted',
+    assertionUri: 'urn:assert:doc-1',
+    assertionName: 'doc-1',
+    agentUri: 'did:dkg:agent:bob',
+    publishedAt: '2026-05-22T10:00:00Z',
+    entityCount: 5,
+  };
+
+  it('emits one row per event (no per-rootEntity unwind)', () => {
+    const items = buildLifecycleActivityRows([baseCreated, basePromoted]);
+    expect(items).toHaveLength(2);
+  });
+
+  it('maps created→`added` and promoted→`promoted`, with the right trust layer', () => {
+    const items = buildLifecycleActivityRows([baseCreated, basePromoted]);
+    const created = items.find(i => i.entity.uri === 'urn:assert:doc-1' && i.event === 'added');
+    const promoted = items.find(i => i.entity.uri === 'urn:assert:doc-1' && i.event === 'promoted');
+    expect(created?.layer).toBe('working');
+    expect(promoted?.layer).toBe('shared');
+  });
+
+  it('carries the agent DID on `authorUri` (no peer-id leak)', () => {
+    const items = buildLifecycleActivityRows([baseCreated, basePromoted]);
+    expect(items.find(i => i.event === 'added')?.authorUri).toBe('did:dkg:agent:alice');
+    expect(items.find(i => i.event === 'promoted')?.authorUri).toBe('did:dkg:agent:bob');
+  });
+
+  it('surfaces entityCount only on promoted rows (created rows omit it)', () => {
+    const items = buildLifecycleActivityRows([baseCreated, basePromoted]);
+    const created = items.find(i => i.event === 'added');
+    const promoted = items.find(i => i.event === 'promoted');
+    expect(created?.entityCount).toBeUndefined();
+    expect(promoted?.entityCount).toBe(5);
+  });
+
+  it('uses the assertion name as the entity label, with URI-tail fallback', () => {
+    const items = buildLifecycleActivityRows([
+      baseCreated,
+      { ...basePromoted, assertionName: '' },
+    ]);
+    expect(items.find(i => i.event === 'added')?.entity.label).toBe('doc-1');
+    // Fallback path strips the URN prefix and shows the tail.
+    expect(items.find(i => i.event === 'promoted')?.entity.label).toBe('doc-1');
+  });
+
+  it('renders rows non-clickable (pre-S4: no assertion-detail surface)', () => {
+    const items = buildLifecycleActivityRows([baseCreated, basePromoted]);
+    expect(items.every(i => i.clickable === false)).toBe(true);
+  });
+
+  it('produces stable per-event ids (one bundle promote = one id)', () => {
+    const items = buildLifecycleActivityRows([
+      basePromoted,
+      // Same agent re-promoting the same assertion gets a fresh event URI
+      // → distinct row + distinct id.
+      { ...basePromoted, eventUri: 'urn:evt:promote-2', publishedAt: '2026-05-23T10:00:00Z' },
+    ]);
+    expect(items).toHaveLength(2);
+    expect(items[0].id).not.toBe(items[1].id);
+  });
+
+  it('sorts newest-first', () => {
+    const items = buildLifecycleActivityRows([baseCreated, basePromoted]);
+    expect(items[0].event).toBe('promoted'); // 05-22 > 05-20
+    expect(items[1].event).toBe('added');
+  });
+
+  it('filters by agentUri when supplied', () => {
+    const items = buildLifecycleActivityRows(
+      [baseCreated, basePromoted],
+      { agentUri: 'did:dkg:agent:bob' },
+    );
+    expect(items.map(i => i.authorUri)).toEqual(['did:dkg:agent:bob']);
+  });
+
+  it('drops rows with unparseable timestamps', () => {
+    const items = buildLifecycleActivityRows([
+      { ...baseCreated, publishedAt: 'not-a-date' },
+    ]);
+    expect(items).toHaveLength(0);
+  });
+});

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -145,7 +145,12 @@ describe('Context Graph shared empty/stat patterns', () => {
     await unmount();
   });
 
-  it('uses the shared empty pattern for empty activity feeds', async () => {
+  it('uses the quieter inline empty pattern for empty activity feeds (N6 polish #23)', async () => {
+    // The Overview activity feed switched off the shared centered/bold
+    // `EmptyState` primitive — that read as a load-bearing message on
+    // an otherwise calm Overview. Quieter inline tertiary hint receeds
+    // so the surface stays the focal area. Empty-state copy is still
+    // surfaced (the hint is the user-facing payload).
     const { container, unmount } = await render(
       React.createElement(ActivityFeed, {
         entities: [],
@@ -154,7 +159,12 @@ describe('Context Graph shared empty/stat patterns', () => {
       }),
     );
 
-    expect(container.querySelector('.v10-activity-feed-empty .v10-empty-state')).toBeTruthy();
+    const empty = container.querySelector('.v10-activity-feed-empty');
+    expect(empty).toBeTruthy();
+    // Quieter inline class replaces the shared `EmptyState` shell.
+    expect(empty?.querySelector('.v10-activity-feed-empty-hint')).toBeTruthy();
+    // The shared EmptyState primitive is no longer used here.
+    expect(empty?.querySelector('.v10-empty-state')).toBeNull();
     expect(container.textContent).toContain('No recent updates yet.');
 
     await unmount();

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -170,6 +170,122 @@ describe('Context Graph shared empty/stat patterns', () => {
     await unmount();
   });
 
+  // PR #694 Comment 8 — when the lifecycle SPARQL errors, the feed
+  // must render a distinguishable indicator instead of degrading to
+  // a normal empty state. The Comment 3 catch-side fix made
+  // `events.length === 0` true in both success-empty and error
+  // states, so the explicit `lifecycleError` prop is the signal.
+  it('renders the lifecycle error indicator, distinct from the empty hint', async () => {
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: [],
+        onSelectEntity: vi.fn(),
+        emptyHint: 'No recent updates yet.',
+        lifecycleError: 'SPARQL query failed: 503',
+      }),
+    );
+
+    const empty = container.querySelector('.v10-activity-feed-empty');
+    expect(empty).toBeTruthy();
+    // Error indicator present.
+    const err = empty?.querySelector('.v10-activity-feed-error');
+    expect(err).toBeTruthy();
+    expect(err?.textContent ?? '').toContain("Couldn't load");
+    // Empty hint is replaced by the error indicator — we don't show
+    // both, so the user isn't given two contradictory states.
+    expect(empty?.querySelector('.v10-activity-feed-empty-hint')).toBeNull();
+    // The underlying error message is exposed via the title attribute
+    // for power users / diagnostics.
+    expect(err?.getAttribute('title')).toBe('SPARQL query failed: 503');
+
+    await unmount();
+  });
+
+  // PR #694 Comment 9 — when the joiner saturates at `limit`, the
+  // title badge must read `${limit}+` so the user can tell a project
+  // at the cap apart from one that happens to have exactly that
+  // many items. Below the cap, the exact count renders verbatim.
+  it('renders `${limit}+` on the title badge when the feed saturates the cap', async () => {
+    // Build 50 entities each with a dcterms:created triple; the
+    // legacy `useProjectActivity` path will surface them as `'added'`
+    // rows. Cap at 10 to trigger saturation.
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DC_CREATED = 'http://purl.org/dc/terms/created';
+    const triples = [];
+    for (let i = 0; i < 50; i++) {
+      triples.push({
+        subject: `urn:e:doc-${i}`,
+        predicate: RDF_TYPE,
+        object: 'http://schema.org/CreativeWork',
+        layer: 'working' as const,
+      });
+      triples.push({
+        subject: `urn:e:doc-${i}`,
+        predicate: DC_CREATED,
+        object: `"2026-05-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z"`,
+        layer: 'working' as const,
+      });
+    }
+    const { buildMemoryEntities } = await import('../src/ui/hooks/useMemoryEntities.js');
+    const entityMap = buildMemoryEntities(triples);
+    const entityList = [...entityMap.values()];
+
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: entityList,
+        onSelectEntity: vi.fn(),
+        title: 'Recent activity',
+        limit: 10,
+        includeUndated: false,
+      }),
+    );
+
+    const badge = container.querySelector('.v10-activity-feed-title-count');
+    expect(badge).toBeTruthy();
+    // 50 entities >= limit 10 → saturation indicator.
+    expect(badge?.textContent).toBe('10+');
+
+    await unmount();
+  });
+
+  it('renders the exact count on the title badge below the cap', async () => {
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DC_CREATED = 'http://purl.org/dc/terms/created';
+    const triples = [];
+    for (let i = 0; i < 3; i++) {
+      triples.push({
+        subject: `urn:e:doc-${i}`,
+        predicate: RDF_TYPE,
+        object: 'http://schema.org/CreativeWork',
+        layer: 'working' as const,
+      });
+      triples.push({
+        subject: `urn:e:doc-${i}`,
+        predicate: DC_CREATED,
+        object: `"2026-05-2${i + 1}T10:00:00Z"`,
+        layer: 'working' as const,
+      });
+    }
+    const { buildMemoryEntities } = await import('../src/ui/hooks/useMemoryEntities.js');
+    const entityMap = buildMemoryEntities(triples);
+    const entityList = [...entityMap.values()];
+
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: entityList,
+        onSelectEntity: vi.fn(),
+        title: 'Recent activity',
+        limit: 10,
+        includeUndated: false,
+      }),
+    );
+
+    const badge = container.querySelector('.v10-activity-feed-title-count');
+    expect(badge?.textContent).toBe('3');
+
+    await unmount();
+  });
+
   it('shows the explained interim empty state for SWM assertions', async () => {
     apiMocks.listAssertions.mockResolvedValueOnce([]);
     const { container, unmount } = await render(

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -175,6 +175,10 @@ describe('Context Graph shared empty/stat patterns', () => {
   // a normal empty state. The Comment 3 catch-side fix made
   // `events.length === 0` true in both success-empty and error
   // states, so the explicit `lifecycleError` prop is the signal.
+  //
+  // qa-lead copy tweak (also folded into the Comment 11 commit) —
+  // dropped "Retrying…" because the hook only re-fetches on cgId
+  // change, not on a timer. Test asserts the exact (shorter) copy.
   it('renders the lifecycle error indicator, distinct from the empty hint', async () => {
     const { container, unmount } = await render(
       React.createElement(ActivityFeed, {
@@ -190,7 +194,8 @@ describe('Context Graph shared empty/stat patterns', () => {
     // Error indicator present.
     const err = empty?.querySelector('.v10-activity-feed-error');
     expect(err).toBeTruthy();
-    expect(err?.textContent ?? '').toContain("Couldn't load");
+    // qa-lead copy tweak — exact text (no "Retrying…").
+    expect(err?.textContent?.trim()).toBe("Couldn't load recent activity.");
     // Empty hint is replaced by the error indicator — we don't show
     // both, so the user isn't given two contradictory states.
     expect(empty?.querySelector('.v10-activity-feed-empty-hint')).toBeNull();
@@ -201,82 +206,138 @@ describe('Context Graph shared empty/stat patterns', () => {
     await unmount();
   });
 
-  // PR #694 Comment 9 — when the joiner saturates at `limit`, the
-  // title badge must read `${limit}+` so the user can tell a project
-  // at the cap apart from one that happens to have exactly that
-  // many items. Below the cap, the exact count renders verbatim.
-  it('renders `${limit}+` on the title badge when the feed saturates the cap', async () => {
-    // Build 50 entities each with a dcterms:created triple; the
-    // legacy `useProjectActivity` path will surface them as `'added'`
-    // rows. Cap at 10 to trigger saturation.
+  // PR #694 Comment 11 — the prior Comment 8 fix did an early-return
+  // on `lifecycleError`, which blanked typed Decision/Task/PR rows
+  // sourced from the BASE entity-list path even though they have
+  // nothing to do with the lifecycle stream. The error indicator
+  // now renders inline (above the buckets, below the title) and
+  // only replaces the empty hint when there are no rows at all.
+  it('renders the error indicator inline AND keeps typed base-path rows when both are present', async () => {
+    // Construct a typed Decision row in the entity-list path. The
+    // lifecycle stream errored independently — the indicator must
+    // not blank the typed row.
     const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const TYPE_DECISION = 'http://dkg.io/ontology/decisions/Decision';
     const DC_CREATED = 'http://purl.org/dc/terms/created';
-    const triples = [];
-    for (let i = 0; i < 50; i++) {
-      triples.push({
-        subject: `urn:e:doc-${i}`,
-        predicate: RDF_TYPE,
-        object: 'http://schema.org/CreativeWork',
-        layer: 'working' as const,
-      });
-      triples.push({
-        subject: `urn:e:doc-${i}`,
-        predicate: DC_CREATED,
-        object: `"2026-05-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z"`,
-        layer: 'working' as const,
-      });
-    }
+    const triples = [
+      { subject: 'urn:decision:1', predicate: RDF_TYPE, object: TYPE_DECISION, layer: 'working' as const },
+      { subject: 'urn:decision:1', predicate: DC_CREATED, object: '"2026-05-22T10:00:00Z"', layer: 'working' as const },
+    ];
     const { buildMemoryEntities } = await import('../src/ui/hooks/useMemoryEntities.js');
-    const entityMap = buildMemoryEntities(triples);
-    const entityList = [...entityMap.values()];
+    const entityList = [...buildMemoryEntities(triples).values()];
 
     const { container, unmount } = await render(
       React.createElement(ActivityFeed, {
         entities: entityList,
         onSelectEntity: vi.fn(),
         title: 'Recent activity',
-        limit: 10,
-        includeUndated: false,
+        // Lifecycle stream errored: pass [] for events (consumer
+        // would do this mid-error per the Comment 6 fix) AND the
+        // error string. Without Comment 11 the early-return would
+        // hide the typed row even though it doesn't come from the
+        // lifecycle stream.
+        lifecycleEvents: [],
+        lifecycleError: 'SPARQL query failed: 503',
       }),
     );
 
-    const badge = container.querySelector('.v10-activity-feed-title-count');
-    expect(badge).toBeTruthy();
-    // 50 entities >= limit 10 → saturation indicator.
-    expect(badge?.textContent).toBe('10+');
+    // Typed row renders.
+    const rows = container.querySelectorAll('.v10-activity-feed-row');
+    expect(rows.length).toBeGreaterThan(0);
+    // Error banner ALSO renders.
+    const err = container.querySelector('.v10-activity-feed-error');
+    expect(err).toBeTruthy();
+    expect(err?.textContent?.trim()).toBe("Couldn't load recent activity.");
+    // The populated-feed path does NOT render the empty hint.
+    expect(container.querySelector('.v10-activity-feed-empty-hint')).toBeNull();
 
     await unmount();
   });
 
-  it('renders the exact count on the title badge below the cap', async () => {
-    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
-    const DC_CREATED = 'http://purl.org/dc/terms/created';
-    const triples = [];
-    for (let i = 0; i < 3; i++) {
-      triples.push({
-        subject: `urn:e:doc-${i}`,
-        predicate: RDF_TYPE,
-        object: 'http://schema.org/CreativeWork',
-        layer: 'working' as const,
-      });
-      triples.push({
-        subject: `urn:e:doc-${i}`,
-        predicate: DC_CREATED,
-        object: `"2026-05-2${i + 1}T10:00:00Z"`,
-        layer: 'working' as const,
+  // PR #694 Comment 13 — the saturation badge must read `${limit}+`
+  // ONLY when the joiner reports rows were actually dropped
+  // (`hasMore = merged.length > cap`, computed pre-slice). The
+  // prior `items.length >= effectiveLimit` heuristic lied at the
+  // boundary (exactly `limit` rows rendered as `${limit}+`).
+  //
+  // Drive the saturation through the lifecycle path: that's the
+  // joiner path where the new `hasMore` is honest (the legacy
+  // entity-list path returns the already-capped `base` and reports
+  // `hasMore: false` by construction — no consumer surface today).
+  it('renders `${limit}+` on the title badge only when joiner reports hasMore=true', async () => {
+    const { ActivityFeed } = await import('../src/ui/components/ActivityFeed.js');
+    const events = [];
+    for (let i = 0; i < 15; i++) {
+      events.push({
+        eventUri: `urn:evt:promote-${i}`,
+        kind: 'promoted' as const,
+        assertionUri: `urn:assert:doc-${i}`,
+        assertionName: `doc-${i}`,
+        agentUri: 'did:dkg:agent:bob',
+        publishedAt: `2026-05-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z`,
       });
     }
-    const { buildMemoryEntities } = await import('../src/ui/hooks/useMemoryEntities.js');
-    const entityMap = buildMemoryEntities(triples);
-    const entityList = [...entityMap.values()];
-
     const { container, unmount } = await render(
       React.createElement(ActivityFeed, {
-        entities: entityList,
+        entities: [],
         onSelectEntity: vi.fn(),
         title: 'Recent activity',
         limit: 10,
-        includeUndated: false,
+        lifecycleEvents: events,
+      }),
+    );
+    expect(container.querySelector('.v10-activity-feed-title-count')?.textContent).toBe('10+');
+    await unmount();
+  });
+
+  it('renders the EXACT count on the title badge when at the boundary (merged.length === cap)', async () => {
+    // Reviewer's named case: exactly `limit` rows. Pre-fix the
+    // `items.length >= effectiveLimit` heuristic rendered `'10+'`
+    // here, lying about a project that had exactly 10 rows. The
+    // joiner now reports `hasMore: false` at the boundary.
+    const events = [];
+    for (let i = 0; i < 10; i++) {
+      events.push({
+        eventUri: `urn:evt:promote-${i}`,
+        kind: 'promoted' as const,
+        assertionUri: `urn:assert:doc-${i}`,
+        assertionName: `doc-${i}`,
+        agentUri: 'did:dkg:agent:bob',
+        publishedAt: `2026-05-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z`,
+      });
+    }
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: [],
+        onSelectEntity: vi.fn(),
+        title: 'Recent activity',
+        limit: 10,
+        lifecycleEvents: events,
+      }),
+    );
+    expect(container.querySelector('.v10-activity-feed-title-count')?.textContent).toBe('10');
+    await unmount();
+  });
+
+  it('renders the exact count on the title badge below the cap', async () => {
+    const events = [];
+    for (let i = 0; i < 3; i++) {
+      events.push({
+        eventUri: `urn:evt:promote-${i}`,
+        kind: 'promoted' as const,
+        assertionUri: `urn:assert:doc-${i}`,
+        assertionName: `doc-${i}`,
+        agentUri: 'did:dkg:agent:bob',
+        publishedAt: `2026-05-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z`,
+      });
+    }
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: [],
+        onSelectEntity: vi.fn(),
+        title: 'Recent activity',
+        limit: 10,
+        lifecycleEvents: events,
       }),
     );
 

--- a/packages/node-ui/test/project-helpers.test.ts
+++ b/packages/node-ui/test/project-helpers.test.ts
@@ -1,19 +1,25 @@
 import { describe, expect, it } from 'vitest';
 import { shouldFetchSwmAttribution } from '../src/ui/views/project/helpers.js';
 
-// R2-Local-1 (PR #656) — pins the predicate that ProjectView uses to
-// decide whether to feed `useSwmAttributions` a real `contextGraphId`
-// or `undefined`. Critical that opening an entity detail does NOT
-// flip the predicate to `false` — the hook would clear its cached
-// events and force a 5000-row re-fetch on detail-close, making the
-// Overview activity feed visibly flicker.
+// Pins the predicate that ProjectView uses to decide whether to feed
+// `useSwmAttributions` a real `contextGraphId` or `undefined`.
+//
+// PR #694 review fix — the Overview is no longer a consumer (the
+// activity feed switched to `useAssertionLifecycleEvents` for the
+// agent-DID-keyed bundle stream). Only the SWM-layer graph reads
+// this hook now; the gate tightened to `'swm'`-only so the 5k-row
+// SPARQL doesn't fire on Overview renders and throw the result away.
+//
+// Still no `selectedUri` arg: opening an entity detail on the SWM
+// tab must keep the gate true so the hook's cached events survive
+// the detail round-trip (R2-Local-1 flicker concern, PR #656).
 describe('shouldFetchSwmAttribution — ProjectView gate predicate', () => {
-  it('is true on the Overview tab (activity feed consumer)', () => {
-    expect(shouldFetchSwmAttribution({ activeLayer: 'overview', activeSubGraph: null })).toBe(true);
+  it('is true ONLY on the SWM tab (its sole remaining consumer)', () => {
+    expect(shouldFetchSwmAttribution({ activeLayer: 'swm', activeSubGraph: null })).toBe(true);
   });
 
-  it('is true on the SWM tab (layer graph consumer)', () => {
-    expect(shouldFetchSwmAttribution({ activeLayer: 'swm', activeSubGraph: null })).toBe(true);
+  it('is false on the Overview tab (PR #694 fix — Overview switched to lifecycle source)', () => {
+    expect(shouldFetchSwmAttribution({ activeLayer: 'overview', activeSubGraph: null })).toBe(false);
   });
 
   it('is false on WM / VM / graph-overview / query (no consumer)', () => {
@@ -32,16 +38,17 @@ describe('shouldFetchSwmAttribution — ProjectView gate predicate', () => {
   // gate `true` on consumer views so the hook's cached events stay
   // populated through the detail-open/close round-trip. The predicate
   // intentionally takes no `selectedUri` arg; this test pins that
-  // omission as an invariant rather than an oversight.
-  it('round-tripping a flicker scenario (Overview → detail → Overview) keeps the gate true (R2-Local-1)', () => {
+  // omission as an invariant rather than an oversight (now exercised
+  // on the SWM tab, the sole consumer).
+  it('round-tripping a flicker scenario (SWM → detail → SWM) keeps the gate true (R2-Local-1)', () => {
     // The caller passes `{ activeLayer, activeSubGraph }` only; the
     // detail overlay is orthogonal to both. So the predicate cannot
     // observe a transient `selectedUri` and therefore cannot flip.
-    const overview = { activeLayer: 'overview' as const, activeSubGraph: null };
-    expect(shouldFetchSwmAttribution(overview)).toBe(true);
+    const swm = { activeLayer: 'swm' as const, activeSubGraph: null };
+    expect(shouldFetchSwmAttribution(swm)).toBe(true);
     // Simulated detail-open: same args, same answer.
-    expect(shouldFetchSwmAttribution(overview)).toBe(true);
+    expect(shouldFetchSwmAttribution(swm)).toBe(true);
     // Simulated detail-close: same args, same answer.
-    expect(shouldFetchSwmAttribution(overview)).toBe(true);
+    expect(shouldFetchSwmAttribution(swm)).toBe(true);
   });
 });

--- a/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
+++ b/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
@@ -269,9 +269,37 @@ describe('useAssertionLifecycleEvents — bindings parse', () => {
       root.render(React.createElement(Probe, { id: 'cg-A' }));
     });
     await flush();
-    expect(latest!.error).toContain('503');
+    expect(latest!.error).toBe('SPARQL query failed: 503');
     expect(latest!.events).toHaveLength(0);
     // The discriminator now reads "cg-A errored", not "stale".
     expect(latest!.resultContextGraphId).toBe('cg-A');
+  });
+
+  // PR #694 Comment 8 — the Comment 3 catch-side fix made
+  // `resultContextGraphId === contextGraphId` true in BOTH success
+  // and error states, so consumers can no longer distinguish "loaded
+  // with zero rows" from "the query failed" via the discriminator
+  // alone. The hook's `error` field is the authoritative signal —
+  // consumers (ProjectView → ActivityFeed) plumb it through to
+  // render an error indicator. This test pins the hook contract:
+  // error message is exposed verbatim so the UI can surface it.
+  it('exposes the rejection message verbatim on error (Comment 8 distinguishability)', async () => {
+    let latest: AssertionLifecycleEventsResult | null = null;
+    function Probe({ id }: { id: string }) {
+      latest = useAssertionLifecycleEvents(id);
+      return null;
+    }
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('Custom upstream message');
+    }) as any;
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-A' }));
+    });
+    await flush();
+    // The exact message must reach the consumer so the title
+    // attribute on the inline error indicator surfaces it.
+    expect(latest!.error).toBe('Custom upstream message');
+    expect(latest!.resultContextGraphId).toBe('cg-A');
+    expect(latest!.events).toHaveLength(0);
   });
 });

--- a/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
+++ b/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
@@ -29,12 +29,23 @@ describe('buildLifecycleEventsQuery — SPARQL shape', () => {
     expect(q).not.toContain('dkg:subGraphName');
   });
 
-  it('UNION-binds created→`prov:generated` and promoted→`prov:used`', () => {
+  it('COALESCEs created→`prov:generated` and promoted→`prov:used` (with a single outer type filter)', () => {
     const q = buildLifecycleEventsQuery('cg-1');
-    expect(q).toContain('prov:generated ?assertion');
-    expect(q).toContain('FILTER(?type = dkg:AssertionCreated)');
-    expect(q).toContain('prov:used ?assertion');
-    expect(q).toContain('FILTER(?type = dkg:AssertionPromoted)');
+    // Both predicates are projected as OPTIONAL → COALESCE; the type
+    // filter is applied ONCE on the outer pattern, not inside per-branch
+    // UNION clauses. The prior UNION-with-inner-FILTER shape silently
+    // returned zero rows against oxigraph in production (the filter on
+    // ?type didn't interact with the outer multi-rdf:type binding) —
+    // this guard locks the working shape.
+    expect(q).toContain('OPTIONAL { ?event prov:generated ?gen }');
+    expect(q).toContain('OPTIONAL { ?event prov:used ?used }');
+    expect(q).toContain('BIND(COALESCE(?gen, ?used) AS ?assertion)');
+    expect(q).toContain('FILTER(?type IN (dkg:AssertionCreated, dkg:AssertionPromoted))');
+    // Regression guard: the broken UNION-with-inner-FILTER pattern
+    // must not come back.
+    expect(q).not.toContain('FILTER(?type = dkg:AssertionCreated)');
+    expect(q).not.toContain('FILTER(?type = dkg:AssertionPromoted)');
+    expect(q).not.toMatch(/UNION\s*\{/);
   });
 
   it('scopes the query to the project `_meta` graph for the given context graph id', () => {

--- a/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
+++ b/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import {
   buildLifecycleEventsQuery,
+  subGraphFromAssertionGraphUri,
   useAssertionLifecycleEvents,
   type AssertionLifecycleEventsResult,
 } from '../src/ui/hooks/useAssertionLifecycleEvents.js';
@@ -17,8 +18,15 @@ describe('buildLifecycleEventsQuery — SPARQL shape', () => {
   // feed source.
   it('SELECTs the lifecycle binding set keyed by event + assertion + agent + ts + entityCount', () => {
     const q = buildLifecycleEventsQuery('cg-1');
-    expect(q).toContain('SELECT ?event ?type ?assertion ?name ?agent ?ts ?subGraph');
+    // PR #694 review fix — the projection swapped `?subGraph` for
+    // `?assertionGraph` since the lifecycle writers don't emit
+    // `dkg:subGraphName`; the slug is derived client-side from the
+    // assertion-graph URI shape.
+    expect(q).toContain('SELECT ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph');
     expect(q).toContain('(COUNT(?root) AS ?entityCount)');
+    expect(q).toContain('OPTIONAL { ?assertion dkg:assertionGraph ?assertionGraph }');
+    // Guard: the dead `dkg:subGraphName` OPTIONAL must not regress.
+    expect(q).not.toContain('dkg:subGraphName');
   });
 
   it('UNION-binds created→`prov:generated` and promoted→`prov:used`', () => {
@@ -36,9 +44,36 @@ describe('buildLifecycleEventsQuery — SPARQL shape', () => {
 
   it('groups by all non-aggregated bindings and orders by ?ts DESC with LIMIT 5000', () => {
     const q = buildLifecycleEventsQuery('cg-1');
-    expect(q).toContain('GROUP BY ?event ?type ?assertion ?name ?agent ?ts ?subGraph');
+    expect(q).toContain('GROUP BY ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph');
     expect(q).toContain('ORDER BY DESC(?ts)');
     expect(q).toContain('LIMIT 5000');
+  });
+});
+
+describe('subGraphFromAssertionGraphUri — slug parse', () => {
+  // PR #694 review fix — mirror of `contextGraphAssertionUri` in
+  // `packages/core/src/constants.ts`. The writer's URI shape is the
+  // authoritative source for the slug; the lifecycle metadata never
+  // emits `dkg:subGraphName` directly.
+  it('returns the slug for sub-graph-scoped assertions', () => {
+    const uri = 'did:dkg:context-graph:cg-1/research/assertion/0xabc/notes';
+    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBe('research');
+  });
+
+  it('returns undefined for root-bucket assertions', () => {
+    const uri = 'did:dkg:context-graph:cg-1/assertion/0xabc/notes';
+    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBeUndefined();
+  });
+
+  it('returns undefined when the prefix does not match the contextGraphId', () => {
+    const uri = 'did:dkg:context-graph:cg-2/research/assertion/0xabc/notes';
+    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBeUndefined();
+  });
+
+  it('returns undefined for malformed URIs that lack the assertion segment', () => {
+    expect(subGraphFromAssertionGraphUri('did:dkg:context-graph:cg-1/research', 'cg-1')).toBeUndefined();
+    expect(subGraphFromAssertionGraphUri('did:dkg:context-graph:cg-1/research/other/0xabc/notes', 'cg-1')).toBeUndefined();
+    expect(subGraphFromAssertionGraphUri('', 'cg-1')).toBeUndefined();
   });
 });
 
@@ -86,7 +121,7 @@ describe('useAssertionLifecycleEvents — bindings parse', () => {
     name: string;
     agent: string;
     ts: string;
-    subGraph?: string;
+    assertionGraph?: string;
     entityCount?: number;
   }) {
     const typeUri = opts.kind === 'created'
@@ -99,7 +134,7 @@ describe('useAssertionLifecycleEvents — bindings parse', () => {
       name: `"${opts.name}"`,
       agent: `"${opts.agent}"`,
       ts: `"${opts.ts}"`,
-      subGraph: opts.subGraph ? `"${opts.subGraph}"` : undefined,
+      assertionGraph: opts.assertionGraph ? `"${opts.assertionGraph}"` : undefined,
       entityCount: opts.entityCount !== undefined
         ? `"${opts.entityCount}"^^<http://www.w3.org/2001/XMLSchema#integer>`
         : undefined,
@@ -172,5 +207,71 @@ describe('useAssertionLifecycleEvents — bindings parse', () => {
     const promoted = latest!.events.find(e => e.kind === 'promoted');
     expect(created?.entityCount).toBeUndefined();
     expect(promoted?.entityCount).toBe(12);
+  });
+
+  // PR #694 review fix — the sub-graph slug is derived from
+  // `dkg:assertionGraph` (the URI shape mirrors
+  // `contextGraphAssertionUri`), not the never-emitted
+  // `dkg:subGraphName`. A sub-graph-scoped assertion URI carries
+  // the slug as its first path segment after the cgId; a
+  // root-bucket assertion has `assertion/` directly.
+  it('derives `subGraph` from `dkg:assertionGraph` for sub-graph-scoped assertions', async () => {
+    let latest: AssertionLifecycleEventsResult | null = null;
+    function Probe({ id }: { id: string }) {
+      latest = useAssertionLifecycleEvents(id);
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-A' }));
+    });
+    await flush();
+    pending.get('cg-A')!.resolve([
+      row({
+        event: 'urn:evt:c-1', kind: 'created',
+        assertion: 'urn:assert:scoped', name: 'scoped-doc',
+        agent: 'did:dkg:agent:alice', ts: '2026-05-20T10:00:00Z',
+        assertionGraph: 'did:dkg:context-graph:cg-A/research/assertion/0xabc/scoped-doc',
+      }),
+      row({
+        event: 'urn:evt:c-2', kind: 'created',
+        assertion: 'urn:assert:root', name: 'root-doc',
+        agent: 'did:dkg:agent:alice', ts: '2026-05-20T11:00:00Z',
+        assertionGraph: 'did:dkg:context-graph:cg-A/assertion/0xabc/root-doc',
+      }),
+    ]);
+    await flush();
+    const scoped = latest!.events.find(e => e.assertionUri === 'urn:assert:scoped');
+    const rootBucket = latest!.events.find(e => e.assertionUri === 'urn:assert:root');
+    expect(scoped?.subGraph).toBe('research');
+    expect(rootBucket?.subGraph).toBeUndefined();
+  });
+
+  // PR #694 review fix — on fetch failure, `resultContextGraphId`
+  // must advance to the requested `contextGraphId` so consumers
+  // gating on `resultContextGraphId === contextGraphId` (the Code7
+  // pattern shared with `useSwmAttributions`) can distinguish "still
+  // loading the new graph" from "the new graph errored — final
+  // answer". Pre-fix, the catch block cleared `events` but left
+  // `resultContextGraphId` stuck on the previous graph (or
+  // `undefined` on first load), holding consumers in the stale state
+  // until the hook re-ran.
+  it('advances `resultContextGraphId` on fetch failure (catch-side mirror of success path)', async () => {
+    let latest: AssertionLifecycleEventsResult | null = null;
+    function Probe({ id }: { id: string }) {
+      latest = useAssertionLifecycleEvents(id);
+      return null;
+    }
+    // Override the default deferred-success fetch with one that rejects.
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('SPARQL query failed: 503');
+    }) as any;
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-A' }));
+    });
+    await flush();
+    expect(latest!.error).toContain('503');
+    expect(latest!.events).toHaveLength(0);
+    // The discriminator now reads "cg-A errored", not "stale".
+    expect(latest!.resultContextGraphId).toBe('cg-A');
   });
 });

--- a/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
+++ b/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  buildLifecycleEventsQuery,
+  useAssertionLifecycleEvents,
+  type AssertionLifecycleEventsResult,
+} from '../src/ui/hooks/useAssertionLifecycleEvents.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('buildLifecycleEventsQuery — SPARQL shape', () => {
+  // N6 polish (task #23) — pin the load-bearing parts of the query
+  // so a refactor can't silently break the agent-DID-keyed activity
+  // feed source.
+  it('SELECTs the lifecycle binding set keyed by event + assertion + agent + ts + entityCount', () => {
+    const q = buildLifecycleEventsQuery('cg-1');
+    expect(q).toContain('SELECT ?event ?type ?assertion ?name ?agent ?ts ?subGraph');
+    expect(q).toContain('(COUNT(?root) AS ?entityCount)');
+  });
+
+  it('UNION-binds created→`prov:generated` and promoted→`prov:used`', () => {
+    const q = buildLifecycleEventsQuery('cg-1');
+    expect(q).toContain('prov:generated ?assertion');
+    expect(q).toContain('FILTER(?type = dkg:AssertionCreated)');
+    expect(q).toContain('prov:used ?assertion');
+    expect(q).toContain('FILTER(?type = dkg:AssertionPromoted)');
+  });
+
+  it('scopes the query to the project `_meta` graph for the given context graph id', () => {
+    const q = buildLifecycleEventsQuery('cg-42');
+    expect(q).toContain('GRAPH <did:dkg:context-graph:cg-42/_meta>');
+  });
+
+  it('groups by all non-aggregated bindings and orders by ?ts DESC with LIMIT 5000', () => {
+    const q = buildLifecycleEventsQuery('cg-1');
+    expect(q).toContain('GROUP BY ?event ?type ?assertion ?name ?agent ?ts ?subGraph');
+    expect(q).toContain('ORDER BY DESC(?ts)');
+    expect(q).toContain('LIMIT 5000');
+  });
+});
+
+describe('useAssertionLifecycleEvents — bindings parse', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let originalFetch: typeof globalThis.fetch | undefined;
+  let pending: Map<string, { resolve: (rows: any[]) => void }>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    pending = new Map();
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (_url: any, init?: any) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      const cgId: string = body.contextGraphId;
+      const p = new Promise<any[]>((resolve) => {
+        pending.set(cgId, { resolve });
+      });
+      const rows = await p;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ result: { bindings: rows } }),
+      } as any;
+    }) as any;
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  async function flush() {
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+  }
+
+  function row(opts: {
+    event: string;
+    kind: 'created' | 'promoted';
+    assertion: string;
+    name: string;
+    agent: string;
+    ts: string;
+    subGraph?: string;
+    entityCount?: number;
+  }) {
+    const typeUri = opts.kind === 'created'
+      ? 'http://dkg.io/ontology/AssertionCreated'
+      : 'http://dkg.io/ontology/AssertionPromoted';
+    return {
+      event: `"${opts.event}"`,
+      type: `"${typeUri}"`,
+      assertion: `"${opts.assertion}"`,
+      name: `"${opts.name}"`,
+      agent: `"${opts.agent}"`,
+      ts: `"${opts.ts}"`,
+      subGraph: opts.subGraph ? `"${opts.subGraph}"` : undefined,
+      entityCount: opts.entityCount !== undefined
+        ? `"${opts.entityCount}"^^<http://www.w3.org/2001/XMLSchema#integer>`
+        : undefined,
+    };
+  }
+
+  it('discriminates created vs promoted via rdf:type and exposes both kinds in one stream', async () => {
+    let latest: AssertionLifecycleEventsResult | null = null;
+    function Probe({ id }: { id: string }) {
+      latest = useAssertionLifecycleEvents(id);
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-A' }));
+    });
+    await flush();
+    pending.get('cg-A')!.resolve([
+      row({
+        event: 'urn:evt:create-1', kind: 'created',
+        assertion: 'urn:assert:doc-1', name: 'doc-1',
+        agent: 'did:dkg:agent:alice', ts: '2026-05-20T10:00:00Z',
+        // created events GROUP-BY counts to 0 (no dkg:rootEntity triples).
+        entityCount: 0,
+      }),
+      row({
+        event: 'urn:evt:promote-1', kind: 'promoted',
+        assertion: 'urn:assert:doc-1', name: 'doc-1',
+        agent: 'did:dkg:agent:bob', ts: '2026-05-22T10:00:00Z',
+        entityCount: 5,
+      }),
+    ]);
+    await flush();
+    expect(latest!.events).toHaveLength(2);
+    const byKind = new Map(latest!.events.map(e => [e.kind, e]));
+    expect(byKind.get('created')?.assertionName).toBe('doc-1');
+    expect(byKind.get('created')?.agentUri).toBe('did:dkg:agent:alice');
+    expect(byKind.get('promoted')?.agentUri).toBe('did:dkg:agent:bob');
+  });
+
+  it('populates entityCount on promoted rows; leaves it undefined on created rows', async () => {
+    let latest: AssertionLifecycleEventsResult | null = null;
+    function Probe({ id }: { id: string }) {
+      latest = useAssertionLifecycleEvents(id);
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-A' }));
+    });
+    await flush();
+    pending.get('cg-A')!.resolve([
+      // Created with a 0 count from GROUP BY — should still surface
+      // as `undefined`, not `0`, so the renderer can branch cleanly
+      // ("hide" vs "show 0 entities").
+      row({
+        event: 'urn:evt:create-1', kind: 'created',
+        assertion: 'urn:assert:doc-1', name: 'doc-1',
+        agent: 'did:dkg:agent:alice', ts: '2026-05-20T10:00:00Z',
+        entityCount: 0,
+      }),
+      // Promoted with a real bundle count.
+      row({
+        event: 'urn:evt:promote-1', kind: 'promoted',
+        assertion: 'urn:assert:doc-1', name: 'doc-1',
+        agent: 'did:dkg:agent:bob', ts: '2026-05-22T10:00:00Z',
+        entityCount: 12,
+      }),
+    ]);
+    await flush();
+    const created = latest!.events.find(e => e.kind === 'created');
+    const promoted = latest!.events.find(e => e.kind === 'promoted');
+    expect(created?.entityCount).toBeUndefined();
+    expect(promoted?.entityCount).toBe(12);
+  });
+});

--- a/packages/node-ui/test/use-project-activity-events-joiner.test.ts
+++ b/packages/node-ui/test/use-project-activity-events-joiner.test.ts
@@ -213,4 +213,81 @@ describe('useProjectActivityEvents — hasMore signal (PR #694 Comment 13)', () 
     expect(events).toHaveLength(3);
     expect(readHasMore(container)).toBe(false);
   });
+
+  // PR #694 Comment 14 — the typed/decision rows must survive even
+  // when a flood of imports ranks above them. Pre-fix, the base hook
+  // sliced first and the joiner filtered second, so the typed rows
+  // below the 200-cap would be silently dropped. Post-fix, the
+  // joiner pushes `excludeEvents: ['added']` into base, so the slice
+  // operates on the post-filter set.
+  it('typed rows survive when imports outrank them within the cap (Comment 14)', () => {
+    const TYPE_DECISION = 'http://dkg.io/ontology/decisions/Decision';
+    const triples: LayeredTriple[] = [];
+    // 50 imports, newest first — these would have filled the cap pre-fix.
+    for (let i = 0; i < 50; i++) {
+      const ts = new Date(Date.UTC(2026, 4, 25 - Math.floor(i / 2), 12, i % 60, 0)).toISOString();
+      triples.push(
+        { subject: `urn:doc:${i}`, predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+        { subject: `urn:doc:${i}`, predicate: DC_CREATED, object: `"${ts}"`, layer: 'working' },
+      );
+    }
+    // 5 typed Decision rows ranked OLDER than the imports — would be
+    // pushed out of a 10-cap window pre-fix.
+    for (let i = 0; i < 5; i++) {
+      const ts = new Date(Date.UTC(2026, 3, 5 - i, 12, 0, 0)).toISOString();
+      triples.push(
+        { subject: `urn:decision:${i}`, predicate: RDF_TYPE, object: TYPE_DECISION, layer: 'working' },
+        { subject: `urn:decision:${i}`, predicate: DC_CREATED, object: `"${ts}"`, layer: 'working' },
+      );
+    }
+    const lifecycle: AssertionLifecycleEvent[] = [
+      {
+        eventUri: 'urn:evt:promote-bundle',
+        kind: 'promoted',
+        assertionUri: 'urn:assert:bundle',
+        assertionName: 'bundle',
+        agentUri: 'did:dkg:agent:bob',
+        publishedAt: '2026-05-30T10:00:00Z',
+        entityCount: 50,
+      },
+    ];
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: entitiesFrom(triples),
+        opts: { lifecycleEvents: lifecycle, limit: 10 },
+      }));
+    });
+    const events = readEvents(container);
+    // 5 typed rows + 1 lifecycle promoted; NO `'added'` rows because
+    // lifecycle is the authoritative source.
+    expect(events.filter(e => e === 'added')).toHaveLength(0);
+    expect(events.filter(e => e === 'typed')).toHaveLength(5);
+    expect(events.filter(e => e === 'promoted')).toHaveLength(1);
+  });
+
+  // PR #694 Comment 15 — the saturation badge must be honest on the
+  // legacy (non-lifecycle, non-swm) path too. Pre-fix, the joiner
+  // hard-coded `hasMore: false` for that path; the title badge then
+  // displayed `200` on an over-capped AgentProfileView feed instead
+  // of `200+`. Post-fix, the base hook surfaces its own `hasMore`
+  // and the joiner propagates it.
+  it('hasMore propagates from base on the legacy path (Comment 15)', () => {
+    const triples: LayeredTriple[] = [];
+    for (let i = 0; i < 15; i++) {
+      const ts = new Date(Date.UTC(2026, 4, 1, 12, i, 0)).toISOString();
+      triples.push(
+        { subject: `urn:doc:${i}`, predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+        { subject: `urn:doc:${i}`, predicate: DC_CREATED, object: `"${ts}"`, layer: 'working' },
+      );
+    }
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: entitiesFrom(triples),
+        // No lifecycleEvents, no swmEvents — pure legacy path.
+        opts: { limit: 10 },
+      }));
+    });
+    expect(readEvents(container)).toHaveLength(10);
+    expect(readHasMore(container)).toBe(true);
+  });
 });

--- a/packages/node-ui/test/use-project-activity-events-joiner.test.ts
+++ b/packages/node-ui/test/use-project-activity-events-joiner.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  useProjectActivityEvents,
+  type ActivityItem,
+  type UseProjectActivityEventsOptions,
+} from '../src/ui/hooks/useProjectActivity.js';
+import {
+  buildMemoryEntities,
+  type LayeredTriple,
+  type MemoryEntity,
+} from '../src/ui/hooks/useMemoryEntities.js';
+import type { AssertionLifecycleEvent } from '../src/ui/hooks/useAssertionLifecycleEvents.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const DC_CREATED = 'http://purl.org/dc/terms/created';
+
+function entitiesFrom(triples: LayeredTriple[]): MemoryEntity[] {
+  return [...buildMemoryEntities(triples).values()];
+}
+
+function Probe({
+  entities,
+  opts,
+}: {
+  entities: MemoryEntity[];
+  opts: UseProjectActivityEventsOptions;
+}) {
+  const items = useProjectActivityEvents(entities, opts);
+  return React.createElement('div', {
+    id: 'probe',
+    'data-events': items.map(i => i.event).join('|'),
+  });
+}
+
+function readEvents(container: HTMLElement): string[] {
+  const probe = container.querySelector('#probe');
+  if (!probe) return [];
+  const raw = probe.getAttribute('data-events') ?? '';
+  return raw.split('|').filter(Boolean);
+}
+
+// PR #694 review fix — the `lifecycleEvents` prop is presence-keyed,
+// not size-keyed. Passing it (even as an empty array) opts INTO the
+// lifecycle contract: `'added'` rows from the entity-list
+// `dcterms:created` path are suppressed, and the only `'promoted'`
+// rows come from the lifecycle stream (zero when the array is
+// empty). Passing `undefined` keeps the legacy path. This guard
+// prevents the Overview shape from silently changing the moment a
+// project records its first `dkg:AssertionCreated` event.
+describe('useProjectActivityEvents — lifecycleEvents presence semantics (PR #694)', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function importedEntities(): MemoryEntity[] {
+    // Two imported entities with `dcterms:created` triples — these
+    // would surface as `'added'` rows on the legacy path.
+    return entitiesFrom([
+      { subject: 'urn:e:doc-1', predicate: RDF_TYPE, object: 'http://schema.org/CreativeWork', layer: 'working' },
+      { subject: 'urn:e:doc-1', predicate: DC_CREATED, object: '"2026-05-20T08:00:00Z"', layer: 'working' },
+      { subject: 'urn:e:doc-2', predicate: RDF_TYPE, object: 'http://schema.org/CreativeWork', layer: 'working' },
+      { subject: 'urn:e:doc-2', predicate: DC_CREATED, object: '"2026-05-21T08:00:00Z"', layer: 'working' },
+    ]);
+  }
+
+  it('legacy path: `lifecycleEvents` undefined → `added` rows from entity-list survive', () => {
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: importedEntities(),
+        opts: {},
+      }));
+    });
+    const events = readEvents(container);
+    // Two imported entities → two `added` rows. Legacy contract preserved.
+    expect(events.filter(e => e === 'added')).toHaveLength(2);
+  });
+
+  it('empty array opts INTO the lifecycle contract: `added` rows from entity-list ARE suppressed', () => {
+    // The regression: pre-fix this case fell through to the legacy
+    // path (`useLifecycle = lifecycleEvents && lifecycleEvents.length > 0`
+    // evaluated false on empty array), so the Overview would surface
+    // 2 `added` rows for the imported entities — then silently flip
+    // to 0 of them the moment the first AssertionCreated event landed.
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: importedEntities(),
+        opts: { lifecycleEvents: [] },
+      }));
+    });
+    const events = readEvents(container);
+    expect(events).toHaveLength(0);
+    expect(events).not.toContain('added');
+  });
+
+  it('non-empty array: lifecycle promoted rows merge in; entity-list `added` rows still suppressed', () => {
+    const lifecycle: AssertionLifecycleEvent[] = [
+      {
+        eventUri: 'urn:evt:promote-1',
+        kind: 'promoted',
+        assertionUri: 'urn:assert:doc-1',
+        assertionName: 'doc-1',
+        agentUri: 'did:dkg:agent:bob',
+        publishedAt: '2026-05-22T10:00:00Z',
+        entityCount: 3,
+      },
+    ];
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: importedEntities(),
+        opts: { lifecycleEvents: lifecycle },
+      }));
+    });
+    const events = readEvents(container);
+    expect(events).toEqual(['promoted']);
+  });
+});

--- a/packages/node-ui/test/use-project-activity-events-joiner.test.ts
+++ b/packages/node-ui/test/use-project-activity-events-joiner.test.ts
@@ -31,10 +31,14 @@ function Probe({
   entities: MemoryEntity[];
   opts: UseProjectActivityEventsOptions;
 }) {
-  const items = useProjectActivityEvents(entities, opts);
+  // PR #694 Comment 13 — the joiner returns `{ items, hasMore }`
+  // now. `data-has-more` lets the saturation badge be exercised
+  // alongside the row stream without a second probe.
+  const { items, hasMore } = useProjectActivityEvents(entities, opts);
   return React.createElement('div', {
     id: 'probe',
     'data-events': items.map(i => i.event).join('|'),
+    'data-has-more': hasMore ? '1' : '0',
   });
 }
 
@@ -43,6 +47,10 @@ function readEvents(container: HTMLElement): string[] {
   if (!probe) return [];
   const raw = probe.getAttribute('data-events') ?? '';
   return raw.split('|').filter(Boolean);
+}
+
+function readHasMore(container: HTMLElement): boolean {
+  return container.querySelector('#probe')?.getAttribute('data-has-more') === '1';
 }
 
 // PR #694 review fix — the `lifecycleEvents` prop is presence-keyed,
@@ -128,5 +136,81 @@ describe('useProjectActivityEvents — lifecycleEvents presence semantics (PR #6
     });
     const events = readEvents(container);
     expect(events).toEqual(['promoted']);
+  });
+});
+
+// PR #694 Comment 13 — `hasMore` is the pre-slice honest signal so
+// the title saturation badge doesn't lie at the boundary. The prior
+// `items.length >= effectiveLimit` heuristic in the consumer
+// rendered `${limit}+` for projects with *exactly* `limit` rows
+// (no rows dropped). The joiner now reports `hasMore = merged.length
+// > cap`, computed before the slice.
+describe('useProjectActivityEvents — hasMore signal (PR #694 Comment 13)', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function nLifecycleEvents(n: number): AssertionLifecycleEvent[] {
+    const out: AssertionLifecycleEvent[] = [];
+    for (let i = 0; i < n; i++) {
+      out.push({
+        eventUri: `urn:evt:promote-${i}`,
+        kind: 'promoted',
+        assertionUri: `urn:assert:doc-${i}`,
+        assertionName: `doc-${i}`,
+        agentUri: 'did:dkg:agent:bob',
+        // Distinct timestamps so the sort is deterministic.
+        publishedAt: `2026-05-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z`,
+      });
+    }
+    return out;
+  }
+
+  it('hasMore is FALSE at the exact boundary (merged.length === cap)', () => {
+    // Reviewer's named case: project with exactly `limit` rows. The
+    // saturation badge must NOT show `${limit}+`; the count is exact.
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: [],
+        opts: { lifecycleEvents: nLifecycleEvents(10), limit: 10 },
+      }));
+    });
+    const events = readEvents(container);
+    expect(events).toHaveLength(10);
+    expect(readHasMore(container)).toBe(false);
+  });
+
+  it('hasMore is TRUE when merged.length > cap (rows dropped by the slice)', () => {
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: [],
+        opts: { lifecycleEvents: nLifecycleEvents(15), limit: 10 },
+      }));
+    });
+    const events = readEvents(container);
+    expect(events).toHaveLength(10);
+    expect(readHasMore(container)).toBe(true);
+  });
+
+  it('hasMore is FALSE when below the cap', () => {
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: [],
+        opts: { lifecycleEvents: nLifecycleEvents(3), limit: 10 },
+      }));
+    });
+    const events = readEvents(container);
+    expect(events).toHaveLength(3);
+    expect(readHasMore(container)).toBe(false);
   });
 });

--- a/packages/node-ui/test/use-project-activity.test.ts
+++ b/packages/node-ui/test/use-project-activity.test.ts
@@ -41,11 +41,12 @@ function Probe({
   entities: MemoryEntity[];
   opts?: Parameters<typeof useProjectActivity>[1];
 }) {
-  const items = useProjectActivity(entities, opts);
+  const { items, hasMore } = useProjectActivity(entities, opts);
   const dump: CapturedItem[] = items.map(toCaptured);
   return React.createElement('div', {
     id: 'probe',
     'data-items': JSON.stringify(dump),
+    'data-has-more': hasMore ? 'true' : 'false',
   });
 }
 
@@ -236,6 +237,83 @@ describe('useProjectActivity — N6 event classification', () => {
     const items = readItems(container);
     expect(items.map(i => i.uri)).toEqual(['urn:doc:1']);
     expect(items[0].author).toBe('did:dkg:agent:alice');
+  });
+
+  // PR #694 Comment 14 — the joiner pushes `excludeEvents: ['added']`
+  // down into base when lifecycle is supplying its own bundle-level
+  // created rows. Verify base honours the filter at source (during the
+  // loop, before sort+slice) so older typed rows survive a flood of
+  // imports ranking above them.
+  it('excludeEvents drops matching rows during the loop, leaving the slice for the rest', () => {
+    const triples: LayeredTriple[] = [];
+    // 50 imports, newest first.
+    for (let i = 0; i < 50; i++) {
+      const ts = new Date(Date.UTC(2026, 4, 25 - i, 12, 0, 0)).toISOString();
+      triples.push(
+        { subject: `urn:doc:${i}`, predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+        { subject: `urn:doc:${i}`, predicate: DC_CREATED, object: `"${ts}"`, layer: 'working' },
+      );
+    }
+    // 5 typed Decision rows, older than all imports.
+    for (let i = 0; i < 5; i++) {
+      const ts = new Date(Date.UTC(2026, 3, 5 - i, 12, 0, 0)).toISOString();
+      triples.push(
+        { subject: `urn:decision:${i}`, predicate: RDF_TYPE, object: TYPE_DECISION, layer: 'working' },
+        { subject: `urn:decision:${i}`, predicate: DC_CREATED, object: `"${ts}"`, layer: 'working' },
+      );
+    }
+    act(() => {
+      root.render(React.createElement(Probe, {
+        entities: entitiesFrom(triples),
+        opts: { limit: 10, excludeEvents: ['added'] },
+      }));
+    });
+    const items = readItems(container);
+    // Without excludeEvents, the 10-cap window would have been all
+    // imports. With the filter at source, the 5 typed rows are kept
+    // and there's no `'added'` row in the slice.
+    expect(items).toHaveLength(5);
+    expect(items.every(i => i.event === 'typed')).toBe(true);
+    expect(items.map(i => i.uri).sort()).toEqual([
+      'urn:decision:0',
+      'urn:decision:1',
+      'urn:decision:2',
+      'urn:decision:3',
+      'urn:decision:4',
+    ]);
+  });
+
+  // PR #694 Comment 15 — `hasMore` from the base hook is the pre-slice,
+  // post-filter overflow signal so the joiner can propagate an honest
+  // saturation indicator on non-lifecycle paths too.
+  it('hasMore is true when the post-filter row count exceeds limit, false otherwise', () => {
+    const triples: LayeredTriple[] = [];
+    for (let i = 0; i < 12; i++) {
+      const ts = new Date(Date.UTC(2026, 4, 1, 12, i, 0)).toISOString();
+      triples.push(
+        { subject: `urn:doc:${i}`, predicate: RDF_TYPE, object: 'http://schema.org/Article', layer: 'working' },
+        { subject: `urn:doc:${i}`, predicate: DC_CREATED, object: `"${ts}"`, layer: 'working' },
+      );
+    }
+    const entities = entitiesFrom(triples);
+
+    // limit < count → hasMore true
+    act(() => {
+      root.render(React.createElement(Probe, { entities, opts: { limit: 10 } }));
+    });
+    expect(container.querySelector('#probe')?.getAttribute('data-has-more')).toBe('true');
+
+    // limit === count → hasMore false (boundary)
+    act(() => {
+      root.render(React.createElement(Probe, { entities, opts: { limit: 12 } }));
+    });
+    expect(container.querySelector('#probe')?.getAttribute('data-has-more')).toBe('false');
+
+    // limit > count → hasMore false
+    act(() => {
+      root.render(React.createElement(Probe, { entities, opts: { limit: 100 } }));
+    });
+    expect(container.querySelector('#probe')?.getAttribute('data-has-more')).toBe('false');
   });
 });
 

--- a/packages/node-ui/test/use-project-activity.test.ts
+++ b/packages/node-ui/test/use-project-activity.test.ts
@@ -254,7 +254,9 @@ function ProbeEvents({
   entities: MemoryEntity[];
   opts?: Parameters<typeof useProjectActivityEvents>[1];
 }) {
-  const items = useProjectActivityEvents(entities, opts);
+  // PR #694 Comment 13 — joiner returns `{ items, hasMore }` now;
+  // existing tests in this block read items only.
+  const { items } = useProjectActivityEvents(entities, opts);
   const dump: CapturedItem[] = items.map(toCaptured);
   return React.createElement('div', {
     id: 'probe',


### PR DESCRIPTION
## Summary

- **Switches the Overview activity feed source** from `dkg:WorkspaceOperation` (per-rootEntity, peer-id-keyed) to `dkg:AssertionCreated` / `dkg:AssertionPromoted` (per-bundle, agent-DID-keyed). Each promote action now renders as **one row, not N rows** — a single bundle of 32 entities shows `Promoted to SWM · 32 entities`, not 32 separate rows.
- **Closes the peer-id-in-author-column gap** at the source: the new query returns `did:dkg:agent:0x…` directly, so AgentChip resolves cleanly without a peer→agent reverse index.
- **Polishes the empty state**, the "RECENT ACTIVITY" title, the lifecycle row labels, and agent-ID truncation per `agent-docs/context-graph-implementation-plan.md` canonical wording.

`useSwmAttributions` is unchanged — it still owns the SWM graph attribution coloring + legend (which need the `WorkspaceOperation` source for the per-agent palette assignment). Only the activity feed switches sources.

Activity rows are **non-interactive in this PR** — assertion-detail click-through lands when **S4** ships.

## Related

- Closes Task #23 (N6 polish bundle)
- Implements ux-lead's locked B-collapse direction (2026-05-26)
- Positions follow-up Task #21 (N6 publishes SWM→VM events) for a near-trivial one-query extension — same `AssertionPublished` shape already exists in `metadata.ts:695-712`
- Activity rows go live (clickable) when **S4** (assertion detail view) ships per the plan

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts` | **New.** SPARQL hook querying `_meta` for `dkg:AssertionCreated` / `dkg:AssertionPromoted` events. Returns per-bundle events with `entityCount` (promoted) or undefined (created). |
| `packages/node-ui/src/ui/hooks/useProjectActivity.ts` | Adds `lifecycleEvents` option to `useProjectActivityEvents`; new `buildLifecycleActivityRows()` builder; joiner suppression so `lifecycleEvents` is the sole source for created+promoted rows when supplied (no dual-source duplication). Legacy `swmEvents` path untouched for `AgentProfileView`. |
| `packages/node-ui/src/ui/views/ProjectView.tsx` | Calls `useAssertionLifecycleEvents`, passes `lifecycleEvents` to the Overview `<ActivityFeed>`, swaps the empty-hint copy. |
| `packages/node-ui/src/ui/components/ActivityFeed.tsx` | Total-feed-count badge next to the section title; quieter inline empty-state variant; shortened lifecycle labels (`Promoted to SWM`, `Published to VM`); promoted-row label includes ` · {N} entities`. |
| `packages/node-ui/src/ui/components/AgentChip.tsx` | Head+tail truncation (`head6…tail4`) for unresolved fallback URIs — matches the plan's S13 `0x9f3a…c1` pattern. Resolved agents (with a real `name`) unchanged. |
| `packages/node-ui/src/ui/styles.css` | `.v10-activity-feed-title-count` (mono, `--text-tertiary`) + `.v10-activity-feed-empty-hint` quieter variant. |
| `packages/node-ui/test/use-assertion-lifecycle-events.test.ts` | **New.** 6 tests — SPARQL shape snapshot, binding parsing, kind discrimination, `entityCount` populated only on promoted. |
| `packages/node-ui/test/build-lifecycle-activity-rows.test.ts` | **New.** 10 tests — one row per event, agent-DID on `authorUri`, entityCount surfacing, non-clickable pre-S4, sort, `agentUri` filter, invalid-timestamp drop, URI-tail fallback for empty `assertionName`. |
| `packages/node-ui/test/agent-chip.test.ts` | **New.** 5 tests — peer-id truncation, ETH address truncation, did:colon-split tail, short-id no-op, resolved-name passthrough. |
| `packages/node-ui/test/context-graph-empty-stat-components.test.ts` | Updated to assert the new `.v10-activity-feed-empty-hint` class + verify the loud `EmptyState` primitive is gone from the activity-feed-empty path. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec tsc --noEmit` — clean
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run` — full node-ui suite: 712 pass / 119 fail (all 7 failing files are the pre-existing `better-sqlite3` native-binding env issue, same baseline as PR #677 — zero PR-related failures)
- [x] Focused suites: `use-assertion-lifecycle-events.test.ts` 6/6, `build-lifecycle-activity-rows.test.ts` 10/10, `agent-chip.test.ts` 5/5, `use-project-activity.test.ts` 22/22, `context-graph-empty-stat-components.test.ts` 8/8
- [x] `useSwmAttributions` unchanged — SWM graph attribution coloring/legend unaffected (verified via diff scope)
- [ ] **Live walk** (post-merge or pre-merge by user): empty Overview shows the quieter empty state with the new copy
- [ ] **Live walk**: import an MD file → confirm one `AssertionCreated` row appears (not N per-entity rows)
- [ ] **Live walk**: promote multiple entities in one op → confirm ONE `Promoted to SWM · {N} entities` row appears (not N rows)
- [ ] **Live walk**: `RECENT ACTIVITY · {total}` reads correctly alongside the per-bucket `TODAY` chip
- [ ] **Live walk**: AgentChip renders `did:dkg:agent:0x…d34`-style truncation for unresolved agents

## Notes

- **Joiner suppression** when `lifecycleEvents` is supplied also drops entity-list `'added'` rows (sourced from `dcterms:created`). The backend never emitted `dcterms:created` on imports anyway — `dkg:AssertionCreated` is the authoritative source. Typed activity rows (Decision/Task/PR/Issue/Commit) still flow via the base path.
- **`entityCount` is `undefined` for created rows** (the SPARQL `GROUP BY` emits 0, normalised to undefined on the UI side so the `· N entities` suffix branches off cleanly).
- **Empty `assertionName` falls back to `uriTail(assertionUri)`** so rows still read sensibly in the (uncommon) no-name case.