### PR TITLE
Fix PR 716 review follow-ups

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -8483,10 +8483,12 @@ export class DKGAgent {
    *   1. slice plaintext into `CIPHERTEXT_CHUNK_SIZE_BYTES`-sized
    *      pieces (last chunk smaller),
    *   2. AEAD-encrypt each chunk with a publish-operation-deterministic
-   *      nonce (`deriveChunkNonce(batchId, chunkIndex)`) so retries
-   *      produce bit-identical ciphertext and idempotent SWM writes
-   *      (idempotency is the spec's only protection against double-
-   *      gossip racing the on-chain commitment),
+   *      nonce (`deriveChunkNonce(publishOperationId, chunkIndex)`) so
+   *      retries produce bit-identical ciphertext and idempotent SWM
+   *      writes (idempotency is the spec's only protection against double-
+   *      gossip racing the on-chain commitment), while distinct publish
+   *      attempts rotate the AEAD nonce domain even if they share the
+   *      same merkle root,
    *   3. fan each ciphertext chunk out as a V2 SWM gossip envelope
    *      (`type = 'share-write-chunked'`, `swmMessageIndex = i`,
    *      payload = `[batchId(32)][ct_i]`) on the curated CG's
@@ -8509,7 +8511,7 @@ export class DKGAgent {
     authorAgentAddress?: string,
     publishContextGraphId?: string,
   ): Promise<
-    | ((input: { plaintextNquads: Uint8Array; batchId: Uint8Array }) => Promise<{
+    | ((input: { plaintextNquads: Uint8Array; batchId: Uint8Array; publishOperationId: string }) => Promise<{
         ciphertextChunksRoot: Uint8Array;
         ciphertextChunkCount: number;
         totalCiphertextBytes: number;
@@ -8537,7 +8539,7 @@ export class DKGAgent {
     const ctx = createOperationContext('publish');
     const gossip = this.gossip;
 
-    return async (input: { plaintextNquads: Uint8Array; batchId: Uint8Array }): Promise<{
+    return async (input: { plaintextNquads: Uint8Array; batchId: Uint8Array; publishOperationId: string }): Promise<{
       ciphertextChunksRoot: Uint8Array;
       ciphertextChunkCount: number;
       totalCiphertextBytes: number;
@@ -8547,15 +8549,18 @@ export class DKGAgent {
           `LU-11: chunked emit requires a 32-byte batchId (V10 KC merkleRoot); got ${input.batchId.length}`,
         );
       }
+      if (input.publishOperationId.length === 0) {
+        throw new Error('LU-11: chunked emit requires a non-empty publishOperationId');
+      }
       const plaintextChunks = sliceIntoCiphertextChunks(input.plaintextNquads);
-      const publishOperationId = ethers.hexlify(input.batchId);
       const { ciphertextChunks } = encryptChunked({
         chainKey,
         contextGraphId: aeadCgId,
         plaintextChunks,
-        publishOperationId,
+        publishOperationId: input.publishOperationId,
       });
       const { root, leafCount } = buildCiphertextChunksRoot(ciphertextChunks);
+      const batchIdHex = ethers.hexlify(input.batchId);
       let totalCiphertextBytes = 0;
       for (let i = 0; i < ciphertextChunks.length; i++) {
         const ct = ciphertextChunks[i];
@@ -8588,7 +8593,7 @@ export class DKGAgent {
           log.warn(
             ctx,
             `LU-11: chunked gossip publish failed for cgId=${contextGraphId} ` +
-            `batchId=${publishOperationId.slice(0, 18)}... chunkIndex=${i}: ${
+            `batchId=${batchIdHex.slice(0, 18)}... op=${input.publishOperationId} chunkIndex=${i}: ${
               err instanceof Error ? err.message : String(err)
             } — cores without this chunk will DECLINE the V2 ACK; ` +
             `late-join sync can backfill once the catchup verb lands.`,
@@ -8599,7 +8604,7 @@ export class DKGAgent {
         ctx,
         `LU-11: emitted ${ciphertextChunks.length} ciphertext chunks ` +
         `(${totalCiphertextBytes} bytes total) for curated CG ${contextGraphId} ` +
-        `batchId=${publishOperationId.slice(0, 18)}... on topic ${topic}`,
+        `batchId=${batchIdHex.slice(0, 18)}... op=${input.publishOperationId} on topic ${topic}`,
       );
       return {
         ciphertextChunksRoot: root,

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -6,6 +6,7 @@
  * closed instead of falling back to plaintext.
  */
 import { describe, it, expect, vi } from 'vitest';
+import { ethers } from 'ethers';
 import { DKGAgent } from '../src/dkg-agent.js';
 
 function makeAgentLike(opts: {
@@ -107,5 +108,54 @@ describe('DKGAgent._resolveEncryptInlinePayload policy lookup', () => {
     await expect(resolveEncryptInlinePayload(agentLike, 'local-public-cg', '42')).rejects.toThrow(
       /target CG "42" curated=unknown/,
     );
+  });
+});
+
+describe('DKGAgent._resolveEncryptInlineChunked nonce domain', () => {
+  it('uses publishOperationId, not batchId, as the chunked AEAD nonce domain', async () => {
+    const signer = ethers.Wallet.createRandom();
+    const agentLike = {
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      gossip: {
+        publish: vi.fn(async () => {}),
+      },
+      gossipWireIdFor: vi.fn((cgId: string) => cgId),
+      _resolveCuratedChainKeyContext: vi.fn(async () => ({
+        chainKey: new Uint8Array(32).fill(7),
+        aeadCgId: '42',
+      })),
+      resolveWorkspaceGossipSigningAgent: vi.fn(async () => ({
+        privateKey: signer.privateKey,
+        agentAddress: signer.address,
+      })),
+    } as any;
+
+    const encryptInlineChunked = await (DKGAgent.prototype as any)
+      ._resolveEncryptInlineChunked.call(agentLike, '42');
+    expect(encryptInlineChunked).toBeDefined();
+
+    const batchId = ethers.getBytes(ethers.id('same-merkle-root'));
+    const plaintextNquads = new TextEncoder().encode(
+      '<urn:a> <urn:p> "one" <urn:g> .\n<urn:b> <urn:p> "two" <urn:g> .',
+    );
+
+    const first = await encryptInlineChunked({
+      plaintextNquads,
+      batchId,
+      publishOperationId: 'publish-op-1',
+    });
+    const second = await encryptInlineChunked({
+      plaintextNquads,
+      batchId,
+      publishOperationId: 'publish-op-2',
+    });
+
+    expect(Buffer.from(first.ciphertextChunksRoot).toString('hex'))
+      .not.toBe(Buffer.from(second.ciphertextChunksRoot).toString('hex'));
   });
 });

--- a/packages/cli/src/daemon/plugin-loader.ts
+++ b/packages/cli/src/daemon/plugin-loader.ts
@@ -119,14 +119,20 @@ async function importSpec(
   //   3. On ESM resolver-shape failure, retry via the loader-local
   //      `createRequire` (final fallback for CJS-only packages).
   if (stableRootRequire) {
+    let resolved: string | undefined;
     try {
-      const resolved = stableRootRequire.resolve(spec);
-      return await import(pathToFileURL(resolved).href);
-    } catch (stableErr) {
+      resolved = stableRootRequire.resolve(spec);
+    } catch {
       // Stable root either does not have the plugin installed yet
       // or hit a resolver-shape edge case. Fall through to ESM
       // import — the loader-level try/catch surfaces the failure
       // with a clear spec name if both anchors miss.
+    }
+    if (resolved) {
+      // Once the stable root resolves the plugin, load/evaluation errors
+      // are authoritative and must not fall through to an older daemon-local
+      // or global install of the same package.
+      return await import(pathToFileURL(resolved).href);
     }
   }
   try {

--- a/packages/cli/src/doctor/checks/install-layout.ts
+++ b/packages/cli/src/doctor/checks/install-layout.ts
@@ -132,9 +132,12 @@ export async function runInstallLayoutCheck(
   }
 
   if (state.daemon.entryPoint && state.paths.npmGlobalDkg) {
-    const ep = state.daemon.entryPoint.replace(/\\/g, '/');
-    const npm = state.paths.npmGlobalDkg.replace(/\\/g, '/');
-    if (!ep.startsWith(npm + '/') && !ep.startsWith(npm)) {
+    const normalizePathForContainment = (p: string) =>
+      p.replace(/\\/g, '/').replace(/\/+$/, '');
+    const ep = normalizePathForContainment(state.daemon.entryPoint);
+    const npm = normalizePathForContainment(state.paths.npmGlobalDkg);
+    const insideNpmGlobal = ep === npm || ep.startsWith(npm + '/');
+    if (!insideNpmGlobal) {
       // Edge daemon is running from somewhere unexpected. Possible
       // causes: stale slot, contributor monorepo, manual override.
       // We report this as a warning so the operator + agent can

--- a/packages/cli/test/daemon/plugin-loader.test.ts
+++ b/packages/cli/test/daemon/plugin-loader.test.ts
@@ -186,6 +186,58 @@ describe('loadRoutePlugins', () => {
     }
   });
 
+  it('does not fall back to a stale daemon-local package when stable-root import fails', async () => {
+    // Stable-root resolution is authoritative once it finds a package. A
+    // broken plugin under ~/.dkg/plugins must surface as broken instead of
+    // being silently rescued by an older daemon-local/global install with the
+    // same package name.
+    const pkgName = `@dkg-test/stable-root-broken-fixture-${process.pid}-${Date.now()}`;
+    const dkgHome = mkdtempSync(join(tmpdir(), 'dkg-stable-root-'));
+    const stableInstallDir = join(dkgHome, 'plugins', 'node_modules', ...pkgName.split('/'));
+    const cliInstallDir = join(resolve(__dirname, '../../node_modules'), ...pkgName.split('/'));
+    mkdirSync(stableInstallDir, { recursive: true });
+    mkdirSync(cliInstallDir, { recursive: true });
+    writeFileSync(
+      join(stableInstallDir, 'package.json'),
+      JSON.stringify({
+        name: pkgName,
+        version: '0.0.0',
+        type: 'module',
+        exports: { '.': './index.mjs' },
+      }),
+    );
+    writeFileSync(
+      join(stableInstallDir, 'index.mjs'),
+      "import helper from './missing-from-stable-root.mjs';\nexport default { name: 'stable-root-broken', handle: helper };\n",
+    );
+    writeFileSync(
+      join(cliInstallDir, 'package.json'),
+      JSON.stringify({
+        name: pkgName,
+        version: '0.0.0',
+        type: 'module',
+        exports: { '.': './index.mjs' },
+      }),
+    );
+    writeFileSync(
+      join(cliInstallDir, 'index.mjs'),
+      "export default { name: 'stale-daemon-local-plugin', handle() {} };\n",
+    );
+    try {
+      const { log, warn } = makeLogger();
+      const plugins = await loadRoutePlugins([pkgName], log, { dkgHome });
+      expect(plugins).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = String(warn.mock.calls[0][1]);
+      expect(msg).toContain('route-plugin-load-failed');
+      expect(msg).toContain('missing-from-stable-root');
+      expect(msg).not.toContain('stale-daemon-local-plugin');
+    } finally {
+      rmSync(dkgHome, { recursive: true, force: true });
+      rmSync(cliInstallDir, { recursive: true, force: true });
+    }
+  });
+
   it('returns [] and warns once when routePlugins is a non-array string value', async () => {
     // Typo case: operator writes a bare string instead of an array. Reject with one warn, don't iterate characters.
     const { log, warn } = makeLogger();

--- a/packages/cli/test/dkg-doctor.test.ts
+++ b/packages/cli/test/dkg-doctor.test.ts
@@ -456,6 +456,19 @@ describe('install-layout check (§4.7.3)', () => {
     expect(findings.find((f) => f.message.includes('not inside the npm-global install'))).toBeDefined();
   });
 
+  it('Edge: warns when daemon entryPoint only shares the npm-global path prefix', async () => {
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+      },
+    });
+    const state = await collectStateSummary(deps);
+    state.paths.npmGlobalDkg = '/usr/local/lib/node_modules/@origintrail-official/dkg';
+    state.daemon.entryPoint = '/usr/local/lib/node_modules/@origintrail-official/dkg-old/dist/cli.js';
+    const findings = await runInstallLayoutCheck(deps, state);
+    expect(findings.find((f) => f.message.includes('not inside the npm-global install'))).toBeDefined();
+  });
+
   it('Core: errors on missing current symlink', async () => {
     const deps = makeDeps({
       fs: {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1802,6 +1802,17 @@ export class DKGPublisher implements Publisher {
       .join('\n');
     const publicByteSize = BigInt(new TextEncoder().encode(nquadsStr).length);
     const merkleRootHex = ethers.hexlify(kcMerkleRoot);
+    let publishOperationId = '';
+    let ual = '';
+    const ensurePublishOperationIdentity = () => {
+      if (publishOperationId.length > 0) return;
+      const tentativeSeq = ++this.tentativeCounter;
+      // RFC-001 §3.5 publication identifier. Stable across tentative and
+      // confirmed states for this publish so the `dkg:Publication` subject
+      // emitted in metadata stays the same after on-chain confirmation.
+      publishOperationId = `${this.sessionId}-${tentativeSeq}`;
+      ual = `did:dkg:${this.chain.chainId}/${publisherAddress}/t${publishOperationId}`;
+    };
 
     // V10: Collect core node StorageACKs (spec §9.0, Phase 3).
     // For direct publish: send staging quads inline via P2P so core nodes
@@ -1837,13 +1848,14 @@ export class DKGPublisher implements Publisher {
     } | undefined;
     if (useChunkedInline) {
       const plaintextBytes = new TextEncoder().encode(nquadsStr);
-      // batchId = V10 KC merkleRoot. Stable per-publish identifier the
-      // cores use to key per-chunk persistence as
-      // (cgId, batchId, chunkIndex) — the exact triple RFC-39 random
-      // sampling samples against.
+      ensurePublishOperationIdentity();
+      // batchId = V10 KC merkleRoot. It remains the core-side
+      // persistence/sampling key, while publishOperationId is the
+      // distinct per-operation nonce domain for chunked AEAD.
       const chunked = await options.encryptInlineChunked!({
         plaintextNquads: plaintextBytes,
         batchId: kcMerkleRoot,
+        publishOperationId,
       });
       // No stagingQuads on the chunked path — chunks travel via SWM
       // gossip, never on the ACK wire. Cores recompute the root from
@@ -2108,12 +2120,7 @@ export class DKGPublisher implements Publisher {
 
     let onChainResult: OnChainPublishResult | undefined;
     let status: 'tentative' | 'confirmed' = 'tentative';
-    const tentativeSeq = ++this.tentativeCounter;
-    // RFC-001 §3.5 publication identifier. Stable across tentative and
-    // confirmed states for this publish so the `dkg:Publication` subject
-    // emitted in metadata stays the same after on-chain confirmation.
-    const publishOperationId = `${this.sessionId}-${tentativeSeq}`;
-    let ual = `did:dkg:${this.chain.chainId}/${publisherAddress}/t${publishOperationId}`;
+    ensurePublishOperationIdentity();
 
     // Resolve the on-chain attribution target from the per-call override
     // (computed above) or fall back to the daemon's persistent identity.

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -189,15 +189,19 @@ export interface PublishOptions {
    * carrying only the resulting `ciphertextChunksRoot` +
    * `ciphertextChunkCount` over `PROTOCOL_STORAGE_ACK_V2`. The
    * `batchId` argument lets the agent's implementation key each
-   * chunk's persistence slot to a stable per-publish identifier
-   * (the V10 KC `merkleRoot`) so cores can index per-chunk
-   * ciphertexts by `(cgId, batchId, chunkIndex)` for RFC-39 random
-   * sampling. Returning bytes is intentionally NOT exposed here —
-   * the chunks live on the SWM substrate, never in the ACK request.
+   * chunk's persistence slot to the V10 KC `merkleRoot` so cores can
+   * index per-chunk ciphertexts by `(cgId, batchId, chunkIndex)` for
+   * RFC-39 random sampling. `publishOperationId` is intentionally
+   * separate: it is the unique per-operation nonce domain for chunked
+   * AEAD, so the same merkle root can never force nonce reuse across
+   * distinct publish attempts. Returning bytes is intentionally NOT
+   * exposed here — the chunks live on the SWM substrate, never in the
+   * ACK request.
    */
   encryptInlineChunked?: (input: {
     plaintextNquads: Uint8Array;
     batchId: Uint8Array;
+    publishOperationId: string;
   }) => Promise<{
     ciphertextChunksRoot: Uint8Array;
     ciphertextChunkCount: number;


### PR DESCRIPTION
Summary:
- Pass the operation-scoped publishOperationId into LU-11 chunked encryption while keeping the merkle root as the chunk storage key.
- Make stable-route-plugin resolution authoritative once the stable root resolves a package.
- Tighten Edge install-layout containment checks so sibling path prefixes warn correctly.

Tests:
- pnpm --filter @origintrail-official/dkg-core build
- pnpm --filter @origintrail-official/dkg-agent exec vitest run test/encrypt-inline-policy.test.ts
- pnpm --filter @origintrail-official/dkg exec vitest run test/daemon/plugin-loader.test.ts test/dkg-doctor.test.ts
- pnpm --filter @origintrail-official/dkg-publisher build
- pnpm --filter @origintrail-official/dkg-chain build
- pnpm --filter @origintrail-official/dkg-random-sampling build
- pnpm --filter @origintrail-official/dkg-agent build

Known:
- pnpm --filter @origintrail-official/dkg build still fails on release/rc.12 at packages/cli/src/cli.ts:4671 with TS2352, unrelated to this patch.