### PR TITLE
chore: merge main into release/rc.12 (3 node-ui polish fixes)

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -524,6 +524,15 @@ export interface AssertionInfo {
   name: string;
   graphUri: string;
   tripleCount?: number;
+  /**
+   * Sub-graph slug when the assertion lives in a sub-graph
+   * partition, undefined for root-bucket assertions. Lets the UI
+   * surface the structural placement inline on each row without a
+   * separate lookup. Field is uniformly populated on both WM and
+   * SWM `AssertionInfo`s so consumers don't need a layer-aware
+   * branch.
+   */
+  subGraph?: string;
 }
 
 /**
@@ -623,7 +632,7 @@ export async function listAssertions(
 
       if (seen.has(lifecycle)) continue;
       seen.add(lifecycle);
-      result.push({ name, graphUri: lifecycle });
+      result.push({ name, graphUri: lifecycle, subGraph: subGraphName });
     }
     return result;
   }
@@ -632,23 +641,66 @@ export async function listAssertions(
   const sparql = `SELECT DISTINCT ?g (COUNT(?s) AS ?cnt) WHERE { GRAPH ?g { ?s ?p ?o } } GROUP BY ?g`;
   const data = await executeQuery(sparql, contextGraphId);
   const bindings: any[] = data?.result?.bindings ?? [];
-  const prefix = `did:dkg:context-graph:${contextGraphId}/assertion/`;
+  // #706 fix — the prior `startsWith('did:dkg:context-graph:<cg>/assertion/')`
+  // shape silently dropped sub-graph-scoped WM assertions, whose graph
+  // URI is `did:dkg:context-graph:<cg>/<sg>/assertion/<agent>/<name>`
+  // (the sub-graph segment sits between `<cg>/` and `/assertion/`).
+  // We accept exactly two shapes, post-cgPrefix:
+  //   root-bucket : ['assertion', <agent>, <name>]            (3 segs)
+  //   sub-graph   : [<subGraphName>, 'assertion', <agent>, <name>] (4 segs)
+  // Anything else (extra segments on either side, internal meta
+  // graphs sharing the prefix, etc.) is silently dropped. The parse
+  // is deliberately strict so a row never gets admitted with a
+  // mis-derived name — promote/preview lookups key on `name` and
+  // would silently miss otherwise. The cgId itself is treated as
+  // opaque (it may contain `/assertion/` as a literal substring,
+  // per `validateContextGraphId`).
+  const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
   const result: AssertionInfo[] = [];
   for (const b of bindings) {
     const g = typeof b.g === 'string' ? b.g : b.g?.value;
-    if (!g || !g.startsWith(prefix)) continue;
-    const tail = g.slice(prefix.length);
-    const slash = tail.indexOf('/');
-    const name = slash >= 0 ? tail.slice(slash + 1) : tail;
+    if (!g || !g.startsWith(cgPrefix)) continue;
+    const segments = g.slice(cgPrefix.length).split('/');
+    let subGraph: string | undefined;
+    let name: string;
+    if (segments.length === 3 && segments[0] === 'assertion') {
+      subGraph = undefined;
+      name = segments[2];
+    } else if (segments.length === 4 && segments[1] === 'assertion') {
+      subGraph = segments[0];
+      name = segments[3];
+    } else {
+      continue;
+    }
+    if (!name) continue;
     const cnt = typeof b.cnt === 'string' ? parseInt(b.cnt, 10) : (b.cnt?.value ? parseInt(b.cnt.value, 10) : undefined);
-    result.push({ name, graphUri: g, tripleCount: Number.isFinite(cnt) ? cnt : undefined });
+    result.push({ name, graphUri: g, tripleCount: Number.isFinite(cnt) ? cnt : undefined, subGraph });
   }
   return result;
 }
 
-/** Promote an assertion from WM to SWM. */
-export const promoteAssertion = (contextGraphId: string, assertionName: string, entities: string | string[] = 'all') =>
-  post<{ promotedCount: number }>(`/api/assertion/${encodeURIComponent(assertionName)}/promote`, { contextGraphId, entities });
+/**
+ * Promote an assertion from WM to SWM.
+ *
+ * PR #710 fix — `subGraphName` is the third part of the daemon's
+ * lookup key alongside `(contextGraphId, assertionName)`. Without
+ * it, promoting a sub-graph-scoped assertion either 404s or
+ * silently promotes a same-named root-bucket assertion. The
+ * daemon route already accepts the field
+ * (`packages/cli/src/daemon/routes/assertion.ts:820-823`); only
+ * spread it when supplied so root-bucket promotes keep the prior
+ * wire shape.
+ */
+export const promoteAssertion = (
+  contextGraphId: string,
+  assertionName: string,
+  entities: string | string[] = 'all',
+  subGraphName?: string,
+) =>
+  post<{ promotedCount: number }>(
+    `/api/assertion/${encodeURIComponent(assertionName)}/promote`,
+    { contextGraphId, entities, ...(subGraphName ? { subGraphName } : {}) },
+  );
 
 // --- File preview ---
 
@@ -664,9 +716,26 @@ export interface ExtractionStatus {
   completedAt?: string;
 }
 
