### PR TITLE
RFC-41 §6.2: Edge npm-only update + rollback devnet integration suite

### DIFF
--- a/devnet/edge-update-flow/automated.test.ts
+++ b/devnet/edge-update-flow/automated.test.ts
@@ -1,0 +1,104 @@
+/**
+ * OT-RFC-41 Bundle B — Edge npm-only update + rollback flow integration test.
+ *
+ * The unit suite in `packages/cli/test/rfc-41-bundle-b.test.ts` covers
+ * the LOGIC of `performNpmUpdateEdge` + `dkg rollback` (Edge branch)
+ * with a mocked `_autoUpdateIo.exec`. That gets us 95% of the
+ * confidence. The last 5% — that `npm install -g` actually mutates
+ * disk, that the installed binary actually runs, that the
+ * previous-version breadcrumb survives a real exec round-trip — is
+ * what this integration test closes.
+ *
+ * The actual orchestration lives in `scripts/devnet-test-edge-update.sh`
+ * for two reasons:
+ *
+ *   1. The script is the form an operator can also run by hand for
+ *      ad-hoc validation. Keeping the wiring in shell means the
+ *      runbook in `docs/devnet/EDGE_UPDATE_VALIDATION.md` is a direct
+ *      copy-paste of what CI executes — no test-runner-specific glue.
+ *   2. Running `npm install -g` requires a clean process env (npm
+ *      reads `NPM_CONFIG_*`, `.npmrc`, etc. up front, not per-spawn),
+ *      so a child process boundary is the path of least resistance.
+ *      Vitest+forks gives us that boundary naturally.
+ *
+ * This file is the thinnest possible vitest wrapper: it shells out to
+ * the script, asserts a clean exit code, and surfaces failures with
+ * the script's own stderr so the failure report is grep-friendly.
+ *
+ * Preconditions:
+ *   - `pnpm install` + `pnpm build` from the repo root.
+ *   - `npx -y verdaccio --version` works on the host (the script
+ *     uses `npx -y verdaccio@latest` to boot the registry).
+ *
+ * Runtime: ~3-5 minutes — the publish stage iterates ~15 public
+ * workspace packages and the install stage does two `npm install -g`
+ * round-trips with the MarkItDown postinstall.
+ *
+ * Run via `pnpm test:devnet:edge-update-flow` from the repo root.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..');
+const SCRIPT = resolve(REPO_ROOT, 'scripts', 'devnet-test-edge-update.sh');
+
+describe('RFC-41 Bundle B — Edge npm-only update + rollback round-trip', () => {
+  it('runs scripts/devnet-test-edge-update.sh to completion', async () => {
+    expect(existsSync(SCRIPT), `expected ${SCRIPT} to exist`).toBe(true);
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    const proc = spawn('bash', [SCRIPT], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        // Honour any operator overrides the runbook documents, but
+        // do not silently inject anything else — keep this transparent
+        // for debugging.
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    proc.stdout.on('data', (c: Buffer) => {
+      stdoutChunks.push(c);
+      // Stream the script's progress so a stalled stage is visible
+      // in CI logs without having to wait for the test to time out.
+      process.stdout.write(c);
+    });
+    proc.stderr.on('data', (c: Buffer) => {
+      stderrChunks.push(c);
+      process.stderr.write(c);
+    });
+
+    const exitCode: number = await new Promise((res, rej) => {
+      proc.once('error', rej);
+      proc.once('close', (code) => res(code ?? -1));
+    });
+
+    if (exitCode !== 0) {
+      const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+      const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
+      const tail = (s: string, n: number) => s.split('\n').slice(-n).join('\n');
+      throw new Error(
+        `devnet-test-edge-update.sh exited ${exitCode}\n` +
+          `--- last 40 lines of stderr ---\n${tail(stderr, 40)}\n` +
+          `--- last 40 lines of stdout ---\n${tail(stdout, 40)}`,
+      );
+    }
+
+    const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
+    // Final assertion lines emitted by the script — anchor the test
+    // to the production contract so a regression that quietly skips
+    // a stage still fails here.
+    expect(stdout).toMatch(/\[edge-update\] v1 installed and reports version /);
+    expect(stdout).toMatch(/\[edge-update\] previous-version=.* \(matches v1\)/);
+    expect(stdout).toMatch(/\[edge-update\] binary now reports /);
+    expect(stdout).toMatch(/\[edge-update\] binary back to .* after rollback — round-trip complete/);
+    expect(stdout).toMatch(/\[edge-update\] PASS — Edge npm-only update \+ rollback round-trip/);
+  });
+});

--- a/devnet/edge-update-flow/package.json
+++ b/devnet/edge-update-flow/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@origintrail-official/dkg-devnet-edge-update-flow",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:devnet": "vitest run --config vitest.config.ts"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
+  }
+}

--- a/devnet/edge-update-flow/package.json
+++ b/devnet/edge-update-flow/package.json
@@ -7,6 +7,6 @@
     "test:devnet": "vitest run --config vitest.config.ts"
   },
   "devDependencies": {
-    "vitest": "^4.0.18"
+    "vitest": "4.0.18"
   }
 }

--- a/devnet/edge-update-flow/vitest.config.ts
+++ b/devnet/edge-update-flow/vitest.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+/**
+ * OT-RFC-41 Bundle B — Edge npm-only update + rollback flow.
+ *
+ * Wraps `scripts/devnet-test-edge-update.sh`, which spins up a local
+ * verdaccio registry, packs + publishes every public workspace
+ * package, installs the CLI globally into a scratch npm prefix,
+ * exercises the full `dkg update` → `dkg rollback` round-trip against
+ * a real `npm install -g`, and asserts the production
+ * `performNpmUpdateEdge` + `dkg rollback` (Edge branch) code paths
+ * actually mutate disk the way unit tests expect.
+ *
+ * This is the §6.2 testing-gap closer for RFC-41: unit tests in
+ * `packages/cli/test/rfc-41-bundle-b.test.ts` cover the LOGIC with a
+ * mocked `_autoUpdateIo.exec`; this suite covers the INTEGRATION with
+ * the real npm CLI.
+ *
+ * Pre-requisites (see `docs/devnet/EDGE_UPDATE_VALIDATION.md`):
+ *   - `pnpm install` from the repo root
+ *   - `pnpm build` (so `packages/* /dist/` exists for `pnpm pack`)
+ *   - `npx -y verdaccio --version` works on the host (warm the cache)
+ *
+ * Run: `pnpm test:devnet:edge-update-flow`
+ *
+ * Runtime: ~3-5 minutes. Dominated by verdaccio cold-start and two
+ * `npm install -g` round-trips against the scratch prefix.
+ */
+export default defineConfig({
+  test: {
+    include: [resolve(import.meta.dirname, 'automated.test.ts')],
+    testTimeout: 600_000,
+    hookTimeout: 60_000,
+    pool: 'forks',
+    sequence: { concurrent: false },
+    globals: false,
+  },
+  resolve: {
+    modules: [
+      resolve(import.meta.dirname, '../../node_modules'),
+      'node_modules',
+    ],
+  },
+});

