### PR TITLE
fix(v10): align off-chain ACK gate with on-chain ST membership + structured rejection reasons

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -17962,6 +17962,20 @@ export class DKGAgent {
             }
           }
         : undefined,
+      // Surface the structured verifier when the chain adapter implements
+      // it. Translates a thrown chain-side exception into an explicit
+      // `'rpc-error'` reason so the ACKCollector can log infra failures
+      // distinctly from definitive key/stake rejections — pre-PR this
+      // try/catch swallowed RPC errors as `false`, conflating them.
+      verifyIdentityDetailed: typeof this.chain.verifyACKIdentityDetailed === 'function'
+        ? async (recoveredAddress: string, claimedIdentityId: bigint) => {
+            try {
+              return await this.chain.verifyACKIdentityDetailed!(recoveredAddress, claimedIdentityId);
+            } catch {
+              return { valid: false, reason: 'rpc-error' as const };
+            }
+          }
+        : undefined,
       log: (msg: string) => {
         const ctx = createOperationContext('publish');
         this.log.info(ctx, msg);

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -113,6 +113,26 @@ export interface ChainEvent {
   data: Record<string, unknown>;
 }
 
+/**
+ * Why an off-chain ACK signer pre-flight rejected a recovered signer.
+ * Mirrors the two on-chain gates in
+ * `KnowledgeAssetsV10._verifyACKSignature` plus an explicit
+ * `'rpc-error'` for transient chain-read failures so the publisher
+ * can distinguish "definitive rejection" from "couldn't verify".
+ * Stable wire surface — the ACKCollector rejection log includes
+ * this string verbatim.
+ */
+export type VerifyACKIdentityReason =
+  | 'key-not-registered'      // signer is not an OPERATIONAL_KEY for the claimed identity
+  | 'not-in-sharding-table'   // identity exists & key registered, but identity is not in active sharding table
+  | 'rpc-error';              // chain read threw — distinct from a definitive negative
+
+export interface VerifyACKIdentityResult {
+  valid: boolean;
+  /** Present iff `valid === false`. */
+  reason?: VerifyACKIdentityReason;
+}
+
 export interface EventFilter {
   eventTypes: string[];
   fromBlock?: number;
@@ -795,6 +815,22 @@ export interface ChainAdapter {
 
   /** Verify that a recovered signer address is a registered operational key for the given identity. */
   verifyACKIdentity?(recoveredAddress: string, claimedIdentityId: bigint): Promise<boolean>;
+
+  /**
+   * Same gate as `verifyACKIdentity`, but returns the FAILING gate so callers
+   * can produce diagnostics that an operator can act on (key registration vs
+   * stake/sharding-table eligibility vs RPC outage). The publisher's ACK
+   * collector uses this to log a precise rejection reason instead of the
+   * three-failure-modes-look-the-same legacy "not registered" string.
+   *
+   * `valid: true` MUST imply that `verifyACKIdentity` would also return `true`
+   * for the same inputs at the same chain height. Adapters that don't or
+   * can't distinguish the gates may omit this method.
+   */
+  verifyACKIdentityDetailed?(
+    recoveredAddress: string,
+    claimedIdentityId: bigint,
+  ): Promise<VerifyACKIdentityResult>;
 
   /** Idempotently register local operational wallets for an existing identity. */
   ensureOperationalWalletsRegistered?(options?: {

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -2544,7 +2544,9 @@ export class EVMChainAdapter implements ChainAdapter {
     const identityStorage = await this.resolveContract('IdentityStorage');
     if (!identityStorage) return false;
 
-    // Match on-chain verification: keyHasPurpose(identityId, keccak256(signer), OPERATIONAL_KEY)
+    // Gate 1: signer must be registered as an operational key for the claimed
+    // identity. Mirrors the on-chain `keyHasPurpose(id, keccak256(signer),
+    // OPERATIONAL_KEY)` check inside `KnowledgeAssetsV10._verifyACKSignature`.
     const keyHash = ethers.keccak256(ethers.solidityPacked(['address'], [recoveredAddress]));
     const hasPurpose: boolean = await identityStorage.keyHasPurpose(
       claimedIdentityId,
@@ -2553,36 +2555,21 @@ export class EVMChainAdapter implements ChainAdapter {
     );
     if (!hasPurpose) return false;
 
-    // Verify the identity is a staked core node (spec §9.0: "Core nodes MUST be staked").
-    // v4.0.0 — read V10 canonical stake (`ConvictionStakingStorage.getNodeStakeV10`)
-    // instead of the V8 `StakingStorage.getNodeStake` archive: under mandatory
-    // migration the V8 `nodeStake` field is unmaintained for V10 nodes and
-    // would zero-gate every legitimate V10 ACK signer (this exactly mirrors
-    // the on-chain `KnowledgeAssetsV10` ACK-signer gate, also rewired in
-    // v4.0.0). Falls back to V8 if CSS is not registered (older deploys).
-    let cs: Contract | null = null;
-    try {
-      cs = await this.resolveContract('ConvictionStakingStorage');
-    } catch {
-      cs = null;
-    }
-    if (cs) {
-      const stake: bigint = await cs.getNodeStakeV10(claimedIdentityId);
-      if (stake === 0n) return false;
-      return true;
-    }
-
-    let ss: Contract | null = null;
-    try {
-      ss = await this.resolveContract('StakingStorage');
-    } catch {
-      ss = null;
-    }
-    if (!ss) return false;
-    const v8Stake: bigint = await ss.getNodeStake(claimedIdentityId);
-    if (v8Stake === 0n) return false;
-
-    return true;
+    // Gate 2: identity must be in the active sharding table.
+    //
+    // RFC-001 rewired the on-chain ACK signer gate from `getNodeStakeV10 > 0`
+    // to `shardingTableStorage.nodeExists(identityId)` (see
+    // `KnowledgeAssetsV10._verifyACKSignature`: "ACK signers must be in the
+    // active sharding table, not merely staked"). The off-chain pre-flight
+    // here exists to spare a doomed on-chain submission gas — so it MUST
+    // mirror the on-chain check exactly. Pre-RFC-001 versions of this method
+    // gated on positive V10 stake, which let sub-`minimumStake` operators
+    // pass off-chain but reverted on-chain with `ACK signer not in sharding
+    // table`. ST membership is updated atomically by `StakingV10` whenever a
+    // node's V10 stake crosses `minimumStake` up or down.
+    const shardingTableStorage = await this.resolveContract('ShardingTableStorage');
+    if (!shardingTableStorage) return false;
+    return Boolean(await shardingTableStorage.nodeExists(claimedIdentityId));
   }
 
   async verifySyncIdentity(recoveredAddress: string, claimedIdentityId: bigint): Promise<boolean> {

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -32,6 +32,7 @@ import type {
   CreateChallengeResult,
   OperationalWalletRegistrationResult,
   V10PublishingConvictionAccountInfo,
+  VerifyACKIdentityResult,
 } from './chain-adapter.js';
 import {
   NoEligibleContextGraphError,
@@ -2539,37 +2540,56 @@ export class EVMChainAdapter implements ChainAdapter {
     return Boolean(await storage.nodeExists(identityId));
   }
 
+  /**
+   * Off-chain pre-flight for the V10 ACK signer gate. Mirrors the on-chain
+   * check in `KnowledgeAssetsV10._verifyACKSignature` (post-RFC-001): the
+   * recovered signer must be a registered OPERATIONAL_KEY for the claimed
+   * identity AND that identity must be in the active sharding table.
+   *
+   * Returns a structured reason on rejection so the ACKCollector log can
+   * distinguish operator-actionable failures (key registration, sub-
+   * `minimumStake` stake) from infrastructure failures (RPC outage). Pre-
+   * RFC-001 versions of this method gated on `getNodeStakeV10 > 0`, which
+   * let sub-`minimumStake` operators clear off-chain quorum and then revert
+   * on-chain with `"ACK signer not in sharding table"`. ST membership is
+   * updated atomically by `StakingV10` whenever a node's V10 stake crosses
+   * `minimumStake` up or down.
+   */
+  async verifyACKIdentityDetailed(
+    recoveredAddress: string,
+    claimedIdentityId: bigint,
+  ): Promise<VerifyACKIdentityResult> {
+    try {
+      await this.init();
+      const identityStorage = await this.resolveContract('IdentityStorage');
+      if (!identityStorage) return { valid: false, reason: 'rpc-error' };
+
+      const keyHash = ethers.keccak256(ethers.solidityPacked(['address'], [recoveredAddress]));
+      const hasPurpose: boolean = await identityStorage.keyHasPurpose(
+        claimedIdentityId,
+        keyHash,
+        OPERATIONAL_KEY_PURPOSE,
+      );
+      if (!hasPurpose) return { valid: false, reason: 'key-not-registered' };
+
+      const shardingTableStorage = await this.resolveContract('ShardingTableStorage');
+      if (!shardingTableStorage) return { valid: false, reason: 'rpc-error' };
+      const inST: boolean = Boolean(await shardingTableStorage.nodeExists(claimedIdentityId));
+      if (!inST) return { valid: false, reason: 'not-in-sharding-table' };
+      return { valid: true };
+    } catch {
+      // Any chain-side throw (filter expired, RPC rate-limit, contract
+      // resolution failure mid-call) is reported as `rpc-error` so the
+      // ACKCollector can log it distinctly from a definitive negative.
+      // Mirrors the existing wrapper in `dkg-agent.ts:createV10ACKProvider`
+      // which used to swallow these exceptions as `false`, conflating
+      // transient infra failures with permanent rejections.
+      return { valid: false, reason: 'rpc-error' };
+    }
+  }
+
   async verifyACKIdentity(recoveredAddress: string, claimedIdentityId: bigint): Promise<boolean> {
-    await this.init();
-    const identityStorage = await this.resolveContract('IdentityStorage');
-    if (!identityStorage) return false;
-
-    // Gate 1: signer must be registered as an operational key for the claimed
-    // identity. Mirrors the on-chain `keyHasPurpose(id, keccak256(signer),
-    // OPERATIONAL_KEY)` check inside `KnowledgeAssetsV10._verifyACKSignature`.
-    const keyHash = ethers.keccak256(ethers.solidityPacked(['address'], [recoveredAddress]));
-    const hasPurpose: boolean = await identityStorage.keyHasPurpose(
-      claimedIdentityId,
-      keyHash,
-      OPERATIONAL_KEY_PURPOSE,
-    );
-    if (!hasPurpose) return false;
-
-    // Gate 2: identity must be in the active sharding table.
-    //
-    // RFC-001 rewired the on-chain ACK signer gate from `getNodeStakeV10 > 0`
-    // to `shardingTableStorage.nodeExists(identityId)` (see
-    // `KnowledgeAssetsV10._verifyACKSignature`: "ACK signers must be in the
-    // active sharding table, not merely staked"). The off-chain pre-flight
-    // here exists to spare a doomed on-chain submission gas — so it MUST
-    // mirror the on-chain check exactly. Pre-RFC-001 versions of this method
-    // gated on positive V10 stake, which let sub-`minimumStake` operators
-    // pass off-chain but reverted on-chain with `ACK signer not in sharding
-    // table`. ST membership is updated atomically by `StakingV10` whenever a
-    // node's V10 stake crosses `minimumStake` up or down.
-    const shardingTableStorage = await this.resolveContract('ShardingTableStorage');
-    if (!shardingTableStorage) return false;
-    return Boolean(await shardingTableStorage.nodeExists(claimedIdentityId));
+    return (await this.verifyACKIdentityDetailed(recoveredAddress, claimedIdentityId)).valid;
   }
 
   async verifySyncIdentity(recoveredAddress: string, claimedIdentityId: bigint): Promise<boolean> {

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -23,6 +23,7 @@ import type {
   CreateChallengeResult,
   OperationalWalletRegistrationResult,
   V10PublishingConvictionAccountInfo,
+  VerifyACKIdentityResult,
 } from './chain-adapter.js';
 import {
   NoEligibleContextGraphError,
@@ -812,14 +813,27 @@ export class MockChainAdapter implements ChainAdapter {
   }
 
   async verifyACKIdentity(recoveredAddress: string, claimedIdentityId: bigint): Promise<boolean> {
-    // Strict binding: recovered address must match the identity's registered address
+    return (await this.verifyACKIdentityDetailed(recoveredAddress, claimedIdentityId)).valid;
+  }
+
+  /**
+   * Mock implementation: the harness has no separate sharding-table /
+   * stake state, so a key registered for the claimed identity is treated
+   * as both `keyHasPurpose` AND `nodeExists`. Tests that need to exercise
+   * the `'not-in-sharding-table'` branch should use the EVM adapter
+   * against a Hardhat env with a freshly-keyed but unstaked profile.
+   */
+  async verifyACKIdentityDetailed(
+    recoveredAddress: string,
+    claimedIdentityId: bigint,
+  ): Promise<VerifyACKIdentityResult> {
     const normalizedAddress = recoveredAddress.toLowerCase();
     for (const [addr, id] of this.identities) {
       if (id === claimedIdentityId && addr.toLowerCase() === normalizedAddress) {
-        return true;
+        return { valid: true };
       }
     }
-    return false;
+    return { valid: false, reason: 'key-not-registered' };
   }
 
   async isOperationalWalletRegistered(identityId: bigint, address: string): Promise<boolean> {

--- a/packages/chain/test/evm-adapter.test.ts
+++ b/packages/chain/test/evm-adapter.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ethers, Wallet } from 'ethers';
 import { EVMChainAdapter } from '../src/evm-adapter.js';
 import {
   spawnHardhatEnv,
   killHardhat,
   makeAdapterConfig,
   HARDHAT_KEYS,
+  createNodeProfile,
   type HardhatContext,
 } from './hardhat-harness.js';
 
@@ -54,4 +56,53 @@ describe('EVMChainAdapter integration', () => {
     const owns = await adapter.verifyPublisherOwnsRange(deployer, 1n, 1n);
     expect(owns).toBe(false);
   }, 30_000);
+
+  // verifyACKIdentity gates the off-chain ACKCollector pre-flight. Post RFC-001
+  // the on-chain check inside `KnowledgeAssetsV10._verifyACKSignature` is
+  // (`keyHasPurpose` && `shardingTableStorage.nodeExists`), and the off-chain
+  // pre-flight must mirror that exactly. The harness stakes CORE + REC1..REC3
+  // at `minimumStake` so all four are in the sharding table; any newly minted
+  // profile with no stake must NOT pass the gate.
+  describe('verifyACKIdentity (RFC-001 off-chain ↔ on-chain gate parity)', () => {
+    it('accepts a staked-and-in-sharding-table operator key', async () => {
+      const adapter = new EVMChainAdapter(makeAdapterConfig(ctx.rpcUrl, ctx.hubAddress, HARDHAT_KEYS.DEPLOYER));
+      const coreOpAddr = new Wallet(HARDHAT_KEYS.CORE_OP).address;
+      const ok = await adapter.verifyACKIdentity(coreOpAddr, BigInt(ctx.coreProfileId));
+      expect(ok).toBe(true);
+      // Off-chain decision must agree with the on-chain ST gate that
+      // KnowledgeAssetsV10 enforces at publish time.
+      const inST = await adapter.isShardingTableMember!(BigInt(ctx.coreProfileId));
+      expect(inST).toBe(true);
+    }, 30_000);
+
+    it('rejects a signer that is not a registered operational key for the identity', async () => {
+      const adapter = new EVMChainAdapter(makeAdapterConfig(ctx.rpcUrl, ctx.hubAddress, HARDHAT_KEYS.DEPLOYER));
+      const stranger = ethers.Wallet.createRandom().address;
+      const ok = await adapter.verifyACKIdentity(stranger, BigInt(ctx.coreProfileId));
+      expect(ok).toBe(false);
+    }, 30_000);
+
+    it('rejects an operator whose identity is not in the sharding table (unstaked)', async () => {
+      // Mint a fresh profile with the EXTRA1 wallet but DON'T stake it. Its
+      // operational key is registered (so `keyHasPurpose` passes) but
+      // `shardingTableStorage.nodeExists` returns false because the node
+      // never crossed `minimumStake`. Pre-RFC-001 this method would have
+      // accepted it as long as `getNodeStakeV10 > 0`; we assert the new
+      // ST-membership gate keeps it locked out, matching the on-chain
+      // contract that would revert the publish with
+      // `"ACK signer not in sharding table"`.
+      const newId = await createNodeProfile(
+        ctx.provider, ctx.hubAddress,
+        HARDHAT_KEYS.EXTRA1, HARDHAT_KEYS.EXTRA2, // op + admin keys (unique)
+        'UnstakedProfile',
+      );
+      const adapter = new EVMChainAdapter(makeAdapterConfig(ctx.rpcUrl, ctx.hubAddress, HARDHAT_KEYS.DEPLOYER));
+      const opAddr = new Wallet(HARDHAT_KEYS.EXTRA1).address;
+      const ok = await adapter.verifyACKIdentity(opAddr, BigInt(newId));
+      expect(ok).toBe(false);
+      // Confirm the on-chain ST gate is in the same state.
+      const inST = await adapter.isShardingTableMember!(BigInt(newId));
+      expect(inST).toBe(false);
+    }, 60_000);
+  });
 });

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -309,6 +309,10 @@ function createV10ACKProviderForPublisher(
     chain?: {
       isV10Ready?: () => boolean;
       verifyACKIdentity?: (recoveredAddress: string, claimedIdentityId: bigint) => Promise<boolean>;
+      verifyACKIdentityDetailed?: (
+        recoveredAddress: string,
+        claimedIdentityId: bigint,
+      ) => Promise<{ valid: boolean; reason?: 'key-not-registered' | 'not-in-sharding-table' | 'rpc-error' }>;
       getMinimumRequiredSignatures?: () => Promise<number>;
       getEvmChainId?: () => Promise<bigint>;
       getKnowledgeAssetsV10Address?: () => Promise<string>;
@@ -329,6 +333,12 @@ function createV10ACKProviderForPublisher(
     sendP2P: transport.sendP2P,
     getConnectedCorePeers: transport.getConnectedCorePeers,
     verifyIdentity: async (recoveredAddress: string, claimedIdentityId: bigint) => chain.verifyACKIdentity!(recoveredAddress, claimedIdentityId),
+    // Prefer the structured verifier when the chain adapter exposes it
+    // so the rejection log can report the specific failing gate.
+    ...(typeof chain.verifyACKIdentityDetailed === 'function' ? {
+      verifyIdentityDetailed: async (recoveredAddress: string, claimedIdentityId: bigint) =>
+        chain.verifyACKIdentityDetailed!(recoveredAddress, claimedIdentityId),
+    } : {}),
     log: transport.log,
   });
 

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -13,11 +13,42 @@ import {
 import { ethers } from 'ethers';
 import { QuorumUnmetError, type PeerOutcome } from './ack-errors.js';
 
+/**
+ * Why an ACK signer pre-flight rejected a recovered signer. Mirrors
+ * `VerifyACKIdentityReason` from `@origintrail-official/dkg-chain`.
+ * Kept as a string union here to avoid a hard cross-package type dep
+ * — adapters wire concrete reasons through; legacy `boolean` callers
+ * still work and surface `undefined`.
+ */
+export type ACKVerifyReason = 'key-not-registered' | 'not-in-sharding-table' | 'rpc-error';
+
+export interface ACKVerifyResult {
+  valid: boolean;
+  reason?: ACKVerifyReason;
+}
+
 export interface ACKCollectorDeps {
   gossipPublish: (topic: string, data: Uint8Array) => Promise<void>;
   sendP2P: (peerId: string, protocol: string, data: Uint8Array) => Promise<Uint8Array>;
   getConnectedCorePeers: () => string[];
+  /**
+   * Boolean ACK signer pre-flight. Backward-compatible legacy entry
+   * point — when only this is provided the rejection log surfaces a
+   * generic "ACK rejected" line without a reason. New code should
+   * prefer `verifyIdentityDetailed`.
+   */
   verifyIdentity?: (recoveredAddress: string, claimedIdentityId: bigint) => Promise<boolean>;
+  /**
+   * Structured ACK signer pre-flight. When provided, the collector
+   * uses this in preference to `verifyIdentity` and surfaces the
+   * specific failing gate (`key-not-registered`, `not-in-sharding-
+   * table`, `rpc-error`) in the rejection log so operators can act on
+   * the actual root cause instead of guessing.
+   */
+  verifyIdentityDetailed?: (
+    recoveredAddress: string,
+    claimedIdentityId: bigint,
+  ) => Promise<ACKVerifyResult>;
   log?: (msg: string) => void;
 }
 
@@ -330,7 +361,24 @@ export class ACKCollector {
             ? BigInt(ack.nodeIdentityId)
             : BigInt(ack.nodeIdentityId.low) | (BigInt(ack.nodeIdentityId.high) << 32n);
 
-          if (this.deps.verifyIdentity) {
+          // Prefer the detailed verifier — surfaces the specific failing
+          // gate in the rejection log so operators can tell apart "this
+          // signer is genuinely not registered" (operator-side) from
+          // "the node is registered but has not crossed minimumStake"
+          // (operator-side, different action) from "we couldn't reach
+          // the chain to check" (infra-side, retryable). Pre-PR every
+          // failure surfaced as the same "not registered" string.
+          if (this.deps.verifyIdentityDetailed) {
+            const verdict = await this.deps.verifyIdentityDetailed(recoveredAddress, identityId);
+            if (!verdict.valid) {
+              const reason = verdict.reason ?? 'unknown';
+              log(
+                `[ACKCollector] ACK from ${peerId.slice(-8)} rejected: ${reason}` +
+                ` (signer=${recoveredAddress.slice(0, 10)}..., identity=${identityId})`,
+              );
+              return null;
+            }
+          } else if (this.deps.verifyIdentity) {
             const valid = await this.deps.verifyIdentity(recoveredAddress, identityId);
             if (!valid) {
               log(`[ACKCollector] Signer ${recoveredAddress.slice(0, 10)}... not registered for identity ${identityId} — rejecting ACK from ${peerId.slice(-8)}`);

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -324,6 +324,77 @@ describe('ACKCollector identity verification', () => {
       (c: unknown[]) => (c[0] as string).includes('not registered'),
     )).toBe(true);
   });
+
+  // Structured-verifier path: when the chain adapter implements
+  // `verifyACKIdentityDetailed` the rejection log surfaces the actual
+  // failing gate so operators can tell apart key-registration issues,
+  // sub-`minimumStake` stake (the regression case after rc.11), and
+  // RPC outages — three distinct operational situations that all
+  // looked identical pre-PR.
+  it('detailed verifier surfaces specific reason in rejection log', async () => {
+    const log = noop();
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: buildSendP2P(),
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      verifyIdentityDetailed: tracked(async () => ({ valid: false, reason: 'not-in-sharding-table' as const })),
+      log,
+    };
+    const collector = new ACKCollector(deps);
+
+    await expect(collector.collect(buildCollectParams()))
+      .rejects.toThrow('storage_ack_insufficient');
+    expect(log.calls.some(
+      (c: unknown[]) => /not-in-sharding-table/.test(c[0] as string),
+    )).toBe(true);
+    // Legacy "not registered" string MUST NOT appear when the structured
+    // path is taken — operators relying on the new reason for alerting
+    // would silently miss every stake-side rejection otherwise.
+    expect(log.calls.some(
+      (c: unknown[]) => /not registered for identity/.test(c[0] as string),
+    )).toBe(false);
+  });
+
+  it('detailed verifier flags rpc-error distinct from key-not-registered', async () => {
+    const log = noop();
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: buildSendP2P(),
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      verifyIdentityDetailed: tracked(async () => ({ valid: false, reason: 'rpc-error' as const })),
+      log,
+    };
+    const collector = new ACKCollector(deps);
+
+    await expect(collector.collect(buildCollectParams()))
+      .rejects.toThrow('storage_ack_insufficient');
+    expect(log.calls.some(
+      (c: unknown[]) => /rpc-error/.test(c[0] as string),
+    )).toBe(true);
+  });
+
+  it('detailed verifier takes precedence over legacy boolean verifier', async () => {
+    const log = noop();
+    const verifyIdentity = tracked(async () => true);
+    const verifyIdentityDetailed = tracked(async () => ({ valid: false, reason: 'key-not-registered' as const }));
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: buildSendP2P(),
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      verifyIdentity,
+      verifyIdentityDetailed,
+      log,
+    };
+    const collector = new ACKCollector(deps);
+
+    await expect(collector.collect(buildCollectParams()))
+      .rejects.toThrow('storage_ack_insufficient');
+    // Legacy `verifyIdentity` MUST NOT be consulted when the detailed
+    // form is provided — otherwise contradictory verdicts would let
+    // ACKs through that the structured verifier rejected.
+    expect(verifyIdentity.calls.length).toBe(0);
+    expect(verifyIdentityDetailed.calls.length).toBeGreaterThan(0);
+  });
 });
 
 // ── ACKCollector deduplication ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two related fixes uncovered by debugging a stuck rc.11 testnet publish where every core peer's ACK was rejected by the publisher with the same opaque \`Signer X not registered for identity Y\` line. Root cause was an off-chain ACK gate that drifted from the on-chain check in RFC-001, masked by a rejection log that conflated three distinct failure modes into one string.

## Commits

### 1. \`ec5e490d\` — fix(chain): align verifyACKIdentity with on-chain RFC-001 ACK signer gate

\`KnowledgeAssetsV10._verifyACKSignature\` was rewired by RFC-001 from \`getNodeStakeV10 > 0\` to \`shardingTableStorage.nodeExists(identityId)\`:

\`\`\`solidity
// packages/evm-module/contracts/KnowledgeAssetsV10.sol:777-783
// RFC-001 edge-publish unblocker: ACK signers must be in the active
// sharding table, not merely staked.
require(shardingTableStorage.nodeExists(identityId), \"ACK signer not in sharding table\");
\`\`\`

The off-chain pre-flight in \`evm-adapter.ts:verifyACKIdentity\` exists specifically to skip a doomed on-chain submission, so it must mirror the on-chain gate exactly. It still gated on positive V10 stake, which let sub-\`minimumStake\` operators clear the off-chain ACK quorum and then revert on-chain with \`\"ACK signer not in sharding table\"\` — the publisher saw the off-chain quorum success followed by an opaque contract revert.

Replaces the stake>0 branch with a \`ShardingTableStorage.nodeExists\` read. Drops the V8 archive fallback (the on-chain gate has no V8 fallback either; keeping ours diverged behaviour silently).

Adds three integration tests against the existing Hardhat harness: (a) fully-staked core passes, (b) unrelated wallet not registered as op-key fails, (c) freshly-keyed but unstaked profile fails — the regression case where pre-fix the gate would still pass once any non-zero stake was present.

### 2. \`f44669d5\` — feat(publisher): structured ACK rejection reasons (key/stake/RPC)

The rejection log conflated three different failure modes into the same string:

> \`[ACKCollector] Signer 0xAB... not registered for identity 5 — rejecting ACK from <peer>\`

…which could be: (a) signer is genuinely not an OPERATIONAL_KEY, (b) node is below \`minimumStake\` and not in the sharding table, or (c) the chain RPC threw and we couldn't tell. Each requires a different operator action — same log line. The rc.11 testnet incident burned ~90 min diagnosing a stake-side rejection that looked like a key-side rejection.

Surfaces the three reasons end-to-end:

- \`chain-adapter.ts\`: new \`VerifyACKIdentityReason\` type + \`VerifyACKIdentityResult\` + optional \`verifyACKIdentityDetailed\` method.
- \`evm-adapter.ts\` + \`mock-adapter.ts\`: implement the structured variant; \`verifyACKIdentity\` defers to it for parity.
- \`ack-collector.ts\`: prefer \`verifyIdentityDetailed\` when supplied, surface the reason verbatim, fall back to the legacy boolean callback otherwise.
- \`publisher-runner.ts\` + \`dkg-agent.ts\`: wire the new method through. The agent's wrapper translates a thrown chain-side exception into \`{ valid: false, reason: 'rpc-error' }\` so a filter-expired / rate-limited RPC stops masquerading as a definitive identity rejection (the existing \`try/catch\` returned \`false\` and lost that signal).

Adds three ACKCollector unit tests (structured reason in log, rpc-error distinct from key-not-registered, detailed-takes-precedence-over-boolean). Existing 45 ACK edge-case tests still pass.

## Why ship them together

Patch 2's \`'rpc-error'\` reason exists specifically to make Patch 1's behaviour observable. Without Patch 2 the agent's \`try/catch → return false\` still hides RPC blips behind the (now-correct) ST-membership rejection — same diagnostic confusion as before, just with a slightly different colour.

## Test plan

- [x] \`packages/publisher\` unit suite: \`v10-ack-edge-cases.test.ts\` — 45/45 pass (incl. 3 new structured-verifier cases).
- [x] \`packages/publisher\` unit suite: \`v10-protocol-operations.test.ts\` — 48/48 pass.
- [x] \`packages/chain\` unit + parity: \`evm-adapter.unit.test.ts\` 41/41, \`mock-adapter-parity.test.ts\` 15/15 — parity preserved with new method on both adapters.
- [x] \`packages/agent\` verify-related cases — 2/2 pass.
- [ ] \`packages/chain\` Hardhat integration: 3 new \`evm-adapter.test.ts\` cases — linted clean and follow the existing harness pattern, but require \`spawnHardhatEnv\` to run; CI will exercise them.

## Reproduction context

Triggered while diagnosing why \`Miles\` (rc.11 edge node) couldn't publish to the rc.11 Base Sepolia testnet — every core peer's ACK was rejected with \`Signer X not registered for identity N\`. Probing the chain directly showed all 7 testnet bootstrap identities had \`getNodeStakeV10() = 0\` AND were not in the sharding table — \`getTotalStakeV10()\` was \`0\` network-wide. Seeding 50,001 v9TRAC per identity from a funded test wallet pushed all 7 across \`minimumStake\` and back into the sharding table; the publish then needed BOTH this PR's gate change to make the off-chain pre-flight match the on-chain reality, and the diagnostic split to make future incidents debuggable in minutes instead of hours.


Made with [Cursor](https://cursor.com)