-/** Fetch extraction status for an assertion (includes fileHash + contentType). */
-export const fetchExtractionStatus = (assertionName: string, contextGraphId: string) =>
-  get<ExtractionStatus>(`/api/assertion/${encodeURIComponent(assertionName)}/extraction-status?contextGraphId=${encodeURIComponent(contextGraphId)}`);
+/**
+ * Fetch extraction status for an assertion (includes fileHash + contentType).
+ *
+ * PR #710 Fix E — `subGraphName` is the third part of the daemon's
+ * lookup key alongside `(contextGraphId, assertionName)`. The route
+ * already accepts the query param
+ * (`packages/cli/src/daemon/routes/assertion.ts:3364`); only set it
+ * when supplied so root-bucket calls keep the prior URL shape.
+ */
+export const fetchExtractionStatus = (
+  assertionName: string,
+  contextGraphId: string,
+  subGraphName?: string,
+) => {
+  const params = new URLSearchParams({ contextGraphId });
+  if (subGraphName) params.set('subGraphName', subGraphName);
+  return get<ExtractionStatus>(
+    `/api/assertion/${encodeURIComponent(assertionName)}/extraction-status?${params}`,
+  );
+};
 
 /** Build a URL to serve a stored file by its hash (sha256: or keccak256:). */
 export function fileUrl(hash: string, contentType?: string): string {

--- a/packages/node-ui/src/ui/components/Modals/FilePreviewModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/FilePreviewModal.tsx
@@ -6,6 +6,13 @@ interface FilePreviewModalProps {
   onClose: () => void;
   assertionName: string;
   contextGraphId: string;
+  /**
+   * PR #710 Fix E — sub-graph slug for partition-scoped assertions.
+   * Omitted for root-bucket assertions. Threaded into
+   * `fetchExtractionStatus` so the daemon's
+   * `(cg, name, subGraphName)` lookup hits the right partition.
+   */
+  subGraphName?: string;
 }
 
 const PREVIEWABLE_TYPES: Record<string, 'pdf' | 'image' | 'text' | 'markdown'> = {
@@ -33,7 +40,7 @@ async function authenticatedBlobUrl(url: string): Promise<string> {
   return URL.createObjectURL(blob);
 }
 
-export function FilePreviewModal({ open, onClose, assertionName, contextGraphId }: FilePreviewModalProps) {
+export function FilePreviewModal({ open, onClose, assertionName, contextGraphId, subGraphName }: FilePreviewModalProps) {
   const [status, setStatus] = useState<ExtractionStatus | null>(null);
   const [textContent, setTextContent] = useState<string | null>(null);
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
@@ -48,7 +55,7 @@ export function FilePreviewModal({ open, onClose, assertionName, contextGraphId 
     setTextContent(null);
     setBlobUrl(null);
 
-    fetchExtractionStatus(assertionName, contextGraphId)
+    fetchExtractionStatus(assertionName, contextGraphId, subGraphName)
       .then(async (s) => {
         setStatus(s);
         const kind = previewKind(s.detectedContentType);
@@ -67,7 +74,7 @@ export function FilePreviewModal({ open, onClose, assertionName, contextGraphId 
     return () => {
       if (blobUrl) URL.revokeObjectURL(blobUrl);
     };
-  }, [open, assertionName, contextGraphId]);
+  }, [open, assertionName, contextGraphId, subGraphName]);
 
   useEffect(() => {
     return () => {

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -122,13 +122,25 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
   // per-sub-graph counts would double-count entities living in two or
   // more sub-graphs (the entity list under us is layer-filtered
   // without sub-graph multiplicity, so the sum disagrees with it).
+  //
+  // Layer-scoped semantic differs from layer-agnostic semantic:
+  //   • Layer mode (WM/SWM/VM page): "All" should match the layer tab
+  //     badge — every distinct entity at that layer, including
+  //     root-bucket SWM entities whose graph URI is
+  //     `<cg>/_shared_memory` (subGraphOf filters underscore-prefixed
+  //     segments, leaving an empty `subGraphs` set). Without them
+  //     "All" undercut the badge (e.g. 25 vs 27) and confused users.
+  //   • Layer-agnostic mode (sub-graph page): "All" is the umbrella
+  //     over named-sub-graph chips, so entities with no chip
+  //     membership stay excluded — including them would inflate the
+  //     total past anything the user can drill into by clicking a chip.
   const entityScopedAllTotal = React.useMemo(() => {
     if (!entities) return null;
     const trust = layer ? LAYER_TRUST_LEVEL[layer] : null;
     let n = 0;
     for (const e of entities) {
       if (trust !== null && e.trustLevel !== trust) continue;
-      if (e.subGraphs.size === 0) continue; // entity has no sub-graph — not in any chip
+      if (layer === undefined && e.subGraphs.size === 0) continue;
       n++;
     }
     return n;

--- a/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
+++ b/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
@@ -32,6 +32,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { authHeaders } from '../api.js';
+import { subGraphFromAssertionGraphUri } from '../lib/sub-graph-uri.js';
 
 export type AssertionLifecycleKind = 'created' | 'promoted';
 
@@ -125,35 +126,6 @@ SELECT ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph (COUNT(?root) AS
   }
 } GROUP BY ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph
   ORDER BY DESC(?ts) LIMIT 5000`;
-}
-
-/**
- * Parse a sub-graph slug out of a `dkg:assertionGraph` URI. Mirror of
- * `contextGraphAssertionUri` in `packages/core/src/constants.ts`:
- *
- *   root-bucket : `did:dkg:context-graph:<cgId>/assertion/<agent>/<name>`
- *   sub-graph   : `did:dkg:context-graph:<cgId>/<subGraphName>/assertion/<agent>/<name>`
- *
- * Returns the slug when present, `undefined` for root-bucket
- * assertions or any URI that doesn't match the expected shape (the
- * latter shouldn't happen in practice — `dkg:assertionGraph` is set
- * by the writer — but the parse stays defensive so a malformed URI
- * just suppresses the sub-graph filter rather than throwing).
- */
-export function subGraphFromAssertionGraphUri(
-  assertionGraphUri: string,
-  contextGraphId: string,
-): string | undefined {
-  const prefix = `did:dkg:context-graph:${contextGraphId}/`;
-  if (!assertionGraphUri.startsWith(prefix)) return undefined;
-  const tail = assertionGraphUri.slice(prefix.length);
-  const segments = tail.split('/');
-  // Root-bucket: tail starts with `assertion/…` (no sub-graph segment).
-  if (segments[0] === 'assertion') return undefined;
-  // Sub-graph: `<subGraphName>/assertion/…`. Require the assertion
-  // segment to actually be there so we don't misparse stray URIs.
-  if (segments.length >= 2 && segments[1] === 'assertion') return segments[0];
-  return undefined;
 }
 
 function bv(v: unknown): string | undefined {

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -17,6 +17,37 @@ export interface MemoryEntity {
   subGraphs: Set<string>;
   properties: Map<string, string[]>;
   connections: Array<{ predicate: string; targetUri: string; targetLabel: string }>;
+  /**
+   * Number of *distinct* (subject, predicate, object) triples in
+   * this entity's CANONICAL layer (`trustLevel`) that reference
+   * the entity as subject or object — matches the row count the
+   * entity-detail Triples tab shows on the layer page where the
+   * entity lives (which filters by layer via `useLayerTriples`
+   * and SPO-dedupes via `dedupeTriplesBySpo`, see `ProjectView.tsx`).
+   *
+   * Drives the entity-row badge and is the sort key for entity
+   * lists. Promoted-entity WM residue does NOT inflate this — a
+   * promoted SWM entity with leftover WM-only draft triples shows
+   * only the SWM-layer count (matching the SWM tab the user opens).
+   *
+   * NOT used by the KADetailView header / sidebar / footer — those
+   * derive directly from `entityTriples.length` so they always
+   * mirror whichever scope the user opened the detail page from
+   * (layer-page = layer-filtered + deduped, overview = raw).
+   *
+   * Optional because non-`buildEntities` callers (synthetic stubs
+   * in `useProjectActivity`, test fixtures) construct `MemoryEntity`
+   * literals without it. `buildEntities` always populates it;
+   * consumers should fall back to `0` for stubs.
+   *
+   * PER-ENTITY METRIC ONLY. An IRI-object triple `(A, p, B)` bumps
+   * BOTH `A.tripleCount` and `B.tripleCount`, so
+   * `sum(e.tripleCount)` across a layer is NOT the layer's triple
+   * total. Layer totals belong to `mem.allTriples.length`
+   * (DashboardView); CG/sub-graph totals to the daemon's
+   * `/api/sub-graph/list` `tripleCount` (SubGraphBar).
+   */
+  tripleCount?: number;
 }
 
 export interface Triple {
@@ -314,7 +345,38 @@ async function queryLayer(
 export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntity> {
   const entities = new Map<string, MemoryEntity>();
   const connectionKeys = new Map<string, Set<string>>();
-
+  // Per-(entity, layer) SPO-dedup keys for `tripleCount`. Mirrors
+  // `useLayerTriples` + `dedupeTriplesBySpo` (`ProjectView.tsx`) so
+  // the precomputed count agrees with the layer-page Triples tab.
+  // Per-layer because a triple residing in two named graphs of the
+  // SAME layer (e.g. `<cg>/_shared_memory` and
+  // `<cg>/<sg>/_shared_memory` both at the SWM layer) must dedupe,
+  // while a triple residing in DIFFERENT layers (WM residue + SWM
+  // current for a promoted entity) is a distinct row on each
+  // layer's tab and so contributes to each layer's count.
+  const tripleSeen = new Map<string, Map<TrustLevel, Set<string>>>();
+  const tripleCountByLayer = new Map<string, Record<TrustLevel, number>>();
+  function bumpTriple(entityUri: string, layer: TrustLevel, key: string): boolean {
+    let layerMap = tripleSeen.get(entityUri);
+    if (!layerMap) {
+      layerMap = new Map();
+      tripleSeen.set(entityUri, layerMap);
+    }
+    let seen = layerMap.get(layer);
+    if (!seen) {
+      seen = new Set<string>();
+      layerMap.set(layer, seen);
+    }
+    if (seen.has(key)) return false;
+    seen.add(key);
+    let counts = tripleCountByLayer.get(entityUri);
+    if (!counts) {
+      counts = { working: 0, shared: 0, verified: 0 };
+      tripleCountByLayer.set(entityUri, counts);
+    }
+    counts[layer]++;
+    return true;
+  }
   function getOrCreate(uri: string): MemoryEntity {
     const entityUri = canonicalEntityUri(uri);
     let e = entities.get(entityUri);
@@ -328,12 +390,19 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
         subGraphs: new Set(),
         properties: new Map(),
         connections: [],
+        tripleCount: 0, // finalised to canonical-layer count post-loop
       };
       entities.set(entityUri, e);
     }
     return e;
   }
 
+  // PASS 1 — populate entities, types, connections, properties, layers.
+  // Triple counts are intentionally NOT bumped here: they need to be
+  // gated by the same residue filter `useLayerTriples` applies (subject
+  // and object trustLevel must equal the layer), and trustLevels are
+  // only known after this pass. Pass 3 below redoes the walk with
+  // residue-filter-aware counting.
   for (const t of layered) {
     const entity = getOrCreate(t.subject);
     entity.layers.add(t.layer);
@@ -344,6 +413,15 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
       if (!entity.types.includes(typeUri)) {
         entity.types.push(typeUri);
       }
+      // Class targets (e.g. `urn:type:ObjectEvent`) are NOT created via
+      // getOrCreate here — that would inject schema URIs like
+      // `schema:Thing` into the entity map with `trustLevel = 'working'`
+      // (no layers), breaking `useLayerTriples`' residue filter
+      // (`helpers.ts:444-448`: `objectEntity.trustLevel !== targetLayer`
+      // ⇒ drops the rdf:type row from SWM/VM views). Pass 3 bumps
+      // class-entity counts only for classes that already exist by
+      // virtue of their own triples — matches Codex's "if the type
+      // node has its own triples" condition.
     } else if (isUri(t.object)) {
       const targetUri = canonicalEntityUri(t.object);
       const targetEntity = getOrCreate(targetUri);
@@ -370,12 +448,70 @@ export function buildEntities(layered: LayeredTriple[]): Map<string, MemoryEntit
     }
   }
 
+  // PASS 2 — finalise label + trustLevel so Pass 3's residue filter
+  // sees authoritative per-entity layer.
   for (const entity of entities.values()) {
     entity.label = deriveEntityLabel(entity);
 
     if (entity.layers.has('verified')) entity.trustLevel = 'verified';
     else if (entity.layers.has('shared')) entity.trustLevel = 'shared';
     else entity.trustLevel = 'working';
+  }
+
+  // PASS 3 — count triples per (entity, layer) under the same residue
+  // filter `useLayerTriples` uses (`helpers.ts:444-448`). A cross-layer
+  // edge `wm:A → swm:B` is dropped from the WM tab because the object
+  // has been promoted past WM, so it must not bump A's WM count either
+  // — otherwise badge over-counts vs tab.
+  for (const t of layered) {
+    const subjectUri = canonicalEntityUri(t.subject);
+    const subjectEntity = entities.get(subjectUri);
+    // Mirror `useLayerTriples` line 426-427: if the subject entity
+    // exists and its canonical layer differs from this triple's layer,
+    // it's residue — drop. Subjects that don't resolve to a tracked
+    // entity (literal orphans / class IRIs) pass through.
+    if (subjectEntity && subjectEntity.trustLevel !== t.layer) continue;
+
+    const canonicalObject = isUri(t.object) ? canonicalEntityUri(t.object) : t.object;
+    const objectIsResource = isUri(t.object);
+    if (objectIsResource) {
+      const objectEntity = entities.get(canonicalObject);
+      // Mirror `useLayerTriples` line 444-448: object-side trust
+      // check. Cross-layer resource→resource edges are dropped on
+      // the source layer's tab; they must not bump either endpoint's
+      // count for that layer.
+      if (objectEntity && objectEntity.trustLevel !== t.layer) continue;
+    }
+
+    const spoKey = `${subjectUri}\0${t.predicate}\0${canonicalObject}`;
+    if (subjectEntity) bumpTriple(subjectEntity.uri, t.layer, spoKey);
+
+    if (t.predicate === RDF_TYPE) {
+      // Class-target bump only when the class is a first-class entity
+      // (created by its own triples in Pass 1). Self-link guard same
+      // as the IRI branch below.
+      if (canonicalObject !== subjectUri) {
+        const typeEntity = entities.get(canonicalObject);
+        if (typeEntity) bumpTriple(typeEntity.uri, t.layer, spoKey);
+      }
+    } else if (objectIsResource) {
+      // Self-link guard: `(A, p, A)` is one row in the Triples tab
+      // (`s===uri || o===uri` matches once); subject-side bump above
+      // already counted it.
+      if (canonicalObject !== subjectUri) {
+        const targetEntity = entities.get(canonicalObject);
+        if (targetEntity) bumpTriple(targetEntity.uri, t.layer, spoKey);
+      }
+    }
+  }
+
+  // PASS 4 — finalise `tripleCount` to the canonical-layer count.
+  // What the entity-row badge on this entity's layer page shows after
+  // useLayerTriples + dedupeTriplesBySpo. Cross-layer residue (e.g. a
+  // promoted SWM entity's WM-only drafts) does not inflate it.
+  for (const entity of entities.values()) {
+    const counts = tripleCountByLayer.get(entity.uri);
+    entity.tripleCount = counts ? counts[entity.trustLevel] : 0;
   }
 
   for (const entity of entities.values()) {
@@ -486,8 +622,8 @@ export function useMemoryEntities(
         const trustOrder = { verified: 0, shared: 1, working: 2 };
         const td = trustOrder[a.trustLevel] - trustOrder[b.trustLevel];
         if (td !== 0) return td;
-        const ca = a.connections.length + a.properties.size;
-        const cb = b.connections.length + b.properties.size;
+        const ca = a.tripleCount ?? 0;
+        const cb = b.tripleCount ?? 0;
         if (cb !== ca) return cb - ca;
         return a.label.localeCompare(b.label);
       }),

--- a/packages/node-ui/src/ui/lib/sub-graph-uri.ts
+++ b/packages/node-ui/src/ui/lib/sub-graph-uri.ts
@@ -1,0 +1,32 @@
+/**
+ * Parse a sub-graph slug out of a `dkg:assertionGraph` URI. Mirror of
+ * `contextGraphAssertionUri` in `packages/core/src/constants.ts`:
+ *
+ *   root-bucket : `did:dkg:context-graph:<cgId>/assertion/<agent>/<name>`
+ *   sub-graph   : `did:dkg:context-graph:<cgId>/<subGraphName>/assertion/<agent>/<name>`
+ *
+ * Returns the slug when present, `undefined` for root-bucket
+ * assertions or any URI that doesn't match the expected shape (the
+ * latter shouldn't happen in practice — `dkg:assertionGraph` is set
+ * by the writer — but the parse stays defensive so a malformed URI
+ * just suppresses the sub-graph filter rather than throwing).
+ *
+ * Lives in `lib/` so both the transport layer (`api.ts`) and the
+ * lifecycle hook can import it without creating a module cycle —
+ * pure string parser, no React or transport dependency.
+ */
+export function subGraphFromAssertionGraphUri(
+  assertionGraphUri: string,
+  contextGraphId: string,
+): string | undefined {
+  const prefix = `did:dkg:context-graph:${contextGraphId}/`;
+  if (!assertionGraphUri.startsWith(prefix)) return undefined;
+  const tail = assertionGraphUri.slice(prefix.length);
+  const segments = tail.split('/');
+  // Root-bucket: tail starts with `assertion/…` (no sub-graph segment).
+  if (segments[0] === 'assertion') return undefined;
+  // Sub-graph: `<subGraphName>/assertion/…`. Require the assertion
+  // segment to actually be there so we don't misparse stray URIs.
+  if (segments.length >= 2 && segments[1] === 'assertion') return segments[0];
+  return undefined;
+}

--- a/packages/node-ui/src/ui/lib/truncate.ts
+++ b/packages/node-ui/src/ui/lib/truncate.ts
@@ -1,0 +1,19 @@
+/**
+ * Middle-ellipsis truncation for chip-sized strings. Originally added
+ * for the #706 sub-graph chip (slugs are commonly prefix-namespaced
+ * — `epcis-*`, `github-*` — so the discriminator lives at the end;
+ * mid-truncation preserves both sides and keeps the chip compact).
+ * Lives in `lib/` so both `AssertionsList` (components.tsx) and the
+ * `MemoryLayerView` AssertionList row can render the same chip
+ * without either consumer reaching across views.
+ */
+export function truncateMiddle(s: string, max: number): string {
+  if (s.length <= max) return s;
+  // Reserve 1 char for the ellipsis; split the remaining budget
+  // weighted slightly toward the prefix (so namespace prefixes
+  // like `epcis-` survive in full on common slug widths).
+  const budget = max - 1;
+  const head = Math.ceil(budget / 2);
+  const tail = budget - head;
+  return `${s.slice(0, head)}…${s.slice(-tail)}`;
+}

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -4,6 +4,7 @@ import { executeQuery, listAssertions, promoteAssertion, publishSharedMemory, li
 import { FilePreviewModal } from '../components/Modals/FilePreviewModal.js';
 import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
 import { memoryGraphLabels } from '../lib/memoryLabels.js';
+import { truncateMiddle } from '../lib/truncate.js';
 
 const RdfGraph = lazy(() =>
   import('@origintrail-official/dkg-graph-viz/react').then(m => ({ default: m.RdfGraph }))
@@ -391,18 +392,35 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
     0
   );
   useMemoryGraphEvents(contextGraphId, refresh, { layers: ['wm'] });
+  // PR #710 Fix D — busy state keyed on `graphUri` (unique per row,
+  // produced by the daemon). `name` is no longer unique once
+  // sub-graph + root partitions share names, so a name-keyed busy
+  // would highlight two rows on a single click. `'__all__'`
+  // sentinel stays — not collidable with any graphUri.
   const [promoting, setPromoting] = useState<string | null>(null);
-  const [promoteResult, setPromoteResult] = useState<{ name: string; count: number } | null>(null);
+  // PR #710 — track `subGraph` on the success state so the result
+  // copy can disambiguate which partition was promoted. Two rows
+  // labeled `draft` (one root, one sub-graph) would otherwise emit
+  // the same message and leave the user guessing.
+  const [promoteResult, setPromoteResult] = useState<{ name: string; count: number; subGraph?: string } | null>(null);
   const [promoteError, setPromoteError] = useState<string | null>(null);
-  const [previewName, setPreviewName] = useState<string | null>(null);
+  // PR #710 Fix E — preview state carries the sub-graph slug too so
+  // `FilePreviewModal` can pass it through to the daemon's
+  // `/extraction-status` route. Pre-fix, clicking a sub-graph
+  // assertion's filename queried the root-bucket assertion → 404
+  // or wrong file.
+  const [preview, setPreview] = useState<{ name: string; subGraph?: string } | null>(null);
 
-  const handlePromote = useCallback(async (name: string) => {
-    setPromoting(name);
+  const handlePromote = useCallback(async (assertion: AssertionInfo) => {
+    setPromoting(assertion.graphUri);
     setPromoteResult(null);
     setPromoteError(null);
     try {
-      const res = await promoteAssertion(contextGraphId, name);
-      setPromoteResult({ name, count: res.promotedCount });
+      // PR #710 Fix A — thread `subGraph` so the daemon's
+      // `(cg, name, subGraph)` lookup hits the right partition;
+      // mirrors the AssertionsList fix in components.tsx.
+      const res = await promoteAssertion(contextGraphId, assertion.name, 'all', assertion.subGraph);
+      setPromoteResult({ name: assertion.name, count: res.promotedCount, subGraph: assertion.subGraph });
       refresh();
       onPromoted();
     } catch (err: any) {
@@ -420,7 +438,8 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
     let totalPromoted = 0;
     try {
       for (const a of assertions) {
-        const res = await promoteAssertion(contextGraphId, a.name);
+        // PR #710 — see comment on the single-row handler above.
+        const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
         totalPromoted += res.promotedCount;
       }
       setPromoteResult({ name: 'all assertions', count: totalPromoted });
@@ -450,33 +469,46 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
       </div>
       <div className="v10-assertion-items">
         {assertions.map((a) => (
-          <div key={a.name} className="v10-assertion-item">
+          <div key={a.graphUri} className="v10-assertion-item">
             <div className="v10-assertion-item-info">
               <button
                 className="v10-assertion-item-name clickable"
                 title={a.graphUri}
-                onClick={() => setPreviewName(a.name)}
+                onClick={() => setPreview({ name: a.name, subGraph: a.subGraph })}
               >
                 {a.name}
               </button>
               {a.tripleCount != null && (
                 <span className="v10-assertion-item-count">{a.tripleCount} triples</span>
               )}
+              {a.subGraph && (
+                // PR #710 — mirror the AssertionsList chip pattern
+                // (components.tsx). Same class, same `›` glyph, same
+                // truncation, same tooltip — disambiguates rows that
+                // share a name across root/sub-graph partitions.
+                <span
+                  className="v10-item-count v10-item-subgraph"
+                  title={`In sub-graph: ${a.subGraph}`}
+                >
+                  › {truncateMiddle(a.subGraph, 18)}
+                </span>
+              )}
             </div>
             <button
               className="v10-btn-promote"
               disabled={promoting !== null}
-              onClick={() => handlePromote(a.name)}
+              onClick={() => handlePromote(a)}
               title="Copy these triples to Shared Working Memory"
             >
-              {promoting === a.name ? 'Promoting...' : '→ SWM'}
+              {promoting === a.graphUri ? 'Promoting...' : '→ SWM'}
             </button>
           </div>
         ))}
       </div>
       {promoteResult && (
         <div className="v10-promote-result success">
-          Promoted {promoteResult.count} triples from {promoteResult.name} to Shared Working Memory.
+          Promoted {promoteResult.count} triples from {promoteResult.name}
+          {promoteResult.subGraph ? ` (in ${promoteResult.subGraph})` : ''} to Shared Working Memory.
         </div>
       )}
       {promoteError && (
@@ -485,11 +517,12 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
         </div>
       )}
 
-      {previewName && (
+      {preview && (
         <FilePreviewModal
           open
-          onClose={() => setPreviewName(null)}
-          assertionName={previewName}
+          onClose={() => setPreview(null)}
+          assertionName={preview.name}
+          subGraphName={preview.subGraph}
           contextGraphId={contextGraphId}
         />
       )}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -5,6 +5,7 @@ import { ImportFilesModal } from '../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../components/Modals/ShareProjectModal.js';
 import {
   buildMemoryEntities,
+  canonicalEntityUri,
   useMemoryEntities,
   type LayeredTriple,
   type TrustLevel,
@@ -70,7 +71,14 @@ function isMemoryLayerView(layer: LayerView): layer is MemoryLayerView {
 function dedupeTriplesBySpo<T extends { subject: string; predicate: string; object: string }>(triples: T[]): T[] {
   const seen = new Set<string>();
   return triples.filter(t => {
-    const key = `${t.subject}|${t.predicate}|${t.object}`;
+    // Canonicalise wrapped/bare IRIs so this dedup agrees with
+    // `buildEntities`' per-entity `tripleCount` dedup
+    // (`useMemoryEntities.ts` builds its SPO key from canonical
+    // subject/object). Daemon sometimes ships wrapped `<urn:...>`
+    // for the same triple it returns bare elsewhere; without
+    // canonicalisation here the detail-page Triples tab would show
+    // two rows for what the badge counts as one.
+    const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
     if (seen.has(key)) return false;
     seen.add(key);
     return true;

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1689,8 +1689,8 @@ export function EntityList({
     if (externallySorted) return entities;
     const copy = [...entities];
     copy.sort((a, b) => {
-      const aCount = a.connections.length + a.properties.size;
-      const bCount = b.connections.length + b.properties.size;
+      const aCount = a.tripleCount ?? 0;
+      const bCount = b.tripleCount ?? 0;
       return bCount - aCount;
     });
     return copy;
@@ -1723,7 +1723,7 @@ export function EntityList({
       </div>
       {sorted.map(e => {
         const { icon, type } = entityMeta(e, profile);
-        const tripleCount = e.connections.length + e.properties.size;
+        const tripleCount = e.tripleCount ?? 0;
         const authorUri = entityAuthorUri(e);
         const author = authorUri ? agents?.get(authorUri) : null;
         const ts = timestampPredicate ? entityTimestamp(e, timestampPredicate) : null;
@@ -3227,7 +3227,16 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
   }, [entity.uri, allEntities]);
 
   const entityTriples = useMemo(
-    () => allTriples.filter(t => t.subject === entity.uri || t.object === entity.uri),
+    // Canonicalise raw triple sides before comparing — `entity.uri`
+    // was canonicalised by `getOrCreate` in `buildEntities`, but
+    // `allTriples` keeps the raw daemon strings (which can ship
+    // wrapped as `<urn:...>`). Without this both surfaces disagree
+    // for wrapped-IRI rows: the entity-row badge counts them (it
+    // uses the canonicalised entity key) while this filter would
+    // drop them. Idempotent + no-op for already-bare URIs.
+    () => allTriples.filter(t =>
+      canonicalEntityUri(t.subject) === entity.uri ||
+      canonicalEntityUri(t.object) === entity.uri),
     [entity.uri, allTriples]
   );
 
@@ -3300,7 +3309,14 @@ export function KADetailView({ entity, allEntities, allTriples, onNavigate, onCl
     focal: { uri: entity.uri, sizeMultiplier: 2.4 },
   }), [entity.uri, theme]);
 
-  const tripleCount = entity.connections.length + entity.properties.size;
+  // Derive from the actual triples this view renders, NOT from
+  // `entity.tripleCount`. The KADetailView is opened with either
+  // the raw `allTriples` (overview scope) or the SPO-deduped slice
+  // (layer scope, see `ProjectView.dedupeTriplesBySpo`). Reading
+  // the precomputed field would freeze on the deduped semantic and
+  // disagree with the tab on overview-scoped opens. `entityTriples`
+  // is already the filtered set the Triples tab counts rows from.
+  const tripleCount = entityTriples.length;
 
   return (
     <div className="v10-ka-detail">
@@ -4305,8 +4321,8 @@ export function SubGraphDetailView({
     }
     // 'triples' (default fallback)
     copy.sort((a, b) => {
-      const aCount = a.connections.length + a.properties.size;
-      const bCount = b.connections.length + b.properties.size;
+      const aCount = a.tripleCount ?? 0;
+      const bCount = b.tripleCount ?? 0;
       return bCount - aCount;
     });
     return copy;

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3,13 +3,14 @@ import type { ReactNode } from 'react';
 import { useFetch } from '../../hooks.js';
 import { api } from '../../api-wrapper.js';
 import { encodeDocTabId, resolveDocRef } from '../../lib/doc-tab-id.js';
+import { truncateMiddle } from '../../lib/truncate.js';
 import {
   listJoinRequests, approveJoinRequest, rejectJoinRequest,
   listAssertions, promoteAssertion,
   publishSharedMemory, executeQuery,
   writeProfileQueryCatalog,
   fetchSubGraphs,
-  type AgentIdentity, type PendingJoinRequest, type PublishResult, type SubGraphInfo,
+  type AgentIdentity, type AssertionInfo, type PendingJoinRequest, type PublishResult, type SubGraphInfo,
 } from '../../api.js';
 import { ImportFilesModal } from '../../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../../components/Modals/ShareProjectModal.js';
@@ -1560,7 +1561,9 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
         const assertions = await listAssertions(contextGraphId, 'wm');
         let promoted = 0;
         for (const a of assertions) {
-          const res = await promoteAssertion(contextGraphId, a.name);
+          // PR #710 — thread `subGraph` so sub-graph-scoped assertions
+          // hit the correct daemon lookup key `(cg, name, subGraph)`.
+          const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
           promoted += res.promotedCount;
         }
         setResult(`Promoted ${promoted} triple${promoted !== 1 ? 's' : ''} to Shared Memory`);
@@ -2668,13 +2671,21 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const handlePromote = useCallback(async (name: string) => {
-    setBusy(name);
+  const handlePromote = useCallback(async (assertion: AssertionInfo) => {
+    // PR #710 Fix D — busy / React keys must use `graphUri`, not
+    // `name`. A root + sub-graph pair can share a name and would
+    // otherwise both highlight as busy on a single click. `graphUri`
+    // is produced by the daemon and uniquely identifies the row.
+    setBusy(assertion.graphUri);
     setResult(null);
     setError(null);
     try {
       if (layer === 'wm') {
-        const res = await promoteAssertion(contextGraphId, name);
+        // PR #710 Fix A — sub-graph slug threads into the daemon's
+        // `(cg, name, subGraph)` lookup so a row clicked from a
+        // sub-graph partition resolves to that partition's
+        // assertion, not a same-named root one.
+        const res = await promoteAssertion(contextGraphId, assertion.name, 'all', assertion.subGraph);
         setResult(`Promoted ${res.promotedCount} triples to Shared Memory`);
       } else {
         await publishSharedMemory(contextGraphId);
@@ -2698,7 +2709,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
       if (layer === 'wm') {
         let total = 0;
         for (const a of assertions) {
-          const res = await promoteAssertion(contextGraphId, a.name);
+          // PR #710 — see comment on the single-row handler above.
+          const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
           total += res.promotedCount;
         }
         setResult(`Promoted ${total} triples across ${assertions.length} assertion${assertions.length !== 1 ? 's' : ''}`);
@@ -2766,21 +2778,29 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
       {result && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--text-success)' }}>✓ {result}</div>}
       {error && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--text-danger)' }}>✕ {error}</div>}
       {assertions.map(a => (
-        <div key={a.name} className="v10-item-row">
+        <div key={a.graphUri} className="v10-item-row">
           <span className="v10-item-icon">▤</span>
           <div className="v10-item-info">
             <div className="v10-item-name" style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{a.name}</div>
             <div className="v10-item-meta-row">
               {a.tripleCount != null && <span className="v10-item-count">{a.tripleCount} triples</span>}
+              {a.subGraph && (
+                <span
+                  className="v10-item-count v10-item-subgraph"
+                  title={`In sub-graph: ${a.subGraph}`}
+                >
+                  › {truncateMiddle(a.subGraph, 18)}
+                </span>
+              )}
             </div>
           </div>
           <button
             className={`v10-layer-expand-footer-btn ${layer === 'wm' ? 'promote' : 'publish'}`}
             disabled={busy !== null}
-            onClick={ev => { ev.stopPropagation(); handlePromote(a.name); }}
-            style={{ opacity: busy === a.name ? 0.5 : 1, flexShrink: 0 }}
+            onClick={ev => { ev.stopPropagation(); handlePromote(a); }}
+            style={{ opacity: busy === a.graphUri ? 0.5 : 1, flexShrink: 0 }}
           >
-            {busy === a.name ? '...' : actionLabel}
+            {busy === a.graphUri ? '...' : actionLabel}
           </button>
         </div>
       ))}
@@ -3020,12 +3040,16 @@ export function VerifyOnDkgButton({
     return null;
   }, [entity.types, profile, layer]);
 
+  // PR #710 — keep the matched sub-graph slug alongside the binding so
+  // the promote call below can pass it to the daemon (the source
+  // assertion is sub-graph-scoped; daemon lookup keys on
+  // `(cg, name, subGraph)`).
   const sgBinding = useMemo(() => {
     if (!profile) return null;
     for (const s of entity.subGraphs) {
       if (s === 'meta') continue;
       const b = profile.forSubGraph(s);
-      if (b?.sourceAssertion) return b;
+      if (b?.sourceAssertion) return { binding: b, subGraph: s };
     }
     return null;
   }, [entity.subGraphs, profile]);
@@ -3039,8 +3063,8 @@ export function VerifyOnDkgButton({
         label:    binding.promoteLabel ?? 'Promote to Shared Memory',
         hint:     binding.promoteHint  ?? 'Shares this entity with the team.',
         busyCopy: 'Sharing…',
-        disabled: !sgBinding?.sourceAssertion,
-        disabledReason: !sgBinding?.sourceAssertion
+        disabled: !sgBinding?.binding.sourceAssertion,
+        disabledReason: !sgBinding?.binding.sourceAssertion
           ? `No sourceAssertion declared on the sub-graph profile — add profile:sourceAssertion to the SubGraphBinding for "${[...entity.subGraphs].filter(s => s !== 'meta')[0] ?? '?'}".`
           : null,
       }
@@ -3061,10 +3085,17 @@ export function VerifyOnDkgButton({
     setResultKind(action.kind);
     try {
       if (action.kind === 'promote') {
+        // PR #710 — `sgBinding.sourceAssertion` is itself
+        // sub-graph-scoped (the binding came from a SubGraphBinding
+        // for slug `sgBinding.subGraph`), so we thread that slug as
+        // the 4th arg. Without it the daemon's `(cg, name, subGraph)`
+        // lookup falls back to the root-bucket assertion of the same
+        // name (404 or wrong-target).
         const r = await promoteAssertion(
           contextGraphId,
-          sgBinding!.sourceAssertion!,
+          sgBinding!.binding.sourceAssertion!,
           [entity.uri],
+          sgBinding!.subGraph,
         );
         setResult(r);
       } else {

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -334,17 +334,27 @@ export function getDescription(e: MemoryEntity): string | null {
  * with clear name + JSDoc so the two semantics stay distinguishable.
  */
 export function neighborhoodTriples(entityUri: string, allTriples: Triple[], hops: number = 2): Triple[] {
+  // Canonicalise both sides of the comparison: `entityUri` is the
+  // canonical form (`MemoryEntity.uri`) but `allTriples` keeps raw
+  // daemon strings, which can ship wrapped as `<urn:...>`. A bare
+  // entity URI would miss wrapped-IRI rows that the entity-detail
+  // Triples tab + KADetailView header (now canonicalised) include —
+  // the graph pane right below would silently drop them.
+  const canonicalSubject = (t: Triple) => canonicalEntityUri(t.subject);
+  const canonicalObject = (t: Triple) => canonicalEntityUri(t.object);
   const visited = new Set<string>([entityUri]);
   let frontier = new Set<string>([entityUri]);
 
   for (let i = 0; i < hops; i++) {
     const nextFrontier = new Set<string>();
     for (const t of allTriples) {
-      if (frontier.has(t.subject) && !visited.has(t.object)) {
-        nextFrontier.add(t.object);
+      const s = canonicalSubject(t);
+      const o = canonicalObject(t);
+      if (frontier.has(s) && !visited.has(o)) {
+        nextFrontier.add(o);
       }
-      if (frontier.has(t.object) && !visited.has(t.subject)) {
-        nextFrontier.add(t.subject);
+      if (frontier.has(o) && !visited.has(s)) {
+        nextFrontier.add(s);
       }
     }
     for (const u of nextFrontier) visited.add(u);
@@ -352,7 +362,7 @@ export function neighborhoodTriples(entityUri: string, allTriples: Triple[], hop
     if (frontier.size === 0) break;
   }
 
-  return allTriples.filter(t => visited.has(t.subject) && visited.has(t.object));
+  return allTriples.filter(t => visited.has(canonicalSubject(t)) && visited.has(canonicalObject(t)));
 }
 
 export function matchesSearch(e: MemoryEntity, q: string): boolean {
@@ -446,7 +456,13 @@ export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, la
         const objectEntity = memory.entities.get(canonicalObject);
         if (objectEntity && objectEntity.trustLevel !== targetLayer) continue;
       }
-      const key = `${t.subject}|${t.predicate}|${t.object}`;
+      // Canonicalise the dedup key so wrapped/bare duplicates of the
+      // same `(s,p,o)` collapse — mirrors `dedupeTriplesBySpo` in
+      // `ProjectView.tsx` and `buildEntities`' per-entity SPO key.
+      // Without this the layer header / graph counts a wrapped-IRI
+      // duplicate row twice while the KADetailView Triples tab
+      // (canonicalised) shows it once.
+      const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
       if (seen.has(key)) continue;
       seen.add(key);
       out.push(t);

--- a/packages/node-ui/test/build-entities-triple-count.test.ts
+++ b/packages/node-ui/test/build-entities-triple-count.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+import { buildEntities, type LayeredTriple, type TrustLevel } from '../src/ui/hooks/useMemoryEntities.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+const triple = (
+  subject: string,
+  predicate: string,
+  object: string,
+  layer: TrustLevel = 'working',
+): LayeredTriple => ({ subject, predicate, object, layer });
+
+describe('buildEntities — MemoryEntity.tripleCount', () => {
+  // `tripleCount` must match the entity-row badge ↔ layer-page Triples
+  // tab. The tab is fed `dedupeTriplesBySpo(...)` on layer pages
+  // (`ProjectView.tsx`), so this count is distinct (s,p,o) across
+  // input layered triples. Pre-fix the entity-row badge derived from
+  // `connections.length + properties.size` and undercounted in three
+  // independent ways: missing types, multi-value literal collapse,
+  // and incoming triples not tracked. Cases below pin each + the
+  // SPO dedup, self-link, and rdf:type-target edge cases.
+
+  it('counts subject-side IRI connections (1 per distinct triple)', () => {
+    const entities = buildEntities([
+      triple('urn:e:a', 'urn:p:linksTo', 'urn:e:b'),
+      triple('urn:e:a', 'urn:p:relates', 'urn:e:c'),
+    ]);
+    expect(entities.get('urn:e:a')?.tripleCount).toBe(2);
+  });
+
+  it('counts every literal value, not just distinct predicates (cause #2)', () => {
+    // Two `description` literals on the same subject. `properties.size`
+    // collapses both into one map entry — Triples tab shows 2 rows.
+    const entities = buildEntities([
+      triple('urn:e:x', 'urn:p:description', '"Sample EPCIS event"'),
+      triple('urn:e:x', 'urn:p:description', '"Warehouse handling node"'),
+    ]);
+    expect(entities.get('urn:e:x')?.tripleCount).toBe(2);
+  });
+
+  it('counts rdf:type triples (cause #1)', () => {
+    // Type triples are routed into `entity.types` and were never
+    // counted by the pre-fix formula. Triples tab shows them as rows
+    // (e.g. the "type → ObjectEvent" row in the ObjectEvent example).
+    const entities = buildEntities([
+      triple('urn:e:t', RDF_TYPE, 'urn:type:Thing'),
+      triple('urn:e:t', 'urn:p:name', '"Hello"'),
+    ]);
+    expect(entities.get('urn:e:t')?.tripleCount).toBe(2);
+  });
+
+  it('counts incoming triples — entity as object (cause #3)', () => {
+    // `(other, p, target)` shows in `target`'s Triples tab too; pre-fix
+    // `target.tripleCount` ignored it entirely (no MemoryEntity field
+    // tracked incoming references). This is the WM A260527 case.
+    const entities = buildEntities([
+      triple('urn:e:other', 'urn:p:isPartOf', 'urn:e:target'),
+    ]);
+    expect(entities.get('urn:e:other')?.tripleCount).toBe(1);
+    expect(entities.get('urn:e:target')?.tripleCount).toBe(1);
+  });
+
+  it('combined: type + multi-value literal + connection + incoming sums correctly', () => {
+    // Mirrors the SWM ObjectEvent sub-001 shape: 1 type, 1 name (literal),
+    // 2 description literals (same predicate, different objects), 4 IRI
+    // connections out, plus 1 incoming reference. Triples tab shows
+    // 1+1+2+4+1 = 9 rows; pre-fix badge would have been 4+2 = 6.
+    const sub = 'urn:e:sub';
+    const entities = buildEntities([
+      triple(sub, RDF_TYPE, 'urn:type:ObjectEvent'),
+      triple(sub, 'urn:p:name', '"Inbound pallet receipt"'),
+      triple(sub, 'urn:p:description', '"Sample EPCIS event"'),
+      triple(sub, 'urn:p:description', '"Warehouse handling"'),
+      triple(sub, 'urn:p:containsPlace', 'urn:e:warehouse'),
+      triple(sub, 'urn:p:knowsAbout', 'urn:e:product'),
+      triple(sub, 'urn:p:relatedLink', 'urn:e:distribution'),
+      triple(sub, 'urn:p:relatedLink', 'urn:e:receipt'),
+      triple('urn:e:parent', 'urn:p:hasPart', sub),
+    ]);
+    expect(entities.get(sub)?.tripleCount).toBe(9);
+  });
+
+  it('self-referential triples count once, not twice (`(A, p, A)`)', () => {
+    // Regression: subject-side + object-side bumps are both `A`, so
+    // a naive double-bump would yield 2 — but the Triples-tab filter
+    // `s===uri || o===uri` matches the row once and shows 1. The
+    // object-side bump must skip when `targetUri === entity.uri`.
+    const entities = buildEntities([
+      triple('urn:e:loop', 'urn:p:knows', 'urn:e:loop'),
+    ]);
+    expect(entities.get('urn:e:loop')?.tripleCount).toBe(1);
+  });
+
+  it('dedupes by SPO across multiple layered entries (matches layer-page tab)', () => {
+    // The same `(s,p,o)` can appear in multiple named graphs — e.g. an
+    // SWM entity promoted into a sub-graph lives in both
+    // `<cg>/_shared_memory` and `<cg>/<sg>/_shared_memory`. The layer
+    // page's Triples tab `dedupeTriplesBySpo`s before render
+    // (`ProjectView.tsx`), so `tripleCount` must dedupe too — otherwise
+    // the badge over-counts what the user sees in the tab.
+    const entities = buildEntities([
+      triple('urn:e:p', 'urn:p:knows', 'urn:e:q'),
+      triple('urn:e:p', 'urn:p:knows', 'urn:e:q'),    // exact duplicate (different graph in reality)
+      triple('urn:e:p', 'urn:p:knows', 'urn:e:other'), // distinct, still counts
+    ]);
+    // p sees 2 distinct outgoing triples; q sees 1 distinct incoming.
+    expect(entities.get('urn:e:p')?.tripleCount).toBe(2);
+    expect(entities.get('urn:e:q')?.tripleCount).toBe(1);
+  });
+
+  it('rdf:type bumps the type entity only when it has its own triples (Codex condition)', () => {
+    // Two-tier behavior:
+    //  • `schema:Thing` is a pure vocabulary URI with no own triples
+    //    — never appears as an entity, so its incoming `rdf:type` rows
+    //    are not tracked anywhere (matches pre-fix: it's invisible).
+    //    Critically we must NOT create it as an entity (would break
+    //    `useLayerTriples` residue filter by giving it a default
+    //    `working` trustLevel — see inline note in `useMemoryEntities`).
+    //  • `urn:type:Custom` has its own metadata triple, so it IS an
+    //    entity. Its `tripleCount` must include incoming `rdf:type`
+    //    rows so the badge matches the Triples tab.
+    const entities = buildEntities([
+      triple('urn:e:i1', RDF_TYPE, 'http://schema.org/Thing'),
+      triple('urn:e:i2', RDF_TYPE, 'http://schema.org/Thing'),
+      triple('urn:e:i3', RDF_TYPE, 'urn:type:Custom'),
+      triple('urn:e:i4', RDF_TYPE, 'urn:type:Custom'),
+      // Custom's own metadata — makes it a first-class entity.
+      triple('urn:type:Custom', 'http://schema.org/label', '"Custom Class"'),
+    ]);
+    // Pure vocabulary class — not promoted to an entity.
+    expect(entities.has('http://schema.org/Thing')).toBe(false);
+    // Class with its own metadata — entity exists, count includes
+    // own triples (1: label) + incoming rdf:type rows (2: from i3, i4).
+    expect(entities.get('urn:type:Custom')?.tripleCount).toBe(3);
+    // Instances unchanged: 1 distinct triple each.
+    expect(entities.get('urn:e:i1')?.tripleCount).toBe(1);
+    expect(entities.get('urn:e:i3')?.tripleCount).toBe(1);
+  });
+
+  it('rdf:type self-link counts once, not twice (defensive)', () => {
+    // `(A, rdf:type, A)` is nonsense but the self-link guard in the
+    // rdf:type branch must mirror the IRI-object branch — and the
+    // class-target bump would otherwise be self-applied.
+    const entities = buildEntities([
+      triple('urn:e:weird', RDF_TYPE, 'urn:e:weird'),
+    ]);
+    expect(entities.get('urn:e:weird')?.tripleCount).toBe(1);
+  });
+
+  it('an IRI-object triple bumps BOTH endpoints (per-entity metric, summing overcounts)', () => {
+    // Guardrail: this is the invariant that makes the field safe for
+    // per-entity questions but unsafe for layer totals. Calling it out
+    // explicitly so a future refactor that "optimises" the loop can't
+    // silently drop the object-side bump.
+    const entities = buildEntities([
+      triple('urn:e:a', 'urn:p:linksTo', 'urn:e:b'),
+    ]);
+    const a = entities.get('urn:e:a')!;
+    const b = entities.get('urn:e:b')!;
+    expect(a.tripleCount).toBe(1);
+    expect(b.tripleCount).toBe(1);
+    // Sum (2) > input triples (1) — per-entity metric, not a layer aggregate.
+    expect((a.tripleCount ?? 0) + (b.tripleCount ?? 0)).toBeGreaterThan(1);
+  });
+
+  it('promoted-entity residue: tripleCount reflects canonical-layer count only, not cross-layer total', () => {
+    // Codex regression: a promoted SWM entity with WM-only draft residue
+    // would have a badge that includes the WM rows, but the SWM-tab
+    // detail view filters those out via `useLayerTriples`. Per-layer
+    // SPO-deduped count finalised to canonical-layer slice fixes this.
+    //
+    // Scenario: `urn:e:promoted` has been promoted to SWM. Its current
+    // SWM triples are 2 distinct rows; the daemon also leaves 1 WM
+    // draft-residue triple on disk that the SWM tab would never show.
+    const entities = buildEntities([
+      // WM residue (pre-promote draft) — shows on no tab for the
+      // promoted entity (`useLayerTriples` drops via residue filter).
+      triple('urn:e:promoted', 'urn:p:draft', '"draft content"', 'working'),
+      // Current SWM triples — what the SWM tab actually shows.
+      triple('urn:e:promoted', 'urn:p:label', '"Promoted"', 'shared'),
+      triple('urn:e:promoted', 'urn:p:status', '"published"', 'shared'),
+    ]);
+    const promoted = entities.get('urn:e:promoted')!;
+    expect(promoted.trustLevel).toBe('shared');
+    // Pre-fix this would be 3 (sum across layers). With per-layer
+    // dedup + canonical-layer finalisation, it's 2 — what the SWM
+    // tab actually shows.
+    expect(promoted.tripleCount).toBe(2);
+  });
+
+  it('cross-layer resource→resource edges are dropped from per-layer count (matches useLayerTriples residue filter)', () => {
+    // Codex regression: a WM-layer triple `(wm-a, p, swm-b)` is shown
+    // on the WM Triples tab only if both endpoints are in WM
+    // (`helpers.ts:444-448`). Since swm-b's canonical layer is `shared`,
+    // useLayerTriples drops the row from WM view. The per-layer count
+    // for wm-a must mirror this — otherwise badge over-counts vs tab.
+    const entities = buildEntities([
+      // Establish swm-b's canonical layer as `shared` via its own SWM triple.
+      triple('urn:e:swm-b', 'urn:p:label', '"B"', 'shared'),
+      // The cross-layer edge in WM — should NOT bump wm-a's WM count.
+      triple('urn:e:wm-a', 'urn:p:references', 'urn:e:swm-b', 'working'),
+      // A same-layer WM edge for comparison — SHOULD bump wm-a's WM count.
+      triple('urn:e:wm-a', 'urn:p:knows', 'urn:e:wm-c', 'working'),
+    ]);
+    const wmA = entities.get('urn:e:wm-a')!;
+    expect(wmA.trustLevel).toBe('working');
+    // Only the wm-a→wm-c edge counts; the cross-layer edge is dropped.
+    expect(wmA.tripleCount).toBe(1);
+    // swm-b's canonical-layer count includes its own label only — the
+    // cross-layer incoming edge from wm-a does NOT bump swm-b in WM
+    // (it would, pre-fix, contribute to swm-b.counts.working, but
+    // tripleCount = counts.shared which excludes WM bumps).
+    expect(entities.get('urn:e:swm-b')?.tripleCount).toBe(1);
+  });
+
+  it('residue-filter does not over-drop: literal-object triples on a residue-layer pass', () => {
+    // Subtle complement of the cross-layer-drop case. `useLayerTriples`
+    // only checks subject.trustLevel for residue (line 426-427) and
+    // ONLY checks the object trust level if the object is a resource
+    // (line 444). A WM-layer LITERAL triple on a promoted SWM entity
+    // still gets dropped by the subject-check, but the object-check
+    // doesn't apply to literals — so for a SAME-layer literal edge on
+    // a same-layer entity, nothing drops.
+    const entities = buildEntities([
+      triple('urn:e:e', 'urn:p:label', '"L"', 'working'),
+    ]);
+    expect(entities.get('urn:e:e')?.tripleCount).toBe(1);
+  });
+
+  it('cross-layer same-SPO does NOT collapse (each layer is its own dedup scope)', () => {
+    // Edge of the dedup design: if the same (s,p,o) appears in two
+    // DIFFERENT layers (e.g. as residue + current), each layer's count
+    // includes it once. They contribute independently to per-layer
+    // tabs and therefore must NOT cross-collapse.
+    const entities = buildEntities([
+      triple('urn:e:dual', 'urn:p:label', '"X"', 'working'),
+      triple('urn:e:dual', 'urn:p:label', '"X"', 'shared'),
+    ]);
+    const dual = entities.get('urn:e:dual')!;
+    expect(dual.trustLevel).toBe('shared');
+    // Canonical-layer = 'shared' has 1 distinct triple. WM residue
+    // is the same (s,p,o) but lives in its own per-layer count
+    // (which we don't surface via `tripleCount` for an SWM-canonical
+    // entity).
+    expect(dual.tripleCount).toBe(1);
+  });
+});

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -411,7 +411,9 @@ describe('Context Graph shared empty/stat patterns', () => {
 
   it('renders assertion rows when SWM assertions become listable', async () => {
     apiMocks.listAssertions.mockResolvedValueOnce([
-      { name: 'turn-anno-test', tripleCount: 3 },
+      // PR #710 Fix D — React key + busy state now use `graphUri`
+      // (unique per row); fixtures must include it.
+      { name: 'turn-anno-test', graphUri: 'urn:dkg:assertion:cg-test:0xabc:turn-anno-test', tripleCount: 3 },
     ]);
     const { container, unmount } = await render(
       React.createElement(AssertionsList, {
@@ -424,6 +426,63 @@ describe('Context Graph shared empty/stat patterns', () => {
     await waitForText(container, 'turn-anno-test');
     expect(container.textContent).toContain('3 triples');
     expect(container.textContent).not.toContain('No Shared Working Memory assertions listed yet.');
+
+    await unmount();
+  });
+
+  // #706 — WM Assertions tab was silently dropping sub-graph-scoped
+  // assertions because the client-side filter only matched the root
+  // `did:dkg:context-graph:<cg>/assertion/…` shape. Fix surfaces both
+  // shapes and tags each row with an inline sub-graph chip when the
+  // assertion is scoped to a partition. Root rows render no chip.
+  it('renders sub-graph chip on partitioned assertions and omits it on root rows (#706)', async () => {
+    apiMocks.listAssertions.mockResolvedValueOnce([
+      { name: 'root-doc', graphUri: 'did:dkg:context-graph:cg-test/assertion/0xabc/root-doc', tripleCount: 2 },
+      { name: 'scoped-doc', graphUri: 'did:dkg:context-graph:cg-test/epcis-supply-chain/assertion/0xabc/scoped-doc', tripleCount: 5, subGraph: 'epcis-supply-chain' },
+      // Long slug to exercise the 18-char middle-ellipsis truncation.
+      { name: 'long-scoped-doc', graphUri: 'did:dkg:context-graph:cg-test/pharmaceutical-derived-product-graph/assertion/0xabc/long-scoped-doc', tripleCount: 1, subGraph: 'pharmaceutical-derived-product-graph' },
+    ]);
+    const { container, unmount } = await render(
+      React.createElement(AssertionsList, {
+        contextGraphId: 'cg-test',
+        layer: 'wm',
+        onComplete: vi.fn(),
+      }),
+    );
+
+    await waitForText(container, 'root-doc');
+    await waitForText(container, 'scoped-doc');
+    await waitForText(container, 'long-scoped-doc');
+
+    // Three rows rendered (no silent drop on sub-graph rows).
+    const rows = container.querySelectorAll('.v10-item-row');
+    expect(rows.length).toBe(3);
+
+    // Locate each row by its name and verify chip presence/absence.
+    const rowFor = (name: string) =>
+      Array.from(rows).find(r => r.querySelector('.v10-item-name')?.textContent === name)!;
+
+    const rootRow = rowFor('root-doc');
+    const scopedRow = rowFor('scoped-doc');
+    const longRow = rowFor('long-scoped-doc');
+
+    // Root row has no sub-graph chip.
+    expect(rootRow.querySelector('.v10-item-subgraph')).toBeNull();
+
+    // Short slug renders verbatim (≤ 18 chars).
+    const scopedChip = scopedRow.querySelector('.v10-item-subgraph');
+    expect(scopedChip).toBeTruthy();
+    expect(scopedChip!.textContent).toContain('epcis-supply-chain');
+    // Tooltip carries the full slug regardless of truncation.
+    expect(scopedChip!.getAttribute('title')).toBe('In sub-graph: epcis-supply-chain');
+
+    // Long slug (>18 chars) gets middle-ellipsis truncated.
+    const longChip = longRow.querySelector('.v10-item-subgraph');
+    expect(longChip).toBeTruthy();
+    expect(longChip!.textContent).toContain('…');
+    expect(longChip!.textContent).not.toContain('pharmaceutical-derived-product-graph');
+    // Tooltip preserves the full slug for power users.
+    expect(longChip!.getAttribute('title')).toBe('In sub-graph: pharmaceutical-derived-product-graph');
 
     await unmount();
   });

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { listAssertions } from '../src/ui/api.js';
+
+// PR #710 — pins `listAssertions`' URI parsing directly. The
+// component test in `context-graph-empty-stat-components.test.ts`
+// mocks `listAssertions` itself, so a regression in the parsing /
+// filter logic wouldn't be caught there. This test mocks the
+// underlying `fetch` (the SPARQL transport) and exercises
+// `listAssertions` end-to-end against fixture bindings.
+//
+// Why fetch-mock rather than `vi.mock('../src/ui/api.js', …)`:
+// `listAssertions` calls `executeQuery` from inside the same module,
+// and ES intra-module references resolve to the local binding —
+// not the mocked export. Mocking the transport boundary
+// (`globalThis.fetch`, used by `post()` in api.ts) keeps the
+// parser code-path under test verbatim. Same pattern as
+// `use-swm-attributions.test.ts` from the prior round.
+
+function bRow(g: string, cnt: number) {
+  // Daemon's SPARQL JSON-binding shape: object with `value`.
+  return { g: { value: g }, cnt: { value: String(cnt) } };
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as any;
+}
+
+describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
+  let originalFetch: typeof globalThis.fetch | undefined;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as any;
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  function setBindings(bindings: unknown[]) {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ result: { bindings } }),
+    );
+  }
+
+  it('parses root-bucket assertion: name extracted, subGraph undefined', async () => {
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: 'notes',
+      graphUri: 'did:dkg:context-graph:cg-A/assertion/0xabc/notes',
+      tripleCount: 5,
+      subGraph: undefined,
+    });
+  });
+
+  it('parses sub-graph-scoped + root in the same response (#706 regression guard)', async () => {
+    // Both shapes must surface. Pre-fix, the `startsWith(…/assertion/)`
+    // filter silently dropped sub-graph rows entirely; this test
+    // pins that they're surfaced AND that the slug + name parse out.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/root-doc', 3),
+      bRow('did:dkg:context-graph:cg-A/research/assertion/0xabc/scoped-doc', 7),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(2);
+    const root = out.find(a => a.name === 'root-doc')!;
+    const scoped = out.find(a => a.name === 'scoped-doc')!;
+    expect(root.subGraph).toBeUndefined();
+    expect(scoped.subGraph).toBe('research');
+    expect(scoped.tripleCount).toBe(7);
+  });
+
+  it('silently drops malformed graph URIs that lack `/assertion/`', async () => {
+    // E.g. internal meta graphs, prefix-only matches, or any future
+    // graph layout that shares the CG prefix but isn't an assertion.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/_meta', 12),
+      bRow('did:dkg:context-graph:cg-A/research', 1),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/real', 4),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('real');
+  });
+
+  it('scopes by cgPrefix — only the queried cgId surfaces', async () => {
+    // Multi-CG responses can arise if the SPARQL is run against a
+    // wider store. The `startsWith(cgPrefix)` filter must reject
+    // bindings from other CGs. Note: the prefix is
+    // `did:dkg:context-graph:cg-A/` (trailing slash); a CG named
+    // `cg-A-suffix` has prefix `…cg-A-suffix/` which does NOT
+    // startsWith the queried prefix.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-OTHER/assertion/0xabc/other', 2),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/mine', 6),
+      bRow('did:dkg:context-graph:cg-A-suffix/assertion/0xabc/foo', 1),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('mine');
+  });
+
+  it('returns an empty list when no bindings match the cg-prefix + /assertion/ filter', async () => {
+    setBindings([
+      bRow('did:dkg:context-graph:cg-B/assertion/0xabc/foo', 1),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toEqual([]);
+  });
+
+  it('drops bindings with 3+ segments before `assertion/` (left-side strict shape)', async () => {
+    // Reviewer-flagged case: a binding like `<cg>/foo/bar/assertion/<a>/<n>`
+    // doesn't match either accepted shape (root = 3 segs, sub-graph =
+    // 4 segs). The prior `indexOf('/assertion/')` branch admitted it
+    // as a `subGraph: undefined` row with a mis-derived name —
+    // promote/preview lookups would silently miss. Strict-shape parse
+    // drops it.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/foo/bar/assertion/0xabc/baz', 9),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/keep', 1),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('keep');
+  });
+
+  it('drops bindings with extra segments after the name (right-side strict shape)', async () => {
+    // Pins the right-side strict-shape contract. The sub-graph branch
+    // expects exactly `<sg>/assertion/<agent>/<name>` — anything
+    // longer would mis-extract the name and orphan the row from
+    // promote/preview.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/sg/assertion/0xabc/foo/extra', 2),
+      bRow('did:dkg:context-graph:cg-A/sg/assertion/0xabc/clean', 3),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: 'clean',
+      subGraph: 'sg',
+      tripleCount: 3,
+    });
+  });
+
+  it('scopes the /assertion/ discriminator to the tail when cgId itself contains "/assertion/"', async () => {
+    // PR #710 reviewer guard — `validateContextGraphId` permits
+    // slashes, so a cgId can literally contain `/assertion/` as a
+    // substring. The prior `g.indexOf('/assertion/')` (full URI)
+    // would have hit the cgId's internal `/assertion/` and
+    // mis-sliced the name. After tail-scoping the parse, the cgId
+    // is treated as opaque and only the tail's `/assertion/`
+    // delimiter is consulted.
+    setBindings([
+      bRow('did:dkg:context-graph:weird/assertion/cg/assertion/0xabc/foo', 4),
+    ]);
+    const out = await listAssertions('weird/assertion/cg', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: 'foo',
+      subGraph: undefined,
+      tripleCount: 4,
+    });
+  });
+});

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -175,6 +175,13 @@ vi.mock('../src/ui/api.js', () => ({
 vi.mock('../src/ui/hooks/useMemoryEntities.js', () => ({
   useMemoryEntities: () => memory,
   buildMemoryEntities: buildTestMemoryEntities,
+  // ProjectView imports `canonicalEntityUri` for `dedupeTriplesBySpo`.
+  // Idempotent strip of `<...>` wrappers mirrors the real impl.
+  canonicalEntityUri: (uri: string) => {
+    const trimmed = uri.trim();
+    if (trimmed.startsWith('<') && trimmed.endsWith('>')) return trimmed.slice(1, -1);
+    return trimmed;
+  },
 }));
 
 vi.mock('../src/ui/hooks/useProjectProfile.js', () => ({

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -224,6 +224,89 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(allCount).toBe(1);
   });
 
+  // Root-bucket regression: SWM entities whose graph URI is
+  // `<cg>/_shared_memory` (the root SWM bucket) surface with an empty
+  // `subGraphs` set — `subGraphOf` in useMemoryEntities.ts filters
+  // underscore-prefixed segments, leaving no slug. Pre-fix the "All"
+  // chip excluded those entities via a `subGraphs.size === 0` skip,
+  // so it undercounted vs the layer tab badge (e.g. tab 27 / All 25
+  // when 2 root-bucket SWM entities existed). They still belong to
+  // the layer and must count toward the umbrella.
+  it('with `layer`: the "All" chip total includes entities with no named sub-graph membership (matches layer tab badge)', async () => {
+    const rootEntity = (uri: string): any => ({
+      uri, label: uri, types: [],
+      trustLevel: 'shared' as const,
+      layers: new Set(['shared']),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    });
+    const entities = [
+      mkEntity('urn:swm-alpha', 'shared', 'alpha'),
+      rootEntity('urn:swm-root-1'),
+      rootEntity('urn:swm-root-2'),
+    ];
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        entities,
+        layer: 'swm',
+      }));
+    });
+    await flushNet();
+    expect(chipCount('alpha')).toBe(1);  // per-sub-graph unchanged
+    // All counts every SWM entity, including the two root-bucket
+    // entities with no named sub-graph membership. Pre-fix: 1.
+    const allChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
+      .find(b => b.textContent?.includes('All'));
+    const allCount = Number(allChip?.querySelector('.v10-subgraph-chip-count')?.textContent ?? 'NaN');
+    expect(allCount).toBe(3);
+  });
+
+  // Layer-agnostic counterpart of the previous case: on the sub-graph
+  // page `ProjectView` passes `entities` without `layer`, and "All"
+  // represents the umbrella over named-sub-graph chips. Entities with
+  // no chip membership (root-bucket SWM entities, empty `subGraphs`)
+  // must STAY excluded here — including them would inflate the total
+  // past anything the user can reach by clicking a chip.
+  it('without `layer`: the "All" chip total excludes entities with no named sub-graph membership (umbrella over chips)', async () => {
+    const rootEntity = (uri: string, trust: 'working' | 'shared' | 'verified'): any => ({
+      uri, label: uri, types: [],
+      trustLevel: trust,
+      layers: new Set([trust]),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    });
+    const entities = [
+      mkEntity('urn:e:alpha', 'shared', 'alpha'),
+      mkEntity('urn:e:beta', 'shared', 'beta'),
+      rootEntity('urn:e:root-1', 'shared'),
+      rootEntity('urn:e:root-2', 'working'),
+    ];
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        entities,
+        // intentionally no `layer` — sub-graph page semantic
+      }));
+    });
+    await flushNet();
+    expect(chipCount('alpha')).toBe(1);
+    expect(chipCount('beta')).toBe(1);
+    const allChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
+      .find(b => b.textContent?.includes('All'));
+    const allCount = Number(allChip?.querySelector('.v10-subgraph-chip-count')?.textContent ?? 'NaN');
+    // 2 chip-reachable entities (alpha, beta). Root entities excluded.
+    expect(allCount).toBe(2);
+  });
+
   // Issue B regression — sub-graph page chip row in layer-agnostic mode.
   // User repro: SWM tab + sub-graph 'ui-epcis' open → chip row shows
   // "All 27 / ui-epcis 27" while the entity list shows 11. The "27"

--- a/packages/node-ui/test/sub-graph-uri.test.ts
+++ b/packages/node-ui/test/sub-graph-uri.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { subGraphFromAssertionGraphUri } from '../src/ui/lib/sub-graph-uri.js';
+
+// Mirror of `contextGraphAssertionUri` in `packages/core/src/constants.ts`.
+// The writer's URI shape is the authoritative source for the slug; the
+// lifecycle metadata never emits `dkg:subGraphName` directly. PR #710 —
+// helper relocated from `useAssertionLifecycleEvents.ts` into `lib/` so
+// `api.ts` and the lifecycle hook can both consume it without forming
+// a module cycle.
+describe('subGraphFromAssertionGraphUri — slug parse', () => {
+  it('returns the slug for sub-graph-scoped assertions', () => {
+    const uri = 'did:dkg:context-graph:cg-1/research/assertion/0xabc/notes';
+    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBe('research');
+  });
+
+  it('returns undefined for root-bucket assertions', () => {
+    const uri = 'did:dkg:context-graph:cg-1/assertion/0xabc/notes';
+    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBeUndefined();
+  });
+
+  it('returns undefined when the prefix does not match the contextGraphId', () => {
+    const uri = 'did:dkg:context-graph:cg-2/research/assertion/0xabc/notes';
+    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBeUndefined();
+  });
+
+  it('returns undefined for malformed URIs that lack the assertion segment', () => {
+    expect(subGraphFromAssertionGraphUri('did:dkg:context-graph:cg-1/research', 'cg-1')).toBeUndefined();
+    expect(subGraphFromAssertionGraphUri('did:dkg:context-graph:cg-1/research/other/0xabc/notes', 'cg-1')).toBeUndefined();
+    expect(subGraphFromAssertionGraphUri('', 'cg-1')).toBeUndefined();
+  });
+});

--- a/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
+++ b/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import {
   buildLifecycleEventsQuery,
-  subGraphFromAssertionGraphUri,
   useAssertionLifecycleEvents,
   type AssertionLifecycleEventsResult,
 } from '../src/ui/hooks/useAssertionLifecycleEvents.js';
@@ -58,33 +57,6 @@ describe('buildLifecycleEventsQuery — SPARQL shape', () => {
     expect(q).toContain('GROUP BY ?event ?type ?assertion ?name ?agent ?ts ?assertionGraph');
     expect(q).toContain('ORDER BY DESC(?ts)');
     expect(q).toContain('LIMIT 5000');
-  });
-});
-
-describe('subGraphFromAssertionGraphUri — slug parse', () => {
-  // PR #694 review fix — mirror of `contextGraphAssertionUri` in
-  // `packages/core/src/constants.ts`. The writer's URI shape is the
-  // authoritative source for the slug; the lifecycle metadata never
-  // emits `dkg:subGraphName` directly.
-  it('returns the slug for sub-graph-scoped assertions', () => {
-    const uri = 'did:dkg:context-graph:cg-1/research/assertion/0xabc/notes';
-    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBe('research');
-  });
-
-  it('returns undefined for root-bucket assertions', () => {
-    const uri = 'did:dkg:context-graph:cg-1/assertion/0xabc/notes';
-    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBeUndefined();
-  });
-
-  it('returns undefined when the prefix does not match the contextGraphId', () => {
-    const uri = 'did:dkg:context-graph:cg-2/research/assertion/0xabc/notes';
-    expect(subGraphFromAssertionGraphUri(uri, 'cg-1')).toBeUndefined();
-  });
-
-  it('returns undefined for malformed URIs that lack the assertion segment', () => {
-    expect(subGraphFromAssertionGraphUri('did:dkg:context-graph:cg-1/research', 'cg-1')).toBeUndefined();
-    expect(subGraphFromAssertionGraphUri('did:dkg:context-graph:cg-1/research/other/0xabc/notes', 'cg-1')).toBeUndefined();
-    expect(subGraphFromAssertionGraphUri('', 'cg-1')).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Brings forward 3 node-ui UI bug fixes that landed on `main` but hadn't yet flowed into `release/rc.12`. As of this PR, `main` was 3 commits ahead of rc.12; rc.12 was 91+ commits ahead of main (release-candidate work). All three brought-forward commits touch **only** node-ui files (UI + UI tests) — zero runtime / chain / publisher / agent surface area.

## Commits

| SHA | Title | Author |
|---|---|---|
| `902a618e6` | fix(node-ui): entity tripleCount matches Triples tab (count type + multi-value + incoming) (#728) | Jurij89 |
| `76b86b907` | fix(node-ui): SubGraphBar "All" pill now matches layer tab badge (#725) | Jurij89 |
| `387b0e0ba` | fix(node-ui): WM Assertions tab surfaces sub-graph assertions (#706) (#710) | Jurij89 |

## Conflicts

Auto-merge was clean — one file (`packages/node-ui/src/ui/api.ts`) merged automatically with no conflicts; nothing to resolve manually.

## Validation

- [x] `pnpm install` — clean
- [x] `pnpm run build:runtime:packages` — clean (node-ui included in the runtime build set)
- [x] Diff inspected: only node-ui code / tests touched; runtime packages untouched

Made with [Cursor](https://cursor.com)