--- a/docs/devnet/EDGE_UPDATE_VALIDATION.md
+++ b/docs/devnet/EDGE_UPDATE_VALIDATION.md
@@ -1,0 +1,299 @@
+# Edge npm-only update + rollback validation (RFC-41 Bundle B)
+
+This runbook is the operator-facing companion to
+`scripts/devnet-test-edge-update.sh` and the vitest harness at
+`devnet/edge-update-flow/automated.test.ts`. It closes RFC-41 §6.2:
+end-to-end validation of the Edge node `dkg update` + `dkg rollback`
+flow against a real `npm install -g` against a real (local) npm
+registry, _without_ requiring a Trace Labs NPM publish.
+
+The §6.2 gap exists because automated devnet update testing has been
+gated on the prerequisites in §6.5 (Trace Labs publishing a `next`
+dist-tag with the Bundle B build). Until that lands, this runbook +
+script let any contributor exercise the full flow on their own laptop
+against a self-hosted `verdaccio` registry.
+
+## What this validates
+
+Bundle B's contract (RFC-41 §4.7, §4.8):
+
+1. `npm install -g @origintrail-official/dkg@<version>` resolves through
+   the registry and installs the global binary at the npm prefix.
+2. `dkg --version` reports the installed version.
+3. `dkg update <new-version>` runs `npm install -g
+   @origintrail-official/dkg@<new-version>`, writes the OLD version to
+   `~/.dkg/previous-version`, and the binary reports the new version.
+4. `dkg rollback` reads `~/.dkg/previous-version`, runs `npm install
+   -g @origintrail-official/dkg@<previous-version>`, and the binary
+   reports the previous version. Round-trip lands back on the
+   starting version.
+
+What this does **not** validate (separate suites cover these):
+
+- `dkg init --role edge` flow — covered by Bundle B unit tests in
+  `packages/cli/test/rfc-41-bundle-b.test.ts` (monorepo guard,
+  `--role` parsing, config layout). The runbook below bootstraps a
+  minimal `~/.dkg/config.json` directly to keep the focus on the
+  update + rollback path.
+- Daemon HTTP behavior under the new install — covered by
+  `devnet/v10-core-flows/` once the daemon is started against an
+  Edge-mode `config.json`.
+- Core slot-based update — RFC-41 §4.7.2 keeps that path for Core
+  nodes; this runbook is Edge-only.
+- Build-info / install-mode telemetry — Bundle A's `/api/status` +
+  `dkg doctor` output is covered by Bundle A's unit suite.
+
+## Prerequisites
+
+1. **Built workspace.** `pnpm pack` packs `dist/`, not source; without
+   it the packed tarballs are stubs.
+   ```bash
+   pnpm install
+   pnpm build
+   ```
+2. **Network access for `npx`.** The script boots verdaccio via
+   `npx -y verdaccio@latest`. Warm the npx cache once:
+   ```bash
+   npx -y verdaccio@latest --version
+   ```
+3. **No conflicting verdaccio.** Port `4873` must be free, or set
+   `VERDACCIO_PORT=<free port>` when invoking the script.
+4. **Node ≥ what the repo requires.** Use `nvm use` (reads `.nvmrc`)
+   to pin the right version.
+
+The script does NOT touch:
+
+- The host's `~/.dkg` (uses `DKG_HOME=<scratch>/dkg-home`).
+- The host's npm global prefix (uses `NPM_CONFIG_PREFIX=<scratch>/npm-global`).
+- The host's `~/.npmrc` (uses `NPM_CONFIG_USERCONFIG=<scratch>/.npmrc`).
+
+## Run it (automated)
+
+From the repo root:
+
+```bash
+pnpm test:devnet:edge-update-flow
+```
+
+That registers the script as a vitest scenario alongside the other
+`pnpm test:devnet:*` suites, gives you streamed progress, and fails
+loud with the script's own stderr captured.
+
+To debug a failure, re-run the script directly with the scratch root
+preserved:
+
+```bash
+EDGE_UPDATE_KEEP_SCRATCH=1 ./scripts/devnet-test-edge-update.sh
+```
+
+The path it printed under `[edge-update] scratch root:` survives the
+exit trap and contains:
+
+- `dkg-home/` — `config.json`, `previous-version`, etc.
+- `npm-global/` — the scratch npm prefix with `bin/dkg`.
+- `verdaccio-storage/` — the local registry's package storage.
+- `verdaccio.log` — the registry's stderr.
+- `tarballs/` — every packed tarball (v1 for all public packages,
+  plus v2 of the CLI).
+- `.npmrc` — the registry/auth config the script used.
+
+## Run it (manual, step by step)
+
+If the script is failing in a way that's hard to read from logs alone,
+here's the same flow broken into copy-pasteable shell. Same env vars,
+same paths.
+
+### 1. Scratch root + env
+
+```bash
+export SCRATCH_ROOT="$(mktemp -d -t dkg-edge-update.XXXXXX)"
+export NPM_CONFIG_PREFIX="$SCRATCH_ROOT/npm-global"
+export DKG_HOME="$SCRATCH_ROOT/dkg-home"
+export NPM_CONFIG_USERCONFIG="$SCRATCH_ROOT/.npmrc"
+export NPM_CONFIG_REGISTRY="http://127.0.0.1:4873/"
+export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
+mkdir -p "$NPM_CONFIG_PREFIX" "$DKG_HOME" "$SCRATCH_ROOT/tarballs"
+
+cat > "$NPM_CONFIG_USERCONFIG" <<EOF
+registry=$NPM_CONFIG_REGISTRY
+//127.0.0.1:4873/:_authToken=anon-token-for-verdaccio
+@origintrail-official:registry=$NPM_CONFIG_REGISTRY
+EOF
+```
+
+### 2. Boot verdaccio
+
+```bash
+cat > "$SCRATCH_ROOT/verdaccio-config.yaml" <<EOF
+storage: $SCRATCH_ROOT/verdaccio-storage
+auth:
+  htpasswd:
+    file: $SCRATCH_ROOT/htpasswd
+    max_users: -1
+uplinks: {}
+packages:
+  '@origintrail-official/*':
+    access: \$anonymous
+    publish: \$anonymous
+    unpublish: \$anonymous
+  '**':
+    access: \$anonymous
+    publish: \$authenticated
+log:
+  type: stdout
+  format: pretty
+  level: warn
+EOF
+
+nohup npx -y verdaccio@latest \
+  --listen 4873 --config "$SCRATCH_ROOT/verdaccio-config.yaml" \
+  >"$SCRATCH_ROOT/verdaccio.log" 2>&1 &
+echo "verdaccio pid: $!"
+
+# Wait until /ping returns 200.
+until curl -fsS "$NPM_CONFIG_REGISTRY/-/ping" >/dev/null; do sleep 1; done
+```
+
+### 3. Pack + publish v1 of every public package
+
+```bash
+cd <repo-root>
+V1="$(node -p "require('./packages/cli/package.json').version")"
+echo "v1 = $V1"
+
+# Discover public packages.
+for d in packages/*; do
+  [ -f "$d/package.json" ] || continue
+  IS_PRIVATE="$(node -p "JSON.parse(require('fs').readFileSync('$d/package.json','utf-8')).private === true")"
+  [ "$IS_PRIVATE" = "true" ] && continue
+  ( cd "$d" && pnpm pack --pack-destination "$SCRATCH_ROOT/tarballs" >/dev/null )
+done
+
+for tgz in "$SCRATCH_ROOT/tarballs"/*.tgz; do
+  npm publish "$tgz"
+done
+```
+
+### 4. Bump CLI to v2 and publish
+
+```bash
+V2="${V1}-edge-update-test.1"
+cp packages/cli/package.json "$SCRATCH_ROOT/cli-package.json.bak"
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('packages/cli/package.json','utf-8'));
+  p.version = '$V2';
+  fs.writeFileSync('packages/cli/package.json', JSON.stringify(p, null, 2) + '\n');
+"
+( cd packages/cli && pnpm pack --pack-destination "$SCRATCH_ROOT/tarballs" >/dev/null )
+npm publish "$SCRATCH_ROOT/tarballs/origintrail-official-dkg-${V2}.tgz"
+cp "$SCRATCH_ROOT/cli-package.json.bak" packages/cli/package.json
+echo "v2 = $V2"
+```
+
+### 5. Install v1 globally
+
+```bash
+npm install -g "@origintrail-official/dkg@$V1"
+which dkg               # → $NPM_CONFIG_PREFIX/bin/dkg
+dkg --version           # → $V1
+```
+
+### 6. Bootstrap a minimal Edge config
+
+(`dkg init` is interactive and asks ~12 questions; we bypass it here
+because the focus is the UPDATE flow. Bundle B unit tests cover the
+init flow.)
+
+```bash
+cat > "$DKG_HOME/config.json" <<EOF
+{
+  "name": "dkg-edge-update-test",
+  "nodeRole": "edge",
+  "apiPort": 8901,
+  "autoUpdate": { "enabled": false, "source": "npm" },
+  "auth": { "enabled": false }
+}
+EOF
+```
+
+### 7. `dkg update <V2>` — the headline assertion
+
+```bash
+dkg update "$V2"
+cat "$DKG_HOME/previous-version"   # → $V1 (rollback breadcrumb)
+dkg --version                      # → $V2
+```
+
+### 8. `dkg rollback`
+
+```bash
+dkg rollback
+dkg --version                      # → $V1 (back to starting version)
+```
+
+### 9. Cleanup
+
+```bash
+kill %1 2>/dev/null               # stop verdaccio
+rm -rf "$SCRATCH_ROOT"
+```
+
+## Expected output (script form)
+
+A passing run looks like:
+
+```
+[edge-update] scratch root: /tmp/dkg-edge-update.XXXXXX
+[edge-update] verdaccio:    http://127.0.0.1:4873 ...
+[edge-update] stage 1: launching verdaccio
+[edge-update] verdaccio up after 2s (pid=12345)
+[edge-update] stage 2: v1=10.0.0-rc.11  v2=10.0.0-rc.11-edge-update-test.1
+[edge-update] packing public packages at v1 (10.0.0-rc.11)
+[edge-update] packed 15 v1 tarballs into ...
+[edge-update] packing v2 (CLI only, with bumped version ...)
+[edge-update] v2 tarball: .../origintrail-official-dkg-10.0.0-rc.11-edge-update-test.1.tgz
+[edge-update] restored .../packages/cli/package.json
+[edge-update] stage 3: publishing 16 tarballs to verdaccio
+[edge-update] published all tarballs
+[edge-update] verdaccio knows CLI v1 + v2
+[edge-update] stage 4: npm install -g @origintrail-official/dkg@10.0.0-rc.11
+[edge-update] v1 installed and reports version 10.0.0-rc.11
+[edge-update] stage 5: bootstrap minimal Edge config at .../dkg-home/config.json
+[edge-update] config.json nodeRole=edge, autoUpdate.source=npm
+[edge-update] stage 6: dkg update 10.0.0-rc.11-edge-update-test.1
+[edge-update] previous-version=10.0.0-rc.11 (matches v1)
+[edge-update] binary now reports 10.0.0-rc.11-edge-update-test.1
+[edge-update] stage 7: dkg rollback (expected back to 10.0.0-rc.11)
+[edge-update] binary back to 10.0.0-rc.11 after rollback — round-trip complete
+[edge-update] PASS — Edge npm-only update + rollback round-trip ...
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `verdaccio did not respond to /-/ping within 60s` | First-time `npx verdaccio` is downloading | Pre-warm with `npx -y verdaccio@latest --version` |
+| `port 4873 in use` | Existing verdaccio | `lsof -i :4873` → kill it, or `VERDACCIO_PORT=4874 ./script.sh` |
+| `pnpm pack failed` | Workspace not built | `pnpm build` from repo root |
+| `expected dkg binary at .../bin/dkg after install` | `npm install -g` silently failed | Re-run with `EDGE_UPDATE_KEEP_SCRATCH=1`, then `cat <scratch>/verdaccio.log` |
+| `dkg update <v2> failed` | Pre-flight doctor check found error severity | Re-run script directly with stderr visible: `bash -x scripts/devnet-test-edge-update.sh 2>&1 \| tee /tmp/dkg-update-log` |
+| `previous-version` missing after `dkg update` | `getCurrentCliVersion()` returned empty | Check that v1 tarball includes a non-empty `package.json#version` |
+| Test passes locally, fails in CI | CI host has a stale npm global prefix | Confirm CI uses an ephemeral runner; the script's scratch prefix is per-run |
+
+## Tying back to RFC-41
+
+Run this **before** you merge any change that touches:
+
+- `packages/cli/src/daemon/auto-update.ts` (especially
+  `performNpmUpdateEdge` and `_performNpmUpdateInnerEdge`).
+- `packages/cli/src/cli.ts` `dkg update` / `dkg rollback` action
+  handlers.
+- `packages/cli/src/migration.ts` `noteEdgeLegacyReleases`.
+- Any code under `packages/cli/src/daemon/manifest.ts` that exports
+  `_autoUpdateIo`.
+
+It's also a pre-merge gate for the RFC-41 follow-up PRs (deletion of
+the dead git-build code paths) once Bundle B has soaked on devnet —
+the script ensures the deletions did not accidentally break the
+update flow that survived the cleanup.

