### PR TITLE
fix(node-ui): N6 polish carry-overs from PR #694

### DIFF
--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -141,10 +141,22 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   // mirroring the per-bucket chip; we render the same row in both
   // the empty and populated branches so the heading stays anchored
   // (showing "0" rather than vanishing into the empty state).
+  //
+  // PR #694 polish carry-over (b) — when the lifecycle SPARQL
+  // errored, suppress the exact count and render `—` instead.
+  // Showing "0" next to "RECENT ACTIVITY" while the error indicator
+  // below says "Couldn't load recent activity." contradicts itself
+  // (precise count vs not-loaded). The em-dash keeps the row
+  // anchored without claiming a specific number.
   const titleRow = title ? (
     <div className="v10-activity-feed-title">
       <span className="v10-activity-feed-title-label">{title}</span>
-      <span className="v10-activity-feed-title-count">{titleCount}</span>
+      <span
+        className="v10-activity-feed-title-count"
+        data-state={lifecycleError ? 'error' : undefined}
+      >
+        {lifecycleError ? '—' : titleCount}
+      </span>
     </div>
   ) : null;
 

--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -143,19 +143,27 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   // (showing "0" rather than vanishing into the empty state).
   //
   // PR #694 polish carry-over (b) — when the lifecycle SPARQL
-  // errored, suppress the exact count and render `—` instead.
-  // Showing "0" next to "RECENT ACTIVITY" while the error indicator
-  // below says "Couldn't load recent activity." contradicts itself
-  // (precise count vs not-loaded). The em-dash keeps the row
-  // anchored without claiming a specific number.
+  // errored AND no rows are visible (`items.length === 0`), render
+  // `—` instead of "0". Showing "0" next to "RECENT ACTIVITY" while
+  // the error indicator below says "Couldn't load recent activity."
+  // contradicts itself (precise count vs not-loaded). The em-dash
+  // keeps the row anchored without claiming a specific number.
+  //
+  // Codex review on PR #769 — when carry-over (a)'s cached rows
+  // remain after a same-graph refresh failure, we DO have a real
+  // list visible below. Falling back to `—` in that path would
+  // make the badge disagree with the rendered count. Tighten the
+  // condition: only render `—` when there are genuinely no rows
+  // to count.
+  const showErrorPlaceholder = lifecycleError != null && items.length === 0;
   const titleRow = title ? (
     <div className="v10-activity-feed-title">
       <span className="v10-activity-feed-title-label">{title}</span>
       <span
         className="v10-activity-feed-title-count"
-        data-state={lifecycleError ? 'error' : undefined}
+        data-state={showErrorPlaceholder ? 'error' : undefined}
       >
-        {lifecycleError ? '—' : titleCount}
+        {showErrorPlaceholder ? '—' : titleCount}
       </span>
     </div>
   ) : null;

