### PR TITLE
fix(publisher): emit dkg:subGraphName from assertion-lifecycle writers (#696)

### DIFF
--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -621,7 +621,7 @@ export function generateAssertionCreatedMetadata(meta: AssertionCreatedMeta): Qu
   const agentUri = `did:dkg:agent:${meta.agentAddress}`;
   const eventUri = `${subject}/event/${nextEventId()}`;
 
-  return [
+  const quads: Quad[] = [
     // Assertion entity (prov:Entity + DKG identity)
     mq(subject, `${RDF}type`, `${PROV}Entity`, metaGraph),
     mq(subject, `${RDF}type`, `${DKG}Assertion`, metaGraph),
@@ -641,6 +641,12 @@ export function generateAssertionCreatedMetadata(meta: AssertionCreatedMeta): Qu
     mq(eventUri, `${DKG}fromLayer`, lit('none'), metaGraph),
     mq(eventUri, `${DKG}toLayer`, lit(MemoryLayer.WorkingMemory), metaGraph),
   ];
+
+  if (meta.subGraphName) {
+    quads.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), metaGraph));
+  }
+
+  return quads;
 }
 
 export interface AssertionPromotedMeta {
@@ -680,6 +686,9 @@ export function generateAssertionPromotedMetadata(meta: AssertionPromotedMeta): 
   for (const entity of meta.rootEntities) {
     ins.push(mq(eventUri, `${DKG}rootEntity`, entity, metaGraph));
   }
+  if (meta.subGraphName) {
+    ins.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), metaGraph));
+  }
   return { insert: ins, delete: del };
 }
 
@@ -697,19 +706,23 @@ export function generateAssertionPublishedMetadata(meta: AssertionPublishedMeta)
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
   const agentUri = `did:dkg:agent:${meta.agentAddress}`;
   const eventUri = `${subject}/event/${nextEventId()}`;