--- a/docs/devnet/EDGE_UPDATE_VALIDATION.md
+++ b/docs/devnet/EDGE_UPDATE_VALIDATION.md
@@ -51,11 +51,17 @@ What this does **not** validate (separate suites cover these):
    pnpm install
    pnpm build
    ```
-2. **Network access for `npx`.** The script boots verdaccio via
-   `npx -y verdaccio@latest`. Warm the npx cache once:
+2. **Network access for `npx`.** The script boots a pinned
+   verdaccio (default `verdaccio@6.7.2`, see `VERDACCIO_VERSION`
+   in `scripts/devnet-test-edge-update.sh`) via `npx`. Warm the
+   npx cache once:
    ```bash
-   npx -y verdaccio@latest --version
+   npx -y verdaccio@6.7.2 --version
    ```
+   Override the pin per-run with `VERDACCIO_VERSION=<x.y.z>
+   ./scripts/devnet-test-edge-update.sh` when debugging against
+   a different verdaccio. Bumping the default pin should be a
+   deliberate edit + a manual re-run against the updated runbook.
 3. **No conflicting verdaccio.** Port `4873` must be free, or set
    `VERDACCIO_PORT=<free port>` when invoking the script.
 4. **Node ≥ what the repo requires.** Use `nvm use` (reads `.nvmrc`)
@@ -145,7 +151,7 @@ log:
   level: warn
 EOF
 
-nohup npx -y verdaccio@latest \
+nohup npx -y verdaccio@6.7.2 \
   --listen 4873 --config "$SCRATCH_ROOT/verdaccio-config.yaml" \
   >"$SCRATCH_ROOT/verdaccio.log" 2>&1 &
 echo "verdaccio pid: $!"
@@ -273,7 +279,7 @@ A passing run looks like:
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `verdaccio did not respond to /-/ping within 60s` | First-time `npx verdaccio` is downloading | Pre-warm with `npx -y verdaccio@latest --version` |
+| `verdaccio did not respond to /-/ping within 60s` | First-time `npx verdaccio` is downloading | Pre-warm with `npx -y verdaccio@6.7.2 --version` |
 | `port 4873 in use` | Existing verdaccio | `lsof -i :4873` → kill it, or `VERDACCIO_PORT=4874 ./script.sh` |
 | `pnpm pack failed` | Workspace not built | `pnpm build` from repo root |
 | `expected dkg binary at .../bin/dkg after install` | `npm install -g` silently failed | Re-run with `EDGE_UPDATE_KEEP_SCRATCH=1`, then `cat <scratch>/verdaccio.log` |

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:devnet:v10-e2e": "vitest run --config devnet/v10-end-to-end/vitest.config.ts",
     "test:devnet:v10-stress": "vitest run --config devnet/v10-stress/vitest.config.ts",
     "test:devnet:conviction-lazy-settle": "vitest run --config devnet/conviction-lazy-settle/vitest.config.ts",
+    "test:devnet:edge-update-flow": "vitest run --config devnet/edge-update-flow/vitest.config.ts",
     "test:all": "pnpm test && pnpm test:evm"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,12 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  devnet/edge-update-flow:
+    devDependencies:
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
   devnet/v10-core-flows:
     dependencies:
       ethers:
@@ -5896,10 +5902,6 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
@@ -8614,7 +8616,7 @@ snapshots:
       '@vitest/spy': 4.0.18
       '@vitest/utils': 4.0.18
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -8643,7 +8645,7 @@ snapshots:
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -12607,8 +12609,6 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.0.2: {}
-
   tinyexec@1.1.2: {}
 
   tinyglobby@0.2.15:
@@ -13040,9 +13040,9 @@ snapshots:
       picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@22.19.11)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -13078,9 +13078,9 @@ snapshots:
       picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@22.19.11)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
   - "devnet/v10-end-to-end"
   - "devnet/v10-stress"
   - "devnet/conviction-lazy-settle"
+  - "devnet/edge-update-flow"

--- a/scripts/devnet-test-edge-update.sh
+++ b/scripts/devnet-test-edge-update.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+#
+# RFC-41 Bundle B — Edge node npm-only update + rollback flow validation.
+#
+# Closes the §6.2 testing gap by exercising the production
+# `performNpmUpdateEdge` and `dkg rollback` (Edge branch) code paths
+# against a real `npm install -g` against a real (local) npm registry.
+# Unit tests cover the LOGIC with mocked `exec`; this script covers
+# the INTEGRATION:
+#
+#   * `npm install -g @origintrail-official/dkg@<v>` actually mutates
+#     the global prefix.
+#   * The installed `dkg` binary runs and reports the expected version.
+#   * A minimal Edge `config.json` routes `dkg update` through the
+#     `performNpmUpdateEdge` branch (rather than the slot branch).
+#   * `dkg update <new-version>` reinstalls globally, writes
+#     `~/.dkg/previous-version` containing the OLD version, and the
+#     binary now reports `<new-version>`.
+#   * `dkg rollback` reads `~/.dkg/previous-version` and reinstalls the
+#     OLD version. Round-trip lands back on the original version.
+#
+# The script does NOT exercise `dkg init` (interactive; ~12 prompts).
+# That command's monorepo guard + `--role` flag are covered by unit
+# tests in `packages/cli/test/rfc-41-bundle-b.test.ts`. The runbook in
+# `docs/devnet/EDGE_UPDATE_VALIDATION.md` documents the bypass.
+#
+# Verdaccio runs locally as the npm registry. Because the CLI declares
+# 10+ `workspace:*` dependencies, the script must publish EVERY public
+# workspace package at v1 (mirrors `.github/workflows/npm-publish.yml`),
+# then bump the CLI to v2 and publish that one tarball. v2 CLI depends
+# on v1 workspace deps already in verdaccio, so `npm install -g` works.
+# The scratch npm prefix and scratch `DKG_HOME` are isolated under a
+# per-run mktemp dir; no system state is touched.
+#
+# Flow:
+#   1. mktemp scratch root → NPM_CONFIG_PREFIX, DKG_HOME, verdaccio storage.
+#   2. Boot verdaccio on a free port (default 4873; override with VERDACCIO_PORT).
+#   3. `pnpm pack` every public `packages/*` at HEAD → publish v1 of all.
+#      Bump `packages/cli/package.json` → repack CLI only → publish v2.
+#   4. `npm install -g @origintrail-official/dkg@<v1>` into the scratch prefix.
+#   5. Bootstrap a minimal Edge `config.json` under DKG_HOME.
+#   6. `dkg update <v2>` → assert previous-version file + new binary version.
+#   7. `dkg rollback` → assert binary version back to v1.
+#   8. Trap cleans up: stop verdaccio, rm scratch root.
+#
+# Exit 0 on full round-trip pass. Non-zero on any assertion failure
+# with a clear "[edge-update] FAIL: ..." line on stderr.
+#
+# Runtime: ~3-5 minutes (verdaccio cold-start + pack/publish of ~15
+# workspace packages + two `npm install -g` round-trips dominate).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI_PKG_DIR="$REPO_ROOT/packages/cli"
+
+# ---------------------------------------------------------------------------
+# Logging helpers (match existing devnet-test-*.sh conventions).
+# ---------------------------------------------------------------------------
+
+log()  { echo "[edge-update] $*"; }
+warn() { echo "[edge-update] WARN: $*" >&2; }
+fail() { echo "[edge-update] FAIL: $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Tunables (env-overridable).
+# ---------------------------------------------------------------------------
+
+VERDACCIO_PORT="${VERDACCIO_PORT:-4873}"
+# Allow the operator to pre-create a scratch root (useful for debugging
+# state between runs); otherwise mktemp.
+SCRATCH_ROOT="${EDGE_UPDATE_SCRATCH:-$(mktemp -d -t dkg-edge-update.XXXXXX)}"
+KEEP_SCRATCH="${EDGE_UPDATE_KEEP_SCRATCH:-0}"
+
+NPM_PREFIX="$SCRATCH_ROOT/npm-global"
+DKG_HOME_DIR="$SCRATCH_ROOT/dkg-home"
+VERDACCIO_STORAGE="$SCRATCH_ROOT/verdaccio-storage"
+VERDACCIO_CONFIG="$SCRATCH_ROOT/verdaccio-config.yaml"
+VERDACCIO_LOG="$SCRATCH_ROOT/verdaccio.log"
+NPMRC="$SCRATCH_ROOT/.npmrc"
+TARBALL_DIR="$SCRATCH_ROOT/tarballs"
+
+mkdir -p "$NPM_PREFIX" "$DKG_HOME_DIR" "$VERDACCIO_STORAGE" "$TARBALL_DIR"
+
+log "scratch root: $SCRATCH_ROOT"
+log "npm prefix:   $NPM_PREFIX"
+log "DKG_HOME:     $DKG_HOME_DIR"
+log "verdaccio:    http://127.0.0.1:$VERDACCIO_PORT (log: $VERDACCIO_LOG)"
+
+# ---------------------------------------------------------------------------
+# Cleanup trap.
+# ---------------------------------------------------------------------------
+
+VERDACCIO_PID=""
+ORIGINAL_PKG_JSON_BACKUP=""
+
+cleanup() {
+  local exit_code=$?
+  set +e
+  if [ -n "$VERDACCIO_PID" ] && kill -0 "$VERDACCIO_PID" 2>/dev/null; then
+    log "stopping verdaccio (pid=$VERDACCIO_PID)"
+    kill "$VERDACCIO_PID" 2>/dev/null
+    wait "$VERDACCIO_PID" 2>/dev/null
+  fi
+  # Restore package.json if we mutated it for the v2 pack and didn't
+  # already restore on the happy path.
+  if [ -n "$ORIGINAL_PKG_JSON_BACKUP" ] && [ -f "$ORIGINAL_PKG_JSON_BACKUP" ]; then
+    cp "$ORIGINAL_PKG_JSON_BACKUP" "$CLI_PKG_DIR/package.json"
+    log "restored $CLI_PKG_DIR/package.json from backup"
+  fi
+  if [ "$KEEP_SCRATCH" = "1" ]; then
+    log "keeping scratch root for inspection: $SCRATCH_ROOT"
+  else
+    rm -rf "$SCRATCH_ROOT"
+  fi
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Stage 1 — boot verdaccio.
+#
+# Config allows anonymous publish for the `@origintrail-official/*`
+# scope so we don't have to `npm adduser`. A dummy `_authToken` in the
+# scratch npmrc satisfies npm's "must have an auth header" check; the
+# token value is never validated server-side because `$anonymous` is
+# the publish ACL.
+# ---------------------------------------------------------------------------
+
+cat > "$VERDACCIO_CONFIG" <<EOF
+storage: $VERDACCIO_STORAGE
+auth:
+  htpasswd:
+    file: $SCRATCH_ROOT/htpasswd
+    # max_users: -1 disables registration but does NOT disable
+    # anonymous access — \$anonymous below still works.
+    max_users: -1
+uplinks: {}
+packages:
+  '@origintrail-official/*':
+    access: \$anonymous
+    publish: \$anonymous
+    unpublish: \$anonymous
+  '**':
+    access: \$anonymous
+    # Block accidental publishes of unrelated packages.
+    publish: \$authenticated
+log:
+  type: stdout
+  format: pretty
+  level: warn
+EOF
+
+cat > "$NPMRC" <<EOF
+registry=http://127.0.0.1:$VERDACCIO_PORT/
+//127.0.0.1:$VERDACCIO_PORT/:_authToken=anon-token-for-verdaccio
+@origintrail-official:registry=http://127.0.0.1:$VERDACCIO_PORT/
+EOF
+
+# Always-on env so every subsequent `npm` / `dkg` invocation in this
+# shell uses the scratch registry + scratch prefix + scratch npmrc.
+export NPM_CONFIG_USERCONFIG="$NPMRC"
+export NPM_CONFIG_PREFIX="$NPM_PREFIX"
+export NPM_CONFIG_REGISTRY="http://127.0.0.1:$VERDACCIO_PORT/"
+# `dkg init` and `dkg rollback` read DKG_HOME for state. Without this
+# they'd write into the operator's real ~/.dkg, polluting the host.
+export DKG_HOME="$DKG_HOME_DIR"
+# Put the scratch npm prefix's bin on PATH ahead of the system one so
+# `dkg` after install resolves to the scratch install, not a global
+# `@origintrail-official/dkg` the operator might already have.
+export PATH="$NPM_PREFIX/bin:$PATH"
+
+log "stage 1: launching verdaccio"
+nohup npx -y verdaccio@latest --listen "$VERDACCIO_PORT" --config "$VERDACCIO_CONFIG" \
+  >"$VERDACCIO_LOG" 2>&1 &
+VERDACCIO_PID=$!
+
+# Wait for verdaccio to be ready.
+for i in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:$VERDACCIO_PORT/-/ping" >/dev/null 2>&1; then
+    log "verdaccio up after ${i}s (pid=$VERDACCIO_PID)"
+    break
+  fi
+  if ! kill -0 "$VERDACCIO_PID" 2>/dev/null; then
+    fail "verdaccio process exited during startup — see $VERDACCIO_LOG"
+  fi
+  sleep 1
+done
+if ! curl -fsS "http://127.0.0.1:$VERDACCIO_PORT/-/ping" >/dev/null 2>&1; then
+  fail "verdaccio did not respond to /-/ping within 60s — see $VERDACCIO_LOG"
+fi
+
+# ---------------------------------------------------------------------------
+# Stage 2 — pack every public workspace package, then a v2 of just the CLI.
+#
+# The CLI declares 10+ workspace-protocol dependencies. `pnpm pack`
+# rewrites `workspace:*` to the resolved version at pack time, but the
+# resulting tarball still REQUIRES those packages to be resolvable
+# from the registry npm hits. We therefore mirror the CI publish flow
+# (.github/workflows/npm-publish.yml step "Pack public packages") and
+# publish every non-private `packages/*` to verdaccio at v1.
+#
+# v1 = the repo's current version (e.g. `10.0.0-rc.11`).
+# v2 = `<v1>-edge-update-test.1`. Suffix keeps semver order so npm
+#      correctly considers v2 > v1, AND `^v1` does NOT match v2 (npm's
+#      caret semantics on prereleases are strict), so v2 CLI installs
+#      sit cleanly on top of v1 workspace deps already in verdaccio.
+#
+# Pre-requisite: `pnpm build` must have produced `packages/*/dist/`
+# before this script runs. Otherwise `pnpm pack` emits stub tarballs
+# missing the daemon JS and the v1 install reports a phantom
+# `Cannot find module ./dist/cli.js` at first invocation.
+# ---------------------------------------------------------------------------
+
+cd "$REPO_ROOT"
+V1_VERSION="$(node -p "require('./packages/cli/package.json').version")"
+V2_VERSION="${V1_VERSION}-edge-update-test.1"
+log "stage 2: v1=$V1_VERSION  v2=$V2_VERSION"
+
+# Sanity-check that the workspace is built.
+if [ ! -f "$CLI_PKG_DIR/dist/cli.js" ]; then
+  fail "CLI build output missing at $CLI_PKG_DIR/dist/cli.js — run 'pnpm build' from the repo root first"
+fi
+
+# Discover public packages — same logic the CI workflow uses, kept in
+# sync deliberately.
+PUBLIC_PKG_DIRS_RAW="$(node -e "
+  const fs = require('fs');
+  const path = require('path');
+  const pkgsDir = path.join(process.cwd(), 'packages');
+  const result = [];
+  for (const dir of fs.readdirSync(pkgsDir)) {
+    const pkgPath = path.join(pkgsDir, dir, 'package.json');
+    if (!fs.existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    if (pkg.private) continue;
+    result.push(path.join(pkgsDir, dir));
+  }
+  process.stdout.write(result.join('\n'));
+")"
+[ -n "$PUBLIC_PKG_DIRS_RAW" ] || fail "no public workspace packages discovered under packages/*"
+
+# Pack every public package at v1.
+log "packing public packages at v1 ($V1_VERSION)"
+PUBLIC_PKG_COUNT=0
+while IFS= read -r pkg_dir; do
+  [ -n "$pkg_dir" ] || continue
+  PUBLIC_PKG_COUNT=$((PUBLIC_PKG_COUNT + 1))
+  ( cd "$pkg_dir" && pnpm pack --pack-destination "$TARBALL_DIR" >/dev/null ) \
+    || fail "pnpm pack failed for $pkg_dir"
+done <<< "$PUBLIC_PKG_DIRS_RAW"
+log "packed $PUBLIC_PKG_COUNT v1 tarballs into $TARBALL_DIR"
+
+# Bump ONLY the CLI to v2 → repack → restore. v2's workspace deps are
+# left at v1 (already in verdaccio); npm's semver matcher resolves them
+# against the v1 packages we just packed.
+ORIGINAL_PKG_JSON_BACKUP="$SCRATCH_ROOT/cli-package.json.v1.bak"
+cp "$CLI_PKG_DIR/package.json" "$ORIGINAL_PKG_JSON_BACKUP"
+
+log "packing v2 (CLI only, with bumped version $V2_VERSION)"
+node -e "
+  const fs = require('fs');
+  const pkg = JSON.parse(fs.readFileSync('packages/cli/package.json', 'utf8'));
+  pkg.version = '$V2_VERSION';
+  fs.writeFileSync('packages/cli/package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+( cd "$CLI_PKG_DIR" && pnpm pack --pack-destination "$TARBALL_DIR" >/dev/null ) \
+  || { cp "$ORIGINAL_PKG_JSON_BACKUP" "$CLI_PKG_DIR/package.json"; fail "pnpm pack v2 failed"; }
+V2_TARBALL="$TARBALL_DIR/origintrail-official-dkg-${V2_VERSION}.tgz"
+[ -f "$V2_TARBALL" ] || { cp "$ORIGINAL_PKG_JSON_BACKUP" "$CLI_PKG_DIR/package.json"; fail "expected v2 tarball at $V2_TARBALL"; }
+log "v2 tarball: $V2_TARBALL"
+
+# Restore package.json immediately (don't wait for EXIT trap).
+cp "$ORIGINAL_PKG_JSON_BACKUP" "$CLI_PKG_DIR/package.json"
+ORIGINAL_PKG_JSON_BACKUP=""
+log "restored $CLI_PKG_DIR/package.json"
+
+# ---------------------------------------------------------------------------
+# Stage 3 — publish every packed tarball to verdaccio.
+#
+# `npm publish` reads .npmrc via NPM_CONFIG_USERCONFIG. The dummy
+# `_authToken` satisfies npm; verdaccio's `$anonymous` publish ACL
+# accepts the upload regardless of token value.
+# ---------------------------------------------------------------------------
+
+log "stage 3: publishing $(ls -1 "$TARBALL_DIR"/*.tgz | wc -l | tr -d ' ') tarballs to verdaccio"
+for tarball in "$TARBALL_DIR"/*.tgz; do
+  pkg_name="$(tar -xOf "$tarball" package/package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf-8')).name")"
+  npm publish --registry "$NPM_CONFIG_REGISTRY" "$tarball" >/dev/null 2>&1 \
+    || fail "npm publish failed for $tarball ($pkg_name) — see $VERDACCIO_LOG"
+done
+log "published all tarballs"
+
+# Sanity: verify verdaccio knows about CLI v1 + v2.
+VERSIONS_JSON="$(curl -fsS "http://127.0.0.1:$VERDACCIO_PORT/@origintrail-official%2Fdkg" \
+  || fail "verdaccio metadata fetch failed for @origintrail-official/dkg")"
+node -e "
+  const meta = $VERSIONS_JSON;
+  const versions = Object.keys(meta.versions || {});
+  if (!versions.includes('$V1_VERSION')) { console.error('missing v1: $V1_VERSION'); process.exit(1); }
+  if (!versions.includes('$V2_VERSION')) { console.error('missing v2: $V2_VERSION'); process.exit(1); }
+" || fail "verdaccio is missing CLI v1 or v2 — see $VERDACCIO_LOG"
+log "verdaccio knows CLI v1 + v2"
+
+# ---------------------------------------------------------------------------
+# Stage 4 — install v1 into the scratch prefix.
+#
+# `npm install -g @origintrail-official/dkg@<v1>` mirrors what
+# operators run for first install. The scratch prefix isolates state
+# from any pre-existing system install.
+# ---------------------------------------------------------------------------
+
+log "stage 4: npm install -g @origintrail-official/dkg@$V1_VERSION"
+npm install -g "@origintrail-official/dkg@$V1_VERSION" >/dev/null \
+  || fail "initial install failed"
+
+INSTALLED_BIN="$NPM_PREFIX/bin/dkg"
+[ -x "$INSTALLED_BIN" ] || fail "expected dkg binary at $INSTALLED_BIN after install"
+
+REPORTED_V1="$("$INSTALLED_BIN" --version 2>&1 | tail -1 | tr -d '\r\n')"
+[ "$REPORTED_V1" = "$V1_VERSION" ] \
+  || fail "expected dkg --version=$V1_VERSION after initial install, got: $REPORTED_V1"
+log "v1 installed and reports version $REPORTED_V1"
+
+# ---------------------------------------------------------------------------
+# Stage 5 — bootstrap a minimal Edge config under DKG_HOME.
+#
+# `dkg init` in rc.12 is interactive (~12 prompts: name, relay, context
+# graphs, API port, auto-update, chain RPC, hub address, auth, etc.)
+# and does not expose a `--yes` / `--non-interactive` flag — the
+# operator runs it once at first install and accepts defaults via
+# Enter. Piping `\n` x 12 to stdin would work but breaks silently the
+# moment a new prompt is added, which is brittle for an integration
+# test whose subject is the UPDATE flow, not init.
+#
+# Instead we write `$DKG_HOME/config.json` directly with the fields
+# that `dkg update` / `dkg rollback` read:
+#
+#   * `nodeRole: 'edge'`   → dispatches update/rollback through the
+#                            Edge branch (`performNpmUpdateEdge`).
+#   * `autoUpdate.source: 'npm'` → marks the install as npm-managed
+#                                  (no legacy git-build dispatch).
+#
+# The `dkg init --role edge` monorepo guard + --role flag are covered
+# by Bundle B's unit tests in `packages/cli/test/rfc-41-bundle-b.test.ts`;
+# this script does not duplicate that coverage.
+# ---------------------------------------------------------------------------
+
+log "stage 5: bootstrap minimal Edge config at $DKG_HOME/config.json"
+mkdir -p "$DKG_HOME"
+cat > "$DKG_HOME/config.json" <<EOF
+{
+  "name": "dkg-edge-update-test",
+  "nodeRole": "edge",
+  "apiPort": 8901,
+  "autoUpdate": {
+    "enabled": false,
+    "source": "npm"
+  },
+  "auth": {
+    "enabled": false
+  }
+}
+EOF
+INIT_ROLE="$(node -p "JSON.parse(require('fs').readFileSync('$DKG_HOME/config.json','utf8')).nodeRole" 2>/dev/null || echo '')"
+[ "$INIT_ROLE" = "edge" ] || fail "expected nodeRole=edge in config.json, got: $INIT_ROLE"
+log "config.json nodeRole=edge, autoUpdate.source=npm"
+
+# ---------------------------------------------------------------------------
+# Stage 6 — `dkg update <V2_VERSION>`.
+#
+# This is the headline Bundle B assertion: the Edge branch of
+# `dkg update` runs `npm install -g @origintrail-official/dkg@<v2>`,
+# writes the OLD version to `$DKG_HOME/previous-version`, and the
+# binary now reports v2.
+# ---------------------------------------------------------------------------
+
+log "stage 6: dkg update $V2_VERSION"
+"$INSTALLED_BIN" update "$V2_VERSION" >/dev/null 2>&1 \
+  || fail "dkg update $V2_VERSION failed — re-run with EDGE_UPDATE_KEEP_SCRATCH=1 and inspect $DKG_HOME"
+
+PREV_FILE="$DKG_HOME/previous-version"
+[ -f "$PREV_FILE" ] || fail "expected $PREV_FILE after dkg update (Edge rollback breadcrumb)"
+PREV_CONTENT="$(tr -d '\r\n[:space:]' <"$PREV_FILE")"
+[ "$PREV_CONTENT" = "$V1_VERSION" ] \
+  || fail "expected previous-version=$V1_VERSION, got: '$PREV_CONTENT'"
+log "previous-version=$PREV_CONTENT (matches v1)"
+
+REPORTED_V2="$("$INSTALLED_BIN" --version 2>&1 | tail -1 | tr -d '\r\n')"
+[ "$REPORTED_V2" = "$V2_VERSION" ] \
+  || fail "expected dkg --version=$V2_VERSION after update, got: $REPORTED_V2"
+log "binary now reports $REPORTED_V2"
+
+# ---------------------------------------------------------------------------
+# Stage 7 — `dkg rollback`.
+#
+# Edge rollback reads `previous-version`, runs `npm install -g
+# @origintrail-official/dkg@<old>`, and the binary returns to v1.
+# ---------------------------------------------------------------------------
+
+log "stage 7: dkg rollback (expected back to $V1_VERSION)"
+"$INSTALLED_BIN" rollback >/dev/null 2>&1 \
+  || fail "dkg rollback failed — re-run with EDGE_UPDATE_KEEP_SCRATCH=1 and inspect $DKG_HOME"
+
+REPORTED_ROLLBACK="$("$INSTALLED_BIN" --version 2>&1 | tail -1 | tr -d '\r\n')"
+[ "$REPORTED_ROLLBACK" = "$V1_VERSION" ] \
+  || fail "expected dkg --version=$V1_VERSION after rollback, got: $REPORTED_ROLLBACK"
+log "binary back to $REPORTED_ROLLBACK after rollback — round-trip complete"
+
+# ---------------------------------------------------------------------------
+# Done.
+# ---------------------------------------------------------------------------
+
+log "PASS — Edge npm-only update + rollback round-trip ($V1_VERSION → $V2_VERSION → $V1_VERSION)"
+exit 0

