### PR TITLE
fix(scripts/docs): address Codex review on PR #721 + PR #722 (6 follow-ups)

### DIFF
--- a/packages/cli/skills/dkg-importer/SKILL.md
+++ b/packages/cli/skills/dkg-importer/SKILL.md
@@ -428,9 +428,19 @@ function buildPartitionQuads(partitionIdx, rawQuads, anchorUri) {
 
   // 2. Rewrite every non-anchor URI in the subject (and object, when an IRI)
   //    position to its partition-scoped blank node.
+  //
+  // Detect IRIs generically via the RFC 3986 scheme grammar rather than
+  // hard-coding a scheme list. Earlier drafts checked only `http` / `urn:`,
+  // which silently misses valid RDF IRIs that use other schemes — `did:`,
+  // `ipfs:`, `tag:`, `file:`, plain-IRI imports etc. — and lets colliding
+  // root entities leak through to keep hitting Rule 4 on subsequent
+  // partitions. If your parser exposes `term.termType === 'NamedNode'`,
+  // prefer that over the regex.
+  const ABS_IRI = /^[A-Za-z][A-Za-z0-9+\-.]*:/;
+  const isIri = (s) => ABS_IRI.test(s);
   const out = [];
   for (const { s, p, o } of rawQuads) {
-    const subj = s.startsWith('http') || s.startsWith('urn:') ? blankNodeFor(s) : s;
+    const subj = isIri(s) ? blankNodeFor(s) : s;
     const obj  = (o.kind === 'iri' && o.value !== anchorUri)
       ? blankNodeFor(o.value)
       : serializeObject(o);

--- a/scripts/testnet-publish-stress/fetch-wikidata-music.mjs
+++ b/scripts/testnet-publish-stress/fetch-wikidata-music.mjs
@@ -69,7 +69,7 @@ const QUERY_CLASSES = [
           OPTIONAL { ?s wdt:P569 ?birthDate }
           OPTIONAL { ?s wdt:P19 ?birthPlace }
           OPTIONAL { ?s wdt:P27 ?country }
-        } LIMIT ${limit} OFFSET ${offset}
+        } ORDER BY ?s LIMIT ${limit} OFFSET ${offset}
       }`,
   },
   {
@@ -98,7 +98,7 @@ const QUERY_CLASSES = [
           OPTIONAL { ?s wdt:P571 ?inception }
           OPTIONAL { ?s wdt:P2031 ?activeStart }
           OPTIONAL { ?s wdt:P2032 ?activeEnd }
-        } LIMIT ${limit} OFFSET ${offset}
+        } ORDER BY ?s LIMIT ${limit} OFFSET ${offset}
       }`,
   },
   {
@@ -127,7 +127,7 @@ const QUERY_CLASSES = [
           OPTIONAL { ?s wdt:P136 ?genre }
           OPTIONAL { ?s wdt:P364 ?language }
           OPTIONAL { ?s wdt:P162 ?producer }
-        } LIMIT ${limit} OFFSET ${offset}
+        } ORDER BY ?s LIMIT ${limit} OFFSET ${offset}
       }`,
   },
   {
@@ -154,7 +154,7 @@ const QUERY_CLASSES = [
           OPTIONAL { ?s wdt:P577 ?pubDate }
           OPTIONAL { ?s wdt:P136 ?genre }
           OPTIONAL { ?s wdt:P361 ?partOfAlbum }
-        } LIMIT ${limit} OFFSET ${offset}
+        } ORDER BY ?s LIMIT ${limit} OFFSET ${offset}
       }`,
   },
   {
@@ -179,7 +179,7 @@ const QUERY_CLASSES = [
           OPTIONAL { ?s wdt:P279 ?parentGenre }
           OPTIONAL { ?s wdt:P495 ?country }
           OPTIONAL { ?s wdt:P571 ?inception }
-        } LIMIT ${limit} OFFSET ${offset}
+        } ORDER BY ?s LIMIT ${limit} OFFSET ${offset}
       }`,
   },
 ];
@@ -214,6 +214,33 @@ function parseNtriplesLines(body) {
     if (trimmed.length > 0) out.push(trimmed);
   }
   return out;
+}
+
+// Codex review on PR #722: persist per-class offsets + class cursor in a
+// sidecar state file so a resumed run continues from the same SPARQL pages
+// it left off on, instead of restarting from offset 0 and appending
+// duplicated early data under new partition ids. The buffer of in-flight
+// triples is NOT persisted (cheap to rebuild on the next fetch), but the
+// fetch-cursor IS — the cost is one tiny JSON write per fetch.
+const STATE_PATH = `${OUT_PATH}.state.json`;
+
+async function loadFetchState() {
+  try {
+    const { readFile } = await import('node:fs/promises');
+    const raw = await readFile(STATE_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed.offsets)
+        && parsed.offsets.length === QUERY_CLASSES.length
+        && Number.isInteger(parsed.classCursor)) {
+      return { offsets: parsed.offsets.slice(), classCursor: parsed.classCursor };
+    }
+  } catch { /* fresh */ }
+  return null;
+}
+
+async function saveFetchState(offsets, classCursor) {
+  const { writeFile } = await import('node:fs/promises');
+  await writeFile(STATE_PATH, JSON.stringify({ offsets, classCursor }, null, 2));
 }
 
 async function main() {
@@ -262,8 +289,14 @@ async function main() {
   };
 
   // Round-robin pages across the 5 classes until we hit the partition target.
-  let classCursor = 0;
-  const offsets = new Array(QUERY_CLASSES.length).fill(0);
+  // Codex review on PR #722: load the persisted fetch cursor so resume
+  // continues from where the prior run left off.
+  const restored = await loadFetchState();
+  let classCursor = restored?.classCursor ?? 0;
+  const offsets = restored?.offsets ?? new Array(QUERY_CLASSES.length).fill(0);
+  if (restored) {
+    console.error(`[resume] fetch cursor: classCursor=${classCursor} offsets=${JSON.stringify(offsets)}`);
+  }
 
   while (partitionIdx < TARGET_PARTITIONS) {
     const cls = QUERY_CLASSES[classCursor];
@@ -297,6 +330,9 @@ async function main() {
     );
     await flushPartition();
     classCursor = (classCursor + 1) % QUERY_CLASSES.length;
+    // Persist the fetch cursor after every page so a crash between
+    // partition flushes still allows clean resume.
+    await saveFetchState(offsets, classCursor);
     await sleep(PAGE_SLEEP_MS);
   }
 

--- a/scripts/testnet-publish-stress/preflight.mjs
+++ b/scripts/testnet-publish-stress/preflight.mjs
@@ -90,7 +90,11 @@ let alreadyExists = false;
 let resolvedCgId = null;
 let onChainId = null;
 {
-  const r = await apiCall('GET', '/api/context-graph');
+  // Codex review on PR #722: the daemon-side route is `/api/context-graph/list`;
+  // GET `/api/context-graph` would not list existing CGs, which made this
+  // helper drop through to create() and exit on a duplicate-id 409 instead
+  // of being idempotent as documented.
+  const r = await apiCall('GET', '/api/context-graph/list');
   if (r.ok && Array.isArray(r.json.contextGraphs)) {
     const match = r.json.contextGraphs.find(
       (cg) => cg.id === CG_SHORT_ID || cg.id?.endsWith(`/${CG_SHORT_ID}`),
@@ -104,7 +108,7 @@ let onChainId = null;
       console.error(`  ${r.json.contextGraphs.length} other CG(s) present; '${CG_SHORT_ID}' not yet created.`);
     }
   } else {
-    console.error(`  (no /api/context-graph response — will attempt create anyway)`);
+    console.error(`  (no /api/context-graph/list response — will attempt create anyway)`);
   }
 }
 

--- a/scripts/testnet-publish-stress/publish-loop.mjs
+++ b/scripts/testnet-publish-stress/publish-loop.mjs
@@ -419,7 +419,18 @@ async function main() {
     }
     checkpoint.lastPublishedIdx = i;
 
-    // Periodic snapshot for cost tracking
+    // Codex review on PR #722: persist `lastPublishedIdx` after EVERY
+    // successful publish so a crash between the costly periodic snapshot
+    // boundaries can't replay an already-published partition on restart
+    // (which would hit Rule 4 / root-entity conflicts because each
+    // partition's anchor URI is deterministic). The expensive wallet-
+    // snapshot path below still runs only every `CFG.checkpointEvery`,
+    // but the cheap partition-bookkeeping write is now eager.
+    await saveCheckpoint(checkpoint);
+
+    // Periodic snapshot for cost tracking (expensive: N getWalletSnapshot
+    // RPC calls). Kept on the original cadence — only `lastPublishedIdx`
+    // needed the every-success treatment above.
     if ((i + 1) % CFG.checkpointEvery === 0 || i + 1 === target) {
       const snap = await getWalletSnapshot();
       checkpoint.tracSpent = startSnap.trac - snap.trac;

--- a/scripts/testnet-publish-stress/rs-scan.mjs
+++ b/scripts/testnet-publish-stress/rs-scan.mjs
@@ -50,8 +50,15 @@ const RPC_URL = process.env.RPC_URL ?? 'https://sepolia.base.org';
 const WINDOW_HOURS = parseFloat(process.env.WINDOW_HOURS ?? '4');
 const BASE_SEPOLIA_BLOCK_TIME_S = 2;  // observed
 const WINDOW_BLOCKS = Math.floor((WINDOW_HOURS * 3600) / BASE_SEPOLIA_BLOCK_TIME_S);
+// Codex review on PR #722: derive the default checkpoint filename from the
+// same `STRESS_RUN_ID` env var the producer (`publish-loop.mjs`) uses, so a
+// vanilla run of `rs-scan.mjs` against a vanilla run of `publish-loop.mjs`
+// loads the right KC ids out of the box. Hard-coding `26may2.json` here
+// (an artefact of the original Base Sepolia sweep) caused rs-scan to load
+// no KC ids and report "none of ours sampled" on fresh runs.
+const STRESS_RUN_ID = process.env.STRESS_RUN_ID ?? '26may';
 const CHECKPOINT_FILE = process.env.CHECKPOINT_FILE
-  ?? `${homedir()}/.dkg-publish-stress/checkpoints/26may2.json`;
+  ?? `${homedir()}/.dkg-publish-stress/checkpoints/${STRESS_RUN_ID}.json`;
 
 const RS_ADDR = '0x73AefE8AD301f7eac8c45C1B91A60Ed01BF24B1b';
 const RS_STORAGE_ADDR = '0xd84640BA70F18527827A3572C8Acf52E10ff5BC5';


### PR DESCRIPTION
## Summary

Closes the remaining open Codex findings on the rc.12 integration branch (#716) for the operational scripts and importer-skill docs landed by #721 and #722. None of these are production-code regressions — they are testnet stress-harness bugs and one documentation example — but they each made the tooling silently lossy or non-idempotent in ways that would bite the next operator to run them.

Identified as part of the rc.12 review-consolidation sweep on #716 ([audit comment]( https://github.com/OriginTrail/dkg/pull/716 )). With this PR + the already-landed `fb3a5283` (3 #727 round-2 fixes via #729), every Codex review thread across the 15 source PRs aggregated into `release/rc.12` is closed.

## What's in this PR

| # | Source PR | File | Concern | Fix |
|---|---|---|---|---|
| 1 | #722 | `scripts/testnet-publish-stress/preflight.mjs:93` | Wrong API path (`/api/context-graph` vs `/api/context-graph/list`) — the helper always missed existing CGs and fell through to create() / 409. | One-line path correction, plus the matching error-message string. |
| 2 | #722 | `scripts/testnet-publish-stress/rs-scan.mjs:54` | Default checkpoint filename `26may2.json` didn't match the producer's `STRESS_RUN_ID=26may` default → vanilla pair loaded no KC ids and reported "none of ours sampled". | Read `STRESS_RUN_ID` from the same env var the producer uses. |
| 3 | #722 | `scripts/testnet-publish-stress/fetch-wikidata-music.mjs` (×5 queries) | `LIMIT … OFFSET …` without `ORDER BY` → SPARQL result order is unspecified, so two requests with the same offset can return different/overlapping subjects. | `ORDER BY ?s` added to all five paginated subqueries. |
| 4 | #722 | `scripts/testnet-publish-stress/fetch-wikidata-music.mjs` (resume) | Resume tracked the partition counter but reset `classCursor` + per-class `offsets` to 0 on every fresh run → duplicate early data appended under new partition ids after any interruption. | Persists `{ offsets, classCursor }` to a sidecar `<OUT_PATH>.state.json` after every fetch; reloads at startup. The in-flight buffer is intentionally NOT persisted (cheap to rebuild). |
| 5 | #722 | `scripts/testnet-publish-stress/publish-loop.mjs:423` | `lastPublishedIdx` only persisted every `checkpointEvery=50` partitions (alongside the expensive wallet snapshot) → crash between snapshots replayed already-published partitions, deterministically hit Rule 4 / root-entity conflicts on retry. | Split the cheap partition-bookkeeping save from the expensive wallet snapshot: `saveCheckpoint(checkpoint)` now runs after every publish; wallet snapshot stays on the original cadence. |
| 6 | #721 | `packages/cli/skills/dkg-importer/SKILL.md:433` | Reference example only treated `http` / `urn:` subjects as IRIs → silently missed `did:`, `ipfs:`, `tag:`, `file:`, etc. Copying the example verbatim left colliding root entities un-rewritten and kept hitting Rule 4. | RFC 3986 absolute-IRI regex; doc note steering callers whose parser exposes `term.termType` toward that. |

## Mergeability

Targets `release/rc.12`. No conflicts (just-landed merges #726, #729, #731 don't touch any of these paths). Scripts-only + one docs file — no build / TS impact.

## Verification

- [x] Linted clean (5 files, no new lint errors).
- [x] `/api/context-graph/list` confirmed as the canonical route via `packages/cli/src/api-client.ts:1242` + `packages/cli/test/daemon-http-behavior-extra.test.ts:803` on rc.12.
- [ ] (CI) ESLint + format across the workspaces.

Made with [Cursor](https://cursor.com)