### PR TITLE
perf(node-ui): coalesce concurrent identical /api/query POSTs

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -463,6 +463,46 @@ export async function importFile(
 }
 
 // --- Query ---
+
+// In-flight POST /api/query dedup. Coalesces concurrent identical
+// requests so React strict-mode double-mounts and sibling views asking
+// the same SPARQL against the same CG share one underlying fetch.
+//
+// Scope is *strictly inflight*: the entry is deleted as soon as the
+// promise settles (success OR failure), so the next call always issues
+// a fresh request. No caching, no staleness window — this is purely
+// concurrent-coalescing, drop-in safe for every existing caller.
+//
+// Motivation: opening a project on the dashboard fires `useMemoryEntities`
+// from two mounted instances (Dashboard card + ProjectView), giving 6
+// identical `/api/query` POSTs for the WM/SWM/VM fan-out against a
+// multi-GB Oxigraph store. Each duplicate adds seconds of wall time on
+// large stores. Inflight dedup collapses the dupes to one.
+const inflightQuery = new Map<string, Promise<{ result: any }>>();
+
+export function postQueryDeduped(body: Record<string, unknown>): Promise<{ result: any }> {
+  const key = JSON.stringify(body);
+  const existing = inflightQuery.get(key);
+  if (existing) return existing;
+  const promise = (async () => {
+    const res = await fetch(`${BASE}/api/query`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: key,
+    });
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      const msg = (errBody as { error?: string })?.error ?? `HTTP ${res.status}`;
+      throw new HttpError(res.status, msg, errBody);
+    }
+    return res.json() as Promise<{ result: any }>;
+  })().finally(() => {
+    inflightQuery.delete(key);
+  });
+  inflightQuery.set(key, promise);
+  return promise;
+}
+
 export const executeQuery = (
   sparql: string,
   contextGraphId?: string,
@@ -470,7 +510,7 @@ export const executeQuery = (
   graphSuffix?: '_shared_memory',
   view?: 'verified-memory' | 'shared-working-memory',
 ) =>
-  post<{ result: any }>('/api/query', { sparql, contextGraphId, includeSharedMemory, graphSuffix, view });
+  postQueryDeduped({ sparql, contextGraphId, includeSharedMemory, graphSuffix, view });
 
 // --- Publish (assertion-lifecycle: RFC-001 §9.x sign-at-creation) ---
 //

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { authHeaders } from '../api.js';
+import { postQueryDeduped } from '../api.js';
 import { useMemoryGraphEvents } from './useNodeEvents.js';
 import { MEMORY_LABEL_PREDICATES } from '../lib/memoryLabels.js';
 
@@ -316,14 +316,12 @@ async function queryLayer(
   // (Codex). Whether a total failure escalates to a hard `error` stays
   // the configurable part (see `signalErrors`).
   try {
+    // Routed through `postQueryDeduped` so the 3-way WM/SWM/VM fan-out
+    // here coalesces with any other concurrently-mounted instance of
+    // this hook (e.g. Dashboard card + ProjectView both subscribed to
+    // the same CG). One underlying fetch instead of N for each layer.
     const body: any = { sparql, contextGraphId, ...opts };
-    const res = await fetch('/api/query', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...authHeaders() },
-      body: JSON.stringify(body),
-    });
-    if (!res.ok) throw new Error(`/api/query failed (${res.status})`);
-    const data = await res.json();
+    const data: any = await postQueryDeduped(body);
     const bindings = data?.result?.bindings ?? data?.results?.bindings ?? [];
     const triples = bindings
       .map((row: any) => {

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -346,6 +346,53 @@ describe('UI API tests', () => {
     });
   });
 
+  // The Node UI mounts `useMemoryEntities` and `useProjectProfile` from
+  // multiple sibling views simultaneously when a project is opened
+  // (e.g. Dashboard card + ProjectView). Pre-dedup, each duplicate
+  // fan-out hit `/api/query` separately and added seconds of wall-time
+  // on a multi-GB Oxigraph store. These tests pin the contract that
+  // `executeQuery` collapses concurrent identical POSTs to one fetch
+  // while still firing fresh requests once a prior one settles.
+  describe('executeQuery in-flight dedup', () => {
+    it('coalesces concurrent identical queries to one /api/query POST', async () => {
+      const results = await Promise.all([
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-dedup'),
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-dedup'),
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-dedup'),
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-dedup'),
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-dedup'),
+      ]);
+      const queryCalls = requestLog.filter(
+        r => r.method === 'POST' && r.url.startsWith('/api/query'),
+      );
+      expect(queryCalls).toHaveLength(1);
+      expect(results).toHaveLength(5);
+      for (const r of results) {
+        expect(r).toEqual({ result: { bindings: [] } });
+      }
+    });
+
+    it('does not coalesce when args differ', async () => {
+      await Promise.all([
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-a'),
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-b'),
+      ]);
+      const queryCalls = requestLog.filter(
+        r => r.method === 'POST' && r.url.startsWith('/api/query'),
+      );
+      expect(queryCalls).toHaveLength(2);
+    });
+
+    it('issues a fresh fetch once the prior request has settled', async () => {
+      await executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-sequential');
+      await executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-sequential');
+      const queryCalls = requestLog.filter(
+        r => r.method === 'POST' && r.url.startsWith('/api/query'),
+      );
+      expect(queryCalls).toHaveLength(2);
+    });
+  });
+
   // IMPORT_SOURCES test block removed — the constant was retired along
   // with /api/memory/import as part of the openclaw-dkg-primary-memory
   // work. See Dashboard / ui/api.ts for the deletion context.


### PR DESCRIPTION
## Summary

Opening a project on the dashboard mounts `useMemoryEntities` twice (the Dashboard card for that CG and `ProjectView` for the same CG), so its WM/SWM/VM fan-out fires the same 3 SPARQL queries from two sibling React subtrees in parallel — 6 identical `/api/query` POSTs hit the daemon simultaneously. On a multi-GB Oxigraph store each duplicate adds seconds of wall time (observed locally on Miles: opening a fresh CG fired e.g. `SELECT ?s ?p ?o ?g WHERE { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS …) }` six times back-to-back, with several taking 3-5s).

This PR adds a small in-flight dedup at the `/api/query` POST layer in `packages/node-ui/src/ui/api.ts`:

- New `postQueryDeduped(body)` helper. Keys by the stringified request body; returns the existing promise for any caller that arrives while one is in flight. The map entry is removed the moment the promise settles, so this is **purely concurrent-coalescing — no cache, no staleness window**.
- `executeQuery` now routes through it (so `useProjectProfile`'s 7-query fan-out also benefits, plus any other view that fires concurrent identical SPARQL).
- `useMemoryEntities.queryLayer` switched from its raw \`fetch('/api/query', …)\` call to `postQueryDeduped`, so the WM/SWM/VM fan-out coalesces across sibling hook instances.

Surgical: 3 files, +94 / -9 LOC. No public-API changes; every existing caller of `executeQuery` keeps the same signature and observable semantics. Callers passing a `signal` would skip the pool (not done here because no caller currently passes one and abort would race the shared promise — left as a future enhancement).

## Out of scope / follow-ups

- Two larger wins observed in the same session but not addressed here:
  - The join → curator approval handshake takes ~77s on first-open (one-time per CG).
  - SWM gossip subscription denied warnings (`SWM gossip subscription denied for "<cg>": local node is not authorized`) keep us on poll-only updates for non-allowlisted CGs.

## Test plan

- [x] `pnpm test test/ui-api-pure.test.ts` — adds 3 dedup contract tests, all 35 tests pass
- [x] `pnpm test test/use-memory-entities-{counts,labels,live-updates,partial}.test.ts test/build-entities-triple-count.test.ts` — 22 existing memory-entity tests still pass
- [x] `pnpm tsc --noEmit` clean for all changed files
- [ ] Manual: open a CG with non-trivial WM in the Node UI; observe daemon log shows the 6→3 (or 6→1 in the same render tick) collapse for the `SELECT ?s ?p ?o ?g WHERE { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS …) }` query family

Made with [Cursor](https://cursor.com)