--- a/scripts/devnet-test-edge-update.sh
+++ b/scripts/devnet-test-edge-update.sh
@@ -312,14 +312,35 @@ done
 log "published all tarballs"
 
 # Sanity: verify verdaccio knows about CLI v1 + v2.
+#
+# Stream the registry JSON to Node via stdin (NOT shell-interpolated)
+# and pass the expected versions through env vars. The package
+# metadata can legitimately contain shell-significant characters
+# like `$` or backticks (e.g. in `description`, `readme`, or
+# `repository.url` fields), and direct interpolation into `node -e`
+# would let bash expand them before Node ever parses the script.
+# Single-quoting the node script keeps bash out of its body entirely.
 VERSIONS_JSON="$(curl -fsS "http://127.0.0.1:$VERDACCIO_PORT/@origintrail-official%2Fdkg" \
   || fail "verdaccio metadata fetch failed for @origintrail-official/dkg")"
-node -e "
-  const meta = $VERSIONS_JSON;
-  const versions = Object.keys(meta.versions || {});
-  if (!versions.includes('$V1_VERSION')) { console.error('missing v1: $V1_VERSION'); process.exit(1); }
-  if (!versions.includes('$V2_VERSION')) { console.error('missing v2: $V2_VERSION'); process.exit(1); }
-" || fail "verdaccio is missing CLI v1 or v2 — see $VERDACCIO_LOG"
+printf '%s' "$VERSIONS_JSON" | \
+  V1_VERSION="$V1_VERSION" V2_VERSION="$V2_VERSION" node -e '
+    let d = "";
+    process.stdin.on("data", (c) => { d += c; });
+    process.stdin.on("end", () => {
+      const meta = JSON.parse(d);
+      const versions = Object.keys(meta.versions || {});
+      const want1 = process.env.V1_VERSION;
+      const want2 = process.env.V2_VERSION;
+      if (!versions.includes(want1)) {
+        console.error("missing v1: " + want1);
+        process.exit(1);
+      }
+      if (!versions.includes(want2)) {
+        console.error("missing v2: " + want2);
+        process.exit(1);
+      }
+    });
+  ' || fail "verdaccio is missing CLI v1 or v2 — see $VERDACCIO_LOG"
 log "verdaccio knows CLI v1 + v2"
 
 # ---------------------------------------------------------------------------

