### PR TITLE
test(agent): pin #711 ACK provider wiring (rpc-error translation, legacy fallback)

### DIFF
--- a/packages/agent/test/v10-ack-provider-wiring.test.ts
+++ b/packages/agent/test/v10-ack-provider-wiring.test.ts
@@ -1,0 +1,233 @@
+/**
+ * PR #716 audit cluster **C** — agent-side wiring of the structured
+ * ACK identity verifier introduced in PR #711.
+ *
+ * Where the wiring lives:
+ *   `packages/agent/src/dkg-agent.ts:19161-19236` (`createV10ACKProvider`).
+ *
+ * The agent's job is to translate the chain adapter's verifier shape
+ * into the `ACKCollector` deps shape. Two non-trivial pieces:
+ *
+ *   1. `verifyIdentityDetailed` — wired only when the chain adapter
+ *      implements `verifyACKIdentityDetailed`. The closure wraps the
+ *      adapter call in a `try/catch` and translates a thrown error
+ *      into `{ valid: false, reason: 'rpc-error' }`. Without this
+ *      translation, a flaky / rate-limited / filter-expired RPC
+ *      surfaces in the ACK log as a definitive key-not-registered
+ *      rejection — exactly the 90-minute diagnostic dead-end PR #711
+ *      was opened to fix.
+ *
+ *   2. `verifyIdentity` (legacy boolean) — kept as a fallback for
+ *      adapters that don't (yet) implement the structured method.
+ *      The legacy wrapper also try/catches and swallows to `false`
+ *      to preserve the pre-PR-#711 contract.
+ *
+ * Existing coverage:
+ *   - `packages/publisher/test/v10-ack-edge-cases.test.ts` covers
+ *     the **collector-side** consumption of these deps (3 tests on
+ *     `verifyIdentityDetailed`).
+ *   - The **agent-side wiring** that produces those deps had ZERO
+ *     direct coverage — a refactor that drops the `rpc-error`
+ *     translation or stops wiring the detailed verifier would
+ *     re-introduce the pre-PR-#711 diagnostic conflation silently.
+ *
+ * This file pins the agent-side closures by intercepting the
+ * `ACKCollector` constructor (via `vi.mock`) so we can capture the
+ * exact deps the agent hands it, then invoking those deps with
+ * controlled chain behaviours.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import type { ACKVerifyResult } from '@origintrail-official/dkg-chain';
+import { DKGAgent } from '../src/index.js';
+
+/**
+ * Capture every `ACKCollector` constructor call so each test can
+ * inspect the exact deps the agent wired. Cleared in `beforeEach`.
+ */
+const capturedAckCollectorDeps: unknown[] = [];
+
+vi.mock('@origintrail-official/dkg-publisher', async () => {
+  const actual = await vi.importActual<typeof import('@origintrail-official/dkg-publisher')>(
+    '@origintrail-official/dkg-publisher',
+  );
+  return {
+    ...actual,
+    // Replace the `ACKCollector` class with a tiny capture stand-in.
+    // We don't need its full behaviour for these wiring tests — the
+    // agent only constructs it; the actual `collect()` only runs on
+    // publish, which isn't exercised here.
+    ACKCollector: class CapturingACKCollector {
+      constructor(deps: unknown) {
+        capturedAckCollectorDeps.push(deps);
+      }
+      // Required for the agent's outer closure shape — never called
+      // in this file, but TypeScript's structural matching expects
+      // the surface to exist.
+      async collect(): Promise<never> {
+        throw new Error('CapturingACKCollector.collect should not be invoked in wiring tests');
+      }
+    },
+  };
+});
+
+/**
+ * Shape the agent passes to the (now-mocked) `ACKCollector`
+ * constructor. We only assert on the two verifier callbacks here.
+ */
+interface ACKCollectorDepsCapture {
+  verifyIdentity?: (recoveredAddress: string, identityId: bigint) => Promise<boolean>;
+  verifyIdentityDetailed?: (
+    recoveredAddress: string,
+    identityId: bigint,
+  ) => Promise<ACKVerifyResult>;
+}
+
+/**
+ * Reach into the agent's `private createV10ACKProvider(cgId)` so the
+ * ACK collector is actually constructed and its deps are captured.
+ *
+ * Also stub the two start-time fields (`router`, `gossip`) the
+ * `createV10ACKProvider` guard checks — without a real `start()` they
+ * are `undefined`/null, and the function would short-circuit at the
+ * very first `if (!this.router || !this.gossip) return undefined;`
+ * without ever constructing an `ACKCollector`.
+ */
+interface ProviderInternals {
+  createV10ACKProvider(cgId: string): unknown;
+  router: unknown;
+  gossip: unknown;
+  chain: MockChainAdapter & {
+    verifyACKIdentity?: (recoveredAddress: string, identityId: bigint) => Promise<boolean>;
+    verifyACKIdentityDetailed?: (
+      recoveredAddress: string,
+      identityId: bigint,
+    ) => Promise<ACKVerifyResult>;
+  };
+  node: { libp2p: { getPeers(): unknown[] } };
+}
+
+async function bootProviderAgent(): Promise<{ agent: DKGAgent; internals: ProviderInternals }> {
+  const chain = new MockChainAdapter();
+  const agent = await DKGAgent.create({
+    name: 'ACKProviderWiringTest',
+    chainAdapter: chain,
+  });
+  const internals = agent as unknown as ProviderInternals;
+  // The guards at the top of `createV10ACKProvider` only check
+  // truthiness, not type. Pass empty objects so the function reaches
+  // the `new ACKCollector(...)` call site.
+  internals.router = {};
+  internals.gossip = { publish: async () => undefined };
+  // Unconditionally override `node` — the real `DKGNode` getter
+  // throws on access before `start()` is called, so even the
+  // existence check `!internals.node.libp2p` blows up. Provide a
+  // structurally-typed stub that satisfies the `getConnectedCorePeers`
+  // callback's `this.node.libp2p.getPeers()` call without spinning
+  // libp2p.
+  (internals as { node: { libp2p: { getPeers(): unknown[] } } }).node = {
+    libp2p: { getPeers: () => [] },
+  };
+  return { agent, internals };
+}
+
+describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #711)', () => {
+  let agent: DKGAgent | null = null;
+
+  beforeEach(() => {
+    capturedAckCollectorDeps.length = 0;
+  });
+
+  afterEach(async () => {
+    if (agent) {
+      await agent.stop().catch(() => undefined);
+      agent = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('chain exposes verifyACKIdentityDetailed: agent wires verifyIdentityDetailed AND translates thrown errors to {valid: false, reason: "rpc-error"}', async () => {
+    const boot = await bootProviderAgent();
+    agent = boot.agent;
+    const internals = boot.internals;
+
+    // Make the chain's structured verifier THROW — the pre-PR-#711
+    // contract was that the agent's try/catch returned `false`,
+    // which the collector logged as the same "not registered"
+    // string as a definitive identity rejection. PR #711's fix is
+    // that the agent translates the throw into the dedicated
+    // `'rpc-error'` reason so operators can act on it.
+    internals.chain.verifyACKIdentityDetailed = async (): Promise<ACKVerifyResult> => {
+      throw new Error('synthetic RPC outage — filter expired');
+    };
+
+    internals.createV10ACKProvider('test-cg');
+
+    expect(capturedAckCollectorDeps).toHaveLength(1);
+    const deps = capturedAckCollectorDeps[0] as ACKCollectorDepsCapture;
+    expect(deps.verifyIdentityDetailed).toBeTypeOf('function');
+
+    const verdict = await deps.verifyIdentityDetailed!(
+      '0xabCDeF0123456789abcDef0123456789AbCdef01',
+      42n,
+    );
+    expect(verdict).toEqual({ valid: false, reason: 'rpc-error' });
+  });
+
+  it('chain exposes verifyACKIdentityDetailed: agent forwards a definitive {valid: false, reason: "key-not-registered"} verdict UNCHANGED', async () => {
+    // The wrapper must not corrupt definitive verdicts — only
+    // translate THROWS into rpc-error. If a refactor accidentally
+    // started squashing reason fields to undefined, operators would
+    // lose the ability to act on the specific failure mode.
+    const boot = await bootProviderAgent();
+    agent = boot.agent;
+    const internals = boot.internals;
+
+    internals.chain.verifyACKIdentityDetailed = async (): Promise<ACKVerifyResult> => ({
+      valid: false,
+      reason: 'key-not-registered' as const,
+    });
+
+    internals.createV10ACKProvider('test-cg');
+
+    const deps = capturedAckCollectorDeps[0] as ACKCollectorDepsCapture;
+    const verdict = await deps.verifyIdentityDetailed!(
+      '0xabCDeF0123456789abcDef0123456789AbCdef01',
+      42n,
+    );
+    expect(verdict).toEqual({ valid: false, reason: 'key-not-registered' });
+  });
+
+  it('chain exposes only the boolean verifyACKIdentity (no structured method): agent wires verifyIdentity, leaves verifyIdentityDetailed undefined; the legacy wrapper swallows throws to false', async () => {
+    // Backward-compat path. The collector falls back to its legacy
+    // log line "Signer X not registered for identity Y" when only
+    // the boolean callback is provided, so the wiring difference
+    // is observable end-to-end.
+    const boot = await bootProviderAgent();
+    agent = boot.agent;
+    const internals = boot.internals;
+
+    // Strip the structured method so the `typeof === 'function'`
+    // guard reads false and the agent skips wiring it.
+    (internals.chain as { verifyACKIdentityDetailed?: unknown }).verifyACKIdentityDetailed =
+      undefined;
+    // Make the boolean verifier throw, so we can assert the legacy
+    // wrapper translates the throw to `false` rather than letting
+    // it propagate.
+    internals.chain.verifyACKIdentity = async (): Promise<boolean> => {
+      throw new Error('synthetic RPC outage on legacy path');
+    };
+
+    internals.createV10ACKProvider('test-cg');
+
+    const deps = capturedAckCollectorDeps[0] as ACKCollectorDepsCapture;
+    expect(deps.verifyIdentityDetailed).toBeUndefined();
+    expect(deps.verifyIdentity).toBeTypeOf('function');
+
+    const verdict = await deps.verifyIdentity!(
+      '0xabCDeF0123456789abcDef0123456789AbCdef01',
+      42n,
+    );
+    expect(verdict).toBe(false);
+  });
+});

--- a/packages/agent/test/v10-ack-provider-wiring.test.ts
+++ b/packages/agent/test/v10-ack-provider-wiring.test.ts
@@ -38,7 +38,10 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
-import type { ACKVerifyResult } from '@origintrail-official/dkg-chain';
+// Codex review feedback: the chain package exports the verifier
+// result type as `VerifyACKIdentityResult`; `ACKVerifyResult` is the
+// publisher-side mirror (same shape, different export site).
+import type { VerifyACKIdentityResult } from '@origintrail-official/dkg-chain';
 import { DKGAgent } from '../src/index.js';
 
 /**
@@ -80,7 +83,7 @@ interface ACKCollectorDepsCapture {
   verifyIdentityDetailed?: (
     recoveredAddress: string,
     identityId: bigint,
-  ) => Promise<ACKVerifyResult>;
+  ) => Promise<VerifyACKIdentityResult>;
 }
 
 /**
@@ -102,7 +105,7 @@ interface ProviderInternals {
     verifyACKIdentityDetailed?: (
       recoveredAddress: string,
       identityId: bigint,
-    ) => Promise<ACKVerifyResult>;
+    ) => Promise<VerifyACKIdentityResult>;
   };
   node: { libp2p: { getPeers(): unknown[] } };
 }
@@ -157,7 +160,7 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
     // string as a definitive identity rejection. PR #711's fix is
     // that the agent translates the throw into the dedicated
     // `'rpc-error'` reason so operators can act on it.
-    internals.chain.verifyACKIdentityDetailed = async (): Promise<ACKVerifyResult> => {
+    internals.chain.verifyACKIdentityDetailed = async (): Promise<VerifyACKIdentityResult> => {
       throw new Error('synthetic RPC outage — filter expired');
     };
 
@@ -183,7 +186,7 @@ describe('DKGAgent.createV10ACKProvider — structured ACK verifier wiring (PR #
     agent = boot.agent;
     const internals = boot.internals;
 
-    internals.chain.verifyACKIdentityDetailed = async (): Promise<ACKVerifyResult> => ({
+    internals.chain.verifyACKIdentityDetailed = async (): Promise<VerifyACKIdentityResult> => ({
       valid: false,
       reason: 'key-not-registered' as const,
     });


### PR DESCRIPTION
## Summary

PR #716 audit cluster **C**. PR #711 introduced two diagnostic
improvements:

1. A structured ACK identity verifier
   (\`chain.verifyACKIdentityDetailed\`) returning
   \`{valid, reason: 'key-not-registered' | 'not-in-sharding-table' | 'rpc-error'}\`.
2. The agent's \`createV10ACKProvider\` wraps the chain method in a
   try/catch that translates a thrown RPC error into
   \`{valid: false, reason: 'rpc-error'}\` — the whole point being
   to make infrastructure failures distinguishable from definitive
   identity rejections in the ACK log.

### The coverage gap

- The **publisher-side** \`ACKCollector\` consumption of these deps
  is already covered (3 tests in
  \`packages/publisher/test/v10-ack-edge-cases.test.ts\`).
- The **agent-side wiring** that PRODUCES those deps had ZERO
  coverage. A refactor that drops the rpc-error translation, or
  stops wiring the detailed verifier when present, would silently
  re-introduce the pre-PR-#711 diagnostic conflation — every
  failure logs as \"not registered\" and operators would burn hours
  diagnosing transient RPC issues as definitive key rejections.
  That's exactly the rc.11 incident PR #711 was opened to prevent.

## What this PR adds

New file \`packages/agent/test/v10-ack-provider-wiring.test.ts\`. It
intercepts the \`ACKCollector\` constructor via \`vi.mock\` so the
exact deps the agent wires are captured. Then invokes those deps
with controlled chain behaviours.

**3 tests:**
- Detailed verifier wired: chain THROWS → wrapper returns
  \`{valid: false, reason: 'rpc-error'}\`. The translation that's the
  whole reason this wrapper exists.
- Detailed verifier wired: chain returns
  \`{valid: false, reason: 'key-not-registered'}\` → wrapper forwards
  it UNCHANGED. Pins that only throws get translated, not
  definitive verdicts.
- Only legacy boolean verifier present: agent leaves
  \`verifyIdentityDetailed\` undefined, wires \`verifyIdentity\` with
  its own try/catch → \`false\` on throw (pre-PR-#711 contract preserved).

## Test plan
- [x] \`pnpm exec vitest run test/v10-ack-provider-wiring.test.ts\` — 3 passed
- [x] No lints
- [x] Existing publisher-side ACK collector tests still pass (untouched).

Related: #716, #711.

Made with [Cursor](https://cursor.com)