### PR TITLE
fix(chain): close TRAC auto-approve gap (1n floor) + configurable allowance policy

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -33,7 +33,7 @@ import type {
   LiftAuthorityProof,
   SharedMemoryPublicSnapshotStorageConfig,
 } from '@origintrail-official/dkg-publisher';
-import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+import type { ApprovalPolicy, ChainAdapter } from '@origintrail-official/dkg-chain';
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
 import type { SkillHandler } from './messaging.js';
 import type { CclFactResolutionMode } from './ccl-fact-resolution.js';
@@ -743,6 +743,13 @@ export interface DKGAgentConfig {
     adminPrivateKey?: string;
     operationalKeys: string[];
     chainId?: string;
+    /**
+     * Optional V10 allowance-sizing policy. Threaded straight through to
+     * the `EVMChainAdapter`; see `ApprovalPolicy` in
+     * `@origintrail-official/dkg-chain`. Omit to inherit the default
+     * (`'per-publish'`, bounded-per-publish with on-chain 1n floor).
+     */
+    approvalPolicy?: ApprovalPolicy;
   };
   /** Cross-agent query access configuration. */
   queryAccess?: QueryAccessConfig;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1054,6 +1054,7 @@ export class DKGAgent {
         additionalKeys: opKeys.slice(1),
         hubAddress: config.chainConfig.hubAddress,
         chainId: config.chainConfig.chainId,
+        approvalPolicy: config.chainConfig.approvalPolicy,
       };
       if (config.chainConfig.adminPrivateKey) {
         chain = new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey });

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -37,6 +37,55 @@ export interface PublishParams {
   receiverSignatures: Array<{ identityId: bigint; r: Uint8Array; vs: Uint8Array }>;
 }
 
