### PR TITLE
fix(agent): plumb on-chain CG id into finalization gossip (unblocks RS sampling for fresh publishes)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -8865,6 +8865,10 @@ export class DKGAgent {
   ): Promise<PublishResult> {
     const ctx = options?.operationCtx ?? createOperationContext('publishFromSWM');
     const effectiveSubCG = options?.subContextGraphId ?? options?.contextGraphId;
+    // `ctxGraphIdStr` doubles as `publishContextGraphId` for REMAP-flow
+    // publishes — the publisher uses its presence as a signal to DELETE the
+    // original copy from the default data graph. Keep it empty for non-REMAP
+    // publishes so we don't accidentally trigger the delete.
     const ctxGraphIdStr = effectiveSubCG != null ? String(effectiveSubCG) : undefined;
 
     const onChainId = ctxGraphIdStr ?? (await this.getContextGraphOnChainId(contextGraphId)) ?? undefined;
@@ -8963,6 +8967,16 @@ export class DKGAgent {
     if (result.status === 'confirmed' && result.onChainResult) {
       const rootEntities = result.kaManifest.map(ka => ka.rootEntity);
 
+      // Always carry the resolved on-chain CG id in the finalization gossip
+      // so receiving cores promote SWM into the per-cgId `_meta` namespace
+      // (`<cgName>/context/<cgId>/_meta`) that the RS prover reads from.
+      // Without this the prover 404'd with `KCNotFoundError` on every
+      // freshly-published KC even though the SWM payload had been
+      // replicated — see scripts/devnet-test-rfc39-comprehensive.sh
+      // Scenario A. We pass the *publisher-resolved* `onChainId` (which
+      // includes both explicit REMAP targets and the auto-lookup fallback)
+      // rather than the REMAP-only `ctxGraphIdStr`.
+      const broadcastCgId = onChainId != null ? String(onChainId) : undefined;
       const msg: FinalizationMessageMsg = {
         ual: result.ual,
         contextGraphId: contextGraphId,
@@ -8976,14 +8990,14 @@ export class DKGAgent {
         rootEntities,
         timestampMs: Date.now(),
         operationId: ctx.operationId,
-        targetContextGraphId: result.contextGraphError ? undefined : ctxGraphIdStr,
+        targetContextGraphId: result.contextGraphError ? undefined : broadcastCgId,
         subGraphName: options?.subGraphName,
       };
 
       const topic = contextGraphFinalizationTopic(contextGraphId);
       try {
         await this.gossip.publish(topic, encodeFinalizationMessage(msg));
-        this.log.info(ctx, `Broadcast finalization for ${result.ual} to ${topic}${ctxGraphIdStr ? ` (contextGraph=${ctxGraphIdStr})` : ''}${result.contextGraphError ? ' (ctx-graph registration failed, omitting targetContextGraphId)' : ''}`);
+        this.log.info(ctx, `Broadcast finalization for ${result.ual} to ${topic}${broadcastCgId ? ` (contextGraph=${broadcastCgId})` : ''}${result.contextGraphError ? ' (ctx-graph registration failed, omitting targetContextGraphId)' : ''}`);
       } catch {
         this.log.warn(ctx, `No peers subscribed to ${topic} yet`);
       }

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -927,7 +927,7 @@ cmd_start() {
         if (idId === 0n) { console.log('Node ' + (i+1) + ' (core): no identity after 60s, skipping'); continue; }
 
         const stakeAmount = ethers.parseEther('50000');
-        const askAmount = ethers.parseEther('1');
+        const askAmount = ethers.parseEther('${DEVNET_CORE_ASK_TRAC:-1}');
         // Lock tier 1 (1-month). Cheapest tier with non-zero multiplier; sufficient
         // for devnet random-sampling soak tests where we need nodeStakeV10 > 0.
         const lockTier = 1;


### PR DESCRIPTION
## Summary

`publishFromSWM` emitted `targetContextGraphId: undefined` on every non-REMAP publish, so receiving cores promoted the SWM snapshot into the legacy `<cgName>/_meta` graph instead of the per-cgId `<cgName>/context/<cgId>/_meta` graph that the RS prover's `extractV10KCFromStore` reads from → every freshly published KC failed random sampling with `KCNotFoundError` even though SWM had been replicated correctly.

Found while running `scripts/devnet-test-rfc39-comprehensive.sh` against `release/rc.12` HEAD — Scenario A (public-CG regression) reproed it on the very first publish, with the cores' `_meta` graph stuck at `<cgName>/_meta` while the publisher's local copy was correctly at `<cgName>/context/3/_meta`.

The publisher already resolves `onChainId` (explicit REMAP target OR `getContextGraphOnChainId` fallback). We thread that into the gossip's `targetContextGraphId` while keeping `ctxGraphIdStr` REMAP-only — so we don't accidentally trip the publisher's REMAP-delete branch for regular publishes.

## Test plan

- Manually verified end-to-end on a fresh 6-node devnet (4 core + 2 edge, ask = 0.5 TRAC/KiB, stake = 50k TRAC):

  | Scenario | kcId | proof tx | Notes |
  |---|---|---|---|
  | A — public CG | 1 | `0xa5d29be4…` | flat-KC prover, regression check |
  | B — curated 1-chunk LU-11 | 2 | `0xac19bd3a…` | ct_root=`0x79395f63…`, ct_count=1 |
  | C — curated multi-chunk | 3 | `0x6e2e1aaa…` | ct_count=4, multi-leaf Merkle |
  | D — late-join backfill | 4 | `0x7f891d99…` | `LU-11 backfill done … fetched=4 failures=0`, 3/3 sibling cores served |

  All four landed `submitChallengeProof` on chain. Before the fix Scenario A timed out at 180s on `kc-not-synced` / `KCNotFoundError` for every core, blocking the whole suite (`set -euo pipefail`).

- Also exposes `DEVNET_CORE_ASK_TRAC` env var so the devnet bootstrap can use a realistic ask (default unchanged at 1 TRAC).

## Related

- Surfaced during the post-merge devnet validation of PRs #738-#744 (RFC-39 / LU-11 test-gap series).

Made with [Cursor](https://cursor.com)