--- a/scripts/devnet-test-edge-update.sh
+++ b/scripts/devnet-test-edge-update.sh
@@ -157,11 +157,20 @@ registry=http://127.0.0.1:$VERDACCIO_PORT/
 @origintrail-official:registry=http://127.0.0.1:$VERDACCIO_PORT/
 EOF
 
-# Always-on env so every subsequent `npm` / `dkg` invocation in this
-# shell uses the scratch registry + scratch prefix + scratch npmrc.
+# PUBLIC_REGISTRY is the upstream we fetch verdaccio's own package
+# from. Required because once `NPM_CONFIG_REGISTRY` flips to the
+# scratch verdaccio (below, after it's up), a cold `npx -y
+# verdaccio@latest` would chicken-and-egg itself — npx would try to
+# fetch verdaccio's tarball from `http://127.0.0.1:$VERDACCIO_PORT/`
+# and get ECONNREFUSED before the registry has been launched.
+PUBLIC_REGISTRY="https://registry.npmjs.org/"
+
+# DKG_HOME, NPM_CONFIG_PREFIX, NPM_CONFIG_USERCONFIG can be exported
+# unconditionally — they don't affect the `npx verdaccio` fetch
+# (npx's own cache lives outside our scratch prefix). NPM_CONFIG_REGISTRY
+# is the dangerous one and is applied AFTER verdaccio is up.
 export NPM_CONFIG_USERCONFIG="$NPMRC"
 export NPM_CONFIG_PREFIX="$NPM_PREFIX"
