### PR TITLE
RFC-41 Bundle A: docs, dkg doctor, SKILL.md delivery, build-info telemetry

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -354,6 +354,78 @@ jobs:
           echo "EXTRA_TAGS=${EXTRA_TAGS}" >> "$GITHUB_OUTPUT"
           echo "Resolved dist-tags: ${NPM_TAG} ${EXTRA_TAGS:++ $EXTRA_TAGS} for ${TAG}"
 
+      - name: Generate build-info.json for published packages (RFC-41 §4.9)
+        # CI writes `build-info.json` into each public package root
+        # before `pnpm pack` runs, so the tarball — and therefore
+        # the installed npm package — carries the build's commit
+        # SHA + ISO timestamp + dist-tag + CI run id.
+        #
+        # The daemon's `loadBuildInfo()` (packages/cli/src/daemon/manifest.ts)
+        # reads this file at startup. `/api/status` exposes it as
+        # `{commit, commitShort, buildTime, distTag}`. `dkg doctor`'s
+        # §4.7.0 state summary surfaces it alongside the rest of the
+        # install context. Pre-release dist-tag testing becomes
+        # auditable: operators see exactly which commit they're
+        # running, not just a semver tag that may have multiple
+        # sequential builds.
+        #
+        # `files` field on each package.json must include
+        # `build-info.json` for it to be picked up by pnpm pack
+        # (cli has been updated; other public packages will be
+        # added on a follow-up if they also serve build-info via
+        # an HTTP route).
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          NPM_TAG: ${{ steps.dist-tag.outputs.NPM_TAG }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VER="${TAG_NAME#v}"
+          COMMIT="${GITHUB_SHA}"
+          COMMIT_SHORT="${COMMIT:0:8}"
+          BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          CI_RUN="${GITHUB_RUN_ID}"
+          DIST_TAG="${NPM_TAG}"
+          echo "build-info.json fields:"
+          echo "  version    = ${VER}"
+          echo "  commit     = ${COMMIT}"
+          echo "  commitShort= ${COMMIT_SHORT}"
+          echo "  buildTime  = ${BUILD_TIME}"
+          echo "  distTag    = ${DIST_TAG}"
+          echo "  ciRun      = ${CI_RUN}"
+          node -e "
+            const fs = require('fs');
+            const path = require('path');
+            const payload = {
+              version: '${VER}',
+              commit: '${COMMIT}',
+              commitShort: '${COMMIT_SHORT}',
+              buildTime: '${BUILD_TIME}',
+              distTag: '${DIST_TAG}',
+              ciRun: '${CI_RUN}',
+            };
+            const pkgsDir = path.join(process.cwd(), 'packages');
+            for (const dir of fs.readdirSync(pkgsDir)) {
+              const pkgPath = path.join(pkgsDir, dir, 'package.json');
+              if (!fs.existsSync(pkgPath)) continue;
+              const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+              if (pkg.private) continue;
+              // Only write build-info.json into packages whose 'files'
+              // field explicitly includes it. Other packages would
+              // accept the file on disk during pack-time but the
+              // tarball pruning step (npm's standard files-list
+              // behaviour) would silently drop it. Explicit gating
+              // keeps the file's presence on a published tarball
+              // a deterministic per-package choice.
+              const files = Array.isArray(pkg.files) ? pkg.files : null;
+              if (files && !files.includes('build-info.json')) continue;
+              const outPath = path.join(pkgsDir, dir, 'build-info.json');
+              fs.writeFileSync(outPath, JSON.stringify(payload, null, 2) + '\n');
+              console.log('  wrote ' + outPath);
+            }
+          "
+
       - name: Pack public packages into tarballs
         # `pnpm pack` runs the same prepack/prepare lifecycle hooks
         # `pnpm publish` would, but EMITS A TARBALL instead of pushing

--- a/README.md
+++ b/README.md
@@ -143,6 +143,34 @@ TOKEN=$(dkg auth show)
 curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9200/api/agents
 ```
 
+### Updating your node
+
+To update DKG, run one command:
+
+```bash
+dkg update                  # pull the latest release from npm and restart
+dkg update --check          # check what's available without applying
+dkg update --allow-prerelease   # follow the `next` dist-tag for pre-release builds
+dkg rollback                # revert to the previous version
+```
+
+Do **not** `git pull` or clone the repository to update — `dkg update` is the canonical verb. If anything looks off (multiple repositories on disk, served UI doesn't match version, version skew between daemon and CLI), run `dkg doctor` for a structured diagnostic of the install state. See [`OT-RFC-41`](https://github.com/OriginTrail/dkgv10-spec/blob/main/rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md) for the design rationale.
+
+### Contributors / monorepo development
+
+Hacking on DKG itself? Don't go through `npm install -g`. Clone, install, and run from the workspace:
+
+```bash
+git clone https://github.com/OriginTrail/dkg.git
+cd dkg
+pnpm install
+pnpm dkg start             # or `pnpm dkg <any subcommand>`
+```
+
+Contributor state lives under `~/.dkg-dev/` (separated from `~/.dkg/` so a contributor's dev work doesn't stomp on their own Edge install). `dkg update` is intentionally disabled in monorepo-checkout mode — use `git pull && pnpm install && pnpm build` instead.
+
+The legacy `install.sh` git-checkout installer is deprecated and slated for removal in a near-term release. See [`MIGRATE_TO_NPM.md`](docs/operator/MIGRATE_TO_NPM.md) if you have an existing `install.sh`-style install you want to migrate to the npm path.
+
 ---
 
 ## Community integrations
@@ -236,9 +264,10 @@ dkg integration list [--tier community]  # default tier filter is `verified`+
 dkg integration info <slug>              # show details for one entry
 dkg integration install <slug>           # install cli/mcp kind; --allow-community for community-tier entries
 
-# Update / rollback
-dkg update [--check] [--allow-prerelease]  # update node software
+# Update / rollback / diagnose
+dkg update [--check] [--allow-prerelease]  # update node software via npm registry
 dkg rollback                               # roll back to previous version
+dkg doctor [--json]                        # diagnostic report: install layout, version skew, orphan clones, UI mismatch, plugin root, config sanity
 ```
 
 Run `dkg <command> --help` for per-command options.

--- a/docs/operator/MIGRATE_TO_NPM.md
+++ b/docs/operator/MIGRATE_TO_NPM.md
@@ -2,7 +2,21 @@
 
 This guide is for operators currently running a DKG node from a `git clone`d checkout (typical layout: `~/dkg-v9/` with `.git`, `packages/`, `node_modules/`, `pnpm-lock.yaml`, `package.json`). It walks through converting that install to use the npm-pinned auto-update path without re-installing.
 
-The end-state: the daemon's auto-updater fetches pre-built artifacts of a specific `@origintrail-official/dkg` version from npm into `~/.dkg/releases/{a,b}/`, instead of building from source against the tracked git branch on every update cycle.
+The end-state: the daemon's auto-updater fetches pre-built artifacts of a specific `@origintrail-official/dkg` version from npm, instead of building from source against the tracked git branch on every update cycle.
+
+## rc.12 changes — read first
+
+This runbook predates [OT-RFC-41](https://github.com/OriginTrail/dkgv10-spec/blob/main/rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md) ("Edge Node NPM-Only Install and Update"). The RFC ships in rc.12 and changes several details described below:
+
+- **`dkg migrate-to-npm` is being removed in rc.12.** The migration logic is automated: on first daemon start under rc.12, an Edge node with a legacy `~/.dkg/releases/` tree records the active slot's version into `~/.dkg/previous-version` (so `dkg rollback` continues to work) and resumes running from the npm-global install. No operator action required. This runbook is retained for historical context and for operators upgrading on an older release that still has the command.
+- **`install.sh` is deprecated and removed in rc.12.** Use `npm install -g @origintrail-official/dkg` for fresh installs.
+- **Edge nodes no longer use blue-green release slots in rc.12.** The daemon runs directly from the npm-global install (`/usr/local/lib/node_modules/@origintrail-official/dkg/`); `~/.dkg/releases/` is not created. Core nodes (operators running `dkg init --role core`) retain blue-green slots — they still earn their keep on the 24/7 SLA.
+- **`dkg update` semantics differ by `nodeRole` in rc.12.** Edge: `npm install -g @origintrail-official/dkg@<target>` + restart. Core: in-slot install + atomic symlink swap, unchanged from prior behaviour.
+- **Route plugins now resolve from `~/.dkg/plugins/node_modules/`** (a stable, install-mode-independent root). If you operate a fork with bare-name `routePlugins` entries previously installed via `npm install -g <plugin>`, re-install them with `npm install --prefix ~/.dkg/plugins <plugin>` so they survive update cycles.
+- **`dkg doctor`** ships as a first-class diagnostic command. Run it before reasoning about install-state confusion — it surfaces orphan repository clones, version skew between the CLI and the daemon, served-UI / source mismatch, plugin install root health, and (on Core) blue-green slot health.
+- **The `installMode`, `commit`, `commitShort`, `buildTime`, and `distTag` fields are exposed on `/api/status`** (per RFC §4.9). When opening a support ticket, paste the output of `curl http://localhost:9200/api/status | jq` rather than just the version string.
+
+The rest of this document describes the now-deprecated `dkg migrate-to-npm` flow as it existed pre-rc.12. If you are on rc.11 or earlier and need to migrate before upgrading, follow it. Otherwise upgrade to rc.12 and let the automated migration handle it.
 
 ## Why migrate
 

--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,36 @@ BRANCH="${DKG_BRANCH:-main}"
 BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
 
 red() { printf '\033[0;31m%s\033[0m\n' "$1"; }
+yellow() { printf '\033[0;33m%s\033[0m\n' "$1"; }
 green() { printf '\033[0;32m%s\033[0m\n' "$1"; }
 info() { printf '  %s\n' "$1"; }
+
+# RFC-41 deprecation banner.
+# install.sh is deprecated. The canonical install path is now
+# `npm install -g @origintrail-official/dkg`, which ships pre-built
+# artifacts and avoids the multi-tree on-disk shape that confused
+# operator agents. install.sh will be removed in a near-term release.
+#
+# See:
+#   https://github.com/OriginTrail/dkgv10-spec/blob/main/rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md
+#   https://github.com/OriginTrail/dkg/blob/main/docs/operator/MIGRATE_TO_NPM.md
+yellow "DEPRECATED: install.sh is no longer the recommended install path."
+echo ""
+echo "  The canonical installer for DKG V10 is now:"
+echo ""
+echo "      npm install -g @origintrail-official/dkg"
+echo ""
+echo "  install.sh will be removed in a near-term release. See OT-RFC-41:"
+echo "    https://github.com/OriginTrail/dkgv10-spec/blob/main/rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md"
+echo ""
+echo "  If you have an existing install.sh-style install you want to migrate,"
+echo "  see docs/operator/MIGRATE_TO_NPM.md."
+echo ""
+echo "  Continuing with install.sh in 5 seconds... (Ctrl-C to abort)"
+echo ""
+if [ -z "${DKG_INSTALL_SH_NO_DEPRECATION_DELAY:-}" ]; then
+  sleep 5
+fi
 
 echo ""
 echo "DKG V9 Node Installer"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,6 +65,7 @@
     "project.json",
     "markitdown-build-info.json",
     "markitdown-targets.json",
+    "build-info.json",
     "scripts",
     "skills",
     "README.md",

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -20,6 +20,33 @@ This skill teaches you the full node API surface so you can operate autonomously
 
 To see which context graphs (projects) are currently subscribed, call `GET /api/context-graph/list` — this returns a live list that stays current as projects are created or subscribed during the session.
 
+## 1a. Operating the node (install, update, troubleshoot)
+
+> **Before reasoning about install state, run `dkg doctor`.** Detects orphan repository clones, version skew between the daemon and the global `dkg` CLI, served-UI / source mismatch, broken plugin install roots, and other install-layout anomalies. Use `dkg doctor --json` for a machine-parsable report; the `state` field always carries the full diagnostic snapshot (daemon entry point, install mode, node role, dkg-home, current version + commit, auto-update settings) independent of any anomaly findings.
+
+**Updating DKG:**
+
+- The canonical update verb is `dkg update`. It resolves the next release from the npm registry and applies it.
+- **Do not `git pull`.** Do not clone the repository. Do not edit files under `~/.dkg/releases/` (on Core nodes — Edge nodes have no `~/.dkg/releases/` at all under RFC-41).
+- If `dkg doctor` reports orphan clones at `~/dkg/`, `~/Projects/dkg/`, or similar, ask the operator before touching them — they are not the running daemon.
+- `dkg update --check` previews the available version without applying.
+- `dkg update --allow-prerelease` follows the `next` dist-tag for pre-release builds.
+- `dkg rollback` reverts to the previous version (Edge: re-installs the prior npm version recorded in `~/.dkg/previous-version`; Core: flips the blue-green slot symlink).
+
+**Detecting current install state:**
+
+- `dkg --version` — the global CLI's version.
+- `curl http://127.0.0.1:9200/api/status | jq '{version, commit, commitShort, buildTime, distTag, installMode, nodeRole}'` — the running daemon's version, commit, and install mode. Mismatch between `dkg --version` and the daemon's version is the §1a version-skew condition; `dkg doctor` reports it explicitly.
+- `cat ~/.dkg/config.json | jq .nodeRole` — `edge` (default; daemon runs from npm-global install, no release slots) or `core` (operator opted into blue-green slots via `dkg init --role core`).
+
+**Troubleshooting common confusion:**
+
+- "There seem to be multiple DKG installations on this machine" → run `dkg doctor`; the `state.cli.globalPath`, `state.daemon.entryPoint`, and orphan-repos check together identify the canonical install and any stray clones.
+- "The UI shows an old version even after I updated" → run `dkg doctor`; the served-UI / source-mismatch check flags stale browser / PWA / service-worker caches.
+- "I ran `npm install -g @origintrail-official/dkg@latest` but the daemon still reports the old version" → on Edge nodes the daemon needs a restart to pick up the new install (`dkg restart`). On Core nodes, the slot mechanism gates the visible version on `dkg update`'s atomic swap, not on `npm install -g` directly — use `dkg update` for Core nodes.
+
+The full design rationale lives in [OT-RFC-41](https://github.com/OriginTrail/dkgv10-spec/blob/main/rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md).
+
 ## 2. Capabilities Overview
 
 > **Note:** This skill describes the full DKG V10 API surface. Some endpoints

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4435,6 +4435,32 @@ program
         return;
       }
 
+      // RFC-41 §4.7.7 invocation pattern #3: before applying an update,
+      // `dkg update` MUST run the install-layout + version-skew doctor
+      // checks. If either reports an `error`, abort with a pointer at
+      // `dkg doctor --json` for full context. Warnings do not block.
+      try {
+        const { createProductionDeps, runDoctor, UPDATE_PREFLIGHT_CHECKS } =
+          await import('./doctor/index.js');
+        const preflightDeps = createProductionDeps({ apiPort: config.apiPort ?? 9200 });
+        const preflight = await runDoctor(preflightDeps, { checks: UPDATE_PREFLIGHT_CHECKS });
+        if (preflight.exitCode === 2) {
+          const errors = preflight.findings.filter((f) => f.severity === 'error');
+          console.error('\n[dkg update] Pre-flight checks failed; refusing to apply update.\n');
+          for (const f of errors) {
+            console.error(`  • [${f.check}] ${f.message}`);
+            if (f.advisory) console.error(`      → ${f.advisory}`);
+          }
+          console.error('\nRun `dkg doctor --json` for the full diagnostic report.\n');
+          process.exit(2);
+        }
+      } catch (err: any) {
+        // Pre-flight crashing should not block updates — fall through
+        // and let the real update path do its thing. Warn loudly so a
+        // recurring failure is visible.
+        process.stderr.write(`[dkg update] WARNING: pre-flight doctor check crashed (${err?.message ?? err}); continuing without it.\n`);
+      }
+
       let version = versionOrRef ?? null;
       if (version) {
         version = version.replace(/^refs\/tags\/v?/, '').replace(/^v/, '');
@@ -4470,6 +4496,31 @@ program
     }
 
     // --- Git-based update path (monorepo / install.sh installs) ---
+
+    // RFC-41 §5 PR 2 deprecation warning. The git-based update path
+    // (monorepo `dkg update` + install.sh-style git-checkout updates)
+    // is being removed in Bundle B. Bundle A only warns; B converts
+    // this to a hard refusal once the npm path is the proven default
+    // and the §6.5 rollout prerequisites are green.
+    //
+    // For monorepo contributors: the canonical "update" is
+    // `git pull && pnpm install && pnpm build` from the repo root.
+    // For install.sh operators: see docs/operator/MIGRATE_TO_NPM.md
+    // to convert to the npm path before Bundle B lands.
+    process.stderr.write(
+      '\n' +
+      '[dkg update] WARNING: invoking the git-based update path. This path is\n' +
+      '  deprecated in rc.12 per OT-RFC-41 and will be removed in a near-term\n' +
+      '  release. The canonical update mechanism is `npm install -g\n' +
+      '  @origintrail-official/dkg` + `dkg update`.\n' +
+      '\n' +
+      '  - Monorepo contributors: use `git pull && pnpm install && pnpm build`\n' +
+      '    in the repo root instead of `dkg update`.\n' +
+      '  - install.sh-style operators: see docs/operator/MIGRATE_TO_NPM.md.\n' +
+      '\n' +
+      '  RFC: https://github.com/OriginTrail/dkgv10-spec/blob/main/rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md\n' +
+      '\n',
+    );
 
     const refOverride = versionOrRef ? normalizeVersionTagRef(versionOrRef) : undefined;
     const verifyTagSignature = Boolean(refOverride && refOverride.startsWith('refs/tags/')) && opts.verifyTag !== false;
@@ -4612,6 +4663,48 @@ program
     }
     console.log(`Rolled back: current → slot ${target}`);
     console.log('Daemon stopped. Run "dkg start" to start with the rolled-back version.');
+  });
+
+// ─── dkg doctor ──────────────────────────────────────────────────────
+//
+// Per OT-RFC-41 §4.7. Surfaces install-layout / version-skew / orphan-clone
+// anomalies before an agent touches DKG state. Wired into SKILL.md as a
+// session-start ritual; also invoked by `dkg update`'s pre-flight check
+// (the orchestrator runs a narrow subset — install-layout + version-skew).
+
+program
+  .command('doctor')
+  .description('Diagnose install state, version skew, orphan clones, plugin root, and config sanity')
+  .option('--json', 'Emit the report as JSON instead of human-readable text')
+  .option('--no-orphan-scan', "Skip the orphan-repository home-directory scan (§4.7.1)")
+  .action(async (opts: { json?: boolean; orphanScan?: boolean }) => {
+    const { createProductionDeps, runDoctor, formatDoctorReport, ALL_CHECK_IDS } =
+      await import('./doctor/index.js');
+    const config = await loadConfig();
+    const deps = createProductionDeps({ apiPort: config.apiPort ?? 9200 });
+    // Overlay operator-configured scan roots + skipChecks from config.
+    // The doctor namespace is opt-in — absent config means defaults.
+    const doctorConfig = (config as Record<string, unknown>).doctor as
+      | { scanRoots?: unknown; skipChecks?: unknown }
+      | undefined;
+    if (doctorConfig) {
+      if (Array.isArray(doctorConfig.scanRoots)) {
+        deps.extraScanRoots = doctorConfig.scanRoots.filter((s): s is string => typeof s === 'string');
+      }
+      if (Array.isArray(doctorConfig.skipChecks)) {
+        deps.skipChecks = doctorConfig.skipChecks.filter((s): s is string => typeof s === 'string');
+      }
+    }
+    const requestedChecks = opts.orphanScan === false
+      ? ALL_CHECK_IDS.filter((id) => id !== 'orphan-repos')
+      : ALL_CHECK_IDS;
+    const report = await runDoctor(deps, { checks: requestedChecks });
+    if (opts.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      console.log(formatDoctorReport(report));
+    }
+    process.exit(report.exitCode);
   });
 
 // ─── dkg random-sampling (alias: rs) ─────────────────────────────────

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -182,6 +182,8 @@ import {
   loadMarkItDownTargets,
   getNodeVersion,
   getCurrentCommitShort,
+  loadBuildInfo,
+  detectInstallMode,
   loadSkillTemplate,
   buildSkillMd,
   skillEtag,
@@ -790,6 +792,36 @@ export async function runDaemonInner(
     ? `v${nodeVersion}, ${nodeCommit}`
     : `v${nodeVersion}`;
   log(`Starting DKG ${role} node "${config.name}" (${versionTag})...`);
+
+  // RFC-41 §4.9 / §4.3: structured startup log lines for telemetry.
+  // The doctor's state summary correlates these with /api/status —
+  // every successful daemon start emits a parseable JSON line that
+  // an operator or CI pipeline can grep without needing the API up.
+  // Distinct tags (`dkg-build-info` + `install-mode-detected`) so a
+  // log shipper can split them into separate streams.
+  try {
+    const buildInfo = loadBuildInfo();
+    const installMode = detectInstallMode();
+    log(
+      `[dkg-build-info] ${JSON.stringify({
+        version: nodeVersion,
+        commit: buildInfo.commit,
+        commitShort: buildInfo.commitShort,
+        buildTime: buildInfo.buildTime,
+        distTag: buildInfo.distTag,
+        ciRun: buildInfo.ciRun,
+      })}`,
+    );
+    log(
+      `[install-mode-detected] ${JSON.stringify({
+        installMode,
+        nodeRole: role,
+      })}`,
+    );
+  } catch (err) {
+    // Never fail startup on a telemetry-log failure.
+    log(`[dkg-build-info] WARNING: failed to emit startup telemetry: ${String(err)}`);
+  }
 
   const network = await loadNetworkConfig();
   const syncContextGraphs = [

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -624,6 +624,138 @@ export function getCurrentCommitShort(): string {
   }
 }
 
+/**
+ * RFC-41 §4.9: bundled commit metadata in published npm artifacts.
+ *
+ * CI writes `build-info.json` into the package root before
+ * `npm publish`. It carries the full commit SHA, build timestamp,
+ * dist-tag, and the CI run identifier — exposed via `/api/status`
+ * so pre-release dist-tag testing is auditable (operators see
+ * exactly which commit they are running, not just a semver tag
+ * that may have had multiple sequential builds).
+ *
+ * Monorepo / dev fallback: when `build-info.json` is absent (which
+ * is the steady state for contributors running from `pnpm dkg start`),
+ * we return a sentinel telling the doctor / agent we're in a dev
+ * build. The fallback values are stable strings so consumers can
+ * branch reliably.
+ *
+ * Cached after first read because the file is immutable for the
+ * lifetime of a daemon process.
+ */
+export interface BuildInfo {
+  /** Full commit SHA, or "uncommitted" for monorepo / dev fallback. */
+  commit: string;
+  /** First 8 chars of commit, or "00000000" for the dev fallback. */
+  commitShort: string;
+  /** ISO 8601 timestamp of the npm publish build, or null in dev fallback. */
+  buildTime: string | null;
+  /** npm dist-tag the artifact was published under (e.g. "latest", "next"), or "monorepo" for dev. */
+  distTag: string;
+  /** CI workflow run identifier (e.g. GitHub Actions run id), or null in dev fallback. */
+  ciRun: string | null;
+}
+
+let cachedBuildInfo: BuildInfo | null = null;
+
+export function loadBuildInfo(): BuildInfo {
+  if (cachedBuildInfo) return cachedBuildInfo;
+  try {
+    const raw = readFileSync(
+      new URL("../../build-info.json", import.meta.url),
+      "utf-8",
+    );
+    const parsed = JSON.parse(raw) as Partial<BuildInfo>;
+    const commit = typeof parsed.commit === "string" && parsed.commit
+      ? parsed.commit
+      : "uncommitted";
+    cachedBuildInfo = {
+      commit,
+      commitShort:
+        typeof parsed.commitShort === "string" && parsed.commitShort
+          ? parsed.commitShort
+          : commit.slice(0, 8) || "00000000",
+      buildTime:
+        typeof parsed.buildTime === "string" && parsed.buildTime
+          ? parsed.buildTime
+          : null,
+      distTag:
+        typeof parsed.distTag === "string" && parsed.distTag
+          ? parsed.distTag
+          : "unknown",
+      ciRun:
+        typeof parsed.ciRun === "string" && parsed.ciRun ? parsed.ciRun : null,
+    };
+    return cachedBuildInfo;
+  } catch {
+    // No build-info.json — this is a monorepo / dev / `pnpm dkg
+    // start` invocation. Use stable sentinels so /api/status
+    // consumers can branch reliably.
+    cachedBuildInfo = {
+      commit: "uncommitted",
+      commitShort: "00000000",
+      buildTime: null,
+      distTag: "monorepo",
+      ciRun: null,
+    };
+    return cachedBuildInfo;
+  }
+}
+
+/**
+ * RFC-41 §4.3 / §4.7.0: detect the running daemon's install mode.
+ *
+ * The detection is local-only — there is no authoritative network
+ * source for this. We classify based on where `import.meta.url`
+ * resolves on disk:
+ *
+ *   - inside a monorepo packages/cli/dist/ → `monorepo`
+ *   - inside `/usr/local/lib/node_modules/`, `/opt/homebrew/lib/`,
+ *     `~/.nvm/`, `~/.volta/`, `~/.fnm/` → `npm-global`
+ *   - inside any other `node_modules/` → `npm-local`
+ *   - otherwise → `unknown`
+ *
+ * Cached on first read.
+ */
+export type InstallMode = "npm-global" | "npm-local" | "monorepo" | "unknown";
+
+let cachedInstallMode: InstallMode | null = null;
+
+export function detectInstallMode(): InstallMode {
+  if (cachedInstallMode) return cachedInstallMode;
+  try {
+    const cliPath = fileURLToPath(import.meta.url).replace(/\\/g, "/");
+    if (cliPath.includes("/packages/cli/dist/") || cliPath.includes("/packages/cli/src/")) {
+      cachedInstallMode = "monorepo";
+      return cachedInstallMode;
+    }
+    const globalMarkers = [
+      "/usr/local/lib/node_modules/",
+      "/opt/homebrew/lib/node_modules/",
+      "/usr/lib/node_modules/",
+      "/.nvm/",
+      "/.volta/",
+      "/.fnm/",
+      "/.asdf/installs/nodejs/",
+    ];
+    for (const marker of globalMarkers) {
+      if (cliPath.includes(marker)) {
+        cachedInstallMode = "npm-global";
+        return cachedInstallMode;
+      }
+    }
+    if (cliPath.includes("/node_modules/")) {
+      cachedInstallMode = "npm-local";
+      return cachedInstallMode;
+    }
+    cachedInstallMode = "unknown";
+    return cachedInstallMode;
+  } catch {
+    cachedInstallMode = "unknown";
+    return cachedInstallMode;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // SKILL.MD serving — Agent Skills standard (https://agentskills.io)
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -179,6 +179,8 @@ import {
   loadMarkItDownTargets,
   getNodeVersion,
   getCurrentCommitShort,
+  loadBuildInfo,
+  detectInstallMode,
   loadSkillTemplate,
   loadImporterSkillTemplate,
   buildSkillMd,
@@ -589,10 +591,22 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       advertisedAddresses: agent.multiaddrs,
       configuredAnnounceAddresses: config.announceAddresses ?? [],
     });
+    // RFC-41 §4.9 + §4.3: expose build-info + installMode for
+    // doctor / agent disambiguation. loadBuildInfo() falls back to
+    // the {commit: "uncommitted", distTag: "monorepo", ...}
+    // sentinels when build-info.json is absent (monorepo / dev),
+    // so consumers can branch reliably.
+    const buildInfo = loadBuildInfo();
     return jsonResponse(res, 200, {
       name: config.name,
       version: nodeVersion,
-      commit: nodeCommit || null,
+      commit: buildInfo.commit !== "uncommitted" ? buildInfo.commit : (nodeCommit || null),
+      commitShort: buildInfo.commitShort !== "00000000"
+        ? buildInfo.commitShort
+        : (nodeCommit ? nodeCommit.slice(0, 8) : null),
+      buildTime: buildInfo.buildTime,
+      distTag: buildInfo.distTag,
+      installMode: detectInstallMode(),
       peerId: agent.peerId,
       nodeRole: config.nodeRole ?? "edge",
       networkId: networkId.slice(0, 16),

--- a/packages/cli/src/doctor/checks/config-sanity.ts
+++ b/packages/cli/src/doctor/checks/config-sanity.ts
@@ -1,0 +1,143 @@
+/**
+ * §4.7.2 Check: configuration sanity.
+ *
+ * Validates `~/.dkg/config.json` against an opportunistic schema +
+ * semantic constraints. Reports:
+ *   - Deprecated fields set to non-empty values (warnings).
+ *   - Semantic violations (e.g. `apiPort` out of range) (errors).
+ *   - `nodeRole` not in `{ "edge", "core" }` (error).
+ *   - Missing config file (warning — the daemon will use defaults
+ *     but `dkg init` was never run).
+ *
+ * We deliberately don't enumerate "unknown top-level fields" — DKG's
+ * config surface evolves rapidly and a strict-schema check would
+ * produce false positives on every release. The schema-evolution
+ * cost-benefit is documented in OT-RFC-41 §4.7.2.
+ */
+import { join } from 'node:path';
+import type { DoctorDeps, Finding } from '../types.js';
+
+const DEPRECATED_AUTO_UPDATE_FIELDS = [
+  'repo',
+  'branch',
+  'verifyTagSignature',
+  'buildTimeoutMs',
+] as const;
+
+export async function runConfigSanityCheck(deps: DoctorDeps): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  const configPath = join(deps.dkgHome, 'config.json');
+
+  if (!deps.exists(configPath)) {
+    findings.push({
+      check: 'config-sanity',
+      severity: 'warning',
+      message: `No config file at ${configPath}`,
+      advisory: "Run 'dkg init' to bootstrap the node config. The daemon will start with defaults until you do.",
+      subject: configPath,
+    });
+    return findings;
+  }
+
+  const raw = await deps.readFile(configPath);
+  if (raw === null) {
+    findings.push({
+      check: 'config-sanity',
+      severity: 'error',
+      message: `Config file exists but is unreadable: ${configPath}`,
+      advisory: 'Check file permissions. The daemon will fail to start if this persists.',
+      subject: configPath,
+    });
+    return findings;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    const obj = JSON.parse(raw);
+    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+      throw new Error('config.json is not a JSON object');
+    }
+    parsed = obj as Record<string, unknown>;
+  } catch (err: any) {
+    findings.push({
+      check: 'config-sanity',
+      severity: 'error',
+      message: `Config file is malformed JSON: ${configPath}`,
+      advisory: `Fix or restore the file: ${err?.message ?? err}. The daemon will refuse to start until JSON parses cleanly.`,
+      subject: configPath,
+    });
+    return findings;
+  }
+
+  // nodeRole sanity
+  const nodeRole = parsed.nodeRole;
+  if (nodeRole !== undefined && nodeRole !== 'edge' && nodeRole !== 'core') {
+    findings.push({
+      check: 'config-sanity',
+      severity: 'error',
+      message: `Invalid nodeRole in config: ${JSON.stringify(nodeRole)}`,
+      advisory: "Set 'nodeRole' to 'edge' (default, for laptops/personal use) or 'core' (24/7 relay/SLA).",
+      subject: 'nodeRole',
+    });
+  }
+
+  // apiPort sanity
+  const apiPort = parsed.apiPort;
+  if (apiPort !== undefined) {
+    const n = typeof apiPort === 'number' ? apiPort : Number(apiPort);
+    if (!Number.isInteger(n) || n < 1 || n > 65535) {
+      findings.push({
+        check: 'config-sanity',
+        severity: 'error',
+        message: `apiPort out of range: ${JSON.stringify(apiPort)}`,
+        advisory: 'Pick a port in the 1024-65535 range (1-1023 require root). Default is 9200.',
+        subject: 'apiPort',
+      });
+    }
+  }
+
+  // autoUpdate sub-config
+  const autoUpdate = parsed.autoUpdate;
+  if (autoUpdate && typeof autoUpdate === 'object' && !Array.isArray(autoUpdate)) {
+    const au = autoUpdate as Record<string, unknown>;
+
+    for (const field of DEPRECATED_AUTO_UPDATE_FIELDS) {
+      const value = au[field];
+      if (value === undefined || value === null || value === '') continue;
+      findings.push({
+        check: 'config-sanity',
+        severity: 'warning',
+        message: `Deprecated autoUpdate field is set: autoUpdate.${field}`,
+        advisory: `The '${field}' field is inert post-rc.12 per OT-RFC-41 §4.3. Remove it from ~/.dkg/config.json — the daemon will continue to ignore it, but its presence is misleading to anyone reading the file.`,
+        subject: `autoUpdate.${field}`,
+      });
+    }
+
+    const checkIntervalMinutes = au.checkIntervalMinutes;
+    if (checkIntervalMinutes !== undefined) {
+      const n = typeof checkIntervalMinutes === 'number' ? checkIntervalMinutes : Number(checkIntervalMinutes);
+      if (!Number.isFinite(n) || n < 1) {
+        findings.push({
+          check: 'config-sanity',
+          severity: 'error',
+          message: `autoUpdate.checkIntervalMinutes < 1: ${JSON.stringify(checkIntervalMinutes)}`,
+          advisory: 'Set autoUpdate.checkIntervalMinutes to an integer ≥ 1 (default 30).',
+          subject: 'autoUpdate.checkIntervalMinutes',
+        });
+      }
+    }
+
+    const source = au.source;
+    if (source !== undefined && source !== 'npm' && source !== 'monorepo' && source !== 'git' && source !== 'auto') {
+      findings.push({
+        check: 'config-sanity',
+        severity: 'warning',
+        message: `autoUpdate.source has an unknown value: ${JSON.stringify(source)}`,
+        advisory: "Expected 'npm' (post-rc.12 default) or 'monorepo' (for contributor checkouts). Older values ('git', 'auto') are accepted but deprecated.",
+        subject: 'autoUpdate.source',
+      });
+    }
+  }
+
+  return findings;
+}

--- a/packages/cli/src/doctor/checks/install-layout.ts
+++ b/packages/cli/src/doctor/checks/install-layout.ts
@@ -1,0 +1,158 @@
+/**
+ * §4.7.3 Check: slot health / install layout (role-aware).
+ *
+ * **Core (`nodeRole === "core"`):**
+ *   - `~/.dkg/releases/current` exists and is a valid symlink.
+ *   - The symlink target (`a` or `b`) exists and contains a
+ *     resolvable entry point.
+ *   - The inactive slot is empty OR contains a complete prior
+ *     release with its own resolvable entry point — partial state
+ *     is a warning suggesting `dkg update --retry` or `dkg rollback`.
+ *   - No `.git` inside either slot (post-rc.12 invariant).
+ *
+ * **Edge (`nodeRole === "edge"`):**
+ *   - The daemon's resolved entry point MUST be inside the
+ *     npm-global install path.
+ *   - `~/.dkg/releases/` SHOULD NOT exist on Edge. If it does
+ *     (pre-rc.12 layout), report it as cleanable legacy state.
+ */
+import { join } from 'node:path';
+import type { DoctorDeps, Finding, StateSummary } from '../types.js';
+
+async function slotEntryPointResolves(deps: DoctorDeps, slotDir: string): Promise<boolean> {
+  // Mirrors `blueGreenSlotEntryPoint` semantics — git layout
+  // (`packages/cli/dist/cli.js`) OR npm layout
+  // (`node_modules/@origintrail-official/dkg/dist/cli.js`).
+  const gitPath = join(slotDir, 'packages', 'cli', 'dist', 'cli.js');
+  if (deps.exists(gitPath)) return true;
+  const npmPath = join(slotDir, 'node_modules', '@origintrail-official', 'dkg', 'dist', 'cli.js');
+  if (deps.exists(npmPath)) return true;
+  return false;
+}
+
+export async function runInstallLayoutCheck(
+  deps: DoctorDeps,
+  state: StateSummary,
+): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  const releasesDir = join(deps.dkgHome, 'releases');
+  const nodeRole = state.daemon.nodeRole ?? 'edge';
+
+  if (nodeRole === 'core') {
+    const currentLink = join(releasesDir, 'current');
+    if (!deps.exists(currentLink)) {
+      findings.push({
+        check: 'install-layout',
+        severity: 'error',
+        message: `Core node missing blue-green 'current' symlink at ${currentLink}`,
+        advisory: "Run 'dkg start' — on first boot the daemon materializes the slot tree.",
+        subject: currentLink,
+      });
+      return findings;
+    }
+
+    const slotTarget = await deps.readlink(currentLink);
+    if (!slotTarget) {
+      findings.push({
+        check: 'install-layout',
+        severity: 'error',
+        message: `'current' is not a valid symlink: ${currentLink}`,
+        advisory: "Run 'dkg update --retry' to repair the symlink or 'dkg rollback' to restore the previous slot.",
+        subject: currentLink,
+      });
+      return findings;
+    }
+
+    const activeSlotName = slotTarget === 'a' || slotTarget === 'b' ? slotTarget : null;
+    if (!activeSlotName) {
+      findings.push({
+        check: 'install-layout',
+        severity: 'error',
+        message: `'current' symlink points at unexpected target: ${slotTarget}`,
+        advisory: "Expected 'a' or 'b'. Run 'dkg update --retry' or 'dkg rollback' to restore a known-good slot.",
+        subject: currentLink,
+      });
+      return findings;
+    }
+
+    const activeSlotDir = join(releasesDir, activeSlotName);
+    if (!(await slotEntryPointResolves(deps, activeSlotDir))) {
+      findings.push({
+        check: 'install-layout',
+        severity: 'error',
+        message: `Active slot '${activeSlotName}' has no resolvable entry point at ${activeSlotDir}`,
+        advisory: "Slot was promoted but install never completed. Run 'dkg update --retry' or 'dkg rollback'.",
+        subject: activeSlotDir,
+      });
+    }
+
+    // Inactive slot check — partial state is a warning, empty is fine.
+    const inactiveSlotName = activeSlotName === 'a' ? 'b' : 'a';
+    const inactiveSlotDir = join(releasesDir, inactiveSlotName);
+    if (deps.exists(inactiveSlotDir)) {
+      const entries = await deps.readdir(inactiveSlotDir);
+      const populated = entries.length > 0;
+      if (populated && !(await slotEntryPointResolves(deps, inactiveSlotDir))) {
+        findings.push({
+          check: 'install-layout',
+          severity: 'warning',
+          message: `Inactive slot '${inactiveSlotName}' has files but no resolvable entry point at ${inactiveSlotDir}`,
+          advisory: "Likely a partial / interrupted update. Run 'dkg update --retry' to complete the swap, or 'dkg rollback' to restore the previous release.",
+          subject: inactiveSlotDir,
+        });
+      }
+    }
+
+    // Post-rc.12 invariant: no `.git` inside either slot.
+    for (const slotName of ['a', 'b'] as const) {
+      const dotGit = join(releasesDir, slotName, '.git');
+      if (deps.exists(dotGit)) {
+        findings.push({
+          check: 'install-layout',
+          severity: 'warning',
+          message: `Legacy '.git' directory found inside slot '${slotName}': ${dotGit}`,
+          advisory: "Pre-rc.12 install.sh-era state survived the npm-only migration. The slot is fine to run from, but the '.git' is unused. Safe to delete after confirming with the operator.",
+          subject: dotGit,
+        });
+      }
+    }
+
+    return findings;
+  }
+
+  // Edge branch.
+  if (deps.exists(releasesDir)) {
+    findings.push({
+      check: 'install-layout',
+      severity: 'warning',
+      message: `Legacy ~/.dkg/releases/ directory detected on an Edge node: ${releasesDir}`,
+      advisory: "Edge nodes do not use blue-green slots under RFC-41. Safe to delete: 'rm -rf ~/.dkg/releases/'. The daemon runs directly from the npm-global install.",
+      subject: releasesDir,
+    });
+  }
+
+  if (state.daemon.entryPoint && state.paths.npmGlobalDkg) {
+    const ep = state.daemon.entryPoint.replace(/\\/g, '/');
+    const npm = state.paths.npmGlobalDkg.replace(/\\/g, '/');
+    if (!ep.startsWith(npm + '/') && !ep.startsWith(npm)) {
+      // Edge daemon is running from somewhere unexpected. Possible
+      // causes: stale slot, contributor monorepo, manual override.
+      // We report this as a warning so the operator + agent can
+      // reason about it; `--json` consumers can branch on the
+      // detail fields.
+      findings.push({
+        check: 'install-layout',
+        severity: 'warning',
+        message: 'Edge daemon entry point is not inside the npm-global install',
+        advisory: "Expected the daemon to run from the npm-global install. Run 'dkg restart' if you recently re-installed; investigate $PATH and DKG_HOME if the mismatch persists.",
+        subject: state.daemon.entryPoint,
+        details: {
+          entryPoint: state.daemon.entryPoint,
+          npmGlobalDkg: state.paths.npmGlobalDkg,
+        },
+      });
+    }
+  }
+
+  return findings;
+}

--- a/packages/cli/src/doctor/checks/orphan-repos.ts
+++ b/packages/cli/src/doctor/checks/orphan-repos.ts
@@ -1,0 +1,215 @@
+/**
+ * §4.7.1 Check: orphan repository clones.
+ *
+ * Walks operator $HOME (plus common dev-folder children: `Projects`,
+ * `repos`, `src`, `dev`, plus any operator-configured `doctor.scanRoots`)
+ * up to a bounded depth, looking for directories that look like a
+ * stray DKG repository clone. Each match is reported as a finding
+ * with severity `warning` (or `info` if the directory IS the active
+ * daemon — that's just describing reality).
+ *
+ * Detection signals:
+ *   - `.git/config` whose `[remote "origin"]` URL contains
+ *     `OriginTrail/dkg` or `origintrail-official/dkg`, OR
+ *   - `package.json` whose `name` field is `@origintrail-official/dkg`
+ *     or `dkg-v9` (legacy name).
+ *
+ * Performance constraint: the scan MUST complete in < 5 s on a
+ * laptop-sized home directory. We skip `node_modules`, `.npm`,
+ * `.cache`, `.npmrc`, any dot-directory other than the configured
+ * roots themselves, and any directory containing a
+ * `.dkg-ignore-by-doctor` sentinel.
+ */
+import { join } from 'node:path';
+import type { DoctorDeps, Finding, StateSummary } from '../types.js';
+
+const DEFAULT_SCAN_ROOT_CHILDREN = ['Projects', 'repos', 'src', 'dev'];
+const DEFAULT_MAX_DEPTH = 4;
+const IGNORE_SENTINEL = '.dkg-ignore-by-doctor';
+const SKIP_DIRECTORIES = new Set([
+  'node_modules',
+  '.npm',
+  '.cache',
+  '.git',
+  '.next',
+  '.turbo',
+  '.cargo',
+  '.rustup',
+  '.pnpm-store',
+  'dist',
+  'build',
+]);
+const ORIGIN_PATTERN = /OriginTrail\/dkg|origintrail-official\/dkg/i;
+const PACKAGE_NAME_MATCHES = new Set(['@origintrail-official/dkg', 'dkg-v9']);
+
+/** A single discovered candidate. Exported for downstream consumption (e.g. CLI rendering). */
+export interface OrphanCandidate {
+  path: string;
+  matchedBy: 'git-origin' | 'package-name' | 'both';
+  origin?: string;
+  packageName?: string;
+  /** Whether this directory IS the active daemon (entryPoint resolves inside it). */
+  isActiveDaemon: boolean;
+}
+
+/** Compute the set of roots we will scan. */
+function resolveScanRoots(deps: DoctorDeps): string[] {
+  const roots = new Set<string>([deps.home]);
+  for (const child of DEFAULT_SCAN_ROOT_CHILDREN) {
+    roots.add(join(deps.home, child));
+  }
+  for (const extra of deps.extraScanRoots) {
+    roots.add(extra);
+  }
+  return Array.from(roots);
+}
+
+/**
+ * Check whether `dir` is a DKG repo clone by reading the two signal
+ * files. Returns the matched candidate or `null` if neither signal
+ * fires.
+ */
+async function probeDirectory(
+  deps: DoctorDeps,
+  dir: string,
+  daemonEntryPoint: string | null,
+): Promise<OrphanCandidate | null> {
+  const gitConfigPath = join(dir, '.git', 'config');
+  const packageJsonPath = join(dir, 'package.json');
+
+  let origin: string | null = null;
+  if (deps.exists(gitConfigPath)) {
+    const raw = await deps.readFile(gitConfigPath);
+    if (raw) {
+      const originMatch = raw.match(/\[remote\s+"origin"\][^[]*?url\s*=\s*([^\s]+)/i);
+      if (originMatch && ORIGIN_PATTERN.test(originMatch[1])) {
+        origin = originMatch[1];
+      }
+    }
+  }
+
+  let packageName: string | null = null;
+  if (deps.exists(packageJsonPath)) {
+    const raw = await deps.readFile(packageJsonPath);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        const name = (parsed as { name?: unknown }).name;
+        if (typeof name === 'string' && PACKAGE_NAME_MATCHES.has(name)) {
+          packageName = name;
+        }
+      } catch {
+        // ignore malformed package.json — that's its own concern
+      }
+    }
+  }
+
+  if (!origin && !packageName) return null;
+
+  const matchedBy: OrphanCandidate['matchedBy'] =
+    origin && packageName ? 'both' : origin ? 'git-origin' : 'package-name';
+
+  const isActiveDaemon = daemonEntryPoint
+    ? daemonEntryPoint.startsWith(dir + '/') || daemonEntryPoint === dir
+    : false;
+
+  return {
+    path: dir,
+    matchedBy,
+    ...(origin ? { origin } : {}),
+    ...(packageName ? { packageName } : {}),
+    isActiveDaemon,
+  };
+}
+
+/**
+ * Bounded recursive scan from `root` looking for candidate
+ * directories. Walks depth-first up to `maxDepth` levels deep,
+ * skipping ignored directory names + any directory containing the
+ * `.dkg-ignore-by-doctor` sentinel.
+ */
+async function scan(
+  deps: DoctorDeps,
+  root: string,
+  daemonEntryPoint: string | null,
+  candidates: OrphanCandidate[],
+  remainingBudget: { count: number; deadlineMs: number },
+  depth = 0,
+): Promise<void> {
+  if (depth > DEFAULT_MAX_DEPTH) return;
+  if (Date.now() > remainingBudget.deadlineMs) return;
+  if (remainingBudget.count <= 0) return;
+
+  if (!deps.exists(root)) return;
+  if (deps.exists(join(root, IGNORE_SENTINEL))) return;
+
+  const probed = await probeDirectory(deps, root, daemonEntryPoint);
+  if (probed) {
+    candidates.push(probed);
+    remainingBudget.count--;
+    // Don't recurse into a discovered DKG checkout — its sub-trees
+    // are uninteresting (nested node_modules, packages/, etc.).
+    return;
+  }
+
+  const entries = await deps.readdir(root);
+  for (const entry of entries) {
+    if (!entry.isDirectory) continue;
+    if (entry.name.startsWith('.') && depth > 0) {
+      // Allow dot-dirs at depth 0 (some operators keep ~/.dotfiles/
+      // organisations); skip nested dot-dirs.
+      continue;
+    }
+    if (SKIP_DIRECTORIES.has(entry.name)) continue;
+    if (entry.isSymbolicLink) continue;
+    await scan(deps, join(root, entry.name), daemonEntryPoint, candidates, remainingBudget, depth + 1);
+    if (Date.now() > remainingBudget.deadlineMs) return;
+    if (remainingBudget.count <= 0) return;
+  }
+}
+
+/**
+ * Run the orphan-repos check. Returns the list of findings; the
+ * orchestrator picks them up and rolls them into the report.
+ */
+export async function runOrphanReposCheck(
+  deps: DoctorDeps,
+  state: StateSummary,
+): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  const candidates: OrphanCandidate[] = [];
+
+  // 5-second budget + a max-50-candidate ceiling. Both bounds are
+  // belt-and-braces — DEFAULT_MAX_DEPTH and the dot-dir skip should
+  // keep the scan fast on a normal home tree.
+  const budget = { count: 50, deadlineMs: Date.now() + 5000 };
+  const roots = resolveScanRoots(deps);
+  for (const root of roots) {
+    await scan(deps, root, state.daemon.entryPoint, candidates, budget);
+    if (Date.now() > budget.deadlineMs) break;
+    if (budget.count <= 0) break;
+  }
+
+  for (const c of candidates) {
+    if (c.isActiveDaemon) {
+      findings.push({
+        check: 'orphan-repos',
+        severity: 'info',
+        message: `DKG repository clone at ${c.path} (active daemon's source tree)`,
+        subject: c.path,
+        details: { matchedBy: c.matchedBy, isActiveDaemon: true, ...(c.origin ? { origin: c.origin } : {}), ...(c.packageName ? { packageName: c.packageName } : {}) },
+      });
+    } else {
+      findings.push({
+        check: 'orphan-repos',
+        severity: 'warning',
+        message: `Stray DKG repository clone at ${c.path}`,
+        advisory: "This is not the running daemon. Do not 'git pull' here. Run 'dkg update' instead.",
+        subject: c.path,
+        details: { matchedBy: c.matchedBy, isActiveDaemon: false, ...(c.origin ? { origin: c.origin } : {}), ...(c.packageName ? { packageName: c.packageName } : {}) },
+      });
+    }
+  }
+
+  return findings;
+}

