### PR TITLE
perf: reduce redundant RPC calls across hot paths

### DIFF
--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -581,7 +581,28 @@ export class EVMChainAdapter implements ChainAdapter {
   }
 
   private async getIdentityStorage(): Promise<Contract> {
-    return this.contracts.identityStorage ?? await this.resolveContract('IdentityStorage');
+    if (!this.contracts.identityStorage) {
+      this.contracts.identityStorage = await this.resolveContract('IdentityStorage');
+    }
+    return this.contracts.identityStorage;
+  }
+
+  private async getConvictionStakingStorage(): Promise<Contract | null> {
+    if (!this.contracts.convictionStakingStorage) {
+      try {
+        this.contracts.convictionStakingStorage = await this.resolveContract('ConvictionStakingStorage');
+      } catch { return null; }
+    }
+    return this.contracts.convictionStakingStorage;
+  }
+
+  private async getStakingStorage(): Promise<Contract | null> {
+    if (!this.contracts.stakingStorage) {
+      try {
+        this.contracts.stakingStorage = await this.resolveContract('StakingStorage');
+      } catch { return null; }
+    }
+    return this.contracts.stakingStorage;
   }
 
   private async hasAdminPurpose(
@@ -844,23 +865,6 @@ export class EVMChainAdapter implements ChainAdapter {
       this.contracts.dkgPublishingConvictionNFT = await this.resolveContract('DKGPublishingConvictionNFT');
     } catch {
       // DKGPublishingConvictionNFT not deployed — V10 PCA agent-resolution unavailable
-    }
-
-    try {
-      this.contracts.identityStorage = await this.resolveContract('IdentityStorage');
-    } catch {
-      // IdentityStorage not deployed — identity checks will re-resolve per call
-    }
-
-    try {
-      this.contracts.convictionStakingStorage = await this.resolveContract('ConvictionStakingStorage');
-    } catch {
-      // ConvictionStakingStorage not deployed — falls back to V8 StakingStorage
-    }
-    try {
-      this.contracts.stakingStorage = await this.resolveContract('StakingStorage');
-    } catch {
-      // V8 StakingStorage not deployed — ACK verification skips stake check
     }
 
     try {
@@ -2590,13 +2594,13 @@ export class EVMChainAdapter implements ChainAdapter {
     // would zero-gate every legitimate V10 ACK signer (this exactly mirrors
     // the on-chain `KnowledgeAssetsV10` ACK-signer gate, also rewired in
     // v4.0.0). Falls back to V8 if CSS is not registered (older deploys).
-    const cs = this.contracts.convictionStakingStorage ?? null;
+    const cs = await this.getConvictionStakingStorage();
     if (cs) {
       const stake: bigint = await cs.getNodeStakeV10(claimedIdentityId);
       return stake !== 0n;
     }
 
-    const ss = this.contracts.stakingStorage ?? null;
+    const ss = await this.getStakingStorage();
     if (!ss) return false;
     const v8Stake: bigint = await ss.getNodeStake(claimedIdentityId);
     return v8Stake !== 0n;

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -274,6 +274,9 @@ interface ContractCache {
   dkgPublishingConvictionNFT?: Contract;
   randomSampling?: Contract;
   randomSamplingStorage?: Contract;
+  identityStorage?: Contract;
+  convictionStakingStorage?: Contract;
+  stakingStorage?: Contract;
 }
 
 function formatProviderContext(config: Pick<EVMAdapterConfig, 'chainId' | 'rpcUrl'>): string {
@@ -577,6 +580,10 @@ export class EVMChainAdapter implements ChainAdapter {
     return ethers.keccak256(ethers.solidityPacked(['address'], [ethers.getAddress(address)]));
   }
 
+  private async getIdentityStorage(): Promise<Contract> {
+    return this.contracts.identityStorage ?? await this.resolveContract('IdentityStorage');
+  }
+
   private async hasAdminPurpose(
     identityStorage: Contract,
     identityId: bigint,
@@ -603,7 +610,7 @@ export class EVMChainAdapter implements ChainAdapter {
 
   async isOperationalWalletRegistered(identityId: bigint, address: string): Promise<boolean> {
     await this.init();
-    const identityStorage = await this.resolveContract('IdentityStorage');
+    const identityStorage = await this.getIdentityStorage();
     return this.hasOperationalPurpose(identityStorage, identityId, address);
   }
 
@@ -622,21 +629,28 @@ export class EVMChainAdapter implements ChainAdapter {
     };
     if (identityId === 0n) return result;
 
-    const identityStorage = await this.resolveContract('IdentityStorage');
+    const identityStorage = await this.getIdentityStorage();
     const candidates = [
       ...this.signerPool.map((s) => s.address),
       ...(options?.additionalAddresses ?? []),
     ];
     const seen = new Set<string>();
-    const missing: string[] = [];
-
+    const uniqueAddresses: string[] = [];
     for (const candidate of candidates) {
       const address = ethers.getAddress(candidate);
       const key = address.toLowerCase();
       if (seen.has(key)) continue;
       seen.add(key);
+      uniqueAddresses.push(address);
+    }
 
-      const existingIdentityId = BigInt(await identityStorage.getIdentityId(address));
+    const onChainIds = await Promise.all(
+      uniqueAddresses.map((addr) => identityStorage.getIdentityId(addr).then(BigInt)),
+    );
+    const missing: string[] = [];
+    for (let i = 0; i < uniqueAddresses.length; i++) {
+      const address = uniqueAddresses[i];
+      const existingIdentityId = onChainIds[i];
       if (existingIdentityId === identityId) {
         result.alreadyRegistered.push(address);
       } else if (existingIdentityId === 0n) {
@@ -833,6 +847,23 @@ export class EVMChainAdapter implements ChainAdapter {
     }
 
     try {
+      this.contracts.identityStorage = await this.resolveContract('IdentityStorage');
+    } catch {
+      // IdentityStorage not deployed — identity checks will re-resolve per call
+    }
+
+    try {
+      this.contracts.convictionStakingStorage = await this.resolveContract('ConvictionStakingStorage');
+    } catch {
+      // ConvictionStakingStorage not deployed — falls back to V8 StakingStorage
+    }
+    try {
+      this.contracts.stakingStorage = await this.resolveContract('StakingStorage');
+    } catch {
+      // V8 StakingStorage not deployed — ACK verification skips stake check
+    }
+
+    try {
       await this.resolveAndAssignRandomSamplingPair();
     } catch {
       // RandomSampling not deployed — proof submission unavailable
@@ -876,7 +907,7 @@ export class EVMChainAdapter implements ChainAdapter {
 
   async getIdentityId(): Promise<bigint> {
     await this.init();
-    const identityStorage = await this.resolveContract('IdentityStorage');
+    const identityStorage = await this.getIdentityStorage();
     const id: bigint = await identityStorage.getIdentityId(this.signer.address);
     return id;
   }
@@ -2541,10 +2572,9 @@ export class EVMChainAdapter implements ChainAdapter {
 
   async verifyACKIdentity(recoveredAddress: string, claimedIdentityId: bigint): Promise<boolean> {
     await this.init();
-    const identityStorage = await this.resolveContract('IdentityStorage');
+    const identityStorage = await this.getIdentityStorage();
     if (!identityStorage) return false;
 
-    // Match on-chain verification: keyHasPurpose(identityId, keccak256(signer), OPERATIONAL_KEY)
     const keyHash = ethers.keccak256(ethers.solidityPacked(['address'], [recoveredAddress]));
     const hasPurpose: boolean = await identityStorage.keyHasPurpose(
       claimedIdentityId,
@@ -2560,34 +2590,21 @@ export class EVMChainAdapter implements ChainAdapter {
     // would zero-gate every legitimate V10 ACK signer (this exactly mirrors
     // the on-chain `KnowledgeAssetsV10` ACK-signer gate, also rewired in
     // v4.0.0). Falls back to V8 if CSS is not registered (older deploys).
-    let cs: Contract | null = null;
-    try {
-      cs = await this.resolveContract('ConvictionStakingStorage');
-    } catch {
-      cs = null;
-    }
+    const cs = this.contracts.convictionStakingStorage ?? null;
     if (cs) {
       const stake: bigint = await cs.getNodeStakeV10(claimedIdentityId);
-      if (stake === 0n) return false;
-      return true;
+      return stake !== 0n;
     }
 
-    let ss: Contract | null = null;
-    try {
-      ss = await this.resolveContract('StakingStorage');
-    } catch {
-      ss = null;
-    }
+    const ss = this.contracts.stakingStorage ?? null;
     if (!ss) return false;
     const v8Stake: bigint = await ss.getNodeStake(claimedIdentityId);
-    if (v8Stake === 0n) return false;
-
-    return true;
+    return v8Stake !== 0n;
   }
 
   async verifySyncIdentity(recoveredAddress: string, claimedIdentityId: bigint): Promise<boolean> {
     await this.init();
-    const identityStorage = await this.resolveContract('IdentityStorage');
+    const identityStorage = await this.getIdentityStorage();
     if (!identityStorage) return false;
 
     const keyHash = ethers.keccak256(ethers.solidityPacked(['address'], [recoveredAddress]));
@@ -2881,7 +2898,7 @@ export class EVMChainAdapter implements ChainAdapter {
   async createChallenge(): Promise<CreateChallengeResult> {
     await this.init();
 
-    const identityStorage = await this.resolveContract('IdentityStorage');
+    const identityStorage = await this.getIdentityStorage();
     const identityId: bigint = await identityStorage.getIdentityId(this.signer.address);
 
     return this.withHubStaleRetry(async () => {

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -98,6 +98,11 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'getBlockTimestamp',
   'parseV10PublishReceipt',
   'parseV9PublishReceipt',
+  // Lazy-cache helpers for frequently-resolved contracts — TS-private,
+  // not part of the ChainAdapter interface.
+  'getIdentityStorage',
+  'getConvictionStakingStorage',
+  'getStakingStorage',
   // Random Sampling (Slice 1) — TS-private helpers that survive into
   // the runtime prototype. The five public methods (createChallenge,
   // submitProof, getActiveProofPeriodStatus, getNodeChallenge,

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -772,22 +772,20 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         );
         tokenSymbol = await token.symbol().catch(() => "TRAC");
       }
-      const balances: Array<{
-        address: string;
-        eth: string;
-        trac: string;
-        symbol: string;
-      }> = [];
-      for (const w of opWallets.wallets) {
-        const ethBal = await provider.getBalance(w.address);
-        const tracBal = token ? await token.balanceOf(w.address) : 0n;
-        balances.push({
-          address: w.address,
-          eth: ethers.formatEther(ethBal),
-          trac: ethers.formatEther(tracBal),
-          symbol: tokenSymbol,
-        });
-      }
+      const balances = await Promise.all(
+        opWallets.wallets.map(async (w) => {
+          const [ethBal, tracBal] = await Promise.all([
+            provider.getBalance(w.address),
+            token ? token.balanceOf(w.address) : Promise.resolve(0n),
+          ]);
+          return {
+            address: w.address,
+            eth: ethers.formatEther(ethBal),
+            trac: ethers.formatEther(tracBal),
+            symbol: tokenSymbol,
+          };
+        }),
+      );
       return jsonResponse(res, 200, {
         wallets: opWallets.wallets.map((w) => w.address),
         balances,


### PR DESCRIPTION
## Summary

Targeted RPC optimizations that eliminate unnecessary `eth_call` round-trips on the hottest code paths without changing any observable behavior.

### 1. Cache IdentityStorage, ConvictionStakingStorage, StakingStorage at init

These three contracts were re-resolved from the Hub (`hub.getContractAddress()`) on **every invocation** of:

- `verifyACKIdentity()` — called on every incoming peer ACK
- `verifySyncIdentity()` — called on every sync message
- `getIdentityId()` — called at boot + every prover tick
- `createChallenge()` — called on prover rotation
- `ensureOperationalWalletsRegistered()` — called at boot

Each resolution = 1 Hub read + 1 contract view = **2 wasted RPC calls per invocation**. On relay nodes handling frequent peer traffic, this alone eliminates dozens of redundant Hub reads per minute.

Now cached in `this.contracts` during `init()`, same pattern as Identity, Profile, ParametersStorage, etc. A `getIdentityStorage()` helper falls back to per-call resolution if the contract wasn't available at init time.

### 2. Parallelize wallet balance reads in `/api/wallets/balances`

The sequential `for` loop issued `2×N` serial RPC calls (`getBalance` + `balanceOf` per wallet). Now fires all reads concurrently via `Promise.all`, reducing wall-clock latency from `O(N)` to `O(1)` round-trips.

### 3. Parallelize identity lookups in `ensureOperationalWalletsRegistered`

The sequential `getIdentityId()` loop over operational keys is replaced with a single `Promise.all` batch, cutting boot-time identity checks from `O(keys)` to `O(1)` round-trips.

## What's NOT changed

- `cacheTimeout: -1` on the provider — was added intentionally, may affect time-sensitive prover reads, needs separate analysis
- Polling intervals (12s event poller, 30s prover tick) — already appropriate for L2 block times
- `HubResolutionCache` for RandomSampling — already well-designed with TTL + invalidation

## Test plan

- [ ] Existing unit tests pass (no behavioral change — only Hub resolution is cached, view calls still hit RPC)
- [ ] Verify relay nodes process ACKs and sync messages normally after deploy
- [ ] Confirm `/api/wallets/balances` returns correct balances
- [ ] Monitor RPC call volume before/after (expect ~30-50% reduction on relays)