-export NPM_CONFIG_REGISTRY="http://127.0.0.1:$VERDACCIO_PORT/"
 # `dkg init` and `dkg rollback` read DKG_HOME for state. Without this
 # they'd write into the operator's real ~/.dkg, polluting the host.
 export DKG_HOME="$DKG_HOME_DIR"
@@ -170,8 +179,14 @@ export DKG_HOME="$DKG_HOME_DIR"
 # `@origintrail-official/dkg` the operator might already have.
 export PATH="$NPM_PREFIX/bin:$PATH"
 
-log "stage 1: launching verdaccio"
-nohup npx -y verdaccio@latest --listen "$VERDACCIO_PORT" --config "$VERDACCIO_CONFIG" \
+log "stage 1: launching verdaccio (npx fetch via $PUBLIC_REGISTRY)"
+# Inline `NPM_CONFIG_REGISTRY` override for the npx subprocess only:
+# npx fetches verdaccio's tarball from the public registry, NOT from
+# the local verdaccio that doesn't exist yet. The export below
+# (after verdaccio is reachable) then flips NPM_CONFIG_REGISTRY to
+# the scratch instance for all subsequent npm/dkg invocations.
+NPM_CONFIG_REGISTRY="$PUBLIC_REGISTRY" nohup npx -y verdaccio@latest \
+  --listen "$VERDACCIO_PORT" --config "$VERDACCIO_CONFIG" \
   >"$VERDACCIO_LOG" 2>&1 &
 VERDACCIO_PID=$!
 
