### PR TITLE
fix(node-ui): codex review follow-up on rc.11 bug-fix batch (#752)

### DIFF
--- a/packages/node-ui/src/ui/components/Modals/cgNameValidation.ts
+++ b/packages/node-ui/src/ui/components/Modals/cgNameValidation.ts
@@ -119,6 +119,14 @@ export function validateCgName(input: string): string | null {
   if (HTML_TAG_SHAPE_RE.test(input)) {
     return 'HTML tags are not allowed in the name — they have been stripped automatically.';
   }
+  // Any residual `<` or `>` in the raw input is also lossy: bare
+  // brackets are dropped by `sanitiseCgName`, and an unclosed `<tag`
+  // causes `stripHtmlTagSpans` to discard everything after the `<`.
+  // Both produce a submitted name that differs from what the user
+  // saw without any warning (codex #752 review). Surface it.
+  if (/[<>]/.test(input)) {
+    return 'Angle brackets (< or >) are not allowed in the name — they and any text consumed by an unclosed tag have been stripped automatically.';
+  }
   if (input.length > CG_NAME_MAX_LENGTH) {
     return `Name was trimmed to ${CG_NAME_MAX_LENGTH} characters (was ${input.length}).`;
   }

--- a/packages/node-ui/src/ui/hooks/useVisibilityPolling.ts
+++ b/packages/node-ui/src/ui/hooks/useVisibilityPolling.ts
@@ -50,7 +50,14 @@ export function useVisibilityPolling(
       start();
     };
 
-    if (optionsRef.current.runImmediately !== false) cbRef.current();
+    // BUG-007 / codex #752: the eager mount call must also pause when
+    // the tab is hidden. Browser session restore and "open all tabs"
+    // commonly mount React in a backgrounded tab; without this guard
+    // every `useVisibilityPolling` consumer still fires one fetch on
+    // mount, which is most of the daemon-fan-out we were trying to
+    // suppress. The visibilitychange handler will run the deferred
+    // initial refresh as soon as the user returns to the tab.
+    if (optionsRef.current.runImmediately !== false && !document.hidden) cbRef.current();
     if (!document.hidden) start();
     document.addEventListener('visibilitychange', onVisibility);
 

--- a/packages/node-ui/src/ui/lib/redactRpcUrl.ts
+++ b/packages/node-ui/src/ui/lib/redactRpcUrl.ts
@@ -14,20 +14,31 @@
  * shaped" path segment. A segment is treated as a secret if it's
  * length-≥16 and consists of hex/base64-ish characters.
  */
+// Use ASCII bullet `*` for masking — `URL` percent-encodes any
+// non-ASCII character we put back into pathname/search, which would
+// turn a friendly `••••••••` into `%E2%80%A2…` and defeat the point
+// of the redaction.
+const MASK = '************';
+
+// "Secret-shaped" run heuristic: length-≥16 alphanumeric (+ `_` / `-`)
+// span, matching the per-segment predicate used on the parsed path
+// branch. Covers hex (Infura/Alchemy), base62 (QuickNode), and JWT-ish
+// path tokens uniformly so the malformed-URL fallback below does not
+// silently leak non-hex secrets (codex #752 review).
+const SECRET_RUN_RE = /[A-Za-z0-9_-]{16,}/g;
+
 export function redactRpcUrl(rpc: string | null | undefined): string {
   if (!rpc) return '';
   let parsed: URL;
   try {
     parsed = new URL(rpc);
   } catch {
-    // Not a valid URL — at minimum, mask anything that looks tokenish.
-    return rpc.replace(/[a-f0-9]{16,}/gi, (m) => '*'.repeat(Math.min(m.length, 12)));
+    // Not a valid URL (typically a scheme-less paste like
+    // `mainnet.infura.io/v3/<token>`). Reuse the same secret-run
+    // heuristic the parsed-path branch uses so we still mask base62
+    // / base64 tokens, not only hex ones.
+    return rpc.replace(SECRET_RUN_RE, MASK);
   }
-  // Use ASCII bullet `*` for masking — `URL` percent-encodes any
-  // non-ASCII character we put back into pathname/search, which would
-  // turn a friendly `••••••••` into `%E2%80%A2…` and defeat the point
-  // of the redaction.
-  const MASK = '************';
   // Some operators paste RPC URLs with HTTP basic auth baked in
   // (`https://user:pass@host/path` or `https://tenantonly@host/path`).
   // Strip BOTH userinfo fields whenever EITHER is present — the

--- a/packages/node-ui/test/cg-name-validation.test.ts
+++ b/packages/node-ui/test/cg-name-validation.test.ts
@@ -102,5 +102,30 @@ describe('cg-name validation (BUG-016)', () => {
         expect(validateCgName('<b>tagged</b>')).toContain('HTML');
       }
     });
+
+    it('warns when sanitise drops content via an unclosed `<tag` (codex #752 — was silent)', () => {
+      // `Project <b` has tag-shape start but no closing `>`. The
+      // sanitiser drops everything from `<` onward; submitting would
+      // post just `Project` while the input field shows `Project <b`.
+      // Pre-fix this returned null (no warning). The new check must
+      // surface it to the user.
+      const msg = validateCgName('Project <b');
+      expect(msg).not.toBeNull();
+      expect(msg).toMatch(/angle bracket|<|>|stripped/i);
+    });
+
+    it('warns when sanitise strips bare `<` / `>` characters that did not form a tag span (codex #752 — was silent)', () => {
+      // `< not a tag >` survives the tag-span scan (because `< ` does
+      // not look like a tag start), then the bare-bracket strip drops
+      // both `<` and `>`. Pre-fix the user saw `< not a tag >` in the
+      // input but submitted `not a tag`.
+      const msg = validateCgName('< not a tag >');
+      expect(msg).not.toBeNull();
+      expect(msg).toMatch(/angle bracket|stripped/i);
+
+      const msg2 = validateCgName('Project >>> Beta');
+      expect(msg2).not.toBeNull();
+      expect(msg2).toMatch(/angle bracket|stripped/i);
+    });
   });
 });

