### PR TITLE
Preserve EPCIS eventTimeZoneOffset in event queries

### DIFF
--- a/packages/epcis/src/handlers.ts
+++ b/packages/epcis/src/handlers.ts
@@ -93,6 +93,9 @@ export function toEpcisEvent(binding: Record<string, string>): Record<string, un
   const eventTime = unwrapLiteral(binding['eventTime']);
   if (eventTime) event.eventTime = eventTime;
 
+  const eventTimeZoneOffset = unwrapLiteral(binding['eventTimeZoneOffset']);
+  if (eventTimeZoneOffset) event.eventTimeZoneOffset = eventTimeZoneOffset;
+
   const action = unwrapLiteral(binding['action']);
   if (action) event.action = action;
 

--- a/packages/epcis/src/query-builder.ts
+++ b/packages/epcis/src/query-builder.ts
@@ -176,6 +176,7 @@ export function buildEpcisQuery(params: EpcisQueryParams, contextGraphId: string
   } else {
     optionalClauses.push('OPTIONAL { ?event epcis:eventTime ?eventTime . }');
   }
+  optionalClauses.push('OPTIONAL { ?event epcis:eventTimeZoneOffset ?eventTimeZoneOffset . }');
 
   // Action filter — required when filtered, OPTIONAL otherwise
   if (params.action) {
@@ -236,7 +237,7 @@ export function buildEpcisQuery(params: EpcisQueryParams, contextGraphId: string
   ].join('\n      ');
 
   return `${PREFIXES}
-SELECT ?event ?eventType ?eventTime ?bizStep ?bizLocation ?disposition ?readPoint ?action ?parentID ?configurationId ?shipmentId ?ual
+SELECT ?event ?eventType ?eventTime ?eventTimeZoneOffset ?bizStep ?bizLocation ?disposition ?readPoint ?action ?parentID ?configurationId ?shipmentId ?ual
   (GROUP_CONCAT(DISTINCT ?epc; SEPARATOR=", ") AS ?epcList)
   (GROUP_CONCAT(DISTINCT ?childEPCs; SEPARATOR=", ") AS ?childEPCList)
   (GROUP_CONCAT(DISTINCT ?inputEPCList; SEPARATOR=", ") AS ?inputEPCs)
@@ -266,7 +267,7 @@ WHERE {
     }
   }
 }
-GROUP BY ?event ?eventType ?eventTime ?bizStep ?bizLocation ?disposition ?readPoint ?action ?parentID ?configurationId ?shipmentId ?ual
+GROUP BY ?event ?eventType ?eventTime ?eventTimeZoneOffset ?bizStep ?bizLocation ?disposition ?readPoint ?action ?parentID ?configurationId ?shipmentId ?ual
 ORDER BY DESC(?eventTime) ?event
 LIMIT ${limit}
 OFFSET ${offset}`;

--- a/packages/epcis/test/events-query.test.ts
+++ b/packages/epcis/test/events-query.test.ts
@@ -461,6 +461,7 @@ describe('toEpcisEvent', () => {
       parentID: '',
       disposition: '',
       bizStep: '',
+      eventTimeZoneOffset: '',
       ual: '',
     });
     const event = toEpcisEvent(binding);
@@ -477,6 +478,7 @@ describe('toEpcisEvent', () => {
     expect(event).not.toHaveProperty('parentID');
     expect(event).not.toHaveProperty('disposition');
     expect(event).not.toHaveProperty('bizStep');
+    expect(event).not.toHaveProperty('eventTimeZoneOffset');
     expect(event).not.toHaveProperty('dkg:ual');
   });
 
@@ -494,6 +496,12 @@ describe('toEpcisEvent', () => {
     const event = toEpcisEvent(binding);
     expect(event.configurationId).toBe('CFG-001');
     expect(event.shipmentId).toBe('SHIP-001');
+  });
+
+  it('includes eventTimeZoneOffset when binding is present', () => {
+    const binding = makeBindings({ eventTimeZoneOffset: '"+02:00"' });
+    const event = toEpcisEvent(binding);
+    expect(event.eventTimeZoneOffset).toBe('+02:00');
   });
 
   it('omits dkg:ual when UAL binding is empty', () => {

--- a/packages/epcis/test/query-builder.test.ts
+++ b/packages/epcis/test/query-builder.test.ts
@@ -142,14 +142,23 @@ describe('buildEpcisQuery', () => {
       CONTEXT_GRAPH_ID,
     );
 
-    expect(sparql).toContain('SELECT ?event ?eventType ?eventTime ?bizStep ?bizLocation ?disposition ?readPoint ?action ?parentID ?configurationId ?shipmentId ?ual');
+    expect(sparql).toContain('SELECT ?event ?eventType ?eventTime ?eventTimeZoneOffset ?bizStep ?bizLocation ?disposition ?readPoint ?action ?parentID ?configurationId ?shipmentId ?ual');
     expect(sparql).toContain('?event ?configurationIdPredicate ?configurationId .');
     expect(sparql).toContain('FILTER(REPLACE(STR(?configurationIdPredicate), "^.*[/#]", "") = "configurationId")');
     expect(sparql).toContain('FILTER(STR(?configurationId) = "CFG-001")');
     expect(sparql).toContain('?event ?shipmentIdPredicate ?shipmentId .');
     expect(sparql).toContain('FILTER(REPLACE(STR(?shipmentIdPredicate), "^.*[/#]", "") = "shipmentId")');
     expect(sparql).toContain('FILTER(STR(?shipmentId) = "SHIP-001")');
-    expect(sparql).toContain('GROUP BY ?event ?eventType ?eventTime ?bizStep ?bizLocation ?disposition ?readPoint ?action ?parentID ?configurationId ?shipmentId ?ual');
+    expect(sparql).toContain('GROUP BY ?event ?eventType ?eventTime ?eventTimeZoneOffset ?bizStep ?bizLocation ?disposition ?readPoint ?action ?parentID ?configurationId ?shipmentId ?ual');
+  });
+
+  it('projects optional eventTimeZoneOffset without changing eventTime ordering', () => {
+    const sparql = buildEpcisQuery({ epc: 'urn:test' }, CONTEXT_GRAPH_ID);
+
+    expect(sparql).toContain('OPTIONAL { ?event epcis:eventTimeZoneOffset ?eventTimeZoneOffset . }');
+    expect(sparql).toContain('SELECT ?event ?eventType ?eventTime ?eventTimeZoneOffset ?bizStep');
+    expect(sparql).toContain('GROUP BY ?event ?eventType ?eventTime ?eventTimeZoneOffset ?bizStep');
+    expect(sparql).toContain('ORDER BY DESC(?eventTime) ?event');
   });
 
   it('uses default pagination (limit 100, offset 0)', () => {


### PR DESCRIPTION
## Why

EPCIS captures can include `eventTimeZoneOffset`, but the events query was dropping it on the way back out.

Example capture:

```json
{
  "eventTime": "2026-05-26T11:00:00.000Z",
  "eventTimeZoneOffset": "+02:00",
  "epcList": ["urn:epc:id:sgtin:0614141.1779875189621.002"]
}
```

Before this change, querying that event by its event time window returned `eventTime`, `epcList`, and `action`, but not `eventTimeZoneOffset`. That loses captured EPCIS data. After this change, the returned event includes:

```json
{
  "eventTime": "2026-05-26T11:00:00.000Z",
  "eventTimeZoneOffset": "+02:00"
}
```

## What Changed

- Project `epcis:eventTimeZoneOffset` in the EPCIS events SPARQL query.
- Add `?eventTimeZoneOffset` to the query `GROUP BY`.
- Map `eventTimeZoneOffset` in `toEpcisEvent()` when the binding is present.
- Cover the query builder and response mapping with focused tests.

## Verification

- Devnet proof on a two-core local devnet: captured a public EPCIS ObjectEvent with `eventTimeZoneOffset: "+02:00"` and queried it by `from=2026-05-26T10:59:00.000Z`, `to=2026-05-26T11:01:00.000Z`, and its unique EPC. The finalized response returned `eventTimeZoneOffset: "+02:00"`.
- `pnpm --dir packages/epcis exec vitest run test/query-builder.test.ts test/events-query.test.ts`
- `pnpm --dir packages/epcis run build`
