### PR TITLE
Fix scoped query edge cases validated on devnet

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -284,6 +284,19 @@ export interface LocalAgentIntegrationConfig {
   updatedAt?: string;
 }
 
+export interface QueryAccessConfig {
+  defaultPolicy: 'deny' | 'public';
+  contextGraphs?: Record<string, {
+    policy: 'deny' | 'public' | 'allowList';
+    allowedPeers?: string[];
+    allowedLookupTypes?: Array<'ENTITY_BY_UAL' | 'ENTITIES_BY_TYPE' | 'ENTITY_TRIPLES' | 'SPARQL_QUERY'>;
+    sparqlEnabled?: boolean;
+    sparqlTimeout?: number;
+    sparqlMaxResults?: number;
+  }>;
+  rateLimitPerMinute?: number;
+}
+
 export interface DkgConfig {
   name: string;
   relay?: string;
@@ -343,6 +356,8 @@ export interface DkgConfig {
   bootstrapPeers?: string[];
   /** V10: context graphs to subscribe. */
   contextGraphs?: string[];
+  /** Cross-agent query access policy for inbound query-remote requests. */
+  queryAccess?: QueryAccessConfig;
   autoUpdate?: AutoUpdateConfig;
   /**
    * Chain config. Field-merged on top of `network/<env>.json#chain` via

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -687,6 +687,7 @@ export async function runDaemonInner(
     largeLiteralStorage: config.largeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: config.sharedMemoryPublicSnapshotStorage,
     syncSharedMemoryOnConnect: config.syncSharedMemoryOnConnect,
+    queryAccess: config.queryAccess,
     chainAdapter: mockChainAdapter,
     // Only forward chain to the agent when both required fields resolved.
     // resolveChainConfig() may return a partial block if neither config nor

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -197,7 +197,7 @@ export class DKGQueryEngine implements QueryEngine {
     // ── Legacy routing (V9 compat) ────────────────────────────────────
     let effectiveSparql = sparql;
 
-    if (effectiveContextGraphId && !sparql.toLowerCase().includes('from ')) {
+    if (effectiveContextGraphId) {
       const dataGraph = options?.subGraphName
         ? contextGraphSubGraphUri(effectiveContextGraphId, options.subGraphName)
         : contextGraphDataUri(effectiveContextGraphId);

--- a/packages/query/src/query-handler.ts
+++ b/packages/query/src/query-handler.ts
@@ -87,6 +87,7 @@ export class QueryHandler {
     try {
       const limit = Math.min(request.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
       const timeout = Math.min(request.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
+      const contextGraphPolicy = this.contextGraphPolicy(contextGraphId);
 
       let response: QueryResponse;
 
@@ -101,7 +102,13 @@ export class QueryHandler {
           response = await this.lookupEntityTriples(opId, contextGraphId!, request.entityUri!);
           break;
         case 'SPARQL_QUERY':
-          response = await this.executeSparql(opId, contextGraphId!, request.sparql!, limit, timeout);
+          response = await this.executeSparql(
+            opId,
+            contextGraphId!,
+            request.sparql!,
+            capByPolicy(limit, contextGraphPolicy?.sparqlMaxResults),
+            capByPolicy(timeout, contextGraphPolicy?.sparqlTimeout),
+          );
           break;
         default:
           response = errorResponse(opId, 'UNSUPPORTED_LOOKUP', `Unknown lookup type: ${request.lookupType}`);
@@ -168,6 +175,11 @@ export class QueryHandler {
     const cgConfigs = this.config.contextGraphs ?? this.config.contextGraphs;
     if (!cgConfigs) return false;
     return Object.values(cgConfigs).some(p => p.policy === 'public');
+  }
+
+  private contextGraphPolicy(contextGraphId: string | undefined): ContextGraphQueryPolicy | undefined {
+    if (!contextGraphId) return undefined;
+    return this.config.contextGraphs?.[contextGraphId];
   }
 
   private checkRateLimit(peerId: string): QueryResponse | null {
@@ -347,6 +359,13 @@ function errorResponse(opId: string, status: QueryStatus, error: string): QueryR
     resultCount: 0,
     error,
   };
+}
+
+function capByPolicy(value: number, policyCap: number | undefined): number {
+  if (policyCap === undefined || !Number.isFinite(policyCap) || policyCap <= 0) {
+    return value;
+  }
+  return Math.min(value, Math.floor(policyCap));
 }
 
 function formatObject(value: string): string {

--- a/packages/query/src/sparql-guard.ts
+++ b/packages/query/src/sparql-guard.ts
@@ -26,8 +26,10 @@ const MUTATING_PATTERN = new RegExp(
   'i',
 );
 
-// Matches the query form keyword after optional PREFIX/BASE preamble
-const READ_ONLY_FORMS = /^\s*(?:(?:PREFIX|BASE)\s+[^\n]*\n\s*)*(SELECT|CONSTRUCT|ASK|DESCRIBE)\b/i;
+// Matches the query form keyword after optional PREFIX/BASE preamble.
+// `stripLiteralsAndComments` blanks IRI bodies first, so this accepts both
+// newline-separated and inline declarations, e.g. `PREFIX ex: <...> SELECT`.
+const READ_ONLY_FORMS = /^\s*(?:(?:PREFIX\s+(?:[A-Za-z][A-Za-z0-9_-]*)?:\s*)|(?:BASE\s+))*\s*(SELECT|CONSTRUCT|ASK|DESCRIBE)\b/i;
 
 /** SPARQL query form — enough to shape a `QueryResult` correctly. */
 export type SparqlQueryForm = 'SELECT' | 'CONSTRUCT' | 'ASK' | 'DESCRIBE' | 'UNKNOWN';

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -314,10 +314,19 @@ describe('DKGQueryEngine', () => {
     ]);
 
     await expect(engine.query(
+      `SELECT ?from WHERE { ?s <http://example.com/from> ?from }`,
+      { contextGraphId: CONTEXT_GRAPH },
+    )).resolves.toMatchObject({
+      bindings: [{ from: '"FromPredicate"' }],
+    });
+
+    await expect(engine.query(
       `PREFIX ex: <http://example.com/>
        SELECT ?name WHERE { ?s ex:from ?name }`,
       { contextGraphId: CONTEXT_GRAPH },
-    )).resolves.toMatchObject({ bindings: expect.any(Array) });
+    )).resolves.toMatchObject({
+      bindings: [{ name: '"FromPredicate"' }],
+    });
   });
 
   it('allows scoped queries with a prefix label named from', async () => {
@@ -673,6 +682,20 @@ describe('validateReadOnlySparql', () => {
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
       SELECT ?name WHERE { ?s <http://schema.org/name> ?name }
     `);
+    expect(result.safe).toBe(true);
+  });
+
+  it('allows inline PREFIX declarations before SELECT', () => {
+    const result = validateReadOnlySparql(
+      'PREFIX schema: <http://schema.org/> SELECT ?s WHERE { ?s schema:name ?name }',
+    );
+    expect(result.safe).toBe(true);
+  });
+
+  it('allows inline default PREFIX declarations before SELECT', () => {
+    const result = validateReadOnlySparql(
+      'PREFIX : <http://schema.org/> SELECT ?s WHERE { ?s :name ?name }',
+    );
     expect(result.safe).toBe(true);
   });
 

--- a/packages/query/test/query-handler.test.ts
+++ b/packages/query/test/query-handler.test.ts
@@ -220,6 +220,67 @@ describe('QueryHandler', () => {
     });
   });
 
+  describe('SPARQL policy limits', () => {
+    it('caps SPARQL results using the context-graph sparqlMaxResults policy', async () => {
+      const handler = new QueryHandler(engine, {
+        defaultPolicy: 'deny',
+        contextGraphs: {
+          [CONTEXT_GRAPH]: {
+            policy: 'public',
+            allowedLookupTypes: ['SPARQL_QUERY'],
+            sparqlEnabled: true,
+            sparqlMaxResults: 1,
+          },
+        },
+      });
+
+      const response = await handler.handle(
+        makeRequest({
+          lookupType: 'SPARQL_QUERY',
+          limit: 100,
+          sparql: `SELECT ?name WHERE { ?s <${SCHEMA_NAME}> ?name } ORDER BY ?name`,
+        }),
+        'peer-1',
+      );
+
+      expect(response.status).toBe('OK');
+      expect(JSON.parse(response.bindings!)).toHaveLength(1);
+      expect(response.resultCount).toBe(2);
+      expect(response.truncated).toBe(true);
+    });
+
+    it('caps SPARQL execution time using the context-graph sparqlTimeout policy', async () => {
+      const slowEngine = {
+        query: () => new Promise((resolve) => {
+          setTimeout(() => resolve({ bindings: [{ s: 'late' }] }), 50);
+        }),
+      } as unknown as DKGQueryEngine;
+      const handler = new QueryHandler(slowEngine, {
+        defaultPolicy: 'deny',
+        contextGraphs: {
+          [CONTEXT_GRAPH]: {
+            policy: 'public',
+            allowedLookupTypes: ['SPARQL_QUERY'],
+            sparqlEnabled: true,
+            sparqlTimeout: 1,
+          },
+        },
+      });
+
+      const response = await handler.handle(
+        makeRequest({
+          lookupType: 'SPARQL_QUERY',
+          timeout: 30_000,
+          sparql: `SELECT ?name WHERE { ?s <${SCHEMA_NAME}> ?name }`,
+        }),
+        'peer-1',
+      );
+
+      expect(response.status).toBe('GAS_LIMIT_EXCEEDED');
+      expect(response.error).toContain('time limit');
+    });
+  });
+
   describe('with allowList policy', () => {
     let handler: QueryHandler;
 


### PR DESCRIPTION
## Summary
- Follow-up to the scoped query/view isolation work after PR #749 merged.
- Allow inline `PREFIX ... SELECT` forms in the scoped query guard, including default prefixes.
- Remove the stale raw `FROM` substring check so valid terms like `?from` and `ex:from` are scoped normally instead of rejected.
- Enforce context-graph `queryAccess` timeout and max-result caps for remote query handlers, and wire daemon config through.

## Verification
- `pnpm --dir packages/query exec vitest run test/query-engine.test.ts test/query-extra.test.ts test/query-security.test.ts test/query-handler.test.ts --configLoader runner` — 193 passed.
- `pnpm run build:runtime:packages` — passed.
- Devnet harness on `API_PORT_BASE=9301` / nodes `9301` and `9302` — 30/30 normal-query and attack-vector checks passed.
- `review-prompt.md` subagent review — no comments.