@@ -189,6 +204,11 @@ done
 if ! curl -fsS "http://127.0.0.1:$VERDACCIO_PORT/-/ping" >/dev/null 2>&1; then
   fail "verdaccio did not respond to /-/ping within 60s — see $VERDACCIO_LOG"
 fi
+
+# Verdaccio is now serving — safe to flip the default registry. Every
+# subsequent npm / dkg invocation in this shell now uses the scratch
+# verdaccio for resolution + publish.
+export NPM_CONFIG_REGISTRY="http://127.0.0.1:$VERDACCIO_PORT/"
 
 # ---------------------------------------------------------------------------
 # Stage 2 — pack every public workspace package, then a v2 of just the CLI.

--- a/scripts/devnet-test-edge-update.sh
+++ b/scripts/devnet-test-edge-update.sh
@@ -160,10 +160,17 @@ EOF
 # PUBLIC_REGISTRY is the upstream we fetch verdaccio's own package
 # from. Required because once `NPM_CONFIG_REGISTRY` flips to the
 # scratch verdaccio (below, after it's up), a cold `npx -y
-# verdaccio@latest` would chicken-and-egg itself — npx would try to
+# verdaccio@<pin>` would chicken-and-egg itself — npx would try to
 # fetch verdaccio's tarball from `http://127.0.0.1:$VERDACCIO_PORT/`
 # and get ECONNREFUSED before the registry has been launched.
 PUBLIC_REGISTRY="https://registry.npmjs.org/"
