### PR TITLE
Fix durable SWM promote ownership enforcement

### DIFF
--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3075,12 +3075,12 @@ export class DKGPublisher implements Publisher {
     subGraphName: string | undefined,
     ownershipKey: string,
     rootEntities: readonly string[],
-  ): Promise<Map<string, Set<string>>> {
-    const owners = new Map<string, Set<string>>();
+  ): Promise<Map<string, string>> {
+    const owners = new Map<string, string>();
     const liveOwned = this.sharedMemoryOwnedEntities.get(ownershipKey);
     if (liveOwned) {
       for (const [root, owner] of liveOwned) {
-        addOwner(owners, root, owner);
+        setEffectiveOwner(owners, root, owner);
       }
     }
 
@@ -3123,6 +3123,7 @@ export class DKGPublisher implements Publisher {
       }
     }
 
+    const durableOwners = new Map<string, string>();
     if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {
       this.sharedMemoryOwnedEntities.set(ownershipKey, new Map());
     }
@@ -3134,10 +3135,12 @@ export class DKGPublisher implements Publisher {
       if (!entity || !creator) continue;
       const validPeers = validatedOwners.get(entity);
       if (!validPeers?.has(creator)) continue;
-      addOwner(owners, entity, creator);
-      if (!hydratedOwned.has(entity)) {
-        hydratedOwned.set(entity, creator);
-      }
+      setEffectiveOwner(durableOwners, entity, creator);
+    }
+
+    for (const [entity, creator] of durableOwners) {
+      owners.set(entity, creator);
+      hydratedOwned.set(entity, creator);
     }
 
     return owners;
