### PR TITLE
feat(core/cli): expose libp2p tunables for small / sparse networks

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -647,19 +647,16 @@ export interface DKGAgentConfig {
    */
   nodeVersion?: string;
   /**
-   * libp2p networking tunables for small / sparse networks. The
-   * peer-store and DHT fields are forwarded into `DKGNodeConfig`;
-   * `peerResolveTimeoutMs` is applied when constructing the agent's
-   * `PeerResolver`. Omitting any field preserves the upstream default.
-   * See `packages/core/src/types.ts` and
-   * `packages/core/src/network/peer-resolver.ts` for per-field
-   * semantics and the operator-facing surface in
-   * `packages/cli/src/config.ts` (`network` block).
+   * libp2p networking tunables for small / sparse networks. All three
+   * fields are optional and forwarded straight into the matching
+   * `DKGNodeConfig` slots. Omitting any field preserves the upstream
+   * default. See `packages/core/src/types.ts` for per-field semantics
+   * and the operator-facing surface in `packages/cli/src/config.ts`
+   * (`network` block).
    */
   peerStoreMaxAddressAgeMs?: number;
   peerStoreMaxPeerAgeMs?: number;
   dhtQuerySelfIntervalMs?: number;
-  peerResolveTimeoutMs?: number;
   /**
    * Path to the V10 Random Sampling prover write-ahead log. Core
    * nodes only; ignored on edge. When omitted, an in-memory WAL is

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -647,6 +647,18 @@ export interface DKGAgentConfig {
    */
   nodeVersion?: string;
   /**
+   * libp2p networking tunables for small / sparse networks. All four
+   * fields are optional and forwarded straight into the matching
+   * `DKGNodeConfig` slots. Omitting any field preserves the upstream
+   * default. See `packages/core/src/types.ts` for per-field semantics
+   * and the operator-facing surface in `packages/cli/src/config.ts`
+   * (`network` block).
+   */
+  peerStoreMaxAddressAgeMs?: number;
+  peerStoreMaxPeerAgeMs?: number;
+  dhtQuerySelfIntervalMs?: number;
+  peerResolveTimeoutMs?: number;
+  /**
    * Path to the V10 Random Sampling prover write-ahead log. Core
    * nodes only; ignored on edge. When omitted, an in-memory WAL is
    * used (loses crash-recovery context on restart). Production

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -647,12 +647,14 @@ export interface DKGAgentConfig {
    */
   nodeVersion?: string;
   /**
-   * libp2p networking tunables for small / sparse networks. All four
-   * fields are optional and forwarded straight into the matching
-   * `DKGNodeConfig` slots. Omitting any field preserves the upstream
-   * default. See `packages/core/src/types.ts` for per-field semantics
-   * and the operator-facing surface in `packages/cli/src/config.ts`
-   * (`network` block).
+   * libp2p networking tunables for small / sparse networks. The
+   * peer-store and DHT fields are forwarded into `DKGNodeConfig`;
+   * `peerResolveTimeoutMs` is applied when constructing the agent's
+   * `PeerResolver`. Omitting any field preserves the upstream default.
+   * See `packages/core/src/types.ts` and
+   * `packages/core/src/network/peer-resolver.ts` for per-field
+   * semantics and the operator-facing surface in
+   * `packages/cli/src/config.ts` (`network` block).
    */
   peerStoreMaxAddressAgeMs?: number;
   peerStoreMaxPeerAgeMs?: number;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -71,6 +71,7 @@ import {
   encryptV10PublishPayload,
   type SubscriptionSource,
   SUBSCRIPTION_SOURCES,
+  pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
@@ -1023,9 +1024,7 @@ export class DKGAgent {
       relayServerCapacity: config.relayServerCapacity,
       relayReservationCount: config.relayReservationCount,
       nodeVersion: config.nodeVersion,
-      peerStoreMaxAddressAgeMs: config.peerStoreMaxAddressAgeMs,
-      peerStoreMaxPeerAgeMs: config.peerStoreMaxPeerAgeMs,
-      dhtQuerySelfIntervalMs: config.dhtQuerySelfIntervalMs,
+      ...pickNetworkTunables(config),
     };
 
     const node = new DKGNode(nodeConfig);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1239,7 +1239,14 @@ export class DKGAgent {
       // Bootstrap is a libp2p-startup concern (`bootstrap({ list })` in
       // peerDiscovery, see node.ts) — not a per-peer resolution concern.
       // Removed here per Codex review feedback on PR #496.
-      defaultPerStepTimeoutMs: this.config.peerResolveTimeoutMs,
+      //
+      // Note: `defaultPerStepTimeoutMs` is intentionally NOT wired from
+      // operator config. Production callers (`connectToPeerId`, chat /
+      // routed sends) always pass an explicit `perStepTimeoutMs`
+      // derived from their own deadline budget, so any constructor
+      // default would be a silent no-op for those paths. The
+      // constructor option survives as a test-fixture surface.
+      // Codex review of PR #698 round 2 caught this.
     });
     this.peerResolver = peerResolver;
     this.router = new ProtocolRouter(this.node, { peerResolver });

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1023,6 +1023,9 @@ export class DKGAgent {
       relayServerCapacity: config.relayServerCapacity,
       relayReservationCount: config.relayReservationCount,
       nodeVersion: config.nodeVersion,
+      peerStoreMaxAddressAgeMs: config.peerStoreMaxAddressAgeMs,
+      peerStoreMaxPeerAgeMs: config.peerStoreMaxPeerAgeMs,
+      dhtQuerySelfIntervalMs: config.dhtQuerySelfIntervalMs,
     };
 
     const node = new DKGNode(nodeConfig);
@@ -1236,6 +1239,7 @@ export class DKGAgent {
       // Bootstrap is a libp2p-startup concern (`bootstrap({ list })` in
       // peerDiscovery, see node.ts) — not a per-peer resolution concern.
       // Removed here per Codex review feedback on PR #496.
+      defaultPerStepTimeoutMs: this.config.peerResolveTimeoutMs,
     });
     this.peerResolver = peerResolver;
     this.router = new ProtocolRouter(this.node, { peerResolver });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -505,10 +505,12 @@ export interface DkgConfig {
   routePlugins?: string[];
   /**
    * libp2p networking tunables for small / sparse networks. Forwarded
-   * to `DKGNodeConfig` and applied at `createLibp2p` / `kadDHT` /
-   * `PeerResolver` construction. All optional; omitting any field
-   * preserves the upstream default. See packages/core/src/types.ts
-   * for per-field rationale + default values.
+   * through `DKGAgentConfig`; peer-store / DHT values are applied at
+   * `createLibp2p` / `kadDHT` construction and `peerResolveTimeoutMs`
+   * is applied at `PeerResolver` construction. All optional; omitting
+   * any field preserves the upstream default. See packages/core/src/types.ts
+   * and packages/core/src/network/peer-resolver.ts for per-field
+   * rationale + default values.
    *
    * Targeted at testnet / small-mesh operators where DHT lookups are
    * flaky (sparse routing tables) and direct addresses age out before

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -503,6 +503,28 @@ export interface DkgConfig {
   chat?: ChatConfig;
   /** Route-plugin specs (absolute paths / package names) loaded at daemon startup. ADR 0001. */
   routePlugins?: string[];
+  /**
+   * libp2p networking tunables for small / sparse networks. Forwarded
+   * to `DKGNodeConfig` and applied at `createLibp2p` / `kadDHT` /
+   * `PeerResolver` construction. All optional; omitting any field
+   * preserves the upstream default. See packages/core/src/types.ts
+   * for per-field rationale + default values.
+   *
+   * Targeted at testnet / small-mesh operators where DHT lookups are
+   * flaky (sparse routing tables) and direct addresses age out before
+   * being re-discovered. Mainnet / large-mesh deployments should leave
+   * all fields unset to keep upstream defaults.
+   */
+  network?: {
+    /** libp2p `peerStore.maxAddressAge` (default 3_600_000 = 1h upstream). */
+    peerStoreMaxAddressAgeMs?: number;
+    /** libp2p `peerStore.maxPeerAge` (default 21_600_000 = 6h upstream). */
+    peerStoreMaxPeerAgeMs?: number;
+    /** libp2p `kadDHT.querySelfInterval` (default kad-DHT upstream). */
+    dhtQuerySelfIntervalMs?: number;
+    /** `PeerResolver` per-step timeout (default 5_000ms). */
+    peerResolveTimeoutMs?: number;
+  };
 }
 
 /**

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -505,17 +505,23 @@ export interface DkgConfig {
   routePlugins?: string[];
   /**
    * libp2p networking tunables for small / sparse networks. Forwarded
-   * through `DKGAgentConfig`; peer-store / DHT values are applied at
-   * `createLibp2p` / `kadDHT` construction and `peerResolveTimeoutMs`
-   * is applied at `PeerResolver` construction. All optional; omitting
-   * any field preserves the upstream default. See packages/core/src/types.ts
-   * and packages/core/src/network/peer-resolver.ts for per-field
+   * through `DKGAgentConfig` and applied at `createLibp2p` / `kadDHT`
+   * construction. All optional; omitting any field preserves the
+   * upstream default. See packages/core/src/types.ts for per-field
    * rationale + default values.
    *
    * Targeted at testnet / small-mesh operators where DHT lookups are
    * flaky (sparse routing tables) and direct addresses age out before
    * being re-discovered. Mainnet / large-mesh deployments should leave
    * all fields unset to keep upstream defaults.
+   *
+   * Note: a per-step PeerResolver timeout knob was intentionally NOT
+   * exposed here. Production callers (`connectToPeerId`, chat /
+   * routed sends) always pass an explicit `perStepTimeoutMs` derived
+   * from their own deadline budget, so an operator default would be a
+   * silent no-op for those paths. To influence dial latency on small
+   * networks, bump the caller-side `timeoutMs` (e.g. `connectToPeerId`'s
+   * `timeoutMs` option) instead. Codex review of PR #698 caught this.
    */
   network?: {
     /** libp2p `peerStore.maxAddressAge` (default 3_600_000 = 1h upstream). */
@@ -524,8 +530,6 @@ export interface DkgConfig {
     peerStoreMaxPeerAgeMs?: number;
     /** libp2p `kadDHT.querySelfInterval` (default kad-DHT upstream). */
     dhtQuerySelfIntervalMs?: number;
-    /** `PeerResolver` per-step timeout (default 5_000ms). */
-    peerResolveTimeoutMs?: number;
   };
 }
 

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -55,7 +55,7 @@ const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
@@ -990,9 +990,7 @@ export async function runDaemonInner(
     // having to guess from contract registrations. Travels the wire
     // as libp2p's `AgentVersion` PB field (their naming, not ours).
     nodeVersion: `dkg/${nodeVersion}`,
-    peerStoreMaxAddressAgeMs: config.network?.peerStoreMaxAddressAgeMs,
-    peerStoreMaxPeerAgeMs: config.network?.peerStoreMaxPeerAgeMs,
-    dhtQuerySelfIntervalMs: config.network?.dhtQuerySelfIntervalMs,
+    ...pickNetworkTunables(config.network ?? {}),
     syncContextGraphs: syncContextGraphs,
     storeConfig: config.store ? {
       backend: config.store.backend,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -990,6 +990,10 @@ export async function runDaemonInner(
     // having to guess from contract registrations. Travels the wire
     // as libp2p's `AgentVersion` PB field (their naming, not ours).
     nodeVersion: `dkg/${nodeVersion}`,
+    peerStoreMaxAddressAgeMs: config.network?.peerStoreMaxAddressAgeMs,
+    peerStoreMaxPeerAgeMs: config.network?.peerStoreMaxPeerAgeMs,
+    dhtQuerySelfIntervalMs: config.network?.dhtQuerySelfIntervalMs,
+    peerResolveTimeoutMs: config.network?.peerResolveTimeoutMs,
     syncContextGraphs: syncContextGraphs,
     storeConfig: config.store ? {
       backend: config.store.backend,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -993,7 +993,6 @@ export async function runDaemonInner(
     peerStoreMaxAddressAgeMs: config.network?.peerStoreMaxAddressAgeMs,
     peerStoreMaxPeerAgeMs: config.network?.peerStoreMaxPeerAgeMs,
     dhtQuerySelfIntervalMs: config.network?.dhtQuerySelfIntervalMs,
-    peerResolveTimeoutMs: config.network?.peerResolveTimeoutMs,
     syncContextGraphs: syncContextGraphs,
     storeConfig: config.store ? {
       backend: config.store.backend,

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -287,11 +287,11 @@ describe('localAgentIntegrations config round-trip', () => {
   });
 
   it('round-trips the network.* libp2p tunables through saveConfig/loadConfig', async () => {
-    // PR feat/chain-network-libp2p-tunables: the four small-network
-    // knobs are documented as `config.json` keys, so the CLI schema
-    // must persist + restore them. This guards against regressions
-    // where any field gets dropped from the DkgConfig type or
-    // stripped on serialization.
+    // PR feat/chain-network-libp2p-tunables: the small-network knobs
+    // are documented as `config.json` keys, so the CLI schema must
+    // persist + restore them. This guards against regressions where
+    // any field gets dropped from the DkgConfig type or stripped on
+    // serialization.
     await saveConfig({
       name: 'test-node',
       apiPort: 9200,
@@ -301,7 +301,6 @@ describe('localAgentIntegrations config round-trip', () => {
         peerStoreMaxAddressAgeMs: 24 * 3_600_000,
         peerStoreMaxPeerAgeMs: 7 * 24 * 3_600_000,
         dhtQuerySelfIntervalMs: 60_000,
-        peerResolveTimeoutMs: 15_000,
       },
     });
 
@@ -309,7 +308,6 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(loaded.network?.peerStoreMaxAddressAgeMs).toBe(24 * 3_600_000);
     expect(loaded.network?.peerStoreMaxPeerAgeMs).toBe(7 * 24 * 3_600_000);
     expect(loaded.network?.dhtQuerySelfIntervalMs).toBe(60_000);
-    expect(loaded.network?.peerResolveTimeoutMs).toBe(15_000);
   });
 
   it('omits the network block entirely when not set (upstream libp2p defaults apply)', async () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -285,6 +285,44 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(loaded.nodeRole).toBe('core');
     expect(loaded.relayServerCapacity).toBeUndefined();
   });
+
+  it('round-trips the network.* libp2p tunables through saveConfig/loadConfig', async () => {
+    // PR feat/chain-network-libp2p-tunables: the four small-network
+    // knobs are documented as `config.json` keys, so the CLI schema
+    // must persist + restore them. This guards against regressions
+    // where any field gets dropped from the DkgConfig type or
+    // stripped on serialization.
+    await saveConfig({
+      name: 'test-node',
+      apiPort: 9200,
+      listenPort: 0,
+      nodeRole: 'edge',
+      network: {
+        peerStoreMaxAddressAgeMs: 24 * 3_600_000,
+        peerStoreMaxPeerAgeMs: 7 * 24 * 3_600_000,
+        dhtQuerySelfIntervalMs: 60_000,
+        peerResolveTimeoutMs: 15_000,
+      },
+    });
+
+    const loaded = await loadConfig();
+    expect(loaded.network?.peerStoreMaxAddressAgeMs).toBe(24 * 3_600_000);
+    expect(loaded.network?.peerStoreMaxPeerAgeMs).toBe(7 * 24 * 3_600_000);
+    expect(loaded.network?.dhtQuerySelfIntervalMs).toBe(60_000);
+    expect(loaded.network?.peerResolveTimeoutMs).toBe(15_000);
+  });
+
+  it('omits the network block entirely when not set (upstream libp2p defaults apply)', async () => {
+    await saveConfig({
+      name: 'test-node',
+      apiPort: 9200,
+      listenPort: 0,
+      nodeRole: 'edge',
+    });
+
+    const loaded = await loadConfig();
+    expect(loaded.network).toBeUndefined();
+  });
 });
 
 describe('resolveAutoUpdateSource', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,14 @@ export {
   MAX_RELAY_RESERVATION_COUNT,
   validateRelayReservationCount,
   type RelayReservationCountValidation,
+  // Pure libp2p-tunable builders. Exported so the wiring test in
+  // `core/test/libp2p-tunables-wiring.test.ts` can assert that
+  // operator config flows into the libp2p init objects without
+  // having to spin up a real libp2p node. Codex review of PR #698
+  // round 2 requested this regression fence.
+  isFinitePositiveInteger,
+  buildPeerStoreOverrides,
+  buildKadDHTOptions,
 } from './node.js';
 export {
   type Network,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,15 +29,24 @@ export {
   MAX_RELAY_RESERVATION_COUNT,
   validateRelayReservationCount,
   type RelayReservationCountValidation,
-  // Pure libp2p-tunable builders. Exported so the wiring test in
-  // `core/test/libp2p-tunables-wiring.test.ts` can assert that
-  // operator config flows into the libp2p init objects without
-  // having to spin up a real libp2p node. Codex review of PR #698
-  // round 2 requested this regression fence.
-  isFinitePositiveInteger,
-  buildPeerStoreOverrides,
-  buildKadDHTOptions,
+  // Single-source-of-truth interface for the small / sparse-network
+  // tunables forwarded `DkgConfig.network` → `DKGAgentConfig` →
+  // `DKGNodeConfig`, plus the choke-point helper every forwarder
+  // calls. Exported because `cli/src/daemon/lifecycle.ts` and
+  // `agent/src/dkg-agent.ts` BOTH need to call it; centralising
+  // here keeps the field list and forwarding logic identical at
+  // every hop. Codex review of PR #698 round 3.
+  type NetworkTunables,
+  pickNetworkTunables,
 } from './node.js';
+// NOTE: `isFinitePositiveInteger`, `buildPeerStoreOverrides`, and
+// `buildKadDHTOptions` are intentionally NOT re-exported. They are
+// implementation details of `DKGNode.start()`; the wiring test in
+// `core/test/libp2p-tunables-wiring.test.ts` reaches them via
+// `../src/node.js` directly so the package root stays free of
+// internals that would otherwise commit us to a semver contract
+// for test-only surface. Codex review of PR #698 round 3 flagged
+// the prior leak.
 export {
   type Network,
   type NodeIdentity,

--- a/packages/core/src/network/peer-resolver.ts
+++ b/packages/core/src/network/peer-resolver.ts
@@ -75,6 +75,20 @@ export interface PeerResolverDeps {
   agentDirectory: AgentDirectoryLookup;
   /** Optional logger; defaults to silent except for serious errors. */
   logger?: PeerResolverLogger;
+  /**
+   * Optional default per-step timeout in ms. When set, this overrides
+   * the built-in `DEFAULT_PER_STEP_TIMEOUT_MS` (5s) for every call to
+   * `resolve()` that doesn't explicitly pass `opts.perStepTimeoutMs`.
+   * Per-call values still take precedence over this default.
+   *
+   * Operator-tunable via `network.peerResolveTimeoutMs` in
+   * `~/.dkg/config.json` — on small networks where DHT lookups
+   * legitimately need >5s, bumping this avoids unnecessary fallback
+   * to slower agents-CG resolution.
+   *
+   * Ignored when not a positive finite integer.
+   */
+  defaultPerStepTimeoutMs?: number;
 }
 
 export interface PeerResolverLogger {
@@ -108,12 +122,21 @@ export class PeerResolver {
   private readonly registry: NetworkStateRegistry;
   private readonly agentDirectory: AgentDirectoryLookup;
   private readonly logger: PeerResolverLogger;
+  private readonly defaultPerStepTimeoutMs: number;
 
   constructor(deps: PeerResolverDeps) {
     this.network = deps.network;
     this.registry = deps.registry;
     this.agentDirectory = deps.agentDirectory;
     this.logger = deps.logger ?? SILENT_LOGGER;
+    const override = deps.defaultPerStepTimeoutMs;
+    this.defaultPerStepTimeoutMs =
+      typeof override === 'number' &&
+      Number.isFinite(override) &&
+      Number.isInteger(override) &&
+      override > 0
+        ? override
+        : DEFAULT_PER_STEP_TIMEOUT_MS;
   }
 
   /**
@@ -219,7 +242,7 @@ export class PeerResolver {
     if (!opts?.skipDht && typeof this.network.findPeer === 'function') {
       if (aborted()) return accumulated;
       try {
-        const perStepMs = opts?.perStepTimeoutMs ?? DEFAULT_PER_STEP_TIMEOUT_MS;
+        const perStepMs = opts?.perStepTimeoutMs ?? this.defaultPerStepTimeoutMs;
         const dhtAddrs = await this.network.findPeer(peerId, {
           signal: stepSignal(perStepMs),
           timeoutMs: perStepMs,

--- a/packages/core/src/network/peer-resolver.ts
+++ b/packages/core/src/network/peer-resolver.ts
@@ -81,10 +81,12 @@ export interface PeerResolverDeps {
    * `resolve()` that doesn't explicitly pass `opts.perStepTimeoutMs`.
    * Per-call values still take precedence over this default.
    *
-   * Operator-tunable via `network.peerResolveTimeoutMs` in
-   * `~/.dkg/config.json` — on small networks where DHT lookups
-   * legitimately need >5s, bumping this avoids unnecessary fallback
-   * to slower agents-CG resolution.
+   * NOTE: this option is intentionally NOT wired to operator config.
+   * Production callers (`connectToPeerId`, chat / routed sends) always
+   * pass an explicit `perStepTimeoutMs` derived from their own
+   * deadline budget, so a constructor default would be a silent no-op
+   * for those paths. It survives as a test-fixture surface. Codex
+   * review of PR #698 round 2 caught the earlier operator wiring.
    *
    * Ignored when not a positive finite integer.
    */

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -126,6 +126,46 @@ export function isFinitePositiveInteger(input: unknown): input is number {
 }
 
 /**
+ * The three small / sparse-network tunables we forward end-to-end
+ * (`DkgConfig.network` → `DKGAgentConfig` → `DKGNodeConfig` →
+ * `createLibp2p` / `kadDHT`). Centralising the field list as a single
+ * named type means the forwarding hops cannot drift — `pickNetworkTunables`
+ * below is the one chokepoint they all travel through, and its return
+ * type is pinned to this interface so a missing / typo'd field in any
+ * forwarder fails at compile time. Codex review of PR #698 round 3.
+ */
+export interface NetworkTunables {
+  peerStoreMaxAddressAgeMs?: number;
+  peerStoreMaxPeerAgeMs?: number;
+  dhtQuerySelfIntervalMs?: number;
+}
+
+/**
+ * Forward exactly the three operator-tunable network fields. Used at
+ * every hop along `DkgConfig.network` → `DKGAgentConfig` →
+ * `DKGNodeConfig`, so the mapping (and any future addition to
+ * `NetworkTunables`) lives in exactly one place.
+ *
+ * The explicit field-by-field assignment is intentional: it guarantees
+ * (via the `NetworkTunables` return type) that a typo at any caller
+ * would fail to compile, and the value-preserving test in
+ * `libp2p-tunables-wiring.test.ts` catches copy-paste-cross bugs
+ * (e.g. wiring `peerStoreMaxAddressAgeMs ← source.peerStoreMaxPeerAgeMs`).
+ * Round-2 tests fence the lowest layer (`buildPeerStoreOverrides` /
+ * `buildKadDHTOptions`); this helper + its test fence the two
+ * forwarding hops above that. Codex review of PR #698 round 3.
+ */
+export function pickNetworkTunables(
+  source: Partial<NetworkTunables>,
+): NetworkTunables {
+  return {
+    peerStoreMaxAddressAgeMs: source.peerStoreMaxAddressAgeMs,
+    peerStoreMaxPeerAgeMs: source.peerStoreMaxPeerAgeMs,
+    dhtQuerySelfIntervalMs: source.dhtQuerySelfIntervalMs,
+  };
+}
+
+/**
  * Pure builder for the libp2p `peerStore` overrides we forward into
  * `createLibp2p`. Returns `undefined` when no operator field is valid
  * (the canonical signal for "omit the option block entirely so libp2p

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -107,11 +107,11 @@ export const MAX_RELAY_RESERVATION_COUNT = 16;
 /**
  * Permissive validator for the small / sparse-network tunables
  * (`peerStoreMaxAddressAgeMs`, `peerStoreMaxPeerAgeMs`,
- * `dhtQuerySelfIntervalMs`, `peerResolveTimeoutMs`). Returns the
+ * `dhtQuerySelfIntervalMs`). Returns the
  * value when it is a positive finite integer; returns `undefined`
  * otherwise so callers can fall through to the upstream default
  * silently. Unlike `validateRelayServerCapacity` these knobs are
- * passed straight to libp2p / resolver code that already validates
+ * passed straight to libp2p / kad-DHT code that already validates
  * its own input — we just defend against the obviously-wrong values
  * (0, negative, NaN, fractional, non-numeric) without taking on a
  * warning surface.

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -954,7 +954,13 @@ export class DKGNode {
     const peerStoreMaxPeerAge = isFinitePositiveInteger(this.config.peerStoreMaxPeerAgeMs)
       ? this.config.peerStoreMaxPeerAgeMs
       : undefined;
-    const peerStoreOverrides: Record<string, number> = {};
+    // Explicit field shape (NOT `Record<string, number>`) so a typo in
+    // a new key fails to compile instead of silently disabling the
+    // tunable. Mirrors `PersistentPeerStoreInit` from
+    // `@libp2p/peer-store`; if upstream adds a third knob we want to
+    // expose, this object is the single place to extend.
+    // Codex review of PR #698 caught the prior loose typing.
+    const peerStoreOverrides: { maxAddressAge?: number; maxPeerAge?: number } = {};
     if (peerStoreMaxAddressAge !== undefined) peerStoreOverrides.maxAddressAge = peerStoreMaxAddressAge;
     if (peerStoreMaxPeerAge !== undefined) peerStoreOverrides.maxPeerAge = peerStoreMaxPeerAge;
 

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -105,6 +105,27 @@ export const DEFAULT_RELAY_RESERVATION_COUNT = 3;
 export const MAX_RELAY_RESERVATION_COUNT = 16;
 
 /**
+ * Permissive validator for the small / sparse-network tunables
+ * (`peerStoreMaxAddressAgeMs`, `peerStoreMaxPeerAgeMs`,
+ * `dhtQuerySelfIntervalMs`, `peerResolveTimeoutMs`). Returns the
+ * value when it is a positive finite integer; returns `undefined`
+ * otherwise so callers can fall through to the upstream default
+ * silently. Unlike `validateRelayServerCapacity` these knobs are
+ * passed straight to libp2p / resolver code that already validates
+ * its own input — we just defend against the obviously-wrong values
+ * (0, negative, NaN, fractional, non-numeric) without taking on a
+ * warning surface.
+ */
+export function isFinitePositiveInteger(input: unknown): input is number {
+  return (
+    typeof input === 'number' &&
+    Number.isFinite(input) &&
+    Number.isInteger(input) &&
+    input > 0
+  );
+}
+
+/**
  * Validate an operator-supplied `relayReservationCount`. Same shape +
  * defensive surface as `validateRelayServerCapacity` (rejects 0,
  * negatives, NaN, Infinity, fractional, non-numbers). Additionally
@@ -779,10 +800,19 @@ export class DKGNode {
     const useAutoNAT = this.config.enableAutoNAT ??
       !(usableRelayCandidates.length > 0 || enableRelay);
 
+    const dhtQuerySelfInterval = isFinitePositiveInteger(this.config.dhtQuerySelfIntervalMs)
+      ? this.config.dhtQuerySelfIntervalMs
+      : undefined;
+
     const services: Record<string, any> = {
       identify: identify(),
       ping: ping(),
-      dht: kadDHT({ protocol: DHT_PROTOCOL }),
+      dht: kadDHT({
+        protocol: DHT_PROTOCOL,
+        ...(dhtQuerySelfInterval !== undefined
+          ? { querySelfInterval: dhtQuerySelfInterval }
+          : {}),
+      }),
       pubsub: gossipsub({
         emitSelf: false,
         allowPublishToZeroTopicPeers: true,
@@ -918,8 +948,21 @@ export class DKGNode {
       this.relayReservationCountTarget = 1;
     }
 
+    const peerStoreMaxAddressAge = isFinitePositiveInteger(this.config.peerStoreMaxAddressAgeMs)
+      ? this.config.peerStoreMaxAddressAgeMs
+      : undefined;
+    const peerStoreMaxPeerAge = isFinitePositiveInteger(this.config.peerStoreMaxPeerAgeMs)
+      ? this.config.peerStoreMaxPeerAgeMs
+      : undefined;
+    const peerStoreOverrides: Record<string, number> = {};
+    if (peerStoreMaxAddressAge !== undefined) peerStoreOverrides.maxAddressAge = peerStoreMaxAddressAge;
+    if (peerStoreMaxPeerAge !== undefined) peerStoreOverrides.maxPeerAge = peerStoreMaxPeerAge;
+
     this.node = await createLibp2p<DKGServices>({
       privateKey,
+      ...(Object.keys(peerStoreOverrides).length > 0
+        ? { peerStore: peerStoreOverrides }
+        : {}),
       // `nodeInfo.userAgent` is libp2p's only knob for the identify
       // protocol's `agentVersion` PB field — every remote peer reads
       // it back as `Peer.metadata.AgentVersion`. Without it, libp2p

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -126,6 +126,58 @@ export function isFinitePositiveInteger(input: unknown): input is number {
 }
 
 /**
+ * Pure builder for the libp2p `peerStore` overrides we forward into
+ * `createLibp2p`. Returns `undefined` when no operator field is valid
+ * (the canonical signal for "omit the option block entirely so libp2p
+ * keeps every upstream default"), otherwise returns an object whose
+ * shape mirrors `@libp2p/peer-store`'s `PersistentPeerStoreInit`.
+ *
+ * Extracted from `DKGNode.start()` so a regression test can assert the
+ * wiring without having to spin up a real libp2p node — Codex review
+ * of PR #698 round 2 flagged that the previous test suite only
+ * verified JSON persistence, so a typo in `maxAddressAge` /
+ * `maxPeerAge` would ship as a silent no-op while the existing tests
+ * still passed.
+ */
+export function buildPeerStoreOverrides(
+  config: Pick<DKGNodeConfig, 'peerStoreMaxAddressAgeMs' | 'peerStoreMaxPeerAgeMs'>,
+): { maxAddressAge?: number; maxPeerAge?: number } | undefined {
+  const maxAddressAge = isFinitePositiveInteger(config.peerStoreMaxAddressAgeMs)
+    ? config.peerStoreMaxAddressAgeMs
+    : undefined;
+  const maxPeerAge = isFinitePositiveInteger(config.peerStoreMaxPeerAgeMs)
+    ? config.peerStoreMaxPeerAgeMs
+    : undefined;
+  if (maxAddressAge === undefined && maxPeerAge === undefined) return undefined;
+  const out: { maxAddressAge?: number; maxPeerAge?: number } = {};
+  if (maxAddressAge !== undefined) out.maxAddressAge = maxAddressAge;
+  if (maxPeerAge !== undefined) out.maxPeerAge = maxPeerAge;
+  return out;
+}
+
+/**
+ * Pure builder for the `kadDHT()` init object. Always includes the
+ * `protocol` (the daemon never wants the upstream default protocol
+ * string); adds `querySelfInterval` only when operator config supplies
+ * a positive finite integer.
+ *
+ * Extracted so the wiring is unit-testable without spinning up a real
+ * libp2p — Codex review of PR #698 round 2 flagged the same silent-
+ * no-op risk as `buildPeerStoreOverrides` above.
+ */
+export function buildKadDHTOptions(
+  config: Pick<DKGNodeConfig, 'dhtQuerySelfIntervalMs'>,
+  protocol: string,
+): { protocol: string; querySelfInterval?: number } {
+  const querySelfInterval = isFinitePositiveInteger(config.dhtQuerySelfIntervalMs)
+    ? config.dhtQuerySelfIntervalMs
+    : undefined;
+  return querySelfInterval !== undefined
+    ? { protocol, querySelfInterval }
+    : { protocol };
+}
+
+/**
  * Validate an operator-supplied `relayReservationCount`. Same shape +
  * defensive surface as `validateRelayServerCapacity` (rejects 0,
  * negatives, NaN, Infinity, fractional, non-numbers). Additionally
@@ -800,19 +852,10 @@ export class DKGNode {
     const useAutoNAT = this.config.enableAutoNAT ??
       !(usableRelayCandidates.length > 0 || enableRelay);
 
-    const dhtQuerySelfInterval = isFinitePositiveInteger(this.config.dhtQuerySelfIntervalMs)
-      ? this.config.dhtQuerySelfIntervalMs
-      : undefined;
-
     const services: Record<string, any> = {
       identify: identify(),
       ping: ping(),
-      dht: kadDHT({
-        protocol: DHT_PROTOCOL,
-        ...(dhtQuerySelfInterval !== undefined
-          ? { querySelfInterval: dhtQuerySelfInterval }
-          : {}),
-      }),
+      dht: kadDHT(buildKadDHTOptions(this.config, DHT_PROTOCOL)),
       pubsub: gossipsub({
         emitSelf: false,
         allowPublishToZeroTopicPeers: true,
@@ -948,25 +991,20 @@ export class DKGNode {
       this.relayReservationCountTarget = 1;
     }
 
-    const peerStoreMaxAddressAge = isFinitePositiveInteger(this.config.peerStoreMaxAddressAgeMs)
-      ? this.config.peerStoreMaxAddressAgeMs
-      : undefined;
-    const peerStoreMaxPeerAge = isFinitePositiveInteger(this.config.peerStoreMaxPeerAgeMs)
-      ? this.config.peerStoreMaxPeerAgeMs
-      : undefined;
     // Explicit field shape (NOT `Record<string, number>`) so a typo in
     // a new key fails to compile instead of silently disabling the
     // tunable. Mirrors `PersistentPeerStoreInit` from
     // `@libp2p/peer-store`; if upstream adds a third knob we want to
-    // expose, this object is the single place to extend.
-    // Codex review of PR #698 caught the prior loose typing.
-    const peerStoreOverrides: { maxAddressAge?: number; maxPeerAge?: number } = {};
-    if (peerStoreMaxAddressAge !== undefined) peerStoreOverrides.maxAddressAge = peerStoreMaxAddressAge;
-    if (peerStoreMaxPeerAge !== undefined) peerStoreOverrides.maxPeerAge = peerStoreMaxPeerAge;
+    // expose, the `buildPeerStoreOverrides` return type is the single
+    // place to extend. Codex review of PR #698 caught the prior loose
+    // typing; round 2 then asked for a wiring test, which lives in
+    // `core/test/libp2p-tunables-wiring.test.ts` against the same
+    // helper.
+    const peerStoreOverrides = buildPeerStoreOverrides(this.config);
 
     this.node = await createLibp2p<DKGServices>({
       privateKey,
-      ...(Object.keys(peerStoreOverrides).length > 0
+      ...(peerStoreOverrides !== undefined
         ? { peerStore: peerStoreOverrides }
         : {}),
       // `nodeInfo.userAgent` is libp2p's only knob for the identify

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -129,6 +129,65 @@ export interface DKGNodeConfig {
    * `peerStore.nodeVersion`.
    */
   nodeVersion?: string;
+  /**
+   * libp2p peerStore: max age in ms before a stored multiaddr is
+   * considered expired and must be re-fetched via peer routing. Forwarded
+   * as `peerStore.maxAddressAge` into `createLibp2p`.
+   *
+   * Default: undefined → libp2p default (3_600_000 = 1h). On small
+   * networks where DHT lookups are flaky, operators may want to bump
+   * this (e.g. 24h) so direct addresses survive longer and the dial
+   * path doesn't fall back to circuit/DHT walks unnecessarily. Paired
+   * with `peerStoreMaxPeerAgeMs` — bumping only one is partial.
+   *
+   * Invalid values (0, negative, NaN, fractional, non-numeric) fall
+   * back to the upstream default with no warning (silently ignored).
+   */
+  peerStoreMaxAddressAgeMs?: number;
+  /**
+   * libp2p peerStore: max age in ms before a peer entry with no
+   * multiaddrs is evicted entirely. Forwarded as `peerStore.maxPeerAge`
+   * into `createLibp2p`.
+   *
+   * Default: undefined → libp2p default (21_600_000 = 6h). Paired
+   * with `peerStoreMaxAddressAgeMs` — without bumping this, peer
+   * entries themselves get evicted at 6h even if addresses live
+   * longer.
+   *
+   * Invalid values (0, negative, NaN, fractional, non-numeric) fall
+   * back to the upstream default with no warning.
+   */
+  peerStoreMaxPeerAgeMs?: number;
+  /**
+   * libp2p kad-DHT: how often the node queries its own PeerId to keep
+   * its KAD-routing-table view warm. Forwarded as
+   * `kadDHT.querySelfInterval` into the DHT service.
+   *
+   * Default: undefined → libp2p kad-DHT default. On small networks
+   * this also functions as the practical republish cadence: a faster
+   * interval keeps the local k-buckets fresh so other nodes' DHT
+   * lookups for us succeed even when we haven't been directly dialled
+   * in a while.
+   *
+   * Invalid values (0, negative, NaN, fractional, non-numeric) fall
+   * back to the upstream default with no warning.
+   */
+  dhtQuerySelfIntervalMs?: number;
+  /**
+   * Default per-step timeout in ms for the in-process PeerResolver
+   * (used by `ProtocolRouter` on every outbound dial attempt).
+   * Overrides the built-in 5_000ms default; per-call
+   * `ResolveOpts.perStepTimeoutMs` still wins over this value.
+   *
+   * On small networks DHT lookups often need >5s to converge — bumping
+   * to e.g. 15_000 trades dial latency for a meaningfully better hit
+   * rate on the resolver's DHT step, which in turn reduces fallback
+   * pressure on the agents-CG step and outbox retries.
+   *
+   * Invalid values (0, negative, NaN, fractional, non-numeric) fall
+   * back to the built-in default with no warning.
+   */
+  peerResolveTimeoutMs?: number;
 }
 
 export type ConnectionTransport = 'direct' | 'relayed';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -173,21 +173,12 @@ export interface DKGNodeConfig {
    * back to the upstream default with no warning.
    */
   dhtQuerySelfIntervalMs?: number;
-  /**
-   * Default per-step timeout in ms for the in-process PeerResolver
-   * (used by `ProtocolRouter` on every outbound dial attempt).
-   * Overrides the built-in 5_000ms default; per-call
-   * `ResolveOpts.perStepTimeoutMs` still wins over this value.
-   *
-   * On small networks DHT lookups often need >5s to converge — bumping
-   * to e.g. 15_000 trades dial latency for a meaningfully better hit
-   * rate on the resolver's DHT step, which in turn reduces fallback
-   * pressure on the agents-CG step and outbox retries.
-   *
-   * Invalid values (0, negative, NaN, fractional, non-numeric) fall
-   * back to the built-in default with no warning.
-   */
-  peerResolveTimeoutMs?: number;
+  // NOTE: `peerResolveTimeoutMs` intentionally lives on
+  // `DKGAgentConfig` (packages/agent), not here. The PeerResolver is
+  // owned by `DKGAgent` (constructed at agent start, not by `DKGNode`),
+  // so a field on `DKGNodeConfig` would be a silent no-op for direct
+  // `new DKGNode({...})` consumers. Codex review of PR #698 caught
+  // this leak.
 }
 
 export type ConnectionTransport = 'direct' | 'relayed';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -173,12 +173,14 @@ export interface DKGNodeConfig {
    * back to the upstream default with no warning.
    */
   dhtQuerySelfIntervalMs?: number;
-  // NOTE: `peerResolveTimeoutMs` intentionally lives on
-  // `DKGAgentConfig` (packages/agent), not here. The PeerResolver is
-  // owned by `DKGAgent` (constructed at agent start, not by `DKGNode`),
-  // so a field on `DKGNodeConfig` would be a silent no-op for direct
-  // `new DKGNode({...})` consumers. Codex review of PR #698 caught
-  // this leak.
+  // NOTE: `peerResolveTimeoutMs` was considered but intentionally NOT
+  // exposed. Production callers (`connectToPeerId`, chat / routed
+  // sends) always pass an explicit `perStepTimeoutMs` derived from
+  // their own deadline budget, so a constructor default on the
+  // `PeerResolver` would be a silent no-op for those paths. To
+  // influence dial latency on small / sparse networks, bump the
+  // caller-side timeout instead. Codex review of PR #698 rounds 1+2
+  // caught this leak.
 }
 
 export type ConnectionTransport = 'direct' | 'relayed';

--- a/packages/core/test/libp2p-tunables-wiring.test.ts
+++ b/packages/core/test/libp2p-tunables-wiring.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildPeerStoreOverrides,
+  buildKadDHTOptions,
+} from '../src/node.js';
+
+// PR feat/chain-network-libp2p-tunables, round 2 (Codex review of PR
+// #698): the round-1 `cli/test/config.test.ts` cases only proved that
+// `network.peerStoreMaxAddressAgeMs` / `network.peerStoreMaxPeerAgeMs`
+// / `network.dhtQuerySelfIntervalMs` survive a config save/load
+// round-trip. They did NOT prove the values actually reach
+// `createLibp2p({ peerStore: {...} })` and `kadDHT({...})` under the
+// libp2p-expected key names. A typo like `maxAddrAge` would have
+// shipped as a silent no-op while the round-1 suite still passed.
+//
+// These tests pin the wiring at the pure-helper boundary that
+// `DKGNode.start()` consumes, so a regression in the option key
+// names or a regression that drops a valid value would fail here
+// before reaching a libp2p version pin.
+
+describe('buildPeerStoreOverrides', () => {
+  it('returns undefined when neither field is supplied', () => {
+    expect(buildPeerStoreOverrides({})).toBeUndefined();
+  });
+
+  it('returns undefined when both fields are invalid (defensive)', () => {
+    // Permissive validator: invalid values silently fall back to the
+    // libp2p default — we MUST return `undefined` so `createLibp2p` is
+    // invoked WITHOUT a `peerStore` block (anything else would override
+    // a default the operator never asked us to touch).
+    for (const bad of [NaN, 0, -1, 1.5, Infinity, -Infinity]) {
+      expect(
+        buildPeerStoreOverrides({
+          peerStoreMaxAddressAgeMs: bad,
+          peerStoreMaxPeerAgeMs: bad,
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it('emits the exact libp2p key `maxAddressAge` when only that is set', () => {
+    // Key-name pin: this is the regression fence Codex asked for.
+    const out = buildPeerStoreOverrides({
+      peerStoreMaxAddressAgeMs: 24 * 3_600_000,
+    });
+    expect(out).toEqual({ maxAddressAge: 24 * 3_600_000 });
+    // Belt-and-suspenders: the other slot MUST NOT be present (we want
+    // libp2p to keep its default for unspecified fields, not receive
+    // `undefined` and choke on the type check).
+    expect(out).not.toHaveProperty('maxPeerAge');
+  });
+
+  it('emits the exact libp2p key `maxPeerAge` when only that is set', () => {
+    const out = buildPeerStoreOverrides({
+      peerStoreMaxPeerAgeMs: 7 * 24 * 3_600_000,
+    });
+    expect(out).toEqual({ maxPeerAge: 7 * 24 * 3_600_000 });
+    expect(out).not.toHaveProperty('maxAddressAge');
+  });
+
+  it('emits both keys when both are set', () => {
+    const out = buildPeerStoreOverrides({
+      peerStoreMaxAddressAgeMs: 60_000,
+      peerStoreMaxPeerAgeMs: 120_000,
+    });
+    expect(out).toEqual({ maxAddressAge: 60_000, maxPeerAge: 120_000 });
+  });
+
+  it('drops invalid `peerStoreMaxAddressAgeMs` but keeps valid `peerStoreMaxPeerAgeMs`', () => {
+    const out = buildPeerStoreOverrides({
+      peerStoreMaxAddressAgeMs: 0,
+      peerStoreMaxPeerAgeMs: 120_000,
+    });
+    expect(out).toEqual({ maxPeerAge: 120_000 });
+    expect(out).not.toHaveProperty('maxAddressAge');
+  });
+});
+
+describe('buildKadDHTOptions', () => {
+  it('always returns the protocol (no silent fallthrough to upstream default)', () => {
+    const out = buildKadDHTOptions({}, '/dkg/test/kad/1.0.0');
+    expect(out).toEqual({ protocol: '/dkg/test/kad/1.0.0' });
+    expect(out).not.toHaveProperty('querySelfInterval');
+  });
+
+  it('emits the exact libp2p key `querySelfInterval` when supplied', () => {
+    // Key-name pin: a typo like `querySelfInteval` in the helper would
+    // fail the test below AND fail the TypeScript return-type check.
+    const out = buildKadDHTOptions(
+      { dhtQuerySelfIntervalMs: 60_000 },
+      '/dkg/test/kad/1.0.0',
+    );
+    expect(out).toEqual({
+      protocol: '/dkg/test/kad/1.0.0',
+      querySelfInterval: 60_000,
+    });
+  });
+
+  it('drops invalid `dhtQuerySelfIntervalMs` values (defensive)', () => {
+    for (const bad of [NaN, 0, -1, 1.5, Infinity, -Infinity]) {
+      const out = buildKadDHTOptions(
+        { dhtQuerySelfIntervalMs: bad },
+        '/dkg/test/kad/1.0.0',
+      );
+      expect(out, `bad value: ${bad}`).toEqual({
+        protocol: '/dkg/test/kad/1.0.0',
+      });
+      expect(out, `bad value: ${bad}`).not.toHaveProperty('querySelfInterval');
+    }
+  });
+});

--- a/packages/core/test/libp2p-tunables-wiring.test.ts
+++ b/packages/core/test/libp2p-tunables-wiring.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildPeerStoreOverrides,
   buildKadDHTOptions,
+  pickNetworkTunables,
 } from '../src/node.js';
 
 // PR feat/chain-network-libp2p-tunables, round 2 (Codex review of PR
@@ -73,6 +74,67 @@ describe('buildPeerStoreOverrides', () => {
     });
     expect(out).toEqual({ maxPeerAge: 120_000 });
     expect(out).not.toHaveProperty('maxAddressAge');
+  });
+});
+
+describe('pickNetworkTunables (forwarding-hop fence)', () => {
+  // PR feat/chain-network-libp2p-tunables, round 3 (Codex review of
+  // PR #698): round-2's test pinned the lowest layer
+  // (`buildPeerStoreOverrides` / `buildKadDHTOptions`) against the
+  // libp2p init keys. The two forwarding hops above that —
+  // `DkgConfig.network` → `DKGAgentConfig` (in
+  // `cli/src/daemon/lifecycle.ts`) and `DKGAgentConfig` →
+  // `DKGNodeConfig` (in `agent/src/dkg-agent.ts`) — were still
+  // unfenced. Both now route through `pickNetworkTunables`, so the
+  // tests below are the single regression fence for the whole chain.
+  // A typo at any caller is a compile-time failure (the helper's
+  // return type is `NetworkTunables`); a copy-paste-cross bug at
+  // the helper itself is what these tests catch.
+
+  it('returns an empty-valued shape when source is empty', () => {
+    // We MUST return all three keys (even when undefined) so that
+    // spread-merging at the call site keeps the property names
+    // explicit in the resulting config object — easier to grep for
+    // when debugging.
+    expect(pickNetworkTunables({})).toEqual({
+      peerStoreMaxAddressAgeMs: undefined,
+      peerStoreMaxPeerAgeMs: undefined,
+      dhtQuerySelfIntervalMs: undefined,
+    });
+  });
+
+  it('forwards each field to the SAME-named slot (no copy-paste-cross)', () => {
+    // Distinct integers — a swap like
+    // `peerStoreMaxAddressAgeMs ← source.peerStoreMaxPeerAgeMs`
+    // would surface here as a value mismatch.
+    const out = pickNetworkTunables({
+      peerStoreMaxAddressAgeMs: 111,
+      peerStoreMaxPeerAgeMs: 222,
+      dhtQuerySelfIntervalMs: 333,
+    });
+    expect(out).toEqual({
+      peerStoreMaxAddressAgeMs: 111,
+      peerStoreMaxPeerAgeMs: 222,
+      dhtQuerySelfIntervalMs: 333,
+    });
+  });
+
+  it('ignores extra fields on the source (defensive against partial supersets)', () => {
+    // The forwarding hops pass `DkgConfig.network` (cli) and
+    // `DKGAgentConfig` (agent) — both have many other fields. The
+    // helper must not leak any of them into the result, otherwise
+    // a spread would pollute the downstream config object.
+    const out = pickNetworkTunables({
+      peerStoreMaxAddressAgeMs: 111,
+      // @ts-expect-error testing runtime defensive behaviour
+      unrelated: 'ignored',
+    });
+    expect(out).toEqual({
+      peerStoreMaxAddressAgeMs: 111,
+      peerStoreMaxPeerAgeMs: undefined,
+      dhtQuerySelfIntervalMs: undefined,
+    });
+    expect(out).not.toHaveProperty('unrelated');
   });
 });
 

--- a/packages/core/test/peer-resolver.test.ts
+++ b/packages/core/test/peer-resolver.test.ts
@@ -405,11 +405,14 @@ describe('PeerResolver', () => {
   });
 
   it('defaultPerStepTimeoutMs constructor override applies when opts.perStepTimeoutMs is omitted', async () => {
-    // PR feat/chain-network-libp2p-tunables: operators on small
-    // networks can bump the resolver's per-step timeout via
-    // config.network.peerResolveTimeoutMs. Verify the constructor
-    // override is honoured when callers don't pass a per-call value,
-    // and that per-call values still win when they do.
+    // PR feat/chain-network-libp2p-tunables: the constructor option
+    // exists for test fixtures and embedders that wire their own
+    // resolver — production callers (`connectToPeerId`, chat / routed
+    // sends) always pass an explicit `perStepTimeoutMs`. Verify the
+    // constructor override is honoured when callers don't pass a
+    // per-call value, and that per-call values still win when they
+    // do. Codex review of PR #698 round 2 removed the operator-facing
+    // wiring; this test still covers the embedder surface.
     const seenTimeouts: number[] = [];
     net.__findPeerImpl = async (_pid, opts) => {
       if (opts?.timeoutMs != null) seenTimeouts.push(opts.timeoutMs);

--- a/packages/core/test/peer-resolver.test.ts
+++ b/packages/core/test/peer-resolver.test.ts
@@ -404,6 +404,54 @@ describe('PeerResolver', () => {
     expect(receivedSignal).toBe(ctrl.signal);
   });
 
+  it('defaultPerStepTimeoutMs constructor override applies when opts.perStepTimeoutMs is omitted', async () => {
+    // PR feat/chain-network-libp2p-tunables: operators on small
+    // networks can bump the resolver's per-step timeout via
+    // config.network.peerResolveTimeoutMs. Verify the constructor
+    // override is honoured when callers don't pass a per-call value,
+    // and that per-call values still win when they do.
+    const seenTimeouts: number[] = [];
+    net.__findPeerImpl = async (_pid, opts) => {
+      if (opts?.timeoutMs != null) seenTimeouts.push(opts.timeoutMs);
+      return [];
+    };
+    const resolver = new PeerResolver({
+      network: net,
+      registry,
+      agentDirectory: makeAgentDir(),
+      defaultPerStepTimeoutMs: 9999,
+    });
+
+    await resolver.resolve(PEER_B);
+    expect(seenTimeouts).toEqual([9999]);
+
+    seenTimeouts.length = 0;
+    await resolver.resolve(PEER_B, { perStepTimeoutMs: 1234 });
+    expect(seenTimeouts).toEqual([1234]);
+  });
+
+  it('defaultPerStepTimeoutMs ignores invalid values (NaN / 0 / fractional / negative)', async () => {
+    // Permissive validator: invalid values silently fall back to the
+    // built-in 5s default so a typo in config.json doesn't brick the
+    // resolver at startup.
+    const seenTimeouts: number[] = [];
+    net.__findPeerImpl = async (_pid, opts) => {
+      if (opts?.timeoutMs != null) seenTimeouts.push(opts.timeoutMs);
+      return [];
+    };
+    for (const bad of [NaN, 0, -1, 1.5, Infinity, -Infinity]) {
+      seenTimeouts.length = 0;
+      const resolver = new PeerResolver({
+        network: net,
+        registry,
+        agentDirectory: makeAgentDir(),
+        defaultPerStepTimeoutMs: bad,
+      });
+      await resolver.resolve(PEER_B);
+      expect(seenTimeouts, `bad value: ${bad}`).toEqual([5_000]);
+    }
+  });
+
   it('returns empty array when nothing resolves', async () => {
     net.__findPeerImpl = async () => [];
     const resolver = new PeerResolver({


### PR DESCRIPTION
## Summary

Surface four upstream libp2p defaults as operator-tunable config under a new `network` block in `~/.dkg/config.json`. Targeted at testnet / small-mesh deployments where the upstream defaults (peerStore: 1h address age / 6h peer age; PeerResolver: 5s per-step timeout) cause direct addresses to age out before being re-discovered via the (sparse) DHT — visible as the "can't dial Muy-Sentinel anymore" / "need to manually /api/connect after every restart" patterns on the testnet.

| Field (under `network`) | Wire mapping | Upstream default |
|---|---|---|
| `peerStoreMaxAddressAgeMs` | `createLibp2p({ peerStore: { maxAddressAge } })` | 1h |
| `peerStoreMaxPeerAgeMs` | `createLibp2p({ peerStore: { maxPeerAge } })` | 6h |
| `dhtQuerySelfIntervalMs` | `kadDHT({ querySelfInterval })` | kad-DHT default |
| `peerResolveTimeoutMs` | `new PeerResolver({ defaultPerStepTimeoutMs })` | 5s |

All four are optional. Omitting a field preserves the upstream default — zero behaviour change for any existing operator.

## Wiring

Follows the existing `relayServerCapacity` pattern:

1. Typed on [`DkgConfig`](packages/cli/src/config.ts) (cli) and [`DKGNodeConfig`](packages/core/src/types.ts) (core).
2. Forwarded through [`lifecycle.ts`](packages/cli/src/daemon/lifecycle.ts) -> `DKGAgent.create()` -> [`dkg-agent.ts`](packages/agent/src/dkg-agent.ts) mapping.
3. Applied in [`createLibp2p`](packages/core/src/node.ts) / `kadDHT` / [`PeerResolver`](packages/core/src/network/peer-resolver.ts) constructor.

A small permissive validator (`isFinitePositiveInteger` in [`node.ts`](packages/core/src/node.ts)) silently ignores invalid values (0, NaN, fractional, negative, non-numeric) so a config typo doesn't brick startup — these knobs are tuning, not safety gates, so the warn-and-fall-back surface from `validateRelayServerCapacity` would be noise.

## Tests

- [`peer-resolver.test.ts`](packages/core/test/peer-resolver.test.ts):
  - constructor override applies when `opts.perStepTimeoutMs` is omitted
  - per-call values still win over the constructor override
  - invalid values (NaN, 0, fractional, negative, Infinity) fall back to the 5s built-in default
- [`config.test.ts`](packages/cli/test/config.test.ts):
  - round-trip the four knobs through `saveConfig` / `loadConfig`
  - absent `network` block stays undefined so libp2p defaults apply

Full suites: `@dkg/core` 933 / 933 green, `@dkg/cli` config tests 33 / 33 green. `@dkg/agent` has one pre-existing `swm-snapshot-sync` failure unrelated to this PR (verified on `main`: `Unknown file extension ".ts" for sync-verify-worker-impl.ts`, worker-thread loader issue).

## Test plan

- [x] Build green: `pnpm -F @origintrail-official/dkg-core build`
- [x] Build green: `pnpm -F @origintrail-official/dkg-agent build`
- [x] Build green: `pnpm -F @origintrail-official/dkg build` (cli)
- [x] Unit tests green: `peer-resolver.test.ts` (21/21), `config.test.ts` (33/33), full `@dkg/core` suite (933/933)
- [ ] Manual: edit `~/.dkg/config.json` on Miles to add `{ network: { peerStoreMaxAddressAgeMs: 86400000, peerResolveTimeoutMs: 15000 } }`, restart, confirm no startup warnings, watch peerStore age behavior over a few hours.

## Companion work

PR B (`feat/chain-agents-cg-phonebook`) lands next: extends the agents Context Graph with `dkg:multiaddr` + `dkg:lastSeen`, adds a periodic profile heartbeat, and threads agents-CG addresses into the outbox stall-recovery path. PR A is the smaller half of a two-PR network-robustness pair planned during the post-rc.11 testnet diagnostics session.

Related issue: discussion thread in [#697](https://github.com/OriginTrail/dkg/issues/697) (Muy-Sentinel's publish-quorum failure).

Made with [Cursor](https://cursor.com)