### PR TITLE
fix(cli): strict-TS double-cast for doctor config overlay

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4668,7 +4668,7 @@ program
     const deps = createProductionDeps({ apiPort: config.apiPort ?? 9200 });
     // Overlay operator-configured scan roots + skipChecks from config.
     // The doctor namespace is opt-in — absent config means defaults.
-    const doctorConfig = (config as Record<string, unknown>).doctor as
+    const doctorConfig = (config as unknown as Record<string, unknown>).doctor as
       | { scanRoots?: unknown; skipChecks?: unknown }
       | undefined;
     if (doctorConfig) {


### PR DESCRIPTION
## Summary
- Blocks `pnpm -r build` on a clean clone of `release/rc.12` head `8e19c4481`:
  ```
  src/cli.ts(4671,27): error TS2352: Conversion of type 'DkgConfig' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  ```
- Trivial double-cast (`as unknown as Record<string, unknown>`) per the TypeScript diagnostic guidance.
- No runtime change; the resulting `doctorConfig` shape and downstream array filtering are identical.

## Why this slipped through
- The cast was added in #750 (RFC-41 bundle A — `dkg doctor`) and didn't trip CI because the package was rebuilt against incremental TS state that already had the prior, looser `DkgConfig` shape cached. Surfaced immediately on a clean checkout / fresh `pnpm install`.

## Test plan
- [x] `pnpm -r build` passes from a clean tree
- [x] `dkg doctor --no-orphan-scan` runs and returns a report (verified against a 6-node devnet)

Made with [Cursor](https://cursor.com)