### PR TITLE
Fix query scoping and view isolation

### DIFF
--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -625,6 +625,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
         msg.includes("agentAddress is required") ||
         msg.includes("requires a contextGraphId") ||
         msg.includes("cannot be combined with") ||
+        msg.startsWith("Scoped query violation:") ||
         // A-1 review: DKGAgent.query throws these when the caller sends
         // a non-string `agentAddress` / `callerAgentAddress` in the
         // body. Classify as 400 so malformed input is a clean client

--- a/packages/cli/test/daemon/routes/query.test.ts
+++ b/packages/cli/test/daemon/routes/query.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { RequestContext } from '../../../src/daemon/routes/context.js';
+import { handleQueryRoutes } from '../../../src/daemon/routes/query.js';
+
+interface FakeRes {
+  writableEnded: boolean;
+  headersSent: boolean;
+  statusCode: number;
+  headers: Record<string, string | number | string[]>;
+  body: string;
+  writeHead: (status: number, headers?: Record<string, string | number | string[]>) => FakeRes;
+  end: (chunk?: string) => void;
+}
+
+function makeRes(): FakeRes {
+  const res: FakeRes = {
+    writableEnded: false,
+    headersSent: false,
+    statusCode: 200,
+    headers: {},
+    body: '',
+    writeHead(status, headers) {
+      res.statusCode = status;
+      if (headers) Object.assign(res.headers, headers);
+      res.headersSent = true;
+      return res;
+    },
+    end(chunk?: string) {
+      if (typeof chunk === 'string') res.body += chunk;
+      res.headersSent = true;
+      res.writableEnded = true;
+    },
+  };
+  return res;
+}
+
+function makeReq(body: Record<string, unknown>): IncomingMessage {
+  return {
+    method: 'POST',
+    headers: {},
+    __dkgPrebufferedBody: Buffer.from(JSON.stringify(body)),
+  } as unknown as IncomingMessage;
+}
+
+function makeTracker() {
+  return {
+    start: vi.fn(),
+    startPhase: vi.fn(),
+    completePhase: vi.fn(),
+    complete: vi.fn(),
+    fail: vi.fn(),
+  };
+}
+
+function makeCtx(agent: Record<string, unknown>, body: Record<string, unknown>, res = makeRes()): {
+  ctx: RequestContext;
+  res: FakeRes;
+} {
+  const ctx = {
+    req: makeReq(body),
+    res: res as unknown as ServerResponse,
+    agent,
+    tracker: makeTracker(),
+    validTokens: new Set<string>(),
+    path: '/api/query',
+    url: new URL('http://127.0.0.1/api/query'),
+    requestToken: undefined,
+  } as unknown as RequestContext;
+  return { ctx, res };
+}
+
+describe('handleQueryRoutes /api/query', () => {
+  it('maps scoped-query violations from the query engine to HTTP 400', async () => {
+    const error = new Error(
+      'Scoped query violation: GRAPH <did:dkg:context-graph:other> is outside the allowed graph set',
+    );
+    const agent = {
+      resolveAgentByToken: vi.fn(),
+      query: vi.fn().mockRejectedValue(error),
+    };
+    const { ctx, res } = makeCtx(agent, {
+      sparql: 'SELECT ?s WHERE { GRAPH <did:dkg:context-graph:other> { ?s ?p ?o } }',
+      contextGraphId: 'agent-registry',
+    });
+
+    await handleQueryRoutes(ctx);
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe(error.message);
+  });
+});

