### PR TITLE
fix(node-ui): resolve 22 UI bugs found in rc.11 manual QA

### DIFF
--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -1,6 +1,7 @@
 import { ethers, JsonRpcProvider, Wallet, Contract, Interface } from 'ethers';
 import {
   createFilterErrorSilencer,
+  installFilterNotFoundConsoleSuppressor,
   formatProviderError,
   type FilterErrorSilencer,
 } from './filter-error-silencer.js';
@@ -445,6 +446,16 @@ export class EVMChainAdapter implements ChainAdapter {
     this.filterErrorSilencer = createFilterErrorSilencer({
       log: (msg) => console.warn(`${msg} (${providerContext})`),
     });
+    // BUG-022: ethers v6 swallows `eth_getFilterChanges` "filter not
+    // found" errors with a literal `console.log("@TODO", error)` from
+    // subscriber-filterid.js — that path bypasses
+    // `provider.on('error', ...)` entirely, so the per-provider
+    // silencer above never gets a chance to suppress them. Install a
+    // process-wide `console.log` interceptor (idempotent) that catches
+    // exactly that two-arg shape and routes it through a dedicated
+    // silencer with the same dedup window. Real `console.log` calls
+    // are forwarded untouched.
+    installFilterNotFoundConsoleSuppressor();
     const providerErrorHandler = (err: unknown) => {
       if (this.filterErrorSilencer.handle(err)) return;
       // Non-filter provider errors fall through to the error

--- a/packages/chain/src/filter-error-silencer.ts
+++ b/packages/chain/src/filter-error-silencer.ts
@@ -242,6 +242,7 @@ export function createFilterErrorSilencer(opts: FilterErrorSilencerOpts = {}): F
  */
 let consoleSuppressorInstalled = false;
 let consoleSuppressorSilencer: FilterErrorSilencer | null = null;
+let consoleSuppressorOriginalLog: typeof console.log | null = null;
 
 export function installFilterNotFoundConsoleSuppressor(opts: FilterErrorSilencerOpts = {}): FilterErrorSilencer {
   if (consoleSuppressorInstalled && consoleSuppressorSilencer) return consoleSuppressorSilencer;
@@ -254,14 +255,15 @@ export function installFilterNotFoundConsoleSuppressor(opts: FilterErrorSilencer
     ...opts,
     log: opts.log ?? ((msg: string) => originalConsoleWarn(msg)),
   });
-  const originalConsoleLog = console.log.bind(console);
+  const originalConsoleLog = console.log;
+  consoleSuppressorOriginalLog = originalConsoleLog;
   console.log = (...args: unknown[]) => {
     // ethers v6 emits `console.log("@TODO", error)` from
     // subscriber-filterid.js. Intercept exactly that two-arg shape so
     // we don't accidentally swallow legitimate "@TODO" log lines that
     // happen to start with the same string.
     if (args.length === 2 && args[0] === '@TODO' && silencer.handle(args[1])) return;
-    originalConsoleLog(...args);
+    originalConsoleLog.apply(console, args);
   };
   consoleSuppressorInstalled = true;
   consoleSuppressorSilencer = silencer;
@@ -273,6 +275,10 @@ export function installFilterNotFoundConsoleSuppressor(opts: FilterErrorSilencer
  *  production, but vitest specs need a way to undo the wrap between
  *  cases. */
 export function _uninstallFilterNotFoundConsoleSuppressorForTest(): void {
+  if (consoleSuppressorOriginalLog) {
+    console.log = consoleSuppressorOriginalLog;
+  }
   consoleSuppressorInstalled = false;
   consoleSuppressorSilencer = null;
+  consoleSuppressorOriginalLog = null;
 }

--- a/packages/chain/src/filter-error-silencer.ts
+++ b/packages/chain/src/filter-error-silencer.ts
@@ -219,3 +219,60 @@ export function createFilterErrorSilencer(opts: FilterErrorSilencerOpts = {}): F
     },
   };
 }
+
+/**
+ * BUG-022 — ethers v6 swallows the `eth_getFilterChanges` "filter not
+ * found" error inside `subscriber-filterid.js#poll()` with a literal
+ * `console.log("@TODO", error)` (see ethers v6.16.0). That code path
+ * NEVER fires the `provider.on('error', ...)` event we hook in
+ * `evm-adapter.ts`, so the per-provider `FilterErrorSilencer` only
+ * catches the (rare) errors that surface through real `_perform`
+ * exceptions. Operators kept seeing a hot stream of `@TODO Error:
+ * could not coalesce error … filter not found` entries in
+ * `daemon.log` even after the rc.11 silencer landed.
+ *
+ * Fix: wrap `console.log` once per process. When a `@TODO`-prefixed
+ * call carries a filter-not-found error, route it through a dedicated
+ * dedup'd silencer instead of writing it to the log. Every other
+ * `console.log` call is forwarded untouched. Idempotent — subsequent
+ * adapter constructions skip the wrap.
+ *
+ * Returns the silencer so callers can read its stats (`/api/status`
+ * surfaces filter-error counts).
+ */
+let consoleSuppressorInstalled = false;
+let consoleSuppressorSilencer: FilterErrorSilencer | null = null;
+
+export function installFilterNotFoundConsoleSuppressor(opts: FilterErrorSilencerOpts = {}): FilterErrorSilencer {
+  if (consoleSuppressorInstalled && consoleSuppressorSilencer) return consoleSuppressorSilencer;
+  // Capture `console.warn` BEFORE wrapping `console.log`. The
+  // dedup-emit path uses `console.warn` so operators still see one
+  // line per dedup window (with a count of suppressed repeats),
+  // matching the per-provider silencer's UX.
+  const originalConsoleWarn = console.warn.bind(console);
+  const silencer = createFilterErrorSilencer({
+    ...opts,
+    log: opts.log ?? ((msg: string) => originalConsoleWarn(msg)),
+  });
+  const originalConsoleLog = console.log.bind(console);
+  console.log = (...args: unknown[]) => {
+    // ethers v6 emits `console.log("@TODO", error)` from
+    // subscriber-filterid.js. Intercept exactly that two-arg shape so
+    // we don't accidentally swallow legitimate "@TODO" log lines that
+    // happen to start with the same string.
+    if (args.length === 2 && args[0] === '@TODO' && silencer.handle(args[1])) return;
+    originalConsoleLog(...args);
+  };
+  consoleSuppressorInstalled = true;
+  consoleSuppressorSilencer = silencer;
+  return silencer;
+}
+
+/** Test-only — restore the original `console.log` so subsequent tests
+ *  see real output. Not exported as part of the public surface in
+ *  production, but vitest specs need a way to undo the wrap between
+ *  cases. */
+export function _uninstallFilterNotFoundConsoleSuppressorForTest(): void {
+  consoleSuppressorInstalled = false;
+  consoleSuppressorSilencer = null;
+}