--- a/packages/node-ui/test/redact-rpc-url.test.ts
+++ b/packages/node-ui/test/redact-rpc-url.test.ts
@@ -56,6 +56,26 @@ describe('redactRpcUrl (BUG-012)', () => {
     expect(redacted).not.toContain('664a23a04122d3fa485778b9141bc92e17293c73');
   });
 
+  it('redacts a base62/JWT-shaped (non-hex) secret in a malformed URL (codex #752 — fallback used to leak)', () => {
+    // `new URL()` throws on a scheme-less RPC paste like this, so the
+    // fallback branch handles redaction. The previous regex only matched
+    // hex runs, so a mixed-case base62 / JWT-ish token survived unmasked.
+    const malformed = 'mainnet.infura.io/v3/JBKLMNZ5HrA1B2C3D4E5F6G7H8I9';
+    const redacted = redactRpcUrl(malformed);
+    expect(redacted).not.toContain('JBKLMNZ5HrA1B2C3D4E5F6G7H8I9');
+    expect(redacted).toContain('infura.io');
+    expect(redacted).toContain('/v3/');
+    expect(redacted).toMatch(/\*+/);
+  });
+
+  it('also redacts base62 tokens in scheme-less paste with mixed-case + hyphens (defence in depth)', () => {
+    // A QuickNode-style mixed-case + hyphen token without a scheme.
+    const malformed = 'greatest-sound.base-sepolia.quiknode.pro/AbCdEf01234567-MixedCase';
+    const redacted = redactRpcUrl(malformed);
+    expect(redacted).not.toContain('AbCdEf01234567-MixedCase');
+    expect(redacted).toContain('quiknode.pro');
+  });
+
   it('strips HTTP basic-auth credentials baked into the URL (user:pass@host)', () => {
     const original = 'https://tenant1234:s3cr3t-shared-token@rpc.example.com/path';
     const redacted = redactRpcUrl(original);

--- a/packages/node-ui/test/use-visibility-polling.test.ts
+++ b/packages/node-ui/test/use-visibility-polling.test.ts
@@ -142,4 +142,28 @@ describe('useVisibilityPolling (BUG-007)', () => {
     act(() => { vi.advanceTimersByTime(5000); });
     expect(cb).not.toHaveBeenCalled();
   });
+
+  it('suppresses the eager mount fire when the tab is already hidden (codex #752 — was firing once)', () => {
+    // Pre-fix: with the default `runImmediately: true`, the hook
+    // fired the callback once on mount regardless of `document.hidden`.
+    // In the "browser session restore / background tab" case every
+    // consumer still hit the daemon once on mount, leaving a chunk of
+    // the BUG-007 fan-out in place. Now the eager call must also
+    // pause until the tab becomes visible.
+    Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+    const cb = vi.fn();
+    mount({ cb, intervalMs: 1000 });
+    expect(cb).not.toHaveBeenCalled();
+
+    // While hidden, the interval is also paused (existing behaviour).
+    act(() => { vi.advanceTimersByTime(5000); });
+    expect(cb).not.toHaveBeenCalled();
+
+    // On becoming visible the visibilitychange handler runs an
+    // immediate refresh AND resumes the cadence — both expected.
+    act(() => { setHidden(false); });
+    expect(cb).toHaveBeenCalledTimes(1);
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary

Three findings surfaced when codex got a chance to re-review the smaller rc.12 merge PR #752 (the diff on the original #699 was over the 5,000-line review cap, so codex skipped). All three are real and all three already shipped on `main` + `release/rc.12` via #699. This PR fixes them on `main` so the next \"merge main into release/rc.12\" PR carries them forward to rc.12 cleanly (matches the #736 / #752 pattern).

## Findings addressed

### 1. 🔴 `redactRpcUrl` — malformed-URL fallback was hex-only

`packages/node-ui/src/ui/lib/redactRpcUrl.ts`

The `new URL()` path masks any `[A-Za-z0-9_-]{16,}` path segment, but the catch branch ran `rpc.replace(/[a-f0-9]{16,}/gi, …)`, so a common scheme-less paste like `mainnet.infura.io/v3/JBKLMNZ5HrA1B2C3D4E5F6G7H8I9` (mixed-case base62 / JWT-ish token) went through unredacted.

Fix: hoist `MASK` to module scope, introduce `SECRET_RUN_RE = /[A-Za-z0-9_-]{16,}/g`, and have the fallback reuse the same predicate as the parsed-path branch.

Codex review thread: https://github.com/OriginTrail/dkg/pull/752#discussion_r3311377083

### 2. 🔴 `validateCgName` — silent data loss on lossy sanitise

`packages/node-ui/src/ui/components/Modals/cgNameValidation.ts`

`sanitiseCgName` strips bare angle brackets AND drops everything after an unclosed `<tag`. The modal binds the input to the raw value but submits the sanitised one, so `Project <b` displayed as-typed but was silently submitted as `Project`. `HTML_TAG_SHAPE_RE` only matches *complete* tag pairs (`<b>…</b>`), so both bare-bracket and unclosed-tag cases passed validation without warning.

Fix: add a second predicate after the tag-shape branch — any residual `<` or `>` in the raw input — with a more specific \"angle brackets stripped\" warning.

Codex review thread: https://github.com/OriginTrail/dkg/pull/752#discussion_r3311377094

### 3. 🟡 `useVisibilityPolling` — eager mount call still fires on hidden tab

`packages/node-ui/src/ui/hooks/useVisibilityPolling.ts`

BUG-007's whole point was \"a backgrounded tab no longer storms /api/* every 10s\", but the eager-on-mount path ignored `document.hidden`. Browser session restore / \"open all tabs\" commonly mounts React in a backgrounded tab, where every consumer still hit the daemon once on mount.

Fix: guard the eager call with `!document.hidden`. The existing `visibilitychange` handler already runs an immediate refresh when the tab regains focus, so the deferred initial load is recovered for free.

Codex review thread: https://github.com/OriginTrail/dkg/pull/752#discussion_r3311377099

## Test plan

- `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/redact-rpc-url.test.ts test/cg-name-validation.test.ts test/use-visibility-polling.test.ts` — **38/38** (was 33; +5 regression tests across the three suites).
- Integration paths that consume the touched helpers: `test/create-project-modal.test.ts test/ui-compat.test.ts` — **91/91 + 38 skipped**, no regression.
- `useVisibilityPolling` consumer paths: `test/panel-left.test.ts test/panel-right.component.test.ts test/panel-right.refresh-history.test.ts` — **16/16**, no regression.

## Follow-up on rc.12

Once this lands on `main`, I'll re-merge `main` into `merge/main-into-rc.12` so PR #752 picks these fixes up automatically — that's the same pattern as #736 → next merge → forward.

Made with [Cursor](https://cursor.com)