### PR TITLE
feat(node-ui): finalize Subgraph Explorer (S3)

### DIFF
--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -13,7 +13,7 @@ import { fetchSubGraphs, type SubGraphInfo } from '../api.js';
 import type { ProjectProfile } from '../hooks/useProjectProfile.js';
 import type { MemoryEntity } from '../hooks/useMemoryEntities.js';
 import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
-import { isUserFacingSubGraph } from '../lib/subGraphs.js';
+import { isUserFacingSubGraph, ROOT_SLUG_SENTINEL } from '../lib/subGraphs.js';
 
 export interface SubGraphBadge {
   /** Short label shown inline on the chip, e.g. "2 proposed" */
@@ -148,6 +148,21 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
     return n;
   }, [layer, entities]);
 
+  // S3 fold-in: the synthesized "Root" bucket is "all entities minus
+  // those in any named sub-graph". Computed from the same entity list
+  // the named chips use so the counts agree row-by-row.
+  const rootEntityCount = React.useMemo(() => {
+    if (!entities) return null;
+    const trust = layer ? LAYER_TRUST_LEVEL[layer] : null;
+    let n = 0;
+    for (const e of entities) {
+      if (trust !== null && e.trustLevel !== trust) continue;
+      if (e.subGraphs.size > 0) continue;
+      n++;
+    }
+    return n;
+  }, [layer, entities]);
+
   const loadSubGraphs = React.useCallback(() => {
     const requestId = ++requestIdRef.current;
     setLoading(true);
@@ -196,8 +211,13 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
       .sort((a, b) => a.rank - b.rank);
   }, [subGraphs, profile, entityScopedCounts]);
 
-  if (loading && merged.length === 0) return null;
-  if (merged.length === 0) return null;
+  // Show the Root chip when the consumer derives root from entities
+  // and at least one entity is in the root bucket. Without entities
+  // (Overview / Subgraphs page) we'd be guessing — keep it hidden.
+  const showRootChip = rootEntityCount !== null && rootEntityCount > 0;
+
+  if (loading && merged.length === 0 && !showRootChip) return null;
+  if (merged.length === 0 && !showRootChip) return null;
 
   // Prefer the distinct-entity total (R2-5 / Issue B); fall back to
   // the daemon-sum only when no entities prop was passed.
@@ -214,12 +234,12 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
 
   return (
     <div className="v10-subgraph-bar">
-      <div className="v10-subgraph-bar-label">Sub-graphs</div>
+      <div className="v10-subgraph-bar-label">Subgraphs</div>
       <button
         type="button"
         className={`v10-subgraph-chip${selected === null ? ' active' : ''}`}
         onClick={() => onSelect(null)}
-        title={`All sub-graphs · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`}
+        title={`All subgraphs · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`}
       >
         <span className="v10-subgraph-chip-icon">⊚</span>
         <span className="v10-subgraph-chip-label">All</span>
@@ -250,6 +270,19 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
           </button>
         );
       })}
+      {showRootChip && (
+        <button
+          type="button"
+          className={`v10-subgraph-chip v10-subgraph-chip-root${selected === ROOT_SLUG_SENTINEL ? ' active' : ''}`}
+          onClick={() => onSelect(ROOT_SLUG_SENTINEL)}
+          title={`Entities not in any subgraph (Context Graph root) · ${rootEntityCount} entities${scopeSuffix}`}
+          aria-label="Entities not in any subgraph (Context Graph root)"
+        >
+          <span className="v10-subgraph-chip-icon">⊘</span>
+          <span className="v10-subgraph-chip-label">Root</span>
+          <span className="v10-subgraph-chip-count">{rootEntityCount}</span>
+        </button>
+      )}
     </div>
   );
 };

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -214,7 +214,13 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
   // Show the Root chip when the consumer derives root from entities
   // and at least one entity is in the root bucket. Without entities
   // (Overview / Subgraphs page) we'd be guessing — keep it hidden.
-  const showRootChip = rootEntityCount !== null && rootEntityCount > 0;
+  // Also keep it visible whenever Root is the currently selected
+  // chip — otherwise a live refresh (or the "View root" empty-state
+  // action) that drops the count to 0 hides the chip while the
+  // detail body remains in Root scope, leaving no active chip.
+  // The count still renders honestly (0 if no root entities).
+  const hasRootEntities = rootEntityCount !== null && rootEntityCount > 0;
+  const showRootChip = hasRootEntities || selected === ROOT_SLUG_SENTINEL;
 
   if (loading && merged.length === 0 && !showRootChip) return null;
   if (merged.length === 0 && !showRootChip) return null;
@@ -270,19 +276,25 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
           </button>
         );
       })}
