### PR TITLE
fix(publisher): bind SWM prov:wasAttributedTo to agent DID, not peer ID (closes #748)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1079,7 +1079,7 @@ export class DKGAgent {
         const log = new Logger('DKGAgent');
         log.info(
           createOperationContext('init'),
-          `Migrated SWM attribution across ${migrated.cgs} CG(s): rewrote ${migrated.rewritten} literal(s) to agent DID, ${migrated.skipped} unresolved`,
+          `Migrated SWM attribution across ${migrated.swmMetaGraphs} SWM meta graph(s): rewrote ${migrated.rewritten} literal(s) to agent DID, ${migrated.skipped} unresolved`,
         );
       }
     } catch (err) {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1070,6 +1070,23 @@ export class DKGAgent {
       log.warn(createOperationContext('init'), `Failed to reconstruct shared memory ownership, continuing without: ${err instanceof Error ? err.message : String(err)}`);
     }
 
+    // GH #748: one-shot migration of SWM `prov:wasAttributedTo` from
+    // peer-ID string literals to agent DID URIs. Idempotent via a
+    // per-CG marker; non-fatal on failure (match the pattern above).
+    try {
+      const migrated = await publisher.migrateSwmAttributionToAgentDid();
+      if (migrated.rewritten > 0 || migrated.skipped > 0) {
+        const log = new Logger('DKGAgent');
+        log.info(
+          createOperationContext('init'),
+          `Migrated SWM attribution across ${migrated.cgs} CG(s): rewrote ${migrated.rewritten} literal(s) to agent DID, ${migrated.skipped} unresolved`,
+        );
+      }
+    } catch (err) {
+      const log = new Logger('DKGAgent');
+      log.warn(createOperationContext('init'), `Failed to migrate SWM attribution to agent DID, continuing without: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
     const queryEngine = new DKGQueryEngine(store);
 
     return new DKGAgent(

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -225,6 +225,12 @@ export class FinalizationHandler {
     // literal); fall back to literal-form `prov:wasAttributedTo` for legacy
     // un-migrated SWM rows. Skip URI form — that's an agent DID, not a
     // peer ID, and downstream dials a libp2p peer with this value.
+    //
+    // `FILTER(BOUND(?peerId))` guards the LIMIT 1: without it, an op with
+    // `rootEntity` but neither peer-ID source produces an unbound `?peerId`
+    // that LIMIT could pick. The caller's `wsPeerId || publisherAddress`
+    // fallback would then store an EVM address where a libp2p peer ID is
+    // expected. With BOUND, only ops carrying a real peer-ID match.
     const sparql = `SELECT ?peerId WHERE {
       GRAPH <${wsMetaGraph}> {
         VALUES ?root { ${values} }
@@ -232,6 +238,7 @@ export class FinalizationHandler {
         OPTIONAL { ?op <${DKG_NS}publisherPeerId> ?pidField }
         OPTIONAL { ?op <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
         BIND(COALESCE(?pidField, ?attrField) AS ?peerId)
+        FILTER(BOUND(?peerId))
       }
     } LIMIT 1`;
 

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -221,11 +221,17 @@ export class FinalizationHandler {
 
     const values = safeRoots.map(r => `<${r}>`).join(' ');
     const PROV = 'http://www.w3.org/ns/prov#';
+    // GH #748: prefer the dedicated `dkg:publisherPeerId` field (peer-ID
+    // literal); fall back to literal-form `prov:wasAttributedTo` for legacy
+    // un-migrated SWM rows. Skip URI form — that's an agent DID, not a
+    // peer ID, and downstream dials a libp2p peer with this value.
     const sparql = `SELECT ?peerId WHERE {
       GRAPH <${wsMetaGraph}> {
         VALUES ?root { ${values} }
         ?op <${DKG_NS}rootEntity> ?root .
-        ?op <${PROV}wasAttributedTo> ?peerId .
+        OPTIONAL { ?op <${DKG_NS}publisherPeerId> ?pidField }
+        OPTIONAL { ?op <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
+        BIND(COALESCE(?pidField, ?attrField) AS ?peerId)
       }
     } LIMIT 1`;
 

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -204,6 +204,7 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
   const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
   const DKG_WORKSPACE_OP = 'http://dkg.io/ontology/WorkspaceOperation';
   const DKG_PUBLISHED_AT = 'http://dkg.io/ontology/publishedAt';
+  const DKG_PUBLISHER_PEER_ID = 'http://dkg.io/ontology/publisherPeerId';
   const PROV_ATTRIBUTED_TO = 'http://www.w3.org/ns/prov#wasAttributedTo';
   const SKOLEM_PREFIX = '/.well-known/genid/';
 
@@ -231,11 +232,27 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
     return false;
   });
 
-  const opCreators = new Map<string, string>();
+  // GH #748 Codex round 4: prefer the dedicated `dkg:publisherPeerId` literal
+  // for ownership-cache hydration; only fall back to `prov:wasAttributedTo`
+  // when it's a literal (the legacy shape). Post-fix `wasAttributedTo`
+  // carries an agent DID URI, and caching that as the peer-ID owner here
+  // would break first-writer/upsert recognition for follow-up writes from
+  // the same peer (the check at `_shareImpl` compares against the live
+  // `publisherPeerId` of the new write).
+  const opPeerIdField = new Map<string, string>();
+  const opAttrLiteralFallback = new Map<string, string>();
   for (const q of wsMetaQuads) {
-    if (q.predicate === PROV_ATTRIBUTED_TO && validOps.has(q.subject)) {
-      opCreators.set(q.subject, q.object.startsWith('"') ? stripLiteral(q.object) : q.object);
+    if (!validOps.has(q.subject)) continue;
+    if (q.predicate === DKG_PUBLISHER_PEER_ID) {
+      opPeerIdField.set(q.subject, q.object.startsWith('"') ? stripLiteral(q.object) : q.object);
+    } else if (q.predicate === PROV_ATTRIBUTED_TO && q.object.startsWith('"')) {
+      opAttrLiteralFallback.set(q.subject, stripLiteral(q.object));
     }
+  }
+  const opCreators = new Map<string, string>();
+  for (const op of validOps) {
+    const peer = opPeerIdField.get(op) ?? opAttrLiteralFallback.get(op);
+    if (peer) opCreators.set(op, peer);
   }
 
   const entityCreators = new Map<string, string>();

--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -207,11 +207,14 @@ describe('FinalizationHandler', () => {
       subGraphName,
     );
 
+    // GH #748: agent DID subjects are lowercased per `canonicalAgentDidSubject`
+    // so the same wallet doesn't split into multiple RDF subjects (see
+    // `agentDid()` in packages/publisher/src/metadata.ts).
     const registration = await store.query(
       `ASK { GRAPH <${metaGraph}> {
         <${subGraphUri}> a <http://dkg.io/ontology/SubGraph> ;
           <http://schema.org/name> "code" ;
-          <http://dkg.io/ontology/createdBy> <did:dkg:agent:${publisherAddress}> .
+          <http://dkg.io/ontology/createdBy> <did:dkg:agent:${publisherAddress.toLowerCase()}> .
       } }`,
     );
     expect(registration.type).toBe('boolean');

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-export type OperationName = 'publish' | 'update' | 'query' | 'resolve' | 'connect' | 'sync' | 'system' | 'share' | 'publishFromSWM' | 'gossip' | 'ka-update' | 'reconstruct' | 'init' | 'verify';
+export type OperationName = 'publish' | 'update' | 'query' | 'resolve' | 'connect' | 'sync' | 'system' | 'share' | 'publishFromSWM' | 'gossip' | 'ka-update' | 'reconstruct' | 'init' | 'verify' | 'migrate-swm-attr';
 
 export interface OperationContext {
   operationId: string;

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3161,8 +3161,36 @@ export class DKGPublisher implements Publisher {
         const markerResult = await this.store.query(
           `SELECT ?ts WHERE { GRAPH <${markerGraph}> { <${MIGRATION_MARKER_SUBJECT}> <${DKG}appliedAt> ?ts } } LIMIT 1`,
         );
-        if (markerResult.type === 'bindings' && markerResult.bindings.length > 0) {
-          continue;
+        const markerPresent =
+          markerResult.type === 'bindings' && markerResult.bindings.length > 0;
+
+        // GH #748 (user-reported regression): the round-1 → round-6 delete
+        // logic used `store.delete([{ object: literalString }])` which
+        // silently no-op'd against `xsd:string`-typed literals on a
+        // persistent oxigraph store — the URI insert succeeded but the
+        // literal stayed. Affected stores end up with BOTH forms for the
+        // same subject. If a marker is present BUT subjects exist with
+        // BOTH a literal AND a URI `wasAttributedTo`, the previous pass
+        // was broken — override the marker so we re-process and clean up.
+        // Only this exact broken state triggers re-run; legitimate
+        // remaining literals (e.g. `"unknown"` permanent placeholders) do
+        // not, because they don't also have a URI counterpart.
+        if (markerPresent) {
+          const staleCheck = await this.store.query(
+            `ASK { GRAPH <${swmMetaGraph}> {
+              ?s <${PROV}wasAttributedTo> ?lit . FILTER(isLiteral(?lit))
+              ?s <${PROV}wasAttributedTo> ?uri . FILTER(isURI(?uri))
+            } }`,
+          );
+          const hasBrokenDuplicates = staleCheck.type === 'boolean' && staleCheck.value;
+          if (!hasBrokenDuplicates) continue;
+          // Drop the stale marker so we record a fresh `appliedAt`
+          // timestamp when the (now-fixed) pass completes.
+          await this.store.deleteByPattern({
+            graph: markerGraph,
+            subject: MIGRATION_MARKER_SUBJECT,
+            predicate: `${DKG}appliedAt`,
+          });
         }
 
         let swmRewritten = 0;
@@ -3226,12 +3254,20 @@ export class DKGPublisher implements Publisher {
               }]);
             }
 
-            await this.store.delete([{
+            // GH #748 (user-reported regression): use `deleteByPattern` rather
+            // than `store.delete([{ object: literalString }])`. Exact-match
+            // delete silently no-op'd against `xsd:string`-typed literals on
+            // a persistent oxigraph store — the literal stayed alongside the
+            // newly-inserted URI, leaving the legend with duplicate
+            // peer-ID + agent-DID attribution for every migrated row.
+            // Pattern-based delete is form-agnostic; safe to wipe all
+            // wasAttributedTo for this subject because writers only ever
+            // emit one (we're about to insert the canonical URI).
+            await this.store.deleteByPattern({
+              graph: swmMetaGraph,
               subject,
               predicate: `${PROV}wasAttributedTo`,
-              object: objectLit,
-              graph: swmMetaGraph,
-            }]);
+            });
             await this.store.insert([{
               subject,
               predicate: `${PROV}wasAttributedTo`,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3216,15 +3216,22 @@ export class DKGPublisher implements Publisher {
           }
         }
 
-        // Drop a marker so the next boot skips this CG. Use the CG `_meta`
-        // graph rather than `_shared_memory_meta` so a SWM graph wipe
-        // doesn't accidentally re-arm the migration.
-        await this.store.insert([{
-          subject: MIGRATION_MARKER_SUBJECT,
-          predicate: `${DKG}appliedAt`,
-          object: `"${new Date().toISOString()}"^^<${XSD}dateTime>`,
-          graph: cgMetaGraph,
-        }]);
+        // GH #748 Codex round 2: only write the per-CG marker when this pass
+        // resolved every literal-form row. If anything was skipped (peer→agent
+        // mapping missing, ambiguous, or unknown), leave the marker off so
+        // future boots retry as the AGENTS graph syncs more records. The
+        // re-run cost is bounded by the residual literal count — already-
+        // rewritten rows fail the `isLiteral(?o)` filter and contribute zero
+        // work. Use the CG `_meta` graph rather than `_shared_memory_meta`
+        // so a SWM graph wipe doesn't accidentally re-arm the migration.
+        if (cgSkipped === 0) {
+          await this.store.insert([{
+            subject: MIGRATION_MARKER_SUBJECT,
+            predicate: `${DKG}appliedAt`,
+            object: `"${new Date().toISOString()}"^^<${XSD}dateTime>`,
+            graph: cgMetaGraph,
+          }]);
+        }
 
         totalRewritten += cgRewritten;
         totalSkipped += cgSkipped;
@@ -3233,7 +3240,7 @@ export class DKGPublisher implements Publisher {
         if (cgRewritten > 0 || cgSkipped > 0) {
           this.log.info(
             ctx,
-            `CG ${cgId}: rewrote ${cgRewritten} attribution literal(s) to agent DID, left ${cgSkipped} unresolved`,
+            `CG ${cgId}: rewrote ${cgRewritten} attribution literal(s) to agent DID, left ${cgSkipped} unresolved${cgSkipped > 0 ? ' (will retry on next boot)' : ''}`,
           );
         }
       }
@@ -3253,14 +3260,21 @@ export class DKGPublisher implements Publisher {
   ): Promise<string | null> {
     // SPARQL string-literal escape: only `"` and `\` are special inside `"..."`.
     const escaped = peerId.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    // GH #748 Codex round 2: a single libp2p PeerId can be shared across
+    // multiple registered agents on the same node (multi-agent-per-node via
+    // `DKGAgent.registerAgent`). Resolve only when exactly one AGENTS record
+    // matches — `LIMIT 2` + length-check is the cheapest way to detect
+    // ambiguity. On 0 or >1 matches, return null so the migration preserves
+    // the literal-form attribution rather than silently mis-attributing it
+    // to whichever agent happens to come first.
     const sparql = `SELECT ?agent WHERE {
       GRAPH <${agentsGraph}> {
         ?agent <${RDF}type> <${DKG}Agent> ;
                <${DKG}peerId> "${escaped}" .
       }
-    } LIMIT 1`;
+    } LIMIT 2`;
     const result = await this.store.query(sparql);
-    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+    if (result.type !== 'bindings' || result.bindings.length !== 1) return null;
     const agentUri = result.bindings[0]['agent'];
     if (!agentUri || !agentUri.startsWith('did:dkg:agent:')) return null;
     const address = agentUri.slice('did:dkg:agent:'.length);

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -948,6 +948,7 @@ export class DKGPublisher implements Publisher {
       rootEntities,
       quads: normalized,
       publisherPeerId: options.publisherPeerId,
+      agentAddress: options.senderAgentAddress,
       subGraphName: options.subGraphName,
       timestamp: operationTimestamp,
       publicSnapshotStore: this.publicSnapshotStore,
@@ -3075,6 +3076,163 @@ export class DKGPublisher implements Publisher {
     return this.reconstructSharedMemoryOwnership();
   }
 
+  /**
+   * One-shot startup migration for GH #748: rewrite SWM
+   * `prov:wasAttributedTo` from peer-ID string literals to agent DID
+   * URIs (`<did:dkg:agent:0x…>`). Idempotent — each CG carries a
+   * `<urn:dkg:migration:swm-attr-agent-did> dkg:appliedAt "<ts>"`
+   * marker in `_meta` after a successful pass; subsequent boots skip
+   * marked CGs. Best-effort: rows whose peer ID can't be resolved
+   * against the AGENTS system graph are left in place.
+   */
+  async migrateSwmAttributionToAgentDid(): Promise<{ rewritten: number; skipped: number; cgs: number }> {
+    const DKG = 'http://dkg.io/ontology/';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+    const XSD = 'http://www.w3.org/2001/XMLSchema#';
+    const SWM_META_SUFFIX = '/_shared_memory_meta';
+    const CG_PREFIX = 'did:dkg:context-graph:';
+    const MIGRATION_MARKER_SUBJECT = 'urn:dkg:migration:swm-attr-agent-did';
+    const AGENTS_GRAPH = `${CG_PREFIX}agents/_data`;
+    const ctx = createOperationContext('migrate-swm-attr');
+
+    let totalRewritten = 0;
+    let totalSkipped = 0;
+    let cgsProcessed = 0;
+
+    try {
+      const contextGraphs = await this.graphManager.listContextGraphs();
+      const peerToAddress = new Map<string, string | null>();
+      const allGraphs = await this.store.listGraphs();
+
+      for (const cgId of contextGraphs) {
+        if (cgId === 'agents' || cgId === 'ontology') continue; // system graphs hold no SWM
+        const cgMetaGraph = `${CG_PREFIX}${cgId}/_meta`;
+
+        // Skip if migration marker already present for this CG.
+        const markerResult = await this.store.query(
+          `SELECT ?ts WHERE { GRAPH <${cgMetaGraph}> { <${MIGRATION_MARKER_SUBJECT}> <${DKG}appliedAt> ?ts } } LIMIT 1`,
+        );
+        if (markerResult.type === 'bindings' && markerResult.bindings.length > 0) {
+          continue;
+        }
+
+        // Collect root SWM-meta graph plus any sub-graph-scoped ones for this CG.
+        const swmMetaGraphs: string[] = [this.graphManager.sharedMemoryMetaUri(cgId)];
+        const sgPrefix = `${CG_PREFIX}${cgId}/`;
+        for (const g of allGraphs) {
+          if (g.startsWith(sgPrefix) && g.endsWith(SWM_META_SUFFIX)) {
+            const middle = g.slice(sgPrefix.length, g.length - SWM_META_SUFFIX.length);
+            if (middle && !middle.includes('/')) {
+              swmMetaGraphs.push(g);
+            }
+          }
+        }
+
+        let cgRewritten = 0;
+        let cgSkipped = 0;
+
+        for (const swmMetaGraph of swmMetaGraphs) {
+          const sparql = `SELECT ?s ?o WHERE { GRAPH <${swmMetaGraph}> { ?s <${PROV}wasAttributedTo> ?o . FILTER(isLiteral(?o)) } }`;
+          const result = await this.store.query(sparql);
+          if (result.type !== 'bindings') continue;
+
+          for (const row of result.bindings) {
+            const subject = row['s'];
+            const objectLit = row['o'];
+            if (!subject || !objectLit) continue;
+
+            const peerId = objectLit.startsWith('"')
+              ? objectLit.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '')
+              : objectLit;
+            // Don't migrate the literal sentinel `"unknown"` (legacy
+            // `generateKCMetadata` placeholder when peer ID wasn't supplied).
+            if (!peerId || peerId === 'unknown') {
+              cgSkipped++;
+              continue;
+            }
+
+            let address: string | null;
+            if (peerToAddress.has(peerId)) {
+              address = peerToAddress.get(peerId)!;
+            } else {
+              address = await this.resolveAgentAddressForPeer(peerId, AGENTS_GRAPH, DKG, RDF);
+              peerToAddress.set(peerId, address);
+            }
+
+            if (!address) {
+              cgSkipped++;
+              continue;
+            }
+
+            await this.store.delete([{
+              subject,
+              predicate: `${PROV}wasAttributedTo`,
+              object: objectLit,
+              graph: swmMetaGraph,
+            }]);
+            await this.store.insert([{
+              subject,
+              predicate: `${PROV}wasAttributedTo`,
+              object: `did:dkg:agent:${address}`,
+              graph: swmMetaGraph,
+            }]);
+            cgRewritten++;
+          }
+        }
+
+        // Drop a marker so the next boot skips this CG. Use the CG `_meta`
+        // graph rather than `_shared_memory_meta` so a SWM graph wipe
+        // doesn't accidentally re-arm the migration.
+        await this.store.insert([{
+          subject: MIGRATION_MARKER_SUBJECT,
+          predicate: `${DKG}appliedAt`,
+          object: `"${new Date().toISOString()}"^^<${XSD}dateTime>`,
+          graph: cgMetaGraph,
+        }]);
+
+        totalRewritten += cgRewritten;
+        totalSkipped += cgSkipped;
+        cgsProcessed++;
+
+        if (cgRewritten > 0 || cgSkipped > 0) {
+          this.log.info(
+            ctx,
+            `CG ${cgId}: rewrote ${cgRewritten} attribution literal(s) to agent DID, left ${cgSkipped} unresolved`,
+          );
+        }
+      }
+
+      return { rewritten: totalRewritten, skipped: totalSkipped, cgs: cgsProcessed };
+    } catch (err) {
+      this.log.warn(
+        ctx,
+        `migrateSwmAttributionToAgentDid failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return { rewritten: totalRewritten, skipped: totalSkipped, cgs: cgsProcessed };
+    }
+  }
+
+  private async resolveAgentAddressForPeer(
+    peerId: string, agentsGraph: string, DKG: string, RDF: string,
+  ): Promise<string | null> {
+    // SPARQL string-literal escape: only `"` and `\` are special inside `"..."`.
+    const escaped = peerId.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const sparql = `SELECT ?agent WHERE {
+      GRAPH <${agentsGraph}> {
+        ?agent <${RDF}type> <${DKG}Agent> ;
+               <${DKG}peerId> "${escaped}" .
+      }
+    } LIMIT 1`;
+    const result = await this.store.query(sparql);
+    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+    const agentUri = result.bindings[0]['agent'];
+    if (!agentUri || !agentUri.startsWith('did:dkg:agent:')) return null;
+    const address = agentUri.slice('did:dkg:agent:'.length);
+    if (!/^0x[0-9a-fA-F]{40}$/.test(address)) return null;
+    return address;
+  }
+
   private async deleteMetaForRoot(metaGraph: string, rootEntity: string): Promise<void> {
     const DKG = 'http://dkg.io/ontology/';
     const result = await this.store.query(
@@ -3487,6 +3645,7 @@ export class DKGPublisher implements Publisher {
         rootEntities: effectiveRoots,
         quads: swmQuads,
         publisherPeerId: opts.publisherPeerId,
+        agentAddress,
         subGraphName: opts.subGraphName,
         timestamp: operationTimestamp,
         publicSnapshotStore: this.publicSnapshotStore,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3126,47 +3126,52 @@ export class DKGPublisher implements Publisher {
     let cgsProcessed = 0;
 
     try {
-      const contextGraphs = await this.graphManager.listContextGraphs();
       const peerToAddress = new Map<string, string | null>();
       const allGraphs = await this.store.listGraphs();
+      // GH #748 Codex round 6 (user report): enumerate `_shared_memory_meta`
+      // graphs directly via `store.listGraphs()`. The earlier approach used
+      // `graphManager.listContextGraphs()`, but that helper filters out CG
+      // IDs containing a slash (storage/graph-manager.ts:104) to dedupe
+      // sub-graph paths — which also excludes legitimate curated CGs of the
+      // `<addr>/<slug>` shape (the on-chain-anchored ones a user is NOT the
+      // curator of). On a real node, that meant the migration silently
+      // skipped every curated CG and only touched bare-slug shadows.
+      // Iterating the SWM-meta graphs directly catches both forms (curated
+      // root + sub-graph-scoped) naturally — each graph is processed once,
+      // marker stored adjacent at `<...>/_meta`.
+      const swmMetaGraphs = allGraphs.filter(
+        g => g.startsWith(CG_PREFIX) && g.endsWith(SWM_META_SUFFIX),
+      );
 
-      for (const cgId of contextGraphs) {
-        if (cgId === 'agents' || cgId === 'ontology') continue; // system graphs hold no SWM
-        const cgMetaGraph = `${CG_PREFIX}${cgId}/_meta`;
+      for (const swmMetaGraph of swmMetaGraphs) {
+        // Defensive: skip system graphs even though they shouldn't carry SWM.
+        const cgPath = swmMetaGraph.slice(CG_PREFIX.length, swmMetaGraph.length - SWM_META_SUFFIX.length);
+        if (cgPath === 'agents' || cgPath === 'ontology') continue;
 
-        // Skip if migration marker already present for this CG.
+        // Derive marker graph by swapping the suffix — works for root CG
+        // and sub-graph-scoped SWMs alike. Marker lives in the adjacent
+        // `_meta` graph so a SWM graph wipe doesn't accidentally re-arm
+        // the migration.
+        const markerGraph = `${CG_PREFIX}${cgPath}/_meta`;
+
         const markerResult = await this.store.query(
-          `SELECT ?ts WHERE { GRAPH <${cgMetaGraph}> { <${MIGRATION_MARKER_SUBJECT}> <${DKG}appliedAt> ?ts } } LIMIT 1`,
+          `SELECT ?ts WHERE { GRAPH <${markerGraph}> { <${MIGRATION_MARKER_SUBJECT}> <${DKG}appliedAt> ?ts } } LIMIT 1`,
         );
         if (markerResult.type === 'bindings' && markerResult.bindings.length > 0) {
           continue;
         }
 
-        // Collect root SWM-meta graph plus any sub-graph-scoped ones for this CG.
-        const swmMetaGraphs: string[] = [this.graphManager.sharedMemoryMetaUri(cgId)];
-        const sgPrefix = `${CG_PREFIX}${cgId}/`;
-        for (const g of allGraphs) {
-          if (g.startsWith(sgPrefix) && g.endsWith(SWM_META_SUFFIX)) {
-            const middle = g.slice(sgPrefix.length, g.length - SWM_META_SUFFIX.length);
-            if (middle && !middle.includes('/')) {
-              swmMetaGraphs.push(g);
-            }
-          }
-        }
-
-        let cgRewritten = 0;
+        let swmRewritten = 0;
         // GH #748 Codex round 4: track retriable vs permanent skips
         // separately. Marker-block decision uses retriable only — permanent
         // misses (sentinel `"unknown"`, empty string) can never be resolved,
         // so they must not keep the migration hot on every boot.
-        let cgRetriableSkipped = 0;
-        let cgPermanentSkipped = 0;
+        let swmRetriableSkipped = 0;
+        let swmPermanentSkipped = 0;
 
-        for (const swmMetaGraph of swmMetaGraphs) {
-          const sparql = `SELECT ?s ?o WHERE { GRAPH <${swmMetaGraph}> { ?s <${PROV}wasAttributedTo> ?o . FILTER(isLiteral(?o)) } }`;
-          const result = await this.store.query(sparql);
-          if (result.type !== 'bindings') continue;
-
+        const sparql = `SELECT ?s ?o WHERE { GRAPH <${swmMetaGraph}> { ?s <${PROV}wasAttributedTo> ?o . FILTER(isLiteral(?o)) } }`;
+        const result = await this.store.query(sparql);
+        if (result.type === 'bindings') {
           for (const row of result.bindings) {
             const subject = row['s'];
             const objectLit = row['o'];
@@ -3179,7 +3184,7 @@ export class DKGPublisher implements Publisher {
             // `generateKCMetadata` placeholder when peer ID wasn't supplied)
             // or empty — neither can ever resolve to an agent address.
             if (!peerId || peerId === 'unknown') {
-              cgPermanentSkipped++;
+              swmPermanentSkipped++;
               continue;
             }
 
@@ -3193,7 +3198,7 @@ export class DKGPublisher implements Publisher {
 
             if (!address) {
               // Retriable: AGENTS record might sync on a future boot.
-              cgRetriableSkipped++;
+              swmRetriableSkipped++;
               continue;
             }
 
@@ -3229,43 +3234,41 @@ export class DKGPublisher implements Publisher {
               object: `did:dkg:agent:${address}`,
               graph: swmMetaGraph,
             }]);
-            cgRewritten++;
+            swmRewritten++;
           }
         }
 
-        // GH #748 Codex rounds 2 + 4: write the per-CG marker when there are
-        // no RETRIABLE misses left. Permanent placeholders (sentinel
+        // GH #748 Codex rounds 2 + 4: write the marker when there are no
+        // RETRIABLE misses left. Permanent placeholders (sentinel
         // `"unknown"`) are never resolvable, so blocking the marker on them
         // would keep the migration hot on every boot forever. Retriable
         // misses (AGENTS record not yet synced) still suppress the marker so
         // future boots retry. The re-run cost is bounded by the residual
         // literal count — already-rewritten rows fail the `isLiteral(?o)`
-        // filter and contribute zero work. Use the CG `_meta` graph rather
-        // than `_shared_memory_meta` so a SWM graph wipe doesn't accidentally
-        // re-arm the migration.
-        if (cgRetriableSkipped === 0) {
+        // filter and contribute zero work.
+        if (swmRetriableSkipped === 0) {
           await this.store.insert([{
             subject: MIGRATION_MARKER_SUBJECT,
             predicate: `${DKG}appliedAt`,
             object: `"${new Date().toISOString()}"^^<${XSD}dateTime>`,
-            graph: cgMetaGraph,
+            graph: markerGraph,
           }]);
         }
 
-        const cgSkipped = cgRetriableSkipped + cgPermanentSkipped;
-        totalRewritten += cgRewritten;
-        totalSkipped += cgSkipped;
+        const swmSkipped = swmRetriableSkipped + swmPermanentSkipped;
+        totalRewritten += swmRewritten;
+        totalSkipped += swmSkipped;
         cgsProcessed++;
 
-        if (cgRewritten > 0 || cgSkipped > 0) {
-          const retryNote = cgRetriableSkipped > 0
-            ? ` (${cgRetriableSkipped} will retry on next boot, ${cgPermanentSkipped} permanent placeholders)`
-            : cgPermanentSkipped > 0
-              ? ` (${cgPermanentSkipped} permanent placeholders)`
+        if (swmRewritten > 0 || swmSkipped > 0) {
+          const retryNote = swmRetriableSkipped > 0
+            ? ` (${swmRetriableSkipped} will retry on next boot, ${swmPermanentSkipped} permanent placeholders)`
+            : swmPermanentSkipped > 0
+              ? ` (${swmPermanentSkipped} permanent placeholders)`
               : '';
           this.log.info(
             ctx,
-            `CG ${cgId}: rewrote ${cgRewritten} attribution literal(s) to agent DID, left ${cgSkipped} unresolved${retryNote}`,
+            `SWM ${cgPath}: rewrote ${swmRewritten} attribution literal(s) to agent DID, left ${swmSkipped} unresolved${retryNote}`,
           );
         }
       }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import type { Publisher, PublishOptions, PublishResult, KAManifestEntry, PhaseCallback, V10CoreNodeACK } from './publisher.js';
 import { autoPartition } from './auto-partition.js';
@@ -3015,7 +3015,19 @@ export class DKGPublisher implements Publisher {
     if (result.type !== 'bindings' || result.bindings.length === 0) return 0;
 
     const opsResult = await this.store.query(
-      `SELECT ?op ?peer ?root WHERE { GRAPH <${swmMetaGraph}> { ?op <${PROV}wasAttributedTo> ?peer . ?op <${DKG}rootEntity> ?root } }`,
+      // GH #748: prefer the dedicated `dkg:publisherPeerId` literal; fall
+      // back to a literal-form `prov:wasAttributedTo` for legacy rows
+      // (which only carry the peer ID in attribution). Skip post-fix URI
+      // attribution — `workspaceOwner` is always a peer-ID literal and a
+      // URI peer would never match, breaking ownership validation.
+      `SELECT ?op ?peer ?root WHERE {
+        GRAPH <${swmMetaGraph}> {
+          ?op <${DKG}rootEntity> ?root .
+          OPTIONAL { ?op <${DKG}publisherPeerId> ?pidField }
+          OPTIONAL { ?op <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
+          BIND(COALESCE(?pidField, ?attrField) AS ?peer)
+        }
+      }`,
     );
     const validatedOwners = new Map<string, Set<string>>();
     if (opsResult.type === 'bindings') {
@@ -3093,7 +3105,10 @@ export class DKGPublisher implements Publisher {
     const SWM_META_SUFFIX = '/_shared_memory_meta';
     const CG_PREFIX = 'did:dkg:context-graph:';
     const MIGRATION_MARKER_SUBJECT = 'urn:dkg:migration:swm-attr-agent-did';
-    const AGENTS_GRAPH = `${CG_PREFIX}agents/_data`;
+    // Use the canonical AGENTS system-graph URI helper rather than hardcoding;
+    // `contextGraphDataGraphUri('agents')` yields `did:dkg:context-graph:agents`
+    // (no `/_data` suffix), which is where `registerAgent()` actually writes.
+    const AGENTS_GRAPH = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
     const ctx = createOperationContext('migrate-swm-attr');
 
     let totalRewritten = 0;
@@ -3163,6 +3178,26 @@ export class DKGPublisher implements Publisher {
             if (!address) {
               cgSkipped++;
               continue;
+            }
+
+            // Backward-compat: per-root snapshot rows historically stored the
+            // peer ID only via `wasAttributedTo`. If this subject has no
+            // `dkg:publisherPeerId` quad yet, materialise one from the literal
+            // we're about to rewrite — otherwise the post-fix readers (which
+            // now query `dkg:publisherPeerId` rather than `wasAttributedTo`)
+            // would lose the peer ID entirely for migrated rows.
+            const hasPeerIdField = await this.store.query(
+              `ASK { GRAPH <${swmMetaGraph}> { <${subject}> <${DKG}publisherPeerId> ?x } }`,
+            );
+            const peerIdFieldPresent =
+              hasPeerIdField.type === 'boolean' ? hasPeerIdField.value : false;
+            if (!peerIdFieldPresent) {
+              await this.store.insert([{
+                subject,
+                predicate: `${DKG}publisherPeerId`,
+                object: objectLit,
+                graph: swmMetaGraph,
+              }]);
             }
 
             await this.store.delete([{

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3155,7 +3155,12 @@ export class DKGPublisher implements Publisher {
         }
 
         let cgRewritten = 0;
-        let cgSkipped = 0;
+        // GH #748 Codex round 4: track retriable vs permanent skips
+        // separately. Marker-block decision uses retriable only — permanent
+        // misses (sentinel `"unknown"`, empty string) can never be resolved,
+        // so they must not keep the migration hot on every boot.
+        let cgRetriableSkipped = 0;
+        let cgPermanentSkipped = 0;
 
         for (const swmMetaGraph of swmMetaGraphs) {
           const sparql = `SELECT ?s ?o WHERE { GRAPH <${swmMetaGraph}> { ?s <${PROV}wasAttributedTo> ?o . FILTER(isLiteral(?o)) } }`;
@@ -3170,10 +3175,11 @@ export class DKGPublisher implements Publisher {
             const peerId = objectLit.startsWith('"')
               ? objectLit.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '')
               : objectLit;
-            // Don't migrate the literal sentinel `"unknown"` (legacy
-            // `generateKCMetadata` placeholder when peer ID wasn't supplied).
+            // Permanent skip: the literal sentinel `"unknown"` (legacy
+            // `generateKCMetadata` placeholder when peer ID wasn't supplied)
+            // or empty — neither can ever resolve to an agent address.
             if (!peerId || peerId === 'unknown') {
-              cgSkipped++;
+              cgPermanentSkipped++;
               continue;
             }
 
@@ -3186,7 +3192,8 @@ export class DKGPublisher implements Publisher {
             }
 
             if (!address) {
-              cgSkipped++;
+              // Retriable: AGENTS record might sync on a future boot.
+              cgRetriableSkipped++;
               continue;
             }
 
@@ -3226,15 +3233,17 @@ export class DKGPublisher implements Publisher {
           }
         }
 
-        // GH #748 Codex round 2: only write the per-CG marker when this pass
-        // resolved every literal-form row. If anything was skipped (peer→agent
-        // mapping missing, ambiguous, or unknown), leave the marker off so
-        // future boots retry as the AGENTS graph syncs more records. The
-        // re-run cost is bounded by the residual literal count — already-
-        // rewritten rows fail the `isLiteral(?o)` filter and contribute zero
-        // work. Use the CG `_meta` graph rather than `_shared_memory_meta`
-        // so a SWM graph wipe doesn't accidentally re-arm the migration.
-        if (cgSkipped === 0) {
+        // GH #748 Codex rounds 2 + 4: write the per-CG marker when there are
+        // no RETRIABLE misses left. Permanent placeholders (sentinel
+        // `"unknown"`) are never resolvable, so blocking the marker on them
+        // would keep the migration hot on every boot forever. Retriable
+        // misses (AGENTS record not yet synced) still suppress the marker so
+        // future boots retry. The re-run cost is bounded by the residual
+        // literal count — already-rewritten rows fail the `isLiteral(?o)`
+        // filter and contribute zero work. Use the CG `_meta` graph rather
+        // than `_shared_memory_meta` so a SWM graph wipe doesn't accidentally
+        // re-arm the migration.
+        if (cgRetriableSkipped === 0) {
           await this.store.insert([{
             subject: MIGRATION_MARKER_SUBJECT,
             predicate: `${DKG}appliedAt`,
@@ -3243,14 +3252,20 @@ export class DKGPublisher implements Publisher {
           }]);
         }
 
+        const cgSkipped = cgRetriableSkipped + cgPermanentSkipped;
         totalRewritten += cgRewritten;
         totalSkipped += cgSkipped;
         cgsProcessed++;
 
         if (cgRewritten > 0 || cgSkipped > 0) {
+          const retryNote = cgRetriableSkipped > 0
+            ? ` (${cgRetriableSkipped} will retry on next boot, ${cgPermanentSkipped} permanent placeholders)`
+            : cgPermanentSkipped > 0
+              ? ` (${cgPermanentSkipped} permanent placeholders)`
+              : '';
           this.log.info(
             ctx,
-            `CG ${cgId}: rewrote ${cgRewritten} attribution literal(s) to agent DID, left ${cgSkipped} unresolved${cgSkipped > 0 ? ' (will retry on next boot)' : ''}`,
+            `CG ${cgId}: rewrote ${cgRewritten} attribution literal(s) to agent DID, left ${cgSkipped} unresolved${retryNote}`,
           );
         }
       }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3098,7 +3098,17 @@ export class DKGPublisher implements Publisher {
    * against the AGENTS system graph are left in place.
    */
   async migrateSwmAttributionToAgentDid(): Promise<{ rewritten: number; skipped: number; cgs: number }> {
+    // GH #748 Codex round 3: the AGENTS registry vocabulary is the spec-aligned
+    // `https://dkg.network/ontology#` namespace (see `buildAgentProfile` and
+    // `discovery.ts:findAgentByPeerId`), distinct from the internal
+    // `http://dkg.io/ontology/` namespace used by SWM meta predicates
+    // (`dkg:rootEntity`, `dkg:publisherPeerId`, `dkg:workspaceOwner`, etc.).
+    // The migration touches both: SWM meta predicates use DKG_INTERNAL; the
+    // AGENTS registry lookup uses DKG_REGISTRY. Confirmed against live data:
+    // a real node's `did:dkg:context-graph:agents` graph carries
+    // `https://dkg.network/ontology#peerId`, not `http://dkg.io/ontology/peerId`.
     const DKG = 'http://dkg.io/ontology/';
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
     const PROV = 'http://www.w3.org/ns/prov#';
     const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
     const XSD = 'http://www.w3.org/2001/XMLSchema#';
@@ -3171,7 +3181,7 @@ export class DKGPublisher implements Publisher {
             if (peerToAddress.has(peerId)) {
               address = peerToAddress.get(peerId)!;
             } else {
-              address = await this.resolveAgentAddressForPeer(peerId, AGENTS_GRAPH, DKG, RDF);
+              address = await this.resolveAgentAddressForPeer(peerId, AGENTS_GRAPH, DKG_REGISTRY, RDF);
               peerToAddress.set(peerId, address);
             }
 
@@ -3256,7 +3266,7 @@ export class DKGPublisher implements Publisher {
   }
 
   private async resolveAgentAddressForPeer(
-    peerId: string, agentsGraph: string, DKG: string, RDF: string,
+    peerId: string, agentsGraph: string, dkgRegistry: string, RDF: string,
   ): Promise<string | null> {
     // SPARQL string-literal escape: only `"` and `\` are special inside `"..."`.
     const escaped = peerId.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
@@ -3267,10 +3277,14 @@ export class DKGPublisher implements Publisher {
     // ambiguity. On 0 or >1 matches, return null so the migration preserves
     // the literal-form attribution rather than silently mis-attributing it
     // to whichever agent happens to come first.
+    // GH #748 Codex round 3: vocabulary is `https://dkg.network/ontology#`
+    // (the registry namespace `buildAgentProfile` writes), NOT the internal
+    // `http://dkg.io/ontology/` namespace — the latter would match zero rows
+    // against a real node's AGENTS graph and silently skip every literal.
     const sparql = `SELECT ?agent WHERE {
       GRAPH <${agentsGraph}> {
-        ?agent <${RDF}type> <${DKG}Agent> ;
-               <${DKG}peerId> "${escaped}" .
+        ?agent <${RDF}type> <${dkgRegistry}Agent> ;
+               <${dkgRegistry}peerId> "${escaped}" .
       }
     } LIMIT 2`;
     const result = await this.store.query(sparql);

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3097,7 +3097,7 @@ export class DKGPublisher implements Publisher {
    * marked CGs. Best-effort: rows whose peer ID can't be resolved
    * against the AGENTS system graph are left in place.
    */
-  async migrateSwmAttributionToAgentDid(): Promise<{ rewritten: number; skipped: number; cgs: number }> {
+  async migrateSwmAttributionToAgentDid(): Promise<{ rewritten: number; skipped: number; swmMetaGraphs: number }> {
     // GH #748 Codex round 3: the AGENTS registry vocabulary is the spec-aligned
     // `https://dkg.network/ontology#` namespace (see `buildAgentProfile` and
     // `discovery.ts:findAgentByPeerId`), distinct from the internal
@@ -3123,7 +3123,11 @@ export class DKGPublisher implements Publisher {
 
     let totalRewritten = 0;
     let totalSkipped = 0;
-    let cgsProcessed = 0;
+    // GH #748 Codex round 7: counts SWM-meta graphs processed (root + any
+    // sub-graph-scoped ones), not distinct context graphs — the migration
+    // operates per SWM-meta graph after the round-6 enumeration fix. Field
+    // name kept honest so the startup log doesn't over-report "CG(s)".
+    let swmMetaGraphsProcessed = 0;
 
     try {
       const peerToAddress = new Map<string, string | null>();
@@ -3258,7 +3262,7 @@ export class DKGPublisher implements Publisher {
         const swmSkipped = swmRetriableSkipped + swmPermanentSkipped;
         totalRewritten += swmRewritten;
         totalSkipped += swmSkipped;
-        cgsProcessed++;
+        swmMetaGraphsProcessed++;
 
         if (swmRewritten > 0 || swmSkipped > 0) {
           const retryNote = swmRetriableSkipped > 0
@@ -3273,13 +3277,13 @@ export class DKGPublisher implements Publisher {
         }
       }
 
-      return { rewritten: totalRewritten, skipped: totalSkipped, cgs: cgsProcessed };
+      return { rewritten: totalRewritten, skipped: totalSkipped, swmMetaGraphs: swmMetaGraphsProcessed };
     } catch (err) {
       this.log.warn(
         ctx,
         `migrateSwmAttributionToAgentDid failed: ${err instanceof Error ? err.message : String(err)}`,
       );
-      return { rewritten: totalRewritten, skipped: totalSkipped, cgs: cgsProcessed };
+      return { rewritten: totalRewritten, skipped: totalSkipped, swmMetaGraphs: swmMetaGraphsProcessed };
     }
   }
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3285,30 +3285,63 @@ export class DKGPublisher implements Publisher {
   ): Promise<string | null> {
     // SPARQL string-literal escape: only `"` and `\` are special inside `"..."`.
     const escaped = peerId.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    // GH #748 Codex round 2: a single libp2p PeerId can be shared across
-    // multiple registered agents on the same node (multi-agent-per-node via
-    // `DKGAgent.registerAgent`). Resolve only when exactly one AGENTS record
-    // matches — `LIMIT 2` + length-check is the cheapest way to detect
-    // ambiguity. On 0 or >1 matches, return null so the migration preserves
-    // the literal-form attribution rather than silently mis-attributing it
-    // to whichever agent happens to come first.
-    // GH #748 Codex round 3: vocabulary is `https://dkg.network/ontology#`
-    // (the registry namespace `buildAgentProfile` writes), NOT the internal
-    // `http://dkg.io/ontology/` namespace — the latter would match zero rows
-    // against a real node's AGENTS graph and silently skip every literal.
-    const sparql = `SELECT ?agent WHERE {
+    // GH #748 Codex rounds 2, 3, 5: resolve the agent address for a peer ID.
+    // - Round 3: vocabulary is `https://dkg.network/ontology#` (the registry
+    //   namespace `buildAgentProfile` writes), NOT the internal
+    //   `http://dkg.io/ontology/` one — the latter matches zero rows.
+    // - Round 2: a libp2p PeerId can be shared across multiple registered
+    //   agents on the same node (multi-agent-per-node via
+    //   `DKGAgent.registerAgent`). Reject genuine cross-agent ambiguity.
+    // - Round 5: an upgraded store can legitimately have multiple AGENTS
+    //   records for the SAME agent — e.g. the legacy
+    //   `did:dkg:agent:<peerId>` subject (profile.ts fallback) plus the
+    //   canonical `did:dkg:agent:<address>` subject. Prefer the explicit
+    //   `dkg:agentAddress` literal as the source of truth, and dedup by
+    //   normalised address before deciding the mapping is ambiguous.
+    // - The fallback subject-URI parse handles records that pre-date the
+    //   `dkg:agentAddress` field and still encode the address only in the
+    //   subject (`did:dkg:agent:0x<40hex>`).
+    const sparql = `SELECT ?agent ?addr WHERE {
       GRAPH <${agentsGraph}> {
         ?agent <${RDF}type> <${dkgRegistry}Agent> ;
                <${dkgRegistry}peerId> "${escaped}" .
+        OPTIONAL { ?agent <${dkgRegistry}agentAddress> ?addr }
       }
-    } LIMIT 2`;
+    }`;
     const result = await this.store.query(sparql);
-    if (result.type !== 'bindings' || result.bindings.length !== 1) return null;
-    const agentUri = result.bindings[0]['agent'];
-    if (!agentUri || !agentUri.startsWith('did:dkg:agent:')) return null;
-    const address = agentUri.slice('did:dkg:agent:'.length);
-    if (!/^0x[0-9a-fA-F]{40}$/.test(address)) return null;
-    return address;
+    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+
+    const addresses = new Set<string>();
+    for (const row of result.bindings) {
+      const explicit = row['addr'];
+      if (explicit) {
+        // `dkg:agentAddress` is a literal — strip surrounding quotes.
+        const raw = explicit.startsWith('"')
+          ? explicit.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '')
+          : explicit;
+        if (/^0x[0-9a-fA-F]{40}$/.test(raw)) {
+          addresses.add(raw.toLowerCase());
+          continue;
+        }
+      }
+      // Fallback: parse the subject URI for records without an explicit
+      // `agentAddress` field. Only accept the canonical wallet-DID shape
+      // — a legacy `did:dkg:agent:<peerId>` subject is NOT an address and
+      // contributes nothing useful here.
+      const agentUri = row['agent'];
+      if (agentUri && agentUri.startsWith('did:dkg:agent:')) {
+        const tail = agentUri.slice('did:dkg:agent:'.length);
+        if (/^0x[0-9a-fA-F]{40}$/.test(tail)) {
+          addresses.add(tail.toLowerCase());
+        }
+      }
+    }
+
+    // 0 distinct addresses → no resolvable mapping.
+    // 1 → unambiguous: same agent (possibly across multiple profile records).
+    // 2+ → genuinely multiple agents on this peer; refuse to mis-attribute.
+    if (addresses.size !== 1) return null;
+    return [...addresses][0];
   }
 
   private async deleteMetaForRoot(metaGraph: string, rootEntity: string): Promise<void> {

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -299,7 +299,16 @@ function dateLit(d: Date): string {
 }
 
 export function agentDid(address: string): string {
-  return `did:dkg:agent:${address}`;
+  // GH #748 Codex round 3: canonicalise EVM-address DID subjects to lowercase
+  // so the same wallet doesn't split into multiple RDF subjects when callers
+  // pass checksummed vs lowercased forms (e.g. `ethers.getAddress(...)` in
+  // workspace-handler returns checksummed, while config files often carry
+  // lowercase). Mirrors `canonicalAgentDidSubject` in
+  // `packages/agent/src/profile.ts:20` — the canonical writer for agent
+  // registry records, which has lowercased EVM subjects since A-12. Non-EVM
+  // shapes (peer IDs, names) pass through unchanged.
+  const subject = /^0x[0-9a-fA-F]{40}$/.test(address) ? address.toLowerCase() : address;
+  return `did:dkg:agent:${subject}`;
 }
 
 function hexLit(hex: string): string {

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -115,9 +115,17 @@ export function generateKCMetadata(
       // so prefer that when `agentAddress` wasn't explicitly threaded.
       // Falls back to the peer-ID literal only for legacy/tentative
       // callers with neither identity available.
-      (meta.agentAddress ?? meta.authorAddress)
-        ? agentDid((meta.agentAddress ?? meta.authorAddress)!)
-        : lit(meta.publisherPeerId || 'unknown'),
+      // GH #748 Codex round 7: treat `0x0000…0000` as the no-author sentinel
+      // (used when `publisherNodeIdentityIdOverride = 0`). Without this guard
+      // an unattributed publish would mint `did:dkg:agent:0x000…000`, making
+      // the provenance look like a real agent authored the KC.
+      ((): string => {
+        const candidate = meta.agentAddress ?? meta.authorAddress;
+        if (candidate && !isZeroEthAddress(candidate)) {
+          return agentDid(candidate);
+        }
+        return lit(meta.publisherPeerId || 'unknown');
+      })(),
       metaGraph,
     ),
     mq(
@@ -296,6 +304,15 @@ function intLit(val: number | bigint): string {
 
 function dateLit(d: Date): string {
   return `"${d.toISOString()}"^^<${XSD}dateTime>`;
+}
+
+/**
+ * Returns true for the EVM zero address sentinel `0x0000…0000` (any casing).
+ * Used to detect "unattributed publish" intent (`publisherNodeIdentityIdOverride = 0`)
+ * so callers don't mint a fake `did:dkg:agent:0x000…000` URI for it.
+ */
+export function isZeroEthAddress(address: string): boolean {
+  return /^0x0{40}$/i.test(address);
 }
 
 export function agentDid(address: string): string {

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -21,6 +21,14 @@ export interface KCMetadata {
   merkleRoot: Uint8Array;
   kaCount: number;
   publisherPeerId: string;
+  /**
+   * Durable on-chain agent identifier (EVM address, bare `0x…`). When
+   * supplied, `prov:wasAttributedTo` is emitted as `<did:dkg:agent:0x…>`.
+   * When omitted, falls back to `lit(publisherPeerId)` for backwards
+   * compatibility with callers that don't yet have the agent address.
+   * See GH #748.
+   */
+  agentAddress?: string;
   accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
   allowedPeers?: string[];
   timestamp: Date;
@@ -103,7 +111,13 @@ export function generateKCMetadata(
     mq(
       meta.ual,
       `${PROV}wasAttributedTo`,
-      lit(meta.publisherPeerId || 'unknown'),
+      // KC publishes always know their author on-chain (`authorAddress`),
+      // so prefer that when `agentAddress` wasn't explicitly threaded.
+      // Falls back to the peer-ID literal only for legacy/tentative
+      // callers with neither identity available.
+      (meta.agentAddress ?? meta.authorAddress)
+        ? agentDid((meta.agentAddress ?? meta.authorAddress)!)
+        : lit(meta.publisherPeerId || 'unknown'),
       metaGraph,
     ),
     mq(
@@ -284,6 +298,10 @@ function dateLit(d: Date): string {
   return `"${d.toISOString()}"^^<${XSD}dateTime>`;
 }
 
+export function agentDid(address: string): string {
+  return `did:dkg:agent:${address}`;
+}
+
 function hexLit(hex: string): string {
   // `xsd:hexBinary` lexical space is hex digits ONLY — no `0x` prefix
   // (per XML Schema Part 2: Datatypes, §3.2.16). A typed literal
@@ -313,7 +331,7 @@ export function generateAuthorshipProof(proof: AuthorshipProof): Quad[] {
   return [
     mq(proof.kcUal, `${DKG}authoredBy`, blankNode, metaGraph),
     mq(blankNode, `${RDF}type`, `${DKG}AuthorshipProof`, metaGraph),
-    mq(blankNode, `${DKG}agent`, `did:dkg:agent:${proof.agentAddress}`, metaGraph),
+    mq(blankNode, `${DKG}agent`, agentDid(proof.agentAddress), metaGraph),
     mq(blankNode, `${DKG}signature`, lit(proof.signature), metaGraph),
     mq(blankNode, `${DKG}signedHash`, lit(proof.signedHash), metaGraph),
   ];
@@ -338,7 +356,7 @@ export function generateShareTransitionMetadata(meta: ShareTransitionMetadata): 
   const quads: Quad[] = [
     mq(subject, `${RDF}type`, `${DKG}ShareTransition`, metaGraph),
     mq(subject, `${DKG}source`, lit(`assertion/${meta.agentAddress}/${meta.assertionName}`), metaGraph),
-    mq(subject, `${DKG}agent`, `did:dkg:agent:${meta.agentAddress}`, metaGraph),
+    mq(subject, `${DKG}agent`, agentDid(meta.agentAddress), metaGraph),
     mq(subject, `${DKG}timestamp`, dateLit(meta.timestamp), metaGraph),
   ];
   for (const entity of meta.entities) {
@@ -353,6 +371,14 @@ export interface ShareMetadata {
   contextGraphId: string;
   rootEntities: string[];
   publisherPeerId: string;
+  /**
+   * Durable on-chain agent identifier (EVM address, bare `0x…`). When
+   * supplied, `prov:wasAttributedTo` is emitted as `<did:dkg:agent:0x…>`.
+   * When omitted, falls back to `lit(publisherPeerId)` so legacy callers
+   * (notably the gossip-received `SharedMemoryHandler` path) continue to
+   * work until the peer-ID → agent-address lookup is wired in. See GH #748.
+   */
+  agentAddress?: string;
   timestamp: Date;
   subGraphName?: string;
 }
@@ -379,7 +405,7 @@ export function generateShareMetadata(
     mq(
       subject,
       `${PROV}wasAttributedTo`,
-      lit(meta.publisherPeerId),
+      meta.agentAddress ? agentDid(meta.agentAddress) : lit(meta.publisherPeerId),
       swmMetaGraph,
     ),
     mq(
@@ -519,7 +545,7 @@ export function generateSubGraphRegistration(reg: SubGraphRegistration): Quad[] 
     mq(subGraphUri, `${RDF}type`, `${DKG}SubGraph`, metaGraph),
     mq(subGraphUri, `${DKG}parentContextGraph`, parentUri, metaGraph),
     mq(subGraphUri, `${SCHEMA}name`, lit(reg.subGraphName), metaGraph),
-    mq(subGraphUri, `${DKG}createdBy`, `did:dkg:agent:${reg.createdBy}`, metaGraph),
+    mq(subGraphUri, `${DKG}createdBy`, agentDid(reg.createdBy), metaGraph),
     mq(subGraphUri, `${DKG}createdAt`, dateLit(reg.timestamp), metaGraph),
   ];
 
@@ -529,7 +555,7 @@ export function generateSubGraphRegistration(reg: SubGraphRegistration): Quad[] 
 
   if (reg.authorizedWriters && reg.authorizedWriters.length > 0) {
     for (const writer of reg.authorizedWriters) {
-      const writerUri = `did:dkg:agent:${writer}`;
+      const writerUri = agentDid(writer);
       if (!isSafeIri(writerUri)) continue;
       quads.push(mq(subGraphUri, `${DKG}authorizedWriter`, writerUri, metaGraph));
     }
@@ -618,7 +644,7 @@ export function generateAssertionCreatedMetadata(meta: AssertionCreatedMeta): Qu
   const metaGraph = `did:dkg:context-graph:${meta.contextGraphId}/_meta`;
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
   const graphUri = contextGraphAssertionUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
-  const agentUri = `did:dkg:agent:${meta.agentAddress}`;
+  const agentUri = agentDid(meta.agentAddress);
   const eventUri = `${subject}/event/${nextEventId()}`;
 
   return [
@@ -656,7 +682,7 @@ export interface AssertionPromotedMeta {
 export function generateAssertionPromotedMetadata(meta: AssertionPromotedMeta): { insert: Quad[]; delete: Quad[] } {
   const metaGraph = `did:dkg:context-graph:${meta.contextGraphId}/_meta`;
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
-  const agentUri = `did:dkg:agent:${meta.agentAddress}`;
+  const agentUri = agentDid(meta.agentAddress);
   const eventUri = `${subject}/event/${nextEventId()}`;
 
   const del = [
@@ -695,7 +721,7 @@ export interface AssertionPublishedMeta {
 export function generateAssertionPublishedMetadata(meta: AssertionPublishedMeta): { insert: Quad[]; delete: Quad[] } {
   const metaGraph = `did:dkg:context-graph:${meta.contextGraphId}/_meta`;
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
-  const agentUri = `did:dkg:agent:${meta.agentAddress}`;
+  const agentUri = agentDid(meta.agentAddress);
   const eventUri = `${subject}/event/${nextEventId()}`;
   return {
     insert: [
@@ -728,7 +754,7 @@ export interface AssertionDiscardedMeta {
 export function generateAssertionDiscardedMetadata(meta: AssertionDiscardedMeta): { insert: Quad[]; delete: Quad[] } {
   const metaGraph = `did:dkg:context-graph:${meta.contextGraphId}/_meta`;
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
-  const agentUri = `did:dkg:agent:${meta.agentAddress}`;
+  const agentUri = agentDid(meta.agentAddress);
   const eventUri = `${subject}/event/${nextEventId()}`;
   return {
     insert: [

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1056,6 +1056,20 @@ export class SharedMemoryHandler {
         if (metaQuads.length > 0) {
           await this.store.insert(metaQuads);
         }
+        // The gossip envelope carries the verified author address
+        // (`verifyAgentEnvelope` above already cryptographically bound
+        // it to `recovered`); use it for SWM `prov:wasAttributedTo` so
+        // attribution survives peer-key rotation. Falls back to peer-ID
+        // literal in the writer if envelope agentAddress is missing or
+        // unparseable. See GH #748.
+        let senderAgentAddress: string | undefined;
+        if (envelope?.agentAddress && envelope.agentAddress.length > 0) {
+          try {
+            senderAgentAddress = ethers.getAddress(envelope.agentAddress);
+          } catch {
+            senderAgentAddress = undefined;
+          }
+        }
         await storeWorkspaceOperationPublicQuads({
           store: this.store,
           graphManager: this.graphManager,
@@ -1064,6 +1078,7 @@ export class SharedMemoryHandler {
           rootEntities,
           quads: normalized,
           publisherPeerId,
+          agentAddress: senderAgentAddress,
           subGraphName,
           timestamp: operationTimestamp,
           publicSnapshotStore: this.publicSnapshotStore,

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -145,6 +145,10 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       { subject, predicate: `${DKG}publicSliceRootEntity`, object: root, graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicQuadsDigest`, object: lit(digest), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicQuadsCount`, object: intLit(rootQuads.length), graph: workspaceMetaGraph },
+      // GH #748: dedicated `dkg:publisherPeerId` field for peer-ID-bound reads
+      // (resolveCompactWorkspaceOperationPublicQuads / Legacy variant + finalization);
+      // `prov:wasAttributedTo` carries the durable agent DID URI when known.
+      { subject, predicate: `${DKG}publisherPeerId`, object: lit(publisherPeerId), graph: workspaceMetaGraph },
       { subject, predicate: `${PROV}wasAttributedTo`, object: agentAddress ? agentDid(agentAddress) : lit(publisherPeerId), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publishedAt`, object: dateLit(timestamp), graph: workspaceMetaGraph },
     );
@@ -178,10 +182,18 @@ export async function resolveWorkspaceOperation(params: {
   const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, subGraphName);
   const subject = workspaceOperationSubject(params.contextGraphId, params.shareOperationId);
   const result = await params.store.query(
+    // GH #748: prefer the dedicated `dkg:publisherPeerId` literal; fall back
+    // to a literal-form `prov:wasAttributedTo` for legacy/un-migrated rows
+    // that only have the deprecated peer-ID-in-attribution shape. The
+    // `FILTER(isLiteral(...))` guard skips post-fix rows where
+    // `wasAttributedTo` carries an agent DID URI (which downstream contact
+    // code would mis-interpret as a libp2p peer ID).
     `SELECT ?root ?publisherPeerId WHERE {
       GRAPH <${workspaceMetaGraph}> {
         OPTIONAL { <${subject}> <${DKG}rootEntity> ?root }
-        OPTIONAL { <${subject}> <${PROV}wasAttributedTo> ?publisherPeerId }
+        OPTIONAL { <${subject}> <${DKG}publisherPeerId> ?pidField }
+        OPTIONAL { <${subject}> <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
+        BIND(COALESCE(?pidField, ?attrField) AS ?publisherPeerId)
       }
     }`,
   );
@@ -365,7 +377,12 @@ async function resolveCompactWorkspaceOperationPublicQuads(params: {
             <${DKG}publicQuadsCount> ?count .
           OPTIONAL { <${assertSafeIri(subject)}> <${DKG}publicSnapshotRef> ?snapshotRef }
           OPTIONAL { <${assertSafeIri(subject)}> <${DKG}publicSnapshotGraph> ?snapshotGraph }
-          OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?publisherPeerId }
+          # GH #748: prefer dedicated peer-ID field; fall back to a literal
+          # wasAttributedTo for legacy/un-migrated snapshots. Skip URI form
+          # (agent DID) — that's not a peer ID.
+          OPTIONAL { <${assertSafeIri(subject)}> <${DKG}publisherPeerId> ?pidField }
+          OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
+          BIND(COALESCE(?pidField, ?attrField) AS ?publisherPeerId)
         }
       } LIMIT 1`,
     );
@@ -443,7 +460,11 @@ async function resolveLegacyWorkspaceOperationPublicQuads(params: {
       `SELECT ?payload ?publisherPeerId WHERE {
         GRAPH <${assertSafeIri(workspaceMetaGraph)}> {
           <${assertSafeIri(subject)}> <${DKG}publicStagedQuads> ?payload .
-          OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?publisherPeerId }
+          # GH #748: prefer dedicated peer-ID field; fall back to literal
+          # wasAttributedTo for legacy snapshots. Skip URI form (agent DID).
+          OPTIONAL { <${assertSafeIri(subject)}> <${DKG}publisherPeerId> ?pidField }
+          OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
+          BIND(COALESCE(?pidField, ?attrField) AS ?publisherPeerId)
         }
       } LIMIT 1`,
     );

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -3,7 +3,7 @@ import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-sto
 import { assertSafeIri, isSafeIri, validateSubGraphName } from '@origintrail-official/dkg-core';
 import type { LiftRequest } from './lift-job.js';
 import type { LiftResolvedPublishSlice } from './async-lift-publish-options.js';
-import { generateShareMetadata } from './metadata.js';
+import { agentDid, generateShareMetadata } from './metadata.js';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 
 const DKG = 'http://dkg.io/ontology/';
@@ -64,6 +64,16 @@ export async function storeWorkspaceOperationPublicQuads(params: {
   // Retained for API compatibility; new metadata stores roots, not serialized payloads.
   quads: readonly Quad[];
   publisherPeerId?: string;
+  /**
+   * Durable on-chain agent identifier (EVM address, bare `0x…`). When
+   * supplied, both the share-operation `prov:wasAttributedTo` (via
+   * `generateShareMetadata`) and the per-root attribution emit
+   * `<did:dkg:agent:0x…>` URIs. When omitted, attribution falls back to
+   * `lit(publisherPeerId)` — preserves behaviour for the gossip-received
+   * `SharedMemoryHandler` path until peer-ID → agent-address resolution
+   * is wired in there. See GH #748.
+   */
+  agentAddress?: string;
   subGraphName?: string;
   timestamp?: Date;
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
@@ -75,6 +85,7 @@ export async function storeWorkspaceOperationPublicQuads(params: {
   const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, subGraphName);
   const operationSubject = workspaceOperationSubject(params.contextGraphId, params.shareOperationId);
   const publisherPeerId = params.publisherPeerId?.trim() || 'unknown';
+  const agentAddress = params.agentAddress?.trim() || undefined;
   const timestamp = params.timestamp ?? new Date();
 
   for (const root of roots) {
@@ -94,6 +105,7 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       contextGraphId: params.contextGraphId,
       rootEntities: roots,
       publisherPeerId,
+      agentAddress,
       timestamp,
       subGraphName,
     },
@@ -133,7 +145,7 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       { subject, predicate: `${DKG}publicSliceRootEntity`, object: root, graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicQuadsDigest`, object: lit(digest), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicQuadsCount`, object: intLit(rootQuads.length), graph: workspaceMetaGraph },
-      { subject, predicate: `${PROV}wasAttributedTo`, object: lit(publisherPeerId), graph: workspaceMetaGraph },
+      { subject, predicate: `${PROV}wasAttributedTo`, object: agentAddress ? agentDid(agentAddress) : lit(publisherPeerId), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publishedAt`, object: dateLit(timestamp), graph: workspaceMetaGraph },
     );
     if (snapshotRef) {

--- a/packages/publisher/test/access-protocol.test.ts
+++ b/packages/publisher/test/access-protocol.test.ts
@@ -310,8 +310,16 @@ describe('Access Protocol', () => {
     await storeA.delete([
       { subject: kcUal, predicate: 'http://dkg.io/ontology/accessPolicy', object: '"ownerOnly"', graph: metaGraph },
       { subject: kcUal, predicate: 'http://dkg.io/ontology/publisherPeerId', object: `"${nodeA.peerId}"`, graph: metaGraph },
-      { subject: kcUal, predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: `"${nodeA.peerId}"`, graph: metaGraph },
     ]);
+    // GH #748: `wasAttributedTo` may be either a peer-ID literal (legacy)
+    // or a `did:dkg:agent:0x…` URI (post-fix when authorAddress is known).
+    // Drop the quad by pattern to cover both shapes for this "owner identity
+    // missing" simulation.
+    await storeA.deleteByPattern({
+      graph: metaGraph,
+      subject: kcUal,
+      predicate: 'http://www.w3.org/ns/prov#wasAttributedTo',
+    });
 
     const accessHandler = new AccessHandler(storeA, bus);
     const routerA = new ProtocolRouter(nodeA);
@@ -349,8 +357,15 @@ describe('Access Protocol', () => {
     const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
     await storeA.delete([
       { subject: kcUal, predicate: 'http://dkg.io/ontology/publisherPeerId', object: `"${nodeA.peerId}"`, graph: metaGraph },
-      { subject: kcUal, predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: `"${nodeA.peerId}"`, graph: metaGraph },
     ]);
+    // GH #748: `wasAttributedTo` may be either a peer-ID literal or an
+    // agent DID URI; drop by pattern to simulate the "owner identity missing"
+    // case regardless of which shape is stored.
+    await storeA.deleteByPattern({
+      graph: metaGraph,
+      subject: kcUal,
+      predicate: 'http://www.w3.org/ns/prov#wasAttributedTo',
+    });
 
     const kaUal = `${result.ual}/1`;
     const accessResult = await accessClient.requestAccess(nodeA.peerId, kaUal);

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -362,6 +362,61 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(r4.skipped).toBe(0);
   });
 
+  it('GH #748 Codex round 6: curated CG (<addr>/<slug> form) is migrated, not silently skipped', async () => {
+    // Regression for a user-reported bug: the previous version iterated
+    // `graphManager.listContextGraphs()`, which filters out IDs containing
+    // a slash — silently skipping every curated `<addr>/<slug>` CG (the
+    // ones a user is NOT the curator of). The migration now enumerates
+    // `_shared_memory_meta` graphs directly so both bare-slug and curated
+    // CGs are processed.
+    const CURATOR = '0xE5B88968Ed464F4e3f5354C54DFAB9e39dfEAfBd';
+    const CURATED_CG = `${CURATOR}/tuesday-cg-curated`;
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const CURATED_META = `did:dkg:context-graph:${CURATED_CG}/_meta`;
+    const CURATED_SWM_META = `did:dkg:context-graph:${CURATED_CG}/_shared_memory_meta`;
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const PEER = '12D3KooWCuratedAgent';
+    const ADDR = '0xc7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7';
+
+    await store.insert([
+      { subject: `did:dkg:agent:${ADDR}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}agentAddress`, object: `"${ADDR}"`, graph: AGENTS_GRAPH },
+    ]);
+
+    // Seed a SWM op in the curated CG with the legacy literal shape.
+    const OP = `urn:dkg:share:${CURATED_CG}:op-curated`;
+    await store.insert([
+      { subject: OP, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: CURATED_SWM_META },
+      { subject: OP, predicate: `${DKG}publisherPeerId`, object: `"${PEER}"`, graph: CURATED_SWM_META },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: `"${PEER}"`, graph: CURATED_SWM_META },
+      // No CG existence triple — the migration must find the SWM-meta
+      // graph by direct enumeration, not via `listContextGraphs()`.
+    ]);
+
+    const r = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r.rewritten).toBeGreaterThanOrEqual(1);
+
+    // Curated CG's SWM-meta row was rewritten to URI form.
+    const after = await store.query(
+      `SELECT ?o WHERE { GRAPH <${CURATED_SWM_META}> { <${OP}> <${PROV}wasAttributedTo> ?o } }`,
+    );
+    if (after.type === 'bindings') {
+      expect(after.bindings.length).toBe(1);
+      expect(after.bindings[0]['o']).toBe(`did:dkg:agent:${ADDR}`);
+    }
+
+    // Marker landed in the adjacent CG `_meta` for the curated form (note
+    // the `<addr>/<slug>` segment is preserved verbatim in the marker path).
+    const marker = await store.query(
+      `SELECT ?ts WHERE { GRAPH <${CURATED_META}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
+    );
+    if (marker.type === 'bindings') expect(marker.bindings.length).toBe(1);
+  });
+
   it('GH #748 Codex round 4: permanent "unknown" sentinel does not block the marker', async () => {
     // Legacy `generateKCMetadata` wrote `prov:wasAttributedTo "unknown"`
     // when no peer ID was supplied. That value can never resolve to an

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -232,8 +232,10 @@ describe('Working Memory Assertion Lifecycle', () => {
     }
   });
 
-  it('GH #748 migration: rewrites peer-ID literal wasAttributedTo → agent DID URI when AGENTS lookup hits, leaves miss as-is, skips marked CGs on re-run', async () => {
-    const AGENTS_GRAPH = 'did:dkg:context-graph:agents/_data';
+  it('GH #748 migration: rewrites peer-ID literal wasAttributedTo → agent DID URI when AGENTS lookup hits, leaves miss as-is, backfills dkg:publisherPeerId on legacy per-root snapshots, skips marked CGs on re-run', async () => {
+    // Canonical AGENTS graph URI — `did:dkg:context-graph:agents` (no /_data
+    // suffix) per `contextGraphDataGraphUri('agents')` in @origintrail-official/dkg-core.
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
     const CG_META = `did:dkg:context-graph:${CG_ID}/_meta`;
     const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
     const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
@@ -250,10 +252,17 @@ describe('Working Memory Assertion Lifecycle', () => {
       { subject: `did:dkg:agent:${ADDR_KNOWN}`, predicate: `${DKG}peerId`, object: `"${PEER_KNOWN}"`, graph: AGENTS_GRAPH },
     ]);
 
-    // Seed CG with one SWM WorkspaceOperation per peer, with literal-form
-    // wasAttributedTo (the legacy/buggy shape).
+    // Seed SWM meta with three legacy rows that mirror real shapes:
+    //   - WorkspaceOperation (resolvable peer) — already has both
+    //     `dkg:publisherPeerId` and `prov:wasAttributedTo` (the new field
+    //     should NOT be re-inserted by the backfill).
+    //   - WorkspaceOperation (unresolved peer) — same two fields.
+    //   - Per-root snapshot (resolvable peer) — only `prov:wasAttributedTo`
+    //     literal, NO `dkg:publisherPeerId`. The migration must materialise
+    //     the peer-ID field from the literal before rewriting.
     const OP_KNOWN = `urn:dkg:share:${CG_ID}:op-known`;
     const OP_UNKNOWN = `urn:dkg:share:${CG_ID}:op-unknown`;
+    const SNAPSHOT_LEGACY = `urn:dkg:share:${CG_ID}:op-known:snapshot/urn:test:root`;
     await store.insert([
       { subject: OP_KNOWN, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
       { subject: OP_KNOWN, predicate: `${DKG}publisherPeerId`, object: `"${PEER_KNOWN}"`, graph: SWM_META },
@@ -261,6 +270,8 @@ describe('Working Memory Assertion Lifecycle', () => {
       { subject: OP_UNKNOWN, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
       { subject: OP_UNKNOWN, predicate: `${DKG}publisherPeerId`, object: `"${PEER_UNKNOWN}"`, graph: SWM_META },
       { subject: OP_UNKNOWN, predicate: `${PROV}wasAttributedTo`, object: `"${PEER_UNKNOWN}"`, graph: SWM_META },
+      // Legacy per-root snapshot row — wasAttributedTo only, no dkg:publisherPeerId
+      { subject: SNAPSHOT_LEGACY, predicate: `${PROV}wasAttributedTo`, object: `"${PEER_KNOWN}"`, graph: SWM_META },
     ]);
     // Ensure the CG itself appears in `listContextGraphs` so the migration
     // visits its meta graph (the bare `_meta` graph plus any data is enough).
@@ -268,10 +279,10 @@ describe('Working Memory Assertion Lifecycle', () => {
       { subject: `did:dkg:context-graph:${CG_ID}`, predicate: RDF_TYPE, object: `${DKG}ContextGraph`, graph: CG_META },
     ]);
 
-    // First pass: should rewrite the resolvable row, leave the unresolved
-    // one, and drop a marker.
+    // First pass: rewrite resolvable rows (OP_KNOWN + SNAPSHOT_LEGACY = 2),
+    // leave the unresolved one, drop a marker.
     const r1 = await publisher.migrateSwmAttributionToAgentDid();
-    expect(r1.rewritten).toBe(1);
+    expect(r1.rewritten).toBe(2);
     expect(r1.skipped).toBe(1);
 
     const rowsAfter = await store.query(
@@ -281,10 +292,30 @@ describe('Working Memory Assertion Lifecycle', () => {
     if (rowsAfter.type === 'bindings') {
       const known = rowsAfter.bindings.find((b) => b['s'] === OP_KNOWN);
       const unknown = rowsAfter.bindings.find((b) => b['s'] === OP_UNKNOWN);
-      // Known peer → rewritten to URI form (no surrounding quotes).
+      const snapshot = rowsAfter.bindings.find((b) => b['s'] === SNAPSHOT_LEGACY);
+      // Resolvable rows → URI form (no surrounding quotes).
       expect(known!['o']).toBe(`did:dkg:agent:${ADDR_KNOWN}`);
-      // Unknown peer → still a literal.
+      expect(snapshot!['o']).toBe(`did:dkg:agent:${ADDR_KNOWN}`);
+      // Unresolved peer → still a literal.
       expect(unknown!['o']).toBe(`"${PEER_UNKNOWN}"`);
+    }
+
+    // Backward-compat backfill: SNAPSHOT_LEGACY had no `dkg:publisherPeerId`
+    // before the migration. After migration, it MUST carry the peer-ID
+    // literal materialised from the old `wasAttributedTo` value, so the
+    // post-fix readers (which now query `dkg:publisherPeerId`) still find it.
+    const peerIdAfter = await store.query(
+      `SELECT ?s ?o WHERE { GRAPH <${SWM_META}> { ?s <${DKG}publisherPeerId> ?o } }`,
+    );
+    expect(peerIdAfter.type).toBe('bindings');
+    if (peerIdAfter.type === 'bindings') {
+      const snapshotPid = peerIdAfter.bindings.find((b) => b['s'] === SNAPSHOT_LEGACY);
+      expect(snapshotPid).toBeDefined();
+      expect(snapshotPid!['o']).toBe(`"${PEER_KNOWN}"`);
+      // OP_KNOWN already had a dkg:publisherPeerId — the migration must NOT
+      // have duplicated it.
+      const opKnownPids = peerIdAfter.bindings.filter((b) => b['s'] === OP_KNOWN);
+      expect(opKnownPids.length).toBe(1);
     }
 
     const markerAfter = await store.query(

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -362,6 +362,52 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(r4.skipped).toBe(0);
   });
 
+  it('GH #748 Codex round 4: permanent "unknown" sentinel does not block the marker', async () => {
+    // Legacy `generateKCMetadata` wrote `prov:wasAttributedTo "unknown"`
+    // when no peer ID was supplied. That value can never resolve to an
+    // agent address — it's permanent, not retriable. The migration must
+    // still write the per-CG marker so subsequent boots fast-path skip
+    // instead of re-scanning every time.
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const CG_META = `did:dkg:context-graph:${CG_ID}/_meta`;
+    const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const PROV = 'http://www.w3.org/ns/prov#';
+
+    const OP = `urn:dkg:share:${CG_ID}:op-unknown-sentinel`;
+    await store.insert([
+      { subject: OP, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: '"unknown"', graph: SWM_META },
+      { subject: `did:dkg:context-graph:${CG_ID}`, predicate: RDF_TYPE, object: `${DKG}ContextGraph`, graph: CG_META },
+    ]);
+
+    const r1 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r1.rewritten).toBe(0);
+    expect(r1.skipped).toBe(1); // counted as permanent skip
+
+    // Marker IS written even though one row was skipped (permanent).
+    const marker = await store.query(
+      `SELECT ?ts WHERE { GRAPH <${CG_META}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
+    );
+    if (marker.type === 'bindings') expect(marker.bindings.length).toBe(1);
+
+    // The "unknown" literal is left in place — there's no real attribution
+    // to migrate to.
+    const after = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_META}> { <${OP}> <${PROV}wasAttributedTo> ?o } }`,
+    );
+    if (after.type === 'bindings') {
+      expect(after.bindings.length).toBe(1);
+      expect(after.bindings[0]['o']).toBe('"unknown"');
+    }
+
+    // Second pass: marker present → fast-path skip, no work.
+    const r2 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r2.rewritten).toBe(0);
+    expect(r2.skipped).toBe(0);
+  });
+
   it('GH #748 Codex round 2: ambiguous peer→agent mapping (multi-agent-per-node) leaves literal in place', async () => {
     // Two agents share the same libp2p peer ID (multi-agent-per-node, e.g.
     // via `DKGAgent.registerAgent`). The resolver must NOT pick one

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -318,16 +318,84 @@ describe('Working Memory Assertion Lifecycle', () => {
       expect(opKnownPids.length).toBe(1);
     }
 
+    // Codex round 2 Finding 6: marker is NOT written when cgSkipped > 0 (one
+    // unresolved row remained). Future boots must retry as AGENTS data syncs.
     const markerAfter = await store.query(
       `SELECT ?ts WHERE { GRAPH <${CG_META}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
     );
     expect(markerAfter.type).toBe('bindings');
-    if (markerAfter.type === 'bindings') expect(markerAfter.bindings.length).toBe(1);
+    if (markerAfter.type === 'bindings') expect(markerAfter.bindings.length).toBe(0);
 
-    // Second pass: marker present → no work done.
+    // Second pass with no AGENTS changes: nothing new to resolve, marker
+    // still not written, no churn — the literal-only filter eliminates the
+    // already-rewritten URI rows so we only retry the genuine unresolved one.
     const r2 = await publisher.migrateSwmAttributionToAgentDid();
     expect(r2.rewritten).toBe(0);
-    expect(r2.skipped).toBe(0);
+    expect(r2.skipped).toBe(1);
+
+    // Add the previously-missing AGENTS record for the unresolved peer.
+    const ADDR_LATE = '0xbA7E932F79263F1a303790Bd6C01B096F5334Bba';
+    await store.insert([
+      { subject: `did:dkg:agent:${ADDR_LATE}`, predicate: RDF_TYPE, object: `${DKG}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_LATE}`, predicate: `${DKG}peerId`, object: `"${PEER_UNKNOWN}"`, graph: AGENTS_GRAPH },
+    ]);
+    // Third pass: the previously-unresolved row now resolves, and since
+    // cgSkipped reaches 0 the marker finally gets written.
+    const r3 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r3.rewritten).toBe(1);
+    expect(r3.skipped).toBe(0);
+    const markerFinal = await store.query(
+      `SELECT ?ts WHERE { GRAPH <${CG_META}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
+    );
+    if (markerFinal.type === 'bindings') expect(markerFinal.bindings.length).toBe(1);
+
+    // Fourth pass: marker present → fast-path skip; no SPARQL work.
+    const r4 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r4.rewritten).toBe(0);
+    expect(r4.skipped).toBe(0);
+  });
+
+  it('GH #748 Codex round 2: ambiguous peer→agent mapping (multi-agent-per-node) leaves literal in place', async () => {
+    // Two agents share the same libp2p peer ID (multi-agent-per-node, e.g.
+    // via `DKGAgent.registerAgent`). The resolver must NOT pick one
+    // arbitrarily — the migration leaves the legacy literal alone.
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const CG_META = `did:dkg:context-graph:${CG_ID}/_meta`;
+    const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const PEER_SHARED = '12D3KooWMultiAgentNode';
+    const ADDR_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const ADDR_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    await store.insert([
+      { subject: `did:dkg:agent:${ADDR_A}`, predicate: RDF_TYPE, object: `${DKG}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_A}`, predicate: `${DKG}peerId`, object: `"${PEER_SHARED}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_B}`, predicate: RDF_TYPE, object: `${DKG}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_B}`, predicate: `${DKG}peerId`, object: `"${PEER_SHARED}"`, graph: AGENTS_GRAPH },
+    ]);
+
+    const OP = `urn:dkg:share:${CG_ID}:op-ambiguous`;
+    await store.insert([
+      { subject: OP, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
+      { subject: OP, predicate: `${DKG}publisherPeerId`, object: `"${PEER_SHARED}"`, graph: SWM_META },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: `"${PEER_SHARED}"`, graph: SWM_META },
+      { subject: `did:dkg:context-graph:${CG_ID}`, predicate: RDF_TYPE, object: `${DKG}ContextGraph`, graph: CG_META },
+    ]);
+
+    const r = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r.rewritten).toBe(0);
+    expect(r.skipped).toBe(1);
+
+    // The row stays as a literal — no arbitrary attribution.
+    const after = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_META}> { <${OP}> <${PROV}wasAttributedTo> ?o } }`,
+    );
+    if (after.type === 'bindings') {
+      expect(after.bindings.length).toBe(1);
+      expect(after.bindings[0]['o']).toBe(`"${PEER_SHARED}"`);
+    }
   });
 
   it('full lifecycle: create → write → promote → verify SWM → discard', async () => {

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -408,6 +408,54 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(r2.skipped).toBe(0);
   });
 
+  it('GH #748 Codex round 5: legacy + canonical AGENTS records for the same agent resolve unambiguously', async () => {
+    // Upgraded stores can carry two profile records for the same wallet:
+    // - the legacy `did:dkg:agent:<peerId>` subject (profile.ts fallback)
+    // - the canonical `did:dkg:agent:<address>` subject
+    // The resolver must dedupe by normalised address (preferring the
+    // explicit `dkg:agentAddress` literal) and treat them as one agent
+    // rather than rejecting as ambiguous.
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const CG_META = `did:dkg:context-graph:${CG_ID}/_meta`;
+    const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const PEER = '12D3KooWUpgradedNode';
+    const ADDR = '0xaf7e932f79263f1a303790bd6c01b096f5334bbb';
+
+    await store.insert([
+      // Legacy profile: subject is the peer ID, no explicit agentAddress.
+      { subject: `did:dkg:agent:${PEER}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${PEER}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER}"`, graph: AGENTS_GRAPH },
+      // Canonical profile: subject is the wallet DID, explicit agentAddress literal.
+      { subject: `did:dkg:agent:${ADDR}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}agentAddress`, object: `"${ADDR}"`, graph: AGENTS_GRAPH },
+    ]);
+
+    const OP = `urn:dkg:share:${CG_ID}:op-legacy-canonical`;
+    await store.insert([
+      { subject: OP, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
+      { subject: OP, predicate: `${DKG}publisherPeerId`, object: `"${PEER}"`, graph: SWM_META },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: `"${PEER}"`, graph: SWM_META },
+      { subject: `did:dkg:context-graph:${CG_ID}`, predicate: RDF_TYPE, object: `${DKG}ContextGraph`, graph: CG_META },
+    ]);
+
+    const r = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r.rewritten).toBe(1);
+    expect(r.skipped).toBe(0);
+
+    const after = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_META}> { <${OP}> <${PROV}wasAttributedTo> ?o } }`,
+    );
+    if (after.type === 'bindings') {
+      expect(after.bindings.length).toBe(1);
+      expect(after.bindings[0]['o']).toBe(`did:dkg:agent:${ADDR}`);
+    }
+  });
+
   it('GH #748 Codex round 2: ambiguous peer→agent mapping (multi-agent-per-node) leaves literal in place', async () => {
     // Two agents share the same libp2p peer ID (multi-agent-per-node, e.g.
     // via `DKGAgent.registerAgent`). The resolver must NOT pick one

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -362,6 +362,65 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(r4.skipped).toBe(0);
   });
 
+  it('GH #748 user-reported: stale literal duplicates from a broken previous pass are cleaned up despite marker present', async () => {
+    // Regression: round-1 → round-6 `store.delete([{ object: literalString }])`
+    // silently no-op'd against `xsd:string`-typed literals on a persistent
+    // store. The URI insert succeeded, leaving BOTH forms behind. The
+    // user's daemon ended up with 52 literals + 52 URIs after a single
+    // migration pass, with the marker set so subsequent boots wouldn't
+    // self-heal.
+    //
+    // This test seeds that exact end state — marker present + both literal
+    // AND URI form `wasAttributedTo` on the same subject — and asserts the
+    // next migration pass overrides the marker, deletes the literal via
+    // `deleteByPattern`, and writes a fresh marker.
+    const CG_META_LOCAL = `did:dkg:context-graph:${CG_ID}/_meta`;
+    const SWM_META_LOCAL = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const PEER = '12D3KooWStaleLiteralPeer';
+    const ADDR = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+    await store.insert([
+      { subject: `did:dkg:agent:${ADDR}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}agentAddress`, object: `"${ADDR}"`, graph: AGENTS_GRAPH },
+    ]);
+
+    // Seed inconsistent state: WorkspaceOperation with BOTH literal and URI
+    // form `wasAttributedTo`, marker present from the broken previous pass.
+    const OP = `urn:dkg:share:${CG_ID}:op-stale-dup`;
+    await store.insert([
+      { subject: OP, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META_LOCAL },
+      { subject: OP, predicate: `${DKG}publisherPeerId`, object: `"${PEER}"`, graph: SWM_META_LOCAL },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: `"${PEER}"`, graph: SWM_META_LOCAL },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: `did:dkg:agent:${ADDR}`, graph: SWM_META_LOCAL },
+      { subject: 'urn:dkg:migration:swm-attr-agent-did', predicate: `${DKG}appliedAt`, object: `"2026-05-26T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>`, graph: CG_META_LOCAL },
+    ]);
+
+    const r = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r.rewritten).toBeGreaterThanOrEqual(1);
+
+    // After cleanup, exactly ONE wasAttributedTo (the URI form) remains.
+    const after = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_META_LOCAL}> { <${OP}> <${PROV}wasAttributedTo> ?o } }`,
+    );
+    if (after.type === 'bindings') {
+      expect(after.bindings.length).toBe(1);
+      expect(after.bindings[0]['o']).toBe(`did:dkg:agent:${ADDR}`);
+    }
+
+    // Marker still present, refreshed with a new timestamp (we deleted the
+    // stale one before re-running). Just assert presence.
+    const marker = await store.query(
+      `SELECT ?ts WHERE { GRAPH <${CG_META_LOCAL}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
+    );
+    if (marker.type === 'bindings') expect(marker.bindings.length).toBe(1);
+  });
+
   it('GH #748 Codex round 6: curated CG (<addr>/<slug> form) is migrated, not silently skipped', async () => {
     // Regression for a user-reported bug: the previous version iterated
     // `graphManager.listContextGraphs()`, which filters out IDs containing

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -240,16 +240,23 @@ describe('Working Memory Assertion Lifecycle', () => {
     const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
     const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
     const DKG = 'http://dkg.io/ontology/';
+    // GH #748 Codex round 3: AGENTS registry uses the spec-aligned
+    // `https://dkg.network/ontology#` namespace (same as `buildAgentProfile`
+    // in agent/profile.ts), not the internal `http://dkg.io/ontology/` one
+    // used by SWM meta predicates.
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
     const PROV = 'http://www.w3.org/ns/prov#';
 
     // Seed AGENTS registry: one peer with a known agent address, one without.
     const PEER_KNOWN = '12D3KooWKnownPeer';
     const PEER_UNKNOWN = '12D3KooWUnknownPeer';
-    const ADDR_KNOWN = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
+    // Lowercased per `canonicalAgentDidSubject` — matches what
+    // `buildAgentProfile` writes when registering an agent.
+    const ADDR_KNOWN = '0xaf7e932f79263f1a303790bd6c01b096f5334bbb';
 
     await store.insert([
-      { subject: `did:dkg:agent:${ADDR_KNOWN}`, predicate: RDF_TYPE, object: `${DKG}Agent`, graph: AGENTS_GRAPH },
-      { subject: `did:dkg:agent:${ADDR_KNOWN}`, predicate: `${DKG}peerId`, object: `"${PEER_KNOWN}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_KNOWN}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_KNOWN}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER_KNOWN}"`, graph: AGENTS_GRAPH },
     ]);
 
     // Seed SWM meta with three legacy rows that mirror real shapes:
@@ -334,10 +341,10 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(r2.skipped).toBe(1);
 
     // Add the previously-missing AGENTS record for the unresolved peer.
-    const ADDR_LATE = '0xbA7E932F79263F1a303790Bd6C01B096F5334Bba';
+    const ADDR_LATE = '0xba7e932f79263f1a303790bd6c01b096f5334bba';
     await store.insert([
-      { subject: `did:dkg:agent:${ADDR_LATE}`, predicate: RDF_TYPE, object: `${DKG}Agent`, graph: AGENTS_GRAPH },
-      { subject: `did:dkg:agent:${ADDR_LATE}`, predicate: `${DKG}peerId`, object: `"${PEER_UNKNOWN}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_LATE}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_LATE}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER_UNKNOWN}"`, graph: AGENTS_GRAPH },
     ]);
     // Third pass: the previously-unresolved row now resolves, and since
     // cgSkipped reaches 0 the marker finally gets written.
@@ -368,12 +375,14 @@ describe('Working Memory Assertion Lifecycle', () => {
     const PEER_SHARED = '12D3KooWMultiAgentNode';
     const ADDR_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     const ADDR_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    // GH #748 Codex round 3: registry namespace is `https://dkg.network/ontology#`.
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
 
     await store.insert([
-      { subject: `did:dkg:agent:${ADDR_A}`, predicate: RDF_TYPE, object: `${DKG}Agent`, graph: AGENTS_GRAPH },
-      { subject: `did:dkg:agent:${ADDR_A}`, predicate: `${DKG}peerId`, object: `"${PEER_SHARED}"`, graph: AGENTS_GRAPH },
-      { subject: `did:dkg:agent:${ADDR_B}`, predicate: RDF_TYPE, object: `${DKG}Agent`, graph: AGENTS_GRAPH },
-      { subject: `did:dkg:agent:${ADDR_B}`, predicate: `${DKG}peerId`, object: `"${PEER_SHARED}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_A}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_A}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER_SHARED}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_B}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_B}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER_SHARED}"`, graph: AGENTS_GRAPH },
     ]);
 
     const OP = `urn:dkg:share:${CG_ID}:op-ambiguous`;

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -232,6 +232,73 @@ describe('Working Memory Assertion Lifecycle', () => {
     }
   });
 
+  it('GH #748 migration: rewrites peer-ID literal wasAttributedTo → agent DID URI when AGENTS lookup hits, leaves miss as-is, skips marked CGs on re-run', async () => {
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents/_data';
+    const CG_META = `did:dkg:context-graph:${CG_ID}/_meta`;
+    const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const PROV = 'http://www.w3.org/ns/prov#';
+
+    // Seed AGENTS registry: one peer with a known agent address, one without.
+    const PEER_KNOWN = '12D3KooWKnownPeer';
+    const PEER_UNKNOWN = '12D3KooWUnknownPeer';
+    const ADDR_KNOWN = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
+
+    await store.insert([
+      { subject: `did:dkg:agent:${ADDR_KNOWN}`, predicate: RDF_TYPE, object: `${DKG}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_KNOWN}`, predicate: `${DKG}peerId`, object: `"${PEER_KNOWN}"`, graph: AGENTS_GRAPH },
+    ]);
+
+    // Seed CG with one SWM WorkspaceOperation per peer, with literal-form
+    // wasAttributedTo (the legacy/buggy shape).
+    const OP_KNOWN = `urn:dkg:share:${CG_ID}:op-known`;
+    const OP_UNKNOWN = `urn:dkg:share:${CG_ID}:op-unknown`;
+    await store.insert([
+      { subject: OP_KNOWN, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
+      { subject: OP_KNOWN, predicate: `${DKG}publisherPeerId`, object: `"${PEER_KNOWN}"`, graph: SWM_META },
+      { subject: OP_KNOWN, predicate: `${PROV}wasAttributedTo`, object: `"${PEER_KNOWN}"`, graph: SWM_META },
+      { subject: OP_UNKNOWN, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
+      { subject: OP_UNKNOWN, predicate: `${DKG}publisherPeerId`, object: `"${PEER_UNKNOWN}"`, graph: SWM_META },
+      { subject: OP_UNKNOWN, predicate: `${PROV}wasAttributedTo`, object: `"${PEER_UNKNOWN}"`, graph: SWM_META },
+    ]);
+    // Ensure the CG itself appears in `listContextGraphs` so the migration
+    // visits its meta graph (the bare `_meta` graph plus any data is enough).
+    await store.insert([
+      { subject: `did:dkg:context-graph:${CG_ID}`, predicate: RDF_TYPE, object: `${DKG}ContextGraph`, graph: CG_META },
+    ]);
+
+    // First pass: should rewrite the resolvable row, leave the unresolved
+    // one, and drop a marker.
+    const r1 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r1.rewritten).toBe(1);
+    expect(r1.skipped).toBe(1);
+
+    const rowsAfter = await store.query(
+      `SELECT ?s ?o WHERE { GRAPH <${SWM_META}> { ?s <${PROV}wasAttributedTo> ?o } }`,
+    );
+    expect(rowsAfter.type).toBe('bindings');
+    if (rowsAfter.type === 'bindings') {
+      const known = rowsAfter.bindings.find((b) => b['s'] === OP_KNOWN);
+      const unknown = rowsAfter.bindings.find((b) => b['s'] === OP_UNKNOWN);
+      // Known peer → rewritten to URI form (no surrounding quotes).
+      expect(known!['o']).toBe(`did:dkg:agent:${ADDR_KNOWN}`);
+      // Unknown peer → still a literal.
+      expect(unknown!['o']).toBe(`"${PEER_UNKNOWN}"`);
+    }
+
+    const markerAfter = await store.query(
+      `SELECT ?ts WHERE { GRAPH <${CG_META}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
+    );
+    expect(markerAfter.type).toBe('bindings');
+    if (markerAfter.type === 'bindings') expect(markerAfter.bindings.length).toBe(1);
+
+    // Second pass: marker present → no work done.
+    const r2 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r2.rewritten).toBe(0);
+    expect(r2.skipped).toBe(0);
+  });
+
   it('full lifecycle: create → write → promote → verify SWM → discard', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -134,7 +134,10 @@ describe('generateKCMetadata', () => {
     const quads = generateKCMetadata(makeMeta({ agentAddress: ADDR }), [makeKA()]);
     const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
     expect(attribution).toBeDefined();
-    expect(attribution!.object).toBe(`did:dkg:agent:${ADDR}`);
+    // GH #748 Codex round 3: EVM-shape addresses lowercased so the same
+    // wallet doesn't split into multiple RDF subjects (see `agentDid()`
+    // and `canonicalAgentDidSubject` in agent/profile.ts:20).
+    expect(attribution!.object).toBe(`did:dkg:agent:${ADDR.toLowerCase()}`);
   });
 
   it('GH #748: attribution falls back to authorAddress when agentAddress is omitted but publication provenance is set', () => {
@@ -145,7 +148,10 @@ describe('generateKCMetadata', () => {
     );
     const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
     expect(attribution).toBeDefined();
-    expect(attribution!.object).toBe(`did:dkg:agent:${ADDR}`);
+    // GH #748 Codex round 3: EVM-shape addresses lowercased so the same
+    // wallet doesn't split into multiple RDF subjects (see `agentDid()`
+    // and `canonicalAgentDidSubject` in agent/profile.ts:20).
+    expect(attribution!.object).toBe(`did:dkg:agent:${ADDR.toLowerCase()}`);
   });
 
   it('GH #748: explicit agentAddress takes precedence over authorAddress', () => {
@@ -156,7 +162,7 @@ describe('generateKCMetadata', () => {
       [makeKA()],
     );
     const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
-    expect(attribution!.object).toBe(`did:dkg:agent:${AGENT}`);
+    expect(attribution!.object).toBe(`did:dkg:agent:${AGENT.toLowerCase()}`);
   });
 });
 
@@ -369,16 +375,35 @@ describe('generateShareMetadata', () => {
   });
 
   it('GH #748: attribution is the agent DID URI when agentAddress is supplied', () => {
+    const ADDR = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
     const quads = generateShareMetadata(
-      { ...wsMeta, agentAddress: '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB' },
+      { ...wsMeta, agentAddress: ADDR },
       wsGraph,
     );
     const attribution = quads.find(q => q.predicate === 'http://www.w3.org/ns/prov#wasAttributedTo');
     expect(attribution).toBeDefined();
-    expect(attribution!.object).toBe('did:dkg:agent:0xaF7E932F79263f1A303790Bd6C01b096f5334BBB');
+    // GH #748 Codex round 3: EVM-shape addresses lowercased to converge with
+    // `canonicalAgentDidSubject` in agent/profile.ts:20.
+    expect(attribution!.object).toBe(`did:dkg:agent:${ADDR.toLowerCase()}`);
     // The peer ID is still recorded separately for transport-layer audit.
     const peerIdQuad = quads.find(q => q.predicate === `${DKG}publisherPeerId`);
     expect(peerIdQuad!.object).toBe('"12D3KooWTestPeer"');
+  });
+
+  it('GH #748 Codex round 3: agentDid lowercases EVM-shape addresses, passes through non-EVM', () => {
+    // EVM checksummed → lowercased (test via the share writer which calls agentDid)
+    const checksummedAddr = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
+    const lowerQuads = generateShareMetadata(
+      { ...wsMeta, agentAddress: checksummedAddr.toLowerCase() }, wsGraph,
+    );
+    const upperQuads = generateShareMetadata(
+      { ...wsMeta, agentAddress: checksummedAddr }, wsGraph,
+    );
+    const lowerAttr = lowerQuads.find(q => q.predicate === 'http://www.w3.org/ns/prov#wasAttributedTo');
+    const upperAttr = upperQuads.find(q => q.predicate === 'http://www.w3.org/ns/prov#wasAttributedTo');
+    // Same wallet, two casings, must converge on one DID.
+    expect(lowerAttr!.object).toBe(upperAttr!.object);
+    expect(lowerAttr!.object).toBe('did:dkg:agent:0xaf7e932f79263f1a303790bd6c01b096f5334bbb');
   });
 
   it('includes compact operation reference fields', () => {

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -121,6 +121,43 @@ describe('generateKCMetadata', () => {
     const kaSubjects = new Set(quads.filter(q => q.predicate === RDF_TYPE && q.object === `${DKG}KnowledgeAsset`).map(q => q.subject));
     expect(kaSubjects.size).toBe(2);
   });
+
+  it('GH #748 fallback: attribution is the peer-ID literal when neither agentAddress nor authorAddress is supplied', () => {
+    const quads = generateKCMetadata(makeMeta(), [makeKA()]);
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution).toBeDefined();
+    expect(attribution!.object).toBe('"12D3KooWTestPeer"');
+  });
+
+  it('GH #748: attribution is the agent DID URI when agentAddress is supplied', () => {
+    const ADDR = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
+    const quads = generateKCMetadata(makeMeta({ agentAddress: ADDR }), [makeKA()]);
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution).toBeDefined();
+    expect(attribution!.object).toBe(`did:dkg:agent:${ADDR}`);
+  });
+
+  it('GH #748: attribution falls back to authorAddress when agentAddress is omitted but publication provenance is set', () => {
+    const ADDR = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+    const quads = generateKCMetadata(
+      makeMeta({ authorAddress: ADDR, publishOperationId: 'op-x' }),
+      [makeKA()],
+    );
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution).toBeDefined();
+    expect(attribution!.object).toBe(`did:dkg:agent:${ADDR}`);
+  });
+
+  it('GH #748: explicit agentAddress takes precedence over authorAddress', () => {
+    const AGENT = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
+    const AUTHOR = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+    const quads = generateKCMetadata(
+      makeMeta({ agentAddress: AGENT, authorAddress: AUTHOR, publishOperationId: 'op-x' }),
+      [makeKA()],
+    );
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution!.object).toBe(`did:dkg:agent:${AGENT}`);
+  });
 });
 
 describe('generateKCMetadata — RFC-001 §3.5 publication provenance', () => {
@@ -322,6 +359,26 @@ describe('generateShareMetadata', () => {
     const preds = quads.map(q => q.predicate);
     expect(preds).toContain(`${DKG}publishedAt`);
     expect(preds).toContain('http://www.w3.org/ns/prov#wasAttributedTo');
+  });
+
+  it('GH #748 fallback: attribution is the peer-ID literal when agentAddress is omitted', () => {
+    const quads = generateShareMetadata(wsMeta, wsGraph);
+    const attribution = quads.find(q => q.predicate === 'http://www.w3.org/ns/prov#wasAttributedTo');
+    expect(attribution).toBeDefined();
+    expect(attribution!.object).toBe('"12D3KooWTestPeer"');
+  });
+
+  it('GH #748: attribution is the agent DID URI when agentAddress is supplied', () => {
+    const quads = generateShareMetadata(
+      { ...wsMeta, agentAddress: '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB' },
+      wsGraph,
+    );
+    const attribution = quads.find(q => q.predicate === 'http://www.w3.org/ns/prov#wasAttributedTo');
+    expect(attribution).toBeDefined();
+    expect(attribution!.object).toBe('did:dkg:agent:0xaF7E932F79263f1A303790Bd6C01b096f5334BBB');
+    // The peer ID is still recorded separately for transport-layer audit.
+    const peerIdQuad = quads.find(q => q.predicate === `${DKG}publisherPeerId`);
+    expect(peerIdQuad!.object).toBe('"12D3KooWTestPeer"');
   });
 
   it('includes compact operation reference fields', () => {

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -154,6 +154,33 @@ describe('generateKCMetadata', () => {
     expect(attribution!.object).toBe(`did:dkg:agent:${ADDR.toLowerCase()}`);
   });
 
+  it('GH #748 Codex round 7: zero-address authorAddress is treated as unattributed (no fake agent DID)', () => {
+    // `publisherNodeIdentityIdOverride = 0` writes `authorAddress = 0x0…0`
+    // as the sentinel for "no author". The fallback chain must NOT mint a
+    // real-looking `did:dkg:agent:0x000…000` URI — fall through to the
+    // peer-ID literal so downstream provenance correctly reflects the
+    // unattributed publish.
+    const ZERO = '0x0000000000000000000000000000000000000000';
+    const quads = generateKCMetadata(
+      makeMeta({ authorAddress: ZERO, publishOperationId: 'op-x' }),
+      [makeKA()],
+    );
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution).toBeDefined();
+    // Must NOT be the synthesised zero-address agent DID.
+    expect(attribution!.object).not.toBe(`did:dkg:agent:${ZERO}`);
+    // Falls back to peer-ID literal — preserves the pre-fix unattributed shape.
+    expect(attribution!.object).toBe('"12D3KooWTestPeer"');
+  });
+
+  it('GH #748 Codex round 7: zero-address with mixed casing also treated as unattributed', () => {
+    // Sanity: case-insensitive zero-address detection.
+    const ZERO_MIXED = '0x0000000000000000000000000000000000000000';
+    const quads = generateKCMetadata(makeMeta({ agentAddress: ZERO_MIXED }), [makeKA()]);
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution!.object).toBe('"12D3KooWTestPeer"');
+  });
+
   it('GH #748: explicit agentAddress takes precedence over authorAddress', () => {
     const AGENT = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
     const AUTHOR = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';


### PR DESCRIPTION
## Summary

- Bind SWM `prov:wasAttributedTo` to the durable agent DID (`<did:dkg:agent:0x…>`) instead of the libp2p peer-ID string literal. Fixes the SWM Attribution legend showing `12D3KooW…` instead of agent addresses, and closes the cross-system reference gap that would have caused #747's "In review" check to false-positive when one agent uses multiple peer keys.
- New `agentDid(address)` helper consolidates four inlined `did:dkg:agent:${addr}` sites in `metadata.ts`.
- Three writer paths conditionally emit the URI form when the caller supplies an agent address, falling back to the peer-ID literal for backwards compatibility. Includes the KC metadata writer (`generateKCMetadata`) since it carries the same bug class on a different surface.
- One-shot startup migration `migrateSwmAttributionToAgentDid` rewrites legacy `_shared_memory_meta` peer-ID literals to agent DIDs via the AGENTS system graph, idempotent per CG.

UI requires no changes — `useSwmAttributions.canonicaliseAgent` (`packages/node-ui/src/ui/hooks/useSwmAttributions.ts:104-109`) already handles the `did:dkg:agent:0x…` form correctly; the legend will start showing agent addresses automatically once data is in URI form.

## Related

- Closes #748
- Related to #747 (cross-author SWM promote check). If #747 Phase 0 drops the in-memory `sharedMemoryOwnedEntities` and reads from `_shared_memory_meta` directly, ownership becomes correctly bound to durable agent identity rather than rotating peer keys.

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/metadata.ts` | Adds `agentDid()` helper; conditional URI emit in `generateShareMetadata` and `generateKCMetadata`; extends both input types with `agentAddress?: string`. KC writer falls back to `authorAddress` when set. |
| `packages/publisher/src/workspace-resolution.ts` | Extends `storeWorkspaceOperationPublicQuads` params with `agentAddress?: string`; conditional URI emit at the per-root attribution write; threads `agentAddress` into the nested `generateShareMetadata` call. |
| `packages/publisher/src/workspace-handler.ts` | Gossip-received SWM path: derives `senderAgentAddress` from the cryptographically verified `envelope.agentAddress`, passes through to `storeWorkspaceOperationPublicQuads`. |
| `packages/publisher/src/dkg-publisher.ts` | Threads `agentAddress` from `assertionPromote` and `_shareImpl` (via `options.senderAgentAddress`) into `storeWorkspaceOperationPublicQuads`. Adds `migrateSwmAttributionToAgentDid` + private `resolveAgentAddressForPeer` (queries AGENTS graph). |
| `packages/agent/src/dkg-agent.ts` | Wires `publisher.migrateSwmAttributionToAgentDid()` into `DKGAgent.create()` immediately after `reconstructWorkspaceOwnership`. Non-fatal on failure, log + skip. |
| `packages/core/src/logger.ts` | Adds `'migrate-swm-attr'` to the `OperationName` union. |
| `packages/publisher/test/metadata.test.ts` | 6 new tests: URI-shape assertions for both writers with/without `agentAddress`; KC writer fallback to `authorAddress`; `agentAddress` takes precedence over `authorAddress`. |
| `packages/publisher/test/draft-lifecycle.test.ts` | New end-to-end migration test: seeds literal-form attribution + an AGENTS record, runs the migration, asserts the resolvable row rewrites and the unresolved one is left alone, then re-runs and asserts the marker prevents re-mutation. |
| `packages/publisher/test/access-protocol.test.ts` | Two "owner identity missing" tests deleted the literal-form attribution quad by exact match; switched to `deleteByPattern` so they cover both shapes regardless of which the writer emits. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-publisher exec tsc --noEmit` — clean
- [x] `pnpm --filter @origintrail-official/dkg-agent exec tsc --noEmit` — clean
- [x] `pnpm --filter @origintrail-official/dkg-publisher test` — full suite, 1057 passed (1051 pre-fix + 6 new metadata tests; access-protocol regressions caught and fixed)
- [x] `pnpm --filter @origintrail-official/dkg-node-ui test` — 883 passed, 0 fail (no UI files changed; defensive run)
- [x] `pnpm --filter @origintrail-official/dkg-agent exec vitest run` — 73/74 files pass, 874 tests pass. One pre-existing vitest worker-fork environmental error on Windows (reproducible across two runs, unrelated to this change — main agent only edited one location in `dkg-agent.ts:1063` area, all neighbouring tests pass)
- [ ] qa-lead live walkthrough on dev daemon: SPARQL `?o` for `<prov:wasAttributedTo>` shows `<did:dkg:agent:0x…>` (URI), SWM Attribution legend shows agent-address slice (e.g. `0xaF7E…BBBB`) instead of `12D3KooW…` peer ID
- [ ] qa-lead migration check on Tuesday CG data: boot worktree daemon once, observe log line, query `_shared_memory_meta` for `urn:collection:weekday-name-origins` and confirm both attribution rows are now URI form (or peer-ID for unresolved peers, logged); boot again to confirm "skipped (marker present)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
