### PR TITLE
feat(storage,cli): add Blazegraph + SPARQL-HTTP external triple-store support (RFC 120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,109 @@ analysis reports are under `bench/results/profiles/`, including
 
 ---
 
+## Triple Store Backends
+
+A DKG node keeps every assertion in an [RDF](https://www.w3.org/RDF/) triple store. Out of the box the node runs an embedded [Oxigraph](https://github.com/oxigraph/oxigraph) instance, which is everything you need on a workstation — no extra process, no extra port, no extra config. Heavier deployments can swap in [Blazegraph](https://blazegraph.com/) (the mainnet store) or any SPARQL 1.1 server.
+
+| Backend | When to pick it |
+|---|---|
+| `oxigraph-worker` (default) | Single-operator nodes, dev, CI. No setup. File-backed, capped at process RAM. |
+| `blazegraph` | High-throughput nodes, mainnet parity, very large graphs (10M+ quads). Run as a separate daemon (Docker or `java -jar`). Shares cleanly with V6 / V8 instances — DKG scopes its writes to the `did:dkg:context-graph:` named-graph prefix. |
+| `sparql-http` | Any SPARQL 1.1 Protocol server (Fuseki, GraphDB, Stardog, Neptune…). Bring your own URL + (optional) auth header. |
+
+### Configure via `dkg init`
+
+Two paths:
+
+**1. Point at an existing Blazegraph instance:**
+
+```
+$ dkg init
+…
+Triple store backend (oxigraph / blazegraph) (oxigraph): blazegraph
+Blazegraph SPARQL endpoint URL: http://127.0.0.1:9999/bigdata/namespace/mynode/sparql
+  Store endpoint reachable: blazegraph http://127.0.0.1:9999/bigdata/namespace/mynode/sparql
+```
+
+**2. Let `dkg init` provision a Blazegraph container via Docker:**
+
+```
+$ dkg init
+…
+Triple store backend (oxigraph / blazegraph) (oxigraph): blazegraph
+Blazegraph SPARQL endpoint URL:                                    ← leave blank
+No URL provided. Provision a Blazegraph container via Docker? (y/n) (y): y
+  Starting Blazegraph in Docker (namespace: mynode)…
+  Docker available: Docker version 24.0.6, build ed223bc
+  Created container "dkg-blazegraph-mynode" on port 9999.
+  Created Blazegraph namespace "mynode".
+```
+
+The Docker provisioner pins `lyrasis/blazegraph:2.1.5` (same image and tag as mainnet and the devnet test fixture), uses `--restart unless-stopped`, auto-bumps the host port if 9999 is taken, and is idempotent — re-running `dkg init` against an already-provisioned namespace reuses the running container.
+
+The wizard validates non-Docker URLs via an `ASK { ?s ?p ?o }` probe before saving — typos or unreachable namespaces are caught at setup time, not at first boot. A 404 surfaces a specific "namespace likely doesn't exist" message rather than the generic network-failure hint.
+
+### Configure via flags (scripted setup)
+
+Every setup entry point honours `--store` / `--store-url`:
+
+```bash
+# Init only
+dkg init --store blazegraph --store-url http://127.0.0.1:9999/bigdata/namespace/mynode/sparql
+
+# Adapter setups (validated + persisted after the adapter step completes)
+dkg hermes setup    --store blazegraph --store-url http://blaze.example/sparql
+dkg openclaw setup  --store blazegraph --store-url http://blaze.example/sparql
+dkg mcp setup       --store blazegraph --store-url http://blaze.example/sparql
+```
+
+`--store oxigraph` on a previously-Blazegraph node clears the persisted block (force-fall-back to the local default).
+
+### Configure via `~/.dkg/config.json`
+
+```json
+{
+  "store": {
+    "backend": "blazegraph",
+    "options": {
+      "url": "http://127.0.0.1:9999/bigdata/namespace/mynode/sparql",
+      "managedByDkg": false
+    }
+  }
+}
+```
+
+For `sparql-http`:
+
+```json
+{
+  "store": {
+    "backend": "sparql-http",
+    "options": {
+      "queryEndpoint": "http://server.example/query",
+      "updateEndpoint": "http://server.example/update",
+      "auth": "Bearer YOUR_TOKEN"
+    }
+  }
+}
+```
+
+### What changes when you pick an external backend
+
+- **Boot-time health check**: the daemon refuses to start until the endpoint answers `ASK`. Unreachable URLs print an actionable message naming the URL — no half-broken daemon.
+- **Namespace identity tag**: on first boot the daemon writes a triple into a reserved `<urn:dkg:store-meta>` graph recording its node name. Subsequent boots verify the tag before doing any writes — two DKG nodes pointed at the same Blazegraph namespace can't silently corrupt each other any more. Mismatches print the cleanup recipe (`DELETE WHERE { ... }`).
+- **Backend-aware reset**: chain-reset (and rebooting against a different backend) scopes its `DELETE` to the `did:dkg:context-graph:` prefix, leaving any V6/V8 data on the same Blazegraph instance untouched. Docker-provisioned namespaces (`managedByDkg: true`) use the faster `DROP ALL` path.
+- **Backend-switch guard**: switching backends between boots is treated like a destructive operation. The daemon prints a multi-line warning and refuses to start unless you set `DKG_ACCEPT_STORE_RESET=1`. Reverting `store.backend` in your config recovers the previous backend's data.
+- **Metrics**: `/api/status` exposes `storeUrl` and `storeQuads` (cached for 30 s) instead of the `storeBytes` file size — quad count is what's meaningful when the store isn't a local file.
+- **Required config**: when you enable `largeLiteralStorage` or `sharedMemoryPublicSnapshotStorage` with an external backend, you must set their `directory` explicitly (no local store path to infer from). The daemon fails fast at config-load if either is missing.
+
+### Limitations
+
+- **Auth / TLS**: only the generic `sparql-http` backend accepts an `Authorization` header. For Blazegraph behind auth or HTTPS-with-custom-CA, run a reverse proxy in front of it for now.
+- **Migration tool**: there is no `dkg migrate-store` between backends. Plan a chain-reset window if you need to switch on a node that holds important non-VM state.
+
+---
+
 ## Testnet Funding
 
 A DKG testnet node needs Base Sepolia ETH (to pay gas for on-chain operations) and test TRAC (for staking and publishing). The Origin Trail testnet faucet hands out both in a single API call, so first-setup paths auto-fund the generated admin wallet plus the three operational wallets when a faucet is configured in the network config.

--- a/docs/setup/SETUP_CUSTOM.md
+++ b/docs/setup/SETUP_CUSTOM.md
@@ -280,10 +280,26 @@ await node.start();
 // Option A: Oxigraph directly
 const store = new OxigraphStore();
 
-// Option B: Any registered backend via the factory
+// Option B: Any registered backend via the factory.
+//
+// Use this when you want the same backend the daemon uses — Blazegraph
+// or any SPARQL 1.1 server (Fuseki, GraphDB, Stardog, …). The factory
+// runs whichever adapter was registered for the named backend; see the
+// "Triple Store Backends" section of the repo README for the full
+// matrix and config shapes.
+//
 // const store = await createTripleStore({
 //   backend: 'blazegraph',
 //   options: { url: 'http://127.0.0.1:9999/bigdata/namespace/mynode/sparql' },
+// });
+//
+// const store = await createTripleStore({
+//   backend: 'sparql-http',
+//   options: {
+//     queryEndpoint: 'http://server.example/query',
+//     updateEndpoint: 'http://server.example/update',
+//     auth: 'Bearer YOUR_TOKEN', // optional
+//   },
 // });
 
 const router = new ProtocolRouter(node);

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -59,6 +59,13 @@ export interface DaemonStatusResponse {
     rpcEndpointCount: number;
     hubConfigured: boolean;
   } | null;
+  // Triple-store backend fields (RFC 120). For local backends only
+  // `storeBackend` is meaningful; external backends additionally surface
+  // `storeUrl` and a TTL-cached `storeQuads` count. `null` when local /
+  // unreachable.
+  storeBackend?: string;
+  storeUrl?: string | null;
+  storeQuads?: number | null;
 }
 
 export class ApiClient {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -32,6 +32,7 @@ import {
 } from './config.js';
 import { ApiClient } from './api-client.js';
 import { parsePositiveIntegerOption, parsePositiveMsOption } from './publisher-runner.js';
+import { promptStoreBackend, applyStoreFlagsToConfig } from './store-wizard.js';
 import { runConfiguredSourceWorker } from './source-worker-runner.js';
 
 function isDaemonUnreachable(err: unknown): boolean {
@@ -602,6 +603,14 @@ program
   .command('init')
   .description('Interactive setup — set node name, role, and relay')
   .option('--role <role>', "Node role: 'edge' (default; personal laptop / behind NAT) or 'core' (24/7 relay / SLA)")
+  .option(
+    '--store <backend>',
+    'Pre-fill the triple-store backend prompt (oxigraph | blazegraph | sparql-http).',
+  )
+  .option(
+    '--store-url <url>',
+    'Pre-fill the SPARQL endpoint URL prompt for external backends.',
+  )
   .action(async (opts: ActionOpts) => {
     // OT-RFC-41 Bundle B1c: monorepo guard. `dkg init` from a
     // contributor checkout is almost always a mistake — the
@@ -630,6 +639,7 @@ program
       );
       process.exit(1);
     }
+
 
     await ensureDkgDir();
     const existing = await loadConfig();
@@ -666,6 +676,19 @@ program
       const roleAnswer = await ask('Node role (edge / core)', defaultRole);
       nodeRole = roleAnswer === 'core' ? 'core' : 'edge';
     }
+
+    // Triple-store backend (RFC 120, plan PR 2 item 1 + PR 3 Docker
+    // branch). Default: stay on local Oxigraph. Operators selecting
+    // "blazegraph" with a blank URL get the Docker convenience path
+    // (if Docker is installed) — the namespace name defaults to the
+    // node name so each operator gets their own DKG-owned namespace.
+    const { storeBlock } = await promptStoreBackend({
+      ask,
+      existingStore: existing.store,
+      flagBackend: opts.store,
+      flagUrl: opts.storeUrl,
+      nodeName: name || existing.name,
+    });
 
     // Pre-fill relay from network config if user hasn't set one.
     // Show the first relay as the default, but only persist to config if the
@@ -800,6 +823,11 @@ program
       autoUpdate: enableAutoUpdate ? autoUpdate : existing.autoUpdate,
       chain: chainSection ?? existing.chain,
       auth: { enabled: enableAuth, tokens: existing.auth?.tokens },
+      // Persist the chosen backend. `storeBlock === null` from the
+      // wizard means "use the local default" — we explicitly clear any
+      // existing block so re-running `dkg init` to switch from
+      // blazegraph back to oxigraph actually applies.
+      store: storeBlock ?? undefined,
     };
     await saveConfig(config);
 
@@ -823,6 +851,13 @@ program
     console.log(`  context graphs: ${contextGraphs.length ? contextGraphs.join(', ') : '(none)'}`);
     console.log(`  apiPort:    ${config.apiPort}`);
     console.log(`  auth:       ${enableAuth ? `enabled (token in ${dkgAuthTokenPath(dkgDir())})` : 'disabled'}`);
+    console.log(
+      `  store:      ${
+        storeBlock
+          ? `${storeBlock.backend} (${(storeBlock.options as { url: string }).url})`
+          : 'oxigraph (local default)'
+      }`,
+    );
     {
       const resolved = resolveAutoUpdateConfig(config, network);
       console.log(
@@ -1200,6 +1235,20 @@ program
       console.log(`  Uptime:    ${uptime}`);
       console.log(`  Peers:     ${s.connectedPeers}`);
       console.log(`  Relay:     ${s.relayConnected ? 'connected' : 'not connected'}`);
+      // Backend visibility: local backends print just the name (file
+      // bytes are graphed via /api/dashboard); external backends print
+      // backend + endpoint + quad count, falling back to a clear
+      // "unreachable" signal when the daemon couldn't talk to the
+      // remote store. Quad count = null is rare in practice (cached
+      // every 30 s on the daemon side) so when it shows up the
+      // operator should treat it as an alert, not a no-op.
+      const backend = s.storeBackend ?? 'oxigraph-worker';
+      if (s.storeUrl) {
+        const quads = s.storeQuads == null ? 'UNREACHABLE' : `${s.storeQuads.toLocaleString()} quads`;
+        console.log(`  Store:     ${backend} (${s.storeUrl}) — ${quads}`);
+      } else {
+        console.log(`  Store:     ${backend}`);
+      }
     } catch (err) {
       console.error(toErrorMessage(err));
       process.exit(1);
@@ -2382,6 +2431,14 @@ openclawCmd
   .option('--dry-run', 'Preview changes without writing anything')
   .option('--no-fund', 'Skip wallet funding via testnet faucet')
   .option('--fund', 'Fund wallets via testnet faucet (default)')
+  .option(
+    '--store <backend>',
+    'Triple-store backend (oxigraph | blazegraph | sparql-http). Validates the URL via an ASK probe and persists the store block after setup completes.',
+  )
+  .option(
+    '--store-url <url>',
+    'SPARQL endpoint URL — required when --store is blazegraph or sparql-http.',
+  )
   .action(async (opts, command) => {
     // Dynamic import + process.exit plumbing stay here; the actual `runSetup`
     // call lives in `openclawSetupAction` so it can be unit-tested without
@@ -2400,6 +2457,14 @@ openclawCmd
     const { openclawSetupAction } = await import('./openclaw-setup.js');
     try {
       await openclawSetupAction(opts, command, { runSetup });
+      // Persist --store / --store-url after the action's ensureDkgNodeConfig
+      // has run; otherwise the config file may not exist yet on a fresh
+      // install. Validation hits the same boot-time probe used by the
+      // daemon, so an invalid URL fails here, not on the next dkg start.
+      await applyStoreFlagsToConfig({
+        storeFlag: opts.store,
+        storeUrlFlag: opts.storeUrl,
+      });
     } catch (err: any) {
       console.error(`\n[setup] ERROR: ${err?.message ?? err}\n`);
       process.exit(1);
@@ -2456,6 +2521,14 @@ mcpCmd
   .option('--force', 'Refresh every detected client regardless of current registration state')
   .option('--print-only', 'Print the canonical JSON to stdout; skip every other step')
   .option('--yes', 'Auto-confirm per-client registrations (default false: prompt interactively in TTY mode; non-TTY auto-confirms — pass `--yes` in scripts for the safer scripted-environment posture)')
+  .option(
+    '--store <backend>',
+    'Triple-store backend (oxigraph | blazegraph | sparql-http). Validates the URL and persists the store block after setup.',
+  )
+  .option(
+    '--store-url <url>',
+    'SPARQL endpoint URL — required when --store is blazegraph or sparql-http.',
+  )
   .option('--installed', 'Force installed-mode setup. Bootstrap home: `~/.dkg`. Registered binary: the running CLI (whichever invoked this command — typically the global `dkg`). Use this from a monorepo cwd when you want the global install instead of the local dist. Mutually exclusive with --monorepo.')
   .option('--monorepo', 'Force monorepo-mode setup. Bootstrap home: `~/.dkg-dev`. Registered binary: the local `<repo>/packages/cli/dist/cli.js` script (located via cwd-first walk; falls back to the running CLI dir). Errors if no DKG monorepo root is detected. Switches BOTH bootstrap home AND the registered binary, unlike --installed which only switches the home. Mutually exclusive with --installed.')
   .action(async (opts) => {
@@ -2493,6 +2566,10 @@ mcpCmd
         requestFaucetFunding: coreExports.requestFaucetFunding,
         findDkgMonorepoRoot: coreExports.findDkgMonorepoRoot,
         resolveDkgConfigHome: coreExports.resolveDkgConfigHome,
+      });
+      await applyStoreFlagsToConfig({
+        storeFlag: opts.store,
+        storeUrlFlag: opts.storeUrl,
       });
     } catch (err: any) {
       console.error(`\n[dkg mcp setup] ERROR: ${err?.message ?? err}\n`);
@@ -2579,6 +2656,14 @@ hermesCmd
     '--no-replace-provider',
     'Alias for --preserve-provider',
   )
+  .option(
+    '--store <backend>',
+    'Triple-store backend (oxigraph | blazegraph | sparql-http). Validates the URL and persists the store block after setup.',
+  )
+  .option(
+    '--store-url <url>',
+    'SPARQL endpoint URL — required when --store is blazegraph or sparql-http.',
+  )
   .action(async (opts, command) => {
     const runSetup = await loadHermesAdapterAction('setup', ['runSetup', 'setup']);
     const { hermesSetupAction } = await import('./hermes-setup.js');
@@ -2590,6 +2675,10 @@ hermesCmd
         ? { ...opts, preserveProvider: true }
         : opts;
       await hermesSetupAction(merged, command, { runSetup });
+      await applyStoreFlagsToConfig({
+        storeFlag: opts.store,
+        storeUrlFlag: opts.storeUrl,
+      });
     } catch (err: any) {
       console.error(`\n[hermes setup] ERROR: ${err?.message ?? err}\n`);
       process.exit(1);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4757,7 +4757,7 @@ program
     const deps = createProductionDeps({ apiPort: config.apiPort ?? 9200 });
     // Overlay operator-configured scan roots + skipChecks from config.
     // The doctor namespace is opt-in — absent config means defaults.
-    const doctorConfig = (config as Record<string, unknown>).doctor as
+    const doctorConfig = (config as unknown as Record<string, unknown>).doctor as
       | { scanRoots?: unknown; skipChecks?: unknown }
       | undefined;
     if (doctorConfig) {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1118,6 +1118,117 @@ export async function loadConfig(): Promise<DkgConfig> {
   }
 }
 
+// =====================================================================
+// External-backend config validation (RFC 120, plan PR 1 item 6)
+// =====================================================================
+//
+// External triple-store backends (Blazegraph, sparql-http) impose two
+// requirements beyond the local-file default:
+//
+//   1. `store.options.url` (or `queryEndpoint`) must be set. The adapter
+//      will throw without it, but only deep inside agent boot — by which
+//      point logs already have stack traces from finalization wiring
+//      that started before the agent. Surfacing the error here at
+//      config-load time gives operators a single-line, actionable error.
+//   2. `largeLiteralStorage.directory` and
+//      `sharedMemoryPublicSnapshotStorage.directory` must be explicit
+//      when those features are enabled. The defaults derive a directory
+//      from the local triple-store's persistent path; an external
+//      backend has no such path, so without explicit directories the
+//      blob store throws when it sees its first oversized literal
+//      (potentially weeks after install).
+//
+// Returns an array of error messages — empty if config is valid. Caller
+// decides whether to log + exit (boot path) or surface as a config-save
+// rejection (future wizard path).
+const EXTERNAL_VALIDATION_PREFIX = '[config] store.backend';
+
+export interface StoreConfigValidationError {
+  /** Field path within the config that failed validation. */
+  field: string;
+  /** Human-readable error message including remediation hint. */
+  message: string;
+}
+
+export function validateStoreConfig(config: DkgConfig): StoreConfigValidationError[] {
+  const errors: StoreConfigValidationError[] = [];
+  const backend = config.store?.backend;
+  // Mirror of `isExternalBackend` from @origintrail-official/dkg-storage.
+  // Duplicated here to keep config.ts free of upward dependencies on the
+  // storage package (config.ts is leaf-imported by many other modules).
+  const isExternal = backend === 'blazegraph' || backend === 'sparql-http';
+  if (!isExternal) return errors;
+
+  const opts = (config.store?.options ?? {}) as Record<string, unknown>;
+
+  if (backend === 'blazegraph') {
+    if (typeof opts.url !== 'string' || !opts.url.trim()) {
+      errors.push({
+        field: 'store.options.url',
+        message:
+          `${EXTERNAL_VALIDATION_PREFIX} is "blazegraph" but ` +
+          `store.options.url is missing. Set it to the SPARQL endpoint URL ` +
+          `(e.g. http://127.0.0.1:9999/bigdata/namespace/mynode/sparql) or ` +
+          `switch backend to oxigraph-worker.`,
+      });
+    }
+  } else if (backend === 'sparql-http') {
+    if (typeof opts.queryEndpoint !== 'string' || !opts.queryEndpoint.trim()) {
+      errors.push({
+        field: 'store.options.queryEndpoint',
+        message:
+          `${EXTERNAL_VALIDATION_PREFIX} is "sparql-http" but ` +
+          `store.options.queryEndpoint is missing. Set it to the SPARQL query URL.`,
+      });
+    }
+  }
+
+  if (config.largeLiteralStorage?.enabled === true) {
+    const dir = config.largeLiteralStorage.directory;
+    if (typeof dir !== 'string' || !dir.trim()) {
+      errors.push({
+        field: 'largeLiteralStorage.directory',
+        message:
+          `largeLiteralStorage.enabled=true with an external store backend requires ` +
+          `largeLiteralStorage.directory to be set explicitly (no local store path ` +
+          `to infer it from). Either set the directory or disable large-literal storage.`,
+      });
+    }
+  }
+
+  if (config.sharedMemoryPublicSnapshotStorage?.enabled === true) {
+    const dir = config.sharedMemoryPublicSnapshotStorage.directory;
+    if (typeof dir !== 'string' || !dir.trim()) {
+      errors.push({
+        field: 'sharedMemoryPublicSnapshotStorage.directory',
+        message:
+          `sharedMemoryPublicSnapshotStorage.enabled=true with an external store backend ` +
+          `requires sharedMemoryPublicSnapshotStorage.directory to be set explicitly.`,
+      });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Convenience helper: validate, log every error, exit if any. Daemon
+ * boot uses this; the future wizard path will iterate `errors` to
+ * re-prompt instead of exiting.
+ */
+export function exitOnStoreConfigErrors(
+  config: DkgConfig,
+  log: (msg: string) => void,
+): void {
+  const errors = validateStoreConfig(config);
+  if (errors.length === 0) return;
+  log(`[STORE-CONFIG] ${errors.length} validation error(s) — refusing to start.`);
+  for (const err of errors) {
+    log(`  ${err.field}: ${err.message}`);
+  }
+  process.exit(1);
+}
+
 export async function saveConfig(config: DkgConfig): Promise<void> {
   await ensureDkgDir();
   await writeFile(configPath(), JSON.stringify(config, null, 2) + '\n');

--- a/packages/cli/src/daemon/blazegraph-docker.ts
+++ b/packages/cli/src/daemon/blazegraph-docker.ts
@@ -1,0 +1,453 @@
+/**
+ * Blazegraph Docker provisioner (RFC 120, plan PR 3 item 1).
+ *
+ * One-command Blazegraph setup for operators who already have Docker.
+ * Ported from `start_blazegraph` in [scripts/devnet.sh:254-303](../../../../scripts/devnet.sh)
+ * with three changes for the operator-facing path:
+ *
+ *  1. Hard errors instead of "warn and fall back" — the operator opted
+ *     in to Docker via the wizard / flag, so silently downgrading to
+ *     Oxigraph would be worse than failing fast.
+ *  2. Idempotent reuse — `docker inspect <name>` first; if the container
+ *     is already running with the right namespace, return its URL
+ *     without re-pulling or re-creating.
+ *  3. Port-collision auto-bump — try ports `[9999, 9999+range)`
+ *     before giving up. Operators may have V6 nodes on 9999 from
+ *     prior installs.
+ *
+ * Every external dependency (docker CLI, fetch, port-free check) is
+ * injectable so the unit tests run in <50 ms without spawning real
+ * processes or making real HTTP calls. The defaults wire up to the
+ * real `node:child_process` and `globalThis.fetch`.
+ *
+ * The "managedByDkg: true" return field is what tells chain-reset-wipe
+ * (PR 1) it's allowed to `DROP ALL` instead of running a scoped DELETE
+ * — Docker-provisioned namespaces are owned end-to-end by this CLI.
+ *
+ * The provisioner does NOT modify `scripts/devnet.sh`. The devnet
+ * loop orchestrates multiple containers across nodes 3-4 with
+ * different concerns; the namespace XML body is the only shared
+ * artifact and is exported as `BLAZEGRAPH_NAMESPACE_XML_TEMPLATE`.
+ */
+import { spawn } from 'node:child_process';
+import * as net from 'node:net';
+
+/**
+ * Shared XML template for a Blazegraph namespace tuned for DKG V10
+ * (quads enabled, no truth maintenance, no text index, no statement
+ * identifiers). Substitutes `{namespace}` for the namespace name.
+ *
+ * Mirrors the body inlined at scripts/devnet.sh:287-294. Kept here so
+ * future tweaks land in one place.
+ */
+export const BLAZEGRAPH_NAMESPACE_XML_TEMPLATE = `<?xml version="1.0" encoding="UTF-8"?>
+<properties>
+  <entry key="com.bigdata.rdf.sail.namespace">{namespace}</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.quads">true</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers">false</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.textIndex">false</entry>
+  <entry key="com.bigdata.rdf.sail.truthMaintenance">false</entry>
+</properties>`;
+
+/** Pinned image tag — matches devnet.sh and Blazegraph mainnet. */
+export const BLAZEGRAPH_IMAGE = 'lyrasis/blazegraph:2.1.5';
+
+/** Default container port that lyrasis/blazegraph exposes. */
+const BLAZEGRAPH_CONTAINER_PORT = 8080;
+
+/** Default starting host port, matches devnet.sh and Blazegraph defaults. */
+const DEFAULT_HOST_PORT_START = 9999;
+/** Inclusive range above start to scan for a free port before failing. */
+const DEFAULT_HOST_PORT_RANGE = 12; // 9999..10010
+
+// --------------------------------------------------------------------
+// Injectable types — tests pass mocks for every external boundary.
+// --------------------------------------------------------------------
+
+export interface DockerCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface DockerRunner {
+  /**
+   * Run `docker <args>`. Should NOT throw on non-zero exit — return
+   * the result so the provisioner can decide whether the failure is
+   * fatal (e.g. `docker run`) or expected (e.g. `docker inspect` on a
+   * non-existent container).
+   */
+  run(args: readonly string[], opts?: { timeoutMs?: number }): Promise<DockerCommandResult>;
+}
+
+export interface ProvisionBlazegraphDockerOptions {
+  /** Used to name the container and create the namespace inside it. */
+  namespace: string;
+  /** Override container name. Default: `dkg-blazegraph-<namespace>`. */
+  containerName?: string;
+  /** Preferred host port. Default: 9999. */
+  port?: number;
+  /** Inclusive count of ports to scan starting at `port` for collisions. */
+  portRange?: number;
+  log?: (msg: string) => void;
+  // Injectables (tests provide these; production callers omit them):
+  docker?: DockerRunner;
+  fetch?: typeof globalThis.fetch;
+  /** Returns true if no listener is bound to the given port. */
+  isPortFree?: (port: number) => Promise<boolean>;
+  /** Polling interval while waiting for /bigdata/status to respond. */
+  pollIntervalMs?: number;
+  /** Total time to wait for Blazegraph to come up. */
+  pollTimeoutMs?: number;
+}
+
+export interface ProvisionBlazegraphDockerResult {
+  url: string;
+  port: number;
+  containerName: string;
+  /**
+   * Marker for chain-reset-wipe (PR 1): a `managedByDkg: true` store
+   * may be wiped with `DROP ALL`. Always true from this function.
+   */
+  managedByDkg: true;
+  /**
+   * Whether the container was already running and re-used. Affects
+   * the wizard log ("container created" vs "reusing existing").
+   */
+  reused: boolean;
+  /**
+   * Whether the namespace was created during this run vs already
+   * present. Lets the wizard surface a useful summary line.
+   */
+  namespaceCreated: boolean;
+}
+
+// --------------------------------------------------------------------
+// Default real-world implementations of the injectables.
+// --------------------------------------------------------------------
+
+function defaultDockerRunner(): DockerRunner {
+  return {
+    run(args, opts) {
+      return new Promise<DockerCommandResult>((resolve, reject) => {
+        const child = spawn('docker', [...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (b) => { stdout += b.toString('utf-8'); });
+        child.stderr.on('data', (b) => { stderr += b.toString('utf-8'); });
+        const timeoutMs = opts?.timeoutMs;
+        const timer = timeoutMs
+          ? setTimeout(() => { child.kill('SIGKILL'); }, timeoutMs)
+          : undefined;
+        child.once('error', (err) => {
+          if (timer) clearTimeout(timer);
+          // Most common case: docker binary not installed → ENOENT.
+          // Surface a clear error rather than the cryptic spawn error.
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code === 'ENOENT') {
+            reject(new Error(
+              "docker CLI not found on PATH — install Docker Desktop or the Docker Engine and ensure 'docker' resolves on your shell PATH",
+            ));
+            return;
+          }
+          reject(err);
+        });
+        child.once('close', (exitCode) => {
+          if (timer) clearTimeout(timer);
+          resolve({ stdout, stderr, exitCode: exitCode ?? 0 });
+        });
+      });
+    },
+  };
+}
+
+async function defaultIsPortFree(port: number): Promise<boolean> {
+  // Use net.createServer instead of `lsof` so we don't shell out and
+  // we keep the check cross-platform. A successful listen → close
+  // means the port is free at this moment (TOCTOU exists but is the
+  // same race Docker itself runs into).
+  return new Promise<boolean>((resolve) => {
+    const tester = net.createServer()
+      .once('error', (err: NodeJS.ErrnoException) => {
+        // EADDRINUSE → port taken. Any other code → assume taken to be
+        // safe (e.g. EACCES on privileged ports).
+        resolve(err.code !== 'EADDRINUSE' ? false : false);
+      })
+      .once('listening', () => {
+        tester.close(() => resolve(true));
+      })
+      .listen(port, '127.0.0.1');
+  });
+}
+
+// --------------------------------------------------------------------
+// Internals
+// --------------------------------------------------------------------
+
+function sanitiseContainerName(namespace: string): string {
+  // Docker container names: [a-zA-Z0-9_.-]+. Slugify so user-provided
+  // node names like "Bob's Node" don't blow up `docker run`.
+  const slug = namespace
+    .normalize('NFKD')
+    .replace(/[^a-zA-Z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+  return `dkg-blazegraph-${slug || 'node'}`;
+}
+
+async function findFreePort(
+  start: number,
+  range: number,
+  isPortFree: (port: number) => Promise<boolean>,
+  log: (msg: string) => void,
+): Promise<number> {
+  for (let p = start; p < start + range; p++) {
+    if (await isPortFree(p)) {
+      if (p !== start) log(`  Port ${start} taken; using ${p} instead.`);
+      return p;
+    }
+  }
+  throw new Error(
+    `No free port found in the range ${start}..${start + range - 1}. ` +
+    'Close another service occupying these ports or pass --port <free port>.',
+  );
+}
+
+interface ContainerInspectInfo {
+  exists: boolean;
+  running: boolean;
+  hostPort?: number;
+}
+
+async function inspectContainer(
+  docker: DockerRunner,
+  name: string,
+): Promise<ContainerInspectInfo> {
+  // `docker inspect <name>` exits non-zero with "No such object" when
+  // the container doesn't exist; non-zero is our "doesn't exist"
+  // signal. Otherwise parse the JSON to get state + port mapping.
+  const result = await docker.run(['inspect', name]);
+  if (result.exitCode !== 0) {
+    return { exists: false, running: false };
+  }
+  try {
+    const arr = JSON.parse(result.stdout);
+    const info = Array.isArray(arr) && arr.length > 0 ? arr[0] : null;
+    if (!info) return { exists: true, running: false };
+    const running = info.State?.Running === true;
+    const portBinding = info.NetworkSettings?.Ports?.[`${BLAZEGRAPH_CONTAINER_PORT}/tcp`];
+    const hostPort = Array.isArray(portBinding) && portBinding.length > 0
+      ? Number(portBinding[0].HostPort)
+      : undefined;
+    return { exists: true, running, hostPort };
+  } catch {
+    return { exists: true, running: false };
+  }
+}
+
+/**
+ * Polls `/bigdata/status` until the server answers HTTP 200 or the
+ * timeout elapses. Mirrors the 30-attempt loop in devnet.sh but
+ * surfaces the failure as a thrown error.
+ */
+async function waitForBlazegraphReady(opts: {
+  url: string;
+  fetch: typeof globalThis.fetch;
+  intervalMs: number;
+  timeoutMs: number;
+  log: (msg: string) => void;
+}): Promise<void> {
+  const start = Date.now();
+  let attempt = 0;
+  while (Date.now() - start < opts.timeoutMs) {
+    attempt++;
+    try {
+      const r = await opts.fetch(`${opts.url}/bigdata/status`, { method: 'GET' });
+      if (r.ok) {
+        opts.log(`  Blazegraph ready after ${attempt} probe(s) (~${Math.round((Date.now() - start) / 1000)}s).`);
+        return;
+      }
+    } catch {
+      // Container not listening yet — keep polling.
+    }
+    await new Promise((res) => setTimeout(res, opts.intervalMs));
+  }
+  throw new Error(
+    `Blazegraph did not become ready within ${opts.timeoutMs}ms ` +
+    `at ${opts.url}/bigdata/status. Container started but the SPARQL endpoint is not responding.`,
+  );
+}
+
+async function namespaceExists(opts: {
+  url: string;
+  namespace: string;
+  fetch: typeof globalThis.fetch;
+}): Promise<boolean> {
+  // Blazegraph exposes per-namespace metadata at
+  // `/bigdata/namespace/<ns>/sparql/properties`. A 200 means present.
+  try {
+    const r = await opts.fetch(
+      `${opts.url}/bigdata/namespace/${encodeURIComponent(opts.namespace)}/sparql/properties`,
+      { method: 'GET' },
+    );
+    return r.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function createNamespace(opts: {
+  url: string;
+  namespace: string;
+  fetch: typeof globalThis.fetch;
+  log: (msg: string) => void;
+}): Promise<void> {
+  const body = BLAZEGRAPH_NAMESPACE_XML_TEMPLATE.replace(
+    '{namespace}',
+    opts.namespace,
+  );
+  const r = await opts.fetch(`${opts.url}/bigdata/namespace`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/xml' },
+    body,
+  });
+  if (!r.ok) {
+    let detail = '';
+    try { detail = (await r.text()).slice(0, 200); } catch { /* ignore */ }
+    throw new Error(
+      `Failed to create Blazegraph namespace "${opts.namespace}" — HTTP ${r.status}${detail ? `: ${detail}` : ''}`,
+    );
+  }
+  opts.log(`  Created Blazegraph namespace "${opts.namespace}".`);
+}
+
+// --------------------------------------------------------------------
+// Public entry point
+// --------------------------------------------------------------------
+
+export async function provisionBlazegraphDocker(
+  opts: ProvisionBlazegraphDockerOptions,
+): Promise<ProvisionBlazegraphDockerResult> {
+  const log = opts.log ?? console.log;
+  const docker = opts.docker ?? defaultDockerRunner();
+  const fetch = opts.fetch ?? globalThis.fetch;
+  const isPortFree = opts.isPortFree ?? defaultIsPortFree;
+  const pollIntervalMs = opts.pollIntervalMs ?? 1000;
+  const pollTimeoutMs = opts.pollTimeoutMs ?? 30_000;
+  const portRange = opts.portRange ?? DEFAULT_HOST_PORT_RANGE;
+  const containerName = opts.containerName ?? sanitiseContainerName(opts.namespace);
+
+  // 1. Pre-flight: is docker installed?
+  const versionResult = await docker.run(['--version'], { timeoutMs: 5000 });
+  if (versionResult.exitCode !== 0) {
+    throw new Error(
+      "docker CLI is on PATH but `docker --version` failed — ensure the Docker daemon is installed and reachable. " +
+      `stderr: ${versionResult.stderr.trim() || '(empty)'}`,
+    );
+  }
+  log(`  Docker available: ${versionResult.stdout.trim().split('\n')[0]}`);
+
+  // 2. Reuse path — is the container already running?
+  const inspectInfo = await inspectContainer(docker, containerName);
+  if (inspectInfo.exists && inspectInfo.running) {
+    const port = inspectInfo.hostPort ?? opts.port ?? DEFAULT_HOST_PORT_START;
+    const url = `http://127.0.0.1:${port}`;
+    log(`  Reusing running container "${containerName}" on port ${port}.`);
+    await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
+    const created = !(await namespaceExists({ url, namespace: opts.namespace, fetch }));
+    if (created) {
+      await createNamespace({ url, namespace: opts.namespace, fetch, log });
+    } else {
+      log(`  Namespace "${opts.namespace}" already exists.`);
+    }
+    return {
+      url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+      port,
+      containerName,
+      managedByDkg: true,
+      reused: true,
+      namespaceCreated: created,
+    };
+  }
+
+  // 3. Stopped-but-exists path — start it back up before re-creating.
+  if (inspectInfo.exists && !inspectInfo.running) {
+    log(`  Container "${containerName}" exists but is stopped; starting it.`);
+    const startResult = await docker.run(['start', containerName]);
+    if (startResult.exitCode !== 0) {
+      // Fall through to recreate — `docker start` failed for some
+      // reason (e.g. config drift); remove and start fresh.
+      log(`  docker start failed (${startResult.stderr.trim() || 'unknown'}); recreating.`);
+      await docker.run(['rm', '-f', containerName]);
+    } else {
+      const port = (await inspectContainer(docker, containerName)).hostPort
+        ?? opts.port
+        ?? DEFAULT_HOST_PORT_START;
+      const url = `http://127.0.0.1:${port}`;
+      await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
+      const created = !(await namespaceExists({ url, namespace: opts.namespace, fetch }));
+      if (created) {
+        await createNamespace({ url, namespace: opts.namespace, fetch, log });
+      } else {
+        log(`  Namespace "${opts.namespace}" already exists.`);
+      }
+      return {
+        url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+        port,
+        containerName,
+        managedByDkg: true,
+        reused: true,
+        namespaceCreated: created,
+      };
+    }
+  }
+
+  // 4. Fresh create path — choose a port and run.
+  const portStart = opts.port ?? DEFAULT_HOST_PORT_START;
+  const chosenPort = await findFreePort(portStart, portRange, isPortFree, log);
+  log(`  Starting Blazegraph container "${containerName}" on port ${chosenPort}…`);
+  const runResult = await docker.run([
+    'run',
+    '-d',
+    '--restart', 'unless-stopped',
+    '--name', containerName,
+    '-p', `${chosenPort}:${BLAZEGRAPH_CONTAINER_PORT}`,
+    BLAZEGRAPH_IMAGE,
+  ]);
+  if (runResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to start Blazegraph container — docker run exited ${runResult.exitCode}. ` +
+      `stderr: ${runResult.stderr.trim() || '(empty)'}`,
+    );
+  }
+
+  const url = `http://127.0.0.1:${chosenPort}`;
+  await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
+  await createNamespace({ url, namespace: opts.namespace, fetch, log });
+
+  return {
+    url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+    port: chosenPort,
+    containerName,
+    managedByDkg: true,
+    reused: false,
+    namespaceCreated: true,
+  };
+}
+
+/**
+ * Cheap "is docker available?" check for the wizard. Doesn't need to
+ * start anything — we just need to know whether to offer the Docker
+ * branch or skip straight to the manual-URL retry.
+ */
+export async function isDockerAvailable(
+  docker?: DockerRunner,
+): Promise<boolean> {
+  const runner = docker ?? defaultDockerRunner();
+  try {
+    const result = await runner.run(['--version'], { timeoutMs: 3000 });
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/daemon/blazegraph-docker.ts
+++ b/packages/cli/src/daemon/blazegraph-docker.ts
@@ -195,6 +195,20 @@ function sanitiseContainerName(namespace: string): string {
   return `dkg-blazegraph-${slug || 'node'}`;
 }
 
+export function normaliseBlazegraphNamespace(namespace: string): string {
+  const slug = namespace
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+  return slug || 'dkg-node';
+}
+
+function sparqlUrlForNamespace(baseUrl: string, namespace: string): string {
+  return `${baseUrl}/bigdata/namespace/${encodeURIComponent(namespace)}/sparql`;
+}
+
 async function findFreePort(
   start: number,
   range: number,
@@ -335,7 +349,11 @@ export async function provisionBlazegraphDocker(
   const pollIntervalMs = opts.pollIntervalMs ?? 1000;
   const pollTimeoutMs = opts.pollTimeoutMs ?? 30_000;
   const portRange = opts.portRange ?? DEFAULT_HOST_PORT_RANGE;
-  const containerName = opts.containerName ?? sanitiseContainerName(opts.namespace);
+  const namespace = normaliseBlazegraphNamespace(opts.namespace);
+  if (namespace !== opts.namespace) {
+    log(`  Normalized Blazegraph namespace "${opts.namespace}" → "${namespace}".`);
+  }
+  const containerName = opts.containerName ?? sanitiseContainerName(namespace);
 
   // 1. Pre-flight: is docker installed?
   const versionResult = await docker.run(['--version'], { timeoutMs: 5000 });
@@ -354,14 +372,14 @@ export async function provisionBlazegraphDocker(
     const url = `http://127.0.0.1:${port}`;
     log(`  Reusing running container "${containerName}" on port ${port}.`);
     await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
-    const created = !(await namespaceExists({ url, namespace: opts.namespace, fetch }));
+    const created = !(await namespaceExists({ url, namespace, fetch }));
     if (created) {
-      await createNamespace({ url, namespace: opts.namespace, fetch, log });
+      await createNamespace({ url, namespace, fetch, log });
     } else {
-      log(`  Namespace "${opts.namespace}" already exists.`);
+      log(`  Namespace "${namespace}" already exists.`);
     }
     return {
-      url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+      url: sparqlUrlForNamespace(url, namespace),
       port,
       containerName,
       managedByDkg: true,
@@ -385,14 +403,14 @@ export async function provisionBlazegraphDocker(
         ?? DEFAULT_HOST_PORT_START;
       const url = `http://127.0.0.1:${port}`;
       await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
-      const created = !(await namespaceExists({ url, namespace: opts.namespace, fetch }));
+      const created = !(await namespaceExists({ url, namespace, fetch }));
       if (created) {
-        await createNamespace({ url, namespace: opts.namespace, fetch, log });
+        await createNamespace({ url, namespace, fetch, log });
       } else {
-        log(`  Namespace "${opts.namespace}" already exists.`);
+        log(`  Namespace "${namespace}" already exists.`);
       }
       return {
-        url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+        url: sparqlUrlForNamespace(url, namespace),
         port,
         containerName,
         managedByDkg: true,
@@ -423,10 +441,10 @@ export async function provisionBlazegraphDocker(
 
   const url = `http://127.0.0.1:${chosenPort}`;
   await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
-  await createNamespace({ url, namespace: opts.namespace, fetch, log });
+  await createNamespace({ url, namespace, fetch, log });
 
   return {
-    url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+    url: sparqlUrlForNamespace(url, namespace),
     port: chosenPort,
     containerName,
     managedByDkg: true,

--- a/packages/cli/src/daemon/chain-reset-wipe.ts
+++ b/packages/cli/src/daemon/chain-reset-wipe.ts
@@ -53,14 +53,62 @@
  */
 import { existsSync, readFileSync, writeFileSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import { isExternalBackend, getSparqlEndpoint } from '@origintrail-official/dkg-storage';
 
 const STATE_FILE = '.network-state.json';
 
 interface PersistedNetworkState {
   /** Last chainResetMarker value the daemon booted on. */
   chainResetMarker: string | null;
+  /**
+   * Last triple-store backend the daemon booted on. Used by
+   * `detectBackendSwitch` to warn loudly when an operator hand-edits
+   * `config.store.backend` between boots — the new backend is fresh
+   * and empty, so silently booting would mean stale SWM/VM data is
+   * inaccessible. `null` on legacy state files (pre-RFC 120) and on
+   * first boot. (RFC 120 review point #6.)
+   */
+  lastBackend?: string | null;
   savedAt: number;
 }
+
+/**
+ * Subset of `DkgConfig['store']` used by the wipe step to talk to an
+ * external SPARQL endpoint. Decoupled from the CLI's config types so
+ * this module stays free of upward dependencies.
+ */
+export interface ChainResetWipeStoreConfig {
+  backend: string;
+  options?: {
+    url?: string;
+    queryEndpoint?: string;
+    updateEndpoint?: string;
+    auth?: string;
+    /**
+     * True when the namespace was provisioned by the CLI (PR 3 Docker
+     * convenience path). Operator-provided URLs default to false; the
+     * wipe then scopes deletes to the V10 named-graph prefix to avoid
+     * clobbering V6/V8 data sharing the same Blazegraph instance.
+     */
+    managedByDkg?: boolean;
+  };
+}
+
+/**
+ * V10 named-graph prefix. Every context-graph the agent writes — meta,
+ * shared-memory, finalisation — is rooted at `did:dkg:context-graph:`
+ * (confirmed in core/genesis.ts + finalization-handler.ts + dkg-agent.ts).
+ * Scoped DELETE for operator-provided external endpoints filters on this
+ * prefix to leave non-V10 data (V6/V8 assertions, operator side
+ * projects) alone.
+ */
+const V10_GRAPH_PREFIX = 'did:dkg:context-graph:';
+
+const SPARQL_DROP_ALL = 'DROP ALL';
+const SPARQL_SCOPED_DELETE =
+  'DELETE { GRAPH ?g { ?s ?p ?o } } ' +
+  'WHERE { GRAPH ?g { ?s ?p ?o } ' +
+  `FILTER(strstarts(str(?g), "${V10_GRAPH_PREFIX}")) }`;
 
 export interface ChainResetWipeResult {
   /** True when a wipe was performed. */
@@ -94,6 +142,19 @@ export interface ChainResetWipeOptions {
    * Falsy → fall back to `dataDir/random-sampling.wal` (the default).
    */
   randomSamplingWalPath?: string;
+  /**
+   * Operator's `config.store` block. Required to wipe an external SPARQL
+   * endpoint when the backend is `blazegraph` / `sparql-http`. Local
+   * backends ignore this field.
+   */
+  storeConfig?: ChainResetWipeStoreConfig;
+  /**
+   * Override for the SPARQL HTTP transport. Tests inject a mock to
+   * assert the issued UPDATE body; defaults to `globalThis.fetch`.
+   * Kept on the options surface (rather than module-scope monkey-patch)
+   * so parallel test cases don't race.
+   */
+  fetch?: typeof globalThis.fetch;
   /** Optional logger. Defaults to no-op so the function is silent in tests by default. */
   log?: (msg: string) => void;
 }
@@ -110,14 +171,94 @@ function loadState(dataDir: string): PersistedNetworkState | null {
 }
 
 function saveState(dataDir: string, marker: string | null): void {
+  // Preserve any sibling fields (lastBackend) that `detectBackendSwitch`
+  // may have written. Otherwise a chain-reset wipe would clobber a
+  // freshly-recorded backend tag and the next boot would re-warn.
+  const existing = loadState(dataDir) ?? { chainResetMarker: null, savedAt: 0 };
   writeFileSync(
     join(dataDir, STATE_FILE),
     JSON.stringify(
-      { chainResetMarker: marker, savedAt: Date.now() } satisfies PersistedNetworkState,
+      {
+        ...existing,
+        chainResetMarker: marker,
+        savedAt: Date.now(),
+      } satisfies PersistedNetworkState,
       null,
       2,
     ),
   );
+}
+
+function saveBackendTag(dataDir: string, backend: string): void {
+  const existing = loadState(dataDir) ?? { chainResetMarker: null, savedAt: 0 };
+  writeFileSync(
+    join(dataDir, STATE_FILE),
+    JSON.stringify(
+      {
+        ...existing,
+        lastBackend: backend,
+        savedAt: Date.now(),
+      } satisfies PersistedNetworkState,
+      null,
+      2,
+    ),
+  );
+}
+
+/**
+ * Wipe the V10 data sitting in an external SPARQL endpoint. Runs after
+ * the local file wipe so we don't strand the operator with a wiped FS
+ * but a populated remote namespace (or vice versa).
+ *
+ * - `managedByDkg === true` → `DROP ALL`. Safe because the namespace
+ *   was provisioned by the CLI and nobody else writes to it.
+ * - otherwise → scoped DELETE filtered by `did:dkg:context-graph:`. The
+ *   operator may be sharing the instance with V6/V8 nodes or unrelated
+ *   data; the wipe must leave anything that isn't V10 alone.
+ */
+async function performExternalWipe(
+  storeConfig: ChainResetWipeStoreConfig,
+  fetchImpl: typeof globalThis.fetch,
+  log: (msg: string) => void,
+): Promise<{ label: string; ok: boolean; error?: string }> {
+  const { updateUrl, headers } = getSparqlEndpoint({
+    backend: storeConfig.backend,
+    options: storeConfig.options,
+  });
+  const managed = storeConfig.options?.managedByDkg === true;
+  const update = managed ? SPARQL_DROP_ALL : SPARQL_SCOPED_DELETE;
+  const label = managed
+    ? `<sparql:drop-all ${updateUrl}>`
+    : `<sparql:scoped-delete ${updateUrl}>`;
+
+  log(
+    managed
+      ? `  external store (DKG-managed namespace): issuing DROP ALL against ${updateUrl}`
+      : `  external store (operator-provided URL): issuing scoped DELETE for "${V10_GRAPH_PREFIX}…" graphs against ${updateUrl}`,
+  );
+
+  try {
+    const res = await fetchImpl(updateUrl, {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `update=${encodeURIComponent(update)}`,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      const error = `${res.status} ${res.statusText}: ${text.slice(0, 200)}`;
+      log(`  WARN: external wipe failed: ${error}`);
+      return { label, ok: false, error };
+    }
+    log(`  removed: ${label}`);
+    return { label, ok: true };
+  } catch (err) {
+    const error = (err as Error).message;
+    log(`  WARN: external wipe transport error: ${error}`);
+    return { label, ok: false, error };
+  }
 }
 
 function performWipe(
@@ -183,8 +324,11 @@ function performWipe(
   return { removedFiles, failedFiles };
 }
 
-export function chainResetWipe(opts: ChainResetWipeOptions): ChainResetWipeResult {
+export async function chainResetWipe(
+  opts: ChainResetWipeOptions,
+): Promise<ChainResetWipeResult> {
   const log = opts.log ?? (() => {});
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
 
   // Networks that haven't opted in: hook is a no-op. No state file is
   // touched so we don't accidentally turn on the protocol later just
@@ -231,6 +375,27 @@ export function chainResetWipe(opts: ChainResetWipeOptions): ChainResetWipeResul
     );
   }
 
+  // External SPARQL wipe runs AFTER local file wipe. We don't gate one
+  // on the other — both wipes attempt independently so an operator with
+  // a flaky external endpoint still gets a clean local state and a
+  // failedFiles entry that retries on next boot. Wrapped in try/catch
+  // because helper construction (URL extraction) can throw on malformed
+  // config; we want to surface that as a failedFile, not crash the boot.
+  if (opts.storeConfig && isExternalBackend(opts.storeConfig.backend)) {
+    try {
+      const result = await performExternalWipe(opts.storeConfig, fetchImpl, log);
+      if (result.ok) {
+        removedFiles.push(result.label);
+      } else {
+        failedFiles.push({ file: result.label, error: result.error ?? 'unknown' });
+      }
+    } catch (err) {
+      const message = (err as Error).message;
+      failedFiles.push({ file: '<external-wipe>', error: message });
+      log(`WARN: external SPARQL wipe failed to start: ${message}.`);
+    }
+  }
+
   if (failedFiles.length === 0) {
     try {
       saveState(opts.dataDir, opts.currentMarker);
@@ -255,4 +420,124 @@ export function chainResetWipe(opts: ChainResetWipeOptions): ChainResetWipeResul
   }
 
   return { wiped: true, prevMarker, removedFiles, failedFiles };
+}
+
+// =====================================================================
+// Backend switch detection (RFC 120 review point #6)
+// =====================================================================
+//
+// Switching from Oxigraph to Blazegraph (or vice versa) mid-flight means
+// the new backend is fresh and empty — all SWM / VM data from the
+// previous backend is unreachable. The chain-reset-wipe marker doesn't
+// move when only the backend changes, so without a separate signal the
+// daemon would silently boot on an empty store and the operator would
+// see vanished context graphs with no explanation.
+//
+// This check runs at boot, BEFORE config validation / health probe /
+// chain-reset wipe. Outcomes:
+//   - First boot (no persisted lastBackend): silently record current.
+//   - Match: silently re-record (handles legacy state files that lacked
+//     the field).
+//   - Mismatch + `acceptStoreReset === true`: log warning, record new.
+//   - Mismatch + no override: log multi-line warning, return aborted.
+//     Caller (lifecycle) exits the process.
+//
+// `acceptStoreReset` is controlled by the env var
+// `DKG_ACCEPT_STORE_RESET=1`. A CLI flag on `dkg start` would also work
+// but env keeps the boot entrypoint flat; operators set the env once,
+// restart the daemon, then unset.
+
+export interface BackendSwitchDetectOptions {
+  dataDir: string;
+  /**
+   * Backend name from the current config. Pass the effective value
+   * including the default — e.g. when `config.store?.backend` is
+   * undefined, callers should pass `'oxigraph-worker'` so the check
+   * is symmetric across "no store block" ↔ "explicit store block".
+   */
+  currentBackend: string;
+  /**
+   * Operator opt-in to proceed despite a backend change. Sourced from
+   * `process.env.DKG_ACCEPT_STORE_RESET === '1'` in production; tests
+   * inject explicitly.
+   */
+  acceptStoreReset: boolean;
+  log?: (msg: string) => void;
+}
+
+export interface BackendSwitchDetectResult {
+  /** True when `lastBackend` was recorded and differs from `currentBackend`. */
+  changed: boolean;
+  /** Previously-recorded backend, or null if none / legacy state file. */
+  previous: string | null;
+  /** Effective current backend (passed through for callers). */
+  current: string;
+  /**
+   * True when the daemon should abort boot. Set on `changed && !acceptStoreReset`.
+   * Caller exits the process so the operator can either flip the env
+   * var or revert their config edit.
+   */
+  aborted: boolean;
+}
+
+export function detectBackendSwitch(
+  opts: BackendSwitchDetectOptions,
+): BackendSwitchDetectResult {
+  const log = opts.log ?? (() => {});
+  const prev = loadState(opts.dataDir);
+  const previous =
+    typeof prev?.lastBackend === 'string' && prev.lastBackend.length > 0
+      ? prev.lastBackend
+      : null;
+
+  // First boot or legacy state file: silently record and move on. We
+  // explicitly do NOT treat null-previous as a "switch from
+  // oxigraph-worker"; that would re-warn every operator who upgrades
+  // into this release without ever having touched their store
+  // configuration. Only operator-visible config changes between two
+  // recorded backends count as a switch.
+  if (previous === null) {
+    try {
+      saveBackendTag(opts.dataDir, opts.currentBackend);
+    } catch {
+      // Non-fatal: if we can't write the tag now, we'll try again next
+      // boot. The downside is one missed early-warning window.
+    }
+    return { changed: false, previous: null, current: opts.currentBackend, aborted: false };
+  }
+
+  if (previous === opts.currentBackend) {
+    return { changed: false, previous, current: opts.currentBackend, aborted: false };
+  }
+
+  // Mismatch.
+  const warningHeader = [
+    `[STORE-SWITCH] triple-store backend changed since last boot:`,
+    `  previous: ${previous}`,
+    `  current:  ${opts.currentBackend}`,
+    ``,
+    `The new backend is a fresh store. Any context graphs, shared`,
+    `memory, or finalised assertions held only in the previous backend`,
+    `are NOT migrated and will be inaccessible until you either:`,
+    `  - revert config.store.backend to "${previous}", or`,
+    `  - accept the data loss by setting DKG_ACCEPT_STORE_RESET=1 in`,
+    `    the environment and restarting.`,
+  ].join('\n');
+
+  if (!opts.acceptStoreReset) {
+    log(warningHeader);
+    log(``);
+    log(`Refusing to start: set DKG_ACCEPT_STORE_RESET=1 to proceed.`);
+    return { changed: true, previous, current: opts.currentBackend, aborted: true };
+  }
+
+  log(warningHeader);
+  log(``);
+  log(`DKG_ACCEPT_STORE_RESET=1 set — proceeding with the new backend.`);
+  try {
+    saveBackendTag(opts.dataDir, opts.currentBackend);
+  } catch (err) {
+    log(`WARN: failed to persist new backend tag: ${(err as Error).message}. Will re-warn on next boot.`);
+  }
+  return { changed: true, previous, current: opts.currentBackend, aborted: false };
 }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -59,6 +59,7 @@ import {
   type ApprovalPolicy,
 } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
+import { isExternalBackend } from '@origintrail-official/dkg-storage';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import {
@@ -110,6 +111,7 @@ import {
   resolveAutoUpdateSource,
   slotEntryPoint,
   CLI_NPM_PACKAGE,
+  exitOnStoreConfigErrors,
 } from '../config.js';
 import { createPublicSnapshotStore, createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
@@ -255,7 +257,13 @@ import {
   performNpmUpdate,
   performNpmUpdateEdge,
 } from './auto-update.js';
-import { chainResetWipe } from './chain-reset-wipe.js';
+import { chainResetWipe, detectBackendSwitch } from './chain-reset-wipe.js';
+import {
+  checkExternalStoreReachable,
+  checkOrSetStoreIdentity,
+  formatHealthCheckFailure,
+  formatIdentityTagMismatch,
+} from './store-health-check.js';
 import { resetNatStatus, startNatStatusWatcher } from './nat-status.js';
 import {
   OPENCLAW_UI_CONNECT_TIMEOUT_MS,
@@ -835,13 +843,84 @@ export async function runDaemonInner(
   // detects the change and wipes the now-orphaned chain state.
   // Operator's keystore + dashboard DB + uploaded files are preserved.
   // See docs/TESTNET_RESET.md and packages/cli/src/daemon/chain-reset-wipe.ts.
-  const wipeResult = chainResetWipe({
+  // Detect backend switch first. If the operator hand-edited
+  // store.backend between boots, refuse to start unless they opt in
+  // via DKG_ACCEPT_STORE_RESET=1. The new backend is fresh — any data
+  // held in the previous one is invisible to this boot. Booting
+  // silently would look like data loss to the operator.
+  const backendSwitch = detectBackendSwitch({
+    dataDir: dkgDir(),
+    currentBackend: config.store?.backend ?? 'oxigraph-worker',
+    acceptStoreReset: process.env.DKG_ACCEPT_STORE_RESET === '1',
+    log,
+  });
+  if (backendSwitch.aborted) {
+    process.exit(1);
+  }
+
+  // Refuse to start on invalid external-backend config (missing URL,
+  // missing blob/snapshot directory). This fires before the health
+  // check so operators see a single-line config error, not a confusing
+  // probe failure when the URL is just plain absent.
+  exitOnStoreConfigErrors(config, log);
+
+  // External triple-store backends (Blazegraph, sparql-http) get a
+  // boot-time reachability probe before anything that depends on them
+  // runs. We want operators who misconfigure the URL to see an
+  // actionable error within seconds — not a confusing failure deep in
+  // agent boot after we've already partially wiped local state.
+  //
+  // Sequencing: this fires BEFORE chainResetWipe so a marker bump
+  // against an unreachable endpoint doesn't strand the operator with
+  // wiped local files but stale remote data; we'd rather not start at
+  // all and let them fix the URL.
+  if (isExternalBackend(config.store?.backend)) {
+    const health = await checkExternalStoreReachable({
+      storeConfig: config.store,
+    });
+    if (!health.ok) {
+      log(formatHealthCheckFailure(health));
+      process.exit(1);
+    }
+    log(
+      `External triple-store reachable: ${health.backend} ${health.endpoint}`,
+    );
+
+    // Namespace identity check (RFC 120, plan PR 3 item 3). Refuses to
+    // start if another DKG node has already booted against this same
+    // namespace — without this, two daemons sharing one Blazegraph
+    // namespace silently corrupt each other. Fires BEFORE
+    // chainResetWipe so a mismatched tag never triggers a wipe of
+    // someone else's data.
+    const identity = await checkOrSetStoreIdentity({
+      storeConfig: config.store,
+      nodeName: config.name,
+    });
+    if (!identity.ok) {
+      if (identity.action === 'mismatch') {
+        log(formatIdentityTagMismatch(identity));
+      } else {
+        log(`[STORE-IDENTITY] failed to verify namespace ownership: ${identity.error}`);
+      }
+      process.exit(1);
+    }
+    if (identity.action === 'tagged') {
+      log(`Tagged triple-store namespace for node "${identity.nodeName}".`);
+    }
+  }
+
+  const wipeResult = await chainResetWipe({
     dataDir: dkgDir(),
     currentMarker: network?.chainResetMarker,
     // Honour operator's `randomSampling.walPath` override; the prover
     // writes its WAL there, so a fresh chain reset must wipe that file
     // (not the default ~/.dkg/random-sampling.wal which would be empty).
     randomSamplingWalPath: config.randomSampling?.walPath,
+    // For external triple-store backends, the wipe extends from local
+    // files to a SPARQL DROP/DELETE on the remote endpoint; otherwise
+    // operators with a chain-reset marker bump would keep stale V10 data
+    // in Blazegraph / sparql-http even after the local store.nq is gone.
+    storeConfig: config.store,
     log,
   });
   if (wipeResult.wiped) {
@@ -1693,6 +1772,14 @@ export async function runDaemonInner(
       return parseRdfInt(r?.bindings?.[0]?.c);
     },
     getStoreBytes: async () => {
+      // External SPARQL backends own no local file; `null` is the
+      // correct signal here (returning 0 misleads operators into
+      // thinking the store is empty). Quad count is exposed on
+      // demand via /api/status instead — too expensive to compute
+      // on the metrics tick. (RFC 120, plan PR 1 item 2.)
+      if (isExternalBackend(config.store?.backend)) {
+        return null;
+      }
       try {
         const s = await stat(join(dkgDir(), "store.nq"));
         return s.size;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -928,6 +928,26 @@ export async function runDaemonInner(
       `Chain-state auto-wipe complete: ${wipeResult.removedFiles.length} file(s) removed ` +
       `(prev marker: ${wipeResult.prevMarker ?? '<none>'}, now: ${network?.chainResetMarker})`,
     );
+    // A DKG-managed external wipe uses DROP ALL, which also removes the
+    // namespace ownership tag verified above. Re-tag before continuing so
+    // this daemon never runs against an unclaimed namespace.
+    if (isExternalBackend(config.store?.backend)) {
+      const identity = await checkOrSetStoreIdentity({
+        storeConfig: config.store,
+        nodeName: config.name,
+      });
+      if (!identity.ok) {
+        if (identity.action === 'mismatch') {
+          log(formatIdentityTagMismatch(identity));
+        } else {
+          log(`[STORE-IDENTITY] failed to re-tag namespace after wipe: ${identity.error}`);
+        }
+        process.exit(1);
+      }
+      if (identity.action === 'tagged') {
+        log(`Re-tagged triple-store namespace for node "${identity.nodeName}" after chain-state wipe.`);
+      }
+    }
   }
 
   // Load admin + operational wallets from ~/.dkg/wallets.json (auto-generated on first run)

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -57,6 +57,7 @@ const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter, resolveRpcUrls } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
+import { isExternalBackend } from '@origintrail-official/dkg-storage';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import {
@@ -402,6 +403,53 @@ function createRouteEvmProvider(rpcUrl: string, rpcUrls?: string[]): ethers.Json
   );
 }
 
+// Quad-count cache for external SPARQL backends. Every /api/status hit
+// otherwise issues a `SELECT (COUNT(*))` against the remote endpoint —
+// expensive on a large namespace, and the route is polled by the
+// dashboard, telemetry, and `dkg status` operators. 30 s TTL is short
+// enough that a fresh wipe / bulk publish shows up quickly without
+// flooding Blazegraph. Local backends bypass this entirely (file-bytes
+// metric stays on the metrics collector tick).
+const STORE_QUADS_CACHE_TTL_MS = 30_000;
+let storeQuadsCache: { value: number | null; fetchedAt: number } | null = null;
+let storeQuadsInflight: Promise<number | null> | null = null;
+
+async function getCachedExternalStoreQuads(
+  agent: DKGAgent,
+  now: number,
+): Promise<number | null> {
+  if (storeQuadsCache && now - storeQuadsCache.fetchedAt < STORE_QUADS_CACHE_TTL_MS) {
+    return storeQuadsCache.value;
+  }
+  if (storeQuadsInflight) return storeQuadsInflight;
+
+  storeQuadsInflight = (async () => {
+    try {
+      const r = await agent.store.query(
+        'SELECT (COUNT(*) AS ?c) WHERE { GRAPH ?g { ?s ?p ?o } }',
+      );
+      let value: number | null = null;
+      if (r.type === 'bindings' && r.bindings.length > 0) {
+        const cell = r.bindings[0].c ?? '';
+        const digits = cell.match(/\d+/)?.[0];
+        value = digits ? parseInt(digits, 10) : 0;
+      }
+      storeQuadsCache = { value, fetchedAt: Date.now() };
+      return value;
+    } catch {
+      // Surface "unknown" rather than a stale value; operators can
+      // distinguish unreachable from genuinely-empty via storeBackend +
+      // their network logs. Cache the null briefly to avoid hammering
+      // a flapping endpoint.
+      storeQuadsCache = { value: null, fetchedAt: Date.now() };
+      return null;
+    } finally {
+      storeQuadsInflight = null;
+    }
+  })();
+  return storeQuadsInflight;
+}
+
 async function getRegistryCacheSnapshot(): Promise<RegistryCacheSnapshot> {
   const now = Date.now();
   if (registryCache && now - registryCache.fetchedAt < REGISTRY_CACHE_TTL_MS) {
@@ -607,6 +655,21 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       networkId: networkId.slice(0, 16),
       networkName: network?.networkName ?? null,
       storeBackend: config.store?.backend ?? "oxigraph-worker",
+      // External backend visibility (RFC 120 / plan PR 1 item 3). For
+      // local backends both fields stay null so the response shape is
+      // stable across deployments.
+      storeUrl: isExternalBackend(config.store?.backend)
+        ? (() => {
+            const opts = (config.store?.options ?? {}) as Record<string, unknown>;
+            const url = typeof opts.url === 'string' ? opts.url
+              : typeof opts.queryEndpoint === 'string' ? opts.queryEndpoint
+              : null;
+            return url;
+          })()
+        : null,
+      storeQuads: isExternalBackend(config.store?.backend)
+        ? await getCachedExternalStoreQuads(agent, Date.now())
+        : null,
       uptimeMs: Date.now() - startedAt,
       connectedPeers: uniquePeers.size,
       connections: {

--- a/packages/cli/src/daemon/store-health-check.ts
+++ b/packages/cli/src/daemon/store-health-check.ts
@@ -1,0 +1,408 @@
+/**
+ * Boot-time reachability probe for external SPARQL endpoints.
+ *
+ * # Why this exists
+ *
+ * When an operator points the daemon at an external triple-store backend
+ * (`store.backend === 'blazegraph'` or `'sparql-http'`), the daemon's
+ * useful surface — publish, query, agent identity loading, finalisation —
+ * all depend on that endpoint being reachable. Without an early probe, a
+ * misconfigured URL or unreachable server fails much later, deep inside
+ * the agent's first SPARQL call, with a stack trace that doesn't include
+ * the URL. Operators see "EHOSTUNREACH" in their logs and have to read
+ * the daemon source to figure out what was being contacted.
+ *
+ * This probe runs synchronously before the agent boots, fails fast with
+ * an actionable message that names the endpoint, and exits the daemon
+ * cleanly. The boot-time exit policy lives in the caller (lifecycle), not
+ * here — this module just answers "is the endpoint reachable, and if not
+ * why?".
+ *
+ * # Design
+ *
+ * - For local backends: returns `{ ok: true }` without I/O. Always safe
+ *   to call regardless of store configuration; centralising the
+ *   backend-class branch here lets callers be unconditional.
+ * - For external backends: constructs a transient `BlazegraphStore` /
+ *   `SparqlHttpStore` directly via the adapter factory, issues
+ *   `ASK { ?s ?p ?o }` with an `AbortController` timeout, returns
+ *   ok/error. The transient store is closed immediately — we don't keep
+ *   it around as the agent will create its own.
+ * - Error wrapping: HTTP 404 commonly indicates the namespace doesn't
+ *   exist (Blazegraph), not that the server is down. We surface that
+ *   case explicitly because the recovery is different (create namespace
+ *   vs check network), and the operator otherwise has to know
+ *   Blazegraph protocol details to diagnose it.
+ *
+ * # Plan reference
+ *
+ * `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 1 item 4.
+ * Sequencing in lifecycle: marker comparison → this probe (if external) →
+ * `chainResetWipe` → agent boot. Health check fires before wipe so we
+ * don't strand the operator with a partial state after the local file
+ * wipe but a SPARQL wipe that can't run.
+ */
+import { isExternalBackend, getSparqlEndpoint } from '@origintrail-official/dkg-storage';
+
+export interface StoreHealthCheckOptions {
+  storeConfig:
+    | {
+        backend: string;
+        options?: Record<string, unknown>;
+      }
+    | undefined;
+  /** Probe timeout in milliseconds. Defaults to 5_000. */
+  timeoutMs?: number;
+  /**
+   * Override for the SPARQL HTTP transport. Tests inject a mock to
+   * exercise reachable / unreachable / 404-namespace-missing branches;
+   * defaults to `globalThis.fetch`.
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface StoreHealthCheckResult {
+  ok: boolean;
+  /** Always populated for external backends, regardless of ok. */
+  endpoint?: string;
+  /** Backend name passed through for log-formatting convenience. */
+  backend?: string;
+  /** Human-readable failure reason. Undefined on success. */
+  error?: string;
+  /**
+   * True when the probe surfaced an HTTP 404, which typically indicates
+   * the namespace doesn't exist on the SPARQL server (Blazegraph) rather
+   * than the server being down. Callers use this to bias the error
+   * message towards "create the namespace" rather than "fix the
+   * network".
+   */
+  namespaceMissing?: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export async function checkExternalStoreReachable(
+  opts: StoreHealthCheckOptions,
+): Promise<StoreHealthCheckResult> {
+  if (!isExternalBackend(opts.storeConfig?.backend)) {
+    return { ok: true };
+  }
+
+  let endpoint: ReturnType<typeof getSparqlEndpoint>;
+  try {
+    endpoint = getSparqlEndpoint({
+      backend: opts.storeConfig!.backend,
+      options: opts.storeConfig!.options,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      backend: opts.storeConfig?.backend,
+      error: (err as Error).message,
+    };
+  }
+
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetchImpl(endpoint.queryUrl, {
+      method: 'POST',
+      headers: {
+        ...endpoint.headers,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/sparql-results+json',
+      },
+      body: `query=${encodeURIComponent('ASK { ?s ?p ?o }')}`,
+      signal: controller.signal,
+    });
+
+    if (res.ok) {
+      // We don't parse the body — a 200 with any body shape proves the
+      // endpoint speaks SPARQL Protocol well enough to answer.
+      return {
+        ok: true,
+        backend: opts.storeConfig!.backend,
+        endpoint: endpoint.queryUrl,
+      };
+    }
+
+    // 404 deserves a specific message because the fix is different from
+    // a network failure. Blazegraph returns 404 when the namespace path
+    // doesn't exist (e.g. operator wrote `…/namespace/mynode/sparql`
+    // before running `dkg init`'s Docker provisioner that creates the
+    // `mynode` namespace).
+    if (res.status === 404) {
+      return {
+        ok: false,
+        backend: opts.storeConfig!.backend,
+        endpoint: endpoint.queryUrl,
+        namespaceMissing: true,
+        error:
+          `endpoint returned 404 — namespace likely doesn't exist. ` +
+          `Create it via the Blazegraph UI / API or use the Docker convenience path (dkg init).`,
+      };
+    }
+
+    const text = await res.text().catch(() => '');
+    return {
+      ok: false,
+      backend: opts.storeConfig!.backend,
+      endpoint: endpoint.queryUrl,
+      error: `HTTP ${res.status} ${res.statusText}: ${text.slice(0, 200)}`,
+    };
+  } catch (err) {
+    const message = (err as Error).message ?? String(err);
+    const isAbort = (err as Error).name === 'AbortError' || /aborted/i.test(message);
+    return {
+      ok: false,
+      backend: opts.storeConfig!.backend,
+      endpoint: endpoint.queryUrl,
+      error: isAbort
+        ? `timed out after ${timeoutMs}ms`
+        : `transport error: ${message}`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ====================================================================
+// Namespace identity tagging (RFC 120, plan PR 3 item 3)
+// ====================================================================
+//
+// Why this exists
+// ---------------
+// Two daemons pointed at the same Blazegraph namespace would silently
+// stomp on each other's data — the named-graph prefix scoping in
+// chain-reset-wipe protects against V6/V8 collisions but doesn't help
+// when two DKG nodes share a namespace. RFC 120 review point #5.
+//
+// The fix is a single triple inside a reserved named graph
+// `<urn:dkg:store-meta>` that records the first node name that booted
+// against this namespace. On every subsequent boot the daemon checks
+// for it and:
+//   - missing: writes it (first boot or operator's reset path).
+//   - matches `config.name`: proceeds silently.
+//   - mismatch: exits with an actionable message naming the other
+//     node so the operator knows which daemon to relocate.
+//
+// Skipped entirely for local backends (no concurrent-access risk — the
+// Oxigraph file is operator-owned).
+
+const STORE_META_GRAPH = 'urn:dkg:store-meta';
+const STORE_META_SUBJECT = 'urn:dkg:store-tag';
+const STORE_META_PREDICATE = 'urn:dkg:storeTaggedFor';
+
+export interface StoreIdentityTagOptions {
+  storeConfig:
+    | {
+        backend: string;
+        options?: Record<string, unknown>;
+      }
+    | undefined;
+  /** Operator-chosen node name from `~/.dkg/config.json`. */
+  nodeName: string;
+  fetch?: typeof globalThis.fetch;
+  /** Probe timeout in milliseconds. Defaults to 5_000. */
+  timeoutMs?: number;
+}
+
+export type StoreIdentityTagResult =
+  | { ok: true; action: 'skipped'; reason: 'local-backend' | 'unknown-backend' }
+  | { ok: true; action: 'matched'; nodeName: string }
+  | { ok: true; action: 'tagged'; nodeName: string }
+  | { ok: false; action: 'mismatch'; existingNodeName: string; expectedNodeName: string; error: string }
+  | { ok: false; action: 'transport-error'; error: string };
+
+/**
+ * Read the existing identity tag (if any) and either accept it, write
+ * a new one, or refuse to start on mismatch.
+ *
+ * Implemented with raw fetch against the SPARQL Query / Update
+ * endpoints so it doesn't need the agent runtime — runs as part of
+ * boot before the agent exists.
+ */
+export async function checkOrSetStoreIdentity(
+  opts: StoreIdentityTagOptions,
+): Promise<StoreIdentityTagResult> {
+  if (!isExternalBackend(opts.storeConfig?.backend)) {
+    return { ok: true, action: 'skipped', reason: 'local-backend' };
+  }
+
+  let endpoint: ReturnType<typeof getSparqlEndpoint>;
+  try {
+    endpoint = getSparqlEndpoint({
+      backend: opts.storeConfig!.backend,
+      options: opts.storeConfig!.options,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      action: 'transport-error',
+      error: (err as Error).message,
+    };
+  }
+
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // 1. SELECT the existing tag value (if any).
+  const selectQuery =
+    `SELECT ?name WHERE { GRAPH <${STORE_META_GRAPH}> { ` +
+    `<${STORE_META_SUBJECT}> <${STORE_META_PREDICATE}> ?name } }`;
+  const selectController = new AbortController();
+  const selectTimer = setTimeout(() => selectController.abort(), timeoutMs);
+  let existing: string | null;
+  try {
+    const res = await fetchImpl(endpoint.queryUrl, {
+      method: 'POST',
+      headers: {
+        ...endpoint.headers,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/sparql-results+json',
+      },
+      body: `query=${encodeURIComponent(selectQuery)}`,
+      signal: selectController.signal,
+    });
+    if (!res.ok) {
+      return {
+        ok: false,
+        action: 'transport-error',
+        error: `identity SELECT returned HTTP ${res.status} ${res.statusText}`,
+      };
+    }
+    const body = await res.json().catch(() => null) as
+      | { results?: { bindings?: Array<{ name?: { value?: string } }> } }
+      | null;
+    const binding = body?.results?.bindings?.[0]?.name?.value;
+    existing = typeof binding === 'string' && binding.length > 0 ? binding : null;
+  } catch (err) {
+    return {
+      ok: false,
+      action: 'transport-error',
+      error: `identity SELECT failed: ${(err as Error).message}`,
+    };
+  } finally {
+    clearTimeout(selectTimer);
+  }
+
+  // 2a. Match: nothing to do.
+  if (existing != null && existing === opts.nodeName) {
+    return { ok: true, action: 'matched', nodeName: existing };
+  }
+
+  // 2b. Mismatch: refuse to start.
+  if (existing != null && existing !== opts.nodeName) {
+    return {
+      ok: false,
+      action: 'mismatch',
+      existingNodeName: existing,
+      expectedNodeName: opts.nodeName,
+      error:
+        `this triple-store is already tagged for node "${existing}". ` +
+        `This node is "${opts.nodeName}". Two daemons can't safely share one namespace — ` +
+        `pick a different namespace, or clear the tag with: ` +
+        `DELETE WHERE { GRAPH <${STORE_META_GRAPH}> { <${STORE_META_SUBJECT}> <${STORE_META_PREDICATE}> ?n } }`,
+    };
+  }
+
+  // 3. Tag-missing path: INSERT the tag.
+  const updateQuery =
+    `INSERT DATA { GRAPH <${STORE_META_GRAPH}> { ` +
+    `<${STORE_META_SUBJECT}> <${STORE_META_PREDICATE}> "${escapeSparqlLiteral(opts.nodeName)}" ` +
+    `} }`;
+  const updateController = new AbortController();
+  const updateTimer = setTimeout(() => updateController.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(endpoint.updateUrl, {
+      method: 'POST',
+      headers: {
+        ...endpoint.headers,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `update=${encodeURIComponent(updateQuery)}`,
+      signal: updateController.signal,
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      return {
+        ok: false,
+        action: 'transport-error',
+        error: `identity INSERT returned HTTP ${res.status}: ${detail.slice(0, 200)}`,
+      };
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      action: 'transport-error',
+      error: `identity INSERT failed: ${(err as Error).message}`,
+    };
+  } finally {
+    clearTimeout(updateTimer);
+  }
+
+  return { ok: true, action: 'tagged', nodeName: opts.nodeName };
+}
+
+/**
+ * Format an identity-tag mismatch into an operator-facing log block.
+ * Multi-line, names both sides, includes the cleanup recipe.
+ */
+export function formatIdentityTagMismatch(result: StoreIdentityTagResult): string {
+  if (result.ok || result.action !== 'mismatch') return '';
+  return [
+    `[STORE-IDENTITY] external triple-store is owned by a different node.`,
+    `  this node:    ${result.expectedNodeName}`,
+    `  store tagged: ${result.existingNodeName}`,
+    ``,
+    `Two daemons sharing one namespace would silently corrupt each other.`,
+    `Fix one of:`,
+    `  - pick a different namespace (recommended): edit \`store.options.url\` in \`~/.dkg/config.json\`.`,
+    `  - reclaim this namespace if the other node is gone, by clearing the tag:`,
+    `      DELETE WHERE {`,
+    `        GRAPH <${STORE_META_GRAPH}> {`,
+    `          <${STORE_META_SUBJECT}> <${STORE_META_PREDICATE}> ?n`,
+    `        }`,
+    `      }`,
+  ].join('\n');
+}
+
+/** SPARQL literal escape — covers the common cases for node names. */
+function escapeSparqlLiteral(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
+/**
+ * Format a failed health-check result into an operator-facing log block.
+ * Multi-line, includes the URL, the error, and a remediation hint chosen
+ * based on the failure mode.
+ */
+export function formatHealthCheckFailure(result: StoreHealthCheckResult): string {
+  if (result.ok) return '';
+  const lines: string[] = [
+    `[STORE-HEALTH] external triple-store backend is unreachable at boot.`,
+    `  backend: ${result.backend ?? '<unknown>'}`,
+    `  endpoint: ${result.endpoint ?? '<unknown>'}`,
+    `  error: ${result.error ?? '<unknown>'}`,
+    ``,
+    `Daemon cannot start without a reachable store. Fix one of:`,
+  ];
+  if (result.namespaceMissing) {
+    lines.push(`  - create the namespace on the SPARQL server.`);
+    lines.push(`  - re-run \`dkg init\` and use the Docker convenience path.`);
+  } else {
+    lines.push(`  - verify the endpoint URL in \`~/.dkg/config.json\` → \`store.options\`.`);
+    lines.push(`  - verify the SPARQL server is running and reachable from this host.`);
+    lines.push(`  - check firewall / network policy if the URL is on a different host.`);
+  }
+  lines.push(`  - switch back to Oxigraph by removing the \`store\` block from config.`);
+  return lines.join('\n');
+}

--- a/packages/cli/src/store-wizard.ts
+++ b/packages/cli/src/store-wizard.ts
@@ -77,10 +77,39 @@ export interface PromptStoreBackendResult {
    * DKG-owned namespaces) and scoped DELETE (mandatory on
    * shared / V6 / V8 instances).
    */
-  storeBlock: {
-    backend: 'blazegraph' | 'sparql-http';
-    options: { url: string; managedByDkg: boolean };
-  } | null;
+  storeBlock: ExternalStoreBlock | null;
+}
+
+export type ExternalStoreBlock =
+  | {
+      backend: 'blazegraph';
+      options: { url: string; managedByDkg: boolean };
+    }
+  | {
+      backend: 'sparql-http';
+      options: {
+        queryEndpoint: string;
+        updateEndpoint: string;
+        managedByDkg: boolean;
+      };
+    };
+
+function externalStoreBlock(
+  backend: 'blazegraph' | 'sparql-http',
+  url: string,
+  managedByDkg: boolean,
+): ExternalStoreBlock {
+  if (backend === 'blazegraph') {
+    return { backend, options: { url, managedByDkg } };
+  }
+  return {
+    backend,
+    options: {
+      queryEndpoint: url,
+      updateEndpoint: url,
+      managedByDkg,
+    },
+  };
 }
 
 export async function promptStoreBackend(
@@ -181,10 +210,7 @@ export async function promptStoreBackend(
     if (health.ok) {
       log(`  Store endpoint reachable: ${backend} ${url}`);
       return {
-        storeBlock: {
-          backend,
-          options: { url, managedByDkg: false },
-        },
+        storeBlock: externalStoreBlock(backend, url, false),
       };
     }
 
@@ -283,10 +309,7 @@ export async function applyStoreFlagsToConfig(
   const existing = await load();
   const next: DkgConfig = {
     ...existing,
-    store: {
-      backend,
-      options: { url, managedByDkg: false },
-    },
+    store: externalStoreBlock(backend, url, false),
   };
   await save(next);
   log(`  Store configured: ${backend} (${url}) — verified reachable.`);

--- a/packages/cli/src/store-wizard.ts
+++ b/packages/cli/src/store-wizard.ts
@@ -1,0 +1,293 @@
+/**
+ * Triple-store wizard primitives (RFC 120, plan PR 2 items 1 + 3).
+ *
+ * Used by `dkg init` (interactive prompt) and by the adapter-setup
+ * commands `dkg hermes setup` / `openclaw setup` / `mcp setup`
+ * (non-interactive flag application). Centralised so URL validation,
+ * the retry loop, and the "no Docker yet" PR 2 message stay identical
+ * across every entry point.
+ *
+ * Extracted out of `cli.ts` so unit tests can exercise the prompt and
+ * flag flows without loading the full Commander program (which has
+ * side effects in process.exit and ApiClient.connect paths).
+ *
+ * PR 3 will replace the "no URL" branch with a Docker provisioner call;
+ * the function signature stays stable so PR 3 only has to flip one
+ * branch.
+ */
+import {
+  checkExternalStoreReachable,
+  formatHealthCheckFailure,
+} from './daemon/store-health-check.js';
+import { loadConfig, saveConfig, type DkgConfig } from './config.js';
+import {
+  isDockerAvailable as defaultIsDockerAvailable,
+  provisionBlazegraphDocker as defaultProvisionBlazegraphDocker,
+  type ProvisionBlazegraphDockerOptions,
+  type ProvisionBlazegraphDockerResult,
+} from './daemon/blazegraph-docker.js';
+
+export interface PromptStoreBackendOptions {
+  /** `ask` callback that closes over a shared readline interface. */
+  ask: (q: string, def?: string) => Promise<string>;
+  /** Existing config's store block (used as the wizard's default). */
+  existingStore?: {
+    backend: string;
+    options?: Record<string, unknown>;
+  };
+  /** Pre-fill from `--store` flag. Always overrides existing config. */
+  flagBackend?: string;
+  /** Pre-fill from `--store-url` flag. Always overrides existing config. */
+  flagUrl?: string;
+  /**
+   * Node name from the config — used as the Blazegraph namespace name
+   * when the Docker provisioning branch fires. Falls back to
+   * `"dkg-node"` if absent (matches `loadConfig` default).
+   */
+  nodeName?: string;
+  /**
+   * Override for the SPARQL HTTP transport. Tests inject a mock so the
+   * URL validation step is deterministic; defaults to `globalThis.fetch`
+   * via the shared health-check helper.
+   */
+  fetch?: typeof globalThis.fetch;
+  /** Logger for status / warning messages. Defaults to console.log. */
+  log?: (msg: string) => void;
+  /**
+   * PR 3 Docker convenience path. Tests inject a fake to exercise the
+   * "Docker available + operator accepts" branch without spawning real
+   * containers. Production callers omit these — they default to the
+   * real Docker CLI probe + provisioner.
+   */
+  isDockerAvailable?: () => Promise<boolean>;
+  provisionBlazegraphDocker?: (
+    opts: ProvisionBlazegraphDockerOptions,
+  ) => Promise<ProvisionBlazegraphDockerResult>;
+}
+
+export interface PromptStoreBackendResult {
+  /**
+   * Persisted store block. `null` means "use the local default" (caller
+   * should omit the field or set it to undefined; saveConfig drops
+   * undefined keys).
+   *
+   * `managedByDkg: true` is set by the Docker provisioner branch only;
+   * manual URLs always get `managedByDkg: false`. The chain-reset-wipe
+   * step in PR 1 uses this flag to decide between `DROP ALL` (safe on
+   * DKG-owned namespaces) and scoped DELETE (mandatory on
+   * shared / V6 / V8 instances).
+   */
+  storeBlock: {
+    backend: 'blazegraph' | 'sparql-http';
+    options: { url: string; managedByDkg: boolean };
+  } | null;
+}
+
+export async function promptStoreBackend(
+  opts: PromptStoreBackendOptions,
+): Promise<PromptStoreBackendResult> {
+  const log = opts.log ?? console.log;
+  const existingBackend = opts.existingStore?.backend;
+  const existingUrl =
+    typeof opts.existingStore?.options?.url === 'string'
+      ? (opts.existingStore?.options?.url as string)
+      : typeof opts.existingStore?.options?.queryEndpoint === 'string'
+        ? (opts.existingStore?.options?.queryEndpoint as string)
+        : undefined;
+
+  const defaultBackend = opts.flagBackend
+    ?? (existingBackend === 'blazegraph' || existingBackend === 'sparql-http' ? existingBackend : 'oxigraph');
+
+  const backendAnswer = (await opts.ask(
+    'Triple store backend (oxigraph / blazegraph)',
+    defaultBackend,
+  )).toLowerCase();
+
+  // Normalise: anything that isn't a known external alias falls back to
+  // the local default. We accept the internal alias `oxigraph-worker`
+  // for power users but don't advertise it.
+  if (backendAnswer !== 'blazegraph' && backendAnswer !== 'sparql-http') {
+    return { storeBlock: null };
+  }
+  const backend = backendAnswer as 'blazegraph' | 'sparql-http';
+
+  // URL prompt loop: validate each attempt, surface the operator-facing
+  // failure message, allow retry or abort.
+  while (true) {
+    const defaultUrl = opts.flagUrl ?? existingUrl;
+    const url = (await opts.ask(
+      backend === 'blazegraph'
+        ? 'Blazegraph SPARQL endpoint URL'
+        : 'SPARQL query endpoint URL',
+      defaultUrl,
+    )).trim();
+
+    if (!url) {
+      // PR 3 Docker branch: only offered for blazegraph (sparql-http is
+      // by definition bring-your-own-server). Probe `docker --version`
+      // first so we don't prompt operators who don't have Docker.
+      if (backend === 'blazegraph') {
+        const probeDocker = opts.isDockerAvailable ?? defaultIsDockerAvailable;
+        const dockerOk = await probeDocker();
+        if (dockerOk) {
+          const yes = (await opts.ask(
+            'No URL provided. Provision a Blazegraph container via Docker? (y/n)',
+            'y',
+          )).toLowerCase();
+          if (yes !== 'n') {
+            const namespace = opts.nodeName || 'dkg-node';
+            log(`  Starting Blazegraph in Docker (namespace: ${namespace})…`);
+            try {
+              const provision = opts.provisionBlazegraphDocker ?? defaultProvisionBlazegraphDocker;
+              const result = await provision({ namespace, log });
+              log(
+                `  ${result.reused ? 'Reusing' : 'Created'} container "${result.containerName}" ` +
+                `on port ${result.port}.`,
+              );
+              log(`  Store endpoint: ${result.url}`);
+              return {
+                storeBlock: {
+                  backend: 'blazegraph',
+                  options: { url: result.url, managedByDkg: true },
+                },
+              };
+            } catch (err) {
+              log('');
+              log(`  Docker provisioning failed: ${(err as Error).message}`);
+              log('');
+              // Fall through to retry / manual URL.
+            }
+          }
+        } else {
+          log('  Docker not detected on PATH. Install Docker Desktop or the Docker Engine');
+          log('  to use the convenience path, or provide a URL to an existing instance.');
+        }
+      }
+      const retry = (await opts.ask('Retry with a URL? (y/n)', 'y')).toLowerCase();
+      if (retry === 'n') {
+        log('  Aborting store setup; defaulting to local Oxigraph.');
+        return { storeBlock: null };
+      }
+      continue;
+    }
+
+    const optionsForProbe =
+      backend === 'blazegraph' ? { url } : { queryEndpoint: url };
+    const health = await checkExternalStoreReachable({
+      storeConfig: { backend, options: optionsForProbe },
+      fetch: opts.fetch,
+    });
+
+    if (health.ok) {
+      log(`  Store endpoint reachable: ${backend} ${url}`);
+      return {
+        storeBlock: {
+          backend,
+          options: { url, managedByDkg: false },
+        },
+      };
+    }
+
+    log('');
+    log(formatHealthCheckFailure(health));
+    log('');
+    const retry = (await opts.ask(
+      'Retry with a different URL? (y/n)',
+      'y',
+    )).toLowerCase();
+    if (retry === 'n') {
+      log('  Aborting store setup; defaulting to local Oxigraph.');
+      return { storeBlock: null };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------
+// Flag-driven flow for adapter setup commands
+// ---------------------------------------------------------------------
+
+export interface ApplyStoreFlagsOptions {
+  storeFlag?: string;
+  storeUrlFlag?: string;
+  /** Mock for tests; defaults to the real `loadConfig` from config.ts. */
+  loadConfig?: () => Promise<DkgConfig>;
+  /** Mock for tests; defaults to the real `saveConfig` from config.ts. */
+  saveConfig?: (config: DkgConfig) => Promise<void>;
+  /** Mock for tests; defaults to `globalThis.fetch` via the probe helper. */
+  fetch?: typeof globalThis.fetch;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Non-interactive sibling of `promptStoreBackend`. Used by the
+ * adapter-setup commands which delegate to action modules that don't
+ * run the init wizard — so the operator has no chance to type a URL.
+ *
+ * Validates via the shared boot-time health-check probe, then writes
+ * the store block into `~/.dkg/config.json` after the action module
+ * has already created/updated the rest of the config.
+ *
+ * Returns silently when no flags are passed (default behaviour: leave
+ * the existing config alone). Throws on validation failure so the CLI
+ * dispatch wrapper catches and exits cleanly.
+ */
+export async function applyStoreFlagsToConfig(
+  opts: ApplyStoreFlagsOptions,
+): Promise<void> {
+  const log = opts.log ?? console.log;
+  const backend = opts.storeFlag;
+  if (!backend) return;
+
+  const load = opts.loadConfig ?? loadConfig;
+  const save = opts.saveConfig ?? saveConfig;
+
+  // Operators who pass `--store oxigraph` may be trying to FORCE local
+  // even though their existing config has a `store` block — honour
+  // that by clearing the block.
+  if (
+    backend === 'oxigraph' ||
+    backend === 'oxigraph-worker' ||
+    backend === 'oxigraph-persistent'
+  ) {
+    const existing = await load();
+    if (existing.store) {
+      log(`  Removing existing store block (--store ${backend} → local default).`);
+      const next = { ...existing };
+      delete next.store;
+      await save(next);
+    }
+    return;
+  }
+
+  if (backend !== 'blazegraph' && backend !== 'sparql-http') {
+    throw new Error(
+      `--store must be one of: oxigraph, blazegraph, sparql-http (got "${backend}")`,
+    );
+  }
+
+  const url = opts.storeUrlFlag?.trim();
+  if (!url) {
+    throw new Error(`--store ${backend} requires --store-url <SPARQL endpoint URL>`);
+  }
+
+  const optionsForProbe =
+    backend === 'blazegraph' ? { url } : { queryEndpoint: url };
+  const health = await checkExternalStoreReachable({
+    storeConfig: { backend, options: optionsForProbe },
+    fetch: opts.fetch,
+  });
+  if (!health.ok) {
+    throw new Error(`store URL validation failed:\n${formatHealthCheckFailure(health)}`);
+  }
+
+  const existing = await load();
+  const next: DkgConfig = {
+    ...existing,
+    store: {
+      backend,
+      options: { url, managedByDkg: false },
+    },
+  };
+  await save(next);
+  log(`  Store configured: ${backend} (${url}) — verified reachable.`);
+}

--- a/packages/cli/test/blazegraph-docker.test.ts
+++ b/packages/cli/test/blazegraph-docker.test.ts
@@ -25,6 +25,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   provisionBlazegraphDocker,
+  normaliseBlazegraphNamespace,
   isDockerAvailable,
   BLAZEGRAPH_NAMESPACE_XML_TEMPLATE,
   type DockerRunner,
@@ -361,15 +362,15 @@ describe('provisionBlazegraphDocker', () => {
         { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'id', stderr: '', exitCode: 0 }) },
       ],
     });
-    const { fn } = mockFetch((url) => {
+    const { fn, calls: httpCalls } = mockFetch((url) => {
       if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
       if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
       return new Response(null, { status: 200 });
     });
-    await provisionBlazegraphDocker({
-      // Embedded spaces + apostrophes + uppercase get slugified down to
-      // characters Docker accepts.
-      namespace: "Bob's Node",
+    const result = await provisionBlazegraphDocker({
+      // Embedded spaces + apostrophes + uppercase and path/query-sensitive
+      // characters get slugified down once before Docker, XML, and URL use.
+      namespace: "Bob's Node / Main & Co",
       docker: runner,
       fetch: fn,
       isPortFree: async () => true,
@@ -378,6 +379,21 @@ describe('provisionBlazegraphDocker', () => {
     const inspectCall = calls.find((c) => c[0] === 'inspect');
     expect(inspectCall?.[1]).toMatch(/^dkg-blazegraph-/);
     expect(inspectCall?.[1]).not.toMatch(/['\s]/);
+    expect(result.url).toBe(
+      'http://127.0.0.1:9999/bigdata/namespace/bob-s-node-main-co/sparql',
+    );
+    const createCall = httpCalls.find((c) => c.url.endsWith('/bigdata/namespace'));
+    expect(String(createCall?.init?.body)).toContain(
+      '<entry key="com.bigdata.rdf.sail.namespace">bob-s-node-main-co</entry>',
+    );
+  });
+
+  it('normalises operator node names into safe Blazegraph namespace names', () => {
+    expect(normaliseBlazegraphNamespace("Bob's Node / Main & Co")).toBe(
+      'bob-s-node-main-co',
+    );
+    expect(normaliseBlazegraphNamespace('dkg.node_01')).toBe('dkg.node_01');
+    expect(normaliseBlazegraphNamespace('   ')).toBe('dkg-node');
   });
 });
 

--- a/packages/cli/test/blazegraph-docker.test.ts
+++ b/packages/cli/test/blazegraph-docker.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Blazegraph Docker provisioner — unit tests with full mock injection.
+ *
+ * Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 3
+ * items 1, 2.
+ *
+ * Locks in:
+ *   - Hard fail when `docker` CLI is missing (no silent Oxigraph
+ *     fallback like devnet.sh — operator opted into Docker).
+ *   - Idempotent reuse when a running container with the same name
+ *     exists (no re-pull, no recreate).
+ *   - Stopped container restarted instead of recreated.
+ *   - Stopped container that can't restart → recreated cleanly.
+ *   - Port-collision auto-bump scans up to the configured range.
+ *   - Port range exhaustion throws with a clear message.
+ *   - `/bigdata/status` polling times out cleanly.
+ *   - Namespace creation failure surfaces an actionable error.
+ *   - `managedByDkg: true` always set (signals scoped-DELETE in PR 1
+ *     wipe is unnecessary — DROP ALL is safe).
+ *   - Namespace XML body contains the V10-required quad mode.
+ *
+ * No real Docker, no real fetch, no real ports. Everything's
+ * injectable; tests run in <50 ms.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  provisionBlazegraphDocker,
+  isDockerAvailable,
+  BLAZEGRAPH_NAMESPACE_XML_TEMPLATE,
+  type DockerRunner,
+  type DockerCommandResult,
+} from '../src/daemon/blazegraph-docker.js';
+
+interface MockDockerScript {
+  /**
+   * Sequence of responses keyed by argv prefix; map iteration order
+   * matters here for cases that ask the same docker subcommand more
+   * than once (e.g. inspect → start → inspect).
+   */
+  matchers: Array<{
+    when: (args: readonly string[]) => boolean;
+    respond: (args: readonly string[]) => DockerCommandResult;
+  }>;
+}
+
+function mockDocker(script: MockDockerScript): { runner: DockerRunner; calls: string[][] } {
+  const calls: string[][] = [];
+  const runner: DockerRunner = {
+    async run(args) {
+      calls.push([...args]);
+      for (const matcher of script.matchers) {
+        if (matcher.when(args)) {
+          return matcher.respond(args);
+        }
+      }
+      // Default: pretend success so tests that don't care about a
+      // particular subcommand stay short.
+      return { stdout: '', stderr: '', exitCode: 0 };
+    },
+  };
+  return { runner, calls };
+}
+
+function dockerVersionOk(): DockerCommandResult {
+  return { stdout: 'Docker version 24.0.6, build ed223bc', stderr: '', exitCode: 0 };
+}
+
+function dockerInspectNotFound(): DockerCommandResult {
+  return {
+    stdout: '',
+    stderr: 'Error: No such object: dkg-blazegraph-node',
+    exitCode: 1,
+  };
+}
+
+function dockerInspectRunning(hostPort = 9999): DockerCommandResult {
+  return {
+    stdout: JSON.stringify([
+      {
+        State: { Running: true },
+        NetworkSettings: {
+          Ports: {
+            '8080/tcp': [{ HostIp: '0.0.0.0', HostPort: String(hostPort) }],
+          },
+        },
+      },
+    ]),
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+function dockerInspectStopped(): DockerCommandResult {
+  return {
+    stdout: JSON.stringify([
+      {
+        State: { Running: false },
+        NetworkSettings: {
+          Ports: { '8080/tcp': [{ HostIp: '0.0.0.0', HostPort: '9999' }] },
+        },
+      },
+    ]),
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+function mockFetch(handler: (url: string, init?: any) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn: typeof globalThis.fetch = (async (input: any, init?: any) => {
+    calls.push({ url: String(input), init });
+    return handler(String(input), init);
+  }) as typeof globalThis.fetch;
+  return { fn, calls };
+}
+
+describe('provisionBlazegraphDocker', () => {
+  it('throws an actionable error when the docker CLI is missing', async () => {
+    const docker: DockerRunner = {
+      async run() {
+        const err: NodeJS.ErrnoException = new Error('spawn docker ENOENT');
+        err.code = 'ENOENT';
+        throw err;
+      },
+    };
+    await expect(
+      provisionBlazegraphDocker({
+        namespace: 'mynode',
+        docker,
+        log: () => {},
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('throws when `docker --version` returns non-zero (daemon dead)', async () => {
+    const { runner } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: () => ({ stdout: '', stderr: 'Cannot connect to the Docker daemon', exitCode: 1 }) },
+      ],
+    });
+    await expect(
+      provisionBlazegraphDocker({
+        namespace: 'mynode',
+        docker: runner,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/docker --version.*failed|Docker daemon/);
+  });
+
+  it('reuses a running container without re-creating it', async () => {
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: () => dockerInspectRunning(9999) },
+      ],
+    });
+    const { fn, calls: httpCalls } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    expect(result.reused).toBe(true);
+    expect(result.managedByDkg).toBe(true);
+    expect(result.url).toBe('http://127.0.0.1:9999/bigdata/namespace/mynode/sparql');
+    expect(calls.some((c) => c[0] === 'run')).toBe(false);
+    expect(httpCalls.some((c) => c.url.endsWith('/bigdata/status'))).toBe(true);
+  });
+
+  it('creates the namespace when reusing a container with no existing namespace', async () => {
+    const { runner } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: () => dockerInspectRunning() },
+      ],
+    });
+    const { fn, calls: httpCalls } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 404 });
+      if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    expect(result.namespaceCreated).toBe(true);
+    const createCall = httpCalls.find((c) => c.url.endsWith('/bigdata/namespace'));
+    expect(createCall).toBeDefined();
+    expect(String(createCall?.init?.body)).toContain('<entry key="com.bigdata.rdf.sail.namespace">mynode</entry>');
+    expect(String(createCall?.init?.body)).toContain('quads">true');
+  });
+
+  it('starts an existing stopped container instead of recreating', async () => {
+    let inspectCount = 0;
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        {
+          when: (a) => a[0] === 'inspect',
+          respond: () => {
+            inspectCount += 1;
+            // First inspect → stopped. Second inspect (after `start`) → running.
+            return inspectCount === 1 ? dockerInspectStopped() : dockerInspectRunning();
+          },
+        },
+        { when: (a) => a[0] === 'start', respond: () => ({ stdout: 'dkg-blazegraph-node', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    expect(result.reused).toBe(true);
+    expect(calls.some((c) => c[0] === 'start')).toBe(true);
+    expect(calls.some((c) => c[0] === 'run')).toBe(false);
+  });
+
+  it('recreates the container when `docker start` fails on a stopped container', async () => {
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: () => dockerInspectStopped() },
+        { when: (a) => a[0] === 'start', respond: () => ({ stdout: '', stderr: 'config drift', exitCode: 1 }) },
+        { when: (a) => a[0] === 'rm', respond: () => ({ stdout: '', stderr: '', exitCode: 0 }) },
+        { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'container-id', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    expect(result.reused).toBe(false);
+    expect(calls.some((c) => c[0] === 'rm')).toBe(true);
+    expect(calls.some((c) => c[0] === 'run')).toBe(true);
+  });
+
+  it('auto-bumps to the next free port when 9999 is taken', async () => {
+    const takenPorts = new Set([9999, 10000]);
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+      ],
+    });
+    const { fn } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async (p) => !takenPorts.has(p),
+      log: () => {},
+    });
+    expect(result.port).toBe(10001);
+    const runCall = calls.find((c) => c[0] === 'run');
+    expect(runCall).toBeDefined();
+    expect(runCall?.join(' ')).toContain('10001:8080');
+  });
+
+  it('throws when every port in the scan range is taken', async () => {
+    const { runner } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+      ],
+    });
+    await expect(
+      provisionBlazegraphDocker({
+        namespace: 'mynode',
+        docker: runner,
+        fetch: globalThis.fetch,
+        isPortFree: async () => false,
+        portRange: 3,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/No free port found in the range 9999\.\.10001/);
+  });
+
+  it('times out cleanly when /bigdata/status never responds', async () => {
+    const { runner } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+        { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'id', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch(() => {
+      throw new Error('ECONNREFUSED');
+    });
+    await expect(
+      provisionBlazegraphDocker({
+        namespace: 'mynode',
+        docker: runner,
+        fetch: fn,
+        isPortFree: async () => true,
+        pollIntervalMs: 5,
+        pollTimeoutMs: 30,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/did not become ready within 30ms/);
+  });
+
+  it('surfaces a clear error when namespace POST returns non-2xx', async () => {
+    const { runner } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+        { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'id', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.endsWith('/bigdata/namespace')) return new Response('namespace exists already', { status: 409 });
+      return new Response(null, { status: 200 });
+    });
+    await expect(
+      provisionBlazegraphDocker({
+        namespace: 'mynode',
+        docker: runner,
+        fetch: fn,
+        isPortFree: async () => true,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/Failed to create Blazegraph namespace "mynode" — HTTP 409/);
+  });
+
+  it('sanitises the container name for tricky namespaces', async () => {
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+        { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'id', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    await provisionBlazegraphDocker({
+      // Embedded spaces + apostrophes + uppercase get slugified down to
+      // characters Docker accepts.
+      namespace: "Bob's Node",
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    const inspectCall = calls.find((c) => c[0] === 'inspect');
+    expect(inspectCall?.[1]).toMatch(/^dkg-blazegraph-/);
+    expect(inspectCall?.[1]).not.toMatch(/['\s]/);
+  });
+});
+
+describe('isDockerAvailable', () => {
+  it('returns true when docker --version succeeds', async () => {
+    const { runner } = mockDocker({
+      matchers: [{ when: (a) => a[0] === '--version', respond: dockerVersionOk }],
+    });
+    await expect(isDockerAvailable(runner)).resolves.toBe(true);
+  });
+
+  it('returns false when docker --version fails', async () => {
+    const { runner } = mockDocker({
+      matchers: [{ when: (a) => a[0] === '--version', respond: () => ({ stdout: '', stderr: '', exitCode: 1 }) }],
+    });
+    await expect(isDockerAvailable(runner)).resolves.toBe(false);
+  });
+
+  it('returns false when the runner throws', async () => {
+    const runner: DockerRunner = {
+      async run() { throw new Error('ENOENT'); },
+    };
+    await expect(isDockerAvailable(runner)).resolves.toBe(false);
+  });
+});
+
+describe('BLAZEGRAPH_NAMESPACE_XML_TEMPLATE', () => {
+  it('parameterises the namespace and locks in DKG V10 settings', () => {
+    const body = BLAZEGRAPH_NAMESPACE_XML_TEMPLATE.replace('{namespace}', 'mynode');
+    expect(body).toContain('<entry key="com.bigdata.rdf.sail.namespace">mynode</entry>');
+    // Quads MUST be true for DKG V10 (named-graph scoping). Any
+    // change to false would break scoped DELETE wipe.
+    expect(body).toContain('com.bigdata.rdf.store.AbstractTripleStore.quads">true');
+    expect(body).toContain('truthMaintenance">false');
+    expect(body).toContain('statementIdentifiers">false');
+  });
+});

--- a/packages/cli/test/blazegraph-integration.test.ts
+++ b/packages/cli/test/blazegraph-integration.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Real-Blazegraph end-to-end integration test (RFC 120, plan PR 3
+ * §"Real-Blazegraph integration test (opt-in)").
+ *
+ * What this proves that the mocked tests can't
+ * ------------------------------------------------
+ * The unit tests for `BlazegraphStore`, `provisionBlazegraphDocker`,
+ * `chainResetWipe`, and `checkOrSetStoreIdentity` all use a fake fetch
+ * to verify *what we send*. They can't catch:
+ *
+ *   - Blazegraph protocol divergences (response shapes, status codes,
+ *     content negotiation quirks, namespace creation race conditions).
+ *   - SPARQL semantics for `DROP ALL` vs scoped DELETE (does Blazegraph
+ *     actually leave non-V10 named graphs alone? does `DROP ALL`
+ *     clean up the namespace metadata or just the data?).
+ *   - Docker run/inspect contract drift (lyrasis/blazegraph:2.1.5 has
+ *     been frozen for years, but Docker behavioural changes —
+ *     log-driver defaults, port-binding shape — can still bite).
+ *   - The identity tag round-trip against real SPARQL UPDATE parsing.
+ *
+ * This test wires the full Docker → BlazegraphStore → chainResetWipe →
+ * identity-tag pipeline against a real container.
+ *
+ * Why it's opt-in
+ * ----------------
+ * Spinning up a Blazegraph container takes 30-60 s on a cold machine
+ * (image pull + JVM warmup) which is too slow for CI per-PR. Gate via
+ * `BLAZEGRAPH_INTEGRATION_TEST=1`. Run locally with:
+ *
+ *   BLAZEGRAPH_INTEGRATION_TEST=1 npx vitest run \
+ *     --config vitest.unit.config.ts test/blazegraph-integration.test.ts
+ *
+ * The test self-cleans the container on teardown even when individual
+ * cases fail, so re-running the suite is idempotent.
+ *
+ * Apple Silicon (arm64) caveat
+ * -----------------------------
+ * `lyrasis/blazegraph:2.1.5` is published as `linux/amd64` only — the
+ * upstream Blazegraph project at github.com/blazegraph was archived in
+ * March 2026 and no longer publishes new images. We pin this tag for
+ * mainnet + devnet.sh parity.
+ *
+ * On Apple Silicon Macs the image runs under QEMU emulation (or
+ * Rosetta on macOS 14.1+ with Docker Desktop ≥ 4.25). The JVM startup
+ * under emulation can take much longer than the 30-second default,
+ * and the QEMU path is known to crash Docker Desktop entirely under
+ * sustained JVM warmup on some machines. To improve odds:
+ *
+ *   - Docker Desktop → Settings → General → "Use Rosetta for x86_64
+ *     emulation" (enabled by default on macOS 14.1+).
+ *   - Bumped `pollTimeoutMs` in `beforeAll` below from 30 s to 120 s.
+ *
+ * If your `beforeAll` fails with "Blazegraph did not become ready
+ * within 120000ms" on an arm64 host, the test is correctly designed
+ * but the JVM emulation is overloading your Docker Desktop. Re-run on
+ * an amd64 box (CI / Linux server). The mocked unit-tests still cover
+ * the contract.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { BlazegraphStore } from '@origintrail-official/dkg-storage';
+import {
+  provisionBlazegraphDocker,
+  isDockerAvailable,
+  type ProvisionBlazegraphDockerResult,
+} from '../src/daemon/blazegraph-docker.js';
+import { chainResetWipe } from '../src/daemon/chain-reset-wipe.js';
+import {
+  checkOrSetStoreIdentity,
+} from '../src/daemon/store-health-check.js';
+
+const ENABLED = process.env.BLAZEGRAPH_INTEGRATION_TEST === '1';
+
+const V10_GRAPH = 'did:dkg:context-graph:integration-test';
+const OTHER_GRAPH = 'urn:other-app:integration-cotenant';
+
+function execDocker(args: readonly string[], timeoutMs = 30_000): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const child = spawn('docker', [...args], { stdio: 'ignore' });
+    const timer = setTimeout(() => child.kill('SIGKILL'), timeoutMs);
+    child.once('close', () => { clearTimeout(timer); resolve(); });
+    child.once('error', () => { clearTimeout(timer); resolve(); });
+  });
+}
+
+describe.skipIf(!ENABLED)('Blazegraph end-to-end integration', () => {
+  let provisioned: ProvisionBlazegraphDockerResult | null = null;
+  let store: BlazegraphStore | null = null;
+  let dataDir: string;
+  // Each test suite run uses a fresh namespace so a re-run doesn't see
+  // stale identity tags or stale quads from the previous run. The
+  // container is reused (idempotent provisioner), only the namespace
+  // is new.
+  const namespace = `integ-${process.pid}-${Date.now().toString(36)}`;
+
+  beforeAll(async () => {
+    if (!(await isDockerAvailable())) {
+      throw new Error(
+        'BLAZEGRAPH_INTEGRATION_TEST=1 but `docker --version` failed. ' +
+        'Install Docker or unset the env var to skip the test.',
+      );
+    }
+
+    dataDir = await mkdtemp(join(tmpdir(), 'dkg-blaze-integ-'));
+
+    provisioned = await provisionBlazegraphDocker({
+      namespace,
+      // Use a low port-range cap so multiple parallel runs on the same
+      // host don't collide indefinitely; integration runs sequentially
+      // in practice.
+      portRange: 12,
+      // 120 s instead of the 30 s provisioner default — JVM warmup
+      // under amd64-via-QEMU/Rosetta on Apple Silicon can take 60 s+.
+      // On native amd64 this is still essentially "as fast as the
+      // container becomes ready", since we poll every second.
+      pollTimeoutMs: 120_000,
+      log: () => {},
+    });
+
+    store = new BlazegraphStore(provisioned.url);
+  }, /* timeoutMs */ 180_000);
+
+  afterAll(async () => {
+    try { await store?.close(); } catch { /* ignore */ }
+    // Best-effort container cleanup. We only destroy the container if
+    // it was freshly created; reusing a pre-existing container is a
+    // hint the operator wants to keep it around.
+    if (provisioned && !provisioned.reused) {
+      await execDocker(['rm', '-f', provisioned.containerName]);
+    }
+    if (dataDir) {
+      await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }, /* timeoutMs */ 60_000);
+
+  // -----------------------------------------------------------------
+  // Adapter round-trip — insert / query / count / delete patterns.
+  // -----------------------------------------------------------------
+
+  it('insert + SELECT count → real Blazegraph returns the right total', async () => {
+    expect(store).not.toBeNull();
+    await store!.insert([
+      { subject: 'urn:integ:s1', predicate: 'urn:integ:p', object: 'urn:integ:o1', graph: V10_GRAPH },
+      { subject: 'urn:integ:s2', predicate: 'urn:integ:p', object: 'urn:integ:o2', graph: V10_GRAPH },
+      { subject: 'urn:integ:s3', predicate: 'urn:integ:p', object: 'urn:integ:o3', graph: V10_GRAPH },
+    ]);
+    const count = await store!.countQuads(V10_GRAPH);
+    expect(count).toBe(3);
+  });
+
+  it('ASK over real Blazegraph returns the right boolean', async () => {
+    const result = await store!.query(
+      `ASK { GRAPH <${V10_GRAPH}> { <urn:integ:s1> ?p ?o } }`,
+    );
+    expect(result.type).toBe('boolean');
+    if (result.type === 'boolean') {
+      expect(result.value).toBe(true);
+    }
+  });
+
+  it('deleteByPattern reduces the count', async () => {
+    const before = await store!.countQuads(V10_GRAPH);
+    const removed = await store!.deleteByPattern({
+      subject: 'urn:integ:s2',
+      graph: V10_GRAPH,
+    });
+    expect(removed).toBeGreaterThanOrEqual(1);
+    const after = await store!.countQuads(V10_GRAPH);
+    expect(after).toBe(before - removed);
+  });
+
+  // -----------------------------------------------------------------
+  // Scoped DELETE — the safety guarantee for shared instances.
+  // -----------------------------------------------------------------
+
+  it('chainResetWipe scoped DELETE leaves non-V10 named graphs alone', async () => {
+    // Seed: V10 data in did:dkg:context-graph:* + co-tenant data in a
+    // non-V10 graph. The scoped wipe must remove the V10 quads and
+    // preserve the co-tenant ones.
+    await store!.insert([
+      { subject: 'urn:integ:scoped-v10', predicate: 'urn:p', object: 'urn:o', graph: V10_GRAPH },
+      { subject: 'urn:integ:cotenant', predicate: 'urn:p', object: 'urn:o', graph: OTHER_GRAPH },
+    ]);
+    expect(await store!.countQuads(V10_GRAPH)).toBeGreaterThan(0);
+    expect(await store!.countQuads(OTHER_GRAPH)).toBeGreaterThan(0);
+
+    // First call seeds the marker so the second is recognised as a
+    // chain-reset event.
+    await chainResetWipe({
+      dataDir,
+      currentMarker: 'seed-marker',
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url, managedByDkg: false },
+      },
+    });
+
+    // Now bump the marker → scoped DELETE on the remote.
+    const wipe = await chainResetWipe({
+      dataDir,
+      currentMarker: 'bumped-marker',
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url, managedByDkg: false },
+      },
+    });
+    expect(wipe.wiped).toBe(true);
+    expect(wipe.failedFiles).toEqual([]);
+
+    expect(await store!.countQuads(V10_GRAPH)).toBe(0);
+    // Critical assertion: co-tenant data survived.
+    expect(await store!.countQuads(OTHER_GRAPH)).toBeGreaterThan(0);
+
+    // Cleanup so subsequent tests don't see the co-tenant quad.
+    await store!.deleteByPattern({ graph: OTHER_GRAPH });
+  });
+
+  // -----------------------------------------------------------------
+  // DROP ALL — fast path for DKG-managed namespaces.
+  // -----------------------------------------------------------------
+
+  it('chainResetWipe managedByDkg=true issues DROP ALL — wipes every graph', async () => {
+    await store!.insert([
+      { subject: 'urn:integ:drop-v10', predicate: 'urn:p', object: 'urn:o', graph: V10_GRAPH },
+      { subject: 'urn:integ:drop-other', predicate: 'urn:p', object: 'urn:o', graph: OTHER_GRAPH },
+    ]);
+
+    // Marker has to differ from the persisted one to trigger the wipe.
+    const wipe = await chainResetWipe({
+      dataDir,
+      currentMarker: 'drop-all-marker',
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url, managedByDkg: true },
+      },
+    });
+    expect(wipe.wiped).toBe(true);
+    expect(wipe.failedFiles).toEqual([]);
+
+    // Both graphs gone — DROP ALL is unconditional.
+    expect(await store!.countQuads(V10_GRAPH)).toBe(0);
+    expect(await store!.countQuads(OTHER_GRAPH)).toBe(0);
+  });
+
+  // -----------------------------------------------------------------
+  // Namespace identity tag round-trip.
+  // -----------------------------------------------------------------
+
+  it('checkOrSetStoreIdentity round-trips against a real namespace', async () => {
+    // The provisioner-created namespace starts with no identity tag.
+    // Use a fresh sub-namespace so the round-trip is deterministic
+    // regardless of test order: clear any prior tag first.
+    await store!.dropGraph('urn:dkg:store-meta');
+
+    const first = await checkOrSetStoreIdentity({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url },
+      },
+      nodeName: 'alice-integ',
+    });
+    expect(first.ok).toBe(true);
+    if (first.ok) expect(first.action).toBe('tagged');
+
+    const second = await checkOrSetStoreIdentity({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url },
+      },
+      nodeName: 'alice-integ',
+    });
+    expect(second.ok).toBe(true);
+    if (second.ok) expect(second.action).toBe('matched');
+
+    const third = await checkOrSetStoreIdentity({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url },
+      },
+      nodeName: 'bob-integ',
+    });
+    expect(third.ok).toBe(false);
+    if (!third.ok && third.action === 'mismatch') {
+      expect(third.existingNodeName).toBe('alice-integ');
+      expect(third.expectedNodeName).toBe('bob-integ');
+    }
+  });
+
+  // -----------------------------------------------------------------
+  // Provisioner idempotency — second call reuses the running container.
+  // -----------------------------------------------------------------
+
+  it('provisionBlazegraphDocker second call reuses the running container', async () => {
+    const again = await provisionBlazegraphDocker({
+      namespace,
+      log: () => {},
+    });
+    expect(again.containerName).toBe(provisioned!.containerName);
+    expect(again.port).toBe(provisioned!.port);
+    expect(again.reused).toBe(true);
+    // Namespace was created on first run; second run must NOT try to
+    // re-create it (Blazegraph 409s on duplicates).
+    expect(again.namespaceCreated).toBe(false);
+  });
+});
+
+// When BLAZEGRAPH_INTEGRATION_TEST is unset, vitest still runs this
+// file but `describe.skipIf(!ENABLED)` makes every case a no-op. Print
+// a one-liner so contributors discover the env-var.
+if (!ENABLED) {
+  // eslint-disable-next-line no-console
+  console.log(
+    '[blazegraph-integration] SKIPPED — set BLAZEGRAPH_INTEGRATION_TEST=1 to enable.',
+  );
+}

--- a/packages/cli/test/chain-reset-wipe.test.ts
+++ b/packages/cli/test/chain-reset-wipe.test.ts
@@ -26,7 +26,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync, chmodSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { chainResetWipe } from '../src/daemon/chain-reset-wipe.js';
+import { chainResetWipe, detectBackendSwitch } from '../src/daemon/chain-reset-wipe.js';
 
 const STATE_FILE = '.network-state.json';
 const NEW_MARKER = 'v10-rs-staking-consolidation-2026-04-30';
@@ -62,9 +62,9 @@ afterEach(() => {
 });
 
 describe('chainResetWipe — opt-in protocol', () => {
-  it('is a no-op when network config has no marker (back-compat)', () => {
+  it('is a no-op when network config has no marker (back-compat)', async () => {
     seedAllFiles(dataDir);
-    const result = chainResetWipe({ dataDir, currentMarker: undefined });
+    const result = await chainResetWipe({ dataDir, currentMarker: undefined });
 
     expect(result.wiped).toBe(false);
     expect(result.prevMarker).toBeNull();
@@ -78,11 +78,11 @@ describe('chainResetWipe — opt-in protocol', () => {
 });
 
 describe('chainResetWipe — first boot with marker present', () => {
-  it('wipes and saves marker (the chain-reset rollout case)', () => {
+  it('wipes and saves marker (the chain-reset rollout case)', async () => {
     seedAllFiles(dataDir);
     const logs: string[] = [];
 
-    const result = chainResetWipe({
+    const result = await chainResetWipe({
       dataDir,
       currentMarker: NEW_MARKER,
       log: (msg) => logs.push(msg),
@@ -110,8 +110,8 @@ describe('chainResetWipe — first boot with marker present', () => {
     expect(logs.some((l) => l.includes('first detected'))).toBe(true);
   });
 
-  it('still records the marker on a fresh install with no chain-state files yet', () => {
-    const result = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+  it('still records the marker on a fresh install with no chain-state files yet', async () => {
+    const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
     expect(result.wiped).toBe(true);
     expect(result.removedFiles).toEqual([]);
@@ -120,14 +120,14 @@ describe('chainResetWipe — first boot with marker present', () => {
 });
 
 describe('chainResetWipe — same marker (steady state)', () => {
-  it('does nothing when persisted marker equals current', () => {
+  it('does nothing when persisted marker equals current', async () => {
     writeFileSync(
       join(dataDir, STATE_FILE),
       JSON.stringify({ chainResetMarker: NEW_MARKER, savedAt: Date.now() }),
     );
     seedAllFiles(dataDir);
 
-    const result = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
     expect(result.wiped).toBe(false);
     expect(result.prevMarker).toBe(NEW_MARKER);
@@ -138,7 +138,7 @@ describe('chainResetWipe — same marker (steady state)', () => {
 });
 
 describe('chainResetWipe — marker changed (chain reset)', () => {
-  it('wipes chain-state files and preserves operator state when marker differs', () => {
+  it('wipes chain-state files and preserves operator state when marker differs', async () => {
     writeFileSync(
       join(dataDir, STATE_FILE),
       JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() - 86_400_000 }),
@@ -146,7 +146,7 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
     seedAllFiles(dataDir);
 
     const logs: string[] = [];
-    const result = chainResetWipe({
+    const result = await chainResetWipe({
       dataDir,
       currentMarker: NEW_MARKER,
       log: (msg) => logs.push(msg),
@@ -183,7 +183,7 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
     expect(logs.some((l) => l.includes('Wiping'))).toBe(true);
   });
 
-  it('handles missing chain-state files gracefully (subset wipe)', () => {
+  it('handles missing chain-state files gracefully (subset wipe)', async () => {
     writeFileSync(
       join(dataDir, STATE_FILE),
       JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
@@ -191,27 +191,27 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
     // Only seed store.nq; the others don't exist on this node yet.
     writeFileSync(join(dataDir, 'store.nq'), '...');
 
-    const result = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
     expect(result.wiped).toBe(true);
     expect(result.removedFiles).toEqual(['store.nq']);
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(false);
   });
 
-  it('is idempotent: a second call with the same input is a no-op', () => {
+  it('is idempotent: a second call with the same input is a no-op', async () => {
     writeFileSync(
       join(dataDir, STATE_FILE),
       JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
     );
     seedAllFiles(dataDir);
 
-    const first = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    const first = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
     expect(first.wiped).toBe(true);
 
     // Re-seed the chain-state files to simulate "boot, work, boot again".
     writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
 
-    const second = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    const second = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
     expect(second.wiped).toBe(false);
     expect(second.prevMarker).toBe(NEW_MARKER);
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(true);
@@ -219,11 +219,11 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
 });
 
 describe('chainResetWipe — corrupt state file', () => {
-  it('treats unparseable state as missing (first-boot semantics)', () => {
+  it('treats unparseable state as missing (first-boot semantics)', async () => {
     writeFileSync(join(dataDir, STATE_FILE), '{ this is not valid JSON');
     seedAllFiles(dataDir);
 
-    const result = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
     expect(result.wiped).toBe(true);
     expect(result.prevMarker).toBeNull();
@@ -238,7 +238,7 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
   // their config keep a stale WAL across chain resets — the wipe was
   // hardcoding `dataDir/random-sampling.wal`. These tests pin the fix.
 
-  it('wipes the operator-supplied WAL path when set, not the default', () => {
+  it('wipes the operator-supplied WAL path when set, not the default', async () => {
     const customWal = join(dataDir, 'custom', 'rs.wal');
     mkdirSync(join(dataDir, 'custom'), { recursive: true });
     writeFileSync(customWal, 'WAL\n');
@@ -247,7 +247,7 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
     writeFileSync(join(dataDir, 'random-sampling.wal'), 'STALE\n');
     writeFileSync(join(dataDir, 'store.nq'), '...');
 
-    const result = chainResetWipe({
+    const result = await chainResetWipe({
       dataDir,
       currentMarker: NEW_MARKER,
       randomSamplingWalPath: customWal,
@@ -259,10 +259,10 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
     expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(true);
   });
 
-  it('falls back to default WAL path when randomSamplingWalPath is empty', () => {
+  it('falls back to default WAL path when randomSamplingWalPath is empty', async () => {
     writeFileSync(join(dataDir, 'random-sampling.wal'), 'WAL\n');
 
-    const result = chainResetWipe({
+    const result = await chainResetWipe({
       dataDir,
       currentMarker: NEW_MARKER,
       randomSamplingWalPath: '',
@@ -272,13 +272,13 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
     expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(false);
   });
 
-  it('handles WAL path outside dataDir (absolute, e.g. /var/lib/dkg/wal)', () => {
+  it('handles WAL path outside dataDir (absolute, e.g. /var/lib/dkg/wal)', async () => {
     const externalWalDir = mkdtempSync(join(tmpdir(), 'dkg-external-wal-'));
     const externalWal = join(externalWalDir, 'rs.wal');
     writeFileSync(externalWal, 'EXTERNAL_WAL\n');
 
     try {
-      const result = chainResetWipe({
+      const result = await chainResetWipe({
         dataDir,
         currentMarker: NEW_MARKER,
         randomSamplingWalPath: externalWal,
@@ -300,7 +300,7 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
   // to boot. Crashing here would create a worse failure mode (node down)
   // than the original problem (stale state).
 
-  it('logs and continues when saveState throws (e.g. read-only FS)', () => {
+  it('logs and continues when saveState throws (e.g. read-only FS)', async () => {
     // Make dataDir read-only so writeFileSync on the state file throws.
     // Skip on platforms where chmod 0o555 doesn't actually deny root or
     // where tests run as root (CI containers); the scenario we care
@@ -322,13 +322,13 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
         // Good: FS denied the write. Now run the wipe.
       }
 
-      expect(() => {
+      await expect(
         chainResetWipe({
           dataDir,
           currentMarker: NEW_MARKER,
           log: (msg) => logsCaptured.push(msg),
-        });
-      }).not.toThrow();
+        }),
+      ).resolves.toBeDefined();
 
       // Loud log so operators can find this in journalctl.
       expect(logsCaptured.some((l) => l.includes('failed to persist chain reset marker'))).toBe(true);
@@ -337,7 +337,7 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
     }
   });
 
-  it('does not save the marker when an individual file wipe throws', () => {
+  it('does not save the marker when an individual file wipe throws', async () => {
     writeFileSync(
       join(dataDir, STATE_FILE),
       JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
@@ -356,14 +356,12 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
         // Good: removing from this directory is denied for this process.
       }
 
-      expect(() => {
-        const result = chainResetWipe({
-          dataDir,
-          currentMarker: NEW_MARKER,
-          log: (msg) => logsCaptured.push(msg),
-        });
-        expect(result.failedFiles.some((f) => f.file === 'store.nq')).toBe(true);
-      }).not.toThrow();
+      const result = await chainResetWipe({
+        dataDir,
+        currentMarker: NEW_MARKER,
+        log: (msg) => logsCaptured.push(msg),
+      });
+      expect(result.failedFiles.some((f) => f.file === 'store.nq')).toBe(true);
     } finally {
       chmodSync(dataDir, originalMode);
       rmSync(join(dataDir, '.probe'), { force: true });
@@ -372,5 +370,360 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
     const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
     expect(persisted.chainResetMarker).toBe(OLD_MARKER);
     expect(logsCaptured.some((l) => l.includes('marker was not persisted'))).toBe(true);
+  });
+});
+
+// =====================================================================
+// External SPARQL wipe (RFC 120, plan PR 1 item 5b)
+// =====================================================================
+//
+// Operators who configure an external triple-store backend (Blazegraph
+// or sparql-http) need the same "stale state goes away on chain reset"
+// guarantee as Oxigraph operators get from the local file wipe. The
+// wipe runs a SPARQL UPDATE against the configured endpoint after the
+// local file wipe. Two modes:
+//
+//   - `managedByDkg: true` (Docker convenience path, PR 3): DROP ALL.
+//     Safe because the CLI owns the namespace exclusively.
+//   - operator-provided URL (default): scoped DELETE filtered by the
+//     V10 named-graph prefix `did:dkg:context-graph:` so V6/V8 nodes or
+//     unrelated data sharing the same Blazegraph instance survive.
+//
+// Failures append to `failedFiles`, marker is not persisted, wipe
+// retries on next boot — same partial-failure semantics as the local
+// file wipe.
+
+describe('chainResetWipe — external SPARQL wipe', () => {
+  type FetchCall = { url: string; init?: RequestInit };
+
+  function mockFetch(handler: (call: FetchCall) => Response | Promise<Response>) {
+    const calls: FetchCall[] = [];
+    const fn: typeof globalThis.fetch = (async (input: any, init?: any) => {
+      const call: FetchCall = { url: String(input), init };
+      calls.push(call);
+      return handler(call);
+    }) as typeof globalThis.fetch;
+    return { fn, calls };
+  }
+
+  function decodeUpdateBody(body: unknown): string {
+    const s = String(body ?? '');
+    if (!s.startsWith('update=')) return '';
+    return decodeURIComponent(s.slice('update='.length));
+  }
+
+  it('issues DROP ALL when storeConfig.options.managedByDkg=true', async () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
+    );
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://blaze.test/sparql', managedByDkg: true },
+      },
+      fetch: fn,
+    });
+
+    expect(result.wiped).toBe(true);
+    expect(result.failedFiles).toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://blaze.test/sparql');
+    expect(decodeUpdateBody(calls[0].init?.body)).toBe('DROP ALL');
+    expect(result.removedFiles.some((f) => f.includes('drop-all'))).toBe(true);
+  });
+
+  it('issues scoped DELETE when managedByDkg is false (operator URL — V6/V8 safety)', async () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
+    );
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://shared-blaze.test/sparql' },
+      },
+      fetch: fn,
+    });
+
+    expect(result.wiped).toBe(true);
+    expect(calls).toHaveLength(1);
+    const update = decodeUpdateBody(calls[0].init?.body);
+    expect(update).toContain('DELETE');
+    expect(update).toContain('did:dkg:context-graph:');
+    expect(update).toContain('strstarts');
+    expect(update).not.toBe('DROP ALL');
+  });
+
+  it('records SPARQL failure in failedFiles + does not persist marker', async () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
+    );
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const { fn } = mockFetch(
+      () => new Response('endpoint exploded', { status: 500, statusText: 'Server Error' }),
+    );
+    const logs: string[] = [];
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://broken.test/sparql' },
+      },
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.wiped).toBe(true);
+    expect(result.failedFiles).toHaveLength(1);
+    expect(result.failedFiles[0].file).toContain('scoped-delete');
+    expect(result.failedFiles[0].error).toContain('500');
+
+    // Local files still wiped (we don't gate file wipe on SPARQL).
+    expect(existsSync(join(dataDir, 'store.nq'))).toBe(false);
+
+    // Marker NOT persisted — retry on next boot.
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.chainResetMarker).toBe(OLD_MARKER);
+    expect(logs.some((l) => l.includes('Chain reset marker was not persisted'))).toBe(true);
+  });
+
+  it('records transport error in failedFiles', async () => {
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const fn: typeof globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as typeof globalThis.fetch;
+
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://nope.test/sparql' },
+      },
+      fetch: fn,
+    });
+
+    expect(result.failedFiles.some((f) => f.error.includes('ECONNREFUSED'))).toBe(true);
+  });
+
+  it('skips external wipe entirely for local backends (storeConfig present, backend oxigraph-worker)', async () => {
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'oxigraph-worker',
+        // Options that LOOK like an external URL: these must be ignored
+        // because the backend itself is local. Otherwise an operator who
+        // hand-tuned options would see surprise SPARQL requests.
+        options: { url: 'http://ignored.test/sparql' as unknown as string },
+      },
+      fetch: fn,
+    });
+
+    expect(result.wiped).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(result.failedFiles).toEqual([]);
+  });
+
+  it('uses sparql-http updateEndpoint when configured separately from queryEndpoint', async () => {
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'sparql-http',
+        options: {
+          queryEndpoint: 'http://server.test/query',
+          updateEndpoint: 'http://server.test/update',
+          auth: 'Bearer t0ken',
+          managedByDkg: false,
+        },
+      },
+      fetch: fn,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://server.test/update');
+    const headers = (calls[0].init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer t0ken');
+  });
+});
+
+// =====================================================================
+// Backend-switch detection (RFC 120 review point #6 / plan PR 1 item 8)
+// =====================================================================
+//
+// Without an explicit check, an operator who hand-edits
+// `config.store.backend` between boots gets a fresh empty backend and
+// no warning — looks identical to data loss. detectBackendSwitch tags
+// each boot's backend into the same `.network-state.json` file and
+// refuses to boot on mismatch unless `acceptStoreReset` is true.
+
+describe('detectBackendSwitch', () => {
+  it('records current backend on first boot (no state file) without warning', () => {
+    const logs: string[] = [];
+    const result = detectBackendSwitch({
+      dataDir,
+      currentBackend: 'oxigraph-worker',
+      acceptStoreReset: false,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.previous).toBeNull();
+    expect(result.aborted).toBe(false);
+
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.lastBackend).toBe('oxigraph-worker');
+    // First-boot path is silent — no STORE-SWITCH warning header.
+    expect(logs.find((l) => l.includes('STORE-SWITCH'))).toBeUndefined();
+  });
+
+  it('records current backend on a legacy state file (lastBackend absent) without warning', () => {
+    // Legacy: state file from before this field was added. Has only
+    // chainResetMarker + savedAt.
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: NEW_MARKER, savedAt: Date.now() }),
+    );
+
+    const logs: string[] = [];
+    const result = detectBackendSwitch({
+      dataDir,
+      currentBackend: 'blazegraph',
+      acceptStoreReset: false,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.previous).toBeNull();
+    expect(result.aborted).toBe(false);
+
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.lastBackend).toBe('blazegraph');
+    // chainResetMarker must survive the backend-tag write.
+    expect(persisted.chainResetMarker).toBe(NEW_MARKER);
+  });
+
+  it('is a no-op when backend matches previous boot', () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: null, lastBackend: 'oxigraph-worker', savedAt: Date.now() }),
+    );
+
+    const logs: string[] = [];
+    const result = detectBackendSwitch({
+      dataDir,
+      currentBackend: 'oxigraph-worker',
+      acceptStoreReset: false,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.previous).toBe('oxigraph-worker');
+    expect(result.aborted).toBe(false);
+    expect(logs).toEqual([]);
+  });
+
+  it('aborts boot on mismatch without acceptStoreReset, surfaces multi-line warning', () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: null, lastBackend: 'oxigraph-worker', savedAt: Date.now() }),
+    );
+
+    const logs: string[] = [];
+    const result = detectBackendSwitch({
+      dataDir,
+      currentBackend: 'blazegraph',
+      acceptStoreReset: false,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.previous).toBe('oxigraph-worker');
+    expect(result.aborted).toBe(true);
+
+    const joined = logs.join('\n');
+    expect(joined).toMatch(/STORE-SWITCH/);
+    expect(joined).toMatch(/previous: oxigraph-worker/);
+    expect(joined).toMatch(/current:\s+blazegraph/);
+    expect(joined).toMatch(/DKG_ACCEPT_STORE_RESET=1/);
+
+    // State file MUST still record the old backend so a corrected
+    // config (operator reverts the edit) sees a match on next boot.
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.lastBackend).toBe('oxigraph-worker');
+  });
+
+  it('proceeds and updates state when acceptStoreReset=true', () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: null, lastBackend: 'oxigraph-worker', savedAt: Date.now() }),
+    );
+
+    const logs: string[] = [];
+    const result = detectBackendSwitch({
+      dataDir,
+      currentBackend: 'blazegraph',
+      acceptStoreReset: true,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.aborted).toBe(false);
+
+    // Warning still surfaces so the choice is visible in journalctl,
+    // but with the "proceeding" tail rather than the "refusing" tail.
+    const joined = logs.join('\n');
+    expect(joined).toMatch(/STORE-SWITCH/);
+    expect(joined).toMatch(/proceeding/i);
+    expect(joined).not.toMatch(/Refusing to start/);
+
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.lastBackend).toBe('blazegraph');
+  });
+
+  it('coexists with chainResetWipe — wipe does not clobber the backend tag', async () => {
+    // Establish a baseline by running detectBackendSwitch first.
+    detectBackendSwitch({
+      dataDir,
+      currentBackend: 'oxigraph-worker',
+      acceptStoreReset: false,
+    });
+    expect(
+      JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8')).lastBackend,
+    ).toBe('oxigraph-worker');
+
+    // Now run a marker change — the wipe path persists chainResetMarker
+    // and MUST preserve lastBackend.
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+    await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+    });
+
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.chainResetMarker).toBe(NEW_MARKER);
+    expect(persisted.lastBackend).toBe('oxigraph-worker');
   });
 });

--- a/packages/cli/test/store-health-check.test.ts
+++ b/packages/cli/test/store-health-check.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Boot-time reachability probe for external SPARQL backends.
+ *
+ * Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 1 item 4.
+ * Locks in:
+ *   - local backends pass without I/O (no fetch issued).
+ *   - external + reachable → ok with endpoint reported.
+ *   - external + HTTP 500 → ok=false with the body snippet surfaced.
+ *   - external + HTTP 404 → namespaceMissing=true + a hint that mentions
+ *     creating the namespace (Blazegraph operators hit this when they
+ *     point at a path before provisioning it).
+ *   - external + transport error → ok=false, error contains the cause.
+ *   - external + AbortController timeout → ok=false, error mentions ms.
+ *   - sparql-http with auth header → Authorization passed through.
+ *   - malformed config (external backend with no URL) → ok=false with a
+ *     config-shape error, not a crashed probe.
+ *   - formatHealthCheckFailure renders multi-line, contains endpoint
+ *     and remediation hints; namespace-missing path mentions creating
+ *     the namespace, not network checks.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  checkExternalStoreReachable,
+  formatHealthCheckFailure,
+} from '../src/daemon/store-health-check.js';
+
+function mockFetch(handler: (input: any, init?: any) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn: typeof globalThis.fetch = (async (input: any, init?: any) => {
+    calls.push({ url: String(input), init });
+    return handler(input, init);
+  }) as typeof globalThis.fetch;
+  return { fn, calls };
+}
+
+describe('checkExternalStoreReachable', () => {
+  it('passes through with no I/O for local backends', async () => {
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await checkExternalStoreReachable({
+      storeConfig: { backend: 'oxigraph-worker' },
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('passes through when storeConfig is undefined (default deployment)', async () => {
+    const result = await checkExternalStoreReachable({ storeConfig: undefined });
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns ok=true for a reachable Blazegraph endpoint', async () => {
+    const { fn, calls } = mockFetch(
+      () =>
+        new Response(JSON.stringify({ head: { vars: [] }, boolean: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    const result = await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://blaze.test/sparql' },
+      },
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.endpoint).toBe('http://blaze.test/sparql');
+    expect(result.backend).toBe('blazegraph');
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0].init?.body)).toContain('query=ASK');
+  });
+
+  it('returns ok=false with HTTP details on 500', async () => {
+    const { fn } = mockFetch(
+      () => new Response('boom', { status: 500, statusText: 'Server Error' }),
+    );
+    const result = await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://broken.test/sparql' },
+      },
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('500');
+    expect(result.namespaceMissing).toBeUndefined();
+  });
+
+  it('returns namespaceMissing=true on HTTP 404 with actionable message', async () => {
+    const { fn } = mockFetch(
+      () => new Response('not found', { status: 404, statusText: 'Not Found' }),
+    );
+    const result = await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://blaze.test/namespace/missing/sparql' },
+      },
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.namespaceMissing).toBe(true);
+    expect(result.error).toMatch(/namespace/i);
+  });
+
+  it('reports transport errors with the underlying message', async () => {
+    const fn: typeof globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as typeof globalThis.fetch;
+    const result = await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://nope.test/sparql' },
+      },
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('ECONNREFUSED');
+  });
+
+  it('reports timeout when the endpoint hangs past timeoutMs', async () => {
+    const fn: typeof globalThis.fetch = (async (
+      _input: any,
+      init?: any,
+    ) => {
+      await new Promise((_resolve, reject) => {
+        const sig = init?.signal as AbortSignal | undefined;
+        if (sig) sig.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+      return new Response();
+    }) as typeof globalThis.fetch;
+
+    const result = await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://slow.test/sparql' },
+      },
+      fetch: fn,
+      timeoutMs: 30,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timed out after 30ms/);
+  });
+
+  it('threads the Authorization header for sparql-http with auth set', async () => {
+    const { fn, calls } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'sparql-http',
+        options: {
+          queryEndpoint: 'http://server.test/query',
+          auth: 'Bearer t0ken',
+        },
+      },
+      fetch: fn,
+    });
+    const headers = (calls[0].init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer t0ken');
+  });
+
+  it('returns ok=false without throwing when storeConfig is malformed', async () => {
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await checkExternalStoreReachable({
+      storeConfig: { backend: 'blazegraph', options: {} }, // url missing
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/options\.url/);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('formatHealthCheckFailure', () => {
+  it('renders an empty string for ok=true', () => {
+    expect(formatHealthCheckFailure({ ok: true })).toBe('');
+  });
+
+  it('renders endpoint + remediation for a generic failure', () => {
+    const block = formatHealthCheckFailure({
+      ok: false,
+      backend: 'blazegraph',
+      endpoint: 'http://blaze.test/sparql',
+      error: 'HTTP 500',
+    });
+    expect(block).toMatch(/STORE-HEALTH/);
+    expect(block).toMatch(/blazegraph/);
+    expect(block).toMatch(/http:\/\/blaze\.test\/sparql/);
+    expect(block).toMatch(/config\.json/);
+    expect(block).toMatch(/firewall/i);
+  });
+
+  it('biases the hint toward namespace creation when namespaceMissing=true', () => {
+    const block = formatHealthCheckFailure({
+      ok: false,
+      backend: 'blazegraph',
+      endpoint: 'http://blaze.test/namespace/missing/sparql',
+      error: 'HTTP 404 …',
+      namespaceMissing: true,
+    });
+    expect(block).toMatch(/create the namespace/);
+    expect(block).toMatch(/Docker/);
+    expect(block).not.toMatch(/firewall/i);
+  });
+});

--- a/packages/cli/test/store-identity-tag.test.ts
+++ b/packages/cli/test/store-identity-tag.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Namespace identity tagging — locks in the two-daemons-one-namespace
+ * guard added in PR 3 (RFC 120 review point #5).
+ *
+ * Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 3
+ * item 3.
+ *
+ * Locks in:
+ *   - Local backends skipped entirely (no concurrent-access risk).
+ *   - Fresh namespace → tag written via SPARQL UPDATE.
+ *   - Existing tag matches → matched, no UPDATE issued.
+ *   - Existing tag mismatches → ok=false, action='mismatch', message
+ *     includes both node names AND the cleanup recipe.
+ *   - SELECT transport failure → ok=false, action='transport-error'.
+ *   - INSERT transport failure surfaces as transport-error too (i.e.
+ *     we don't silently treat write failure as "tag absent").
+ *   - SELECT 404 → transport-error (not silently treated as "fresh").
+ *   - formatIdentityTagMismatch produces a multi-line block with the
+ *     DELETE WHERE recipe referencing the right URIs.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  checkOrSetStoreIdentity,
+  formatIdentityTagMismatch,
+} from '../src/daemon/store-health-check.js';
+
+function mockFetch(handler: (url: string, init?: any) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit; body?: string }> = [];
+  const fn: typeof globalThis.fetch = (async (input: any, init?: any) => {
+    const body = init?.body != null ? String(init.body) : undefined;
+    calls.push({ url: String(input), init, body });
+    return handler(String(input), init);
+  }) as typeof globalThis.fetch;
+  return { fn, calls };
+}
+
+const BLAZEGRAPH_CONFIG = {
+  backend: 'blazegraph',
+  options: { url: 'http://blaze.test/sparql' },
+};
+
+describe('checkOrSetStoreIdentity', () => {
+  it('skips for local oxigraph backend', async () => {
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: { backend: 'oxigraph-worker' },
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok && result.action === 'skipped') {
+      expect(result.reason).toBe('local-backend');
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  it('skips for undefined storeConfig', async () => {
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: undefined,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('writes the tag when the namespace has no existing identity', async () => {
+    const { fn, calls } = mockFetch((url, init) => {
+      if (init?.body != null && String(init.body).startsWith('query=')) {
+        // SELECT returns no bindings.
+        return new Response(
+          JSON.stringify({ head: { vars: ['name'] }, results: { bindings: [] } }),
+          { status: 200, headers: { 'content-type': 'application/sparql-results+json' } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok && result.action === 'tagged') {
+      expect(result.nodeName).toBe('mynode');
+    }
+    const selectCall = calls.find((c) => c.body?.startsWith('query='));
+    const updateCall = calls.find((c) => c.body?.startsWith('update='));
+    expect(selectCall).toBeDefined();
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.body).toContain(encodeURIComponent('urn:dkg:store-meta'));
+    expect(updateCall?.body).toContain(encodeURIComponent('urn:dkg:storeTaggedFor'));
+    expect(updateCall?.body).toContain(encodeURIComponent('"mynode"'));
+  });
+
+  it('matches silently when the existing tag equals the configured node name', async () => {
+    const { fn, calls } = mockFetch((_url, init) => {
+      if (init?.body != null && String(init.body).startsWith('query=')) {
+        return new Response(
+          JSON.stringify({
+            head: { vars: ['name'] },
+            results: { bindings: [{ name: { type: 'literal', value: 'mynode' } }] },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(null, { status: 200 });
+    });
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok && result.action === 'matched') {
+      expect(result.nodeName).toBe('mynode');
+    }
+    // Crucially: no UPDATE call (no INSERT DATA) when matched.
+    const updateCall = calls.find((c) => c.body?.startsWith('update='));
+    expect(updateCall).toBeUndefined();
+  });
+
+  it('refuses to start when the tag belongs to another node', async () => {
+    const { fn } = mockFetch((_url, init) => {
+      if (init?.body != null && String(init.body).startsWith('query=')) {
+        return new Response(
+          JSON.stringify({
+            head: { vars: ['name'] },
+            results: { bindings: [{ name: { type: 'literal', value: 'alice-node' } }] },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(null, { status: 200 });
+    });
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'bob-node',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.action === 'mismatch') {
+      expect(result.existingNodeName).toBe('alice-node');
+      expect(result.expectedNodeName).toBe('bob-node');
+      expect(result.error).toContain('alice-node');
+      expect(result.error).toContain('bob-node');
+    }
+  });
+
+  it('surfaces transport error on SELECT failure (does not silently treat as fresh)', async () => {
+    const { fn } = mockFetch(() => new Response('boom', { status: 500 }));
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.action).toBe('transport-error');
+      expect(result.error).toMatch(/identity SELECT/);
+    }
+  });
+
+  it('surfaces transport error on INSERT failure', async () => {
+    const { fn } = mockFetch((_url, init) => {
+      if (init?.body != null && String(init.body).startsWith('query=')) {
+        return new Response(
+          JSON.stringify({ head: { vars: ['name'] }, results: { bindings: [] } }),
+          { status: 200 },
+        );
+      }
+      return new Response('write rejected', { status: 503 });
+    });
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.action).toBe('transport-error');
+      expect(result.error).toMatch(/identity INSERT/);
+    }
+  });
+
+  it('surfaces transport error on connection failure', async () => {
+    const { fn } = mockFetch(() => {
+      throw new Error('ECONNREFUSED');
+    });
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.action).toBe('transport-error');
+      expect(result.error).toMatch(/identity SELECT failed/);
+    }
+  });
+
+  it('escapes special characters in the node-name literal', async () => {
+    const { fn, calls } = mockFetch((_url, init) => {
+      if (init?.body != null && String(init.body).startsWith('query=')) {
+        return new Response(
+          JSON.stringify({ head: { vars: ['name'] }, results: { bindings: [] } }),
+          { status: 200 },
+        );
+      }
+      return new Response(null, { status: 200 });
+    });
+    await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'node "with quotes"',
+      fetch: fn,
+    });
+    const updateCall = calls.find((c) => c.body?.startsWith('update='));
+    expect(updateCall).toBeDefined();
+    // After url-decoding, the literal should be `"node \"with quotes\""`.
+    const decoded = decodeURIComponent(updateCall!.body!.replace(/^update=/, ''));
+    expect(decoded).toContain('"node \\"with quotes\\""');
+  });
+
+  it('respects custom timeoutMs (the controller fires AbortError quickly)', async () => {
+    const { fn } = mockFetch(
+      () => new Promise((_resolve, reject) => {
+        setTimeout(() => {
+          const e = new Error('aborted');
+          e.name = 'AbortError';
+          reject(e);
+        }, 10);
+      }),
+    );
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+      timeoutMs: 20,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.action).toBe('transport-error');
+  });
+});
+
+describe('formatIdentityTagMismatch', () => {
+  it('returns empty string for any non-mismatch result', () => {
+    expect(formatIdentityTagMismatch({ ok: true, action: 'skipped', reason: 'local-backend' })).toBe('');
+    expect(formatIdentityTagMismatch({ ok: true, action: 'matched', nodeName: 'mynode' })).toBe('');
+    expect(formatIdentityTagMismatch({ ok: true, action: 'tagged', nodeName: 'mynode' })).toBe('');
+    expect(formatIdentityTagMismatch({ ok: false, action: 'transport-error', error: 'boom' })).toBe('');
+  });
+
+  it('formats a mismatch as a multi-line block with the cleanup recipe', () => {
+    const block = formatIdentityTagMismatch({
+      ok: false,
+      action: 'mismatch',
+      existingNodeName: 'alice-node',
+      expectedNodeName: 'bob-node',
+      error: 'boom',
+    });
+    expect(block).toContain('STORE-IDENTITY');
+    expect(block).toContain('this node:    bob-node');
+    expect(block).toContain('store tagged: alice-node');
+    expect(block).toContain('DELETE WHERE');
+    expect(block).toContain('urn:dkg:store-meta');
+    expect(block).toContain('urn:dkg:storeTaggedFor');
+  });
+});

--- a/packages/cli/test/store-wizard.test.ts
+++ b/packages/cli/test/store-wizard.test.ts
@@ -109,7 +109,13 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: (m) => logs.push(m),
     });
-    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://blaze.test/sparql',
+        managedByDkg: false,
+      },
+    });
     expect(logs.some((l) => l.includes('STORE-HEALTH'))).toBe(true);
   });
 
@@ -161,7 +167,13 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: (m) => logs.push(m),
     });
-    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://blaze.test/sparql',
+        managedByDkg: false,
+      },
+    });
     expect(logs.some((l) => l.includes('Docker not detected'))).toBe(true);
   });
 
@@ -251,7 +263,13 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: (m) => logs.push(m),
     });
-    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://blaze.test/sparql',
+        managedByDkg: false,
+      },
+    });
     expect(logs.some((l) => l.includes('Docker provisioning failed'))).toBe(true);
   });
 
@@ -297,7 +315,13 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: () => {},
     });
-    expect(result.storeBlock?.options.url).toBe('http://prefilled.test/sparql');
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://prefilled.test/sparql',
+        managedByDkg: false,
+      },
+    });
     expect(calls[0].url).toBe('http://prefilled.test/sparql');
   });
 
@@ -314,7 +338,13 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: () => {},
     });
-    expect(result.storeBlock?.options.url).toBe('http://existing.test/sparql');
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://existing.test/sparql',
+        managedByDkg: false,
+      },
+    });
   });
 
   it('supports sparql-http with its own queryEndpoint URL', async () => {
@@ -326,8 +356,14 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: () => {},
     });
-    expect(result.storeBlock?.backend).toBe('sparql-http');
-    expect(result.storeBlock?.options.url).toBe('http://server.test/query');
+    expect(result.storeBlock).toEqual({
+      backend: 'sparql-http',
+      options: {
+        queryEndpoint: 'http://server.test/query',
+        updateEndpoint: 'http://server.test/query',
+        managedByDkg: false,
+      },
+    });
     expect(calls[0].url).toBe('http://server.test/query');
   });
 });
@@ -468,7 +504,14 @@ describe('applyStoreFlagsToConfig', () => {
       fetch: fn,
       log: () => {},
     });
-    expect(store.saved[0].store?.backend).toBe('sparql-http');
+    expect(store.saved[0].store).toEqual({
+      backend: 'sparql-http',
+      options: {
+        queryEndpoint: 'http://server.test/query',
+        updateEndpoint: 'http://server.test/query',
+        managedByDkg: false,
+      },
+    });
     expect(calls[0].url).toBe('http://server.test/query');
   });
 });

--- a/packages/cli/test/store-wizard.test.ts
+++ b/packages/cli/test/store-wizard.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Wizard + flag helpers that thread the triple-store backend through
+ * `dkg init` and the adapter-setup commands.
+ *
+ * Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 2
+ * items 1, 2, 3, 5.
+ *
+ * Locks in:
+ *   - Default path (operator hits Enter / no flag): no store block.
+ *   - Blazegraph + valid URL: store block persisted with
+ *     `managedByDkg: false`.
+ *   - Blazegraph + unreachable URL: surfaces formatted failure, allows
+ *     retry, abort returns to local default.
+ *   - Blazegraph + 404 URL: namespace-missing branch fires; message
+ *     mentions namespace, not network.
+ *   - Blank URL prompt: PR 2's "no Docker yet" message + retry.
+ *   - `--store oxigraph` on a config that already has a Blazegraph
+ *     block: clears the block (operator forcing local).
+ *   - `--store blazegraph` without `--store-url`: throws with the
+ *     missing-URL message (no half-written config).
+ *   - Validation failure throws so the CLI dispatch wrapper exits.
+ *   - Unknown backend value throws with the allow-list error.
+ *
+ * No filesystem I/O — `loadConfig` / `saveConfig` are injected as
+ * mocks. Real config wiring is exercised in the higher-level adapter-
+ * setup integration tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { applyStoreFlagsToConfig, promptStoreBackend } from '../src/store-wizard.js';
+import type { DkgConfig } from '../src/config.js';
+
+function mockFetch(handler: (input: any, init?: any) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn: typeof globalThis.fetch = (async (input: any, init?: any) => {
+    calls.push({ url: String(input), init });
+    return handler(input, init);
+  }) as typeof globalThis.fetch;
+  return { fn, calls };
+}
+
+function mockAsk(scriptedAnswers: string[]): (q: string, def?: string) => Promise<string> {
+  let i = 0;
+  return async (q: string, def?: string) => {
+    if (i >= scriptedAnswers.length) {
+      throw new Error(`Out of scripted answers (asked: "${q}" default="${def ?? ''}")`);
+    }
+    const answer = scriptedAnswers[i++];
+    return answer === '' && def ? def : answer;
+  };
+}
+
+// ---------------------------------------------------------------------
+// promptStoreBackend
+// ---------------------------------------------------------------------
+
+describe('promptStoreBackend', () => {
+  it('returns no store block when operator accepts the oxigraph default', async () => {
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await promptStoreBackend({
+      ask: mockAsk(['']), // accept default ("oxigraph")
+      fetch: fn,
+      log: () => {},
+    });
+    expect(result.storeBlock).toBeNull();
+    expect(calls).toHaveLength(0); // no URL probe issued for local
+  });
+
+  it('returns no store block when operator types "oxigraph" explicitly', async () => {
+    const result = await promptStoreBackend({
+      ask: mockAsk(['oxigraph']),
+      log: () => {},
+    });
+    expect(result.storeBlock).toBeNull();
+  });
+
+  it('persists Blazegraph + reachable URL with managedByDkg=false', async () => {
+    const { fn, calls } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', 'http://blaze.test/sparql']),
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: { url: 'http://blaze.test/sparql', managedByDkg: false },
+    });
+    expect(calls).toHaveLength(1);
+    expect(logs.some((l) => l.includes('reachable'))).toBe(true);
+  });
+
+  it('surfaces failure formatter on unreachable URL, retries with a working one', async () => {
+    let attempt = 0;
+    const { fn } = mockFetch(() => {
+      attempt++;
+      if (attempt === 1) return new Response('boom', { status: 500 });
+      return new Response(JSON.stringify({ boolean: true }), { status: 200 });
+    });
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        'http://broken.test/sparql', // first attempt: 500
+        'y', // retry
+        'http://blaze.test/sparql', // works
+      ]),
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(logs.some((l) => l.includes('STORE-HEALTH'))).toBe(true);
+  });
+
+  it('aborts to local default when operator declines retry on unreachable URL', async () => {
+    const { fn } = mockFetch(() => new Response('boom', { status: 500 }));
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        'http://broken.test/sparql',
+        'n', // refuse retry
+      ]),
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock).toBeNull();
+    expect(logs.some((l) => l.includes('Aborting store setup'))).toBe(true);
+  });
+
+  it('surfaces namespace-missing branch on 404 with namespace-specific hint', async () => {
+    const { fn } = mockFetch(
+      () => new Response('not found', { status: 404 }),
+    );
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', 'http://blaze.test/namespace/missing/sparql', 'n']),
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock).toBeNull();
+    const block = logs.join('\n');
+    expect(block).toMatch(/create the namespace/);
+    expect(block).not.toMatch(/firewall/i); // namespace-missing biases AWAY from network hints
+  });
+
+  it('shows "Docker not detected" message on blank URL when Docker is unavailable, then accepts a manual URL', async () => {
+    const { fn } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        '', // blank URL — Docker probe fails → operator gets retry prompt
+        'y', // retry
+        'http://blaze.test/sparql', // works
+      ]),
+      isDockerAvailable: async () => false,
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(logs.some((l) => l.includes('Docker not detected'))).toBe(true);
+  });
+
+  it('aborts when operator types blank URL and declines retry (Docker unavailable)', async () => {
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', '', 'n']),
+      isDockerAvailable: async () => false,
+      log: () => {},
+    });
+    expect(result.storeBlock).toBeNull();
+  });
+
+  // ---------------------------------------------------------------
+  // PR 3 Docker convenience branch
+  // ---------------------------------------------------------------
+
+  it('offers Docker provisioning when blank URL + Docker available, returns managedByDkg=true on accept', async () => {
+    const provisionCalls: any[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        '', // blank URL — triggers Docker offer
+        'y', // accept Docker offer
+      ]),
+      nodeName: 'mynode',
+      isDockerAvailable: async () => true,
+      provisionBlazegraphDocker: async (opts) => {
+        provisionCalls.push(opts);
+        return {
+          url: 'http://127.0.0.1:9999/bigdata/namespace/mynode/sparql',
+          port: 9999,
+          containerName: 'dkg-blazegraph-mynode',
+          managedByDkg: true,
+          reused: false,
+          namespaceCreated: true,
+        };
+      },
+      log: () => {},
+    });
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://127.0.0.1:9999/bigdata/namespace/mynode/sparql',
+        managedByDkg: true,
+      },
+    });
+    expect(provisionCalls).toHaveLength(1);
+    expect(provisionCalls[0].namespace).toBe('mynode');
+  });
+
+  it('declines Docker offer ("n") falls through to retry/abort branch', async () => {
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        '',  // blank URL
+        'n', // decline Docker
+        'n', // decline retry-with-URL → abort to local default
+      ]),
+      isDockerAvailable: async () => true,
+      provisionBlazegraphDocker: async () => {
+        throw new Error('should not be called when operator declines');
+      },
+      log: () => {},
+    });
+    expect(result.storeBlock).toBeNull();
+  });
+
+  it('falls through to retry when Docker provisioning fails', async () => {
+    const logs: string[] = [];
+    const { fn } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        '', // blank URL
+        'y', // accept Docker
+        // Docker fails → retry-with-URL prompt
+        'y', // retry
+        'http://blaze.test/sparql', // provide URL
+      ]),
+      nodeName: 'mynode',
+      isDockerAvailable: async () => true,
+      provisionBlazegraphDocker: async () => {
+        throw new Error('docker daemon down');
+      },
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(logs.some((l) => l.includes('Docker provisioning failed'))).toBe(true);
+  });
+
+  it('does not offer Docker when isDockerAvailable returns false', async () => {
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', '', 'n']),
+      isDockerAvailable: async () => false,
+      provisionBlazegraphDocker: async () => {
+        throw new Error('should not be called');
+      },
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock).toBeNull();
+    expect(logs.some((l) => l.includes('Docker not detected'))).toBe(true);
+  });
+
+  it('does not offer Docker for sparql-http backend', async () => {
+    let provisionCalled = false;
+    const result = await promptStoreBackend({
+      ask: mockAsk(['sparql-http', '', 'n']),
+      isDockerAvailable: async () => true,
+      provisionBlazegraphDocker: async () => {
+        provisionCalled = true;
+        throw new Error('should not happen');
+      },
+      log: () => {},
+    });
+    expect(provisionCalled).toBe(false);
+    expect(result.storeBlock).toBeNull();
+  });
+
+  it('pre-fills URL prompt from --store-url flag', async () => {
+    const { fn, calls } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    // Mock ask returns the default when the answer is empty; passing
+    // '' simulates the operator hitting Enter to accept the pre-fill.
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', '']),
+      flagBackend: 'blazegraph',
+      flagUrl: 'http://prefilled.test/sparql',
+      fetch: fn,
+      log: () => {},
+    });
+    expect(result.storeBlock?.options.url).toBe('http://prefilled.test/sparql');
+    expect(calls[0].url).toBe('http://prefilled.test/sparql');
+  });
+
+  it('honours existingStore.options.url as the URL default on re-run', async () => {
+    const { fn } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', '']), // accept defaults
+      existingStore: {
+        backend: 'blazegraph',
+        options: { url: 'http://existing.test/sparql' },
+      },
+      fetch: fn,
+      log: () => {},
+    });
+    expect(result.storeBlock?.options.url).toBe('http://existing.test/sparql');
+  });
+
+  it('supports sparql-http with its own queryEndpoint URL', async () => {
+    const { fn, calls } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    const result = await promptStoreBackend({
+      ask: mockAsk(['sparql-http', 'http://server.test/query']),
+      fetch: fn,
+      log: () => {},
+    });
+    expect(result.storeBlock?.backend).toBe('sparql-http');
+    expect(result.storeBlock?.options.url).toBe('http://server.test/query');
+    expect(calls[0].url).toBe('http://server.test/query');
+  });
+});
+
+// ---------------------------------------------------------------------
+// applyStoreFlagsToConfig
+// ---------------------------------------------------------------------
+
+interface MockConfigStore {
+  current: DkgConfig;
+  saved: DkgConfig[];
+}
+
+function newMockConfig(initial: DkgConfig): MockConfigStore {
+  return { current: { ...initial }, saved: [] };
+}
+
+function mockConfigIO(store: MockConfigStore) {
+  return {
+    loadConfig: async () => ({ ...store.current }),
+    saveConfig: async (next: DkgConfig) => {
+      store.current = { ...next };
+      store.saved.push({ ...next });
+    },
+  };
+}
+
+describe('applyStoreFlagsToConfig', () => {
+  const baseConfig: DkgConfig = {
+    name: 'dkg-node',
+    apiPort: 9200,
+    listenPort: 4001,
+  } as DkgConfig;
+
+  it('is a no-op when no --store flag is provided', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    await applyStoreFlagsToConfig({ ...io, log: () => {} });
+    expect(store.saved).toEqual([]);
+  });
+
+  it('persists blazegraph + URL after probe succeeds', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    const { fn } = mockFetch(() => new Response(null, { status: 200 }));
+    await applyStoreFlagsToConfig({
+      ...io,
+      storeFlag: 'blazegraph',
+      storeUrlFlag: 'http://blaze.test/sparql',
+      fetch: fn,
+      log: () => {},
+    });
+    expect(store.saved).toHaveLength(1);
+    expect(store.saved[0].store).toEqual({
+      backend: 'blazegraph',
+      options: { url: 'http://blaze.test/sparql', managedByDkg: false },
+    });
+  });
+
+  it('throws when --store blazegraph is passed without --store-url (no half-written config)', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    await expect(
+      applyStoreFlagsToConfig({
+        ...io,
+        storeFlag: 'blazegraph',
+        log: () => {},
+      }),
+    ).rejects.toThrow(/requires --store-url/);
+    expect(store.saved).toEqual([]);
+  });
+
+  it('throws when the URL is unreachable, persists nothing', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    const { fn } = mockFetch(() => new Response('boom', { status: 500 }));
+    await expect(
+      applyStoreFlagsToConfig({
+        ...io,
+        storeFlag: 'blazegraph',
+        storeUrlFlag: 'http://broken.test/sparql',
+        fetch: fn,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/store URL validation failed/);
+    expect(store.saved).toEqual([]);
+  });
+
+  it('throws on unknown backend value', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    await expect(
+      applyStoreFlagsToConfig({
+        ...io,
+        storeFlag: 'neptune',
+        log: () => {},
+      }),
+    ).rejects.toThrow(/oxigraph, blazegraph, sparql-http/);
+  });
+
+  it('clears existing store block when --store oxigraph is passed', async () => {
+    const store = newMockConfig({
+      ...baseConfig,
+      store: {
+        backend: 'blazegraph',
+        options: { url: 'http://blaze.test/sparql', managedByDkg: false },
+      },
+    });
+    const io = mockConfigIO(store);
+    await applyStoreFlagsToConfig({
+      ...io,
+      storeFlag: 'oxigraph',
+      log: () => {},
+    });
+    expect(store.saved).toHaveLength(1);
+    expect(store.saved[0].store).toBeUndefined();
+  });
+
+  it('is a no-op when --store oxigraph is passed and no existing store block', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    await applyStoreFlagsToConfig({
+      ...io,
+      storeFlag: 'oxigraph',
+      log: () => {},
+    });
+    expect(store.saved).toEqual([]);
+  });
+
+  it('accepts sparql-http with its endpoint URL', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    await applyStoreFlagsToConfig({
+      ...io,
+      storeFlag: 'sparql-http',
+      storeUrlFlag: 'http://server.test/query',
+      fetch: fn,
+      log: () => {},
+    });
+    expect(store.saved[0].store?.backend).toBe('sparql-http');
+    expect(calls[0].url).toBe('http://server.test/query');
+  });
+});