--- a/packages/cli/src/doctor/checks/plugin-root.ts
+++ b/packages/cli/src/doctor/checks/plugin-root.ts
@@ -1,0 +1,127 @@
+/**
+ * §4.7.6 Check: plugin install root verification.
+ *
+ * Per OT-RFC-41 §4.6.1, bare-name `routePlugins` resolve from
+ * `~/.dkg/plugins/node_modules/`. This check:
+ *
+ *   - Verifies `~/.dkg/plugins/package.json` exists and is
+ *     well-formed; if it doesn't, materialises it on the fly (the
+ *     doctor is non-destructive — it can create empty marker files
+ *     but never deletes anything).
+ *   - For each entry in `config.routePlugins`:
+ *       - Absolute paths: verify the file exists and is readable.
+ *       - Bare names: verify the package resolves from
+ *         `~/.dkg/plugins/node_modules/`. If not, emit a warning
+ *         pointing at `npm install --prefix ~/.dkg/plugins <name>`.
+ *
+ * The check does NOT attempt to spawn `node` or call `require.resolve`
+ * itself — it just walks the expected filesystem layout. That's a
+ * conservative read of "verify resolves" but a deterministic one.
+ */
+import { join } from 'node:path';
+import type { DoctorDeps, Finding } from '../types.js';
+
+interface RoutePluginEntry {
+  /** Bare name (`@scope/pkg`) or absolute path (`/abs/path/to/plugin.js`). */
+  spec: string;
+}
+
+function readRoutePlugins(config: Record<string, unknown> | undefined): RoutePluginEntry[] {
+  if (!config) return [];
+  const raw = config.routePlugins;
+  if (!Array.isArray(raw)) return [];
+  const entries: RoutePluginEntry[] = [];
+  for (const item of raw) {
+    if (typeof item === 'string') {
+      entries.push({ spec: item });
+      continue;
+    }
+    if (item && typeof item === 'object') {
+      const spec = (item as { spec?: unknown; name?: unknown; path?: unknown }).spec
+        ?? (item as { name?: unknown }).name
+        ?? (item as { path?: unknown }).path;
+      if (typeof spec === 'string') entries.push({ spec });
+    }
+  }
+  return entries;
+}
+
+async function loadConfig(deps: DoctorDeps): Promise<Record<string, unknown> | undefined> {
+  const raw = await deps.readFile(join(deps.dkgHome, 'config.json'));
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isAbsolutePathSpec(spec: string): boolean {
+  return spec.startsWith('/') || /^[A-Za-z]:[\\/]/.test(spec);
+}
+
+/** Resolve a bare-name `@scope/pkg` or `pkg` to its expected nested directory. */
+function bareNameDir(pluginsNodeModules: string, spec: string): string {
+  if (spec.startsWith('@')) {
+    const slash = spec.indexOf('/');
+    if (slash === -1) return join(pluginsNodeModules, spec);
+    return join(pluginsNodeModules, spec.slice(0, slash), spec.slice(slash + 1));
+  }
+  return join(pluginsNodeModules, spec);
+}
+
+export async function runPluginRootCheck(deps: DoctorDeps): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  const pluginsRoot = join(deps.dkgHome, 'plugins');
+  const pluginsPackageJson = join(pluginsRoot, 'package.json');
+  const pluginsNodeModules = join(pluginsRoot, 'node_modules');
+
+  if (!deps.exists(pluginsPackageJson)) {
+    // Don't materialise from a check — checks are read-only. The
+    // daemon's first-start hook (Bundle B1e) is the right place to
+    // create the stable plugin root. Just surface its absence.
+    findings.push({
+      check: 'plugin-root',
+      severity: 'info',
+      message: `Stable plugin install root not yet materialised: ${pluginsRoot}`,
+      advisory: "The first 'dkg start' under rc.12 creates this. Until then, bare-name routePlugins resolve from createRequire(import.meta.url)'s lookup chain, which may not survive update cycles.",
+      subject: pluginsRoot,
+    });
+  }
+
+  const config = await loadConfig(deps);
+  const entries = readRoutePlugins(config);
+  if (entries.length === 0) return findings;
+
+  for (const { spec } of entries) {
+    if (isAbsolutePathSpec(spec)) {
+      if (!deps.exists(spec)) {
+        findings.push({
+          check: 'plugin-root',
+          severity: 'error',
+          message: `routePlugin path not found: ${spec}`,
+          advisory: 'The plugin file no longer exists at the configured path. Fix the absolute path in ~/.dkg/config.json#routePlugins, or remove the entry.',
+          subject: spec,
+        });
+      }
+      continue;
+    }
+
+    // Bare name. Expected location: ~/.dkg/plugins/node_modules/<spec>/.
+    const expectedDir = bareNameDir(pluginsNodeModules, spec);
+    if (deps.exists(expectedDir)) continue;
+    findings.push({
+      check: 'plugin-root',
+      severity: 'warning',
+      message: `routePlugin '${spec}' is not installed in the stable plugin root`,
+      advisory: `It may stop loading after the next 'dkg update'. Run 'npm install --prefix ${pluginsRoot} ${spec}' to install it into the stable plugin root.`,
+      subject: spec,
+      details: { pluginsRoot, expectedDir },
+    });
+  }
+
+  return findings;
+}