+  const ins: Quad[] = [
+    mq(subject, `${DKG}state`, lit('published'), metaGraph),
+    mq(subject, `${DKG}memoryLayer`, lit(MemoryLayer.VerifiedMemory), metaGraph),
+    mq(eventUri, `${RDF}type`, `${PROV}Activity`, metaGraph),
+    mq(eventUri, `${RDF}type`, `${DKG}AssertionPublished`, metaGraph),
+    mq(eventUri, `${PROV}startedAtTime`, dateLit(meta.timestamp), metaGraph),
+    mq(eventUri, `${PROV}wasAssociatedWith`, agentUri, metaGraph),
+    mq(eventUri, `${PROV}used`, subject, metaGraph),
+    mq(eventUri, `${DKG}fromLayer`, lit(MemoryLayer.SharedWorkingMemory), metaGraph),
+    mq(eventUri, `${DKG}toLayer`, lit(MemoryLayer.VerifiedMemory), metaGraph),
+    mq(eventUri, `${DKG}kcUal`, meta.kcUal, metaGraph),
+  ];
+  if (meta.subGraphName) {
+    ins.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), metaGraph));
+  }
   return {
-    insert: [
-      mq(subject, `${DKG}state`, lit('published'), metaGraph),
-      mq(subject, `${DKG}memoryLayer`, lit(MemoryLayer.VerifiedMemory), metaGraph),
-      mq(eventUri, `${RDF}type`, `${PROV}Activity`, metaGraph),
-      mq(eventUri, `${RDF}type`, `${DKG}AssertionPublished`, metaGraph),
-      mq(eventUri, `${PROV}startedAtTime`, dateLit(meta.timestamp), metaGraph),
-      mq(eventUri, `${PROV}wasAssociatedWith`, agentUri, metaGraph),
-      mq(eventUri, `${PROV}used`, subject, metaGraph),
-      mq(eventUri, `${DKG}fromLayer`, lit(MemoryLayer.SharedWorkingMemory), metaGraph),
-      mq(eventUri, `${DKG}toLayer`, lit(MemoryLayer.VerifiedMemory), metaGraph),
-      mq(eventUri, `${DKG}kcUal`, meta.kcUal, metaGraph),
-    ],
+    insert: ins,
     delete: [
       assertionStateQuad(subject, 'promoted', metaGraph),
       assertionLayerQuad(subject, MemoryLayer.SharedWorkingMemory, metaGraph),
@@ -730,18 +743,22 @@ export function generateAssertionDiscardedMetadata(meta: AssertionDiscardedMeta)
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
   const agentUri = `did:dkg:agent:${meta.agentAddress}`;
   const eventUri = `${subject}/event/${nextEventId()}`;
+  const ins: Quad[] = [
+    mq(subject, `${DKG}state`, lit('discarded'), metaGraph),
+    mq(subject, `${PROV}wasInvalidatedBy`, eventUri, metaGraph),
+    mq(eventUri, `${RDF}type`, `${PROV}Activity`, metaGraph),
+    mq(eventUri, `${RDF}type`, `${DKG}AssertionDiscarded`, metaGraph),
+    mq(eventUri, `${PROV}startedAtTime`, dateLit(meta.timestamp), metaGraph),
+    mq(eventUri, `${PROV}wasAssociatedWith`, agentUri, metaGraph),
+    mq(eventUri, `${PROV}used`, subject, metaGraph),
+    mq(eventUri, `${DKG}fromLayer`, lit(MemoryLayer.WorkingMemory), metaGraph),
+    mq(eventUri, `${DKG}toLayer`, lit('none'), metaGraph),
+  ];
+  if (meta.subGraphName) {
+    ins.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), metaGraph));
+  }
   return {
-    insert: [
-      mq(subject, `${DKG}state`, lit('discarded'), metaGraph),
-      mq(subject, `${PROV}wasInvalidatedBy`, eventUri, metaGraph),
-      mq(eventUri, `${RDF}type`, `${PROV}Activity`, metaGraph),
-      mq(eventUri, `${RDF}type`, `${DKG}AssertionDiscarded`, metaGraph),
-      mq(eventUri, `${PROV}startedAtTime`, dateLit(meta.timestamp), metaGraph),
-      mq(eventUri, `${PROV}wasAssociatedWith`, agentUri, metaGraph),
-      mq(eventUri, `${PROV}used`, subject, metaGraph),
-      mq(eventUri, `${DKG}fromLayer`, lit(MemoryLayer.WorkingMemory), metaGraph),
-      mq(eventUri, `${DKG}toLayer`, lit('none'), metaGraph),
-    ],
+    insert: ins,
     delete: [
       assertionStateQuad(subject, 'created', metaGraph),
       assertionLayerQuad(subject, MemoryLayer.WorkingMemory, metaGraph),

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -551,6 +551,22 @@ describe('generateAssertionCreatedMetadata', () => {
       expect(q.graph).toBe(META_GRAPH);
     }
   });
+
+  it('emits dkg:subGraphName on the assertion subject when scoped to a sub-graph', () => {
+    const scopedLifecycleUri = assertionLifecycleUri(CONTEXT_GRAPH, AGENT_ADDR, ASSERTION, 'players');
+    const quads = generateAssertionCreatedMetadata({ ...meta, subGraphName: 'players' });
+    expect(quads).toContainEqual(expect.objectContaining({
+      subject: scopedLifecycleUri,
+      predicate: `${DKG}subGraphName`,
+      object: '"players"',
+      graph: META_GRAPH,
+    }));
+  });
+
+  it('omits dkg:subGraphName when assertion is in the root bucket', () => {
+    const quads = generateAssertionCreatedMetadata(meta);
+    expect(quads.find(q => q.predicate === `${DKG}subGraphName`)).toBeUndefined();
+  });
 });
 
 describe('generateAssertionPromotedMetadata', () => {
@@ -602,6 +618,22 @@ describe('generateAssertionPromotedMetadata', () => {
     expect(entities.map(q => q.object)).toContain('urn:test:alice');
     expect(entities.map(q => q.object)).toContain('urn:test:bob');
   });
+
+  it('emits dkg:subGraphName on the assertion subject when scoped to a sub-graph', () => {
+    const scopedLifecycleUri = assertionLifecycleUri(CONTEXT_GRAPH, AGENT_ADDR, ASSERTION, 'players');
+    const { insert } = generateAssertionPromotedMetadata({ ...meta, subGraphName: 'players' });
+    expect(insert).toContainEqual(expect.objectContaining({
+      subject: scopedLifecycleUri,
+      predicate: `${DKG}subGraphName`,
+      object: '"players"',
+      graph: META_GRAPH,
+    }));
+  });
+
+  it('omits dkg:subGraphName when assertion is in the root bucket', () => {
+    const { insert } = generateAssertionPromotedMetadata(meta);
+    expect(insert.find(q => q.predicate === `${DKG}subGraphName`)).toBeUndefined();
+  });
 });
 
 describe('generateAssertionPublishedMetadata', () => {
@@ -625,6 +657,22 @@ describe('generateAssertionPublishedMetadata', () => {
     const { insert } = generateAssertionPublishedMetadata(meta);
     const eventUri = findEventUriFromInsert(insert);
     expect(insert.find(q => q.subject === eventUri && q.predicate === `${DKG}kcUal`)!.object).toBe('did:dkg:kc:test-kc-001');
+  });
+
+  it('emits dkg:subGraphName on the assertion subject when scoped to a sub-graph', () => {
+    const scopedLifecycleUri = assertionLifecycleUri(CONTEXT_GRAPH, AGENT_ADDR, ASSERTION, 'players');
+    const { insert } = generateAssertionPublishedMetadata({ ...meta, subGraphName: 'players' });
+    expect(insert).toContainEqual(expect.objectContaining({
+      subject: scopedLifecycleUri,
+      predicate: `${DKG}subGraphName`,
+      object: '"players"',
+      graph: META_GRAPH,
+    }));
+  });
+
+  it('omits dkg:subGraphName when assertion is in the root bucket', () => {
+    const { insert } = generateAssertionPublishedMetadata(meta);
+    expect(insert.find(q => q.predicate === `${DKG}subGraphName`)).toBeUndefined();
   });
 });
 
