### PR TITLE
fix(graph-viz): normalise _triples on ingress to fix removeTriples bracket asymmetry (#692)

### DIFF
--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.11",
+  "version": "10.0.0-rc.12",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/graph-viz/src/core/graph-model.ts
+++ b/packages/graph-viz/src/core/graph-model.ts
@@ -55,7 +55,14 @@ export class GraphModel {
   readonly edges = new Map<string, GraphEdge>();
   prefixes: PrefixMap = {};
 
-  /** All raw triples stored for reification processing and export */
+  /**
+   * Stores triples in canonical form — subject, predicate, and (when the
+   * object is a resource) object are `cleanUri`-normalised at ingress so
+   * downstream consumers and lookup paths (e.g. `removeTriples`,
+   * reification mirrors, diff exporters) all operate on a single
+   * representation. Literal objects are kept verbatim so quoting,
+   * datatypes, and language tags survive the round-trip.
+   */
   private _triples: RdfTriple[] = [];
 
   /** Set of predicate URIs treated as metadata (not rendered as edges) */
@@ -118,11 +125,17 @@ export class GraphModel {
 
   /** Add a single triple to the model */
   addTriple(triple: RdfTriple): void {
-    this._triples.push(triple);
-
     const subj = cleanUri(triple.subject);
     const pred = cleanUri(triple.predicate);
-    const obj = cleanUri(triple.object);
+    const objectIsResource = isResourceObject(triple.object);
+    const obj = objectIsResource ? cleanUri(triple.object) : triple.object;
+
+    this._triples.push({
+      ...triple,
+      subject: subj,
+      predicate: pred,
+      object: obj,
+    });
 
     const subjectNode = this.ensureNode(subj);
 
@@ -133,9 +146,6 @@ export class GraphModel {
       }
       return;
     }
-
-    // Check if object is a resource (URI/bnode) or a literal
-    const objectIsResource = isResourceObject(triple.object);
 
     if (objectIsResource) {
       // Metadata predicates → store as metadata properties, not edges
@@ -255,11 +265,12 @@ export class GraphModel {
     for (const triple of triples) {
       const subj = cleanUri(triple.subject);
       const pred = cleanUri(triple.predicate);
-      const obj = cleanUri(triple.object);
+      const objectIsResource = isResourceObject(triple.object);
+      const obj = objectIsResource ? cleanUri(triple.object) : triple.object;
 
-      // Remove from raw triples
+      // Match against the canonical form `_triples` stores (see field doc).
       const idx = this._triples.findIndex(
-        (t) => t.subject === triple.subject && t.predicate === triple.predicate && t.object === triple.object
+        (t) => t.subject === subj && t.predicate === pred && t.object === obj
       );
       if (idx !== -1) this._triples.splice(idx, 1);
 
@@ -271,8 +282,6 @@ export class GraphModel {
         }
         continue;
       }
-
-      const objectIsResource = isResourceObject(triple.object);
 
       if (objectIsResource && !this._metadataPredicates.has(pred)) {
         const eid = edgeId(subj, pred, obj);
@@ -298,7 +307,7 @@ export class GraphModel {
           const store = this._metadataPredicates.has(pred) ? node.metadata : node.properties;
           const vals = store.get(pred);
           if (vals) {
-            const filtered = vals.filter((v) => v.value !== triple.object);
+            const filtered = vals.filter((v) => v.value !== obj);
             if (filtered.length === 0) {
               store.delete(pred);
             } else {

--- a/packages/graph-viz/tests/graph-model.test.ts
+++ b/packages/graph-viz/tests/graph-model.test.ts
@@ -235,6 +235,89 @@ describe('GraphModel', () => {
       expect(fromA).toHaveLength(1);
       expect(fromA[0].predicate).toBe('https://schema.org/likes');
     });
+
+    // Regression: GH #692 — `addTriple` cleanUri-normalises the indices but
+    // used to push the raw triple into `_triples`, so a later `removeTriples`
+    // call that used the opposite bracket style would tear down the indices
+    // while leaving the orphaned triple stranded in `_triples`.
+    it('removes a triple added with brackets when called without brackets', () => {
+      model.addTriple({
+        subject: '<urn:x>',
+        predicate: '<urn:p>',
+        object: '<urn:y>',
+      });
+      model.removeTriples([{
+        subject: 'urn:x',
+        predicate: 'urn:p',
+        object: 'urn:y',
+      }]);
+
+      expect(model.tripleCount).toBe(0);
+      expect(model.edges.size).toBe(0);
+      expect(model.nodes.size).toBe(0);
+    });
+
+    it('removes a triple added without brackets when called with brackets', () => {
+      model.addTriple({
+        subject: 'urn:x',
+        predicate: 'urn:p',
+        object: 'urn:y',
+      });
+      model.removeTriples([{
+        subject: '<urn:x>',
+        predicate: '<urn:p>',
+        object: '<urn:y>',
+      }]);
+
+      expect(model.tripleCount).toBe(0);
+      expect(model.edges.size).toBe(0);
+      expect(model.nodes.size).toBe(0);
+    });
+
+    it('stores triples in canonical (cleanUri-normalised) form', () => {
+      model.addTriple({
+        subject: '<urn:x>',
+        predicate: '<urn:p>',
+        object: '<urn:y>',
+      });
+
+      const [stored] = model.triples;
+      expect(stored.subject).toBe('urn:x');
+      expect(stored.predicate).toBe('urn:p');
+      expect(stored.object).toBe('urn:y');
+    });
+
+    it('preserves literal objects verbatim (no bracket-stripping on literals)', () => {
+      model.addTriple({
+        subject: '<urn:x>',
+        predicate: '<urn:name>',
+        object: 'Alice',
+      });
+
+      const [stored] = model.triples;
+      expect(stored.subject).toBe('urn:x');
+      expect(stored.object).toBe('Alice');
+    });
+
+    it('removes an rdf:type triple regardless of bracket style on either side', () => {
+      const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+      model.addTriple({
+        subject: '<urn:x>',
+        predicate: RDF_TYPE,
+        object: '<https://schema.org/Person>',
+      });
+
+      expect(model.nodes.get('urn:x')!.types).toContain('https://schema.org/Person');
+
+      model.removeTriples([{
+        subject: 'urn:x',
+        predicate: RDF_TYPE,
+        object: 'https://schema.org/Person',
+      }]);
+
+      expect(model.tripleCount).toBe(0);
+      expect(model.nodes.size).toBe(0);
+    });
   });
 
   describe('clear', () => {


### PR DESCRIPTION
## Summary

- `GraphModel.addTriple` used to push the **raw** input triple onto `_triples` while applying `cleanUri()` (strip angle brackets + trim) to the subj/pred/obj used to build node/edge indices. `removeTriples` did the same `cleanUri()` for indices but matched against `_triples` by **raw-string equality**. The two paths therefore disagreed on any triple whose endpoint was passed with brackets on one call and without on the other — the canonical-form indices were torn down while the bracketed triple stayed stranded in `_triples`, and any subsequent diff/mirror that iterated `_triples` re-emitted it and reconstructed the index, defeating the remove.
- Fix follows option 1 from the issue (recommended): normalise on ingress. `addTriple` now stores the canonical (`cleanUri`-normalised) form on `_triples` so every downstream consumer — `removeTriples`, the `triples` getter, `exportTriples`, reification mirrors — operates on a single representation. Literal objects are kept verbatim so quoting, datatypes, and language tags survive the round-trip. `removeTriples`'s `_triples.findIndex` was switched to match against canonical form so callers can pass either bracket style on either side and still get a clean teardown.
- Documented the invariant on the `_triples` field declaration, so future readers don't reintroduce the asymmetry.
- Side benefit: `rdf-graph-viz.exportTriples()` uses `formatNTerm(value)` which always wraps with `<...>`. With the old behaviour, a triple ingested as `'<urn:x>'` produced `<<urn:x>>` in the N-Triples export (invalid). Storing the canonical form fixes that latent N-Triples export bug.
- Bumped `@origintrail-official/dkg-graph-viz` from `10.0.0-rc.11` → `10.0.0-rc.12` (patch-level bump on the release-candidate train). Internal consumer (`packages/node-ui`) pins via `workspace:*` so no consumer-side change was needed; the bump is for the published version.

### Asymmetry shape — before vs after

Before:
```ts
// addTriple
this._triples.push(triple); // raw — keeps angle brackets if passed
const subj = cleanUri(triple.subject);   // canonical → drives indices

// removeTriples
const idx = this._triples.findIndex(
  (t) => t.subject === triple.subject &&  // raw === raw
         t.predicate === triple.predicate &&
         t.object === triple.object
);
```

After:
```ts
// addTriple
const subj = cleanUri(triple.subject);
const pred = cleanUri(triple.predicate);
const objectIsResource = isResourceObject(triple.object);
const obj = objectIsResource ? cleanUri(triple.object) : triple.object;
this._triples.push({ ...triple, subject: subj, predicate: pred, object: obj });

// removeTriples
const idx = this._triples.findIndex(
  (t) => t.subject === subj &&     // canonical === canonical
         t.predicate === pred &&
         t.object === obj
);
```

### Regression test

`packages/graph-viz/tests/graph-model.test.ts` gains five assertions inside the `removeTriples` block that all fail on baseline and pass with the patch:

- `removes a triple added with brackets when called without brackets` — original direction from the ticket.
- `removes a triple added without brackets when called with brackets` — the symmetric direction.
- `stores triples in canonical (cleanUri-normalised) form` — encodes the new invariant directly.
- `preserves literal objects verbatim (no bracket-stripping on literals)` — guards against accidentally normalising literal payloads.
- `removes an rdf:type triple regardless of bracket style on either side` — covers the rdf:type early-return branch.

Confirmed by stashing the source patch and running `pnpm --filter @origintrail-official/dkg-graph-viz vitest run tests/graph-model.test.ts`: the five new assertions fail on `origin/main` and pass with the patch. All other graph-viz tests (135 total across 9 files) stay green.

## Related

- Closes #692
- Closes internal Task #12 (graph-viz removeTriples raw-string asymmetry)
- Surfaced during the PR #639 deferred-follow-ups audit referenced in the issue.

## Files changed

| File | What |
|------|------|
| `packages/graph-viz/src/core/graph-model.ts` | Normalise subject/predicate/(resource) object via `cleanUri` at ingress in `addTriple` and store canonical form on `_triples`; switch `removeTriples` lookup + literal-property filter to canonical form; document the invariant on the `_triples` field. |
| `packages/graph-viz/tests/graph-model.test.ts` | Five new regression cases in the `removeTriples` block covering both asymmetry directions, the canonical-form invariant, literal preservation, and rdf:type. |
| `packages/graph-viz/package.json` | Patch-level version bump `10.0.0-rc.11` → `10.0.0-rc.12`. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-graph-viz vitest run` — 9 files, 135 tests, all green with the patch.
- [x] Baseline confirmation: stashed the source patch and re-ran the graph-viz vitest suite; the five new assertions fail on baseline as expected.
- [x] `pnpm --filter @origintrail-official/dkg-graph-viz build` — full ESM + CJS + d.ts build succeeds.
- [x] `pnpm --filter @origintrail-official/dkg-node-ui vitest run test/graph-label-predicates.test.ts test/layer-graph-panel.test.ts` — both graph-viz-touching node-ui suites pass (13/13 tests).
- [x] Full node-ui vitest run on patched vs. baseline graph-viz produces an identical deterministic-failure set (worktree-environment / pre-existing time-dependent flakes only); no new failures attributable to the patch.