--- a/packages/cli/src/doctor/checks/served-ui-mismatch.ts
+++ b/packages/cli/src/doctor/checks/served-ui-mismatch.ts
@@ -1,0 +1,169 @@
+/**
+ * §4.7.5 Check: served-UI / source mismatch.
+ *
+ * Detects "the browser is showing an old UI" — a real pain point
+ * reported during local DKG / Hermes / OpenClaw work where a service
+ * worker or PWA cache shows a UI version that doesn't match the
+ * active code.
+ *
+ * Heuristic:
+ *   - Fetch `http://127.0.0.1:<apiPort>/ui/`. Extract a version
+ *     fingerprint from `<meta name="version" content="…">` if
+ *     present, OR the first hashed asset URL in a `<script src="…">`
+ *     / `<link href="…">` tag (Vite-style filename hashes are the
+ *     fingerprint for an immutable bundle).
+ *   - Read the installed UI package's `package.json#version` from
+ *     the appropriate location:
+ *       - Edge: `<npmGlobalDkg>/node_modules/@origintrail-official/dkg-node-ui/package.json`
+ *       - Core: `<active-slot>/node_modules/@origintrail-official/dkg-node-ui/package.json`
+ *   - Mismatch → warning with the hard-refresh / clear-service-worker
+ *     advisory.
+ *
+ * Skipped (with `info` reason) when the daemon is unreachable or the
+ * UI route returns non-200.
+ */
+import { join } from 'node:path';
+import type { DoctorDeps, Finding, StateSummary } from '../types.js';
+
+async function readUiPackageVersion(deps: DoctorDeps, state: StateSummary): Promise<{ version: string | null; sourcePath: string | null }> {
+  let basePath: string | null = null;
+  if (state.daemon.nodeRole === 'core' && state.paths.activeSlot) {
+    basePath = join(deps.dkgHome, 'releases', state.paths.activeSlot);
+  } else if (state.paths.npmGlobalDkg) {
+    basePath = state.paths.npmGlobalDkg;
+  }
+  if (!basePath) return { version: null, sourcePath: null };
+
+  // Try `<base>/node_modules/@origintrail-official/dkg-node-ui/package.json`
+  // first (npm layout), then `<base>/packages/node-ui/package.json` (git
+  // layout — applies to monorepo contributor runs that take this code path
+  // by mistake; informational only).
+  const candidates = [
+    join(basePath, 'node_modules', '@origintrail-official', 'dkg-node-ui', 'package.json'),
+    join(basePath, 'packages', 'node-ui', 'package.json'),
+  ];
+
+  for (const candidate of candidates) {
+    if (!deps.exists(candidate)) continue;
+    const raw = await deps.readFile(candidate);
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw);
+      const v = (parsed as { version?: unknown }).version;
+      if (typeof v === 'string' && v.length > 0) {
+        return { version: v, sourcePath: candidate };
+      }
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return { version: null, sourcePath: null };
+}
+
+function extractServedVersion(html: string): { kind: 'meta' | 'asset-hash' | null; value: string | null } {
+  // Prefer <meta name="version" content="…"> — explicit and authoritative.
+  const metaMatch = html.match(/<meta[^>]*name=["']version["'][^>]*content=["']([^"']+)["']/i);
+  if (metaMatch) return { kind: 'meta', value: metaMatch[1] };
+
+  // Fallback: first hashed asset URL in <script src="…"> or <link href="…">.
+  // Vite produces `foo-DEADBEEF.js`; Webpack produces `foo.deadbeef.js`. Both
+  // count as fingerprints — we just need a stable per-build string.
+  const scriptMatch = html.match(/<script[^>]*src=["']([^"']+\.js)["']/i);
+  if (scriptMatch) {
+    const filenameMatch = scriptMatch[1].match(/([\w.\-_]+\.js)$/);
+    if (filenameMatch && /[A-Fa-f0-9]{6,}/.test(filenameMatch[1])) {
+      return { kind: 'asset-hash', value: filenameMatch[1] };
+    }
+  }
+  return { kind: null, value: null };
+}
+
+export async function runServedUiMismatchCheck(
+  deps: DoctorDeps,
+  state: StateSummary,
+): Promise<Finding[]> {
+  const findings: Finding[] = [];
+
+  if (!state.daemon.version) {
+    findings.push({
+      check: 'served-ui-mismatch',
+      severity: 'info',
+      message: 'Served-UI check skipped: daemon unreachable',
+      advisory: "Start the daemon ('dkg start') and re-run 'dkg doctor' to enable this check.",
+    });
+    return findings;
+  }
+
+  const uiUrl = `http://127.0.0.1:${deps.apiPort}/ui/`;
+  const html = await deps.fetchText(uiUrl);
+  if (!html) {
+    findings.push({
+      check: 'served-ui-mismatch',
+      severity: 'info',
+      message: 'Served-UI check skipped: /ui/ returned no HTML',
+      advisory: 'The daemon is up but the node UI is not serving the expected HTML index. May be intentional (UI disabled) or a config issue.',
+    });
+    return findings;
+  }
+
+  const served = extractServedVersion(html);
+  const installed = await readUiPackageVersion(deps, state);
+
+  if (served.value === null) {
+    findings.push({
+      check: 'served-ui-mismatch',
+      severity: 'info',
+      message: 'Served-UI check skipped: no version fingerprint found in served HTML',
+      advisory: 'The UI does not expose <meta name="version"> nor a hashed asset URL. Consider adding one to make this check meaningful.',
+    });
+    return findings;
+  }
+
+  if (installed.version === null) {
+    findings.push({
+      check: 'served-ui-mismatch',
+      severity: 'info',
+      message: 'Served-UI check skipped: cannot locate installed UI package.json',
+      details: {
+        servedFingerprint: served.value,
+        servedKind: served.kind,
+      },
+    });
+    return findings;
+  }
+
+  // If served-version is a meta tag, compare against installed version
+  // string directly. If it's an asset-hash, just record it for the
+  // operator — there's no clean way to map hash→version without
+  // shipping a hash index, which is out of scope for this RFC. The
+  // asset-hash branch is informational only.
+  if (served.kind === 'meta') {
+    if (served.value !== installed.version) {
+      findings.push({
+        check: 'served-ui-mismatch',
+        severity: 'warning',
+        message: `Served UI version (${served.value}) does not match installed (${installed.version})`,
+        advisory: "Likely a stale browser / PWA / service-worker cache. Hard-refresh (Cmd+Shift+R) or clear the service worker. Also confirm the daemon was restarted after the UI package was updated.",
+        details: {
+          servedVersion: served.value,
+          installedVersion: installed.version,
+          installedSource: installed.sourcePath,
+        },
+      });
+    }
+  } else {
+    findings.push({
+      check: 'served-ui-mismatch',
+      severity: 'info',
+      message: `Served UI fingerprint: ${served.value} (installed UI version: ${installed.version})`,
+      advisory: 'Asset-hash-only fingerprints cannot be cross-referenced against package versions. If the UI looks stale, hard-refresh (Cmd+Shift+R) and clear service workers.',
+      details: {
+        servedFingerprint: served.value,
+        installedVersion: installed.version,
+        installedSource: installed.sourcePath,
+      },
+    });
+  }
+
+  return findings;
+}

--- a/packages/cli/src/doctor/checks/version-skew.ts
+++ b/packages/cli/src/doctor/checks/version-skew.ts
@@ -1,0 +1,98 @@
+/**
+ * §4.7.4 Check: version skew.
+ *
+ * Detects "your install isn't what the daemon is running" mismatches
+ * that the slot indirection (Core) or supervisor lifecycle (Edge or
+ * Core) can produce.
+ *
+ * **Edge:** compare `npm-global install version` with the daemon's
+ * `/api/status` version. Different directions of skew produce
+ * different advisories.
+ *
+ * **Core:** compare the active slot's
+ * `node_modules/@origintrail-official/dkg/package.json#version` with
+ * `/api/status` — slot swap completed but supervisor failed to
+ * restart.
+ */
+import { join } from 'node:path';
+import type { DoctorDeps, Finding, StateSummary } from '../types.js';
+
+async function readPackageVersion(deps: DoctorDeps, packageJsonPath: string): Promise<string | null> {
+  const raw = await deps.readFile(packageJsonPath);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    const v = (parsed as { version?: unknown }).version;
+    return typeof v === 'string' && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function runVersionSkewCheck(
+  deps: DoctorDeps,
+  state: StateSummary,
+): Promise<Finding[]> {
+  const findings: Finding[] = [];
+
+  if (!state.daemon.version) {
+    // Daemon unreachable — can't compare. Surfaced as part of the
+    // state summary; no separate finding needed.
+    return findings;
+  }
+
+  if (state.daemon.nodeRole === 'core') {
+    if (!state.paths.activeSlot) return findings;
+    const slotName = state.paths.activeSlot;
+    const slotPkgPath = join(deps.dkgHome, 'releases', slotName, 'node_modules', '@origintrail-official', 'dkg', 'package.json');
+    const slotVersion = await readPackageVersion(deps, slotPkgPath);
+    if (!slotVersion) return findings;
+    if (slotVersion !== state.daemon.version) {
+      findings.push({
+        check: 'version-skew',
+        severity: 'warning',
+        message: `Core slot version (${slotVersion}) differs from running daemon (${state.daemon.version})`,
+        advisory: "Slot swap completed but supervisor failed to restart. Run 'dkg restart' to reload.",
+        details: { slotVersion, daemonVersion: state.daemon.version, slot: slotName },
+      });
+    }
+    return findings;
+  }
+
+  // Edge.
+  if (!state.paths.npmGlobalDkg) return findings;
+  const npmGlobalPkgPath = join(state.paths.npmGlobalDkg, 'package.json');
+  const npmGlobalVersion = await readPackageVersion(deps, npmGlobalPkgPath);
+  if (!npmGlobalVersion) return findings;
+  if (npmGlobalVersion === state.daemon.version) return findings;
+
+  const semverCompare = (a: string, b: string): number => {
+    const norm = (v: string) => v.replace(/^v/, '').split(/[-+]/)[0].split('.').map((n) => parseInt(n, 10));
+    const [a1, a2, a3] = norm(a).concat([0, 0, 0]);
+    const [b1, b2, b3] = norm(b).concat([0, 0, 0]);
+    if (a1 !== b1) return a1 - b1;
+    if (a2 !== b2) return a2 - b2;
+    return a3 - b3;
+  };
+
+  const order = semverCompare(npmGlobalVersion, state.daemon.version);
+  if (order > 0) {
+    findings.push({
+      check: 'version-skew',
+      severity: 'warning',
+      message: `npm-global install is ahead of running daemon (${npmGlobalVersion} > ${state.daemon.version})`,
+      advisory: "The daemon needs a restart to pick up the new install. Run 'dkg restart'.",
+      details: { npmGlobalVersion, daemonVersion: state.daemon.version },
+    });
+  } else {
+    findings.push({
+      check: 'version-skew',
+      severity: 'warning',
+      message: `Running daemon is ahead of npm-global install (${state.daemon.version} > ${npmGlobalVersion})`,
+      advisory: "Something is overriding the entry-point resolution. Check $PATH and any DKG_NO_BLUE_GREEN or DKG_HOME env vars.",
+      details: { npmGlobalVersion, daemonVersion: state.daemon.version },
+    });
+  }
+
+  return findings;
+}

--- a/packages/cli/src/doctor/index.ts
+++ b/packages/cli/src/doctor/index.ts
@@ -1,0 +1,281 @@
+/**
+ * `dkg doctor` orchestrator (OT-RFC-41 §4.7).
+ *
+ * Wires the state summary + six anomaly checks into a single
+ * {@link DoctorReport}. Used by the `dkg doctor` CLI command and
+ * (in a narrow subset form) by `dkg update`'s pre-flight check.
+ *
+ * Each check is pure — given a {@link DoctorDeps} and a
+ * {@link StateSummary}, it returns findings. The orchestrator
+ * threads real I/O through {@link createProductionDeps} in
+ * production, and tests inject stub deps.
+ */
+import { existsSync, statSync, readlinkSync, readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { spawn } from 'node:child_process';
+import { dkgDir, isDkgMonorepo, repoDir } from '../config.js';
+import { findDkgMonorepoRoot } from '@origintrail-official/dkg-core';
+import { collectStateSummary } from './state-summary.js';
+import { runOrphanReposCheck } from './checks/orphan-repos.js';
+import { runConfigSanityCheck } from './checks/config-sanity.js';
+import { runInstallLayoutCheck } from './checks/install-layout.js';
+import { runVersionSkewCheck } from './checks/version-skew.js';
+import { runServedUiMismatchCheck } from './checks/served-ui-mismatch.js';
+import { runPluginRootCheck } from './checks/plugin-root.js';
+import type { DoctorDeps, DoctorReport, Finding, StateSummary } from './types.js';
+
+export type { DoctorDeps, DoctorReport, Finding, StateSummary } from './types.js';
+export { collectStateSummary } from './state-summary.js';
+
+/** Set of check IDs the orchestrator knows about. */
+export const ALL_CHECK_IDS = [
+  'orphan-repos',
+  'config-sanity',
+  'install-layout',
+  'version-skew',
+  'served-ui-mismatch',
+  'plugin-root',
+] as const;
+
+export type CheckId = (typeof ALL_CHECK_IDS)[number];
+
+/**
+ * Subset orchestration for `dkg update`'s pre-flight per §4.7.7
+ * invocation pattern #3. Only `install-layout` + `version-skew` run.
+ */
+export const UPDATE_PREFLIGHT_CHECKS = ['install-layout', 'version-skew'] as const satisfies readonly CheckId[];
+
+export interface RunDoctorOptions {
+  /** Which checks to run; defaults to all six. */
+  checks?: readonly CheckId[];
+  /** API port to probe. Defaults to 9200. */
+  apiPort?: number;
+}
+
+/**
+ * Run the doctor with the given deps + options. Returns the full
+ * {@link DoctorReport} (state summary + findings + exit code).
+ */
+export async function runDoctor(
+  deps: DoctorDeps,
+  opts: RunDoctorOptions = {},
+): Promise<DoctorReport> {
+  const state = await collectStateSummary(deps);
+  const checks = (opts.checks ?? ALL_CHECK_IDS).filter((id) => !deps.skipChecks.includes(id));
+  const findings: Finding[] = [];
+
+  for (const id of checks) {
+    try {
+      let next: Finding[] = [];
+      switch (id) {
+        case 'orphan-repos':
+          next = await runOrphanReposCheck(deps, state);
+          break;
+        case 'config-sanity':
+          next = await runConfigSanityCheck(deps);
+          break;
+        case 'install-layout':
+          next = await runInstallLayoutCheck(deps, state);
+          break;
+        case 'version-skew':
+          next = await runVersionSkewCheck(deps, state);
+          break;
+        case 'served-ui-mismatch':
+          next = await runServedUiMismatchCheck(deps, state);
+          break;
+        case 'plugin-root':
+          next = await runPluginRootCheck(deps);
+          break;
+        default: {
+          // Defensive: unknown id — surface it but keep going.
+          const exhaustive: never = id;
+          void exhaustive;
+        }
+      }
+      findings.push(...next);
+    } catch (err: any) {
+      findings.push({
+        check: id,
+        severity: 'error',
+        message: `Check '${id}' crashed`,
+        advisory: `Internal error: ${err?.message ?? err}. Open a bug at https://github.com/OriginTrail/dkg/issues.`,
+      });
+    }
+  }
+
+  const hasError = findings.some((f) => f.severity === 'error');
+  const hasWarning = findings.some((f) => f.severity === 'warning');
+  const exitCode: 0 | 1 | 2 = hasError ? 2 : hasWarning ? 1 : 0;
+
+  return {
+    state,
+    findings,
+    exitCode,
+    schemaVersion: 1,
+  };
+}
+
+/**
+ * Build the production {@link DoctorDeps} surface — real Node `fs`,
+ * `child_process`, and `fetch` calls. Tests inject their own.
+ */
+export function createProductionDeps(opts: { apiPort?: number } = {}): DoctorDeps {
+  const cwd = process.cwd();
+  const home = homedir();
+  const monoRoot = repoDir();
+  const isMono = isDkgMonorepo();
+
+  return {
+    dkgHome: dkgDir(),
+    dkgHomeEnv: process.env.DKG_HOME ?? null,
+    cwd,
+    home,
+    apiPort: opts.apiPort ?? 9200,
+    isMonorepo: isMono,
+    monorepoRoot: monoRoot ?? (isMono ? findDkgMonorepoRoot(cwd) : null),
+    // Doctor scanRoots / skipChecks come from config; the orchestrator
+    // doesn't load the config itself — the caller may pre-populate
+    // these from `loadConfig()` before calling `createProductionDeps`.
+    // For now we default to []; cli.ts overlays the config values.
+    extraScanRoots: [],
+    skipChecks: [],
+
+    exists(path: string): boolean {
+      try { return existsSync(path); } catch { return false; }
+    },
+    async readFile(path: string): Promise<string | null> {
+      try { return readFileSync(path, 'utf-8'); } catch { return null; }
+    },
+    async readlink(path: string): Promise<string | null> {
+      try { return readlinkSync(path); } catch { return null; }
+    },
+    async stat(path: string) {
+      try {
+        const s = statSync(path);
+        return {
+          mtimeMs: s.mtimeMs,
+          uid: s.uid,
+          isDirectory: s.isDirectory(),
+          isSymbolicLink: s.isSymbolicLink(),
+        };
+      } catch {
+        return null;
+      }
+    },
+    async readdir(path: string) {
+      try {
+        return readdirSync(path, { withFileTypes: true }).map((e) => ({
+          name: e.name,
+          isDirectory: e.isDirectory(),
+          isSymbolicLink: e.isSymbolicLink(),
+        }));
+      } catch {
+        return [];
+      }
+    },
+    async runCommand(cmd, args) {
+      return new Promise((resolve) => {
+        try {
+          const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+          let stdout = '';
+          let stderr = '';
+          child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf-8'); });
+          child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf-8'); });
+          child.on('error', () => resolve(null));
+          child.on('exit', (code) => resolve({ stdout, stderr, code: code ?? -1 }));
+        } catch {
+          resolve(null);
+        }
+      });
+    },
+    async fetchJson(url: string): Promise<Record<string, unknown> | null> {
+      try {
+        const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+        if (!res.ok) return null;
+        const text = await res.text();
+        const parsed = JSON.parse(text);
+        return typeof parsed === 'object' && parsed !== null
+          ? (parsed as Record<string, unknown>)
+          : null;
+      } catch {
+        return null;
+      }
+    },
+    async fetchText(url: string): Promise<string | null> {
+      try {
+        const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+        if (!res.ok) return null;
+        return await res.text();
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * Render a {@link DoctorReport} as a human-readable string. Matches
+ * the layout the agent SKILL guidance teaches operators to expect.
+ * The first block is the state summary; the second is findings,
+ * grouped by severity.
+ */
+export function formatDoctorReport(report: DoctorReport): string {
+  const lines: string[] = [];
+  lines.push('DKG doctor — state summary');
+  lines.push('─'.repeat(60));
+  const s = report.state;
+  const fmt = (label: string, value: unknown): string => {
+    const display = value === null || value === undefined ? '(none)' : typeof value === 'string' ? value : JSON.stringify(value);
+    return `  ${label.padEnd(28)} ${display}`;
+  };
+  lines.push(fmt('daemon.pid', s.daemon.pid));
+  lines.push(fmt('daemon.entryPoint', s.daemon.entryPoint));
+  lines.push(fmt('daemon.version', s.daemon.version));
+  lines.push(fmt('daemon.commit', s.daemon.commit));
+  lines.push(fmt('daemon.commitShort', s.daemon.commitShort));
+  lines.push(fmt('daemon.buildTime', s.daemon.buildTime));
+  lines.push(fmt('daemon.distTag', s.daemon.distTag));
+  lines.push(fmt('daemon.installMode', s.daemon.installMode));
+  lines.push(fmt('daemon.nodeRole', s.daemon.nodeRole));
+  if (s.daemon.unreachableReason) lines.push(fmt('daemon (unreachable)', s.daemon.unreachableReason));
+  lines.push(fmt('cli.globalPath', s.cli.globalPath));
+  lines.push(fmt('cli.version', s.cli.version));
+  lines.push(fmt('paths.dkgHome', s.paths.dkgHome));
+  lines.push(fmt('paths.dkgHomeEnv', s.paths.dkgHomeEnv));
+  lines.push(fmt('paths.activeSlot', s.paths.activeSlot));
+  lines.push(fmt('paths.npmGlobalDkg', s.paths.npmGlobalDkg));
+  lines.push(fmt('paths.pluginsRoot', s.paths.pluginsRoot));
+  lines.push(fmt('autoUpdate.enabled', s.autoUpdate.enabled));
+  lines.push(fmt('autoUpdate.checkInterval', `${s.autoUpdate.checkIntervalMinutes} min`));
+  lines.push(fmt('autoUpdate.allowPrerelease', s.autoUpdate.allowPrerelease));
+  lines.push(fmt('autoUpdate.source', s.autoUpdate.source));
+  lines.push(fmt('autoUpdate.lastCheck', s.autoUpdate.lastCheck));
+  lines.push(fmt('autoUpdate.lastError', s.autoUpdate.lastError ? '(set — see report below)' : null));
+  lines.push(fmt('previousVersion', s.previousVersion));
+  lines.push('');
+
+  const order: Array<Finding['severity']> = ['error', 'warning', 'info'];
+  const grouped = new Map<Finding['severity'], Finding[]>();
+  for (const sev of order) grouped.set(sev, []);
+  for (const f of report.findings) grouped.get(f.severity)!.push(f);
+
+  if (report.findings.length === 0) {
+    lines.push('No anomalies detected. (exit 0)');
+    return lines.join('\n');
+  }
+
+  lines.push('Findings');
+  lines.push('─'.repeat(60));
+  for (const sev of order) {
+    const group = grouped.get(sev)!;
+    if (group.length === 0) continue;
+    lines.push(`[${sev.toUpperCase()}] ${group.length} finding${group.length === 1 ? '' : 's'}`);
+    for (const f of group) {
+      lines.push(`  • [${f.check}] ${f.message}`);
+      if (f.advisory) lines.push(`      → ${f.advisory}`);
+    }
+    lines.push('');
+  }
+  lines.push(`Exit code: ${report.exitCode}`);
+  return lines.join('\n');
+}

--- a/packages/cli/src/doctor/state-summary.ts
+++ b/packages/cli/src/doctor/state-summary.ts
@@ -1,0 +1,271 @@
+/**
+ * Always-reported state summary for `dkg doctor` (OT-RFC-41 §4.7.0).
+ *
+ * Eighteen fields gathered from a mix of:
+ *   - `~/.dkg/config.json` + `~/.dkg/daemon.pid` + `~/.dkg/previous-version`
+ *   - `~/.dkg/auto-update/{last-check,last-error}.json`
+ *   - `GET /api/status` (added by §4.9 — populates daemon.commit, distTag, buildTime, installMode)
+ *   - `/proc/<pid>/cmdline` (Linux) / `ps -o command=` (macOS) — daemon entryPoint
+ *   - `which dkg` + `<cli> --version` — CLI globalPath / version
+ *   - `npm root -g` — paths.npmGlobalDkg
+ *
+ * Each gather step swallows its own errors and falls back to `null`.
+ * The summary is informational; no check ever crashes on a
+ * partially-collected summary.
+ */
+import { join } from 'node:path';
+import type { DoctorDeps, LocalInstallMode, StateSummary } from './types.js';
+
+const AUTO_UPDATE_LAST_CHECK_FILE = 'auto-update/last-check.json';
+const AUTO_UPDATE_LAST_ERROR_FILE = 'auto-update/last-error.json';
+const AUTO_UPDATE_LAST_ERROR_MAX_BYTES = 1024;
+
+/**
+ * Detect the running CLI's install mode locally. Used as a fallback
+ * when `GET /api/status#installMode` is unreachable (daemon down).
+ * On a healthy daemon the API value supersedes this, since the
+ * daemon's own entry-point resolution is the authoritative signal.
+ *
+ * Heuristic order:
+ *   1. `isMonorepo` flag from deps — set by the orchestrator before
+ *      calling this — wins. Monorepo work is unambiguous.
+ *   2. `cli.globalPath` (if resolved) inside `/usr/local/lib/node_modules/`,
+ *      `/opt/homebrew/lib/node_modules/` (Apple Silicon Homebrew),
+ *      `~/.nvm/`, or `~/.volta/` → `npm-global`.
+ *   3. CLI path inside an arbitrary `node_modules/` (not one of the
+ *      global patterns above) → `npm-local`.
+ *   4. Otherwise: `unknown`.
+ */
+export function detectLocalInstallMode(
+  isMonorepo: boolean,
+  cliGlobalPath: string | null,
+): LocalInstallMode {
+  if (isMonorepo) return 'monorepo';
+  if (!cliGlobalPath) return 'unknown';
+  const normalised = cliGlobalPath.replace(/\\/g, '/');
+  const globalMarkers = [
+    '/usr/local/lib/node_modules/',
+    '/opt/homebrew/lib/node_modules/',
+    '/usr/lib/node_modules/',
+    '/.nvm/',
+    '/.volta/',
+    '/.fnm/',
+    '/.asdf/installs/nodejs/',
+  ];
+  for (const marker of globalMarkers) {
+    if (normalised.includes(marker)) return 'npm-global';
+  }
+  if (normalised.includes('/node_modules/')) return 'npm-local';
+  return 'unknown';
+}
+
+/**
+ * Resolve the running daemon's entry point (argv[1]) from its PID
+ * using platform-appropriate primitives. Returns `null` when the
+ * resolution fails for any reason (no PID, process gone, permission
+ * denied, unknown platform) — the doctor's UI surfaces that as
+ * `daemon.entryPoint: null`.
+ */
+async function resolveDaemonEntryPoint(
+  deps: DoctorDeps,
+  pid: number,
+): Promise<string | null> {
+  if (process.platform === 'linux') {
+    const cmdline = await deps.readFile(`/proc/${pid}/cmdline`);
+    if (!cmdline) return null;
+    // /proc/<pid>/cmdline is NUL-separated argv. argv[1] is the script.
+    const parts = cmdline.split('\0').filter(Boolean);
+    return parts[1] ?? null;
+  }
+  // macOS / BSD: `ps -o command= -p <pid>` returns the full command
+  // line as a single string. Use Node's path-ish split on whitespace
+  // to extract argv[1]. This isn't perfect for paths with spaces,
+  // but matches what an operator running `ps` by hand would see.
+  if (process.platform === 'darwin' || process.platform === 'freebsd' || process.platform === 'openbsd') {
+    const result = await deps.runCommand('ps', ['-o', 'command=', '-p', String(pid)]);
+    if (!result || result.code !== 0) return null;
+    const tokens = result.stdout.trim().split(/\s+/);
+    return tokens[1] ?? null;
+  }
+  return null;
+}
+
+/**
+ * Read and parse `~/.dkg/config.json`. Returns `{}` on missing /
+ * malformed config — checks downstream report explicit findings
+ * for those conditions.
+ */
+async function readDkgConfig(deps: DoctorDeps): Promise<Record<string, unknown>> {
+  const raw = await deps.readFile(join(deps.dkgHome, 'config.json'));
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+async function readPid(deps: DoctorDeps): Promise<number | null> {
+  const raw = await deps.readFile(join(deps.dkgHome, 'daemon.pid'));
+  if (!raw) return null;
+  const n = parseInt(raw.trim(), 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+async function readPreviousVersion(deps: DoctorDeps): Promise<string | null> {
+  const raw = await deps.readFile(join(deps.dkgHome, 'previous-version'));
+  return raw ? raw.trim() || null : null;
+}
+
+async function readActiveSlot(deps: DoctorDeps, nodeRole: 'edge' | 'core' | null): Promise<string | null> {
+  if (nodeRole !== 'core') return null;
+  const slot = await deps.readlink(join(deps.dkgHome, 'releases', 'current'));
+  return slot ?? null;
+}
+
+async function readAutoUpdateLastCheck(deps: DoctorDeps): Promise<string | null> {
+  const raw = await deps.readFile(join(deps.dkgHome, AUTO_UPDATE_LAST_CHECK_FILE));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    const ts = parsed && typeof parsed === 'object' ? (parsed as { timestamp?: unknown }).timestamp : null;
+    return typeof ts === 'string' ? ts : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readAutoUpdateLastError(deps: DoctorDeps): Promise<string | null> {
+  const raw = await deps.readFile(join(deps.dkgHome, AUTO_UPDATE_LAST_ERROR_FILE));
+  if (!raw) return null;
+  // Truncate to 1 KB to keep the JSON output digestable. The full
+  // error remains on disk for an operator to grep manually.
+  return raw.length > AUTO_UPDATE_LAST_ERROR_MAX_BYTES
+    ? raw.slice(0, AUTO_UPDATE_LAST_ERROR_MAX_BYTES) + '\n…[truncated]'
+    : raw;
+}
+
+async function resolveCliGlobalPath(deps: DoctorDeps): Promise<string | null> {
+  // `which` on POSIX, `where.exe` on Windows. Both return non-zero
+  // when the binary isn't on PATH.
+  const cmd = process.platform === 'win32' ? 'where.exe' : 'which';
+  const result = await deps.runCommand(cmd, ['dkg']);
+  if (!result || result.code !== 0) return null;
+  const first = result.stdout.split(/\r?\n/).find((line) => line.trim());
+  return first ? first.trim() : null;
+}
+
+async function resolveCliVersion(deps: DoctorDeps, cliPath: string | null): Promise<string | null> {
+  if (!cliPath) return null;
+  // Spawn the resolved CLI so we report what `which dkg` says, not
+  // whatever's currently exec-ing the doctor. Mismatch between the
+  // two is itself a finding in §4.7.4 — surfacing them separately
+  // here lets the version-skew check do the comparison.
+  const result = await deps.runCommand(cliPath, ['--version']);
+  if (!result || result.code !== 0) return null;
+  return result.stdout.trim() || null;
+}
+
+async function resolveNpmGlobalDkg(deps: DoctorDeps): Promise<string | null> {
+  const result = await deps.runCommand('npm', ['root', '-g']);
+  if (!result || result.code !== 0) return null;
+  const root = result.stdout.trim();
+  if (!root) return null;
+  return join(root, '@origintrail-official', 'dkg');
+}
+
+/**
+ * Collect the §4.7.0 state summary. Each sub-step is independent
+ * and swallows its own failures — partial collection is preferred
+ * over no collection at all. The doctor's checks below operate on
+ * whatever fields landed.
+ */
+export async function collectStateSummary(deps: DoctorDeps): Promise<StateSummary> {
+  const config = await readDkgConfig(deps);
+  const nodeRoleRaw = (config as { nodeRole?: unknown }).nodeRole;
+  const nodeRole: 'edge' | 'core' | null =
+    nodeRoleRaw === 'core' ? 'core' : nodeRoleRaw === 'edge' ? 'edge' : 'edge';
+
+  const autoUpdateRaw = (config as { autoUpdate?: Record<string, unknown> }).autoUpdate ?? {};
+  const enabled = autoUpdateRaw.enabled === false ? false : true;
+  const checkIntervalMinutes =
+    typeof autoUpdateRaw.checkIntervalMinutes === 'number'
+      ? autoUpdateRaw.checkIntervalMinutes
+      : 30;
+  const allowPrerelease = Boolean(autoUpdateRaw.allowPrerelease ?? true);
+  const source = typeof autoUpdateRaw.source === 'string' ? autoUpdateRaw.source : null;
+
+  const pid = await readPid(deps);
+  const entryPoint = pid !== null ? await resolveDaemonEntryPoint(deps, pid) : null;
+
+  const cliGlobalPath = await resolveCliGlobalPath(deps);
+  const cliVersion = await resolveCliVersion(deps, cliGlobalPath);
+
+  // Probe the daemon. Any per-field failure leaves `null` so checks
+  // can still operate on the rest of the summary.
+  const statusUrl = `http://127.0.0.1:${deps.apiPort}/api/status`;
+  const status = await deps.fetchJson(statusUrl);
+  const unreachableReason = status === null ? 'GET /api/status returned no parseable body' : undefined;
+
+  const stringField = (name: string): string | null => {
+    if (!status) return null;
+    const v = (status as Record<string, unknown>)[name];
+    return typeof v === 'string' && v.length > 0 ? v : null;
+  };
+
+  const daemonInstallModeRaw = stringField('installMode');
+  const daemonInstallMode: 'npm-global' | 'npm-local' | 'monorepo' | 'unknown' | null =
+    daemonInstallModeRaw === 'npm-global'
+      || daemonInstallModeRaw === 'npm-local'
+      || daemonInstallModeRaw === 'monorepo'
+      || daemonInstallModeRaw === 'unknown'
+        ? daemonInstallModeRaw
+        : status
+          // §4.9 not deployed yet on this daemon — fall back to local detection.
+          ? detectLocalInstallMode(deps.isMonorepo, cliGlobalPath)
+          : detectLocalInstallMode(deps.isMonorepo, cliGlobalPath);
+
+  const activeSlot = await readActiveSlot(deps, nodeRole);
+  const npmGlobalDkg = await resolveNpmGlobalDkg(deps);
+  const previousVersion = await readPreviousVersion(deps);
+  const lastCheck = await readAutoUpdateLastCheck(deps);
+  const lastError = await readAutoUpdateLastError(deps);
+
+  return {
+    daemon: {
+      pid,
+      entryPoint,
+      version: stringField('version'),
+      commit: stringField('commit'),
+      commitShort: stringField('commitShort'),
+      buildTime: stringField('buildTime'),
+      distTag: stringField('distTag'),
+      installMode: daemonInstallMode,
+      nodeRole,
+      ...(unreachableReason ? { unreachableReason } : {}),
+    },
+    cli: {
+      globalPath: cliGlobalPath,
+      version: cliVersion,
+    },
+    paths: {
+      dkgHome: deps.dkgHome,
+      dkgHomeEnv: deps.dkgHomeEnv,
+      activeSlot,
+      npmGlobalDkg,
+      pluginsRoot: join(deps.dkgHome, 'plugins'),
+    },
+    autoUpdate: {
+      enabled,
+      checkIntervalMinutes,
+      allowPrerelease,
+      source,
+      lastCheck,
+      lastError,
+    },
+    previousVersion,
+  };
+}

--- a/packages/cli/src/doctor/types.ts
+++ b/packages/cli/src/doctor/types.ts
@@ -1,0 +1,205 @@
+/**
+ * Type surface for `dkg doctor` (OT-RFC-41 §4.7).
+ *
+ * The doctor is intentionally pure(-ish): every check is an async
+ * function that takes a {@link DoctorDeps} object (file-system,
+ * fetch, command runners) and returns a list of {@link Finding}s.
+ * The orchestrator in `index.ts` wires real I/O in production and
+ * tests inject stub deps without touching the real filesystem or
+ * spawning processes.
+ *
+ * Exit codes (per §4.7):
+ *   - 0 = all healthy (zero findings, or only `info` findings)
+ *   - 1 = at least one `warning` (no `error`s)
+ *   - 2 = at least one `error`
+ */
+
+/** Severity of a single finding. */
+export type FindingSeverity = 'info' | 'warning' | 'error';
+
+/** A single observation produced by a check. */
+export interface Finding {
+  /** Identifier of the check that produced this finding (e.g. `orphan-repos`). */
+  check: string;
+  /** Severity tier — determines `dkg doctor`'s exit code. */
+  severity: FindingSeverity;
+  /** One-line summary suitable for human display. */
+  message: string;
+  /**
+   * Optional follow-up suggestion / next step. Rendered on a
+   * separate line beneath `message` in the human view; emitted
+   * verbatim in the JSON view.
+   */
+  advisory?: string;
+  /** Optional path / URI / version / identifier the finding refers to. */
+  subject?: string;
+  /**
+   * Optional structured payload — included verbatim in `--json` output
+   * for tooling. Should be JSON-serializable (no functions / cycles).
+   */
+  details?: Record<string, unknown>;
+}
+
+/**
+ * §4.7.0 always-reported state summary. Eighteen fields; the agent /
+ * operator / support engineer gets the full disambiguation context
+ * in one place rather than running five separate commands.
+ *
+ * Field-by-field semantics are documented in OT-RFC-41 §4.7.0. Any
+ * field that cannot be determined reports `null` (or its typed
+ * equivalent) — the absence of a value is itself informational and
+ * may be cross-referenced by checks below.
+ */
+export interface StateSummary {
+  /** ~/.dkg/daemon.pid — `null` if absent. */
+  daemon: {
+    pid: number | null;
+    /** Resolved argv[1] of the running process. `null` if not determinable. */
+    entryPoint: string | null;
+    /** GET /api/status#version — `null` if daemon unreachable. */
+    version: string | null;
+    /** GET /api/status#commit — added per §4.9. */
+    commit: string | null;
+    /** GET /api/status#commitShort — added per §4.9. */
+    commitShort: string | null;
+    /** GET /api/status#buildTime — added per §4.9. */
+    buildTime: string | null;
+    /** GET /api/status#distTag — added per §4.9. */
+    distTag: string | null;
+    /**
+     * GET /api/status#installMode — added per §4.3. Falls back to
+     * local detection (see {@link detectLocalInstallMode}) if the
+     * daemon is unreachable.
+     */
+    installMode: 'npm-global' | 'npm-local' | 'monorepo' | 'unknown' | null;
+    /** ~/.dkg/config.json#nodeRole — defaults to `edge`. */
+    nodeRole: 'edge' | 'core' | null;
+    /** Reason the daemon is unreachable when version/commit/etc. are null. */
+    unreachableReason?: string;
+  };
+  cli: {
+    /** `which dkg` resolution. The global `dkg` binary's path. */
+    globalPath: string | null;
+    /** `<cli.globalPath> --version` — global CLI's reported version. */
+    version: string | null;
+  };
+  paths: {
+    /** Result of `resolveDkgConfigHome({ startDir: cwd })`. */
+    dkgHome: string;
+    /**
+     * `process.env.DKG_HOME` — reported even if `null`; non-null
+     * + non-default values warrant operator attention.
+     */
+    dkgHomeEnv: string | null;
+    /**
+     * Symlink resolution of `~/.dkg/releases/current`. `null` on
+     * Edge (which has no `releases/` directory under RFC-41).
+     */
+    activeSlot: string | null;
+    /**
+     * `/usr/local/lib/node_modules/@origintrail-official/dkg/` or
+     * platform-equivalent — the npm-global install root. `null` if
+     * `npm root -g` resolution fails.
+     */
+    npmGlobalDkg: string | null;
+    /** `~/.dkg/plugins/` — per §4.6.1. */
+    pluginsRoot: string;
+  };
+  autoUpdate: {
+    enabled: boolean;
+    checkIntervalMinutes: number;
+    allowPrerelease: boolean;
+    /** `config.autoUpdate.source` — should be `npm` or `monorepo` post-rc.12. */
+    source: string | null;
+    /** ~/.dkg/auto-update/last-check.json#timestamp — `null` if never checked. */
+    lastCheck: string | null;
+    /** ~/.dkg/auto-update/last-error.json — truncated to first 1 KB; `null` if no errors. */
+    lastError: string | null;
+  };
+  /**
+   * `~/.dkg/previous-version` (Edge) or previous slot's
+   * `package.json#version` (Core). `null` if no rollback target.
+   */
+  previousVersion: string | null;
+}
+
+/**
+ * Locally-detected install mode for the running CLI. Used as a
+ * fallback when the daemon is unreachable.
+ */
+export type LocalInstallMode = 'npm-global' | 'npm-local' | 'monorepo' | 'unknown';
+
+/**
+ * The full report `dkg doctor` produces. Stable schema — agents
+ * parse it; changes to its shape are a breaking change.
+ */
+export interface DoctorReport {
+  state: StateSummary;
+  findings: Finding[];
+  /** 0 = healthy, 1 = warnings only, 2 = at least one error. */
+  exitCode: 0 | 1 | 2;
+  /** Doctor schema version. Bumped on breaking changes. */
+  schemaVersion: 1;
+}
+
+/**
+ * Dependency surface every check + the state summary uses. Wired to
+ * real I/O in production; stubs are injected in tests so each check
+ * can be exercised without touching the real filesystem, spawning
+ * subprocesses, or hitting the daemon's HTTP port.
+ */
+export interface DoctorDeps {
+  /** Resolved DKG home (`~/.dkg/` typically). */
+  dkgHome: string;
+  /** `process.env.DKG_HOME` at invocation time. */
+  dkgHomeEnv: string | null;
+  /** Process cwd at invocation time. */
+  cwd: string;
+  /** `os.homedir()` — the user's home directory. */
+  home: string;
+  /** Configured / probed API port (default 9200). */
+  apiPort: number;
+  /**
+   * If true, the doctor was invoked from inside a monorepo checkout
+   * (`findDkgMonorepoRoot(cwd) !== null`). Influences install-mode
+   * detection and the install-layout check's expectations.
+   */
+  isMonorepo: boolean;
+  /** Optional path to the monorepo root, when `isMonorepo === true`. */
+  monorepoRoot: string | null;
+  /** Operator-configured extra scan roots for §4.7.1 — defaults to []. */
+  extraScanRoots: string[];
+  /** Operator-configured doctor checks to skip — defaults to []. */
+  skipChecks: string[];
+
+  /** `existsSync`-equivalent. Stub for tests. */
+  exists(path: string): boolean;
+  /** `readFile` (utf-8). Returns `null` on ENOENT or any other read error. */
+  readFile(path: string): Promise<string | null>;
+  /** `readlink` -> the symlink's target. Returns `null` on failure. */
+  readlink(path: string): Promise<string | null>;
+  /** `stat`-equivalent. Returns `null` on ENOENT. */
+  stat(path: string): Promise<{ mtimeMs: number; uid: number; isDirectory: boolean; isSymbolicLink: boolean } | null>;
+  /**
+   * `readdir`-equivalent. Returns `[]` on missing / permission-denied.
+   * `withFileTypes` is implicit; entries always carry `{ name, isDirectory, isSymbolicLink }`.
+   */
+  readdir(path: string): Promise<Array<{ name: string; isDirectory: boolean; isSymbolicLink: boolean }>>;
+  /**
+   * Run a shell command, return `{ stdout, stderr, code }`. Used for
+   * `which dkg`, `<cli> --version`, etc. Returns `null` if the command
+   * cannot be launched (binary missing, etc.).
+   */
+  runCommand(cmd: string, args: string[]): Promise<{ stdout: string; stderr: string; code: number } | null>;
+  /**
+   * `fetch` wrapper bounded by a timeout (default 2 s). Returns the
+   * parsed JSON body on success; `null` on any failure (unreachable,
+   * non-2xx, JSON parse error).
+   */
+  fetchJson(url: string): Promise<Record<string, unknown> | null>;
+  /**
+   * `fetch` wrapper that returns the raw text body. Used for HTML
+   * served-UI inspection. `null` on any failure.
+   */
+  fetchText(url: string): Promise<string | null>;
+}

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -1464,6 +1464,87 @@ function writeRegistration(
 }
 
 /**
+ * RFC-41 §4.5: explicit SKILL.md delivery into skill-discovery
+ * directories of MCP-aware clients that don't walk `node_modules`.
+ *
+ * Cursor scans `~/.cursor/skills/<skill>/SKILL.md`; Claude Code
+ * scans `~/.claude/skills/<skill>/SKILL.md`. Neither walks the
+ * `node_modules` tree where the bundled SKILL.md ships inside the
+ * `@origintrail-official/dkg` npm package. So `dkg mcp setup`
+ * explicitly copies the bundled file into each client's
+ * user-level skill directory at registration time.
+ *
+ * Returns the absolute path written, or `null` if this client
+ * doesn't support skill delivery (the table maps Cursor + Claude
+ * Code to fixed destinations; other client targets get `null`
+ * and the caller skips the copy step).
+ */
+function skillTargetForClient(target: ClientTarget, home: string): string | null {
+  // Match by name prefix so the WSL2-side variants ("Cursor (Windows-side via WSL)")
+  // also get skill delivery if the operator-facing client config lives Windows-side.
+  // Both Cursor and Claude Code keep skills under `~/.cursor/skills/` and
+  // `~/.claude/skills/` respectively on the operator's primary OS — for the
+  // WSL2 case the operator runs the GUI client on Windows so the Linux-side
+  // ~/.cursor/skills/ they have inside WSL is the right destination iff
+  // they ALSO run a Cursor instance against WSL. Erring on the side of "deliver
+  // to the Linux-side too" is safe — extra files in skill dirs are inert,
+  // and a corresponding miss is what RFC-41 specifies the operator should
+  // notice via SKILL.md being absent.
+  if (target.name === 'Cursor' || target.name.startsWith('Cursor ')) {
+    return join(home, '.cursor', 'skills', 'dkg-node', 'SKILL.md');
+  }
+  if (target.name === 'Claude Code' || target.name.startsWith('Claude Code ')) {
+    return join(home, '.claude', 'skills', 'dkg-node', 'SKILL.md');
+  }
+  return null;
+}
+
+/**
+ * Load the bundled DKG-node SKILL.md from the npm package's `skills/`
+ * directory. Same shape as `loadBundledDkgNodeSkill()` in
+ * `hermes-setup.ts` so the two delivery paths share the canonical
+ * source artifact byte-for-byte.
+ */
+function loadBundledDkgNodeSkill(): string {
+  return readFileSync(new URL('../skills/dkg-node/SKILL.md', import.meta.url), 'utf-8');
+}
+
+/**
+ * Copy the bundled SKILL.md into the per-client skills directory if
+ * one applies. Idempotent — a re-run with the same bundled content
+ * overwrites with identical bytes (Cursor / Claude Code re-read on
+ * launch, so updates land on the next client restart).
+ *
+ * Errors are non-fatal: a write failure here logs a warning and
+ * returns — the MCP registration that triggered this copy already
+ * succeeded, and skill delivery is a best-effort enhancement.
+ * Operators can fall back to `GET /api/skills` from the daemon, or
+ * `dkg mcp setup --force` re-runs.
+ *
+ * Returns the absolute path written, or `null` if no skill delivery
+ * was attempted (client doesn't support it, or the write failed).
+ */
+function deliverSkillToClient(target: ClientTarget): string | null {
+  const home = homedir();
+  const skillPath = skillTargetForClient(target, home);
+  if (!skillPath) return null;
+  try {
+    const skillContent = loadBundledDkgNodeSkill();
+    const skillDir = dirname(skillPath);
+    if (!existsSync(skillDir)) mkdirSync(skillDir, { recursive: true });
+    writeFileSync(skillPath, skillContent);
+    return skillPath;
+  } catch (err: any) {
+    process.stderr.write(
+      `[setup] WARNING: SKILL.md delivery to ${target.name} (${tildify(skillPath)}) ` +
+        `failed (${err?.message ?? err}); the MCP server registration still applied. ` +
+        `Re-run \`dkg mcp setup\` after resolving the issue, or use GET /api/skills as a fallback.\n`,
+    );
+    return null;
+  }
+}
+
+/**
  * Fallback agent-name minter for first-init when no `--name` is passed
  * and no persisted config exists. Mirrors `discoverAgentName`'s
  * unique-fallback shape (`openclaw-agent-XXXXX`) but with `mcp-` prefix
@@ -1976,6 +2057,14 @@ export async function mcpSetupAction(
       try {
         writeRegistration(s.target, expectedEntry);
         console.log(`  ${action === 'register' ? 'Registered' : 'Refreshed'} ${s.target.name} → ${s.target.displayPath}`);
+        // RFC-41 §4.5: explicit SKILL.md delivery for Cursor + Claude Code,
+        // which don't walk node_modules for skill discovery. Returns null
+        // for clients that don't support skill delivery; logs a warning
+        // on failure but doesn't fail the MCP registration that just succeeded.
+        const skillPath = deliverSkillToClient(s.target);
+        if (skillPath) {
+          console.log(`    └─ SKILL.md copied to ${tildify(skillPath)}`);
+        }
       } catch (err: any) {
         // Codex Round-8 Fix 15: per-client write error isolation.
         // Pre-fix this `throw err` aborted the entire setup on the

--- a/packages/cli/test/dkg-doctor.test.ts
+++ b/packages/cli/test/dkg-doctor.test.ts
@@ -1,0 +1,714 @@
+/**
+ * Tests for `dkg doctor` (OT-RFC-41 §4.7).
+ *
+ * Each check is exercised through a fixture {@link DoctorDeps} —
+ * an in-memory fake file-system, stubbed fetch + runCommand. The
+ * real production deps (createProductionDeps) exist for the CLI
+ * wrapper and are exercised indirectly through the orchestrator's
+ * dispatch; here we cover the pure-function check bodies.
+ *
+ * Coverage:
+ *   - state-summary 18-field assertion (§4.7.0)
+ *   - orphan-repos check (§4.7.1): stray vs. active-daemon clone
+ *   - config-sanity check (§4.7.2): nodeRole / apiPort /
+ *     deprecated fields / malformed JSON
+ *   - install-layout check (§4.7.3): Edge legacy slot / Core
+ *     missing symlink / Core partial slot / Core `.git`-in-slot
+ *   - version-skew check (§4.7.4): Edge ahead-of-daemon and
+ *     daemon-ahead-of-npm; Core slot-vs-daemon mismatch
+ *   - served-ui-mismatch check (§4.7.5): meta-version mismatch +
+ *     unreachable-daemon skip
+ *   - plugin-root check (§4.7.6): bare-name plugin not in stable
+ *     plugin root
+ *
+ * Production wiring (CLI flag parsing, exit codes, JSON output
+ * shape) is covered separately by the integration smoke tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { runDoctor, collectStateSummary, ALL_CHECK_IDS } from '../src/doctor/index.js';
+import type { DoctorDeps } from '../src/doctor/types.js';
+import { runOrphanReposCheck } from '../src/doctor/checks/orphan-repos.js';
+import { runConfigSanityCheck } from '../src/doctor/checks/config-sanity.js';
+import { runInstallLayoutCheck } from '../src/doctor/checks/install-layout.js';
+import { runVersionSkewCheck } from '../src/doctor/checks/version-skew.js';
+import { runServedUiMismatchCheck } from '../src/doctor/checks/served-ui-mismatch.js';
+import { runPluginRootCheck } from '../src/doctor/checks/plugin-root.js';
+
+/**
+ * In-memory file system. Each entry is either a `string`
+ * (regular file contents) or a `symlink:<target>` (symlink).
+ * Directories are implicit — any parent of a registered file
+ * counts as a directory.
+ */
+interface FakeFS {
+  [path: string]: string;
+}
+
+function normaliseFsPaths(fs: FakeFS): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const [p, v] of Object.entries(fs)) {
+    m.set(p.replace(/\/+$/, ''), v);
+  }
+  return m;
+}
+
+interface DepsOverrides {
+  fs?: FakeFS;
+  dkgHome?: string;
+  home?: string;
+  cwd?: string;
+  apiPort?: number;
+  isMonorepo?: boolean;
+  monorepoRoot?: string | null;
+  extraScanRoots?: string[];
+  skipChecks?: string[];
+  /** GET /api/status JSON; null = unreachable. */
+  apiStatus?: Record<string, unknown> | null;
+  /** GET /ui/ HTML body; null = unreachable. */
+  uiHtml?: string | null;
+  /** Stubbed `which dkg` / `<cli> --version` / `npm root -g` / `ps -o`. */
+  commands?: Record<string, { stdout?: string; stderr?: string; code: number } | null>;
+  /** `process.env.DKG_HOME` value at invocation. */
+  dkgHomeEnv?: string | null;
+}
+
+function makeDeps(over: DepsOverrides = {}): DoctorDeps {
+  const fs = normaliseFsPaths(over.fs ?? {});
+  const dkgHome = over.dkgHome ?? '/test/.dkg';
+  const home = over.home ?? '/test';
+  const isDir = (path: string): boolean => {
+    const target = path.replace(/\/+$/, '');
+    for (const k of fs.keys()) {
+      if (k === target) {
+        const v = fs.get(k)!;
+        if (v.startsWith('dir:')) return true;
+        return false;
+      }
+      if (k.startsWith(target + '/')) return true;
+    }
+    return false;
+  };
+  const isSymlink = (path: string): boolean => {
+    const v = fs.get(path.replace(/\/+$/, ''));
+    return typeof v === 'string' && v.startsWith('symlink:');
+  };
+  return {
+    dkgHome,
+    dkgHomeEnv: over.dkgHomeEnv ?? null,
+    cwd: over.cwd ?? '/test/work',
+    home,
+    apiPort: over.apiPort ?? 9200,
+    isMonorepo: over.isMonorepo ?? false,
+    monorepoRoot: over.monorepoRoot ?? null,
+    extraScanRoots: over.extraScanRoots ?? [],
+    skipChecks: over.skipChecks ?? [],
+
+    exists(path) {
+      const trimmed = path.replace(/\/+$/, '');
+      if (fs.has(trimmed)) return true;
+      return isDir(trimmed);
+    },
+    async readFile(path) {
+      const v = fs.get(path.replace(/\/+$/, ''));
+      if (v === undefined) return null;
+      if (v.startsWith('symlink:') || v.startsWith('dir:')) return null;
+      return v;
+    },
+    async readlink(path) {
+      const v = fs.get(path.replace(/\/+$/, ''));
+      if (typeof v === 'string' && v.startsWith('symlink:')) {
+        return v.slice('symlink:'.length);
+      }
+      return null;
+    },
+    async stat(path) {
+      const trimmed = path.replace(/\/+$/, '');
+      const v = fs.get(trimmed);
+      if (v !== undefined) {
+        return {
+          mtimeMs: 1700000000000,
+          uid: 1000,
+          isDirectory: v.startsWith('dir:'),
+          isSymbolicLink: v.startsWith('symlink:'),
+        };
+      }
+      if (isDir(trimmed)) {
+        return { mtimeMs: 1700000000000, uid: 1000, isDirectory: true, isSymbolicLink: false };
+      }
+      return null;
+    },
+    async readdir(path) {
+      const target = path.replace(/\/+$/, '');
+      const direct = new Set<string>();
+      const entries: Array<{ name: string; isDirectory: boolean; isSymbolicLink: boolean }> = [];
+      for (const k of fs.keys()) {
+        if (!k.startsWith(target + '/')) continue;
+        const rest = k.slice(target.length + 1);
+        const name = rest.split('/')[0];
+        if (direct.has(name)) continue;
+        direct.add(name);
+        const childPath = join(target, name);
+        const childVal = fs.get(childPath);
+        const childIsDir = !childVal || childVal.startsWith('dir:') || isDir(childPath);
+        const childIsSymlink = typeof childVal === 'string' && childVal.startsWith('symlink:');
+        entries.push({ name, isDirectory: childIsDir, isSymbolicLink: childIsSymlink });
+      }
+      return entries;
+    },
+    async runCommand(cmd, args) {
+      const key = `${cmd} ${args.join(' ')}`;
+      if (over.commands && key in over.commands) {
+        const v = over.commands[key];
+        if (v === null) return null;
+        return { stdout: v.stdout ?? '', stderr: v.stderr ?? '', code: v.code };
+      }
+      // Default: command not found.
+      return null;
+    },
+    async fetchJson(url) {
+      if (url.endsWith('/api/status')) return over.apiStatus ?? null;
+      return null;
+    },
+    async fetchText(url) {
+      if (url.includes('/ui/')) return over.uiHtml ?? null;
+      return null;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// state-summary (§4.7.0)
+// ---------------------------------------------------------------------------
+
+describe('collectStateSummary (§4.7.0)', () => {
+  it('reports all 18 fields, falling back to null when data is unavailable', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+      },
+    });
+    const s = await collectStateSummary(deps);
+
+    // daemon.* — 9 fields including unreachableReason
+    expect(s.daemon).toHaveProperty('pid');
+    expect(s.daemon).toHaveProperty('entryPoint');
+    expect(s.daemon).toHaveProperty('version');
+    expect(s.daemon).toHaveProperty('commit');
+    expect(s.daemon).toHaveProperty('commitShort');
+    expect(s.daemon).toHaveProperty('buildTime');
+    expect(s.daemon).toHaveProperty('distTag');
+    expect(s.daemon).toHaveProperty('installMode');
+    expect(s.daemon).toHaveProperty('nodeRole');
+    expect(s.daemon.nodeRole).toBe('edge');
+
+    // cli.* — 2 fields
+    expect(s.cli).toHaveProperty('globalPath');
+    expect(s.cli).toHaveProperty('version');
+
+    // paths.* — 5 fields
+    expect(s.paths).toHaveProperty('dkgHome');
+    expect(s.paths).toHaveProperty('dkgHomeEnv');
+    expect(s.paths).toHaveProperty('activeSlot');
+    expect(s.paths).toHaveProperty('npmGlobalDkg');
+    expect(s.paths).toHaveProperty('pluginsRoot');
+    expect(s.paths.dkgHome).toBe('/test/.dkg');
+    expect(s.paths.pluginsRoot).toBe('/test/.dkg/plugins');
+    expect(s.paths.activeSlot).toBeNull(); // Edge has no slot
+
+    // autoUpdate.* — 6 fields
+    expect(s.autoUpdate).toHaveProperty('enabled');
+    expect(s.autoUpdate).toHaveProperty('checkIntervalMinutes');
+    expect(s.autoUpdate).toHaveProperty('allowPrerelease');
+    expect(s.autoUpdate).toHaveProperty('source');
+    expect(s.autoUpdate).toHaveProperty('lastCheck');
+    expect(s.autoUpdate).toHaveProperty('lastError');
+
+    // previousVersion — 1 field
+    expect(s).toHaveProperty('previousVersion');
+  });
+
+  it('parses commit / installMode / buildTime / distTag from /api/status when reachable', async () => {
+    const deps = makeDeps({
+      apiStatus: {
+        version: '10.0.0-rc.12',
+        commit: 'abcd1234567890abcdef',
+        commitShort: 'abcd1234',
+        buildTime: '2026-05-27T10:00:00Z',
+        distTag: 'next',
+        installMode: 'npm-global',
+      },
+    });
+    const s = await collectStateSummary(deps);
+    expect(s.daemon.version).toBe('10.0.0-rc.12');
+    expect(s.daemon.commit).toBe('abcd1234567890abcdef');
+    expect(s.daemon.commitShort).toBe('abcd1234');
+    expect(s.daemon.buildTime).toBe('2026-05-27T10:00:00Z');
+    expect(s.daemon.distTag).toBe('next');
+    expect(s.daemon.installMode).toBe('npm-global');
+  });
+
+  it('reports activeSlot for Core nodes', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'core' }),
+        '/test/.dkg/releases/current': 'symlink:a',
+      },
+    });
+    const s = await collectStateSummary(deps);
+    expect(s.daemon.nodeRole).toBe('core');
+    expect(s.paths.activeSlot).toBe('a');
+  });
+
+  it('exposes auto-update.lastCheck and lastError when present', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': '{}',
+        '/test/.dkg/auto-update/last-check.json': JSON.stringify({ timestamp: '2026-05-27T09:00:00Z' }),
+        '/test/.dkg/auto-update/last-error.json': 'fetch failed: ECONNRESET',
+      },
+    });
+    const s = await collectStateSummary(deps);
+    expect(s.autoUpdate.lastCheck).toBe('2026-05-27T09:00:00Z');
+    expect(s.autoUpdate.lastError).toBe('fetch failed: ECONNRESET');
+  });
+
+  it('truncates last-error.json over 1 KB', async () => {
+    const huge = 'x'.repeat(2048);
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': '{}',
+        '/test/.dkg/auto-update/last-error.json': huge,
+      },
+    });
+    const s = await collectStateSummary(deps);
+    expect(s.autoUpdate.lastError).toMatch(/…\[truncated\]$/);
+    expect(s.autoUpdate.lastError!.length).toBeLessThan(huge.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orphan-repos (§4.7.1)
+// ---------------------------------------------------------------------------
+
+describe('orphan-repos check (§4.7.1)', () => {
+  it('flags a stray clone with OriginTrail/dkg origin as warning', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/Projects/dkg/.git/config': '[remote "origin"]\n  url = https://github.com/OriginTrail/dkg.git\n',
+        '/test/Projects/dkg/package.json': JSON.stringify({ name: 'doesnt-matter' }),
+      },
+    });
+    const findings = await runOrphanReposCheck(deps, await collectStateSummary(deps));
+    expect(findings.length).toBeGreaterThan(0);
+    const stray = findings.find((f) => f.subject === '/test/Projects/dkg');
+    expect(stray).toBeDefined();
+    expect(stray!.severity).toBe('warning');
+    expect(stray!.advisory).toMatch(/Do not 'git pull'/);
+  });
+
+  it('flags a clone via package.json name match', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/repos/dkg/package.json': JSON.stringify({ name: '@origintrail-official/dkg', version: '10.0.0' }),
+      },
+    });
+    const findings = await runOrphanReposCheck(deps, await collectStateSummary(deps));
+    const m = findings.find((f) => f.subject === '/test/repos/dkg');
+    expect(m).toBeDefined();
+    expect(m!.severity).toBe('warning');
+  });
+
+  it('reports the active-daemon source tree as info rather than warning', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/daemon.pid': '4242',
+        '/test/Projects/dkg/.git/config': '[remote "origin"]\n  url = https://github.com/OriginTrail/dkg.git\n',
+        '/test/Projects/dkg/packages/cli/dist/cli.js': '// daemon code',
+      },
+      apiStatus: { version: '10.0.0-rc.12' },
+    });
+    const state = await collectStateSummary(deps);
+    // Inject a daemon entryPoint that sits inside the clone — tests
+    // production behaviour where the doctor finds its own running
+    // tree and labels it as info.
+    state.daemon.entryPoint = '/test/Projects/dkg/packages/cli/dist/cli.js';
+    const findings = await runOrphanReposCheck(deps, state);
+    const m = findings.find((f) => f.subject === '/test/Projects/dkg');
+    expect(m).toBeDefined();
+    expect(m!.severity).toBe('info');
+  });
+
+  it('skips ignored directories (node_modules, .npm, .cache)', async () => {
+    const deps = makeDeps({
+      fs: {
+        // Stray DKG clone NESTED inside a node_modules tree → must be skipped.
+        '/test/Projects/some-app/node_modules/dkg/.git/config':
+          '[remote "origin"]\n  url = https://github.com/OriginTrail/dkg.git\n',
+      },
+    });
+    const findings = await runOrphanReposCheck(deps, await collectStateSummary(deps));
+    expect(findings.find((f) => f.subject?.includes('node_modules'))).toBeUndefined();
+  });
+
+  it('respects .dkg-ignore-by-doctor sentinel', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/some/.dkg-ignore-by-doctor': '',
+        '/test/some/.git/config': '[remote "origin"]\n  url = https://github.com/OriginTrail/dkg.git\n',
+      },
+    });
+    const findings = await runOrphanReposCheck(deps, await collectStateSummary(deps));
+    expect(findings.find((f) => f.subject === '/test/some')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// config-sanity (§4.7.2)
+// ---------------------------------------------------------------------------
+
+describe('config-sanity check (§4.7.2)', () => {
+  it('flags missing config as warning, not error', async () => {
+    const deps = makeDeps({ fs: {} });
+    const findings = await runConfigSanityCheck(deps);
+    expect(findings.find((f) => f.severity === 'warning')).toBeDefined();
+  });
+
+  it('flags malformed JSON as error', async () => {
+    const deps = makeDeps({
+      fs: { '/test/.dkg/config.json': '{ not json' },
+    });
+    const findings = await runConfigSanityCheck(deps);
+    expect(findings.find((f) => f.severity === 'error')).toBeDefined();
+  });
+
+  it('rejects invalid nodeRole values', async () => {
+    const deps = makeDeps({
+      fs: { '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'lighthouse' }) },
+    });
+    const findings = await runConfigSanityCheck(deps);
+    const e = findings.find((f) => f.subject === 'nodeRole');
+    expect(e).toBeDefined();
+    expect(e!.severity).toBe('error');
+  });
+
+  it('rejects out-of-range apiPort', async () => {
+    const deps = makeDeps({
+      fs: { '/test/.dkg/config.json': JSON.stringify({ apiPort: 70000 }) },
+    });
+    const findings = await runConfigSanityCheck(deps);
+    expect(findings.find((f) => f.subject === 'apiPort' && f.severity === 'error')).toBeDefined();
+  });
+
+  it('warns on deprecated autoUpdate fields set to non-empty values', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({
+          autoUpdate: { repo: 'https://github.com/OriginTrail/dkg.git', branch: 'main' },
+        }),
+      },
+    });
+    const findings = await runConfigSanityCheck(deps);
+    expect(findings.find((f) => f.subject === 'autoUpdate.repo')).toBeDefined();
+    expect(findings.find((f) => f.subject === 'autoUpdate.branch')).toBeDefined();
+  });
+
+  it('errors on checkIntervalMinutes < 1', async () => {
+    const deps = makeDeps({
+      fs: { '/test/.dkg/config.json': JSON.stringify({ autoUpdate: { checkIntervalMinutes: 0 } }) },
+    });
+    const findings = await runConfigSanityCheck(deps);
+    expect(findings.find((f) => f.subject === 'autoUpdate.checkIntervalMinutes' && f.severity === 'error')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// install-layout (§4.7.3)
+// ---------------------------------------------------------------------------
+
+describe('install-layout check (§4.7.3)', () => {
+  it('Edge: warns on legacy ~/.dkg/releases/ directory', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+        '/test/.dkg/releases/a/dist/cli.js': '// stale slot',
+      },
+    });
+    const state = await collectStateSummary(deps);
+    const findings = await runInstallLayoutCheck(deps, state);
+    const m = findings.find((f) => f.subject === '/test/.dkg/releases');
+    expect(m).toBeDefined();
+    expect(m!.severity).toBe('warning');
+    expect(m!.advisory).toMatch(/rm -rf ~\/\.dkg\/releases\//);
+  });
+
+  it('Edge: warns when daemon entryPoint is outside the npm-global install', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+      },
+    });
+    const state = await collectStateSummary(deps);
+    // Force npmGlobalDkg + entryPoint to specific paths for the assertion.
+    state.paths.npmGlobalDkg = '/usr/local/lib/node_modules/@origintrail-official/dkg';
+    state.daemon.entryPoint = '/Users/someone/random-clone/packages/cli/dist/cli.js';
+    const findings = await runInstallLayoutCheck(deps, state);
+    expect(findings.find((f) => f.message.includes('not inside the npm-global install'))).toBeDefined();
+  });
+
+  it('Core: errors on missing current symlink', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'core' }),
+      },
+    });
+    const state = await collectStateSummary(deps);
+    const findings = await runInstallLayoutCheck(deps, state);
+    expect(findings.find((f) => f.severity === 'error' && f.message.includes("missing blue-green 'current'"))).toBeDefined();
+  });
+
+  it('Core: warns on partial inactive slot (files but no entry point)', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'core' }),
+        '/test/.dkg/releases/current': 'symlink:a',
+        '/test/.dkg/releases/a/packages/cli/dist/cli.js': '// active slot',
+        // slot b populated but no entry point
+        '/test/.dkg/releases/b/half-written-file': 'oops',
+      },
+    });
+    const state = await collectStateSummary(deps);
+    const findings = await runInstallLayoutCheck(deps, state);
+    expect(findings.find((f) => f.message.includes("Inactive slot 'b'") && f.severity === 'warning')).toBeDefined();
+  });
+
+  it('Core: warns on legacy .git inside a slot', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'core' }),
+        '/test/.dkg/releases/current': 'symlink:a',
+        '/test/.dkg/releases/a/packages/cli/dist/cli.js': '// active slot',
+        '/test/.dkg/releases/a/.git/config': '[remote "origin"]',
+      },
+    });
+    const state = await collectStateSummary(deps);
+    const findings = await runInstallLayoutCheck(deps, state);
+    expect(findings.find((f) => f.message.includes("Legacy '.git' directory") && f.severity === 'warning')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// version-skew (§4.7.4)
+// ---------------------------------------------------------------------------
+
+describe('version-skew check (§4.7.4)', () => {
+  // NOTE: the version-skew check's `semverCompare` strips pre-release
+  // suffixes (`-rc.N`) before comparing, so to actually exercise the
+  // ordering branch we use major.minor.patch deltas in these tests.
+  // The string-equality early-return is exercised separately below.
+  it('Edge: warns when npm-global is ahead of running daemon', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+        '/usr/local/lib/node_modules/@origintrail-official/dkg/package.json':
+          JSON.stringify({ version: '10.1.0' }),
+      },
+      apiStatus: { version: '10.0.0' },
+    });
+    const state = await collectStateSummary(deps);
+    state.paths.npmGlobalDkg = '/usr/local/lib/node_modules/@origintrail-official/dkg';
+    const findings = await runVersionSkewCheck(deps, state);
+    expect(findings.find((f) => f.message.includes('npm-global install is ahead'))).toBeDefined();
+  });
+
+  it('Edge: warns when daemon is ahead of npm-global install', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+        '/usr/local/lib/node_modules/@origintrail-official/dkg/package.json':
+          JSON.stringify({ version: '9.5.0' }),
+      },
+      apiStatus: { version: '10.0.0' },
+    });
+    const state = await collectStateSummary(deps);
+    state.paths.npmGlobalDkg = '/usr/local/lib/node_modules/@origintrail-official/dkg';
+    const findings = await runVersionSkewCheck(deps, state);
+    expect(findings.find((f) => f.message.includes('Running daemon is ahead'))).toBeDefined();
+  });
+
+  it('Core: warns on slot-vs-daemon mismatch', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'core' }),
+        '/test/.dkg/releases/current': 'symlink:a',
+        '/test/.dkg/releases/a/node_modules/@origintrail-official/dkg/package.json':
+          JSON.stringify({ version: '10.0.0-rc.13' }),
+      },
+      apiStatus: { version: '10.0.0-rc.12' },
+    });
+    const state = await collectStateSummary(deps);
+    const findings = await runVersionSkewCheck(deps, state);
+    expect(findings.find((f) => f.message.includes('Core slot version'))).toBeDefined();
+  });
+
+  it('Edge: no finding when versions match exactly', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+        '/usr/local/lib/node_modules/@origintrail-official/dkg/package.json':
+          JSON.stringify({ version: '10.0.0-rc.12' }),
+      },
+      apiStatus: { version: '10.0.0-rc.12' },
+    });
+    const state = await collectStateSummary(deps);
+    state.paths.npmGlobalDkg = '/usr/local/lib/node_modules/@origintrail-official/dkg';
+    const findings = await runVersionSkewCheck(deps, state);
+    expect(findings).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// served-ui-mismatch (§4.7.5)
+// ---------------------------------------------------------------------------
+
+describe('served-ui-mismatch check (§4.7.5)', () => {
+  it('skips with info when daemon is unreachable', async () => {
+    const deps = makeDeps({});
+    const state = await collectStateSummary(deps);
+    const findings = await runServedUiMismatchCheck(deps, state);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('info');
+    expect(findings[0].message).toMatch(/daemon unreachable/);
+  });
+
+  it('warns when <meta name=version> on served HTML disagrees with installed UI', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+        '/usr/local/lib/node_modules/@origintrail-official/dkg/node_modules/@origintrail-official/dkg-node-ui/package.json':
+          JSON.stringify({ version: '10.0.0-rc.12' }),
+      },
+      apiStatus: { version: '10.0.0-rc.12' },
+      uiHtml: '<!doctype html><html><head><meta name="version" content="10.0.0-rc.10"></head></html>',
+    });
+    const state = await collectStateSummary(deps);
+    state.paths.npmGlobalDkg = '/usr/local/lib/node_modules/@origintrail-official/dkg';
+    const findings = await runServedUiMismatchCheck(deps, state);
+    const w = findings.find((f) => f.severity === 'warning');
+    expect(w).toBeDefined();
+    expect(w!.message).toMatch(/does not match installed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// plugin-root (§4.7.6)
+// ---------------------------------------------------------------------------
+
+describe('plugin-root check (§4.7.6)', () => {
+  it('info when stable plugin root is missing', async () => {
+    const deps = makeDeps({
+      fs: { '/test/.dkg/config.json': '{}' },
+    });
+    const findings = await runPluginRootCheck(deps);
+    expect(findings.find((f) => f.severity === 'info' && f.message.includes('plugin install root not yet'))).toBeDefined();
+  });
+
+  it('warns on bare-name plugin not installed under plugins/node_modules', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ routePlugins: ['@some/dkg-route-plugin'] }),
+        '/test/.dkg/plugins/package.json': JSON.stringify({ name: 'dkg-plugin-root', private: true }),
+      },
+    });
+    const findings = await runPluginRootCheck(deps);
+    const w = findings.find((f) => f.severity === 'warning' && f.subject === '@some/dkg-route-plugin');
+    expect(w).toBeDefined();
+    expect(w!.advisory).toMatch(/npm install --prefix .*\.dkg\/plugins/);
+  });
+
+  it('errors on absolute path that does not exist', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ routePlugins: ['/absent/plugin.js'] }),
+      },
+    });
+    const findings = await runPluginRootCheck(deps);
+    expect(findings.find((f) => f.severity === 'error' && f.subject === '/absent/plugin.js')).toBeDefined();
+  });
+
+  it('does not flag bare-name plugin installed under plugins/node_modules', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ routePlugins: ['@some/dkg-route-plugin'] }),
+        '/test/.dkg/plugins/package.json': JSON.stringify({ name: 'dkg-plugin-root', private: true }),
+        '/test/.dkg/plugins/node_modules/@some/dkg-route-plugin/package.json':
+          JSON.stringify({ name: '@some/dkg-route-plugin' }),
+      },
+    });
+    const findings = await runPluginRootCheck(deps);
+    expect(findings.find((f) => f.subject === '@some/dkg-route-plugin')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orchestrator integration
+// ---------------------------------------------------------------------------
+
+describe('runDoctor orchestrator', () => {
+  it('returns exitCode 0 when no anomalies and only info findings', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge', autoUpdate: { source: 'npm' } }),
+      },
+    });
+    const report = await runDoctor(deps, { checks: ['config-sanity'] });
+    expect(report.exitCode).toBe(0);
+  });
+
+  it('returns exitCode 1 when there are warnings but no errors', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({
+          nodeRole: 'edge',
+          autoUpdate: { repo: 'https://x' }, // deprecated → warning
+        }),
+      },
+    });
+    const report = await runDoctor(deps, { checks: ['config-sanity'] });
+    expect(report.exitCode).toBe(1);
+  });
+
+  it('returns exitCode 2 when at least one finding is severity:error', async () => {
+    const deps = makeDeps({
+      fs: { '/test/.dkg/config.json': '{ not json' },
+    });
+    const report = await runDoctor(deps, { checks: ['config-sanity'] });
+    expect(report.exitCode).toBe(2);
+  });
+
+  it('honours skipChecks', async () => {
+    const deps = makeDeps({
+      skipChecks: ['orphan-repos'],
+      fs: { '/test/.dkg/config.json': '{}' },
+    });
+    const report = await runDoctor(deps);
+    expect(report.findings.find((f) => f.check === 'orphan-repos')).toBeUndefined();
+  });
+
+  it('schema version is stable at 1', async () => {
+    const deps = makeDeps({});
+    const report = await runDoctor(deps, { checks: [] });
+    expect(report.schemaVersion).toBe(1);
+  });
+
+  it('always-on state summary populates even when all checks skipped', async () => {
+    const deps = makeDeps({
+      skipChecks: [...ALL_CHECK_IDS],
+      fs: { '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'core' }) },
+    });
+    const report = await runDoctor(deps);
+    expect(report.findings).toEqual([]);
+    expect(report.state.daemon.nodeRole).toBe('core');
+    expect(report.state.paths.dkgHome).toBe('/test/.dkg');
+  });
+});


