### PR TITLE
test(devnet/agent-provenance): pin gas-only publisher EOA scenario for PCA path

### DIFF
--- a/devnet/agent-provenance/README.md
+++ b/devnet/agent-provenance/README.md
@@ -14,7 +14,7 @@ prefer running them before falling back to the manual recipes below.
 | Suite | Scope | Runtime | Command |
 | --- | --- | --- | --- |
 | Hardhat e2e | All 10 sequence diagrams from `RFC-001-implementation-walkthrough.md` (incl. Phase 4 author override + pre-signed AuthorAttestation), run against an in-process Hardhat EVM. Covers contract correctness + publisher integration in a single process. | ~30s | `pnpm test:e2e:agent-provenance` |
-| 5-node devnet | All 4 modes (a/b/c/d) + negative case from §4 + §9.5, run against `./scripts/devnet.sh start 5`. Mode (b) registers a custodial agent on core 2 and validates `KC.author = agent.wallet` while `publisherNodeIdentityId = core2.id`. | ~35s after devnet is up | `pnpm test:devnet:agent-provenance` |
+| 5-node devnet | All 4 modes (a/b/c/d) + negative case from §4 + §9.5, run against `./scripts/devnet.sh start 5`. Mode (b) registers a custodial agent on core 2 and validates `KC.author = agent.wallet` while `publisherNodeIdentityId = core2.id`. Includes a `mode (a) strict` variant that drains edge op-wallets' TRAC to literal zero via `hardhat_setStorageAt` and asserts the publish still succeeds via the PCA — pinning the "publisher EOA holds only gas tokens, spends TRAC from PCA" operator scenario. | ~35s after devnet is up | `pnpm test:devnet:agent-provenance` |
 
 Phase 4 author override (RFC §4(b)) is now wired end-to-end via the
 agent-keystore: end-user agents register on a daemon (`POST

--- a/devnet/agent-provenance/automated.test.ts
+++ b/devnet/agent-provenance/automated.test.ts
@@ -239,6 +239,37 @@ async function ensurePcaAccountForOpWallets(
   return accountId;
 }
 
+/**
+ * Zero out the TRAC balance of every op wallet on `node` via direct
+ * storage writes against the Hardhat TRAC contract. Native ETH is
+ * untouched, so the wallets keep enough gas to submit publishes.
+ *
+ * Token = `Ownable, ERC20, AccessControl` — same layout
+ * `ensurePcaAccountForOpWallets` exploits to MINT TRAC. ERC20's
+ * `_balances` mapping is at slot 1 (Ownable's `_owner` takes slot 0).
+ * Storage key for `mapping(address => uint256)`:
+ *   `keccak256(abi.encode(holder, slot))`.
+ *
+ * Used by the gas-only mode (a) variant below to construct the
+ * literal "publisher EOA has zero TRAC, only ETH for gas" precondition.
+ */
+async function drainOpWalletTrac(s: DevnetState, node: DevnetNode): Promise<void> {
+  const tokenAddress = await s.token.getAddress();
+  for (const w of node.opWallets) {
+    const slotKey = ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ['address', 'uint256'],
+        [w.address, 1n],
+      ),
+    );
+    await s.provider.send('hardhat_setStorageAt', [
+      tokenAddress,
+      slotKey,
+      ethers.ZeroHash,
+    ]);
+  }
+}
+
 async function fetchStatus(node: DevnetNode): Promise<{ identityId: bigint; nodeRole: string }> {
   const res = await fetch(`http://127.0.0.1:${node.apiPort}/api/status`);
   if (!res.ok) {
@@ -576,6 +607,98 @@ describe('Agent provenance — automated 5-node devnet validation', () => {
     // Op-wallet pool TRAC must NOT decrement — PCA covered the cost.
     const afterBalance = await sumOpBalances(s.token, edge);
     expect(afterBalance).toBe(beforeBalance);
+  }, 180_000);
+
+  // =========================================================================
+  // Mode (a) — STRICT: publisher EOA holds ZERO TRAC, only gas (ETH).
+  //
+  // Tightens the cost-coverage invariant in mode (a). The plain mode (a)
+  // asserts "balance unchanged across publish"; that's necessary but
+  // doesn't pin the actual operator scenario where a publishing agent
+  // wallet is provisioned with ONLY gas tokens and never holds TRAC.
+  //
+  // Setup:
+  //   1. Reuse / create the mode (a) PCA so every edge op wallet is a
+  //      registered conviction agent (`agentToAccountId != 0`).
+  //   2. Zero the TRAC `_balances` slot for every edge op wallet via
+  //      `hardhat_setStorageAt`. ETH is untouched — daemon can still
+  //      pay gas. After this step `sumOpBalances(edge) == 0n`.
+  //
+  // Action: edge runs `dkg publish` naming core1 for attribution. The
+  // daemon will pick one of the now-zero-TRAC op wallets as `msg.sender`
+  // for `KAV10.publish()`. The conviction branch fires
+  // (`agentToAccountId[msg.sender] != 0`, `epochs == lockDurationEpochs`,
+  // not expired) → `NFT.coverPublishingCost` updates `windowSpent`
+  // without calling `transferFrom(msg.sender, ...)` for TRAC, so the
+  // publish must succeed even though the EOA's TRAC balance is zero.
+  //
+  // Assertions:
+  //   - Pre-publish `sumOpBalances(edge) == 0n` (precondition pinned).
+  //   - Publish status == confirmed.
+  //   - KC author is one of edge's op wallets.
+  //   - `NFT.windowSpent(accountId, currentBillingWindow)` grew.
+  //   - core1's `EpochStorage` publishing-value counter grew.
+  //   - Post-publish `sumOpBalances(edge) == 0n` (the agent EOA's TRAC
+  //     ledger entry was NEVER touched — strongest possible "agent only
+  //     spent gas" assertion).
+  //
+  // Side effect: edge op-wallets stay at zero TRAC for the rest of the
+  // suite. This is fine for mode (c) (the `firstOpAccount !== 0n` skip
+  // already kicks in once mode (a) has run), mode (d) (unattributed
+  // publish still covered by PCA), the unauthorized-fall-through
+  // negative case (Eps-only assertion), and mode (b) (uses core2,
+  // independent of edge wallets).
+  // =========================================================================
+  it('mode (a) strict — gas-only edge op-wallets (zero TRAC) publish via PCA', async () => {
+    const s = state.v!;
+    const core1 = s.nodes[1]!;
+    const edge = s.nodes[5]!;
+    if (core1.identityId === 0n) throw new Error('core1 has no identity');
+
+    const accountId = await ensurePcaAccountForOpWallets(s, edge);
+
+    await drainOpWalletTrac(s, edge);
+    const drainedBalance = await sumOpBalances(s.token, edge);
+    expect(drainedBalance).toBe(0n);
+
+    const epoch: bigint = await s.chronos.getCurrentEpoch();
+    const beforeWindow: bigint = BigInt(await s.nft.getCurrentBillingWindow(accountId));
+    const beforeSpent: bigint =
+      (await s.nft.windowSpent(accountId, beforeWindow)) +
+      (await s.nft.windowSpent(accountId, beforeWindow + 1n));
+    const beforeEps: bigint = await s.eps.getNodeEpochProducedKnowledgeValue(core1.identityId, epoch);
+
+    const file = makeNquadsFile('mode-a-strict');
+    const result = await publishViaCli(edge, CONTEXT_GRAPH, file, {
+      publisherNodeIdentityId: core1.identityId,
+    });
+
+    expect(result.status.toLowerCase()).toBe('confirmed');
+    expect(result.kcId).toBeDefined();
+
+    const onChainAuthor: string = await s.kcs.getLatestMerkleRootAuthor(result.kcId!);
+    const matchesAnyOpWallet = edge.opWallets.some(
+      (w) => w.address.toLowerCase() === onChainAuthor.toLowerCase(),
+    );
+    expect(matchesAnyOpWallet).toBe(true);
+
+    const afterWindow: bigint = BigInt(await s.nft.getCurrentBillingWindow(accountId));
+    const afterSpent: bigint =
+      (await s.nft.windowSpent(accountId, beforeWindow)) +
+      (await s.nft.windowSpent(accountId, beforeWindow + 1n)) +
+      (afterWindow > beforeWindow + 1n
+        ? await s.nft.windowSpent(accountId, afterWindow)
+        : 0n);
+    expect(afterSpent - beforeSpent).toBeGreaterThan(0n);
+
+    const afterEps: bigint = await s.eps.getNodeEpochProducedKnowledgeValue(core1.identityId, epoch);
+    expect(afterEps).toBeGreaterThan(beforeEps);
+
+    // The strict invariant: every edge op-wallet's TRAC balance is STILL
+    // ZERO. The conviction branch never called `transferFrom` on the
+    // publishing agent's TRAC ledger entry — the EOA only spent gas.
+    const finalBalance = await sumOpBalances(s.token, edge);
+    expect(finalBalance).toBe(0n);
   }, 180_000);
 
   // =========================================================================


### PR DESCRIPTION
## Summary

Adds a strict variant of mode (a) in `devnet/agent-provenance/automated.test.ts` that drains TRAC from every edge op-wallet to literal **zero** before publishing, pinning the operator scenario where a publishing agent EOA holds only gas tokens (ETH) and spends TRAC from a PCA where it's a registered conviction agent.

## Why

The plain mode (a) asserts `beforeBalance === afterBalance` across the publish — necessary but not sufficient to pin the "EOA only has gas" operator scenario. After investigating the PCA publish path on `release/rc.12`:

- `KAV10.publish()` conviction branch (`agentToAccountId[msg.sender] != 0`, not expired, `epochs == lockDurationEpochs`) calls `NFT.coverPublishingCost(...)` which only updates `windowSpent` / `topUpBalance` accounting — TRAC stays in the CSS vault from `createAccount` / `topUp`. No `transferFrom` is ever called against the publishing agent EOA on this branch.
- The agent EOA therefore needs ONLY ETH for gas. Across the contract / publisher / devnet test layers this was previously asserted only as "balance unchanged", never as the stronger "balance == 0 before AND after".

This PR pins the stronger invariant.

## What

`devnet/agent-provenance/automated.test.ts`:

- New helper `drainOpWalletTrac` — zeros the TRAC `_balances` mapping slot (slot 1; `Ownable, ERC20, AccessControl` layout, same as `ensurePcaAccountForOpWallets` exploits to mint TRAC) via `hardhat_setStorageAt` for every op-wallet on a node. Native ETH untouched.
- New test `mode (a) strict — gas-only edge op-wallets (zero TRAC) publish via PCA`:
  - Reuses or creates the mode (a) PCA via `ensurePcaAccountForOpWallets`.
  - Drains every edge op-wallet's TRAC to zero.
  - Asserts `sumOpBalances(edge) == 0n` as the **precondition**.
  - Runs `dkg publish` via the CLI naming core1 for attribution.
  - Asserts: publish confirmed, KC author is one of the zero-TRAC edge op-wallets, `NFT.windowSpent(accountId, currentBillingWindow)` grew, core1's EpochStorage publishing-value counter grew, and `sumOpBalances(edge) == 0n` **postcondition** — the conviction branch never touched the publisher's TRAC ledger entry.

Test order: sits between the plain mode (a) and mode (c). Mode (c) already has a `firstOpAccount !== 0n` skip for "edge wallets are PCA-registered" (set by plain mode (a)), so it gracefully handles the zero-TRAC follow-on state. Modes (d), the unauthorized-PCA fall-through negative, and mode (b) (which uses core2) all keep working.

`devnet/agent-provenance/README.md`: one-line addition referencing the new variant in the test-suite table.

## Test plan

- [ ] `./scripts/devnet.sh clean && ./scripts/devnet.sh start 5`
- [ ] `pnpm test:devnet:agent-provenance` — all 5 existing tests + the new strict variant green
- [ ] Confirm the new test's pre/post `expect(...).toBe(0n)` both hold (proves PCA branch never called `transferFrom` against the publishing agent)
- [ ] Confirm `windowSpent` grew on the PCA (proves the conviction branch actually fired vs. some other no-op path)
- [ ] Confirm `EpochStorage` got the discounted distribution for core1 (proves attribution still flowed)

## Risk

Low. Pure test addition. No production code touched. The helper uses the same `hardhat_setStorageAt` trick the existing `ensurePcaAccountForOpWallets` uses to mint TRAC (just writing zero instead of `600000e18`), so the storage-layout assumption is already battle-tested by the suite. The new test depends on plain mode (a) having registered the edge wallets first, which always holds because vitest runs `it()` blocks in declaration order and the new test sits immediately below mode (a).


Made with [Cursor](https://cursor.com)