### PR TITLE
fix(agent,cli): receiver defensive cg-id lookup + RS backfill for pre-cd68fa689 KCs

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -12749,6 +12749,11 @@ export class DKGAgent {
         this.store,
         this.chain.chainId === 'none' ? undefined : this.chain,
         this.eventBus,
+        // Defensive: when a peer's finalization gossip omits
+        // `targetContextGraphId` (pre-cd68fa689 publisher in the mesh),
+        // resolve the on-chain id locally so per-cgId promotion still
+        // fires and the RS prover sees the KC.
+        (cgName: string) => this.getContextGraphOnChainId(cgName),
       );
     }
     return this.finalizationHandler;

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -19,17 +19,35 @@ import {
 const DKG_NS = 'http://dkg.io/ontology/';
 import { ethers } from 'ethers';
 
+/**
+ * Resolves a local context-graph id (the topic/CG name used in gossip) to
+ * its on-chain numeric id. Returns `null`/`undefined` for CGs that aren't
+ * registered on-chain. Used as a fallback when a peer-finalization gossip
+ * envelope omits `targetContextGraphId` (e.g. a pre-cd68fa689 publisher
+ * still in the mesh).
+ */
+export type ResolveContextGraphOnChainId = (
+  contextGraphId: string,
+) => Promise<string | null | undefined>;
+
 export class FinalizationHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
   private readonly eventBus: EventBus | undefined;
+  private readonly resolveContextGraphOnChainId: ResolveContextGraphOnChainId | undefined;
   private readonly log = new Logger('FinalizationHandler');
   private readonly processedUals = new Set<string>();
 
-  constructor(store: TripleStore, chain: ChainAdapter | undefined, eventBus?: EventBus) {
+  constructor(
+    store: TripleStore,
+    chain: ChainAdapter | undefined,
+    eventBus?: EventBus,
+    resolveContextGraphOnChainId?: ResolveContextGraphOnChainId,
+  ) {
     this.store = store;
     this.chain = chain;
     this.eventBus = eventBus;
+    this.resolveContextGraphOnChainId = resolveContextGraphOnChainId;
   }
 
   async handleFinalizationMessage(data: Uint8Array, contextGraphId: string): Promise<void> {
@@ -61,7 +79,29 @@ export class FinalizationHandler {
       const startKAId = protoToBigInt(msg.startKAId);
       const endKAId = protoToBigInt(msg.endKAId);
 
-      const ctxGraphId = msg.targetContextGraphId || undefined;
+      // The publisher's `cd68fa689` fix threads the resolved on-chain CG id
+      // into `targetContextGraphId` so receivers route SWM promotion into
+      // the per-cgId `<cgName>/context/<cgId>/_meta` graph that the RS
+      // prover reads from. Pre-fix publishers (or any publisher whose
+      // `getContextGraphOnChainId` lookup returns null at gossip time) emit
+      // `targetContextGraphId: undefined`, which used to silently downgrade
+      // the receiver to legacy `<cgName>/_meta` promotion — leaving the
+      // prover stuck on `kc-not-synced` until every publisher in the mesh
+      // ships the fix. As a belt-and-braces for rolling upgrades we resolve
+      // the id locally when the wire is empty; resolver failures or
+      // not-on-chain CGs fall back to legacy behavior unchanged.
+      let ctxGraphId = msg.targetContextGraphId || undefined;
+      if (!ctxGraphId && this.resolveContextGraphOnChainId) {
+        try {
+          const resolved = await this.resolveContextGraphOnChainId(contextGraphId);
+          if (resolved !== null && resolved !== undefined && String(resolved).length > 0) {
+            ctxGraphId = String(resolved);
+            this.log.info(ctx, `Finalization: gossip omitted targetContextGraphId; resolved locally to ${ctxGraphId} (defensive lookup)`);
+          }
+        } catch (err) {
+          this.log.warn(ctx, `Finalization: defensive on-chain CG id lookup failed for ${contextGraphId}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
 
       // Validate sub-graph name from gossip — reject invalid names entirely
       let subGraphName: string | undefined;

--- a/packages/agent/test/finalization-handler-defensive-cg-id.test.ts
+++ b/packages/agent/test/finalization-handler-defensive-cg-id.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { encodeFinalizationMessage, type FinalizationMessageMsg } from '@origintrail-official/dkg-core';
+import { FinalizationHandler, type ResolveContextGraphOnChainId } from '../src/finalization-handler.js';
+
+/**
+ * Regression tests for the receiver-side `ctxGraphId` resolution in
+ * `handleFinalizationMessage`.
+ *
+ * Two related bugs converge on the same line on the receiver side:
+ *
+ *  1. Pre-cd68fa689 publishers emitted `targetContextGraphId: undefined`
+ *     for every non-REMAP publish (the publish-from-SWM common path).
+ *     Receivers reading the wire literally then promoted SWM into the
+ *     legacy `<cgName>/_meta` graph instead of the per-cgId
+ *     `<cgName>/context/<cgId>/_meta` graph the RS prover reads from —
+ *     so the prover loop reported `kc-not-synced` for every challenge
+ *     on every KC the receiver didn't publish itself.
+ *
+ *     `cd68fa689` fixes the publisher to always plumb the resolved
+ *     on-chain CG id into the gossip envelope. These tests pin the
+ *     receiver-side behavior so a future refactor doesn't accidentally
+ *     re-introduce the "use it iff the wire has it" downgrade.
+ *
+ *  2. During rolling upgrades (one core ships the fix, another doesn't)
+ *     a stale publisher still floats `undefined` on the wire. To keep
+ *     an upgraded receiver useful in a mixed-version mesh we resolve
+ *     the on-chain id locally when the wire is empty, via a constructor-
+ *     injected callback that mirrors `DKGAgent#getContextGraphOnChainId`.
+ *
+ * Strategy
+ * ────────
+ * The dedup guard at the top of `handleFinalizationMessage` runs
+ *   ASK { GRAPH <metaGraph> { <ual> dkg:status "confirmed" } }
+ * where `metaGraph` is computed FROM the resolved `ctxGraphId`. We
+ * pre-seed a confirmed-status quad in each candidate meta graph and
+ * confirm the handler probes the right one (sanity-checked by also
+ * pre-seeding the OTHER meta graph and asserting it is NOT probed).
+ *
+ * Wrapping `store.query` to capture every SPARQL string the handler
+ * issues is the lightest way to observe which graph URI got built —
+ * we don't need to spin up a chain adapter, mock libp2p, or run merkle
+ * verification, all of which are exercised in the existing
+ * `e2e-publish-protocol.test.ts` round-trip.
+ */
+
+const CONTEXT_GRAPH = 'cg-finalize-defensive';
+const PER_CG_ID_FROM_GOSSIP = '5';
+const PER_CG_ID_FROM_RESOLVER = '7';
+const UAL = 'did:dkg:evm:31337/0xABC/1';
+const LEGACY_META_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
+const GOSSIP_PER_CG_META_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/context/${PER_CG_ID_FROM_GOSSIP}/_meta`;
+const RESOLVER_PER_CG_META_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/context/${PER_CG_ID_FROM_RESOLVER}/_meta`;
+
+function makeMsg(overrides?: Partial<FinalizationMessageMsg>): FinalizationMessageMsg {
+  return {
+    ual: UAL,
+    contextGraphId: CONTEXT_GRAPH,
+    kcMerkleRoot: new Uint8Array(32),
+    txHash: '0x' + 'ab'.repeat(32),
+    blockNumber: 100,
+    batchId: 1,
+    startKAId: 1,
+    endKAId: 2,
+    publisherAddress: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    rootEntities: ['urn:test:entity'],
+    timestampMs: Date.now(),
+    operationId: 'op-defensive-test',
+    ...overrides,
+  };
+}
+
+/**
+ * Wrap `store.query` to capture every SPARQL string the handler issues.
+ * Returns the underlying captured-strings array (mutated in place).
+ */
+function captureQueries(store: OxigraphStore): string[] {
+  const captured: string[] = [];
+  const orig = store.query.bind(store);
+  store.query = (async (sparql: string, ...rest: unknown[]) => {
+    captured.push(sparql);
+    return (orig as (s: string, ...r: unknown[]) => unknown)(sparql, ...rest);
+  }) as typeof store.query;
+  return captured;
+}
+
+/** Did any captured SPARQL string mention the given graph URI? */
+function queriedGraph(captured: string[], graphUri: string): boolean {
+  return captured.some((q) => q.includes(`<${graphUri}>`));
+}
+
+/**
+ * Seed a `<UAL> dkg:status "confirmed"` quad in the given meta graph so
+ * the handler's dedup ASK probe lights up and short-circuits processing.
+ * This is the same dedup mechanism the existing
+ * `finalization-handler.test.ts` "deduplicates messages with same UAL"
+ * test relies on.
+ */
+async function seedConfirmedAt(store: OxigraphStore, metaGraph: string): Promise<void> {
+  await store.insert([
+    {
+      subject: UAL,
+      predicate: 'http://dkg.io/ontology/status',
+      object: '"confirmed"',
+      graph: metaGraph,
+    },
+  ]);
+}
+
+describe('FinalizationHandler ctxGraphId resolution', () => {
+  let store: OxigraphStore;
+  let captured: string[];
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+    captured = captureQueries(store);
+  });
+
+  it('uses targetContextGraphId from the gossip envelope when present (cd68fa689 contract)', async () => {
+    // Pre-seed BOTH candidate meta graphs with the confirmed-status sentinel.
+    // The handler should dedup against the per-cgId graph (because the
+    // gossip envelope carries targetContextGraphId="5"); the legacy graph
+    // seed is a tripwire that lights up only on regression.
+    await seedConfirmedAt(store, GOSSIP_PER_CG_META_GRAPH);
+    await seedConfirmedAt(store, LEGACY_META_GRAPH);
+
+    const resolver = vi.fn<Parameters<ResolveContextGraphOnChainId>, ReturnType<ResolveContextGraphOnChainId>>(
+      () => Promise.resolve('UNEXPECTED'),
+    );
+    const handler = new FinalizationHandler(store, undefined, undefined, resolver);
+
+    const msg = makeMsg({ targetContextGraphId: PER_CG_ID_FROM_GOSSIP });
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CONTEXT_GRAPH);
+
+    expect(queriedGraph(captured, GOSSIP_PER_CG_META_GRAPH)).toBe(true);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the resolver when the gossip envelope omits targetContextGraphId', async () => {
+    // Pre-seed the resolver-target meta graph so dedup short-circuits there.
+    // The legacy graph stays empty — if we regress and skip the resolver,
+    // dedup will miss and the handler will proceed to the SWM lookup
+    // (which we'd observe via additional queries against the canonical
+    // workspace graph, NOT the resolver-target graph).
+    await seedConfirmedAt(store, RESOLVER_PER_CG_META_GRAPH);
+
+    const resolver = vi.fn<Parameters<ResolveContextGraphOnChainId>, ReturnType<ResolveContextGraphOnChainId>>(
+      () => Promise.resolve(PER_CG_ID_FROM_RESOLVER),
+    );
+    const handler = new FinalizationHandler(store, undefined, undefined, resolver);
+
+    const msg = makeMsg();
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CONTEXT_GRAPH);
+
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(resolver).toHaveBeenCalledWith(CONTEXT_GRAPH);
+    expect(queriedGraph(captured, RESOLVER_PER_CG_META_GRAPH)).toBe(true);
+    expect(queriedGraph(captured, LEGACY_META_GRAPH)).toBe(false);
+  });
+
+  it('falls back to the legacy meta URI when no resolver is wired (back-compat)', async () => {
+    await seedConfirmedAt(store, LEGACY_META_GRAPH);
+    const handler = new FinalizationHandler(store, undefined);
+
+    const msg = makeMsg();
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CONTEXT_GRAPH);
+
+    expect(queriedGraph(captured, LEGACY_META_GRAPH)).toBe(true);
+  });
+
+  it('falls back to the legacy meta URI when the resolver throws', async () => {
+    // Resolver failure must NOT poison finalization — the receiver should
+    // still attempt the legacy meta probe so we degrade gracefully to the
+    // pre-cd68fa689 behaviour rather than dropping the gossip on the floor.
+    await seedConfirmedAt(store, LEGACY_META_GRAPH);
+
+    const resolver = vi.fn<Parameters<ResolveContextGraphOnChainId>, ReturnType<ResolveContextGraphOnChainId>>(
+      () => Promise.reject(new Error('chain RPC dead')),
+    );
+    const handler = new FinalizationHandler(store, undefined, undefined, resolver);
+
+    const msg = makeMsg();
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CONTEXT_GRAPH);
+
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(queriedGraph(captured, LEGACY_META_GRAPH)).toBe(true);
+  });
+
+  it('falls back to the legacy meta URI when the resolver returns null (CG not on-chain)', async () => {
+    // A CG that exists locally but hasn't been registered on-chain returns
+    // null from `getContextGraphOnChainId`. Per-cgId promotion is
+    // meaningless in that case — the prover only ever samples on-chain
+    // CGs — so we keep the legacy semantics intact.
+    await seedConfirmedAt(store, LEGACY_META_GRAPH);
+
+    const resolver = vi.fn<Parameters<ResolveContextGraphOnChainId>, ReturnType<ResolveContextGraphOnChainId>>(
+      () => Promise.resolve(null),
+    );
+    const handler = new FinalizationHandler(store, undefined, undefined, resolver);
+
+    const msg = makeMsg();
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CONTEXT_GRAPH);
+
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(queriedGraph(captured, LEGACY_META_GRAPH)).toBe(true);
+  });
+
+  it('prefers gossip targetContextGraphId over the resolver (resolver never called)', async () => {
+    // Two-source-of-truth precedence test: when the wire carries an id
+    // AND a resolver is wired, the wire wins. This locks in the contract
+    // that publisher-side fix #758 is the canonical signal; the resolver
+    // is a strict fallback, not an override.
+    await seedConfirmedAt(store, GOSSIP_PER_CG_META_GRAPH);
+
+    const resolver = vi.fn<Parameters<ResolveContextGraphOnChainId>, ReturnType<ResolveContextGraphOnChainId>>(
+      () => Promise.resolve('99'),
+    );
+    const handler = new FinalizationHandler(store, undefined, undefined, resolver);
+
+    const msg = makeMsg({ targetContextGraphId: PER_CG_ID_FROM_GOSSIP });
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(msg), CONTEXT_GRAPH);
+
+    expect(resolver).not.toHaveBeenCalled();
+    expect(queriedGraph(captured, GOSSIP_PER_CG_META_GRAPH)).toBe(true);
+    expect(queriedGraph(captured, `did:dkg:context-graph:${CONTEXT_GRAPH}/context/99/_meta`)).toBe(false);
+  });
+});

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -968,21 +968,27 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
   // prover tick returns `kc-not-synced`.
   //
   // For each subscribed CG that has an on-chain id, we copy the