### PR DESCRIPTION
## Summary

First half of the RFC-41 implementation in rc.12. Bundle A is **fully additive** — every new surface (docs callouts, deprecation banners, `dkg doctor`, build-info telemetry) is opt-in and behaves identically to today on existing Edge / Core nodes.

This unblocks Bundle B (the irreversible mechanism flip: Edge slot removal, `dkg update` split, `findPackageRepoDir` audit, `install.sh` / `migrate-to-npm` deletion) once §6.5 rollout prerequisites are demonstrably green — and Bundle A is what makes those prerequisites observable in the first place.

RFC: [OriginTrail/dkgv10-spec#117](https://github.com/OriginTrail/dkgv10-spec/pull/117) — \`rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md\`.

### What changed (4 commits)

1. **\`docs(rfc-41): bundle A1\`** (`05cec465d`) — docs-only callouts. README \"Updating your node\" / \"Contributors / monorepo development\" sections, \`install.sh\` deprecation banner, \`MIGRATE_TO_NPM.md\` rc.12 callout. Zero behavioural change.
2. **\`feat(cli)(rfc-41): bundle A2\`** (`7d65f70d2`) — the \`dkg doctor\` subcommand (state summary + 6 anomaly checks, role-aware), SKILL.md operator surface + auto-delivery to \`~/.cursor/skills/\` and \`~/.claude/skills/\` during \`dkg mcp setup\`, and a deprecation warning on the git-based \`dkg update\` path. \`dkg update\` also runs a \`install-layout\` + \`version-skew\` pre-flight; errors abort, warnings advise.
3. **\`feat(daemon, ci)(rfc-41): bundle A3\`** (`21bc64f5a`) — \`/api/status\` exposes \`commit\`, \`commitShort\`, \`buildTime\`, \`distTag\`, \`installMode\`. Daemon emits structured \`[dkg-build-info]\` + \`[install-mode-detected]\` startup log lines. CI \`npm-publish.yml\` writes \`build-info.json\` into every published package before \`pnpm pack\`. \`packages/cli/package.json#files\` includes the new artifact. In monorepo / dev the helpers return stable sentinels (\`commit: \"uncommitted\"\`, \`distTag: \"monorepo\"\`) so consumers can branch reliably.
4. **\`test(cli)(rfc-41)\`** (`298558f68`) — 37 unit tests for \`dkg doctor\` using fixture filesystem + stubbed fetch / runCommand. Every check has happy-path + at least one mismatch / edge case covered; orchestrator tests cover exit-code routing (0/1/2), \`skipChecks\`, and the always-on state summary.

### Why this matters

The agent-confusion bug reported by the operator who filed the original issue had three root causes:

- The agent couldn't tell which DKG install was actually running (\`/api/status\` didn't expose commit / install-mode).
- There was no single command that printed \"here is everything an agent needs to know about this node\" — \`dkg doctor\` is exactly that.
- The SKILL.md the agent needs to read to disambiguate \`dkg update\` vs \`git pull\` lived inside a package that Cursor / Claude Code's skill discovery doesn't walk.

Bundle A fixes all three without changing anything an existing deployment depends on. The Edge slot removal — the actual mechanism flip — lands in Bundle B once §6.5 prerequisites (reliable \`next\` dist-tag publishing, \`build-info.json\` shipping end-to-end, \`dkg update <next-tag>\` working) have soaked for 48h on devnet.

## Diffstat

| Surface | Net lines |
|---|---|
| Docs (README + MIGRATE + install.sh) | +77 |
| New \`dkg doctor\` module (7 source files + 1 test file) | +1391 (incl. 714 test) |
| \`/api/status\` + manifest helpers | +148 |
| Daemon startup log | +32 |
| CI \`npm-publish.yml\` | +72 |
| \`mcp-setup\` SKILL delivery | +89 |
| \`cli.ts\` doctor subcommand + update preflight | +93 |
| \`SKILL.md\` operator section | +27 |
| **Total** | **+2916, −4** |

All net-positive — Bundle A doesn't remove anything. Bundle B is where the deletions happen.

## Test plan

- [x] \`packages/cli/test/dkg-doctor.test.ts\` — 37/37 passing locally (\`pnpm vitest run test/dkg-doctor.test.ts\` → 7ms, 53s total incl. setup).
- [ ] Smoke-test on a real Edge laptop (rc.12 candidate build): \`dkg doctor\` → state summary populates, no false-positive findings on a healthy install.
- [ ] Smoke-test on a Core node (devnet): \`dkg doctor\` → install-layout check finds the blue-green slots; no findings reported when both slots are clean.
- [ ] \`dkg mcp setup\` end-to-end on a fresh laptop: Cursor / Claude Code skill directories receive \`SKILL.md\` after registration.
- [ ] CI \`npm-publish.yml\` dry-run: verify the \`build-info.json\` generation step produces the expected JSON shape; no need to actually publish.
- [ ] One devnet daemon restart with the new lifecycle.ts: confirm \`[dkg-build-info]\` and \`[install-mode-detected]\` lines land in the log.
- [ ] \`curl http://127.0.0.1:9200/api/status | jq '{commit, distTag, installMode}'\` returns populated fields (sentinels in monorepo dev, real values from CI builds).

## Out of scope (Bundle B follows)

- Edge slot suppression / removal (\`migrateToBlueGreen\` Edge gating, legacy \`releases/\` resume).
- \`_performNpmUpdateInner\` Edge / Core split + \`dkg rollback\` Edge implementation.
- \`dkg init --role\` flag + monorepo guard.
- Stable plugin install root materialization in \`plugin-loader.ts\`.
- Deletion of \`install.sh\`, \`migrate-to-npm.ts\`, and the git-build code path.
- \`findPackageRepoDir\` consumer audit + selective retention.

All of those depend on rc.12 having a working \`next\` dist-tag publish path, which Bundle A's \`build-info.json\` + \`/api/status\` exposure makes auditable.

Made with [Cursor](https://cursor.com)