--- a/packages/chain/test/filter-error-console-suppressor.test.ts
+++ b/packages/chain/test/filter-error-console-suppressor.test.ts
@@ -1,0 +1,97 @@
+/**
+ * BUG-022: ethers v6 swallows `eth_getFilterChanges` "filter not found"
+ * errors with `console.log("@TODO", error)` from
+ * `subscriber-filterid.js`, bypassing `provider.on('error', ...)` so
+ * the per-provider `FilterErrorSilencer` never sees them. The
+ * `installFilterNotFoundConsoleSuppressor` patches `console.log` once
+ * per process to catch exactly that two-arg shape and dedup-emit a
+ * single warning per window.
+ *
+ * Tests:
+ *   1. Filter-not-found `@TODO` calls are suppressed (no log spam).
+ *   2. Suppression is dedup'd against the silencer's window.
+ *   3. Unrelated `@TODO` calls (e.g. legitimate ethers warnings that
+ *      aren't filter errors) propagate untouched.
+ *   4. All other `console.log` calls are unaffected.
+ *   5. Idempotent — calling install twice returns the same silencer.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import {
+  installFilterNotFoundConsoleSuppressor,
+  _uninstallFilterNotFoundConsoleSuppressorForTest,
+} from '../src/filter-error-silencer.js';
+
+let originalLog: typeof console.log;
+let originalWarn: typeof console.warn;
+
+beforeEach(() => {
+  originalLog = console.log;
+  originalWarn = console.warn;
+});
+
+afterEach(() => {
+  // Restore unconditionally — install patches console.log; tests must
+  // not leak that patch between cases.
+  console.log = originalLog;
+  console.warn = originalWarn;
+  _uninstallFilterNotFoundConsoleSuppressorForTest();
+});
+
+function buildEthersFilterError(): Error {
+  const err = new Error('could not coalesce error (error={ "code": -32602, "message": "filter not found" }, payload={ "id": 92590, "jsonrpc": "2.0", "method": "eth_getFilterChanges", "params": [ "0xb5fdcb85048ee0132aae792ffcba21a2" ] }, code=UNKNOWN_ERROR, version=6.16.0)');
+  (err as unknown as { code: string }).code = 'UNKNOWN_ERROR';
+  (err as unknown as { info: unknown }).info = {
+    error: { code: -32602, message: 'filter not found' },
+    payload: { method: 'eth_getFilterChanges' },
+  };
+  return err;
+}
+
+describe('installFilterNotFoundConsoleSuppressor (BUG-022)', () => {
+  it('suppresses `console.log("@TODO", filterError)` so the daemon log stays clean', () => {
+    const captured: unknown[][] = [];
+    console.log = (...args: unknown[]) => { captured.push(args); };
+    const silencer = installFilterNotFoundConsoleSuppressor({ now: () => 0 });
+    console.log('@TODO', buildEthersFilterError());
+    expect(captured).toHaveLength(0);
+    expect(silencer.stats().filterErrorsTotal).toBe(1);
+  });
+
+  it('dedupes repeated suppressions inside the configured window', () => {
+    const warns: string[] = [];
+    console.warn = (msg: string) => { warns.push(msg); };
+    const silencer = installFilterNotFoundConsoleSuppressor({
+      dedupWindowMs: 60_000,
+      now: () => 0,
+    });
+    for (let i = 0; i < 100; i++) console.log('@TODO', buildEthersFilterError());
+    expect(silencer.stats().filterErrorsTotal).toBe(100);
+    expect(warns.length).toBeLessThanOrEqual(2);
+    expect(warns[0]).toMatch(/filter expired/i);
+  });
+
+  it('forwards other console.log calls untouched (non-filter `@TODO` lines remain visible)', () => {
+    const captured: unknown[][] = [];
+    console.log = (...args: unknown[]) => { captured.push(args); };
+    installFilterNotFoundConsoleSuppressor({ now: () => 0 });
+    console.log('@TODO', new Error('some other unrelated error'));
+    console.log('regular operator log line');
+    console.log('@TODO', { code: 'NETWORK_ERROR', message: 'unrelated' });
+    expect(captured).toHaveLength(3);
+  });
+
+  it('idempotent — re-installing returns the same silencer instance', () => {
+    const a = installFilterNotFoundConsoleSuppressor();
+    const b = installFilterNotFoundConsoleSuppressor();
+    expect(a).toBe(b);
+  });
+
+  it('does NOT match when args are not (string, error) — guards against a hostile caller spoofing the shape', () => {
+    const captured: unknown[][] = [];
+    console.log = (...args: unknown[]) => { captured.push(args); };
+    installFilterNotFoundConsoleSuppressor({ now: () => 0 });
+    console.log('@TODO');
+    console.log('@TODO', buildEthersFilterError(), 'extra-arg');
+    expect(captured).toHaveLength(2);
+  });
+});

--- a/packages/chain/test/filter-error-console-suppressor.test.ts
+++ b/packages/chain/test/filter-error-console-suppressor.test.ts
@@ -32,9 +32,9 @@ beforeEach(() => {
 afterEach(() => {
   // Restore unconditionally — install patches console.log; tests must
   // not leak that patch between cases.
+  _uninstallFilterNotFoundConsoleSuppressorForTest();
   console.log = originalLog;
   console.warn = originalWarn;
-  _uninstallFilterNotFoundConsoleSuppressorForTest();
 });
 
 function buildEthersFilterError(): Error {
@@ -84,6 +84,20 @@ describe('installFilterNotFoundConsoleSuppressor (BUG-022)', () => {
     const a = installFilterNotFoundConsoleSuppressor();
     const b = installFilterNotFoundConsoleSuppressor();
     expect(a).toBe(b);
+  });
+
+  it('uninstall restores the console.log implementation captured at install time', () => {
+    const captured: unknown[][] = [];
+    const testLogger = (...args: unknown[]) => { captured.push(args); };
+    console.log = testLogger;
+
+    installFilterNotFoundConsoleSuppressor({ now: () => 0 });
+    expect(console.log).not.toBe(testLogger);
+
+    _uninstallFilterNotFoundConsoleSuppressorForTest();
+    expect(console.log).toBe(testLogger);
+    console.log('after uninstall');
+    expect(captured).toEqual([['after uninstall']]);
   });
 
   it('does NOT match when args are not (string, error) — guards against a hostile caller spoofing the shape', () => {

--- a/packages/chain/vitest.unit.config.ts
+++ b/packages/chain/vitest.unit.config.ts
@@ -12,6 +12,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: [
+      'test/filter-error-console-suppressor.test.ts',
       'test/filter-error-silencer.test.ts',
       'test/evm-adapter.unit.test.ts',
     ],

--- a/packages/node-ui/src/api.ts
+++ b/packages/node-ui/src/api.ts
@@ -504,7 +504,16 @@ export async function handleNodeUIRequest(
         ...(parsedLimit != null ? { limit: parsedLimit } : {}),
         order: rawOrder,
       });
-      if (!session) return json(res, 404, { error: 'Session not found' });
+      // Returning 404 for "no history yet" was a bad UX/observability
+      // contract: the OpenClaw chat panel hits this endpoint on every
+      // page load, so a fresh node showed a red 404 line in DevTools
+      // even though the panel was working correctly. Return 200 with
+      // an empty `messages: []` envelope instead — semantically
+      // accurate (the session simply has no turns yet) and matches the
+      // shape `fetchLocalAgentHistoryBySessionId` expects (BUG-001).
+      if (!session) {
+        return json(res, 200, { session: sessionId, messages: [] });
+      }
       return json(res, 200, session);
     } catch (err: any) {
       return json(res, 500, { error: err.message ?? 'Failed to fetch session' });

--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -189,13 +189,21 @@ function useShellRouting() {
 
   // Step 2: keep the URL aligned with the *active* tab so a refresh
   // restores you to the same place and the location bar reflects what
-  // the user sees. We only touch the URL when the canonical mapping
-  // disagrees with the current pathname — non-deep-linkable tabs
-  // (project:..., context-graph-primer, etc.) leave the URL alone.
+  // the user sees. When the active tab IS deep-linkable, sync to its
+  // mapped path. When the active tab is NOT deep-linkable (project:…,
+  // context-graph-primer, etc.) but the URL is still showing a
+  // previously-deep-linked path, reset to `/` so a refresh doesn't
+  // ping-pong the user back into the old tab. Other routes (/network,
+  // /context-graph-primer) aren't in the mapping table, so this leaves
+  // them alone.
   useEffect(() => {
     const target = TAB_TO_URL_PATH[activeTabId];
-    if (target && target !== pathname) {
-      navigate(target, { replace: true });
+    if (target) {
+      if (target !== pathname) navigate(target, { replace: true });
+      return;
+    }
+    if (URL_PATH_TO_TAB[pathname]) {
+      navigate('/', { replace: true });
     }
   }, [activeTabId, pathname, navigate]);
 }

--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react';
-import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import { Header } from './components/Shell/Header.js';
 import { PanelLeft } from './components/Shell/PanelLeft.js';
 import { PanelCenter } from './components/Shell/PanelCenter.js';
@@ -11,6 +11,8 @@ import { useTabsStore } from './stores/tabs.js';
 import { api } from './api-wrapper.js';
 import { CONTEXT_GRAPH_PRIMER_TAB } from './lib/contextGraphPrimer.js';
 import { useVisibilityPolling } from './hooks/useVisibilityPolling.js';
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts.js';
+import { useShellRouting } from './hooks/useShellRouting.js';
 
 function useLiveStatus() {
   const setNodeStatus = useAgentsStore((s) => s.setNodeStatus);
@@ -21,31 +23,6 @@ function useLiveStatus() {
   useVisibilityPolling(() => {
     api.fetchStatus().then(setNodeStatus).catch(() => {});
   }, 10_000);
-}
-
-function useKeyboardShortcuts() {
-  const { toggleLeft, toggleRight, toggleBottom } = useLayoutStore();
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
-      // Normalise the key — Chrome reports the *uppercase* letter when
-      // Shift is held (or Caps Lock is on), so the lowercase comparisons
-      // below would silently miss `Cmd+Shift+B` and `Cmd+B` with Caps
-      // Lock. Normalising here keeps the dispatch table case-insensitive.
-      const k = e.key.toLowerCase();
-      // Order matters: handle the shift-modified shortcut first and
-      // `return` so the non-shift branches below can't double-fire on
-      // the same event.
-      if (e.shiftKey && k === 'b') { e.preventDefault(); toggleRight(); return; }
-      if (e.shiftKey) return;
-      if (k === 'b') { e.preventDefault(); toggleLeft(); return; }
-      if (k === 'j') { e.preventDefault(); toggleBottom(); return; }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [toggleLeft, toggleRight, toggleBottom]);
 }
 
 function useDragResize(onDrag: (delta: number) => void) {
@@ -148,64 +125,6 @@ function useDragResizeV(onDrag: (delta: number) => void) {
   // Stable callback ref: React invokes it with the node on mount and
   // null on unmount, driving the effect above.
   return useCallback((node: HTMLDivElement | null) => setHandle(node), []);
-}
-
-// Map between deep-link URL paths and centre-tab IDs. Keeping this here
-// (rather than inside `useTabsStore`) lets the route layer stay a thin
-// adapter — the store is still the source of truth for which tabs are
-// open, but a fresh navigation to e.g. `/ui/settings` opens that tab on
-// mount and clicking the tab pushes the corresponding URL.
-const URL_PATH_TO_TAB: Record<string, { id: string; label: string }> = {
-  '/observability': { id: 'operations', label: 'Observability' },
-  '/operations': { id: 'operations', label: 'Observability' },
-  '/settings': { id: 'settings', label: 'Settings' },
-};
-const TAB_TO_URL_PATH: Record<string, string> = {
-  operations: '/observability',
-  settings: '/settings',
-  dashboard: '/',
-};
-
-function useShellRouting() {
-  const { pathname } = useLocation();
-  const navigate = useNavigate();
-  const openTab = useTabsStore((s) => s.openTab);
-  const activeTabId = useTabsStore((s) => s.activeTabId);
-
-  // Step 1: when the user lands on a deep-link path, open the matching
-  // centre tab once. We deliberately key the effect on `pathname` so
-  // browser back/forward also re-opens the corresponding tab.
-  //
-  // We intentionally do NOT force-switch to the dashboard at `/`: other
-  // routes (e.g. the Context-Graph primer) redirect to `/` after
-  // opening their own tab, and stomping the active tab here would
-  // ping-pong the user back to the dashboard mid-flow.
-  useEffect(() => {
-    const match = URL_PATH_TO_TAB[pathname];
-    if (match) {
-      openTab({ id: match.id, label: match.label, closable: true });
-    }
-  }, [pathname, openTab]);
-
-  // Step 2: keep the URL aligned with the *active* tab so a refresh
-  // restores you to the same place and the location bar reflects what
-  // the user sees. When the active tab IS deep-linkable, sync to its
-  // mapped path. When the active tab is NOT deep-linkable (project:…,
-  // context-graph-primer, etc.) but the URL is still showing a
-  // previously-deep-linked path, reset to `/` so a refresh doesn't
-  // ping-pong the user back into the old tab. Other routes (/network,
-  // /context-graph-primer) aren't in the mapping table, so this leaves
-  // them alone.
-  useEffect(() => {
-    const target = TAB_TO_URL_PATH[activeTabId];
-    if (target) {
-      if (target !== pathname) navigate(target, { replace: true });
-      return;
-    }
-    if (URL_PATH_TO_TAB[pathname]) {
-      navigate('/', { replace: true });
-    }
-  }, [activeTabId, pathname, navigate]);
 }
 
 function AppShell() {

--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -171,7 +171,6 @@ function useShellRouting() {
   const navigate = useNavigate();
   const openTab = useTabsStore((s) => s.openTab);
   const activeTabId = useTabsStore((s) => s.activeTabId);
-  const setActiveTab = useTabsStore((s) => s.setActiveTab);
 
   // Step 1: when the user lands on a deep-link path, open the matching
   // centre tab once. We deliberately key the effect on `pathname` so
@@ -187,7 +186,6 @@ function useShellRouting() {
       openTab({ id: match.id, label: match.label, closable: true });
     }
   }, [pathname, openTab]);
-  void setActiveTab; // kept on the hook surface for future deep-link work
 
   // Step 2: keep the URL aligned with the *active* tab so a refresh
   // restores you to the same place and the location bar reflects what

--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { Header } from './components/Shell/Header.js';
 import { PanelLeft } from './components/Shell/PanelLeft.js';
 import { PanelCenter } from './components/Shell/PanelCenter.js';
@@ -10,18 +10,17 @@ import { useAgentsStore } from './stores/agents.js';
 import { useTabsStore } from './stores/tabs.js';
 import { api } from './api-wrapper.js';
 import { CONTEXT_GRAPH_PRIMER_TAB } from './lib/contextGraphPrimer.js';
+import { useVisibilityPolling } from './hooks/useVisibilityPolling.js';
 
 function useLiveStatus() {
   const setNodeStatus = useAgentsStore((s) => s.setNodeStatus);
-  useEffect(() => {
-    let mounted = true;
-    const poll = () => {
-      api.fetchStatus().then((s) => { if (mounted) setNodeStatus(s); }).catch(() => {});
-    };
-    poll();
-    const iv = setInterval(poll, 10_000);
-    return () => { mounted = false; clearInterval(iv); };
-  }, [setNodeStatus]);
+  // Status was previously polled every 10s with a raw `setInterval`,
+  // even when the tab was hidden — burning ~6 requests/minute against
+  // the daemon for nothing. Route through the visibility-aware
+  // helper so a backgrounded tab stops polling entirely (BUG-007).
+  useVisibilityPolling(() => {
+    api.fetchStatus().then(setNodeStatus).catch(() => {});
+  }, 10_000);
 }
 
 function useKeyboardShortcuts() {
@@ -30,9 +29,19 @@ function useKeyboardShortcuts() {
     const handler = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
       const mod = e.metaKey || e.ctrlKey;
-      if (mod && e.key === 'b') { e.preventDefault(); toggleLeft(); }
-      if (mod && e.key === 'j') { e.preventDefault(); toggleBottom(); }
-      if (mod && e.shiftKey && e.key === 'b') { e.preventDefault(); toggleRight(); }
+      if (!mod) return;
+      // Normalise the key — Chrome reports the *uppercase* letter when
+      // Shift is held (or Caps Lock is on), so the lowercase comparisons
+      // below would silently miss `Cmd+Shift+B` and `Cmd+B` with Caps
+      // Lock. Normalising here keeps the dispatch table case-insensitive.
+      const k = e.key.toLowerCase();
+      // Order matters: handle the shift-modified shortcut first and
+      // `return` so the non-shift branches below can't double-fire on
+      // the same event.
+      if (e.shiftKey && k === 'b') { e.preventDefault(); toggleRight(); return; }
+      if (e.shiftKey) return;
+      if (k === 'b') { e.preventDefault(); toggleLeft(); return; }
+      if (k === 'j') { e.preventDefault(); toggleBottom(); return; }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
@@ -141,13 +150,76 @@ function useDragResizeV(onDrag: (delta: number) => void) {
   return useCallback((node: HTMLDivElement | null) => setHandle(node), []);
 }
 
+// Map between deep-link URL paths and centre-tab IDs. Keeping this here
+// (rather than inside `useTabsStore`) lets the route layer stay a thin
+// adapter — the store is still the source of truth for which tabs are
+// open, but a fresh navigation to e.g. `/ui/settings` opens that tab on
+// mount and clicking the tab pushes the corresponding URL.
+const URL_PATH_TO_TAB: Record<string, { id: string; label: string }> = {
+  '/observability': { id: 'operations', label: 'Observability' },
+  '/operations': { id: 'operations', label: 'Observability' },
+  '/settings': { id: 'settings', label: 'Settings' },
+};
+const TAB_TO_URL_PATH: Record<string, string> = {
+  operations: '/observability',
+  settings: '/settings',
+  dashboard: '/',
+};
+
+function useShellRouting() {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const openTab = useTabsStore((s) => s.openTab);
+  const activeTabId = useTabsStore((s) => s.activeTabId);
+  const setActiveTab = useTabsStore((s) => s.setActiveTab);
+
+  // Step 1: when the user lands on a deep-link path, open the matching
+  // centre tab once. We deliberately key the effect on `pathname` so
+  // browser back/forward also re-opens the corresponding tab.
+  //
+  // We intentionally do NOT force-switch to the dashboard at `/`: other
+  // routes (e.g. the Context-Graph primer) redirect to `/` after
+  // opening their own tab, and stomping the active tab here would
+  // ping-pong the user back to the dashboard mid-flow.
+  useEffect(() => {
+    const match = URL_PATH_TO_TAB[pathname];
+    if (match) {
+      openTab({ id: match.id, label: match.label, closable: true });
+    }
+  }, [pathname, openTab]);
+  void setActiveTab; // kept on the hook surface for future deep-link work
+
+  // Step 2: keep the URL aligned with the *active* tab so a refresh
+  // restores you to the same place and the location bar reflects what
+  // the user sees. We only touch the URL when the canonical mapping
+  // disagrees with the current pathname — non-deep-linkable tabs
+  // (project:..., context-graph-primer, etc.) leave the URL alone.
+  useEffect(() => {
+    const target = TAB_TO_URL_PATH[activeTabId];
+    if (target && target !== pathname) {
+      navigate(target, { replace: true });
+    }
+  }, [activeTabId, pathname, navigate]);
+}
+
 function AppShell() {
   useLiveStatus();
   useKeyboardShortcuts();
+  useShellRouting();
   const { leftCollapsed, rightCollapsed, bottomCollapsed, theme, leftWidth, rightWidth, setLeftWidth, setRightWidth, setBottomHeight } = useLayoutStore();
   const [, setVpTick] = useState(0);
 
   useEffect(() => {
+    // Toggle the class on `<html>` (documentElement) — not `<body>` —
+    // because `:root` defines `--bg-root: #000000` and the
+    // `html, body, #root { background: var(--bg-root) }` rule applies
+    // that variable to the `<html>` element first. Putting the override
+    // class on `<body>` only re-cascaded the variable to the body, so
+    // the html element kept rendering the dark colour and rubber-band
+    // overscroll on macOS showed a black strip in light mode. Keep the
+    // body class as well for any selectors authored against `body.light`
+    // historically.
+    document.documentElement.classList.toggle('light', theme === 'light');
     document.body.classList.toggle('light', theme === 'light');
   }, [theme]);
 
@@ -253,7 +325,6 @@ export function App() {
       <Route path="/context-graph-primer" element={<ContextGraphPrimerRoute />} />
       <Route path="/agent" element={<Navigate to="/" replace />} />
       <Route path="/explorer" element={<Navigate to="/" replace />} />
-      <Route path="/settings" element={<Navigate to="/" replace />} />
       <Route path="/messages" element={<Navigate to="/" replace />} />
       {/* V9 installable apps framework was retired in V10 (see daemon 410 handler).
           Redirect stale bookmarks for /ui/apps/... back to the dashboard so upgraded

--- a/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
@@ -6,6 +6,8 @@ import { useJourneyStore } from '../../stores/journey.js';
 import { installOntology, listStarters } from '../../lib/ontologyInstall.js';
 import { publishProjectManifest } from '../../lib/projectManifest.js';
 import { WireWorkspacePanel } from '../Workspace/WireWorkspacePanel.js';
+import { useModalDismiss } from './useModalDismiss.js';
+import { CG_NAME_MAX_LENGTH, sanitiseCgName, validateCgName } from './cgNameValidation.js';
 
 function slugify(str: string): string {
   return str
@@ -79,12 +81,29 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
     }
   }, [open]);
 
+  const wireDismiss = useModalDismiss(open && !wiredCgId, onClose);
+  const wiredDismiss = useModalDismiss(open && !!wiredCgId, () => {
+    setWiredCgId(null);
+    setWiredProjectName('');
+    setRegistrationWarning(null);
+    setName('');
+    setDescription('');
+    onClose();
+  });
+
   if (!open) return null;
 
   const slug = slugify(name);
   const cgIdPreview = agentAddress && slug
     ? `${agentAddress}/${slug}`
     : slug ? `<agent-address>/${slug}` : '';
+  const nameValidationError = name ? validateCgName(name) : null;
+  const onNameChange = (raw: string) => {
+    // Always feed the sanitised value back through the controlled
+    // input — the user sees the cleaned-up name exactly as it will be
+    // submitted, no surprise transform on the server side.
+    setName(sanitiseCgName(raw));
+  };
 
   const handleCreate = async () => {
     const trimmedName = name.trim();
@@ -248,10 +267,30 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
 
   if (wiredCgId) {
     return (
-      <div className="v10-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) handleWireDone(); }}>
-        <div className="v10-modal-box">
+      <div
+        className="v10-modal-overlay"
+        onClick={wiredDismiss.onBackdropClick}
+        role="presentation"
+      >
+        <div
+          className="v10-modal-box"
+          ref={wiredDismiss.dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="dkg-wire-modal-title"
+        >
+          <button
+            type="button"
+            className="v10-modal-close"
+            onClick={handleWireDone}
+            aria-label="Close wire workspace dialog"
+            title="Close (Esc)"
+            style={{ position: 'absolute', top: 12, right: 12, background: 'none', border: 'none', color: 'var(--text-tertiary)', cursor: 'pointer', fontSize: 18, lineHeight: 1, padding: 4 }}
+          >
+            ×
+          </button>
           <div className="v10-modal-header">
-            <div className="v10-modal-title">Wire workspace for {wiredProjectName}</div>
+            <div id="dkg-wire-modal-title" className="v10-modal-title">Wire workspace for {wiredProjectName}</div>
             <div className="v10-modal-subtitle">
               Context graph created. Now wire a local workspace so you can plan it from your own Cursor.
             </div>
@@ -275,11 +314,32 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
   }
 
   return (
-    <div className="v10-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-      <div className="v10-modal-box">
+    <div
+      className="v10-modal-overlay"
+      onClick={wireDismiss.onBackdropClick}
+      role="presentation"
+    >
+      <div
+        className="v10-modal-box"
+        ref={wireDismiss.dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dkg-create-cg-title"
+        aria-describedby="dkg-create-cg-subtitle"
+      >
+        <button
+          type="button"
+          className="v10-modal-close"
+          onClick={onClose}
+          aria-label="Close create context graph dialog"
+          title="Close (Esc)"
+          style={{ position: 'absolute', top: 12, right: 12, background: 'none', border: 'none', color: 'var(--text-tertiary)', cursor: 'pointer', fontSize: 18, lineHeight: 1, padding: 4, zIndex: 1 }}
+        >
+          ×
+        </button>
         <div className="v10-modal-header">
-          <div className="v10-modal-title">Create New Context Graph</div>
-          <div className="v10-modal-subtitle">
+          <div id="dkg-create-cg-title" className="v10-modal-title">Create New Context Graph</div>
+          <div id="dkg-create-cg-subtitle" className="v10-modal-subtitle">
             A context graph gives your agent structured memory — a place to draft, share, and publish knowledge.
           </div>
         </div>
@@ -306,29 +366,44 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
           )}
 
           <div className="v10-form-group">
-            <label className="v10-form-label">Context Graph Name</label>
+            <label className="v10-form-label" htmlFor="dkg-cg-name">Context Graph Name</label>
             <input
+              id="dkg-cg-name"
+              name="dkg-cg-name"
               className="v10-form-input"
               type="text"
               placeholder="e.g. Pharma Drug Interactions"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => onNameChange(e.target.value)}
               autoFocus
+              maxLength={CG_NAME_MAX_LENGTH}
+              aria-invalid={nameValidationError ? 'true' : 'false'}
+              aria-describedby="dkg-cg-name-help"
+              autoComplete="off"
+              spellCheck={true}
             />
-            {cgIdPreview && (
-              <div style={{ marginTop: 4, fontSize: 11, color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)' }}>
-                ID: did:dkg:context-graph:{cgIdPreview}
-              </div>
-            )}
+            <div
+              id="dkg-cg-name-help"
+              style={{ marginTop: 4, fontSize: 11, color: nameValidationError ? 'var(--red, #f87171)' : 'var(--text-tertiary)', fontFamily: 'var(--font-mono)' }}
+            >
+              {nameValidationError
+                ? nameValidationError
+                : cgIdPreview
+                  ? `ID: did:dkg:context-graph:${cgIdPreview}`
+                  : `${name.length}/${CG_NAME_MAX_LENGTH} characters`}
+            </div>
           </div>
 
           <div className="v10-form-group">
-            <label className="v10-form-label">Description</label>
+            <label className="v10-form-label" htmlFor="dkg-cg-description">Description</label>
             <textarea
+              id="dkg-cg-description"
+              name="dkg-cg-description"
               className="v10-form-textarea"
               placeholder="What should your agent remember? Describe the domain, goals, or context..."
               value={description}
               onChange={(e) => setDescription(e.target.value)}
+              aria-label="Context graph description"
             />
           </div>
 
@@ -477,7 +552,7 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
           <button
             className="v10-modal-btn primary"
             onClick={handleCreate}
-            disabled={!name.trim() || creating || !agentAddress || identityLoading}
+            disabled={!name.trim() || !!validateCgName(name) || creating || !agentAddress || identityLoading}
           >
             {creating ? progress || 'Creating…' : identityLoading ? 'Loading agent…' : !agentAddress ? 'Agent unavailable' : 'Create Context Graph'}
           </button>

--- a/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
@@ -93,21 +93,23 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
 
   if (!open) return null;
 
-  const slug = slugify(name);
+  // Store the raw user input verbatim so `validateCgName(name)` can
+  // see and surface every warning the helper emits (stripped HTML
+  // tags, over-length, slug-empty). The cleaned form is derived for
+  // the submit path and the slug preview only.
+  const cleanedName = sanitiseCgName(name);
+  const slug = slugify(cleanedName);
   const cgIdPreview = agentAddress && slug
     ? `${agentAddress}/${slug}`
     : slug ? `<agent-address>/${slug}` : '';
   const nameValidationError = name ? validateCgName(name) : null;
   const onNameChange = (raw: string) => {
-    // Always feed the sanitised value back through the controlled
-    // input — the user sees the cleaned-up name exactly as it will be
-    // submitted, no surprise transform on the server side.
-    setName(sanitiseCgName(raw));
+    setName(raw);
   };
 
   const handleCreate = async () => {
-    const trimmedName = name.trim();
-    if (!trimmedName) return;
+    const trimmedName = cleanedName;
+    if (!trimmedName || nameValidationError) return;
 
     setCreating(true);
     setError(null);

--- a/packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/JoinProjectModal.tsx
@@ -9,6 +9,7 @@ import { useProjectsStore } from '../../stores/projects.js';
 import { useTabsStore } from '../../stores/tabs.js';
 import { useNodeEvents } from '../../hooks/useNodeEvents.js';
 import { WireWorkspacePanel } from '../Workspace/WireWorkspacePanel.js';
+import { useModalDismiss } from './useModalDismiss.js';
 
 interface JoinProjectModalProps {
   open: boolean;
@@ -320,6 +321,13 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
   }, [pendingCgId, transitionToApproved]);
   useNodeEvents(onNodeEvent);
 
+  const inviteDismiss = useModalDismiss(open && !wiredCgId, onClose);
+  const wireDismiss = useModalDismiss(open && !!wiredCgId, () => {
+    setWiredCgId(null);
+    setWiredProjectName('');
+    onClose();
+  });
+
   if (!open) return null;
 
   const handleRequestJoin = async () => {
@@ -403,10 +411,30 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
 
   if (wiredCgId) {
     return (
-      <div className="v10-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) handleWireDone(); }}>
-        <div className="v10-modal-box">
+      <div
+        className="v10-modal-overlay"
+        onClick={wireDismiss.onBackdropClick}
+        role="presentation"
+      >
+        <div
+          className="v10-modal-box"
+          ref={wireDismiss.dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="dkg-join-wire-title"
+        >
+          <button
+            type="button"
+            className="v10-modal-close"
+            onClick={handleWireDone}
+            aria-label="Close wire workspace dialog"
+            title="Close (Esc)"
+            style={{ position: 'absolute', top: 12, right: 12, background: 'none', border: 'none', color: 'var(--text-tertiary)', cursor: 'pointer', fontSize: 18, lineHeight: 1, padding: 4, zIndex: 1 }}
+          >
+            ×
+          </button>
           <div className="v10-modal-header">
-            <div className="v10-modal-title">Wire workspace for {wiredProjectName}</div>
+            <div id="dkg-join-wire-title" className="v10-modal-title">Wire workspace for {wiredProjectName}</div>
             <div className="v10-modal-subtitle">
               Curator approved. Now wire a local workspace so this Cursor can collaborate on the context graph.
             </div>
@@ -430,11 +458,32 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
   const rejected = phase === 'rejected';
 
   return (
-    <div className="v10-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-      <div className="v10-modal-box">
+    <div
+      className="v10-modal-overlay"
+      onClick={inviteDismiss.onBackdropClick}
+      role="presentation"
+    >
+      <div
+        className="v10-modal-box"
+        ref={inviteDismiss.dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dkg-join-cg-title"
+        aria-describedby="dkg-join-cg-subtitle"
+      >
+        <button
+          type="button"
+          className="v10-modal-close"
+          onClick={onClose}
+          aria-label="Close join context graph dialog"
+          title="Close (Esc)"
+          style={{ position: 'absolute', top: 12, right: 12, background: 'none', border: 'none', color: 'var(--text-tertiary)', cursor: 'pointer', fontSize: 18, lineHeight: 1, padding: 4, zIndex: 1 }}
+        >
+          ×
+        </button>
         <div className="v10-modal-header">
-          <div className="v10-modal-title">Join a Context Graph</div>
-          <div className="v10-modal-subtitle">
+          <div id="dkg-join-cg-title" className="v10-modal-title">Join a Context Graph</div>
+          <div id="dkg-join-cg-subtitle" className="v10-modal-subtitle">
             Paste the invite from the curator. Your node will send a signed join request and wait for approval.
           </div>
         </div>
@@ -473,8 +522,10 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
           )}
 
           <div className="v10-form-group">
-            <label className="v10-form-label">Invite Code</label>
+            <label className="v10-form-label" htmlFor="dkg-cg-invite">Invite Code</label>
             <textarea
+              id="dkg-cg-invite"
+              name="dkg-cg-invite"
               className="v10-form-textarea"
               placeholder={"Paste the invite code from the context graph curator.\n\ne.g.\nmy-context-graph-abc123\n12D3KooW..."}
               value={inviteCode}
@@ -483,6 +534,9 @@ export function JoinProjectModal({ open, onClose, initialContextGraphId }: JoinP
               rows={3}
               disabled={sending || pending || approved}
               style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}
+              aria-label="Context graph invite code"
+              autoComplete="off"
+              spellCheck={false}
             />
           </div>
         </div>

--- a/packages/node-ui/src/ui/components/Modals/cgNameValidation.ts
+++ b/packages/node-ui/src/ui/components/Modals/cgNameValidation.ts
@@ -1,0 +1,62 @@
+/**
+ * Client-side input contract for the Create Context Graph modal name
+ * field (BUG-016). The previous implementation accepted *any* string —
+ * unbounded length, raw HTML, leading/trailing whitespace — and only
+ * the daemon's slugify pass downstream caught the most blatant abuse.
+ * That meant pasting a 5,000-character HTML chunk into the field
+ * silently sent a 5,000-character payload (with embedded `<script>`
+ * tags) over the wire, and the user only learned something was wrong
+ * when the request 4xx'd or worse. The redacted display name in
+ * dashboards then surfaced the raw HTML without escaping.
+ *
+ * The module exports three small helpers, all pure (no React, no DOM):
+ *
+ * - `CG_NAME_MAX_LENGTH`    — single source of truth for the cap. 80
+ *                             chars is plenty for a human-readable
+ *                             label and keeps the URL-encoded slug
+ *                             well under the 60-char slug ceiling
+ *                             enforced by the daemon (`slugify`).
+ * - `sanitiseCgName(input)` — returns the cleaned version of the raw
+ *                             input: HTML/control chars stripped,
+ *                             whitespace collapsed, length capped.
+ *                             This is what we feed back into the
+ *                             controlled `<input>` so the user sees
+ *                             exactly what will be submitted.
+ * - `validateCgName(input)` — returns a user-facing error string if
+ *                             the *raw* input fails a hard rule (empty
+ *                             after sanitise, contained an HTML tag),
+ *                             or `null` when acceptable.
+ */
+export const CG_NAME_MAX_LENGTH = 80;
+
+const HTML_TAG_RE = /<\/?[a-z][^>]*>/gi;
+// Strip every ASCII control character EXCEPT the whitespace ones (tab,
+// LF, CR) — those are still control codes (0x09/0x0A/0x0D) but the
+// next step intentionally collapses them into spaces. Stripping them
+// up-front would silently glue surrounding tokens together
+// ("\nnewlines\nand\ttabs\n" would render as "newlinesandtabs").
+const NON_WHITESPACE_CONTROL_CHARS_RE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+
+export function sanitiseCgName(input: string): string {
+  if (typeof input !== 'string') return '';
+  let v = input;
+  v = v.replace(HTML_TAG_RE, '');
+  v = v.replace(/<|>/g, '');
+  v = v.replace(NON_WHITESPACE_CONTROL_CHARS_RE, '');
+  v = v.replace(/\s+/g, ' ');
+  v = v.trim();
+  if (v.length > CG_NAME_MAX_LENGTH) v = v.slice(0, CG_NAME_MAX_LENGTH);
+  return v;
+}
+
+export function validateCgName(input: string): string | null {
+  const cleaned = sanitiseCgName(input);
+  if (!cleaned) return 'Enter a name with at least one letter or digit.';
+  if (HTML_TAG_RE.test(input)) {
+    return 'HTML tags are not allowed in the name — they have been stripped automatically.';
+  }
+  if (input.length > CG_NAME_MAX_LENGTH) {
+    return `Name was trimmed to ${CG_NAME_MAX_LENGTH} characters (was ${input.length}).`;
+  }
+  return null;
+}

--- a/packages/node-ui/src/ui/components/Modals/cgNameValidation.ts
+++ b/packages/node-ui/src/ui/components/Modals/cgNameValidation.ts
@@ -24,12 +24,19 @@
  *                             exactly what will be submitted.
  * - `validateCgName(input)` — returns a user-facing error string if
  *                             the *raw* input fails a hard rule (empty
- *                             after sanitise, contained an HTML tag),
- *                             or `null` when acceptable.
+ *                             after sanitise, contained an HTML tag,
+ *                             or sanitises to something the daemon's
+ *                             slugify would collapse to an empty
+ *                             slug), or `null` when acceptable.
  */
 export const CG_NAME_MAX_LENGTH = 80;
 
-const HTML_TAG_RE = /<\/?[a-z][^>]*>/gi;
+// Detect HTML tag *shape* in the raw input. Used only for the
+// "you typed HTML" warning, never for sanitisation. Declared without
+// the `g` flag so `.test()` is stateless and safe to call on every
+// keystroke without stepping `lastIndex` between calls.
+const HTML_TAG_SHAPE_RE = /<\/?[a-z][^>]*>/i;
+
 // Strip every ASCII control character EXCEPT the whitespace ones (tab,
 // LF, CR) — those are still control codes (0x09/0x0A/0x0D) but the
 // next step intentionally collapses them into spaces. Stripping them
@@ -37,20 +44,63 @@ const HTML_TAG_RE = /<\/?[a-z][^>]*>/gi;
 // ("\nnewlines\nand\ttabs\n" would render as "newlinesandtabs").
 const NON_WHITESPACE_CONTROL_CHARS_RE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
 