-  // per-KC subset of `<cgName>/_meta` (subjects with a `dkg:batchId`
-  // triple, plus the KA UALs they reference via `dkg:partOf`, plus the
-  // publication URIs referenced via `dkg:authoredBy`) into
-  // `<cgName>/context/<cgId>/_meta`. Mirrors the publisher's own
-  // promotion in `dkg-publisher.ts:1407-1422` so the prover sees the
-  // exact same shape it would have seen on a fresh publish.
+  // per-KC subset of `<cgName>/_meta` into
+  // `<cgName>/context/<cgId>/_meta`. The "per-KC subset" matches the
+  // shape `generateKCMetadata` emits (`packages/publisher/src/metadata.ts`):
+  //   - KC UAL subjects (carry `dkg:batchId`, `dkg:merkleRoot`, `dkg:status`, …).
+  //   - KA UAL subjects (`<UAL/tokenId>`; identified by `dkg:partOf <KC>`).
+  //   - Publication URIs (`<urn:dkg:publication:opId>`; reached from a KA
+  //     via `<KA> dkg:publication <pub>`; carry `dkg:authoredBy`,
+  //     `dkg:Publication` type, etc).
+  //
+  // Granularity is PER-KC, not per-CG: each KC is gated by an
+  // independent `FILTER NOT EXISTS` against the target graph, so a
+  // mixed-state CG (some pre-fix KCs orphaned at `<cg>/_meta`, some
+  // post-fix KCs already in the per-cgId graph) gets only the missing
+  // KCs copied. Re-running the backfill after additional post-fix
+  // publishes is a no-op for KCs already present in the target.
   //
   // Body (all fields optional):
   //   {
   //     "contextGraphIds": ["foo", "bar"], // restrict to specific CG names; omit/empty for all subscribed
   //     "dryRun": true                     // probe-only: don't write, just report what would happen
   //   }
-  //
-  // Idempotent. Cores that already have a populated per-cgId meta graph
-  // are skipped with `status: "already-populated"`.
   if (req.method === 'POST' && path === '/api/random-sampling/backfill-percgid-meta') {
     const body = await readBody(req, SMALL_BODY_BYTES);
     let parsed: { contextGraphIds?: unknown; dryRun?: unknown };
@@ -1000,9 +1006,12 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       contextGraphId: string;
       onChainId?: string;
       status: 'backfilled' | 'already-populated' | 'no-source-meta' | 'not-on-chain' | 'failed';
+      /** Total triples written (or that would be written, in dry-run). */
       copiedTriples?: number;
-      sourceTripleCount?: number;
-      preExistingTargetTripleCount?: number;
+      /** Distinct KCs that needed backfilling (rows where source had a KC absent from target). */
+      copiedKcCount?: number;
+      /** Distinct KCs present in `<cg>/_meta` regardless of target state — observability signal. */
+      sourceKcCount?: number;
       error?: string;
     };
 
@@ -1017,6 +1026,10 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       cgEntries.push([cgName, String(sub.onChainId)]);
     }
 
+    const DKG_BATCH_ID = 'http://dkg.io/ontology/batchId';
+    const DKG_PART_OF = 'http://dkg.io/ontology/partOf';
+    const DKG_PUBLICATION = 'http://dkg.io/ontology/publication';
+
     const reports: CgReport[] = [];
     for (const [cgName, onChainId] of cgEntries) {
       if (!onChainId) {
@@ -1026,52 +1039,82 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       const sourceMeta = `did:dkg:context-graph:${cgName}/_meta`;
       const targetMeta = contextGraphMetaUri(cgName, onChainId);
       try {
-        const preCount = await agent.store.query(
-          `SELECT (COUNT(*) AS ?n) WHERE { GRAPH <${targetMeta}> { ?s ?p ?o } }`,
+        // Total distinct KCs present in source — observability counter.
+        // Includes both KCs that need copying and KCs already in target.
+        const sourceKcResult = await agent.store.query(
+          `SELECT (COUNT(DISTINCT ?kc) AS ?n) WHERE { GRAPH <${sourceMeta}> { ?kc <${DKG_BATCH_ID}> ?bid } }`,
         );
-        const preTriples = preCount.type === 'bindings'
-          ? Number((preCount.bindings[0]?.['n'] as string ?? '"0"').replace(/^"|".*$/g, ''))
+        const sourceKcCount = sourceKcResult.type === 'bindings'
+          ? Number((sourceKcResult.bindings[0]?.['n'] as string ?? '"0"').replace(/^"|".*$/g, ''))
           : 0;
-        if (preTriples > 0) {
-          reports.push({
-            contextGraphId: cgName,
-            onChainId,
-            status: 'already-populated',
-            preExistingTargetTripleCount: preTriples,
-          });
+
+        if (sourceKcCount === 0) {
+          reports.push({ contextGraphId: cgName, onChainId, status: 'no-source-meta', sourceKcCount: 0 });
           continue;
         }
 
-        // CONSTRUCT the per-KC subset of source meta — three disjoint
-        // patterns matching the publisher's own promotion filter:
-        //   1. KC UAL subjects (have `dkg:batchId`).
-        //   2. KA UAL subjects (have `dkg:partOf <KC>` where KC has `dkg:batchId`).
-        //   3. Publication URIs referenced from a KC via `dkg:authoredBy`.
-        // SPARQL union ⇒ each ?s ?p ?o is duplicated per matching
-        // arm; store.insert is set-based so duplicates collapse.
+        // CONSTRUCT only the meta for KCs that are MISSING from the
+        // target per-cgId graph. Three UNION arms:
+        //   1. KC subjects (`?kc`) whose `dkg:batchId` is in source
+        //      but not in target.
+        //   2. KA subjects (`?ka`) whose parent KC is in that
+        //      missing-from-target set.
+        //   3. Publication subjects (`?pub`) reached from a KA via
+        //      `<KA> dkg:publication <pub>`. This is the actual
+        //      provenance shape `generateKCMetadata` emits — earlier
+        //      revisions of this endpoint used the wrong direction
+        //      (`<KC> dkg:authoredBy <pub>`) and silently dropped all
+        //      `dkg:Publication` / `dkg:authoredBy` triples (Codex
+        //      review on PR #763).
+        //
+        // The `FILTER NOT EXISTS` is anchored on the KC's `dkg:batchId`
+        // because every per-KC promotion writes that triple — so its
+        // presence in the target is the canonical signal that the KC
+        // (and its KAs + publication) are already there. Set semantics
+        // of `store.insert` mean accidentally re-inserting a quad is a
+        // no-op; the filter is for efficiency + clean diagnostic
+        // counts, not for correctness.
         const constructResult = await agent.store.query(`CONSTRUCT { ?s ?p ?o } WHERE {
           GRAPH <${sourceMeta}> {
             {
               ?s ?p ?o .
-              ?s <http://dkg.io/ontology/batchId> ?bid .
+              ?s <${DKG_BATCH_ID}> ?bid .
+              FILTER NOT EXISTS { GRAPH <${targetMeta}> { ?s <${DKG_BATCH_ID}> ?bidT } }
             } UNION {
               ?s ?p ?o .
-              ?s <http://dkg.io/ontology/partOf> ?kc .
-              ?kc <http://dkg.io/ontology/batchId> ?bid2 .
+              ?s <${DKG_PART_OF}> ?kc .
+              ?kc <${DKG_BATCH_ID}> ?bid2 .
+              FILTER NOT EXISTS { GRAPH <${targetMeta}> { ?kc <${DKG_BATCH_ID}> ?bidT2 } }
             } UNION {
               ?s ?p ?o .
-              ?kc2 <http://dkg.io/ontology/authoredBy> ?s .
-              ?kc2 <http://dkg.io/ontology/batchId> ?bid3 .
+              ?ka <${DKG_PUBLICATION}> ?s .
+              ?ka <${DKG_PART_OF}> ?kc3 .
+              ?kc3 <${DKG_BATCH_ID}> ?bid3 .
+              FILTER NOT EXISTS { GRAPH <${targetMeta}> { ?kc3 <${DKG_BATCH_ID}> ?bidT3 } }
             }
           }
         }`);
         const sourceQuads = constructResult.type === 'quads' ? constructResult.quads : [];
+
+        // Distinct KCs in the construct result — every backfilled KC
+        // shows up as at least one quad with itself as subject (the
+        // first UNION arm). De-duplicating by subject is the cleanest
+        // way to derive a per-KC count without a second SPARQL probe.
+        const copiedKcCount = new Set(
+          sourceQuads
+            .filter(q => sourceQuads.some(qq => qq.subject === q.subject && qq.predicate === DKG_BATCH_ID))
+            .map(q => q.subject),
+        ).size;
+
         if (sourceQuads.length === 0) {
+          // Source has KCs but none are missing from target — fully synced.
           reports.push({
             contextGraphId: cgName,
             onChainId,
-            status: 'no-source-meta',
-            sourceTripleCount: 0,
+            status: 'already-populated',
+            sourceKcCount,
+            copiedKcCount: 0,
+            copiedTriples: 0,
           });
           continue;
         }
@@ -1081,8 +1124,9 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
             contextGraphId: cgName,
             onChainId,
             status: 'backfilled',
+            sourceKcCount,
+            copiedKcCount,
             copiedTriples: sourceQuads.length,
-            sourceTripleCount: sourceQuads.length,
           });
           continue;
         }
@@ -1094,8 +1138,9 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
           contextGraphId: cgName,
           onChainId,
           status: 'backfilled',
+          sourceKcCount,
+          copiedKcCount,
           copiedTriples: targeted.length,
-          sourceTripleCount: sourceQuads.length,
         });
       } catch (err) {
         reports.push({

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -1026,6 +1026,15 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       cgEntries.push([cgName, String(sub.onChainId)]);
     }
 
+    // Operator-typo guard: requested CG names that don't match any
+    // subscribed CG on this node are surfaced explicitly so a no-op
+    // run is diagnosable. Without this, a typo like
+    // `miles-publish-stress-26mayyy` yields `processed: 0` and looks
+    // identical to "nothing needed backfilling". (Codex review on PR
+    // #763, round 2.)
+    const subscribedNames = new Set(subscribed.keys());
+    const unknownContextGraphIds = requestedIds.filter((id) => !subscribedNames.has(id));
+
     const DKG_BATCH_ID = 'http://dkg.io/ontology/batchId';
     const DKG_PART_OF = 'http://dkg.io/ontology/partOf';
     const DKG_PUBLICATION = 'http://dkg.io/ontology/publication';
@@ -1162,6 +1171,10 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         notOnChain: reports.filter(r => r.status === 'not-on-chain').length,
         failed: reports.filter(r => r.status === 'failed').length,
       },
+      // Always included so the script/operator can `.length > 0`-check.
+      // Empty array when no filter was supplied or every requested CG
+      // resolved against the local subscription set.
+      unknownContextGraphIds,
       reports,
     });
   }

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -957,6 +957,170 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     return jsonResponse(res, 200, status);
   }
 