--- a/packages/mcp-dkg/src/tools.ts
+++ b/packages/mcp-dkg/src/tools.ts
@@ -163,6 +163,8 @@ export function registerReadTools(
         'just write `SELECT ?d WHERE { ?d a decisions:Decision }`. Scope ' +
         'with `view` — "working-memory" (default, private), ' +
         '"shared-working-memory" (team), or "verified-memory" (on-chain). ' +
+        '`contextGraphId` and `view` are authoritative: local `GRAPH ?g` ' +
+        'patterns are constrained to that resolved graph set. ' +
         'Set `includeSharedMemory: true` alongside `view: "working-memory"` ' +
         'to query WM ∪ SWM in one call.',
       inputSchema: {

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -19,15 +19,26 @@ const engine = new DKGQueryEngine(store);
 
 const results = await engine.query(
   'SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10',
-  { contextGraphId: 'urn:contextGraph:example' },
+  { contextGraphId: 'example', view: 'verified-memory' },
 );
 
-// Query with workspace data included
-const wsResults = await engine.query(
-  'SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10',
-  { contextGraphId: 'urn:contextGraph:example', includeWorkspace: true },
+// Inspect allowed named graphs without expanding the selected scope.
+const graphResults = await engine.query(
+  'SELECT ?g ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } } LIMIT 10',
+  { contextGraphId: 'example', view: 'shared-working-memory' },
 );
 ```
+
+contextGraphId and view are authoritative for local queries. A local
+`GRAPH ?g` pattern is constrained locally to the graph set resolved from those
+fields; it cannot range over another context graph or memory view. Local scoped
+queries reject explicit out-of-scope `GRAPH <iri>` targets and `FROM` /
+`FROM NAMED` clauses because those would let caller SPARQL redefine the dataset.
+
+Remote raw SPARQL handled by `QueryHandler` remains stricter: `GRAPH`, `FROM`,
+and `FROM NAMED` clauses are rejected before execution. Structured remote
+lookups such as `ENTITIES_BY_TYPE` and `ENTITY_TRIPLES` continue to build their
+own internal graph patterns.
 
 ## Internal Dependencies
 

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -166,6 +166,19 @@ export class DKGQueryEngine implements QueryEngine {
       if (!v.valid) throw new Error(`Invalid sub-graph name for query: ${v.reason}`);
     }
 
+    if (effectiveContextGraphId && !options?.view) {
+      const dataGraph = options?.subGraphName
+        ? contextGraphSubGraphUri(effectiveContextGraphId, options.subGraphName)
+        : contextGraphDataUri(effectiveContextGraphId);
+      const sharedMemoryGraph = contextGraphSharedMemoryUri(effectiveContextGraphId, options?.subGraphName);
+      const allowedGraphs = options?.includeSharedMemory ?? options?.includeWorkspace
+        ? [dataGraph, sharedMemoryGraph]
+        : options?.graphSuffix === '_shared_memory'
+          ? [sharedMemoryGraph]
+          : [dataGraph];
+      assertExplicitGraphIrisAllowed(sparql, allowedGraphs);
+    }
+
     if (options?.view) {
       if (!effectiveContextGraphId) {
         throw new Error(
@@ -432,6 +445,99 @@ function assertNoCallerDatasetClauses(sparql: string): void {
       'FROM clauses are not allowed on scoped local queries',
     );
   }
+}
+
+function assertExplicitGraphIrisAllowed(sparql: string, allowedGraphs: string[]): void {
+  const allowed = new Set(allowedGraphs);
+  for (const graphIri of collectExplicitGraphIris(sparql)) {
+    if (!allowed.has(graphIri)) {
+      throw new ScopedQueryViolationError(
+        `GRAPH <${graphIri}> is outside the allowed graph set`,
+      );
+    }
+  }
+}
+
+function collectExplicitGraphIris(sparql: string): string[] {
+  const iris: string[] = [];
+  const n = sparql.length;
+  let i = 0;
+
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const end = sparql.indexOf('>', i + 1);
+      if (end === -1) return iris;
+      i = end + 1;
+      continue;
+    }
+    if (isKeywordStart(sparql, i)) {
+      let j = i + 1;
+      while (j < n && isWordContinuation(sparql[j])) j++;
+      const word = sparql.slice(i, j);
+      if (word.toUpperCase() === 'GRAPH') {
+        const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
+        if (operandStart > j && sparql[operandStart] === '<') {
+          const operandEnd = sparql.indexOf('>', operandStart + 1);
+          if (operandEnd === -1) return iris;
+          iris.push(sparql.slice(operandStart + 1, operandEnd));
+          i = operandEnd + 1;
+          continue;
+        }
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+
+  return iris;
+}
+
+function skipSparqlSpaceAndLineComments(sparql: string, start: number): number {
+  let i = start;
+  while (i < sparql.length) {
+    if (/\s/.test(sparql[i])) {
+      i++;
+      continue;
+    }
+    if (sparql[i] === '#') {
+      while (i < sparql.length && sparql[i] !== '\n') i++;
+      continue;
+    }
+    break;
+  }
+  return i;
+}
+
+function isKeywordStart(src: string, idx: number): boolean {
+  const ch = src[idx];
+  if (!isWordStart(ch)) return false;
+  const prev = idx > 0 ? src[idx - 1] : '';
+  return !prev || (!isWordContinuation(prev) && prev !== '?' && prev !== '$' && prev !== ':' && prev !== '#');
+}
+
+function isWordStart(ch: string | undefined): ch is string {
+  return !!ch && (
+    (ch >= 'A' && ch <= 'Z') ||
+    (ch >= 'a' && ch <= 'z') ||
+    ch === '_'
+  );
+}
+
+function isWordContinuation(ch: string | undefined): ch is string {
+  return !!ch && (
+    isWordStart(ch) ||
+    (ch >= '0' && ch <= '9')
+  );
 }
 
 /**

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -741,15 +741,68 @@ function readSparqlVariable(sparql: string, start: number): string | null {
   const sigil = sparql[start];
   if (sigil !== '?' && sigil !== '$') return null;
   let end = start + 1;
-  while (end < sparql.length && isSparqlVariableContinuation(sparql[end])) end++;
+  const first = readCodePoint(sparql, end);
+  if (!first || !isSparqlVariableInitialCodePoint(first.codePoint)) return null;
+  end += first.width;
+
+  while (end < sparql.length) {
+    const next = readCodePoint(sparql, end);
+    if (!next || !isSparqlVariableContinuationCodePoint(next.codePoint)) break;
+    end += next.width;
+  }
+
   return end > start + 1 ? sparql.slice(start, end) : null;
 }
 
-function isSparqlVariableContinuation(ch: string | undefined): ch is string {
-  return !!ch && (
-    isWordStart(ch) ||
-    (ch >= '0' && ch <= '9')
+function readCodePoint(src: string, index: number): { codePoint: number; width: number } | null {
+  if (index >= src.length) return null;
+  const codePoint = src.codePointAt(index);
+  if (codePoint === undefined) return null;
+  return { codePoint, width: codePoint > 0xffff ? 2 : 1 };
+}
+
+function isSparqlVariableInitialCodePoint(codePoint: number): boolean {
+  return isSparqlPnCharsUCodePoint(codePoint) || isAsciiDigitCodePoint(codePoint);
+}
+
+function isSparqlVariableContinuationCodePoint(codePoint: number): boolean {
+  return (
+    isSparqlPnCharsUCodePoint(codePoint) ||
+    isAsciiDigitCodePoint(codePoint) ||
+    codePoint === 0x00b7 ||
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    (codePoint >= 0x203f && codePoint <= 0x2040)
   );
+}
+
+function isSparqlPnCharsUCodePoint(codePoint: number): boolean {
+  return (
+    codePoint === 0x5f ||
+    isAsciiAlphaCodePoint(codePoint) ||
+    (codePoint >= 0x00c0 && codePoint <= 0x00d6) ||
+    (codePoint >= 0x00d8 && codePoint <= 0x00f6) ||
+    (codePoint >= 0x00f8 && codePoint <= 0x02ff) ||
+    (codePoint >= 0x0370 && codePoint <= 0x037d) ||
+    (codePoint >= 0x037f && codePoint <= 0x1fff) ||
+    (codePoint >= 0x200c && codePoint <= 0x200d) ||
+    (codePoint >= 0x2070 && codePoint <= 0x218f) ||
+    (codePoint >= 0x2c00 && codePoint <= 0x2fef) ||
+    (codePoint >= 0x3001 && codePoint <= 0xd7ff) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfdcf) ||
+    (codePoint >= 0xfdf0 && codePoint <= 0xfffd) ||
+    (codePoint >= 0x10000 && codePoint <= 0xeffff)
+  );
+}
+
+function isAsciiAlphaCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x41 && codePoint <= 0x5a) ||
+    (codePoint >= 0x61 && codePoint <= 0x7a)
+  );
+}
+
+function isAsciiDigitCodePoint(codePoint: number): boolean {
+  return codePoint >= 0x30 && codePoint <= 0x39;
 }
 
 function skipSparqlSpaceAndLineComments(sparql: string, start: number): number {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -282,6 +282,11 @@ export class DKGQueryEngine implements QueryEngine {
       return emptyResultForSparql(sparql);
     }
 
+    if (view === 'verified-memory') {
+      assertExplicitGraphIrisAllowed(sparql, allGraphs);
+      sparql = constrainGraphVariablesToAllowedSet(sparql, allGraphs);
+    }
+
     // Spec §14 trust-gradient filter — only enforced on verified-memory
     // where on-chain-anchored trust metadata is expected to live.
     // When `minTrust` (or legacy `_minTrust`) is set, rewrite the query so

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -966,6 +966,7 @@ function findExplicitWhereTokenIdx(sparql: string): number {
   };
 
   let i = 0;
+  let braceDepth = 0;
   while (i < n) {
     const ch = sparql[i];
     if (ch === '#') {
@@ -986,6 +987,16 @@ function findExplicitWhereTokenIdx(sparql: string): number {
       i++;
       continue;
     }
+    if (ch === '{') {
+      braceDepth++;
+      i++;
+      continue;
+    }
+    if (ch === '}') {
+      braceDepth = Math.max(0, braceDepth - 1);
+      i++;
+      continue;
+    }
     if (isWordStart(ch)) {
       // Word boundary check: previous char (if any) must NOT be a
       // word-continuation byte. The outer lexer already skipped
@@ -1002,7 +1013,7 @@ function findExplicitWhereTokenIdx(sparql: string): number {
       let j = i + 1;
       while (j < n && isWordCont(sparql[j])) j++;
       const word = sparql.substring(i, j);
-      if (word.length === 5 && word.toUpperCase() === 'WHERE') {
+      if (braceDepth === 0 && word.length === 5 && word.toUpperCase() === 'WHERE') {
         return i;
       }
       i = j;

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -14,6 +14,7 @@ import {
   validateReadOnlySparql,
   emptyResultForSparql,
 } from './sparql-guard.js';
+import { stripLiteralsAndComments } from './sparql-utils.js';
 
 /**
  * Result of resolving a V10 GET view to concrete graph targets.
@@ -27,6 +28,13 @@ export interface ViewResolution {
    * assertions) and verified-memory (multiple quorum graphs).
    */
   graphPrefixes: string[];
+}
+
+export class ScopedQueryViolationError extends Error {
+  constructor(message: string) {
+    super(`Scoped query violation: ${message}`);
+    this.name = 'ScopedQueryViolationError';
+  }
 }
 
 /**
@@ -149,6 +157,9 @@ export class DKGQueryEngine implements QueryEngine {
 
     // ── V10 view-based routing ────────────────────────────────────────
     const effectiveContextGraphId = options?.contextGraphId;
+    if (effectiveContextGraphId) {
+      assertNoCallerDatasetClauses(sparql);
+    }
 
     if (options?.subGraphName) {
       const v = validateSubGraphName(options.subGraphName);
@@ -412,6 +423,15 @@ export class DKGQueryEngine implements QueryEngine {
     return { bindings: allBindings };
   }
 
+}
+
+function assertNoCallerDatasetClauses(sparql: string): void {
+  const code = stripLiteralsAndComments(sparql);
+  if (/\bFROM\s+(?:NAMED\s+)?/i.test(code)) {
+    throw new ScopedQueryViolationError(
+      'FROM clauses are not allowed on scoped local queries',
+    );
+  }
 }
 
 /**

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -972,7 +972,11 @@ function isKeywordStart(src: string, idx: number): boolean {
 }
 
 function isSparqlKeyword(src: string, start: number, end: number, keyword: string): boolean {
-  return src.slice(start, end).toUpperCase() === keyword && src[end] !== ':';
+  const next = src[end];
+  return src.slice(start, end).toUpperCase() === keyword
+    && next !== ':'
+    && next !== '-'
+    && next !== '.';
 }
 
 function isWordStart(ch: string | undefined): ch is string {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -177,6 +177,7 @@ export class DKGQueryEngine implements QueryEngine {
           ? [sharedMemoryGraph]
           : [dataGraph];
       assertExplicitGraphIrisAllowed(sparql, allowedGraphs);
+      sparql = constrainGraphVariablesToAllowedSet(sparql, allowedGraphs);
     }
 
     if (options?.view) {
@@ -458,6 +459,27 @@ function assertExplicitGraphIrisAllowed(sparql: string, allowedGraphs: string[])
   }
 }
 
+function constrainGraphVariablesToAllowedSet(sparql: string, allowedGraphs: string[]): string {
+  const graphVariables = collectGraphVariables(sparql);
+  if (graphVariables.length === 0) return sparql;
+
+  const braceStart = findWhereBraceStart(sparql);
+  if (braceStart === -1) {
+    throw new ScopedQueryViolationError(
+      'GRAPH variables cannot be constrained because the WHERE block could not be located',
+    );
+  }
+
+  const values = allowedGraphs
+    .map((g) => `<${assertSafeIri(g)}>`)
+    .join(' ');
+  const constraints = graphVariables
+    .map((variable) => `VALUES ${variable} { ${values} }`)
+    .join(' ');
+
+  return `${sparql.slice(0, braceStart + 1)} ${constraints} ${sparql.slice(braceStart + 1)}`;
+}
+
 function collectExplicitGraphIris(sparql: string): string[] {
   const iris: string[] = [];
   const n = sparql.length;
@@ -500,6 +522,66 @@ function collectExplicitGraphIris(sparql: string): string[] {
   }
 
   return iris;
+}
+
+function collectGraphVariables(sparql: string): string[] {
+  const variables: string[] = [];
+  const seen = new Set<string>();
+  const n = sparql.length;
+  let i = 0;
+
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const end = sparql.indexOf('>', i + 1);
+      if (end === -1) return variables;
+      i = end + 1;
+      continue;
+    }
+    if (isKeywordStart(sparql, i)) {
+      let j = i + 1;
+      while (j < n && isWordContinuation(sparql[j])) j++;
+      const word = sparql.slice(i, j);
+      if (word.toUpperCase() === 'GRAPH') {
+        const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
+        const variable = readSparqlVariable(sparql, operandStart);
+        if (variable && !seen.has(variable)) {
+          seen.add(variable);
+          variables.push(variable);
+        }
+        i = operandStart + (variable?.length ?? 0);
+        continue;
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+
+  return variables;
+}
+
+function readSparqlVariable(sparql: string, start: number): string | null {
+  const sigil = sparql[start];
+  if (sigil !== '?' && sigil !== '$') return null;
+  let end = start + 1;
+  while (end < sparql.length && isSparqlVariableContinuation(sparql[end])) end++;
+  return end > start + 1 ? sparql.slice(start, end) : null;
+}
+
+function isSparqlVariableContinuation(ch: string | undefined): ch is string {
+  return !!ch && (
+    isWordStart(ch) ||
+    (ch >= '0' && ch <= '9')
+  );
 }
 
 function skipSparqlSpaceAndLineComments(sparql: string, start: number): number {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -471,7 +471,7 @@ function hasCallerDatasetClause(sparql: string): boolean {
     if (isKeywordStart(sparql, i)) {
       let j = i + 1;
       while (j < n && isWordContinuation(sparql[j])) j++;
-      if (sparql.slice(i, j).toUpperCase() === 'FROM') {
+      if (sparql.slice(i, j).toUpperCase() === 'FROM' && sparql[j] !== ':') {
         return true;
       }
       i = j;

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -484,6 +484,8 @@ function hasCallerDatasetClause(sparql: string): boolean {
 }
 
 function assertExplicitGraphIrisAllowed(sparql: string, allowedGraphs: string[]): void {
+  assertNoUnvalidatedExplicitGraphTargets(sparql);
+
   const allowed = new Set(allowedGraphs);
   for (const graphIri of collectExplicitGraphIris(sparql)) {
     if (!allowed.has(graphIri)) {
@@ -491,6 +493,57 @@ function assertExplicitGraphIrisAllowed(sparql: string, allowedGraphs: string[])
         `GRAPH <${graphIri}> is outside the allowed graph set`,
       );
     }
+  }
+}
+
+function assertNoUnvalidatedExplicitGraphTargets(sparql: string): void {
+  const n = sparql.length;
+  let i = 0;
+
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const end = skipSparqlIriRef(sparql, i);
+      i = end ?? i + 1;
+      continue;
+    }
+    if (isKeywordStart(sparql, i)) {
+      let j = i + 1;
+      while (j < n && isWordContinuation(sparql[j])) j++;
+      const word = sparql.slice(i, j);
+      if (word.toUpperCase() === 'GRAPH') {
+        const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
+        const variable = readSparqlVariable(sparql, operandStart);
+        if (variable) {
+          i = operandStart + variable.length;
+          continue;
+        }
+        if (sparql[operandStart] === '<') {
+          const iriEnd = skipSparqlIriRef(sparql, operandStart);
+          if (!iriEnd) {
+            throw new ScopedQueryViolationError(
+              'GRAPH target must be a variable or explicit IRI on scoped queries',
+            );
+          }
+          i = iriEnd;
+          continue;
+        }
+        throw new ScopedQueryViolationError(
+          'GRAPH target must be a variable or explicit IRI on scoped queries',
+        );
+      }
+      i = j;
+      continue;
+    }
+    i++;
   }
 }
 

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -282,7 +282,7 @@ export class DKGQueryEngine implements QueryEngine {
       return emptyResultForSparql(sparql);
     }
 
-    if (view === 'verified-memory') {
+    if (view === 'verified-memory' || view === 'shared-working-memory') {
       assertExplicitGraphIrisAllowed(sparql, allGraphs);
       sparql = constrainGraphVariablesToAllowedSet(sparql, allGraphs);
     }

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -282,10 +282,8 @@ export class DKGQueryEngine implements QueryEngine {
       return emptyResultForSparql(sparql);
     }
 
-    if (view === 'verified-memory' || view === 'shared-working-memory') {
-      assertExplicitGraphIrisAllowed(sparql, allGraphs);
-      sparql = constrainGraphVariablesToAllowedSet(sparql, allGraphs);
-    }
+    assertExplicitGraphIrisAllowed(sparql, allGraphs);
+    sparql = constrainGraphVariablesToAllowedSet(sparql, allGraphs);
 
     // Spec §14 trust-gradient filter — only enforced on verified-memory
     // where on-chain-anchored trust metadata is expected to live.

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -563,6 +563,7 @@ function constrainGraphVariablesToAllowedSet(sparql: string, allowedGraphs: stri
       'GRAPH variables cannot be constrained because the WHERE block could not be located',
     );
   }
+  assertGraphVariablesAreTopLevel(sparql, braceStart);
 
   const values = allowedGraphs
     .map((g) => `<${assertSafeIri(g)}>`)
@@ -572,6 +573,60 @@ function constrainGraphVariablesToAllowedSet(sparql: string, allowedGraphs: stri
     .join(' ');
 
   return `${sparql.slice(0, braceStart + 1)} ${constraints} ${sparql.slice(braceStart + 1)}`;
+}
+
+function assertGraphVariablesAreTopLevel(sparql: string, braceStart: number): void {
+  const braceEnd = findMatchingCloseBrace(sparql, braceStart);
+  if (braceEnd === -1) {
+    throw new ScopedQueryViolationError(
+      'GRAPH variables cannot be constrained because the WHERE block could not be located',
+    );
+  }
+
+  let depth = 0;
+  let i = braceStart + 1;
+
+  while (i < braceEnd) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < braceEnd && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const iriEnd = skipSparqlIriRef(sparql, i);
+      i = iriEnd && iriEnd <= braceEnd ? iriEnd : i + 1;
+      continue;
+    }
+    if (ch === '{') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}') {
+      depth = Math.max(0, depth - 1);
+      i++;
+      continue;
+    }
+    if (isKeywordStart(sparql, i)) {
+      let j = i + 1;
+      while (j < braceEnd && isWordContinuation(sparql[j])) j++;
+      if (isSparqlKeyword(sparql, i, j, 'GRAPH')) {
+        const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
+        if (operandStart < braceEnd && readSparqlVariable(sparql, operandStart) && depth !== 0) {
+          throw new ScopedQueryViolationError(
+            'GRAPH variables must appear at the top level of scoped local queries',
+          );
+        }
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
 }
 
 function hasNestedSelectWithGraphVariable(sparql: string): boolean {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -484,8 +484,6 @@ function hasCallerDatasetClause(sparql: string): boolean {
 }
 
 function assertExplicitGraphIrisAllowed(sparql: string, allowedGraphs: string[]): void {
-  assertNoUnvalidatedExplicitGraphTargets(sparql);
-
   const allowed = new Set(allowedGraphs);
   for (const graphIri of collectExplicitGraphIris(sparql)) {
     if (!allowed.has(graphIri)) {
@@ -496,7 +494,8 @@ function assertExplicitGraphIrisAllowed(sparql: string, allowedGraphs: string[])
   }
 }
 
-function assertNoUnvalidatedExplicitGraphTargets(sparql: string): void {
+function collectPrefixDeclarations(sparql: string): Map<string, string> {
+  const prefixes = new Map<string, string>();
   const n = sparql.length;
   let i = 0;
 
@@ -518,33 +517,120 @@ function assertNoUnvalidatedExplicitGraphTargets(sparql: string): void {
     if (isKeywordStart(sparql, i)) {
       let j = i + 1;
       while (j < n && isWordContinuation(sparql[j])) j++;
-      const word = sparql.slice(i, j);
-      if (isSparqlKeyword(sparql, i, j, 'GRAPH')) {
-        const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
-        const variable = readSparqlVariable(sparql, operandStart);
-        if (variable) {
-          i = operandStart + variable.length;
+      if (isSparqlKeyword(sparql, i, j, 'PREFIX')) {
+        const prefixStart = skipSparqlSpaceAndLineComments(sparql, j);
+        const prefix = readSparqlPrefixName(sparql, prefixStart);
+        if (!prefix || prefix.local.length > 0) {
+          i = j;
           continue;
         }
-        if (sparql[operandStart] === '<') {
-          const iriEnd = skipSparqlIriRef(sparql, operandStart);
-          if (!iriEnd) {
-            throw new ScopedQueryViolationError(
-              'GRAPH target must be a variable or explicit IRI on scoped queries',
-            );
-          }
+        const iriStart = skipSparqlSpaceAndLineComments(sparql, prefixStart + prefix.length);
+        const iriEnd = skipSparqlIriRef(sparql, iriStart);
+        if (iriEnd) {
+          prefixes.set(prefix.prefix, sparql.slice(iriStart + 1, iriEnd - 1));
           i = iriEnd;
           continue;
         }
-        throw new ScopedQueryViolationError(
-          'GRAPH target must be a variable or explicit IRI on scoped queries',
-        );
       }
       i = j;
       continue;
     }
     i++;
   }
+
+  return prefixes;
+}
+
+interface SparqlPrefixName {
+  prefix: string;
+  local: string;
+  length: number;
+}
+
+function readSparqlPrefixName(sparql: string, start: number): SparqlPrefixName | null {
+  let colon = start;
+  while (colon < sparql.length && isSparqlPrefixLabelChar(sparql[colon])) colon++;
+  if (sparql[colon] !== ':') return null;
+
+  let end = colon + 1;
+  while (end < sparql.length && isSparqlPrefixedLocalChar(sparql[end])) end++;
+
+  return {
+    prefix: sparql.slice(start, colon),
+    local: sparql.slice(colon + 1, end),
+    length: end - start,
+  };
+}
+
+function isSparqlPrefixLabelChar(ch: string | undefined): ch is string {
+  return !!ch && (
+    (ch >= 'A' && ch <= 'Z') ||
+    (ch >= 'a' && ch <= 'z') ||
+    (ch >= '0' && ch <= '9') ||
+    ch === '_' ||
+    ch === '-'
+  );
+}
+
+function isSparqlPrefixedLocalChar(ch: string | undefined): ch is string {
+  return !!ch && !/\s/.test(ch) && ch !== '{' && ch !== '}' && ch !== '(' && ch !== ')' && ch !== ';' && ch !== ',';
+}
+
+function resolveSparqlPrefixedName(
+  prefixedName: SparqlPrefixName,
+  prefixes: Map<string, string>,
+): string | null {
+  const base = prefixes.get(prefixedName.prefix);
+  if (base === undefined) return null;
+  return `${base}${prefixedName.local}`;
+}
+
+interface GraphTarget {
+  kind: 'variable' | 'iri';
+  iri?: string;
+  end: number;
+}
+
+function readGraphTarget(
+  sparql: string,
+  start: number,
+  prefixes: Map<string, string>,
+): GraphTarget | null {
+  const variable = readSparqlVariable(sparql, start);
+  if (variable) {
+    return { kind: 'variable', end: start + variable.length };
+  }
+
+  if (sparql[start] === '<') {
+    const iriEnd = skipSparqlIriRef(sparql, start);
+    if (!iriEnd) {
+      throw new ScopedQueryViolationError(
+        'GRAPH target must be a variable, explicit IRI, or resolvable prefixed name on scoped queries',
+      );
+    }
+    return {
+      kind: 'iri',
+      iri: sparql.slice(start + 1, iriEnd - 1),
+      end: iriEnd,
+    };
+  }
+
+  const prefixedName = readSparqlPrefixName(sparql, start);
+  if (prefixedName) {
+    const iri = resolveSparqlPrefixedName(prefixedName, prefixes);
+    if (!iri) {
+      throw new ScopedQueryViolationError(
+        `GRAPH prefixed target ${sparql.slice(start, start + prefixedName.length)} cannot be resolved from PREFIX declarations`,
+      );
+    }
+    return {
+      kind: 'iri',
+      iri,
+      end: start + prefixedName.length,
+    };
+  }
+
+  return null;
 }
 
 function constrainGraphVariablesToAllowedSet(sparql: string, allowedGraphs: string[]): string {
@@ -588,6 +674,7 @@ function hasTopLevelDefaultGraphPattern(sparql: string, braceStart: number): boo
   const braceEnd = findMatchingCloseBrace(sparql, braceStart);
   if (braceEnd === -1) return true;
 
+  const prefixes = collectPrefixDeclarations(sparql);
   let depth = 0;
   let i = braceStart + 1;
 
@@ -622,15 +709,8 @@ function hasTopLevelDefaultGraphPattern(sparql: string, braceStart: number): boo
       while (j < braceEnd && isWordContinuation(sparql[j])) j++;
       if (isSparqlKeyword(sparql, i, j, 'GRAPH')) {
         const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
-        const variable = readSparqlVariable(sparql, operandStart);
-        if (variable) {
-          i = operandStart + variable.length;
-          continue;
-        }
-        const iriEnd = sparql[operandStart] === '<'
-          ? skipSparqlIriRef(sparql, operandStart)
-          : null;
-        i = iriEnd && iriEnd <= braceEnd ? iriEnd : j;
+        const target = readGraphTarget(sparql, operandStart, prefixes);
+        i = target && target.end <= braceEnd ? target.end : j;
         continue;
       }
       if (isSparqlKeyword(sparql, i, j, 'FILTER') || isSparqlKeyword(sparql, i, j, 'BIND')) {
@@ -846,6 +926,7 @@ function rangeContainsGraphVariable(sparql: string, start: number, end: number):
 
 function collectExplicitGraphIris(sparql: string): string[] {
   const iris: string[] = [];
+  const prefixes = collectPrefixDeclarations(sparql);
   const n = sparql.length;
   let i = 0;
 
@@ -867,16 +948,17 @@ function collectExplicitGraphIris(sparql: string): string[] {
     if (isKeywordStart(sparql, i)) {
       let j = i + 1;
       while (j < n && isWordContinuation(sparql[j])) j++;
-      const word = sparql.slice(i, j);
       if (isSparqlKeyword(sparql, i, j, 'GRAPH')) {
         const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
-        if (sparql[operandStart] === '<') {
-          const operandEnd = skipSparqlIriRef(sparql, operandStart);
-          if (!operandEnd) return iris;
-          iris.push(sparql.slice(operandStart + 1, operandEnd - 1));
-          i = operandEnd;
-          continue;
+        const target = readGraphTarget(sparql, operandStart, prefixes);
+        if (!target) {
+          throw new ScopedQueryViolationError(
+            'GRAPH target must be a variable, explicit IRI, or resolvable prefixed name on scoped queries',
+          );
         }
+        if (target.kind === 'iri' && target.iri) iris.push(target.iri);
+        i = target.end;
+        continue;
       }
       i = j;
       continue;
@@ -885,6 +967,40 @@ function collectExplicitGraphIris(sparql: string): string[] {
   }
 
   return iris;
+}
+
+function hasGraphClause(sparql: string): boolean {
+  const n = sparql.length;
+  let i = 0;
+
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const end = skipSparqlIriRef(sparql, i);
+      i = end ?? i + 1;
+      continue;
+    }
+    if (isKeywordStart(sparql, i)) {
+      let j = i + 1;
+      while (j < n && isWordContinuation(sparql[j])) j++;
+      if (isSparqlKeyword(sparql, i, j, 'GRAPH')) {
+        return true;
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+
+  return false;
 }
 
 function collectGraphVariables(sparql: string): string[] {
@@ -1129,10 +1245,11 @@ function isWordStart(ch: string | undefined): ch is string {
 }
 
 function isWordContinuation(ch: string | undefined): ch is string {
-  return !!ch && (
-    isWordStart(ch) ||
-    (ch >= '0' && ch <= '9')
-  );
+  return isWordStart(ch) || isAsciiDigitChar(ch);
+}
+
+function isAsciiDigitChar(ch: string | undefined): ch is string {
+  return !!ch && ch >= '0' && ch <= '9';
 }
 
 /**
@@ -1583,7 +1700,7 @@ function findMatchingCloseBrace(sparql: string, openIdx: number): number {
  * If the query already uses GRAPH patterns, returns it unchanged.
  */
 function wrapWithGraph(sparql: string, graphUri: string): string {
-  if (sparql.toLowerCase().includes('graph ')) return sparql;
+  if (hasGraphClause(sparql)) return sparql;
 
   const braceStart = findWhereBraceStart(sparql);
   if (braceStart === -1) return sparql;
@@ -1626,7 +1743,7 @@ function wrapWithGraph(sparql: string, graphUri: string): string {
  * `GRAPH <uri>` block.
  */
 function wrapWithGraphUnion(sparql: string, graphUris: string[]): string {
-  if (sparql.toLowerCase().includes('graph ')) return sparql;
+  if (hasGraphClause(sparql)) return sparql;
   if (graphUris.length === 0) return sparql;
 
   const braceStart = findWhereBraceStart(sparql);

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -460,6 +460,12 @@ function assertExplicitGraphIrisAllowed(sparql: string, allowedGraphs: string[])
 }
 
 function constrainGraphVariablesToAllowedSet(sparql: string, allowedGraphs: string[]): string {
+  if (hasNestedSelectWithGraphVariable(sparql)) {
+    throw new ScopedQueryViolationError(
+      'GRAPH variables inside nested SELECT subqueries cannot be constrained safely',
+    );
+  }
+
   const graphVariables = collectGraphVariables(sparql);
   if (graphVariables.length === 0) return sparql;
 
@@ -480,6 +486,133 @@ function constrainGraphVariablesToAllowedSet(sparql: string, allowedGraphs: stri
   return `${sparql.slice(0, braceStart + 1)} ${constraints} ${sparql.slice(braceStart + 1)}`;
 }
 
+function hasNestedSelectWithGraphVariable(sparql: string): boolean {
+  const n = sparql.length;
+  let i = 0;
+  let braceDepth = 0;
+
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const end = skipSparqlIriRef(sparql, i);
+      i = end ?? i + 1;
+      continue;
+    }
+    if (ch === '{') {
+      braceDepth++;
+      i++;
+      continue;
+    }
+    if (ch === '}') {
+      braceDepth = Math.max(0, braceDepth - 1);
+      i++;
+      continue;
+    }
+    if (isKeywordStart(sparql, i)) {
+      let j = i + 1;
+      while (j < n && isWordContinuation(sparql[j])) j++;
+      const word = sparql.slice(i, j);
+      if (word.toUpperCase() === 'SELECT' && braceDepth > 0) {
+        const end = findNestedSelectEnd(sparql, j, braceDepth);
+        if (rangeContainsGraphVariable(sparql, j, end === -1 ? n : end)) {
+          return true;
+        }
+        i = end === -1 ? j : end + 1;
+        continue;
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+
+  return false;
+}
+
+function findNestedSelectEnd(sparql: string, start: number, startingDepth: number): number {
+  const n = sparql.length;
+  let depth = startingDepth;
+  let i = start;
+
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const end = skipSparqlIriRef(sparql, i);
+      i = end ?? i + 1;
+      continue;
+    }
+    if (ch === '{') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}') {
+      depth--;
+      if (depth < startingDepth) return i;
+      if (depth < 0) return -1;
+      i++;
+      continue;
+    }
+    i++;
+  }
+
+  return -1;
+}
+
+function rangeContainsGraphVariable(sparql: string, start: number, end: number): boolean {
+  const n = Math.min(sparql.length, end);
+  let i = start;
+
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const iriEnd = skipSparqlIriRef(sparql, i);
+      i = iriEnd && iriEnd <= n ? iriEnd : i + 1;
+      continue;
+    }
+    if (isKeywordStart(sparql, i)) {
+      let j = i + 1;
+      while (j < n && isWordContinuation(sparql[j])) j++;
+      const word = sparql.slice(i, j);
+      if (word.toUpperCase() === 'GRAPH') {
+        const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
+        if (operandStart < n && readSparqlVariable(sparql, operandStart)) {
+          return true;
+        }
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+
+  return false;
+}
+
 function collectExplicitGraphIris(sparql: string): string[] {
   const iris: string[] = [];
   const n = sparql.length;
@@ -496,9 +629,8 @@ function collectExplicitGraphIris(sparql: string): string[] {
       continue;
     }
     if (ch === '<') {
-      const end = sparql.indexOf('>', i + 1);
-      if (end === -1) return iris;
-      i = end + 1;
+      const end = skipSparqlIriRef(sparql, i);
+      i = end ?? i + 1;
       continue;
     }
     if (isKeywordStart(sparql, i)) {
@@ -541,9 +673,8 @@ function collectGraphVariables(sparql: string): string[] {
       continue;
     }
     if (ch === '<') {
-      const end = sparql.indexOf('>', i + 1);
-      if (end === -1) return variables;
-      i = end + 1;
+      const end = skipSparqlIriRef(sparql, i);
+      i = end ?? i + 1;
       continue;
     }
     if (isKeywordStart(sparql, i)) {
@@ -567,6 +698,43 @@ function collectGraphVariables(sparql: string): string[] {
   }
 
   return variables;
+}
+
+function skipSparqlIriRef(sparql: string, start: number): number | null {
+  if (sparql[start] !== '<') return null;
+  const next = sparql[start + 1];
+  if (!isLikelyIriRefStart(next)) return null;
+
+  for (let i = start + 1; i < sparql.length; i++) {
+    const ch = sparql[i];
+    if (ch === '>') return i + 1;
+    if (
+      ch === '<' ||
+      ch === '"' ||
+      ch === '{' ||
+      ch === '}' ||
+      ch === '|' ||
+      ch === '\\' ||
+      ch === '^' ||
+      ch === '`' ||
+      /\s/.test(ch)
+    ) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function isLikelyIriRefStart(ch: string | undefined): boolean {
+  return !!ch && (
+    (ch >= 'A' && ch <= 'Z') ||
+    (ch >= 'a' && ch <= 'z') ||
+    ch === '#' ||
+    ch === '_' ||
+    ch === '/' ||
+    ch === '.'
+  );
 }
 
 function readSparqlVariable(sparql: string, start: number): string | null {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -471,7 +471,7 @@ function hasCallerDatasetClause(sparql: string): boolean {
     if (isKeywordStart(sparql, i)) {
       let j = i + 1;
       while (j < n && isWordContinuation(sparql[j])) j++;
-      if (sparql.slice(i, j).toUpperCase() === 'FROM' && sparql[j] !== ':') {
+      if (isSparqlKeyword(sparql, i, j, 'FROM')) {
         return true;
       }
       i = j;
@@ -519,7 +519,7 @@ function assertNoUnvalidatedExplicitGraphTargets(sparql: string): void {
       let j = i + 1;
       while (j < n && isWordContinuation(sparql[j])) j++;
       const word = sparql.slice(i, j);
-      if (word.toUpperCase() === 'GRAPH') {
+      if (isSparqlKeyword(sparql, i, j, 'GRAPH')) {
         const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
         const variable = readSparqlVariable(sparql, operandStart);
         if (variable) {
@@ -608,7 +608,7 @@ function hasNestedSelectWithGraphVariable(sparql: string): boolean {
       let j = i + 1;
       while (j < n && isWordContinuation(sparql[j])) j++;
       const word = sparql.slice(i, j);
-      if (word.toUpperCase() === 'SELECT' && braceDepth > 0) {
+      if (isSparqlKeyword(sparql, i, j, 'SELECT') && braceDepth > 0) {
         const end = findNestedSelectEnd(sparql, j, braceDepth);
         if (rangeContainsGraphVariable(sparql, j, end === -1 ? n : end)) {
           return true;
@@ -686,7 +686,7 @@ function rangeContainsGraphVariable(sparql: string, start: number, end: number):
       let j = i + 1;
       while (j < n && isWordContinuation(sparql[j])) j++;
       const word = sparql.slice(i, j);
-      if (word.toUpperCase() === 'GRAPH') {
+      if (isSparqlKeyword(sparql, i, j, 'GRAPH')) {
         const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
         if (operandStart < n && readSparqlVariable(sparql, operandStart)) {
           return true;
@@ -725,7 +725,7 @@ function collectExplicitGraphIris(sparql: string): string[] {
       let j = i + 1;
       while (j < n && isWordContinuation(sparql[j])) j++;
       const word = sparql.slice(i, j);
-      if (word.toUpperCase() === 'GRAPH') {
+      if (isSparqlKeyword(sparql, i, j, 'GRAPH')) {
         const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
         if (sparql[operandStart] === '<') {
           const operandEnd = skipSparqlIriRef(sparql, operandStart);
@@ -769,7 +769,7 @@ function collectGraphVariables(sparql: string): string[] {
       let j = i + 1;
       while (j < n && isWordContinuation(sparql[j])) j++;
       const word = sparql.slice(i, j);
-      if (word.toUpperCase() === 'GRAPH') {
+      if (isSparqlKeyword(sparql, i, j, 'GRAPH')) {
         const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
         const variable = readSparqlVariable(sparql, operandStart);
         if (variable && !seen.has(variable)) {
@@ -914,6 +914,10 @@ function isKeywordStart(src: string, idx: number): boolean {
   if (!isWordStart(ch)) return false;
   const prev = idx > 0 ? src[idx - 1] : '';
   return !prev || (!isWordContinuation(prev) && prev !== '?' && prev !== '$' && prev !== ':' && prev !== '#');
+}
+
+function isSparqlKeyword(src: string, start: number, end: number, keyword: string): boolean {
+  return src.slice(start, end).toUpperCase() === keyword && src[end] !== ':';
 }
 
 function isWordStart(ch: string | undefined): ch is string {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -564,6 +564,7 @@ function constrainGraphVariablesToAllowedSet(sparql: string, allowedGraphs: stri
     );
   }
   assertGraphVariablesAreTopLevel(sparql, braceStart);
+  assertNoTopLevelDefaultGraphPatternsWithGraphVariables(sparql, braceStart);
 
   const values = allowedGraphs
     .map((g) => `<${assertSafeIri(g)}>`)
@@ -573,6 +574,93 @@ function constrainGraphVariablesToAllowedSet(sparql: string, allowedGraphs: stri
     .join(' ');
 
   return `${sparql.slice(0, braceStart + 1)} ${constraints} ${sparql.slice(braceStart + 1)}`;
+}
+
+function assertNoTopLevelDefaultGraphPatternsWithGraphVariables(sparql: string, braceStart: number): void {
+  if (!hasTopLevelDefaultGraphPattern(sparql, braceStart)) return;
+
+  throw new ScopedQueryViolationError(
+    'GRAPH variables cannot be mixed with default-graph triple patterns on scoped local queries',
+  );
+}
+
+function hasTopLevelDefaultGraphPattern(sparql: string, braceStart: number): boolean {
+  const braceEnd = findMatchingCloseBrace(sparql, braceStart);
+  if (braceEnd === -1) return true;
+
+  let depth = 0;
+  let i = braceStart + 1;
+
+  while (i < braceEnd) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < braceEnd && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '{') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}') {
+      depth = Math.max(0, depth - 1);
+      i++;
+      continue;
+    }
+    if (depth !== 0 || /\s/.test(ch) || ch === '.' || ch === ';' || ch === ',') {
+      i++;
+      continue;
+    }
+    if (ch === '<') return !!skipSparqlIriRef(sparql, i);
+    if (ch === '?' || ch === '$' || ch === '[') return true;
+    if (isKeywordStart(sparql, i)) {
+      let j = i + 1;
+      while (j < braceEnd && isWordContinuation(sparql[j])) j++;
+      if (isSparqlKeyword(sparql, i, j, 'GRAPH')) {
+        const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
+        const variable = readSparqlVariable(sparql, operandStart);
+        if (variable) {
+          i = operandStart + variable.length;
+          continue;
+        }
+        const iriEnd = sparql[operandStart] === '<'
+          ? skipSparqlIriRef(sparql, operandStart)
+          : null;
+        i = iriEnd && iriEnd <= braceEnd ? iriEnd : j;
+        continue;
+      }
+      if (isSparqlKeyword(sparql, i, j, 'FILTER') || isSparqlKeyword(sparql, i, j, 'BIND')) {
+        const exprStart = skipSparqlSpaceAndLineComments(sparql, j);
+        if (sparql[exprStart] === '(') {
+          const exprEnd = skipBalancedParentheses(sparql, exprStart, braceEnd);
+          i = exprEnd ?? j;
+          continue;
+        }
+      }
+      if (isSparqlKeyword(sparql, i, j, 'VALUES')) {
+        i = skipValuesClause(sparql, j, braceEnd);
+        continue;
+      }
+      if (
+        isSparqlKeyword(sparql, i, j, 'OPTIONAL') ||
+        isSparqlKeyword(sparql, i, j, 'MINUS') ||
+        isSparqlKeyword(sparql, i, j, 'SERVICE') ||
+        isSparqlKeyword(sparql, i, j, 'UNION') ||
+        isSparqlKeyword(sparql, i, j, 'SELECT')
+      ) {
+        i = j;
+        continue;
+      }
+      return true;
+    }
+    i++;
+  }
+
+  return false;
 }
 
 function assertGraphVariablesAreTopLevel(sparql: string, braceStart: number): void {
@@ -960,6 +1048,59 @@ function skipSparqlSpaceAndLineComments(sparql: string, start: number): number {
       continue;
     }
     break;
+  }
+  return i;
+}
+
+function skipBalancedParentheses(sparql: string, start: number, limit = sparql.length): number | null {
+  if (sparql[start] !== '(') return null;
+  let depth = 1;
+  let i = start + 1;
+
+  while (i < limit) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < limit && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const iriEnd = skipSparqlIriRef(sparql, i);
+      i = iriEnd && iriEnd <= limit ? iriEnd : i + 1;
+      continue;
+    }
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+    i++;
+  }
+
+  return null;
+}
+
+function skipValuesClause(sparql: string, start: number, limit: number): number {
+  let i = start;
+  while (i < limit) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < limit && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '{') {
+      const end = findMatchingCloseBrace(sparql, i);
+      return end === -1 || end > limit ? i : end + 1;
+    }
+    if (ch === '.') return i + 1;
+    i++;
   }
   return i;
 }

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -14,7 +14,6 @@ import {
   validateReadOnlySparql,
   emptyResultForSparql,
 } from './sparql-guard.js';
-import { stripLiteralsAndComments } from './sparql-utils.js';
 
 /**
  * Result of resolving a V10 GET view to concrete graph targets.
@@ -443,12 +442,45 @@ export class DKGQueryEngine implements QueryEngine {
 }
 
 function assertNoCallerDatasetClauses(sparql: string): void {
-  const code = stripLiteralsAndComments(sparql);
-  if (/\bFROM\s+(?:NAMED\s+)?/i.test(code)) {
+  if (hasCallerDatasetClause(sparql)) {
     throw new ScopedQueryViolationError(
       'FROM clauses are not allowed on scoped local queries',
     );
   }
+}
+
+function hasCallerDatasetClause(sparql: string): boolean {
+  const n = sparql.length;
+  let i = 0;
+
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      const end = skipSparqlIriRef(sparql, i);
+      i = end ?? i + 1;
+      continue;
+    }
+    if (isKeywordStart(sparql, i)) {
+      let j = i + 1;
+      while (j < n && isWordContinuation(sparql[j])) j++;
+      if (sparql.slice(i, j).toUpperCase() === 'FROM') {
+        return true;
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+
+  return false;
 }
 
 function assertExplicitGraphIrisAllowed(sparql: string, allowedGraphs: string[]): void {
@@ -642,11 +674,11 @@ function collectExplicitGraphIris(sparql: string): string[] {
       const word = sparql.slice(i, j);
       if (word.toUpperCase() === 'GRAPH') {
         const operandStart = skipSparqlSpaceAndLineComments(sparql, j);
-        if (operandStart > j && sparql[operandStart] === '<') {
-          const operandEnd = sparql.indexOf('>', operandStart + 1);
-          if (operandEnd === -1) return iris;
-          iris.push(sparql.slice(operandStart + 1, operandEnd));
-          i = operandEnd + 1;
+        if (sparql[operandStart] === '<') {
+          const operandEnd = skipSparqlIriRef(sparql, operandStart);
+          if (!operandEnd) return iris;
+          iris.push(sparql.slice(operandStart + 1, operandEnd - 1));
+          i = operandEnd;
           continue;
         }
       }

--- a/packages/query/src/query-handler.ts
+++ b/packages/query/src/query-handler.ts
@@ -289,7 +289,7 @@ export class QueryHandler {
       return errorResponse(opId, 'ERROR', 'Explicit GRAPH clauses are not allowed in remote queries — queries are automatically scoped to the target context graph');
     }
 
-    if (/\bFROM\s+/i.test(stripped)) {
+    if (/\bFROM(?:\s+|(?=<))/i.test(stripped)) {
       return errorResponse(opId, 'ERROR', 'FROM/FROM NAMED clauses are not allowed in remote queries — queries are automatically scoped to the target context graph');
     }
 

--- a/packages/query/src/query-handler.ts
+++ b/packages/query/src/query-handler.ts
@@ -285,7 +285,7 @@ export class QueryHandler {
       return errorResponse(opId, 'ERROR', 'SERVICE clauses are not allowed in remote queries');
     }
 
-    if (/\bGRAPH\s+/i.test(stripped)) {
+    if (/\bGRAPH(?:\s+|(?=[?$<]))/i.test(stripped)) {
       return errorResponse(opId, 'ERROR', 'Explicit GRAPH clauses are not allowed in remote queries — queries are automatically scoped to the target context graph');
     }
 

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -310,6 +310,24 @@ describe('DKGQueryEngine', () => {
     )).resolves.toMatchObject({ bindings: expect.any(Array) });
   });
 
+  it('allows scoped queries with hyphenated graph/from prefix labels', async () => {
+    await store.insert([
+      q(ENTITY, 'http://example.com/name', '"HyphenatedPrefixPredicate"'),
+    ]);
+
+    await expect(engine.query(
+      `PREFIX graph-viz: <http://example.com/>
+       SELECT ?name WHERE { ?s graph-viz:name ?name }`,
+      { contextGraphId: CONTEXT_GRAPH },
+    )).resolves.toMatchObject({ bindings: expect.any(Array) });
+
+    await expect(engine.query(
+      `PREFIX from-schema: <http://example.com/>
+       SELECT ?name WHERE { ?s from-schema:name ?name }`,
+      { contextGraphId: CONTEXT_GRAPH },
+    )).resolves.toMatchObject({ bindings: expect.any(Array) });
+  });
+
   it('rejects explicit GRAPH IRIs outside the scoped context graph', async () => {
     const otherGraph = 'did:dkg:context-graph:other-agent-registry';
     await store.insert([

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -498,6 +498,20 @@ describe('DKGQueryEngine', () => {
       ),
     ).rejects.toThrow(/Scoped query violation: GRAPH variables inside nested SELECT subqueries/i);
   });
+
+  it('rejects optional GRAPH-variable patterns instead of changing OPTIONAL semantics', async () => {
+    await expect(
+      engine.query(
+        `SELECT ?name ?g ?nickname WHERE {
+          ?s <http://schema.org/name> ?name
+          OPTIONAL {
+            GRAPH ?g { ?s <http://schema.org/alternateName> ?nickname }
+          }
+        }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: GRAPH variables must appear at the top level/i);
+  });
 });
 
 describe('validateReadOnlySparql', () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -386,6 +386,18 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings[0]['name']).toBe('"ImageBot"');
   });
 
+  it('rejects mixed GRAPH-variable and default-graph triple patterns', async () => {
+    await expect(
+      engine.query(
+        `SELECT ?g ?name ?description WHERE {
+          GRAPH ?g { ?s <http://schema.org/name> ?name }
+          ?s <http://schema.org/description> ?description
+        }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: GRAPH variables cannot be mixed with default-graph triple patterns/i);
+  });
+
   it('constrains GRAPH variables with non-ASCII names to the scoped context graph data graph', async () => {
     await store.insert([
       q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -338,6 +338,46 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings.map((row) => row['name'])).toEqual(['"Team Data"', '"Team Workspace"']);
     expect(result.bindings.map((row) => row['g']).sort()).toEqual([subGraph, subGraphSharedMemory].sort());
   });
+
+  it('rejects nested subqueries that would keep GRAPH variables outside the scoped binding', async () => {
+    await store.insert([
+      q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),
+    ]);
+
+    await expect(
+      engine.query(
+        `SELECT ?name WHERE {
+          {
+            SELECT ?name WHERE {
+              GRAPH ?g { ?s <http://schema.org/name> ?name }
+            }
+          }
+        }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: GRAPH variables inside nested SELECT subqueries/i);
+  });
+
+  it('rejects nested GRAPH-variable subqueries even when comparison syntax appears before GRAPH', async () => {
+    await store.insert([
+      q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),
+    ]);
+
+    await expect(
+      engine.query(
+        `SELECT ?name WHERE {
+          {
+            SELECT ?name WHERE {
+              BIND(1 AS ?score)
+              FILTER(?score < 10)
+              GRAPH ?g { ?s <http://schema.org/name> ?name }
+            }
+          }
+        }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: GRAPH variables inside nested SELECT subqueries/i);
+  });
 });
 
 describe('validateReadOnlySparql', () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -285,6 +285,21 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings[0]['name']).toBe('"ImageBot"');
   });
 
+  it('constrains GRAPH variables with non-ASCII names to the scoped context graph data graph', async () => {
+    await store.insert([
+      q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?name WHERE { GRAPH ?é { ?s <http://schema.org/name> ?name } } ORDER BY ?name',
+      { contextGraphId: CONTEXT_GRAPH },
+    );
+
+    expect(result.bindings).toEqual([
+      { name: '"ImageBot"' },
+    ]);
+  });
+
   it('constrains GRAPH variables to data and shared memory for includeSharedMemory', async () => {
     const sharedMemoryGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;
     await store.insert([

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -256,6 +256,36 @@ describe('DKGQueryEngine', () => {
     ).rejects.toThrow(/Scoped query violation: FROM clauses are not allowed/i);
   });
 
+  it('rejects compact FROM clauses on context-graph-scoped local queries', async () => {
+    await expect(
+      engine.query(
+        `SELECT ?name FROM<${GRAPH}> WHERE { ?s <http://schema.org/name> ?name }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: FROM clauses are not allowed/i);
+  });
+
+  it('rejects compact FROM NAMED clauses on context-graph-scoped local queries', async () => {
+    await expect(
+      engine.query(
+        `SELECT ?name FROM NAMED<${GRAPH}> WHERE { GRAPH ?g { ?s <http://schema.org/name> ?name } }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: FROM clauses are not allowed/i);
+  });
+
+  it('allows scoped queries with prefixed names that contain FROM', async () => {
+    await store.insert([
+      q(ENTITY, 'http://example.com/from', '"FromPredicate"'),
+    ]);
+
+    await expect(engine.query(
+      `PREFIX ex: <http://example.com/>
+       SELECT ?name WHERE { ?s ex:from ?name }`,
+      { contextGraphId: CONTEXT_GRAPH },
+    )).resolves.toMatchObject({ bindings: expect.any(Array) });
+  });
+
   it('rejects explicit GRAPH IRIs outside the scoped context graph', async () => {
     const otherGraph = 'did:dkg:context-graph:other-agent-registry';
     await store.insert([
@@ -265,6 +295,20 @@ describe('DKGQueryEngine', () => {
     await expect(
       engine.query(
         `SELECT ?name WHERE { GRAPH <${otherGraph}> { ?s <http://schema.org/name> ?name } }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: GRAPH <did:dkg:context-graph:other-agent-registry> is outside the allowed graph set/i);
+  });
+
+  it('rejects compact explicit GRAPH IRIs outside the scoped context graph', async () => {
+    const otherGraph = 'did:dkg:context-graph:other-agent-registry';
+    await store.insert([
+      q('urn:secret:entity', 'http://schema.org/name', '"Secret"', otherGraph),
+    ]);
+
+    await expect(
+      engine.query(
+        `SELECT ?name WHERE { GRAPH<${otherGraph}> { ?s <http://schema.org/name> ?name } }`,
         { contextGraphId: CONTEXT_GRAPH },
       ),
     ).rejects.toThrow(/Scoped query violation: GRAPH <did:dkg:context-graph:other-agent-registry> is outside the allowed graph set/i);

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -206,6 +206,40 @@ describe('DKGQueryEngine', () => {
     expect(names).toContain('"Quorum Verified"');
   });
 
+  it('view=verified-memory constrains compact GRAPH variables without duplicating multi-graph rows', async () => {
+    const vmGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_verified_memory/quorum-1`;
+    await store.insert([
+      q('urn:vm:entity:1', 'http://schema.org/name', '"Quorum Verified"', vmGraph),
+      q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?g ?name WHERE { GRAPH?g { ?s <http://schema.org/name> ?name } } ORDER BY ?name',
+      { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+    );
+
+    expect(result.bindings).toEqual([
+      { g: GRAPH, name: '"ImageBot"' },
+      { g: vmGraph, name: '"Quorum Verified"' },
+    ]);
+  });
+
+  it('view=verified-memory honors compact explicit GRAPH IRIs without duplicating multi-graph rows', async () => {
+    const vmGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_verified_memory/quorum-1`;
+    await store.insert([
+      q('urn:vm:entity:1', 'http://schema.org/name', '"Quorum Verified"', vmGraph),
+    ]);
+
+    const result = await engine.query(
+      `SELECT ?name WHERE { GRAPH<${vmGraph}> { ?s <http://schema.org/name> ?name } }`,
+      { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+    );
+
+    expect(result.bindings).toEqual([
+      { name: '"Quorum Verified"' },
+    ]);
+  });
+
   it('view=verified-memory with verifiedGraph scopes to that graph only', async () => {
     const vmGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_verified_memory/team-a`;
     await store.insert([
@@ -356,7 +390,19 @@ describe('DKGQueryEngine', () => {
     ).rejects.toThrow(/Scoped query violation: GRAPH <did:dkg:context-graph:other-agent-registry> is outside the allowed graph set/i);
   });
 
-  it('rejects prefixed explicit GRAPH targets that cannot be validated against the scoped graph set', async () => {
+  it('allows prefixed explicit GRAPH targets that resolve to the scoped graph', async () => {
+    const result = await engine.query(
+      `PREFIX cg: <did:dkg:context-graph:>
+       SELECT ?name WHERE { GRAPH cg:${CONTEXT_GRAPH} { ?s <http://schema.org/name> ?name } }`,
+      { contextGraphId: CONTEXT_GRAPH },
+    );
+
+    expect(result.bindings).toEqual([
+      { name: '"ImageBot"' },
+    ]);
+  });
+
+  it('rejects prefixed explicit GRAPH targets outside the scoped graph set', async () => {
     const otherGraph = 'did:dkg:context-graph:other-agent-registry';
     await store.insert([
       q('urn:secret:entity', 'http://schema.org/name', '"Secret"', otherGraph),
@@ -368,7 +414,35 @@ describe('DKGQueryEngine', () => {
          SELECT ?name WHERE { GRAPH other: { ?s <http://schema.org/name> ?name } }`,
         { contextGraphId: CONTEXT_GRAPH },
       ),
-    ).rejects.toThrow(/Scoped query violation: GRAPH target must be a variable or explicit IRI/i);
+    ).rejects.toThrow(/Scoped query violation: GRAPH <did:dkg:context-graph:other-agent-registry> is outside the allowed graph set/i);
+  });
+
+  it('rejects unresolved prefixed GRAPH targets fail-closed', async () => {
+    await expect(
+      engine.query(
+        `SELECT ?name WHERE { GRAPH missing:allowed { ?s <http://schema.org/name> ?name } }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: GRAPH prefixed target missing:allowed cannot be resolved/i);
+  });
+
+  it('allows prefixed explicit GRAPH targets alongside constrained GRAPH variables', async () => {
+    await store.insert([
+      q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),
+    ]);
+
+    const result = await engine.query(
+      `PREFIX cg: <did:dkg:context-graph:>
+       SELECT ?g ?name ?sameName WHERE {
+         GRAPH ?g { ?s <http://schema.org/name> ?name }
+         GRAPH cg:${CONTEXT_GRAPH} { ?s <http://schema.org/name> ?sameName }
+       }`,
+      { contextGraphId: CONTEXT_GRAPH },
+    );
+
+    expect(result.bindings).toEqual([
+      { g: GRAPH, name: '"ImageBot"', sameName: '"ImageBot"' },
+    ]);
   });
 
   it('constrains GRAPH variables to the scoped context graph data graph', async () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -298,6 +298,18 @@ describe('DKGQueryEngine', () => {
     )).resolves.toMatchObject({ bindings: expect.any(Array) });
   });
 
+  it('allows scoped queries with a prefix label named graph', async () => {
+    await store.insert([
+      q(ENTITY, 'http://example.com/name', '"GraphPrefixPredicate"'),
+    ]);
+
+    await expect(engine.query(
+      `PREFIX graph: <http://example.com/>
+       SELECT ?name WHERE { ?s graph:name ?name }`,
+      { contextGraphId: CONTEXT_GRAPH },
+    )).resolves.toMatchObject({ bindings: expect.any(Array) });
+  });
+
   it('rejects explicit GRAPH IRIs outside the scoped context graph', async () => {
     const otherGraph = 'did:dkg:context-graph:other-agent-registry';
     await store.insert([

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -354,6 +354,28 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings.map((row) => row['g']).sort()).toEqual([subGraph, subGraphSharedMemory].sort());
   });
 
+  it('constrains outer shorthand GRAPH variables after a nested SELECT WHERE', async () => {
+    await store.insert([
+      q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),
+    ]);
+
+    const result = await engine.query(
+      `SELECT ?g ?name {
+        {
+          SELECT ?x WHERE {
+            BIND("keep" AS ?x)
+          }
+        }
+        GRAPH ?g { ?s <http://schema.org/name> ?name }
+      } ORDER BY ?name`,
+      { contextGraphId: CONTEXT_GRAPH },
+    );
+
+    expect(result.bindings).toEqual([
+      { g: GRAPH, name: '"ImageBot"' },
+    ]);
+  });
+
   it('rejects nested subqueries that would keep GRAPH variables outside the scoped binding', async () => {
     await store.insert([
       q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -326,6 +326,21 @@ describe('DKGQueryEngine', () => {
     ).rejects.toThrow(/Scoped query violation: GRAPH <did:dkg:context-graph:other-agent-registry> is outside the allowed graph set/i);
   });
 
+  it('rejects prefixed explicit GRAPH targets that cannot be validated against the scoped graph set', async () => {
+    const otherGraph = 'did:dkg:context-graph:other-agent-registry';
+    await store.insert([
+      q('urn:secret:entity', 'http://schema.org/name', '"Secret"', otherGraph),
+    ]);
+
+    await expect(
+      engine.query(
+        `PREFIX other: <${otherGraph}>
+         SELECT ?name WHERE { GRAPH other: { ?s <http://schema.org/name> ?name } }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: GRAPH target must be a variable or explicit IRI/i);
+  });
+
   it('constrains GRAPH variables to the scoped context graph data graph', async () => {
     await store.insert([
       q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -269,6 +269,21 @@ describe('DKGQueryEngine', () => {
       ),
     ).rejects.toThrow(/Scoped query violation: GRAPH <did:dkg:context-graph:other-agent-registry> is outside the allowed graph set/i);
   });
+
+  it('constrains GRAPH variables to the scoped context graph data graph', async () => {
+    await store.insert([
+      q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?g ?name WHERE { GRAPH ?g { ?s <http://schema.org/name> ?name } } ORDER BY ?name',
+      { contextGraphId: CONTEXT_GRAPH },
+    );
+
+    expect(result.bindings).toHaveLength(1);
+    expect(result.bindings[0]['g']).toBe(GRAPH);
+    expect(result.bindings[0]['name']).toBe('"ImageBot"');
+  });
 });
 
 describe('validateReadOnlySparql', () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -255,6 +255,20 @@ describe('DKGQueryEngine', () => {
       ),
     ).rejects.toThrow(/Scoped query violation: FROM clauses are not allowed/i);
   });
+
+  it('rejects explicit GRAPH IRIs outside the scoped context graph', async () => {
+    const otherGraph = 'did:dkg:context-graph:other-agent-registry';
+    await store.insert([
+      q('urn:secret:entity', 'http://schema.org/name', '"Secret"', otherGraph),
+    ]);
+
+    await expect(
+      engine.query(
+        `SELECT ?name WHERE { GRAPH <${otherGraph}> { ?s <http://schema.org/name> ?name } }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: GRAPH <did:dkg:context-graph:other-agent-registry> is outside the allowed graph set/i);
+  });
 });
 
 describe('validateReadOnlySparql', () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -246,6 +246,15 @@ describe('DKGQueryEngine', () => {
       engine.query('SELECT ?s WHERE { ?s ?p ?o }', { view: 'verified-memory' }),
     ).rejects.toThrow('requires a contextGraphId');
   });
+
+  it('rejects FROM clauses on context-graph-scoped local queries', async () => {
+    await expect(
+      engine.query(
+        `SELECT ?name FROM <${GRAPH}> WHERE { ?s <http://schema.org/name> ?name }`,
+        { contextGraphId: CONTEXT_GRAPH },
+      ),
+    ).rejects.toThrow(/Scoped query violation: FROM clauses are not allowed/i);
+  });
 });
 
 describe('validateReadOnlySparql', () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -286,6 +286,18 @@ describe('DKGQueryEngine', () => {
     )).resolves.toMatchObject({ bindings: expect.any(Array) });
   });
 
+  it('allows scoped queries with a prefix label named from', async () => {
+    await store.insert([
+      q(ENTITY, 'http://example.com/name', '"FromPrefixPredicate"'),
+    ]);
+
+    await expect(engine.query(
+      `PREFIX from: <http://example.com/>
+       SELECT ?name WHERE { ?s from:name ?name }`,
+      { contextGraphId: CONTEXT_GRAPH },
+    )).resolves.toMatchObject({ bindings: expect.any(Array) });
+  });
+
   it('rejects explicit GRAPH IRIs outside the scoped context graph', async () => {
     const otherGraph = 'did:dkg:context-graph:other-agent-registry';
     await store.insert([

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -318,6 +318,26 @@ describe('DKGQueryEngine', () => {
       { g: sharedMemoryGraph, name: '"Workspace Only"' },
     ]);
   });
+
+  it('constrains GRAPH variables to the requested legacy sub-graph and shared memory graph', async () => {
+    const subGraphName = 'team-a';
+    const subGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/${subGraphName}`;
+    const subGraphSharedMemory = `did:dkg:context-graph:${CONTEXT_GRAPH}/${subGraphName}/_shared_memory`;
+    await store.insert([
+      q('urn:team:entity', 'http://schema.org/name', '"Team Data"', subGraph),
+      q('urn:team:ws', 'http://schema.org/name', '"Team Workspace"', subGraphSharedMemory),
+      q('urn:other-team:entity', 'http://schema.org/name', '"Other Team"', `did:dkg:context-graph:${CONTEXT_GRAPH}/team-b`),
+      q('urn:other-team:ws', 'http://schema.org/name', '"Other Team Workspace"', `did:dkg:context-graph:${CONTEXT_GRAPH}/team-b/_shared_memory`),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?g ?name WHERE { GRAPH ?g { ?s <http://schema.org/name> ?name } } ORDER BY ?name',
+      { contextGraphId: CONTEXT_GRAPH, subGraphName, includeSharedMemory: true },
+    );
+
+    expect(result.bindings.map((row) => row['name'])).toEqual(['"Team Data"', '"Team Workspace"']);
+    expect(result.bindings.map((row) => row['g']).sort()).toEqual([subGraph, subGraphSharedMemory].sort());
+  });
 });
 
 describe('validateReadOnlySparql', () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -284,6 +284,23 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings[0]['g']).toBe(GRAPH);
     expect(result.bindings[0]['name']).toBe('"ImageBot"');
   });
+
+  it('constrains GRAPH variables to data and shared memory for includeSharedMemory', async () => {
+    const sharedMemoryGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;
+    await store.insert([
+      q('urn:ws:entity:1', 'http://schema.org/name', '"Workspace Only"', sharedMemoryGraph),
+      q('urn:other:entity', 'http://schema.org/name', '"OtherGraph"', 'did:dkg:context-graph:other-agent-registry'),
+      q('urn:other:ws', 'http://schema.org/name', '"OtherWorkspace"', 'did:dkg:context-graph:other-agent-registry/_shared_memory'),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?g ?name WHERE { GRAPH ?g { ?s <http://schema.org/name> ?name } } ORDER BY ?name',
+      { contextGraphId: CONTEXT_GRAPH, includeSharedMemory: true },
+    );
+
+    expect(result.bindings.map((row) => row['name'])).toEqual(['"ImageBot"', '"Workspace Only"']);
+    expect(result.bindings.map((row) => row['g']).sort()).toEqual([GRAPH, sharedMemoryGraph].sort());
+  });
 });
 
 describe('validateReadOnlySparql', () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -301,6 +301,23 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings.map((row) => row['name'])).toEqual(['"ImageBot"', '"Workspace Only"']);
     expect(result.bindings.map((row) => row['g']).sort()).toEqual([GRAPH, sharedMemoryGraph].sort());
   });
+
+  it('constrains GRAPH variables to shared memory when graphSuffix is _shared_memory', async () => {
+    const sharedMemoryGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;
+    await store.insert([
+      q('urn:ws:entity:1', 'http://schema.org/name', '"Workspace Only"', sharedMemoryGraph),
+      q('urn:other:ws', 'http://schema.org/name', '"OtherWorkspace"', 'did:dkg:context-graph:other-agent-registry/_shared_memory'),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?g ?name WHERE { GRAPH ?g { ?s <http://schema.org/name> ?name } } ORDER BY ?name',
+      { contextGraphId: CONTEXT_GRAPH, graphSuffix: '_shared_memory' },
+    );
+
+    expect(result.bindings).toEqual([
+      { g: sharedMemoryGraph, name: '"Workspace Only"' },
+    ]);
+  });
 });
 
 describe('validateReadOnlySparql', () => {

--- a/packages/query/test/query-extra.test.ts
+++ b/packages/query/test/query-extra.test.ts
@@ -704,6 +704,24 @@ describe('DKGQueryEngine view routing constrains GRAPH variables', () => {
 
     expect(result.bindings.map((b) => b['name'])).toEqual(['"Mine"']);
   });
+
+  it('verified-memory minTrust with GRAPH ?g fails closed instead of returning trusted data', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const graph = contextGraphVerifiedMemoryUri(CG, 'trusted-graph-pattern');
+
+    await store.insert([
+      quad('urn:view:trusted', 'http://schema.org/name', '"Trusted"', graph),
+      quad('urn:view:trusted', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, graph),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?g ?name WHERE { GRAPH ?g { ?s <http://schema.org/name> ?name } }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.Endorsed },
+    );
+
+    expect(result.bindings).toEqual([]);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/query/test/query-extra.test.ts
+++ b/packages/query/test/query-extra.test.ts
@@ -651,6 +651,27 @@ describe('[Q-3] resolveViewGraphs + DKGQueryEngine route working-memory', () => 
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// View routing constrains caller GRAPH variables to the selected View
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DKGQueryEngine view routing constrains GRAPH variables', () => {
+  it('verified-memory with GRAPH ?g does not read SWM-only data', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+
+    await store.insert([
+      quad('urn:view:swm-only', 'http://schema.org/name', '"SwmOnly"', contextGraphSharedMemoryUri(CG)),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?g ?name WHERE { GRAPH ?g { ?s <http://schema.org/name> ?name } }',
+      { contextGraphId: CG, view: 'verified-memory' },
+    );
+
+    expect(result.bindings).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Q-4  QueryHandler.executeSparql timeout → GAS_LIMIT_EXCEEDED
 // ─────────────────────────────────────────────────────────────────────────────
 describe('[Q-4] QueryHandler executeSparql hits the timeout path', () => {

--- a/packages/query/test/query-extra.test.ts
+++ b/packages/query/test/query-extra.test.ts
@@ -685,6 +685,25 @@ describe('DKGQueryEngine view routing constrains GRAPH variables', () => {
 
     expect(result.bindings).toEqual([]);
   });
+
+  it('working-memory with GRAPH ?g does not read another agent assertion', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const agent = '0xAbC0000000000000000000000000000000000001';
+    const otherAgent = '0xDeAd000000000000000000000000000000000002';
+
+    await store.insert([
+      quad('urn:view:mine', 'http://schema.org/name', '"Mine"', contextGraphAssertionUri(CG, agent, 'mine')),
+      quad('urn:view:theirs', 'http://schema.org/name', '"Theirs"', contextGraphAssertionUri(CG, otherAgent, 'theirs')),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?g ?name WHERE { GRAPH ?g { ?s <http://schema.org/name> ?name } }',
+      { contextGraphId: CG, view: 'working-memory', agentAddress: agent },
+    );
+
+    expect(result.bindings.map((b) => b['name'])).toEqual(['"Mine"']);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/query/test/query-extra.test.ts
+++ b/packages/query/test/query-extra.test.ts
@@ -669,6 +669,22 @@ describe('DKGQueryEngine view routing constrains GRAPH variables', () => {
 
     expect(result.bindings).toEqual([]);
   });
+
+  it('shared-working-memory with GRAPH ?g does not read verified data', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+
+    await store.insert([
+      quad('urn:view:verified-only', 'http://schema.org/name', '"VerifiedOnly"', contextGraphVerifiedMemoryUri(CG, 'published')),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?g ?name WHERE { GRAPH ?g { ?s <http://schema.org/name> ?name } }',
+      { contextGraphId: CG, view: 'shared-working-memory' },
+    );
+
+    expect(result.bindings).toEqual([]);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/query/test/query-security.test.ts
+++ b/packages/query/test/query-security.test.ts
@@ -7,6 +7,7 @@
  * - FROM/FROM NAMED clauses in remote SPARQL are rejected
  * - Standard context-graph-scoped queries still work correctly
  */
+import { readFileSync } from 'node:fs';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { DKGQueryEngine } from '../src/dkg-query-engine.js';
@@ -526,5 +527,15 @@ describe('I-009: SPARQL keyword detection — no false positives on literals/com
     );
     expect(response.status).toBe('ERROR');
     expect(response.error).toContain('FROM');
+  });
+});
+
+describe('caller documentation for named graph scope', () => {
+  it('documents that local GRAPH variables stay constrained by contextGraphId and view', () => {
+    const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+
+    expect(readme).toContain('contextGraphId and view are authoritative');
+    expect(readme).toContain('GRAPH ?g');
+    expect(readme).toMatch(/constrained locally/i);
   });
 });

--- a/packages/query/test/query-security.test.ts
+++ b/packages/query/test/query-security.test.ts
@@ -37,6 +37,29 @@ function makeRequest(overrides: Partial<QueryRequest> = {}): QueryRequest {
   };
 }
 
+function makeNoExecuteBoundary(): { handler: QueryHandler; wasExecuted: () => boolean } {
+  let executed = false;
+  const noExecuteEngine = {
+    query: async () => {
+      executed = true;
+      return { bindings: [] };
+    },
+    resolveKA: async () => {
+      throw new Error('not used');
+    },
+  } as unknown as DKGQueryEngine;
+
+  return {
+    handler: new QueryHandler(noExecuteEngine, {
+      defaultPolicy: 'deny',
+      contextGraphs: {
+        [CONTEXT_GRAPH]: { policy: 'public', sparqlEnabled: true },
+      },
+    }),
+    wasExecuted: () => executed,
+  };
+}
+
 describe('I-004: Default query access should be deny', () => {
   let store: OxigraphStore;
   let engine: DKGQueryEngine;
@@ -152,24 +175,9 @@ describe('I-009: SPARQL graph scope bypass prevention', () => {
   });
 
   it('rejects token-adjacent GRAPH variables before executing remote SPARQL', async () => {
-    let executed = false;
-    const noExecuteEngine = {
-      query: async () => {
-        executed = true;
-        return { bindings: [] };
-      },
-      resolveKA: async () => {
-        throw new Error('not used');
-      },
-    } as unknown as DKGQueryEngine;
-    const boundaryHandler = new QueryHandler(noExecuteEngine, {
-      defaultPolicy: 'deny',
-      contextGraphs: {
-        [CONTEXT_GRAPH]: { policy: 'public', sparqlEnabled: true },
-      },
-    });
+    const boundary = makeNoExecuteBoundary();
 
-    const response = await boundaryHandler.handle(
+    const response = await boundary.handler.handle(
       makeRequest({
         sparql: `SELECT ?s WHERE { GRAPH?g { ?s <${SCHEMA_NAME}> ?name } }`,
       }),
@@ -178,7 +186,7 @@ describe('I-009: SPARQL graph scope bypass prevention', () => {
 
     expect(response.status).toBe('ERROR');
     expect(response.error).toContain('GRAPH clauses are not allowed');
-    expect(executed).toBe(false);
+    expect(boundary.wasExecuted()).toBe(false);
   });
 
   it('rejects SPARQL with GRAPH clause targeting the allowed context graph too', async () => {
@@ -207,24 +215,9 @@ describe('I-009: SPARQL graph scope bypass prevention', () => {
   });
 
   it('rejects token-adjacent FROM IRIs before executing remote SPARQL', async () => {
-    let executed = false;
-    const noExecuteEngine = {
-      query: async () => {
-        executed = true;
-        return { bindings: [] };
-      },
-      resolveKA: async () => {
-        throw new Error('not used');
-      },
-    } as unknown as DKGQueryEngine;
-    const boundaryHandler = new QueryHandler(noExecuteEngine, {
-      defaultPolicy: 'deny',
-      contextGraphs: {
-        [CONTEXT_GRAPH]: { policy: 'public', sparqlEnabled: true },
-      },
-    });
+    const boundary = makeNoExecuteBoundary();
 
-    const response = await boundaryHandler.handle(
+    const response = await boundary.handler.handle(
       makeRequest({
         sparql: `SELECT ?name FROM<${OTHER_GRAPH}> WHERE { ?s <${SCHEMA_NAME}> ?name }`,
       }),
@@ -233,7 +226,7 @@ describe('I-009: SPARQL graph scope bypass prevention', () => {
 
     expect(response.status).toBe('ERROR');
     expect(response.error).toContain('FROM');
-    expect(executed).toBe(false);
+    expect(boundary.wasExecuted()).toBe(false);
   });
 
   it('rejects SPARQL with FROM NAMED clause', async () => {

--- a/packages/query/test/query-security.test.ts
+++ b/packages/query/test/query-security.test.ts
@@ -150,6 +150,36 @@ describe('I-009: SPARQL graph scope bypass prevention', () => {
     expect(response.error).toContain('GRAPH clauses are not allowed');
   });
 
+  it('rejects token-adjacent GRAPH variables before executing remote SPARQL', async () => {
+    let executed = false;
+    const noExecuteEngine = {
+      query: async () => {
+        executed = true;
+        return { bindings: [] };
+      },
+      resolveKA: async () => {
+        throw new Error('not used');
+      },
+    } as unknown as DKGQueryEngine;
+    const boundaryHandler = new QueryHandler(noExecuteEngine, {
+      defaultPolicy: 'deny',
+      contextGraphs: {
+        [CONTEXT_GRAPH]: { policy: 'public', sparqlEnabled: true },
+      },
+    });
+
+    const response = await boundaryHandler.handle(
+      makeRequest({
+        sparql: `SELECT ?s WHERE { GRAPH?g { ?s <${SCHEMA_NAME}> ?name } }`,
+      }),
+      'peer-attacker',
+    );
+
+    expect(response.status).toBe('ERROR');
+    expect(response.error).toContain('GRAPH clauses are not allowed');
+    expect(executed).toBe(false);
+  });
+
   it('rejects SPARQL with GRAPH clause targeting the allowed context graph too', async () => {
     // Even queries targeting the "correct" graph should not use explicit GRAPH
     const response = await handler.handle(

--- a/packages/query/test/query-security.test.ts
+++ b/packages/query/test/query-security.test.ts
@@ -205,6 +205,36 @@ describe('I-009: SPARQL graph scope bypass prevention', () => {
     expect(response.error).toContain('FROM');
   });
 
+  it('rejects token-adjacent FROM IRIs before executing remote SPARQL', async () => {
+    let executed = false;
+    const noExecuteEngine = {
+      query: async () => {
+        executed = true;
+        return { bindings: [] };
+      },
+      resolveKA: async () => {
+        throw new Error('not used');
+      },
+    } as unknown as DKGQueryEngine;
+    const boundaryHandler = new QueryHandler(noExecuteEngine, {
+      defaultPolicy: 'deny',
+      contextGraphs: {
+        [CONTEXT_GRAPH]: { policy: 'public', sparqlEnabled: true },
+      },
+    });
+
+    const response = await boundaryHandler.handle(
+      makeRequest({
+        sparql: `SELECT ?name FROM<${OTHER_GRAPH}> WHERE { ?s <${SCHEMA_NAME}> ?name }`,
+      }),
+      'peer-attacker',
+    );
+
+    expect(response.status).toBe('ERROR');
+    expect(response.error).toContain('FROM');
+    expect(executed).toBe(false);
+  });
+
   it('rejects SPARQL with FROM NAMED clause', async () => {
     const response = await handler.handle(
       makeRequest({


### PR DESCRIPTION
## Summary

- Reject scoped-query dataset clauses and out-of-scope explicit graph references with client-class errors.
- Constrain local `GRAPH ?g` queries to the requested Context Graph, sub-graph, shared-memory graph, or memory view instead of allowing cross-scope graph enumeration.
- Keep remote raw SPARQL stricter by rejecting `GRAPH`, `FROM`, and token-adjacent forms before execution, and document the caller contract.

## Test Plan

- `pnpm --dir packages/query exec vitest run test/query-security.test.ts test/query-extra.test.ts --configLoader runner`

## Notes

- Final orchestrator branch: `orch/query-scoping-view-isolation/0004`
- Orchestrator run: `design-1779883252310269000`
- Review approved issues `0002`, `0003`, and `0004`.
- Reviewer saw the known Vite temp-file EPERM with symlinked `node_modules`; the same query test set passed with `--configLoader runner`.