+/**
+ * How the EVM adapter sizes the TRAC allowance it requests from an
+ * operational signer before a V10 publish or update.
+ *
+ * - `per-publish` (default, backward-compatible) — approve exactly what
+ *   this publish needs (floored at the on-chain `1n` minimum). Re-approve
+ *   on every publish where `tokenAmount > currentAllowance`. Cheapest blast
+ *   radius if the KA contract is ever compromised; most expensive gas
+ *   profile because every dynamic-priced publish triggers an approve tx.
+ *
+ * - `replenishing` (recommended for mainnet operators) — approve a
+ *   configurable target ceiling (default 1000 TRAC) and refill only when
+ *   `currentAllowance` drops below `target × refillBelowFraction` (default
+ *   10%). One approve per ~9 publishes' worth of TRAC, capped exposure.
+ *
+ * - `unlimited` (V9 pattern) — approve `MaxUint256` once per wallet; never
+ *   approve again. Lowest gas, widest blast radius. Choose only if you
+ *   trust the KA contract address absolutely.
+ *
+ * Computed by `computeApprovalAction` in `evm-adapter.ts`. Operators set
+ * this via the daemon config (`chain.approvalPolicy` block in
+ * `dkg.config.yaml`); the field threads through `DKGAgentConfig.chainConfig`
+ * → `EVMAdapterBaseConfig`.
+ */
+export type ApprovalPolicyMode = 'per-publish' | 'replenishing' | 'unlimited';
+
+export interface ApprovalPolicy {
+  /** Sizing strategy. Defaults to `'per-publish'`. */
+  mode: ApprovalPolicyMode;
+  /**
+   * `replenishing` only. Ceiling to approve to when topping up. Defaults
+   * to 1000 TRAC (`10n ** 21n` wei-TRAC). Always raised to at least the
+   * current publish's `tokenAmount` so the immediate publish succeeds even
+   * if the operator misconfigured `targetAllowance` too low.
+   */
+  targetAllowance?: bigint;
+  /**
+   * `replenishing` only. Refill when `currentAllowance < target ×
+   * refillBelowFraction`. Defaults to `0.1` (refill at 10% remaining).
+   * Clamped to `[0, 1]`.
+   */
+  refillBelowFraction?: number;
+}
+
+/** Defaults used when the daemon config omits the field. */
+export const DEFAULT_APPROVAL_POLICY: ApprovalPolicy = { mode: 'per-publish' };
+export const DEFAULT_REPLENISH_TARGET_ALLOWANCE: bigint = 1000n * (10n ** 18n);
+export const DEFAULT_REFILL_BELOW_FRACTION: number = 0.1;
+
 export interface OnChainPublishResult {
   batchId: bigint;
   /** Absent for updates (no new KAs minted). */

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -33,12 +33,16 @@ import type {
   OperationalWalletRegistrationResult,
   V10PublishingConvictionAccountInfo,
   VerifyACKIdentityResult,
+  ApprovalPolicy,
 } from './chain-adapter.js';
 import {
   NoEligibleContextGraphError,
   NoEligibleKnowledgeCollectionError,
   MerkleRootMismatchError,
   ChallengeNoLongerActiveError,
+  DEFAULT_APPROVAL_POLICY,
+  DEFAULT_REPLENISH_TARGET_ALLOWANCE,
+  DEFAULT_REFILL_BELOW_FRACTION,
 } from './chain-adapter.js';
 import { HubResolutionCache } from './hub-resolution-cache.js';
 import { PcaUnavailableError } from './pca-errors.js';
@@ -173,21 +177,103 @@ export function resolveRpcUrls(rpcUrl: string, rpcUrls?: string[]): string[] {
 export const V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE: bigint = 1n;
 
 /**
- * Returns the TRAC allowance ceiling that must be approved before a V10
- * publish / update for the chosen operational signer. Floors at the
- * on-chain minimum (`V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE`) so the
- * direct-spend branch (`token.transferFrom(..., fullCost)`) never reverts
- * with `TooLowAllowance` when the JS-side `tokenAmount` is `0n`.
+ * Returns the TRAC allowance ceiling required to cover one V10 publish /
+ * update. Floors at the on-chain minimum so the direct-spend branch
+ * (`token.transferFrom(..., fullCost)`) never reverts with
+ * `TooLowAllowance` when the JS-side `tokenAmount` is `0n`.
  *
- * Preserves the existing bounded-approval policy (we still approve only
- * what we need, never `MaxUint256` from this code path) so a compromised
- * KA contract can't drain more than the per-publish ceiling.
+ * This is the *building block* for the `per-publish` approval policy and
+ * the lower-bound clamp used by every other policy mode in
+ * `computeApprovalAction`. The bounded-per-publish security property of
+ * the legacy code path lives here.
  */
 export function effectivePublishAllowance(
   tokenAmount: bigint,
   onChainMin: bigint = V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE,
 ): bigint {
   return tokenAmount > onChainMin ? tokenAmount : onChainMin;
+}
+
+const MAX_UINT256_ALLOWANCE: bigint = (1n << 256n) - 1n;
+
+function clampApprovalFraction(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_REFILL_BELOW_FRACTION;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/**
+ * Computes the approval action for one V10 publish / update, dispatched
+ * by `ApprovalPolicy.mode`.
+ *
+ * Contract:
+ *   - `needsApprove === true`  → caller MUST submit `approve(KA,
+ *     targetAllowance)` before the publish to satisfy
+ *     `token.transferFrom(..., fullCost)` on-chain.
+ *   - `needsApprove === false` → skip the approve; the existing allowance
+ *     already covers this publish.
+ *
+ * Invariants enforced for every mode:
+ *   - `targetAllowance >= effectivePublishAllowance(tokenAmount)` — even
+ *     a misconfigured `replenishing` target gets raised to the on-chain
+ *     minimum so the immediate publish succeeds.
+ *   - `needsApprove` is monotone in `currentAllowance` — strictly more
+ *     existing allowance never flips a `false` to `true`.
+ *
+ * See {@link ApprovalPolicy} in `chain-adapter.ts` for the mode
+ * semantics; see `evm-adapter.unit.test.ts` for the pinned-down behaviour
+ * under every combination of `(mode, tokenAmount, currentAllowance)`.
+ */
+export function computeApprovalAction(
+  policy: ApprovalPolicy,
+  tokenAmount: bigint,
+  currentAllowance: bigint,
+): { needsApprove: boolean; targetAllowance: bigint } {
+  const publishFloor = effectivePublishAllowance(tokenAmount);
+  switch (policy.mode) {
+    case 'unlimited': {
+      // Approve `MaxUint256` once per wallet. After that, currentAllowance
+      // covers any plausible tokenAmount — re-approve only if some external
+      // actor brought it back under the immediate publish's floor (manual
+      // `approve(KA, 0)`, contract upgrade, etc.).
+      return {
+        needsApprove: currentAllowance < publishFloor,
+        targetAllowance: MAX_UINT256_ALLOWANCE,
+      };
+    }
+    case 'replenishing': {
+      // Approve a configurable ceiling once, then refill when current drops
+      // below `target × fraction`. Raise the target to at least the publish
+      // floor so a misconfigured low `targetAllowance` doesn't brick the
+      // publish — the bigger of (operator's intent, what we need right now).
+      const requestedTarget =
+        policy.targetAllowance ?? DEFAULT_REPLENISH_TARGET_ALLOWANCE;
+      const target = requestedTarget > publishFloor ? requestedTarget : publishFloor;
+      const fraction = clampApprovalFraction(
+        policy.refillBelowFraction ?? DEFAULT_REFILL_BELOW_FRACTION,
+      );
+      // bigint-safe `target * fraction` via basis points so a fractional
+      // refill threshold never drifts on round-trip.
+      const fractionBp = BigInt(Math.round(fraction * 10_000));
+      let threshold = (target * fractionBp) / 10_000n;
+      // The refill threshold must cover the immediate publish's floor too —
+      // refilling below it would just let the next publish revert with
+      // `TooLowAllowance` again.
+      if (threshold < publishFloor) threshold = publishFloor;
+      return { needsApprove: currentAllowance < threshold, targetAllowance: target };
+    }
+    case 'per-publish':
+    default: {
+      // Approve exactly the publish floor. Matches the legacy bounded-
+      // per-publish behaviour (with the 1n on-chain minimum closing the
+      // gap that previously bricked zero-cost publishes).
+      return {
+        needsApprove: currentAllowance < publishFloor,
+        targetAllowance: publishFloor,
+      };
+    }
+  }
 }
 
 function sleep(ms: number): Promise<void> {
@@ -419,6 +505,14 @@ interface EVMAdapterBaseConfig {
    * still effectively zero.
    */
   randomSamplingHubRefreshMs?: number;
+  /**
+   * Policy that controls how the V10 publish / update auto-approve sizes
+   * its TRAC allowance request. Defaults to {@link DEFAULT_APPROVAL_POLICY}
+   * (`per-publish`), preserving the bounded-per-publish behaviour that
+   * existed before this field landed. See {@link ApprovalPolicy} for the
+   * mode semantics.
+   */
+  approvalPolicy?: ApprovalPolicy;
 }
 
 export interface EVMAdapterConfig extends EVMAdapterBaseConfig {
@@ -498,6 +592,13 @@ export class EVMChainAdapter implements ChainAdapter {
   private signerIndex = 0;
   private signerSelectionQueue: Promise<void> = Promise.resolve();
   private readonly hubAddress: string;
+  /**
+   * Operator-configured allowance sizing policy for V10 publish / update
+   * auto-approve. See {@link ApprovalPolicy}. Default is `'per-publish'`,
+   * preserving the bounded-per-publish behaviour from before the policy
+   * landed.
+   */
+  private readonly approvalPolicy: ApprovalPolicy;
   private contracts: ContractCache;
   private initialized = false;
   /**
@@ -684,6 +785,7 @@ export class EVMChainAdapter implements ChainAdapter {
     }
     this.hubAddress = config.hubAddress;
     this.chainId = config.chainId ?? 'evm:31337';
+    this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
 
     this.contracts = {
       hub: new Contract(config.hubAddress, loadAbi('Hub'), this.signer),
@@ -2218,22 +2320,31 @@ export class EVMChainAdapter implements ChainAdapter {
     // `agentToAccountId[msg.sender] != 0` and falls through to
     // `token.transferFrom(msg.sender, CSS, fullCost)` for the
     // direct-spend branch. A redundant allowance is cheap and idle when
-    // the PCA branch covers the cost, so we always approve up to
-    // `tokenAmount` for the direct-spend ceiling.
+    // the PCA branch covers the cost.
     //
-    // Floor at the on-chain minimum (`V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE`)
-    // so a JS-side `tokenAmount` of `0n` (testnet pricing oracle, dust
-    // CGs, mainnet pricing edge cases) still satisfies the contract's
-    // `transferFrom(..., 1n)` minimum — see `effectivePublishAllowance`.
+    // How much to approve is delegated to `computeApprovalAction(policy,
+    // tokenAmount, currentAllowance)`. The default `per-publish` policy
+    // matches the legacy bounded-per-publish behaviour with the on-chain
+    // 1n floor; operators preparing for high-volume publishing can
+    // switch to `replenishing` (approve a ceiling, refill at threshold)
+    // or `unlimited` (approve MaxUint256 once) via the daemon config's
+    // `chain.approvalPolicy` block. See {@link ApprovalPolicy}.
     if (this.contracts.token) {
       const tokenWithSigner = this.contracts.token.connect(txSigner) as Contract;
-      const requiredAllowance = effectivePublishAllowance(params.tokenAmount);
-      const currentAllowance = await tokenWithSigner.allowance(txSigner.address, kaAddress);
-      if (currentAllowance < requiredAllowance) {
+      const currentAllowance: bigint = await tokenWithSigner.allowance(
+        txSigner.address,
+        kaAddress,
+      );
+      const { needsApprove, targetAllowance } = computeApprovalAction(
+        this.approvalPolicy,
+        params.tokenAmount,
+        currentAllowance,
+      );
+      if (needsApprove) {
         await this.sendContractTransaction(
           tokenWithSigner,
           'approve',
-          [kaAddress, requiredAllowance],
+          [kaAddress, targetAllowance],
           txSigner,
           'approve V10 publish TRAC',
         );
@@ -2623,18 +2734,27 @@ export class EVMChainAdapter implements ChainAdapter {
 
     // Approve TRAC for the V10 update — the contract may transferFrom
     // for the newTokenAmount (same direct-spend policy as publish).
-    // Same `effectivePublishAllowance` floor as the publish path: even a
-    // metadata-only update with `newTokenAmount === 0n` still requires
-    // `>= 1n` allowance for the on-chain `transferFrom(..., 1n)` minimum.
+    // Same `computeApprovalAction` dispatch as the publish path so a
+    // single config knob (`chain.approvalPolicy`) controls allowance
+    // sizing for both V10 surfaces. The default `per-publish` policy
+    // floors at 1n so metadata-only updates with `newTokenAmount === 0n`
+    // still satisfy the contract's `transferFrom(..., 1n)` minimum.
     if (this.contracts.token) {
       const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
-      const requiredAllowance = effectivePublishAllowance(newTokenAmount);
-      const prevAllowance = await tokenWithSigner.allowance(signer.address, kav10Address);
-      if (prevAllowance < requiredAllowance) {
+      const prevAllowance: bigint = await tokenWithSigner.allowance(
+        signer.address,
+        kav10Address,
+      );
+      const { needsApprove, targetAllowance } = computeApprovalAction(
+        this.approvalPolicy,
+        newTokenAmount,
+        prevAllowance,
+      );
+      if (needsApprove) {
         await this.sendContractTransaction(
           tokenWithSigner,
           'approve',
-          [kav10Address, requiredAllowance],
+          [kav10Address, targetAllowance],
           signer,
           'approve V10 update TRAC',
         );

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -156,6 +156,40 @@ export function resolveRpcUrls(rpcUrl: string, rpcUrls?: string[]): string[] {
   return out;
 }
 
+/**
+ * On-chain minimum the `KnowledgeAssetsV10.publish` / `update` contract
+ * pulls via `token.transferFrom(msg.sender, CSS, fullCost)` even for
+ * zero-byte / zero-value publishes — the contract rounds `fullCost` up to
+ * `1` wei-TRAC. Empirically reproduced on Base Sepolia, May 2026: a
+ * publish with JS-side `params.tokenAmount === 0n` reverted with
+ * `TooLowAllowance(token, 0, 1)` because the auto-approve path (then
+ * gated on `tokenAmount > 0n` / `currentAllowance < tokenAmount`) skipped
+ * approval entirely.
+ *
+ * On mainnet the same fires whenever the pricing oracle returns `0`
+ * (new / dust-value CGs, certain edge cases in `getRequiredPublishTokenAmount`),
+ * so we floor the approval ceiling at the on-chain minimum.
+ */
+export const V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE: bigint = 1n;
+
+/**
+ * Returns the TRAC allowance ceiling that must be approved before a V10
+ * publish / update for the chosen operational signer. Floors at the
+ * on-chain minimum (`V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE`) so the
+ * direct-spend branch (`token.transferFrom(..., fullCost)`) never reverts
+ * with `TooLowAllowance` when the JS-side `tokenAmount` is `0n`.
+ *
+ * Preserves the existing bounded-approval policy (we still approve only
+ * what we need, never `MaxUint256` from this code path) so a compromised
+ * KA contract can't drain more than the per-publish ceiling.
+ */
+export function effectivePublishAllowance(
+  tokenAmount: bigint,
+  onChainMin: bigint = V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE,
+): bigint {
+  return tokenAmount > onChainMin ? tokenAmount : onChainMin;
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -2186,14 +2220,20 @@ export class EVMChainAdapter implements ChainAdapter {
     // direct-spend branch. A redundant allowance is cheap and idle when
     // the PCA branch covers the cost, so we always approve up to
     // `tokenAmount` for the direct-spend ceiling.
+    //
+    // Floor at the on-chain minimum (`V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE`)
+    // so a JS-side `tokenAmount` of `0n` (testnet pricing oracle, dust
+    // CGs, mainnet pricing edge cases) still satisfies the contract's
+    // `transferFrom(..., 1n)` minimum — see `effectivePublishAllowance`.
     if (this.contracts.token) {
       const tokenWithSigner = this.contracts.token.connect(txSigner) as Contract;
+      const requiredAllowance = effectivePublishAllowance(params.tokenAmount);
       const currentAllowance = await tokenWithSigner.allowance(txSigner.address, kaAddress);
-      if (currentAllowance < params.tokenAmount) {
+      if (currentAllowance < requiredAllowance) {
         await this.sendContractTransaction(
           tokenWithSigner,
           'approve',
-          [kaAddress, params.tokenAmount],
+          [kaAddress, requiredAllowance],
           txSigner,
           'approve V10 publish TRAC',
         );
@@ -2583,14 +2623,18 @@ export class EVMChainAdapter implements ChainAdapter {
 
     // Approve TRAC for the V10 update — the contract may transferFrom
     // for the newTokenAmount (same direct-spend policy as publish).
-    if (this.contracts.token && newTokenAmount > 0n) {
+    // Same `effectivePublishAllowance` floor as the publish path: even a
+    // metadata-only update with `newTokenAmount === 0n` still requires
+    // `>= 1n` allowance for the on-chain `transferFrom(..., 1n)` minimum.
+    if (this.contracts.token) {
       const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
+      const requiredAllowance = effectivePublishAllowance(newTokenAmount);
       const prevAllowance = await tokenWithSigner.allowance(signer.address, kav10Address);
-      if (prevAllowance < newTokenAmount) {
+      if (prevAllowance < requiredAllowance) {
         await this.sendContractTransaction(
           tokenWithSigner,
           'approve',
-          [kav10Address, newTokenAmount],
+          [kav10Address, requiredAllowance],
           signer,
           'approve V10 update TRAC',
         );

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -1,6 +1,15 @@
 export * from './chain-adapter.js';
 export { MockChainAdapter, MOCK_DEFAULT_SIGNER } from './mock-adapter.js';
-export { EVMChainAdapter, type EVMAdapterConfig, decodeEvmError, enrichEvmError, resolveRpcUrls } from './evm-adapter.js';
+export {
+  EVMChainAdapter,
+  type EVMAdapterConfig,
+  decodeEvmError,
+  enrichEvmError,
+  resolveRpcUrls,
+  effectivePublishAllowance,
+  computeApprovalAction,
+  V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE,
+} from './evm-adapter.js';
 export { NoChainAdapter } from './no-chain-adapter.js';
 export {
   HubResolutionCache,

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -4,7 +4,15 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Interface, ethers } from 'ethers';
-import { decodeEvmError, enrichEvmError, EVMChainAdapter, resolveRpcUrls, type EVMAdapterConfig } from '../src/evm-adapter.js';
+import {
+  decodeEvmError,
+  effectivePublishAllowance,
+  enrichEvmError,
+  EVMChainAdapter,
+  resolveRpcUrls,
+  V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE,
+  type EVMAdapterConfig,
+} from '../src/evm-adapter.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const OTHER_PK = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b63b91100';
@@ -936,3 +944,45 @@ describe('PR3 / RC11 — publish-preflight TTL cache', () => {
     expect(getNetwork).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('effectivePublishAllowance (V10 approval-ceiling policy)', () => {
+  // Empirical motivation, May 2026 on Base Sepolia (`miles-publish-stress-26may`):
+  // a publish with JS-side `params.tokenAmount === 0n` reverted with
+  // `TooLowAllowance(token, 0, 1)` because the auto-approve path skipped
+  // approval entirely (`currentAllowance < 0n` is never true). The contract
+  // pulls `transferFrom(..., 1n)` even for zero-value publishes. These tests
+  // pin down the policy that floors approvals at the on-chain minimum.
+
+  it('exposes the on-chain minimum constant as 1n', () => {
+    expect(V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE).toBe(1n);
+  });
+
+  it('floors at 1n when tokenAmount is 0n (the bug we hit)', () => {
+    expect(effectivePublishAllowance(0n)).toBe(1n);
+  });
+
+  it('floors at 1n when tokenAmount equals the minimum', () => {
+    expect(effectivePublishAllowance(1n)).toBe(1n);
+  });
+
+  it('passes through tokenAmount when larger than the minimum', () => {
+    expect(effectivePublishAllowance(42n)).toBe(42n);
+    expect(effectivePublishAllowance(10n ** 18n)).toBe(10n ** 18n);
+  });
+
+  it('respects an injected on-chain minimum (forward-compat for contract upgrades)', () => {
+    expect(effectivePublishAllowance(0n, 10n)).toBe(10n);
+    expect(effectivePublishAllowance(5n, 10n)).toBe(10n);
+    expect(effectivePublishAllowance(50n, 10n)).toBe(50n);
+  });
+
+  it('preserves the bounded-approval security property (never returns MaxUint256 unless asked)', () => {
+    // The policy must never silently widen approval beyond what the caller
+    // requested — that would defeat the per-publish ceiling that protects
+    // the operational wallet against a compromised KA contract.
+    const huge = 10n ** 30n;
+    expect(effectivePublishAllowance(huge)).toBe(huge);
+    expect(effectivePublishAllowance(huge)).not.toBe(ethers.MaxUint256);
+  });
+});
+

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Interface, ethers } from 'ethers';
 import {
+  computeApprovalAction,
   decodeEvmError,
   effectivePublishAllowance,
   enrichEvmError,
@@ -13,6 +14,12 @@ import {
   V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE,
   type EVMAdapterConfig,
 } from '../src/evm-adapter.js';
+import {
+  DEFAULT_APPROVAL_POLICY,
+  DEFAULT_REPLENISH_TARGET_ALLOWANCE,
+  DEFAULT_REFILL_BELOW_FRACTION,
+  type ApprovalPolicy,
+} from '../src/chain-adapter.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const OTHER_PK = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b63b91100';
@@ -983,6 +990,232 @@ describe('effectivePublishAllowance (V10 approval-ceiling policy)', () => {
     const huge = 10n ** 30n;
     expect(effectivePublishAllowance(huge)).toBe(huge);
     expect(effectivePublishAllowance(huge)).not.toBe(ethers.MaxUint256);
+  });
+});
+
+describe('computeApprovalAction — per-publish (default, backward-compatible)', () => {
+  // Reproduces every code path the policy-less adapter took before this
+  // PR. New operators inherit this default; explicit `mode: 'per-publish'`
+  // produces identical behaviour.
+
+  const policy: ApprovalPolicy = { mode: 'per-publish' };
+
+  it('matches DEFAULT_APPROVAL_POLICY', () => {
+    expect(DEFAULT_APPROVAL_POLICY.mode).toBe('per-publish');
+  });
+
+  it('approves the 1n floor when tokenAmount=0n and currentAllowance=0n', () => {
+    const action = computeApprovalAction(policy, 0n, 0n);
+    expect(action.needsApprove).toBe(true);
+    expect(action.targetAllowance).toBe(1n);
+  });
+
+  it('skips approve when current already covers the publish floor (0n / 1n)', () => {
+    expect(computeApprovalAction(policy, 0n, 1n)).toEqual({
+      needsApprove: false,
+      targetAllowance: 1n,
+    });
+  });
+
+  it('approves exactly tokenAmount when current is short', () => {
+    const action = computeApprovalAction(policy, 1000n, 500n);
+    expect(action.needsApprove).toBe(true);
+    expect(action.targetAllowance).toBe(1000n);
+  });
+
+  it('does not re-approve when current >= tokenAmount', () => {
+    expect(computeApprovalAction(policy, 1000n, 1000n).needsApprove).toBe(false);
+    expect(computeApprovalAction(policy, 1000n, 5000n).needsApprove).toBe(false);
+  });
+
+  it('never widens approval beyond tokenAmount (bounded-per-publish security property)', () => {
+    const action = computeApprovalAction(policy, 10n ** 18n, 0n);
+    expect(action.targetAllowance).toBe(10n ** 18n);
+    expect(action.targetAllowance).not.toBe(ethers.MaxUint256);
+  });
+});
+
+describe('computeApprovalAction — replenishing (recommended for mainnet)', () => {
+  // Approve a configurable ceiling once; refill when current drops below
+  // `target × refillBelowFraction`. Pre-mainnet stress run on Base Sepolia
+  // showed this would amortise approve-gas to ~1/9 of the per-publish
+  // policy at default config.
+
+  it('exposes sane defaults', () => {
+    // 1000 TRAC = 1e21 wei-TRAC
+    expect(DEFAULT_REPLENISH_TARGET_ALLOWANCE).toBe(10n ** 21n);
+    expect(DEFAULT_REFILL_BELOW_FRACTION).toBe(0.1);
+  });
+
+  it('approves the default 1000 TRAC ceiling on a fresh wallet', () => {
+    const policy: ApprovalPolicy = { mode: 'replenishing' };
+    const action = computeApprovalAction(policy, 1n, 0n);
+    expect(action.needsApprove).toBe(true);
+    expect(action.targetAllowance).toBe(10n ** 21n);
+  });
+
+  it('skips approve when current is comfortably above the refill threshold', () => {
+    const policy: ApprovalPolicy = { mode: 'replenishing' };
+    // Default target 1000 TRAC, refill at 100 TRAC. 500 TRAC current → no refill.
+    const action = computeApprovalAction(policy, 1n, 500n * (10n ** 18n));
+    expect(action.needsApprove).toBe(false);
+    expect(action.targetAllowance).toBe(10n ** 21n);
+  });
+
+  it('triggers refill when current drops below 10% of target (default fraction)', () => {
+    const policy: ApprovalPolicy = { mode: 'replenishing' };
+    // 99 TRAC current, threshold is 100 TRAC → refill.
+    const action = computeApprovalAction(policy, 1n, 99n * (10n ** 18n));
+    expect(action.needsApprove).toBe(true);
+    expect(action.targetAllowance).toBe(10n ** 21n);
+  });
+
+  it('respects a custom targetAllowance + refillBelowFraction', () => {
+    const policy: ApprovalPolicy = {
+      mode: 'replenishing',
+      targetAllowance: 100n * (10n ** 18n), // 100 TRAC ceiling
+      refillBelowFraction: 0.5,              // refill at 50 TRAC
+    };
+    // Current 60 TRAC → above threshold (50 TRAC) → no refill.
+    expect(computeApprovalAction(policy, 1n, 60n * (10n ** 18n)).needsApprove).toBe(false);
+    // Current 40 TRAC → below threshold → refill to 100 TRAC.
+    const action = computeApprovalAction(policy, 1n, 40n * (10n ** 18n));
+    expect(action.needsApprove).toBe(true);
+    expect(action.targetAllowance).toBe(100n * (10n ** 18n));
+  });
+
+  it('raises a too-low targetAllowance to at least the publish floor', () => {
+    // Operator misconfigured `targetAllowance: 100n` but this publish
+    // needs 500n — should approve 500n, not let it brick the publish.
+    const policy: ApprovalPolicy = { mode: 'replenishing', targetAllowance: 100n };
+    const action = computeApprovalAction(policy, 500n, 0n);
+    expect(action.needsApprove).toBe(true);
+    expect(action.targetAllowance).toBe(500n);
+  });
+
+  it('treats targetAllowance=0n as "use publish floor"', () => {
+    const policy: ApprovalPolicy = { mode: 'replenishing', targetAllowance: 0n };
+    const action = computeApprovalAction(policy, 0n, 0n);
+    expect(action.needsApprove).toBe(true);
+    expect(action.targetAllowance).toBe(1n); // publish floor wins
+  });
+
+  it('clamps refillBelowFraction to [0, 1]', () => {
+    const above: ApprovalPolicy = { mode: 'replenishing', refillBelowFraction: 2 };
+    const aboveAction = computeApprovalAction(above, 1n, 10n ** 21n - 1n);
+    expect(aboveAction.needsApprove).toBe(true); // fraction clamps to 1 → always refill below full target
+
+    const below: ApprovalPolicy = { mode: 'replenishing', refillBelowFraction: -1 };
+    const belowAction = computeApprovalAction(below, 1n, 0n);
+    // fraction clamps to 0 → threshold = 0, but publishFloor (1n) wins
+    expect(belowAction.needsApprove).toBe(true);
+    expect(belowAction.targetAllowance).toBe(10n ** 21n);
+  });
+
+  it('handles NaN / non-finite refillBelowFraction by falling back to the default', () => {
+    const policy: ApprovalPolicy = {
+      mode: 'replenishing',
+      refillBelowFraction: Number.NaN,
+    };
+    // Default 0.1 → threshold = 100 TRAC. 99 TRAC current → refill.
+    const action = computeApprovalAction(policy, 1n, 99n * (10n ** 18n));
+    expect(action.needsApprove).toBe(true);
+  });
+
+  it('refill threshold respects the publish floor even when fraction × target is below it', () => {
+    // Tiny target, tiny fraction, but the immediate publish needs 1000n.
+    const policy: ApprovalPolicy = {
+      mode: 'replenishing',
+      targetAllowance: 100n,
+      refillBelowFraction: 0.01, // threshold = 1n
+    };
+    // Current 500n: above the 1n threshold but below the publish floor (1000n).
+    const action = computeApprovalAction(policy, 1000n, 500n);
+    expect(action.needsApprove).toBe(true);
+    expect(action.targetAllowance).toBe(1000n); // target raised to publish floor
+  });
+});
+
+describe('computeApprovalAction — unlimited (V9 pattern)', () => {
+  const policy: ApprovalPolicy = { mode: 'unlimited' };
+
+  it('approves MaxUint256 on a fresh wallet', () => {
+    const action = computeApprovalAction(policy, 1n, 0n);
+    expect(action.needsApprove).toBe(true);
+    expect(action.targetAllowance).toBe(ethers.MaxUint256);
+  });
+
+  it('never re-approves once the wallet has any usable allowance', () => {
+    // currentAllowance of 1n is enough for a 0n-floored publish — skip approve.
+    expect(computeApprovalAction(policy, 0n, 1n).needsApprove).toBe(false);
+    // currentAllowance of MaxUint256 — definitely skip.
+    expect(computeApprovalAction(policy, 10n ** 30n, ethers.MaxUint256).needsApprove).toBe(false);
+  });
+
+  it('re-approves if external actor revoked allowance back below the publish floor', () => {
+    // Defensive path: if someone called approve(KA, 0) on this wallet, the
+    // next publish should refill MaxUint256, not silently revert.
+    expect(computeApprovalAction(policy, 1n, 0n).needsApprove).toBe(true);
+  });
+});
+
+describe('computeApprovalAction — invariants across all modes', () => {
+  // Properties that must hold for every policy/tokenAmount/currentAllowance
+  // combination — exercised explicitly because they're the structural
+  // safety net behind the policy abstraction.
+
+  const allModes: ApprovalPolicy[] = [
+    { mode: 'per-publish' },
+    { mode: 'replenishing' },
+    { mode: 'unlimited' },
+  ];
+
+  it('targetAllowance is always >= effectivePublishAllowance(tokenAmount)', () => {
+    for (const policy of allModes) {
+      for (const tokenAmount of [0n, 1n, 1000n, 10n ** 18n]) {
+        for (const currentAllowance of [0n, 1n, 10n ** 21n]) {
+          const action = computeApprovalAction(policy, tokenAmount, currentAllowance);
+          const floor = effectivePublishAllowance(tokenAmount);
+          expect(action.targetAllowance).toBeGreaterThanOrEqual(floor);
+        }
+      }
+    }
+  });
+
+  it('needsApprove is monotone in currentAllowance (more allowance never flips false → true)', () => {
+    for (const policy of allModes) {
+      for (const tokenAmount of [0n, 1n, 1000n, 10n ** 18n]) {
+        let lastNeedsApprove = true;
+        for (const currentAllowance of [
+          0n,
+          1n,
+          10n ** 18n,
+          10n ** 21n,
+          ethers.MaxUint256,
+        ]) {
+          const action = computeApprovalAction(policy, tokenAmount, currentAllowance);
+          // Once we've seen needsApprove=false for some currentAllowance,
+          // any larger currentAllowance must also yield false.
+          if (lastNeedsApprove === false) {
+            expect(action.needsApprove).toBe(false);
+          }
+          lastNeedsApprove = action.needsApprove;
+        }
+      }
+    }
+  });
+
+  it('unknown mode falls back to per-publish behaviour', () => {
+    // Defensive — if a malformed config sneaks through, we should still
+    // produce *some* sane action rather than throwing inside the publish
+    // hot path.
+    const action = computeApprovalAction(
+      { mode: 'gibberish' as any },
+      1000n,
+      0n,
+    );
+    expect(action.needsApprove).toBe(true);
+    expect(action.targetAllowance).toBe(1000n); // per-publish
   });
 });
 

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -637,6 +637,36 @@ Failure classifications you'll see in `attempt.lastError.classification`:
 | `cap_exceeded` | no | `Promoted assertion too large for gossip` (10 MB) or `Request body too large` (256 KB) | Re-enqueue with a smaller `entities` slice — the queue can't subdivide on its own. |
 | `fatal` | no | Bad request, missing assertion, etc. | Inspect the error message, fix the cause, then `POST /api/assertion/promote-async/{jobId}/recover`. |
 
+### TRAC auto-approve policy (V10 publish + update)
+
+Every V10 publish or update pulls TRAC from the operational signer via `token.transferFrom(msg.sender, CSS, fullCost)`. Before that call, the EVM adapter checks the signer's allowance for the V10 KA contract and approves more if it's short. `config.chain.approvalPolicy` controls how much it approves at each top-up — a per-publish gas trade-off that's neutral on testnet (zero-cost publishes) but matters at mainnet scale.
+
+| Mode | Per-publish gas | Blast radius (compromised KA) | When to use |
+|---|---|---|---|
+| `per-publish` (default) | One `approve` tx whenever `tokenAmount` exceeds prior allowance | One publish's cost ceiling | Conservative default. Low publish volume, or operators who trust nothing. |
+| `replenishing` | One `approve` per ~`targetAllowance / avgPublishCost` publishes | Capped at `targetAllowance` (1000 TRAC default) | **Recommended for mainnet at any volume.** Predictable gas profile + bounded exposure. |
+| `unlimited` | One `approve` ever per wallet | Operational wallet's full TRAC balance | High-volume operators on a contract they trust absolutely. Matches V9 behaviour. |
+
+Configuration (defaults shown):
+
+```yaml
+chain:
+  type: evm
+  rpcUrl: https://base.llamarpc.com
+  hubAddress: '0x...'
+  approvalPolicy:
+    mode: per-publish                # 'per-publish' | 'replenishing' | 'unlimited'
+    # `replenishing` mode only:
+    targetAllowance: '1000000000000000000000'   # decimal wei-TRAC string (1000 TRAC = 10^21)
+    refillBelowFraction: 0.1                     # refill when current < target × this (default 10%)
+```
+
+`targetAllowance` is a string because YAML/JSON can't carry bigints natively — the daemon parses it into a bigint at startup, fails fast on garbage input. `refillBelowFraction` clamps to `[0, 1]`; a value of `1` means "refill on every publish" (defeats the policy) and `0` means "never refill until the publish floor (1 wei-TRAC) is breached" (which on a zero-cost CG would mean approve once then never again).
+
+The policy never approves *less* than the immediate publish needs — a too-low `targetAllowance` gets quietly raised to the publish's on-chain floor so misconfiguration can't brick a publish.
+
+This entire surface was empirically driven by [PR #720](https://github.com/OriginTrail/dkg/pull/720)'s `TooLowAllowance(token, 0, 1)` finding on the May 2026 Base Sepolia publish-stress run; see also `packages/chain/test/evm-adapter.unit.test.ts` for the policy's invariants and edge cases.
+
 ## 9. Error Reference
 
 | Status | Meaning | Recovery |

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -155,6 +155,46 @@ export interface NetworkConfig {
   chainResetMarker?: string;
 }
 
+/**
+ * Operator-facing config block for V10 TRAC allowance sizing. Mirrors
+ * `ApprovalPolicy` from `@origintrail-official/dkg-chain` but with
+ * stringly-typed numeric fields (YAML doesn't speak bigint) so YAML/JSON
+ * config can express it.
+ *
+ * Defaults match the legacy behaviour (`mode: per-publish`); operators
+ * preparing for high-volume publishing should consider `replenishing`.
+ * See `packages/cli/skills/dkg-node/SKILL.md` §8 for the operator guide.
+ */
+export interface ApprovalPolicyConfig {
+  /**
+   * Allowance sizing strategy. Defaults to `'per-publish'`:
+   *
+   *   - `per-publish` — approve exactly each publish's TRAC cost (with the
+   *     on-chain `1n` floor). Cheapest blast radius, most approve-gas at
+   *     scale. Backward-compatible.
+   *   - `replenishing` — approve a configurable ceiling (default 1000 TRAC),
+   *     refill when allowance drops below `target × refillBelowFraction`
+   *     (default 10%). One approve per ~9 publishes' worth of TRAC.
+   *     **Recommended for mainnet.**
+   *   - `unlimited` — approve `MaxUint256` once per wallet, never again.
+   *     Lowest gas, widest blast radius. Use only if you trust the V10 KA
+   *     contract absolutely.
+   */
+  mode?: 'per-publish' | 'replenishing' | 'unlimited';
+  /**
+   * `replenishing` only. TRAC amount (decimal wei-TRAC string — `1000 *
+   * 10^18 = '1000000000000000000000'` for 1000 TRAC) to approve up to.
+   * Defaults to `'1000000000000000000000'` (1000 TRAC).
+   */
+  targetAllowance?: string;
+  /**
+   * `replenishing` only. Refill when current allowance drops below
+   * `targetAllowance × refillBelowFraction`. Float between 0 and 1.
+   * Defaults to `0.1` (refill at 10% remaining).
+   */
+  refillBelowFraction?: number;
+}
+
 export interface ChainConfig {
   /** 'evm' for real blockchain, omit or 'mock' for in-memory (testing only) */
   type: 'evm' | 'mock';
@@ -173,6 +213,13 @@ export interface ChainConfig {
    * to this identity ID so private participant flows can be exercised from black-box CLI tests.
    */
   mockIdentityId?: string;
+  /**
+   * V10 TRAC auto-approve policy. Controls how the adapter sizes the
+   * allowance it requests from each operational signer before a publish or
+   * update. See {@link ApprovalPolicyConfig} for the modes and
+   * `packages/cli/skills/dkg-node/SKILL.md` §8 for the operator guide.
+   */
+  approvalPolicy?: ApprovalPolicyConfig;
 }
 
 export interface LargeLiteralStorageConfig {
@@ -585,6 +632,63 @@ export function resolveNetworkDefaultContextGraphs(network: NetworkConfig | null
 /** Resolve shared memory TTL from config, accepting both V10 and legacy keys. */
 export function resolveSharedMemoryTtlMs(config: DkgConfig): number | undefined {
   return config.sharedMemoryTtlMs ?? config.workspaceTtlMs;
+}
+
+/**
+ * Translates the operator-facing {@link ApprovalPolicyConfig} (YAML/JSON,
+ * string-typed numerics) into the runtime `ApprovalPolicy` shape the
+ * chain adapter expects (`bigint` for `targetAllowance`).
+ *
+ * - Returns `undefined` if the operator didn't configure a policy — lets
+ *   the chain adapter fall back to its built-in default
+ *   (`DEFAULT_APPROVAL_POLICY`, currently `per-publish`).
+ * - Throws a descriptive `Error` if the operator supplied an unparseable
+ *   `targetAllowance` (e.g. `'one thousand TRAC'`). Fails fast at startup
+ *   rather than silently falling back — config bugs are easier to find
+ *   when they don't lurk for hours.
+ */
+export function resolveApprovalPolicy(
+  policy: ApprovalPolicyConfig | undefined,
+): { mode: 'per-publish' | 'replenishing' | 'unlimited'; targetAllowance?: bigint; refillBelowFraction?: number } | undefined {
+  if (!policy) return undefined;
+  const mode = policy.mode ?? 'per-publish';
+  if (mode !== 'per-publish' && mode !== 'replenishing' && mode !== 'unlimited') {
+    throw new Error(
+      `chain.approvalPolicy.mode must be one of 'per-publish' | 'replenishing' | 'unlimited' (got: ${JSON.stringify(mode)})`,
+    );
+  }
+  let targetAllowance: bigint | undefined;
+  if (policy.targetAllowance !== undefined) {
+    try {
+      targetAllowance = BigInt(policy.targetAllowance);
+    } catch (err: any) {
+      throw new Error(
+        `chain.approvalPolicy.targetAllowance must be a decimal wei-TRAC bigint string (got: ${JSON.stringify(policy.targetAllowance)}, ${err?.message ?? err})`,
+      );
+    }
+    if (targetAllowance < 0n) {
+      throw new Error(
+        `chain.approvalPolicy.targetAllowance must be non-negative (got: ${targetAllowance})`,
+      );
+    }
+  }
+  if (policy.refillBelowFraction !== undefined) {
+    if (
+      typeof policy.refillBelowFraction !== 'number'
+      || !Number.isFinite(policy.refillBelowFraction)
+      || policy.refillBelowFraction < 0
+      || policy.refillBelowFraction > 1
+    ) {
+      throw new Error(
+        `chain.approvalPolicy.refillBelowFraction must be a finite number in [0, 1] (got: ${JSON.stringify(policy.refillBelowFraction)})`,
+      );
+    }
+  }
+  return {
+    mode,
+    targetAllowance,
+    refillBelowFraction: policy.refillBelowFraction,
+  };
 }
 
 let _networkConfig: NetworkConfig | null = null;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -53,7 +53,11 @@ const daemonRequire = createRequire(import.meta.url);
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
-import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  enrichEvmError,
+  MockChainAdapter,
+  type ApprovalPolicy,
+} from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
@@ -93,6 +97,7 @@ import {
   type LocalAgentIntegrationTransport,
   resolveContextGraphs,
   resolveNetworkDefaultContextGraphs,
+  resolveApprovalPolicy,
   resolveSharedMemoryTtlMs,
   repoDir,
   releasesDir,
@@ -1013,6 +1018,7 @@ export async function runDaemonInner(
         : {}),
       operationalKeys: opWallets.wallets.map((w) => w.privateKey),
       chainId: chainBase.chainId,
+      approvalPolicy: resolveApprovalPolicy(chainBase.approvalPolicy) as ApprovalPolicy | undefined,
     } : undefined,
     sharedMemoryTtlMs: resolveSharedMemoryTtlMs(config),
     randomSamplingWalPath: config.randomSampling?.walPath,

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -20,6 +20,7 @@ import {
   dkgDir,
   repoDir,
   resolveAutoUpdateSource,
+  resolveApprovalPolicy,
   resolveChainConfig,
 } from '../src/config.js';
 
@@ -559,5 +560,91 @@ describe('resolveChainConfig (field-level merge)', () => {
     );
     expect(merged).toBeDefined();
     expect(Object.keys(merged ?? {})).toEqual(['type', 'rpcUrl']);
+  });
+});
+
+describe('resolveApprovalPolicy (YAML/JSON config → runtime ApprovalPolicy)', () => {
+  // The chain adapter's runtime API takes a bigint for targetAllowance;
+  // YAML / JSON can't carry bigints natively, so the operator-facing config
+  // accepts a decimal string. This converter pins down the contract.
+
+  it('returns undefined when the operator omitted the field (chain adapter uses its built-in default)', () => {
+    expect(resolveApprovalPolicy(undefined)).toBeUndefined();
+  });
+
+  it('passes through per-publish with no extra fields', () => {
+    expect(resolveApprovalPolicy({ mode: 'per-publish' })).toEqual({
+      mode: 'per-publish',
+      targetAllowance: undefined,
+      refillBelowFraction: undefined,
+    });
+  });
+
+  it('defaults mode to per-publish if omitted (operator could supply only fraction overrides for replenishing post-hoc)', () => {
+    expect(resolveApprovalPolicy({})).toEqual({
+      mode: 'per-publish',
+      targetAllowance: undefined,
+      refillBelowFraction: undefined,
+    });
+  });
+
+  it('converts targetAllowance string → bigint for replenishing', () => {
+    const out = resolveApprovalPolicy({
+      mode: 'replenishing',
+      targetAllowance: '1000000000000000000000', // 1000 TRAC
+      refillBelowFraction: 0.2,
+    });
+    expect(out).toEqual({
+      mode: 'replenishing',
+      targetAllowance: 10n ** 21n,
+      refillBelowFraction: 0.2,
+    });
+  });
+
+  it('accepts unlimited', () => {
+    expect(resolveApprovalPolicy({ mode: 'unlimited' })).toEqual({
+      mode: 'unlimited',
+      targetAllowance: undefined,
+      refillBelowFraction: undefined,
+    });
+  });
+
+  it('throws on unknown mode', () => {
+    expect(() => resolveApprovalPolicy({ mode: 'free-for-all' as any })).toThrow(
+      /must be one of 'per-publish' \| 'replenishing' \| 'unlimited'/,
+    );
+  });
+
+  it('throws on unparseable targetAllowance', () => {
+    expect(() =>
+      resolveApprovalPolicy({
+        mode: 'replenishing',
+        targetAllowance: 'one thousand TRAC',
+      }),
+    ).toThrow(/must be a decimal wei-TRAC bigint string/);
+  });
+
+  it('throws on negative targetAllowance', () => {
+    expect(() =>
+      resolveApprovalPolicy({
+        mode: 'replenishing',
+        targetAllowance: '-1',
+      }),
+    ).toThrow(/must be non-negative/);
+  });
+
+  it('throws on out-of-range refillBelowFraction', () => {
+    expect(() =>
+      resolveApprovalPolicy({ mode: 'replenishing', refillBelowFraction: 1.5 }),
+    ).toThrow(/must be a finite number in \[0, 1\]/);
+    expect(() =>
+      resolveApprovalPolicy({ mode: 'replenishing', refillBelowFraction: -0.1 }),
+    ).toThrow(/must be a finite number in \[0, 1\]/);
+    expect(() =>
+      resolveApprovalPolicy({
+        mode: 'replenishing',
+        refillBelowFraction: Number.NaN,
+      }),
+    ).toThrow(/must be a finite number in \[0, 1\]/);
   });
 });


### PR DESCRIPTION
## Summary

Two commits, both about how the EVM adapter sizes its TRAC allowance approval before a V10 publish or update:

1. **`fix(chain): enforce 1n on-chain TRAC allowance minimum on V10 publish/update`** — closes the **`TooLowAllowance(token, 0, 1)` revert** we reproduced on Base Sepolia. The auto-approve check `currentAllowance < params.tokenAmount` evaluates `false` whenever the JS-side `tokenAmount === 0n` (testnet pricing, dust CGs on mainnet, pricing-oracle edge cases), but the contract still pulls `transferFrom(..., 1n)` from the direct-spend branch. Floor the approval at `1n`.

2. **`feat(chain): configurable TRAC auto-approve policy (per-publish/replenishing/unlimited)`** — once the floor is in place, the existing bounded-per-publish policy is correct but expensive at mainnet scale. Adds a config knob (`chain.approvalPolicy` in `dkg.config.yaml`) so operators can choose between three modes; the default `per-publish` is bit-for-bit identical to today's behaviour.

The second commit builds on the first — the `effectivePublishAllowance` helper from commit 1 is the lower-bound clamp for every mode in commit 2.

## Empirical motivation

Both commits are driven by the May 2026 Base Sepolia publish-stress run (`miles-publish-stress-26may` CG, 800+ publishes via `scripts/testnet-publish-stress/publish-loop.mjs` landing in [PR #722](https://github.com/OriginTrail/dkg/pull/722)):

- Without the **1n floor**: every op-wallet that wasn't manually pre-approved reverted with `TooLowAllowance(token, 0, 1)` on its first publish (we had to ship `approve-op-wallets.mjs` as a workaround).
- Even with the floor, the **bounded-per-publish** policy submits a fresh approve tx whenever `tokenAmount > previousAllowance`. On Base mainnet at ~$0.02-0.05 per approve, that's $400-1000/day on approve gas alone at the publish volumes mainnet integrators are designing for.

## What the policy looks like

```yaml
# dkg.config.yaml
chain:
  type: evm
  rpcUrl: ...
  hubAddress: ...
  approvalPolicy:
    mode: per-publish          # 'per-publish' (default) | 'replenishing' | 'unlimited'
    # `replenishing` mode only:
    targetAllowance: '1000000000000000000000'   # 1000 TRAC (decimal wei-TRAC string)
    refillBelowFraction: 0.1                     # refill at 10% remaining
```

| Mode | Per-publish gas | Blast radius if KA compromised | When to use |
|---|---|---|---|
| `per-publish` (default, today's behaviour) | 1 approve tx every time `tokenAmount > previousAllowance` | One publish's cost ceiling | Low publish volume, conservative |
| `replenishing` | 1 approve per ~9 publishes' worth of TRAC (with defaults) | Capped at `targetAllowance` | **Recommended for mainnet** |
| `unlimited` (V9 pattern) | 1 approve ever per wallet | Operational wallet's full TRAC balance | High-volume, fully-trusted KA contract |

## Files touched

| Package | File | Change |
|---|---|---|
| `chain` | `src/chain-adapter.ts` | Public types: `ApprovalPolicyMode`, `ApprovalPolicy`, defaults |
| `chain` | `src/evm-adapter.ts` | `effectivePublishAllowance` (1n floor) + `computeApprovalAction` (policy dispatch); both V10 call sites swap to it |
| `chain` | `src/index.ts` | Re-export the helpers |
| `chain` | `test/evm-adapter.unit.test.ts` | +28 tests (6 floor, 22 policy) |
| `agent` | `src/dkg-agent-types.ts` | `chainConfig.approvalPolicy?: ApprovalPolicy` |
| `agent` | `src/dkg-agent.ts` | Forward to `EVMChainAdapter` constructor |
| `cli` | `src/config.ts` | `ApprovalPolicyConfig` (YAML-friendly, stringly numerics) + `resolveApprovalPolicy()` |
| `cli` | `src/daemon/lifecycle.ts` | Wire `chain.approvalPolicy` → agent `chainConfig` |
| `cli` | `test/config.test.ts` | +9 tests for the YAML → runtime conversion |
| `cli` | `skills/dkg-node/SKILL.md` | New "TRAC auto-approve policy" subsection under §8 with the trade-off table and config shape |

## Invariants pinned down by tests

Every policy mode honours these (exercised explicitly in the cross-mode invariant tests):

- `targetAllowance >= effectivePublishAllowance(tokenAmount)` — even a misconfigured `replenishing` target gets raised to the on-chain 1n floor so the immediate publish never reverts.
- `needsApprove` is monotone in `currentAllowance` — strictly more existing allowance never flips `false` to `true`.
- Unknown mode (defensive fallback) → behaves as `per-publish` rather than throwing inside the publish hot path.

## Why this is rc.12-worth (both commits)

Commit 1 is a production-blocker: any operator who hasn't pre-approved their op-wallets hits it on the first publish to a zero-cost / dust CG. Must ship in the last RC.

Commit 2 is mainnet-readiness: the bounded-per-publish policy is correct after commit 1 but unnecessarily expensive on mainnet. Shipping the config knob in rc.12 means operators preparing for launch can opt into the better economics before they're on mainnet, without us having to chase a follow-up PR into rc.13. Default is preserved-behaviour so it's a no-op for anyone who doesn't read the new skill section.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-chain exec vitest run -c vitest.unit.config.ts` — 104/104 pass
- [x] `pnpm --filter @origintrail-official/dkg exec vitest run -c vitest.unit.config.ts` — 468/468 pass
- [x] `tsc` green across chain → agent → mcp-dkg → cli
- [x] Zero lints across all 10 modified files
- [ ] Hardhat e2e (in CI)
- [ ] On-chain validation: re-run the stress publish loop with fresh op-wallets (no manual pre-approval) and verify zero `TooLowAllowance` reverts
- [ ] On-chain validation: switch a node to `replenishing` mode, observe one approve tx every ~9 publishes instead of every publish where cost grows