-      {showRootChip && (
-        <button
-          type="button"
-          className={`v10-subgraph-chip v10-subgraph-chip-root${selected === ROOT_SLUG_SENTINEL ? ' active' : ''}`}
-          onClick={() => onSelect(ROOT_SLUG_SENTINEL)}
-          title={`Entities not in any subgraph (Context Graph root) · ${rootEntityCount} entities${scopeSuffix}`}
-          aria-label="Entities not in any subgraph (Context Graph root)"
-        >
-          <span className="v10-subgraph-chip-icon">⊘</span>
-          <span className="v10-subgraph-chip-label">Root</span>
-          <span className="v10-subgraph-chip-count">{rootEntityCount}</span>
-        </button>
-      )}
+      {showRootChip && (() => {
+        const displayCount = rootEntityCount ?? 0;
+        const isActive = selected === ROOT_SLUG_SENTINEL;
+        return (
+          <button
+            type="button"
+            className={`v10-subgraph-chip v10-subgraph-chip-root${isActive ? ' active' : ''}`}
+            data-active={isActive}
+            data-count={displayCount}
+            onClick={() => onSelect(ROOT_SLUG_SENTINEL)}
+            title={`Entities not in any subgraph (Context Graph root) · ${displayCount} entities${scopeSuffix}`}
+            aria-label="Entities not in any subgraph (Context Graph root)"
+          >
+            <span className="v10-subgraph-chip-icon">⊘</span>
+            <span className="v10-subgraph-chip-label">Root</span>
+            <span className="v10-subgraph-chip-count">{displayCount}</span>
+          </button>
+        );
+      })()}
     </div>
   );
 };

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -278,13 +278,18 @@ function vmSparql(cgId: string) {
  * Returns undefined for graph URIs outside the expected project scope
  * (e.g. _meta, _shared_memory) so those triples stay un-bucketed.
  */
-function subGraphOf(gUri: string, cgId: string): string | undefined {
+export function subGraphOf(gUri: string, cgId: string): string | undefined {
   const prefix = `did:dkg:context-graph:${cgId}/`;
   if (!gUri.startsWith(prefix)) return undefined;
   const tail = gUri.slice(prefix.length);
   const slash = tail.indexOf('/');
   const seg = slash >= 0 ? tail.slice(0, slash) : tail;
-  if (!seg || seg.startsWith('_')) return undefined;
+  // `assertion` is the WM assertion-graph segment
+  // (`<cg>/assertion/<addr>/<name>`), not a user-facing sub-graph; leaking
+  // it as a slug surfaces a phantom "Assertion" sub-graph chip on entity
+  // detail pages. Filter alongside underscore-prefixed bookkeeping
+  // segments so `entity.subGraphs` stays semantically pure.
+  if (!seg || seg.startsWith('_') || seg === 'assertion') return undefined;
   return seg;
 }
 

--- a/packages/node-ui/src/ui/hooks/useProjectProfile.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectProfile.ts
@@ -12,6 +12,7 @@
  */
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { executeQuery } from '../api.js';
+import { ROOT_SLUG_SENTINEL } from '../lib/subGraphs.js';
 
 async function runProjectQuery(
   sparql: string,
@@ -148,6 +149,25 @@ const DEFAULT_SUBGRAPH_FALLBACK = (slug: string): SubGraphBinding => ({
   color: '#64748b',
   rank: 99,
 });
+
+// S3 — synthesized binding for the client-only Root bucket. The
+// daemon never emits a binding for ROOT_SLUG_SENTINEL (it's a
+// pure client construct — "entities not in any named sub-graph"),
+// so `forSubGraph` would otherwise hand back the default
+// `__root__`/`•` fallback to consumers like ProjectHeaderStrip.
+// Centralising the Root identity here means every `forSubGraph`
+// call site (breadcrumb, chip, detail header, badge) agrees on
+// the same icon + label + tone.
+const ROOT_SUBGRAPH_BINDING: SubGraphBinding = {
+  slug: ROOT_SLUG_SENTINEL,
+  displayName: 'Root',
+  description: 'Entities not in any subgraph (Context Graph root)',
+  icon: '⊘',
+  // color is left unset so consumers fall through to their own
+  // neutral default (CSS var --text-tertiary on the chip / detail
+  // header, --border-strong on the empty-state accent).
+  rank: 99,
+};
 
 const DEFAULT_TYPE_FALLBACK = (typeIri: string): EntityTypeBinding => ({
   typeIri,
@@ -593,7 +613,15 @@ export function useProjectProfile(contextGraphId: string | undefined): ProjectPr
   }, [contextGraphId]);
 
   const forSubGraph = useCallback(
-    (slug: string) => subIndexRef.current.get(slug) ?? DEFAULT_SUBGRAPH_FALLBACK(slug),
+    (slug: string) => {
+      // S3 — Root bucket has a canonical synthesized binding. Short-
+      // circuit before the daemon-bindings lookup so every consumer
+      // (chip, detail header, breadcrumb, badge) reads the same
+      // identity and the project header strip never displays the
+      // raw sentinel as a breadcrumb label.
+      if (slug === ROOT_SLUG_SENTINEL) return ROOT_SUBGRAPH_BINDING;
+      return subIndexRef.current.get(slug) ?? DEFAULT_SUBGRAPH_FALLBACK(slug);
+    },
     [],
   );
   const forType = useCallback(

--- a/packages/node-ui/src/ui/lib/subGraphs.ts
+++ b/packages/node-ui/src/ui/lib/subGraphs.ts
@@ -14,6 +14,16 @@
 
 export const RESERVED_SUB_GRAPH_SLUGS: ReadonlySet<string> = new Set(['meta']);
 
+// Client-side sentinel for the synthesized "Root" bucket (entities
+// not in any named sub-graph). The double-underscore prefix marks it
+// as a synthesized slug — the daemon's slug guard rejects underscore-
+// prefixed segments, so this can never collide with a real sub-graph.
+// Lives next to RESERVED_SUB_GRAPH_SLUGS so the Root bucket has one
+// source of truth shared by SubGraphBar (chip selection state),
+// SubGraphOverviewGrid (empty-state action), and SubGraphDetailView
+// (scope derivation).
+export const ROOT_SLUG_SENTINEL = '__root__';
+
 /**
  * Returns true if a sub-graph descriptor should be surfaced to
  * users (chip row, card grid, Overview count). False for reserved

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6780,6 +6780,138 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
 .v10-subgraph-badge-icon { font-size: 10px; line-height: 1; }
 .v10-subgraph-badge-label { text-transform: capitalize; }
 
+/* ── Subgraph Explorer page header (S3) ── */
+/* Persistent page identity + 3-sentence intro. Rendered above the
+   SubGraphBar both in the All / overview state and inside every
+   detail body so the explanatory text never disappears. */
+.v10-subgraph-explorer-header {
+  padding: 12px 16px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v10-subgraph-explorer-title {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--text-primary);
+}
+.v10-subgraph-explorer-intro {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  max-width: 760px;
+}
+
+/* ── Subgraph Explorer Root chip (S3) ── */
+/* Quieter than named chips — it's a fallback bucket. The ⊘ glyph
+   signals "no subgraph". Sits at the end of the chip row, after
+   any named chips. */
+.v10-subgraph-chip.v10-subgraph-chip-root {
+  color: var(--text-tertiary);
+}
+.v10-subgraph-chip.v10-subgraph-chip-root .v10-subgraph-chip-icon {
+  color: var(--text-tertiary);
+}
+.v10-subgraph-chip.v10-subgraph-chip-root.active {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: rgba(255,255,255,0.05);
+}
+
+/* ── Cross-layer count strip + active-layer pill (S3) ── */
+/* The count strip is the page's whole point — every subgraph is
+   cross-layer. The pill below it surfaces the active-layer scope
+   so it never silently changes meaning across a navigation
+   transition (M2 / S5 strand). */
+.v10-subgraph-cross-layer {
+  padding: 10px 16px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: rgba(255,255,255,0.01);
+}
+.v10-subgraph-cross-layer-lede {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  letter-spacing: 0.01em;
+}
+.v10-subgraph-cross-layer-strip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.v10-subgraph-cross-layer-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  font-size: 12px;
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+.v10-subgraph-cross-layer-cell-icon {
+  font-size: 13px;
+  line-height: 1;
+}
+.v10-subgraph-cross-layer-cell-label {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.v10-subgraph-cross-layer-cell-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.v10-subgraph-cross-layer-arrow {
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+.v10-subgraph-active-layer-pill {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  background: rgba(255,255,255,0.02);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.v10-subgraph-active-layer-pill:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+.v10-subgraph-active-layer-pill:disabled {
+  cursor: default;
+  opacity: 0.85;
+}
+.v10-subgraph-active-layer-pill.all-layers {
+  color: var(--text-tertiary);
+}
+.v10-subgraph-active-layer-pill-label {
+  text-transform: uppercase;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+.v10-subgraph-active-layer-pill-value {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
 /* ── Verify on DKG CTA (in KA detail right pane) ── */
 /* Two variants: .promote (WM -> SWM, amber) and .publish (SWM -> VM, green).
    The layer-transition icon (◈ / ◉) matches LAYER_CONFIG so the CTA

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { useFetch } from '../hooks.js';
 import { api } from '../api-wrapper.js';
 import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
-import { isUserFacingSubGraph } from '../lib/subGraphs.js';
+import { isUserFacingSubGraph, ROOT_SLUG_SENTINEL } from '../lib/subGraphs.js';
 import { ImportFilesModal } from '../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../components/Modals/ShareProjectModal.js';
 import {
@@ -32,6 +32,7 @@ import {
   OverviewPrimerEntry,
   curatorStatusForOverview,
   SubGraphOverviewGrid,
+  SubGraphExplorerHeader,
   ContextGraphQueryView,
   LayerDetailView,
 } from './project/components.js';
@@ -528,9 +529,13 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
         />
       )}
 
-      {/* Sub-graph page mode — first-class peer of the layer views */}
+      {/* Subgraph Explorer — page mode (specific chip or Root selected).
+          First-class peer of the layer views; the page identity, intro
+          and chip row are shared with the All / Subgraphs-overview state
+          (rendered below in the graph-overview branch). */}
       {activeSubGraph && !selectedEntity && (
         <>
+          <SubGraphExplorerHeader />
           <SubGraphBar
             contextGraphId={contextGraphId}
             profile={profile}
@@ -602,14 +607,26 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
         </>
       )}
 
-      {/* Subgraphs — one mini graph per sub-graph, side-by-side */}
+      {/* Subgraph Explorer — All state (page heading + intro + chip row
+          + card-wall body). Selecting a chip transitions to the detail
+          body via `activeSubGraph` (branch above). */}
       {!activeSubGraph && activeLayer === 'graph-overview' && !selectedEntity && (
-        <SubGraphOverviewGrid
-          contextGraphId={contextGraphId}
-          memory={rawMemory}
-          onNodeClick={handleNodeClick}
-          onSelectSubGraph={handleSelectSubGraph}
-        />
+        <>
+          <SubGraphExplorerHeader />
+          <SubGraphBar
+            contextGraphId={contextGraphId}
+            profile={profile}
+            selected={null}
+            entities={rawMemory.entityList}
+            onSelect={handleSelectSubGraph}
+          />
+          <SubGraphOverviewGrid
+            contextGraphId={contextGraphId}
+            memory={rawMemory}
+            onNodeClick={handleNodeClick}
+            onSelectSubGraph={handleSelectSubGraph}
+          />
+        </>
       )}
 
       {!activeSubGraph && activeLayer === 'query' && !selectedEntity && (

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -477,6 +477,20 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // Active sub-graph binding (for the breadcrumb strip) — stays in scope
   // across sub-graph / layer / overview routes.
   const activeSubGraphBinding = activeSubGraph ? profile.forSubGraph(activeSubGraph) : null;
+
+  // Codex Bug C — gate the `entities`-driven chip-count path on a
+  // fully-loaded memory snapshot. While `useMemoryEntities` is mid-
+  // hydration or a layer query is in-flight, `entityList` is partial
+  // (often empty) and the chip counts derived from it disagree with
+  // the daemon-side `sg.entityCount` fallback used by
+  // SubGraphOverviewGrid — same screen, two numbers for the same
+  // subgraph. Passing `undefined` keeps SubGraphBar on the daemon
+  // total path until both readiness conditions hold; the `partial`
+  // flag covers individual-layer fetch failures (counts incomplete
+  // but not absent), which is also a contradiction we don't want
+  // surfacing on the chip row.
+  const memoryReady = !rawMemory.loading && !rawMemory.error && !rawMemory.partial;
+  const chipBarEntities = memoryReady ? rawMemory.entityList : undefined;
   const activePage = selectedEntity
     ? 'entity'
     : activeSubGraph
@@ -540,7 +554,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             contextGraphId={contextGraphId}
             profile={profile}
             selected={activeSubGraph}
-            entities={rawMemory.entityList}
+            entities={chipBarEntities}
             onSelect={handleSelectSubGraph}
           />
           <SubGraphDetailView
@@ -617,7 +631,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             contextGraphId={contextGraphId}
             profile={profile}
             selected={null}
-            entities={rawMemory.entityList}
+            entities={chipBarEntities}
             onSelect={handleSelectSubGraph}
           />
           <SubGraphOverviewGrid
@@ -640,7 +654,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             contextGraphId={contextGraphId}
             profile={profile}
             selected={activeSubGraph}
-            entities={rawMemory.entityList}
+            entities={chipBarEntities}
             onSelect={handleSelectSubGraph}
             layer={activeLayer}
           />

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -256,7 +256,17 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     [cgData, contextGraphId]
   );
 
-  const rawMemory = useMemoryEntities(contextGraphId);
+  // `signalErrors: true` flips `rawMemory.error` to a real string
+  // when all three layer queries fail. Without it the hook treats
+  // "every layer failed" as `error: null, partial: false` (since
+  // `partial` only triggers on a PARTIAL failure), and the Bug C
+  // `memoryReady` gate below incorrectly classes that state as
+  // ready — passing an empty entityList into SubGraphBar while the
+  // daemon-backed `sg.entityCount` totals stay non-zero (the same
+  // contradiction Bug C set out to prevent). Mirrors the
+  // DashboardView caller, which already opts in for the same
+  // failed-vs-empty-distinct reason.
+  const rawMemory = useMemoryEntities(contextGraphId, { signalErrors: true });
   // SWM attribution drives the SWM graph's agent-tint legend (its
   // sole remaining consumer). PR #694 review — the Overview no
   // longer reads this stream (lifecycle source replaced it), so the

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3859,13 +3859,36 @@ export function SubGraphOverviewGrid({
   const profile = useProjectProfileContext();
   const [subGraphs, setSubGraphs] = useState<SubGraphInfo[]>([]);
   const [loading, setLoading] = useState(true);
+  // Track fetch failure separately from "the daemon returned no
+  // sub-graphs". Issue G — the teaching empty state explains the
+  // subgraph concept and offers `View root`, which is helpful when
+  // the CG genuinely has no sub-graphs yet, but reads as
+  // authoritative "all clear" when the cards endpoint actually
+  // failed mid-flight. The error branch below renders only when
+  // we got nothing from the daemon AND the request failed; a
+  // transient failure during refresh (where prior cards are still
+  // populated) keeps showing the last good grid.
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setFetchError(null);
     fetchSubGraphs(contextGraphId)
-      .then(r => { if (!cancelled) setSubGraphs(r.subGraphs ?? []); })
-      .catch(() => { /* silent */ })
+      .then(r => {
+        if (!cancelled) {
+          setSubGraphs(r.subGraphs ?? []);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setFetchError(err instanceof Error ? err.message : 'Failed to load subgraphs');
+          // Don't blow away prior `subGraphs` on a refresh failure —
+          // the error branch below gates on `cards.length === 0` so
+          // last-good cards stay rendered with a stale-but-readable
+          // state instead of vanishing.
+        }
+      })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
   }, [contextGraphId]);
@@ -3997,6 +4020,22 @@ export function SubGraphOverviewGrid({
         compact
         icon="#"
         title="Loading subgraphs..."
+        className="v10-sgov-state"
+      />
+    );
+  }
+  // Issue G — distinguish "fetch failed" from "no sub-graphs". A
+  // cold-start failure plus the success-empty branch's `View root`
+  // CTA reads as authoritative "no subgraphs exist", but it's
+  // actually a transient API error. Only render this when the
+  // request failed AND we have no last-good cards.
+  if (fetchError && cards.length === 0) {
+    return (
+      <EmptyState
+        icon="!"
+        title="Couldn't load subgraphs."
+        description="Refresh the page to try again."
+        tone="danger"
         className="v10-sgov-state"
       />
     );

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4360,24 +4360,31 @@ export function SubGraphDetailView({
     [scopedEntities],
   );
 
-  // Triples visible in the Graph tab.
-  //  • Named branch: anything tagged with this sub-graph's origin, plus
-  //    any triple admissible under the asymmetric subject+object
-  //    scope rule used by the layer-tab path — subject-scoped is the
-  //    primary admission gate (covers rdf:type / labels / literal-valued
-  //    properties on promoted entities whose `subGraph` was erased on
-  //    promotion); object-scoped resources are admitted as a recovery
-  //    edge so promoted SWM/VM endpoints don't silently disappear
-  //    (fold-in #7, supersedes the over-strict `both ends in scopedUris`
-  //    branch that dropped legitimate cross-layer edges).
-  //  • Root branch: triples whose subject is root-scoped, with the same
-  //    object-side recovery.
+  // Triples visible in the Graph tab. Routing is *exact-tag-first*,
+  // erased-tag recovery second:
+  //   1. Triples carrying an explicit `subGraph` tag are routed to
+  //      that exact slug (named branch only — the Root bucket has no
+  //      tagged triples by definition). A triple tagged for "other"
+  //      must never leak into the current view just because one of
+  //      its endpoints happens to be a scoped entity (an entity in
+  //      multiple sub-graphs is shared territory, not a broadcast
+  //      channel).
+  //   2. Triples with NO `subGraph` tag are admitted if either
+  //      endpoint is in scope. This is the post-promotion recovery
+  //      path — promoting an assertion erases the `subGraph` origin
+  //      tag from the resulting SWM/VM triples; without this branch
+  //      promoted entities lose their rdf:type / labels / literal
+  //      properties and their cross-layer edges in this view.
+  // Root branch: rule (1) can never fire (the Root bucket carries
+  // no tagged triples); only the untagged-recovery path admits.
   const scopedTriples = useMemo(
     () => rawMemory.graphTriples.filter(t => {
       if (!isRoot && t.subGraph === slug) return true;
-      if (scopedUris.has(t.subject)) return true;
-      if (scopedUris.has(t.object)) return true;
-      return false;
+      // Exact-tag-routing: a triple with a non-matching subGraph tag
+      // belongs to that other slug's view, not this one — even if an
+      // endpoint is shared.
+      if (t.subGraph) return false;
+      return scopedUris.has(t.subject) || scopedUris.has(t.object);
     }),
     [rawMemory.graphTriples, scopedUris, slug, isRoot],
   );

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4692,16 +4692,16 @@ export function SubGraphDetailView({
     }
   }, [contextGraphId]);
 
-  // Root branch carries no profile binding (it's a client-side
-  // sentinel slug) — synthesize the chrome. The neutral colour token
-  // and `⊘` glyph match the SubGraphBar chip so the page identity
-  // stays coherent when the user transitions from chip to body.
-  const color = isRoot ? 'var(--text-tertiary)' : (binding?.color ?? '#64748b');
-  const icon = isRoot ? '⊘' : (binding?.icon ?? '•');
-  const title = isRoot ? 'Root' : (binding?.displayName ?? slug);
-  const desc = isRoot
-    ? 'Entities not in any subgraph (Context Graph root).'
-    : binding?.description;
+  // `profile.forSubGraph` short-circuits ROOT_SLUG_SENTINEL to the
+  // synthesized Root binding (icon ⊘ / displayName "Root" /
+  // description) so every Subgraph Explorer surface — chip, this
+  // detail header, the project breadcrumb strip — reads the same
+  // identity. Root's color is left unset so the CSS neutral
+  // (--text-tertiary via the `--sg-color` fallback) wins.
+  const color = binding?.color ?? (isRoot ? 'var(--text-tertiary)' : '#64748b');
+  const icon = binding?.icon ?? '•';
+  const title = binding?.displayName ?? slug;
+  const desc = binding?.description;
 
   // Reset filters when the sub-graph changes — otherwise chips from
   // `tasks` would linger when the user jumps to `decisions` and silently

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -66,7 +66,7 @@ import {
   type SubGraphTab, type SubGraphEntitySort,
 } from './helpers.js';
 import { EmptyState, StatStrip, toneForLayer } from '../../components/ContextGraphPrimitives.js';
-import { isUserFacingSubGraph } from '../../lib/subGraphs.js';
+import { isUserFacingSubGraph, ROOT_SLUG_SENTINEL } from '../../lib/subGraphs.js';
 import { useNodeEvents } from '../../hooks/useNodeEvents.js';
 
 export const RdfGraph = lazy(() =>
@@ -1264,6 +1264,7 @@ export function LayerGraphPanel({
   scopeEntities,
   swmAttribution,
   layerEntities,
+  nodeColorsOverride,
 }: {
   layer: 'wm' | 'swm' | 'vm';
   triples: Triple[];
@@ -1272,6 +1273,19 @@ export function LayerGraphPanel({
   scopeLabel?: string;
   trustLegendActiveLayer?: 'wm' | 'swm' | 'vm' | null;
   title?: string;
+  /**
+   * Per-URI colour override passed straight into the graph style's
+   * `nodeColors` slot. Sits ABOVE `classColors` / `namespaceColors`
+   * in the style-engine priority stack, so the caller wins for
+   * specified URIs while unspecified nodes still inherit the
+   * existing class/namespace palette and layer defaults. Used by
+   * `SubGraphDetailView` (multi-layer view) to paint per-entity
+   * trust colour (TRUST_COLORS keyed by `entity.trustLevel`) on
+   * top of the WM-default-layer fallback (fold-in #6, PR #677
+   * follow-up). Omit on the WM/SWM/VM layer tabs — SWM's own
+   * attribution palette via `swmAttribution` still runs.
+   */
+  nodeColorsOverride?: Record<string, string>;
   // When provided, the panel guarantees every URI in this set appears
   // either on the canvas or on the singleton shelf. Used by callers
   // (e.g. SubGraphDetailView) whose entity scope can include entities
@@ -1386,11 +1400,26 @@ export function LayerGraphPanel({
 
   const renderTriples = uniqueTriples;
 
-  // Only SWM layer uses per-URI node tints — for the rest, classColors rules
-  // so code graphs stay legible (Package purple / File blue / etc).
+  // Per-URI node tints by layer:
+  //   • SWM uses `swmAttr.nodeColors` (agent attribution).
+  //   • Multi-layer sub-graph callers pass `nodeColorsOverride`
+  //     keyed by `entity.trustLevel` so the canvas matches the
+  //     entity's canonical layer (fold-in #6).
+  //   • WM / VM layer tabs use neither — classColors rules.
+  // When both are supplied (SWM sub-graph view), merge with the
+  // caller's override taking precedence — it's the more specific
+  // intent. The style engine still falls back to classColors /
+  // namespaceColors / `defaultNodeColor` for unspecified URIs.
+  const mergedNodeColors = useMemo(() => {
+    const swm = layer === 'swm' ? swmAttr.nodeColors : undefined;
+    if (!swm && !nodeColorsOverride) return undefined;
+    if (!swm) return nodeColorsOverride;
+    if (!nodeColorsOverride) return swm;
+    return { ...swm, ...nodeColorsOverride };
+  }, [layer, swmAttr.nodeColors, nodeColorsOverride]);
   const graphOptions = useMemo(
-    () => buildLayerGraphOptions(layer, layer === 'swm' ? swmAttr.nodeColors : undefined),
-    [layer, swmAttr.nodeColors],
+    () => buildLayerGraphOptions(layer, mergedNodeColors),
+    [layer, mergedNodeColors],
   );
   const { canvasTriples, singletonItems } = useMemo(
     () => splitGraphTriplesForShelf(renderTriples),
@@ -1809,6 +1838,12 @@ export function LayerWidgetStrip({ layer, entities, entityCount, tripleCount, co
 
 // ─── Enhanced Entity list (sorted by triple count, with type pill) ──────
 
+const TRUST_BADGE_CONFIG: Record<TrustLevel, { layerKey: 'wm' | 'swm' | 'vm'; icon: string; label: string }> = {
+  working:  { layerKey: 'wm',  icon: '◇', label: 'Working'  },
+  shared:   { layerKey: 'swm', icon: '◈', label: 'Shared'   },
+  verified: { layerKey: 'vm',  icon: '◉', label: 'Verified' },
+};
+
 export function EntityList({
   entities,
   layerKey,
@@ -1819,6 +1854,7 @@ export function EntityList({
   sortLabel,
   headerExtra,
   timestampPredicate,
+  perEntityTrustBadge = false,
 }: {
   entities: MemoryEntity[];
   layerKey: 'wm' | 'swm' | 'vm';
@@ -1837,6 +1873,11 @@ export function EntityList({
    *  as a relative timestamp on each entity card. Pass `binding.timelinePredicate`
    *  for sub-graphs that have one. */
   timestampPredicate?: string;
+  /** When true, render the trailing trust badge from each entity's own
+   *  `trustLevel` (cross-layer view — e.g. Subgraph Explorer detail).
+   *  When false (default), every row uses `layerKey`/`layerIcon` (the
+   *  WM/SWM/VM layer-tab convention). */
+  perEntityTrustBadge?: boolean;
 }) {
   const profile = useProjectProfileContext();
   const agents = useAgentsContext();
@@ -1915,9 +1956,18 @@ export function EntityList({
                 <span className="v10-entity-card-triples">{tripleCount} triples</span>
               </div>
             </div>
-            <span className={`v10-trust-badge ${layerKey}`}>
-              {layerIcon} {trustLabel}
-            </span>
+            {perEntityTrustBadge ? (() => {
+              const badge = TRUST_BADGE_CONFIG[e.trustLevel];
+              return (
+                <span className={`v10-trust-badge ${badge.layerKey}`} title={`${badge.label} Memory`}>
+                  {badge.icon} {badge.label}
+                </span>
+              );
+            })() : (
+              <span className={`v10-trust-badge ${layerKey}`}>
+                {layerIcon} {trustLabel}
+              </span>
+            )}
           </div>
         );
       })}
@@ -3775,6 +3825,25 @@ export function TrailEvent({
 }
 
 
+// ─── Subgraph Explorer header (page identity + permanent intro) ────
+// Shared between the All / Subgraphs-overview state and every chip
+// detail (named or Root). The three-sentence intro is non-dismissible —
+// the subgraph concept is unfamiliar and needs a tangible always-present
+// definition (UX §4.4.1). Wording is locked in §4.4.1 and must stay in
+// sync with the empty-state copy below in SubGraphOverviewGrid.
+export function SubGraphExplorerHeader() {
+  return (
+    <div className="v10-subgraph-explorer-header">
+      <div className="v10-subgraph-explorer-title">Subgraph Explorer</div>
+      <p className="v10-subgraph-explorer-intro">
+        Subgraphs are optional topical partitions inside this Context Graph.
+        An entity belongs to one memory layer and, optionally, one subgraph.
+        Entities in no subgraph live in the context graph root.
+      </p>
+    </div>
+  );
+}
+
 export function SubGraphOverviewGrid({
   contextGraphId,
   memory,
@@ -3926,17 +3995,31 @@ export function SubGraphOverviewGrid({
       <EmptyState
         compact
         icon="#"
-        title="Loading sub-graphs..."
+        title="Loading subgraphs..."
         className="v10-sgov-state"
       />
     );
   }
   if (cards.length === 0) {
+    // Teaching empty state (UX §4.4.1). Replaces the previous bare
+    // "No sub-graphs registered yet." — explains what a subgraph is,
+    // how one comes into being, and offers a one-click jump to the
+    // Root bucket so the user can still see their actual data.
     return (
       <EmptyState
         icon="#"
-        title="No sub-graphs registered yet."
-        description="This Context Graph currently only has the root memory view."
+        title="No subgraphs in this Context Graph yet."
+        description={
+          <>
+            A subgraph is a named topical slice of this Context Graph
+            (e.g. <code>recipes</code>, <code>decisions</code>). Agents
+            create one when they scope an assertion to a subgraph. All
+            current entities live in the Context Graph root.
+          </>
+        }
+        actions={[
+          { label: 'View root', onClick: () => onSelectSubGraph(ROOT_SLUG_SENTINEL), variant: 'primary' },
+        ]}
         className="v10-sgov-state"
       />
     );
@@ -3945,9 +4028,9 @@ export function SubGraphOverviewGrid({
   return (
     <div className="v10-sgov">
       <div className="v10-sgov-header">
-        <div className="v10-sgov-title">Sub-graph Overview</div>
+        <div className="v10-sgov-title">Subgraphs</div>
         <div className="v10-sgov-sub">
-          {cards.length} sub-graphs · {cards.reduce((a, b) => a + b.entityCount, 0)} entities · {cards.reduce((a, b) => a + b.tripleCount, 0)} triples
+          {cards.length} subgraphs · {cards.reduce((a, b) => a + b.entityCount, 0)} entities · {cards.reduce((a, b) => a + b.tripleCount, 0)} triples
         </div>
       </div>
       <div className="v10-sgov-grid">
@@ -4253,31 +4336,50 @@ export function SubGraphDetailView({
   const [queryLoading, setQueryLoading] = useState(false);
   const [queryError, setQueryError] = useState<string | null>(null);
 
-  // Base slice: every entity that has at least one WM triple in this sub-graph.
-  // SWM/VM triples don't carry sub-graph origin, so we additionally pull in
-  // any SWM/VM entity whose URI matches a scoped one (preserving the promoted
-  // slices of the same entity across layers).
+  // The synthesized Root bucket — "entities not in any named sub-graph" —
+  // and the named-sub-graph branch share this body. They differ only in
+  // their scope predicate (no-membership vs. has-this-slug) and chrome
+  // (icon/title/binding).
+  const isRoot = slug === ROOT_SLUG_SENTINEL;
+
+  // Base slice: every entity scoped to this subgraph.
+  //  • Named branch: at least one WM triple tagged with the slug, plus
+  //    cross-layer slices (an entity promoted to SWM/VM whose WM-era
+  //    membership still pins it here).
+  //  • Root branch: no sub-graph membership at all.
   const scopedEntities = useMemo(() => {
     const scoped: MemoryEntity[] = [];
     for (const e of rawMemory.entityList) {
-      if (e.subGraphs.has(slug)) scoped.push(e);
+      if (isRoot ? e.subGraphs.size === 0 : e.subGraphs.has(slug)) scoped.push(e);
     }
     return scoped;
-  }, [rawMemory.entityList, slug]);
+  }, [rawMemory.entityList, slug, isRoot]);
 
   const scopedUris = useMemo(
     () => new Set(scopedEntities.map(e => e.uri)),
     [scopedEntities],
   );
 
-  // Triples visible in the Graph tab: anything tagged with this sub-graph's
-  // origin, plus any triple whose endpoints are both scoped entities (this
-  // carries promoted SWM/VM edges whose origin was erased on promotion).
+  // Triples visible in the Graph tab.
+  //  • Named branch: anything tagged with this sub-graph's origin, plus
+  //    any triple admissible under the asymmetric subject+object
+  //    scope rule used by the layer-tab path — subject-scoped is the
+  //    primary admission gate (covers rdf:type / labels / literal-valued
+  //    properties on promoted entities whose `subGraph` was erased on
+  //    promotion); object-scoped resources are admitted as a recovery
+  //    edge so promoted SWM/VM endpoints don't silently disappear
+  //    (fold-in #7, supersedes the over-strict `both ends in scopedUris`
+  //    branch that dropped legitimate cross-layer edges).
+  //  • Root branch: triples whose subject is root-scoped, with the same
+  //    object-side recovery.
   const scopedTriples = useMemo(
-    () => rawMemory.graphTriples.filter(t =>
-      t.subGraph === slug || (scopedUris.has(t.subject) && scopedUris.has(t.object)),
-    ),
-    [rawMemory.graphTriples, scopedUris, slug],
+    () => rawMemory.graphTriples.filter(t => {
+      if (!isRoot && t.subGraph === slug) return true;
+      if (scopedUris.has(t.subject)) return true;
+      if (scopedUris.has(t.object)) return true;
+      return false;
+    }),
+    [rawMemory.graphTriples, scopedUris, slug, isRoot],
   );
 
   // Layer counts for the pyramid header. Each entity counted in exactly
@@ -4445,6 +4547,38 @@ export function SubGraphDetailView({
     [graphPanelEntities],
   );
 
+  // Fold-in #6 (PR #677 follow-up). Per-URI trust colouring on the
+  // multi-layer Graph pane. Pre-fix `LayerGraphPanel` received
+  // `layer={singleLayer ?? 'wm'}` and painted every node WM-gray
+  // when no single layer was active — even in a sub-graph spanning
+  // SWM and VM. Build a `nodeColors` map keyed by entity URI using
+  // the canonical `TRUST_COLORS` palette (same hex values as the
+  // layer chips and the Knowledge Pipeline bar). When a single
+  // layer is active, every panel entity belongs to that layer by
+  // construction, so the per-URI map collapses to the layer default
+  // and we can skip the override (saves a copy on the common path).
+  const trustNodeColors = useMemo(() => {
+    if (singleLayer) return undefined;
+    const out: Record<string, string> = {};
+    for (const e of graphPanelEntities) {
+      out[e.uri] = TRUST_COLORS[e.trustLevel];
+      const canonical = canonicalEntityUri(e.uri);
+      if (canonical !== e.uri) out[canonical] = TRUST_COLORS[e.trustLevel];
+    }
+    return out;
+  }, [singleLayer, graphPanelEntities]);
+
+  // Locked active-layer chip pill copy (UX §4.4.1). "All layers"
+  // when every layer is enabled; otherwise the single enabled
+  // layer's title — visible whenever scope is narrower than the
+  // canonical "all three" so the user can never lose sight of
+  // which layer the count strip is reporting on.
+  const activeLayerLabel = enabledLayers.size === 3
+    ? 'All layers'
+    : singleLayer
+      ? LAYER_CONFIG[singleLayer].title
+      : Array.from(enabledLayers).map(l => LAYER_CONFIG[l === 'verified' ? 'vm' : l === 'shared' ? 'swm' : 'wm'].trustLabel).join(' + ');
+
   const timelineItems = useMemo(() => {
     if (!timelinePredicate) return [];
     const out: Array<{ entity: MemoryEntity; date: Date }> = [];
@@ -4551,10 +4685,16 @@ export function SubGraphDetailView({
     }
   }, [contextGraphId]);
 
-  const color = binding?.color ?? '#64748b';
-  const icon = binding?.icon ?? '•';
-  const title = binding?.displayName ?? slug;
-  const desc = binding?.description;
+  // Root branch carries no profile binding (it's a client-side
+  // sentinel slug) — synthesize the chrome. The neutral colour token
+  // and `⊘` glyph match the SubGraphBar chip so the page identity
+  // stays coherent when the user transitions from chip to body.
+  const color = isRoot ? 'var(--text-tertiary)' : (binding?.color ?? '#64748b');
+  const icon = isRoot ? '⊘' : (binding?.icon ?? '•');
+  const title = isRoot ? 'Root' : (binding?.displayName ?? slug);
+  const desc = isRoot
+    ? 'Entities not in any subgraph (Context Graph root).'
+    : binding?.description;
 
   // Reset filters when the sub-graph changes — otherwise chips from
   // `tasks` would linger when the user jumps to `decisions` and silently
@@ -4596,6 +4736,55 @@ export function SubGraphDetailView({
           activeLayers={enabledLayers}
           onClickLayer={toggleLayer}
         />
+      </div>
+
+      {/* Cross-layer count strip + active-layer chip pill (UX §4.4.1).
+          The count strip is the page's whole point — every subgraph
+          (and the Root bucket) is *cross-layer* and the user must
+          never lose sight of that. The active-layer chip pill below
+          the strip surfaces the current scope (M2 / S5 strand —
+          "scope must never silently change semantics across a
+          navigation transition" — the chip makes the change
+          visible). */}
+      <div className="v10-subgraph-cross-layer">
+        <div className="v10-subgraph-cross-layer-lede">
+          {isRoot
+            ? 'Root entities, across the three memory layers:'
+            : 'This subgraph, across the three memory layers:'}
+        </div>
+        <div className="v10-subgraph-cross-layer-strip" data-testid="cross-layer-strip">
+          <span className="v10-subgraph-cross-layer-cell" data-layer="wm">
+            <span className="v10-subgraph-cross-layer-cell-icon" style={{ color: TRUST_COLORS.working }}>◇</span>
+            <span className="v10-subgraph-cross-layer-cell-label">Working</span>
+            <span className="v10-subgraph-cross-layer-cell-count">{layerCounts.wm}</span>
+          </span>
+          <span className="v10-subgraph-cross-layer-arrow" aria-hidden="true">→</span>
+          <span className="v10-subgraph-cross-layer-cell" data-layer="swm">
+            <span className="v10-subgraph-cross-layer-cell-icon" style={{ color: TRUST_COLORS.shared }}>◈</span>
+            <span className="v10-subgraph-cross-layer-cell-label">Shared</span>
+            <span className="v10-subgraph-cross-layer-cell-count">{layerCounts.swm}</span>
+          </span>
+          <span className="v10-subgraph-cross-layer-arrow" aria-hidden="true">→</span>
+          <span className="v10-subgraph-cross-layer-cell" data-layer="vm">
+            <span className="v10-subgraph-cross-layer-cell-icon" style={{ color: TRUST_COLORS.verified }}>◉</span>
+            <span className="v10-subgraph-cross-layer-cell-label">Verified</span>
+            <span className="v10-subgraph-cross-layer-cell-count">{layerCounts.vm}</span>
+          </span>
+        </div>
+        <button
+          type="button"
+          className={`v10-subgraph-active-layer-pill${enabledLayers.size === 3 ? ' all-layers' : ''}`}
+          onClick={() => setEnabledLayers(new Set<TrustLevel>(['working', 'shared', 'verified']))}
+          disabled={enabledLayers.size === 3}
+          data-testid="active-layer-pill"
+          aria-label={`Active layer scope: ${activeLayerLabel}${enabledLayers.size === 3 ? '' : ' — click to reset to all layers'}`}
+          title={enabledLayers.size === 3
+            ? 'Active layer scope: all three memory layers'
+            : 'Click to reset to all layers'}
+        >
+          <span className="v10-subgraph-active-layer-pill-label">Active layer:</span>
+          <span className="v10-subgraph-active-layer-pill-value">{activeLayerLabel}</span>
+        </button>
       </div>
 
       {queryCatalogs.length > 0 && (
@@ -4714,6 +4903,8 @@ export function SubGraphDetailView({
               externallySorted
               sortLabel={sortLabel}
               timestampPredicate={timelinePredicate}
+              perEntityTrustBadge
+
               headerExtra={
                 <label className="v10-entity-list-sort">
                   <span className="v10-entity-list-sort-label">Sort</span>
@@ -4750,6 +4941,7 @@ export function SubGraphDetailView({
               trustLegendActiveLayer={singleLayer}
               scopeEntities={graphPanelScopeEntities}
               layerEntities={graphPanelEntities}
+              nodeColorsOverride={trustNodeColors}
             />
           </div>
         )}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3837,8 +3837,9 @@ export function SubGraphExplorerHeader() {
       <div className="v10-subgraph-explorer-title">Subgraph Explorer</div>
       <p className="v10-subgraph-explorer-intro">
         Subgraphs are optional topical partitions inside this Context Graph.
-        An entity belongs to one memory layer and, optionally, one subgraph.
-        Entities in no subgraph live in the context graph root.
+        An entity belongs to one or more memory layers and, optionally,
+        to one or more subgraphs. Entities in no subgraph live in the
+        context graph root.
       </p>
     </div>
   );

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -281,6 +281,8 @@ vi.mock('../src/ui/views/project/components.js', () => ({
       'data-testid': 'select-subgraph-demo',
       onClick: () => onSelectSubGraph('demo'),
     }, 'Open demo subgraph'),
+  SubGraphExplorerHeader: () =>
+    React.createElement('div', { 'data-testid': 'subgraph-explorer-header' }, 'Subgraph Explorer'),
   ContextGraphQueryView: () => null,
   LayerDetailView: ({ layer, activeTab, onTabChange, onSelectEntity, onNodeClick }: {
     layer: string;

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -226,8 +226,18 @@ vi.mock('../src/ui/components/ActivityFeed.js', () => ({
 }));
 
 vi.mock('../src/ui/components/SubGraphBar.js', () => ({
-  SubGraphBar: ({ selected, onSelect }: { selected: string | null; onSelect: (slug: string | null) => void }) =>
-    React.createElement('div', { 'data-testid': 'subgraph-bar', 'data-selected': selected ?? '' },
+  SubGraphBar: ({ selected, onSelect, entities }: { selected: string | null; onSelect: (slug: string | null) => void; entities?: ReadonlyArray<unknown> }) =>
+    React.createElement('div', {
+      'data-testid': 'subgraph-bar',
+      'data-selected': selected ?? '',
+      // S3 Codex Bug C — surface the `entities` prop's
+      // resolution so tests can assert ProjectView gates it on
+      // a fully-loaded memory snapshot. `defined` while
+      // hydration is mid-flight would put the chip row in
+      // client-scoped counting (count contradiction with the
+      // grid's daemon-side fallback).
+      'data-entities': entities === undefined ? 'undefined' : 'defined',
+    },
       React.createElement('button', { 'data-testid': 'select-subgraph-demo', onClick: () => onSelect('demo') }, 'demo'),
       React.createElement('button', { 'data-testid': 'clear-subgraph', onClick: () => onSelect(null) }, 'all')),
 }));
@@ -577,6 +587,64 @@ describe('ProjectView entity detail navigation', () => {
 
     expect(query('subgraph-detail').dataset.slug).toBe('demo');
     expect(query('subgraph-detail').dataset.tab).toBe('graph');
+  });
+
+  // S3 Codex Bug C — SubGraphBar's `entities` prop drives client-
+  // scoped chip counts. While useMemoryEntities is still hydrating
+  // (`loading: true`) or has surfaced a partial-fetch failure
+  // (`partial: true` / `error: !== null`), entityList is incomplete
+  // and the chip counts disagree with SubGraphOverviewGrid's
+  // daemon-side `sg.entityCount` fallback — same screen, two
+  // numbers. ProjectView must withhold the entities prop until the
+  // memory snapshot is fully loaded.
+  //
+  // SubGraphBar mounts only on the WM/SWM/VM layers, the
+  // Subgraphs tab (graph-overview), and the in-subgraph detail
+  // route. Switch to SWM before asserting on `data-entities`.
+  it('does NOT pass rawMemory.entityList to SubGraphBar while memory is still loading', async () => {
+    memory.loading = true;
+    memory.entityList = [];
+    await act(async () => {
+      root.render(React.createElement(ProjectView, { contextGraphId: 'cg-test' }));
+    });
+    await flush();
+    await click('switch-swm');
+    await flush();
+
+    expect(query('subgraph-bar').dataset.entities).toBe('undefined');
+
+    memory.loading = false;
+    resetMemory();
+  });
+
+  it('does NOT pass rawMemory.entityList to SubGraphBar while memory is in a partial-failure state', async () => {
+    memory.loading = false;
+    memory.partial = true;
+    await act(async () => {
+      root.render(React.createElement(ProjectView, { contextGraphId: 'cg-test' }));
+    });
+    await flush();
+    await click('switch-swm');
+    await flush();
+
+    expect(query('subgraph-bar').dataset.entities).toBe('undefined');
+
+    memory.partial = false;
+    resetMemory();
+  });
+
+  it('passes rawMemory.entityList to SubGraphBar once memory is fully loaded', async () => {
+    memory.loading = false;
+    memory.partial = false;
+    memory.error = null;
+    await act(async () => {
+      root.render(React.createElement(ProjectView, { contextGraphId: 'cg-test' }));
+    });
+    await flush();
+    await click('switch-swm');
+    await flush();
+
+    expect(query('subgraph-bar').dataset.entities).toBe('defined');
   });
 
 });

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -129,7 +129,7 @@ const memory = {
   trustMap: new Map(),
   counts: { wm: 2, swm: 0, vm: 0, total: 2 },
   loading: false,
-  error: null,
+  error: null as string | null,
   partial: false,
   refresh: vi.fn(),
 };
@@ -645,6 +645,36 @@ describe('ProjectView entity detail navigation', () => {
     await flush();
 
     expect(query('subgraph-bar').dataset.entities).toBe('defined');
+  });
+
+  // S3 Codex sweep 3 Bug F — follow-on to Bug C. When all three
+  // layer queries fail, `useMemoryEntities` historically left
+  // `error: null` and `partial: false` (`partial` triggers only on
+  // PARTIAL failure), so the `memoryReady` gate misclassed total
+  // failure as "ready" and passed an empty entityList through.
+  // ProjectView now opts into `signalErrors: true`, so a total
+  // failure surfaces `error: 'Failed to load memory data'` and
+  // the gate fires correctly. The mock here uses a non-null
+  // `error` to simulate the post-fix behavior — the
+  // `signalErrors` opt-in is verified at the hook unit level;
+  // here we lock the downstream gate against any future "treat
+  // total failure as ready" regression.
+  it('does NOT pass rawMemory.entityList to SubGraphBar when all three layer queries failed (signalErrors)', async () => {
+    memory.loading = false;
+    memory.partial = false;
+    memory.error = 'Failed to load memory data';
+    memory.entityList = [];
+    await act(async () => {
+      root.render(React.createElement(ProjectView, { contextGraphId: 'cg-test' }));
+    });
+    await flush();
+    await click('switch-swm');
+    await flush();
+
+    expect(query('subgraph-bar').dataset.entities).toBe('undefined');
+
+    memory.error = null;
+    resetMemory();
   });
 
 });

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -356,4 +356,79 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     const allCount = Number(allChip?.querySelector('.v10-subgraph-chip-count')?.textContent ?? 'NaN');
     expect(allCount).toBe(11);
   });
+
+  // S3 — Root chip rendering. Surfaces only when the consumer
+  // supplies `entities` AND at least one entity is in the root
+  // bucket (no sub-graph membership). On Overview / Subgraphs
+  // pages the bar has no entities prop, so the chip stays hidden
+  // (we can't tell whether root entities exist without the list).
+  it('renders the Root chip when at least one entity has no subGraph membership', async () => {
+    const rootEntity = {
+      uri: 'urn:e:root', label: 'Root', types: [],
+      trustLevel: 'working' as const,
+      layers: new Set(['working']),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    };
+    const namedEntity = mkEntity('urn:e:named', 'shared', 'alpha');
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        entities: [rootEntity, namedEntity],
+      }));
+    });
+    await flushNet();
+    // Root chip is present and reports the single root-bucket
+    // entity. Symbol from §4.4.1 is `⊘` (U+2298).
+    const rootChip = container.querySelector('.v10-subgraph-chip-root') as HTMLButtonElement | null;
+    expect(rootChip).toBeTruthy();
+    expect(rootChip!.textContent).toContain('Root');
+    expect(rootChip!.querySelector('.v10-subgraph-chip-count')?.textContent).toBe('1');
+  });
+
+  it('hides the Root chip when every supplied entity has a sub-graph membership', async () => {
+    const a = mkEntity('urn:a', 'working', 'alpha');
+    const b = mkEntity('urn:b', 'working', 'beta');
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        entities: [a, b],
+      }));
+    });
+    await flushNet();
+    expect(container.querySelector('.v10-subgraph-chip-root')).toBeNull();
+  });
+
+  it('Root chip click calls onSelect with ROOT_SLUG_SENTINEL', async () => {
+    const onSelect = vi.fn();
+    const rootEntity = {
+      uri: 'urn:e:root', label: 'Root', types: [],
+      trustLevel: 'working' as const,
+      layers: new Set(['working']),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    };
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect,
+        entities: [rootEntity, mkEntity('urn:e:named', 'shared', 'alpha')],
+      }));
+    });
+    await flushNet();
+    const { ROOT_SLUG_SENTINEL } = await import('../src/ui/lib/subGraphs.js');
+    const rootChip = container.querySelector('.v10-subgraph-chip-root') as HTMLButtonElement;
+    await act(async () => { rootChip.click(); });
+    expect(onSelect).toHaveBeenCalledWith(ROOT_SLUG_SENTINEL);
+  });
 });

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -431,4 +431,58 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     await act(async () => { rootChip.click(); });
     expect(onSelect).toHaveBeenCalledWith(ROOT_SLUG_SENTINEL);
   });
+
+  // S3 Codex follow-up (Issue B on PR #772). The Root chip must stay
+  // visible whenever Root is the selected scope, even after a live
+  // refresh drops the root-bucket count to 0 (e.g. the last root
+  // entity got scoped to a sub-graph). Pre-fix the chip vanished and
+  // the detail body kept Root scope with no matching active chip in
+  // the row — a confusing UI state.
+  it('keeps the Root chip visible (and active) when ROOT_SLUG_SENTINEL is selected even after the root count drops to 0', async () => {
+    const { ROOT_SLUG_SENTINEL } = await import('../src/ui/lib/subGraphs.js');
+    const rootEntity = {
+      uri: 'urn:e:root', label: 'Root', types: [],
+      trustLevel: 'working' as const,
+      layers: new Set(['working']),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    };
+    // Initial render: one root entity, Root selected.
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: ROOT_SLUG_SENTINEL,
+        onSelect: vi.fn(),
+        entities: [rootEntity, mkEntity('urn:e:named', 'shared', 'alpha')],
+      }));
+    });
+    await flushNet();
+    {
+      const chip = container.querySelector('.v10-subgraph-chip-root') as HTMLElement | null;
+      expect(chip).toBeTruthy();
+      expect(chip!.getAttribute('data-active')).toBe('true');
+      expect(chip!.getAttribute('data-count')).toBe('1');
+    }
+    // Live-refresh: the previously-root entity has been scoped to
+    // `alpha`. The root-bucket count drops to 0, but the user is
+    // still in Root scope (selected stays ROOT_SLUG_SENTINEL).
+    const movedEntity = { ...rootEntity, subGraphs: new Set(['alpha']) };
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: ROOT_SLUG_SENTINEL,
+        onSelect: vi.fn(),
+        entities: [movedEntity, mkEntity('urn:e:named', 'shared', 'alpha')],
+      }));
+    });
+    await flushNet();
+    const chip = container.querySelector('.v10-subgraph-chip-root') as HTMLElement | null;
+    expect(chip).toBeTruthy();
+    // Still active (selected hasn't changed) and now reads 0.
+    expect(chip!.getAttribute('data-active')).toBe('true');
+    expect(chip!.getAttribute('data-count')).toBe('0');
+  });
 });

--- a/packages/node-ui/test/sub-graphs-helper.test.ts
+++ b/packages/node-ui/test/sub-graphs-helper.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { isUserFacingSubGraph, RESERVED_SUB_GRAPH_SLUGS } from '../src/ui/lib/subGraphs.js';
+import { isUserFacingSubGraph, RESERVED_SUB_GRAPH_SLUGS, ROOT_SLUG_SENTINEL } from '../src/ui/lib/subGraphs.js';
+import { subGraphOf } from '../src/ui/hooks/useMemoryEntities.js';
 
 describe('isUserFacingSubGraph', () => {
   it('rejects the reserved `meta` slug', () => {
@@ -15,5 +16,56 @@ describe('isUserFacingSubGraph', () => {
   it('exposes RESERVED_SUB_GRAPH_SLUGS as the single source of truth', () => {
     expect(RESERVED_SUB_GRAPH_SLUGS.has('meta')).toBe(true);
     expect(RESERVED_SUB_GRAPH_SLUGS.size).toBe(1);
+  });
+});
+
+describe('ROOT_SLUG_SENTINEL', () => {
+  // S3 fold-in. The Root chip carries this sentinel as its
+  // "selected" identifier — the daemon's slug guard rejects
+  // underscore-prefixed segments, so this can never collide with a
+  // real sub-graph slug. The double-underscore prefix is
+  // load-bearing.
+  it('is `__root__` (double-underscore prefix; collision-free with daemon slugs)', () => {
+    expect(ROOT_SLUG_SENTINEL).toBe('__root__');
+    // Daemon-side slugs are alphanumeric/-/_ but never start with `_`
+    // (server-side filter). Anchor the contract here so a future
+    // sentinel rename can't silently produce a colliding slug.
+    expect(ROOT_SLUG_SENTINEL.startsWith('__')).toBe(true);
+  });
+
+  it('is excluded from the reserved-set membership rule', () => {
+    // RESERVED_SUB_GRAPH_SLUGS governs *daemon-emitted* slug
+    // suppression. ROOT_SLUG_SENTINEL is a client-only synthesized
+    // slug — by construction the daemon can never emit it, so it
+    // doesn't belong in the reserved set. `isUserFacingSubGraph`
+    // would technically return true for it (irrelevant — daemon
+    // never emits it), but the reserved set stays at {'meta'}.
+    expect(RESERVED_SUB_GRAPH_SLUGS.has(ROOT_SLUG_SENTINEL)).toBe(false);
+  });
+});
+
+describe('subGraphOf — reserved-bookkeeping slug guards (fold-in #5)', () => {
+  // Phantom-slug repro. Pre-fix this URI emitted `'assertion'` as a
+  // user-facing slug, which `SubGraphBadge` then rendered as a fake
+  // "Assertion" pill on every WM entity detail's References /
+  // Referenced By section. The fix admits `'assertion'` to the guard
+  // alongside underscore-prefixed bookkeeping segments.
+  it('returns undefined for WM assertion graphs (`<cg>/assertion/<addr>/<name>`)', () => {
+    expect(subGraphOf('did:dkg:context-graph:cg-1/assertion/0xabc/notes', 'cg-1')).toBeUndefined();
+  });
+
+  it('keeps user-facing sub-graph slugs intact', () => {
+    expect(subGraphOf('did:dkg:context-graph:cg-1/research/assertion/0xabc/notes', 'cg-1')).toBe('research');
+    expect(subGraphOf('did:dkg:context-graph:cg-1/recipes', 'cg-1')).toBe('recipes');
+  });
+
+  it('returns undefined for underscore-prefixed bookkeeping graphs', () => {
+    expect(subGraphOf('did:dkg:context-graph:cg-1/_shared_memory', 'cg-1')).toBeUndefined();
+    expect(subGraphOf('did:dkg:context-graph:cg-1/_meta', 'cg-1')).toBeUndefined();
+  });
+
+  it('returns undefined for graphs outside the project prefix', () => {
+    expect(subGraphOf('did:dkg:context-graph:other/research', 'cg-1')).toBeUndefined();
+    expect(subGraphOf('urn:not-a-cg', 'cg-1')).toBeUndefined();
   });
 });

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -5,22 +5,32 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ProjectProfileContext, type ProjectProfile } from '../src/ui/hooks/useProjectProfile.js';
 import { SubGraphDetailView } from '../src/ui/views/project/components.js';
+import { ROOT_SLUG_SENTINEL } from '../src/ui/lib/subGraphs.js';
+import { TRUST_COLORS } from '../src/ui/views/project/helpers.js';
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock('@origintrail-official/dkg-graph-viz/react', async () => {
   const React = await import('react');
   return {
-    RdfGraph(props: { data: ReadonlyArray<{ subject: string; predicate: string; object: string }> | undefined }) {
+    RdfGraph(props: {
+      data: ReadonlyArray<{ subject: string; predicate: string; object: string }> | undefined;
+      options?: { style?: { nodeColors?: Record<string, string> } };
+    }) {
       // Surface the triples this render received as a DOM attribute so
       // tests can assert on it; the production component never reads
       // these attributes.
       const triples = (props.data ?? []).map((t) => ({ s: t.subject, p: t.predicate, o: t.object }));
       const objects = triples.map((t) => t.o);
+      // Surface the `nodeColors` style override so tests can assert
+      // S3's per-URI trust colouring (fold-in #6) without reaching
+      // into the canvas internals.
+      const nodeColors = props.options?.style?.nodeColors ?? {};
       return React.createElement('div', {
         'data-testid': 'rdf-graph',
         'data-triple-objects': JSON.stringify(objects),
         'data-triples': JSON.stringify(triples),
+        'data-node-colors': JSON.stringify(nodeColors),
       });
     },
   };
@@ -69,7 +79,10 @@ const profile: ProjectProfile = {
     icon: '#',
     rank: 0,
   }),
-  forType: () => undefined,
+  // Tests historically returned undefined; entityMeta reads
+  // `b.label` so a safe no-op fixture must return at least `{}`.
+  // Bucket tests that mount the Entities tab depend on this.
+  forType: () => ({}) as any,
   view: () => undefined,
   chipsFor: () => [],
   savedQueryCatalogsFor: () => [],
@@ -820,6 +833,403 @@ describe('SubGraphDetailView tabs', () => {
         '.v10-graph-singleton-item[title="urn:e:ghost"]',
       );
       expect(ghostChip).toBeTruthy();
+    });
+  });
+
+  // S3 — Root bucket (synthesized `__root__` slug). Scope is "no
+  // sub-graph membership" — entity.subGraphs.size === 0. The detail
+  // body shape matches a named subgraph (header / count strip /
+  // tabs); only the chrome (icon ⊘ / title "Root") and scope
+  // predicate differ.
+  it('renders the Root bucket (slug=ROOT_SLUG_SENTINEL) with the no-membership scope', async () => {
+    const rootEntity = {
+      uri: 'urn:e:rooted',
+      label: 'Rooted',
+      types: ['http://schema.org/Thing'],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    };
+    const namedEntity = {
+      uri: 'urn:e:in-named',
+      label: 'In named subgraph',
+      types: ['http://schema.org/Thing'],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['recipes']),
+      properties: new Map(),
+      connections: [],
+    };
+    const memory = {
+      entities: new Map([[rootEntity.uri, rootEntity], [namedEntity.uri, namedEntity]]),
+      entityList: [rootEntity, namedEntity],
+      allTriples: [],
+      graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false,
+      error: null,
+      partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: ROOT_SLUG_SENTINEL,
+            rawMemory: memory,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+    await flush();
+
+    // Header carries the Root identity (locked literals from §4.4.1).
+    expect(container.querySelector('.v10-subgraph-detail-title')?.textContent).toBe('Root');
+    // Cross-layer count strip exists and reports the root-scoped
+    // entity at WM only — `namedEntity` (recipes-scoped) must not
+    // count toward Root.
+    const strip = container.querySelector('[data-testid="cross-layer-strip"]');
+    expect(strip).toBeTruthy();
+    const cells = strip!.querySelectorAll('.v10-subgraph-cross-layer-cell-count');
+    expect(cells[0]?.textContent).toBe('1'); // wm — rootEntity
+    expect(cells[1]?.textContent).toBe('0'); // swm — namedEntity excluded
+    expect(cells[2]?.textContent).toBe('0'); // vm
+
+    // The Entities tab must show the root-scoped entity only.
+    const entityCards = container.querySelectorAll('.v10-entity-card');
+    expect(entityCards.length).toBe(1);
+    expect(entityCards[0]?.textContent).toContain('Rooted');
+  });
+
+  // S3 — cross-layer count strip + active-layer chip pill (UX §4.4.1).
+  // The pill must be visible whenever scope is narrower than "all
+  // three", and clicking it must reset to All layers.
+  it('renders the active-layer pill and resets to "All layers" on click', async () => {
+    const wmOnly = {
+      uri: 'urn:e:wm', label: 'WM only', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const swmOnly = {
+      uri: 'urn:e:swm', label: 'SWM only', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmOnly.uri, wmOnly], [swmOnly.uri, swmOnly]]),
+      entityList: [wmOnly, swmOnly],
+      allTriples: [],
+      graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'graph',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+    await flush();
+
+    const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLButtonElement | null;
+    expect(pill).toBeTruthy();
+    // Default: all three layers — pill reads "All layers" and is disabled.
+    expect(pill!.textContent).toContain('All layers');
+    expect(pill!.disabled).toBe(true);
+
+    // Narrow to WM only via the mini-pyramid chips.
+    const chips = Array.from(container.querySelectorAll('button.v10-minipyr-chip')) as HTMLButtonElement[];
+    const swmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Shared Memory'));
+    const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verified Memory'));
+    await act(async () => { swmChip!.click(); });
+    await act(async () => { vmChip!.click(); });
+    await flush();
+
+    // Pill now surfaces the narrowed scope and becomes clickable.
+    expect(pill!.textContent).toContain('Working Memory');
+    expect(pill!.disabled).toBe(false);
+
+    // Clicking resets to all layers.
+    await act(async () => { pill!.click(); });
+    await flush();
+    expect(pill!.textContent).toContain('All layers');
+    expect(pill!.disabled).toBe(true);
+  });
+
+  // S3 fold-in #6 (PR #677 follow-up). Multi-layer sub-graph Graph
+  // tab paints per-entity by `trustLevel` via `nodeColorsOverride`,
+  // not the WM-default fallback. Pre-fix every node painted gray.
+  it('passes per-URI trust nodeColors to the Graph pane on a multi-layer subgraph', async () => {
+    const wmEntity = {
+      uri: 'urn:e:wm-node', label: 'WM node', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const swmEntity = {
+      uri: 'urn:e:swm-node', label: 'SWM node', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const vmEntity = {
+      uri: 'urn:e:vm-node', label: 'VM node', types: [],
+      trustLevel: 'verified',
+      layers: new Set(['verified']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const edgeAB = {
+      subject: 'urn:e:wm-node',
+      predicate: 'urn:rel:r',
+      object: 'urn:e:swm-node',
+      subGraph: 'demo',
+      layer: 'working' as const,
+    };
+    const fixture = {
+      entities: new Map([
+        [wmEntity.uri, wmEntity],
+        [swmEntity.uri, swmEntity],
+        [vmEntity.uri, vmEntity],
+      ]),
+      entityList: [wmEntity, swmEntity, vmEntity],
+      allTriples: [edgeAB],
+      graphTriples: [
+        { subject: edgeAB.subject, predicate: edgeAB.predicate, object: edgeAB.object, subGraph: 'demo' },
+      ],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 1, total: 3 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'graph',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+
+    await waitForGraph(() => {
+      const el = container.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+      expect(el).toBeTruthy();
+      const colors = JSON.parse(el!.getAttribute('data-node-colors') ?? '{}');
+      // Each entity URI keyed to its TRUST_COLORS palette value —
+      // canonical hex, NOT a `var(--text-*)` lookup (the canvas
+      // pipeline reads raw color strings).
+      expect(colors['urn:e:wm-node']).toBe(TRUST_COLORS.working);
+      expect(colors['urn:e:swm-node']).toBe(TRUST_COLORS.shared);
+      expect(colors['urn:e:vm-node']).toBe(TRUST_COLORS.verified);
+    });
+  });
+
+  // S3 — per-row trust badge keyed to e.trustLevel (not the fixed
+  // `layerKey` SubGraphDetailView passes to EntityList). Pre-fix
+  // every row read "Working" even on SWM/VM entities.
+  it('renders the per-row trust badge from entity.trustLevel on the Entities tab', async () => {
+    const wmRow = {
+      uri: 'urn:e:wm-row', label: 'WM row', types: ['http://schema.org/Thing'],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const swmRow = {
+      uri: 'urn:e:swm-row', label: 'SWM row', types: ['http://schema.org/Thing'],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const vmRow = {
+      uri: 'urn:e:vm-row', label: 'VM row', types: ['http://schema.org/Thing'],
+      trustLevel: 'verified',
+      layers: new Set(['verified']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const fixture = {
+      entities: new Map([
+        [wmRow.uri, wmRow], [swmRow.uri, swmRow], [vmRow.uri, vmRow],
+      ]),
+      entityList: [wmRow, swmRow, vmRow],
+      allTriples: [],
+      graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 1, total: 3 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+    await flush();
+
+    // Each row carries its OWN trust-level badge — class is keyed
+    // by layer (`.wm` / `.swm` / `.vm`), text is the trust label.
+    const cards = Array.from(container.querySelectorAll('.v10-entity-card')) as HTMLElement[];
+    const byLabel = new Map<string, HTMLElement>();
+    for (const card of cards) {
+      const label = card.querySelector('.v10-entity-card-title')?.textContent ?? '';
+      byLabel.set(label, card);
+    }
+    expect(byLabel.get('WM row')?.querySelector('.v10-trust-badge.wm')?.textContent).toContain('Working');
+    expect(byLabel.get('SWM row')?.querySelector('.v10-trust-badge.swm')?.textContent).toContain('Shared');
+    expect(byLabel.get('VM row')?.querySelector('.v10-trust-badge.vm')?.textContent).toContain('Verified');
+  });
+
+  // S3 fold-in #7 — multi-layer `scopedTriples` predicate admits
+  // edges whose `subGraph` tag was erased on promotion. Pre-fix
+  // (`subGraph === slug || (scopedUris.has(s) && scopedUris.has(o))`)
+  // the both-ends test ALREADY caught this specific case, but the
+  // subject-scoped rule extends admission to edges where the object
+  // is in scope but the subject's `subGraph` tag is missing. The
+  // post-fix predicate keeps the both-ends and adds the asymmetric
+  // recovery so promoted SWM/VM endpoints don't silently drop out
+  // of the multi-layer Graph view.
+  it('admits cross-layer edges whose subGraph tag was erased on promotion (fold-in #7)', async () => {
+    // Two entities both scoped to `demo`. One is WM-only, the other
+    // was promoted to SWM and its triples lost their `subGraph`
+    // origin tag on promotion. The edge has `subGraph: undefined`.
+    const wmEnd = {
+      uri: 'urn:e:wm-end', label: 'WM endpoint',
+      types: ['http://schema.org/Thing'],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const swmEnd = {
+      uri: 'urn:e:swm-end', label: 'SWM endpoint',
+      types: ['http://schema.org/Thing'],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const promotedEdge = {
+      subject: 'urn:e:swm-end',
+      predicate: 'http://schema.org/relatesTo',
+      object: 'urn:e:wm-end',
+      subGraph: undefined as string | undefined,
+      layer: 'shared' as const,
+    };
+    const fixture = {
+      entities: new Map([
+        [wmEnd.uri, wmEnd], [swmEnd.uri, swmEnd],
+      ]),
+      entityList: [wmEnd, swmEnd],
+      allTriples: [promotedEdge],
+      graphTriples: [
+        { subject: promotedEdge.subject, predicate: promotedEdge.predicate, object: promotedEdge.object },
+      ],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'graph',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+
+    await waitForGraph(() => {
+      const el = container.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+      expect(el).toBeTruthy();
+      const triples = JSON.parse(el!.getAttribute('data-triples') ?? '[]');
+      const hasEdge = triples.some(
+        (t: { s: string; p: string; o: string }) =>
+          t.s === 'urn:e:swm-end'
+          && t.p === 'http://schema.org/relatesTo'
+          && t.o === 'urn:e:wm-end',
+      );
+      expect(hasEdge).toBe(true);
     });
   });
 });

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -1232,4 +1232,195 @@ describe('SubGraphDetailView tabs', () => {
       expect(hasEdge).toBe(true);
     });
   });
+
+  // S3 Codex follow-up (Bug A on PR #772). The fold-in #7 recovery
+  // branch must NOT admit triples that carry an explicit non-matching
+  // `subGraph` tag — those belong to the tagged slug's view, even
+  // when an endpoint happens to be in the current scope (an entity
+  // in multiple sub-graphs is shared territory, not a broadcast).
+  // Exact-tag-routing wins; the recovery branch is for `subGraph`
+  // erased by promotion only.
+  it('does NOT admit a triple with an explicit non-matching subGraph tag even when an endpoint is in scope', async () => {
+    // `cross` belongs to BOTH `demo` (current view) and `other`. A
+    // triple tagged `subGraph: 'other'` whose subject is `cross`
+    // must NOT leak into the `demo` view.
+    const cross = {
+      uri: 'urn:e:cross', label: 'Cross-membership entity',
+      types: ['http://schema.org/Thing'],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo', 'other']),
+      properties: new Map(),
+      connections: [],
+    };
+    const demoOnly = {
+      uri: 'urn:e:demo-only', label: 'Demo-only entity',
+      types: ['http://schema.org/Thing'],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(),
+      connections: [],
+    };
+    const demoEdge = {
+      subject: 'urn:e:demo-only',
+      predicate: 'http://schema.org/knows',
+      object: 'urn:e:cross',
+      subGraph: 'demo',
+      layer: 'working' as const,
+    };
+    const otherEdge = {
+      subject: 'urn:e:cross',
+      predicate: 'http://schema.org/knows',
+      object: 'urn:e:demo-only',
+      subGraph: 'other',
+      layer: 'working' as const,
+    };
+    const fixture = {
+      entities: new Map([[cross.uri, cross], [demoOnly.uri, demoOnly]]),
+      entityList: [cross, demoOnly],
+      allTriples: [demoEdge, otherEdge],
+      graphTriples: [
+        { subject: demoEdge.subject, predicate: demoEdge.predicate, object: demoEdge.object, subGraph: 'demo' },
+        { subject: otherEdge.subject, predicate: otherEdge.predicate, object: otherEdge.object, subGraph: 'other' },
+      ],
+      trustMap: new Map(),
+      counts: { wm: 2, swm: 0, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'graph',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+
+    await waitForGraph(() => {
+      const el = container.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+      expect(el).toBeTruthy();
+      const triples = JSON.parse(el!.getAttribute('data-triples') ?? '[]');
+      // The `demo`-tagged edge is admitted via exact-tag routing.
+      const hasDemoEdge = triples.some(
+        (t: { s: string; p: string; o: string }) =>
+          t.s === 'urn:e:demo-only' && t.p === 'http://schema.org/knows' && t.o === 'urn:e:cross',
+      );
+      // The `other`-tagged edge must NOT leak in — even though its
+      // subject (`cross`) is in the `demo` scope. Pre-fix the
+      // subject-scoped fallback admitted it.
+      const hasOtherEdge = triples.some(
+        (t: { s: string; p: string; o: string }) =>
+          t.s === 'urn:e:cross' && t.p === 'http://schema.org/knows' && t.o === 'urn:e:demo-only',
+      );
+      expect(hasDemoEdge).toBe(true);
+      expect(hasOtherEdge).toBe(false);
+    });
+  });
+
+  // S3 Codex follow-up (Bug A on PR #772 — Root branch). Root scope
+  // is "root-bucket entities + root-bucket edges". A `recipes`-tagged
+  // edge whose object happens to be a root entity must NOT show up
+  // in the Root view — that edge belongs to the `recipes` view.
+  it('Root scope rejects named-subgraph edges that merely point at a root entity', async () => {
+    const rootEntity = {
+      uri: 'urn:e:root', label: 'Root entity',
+      types: ['http://schema.org/Thing'],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    };
+    const recipeEntity = {
+      uri: 'urn:e:in-recipes', label: 'In recipes',
+      types: ['http://schema.org/Thing'],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['recipes']),
+      properties: new Map(),
+      connections: [],
+    };
+    const recipesEdge = {
+      subject: 'urn:e:in-recipes',
+      predicate: 'http://schema.org/about',
+      object: 'urn:e:root',
+      subGraph: 'recipes',
+      layer: 'working' as const,
+    };
+    const fixture = {
+      entities: new Map([[rootEntity.uri, rootEntity], [recipeEntity.uri, recipeEntity]]),
+      entityList: [rootEntity, recipeEntity],
+      allTriples: [recipesEdge],
+      graphTriples: [
+        { subject: recipesEdge.subject, predicate: recipesEdge.predicate, object: recipesEdge.object, subGraph: 'recipes' },
+      ],
+      trustMap: new Map(),
+      counts: { wm: 2, swm: 0, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: ROOT_SLUG_SENTINEL,
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'graph',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+
+    // The rejected edge means scopedTriples for Root is empty, so
+    // the canvas falls through to the placeholder. We assert two
+    // things: (1) RdfGraph never received the recipes-tagged
+    // triple (it didn't render at all OR rendered without it),
+    // and (2) the root entity surfaces on the singleton shelf
+    // instead — the entity is in scope even though no admissible
+    // triple references it.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+    const el = container.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+    if (el) {
+      const triples = JSON.parse(el.getAttribute('data-triples') ?? '[]');
+      const hasRecipesEdge = triples.some(
+        (t: { s: string; p: string; o: string }) =>
+          t.s === 'urn:e:in-recipes' && t.o === 'urn:e:root',
+      );
+      expect(hasRecipesEdge).toBe(false);
+    } else {
+      // No canvas at all — even better, since canvasTriples was
+      // empty (the recipes edge was rightly rejected and nothing
+      // else admitted).
+      const placeholder = container.querySelector('.v10-graph-placeholder-centered');
+      expect(placeholder).toBeTruthy();
+    }
+    // The root entity surfaces on the singleton shelf via the
+    // scopeEntities fallback — it's in scope but has no
+    // admissible triple to anchor it on canvas.
+    const rootShelfChip = container.querySelector('.v10-graph-singleton-item[title="urn:e:root"]');
+    expect(rootShelfChip).toBeTruthy();
+  });
 });

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -72,13 +72,28 @@ const profile: ProjectProfile = {
   queryCatalogs: [],
   savedQueries: [],
   loading: false,
-  forSubGraph: (slug: string) => ({
-    slug,
-    displayName: slug,
-    color: '#38bdf8',
-    icon: '#',
-    rank: 0,
-  }),
+  forSubGraph: (slug: string) => {
+    // Mirror the real resolver's ROOT_SLUG_SENTINEL short-circuit so
+    // tests that exercise the Root bucket see the same synthesized
+    // binding the production code path produces (chip + detail
+    // header + breadcrumb all read from this).
+    if (slug === ROOT_SLUG_SENTINEL) {
+      return {
+        slug: ROOT_SLUG_SENTINEL,
+        displayName: 'Root',
+        description: 'Entities not in any subgraph (Context Graph root)',
+        icon: '⊘',
+        rank: 99,
+      };
+    }
+    return {
+      slug,
+      displayName: slug,
+      color: '#38bdf8',
+      icon: '#',
+      rank: 0,
+    };
+  },
   // Tests historically returned undefined; entityMeta reads
   // `b.label` so a safe no-op fixture must return at least `{}`.
   // Bucket tests that mount the Entities tab depend on this.

--- a/packages/node-ui/test/subgraph-explorer-header.test.ts
+++ b/packages/node-ui/test/subgraph-explorer-header.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SubGraphExplorerHeader } from '../src/ui/views/project/components.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('SubGraphExplorerHeader — locked intro copy (UX §4.4.1 Issue D)', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  // ux-lead's Issue D compromise (both axes). The pre-fix copy said
+  // "one memory layer ... optionally, one subgraph" — Codex flagged
+  // it as a data-model contradiction (`MemoryEntity.layers` and
+  // `.subGraphs` are both Sets; the canonical "more than one" cases
+  // are an entity in the WM→SWM promote window and an entity tagged
+  // into multiple sub-graphs). The locked replacement covers both
+  // axes so a future Codex sweep doesn't reopen either side.
+  it('renders the locked "one or more" phrasing on both axes', () => {
+    act(() => {
+      root.render(React.createElement(SubGraphExplorerHeader));
+    });
+    const intro = container.querySelector('.v10-subgraph-explorer-intro');
+    expect(intro).toBeTruthy();
+    const text = intro!.textContent ?? '';
+    expect(text).toContain('one or more memory layers');
+    expect(text).toContain('one or more subgraphs');
+    // The third sentence stays as the locked Root introduction.
+    expect(text).toContain('Entities in no subgraph live in the context graph root.');
+  });
+
+  it('renders the locked page title', () => {
+    act(() => {
+      root.render(React.createElement(SubGraphExplorerHeader));
+    });
+    expect(container.querySelector('.v10-subgraph-explorer-title')?.textContent).toBe('Subgraph Explorer');
+  });
+});

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProjectProfileContext, type ProjectProfile } from '../src/ui/hooks/useProjectProfile.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// fetchSubGraphs is the daemon-backed source that Issue G's fix
+// gates on. Default mock resolves with empty cards (the
+// success-empty branch); individual tests override per-call.
+const fetchSubGraphsMock = vi.fn();
+
+vi.mock('../src/ui/api.js', () => ({
+  fetchSubGraphs: (...args: any[]) => fetchSubGraphsMock(...args),
+  executeQuery: vi.fn(async () => ({ result: { bindings: [] } })),
+}));
+
+// The grid renders mini RdfGraphs per card; the lazy import would
+// otherwise stall the test. Stub it out — only the empty/error
+// branches matter for this file.
+vi.mock('@origintrail-official/dkg-graph-viz/react', async () => {
+  const React = await import('react');
+  return {
+    RdfGraph() {
+      return React.createElement('div', { 'data-testid': 'rdf-graph' });
+    },
+  };
+});
+
+import { SubGraphOverviewGrid } from '../src/ui/views/project/components.js';
+
+const profile: ProjectProfile = {
+  contextGraphId: 'cg-test',
+  displayName: 'Test',
+  primaryColor: '#64748b',
+  accentColor: '#38bdf8',
+  subGraphs: [],
+  typeBindings: [],
+  views: [],
+  filterChips: [],
+  queryCatalogs: [],
+  savedQueries: [],
+  loading: false,
+  forSubGraph: (slug: string) => ({ slug, displayName: slug, color: '#38bdf8', icon: '#', rank: 0 }),
+  forType: () => ({}) as any,
+  view: () => undefined,
+  chipsFor: () => [],
+  savedQueryCatalogsFor: () => [],
+  savedQueriesFor: () => [],
+};
+
+const memory = {
+  entities: new Map(),
+  entityList: [],
+  allTriples: [],
+  graphTriples: [],
+  trustMap: new Map(),
+  counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+  loading: false,
+  error: null,
+  partial: false,
+  layerStatus: { wm: 'ok' as const, swm: 'ok' as const, vm: 'ok' as const },
+  refresh: vi.fn(),
+} as any;
+
+async function flush(): Promise<void> {
+  // Two microtask drains — one for the promise the effect kicks
+  // off, one for the setState in the resolver/finally.
+  await act(async () => { await Promise.resolve(); });
+  await act(async () => { await Promise.resolve(); });
+}
+
+describe('SubGraphOverviewGrid — fetch failure state (S3 Codex sweep 3 Issue G)', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    fetchSubGraphsMock.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render() {
+    return act(async () => {
+      root.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphOverviewGrid, {
+            contextGraphId: 'cg-test',
+            memory,
+            onNodeClick: vi.fn(),
+            onSelectSubGraph: vi.fn(),
+          })),
+      );
+    });
+  }
+
+  // Issue G load-bearing case: a transient `fetchSubGraphs` error
+  // used to render the success-empty teaching state ("No subgraphs
+  // in this Context Graph yet" + View root CTA) because the catch
+  // was silent. That's authoritative-looking but wrong — the user
+  // doesn't know yet whether the CG has sub-graphs or not. The new
+  // error branch shows a distinct "Couldn't load subgraphs" state.
+  it('renders the error state — NOT the teaching empty — when fetchSubGraphs rejects', async () => {
+    fetchSubGraphsMock.mockRejectedValueOnce(new Error('network timeout'));
+    await render();
+    await flush();
+
+    const empty = container.querySelector('.v10-empty-state');
+    expect(empty).toBeTruthy();
+    const title = empty!.querySelector('.v10-empty-state-title')?.textContent ?? '';
+    expect(title).toBe("Couldn't load subgraphs.");
+    // Must NOT be the success-empty teaching copy.
+    expect(title).not.toContain('No subgraphs in this Context Graph yet');
+    // Must NOT show the View root CTA (the user has no way of
+    // knowing whether root is the right place to look until the
+    // sub-graph list actually loads).
+    const action = empty!.querySelector('.v10-empty-state-action');
+    expect(action).toBeNull();
+    // Error tone for the data-tone attribute / styling consumers.
+    expect(empty!.getAttribute('data-tone')).toBe('danger');
+  });
+
+  // Regression guard for the other direction — the new error branch
+  // must NOT swallow the success-empty teaching state when the
+  // daemon legitimately returns an empty list.
+  it('still renders the teaching empty state when fetchSubGraphs resolves with []', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({ subGraphs: [] });
+    await render();
+    await flush();
+
+    const empty = container.querySelector('.v10-empty-state');
+    expect(empty).toBeTruthy();
+    const title = empty!.querySelector('.v10-empty-state-title')?.textContent ?? '';
+    expect(title).toBe('No subgraphs in this Context Graph yet.');
+    // The teaching state offers the View root action.
+    const action = empty!.querySelector('.v10-empty-state-action');
+    expect(action).toBeTruthy();
+    expect(action!.textContent).toContain('View root');
+    // Neutral tone, not danger.
+    expect(empty!.getAttribute('data-tone')).toBe('neutral');
+  });
+});

--- a/packages/node-ui/test/use-project-profile.test.ts
+++ b/packages/node-ui/test/use-project-profile.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it } from 'vitest';
+// @vitest-environment happy-dom
 
-import { buildQueryCatalogState } from '../src/ui/hooks/useProjectProfile.js';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildQueryCatalogState, useProjectProfile, type ProjectProfile } from '../src/ui/hooks/useProjectProfile.js';
+import { ROOT_SLUG_SENTINEL } from '../src/ui/lib/subGraphs.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../src/ui/api.js', () => ({
+  // The hook fires four SPARQL queries on mount; every one resolves to
+  // empty so the profile falls back to defaults (which is all we need
+  // for the resolver-level Root assertion).
+  executeQuery: vi.fn(async () => ({ result: { bindings: [] } })),
+}));
 
 describe('buildQueryCatalogState', () => {
   it('groups saved queries into explicit catalogs and sorts them by rank', () => {
@@ -87,5 +101,66 @@ describe('buildQueryCatalogState', () => {
       catalogSlug: 'default:github',
       catalogName: 'Queries',
     });
+  });
+});
+
+describe('useProjectProfile — forSubGraph Root binding (S3, Codex Bug E)', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let captured: ProjectProfile | null = null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    captured = null;
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function Probe({ contextGraphId }: { contextGraphId: string }) {
+    const profile = useProjectProfile(contextGraphId);
+    captured = profile;
+    return null;
+  }
+
+  // The breadcrumb strip (S2) and every other consumer that resolves
+  // the active sub-graph identity via `profile.forSubGraph(slug)`
+  // would have rendered the raw sentinel `__root__` plus the
+  // generic `•` fallback icon before this fix. Centralising the
+  // Root binding at the resolver level ensures every consumer
+  // reads the same icon/label/description.
+  it('returns the synthesized Root binding for ROOT_SLUG_SENTINEL', async () => {
+    await act(async () => {
+      root.render(React.createElement(Probe, { contextGraphId: 'cg-test' }));
+    });
+    // SPARQL mock resolves on the microtask queue.
+    await act(async () => { await Promise.resolve(); });
+
+    expect(captured).toBeTruthy();
+    const binding = captured!.forSubGraph(ROOT_SLUG_SENTINEL);
+    expect(binding).toBeTruthy();
+    expect(binding!.slug).toBe(ROOT_SLUG_SENTINEL);
+    expect(binding!.displayName).toBe('Root');
+    expect(binding!.icon).toBe('⊘');
+    expect(binding!.description).toBe('Entities not in any subgraph (Context Graph root)');
+  });
+
+  it('keeps the daemon-resolved binding path intact for non-Root slugs', async () => {
+    await act(async () => {
+      root.render(React.createElement(Probe, { contextGraphId: 'cg-test' }));
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    // Daemon mock returns no bindings → falls back to the default
+    // shape. The point of this case is the Root short-circuit
+    // didn't accidentally hijack other slugs.
+    const binding = captured!.forSubGraph('recipes');
+    expect(binding!.slug).toBe('recipes');
+    expect(binding!.displayName).toBe('recipes');
+    expect(binding!.icon).toBe('•');
   });
 });


### PR DESCRIPTION
## Summary

S3 from the Context Graph IA / UX redesign workstream. Rebuilds the Subgraph Explorer page as a cross-layer view per the §4.4 mockup + §4.4.1 finalize decisions (locked literals + ROOT_SLUG_SENTINEL + the corrected fold-in #5 fix-location). Implements all seven plan fold-ins.

### What lands

- **Page identity + permanent intro** — title `Subgraph Explorer`; `Subgraphs` (no hyphen) terminology sweep; new `SubGraphExplorerHeader` component renders the 3-sentence permanent intro on BOTH the overview state AND every detail body so the concept never disappears.
- **`ROOT_SLUG_SENTINEL = '__root__'`** exported from `lib/subGraphs.ts` alongside the existing `RESERVED_SUB_GRAPH_SLUGS = ['meta']` (durability call from S3 intake — `assertion` stays OUT of the reserved set; fold-in #5 lives in `subGraphOf` guard instead).
- **`subGraphOf` guard fix (fold-in #5)** — `useMemoryEntities.ts:288` adds `seg === 'assertion'` alongside the existing `_`-prefix guard so root-level assertion-URI triples no longer surface as a phantom `'assertion'` subgraph slug in `entity.subGraphs`. Single-line fix at the upstream URI-parsing site, not at the reserved-slug filter.
- **SubGraphBar Root chip** — renders the `⊘ Root` chip when entities are supplied AND ≥1 entity has empty `subGraphs`. Tooltip cites entity count. Click routes through the sentinel.
- **Cross-layer count strip + active-layer pill (fold-in #4)** — three-cell strip (`◇ Working N · ◈ Shared N · ◉ Verified N`) below the subgraph header, glyph colours from `TRUST_COLORS`. Pill underneath shows `Active layer: All layers` / `Working Memory` / etc.; clickable to reset narrowed state.
- **Per-row trust chips on Entities tab** — each row's trust badge keyed off `e.trustLevel` (not the fixed `layerKey`) when the new `perEntityTrustBadge` prop is set on `EntityList`.
- **Per-URI `nodeColorsOverride` on the Graph pane (fold-in #6)** — derived from `TRUST_COLORS[e.trustLevel]` for the multi-layer view, passed to `LayerGraphPanel` via a new prop that merges with SWM `nodeColors`; caller override wins. Token source is `TRUST_COLORS` (raw hex from `helpers.ts:47`) — canvas pipeline can't resolve CSS variables, so the `--text-*` token detour is intentionally avoided.
- **`scopedTriples` asymmetric predicate (fold-in #7)** — admits a triple when `subGraph === slug` OR subject is scoped OR object is scoped. Covers promoted SWM/VM edges whose `subGraph` tag was erased upstream.
- **Teaching empty state on `SubGraphOverviewGrid`** — locked title `No subgraphs in this Context Graph yet.` + locked description + `View root` action that routes through `ROOT_SLUG_SENTINEL`. `Loading subgraphs...` (single word).
- **Token discipline** — every new CSS rule consumes defined `--bg-*` / `--border-*` / `--text-*` / `--layer-*` tokens. No `--surface-*` undefined fallbacks introduced; the existing ones on `.v10-subgraph-*` rules are part of ui-lead's Section 3 + 7 sweep tracked in their consolidated spec (kept untouched in this PR scope; future-cycle housekeeping).
- **M4-defect gate held** — no `.v10-stat-strip-cell` cell-overrides; new strip mounts a vanilla S9 StatStrip pattern.

## Related

- Builds on **#745** (S2 — Context Graph Overview finalize) for the Subgraphs stat on the Overview that this PR aligns with the chip-row + detail-view counts (M6 canonical-count parity).
- Builds on the centralised `isUserFacingSubGraph` helper introduced in #745 cleanup commit `c21a501e9`.
- Closes the **S3** plan item per `agent-docs/context-graph-implementation-plan.md`.
- Workstream: Phase 2 of the Context Graph IA / UX redesign. After S3 lands: Track A (S5 breadcrumb → S4 assertion detail) + Track B (S7 graph viewport → S8 entity labels) open in parallel.

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/views/project/components.tsx` | `SubGraphExplorerHeader` (new), `SubGraphOverviewGrid` teaching empty state + loading copy, `SubGraphDetailView` Root branch + cross-layer strip + active-layer pill, `scopedTriples` predicate, per-URI `nodeColorsOverride`, fold-in #7 admission |
| `packages/node-ui/src/ui/components/SubGraphBar.tsx` | Root chip mount, sentinel routing, `Subgraphs` (no hyphen) terminology sweep |
| `packages/node-ui/src/ui/views/ProjectView.tsx` | `SubGraphExplorerHeader` mount above the chip row in overview + detail branches |
| `packages/node-ui/src/ui/hooks/useMemoryEntities.ts` | `subGraphOf` guard fix (fold-in #5) — root-level assertion URIs no longer emit a phantom `'assertion'` slug |
| `packages/node-ui/src/ui/lib/subGraphs.ts` | `ROOT_SLUG_SENTINEL = '__root__'` export alongside the existing `RESERVED_SUB_GRAPH_SLUGS` / `isUserFacingSubGraph` |
| `packages/node-ui/src/ui/styles.css` | New `.v10-subgraph-*` rules for the header / intro / count strip / active-layer pill / Root chip / teaching empty state — all token-disciplined |
| `packages/node-ui/test/subgraph-detail-view.test.ts` | +5 cases: Root bucket scope, active-layer pill states, per-URI trust nodeColors, per-row trust badge, fold-in #7 admission |
| `packages/node-ui/test/sub-graph-bar-layer-scope.test.ts` | +3 cases: Root chip rendering, hide-when-empty, click-routes-through-sentinel |
| `packages/node-ui/test/sub-graphs-helper.test.ts` | +4 cases: `ROOT_SLUG_SENTINEL` invariants, `subGraphOf` reserved-slug guards |
| `packages/node-ui/test/project-view-navigation.test.ts` | `SubGraphExplorerHeader` mock stub |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec tsc --noEmit` — clean.
- [x] Extended S3 vitest slice — **213/213 passing**.
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui` — clean (only pre-existing large-chunk warnings).
- [x] `agent-docs/` not in diff.
- [ ] **[VERIFY-GATE — G-VERIFY-S3]** Behavioural acceptance criteria new-5 / new-9 / new-10 — asymmetric scope predicate, per-node trust coloring under cross-layer scope, cross-layer edge admission — require a populated multi-layer CG with promoted SWM/VM entities + cross-layer triples for manual confirmation. If no such CG is reachable at merge time, the gate carries forward to a follow-up cycle (tracked via team task).

## Known pre-existing env carry-overs (NOT caused by this PR)

- `db.test.ts` / `structured-logger.test.ts` / `relay-stats-route.test.ts` / `messenger-stores.test.ts` / `notifications.test.ts` / `metrics-collector.test.ts` / `operation-tracker.test.ts` — `better-sqlite3` Windows native binding missing (`pnpm --ignore-scripts` postinstall skip; same env-setup pattern flagged in S2). Engineer verified identical failure set on the n6-fix worktree at the same `origin/main` SHA.
- `format-notification-time.test.ts` / `format-time-hooks.test.ts` — Windows locale date-format flake (older-than-week dates render as `26 Mar 2026, 16:00` instead of US `Mar 26, 2026`); same baseline-vs-patched reproduction confirms pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)