@@ -3467,17 +3470,15 @@ export class DKGPublisher implements Publisher {
     // Rule 4: reject roots owned by a different peer before any mutations.
     const skippedRoots = new Set<string>();
     for (const root of rootEntities) {
-      const owners = swmOwners.get(root);
-      if (!owners || owners.size === 0) continue;
+      const owner = swmOwners.get(root);
+      if (!owner) continue;
       if (opts?.publisherPeerId) {
-        const foreignOwner = [...owners].find((owner) => owner !== opts.publisherPeerId);
-        if (foreignOwner) {
+        if (owner !== opts.publisherPeerId) {
           throw new Error(
-            `Cannot promote entity <${root}>: owned by peer ${foreignOwner}, not by caller ${opts.publisherPeerId}.`,
+            `Cannot promote entity <${root}>: owned by peer ${owner}, not by caller ${opts.publisherPeerId}.`,
           );
         }
       } else {
-        const owner = [...owners][0];
         this.log.warn(createOperationContext('share'), `Skipping entity <${root}>: owned by peer ${owner} in SWM but no publisherPeerId provided to verify ownership.`);
         skippedRoots.add(root);
       }
@@ -3667,4 +3668,11 @@ function stripSparqlLiteral(value: string | undefined): string | undefined {
 function addOwner(owners: Map<string, Set<string>>, root: string, owner: string): void {
   if (!owners.has(root)) owners.set(root, new Set());
   owners.get(root)!.add(owner);
+}
+
+function setEffectiveOwner(owners: Map<string, string>, root: string, owner: string): void {
+  const existing = owners.get(root);
+  if (!existing || owner < existing) {
+    owners.set(root, owner);
+  }
 }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3070,6 +3070,79 @@ export class DKGPublisher implements Publisher {
     return count;
   }
 
+  private async sharedMemoryOwnersForPromotion(
+    contextGraphId: string,
+    subGraphName: string | undefined,
+    ownershipKey: string,
+    rootEntities: readonly string[],
+  ): Promise<Map<string, Set<string>>> {
+    const owners = new Map<string, Set<string>>();
+    const liveOwned = this.sharedMemoryOwnedEntities.get(ownershipKey);
+    if (liveOwned) {
+      for (const [root, owner] of liveOwned) {
+        addOwner(owners, root, owner);
+      }
+    }
+
+    if (rootEntities.length === 0) return owners;
+
+    const DKG = 'http://dkg.io/ontology/';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(contextGraphId, subGraphName);
+    const entityValues = rootEntities
+      .map((root) => `<${assertSafeIri(root)}>`)
+      .join(' ');
+
+    const ownershipResult = await this.store.query(
+      `SELECT DISTINCT ?entity ?creator WHERE {
+        GRAPH <${assertSafeIri(swmMetaGraph)}> {
+          VALUES ?entity { ${entityValues} }
+          ?entity <${DKG}workspaceOwner> ?creator .
+        }
+      }`,
+    );
+
+    if (ownershipResult.type !== 'bindings' || ownershipResult.bindings.length === 0) return owners;
+
+    const operationResult = await this.store.query(
+      `SELECT DISTINCT ?entity ?creator WHERE {
+        GRAPH <${assertSafeIri(swmMetaGraph)}> {
+          VALUES ?entity { ${entityValues} }
+          ?op <${DKG}rootEntity> ?entity ;
+              <${PROV}wasAttributedTo> ?creator .
+        }
+      }`,
+    );
+    const validatedOwners = new Map<string, Set<string>>();
+    if (operationResult.type === 'bindings') {
+      for (const row of operationResult.bindings) {
+        const entity = row['entity'];
+        const creator = stripSparqlLiteral(row['creator']);
+        if (!entity || !creator) continue;
+        addOwner(validatedOwners, entity, creator);
+      }
+    }
+
+    if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {
+      this.sharedMemoryOwnedEntities.set(ownershipKey, new Map());
+    }
+    const hydratedOwned = this.sharedMemoryOwnedEntities.get(ownershipKey)!;
+
+    for (const row of ownershipResult.bindings) {
+      const entity = row['entity'];
+      const creator = stripSparqlLiteral(row['creator']);
+      if (!entity || !creator) continue;
+      const validPeers = validatedOwners.get(entity);
+      if (!validPeers?.has(creator)) continue;
+      addOwner(owners, entity, creator);
+      if (!hydratedOwned.has(entity)) {
+        hydratedOwned.set(entity, creator);
+      }
+    }
+
+    return owners;
+  }
+
   /** @deprecated Use reconstructSharedMemoryOwnership */
   async reconstructWorkspaceOwnership(): Promise<number> {
     return this.reconstructSharedMemoryOwnership();
@@ -3324,6 +3397,12 @@ export class DKGPublisher implements Publisher {
 
     const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(contextGraphId, opts?.subGraphName);
     const ownershipKey = opts?.subGraphName ? `${contextGraphId}\0${opts.subGraphName}` : contextGraphId;
+    const swmOwners = await this.sharedMemoryOwnersForPromotion(
+      contextGraphId,
+      opts?.subGraphName,
+      ownershipKey,
+      rootEntities,
+    );
     const swmOwned = this.sharedMemoryOwnedEntities.get(ownershipKey) ?? new Map<string, string>();
 
     // Pre-encode gossip message and enforce size limit BEFORE any destructive
@@ -3388,15 +3467,17 @@ export class DKGPublisher implements Publisher {
     // Rule 4: reject roots owned by a different peer before any mutations.
     const skippedRoots = new Set<string>();
     for (const root of rootEntities) {
-      const owner = swmOwned.get(root);
-      if (!owner) continue;
+      const owners = swmOwners.get(root);
+      if (!owners || owners.size === 0) continue;
       if (opts?.publisherPeerId) {
-        if (owner !== opts.publisherPeerId) {
+        const foreignOwner = [...owners].find((owner) => owner !== opts.publisherPeerId);
+        if (foreignOwner) {
           throw new Error(
-            `Cannot promote entity <${root}>: owned by peer ${owner}, not by caller ${opts.publisherPeerId}.`,
+            `Cannot promote entity <${root}>: owned by peer ${foreignOwner}, not by caller ${opts.publisherPeerId}.`,
           );
         }
       } else {
+        const owner = [...owners][0];
         this.log.warn(createOperationContext('share'), `Skipping entity <${root}>: owned by peer ${owner} in SWM but no publisherPeerId provided to verify ownership.`);
         skippedRoots.add(root);
       }
@@ -3575,4 +3656,15 @@ function parseCountLiteral(val: string | false | undefined): number {
   const stripped = val.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '');
   const n = Number(stripped);
   return Number.isFinite(n) ? n : NaN;
+}
+
+function stripSparqlLiteral(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (!value.startsWith('"')) return value;
+  return value.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '');
+}
+
+function addOwner(owners: Map<string, Set<string>>, root: string, owner: string): void {
+  if (!owners.has(root)) owners.set(root, new Set());
+  owners.get(root)!.add(owner);
 }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3145,8 +3145,8 @@ export class DKGPublisher implements Publisher {
     const hydratedOwned = this.sharedMemoryOwnedEntities.get(ownershipKey)!;
 
     for (const [entity, creator] of durableOwners) {
-      owners.set(entity, creator);
-      hydratedOwned.set(entity, creator);
+      setEffectiveOwner(owners, entity, creator);
+      setEffectiveOwner(hydratedOwned, entity, creator);
     }
 
     return owners;

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3008,66 +3008,107 @@ export class DKGPublisher implements Publisher {
   private async reconstructOwnershipFromGraph(
     ownershipKey: string, swmMetaGraph: string, DKG: string, PROV: string,
   ): Promise<number> {
-    const result = await this.store.query(
-      `SELECT ?entity ?creator WHERE { GRAPH <${swmMetaGraph}> { ?entity <${DKG}workspaceOwner> ?creator } }`,
+    const durableOwners = await this.loadValidatedSharedMemoryOwners(
+      swmMetaGraph,
+      DKG,
+      PROV,
+      undefined,
+      'reconstruct',
     );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return 0;
-
-    const opsResult = await this.store.query(
-      `SELECT ?op ?peer ?root WHERE { GRAPH <${swmMetaGraph}> { ?op <${PROV}wasAttributedTo> ?peer . ?op <${DKG}rootEntity> ?root } }`,
-    );
-    const validatedOwners = new Map<string, Set<string>>();
-    if (opsResult.type === 'bindings') {
-      for (const row of opsResult.bindings) {
-        const root = row['root'];
-        const peer = row['peer'];
-        if (!root || !peer) continue;
-        const peerStr = peer.startsWith('"')
-          ? peer.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '')
-          : peer;
-        if (!validatedOwners.has(root)) validatedOwners.set(root, new Set());
-        validatedOwners.get(root)!.add(peerStr);
-      }
-    }
+    if (durableOwners.size === 0) return 0;
 
     if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {
       this.sharedMemoryOwnedEntities.set(ownershipKey, new Map());
     }
     const ownedMap = this.sharedMemoryOwnedEntities.get(ownershipKey)!;
     let count = 0;
-    for (const row of result.bindings) {
-      const entity = row['entity'];
-      const creator = row['creator'];
-      if (!entity || !creator) continue;
-      const creatorStr = creator.startsWith('"')
-        ? creator.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '')
-        : creator;
-
-      const validPeers = validatedOwners.get(entity);
-      if (!validPeers || !validPeers.has(creatorStr)) {
-        this.log.warn(
-          createOperationContext('reconstruct'),
-          `Skipping unvalidated ownership: entity=${entity} creator=${creatorStr}`,
-        );
-        continue;
-      }
-
+    for (const [entity, creator] of durableOwners) {
       if (ownedMap.has(entity)) {
         const existing = ownedMap.get(entity)!;
-        if (existing !== creatorStr) {
+        if (existing !== creator) {
           this.log.warn(
             createOperationContext('reconstruct'),
-            `Conflicting ownership for ${entity}: "${existing}" vs "${creatorStr}"; keeping alphabetically first`,
+            `Conflicting ownership for ${entity}: "${existing}" vs "${creator}"; keeping alphabetically first`,
           );
-          if (creatorStr < existing) ownedMap.set(entity, creatorStr);
+          setEffectiveOwner(ownedMap, entity, creator);
         }
         continue;
       }
 
-      ownedMap.set(entity, creatorStr);
+      ownedMap.set(entity, creator);
       count++;
     }
     return count;
+  }
+
+  private async loadValidatedSharedMemoryOwners(
+    swmMetaGraph: string,
+    DKG: string,
+    PROV: string,
+    rootEntities: readonly string[] | undefined,
+    logOperation: 'reconstruct' | 'share',
+  ): Promise<Map<string, string>> {
+    const valuesClause = rootEntities?.length
+      ? `VALUES ?entity { ${rootEntities.map((root) => `<${assertSafeIri(root)}>`).join(' ')} }`
+      : '';
+
+    const ownershipResult = await this.store.query(
+      `SELECT DISTINCT ?entity ?creator WHERE {
+        GRAPH <${assertSafeIri(swmMetaGraph)}> {
+          ${valuesClause}
+          ?entity <${DKG}workspaceOwner> ?creator .
+        }
+      }`,
+    );
+    if (ownershipResult.type !== 'bindings' || ownershipResult.bindings.length === 0) {
+      return new Map();
+    }
+
+    const operationResult = await this.store.query(
+      `SELECT DISTINCT ?entity ?creator WHERE {
+        GRAPH <${assertSafeIri(swmMetaGraph)}> {
+          ${valuesClause}
+          ?op <${DKG}rootEntity> ?entity ;
+              <${PROV}wasAttributedTo> ?creator .
+        }
+      }`,
+    );
+
+    const validatedOwners = new Map<string, Set<string>>();
+    if (operationResult.type === 'bindings') {
+      for (const row of operationResult.bindings) {
+        const entity = row['entity'];
+        const creator = stripSparqlLiteral(row['creator']);
+        if (!entity || !creator) continue;
+        addOwner(validatedOwners, entity, creator);
+      }
+    }
+
+    const durableOwners = new Map<string, string>();
+    for (const row of ownershipResult.bindings) {
+      const entity = row['entity'];
+      const creator = stripSparqlLiteral(row['creator']);
+      if (!entity || !creator) continue;
+      const validPeers = validatedOwners.get(entity);
+      if (!validPeers?.has(creator)) {
+        this.log.warn(
+          createOperationContext(logOperation),
+          `Skipping unvalidated ownership: entity=${entity} creator=${creator}`,
+        );
+        continue;
+      }
+
+      const existing = durableOwners.get(entity);
+      if (existing && existing !== creator) {
+        this.log.warn(
+          createOperationContext(logOperation),
+          `Conflicting ownership for ${entity}: "${existing}" vs "${creator}"; keeping alphabetically first`,
+        );
+      }
+      setEffectiveOwner(durableOwners, entity, creator);
+    }
+
+    return durableOwners;
   }
 
   private async sharedMemoryOwnersForPromotion(
@@ -3089,54 +3130,19 @@ export class DKGPublisher implements Publisher {
     const DKG = 'http://dkg.io/ontology/';
     const PROV = 'http://www.w3.org/ns/prov#';
     const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(contextGraphId, subGraphName);
-    const entityValues = rootEntities
-      .map((root) => `<${assertSafeIri(root)}>`)
-      .join(' ');
-
-    const ownershipResult = await this.store.query(
-      `SELECT DISTINCT ?entity ?creator WHERE {
-        GRAPH <${assertSafeIri(swmMetaGraph)}> {
-          VALUES ?entity { ${entityValues} }
-          ?entity <${DKG}workspaceOwner> ?creator .
-        }
-      }`,
+    const durableOwners = await this.loadValidatedSharedMemoryOwners(
+      swmMetaGraph,
+      DKG,
+      PROV,
+      rootEntities,
+      'share',
     );
+    if (durableOwners.size === 0) return owners;
 
-    if (ownershipResult.type !== 'bindings' || ownershipResult.bindings.length === 0) return owners;
-
-    const operationResult = await this.store.query(
-      `SELECT DISTINCT ?entity ?creator WHERE {
-        GRAPH <${assertSafeIri(swmMetaGraph)}> {
-          VALUES ?entity { ${entityValues} }
-          ?op <${DKG}rootEntity> ?entity ;
-              <${PROV}wasAttributedTo> ?creator .
-        }
-      }`,
-    );
-    const validatedOwners = new Map<string, Set<string>>();
-    if (operationResult.type === 'bindings') {
-      for (const row of operationResult.bindings) {
-        const entity = row['entity'];
-        const creator = stripSparqlLiteral(row['creator']);
-        if (!entity || !creator) continue;
-        addOwner(validatedOwners, entity, creator);
-      }
-    }
-
-    const durableOwners = new Map<string, string>();
     if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {
       this.sharedMemoryOwnedEntities.set(ownershipKey, new Map());
     }
     const hydratedOwned = this.sharedMemoryOwnedEntities.get(ownershipKey)!;
-
-    for (const row of ownershipResult.bindings) {
-      const entity = row['entity'];
-      const creator = stripSparqlLiteral(row['creator']);
-      if (!entity || !creator) continue;
-      const validPeers = validatedOwners.get(entity);
-      if (!validPeers?.has(creator)) continue;
-      setEffectiveOwner(durableOwners, entity, creator);
-    }
 
     for (const [entity, creator] of durableOwners) {
       owners.set(entity, creator);

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -15,9 +15,11 @@ import { createEVMAdapter, getSharedContext, HARDHAT_KEYS } from '../../chain/te
 
 const CG_ID = 'test-assertion-cg';
 const SWM_GRAPH = `did:dkg:context-graph:${CG_ID}/_shared_memory`;
+const SWM_META_GRAPH = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
 const AGENT = '0x1234567890abcdef1234567890abcdef12345678';
 const AGENT_B = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
 const PEER = '12D3KooWPromoteBoundary';
+const PEER_B = '12D3KooWPromoteBoundaryB';
 const ASSERTION_NAME = 'my-assertion';
 
 const TRIPLES = [
@@ -111,6 +113,68 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(swmResult.type).toBe('bindings');
     if (swmResult.type === 'bindings') {
       expect(swmResult.bindings.length).toBe(3);
+    }
+  });
+
+  it('durable SWM ownership blocks cross-author promote after publisher restart with empty map', async () => {
+    const root = 'urn:test:entity:restart-owned';
+    const firstAssertion = 'restart-owner-a';
+    const secondAssertion = 'restart-owner-b';
+
+    await publisher.assertionCreate(CG_ID, firstAssertion, AGENT);
+    await publisher.assertionWrite(CG_ID, firstAssertion, AGENT, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Original"' },
+    ]);
+    await publisher.assertionPromote(CG_ID, firstAssertion, AGENT, { publisherPeerId: PEER });
+
+    const ownerBefore = await store.query(
+      `SELECT ?creator WHERE { GRAPH <${SWM_META_GRAPH}> { <${root}> <http://dkg.io/ontology/workspaceOwner> ?creator } }`,
+    );
+    expect(ownerBefore.type).toBe('bindings');
+    if (ownerBefore.type === 'bindings') {
+      expect(ownerBefore.bindings.map((row) => row['creator'])).toEqual([`"${PEER}"`]);
+    }
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const restartedPublisher = new DKGPublisher({
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: new Map(),
+    });
+
+    await restartedPublisher.assertionCreate(CG_ID, secondAssertion, AGENT_B);
+    await restartedPublisher.assertionWrite(CG_ID, secondAssertion, AGENT_B, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Overwritten"' },
+    ]);
+
+    await expect(
+      restartedPublisher.assertionPromote(CG_ID, secondAssertion, AGENT_B, { publisherPeerId: PEER_B }),
+    ).rejects.toThrow(
+      `Cannot promote entity <${root}>: owned by peer ${PEER}, not by caller ${PEER_B}.`,
+    );
+
+    const remaining = await restartedPublisher.assertionQuery(CG_ID, secondAssertion, AGENT_B);
+    expect(remaining).toHaveLength(1);
+
+    const swmAfter = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${root}> <http://schema.org/name> ?o } }`,
+    );
+    expect(swmAfter.type).toBe('bindings');
+    if (swmAfter.type === 'bindings') {
+      expect(swmAfter.bindings.map((row) => row['o'])).toEqual(['"Original"']);
+    }
+
+    const ownerAfter = await store.query(
+      `SELECT ?creator WHERE { GRAPH <${SWM_META_GRAPH}> { <${root}> <http://dkg.io/ontology/workspaceOwner> ?creator } }`,
+    );
+    expect(ownerAfter.type).toBe('bindings');
+    if (ownerAfter.type === 'bindings') {
+      expect(ownerAfter.bindings.map((row) => row['creator'])).toEqual([`"${PEER}"`]);
     }
   });
 

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -178,6 +178,123 @@ describe('Working Memory Assertion Lifecycle', () => {
     }
   });
 
+  it('durable SWM ownership allows owner promote after publisher restart with empty map', async () => {
+    const root = 'urn:test:entity:restart-owned-upsert';
+    const firstAssertion = 'restart-owner-upsert-a';
+    const secondAssertion = 'restart-owner-upsert-b';
+
+    await publisher.assertionCreate(CG_ID, firstAssertion, AGENT);
+    await publisher.assertionWrite(CG_ID, firstAssertion, AGENT, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Original"' },
+    ]);
+    await publisher.assertionPromote(CG_ID, firstAssertion, AGENT, { publisherPeerId: PEER });
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const restartedPublisher = new DKGPublisher({
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: new Map(),
+    });
+
+    await restartedPublisher.assertionCreate(CG_ID, secondAssertion, AGENT_B);
+    await restartedPublisher.assertionWrite(CG_ID, secondAssertion, AGENT_B, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Updated"' },
+    ]);
+
+    const result = await restartedPublisher.assertionPromote(CG_ID, secondAssertion, AGENT_B, {
+      publisherPeerId: PEER,
+    });
+    expect(result.promotedCount).toBe(1);
+
+    const remaining = await restartedPublisher.assertionQuery(CG_ID, secondAssertion, AGENT_B);
+    expect(remaining).toHaveLength(0);
+
+    const swmAfter = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${root}> <http://schema.org/name> ?o } }`,
+    );
+    expect(swmAfter.type).toBe('bindings');
+    if (swmAfter.type === 'bindings') {
+      expect(swmAfter.bindings.map((row) => row['o'])).toEqual(['"Updated"']);
+    }
+
+    const ownerAfter = await store.query(
+      `SELECT ?creator WHERE { GRAPH <${SWM_META_GRAPH}> { <${root}> <http://dkg.io/ontology/workspaceOwner> ?creator } }`,
+    );
+    expect(ownerAfter.type).toBe('bindings');
+    if (ownerAfter.type === 'bindings') {
+      expect(ownerAfter.bindings.map((row) => row['creator'])).toEqual([`"${PEER}"`]);
+    }
+  });
+
+  it('durable SWM ownership collapses conflicts before owner promote after restart', async () => {
+    const root = 'urn:test:entity:restart-owned-conflict';
+    const firstAssertion = 'restart-owner-conflict-a';
+    const secondAssertion = 'restart-owner-conflict-b';
+    const conflictOperation = 'urn:dkg:share:test-assertion-cg:restart-owner-conflict';
+
+    await publisher.assertionCreate(CG_ID, firstAssertion, AGENT);
+    await publisher.assertionWrite(CG_ID, firstAssertion, AGENT, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Original"' },
+    ]);
+    await publisher.assertionPromote(CG_ID, firstAssertion, AGENT, { publisherPeerId: PEER });
+
+    await store.insert([
+      {
+        subject: root,
+        predicate: 'http://dkg.io/ontology/workspaceOwner',
+        object: `"${PEER_B}"`,
+        graph: SWM_META_GRAPH,
+      },
+      {
+        subject: conflictOperation,
+        predicate: 'http://dkg.io/ontology/rootEntity',
+        object: root,
+        graph: SWM_META_GRAPH,
+      },
+      {
+        subject: conflictOperation,
+        predicate: 'http://www.w3.org/ns/prov#wasAttributedTo',
+        object: `"${PEER_B}"`,
+        graph: SWM_META_GRAPH,
+      },
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const restartedPublisher = new DKGPublisher({
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: new Map(),
+    });
+
+    await restartedPublisher.assertionCreate(CG_ID, secondAssertion, AGENT_B);
+    await restartedPublisher.assertionWrite(CG_ID, secondAssertion, AGENT_B, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Effective owner update"' },
+    ]);
+
+    const result = await restartedPublisher.assertionPromote(CG_ID, secondAssertion, AGENT_B, {
+      publisherPeerId: PEER,
+    });
+    expect(result.promotedCount).toBe(1);
+
+    const swmAfter = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${root}> <http://schema.org/name> ?o } }`,
+    );
+    expect(swmAfter.type).toBe('bindings');
+    if (swmAfter.type === 'bindings') {
+      expect(swmAfter.bindings.map((row) => row['o'])).toEqual(['"Effective owner update"']);
+    }
+  });
+
   it('promote accepts a payload above the old 512 KB cap and below 10 MB', async () => {
     await publisher.assertionCreate(CG_ID, 'large-promote', AGENT);
     const quads = largePayloadQuads('large-promote', 2 * 1024 * 1024);

--- a/scripts/_devnet-full-sweep.sh
+++ b/scripts/_devnet-full-sweep.sh
@@ -24,6 +24,7 @@ SCRIPTS=(
   "rfc38-unclean-restart"
   "publish"
   "sharing"
+  "swm-ownership-restart"
   "invite-flow"
   "cli-invite"
   "reject-flow"

--- a/scripts/devnet-test-swm-ownership-restart.sh
+++ b/scripts/devnet-test-swm-ownership-restart.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+#
+# SWM ownership restart regression.
+#
+# Reproduces the Phase 0 correctness slice for issue #747 against real
+# devnet daemons:
+#
+#   1. Node 1 promotes a root entity into the public devnet CG.
+#   2. Node 2 receives the SWM data plus _shared_memory_meta owner row.
+#   3. Node 1 is stopped, so the original owner is offline.
+#   4. Node 2 is restarted, clearing process-local publisher ownership maps
+#      while preserving its local store and without live owner help.
+#   5. Node 2 attempts to promote the same root. This must hard-fail from
+#      durable local SWM metadata, and must not overwrite SWM data or owner.
+#
+# Preconditions:
+#   ./scripts/devnet.sh clean
+#   ./scripts/devnet.sh start 6
+#
+# No bootstrap publishes are required; the script only uses the daemon HTTP API.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+API_PORT_BASE=9201
+CONTEXT_GRAPH="${CONTEXT_GRAPH:-devnet-test}"
+OWNER_NODE="${OWNER_NODE:-1}"
+ATTACKER_NODE="${ATTACKER_NODE:-2}"
+TMPDIR="${TMPDIR:-/tmp}"
+
+DKG_WORKSPACE_OWNER="http://dkg.io/ontology/workspaceOwner"
+SCHEMA_NAME="http://schema.org/name"
+
+log()  { echo "[swm-own] $*"; }
+warn() { echo "[swm-own] WARN: $*" >&2; }
+fail() { echo "[swm-own] FAIL: $*" >&2; exit 1; }
+act()  { echo ""; echo "[swm-own] === $1 ==="; }
+
+node_dir()     { echo "$DEVNET_DIR/node$1"; }
+node_token()   { grep -v '^#' "$(node_dir "$1")/auth.token" 2>/dev/null | tr -d '[:space:]'; }
+node_port()    { echo $((API_PORT_BASE + $1 - 1)); }
+node_pidfile() { echo "$(node_dir "$1")/devnet.pid"; }
+
+require_node() {
+  local node="$1"
+  [ -d "$(node_dir "$node")" ] || fail "node $node home missing; run ./scripts/devnet.sh start 6 first"
+  [ -n "$(node_token "$node")" ] || fail "node $node auth token missing"
+}
+
+api_capture() {
+  local node="$1" method="$2" path="$3" data="${4:-}" body_out="$5" code_out="$6"
+  local port token tmp code content
+  port=$(node_port "$node")
+  token=$(node_token "$node")
+  tmp="$(mktemp "$TMPDIR/swm-own-response-XXXXXX")"
+  local -a curl_args=(-sS --max-time 180 --connect-timeout 5 -o "$tmp" -w "%{http_code}" -X "$method")
+  curl_args+=(-H "Authorization: Bearer $token" -H "Content-Type: application/json")
+  [ -n "$data" ] && curl_args+=(-d "$data")
+  curl_args+=("http://127.0.0.1:${port}${path}")
+  code=$(curl "${curl_args[@]}" 2>/dev/null || echo "000")
+  content="$(cat "$tmp" 2>/dev/null || true)"
+  rm -f "$tmp"
+  printf -v "$body_out" '%s' "$content"
+  printf -v "$code_out" '%s' "$code"
+}
+
+api_call() {
+  local node="$1" method="$2" path="$3" data="${4:-}" body code
+  api_capture "$node" "$method" "$path" "$data" body code
+  if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
+    fail "$method $path on node $node failed with HTTP $code: $body"
+  fi
+  printf '%s' "$body"
+}
+
+parse_json() {
+  printf '%s' "$1" | node -e "
+    let d='';
+    process.stdin.on('data', c => d += c);
+    process.stdin.on('end', () => {
+      try {
+        const j = JSON.parse(d);
+        const v = j$2;
+        console.log(v == null ? '' : v);
+      } catch {
+        process.exit(1);
+      }
+    });
+  "
+}
+
+binding_values() {
+  local json="$1" var="$2"
+  printf '%s' "$json" | VAR="$var" node -e '
+    let d = "";
+    process.stdin.on("data", c => d += c);
+    process.stdin.on("end", () => {
+      try {
+        const j = JSON.parse(d);
+        const bindings = j?.result?.bindings ?? j?.bindings ?? [];
+        const unwrap = (cell) => {
+          if (cell == null) return "";
+          if (typeof cell === "object" && "value" in cell) return String(cell.value);
+          const s = String(cell);
+          const m = s.match(/^"((?:\\.|[^"\\])*)"(?:\^\^<[^>]+>|@[A-Za-z-]+)?$/);
+          if (!m) return s;
+          try { return JSON.parse("\"" + m[1] + "\""); } catch { return m[1]; }
+        };
+        for (const b of bindings) {
+          const v = unwrap(b[process.env.VAR]);
+          if (v) console.log(v);
+        }
+      } catch {
+        process.exit(1);
+      }
+    });
+  '
+}
+
+bindings_count() {
+  local json="$1"
+  printf '%s' "$json" | node -e '
+    let d = "";
+    process.stdin.on("data", c => d += c);
+    process.stdin.on("end", () => {
+      try {
+        const j = JSON.parse(d);
+        const bindings = j?.result?.bindings ?? j?.bindings ?? [];
+        console.log(Array.isArray(bindings) ? bindings.length : "PARSE_ERR");
+      } catch {
+        console.log("PARSE_ERR");
+      }
+    });
+  '
+}
+
+quads_count() {
+  local json="$1"
+  printf '%s' "$json" | node -e '
+    let d = "";
+    process.stdin.on("data", c => d += c);
+    process.stdin.on("end", () => {
+      try {
+        const j = JSON.parse(d);
+        const quads = j?.quads ?? j?.result ?? [];
+        console.log(Array.isArray(quads) ? quads.length : "PARSE_ERR");
+      } catch {
+        console.log("PARSE_ERR");
+      }
+    });
+  '
+}
+
+json_write_payload() {
+  ROOT="$1" VALUE="$2" CG="$CONTEXT_GRAPH" PRED="$SCHEMA_NAME" node -e '
+    console.log(JSON.stringify({
+      contextGraphId: process.env.CG,
+      quads: [{
+        subject: process.env.ROOT,
+        predicate: process.env.PRED,
+        object: JSON.stringify(process.env.VALUE),
+        graph: "",
+      }],
+    }));
+  '
+}
+
+json_owner_query_payload() {
+  ROOT="$1" CG="$CONTEXT_GRAPH" OWNER_PRED="$DKG_WORKSPACE_OWNER" node -e '
+    const metaGraph = `did:dkg:context-graph:${process.env.CG}/_shared_memory_meta`;
+    console.log(JSON.stringify({
+      contextGraphId: process.env.CG,
+      sparql:
+        `SELECT DISTINCT ?owner WHERE { GRAPH <${metaGraph}> { <${process.env.ROOT}> <${process.env.OWNER_PRED}> ?owner } }`,
+    }));
+  '
+}
+
+json_swm_value_query_payload() {
+  ROOT="$1" CG="$CONTEXT_GRAPH" PRED="$SCHEMA_NAME" node -e '
+    console.log(JSON.stringify({
+      contextGraphId: process.env.CG,
+      graphSuffix: "_shared_memory",
+      sparql: `SELECT DISTINCT ?value WHERE { <${process.env.ROOT}> <${process.env.PRED}> ?value }`,
+    }));
+  '
+}
+
+wait_for_node_down() {
+  local node="$1" port
+  port=$(node_port "$node")
+  for _ in $(seq 1 60); do
+    if ! curl -sf --max-time 1 -o /dev/null "http://127.0.0.1:${port}/api/status" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  fail "node $node did not stop within 30s"
+}
+
+wait_for_node_up() {
+  local node="$1" port
+  port=$(node_port "$node")
+  for _ in $(seq 1 240); do
+    if curl -sf --max-time 1 -o /dev/null "http://127.0.0.1:${port}/api/status" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  fail "node $node did not start within 120s"
+}
+
+kill_node() {
+  local node="$1" pid
+  pid=$(cat "$(node_pidfile "$node")" 2>/dev/null || true)
+  [ -n "$pid" ] || return 0
+  kill "$pid" 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.5
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    log "node $node not down after SIGTERM, sending SIGKILL"
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+  wait_for_node_down "$node"
+}
+
+restart_node() {
+  local node="$1"
+  ( cd "$REPO_ROOT" && ./scripts/devnet.sh restart-node "$node" 2>&1 | sed "s/^/  [devnet] /" )
+  wait_for_node_up "$node"
+}
+
+OWNER_STOPPED=0
+restart_owner_if_stopped() {
+  if [ "$OWNER_STOPPED" -eq 1 ]; then
+    log "trap: restarting owner node $OWNER_NODE so the devnet stays usable"
+    restart_node "$OWNER_NODE" || warn "trap: failed to restart owner node $OWNER_NODE"
+  fi
+}
+trap restart_owner_if_stopped EXIT
+
+get_peer_id() {
+  local node="$1" identity
+  identity=$(api_call "$node" GET /api/agent/identity)
+  parse_json "$identity" '.peerId'
+}
+
+assertion_create_write_finalize() {
+  local node="$1" assertion="$2" root="$3" value="$4" response count payload assertion_uri merkle_root
+  response=$(api_call "$node" POST /api/assertion/create "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"name\":\"$assertion\"}")
+  assertion_uri=$(parse_json "$response" '.assertionUri')
+  [ -n "$assertion_uri" ] || fail "create response missing assertionUri: $response"
+
+  payload=$(json_write_payload "$root" "$value")
+  response=$(api_call "$node" POST "/api/assertion/${assertion}/write" "$payload")
+  count=$(parse_json "$response" '.written')
+  [ "$count" = "1" ] || fail "expected one written quad for $assertion, got '$count': $response"
+
+  response=$(api_call "$node" POST "/api/assertion/${assertion}/finalize" "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}")
+  merkle_root=$(parse_json "$response" '.merkleRoot')
+  [ -n "$merkle_root" ] || fail "finalize response missing merkleRoot: $response"
+}
+
+promote_expect_success() {
+  local node="$1" assertion="$2" response count
+  response=$(api_call "$node" POST "/api/assertion/${assertion}/promote" "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}")
+  count=$(parse_json "$response" '.promotedCount')
+  [ "$count" = "1" ] || fail "expected one promoted quad for $assertion, got '$count': $response"
+}
+
+owner_values_on_node() {
+  local node="$1" root="$2" response
+  response=$(api_call "$node" POST /api/query "$(json_owner_query_payload "$root")")
+  binding_values "$response" owner
+}
+
+swm_values_on_node() {
+  local node="$1" root="$2" response
+  response=$(api_call "$node" POST /api/query "$(json_swm_value_query_payload "$root")")
+  binding_values "$response" value
+}
+
+wait_for_owner_meta() {
+  local node="$1" root="$2" expected_owner="$3" values
+  for _ in $(seq 1 90); do
+    values="$(owner_values_on_node "$node" "$root" 2>/dev/null || true)"
+    if [ "$values" = "$expected_owner" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail "node $node did not observe durable owner '$expected_owner' for $root; last owners='$values'"
+}
+
+wait_for_swm_value() {
+  local node="$1" root="$2" expected_value="$3" values
+  for _ in $(seq 1 90); do
+    values="$(swm_values_on_node "$node" "$root" 2>/dev/null || true)"
+    if printf '%s\n' "$values" | grep -Fxq "$expected_value"; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail "node $node did not observe SWM value '$expected_value' for $root; last values='$values'"
+}
+
+require_node "$OWNER_NODE"
+require_node "$ATTACKER_NODE"
+wait_for_node_up "$OWNER_NODE"
+wait_for_node_up "$ATTACKER_NODE"
+
+OWNER_PEER=$(get_peer_id "$OWNER_NODE")
+ATTACKER_PEER=$(get_peer_id "$ATTACKER_NODE")
+[ -n "$OWNER_PEER" ] || fail "owner peer id missing"
+[ -n "$ATTACKER_PEER" ] || fail "attacker peer id missing"
+[ "$OWNER_PEER" != "$ATTACKER_PEER" ] || fail "owner and attacker peer IDs unexpectedly match"
+
+STAMP="$(date +%s)-$$"
+ROOT="urn:swm-ownership-restart:${STAMP}"
+OWNER_ASSERTION="swm-owner-${STAMP}"
+ATTACKER_ASSERTION="swm-attacker-${STAMP}"
+OWNER_VALUE="owner-original-${STAMP}"
+ATTACKER_VALUE="attacker-overwrite-${STAMP}"
+
+log "Context graph: $CONTEXT_GRAPH"
+log "Owner:        node $OWNER_NODE peer=$OWNER_PEER"
+log "Attacker:     node $ATTACKER_NODE peer=$ATTACKER_PEER"
+log "Root:         $ROOT"
+
+act "1. Owner promotes a root into SWM"
+assertion_create_write_finalize "$OWNER_NODE" "$OWNER_ASSERTION" "$ROOT" "$OWNER_VALUE"
+promote_expect_success "$OWNER_NODE" "$OWNER_ASSERTION"
+log "owner promote succeeded"
+
+act "2. Replica has SWM data and durable owner metadata"
+wait_for_swm_value "$ATTACKER_NODE" "$ROOT" "$OWNER_VALUE"
+wait_for_owner_meta "$ATTACKER_NODE" "$ROOT" "$OWNER_PEER"
+log "node $ATTACKER_NODE has owner metadata before restart"
+
+act "3. Stop owner so enforcement cannot depend on live owner gossip"
+OWNER_STOPPED=1
+kill_node "$OWNER_NODE"
+log "owner node $OWNER_NODE is offline"
+
+act "4. Restart replica to clear process-local ownership state while owner is offline"
+restart_node "$ATTACKER_NODE"
+wait_for_swm_value "$ATTACKER_NODE" "$ROOT" "$OWNER_VALUE"
+wait_for_owner_meta "$ATTACKER_NODE" "$ROOT" "$OWNER_PEER"
+log "node $ATTACKER_NODE still has durable owner metadata after offline-owner restart"
+
+act "5. Cross-owner promote must fail from durable local metadata"
+assertion_create_write_finalize "$ATTACKER_NODE" "$ATTACKER_ASSERTION" "$ROOT" "$ATTACKER_VALUE"
+
+PROMOTE_BODY=""
+PROMOTE_CODE=""
+api_capture "$ATTACKER_NODE" POST "/api/assertion/${ATTACKER_ASSERTION}/promote" "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}" PROMOTE_BODY PROMOTE_CODE
+if [ "$PROMOTE_CODE" -ge 200 ] && [ "$PROMOTE_CODE" -lt 300 ]; then
+  fail "cross-owner promote unexpectedly succeeded with HTTP $PROMOTE_CODE: $PROMOTE_BODY"
+fi
+EXPECTED_ERROR="Cannot promote entity <${ROOT}>: owned by peer ${OWNER_PEER}, not by caller ${ATTACKER_PEER}."
+case "$PROMOTE_BODY" in
+  *"$EXPECTED_ERROR"*) log "cross-owner promote failed with expected ownership error" ;;
+  *) fail "promote failed with unexpected body (HTTP $PROMOTE_CODE): $PROMOTE_BODY; expected '$EXPECTED_ERROR'" ;;
+esac
+
+act "6. Failed promote left WM, SWM, and ownership metadata intact"
+ASSERTION_QUERY=$(api_call "$ATTACKER_NODE" POST "/api/assertion/${ATTACKER_ASSERTION}/query" "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}")
+ASSERTION_CT=$(quads_count "$ASSERTION_QUERY")
+[ "$ASSERTION_CT" = "1" ] || fail "attacker WM assertion should still have 1 quad after failed promote, got '$ASSERTION_CT': $ASSERTION_QUERY"
+
+VALUES_AFTER="$(swm_values_on_node "$ATTACKER_NODE" "$ROOT")"
+printf '%s\n' "$VALUES_AFTER" | grep -Fxq "$OWNER_VALUE" \
+  || fail "owner SWM value missing after failed promote; values='$VALUES_AFTER'"
+if printf '%s\n' "$VALUES_AFTER" | grep -Fxq "$ATTACKER_VALUE"; then
+  fail "attacker value leaked into SWM after failed promote; values='$VALUES_AFTER'"
+fi
+
+OWNERS_AFTER="$(owner_values_on_node "$ATTACKER_NODE" "$ROOT")"
+[ "$OWNERS_AFTER" = "$OWNER_PEER" ] \
+  || fail "owner metadata changed after failed promote; owners='$OWNERS_AFTER', expected '$OWNER_PEER'"
+
+log "PASS: durable SWM ownership blocks cross-author promote after restart while owner is offline"


### PR DESCRIPTION
## Summary

- Fixes Phase 0 of #747 by making `DKGPublisher.assertionPromote` consult durable SWM ownership metadata before mutating shared memory.
- Keeps `dkg:workspaceOwner` as the ownership source of truth and uses `WorkspaceOperation` attribution only to validate the owner, matching startup reconstruction semantics.
- Adds publisher regression coverage plus a real devnet restart/offline-owner script proving a restarted peer cannot cross-author promote a root owned by an offline peer.

## Related

- Fixes #747

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/dkg-publisher.ts` | Hydrates promote-root ownership from `_shared_memory_meta` before Rule 4 enforcement and blocks conflicting durable owners. |
| `packages/publisher/test/draft-lifecycle.test.ts` | Adds restart/empty-map regression coverage for cross-author blocks, owner upserts, and effective-owner conflict handling. |
| `scripts/devnet-test-swm-ownership-restart.sh` | Adds a live devnet regression: node1 owns/promotes, node1 goes offline, node2 restarts, and node2 cannot promote the same root from durable local SWM metadata. |
| `scripts/_devnet-full-sweep.sh` | Includes the new SWM ownership restart script in the internal devnet sweep. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-publisher exec vitest run --config vitest.config.ts ./test/draft-lifecycle.test.ts -t "durable SWM ownership"`
- [x] `pnpm --filter @origintrail-official/dkg-publisher... run build`
- [x] `bash -n scripts/devnet-test-swm-ownership-restart.sh`
- [x] `bash -n scripts/_devnet-full-sweep.sh`
- [x] `git diff --check`
- [x] Local PR reviewer using `.codex/review-prompt.md`, `.codex/review-schema.json`, and `pr-diff.patch`; rerun returned `{"comments":[]}`.
- [ ] `./scripts/devnet.sh clean && ./scripts/devnet.sh start 6 && ./scripts/devnet-test-swm-ownership-restart.sh` (not run locally: this checkout has no `.devnet/node1`; direct invocation fails fast with `node 1 home missing; run ./scripts/devnet.sh start 6 first`).

Verification caveat: a later focused publisher Vitest attempt in this local environment was blocked before test collection by the existing Hardhat deployment state (`getContractAddress('DKGStakingConvictionNFT')` revert), while the touched package build and script syntax checks pass.