@@ -654,6 +702,22 @@ describe('generateAssertionDiscardedMetadata', () => {
     const eventUri = findEventUriFromInsert(insert);
     expect(insert.find(q => q.subject === eventUri && q.predicate === `${DKG}fromLayer`)!.object).toBe(`"${MemoryLayer.WorkingMemory}"`);
     expect(insert.find(q => q.subject === eventUri && q.predicate === `${DKG}toLayer`)!.object).toBe('"none"');
+  });
+
+  it('emits dkg:subGraphName on the assertion subject when scoped to a sub-graph', () => {
+    const scopedLifecycleUri = assertionLifecycleUri(CONTEXT_GRAPH, AGENT_ADDR, ASSERTION, 'players');
+    const { insert } = generateAssertionDiscardedMetadata({ ...meta, subGraphName: 'players' });
+    expect(insert).toContainEqual(expect.objectContaining({
+      subject: scopedLifecycleUri,
+      predicate: `${DKG}subGraphName`,
+      object: '"players"',
+      graph: META_GRAPH,
+    }));
+  });
+
+  it('omits dkg:subGraphName when assertion is in the root bucket', () => {
+    const { insert } = generateAssertionDiscardedMetadata(meta);
+    expect(insert.find(q => q.predicate === `${DKG}subGraphName`)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #696. The four assertion-lifecycle metadata writers — `generateAssertionCreatedMetadata`, `generateAssertionPromotedMetadata`, `generateAssertionPublishedMetadata`, `generateAssertionDiscardedMetadata` — take a `subGraphName` on their meta input and use it to build sub-graph-scoped assertion URIs, but they never emit the `dkg:subGraphName` triple on the assertion subject itself. `generateShareMetadata` does (`metadata.ts:393-395`), and that asymmetry is what forced PR #694's review to add a URI parser on the consumer side.

This PR mirrors the existing emission pattern across all four lifecycle writers: append `<subject> dkg:subGraphName "<slug>"` when `meta.subGraphName` is set; omit for root-bucket assertions.

## Scope note (beyond ticket DoD)

The ticket explicitly documents the gap for Created + Promoted. Published + Discarded had the same gap (same `subGraphName?: string` field on the meta interface, same missing emission). Fixed all four for consistency; future-proofs the planned hook simplification across all four event types, not just two. Reviewers — push back if there's a specific reason to keep Published/Discarded untouched.

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/metadata.ts` | One `if (meta.subGraphName)` push per writer in all four lifecycle generators (Created/Promoted/Published/Discarded). Created refactored from `return [...]` literal to a `const quads: Quad[] = [...]` + post-push + `return quads`; Published/Discarded same shape change. Promoted already had the `ins` array variable, clean one-block addition. |
| `packages/publisher/test/metadata.test.ts` | Two new `it` cases per writer (8 total): emits `dkg:subGraphName` when scoped + omits when in root bucket. Scoped tests recompute the sub-graph-scoped `LIFECYCLE_URI` via `assertionLifecycleUri(..., 'players')` so subject equality holds. |

## Test plan

- [x] `pnpm exec vitest run test/metadata.test.ts` in `packages/publisher` → **65 passed** (was 57; +8 new cases). All four scoped-emits + four root-omits green; pre-existing 64 tests still pass.
- [x] Hand-checked: `assertionLifecycleUri(cg, agent, 'name', 'players')` is the subject the new triple is keyed on (same as `dkg:state`, `dkg:assertionGraph`, etc.) — a single SPARQL pattern can carry both.
- [ ] (Optional, reviewer) Broader `pnpm test` shows 45 unrelated failures in sibling workspace packages (`@origintrail-official/dkg-storage`, `dkg-chain`, `dkg-query`) — same module-resolution errors on a `git stash` of these changes, so they pre-exist this PR.

## Follow-up (separate node-ui PR, intentionally out of scope per ticket DoD)

`packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts` can switch the SPARQL from `OPTIONAL { ?assertion dkg:assertionGraph ?assertionGraph }` (parsed client-side via `subGraphFromAssertionGraphUri` from `lib/sub-graph-uri.ts`) to `OPTIONAL { ?assertion dkg:subGraphName ?subGraph }` and read the slug as a literal. The helper then becomes dead code and can be removed. node-ui-engineer can pick this up after merge.

## Related

- Closes #696 (the ticket).
- #694 — adds the URI parser this PR makes redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)