### PR TITLE
CLI: include assertion name in promote publish guidance

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1939,7 +1939,7 @@ assertionCmd
       if (Array.isArray(result.rootEntities) && result.rootEntities.length > 0) {
         console.log(`  Root entities:  ${result.rootEntities.join(', ')}`);
       }
-      console.log(`  Next:           dkg shared-memory publish ${opts.contextGraph}${opts.subGraphName ? ` --sub-graph-name ${opts.subGraphName}` : ''}`);
+      console.log(`  Next:           dkg shared-memory publish ${opts.contextGraph} --name ${name}${opts.subGraphName ? ` --sub-graph-name ${opts.subGraphName}` : ''}`);
     } catch (err) {
       console.error(toErrorMessage(err));
       process.exit(1);

--- a/packages/cli/test/assertion-cli-smoke.test.ts
+++ b/packages/cli/test/assertion-cli-smoke.test.ts
@@ -206,5 +206,19 @@ describe.sequential('assertion CLI smoke', () => {
     expect(promoted.stdout).toContain('Assertion promoted to shared memory:');
     expect(promoted.stdout).toContain('Triples:        14');
     expect(promoted.stdout).toContain('urn:company:acme');
+    expect(promoted.stdout).toContain('Next:           dkg shared-memory publish research --name paper');
+
+    const promotedSubgraph = await execFileAsync('node', [
+      CLI_ENTRY,
+      'assertion',
+      'promote',
+      'paper',
+      '--context-graph',
+      'research',
+      '--sub-graph-name',
+      'lab',
+    ], { env });
+
+    expect(promotedSubgraph.stdout).toContain('Next:           dkg shared-memory publish research --name paper --sub-graph-name lab');
   }, 15000);
 });


### PR DESCRIPTION
## Summary
- Add the promoted assertion name to the next-step publish command printed by `dkg assertion promote`.
- Preserve `--sub-graph-name` in that guidance when promoting from a sub-graph.
- Extend the assertion CLI smoke test to cover both output forms.

## Why
`dkg assertion promote <name> --context-graph <cg>` already receives the assertion name for the promote step. The broken part was the printed follow-up command: `dkg shared-memory publish <cg>` omitted `--name <assertion-name>` even though publish is assertion-scoped. A context graph can contain multiple staged/promoted assertion bundles, so publish needs the assertion name to know which bundle to finalize and publish.

Fixes #701

## Test Plan
- `pnpm --dir packages/cli exec vitest run test/assertion-cli-smoke.test.ts`
- Live devnet: started a two-node local devnet and verified `dkg assertion promote issue701-promote-guidance --context-graph devnet-test` printed `dkg shared-memory publish devnet-test --name issue701-promote-guidance`.
- Live devnet: verified sub-graph promote printed `dkg shared-memory publish devnet-test --name issue701-promote-guidance-sg --sub-graph-name issue701`.