### PR TITLE
fix(node-ui): WM Assertions tab surfaces sub-graph assertions (#706)

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -653,19 +653,30 @@ export async function listAssertions(
   // lifecycle hook uses (`subGraphFromAssertionGraphUri`) — defensive
   // on malformed input, returns undefined for root-bucket URIs.
   const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
+  const ASSERTION_SEG = 'assertion/';
   const result: AssertionInfo[] = [];
   for (const b of bindings) {
     const g = typeof b.g === 'string' ? b.g : b.g?.value;
-    if (!g || !g.startsWith(cgPrefix) || !g.includes('/assertion/')) continue;
-    // The tail after `cgPrefix` is one of:
-    //   `assertion/<agent>/<name>`            → root-bucket
+    if (!g || !g.startsWith(cgPrefix)) continue;
+    // Scope the `/assertion/` discriminator to the tail (post-cgPrefix)
+    // so a `contextGraphId` that itself happens to contain
+    // `/assertion/` can't fool the parser into slicing inside the
+    // cgId. Tail shape is one of:
+    //   `assertion/<agent>/<name>`               → root-bucket
     //   `<subGraphName>/assertion/<agent>/<name>` → sub-graph-scoped
-    // Slice on `/assertion/` and take everything after the agent
-    // segment as the name. `<name>` is slash-free per the daemon's
-    // URI builder (`contextGraphAssertionUri`).
+    // Anything else (e.g. internal meta graphs sharing the prefix)
+    // is silently dropped — replaces the prior outer `.includes(
+    // '/assertion/')` filter.
+    const tail = g.slice(cgPrefix.length);
+    let afterAssertion: string;
+    if (tail.startsWith(ASSERTION_SEG)) {
+      afterAssertion = tail.slice(ASSERTION_SEG.length);
+    } else {
+      const idx = tail.indexOf('/' + ASSERTION_SEG);
+      if (idx === -1) continue;
+      afterAssertion = tail.slice(idx + ('/' + ASSERTION_SEG).length);
+    }
     const subGraph = subGraphFromAssertionGraphUri(g, contextGraphId);
-    const idx = g.indexOf('/assertion/');
-    const afterAssertion = g.slice(idx + '/assertion/'.length);
     const slash = afterAssertion.indexOf('/');
     const name = slash >= 0 ? afterAssertion.slice(slash + 1) : afterAssertion;
     if (!name) continue;

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1,5 +1,3 @@
-import { subGraphFromAssertionGraphUri } from './lib/sub-graph-uri.js';
-
 const BASE = '';
 declare global {
   interface Window { __DKG_TOKEN__?: string; }
@@ -647,38 +645,33 @@ export async function listAssertions(
   // shape silently dropped sub-graph-scoped WM assertions, whose graph
   // URI is `did:dkg:context-graph:<cg>/<sg>/assertion/<agent>/<name>`
   // (the sub-graph segment sits between `<cg>/` and `/assertion/`).
-  // Mirror the daemon's `wmSparql` discriminator: any graph under the
-  // CG prefix that contains `/assertion/` is a WM assertion, root or
-  // sub-graph. Sub-graph slug is recovered via the same parser the
-  // lifecycle hook uses (`subGraphFromAssertionGraphUri`) — defensive
-  // on malformed input, returns undefined for root-bucket URIs.
+  // We accept exactly two shapes, post-cgPrefix:
+  //   root-bucket : ['assertion', <agent>, <name>]            (3 segs)
+  //   sub-graph   : [<subGraphName>, 'assertion', <agent>, <name>] (4 segs)
+  // Anything else (extra segments on either side, internal meta
+  // graphs sharing the prefix, etc.) is silently dropped. The parse
+  // is deliberately strict so a row never gets admitted with a
+  // mis-derived name — promote/preview lookups key on `name` and
+  // would silently miss otherwise. The cgId itself is treated as
+  // opaque (it may contain `/assertion/` as a literal substring,
+  // per `validateContextGraphId`).
   const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
-  const ASSERTION_SEG = 'assertion/';
   const result: AssertionInfo[] = [];
   for (const b of bindings) {
     const g = typeof b.g === 'string' ? b.g : b.g?.value;
     if (!g || !g.startsWith(cgPrefix)) continue;
-    // Scope the `/assertion/` discriminator to the tail (post-cgPrefix)
-    // so a `contextGraphId` that itself happens to contain
-    // `/assertion/` can't fool the parser into slicing inside the
-    // cgId. Tail shape is one of:
-    //   `assertion/<agent>/<name>`               → root-bucket
-    //   `<subGraphName>/assertion/<agent>/<name>` → sub-graph-scoped
-    // Anything else (e.g. internal meta graphs sharing the prefix)
-    // is silently dropped — replaces the prior outer `.includes(
-    // '/assertion/')` filter.
-    const tail = g.slice(cgPrefix.length);
-    let afterAssertion: string;
-    if (tail.startsWith(ASSERTION_SEG)) {
-      afterAssertion = tail.slice(ASSERTION_SEG.length);
+    const segments = g.slice(cgPrefix.length).split('/');
+    let subGraph: string | undefined;
+    let name: string;
+    if (segments.length === 3 && segments[0] === 'assertion') {
+      subGraph = undefined;
+      name = segments[2];
+    } else if (segments.length === 4 && segments[1] === 'assertion') {
+      subGraph = segments[0];
+      name = segments[3];
     } else {
-      const idx = tail.indexOf('/' + ASSERTION_SEG);
-      if (idx === -1) continue;
-      afterAssertion = tail.slice(idx + ('/' + ASSERTION_SEG).length);
+      continue;
     }
-    const subGraph = subGraphFromAssertionGraphUri(g, contextGraphId);
-    const slash = afterAssertion.indexOf('/');
-    const name = slash >= 0 ? afterAssertion.slice(slash + 1) : afterAssertion;
     if (!name) continue;
     const cnt = typeof b.cnt === 'string' ? parseInt(b.cnt, 10) : (b.cnt?.value ? parseInt(b.cnt.value, 10) : undefined);
     result.push({ name, graphUri: g, tripleCount: Number.isFinite(cnt) ? cnt : undefined, subGraph });

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -712,9 +712,26 @@ export interface ExtractionStatus {
   completedAt?: string;
 }
 
-/** Fetch extraction status for an assertion (includes fileHash + contentType). */
-export const fetchExtractionStatus = (assertionName: string, contextGraphId: string) =>
-  get<ExtractionStatus>(`/api/assertion/${encodeURIComponent(assertionName)}/extraction-status?contextGraphId=${encodeURIComponent(contextGraphId)}`);
+/**
+ * Fetch extraction status for an assertion (includes fileHash + contentType).
+ *
+ * PR #710 Fix E — `subGraphName` is the third part of the daemon's
+ * lookup key alongside `(contextGraphId, assertionName)`. The route
+ * already accepts the query param
+ * (`packages/cli/src/daemon/routes/assertion.ts:3364`); only set it
+ * when supplied so root-bucket calls keep the prior URL shape.
+ */
+export const fetchExtractionStatus = (
+  assertionName: string,
+  contextGraphId: string,
+  subGraphName?: string,
+) => {
+  const params = new URLSearchParams({ contextGraphId });
+  if (subGraphName) params.set('subGraphName', subGraphName);
+  return get<ExtractionStatus>(
+    `/api/assertion/${encodeURIComponent(assertionName)}/extraction-status?${params}`,
+  );
+};
 
 /** Build a URL to serve a stored file by its hash (sha256: or keccak256:). */
 export function fileUrl(hash: string, contentType?: string): string {

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1,3 +1,5 @@
+import { subGraphFromAssertionGraphUri } from './hooks/useAssertionLifecycleEvents.js';
+
 const BASE = '';
 declare global {
   interface Window { __DKG_TOKEN__?: string; }
@@ -524,6 +526,15 @@ export interface AssertionInfo {
   name: string;
   graphUri: string;
   tripleCount?: number;
+  /**
+   * Sub-graph slug when the assertion lives in a sub-graph
+   * partition, undefined for root-bucket assertions. Lets the UI
+   * surface the structural placement inline on each row without a
+   * separate lookup. Field is uniformly populated on both WM and
+   * SWM `AssertionInfo`s so consumers don't need a layer-aware
+   * branch.
+   */
+  subGraph?: string;
 }
 
 /**
@@ -623,7 +634,7 @@ export async function listAssertions(
 
       if (seen.has(lifecycle)) continue;
       seen.add(lifecycle);
-      result.push({ name, graphUri: lifecycle });
+      result.push({ name, graphUri: lifecycle, subGraph: subGraphName });
     }
     return result;
   }
@@ -632,16 +643,34 @@ export async function listAssertions(
   const sparql = `SELECT DISTINCT ?g (COUNT(?s) AS ?cnt) WHERE { GRAPH ?g { ?s ?p ?o } } GROUP BY ?g`;
   const data = await executeQuery(sparql, contextGraphId);
   const bindings: any[] = data?.result?.bindings ?? [];
-  const prefix = `did:dkg:context-graph:${contextGraphId}/assertion/`;
+  // #706 fix — the prior `startsWith('did:dkg:context-graph:<cg>/assertion/')`
+  // shape silently dropped sub-graph-scoped WM assertions, whose graph
+  // URI is `did:dkg:context-graph:<cg>/<sg>/assertion/<agent>/<name>`
+  // (the sub-graph segment sits between `<cg>/` and `/assertion/`).
+  // Mirror the daemon's `wmSparql` discriminator: any graph under the
+  // CG prefix that contains `/assertion/` is a WM assertion, root or
+  // sub-graph. Sub-graph slug is recovered via the same parser the
+  // lifecycle hook uses (`subGraphFromAssertionGraphUri`) — defensive
+  // on malformed input, returns undefined for root-bucket URIs.
+  const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
   const result: AssertionInfo[] = [];
   for (const b of bindings) {
     const g = typeof b.g === 'string' ? b.g : b.g?.value;
-    if (!g || !g.startsWith(prefix)) continue;
-    const tail = g.slice(prefix.length);
-    const slash = tail.indexOf('/');
-    const name = slash >= 0 ? tail.slice(slash + 1) : tail;
+    if (!g || !g.startsWith(cgPrefix) || !g.includes('/assertion/')) continue;
+    // The tail after `cgPrefix` is one of:
+    //   `assertion/<agent>/<name>`            → root-bucket
+    //   `<subGraphName>/assertion/<agent>/<name>` → sub-graph-scoped
+    // Slice on `/assertion/` and take everything after the agent
+    // segment as the name. `<name>` is slash-free per the daemon's
+    // URI builder (`contextGraphAssertionUri`).
+    const subGraph = subGraphFromAssertionGraphUri(g, contextGraphId);
+    const idx = g.indexOf('/assertion/');
+    const afterAssertion = g.slice(idx + '/assertion/'.length);
+    const slash = afterAssertion.indexOf('/');
+    const name = slash >= 0 ? afterAssertion.slice(slash + 1) : afterAssertion;
+    if (!name) continue;
     const cnt = typeof b.cnt === 'string' ? parseInt(b.cnt, 10) : (b.cnt?.value ? parseInt(b.cnt.value, 10) : undefined);
-    result.push({ name, graphUri: g, tripleCount: Number.isFinite(cnt) ? cnt : undefined });
+    result.push({ name, graphUri: g, tripleCount: Number.isFinite(cnt) ? cnt : undefined, subGraph });
   }
   return result;
 }

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1,4 +1,4 @@
-import { subGraphFromAssertionGraphUri } from './hooks/useAssertionLifecycleEvents.js';
+import { subGraphFromAssertionGraphUri } from './lib/sub-graph-uri.js';
 
 const BASE = '';
 declare global {
@@ -675,9 +675,28 @@ export async function listAssertions(
   return result;
 }
 
-/** Promote an assertion from WM to SWM. */
-export const promoteAssertion = (contextGraphId: string, assertionName: string, entities: string | string[] = 'all') =>
-  post<{ promotedCount: number }>(`/api/assertion/${encodeURIComponent(assertionName)}/promote`, { contextGraphId, entities });
+/**
+ * Promote an assertion from WM to SWM.
+ *
+ * PR #710 fix — `subGraphName` is the third part of the daemon's
+ * lookup key alongside `(contextGraphId, assertionName)`. Without
+ * it, promoting a sub-graph-scoped assertion either 404s or
+ * silently promotes a same-named root-bucket assertion. The
+ * daemon route already accepts the field
+ * (`packages/cli/src/daemon/routes/assertion.ts:820-823`); only
+ * spread it when supplied so root-bucket promotes keep the prior
+ * wire shape.
+ */
+export const promoteAssertion = (
+  contextGraphId: string,
+  assertionName: string,
+  entities: string | string[] = 'all',
+  subGraphName?: string,
+) =>
+  post<{ promotedCount: number }>(
+    `/api/assertion/${encodeURIComponent(assertionName)}/promote`,
+    { contextGraphId, entities, ...(subGraphName ? { subGraphName } : {}) },
+  );
 
 // --- File preview ---
 

--- a/packages/node-ui/src/ui/components/Modals/FilePreviewModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/FilePreviewModal.tsx
@@ -6,6 +6,13 @@ interface FilePreviewModalProps {
   onClose: () => void;
   assertionName: string;
   contextGraphId: string;
+  /**
+   * PR #710 Fix E — sub-graph slug for partition-scoped assertions.
+   * Omitted for root-bucket assertions. Threaded into
+   * `fetchExtractionStatus` so the daemon's
+   * `(cg, name, subGraphName)` lookup hits the right partition.
+   */
+  subGraphName?: string;
 }
 
 const PREVIEWABLE_TYPES: Record<string, 'pdf' | 'image' | 'text' | 'markdown'> = {
@@ -33,7 +40,7 @@ async function authenticatedBlobUrl(url: string): Promise<string> {
   return URL.createObjectURL(blob);
 }
 
-export function FilePreviewModal({ open, onClose, assertionName, contextGraphId }: FilePreviewModalProps) {
+export function FilePreviewModal({ open, onClose, assertionName, contextGraphId, subGraphName }: FilePreviewModalProps) {
   const [status, setStatus] = useState<ExtractionStatus | null>(null);
   const [textContent, setTextContent] = useState<string | null>(null);
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
@@ -48,7 +55,7 @@ export function FilePreviewModal({ open, onClose, assertionName, contextGraphId 
     setTextContent(null);
     setBlobUrl(null);
 
-    fetchExtractionStatus(assertionName, contextGraphId)
+    fetchExtractionStatus(assertionName, contextGraphId, subGraphName)
       .then(async (s) => {
         setStatus(s);
         const kind = previewKind(s.detectedContentType);
@@ -67,7 +74,7 @@ export function FilePreviewModal({ open, onClose, assertionName, contextGraphId 
     return () => {
       if (blobUrl) URL.revokeObjectURL(blobUrl);
     };
-  }, [open, assertionName, contextGraphId]);
+  }, [open, assertionName, contextGraphId, subGraphName]);
 
   useEffect(() => {
     return () => {

--- a/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
+++ b/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
@@ -32,6 +32,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { authHeaders } from '../api.js';
+import { subGraphFromAssertionGraphUri } from '../lib/sub-graph-uri.js';
 
 export type AssertionLifecycleKind = 'created' | 'promoted';
 
@@ -125,35 +126,6 @@ SELECT ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph (COUNT(?root) AS
   }
 } GROUP BY ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph
   ORDER BY DESC(?ts) LIMIT 5000`;
-}
-
-/**
- * Parse a sub-graph slug out of a `dkg:assertionGraph` URI. Mirror of
- * `contextGraphAssertionUri` in `packages/core/src/constants.ts`:
- *
- *   root-bucket : `did:dkg:context-graph:<cgId>/assertion/<agent>/<name>`
- *   sub-graph   : `did:dkg:context-graph:<cgId>/<subGraphName>/assertion/<agent>/<name>`
- *
- * Returns the slug when present, `undefined` for root-bucket
- * assertions or any URI that doesn't match the expected shape (the
- * latter shouldn't happen in practice — `dkg:assertionGraph` is set
- * by the writer — but the parse stays defensive so a malformed URI
- * just suppresses the sub-graph filter rather than throwing).
- */
-export function subGraphFromAssertionGraphUri(
-  assertionGraphUri: string,
-  contextGraphId: string,
-): string | undefined {
-  const prefix = `did:dkg:context-graph:${contextGraphId}/`;
-  if (!assertionGraphUri.startsWith(prefix)) return undefined;
-  const tail = assertionGraphUri.slice(prefix.length);
-  const segments = tail.split('/');
-  // Root-bucket: tail starts with `assertion/…` (no sub-graph segment).
-  if (segments[0] === 'assertion') return undefined;
-  // Sub-graph: `<subGraphName>/assertion/…`. Require the assertion
-  // segment to actually be there so we don't misparse stray URIs.
-  if (segments.length >= 2 && segments[1] === 'assertion') return segments[0];
-  return undefined;
 }
 
 function bv(v: unknown): string | undefined {

--- a/packages/node-ui/src/ui/lib/sub-graph-uri.ts
+++ b/packages/node-ui/src/ui/lib/sub-graph-uri.ts
@@ -1,0 +1,32 @@
+/**
+ * Parse a sub-graph slug out of a `dkg:assertionGraph` URI. Mirror of
+ * `contextGraphAssertionUri` in `packages/core/src/constants.ts`:
+ *
+ *   root-bucket : `did:dkg:context-graph:<cgId>/assertion/<agent>/<name>`
+ *   sub-graph   : `did:dkg:context-graph:<cgId>/<subGraphName>/assertion/<agent>/<name>`
+ *
+ * Returns the slug when present, `undefined` for root-bucket
+ * assertions or any URI that doesn't match the expected shape (the
+ * latter shouldn't happen in practice — `dkg:assertionGraph` is set
+ * by the writer — but the parse stays defensive so a malformed URI
+ * just suppresses the sub-graph filter rather than throwing).
+ *
+ * Lives in `lib/` so both the transport layer (`api.ts`) and the
+ * lifecycle hook can import it without creating a module cycle —
+ * pure string parser, no React or transport dependency.
+ */
+export function subGraphFromAssertionGraphUri(
+  assertionGraphUri: string,
+  contextGraphId: string,
+): string | undefined {
+  const prefix = `did:dkg:context-graph:${contextGraphId}/`;
+  if (!assertionGraphUri.startsWith(prefix)) return undefined;
+  const tail = assertionGraphUri.slice(prefix.length);
+  const segments = tail.split('/');
+  // Root-bucket: tail starts with `assertion/…` (no sub-graph segment).
+  if (segments[0] === 'assertion') return undefined;
+  // Sub-graph: `<subGraphName>/assertion/…`. Require the assertion
+  // segment to actually be there so we don't misparse stray URIs.
+  if (segments.length >= 2 && segments[1] === 'assertion') return segments[0];
+  return undefined;
+}

--- a/packages/node-ui/src/ui/lib/truncate.ts
+++ b/packages/node-ui/src/ui/lib/truncate.ts
@@ -1,0 +1,19 @@
+/**
+ * Middle-ellipsis truncation for chip-sized strings. Originally added
+ * for the #706 sub-graph chip (slugs are commonly prefix-namespaced
+ * — `epcis-*`, `github-*` — so the discriminator lives at the end;
+ * mid-truncation preserves both sides and keeps the chip compact).
+ * Lives in `lib/` so both `AssertionsList` (components.tsx) and the
+ * `MemoryLayerView` AssertionList row can render the same chip
+ * without either consumer reaching across views.
+ */
+export function truncateMiddle(s: string, max: number): string {
+  if (s.length <= max) return s;
+  // Reserve 1 char for the ellipsis; split the remaining budget
+  // weighted slightly toward the prefix (so namespace prefixes
+  // like `epcis-` survive in full on common slug widths).
+  const budget = max - 1;
+  const head = Math.ceil(budget / 2);
+  const tail = budget - head;
+  return `${s.slice(0, head)}…${s.slice(-tail)}`;
+}

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -4,6 +4,7 @@ import { executeQuery, listAssertions, promoteAssertion, publishSharedMemory, li
 import { FilePreviewModal } from '../components/Modals/FilePreviewModal.js';
 import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
 import { memoryGraphLabels } from '../lib/memoryLabels.js';
+import { truncateMiddle } from '../lib/truncate.js';
 
 const RdfGraph = lazy(() =>
   import('@origintrail-official/dkg-graph-viz/react').then(m => ({ default: m.RdfGraph }))
@@ -397,7 +398,11 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
   // would highlight two rows on a single click. `'__all__'`
   // sentinel stays — not collidable with any graphUri.
   const [promoting, setPromoting] = useState<string | null>(null);
-  const [promoteResult, setPromoteResult] = useState<{ name: string; count: number } | null>(null);
+  // PR #710 — track `subGraph` on the success state so the result
+  // copy can disambiguate which partition was promoted. Two rows
+  // labeled `draft` (one root, one sub-graph) would otherwise emit
+  // the same message and leave the user guessing.
+  const [promoteResult, setPromoteResult] = useState<{ name: string; count: number; subGraph?: string } | null>(null);
   const [promoteError, setPromoteError] = useState<string | null>(null);
   // PR #710 Fix E — preview state carries the sub-graph slug too so
   // `FilePreviewModal` can pass it through to the daemon's
@@ -415,7 +420,7 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
       // `(cg, name, subGraph)` lookup hits the right partition;
       // mirrors the AssertionsList fix in components.tsx.
       const res = await promoteAssertion(contextGraphId, assertion.name, 'all', assertion.subGraph);
-      setPromoteResult({ name: assertion.name, count: res.promotedCount });
+      setPromoteResult({ name: assertion.name, count: res.promotedCount, subGraph: assertion.subGraph });
       refresh();
       onPromoted();
     } catch (err: any) {
@@ -476,6 +481,18 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
               {a.tripleCount != null && (
                 <span className="v10-assertion-item-count">{a.tripleCount} triples</span>
               )}
+              {a.subGraph && (
+                // PR #710 — mirror the AssertionsList chip pattern
+                // (components.tsx). Same class, same `›` glyph, same
+                // truncation, same tooltip — disambiguates rows that
+                // share a name across root/sub-graph partitions.
+                <span
+                  className="v10-item-count v10-item-subgraph"
+                  title={`In sub-graph: ${a.subGraph}`}
+                >
+                  › {truncateMiddle(a.subGraph, 18)}
+                </span>
+              )}
             </div>
             <button
               className="v10-btn-promote"
@@ -490,7 +507,8 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
       </div>
       {promoteResult && (
         <div className="v10-promote-result success">
-          Promoted {promoteResult.count} triples from {promoteResult.name} to Shared Working Memory.
+          Promoted {promoteResult.count} triples from {promoteResult.name}
+          {promoteResult.subGraph ? ` (in ${promoteResult.subGraph})` : ''} to Shared Working Memory.
         </div>
       )}
       {promoteError && (

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -396,12 +396,15 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
   const [promoteError, setPromoteError] = useState<string | null>(null);
   const [previewName, setPreviewName] = useState<string | null>(null);
 
-  const handlePromote = useCallback(async (name: string) => {
+  const handlePromote = useCallback(async (name: string, subGraph?: string) => {
     setPromoting(name);
     setPromoteResult(null);
     setPromoteError(null);
     try {
-      const res = await promoteAssertion(contextGraphId, name);
+      // PR #710 — thread `subGraph` so the daemon's
+      // `(cg, name, subGraph)` lookup hits the right partition;
+      // mirrors the AssertionsList fix in components.tsx.
+      const res = await promoteAssertion(contextGraphId, name, 'all', subGraph);
       setPromoteResult({ name, count: res.promotedCount });
       refresh();
       onPromoted();
@@ -420,7 +423,8 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
     let totalPromoted = 0;
     try {
       for (const a of assertions) {
-        const res = await promoteAssertion(contextGraphId, a.name);
+        // PR #710 — see comment on the single-row handler above.
+        const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
         totalPromoted += res.promotedCount;
       }
       setPromoteResult({ name: 'all assertions', count: totalPromoted });
@@ -466,7 +470,7 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
             <button
               className="v10-btn-promote"
               disabled={promoting !== null}
-              onClick={() => handlePromote(a.name)}
+              onClick={() => handlePromote(a.name, a.subGraph)}
               title="Copy these triples to Shared Working Memory"
             >
               {promoting === a.name ? 'Promoting...' : '→ SWM'}

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -391,21 +391,31 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
     0
   );
   useMemoryGraphEvents(contextGraphId, refresh, { layers: ['wm'] });
+  // PR #710 Fix D — busy state keyed on `graphUri` (unique per row,
+  // produced by the daemon). `name` is no longer unique once
+  // sub-graph + root partitions share names, so a name-keyed busy
+  // would highlight two rows on a single click. `'__all__'`
+  // sentinel stays — not collidable with any graphUri.
   const [promoting, setPromoting] = useState<string | null>(null);
   const [promoteResult, setPromoteResult] = useState<{ name: string; count: number } | null>(null);
   const [promoteError, setPromoteError] = useState<string | null>(null);
-  const [previewName, setPreviewName] = useState<string | null>(null);
+  // PR #710 Fix E — preview state carries the sub-graph slug too so
+  // `FilePreviewModal` can pass it through to the daemon's
+  // `/extraction-status` route. Pre-fix, clicking a sub-graph
+  // assertion's filename queried the root-bucket assertion → 404
+  // or wrong file.
+  const [preview, setPreview] = useState<{ name: string; subGraph?: string } | null>(null);
 
-  const handlePromote = useCallback(async (name: string, subGraph?: string) => {
-    setPromoting(name);
+  const handlePromote = useCallback(async (assertion: AssertionInfo) => {
+    setPromoting(assertion.graphUri);
     setPromoteResult(null);
     setPromoteError(null);
     try {
-      // PR #710 — thread `subGraph` so the daemon's
+      // PR #710 Fix A — thread `subGraph` so the daemon's
       // `(cg, name, subGraph)` lookup hits the right partition;
       // mirrors the AssertionsList fix in components.tsx.
-      const res = await promoteAssertion(contextGraphId, name, 'all', subGraph);
-      setPromoteResult({ name, count: res.promotedCount });
+      const res = await promoteAssertion(contextGraphId, assertion.name, 'all', assertion.subGraph);
+      setPromoteResult({ name: assertion.name, count: res.promotedCount });
       refresh();
       onPromoted();
     } catch (err: any) {
@@ -454,12 +464,12 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
       </div>
       <div className="v10-assertion-items">
         {assertions.map((a) => (
-          <div key={a.name} className="v10-assertion-item">
+          <div key={a.graphUri} className="v10-assertion-item">
             <div className="v10-assertion-item-info">
               <button
                 className="v10-assertion-item-name clickable"
                 title={a.graphUri}
-                onClick={() => setPreviewName(a.name)}
+                onClick={() => setPreview({ name: a.name, subGraph: a.subGraph })}
               >
                 {a.name}
               </button>
@@ -470,10 +480,10 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
             <button
               className="v10-btn-promote"
               disabled={promoting !== null}
-              onClick={() => handlePromote(a.name, a.subGraph)}
+              onClick={() => handlePromote(a)}
               title="Copy these triples to Shared Working Memory"
             >
-              {promoting === a.name ? 'Promoting...' : '→ SWM'}
+              {promoting === a.graphUri ? 'Promoting...' : '→ SWM'}
             </button>
           </div>
         ))}
@@ -489,11 +499,12 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
         </div>
       )}
 
-      {previewName && (
+      {preview && (
         <FilePreviewModal
           open
-          onClose={() => setPreviewName(null)}
-          assertionName={previewName}
+          onClose={() => setPreview(null)}
+          assertionName={preview.name}
+          subGraphName={preview.subGraph}
           contextGraphId={contextGraphId}
         />
       )}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -9,7 +9,7 @@ import {
   publishSharedMemory, executeQuery,
   writeProfileQueryCatalog,
   fetchSubGraphs,
-  type AgentIdentity, type PendingJoinRequest, type PublishResult, type SubGraphInfo,
+  type AgentIdentity, type AssertionInfo, type PendingJoinRequest, type PublishResult, type SubGraphInfo,
 } from '../../api.js';
 import { ImportFilesModal } from '../../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../../components/Modals/ShareProjectModal.js';
@@ -2688,16 +2688,21 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const handlePromote = useCallback(async (name: string, subGraph?: string) => {
-    setBusy(name);
+  const handlePromote = useCallback(async (assertion: AssertionInfo) => {
+    // PR #710 Fix D — busy / React keys must use `graphUri`, not
+    // `name`. A root + sub-graph pair can share a name and would
+    // otherwise both highlight as busy on a single click. `graphUri`
+    // is produced by the daemon and uniquely identifies the row.
+    setBusy(assertion.graphUri);
     setResult(null);
     setError(null);
     try {
       if (layer === 'wm') {
-        // PR #710 — sub-graph slug threads into the daemon's lookup
-        // key so a row clicked from a sub-graph partition resolves
-        // to that partition's assertion, not a same-named root one.
-        const res = await promoteAssertion(contextGraphId, name, 'all', subGraph);
+        // PR #710 Fix A — sub-graph slug threads into the daemon's
+        // `(cg, name, subGraph)` lookup so a row clicked from a
+        // sub-graph partition resolves to that partition's
+        // assertion, not a same-named root one.
+        const res = await promoteAssertion(contextGraphId, assertion.name, 'all', assertion.subGraph);
         setResult(`Promoted ${res.promotedCount} triples to Shared Memory`);
       } else {
         await publishSharedMemory(contextGraphId);
@@ -2790,7 +2795,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
       {result && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--text-success)' }}>✓ {result}</div>}
       {error && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--text-danger)' }}>✕ {error}</div>}
       {assertions.map(a => (
-        <div key={a.name} className="v10-item-row">
+        <div key={a.graphUri} className="v10-item-row">
           <span className="v10-item-icon">▤</span>
           <div className="v10-item-info">
             <div className="v10-item-name" style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{a.name}</div>
@@ -2809,10 +2814,10 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
           <button
             className={`v10-layer-expand-footer-btn ${layer === 'wm' ? 'promote' : 'publish'}`}
             disabled={busy !== null}
-            onClick={ev => { ev.stopPropagation(); handlePromote(a.name, a.subGraph); }}
-            style={{ opacity: busy === a.name ? 0.5 : 1, flexShrink: 0 }}
+            onClick={ev => { ev.stopPropagation(); handlePromote(a); }}
+            style={{ opacity: busy === a.graphUri ? 0.5 : 1, flexShrink: 0 }}
           >
-            {busy === a.name ? '...' : actionLabel}
+            {busy === a.graphUri ? '...' : actionLabel}
           </button>
         </div>
       ))}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { useFetch } from '../../hooks.js';
 import { api } from '../../api-wrapper.js';
 import { encodeDocTabId, resolveDocRef } from '../../lib/doc-tab-id.js';
+import { truncateMiddle } from '../../lib/truncate.js';
 import {
   listJoinRequests, approveJoinRequest, rejectJoinRequest,
   listAssertions, promoteAssertion,
@@ -2654,24 +2655,6 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
 }
 
 // Small helper: compute unique triples for a given layer slice of memory.
-
-/**
- * #706 sub-graph chip — middle-ellipsis truncation. Sub-graph slugs
- * are commonly prefix-namespaced (`epcis-*`, `github-*`), so the
- * discriminator lives at the end. Mid-truncation preserves both
- * sides and keeps the chip compact. The full slug stays in the
- * row's tooltip so power users can recover it.
- */
-function truncateMiddle(s: string, max: number): string {
-  if (s.length <= max) return s;
-  // Reserve 1 char for the ellipsis; split the remaining budget
-  // weighted slightly toward the prefix (so namespace prefixes
-  // like `epcis-` survive in full on common slug widths).
-  const budget = max - 1;
-  const head = Math.ceil(budget / 2);
-  const tail = budget - head;
-  return `${s.slice(0, head)}…${s.slice(-tail)}`;
-}
 
 export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }: {
   contextGraphId: string;

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -2653,6 +2653,24 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
 
 // Small helper: compute unique triples for a given layer slice of memory.
 
+/**
+ * #706 sub-graph chip — middle-ellipsis truncation. Sub-graph slugs
+ * are commonly prefix-namespaced (`epcis-*`, `github-*`), so the
+ * discriminator lives at the end. Mid-truncation preserves both
+ * sides and keeps the chip compact. The full slug stays in the
+ * row's tooltip so power users can recover it.
+ */
+function truncateMiddle(s: string, max: number): string {
+  if (s.length <= max) return s;
+  // Reserve 1 char for the ellipsis; split the remaining budget
+  // weighted slightly toward the prefix (so namespace prefixes
+  // like `epcis-` survive in full on common slug widths).
+  const budget = max - 1;
+  const head = Math.ceil(budget / 2);
+  const tail = budget - head;
+  return `${s.slice(0, head)}…${s.slice(-tail)}`;
+}
+
 export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }: {
   contextGraphId: string;
   layer: 'wm' | 'swm';
@@ -2772,6 +2790,14 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
             <div className="v10-item-name" style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{a.name}</div>
             <div className="v10-item-meta-row">
               {a.tripleCount != null && <span className="v10-item-count">{a.tripleCount} triples</span>}
+              {a.subGraph && (
+                <span
+                  className="v10-item-count v10-item-subgraph"
+                  title={`In sub-graph: ${a.subGraph}`}
+                >
+                  🗂 {truncateMiddle(a.subGraph, 18)}
+                </span>
+              )}
             </div>
           </div>
           <button

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1560,7 +1560,9 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
         const assertions = await listAssertions(contextGraphId, 'wm');
         let promoted = 0;
         for (const a of assertions) {
-          const res = await promoteAssertion(contextGraphId, a.name);
+          // PR #710 — thread `subGraph` so sub-graph-scoped assertions
+          // hit the correct daemon lookup key `(cg, name, subGraph)`.
+          const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
           promoted += res.promotedCount;
         }
         setResult(`Promoted ${promoted} triple${promoted !== 1 ? 's' : ''} to Shared Memory`);
@@ -2686,13 +2688,16 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const handlePromote = useCallback(async (name: string) => {
+  const handlePromote = useCallback(async (name: string, subGraph?: string) => {
     setBusy(name);
     setResult(null);
     setError(null);
     try {
       if (layer === 'wm') {
-        const res = await promoteAssertion(contextGraphId, name);
+        // PR #710 — sub-graph slug threads into the daemon's lookup
+        // key so a row clicked from a sub-graph partition resolves
+        // to that partition's assertion, not a same-named root one.
+        const res = await promoteAssertion(contextGraphId, name, 'all', subGraph);
         setResult(`Promoted ${res.promotedCount} triples to Shared Memory`);
       } else {
         await publishSharedMemory(contextGraphId);
@@ -2716,7 +2721,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
       if (layer === 'wm') {
         let total = 0;
         for (const a of assertions) {
-          const res = await promoteAssertion(contextGraphId, a.name);
+          // PR #710 — see comment on the single-row handler above.
+          const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
           total += res.promotedCount;
         }
         setResult(`Promoted ${total} triples across ${assertions.length} assertion${assertions.length !== 1 ? 's' : ''}`);
@@ -2803,7 +2809,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
           <button
             className={`v10-layer-expand-footer-btn ${layer === 'wm' ? 'promote' : 'publish'}`}
             disabled={busy !== null}
-            onClick={ev => { ev.stopPropagation(); handlePromote(a.name); }}
+            onClick={ev => { ev.stopPropagation(); handlePromote(a.name, a.subGraph); }}
             style={{ opacity: busy === a.name ? 0.5 : 1, flexShrink: 0 }}
           >
             {busy === a.name ? '...' : actionLabel}
@@ -3046,12 +3052,16 @@ export function VerifyOnDkgButton({
     return null;
   }, [entity.types, profile, layer]);
 
+  // PR #710 — keep the matched sub-graph slug alongside the binding so
+  // the promote call below can pass it to the daemon (the source
+  // assertion is sub-graph-scoped; daemon lookup keys on
+  // `(cg, name, subGraph)`).
   const sgBinding = useMemo(() => {
     if (!profile) return null;
     for (const s of entity.subGraphs) {
       if (s === 'meta') continue;
       const b = profile.forSubGraph(s);
-      if (b?.sourceAssertion) return b;
+      if (b?.sourceAssertion) return { binding: b, subGraph: s };
     }
     return null;
   }, [entity.subGraphs, profile]);
@@ -3065,8 +3075,8 @@ export function VerifyOnDkgButton({
         label:    binding.promoteLabel ?? 'Promote to Shared Memory',
         hint:     binding.promoteHint  ?? 'Shares this entity with the team.',
         busyCopy: 'Sharing…',
-        disabled: !sgBinding?.sourceAssertion,
-        disabledReason: !sgBinding?.sourceAssertion
+        disabled: !sgBinding?.binding.sourceAssertion,
+        disabledReason: !sgBinding?.binding.sourceAssertion
           ? `No sourceAssertion declared on the sub-graph profile — add profile:sourceAssertion to the SubGraphBinding for "${[...entity.subGraphs].filter(s => s !== 'meta')[0] ?? '?'}".`
           : null,
       }
@@ -3087,10 +3097,17 @@ export function VerifyOnDkgButton({
     setResultKind(action.kind);
     try {
       if (action.kind === 'promote') {
+        // PR #710 — `sgBinding.sourceAssertion` is itself
+        // sub-graph-scoped (the binding came from a SubGraphBinding
+        // for slug `sgBinding.subGraph`), so we thread that slug as
+        // the 4th arg. Without it the daemon's `(cg, name, subGraph)`
+        // lookup falls back to the root-bucket assertion of the same
+        // name (404 or wrong-target).
         const r = await promoteAssertion(
           contextGraphId,
-          sgBinding!.sourceAssertion!,
+          sgBinding!.binding.sourceAssertion!,
           [entity.uri],
+          sgBinding!.subGraph,
         );
         setResult(r);
       } else {

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -2795,7 +2795,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
                   className="v10-item-count v10-item-subgraph"
                   title={`In sub-graph: ${a.subGraph}`}
                 >
-                  🗂 {truncateMiddle(a.subGraph, 18)}
+                  › {truncateMiddle(a.subGraph, 18)}
                 </span>
               )}
             </div>

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -411,7 +411,9 @@ describe('Context Graph shared empty/stat patterns', () => {
 
   it('renders assertion rows when SWM assertions become listable', async () => {
     apiMocks.listAssertions.mockResolvedValueOnce([
-      { name: 'turn-anno-test', tripleCount: 3 },
+      // PR #710 Fix D — React key + busy state now use `graphUri`
+      // (unique per row); fixtures must include it.
+      { name: 'turn-anno-test', graphUri: 'urn:dkg:assertion:cg-test:0xabc:turn-anno-test', tripleCount: 3 },
     ]);
     const { container, unmount } = await render(
       React.createElement(AssertionsList, {
@@ -435,10 +437,10 @@ describe('Context Graph shared empty/stat patterns', () => {
   // assertion is scoped to a partition. Root rows render no chip.
   it('renders sub-graph chip on partitioned assertions and omits it on root rows (#706)', async () => {
     apiMocks.listAssertions.mockResolvedValueOnce([
-      { name: 'root-doc', tripleCount: 2 },
-      { name: 'scoped-doc', tripleCount: 5, subGraph: 'epcis-supply-chain' },
+      { name: 'root-doc', graphUri: 'did:dkg:context-graph:cg-test/assertion/0xabc/root-doc', tripleCount: 2 },
+      { name: 'scoped-doc', graphUri: 'did:dkg:context-graph:cg-test/epcis-supply-chain/assertion/0xabc/scoped-doc', tripleCount: 5, subGraph: 'epcis-supply-chain' },
       // Long slug to exercise the 18-char middle-ellipsis truncation.
-      { name: 'long-scoped-doc', tripleCount: 1, subGraph: 'pharmaceutical-derived-product-graph' },
+      { name: 'long-scoped-doc', graphUri: 'did:dkg:context-graph:cg-test/pharmaceutical-derived-product-graph/assertion/0xabc/long-scoped-doc', tripleCount: 1, subGraph: 'pharmaceutical-derived-product-graph' },
     ]);
     const { container, unmount } = await render(
       React.createElement(AssertionsList, {

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -427,4 +427,61 @@ describe('Context Graph shared empty/stat patterns', () => {
 
     await unmount();
   });
+
+  // #706 — WM Assertions tab was silently dropping sub-graph-scoped
+  // assertions because the client-side filter only matched the root
+  // `did:dkg:context-graph:<cg>/assertion/…` shape. Fix surfaces both
+  // shapes and tags each row with an inline sub-graph chip when the
+  // assertion is scoped to a partition. Root rows render no chip.
+  it('renders sub-graph chip on partitioned assertions and omits it on root rows (#706)', async () => {
+    apiMocks.listAssertions.mockResolvedValueOnce([
+      { name: 'root-doc', tripleCount: 2 },
+      { name: 'scoped-doc', tripleCount: 5, subGraph: 'epcis-supply-chain' },
+      // Long slug to exercise the 18-char middle-ellipsis truncation.
+      { name: 'long-scoped-doc', tripleCount: 1, subGraph: 'pharmaceutical-derived-product-graph' },
+    ]);
+    const { container, unmount } = await render(
+      React.createElement(AssertionsList, {
+        contextGraphId: 'cg-test',
+        layer: 'wm',
+        onComplete: vi.fn(),
+      }),
+    );
+
+    await waitForText(container, 'root-doc');
+    await waitForText(container, 'scoped-doc');
+    await waitForText(container, 'long-scoped-doc');
+
+    // Three rows rendered (no silent drop on sub-graph rows).
+    const rows = container.querySelectorAll('.v10-item-row');
+    expect(rows.length).toBe(3);
+
+    // Locate each row by its name and verify chip presence/absence.
+    const rowFor = (name: string) =>
+      Array.from(rows).find(r => r.querySelector('.v10-item-name')?.textContent === name)!;
+
+    const rootRow = rowFor('root-doc');
+    const scopedRow = rowFor('scoped-doc');
+    const longRow = rowFor('long-scoped-doc');
+
+    // Root row has no sub-graph chip.
+    expect(rootRow.querySelector('.v10-item-subgraph')).toBeNull();
+
+    // Short slug renders verbatim (≤ 18 chars).
+    const scopedChip = scopedRow.querySelector('.v10-item-subgraph');
+    expect(scopedChip).toBeTruthy();
+    expect(scopedChip!.textContent).toContain('epcis-supply-chain');
+    // Tooltip carries the full slug regardless of truncation.
+    expect(scopedChip!.getAttribute('title')).toBe('In sub-graph: epcis-supply-chain');
+
+    // Long slug (>18 chars) gets middle-ellipsis truncated.
+    const longChip = longRow.querySelector('.v10-item-subgraph');
+    expect(longChip).toBeTruthy();
+    expect(longChip!.textContent).toContain('…');
+    expect(longChip!.textContent).not.toContain('pharmaceutical-derived-product-graph');
+    // Tooltip preserves the full slug for power users.
+    expect(longChip!.getAttribute('title')).toBe('In sub-graph: pharmaceutical-derived-product-graph');
+
+    await unmount();
+  });
 });

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -120,6 +120,40 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
     expect(out).toEqual([]);
   });
 
+  it('drops bindings with 3+ segments before `assertion/` (left-side strict shape)', async () => {
+    // Reviewer-flagged case: a binding like `<cg>/foo/bar/assertion/<a>/<n>`
+    // doesn't match either accepted shape (root = 3 segs, sub-graph =
+    // 4 segs). The prior `indexOf('/assertion/')` branch admitted it
+    // as a `subGraph: undefined` row with a mis-derived name —
+    // promote/preview lookups would silently miss. Strict-shape parse
+    // drops it.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/foo/bar/assertion/0xabc/baz', 9),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/keep', 1),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('keep');
+  });
+
+  it('drops bindings with extra segments after the name (right-side strict shape)', async () => {
+    // Pins the right-side strict-shape contract. The sub-graph branch
+    // expects exactly `<sg>/assertion/<agent>/<name>` — anything
+    // longer would mis-extract the name and orphan the row from
+    // promote/preview.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/sg/assertion/0xabc/foo/extra', 2),
+      bRow('did:dkg:context-graph:cg-A/sg/assertion/0xabc/clean', 3),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: 'clean',
+      subGraph: 'sg',
+      tripleCount: 3,
+    });
+  });
+
   it('scopes the /assertion/ discriminator to the tail when cgId itself contains "/assertion/"', async () => {
     // PR #710 reviewer guard — `validateContextGraphId` permits
     // slashes, so a cgId can literally contain `/assertion/` as a

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -119,4 +119,24 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
     const out = await listAssertions('cg-A', 'wm');
     expect(out).toEqual([]);
   });
+
+  it('scopes the /assertion/ discriminator to the tail when cgId itself contains "/assertion/"', async () => {
+    // PR #710 reviewer guard — `validateContextGraphId` permits
+    // slashes, so a cgId can literally contain `/assertion/` as a
+    // substring. The prior `g.indexOf('/assertion/')` (full URI)
+    // would have hit the cgId's internal `/assertion/` and
+    // mis-sliced the name. After tail-scoping the parse, the cgId
+    // is treated as opaque and only the tail's `/assertion/`
+    // delimiter is consulted.
+    setBindings([
+      bRow('did:dkg:context-graph:weird/assertion/cg/assertion/0xabc/foo', 4),
+    ]);
+    const out = await listAssertions('weird/assertion/cg', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: 'foo',
+      subGraph: undefined,
+      tripleCount: 4,
+    });
+  });
 });

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { listAssertions } from '../src/ui/api.js';
+
+// PR #710 — pins `listAssertions`' URI parsing directly. The
+// component test in `context-graph-empty-stat-components.test.ts`
+// mocks `listAssertions` itself, so a regression in the parsing /
+// filter logic wouldn't be caught there. This test mocks the
+// underlying `fetch` (the SPARQL transport) and exercises
+// `listAssertions` end-to-end against fixture bindings.
+//
+// Why fetch-mock rather than `vi.mock('../src/ui/api.js', …)`:
+// `listAssertions` calls `executeQuery` from inside the same module,
+// and ES intra-module references resolve to the local binding —
+// not the mocked export. Mocking the transport boundary
+// (`globalThis.fetch`, used by `post()` in api.ts) keeps the
+// parser code-path under test verbatim. Same pattern as
+// `use-swm-attributions.test.ts` from the prior round.
+
+function bRow(g: string, cnt: number) {
+  // Daemon's SPARQL JSON-binding shape: object with `value`.
+  return { g: { value: g }, cnt: { value: String(cnt) } };
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as any;
+}
+
+describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
+  let originalFetch: typeof globalThis.fetch | undefined;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as any;
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  function setBindings(bindings: unknown[]) {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ result: { bindings } }),
+    );
+  }
+
+  it('parses root-bucket assertion: name extracted, subGraph undefined', async () => {
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: 'notes',
+      graphUri: 'did:dkg:context-graph:cg-A/assertion/0xabc/notes',
+      tripleCount: 5,
+      subGraph: undefined,
+    });
+  });
+
+  it('parses sub-graph-scoped + root in the same response (#706 regression guard)', async () => {
+    // Both shapes must surface. Pre-fix, the `startsWith(…/assertion/)`
+    // filter silently dropped sub-graph rows entirely; this test
+    // pins that they're surfaced AND that the slug + name parse out.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/root-doc', 3),
+      bRow('did:dkg:context-graph:cg-A/research/assertion/0xabc/scoped-doc', 7),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(2);
+    const root = out.find(a => a.name === 'root-doc')!;
+    const scoped = out.find(a => a.name === 'scoped-doc')!;
+    expect(root.subGraph).toBeUndefined();
+    expect(scoped.subGraph).toBe('research');
+    expect(scoped.tripleCount).toBe(7);
+  });
+
+  it('silently drops malformed graph URIs that lack `/assertion/`', async () => {
+    // E.g. internal meta graphs, prefix-only matches, or any future
+    // graph layout that shares the CG prefix but isn't an assertion.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/_meta', 12),
+      bRow('did:dkg:context-graph:cg-A/research', 1),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/real', 4),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('real');
+  });
+
+  it('scopes by cgPrefix — only the queried cgId surfaces', async () => {
+    // Multi-CG responses can arise if the SPARQL is run against a
+    // wider store. The `startsWith(cgPrefix)` filter must reject
+    // bindings from other CGs. Note: the prefix is
+    // `did:dkg:context-graph:cg-A/` (trailing slash); a CG named
+    // `cg-A-suffix` has prefix `…cg-A-suffix/` which does NOT
+    // startsWith the queried prefix.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-OTHER/assertion/0xabc/other', 2),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/mine', 6),
+      bRow('did:dkg:context-graph:cg-A-suffix/assertion/0xabc/foo', 1),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('mine');
+  });
+
+  it('returns an empty list when no bindings match the cg-prefix + /assertion/ filter', async () => {
+    setBindings([
+      bRow('did:dkg:context-graph:cg-B/assertion/0xabc/foo', 1),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toEqual([]);
+  });
+});

--- a/packages/node-ui/test/sub-graph-uri.test.ts
+++ b/packages/node-ui/test/sub-graph-uri.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { subGraphFromAssertionGraphUri } from '../src/ui/lib/sub-graph-uri.js';
+
+// Mirror of `contextGraphAssertionUri` in `packages/core/src/constants.ts`.
+// The writer's URI shape is the authoritative source for the slug; the
+// lifecycle metadata never emits `dkg:subGraphName` directly. PR #710 —
+// helper relocated from `useAssertionLifecycleEvents.ts` into `lib/` so
+// `api.ts` and the lifecycle hook can both consume it without forming
+// a module cycle.
+describe('subGraphFromAssertionGraphUri — slug parse', () => {
+  it('returns the slug for sub-graph-scoped assertions', () => {
+    const uri = 'did:dkg:context-graph:cg-1/research/assertion/0xabc/notes';
+    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBe('research');
+  });
+
+  it('returns undefined for root-bucket assertions', () => {
+    const uri = 'did:dkg:context-graph:cg-1/assertion/0xabc/notes';
+    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBeUndefined();
+  });
+
+  it('returns undefined when the prefix does not match the contextGraphId', () => {
+    const uri = 'did:dkg:context-graph:cg-2/research/assertion/0xabc/notes';
+    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBeUndefined();
+  });
+
+  it('returns undefined for malformed URIs that lack the assertion segment', () => {
+    expect(subGraphFromAssertionGraphUri('did:dkg:context-graph:cg-1/research', 'cg-1')).toBeUndefined();
+    expect(subGraphFromAssertionGraphUri('did:dkg:context-graph:cg-1/research/other/0xabc/notes', 'cg-1')).toBeUndefined();
+    expect(subGraphFromAssertionGraphUri('', 'cg-1')).toBeUndefined();
+  });
+});

--- a/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
+++ b/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import {
   buildLifecycleEventsQuery,
-  subGraphFromAssertionGraphUri,
   useAssertionLifecycleEvents,
   type AssertionLifecycleEventsResult,
 } from '../src/ui/hooks/useAssertionLifecycleEvents.js';
@@ -58,33 +57,6 @@ describe('buildLifecycleEventsQuery — SPARQL shape', () => {
     expect(q).toContain('GROUP BY ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph');
     expect(q).toContain('ORDER BY DESC(?ts)');
     expect(q).toContain('LIMIT 5000');
-  });
-});
-
-describe('subGraphFromAssertionGraphUri — slug parse', () => {
-  // PR #694 review fix — mirror of `contextGraphAssertionUri` in
-  // `packages/core/src/constants.ts`. The writer's URI shape is the
-  // authoritative source for the slug; the lifecycle metadata never
-  // emits `dkg:subGraphName` directly.
-  it('returns the slug for sub-graph-scoped assertions', () => {
-    const uri = 'did:dkg:context-graph:cg-1/research/assertion/0xabc/notes';
-    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBe('research');
-  });
-
-  it('returns undefined for root-bucket assertions', () => {
-    const uri = 'did:dkg:context-graph:cg-1/assertion/0xabc/notes';
-    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBeUndefined();
-  });
-
-  it('returns undefined when the prefix does not match the contextGraphId', () => {
-    const uri = 'did:dkg:context-graph:cg-2/research/assertion/0xabc/notes';
-    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBeUndefined();
-  });
-
-  it('returns undefined for malformed URIs that lack the assertion segment', () => {
-    expect(subGraphFromAssertionGraphUri('did:dkg:context-graph:cg-1/research', 'cg-1')).toBeUndefined();
-    expect(subGraphFromAssertionGraphUri('did:dkg:context-graph:cg-1/research/other/0xabc/notes', 'cg-1')).toBeUndefined();
-    expect(subGraphFromAssertionGraphUri('', 'cg-1')).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- The Node UI's Working Memory → Assertions tab silently dropped every assertion stored in a named sub-graph. Sub-graph entities were visible in the WM Entities tab and graph view, but the corresponding assertion rows never appeared — blocking promote workflows on sub-graph-scoped assertions with no empty-state hint that anything was missing.
- Root cause: `listAssertions(cg, 'wm')` in `packages/node-ui/src/ui/api.ts` ran a permissive `SELECT DISTINCT ?g` SPARQL and then client-side-filtered with a hardcoded prefix `did:dkg:context-graph:<cgId>/assertion/` — sub-graph assertions live at `<cgId>/<subGraphName>/assertion/…` and silently failed the `startsWith` check.
- Fix mirrors the known-good `wmSparql` filter pattern (`useMemoryEntities.ts:171`) and adds a quiet sub-graph indicator to each affected row so the user can see which sub-graph each assertion belongs to.

## Related

- Closes #706 (Node UI half of #675)
- Sibling open: #675 (`dkg_query view: "working-memory"` agent-tool half — same root-only-filter family, different code path; intentionally deferred)
- Unblocks: S3 Subgraph Explorer plan work (depends on the assertion list path being sub-graph-aware)

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/api.ts` | WM filter widened to `startsWith(<cgPrefix>/) && includes('/assertion/')`; added `subGraph?: string` to `AssertionInfo`; sub-graph slug populated via the existing `subGraphFromAssertionGraphUri()` helper from `useAssertionLifecycleEvents.ts`. SWM branch also surfaces the field for uniformity. |
| `packages/node-ui/src/ui/views/project/components.tsx` | `AssertionsList` row renders an inline `🗂 <slug>` chip in `.v10-item-meta-row` when `assertion.subGraph` is set. Reuses `.v10-item-count` styling exactly (low-contrast, no fill, no border) so the chip reads as quiet structural metadata, not a state-change pill. 18-char middle-ellipsis via local `truncateMiddle`; full slug in `title="In sub-graph: <slug>"`. Non-clickable in this PR — click-to-navigate lands with S3. |
| `packages/node-ui/test/context-graph-empty-stat-components.test.ts` | Extended fixture pins root-no-chip / short-slug-verbatim / long-slug-middle-ellipsis-with-full-slug-in-tooltip behaviours. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec tsc --noEmit` clean
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/context-graph-empty-stat-components.test.ts test/use-assertion-lifecycle-events.test.ts` — 27/27
- [x] `pnpm build:ui` green
- [x] Source-side spec verification by ux-lead against the bundled CSS (all 5 spec points: glyph + slug + middle-ellipsis, `--text-tertiary`, position after `.v10-item-count`, threshold = 18, tooltip wording)
- [ ] Live walk on user's WSL node: WM Assertions tab on a CG with both root and sub-graph assertions surfaces all rows; sub-graph rows carry the `🗂 <slug>` chip; root rows don't; hover tooltip reads `In sub-graph: <full-slug>`
- [ ] Live walk: SWM Assertions tab on the same CG shows uniform chip treatment
- [ ] Live walk: a root-only CG's WM Assertions tab renders unchanged (regression sanity)

## Notes

- Out of scope (intentional): the `dkg_query view: "working-memory"` agent-tool half of #675 (separate code path in `packages/mcp-dkg`; lay-down decision deferred to its own cycle); the SubGraphBar chip-scope behaviour (S3 territory); grouping assertions by sub-graph in the list (badge-only treatment per user direction).
- ux-lead flagged a non-blocking Windows-rendering caveat: Segoe UI Emoji can ignore CSS `color` on the 🗂 glyph, so it may render more saturated than the chip's `--text-tertiary` text. CSS-only mitigation exists (`font-variant-emoji: text;`) if needed after live review.