+  // POST /api/random-sampling/backfill-percgid-meta
+  //
+  // One-shot operator tool to rescue KCs that landed on a receiver core
+  // BEFORE the cd68fa689 publisher fix (or before the receiver shipped
+  // the defensive `ctxGraphId` lookup). Such KCs have their per-KC
+  // metadata sitting at the canonical `<cgName>/_meta` URI, but the RS
+  // prover's `extractV10KCFromStore` reads the per-cgId
+  // `<cgName>/context/<cgId>/_meta` graph and so sees nothing — every
+  // prover tick returns `kc-not-synced`.
+  //
+  // For each subscribed CG that has an on-chain id, we copy the
+  // per-KC subset of `<cgName>/_meta` (subjects with a `dkg:batchId`
+  // triple, plus the KA UALs they reference via `dkg:partOf`, plus the
+  // publication URIs referenced via `dkg:authoredBy`) into
+  // `<cgName>/context/<cgId>/_meta`. Mirrors the publisher's own
+  // promotion in `dkg-publisher.ts:1407-1422` so the prover sees the
+  // exact same shape it would have seen on a fresh publish.
+  //
+  // Body (all fields optional):
+  //   {
+  //     "contextGraphIds": ["foo", "bar"], // restrict to specific CG names; omit/empty for all subscribed
+  //     "dryRun": true                     // probe-only: don't write, just report what would happen
+  //   }
+  //
+  // Idempotent. Cores that already have a populated per-cgId meta graph
+  // are skipped with `status: "already-populated"`.
+  if (req.method === 'POST' && path === '/api/random-sampling/backfill-percgid-meta') {
+    const body = await readBody(req, SMALL_BODY_BYTES);
+    let parsed: { contextGraphIds?: unknown; dryRun?: unknown };
+    try {
+      parsed = body.trim() ? JSON.parse(body) : {};
+    } catch {
+      return jsonResponse(res, 400, { error: 'Invalid JSON body' });
+    }
+    const requestedIds = Array.isArray(parsed.contextGraphIds)
+      ? (parsed.contextGraphIds as unknown[]).filter((x): x is string => typeof x === 'string' && x.length > 0)
+      : [];
+    const dryRun = parsed.dryRun === true;
+
+    type CgReport = {
+      contextGraphId: string;
+      onChainId?: string;
+      status: 'backfilled' | 'already-populated' | 'no-source-meta' | 'not-on-chain' | 'failed';
+      copiedTriples?: number;
+      sourceTripleCount?: number;
+      preExistingTargetTripleCount?: number;
+      error?: string;
+    };
+
+    const subscribed = agent.getSubscribedContextGraphs();
+    const cgEntries: Array<[string, string]> = [];
+    for (const [cgName, sub] of subscribed) {
+      if (requestedIds.length > 0 && !requestedIds.includes(cgName)) continue;
+      if (!sub.onChainId) {
+        cgEntries.push([cgName, '']);
+        continue;
+      }
+      cgEntries.push([cgName, String(sub.onChainId)]);
+    }
+
+    const reports: CgReport[] = [];
+    for (const [cgName, onChainId] of cgEntries) {
+      if (!onChainId) {
+        reports.push({ contextGraphId: cgName, status: 'not-on-chain' });
+        continue;
+      }
+      const sourceMeta = `did:dkg:context-graph:${cgName}/_meta`;
+      const targetMeta = contextGraphMetaUri(cgName, onChainId);
+      try {
+        const preCount = await agent.store.query(
+          `SELECT (COUNT(*) AS ?n) WHERE { GRAPH <${targetMeta}> { ?s ?p ?o } }`,
+        );
+        const preTriples = preCount.type === 'bindings'
+          ? Number((preCount.bindings[0]?.['n'] as string ?? '"0"').replace(/^"|".*$/g, ''))
+          : 0;
+        if (preTriples > 0) {
+          reports.push({
+            contextGraphId: cgName,
+            onChainId,
+            status: 'already-populated',
+            preExistingTargetTripleCount: preTriples,
+          });
+          continue;
+        }
+
+        // CONSTRUCT the per-KC subset of source meta — three disjoint
+        // patterns matching the publisher's own promotion filter:
+        //   1. KC UAL subjects (have `dkg:batchId`).
+        //   2. KA UAL subjects (have `dkg:partOf <KC>` where KC has `dkg:batchId`).
+        //   3. Publication URIs referenced from a KC via `dkg:authoredBy`.
+        // SPARQL union ⇒ each ?s ?p ?o is duplicated per matching
+        // arm; store.insert is set-based so duplicates collapse.
+        const constructResult = await agent.store.query(`CONSTRUCT { ?s ?p ?o } WHERE {
+          GRAPH <${sourceMeta}> {
+            {
+              ?s ?p ?o .
+              ?s <http://dkg.io/ontology/batchId> ?bid .
+            } UNION {
+              ?s ?p ?o .
+              ?s <http://dkg.io/ontology/partOf> ?kc .
+              ?kc <http://dkg.io/ontology/batchId> ?bid2 .
+            } UNION {
+              ?s ?p ?o .
+              ?kc2 <http://dkg.io/ontology/authoredBy> ?s .
+              ?kc2 <http://dkg.io/ontology/batchId> ?bid3 .
+            }
+          }
+        }`);
+        const sourceQuads = constructResult.type === 'quads' ? constructResult.quads : [];
+        if (sourceQuads.length === 0) {
+          reports.push({
+            contextGraphId: cgName,
+            onChainId,
+            status: 'no-source-meta',
+            sourceTripleCount: 0,
+          });
+          continue;
+        }
+
+        if (dryRun) {
+          reports.push({
+            contextGraphId: cgName,
+            onChainId,
+            status: 'backfilled',
+            copiedTriples: sourceQuads.length,
+            sourceTripleCount: sourceQuads.length,
+          });
+          continue;
+        }
+
+        const targeted = sourceQuads.map(q => ({ ...q, graph: targetMeta }));
+        await agent.store.insert(targeted);
+
+        reports.push({
+          contextGraphId: cgName,
+          onChainId,
+          status: 'backfilled',
+          copiedTriples: targeted.length,
+          sourceTripleCount: sourceQuads.length,
+        });
+      } catch (err) {
+        reports.push({
+          contextGraphId: cgName,
+          onChainId,
+          status: 'failed',
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return jsonResponse(res, 200, {
+      dryRun,
+      processed: reports.length,
+      summary: {
+        backfilled: reports.filter(r => r.status === 'backfilled').length,
+        alreadyPopulated: reports.filter(r => r.status === 'already-populated').length,
+        noSourceMeta: reports.filter(r => r.status === 'no-source-meta').length,
+        notOnChain: reports.filter(r => r.status === 'not-on-chain').length,
+        failed: reports.filter(r => r.status === 'failed').length,
+      },
+      reports,
+    });
+  }
+
   // POST /api/shutdown
   if (req.method === "POST" && path === "/api/shutdown") {
     jsonResponse(res, 200, { ok: true });

--- a/packages/cli/test/backfill-rs-percgid-meta-route.test.ts
+++ b/packages/cli/test/backfill-rs-percgid-meta-route.test.ts
@@ -6,45 +6,84 @@ import { OxigraphStore } from '@origintrail-official/dkg-storage';
  * Endpoint test for `POST /api/random-sampling/backfill-percgid-meta`.
  *
  * The endpoint reads the canonical `<cgName>/_meta` graph, picks the
- * per-KC subset (subjects with `dkg:batchId`, the KA UALs they
- * reference via `dkg:partOf`, and the publication URIs referenced via
- * `dkg:authoredBy`), and copies that subset into the per-cgId
- * `<cgName>/context/<cgId>/_meta` graph that the RS prover
- * (`kc-extractor.ts`) reads from.
+ * per-KC subset (`generateKCMetadata` shape from
+ * `packages/publisher/src/metadata.ts`):
  *
- * Pre-cd68fa689 publishers gossiped finalization without a
- * `targetContextGraphId`, so receivers settled the per-KC meta at
- * the legacy URI; nothing in the post-fix code path puts it where it
- * belongs in retrospect. This endpoint is the one-shot operator
- * rescue for that historical state.
+ *   - KC UAL subjects (`dkg:batchId` + many siblings).
+ *   - KA UAL subjects (`<UAL/tokenId>`; carry `dkg:partOf <KC>`).
+ *   - Publication URIs (`urn:dkg:publication:<opId>`); reached from a
+ *     KA via `<KA> dkg:publication <pub>`. The publication node itself
+ *     carries `dkg:authoredBy`, `dkg:Publication` type, etc.
+ *
+ * Per-KC granularity is the headline contract: each KC is gated by an
+ * independent `FILTER NOT EXISTS` against the target graph, so a
+ * mixed-state CG (some pre-fix KCs orphaned at `<cg>/_meta`, some
+ * post-fix KCs already in the per-cgId graph) gets only the missing
+ * KCs copied. Earlier revisions of this endpoint short-circuited on
+ * "any triple in target" — Codex review on PR #763 pointed out that
+ * this would silently skip the rescue on every CG that received even
+ * a single post-fix publish.
  */
 
 const { handleStatusRoutes } = await import('../src/daemon/routes/status.js');
 
+type KcEntry = {
+  ual: string;
+  batchId: number;
+  rootEntity: string;
+  tokenId: number;
+  /** When set, emit a `dkg:Publication` node + `<KA> dkg:publication <pubUri>` link.
+   *  Mirrors `generateKCMetadata` (`metadata.ts:172-185`). */
+  publication?: { opId: string; author: string; merkleRootHex: string };
+};
+
 type CGEntry = {
   name: string;
   onChainId: string;
-  /** Pre-seed canonical meta with N per-KC entries. */
-  kcEntries?: Array<{ ual: string; batchId: number; rootEntity: string; tokenId: number }>;
-  /** Pre-seed an extra non-KC subject in the canonical meta so the
-   *  endpoint's filter can be verified — should NOT be copied. */
+  kcEntries?: KcEntry[];
   cgLifecycleSubject?: { subject: string; predicate: string; object: string };
 };
 
-function seedCanonicalMeta(store: OxigraphStore, cg: CGEntry): void {
+const DKG_NS = 'http://dkg.io/ontology/';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+/**
+ * How many quads `seedCanonicalMeta` emits for one KC. Exposed so
+ * counting assertions in the tests stay readable.
+ *   3 KC triples (batchId, kaCount, status)
+ * + 3 KA triples (partOf, rootEntity, tokenId)
+ * + 1 KA→pub link (when `publication` set)
+ * + 5 publication triples (when `publication` set)
+ */
+function tripleCountForKc(kc: KcEntry): number {
+  return 6 + (kc.publication ? 1 + 5 : 0);
+}
+
+function seedCanonicalMeta(store: OxigraphStore, cg: CGEntry, graphOverride?: string): void {
   if (!cg.kcEntries) return;
-  const metaGraph = `did:dkg:context-graph:${cg.name}/_meta`;
+  const metaGraph = graphOverride ?? `did:dkg:context-graph:${cg.name}/_meta`;
   const quads: Array<{ subject: string; predicate: string; object: string; graph: string }> = [];
   for (const kc of cg.kcEntries) {
+    const kaUri = `${kc.ual}/${kc.tokenId}`;
     quads.push(
-      { subject: kc.ual, predicate: 'http://dkg.io/ontology/batchId', object: `"${kc.batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
-      { subject: kc.ual, predicate: 'http://dkg.io/ontology/kaCount', object: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>', graph: metaGraph },
-      { subject: kc.ual, predicate: 'http://dkg.io/ontology/status', object: '"confirmed"', graph: metaGraph },
-      // KA-level subject (resolved via partOf → KC has batchId).
-      { subject: `${kc.ual}/${kc.tokenId}`, predicate: 'http://dkg.io/ontology/partOf', object: kc.ual, graph: metaGraph },
-      { subject: `${kc.ual}/${kc.tokenId}`, predicate: 'http://dkg.io/ontology/rootEntity', object: kc.rootEntity, graph: metaGraph },
-      { subject: `${kc.ual}/${kc.tokenId}`, predicate: 'http://dkg.io/ontology/tokenId', object: `"${kc.tokenId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
+      { subject: kc.ual, predicate: `${DKG_NS}batchId`, object: `"${kc.batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
+      { subject: kc.ual, predicate: `${DKG_NS}kaCount`, object: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>', graph: metaGraph },
+      { subject: kc.ual, predicate: `${DKG_NS}status`, object: '"confirmed"', graph: metaGraph },
+      { subject: kaUri, predicate: `${DKG_NS}partOf`, object: kc.ual, graph: metaGraph },
+      { subject: kaUri, predicate: `${DKG_NS}rootEntity`, object: kc.rootEntity, graph: metaGraph },
+      { subject: kaUri, predicate: `${DKG_NS}tokenId`, object: `"${kc.tokenId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
     );
+    if (kc.publication) {
+      const pubUri = `urn:dkg:publication:${kc.publication.opId}`;
+      quads.push(
+        { subject: kaUri, predicate: `${DKG_NS}publication`, object: pubUri, graph: metaGraph },
+        { subject: pubUri, predicate: RDF_TYPE, object: `${DKG_NS}Publication`, graph: metaGraph },
+        { subject: pubUri, predicate: `${DKG_NS}publishOperationId`, object: `"${kc.publication.opId}"`, graph: metaGraph },
+        { subject: pubUri, predicate: `${DKG_NS}contextGraphId`, object: `"${cg.name}"`, graph: metaGraph },
+        { subject: pubUri, predicate: `${DKG_NS}merkleRoot`, object: `"${kc.publication.merkleRootHex}"^^<http://www.w3.org/2001/XMLSchema#hexBinary>`, graph: metaGraph },
+        { subject: pubUri, predicate: `${DKG_NS}authoredBy`, object: `"${kc.publication.author}"`, graph: metaGraph },
+      );
+    }
   }
   if (cg.cgLifecycleSubject) {
     quads.push({ ...cg.cgLifecycleSubject, graph: metaGraph });
@@ -64,9 +103,6 @@ function makeAgentMock(opts: { store: OxigraphStore; cgs: Array<{ name: string; 
     publisher: { getIdentityId: () => 0n },
     store: opts.store,
     getSubscribedContextGraphs: () => subscribed,
-    // The endpoint doesn't call these but the ctx shape includes them
-    // through unrelated routes — keep them noop-safe in case any
-    // sibling guard touches them.
     getRandomSamplingStatus: () => ({ enabled: false, role: 'edge' }),
   };
 }
@@ -157,16 +193,14 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
   it('copies per-KC meta from <cg>/_meta to <cg>/context/<cgId>/_meta for an on-chain CG', async () => {
     const cgName = 'rs-backfill-happy';
     const onChainId = '42';
-    seedCanonicalMeta(store, {
-      name: cgName,
-      onChainId,
-      kcEntries: [
-        { ual: 'did:dkg:base:84532/0xAAA/1000001', batchId: 7, rootEntity: 'urn:test:e1', tokenId: 1 },
-        { ual: 'did:dkg:base:84532/0xAAA/2000001', batchId: 8, rootEntity: 'urn:test:e2', tokenId: 1 },
-      ],
-    });
+    const kcs: KcEntry[] = [
+      { ual: 'did:dkg:base:84532/0xAAA/1000001', batchId: 7, rootEntity: 'urn:test:e1', tokenId: 1 },
+      { ual: 'did:dkg:base:84532/0xAAA/2000001', batchId: 8, rootEntity: 'urn:test:e2', tokenId: 1 },
+    ];
+    seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: kcs });
     agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
 
+    const expectedTriples = kcs.reduce((acc, kc) => acc + tripleCountForKc(kc), 0);
     const before = await countTriples(store, `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`);
     expect(before).toBe(0);
 
@@ -178,30 +212,144 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
     const body: any = await res.json();
     expect(res.status).toBe(200);
     expect(body.summary).toMatchObject({ backfilled: 1, alreadyPopulated: 0, failed: 0 });
-
-    const after = await countTriples(store, `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`);
-    // 2 KCs × (3 KC-level + 3 KA-level) = 12 triples.
-    expect(after).toBe(12);
     expect(body.reports[0]).toMatchObject({
       contextGraphId: cgName,
       onChainId,
       status: 'backfilled',
-      copiedTriples: 12,
+      sourceKcCount: 2,
+      copiedKcCount: 2,
+      copiedTriples: expectedTriples,
     });
+
+    const after = await countTriples(store, `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`);
+    expect(after).toBe(expectedTriples);
   });
 
-  it('skips already-populated per-cgId meta graphs (idempotent)', async () => {
+  it('per-KC granularity: mixed-state CG only backfills KCs missing from target', async () => {
+    // Regression for Codex review on PR #763: an earlier revision
+    // short-circuited the whole CG when COUNT(*) > 0 in target,
+    // which silently skipped historical KCs on any CG that had
+    // received even one post-fix publish.
+    const cgName = 'rs-backfill-mixed-state';
+    const onChainId = '101';
+    const kcAlreadyInTarget: KcEntry = {
+      ual: 'did:dkg:base:84532/0xMIX/1000001', batchId: 51, rootEntity: 'urn:mix:already', tokenId: 1,
+    };
+    const kcOrphaned: KcEntry = {
+      ual: 'did:dkg:base:84532/0xMIX/2000001', batchId: 52, rootEntity: 'urn:mix:orphan', tokenId: 1,
+    };
+
+    // Source has BOTH KCs (canonical `<cg>/_meta` is the catch-all
+    // where every receiver landing wrote before the publisher fix).
+    seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kcAlreadyInTarget, kcOrphaned] });
+
+    // Target has only the first KC (simulating one post-fix publish).
+    seedCanonicalMeta(
+      store,
+      { name: cgName, onChainId, kcEntries: [kcAlreadyInTarget] },
+      `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`,
+    );
+    const targetBefore = await countTriples(store, `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`);
+    expect(targetBefore).toBe(tripleCountForKc(kcAlreadyInTarget));
+
+    agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.reports[0]).toMatchObject({
+      contextGraphId: cgName,
+      onChainId,
+      status: 'backfilled',
+      sourceKcCount: 2,
+      copiedKcCount: 1,
+      copiedTriples: tripleCountForKc(kcOrphaned),
+    });
+
+    const target = `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`;
+    const targetAfter = await countTriples(store, target);
+    // Target = (1 KC pre-existing) + (1 KC backfilled). De-duplicated by set semantics.
+    expect(targetAfter).toBe(tripleCountForKc(kcAlreadyInTarget) + tripleCountForKc(kcOrphaned));
+
+    // Tripwire: the originally-present KC's triples were NOT re-copied
+    // (FILTER NOT EXISTS gated it out) — only the orphan KC's were.
+    const ask = await store.query(
+      `ASK { GRAPH <${target}> { <${kcOrphaned.ual}> <${DKG_NS}batchId> ?o } }`,
+    );
+    expect(ask.type).toBe('boolean');
+    if (ask.type === 'boolean') expect(ask.value).toBe(true);
+  });
+
+  it('preserves dkg:Publication / dkg:authoredBy provenance for backfilled KCs', async () => {
+    // Regression for Codex review on PR #763: an earlier revision
+    // matched provenance via `?kc dkg:authoredBy ?pub` — the wrong
+    // direction. `generateKCMetadata` emits `<KA> dkg:publication <pub>`
+    // and the publication node ITSELF carries `dkg:authoredBy`. The
+    // fix follows the KA→pub link.
+    const cgName = 'rs-backfill-provenance';
+    const onChainId = '202';
+    const opId = 'op-fixture-2026';
+    const author = '0x600AB8102eB4EFA9De4eFF2f4069D7a2D4c8A8fe';
+    const kc: KcEntry = {
+      ual: 'did:dkg:base:84532/0xPRV/9000001', batchId: 73, rootEntity: 'urn:prov:root', tokenId: 1,
+      publication: { opId, author, merkleRootHex: '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff' },
+    };
+    seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kc] });
+    agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.summary).toMatchObject({ backfilled: 1 });
+
+    // The publication URI MUST be in the target with its dkg:authoredBy.
+    const target = `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`;
+    const pubUri = `urn:dkg:publication:${opId}`;
+    const authorAsk = await store.query(
+      `ASK { GRAPH <${target}> { <${pubUri}> <${DKG_NS}authoredBy> ?author } }`,
+    );
+    expect(authorAsk.type).toBe('boolean');
+    if (authorAsk.type === 'boolean') expect(authorAsk.value).toBe(true);
+
+    const typeAsk = await store.query(
+      `ASK { GRAPH <${target}> { <${pubUri}> <${RDF_TYPE}> <${DKG_NS}Publication> } }`,
+    );
+    expect(typeAsk.type).toBe('boolean');
+    if (typeAsk.type === 'boolean') expect(typeAsk.value).toBe(true);
+
+    // And the KA→pub link is preserved so future readers can resolve
+    // provenance from either direction.
+    const kaPubAsk = await store.query(
+      `ASK { GRAPH <${target}> { <${kc.ual}/${kc.tokenId}> <${DKG_NS}publication> <${pubUri}> } }`,
+    );
+    expect(kaPubAsk.type).toBe('boolean');
+    if (kaPubAsk.type === 'boolean') expect(kaPubAsk.value).toBe(true);
+  });
+
+  it('reports already-populated when every source KC is already in target (idempotent)', async () => {
     const cgName = 'rs-backfill-idempotent';
     const onChainId = '99';
-    seedCanonicalMeta(store, {
-      name: cgName,
-      onChainId,
-      kcEntries: [{ ual: 'did:dkg:base:84532/0xBBB/3000001', batchId: 11, rootEntity: 'urn:test:e3', tokenId: 1 }],
-    });
-    // Pre-seed the per-cgId graph so the endpoint sees it as already done.
-    await store.insert([
-      { subject: 'did:dkg:base:84532/0xBBB/3000001', predicate: 'http://dkg.io/ontology/status', object: '"confirmed"', graph: `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta` },
-    ]);
+    const kc: KcEntry = {
+      ual: 'did:dkg:base:84532/0xBBB/3000001', batchId: 11, rootEntity: 'urn:test:e3', tokenId: 1,
+    };
+    seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kc] });
+    // Pre-seed the per-cgId graph with the SAME KC's `dkg:batchId` —
+    // that's the anchor the endpoint's FILTER NOT EXISTS uses to gate
+    // each KC. Re-running on this state must be a no-op.
+    seedCanonicalMeta(
+      store,
+      { name: cgName, onChainId, kcEntries: [kc] },
+      `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`,
+    );
+    const targetBefore = await countTriples(store, `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`);
     agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
 
     const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
@@ -215,7 +363,44 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
     expect(body.reports[0]).toMatchObject({
       contextGraphId: cgName,
       status: 'already-populated',
-      preExistingTargetTripleCount: 1,
+      sourceKcCount: 1,
+      copiedKcCount: 0,
+      copiedTriples: 0,
+    });
+
+    const targetAfter = await countTriples(store, `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`);
+    expect(targetAfter).toBe(targetBefore);
+  });
+
+  it('reports no-source-meta when canonical _meta has no KCs', async () => {
+    // Belt-and-braces test: a CG that's registered on-chain but
+    // whose canonical meta carries only CG-lifecycle subjects (no
+    // KCs) should report cleanly, not crash.
+    const cgName = 'rs-backfill-empty-source';
+    const onChainId = '7';
+    seedCanonicalMeta(store, {
+      name: cgName,
+      onChainId,
+      cgLifecycleSubject: {
+        subject: `did:dkg:context-graph:${cgName}`,
+        predicate: 'http://schema.org/dateCreated',
+        object: '"2026-05-26T18:18:00Z"',
+      },
+    });
+    agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.summary).toMatchObject({ noSourceMeta: 1, backfilled: 0 });
+    expect(body.reports[0]).toMatchObject({
+      contextGraphId: cgName,
+      status: 'no-source-meta',
+      sourceKcCount: 0,
     });
   });
 