+// Anything Unicode "letter or digit" — what the daemon's slugify pass
+// keeps. If the cleaned name has none of these, slugify returns "" and
+// the resulting context-graph ID would end with a stray "/", which
+// none of the downstream APIs accept.
+const SLUG_PRODUCING_RE = /[\p{L}\p{N}]/u;
+
+/**
+ * Strip HTML-tag-shaped spans (`<…>`) from `input` using a manual
+ * linear scan rather than `String.prototype.replace(TAG_RE, '')`.
+ *
+ * This sidesteps CodeQL's `js/incomplete-multi-character-sanitization`
+ * rule, which trips on the classic "obfuscated tag" attack — input
+ * like `<scr<script>ipt>` collapses to `<script>` after a single
+ * regex pass. We instead consume each `<` deterministically up to its
+ * next `>`, never re-scanning the buffer, so an inner `<` becomes
+ * part of the discarded span and there is no second pass for the
+ * static analyser to worry about. Lone `<` / `>` characters that
+ * don't introduce a tag-shaped span (e.g. `Project > Beta`) are kept
+ * for the bare-bracket strip downstream so we don't over-eat plain
+ * text.
+ */
+function stripHtmlTagSpans(input: string): string {
+  let result = '';
+  let i = 0;
+  while (i < input.length) {
+    const ch = input.charCodeAt(i);
+    if (ch === 0x3C /* '<' */) {
+      const next = input.charCodeAt(i + 1);
+      const isTagStart =
+        // </tagname  or  <tagname  (a–z A–Z, optionally preceded by /)
+        (next >= 0x41 && next <= 0x5A) ||
+        (next >= 0x61 && next <= 0x7A) ||
+        next === 0x2F /* '/' */;
+      if (isTagStart) {
+        const end = input.indexOf('>', i + 1);
+        if (end === -1) {
+          // Unclosed tag: drop the rest of the input. The bare-
+          // bracket strip below clears any residual angle brackets.
+          break;
+        }
+        i = end + 1;
+        continue;
+      }
+    }
+    result += input[i];
+    i += 1;
+  }
+  return result;
+}
+
 export function sanitiseCgName(input: string): string {
   if (typeof input !== 'string') return '';
-  let v = input;
-  // CWE-20 / "incomplete multi-character sanitization": a single pass
-  // of `HTML_TAG_RE` is unsafe because a crafted input like
-  // `<scr<script>ipt>` collapses *to* `<script>` after one pass.
-  // Iterate to a fixed point so any residue is also stripped, then
-  // strip any leftover bare `<`/`>` defensively. CG names have no
-  // legitimate use for angle brackets.
-  let prev: string;
-  do {
-    prev = v;
-    v = v.replace(HTML_TAG_RE, '');
-  } while (v !== prev);
+  let v = stripHtmlTagSpans(input);
+  // Belt-and-braces: drop any residual `<` / `>` characters. Without
+  // this a payload like `< not a tag >` would survive the tag-shape
+  // scan above (since `< ` doesn't look like a tag start) and the
+  // user would still submit a name containing angle brackets.
   v = v.replace(/[<>]/g, '');
   v = v.replace(NON_WHITESPACE_CONTROL_CHARS_RE, '');
   v = v.replace(/\s+/g, ' ');
@@ -62,7 +112,10 @@ export function sanitiseCgName(input: string): string {
 export function validateCgName(input: string): string | null {
   const cleaned = sanitiseCgName(input);
   if (!cleaned) return 'Enter a name with at least one letter or digit.';
-  if (HTML_TAG_RE.test(input)) {
+  if (!SLUG_PRODUCING_RE.test(cleaned)) {
+    return 'Name must contain at least one letter or digit.';
+  }
+  if (HTML_TAG_SHAPE_RE.test(input)) {
     return 'HTML tags are not allowed in the name — they have been stripped automatically.';
   }
   if (input.length > CG_NAME_MAX_LENGTH) {

--- a/packages/node-ui/src/ui/components/Modals/cgNameValidation.ts
+++ b/packages/node-ui/src/ui/components/Modals/cgNameValidation.ts
@@ -44,11 +44,12 @@ const HTML_TAG_SHAPE_RE = /<\/?[a-z][^>]*>/i;
 // ("\nnewlines\nand\ttabs\n" would render as "newlinesandtabs").
 const NON_WHITESPACE_CONTROL_CHARS_RE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
 
-// Anything Unicode "letter or digit" — what the daemon's slugify pass
-// keeps. If the cleaned name has none of these, slugify returns "" and
-// the resulting context-graph ID would end with a stray "/", which
-// none of the downstream APIs accept.
-const SLUG_PRODUCING_RE = /[\p{L}\p{N}]/u;
+// The Create modal and CG setup helpers slugify with `/[^a-z0-9]+/g`.
+// A Unicode-only display name can survive sanitisation, but it still
+// produces an empty context-graph slug. Validate against the exact
+// ASCII slug-producing contract so the submit button never sends an id
+// ending in a stray "/".
+const SLUG_PRODUCING_RE = /[a-z0-9]/i;
 
 /**
  * Strip HTML-tag-shaped spans (`<…>`) from `input` using a manual

--- a/packages/node-ui/src/ui/components/Modals/cgNameValidation.ts
+++ b/packages/node-ui/src/ui/components/Modals/cgNameValidation.ts
@@ -40,8 +40,18 @@ const NON_WHITESPACE_CONTROL_CHARS_RE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F
 export function sanitiseCgName(input: string): string {
   if (typeof input !== 'string') return '';
   let v = input;
-  v = v.replace(HTML_TAG_RE, '');
-  v = v.replace(/<|>/g, '');
+  // CWE-20 / "incomplete multi-character sanitization": a single pass
+  // of `HTML_TAG_RE` is unsafe because a crafted input like
+  // `<scr<script>ipt>` collapses *to* `<script>` after one pass.
+  // Iterate to a fixed point so any residue is also stripped, then
+  // strip any leftover bare `<`/`>` defensively. CG names have no
+  // legitimate use for angle brackets.
+  let prev: string;
+  do {
+    prev = v;
+    v = v.replace(HTML_TAG_RE, '');
+  } while (v !== prev);
+  v = v.replace(/[<>]/g, '');
   v = v.replace(NON_WHITESPACE_CONTROL_CHARS_RE, '');
   v = v.replace(/\s+/g, ' ');
   v = v.trim();

--- a/packages/node-ui/src/ui/components/Modals/useModalDismiss.ts
+++ b/packages/node-ui/src/ui/components/Modals/useModalDismiss.ts
@@ -1,0 +1,95 @@
+import type React from 'react';
+import { useEffect, useRef, useCallback } from 'react';
+
+/**
+ * Shared modal-dismiss + a11y hook (BUG-017).
+ *
+ * The Create/Join Context Graph modals previously had no Esc handler,
+ * no explicit close (×) button, no `role="dialog"`, no focus trap, and
+ * didn't restore focus after closing — every accessibility audit
+ * dimension was missing. Some users could click the backdrop to
+ * dismiss; that left the most common keyboard-only flow (Esc-to-close)
+ * silently broken.
+ *
+ * The hook returns:
+ *   - `dialogRef` to attach to the dialog box `<div>` so we can scope
+ *     focus to its descendants.
+ *   - `onBackdropClick` to wire to the overlay's onClick (preserves the
+ *     current backdrop-to-dismiss behaviour, but keeps it isolated from
+ *     bubbling clicks inside the dialog).
+ *
+ * The hook itself:
+ *   1. Listens for `Escape` while the dialog is open.
+ *   2. Traps Tab focus inside the dialog so Tab/Shift+Tab cycle within
+ *      its focusable descendants (no escaping into the underlying app).
+ *   3. Restores focus to the previously-focused element when the
+ *      dialog closes.
+ *   4. Stamps the document with `aria-hidden` on the rest of the page —
+ *      omitted here to avoid re-implementing a portal; the role and
+ *      focus trap satisfy the WCAG 2.1 modal pattern.
+ */
+export function useModalDismiss(open: boolean, onClose: () => void) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const lastFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    lastFocusRef.current = (document.activeElement as HTMLElement | null) ?? null;
+    // Move focus into the dialog so screen readers announce the
+    // dialog's accessible name and Tab navigation is scoped.
+    queueMicrotask(() => {
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const firstFocusable = dialog.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      // Prefer the explicit `[autofocus]` element when present
+      // (matches React's autoFocus semantics for the name input).
+      const autoFocus = dialog.querySelector<HTMLElement>('[autofocus]');
+      (autoFocus ?? firstFocusable)?.focus();
+    });
+    return () => {
+      // Restore focus on close so keyboard users land back where they
+      // started instead of at <body>.
+      lastFocusRef.current?.focus?.();
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusables = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [open, onClose]);
+
+  const onBackdropClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  }, [onClose]);
+
+  return { dialogRef, onBackdropClick };
+}

--- a/packages/node-ui/src/ui/components/Shell/Header.tsx
+++ b/packages/node-ui/src/ui/components/Shell/Header.tsx
@@ -8,7 +8,7 @@ import { useTabsStore } from '../../stores/tabs.js';
 import { useNodeEvents } from '../../hooks/useNodeEvents.js';
 import { useCurrentAgent } from '../../hooks/useCurrentAgent.js';
 import { useVisibilityPolling } from '../../hooks/useVisibilityPolling.js';
-import { formatNotificationTimestamp } from '../../lib/formatTimestamp.js';
+import { compareNotificationByTsDesc, formatNotificationTimestamp } from '../../lib/formatTimestamp.js';
 
 /** OriginTrail wordmark — same paths as `v9-stable` packages/node-ui App.tsx sidebar. */
 const ORIGINTRAIL_WORDMARK = (
@@ -161,14 +161,15 @@ export function Header() {
   const statusLoaded = nodeStatus != null;
   const synced = statusLoaded && nodeStatus?.synced !== false;
   const peerStatusLabel = formatPeerStatusTooltip(synced, connectedPeers, directConns, relayedConns, uptimeMs);
-  const sortedNotifications = [...notifications].sort((a, b) => {
-    const at = a.ts ? Date.parse(a.ts as unknown as string) : 0;
-    const bt = b.ts ? Date.parse(b.ts as unknown as string) : 0;
-    return bt - at;
-  });
-  const onClear = () => {
+  const sortedNotifications = [...notifications].sort(compareNotificationByTsDesc);
+  // The /api/notifications/read endpoint flips the `read` flag on
+  // existing rows; it does not delete them. We therefore drop the
+  // unread badge but keep the dropdown contents in place — clearing
+  // local state would lie to the user and the same items would come
+  // back on the next poll.
+  const onMarkAllRead = () => {
     api.markNotificationsRead().then(() => {
-      setNotifications([]);
+      setNotifications((prev) => prev.map((n) => ({ ...n, read: 1 })));
       setUnread(0);
     }).catch(() => {});
   };
@@ -232,14 +233,14 @@ export function Header() {
             <div className="v10-header-notif-dropdown" role="region" aria-label="Notifications">
               <div className="v10-header-notif-titlebar">
                 <div className="v10-header-notif-title">Notifications</div>
-                {notifications.length > 0 && (
+                {unread > 0 && (
                   <button
                     type="button"
                     className="v10-header-notif-clear"
-                    onClick={onClear}
-                    title="Mark all as read and clear the list"
+                    onClick={onMarkAllRead}
+                    title="Mark all notifications as read"
                   >
-                    Clear all
+                    Mark all read
                   </button>
                 )}
               </div>

--- a/packages/node-ui/src/ui/components/Shell/Header.tsx
+++ b/packages/node-ui/src/ui/components/Shell/Header.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { type Notification, fetchCurrentAgent, type AgentIdentity } from '../../api.js';
+import { type Notification } from '../../api.js';
 import { api } from '../../api-wrapper.js';
 import { useLayoutStore } from '../../stores/layout.js';
 import { useAgentsStore } from '../../stores/agents.js';
 import { useProjectsStore } from '../../stores/projects.js';
 import { useTabsStore } from '../../stores/tabs.js';
 import { useNodeEvents } from '../../hooks/useNodeEvents.js';
+import { useCurrentAgent } from '../../hooks/useCurrentAgent.js';
+import { useVisibilityPolling } from '../../hooks/useVisibilityPolling.js';
+import { formatNotificationTimestamp } from '../../lib/formatTimestamp.js';
 
 /** OriginTrail wordmark — same paths as `v9-stable` packages/node-ui App.tsx sidebar. */
 const ORIGINTRAIL_WORDMARK = (
@@ -74,6 +77,38 @@ const OBSERVABILITY_ICON = (
   </svg>
 );
 
+/** Build the tooltip string surfaced on the status pill so the user can
+ *  see the direct/relayed connection breakdown and uptime without
+ *  jumping to Settings. Returns a string suitable for the `title`
+ *  attribute (newline-separated lines render as separate lines in
+ *  Chrome's tooltip). */
+export function formatPeerStatusTooltip(
+  synced: boolean,
+  peers: number,
+  direct: number,
+  relayed: number,
+  uptimeMs: number,
+): string {
+  const lines = [
+    synced ? 'Synced with the network' : 'Syncing with the network',
+    `${peers} peer${peers === 1 ? '' : 's'} (${direct} direct, ${relayed} relayed)`,
+  ];
+  if (uptimeMs > 0) lines.push(`Uptime ${formatUptimeShort(uptimeMs)}`);
+  return lines.join('\n');
+}
+
+function formatUptimeShort(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const d = Math.floor(totalSeconds / 86400);
+  const h = Math.floor((totalSeconds % 86400) / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const parts: string[] = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0 || d > 0) parts.push(`${h}h`);
+  parts.push(`${m}m`);
+  return parts.join(' ');
+}
+
 export function Header() {
   const { theme, setTheme, leftCollapsed, toggleLeft, rightCollapsed, toggleRight } = useLayoutStore();
   const nodeStatus = useAgentsStore((s) => s.nodeStatus);
@@ -81,7 +116,14 @@ export function Header() {
   const [unread, setUnread] = useState(0);
   const [showNotifs, setShowNotifs] = useState(false);
   const notifRef = useRef<HTMLDivElement>(null);
-  const [currentAgent, setCurrentAgent] = useState<AgentIdentity | null>(null);
+  // Use the deduplicating shared hook (BUG-007): every other consumer
+  // (Header, PanelRight, PanelLeft, modals, Dashboard's
+  // useMyContextGraphs) used to fire its own `fetchCurrentAgent` on
+  // mount AND poll independently. The shared hook coalesces all
+  // mounts under a single in-flight promise + 60s polling cadence,
+  // so the dashboard fan-out drops from ~14 calls in the first
+  // second to one.
+  const currentAgent = useCurrentAgent().data;
   const setActiveProject = useProjectsStore((s) => s.setActiveProject);
   const { openTab } = useTabsStore();
 
@@ -92,11 +134,7 @@ export function Header() {
     }).catch(() => {});
   }, []);
 
-  useEffect(() => {
-    loadNotifs();
-    const iv = setInterval(loadNotifs, 60_000);
-    return () => clearInterval(iv);
-  }, [loadNotifs]);
+  useVisibilityPolling(loadNotifs, 60_000);
 
   useNodeEvents(useCallback((event) => {
     if (
@@ -116,13 +154,24 @@ export function Header() {
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
-  useEffect(() => {
-    fetchCurrentAgent().then(setCurrentAgent).catch(() => {});
-  }, []);
-
   const connectedPeers = nodeStatus?.connectedPeers ?? nodeStatus?.peerCount ?? 0;
+  const directConns = nodeStatus?.connections?.direct ?? 0;
+  const relayedConns = nodeStatus?.connections?.relayed ?? 0;
+  const uptimeMs = nodeStatus?.uptimeMs ?? 0;
   const statusLoaded = nodeStatus != null;
   const synced = statusLoaded && nodeStatus?.synced !== false;
+  const peerStatusLabel = formatPeerStatusTooltip(synced, connectedPeers, directConns, relayedConns, uptimeMs);
+  const sortedNotifications = [...notifications].sort((a, b) => {
+    const at = a.ts ? Date.parse(a.ts as unknown as string) : 0;
+    const bt = b.ts ? Date.parse(b.ts as unknown as string) : 0;
+    return bt - at;
+  });
+  const onClear = () => {
+    api.markNotificationsRead().then(() => {
+      setNotifications([]);
+      setUnread(0);
+    }).catch(() => {});
+  };
 
   return (
     <header className="v10-header">
@@ -158,7 +207,7 @@ export function Header() {
 
       <div className="v10-header-spacer" />
 
-      <div className="v10-header-meta">
+      <div className="v10-header-meta" title={peerStatusLabel}>
         <span className={`v10-header-status-dot ${synced ? 'online' : 'offline'}`} />
         <span>{synced ? 'synced' : 'syncing'}</span>
         <span className="v10-header-meta-sep">·</span>
@@ -173,16 +222,30 @@ export function Header() {
               setShowNotifs((v) => !v);
               if (unread > 0) api.markNotificationsRead().then(() => setUnread(0)).catch(() => {});
             }}
+            title={unread > 0 ? `Notifications (${unread} unread)` : 'Notifications'}
+            aria-label={unread > 0 ? `Notifications, ${unread} unread` : 'Notifications'}
           >
             {BELL_ICON}
             {unread > 0 && <span className="v10-header-notif-badge">{unread}</span>}
           </button>
           {showNotifs && (
-            <div className="v10-header-notif-dropdown">
-              <div className="v10-header-notif-title">Notifications</div>
-              {notifications.length === 0 ? (
+            <div className="v10-header-notif-dropdown" role="region" aria-label="Notifications">
+              <div className="v10-header-notif-titlebar">
+                <div className="v10-header-notif-title">Notifications</div>
+                {notifications.length > 0 && (
+                  <button
+                    type="button"
+                    className="v10-header-notif-clear"
+                    onClick={onClear}
+                    title="Mark all as read and clear the list"
+                  >
+                    Clear all
+                  </button>
+                )}
+              </div>
+              {sortedNotifications.length === 0 ? (
                 <div className="v10-header-notif-empty">No notifications</div>
-              ) : notifications.slice(0, 12).map((n, i) => {
+              ) : sortedNotifications.slice(0, 12).map((n, i) => {
                 const meta = n.meta ? (() => { try { return JSON.parse(n.meta); } catch { return null; } })() : null;
                 const isJoinReq = n.type === 'join_request';
                 const isJoinApproved = n.type === 'join_approved';
@@ -205,7 +268,14 @@ export function Header() {
                     {isJoinApproved && <span className="v10-notif-join-icon">✓</span>}
                     {isJoinRejected && <span className="v10-notif-join-icon">✕</span>}
                     <div className="v10-header-notif-item-text">{n.message ?? n.title ?? 'Notification'}</div>
-                    {n.ts && <div className="v10-header-notif-item-time">{new Date(n.ts).toLocaleTimeString()}</div>}
+                    {n.ts && (
+                      <div
+                        className="v10-header-notif-item-time"
+                        title={new Date(n.ts).toLocaleString()}
+                      >
+                        {formatNotificationTimestamp(n.ts)}
+                      </div>
+                    )}
                   </div>
                 );
               })}

--- a/packages/node-ui/src/ui/components/Shell/PanelBottom.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelBottom.tsx
@@ -96,16 +96,22 @@ function NodeLogContent() {
     <div className="v10-log-container">
       <div className="v10-log-toolbar">
         <input
+          id="dkg-node-log-filter"
+          name="dkg-node-log-filter"
           type="text"
           placeholder="Filter logs..."
           className="v10-log-filter"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
+          aria-label="Filter node log lines"
         />
         <select
+          id="dkg-node-log-level"
+          name="dkg-node-log-level"
           className="v10-log-level-select"
           value={level}
           onChange={e => setLevel(e.target.value as typeof level)}
+          aria-label="Filter node log level"
         >
           <option value="all">All</option>
           <option value="error">Error</option>
@@ -116,7 +122,13 @@ function NodeLogContent() {
       </div>
       <div className="v10-log-output" ref={scrollRef}>
         {visible.map((line, i) => (
-          <div key={i} className="v10-log-line" style={{ color: LEVEL_COLORS[classifyLine(line)] }}>{line}</div>
+          <div
+            key={i}
+            className="v10-log-line"
+            style={{ color: LEVEL_COLORS[classifyLine(line)], whiteSpace: 'pre-wrap', wordBreak: 'break-word', overflowWrap: 'anywhere' }}
+          >
+            {line}
+          </div>
         ))}
         {visible.length === 0 && (
           <div className="v10-log-line" style={{ color: 'var(--text-tertiary)' }}>No log output</div>
@@ -294,16 +306,25 @@ function GossipContent() {
     <div className="v10-log-container">
       <div className="v10-log-toolbar">
         <input
+          id="dkg-gossip-log-filter"
+          name="dkg-gossip-log-filter"
           type="text"
           placeholder="Filter libp2p / gossip events..."
           className="v10-log-filter"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
+          aria-label="Filter gossip log lines"
         />
       </div>
       <div className="v10-log-output" ref={scrollRef}>
         {visible.map((line, i) => (
-          <div key={i} className="v10-log-line" style={{ color: 'var(--text-secondary)' }}>{line}</div>
+          <div
+            key={i}
+            className="v10-log-line"
+            style={{ color: 'var(--text-secondary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', overflowWrap: 'anywhere' }}
+          >
+            {line}
+          </div>
         ))}
         {visible.length === 0 && (
           <div className="v10-log-line" style={{ color: 'var(--text-tertiary)' }}>

--- a/packages/node-ui/src/ui/components/Shell/PanelBottom.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelBottom.tsx
@@ -122,13 +122,7 @@ function NodeLogContent() {
       </div>
       <div className="v10-log-output" ref={scrollRef}>
         {visible.map((line, i) => (
-          <div
-            key={i}
-            className="v10-log-line"
-            style={{ color: LEVEL_COLORS[classifyLine(line)], whiteSpace: 'pre-wrap', wordBreak: 'break-word', overflowWrap: 'anywhere' }}
-          >
-            {line}
-          </div>
+          <div key={i} className="v10-log-line" style={{ color: LEVEL_COLORS[classifyLine(line)] }}>{line}</div>
         ))}
         {visible.length === 0 && (
           <div className="v10-log-line" style={{ color: 'var(--text-tertiary)' }}>No log output</div>
@@ -318,13 +312,7 @@ function GossipContent() {
       </div>
       <div className="v10-log-output" ref={scrollRef}>
         {visible.map((line, i) => (
-          <div
-            key={i}
-            className="v10-log-line"
-            style={{ color: 'var(--text-secondary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', overflowWrap: 'anywhere' }}
-          >
-            {line}
-          </div>
+          <div key={i} className="v10-log-line" style={{ color: 'var(--text-secondary)' }}>{line}</div>
         ))}
         {visible.length === 0 && (
           <div className="v10-log-line" style={{ color: 'var(--text-tertiary)' }}>

--- a/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useId, useState } from 'react';
+import React, { useCallback, useId, useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { useLayoutStore } from '../../stores/layout.js';
 import { useTabsStore } from '../../stores/tabs.js';
@@ -8,6 +8,7 @@ import { api } from '../../api-wrapper.js';
 import { CreateProjectModal } from '../Modals/CreateProjectModal.js';
 import { JoinProjectModal } from '../Modals/JoinProjectModal.js';
 import { useNodeEvents } from '../../hooks/useNodeEvents.js';
+import { useVisibilityPolling } from '../../hooks/useVisibilityPolling.js';
 import { useHiddenContextGraphIds as useHiddenProjectIds } from '../../hooks/useHiddenContextGraphIds.js';
 import {
   fetchLocalAgentIntegrations,
@@ -93,17 +94,17 @@ function IntegrationsSectionBody() {
   const [localAgents, setLocalAgents] = useState<LocalAgentIntegration[]>([]);
   const [localAgentsError, setLocalAgentsError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    const loadLocal = () => {
-      fetchLocalAgentIntegrations()
-        .then((r) => { if (!cancelled) { setLocalAgents(r.integrations); setLocalAgentsError(null); } })
-        .catch((e: Error) => { if (!cancelled) setLocalAgentsError(e.message); });
-    };
-    loadLocal();
-    const iv = setInterval(loadLocal, 30_000);
-    return () => { cancelled = true; clearInterval(iv); };
+  // BUG-007: 30 s poll now pauses while the tab is hidden via the
+  // shared `useVisibilityPolling` hook (was a raw `setInterval` that
+  // burned 2 calls/min while the user was off-tab). The cancelled
+  // guard is no longer needed because the hook owns its own
+  // tear-down lifecycle.
+  const loadLocal = useCallback(() => {
+    fetchLocalAgentIntegrations()
+      .then((r) => { setLocalAgents(r.integrations); setLocalAgentsError(null); })
+      .catch((e: Error) => setLocalAgentsError(e.message));
   }, []);
+  useVisibilityPolling(loadLocal, 30_000);
 
   return (
     <div className="v10-tree-items" style={{ display: 'block' }}>
@@ -186,20 +187,10 @@ export function PanelLeft() {
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [setContextGraphs, setLoading]);
-
-  useEffect(() => {
-    loadCGs();
-    let timer: ReturnType<typeof setInterval> | null = null;
-    const start = () => { if (!timer) timer = setInterval(loadCGs, 60_000); };
-    const stop = () => { if (timer) { clearInterval(timer); timer = null; } };
-    const onVisibility = () => { if (document.hidden) stop(); else { loadCGs(); start(); } };
-    if (!document.hidden) start();
-    document.addEventListener('visibilitychange', onVisibility);
-    return () => {
-      stop();
-      document.removeEventListener('visibilitychange', onVisibility);
-    };
-  }, [loadCGs]);
+  // BUG-007: 60 s sidebar refresh runs through the shared
+  // visibility-aware hook so the daemon stops absorbing list calls
+  // when the tab is hidden.
+  useVisibilityPolling(loadCGs, 60_000);
 
   useNodeEvents(useCallback((event) => {
     if (event.type === 'join_approved' || event.type === 'project_synced') {

--- a/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
@@ -10,9 +10,7 @@ import { JoinProjectModal } from '../Modals/JoinProjectModal.js';
 import { useNodeEvents } from '../../hooks/useNodeEvents.js';
 import { useHiddenContextGraphIds as useHiddenProjectIds } from '../../hooks/useHiddenContextGraphIds.js';
 import {
-  fetchCurrentAgent,
   fetchLocalAgentIntegrations,
-  type AgentIdentity,
   type LocalAgentIntegration,
   type LocalAgentIntegrationStatus,
 } from '../../api.js';
@@ -22,6 +20,7 @@ import {
   toSidebarIdentity,
   type AgentSidebarIdentity,
 } from '../../lib/contextGraphSidebar.js';
+import { useCurrentAgent } from '../../hooks/useCurrentAgent.js';
 
 // Project tree row: a flat, clickable header that opens the project tab.
 // Memory-layer expansion was removed by request — layers are surfaced inside
@@ -164,7 +163,8 @@ export function PanelLeft() {
   const [treeMode, setTreeMode] = useState<TreeMode>('explorer');
 
   const { hidden: hiddenIds, hide: hideProject, unhideAll } = useHiddenProjectIds();
-  const [agentIdentity, setAgentIdentity] = useState<AgentSidebarIdentity | null>(null);
+  const sharedAgent = useCurrentAgent().data;
+  const agentIdentity: AgentSidebarIdentity | null = sharedAgent ? toSidebarIdentity(sharedAgent) : null;
 
   const visibleContextGraphs = contextGraphs.filter((cg) => !hiddenIds.has(cg.id));
   const myProjects = visibleContextGraphs.filter((cg) =>
@@ -178,7 +178,9 @@ export function PanelLeft() {
 
   const loadCGs = useCallback(() => {
     setLoading(true);
-    fetchCurrentAgent().then((a: AgentIdentity) => setAgentIdentity(toSidebarIdentity(a))).catch(() => {});
+    // Identity is now sourced from the shared `useCurrentAgent` hook
+    // — see `agentIdentity` above. This effect only refreshes the CG
+    // list, which is what the user actually expects from a poll.
     api.fetchContextGraphs()
       .then(({ contextGraphs: cgs }: any) => setContextGraphs(cgs ?? []))
       .catch(() => {})
@@ -187,8 +189,16 @@ export function PanelLeft() {
 
   useEffect(() => {
     loadCGs();
-    const iv = setInterval(loadCGs, 60_000);
-    return () => clearInterval(iv);
+    let timer: ReturnType<typeof setInterval> | null = null;
+    const start = () => { if (!timer) timer = setInterval(loadCGs, 60_000); };
+    const stop = () => { if (timer) { clearInterval(timer); timer = null; } };
+    const onVisibility = () => { if (document.hidden) stop(); else { loadCGs(); start(); } };
+    if (!document.hidden) start();
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
   }, [loadCGs]);
 
   useNodeEvents(useCallback((event) => {

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -30,6 +30,17 @@ import { ArrowDown, ArrowUp, Ban, ChevronDown, ChevronRight, Folder, Loader2, Mo
 import { Select } from '../common/Select.js';
 import { MarkdownMessage } from '../chat/MarkdownMessage.js';
 import { computeSelectableProjects, toSidebarIdentity } from '../../lib/contextGraphSidebar.js';
+import { useCurrentAgent as useSharedCurrentAgentRaw } from '../../hooks/useCurrentAgent.js';
+
+/**
+ * Shared-hook wrapper that returns just the `data` slice — the rest of
+ * `PanelRight` only needs the identity object (or null), and routing
+ * everything through the shared hook fixes the dashboard fan-out poll
+ * storm (BUG-007).
+ */
+function useSharedCurrentAgent(): AgentIdentity | null {
+  return useSharedCurrentAgentRaw().data;
+}
 
 export interface LocalAgentMessage {
   id: string;
@@ -2123,7 +2134,11 @@ export function PanelRight() {
   const [peerAgents, setPeerAgents] = useState<AgentInfo[]>([]);
   const [connections, setConnections] = useState<{ total: number; direct: number; relayed: number; rows: ConnectionRow[] }>({ total: 0, direct: 0, relayed: 0, rows: [] });
   const [peerLoading, setPeerLoading] = useState(true);
-  const [currentAgent, setCurrentAgent] = useState<AgentIdentity | null>(null);
+  // Mirror Header — use the dedup'd shared hook so the panel doesn't
+  // race-fetch its own copy of the current agent on every mount
+  // (BUG-007). The boolean `loading` flag is intentionally ignored;
+  // callers below already null-check `currentAgent`.
+  const currentAgent = useSharedCurrentAgent();
 
   const [integrations, setIntegrations] = useState<LocalAgentIntegration[]>([]);
   const [selectedIntegrationId, setSelectedIntegrationId] = useState('openclaw');
@@ -2476,15 +2491,24 @@ export function PanelRight() {
   }, []);
 
   useEffect(() => {
-    fetchCurrentAgent().then(setCurrentAgent).catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    const intervalId = setInterval(() => {
-      loadSessions();
-      refreshPeers();
-    }, 15_000);
-    return () => clearInterval(intervalId);
+    let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+    const startTimer = () => {
+      if (timer || cancelled) return;
+      timer = setInterval(() => { loadSessions(); refreshPeers(); }, 15_000);
+    };
+    const stopTimer = () => { if (timer) { clearInterval(timer); timer = null; } };
+    const onVisibility = () => {
+      if (document.hidden) stopTimer();
+      else { loadSessions(); refreshPeers(); startTimer(); }
+    };
+    if (!document.hidden) startTimer();
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      cancelled = true;
+      stopTimer();
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
   }, [loadSessions, refreshPeers]);
 
   const localIntegrationRefreshMs = integrations.some((integration) =>

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -31,6 +31,7 @@ import { Select } from '../common/Select.js';
 import { MarkdownMessage } from '../chat/MarkdownMessage.js';
 import { computeSelectableProjects, toSidebarIdentity } from '../../lib/contextGraphSidebar.js';
 import { useCurrentAgent as useSharedCurrentAgentRaw } from '../../hooks/useCurrentAgent.js';
+import { useVisibilityPolling } from '../../hooks/useVisibilityPolling.js';
 
 /**
  * Shared-hook wrapper that returns just the `data` slice — the rest of
@@ -2490,26 +2491,16 @@ export function PanelRight() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
-    let timer: ReturnType<typeof setInterval> | null = null;
-    const startTimer = () => {
-      if (timer || cancelled) return;
-      timer = setInterval(() => { loadSessions(); refreshPeers(); }, 15_000);
-    };
-    const stopTimer = () => { if (timer) { clearInterval(timer); timer = null; } };
-    const onVisibility = () => {
-      if (document.hidden) stopTimer();
-      else { loadSessions(); refreshPeers(); startTimer(); }
-    };
-    if (!document.hidden) startTimer();
-    document.addEventListener('visibilitychange', onVisibility);
-    return () => {
-      cancelled = true;
-      stopTimer();
-      document.removeEventListener('visibilitychange', onVisibility);
-    };
+  // BUG-007: sessions + peers refresh now goes through the shared
+  // visibility-aware poller (was a hand-rolled visibilitychange loop
+  // with the same intent). Skip the immediate fire-on-mount because
+  // both loadSessions and refreshPeers already ran in the mount-time
+  // effect above; otherwise we'd duplicate the network call.
+  const refreshChatPanelLive = useCallback(() => {
+    loadSessions();
+    refreshPeers();
   }, [loadSessions, refreshPeers]);
+  useVisibilityPolling(refreshChatPanelLive, 15_000, { runImmediately: false });
 
   const localIntegrationRefreshMs = integrations.some((integration) =>
     integration.persistentChat && (!integration.chatReady || integration.status === 'connecting'),

--- a/packages/node-ui/src/ui/hooks.ts
+++ b/packages/node-ui/src/ui/hooks.ts
@@ -109,7 +109,7 @@ export function formatDuration(ms: number | null | undefined): string {
  * indistinguishable. Hovering still surfaces the full date+time via
  * the caller's `title` attribute when set.
  */
-export function formatTime(ts: number | string | null | undefined, now: Date = new Date()): string {
+export function formatTime(ts: number | string | Date | null | undefined, now: Date = new Date()): string {
   if (ts == null || ts === '') return '—';
   const d = ts instanceof Date ? ts : new Date(ts);
   if (Number.isNaN(d.getTime())) return '—';

--- a/packages/node-ui/src/ui/hooks.ts
+++ b/packages/node-ui/src/ui/hooks.ts
@@ -44,12 +44,32 @@ export function useFetch<T>(
     setLoading(true);
     load();
     let timer: ReturnType<typeof setInterval> | null = null;
-    if (intervalMs > 0) {
+    const startTimer = () => {
+      if (intervalMs <= 0 || timer) return;
       timer = setInterval(load, intervalMs);
-    }
+    };
+    const stopTimer = () => {
+      if (!timer) return;
+      clearInterval(timer);
+      timer = null;
+    };
+    // Pause polling while the tab is hidden (BUG-007). On the dashboard
+    // alone, ~14 components polled `/api/wallets/balances` and friends
+    // every 10–60s independently of tab visibility — when the user
+    // switches away the daemon kept absorbing all of them. The
+    // visibility listener stops the timer when hidden and fires one
+    // immediate refresh on resume so stale data is replaced fast.
+    const onVisibility = () => {
+      if (typeof document === 'undefined') return;
+      if (document.hidden) stopTimer();
+      else { load(); startTimer(); }
+    };
+    if (typeof document === 'undefined' || !document.hidden) startTimer();
+    if (typeof document !== 'undefined') document.addEventListener('visibilitychange', onVisibility);
     return () => {
       mountedRef.current = false;
-      if (timer) clearInterval(timer);
+      stopTimer();
+      if (typeof document !== 'undefined') document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [load, intervalMs]);
 
@@ -77,9 +97,35 @@ export function formatDuration(ms: number | null | undefined): string {
 }
 
 /** Format a unix timestamp to local time string. */
-export function formatTime(ts: number | null | undefined): string {
-  if (!ts) return '—';
-  return new Date(ts).toLocaleTimeString();
+/**
+ * Render a timestamp as a date-aware short label (BUG-003).
+ *
+ * Same-day events show only `H:MM:SS` (the dense form historical
+ * callers depend on for the realtime-tailing log views), entries from
+ * earlier in the same week show `Wed 14:02`, and anything older shows
+ * `Mar 11 14:02`. The previous implementation used
+ * `toLocaleTimeString()` unconditionally, so a column showing 100 ops
+ * displayed every entry as a clock — three days vs three minutes was
+ * indistinguishable. Hovering still surfaces the full date+time via
+ * the caller's `title` attribute when set.
+ */
+export function formatTime(ts: number | string | null | undefined, now: Date = new Date()): string {
+  if (ts == null || ts === '') return '—';
+  const d = ts instanceof Date ? ts : new Date(ts);
+  if (Number.isNaN(d.getTime())) return '—';
+  if (d.toDateString() === now.toDateString()) {
+    return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  }
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (d.toDateString() === yesterday.toDateString()) {
+    return `Yesterday ${d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}`;
+  }
+  const diffMs = now.getTime() - d.getTime();
+  if (diffMs >= 0 && diffMs < 7 * 24 * 60 * 60 * 1000) {
+    return `${d.toLocaleDateString(undefined, { weekday: 'short' })} ${d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}`;
+  }
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
 }
 
 /** Shorten a UUID or peer ID. */

--- a/packages/node-ui/src/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/node-ui/src/ui/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { useLayoutStore } from '../stores/layout.js';
+
+/**
+ * Global keyboard shortcuts for the shell:
+ *
+ *   Cmd/Ctrl+B          — toggle the left sidebar
+ *   Cmd/Ctrl+Shift+B    — toggle the right agent panel
+ *   Cmd/Ctrl+J          — toggle the bottom panel
+ *
+ * BUG-005 reproducer notes:
+ *
+ *   Chrome reports `e.key` as the *uppercase* letter when Shift is
+ *   held (or Caps Lock is on), so the original lowercase comparison
+ *   silently missed `Cmd+Shift+B` and `Cmd+B`-with-Caps-Lock. We
+ *   normalise to lowercase before dispatching, and `return` after
+ *   each branch so the shift-modified path can't double-fire the
+ *   non-shift branches on the same event.
+ *
+ *   Form fields are skipped entirely so users can still type the
+ *   letter `B` / `J` into inputs without the sidebar flapping.
+ */
+export function useKeyboardShortcuts(): void {
+  const { toggleLeft, toggleRight, toggleBottom } = useLayoutStore();
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+      const k = e.key.toLowerCase();
+      if (e.shiftKey && k === 'b') { e.preventDefault(); toggleRight(); return; }
+      if (e.shiftKey) return;
+      if (k === 'b') { e.preventDefault(); toggleLeft(); return; }
+      if (k === 'j') { e.preventDefault(); toggleBottom(); return; }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [toggleLeft, toggleRight, toggleBottom]);
+}

--- a/packages/node-ui/src/ui/hooks/useShellRouting.ts
+++ b/packages/node-ui/src/ui/hooks/useShellRouting.ts
@@ -1,0 +1,66 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useTabsStore } from '../stores/tabs.js';
+
+// Map between deep-link URL paths and centre-tab IDs. Keeping this here
+// (rather than inside `useTabsStore`) lets the route layer stay a thin
+// adapter — the store is still the source of truth for which tabs are
+// open, but a fresh navigation to e.g. `/observability` opens that tab on
+// mount and clicking the tab pushes the corresponding URL.
+export const URL_PATH_TO_TAB: Record<string, { id: string; label: string }> = {
+  '/observability': { id: 'operations', label: 'Observability' },
+  '/operations': { id: 'operations', label: 'Observability' },
+  '/settings': { id: 'settings', label: 'Settings' },
+};
+export const TAB_TO_URL_PATH: Record<string, string> = {
+  operations: '/observability',
+  settings: '/settings',
+  dashboard: '/',
+};
+
+/**
+ * Two-way sync between the address bar and the centre-tab id (BUG-018).
+ *
+ *   Step 1: a deep-link landing on `/observability` / `/settings` opens
+ *           the matching centre tab. Keyed on `pathname` so browser
+ *           back/forward also re-opens the corresponding tab.
+ *
+ *   Step 2: when the user clicks a deep-linkable tab the URL syncs to
+ *           the mapped path so a refresh / bookmark / back+forward
+ *           restores the same view. When the active tab is NOT
+ *           deep-linkable (project:…, context-graph-primer, etc.)
+ *           but the URL is still showing one of the deep-link paths,
+ *           reset to `/` so a refresh doesn't ping-pong the user back
+ *           into the old tab. Other routes (/network, /context-graph-
+ *           primer) aren't in the mapping table, so they stay
+ *           untouched.
+ *
+ * We intentionally do NOT force-switch the active tab to the dashboard
+ * at `/`: other routes (e.g. the Context-Graph primer) redirect to `/`
+ * after opening their own tab, and stomping the active tab here would
+ * ping-pong the user back to the dashboard mid-flow.
+ */
+export function useShellRouting(): void {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const openTab = useTabsStore((s) => s.openTab);
+  const activeTabId = useTabsStore((s) => s.activeTabId);
+
+  useEffect(() => {
+    const match = URL_PATH_TO_TAB[pathname];
+    if (match) {
+      openTab({ id: match.id, label: match.label, closable: true });
+    }
+  }, [pathname, openTab]);
+
+  useEffect(() => {
+    const target = TAB_TO_URL_PATH[activeTabId];
+    if (target) {
+      if (target !== pathname) navigate(target, { replace: true });
+      return;
+    }
+    if (URL_PATH_TO_TAB[pathname]) {
+      navigate('/', { replace: true });
+    }
+  }, [activeTabId, pathname, navigate]);
+}

--- a/packages/node-ui/src/ui/hooks/useVisibilityPolling.ts
+++ b/packages/node-ui/src/ui/hooks/useVisibilityPolling.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Like `setInterval(callback, intervalMs)` but pauses while the tab is
+ * hidden (BUG-007). The dashboard previously fired ~75 fetch calls per
+ * minute on idle — most components had their own `setInterval(...,
+ * 5_000)` polling the same `/api/status` and `/api/wallets/balances`
+ * endpoints, and none of them paused when the user switched away.
+ *
+ * The hook accepts a `runImmediately` flag because most callers want
+ * an initial fetch on mount; subsequent ticks are deferred whenever
+ * `document.hidden` becomes true and resume (with one immediate tick
+ * to refresh stale data) the moment the tab regains focus.
+ *
+ * Returns nothing; cleanup is automatic on unmount.
+ */
+export function useVisibilityPolling(
+  callback: () => void,
+  intervalMs: number,
+  options: { runImmediately?: boolean } = {},
+): void {
+  const cbRef = useRef(callback);
+  cbRef.current = callback;
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    if (intervalMs <= 0) return undefined;
+    let timer: ReturnType<typeof setInterval> | null = null;
+    let cancelled = false;
+
+    const start = () => {
+      if (timer || cancelled) return;
+      timer = setInterval(() => cbRef.current(), intervalMs);
+    };
+    const stop = () => {
+      if (!timer) return;
+      clearInterval(timer);
+      timer = null;
+    };
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        stop();
+        return;
+      }
+      // Becoming visible: refresh once so stale UI snaps to current,
+      // then resume the cadence.
+      cbRef.current();
+      start();
+    };
+
+    if (optionsRef.current.runImmediately !== false) cbRef.current();
+    if (!document.hidden) start();
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', onVisibility);
+      stop();
+    };
+  }, [intervalMs]);
+}

--- a/packages/node-ui/src/ui/lib/formatEth.ts
+++ b/packages/node-ui/src/ui/lib/formatEth.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared formatter for the native gas-token (ETH/xDAI/NEURO) balance
+ * shown across the UI. Settings has historically rounded to 6 fractional
+ * digits via `parseFloat(x).toFixed(6)`, while the Dashboard wallet card
+ * dumped the raw value at full 17-digit precision (BUG-006/009). Routing
+ * both consumers through this helper keeps the rendering consistent and
+ * gives us one place to evolve the format.
+ *
+ * @param value Raw balance from `/api/wallets/balances`. Accepts string
+ *              ("0.04058352…") or number; null/undefined renders "—".
+ * @param digits Maximum fractional digits to display. Defaults to 6 —
+ *               enough precision to act on a tiny gas balance (microETH
+ *               level) without spilling beyond what JS Number can
+ *               represent (~15 significant digits).
+ */
+export function formatEth(value: unknown, digits = 6): string {
+  if (value == null || value === '') return '—';
+  const n = typeof value === 'number' ? value : parseFloat(String(value));
+  if (!Number.isFinite(n)) return '—';
+  if (n === 0) return '0';
+  const fixed = n.toFixed(digits);
+  // Trim trailing zeros and a stray decimal point so "0.040000" → "0.04"
+  // but keep at least one digit after the decimal so "0" doesn't read as
+  // an int when the underlying value is non-zero (e.g. 0.0000004 → "0").
+  const trimmed = fixed.replace(/\.?0+$/, '');
+  if (n > 0 && Number(trimmed) === 0) {
+    // Below the rounding threshold — surface a `< 1e-6` style hint so
+    // the user knows it isn't literally zero.
+    return `< ${1 / Math.pow(10, digits)}`;
+  }
+  return trimmed;
+}
+
+/**
+ * Build a `title` tooltip string for the formatted balance. The
+ * Dashboard wallet card is now compact (formatEth output), so the user
+ * needs a way to see the underlying full-precision value when they care.
+ * Mirrors how the Settings page already exposes the address tooltip.
+ */
+export function formatEthTooltip(value: unknown): string | undefined {
+  if (value == null || value === '') return undefined;
+  return `Exact balance: ${value} (full precision from chain)`;
+}

--- a/packages/node-ui/src/ui/lib/formatTimestamp.ts
+++ b/packages/node-ui/src/ui/lib/formatTimestamp.ts
@@ -1,0 +1,44 @@
+/**
+ * Render a timestamp with date awareness so old entries are
+ * unmistakable from fresh ones (BUG-003).
+ *
+ * - Same-day: "3:57 PM" (compact, the dropdown's intended form).
+ * - Yesterday: "Yesterday 8:12 PM" — sub-24h-but-not-same-day
+ *   should still be unambiguous.
+ * - Earlier same week: "Mon 9:14 AM".
+ * - Older: "Mar 11, 2026, 9:00 AM".
+ *
+ * Deliberately a separate module so Vitest can import the helper
+ * without booting Header.tsx (which depends on `localStorage` at
+ * module init via the layout store and therefore can't be loaded
+ * inside node-test environments).
+ */
+export function formatNotificationTimestamp(
+  ts: string | number | Date | undefined,
+  now: Date = new Date(),
+): string {
+  if (ts == null || ts === '') return '';
+  const d = ts instanceof Date ? ts : new Date(ts);
+  if (Number.isNaN(d.getTime())) return '';
+  const sameDay = d.toDateString() === now.toDateString();
+  if (sameDay) {
+    return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  }
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (d.toDateString() === yesterday.toDateString()) {
+    return `Yesterday ${d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}`;
+  }
+  const diffMs = now.getTime() - d.getTime();
+  if (diffMs >= 0 && diffMs < 7 * 24 * 60 * 60 * 1000) {
+    const weekday = d.toLocaleDateString(undefined, { weekday: 'short' });
+    return `${weekday} ${d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}`;
+  }
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}

--- a/packages/node-ui/src/ui/lib/formatTimestamp.ts
+++ b/packages/node-ui/src/ui/lib/formatTimestamp.ts
@@ -42,3 +42,27 @@ export function formatNotificationTimestamp(
     minute: '2-digit',
   });
 }
+
+/**
+ * Comparator for sorting notification-shaped objects newest-first.
+ *
+ * `Notification.ts` is a unix-epoch number (see `api.ts`). The naive
+ * comparator
+ *
+ *   (a, b) => Date.parse(String(a.ts)) - Date.parse(String(b.ts))
+ *
+ * silently breaks because `Date.parse('1716732000000')` is `NaN`,
+ * which makes the comparator return `NaN` for every pair and leaves
+ * the dropdown unsorted. We therefore compare the numeric values
+ * directly, falling back to 0 for missing/non-finite/non-numeric
+ * timestamps so a stray `null` doesn't push the entire list to
+ * the top.
+ */
+export function compareNotificationByTsDesc(
+  a: { ts?: number | null },
+  b: { ts?: number | null },
+): number {
+  const at = typeof a.ts === 'number' && Number.isFinite(a.ts) ? a.ts : 0;
+  const bt = typeof b.ts === 'number' && Number.isFinite(b.ts) ? b.ts : 0;
+  return bt - at;
+}

--- a/packages/node-ui/src/ui/lib/formatTrac.ts
+++ b/packages/node-ui/src/ui/lib/formatTrac.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalise the TRAC token symbol surfaced in wallet rows so the
+ * Dashboard and Settings pages agree (BUG-013). The daemon reports
+ * `b.symbol` straight from the on-chain ERC-20: on Base Sepolia it's
+ * `v9TRAC` (the legacy v9 testnet contract), and on Base mainnet it's
+ * `TRAC`. Without normalisation, Settings shows `v9TRAC` while the
+ * Dashboard column header shows `TRAC` for the same balance — the user
+ * can't tell whether they're looking at one token or two.
+ *
+ * The chosen rendering keeps the on-chain identity visible (so users
+ * see the v9 prefix on Base Sepolia and know they're on the legacy
+ * contract) but appends a "(testnet)" qualifier so it's obvious the
+ * token isn't the production TRAC.
+ */
+export function formatTracSymbol(symbol: string | null | undefined, chainId: string | null | undefined): string {
+  const sym = (symbol ?? '').trim();
+  if (!sym) return 'TRAC';
+  const id = (chainId ?? '').includes(':') ? (chainId ?? '').split(':')[1] : (chainId ?? '');
+  const isTestnet = id === '84532' || id === '11155111' || id === '31337' || id === '10200' || id === '20430';
+  if (isTestnet) {
+    if (/test/i.test(sym)) return sym;
+    return `${sym} (testnet)`;
+  }
+  return sym;
+}

--- a/packages/node-ui/src/ui/lib/redactRpcUrl.ts
+++ b/packages/node-ui/src/ui/lib/redactRpcUrl.ts
@@ -28,6 +28,14 @@ export function redactRpcUrl(rpc: string | null | undefined): string {
   // turn a friendly `••••••••` into `%E2%80%A2…` and defeat the point
   // of the redaction.
   const MASK = '************';
+  // Some operators paste RPC URLs with HTTP basic auth baked in
+  // (`https://user:pass@host/path`). Strip the credentials entirely —
+  // a partial mask isn't enough for a screen-share leak class because
+  // the username already identifies the tenant in many setups.
+  if (parsed.password) {
+    parsed.password = '';
+    parsed.username = '';
+  }
   const segments = parsed.pathname.split('/').map((seg) => {
     if (seg.length < 16) return seg;
     if (/^[A-Za-z0-9_-]+$/.test(seg)) return MASK;

--- a/packages/node-ui/src/ui/lib/redactRpcUrl.ts
+++ b/packages/node-ui/src/ui/lib/redactRpcUrl.ts
@@ -29,12 +29,14 @@ export function redactRpcUrl(rpc: string | null | undefined): string {
   // of the redaction.
   const MASK = '************';
   // Some operators paste RPC URLs with HTTP basic auth baked in
-  // (`https://user:pass@host/path`). Strip the credentials entirely —
-  // a partial mask isn't enough for a screen-share leak class because
-  // the username already identifies the tenant in many setups.
-  if (parsed.password) {
-    parsed.password = '';
+  // (`https://user:pass@host/path` or `https://tenantonly@host/path`).
+  // Strip BOTH userinfo fields whenever EITHER is present — the
+  // username alone identifies the tenant on many providers (e.g.
+  // `tenantId@rpc.example.com`) and is just as much of a screen-share
+  // leak as the password.
+  if (parsed.username || parsed.password) {
     parsed.username = '';
+    parsed.password = '';
   }
   const segments = parsed.pathname.split('/').map((seg) => {
     if (seg.length < 16) return seg;

--- a/packages/node-ui/src/ui/lib/redactRpcUrl.ts
+++ b/packages/node-ui/src/ui/lib/redactRpcUrl.ts
@@ -1,0 +1,45 @@
+/**
+ * Mask the trailing path-token segment of a third-party RPC URL so
+ * screenshots / screen-shares don't leak the tenant secret (BUG-012).
+ *
+ * QuickNode, Infura, Alchemy, etc. all use a per-tenant token at the
+ * end of the path:
+ *   https://greatest-greatest-sound.base-sepolia.quiknode.pro/664a23a04122d3fa485778b9141bc92e17293c73/
+ *   https://mainnet.infura.io/v3/abcdef0123456789...
+ *   https://eth-mainnet.alchemyapi.io/v2/abcdef0123456789...
+ *
+ * Anyone with that URL can call the endpoint, billed to the tenant.
+ * We keep the host intact (useful for diagnostics — operators need to
+ * know which provider they're talking to) and redact every "secret-
+ * shaped" path segment. A segment is treated as a secret if it's
+ * length-≥16 and consists of hex/base64-ish characters.
+ */
+export function redactRpcUrl(rpc: string | null | undefined): string {
+  if (!rpc) return '';
+  let parsed: URL;
+  try {
+    parsed = new URL(rpc);
+  } catch {
+    // Not a valid URL — at minimum, mask anything that looks tokenish.
+    return rpc.replace(/[a-f0-9]{16,}/gi, (m) => '*'.repeat(Math.min(m.length, 12)));
+  }
+  // Use ASCII bullet `*` for masking — `URL` percent-encodes any
+  // non-ASCII character we put back into pathname/search, which would
+  // turn a friendly `••••••••` into `%E2%80%A2…` and defeat the point
+  // of the redaction.
+  const MASK = '************';
+  const segments = parsed.pathname.split('/').map((seg) => {
+    if (seg.length < 16) return seg;
+    if (/^[A-Za-z0-9_-]+$/.test(seg)) return MASK;
+    return seg;
+  });
+  parsed.pathname = segments.join('/');
+  if (parsed.search) {
+    const params = new URLSearchParams(parsed.search);
+    for (const key of Array.from(params.keys())) {
+      if (/key|token|secret|auth/i.test(key)) params.set(key, MASK);
+    }
+    parsed.search = params.toString();
+  }
+  return parsed.toString();
+}

--- a/packages/node-ui/src/ui/pages/Operations.tsx
+++ b/packages/node-ui/src/ui/pages/Operations.tsx
@@ -879,7 +879,7 @@ function OperationsTab() {
                   onClick={() => setSelectedOp(op.operation_id)}
                   style={{ cursor: 'pointer', background: selectedOp === op.operation_id ? 'rgba(59,130,246,.1)' : undefined }}
                 >
-                  <td>{formatTime(op.started_at)}</td>
+                  <td title={op.started_at ? new Date(op.started_at).toLocaleString() : undefined}>{formatTime(op.started_at)}</td>
                   <td><span className="badge" title={OP_TYPE_DESCRIPTIONS[op.operation_name] ?? ''} style={{ background: `${OP_TYPE_COLORS[op.operation_name] ?? 'var(--text-muted)'}22`, color: OP_TYPE_COLORS[op.operation_name] ?? 'var(--text-muted)' }}>{op.operation_name}</span></td>
                   <td><StatusBadge status={op.status} /></td>
                   <td><MiniGantt phases={op.phases} totalMs={op.duration_ms} /></td>
@@ -1145,8 +1145,11 @@ function OperationDetail({ op, logs, phases, explorerUrl, onBack }: {
                     <StatusBadge status={p.status} />
                     <span style={{ fontSize: 11, color: 'var(--text-dim)', fontFamily: "'JetBrains Mono', monospace" }}>{formatDuration(p.duration_ms)}</span>
                     {desc && <span style={{ fontSize: 10, color: 'var(--text-dim)', fontStyle: 'italic', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{desc}</span>}
-                    <span style={{ fontSize: 10, color: 'var(--text-dim)', marginLeft: 'auto', flexShrink: 0 }}>
-                      {p.started_at ? new Date(p.started_at).toLocaleTimeString() : ''}
+                    <span
+                      style={{ fontSize: 10, color: 'var(--text-dim)', marginLeft: 'auto', flexShrink: 0 }}
+                      title={p.started_at ? new Date(p.started_at).toLocaleString() : undefined}
+                    >
+                      {p.started_at ? formatTime(p.started_at) : ''}
                     </span>
                     {p.status === 'error' && p.details && (
                       <span style={{ fontSize: 10, color: 'var(--red)', maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={p.details}>

--- a/packages/node-ui/src/ui/pages/Settings.tsx
+++ b/packages/node-ui/src/ui/pages/Settings.tsx
@@ -713,6 +713,26 @@ function CatchupStatusSection() {
           Hide system CGs
         </label>
       </div>
+      {/* If the user filters such that the previously-selected CG is
+          no longer in the visible list, the status panel below still
+          shows that CG's data — which is confusing. Surface a small
+          hint with a one-click "show full list" reset so the user
+          isn't left wondering why their search returned nothing. */}
+      {selectedContextGraph &&
+       filteredContextGraphs.length > 0 &&
+       !filteredContextGraphs.some((p: any) => p.id === selectedContextGraph) && (
+        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 8 }}>
+          Selection hidden by current filter.{' '}
+          <button
+            type="button"
+            onClick={() => { setFilterText(''); setShowOnlyMine(false); }}
+            className="btn btn-ghost btn-xs"
+            style={{ padding: '0 6px' }}
+          >
+            Clear filter
+          </button>
+        </div>
+      )}
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 12 }}>
         <select
           id="dkg-bg-sync-graph"

--- a/packages/node-ui/src/ui/pages/Settings.tsx
+++ b/packages/node-ui/src/ui/pages/Settings.tsx
@@ -17,6 +17,9 @@ import {
   type CatchupStatusResponse,
 } from '../api.js';
 import { ObservabilitySection } from './Operations.js';
+import { formatEth, formatEthTooltip } from '../lib/formatEth.js';
+import { formatTracSymbol } from '../lib/formatTrac.js';
+import { redactRpcUrl } from '../lib/redactRpcUrl.js';
 
 function Field({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
   return (
@@ -27,31 +30,84 @@ function Field({ label, value, mono = false }: { label: string; value: string; m
   );
 }
 
-function Toggle({ label, desc, on, disabled }: { label: string; desc: string; on: boolean; disabled?: boolean }) {
+function Toggle({ label, desc, on, disabled, disabledReason }: { label: string; desc: string; on: boolean; disabled?: boolean; disabledReason?: string }) {
   const [active, setActive] = useState(on);
   useEffect(() => { setActive(on); }, [on]);
+  // Visual contrast fix (BUG-010): disabled toggles previously rendered
+  // at opacity 0.5 with the green "on" track. At a glance that looks
+  // identical to a real enabled control, especially the white knob
+  // which still pops against the green pill. Push opacity lower, swap
+  // the track to a neutral colour even when `on=true`, and grey out the
+  // knob so the user sees "this is read-only".
+  const visuallyDisabled = !!disabled;
+  const trackBg = visuallyDisabled
+    ? 'var(--border)'
+    : (active ? 'var(--green)' : 'var(--border)');
+  const knobBg = visuallyDisabled ? 'var(--text-dim)' : '#fff';
   return (
-    <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', padding: '10px 0', borderBottom: '1px solid var(--border)', opacity: disabled ? 0.5 : 1 }}>
+    <div
+      style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', padding: '10px 0', borderBottom: '1px solid var(--border)', opacity: visuallyDisabled ? 0.45 : 1 }}
+      title={visuallyDisabled ? (disabledReason ?? 'Read-only — managed via configuration file') : undefined}
+    >
       <div>
-        <div style={{ fontSize: 12, fontWeight: 600 }}>{label}</div>
+        <div style={{ fontSize: 12, fontWeight: 600 }}>
+          {label}
+          {visuallyDisabled && (
+            <span
+              style={{ marginLeft: 8, padding: '1px 6px', borderRadius: 4, fontSize: 10, fontWeight: 600, color: 'var(--text-dim)', background: 'var(--border)', textTransform: 'uppercase', letterSpacing: '.04em' }}
+              aria-label="Read-only"
+            >
+              read-only
+            </span>
+          )}
+        </div>
         <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 2, lineHeight: 1.5 }}>{desc}</div>
       </div>
       <button
-        onClick={() => !disabled && setActive(a => !a)}
-        disabled={disabled}
+        type="button"
+        onClick={() => !visuallyDisabled && setActive(a => !a)}
+        disabled={visuallyDisabled}
+        aria-disabled={visuallyDisabled}
+        aria-label={`${label} (read-only, currently ${on ? 'enabled' : 'disabled'})`}
         style={{
           width: 38, height: 22, borderRadius: 11, border: 'none', flexShrink: 0,
-          background: active ? 'var(--green)' : 'var(--border)',
+          background: trackBg,
           transition: 'background .2s', position: 'relative', marginLeft: 16,
-          cursor: disabled ? 'not-allowed' : 'pointer',
+          cursor: visuallyDisabled ? 'not-allowed' : 'pointer',
         }}
       >
         <span style={{
           position: 'absolute', top: 3, left: active ? 19 : 3,
-          width: 16, height: 16, borderRadius: '50%', background: '#fff',
+          width: 16, height: 16, borderRadius: '50%', background: knobBg,
           transition: 'left .2s', display: 'block',
         }} />
       </button>
+    </div>
+  );
+}
+
+function RpcUrlField({ rpcUrl }: { rpcUrl: string }) {
+  const [reveal, setReveal] = useState(false);
+  // Always redact on first render — operators frequently screen-share
+  // Settings without realising the path-token segment is a tenant
+  // secret (BUG-012). Exposing the full URL requires an explicit click,
+  // and we never persist that choice across renders.
+  const display = reveal ? rpcUrl : redactRpcUrl(rpcUrl);
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <div className="prov-field-label" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span>RPC</span>
+        <button
+          type="button"
+          onClick={() => setReveal((v) => !v)}
+          style={{ background: 'none', border: '1px solid var(--border)', color: 'var(--text-dim)', cursor: 'pointer', fontSize: 9, fontWeight: 600, padding: '1px 6px', borderRadius: 4 }}
+          aria-label={reveal ? 'Redact RPC URL' : 'Reveal RPC URL'}
+          title={reveal ? 'Hide the path-token (recommended for screen-shares)' : 'Show full URL — careful, may contain a tenant secret'}
+        >
+          {reveal ? 'Redact' : 'Reveal'}
+        </button>
+      </div>
+      <div className="prov-field-value mono" style={{ wordBreak: 'break-all' }}>{display}</div>
     </div>
   );
 }
@@ -135,38 +191,58 @@ function LlmSection() {
         <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', display: 'block', marginBottom: 5 }}>API Key</label>
         <div style={{ position: 'relative' }}>
           <input
+            id="dkg-llm-api-key"
+            name="dkg-llm-api-key"
             type={showKey ? 'text' : 'password'}
             value={apiKey}
             onChange={e => setApiKey(e.target.value)}
             placeholder={llm?.configured ? '••••••••  (key saved — paste new to replace)' : 'sk-...'}
             style={inputStyle}
+            aria-label="LLM API key"
+            autoComplete="off"
+            spellCheck={false}
           />
-          <button
-            onClick={() => setShowKey(v => !v)}
-            style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', color: 'var(--text-dim)', cursor: 'pointer', fontSize: 10, fontWeight: 600 }}
-          >
-            {showKey ? 'Hide' : 'Show'}
-          </button>
+          {/* Show/Hide toggles `type=password` ↔ `type=text` for the
+              currently typed value. The saved key never leaves the
+              daemon (placeholder is just a hint), so revealing an empty
+              input is a no-op visual lie — hide the button when the
+              field is empty (BUG-015). */}
+          {apiKey.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowKey(v => !v)}
+              style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', color: 'var(--text-dim)', cursor: 'pointer', fontSize: 10, fontWeight: 600 }}
+              aria-label={showKey ? 'Hide API key' : 'Show API key'}
+            >
+              {showKey ? 'Hide' : 'Show'}
+            </button>
+          )}
         </div>
       </div>
 
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 16 }}>
         <div>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', display: 'block', marginBottom: 5 }}>Model</label>
+          <label htmlFor="dkg-llm-model" style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', display: 'block', marginBottom: 5 }}>Model</label>
           <input
+            id="dkg-llm-model"
+            name="dkg-llm-model"
             value={model}
             onChange={e => setModel(e.target.value)}
             placeholder="gpt-4o-mini"
             style={inputStyle}
+            aria-label="LLM model"
           />
         </div>
         <div>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', display: 'block', marginBottom: 5 }}>Base URL</label>
+          <label htmlFor="dkg-llm-base-url" style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', display: 'block', marginBottom: 5 }}>Base URL</label>
           <input
+            id="dkg-llm-base-url"
+            name="dkg-llm-base-url"
             value={baseURL}
             onChange={e => setBaseURL(e.target.value)}
             placeholder="https://api.openai.com/v1"
             style={inputStyle}
+            aria-label="LLM base URL"
           />
         </div>
       </div>
@@ -515,7 +591,11 @@ function DevModeToggle() {
         <div>
           <div style={{ fontSize: 12, fontWeight: 600 }}>Developer Mode</div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 2, lineHeight: 1.5 }}>
-            Unlock the Observability tab on this page with detailed metrics, phase timelines, system stats, and the full daemon log.
+            Reveal advanced developer affordances: the per-operation phase
+            timeline drill-down, raw structured-log viewer, and a verbose
+            daemon log surface inside Observability. The Observability
+            tab itself is now always visible — Developer Mode unlocks the
+            deep-dive views inside it.
           </div>
         </div>
         <button
@@ -554,6 +634,19 @@ function CatchupStatusSection() {
   const { data: contextGraphData } = useFetch(fetchContextGraphs, [], 30_000);
   const contextGraphs = ((contextGraphData as any)?.contextGraphs ?? []).filter((p: any) => p?.id);
   const [selectedContextGraph, setSelectedContextGraph] = useState('');
+  // 200+ context-graph IDs in a `<select>` is an unusable wall of
+  // entries (BUG-014). We expose a `<datalist>` paired with an `<input
+  // type="search">` so the user can type any substring and pick from a
+  // filtered list — the browser handles the filtering, no extra
+  // JS-side state.
+  const [filterText, setFilterText] = useState('');
+  const [showOnlyMine, setShowOnlyMine] = useState(false);
+  const filteredContextGraphs = contextGraphs.filter((p: any) => {
+    if (showOnlyMine && p.isSystem) return false;
+    if (!filterText) return true;
+    const q = filterText.toLowerCase();
+    return String(p.id).toLowerCase().includes(q) || String(p.name ?? '').toLowerCase().includes(q);
+  });
 
   useEffect(() => {
     if (selectedContextGraph) return;
@@ -598,15 +691,41 @@ function CatchupStatusSection() {
         Shows the latest catch-up job for the selected context graph (triggered by subscribe).
       </div>
 
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8, flexWrap: 'wrap' }}>
+        <input
+          id="dkg-bg-sync-filter"
+          name="dkg-bg-sync-filter"
+          type="search"
+          className="input"
+          style={{ flex: '2 1 200px' }}
+          placeholder={`Filter ${contextGraphs.length} context graph${contextGraphs.length === 1 ? '' : 's'}…`}
+          value={filterText}
+          onChange={(e) => setFilterText(e.target.value)}
+          aria-label="Filter context graphs"
+        />
+        <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--text-muted)', cursor: 'pointer', whiteSpace: 'nowrap' }}>
+          <input
+            type="checkbox"
+            checked={showOnlyMine}
+            onChange={(e) => setShowOnlyMine(e.target.checked)}
+            aria-label="Hide system context graphs"
+          />
+          Hide system CGs
+        </label>
+      </div>
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 12 }}>
         <select
+          id="dkg-bg-sync-graph"
+          name="dkg-bg-sync-graph"
           className="input"
           style={{ flex: 1, backgroundImage: 'none', paddingRight: 12 }}
           value={selectedContextGraph}
           onChange={(e) => setSelectedContextGraph(e.target.value)}
+          size={Math.min(8, Math.max(1, filteredContextGraphs.length))}
+          aria-label="Context graph"
         >
-          {contextGraphs.length === 0 && <option value="">No context graphs available</option>}
-          {contextGraphs.map((p: any) => (
+          {filteredContextGraphs.length === 0 && <option value="">{contextGraphs.length === 0 ? 'No context graphs available' : 'No matches'}</option>}
+          {filteredContextGraphs.map((p: any) => (
             <option key={p.id} value={p.id}>{p.id}{p.isSystem ? ' (system)' : ''}</option>
           ))}
         </select>
@@ -754,9 +873,12 @@ function GeneralSettingsTab() {
           <div className="mono" style={{ fontSize: 10, color: isOnline ? 'var(--green)' : 'var(--red)', fontWeight: 700 }}>
             {isOnline ? '● ONLINE' : '● OFFLINE'}
           </div>
-          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 4 }}>
+          <div
+            style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 4 }}
+            title="Peers = unique remote nodes. Direct + Relayed counts are libp2p connections — a single peer can hold both a direct and a relayed link, so they sum to ≥ Peers, not exactly equal to it."
+          >
             {isOnline
-              ? `${peerCount} peer${peerCount !== 1 ? 's' : ''} · ${s?.connections?.direct ?? 0} direct, ${s?.connections?.relayed ?? 0} relayed · up ${formatUptime(s?.uptimeMs ?? 0)}`
+              ? `${peerCount} peer${peerCount !== 1 ? 's' : ''} · ${s?.connections?.direct ?? 0} direct, ${s?.connections?.relayed ?? 0} relayed link${(s?.connections?.relayed ?? 0) === 1 ? '' : 's'} · up ${formatUptime(s?.uptimeMs ?? 0)}`
               : 'Node is not responding'}
           </div>
         </div>
@@ -771,8 +893,16 @@ function GeneralSettingsTab() {
             <div key={b.address} style={{ marginBottom: 10 }}>
               <Field label={w.balances.length > 1 ? `Wallet ${i + 1}` : 'Operational Wallet'} value={b.address} mono />
               <div style={{ display: 'flex', gap: 16, marginTop: -6 }}>
-                <span className="mono" style={{ fontSize: 11, color: 'var(--text-muted)' }}>{parseFloat(b.eth).toFixed(6)} ETH</span>
-                <span className="mono" style={{ fontSize: 11, color: 'var(--text-muted)' }}>{parseFloat(b.trac).toFixed(2)} {b.symbol}</span>
+                <span
+                  className="mono"
+                  style={{ fontSize: 11, color: 'var(--text-muted)' }}
+                  title={formatEthTooltip(b.eth)}
+                >
+                  {formatEth(b.eth)} ETH
+                </span>
+                <span className="mono" style={{ fontSize: 11, color: 'var(--text-muted)' }} title={`Exact: ${b.trac}`}>
+                  {parseFloat(b.trac).toFixed(2)} {formatTracSymbol(b.symbol, w?.chainId)}
+                </span>
               </div>
             </div>
           ))
@@ -780,7 +910,7 @@ function GeneralSettingsTab() {
           <Field label="Operational Wallet" value={w?.wallets?.[0] ? truncateAddress(w.wallets[0]) : '—'} mono />
         )}
         {w?.rpcUrl && (
-          <Field label="RPC" value={w.rpcUrl} mono />
+          <RpcUrlField rpcUrl={w.rpcUrl} />
         )}
         {w?.error ? (
           <div style={{ padding: '8px 12px', borderRadius: 8, background: 'rgba(248,113,113,.05)', border: '1px solid rgba(248,113,113,.2)' }}>
@@ -808,10 +938,22 @@ function GeneralSettingsTab() {
       <div className="settings-card">
         <div className="settings-title">Privacy & Memory</div>
         <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 12, lineHeight: 1.5 }}>
-          These settings are not yet configurable via the UI. Edit <span className="mono" style={{ fontSize: 10 }}>~/.dkg/config.json</span> directly.
+          These settings are configured at startup. Edit <span className="mono" style={{ fontSize: 10 }}>~/.dkg/config.json</span> and restart the node to change them.
         </div>
-        <Toggle label="Publish by Default" desc="Automatically push new Knowledge Assets to the DKG upon creation." on={true} disabled />
-        <Toggle label="Analytics" desc="Share anonymous usage stats to help improve DKG V10." on={false} disabled />
+        <Toggle
+          label="Publish by Default"
+          desc="Automatically push new Knowledge Assets to the DKG upon creation."
+          on={true}
+          disabled
+          disabledReason="Set via config.publishByDefault in ~/.dkg/config.json"
+        />
+        <Toggle
+          label="Analytics"
+          desc="Share anonymous usage stats to help improve DKG V10."
+          on={false}
+          disabled
+          disabledReason="Set via config.telemetry in ~/.dkg/config.json"
+        />
       </div>
 
       {/* Danger zone */}

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -96,7 +96,13 @@
 /* ══════════════════════════════════════════
    LIGHT THEME
    ══════════════════════════════════════════ */
-body.light {
+/* BUG-004: the variable overrides have to apply at the html element
+   level too, otherwise the `html { background: var(--bg-root) }` rule
+   keeps reading the dark `:root` definition and macOS rubber-band
+   overscroll flashes the dark colour in light mode. The matching
+   class is set on both html and body in App.tsx so existing
+   `body.light .foo` selectors below still work unchanged. */
+:root.light, body.light {
   --bg-root: #fafafa;
   --bg-panel: #f5f5f5;
   --bg-surface: #ffffff;

--- a/packages/node-ui/src/ui/views/DashboardView.tsx
+++ b/packages/node-ui/src/ui/views/DashboardView.tsx
@@ -12,6 +12,7 @@ import {
   normalizeAccessPolicy,
   type AgentSidebarIdentity,
 } from '../lib/contextGraphSidebar.js';
+import { formatEth, formatEthTooltip } from '../lib/formatEth.js';
 
 // Single user-facing description shown inside the My Context Graphs
 // card (one line, no separate footnote — round-2 feedback: the split
@@ -782,7 +783,12 @@ export function DashboardView() {
                 <div key={b.address} className="v10-ws-wrow">
                   <span className="v10-ws-addr" title={b.address}>{shortAddr(b.address)}</span>
                   <span className="v10-ws-bal">{fmtTrac(b.trac)}</span>
-                  <span className="v10-ws-bal-sec">{b.eth}</span>
+                  {/* Route gas balance through formatEth — raw `b.eth`
+                      from the daemon is e.g. "0.040583524997839496",
+                      which crowds the column and is unreadable. The
+                      tooltip surfaces the full-precision value for
+                      anyone who actually wants the exact wei (BUG-006/009). */}
+                  <span className="v10-ws-bal-sec" title={formatEthTooltip(b.eth)}>{formatEth(b.eth)}</span>
                 </div>
               ))}
             </div>

--- a/packages/node-ui/test/cg-name-validation.test.ts
+++ b/packages/node-ui/test/cg-name-validation.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { CG_NAME_MAX_LENGTH, sanitiseCgName, validateCgName } from '../src/ui/components/Modals/cgNameValidation.js';
+
+describe('cg-name validation (BUG-016)', () => {
+  describe('sanitiseCgName', () => {
+    it('returns empty for non-string / null / undefined', () => {
+      expect(sanitiseCgName(null as unknown as string)).toBe('');
+      expect(sanitiseCgName(undefined as unknown as string)).toBe('');
+      expect(sanitiseCgName(123 as unknown as string)).toBe('');
+    });
+
+    it('strips full HTML tags including paired open/close', () => {
+      expect(sanitiseCgName('<script>alert(1)</script>')).toBe('alert(1)');
+      expect(sanitiseCgName('<b>Pharma</b>')).toBe('Pharma');
+      expect(sanitiseCgName('<img src=x onerror=foo() />')).toBe('');
+    });
+
+    it('strips lonely `<` and `>` characters', () => {
+      expect(sanitiseCgName('Project >>> Beta')).toBe('Project Beta');
+      expect(sanitiseCgName('< not a tag >')).toBe('not a tag');
+    });
+
+    it('strips ASCII control characters (0x00-0x1F + 0x7F)', () => {
+      expect(sanitiseCgName('a\u0000b\u001Fc\u007Fd')).toBe('abcd');
+    });
+
+    it('collapses internal whitespace and trims edges', () => {
+      expect(sanitiseCgName('  Pharma   Drug   Interactions  ')).toBe('Pharma Drug Interactions');
+      expect(sanitiseCgName('\n\tnewlines\n\tand\ttabs\n\t')).toBe('newlines and tabs');
+    });
+
+    it(`enforces ${CG_NAME_MAX_LENGTH}-char hard cap`, () => {
+      const long = 'A'.repeat(CG_NAME_MAX_LENGTH + 50);
+      const out = sanitiseCgName(long);
+      expect(out.length).toBe(CG_NAME_MAX_LENGTH);
+    });
+
+    it('keeps unicode and emoji intact (multi-byte must survive)', () => {
+      expect(sanitiseCgName('Pharma 🧪')).toBe('Pharma 🧪');
+      expect(sanitiseCgName('日本語プロジェクト')).toBe('日本語プロジェクト');
+    });
+
+    it('idempotent — sanitising a clean string is a no-op', () => {
+      const clean = 'Pharma Drug Interactions';
+      expect(sanitiseCgName(sanitiseCgName(clean))).toBe(clean);
+    });
+  });
+
+  describe('validateCgName', () => {
+    it('rejects empty / whitespace-only / control-only input', () => {
+      expect(validateCgName('')).not.toBeNull();
+      expect(validateCgName('   ')).not.toBeNull();
+      expect(validateCgName('\u0000\u001F')).not.toBeNull();
+    });
+
+    it('flags pasted HTML even though sanitise would scrub it (so the user sees the warning)', () => {
+      expect(validateCgName('<script>alert(1)</script>')).toContain('HTML');
+      expect(validateCgName('<b>safe</b>')).toContain('HTML');
+    });
+
+    it('flags overlong input but tells the user the trim length', () => {
+      const long = 'A'.repeat(CG_NAME_MAX_LENGTH + 1);
+      expect(validateCgName(long)).toMatch(/trimmed.*characters/i);
+    });
+
+    it('accepts a normal short name', () => {
+      expect(validateCgName('Pharma Drug Interactions')).toBeNull();
+      expect(validateCgName('日本語プロジェクト')).toBeNull();
+    });
+
+    it('does NOT flag a name that uses normal ASCII punctuation', () => {
+      expect(validateCgName('Project: alpha & beta (v2)')).toBeNull();
+    });
+  });
+});

--- a/packages/node-ui/test/cg-name-validation.test.ts
+++ b/packages/node-ui/test/cg-name-validation.test.ts
@@ -75,7 +75,7 @@ describe('cg-name validation (BUG-016)', () => {
 
     it('accepts a normal short name', () => {
       expect(validateCgName('Pharma Drug Interactions')).toBeNull();
-      expect(validateCgName('日本語プロジェクト')).toBeNull();
+      expect(validateCgName('Pharma 🧪')).toBeNull();
     });
 
     it('does NOT flag a name that uses normal ASCII punctuation', () => {
@@ -90,6 +90,7 @@ describe('cg-name validation (BUG-016)', () => {
       expect(validateCgName('---')).toMatch(/letter or digit/i);
       expect(validateCgName('***')).toMatch(/letter or digit/i);
       expect(validateCgName('   .   ')).toMatch(/letter or digit/i);
+      expect(validateCgName('日本語プロジェクト')).toMatch(/letter or digit/i);
     });
 
     it('is stateless across calls (HTML_TAG_SHAPE_RE has no `g` flag, .test does not flicker)', () => {

--- a/packages/node-ui/test/cg-name-validation.test.ts
+++ b/packages/node-ui/test/cg-name-validation.test.ts
@@ -81,5 +81,25 @@ describe('cg-name validation (BUG-016)', () => {
     it('does NOT flag a name that uses normal ASCII punctuation', () => {
       expect(validateCgName('Project: alpha & beta (v2)')).toBeNull();
     });
+
+    it('rejects names that survive sanitise but slugify to empty (e.g. !!!, ---)', () => {
+      // These pass `cleaned !== ""` but the daemon's slugify would
+      // reduce them to `""`, producing a context-graph ID that ends
+      // with `/`. validateCgName must reject before submit.
+      expect(validateCgName('!!!')).toMatch(/letter or digit/i);
+      expect(validateCgName('---')).toMatch(/letter or digit/i);
+      expect(validateCgName('***')).toMatch(/letter or digit/i);
+      expect(validateCgName('   .   ')).toMatch(/letter or digit/i);
+    });
+
+    it('is stateless across calls (HTML_TAG_SHAPE_RE has no `g` flag, .test does not flicker)', () => {
+      // If the regex were declared with the global flag, .test() would
+      // step `lastIndex` between calls and the second/third call could
+      // return false for the same tagged input until the regex resets.
+      // Iterate enough times that any g-flag regression would surface.
+      for (let i = 0; i < 5; i += 1) {
+        expect(validateCgName('<b>tagged</b>')).toContain('HTML');
+      }
+    });
   });
 });

--- a/packages/node-ui/test/cg-name-validation.test.ts
+++ b/packages/node-ui/test/cg-name-validation.test.ts
@@ -15,6 +15,16 @@ describe('cg-name validation (BUG-016)', () => {
       expect(sanitiseCgName('<img src=x onerror=foo() />')).toBe('');
     });
 
+    it('survives the classic incomplete-sanitisation obfuscation (CodeQL js/incomplete-multi-character-sanitization)', () => {
+      // A naive single-pass `replace(HTML_TAG_RE, '')` collapses this
+      // to `<script>` because the inner tag is removed and the outer
+      // `<scr` + `ipt>` reunites. The fixed-point loop must keep
+      // chewing until no tags remain.
+      expect(sanitiseCgName('<scr<script>ipt>alert(1)</scr</script>ipt>')).not.toMatch(/<script/i);
+      expect(sanitiseCgName('<scr<script>ipt>alert(1)</scr</script>ipt>')).not.toContain('<');
+      expect(sanitiseCgName('<scr<script>ipt>alert(1)</scr</script>ipt>')).not.toContain('>');
+    });
+
     it('strips lonely `<` and `>` characters', () => {
       expect(sanitiseCgName('Project >>> Beta')).toBe('Project Beta');
       expect(sanitiseCgName('< not a tag >')).toBe('not a tag');

--- a/packages/node-ui/test/create-project-modal.test.ts
+++ b/packages/node-ui/test/create-project-modal.test.ts
@@ -147,4 +147,128 @@ describe('CreateProjectModal partial registration flow', () => {
     expect(container!.querySelector('[data-testid="wire-workspace"]')).toBeTruthy();
     expect(container!.textContent).toContain('On-chain registration failed: rpc unavailable');
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // BUG-016 (unbounded CG name input) + Codex Yellow #2 (raw-input
+  // warnings). The previous implementation sanitised on every keystroke
+  // before validation, so the user never saw the helper text explaining
+  // why their `<script>` tag or 200-char string was being trimmed. The
+  // fix stores the raw input verbatim and validates against it, while
+  // deriving the cleaned form only for the submit path + slug preview.
+  // ─────────────────────────────────────────────────────────────────────
+
+  function findNameInput(): HTMLInputElement {
+    const input = container!.querySelector('input[type="text"]') as HTMLInputElement | null;
+    if (!input) throw new Error('name input not found');
+    return input;
+  }
+
+  function findCreateButton(): HTMLButtonElement {
+    const btn = Array
+      .from(container!.querySelectorAll('button'))
+      .find((b) => b.textContent === 'Create Context Graph') as HTMLButtonElement | undefined;
+    if (!btn) throw new Error('Create button not found');
+    return btn;
+  }
+
+  function findNameHelper(): HTMLDivElement {
+    const helper = container!.querySelector('#dkg-cg-name-help') as HTMLDivElement | null;
+    if (!helper) throw new Error('name helper text not found');
+    return helper;
+  }
+
+  it('shows the HTML-stripped warning when the user types `<b>foo</b>` (Codex Y2 raw-input visibility)', async () => {
+    await renderModal();
+    const input = findNameInput();
+    await act(async () => { setInputValue(input, '<b>foo</b>'); });
+    await flush();
+    const helper = findNameHelper();
+    expect(helper.textContent ?? '').toMatch(/HTML tags are not allowed/i);
+    // The slug preview should still reflect the *sanitised* value
+    // (so the user knows what ID they'd actually get if they
+    // accepted the strip):
+    expect(helper.getAttribute('aria-invalid')).toBe(null);
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('shows the truncation warning when the raw input exceeds CG_NAME_MAX_LENGTH', async () => {
+    await renderModal();
+    const input = findNameInput();
+    // Set the value directly without the `maxLength` HTML guard
+    // intercepting — the validator must still surface a warning even
+    // if a paste somehow bypasses maxLength (e.g. programmatic paste).
+    const original = 'a'.repeat(120);
+    // setInputValue uses the prototype descriptor which honours
+    // maxLength, so set the value via the React-style raw setter then
+    // dispatch input; happy-dom respects maxLength=80, so we
+    // intentionally bypass via the property descriptor on the
+    // instance to simulate paste-past-cap.
+    Object.defineProperty(input, 'value', { configurable: true, value: original });
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await flush();
+    const helper = findNameHelper();
+    // Either of two warnings is acceptable depending on which
+    // branch the validator hits first — both are user-actionable.
+    expect(helper.textContent ?? '').toMatch(/trimmed to 80 characters|letter or digit/i);
+  });
+
+  it('rejects punctuation-only names that slugify to empty (e.g. !!!) and disables the Create button (Codex RED-3 regression)', async () => {
+    await renderModal();
+    const input = findNameInput();
+    const btn = findCreateButton();
+    await act(async () => { setInputValue(input, '!!!'); });
+    await flush();
+    const helper = findNameHelper();
+    expect(helper.textContent ?? '').toMatch(/letter or digit/i);
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('Create button is disabled the moment a validation error is present (no submit slip-through)', async () => {
+    await renderModal();
+    const input = findNameInput();
+    const btn = findCreateButton();
+
+    // Valid name first: button enabled.
+    await act(async () => { setInputValue(input, 'Valid Name'); });
+    await flush();
+    expect(btn.disabled).toBe(false);
+
+    // Replace with HTML — button must disable again on the next render.
+    await act(async () => { setInputValue(input, '<script>x</script>'); });
+    await flush();
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('clicking Create with a validation error is a no-op (createContextGraph never called)', async () => {
+    await renderModal();
+    const input = findNameInput();
+    const btn = findCreateButton();
+    await act(async () => { setInputValue(input, '<b></b>'); });
+    await flush();
+    // Force a click even though the button is disabled (defence in
+    // depth — onClick should `return` early on validation error).
+    await act(async () => {
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+    expect(createContextGraphMock).not.toHaveBeenCalled();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // BUG-017 a11y wiring: the modal should expose role="dialog",
+  // aria-modal, and an explicit × close button. These guard the
+  // useModalDismiss integration end-to-end (the hook itself is unit-
+  // tested separately).
+  // ─────────────────────────────────────────────────────────────────────
+
+  it('renders role="dialog" + aria-modal="true" + an explicit close button (BUG-017 a11y wiring)', async () => {
+    await renderModal();
+    const dialog = container!.querySelector('[role="dialog"]') as HTMLElement | null;
+    expect(dialog).toBeTruthy();
+    expect(dialog?.getAttribute('aria-modal')).toBe('true');
+    // Close button is identified by aria-label so screen readers
+    // announce it; the visible glyph is an `×`.
+    const closeBtn = container!.querySelector('button[aria-label*="lose"], button[aria-label*="ismiss"]');
+    expect(closeBtn).toBeTruthy();
+  });
 });

--- a/packages/node-ui/test/format-eth.test.ts
+++ b/packages/node-ui/test/format-eth.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { formatEth, formatEthTooltip } from '../src/ui/lib/formatEth.js';
+
+describe('formatEth', () => {
+  it('returns em-dash for null/undefined/empty (BUG-006: never crash on missing balance)', () => {
+    expect(formatEth(null)).toBe('—');
+    expect(formatEth(undefined)).toBe('—');
+    expect(formatEth('')).toBe('—');
+  });
+
+  it('returns em-dash for non-numeric input (regression guard against silent NaN render)', () => {
+    expect(formatEth('not-a-number')).toBe('—');
+    expect(formatEth({} as unknown)).toBe('—');
+    expect(formatEth(NaN)).toBe('—');
+    expect(formatEth(Infinity)).toBe('—');
+    expect(formatEth(-Infinity)).toBe('—');
+  });
+
+  it('renders zero as "0" exactly (avoids "0.000000" and "<" prefix on a real zero)', () => {
+    expect(formatEth(0)).toBe('0');
+    expect(formatEth('0')).toBe('0');
+    expect(formatEth('0.000000000000000000')).toBe('0');
+  });
+
+  it('truncates the 17-digit dump from the daemon (BUG-006 reproducer)', () => {
+    expect(formatEth('0.040583524997839496')).toBe('0.040584');
+    expect(formatEth('0.000000000000000001')).toBe('< 0.000001');
+    expect(formatEth('1.234567890123456789')).toBe('1.234568');
+  });
+
+  it('respects custom precision and trims trailing zeros', () => {
+    expect(formatEth('0.04', 2)).toBe('0.04');
+    expect(formatEth('0.040000', 4)).toBe('0.04');
+    expect(formatEth('0.04', 6)).toBe('0.04');
+  });
+
+  it('keeps integer-only balances readable (no spurious decimal)', () => {
+    expect(formatEth('1')).toBe('1');
+    expect(formatEth(2)).toBe('2');
+    expect(formatEth('1234567')).toBe('1234567');
+  });
+
+  it('uses < threshold hint for sub-precision values so the user doesn\'t mistake them for zero', () => {
+    expect(formatEth('0.0000001')).toBe('< 0.000001');
+    expect(formatEth('0.000001', 6)).toBe('0.000001');
+    expect(formatEth('0.0000005', 6)).toBe('< 0.000001');
+  });
+
+  it('handles negative balances literally (chain rarely produces these but we shouldn\'t lie)', () => {
+    expect(formatEth('-0.5')).toBe('-0.5');
+    expect(formatEth(-1)).toBe('-1');
+  });
+});
+
+describe('formatEthTooltip', () => {
+  it('returns undefined for missing values so the title attribute is omitted', () => {
+    expect(formatEthTooltip(null)).toBeUndefined();
+    expect(formatEthTooltip('')).toBeUndefined();
+  });
+
+  it('preserves the raw daemon value verbatim so users can copy full precision', () => {
+    expect(formatEthTooltip('0.040583524997839496'))
+      .toBe('Exact balance: 0.040583524997839496 (full precision from chain)');
+  });
+});

--- a/packages/node-ui/test/format-notification-time.test.ts
+++ b/packages/node-ui/test/format-notification-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatNotificationTimestamp } from '../src/ui/lib/formatTimestamp.js';
+import { compareNotificationByTsDesc, formatNotificationTimestamp } from '../src/ui/lib/formatTimestamp.js';
 
 const NOW = new Date('2026-05-26T14:00:00Z');
 
@@ -39,5 +39,42 @@ describe('formatNotificationTimestamp (BUG-003)', () => {
     const out = formatNotificationTimestamp(old, NOW);
     expect(out).toMatch(/^[A-Z][a-z]{2}/);
     expect(out).toMatch(/202\d/);
+  });
+});
+
+describe('compareNotificationByTsDesc (BUG-019)', () => {
+  it('sorts numeric epoch timestamps newest-first (the production shape)', () => {
+    // Reproducer for the regression we just fixed: the previous
+    // comparator did `Date.parse(String(<epoch>))` which always
+    // returned NaN for numeric timestamps, leaving the dropdown in
+    // arbitrary insertion order.
+    const items = [
+      { id: 'a', ts: 1_716_700_000_000 },
+      { id: 'b', ts: 1_716_900_000_000 },
+      { id: 'c', ts: 1_716_800_000_000 },
+    ];
+    const sorted = [...items].sort(compareNotificationByTsDesc);
+    expect(sorted.map((n) => n.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('handles missing / non-finite timestamps without poisoning the comparator (returns 0 for them)', () => {
+    const items = [
+      { id: 'has-ts', ts: 2000 },
+      { id: 'no-ts' },
+      { id: 'nan-ts', ts: Number.NaN },
+      { id: 'null-ts', ts: null as unknown as number },
+    ];
+    const sorted = [...items].sort(compareNotificationByTsDesc);
+    expect(sorted[0].id).toBe('has-ts');
+  });
+
+  it('preserves insertion order for equal timestamps (stable-comparator contract)', () => {
+    const items = [
+      { id: 'first', ts: 1000 },
+      { id: 'second', ts: 1000 },
+      { id: 'third', ts: 1000 },
+    ];
+    const sorted = [...items].sort(compareNotificationByTsDesc);
+    expect(sorted.map((n) => n.id)).toEqual(['first', 'second', 'third']);
   });
 });

--- a/packages/node-ui/test/format-notification-time.test.ts
+++ b/packages/node-ui/test/format-notification-time.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { formatNotificationTimestamp } from '../src/ui/lib/formatTimestamp.js';
+
+const NOW = new Date('2026-05-26T14:00:00Z');
+
+describe('formatNotificationTimestamp (BUG-003)', () => {
+  it('returns empty string for missing timestamps so the UI doesn\'t render "Invalid Date"', () => {
+    expect(formatNotificationTimestamp(undefined, NOW)).toBe('');
+    expect(formatNotificationTimestamp('', NOW)).toBe('');
+    expect(formatNotificationTimestamp('not-a-date', NOW)).toBe('');
+    expect(formatNotificationTimestamp(NaN as unknown as number, NOW)).toBe('');
+  });
+
+  it('shows only time (no date) for same-day events to keep the dropdown compact', () => {
+    const sameDay = new Date('2026-05-26T13:55:00Z');
+    const out = formatNotificationTimestamp(sameDay, NOW);
+    expect(out).not.toMatch(/May|Yesterday|Mon|Tue|Wed|Thu|Fri|Sat|Sun/i);
+    expect(out).toMatch(/\d/);
+  });
+
+  it('annotates yesterday explicitly so close-but-not-same-day is unambiguous', () => {
+    const yesterday = new Date(NOW);
+    yesterday.setDate(NOW.getDate() - 1);
+    yesterday.setHours(22, 30, 0, 0);
+    expect(formatNotificationTimestamp(yesterday, NOW)).toMatch(/^Yesterday\s/);
+  });
+
+  it('shows a weekday short name for events earlier in the same week', () => {
+    const earlier = new Date(NOW);
+    earlier.setDate(NOW.getDate() - 4);
+    earlier.setHours(10, 0, 0, 0);
+    const out = formatNotificationTimestamp(earlier, NOW);
+    expect(out).toMatch(/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun)/);
+  });
+
+  it('shows full date for older events so a 2-month-old notification is NOT visually fresh (BUG-003 reproducer)', () => {
+    const old = new Date(NOW);
+    old.setMonth(NOW.getMonth() - 2);
+    const out = formatNotificationTimestamp(old, NOW);
+    expect(out).toMatch(/^[A-Z][a-z]{2}/);
+    expect(out).toMatch(/202\d/);
+  });
+});

--- a/packages/node-ui/test/format-time-hooks.test.ts
+++ b/packages/node-ui/test/format-time-hooks.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { formatTime } from '../src/ui/hooks.js';
+
+const NOW = new Date('2026-05-26T14:00:00Z');
+
+describe('formatTime (BUG-003 — Operations table column)', () => {
+  it('returns em-dash for nullish input (matches historical contract)', () => {
+    expect(formatTime(undefined, NOW)).toBe('—');
+    expect(formatTime(null, NOW)).toBe('—');
+    expect(formatTime('', NOW)).toBe('—');
+  });
+
+  it('returns em-dash for unparseable timestamps so the column never breaks layout', () => {
+    expect(formatTime('not-a-date', NOW)).toBe('—');
+  });
+
+  it('shows H:MM:SS for same-day events (preserves the dense form Operations relied on)', () => {
+    const sameDay = new Date('2026-05-26T13:55:30Z');
+    const out = formatTime(sameDay, NOW);
+    expect(out).toMatch(/\d{1,2}/);
+    expect(out).not.toContain('Yesterday');
+    expect(out).not.toMatch(/Mar|May/);
+  });
+
+  it('annotates yesterday so a sub-24h-but-not-same-day event is recognisable at a glance', () => {
+    // Build "yesterday" relative to NOW in the local TZ — the helper
+    // uses `toDateString()` which is local-TZ-aware, so a UTC literal
+    // would flap depending on where CI runs.
+    const yesterday = new Date(NOW);
+    yesterday.setDate(NOW.getDate() - 1);
+    yesterday.setHours(22, 30, 0, 0);
+    expect(formatTime(yesterday, NOW)).toMatch(/^Yesterday\s/);
+  });
+
+  it('uses weekday for events earlier in the week', () => {
+    const earlier = new Date(NOW);
+    earlier.setDate(NOW.getDate() - 4);
+    earlier.setHours(8, 0, 0, 0);
+    expect(formatTime(earlier, NOW)).toMatch(/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun)/);
+  });
+
+  it('shows month/day for older events (older than 7d)', () => {
+    const old = new Date(NOW);
+    old.setMonth(NOW.getMonth() - 2);
+    expect(formatTime(old, NOW)).toMatch(/^[A-Z][a-z]{2}/);
+  });
+});

--- a/packages/node-ui/test/format-time-hooks.test.ts
+++ b/packages/node-ui/test/format-time-hooks.test.ts
@@ -44,4 +44,16 @@ describe('formatTime (BUG-003 — Operations table column)', () => {
     old.setMonth(NOW.getMonth() - 2);
     expect(formatTime(old, NOW)).toMatch(/^[A-Z][a-z]{2}/);
   });
+
+  it('type-checks every accepted input shape (number | string | Date)', () => {
+    // Compile-time guard for the public signature widened in BUG-003.
+    // If the parameter type ever drops `Date` again, this file will
+    // fail `tsc` even before vitest sees it.
+    const numeric: number = NOW.getTime();
+    const stringy: string = NOW.toISOString();
+    const date: Date = NOW;
+    expect(formatTime(numeric, NOW)).toBeTypeOf('string');
+    expect(formatTime(stringy, NOW)).toBeTypeOf('string');
+    expect(formatTime(date, NOW)).toBeTypeOf('string');
+  });
 });

--- a/packages/node-ui/test/format-trac.test.ts
+++ b/packages/node-ui/test/format-trac.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { formatTracSymbol } from '../src/ui/lib/formatTrac.js';
+
+describe('formatTracSymbol (BUG-013)', () => {
+  it('returns "TRAC" for empty/null/undefined symbol', () => {
+    expect(formatTracSymbol('', '8453')).toBe('TRAC');
+    expect(formatTracSymbol(null, '8453')).toBe('TRAC');
+    expect(formatTracSymbol(undefined, '8453')).toBe('TRAC');
+  });
+
+  it('appends "(testnet)" qualifier on testnet chain ids when symbol does not already say so', () => {
+    expect(formatTracSymbol('v9TRAC', '84532')).toBe('v9TRAC (testnet)');
+    expect(formatTracSymbol('TRAC', '11155111')).toBe('TRAC (testnet)');
+    expect(formatTracSymbol('xTRAC', '31337')).toBe('xTRAC (testnet)');
+  });
+
+  it('does NOT double-qualify when the symbol already announces test status', () => {
+    expect(formatTracSymbol('test-TRAC', '84532')).toBe('test-TRAC');
+    expect(formatTracSymbol('TestTRAC', '84532')).toBe('TestTRAC');
+  });
+
+  it('returns the raw symbol for production chain ids', () => {
+    expect(formatTracSymbol('TRAC', '8453')).toBe('TRAC');
+    expect(formatTracSymbol('TRAC', '1')).toBe('TRAC');
+    expect(formatTracSymbol('TRAC', '100')).toBe('TRAC');
+  });
+
+  it('handles compound chain ids ("base:84532")', () => {
+    expect(formatTracSymbol('v9TRAC', 'base:84532')).toBe('v9TRAC (testnet)');
+    expect(formatTracSymbol('TRAC', 'eth:1')).toBe('TRAC');
+  });
+});

--- a/packages/node-ui/test/panel-left.test.ts
+++ b/packages/node-ui/test/panel-left.test.ts
@@ -26,6 +26,11 @@ vi.mock('../src/ui/api.js', async () => {
 vi.mock('../src/ui/api-wrapper.js', () => ({
   api: {
     fetchContextGraphs: apiFetchContextGraphsMock,
+    // BUG-007: PanelLeft now reads its agent identity from the shared
+    // `useCurrentAgent` hook, which goes through `api.fetchCurrentAgent`
+    // (not the named import). Wire the mock here so the hook can
+    // resolve in tests without a live daemon.
+    fetchCurrentAgent: fetchCurrentAgentMock,
   },
 }));
 

--- a/packages/node-ui/test/panel-right.component.test.ts
+++ b/packages/node-ui/test/panel-right.component.test.ts
@@ -44,6 +44,11 @@ vi.mock('../src/ui/api.js', async () => {
 vi.mock('../src/ui/api-wrapper.js', () => ({
   api: {
     fetchMemorySessions: apiFetchMemorySessionsMock,
+    // BUG-007: PanelRight's currentAgent is now sourced from the
+    // shared `useCurrentAgent` hook, which calls `api.fetchCurrentAgent`
+    // through the wrapper (not the named import). Wire the same mock
+    // through the wrapper so the hook resolves under test.
+    fetchCurrentAgent: fetchCurrentAgentMock,
   },
 }));
 

--- a/packages/node-ui/test/panel-right.refresh-history.test.ts
+++ b/packages/node-ui/test/panel-right.refresh-history.test.ts
@@ -16,6 +16,7 @@ const streamLocalAgentChatMock = vi.fn();
 const connectLocalAgentIntegrationMock = vi.fn();
 const disconnectLocalAgentIntegrationMock = vi.fn();
 const apiFetchMemorySessionsMock = vi.fn();
+const fetchCurrentAgentMock = vi.fn().mockResolvedValue(null);
 
 vi.mock('../src/ui/api.js', async () => {
   const actual = await vi.importActual<any>('../src/ui/api.js');
@@ -23,6 +24,7 @@ vi.mock('../src/ui/api.js', async () => {
     ...actual,
     fetchAgents: fetchAgentsMock,
     fetchConnections: fetchConnectionsMock,
+    fetchCurrentAgent: fetchCurrentAgentMock,
     fetchLocalAgentIntegrations: fetchLocalAgentIntegrationsMock,
     fetchLocalAgentHistory: fetchLocalAgentHistoryMock,
     streamLocalAgentChat: streamLocalAgentChatMock,
@@ -34,6 +36,7 @@ vi.mock('../src/ui/api.js', async () => {
 vi.mock('../src/ui/api-wrapper.js', () => ({
   api: {
     fetchMemorySessions: apiFetchMemorySessionsMock,
+    fetchCurrentAgent: fetchCurrentAgentMock,
   },
 }));
 

--- a/packages/node-ui/test/redact-rpc-url.test.ts
+++ b/packages/node-ui/test/redact-rpc-url.test.ts
@@ -64,4 +64,13 @@ describe('redactRpcUrl (BUG-012)', () => {
     expect(redacted).not.toContain('@rpc.example.com');
     expect(redacted).toContain('rpc.example.com');
   });
+
+  it('strips a username-only credential (user@host with no password) — the username alone identifies the tenant', () => {
+    const original = 'https://tenantonly@rpc.example.com/v1/abcdef0123456789abcdef0123456789';
+    const redacted = redactRpcUrl(original);
+    expect(redacted).not.toContain('tenantonly');
+    expect(redacted).not.toContain('tenantonly@');
+    expect(redacted).toContain('rpc.example.com');
+    expect(redacted).not.toContain('abcdef0123456789abcdef0123456789');
+  });
 });

--- a/packages/node-ui/test/redact-rpc-url.test.ts
+++ b/packages/node-ui/test/redact-rpc-url.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { redactRpcUrl } from '../src/ui/lib/redactRpcUrl.js';
+
+describe('redactRpcUrl (BUG-012)', () => {
+  it('returns empty string for nullish input (caller may render "" without a Field row)', () => {
+    expect(redactRpcUrl(null)).toBe('');
+    expect(redactRpcUrl(undefined)).toBe('');
+    expect(redactRpcUrl('')).toBe('');
+  });
+
+  it('redacts QuickNode-style hex token segment', () => {
+    const original = 'https://greatest-greatest-sound.base-sepolia.quiknode.pro/664a23a04122d3fa485778b9141bc92e17293c73/';
+    const redacted = redactRpcUrl(original);
+    expect(redacted).not.toContain('664a23a04122d3fa485778b9141bc92e17293c73');
+    expect(redacted).toContain('quiknode.pro');
+    expect(redacted).toContain('***');
+  });
+
+  it('redacts Infura v3 path token but keeps the version segment', () => {
+    const original = 'https://mainnet.infura.io/v3/abcdef0123456789abcdef0123456789';
+    const redacted = redactRpcUrl(original);
+    expect(redacted).toContain('infura.io');
+    expect(redacted).toContain('/v3/');
+    expect(redacted).not.toContain('abcdef0123456789abcdef0123456789');
+  });
+
+  it('redacts Alchemy /v2/ path token but keeps host', () => {
+    const original = 'https://eth-mainnet.alchemyapi.io/v2/abcdef0123456789abcdef0123456789';
+    const redacted = redactRpcUrl(original);
+    expect(redacted).toContain('alchemyapi.io');
+    expect(redacted).toContain('/v2/');
+    expect(redacted).not.toContain('abcdef0123456789abcdef0123456789');
+  });
+
+  it('keeps short path segments untouched (e.g. /eth, /goerli)', () => {
+    const original = 'https://example.com/eth';
+    const redacted = redactRpcUrl(original);
+    expect(redacted).toBe('https://example.com/eth');
+  });
+
+  it('redacts `?key=` / `?token=` query parameters', () => {
+    const redacted = redactRpcUrl('https://rpc.example.com/?key=abcdef0123456789');
+    expect(redacted).toContain('rpc.example.com');
+    expect(redacted).not.toContain('abcdef0123456789');
+    expect(redacted).toMatch(/key=\*+/);
+  });
+
+  it('preserves a non-secret query parameter', () => {
+    const redacted = redactRpcUrl('https://rpc.example.com/?chain=base');
+    expect(redacted).toBe('https://rpc.example.com/?chain=base');
+  });
+
+  it('still scrubs hex tokens out of a malformed URL string (defence in depth)', () => {
+    const malformed = 'not-a-url-664a23a04122d3fa485778b9141bc92e17293c73-trailing';
+    const redacted = redactRpcUrl(malformed);
+    expect(redacted).not.toContain('664a23a04122d3fa485778b9141bc92e17293c73');
+  });
+});

--- a/packages/node-ui/test/redact-rpc-url.test.ts
+++ b/packages/node-ui/test/redact-rpc-url.test.ts
@@ -55,4 +55,13 @@ describe('redactRpcUrl (BUG-012)', () => {
     const redacted = redactRpcUrl(malformed);
     expect(redacted).not.toContain('664a23a04122d3fa485778b9141bc92e17293c73');
   });
+
+  it('strips HTTP basic-auth credentials baked into the URL (user:pass@host)', () => {
+    const original = 'https://tenant1234:s3cr3t-shared-token@rpc.example.com/path';
+    const redacted = redactRpcUrl(original);
+    expect(redacted).not.toContain('s3cr3t-shared-token');
+    expect(redacted).not.toContain('tenant1234');
+    expect(redacted).not.toContain('@rpc.example.com');
+    expect(redacted).toContain('rpc.example.com');
+  });
 });

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -137,7 +137,11 @@ describe('clickable notifications', () => {
   it('notification items show message and timestamp', () => {
     expect(header).toContain('n.message');
     expect(header).toContain('n.ts');
-    expect(header).toContain('toLocaleTimeString');
+    // BUG-003: timestamp is now rendered through the date-aware
+    // `formatNotificationTimestamp` helper so a 2-month-old notification
+    // doesn't masquerade as fresh — `toLocaleTimeString` alone would
+    // hide the day. Asserting the helper is wired in.
+    expect(header).toContain('formatNotificationTimestamp');
   });
 
   it('empty state shown when no notifications', () => {
@@ -191,7 +195,11 @@ describe('right-rail agent shell replaces Agent Hub', () => {
 describe('backward-compatible URL redirects (V10 consolidation)', () => {
   const app = readFile('App.tsx');
 
-  for (const path of ['/agent', '/explorer', '/settings', '/messages', '/apps/*']) {
+  // BUG-018: `/settings` and `/observability` are now deep-linkable —
+  // they fall through to AppShell where `useShellRouting` opens the
+  // matching centre tab. The remaining stale routes (V9 surfaces with
+  // no V10 home) still hard-redirect.
+  for (const path of ['/agent', '/explorer', '/messages', '/apps/*']) {
     it(`redirects ${path} to /`, () => {
       expect(app).toContain(`path="${path}"`);
       const pattern = new RegExp(`path="${path.replace('*', '\\*')}".*element=\\{<Navigate to="/"`);
@@ -202,6 +210,15 @@ describe('backward-compatible URL redirects (V10 consolidation)', () => {
   it('uses replace to avoid pushing redirect onto history', () => {
     const redirectSection = app.slice(app.indexOf('path="/agent"'), app.indexOf('path="*"'));
     expect(redirectSection).toContain('replace');
+  });
+
+  it('does NOT redirect /settings — it must open the Settings tab via the shell router (BUG-018)', () => {
+    expect(app).not.toMatch(/path="\/settings".*element=\{<Navigate to="\/"/);
+    expect(app).toContain('URL_PATH_TO_TAB');
+  });
+
+  it('exposes /observability as a deep-linkable path (BUG-018)', () => {
+    expect(app).toContain("'/observability'");
   });
 });
 
@@ -255,7 +272,10 @@ describe('notification items are non-interactive until peer chat exists', () => 
   it('renders notification text and timestamp', () => {
     expect(header).toContain('v10-header-notif-item-text');
     expect(header).toContain('v10-header-notif-item-time');
-    expect(header).toContain('toLocaleTimeString');
+    // BUG-003: same date-aware helper as the dropdown above; raw
+    // `toLocaleTimeString` is no longer the source of truth for the
+    // notification timestamp.
+    expect(header).toContain('formatNotificationTimestamp');
   });
 });
 

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -214,11 +214,18 @@ describe('backward-compatible URL redirects (V10 consolidation)', () => {
 
   it('does NOT redirect /settings — it must open the Settings tab via the shell router (BUG-018)', () => {
     expect(app).not.toMatch(/path="\/settings".*element=\{<Navigate to="\/"/);
-    expect(app).toContain('URL_PATH_TO_TAB');
+    expect(app).toContain('useShellRouting');
   });
 
   it('exposes /observability as a deep-linkable path (BUG-018)', () => {
-    expect(app).toContain("'/observability'");
+    // The mapping table now lives in `hooks/useShellRouting.ts`; the
+    // companion behavioural tests in `use-shell-routing.test.ts`
+    // exercise the deep-link / unmapped-tab reset semantics directly.
+    const shellRouting = readFileSync(
+      resolve(__dirname, '../src/ui/hooks/useShellRouting.ts'),
+      'utf-8',
+    );
+    expect(shellRouting).toContain("'/observability'");
   });
 });
 

--- a/packages/node-ui/test/use-keyboard-shortcuts.test.ts
+++ b/packages/node-ui/test/use-keyboard-shortcuts.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+// Mock the layout store BEFORE importing the hook so the hook resolves
+// our spy implementation. We use real Zustand-style return shape so
+// `useLayoutStore()` (no selector) destructures cleanly.
+const toggleLeft = vi.fn();
+const toggleRight = vi.fn();
+const toggleBottom = vi.fn();
+
+vi.mock('../src/ui/stores/layout.js', () => ({
+  useLayoutStore: () => ({ toggleLeft, toggleRight, toggleBottom }),
+  // Some App.tsx imports also pull `maxBottomHeight` from this module —
+  // export a stub so any consumer (we only mount the hook here, but the
+  // module surface is stable for downstream consumers) doesn't crash.
+  maxBottomHeight: () => 600,
+}));
+
+// eslint-disable-next-line import/first -- mock has to be declared before the import
+import { useKeyboardShortcuts } from '../src/ui/hooks/useKeyboardShortcuts.js';
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+function HookHost() {
+  useKeyboardShortcuts();
+  return null;
+}
+
+function mount(): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(HookHost));
+  });
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+}
+
+function fireKeydown(init: KeyboardEventInit & { target?: EventTarget }): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+  // happy-dom honours `bubbles: true` on dispatchEvent against window for
+  // KeyboardEvent. The hook attaches `keydown` directly on `window`.
+  if (init.target) {
+    init.target.dispatchEvent(event);
+  } else {
+    window.dispatchEvent(event);
+  }
+  return event;
+}
+
+describe('useKeyboardShortcuts (BUG-005)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+  });
+
+  it('Cmd+B (lowercase, no modifier) toggles the left sidebar exactly once', () => {
+    mount();
+    const ev = fireKeydown({ key: 'b', metaKey: true });
+    expect(ev.defaultPrevented).toBe(true);
+    expect(toggleLeft).toHaveBeenCalledTimes(1);
+    expect(toggleRight).not.toHaveBeenCalled();
+    expect(toggleBottom).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+B (Windows/Linux) toggles the same way as Cmd+B', () => {
+    mount();
+    fireKeydown({ key: 'b', ctrlKey: true });
+    expect(toggleLeft).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cmd+Shift+B reports `e.key` as uppercase `B` in Chrome — must still toggle the right panel (BUG-005 reproducer)', () => {
+    mount();
+    fireKeydown({ key: 'B', metaKey: true, shiftKey: true });
+    expect(toggleRight).toHaveBeenCalledTimes(1);
+    // CRITICAL: must NOT also fire the non-shift left-toggle path.
+    // Original buggy implementation tested `key === "b"` for both
+    // branches, so the shift branch never matched (case mismatch) and
+    // the user was left wondering why the right panel never toggled.
+    expect(toggleLeft).not.toHaveBeenCalled();
+  });
+
+  it('Cmd+B with Caps Lock active (key reported as `B`) still toggles the LEFT sidebar (case-insensitive dispatch)', () => {
+    mount();
+    fireKeydown({ key: 'B', metaKey: true });
+    expect(toggleLeft).toHaveBeenCalledTimes(1);
+    expect(toggleRight).not.toHaveBeenCalled();
+  });
+
+  it('Cmd+J toggles the bottom panel; Cmd+Shift+J does NOT', () => {
+    mount();
+    fireKeydown({ key: 'j', metaKey: true });
+    expect(toggleBottom).toHaveBeenCalledTimes(1);
+
+    fireKeydown({ key: 'j', metaKey: true, shiftKey: true });
+    // After the shift-modified dispatch the early-return on
+    // `e.shiftKey` should have prevented the J branch from firing
+    // again. So the count stays at 1.
+    expect(toggleBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fire any toggle when typing into a text input (form-field guard)', () => {
+    mount();
+    const input = document.createElement('input');
+    input.type = 'text';
+    document.body.appendChild(input);
+    fireKeydown({ key: 'b', metaKey: true, target: input });
+    fireKeydown({ key: 'j', metaKey: true, target: input });
+    fireKeydown({ key: 'B', metaKey: true, shiftKey: true, target: input });
+    expect(toggleLeft).not.toHaveBeenCalled();
+    expect(toggleRight).not.toHaveBeenCalled();
+    expect(toggleBottom).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  it('does NOT fire any toggle when typing into a textarea (form-field guard #2)', () => {
+    mount();
+    const ta = document.createElement('textarea');
+    document.body.appendChild(ta);
+    fireKeydown({ key: 'b', metaKey: true, target: ta });
+    expect(toggleLeft).not.toHaveBeenCalled();
+    ta.remove();
+  });
+
+  it('does NOT fire on a bare `B` keypress without Cmd/Ctrl (modifier required)', () => {
+    mount();
+    fireKeydown({ key: 'b' });
+    fireKeydown({ key: 'B' });
+    expect(toggleLeft).not.toHaveBeenCalled();
+  });
+
+  it('ignores unrelated modifier keys (Alt alone is not a shortcut)', () => {
+    mount();
+    fireKeydown({ key: 'b', altKey: true });
+    expect(toggleLeft).not.toHaveBeenCalled();
+  });
+
+  it('removes the keydown listener on unmount (no leaked toggles after teardown)', () => {
+    mount();
+    fireKeydown({ key: 'b', metaKey: true });
+    expect(toggleLeft).toHaveBeenCalledTimes(1);
+    // Teardown the host
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+    fireKeydown({ key: 'b', metaKey: true });
+    expect(toggleLeft).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/node-ui/test/use-modal-dismiss.test.ts
+++ b/packages/node-ui/test/use-modal-dismiss.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { useModalDismiss } from '../src/ui/components/Modals/useModalDismiss.js';
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+interface HostProps {
+  open: boolean;
+  onClose: () => void;
+  /** Optional override so individual tests can swap the focusable mix. */
+  children?: React.ReactNode;
+}
+
+function ModalHost({ open, onClose, children }: HostProps) {
+  const { dialogRef, onBackdropClick } = useModalDismiss(open, onClose);
+  if (!open) return null;
+  return React.createElement(
+    'div',
+    {
+      'data-testid': 'backdrop',
+      onClick: onBackdropClick,
+      role: 'presentation',
+    },
+    React.createElement(
+      'div',
+      {
+        ref: dialogRef,
+        role: 'dialog',
+        'aria-modal': 'true',
+      },
+      children ?? React.createElement('button', { id: 'first' }, 'First'),
+    ),
+  );
+}
+
+function mount(open: boolean, onClose: () => void, children?: React.ReactNode): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(ModalHost, { open, onClose, children }));
+  });
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+}
+
+function rerender(open: boolean, onClose: () => void, children?: React.ReactNode): void {
+  const root = mountedRoots[mountedRoots.length - 1];
+  act(() => {
+    root.render(React.createElement(ModalHost, { open, onClose, children }));
+  });
+}
+
+async function tick(): Promise<void> {
+  await act(async () => { await Promise.resolve(); });
+}
+
+describe('useModalDismiss (BUG-017)', () => {
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+  });
+
+  it('Escape key invokes onClose while open', () => {
+    const onClose = vi.fn();
+    mount(true, onClose);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape is a no-op when open=false (listener is detached)', () => {
+    const onClose = vi.fn();
+    mount(false, onClose);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('clicking the backdrop calls onClose; clicking inside the dialog does NOT', () => {
+    const onClose = vi.fn();
+    mount(true, onClose);
+
+    const backdrop = document.querySelector('[data-testid="backdrop"]') as HTMLElement;
+    const dialog = backdrop.querySelector('[role="dialog"]') as HTMLElement;
+
+    // Click *inside* the dialog (event.target !== event.currentTarget)
+    act(() => { dialog.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Click the backdrop directly
+    act(() => { backdrop.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores focus to the previously-focused element on close (a11y restoration)', async () => {
+    const opener = document.createElement('button');
+    opener.id = 'opener';
+    document.body.appendChild(opener);
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    const onClose = vi.fn();
+    mount(true, onClose);
+    await tick();
+
+    // Closing the modal (open: false) should fire the cleanup which
+    // returns focus to the opener.
+    rerender(false, onClose);
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
+
+  it('focus trap: pressing Shift+Tab on the FIRST focusable wraps to the LAST', async () => {
+    const onClose = vi.fn();
+    mount(true, onClose, [
+      React.createElement('button', { key: 'a', id: 'b-first' }, 'A'),
+      React.createElement('button', { key: 'b', id: 'b-mid' }, 'B'),
+      React.createElement('button', { key: 'c', id: 'b-last' }, 'C'),
+    ]);
+    await tick();
+    const first = document.getElementById('b-first') as HTMLElement;
+    const last = document.getElementById('b-last') as HTMLElement;
+    first.focus();
+    expect(document.activeElement).toBe(first);
+
+    const ev = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true });
+    window.dispatchEvent(ev);
+    // The hook calls preventDefault and focuses `last` manually
+    expect(ev.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('focus trap: pressing Tab on the LAST focusable wraps to the FIRST', async () => {
+    const onClose = vi.fn();
+    mount(true, onClose, [
+      React.createElement('button', { key: 'a', id: 't-first' }, 'A'),
+      React.createElement('button', { key: 'b', id: 't-mid' }, 'B'),
+      React.createElement('button', { key: 'c', id: 't-last' }, 'C'),
+    ]);
+    await tick();
+    const first = document.getElementById('t-first') as HTMLElement;
+    const last = document.getElementById('t-last') as HTMLElement;
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    const ev = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    window.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('Tab in the middle of the focus list is NOT intercepted (browser handles natural progression)', async () => {
+    const onClose = vi.fn();
+    mount(true, onClose, [
+      React.createElement('button', { key: 'a', id: 'm-first' }, 'A'),
+      React.createElement('button', { key: 'b', id: 'm-mid' }, 'B'),
+      React.createElement('button', { key: 'c', id: 'm-last' }, 'C'),
+    ]);
+    await tick();
+    const mid = document.getElementById('m-mid') as HTMLElement;
+    mid.focus();
+    const ev = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    window.dispatchEvent(ev);
+    // The hook only intercepts when focus is on first/last edge —
+    // mid-Tab keeps `preventDefault` false so the browser handles it.
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it('prefers an [autofocus] element over the first focusable when moving initial focus', async () => {
+    // The hook reads the literal HTML attribute via
+    // `dialog.querySelector('[autofocus]')` (not React's autoFocus
+    // prop, which never serialises to an attribute). We render the
+    // attribute via JSX spread so the DOM actually carries it.
+    const onClose = vi.fn();
+    mount(true, onClose, [
+      React.createElement('button', { key: 'a', id: 'af-first' }, 'A'),
+      React.createElement('input', {
+        key: 'b',
+        id: 'af-target',
+        defaultValue: '',
+        // Use the attribute form so the matching selector fires.
+        ...({ autofocus: '' } as Record<string, string>),
+      }),
+      React.createElement('button', { key: 'c', id: 'af-last' }, 'C'),
+    ]);
+    await tick();
+    expect(document.activeElement?.id).toBe('af-target');
+  });
+
+  it('handles a dialog with zero focusables without crashing (Tab is a no-op)', async () => {
+    const onClose = vi.fn();
+    mount(true, onClose, React.createElement('p', null, 'No focusables'));
+    await tick();
+    const ev = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    expect(() => window.dispatchEvent(ev)).not.toThrow();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it('uses capture phase so Escape inside a child <input> still closes the dialog (BUG-017 regression guard)', async () => {
+    const onClose = vi.fn();
+    mount(true, onClose, React.createElement('input', { id: 'inside-input', defaultValue: '' }));
+    await tick();
+    const input = document.getElementById('inside-input') as HTMLInputElement;
+    input.focus();
+
+    // Dispatch via input so the event starts at the input target. The
+    // hook listens at the window level with capture=true so Escape
+    // reaches the handler before any input keybinding could swallow
+    // it.
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/node-ui/test/use-shell-routing.test.ts
+++ b/packages/node-ui/test/use-shell-routing.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+
+import {
+  TAB_TO_URL_PATH,
+  URL_PATH_TO_TAB,
+  useShellRouting,
+} from '../src/ui/hooks/useShellRouting.js';
+import { useTabsStore } from '../src/ui/stores/tabs.js';
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+/**
+ * A tiny harness that calls `useShellRouting` and exposes the current
+ * pathname + active tab id back to the test through a ref-like
+ * out-parameter. We render it inside a `MemoryRouter` so React Router
+ * is fully functional in the test environment.
+ */
+function ShellRoutingHarness({ pathnameRef }: { pathnameRef: { current: string } }) {
+  const loc = useLocation();
+  pathnameRef.current = loc.pathname;
+  useShellRouting();
+  return null;
+}
+
+function mountAtPath(initialPath: string, pathnameRef: { current: string }): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      React.createElement(
+        MemoryRouter,
+        { initialEntries: [initialPath] },
+        React.createElement(
+          Routes,
+          null,
+          React.createElement(Route, {
+            path: '*',
+            element: React.createElement(ShellRoutingHarness, { pathnameRef }),
+          }),
+        ),
+      ),
+    );
+  });
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+}
+
+function resetTabsStore() {
+  useTabsStore.setState({
+    tabs: [{ id: 'dashboard', label: 'Dashboard', closable: false }],
+    activeTabId: 'dashboard',
+  });
+}
+
+describe('useShellRouting (BUG-018 + Codex unmapped-tab follow-up)', () => {
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    resetTabsStore();
+  });
+
+  afterEach(() => {
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+    resetTabsStore();
+  });
+
+  describe('mapping table integrity', () => {
+    it('every URL path maps to a tab id that has a corresponding URL back-mapping', () => {
+      // Round-trip /settings -> settings -> /settings is the
+      // contract Step 2 of the hook depends on. If a path ever maps
+      // to a tab id that has no back-mapping the URL would never
+      // sync after a tab click.
+      for (const path of Object.keys(URL_PATH_TO_TAB)) {
+        const tabId = URL_PATH_TO_TAB[path].id;
+        expect(TAB_TO_URL_PATH).toHaveProperty(tabId);
+      }
+    });
+
+    it('TAB_TO_URL_PATH covers the canonical tabs (operations, settings, dashboard)', () => {
+      expect(TAB_TO_URL_PATH.operations).toBeDefined();
+      expect(TAB_TO_URL_PATH.settings).toBeDefined();
+      expect(TAB_TO_URL_PATH.dashboard).toBeDefined();
+    });
+  });
+
+  describe('Step 1 — deep-link landing opens the matching tab', () => {
+    it('landing on /settings opens the Settings tab and makes it active', () => {
+      const ref = { current: '' };
+      mountAtPath('/settings', ref);
+      const { tabs, activeTabId } = useTabsStore.getState();
+      expect(tabs.find((t) => t.id === 'settings')).toBeDefined();
+      expect(activeTabId).toBe('settings');
+    });
+
+    it('landing on /observability opens the Observability tab', () => {
+      const ref = { current: '' };
+      mountAtPath('/observability', ref);
+      const { activeTabId } = useTabsStore.getState();
+      expect(activeTabId).toBe('operations');
+    });
+
+    it('landing on /operations is a back-compat alias for /observability', () => {
+      const ref = { current: '' };
+      mountAtPath('/operations', ref);
+      const { activeTabId } = useTabsStore.getState();
+      expect(activeTabId).toBe('operations');
+    });
+
+    it('landing on a non-deep-link path leaves the dashboard tab active', () => {
+      const ref = { current: '' };
+      mountAtPath('/network', ref);
+      const { activeTabId } = useTabsStore.getState();
+      expect(activeTabId).toBe('dashboard');
+    });
+  });
+
+  describe('Step 2 — URL syncs to the active tab', () => {
+    it('opens /settings → user clicks Operations tab → URL navigates to /observability', async () => {
+      const ref = { current: '' };
+      mountAtPath('/settings', ref);
+      expect(ref.current).toBe('/settings');
+
+      // Simulate the user clicking the Observability tab
+      await act(async () => {
+        useTabsStore.getState().openTab({ id: 'operations', label: 'Observability', closable: true });
+      });
+      expect(ref.current).toBe('/observability');
+    });
+
+    it('Codex follow-up: deep-link to /settings → open project tab (unmapped) → URL resets to / so refresh lands on dashboard', async () => {
+      // The previous implementation only updated the URL for tabs in
+      // TAB_TO_URL_PATH. Deep-linking to /settings then opening a
+      // project:foo tab left pathname stuck at /settings, so refresh
+      // dropped the user back into Settings instead of the project
+      // they were viewing.
+      const ref = { current: '' };
+      mountAtPath('/settings', ref);
+      expect(ref.current).toBe('/settings');
+
+      await act(async () => {
+        useTabsStore.getState().openTab({ id: 'project:foo', label: 'Foo', closable: true });
+      });
+      expect(ref.current).toBe('/');
+    });
+
+    it('returns to / when an unmapped tab is opened from the dashboard (active tab is dashboard, no clobber of other deep-link paths)', async () => {
+      const ref = { current: '' };
+      mountAtPath('/', ref);
+      expect(ref.current).toBe('/');
+
+      // Open an unmapped tab; URL stays at / (dashboard's mapped path).
+      await act(async () => {
+        useTabsStore.getState().openTab({ id: 'project:bar', label: 'Bar', closable: true });
+      });
+      // Active tab is now unmapped, and pathname is '/' which is NOT
+      // in URL_PATH_TO_TAB. The hook leaves the URL alone — Step 2's
+      // reset only fires when pathname IS a known deep-link path.
+      expect(ref.current).toBe('/');
+    });
+
+    it('the unmapped-tab reset is scoped to known deep-link paths: switching from /observability to a project tab triggers the reset (BUG-018 follow-up scope)', async () => {
+      const ref = { current: '' };
+      mountAtPath('/observability', ref);
+      expect(ref.current).toBe('/observability');
+
+      await act(async () => {
+        useTabsStore.getState().openTab({ id: 'project:baz', label: 'Baz', closable: true });
+      });
+      expect(ref.current).toBe('/');
+    });
+
+    it('idempotent — switching to the active tab does not push history when URL already matches', async () => {
+      const ref = { current: '' };
+      mountAtPath('/settings', ref);
+      expect(ref.current).toBe('/settings');
+
+      // Re-asserting the same active tab should be a no-op for the
+      // address bar. The hook uses `navigate(..., { replace: true })`
+      // and only navigates when `target !== pathname`.
+      await act(async () => {
+        useTabsStore.getState().setActiveTab('settings');
+      });
+      expect(ref.current).toBe('/settings');
+    });
+  });
+});

--- a/packages/node-ui/test/use-visibility-polling.test.ts
+++ b/packages/node-ui/test/use-visibility-polling.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { useVisibilityPolling } from '../src/ui/hooks/useVisibilityPolling.js';
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+interface HostProps {
+  cb: () => void;
+  intervalMs: number;
+  runImmediately?: boolean;
+}
+
+function PollHost({ cb, intervalMs, runImmediately }: HostProps) {
+  useVisibilityPolling(cb, intervalMs, { runImmediately });
+  return null;
+}
+
+function mount(props: HostProps): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(PollHost, props));
+  });
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+}
+
+function setHidden(hidden: boolean): void {
+  Object.defineProperty(document, 'hidden', { value: hidden, configurable: true });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+describe('useVisibilityPolling (BUG-007)', () => {
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    // Default to a visible tab; individual tests override.
+    Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+  });
+
+  afterEach(() => {
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+    vi.useRealTimers();
+  });
+
+  it('runs immediately on mount + on each interval while visible', () => {
+    const cb = vi.fn();
+    mount({ cb, intervalMs: 1000 });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(cb).toHaveBeenCalledTimes(5);
+  });
+
+  it('honours runImmediately: false (no initial fire on mount)', () => {
+    const cb = vi.fn();
+    mount({ cb, intervalMs: 1000, runImmediately: false });
+    expect(cb).not.toHaveBeenCalled();
+
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('pauses the timer when the tab becomes hidden', () => {
+    const cb = vi.fn();
+    mount({ cb, intervalMs: 1000 });
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // Hide the tab — visibilitychange handler should stop the interval
+    act(() => { setHidden(true); });
+
+    // 10s of fake time elapses while hidden — must not fire
+    act(() => { vi.advanceTimersByTime(10_000); });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes immediately on resume + resumes interval cadence', () => {
+    const cb = vi.fn();
+    mount({ cb, intervalMs: 1000 });
+    cb.mockClear();
+
+    act(() => { setHidden(true); });
+    act(() => { vi.advanceTimersByTime(5000); });
+    expect(cb).not.toHaveBeenCalled();
+
+    // Tab becomes visible — immediate refresh + interval restart
+    act(() => { setHidden(false); });
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('intervalMs <= 0 disables polling entirely (still safe to mount/unmount)', () => {
+    const cb = vi.fn();
+    mount({ cb, intervalMs: 0 });
+    act(() => { vi.advanceTimersByTime(10_000); });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the visibilitychange listener and timer on unmount (no leaked fires)', () => {
+    const cb = vi.fn();
+    mount({ cb, intervalMs: 1000 });
+    cb.mockClear();
+
+    // Unmount
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+
+    // Both visibility and timer paths must be inert post-unmount.
+    act(() => { vi.advanceTimersByTime(5000); });
+    act(() => { setHidden(true); setHidden(false); });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('does not start the timer if mounted while the tab is already hidden (mount-on-hidden regression)', () => {
+    Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+    const cb = vi.fn();
+    mount({ cb, intervalMs: 1000, runImmediately: false });
+
+    // No initial fire (runImmediately: false), and timer must NOT
+    // have started because document.hidden was true at mount.
+    act(() => { vi.advanceTimersByTime(5000); });
+    expect(cb).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the bugs surfaced during the rc.11 Node-UI manual QA pass. Every fix is applied at the cause (no test-only patches) and ships with greedy unit coverage where a small helper exists; component-level integration tests stay where the surface area is genuinely React.

## Fix list

### UI / UX
- **BUG-001** (P2) — Daemon returns `200` + empty `MemorySession` for unknown sessions instead of 404. The first-render console no longer reds.
- **BUG-002** (P3) — All 11 form fields and the bell button gained `id`/`name`/`aria-label`. Password managers + screen readers stop ignoring them.
- **BUG-003** (P2) — Notification dropdown + Operations table use a date-aware formatter (`Yesterday`, weekday short name, full date for older). A 2-month-old event no longer reads as fresh time.
- **BUG-004** (P1) — Light-mode class toggles on `documentElement` so `:root --bg-root` cascades to `<html>`. macOS rubber-band overscroll no longer flashes black.
- **BUG-005** (P1) — Keyboard shortcut dispatcher normalises `e.key` (Caps Lock + Shift) and guards on `!shiftKey` so `Cmd+B` and `Cmd+Shift+B` can't double-fire.
- **BUG-006/009/013** (P1/P2/P3) — New `formatEth` + `formatTracSymbol` helpers; Dashboard and Settings agree on precision, sub-precision rendering, and label (incl. `(testnet)` qualifier on `v9TRAC`).
- **BUG-008** (P1) — Settings ONLINE row distinguishes _peers_ vs _links_ (a peer can hold both a direct + relayed link). Tooltip exposes the breakdown.
- **BUG-010** (P1) — Disabled Privacy & Memory toggles dim further and show a `read-only` label so users stop trying to flip them.
- **BUG-011** (P3) — Developer Mode description rewritten to describe the observability deep-dive views it actually unlocks.
- **BUG-012/015** (P1/P3) — `redactRpcUrl` masks bearer-style tokens in path/query segments. Settings RPC field has a Reveal toggle. The `Show` button is hidden when the LLM API key field is empty.
- **BUG-014** (P3) — The 200+ context-graph "Background Sync" dropdown is now filterable via search + a `Hide system CGs` toggle.
- **BUG-016** (P1) — Create CG modal sanitises and caps the name field: HTML tags stripped, control chars dropped, length capped at 80.
- **BUG-017** (P2) — Create/Join modals share `useModalDismiss`: Esc key, focus trap, `role="dialog"`, restored focus on close, dedicated close button.
- **BUG-018** (P1) — `/settings` and `/observability` are deep-linkable. Active tab and URL stay in sync across refresh + back/forward.
- **BUG-019** (P3) — Notifications sort newest-first; "Clear all" and read marker added.
- **BUG-020** (P3) — Header status pill exposes the peer breakdown via tooltip.

### Performance / log noise
- **BUG-007** (P1) — `useFetch` pauses on `document.hidden`, and `PanelLeft`/`PanelRight`/`Header` share the `useCurrentAgent` hook. A backgrounded tab no longer storms `/api/*` every 10s.
- **BUG-022** (P1) — ethers v6 logs `eth_getFilterChanges` "filter not found" through `console.log("@TODO", err)`, bypassing the provider error channel. The chain adapter now installs a `console.log` interceptor that routes those entries through the existing dedupe silencer.

## Test plan
- [x] `pnpm --filter @origintrail-official/dkg-chain run test` — pass (incl. new `filter-error-console-suppressor`).
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run test` — 865 pass / 38 skipped / 0 fail (64 test files).
- [x] `pnpm -w build` — clean.
- [x] Manual smoke against a running rc.11 daemon for BUG-001/004/005/007/012/016/018/022.
- [x] CI green on this PR.

## Out of scope
- `packages/epcis` e2e capture suite + the publisher / agent e2e suites — these need a live daemon and reproduce on `main`.

Made with [Cursor](https://cursor.com)