+
+# Verdaccio version is pinned to keep this gate reproducible — an
+# unpinned `@latest` would let an upstream Verdaccio release break
+# CI without any change in this repo. Bump deliberately by editing
+# this constant; verify the new version against the manual runbook
+# in docs/devnet/EDGE_UPDATE_VALIDATION.md before merging.
+VERDACCIO_VERSION="${VERDACCIO_VERSION:-6.7.2}"
 
 # DKG_HOME, NPM_CONFIG_PREFIX, NPM_CONFIG_USERCONFIG can be exported
 # unconditionally — they don't affect the `npx verdaccio` fetch
@@ -179,13 +186,13 @@ export DKG_HOME="$DKG_HOME_DIR"
 # `@origintrail-official/dkg` the operator might already have.
 export PATH="$NPM_PREFIX/bin:$PATH"
 
-log "stage 1: launching verdaccio (npx fetch via $PUBLIC_REGISTRY)"
+log "stage 1: launching verdaccio@$VERDACCIO_VERSION (npx fetch via $PUBLIC_REGISTRY)"
 # Inline `NPM_CONFIG_REGISTRY` override for the npx subprocess only:
 # npx fetches verdaccio's tarball from the public registry, NOT from
 # the local verdaccio that doesn't exist yet. The export below
 # (after verdaccio is reachable) then flips NPM_CONFIG_REGISTRY to
 # the scratch instance for all subsequent npm/dkg invocations.
-NPM_CONFIG_REGISTRY="$PUBLIC_REGISTRY" nohup npx -y verdaccio@latest \
+NPM_CONFIG_REGISTRY="$PUBLIC_REGISTRY" nohup npx -y "verdaccio@$VERDACCIO_VERSION" \
   --listen "$VERDACCIO_PORT" --config "$VERDACCIO_CONFIG" \
   >"$VERDACCIO_LOG" 2>&1 &
 VERDACCIO_PID=$!


### PR DESCRIPTION
## Summary

Follow-up to RFC-41 Bundle B (#753) — ships the §6.2 testing-gap
closer that didn't make it into the original Bundle B merge.

Closes the gap: unit tests in `packages/cli/test/rfc-41-bundle-b.test.ts`
already cover the LOGIC of `performNpmUpdateEdge` + `dkg rollback`
(Edge branch) with a mocked `_autoUpdateIo.exec`. This PR adds the
matching INTEGRATION suite that exercises the same code paths against
a real `npm install -g` against a real (local-verdaccio) registry.

**No production code changes** — pure test infrastructure + docs.
Bundle B's production behaviour is unchanged; this just adds an
operator-runnable + CI-runnable validation gate on top of it.

## What lands

- **`scripts/devnet-test-edge-update.sh`** — single script an operator
  can also run by hand. Boots verdaccio via `npx -y verdaccio@latest`,
  packs every public `packages/*` at v1 (mirrors
  `.github/workflows/npm-publish.yml`), bumps just the CLI to v2 and
  packs that, publishes all to verdaccio, runs `npm install -g v1`
  against a scratch `NPM_CONFIG_PREFIX`, bootstraps a minimal Edge
  config under a scratch `DKG_HOME`, runs `dkg update v2` (asserts
  `previous-version == v1` + binary reports v2), runs `dkg rollback`
  (asserts binary back to v1). Trap-on-EXIT cleans verdaccio + scratch
  root. `EDGE_UPDATE_KEEP_SCRATCH=1` preserves state for debugging.

- **`devnet/edge-update-flow/{package.json, vitest.config.ts,
  automated.test.ts}`** — thin vitest wrapper that shells out to the
  script and asserts per-stage progress markers + final PASS line.
  Same shape as the other `devnet/*` scenarios. Registered as
  `pnpm test:devnet:edge-update-flow` in root `package.json` and as a
  workspace member in `pnpm-workspace.yaml`.

- **`docs/devnet/EDGE_UPDATE_VALIDATION.md`** — operator runbook
  covering the automated path, the manual step-by-step (for debugging
  script failures), expected output, troubleshooting matrix, and
  tie-back to which CLI/auto-update code paths it gates.

## Design tradeoffs (explicit)

1. **Bypass `dkg init` in the script.** `init` is interactive
   (~12 prompts: name, relay, context graphs, API port, auto-update,
   chain RPC, hub address, auth, etc.) with no `--yes`/`--non-interactive`
   flag. Piping newlines is brittle (silently breaks the moment a
   prompt is added). The script's subject is the UPDATE flow; Bundle
   B's init contract (monorepo guard, `--role` parsing, explicit
   `autoUpdate.source: 'npm'` write) is already covered by unit tests
   in `packages/cli/test/rfc-41-bundle-b.test.ts`. Documented in the
   runbook.

2. **Publish all 15 public workspace packages to verdaccio, not just
   the CLI.** The CLI declares 10+ `workspace:*` deps. `pnpm pack`
   rewrites them to resolved semver, but the resulting tarball still
   needs each dep to be resolvable from whatever registry npm hits.
   Only publishing CLI would leave `npm install -g` hunting for
   `dkg-core@<v>` and failing. v2 is CLI-only because workspace deps
   haven't changed; v2 CLI's `^v1` ranges resolve against v1
   workspace deps already in verdaccio.

3. **Shell script + vitest wrapper hybrid** (not pure vitest).
   `npm install -g` reads `NPM_CONFIG_*` and `.npmrc` up front, not
   per-spawn — clean child-process boundary is the path of least
   resistance. AND the script doubles as the operator-runnable form,
   so the runbook in `docs/devnet/` is a direct copy-paste of what CI
   executes, no test-runner-specific glue.

## Test plan

Prerequisites (also documented in the runbook):

- [ ] `pnpm install` + `pnpm build` from repo root (so `packages/*/dist/`
  exists for `pnpm pack`).
- [ ] `npx -y verdaccio@latest --version` works on the host (warm cache).
- [ ] Port 4873 free, or pass `VERDACCIO_PORT=<free>`.

Then:

```bash
pnpm test:devnet:edge-update-flow
```

Or, for ad-hoc operator validation:

```bash
EDGE_UPDATE_KEEP_SCRATCH=1 ./scripts/devnet-test-edge-update.sh
```

Expected: `PASS — Edge npm-only update + rollback round-trip
(<v1> → <v2> → <v1>)` at the end. Runtime ~3-5 minutes.

## Refs

- RFC: [OT-RFC-41 §6.2](https://github.com/OriginTrail/dkgv10-spec/blob/main/rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md)
- Bundle A: #750 (merged)
- Bundle B: #753 (merged) — this PR is the §6.2 follow-up that didn't
  fit before B was merged

Made with [Cursor](https://cursor.com)