@@ -237,11 +422,8 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
   it('dry-run reports copy count without writing', async () => {
     const cgName = 'rs-backfill-dryrun';
     const onChainId = '17';
-    seedCanonicalMeta(store, {
-      name: cgName,
-      onChainId,
-      kcEntries: [{ ual: 'did:dkg:base:84532/0xCCC/4000001', batchId: 19, rootEntity: 'urn:test:e4', tokenId: 1 }],
-    });
+    const kc: KcEntry = { ual: 'did:dkg:base:84532/0xCCC/4000001', batchId: 19, rootEntity: 'urn:test:e4', tokenId: 1 };
+    seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kc] });
     agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
 
     const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
@@ -253,23 +435,28 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
     expect(res.status).toBe(200);
     expect(body.dryRun).toBe(true);
     expect(body.summary).toMatchObject({ backfilled: 1 });
+    expect(body.reports[0]).toMatchObject({
+      status: 'backfilled',
+      copiedKcCount: 1,
+      copiedTriples: tripleCountForKc(kc),
+    });
 
-    // Dry-run MUST NOT have written anything to the per-cgId graph.
     const after = await countTriples(store, `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`);
     expect(after).toBe(0);
   });
 
   it('filters out CG-lifecycle subjects (only copies KC/KA/publication URIs)', async () => {
     // Subjects without `dkg:batchId` (and not reached via `dkg:partOf`
-    // or `dkg:authoredBy`) belong to CG-level metadata — accessPolicy,
-    // createdAt on the cgEntity, allowlist members, etc. The publisher
+    // or `<KA> dkg:publication <s>`) belong to CG-level metadata —
+    // accessPolicy, createdAt on the cgEntity, etc. The publisher
     // doesn't promote them into per-cgId; neither should the backfill.
     const cgName = 'rs-backfill-filter';
     const onChainId = '23';
+    const kc: KcEntry = { ual: 'did:dkg:base:84532/0xDDD/5000001', batchId: 31, rootEntity: 'urn:test:e5', tokenId: 1 };
     seedCanonicalMeta(store, {
       name: cgName,
       onChainId,
-      kcEntries: [{ ual: 'did:dkg:base:84532/0xDDD/5000001', batchId: 31, rootEntity: 'urn:test:e5', tokenId: 1 }],
+      kcEntries: [kc],
       cgLifecycleSubject: {
         subject: `did:dkg:context-graph:${cgName}`,
         predicate: 'http://schema.org/dateCreated',
@@ -287,7 +474,6 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
     expect(res.status).toBe(200);
     expect(body.summary.backfilled).toBe(1);
 
-    // The lifecycle subject should NOT have been copied.
     const target = `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`;
     const lifecycleProbe = await store.query(
       `ASK { GRAPH <${target}> { <did:dkg:context-graph:${cgName}> <http://schema.org/dateCreated> ?o } }`,
@@ -295,9 +481,8 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
     expect(lifecycleProbe.type).toBe('boolean');
     if (lifecycleProbe.type === 'boolean') expect(lifecycleProbe.value).toBe(false);
 
-    // The KC subject SHOULD have been copied.
     const kcProbe = await store.query(
-      `ASK { GRAPH <${target}> { <did:dkg:base:84532/0xDDD/5000001> <http://dkg.io/ontology/batchId> ?o } }`,
+      `ASK { GRAPH <${target}> { <${kc.ual}> <${DKG_NS}batchId> ?o } }`,
     );
     expect(kcProbe.type).toBe('boolean');
     if (kcProbe.type === 'boolean') expect(kcProbe.value).toBe(true);

--- a/packages/cli/test/backfill-rs-percgid-meta-route.test.ts
+++ b/packages/cli/test/backfill-rs-percgid-meta-route.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+
+/**
+ * Endpoint test for `POST /api/random-sampling/backfill-percgid-meta`.
+ *
+ * The endpoint reads the canonical `<cgName>/_meta` graph, picks the
+ * per-KC subset (subjects with `dkg:batchId`, the KA UALs they
+ * reference via `dkg:partOf`, and the publication URIs referenced via
+ * `dkg:authoredBy`), and copies that subset into the per-cgId
+ * `<cgName>/context/<cgId>/_meta` graph that the RS prover
+ * (`kc-extractor.ts`) reads from.
+ *
+ * Pre-cd68fa689 publishers gossiped finalization without a
+ * `targetContextGraphId`, so receivers settled the per-KC meta at
+ * the legacy URI; nothing in the post-fix code path puts it where it
+ * belongs in retrospect. This endpoint is the one-shot operator
+ * rescue for that historical state.
+ */
+
+const { handleStatusRoutes } = await import('../src/daemon/routes/status.js');
+
+type CGEntry = {
+  name: string;
+  onChainId: string;
+  /** Pre-seed canonical meta with N per-KC entries. */
+  kcEntries?: Array<{ ual: string; batchId: number; rootEntity: string; tokenId: number }>;
+  /** Pre-seed an extra non-KC subject in the canonical meta so the
+   *  endpoint's filter can be verified — should NOT be copied. */
+  cgLifecycleSubject?: { subject: string; predicate: string; object: string };
+};
+
+function seedCanonicalMeta(store: OxigraphStore, cg: CGEntry): void {
+  if (!cg.kcEntries) return;
+  const metaGraph = `did:dkg:context-graph:${cg.name}/_meta`;
+  const quads: Array<{ subject: string; predicate: string; object: string; graph: string }> = [];
+  for (const kc of cg.kcEntries) {
+    quads.push(
+      { subject: kc.ual, predicate: 'http://dkg.io/ontology/batchId', object: `"${kc.batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
+      { subject: kc.ual, predicate: 'http://dkg.io/ontology/kaCount', object: '"1"^^<http://www.w3.org/2001/XMLSchema#integer>', graph: metaGraph },
+      { subject: kc.ual, predicate: 'http://dkg.io/ontology/status', object: '"confirmed"', graph: metaGraph },
+      // KA-level subject (resolved via partOf → KC has batchId).
+      { subject: `${kc.ual}/${kc.tokenId}`, predicate: 'http://dkg.io/ontology/partOf', object: kc.ual, graph: metaGraph },
+      { subject: `${kc.ual}/${kc.tokenId}`, predicate: 'http://dkg.io/ontology/rootEntity', object: kc.rootEntity, graph: metaGraph },
+      { subject: `${kc.ual}/${kc.tokenId}`, predicate: 'http://dkg.io/ontology/tokenId', object: `"${kc.tokenId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
+    );
+  }
+  if (cg.cgLifecycleSubject) {
+    quads.push({ ...cg.cgLifecycleSubject, graph: metaGraph });
+  }
+  void store.insert(quads);
+}
+
+function makeAgentMock(opts: { store: OxigraphStore; cgs: Array<{ name: string; onChainId?: string }> }) {
+  const subscribed = new Map<string, { subscribed: boolean; synced: boolean; onChainId?: string }>();
+  for (const c of opts.cgs) {
+    subscribed.set(c.name, { subscribed: true, synced: true, onChainId: c.onChainId });
+  }
+  return {
+    peerId: '12D3KooBackfillTest',
+    multiaddrs: [],
+    node: { libp2p: { getConnections: () => [] } },
+    publisher: { getIdentityId: () => 0n },
+    store: opts.store,
+    getSubscribedContextGraphs: () => subscribed,
+    // The endpoint doesn't call these but the ctx shape includes them
+    // through unrelated routes — keep them noop-safe in case any
+    // sibling guard touches them.
+    getRandomSamplingStatus: () => ({ enabled: false, role: 'edge' }),
+  };
+}
+
+function makeCtx(path: string, agent: ReturnType<typeof makeAgentMock>) {
+  const url = new URL(path, 'http://127.0.0.1');
+  return {
+    agent,
+    publisherControl: {},
+    publisherRuntime: null,
+    config: {
+      name: 'backfill-test',
+      nodeRole: 'core',
+      chain: { type: 'evm', rpcUrl: 'https://test.example/rpc', hubAddress: '0x0000000000000000000000000000000000000001', chainId: 'hardhat:31337' },
+    },
+    startedAt: Date.now() - 1000,
+    dashDb: {},
+    opWallets: { wallets: [] },
+    network: null,
+    tracker: {},
+    memoryManager: {},
+    bridgeAuthToken: undefined,
+    nodeVersion: 'test',
+    nodeCommit: 'abc123',
+    catchupTracker: { jobs: new Map(), latestByContextGraph: new Map() },
+    extractionRegistry: {},
+    fileStore: {},
+    extractionStatus: new Map(),
+    assertionImportLocks: new Map(),
+    vectorStore: {},
+    embeddingProvider: null,
+    validTokens: new Set(),
+    apiHost: '127.0.0.1',
+    apiPortRef: { value: 0 },
+    url,
+    path: url.pathname,
+    requestToken: undefined,
+    requestAgentAddress: 'did:dkg:agent:test',
+    emitMemoryGraphChanged: () => {},
+  };
+}
+
+async function countTriples(store: OxigraphStore, graphUri: string): Promise<number> {
+  const r = await store.query(`SELECT (COUNT(*) AS ?n) WHERE { GRAPH <${graphUri}> { ?s ?p ?o } }`);
+  if (r.type !== 'bindings') return 0;
+  const raw = r.bindings[0]?.['n'] as string | undefined;
+  if (!raw) return 0;
+  const match = /^"(\d+)"/.exec(raw);
+  return match ? Number(match[1]) : 0;
+}
+
+describe('POST /api/random-sampling/backfill-percgid-meta', () => {
+  let server: Server | undefined;
+  let baseUrl = '';
+  let store: OxigraphStore;
+  let agent: ReturnType<typeof makeAgentMock>;
+
+  beforeEach(async () => {
+    store = new OxigraphStore();
+    agent = makeAgentMock({ store, cgs: [] });
+    server = createServer(async (req, res) => {
+      const ctx = { ...makeCtx(req.url ?? '/', agent), req, res };
+      try {
+        await handleStatusRoutes(ctx as any);
+        if (!res.writableEnded) {
+          res.statusCode = 404;
+          res.end();
+        }
+      } catch (err) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+      }
+    });
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('server did not bind');
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => server!.close((err) => (err ? reject(err) : resolve())));
+      server = undefined;
+    }
+  });
+
+  it('copies per-KC meta from <cg>/_meta to <cg>/context/<cgId>/_meta for an on-chain CG', async () => {
+    const cgName = 'rs-backfill-happy';
+    const onChainId = '42';
+    seedCanonicalMeta(store, {
+      name: cgName,
+      onChainId,
+      kcEntries: [
+        { ual: 'did:dkg:base:84532/0xAAA/1000001', batchId: 7, rootEntity: 'urn:test:e1', tokenId: 1 },
+        { ual: 'did:dkg:base:84532/0xAAA/2000001', batchId: 8, rootEntity: 'urn:test:e2', tokenId: 1 },
+      ],
+    });
+    agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
+
+    const before = await countTriples(store, `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`);
+    expect(before).toBe(0);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.summary).toMatchObject({ backfilled: 1, alreadyPopulated: 0, failed: 0 });
+
+    const after = await countTriples(store, `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`);
+    // 2 KCs × (3 KC-level + 3 KA-level) = 12 triples.
+    expect(after).toBe(12);
+    expect(body.reports[0]).toMatchObject({
+      contextGraphId: cgName,
+      onChainId,
+      status: 'backfilled',
+      copiedTriples: 12,
+    });
+  });
+
+  it('skips already-populated per-cgId meta graphs (idempotent)', async () => {
+    const cgName = 'rs-backfill-idempotent';
+    const onChainId = '99';
+    seedCanonicalMeta(store, {
+      name: cgName,
+      onChainId,
+      kcEntries: [{ ual: 'did:dkg:base:84532/0xBBB/3000001', batchId: 11, rootEntity: 'urn:test:e3', tokenId: 1 }],
+    });
+    // Pre-seed the per-cgId graph so the endpoint sees it as already done.
+    await store.insert([
+      { subject: 'did:dkg:base:84532/0xBBB/3000001', predicate: 'http://dkg.io/ontology/status', object: '"confirmed"', graph: `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta` },
+    ]);
+    agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.summary).toMatchObject({ backfilled: 0, alreadyPopulated: 1 });
+    expect(body.reports[0]).toMatchObject({
+      contextGraphId: cgName,
+      status: 'already-populated',
+      preExistingTargetTripleCount: 1,
+    });
+  });
+
+  it('reports not-on-chain for subscribed CGs lacking onChainId', async () => {
+    const cgName = 'rs-backfill-local-only';
+    agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true }]]);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.summary).toMatchObject({ backfilled: 0, notOnChain: 1 });
+    expect(body.reports[0]).toMatchObject({ contextGraphId: cgName, status: 'not-on-chain' });
+  });
+
+  it('dry-run reports copy count without writing', async () => {
+    const cgName = 'rs-backfill-dryrun';
+    const onChainId = '17';
+    seedCanonicalMeta(store, {
+      name: cgName,
+      onChainId,
+      kcEntries: [{ ual: 'did:dkg:base:84532/0xCCC/4000001', batchId: 19, rootEntity: 'urn:test:e4', tokenId: 1 }],
+    });
+    agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dryRun: true }),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.dryRun).toBe(true);
+    expect(body.summary).toMatchObject({ backfilled: 1 });
+
+    // Dry-run MUST NOT have written anything to the per-cgId graph.
+    const after = await countTriples(store, `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`);
+    expect(after).toBe(0);
+  });
+
+  it('filters out CG-lifecycle subjects (only copies KC/KA/publication URIs)', async () => {
+    // Subjects without `dkg:batchId` (and not reached via `dkg:partOf`
+    // or `dkg:authoredBy`) belong to CG-level metadata — accessPolicy,
+    // createdAt on the cgEntity, allowlist members, etc. The publisher
+    // doesn't promote them into per-cgId; neither should the backfill.
+    const cgName = 'rs-backfill-filter';
+    const onChainId = '23';
+    seedCanonicalMeta(store, {
+      name: cgName,
+      onChainId,
+      kcEntries: [{ ual: 'did:dkg:base:84532/0xDDD/5000001', batchId: 31, rootEntity: 'urn:test:e5', tokenId: 1 }],
+      cgLifecycleSubject: {
+        subject: `did:dkg:context-graph:${cgName}`,
+        predicate: 'http://schema.org/dateCreated',
+        object: '"2026-05-26T18:18:00Z"',
+      },
+    });
+    agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.summary.backfilled).toBe(1);
+
+    // The lifecycle subject should NOT have been copied.
+    const target = `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`;
+    const lifecycleProbe = await store.query(
+      `ASK { GRAPH <${target}> { <did:dkg:context-graph:${cgName}> <http://schema.org/dateCreated> ?o } }`,
+    );
+    expect(lifecycleProbe.type).toBe('boolean');
+    if (lifecycleProbe.type === 'boolean') expect(lifecycleProbe.value).toBe(false);
+
+    // The KC subject SHOULD have been copied.
+    const kcProbe = await store.query(
+      `ASK { GRAPH <${target}> { <did:dkg:base:84532/0xDDD/5000001> <http://dkg.io/ontology/batchId> ?o } }`,
+    );
+    expect(kcProbe.type).toBe('boolean');
+    if (kcProbe.type === 'boolean') expect(kcProbe.value).toBe(true);
+  });
+
+  it('restricts to specific CG names when contextGraphIds is provided', async () => {
+    const cgA = 'rs-backfill-restrict-a';
+    const cgB = 'rs-backfill-restrict-b';
+    seedCanonicalMeta(store, { name: cgA, onChainId: '1', kcEntries: [{ ual: 'did:dkg:base:84532/0xEEE/6000001', batchId: 41, rootEntity: 'urn:e:a', tokenId: 1 }] });
+    seedCanonicalMeta(store, { name: cgB, onChainId: '2', kcEntries: [{ ual: 'did:dkg:base:84532/0xFFF/7000001', batchId: 43, rootEntity: 'urn:e:b', tokenId: 1 }] });
+    agent.getSubscribedContextGraphs = () => new Map([
+      [cgA, { subscribed: true, synced: true, onChainId: '1' }],
+      [cgB, { subscribed: true, synced: true, onChainId: '2' }],
+    ]);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contextGraphIds: [cgA] }),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.processed).toBe(1);
+    expect(body.reports[0].contextGraphId).toBe(cgA);
+
+    const aCount = await countTriples(store, `did:dkg:context-graph:${cgA}/context/1/_meta`);
+    const bCount = await countTriples(store, `did:dkg:context-graph:${cgB}/context/2/_meta`);
+    expect(aCount).toBeGreaterThan(0);
+    expect(bCount).toBe(0);
+  });
+});

