### PR TITLE
fix(node-ui): entity tripleCount matches Triples tab (count type + multi-value + incoming)

### DIFF
--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -18,19 +18,27 @@ export interface MemoryEntity {
   properties: Map<string, string[]>;
   connections: Array<{ predicate: string; targetUri: string; targetLabel: string }>;
   /**
-   * Number of *distinct* (subject, predicate, object) triples that
-   * reference this entity as subject or object — matches the row
-   * count the entity-detail Triples tab shows on a layer page
-   * (which `dedupeTriplesBySpo`s before render, see
-   * `ProjectView.tsx`). Drives the entity-row badge and is the
-   * sort key for entity lists.
+   * Number of *distinct* (subject, predicate, object) triples in
+   * this entity's CANONICAL layer (`trustLevel`) that reference
+   * the entity as subject or object — matches the row count the
+   * entity-detail Triples tab shows on the layer page where the
+   * entity lives (which filters by layer via `useLayerTriples`
+   * and SPO-dedupes via `dedupeTriplesBySpo`, see `ProjectView.tsx`).
+   *
+   * Drives the entity-row badge and is the sort key for entity
+   * lists. Promoted-entity WM residue does NOT inflate this — a
+   * promoted SWM entity with leftover WM-only draft triples shows
+   * only the SWM-layer count (matching the SWM tab the user opens).
    *
    * NOT used by the KADetailView header / sidebar / footer — those
    * derive directly from `entityTriples.length` so they always
    * mirror whichever scope the user opened the detail page from
-   * (layer-page = deduped, overview = raw). This split avoids a
-   * mismatch when the same `(s,p,o)` lives in multiple sub-graph
-   * named graphs (the layer view dedupes, the overview view doesn't).
+   * (layer-page = layer-filtered + deduped, overview = raw).
+   *
+   * Optional because non-`buildEntities` callers (synthetic stubs
+   * in `useProjectActivity`, test fixtures) construct `MemoryEntity`
+   * literals without it. `buildEntities` always populates it;
+   * consumers should fall back to `0` for stubs.
    *
    * PER-ENTITY METRIC ONLY. An IRI-object triple `(A, p, B)` bumps
    * BOTH `A.tripleCount` and `B.tripleCount`, so
@@ -39,7 +47,7 @@ export interface MemoryEntity {
    * (DashboardView); CG/sub-graph totals to the daemon's
    * `/api/sub-graph/list` `tripleCount` (SubGraphBar).
    */
-  tripleCount: number;
+  tripleCount?: number;
 }
 
 export interface Triple {
@@ -337,27 +345,43 @@ async function queryLayer(
 export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntity> {
   const entities = new Map<string, MemoryEntity>();
   const connectionKeys = new Map<string, Set<string>>();
-  // Per-entity SPO-dedup keys for `tripleCount`. Mirrors
-  // `dedupeTriplesBySpo` (`ProjectView.tsx`) so the precomputed
-  // count agrees with the layer-page Triples tab even when the
-  // same `(s,p,o)` appears in multiple named graphs (e.g. once in
-  // `<cg>/_shared_memory` and once in `<cg>/<sg>/_shared_memory`).
-  const tripleSeen = new Map<string, Set<string>>();
-  function bumpTriple(entityUri: string, key: string): boolean {
-    let seen = tripleSeen.get(entityUri);
+  // Per-(entity, layer) SPO-dedup keys for `tripleCount`. Mirrors
+  // `useLayerTriples` + `dedupeTriplesBySpo` (`ProjectView.tsx`) so
+  // the precomputed count agrees with the layer-page Triples tab.
+  // Per-layer because a triple residing in two named graphs of the
+  // SAME layer (e.g. `<cg>/_shared_memory` and
+  // `<cg>/<sg>/_shared_memory` both at the SWM layer) must dedupe,
+  // while a triple residing in DIFFERENT layers (WM residue + SWM
+  // current for a promoted entity) is a distinct row on each
+  // layer's tab and so contributes to each layer's count.
+  const tripleSeen = new Map<string, Map<TrustLevel, Set<string>>>();
+  const tripleCountByLayer = new Map<string, Record<TrustLevel, number>>();
+  function bumpTriple(entityUri: string, layer: TrustLevel, key: string): boolean {
+    let layerMap = tripleSeen.get(entityUri);
+    if (!layerMap) {
+      layerMap = new Map();
+      tripleSeen.set(entityUri, layerMap);
+    }
+    let seen = layerMap.get(layer);
     if (!seen) {
       seen = new Set<string>();
-      tripleSeen.set(entityUri, seen);
+      layerMap.set(layer, seen);
     }
     if (seen.has(key)) return false;
     seen.add(key);
+    let counts = tripleCountByLayer.get(entityUri);
+    if (!counts) {
+      counts = { working: 0, shared: 0, verified: 0 };
+      tripleCountByLayer.set(entityUri, counts);
+    }
+    counts[layer]++;
     return true;
   }
   // Deferred bumps for class-entity object sides on rdf:type triples.
   // Applied after the main loop, only for class entities that already
   // exist (i.e. have their own triples). See the inline note in the
   // rdf:type branch for why we cannot bump these eagerly.
-  const deferredTypeBumps: Array<{ typeUri: string; spoKey: string }> = [];
+  const deferredTypeBumps: Array<{ typeUri: string; layer: TrustLevel; spoKey: string }> = [];
 
   function getOrCreate(uri: string): MemoryEntity {
     const entityUri = canonicalEntityUri(uri);
@@ -372,7 +396,7 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
         subGraphs: new Set(),
         properties: new Map(),
         connections: [],
-        tripleCount: 0,
+        tripleCount: 0, // finalised to canonical-layer count post-loop
       };
       entities.set(entityUri, e);
     }
@@ -388,9 +412,10 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
     const canonicalObject = isUri(t.object) ? canonicalEntityUri(t.object) : t.object;
     const spoKey = `${entity.uri}\0${t.predicate}\0${canonicalObject}`;
     // Subject-side bump — every distinct `(s,p,o)` triple referencing
-    // this entity contributes 1, matching the layer-page Triples tab
-    // (which SPO-dedupes via `dedupeTriplesBySpo` before render).
-    if (bumpTriple(entity.uri, spoKey)) entity.tripleCount++;
+    // this entity in `t.layer` contributes 1, matching the layer-page
+    // Triples tab (which filters by layer via `useLayerTriples` and
+    // SPO-dedupes via `dedupeTriplesBySpo` before render).
+    bumpTriple(entity.uri, t.layer, spoKey);
 
     if (t.predicate === RDF_TYPE) {
       const typeUri = canonicalEntityUri(t.object);
@@ -412,7 +437,7 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
       // node has its own triples" condition. Self-link guard same
       // as the IRI branch.
       if (typeUri !== entity.uri) {
-        deferredTypeBumps.push({ typeUri, spoKey });
+        deferredTypeBumps.push({ typeUri, layer: t.layer, spoKey });
       }
     } else if (isUri(t.object)) {
       const targetUri = canonicalObject;
@@ -425,7 +450,7 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
       // `s===uri || o===uri` which yields one row for a self-link,
       // and the subject-side bump above already counted it once.
       if (targetUri !== entity.uri) {
-        if (bumpTriple(targetEntity.uri, spoKey)) targetEntity.tripleCount++;
+        bumpTriple(targetEntity.uri, t.layer, spoKey);
       }
       const keys = connectionKeys.get(entity.uri) ?? new Set<string>();
       const connectionKey = `${t.predicate}\0${targetUri}`;
@@ -452,10 +477,10 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
   // exist (i.e. have their own triples in `entities`). We never
   // `getOrCreate` here — adding `schema:Thing`-style schema URIs as
   // entities would break `useLayerTriples`' residue filter.
-  for (const { typeUri, spoKey } of deferredTypeBumps) {
+  for (const { typeUri, layer, spoKey } of deferredTypeBumps) {
     const typeEntity = entities.get(typeUri);
     if (!typeEntity) continue;
-    if (bumpTriple(typeEntity.uri, spoKey)) typeEntity.tripleCount++;
+    bumpTriple(typeEntity.uri, layer, spoKey);
   }
 
   for (const entity of entities.values()) {
@@ -464,6 +489,13 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
     if (entity.layers.has('verified')) entity.trustLevel = 'verified';
     else if (entity.layers.has('shared')) entity.trustLevel = 'shared';
     else entity.trustLevel = 'working';
+
+    // Finalise `tripleCount` to the canonical-layer count — what the
+    // entity-row badge on this entity's layer page shows after
+    // useLayerTriples + dedupeTriplesBySpo. Cross-layer residue (e.g.
+    // a promoted SWM entity's WM-only drafts) does not inflate it.
+    const counts = tripleCountByLayer.get(entity.uri);
+    entity.tripleCount = counts ? counts[entity.trustLevel] : 0;
   }
 
   for (const entity of entities.values()) {
@@ -574,8 +606,8 @@ export function useMemoryEntities(
         const trustOrder = { verified: 0, shared: 1, working: 2 };
         const td = trustOrder[a.trustLevel] - trustOrder[b.trustLevel];
         if (td !== 0) return td;
-        const ca = a.tripleCount;
-        const cb = b.tripleCount;
+        const ca = a.tripleCount ?? 0;
+        const cb = b.tripleCount ?? 0;
         if (cb !== ca) return cb - ca;
         return a.label.localeCompare(b.label);
       }),

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -370,8 +370,14 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
       if (t.subGraph) targetEntity.subGraphs.add(t.subGraph);
       // Object-side bump — entity appearing as the object of someone
       // else's triple shows up in its own Triples tab too, so its
-      // tripleCount must include it.
-      targetEntity.tripleCount++;
+      // tripleCount must include it. Skip when self-referential
+      // (`(A, p, A)`): the Triples-tab filter is `s===uri || o===uri`
+      // which yields one row for a self-link, so counting both sides
+      // here would disagree by one. Subject-side bump already happened
+      // above, so the self-link is still counted once.
+      if (targetUri !== entity.uri) {
+        targetEntity.tripleCount++;
+      }
       const keys = connectionKeys.get(entity.uri) ?? new Set<string>();
       const connectionKey = `${t.predicate}\0${targetUri}`;
       if (!keys.has(connectionKey)) {

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -17,6 +17,18 @@ export interface MemoryEntity {
   subGraphs: Set<string>;
   properties: Map<string, string[]>;
   connections: Array<{ predicate: string; targetUri: string; targetLabel: string }>;
+  /**
+   * Number of triple rows that reference this entity as subject or object —
+   * matches the row count the entity-detail Triples tab shows. Used by the
+   * entity-row badge and the entity-detail header/sidebar/footer.
+   *
+   * PER-ENTITY METRIC ONLY. An IRI-object triple `(A, p, B)` bumps BOTH
+   * `A.tripleCount` and `B.tripleCount`, so `sum(e.tripleCount)` across
+   * a layer is NOT the layer's triple total. Layer totals belong to
+   * `mem.allTriples.length` (DashboardView); CG/sub-graph totals to the
+   * daemon's `/api/sub-graph/list` `tripleCount` (SubGraphBar).
+   */
+  tripleCount: number;
 }
 
 export interface Triple {
@@ -328,6 +340,7 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
         subGraphs: new Set(),
         properties: new Map(),
         connections: [],
+        tripleCount: 0,
       };
       entities.set(entityUri, e);
     }
@@ -338,6 +351,12 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
     const entity = getOrCreate(t.subject);
     entity.layers.add(t.layer);
     if (t.subGraph) entity.subGraphs.add(t.subGraph);
+    // Every observed triple bumps subject-side count — type, literal,
+    // and connection alike. Counted BEFORE the connection-dedup below
+    // so the badge matches the Triples-tab raw row count (same triple
+    // appearing in two sub-graphs shows twice in the tab and counts
+    // twice here).
+    entity.tripleCount++;
 
     if (t.predicate === RDF_TYPE) {
       const typeUri = canonicalEntityUri(t.object);
@@ -349,6 +368,10 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
       const targetEntity = getOrCreate(targetUri);
       targetEntity.layers.add(t.layer);
       if (t.subGraph) targetEntity.subGraphs.add(t.subGraph);
+      // Object-side bump — entity appearing as the object of someone
+      // else's triple shows up in its own Triples tab too, so its
+      // tripleCount must include it.
+      targetEntity.tripleCount++;
       const keys = connectionKeys.get(entity.uri) ?? new Set<string>();
       const connectionKey = `${t.predicate}\0${targetUri}`;
       if (!keys.has(connectionKey)) {
@@ -486,8 +509,8 @@ export function useMemoryEntities(
         const trustOrder = { verified: 0, shared: 1, working: 2 };
         const td = trustOrder[a.trustLevel] - trustOrder[b.trustLevel];
         if (td !== 0) return td;
-        const ca = a.connections.length + a.properties.size;
-        const cb = b.connections.length + b.properties.size;
+        const ca = a.tripleCount;
+        const cb = b.tripleCount;
         if (cb !== ca) return cb - ca;
         return a.label.localeCompare(b.label);
       }),

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -18,15 +18,26 @@ export interface MemoryEntity {
   properties: Map<string, string[]>;
   connections: Array<{ predicate: string; targetUri: string; targetLabel: string }>;
   /**
-   * Number of triple rows that reference this entity as subject or object —
-   * matches the row count the entity-detail Triples tab shows. Used by the
-   * entity-row badge and the entity-detail header/sidebar/footer.
+   * Number of *distinct* (subject, predicate, object) triples that
+   * reference this entity as subject or object — matches the row
+   * count the entity-detail Triples tab shows on a layer page
+   * (which `dedupeTriplesBySpo`s before render, see
+   * `ProjectView.tsx`). Drives the entity-row badge and is the
+   * sort key for entity lists.
    *
-   * PER-ENTITY METRIC ONLY. An IRI-object triple `(A, p, B)` bumps BOTH
-   * `A.tripleCount` and `B.tripleCount`, so `sum(e.tripleCount)` across
-   * a layer is NOT the layer's triple total. Layer totals belong to
-   * `mem.allTriples.length` (DashboardView); CG/sub-graph totals to the
-   * daemon's `/api/sub-graph/list` `tripleCount` (SubGraphBar).
+   * NOT used by the KADetailView header / sidebar / footer — those
+   * derive directly from `entityTriples.length` so they always
+   * mirror whichever scope the user opened the detail page from
+   * (layer-page = deduped, overview = raw). This split avoids a
+   * mismatch when the same `(s,p,o)` lives in multiple sub-graph
+   * named graphs (the layer view dedupes, the overview view doesn't).
+   *
+   * PER-ENTITY METRIC ONLY. An IRI-object triple `(A, p, B)` bumps
+   * BOTH `A.tripleCount` and `B.tripleCount`, so
+   * `sum(e.tripleCount)` across a layer is NOT the layer's triple
+   * total. Layer totals belong to `mem.allTriples.length`
+   * (DashboardView); CG/sub-graph totals to the daemon's
+   * `/api/sub-graph/list` `tripleCount` (SubGraphBar).
    */
   tripleCount: number;
 }
@@ -326,6 +337,27 @@ async function queryLayer(
 export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntity> {
   const entities = new Map<string, MemoryEntity>();
   const connectionKeys = new Map<string, Set<string>>();
+  // Per-entity SPO-dedup keys for `tripleCount`. Mirrors
+  // `dedupeTriplesBySpo` (`ProjectView.tsx`) so the precomputed
+  // count agrees with the layer-page Triples tab even when the
+  // same `(s,p,o)` appears in multiple named graphs (e.g. once in
+  // `<cg>/_shared_memory` and once in `<cg>/<sg>/_shared_memory`).
+  const tripleSeen = new Map<string, Set<string>>();
+  function bumpTriple(entityUri: string, key: string): boolean {
+    let seen = tripleSeen.get(entityUri);
+    if (!seen) {
+      seen = new Set<string>();
+      tripleSeen.set(entityUri, seen);
+    }
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }
+  // Deferred bumps for class-entity object sides on rdf:type triples.
+  // Applied after the main loop, only for class entities that already
+  // exist (i.e. have their own triples). See the inline note in the
+  // rdf:type branch for why we cannot bump these eagerly.
+  const deferredTypeBumps: Array<{ typeUri: string; spoKey: string }> = [];
 
   function getOrCreate(uri: string): MemoryEntity {
     const entityUri = canonicalEntityUri(uri);
@@ -351,32 +383,49 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
     const entity = getOrCreate(t.subject);
     entity.layers.add(t.layer);
     if (t.subGraph) entity.subGraphs.add(t.subGraph);
-    // Every observed triple bumps subject-side count — type, literal,
-    // and connection alike. Counted BEFORE the connection-dedup below
-    // so the badge matches the Triples-tab raw row count (same triple
-    // appearing in two sub-graphs shows twice in the tab and counts
-    // twice here).
-    entity.tripleCount++;
+    // Build the SPO key from canonicalised subject/object so cross-
+    // graph copies that differ only in `<>` wrapping still dedupe.
+    const canonicalObject = isUri(t.object) ? canonicalEntityUri(t.object) : t.object;
+    const spoKey = `${entity.uri}\0${t.predicate}\0${canonicalObject}`;
+    // Subject-side bump — every distinct `(s,p,o)` triple referencing
+    // this entity contributes 1, matching the layer-page Triples tab
+    // (which SPO-dedupes via `dedupeTriplesBySpo` before render).
+    if (bumpTriple(entity.uri, spoKey)) entity.tripleCount++;
 
     if (t.predicate === RDF_TYPE) {
       const typeUri = canonicalEntityUri(t.object);
       if (!entity.types.includes(typeUri)) {
         entity.types.push(typeUri);
       }
+      // DEFERRED type-class object-side bump: queue, don't getOrCreate.
+      // Opening a class entity (e.g. `urn:type:ObjectEvent`) that has
+      // its own triples shows incoming `rdf:type` rows in its Triples
+      // tab, so its `tripleCount` must include them — but we must
+      // only bump classes that already exist as first-class entities.
+      // Calling `getOrCreate` here would inject schema URIs like
+      // `schema:Thing` into the entity map with `trustLevel = 'working'`
+      // (no layers), which trips `useLayerTriples`' residue filter at
+      // helpers.ts:444-448 (`objectEntity.trustLevel !== targetLayer`
+      // ⇒ drops the rdf:type row from SWM/VM views). The deferred
+      // pass after the loop bumps only entities that already exist
+      // by virtue of their own triples — matches Codex's "if the type
+      // node has its own triples" condition. Self-link guard same
+      // as the IRI branch.
+      if (typeUri !== entity.uri) {
+        deferredTypeBumps.push({ typeUri, spoKey });
+      }
     } else if (isUri(t.object)) {
-      const targetUri = canonicalEntityUri(t.object);
+      const targetUri = canonicalObject;
       const targetEntity = getOrCreate(targetUri);
       targetEntity.layers.add(t.layer);
       if (t.subGraph) targetEntity.subGraphs.add(t.subGraph);
       // Object-side bump — entity appearing as the object of someone
-      // else's triple shows up in its own Triples tab too, so its
-      // tripleCount must include it. Skip when self-referential
-      // (`(A, p, A)`): the Triples-tab filter is `s===uri || o===uri`
-      // which yields one row for a self-link, so counting both sides
-      // here would disagree by one. Subject-side bump already happened
-      // above, so the self-link is still counted once.
+      // else's triple shows up in its own Triples tab too. Skip when
+      // self-referential (`(A, p, A)`): the Triples-tab filter is
+      // `s===uri || o===uri` which yields one row for a self-link,
+      // and the subject-side bump above already counted it once.
       if (targetUri !== entity.uri) {
-        targetEntity.tripleCount++;
+        if (bumpTriple(targetEntity.uri, spoKey)) targetEntity.tripleCount++;
       }
       const keys = connectionKeys.get(entity.uri) ?? new Set<string>();
       const connectionKey = `${t.predicate}\0${targetUri}`;
@@ -397,6 +446,16 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
         entity.properties.set(t.predicate, existing);
       }
     }
+  }
+
+  // Apply deferred type-target bumps for class entities that already
+  // exist (i.e. have their own triples in `entities`). We never
+  // `getOrCreate` here — adding `schema:Thing`-style schema URIs as
+  // entities would break `useLayerTriples`' residue filter.
+  for (const { typeUri, spoKey } of deferredTypeBumps) {
+    const typeEntity = entities.get(typeUri);
+    if (!typeEntity) continue;
+    if (bumpTriple(typeEntity.uri, spoKey)) typeEntity.tripleCount++;
   }
 
   for (const entity of entities.values()) {

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -377,12 +377,6 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
     counts[layer]++;
     return true;
   }
-  // Deferred bumps for class-entity object sides on rdf:type triples.
-  // Applied after the main loop, only for class entities that already
-  // exist (i.e. have their own triples). See the inline note in the
-  // rdf:type branch for why we cannot bump these eagerly.
-  const deferredTypeBumps: Array<{ typeUri: string; layer: TrustLevel; spoKey: string }> = [];
-
   function getOrCreate(uri: string): MemoryEntity {
     const entityUri = canonicalEntityUri(uri);
     let e = entities.get(entityUri);
@@ -403,55 +397,36 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
     return e;
   }
 
+  // PASS 1 — populate entities, types, connections, properties, layers.
+  // Triple counts are intentionally NOT bumped here: they need to be
+  // gated by the same residue filter `useLayerTriples` applies (subject
+  // and object trustLevel must equal the layer), and trustLevels are
+  // only known after this pass. Pass 3 below redoes the walk with
+  // residue-filter-aware counting.
   for (const t of layered) {
     const entity = getOrCreate(t.subject);
     entity.layers.add(t.layer);
     if (t.subGraph) entity.subGraphs.add(t.subGraph);
-    // Build the SPO key from canonicalised subject/object so cross-
-    // graph copies that differ only in `<>` wrapping still dedupe.
-    const canonicalObject = isUri(t.object) ? canonicalEntityUri(t.object) : t.object;
-    const spoKey = `${entity.uri}\0${t.predicate}\0${canonicalObject}`;
-    // Subject-side bump — every distinct `(s,p,o)` triple referencing
-    // this entity in `t.layer` contributes 1, matching the layer-page
-    // Triples tab (which filters by layer via `useLayerTriples` and
-    // SPO-dedupes via `dedupeTriplesBySpo` before render).
-    bumpTriple(entity.uri, t.layer, spoKey);
 
     if (t.predicate === RDF_TYPE) {
       const typeUri = canonicalEntityUri(t.object);
       if (!entity.types.includes(typeUri)) {
         entity.types.push(typeUri);
       }
-      // DEFERRED type-class object-side bump: queue, don't getOrCreate.
-      // Opening a class entity (e.g. `urn:type:ObjectEvent`) that has
-      // its own triples shows incoming `rdf:type` rows in its Triples
-      // tab, so its `tripleCount` must include them — but we must
-      // only bump classes that already exist as first-class entities.
-      // Calling `getOrCreate` here would inject schema URIs like
+      // Class targets (e.g. `urn:type:ObjectEvent`) are NOT created via
+      // getOrCreate here — that would inject schema URIs like
       // `schema:Thing` into the entity map with `trustLevel = 'working'`
-      // (no layers), which trips `useLayerTriples`' residue filter at
-      // helpers.ts:444-448 (`objectEntity.trustLevel !== targetLayer`
-      // ⇒ drops the rdf:type row from SWM/VM views). The deferred
-      // pass after the loop bumps only entities that already exist
-      // by virtue of their own triples — matches Codex's "if the type
-      // node has its own triples" condition. Self-link guard same
-      // as the IRI branch.
-      if (typeUri !== entity.uri) {
-        deferredTypeBumps.push({ typeUri, layer: t.layer, spoKey });
-      }
+      // (no layers), breaking `useLayerTriples`' residue filter
+      // (`helpers.ts:444-448`: `objectEntity.trustLevel !== targetLayer`
+      // ⇒ drops the rdf:type row from SWM/VM views). Pass 3 bumps
+      // class-entity counts only for classes that already exist by
+      // virtue of their own triples — matches Codex's "if the type
+      // node has its own triples" condition.
     } else if (isUri(t.object)) {
-      const targetUri = canonicalObject;
+      const targetUri = canonicalEntityUri(t.object);
       const targetEntity = getOrCreate(targetUri);
       targetEntity.layers.add(t.layer);
       if (t.subGraph) targetEntity.subGraphs.add(t.subGraph);
-      // Object-side bump — entity appearing as the object of someone
-      // else's triple shows up in its own Triples tab too. Skip when
-      // self-referential (`(A, p, A)`): the Triples-tab filter is
-      // `s===uri || o===uri` which yields one row for a self-link,
-      // and the subject-side bump above already counted it once.
-      if (targetUri !== entity.uri) {
-        bumpTriple(targetEntity.uri, t.layer, spoKey);
-      }
       const keys = connectionKeys.get(entity.uri) ?? new Set<string>();
       const connectionKey = `${t.predicate}\0${targetUri}`;
       if (!keys.has(connectionKey)) {
@@ -473,27 +448,68 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
     }
   }
 
-  // Apply deferred type-target bumps for class entities that already
-  // exist (i.e. have their own triples in `entities`). We never
-  // `getOrCreate` here — adding `schema:Thing`-style schema URIs as
-  // entities would break `useLayerTriples`' residue filter.
-  for (const { typeUri, layer, spoKey } of deferredTypeBumps) {
-    const typeEntity = entities.get(typeUri);
-    if (!typeEntity) continue;
-    bumpTriple(typeEntity.uri, layer, spoKey);
-  }
-
+  // PASS 2 — finalise label + trustLevel so Pass 3's residue filter
+  // sees authoritative per-entity layer.
   for (const entity of entities.values()) {
     entity.label = deriveEntityLabel(entity);
 
     if (entity.layers.has('verified')) entity.trustLevel = 'verified';
     else if (entity.layers.has('shared')) entity.trustLevel = 'shared';
     else entity.trustLevel = 'working';
+  }
 
-    // Finalise `tripleCount` to the canonical-layer count — what the
-    // entity-row badge on this entity's layer page shows after
-    // useLayerTriples + dedupeTriplesBySpo. Cross-layer residue (e.g.
-    // a promoted SWM entity's WM-only drafts) does not inflate it.
+  // PASS 3 — count triples per (entity, layer) under the same residue
+  // filter `useLayerTriples` uses (`helpers.ts:444-448`). A cross-layer
+  // edge `wm:A → swm:B` is dropped from the WM tab because the object
+  // has been promoted past WM, so it must not bump A's WM count either
+  // — otherwise badge over-counts vs tab.
+  for (const t of layered) {
+    const subjectUri = canonicalEntityUri(t.subject);
+    const subjectEntity = entities.get(subjectUri);
+    // Mirror `useLayerTriples` line 426-427: if the subject entity
+    // exists and its canonical layer differs from this triple's layer,
+    // it's residue — drop. Subjects that don't resolve to a tracked
+    // entity (literal orphans / class IRIs) pass through.
+    if (subjectEntity && subjectEntity.trustLevel !== t.layer) continue;
+
+    const canonicalObject = isUri(t.object) ? canonicalEntityUri(t.object) : t.object;
+    const objectIsResource = isUri(t.object);
+    if (objectIsResource) {
+      const objectEntity = entities.get(canonicalObject);
+      // Mirror `useLayerTriples` line 444-448: object-side trust
+      // check. Cross-layer resource→resource edges are dropped on
+      // the source layer's tab; they must not bump either endpoint's
+      // count for that layer.
+      if (objectEntity && objectEntity.trustLevel !== t.layer) continue;
+    }
+
+    const spoKey = `${subjectUri}\0${t.predicate}\0${canonicalObject}`;
+    if (subjectEntity) bumpTriple(subjectEntity.uri, t.layer, spoKey);
+
+    if (t.predicate === RDF_TYPE) {
+      // Class-target bump only when the class is a first-class entity
+      // (created by its own triples in Pass 1). Self-link guard same
+      // as the IRI branch below.
+      if (canonicalObject !== subjectUri) {
+        const typeEntity = entities.get(canonicalObject);
+        if (typeEntity) bumpTriple(typeEntity.uri, t.layer, spoKey);
+      }
+    } else if (objectIsResource) {
+      // Self-link guard: `(A, p, A)` is one row in the Triples tab
+      // (`s===uri || o===uri` matches once); subject-side bump above
+      // already counted it.
+      if (canonicalObject !== subjectUri) {
+        const targetEntity = entities.get(canonicalObject);
+        if (targetEntity) bumpTriple(targetEntity.uri, t.layer, spoKey);
+      }
+    }
+  }
+
+  // PASS 4 — finalise `tripleCount` to the canonical-layer count.
+  // What the entity-row badge on this entity's layer page shows after
+  // useLayerTriples + dedupeTriplesBySpo. Cross-layer residue (e.g. a
+  // promoted SWM entity's WM-only drafts) does not inflate it.
+  for (const entity of entities.values()) {
     const counts = tripleCountByLayer.get(entity.uri);
     entity.tripleCount = counts ? counts[entity.trustLevel] : 0;
   }

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -5,6 +5,7 @@ import { ImportFilesModal } from '../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../components/Modals/ShareProjectModal.js';
 import {
   buildMemoryEntities,
+  canonicalEntityUri,
   useMemoryEntities,
   type LayeredTriple,
   type TrustLevel,
@@ -70,7 +71,14 @@ function isMemoryLayerView(layer: LayerView): layer is MemoryLayerView {
 function dedupeTriplesBySpo<T extends { subject: string; predicate: string; object: string }>(triples: T[]): T[] {
   const seen = new Set<string>();
   return triples.filter(t => {
-    const key = `${t.subject}|${t.predicate}|${t.object}`;
+    // Canonicalise wrapped/bare IRIs so this dedup agrees with
+    // `buildEntities`' per-entity `tripleCount` dedup
+    // (`useMemoryEntities.ts` builds its SPO key from canonical
+    // subject/object). Daemon sometimes ships wrapped `<urn:...>`
+    // for the same triple it returns bare elsewhere; without
+    // canonicalisation here the detail-page Triples tab would show
+    // two rows for what the badge counts as one.
+    const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
     if (seen.has(key)) return false;
     seen.add(key);
     return true;

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3227,7 +3227,16 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
   }, [entity.uri, allEntities]);
 
   const entityTriples = useMemo(
-    () => allTriples.filter(t => t.subject === entity.uri || t.object === entity.uri),
+    // Canonicalise raw triple sides before comparing — `entity.uri`
+    // was canonicalised by `getOrCreate` in `buildEntities`, but
+    // `allTriples` keeps the raw daemon strings (which can ship
+    // wrapped as `<urn:...>`). Without this both surfaces disagree
+    // for wrapped-IRI rows: the entity-row badge counts them (it
+    // uses the canonicalised entity key) while this filter would
+    // drop them. Idempotent + no-op for already-bare URIs.
+    () => allTriples.filter(t =>
+      canonicalEntityUri(t.subject) === entity.uri ||
+      canonicalEntityUri(t.object) === entity.uri),
     [entity.uri, allTriples]
   );
 

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1689,8 +1689,8 @@ export function EntityList({
     if (externallySorted) return entities;
     const copy = [...entities];
     copy.sort((a, b) => {
-      const aCount = a.connections.length + a.properties.size;
-      const bCount = b.connections.length + b.properties.size;
+      const aCount = a.tripleCount;
+      const bCount = b.tripleCount;
       return bCount - aCount;
     });
     return copy;
@@ -1723,7 +1723,7 @@ export function EntityList({
       </div>
       {sorted.map(e => {
         const { icon, type } = entityMeta(e, profile);
-        const tripleCount = e.connections.length + e.properties.size;
+        const tripleCount = e.tripleCount;
         const authorUri = entityAuthorUri(e);
         const author = authorUri ? agents?.get(authorUri) : null;
         const ts = timestampPredicate ? entityTimestamp(e, timestampPredicate) : null;
@@ -3300,7 +3300,7 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
     focal: { uri: entity.uri, sizeMultiplier: 2.4 },
   }), [entity.uri, theme]);
 
-  const tripleCount = entity.connections.length + entity.properties.size;
+  const tripleCount = entity.tripleCount;
 
   return (
     <div className="v10-ka-detail">
@@ -4305,8 +4305,8 @@ export function SubGraphDetailView({
     }
     // 'triples' (default fallback)
     copy.sort((a, b) => {
-      const aCount = a.connections.length + a.properties.size;
-      const bCount = b.connections.length + b.properties.size;
+      const aCount = a.tripleCount;
+      const bCount = b.tripleCount;
       return bCount - aCount;
     });
     return copy;

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3309,7 +3309,14 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
     focal: { uri: entity.uri, sizeMultiplier: 2.4 },
   }), [entity.uri, theme]);
 
-  const tripleCount = entity.tripleCount;
+  // Derive from the actual triples this view renders, NOT from
+  // `entity.tripleCount`. The KADetailView is opened with either
+  // the raw `allTriples` (overview scope) or the SPO-deduped slice
+  // (layer scope, see `ProjectView.dedupeTriplesBySpo`). Reading
+  // the precomputed field would freeze on the deduped semantic and
+  // disagree with the tab on overview-scoped opens. `entityTriples`
+  // is already the filtered set the Triples tab counts rows from.
+  const tripleCount = entityTriples.length;
 
   return (
     <div className="v10-ka-detail">

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1689,8 +1689,8 @@ export function EntityList({
     if (externallySorted) return entities;
     const copy = [...entities];
     copy.sort((a, b) => {
-      const aCount = a.tripleCount;
-      const bCount = b.tripleCount;
+      const aCount = a.tripleCount ?? 0;
+      const bCount = b.tripleCount ?? 0;
       return bCount - aCount;
     });
     return copy;
@@ -1723,7 +1723,7 @@ export function EntityList({
       </div>
       {sorted.map(e => {
         const { icon, type } = entityMeta(e, profile);
-        const tripleCount = e.tripleCount;
+        const tripleCount = e.tripleCount ?? 0;
         const authorUri = entityAuthorUri(e);
         const author = authorUri ? agents?.get(authorUri) : null;
         const ts = timestampPredicate ? entityTimestamp(e, timestampPredicate) : null;
@@ -4321,8 +4321,8 @@ export function SubGraphDetailView({
     }
     // 'triples' (default fallback)
     copy.sort((a, b) => {
-      const aCount = a.tripleCount;
-      const bCount = b.tripleCount;
+      const aCount = a.tripleCount ?? 0;
+      const bCount = b.tripleCount ?? 0;
       return bCount - aCount;
     });
     return copy;

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -334,17 +334,27 @@ export function getDescription(e: MemoryEntity): string | null {
  * with clear name + JSDoc so the two semantics stay distinguishable.
  */
 export function neighborhoodTriples(entityUri: string, allTriples: Triple[], hops: number = 2): Triple[] {
+  // Canonicalise both sides of the comparison: `entityUri` is the
+  // canonical form (`MemoryEntity.uri`) but `allTriples` keeps raw
+  // daemon strings, which can ship wrapped as `<urn:...>`. A bare
+  // entity URI would miss wrapped-IRI rows that the entity-detail
+  // Triples tab + KADetailView header (now canonicalised) include —
+  // the graph pane right below would silently drop them.
+  const canonicalSubject = (t: Triple) => canonicalEntityUri(t.subject);
+  const canonicalObject = (t: Triple) => canonicalEntityUri(t.object);
   const visited = new Set<string>([entityUri]);
   let frontier = new Set<string>([entityUri]);
 
   for (let i = 0; i < hops; i++) {
     const nextFrontier = new Set<string>();
     for (const t of allTriples) {
-      if (frontier.has(t.subject) && !visited.has(t.object)) {
-        nextFrontier.add(t.object);
+      const s = canonicalSubject(t);
+      const o = canonicalObject(t);
+      if (frontier.has(s) && !visited.has(o)) {
+        nextFrontier.add(o);
       }
-      if (frontier.has(t.object) && !visited.has(t.subject)) {
-        nextFrontier.add(t.subject);
+      if (frontier.has(o) && !visited.has(s)) {
+        nextFrontier.add(s);
       }
     }
     for (const u of nextFrontier) visited.add(u);
@@ -352,7 +362,7 @@ export function neighborhoodTriples(entityUri: string, allTriples: Triple[], hop
     if (frontier.size === 0) break;
   }
 
-  return allTriples.filter(t => visited.has(t.subject) && visited.has(t.object));
+  return allTriples.filter(t => visited.has(canonicalSubject(t)) && visited.has(canonicalObject(t)));
 }
 
 export function matchesSearch(e: MemoryEntity, q: string): boolean {
@@ -446,7 +456,13 @@ export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, la
         const objectEntity = memory.entities.get(canonicalObject);
         if (objectEntity && objectEntity.trustLevel !== targetLayer) continue;
       }
-      const key = `${t.subject}|${t.predicate}|${t.object}`;
+      // Canonicalise the dedup key so wrapped/bare duplicates of the
+      // same `(s,p,o)` collapse — mirrors `dedupeTriplesBySpo` in
+      // `ProjectView.tsx` and `buildEntities`' per-entity SPO key.
+      // Without this the layer header / graph counts a wrapped-IRI
+      // duplicate row twice while the KADetailView Triples tab
+      // (canonicalised) shows it once.
+      const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
       if (seen.has(key)) continue;
       seen.add(key);
       out.push(t);

--- a/packages/node-ui/test/build-entities-triple-count.test.ts
+++ b/packages/node-ui/test/build-entities-triple-count.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildEntities, type LayeredTriple } from '../src/ui/hooks/useMemoryEntities.js';
+import { buildEntities, type LayeredTriple, type TrustLevel } from '../src/ui/hooks/useMemoryEntities.js';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
@@ -7,7 +7,8 @@ const triple = (
   subject: string,
   predicate: string,
   object: string,
-): LayeredTriple => ({ subject, predicate, object, layer: 'working' });
+  layer: TrustLevel = 'working',
+): LayeredTriple => ({ subject, predicate, object, layer });
 
 describe('buildEntities — MemoryEntity.tripleCount', () => {
   // `tripleCount` must match the entity-row badge ↔ layer-page Triples
@@ -159,6 +160,49 @@ describe('buildEntities — MemoryEntity.tripleCount', () => {
     expect(a.tripleCount).toBe(1);
     expect(b.tripleCount).toBe(1);
     // Sum (2) > input triples (1) — per-entity metric, not a layer aggregate.
-    expect(a.tripleCount + b.tripleCount).toBeGreaterThan(1);
+    expect((a.tripleCount ?? 0) + (b.tripleCount ?? 0)).toBeGreaterThan(1);
+  });
+
+  it('promoted-entity residue: tripleCount reflects canonical-layer count only, not cross-layer total', () => {
+    // Codex regression: a promoted SWM entity with WM-only draft residue
+    // would have a badge that includes the WM rows, but the SWM-tab
+    // detail view filters those out via `useLayerTriples`. Per-layer
+    // SPO-deduped count finalised to canonical-layer slice fixes this.
+    //
+    // Scenario: `urn:e:promoted` has been promoted to SWM. Its current
+    // SWM triples are 2 distinct rows; the daemon also leaves 1 WM
+    // draft-residue triple on disk that the SWM tab would never show.
+    const entities = buildEntities([
+      // WM residue (pre-promote draft) — shows on no tab for the
+      // promoted entity (`useLayerTriples` drops via residue filter).
+      triple('urn:e:promoted', 'urn:p:draft', '"draft content"', 'working'),
+      // Current SWM triples — what the SWM tab actually shows.
+      triple('urn:e:promoted', 'urn:p:label', '"Promoted"', 'shared'),
+      triple('urn:e:promoted', 'urn:p:status', '"published"', 'shared'),
+    ]);
+    const promoted = entities.get('urn:e:promoted')!;
+    expect(promoted.trustLevel).toBe('shared');
+    // Pre-fix this would be 3 (sum across layers). With per-layer
+    // dedup + canonical-layer finalisation, it's 2 — what the SWM
+    // tab actually shows.
+    expect(promoted.tripleCount).toBe(2);
+  });
+
+  it('cross-layer same-SPO does NOT collapse (each layer is its own dedup scope)', () => {
+    // Edge of the dedup design: if the same (s,p,o) appears in two
+    // DIFFERENT layers (e.g. as residue + current), each layer's count
+    // includes it once. They contribute independently to per-layer
+    // tabs and therefore must NOT cross-collapse.
+    const entities = buildEntities([
+      triple('urn:e:dual', 'urn:p:label', '"X"', 'working'),
+      triple('urn:e:dual', 'urn:p:label', '"X"', 'shared'),
+    ]);
+    const dual = entities.get('urn:e:dual')!;
+    expect(dual.trustLevel).toBe('shared');
+    // Canonical-layer = 'shared' has 1 distinct triple. WM residue
+    // is the same (s,p,o) but lives in its own per-layer count
+    // (which we don't surface via `tripleCount` for an SWM-canonical
+    // entity).
+    expect(dual.tripleCount).toBe(1);
   });
 });

--- a/packages/node-ui/test/build-entities-triple-count.test.ts
+++ b/packages/node-ui/test/build-entities-triple-count.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { buildEntities, type LayeredTriple } from '../src/ui/hooks/useMemoryEntities.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+const triple = (
+  subject: string,
+  predicate: string,
+  object: string,
+): LayeredTriple => ({ subject, predicate, object, layer: 'working' });
+
+describe('buildEntities — MemoryEntity.tripleCount', () => {
+  // The Triples tab on the entity-detail page derives its row count
+  // from `allTriples.filter(t => t.subject === uri || t.object === uri)`,
+  // so `tripleCount` must match. Pre-fix the entity-row badge derived
+  // from `connections.length + properties.size` and undercounted in
+  // three independent ways: missing types, multi-value literal collapse,
+  // and incoming triples not tracked. Cases below pin each.
+
+  it('counts subject-side IRI connections (1 per triple, dedup is for display only)', () => {
+    const entities = buildEntities([
+      triple('urn:e:a', 'urn:p:linksTo', 'urn:e:b'),
+      triple('urn:e:a', 'urn:p:relates', 'urn:e:c'),
+    ]);
+    expect(entities.get('urn:e:a')?.tripleCount).toBe(2);
+  });
+
+  it('counts every literal value, not just distinct predicates (cause #2)', () => {
+    // Two `description` literals on the same subject. `properties.size`
+    // collapses both into one map entry — Triples tab shows 2 rows.
+    const entities = buildEntities([
+      triple('urn:e:x', 'urn:p:description', '"Sample EPCIS event"'),
+      triple('urn:e:x', 'urn:p:description', '"Warehouse handling node"'),
+    ]);
+    expect(entities.get('urn:e:x')?.tripleCount).toBe(2);
+  });
+
+  it('counts rdf:type triples (cause #1)', () => {
+    // Type triples are routed into `entity.types` and were never
+    // counted by the pre-fix formula. Triples tab shows them as rows
+    // (e.g. the "type → ObjectEvent" row in the ObjectEvent example).
+    const entities = buildEntities([
+      triple('urn:e:t', RDF_TYPE, 'urn:type:Thing'),
+      triple('urn:e:t', 'urn:p:name', '"Hello"'),
+    ]);
+    expect(entities.get('urn:e:t')?.tripleCount).toBe(2);
+  });
+
+  it('counts incoming triples — entity as object (cause #3)', () => {
+    // `(other, p, target)` shows in `target`'s Triples tab too; pre-fix
+    // `target.tripleCount` ignored it entirely (no MemoryEntity field
+    // tracked incoming references). This is the WM A260527 case.
+    const entities = buildEntities([
+      triple('urn:e:other', 'urn:p:isPartOf', 'urn:e:target'),
+    ]);
+    expect(entities.get('urn:e:other')?.tripleCount).toBe(1);
+    expect(entities.get('urn:e:target')?.tripleCount).toBe(1);
+  });
+
+  it('combined: type + multi-value literal + connection + incoming sums correctly', () => {
+    // Mirrors the SWM ObjectEvent sub-001 shape: 1 type, 1 name (literal),
+    // 2 description literals (same predicate, different objects), 4 IRI
+    // connections out, plus 1 incoming reference. Triples tab shows
+    // 1+1+2+4+1 = 9 rows; pre-fix badge would have been 4+2 = 6.
+    const sub = 'urn:e:sub';
+    const entities = buildEntities([
+      triple(sub, RDF_TYPE, 'urn:type:ObjectEvent'),
+      triple(sub, 'urn:p:name', '"Inbound pallet receipt"'),
+      triple(sub, 'urn:p:description', '"Sample EPCIS event"'),
+      triple(sub, 'urn:p:description', '"Warehouse handling"'),
+      triple(sub, 'urn:p:containsPlace', 'urn:e:warehouse'),
+      triple(sub, 'urn:p:knowsAbout', 'urn:e:product'),
+      triple(sub, 'urn:p:relatedLink', 'urn:e:distribution'),
+      triple(sub, 'urn:p:relatedLink', 'urn:e:receipt'),
+      triple('urn:e:parent', 'urn:p:hasPart', sub),
+    ]);
+    expect(entities.get(sub)?.tripleCount).toBe(9);
+  });
+
+  it('an IRI-object triple bumps BOTH endpoints (per-entity metric, summing overcounts)', () => {
+    // Guardrail: this is the invariant that makes the field safe for
+    // per-entity questions but unsafe for layer totals. Calling it out
+    // explicitly so a future refactor that "optimises" the loop can't
+    // silently drop the object-side bump.
+    const entities = buildEntities([
+      triple('urn:e:a', 'urn:p:linksTo', 'urn:e:b'),
+    ]);
+    const a = entities.get('urn:e:a')!;
+    const b = entities.get('urn:e:b')!;
+    expect(a.tripleCount).toBe(1);
+    expect(b.tripleCount).toBe(1);
+    // Sum (2) > input triples (1) — per-entity metric, not a layer aggregate.
+    expect(a.tripleCount + b.tripleCount).toBeGreaterThan(1);
+  });
+});

--- a/packages/node-ui/test/build-entities-triple-count.test.ts
+++ b/packages/node-ui/test/build-entities-triple-count.test.ts
@@ -10,14 +10,16 @@ const triple = (
 ): LayeredTriple => ({ subject, predicate, object, layer: 'working' });
 
 describe('buildEntities — MemoryEntity.tripleCount', () => {
-  // The Triples tab on the entity-detail page derives its row count
-  // from `allTriples.filter(t => t.subject === uri || t.object === uri)`,
-  // so `tripleCount` must match. Pre-fix the entity-row badge derived
-  // from `connections.length + properties.size` and undercounted in
-  // three independent ways: missing types, multi-value literal collapse,
-  // and incoming triples not tracked. Cases below pin each.
+  // `tripleCount` must match the entity-row badge ↔ layer-page Triples
+  // tab. The tab is fed `dedupeTriplesBySpo(...)` on layer pages
+  // (`ProjectView.tsx`), so this count is distinct (s,p,o) across
+  // input layered triples. Pre-fix the entity-row badge derived from
+  // `connections.length + properties.size` and undercounted in three
+  // independent ways: missing types, multi-value literal collapse,
+  // and incoming triples not tracked. Cases below pin each + the
+  // SPO dedup, self-link, and rdf:type-target edge cases.
 
-  it('counts subject-side IRI connections (1 per triple, dedup is for display only)', () => {
+  it('counts subject-side IRI connections (1 per distinct triple)', () => {
     const entities = buildEntities([
       triple('urn:e:a', 'urn:p:linksTo', 'urn:e:b'),
       triple('urn:e:a', 'urn:p:relates', 'urn:e:c'),
@@ -86,6 +88,62 @@ describe('buildEntities — MemoryEntity.tripleCount', () => {
       triple('urn:e:loop', 'urn:p:knows', 'urn:e:loop'),
     ]);
     expect(entities.get('urn:e:loop')?.tripleCount).toBe(1);
+  });
+
+  it('dedupes by SPO across multiple layered entries (matches layer-page tab)', () => {
+    // The same `(s,p,o)` can appear in multiple named graphs — e.g. an
+    // SWM entity promoted into a sub-graph lives in both
+    // `<cg>/_shared_memory` and `<cg>/<sg>/_shared_memory`. The layer
+    // page's Triples tab `dedupeTriplesBySpo`s before render
+    // (`ProjectView.tsx`), so `tripleCount` must dedupe too — otherwise
+    // the badge over-counts what the user sees in the tab.
+    const entities = buildEntities([
+      triple('urn:e:p', 'urn:p:knows', 'urn:e:q'),
+      triple('urn:e:p', 'urn:p:knows', 'urn:e:q'),    // exact duplicate (different graph in reality)
+      triple('urn:e:p', 'urn:p:knows', 'urn:e:other'), // distinct, still counts
+    ]);
+    // p sees 2 distinct outgoing triples; q sees 1 distinct incoming.
+    expect(entities.get('urn:e:p')?.tripleCount).toBe(2);
+    expect(entities.get('urn:e:q')?.tripleCount).toBe(1);
+  });
+
+  it('rdf:type bumps the type entity only when it has its own triples (Codex condition)', () => {
+    // Two-tier behavior:
+    //  • `schema:Thing` is a pure vocabulary URI with no own triples
+    //    — never appears as an entity, so its incoming `rdf:type` rows
+    //    are not tracked anywhere (matches pre-fix: it's invisible).
+    //    Critically we must NOT create it as an entity (would break
+    //    `useLayerTriples` residue filter by giving it a default
+    //    `working` trustLevel — see inline note in `useMemoryEntities`).
+    //  • `urn:type:Custom` has its own metadata triple, so it IS an
+    //    entity. Its `tripleCount` must include incoming `rdf:type`
+    //    rows so the badge matches the Triples tab.
+    const entities = buildEntities([
+      triple('urn:e:i1', RDF_TYPE, 'http://schema.org/Thing'),
+      triple('urn:e:i2', RDF_TYPE, 'http://schema.org/Thing'),
+      triple('urn:e:i3', RDF_TYPE, 'urn:type:Custom'),
+      triple('urn:e:i4', RDF_TYPE, 'urn:type:Custom'),
+      // Custom's own metadata — makes it a first-class entity.
+      triple('urn:type:Custom', 'http://schema.org/label', '"Custom Class"'),
+    ]);
+    // Pure vocabulary class — not promoted to an entity.
+    expect(entities.has('http://schema.org/Thing')).toBe(false);
+    // Class with its own metadata — entity exists, count includes
+    // own triples (1: label) + incoming rdf:type rows (2: from i3, i4).
+    expect(entities.get('urn:type:Custom')?.tripleCount).toBe(3);
+    // Instances unchanged: 1 distinct triple each.
+    expect(entities.get('urn:e:i1')?.tripleCount).toBe(1);
+    expect(entities.get('urn:e:i3')?.tripleCount).toBe(1);
+  });
+
+  it('rdf:type self-link counts once, not twice (defensive)', () => {
+    // `(A, rdf:type, A)` is nonsense but the self-link guard in the
+    // rdf:type branch must mirror the IRI-object branch — and the
+    // class-target bump would otherwise be self-applied.
+    const entities = buildEntities([
+      triple('urn:e:weird', RDF_TYPE, 'urn:e:weird'),
+    ]);
+    expect(entities.get('urn:e:weird')?.tripleCount).toBe(1);
   });
 
   it('an IRI-object triple bumps BOTH endpoints (per-entity metric, summing overcounts)', () => {

--- a/packages/node-ui/test/build-entities-triple-count.test.ts
+++ b/packages/node-ui/test/build-entities-triple-count.test.ts
@@ -188,6 +188,45 @@ describe('buildEntities — MemoryEntity.tripleCount', () => {
     expect(promoted.tripleCount).toBe(2);
   });
 
+  it('cross-layer resource→resource edges are dropped from per-layer count (matches useLayerTriples residue filter)', () => {
+    // Codex regression: a WM-layer triple `(wm-a, p, swm-b)` is shown
+    // on the WM Triples tab only if both endpoints are in WM
+    // (`helpers.ts:444-448`). Since swm-b's canonical layer is `shared`,
+    // useLayerTriples drops the row from WM view. The per-layer count
+    // for wm-a must mirror this — otherwise badge over-counts vs tab.
+    const entities = buildEntities([
+      // Establish swm-b's canonical layer as `shared` via its own SWM triple.
+      triple('urn:e:swm-b', 'urn:p:label', '"B"', 'shared'),
+      // The cross-layer edge in WM — should NOT bump wm-a's WM count.
+      triple('urn:e:wm-a', 'urn:p:references', 'urn:e:swm-b', 'working'),
+      // A same-layer WM edge for comparison — SHOULD bump wm-a's WM count.
+      triple('urn:e:wm-a', 'urn:p:knows', 'urn:e:wm-c', 'working'),
+    ]);
+    const wmA = entities.get('urn:e:wm-a')!;
+    expect(wmA.trustLevel).toBe('working');
+    // Only the wm-a→wm-c edge counts; the cross-layer edge is dropped.
+    expect(wmA.tripleCount).toBe(1);
+    // swm-b's canonical-layer count includes its own label only — the
+    // cross-layer incoming edge from wm-a does NOT bump swm-b in WM
+    // (it would, pre-fix, contribute to swm-b.counts.working, but
+    // tripleCount = counts.shared which excludes WM bumps).
+    expect(entities.get('urn:e:swm-b')?.tripleCount).toBe(1);
+  });
+
+  it('residue-filter does not over-drop: literal-object triples on a residue-layer pass', () => {
+    // Subtle complement of the cross-layer-drop case. `useLayerTriples`
+    // only checks subject.trustLevel for residue (line 426-427) and
+    // ONLY checks the object trust level if the object is a resource
+    // (line 444). A WM-layer LITERAL triple on a promoted SWM entity
+    // still gets dropped by the subject-check, but the object-check
+    // doesn't apply to literals — so for a SAME-layer literal edge on
+    // a same-layer entity, nothing drops.
+    const entities = buildEntities([
+      triple('urn:e:e', 'urn:p:label', '"L"', 'working'),
+    ]);
+    expect(entities.get('urn:e:e')?.tripleCount).toBe(1);
+  });
+
   it('cross-layer same-SPO does NOT collapse (each layer is its own dedup scope)', () => {
     // Edge of the dedup design: if the same (s,p,o) appears in two
     // DIFFERENT layers (e.g. as residue + current), each layer's count

--- a/packages/node-ui/test/build-entities-triple-count.test.ts
+++ b/packages/node-ui/test/build-entities-triple-count.test.ts
@@ -77,6 +77,17 @@ describe('buildEntities — MemoryEntity.tripleCount', () => {
     expect(entities.get(sub)?.tripleCount).toBe(9);
   });
 
+  it('self-referential triples count once, not twice (`(A, p, A)`)', () => {
+    // Regression: subject-side + object-side bumps are both `A`, so
+    // a naive double-bump would yield 2 — but the Triples-tab filter
+    // `s===uri || o===uri` matches the row once and shows 1. The
+    // object-side bump must skip when `targetUri === entity.uri`.
+    const entities = buildEntities([
+      triple('urn:e:loop', 'urn:p:knows', 'urn:e:loop'),
+    ]);
+    expect(entities.get('urn:e:loop')?.tripleCount).toBe(1);
+  });
+
   it('an IRI-object triple bumps BOTH endpoints (per-entity metric, summing overcounts)', () => {
     // Guardrail: this is the invariant that makes the field safe for
     // per-entity questions but unsafe for layer totals. Calling it out

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -175,6 +175,13 @@ vi.mock('../src/ui/api.js', () => ({
 vi.mock('../src/ui/hooks/useMemoryEntities.js', () => ({
   useMemoryEntities: () => memory,
   buildMemoryEntities: buildTestMemoryEntities,
+  // ProjectView imports `canonicalEntityUri` for `dedupeTriplesBySpo`.
+  // Idempotent strip of `<...>` wrappers mirrors the real impl.
+  canonicalEntityUri: (uri: string) => {
+    const trimmed = uri.trim();
+    if (trimmed.startsWith('<') && trimmed.endsWith('>')) return trimmed.slice(1, -1);
+    return trimmed;
+  },
 }));
 
 vi.mock('../src/ui/hooks/useProjectProfile.js', () => ({


### PR DESCRIPTION
## Summary

- The `X triples` badge on each WM/SWM entity row — and the matching number on the entity-detail page header, sidebar provenance pill, and Content tab footer chip — disagreed with the actual Triples-tab row count by 1–3 depending on the entity's shape. User repro on `ui-refresh` CG: WM `A260527` showed `2 triples` (actual 3), SWM `ObjectEvent sub 001` showed `6 triples` (actual 8).
- Root cause: all four surfaces derived from `e.connections.length + e.properties.size`, which (a) drops `rdf:type` triples (routed into `entity.types`), (b) collapses multi-value literals (`Map.size` counts predicates, not values), and (c) ignores incoming triples (entity as object) entirely.
- Fix: pre-compute `tripleCount` on `MemoryEntity` inside `buildEntities` (already walks every triple). Replace 5 usages of the buggy formula with `e.tripleCount`. Sorts now agree with the visible badge, closing the "sorted by triples" hint loop.
- Per-entity metric only — an IRI-object triple bumps both endpoints, so the sum across entities ≠ the layer total. A docstring on the field calls this out so the planned "total triples panel" on the CG overview pulls from `mem.allTriples.length` (matching `DashboardView`) instead of summing per-entity counts.

## Related

- Follow-up to #725 (surfaced during post-merge live walkthrough of the same `ui-refresh` CG)

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/hooks/useMemoryEntities.ts` | Add `tripleCount` to `MemoryEntity` (with guardrail docstring); init in `getOrCreate`; bump subject-side on every triple, object-side on IRI-object triples in the `buildEntities` loop. Sort tiebreaker switched to `tripleCount`. |
| `packages/node-ui/src/ui/views/project/components.tsx` | Replace 4 occurrences of `connections.length + properties.size`: entity-row badge, entity-detail page tripleCount, two sort comparators. |
| `packages/node-ui/test/build-entities-triple-count.test.ts` | New unit suite pinning the new field across all three root causes: connections, multi-value literals, type triples, incoming references, combined shape mirroring the user's SWM repro, plus a guardrail test asserting both endpoints get bumped on IRI-object triples. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec tsc --noEmit` — clean
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/build-entities-triple-count.test.ts test/use-memory-entities-counts.test.ts test/use-memory-entities-labels.test.ts test/use-layer-triples.test.ts` — 16/16 pass (6 new + 10 adjacent existing)
- [x] Full node-ui suite: only pre-existing native-binding failures (`better_sqlite3.node` not built in fresh worktree under `--ignore-scripts`); zero UI test fallout
- [ ] Live walk on the user's `ui-refresh` CG: WM `A260527` row badge reads `3 triples` (was `2`), Triples tab still `3 of 3`. SWM `ObjectEvent sub 001` row reads `8 triples` (was `6`), Triples tab still `8 of 8`. Header / sidebar provenance pill / Content footer all show the same number.

## Out of scope

- The first-class-entity filter at `useMemoryEntities.ts:469` (still uses `connections.length + properties.size > 0` — deliberately a "is this a true subject?" check, not a row-count question).
- The Triples-tab `Math.min(entityTriples.length, 50)` truncation — separate UX call.
- Backend-side counts. This is purely a client-side hydration fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)