--- a/packages/cli/test/validate-store-config.test.ts
+++ b/packages/cli/test/validate-store-config.test.ts
@@ -1,0 +1,191 @@
+/**
+ * `validateStoreConfig` enforces the extra requirements that external
+ * triple-store backends impose:
+ *
+ *   - blazegraph requires `store.options.url`.
+ *   - sparql-http requires `store.options.queryEndpoint`.
+ *   - largeLiteralStorage/snapshot storage requires explicit `directory`
+ *     when paired with an external backend (no local store path to
+ *     infer from).
+ *
+ * Local backends (default Oxigraph) are unaffected — the function is a
+ * no-op for them.
+ *
+ * Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 1 item 6.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateStoreConfig, type DkgConfig } from '../src/config.js';
+
+function mk(overrides: Partial<DkgConfig> = {}): DkgConfig {
+  return {
+    name: 'dkg-node',
+    apiPort: 9200,
+    listenPort: 4001,
+    ...overrides,
+  } as DkgConfig;
+}
+
+describe('validateStoreConfig', () => {
+  describe('default (no store block)', () => {
+    it('returns no errors when store is undefined', () => {
+      expect(validateStoreConfig(mk())).toEqual([]);
+    });
+  });
+
+  describe('local backends', () => {
+    it('no-op for oxigraph-worker', () => {
+      expect(
+        validateStoreConfig(mk({ store: { backend: 'oxigraph-worker' } })),
+      ).toEqual([]);
+    });
+
+    it('ignores stray external-shaped options on a local backend', () => {
+      // An operator's leftover options field should not trip validation
+      // if the backend is local; the wipe + health check honour
+      // isExternalBackend the same way.
+      const errors = validateStoreConfig(
+        mk({ store: { backend: 'oxigraph-worker', options: { url: 'irrelevant' } } }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('blazegraph', () => {
+    it('errors when options.url is missing', () => {
+      const errors = validateStoreConfig(mk({ store: { backend: 'blazegraph' } }));
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('store.options.url');
+      expect(errors[0].message).toMatch(/store\.options\.url/);
+    });
+
+    it('errors when options.url is empty / whitespace', () => {
+      const errors = validateStoreConfig(
+        mk({ store: { backend: 'blazegraph', options: { url: '  ' } } }),
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('store.options.url');
+    });
+
+    it('passes with a non-empty url', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: {
+            backend: 'blazegraph',
+            options: { url: 'http://127.0.0.1:9999/bigdata/namespace/x/sparql' },
+          },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('sparql-http', () => {
+    it('errors when queryEndpoint is missing', () => {
+      const errors = validateStoreConfig(
+        mk({ store: { backend: 'sparql-http', options: {} } }),
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('store.options.queryEndpoint');
+    });
+
+    it('passes with a queryEndpoint', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: {
+            backend: 'sparql-http',
+            options: { queryEndpoint: 'http://server.test/query' },
+          },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('largeLiteralStorage', () => {
+    it('errors when enabled with external backend but no directory', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: { url: 'http://x/sparql' } },
+          largeLiteralStorage: { enabled: true },
+        }),
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('largeLiteralStorage.directory');
+    });
+
+    it('passes when external + enabled + directory set', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: { url: 'http://x/sparql' } },
+          largeLiteralStorage: { enabled: true, directory: '/var/lib/dkg/blobs' },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('does not error when external but largeLiteralStorage is disabled', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: { url: 'http://x/sparql' } },
+          largeLiteralStorage: { enabled: false },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('does not enforce the directory requirement for local backends', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'oxigraph-worker' },
+          largeLiteralStorage: { enabled: true },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('sharedMemoryPublicSnapshotStorage', () => {
+    it('errors when external + enabled + missing directory', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: { url: 'http://x/sparql' } },
+          sharedMemoryPublicSnapshotStorage: { enabled: true },
+        }),
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('sharedMemoryPublicSnapshotStorage.directory');
+    });
+
+    it('passes when explicit directory set', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: { url: 'http://x/sparql' } },
+          sharedMemoryPublicSnapshotStorage: {
+            enabled: true,
+            directory: '/var/lib/dkg/snapshots',
+          },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('multi-error aggregation', () => {
+    it('reports every problem in one pass, not first-fail', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: {} }, // missing url
+          largeLiteralStorage: { enabled: true }, // missing directory
+          sharedMemoryPublicSnapshotStorage: { enabled: true }, // missing directory
+        }),
+      );
+      expect(errors).toHaveLength(3);
+      const fields = errors.map((e) => e.field).sort();
+      expect(fields).toEqual([
+        'largeLiteralStorage.directory',
+        'sharedMemoryPublicSnapshotStorage.directory',
+        'store.options.url',
+      ]);
+    });
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -34,6 +34,19 @@ export default defineConfig({
           'test/async-promote-worker.test.ts',
           'test/async-promote-queue-e2e.test.ts',
           'test/skill-endpoint.test.ts',
+          // RFC 120 / plan PR 1 + 2 — Blazegraph support. Pure logic
+          // (mocked fetch + in-memory config); cheap to keep in the
+          // fast unit lane.
+          'test/chain-reset-wipe.test.ts',
+          'test/store-health-check.test.ts',
+          'test/validate-store-config.test.ts',
+          'test/store-wizard.test.ts',
+          'test/blazegraph-docker.test.ts',
+          'test/store-identity-tag.test.ts',
+          // Opt-in via BLAZEGRAPH_INTEGRATION_TEST=1. Skips silently
+          // (no fetch / no docker spawn) when the env-var is unset, so
+          // keeping it in the fast unit lane costs nothing.
+          'test/blazegraph-integration.test.ts',
         ],
     testTimeout: runsDaemonHttpBehavior ? 120_000 : 60_000,
     globalSetup: runsDaemonHttpBehavior ? ['../chain/test/hardhat-global-setup.ts'] : [],

--- a/packages/node-ui/src/metrics-collector.ts
+++ b/packages/node-ui/src/metrics-collector.ts
@@ -34,7 +34,12 @@ export interface MetricsSource {
   getTotalKAs(): Promise<number>;
   getConfirmedKCs(): Promise<number>;
   getTentativeKCs(): Promise<number>;
-  getStoreBytes(): Promise<number>;
+  // External SPARQL backends (Blazegraph, sparql-http) own no local
+  // file, so `null` is the correct signal: collector writes a NULL into
+  // the `store_bytes` SQLite column (already nullable). Quad count for
+  // external backends is exposed on demand via `/api/status` instead of
+  // periodically snapshotted.
+  getStoreBytes(): Promise<number | null>;
   getRpcLatencyMs(): Promise<number>;
   isRpcHealthy(): Promise<boolean>;
   /**

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -10,6 +10,9 @@ export {
   type LargeLiteralStorageConfig,
   registerTripleStoreAdapter,
   createTripleStore,
+  isExternalBackend,
+  getSparqlEndpoint,
+  type SparqlEndpoint,
 } from './triple-store.js';
 export {
   EXTERNAL_LITERAL_REF_DATATYPE,

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -65,6 +65,70 @@ export interface TripleStore {
 
 export type TripleStoreBackend = 'oxigraph' | 'oxigraph-persistent' | 'oxigraph-worker' | 'blazegraph' | 'sparql-http' | string;
 
+// Backends that talk to a remote SPARQL endpoint over HTTP rather than
+// owning local files. The local/external split governs three pieces of
+// daemon behaviour:
+//   1. Store-size metric — local backends report file bytes, external
+//      backends have no file to stat (`getStoreBytes` returns null).
+//   2. Chain-reset wipe — local backends `rm` files, external backends
+//      issue SPARQL UPDATE (scoped DELETE for operator-provided URLs to
+//      avoid clobbering V6/V8 data sharing the instance; DROP ALL only
+//      when the namespace is owned by the CLI, signalled via
+//      `storeConfig.options.managedByDkg`).
+//   3. Boot health check — for external backends, an ASK probe runs at
+//      daemon start; an unreachable endpoint exits the daemon with an
+//      actionable message rather than booting half-broken.
+const EXTERNAL_BACKENDS: ReadonlySet<string> = new Set(['blazegraph', 'sparql-http']);
+
+export function isExternalBackend(backend: string | undefined | null): boolean {
+  return typeof backend === 'string' && EXTERNAL_BACKENDS.has(backend);
+}
+
+/**
+ * Shape-normalised SPARQL endpoint extracted from a TripleStoreConfig.
+ *
+ * `blazegraph` adapters use a single `options.url`; `sparql-http`
+ * adapters use distinct `options.queryEndpoint` / `options.updateEndpoint`
+ * with an optional auth header. Callers that need to issue raw SPARQL
+ * (chain-reset wipe, boot health check, namespace identity tag) use this
+ * helper instead of duplicating the options-shape logic in three places.
+ */
+export interface SparqlEndpoint {
+  queryUrl: string;
+  updateUrl: string;
+  headers: Record<string, string>;
+}
+
+export function getSparqlEndpoint(storeConfig: TripleStoreConfig): SparqlEndpoint {
+  if (!isExternalBackend(storeConfig.backend)) {
+    throw new Error(
+      `getSparqlEndpoint called for non-external backend "${storeConfig.backend}"`,
+    );
+  }
+  const opts = (storeConfig.options ?? {}) as Record<string, unknown>;
+  if (storeConfig.backend === 'blazegraph') {
+    const url = typeof opts.url === 'string' ? opts.url : '';
+    if (!url) {
+      throw new Error('blazegraph storeConfig requires options.url');
+    }
+    return { queryUrl: url, updateUrl: url, headers: {} };
+  }
+  // sparql-http
+  const queryEndpoint = typeof opts.queryEndpoint === 'string' ? opts.queryEndpoint : '';
+  if (!queryEndpoint) {
+    throw new Error('sparql-http storeConfig requires options.queryEndpoint');
+  }
+  const updateEndpoint =
+    typeof opts.updateEndpoint === 'string' && opts.updateEndpoint
+      ? opts.updateEndpoint
+      : queryEndpoint;
+  const headers: Record<string, string> = {};
+  if (typeof opts.auth === 'string' && opts.auth) {
+    headers['Authorization'] = opts.auth;
+  }
+  return { queryUrl: queryEndpoint, updateUrl: updateEndpoint, headers };
+}
+
 export interface LargeLiteralStorageConfig {
   /** Enable large SWM literal blob storage. Defaults to true when present. */
   enabled?: boolean;

--- a/packages/storage/test/is-external-backend.test.ts
+++ b/packages/storage/test/is-external-backend.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit coverage for the `isExternalBackend` helper that gates
+ * backend-aware daemon behaviour (metrics, chain-reset-wipe, health
+ * check). Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md`
+ * §PR 1 item 1.
+ */
+import { describe, it, expect } from 'vitest';
+import { isExternalBackend } from '../src/triple-store.js';
+
+describe('isExternalBackend', () => {
+  it('returns true for blazegraph', () => {
+    expect(isExternalBackend('blazegraph')).toBe(true);
+  });
+
+  it('returns true for sparql-http', () => {
+    expect(isExternalBackend('sparql-http')).toBe(true);
+  });
+
+  it('returns false for the oxigraph family', () => {
+    expect(isExternalBackend('oxigraph')).toBe(false);
+    expect(isExternalBackend('oxigraph-worker')).toBe(false);
+    expect(isExternalBackend('oxigraph-persistent')).toBe(false);
+  });
+
+  it('returns false for unknown backends', () => {
+    expect(isExternalBackend('neptune')).toBe(false);
+    expect(isExternalBackend('graphdb')).toBe(false);
+    expect(isExternalBackend('')).toBe(false);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(isExternalBackend(undefined)).toBe(false);
+    expect(isExternalBackend(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements [RFC 120](https://github.com/OriginTrail/dkgv10-spec/pull/120) (external triple-store backends) so DKG nodes can run against **Blazegraph** or any **SPARQL-1.1** endpoint instead of the default in-process Oxigraph, enabling large-graph operators (>50M quads) to scale beyond Oxigraph's working-set limits without rewriting the daemon.

The work is structured as three logical PRs bundled into one commit:

### 1. Daemon internals
- `storage`: `isExternalBackend` + `getSparqlEndpoint` helpers.
- `daemon`: boot-time SPARQL endpoint health probe — hard-exit on unreachable.
- `daemon`: backend-aware `chain-reset-wipe` — scoped `DELETE WHERE { GRAPH ?g ... FILTER STRSTARTS(STR(?g), \"did:dkg:context-graph:\") }` for shared / user-supplied URLs, `DROP ALL` for DKG-managed namespaces.
- `daemon`: config validation for external backends (URL + large-literal / snapshot dirs).
- `daemon`: backend-switch detection via `.network-state.json` with explicit `DKG_ACCEPT_STORE_RESET` guard.
- `api`: \`/api/status\` surfaces \`storeUrl\` + TTL-cached \`storeQuads\` for external backends; \`storeBytes\` returns \`null\` (the local file-bytes metric doesn't apply).
- `cli`: \`dkg status\` renders the new fields.

### 2. CLI UX & docs
- `dkg init`: interactive triple-store prompt (\`oxigraph | blazegraph | sparql-http\`) with URL validation and 404-namespace detection.
- Flags: \`--store\` / \`--store-url\` on \`dkg init\` and the \`hermes\` / \`openclaw\` / \`mcp\` setup subcommands for non-interactive provisioning.
- Docs: README \"Triple Store Backends\" section, \`SETUP_CUSTOM.md\` external-store shapes, \`JOIN_TESTNET.md\` link fix.

### 3. Docker provisioning & namespace identity tagging
- \`blazegraph-docker.ts\`: reusable provisioner (idempotent reuse, port-collision auto-bump, namespace creation) wired into the init wizard when URL is blank and Docker is on PATH.
- \`daemon\`: namespace identity tag in \`<urn:dkg:store-meta>\` prevents two nodes from silently corrupting each other's data on a shared instance — mismatch forces operator-acknowledged exit.

## Test plan

- [x] 108 unit tests (RFC 120 surface), 100% pass on \`release/rc.12\` base:
  - \`packages/storage/test/is-external-backend.test.ts\` (5)
  - \`packages/cli/test/chain-reset-wipe.test.ts\` (25)
  - \`packages/cli/test/store-health-check.test.ts\` (12)
  - \`packages/cli/test/validate-store-config.test.ts\` (15)
  - \`packages/cli/test/store-wizard.test.ts\` (24)
  - \`packages/cli/test/store-identity-tag.test.ts\` (12)
  - \`packages/cli/test/blazegraph-docker.test.ts\` (15)
- [x] Opt-in real-Blazegraph integration test gated by \`BLAZEGRAPH_INTEGRATION_TEST=1\`:
  - \`packages/cli/test/blazegraph-integration.test.ts\` — verifies adapter round-trips, scoped DELETE vs \`DROP ALL\`, and identity tagging against a live Docker-provisioned Blazegraph. (Caveat: \`lyrasis/blazegraph:2.1.5\` is amd64-only; run on amd64 hardware. Apple-Silicon QEMU emulation works but is slow and flaky.)
- [x] Devnet wiring: \`scripts/devnet.sh\` already provisions Blazegraph for nodes 3-4 — **no script changes required**. First-boot flow exercises the new health-check, identity-tag, and scoped-wipe paths automatically.
- [ ] Devnet smoke (recommended pre-merge): \`./scripts/devnet.sh --clean --num-nodes 4\` and confirm nodes 3-4 log \`External triple-store reachable: blazegraph ...\` and \`Tagged triple-store namespace for node \"node3/4\"\`.

## Risk

- **Default backend unchanged.** \`oxigraph-worker\` remains the daemon default. No existing operator config is affected by this change.
- **Scoped wipe is conservative.** When in doubt about ownership (no \`managedByDkg: true\`), the daemon does scoped DELETE rather than \`DROP ALL\`, so a shared external namespace can't be nuked by a single misbehaving node.
- **Identity tag is opt-out friendly.** First boot writes the tag; subsequent boots match. A mismatch is loud (logs the offending node name + the expected one) but allows operators to clear the tag if intentional (e.g. re-keying a namespace).

Spec: https://github.com/OriginTrail/dkgv10-spec/pull/120

Made with [Cursor](https://cursor.com)