--- a/packages/cli/test/backfill-rs-percgid-meta-route.test.ts
+++ b/packages/cli/test/backfill-rs-percgid-meta-route.test.ts
@@ -59,11 +59,11 @@ function tripleCountForKc(kc: KcEntry): number {
   return 6 + (kc.publication ? 1 + 5 : 0);
 }
 
-function seedCanonicalMeta(store: OxigraphStore, cg: CGEntry, graphOverride?: string): void {
-  if (!cg.kcEntries) return;
+async function seedCanonicalMeta(store: OxigraphStore, cg: CGEntry, graphOverride?: string): Promise<void> {
+  if (!cg.kcEntries && !cg.cgLifecycleSubject) return;
   const metaGraph = graphOverride ?? `did:dkg:context-graph:${cg.name}/_meta`;
   const quads: Array<{ subject: string; predicate: string; object: string; graph: string }> = [];
-  for (const kc of cg.kcEntries) {
+  for (const kc of cg.kcEntries ?? []) {
     const kaUri = `${kc.ual}/${kc.tokenId}`;
     quads.push(
       { subject: kc.ual, predicate: `${DKG_NS}batchId`, object: `"${kc.batchId}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
@@ -88,7 +88,7 @@ function seedCanonicalMeta(store: OxigraphStore, cg: CGEntry, graphOverride?: st
   if (cg.cgLifecycleSubject) {
     quads.push({ ...cg.cgLifecycleSubject, graph: metaGraph });
   }
-  void store.insert(quads);
+  await store.insert(quads);
 }
 
 function makeAgentMock(opts: { store: OxigraphStore; cgs: Array<{ name: string; onChainId?: string }> }) {
@@ -197,7 +197,7 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
       { ual: 'did:dkg:base:84532/0xAAA/1000001', batchId: 7, rootEntity: 'urn:test:e1', tokenId: 1 },
       { ual: 'did:dkg:base:84532/0xAAA/2000001', batchId: 8, rootEntity: 'urn:test:e2', tokenId: 1 },
     ];
-    seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: kcs });
+    await seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: kcs });
     agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
 
     const expectedTriples = kcs.reduce((acc, kc) => acc + tripleCountForKc(kc), 0);
@@ -241,10 +241,10 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
 
     // Source has BOTH KCs (canonical `<cg>/_meta` is the catch-all
     // where every receiver landing wrote before the publisher fix).
-    seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kcAlreadyInTarget, kcOrphaned] });
+    await seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kcAlreadyInTarget, kcOrphaned] });
 
     // Target has only the first KC (simulating one post-fix publish).
-    seedCanonicalMeta(
+    await seedCanonicalMeta(
       store,
       { name: cgName, onChainId, kcEntries: [kcAlreadyInTarget] },
       `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`,
@@ -298,7 +298,7 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
       ual: 'did:dkg:base:84532/0xPRV/9000001', batchId: 73, rootEntity: 'urn:prov:root', tokenId: 1,
       publication: { opId, author, merkleRootHex: '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff' },
     };
-    seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kc] });
+    await seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kc] });
     agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
 
     const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
@@ -340,11 +340,11 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
     const kc: KcEntry = {
       ual: 'did:dkg:base:84532/0xBBB/3000001', batchId: 11, rootEntity: 'urn:test:e3', tokenId: 1,
     };
-    seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kc] });
+    await seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kc] });
     // Pre-seed the per-cgId graph with the SAME KC's `dkg:batchId` —
     // that's the anchor the endpoint's FILTER NOT EXISTS uses to gate
     // each KC. Re-running on this state must be a no-op.
-    seedCanonicalMeta(
+    await seedCanonicalMeta(
       store,
       { name: cgName, onChainId, kcEntries: [kc] },
       `did:dkg:context-graph:${cgName}/context/${onChainId}/_meta`,
@@ -378,7 +378,7 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
     // KCs) should report cleanly, not crash.
     const cgName = 'rs-backfill-empty-source';
     const onChainId = '7';
-    seedCanonicalMeta(store, {
+    await seedCanonicalMeta(store, {
       name: cgName,
       onChainId,
       cgLifecycleSubject: {
@@ -423,7 +423,7 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
     const cgName = 'rs-backfill-dryrun';
     const onChainId = '17';
     const kc: KcEntry = { ual: 'did:dkg:base:84532/0xCCC/4000001', batchId: 19, rootEntity: 'urn:test:e4', tokenId: 1 };
-    seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kc] });
+    await seedCanonicalMeta(store, { name: cgName, onChainId, kcEntries: [kc] });
     agent.getSubscribedContextGraphs = () => new Map([[cgName, { subscribed: true, synced: true, onChainId }]]);
 
     const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
@@ -453,7 +453,7 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
     const cgName = 'rs-backfill-filter';
     const onChainId = '23';
     const kc: KcEntry = { ual: 'did:dkg:base:84532/0xDDD/5000001', batchId: 31, rootEntity: 'urn:test:e5', tokenId: 1 };
-    seedCanonicalMeta(store, {
+    await seedCanonicalMeta(store, {
       name: cgName,
       onChainId,
       kcEntries: [kc],
@@ -491,8 +491,8 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
   it('restricts to specific CG names when contextGraphIds is provided', async () => {
     const cgA = 'rs-backfill-restrict-a';
     const cgB = 'rs-backfill-restrict-b';
-    seedCanonicalMeta(store, { name: cgA, onChainId: '1', kcEntries: [{ ual: 'did:dkg:base:84532/0xEEE/6000001', batchId: 41, rootEntity: 'urn:e:a', tokenId: 1 }] });
-    seedCanonicalMeta(store, { name: cgB, onChainId: '2', kcEntries: [{ ual: 'did:dkg:base:84532/0xFFF/7000001', batchId: 43, rootEntity: 'urn:e:b', tokenId: 1 }] });
+    await seedCanonicalMeta(store, { name: cgA, onChainId: '1', kcEntries: [{ ual: 'did:dkg:base:84532/0xEEE/6000001', batchId: 41, rootEntity: 'urn:e:a', tokenId: 1 }] });
+    await seedCanonicalMeta(store, { name: cgB, onChainId: '2', kcEntries: [{ ual: 'did:dkg:base:84532/0xFFF/7000001', batchId: 43, rootEntity: 'urn:e:b', tokenId: 1 }] });
     agent.getSubscribedContextGraphs = () => new Map([
       [cgA, { subscribed: true, synced: true, onChainId: '1' }],
       [cgB, { subscribed: true, synced: true, onChainId: '2' }],
@@ -507,10 +507,51 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
     expect(res.status).toBe(200);
     expect(body.processed).toBe(1);
     expect(body.reports[0].contextGraphId).toBe(cgA);
+    expect(body.unknownContextGraphIds).toEqual([]);
 
     const aCount = await countTriples(store, `did:dkg:context-graph:${cgA}/context/1/_meta`);
     const bCount = await countTriples(store, `did:dkg:context-graph:${cgB}/context/2/_meta`);
     expect(aCount).toBeGreaterThan(0);
     expect(bCount).toBe(0);
+  });
+
+  it('surfaces unknown contextGraphIds when none of the requested names match a subscribed CG', async () => {
+    // Regression for Codex round-2 review on PR #763: a typo'd CG
+    // name used to yield `processed: 0` and looked identical to a
+    // successful no-op. Now the endpoint reports the unknown names
+    // explicitly so the operator script can fail loudly.
+    const cgA = 'rs-backfill-known-cg';
+    await seedCanonicalMeta(store, { name: cgA, onChainId: '1', kcEntries: [{ ual: 'did:dkg:base:84532/0xAAA/1', batchId: 1, rootEntity: 'urn:e:a', tokenId: 1 }] });
+    agent.getSubscribedContextGraphs = () => new Map([[cgA, { subscribed: true, synced: true, onChainId: '1' }]]);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contextGraphIds: ['rs-backfill-typo', 'another-typo'] }),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.processed).toBe(0);
+    expect(body.unknownContextGraphIds).toEqual(['rs-backfill-typo', 'another-typo']);
+  });
+
+  it('reports unknownContextGraphIds even when some requested names DO match', async () => {
+    // Mixed case: operator passes a typo alongside a real CG name —
+    // the real one is processed, the typo is reported as unknown so
+    // the partial-success run is fully diagnosable.
+    const cgA = 'rs-backfill-mixed-known';
+    await seedCanonicalMeta(store, { name: cgA, onChainId: '1', kcEntries: [{ ual: 'did:dkg:base:84532/0xAAA/1', batchId: 1, rootEntity: 'urn:e:m', tokenId: 1 }] });
+    agent.getSubscribedContextGraphs = () => new Map([[cgA, { subscribed: true, synced: true, onChainId: '1' }]]);
+
+    const res = await fetch(`${baseUrl}/api/random-sampling/backfill-percgid-meta`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contextGraphIds: [cgA, 'mistyped'] }),
+    });
+    const body: any = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.processed).toBe(1);
+    expect(body.reports[0]).toMatchObject({ contextGraphId: cgA, status: 'backfilled' });
+    expect(body.unknownContextGraphIds).toEqual(['mistyped']);
   });
 });

--- a/scripts/backfill-rs-percgid-meta.mjs
+++ b/scripts/backfill-rs-percgid-meta.mjs
@@ -89,21 +89,34 @@ try {
   process.exit(1);
 }
 
-const { processed, summary, reports } = result;
+const { processed, summary, reports, unknownContextGraphIds } = result;
 console.log(
   `[backfill] processed=${processed} backfilled=${summary.backfilled} ` +
   `alreadyPopulated=${summary.alreadyPopulated} noSourceMeta=${summary.noSourceMeta} ` +
   `notOnChain=${summary.notOnChain} failed=${summary.failed}`,
 );
 
+if (Array.isArray(unknownContextGraphIds) && unknownContextGraphIds.length > 0) {
+  // Operators commonly mistype CG names. Surface them loudly so a
+  // typo run doesn't look identical to a successful no-op.
+  console.warn(
+    `[backfill] WARNING: ${unknownContextGraphIds.length} requested CG name(s) not in this node's subscription list: ${unknownContextGraphIds.join(', ')}`,
+  );
+}
+
 for (const r of reports) {
   const tag = r.onChainId ? `cg=${r.contextGraphId}#${r.onChainId}` : `cg=${r.contextGraphId}`;
   switch (r.status) {
     case 'backfilled':
-      console.log(`  · ${tag} BACKFILLED copied=${r.copiedTriples}${DRY_RUN ? ' (dry-run)' : ''}`);
+      console.log(
+        `  · ${tag} BACKFILLED kcsCopied=${r.copiedKcCount ?? '?'}/${r.sourceKcCount ?? '?'} ` +
+        `triples=${r.copiedTriples}${DRY_RUN ? ' (dry-run)' : ''}`,
+      );
       break;
     case 'already-populated':
-      console.log(`  · ${tag} ALREADY-POPULATED target=${r.preExistingTargetTripleCount} triples`);
+      console.log(
+        `  · ${tag} ALREADY-POPULATED kcsInSource=${r.sourceKcCount ?? '?'} kcsToCopy=${r.copiedKcCount ?? 0}`,
+      );
       break;
     case 'no-source-meta':
       console.log(`  · ${tag} NO-SOURCE-META (nothing to copy)`);
@@ -119,9 +132,12 @@ for (const r of reports) {
   }
 }
 
-// Exit non-zero only when an actual operation failed; "nothing to do"
-// states are not errors so the script is safe to chain in a multi-host
-// for-loop.
+// Exit non-zero on actual operation failures OR unknown CG name typos —
+// the latter looks like a successful no-op and would mask a real
+// operator error.
 if (summary.failed > 0) {
   process.exit(2);
+}
+if (Array.isArray(unknownContextGraphIds) && unknownContextGraphIds.length > 0) {
+  process.exit(3);
 }

--- a/scripts/backfill-rs-percgid-meta.mjs
+++ b/scripts/backfill-rs-percgid-meta.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Backfill RS per-cgId `_meta` graphs on a receiver core.
+ *
+ * Why
+ * ===
+ * Until cd68fa689 ("fix(agent): always plumb on-chain CG id into
+ * finalization gossip") landed on `release/rc.12`, every non-REMAP
+ * publish emitted a finalization gossip with `targetContextGraphId:
+ * undefined`. Receivers reading the envelope literally then promoted
+ * the SWM snapshot's per-KC `_meta` into the legacy
+ * `<cgName>/_meta` graph instead of the per-cgId
+ * `<cgName>/context/<cgId>/_meta` graph the RS prover reads from —
+ * leaving every freshly-published KC invisible to RS and the prover
+ * loops on `kc-not-synced` indefinitely.
+ *
+ * cd68fa689 fixes the publisher and (with the receiver-defensive
+ * lookup that lands alongside it) fixes the receiver for any FUTURE
+ * publish. It does NOT touch the meta that already landed at the
+ * wrong URI before the upgrade. This script copies the per-KC subset
+ * of every `<cgName>/_meta` graph into the corresponding per-cgId
+ * graph by calling the daemon's
+ * `POST /api/random-sampling/backfill-percgid-meta` admin endpoint
+ * (added in the same PR as this script).
+ *
+ * Operation is idempotent — re-running it on a node that's already
+ * been backfilled reports `already-populated` for each CG and writes
+ * nothing.
+ *
+ * Usage
+ * =====
+ *
+ *   # Probe a remote core (no writes; just see what would happen).
+ *   node scripts/backfill-rs-percgid-meta.mjs \
+ *     --api=https://beacon-01.example.com:9200 \
+ *     --token=PZcq... \
+ *     --dry-run
+ *
+ *   # Backfill all subscribed CGs on the locally-running daemon.
+ *   node scripts/backfill-rs-percgid-meta.mjs
+ *
+ *   # Backfill only specific CGs.
+ *   node scripts/backfill-rs-percgid-meta.mjs \
+ *     --cg=miles-publish-stress-26may \
+ *     --cg=rs-test-20kc-2026-05-27
+ *
+ *   # On a beacon, using the bearer token from `~/.dkg/auth.token`:
+ *   ssh beacon-01 'cd dkg && DEVNET_API=http://127.0.0.1:9200 \
+ *     node scripts/backfill-rs-percgid-meta.mjs'
+ *
+ * Args (all optional, env vars listed in parens):
+ *   --api=URL          (DEVNET_API)    daemon URL (default http://localhost:9200)
+ *   --token=BEARER     (DEVNET_TOKEN)  bearer token (fallback: ~/.dkg/auth.token)
+ *   --cg=NAME          (repeatable)    restrict to specific CG names; default: all subscribed
+ *   --dry-run                          probe-only; no writes
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeClient, parseArgs, resolveToken } from './lib/dkg-daemon.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+const rawArgs = process.argv.slice(2);
+const args = parseArgs(rawArgs);
+const API_BASE = (args.api ?? process.env.DEVNET_API ?? 'http://localhost:9200').replace(/\/$/, '');
+const TOKEN = args.token ?? process.env.DEVNET_TOKEN ?? resolveToken(REPO_ROOT);
+const DRY_RUN = args['dry-run'] === 'true' || args.dryRun === 'true';
+
+// `parseArgs` collapses repeated flags onto the last one. Recover the
+// list of `--cg=...` args by scanning the raw argv.
+const cgArgs = rawArgs
+  .map((a) => /^--cg=(.+)$/.exec(a)?.[1])
+  .filter((v) => typeof v === 'string' && v.length > 0);
+
+const client = makeClient({ apiBase: API_BASE, token: TOKEN });
+
+console.log(`[backfill] api=${API_BASE} dryRun=${DRY_RUN} restrict=${cgArgs.length > 0 ? cgArgs.join(',') : '(all subscribed)'}`);
+
+let result;
+try {
+  result = await client.request('POST', '/api/random-sampling/backfill-percgid-meta', {
+    contextGraphIds: cgArgs,
+    dryRun: DRY_RUN,
+  });
+} catch (err) {
+  console.error(`[backfill] FAILED: ${err.message}`);
+  process.exit(1);
+}
+
+const { processed, summary, reports } = result;
+console.log(
+  `[backfill] processed=${processed} backfilled=${summary.backfilled} ` +
+  `alreadyPopulated=${summary.alreadyPopulated} noSourceMeta=${summary.noSourceMeta} ` +
+  `notOnChain=${summary.notOnChain} failed=${summary.failed}`,
+);
+
+for (const r of reports) {
+  const tag = r.onChainId ? `cg=${r.contextGraphId}#${r.onChainId}` : `cg=${r.contextGraphId}`;
+  switch (r.status) {
+    case 'backfilled':
+      console.log(`  · ${tag} BACKFILLED copied=${r.copiedTriples}${DRY_RUN ? ' (dry-run)' : ''}`);
+      break;
+    case 'already-populated':
+      console.log(`  · ${tag} ALREADY-POPULATED target=${r.preExistingTargetTripleCount} triples`);
+      break;
+    case 'no-source-meta':
+      console.log(`  · ${tag} NO-SOURCE-META (nothing to copy)`);
+      break;
+    case 'not-on-chain':
+      console.log(`  · ${tag} NOT-ON-CHAIN (skipped; on-chain id unknown)`);
+      break;
+    case 'failed':
+      console.warn(`  ! ${tag} FAILED: ${r.error}`);
+      break;
+    default:
+      console.log(`  ? ${tag} status=${r.status}`);
+  }
+}
+
+// Exit non-zero only when an actual operation failed; "nothing to do"
+// states are not errors so the script is safe to chain in a multi-host
+// for-loop.
+if (summary.failed > 0) {
+  process.exit(2);
+}


### PR DESCRIPTION
## Summary

Follow-up to [#758](https://github.com/OriginTrail/dkg/pull/758) (\`cd68fa689\`, *fix(agent): always plumb on-chain CG id into finalization gossip*). That PR closes the **publisher** side of the RS \`kc-not-synced\` bug. This PR closes the two operational gaps it leaves behind:

1. **Rolling-upgrade defense on the receiver.** Pre-fix publishers still floating in a mesh gossip \`targetContextGraphId: undefined\`. An upgraded receiver that reads the wire literally still downgrades to legacy \`<cgName>/_meta\` promotion and the prover stays stuck on \`kc-not-synced\`. Fixed by an optional \`ResolveContextGraphOnChainId\` callback wired from \`DKGAgent\` into \`FinalizationHandler\`; when the gossip envelope is empty, the receiver derives the on-chain id locally (same lookup the publisher uses on the outbound side). Resolver failure / not-on-chain returns cleanly fall back to legacy behavior — pure belt-and-braces.

2. **Historical \`_meta\` rescue.** Every KC published to a core BEFORE its daemon was upgraded has its \`_meta\` parked at \`<cgName>/_meta\` instead of \`<cgName>/context/<cgId>/_meta\`. Restarting the upgraded daemon does NOT retroactively promote those — they stay un-provable forever. \`POST /api/random-sampling/backfill-percgid-meta\` copies the per-KC subset of \`<cgName>/_meta\` into the per-cgId graph for every subscribed CG with an on-chain id, idempotently. \`scripts/backfill-rs-percgid-meta.mjs\` drives it from an operator workstation.

### Diagnostic that motivated this

On \`beacon-01\` (base-sepolia core, identityId=3), every recent prover tick reported \`kc-not-synced\` against CG #4 (\`miles-publish-stress-26may\`). SPARQL probes:

| graph | triples |
| --- | --- |
| \`<cg>/_meta\` (legacy) | **16,409** |
| \`<cg>/context/4/_meta\` (per-cgId) | **0** |

The 16k triples included 628 \`dkg:batchId\` entries — exactly one per published KC. RS extractor was looking in the right place; the publisher had been gossiping the wrong place; cd68fa689 fixes \"the wrong place\"; this PR makes upgraded receivers tolerate stale publishers AND lets the operator rescue the 628 already-orphaned KCs without re-publishing.

## Changes

- \`packages/agent/src/finalization-handler.ts\` — new optional \`ResolveContextGraphOnChainId\` callback; defensive lookup in \`handleFinalizationMessage\` when \`msg.targetContextGraphId\` is empty.
- \`packages/agent/src/dkg-agent.ts\` — wire \`getContextGraphOnChainId(cgName)\` as the resolver in \`getOrCreateFinalizationHandler\`.
- \`packages/cli/src/daemon/routes/status.ts\` — new \`POST /api/random-sampling/backfill-percgid-meta\` endpoint. Filter mirrors the publisher's promotion (\`dkg-publisher.ts:1407-1422\`): KC UALs (have \`dkg:batchId\`), KA UALs (linked via \`dkg:partOf\` to a KC), publication URIs (linked via \`dkg:authoredBy\`). CG-lifecycle subjects are correctly excluded. Supports \`dryRun\` and per-CG targeting; idempotent (already-populated graphs are reported as such).
- \`scripts/backfill-rs-percgid-meta.mjs\` — operator-facing CLI driver. Token/API resolution via existing \`scripts/lib/dkg-daemon.mjs\` helper.
- \`packages/agent/test/finalization-handler-defensive-cg-id.test.ts\` (6 cases) — pins all three \`ctxGraphId\` resolution branches: gossip-set precedence, defensive fallback, legacy fallback, plus resolver-failure and resolver-returns-null degradation paths. Uses the dedup-guard SPARQL probe as a behavioral observer; no chain or merkle setup.
- \`packages/cli/test/backfill-rs-percgid-meta-route.test.ts\` (6 cases) — happy-path copy, idempotence (\`already-populated\`), dry-run, lifecycle-subject filter, not-on-chain skip, CG-restriction args.

## Test plan

- [x] \`pnpm --filter @origintrail-official/dkg-agent test test/finalization-handler-defensive-cg-id.test.ts\` → **6/6** ✅
- [x] \`pnpm --filter @origintrail-official/dkg-agent test test/finalization-handler.test.ts test/adversarial-determinism.test.ts test/sync-responder-per-cgid-meta.test.ts\` → **20/20** ✅ (existing tests, no regression)
- [x] \`pnpm --filter @origintrail-official/dkg-cli test test/backfill-rs-percgid-meta-route.test.ts\` → **6/6** ✅
- [ ] Devnet validation via \`scripts/devnet-test-rfc39-comprehensive.sh\` (Scenario A specifically) on a second laptop — operator-driven; this exercises the publisher-side cd68fa689 fix end-to-end and indirectly validates that the receiver still works when gossip carries \`targetContextGraphId\` (regression guard for the precedence path of this PR).

## Operator workflow on testnet beacons after merge

\`\`\`bash
# 1. Upgrade daemon binary to rc.12 on every core.
# 2. Probe what the backfill would do (no writes):
node scripts/backfill-rs-percgid-meta.mjs --api=http://127.0.0.1:9200 --dry-run

# 3. Execute the backfill on each core:
node scripts/backfill-rs-percgid-meta.mjs --api=http://127.0.0.1:9200

# 4. Watch RS recovery (submittedCount should climb within one sampling period):
curl -s -H \"Authorization: Bearer \$TOKEN\" \\
  http://127.0.0.1:9200/api/random-sampling/status | jq '.loop'
\`\`\`

Idempotent — safe to re-run.


Made with [Cursor](https://cursor.com)