--- a/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
+++ b/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
@@ -155,6 +155,15 @@ export function useAssertionLifecycleEvents(
   const [error, setError] = useState<string | null>(null);
   const [resultContextGraphId, setResultContextGraphId] = useState<string | undefined>(undefined);
   const lastRequestedCg = useRef<string | undefined>(undefined);
+  // Mirrors `resultContextGraphId` for use inside the async effect
+  // closure WITHOUT capturing a stale value. PR #769 Codex review —
+  // the prior shape read `resultContextGraphId` via a functional
+  // `setResultContextGraphId(prev => …)` updater that also fired
+  // `setEvents([])` as a side effect; React requires updaters to
+  // stay pure (and Strict Mode invokes them twice to detect impurity).
+  // A ref kept in sync at every write site is the contract-clean way
+  // to read "what graph last resolved" inside the catch path.
+  const lastResultCg = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     if (!contextGraphId) {
@@ -177,6 +186,7 @@ export function useAssertionLifecycleEvents(
       setEvents([]);
       setError(null);
       setResultContextGraphId(undefined);
+      lastResultCg.current = undefined;
     }
     let cancelled = false;
     const controller = new AbortController();
@@ -254,6 +264,7 @@ export function useAssertionLifecycleEvents(
         }
         setEvents(out);
         setResultContextGraphId(contextGraphId);
+        lastResultCg.current = contextGraphId;
         setError(null);
       } catch (err) {
         if (cancelled || (err as any)?.name === 'AbortError') return;
@@ -262,30 +273,33 @@ export function useAssertionLifecycleEvents(
         // good feed on a same-graph refresh failure (transient
         // 503 / timeout / network blip). Different-graph stale
         // cache was already cleared at the top of the effect
-        // (lines ~176-180) before the fetch fired, so by the time
-        // we reach this catch `resultContextGraphId` is EITHER
+        // (lines ~176-181) before the fetch fired, so by the time
+        // we reach this catch `lastResultCg.current` is EITHER
         // undefined (first fetch on this graph — nothing cached
         // for us to keep) OR === contextGraphId (a prior fetch on
         // THIS graph succeeded — keep those rows so the UI doesn't
         // collapse to empty while the error indicator surfaces
-        // alongside). Functional-setter pattern reads the latest
-        // resultContextGraphId without needing it in effect deps.
-        setResultContextGraphId(prevResultCg => {
-          if (prevResultCg !== contextGraphId) {
-            // No cached rows for this graph — clear the (likely
-            // stale or never-set) events array.
-            setEvents([]);
-          }
-          // PR #694 review fix — advance `resultContextGraphId` on
-          // failure so consumers gating on
-          // `resultContextGraphId === contextGraphId` (the Code7 pattern
-          // shared with `useSwmAttributions`) can distinguish "still
-          // loading the new graph" from "the new graph errored and
-          // that's the answer for this graph". Without this, an early
-          // failure keeps consumers stuck in the previous-graph state
-          // until the hook re-runs.
-          return contextGraphId;
-        });
+        // alongside).
+        //
+        // PR #769 Codex review — the ref-based read avoids both
+        // the stale-closure trap on `resultContextGraphId` AND
+        // the React-contract violation of nesting `setEvents([])`
+        // inside a `setResultContextGraphId` updater (updaters must
+        // stay pure; Strict Mode invokes them twice to detect
+        // impurity).
+        if (lastResultCg.current !== contextGraphId) {
+          setEvents([]);
+        }
+        // PR #694 review fix — advance `resultContextGraphId` on
+        // failure so consumers gating on
+        // `resultContextGraphId === contextGraphId` (the Code7 pattern
+        // shared with `useSwmAttributions`) can distinguish "still
+        // loading the new graph" from "the new graph errored and
+        // that's the answer for this graph". Without this, an early
+        // failure keeps consumers stuck in the previous-graph state
+        // until the hook re-runs.
+        setResultContextGraphId(contextGraphId);
+        lastResultCg.current = contextGraphId;
       } finally {
         if (timeoutId) clearTimeout(timeoutId);
         if (!cancelled) setLoading(false);

--- a/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
+++ b/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
@@ -258,16 +258,34 @@ export function useAssertionLifecycleEvents(
       } catch (err) {
         if (cancelled || (err as any)?.name === 'AbortError') return;
         setError((err as Error).message ?? String(err));
-        setEvents([]);
-        // PR #694 review fix — advance `resultContextGraphId` on
-        // failure so consumers gating on
-        // `resultContextGraphId === contextGraphId` (the Code7 pattern
-        // shared with `useSwmAttributions`) can distinguish "still
-        // loading the new graph" from "the new graph errored and
-        // that's the answer for this graph". Without this, an early
-        // failure keeps consumers stuck in the previous-graph state
-        // until the hook re-runs.
-        setResultContextGraphId(contextGraphId);
+        // PR #694 polish carry-over (a) — preserve the last-known-
+        // good feed on a same-graph refresh failure (transient
+        // 503 / timeout / network blip). Different-graph stale
+        // cache was already cleared at the top of the effect
+        // (lines ~176-180) before the fetch fired, so by the time
+        // we reach this catch `resultContextGraphId` is EITHER
+        // undefined (first fetch on this graph — nothing cached
+        // for us to keep) OR === contextGraphId (a prior fetch on
+        // THIS graph succeeded — keep those rows so the UI doesn't
+        // collapse to empty while the error indicator surfaces
+        // alongside). Functional-setter pattern reads the latest
+        // resultContextGraphId without needing it in effect deps.
+        setResultContextGraphId(prevResultCg => {
+          if (prevResultCg !== contextGraphId) {
+            // No cached rows for this graph — clear the (likely
+            // stale or never-set) events array.
+            setEvents([]);
+          }
+          // PR #694 review fix — advance `resultContextGraphId` on
+          // failure so consumers gating on
+          // `resultContextGraphId === contextGraphId` (the Code7 pattern
+          // shared with `useSwmAttributions`) can distinguish "still
+          // loading the new graph" from "the new graph errored and
+          // that's the answer for this graph". Without this, an early
+          // failure keeps consumers stuck in the previous-graph state
+          // until the hook re-runs.
+          return contextGraphId;
+        });
       } finally {
         if (timeoutId) clearTimeout(timeoutId);
         if (!cancelled) setLoading(false);

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -347,6 +347,52 @@ describe('Context Graph shared empty/stat patterns', () => {
     await unmount();
   });
 
+  it('replaces the title-count number with an em-dash when lifecycleError is set (PR #694 polish carry-over b)', async () => {
+    // Title row would otherwise show "0" next to "Recent activity"
+    // while the inline error indicator below reads "Couldn't load
+    // recent activity." — contradicting itself (precise count vs
+    // not-loaded). The em-dash placeholder keeps the row anchored
+    // without claiming a specific number.
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: [],
+        onSelectEntity: vi.fn(),
+        title: 'Recent activity',
+        lifecycleEvents: [],
+        lifecycleError: 'SPARQL query failed: 503',
+      }),
+    );
+
+    const badge = container.querySelector('.v10-activity-feed-title-count');
+    expect(badge).toBeTruthy();
+    expect(badge?.textContent).toBe('—');
+    expect(badge?.getAttribute('data-state')).toBe('error');
+    // The title row still renders (anchored heading).
+    expect(container.querySelector('.v10-activity-feed-title-label')?.textContent).toBe('Recent activity');
+
+    await unmount();
+  });
+
+  it('keeps the title-count number when error is null even with empty events', async () => {
+    // Regression guard for the carry-over fix — the em-dash only
+    // fires on a lifecycle ERROR, not on an empty-but-healthy feed.
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: [],
+        onSelectEntity: vi.fn(),
+        title: 'Recent activity',
+        lifecycleEvents: [],
+        lifecycleError: null,
+      }),
+    );
+
+    const badge = container.querySelector('.v10-activity-feed-title-count');
+    expect(badge?.textContent).toBe('0');
+    expect(badge?.getAttribute('data-state')).toBeNull();
+
+    await unmount();
+  });
+
   it('shows the explained interim empty state for SWM assertions', async () => {
     apiMocks.listAssertions.mockResolvedValueOnce([]);
     const { container, unmount } = await render(

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -393,6 +393,60 @@ describe('Context Graph shared empty/stat patterns', () => {
     await unmount();
   });
 
+  it('keeps the title-count number when lifecycleError is set BUT events were preserved from a successful prior fetch (Codex interaction between carry-overs)', async () => {
+    // The composition of carry-over (a) + carry-over (b):
+    //   (a) preserves cached rows on a same-graph refresh failure
+    //       → `events` still contains the prior rows.
+    //   (b) falls back to `—` when lifecycleError is set.
+    // Naive (b) would say `—` while N actual rows render below.
+    // Codex caught the contradiction on PR #769 — the badge must
+    // agree with the visible row count, not the error state, when
+    // both fire.
+    const events = [
+      {
+        eventUri: 'urn:evt:promote-1',
+        kind: 'promoted' as const,
+        assertionUri: 'urn:assert:doc-1',
+        assertionName: 'doc-1',
+        agentUri: 'did:dkg:agent:alice',
+        publishedAt: '2026-05-25T10:00:00Z',
+      },
+      {
+        eventUri: 'urn:evt:promote-2',
+        kind: 'promoted' as const,
+        assertionUri: 'urn:assert:doc-2',
+        assertionName: 'doc-2',
+        agentUri: 'did:dkg:agent:bob',
+        publishedAt: '2026-05-26T10:00:00Z',
+      },
+      {
+        eventUri: 'urn:evt:promote-3',
+        kind: 'promoted' as const,
+        assertionUri: 'urn:assert:doc-3',
+        assertionName: 'doc-3',
+        agentUri: 'did:dkg:agent:carol',
+        publishedAt: '2026-05-27T10:00:00Z',
+      },
+    ];
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: [],
+        onSelectEntity: vi.fn(),
+        title: 'Recent activity',
+        lifecycleEvents: events,
+        lifecycleError: 'SPARQL query failed: 503',
+      }),
+    );
+
+    const badge = container.querySelector('.v10-activity-feed-title-count');
+    expect(badge?.textContent).toBe('3');
+    // No error state on the badge — the visible list takes precedence
+    // over the error signal when both fire.
+    expect(badge?.getAttribute('data-state')).toBeNull();
+
+    await unmount();
+  });
+
   it('shows the explained interim empty state for SWM assertions', async () => {
     apiMocks.listAssertions.mockResolvedValueOnce([]);
     const { container, unmount } = await render(

--- a/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
+++ b/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
@@ -266,6 +266,86 @@ describe('useAssertionLifecycleEvents — bindings parse', () => {
   // consumers (ProjectView → ActivityFeed) plumb it through to
   // render an error indicator. This test pins the hook contract:
   // error message is exposed verbatim so the UI can surface it.
+  it('preserves the last-known-good `events` cache when a same-graph refresh fails (PR #694 polish carry-over a)', async () => {
+    let latest: AssertionLifecycleEventsResult | null = null;
+    function Probe({ id }: { id: string | undefined }) {
+      latest = useAssertionLifecycleEvents(id);
+      return null;
+    }
+    // First mount on `cg-A`. Resolve with one row so the hook has a
+    // populated cache + `resultContextGraphId === 'cg-A'`.
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-A' }));
+    });
+    await flush();
+    pending.get('cg-A')!.resolve([
+      row({
+        event: 'urn:event:1',
+        kind: 'created',
+        assertion: 'urn:assertion:1',
+        name: 'a1',
+        agent: 'urn:agent:1',
+        ts: '2026-05-27T12:00:00Z',
+      }),
+    ]);
+    await flush();
+    expect(latest!.events).toHaveLength(1);
+    expect(latest!.resultContextGraphId).toBe('cg-A');
+    expect(latest!.error).toBeNull();
+
+    // User navigates away from Overview — Probe receives `id={undefined}`.
+    // Per PR #694 Comment 20 the hook PRESERVES `events` /
+    // `resultContextGraphId` in this gated-off state.
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: undefined }));
+    });
+    await flush();
+    expect(latest!.events).toHaveLength(1);
+    expect(latest!.resultContextGraphId).toBe('cg-A');
+
+    // User returns to Overview — Probe receives `id='cg-A'` again,
+    // which re-fires the effect. This time the daemon errors
+    // (transient 503).
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('SPARQL query failed: 503');
+    }) as any;
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-A' }));
+    });
+    await flush();
+
+    // The carry-over fix — the cached row from the earlier success
+    // must NOT be clobbered to `[]`. The error message surfaces
+    // alongside.
+    expect(latest!.error).toBe('SPARQL query failed: 503');
+    expect(latest!.events).toHaveLength(1);
+    expect(latest!.events[0].assertionUri).toBe('urn:assertion:1');
+    // The discriminator still points at the current graph.
+    expect(latest!.resultContextGraphId).toBe('cg-A');
+  });
+
+  it('clears `events` when a fetch errors on a graph with no prior cached result', async () => {
+    // Regression guard for the fix: the cache-preservation only
+    // applies when `resultContextGraphId === contextGraphId` (i.e.,
+    // we had a prior success on THIS graph). A first-mount error on
+    // a fresh graph still produces an empty list.
+    let latest: AssertionLifecycleEventsResult | null = null;
+    function Probe({ id }: { id: string }) {
+      latest = useAssertionLifecycleEvents(id);
+      return null;
+    }
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('SPARQL query failed: 503');
+    }) as any;
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-fresh' }));
+    });
+    await flush();
+    expect(latest!.error).toBe('SPARQL query failed: 503');
+    expect(latest!.events).toHaveLength(0);
+    expect(latest!.resultContextGraphId).toBe('cg-fresh');
+  });
+
   it('exposes the rejection message verbatim on error (Comment 8 distinguishability)', async () => {
     let latest: AssertionLifecycleEventsResult | null = null;
     function Probe({ id }: { id: string }) {


### PR DESCRIPTION
## Summary

Two small UI carry-overs from PR #694 (N6 activity feed bundle), both surfaced by reviewer comments at merge time and queued in the implementation plan's N6 "post-merge follow-ups" section:

- **(a) Preserve `events` on same-graph refresh failure.** Pre-fix, `useAssertionLifecycleEvents.ts`'s catch path unconditionally `setEvents([])`, which threw away the last-known-good feed on any transient error during a same-graph re-fetch (e.g. user opens Overview on cgId X with success, navigates away, returns to Overview, the re-fetch errors). The error indicator below the title would say *"Couldn't load recent activity"* while the feed itself collapsed to empty — losing valid cached data the user had just been looking at.

  Fix: functional-setter pattern on `setResultContextGraphId` reads the previous value inside the catch. When `prevResultCg === contextGraphId` (a prior fetch on THIS graph succeeded), preserve `events`. When it doesn't match (first-fetch on this graph), clear as before. The Comment 3 fix from PR #694 (advancing `resultContextGraphId` on failure to keep the Code7 discriminator pattern intact) is preserved.

- **(b) Hide the title-count badge during lifecycle errors.** Pre-fix, `ActivityFeed.tsx`'s title row rendered the exact count (often `0`) next to "Recent activity" while the inline error indicator below said *"Couldn't load recent activity."* — a precise count next to a "couldn't load" message reads as contradictory signal.

  Fix: render `—` (em-dash) when `lifecycleError != null`, plus `data-state="error"` on the badge for styling / a11y consumers. Title label still renders so the heading stays anchored.

## Related

- Follows #694 (N6 activity feed bundle) — these are the two reviewer-comment carry-overs explicitly deferred to a polish PR.
- Implementation plan's §5 / N6 "Post-merge follow-ups from PR #694 polish" section enumerated both; this PR closes that subsection.
- Not related: GH #705 (peer-activity replication gap) — architectural / backend, intentionally out of scope.

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts` | Carry-over (a): catch path uses functional `setResultContextGraphId` to read prior cgId; preserves `events` when the failing fetch is a same-graph refresh. Preserves the PR #694 Comment 3 fix (advance `resultContextGraphId` on failure). |
| `packages/node-ui/src/ui/components/ActivityFeed.tsx` | Carry-over (b): title-count badge renders `—` (em-dash) + `data-state="error"` when `lifecycleError != null`; numeric count otherwise. |
| `packages/node-ui/test/use-assertion-lifecycle-events.test.ts` | Two new regression cases: cache-preservation on same-graph refresh failure; cache-clear on first-fetch failure. |
| `packages/node-ui/test/context-graph-empty-stat-components.test.ts` | Two new regression cases: em-dash on `lifecycleError != null`; numeric count when error is null even with empty events. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec tsc --noEmit` — clean.
- [x] Focused N6 slice (`use-assertion-lifecycle-events` + `context-graph-empty-stat-components`) — 27/27 passing (was 23; +4 new regression cases).
- [x] Broader activity slice (adds `context-graph-ia-overview`, `project-view-navigation`, `use-project-activity`, `use-project-activity-events-joiner`, `build-lifecycle-activity-rows`) — 128/128 passing.
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui` — clean.
- [x] `agent-docs/` not in diff.
- [ ] (Optional, reviewer) Manual walkthrough: open the Overview on a CG with prior activity rows; trigger a transient daemon error during re-fetch (e.g. restart the daemon while the UI is open); verify the rows stay rendered and the error indicator shows alongside, vs the pre-fix collapse to empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
