### PR TITLE
fix(devnet)(swm-ownership-restart): guard empty curl status code (#774 F3 cosmetic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,109 @@ analysis reports are under `bench/results/profiles/`, including
 
 ---
 
+## Triple Store Backends
+
+A DKG node keeps every assertion in an [RDF](https://www.w3.org/RDF/) triple store. Out of the box the node runs an embedded [Oxigraph](https://github.com/oxigraph/oxigraph) instance, which is everything you need on a workstation — no extra process, no extra port, no extra config. Heavier deployments can swap in [Blazegraph](https://blazegraph.com/) (the mainnet store) or any SPARQL 1.1 server.
+
+| Backend | When to pick it |
+|---|---|
+| `oxigraph-worker` (default) | Single-operator nodes, dev, CI. No setup. File-backed, capped at process RAM. |
+| `blazegraph` | High-throughput nodes, mainnet parity, very large graphs (10M+ quads). Run as a separate daemon (Docker or `java -jar`). Shares cleanly with V6 / V8 instances — DKG scopes its writes to the `did:dkg:context-graph:` named-graph prefix. |
+| `sparql-http` | Any SPARQL 1.1 Protocol server (Fuseki, GraphDB, Stardog, Neptune…). Bring your own URL + (optional) auth header. |
+
+### Configure via `dkg init`
+
+Two paths:
+
+**1. Point at an existing Blazegraph instance:**
+
+```
+$ dkg init
+…
+Triple store backend (oxigraph / blazegraph) (oxigraph): blazegraph
+Blazegraph SPARQL endpoint URL: http://127.0.0.1:9999/bigdata/namespace/mynode/sparql
+  Store endpoint reachable: blazegraph http://127.0.0.1:9999/bigdata/namespace/mynode/sparql
+```
+
+**2. Let `dkg init` provision a Blazegraph container via Docker:**
+
+```
+$ dkg init
+…
+Triple store backend (oxigraph / blazegraph) (oxigraph): blazegraph
+Blazegraph SPARQL endpoint URL:                                    ← leave blank
+No URL provided. Provision a Blazegraph container via Docker? (y/n) (y): y
+  Starting Blazegraph in Docker (namespace: mynode)…
+  Docker available: Docker version 24.0.6, build ed223bc
+  Created container "dkg-blazegraph-mynode" on port 9999.
+  Created Blazegraph namespace "mynode".
+```
+
+The Docker provisioner pins `lyrasis/blazegraph:2.1.5` (same image and tag as mainnet and the devnet test fixture), uses `--restart unless-stopped`, auto-bumps the host port if 9999 is taken, and is idempotent — re-running `dkg init` against an already-provisioned namespace reuses the running container.
+
+The wizard validates non-Docker URLs via an `ASK { ?s ?p ?o }` probe before saving — typos or unreachable namespaces are caught at setup time, not at first boot. A 404 surfaces a specific "namespace likely doesn't exist" message rather than the generic network-failure hint.
+
+### Configure via flags (scripted setup)
+
+Every setup entry point honours `--store` / `--store-url`:
+
+```bash
+# Init only
+dkg init --store blazegraph --store-url http://127.0.0.1:9999/bigdata/namespace/mynode/sparql
+
+# Adapter setups (validated + persisted after the adapter step completes)
+dkg hermes setup    --store blazegraph --store-url http://blaze.example/sparql
+dkg openclaw setup  --store blazegraph --store-url http://blaze.example/sparql
+dkg mcp setup       --store blazegraph --store-url http://blaze.example/sparql
+```
+
+`--store oxigraph` on a previously-Blazegraph node clears the persisted block (force-fall-back to the local default).
+
+### Configure via `~/.dkg/config.json`
+
+```json
+{
+  "store": {
+    "backend": "blazegraph",
+    "options": {
+      "url": "http://127.0.0.1:9999/bigdata/namespace/mynode/sparql",
+      "managedByDkg": false
+    }
+  }
+}
+```
+
+For `sparql-http`:
+
+```json
+{
+  "store": {
+    "backend": "sparql-http",
+    "options": {
+      "queryEndpoint": "http://server.example/query",
+      "updateEndpoint": "http://server.example/update",
+      "auth": "Bearer YOUR_TOKEN"
+    }
+  }
+}
+```
+
+### What changes when you pick an external backend
+
+- **Boot-time health check**: the daemon refuses to start until the endpoint answers `ASK`. Unreachable URLs print an actionable message naming the URL — no half-broken daemon.
+- **Namespace identity tag**: on first boot the daemon writes a triple into a reserved `<urn:dkg:store-meta>` graph recording its node name. Subsequent boots verify the tag before doing any writes — two DKG nodes pointed at the same Blazegraph namespace can't silently corrupt each other any more. Mismatches print the cleanup recipe (`DELETE WHERE { ... }`).
+- **Backend-aware reset**: chain-reset (and rebooting against a different backend) scopes its `DELETE` to the `did:dkg:context-graph:` prefix, leaving any V6/V8 data on the same Blazegraph instance untouched. Docker-provisioned namespaces (`managedByDkg: true`) use the faster `DROP ALL` path.
+- **Backend-switch guard**: switching backends between boots is treated like a destructive operation. The daemon prints a multi-line warning and refuses to start unless you set `DKG_ACCEPT_STORE_RESET=1`. Reverting `store.backend` in your config recovers the previous backend's data.
+- **Metrics**: `/api/status` exposes `storeUrl` and `storeQuads` (cached for 30 s) instead of the `storeBytes` file size — quad count is what's meaningful when the store isn't a local file.
+- **Required config**: when you enable `largeLiteralStorage` or `sharedMemoryPublicSnapshotStorage` with an external backend, you must set their `directory` explicitly (no local store path to infer from). The daemon fails fast at config-load if either is missing.
+
+### Limitations
+
+- **Auth / TLS**: only the generic `sparql-http` backend accepts an `Authorization` header. For Blazegraph behind auth or HTTPS-with-custom-CA, run a reverse proxy in front of it for now.
+- **Migration tool**: there is no `dkg migrate-store` between backends. Plan a chain-reset window if you need to switch on a node that holds important non-VM state.
+
+---
+
 ## Testnet Funding
 
 A DKG testnet node needs Base Sepolia ETH (to pay gas for on-chain operations) and test TRAC (for staking and publishing). The Origin Trail testnet faucet hands out both in a single API call, so first-setup paths auto-fund the generated admin wallet plus the three operational wallets when a faucet is configured in the network config.

--- a/devnet/edge-update-flow/automated.test.ts
+++ b/devnet/edge-update-flow/automated.test.ts
@@ -1,0 +1,104 @@
+/**
+ * OT-RFC-41 Bundle B — Edge npm-only update + rollback flow integration test.
+ *
+ * The unit suite in `packages/cli/test/rfc-41-bundle-b.test.ts` covers
+ * the LOGIC of `performNpmUpdateEdge` + `dkg rollback` (Edge branch)
+ * with a mocked `_autoUpdateIo.exec`. That gets us 95% of the
+ * confidence. The last 5% — that `npm install -g` actually mutates
+ * disk, that the installed binary actually runs, that the
+ * previous-version breadcrumb survives a real exec round-trip — is
+ * what this integration test closes.
+ *
+ * The actual orchestration lives in `scripts/devnet-test-edge-update.sh`
+ * for two reasons:
+ *
+ *   1. The script is the form an operator can also run by hand for
+ *      ad-hoc validation. Keeping the wiring in shell means the
+ *      runbook in `docs/devnet/EDGE_UPDATE_VALIDATION.md` is a direct
+ *      copy-paste of what CI executes — no test-runner-specific glue.
+ *   2. Running `npm install -g` requires a clean process env (npm
+ *      reads `NPM_CONFIG_*`, `.npmrc`, etc. up front, not per-spawn),
+ *      so a child process boundary is the path of least resistance.
+ *      Vitest+forks gives us that boundary naturally.
+ *
+ * This file is the thinnest possible vitest wrapper: it shells out to
+ * the script, asserts a clean exit code, and surfaces failures with
+ * the script's own stderr so the failure report is grep-friendly.
+ *
+ * Preconditions:
+ *   - `pnpm install` + `pnpm build` from the repo root.
+ *   - `npx -y verdaccio --version` works on the host (the script
+ *     uses `npx -y verdaccio@latest` to boot the registry).
+ *
+ * Runtime: ~3-5 minutes — the publish stage iterates ~15 public
+ * workspace packages and the install stage does two `npm install -g`
+ * round-trips with the MarkItDown postinstall.
+ *
+ * Run via `pnpm test:devnet:edge-update-flow` from the repo root.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..');
+const SCRIPT = resolve(REPO_ROOT, 'scripts', 'devnet-test-edge-update.sh');
+
+describe('RFC-41 Bundle B — Edge npm-only update + rollback round-trip', () => {
+  it('runs scripts/devnet-test-edge-update.sh to completion', async () => {
+    expect(existsSync(SCRIPT), `expected ${SCRIPT} to exist`).toBe(true);
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    const proc = spawn('bash', [SCRIPT], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        // Honour any operator overrides the runbook documents, but
+        // do not silently inject anything else — keep this transparent
+        // for debugging.
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    proc.stdout.on('data', (c: Buffer) => {
+      stdoutChunks.push(c);
+      // Stream the script's progress so a stalled stage is visible
+      // in CI logs without having to wait for the test to time out.
+      process.stdout.write(c);
+    });
+    proc.stderr.on('data', (c: Buffer) => {
+      stderrChunks.push(c);
+      process.stderr.write(c);
+    });
+
+    const exitCode: number = await new Promise((res, rej) => {
+      proc.once('error', rej);
+      proc.once('close', (code) => res(code ?? -1));
+    });
+
+    if (exitCode !== 0) {
+      const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+      const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
+      const tail = (s: string, n: number) => s.split('\n').slice(-n).join('\n');
+      throw new Error(
+        `devnet-test-edge-update.sh exited ${exitCode}\n` +
+          `--- last 40 lines of stderr ---\n${tail(stderr, 40)}\n` +
+          `--- last 40 lines of stdout ---\n${tail(stdout, 40)}`,
+      );
+    }
+
+    const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
+    // Final assertion lines emitted by the script — anchor the test
+    // to the production contract so a regression that quietly skips
+    // a stage still fails here.
+    expect(stdout).toMatch(/\[edge-update\] v1 installed and reports version /);
+    expect(stdout).toMatch(/\[edge-update\] previous-version=.* \(matches v1\)/);
+    expect(stdout).toMatch(/\[edge-update\] binary now reports /);
+    expect(stdout).toMatch(/\[edge-update\] binary back to .* after rollback — round-trip complete/);
+    expect(stdout).toMatch(/\[edge-update\] PASS — Edge npm-only update \+ rollback round-trip/);
+  });
+});

--- a/devnet/edge-update-flow/package.json
+++ b/devnet/edge-update-flow/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@origintrail-official/dkg-devnet-edge-update-flow",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:devnet": "vitest run --config vitest.config.ts"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
+  }
+}

--- a/devnet/edge-update-flow/package.json
+++ b/devnet/edge-update-flow/package.json
@@ -7,6 +7,6 @@
     "test:devnet": "vitest run --config vitest.config.ts"
   },
   "devDependencies": {
-    "vitest": "^4.0.18"
+    "vitest": "4.0.18"
   }
 }

--- a/devnet/edge-update-flow/vitest.config.ts
+++ b/devnet/edge-update-flow/vitest.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+/**
+ * OT-RFC-41 Bundle B — Edge npm-only update + rollback flow.
+ *
+ * Wraps `scripts/devnet-test-edge-update.sh`, which spins up a local
+ * verdaccio registry, packs + publishes every public workspace
+ * package, installs the CLI globally into a scratch npm prefix,
+ * exercises the full `dkg update` → `dkg rollback` round-trip against
+ * a real `npm install -g`, and asserts the production
+ * `performNpmUpdateEdge` + `dkg rollback` (Edge branch) code paths
+ * actually mutate disk the way unit tests expect.
+ *
+ * This is the §6.2 testing-gap closer for RFC-41: unit tests in
+ * `packages/cli/test/rfc-41-bundle-b.test.ts` cover the LOGIC with a
+ * mocked `_autoUpdateIo.exec`; this suite covers the INTEGRATION with
+ * the real npm CLI.
+ *
+ * Pre-requisites (see `docs/devnet/EDGE_UPDATE_VALIDATION.md`):
+ *   - `pnpm install` from the repo root
+ *   - `pnpm build` (so `packages/* /dist/` exists for `pnpm pack`)
+ *   - `npx -y verdaccio --version` works on the host (warm the cache)
+ *
+ * Run: `pnpm test:devnet:edge-update-flow`
+ *
+ * Runtime: ~3-5 minutes. Dominated by verdaccio cold-start and two
+ * `npm install -g` round-trips against the scratch prefix.
+ */
+export default defineConfig({
+  test: {
+    include: [resolve(import.meta.dirname, 'automated.test.ts')],
+    testTimeout: 600_000,
+    hookTimeout: 60_000,
+    pool: 'forks',
+    sequence: { concurrent: false },
+    globals: false,
+  },
+  resolve: {
+    modules: [
+      resolve(import.meta.dirname, '../../node_modules'),
+      'node_modules',
+    ],
+  },
+});

--- a/docs/devnet/EDGE_UPDATE_VALIDATION.md
+++ b/docs/devnet/EDGE_UPDATE_VALIDATION.md
@@ -1,0 +1,299 @@
+# Edge npm-only update + rollback validation (RFC-41 Bundle B)
+
+This runbook is the operator-facing companion to
+`scripts/devnet-test-edge-update.sh` and the vitest harness at
+`devnet/edge-update-flow/automated.test.ts`. It closes RFC-41 §6.2:
+end-to-end validation of the Edge node `dkg update` + `dkg rollback`
+flow against a real `npm install -g` against a real (local) npm
+registry, _without_ requiring a Trace Labs NPM publish.
+
+The §6.2 gap exists because automated devnet update testing has been
+gated on the prerequisites in §6.5 (Trace Labs publishing a `next`
+dist-tag with the Bundle B build). Until that lands, this runbook +
+script let any contributor exercise the full flow on their own laptop
+against a self-hosted `verdaccio` registry.
+
+## What this validates
+
+Bundle B's contract (RFC-41 §4.7, §4.8):
+
+1. `npm install -g @origintrail-official/dkg@<version>` resolves through
+   the registry and installs the global binary at the npm prefix.
+2. `dkg --version` reports the installed version.
+3. `dkg update <new-version>` runs `npm install -g
+   @origintrail-official/dkg@<new-version>`, writes the OLD version to
+   `~/.dkg/previous-version`, and the binary reports the new version.
+4. `dkg rollback` reads `~/.dkg/previous-version`, runs `npm install
+   -g @origintrail-official/dkg@<previous-version>`, and the binary
+   reports the previous version. Round-trip lands back on the
+   starting version.
+
+What this does **not** validate (separate suites cover these):
+
+- `dkg init --role edge` flow — covered by Bundle B unit tests in
+  `packages/cli/test/rfc-41-bundle-b.test.ts` (monorepo guard,
+  `--role` parsing, config layout). The runbook below bootstraps a
+  minimal `~/.dkg/config.json` directly to keep the focus on the
+  update + rollback path.
+- Daemon HTTP behavior under the new install — covered by
+  `devnet/v10-core-flows/` once the daemon is started against an
+  Edge-mode `config.json`.
+- Core slot-based update — RFC-41 §4.7.2 keeps that path for Core
+  nodes; this runbook is Edge-only.
+- Build-info / install-mode telemetry — Bundle A's `/api/status` +
+  `dkg doctor` output is covered by Bundle A's unit suite.
+
+## Prerequisites
+
+1. **Built workspace.** `pnpm pack` packs `dist/`, not source; without
+   it the packed tarballs are stubs.
+   ```bash
+   pnpm install
+   pnpm build
+   ```
+2. **Network access for `npx`.** The script boots verdaccio via
+   `npx -y verdaccio@latest`. Warm the npx cache once:
+   ```bash
+   npx -y verdaccio@latest --version
+   ```
+3. **No conflicting verdaccio.** Port `4873` must be free, or set
+   `VERDACCIO_PORT=<free port>` when invoking the script.
+4. **Node ≥ what the repo requires.** Use `nvm use` (reads `.nvmrc`)
+   to pin the right version.
+
+The script does NOT touch:
+
+- The host's `~/.dkg` (uses `DKG_HOME=<scratch>/dkg-home`).
+- The host's npm global prefix (uses `NPM_CONFIG_PREFIX=<scratch>/npm-global`).
+- The host's `~/.npmrc` (uses `NPM_CONFIG_USERCONFIG=<scratch>/.npmrc`).
+
+## Run it (automated)
+
+From the repo root:
+
+```bash
+pnpm test:devnet:edge-update-flow
+```
+
+That registers the script as a vitest scenario alongside the other
+`pnpm test:devnet:*` suites, gives you streamed progress, and fails
+loud with the script's own stderr captured.
+
+To debug a failure, re-run the script directly with the scratch root
+preserved:
+
+```bash
+EDGE_UPDATE_KEEP_SCRATCH=1 ./scripts/devnet-test-edge-update.sh
+```
+
+The path it printed under `[edge-update] scratch root:` survives the
+exit trap and contains:
+
+- `dkg-home/` — `config.json`, `previous-version`, etc.
+- `npm-global/` — the scratch npm prefix with `bin/dkg`.
+- `verdaccio-storage/` — the local registry's package storage.
+- `verdaccio.log` — the registry's stderr.
+- `tarballs/` — every packed tarball (v1 for all public packages,
+  plus v2 of the CLI).
+- `.npmrc` — the registry/auth config the script used.
+
+## Run it (manual, step by step)
+
+If the script is failing in a way that's hard to read from logs alone,
+here's the same flow broken into copy-pasteable shell. Same env vars,
+same paths.
+
+### 1. Scratch root + env
+
+```bash
+export SCRATCH_ROOT="$(mktemp -d -t dkg-edge-update.XXXXXX)"
+export NPM_CONFIG_PREFIX="$SCRATCH_ROOT/npm-global"
+export DKG_HOME="$SCRATCH_ROOT/dkg-home"
+export NPM_CONFIG_USERCONFIG="$SCRATCH_ROOT/.npmrc"
+export NPM_CONFIG_REGISTRY="http://127.0.0.1:4873/"
+export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
+mkdir -p "$NPM_CONFIG_PREFIX" "$DKG_HOME" "$SCRATCH_ROOT/tarballs"
+
+cat > "$NPM_CONFIG_USERCONFIG" <<EOF
+registry=$NPM_CONFIG_REGISTRY
+//127.0.0.1:4873/:_authToken=anon-token-for-verdaccio
+@origintrail-official:registry=$NPM_CONFIG_REGISTRY
+EOF
+```
+
+### 2. Boot verdaccio
+
+```bash
+cat > "$SCRATCH_ROOT/verdaccio-config.yaml" <<EOF
+storage: $SCRATCH_ROOT/verdaccio-storage
+auth:
+  htpasswd:
+    file: $SCRATCH_ROOT/htpasswd
+    max_users: -1
+uplinks: {}
+packages:
+  '@origintrail-official/*':
+    access: \$anonymous
+    publish: \$anonymous
+    unpublish: \$anonymous
+  '**':
+    access: \$anonymous
+    publish: \$authenticated
+log:
+  type: stdout
+  format: pretty
+  level: warn
+EOF
+
+nohup npx -y verdaccio@latest \
+  --listen 4873 --config "$SCRATCH_ROOT/verdaccio-config.yaml" \
+  >"$SCRATCH_ROOT/verdaccio.log" 2>&1 &
+echo "verdaccio pid: $!"
+
+# Wait until /ping returns 200.
+until curl -fsS "$NPM_CONFIG_REGISTRY/-/ping" >/dev/null; do sleep 1; done
+```
+
+### 3. Pack + publish v1 of every public package
+
+```bash
+cd <repo-root>
+V1="$(node -p "require('./packages/cli/package.json').version")"
+echo "v1 = $V1"
+
+# Discover public packages.
+for d in packages/*; do
+  [ -f "$d/package.json" ] || continue
+  IS_PRIVATE="$(node -p "JSON.parse(require('fs').readFileSync('$d/package.json','utf-8')).private === true")"
+  [ "$IS_PRIVATE" = "true" ] && continue
+  ( cd "$d" && pnpm pack --pack-destination "$SCRATCH_ROOT/tarballs" >/dev/null )
+done
+
+for tgz in "$SCRATCH_ROOT/tarballs"/*.tgz; do
+  npm publish "$tgz"
+done
+```
+
+### 4. Bump CLI to v2 and publish
+
+```bash
+V2="${V1}-edge-update-test.1"
+cp packages/cli/package.json "$SCRATCH_ROOT/cli-package.json.bak"
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('packages/cli/package.json','utf-8'));
+  p.version = '$V2';
+  fs.writeFileSync('packages/cli/package.json', JSON.stringify(p, null, 2) + '\n');
+"
+( cd packages/cli && pnpm pack --pack-destination "$SCRATCH_ROOT/tarballs" >/dev/null )
+npm publish "$SCRATCH_ROOT/tarballs/origintrail-official-dkg-${V2}.tgz"
+cp "$SCRATCH_ROOT/cli-package.json.bak" packages/cli/package.json
+echo "v2 = $V2"
+```
+
+### 5. Install v1 globally
+
+```bash
+npm install -g "@origintrail-official/dkg@$V1"
+which dkg               # → $NPM_CONFIG_PREFIX/bin/dkg
+dkg --version           # → $V1
+```
+
+### 6. Bootstrap a minimal Edge config
+
+(`dkg init` is interactive and asks ~12 questions; we bypass it here
+because the focus is the UPDATE flow. Bundle B unit tests cover the
+init flow.)
+
+```bash
+cat > "$DKG_HOME/config.json" <<EOF
+{
+  "name": "dkg-edge-update-test",
+  "nodeRole": "edge",
+  "apiPort": 8901,
+  "autoUpdate": { "enabled": false, "source": "npm" },
+  "auth": { "enabled": false }
+}
+EOF
+```
+
+### 7. `dkg update <V2>` — the headline assertion
+
+```bash
+dkg update "$V2"
+cat "$DKG_HOME/previous-version"   # → $V1 (rollback breadcrumb)
+dkg --version                      # → $V2
+```
+
+### 8. `dkg rollback`
+
+```bash
+dkg rollback
+dkg --version                      # → $V1 (back to starting version)
+```
+
+### 9. Cleanup
+
+```bash
+kill %1 2>/dev/null               # stop verdaccio
+rm -rf "$SCRATCH_ROOT"
+```
+
+## Expected output (script form)
+
+A passing run looks like:
+
+```
+[edge-update] scratch root: /tmp/dkg-edge-update.XXXXXX
+[edge-update] verdaccio:    http://127.0.0.1:4873 ...
+[edge-update] stage 1: launching verdaccio
+[edge-update] verdaccio up after 2s (pid=12345)
+[edge-update] stage 2: v1=10.0.0-rc.11  v2=10.0.0-rc.11-edge-update-test.1
+[edge-update] packing public packages at v1 (10.0.0-rc.11)
+[edge-update] packed 15 v1 tarballs into ...
+[edge-update] packing v2 (CLI only, with bumped version ...)
+[edge-update] v2 tarball: .../origintrail-official-dkg-10.0.0-rc.11-edge-update-test.1.tgz
+[edge-update] restored .../packages/cli/package.json
+[edge-update] stage 3: publishing 16 tarballs to verdaccio
+[edge-update] published all tarballs
+[edge-update] verdaccio knows CLI v1 + v2
+[edge-update] stage 4: npm install -g @origintrail-official/dkg@10.0.0-rc.11
+[edge-update] v1 installed and reports version 10.0.0-rc.11
+[edge-update] stage 5: bootstrap minimal Edge config at .../dkg-home/config.json
+[edge-update] config.json nodeRole=edge, autoUpdate.source=npm
+[edge-update] stage 6: dkg update 10.0.0-rc.11-edge-update-test.1
+[edge-update] previous-version=10.0.0-rc.11 (matches v1)
+[edge-update] binary now reports 10.0.0-rc.11-edge-update-test.1
+[edge-update] stage 7: dkg rollback (expected back to 10.0.0-rc.11)
+[edge-update] binary back to 10.0.0-rc.11 after rollback — round-trip complete
+[edge-update] PASS — Edge npm-only update + rollback round-trip ...
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `verdaccio did not respond to /-/ping within 60s` | First-time `npx verdaccio` is downloading | Pre-warm with `npx -y verdaccio@latest --version` |
+| `port 4873 in use` | Existing verdaccio | `lsof -i :4873` → kill it, or `VERDACCIO_PORT=4874 ./script.sh` |
+| `pnpm pack failed` | Workspace not built | `pnpm build` from repo root |
+| `expected dkg binary at .../bin/dkg after install` | `npm install -g` silently failed | Re-run with `EDGE_UPDATE_KEEP_SCRATCH=1`, then `cat <scratch>/verdaccio.log` |
+| `dkg update <v2> failed` | Pre-flight doctor check found error severity | Re-run script directly with stderr visible: `bash -x scripts/devnet-test-edge-update.sh 2>&1 \| tee /tmp/dkg-update-log` |
+| `previous-version` missing after `dkg update` | `getCurrentCliVersion()` returned empty | Check that v1 tarball includes a non-empty `package.json#version` |
+| Test passes locally, fails in CI | CI host has a stale npm global prefix | Confirm CI uses an ephemeral runner; the script's scratch prefix is per-run |
+
+## Tying back to RFC-41
+
+Run this **before** you merge any change that touches:
+
+- `packages/cli/src/daemon/auto-update.ts` (especially
+  `performNpmUpdateEdge` and `_performNpmUpdateInnerEdge`).
+- `packages/cli/src/cli.ts` `dkg update` / `dkg rollback` action
+  handlers.
+- `packages/cli/src/migration.ts` `noteEdgeLegacyReleases`.
+- Any code under `packages/cli/src/daemon/manifest.ts` that exports
+  `_autoUpdateIo`.
+
+It's also a pre-merge gate for the RFC-41 follow-up PRs (deletion of
+the dead git-build code paths) once Bundle B has soaked on devnet —
+the script ensures the deletions did not accidentally break the
+update flow that survived the cleanup.

--- a/docs/devnet/EDGE_UPDATE_VALIDATION.md
+++ b/docs/devnet/EDGE_UPDATE_VALIDATION.md
@@ -51,11 +51,17 @@ What this does **not** validate (separate suites cover these):
    pnpm install
    pnpm build
    ```
-2. **Network access for `npx`.** The script boots verdaccio via
-   `npx -y verdaccio@latest`. Warm the npx cache once:
+2. **Network access for `npx`.** The script boots a pinned
+   verdaccio (default `verdaccio@6.7.2`, see `VERDACCIO_VERSION`
+   in `scripts/devnet-test-edge-update.sh`) via `npx`. Warm the
+   npx cache once:
    ```bash
-   npx -y verdaccio@latest --version
+   npx -y verdaccio@6.7.2 --version
    ```
+   Override the pin per-run with `VERDACCIO_VERSION=<x.y.z>
+   ./scripts/devnet-test-edge-update.sh` when debugging against
+   a different verdaccio. Bumping the default pin should be a
+   deliberate edit + a manual re-run against the updated runbook.
 3. **No conflicting verdaccio.** Port `4873` must be free, or set
    `VERDACCIO_PORT=<free port>` when invoking the script.
 4. **Node ≥ what the repo requires.** Use `nvm use` (reads `.nvmrc`)
@@ -145,7 +151,7 @@ log:
   level: warn
 EOF
 
-nohup npx -y verdaccio@latest \
+nohup npx -y verdaccio@6.7.2 \
   --listen 4873 --config "$SCRATCH_ROOT/verdaccio-config.yaml" \
   >"$SCRATCH_ROOT/verdaccio.log" 2>&1 &
 echo "verdaccio pid: $!"
@@ -273,7 +279,7 @@ A passing run looks like:
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `verdaccio did not respond to /-/ping within 60s` | First-time `npx verdaccio` is downloading | Pre-warm with `npx -y verdaccio@latest --version` |
+| `verdaccio did not respond to /-/ping within 60s` | First-time `npx verdaccio` is downloading | Pre-warm with `npx -y verdaccio@6.7.2 --version` |
 | `port 4873 in use` | Existing verdaccio | `lsof -i :4873` → kill it, or `VERDACCIO_PORT=4874 ./script.sh` |
 | `pnpm pack failed` | Workspace not built | `pnpm build` from repo root |
 | `expected dkg binary at .../bin/dkg after install` | `npm install -g` silently failed | Re-run with `EDGE_UPDATE_KEEP_SCRATCH=1`, then `cat <scratch>/verdaccio.log` |

--- a/docs/setup/SETUP_CUSTOM.md
+++ b/docs/setup/SETUP_CUSTOM.md
@@ -280,10 +280,26 @@ await node.start();
 // Option A: Oxigraph directly
 const store = new OxigraphStore();
 
-// Option B: Any registered backend via the factory
+// Option B: Any registered backend via the factory.
+//
+// Use this when you want the same backend the daemon uses — Blazegraph
+// or any SPARQL 1.1 server (Fuseki, GraphDB, Stardog, …). The factory
+// runs whichever adapter was registered for the named backend; see the
+// "Triple Store Backends" section of the repo README for the full
+// matrix and config shapes.
+//
 // const store = await createTripleStore({
 //   backend: 'blazegraph',
 //   options: { url: 'http://127.0.0.1:9999/bigdata/namespace/mynode/sparql' },
+// });
+//
+// const store = await createTripleStore({
+//   backend: 'sparql-http',
+//   options: {
+//     queryEndpoint: 'http://server.example/query',
+//     updateEndpoint: 'http://server.example/update',
+//     auth: 'Bearer YOUR_TOKEN', // optional
+//   },
 // });
 
 const router = new ProtocolRouter(node);

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:devnet:v10-e2e": "vitest run --config devnet/v10-end-to-end/vitest.config.ts",
     "test:devnet:v10-stress": "vitest run --config devnet/v10-stress/vitest.config.ts",
     "test:devnet:conviction-lazy-settle": "vitest run --config devnet/conviction-lazy-settle/vitest.config.ts",
+    "test:devnet:edge-update-flow": "vitest run --config devnet/edge-update-flow/vitest.config.ts",
     "test:all": "pnpm test && pnpm test:evm"
   },
   "devDependencies": {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1070,6 +1070,23 @@ export class DKGAgent {
       log.warn(createOperationContext('init'), `Failed to reconstruct shared memory ownership, continuing without: ${err instanceof Error ? err.message : String(err)}`);
     }
 
+    // GH #748: one-shot migration of SWM `prov:wasAttributedTo` from
+    // peer-ID string literals to agent DID URIs. Idempotent via a
+    // per-CG marker; non-fatal on failure (match the pattern above).
+    try {
+      const migrated = await publisher.migrateSwmAttributionToAgentDid();
+      if (migrated.rewritten > 0 || migrated.skipped > 0) {
+        const log = new Logger('DKGAgent');
+        log.info(
+          createOperationContext('init'),
+          `Migrated SWM attribution across ${migrated.swmMetaGraphs} SWM meta graph(s): rewrote ${migrated.rewritten} literal(s) to agent DID, ${migrated.skipped} unresolved`,
+        );
+      }
+    } catch (err) {
+      const log = new Logger('DKGAgent');
+      log.warn(createOperationContext('init'), `Failed to migrate SWM attribution to agent DID, continuing without: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
     const queryEngine = new DKGQueryEngine(store);
 
     return new DKGAgent(

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -221,11 +221,24 @@ export class FinalizationHandler {
 
     const values = safeRoots.map(r => `<${r}>`).join(' ');
     const PROV = 'http://www.w3.org/ns/prov#';
+    // GH #748: prefer the dedicated `dkg:publisherPeerId` field (peer-ID
+    // literal); fall back to literal-form `prov:wasAttributedTo` for legacy
+    // un-migrated SWM rows. Skip URI form — that's an agent DID, not a
+    // peer ID, and downstream dials a libp2p peer with this value.
+    //
+    // `FILTER(BOUND(?peerId))` guards the LIMIT 1: without it, an op with
+    // `rootEntity` but neither peer-ID source produces an unbound `?peerId`
+    // that LIMIT could pick. The caller's `wsPeerId || publisherAddress`
+    // fallback would then store an EVM address where a libp2p peer ID is
+    // expected. With BOUND, only ops carrying a real peer-ID match.
     const sparql = `SELECT ?peerId WHERE {
       GRAPH <${wsMetaGraph}> {
         VALUES ?root { ${values} }
         ?op <${DKG_NS}rootEntity> ?root .
-        ?op <${PROV}wasAttributedTo> ?peerId .
+        OPTIONAL { ?op <${DKG_NS}publisherPeerId> ?pidField }
+        OPTIONAL { ?op <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
+        BIND(COALESCE(?pidField, ?attrField) AS ?peerId)
+        FILTER(BOUND(?peerId))
       }
     } LIMIT 1`;
 

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -204,6 +204,7 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
   const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
   const DKG_WORKSPACE_OP = 'http://dkg.io/ontology/WorkspaceOperation';
   const DKG_PUBLISHED_AT = 'http://dkg.io/ontology/publishedAt';
+  const DKG_PUBLISHER_PEER_ID = 'http://dkg.io/ontology/publisherPeerId';
   const PROV_ATTRIBUTED_TO = 'http://www.w3.org/ns/prov#wasAttributedTo';
   const SKOLEM_PREFIX = '/.well-known/genid/';
 
@@ -231,11 +232,27 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
     return false;
   });
 
-  const opCreators = new Map<string, string>();
+  // GH #748 Codex round 4: prefer the dedicated `dkg:publisherPeerId` literal
+  // for ownership-cache hydration; only fall back to `prov:wasAttributedTo`
+  // when it's a literal (the legacy shape). Post-fix `wasAttributedTo`
+  // carries an agent DID URI, and caching that as the peer-ID owner here
+  // would break first-writer/upsert recognition for follow-up writes from
+  // the same peer (the check at `_shareImpl` compares against the live
+  // `publisherPeerId` of the new write).
+  const opPeerIdField = new Map<string, string>();
+  const opAttrLiteralFallback = new Map<string, string>();
   for (const q of wsMetaQuads) {
-    if (q.predicate === PROV_ATTRIBUTED_TO && validOps.has(q.subject)) {
-      opCreators.set(q.subject, q.object.startsWith('"') ? stripLiteral(q.object) : q.object);
+    if (!validOps.has(q.subject)) continue;
+    if (q.predicate === DKG_PUBLISHER_PEER_ID) {
+      opPeerIdField.set(q.subject, q.object.startsWith('"') ? stripLiteral(q.object) : q.object);
+    } else if (q.predicate === PROV_ATTRIBUTED_TO && q.object.startsWith('"')) {
+      opAttrLiteralFallback.set(q.subject, stripLiteral(q.object));
     }
+  }
+  const opCreators = new Map<string, string>();
+  for (const op of validOps) {
+    const peer = opPeerIdField.get(op) ?? opAttrLiteralFallback.get(op);
+    if (peer) opCreators.set(op, peer);
   }
 
   const entityCreators = new Map<string, string>();

--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -207,11 +207,14 @@ describe('FinalizationHandler', () => {
       subGraphName,
     );
 
+    // GH #748: agent DID subjects are lowercased per `canonicalAgentDidSubject`
+    // so the same wallet doesn't split into multiple RDF subjects (see
+    // `agentDid()` in packages/publisher/src/metadata.ts).
     const registration = await store.query(
       `ASK { GRAPH <${metaGraph}> {
         <${subGraphUri}> a <http://dkg.io/ontology/SubGraph> ;
           <http://schema.org/name> "code" ;
-          <http://dkg.io/ontology/createdBy> <did:dkg:agent:${publisherAddress}> .
+          <http://dkg.io/ontology/createdBy> <did:dkg:agent:${publisherAddress.toLowerCase()}> .
       } }`,
     );
     expect(registration.type).toBe('boolean');

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -59,6 +59,13 @@ export interface DaemonStatusResponse {
     rpcEndpointCount: number;
     hubConfigured: boolean;
   } | null;
+  // Triple-store backend fields (RFC 120). For local backends only
+  // `storeBackend` is meaningful; external backends additionally surface
+  // `storeUrl` and a TTL-cached `storeQuads` count. `null` when local /
+  // unreachable.
+  storeBackend?: string;
+  storeUrl?: string | null;
+  storeQuads?: number | null;
 }
 
 export class ApiClient {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -32,6 +32,7 @@ import {
 } from './config.js';
 import { ApiClient } from './api-client.js';
 import { parsePositiveIntegerOption, parsePositiveMsOption } from './publisher-runner.js';
+import { promptStoreBackend, applyStoreFlagsToConfig } from './store-wizard.js';
 import { runConfiguredSourceWorker } from './source-worker-runner.js';
 
 function isDaemonUnreachable(err: unknown): boolean {
@@ -602,6 +603,14 @@ program
   .command('init')
   .description('Interactive setup — set node name, role, and relay')
   .option('--role <role>', "Node role: 'edge' (default; personal laptop / behind NAT) or 'core' (24/7 relay / SLA)")
+  .option(
+    '--store <backend>',
+    'Pre-fill the triple-store backend prompt (oxigraph | blazegraph | sparql-http).',
+  )
+  .option(
+    '--store-url <url>',
+    'Pre-fill the SPARQL endpoint URL prompt for external backends.',
+  )
   .action(async (opts: ActionOpts) => {
     // OT-RFC-41 Bundle B1c: monorepo guard. `dkg init` from a
     // contributor checkout is almost always a mistake — the
@@ -630,6 +639,7 @@ program
       );
       process.exit(1);
     }
+
 
     await ensureDkgDir();
     const existing = await loadConfig();
@@ -666,6 +676,19 @@ program
       const roleAnswer = await ask('Node role (edge / core)', defaultRole);
       nodeRole = roleAnswer === 'core' ? 'core' : 'edge';
     }
+
+    // Triple-store backend (RFC 120, plan PR 2 item 1 + PR 3 Docker
+    // branch). Default: stay on local Oxigraph. Operators selecting
+    // "blazegraph" with a blank URL get the Docker convenience path
+    // (if Docker is installed) — the namespace name defaults to the
+    // node name so each operator gets their own DKG-owned namespace.
+    const { storeBlock } = await promptStoreBackend({
+      ask,
+      existingStore: existing.store,
+      flagBackend: opts.store,
+      flagUrl: opts.storeUrl,
+      nodeName: name || existing.name,
+    });
 
     // Pre-fill relay from network config if user hasn't set one.
     // Show the first relay as the default, but only persist to config if the
@@ -800,6 +823,11 @@ program
       autoUpdate: enableAutoUpdate ? autoUpdate : existing.autoUpdate,
       chain: chainSection ?? existing.chain,
       auth: { enabled: enableAuth, tokens: existing.auth?.tokens },
+      // Persist the chosen backend. `storeBlock === null` from the
+      // wizard means "use the local default" — we explicitly clear any
+      // existing block so re-running `dkg init` to switch from
+      // blazegraph back to oxigraph actually applies.
+      store: storeBlock ?? undefined,
     };
     await saveConfig(config);
 
@@ -823,6 +851,13 @@ program
     console.log(`  context graphs: ${contextGraphs.length ? contextGraphs.join(', ') : '(none)'}`);
     console.log(`  apiPort:    ${config.apiPort}`);
     console.log(`  auth:       ${enableAuth ? `enabled (token in ${dkgAuthTokenPath(dkgDir())})` : 'disabled'}`);
+    console.log(
+      `  store:      ${
+        storeBlock
+          ? `${storeBlock.backend} (${(storeBlock.options as { url: string }).url})`
+          : 'oxigraph (local default)'
+      }`,
+    );
     {
       const resolved = resolveAutoUpdateConfig(config, network);
       console.log(
@@ -1200,6 +1235,20 @@ program
       console.log(`  Uptime:    ${uptime}`);
       console.log(`  Peers:     ${s.connectedPeers}`);
       console.log(`  Relay:     ${s.relayConnected ? 'connected' : 'not connected'}`);
+      // Backend visibility: local backends print just the name (file
+      // bytes are graphed via /api/dashboard); external backends print
+      // backend + endpoint + quad count, falling back to a clear
+      // "unreachable" signal when the daemon couldn't talk to the
+      // remote store. Quad count = null is rare in practice (cached
+      // every 30 s on the daemon side) so when it shows up the
+      // operator should treat it as an alert, not a no-op.
+      const backend = s.storeBackend ?? 'oxigraph-worker';
+      if (s.storeUrl) {
+        const quads = s.storeQuads == null ? 'UNREACHABLE' : `${s.storeQuads.toLocaleString()} quads`;
+        console.log(`  Store:     ${backend} (${s.storeUrl}) — ${quads}`);
+      } else {
+        console.log(`  Store:     ${backend}`);
+      }
     } catch (err) {
       console.error(toErrorMessage(err));
       process.exit(1);
@@ -2382,6 +2431,14 @@ openclawCmd
   .option('--dry-run', 'Preview changes without writing anything')
   .option('--no-fund', 'Skip wallet funding via testnet faucet')
   .option('--fund', 'Fund wallets via testnet faucet (default)')
+  .option(
+    '--store <backend>',
+    'Triple-store backend (oxigraph | blazegraph | sparql-http). Validates the URL via an ASK probe and persists the store block after setup completes.',
+  )
+  .option(
+    '--store-url <url>',
+    'SPARQL endpoint URL — required when --store is blazegraph or sparql-http.',
+  )
   .action(async (opts, command) => {
     // Dynamic import + process.exit plumbing stay here; the actual `runSetup`
     // call lives in `openclawSetupAction` so it can be unit-tested without
@@ -2400,6 +2457,14 @@ openclawCmd
     const { openclawSetupAction } = await import('./openclaw-setup.js');
     try {
       await openclawSetupAction(opts, command, { runSetup });
+      // Persist --store / --store-url after the action's ensureDkgNodeConfig
+      // has run; otherwise the config file may not exist yet on a fresh
+      // install. Validation hits the same boot-time probe used by the
+      // daemon, so an invalid URL fails here, not on the next dkg start.
+      await applyStoreFlagsToConfig({
+        storeFlag: opts.store,
+        storeUrlFlag: opts.storeUrl,
+      });
     } catch (err: any) {
       console.error(`\n[setup] ERROR: ${err?.message ?? err}\n`);
       process.exit(1);
@@ -2456,6 +2521,14 @@ mcpCmd
   .option('--force', 'Refresh every detected client regardless of current registration state')
   .option('--print-only', 'Print the canonical JSON to stdout; skip every other step')
   .option('--yes', 'Auto-confirm per-client registrations (default false: prompt interactively in TTY mode; non-TTY auto-confirms — pass `--yes` in scripts for the safer scripted-environment posture)')
+  .option(
+    '--store <backend>',
+    'Triple-store backend (oxigraph | blazegraph | sparql-http). Validates the URL and persists the store block after setup.',
+  )
+  .option(
+    '--store-url <url>',
+    'SPARQL endpoint URL — required when --store is blazegraph or sparql-http.',
+  )
   .option('--installed', 'Force installed-mode setup. Bootstrap home: `~/.dkg`. Registered binary: the running CLI (whichever invoked this command — typically the global `dkg`). Use this from a monorepo cwd when you want the global install instead of the local dist. Mutually exclusive with --monorepo.')
   .option('--monorepo', 'Force monorepo-mode setup. Bootstrap home: `~/.dkg-dev`. Registered binary: the local `<repo>/packages/cli/dist/cli.js` script (located via cwd-first walk; falls back to the running CLI dir). Errors if no DKG monorepo root is detected. Switches BOTH bootstrap home AND the registered binary, unlike --installed which only switches the home. Mutually exclusive with --installed.')
   .action(async (opts) => {
@@ -2493,6 +2566,10 @@ mcpCmd
         requestFaucetFunding: coreExports.requestFaucetFunding,
         findDkgMonorepoRoot: coreExports.findDkgMonorepoRoot,
         resolveDkgConfigHome: coreExports.resolveDkgConfigHome,
+      });
+      await applyStoreFlagsToConfig({
+        storeFlag: opts.store,
+        storeUrlFlag: opts.storeUrl,
       });
     } catch (err: any) {
       console.error(`\n[dkg mcp setup] ERROR: ${err?.message ?? err}\n`);
@@ -2579,6 +2656,14 @@ hermesCmd
     '--no-replace-provider',
     'Alias for --preserve-provider',
   )
+  .option(
+    '--store <backend>',
+    'Triple-store backend (oxigraph | blazegraph | sparql-http). Validates the URL and persists the store block after setup.',
+  )
+  .option(
+    '--store-url <url>',
+    'SPARQL endpoint URL — required when --store is blazegraph or sparql-http.',
+  )
   .action(async (opts, command) => {
     const runSetup = await loadHermesAdapterAction('setup', ['runSetup', 'setup']);
     const { hermesSetupAction } = await import('./hermes-setup.js');
@@ -2590,6 +2675,10 @@ hermesCmd
         ? { ...opts, preserveProvider: true }
         : opts;
       await hermesSetupAction(merged, command, { runSetup });
+      await applyStoreFlagsToConfig({
+        storeFlag: opts.store,
+        storeUrlFlag: opts.storeUrl,
+      });
     } catch (err: any) {
       console.error(`\n[hermes setup] ERROR: ${err?.message ?? err}\n`);
       process.exit(1);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4757,7 +4757,7 @@ program
     const deps = createProductionDeps({ apiPort: config.apiPort ?? 9200 });
     // Overlay operator-configured scan roots + skipChecks from config.
     // The doctor namespace is opt-in — absent config means defaults.
-    const doctorConfig = (config as Record<string, unknown>).doctor as
+    const doctorConfig = (config as unknown as Record<string, unknown>).doctor as
       | { scanRoots?: unknown; skipChecks?: unknown }
       | undefined;
     if (doctorConfig) {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1118,6 +1118,117 @@ export async function loadConfig(): Promise<DkgConfig> {
   }
 }
 
+// =====================================================================
+// External-backend config validation (RFC 120, plan PR 1 item 6)
+// =====================================================================
+//
+// External triple-store backends (Blazegraph, sparql-http) impose two
+// requirements beyond the local-file default:
+//
+//   1. `store.options.url` (or `queryEndpoint`) must be set. The adapter
+//      will throw without it, but only deep inside agent boot — by which
+//      point logs already have stack traces from finalization wiring
+//      that started before the agent. Surfacing the error here at
+//      config-load time gives operators a single-line, actionable error.
+//   2. `largeLiteralStorage.directory` and
+//      `sharedMemoryPublicSnapshotStorage.directory` must be explicit
+//      when those features are enabled. The defaults derive a directory
+//      from the local triple-store's persistent path; an external
+//      backend has no such path, so without explicit directories the
+//      blob store throws when it sees its first oversized literal
+//      (potentially weeks after install).
+//
+// Returns an array of error messages — empty if config is valid. Caller
+// decides whether to log + exit (boot path) or surface as a config-save
+// rejection (future wizard path).
+const EXTERNAL_VALIDATION_PREFIX = '[config] store.backend';
+
+export interface StoreConfigValidationError {
+  /** Field path within the config that failed validation. */
+  field: string;
+  /** Human-readable error message including remediation hint. */
+  message: string;
+}
+
+export function validateStoreConfig(config: DkgConfig): StoreConfigValidationError[] {
+  const errors: StoreConfigValidationError[] = [];
+  const backend = config.store?.backend;
+  // Mirror of `isExternalBackend` from @origintrail-official/dkg-storage.
+  // Duplicated here to keep config.ts free of upward dependencies on the
+  // storage package (config.ts is leaf-imported by many other modules).
+  const isExternal = backend === 'blazegraph' || backend === 'sparql-http';
+  if (!isExternal) return errors;
+
+  const opts = (config.store?.options ?? {}) as Record<string, unknown>;
+
+  if (backend === 'blazegraph') {
+    if (typeof opts.url !== 'string' || !opts.url.trim()) {
+      errors.push({
+        field: 'store.options.url',
+        message:
+          `${EXTERNAL_VALIDATION_PREFIX} is "blazegraph" but ` +
+          `store.options.url is missing. Set it to the SPARQL endpoint URL ` +
+          `(e.g. http://127.0.0.1:9999/bigdata/namespace/mynode/sparql) or ` +
+          `switch backend to oxigraph-worker.`,
+      });
+    }
+  } else if (backend === 'sparql-http') {
+    if (typeof opts.queryEndpoint !== 'string' || !opts.queryEndpoint.trim()) {
+      errors.push({
+        field: 'store.options.queryEndpoint',
+        message:
+          `${EXTERNAL_VALIDATION_PREFIX} is "sparql-http" but ` +
+          `store.options.queryEndpoint is missing. Set it to the SPARQL query URL.`,
+      });
+    }
+  }
+
+  if (config.largeLiteralStorage?.enabled === true) {
+    const dir = config.largeLiteralStorage.directory;
+    if (typeof dir !== 'string' || !dir.trim()) {
+      errors.push({
+        field: 'largeLiteralStorage.directory',
+        message:
+          `largeLiteralStorage.enabled=true with an external store backend requires ` +
+          `largeLiteralStorage.directory to be set explicitly (no local store path ` +
+          `to infer it from). Either set the directory or disable large-literal storage.`,
+      });
+    }
+  }
+
+  if (config.sharedMemoryPublicSnapshotStorage?.enabled === true) {
+    const dir = config.sharedMemoryPublicSnapshotStorage.directory;
+    if (typeof dir !== 'string' || !dir.trim()) {
+      errors.push({
+        field: 'sharedMemoryPublicSnapshotStorage.directory',
+        message:
+          `sharedMemoryPublicSnapshotStorage.enabled=true with an external store backend ` +
+          `requires sharedMemoryPublicSnapshotStorage.directory to be set explicitly.`,
+      });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Convenience helper: validate, log every error, exit if any. Daemon
+ * boot uses this; the future wizard path will iterate `errors` to
+ * re-prompt instead of exiting.
+ */
+export function exitOnStoreConfigErrors(
+  config: DkgConfig,
+  log: (msg: string) => void,
+): void {
+  const errors = validateStoreConfig(config);
+  if (errors.length === 0) return;
+  log(`[STORE-CONFIG] ${errors.length} validation error(s) — refusing to start.`);
+  for (const err of errors) {
+    log(`  ${err.field}: ${err.message}`);
+  }
+  process.exit(1);
+}
+
 export async function saveConfig(config: DkgConfig): Promise<void> {
   await ensureDkgDir();
   await writeFile(configPath(), JSON.stringify(config, null, 2) + '\n');

--- a/packages/cli/src/daemon/blazegraph-docker.ts
+++ b/packages/cli/src/daemon/blazegraph-docker.ts
@@ -1,0 +1,453 @@
+/**
+ * Blazegraph Docker provisioner (RFC 120, plan PR 3 item 1).
+ *
+ * One-command Blazegraph setup for operators who already have Docker.
+ * Ported from `start_blazegraph` in [scripts/devnet.sh:254-303](../../../../scripts/devnet.sh)
+ * with three changes for the operator-facing path:
+ *
+ *  1. Hard errors instead of "warn and fall back" — the operator opted
+ *     in to Docker via the wizard / flag, so silently downgrading to
+ *     Oxigraph would be worse than failing fast.
+ *  2. Idempotent reuse — `docker inspect <name>` first; if the container
+ *     is already running with the right namespace, return its URL
+ *     without re-pulling or re-creating.
+ *  3. Port-collision auto-bump — try ports `[9999, 9999+range)`
+ *     before giving up. Operators may have V6 nodes on 9999 from
+ *     prior installs.
+ *
+ * Every external dependency (docker CLI, fetch, port-free check) is
+ * injectable so the unit tests run in <50 ms without spawning real
+ * processes or making real HTTP calls. The defaults wire up to the
+ * real `node:child_process` and `globalThis.fetch`.
+ *
+ * The "managedByDkg: true" return field is what tells chain-reset-wipe
+ * (PR 1) it's allowed to `DROP ALL` instead of running a scoped DELETE
+ * — Docker-provisioned namespaces are owned end-to-end by this CLI.
+ *
+ * The provisioner does NOT modify `scripts/devnet.sh`. The devnet
+ * loop orchestrates multiple containers across nodes 3-4 with
+ * different concerns; the namespace XML body is the only shared
+ * artifact and is exported as `BLAZEGRAPH_NAMESPACE_XML_TEMPLATE`.
+ */
+import { spawn } from 'node:child_process';
+import * as net from 'node:net';
+
+/**
+ * Shared XML template for a Blazegraph namespace tuned for DKG V10
+ * (quads enabled, no truth maintenance, no text index, no statement
+ * identifiers). Substitutes `{namespace}` for the namespace name.
+ *
+ * Mirrors the body inlined at scripts/devnet.sh:287-294. Kept here so
+ * future tweaks land in one place.
+ */
+export const BLAZEGRAPH_NAMESPACE_XML_TEMPLATE = `<?xml version="1.0" encoding="UTF-8"?>
+<properties>
+  <entry key="com.bigdata.rdf.sail.namespace">{namespace}</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.quads">true</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers">false</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.textIndex">false</entry>
+  <entry key="com.bigdata.rdf.sail.truthMaintenance">false</entry>
+</properties>`;
+
+/** Pinned image tag — matches devnet.sh and Blazegraph mainnet. */
+export const BLAZEGRAPH_IMAGE = 'lyrasis/blazegraph:2.1.5';
+
+/** Default container port that lyrasis/blazegraph exposes. */
+const BLAZEGRAPH_CONTAINER_PORT = 8080;
+
+/** Default starting host port, matches devnet.sh and Blazegraph defaults. */
+const DEFAULT_HOST_PORT_START = 9999;
+/** Inclusive range above start to scan for a free port before failing. */
+const DEFAULT_HOST_PORT_RANGE = 12; // 9999..10010
+
+// --------------------------------------------------------------------
+// Injectable types — tests pass mocks for every external boundary.
+// --------------------------------------------------------------------
+
+export interface DockerCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface DockerRunner {
+  /**
+   * Run `docker <args>`. Should NOT throw on non-zero exit — return
+   * the result so the provisioner can decide whether the failure is
+   * fatal (e.g. `docker run`) or expected (e.g. `docker inspect` on a
+   * non-existent container).
+   */
+  run(args: readonly string[], opts?: { timeoutMs?: number }): Promise<DockerCommandResult>;
+}
+
+export interface ProvisionBlazegraphDockerOptions {
+  /** Used to name the container and create the namespace inside it. */
+  namespace: string;
+  /** Override container name. Default: `dkg-blazegraph-<namespace>`. */
+  containerName?: string;
+  /** Preferred host port. Default: 9999. */
+  port?: number;
+  /** Inclusive count of ports to scan starting at `port` for collisions. */
+  portRange?: number;
+  log?: (msg: string) => void;
+  // Injectables (tests provide these; production callers omit them):
+  docker?: DockerRunner;
+  fetch?: typeof globalThis.fetch;
+  /** Returns true if no listener is bound to the given port. */
+  isPortFree?: (port: number) => Promise<boolean>;
+  /** Polling interval while waiting for /bigdata/status to respond. */
+  pollIntervalMs?: number;
+  /** Total time to wait for Blazegraph to come up. */
+  pollTimeoutMs?: number;
+}
+
+export interface ProvisionBlazegraphDockerResult {
+  url: string;
+  port: number;
+  containerName: string;
+  /**
+   * Marker for chain-reset-wipe (PR 1): a `managedByDkg: true` store
+   * may be wiped with `DROP ALL`. Always true from this function.
+   */
+  managedByDkg: true;
+  /**
+   * Whether the container was already running and re-used. Affects
+   * the wizard log ("container created" vs "reusing existing").
+   */
+  reused: boolean;
+  /**
+   * Whether the namespace was created during this run vs already
+   * present. Lets the wizard surface a useful summary line.
+   */
+  namespaceCreated: boolean;
+}
+
+// --------------------------------------------------------------------
+// Default real-world implementations of the injectables.
+// --------------------------------------------------------------------
+
+function defaultDockerRunner(): DockerRunner {
+  return {
+    run(args, opts) {
+      return new Promise<DockerCommandResult>((resolve, reject) => {
+        const child = spawn('docker', [...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (b) => { stdout += b.toString('utf-8'); });
+        child.stderr.on('data', (b) => { stderr += b.toString('utf-8'); });
+        const timeoutMs = opts?.timeoutMs;
+        const timer = timeoutMs
+          ? setTimeout(() => { child.kill('SIGKILL'); }, timeoutMs)
+          : undefined;
+        child.once('error', (err) => {
+          if (timer) clearTimeout(timer);
+          // Most common case: docker binary not installed → ENOENT.
+          // Surface a clear error rather than the cryptic spawn error.
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code === 'ENOENT') {
+            reject(new Error(
+              "docker CLI not found on PATH — install Docker Desktop or the Docker Engine and ensure 'docker' resolves on your shell PATH",
+            ));
+            return;
+          }
+          reject(err);
+        });
+        child.once('close', (exitCode) => {
+          if (timer) clearTimeout(timer);
+          resolve({ stdout, stderr, exitCode: exitCode ?? 0 });
+        });
+      });
+    },
+  };
+}
+
+async function defaultIsPortFree(port: number): Promise<boolean> {
+  // Use net.createServer instead of `lsof` so we don't shell out and
+  // we keep the check cross-platform. A successful listen → close
+  // means the port is free at this moment (TOCTOU exists but is the
+  // same race Docker itself runs into).
+  return new Promise<boolean>((resolve) => {
+    const tester = net.createServer()
+      .once('error', (err: NodeJS.ErrnoException) => {
+        // EADDRINUSE → port taken. Any other code → assume taken to be
+        // safe (e.g. EACCES on privileged ports).
+        resolve(err.code !== 'EADDRINUSE' ? false : false);
+      })
+      .once('listening', () => {
+        tester.close(() => resolve(true));
+      })
+      .listen(port, '127.0.0.1');
+  });
+}
+
+// --------------------------------------------------------------------
+// Internals
+// --------------------------------------------------------------------
+
+function sanitiseContainerName(namespace: string): string {
+  // Docker container names: [a-zA-Z0-9_.-]+. Slugify so user-provided
+  // node names like "Bob's Node" don't blow up `docker run`.
+  const slug = namespace
+    .normalize('NFKD')
+    .replace(/[^a-zA-Z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+  return `dkg-blazegraph-${slug || 'node'}`;
+}
+
+async function findFreePort(
+  start: number,
+  range: number,
+  isPortFree: (port: number) => Promise<boolean>,
+  log: (msg: string) => void,
+): Promise<number> {
+  for (let p = start; p < start + range; p++) {
+    if (await isPortFree(p)) {
+      if (p !== start) log(`  Port ${start} taken; using ${p} instead.`);
+      return p;
+    }
+  }
+  throw new Error(
+    `No free port found in the range ${start}..${start + range - 1}. ` +
+    'Close another service occupying these ports or pass --port <free port>.',
+  );
+}
+
+interface ContainerInspectInfo {
+  exists: boolean;
+  running: boolean;
+  hostPort?: number;
+}
+
+async function inspectContainer(
+  docker: DockerRunner,
+  name: string,
+): Promise<ContainerInspectInfo> {
+  // `docker inspect <name>` exits non-zero with "No such object" when
+  // the container doesn't exist; non-zero is our "doesn't exist"
+  // signal. Otherwise parse the JSON to get state + port mapping.
+  const result = await docker.run(['inspect', name]);
+  if (result.exitCode !== 0) {
+    return { exists: false, running: false };
+  }
+  try {
+    const arr = JSON.parse(result.stdout);
+    const info = Array.isArray(arr) && arr.length > 0 ? arr[0] : null;
+    if (!info) return { exists: true, running: false };
+    const running = info.State?.Running === true;
+    const portBinding = info.NetworkSettings?.Ports?.[`${BLAZEGRAPH_CONTAINER_PORT}/tcp`];
+    const hostPort = Array.isArray(portBinding) && portBinding.length > 0
+      ? Number(portBinding[0].HostPort)
+      : undefined;
+    return { exists: true, running, hostPort };
+  } catch {
+    return { exists: true, running: false };
+  }
+}
+
+/**
+ * Polls `/bigdata/status` until the server answers HTTP 200 or the
+ * timeout elapses. Mirrors the 30-attempt loop in devnet.sh but
+ * surfaces the failure as a thrown error.
+ */
+async function waitForBlazegraphReady(opts: {
+  url: string;
+  fetch: typeof globalThis.fetch;
+  intervalMs: number;
+  timeoutMs: number;
+  log: (msg: string) => void;
+}): Promise<void> {
+  const start = Date.now();
+  let attempt = 0;
+  while (Date.now() - start < opts.timeoutMs) {
+    attempt++;
+    try {
+      const r = await opts.fetch(`${opts.url}/bigdata/status`, { method: 'GET' });
+      if (r.ok) {
+        opts.log(`  Blazegraph ready after ${attempt} probe(s) (~${Math.round((Date.now() - start) / 1000)}s).`);
+        return;
+      }
+    } catch {
+      // Container not listening yet — keep polling.
+    }
+    await new Promise((res) => setTimeout(res, opts.intervalMs));
+  }
+  throw new Error(
+    `Blazegraph did not become ready within ${opts.timeoutMs}ms ` +
+    `at ${opts.url}/bigdata/status. Container started but the SPARQL endpoint is not responding.`,
+  );
+}
+
+async function namespaceExists(opts: {
+  url: string;
+  namespace: string;
+  fetch: typeof globalThis.fetch;
+}): Promise<boolean> {
+  // Blazegraph exposes per-namespace metadata at
+  // `/bigdata/namespace/<ns>/sparql/properties`. A 200 means present.
+  try {
+    const r = await opts.fetch(
+      `${opts.url}/bigdata/namespace/${encodeURIComponent(opts.namespace)}/sparql/properties`,
+      { method: 'GET' },
+    );
+    return r.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function createNamespace(opts: {
+  url: string;
+  namespace: string;
+  fetch: typeof globalThis.fetch;
+  log: (msg: string) => void;
+}): Promise<void> {
+  const body = BLAZEGRAPH_NAMESPACE_XML_TEMPLATE.replace(
+    '{namespace}',
+    opts.namespace,
+  );
+  const r = await opts.fetch(`${opts.url}/bigdata/namespace`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/xml' },
+    body,
+  });
+  if (!r.ok) {
+    let detail = '';
+    try { detail = (await r.text()).slice(0, 200); } catch { /* ignore */ }
+    throw new Error(
+      `Failed to create Blazegraph namespace "${opts.namespace}" — HTTP ${r.status}${detail ? `: ${detail}` : ''}`,
+    );
+  }
+  opts.log(`  Created Blazegraph namespace "${opts.namespace}".`);
+}
+
+// --------------------------------------------------------------------
+// Public entry point
+// --------------------------------------------------------------------
+
+export async function provisionBlazegraphDocker(
+  opts: ProvisionBlazegraphDockerOptions,
+): Promise<ProvisionBlazegraphDockerResult> {
+  const log = opts.log ?? console.log;
+  const docker = opts.docker ?? defaultDockerRunner();
+  const fetch = opts.fetch ?? globalThis.fetch;
+  const isPortFree = opts.isPortFree ?? defaultIsPortFree;
+  const pollIntervalMs = opts.pollIntervalMs ?? 1000;
+  const pollTimeoutMs = opts.pollTimeoutMs ?? 30_000;
+  const portRange = opts.portRange ?? DEFAULT_HOST_PORT_RANGE;
+  const containerName = opts.containerName ?? sanitiseContainerName(opts.namespace);
+
+  // 1. Pre-flight: is docker installed?
+  const versionResult = await docker.run(['--version'], { timeoutMs: 5000 });
+  if (versionResult.exitCode !== 0) {
+    throw new Error(
+      "docker CLI is on PATH but `docker --version` failed — ensure the Docker daemon is installed and reachable. " +
+      `stderr: ${versionResult.stderr.trim() || '(empty)'}`,
+    );
+  }
+  log(`  Docker available: ${versionResult.stdout.trim().split('\n')[0]}`);
+
+  // 2. Reuse path — is the container already running?
+  const inspectInfo = await inspectContainer(docker, containerName);
+  if (inspectInfo.exists && inspectInfo.running) {
+    const port = inspectInfo.hostPort ?? opts.port ?? DEFAULT_HOST_PORT_START;
+    const url = `http://127.0.0.1:${port}`;
+    log(`  Reusing running container "${containerName}" on port ${port}.`);
+    await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
+    const created = !(await namespaceExists({ url, namespace: opts.namespace, fetch }));
+    if (created) {
+      await createNamespace({ url, namespace: opts.namespace, fetch, log });
+    } else {
+      log(`  Namespace "${opts.namespace}" already exists.`);
+    }
+    return {
+      url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+      port,
+      containerName,
+      managedByDkg: true,
+      reused: true,
+      namespaceCreated: created,
+    };
+  }
+
+  // 3. Stopped-but-exists path — start it back up before re-creating.
+  if (inspectInfo.exists && !inspectInfo.running) {
+    log(`  Container "${containerName}" exists but is stopped; starting it.`);
+    const startResult = await docker.run(['start', containerName]);
+    if (startResult.exitCode !== 0) {
+      // Fall through to recreate — `docker start` failed for some
+      // reason (e.g. config drift); remove and start fresh.
+      log(`  docker start failed (${startResult.stderr.trim() || 'unknown'}); recreating.`);
+      await docker.run(['rm', '-f', containerName]);
+    } else {
+      const port = (await inspectContainer(docker, containerName)).hostPort
+        ?? opts.port
+        ?? DEFAULT_HOST_PORT_START;
+      const url = `http://127.0.0.1:${port}`;
+      await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
+      const created = !(await namespaceExists({ url, namespace: opts.namespace, fetch }));
+      if (created) {
+        await createNamespace({ url, namespace: opts.namespace, fetch, log });
+      } else {
+        log(`  Namespace "${opts.namespace}" already exists.`);
+      }
+      return {
+        url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+        port,
+        containerName,
+        managedByDkg: true,
+        reused: true,
+        namespaceCreated: created,
+      };
+    }
+  }
+
+  // 4. Fresh create path — choose a port and run.
+  const portStart = opts.port ?? DEFAULT_HOST_PORT_START;
+  const chosenPort = await findFreePort(portStart, portRange, isPortFree, log);
+  log(`  Starting Blazegraph container "${containerName}" on port ${chosenPort}…`);
+  const runResult = await docker.run([
+    'run',
+    '-d',
+    '--restart', 'unless-stopped',
+    '--name', containerName,
+    '-p', `${chosenPort}:${BLAZEGRAPH_CONTAINER_PORT}`,
+    BLAZEGRAPH_IMAGE,
+  ]);
+  if (runResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to start Blazegraph container — docker run exited ${runResult.exitCode}. ` +
+      `stderr: ${runResult.stderr.trim() || '(empty)'}`,
+    );
+  }
+
+  const url = `http://127.0.0.1:${chosenPort}`;
+  await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
+  await createNamespace({ url, namespace: opts.namespace, fetch, log });
+
+  return {
+    url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+    port: chosenPort,
+    containerName,
+    managedByDkg: true,
+    reused: false,
+    namespaceCreated: true,
+  };
+}
+
+/**
+ * Cheap "is docker available?" check for the wizard. Doesn't need to
+ * start anything — we just need to know whether to offer the Docker
+ * branch or skip straight to the manual-URL retry.
+ */
+export async function isDockerAvailable(
+  docker?: DockerRunner,
+): Promise<boolean> {
+  const runner = docker ?? defaultDockerRunner();
+  try {
+    const result = await runner.run(['--version'], { timeoutMs: 3000 });
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/daemon/blazegraph-docker.ts
+++ b/packages/cli/src/daemon/blazegraph-docker.ts
@@ -195,6 +195,20 @@ function sanitiseContainerName(namespace: string): string {
   return `dkg-blazegraph-${slug || 'node'}`;
 }
 
+export function normaliseBlazegraphNamespace(namespace: string): string {
+  const slug = namespace
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+  return slug || 'dkg-node';
+}
+
+function sparqlUrlForNamespace(baseUrl: string, namespace: string): string {
+  return `${baseUrl}/bigdata/namespace/${encodeURIComponent(namespace)}/sparql`;
+}
+
 async function findFreePort(
   start: number,
   range: number,
@@ -335,7 +349,11 @@ export async function provisionBlazegraphDocker(
   const pollIntervalMs = opts.pollIntervalMs ?? 1000;
   const pollTimeoutMs = opts.pollTimeoutMs ?? 30_000;
   const portRange = opts.portRange ?? DEFAULT_HOST_PORT_RANGE;
-  const containerName = opts.containerName ?? sanitiseContainerName(opts.namespace);
+  const namespace = normaliseBlazegraphNamespace(opts.namespace);
+  if (namespace !== opts.namespace) {
+    log(`  Normalized Blazegraph namespace "${opts.namespace}" → "${namespace}".`);
+  }
+  const containerName = opts.containerName ?? sanitiseContainerName(namespace);
 
   // 1. Pre-flight: is docker installed?
   const versionResult = await docker.run(['--version'], { timeoutMs: 5000 });
@@ -354,14 +372,14 @@ export async function provisionBlazegraphDocker(
     const url = `http://127.0.0.1:${port}`;
     log(`  Reusing running container "${containerName}" on port ${port}.`);
     await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
-    const created = !(await namespaceExists({ url, namespace: opts.namespace, fetch }));
+    const created = !(await namespaceExists({ url, namespace, fetch }));
     if (created) {
-      await createNamespace({ url, namespace: opts.namespace, fetch, log });
+      await createNamespace({ url, namespace, fetch, log });
     } else {
-      log(`  Namespace "${opts.namespace}" already exists.`);
+      log(`  Namespace "${namespace}" already exists.`);
     }
     return {
-      url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+      url: sparqlUrlForNamespace(url, namespace),
       port,
       containerName,
       managedByDkg: true,
@@ -385,14 +403,14 @@ export async function provisionBlazegraphDocker(
         ?? DEFAULT_HOST_PORT_START;
       const url = `http://127.0.0.1:${port}`;
       await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
-      const created = !(await namespaceExists({ url, namespace: opts.namespace, fetch }));
+      const created = !(await namespaceExists({ url, namespace, fetch }));
       if (created) {
-        await createNamespace({ url, namespace: opts.namespace, fetch, log });
+        await createNamespace({ url, namespace, fetch, log });
       } else {
-        log(`  Namespace "${opts.namespace}" already exists.`);
+        log(`  Namespace "${namespace}" already exists.`);
       }
       return {
-        url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+        url: sparqlUrlForNamespace(url, namespace),
         port,
         containerName,
         managedByDkg: true,
@@ -423,10 +441,10 @@ export async function provisionBlazegraphDocker(
 
   const url = `http://127.0.0.1:${chosenPort}`;
   await waitForBlazegraphReady({ url, fetch, intervalMs: pollIntervalMs, timeoutMs: pollTimeoutMs, log });
-  await createNamespace({ url, namespace: opts.namespace, fetch, log });
+  await createNamespace({ url, namespace, fetch, log });
 
   return {
-    url: `${url}/bigdata/namespace/${opts.namespace}/sparql`,
+    url: sparqlUrlForNamespace(url, namespace),
     port: chosenPort,
     containerName,
     managedByDkg: true,

--- a/packages/cli/src/daemon/chain-reset-wipe.ts
+++ b/packages/cli/src/daemon/chain-reset-wipe.ts
@@ -53,14 +53,62 @@
  */
 import { existsSync, readFileSync, writeFileSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import { isExternalBackend, getSparqlEndpoint } from '@origintrail-official/dkg-storage';
 
 const STATE_FILE = '.network-state.json';
 
 interface PersistedNetworkState {
   /** Last chainResetMarker value the daemon booted on. */
   chainResetMarker: string | null;
+  /**
+   * Last triple-store backend the daemon booted on. Used by
+   * `detectBackendSwitch` to warn loudly when an operator hand-edits
+   * `config.store.backend` between boots — the new backend is fresh
+   * and empty, so silently booting would mean stale SWM/VM data is
+   * inaccessible. `null` on legacy state files (pre-RFC 120) and on
+   * first boot. (RFC 120 review point #6.)
+   */
+  lastBackend?: string | null;
   savedAt: number;
 }
+
+/**
+ * Subset of `DkgConfig['store']` used by the wipe step to talk to an
+ * external SPARQL endpoint. Decoupled from the CLI's config types so
+ * this module stays free of upward dependencies.
+ */
+export interface ChainResetWipeStoreConfig {
+  backend: string;
+  options?: {
+    url?: string;
+    queryEndpoint?: string;
+    updateEndpoint?: string;
+    auth?: string;
+    /**
+     * True when the namespace was provisioned by the CLI (PR 3 Docker
+     * convenience path). Operator-provided URLs default to false; the
+     * wipe then scopes deletes to the V10 named-graph prefix to avoid
+     * clobbering V6/V8 data sharing the same Blazegraph instance.
+     */
+    managedByDkg?: boolean;
+  };
+}
+
+/**
+ * V10 named-graph prefix. Every context-graph the agent writes — meta,
+ * shared-memory, finalisation — is rooted at `did:dkg:context-graph:`
+ * (confirmed in core/genesis.ts + finalization-handler.ts + dkg-agent.ts).
+ * Scoped DELETE for operator-provided external endpoints filters on this
+ * prefix to leave non-V10 data (V6/V8 assertions, operator side
+ * projects) alone.
+ */
+const V10_GRAPH_PREFIX = 'did:dkg:context-graph:';
+
+const SPARQL_DROP_ALL = 'DROP ALL';
+const SPARQL_SCOPED_DELETE =
+  'DELETE { GRAPH ?g { ?s ?p ?o } } ' +
+  'WHERE { GRAPH ?g { ?s ?p ?o } ' +
+  `FILTER(strstarts(str(?g), "${V10_GRAPH_PREFIX}")) }`;
 
 export interface ChainResetWipeResult {
   /** True when a wipe was performed. */
@@ -94,6 +142,19 @@ export interface ChainResetWipeOptions {
    * Falsy → fall back to `dataDir/random-sampling.wal` (the default).
    */
   randomSamplingWalPath?: string;
+  /**
+   * Operator's `config.store` block. Required to wipe an external SPARQL
+   * endpoint when the backend is `blazegraph` / `sparql-http`. Local
+   * backends ignore this field.
+   */
+  storeConfig?: ChainResetWipeStoreConfig;
+  /**
+   * Override for the SPARQL HTTP transport. Tests inject a mock to
+   * assert the issued UPDATE body; defaults to `globalThis.fetch`.
+   * Kept on the options surface (rather than module-scope monkey-patch)
+   * so parallel test cases don't race.
+   */
+  fetch?: typeof globalThis.fetch;
   /** Optional logger. Defaults to no-op so the function is silent in tests by default. */
   log?: (msg: string) => void;
 }
@@ -110,14 +171,94 @@ function loadState(dataDir: string): PersistedNetworkState | null {
 }
 
 function saveState(dataDir: string, marker: string | null): void {
+  // Preserve any sibling fields (lastBackend) that `detectBackendSwitch`
+  // may have written. Otherwise a chain-reset wipe would clobber a
+  // freshly-recorded backend tag and the next boot would re-warn.
+  const existing = loadState(dataDir) ?? { chainResetMarker: null, savedAt: 0 };
   writeFileSync(
     join(dataDir, STATE_FILE),
     JSON.stringify(
-      { chainResetMarker: marker, savedAt: Date.now() } satisfies PersistedNetworkState,
+      {
+        ...existing,
+        chainResetMarker: marker,
+        savedAt: Date.now(),
+      } satisfies PersistedNetworkState,
       null,
       2,
     ),
   );
+}
+
+function saveBackendTag(dataDir: string, backend: string): void {
+  const existing = loadState(dataDir) ?? { chainResetMarker: null, savedAt: 0 };
+  writeFileSync(
+    join(dataDir, STATE_FILE),
+    JSON.stringify(
+      {
+        ...existing,
+        lastBackend: backend,
+        savedAt: Date.now(),
+      } satisfies PersistedNetworkState,
+      null,
+      2,
+    ),
+  );
+}
+
+/**
+ * Wipe the V10 data sitting in an external SPARQL endpoint. Runs after
+ * the local file wipe so we don't strand the operator with a wiped FS
+ * but a populated remote namespace (or vice versa).
+ *
+ * - `managedByDkg === true` → `DROP ALL`. Safe because the namespace
+ *   was provisioned by the CLI and nobody else writes to it.
+ * - otherwise → scoped DELETE filtered by `did:dkg:context-graph:`. The
+ *   operator may be sharing the instance with V6/V8 nodes or unrelated
+ *   data; the wipe must leave anything that isn't V10 alone.
+ */
+async function performExternalWipe(
+  storeConfig: ChainResetWipeStoreConfig,
+  fetchImpl: typeof globalThis.fetch,
+  log: (msg: string) => void,
+): Promise<{ label: string; ok: boolean; error?: string }> {
+  const { updateUrl, headers } = getSparqlEndpoint({
+    backend: storeConfig.backend,
+    options: storeConfig.options,
+  });
+  const managed = storeConfig.options?.managedByDkg === true;
+  const update = managed ? SPARQL_DROP_ALL : SPARQL_SCOPED_DELETE;
+  const label = managed
+    ? `<sparql:drop-all ${updateUrl}>`
+    : `<sparql:scoped-delete ${updateUrl}>`;
+
+  log(
+    managed
+      ? `  external store (DKG-managed namespace): issuing DROP ALL against ${updateUrl}`
+      : `  external store (operator-provided URL): issuing scoped DELETE for "${V10_GRAPH_PREFIX}…" graphs against ${updateUrl}`,
+  );
+
+  try {
+    const res = await fetchImpl(updateUrl, {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `update=${encodeURIComponent(update)}`,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      const error = `${res.status} ${res.statusText}: ${text.slice(0, 200)}`;
+      log(`  WARN: external wipe failed: ${error}`);
+      return { label, ok: false, error };
+    }
+    log(`  removed: ${label}`);
+    return { label, ok: true };
+  } catch (err) {
+    const error = (err as Error).message;
+    log(`  WARN: external wipe transport error: ${error}`);
+    return { label, ok: false, error };
+  }
 }
 
 function performWipe(
@@ -183,8 +324,11 @@ function performWipe(
   return { removedFiles, failedFiles };
 }
 
-export function chainResetWipe(opts: ChainResetWipeOptions): ChainResetWipeResult {
+export async function chainResetWipe(
+  opts: ChainResetWipeOptions,
+): Promise<ChainResetWipeResult> {
   const log = opts.log ?? (() => {});
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
 
   // Networks that haven't opted in: hook is a no-op. No state file is
   // touched so we don't accidentally turn on the protocol later just
@@ -231,6 +375,27 @@ export function chainResetWipe(opts: ChainResetWipeOptions): ChainResetWipeResul
     );
   }
 
+  // External SPARQL wipe runs AFTER local file wipe. We don't gate one
+  // on the other — both wipes attempt independently so an operator with
+  // a flaky external endpoint still gets a clean local state and a
+  // failedFiles entry that retries on next boot. Wrapped in try/catch
+  // because helper construction (URL extraction) can throw on malformed
+  // config; we want to surface that as a failedFile, not crash the boot.
+  if (opts.storeConfig && isExternalBackend(opts.storeConfig.backend)) {
+    try {
+      const result = await performExternalWipe(opts.storeConfig, fetchImpl, log);
+      if (result.ok) {
+        removedFiles.push(result.label);
+      } else {
+        failedFiles.push({ file: result.label, error: result.error ?? 'unknown' });
+      }
+    } catch (err) {
+      const message = (err as Error).message;
+      failedFiles.push({ file: '<external-wipe>', error: message });
+      log(`WARN: external SPARQL wipe failed to start: ${message}.`);
+    }
+  }
+
   if (failedFiles.length === 0) {
     try {
       saveState(opts.dataDir, opts.currentMarker);
@@ -255,4 +420,124 @@ export function chainResetWipe(opts: ChainResetWipeOptions): ChainResetWipeResul
   }
 
   return { wiped: true, prevMarker, removedFiles, failedFiles };
+}
+
+// =====================================================================
+// Backend switch detection (RFC 120 review point #6)
+// =====================================================================
+//
+// Switching from Oxigraph to Blazegraph (or vice versa) mid-flight means
+// the new backend is fresh and empty — all SWM / VM data from the
+// previous backend is unreachable. The chain-reset-wipe marker doesn't
+// move when only the backend changes, so without a separate signal the
+// daemon would silently boot on an empty store and the operator would
+// see vanished context graphs with no explanation.
+//
+// This check runs at boot, BEFORE config validation / health probe /
+// chain-reset wipe. Outcomes:
+//   - First boot (no persisted lastBackend): silently record current.
+//   - Match: silently re-record (handles legacy state files that lacked
+//     the field).
+//   - Mismatch + `acceptStoreReset === true`: log warning, record new.
+//   - Mismatch + no override: log multi-line warning, return aborted.
+//     Caller (lifecycle) exits the process.
+//
+// `acceptStoreReset` is controlled by the env var
+// `DKG_ACCEPT_STORE_RESET=1`. A CLI flag on `dkg start` would also work
+// but env keeps the boot entrypoint flat; operators set the env once,
+// restart the daemon, then unset.
+
+export interface BackendSwitchDetectOptions {
+  dataDir: string;
+  /**
+   * Backend name from the current config. Pass the effective value
+   * including the default — e.g. when `config.store?.backend` is
+   * undefined, callers should pass `'oxigraph-worker'` so the check
+   * is symmetric across "no store block" ↔ "explicit store block".
+   */
+  currentBackend: string;
+  /**
+   * Operator opt-in to proceed despite a backend change. Sourced from
+   * `process.env.DKG_ACCEPT_STORE_RESET === '1'` in production; tests
+   * inject explicitly.
+   */
+  acceptStoreReset: boolean;
+  log?: (msg: string) => void;
+}
+
+export interface BackendSwitchDetectResult {
+  /** True when `lastBackend` was recorded and differs from `currentBackend`. */
+  changed: boolean;
+  /** Previously-recorded backend, or null if none / legacy state file. */
+  previous: string | null;
+  /** Effective current backend (passed through for callers). */
+  current: string;
+  /**
+   * True when the daemon should abort boot. Set on `changed && !acceptStoreReset`.
+   * Caller exits the process so the operator can either flip the env
+   * var or revert their config edit.
+   */
+  aborted: boolean;
+}
+
+export function detectBackendSwitch(
+  opts: BackendSwitchDetectOptions,
+): BackendSwitchDetectResult {
+  const log = opts.log ?? (() => {});
+  const prev = loadState(opts.dataDir);
+  const previous =
+    typeof prev?.lastBackend === 'string' && prev.lastBackend.length > 0
+      ? prev.lastBackend
+      : null;
+
+  // First boot or legacy state file: silently record and move on. We
+  // explicitly do NOT treat null-previous as a "switch from
+  // oxigraph-worker"; that would re-warn every operator who upgrades
+  // into this release without ever having touched their store
+  // configuration. Only operator-visible config changes between two
+  // recorded backends count as a switch.
+  if (previous === null) {
+    try {
+      saveBackendTag(opts.dataDir, opts.currentBackend);
+    } catch {
+      // Non-fatal: if we can't write the tag now, we'll try again next
+      // boot. The downside is one missed early-warning window.
+    }
+    return { changed: false, previous: null, current: opts.currentBackend, aborted: false };
+  }
+
+  if (previous === opts.currentBackend) {
+    return { changed: false, previous, current: opts.currentBackend, aborted: false };
+  }
+
+  // Mismatch.
+  const warningHeader = [
+    `[STORE-SWITCH] triple-store backend changed since last boot:`,
+    `  previous: ${previous}`,
+    `  current:  ${opts.currentBackend}`,
+    ``,
+    `The new backend is a fresh store. Any context graphs, shared`,
+    `memory, or finalised assertions held only in the previous backend`,
+    `are NOT migrated and will be inaccessible until you either:`,
+    `  - revert config.store.backend to "${previous}", or`,
+    `  - accept the data loss by setting DKG_ACCEPT_STORE_RESET=1 in`,
+    `    the environment and restarting.`,
+  ].join('\n');
+
+  if (!opts.acceptStoreReset) {
+    log(warningHeader);
+    log(``);
+    log(`Refusing to start: set DKG_ACCEPT_STORE_RESET=1 to proceed.`);
+    return { changed: true, previous, current: opts.currentBackend, aborted: true };
+  }
+
+  log(warningHeader);
+  log(``);
+  log(`DKG_ACCEPT_STORE_RESET=1 set — proceeding with the new backend.`);
+  try {
+    saveBackendTag(opts.dataDir, opts.currentBackend);
+  } catch (err) {
+    log(`WARN: failed to persist new backend tag: ${(err as Error).message}. Will re-warn on next boot.`);
+  }
+  return { changed: true, previous, current: opts.currentBackend, aborted: false };
 }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -59,6 +59,7 @@ import {
   type ApprovalPolicy,
 } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
+import { isExternalBackend } from '@origintrail-official/dkg-storage';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import {
@@ -110,6 +111,7 @@ import {
   resolveAutoUpdateSource,
   slotEntryPoint,
   CLI_NPM_PACKAGE,
+  exitOnStoreConfigErrors,
 } from '../config.js';
 import { createPublicSnapshotStore, createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
@@ -255,7 +257,13 @@ import {
   performNpmUpdate,
   performNpmUpdateEdge,
 } from './auto-update.js';
-import { chainResetWipe } from './chain-reset-wipe.js';
+import { chainResetWipe, detectBackendSwitch } from './chain-reset-wipe.js';
+import {
+  checkExternalStoreReachable,
+  checkOrSetStoreIdentity,
+  formatHealthCheckFailure,
+  formatIdentityTagMismatch,
+} from './store-health-check.js';
 import { resetNatStatus, startNatStatusWatcher } from './nat-status.js';
 import {
   OPENCLAW_UI_CONNECT_TIMEOUT_MS,
@@ -835,13 +843,84 @@ export async function runDaemonInner(
   // detects the change and wipes the now-orphaned chain state.
   // Operator's keystore + dashboard DB + uploaded files are preserved.
   // See docs/TESTNET_RESET.md and packages/cli/src/daemon/chain-reset-wipe.ts.
-  const wipeResult = chainResetWipe({
+  // Detect backend switch first. If the operator hand-edited
+  // store.backend between boots, refuse to start unless they opt in
+  // via DKG_ACCEPT_STORE_RESET=1. The new backend is fresh — any data
+  // held in the previous one is invisible to this boot. Booting
+  // silently would look like data loss to the operator.
+  const backendSwitch = detectBackendSwitch({
+    dataDir: dkgDir(),
+    currentBackend: config.store?.backend ?? 'oxigraph-worker',
+    acceptStoreReset: process.env.DKG_ACCEPT_STORE_RESET === '1',
+    log,
+  });
+  if (backendSwitch.aborted) {
+    process.exit(1);
+  }
+
+  // Refuse to start on invalid external-backend config (missing URL,
+  // missing blob/snapshot directory). This fires before the health
+  // check so operators see a single-line config error, not a confusing
+  // probe failure when the URL is just plain absent.
+  exitOnStoreConfigErrors(config, log);
+
+  // External triple-store backends (Blazegraph, sparql-http) get a
+  // boot-time reachability probe before anything that depends on them
+  // runs. We want operators who misconfigure the URL to see an
+  // actionable error within seconds — not a confusing failure deep in
+  // agent boot after we've already partially wiped local state.
+  //
+  // Sequencing: this fires BEFORE chainResetWipe so a marker bump
+  // against an unreachable endpoint doesn't strand the operator with
+  // wiped local files but stale remote data; we'd rather not start at
+  // all and let them fix the URL.
+  if (isExternalBackend(config.store?.backend)) {
+    const health = await checkExternalStoreReachable({
+      storeConfig: config.store,
+    });
+    if (!health.ok) {
+      log(formatHealthCheckFailure(health));
+      process.exit(1);
+    }
+    log(
+      `External triple-store reachable: ${health.backend} ${health.endpoint}`,
+    );
+
+    // Namespace identity check (RFC 120, plan PR 3 item 3). Refuses to
+    // start if another DKG node has already booted against this same
+    // namespace — without this, two daemons sharing one Blazegraph
+    // namespace silently corrupt each other. Fires BEFORE
+    // chainResetWipe so a mismatched tag never triggers a wipe of
+    // someone else's data.
+    const identity = await checkOrSetStoreIdentity({
+      storeConfig: config.store,
+      nodeName: config.name,
+    });
+    if (!identity.ok) {
+      if (identity.action === 'mismatch') {
+        log(formatIdentityTagMismatch(identity));
+      } else {
+        log(`[STORE-IDENTITY] failed to verify namespace ownership: ${identity.error}`);
+      }
+      process.exit(1);
+    }
+    if (identity.action === 'tagged') {
+      log(`Tagged triple-store namespace for node "${identity.nodeName}".`);
+    }
+  }
+
+  const wipeResult = await chainResetWipe({
     dataDir: dkgDir(),
     currentMarker: network?.chainResetMarker,
     // Honour operator's `randomSampling.walPath` override; the prover
     // writes its WAL there, so a fresh chain reset must wipe that file
     // (not the default ~/.dkg/random-sampling.wal which would be empty).
     randomSamplingWalPath: config.randomSampling?.walPath,
+    // For external triple-store backends, the wipe extends from local
+    // files to a SPARQL DROP/DELETE on the remote endpoint; otherwise
+    // operators with a chain-reset marker bump would keep stale V10 data
+    // in Blazegraph / sparql-http even after the local store.nq is gone.
+    storeConfig: config.store,
     log,
   });
   if (wipeResult.wiped) {
@@ -1693,6 +1772,14 @@ export async function runDaemonInner(
       return parseRdfInt(r?.bindings?.[0]?.c);
     },
     getStoreBytes: async () => {
+      // External SPARQL backends own no local file; `null` is the
+      // correct signal here (returning 0 misleads operators into
+      // thinking the store is empty). Quad count is exposed on
+      // demand via /api/status instead — too expensive to compute
+      // on the metrics tick. (RFC 120, plan PR 1 item 2.)
+      if (isExternalBackend(config.store?.backend)) {
+        return null;
+      }
       try {
         const s = await stat(join(dkgDir(), "store.nq"));
         return s.size;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -928,6 +928,26 @@ export async function runDaemonInner(
       `Chain-state auto-wipe complete: ${wipeResult.removedFiles.length} file(s) removed ` +
       `(prev marker: ${wipeResult.prevMarker ?? '<none>'}, now: ${network?.chainResetMarker})`,
     );
+    // A DKG-managed external wipe uses DROP ALL, which also removes the
+    // namespace ownership tag verified above. Re-tag before continuing so
+    // this daemon never runs against an unclaimed namespace.
+    if (isExternalBackend(config.store?.backend)) {
+      const identity = await checkOrSetStoreIdentity({
+        storeConfig: config.store,
+        nodeName: config.name,
+      });
+      if (!identity.ok) {
+        if (identity.action === 'mismatch') {
+          log(formatIdentityTagMismatch(identity));
+        } else {
+          log(`[STORE-IDENTITY] failed to re-tag namespace after wipe: ${identity.error}`);
+        }
+        process.exit(1);
+      }
+      if (identity.action === 'tagged') {
+        log(`Re-tagged triple-store namespace for node "${identity.nodeName}" after chain-state wipe.`);
+      }
+    }
   }
 
   // Load admin + operational wallets from ~/.dkg/wallets.json (auto-generated on first run)

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -57,6 +57,7 @@ const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter, resolveRpcUrls } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
+import { isExternalBackend } from '@origintrail-official/dkg-storage';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import {
@@ -402,6 +403,53 @@ function createRouteEvmProvider(rpcUrl: string, rpcUrls?: string[]): ethers.Json
   );
 }
 
+// Quad-count cache for external SPARQL backends. Every /api/status hit
+// otherwise issues a `SELECT (COUNT(*))` against the remote endpoint —
+// expensive on a large namespace, and the route is polled by the
+// dashboard, telemetry, and `dkg status` operators. 30 s TTL is short
+// enough that a fresh wipe / bulk publish shows up quickly without
+// flooding Blazegraph. Local backends bypass this entirely (file-bytes
+// metric stays on the metrics collector tick).
+const STORE_QUADS_CACHE_TTL_MS = 30_000;
+let storeQuadsCache: { value: number | null; fetchedAt: number } | null = null;
+let storeQuadsInflight: Promise<number | null> | null = null;
+
+async function getCachedExternalStoreQuads(
+  agent: DKGAgent,
+  now: number,
+): Promise<number | null> {
+  if (storeQuadsCache && now - storeQuadsCache.fetchedAt < STORE_QUADS_CACHE_TTL_MS) {
+    return storeQuadsCache.value;
+  }
+  if (storeQuadsInflight) return storeQuadsInflight;
+
+  storeQuadsInflight = (async () => {
+    try {
+      const r = await agent.store.query(
+        'SELECT (COUNT(*) AS ?c) WHERE { GRAPH ?g { ?s ?p ?o } }',
+      );
+      let value: number | null = null;
+      if (r.type === 'bindings' && r.bindings.length > 0) {
+        const cell = r.bindings[0].c ?? '';
+        const digits = cell.match(/\d+/)?.[0];
+        value = digits ? parseInt(digits, 10) : 0;
+      }
+      storeQuadsCache = { value, fetchedAt: Date.now() };
+      return value;
+    } catch {
+      // Surface "unknown" rather than a stale value; operators can
+      // distinguish unreachable from genuinely-empty via storeBackend +
+      // their network logs. Cache the null briefly to avoid hammering
+      // a flapping endpoint.
+      storeQuadsCache = { value: null, fetchedAt: Date.now() };
+      return null;
+    } finally {
+      storeQuadsInflight = null;
+    }
+  })();
+  return storeQuadsInflight;
+}
+
 async function getRegistryCacheSnapshot(): Promise<RegistryCacheSnapshot> {
   const now = Date.now();
   if (registryCache && now - registryCache.fetchedAt < REGISTRY_CACHE_TTL_MS) {
@@ -607,6 +655,21 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       networkId: networkId.slice(0, 16),
       networkName: network?.networkName ?? null,
       storeBackend: config.store?.backend ?? "oxigraph-worker",
+      // External backend visibility (RFC 120 / plan PR 1 item 3). For
+      // local backends both fields stay null so the response shape is
+      // stable across deployments.
+      storeUrl: isExternalBackend(config.store?.backend)
+        ? (() => {
+            const opts = (config.store?.options ?? {}) as Record<string, unknown>;
+            const url = typeof opts.url === 'string' ? opts.url
+              : typeof opts.queryEndpoint === 'string' ? opts.queryEndpoint
+              : null;
+            return url;
+          })()
+        : null,
+      storeQuads: isExternalBackend(config.store?.backend)
+        ? await getCachedExternalStoreQuads(agent, Date.now())
+        : null,
       uptimeMs: Date.now() - startedAt,
       connectedPeers: uniquePeers.size,
       connections: {

--- a/packages/cli/src/daemon/store-health-check.ts
+++ b/packages/cli/src/daemon/store-health-check.ts
@@ -1,0 +1,408 @@
+/**
+ * Boot-time reachability probe for external SPARQL endpoints.
+ *
+ * # Why this exists
+ *
+ * When an operator points the daemon at an external triple-store backend
+ * (`store.backend === 'blazegraph'` or `'sparql-http'`), the daemon's
+ * useful surface — publish, query, agent identity loading, finalisation —
+ * all depend on that endpoint being reachable. Without an early probe, a
+ * misconfigured URL or unreachable server fails much later, deep inside
+ * the agent's first SPARQL call, with a stack trace that doesn't include
+ * the URL. Operators see "EHOSTUNREACH" in their logs and have to read
+ * the daemon source to figure out what was being contacted.
+ *
+ * This probe runs synchronously before the agent boots, fails fast with
+ * an actionable message that names the endpoint, and exits the daemon
+ * cleanly. The boot-time exit policy lives in the caller (lifecycle), not
+ * here — this module just answers "is the endpoint reachable, and if not
+ * why?".
+ *
+ * # Design
+ *
+ * - For local backends: returns `{ ok: true }` without I/O. Always safe
+ *   to call regardless of store configuration; centralising the
+ *   backend-class branch here lets callers be unconditional.
+ * - For external backends: constructs a transient `BlazegraphStore` /
+ *   `SparqlHttpStore` directly via the adapter factory, issues
+ *   `ASK { ?s ?p ?o }` with an `AbortController` timeout, returns
+ *   ok/error. The transient store is closed immediately — we don't keep
+ *   it around as the agent will create its own.
+ * - Error wrapping: HTTP 404 commonly indicates the namespace doesn't
+ *   exist (Blazegraph), not that the server is down. We surface that
+ *   case explicitly because the recovery is different (create namespace
+ *   vs check network), and the operator otherwise has to know
+ *   Blazegraph protocol details to diagnose it.
+ *
+ * # Plan reference
+ *
+ * `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 1 item 4.
+ * Sequencing in lifecycle: marker comparison → this probe (if external) →
+ * `chainResetWipe` → agent boot. Health check fires before wipe so we
+ * don't strand the operator with a partial state after the local file
+ * wipe but a SPARQL wipe that can't run.
+ */
+import { isExternalBackend, getSparqlEndpoint } from '@origintrail-official/dkg-storage';
+
+export interface StoreHealthCheckOptions {
+  storeConfig:
+    | {
+        backend: string;
+        options?: Record<string, unknown>;
+      }
+    | undefined;
+  /** Probe timeout in milliseconds. Defaults to 5_000. */
+  timeoutMs?: number;
+  /**
+   * Override for the SPARQL HTTP transport. Tests inject a mock to
+   * exercise reachable / unreachable / 404-namespace-missing branches;
+   * defaults to `globalThis.fetch`.
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface StoreHealthCheckResult {
+  ok: boolean;
+  /** Always populated for external backends, regardless of ok. */
+  endpoint?: string;
+  /** Backend name passed through for log-formatting convenience. */
+  backend?: string;
+  /** Human-readable failure reason. Undefined on success. */
+  error?: string;
+  /**
+   * True when the probe surfaced an HTTP 404, which typically indicates
+   * the namespace doesn't exist on the SPARQL server (Blazegraph) rather
+   * than the server being down. Callers use this to bias the error
+   * message towards "create the namespace" rather than "fix the
+   * network".
+   */
+  namespaceMissing?: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export async function checkExternalStoreReachable(
+  opts: StoreHealthCheckOptions,
+): Promise<StoreHealthCheckResult> {
+  if (!isExternalBackend(opts.storeConfig?.backend)) {
+    return { ok: true };
+  }
+
+  let endpoint: ReturnType<typeof getSparqlEndpoint>;
+  try {
+    endpoint = getSparqlEndpoint({
+      backend: opts.storeConfig!.backend,
+      options: opts.storeConfig!.options,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      backend: opts.storeConfig?.backend,
+      error: (err as Error).message,
+    };
+  }
+
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetchImpl(endpoint.queryUrl, {
+      method: 'POST',
+      headers: {
+        ...endpoint.headers,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/sparql-results+json',
+      },
+      body: `query=${encodeURIComponent('ASK { ?s ?p ?o }')}`,
+      signal: controller.signal,
+    });
+
+    if (res.ok) {
+      // We don't parse the body — a 200 with any body shape proves the
+      // endpoint speaks SPARQL Protocol well enough to answer.
+      return {
+        ok: true,
+        backend: opts.storeConfig!.backend,
+        endpoint: endpoint.queryUrl,
+      };
+    }
+
+    // 404 deserves a specific message because the fix is different from
+    // a network failure. Blazegraph returns 404 when the namespace path
+    // doesn't exist (e.g. operator wrote `…/namespace/mynode/sparql`
+    // before running `dkg init`'s Docker provisioner that creates the
+    // `mynode` namespace).
+    if (res.status === 404) {
+      return {
+        ok: false,
+        backend: opts.storeConfig!.backend,
+        endpoint: endpoint.queryUrl,
+        namespaceMissing: true,
+        error:
+          `endpoint returned 404 — namespace likely doesn't exist. ` +
+          `Create it via the Blazegraph UI / API or use the Docker convenience path (dkg init).`,
+      };
+    }
+
+    const text = await res.text().catch(() => '');
+    return {
+      ok: false,
+      backend: opts.storeConfig!.backend,
+      endpoint: endpoint.queryUrl,
+      error: `HTTP ${res.status} ${res.statusText}: ${text.slice(0, 200)}`,
+    };
+  } catch (err) {
+    const message = (err as Error).message ?? String(err);
+    const isAbort = (err as Error).name === 'AbortError' || /aborted/i.test(message);
+    return {
+      ok: false,
+      backend: opts.storeConfig!.backend,
+      endpoint: endpoint.queryUrl,
+      error: isAbort
+        ? `timed out after ${timeoutMs}ms`
+        : `transport error: ${message}`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ====================================================================
+// Namespace identity tagging (RFC 120, plan PR 3 item 3)
+// ====================================================================
+//
+// Why this exists
+// ---------------
+// Two daemons pointed at the same Blazegraph namespace would silently
+// stomp on each other's data — the named-graph prefix scoping in
+// chain-reset-wipe protects against V6/V8 collisions but doesn't help
+// when two DKG nodes share a namespace. RFC 120 review point #5.
+//
+// The fix is a single triple inside a reserved named graph
+// `<urn:dkg:store-meta>` that records the first node name that booted
+// against this namespace. On every subsequent boot the daemon checks
+// for it and:
+//   - missing: writes it (first boot or operator's reset path).
+//   - matches `config.name`: proceeds silently.
+//   - mismatch: exits with an actionable message naming the other
+//     node so the operator knows which daemon to relocate.
+//
+// Skipped entirely for local backends (no concurrent-access risk — the
+// Oxigraph file is operator-owned).
+
+const STORE_META_GRAPH = 'urn:dkg:store-meta';
+const STORE_META_SUBJECT = 'urn:dkg:store-tag';
+const STORE_META_PREDICATE = 'urn:dkg:storeTaggedFor';
+
+export interface StoreIdentityTagOptions {
+  storeConfig:
+    | {
+        backend: string;
+        options?: Record<string, unknown>;
+      }
+    | undefined;
+  /** Operator-chosen node name from `~/.dkg/config.json`. */
+  nodeName: string;
+  fetch?: typeof globalThis.fetch;
+  /** Probe timeout in milliseconds. Defaults to 5_000. */
+  timeoutMs?: number;
+}
+
+export type StoreIdentityTagResult =
+  | { ok: true; action: 'skipped'; reason: 'local-backend' | 'unknown-backend' }
+  | { ok: true; action: 'matched'; nodeName: string }
+  | { ok: true; action: 'tagged'; nodeName: string }
+  | { ok: false; action: 'mismatch'; existingNodeName: string; expectedNodeName: string; error: string }
+  | { ok: false; action: 'transport-error'; error: string };
+
+/**
+ * Read the existing identity tag (if any) and either accept it, write
+ * a new one, or refuse to start on mismatch.
+ *
+ * Implemented with raw fetch against the SPARQL Query / Update
+ * endpoints so it doesn't need the agent runtime — runs as part of
+ * boot before the agent exists.
+ */
+export async function checkOrSetStoreIdentity(
+  opts: StoreIdentityTagOptions,
+): Promise<StoreIdentityTagResult> {
+  if (!isExternalBackend(opts.storeConfig?.backend)) {
+    return { ok: true, action: 'skipped', reason: 'local-backend' };
+  }
+
+  let endpoint: ReturnType<typeof getSparqlEndpoint>;
+  try {
+    endpoint = getSparqlEndpoint({
+      backend: opts.storeConfig!.backend,
+      options: opts.storeConfig!.options,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      action: 'transport-error',
+      error: (err as Error).message,
+    };
+  }
+
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // 1. SELECT the existing tag value (if any).
+  const selectQuery =
+    `SELECT ?name WHERE { GRAPH <${STORE_META_GRAPH}> { ` +
+    `<${STORE_META_SUBJECT}> <${STORE_META_PREDICATE}> ?name } }`;
+  const selectController = new AbortController();
+  const selectTimer = setTimeout(() => selectController.abort(), timeoutMs);
+  let existing: string | null;
+  try {
+    const res = await fetchImpl(endpoint.queryUrl, {
+      method: 'POST',
+      headers: {
+        ...endpoint.headers,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/sparql-results+json',
+      },
+      body: `query=${encodeURIComponent(selectQuery)}`,
+      signal: selectController.signal,
+    });
+    if (!res.ok) {
+      return {
+        ok: false,
+        action: 'transport-error',
+        error: `identity SELECT returned HTTP ${res.status} ${res.statusText}`,
+      };
+    }
+    const body = await res.json().catch(() => null) as
+      | { results?: { bindings?: Array<{ name?: { value?: string } }> } }
+      | null;
+    const binding = body?.results?.bindings?.[0]?.name?.value;
+    existing = typeof binding === 'string' && binding.length > 0 ? binding : null;
+  } catch (err) {
+    return {
+      ok: false,
+      action: 'transport-error',
+      error: `identity SELECT failed: ${(err as Error).message}`,
+    };
+  } finally {
+    clearTimeout(selectTimer);
+  }
+
+  // 2a. Match: nothing to do.
+  if (existing != null && existing === opts.nodeName) {
+    return { ok: true, action: 'matched', nodeName: existing };
+  }
+
+  // 2b. Mismatch: refuse to start.
+  if (existing != null && existing !== opts.nodeName) {
+    return {
+      ok: false,
+      action: 'mismatch',
+      existingNodeName: existing,
+      expectedNodeName: opts.nodeName,
+      error:
+        `this triple-store is already tagged for node "${existing}". ` +
+        `This node is "${opts.nodeName}". Two daemons can't safely share one namespace — ` +
+        `pick a different namespace, or clear the tag with: ` +
+        `DELETE WHERE { GRAPH <${STORE_META_GRAPH}> { <${STORE_META_SUBJECT}> <${STORE_META_PREDICATE}> ?n } }`,
+    };
+  }
+
+  // 3. Tag-missing path: INSERT the tag.
+  const updateQuery =
+    `INSERT DATA { GRAPH <${STORE_META_GRAPH}> { ` +
+    `<${STORE_META_SUBJECT}> <${STORE_META_PREDICATE}> "${escapeSparqlLiteral(opts.nodeName)}" ` +
+    `} }`;
+  const updateController = new AbortController();
+  const updateTimer = setTimeout(() => updateController.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(endpoint.updateUrl, {
+      method: 'POST',
+      headers: {
+        ...endpoint.headers,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `update=${encodeURIComponent(updateQuery)}`,
+      signal: updateController.signal,
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      return {
+        ok: false,
+        action: 'transport-error',
+        error: `identity INSERT returned HTTP ${res.status}: ${detail.slice(0, 200)}`,
+      };
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      action: 'transport-error',
+      error: `identity INSERT failed: ${(err as Error).message}`,
+    };
+  } finally {
+    clearTimeout(updateTimer);
+  }
+
+  return { ok: true, action: 'tagged', nodeName: opts.nodeName };
+}
+
+/**
+ * Format an identity-tag mismatch into an operator-facing log block.
+ * Multi-line, names both sides, includes the cleanup recipe.
+ */
+export function formatIdentityTagMismatch(result: StoreIdentityTagResult): string {
+  if (result.ok || result.action !== 'mismatch') return '';
+  return [
+    `[STORE-IDENTITY] external triple-store is owned by a different node.`,
+    `  this node:    ${result.expectedNodeName}`,
+    `  store tagged: ${result.existingNodeName}`,
+    ``,
+    `Two daemons sharing one namespace would silently corrupt each other.`,
+    `Fix one of:`,
+    `  - pick a different namespace (recommended): edit \`store.options.url\` in \`~/.dkg/config.json\`.`,
+    `  - reclaim this namespace if the other node is gone, by clearing the tag:`,
+    `      DELETE WHERE {`,
+    `        GRAPH <${STORE_META_GRAPH}> {`,
+    `          <${STORE_META_SUBJECT}> <${STORE_META_PREDICATE}> ?n`,
+    `        }`,
+    `      }`,
+  ].join('\n');
+}
+
+/** SPARQL literal escape — covers the common cases for node names. */
+function escapeSparqlLiteral(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
+/**
+ * Format a failed health-check result into an operator-facing log block.
+ * Multi-line, includes the URL, the error, and a remediation hint chosen
+ * based on the failure mode.
+ */
+export function formatHealthCheckFailure(result: StoreHealthCheckResult): string {
+  if (result.ok) return '';
+  const lines: string[] = [
+    `[STORE-HEALTH] external triple-store backend is unreachable at boot.`,
+    `  backend: ${result.backend ?? '<unknown>'}`,
+    `  endpoint: ${result.endpoint ?? '<unknown>'}`,
+    `  error: ${result.error ?? '<unknown>'}`,
+    ``,
+    `Daemon cannot start without a reachable store. Fix one of:`,
+  ];
+  if (result.namespaceMissing) {
+    lines.push(`  - create the namespace on the SPARQL server.`);
+    lines.push(`  - re-run \`dkg init\` and use the Docker convenience path.`);
+  } else {
+    lines.push(`  - verify the endpoint URL in \`~/.dkg/config.json\` → \`store.options\`.`);
+    lines.push(`  - verify the SPARQL server is running and reachable from this host.`);
+    lines.push(`  - check firewall / network policy if the URL is on a different host.`);
+  }
+  lines.push(`  - switch back to Oxigraph by removing the \`store\` block from config.`);
+  return lines.join('\n');
+}

--- a/packages/cli/src/store-wizard.ts
+++ b/packages/cli/src/store-wizard.ts
@@ -77,10 +77,39 @@ export interface PromptStoreBackendResult {
    * DKG-owned namespaces) and scoped DELETE (mandatory on
    * shared / V6 / V8 instances).
    */
-  storeBlock: {
-    backend: 'blazegraph' | 'sparql-http';
-    options: { url: string; managedByDkg: boolean };
-  } | null;
+  storeBlock: ExternalStoreBlock | null;
+}
+
+export type ExternalStoreBlock =
+  | {
+      backend: 'blazegraph';
+      options: { url: string; managedByDkg: boolean };
+    }
+  | {
+      backend: 'sparql-http';
+      options: {
+        queryEndpoint: string;
+        updateEndpoint: string;
+        managedByDkg: boolean;
+      };
+    };
+
+function externalStoreBlock(
+  backend: 'blazegraph' | 'sparql-http',
+  url: string,
+  managedByDkg: boolean,
+): ExternalStoreBlock {
+  if (backend === 'blazegraph') {
+    return { backend, options: { url, managedByDkg } };
+  }
+  return {
+    backend,
+    options: {
+      queryEndpoint: url,
+      updateEndpoint: url,
+      managedByDkg,
+    },
+  };
 }
 
 export async function promptStoreBackend(
@@ -181,10 +210,7 @@ export async function promptStoreBackend(
     if (health.ok) {
       log(`  Store endpoint reachable: ${backend} ${url}`);
       return {
-        storeBlock: {
-          backend,
-          options: { url, managedByDkg: false },
-        },
+        storeBlock: externalStoreBlock(backend, url, false),
       };
     }
 
@@ -283,10 +309,7 @@ export async function applyStoreFlagsToConfig(
   const existing = await load();
   const next: DkgConfig = {
     ...existing,
-    store: {
-      backend,
-      options: { url, managedByDkg: false },
-    },
+    store: externalStoreBlock(backend, url, false),
   };
   await save(next);
   log(`  Store configured: ${backend} (${url}) — verified reachable.`);

--- a/packages/cli/src/store-wizard.ts
+++ b/packages/cli/src/store-wizard.ts
@@ -1,0 +1,293 @@
+/**
+ * Triple-store wizard primitives (RFC 120, plan PR 2 items 1 + 3).
+ *
+ * Used by `dkg init` (interactive prompt) and by the adapter-setup
+ * commands `dkg hermes setup` / `openclaw setup` / `mcp setup`
+ * (non-interactive flag application). Centralised so URL validation,
+ * the retry loop, and the "no Docker yet" PR 2 message stay identical
+ * across every entry point.
+ *
+ * Extracted out of `cli.ts` so unit tests can exercise the prompt and
+ * flag flows without loading the full Commander program (which has
+ * side effects in process.exit and ApiClient.connect paths).
+ *
+ * PR 3 will replace the "no URL" branch with a Docker provisioner call;
+ * the function signature stays stable so PR 3 only has to flip one
+ * branch.
+ */
+import {
+  checkExternalStoreReachable,
+  formatHealthCheckFailure,
+} from './daemon/store-health-check.js';
+import { loadConfig, saveConfig, type DkgConfig } from './config.js';
+import {
+  isDockerAvailable as defaultIsDockerAvailable,
+  provisionBlazegraphDocker as defaultProvisionBlazegraphDocker,
+  type ProvisionBlazegraphDockerOptions,
+  type ProvisionBlazegraphDockerResult,
+} from './daemon/blazegraph-docker.js';
+
+export interface PromptStoreBackendOptions {
+  /** `ask` callback that closes over a shared readline interface. */
+  ask: (q: string, def?: string) => Promise<string>;
+  /** Existing config's store block (used as the wizard's default). */
+  existingStore?: {
+    backend: string;
+    options?: Record<string, unknown>;
+  };
+  /** Pre-fill from `--store` flag. Always overrides existing config. */
+  flagBackend?: string;
+  /** Pre-fill from `--store-url` flag. Always overrides existing config. */
+  flagUrl?: string;
+  /**
+   * Node name from the config — used as the Blazegraph namespace name
+   * when the Docker provisioning branch fires. Falls back to
+   * `"dkg-node"` if absent (matches `loadConfig` default).
+   */
+  nodeName?: string;
+  /**
+   * Override for the SPARQL HTTP transport. Tests inject a mock so the
+   * URL validation step is deterministic; defaults to `globalThis.fetch`
+   * via the shared health-check helper.
+   */
+  fetch?: typeof globalThis.fetch;
+  /** Logger for status / warning messages. Defaults to console.log. */
+  log?: (msg: string) => void;
+  /**
+   * PR 3 Docker convenience path. Tests inject a fake to exercise the
+   * "Docker available + operator accepts" branch without spawning real
+   * containers. Production callers omit these — they default to the
+   * real Docker CLI probe + provisioner.
+   */
+  isDockerAvailable?: () => Promise<boolean>;
+  provisionBlazegraphDocker?: (
+    opts: ProvisionBlazegraphDockerOptions,
+  ) => Promise<ProvisionBlazegraphDockerResult>;
+}
+
+export interface PromptStoreBackendResult {
+  /**
+   * Persisted store block. `null` means "use the local default" (caller
+   * should omit the field or set it to undefined; saveConfig drops
+   * undefined keys).
+   *
+   * `managedByDkg: true` is set by the Docker provisioner branch only;
+   * manual URLs always get `managedByDkg: false`. The chain-reset-wipe
+   * step in PR 1 uses this flag to decide between `DROP ALL` (safe on
+   * DKG-owned namespaces) and scoped DELETE (mandatory on
+   * shared / V6 / V8 instances).
+   */
+  storeBlock: {
+    backend: 'blazegraph' | 'sparql-http';
+    options: { url: string; managedByDkg: boolean };
+  } | null;
+}
+
+export async function promptStoreBackend(
+  opts: PromptStoreBackendOptions,
+): Promise<PromptStoreBackendResult> {
+  const log = opts.log ?? console.log;
+  const existingBackend = opts.existingStore?.backend;
+  const existingUrl =
+    typeof opts.existingStore?.options?.url === 'string'
+      ? (opts.existingStore?.options?.url as string)
+      : typeof opts.existingStore?.options?.queryEndpoint === 'string'
+        ? (opts.existingStore?.options?.queryEndpoint as string)
+        : undefined;
+
+  const defaultBackend = opts.flagBackend
+    ?? (existingBackend === 'blazegraph' || existingBackend === 'sparql-http' ? existingBackend : 'oxigraph');
+
+  const backendAnswer = (await opts.ask(
+    'Triple store backend (oxigraph / blazegraph)',
+    defaultBackend,
+  )).toLowerCase();
+
+  // Normalise: anything that isn't a known external alias falls back to
+  // the local default. We accept the internal alias `oxigraph-worker`
+  // for power users but don't advertise it.
+  if (backendAnswer !== 'blazegraph' && backendAnswer !== 'sparql-http') {
+    return { storeBlock: null };
+  }
+  const backend = backendAnswer as 'blazegraph' | 'sparql-http';
+
+  // URL prompt loop: validate each attempt, surface the operator-facing
+  // failure message, allow retry or abort.
+  while (true) {
+    const defaultUrl = opts.flagUrl ?? existingUrl;
+    const url = (await opts.ask(
+      backend === 'blazegraph'
+        ? 'Blazegraph SPARQL endpoint URL'
+        : 'SPARQL query endpoint URL',
+      defaultUrl,
+    )).trim();
+
+    if (!url) {
+      // PR 3 Docker branch: only offered for blazegraph (sparql-http is
+      // by definition bring-your-own-server). Probe `docker --version`
+      // first so we don't prompt operators who don't have Docker.
+      if (backend === 'blazegraph') {
+        const probeDocker = opts.isDockerAvailable ?? defaultIsDockerAvailable;
+        const dockerOk = await probeDocker();
+        if (dockerOk) {
+          const yes = (await opts.ask(
+            'No URL provided. Provision a Blazegraph container via Docker? (y/n)',
+            'y',
+          )).toLowerCase();
+          if (yes !== 'n') {
+            const namespace = opts.nodeName || 'dkg-node';
+            log(`  Starting Blazegraph in Docker (namespace: ${namespace})…`);
+            try {
+              const provision = opts.provisionBlazegraphDocker ?? defaultProvisionBlazegraphDocker;
+              const result = await provision({ namespace, log });
+              log(
+                `  ${result.reused ? 'Reusing' : 'Created'} container "${result.containerName}" ` +
+                `on port ${result.port}.`,
+              );
+              log(`  Store endpoint: ${result.url}`);
+              return {
+                storeBlock: {
+                  backend: 'blazegraph',
+                  options: { url: result.url, managedByDkg: true },
+                },
+              };
+            } catch (err) {
+              log('');
+              log(`  Docker provisioning failed: ${(err as Error).message}`);
+              log('');
+              // Fall through to retry / manual URL.
+            }
+          }
+        } else {
+          log('  Docker not detected on PATH. Install Docker Desktop or the Docker Engine');
+          log('  to use the convenience path, or provide a URL to an existing instance.');
+        }
+      }
+      const retry = (await opts.ask('Retry with a URL? (y/n)', 'y')).toLowerCase();
+      if (retry === 'n') {
+        log('  Aborting store setup; defaulting to local Oxigraph.');
+        return { storeBlock: null };
+      }
+      continue;
+    }
+
+    const optionsForProbe =
+      backend === 'blazegraph' ? { url } : { queryEndpoint: url };
+    const health = await checkExternalStoreReachable({
+      storeConfig: { backend, options: optionsForProbe },
+      fetch: opts.fetch,
+    });
+
+    if (health.ok) {
+      log(`  Store endpoint reachable: ${backend} ${url}`);
+      return {
+        storeBlock: {
+          backend,
+          options: { url, managedByDkg: false },
+        },
+      };
+    }
+
+    log('');
+    log(formatHealthCheckFailure(health));
+    log('');
+    const retry = (await opts.ask(
+      'Retry with a different URL? (y/n)',
+      'y',
+    )).toLowerCase();
+    if (retry === 'n') {
+      log('  Aborting store setup; defaulting to local Oxigraph.');
+      return { storeBlock: null };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------
+// Flag-driven flow for adapter setup commands
+// ---------------------------------------------------------------------
+
+export interface ApplyStoreFlagsOptions {
+  storeFlag?: string;
+  storeUrlFlag?: string;
+  /** Mock for tests; defaults to the real `loadConfig` from config.ts. */
+  loadConfig?: () => Promise<DkgConfig>;
+  /** Mock for tests; defaults to the real `saveConfig` from config.ts. */
+  saveConfig?: (config: DkgConfig) => Promise<void>;
+  /** Mock for tests; defaults to `globalThis.fetch` via the probe helper. */
+  fetch?: typeof globalThis.fetch;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Non-interactive sibling of `promptStoreBackend`. Used by the
+ * adapter-setup commands which delegate to action modules that don't
+ * run the init wizard — so the operator has no chance to type a URL.
+ *
+ * Validates via the shared boot-time health-check probe, then writes
+ * the store block into `~/.dkg/config.json` after the action module
+ * has already created/updated the rest of the config.
+ *
+ * Returns silently when no flags are passed (default behaviour: leave
+ * the existing config alone). Throws on validation failure so the CLI
+ * dispatch wrapper catches and exits cleanly.
+ */
+export async function applyStoreFlagsToConfig(
+  opts: ApplyStoreFlagsOptions,
+): Promise<void> {
+  const log = opts.log ?? console.log;
+  const backend = opts.storeFlag;
+  if (!backend) return;
+
+  const load = opts.loadConfig ?? loadConfig;
+  const save = opts.saveConfig ?? saveConfig;
+
+  // Operators who pass `--store oxigraph` may be trying to FORCE local
+  // even though their existing config has a `store` block — honour
+  // that by clearing the block.
+  if (
+    backend === 'oxigraph' ||
+    backend === 'oxigraph-worker' ||
+    backend === 'oxigraph-persistent'
+  ) {
+    const existing = await load();
+    if (existing.store) {
+      log(`  Removing existing store block (--store ${backend} → local default).`);
+      const next = { ...existing };
+      delete next.store;
+      await save(next);
+    }
+    return;
+  }
+
+  if (backend !== 'blazegraph' && backend !== 'sparql-http') {
+    throw new Error(
+      `--store must be one of: oxigraph, blazegraph, sparql-http (got "${backend}")`,
+    );
+  }
+
+  const url = opts.storeUrlFlag?.trim();
+  if (!url) {
+    throw new Error(`--store ${backend} requires --store-url <SPARQL endpoint URL>`);
+  }
+
+  const optionsForProbe =
+    backend === 'blazegraph' ? { url } : { queryEndpoint: url };
+  const health = await checkExternalStoreReachable({
+    storeConfig: { backend, options: optionsForProbe },
+    fetch: opts.fetch,
+  });
+  if (!health.ok) {
+    throw new Error(`store URL validation failed:\n${formatHealthCheckFailure(health)}`);
+  }
+
+  const existing = await load();
+  const next: DkgConfig = {
+    ...existing,
+    store: {
+      backend,
+      options: { url, managedByDkg: false },
+    },
+  };
+  await save(next);
+  log(`  Store configured: ${backend} (${url}) — verified reachable.`);
+}

--- a/packages/cli/test/blazegraph-docker.test.ts
+++ b/packages/cli/test/blazegraph-docker.test.ts
@@ -25,6 +25,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   provisionBlazegraphDocker,
+  normaliseBlazegraphNamespace,
   isDockerAvailable,
   BLAZEGRAPH_NAMESPACE_XML_TEMPLATE,
   type DockerRunner,
@@ -361,15 +362,15 @@ describe('provisionBlazegraphDocker', () => {
         { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'id', stderr: '', exitCode: 0 }) },
       ],
     });
-    const { fn } = mockFetch((url) => {
+    const { fn, calls: httpCalls } = mockFetch((url) => {
       if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
       if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
       return new Response(null, { status: 200 });
     });
-    await provisionBlazegraphDocker({
-      // Embedded spaces + apostrophes + uppercase get slugified down to
-      // characters Docker accepts.
-      namespace: "Bob's Node",
+    const result = await provisionBlazegraphDocker({
+      // Embedded spaces + apostrophes + uppercase and path/query-sensitive
+      // characters get slugified down once before Docker, XML, and URL use.
+      namespace: "Bob's Node / Main & Co",
       docker: runner,
       fetch: fn,
       isPortFree: async () => true,
@@ -378,6 +379,21 @@ describe('provisionBlazegraphDocker', () => {
     const inspectCall = calls.find((c) => c[0] === 'inspect');
     expect(inspectCall?.[1]).toMatch(/^dkg-blazegraph-/);
     expect(inspectCall?.[1]).not.toMatch(/['\s]/);
+    expect(result.url).toBe(
+      'http://127.0.0.1:9999/bigdata/namespace/bob-s-node-main-co/sparql',
+    );
+    const createCall = httpCalls.find((c) => c.url.endsWith('/bigdata/namespace'));
+    expect(String(createCall?.init?.body)).toContain(
+      '<entry key="com.bigdata.rdf.sail.namespace">bob-s-node-main-co</entry>',
+    );
+  });
+
+  it('normalises operator node names into safe Blazegraph namespace names', () => {
+    expect(normaliseBlazegraphNamespace("Bob's Node / Main & Co")).toBe(
+      'bob-s-node-main-co',
+    );
+    expect(normaliseBlazegraphNamespace('dkg.node_01')).toBe('dkg.node_01');
+    expect(normaliseBlazegraphNamespace('   ')).toBe('dkg-node');
   });
 });
 

--- a/packages/cli/test/blazegraph-docker.test.ts
+++ b/packages/cli/test/blazegraph-docker.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Blazegraph Docker provisioner — unit tests with full mock injection.
+ *
+ * Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 3
+ * items 1, 2.
+ *
+ * Locks in:
+ *   - Hard fail when `docker` CLI is missing (no silent Oxigraph
+ *     fallback like devnet.sh — operator opted into Docker).
+ *   - Idempotent reuse when a running container with the same name
+ *     exists (no re-pull, no recreate).
+ *   - Stopped container restarted instead of recreated.
+ *   - Stopped container that can't restart → recreated cleanly.
+ *   - Port-collision auto-bump scans up to the configured range.
+ *   - Port range exhaustion throws with a clear message.
+ *   - `/bigdata/status` polling times out cleanly.
+ *   - Namespace creation failure surfaces an actionable error.
+ *   - `managedByDkg: true` always set (signals scoped-DELETE in PR 1
+ *     wipe is unnecessary — DROP ALL is safe).
+ *   - Namespace XML body contains the V10-required quad mode.
+ *
+ * No real Docker, no real fetch, no real ports. Everything's
+ * injectable; tests run in <50 ms.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  provisionBlazegraphDocker,
+  isDockerAvailable,
+  BLAZEGRAPH_NAMESPACE_XML_TEMPLATE,
+  type DockerRunner,
+  type DockerCommandResult,
+} from '../src/daemon/blazegraph-docker.js';
+
+interface MockDockerScript {
+  /**
+   * Sequence of responses keyed by argv prefix; map iteration order
+   * matters here for cases that ask the same docker subcommand more
+   * than once (e.g. inspect → start → inspect).
+   */
+  matchers: Array<{
+    when: (args: readonly string[]) => boolean;
+    respond: (args: readonly string[]) => DockerCommandResult;
+  }>;
+}
+
+function mockDocker(script: MockDockerScript): { runner: DockerRunner; calls: string[][] } {
+  const calls: string[][] = [];
+  const runner: DockerRunner = {
+    async run(args) {
+      calls.push([...args]);
+      for (const matcher of script.matchers) {
+        if (matcher.when(args)) {
+          return matcher.respond(args);
+        }
+      }
+      // Default: pretend success so tests that don't care about a
+      // particular subcommand stay short.
+      return { stdout: '', stderr: '', exitCode: 0 };
+    },
+  };
+  return { runner, calls };
+}
+
+function dockerVersionOk(): DockerCommandResult {
+  return { stdout: 'Docker version 24.0.6, build ed223bc', stderr: '', exitCode: 0 };
+}
+
+function dockerInspectNotFound(): DockerCommandResult {
+  return {
+    stdout: '',
+    stderr: 'Error: No such object: dkg-blazegraph-node',
+    exitCode: 1,
+  };
+}
+
+function dockerInspectRunning(hostPort = 9999): DockerCommandResult {
+  return {
+    stdout: JSON.stringify([
+      {
+        State: { Running: true },
+        NetworkSettings: {
+          Ports: {
+            '8080/tcp': [{ HostIp: '0.0.0.0', HostPort: String(hostPort) }],
+          },
+        },
+      },
+    ]),
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+function dockerInspectStopped(): DockerCommandResult {
+  return {
+    stdout: JSON.stringify([
+      {
+        State: { Running: false },
+        NetworkSettings: {
+          Ports: { '8080/tcp': [{ HostIp: '0.0.0.0', HostPort: '9999' }] },
+        },
+      },
+    ]),
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+function mockFetch(handler: (url: string, init?: any) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn: typeof globalThis.fetch = (async (input: any, init?: any) => {
+    calls.push({ url: String(input), init });
+    return handler(String(input), init);
+  }) as typeof globalThis.fetch;
+  return { fn, calls };
+}
+
+describe('provisionBlazegraphDocker', () => {
+  it('throws an actionable error when the docker CLI is missing', async () => {
+    const docker: DockerRunner = {
+      async run() {
+        const err: NodeJS.ErrnoException = new Error('spawn docker ENOENT');
+        err.code = 'ENOENT';
+        throw err;
+      },
+    };
+    await expect(
+      provisionBlazegraphDocker({
+        namespace: 'mynode',
+        docker,
+        log: () => {},
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('throws when `docker --version` returns non-zero (daemon dead)', async () => {
+    const { runner } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: () => ({ stdout: '', stderr: 'Cannot connect to the Docker daemon', exitCode: 1 }) },
+      ],
+    });
+    await expect(
+      provisionBlazegraphDocker({
+        namespace: 'mynode',
+        docker: runner,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/docker --version.*failed|Docker daemon/);
+  });
+
+  it('reuses a running container without re-creating it', async () => {
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: () => dockerInspectRunning(9999) },
+      ],
+    });
+    const { fn, calls: httpCalls } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    expect(result.reused).toBe(true);
+    expect(result.managedByDkg).toBe(true);
+    expect(result.url).toBe('http://127.0.0.1:9999/bigdata/namespace/mynode/sparql');
+    expect(calls.some((c) => c[0] === 'run')).toBe(false);
+    expect(httpCalls.some((c) => c.url.endsWith('/bigdata/status'))).toBe(true);
+  });
+
+  it('creates the namespace when reusing a container with no existing namespace', async () => {
+    const { runner } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: () => dockerInspectRunning() },
+      ],
+    });
+    const { fn, calls: httpCalls } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 404 });
+      if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    expect(result.namespaceCreated).toBe(true);
+    const createCall = httpCalls.find((c) => c.url.endsWith('/bigdata/namespace'));
+    expect(createCall).toBeDefined();
+    expect(String(createCall?.init?.body)).toContain('<entry key="com.bigdata.rdf.sail.namespace">mynode</entry>');
+    expect(String(createCall?.init?.body)).toContain('quads">true');
+  });
+
+  it('starts an existing stopped container instead of recreating', async () => {
+    let inspectCount = 0;
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        {
+          when: (a) => a[0] === 'inspect',
+          respond: () => {
+            inspectCount += 1;
+            // First inspect → stopped. Second inspect (after `start`) → running.
+            return inspectCount === 1 ? dockerInspectStopped() : dockerInspectRunning();
+          },
+        },
+        { when: (a) => a[0] === 'start', respond: () => ({ stdout: 'dkg-blazegraph-node', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.includes('/sparql/properties')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    expect(result.reused).toBe(true);
+    expect(calls.some((c) => c[0] === 'start')).toBe(true);
+    expect(calls.some((c) => c[0] === 'run')).toBe(false);
+  });
+
+  it('recreates the container when `docker start` fails on a stopped container', async () => {
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: () => dockerInspectStopped() },
+        { when: (a) => a[0] === 'start', respond: () => ({ stdout: '', stderr: 'config drift', exitCode: 1 }) },
+        { when: (a) => a[0] === 'rm', respond: () => ({ stdout: '', stderr: '', exitCode: 0 }) },
+        { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'container-id', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    expect(result.reused).toBe(false);
+    expect(calls.some((c) => c[0] === 'rm')).toBe(true);
+    expect(calls.some((c) => c[0] === 'run')).toBe(true);
+  });
+
+  it('auto-bumps to the next free port when 9999 is taken', async () => {
+    const takenPorts = new Set([9999, 10000]);
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+      ],
+    });
+    const { fn } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    const result = await provisionBlazegraphDocker({
+      namespace: 'mynode',
+      docker: runner,
+      fetch: fn,
+      isPortFree: async (p) => !takenPorts.has(p),
+      log: () => {},
+    });
+    expect(result.port).toBe(10001);
+    const runCall = calls.find((c) => c[0] === 'run');
+    expect(runCall).toBeDefined();
+    expect(runCall?.join(' ')).toContain('10001:8080');
+  });
+
+  it('throws when every port in the scan range is taken', async () => {
+    const { runner } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+      ],
+    });
+    await expect(
+      provisionBlazegraphDocker({
+        namespace: 'mynode',
+        docker: runner,
+        fetch: globalThis.fetch,
+        isPortFree: async () => false,
+        portRange: 3,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/No free port found in the range 9999\.\.10001/);
+  });
+
+  it('times out cleanly when /bigdata/status never responds', async () => {
+    const { runner } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+        { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'id', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch(() => {
+      throw new Error('ECONNREFUSED');
+    });
+    await expect(
+      provisionBlazegraphDocker({
+        namespace: 'mynode',
+        docker: runner,
+        fetch: fn,
+        isPortFree: async () => true,
+        pollIntervalMs: 5,
+        pollTimeoutMs: 30,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/did not become ready within 30ms/);
+  });
+
+  it('surfaces a clear error when namespace POST returns non-2xx', async () => {
+    const { runner } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+        { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'id', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.endsWith('/bigdata/namespace')) return new Response('namespace exists already', { status: 409 });
+      return new Response(null, { status: 200 });
+    });
+    await expect(
+      provisionBlazegraphDocker({
+        namespace: 'mynode',
+        docker: runner,
+        fetch: fn,
+        isPortFree: async () => true,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/Failed to create Blazegraph namespace "mynode" — HTTP 409/);
+  });
+
+  it('sanitises the container name for tricky namespaces', async () => {
+    const { runner, calls } = mockDocker({
+      matchers: [
+        { when: (a) => a[0] === '--version', respond: dockerVersionOk },
+        { when: (a) => a[0] === 'inspect', respond: dockerInspectNotFound },
+        { when: (a) => a[0] === 'run', respond: () => ({ stdout: 'id', stderr: '', exitCode: 0 }) },
+      ],
+    });
+    const { fn } = mockFetch((url) => {
+      if (url.endsWith('/bigdata/status')) return new Response('ok', { status: 200 });
+      if (url.endsWith('/bigdata/namespace')) return new Response(null, { status: 200 });
+      return new Response(null, { status: 200 });
+    });
+    await provisionBlazegraphDocker({
+      // Embedded spaces + apostrophes + uppercase get slugified down to
+      // characters Docker accepts.
+      namespace: "Bob's Node",
+      docker: runner,
+      fetch: fn,
+      isPortFree: async () => true,
+      log: () => {},
+    });
+    const inspectCall = calls.find((c) => c[0] === 'inspect');
+    expect(inspectCall?.[1]).toMatch(/^dkg-blazegraph-/);
+    expect(inspectCall?.[1]).not.toMatch(/['\s]/);
+  });
+});
+
+describe('isDockerAvailable', () => {
+  it('returns true when docker --version succeeds', async () => {
+    const { runner } = mockDocker({
+      matchers: [{ when: (a) => a[0] === '--version', respond: dockerVersionOk }],
+    });
+    await expect(isDockerAvailable(runner)).resolves.toBe(true);
+  });
+
+  it('returns false when docker --version fails', async () => {
+    const { runner } = mockDocker({
+      matchers: [{ when: (a) => a[0] === '--version', respond: () => ({ stdout: '', stderr: '', exitCode: 1 }) }],
+    });
+    await expect(isDockerAvailable(runner)).resolves.toBe(false);
+  });
+
+  it('returns false when the runner throws', async () => {
+    const runner: DockerRunner = {
+      async run() { throw new Error('ENOENT'); },
+    };
+    await expect(isDockerAvailable(runner)).resolves.toBe(false);
+  });
+});
+
+describe('BLAZEGRAPH_NAMESPACE_XML_TEMPLATE', () => {
+  it('parameterises the namespace and locks in DKG V10 settings', () => {
+    const body = BLAZEGRAPH_NAMESPACE_XML_TEMPLATE.replace('{namespace}', 'mynode');
+    expect(body).toContain('<entry key="com.bigdata.rdf.sail.namespace">mynode</entry>');
+    // Quads MUST be true for DKG V10 (named-graph scoping). Any
+    // change to false would break scoped DELETE wipe.
+    expect(body).toContain('com.bigdata.rdf.store.AbstractTripleStore.quads">true');
+    expect(body).toContain('truthMaintenance">false');
+    expect(body).toContain('statementIdentifiers">false');
+  });
+});

--- a/packages/cli/test/blazegraph-integration.test.ts
+++ b/packages/cli/test/blazegraph-integration.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Real-Blazegraph end-to-end integration test (RFC 120, plan PR 3
+ * §"Real-Blazegraph integration test (opt-in)").
+ *
+ * What this proves that the mocked tests can't
+ * ------------------------------------------------
+ * The unit tests for `BlazegraphStore`, `provisionBlazegraphDocker`,
+ * `chainResetWipe`, and `checkOrSetStoreIdentity` all use a fake fetch
+ * to verify *what we send*. They can't catch:
+ *
+ *   - Blazegraph protocol divergences (response shapes, status codes,
+ *     content negotiation quirks, namespace creation race conditions).
+ *   - SPARQL semantics for `DROP ALL` vs scoped DELETE (does Blazegraph
+ *     actually leave non-V10 named graphs alone? does `DROP ALL`
+ *     clean up the namespace metadata or just the data?).
+ *   - Docker run/inspect contract drift (lyrasis/blazegraph:2.1.5 has
+ *     been frozen for years, but Docker behavioural changes —
+ *     log-driver defaults, port-binding shape — can still bite).
+ *   - The identity tag round-trip against real SPARQL UPDATE parsing.
+ *
+ * This test wires the full Docker → BlazegraphStore → chainResetWipe →
+ * identity-tag pipeline against a real container.
+ *
+ * Why it's opt-in
+ * ----------------
+ * Spinning up a Blazegraph container takes 30-60 s on a cold machine
+ * (image pull + JVM warmup) which is too slow for CI per-PR. Gate via
+ * `BLAZEGRAPH_INTEGRATION_TEST=1`. Run locally with:
+ *
+ *   BLAZEGRAPH_INTEGRATION_TEST=1 npx vitest run \
+ *     --config vitest.unit.config.ts test/blazegraph-integration.test.ts
+ *
+ * The test self-cleans the container on teardown even when individual
+ * cases fail, so re-running the suite is idempotent.
+ *
+ * Apple Silicon (arm64) caveat
+ * -----------------------------
+ * `lyrasis/blazegraph:2.1.5` is published as `linux/amd64` only — the
+ * upstream Blazegraph project at github.com/blazegraph was archived in
+ * March 2026 and no longer publishes new images. We pin this tag for
+ * mainnet + devnet.sh parity.
+ *
+ * On Apple Silicon Macs the image runs under QEMU emulation (or
+ * Rosetta on macOS 14.1+ with Docker Desktop ≥ 4.25). The JVM startup
+ * under emulation can take much longer than the 30-second default,
+ * and the QEMU path is known to crash Docker Desktop entirely under
+ * sustained JVM warmup on some machines. To improve odds:
+ *
+ *   - Docker Desktop → Settings → General → "Use Rosetta for x86_64
+ *     emulation" (enabled by default on macOS 14.1+).
+ *   - Bumped `pollTimeoutMs` in `beforeAll` below from 30 s to 120 s.
+ *
+ * If your `beforeAll` fails with "Blazegraph did not become ready
+ * within 120000ms" on an arm64 host, the test is correctly designed
+ * but the JVM emulation is overloading your Docker Desktop. Re-run on
+ * an amd64 box (CI / Linux server). The mocked unit-tests still cover
+ * the contract.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { BlazegraphStore } from '@origintrail-official/dkg-storage';
+import {
+  provisionBlazegraphDocker,
+  isDockerAvailable,
+  type ProvisionBlazegraphDockerResult,
+} from '../src/daemon/blazegraph-docker.js';
+import { chainResetWipe } from '../src/daemon/chain-reset-wipe.js';
+import {
+  checkOrSetStoreIdentity,
+} from '../src/daemon/store-health-check.js';
+
+const ENABLED = process.env.BLAZEGRAPH_INTEGRATION_TEST === '1';
+
+const V10_GRAPH = 'did:dkg:context-graph:integration-test';
+const OTHER_GRAPH = 'urn:other-app:integration-cotenant';
+
+function execDocker(args: readonly string[], timeoutMs = 30_000): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const child = spawn('docker', [...args], { stdio: 'ignore' });
+    const timer = setTimeout(() => child.kill('SIGKILL'), timeoutMs);
+    child.once('close', () => { clearTimeout(timer); resolve(); });
+    child.once('error', () => { clearTimeout(timer); resolve(); });
+  });
+}
+
+describe.skipIf(!ENABLED)('Blazegraph end-to-end integration', () => {
+  let provisioned: ProvisionBlazegraphDockerResult | null = null;
+  let store: BlazegraphStore | null = null;
+  let dataDir: string;
+  // Each test suite run uses a fresh namespace so a re-run doesn't see
+  // stale identity tags or stale quads from the previous run. The
+  // container is reused (idempotent provisioner), only the namespace
+  // is new.
+  const namespace = `integ-${process.pid}-${Date.now().toString(36)}`;
+
+  beforeAll(async () => {
+    if (!(await isDockerAvailable())) {
+      throw new Error(
+        'BLAZEGRAPH_INTEGRATION_TEST=1 but `docker --version` failed. ' +
+        'Install Docker or unset the env var to skip the test.',
+      );
+    }
+
+    dataDir = await mkdtemp(join(tmpdir(), 'dkg-blaze-integ-'));
+
+    provisioned = await provisionBlazegraphDocker({
+      namespace,
+      // Use a low port-range cap so multiple parallel runs on the same
+      // host don't collide indefinitely; integration runs sequentially
+      // in practice.
+      portRange: 12,
+      // 120 s instead of the 30 s provisioner default — JVM warmup
+      // under amd64-via-QEMU/Rosetta on Apple Silicon can take 60 s+.
+      // On native amd64 this is still essentially "as fast as the
+      // container becomes ready", since we poll every second.
+      pollTimeoutMs: 120_000,
+      log: () => {},
+    });
+
+    store = new BlazegraphStore(provisioned.url);
+  }, /* timeoutMs */ 180_000);
+
+  afterAll(async () => {
+    try { await store?.close(); } catch { /* ignore */ }
+    // Best-effort container cleanup. We only destroy the container if
+    // it was freshly created; reusing a pre-existing container is a
+    // hint the operator wants to keep it around.
+    if (provisioned && !provisioned.reused) {
+      await execDocker(['rm', '-f', provisioned.containerName]);
+    }
+    if (dataDir) {
+      await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }, /* timeoutMs */ 60_000);
+
+  // -----------------------------------------------------------------
+  // Adapter round-trip — insert / query / count / delete patterns.
+  // -----------------------------------------------------------------
+
+  it('insert + SELECT count → real Blazegraph returns the right total', async () => {
+    expect(store).not.toBeNull();
+    await store!.insert([
+      { subject: 'urn:integ:s1', predicate: 'urn:integ:p', object: 'urn:integ:o1', graph: V10_GRAPH },
+      { subject: 'urn:integ:s2', predicate: 'urn:integ:p', object: 'urn:integ:o2', graph: V10_GRAPH },
+      { subject: 'urn:integ:s3', predicate: 'urn:integ:p', object: 'urn:integ:o3', graph: V10_GRAPH },
+    ]);
+    const count = await store!.countQuads(V10_GRAPH);
+    expect(count).toBe(3);
+  });
+
+  it('ASK over real Blazegraph returns the right boolean', async () => {
+    const result = await store!.query(
+      `ASK { GRAPH <${V10_GRAPH}> { <urn:integ:s1> ?p ?o } }`,
+    );
+    expect(result.type).toBe('boolean');
+    if (result.type === 'boolean') {
+      expect(result.value).toBe(true);
+    }
+  });
+
+  it('deleteByPattern reduces the count', async () => {
+    const before = await store!.countQuads(V10_GRAPH);
+    const removed = await store!.deleteByPattern({
+      subject: 'urn:integ:s2',
+      graph: V10_GRAPH,
+    });
+    expect(removed).toBeGreaterThanOrEqual(1);
+    const after = await store!.countQuads(V10_GRAPH);
+    expect(after).toBe(before - removed);
+  });
+
+  // -----------------------------------------------------------------
+  // Scoped DELETE — the safety guarantee for shared instances.
+  // -----------------------------------------------------------------
+
+  it('chainResetWipe scoped DELETE leaves non-V10 named graphs alone', async () => {
+    // Seed: V10 data in did:dkg:context-graph:* + co-tenant data in a
+    // non-V10 graph. The scoped wipe must remove the V10 quads and
+    // preserve the co-tenant ones.
+    await store!.insert([
+      { subject: 'urn:integ:scoped-v10', predicate: 'urn:p', object: 'urn:o', graph: V10_GRAPH },
+      { subject: 'urn:integ:cotenant', predicate: 'urn:p', object: 'urn:o', graph: OTHER_GRAPH },
+    ]);
+    expect(await store!.countQuads(V10_GRAPH)).toBeGreaterThan(0);
+    expect(await store!.countQuads(OTHER_GRAPH)).toBeGreaterThan(0);
+
+    // First call seeds the marker so the second is recognised as a
+    // chain-reset event.
+    await chainResetWipe({
+      dataDir,
+      currentMarker: 'seed-marker',
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url, managedByDkg: false },
+      },
+    });
+
+    // Now bump the marker → scoped DELETE on the remote.
+    const wipe = await chainResetWipe({
+      dataDir,
+      currentMarker: 'bumped-marker',
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url, managedByDkg: false },
+      },
+    });
+    expect(wipe.wiped).toBe(true);
+    expect(wipe.failedFiles).toEqual([]);
+
+    expect(await store!.countQuads(V10_GRAPH)).toBe(0);
+    // Critical assertion: co-tenant data survived.
+    expect(await store!.countQuads(OTHER_GRAPH)).toBeGreaterThan(0);
+
+    // Cleanup so subsequent tests don't see the co-tenant quad.
+    await store!.deleteByPattern({ graph: OTHER_GRAPH });
+  });
+
+  // -----------------------------------------------------------------
+  // DROP ALL — fast path for DKG-managed namespaces.
+  // -----------------------------------------------------------------
+
+  it('chainResetWipe managedByDkg=true issues DROP ALL — wipes every graph', async () => {
+    await store!.insert([
+      { subject: 'urn:integ:drop-v10', predicate: 'urn:p', object: 'urn:o', graph: V10_GRAPH },
+      { subject: 'urn:integ:drop-other', predicate: 'urn:p', object: 'urn:o', graph: OTHER_GRAPH },
+    ]);
+
+    // Marker has to differ from the persisted one to trigger the wipe.
+    const wipe = await chainResetWipe({
+      dataDir,
+      currentMarker: 'drop-all-marker',
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url, managedByDkg: true },
+      },
+    });
+    expect(wipe.wiped).toBe(true);
+    expect(wipe.failedFiles).toEqual([]);
+
+    // Both graphs gone — DROP ALL is unconditional.
+    expect(await store!.countQuads(V10_GRAPH)).toBe(0);
+    expect(await store!.countQuads(OTHER_GRAPH)).toBe(0);
+  });
+
+  // -----------------------------------------------------------------
+  // Namespace identity tag round-trip.
+  // -----------------------------------------------------------------
+
+  it('checkOrSetStoreIdentity round-trips against a real namespace', async () => {
+    // The provisioner-created namespace starts with no identity tag.
+    // Use a fresh sub-namespace so the round-trip is deterministic
+    // regardless of test order: clear any prior tag first.
+    await store!.dropGraph('urn:dkg:store-meta');
+
+    const first = await checkOrSetStoreIdentity({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url },
+      },
+      nodeName: 'alice-integ',
+    });
+    expect(first.ok).toBe(true);
+    if (first.ok) expect(first.action).toBe('tagged');
+
+    const second = await checkOrSetStoreIdentity({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url },
+      },
+      nodeName: 'alice-integ',
+    });
+    expect(second.ok).toBe(true);
+    if (second.ok) expect(second.action).toBe('matched');
+
+    const third = await checkOrSetStoreIdentity({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: provisioned!.url },
+      },
+      nodeName: 'bob-integ',
+    });
+    expect(third.ok).toBe(false);
+    if (!third.ok && third.action === 'mismatch') {
+      expect(third.existingNodeName).toBe('alice-integ');
+      expect(third.expectedNodeName).toBe('bob-integ');
+    }
+  });
+
+  // -----------------------------------------------------------------
+  // Provisioner idempotency — second call reuses the running container.
+  // -----------------------------------------------------------------
+
+  it('provisionBlazegraphDocker second call reuses the running container', async () => {
+    const again = await provisionBlazegraphDocker({
+      namespace,
+      log: () => {},
+    });
+    expect(again.containerName).toBe(provisioned!.containerName);
+    expect(again.port).toBe(provisioned!.port);
+    expect(again.reused).toBe(true);
+    // Namespace was created on first run; second run must NOT try to
+    // re-create it (Blazegraph 409s on duplicates).
+    expect(again.namespaceCreated).toBe(false);
+  });
+});
+
+// When BLAZEGRAPH_INTEGRATION_TEST is unset, vitest still runs this
+// file but `describe.skipIf(!ENABLED)` makes every case a no-op. Print
+// a one-liner so contributors discover the env-var.
+if (!ENABLED) {
+  // eslint-disable-next-line no-console
+  console.log(
+    '[blazegraph-integration] SKIPPED — set BLAZEGRAPH_INTEGRATION_TEST=1 to enable.',
+  );
+}

--- a/packages/cli/test/chain-reset-wipe.test.ts
+++ b/packages/cli/test/chain-reset-wipe.test.ts
@@ -26,7 +26,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync, chmodSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { chainResetWipe } from '../src/daemon/chain-reset-wipe.js';
+import { chainResetWipe, detectBackendSwitch } from '../src/daemon/chain-reset-wipe.js';
 
 const STATE_FILE = '.network-state.json';
 const NEW_MARKER = 'v10-rs-staking-consolidation-2026-04-30';
@@ -62,9 +62,9 @@ afterEach(() => {
 });
 
 describe('chainResetWipe — opt-in protocol', () => {
-  it('is a no-op when network config has no marker (back-compat)', () => {
+  it('is a no-op when network config has no marker (back-compat)', async () => {
     seedAllFiles(dataDir);
-    const result = chainResetWipe({ dataDir, currentMarker: undefined });
+    const result = await chainResetWipe({ dataDir, currentMarker: undefined });
 
     expect(result.wiped).toBe(false);
     expect(result.prevMarker).toBeNull();
@@ -78,11 +78,11 @@ describe('chainResetWipe — opt-in protocol', () => {
 });
 
 describe('chainResetWipe — first boot with marker present', () => {
-  it('wipes and saves marker (the chain-reset rollout case)', () => {
+  it('wipes and saves marker (the chain-reset rollout case)', async () => {
     seedAllFiles(dataDir);
     const logs: string[] = [];
 
-    const result = chainResetWipe({
+    const result = await chainResetWipe({
       dataDir,
       currentMarker: NEW_MARKER,
       log: (msg) => logs.push(msg),
@@ -110,8 +110,8 @@ describe('chainResetWipe — first boot with marker present', () => {
     expect(logs.some((l) => l.includes('first detected'))).toBe(true);
   });
 
-  it('still records the marker on a fresh install with no chain-state files yet', () => {
-    const result = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+  it('still records the marker on a fresh install with no chain-state files yet', async () => {
+    const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
     expect(result.wiped).toBe(true);
     expect(result.removedFiles).toEqual([]);
@@ -120,14 +120,14 @@ describe('chainResetWipe — first boot with marker present', () => {
 });
 
 describe('chainResetWipe — same marker (steady state)', () => {
-  it('does nothing when persisted marker equals current', () => {
+  it('does nothing when persisted marker equals current', async () => {
     writeFileSync(
       join(dataDir, STATE_FILE),
       JSON.stringify({ chainResetMarker: NEW_MARKER, savedAt: Date.now() }),
     );
     seedAllFiles(dataDir);
 
-    const result = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
     expect(result.wiped).toBe(false);
     expect(result.prevMarker).toBe(NEW_MARKER);
@@ -138,7 +138,7 @@ describe('chainResetWipe — same marker (steady state)', () => {
 });
 
 describe('chainResetWipe — marker changed (chain reset)', () => {
-  it('wipes chain-state files and preserves operator state when marker differs', () => {
+  it('wipes chain-state files and preserves operator state when marker differs', async () => {
     writeFileSync(
       join(dataDir, STATE_FILE),
       JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() - 86_400_000 }),
@@ -146,7 +146,7 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
     seedAllFiles(dataDir);
 
     const logs: string[] = [];
-    const result = chainResetWipe({
+    const result = await chainResetWipe({
       dataDir,
       currentMarker: NEW_MARKER,
       log: (msg) => logs.push(msg),
@@ -183,7 +183,7 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
     expect(logs.some((l) => l.includes('Wiping'))).toBe(true);
   });
 
-  it('handles missing chain-state files gracefully (subset wipe)', () => {
+  it('handles missing chain-state files gracefully (subset wipe)', async () => {
     writeFileSync(
       join(dataDir, STATE_FILE),
       JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
@@ -191,27 +191,27 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
     // Only seed store.nq; the others don't exist on this node yet.
     writeFileSync(join(dataDir, 'store.nq'), '...');
 
-    const result = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
     expect(result.wiped).toBe(true);
     expect(result.removedFiles).toEqual(['store.nq']);
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(false);
   });
 
-  it('is idempotent: a second call with the same input is a no-op', () => {
+  it('is idempotent: a second call with the same input is a no-op', async () => {
     writeFileSync(
       join(dataDir, STATE_FILE),
       JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
     );
     seedAllFiles(dataDir);
 
-    const first = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    const first = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
     expect(first.wiped).toBe(true);
 
     // Re-seed the chain-state files to simulate "boot, work, boot again".
     writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
 
-    const second = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    const second = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
     expect(second.wiped).toBe(false);
     expect(second.prevMarker).toBe(NEW_MARKER);
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(true);
@@ -219,11 +219,11 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
 });
 
 describe('chainResetWipe — corrupt state file', () => {
-  it('treats unparseable state as missing (first-boot semantics)', () => {
+  it('treats unparseable state as missing (first-boot semantics)', async () => {
     writeFileSync(join(dataDir, STATE_FILE), '{ this is not valid JSON');
     seedAllFiles(dataDir);
 
-    const result = chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
     expect(result.wiped).toBe(true);
     expect(result.prevMarker).toBeNull();
@@ -238,7 +238,7 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
   // their config keep a stale WAL across chain resets — the wipe was
   // hardcoding `dataDir/random-sampling.wal`. These tests pin the fix.
 
-  it('wipes the operator-supplied WAL path when set, not the default', () => {
+  it('wipes the operator-supplied WAL path when set, not the default', async () => {
     const customWal = join(dataDir, 'custom', 'rs.wal');
     mkdirSync(join(dataDir, 'custom'), { recursive: true });
     writeFileSync(customWal, 'WAL\n');
@@ -247,7 +247,7 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
     writeFileSync(join(dataDir, 'random-sampling.wal'), 'STALE\n');
     writeFileSync(join(dataDir, 'store.nq'), '...');
 
-    const result = chainResetWipe({
+    const result = await chainResetWipe({
       dataDir,
       currentMarker: NEW_MARKER,
       randomSamplingWalPath: customWal,
@@ -259,10 +259,10 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
     expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(true);
   });
 
-  it('falls back to default WAL path when randomSamplingWalPath is empty', () => {
+  it('falls back to default WAL path when randomSamplingWalPath is empty', async () => {
     writeFileSync(join(dataDir, 'random-sampling.wal'), 'WAL\n');
 
-    const result = chainResetWipe({
+    const result = await chainResetWipe({
       dataDir,
       currentMarker: NEW_MARKER,
       randomSamplingWalPath: '',
@@ -272,13 +272,13 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
     expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(false);
   });
 
-  it('handles WAL path outside dataDir (absolute, e.g. /var/lib/dkg/wal)', () => {
+  it('handles WAL path outside dataDir (absolute, e.g. /var/lib/dkg/wal)', async () => {
     const externalWalDir = mkdtempSync(join(tmpdir(), 'dkg-external-wal-'));
     const externalWal = join(externalWalDir, 'rs.wal');
     writeFileSync(externalWal, 'EXTERNAL_WAL\n');
 
     try {
-      const result = chainResetWipe({
+      const result = await chainResetWipe({
         dataDir,
         currentMarker: NEW_MARKER,
         randomSamplingWalPath: externalWal,
@@ -300,7 +300,7 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
   // to boot. Crashing here would create a worse failure mode (node down)
   // than the original problem (stale state).
 
-  it('logs and continues when saveState throws (e.g. read-only FS)', () => {
+  it('logs and continues when saveState throws (e.g. read-only FS)', async () => {
     // Make dataDir read-only so writeFileSync on the state file throws.
     // Skip on platforms where chmod 0o555 doesn't actually deny root or
     // where tests run as root (CI containers); the scenario we care
@@ -322,13 +322,13 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
         // Good: FS denied the write. Now run the wipe.
       }
 
-      expect(() => {
+      await expect(
         chainResetWipe({
           dataDir,
           currentMarker: NEW_MARKER,
           log: (msg) => logsCaptured.push(msg),
-        });
-      }).not.toThrow();
+        }),
+      ).resolves.toBeDefined();
 
       // Loud log so operators can find this in journalctl.
       expect(logsCaptured.some((l) => l.includes('failed to persist chain reset marker'))).toBe(true);
@@ -337,7 +337,7 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
     }
   });
 
-  it('does not save the marker when an individual file wipe throws', () => {
+  it('does not save the marker when an individual file wipe throws', async () => {
     writeFileSync(
       join(dataDir, STATE_FILE),
       JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
@@ -356,14 +356,12 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
         // Good: removing from this directory is denied for this process.
       }
 
-      expect(() => {
-        const result = chainResetWipe({
-          dataDir,
-          currentMarker: NEW_MARKER,
-          log: (msg) => logsCaptured.push(msg),
-        });
-        expect(result.failedFiles.some((f) => f.file === 'store.nq')).toBe(true);
-      }).not.toThrow();
+      const result = await chainResetWipe({
+        dataDir,
+        currentMarker: NEW_MARKER,
+        log: (msg) => logsCaptured.push(msg),
+      });
+      expect(result.failedFiles.some((f) => f.file === 'store.nq')).toBe(true);
     } finally {
       chmodSync(dataDir, originalMode);
       rmSync(join(dataDir, '.probe'), { force: true });
@@ -372,5 +370,360 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
     const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
     expect(persisted.chainResetMarker).toBe(OLD_MARKER);
     expect(logsCaptured.some((l) => l.includes('marker was not persisted'))).toBe(true);
+  });
+});
+
+// =====================================================================
+// External SPARQL wipe (RFC 120, plan PR 1 item 5b)
+// =====================================================================
+//
+// Operators who configure an external triple-store backend (Blazegraph
+// or sparql-http) need the same "stale state goes away on chain reset"
+// guarantee as Oxigraph operators get from the local file wipe. The
+// wipe runs a SPARQL UPDATE against the configured endpoint after the
+// local file wipe. Two modes:
+//
+//   - `managedByDkg: true` (Docker convenience path, PR 3): DROP ALL.
+//     Safe because the CLI owns the namespace exclusively.
+//   - operator-provided URL (default): scoped DELETE filtered by the
+//     V10 named-graph prefix `did:dkg:context-graph:` so V6/V8 nodes or
+//     unrelated data sharing the same Blazegraph instance survive.
+//
+// Failures append to `failedFiles`, marker is not persisted, wipe
+// retries on next boot — same partial-failure semantics as the local
+// file wipe.
+
+describe('chainResetWipe — external SPARQL wipe', () => {
+  type FetchCall = { url: string; init?: RequestInit };
+
+  function mockFetch(handler: (call: FetchCall) => Response | Promise<Response>) {
+    const calls: FetchCall[] = [];
+    const fn: typeof globalThis.fetch = (async (input: any, init?: any) => {
+      const call: FetchCall = { url: String(input), init };
+      calls.push(call);
+      return handler(call);
+    }) as typeof globalThis.fetch;
+    return { fn, calls };
+  }
+
+  function decodeUpdateBody(body: unknown): string {
+    const s = String(body ?? '');
+    if (!s.startsWith('update=')) return '';
+    return decodeURIComponent(s.slice('update='.length));
+  }
+
+  it('issues DROP ALL when storeConfig.options.managedByDkg=true', async () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
+    );
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://blaze.test/sparql', managedByDkg: true },
+      },
+      fetch: fn,
+    });
+
+    expect(result.wiped).toBe(true);
+    expect(result.failedFiles).toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://blaze.test/sparql');
+    expect(decodeUpdateBody(calls[0].init?.body)).toBe('DROP ALL');
+    expect(result.removedFiles.some((f) => f.includes('drop-all'))).toBe(true);
+  });
+
+  it('issues scoped DELETE when managedByDkg is false (operator URL — V6/V8 safety)', async () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
+    );
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://shared-blaze.test/sparql' },
+      },
+      fetch: fn,
+    });
+
+    expect(result.wiped).toBe(true);
+    expect(calls).toHaveLength(1);
+    const update = decodeUpdateBody(calls[0].init?.body);
+    expect(update).toContain('DELETE');
+    expect(update).toContain('did:dkg:context-graph:');
+    expect(update).toContain('strstarts');
+    expect(update).not.toBe('DROP ALL');
+  });
+
+  it('records SPARQL failure in failedFiles + does not persist marker', async () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
+    );
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const { fn } = mockFetch(
+      () => new Response('endpoint exploded', { status: 500, statusText: 'Server Error' }),
+    );
+    const logs: string[] = [];
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://broken.test/sparql' },
+      },
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.wiped).toBe(true);
+    expect(result.failedFiles).toHaveLength(1);
+    expect(result.failedFiles[0].file).toContain('scoped-delete');
+    expect(result.failedFiles[0].error).toContain('500');
+
+    // Local files still wiped (we don't gate file wipe on SPARQL).
+    expect(existsSync(join(dataDir, 'store.nq'))).toBe(false);
+
+    // Marker NOT persisted — retry on next boot.
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.chainResetMarker).toBe(OLD_MARKER);
+    expect(logs.some((l) => l.includes('Chain reset marker was not persisted'))).toBe(true);
+  });
+
+  it('records transport error in failedFiles', async () => {
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const fn: typeof globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as typeof globalThis.fetch;
+
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://nope.test/sparql' },
+      },
+      fetch: fn,
+    });
+
+    expect(result.failedFiles.some((f) => f.error.includes('ECONNREFUSED'))).toBe(true);
+  });
+
+  it('skips external wipe entirely for local backends (storeConfig present, backend oxigraph-worker)', async () => {
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'oxigraph-worker',
+        // Options that LOOK like an external URL: these must be ignored
+        // because the backend itself is local. Otherwise an operator who
+        // hand-tuned options would see surprise SPARQL requests.
+        options: { url: 'http://ignored.test/sparql' as unknown as string },
+      },
+      fetch: fn,
+    });
+
+    expect(result.wiped).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(result.failedFiles).toEqual([]);
+  });
+
+  it('uses sparql-http updateEndpoint when configured separately from queryEndpoint', async () => {
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'sparql-http',
+        options: {
+          queryEndpoint: 'http://server.test/query',
+          updateEndpoint: 'http://server.test/update',
+          auth: 'Bearer t0ken',
+          managedByDkg: false,
+        },
+      },
+      fetch: fn,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://server.test/update');
+    const headers = (calls[0].init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer t0ken');
+  });
+});
+
+// =====================================================================
+// Backend-switch detection (RFC 120 review point #6 / plan PR 1 item 8)
+// =====================================================================
+//
+// Without an explicit check, an operator who hand-edits
+// `config.store.backend` between boots gets a fresh empty backend and
+// no warning — looks identical to data loss. detectBackendSwitch tags
+// each boot's backend into the same `.network-state.json` file and
+// refuses to boot on mismatch unless `acceptStoreReset` is true.
+
+describe('detectBackendSwitch', () => {
+  it('records current backend on first boot (no state file) without warning', () => {
+    const logs: string[] = [];
+    const result = detectBackendSwitch({
+      dataDir,
+      currentBackend: 'oxigraph-worker',
+      acceptStoreReset: false,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.previous).toBeNull();
+    expect(result.aborted).toBe(false);
+
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.lastBackend).toBe('oxigraph-worker');
+    // First-boot path is silent — no STORE-SWITCH warning header.
+    expect(logs.find((l) => l.includes('STORE-SWITCH'))).toBeUndefined();
+  });
+
+  it('records current backend on a legacy state file (lastBackend absent) without warning', () => {
+    // Legacy: state file from before this field was added. Has only
+    // chainResetMarker + savedAt.
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: NEW_MARKER, savedAt: Date.now() }),
+    );
+
+    const logs: string[] = [];
+    const result = detectBackendSwitch({
+      dataDir,
+      currentBackend: 'blazegraph',
+      acceptStoreReset: false,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.previous).toBeNull();
+    expect(result.aborted).toBe(false);
+
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.lastBackend).toBe('blazegraph');
+    // chainResetMarker must survive the backend-tag write.
+    expect(persisted.chainResetMarker).toBe(NEW_MARKER);
+  });
+
+  it('is a no-op when backend matches previous boot', () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: null, lastBackend: 'oxigraph-worker', savedAt: Date.now() }),
+    );
+
+    const logs: string[] = [];
+    const result = detectBackendSwitch({
+      dataDir,
+      currentBackend: 'oxigraph-worker',
+      acceptStoreReset: false,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.previous).toBe('oxigraph-worker');
+    expect(result.aborted).toBe(false);
+    expect(logs).toEqual([]);
+  });
+
+  it('aborts boot on mismatch without acceptStoreReset, surfaces multi-line warning', () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: null, lastBackend: 'oxigraph-worker', savedAt: Date.now() }),
+    );
+
+    const logs: string[] = [];
+    const result = detectBackendSwitch({
+      dataDir,
+      currentBackend: 'blazegraph',
+      acceptStoreReset: false,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.previous).toBe('oxigraph-worker');
+    expect(result.aborted).toBe(true);
+
+    const joined = logs.join('\n');
+    expect(joined).toMatch(/STORE-SWITCH/);
+    expect(joined).toMatch(/previous: oxigraph-worker/);
+    expect(joined).toMatch(/current:\s+blazegraph/);
+    expect(joined).toMatch(/DKG_ACCEPT_STORE_RESET=1/);
+
+    // State file MUST still record the old backend so a corrected
+    // config (operator reverts the edit) sees a match on next boot.
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.lastBackend).toBe('oxigraph-worker');
+  });
+
+  it('proceeds and updates state when acceptStoreReset=true', () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: null, lastBackend: 'oxigraph-worker', savedAt: Date.now() }),
+    );
+
+    const logs: string[] = [];
+    const result = detectBackendSwitch({
+      dataDir,
+      currentBackend: 'blazegraph',
+      acceptStoreReset: true,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.aborted).toBe(false);
+
+    // Warning still surfaces so the choice is visible in journalctl,
+    // but with the "proceeding" tail rather than the "refusing" tail.
+    const joined = logs.join('\n');
+    expect(joined).toMatch(/STORE-SWITCH/);
+    expect(joined).toMatch(/proceeding/i);
+    expect(joined).not.toMatch(/Refusing to start/);
+
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.lastBackend).toBe('blazegraph');
+  });
+
+  it('coexists with chainResetWipe — wipe does not clobber the backend tag', async () => {
+    // Establish a baseline by running detectBackendSwitch first.
+    detectBackendSwitch({
+      dataDir,
+      currentBackend: 'oxigraph-worker',
+      acceptStoreReset: false,
+    });
+    expect(
+      JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8')).lastBackend,
+    ).toBe('oxigraph-worker');
+
+    // Now run a marker change — the wipe path persists chainResetMarker
+    // and MUST preserve lastBackend.
+    writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
+    await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+    });
+
+    const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
+    expect(persisted.chainResetMarker).toBe(NEW_MARKER);
+    expect(persisted.lastBackend).toBe('oxigraph-worker');
   });
 });

--- a/packages/cli/test/store-health-check.test.ts
+++ b/packages/cli/test/store-health-check.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Boot-time reachability probe for external SPARQL backends.
+ *
+ * Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 1 item 4.
+ * Locks in:
+ *   - local backends pass without I/O (no fetch issued).
+ *   - external + reachable → ok with endpoint reported.
+ *   - external + HTTP 500 → ok=false with the body snippet surfaced.
+ *   - external + HTTP 404 → namespaceMissing=true + a hint that mentions
+ *     creating the namespace (Blazegraph operators hit this when they
+ *     point at a path before provisioning it).
+ *   - external + transport error → ok=false, error contains the cause.
+ *   - external + AbortController timeout → ok=false, error mentions ms.
+ *   - sparql-http with auth header → Authorization passed through.
+ *   - malformed config (external backend with no URL) → ok=false with a
+ *     config-shape error, not a crashed probe.
+ *   - formatHealthCheckFailure renders multi-line, contains endpoint
+ *     and remediation hints; namespace-missing path mentions creating
+ *     the namespace, not network checks.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  checkExternalStoreReachable,
+  formatHealthCheckFailure,
+} from '../src/daemon/store-health-check.js';
+
+function mockFetch(handler: (input: any, init?: any) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn: typeof globalThis.fetch = (async (input: any, init?: any) => {
+    calls.push({ url: String(input), init });
+    return handler(input, init);
+  }) as typeof globalThis.fetch;
+  return { fn, calls };
+}
+
+describe('checkExternalStoreReachable', () => {
+  it('passes through with no I/O for local backends', async () => {
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await checkExternalStoreReachable({
+      storeConfig: { backend: 'oxigraph-worker' },
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('passes through when storeConfig is undefined (default deployment)', async () => {
+    const result = await checkExternalStoreReachable({ storeConfig: undefined });
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns ok=true for a reachable Blazegraph endpoint', async () => {
+    const { fn, calls } = mockFetch(
+      () =>
+        new Response(JSON.stringify({ head: { vars: [] }, boolean: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    const result = await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://blaze.test/sparql' },
+      },
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.endpoint).toBe('http://blaze.test/sparql');
+    expect(result.backend).toBe('blazegraph');
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0].init?.body)).toContain('query=ASK');
+  });
+
+  it('returns ok=false with HTTP details on 500', async () => {
+    const { fn } = mockFetch(
+      () => new Response('boom', { status: 500, statusText: 'Server Error' }),
+    );
+    const result = await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://broken.test/sparql' },
+      },
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('500');
+    expect(result.namespaceMissing).toBeUndefined();
+  });
+
+  it('returns namespaceMissing=true on HTTP 404 with actionable message', async () => {
+    const { fn } = mockFetch(
+      () => new Response('not found', { status: 404, statusText: 'Not Found' }),
+    );
+    const result = await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://blaze.test/namespace/missing/sparql' },
+      },
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.namespaceMissing).toBe(true);
+    expect(result.error).toMatch(/namespace/i);
+  });
+
+  it('reports transport errors with the underlying message', async () => {
+    const fn: typeof globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as typeof globalThis.fetch;
+    const result = await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://nope.test/sparql' },
+      },
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('ECONNREFUSED');
+  });
+
+  it('reports timeout when the endpoint hangs past timeoutMs', async () => {
+    const fn: typeof globalThis.fetch = (async (
+      _input: any,
+      init?: any,
+    ) => {
+      await new Promise((_resolve, reject) => {
+        const sig = init?.signal as AbortSignal | undefined;
+        if (sig) sig.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+      return new Response();
+    }) as typeof globalThis.fetch;
+
+    const result = await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://slow.test/sparql' },
+      },
+      fetch: fn,
+      timeoutMs: 30,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timed out after 30ms/);
+  });
+
+  it('threads the Authorization header for sparql-http with auth set', async () => {
+    const { fn, calls } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    await checkExternalStoreReachable({
+      storeConfig: {
+        backend: 'sparql-http',
+        options: {
+          queryEndpoint: 'http://server.test/query',
+          auth: 'Bearer t0ken',
+        },
+      },
+      fetch: fn,
+    });
+    const headers = (calls[0].init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer t0ken');
+  });
+
+  it('returns ok=false without throwing when storeConfig is malformed', async () => {
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await checkExternalStoreReachable({
+      storeConfig: { backend: 'blazegraph', options: {} }, // url missing
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/options\.url/);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('formatHealthCheckFailure', () => {
+  it('renders an empty string for ok=true', () => {
+    expect(formatHealthCheckFailure({ ok: true })).toBe('');
+  });
+
+  it('renders endpoint + remediation for a generic failure', () => {
+    const block = formatHealthCheckFailure({
+      ok: false,
+      backend: 'blazegraph',
+      endpoint: 'http://blaze.test/sparql',
+      error: 'HTTP 500',
+    });
+    expect(block).toMatch(/STORE-HEALTH/);
+    expect(block).toMatch(/blazegraph/);
+    expect(block).toMatch(/http:\/\/blaze\.test\/sparql/);
+    expect(block).toMatch(/config\.json/);
+    expect(block).toMatch(/firewall/i);
+  });
+
+  it('biases the hint toward namespace creation when namespaceMissing=true', () => {
+    const block = formatHealthCheckFailure({
+      ok: false,
+      backend: 'blazegraph',
+      endpoint: 'http://blaze.test/namespace/missing/sparql',
+      error: 'HTTP 404 …',
+      namespaceMissing: true,
+    });
+    expect(block).toMatch(/create the namespace/);
+    expect(block).toMatch(/Docker/);
+    expect(block).not.toMatch(/firewall/i);
+  });
+});

--- a/packages/cli/test/store-identity-tag.test.ts
+++ b/packages/cli/test/store-identity-tag.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Namespace identity tagging — locks in the two-daemons-one-namespace
+ * guard added in PR 3 (RFC 120 review point #5).
+ *
+ * Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 3
+ * item 3.
+ *
+ * Locks in:
+ *   - Local backends skipped entirely (no concurrent-access risk).
+ *   - Fresh namespace → tag written via SPARQL UPDATE.
+ *   - Existing tag matches → matched, no UPDATE issued.
+ *   - Existing tag mismatches → ok=false, action='mismatch', message
+ *     includes both node names AND the cleanup recipe.
+ *   - SELECT transport failure → ok=false, action='transport-error'.
+ *   - INSERT transport failure surfaces as transport-error too (i.e.
+ *     we don't silently treat write failure as "tag absent").
+ *   - SELECT 404 → transport-error (not silently treated as "fresh").
+ *   - formatIdentityTagMismatch produces a multi-line block with the
+ *     DELETE WHERE recipe referencing the right URIs.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  checkOrSetStoreIdentity,
+  formatIdentityTagMismatch,
+} from '../src/daemon/store-health-check.js';
+
+function mockFetch(handler: (url: string, init?: any) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit; body?: string }> = [];
+  const fn: typeof globalThis.fetch = (async (input: any, init?: any) => {
+    const body = init?.body != null ? String(init.body) : undefined;
+    calls.push({ url: String(input), init, body });
+    return handler(String(input), init);
+  }) as typeof globalThis.fetch;
+  return { fn, calls };
+}
+
+const BLAZEGRAPH_CONFIG = {
+  backend: 'blazegraph',
+  options: { url: 'http://blaze.test/sparql' },
+};
+
+describe('checkOrSetStoreIdentity', () => {
+  it('skips for local oxigraph backend', async () => {
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: { backend: 'oxigraph-worker' },
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok && result.action === 'skipped') {
+      expect(result.reason).toBe('local-backend');
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  it('skips for undefined storeConfig', async () => {
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: undefined,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('writes the tag when the namespace has no existing identity', async () => {
+    const { fn, calls } = mockFetch((url, init) => {
+      if (init?.body != null && String(init.body).startsWith('query=')) {
+        // SELECT returns no bindings.
+        return new Response(
+          JSON.stringify({ head: { vars: ['name'] }, results: { bindings: [] } }),
+          { status: 200, headers: { 'content-type': 'application/sparql-results+json' } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok && result.action === 'tagged') {
+      expect(result.nodeName).toBe('mynode');
+    }
+    const selectCall = calls.find((c) => c.body?.startsWith('query='));
+    const updateCall = calls.find((c) => c.body?.startsWith('update='));
+    expect(selectCall).toBeDefined();
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.body).toContain(encodeURIComponent('urn:dkg:store-meta'));
+    expect(updateCall?.body).toContain(encodeURIComponent('urn:dkg:storeTaggedFor'));
+    expect(updateCall?.body).toContain(encodeURIComponent('"mynode"'));
+  });
+
+  it('matches silently when the existing tag equals the configured node name', async () => {
+    const { fn, calls } = mockFetch((_url, init) => {
+      if (init?.body != null && String(init.body).startsWith('query=')) {
+        return new Response(
+          JSON.stringify({
+            head: { vars: ['name'] },
+            results: { bindings: [{ name: { type: 'literal', value: 'mynode' } }] },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(null, { status: 200 });
+    });
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok && result.action === 'matched') {
+      expect(result.nodeName).toBe('mynode');
+    }
+    // Crucially: no UPDATE call (no INSERT DATA) when matched.
+    const updateCall = calls.find((c) => c.body?.startsWith('update='));
+    expect(updateCall).toBeUndefined();
+  });
+
+  it('refuses to start when the tag belongs to another node', async () => {
+    const { fn } = mockFetch((_url, init) => {
+      if (init?.body != null && String(init.body).startsWith('query=')) {
+        return new Response(
+          JSON.stringify({
+            head: { vars: ['name'] },
+            results: { bindings: [{ name: { type: 'literal', value: 'alice-node' } }] },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(null, { status: 200 });
+    });
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'bob-node',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.action === 'mismatch') {
+      expect(result.existingNodeName).toBe('alice-node');
+      expect(result.expectedNodeName).toBe('bob-node');
+      expect(result.error).toContain('alice-node');
+      expect(result.error).toContain('bob-node');
+    }
+  });
+
+  it('surfaces transport error on SELECT failure (does not silently treat as fresh)', async () => {
+    const { fn } = mockFetch(() => new Response('boom', { status: 500 }));
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.action).toBe('transport-error');
+      expect(result.error).toMatch(/identity SELECT/);
+    }
+  });
+
+  it('surfaces transport error on INSERT failure', async () => {
+    const { fn } = mockFetch((_url, init) => {
+      if (init?.body != null && String(init.body).startsWith('query=')) {
+        return new Response(
+          JSON.stringify({ head: { vars: ['name'] }, results: { bindings: [] } }),
+          { status: 200 },
+        );
+      }
+      return new Response('write rejected', { status: 503 });
+    });
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.action).toBe('transport-error');
+      expect(result.error).toMatch(/identity INSERT/);
+    }
+  });
+
+  it('surfaces transport error on connection failure', async () => {
+    const { fn } = mockFetch(() => {
+      throw new Error('ECONNREFUSED');
+    });
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.action).toBe('transport-error');
+      expect(result.error).toMatch(/identity SELECT failed/);
+    }
+  });
+
+  it('escapes special characters in the node-name literal', async () => {
+    const { fn, calls } = mockFetch((_url, init) => {
+      if (init?.body != null && String(init.body).startsWith('query=')) {
+        return new Response(
+          JSON.stringify({ head: { vars: ['name'] }, results: { bindings: [] } }),
+          { status: 200 },
+        );
+      }
+      return new Response(null, { status: 200 });
+    });
+    await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'node "with quotes"',
+      fetch: fn,
+    });
+    const updateCall = calls.find((c) => c.body?.startsWith('update='));
+    expect(updateCall).toBeDefined();
+    // After url-decoding, the literal should be `"node \"with quotes\""`.
+    const decoded = decodeURIComponent(updateCall!.body!.replace(/^update=/, ''));
+    expect(decoded).toContain('"node \\"with quotes\\""');
+  });
+
+  it('respects custom timeoutMs (the controller fires AbortError quickly)', async () => {
+    const { fn } = mockFetch(
+      () => new Promise((_resolve, reject) => {
+        setTimeout(() => {
+          const e = new Error('aborted');
+          e.name = 'AbortError';
+          reject(e);
+        }, 10);
+      }),
+    );
+    const result = await checkOrSetStoreIdentity({
+      storeConfig: BLAZEGRAPH_CONFIG,
+      nodeName: 'mynode',
+      fetch: fn,
+      timeoutMs: 20,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.action).toBe('transport-error');
+  });
+});
+
+describe('formatIdentityTagMismatch', () => {
+  it('returns empty string for any non-mismatch result', () => {
+    expect(formatIdentityTagMismatch({ ok: true, action: 'skipped', reason: 'local-backend' })).toBe('');
+    expect(formatIdentityTagMismatch({ ok: true, action: 'matched', nodeName: 'mynode' })).toBe('');
+    expect(formatIdentityTagMismatch({ ok: true, action: 'tagged', nodeName: 'mynode' })).toBe('');
+    expect(formatIdentityTagMismatch({ ok: false, action: 'transport-error', error: 'boom' })).toBe('');
+  });
+
+  it('formats a mismatch as a multi-line block with the cleanup recipe', () => {
+    const block = formatIdentityTagMismatch({
+      ok: false,
+      action: 'mismatch',
+      existingNodeName: 'alice-node',
+      expectedNodeName: 'bob-node',
+      error: 'boom',
+    });
+    expect(block).toContain('STORE-IDENTITY');
+    expect(block).toContain('this node:    bob-node');
+    expect(block).toContain('store tagged: alice-node');
+    expect(block).toContain('DELETE WHERE');
+    expect(block).toContain('urn:dkg:store-meta');
+    expect(block).toContain('urn:dkg:storeTaggedFor');
+  });
+});

--- a/packages/cli/test/store-wizard.test.ts
+++ b/packages/cli/test/store-wizard.test.ts
@@ -109,7 +109,13 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: (m) => logs.push(m),
     });
-    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://blaze.test/sparql',
+        managedByDkg: false,
+      },
+    });
     expect(logs.some((l) => l.includes('STORE-HEALTH'))).toBe(true);
   });
 
@@ -161,7 +167,13 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: (m) => logs.push(m),
     });
-    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://blaze.test/sparql',
+        managedByDkg: false,
+      },
+    });
     expect(logs.some((l) => l.includes('Docker not detected'))).toBe(true);
   });
 
@@ -251,7 +263,13 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: (m) => logs.push(m),
     });
-    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://blaze.test/sparql',
+        managedByDkg: false,
+      },
+    });
     expect(logs.some((l) => l.includes('Docker provisioning failed'))).toBe(true);
   });
 
@@ -297,7 +315,13 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: () => {},
     });
-    expect(result.storeBlock?.options.url).toBe('http://prefilled.test/sparql');
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://prefilled.test/sparql',
+        managedByDkg: false,
+      },
+    });
     expect(calls[0].url).toBe('http://prefilled.test/sparql');
   });
 
@@ -314,7 +338,13 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: () => {},
     });
-    expect(result.storeBlock?.options.url).toBe('http://existing.test/sparql');
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://existing.test/sparql',
+        managedByDkg: false,
+      },
+    });
   });
 
   it('supports sparql-http with its own queryEndpoint URL', async () => {
@@ -326,8 +356,14 @@ describe('promptStoreBackend', () => {
       fetch: fn,
       log: () => {},
     });
-    expect(result.storeBlock?.backend).toBe('sparql-http');
-    expect(result.storeBlock?.options.url).toBe('http://server.test/query');
+    expect(result.storeBlock).toEqual({
+      backend: 'sparql-http',
+      options: {
+        queryEndpoint: 'http://server.test/query',
+        updateEndpoint: 'http://server.test/query',
+        managedByDkg: false,
+      },
+    });
     expect(calls[0].url).toBe('http://server.test/query');
   });
 });
@@ -468,7 +504,14 @@ describe('applyStoreFlagsToConfig', () => {
       fetch: fn,
       log: () => {},
     });
-    expect(store.saved[0].store?.backend).toBe('sparql-http');
+    expect(store.saved[0].store).toEqual({
+      backend: 'sparql-http',
+      options: {
+        queryEndpoint: 'http://server.test/query',
+        updateEndpoint: 'http://server.test/query',
+        managedByDkg: false,
+      },
+    });
     expect(calls[0].url).toBe('http://server.test/query');
   });
 });

--- a/packages/cli/test/store-wizard.test.ts
+++ b/packages/cli/test/store-wizard.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Wizard + flag helpers that thread the triple-store backend through
+ * `dkg init` and the adapter-setup commands.
+ *
+ * Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 2
+ * items 1, 2, 3, 5.
+ *
+ * Locks in:
+ *   - Default path (operator hits Enter / no flag): no store block.
+ *   - Blazegraph + valid URL: store block persisted with
+ *     `managedByDkg: false`.
+ *   - Blazegraph + unreachable URL: surfaces formatted failure, allows
+ *     retry, abort returns to local default.
+ *   - Blazegraph + 404 URL: namespace-missing branch fires; message
+ *     mentions namespace, not network.
+ *   - Blank URL prompt: PR 2's "no Docker yet" message + retry.
+ *   - `--store oxigraph` on a config that already has a Blazegraph
+ *     block: clears the block (operator forcing local).
+ *   - `--store blazegraph` without `--store-url`: throws with the
+ *     missing-URL message (no half-written config).
+ *   - Validation failure throws so the CLI dispatch wrapper exits.
+ *   - Unknown backend value throws with the allow-list error.
+ *
+ * No filesystem I/O — `loadConfig` / `saveConfig` are injected as
+ * mocks. Real config wiring is exercised in the higher-level adapter-
+ * setup integration tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { applyStoreFlagsToConfig, promptStoreBackend } from '../src/store-wizard.js';
+import type { DkgConfig } from '../src/config.js';
+
+function mockFetch(handler: (input: any, init?: any) => Response | Promise<Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn: typeof globalThis.fetch = (async (input: any, init?: any) => {
+    calls.push({ url: String(input), init });
+    return handler(input, init);
+  }) as typeof globalThis.fetch;
+  return { fn, calls };
+}
+
+function mockAsk(scriptedAnswers: string[]): (q: string, def?: string) => Promise<string> {
+  let i = 0;
+  return async (q: string, def?: string) => {
+    if (i >= scriptedAnswers.length) {
+      throw new Error(`Out of scripted answers (asked: "${q}" default="${def ?? ''}")`);
+    }
+    const answer = scriptedAnswers[i++];
+    return answer === '' && def ? def : answer;
+  };
+}
+
+// ---------------------------------------------------------------------
+// promptStoreBackend
+// ---------------------------------------------------------------------
+
+describe('promptStoreBackend', () => {
+  it('returns no store block when operator accepts the oxigraph default', async () => {
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    const result = await promptStoreBackend({
+      ask: mockAsk(['']), // accept default ("oxigraph")
+      fetch: fn,
+      log: () => {},
+    });
+    expect(result.storeBlock).toBeNull();
+    expect(calls).toHaveLength(0); // no URL probe issued for local
+  });
+
+  it('returns no store block when operator types "oxigraph" explicitly', async () => {
+    const result = await promptStoreBackend({
+      ask: mockAsk(['oxigraph']),
+      log: () => {},
+    });
+    expect(result.storeBlock).toBeNull();
+  });
+
+  it('persists Blazegraph + reachable URL with managedByDkg=false', async () => {
+    const { fn, calls } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', 'http://blaze.test/sparql']),
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: { url: 'http://blaze.test/sparql', managedByDkg: false },
+    });
+    expect(calls).toHaveLength(1);
+    expect(logs.some((l) => l.includes('reachable'))).toBe(true);
+  });
+
+  it('surfaces failure formatter on unreachable URL, retries with a working one', async () => {
+    let attempt = 0;
+    const { fn } = mockFetch(() => {
+      attempt++;
+      if (attempt === 1) return new Response('boom', { status: 500 });
+      return new Response(JSON.stringify({ boolean: true }), { status: 200 });
+    });
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        'http://broken.test/sparql', // first attempt: 500
+        'y', // retry
+        'http://blaze.test/sparql', // works
+      ]),
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(logs.some((l) => l.includes('STORE-HEALTH'))).toBe(true);
+  });
+
+  it('aborts to local default when operator declines retry on unreachable URL', async () => {
+    const { fn } = mockFetch(() => new Response('boom', { status: 500 }));
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        'http://broken.test/sparql',
+        'n', // refuse retry
+      ]),
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock).toBeNull();
+    expect(logs.some((l) => l.includes('Aborting store setup'))).toBe(true);
+  });
+
+  it('surfaces namespace-missing branch on 404 with namespace-specific hint', async () => {
+    const { fn } = mockFetch(
+      () => new Response('not found', { status: 404 }),
+    );
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', 'http://blaze.test/namespace/missing/sparql', 'n']),
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock).toBeNull();
+    const block = logs.join('\n');
+    expect(block).toMatch(/create the namespace/);
+    expect(block).not.toMatch(/firewall/i); // namespace-missing biases AWAY from network hints
+  });
+
+  it('shows "Docker not detected" message on blank URL when Docker is unavailable, then accepts a manual URL', async () => {
+    const { fn } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        '', // blank URL — Docker probe fails → operator gets retry prompt
+        'y', // retry
+        'http://blaze.test/sparql', // works
+      ]),
+      isDockerAvailable: async () => false,
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(logs.some((l) => l.includes('Docker not detected'))).toBe(true);
+  });
+
+  it('aborts when operator types blank URL and declines retry (Docker unavailable)', async () => {
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', '', 'n']),
+      isDockerAvailable: async () => false,
+      log: () => {},
+    });
+    expect(result.storeBlock).toBeNull();
+  });
+
+  // ---------------------------------------------------------------
+  // PR 3 Docker convenience branch
+  // ---------------------------------------------------------------
+
+  it('offers Docker provisioning when blank URL + Docker available, returns managedByDkg=true on accept', async () => {
+    const provisionCalls: any[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        '', // blank URL — triggers Docker offer
+        'y', // accept Docker offer
+      ]),
+      nodeName: 'mynode',
+      isDockerAvailable: async () => true,
+      provisionBlazegraphDocker: async (opts) => {
+        provisionCalls.push(opts);
+        return {
+          url: 'http://127.0.0.1:9999/bigdata/namespace/mynode/sparql',
+          port: 9999,
+          containerName: 'dkg-blazegraph-mynode',
+          managedByDkg: true,
+          reused: false,
+          namespaceCreated: true,
+        };
+      },
+      log: () => {},
+    });
+    expect(result.storeBlock).toEqual({
+      backend: 'blazegraph',
+      options: {
+        url: 'http://127.0.0.1:9999/bigdata/namespace/mynode/sparql',
+        managedByDkg: true,
+      },
+    });
+    expect(provisionCalls).toHaveLength(1);
+    expect(provisionCalls[0].namespace).toBe('mynode');
+  });
+
+  it('declines Docker offer ("n") falls through to retry/abort branch', async () => {
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        '',  // blank URL
+        'n', // decline Docker
+        'n', // decline retry-with-URL → abort to local default
+      ]),
+      isDockerAvailable: async () => true,
+      provisionBlazegraphDocker: async () => {
+        throw new Error('should not be called when operator declines');
+      },
+      log: () => {},
+    });
+    expect(result.storeBlock).toBeNull();
+  });
+
+  it('falls through to retry when Docker provisioning fails', async () => {
+    const logs: string[] = [];
+    const { fn } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    const result = await promptStoreBackend({
+      ask: mockAsk([
+        'blazegraph',
+        '', // blank URL
+        'y', // accept Docker
+        // Docker fails → retry-with-URL prompt
+        'y', // retry
+        'http://blaze.test/sparql', // provide URL
+      ]),
+      nodeName: 'mynode',
+      isDockerAvailable: async () => true,
+      provisionBlazegraphDocker: async () => {
+        throw new Error('docker daemon down');
+      },
+      fetch: fn,
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock?.options.url).toBe('http://blaze.test/sparql');
+    expect(logs.some((l) => l.includes('Docker provisioning failed'))).toBe(true);
+  });
+
+  it('does not offer Docker when isDockerAvailable returns false', async () => {
+    const logs: string[] = [];
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', '', 'n']),
+      isDockerAvailable: async () => false,
+      provisionBlazegraphDocker: async () => {
+        throw new Error('should not be called');
+      },
+      log: (m) => logs.push(m),
+    });
+    expect(result.storeBlock).toBeNull();
+    expect(logs.some((l) => l.includes('Docker not detected'))).toBe(true);
+  });
+
+  it('does not offer Docker for sparql-http backend', async () => {
+    let provisionCalled = false;
+    const result = await promptStoreBackend({
+      ask: mockAsk(['sparql-http', '', 'n']),
+      isDockerAvailable: async () => true,
+      provisionBlazegraphDocker: async () => {
+        provisionCalled = true;
+        throw new Error('should not happen');
+      },
+      log: () => {},
+    });
+    expect(provisionCalled).toBe(false);
+    expect(result.storeBlock).toBeNull();
+  });
+
+  it('pre-fills URL prompt from --store-url flag', async () => {
+    const { fn, calls } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    // Mock ask returns the default when the answer is empty; passing
+    // '' simulates the operator hitting Enter to accept the pre-fill.
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', '']),
+      flagBackend: 'blazegraph',
+      flagUrl: 'http://prefilled.test/sparql',
+      fetch: fn,
+      log: () => {},
+    });
+    expect(result.storeBlock?.options.url).toBe('http://prefilled.test/sparql');
+    expect(calls[0].url).toBe('http://prefilled.test/sparql');
+  });
+
+  it('honours existingStore.options.url as the URL default on re-run', async () => {
+    const { fn } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    const result = await promptStoreBackend({
+      ask: mockAsk(['blazegraph', '']), // accept defaults
+      existingStore: {
+        backend: 'blazegraph',
+        options: { url: 'http://existing.test/sparql' },
+      },
+      fetch: fn,
+      log: () => {},
+    });
+    expect(result.storeBlock?.options.url).toBe('http://existing.test/sparql');
+  });
+
+  it('supports sparql-http with its own queryEndpoint URL', async () => {
+    const { fn, calls } = mockFetch(
+      () => new Response(JSON.stringify({ boolean: true }), { status: 200 }),
+    );
+    const result = await promptStoreBackend({
+      ask: mockAsk(['sparql-http', 'http://server.test/query']),
+      fetch: fn,
+      log: () => {},
+    });
+    expect(result.storeBlock?.backend).toBe('sparql-http');
+    expect(result.storeBlock?.options.url).toBe('http://server.test/query');
+    expect(calls[0].url).toBe('http://server.test/query');
+  });
+});
+
+// ---------------------------------------------------------------------
+// applyStoreFlagsToConfig
+// ---------------------------------------------------------------------
+
+interface MockConfigStore {
+  current: DkgConfig;
+  saved: DkgConfig[];
+}
+
+function newMockConfig(initial: DkgConfig): MockConfigStore {
+  return { current: { ...initial }, saved: [] };
+}
+
+function mockConfigIO(store: MockConfigStore) {
+  return {
+    loadConfig: async () => ({ ...store.current }),
+    saveConfig: async (next: DkgConfig) => {
+      store.current = { ...next };
+      store.saved.push({ ...next });
+    },
+  };
+}
+
+describe('applyStoreFlagsToConfig', () => {
+  const baseConfig: DkgConfig = {
+    name: 'dkg-node',
+    apiPort: 9200,
+    listenPort: 4001,
+  } as DkgConfig;
+
+  it('is a no-op when no --store flag is provided', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    await applyStoreFlagsToConfig({ ...io, log: () => {} });
+    expect(store.saved).toEqual([]);
+  });
+
+  it('persists blazegraph + URL after probe succeeds', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    const { fn } = mockFetch(() => new Response(null, { status: 200 }));
+    await applyStoreFlagsToConfig({
+      ...io,
+      storeFlag: 'blazegraph',
+      storeUrlFlag: 'http://blaze.test/sparql',
+      fetch: fn,
+      log: () => {},
+    });
+    expect(store.saved).toHaveLength(1);
+    expect(store.saved[0].store).toEqual({
+      backend: 'blazegraph',
+      options: { url: 'http://blaze.test/sparql', managedByDkg: false },
+    });
+  });
+
+  it('throws when --store blazegraph is passed without --store-url (no half-written config)', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    await expect(
+      applyStoreFlagsToConfig({
+        ...io,
+        storeFlag: 'blazegraph',
+        log: () => {},
+      }),
+    ).rejects.toThrow(/requires --store-url/);
+    expect(store.saved).toEqual([]);
+  });
+
+  it('throws when the URL is unreachable, persists nothing', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    const { fn } = mockFetch(() => new Response('boom', { status: 500 }));
+    await expect(
+      applyStoreFlagsToConfig({
+        ...io,
+        storeFlag: 'blazegraph',
+        storeUrlFlag: 'http://broken.test/sparql',
+        fetch: fn,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/store URL validation failed/);
+    expect(store.saved).toEqual([]);
+  });
+
+  it('throws on unknown backend value', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    await expect(
+      applyStoreFlagsToConfig({
+        ...io,
+        storeFlag: 'neptune',
+        log: () => {},
+      }),
+    ).rejects.toThrow(/oxigraph, blazegraph, sparql-http/);
+  });
+
+  it('clears existing store block when --store oxigraph is passed', async () => {
+    const store = newMockConfig({
+      ...baseConfig,
+      store: {
+        backend: 'blazegraph',
+        options: { url: 'http://blaze.test/sparql', managedByDkg: false },
+      },
+    });
+    const io = mockConfigIO(store);
+    await applyStoreFlagsToConfig({
+      ...io,
+      storeFlag: 'oxigraph',
+      log: () => {},
+    });
+    expect(store.saved).toHaveLength(1);
+    expect(store.saved[0].store).toBeUndefined();
+  });
+
+  it('is a no-op when --store oxigraph is passed and no existing store block', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    await applyStoreFlagsToConfig({
+      ...io,
+      storeFlag: 'oxigraph',
+      log: () => {},
+    });
+    expect(store.saved).toEqual([]);
+  });
+
+  it('accepts sparql-http with its endpoint URL', async () => {
+    const store = newMockConfig(baseConfig);
+    const io = mockConfigIO(store);
+    const { fn, calls } = mockFetch(() => new Response(null, { status: 200 }));
+    await applyStoreFlagsToConfig({
+      ...io,
+      storeFlag: 'sparql-http',
+      storeUrlFlag: 'http://server.test/query',
+      fetch: fn,
+      log: () => {},
+    });
+    expect(store.saved[0].store?.backend).toBe('sparql-http');
+    expect(calls[0].url).toBe('http://server.test/query');
+  });
+});

--- a/packages/cli/test/validate-store-config.test.ts
+++ b/packages/cli/test/validate-store-config.test.ts
@@ -1,0 +1,191 @@
+/**
+ * `validateStoreConfig` enforces the extra requirements that external
+ * triple-store backends impose:
+ *
+ *   - blazegraph requires `store.options.url`.
+ *   - sparql-http requires `store.options.queryEndpoint`.
+ *   - largeLiteralStorage/snapshot storage requires explicit `directory`
+ *     when paired with an external backend (no local store path to
+ *     infer from).
+ *
+ * Local backends (default Oxigraph) are unaffected — the function is a
+ * no-op for them.
+ *
+ * Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md` §PR 1 item 6.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateStoreConfig, type DkgConfig } from '../src/config.js';
+
+function mk(overrides: Partial<DkgConfig> = {}): DkgConfig {
+  return {
+    name: 'dkg-node',
+    apiPort: 9200,
+    listenPort: 4001,
+    ...overrides,
+  } as DkgConfig;
+}
+
+describe('validateStoreConfig', () => {
+  describe('default (no store block)', () => {
+    it('returns no errors when store is undefined', () => {
+      expect(validateStoreConfig(mk())).toEqual([]);
+    });
+  });
+
+  describe('local backends', () => {
+    it('no-op for oxigraph-worker', () => {
+      expect(
+        validateStoreConfig(mk({ store: { backend: 'oxigraph-worker' } })),
+      ).toEqual([]);
+    });
+
+    it('ignores stray external-shaped options on a local backend', () => {
+      // An operator's leftover options field should not trip validation
+      // if the backend is local; the wipe + health check honour
+      // isExternalBackend the same way.
+      const errors = validateStoreConfig(
+        mk({ store: { backend: 'oxigraph-worker', options: { url: 'irrelevant' } } }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('blazegraph', () => {
+    it('errors when options.url is missing', () => {
+      const errors = validateStoreConfig(mk({ store: { backend: 'blazegraph' } }));
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('store.options.url');
+      expect(errors[0].message).toMatch(/store\.options\.url/);
+    });
+
+    it('errors when options.url is empty / whitespace', () => {
+      const errors = validateStoreConfig(
+        mk({ store: { backend: 'blazegraph', options: { url: '  ' } } }),
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('store.options.url');
+    });
+
+    it('passes with a non-empty url', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: {
+            backend: 'blazegraph',
+            options: { url: 'http://127.0.0.1:9999/bigdata/namespace/x/sparql' },
+          },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('sparql-http', () => {
+    it('errors when queryEndpoint is missing', () => {
+      const errors = validateStoreConfig(
+        mk({ store: { backend: 'sparql-http', options: {} } }),
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('store.options.queryEndpoint');
+    });
+
+    it('passes with a queryEndpoint', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: {
+            backend: 'sparql-http',
+            options: { queryEndpoint: 'http://server.test/query' },
+          },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('largeLiteralStorage', () => {
+    it('errors when enabled with external backend but no directory', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: { url: 'http://x/sparql' } },
+          largeLiteralStorage: { enabled: true },
+        }),
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('largeLiteralStorage.directory');
+    });
+
+    it('passes when external + enabled + directory set', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: { url: 'http://x/sparql' } },
+          largeLiteralStorage: { enabled: true, directory: '/var/lib/dkg/blobs' },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('does not error when external but largeLiteralStorage is disabled', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: { url: 'http://x/sparql' } },
+          largeLiteralStorage: { enabled: false },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('does not enforce the directory requirement for local backends', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'oxigraph-worker' },
+          largeLiteralStorage: { enabled: true },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('sharedMemoryPublicSnapshotStorage', () => {
+    it('errors when external + enabled + missing directory', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: { url: 'http://x/sparql' } },
+          sharedMemoryPublicSnapshotStorage: { enabled: true },
+        }),
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('sharedMemoryPublicSnapshotStorage.directory');
+    });
+
+    it('passes when explicit directory set', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: { url: 'http://x/sparql' } },
+          sharedMemoryPublicSnapshotStorage: {
+            enabled: true,
+            directory: '/var/lib/dkg/snapshots',
+          },
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('multi-error aggregation', () => {
+    it('reports every problem in one pass, not first-fail', () => {
+      const errors = validateStoreConfig(
+        mk({
+          store: { backend: 'blazegraph', options: {} }, // missing url
+          largeLiteralStorage: { enabled: true }, // missing directory
+          sharedMemoryPublicSnapshotStorage: { enabled: true }, // missing directory
+        }),
+      );
+      expect(errors).toHaveLength(3);
+      const fields = errors.map((e) => e.field).sort();
+      expect(fields).toEqual([
+        'largeLiteralStorage.directory',
+        'sharedMemoryPublicSnapshotStorage.directory',
+        'store.options.url',
+      ]);
+    });
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -34,6 +34,19 @@ export default defineConfig({
           'test/async-promote-worker.test.ts',
           'test/async-promote-queue-e2e.test.ts',
           'test/skill-endpoint.test.ts',
+          // RFC 120 / plan PR 1 + 2 — Blazegraph support. Pure logic
+          // (mocked fetch + in-memory config); cheap to keep in the
+          // fast unit lane.
+          'test/chain-reset-wipe.test.ts',
+          'test/store-health-check.test.ts',
+          'test/validate-store-config.test.ts',
+          'test/store-wizard.test.ts',
+          'test/blazegraph-docker.test.ts',
+          'test/store-identity-tag.test.ts',
+          // Opt-in via BLAZEGRAPH_INTEGRATION_TEST=1. Skips silently
+          // (no fetch / no docker spawn) when the env-var is unset, so
+          // keeping it in the fast unit lane costs nothing.
+          'test/blazegraph-integration.test.ts',
         ],
     testTimeout: runsDaemonHttpBehavior ? 120_000 : 60_000,
     globalSetup: runsDaemonHttpBehavior ? ['../chain/test/hardhat-global-setup.ts'] : [],

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-export type OperationName = 'publish' | 'update' | 'query' | 'resolve' | 'connect' | 'sync' | 'system' | 'share' | 'publishFromSWM' | 'gossip' | 'ka-update' | 'reconstruct' | 'init' | 'verify';
+export type OperationName = 'publish' | 'update' | 'query' | 'resolve' | 'connect' | 'sync' | 'system' | 'share' | 'publishFromSWM' | 'gossip' | 'ka-update' | 'reconstruct' | 'init' | 'verify' | 'migrate-swm-attr';
 
 export interface OperationContext {
   operationId: string;

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.11",
+  "version": "10.0.0-rc.12",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/graph-viz/src/core/graph-model.ts
+++ b/packages/graph-viz/src/core/graph-model.ts
@@ -55,7 +55,14 @@ export class GraphModel {
   readonly edges = new Map<string, GraphEdge>();
   prefixes: PrefixMap = {};
 
-  /** All raw triples stored for reification processing and export */
+  /**
+   * Stores triples in canonical form — subject, predicate, and (when the
+   * object is a resource) object are `cleanUri`-normalised at ingress so
+   * downstream consumers and lookup paths (e.g. `removeTriples`,
+   * reification mirrors, diff exporters) all operate on a single
+   * representation. Literal objects are kept verbatim so quoting,
+   * datatypes, and language tags survive the round-trip.
+   */
   private _triples: RdfTriple[] = [];
 
   /** Set of predicate URIs treated as metadata (not rendered as edges) */
@@ -118,11 +125,17 @@ export class GraphModel {
 
   /** Add a single triple to the model */
   addTriple(triple: RdfTriple): void {
-    this._triples.push(triple);
-
     const subj = cleanUri(triple.subject);
     const pred = cleanUri(triple.predicate);
-    const obj = cleanUri(triple.object);
+    const objectIsResource = isResourceObject(triple.object);
+    const obj = objectIsResource ? cleanUri(triple.object) : triple.object;
+
+    this._triples.push({
+      ...triple,
+      subject: subj,
+      predicate: pred,
+      object: obj,
+    });
 
     const subjectNode = this.ensureNode(subj);
 
@@ -133,9 +146,6 @@ export class GraphModel {
       }
       return;
     }
-
-    // Check if object is a resource (URI/bnode) or a literal
-    const objectIsResource = isResourceObject(triple.object);
 
     if (objectIsResource) {
       // Metadata predicates → store as metadata properties, not edges
@@ -255,11 +265,12 @@ export class GraphModel {
     for (const triple of triples) {
       const subj = cleanUri(triple.subject);
       const pred = cleanUri(triple.predicate);
-      const obj = cleanUri(triple.object);
+      const objectIsResource = isResourceObject(triple.object);
+      const obj = objectIsResource ? cleanUri(triple.object) : triple.object;
 
-      // Remove from raw triples
+      // Match against the canonical form `_triples` stores (see field doc).
       const idx = this._triples.findIndex(
-        (t) => t.subject === triple.subject && t.predicate === triple.predicate && t.object === triple.object
+        (t) => t.subject === subj && t.predicate === pred && t.object === obj
       );
       if (idx !== -1) this._triples.splice(idx, 1);
 
@@ -271,8 +282,6 @@ export class GraphModel {
         }
         continue;
       }
-
-      const objectIsResource = isResourceObject(triple.object);
 
       if (objectIsResource && !this._metadataPredicates.has(pred)) {
         const eid = edgeId(subj, pred, obj);
@@ -298,7 +307,7 @@ export class GraphModel {
           const store = this._metadataPredicates.has(pred) ? node.metadata : node.properties;
           const vals = store.get(pred);
           if (vals) {
-            const filtered = vals.filter((v) => v.value !== triple.object);
+            const filtered = vals.filter((v) => v.value !== obj);
             if (filtered.length === 0) {
               store.delete(pred);
             } else {

--- a/packages/graph-viz/tests/graph-model.test.ts
+++ b/packages/graph-viz/tests/graph-model.test.ts
@@ -235,6 +235,89 @@ describe('GraphModel', () => {
       expect(fromA).toHaveLength(1);
       expect(fromA[0].predicate).toBe('https://schema.org/likes');
     });
+
+    // Regression: GH #692 — `addTriple` cleanUri-normalises the indices but
+    // used to push the raw triple into `_triples`, so a later `removeTriples`
+    // call that used the opposite bracket style would tear down the indices
+    // while leaving the orphaned triple stranded in `_triples`.
+    it('removes a triple added with brackets when called without brackets', () => {
+      model.addTriple({
+        subject: '<urn:x>',
+        predicate: '<urn:p>',
+        object: '<urn:y>',
+      });
+      model.removeTriples([{
+        subject: 'urn:x',
+        predicate: 'urn:p',
+        object: 'urn:y',
+      }]);
+
+      expect(model.tripleCount).toBe(0);
+      expect(model.edges.size).toBe(0);
+      expect(model.nodes.size).toBe(0);
+    });
+
+    it('removes a triple added without brackets when called with brackets', () => {
+      model.addTriple({
+        subject: 'urn:x',
+        predicate: 'urn:p',
+        object: 'urn:y',
+      });
+      model.removeTriples([{
+        subject: '<urn:x>',
+        predicate: '<urn:p>',
+        object: '<urn:y>',
+      }]);
+
+      expect(model.tripleCount).toBe(0);
+      expect(model.edges.size).toBe(0);
+      expect(model.nodes.size).toBe(0);
+    });
+
+    it('stores triples in canonical (cleanUri-normalised) form', () => {
+      model.addTriple({
+        subject: '<urn:x>',
+        predicate: '<urn:p>',
+        object: '<urn:y>',
+      });
+
+      const [stored] = model.triples;
+      expect(stored.subject).toBe('urn:x');
+      expect(stored.predicate).toBe('urn:p');
+      expect(stored.object).toBe('urn:y');
+    });
+
+    it('preserves literal objects verbatim (no bracket-stripping on literals)', () => {
+      model.addTriple({
+        subject: '<urn:x>',
+        predicate: '<urn:name>',
+        object: 'Alice',
+      });
+
+      const [stored] = model.triples;
+      expect(stored.subject).toBe('urn:x');
+      expect(stored.object).toBe('Alice');
+    });
+
+    it('removes an rdf:type triple regardless of bracket style on either side', () => {
+      const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+      model.addTriple({
+        subject: '<urn:x>',
+        predicate: RDF_TYPE,
+        object: '<https://schema.org/Person>',
+      });
+
+      expect(model.nodes.get('urn:x')!.types).toContain('https://schema.org/Person');
+
+      model.removeTriples([{
+        subject: 'urn:x',
+        predicate: RDF_TYPE,
+        object: 'https://schema.org/Person',
+      }]);
+
+      expect(model.tripleCount).toBe(0);
+      expect(model.nodes.size).toBe(0);
+    });
   });
 
   describe('clear', () => {

--- a/packages/node-ui/src/metrics-collector.ts
+++ b/packages/node-ui/src/metrics-collector.ts
@@ -34,7 +34,12 @@ export interface MetricsSource {
   getTotalKAs(): Promise<number>;
   getConfirmedKCs(): Promise<number>;
   getTentativeKCs(): Promise<number>;
-  getStoreBytes(): Promise<number>;
+  // External SPARQL backends (Blazegraph, sparql-http) own no local
+  // file, so `null` is the correct signal: collector writes a NULL into
+  // the `store_bytes` SQLite column (already nullable). Quad count for
+  // external backends is exposed on demand via `/api/status` instead of
+  // periodically snapshotted.
+  getStoreBytes(): Promise<number | null>;
   getRpcLatencyMs(): Promise<number>;
   isRpcHealthy(): Promise<boolean>;
   /**

--- a/packages/node-ui/src/ui/api-wrapper.ts
+++ b/packages/node-ui/src/ui/api-wrapper.ts
@@ -55,6 +55,7 @@ export const api = {
   fetchWalletsBalances: () => withFallback(realApi.fetchWalletsBalances, mockApi.fetchWalletsBalances),
   fetchCurrentAgent: () => withFallback(realApi.fetchCurrentAgent, mockApi.fetchCurrentAgent),
   listParticipants: (id: string) => withFallback(() => realApi.listParticipants(id), () => mockApi.listParticipants(id)),
+  fetchSubGraphs: (id: string) => withFallback(() => realApi.fetchSubGraphs(id), () => mockApi.fetchSubGraphs(id)),
   fetchNotifications: (p?: any) => withFallback(() => realApi.fetchNotifications(p), mockApi.fetchNotifications),
   fetchNodeLog: (p?: any) => withFallback(() => realApi.fetchNodeLog(p), mockApi.fetchNodeLog),
   fetchMemorySessions: (n?: number) => withFallback(() => realApi.fetchMemorySessions(n), mockApi.fetchMemorySessions),

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -463,6 +463,46 @@ export async function importFile(
 }
 
 // --- Query ---
+
+// In-flight POST /api/query dedup. Coalesces concurrent identical
+// requests so React strict-mode double-mounts and sibling views asking
+// the same SPARQL against the same CG share one underlying fetch.
+//
+// Scope is *strictly inflight*: the entry is deleted as soon as the
+// promise settles (success OR failure), so the next call always issues
+// a fresh request. No caching, no staleness window — this is purely
+// concurrent-coalescing, drop-in safe for every existing caller.
+//
+// Motivation: opening a project on the dashboard fires `useMemoryEntities`
+// from two mounted instances (Dashboard card + ProjectView), giving 6
+// identical `/api/query` POSTs for the WM/SWM/VM fan-out against a
+// multi-GB Oxigraph store. Each duplicate adds seconds of wall time on
+// large stores. Inflight dedup collapses the dupes to one.
+const inflightQuery = new Map<string, Promise<{ result: any }>>();
+
+export function postQueryDeduped(body: Record<string, unknown>): Promise<{ result: any }> {
+  const key = JSON.stringify(body);
+  const existing = inflightQuery.get(key);
+  if (existing) return existing;
+  const promise = (async () => {
+    const res = await fetch(`${BASE}/api/query`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: key,
+    });
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      const msg = (errBody as { error?: string })?.error ?? `HTTP ${res.status}`;
+      throw new HttpError(res.status, msg, errBody);
+    }
+    return res.json() as Promise<{ result: any }>;
+  })().finally(() => {
+    inflightQuery.delete(key);
+  });
+  inflightQuery.set(key, promise);
+  return promise;
+}
+
 export const executeQuery = (
   sparql: string,
   contextGraphId?: string,
@@ -470,7 +510,7 @@ export const executeQuery = (
   graphSuffix?: '_shared_memory',
   view?: 'verified-memory' | 'shared-working-memory',
 ) =>
-  post<{ result: any }>('/api/query', { sparql, contextGraphId, includeSharedMemory, graphSuffix, view });
+  postQueryDeduped({ sparql, contextGraphId, includeSharedMemory, graphSuffix, view });
 
 // --- Publish (assertion-lifecycle: RFC-001 §9.x sign-at-creation) ---
 //

--- a/packages/node-ui/src/ui/components/ActivityFeed.tsx
+++ b/packages/node-ui/src/ui/components/ActivityFeed.tsx
@@ -141,10 +141,30 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   // mirroring the per-bucket chip; we render the same row in both
   // the empty and populated branches so the heading stays anchored
   // (showing "0" rather than vanishing into the empty state).
+  //
+  // PR #694 polish carry-over (b) — when the lifecycle SPARQL
+  // errored AND no rows are visible (`items.length === 0`), render
+  // `—` instead of "0". Showing "0" next to "RECENT ACTIVITY" while
+  // the error indicator below says "Couldn't load recent activity."
+  // contradicts itself (precise count vs not-loaded). The em-dash
+  // keeps the row anchored without claiming a specific number.
+  //
+  // Codex review on PR #769 — when carry-over (a)'s cached rows
+  // remain after a same-graph refresh failure, we DO have a real
+  // list visible below. Falling back to `—` in that path would
+  // make the badge disagree with the rendered count. Tighten the
+  // condition: only render `—` when there are genuinely no rows
+  // to count.
+  const showErrorPlaceholder = lifecycleError != null && items.length === 0;
   const titleRow = title ? (
     <div className="v10-activity-feed-title">
       <span className="v10-activity-feed-title-label">{title}</span>
-      <span className="v10-activity-feed-title-count">{titleCount}</span>
+      <span
+        className="v10-activity-feed-title-count"
+        data-state={showErrorPlaceholder ? 'error' : undefined}
+      >
+        {showErrorPlaceholder ? '—' : titleCount}
+      </span>
     </div>
   ) : null;
 

--- a/packages/node-ui/src/ui/components/ContextGraphPrimitives.tsx
+++ b/packages/node-ui/src/ui/components/ContextGraphPrimitives.tsx
@@ -86,6 +86,13 @@ export type StatStripItem = {
   label: ReactNode;
   value: ReactNode;
   hint?: ReactNode;
+  /** Advisory text rendered as a native `title` tooltip on the
+   *  cell. Use this for contextual/status copy that would clutter
+   *  the grid if rendered inline (e.g. M6 layer-availability hints
+   *  on the Overview Entities cell). `hint` and `tooltip` are
+   *  independent — `hint` still renders inline; `tooltip` only
+   *  appears on hover. */
+  tooltip?: string;
 };
 
 export function StatStrip({
@@ -110,7 +117,12 @@ export function StatStrip({
       style={style}
     >
       {items.map((item, index) => (
-        <div key={item.id ?? index} className="v10-stat-strip-cell">
+        <div
+          key={item.id ?? index}
+          className="v10-stat-strip-cell"
+          data-stat-id={item.id}
+          title={item.tooltip}
+        >
           <span className="v10-stat-strip-label">{item.label}</span>
           <span className="v10-stat-strip-value">{item.value}</span>
           {item.hint && <span className="v10-stat-strip-hint">{item.hint}</span>}

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -1,6 +1,7 @@
 /**
- * Compact horizontal strip of sub-graph chips. Sits above MemoryStrip and
- * scopes the whole project view to the selected sub-graph (or "All").
+ * Compact horizontal strip of sub-graph chips. Sits above the layer
+ * detail view and scopes the whole project view to the selected
+ * sub-graph (or "All").
  *
  * Visual styling is fully driven by the project profile: each SubGraphBinding
  * contributes its icon/color/label. Per-sub-graph entity/triple counts come
@@ -12,6 +13,7 @@ import { fetchSubGraphs, type SubGraphInfo } from '../api.js';
 import type { ProjectProfile } from '../hooks/useProjectProfile.js';
 import type { MemoryEntity } from '../hooks/useMemoryEntities.js';
 import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
+import { isUserFacingSubGraph } from '../lib/subGraphs.js';
 
 export interface SubGraphBadge {
   /** Short label shown inline on the chip, e.g. "2 proposed" */
@@ -169,7 +171,7 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
     // the daemon's `sg.entityCount` (project-wide total) is still used
     // as the fallback for Overview / Subgraphs callers that omit `layer`.
     return subGraphs
-      .filter(sg => sg.name !== 'meta')
+      .filter(isUserFacingSubGraph)
       .map(sg => {
         const binding = profile.forSubGraph(sg.name);
         // Prefer the locally-derived distinct count (matches the entity

--- a/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
+++ b/packages/node-ui/src/ui/hooks/useAssertionLifecycleEvents.ts
@@ -155,6 +155,15 @@ export function useAssertionLifecycleEvents(
   const [error, setError] = useState<string | null>(null);
   const [resultContextGraphId, setResultContextGraphId] = useState<string | undefined>(undefined);
   const lastRequestedCg = useRef<string | undefined>(undefined);
+  // Mirrors `resultContextGraphId` for use inside the async effect
+  // closure WITHOUT capturing a stale value. PR #769 Codex review —
+  // the prior shape read `resultContextGraphId` via a functional
+  // `setResultContextGraphId(prev => …)` updater that also fired
+  // `setEvents([])` as a side effect; React requires updaters to
+  // stay pure (and Strict Mode invokes them twice to detect impurity).
+  // A ref kept in sync at every write site is the contract-clean way
+  // to read "what graph last resolved" inside the catch path.
+  const lastResultCg = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     if (!contextGraphId) {
@@ -177,6 +186,7 @@ export function useAssertionLifecycleEvents(
       setEvents([]);
       setError(null);
       setResultContextGraphId(undefined);
+      lastResultCg.current = undefined;
     }
     let cancelled = false;
     const controller = new AbortController();
@@ -254,11 +264,32 @@ export function useAssertionLifecycleEvents(
         }
         setEvents(out);
         setResultContextGraphId(contextGraphId);
+        lastResultCg.current = contextGraphId;
         setError(null);
       } catch (err) {
         if (cancelled || (err as any)?.name === 'AbortError') return;
         setError((err as Error).message ?? String(err));
-        setEvents([]);
+        // PR #694 polish carry-over (a) — preserve the last-known-
+        // good feed on a same-graph refresh failure (transient
+        // 503 / timeout / network blip). Different-graph stale
+        // cache was already cleared at the top of the effect
+        // (lines ~176-181) before the fetch fired, so by the time
+        // we reach this catch `lastResultCg.current` is EITHER
+        // undefined (first fetch on this graph — nothing cached
+        // for us to keep) OR === contextGraphId (a prior fetch on
+        // THIS graph succeeded — keep those rows so the UI doesn't
+        // collapse to empty while the error indicator surfaces
+        // alongside).
+        //
+        // PR #769 Codex review — the ref-based read avoids both
+        // the stale-closure trap on `resultContextGraphId` AND
+        // the React-contract violation of nesting `setEvents([])`
+        // inside a `setResultContextGraphId` updater (updaters must
+        // stay pure; Strict Mode invokes them twice to detect
+        // impurity).
+        if (lastResultCg.current !== contextGraphId) {
+          setEvents([]);
+        }
         // PR #694 review fix — advance `resultContextGraphId` on
         // failure so consumers gating on
         // `resultContextGraphId === contextGraphId` (the Code7 pattern
@@ -268,6 +299,7 @@ export function useAssertionLifecycleEvents(
         // failure keeps consumers stuck in the previous-graph state
         // until the hook re-runs.
         setResultContextGraphId(contextGraphId);
+        lastResultCg.current = contextGraphId;
       } finally {
         if (timeoutId) clearTimeout(timeoutId);
         if (!cancelled) setLoading(false);

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { authHeaders } from '../api.js';
+import { postQueryDeduped } from '../api.js';
 import { useMemoryGraphEvents } from './useNodeEvents.js';
 import { MEMORY_LABEL_PREDICATES } from '../lib/memoryLabels.js';
 
@@ -316,14 +316,12 @@ async function queryLayer(
   // (Codex). Whether a total failure escalates to a hard `error` stays
   // the configurable part (see `signalErrors`).
   try {
+    // Routed through `postQueryDeduped` so the 3-way WM/SWM/VM fan-out
+    // here coalesces with any other concurrently-mounted instance of
+    // this hook (e.g. Dashboard card + ProjectView both subscribed to
+    // the same CG). One underlying fetch instead of N for each layer.
     const body: any = { sparql, contextGraphId, ...opts };
-    const res = await fetch('/api/query', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...authHeaders() },
-      body: JSON.stringify(body),
-    });
-    if (!res.ok) throw new Error(`/api/query failed (${res.status})`);
-    const data = await res.json();
+    const data: any = await postQueryDeduped(body);
     const bindings = data?.result?.bindings ?? data?.results?.bindings ?? [];
     const triples = bindings
       .map((row: any) => {

--- a/packages/node-ui/src/ui/lib/subGraphs.ts
+++ b/packages/node-ui/src/ui/lib/subGraphs.ts
@@ -1,0 +1,28 @@
+// Single source of truth for the "which sub-graphs count as
+// user-facing" filter, consumed by three call sites: ProjectView's
+// Overview Subgraphs stat, SubGraphBar's chip row, and
+// SubGraphOverviewGrid's card wall. Centralising here means S3
+// has one place to extend if the reserved set ever grows.
+//
+// Contract: `meta` is the only reserved slug. It's the auto-registered
+// profile/metadata subgraph that surfaces in the daemon's
+// `listSubGraphs` (`packages/agent/src/dkg-agent.ts`); it holds the
+// project profile, not user-facing entities, so consumers filter it.
+// The daemon itself doesn't return `_`-prefixed internal graphs in
+// `/sub-graph/list` — that filtering happens server-side, so we don't
+// need to enumerate them here.
+
+export const RESERVED_SUB_GRAPH_SLUGS: ReadonlySet<string> = new Set(['meta']);
+
+/**
+ * Returns true if a sub-graph descriptor should be surfaced to
+ * users (chip row, card grid, Overview count). False for reserved
+ * bookkeeping slugs.
+ *
+ * Accepts any object that carries a `name` (the slug). Both the
+ * daemon's `SubGraphInfo` (`api.ts`) and ad-hoc test fixtures
+ * fit.
+ */
+export function isUserFacingSubGraph(sg: { name: string }): boolean {
+  return !RESERVED_SUB_GRAPH_SLUGS.has(sg.name);
+}

--- a/packages/node-ui/src/ui/mocks/provider.ts
+++ b/packages/node-ui/src/ui/mocks/provider.ts
@@ -15,6 +15,12 @@ export const mockApi = {
   fetchCurrentAgent: () => delay(mock.MOCK_AGENT_IDENTITY),
   listParticipants: (id: string) =>
     delay(mock.MOCK_PARTICIPANTS[id] ?? { contextGraphId: id, allowedAgents: [] }),
+  // Codex review bug F — Overview's Subgraphs stat consumes the
+  // wrapped `fetchSubGraphs` so it resolves in mock mode instead of
+  // sitting at "..." after a real /sub-graph/list 404. Default to an
+  // empty list; per-CG mocks can override via MOCK_SUBGRAPHS.
+  fetchSubGraphs: (id: string) =>
+    delay((mock as any).MOCK_SUBGRAPHS?.[id] ?? { contextGraphId: id, subGraphs: [] }),
   fetchNotifications: () => delay(mock.MOCK_NOTIFICATIONS),
   fetchNodeLog: () => delay(mock.MOCK_NODE_LOG),
   fetchMemorySessions: () => delay(mock.MOCK_SESSIONS),

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -4859,32 +4859,6 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-ph-agent-tool { font-size: 9px; font-weight: 500; color: var(--text-tertiary); background: var(--bg-elevated); padding: 0 5px; border-radius: 3px; }
 
-.v10-ph-join-requests { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border-subtle); }
-.v10-ph-join-badge {
-  display: inline-flex; align-items: center; justify-content: center;
-  min-width: 16px; height: 16px; border-radius: 8px; font-size: 9px; font-weight: 700;
-  background: #f59e0b; color: #000; margin-left: 6px; padding: 0 4px;
-}
-.v10-ph-join-list { display: flex; flex-direction: column; gap: 6px; }
-.v10-ph-join-item {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 6px 10px; border-radius: 8px; background: var(--bg-surface);
-  border: 1px solid #f59e0b44;
-}
-.v10-ph-join-info { display: flex; flex-direction: column; gap: 1px; }
-.v10-ph-join-name { font-size: 11px; font-weight: 600; color: var(--text-primary); }
-.v10-ph-join-addr { font-size: 9px; font-family: var(--font-mono); color: var(--text-tertiary); }
-.v10-ph-join-actions { display: flex; gap: 4px; }
-.v10-ph-join-btn {
-  border: none; border-radius: 6px; font-size: 10px; font-weight: 600; cursor: pointer;
-  padding: 4px 10px; transition: background 0.15s;
-}
-.v10-ph-join-btn.approve { background: #22c55e22; color: var(--text-success); border: 1px solid #22c55e44; }
-.v10-ph-join-btn.approve:hover { background: #22c55e44; }
-.v10-ph-join-btn.reject { background: #ef444422; color: var(--text-danger); border: 1px solid #ef444444; padding: 4px 8px; }
-.v10-ph-join-btn.reject:hover { background: #ef444444; }
-.v10-ph-join-btn:disabled { opacity: 0.5; cursor: default; }
-
 /* Lazy route spinner */
 .lazy-spinner{display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-tertiary);font-size:13px}
 
@@ -5102,6 +5076,16 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   border: 1px solid color-mix(in srgb, var(--v10-stat-accent) 18%, var(--border-default));
   border-radius: 8px;
   background: color-mix(in srgb, var(--v10-stat-accent) 5%, var(--bg-surface));
+  /* ui-lead item 7 — Dashboard-style hover: border tints toward
+     the layer accent (falls back to --border-strong on vanilla
+     cells) and a soft shadow rises. The M4 VM-hero gate still
+     binds — DO NOT modify cell padding, border radius, or value
+     size; only the hover-state border-color and box-shadow. */
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.v10-stat-strip-cell:hover {
+  border-color: color-mix(in srgb, var(--v10-stat-accent) 35%, var(--border-strong));
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 .v10-stat-strip-value {
   display: block;
@@ -5165,78 +5149,252 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 
 /* ── Project Overview Card ── */
-.v10-po { flex-shrink: 0; padding: 16px; border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel); }
-.v10-po-top { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 14px; }
-.v10-po-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--text-primary); flex-shrink: 0; margin-top: 4px; }
-.v10-po-heading { flex: 1 1 auto; min-width: 0; }
-.v10-po-title { font-size: 15px; font-weight: 600; color: var(--text-primary); }
-.v10-po-desc { font-size: 11px; color: var(--text-tertiary); margin-top: 2px; line-height: 1.5; }
-.v10-po-stat-strip { margin-bottom: 12px; }
-.v10-po-stats { display: flex; gap: 20px; margin-bottom: 12px; flex-wrap: wrap; }
-.v10-po-stat { display: flex; flex-direction: column; align-items: center; gap: 1px; min-width: 50px; }
-.v10-po-stat-val { font-size: 20px; font-weight: 700; color: var(--text-primary); font-family: var(--font-mono); }
-.v10-po-stat-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-tertiary); font-weight: 600; }
-.v10-po-participants { margin-bottom: 12px; }
-.v10-po-participants-label { font-size: 9px; font-weight: 700; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 6px; }
-.v10-po-participants-list { display: flex; flex-wrap: wrap; gap: 6px; }
-.v10-po-participant {
-  display: inline-flex; align-items: center; gap: 5px;
-  padding: 3px 10px; border-radius: 12px; font-size: 11px; font-weight: 600;
-  background: var(--bg-surface); border: 1px solid var(--border-default); color: var(--text-primary);
-}
-.v10-po-participant-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
-.v10-po-progress { margin-bottom: 0; }
-.v10-po-progress-label { display: flex; justify-content: space-between; font-size: 10px; color: var(--text-tertiary); margin-bottom: 4px; }
-.v10-po-progress-bar { display: flex; height: 6px; border-radius: 3px; overflow: hidden; background: var(--bg-elevated); }
-.v10-po-progress-seg { min-width: 3px; transition: width 0.3s ease; }
-.v10-po-progress-seg.wm { background: #64748b; }
-.v10-po-progress-seg.swm { background: #f59e0b; }
-.v10-po-progress-seg.vm { background: #22c55e; }
-.v10-po-progress-legend { display: flex; gap: 14px; margin-top: 6px; font-size: 9px; font-family: var(--font-mono); color: var(--text-tertiary); }
-.v10-po-legend-item { display: flex; align-items: center; gap: 4px; }
-.v10-po-legend-dot { width: 6px; height: 6px; border-radius: 50%; }
-.v10-po-badges {
+.v10-po { flex-shrink: 0; padding: 16px; border-bottom: 1px solid var(--border-subtle); background: var(--bg-surface); }
+/* Identity row (S2 finalize §4.2.1) — label-pill pairs left, primer
+   link right. Name + description live in the persistent
+   ProjectHeaderStrip. The role glyph (◆) is applied here in CSS via
+   `data-role` so the data string stays semantic-free; same for the
+   curator marker on a participant row. */
+.v10-po-identity {
   display: flex;
-  flex: 0 0 auto;
   flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 6px;
-  max-width: 45%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin: 0 0 14px;
+  padding: 0 0 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.v10-po-identity-pairs {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 18px;
+}
+.v10-po-identity-pair {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.v10-po-identity-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
 }
 .v10-po-badge {
   display: inline-flex;
   align-items: center;
+  gap: 4px;
   min-height: 22px;
-  padding: 0 9px;
+  padding: 2px 10px;
   border-radius: 999px;
   border: 1px solid var(--border-default);
   background: var(--bg-surface);
-  color: var(--text-secondary);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 700;
-  text-transform: uppercase;
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
 }
-.v10-po-badge.curator,
-.v10-po-badge.public {
-  border-color: rgba(34, 197, 94, 0.38);
-  background: rgba(34, 197, 94, 0.11);
+.v10-po-badge[data-role="curator"]::before {
+  content: "◆";
+  margin-right: 4px;
+  font-weight: 700;
   color: var(--text-success);
 }
-.v10-po-badge.participant,
-.v10-po-badge.curated {
+.v10-po-badge[data-role="curator"] {
+  border-color: rgba(34, 197, 94, 0.4);
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--text-success);
+}
+.v10-po-badge[data-role="participant"] {
+  border-color: rgba(59, 130, 246, 0.4);
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--text-primary);
+}
+.v10-po-badge[data-role="viewer"],
+.v10-po-badge[data-role="unknown"] {
+  color: var(--text-secondary);
+}
+.v10-po-badge[data-cg-type="public"] {
+  border-color: rgba(34, 197, 94, 0.4);
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--text-success);
+}
+.v10-po-badge[data-cg-type="curated"] {
   border-color: rgba(245, 158, 11, 0.4);
-  background: rgba(245, 158, 11, 0.12);
+  background: rgba(245, 158, 11, 0.1);
   color: var(--text-warning);
 }
-.v10-po-badge.viewer,
-.v10-po-badge.unknown {
-  color: var(--text-tertiary);
+.v10-po-badge[data-cg-type="unknown"] {
+  color: var(--text-secondary);
 }
+.v10-po-identity-primer {
+  flex: 0 0 auto;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  min-height: 28px;
+  padding: 0 12px;
+}
+.v10-po-identity-primer:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+.v10-po-stat-strip { margin-bottom: 12px; }
+/* ui-lead item 3 — section title above the At-a-glance grid so it
+   matches the structure of the other peer regions (Knowledge
+   Pipeline, Participant agents, Pending join requests). */
+.v10-po-stat-block { margin-bottom: 12px; }
+.v10-po-stat-block > .v10-po-section-title { margin-bottom: 8px; }
+/* Participant agents list */
+.v10-po-people { margin: 12px 0 0; padding-top: 12px; border-top: 1px solid var(--border-subtle); }
+.v10-po-people > .v10-po-section-title { margin-bottom: 8px; }
+.v10-po-people-empty {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+.v10-po-participants-list { display: flex; flex-wrap: wrap; gap: 6px; }
+.v10-po-participant {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 10px; border-radius: 12px; font-size: 11px; font-weight: 600;
+  background: var(--bg-surface); border: 1px solid var(--border-default); color: var(--text-primary);
+}
+/* Glyph is rendered in CSS so the data string the test reads stays
+   unambiguous (just the suffix). Default participants get the
+   hollow ◯ glyph in `--text-secondary`. */
+.v10-po-participant::before {
+  content: "◯ ";
+  font-size: 12px;
+  line-height: 1;
+  color: var(--text-secondary);
+}
+/* §4.2.1 Delta 1 (locked) — `.is-self` carries TWO signals only:
+   weight (you-ness, paired with the ` · you` suffix in the data
+   string) + the filled ◆ glyph in `--text-info`. No border or
+   background override — three signals for one fact would be the
+   M4 VM-hero regression pattern. */
+.v10-po-participant.is-self { font-weight: 700; }
+.v10-po-participant.is-self::before {
+  content: "◆ ";
+  color: var(--text-info);
+}
+/* A non-self curator also carries the filled ◆ glyph (canonical
+   role glyph), tinted with the verified-trust color. No bold, no
+   chip-level tint — the glyph + ` · curator` suffix carry the
+   meaning. */
+.v10-po-participant.is-curator:not(.is-self)::before {
+  content: "◆ ";
+  color: var(--text-success);
+}
+/* When the current user IS the curator, success color wins over
+   info so curator role reads first. The .is-self bold is retained. */
+.v10-po-participant.is-self.is-curator::before {
+  color: var(--text-success);
+}
+.v10-po-participant-name {
+  white-space: nowrap;
+}
+/* ui-lead item 2 — suffix tags render as separate spans with a
+   CSS-driven `·` separator. Keeps the data string semantic-free
+   (the tag text is just "you" / "curator" — no glyphs or
+   punctuation in the DOM textContent). */
+.v10-po-participant-tag {
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+.v10-po-participant-tag::before {
+  content: "·";
+  margin: 0 6px;
+  color: var(--text-ghost);
+  font-weight: 400;
+}
+/* Pending join requests — peer section under Participant agents,
+   curator-only. */
+.v10-po-join { margin: 12px 0 0; padding: 12px 16px 0; border-top: 1px solid var(--border-subtle); }
+.v10-po-join-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.v10-po-join-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  background: rgba(245, 158, 11, 0.16);
+  color: var(--text-warning);
+  border: 1px solid rgba(245, 158, 11, 0.4);
+}
+.v10-po-join-count[data-empty="true"] {
+  background: var(--bg-elevated);
+  color: var(--text-tertiary);
+  border-color: var(--border-default);
+}
+.v10-po-join-empty {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+.v10-po-join-list { display: flex; flex-direction: column; gap: 6px; }
+.v10-po-join-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+}
+.v10-po-join-info { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.v10-po-join-name { font-size: 12px; font-weight: 600; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; }
+.v10-po-join-addr { font-size: 10px; font-family: var(--font-mono); color: var(--text-tertiary); }
+.v10-po-join-actions { display: flex; gap: 6px; flex-shrink: 0; }
+.v10-po-join-btn {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.v10-po-join-btn.approve { background: rgba(34, 197, 94, 0.12); color: var(--text-success); border: 1px solid rgba(34, 197, 94, 0.32); }
+.v10-po-join-btn.approve:hover { background: rgba(34, 197, 94, 0.2); }
+.v10-po-join-btn.reject { background: rgba(239, 68, 68, 0.12); color: var(--text-danger); border: 1px solid rgba(239, 68, 68, 0.32); padding: 4px 8px; }
+.v10-po-join-btn.reject:hover { background: rgba(239, 68, 68, 0.2); }
+.v10-po-join-btn:disabled { opacity: 0.5; cursor: default; }
 .v10-po-pipeline {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin: 4px 0 12px;
+  margin: 12px 0 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+/* §4.2.1 ui-lead review finding #1 — even divider rhythm across all
+   7 peer regions. The two boundaries that were previously missing
+   borders (at-a-glance ↔ pipeline above; join-requests ↔ activity
+   below) get them via `[data-section]` attribute selectors, which
+   are the stable hook regardless of inner wrapper class. */
+[data-section="activity"] {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-subtle);
 }
 .v10-po-pipeline-head {
   display: flex;
@@ -5255,24 +5413,6 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   color: var(--text-secondary);
   font-size: 12px;
   line-height: 1.45;
-}
-.v10-po-primer-link {
-  flex: 0 0 auto;
-  border: 1px solid var(--border-default);
-  border-radius: 6px;
-  background: var(--bg-surface);
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-family: var(--font-sans);
-  font-size: 11px;
-  font-weight: 700;
-  min-height: 30px;
-  padding: 0 12px;
-}
-.v10-po-primer-link:hover {
-  border-color: var(--border-strong);
-  color: var(--text-primary);
-  background: var(--bg-hover);
 }
 .v10-po-pipeline-track {
   display: flex;
@@ -5357,6 +5497,47 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
   text-align: right;
 }
 
+/* Primer footer (§4.2.1) — quiet last-row escape hatch. No card
+   chrome; sits flush in the Overview's panel padding. */
+.v10-po-primer-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  padding: 14px 16px;
+  margin-top: 12px;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-tertiary);
+}
+.v10-po-primer-footer-lede {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.v10-po-primer-footer-arrow {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.v10-po-primer-footer-link {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--text-link);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 650;
+}
+.v10-po-primer-footer-link:hover { text-decoration: underline; }
+.v10-po-primer-footer-sub {
+  flex: 1 0 100%;
+  margin-top: 2px;
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-tertiary);
+}
+
 @media (max-width: 1500px) {
   .v10-layer-switch-label-full { display: none; }
   .v10-layer-switch-label-compact { display: inline; }
@@ -5401,74 +5582,25 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 
 @media (max-width: 900px) {
-  .v10-po-top,
+  .v10-po-identity,
   .v10-po-pipeline-head {
     flex-direction: column;
     align-items: stretch;
   }
-  .v10-po-badges {
-    max-width: none;
-    justify-content: flex-start;
+  .v10-po-identity-pairs {
+    flex-wrap: wrap;
+  }
+  .v10-po-identity-primer {
+    align-self: flex-start;
   }
   .v10-po-pipeline-steps {
     grid-template-columns: 1fr;
   }
-  .v10-po-primer-link {
-    align-self: flex-start;
+  .v10-po-primer-footer {
+    flex-direction: row;
+    flex-wrap: wrap;
   }
 }
-
-/* ── Memory Strip ── */
-.v10-memory-strip { flex-shrink: 0; border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel); }
-.v10-memory-layer {
-  display: flex; align-items: stretch; border-bottom: 1px solid var(--border-subtle); min-height: 0; cursor: pointer;
-}
-.v10-memory-layer:last-child { border-bottom: none; }
-.v10-layer-label {
-  width: 160px; flex-shrink: 0; display: flex; align-items: center;
-  gap: 8px; padding: 8px 12px;
-  border-right: 1px solid var(--border-subtle); cursor: pointer;
-  transition: background 0.15s;
-}
-.v10-layer-label:hover { background: var(--bg-hover); }
-.v10-layer-abbr { font-family: var(--font-sans); font-size: 12px; font-weight: 600; white-space: nowrap; }
-.v10-layer-count { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); margin-left: auto; }
-.v10-layer-items {
-  flex: 1; display: flex; align-items: center; gap: 6px;
-  padding: 5px 10px; overflow-x: auto; min-width: 0;
-}
-.v10-layer-chip {
-  flex-shrink: 0; display: flex; align-items: center; gap: 6px;
-  padding: 4px 10px; border-radius: 6px; font-size: 11px;
-  border: 1px solid var(--border-default); background: var(--bg-surface);
-  cursor: pointer; transition: all 0.15s; max-width: 260px;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.v10-layer-chip:hover { border-color: var(--border-strong); background: var(--bg-elevated); }
-.v10-chip-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
-.v10-chip-text { color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; }
-.v10-chip-meta { font-family: var(--font-mono); font-size: 9px; color: var(--text-tertiary); flex-shrink: 0; }
-@keyframes v10-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-.v10-chip-activity { animation: v10-pulse 2s ease-in-out infinite; }
-.v10-memory-layer.wm { background: rgba(100,116,139,0.03); }
-.v10-memory-layer.wm .v10-layer-chip { border-style: dashed; opacity: 0.8; }
-.v10-memory-layer.wm .v10-layer-chip:hover { opacity: 1; }
-.v10-memory-layer.swm { background: rgba(245,158,11,0.02); }
-.v10-memory-layer.vm { background: rgba(34,197,94,0.02); }
-.v10-memory-layer.vm .v10-layer-chip { border-color: rgba(34,197,94,0.2); }
-.v10-layer-chevron {
-  font-size: 10px; color: var(--text-ghost); transition: transform 0.2s; margin-right: 2px;
-  flex-shrink: 0; width: 14px; text-align: center;
-}
-.v10-memory-layer.expanded .v10-layer-chevron { transform: rotate(90deg); }
-
-/* ── Expandable layer in overview ── */
-.v10-layer-expand-content {
-  max-height: 0; overflow: hidden; transition: max-height 0.3s ease;
-  background: var(--bg-root); border-bottom: 1px solid var(--border-subtle);
-  display: flex; flex-direction: column;
-}
-.v10-layer-expand-content.open { max-height: 70vh; height: 70vh; }
 
 /* Tab body fills the remaining space below the tabs strip */
 .v10-layer-expand-body {
@@ -5666,12 +5798,6 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 }
 .v10-layer-expand-items .v10-item-row { padding: 6px 16px; }
 .v10-layer-expand-items .v10-item-row:last-child { border-bottom: none; }
-.v10-layer-expand-footer {
-  padding: 6px 16px 8px; display: flex; gap: 8px;
-  flex-shrink: 0;
-  border-top: 1px solid var(--border-subtle);
-  background: var(--bg-root);
-}
 .v10-layer-expand-footer-btn {
   font-size: 10px; font-weight: 600; color: var(--text-tertiary);
   padding: 4px 10px; border-radius: 5px; border: 1px solid var(--border-default);
@@ -5683,7 +5809,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-layer-expand-footer-btn.publish { color: var(--text-success); border-color: rgba(34,197,94,0.25); }
 .v10-layer-expand-footer-btn.publish:hover { background: rgba(34,197,94,0.08); }
 
-/* ── Item rows (shared by strip and layer views) ── */
+/* ── Item rows (shared by layer views) ── */
 .v10-item-row {
   display: flex; align-items: center; gap: 10px; padding: 8px 16px;
   border-bottom: 1px solid var(--border-subtle); cursor: pointer; transition: background 0.1s;
@@ -7419,11 +7545,12 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
 }
 .v10-project-strip-sg-icon { font-size: 13px; line-height: 1; }
 .v10-project-strip-desc {
-  font-size: 11px; color: var(--text-tertiary);
+  font-size: 12px; color: var(--text-secondary);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  margin-left: auto;
-  max-width: 560px;
-  padding-left: 12px;
+  margin-left: 14px;
+  max-width: 720px;
+  padding-left: 0;
+  flex: 0 1 auto;
 }
 
 /* Context Graph primer */

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { useFetch } from '../hooks.js';
 import { api } from '../api-wrapper.js';
+import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
+import { isUserFacingSubGraph } from '../lib/subGraphs.js';
 import { ImportFilesModal } from '../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../components/Modals/ShareProjectModal.js';
 import {
@@ -26,7 +28,9 @@ import {
   KADetailView,
   SubGraphDetailView,
   ProjectOverviewCard,
-  PendingJoinRequestsBar,
+  PendingJoinRequestsSection,
+  OverviewPrimerEntry,
+  curatorStatusForOverview,
   SubGraphOverviewGrid,
   ContextGraphQueryView,
   LayerDetailView,
@@ -105,6 +109,16 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     list: [],
     status: 'loading',
   });
+  // S2 finalize — Overview "At a glance" needs a subgraph count.
+  // Lifted from SubGraphBar's identical fetch so we don't sneak a
+  // peer hook into useMemoryEntities. `null` = not yet known; the
+  // stat strip then suppresses the cell rather than rendering "0".
+  // The reserved `meta` slug never counts (see `lib/subGraphs.ts`).
+  // `subGraphFetchFailed` distinguishes "still loading" from
+  // "permanently unavailable" (Codex review bug D).
+  const [subGraphCount, setSubGraphCount] = useState<number | null>(null);
+  const [subGraphFetchFailed, setSubGraphFetchFailed] = useState(false);
+  const subGraphRequestRef = useRef(0);
   // Active sub-graph *page* — when set, the middle pane renders the sub-graph
   // detail view instead of the overview / layer views. This is structurally
   // a sibling of `activeLayer`, not a filter over it: sub-graphs are a peer
@@ -311,6 +325,42 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
 
   useEffect(() => { refreshParticipants(); }, [refreshParticipants]);
 
+  const refreshSubGraphCount = useCallback(() => {
+    const requestId = ++subGraphRequestRef.current;
+    // Codex review bug F — route through api-wrapper so the
+    // Subgraphs stat resolves in mock mode (the direct
+    // `../api.js` import bypassed the mock/offline fallback and
+    // left the cell stuck in the loading state forever).
+    api.fetchSubGraphs(contextGraphId)
+      .then(res => {
+        if (subGraphRequestRef.current !== requestId) return;
+        // Codex review issue M — single source of truth for the
+        // reserved-slug rule. Used by SubGraphBar (chips),
+        // SubGraphOverviewGrid (cards), and this Overview stat.
+        // Previously diverged between sites; centralising avoids
+        // future drift.
+        const count = (res.subGraphs ?? []).filter(isUserFacingSubGraph).length;
+        setSubGraphCount(count);
+        setSubGraphFetchFailed(false);
+      })
+      .catch(() => {
+        if (subGraphRequestRef.current !== requestId) return;
+        // Codex review bug D — distinguish "still loading" (count
+        // null + failed=false) from "permanently unavailable"
+        // (count null + failed=true) so the stat strip can render
+        // 'Unavailable' instead of a perpetual ellipsis.
+        setSubGraphCount(null);
+        setSubGraphFetchFailed(true);
+      });
+  }, [contextGraphId]);
+
+  useEffect(() => {
+    setSubGraphCount(null);
+    setSubGraphFetchFailed(false);
+    refreshSubGraphCount();
+  }, [refreshSubGraphCount]);
+  useMemoryGraphEvents(contextGraphId, refreshSubGraphCount);
+
   const selectedLayerTrust = selectedLayerContext ? TRUST_FOR_LAYER[selectedLayerContext] : null;
   const detailEntityTriples = useMemo(
     () => selectedLayerTrust
@@ -500,12 +550,19 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
         </>
       )}
 
-      {/* Overview View */}
+      {/* Overview View — S2 finalize section order (§4.2.1):
+          identity row + At a glance + Knowledge Pipeline + Participant
+          agents live inside ProjectOverviewCard. Pending join requests
+          is a peer section below it (curator-only). Recent activity
+          moves to the last content row before the primer escape hatch
+          which lives inside the card's footer. */}
       {!activeSubGraph && activeLayer === 'overview' && !selectedEntity && (
         <>
           <ProjectOverviewCard
             cg={cg}
             memory={rawMemory}
+            subGraphCount={subGraphCount}
+            subGraphFetchFailed={subGraphFetchFailed}
             participants={participantsForCurrentGraph}
             participantsStatus={participantsStatusForCurrentGraph}
             currentAgent={currentAgent ?? null}
@@ -513,24 +570,35 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             onSwitchLayer={handleLayerSwitch}
             onOpenPrimer={handleOpenPrimer}
           />
-          <PendingJoinRequestsBar contextGraphId={contextGraphId} onParticipantsChanged={refreshParticipants} />
+          <PendingJoinRequestsSection
+            contextGraphId={contextGraphId}
+            curatorStatus={curatorStatusForOverview({
+              cg,
+              currentAgent: currentAgent ?? null,
+              currentAgentStatus: currentAgentLoading ? 'loading' : currentAgentError ? 'error' : 'ok',
+            })}
+            onParticipantsChanged={refreshParticipants}
+          />
           {rawMemory.loading && (
             <div className="v10-me-loading"><div className="v10-me-loading-text">Loading memory...</div></div>
           )}
           {rawMemory.error && (
             <div className="v10-me-error">Error: {rawMemory.error}</div>
           )}
-          <ActivityFeed
-            entities={rawMemory.entityList}
-            lifecycleEvents={overviewLifecycleEvents}
-            lifecycleError={overviewLifecycleError}
-            onSelectEntity={handleOverviewActivityNavigate}
-            title="Recent activity"
-            limit={40}
-            includeUndated={false}
-            emptyHint="Once knowledge starts being added and managed in this context graph, activities will show up here as a live feed."
-            className="v10-overview-activity"
-          />
+          <div data-section="activity">
+            <ActivityFeed
+              entities={rawMemory.entityList}
+              lifecycleEvents={overviewLifecycleEvents}
+              lifecycleError={overviewLifecycleError}
+              onSelectEntity={handleOverviewActivityNavigate}
+              title="Recent activity"
+              limit={40}
+              includeUndated={false}
+              emptyHint="Once knowledge starts being added and managed in this context graph, activities will show up here as a live feed."
+              className="v10-overview-activity"
+            />
+          </div>
+          <OverviewPrimerEntry onOpenPrimer={handleOpenPrimer} />
         </>
       )}
 

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -66,6 +66,8 @@ import {
   type SubGraphTab, type SubGraphEntitySort,
 } from './helpers.js';
 import { EmptyState, StatStrip, toneForLayer } from '../../components/ContextGraphPrimitives.js';
+import { isUserFacingSubGraph } from '../../lib/subGraphs.js';
+import { useNodeEvents } from '../../hooks/useNodeEvents.js';
 
 export const RdfGraph = lazy(() =>
   import('@origintrail-official/dkg-graph-viz/react').then(m => ({ default: m.RdfGraph }))
@@ -538,13 +540,19 @@ function overviewRoleState(
   participantsStatus: OverviewParticipantsStatus,
 ): OverviewRoleState {
   const curator = typeof cg?.curator === 'string' ? cg.curator.trim() : '';
-  const agentDid = currentAgent?.agentDid?.trim() ?? '';
+  // Codex review issue P — match the address-or-did predicate
+  // `curatorStatusForOverview` uses (bug G), so the role pill and
+  // the join-requests gate can't disagree on older daemons that
+  // only surface `agentAddress`. `canonicalAgentDid` already
+  // normalises bare EVM addresses to the prefixed DID form, so
+  // any-of-the-two-matches resolves correctly.
   const agentIds = new Set(
     [currentAgent?.agentDid, currentAgent?.agentAddress]
       .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
       .map(canonicalAgentDid),
   );
-  if (curator && agentDid && canonicalAgentDid(curator) === canonicalAgentDid(agentDid)) {
+  const hasIdentity = agentIds.size > 0;
+  if (curator && hasIdentity && agentIds.has(canonicalAgentDid(curator))) {
     return {
       label: 'Curator',
       title: 'This agent is the curator for this Context Graph.',
@@ -552,14 +560,14 @@ function overviewRoleState(
     };
   }
   if (cg?.callerInvolved === true) {
-    if (curator && !agentDid && currentAgentStatus === 'loading') {
+    if (curator && !hasIdentity && currentAgentStatus === 'loading') {
       return {
         label: 'Role checking',
         title: 'This agent is involved in this Context Graph; curator status is still loading.',
         tone: 'unknown',
       };
     }
-    if (curator && !agentDid && currentAgentStatus === 'error') {
+    if (curator && !hasIdentity && currentAgentStatus === 'error') {
       return {
         label: 'Role unknown',
         title: 'This agent is involved in this Context Graph, but curator status could not be confirmed.',
@@ -608,7 +616,7 @@ function overviewAccessAgentStat(
       id: 'participants',
       value: 'Open',
       label: 'Public access',
-      hint: 'Public Context Graphs do not have an authoritative allowlist count.',
+      tooltip: 'Public Context Graphs do not have an authoritative allowlist count.',
     };
   }
   if (participantsStatus === 'loading') {
@@ -616,7 +624,7 @@ function overviewAccessAgentStat(
       id: 'participants',
       value: '...',
       label: 'Agents with access',
-      hint: 'Participant list is loading.',
+      tooltip: 'Participant list is loading.',
     };
   }
   if (participantsStatus === 'error') {
@@ -624,7 +632,7 @@ function overviewAccessAgentStat(
       id: 'participants',
       value: 'Unavailable',
       label: 'Agents with access',
-      hint: 'Participant list unavailable; access count is unknown.',
+      tooltip: 'Participant list unavailable; access count is unknown.',
     };
   }
 
@@ -641,7 +649,7 @@ function overviewAccessAgentStat(
     id: 'participants',
     value: agents.size.toLocaleString(),
     label: 'Agents with access',
-    hint: 'Includes the curator plus allowlisted participants reported by the node.',
+    tooltip: 'Includes the curator plus allowlisted participants reported by the node.',
   };
 }
 
@@ -668,9 +676,72 @@ function overviewAccessState(raw?: string): { label: string; title: string; tone
   };
 }
 
+// S2 finalize (§4.2.1) — true if the current agent owns the curator
+// role on this CG. Lifted out of overviewRoleState so the Pending
+// Join Requests section can gate on the same predicate without
+// re-deriving it.
+// Codex review bug C — tri-state replaces the prior boolean
+// predicate so a curator's join-requests section isn't hidden
+// while `/api/agent/identity` is still resolving or after a
+// transient error. Consumers decide how to render the `'unknown'`
+// state (we show a 'Verifying access…' loading panel).
+export type CuratorStatus = 'curator' | 'not-curator' | 'unknown';
+
+export function curatorStatusForOverview({
+  cg,
+  currentAgent,
+  currentAgentStatus = 'ok',
+}: {
+  cg: any;
+  currentAgent: OverviewAgentIdentity | null;
+  currentAgentStatus?: OverviewAgentStatus;
+}): CuratorStatus {
+  const curator = typeof cg?.curator === 'string' ? cg.curator.trim() : '';
+  if (!curator) {
+    // Codex review bug I — older / partial CG payloads may omit
+    // `curator` entirely. Returning `'not-curator'` here hard-hides
+    // PendingJoinRequestsSection from real curators whose daemon
+    // simply didn't surface the field (pre-PR boolean predicate
+    // still let /join-requests gate authorisation). `'unknown'`
+    // routes through the "Verifying access…" panel, which is the
+    // right state when we genuinely can't decide.
+    return 'unknown';
+  }
+  // Codex review bug G — older daemons / transient identity errors
+  // may surface `agentAddress` without `agentDid`. `canonicalAgentDid`
+  // already accepts both forms (it normalises bare EVM addresses to
+  // the prefixed DID), so prefer ANY identity material we have over
+  // falling closed. `'unknown'` is reserved for the case where we
+  // truly have nothing to compare against.
+  const did = currentAgent?.agentDid?.trim() ?? '';
+  const addr = currentAgent?.agentAddress?.trim() ?? '';
+  const identity = did || addr;
+  if (!identity) {
+    if (currentAgentStatus === 'loading' || currentAgentStatus === 'error') {
+      return 'unknown';
+    }
+    // Status reports OK but neither agentDid nor agentAddress
+    // materialised — treat as unknown rather than fail-closed.
+    return 'unknown';
+  }
+  return canonicalAgentDid(curator) === canonicalAgentDid(identity)
+    ? 'curator'
+    : 'not-curator';
+}
+
+function overviewIdentitySet(currentAgent: OverviewAgentIdentity | null): Set<string> {
+  return new Set(
+    [currentAgent?.agentDid, currentAgent?.agentAddress]
+      .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+      .map(canonicalAgentDid),
+  );
+}
+
 export function ProjectOverviewCard({
   cg,
   memory,
+  subGraphCount,
+  subGraphFetchFailed = false,
   participants,
   participantsStatus = 'ok',
   currentAgent,
@@ -680,6 +751,13 @@ export function ProjectOverviewCard({
 }: {
   cg: any;
   memory: ReturnType<typeof useMemoryEntities>;
+  /** Count of user-facing sub-graphs (excludes the reserved `meta`
+   *  slug). `null` while loading or on fetch error. */
+  subGraphCount?: number | null;
+  /** True if the last `/sub-graph/list` fetch errored. Lets the
+   *  stat strip distinguish "still loading" from "permanently
+   *  unavailable" (Codex review bug D). */
+  subGraphFetchFailed?: boolean;
   participants: string[];
   participantsStatus?: OverviewParticipantsStatus;
   currentAgent?: OverviewAgentIdentity | null;
@@ -691,8 +769,11 @@ export function ProjectOverviewCard({
   const layerSum = working + shared + verified;
   const role = overviewRoleState(cg, currentAgent ?? null, currentAgentStatus, participants, participantsStatus);
   const access = overviewAccessState(cg?.accessPolicy);
-  const isPublicAccess = normalizeAccessPolicy(cg?.accessPolicy) === 'public';
   const accessAgentStat = overviewAccessAgentStat(cg, participants, participantsStatus);
+  const curator = typeof cg?.curator === 'string' ? cg.curator.trim() : '';
+  const curatorCanonical = curator ? canonicalAgentDid(curator) : '';
+  const isPublicAccess = normalizeAccessPolicy(cg?.accessPolicy) === 'public';
+  const selfIds = overviewIdentitySet(currentAgent ?? null);
   const layerStatuses = Object.values(memory.layerStatus ?? {});
   const unavailableLayerCount = layerStatuses.filter(status => status === 'error').length;
   const allLayerCountsUnavailable =
@@ -706,6 +787,44 @@ export function ProjectOverviewCard({
           ? 'One or more layer counts are currently a lower bound.'
           : 'Canonical current-layer entity counts.';
   const totalEntitiesValue = allLayerCountsUnavailable ? 'Unavailable' : layerSum.toLocaleString();
+  // Triples: canonical layer-correct total exposed by the hook
+  // (§4.2.1 trap — do NOT sum per-entity tripleCount, do NOT borrow
+  // SubGraphBar's `totalTriples` which excludes the root bucket).
+  //
+  // Codex review bug B — `useMemoryEntities` preserves partial
+  // results when one layer query fails, so `allTriples.length` is
+  // only a LOWER BOUND in that case. Mirror the Entities cell
+  // logic: 'Unavailable' if every layer errored, '<n>+' when
+  // partial, the plain number otherwise. The tooltip carries the
+  // explanation (consistent with the Delta-2 tooltip-only hint
+  // pattern).
+  const triplesCount = memory.allTriples?.length ?? 0;
+  const triplesIsPartial = !memory.loading && (memory.partial || hasUnavailableLayer);
+  const triplesValue = allLayerCountsUnavailable
+    ? 'Unavailable'
+    : memory.loading && triplesCount === 0
+      ? '...'
+      : triplesIsPartial
+        ? `${triplesCount.toLocaleString()}+`
+        : triplesCount.toLocaleString();
+  const triplesTooltip = allLayerCountsUnavailable
+    ? 'Live triple counts are unavailable.'
+    : triplesIsPartial
+      ? 'One or more layer triple counts are currently a lower bound.'
+      : 'Canonical triple total across all layers.';
+  // Codex review bug D — distinguish "still fetching" from
+  // "fetch failed" for the Subgraphs cell so we don't show a
+  // perpetual ellipsis after a failed `/sub-graph/list` call. A
+  // failure renders the same `Unavailable` affordance the Entities
+  // outage cell uses (so the four cells share one failure idiom).
+  const subGraphsValue = subGraphCount == null
+    ? subGraphFetchFailed ? 'Unavailable' : '...'
+    : subGraphCount.toLocaleString();
+  const subGraphsTooltip = subGraphCount == null
+    ? subGraphFetchFailed
+      ? 'Sub-graph list is currently unavailable.'
+      : 'Sub-graph count is loading.'
+    : 'Topical partitions inside this Context Graph.';
   const pipeline = [
     {
       key: 'wm' as const,
@@ -736,35 +855,66 @@ export function ProjectOverviewCard({
 
   return (
     <div className="v10-po">
-      <div className="v10-po-top">
-        <span className="v10-po-dot" />
-        <div className="v10-po-heading">
-          <div className="v10-po-title">{cg.name || cg.id}</div>
-          {cg.description && <div className="v10-po-desc">{cg.description}</div>}
+      {/* Identity row (§4.2.1 — locked spec) — label-pill pairs on
+          the left, inline primer link on the right. Name + description
+          live in the persistent `ProjectHeaderStrip`; the role glyph
+          (◆) is applied in CSS via `data-role`/`data-tone`, never in
+          the data string itself. */}
+      <div className="v10-po-identity" data-section="identity">
+        <div className="v10-po-identity-pairs">
+          <div className="v10-po-identity-pair">
+            <span className="v10-po-identity-label">Your role:</span>
+            <span
+              className="v10-po-badge"
+              data-role={role.tone}
+              title={role.title}
+            >
+              {role.label}
+            </span>
+          </div>
+          <div className="v10-po-identity-pair">
+            <span className="v10-po-identity-label">Context Graph:</span>
+            <span
+              className="v10-po-badge"
+              data-cg-type={access.tone}
+              title={access.title}
+            >
+              {access.label}
+            </span>
+          </div>
         </div>
-        <div className="v10-po-badges">
-          <span className={`v10-po-badge ${role.tone}`} title={role.title}>{role.label}</span>
-          <span className={`v10-po-badge ${access.tone}`} title={access.title}>{access.label}</span>
-        </div>
+        {onOpenPrimer && (
+          <button
+            type="button"
+            className="v10-po-identity-primer"
+            onClick={onOpenPrimer}
+            title="Open the Context Graph primer"
+          >
+            What is a Context Graph?
+          </button>
+        )}
       </div>
-      <StatStrip
-        className="v10-po-stat-strip"
-        items={[
-          { id: 'total', value: totalEntitiesValue, label: 'Total entities', hint: statusHint },
-          accessAgentStat,
-        ]}
-      />
-      <div className="v10-po-pipeline" aria-label="Knowledge Pipeline">
+      {/* §4.2.1 Delta 2 (locked) — M6 layer-availability status copy
+          renders as a `title` tooltip on the Entities cell, not as
+          an inline `hint:`, to keep the 4-card grid clean. */}
+      <div data-section="at-a-glance" className="v10-po-stat-block">
+        <div className="v10-po-section-title">At a glance</div>
+        <StatStrip
+          className="v10-po-stat-strip"
+          items={[
+            { id: 'entities', value: totalEntitiesValue, label: 'Entities', tooltip: statusHint },
+            { id: 'triples', value: triplesValue, label: 'Triples', tooltip: triplesTooltip },
+            { id: 'subgraphs', value: subGraphsValue, label: 'Subgraphs', tooltip: subGraphsTooltip },
+            accessAgentStat,
+          ]}
+        />
+      </div>
+      <div className="v10-po-pipeline" data-section="pipeline" aria-label="Knowledge Pipeline">
         <div className="v10-po-pipeline-head">
           <div>
             <div className="v10-po-section-title">Knowledge Pipeline</div>
             <div className="v10-po-section-desc">Entities move from private staging to shared review; published assertion bundles become Knowledge Assets with on-chain provenance.</div>
           </div>
-          {onOpenPrimer && (
-            <button type="button" className="v10-po-primer-link" onClick={onOpenPrimer}>
-              What is a Context Graph?
-            </button>
-          )}
         </div>
         <div className="v10-po-pipeline-track" aria-hidden="true">
           {!pipelineHasUnavailableLayer && layerSum > 0
@@ -803,38 +953,212 @@ export function ProjectOverviewCard({
           ))}
         </div>
       </div>
-      {participants.length > 0 && (
-        <div className="v10-po-participants">
-          <div className="v10-po-participants-label">
-            {isPublicAccess ? 'Known participants' : 'Allowlisted participants'}
-          </div>
-          <div className="v10-po-participants-list">
-            {participants.map(addr => (
-              <span key={addr} className="v10-po-participant" title={addr}>
-                <span className="v10-po-participant-dot" style={{ background: '#3b82f6' }} />
-                {addr.slice(0, 6)}…{addr.slice(-4)}
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
+      {/* Participant agents (§4.2.1) — uniform "Participant agents"
+          heading regardless of access policy. The current user's
+          row carries the `· you` suffix; the curator (whether the
+          current user or someone else) gets `· curator`. Glyphs are
+          applied in CSS via `.is-self` / `.is-curator` — never in the
+          data string. */}
+      <div className="v10-po-people" data-section="participants">
+        <div className="v10-po-section-title">Participant agents</div>
+        {(() => {
+          // Codex review bug A — `/participants` returns `allowedAgents`
+          // and does NOT include the curator on a private CG. Render
+          // the de-duplicated UNION so the curator's own row is always
+          // present (and so the ` · curator` / ` · you · curator`
+          // markers actually have a row to attach to). On a public CG
+          // where the curator may already be in `allowedAgents`, the
+          // dedup makes this a no-op.
+          // Codex review bug H — `cg.curator` arrives as a
+          // `did:dkg:agent:0x…` URI; the rest of the roster comes
+          // from `/participants` as bare EVM addresses. The row
+          // renderer truncates with `slice(0, 6) + … + slice(-4)`,
+          // which would print `did:dk…1234` for the curator row.
+          // Strip the prefix so every row reads in the same
+          // address shape; preserve the full string in the row's
+          // hover `title` so the DID origin is recoverable.
+          const DID_PREFIX = 'did:dkg:agent:';
+          const displayOf = (raw: string): string =>
+            raw.toLowerCase().startsWith(DID_PREFIX)
+              ? raw.slice(DID_PREFIX.length)
+              : raw;
+          // Codex review issue J — only seed the curator row when
+          // the participants list is authoritative. While
+          // `/participants` is loading or has errored, showing
+          // "[◆ curator (you)]" alone would imply a complete roster
+          // on a CG that may actually have other allowlisted members
+          // we can't yet see. Loading / error branches fall through
+          // to the empty-state path which renders the appropriate
+          // status copy.
+          const seen = new Set<string>();
+          const rows: { display: string; full: string; canonical: string }[] = [];
+          if (curator && participantsStatus === 'ok') {
+            const c = canonicalAgentDid(curator);
+            seen.add(c);
+            rows.push({ display: displayOf(curator), full: curator, canonical: c });
+          }
+          if (participantsStatus === 'ok') {
+            for (const addr of participants) {
+              const c = canonicalAgentDid(addr);
+              if (seen.has(c)) continue;
+              seen.add(c);
+              rows.push({ display: displayOf(addr), full: addr, canonical: c });
+            }
+          }
+          if (rows.length === 0) {
+            // Codex review bug E + issue S — access policy is
+            // local-only state from `cg.accessPolicy` and is known
+            // regardless of whether `/participants` succeeded.
+            // Issue S — re-ordered so `isPublicAccess` takes
+            // precedence over the loading/error branches: a public
+            // CG whose `/participants` errored should still tell
+            // the user access is open, not parrot the unavailable
+            // copy. Only curated CGs fall through to the loading /
+            // error / "no participants" sequence.
+            const emptyCopy = isPublicAccess
+              ? 'This Context Graph is public — anyone can subscribe.'
+              : participantsStatus === 'loading'
+                ? 'Loading participant agents...'
+                : participantsStatus === 'error'
+                  ? 'Participant list unavailable.'
+                  : 'No participant agents recorded yet.';
+            return <div className="v10-po-people-empty">{emptyCopy}</div>;
+          }
+          return (
+            <div className="v10-po-participants-list">
+              {rows.map(({ display, full, canonical }) => {
+                const isSelf = selfIds.has(canonical);
+                const isCurator = !!curatorCanonical && canonical === curatorCanonical;
+                // ui-lead item 2 — suffixes render as separate
+                // `.v10-po-participant-tag` spans so the spacing
+                // (the `·` separator) lives in CSS `::before`
+                // pseudo-content instead of the data string.
+                // `aria-label` preserves a screen-reader-friendly
+                // form, since the visible separators aren't in the
+                // accessible name.
+                const shortAddress = `${display.slice(0, 6)}…${display.slice(-4)}`;
+                const ariaLabelParts = [shortAddress];
+                if (isSelf) ariaLabelParts.push('you');
+                if (isCurator) ariaLabelParts.push('curator');
+                return (
+                  <span
+                    key={canonical}
+                    className={`v10-po-participant${isSelf ? ' is-self' : ''}${isCurator ? ' is-curator' : ''}`}
+                    title={full}
+                    aria-label={ariaLabelParts.join(' ')}
+                  >
+                    <span className="v10-po-participant-name">{shortAddress}</span>
+                    {isSelf && <span className="v10-po-participant-tag">you</span>}
+                    {isCurator && <span className="v10-po-participant-tag">curator</span>}
+                  </span>
+                );
+              })}
+            </div>
+          );
+        })()}
+      </div>
     </div>
   );
 }
 
 // ─── Pending Join Requests ───────────────────────────────────
 
-export function PendingJoinRequestsBar({ contextGraphId, onParticipantsChanged }: { contextGraphId: string; onParticipantsChanged?: () => void }) {
+// S2 finalize (§4.2.1) — Pending Join Requests is a peer section
+// under Participant agents. Visible to curators ALWAYS (with a
+// graceful empty state); hidden from definitive non-curators;
+// shown with a 'Verifying access…' state when curator status is
+// still unknown (Codex review bug C — don't fail closed during
+// identity loading / error).
+export function PendingJoinRequestsSection({
+  contextGraphId,
+  curatorStatus,
+  onParticipantsChanged,
+}: {
+  contextGraphId: string;
+  curatorStatus: CuratorStatus;
+  onParticipantsChanged?: () => void;
+}) {
   const [requests, setRequests] = useState<PendingJoinRequest[]>([]);
   const [processing, setProcessing] = useState<string | null>(null);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('loading');
+  // Mirror `cancelled` across the effect via a ref so the
+  // event-driven refetch path can share it with the mount-effect
+  // path without re-creating the closure on every render.
+  const fetchRequestIdRef = useRef(0);
+
+  // Codex review bug N (reverts the optimistic-fetch logic from
+  // bug L). The daemon's `/join-requests` route does NOT gate
+  // on curator identity — see `packages/cli/src/daemon/routes/
+  // context-graph.ts:898-909` which calls
+  // `agent.listPendingJoinRequests`, whose body is a raw SPARQL
+  // read of the meta graph (`packages/agent/src/dkg-agent.ts:
+  // 13126-13152`) with no caller authentication. Until that
+  // gating lands server-side, firing the request in `'unknown'`
+  // status would leak pending-moderation metadata to any caller
+  // whose `/api/agent/identity` lookup is mid-resolution / errored.
+  // Fail closed at the UI: only fetch when we have positive
+  // local proof of curator status. The "Verifying access…"
+  // panel below stays as the safe gate for `'unknown'`.
+  const refresh = useCallback(() => {
+    if (curatorStatus !== 'curator') {
+      setRequests([]);
+      setStatus('idle');
+      return;
+    }
+    const requestId = ++fetchRequestIdRef.current;
+    setStatus('loading');
+    listJoinRequests(contextGraphId)
+      .then(data => {
+        if (fetchRequestIdRef.current !== requestId) return;
+        setRequests(data.requests.filter(r => r.status === 'pending'));
+        setStatus('idle');
+      })
+      .catch(() => {
+        if (fetchRequestIdRef.current !== requestId) return;
+        setRequests([]);
+        setStatus('error');
+      });
+  }, [contextGraphId, curatorStatus]);
 
   useEffect(() => {
-    listJoinRequests(contextGraphId)
-      .then(data => setRequests(data.requests.filter(r => r.status === 'pending')))
-      .catch(() => setRequests([]));
-  }, [contextGraphId]);
+    refresh();
+    return () => { fetchRequestIdRef.current++; };
+  }, [refresh]);
 
-  if (requests.length === 0) return null;
+  // Auto-refresh on SSE events scoped to this CG. The daemon
+  // emits `join_request` when a new request arrives
+  // (cli/src/daemon/lifecycle.ts:1899-1921), and
+  // `join_approved` / `join_rejected` when a moderation action
+  // resolves — refetching on all three keeps the list live
+  // across browser tabs, multi-curator nodes, and concurrent
+  // sessions without polling.
+  useNodeEvents(useCallback((event) => {
+    if (
+      event.type !== 'join_request'
+      && event.type !== 'join_approved'
+      && event.type !== 'join_rejected'
+    ) return;
+    if (event.data?.contextGraphId !== contextGraphId) return;
+    refresh();
+  }, [contextGraphId, refresh]));
+
+  // Definitive non-curator — section is dead UI and stays hidden.
+  if (curatorStatus === 'not-curator') return null;
+
+  // Unknown — render a quiet "verifying access" panel so the user
+  // sees something is in progress (no actionable controls; the
+  // request fetch is gated until we know they're the curator).
+  // See effect comment above for why we fail closed here.
+  if (curatorStatus === 'unknown') {
+    return (
+      <section className="v10-po-join" data-section="join-requests">
+        <header className="v10-po-join-head">
+          <span className="v10-po-section-title">Pending join requests</span>
+        </header>
+        <div className="v10-po-join-empty">Verifying access…</div>
+      </section>
+    );
+  }
 
   const handleApprove = async (addr: string) => {
     setProcessing(addr);
@@ -855,25 +1179,73 @@ export function PendingJoinRequestsBar({ contextGraphId, onParticipantsChanged }
   };
 
   return (
-    <div className="v10-ph-join-requests" style={{ margin: '0 16px 8px', padding: '8px 12px', borderRadius: 8, background: 'var(--bg-surface)', border: '1px solid #f59e0b44' }}>
-      <span style={{ fontSize: 9, fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: '0.8px', color: 'var(--text-tertiary)', marginBottom: 6, display: 'block' }}>
-        Pending Join Requests <span className="v10-ph-join-badge">{requests.length}</span>
-      </span>
-      <div className="v10-ph-join-list">
-        {requests.map(req => (
-          <div key={req.agentAddress} className="v10-ph-join-item">
-            <div className="v10-ph-join-info">
-              <span className="v10-ph-join-name">{req.name || `${req.agentAddress.slice(0, 6)}…${req.agentAddress.slice(-4)}`}</span>
-              <span className="v10-ph-join-addr" title={req.agentAddress}>{req.agentAddress.slice(0, 10)}…</span>
-            </div>
-            <div className="v10-ph-join-actions">
-              <button className="v10-ph-join-btn approve" onClick={() => handleApprove(req.agentAddress)} disabled={processing === req.agentAddress}>
-                {processing === req.agentAddress ? '…' : '✓ Approve'}
-              </button>
-              <button className="v10-ph-join-btn reject" onClick={() => handleReject(req.agentAddress)} disabled={processing === req.agentAddress}>✕</button>
-            </div>
-          </div>
-        ))}
+    <section className="v10-po-join" data-section="join-requests">
+      <header className="v10-po-join-head">
+        <span className="v10-po-section-title">Pending join requests</span>
+        <span className="v10-po-join-count" data-empty={requests.length === 0 ? 'true' : 'false'}>
+          {requests.length}
+        </span>
+      </header>
+      {status === 'loading'
+        ? <div className="v10-po-join-empty">Loading join requests...</div>
+        : status === 'error'
+          ? <div className="v10-po-join-empty">Join requests are currently unavailable.</div>
+          : requests.length === 0
+            ? <div className="v10-po-join-empty">No pending join requests.</div>
+            : <div className="v10-po-join-list">
+                {requests.map(req => (
+                  <div key={req.agentAddress} className="v10-po-join-item">
+                    <div className="v10-po-join-info">
+                      <span className="v10-po-join-name">{req.name || `${req.agentAddress.slice(0, 6)}…${req.agentAddress.slice(-4)}`}</span>
+                      <span className="v10-po-join-addr" title={req.agentAddress}>{req.agentAddress.slice(0, 10)}…</span>
+                    </div>
+                    <div className="v10-po-join-actions">
+                      <button
+                        className="v10-po-join-btn approve"
+                        onClick={() => handleApprove(req.agentAddress)}
+                        disabled={processing === req.agentAddress}
+                      >
+                        {processing === req.agentAddress ? '…' : '✓ Approve'}
+                      </button>
+                      <button
+                        className="v10-po-join-btn reject"
+                        onClick={() => handleReject(req.agentAddress)}
+                        disabled={processing === req.agentAddress}
+                        aria-label="Reject join request"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>}
+    </section>
+  );
+}
+
+// ─── Overview primer footer (§4.2.1 — last row before the bottom of
+//     the Overview, deliberately quieter than the identity-row primer
+//     link so first-time users still have a visible escape hatch
+//     even if they scrolled past the identity row).
+//
+// "New here?  →  What is a Context Graph?" plus a one-line sub-copy.
+// Re-uses the same `onOpenPrimer` handler the identity-row link
+// fires, so wiring is one call site in ProjectView. ────────────
+
+export function OverviewPrimerEntry({ onOpenPrimer }: { onOpenPrimer: () => void }) {
+  return (
+    <div className="v10-po-primer-footer" data-section="primer">
+      <span className="v10-po-primer-footer-lede">New here?</span>
+      <span className="v10-po-primer-footer-arrow" aria-hidden="true">→</span>
+      <button
+        type="button"
+        className="v10-po-primer-footer-link"
+        onClick={onOpenPrimer}
+      >
+        What is a Context Graph?
+      </button>
+      <div className="v10-po-primer-footer-sub">
+        A short primer on context graphs, the WM → SWM → VM pipeline, and how participant agents collaborate.
       </div>
     </div>
   );
@@ -1226,227 +1598,11 @@ export function VerifiedGraphLegend({ anchors }: { anchors: PublishAnchor[] }) {
   );
 }
 
-// ─── Memory Strip (expandable layer rows) ────────────────────
-
-type MemoryStripLayer = 'wm' | 'swm' | 'vm';
-
-export function MemoryStrip({
-  memory,
-  onSwitchLayer,
-  onSelectEntity,
-  contextGraphId,
-  onNodeClick,
-  expandedLayer,
-  onExpandedLayerChange,
-  expandTabs,
-  onExpandTabChange,
-  swmAttribution,
-}: {
-  memory: ReturnType<typeof useMemoryEntities>;
-  onSwitchLayer: (layer: LayerView) => void;
-  onSelectEntity: (uri: string) => void;
-  contextGraphId: string;
-  onNodeClick?: (node: any) => void;
-  expandedLayer?: MemoryStripLayer | null;
-  onExpandedLayerChange?: (layer: MemoryStripLayer | null) => void;
-  expandTabs?: Record<MemoryStripLayer, LayerContentTab>;
-  onExpandTabChange?: (layer: MemoryStripLayer, tab: LayerContentTab) => void;
-  /** Codex Code6 (PR #656) — pass-through of the parent's shared
-   *  SWM attribution result. */
-  swmAttribution?: SwmAttributionsResult;
-}) {
-  const [localExpanded, setLocalExpanded] = useState<MemoryStripLayer | null>(null);
-  const [localExpandTabs, setLocalExpandTabs] = useState<Record<MemoryStripLayer, LayerContentTab>>({
-    wm: 'items',
-    swm: 'items',
-    vm: 'items',
-  });
-  const expanded = expandedLayer !== undefined ? expandedLayer : localExpanded;
-  const activeExpandTabs = expandTabs ?? localExpandTabs;
-  const profile = useProjectProfileContext();
-
-  const layerEntities = useMemo(() => {
-    const wm: MemoryEntity[] = [];
-    const swm: MemoryEntity[] = [];
-    const vm: MemoryEntity[] = [];
-    for (const e of memory.entityList) {
-      if (e.trustLevel === 'verified') vm.push(e);
-      else if (e.trustLevel === 'shared') swm.push(e);
-      else wm.push(e);
-    }
-    return { wm, swm, vm };
-  }, [memory.entityList]);
-
-  // R2-6: per-layer triple counts must agree with the in-page count
-  // shown by the layer-detail tab on the same memory. The detail tab
-  // uses `useLayerTriples`, which residue-filters out triples whose
-  // subject is a promoted entity (post-P1). Summing `memory.allTriples`
-  // raw would double-count promoted residue and disagree with the
-  // badge under it. Source from `useLayerTriples` per layer so both
-  // surfaces stay in sync.
-  const wmLayerTriples = useLayerTriples(memory, 'wm');
-  const swmLayerTriples = useLayerTriples(memory, 'swm');
-  const vmLayerTriples = useLayerTriples(memory, 'vm');
-  const layerTripleCounts = useMemo(() => ({
-    wm: wmLayerTriples.length,
-    swm: swmLayerTriples.length,
-    vm: vmLayerTriples.length,
-  }), [wmLayerTriples.length, swmLayerTriples.length, vmLayerTriples.length]);
-
-  const toggleExpand = (layer: MemoryStripLayer) => {
-    const next = expanded === layer ? null : layer;
-    if (onExpandedLayerChange) onExpandedLayerChange(next);
-    else setLocalExpanded(next);
-  };
-
-  const handleExpandTab = (layer: MemoryStripLayer, tab: LayerContentTab) => {
-    if (onExpandTabChange) onExpandTabChange(layer, tab);
-    else setLocalExpandTabs(prev => ({ ...prev, [layer]: tab }));
-  };
-
-  const layers: Array<{
-    key: MemoryStripLayer;
-    label: string;
-    color: string;
-    icon: string;
-    entities: MemoryEntity[];
-    count: number;
-    promoteLabel: string | null;
-    viewLayer: LayerView;
-  }> = [
-    { key: 'wm', label: 'Working Memory', color: '#64748b', icon: '◇', entities: layerEntities.wm, count: memory.counts.wm, promoteLabel: 'Promote All → Shared', viewLayer: 'wm' },
-    { key: 'swm', label: 'Shared Working Memory', color: '#f59e0b', icon: '◈', entities: layerEntities.swm, count: memory.counts.swm, promoteLabel: 'Publish to Verifiable Memory', viewLayer: 'swm' },
-    { key: 'vm', label: 'Verifiable Memory', color: '#22c55e', icon: '◉', entities: layerEntities.vm, count: memory.counts.vm, promoteLabel: null, viewLayer: 'vm' },
-  ];
-
-  return (
-    <div className="v10-memory-strip">
-      {layers.map(layer => {
-        const isExpanded = expanded === layer.key;
-        const activeTab = activeExpandTabs[layer.key] ?? 'items';
-        return (
-          <React.Fragment key={layer.key}>
-            <div
-              className={`v10-memory-layer ${layer.key} ${isExpanded ? 'expanded' : ''}`}
-              onClick={() => toggleExpand(layer.key)}
-            >
-              <div className="v10-layer-label">
-                <span className="v10-layer-abbr">{layer.label}</span>
-                <span className="v10-layer-count">{layer.count}</span>
-              </div>
-              <div className="v10-layer-items">
-                <span className="v10-layer-chevron">▸</span>
-                {layer.entities.length === 0 && (
-                  <EmptyState
-                    inline
-                    tone={toneForLayer(layer.key)}
-                    icon={layer.icon}
-                    title={`No ${layerNoun(layer.key, 2).toLowerCase()} yet`}
-                  />
-                )}
-                {layer.entities.slice(0, 6).map(e => {
-                  const { icon } = entityMeta(e, profile);
-                  return (
-                    <div key={e.uri} className="v10-layer-chip" style={{ borderColor: `${layer.color}40` }}>
-                      <span className="v10-chip-dot" style={{ background: layer.color }} />
-                      <span className="v10-chip-text">{e.label}</span>
-                      <span className="v10-chip-meta">{icon}</span>
-                    </div>
-                  );
-                })}
-                {layer.entities.length > 6 && (
-                  <span className="v10-chip-meta">+{layer.entities.length - 6} more</span>
-                )}
-              </div>
-            </div>
-            <div className={`v10-layer-expand-content ${isExpanded ? 'open' : ''}`}>
-              {isExpanded && (
-                <MemoryStripExpanded
-                  layerKey={layer.key as 'wm' | 'swm' | 'vm'}
-                  entities={layer.entities}
-                  tripleCount={layerTripleCounts[layer.key as 'wm' | 'swm' | 'vm']}
-                  contextGraphId={contextGraphId}
-                  memory={memory}
-                  activeTab={activeTab as LayerContentTab}
-                  onTabChange={tab => handleExpandTab(layer.key, tab)}
-                  onSelectEntity={onSelectEntity}
-                  onNodeClick={onNodeClick}
-                  onSwitchLayer={() => onSwitchLayer(layer.viewLayer)}
-                  swmAttribution={layer.key === 'swm' ? swmAttribution : undefined}
-                />
-              )}
-            </div>
-          </React.Fragment>
-        );
-      })}
-    </div>
-  );
-}
-
-// Thin wrapper that computes the layer's triples once and renders LayerContent with a footer.
-export function MemoryStripExpanded({
-  layerKey,
-  entities,
-  tripleCount,
-  contextGraphId,
-  memory,
-  activeTab,
-  onTabChange,
-  onSelectEntity,
-  onNodeClick,
-  onSwitchLayer,
-  swmAttribution,
-}: {
-  layerKey: 'wm' | 'swm' | 'vm';
-  entities: MemoryEntity[];
-  tripleCount: number;
-  contextGraphId: string;
-  memory: ReturnType<typeof useMemoryEntities>;
-  activeTab: LayerContentTab;
-  onTabChange: (tab: LayerContentTab) => void;
-  onSelectEntity: (uri: string) => void;
-  onNodeClick?: (node: any) => void;
-  onSwitchLayer: () => void;
-  /** Codex Code6 (PR #656) — pass-through of the parent's shared
-   *  SWM attribution result so the SWM-tab graph reuses the network
-   *  call ProjectView already made for the Overview feed. */
-  swmAttribution?: SwmAttributionsResult;
-}) {
-  const layerTriples = useLayerTriples(memory, layerKey);
-  // No wrapper here: `LayerGraphPanel` already injects `trustLayer:
-  // nodeLayerContext` (which resolves to `layer === layerKey` in this
-  // path) on every node click, including the singleton-shelf path.
-  // Re-wrapping would double-inject the same value and mask any future
-  // intentional divergence between the panel's `layer` and ours.
-  return (
-    <LayerContent
-      layer={layerKey}
-      entities={entities}
-      tripleCount={tripleCount}
-      layerTriples={layerTriples}
-      contextGraphId={contextGraphId}
-      memory={memory}
-      activeTab={activeTab}
-      onTabChange={onTabChange}
-      onSelectEntity={onSelectEntity}
-      onNodeClick={onNodeClick}
-      swmAttribution={swmAttribution}
-      footer={
-        <div className="v10-layer-expand-footer">
-          <button
-            className="v10-layer-expand-footer-btn"
-            onClick={e => {
-              e.stopPropagation();
-              onSwitchLayer();
-            }}
-          >
-            View full layer →
-          </button>
-        </div>
-      }
-    />
-  );
-}
+// S2 finalize: the expandable WM/SWM/VM `MemoryStrip` /
+// `MemoryStripExpanded` duplicated the layer tabs and was removed
+// from the Overview branch in PR #615. The exports lingered with
+// no production caller. Removed here per "no backwards-compat
+// shims" (initial release).
 
 // ─── Generative Widget Components ─────────────────────────────
 
@@ -2834,7 +2990,7 @@ export function LayerDetailView({
   const config = LAYER_CONFIG[layer];
   // No wrapper here: `LayerGraphPanel` already injects `trustLayer:
   // nodeLayerContext` (which resolves to `layer` in this path) on every
-  // node click. See sibling `MemoryStripExpanded` comment.
+  // node click; re-wrapping would double-inject the same value.
 
   const entities = useMemo(
     () => memory.entityList.filter(e => e.trustLevel === config.trustLevel),
@@ -3730,11 +3886,14 @@ export function SubGraphOverviewGrid({
     return out;
   }, [memory.entityList]);
 
-  // Merge registered sub-graphs (minus `meta`) with profile bindings so
+  // Merge registered user-facing sub-graphs with profile bindings so
   // icon/color/label/rank all flow from the single source of truth.
+  // `isUserFacingSubGraph` centralises the reserved-slug rule
+  // (Codex review issue M) — same filter as SubGraphBar + the
+  // Overview Subgraphs stat.
   const cards = useMemo(() => {
     return subGraphs
-      .filter(sg => sg.name !== 'meta')
+      .filter(isUserFacingSubGraph)
       .map(sg => {
         const binding = profile?.forSubGraph(sg.name) ?? {};
         const rawTriples = triplesBySubGraph.get(sg.name) ?? [];

--- a/packages/node-ui/test/context-graph-contrast.test.ts
+++ b/packages/node-ui/test/context-graph-contrast.test.ts
@@ -73,8 +73,6 @@ describe('Context Graph contrast tokens', () => {
   it('keeps readable Context Graph text off the decoration-only ghost token', () => {
     const readableSelectors = [
       '.v10-layer-switch-count',
-      '.v10-po-stat-label',
-      '.v10-po-progress-legend',
       '.v10-entity-list-empty',
       '.v10-entity-list-header',
       '.v10-entity-card-triples',
@@ -98,6 +96,18 @@ describe('Context Graph contrast tokens', () => {
       '.v10-empty-state-desc',
       '.v10-stat-strip-label',
       '.v10-entity-list-sort-select',
+      // S2 Overview finalize (§4.2.1) — readable chrome rendered
+      // via `--text-*` tokens. Registered here so a future
+      // regression on any of these is caught explicitly.
+      '.v10-po-identity-label',
+      '.v10-po-section-title',
+      '.v10-po-pipeline-step-desc',
+      '.v10-po-people-empty',
+      '.v10-po-participant-name',
+      '.v10-po-join-empty',
+      '.v10-po-join-addr',
+      '.v10-po-primer-footer-lede',
+      '.v10-po-primer-footer-sub',
     ];
 
     for (const selector of readableSelectors) {
@@ -135,8 +145,8 @@ describe('Context Graph contrast tokens', () => {
       '.v10-activity-feed-status.status-good',
       '.v10-activity-feed-status.status-warn',
       '.v10-activity-feed-status.status-bad',
-      '.v10-ph-join-btn.approve',
-      '.v10-ph-join-btn.reject',
+      '.v10-po-join-btn.approve',
+      '.v10-po-join-btn.reject',
     ];
 
     for (const selector of selectorsOnSurface) {

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -347,6 +347,106 @@ describe('Context Graph shared empty/stat patterns', () => {
     await unmount();
   });
 
+  it('replaces the title-count number with an em-dash when lifecycleError is set (PR #694 polish carry-over b)', async () => {
+    // Title row would otherwise show "0" next to "Recent activity"
+    // while the inline error indicator below reads "Couldn't load
+    // recent activity." — contradicting itself (precise count vs
+    // not-loaded). The em-dash placeholder keeps the row anchored
+    // without claiming a specific number.
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: [],
+        onSelectEntity: vi.fn(),
+        title: 'Recent activity',
+        lifecycleEvents: [],
+        lifecycleError: 'SPARQL query failed: 503',
+      }),
+    );
+
+    const badge = container.querySelector('.v10-activity-feed-title-count');
+    expect(badge).toBeTruthy();
+    expect(badge?.textContent).toBe('—');
+    expect(badge?.getAttribute('data-state')).toBe('error');
+    // The title row still renders (anchored heading).
+    expect(container.querySelector('.v10-activity-feed-title-label')?.textContent).toBe('Recent activity');
+
+    await unmount();
+  });
+
+  it('keeps the title-count number when error is null even with empty events', async () => {
+    // Regression guard for the carry-over fix — the em-dash only
+    // fires on a lifecycle ERROR, not on an empty-but-healthy feed.
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: [],
+        onSelectEntity: vi.fn(),
+        title: 'Recent activity',
+        lifecycleEvents: [],
+        lifecycleError: null,
+      }),
+    );
+
+    const badge = container.querySelector('.v10-activity-feed-title-count');
+    expect(badge?.textContent).toBe('0');
+    expect(badge?.getAttribute('data-state')).toBeNull();
+
+    await unmount();
+  });
+
+  it('keeps the title-count number when lifecycleError is set BUT events were preserved from a successful prior fetch (Codex interaction between carry-overs)', async () => {
+    // The composition of carry-over (a) + carry-over (b):
+    //   (a) preserves cached rows on a same-graph refresh failure
+    //       → `events` still contains the prior rows.
+    //   (b) falls back to `—` when lifecycleError is set.
+    // Naive (b) would say `—` while N actual rows render below.
+    // Codex caught the contradiction on PR #769 — the badge must
+    // agree with the visible row count, not the error state, when
+    // both fire.
+    const events = [
+      {
+        eventUri: 'urn:evt:promote-1',
+        kind: 'promoted' as const,
+        assertionUri: 'urn:assert:doc-1',
+        assertionName: 'doc-1',
+        agentUri: 'did:dkg:agent:alice',
+        publishedAt: '2026-05-25T10:00:00Z',
+      },
+      {
+        eventUri: 'urn:evt:promote-2',
+        kind: 'promoted' as const,
+        assertionUri: 'urn:assert:doc-2',
+        assertionName: 'doc-2',
+        agentUri: 'did:dkg:agent:bob',
+        publishedAt: '2026-05-26T10:00:00Z',
+      },
+      {
+        eventUri: 'urn:evt:promote-3',
+        kind: 'promoted' as const,
+        assertionUri: 'urn:assert:doc-3',
+        assertionName: 'doc-3',
+        agentUri: 'did:dkg:agent:carol',
+        publishedAt: '2026-05-27T10:00:00Z',
+      },
+    ];
+    const { container, unmount } = await render(
+      React.createElement(ActivityFeed, {
+        entities: [],
+        onSelectEntity: vi.fn(),
+        title: 'Recent activity',
+        lifecycleEvents: events,
+        lifecycleError: 'SPARQL query failed: 503',
+      }),
+    );
+
+    const badge = container.querySelector('.v10-activity-feed-title-count');
+    expect(badge?.textContent).toBe('3');
+    // No error state on the badge — the visible list takes precedence
+    // over the error signal when both fire.
+    expect(badge?.getAttribute('data-state')).toBeNull();
+
+    await unmount();
+  });
+
   it('shows the explained interim empty state for SWM assertions', async () => {
     apiMocks.listAssertions.mockResolvedValueOnce([]);
     const { container, unmount } = await render(

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -3,7 +3,63 @@
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { LayerSwitcher, ProjectOverviewCard } from '../src/ui/views/project/components.js';
+
+// Codex bug L — the `'unknown'` branch of PendingJoinRequestsSection
+// now optimistically fires `listJoinRequests`. Mock the API module so
+// tests can drive the response (success / 401 / 403 / generic error).
+const apiMock = vi.hoisted(() => ({
+  listJoinRequests: vi.fn(async () => ({ requests: [] })),
+  approveJoinRequest: vi.fn(async () => ({ ok: true })),
+  rejectJoinRequest: vi.fn(async () => ({ ok: true })),
+  HttpError: class HttpError extends Error {
+    status: number;
+    body?: unknown;
+    constructor(status: number, message?: string, body?: unknown) {
+      super(message ?? `HTTP ${status}`);
+      this.status = status;
+      this.body = body;
+    }
+  },
+}));
+
+vi.mock('../src/ui/api.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/ui/api.js')>();
+  return {
+    ...actual,
+    listJoinRequests: apiMock.listJoinRequests,
+    approveJoinRequest: apiMock.approveJoinRequest,
+    rejectJoinRequest: apiMock.rejectJoinRequest,
+    HttpError: apiMock.HttpError,
+  };
+});
+
+// SSE-driven auto-refresh path (`PendingJoinRequestsSection` now
+// subscribes via `useNodeEvents`). Capture the registered handler
+// so tests can drive a fake `join_request` event without standing
+// up an EventSource.
+const nodeEventsMock = vi.hoisted(() => {
+  const handlers = new Set<(event: { type: string; data: Record<string, unknown> }) => void>();
+  return {
+    useNodeEvents: (handler: (event: { type: string; data: Record<string, unknown> }) => void) => {
+      handlers.add(handler);
+    },
+    emit(event: { type: string; data: Record<string, unknown> }) {
+      handlers.forEach(h => h(event));
+    },
+    reset() { handlers.clear(); },
+  };
+});
+vi.mock('../src/ui/hooks/useNodeEvents.js', () => ({
+  useNodeEvents: nodeEventsMock.useNodeEvents,
+}));
+
+import {
+  LayerSwitcher,
+  ProjectOverviewCard,
+  OverviewPrimerEntry,
+  PendingJoinRequestsSection,
+  curatorStatusForOverview,
+} from '../src/ui/views/project/components.js';
 import { ContextGraphPrimerView } from '../src/ui/views/ContextGraphPrimerView.js';
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -35,6 +91,14 @@ async function render(element: React.ReactElement): Promise<{ container: HTMLDiv
 describe('Context Graph IA and Overview', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
+    // Reset the listJoinRequests mock back to a benign empty
+    // response so tests that don't touch the join-requests path
+    // don't trip Bug L's new optimistic fetch.
+    apiMock.listJoinRequests.mockReset();
+    apiMock.listJoinRequests.mockResolvedValue({ requests: [] });
+    apiMock.approveJoinRequest.mockReset();
+    apiMock.rejectJoinRequest.mockReset();
+    nodeEventsMock.reset();
   });
 
   afterEach(() => {
@@ -126,16 +190,45 @@ describe('Context Graph IA and Overview', () => {
           callerInvolved: true,
         },
         memory: baseMemory,
-        participants: ['0x1234567890abcdef', '0xabcdef1234567890'],
+        subGraphCount: 3,
+        participants: [
+          '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+          '0x1234567890abcdef1234567890abcdef12345678',
+        ],
         currentAgent: { agentDid: 'did:dkg:agent:0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD' },
         onSwitchLayer,
         onOpenPrimer,
       }),
     );
 
-    expect(container.textContent).toContain('Curator');
-    expect(container.textContent).toContain('Curated');
+    // Identity row (S2 finalize §4.2.1) — label-pill pairs in
+    // locked order: role first, then CG-type. The role glyph (◆) is
+    // applied in CSS via `data-role`, NOT in the data string.
+    const pairs = Array.from(container.querySelectorAll('.v10-po-identity-pair'));
+    expect(pairs).toHaveLength(2);
+    const roleLabel = pairs[0].querySelector('.v10-po-identity-label');
+    const roleBadge = pairs[0].querySelector('.v10-po-badge');
+    expect(roleLabel?.textContent?.trim()).toBe('Your role:');
+    expect(roleBadge?.textContent?.trim()).toBe('Curator');
+    expect(roleBadge?.getAttribute('data-role')).toBe('curator');
+    const typeLabel = pairs[1].querySelector('.v10-po-identity-label');
+    const typeBadge = pairs[1].querySelector('.v10-po-badge');
+    expect(typeLabel?.textContent?.trim()).toBe('Context Graph:');
+    expect(typeBadge?.textContent?.trim()).toBe('Curated');
+    expect(typeBadge?.getAttribute('data-cg-type')).toBe('curated');
     expect(container.textContent).toContain('Agents with access');
+
+    // At a glance — 4 stats (§4.2.1): Entities · Triples · Subgraphs
+    // · Agents with access. Subgraph count is passed in by ProjectView.
+    // ui-lead item 3 — the section block carries an "At a glance"
+    // title so it matches the structure of the other peer sections.
+    const atAGlance = container.querySelector('[data-section="at-a-glance"]');
+    expect(atAGlance).toBeTruthy();
+    expect(atAGlance?.querySelector('.v10-po-section-title')?.textContent?.trim()).toBe('At a glance');
+    const statLabels = Array.from(container.querySelectorAll('.v10-stat-strip-label'))
+      .map(node => node.textContent?.trim());
+    expect(statLabels).toEqual(['Entities', 'Triples', 'Subgraphs', 'Agents with access']);
+
     expect(container.textContent).toContain('Knowledge Pipeline');
     expect(container.textContent).toContain('published assertion bundles become Knowledge Assets');
     expect(container.querySelector('.v10-memory-strip')).toBeNull();
@@ -153,11 +246,728 @@ describe('Context Graph IA and Overview', () => {
     }
     expect(onSwitchLayer.mock.calls.map(call => call[0])).toEqual(['wm', 'swm', 'vm']);
 
-    const primer = container.querySelector<HTMLButtonElement>('.v10-po-primer-link');
+    // Participant agents section (§4.2.1) — heading uniform across
+    // access policy. Self row carries ` · you · curator` suffix +
+    // `.is-self.is-curator` for the CSS-driven ◆ glyph; the other
+    // row stays bare with the default ◯ glyph supplied by CSS.
+    // ui-lead item 2 — `you` / `curator` render as separate
+    // `.v10-po-participant-tag` spans with a CSS `::before` `·`
+    // separator; the DOM text reads the tag content only.
+    expect(container.textContent).toContain('Participant agents');
+    const participantRows = Array.from(container.querySelectorAll('.v10-po-participant'));
+    expect(participantRows).toHaveLength(2);
+    const self = participantRows[0];
+    expect(self.classList.contains('is-self')).toBe(true);
+    expect(self.classList.contains('is-curator')).toBe(true);
+    const selfTags = Array.from(self.querySelectorAll('.v10-po-participant-tag')).map(n => n.textContent);
+    expect(selfTags).toEqual(['you', 'curator']);
+    expect(self.getAttribute('aria-label')).toMatch(/ you curator$/);
+    const other = participantRows[1];
+    expect(other.classList.contains('is-self')).toBe(false);
+    expect(other.classList.contains('is-curator')).toBe(false);
+    expect(other.querySelectorAll('.v10-po-participant-tag')).toHaveLength(0);
+
+    const primer = container.querySelector<HTMLButtonElement>('.v10-po-identity-primer');
+    expect(primer).toBeTruthy();
     await act(async () => {
       primer!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(onOpenPrimer).toHaveBeenCalledTimes(1);
+
+    await act(async () => root.unmount());
+  });
+
+  it('always renders the curator row in Participant agents, even when `allowedAgents` omits them (Codex bug A)', async () => {
+    const curatorAddress = '0xCAFE0000000000000000000000000000000000A1';
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-curator-omitted',
+          name: 'Curator Omitted',
+          accessPolicy: 'private',
+          curator: `did:dkg:agent:${curatorAddress}`,
+          callerInvolved: false,
+        },
+        memory: baseMemory,
+        // `allowedAgents` from /participants does NOT contain the curator
+        // on a normal private CG — Codex bug A pre-fix dropped the row.
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xDEADBEEF' },
+      }),
+    );
+
+    const rows = Array.from(container.querySelectorAll('.v10-po-participant'));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].classList.contains('is-curator')).toBe(true);
+    expect(Array.from(rows[0].querySelectorAll('.v10-po-participant-tag')).map(n => n.textContent))
+      .toEqual(['curator']);
+
+    await act(async () => root.unmount());
+  });
+
+  it('does NOT seed the curator row while participants are loading, even with a curator field set (Codex bug J)', async () => {
+    const curatorAddress = '0xCAFE0000000000000000000000000000000000A4';
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-loading-with-curator',
+          name: 'Loading',
+          accessPolicy: 'private',
+          curator: `did:dkg:agent:${curatorAddress}`,
+        },
+        memory: baseMemory,
+        participants: [],
+        participantsStatus: 'loading',
+        currentAgent: { agentDid: `did:dkg:agent:${curatorAddress}` },
+      }),
+    );
+
+    // Loading copy renders; curator row does NOT (would imply a
+    // complete roster while the allowlist is still resolving).
+    expect(container.textContent).toContain('Loading participant agents');
+    expect(container.querySelectorAll('.v10-po-participant')).toHaveLength(0);
+
+    await act(async () => root.unmount());
+  });
+
+  it('does NOT seed the curator row when participants errored, even with a curator field set (Codex bug J)', async () => {
+    const curatorAddress = '0xCAFE0000000000000000000000000000000000A5';
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-errored-with-curator',
+          name: 'Errored',
+          accessPolicy: 'private',
+          curator: `did:dkg:agent:${curatorAddress}`,
+        },
+        memory: baseMemory,
+        participants: [],
+        participantsStatus: 'error',
+        currentAgent: { agentDid: `did:dkg:agent:${curatorAddress}` },
+      }),
+    );
+
+    expect(container.textContent).toContain('Participant list unavailable');
+    expect(container.querySelectorAll('.v10-po-participant')).toHaveLength(0);
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders the curator row in the bare-address shape, not the raw DID (Codex bug H)', async () => {
+    const curatorAddress = '0x1234567890ABCDEF1234567890ABCDEF12345678';
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-curator-display',
+          name: 'Display',
+          accessPolicy: 'private',
+          curator: `did:dkg:agent:${curatorAddress}`,
+        },
+        memory: baseMemory,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xDEADBEEF' },
+      }),
+    );
+
+    const rows = Array.from(container.querySelectorAll('.v10-po-participant'));
+    expect(rows).toHaveLength(1);
+    // Display reads in address shape (0x… …last4), NOT `did:dk…last4`.
+    expect(rows[0].textContent).not.toContain('did:dk');
+    expect(rows[0].textContent).toContain('0x1234');
+    expect(rows[0].textContent).toContain('5678');
+    // Hover title preserves the full DID for traceability.
+    expect(rows[0].getAttribute('title')).toBe(`did:dkg:agent:${curatorAddress}`);
+
+    await act(async () => root.unmount());
+  });
+
+  it('does not duplicate the curator row when `allowedAgents` already contains them (Codex bug A dedup)', async () => {
+    const curatorAddress = '0xCAFE0000000000000000000000000000000000B2';
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-curator-dup',
+          name: 'Curator Already Allowed',
+          accessPolicy: 'public',
+          curator: `did:dkg:agent:${curatorAddress}`,
+          callerInvolved: true,
+        },
+        memory: baseMemory,
+        participants: [curatorAddress],
+        currentAgent: { agentDid: 'did:dkg:agent:0xDEADBEEF' },
+      }),
+    );
+
+    const rows = Array.from(container.querySelectorAll('.v10-po-participant'));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].classList.contains('is-curator')).toBe(true);
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders Triples as a lower bound when a layer query is partial (Codex bug B)', async () => {
+    const partialMemory = {
+      ...baseMemory,
+      counts: { wm: 4, swm: 2, vm: 0, total: 6 },
+      layerStatus: { wm: 'ok', swm: 'ok', vm: 'error' },
+      partial: true,
+      allTriples: new Array(120).fill({ subject: 's', predicate: 'p', object: 'o', layer: 'working' }),
+      error: null,
+    };
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-triples-partial', name: 'Partial', accessPolicy: 'public' },
+        memory: partialMemory,
+        subGraphCount: 1,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    const triplesCell = container.querySelector<HTMLElement>('[data-stat-id="triples"]');
+    expect(triplesCell).toBeTruthy();
+    expect(triplesCell!.querySelector('.v10-stat-strip-value')?.textContent?.trim())
+      .toBe('120+');
+    expect(triplesCell!.getAttribute('title'))
+      .toBe('One or more layer triple counts are currently a lower bound.');
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders Triples as Unavailable when every layer query failed (Codex bug B all-error)', async () => {
+    const outageMemory = {
+      ...baseMemory,
+      counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+      layerStatus: { wm: 'error', swm: 'error', vm: 'error' },
+      partial: false,
+      allTriples: [],
+      error: null,
+    };
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-triples-outage', name: 'Outage', accessPolicy: 'public' },
+        memory: outageMemory,
+        subGraphCount: 0,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    const triplesCell = container.querySelector<HTMLElement>('[data-stat-id="triples"]');
+    expect(triplesCell?.querySelector('.v10-stat-strip-value')?.textContent?.trim())
+      .toBe('Unavailable');
+    expect(triplesCell?.getAttribute('title')).toBe('Live triple counts are unavailable.');
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders Subgraphs as Unavailable when subGraphFetchFailed is true (Codex bug D)', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-sg-failed', name: 'SG Failed', accessPolicy: 'public' },
+        memory: baseMemory,
+        subGraphCount: null,
+        subGraphFetchFailed: true,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    const subgraphsCell = container.querySelector<HTMLElement>('[data-stat-id="subgraphs"]');
+    expect(subgraphsCell?.querySelector('.v10-stat-strip-value')?.textContent?.trim())
+      .toBe('Unavailable');
+    expect(subgraphsCell?.getAttribute('title')).toBe('Sub-graph list is currently unavailable.');
+
+    await act(async () => root.unmount());
+  });
+
+  it('marks a non-self curator with the curator suffix only — no `you` leakage', async () => {
+    const curatorAddress = '0xCAFE000000000000000000000000000000000001';
+    const otherAddress = '0xCAFE000000000000000000000000000000000002';
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-other-curator',
+          name: 'Other Curator Graph',
+          accessPolicy: 'private',
+          curator: `did:dkg:agent:${curatorAddress}`,
+          callerInvolved: true,
+        },
+        memory: baseMemory,
+        participants: [curatorAddress, otherAddress],
+        currentAgent: { agentDid: `did:dkg:agent:${otherAddress}`, agentAddress: otherAddress },
+      }),
+    );
+
+    const rows = Array.from(container.querySelectorAll('.v10-po-participant'));
+    expect(rows).toHaveLength(2);
+
+    const curatorRow = rows[0];
+    expect(curatorRow.classList.contains('is-curator')).toBe(true);
+    expect(curatorRow.classList.contains('is-self')).toBe(false);
+    expect(Array.from(curatorRow.querySelectorAll('.v10-po-participant-tag')).map(n => n.textContent))
+      .toEqual(['curator']);
+
+    const selfRow = rows[1];
+    expect(selfRow.classList.contains('is-self')).toBe(true);
+    expect(selfRow.classList.contains('is-curator')).toBe(false);
+    expect(Array.from(selfRow.querySelectorAll('.v10-po-participant-tag')).map(n => n.textContent))
+      .toEqual(['you']);
+
+    await act(async () => root.unmount());
+  });
+
+  it('shows a graceful Participant agents empty state when none are recorded on a curated CG', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-empty', name: 'Empty', accessPolicy: 'private' },
+        memory: baseMemory,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    expect(container.textContent).toContain('Participant agents');
+    expect(container.textContent).toContain('No participant agents recorded yet.');
+    expect(container.textContent).not.toContain('public — anyone can subscribe');
+    expect(container.querySelectorAll('.v10-po-participant')).toHaveLength(0);
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders open-access copy on a public CG when allowedAgents is empty AND no curator (Codex bug E)', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-public-open', name: 'Open', accessPolicy: 'public' },
+        memory: baseMemory,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    expect(container.textContent).toContain('Participant agents');
+    expect(container.textContent).toContain('This Context Graph is public — anyone can subscribe.');
+    expect(container.textContent).not.toContain('No participant agents recorded yet.');
+    expect(container.querySelectorAll('.v10-po-participant')).toHaveLength(0);
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders the public-access copy on a public CG even when participantsStatus is "error" (Codex issue S)', async () => {
+    // Access policy is local-only state from `cg.accessPolicy`;
+    // it's known regardless of whether `/participants` succeeded.
+    // The open-access copy must take precedence over the "list
+    // unavailable" copy on a public CG.
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-public-errored', name: 'Open Errored', accessPolicy: 'public' },
+        memory: baseMemory,
+        participants: [],
+        participantsStatus: 'error',
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    expect(container.textContent).toContain('This Context Graph is public — anyone can subscribe.');
+    expect(container.textContent).not.toContain('Participant list unavailable.');
+    expect(container.textContent).not.toContain('Loading participant agents');
+    expect(container.querySelectorAll('.v10-po-participant')).toHaveLength(0);
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders the public-access copy on a public CG even when participantsStatus is "loading" (Codex issue S)', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-public-loading', name: 'Open Loading', accessPolicy: 'public' },
+        memory: baseMemory,
+        participants: [],
+        participantsStatus: 'loading',
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    expect(container.textContent).toContain('This Context Graph is public — anyone can subscribe.');
+    expect(container.textContent).not.toContain('Loading participant agents');
+    expect(container.textContent).not.toContain('Participant list unavailable.');
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders the loading copy on a curated CG when participantsStatus is "loading" (Codex issue S — curated path unchanged)', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-curated-loading', name: 'Curated Loading', accessPolicy: 'private' },
+        memory: baseMemory,
+        participants: [],
+        participantsStatus: 'loading',
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    expect(container.textContent).toContain('Loading participant agents');
+    expect(container.textContent).not.toContain('public — anyone can subscribe');
+    expect(container.textContent).not.toContain('Participant list unavailable.');
+
+    await act(async () => root.unmount());
+  });
+
+  it('still shows the curator row on a public CG that has a curator + empty allowedAgents (Codex bug E + A together)', async () => {
+    const curatorAddress = '0xCAFE0000000000000000000000000000000000E5';
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-public-with-curator',
+          name: 'Open with curator',
+          accessPolicy: 'public',
+          curator: `did:dkg:agent:${curatorAddress}`,
+        },
+        memory: baseMemory,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    // Curator row must still render (Bug A) — open-access copy is
+    // the EMPTY-state, not a hard override.
+    const rows = Array.from(container.querySelectorAll('.v10-po-participant'));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].classList.contains('is-curator')).toBe(true);
+    expect(container.textContent).not.toContain('public — anyone can subscribe');
+    expect(container.textContent).not.toContain('No participant agents recorded yet.');
+
+    await act(async () => root.unmount());
+  });
+
+  it('Overview sections render in the locked §4.2.1 order with stable `data-section` hooks', async () => {
+    // The four card-internal sections (identity → at-a-glance →
+    // pipeline → participants) live inside ProjectOverviewCard;
+    // the next three (join-requests → activity → primer) are
+    // siblings in ProjectView's Overview branch and verified
+    // separately (PendingJoinRequestsSection + OverviewPrimerEntry
+    // assertions below + the ProjectView mount order).
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-order',
+          name: 'Order',
+          accessPolicy: 'private',
+          callerInvolved: false,
+        },
+        memory: baseMemory,
+        subGraphCount: 1,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+        onSwitchLayer: vi.fn(),
+        onOpenPrimer: vi.fn(),
+      }),
+    );
+
+    const sections = Array.from(container.querySelectorAll('[data-section]'))
+      .map(node => node.getAttribute('data-section'));
+    expect(sections).toEqual([
+      'identity',
+      'at-a-glance',
+      'pipeline',
+      'participants',
+    ]);
+
+    await act(async () => root.unmount());
+  });
+
+  it('OverviewPrimerEntry tags itself with data-section="primer"', async () => {
+    const { container, root } = await render(
+      React.createElement(OverviewPrimerEntry, { onOpenPrimer: vi.fn() }),
+    );
+    expect(container.querySelector('[data-section="primer"]')).toBeTruthy();
+    await act(async () => root.unmount());
+  });
+
+  it('PendingJoinRequestsSection tags itself with data-section="join-requests" when curatorStatus is "curator"', async () => {
+    const { container, root } = await render(
+      React.createElement(PendingJoinRequestsSection, {
+        contextGraphId: 'cg-join',
+        curatorStatus: 'curator' as const,
+      }),
+    );
+    expect(container.querySelector('[data-section="join-requests"]')).toBeTruthy();
+    await act(async () => root.unmount());
+  });
+
+  it('PendingJoinRequestsSection renders nothing when curatorStatus is "not-curator"', async () => {
+    const { container, root } = await render(
+      React.createElement(PendingJoinRequestsSection, {
+        contextGraphId: 'cg-join',
+        curatorStatus: 'not-curator' as const,
+      }),
+    );
+    expect(container.querySelector('[data-section="join-requests"]')).toBeNull();
+    await act(async () => root.unmount());
+  });
+
+  it('PendingJoinRequestsSection renders the verifying-access panel for curatorStatus "unknown" WITHOUT firing listJoinRequests (Codex bug N — reverts bug L)', async () => {
+    // The daemon `/join-requests` route is NOT curator-gated
+    // (cli/src/daemon/routes/context-graph.ts:898; agent.ts:13126
+    // calls a raw SPARQL read with no caller auth). Firing it in
+    // the 'unknown' state would leak pending-moderation metadata
+    // to any caller whose `/api/agent/identity` is mid-resolution
+    // or errored. Fail closed: render the quiet verifying panel,
+    // skip the fetch.
+    const { container, root } = await render(
+      React.createElement(PendingJoinRequestsSection, {
+        contextGraphId: 'cg-join',
+        curatorStatus: 'unknown' as const,
+      }),
+    );
+    const section = container.querySelector('[data-section="join-requests"]');
+    expect(section).toBeTruthy();
+    expect(section?.textContent).toContain('Verifying access');
+    expect(container.querySelector('.v10-po-join-btn')).toBeNull();
+    // Codex bug N regression — `listJoinRequests` MUST NOT fire.
+    expect(apiMock.listJoinRequests).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+
+  it('PendingJoinRequestsSection does not fire listJoinRequests for definitive non-curators (Codex bug N)', async () => {
+    const { container, root } = await render(
+      React.createElement(PendingJoinRequestsSection, {
+        contextGraphId: 'cg-join',
+        curatorStatus: 'not-curator' as const,
+      }),
+    );
+    expect(container.querySelector('[data-section="join-requests"]')).toBeNull();
+    expect(apiMock.listJoinRequests).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+
+  it('PendingJoinRequestsSection fires listJoinRequests only when curatorStatus is positively "curator"', async () => {
+    apiMock.listJoinRequests.mockResolvedValue({ requests: [] });
+    const { container, root } = await render(
+      React.createElement(PendingJoinRequestsSection, {
+        contextGraphId: 'cg-join',
+        curatorStatus: 'curator' as const,
+      }),
+    );
+    expect(container.querySelector('[data-section="join-requests"]')).toBeTruthy();
+    expect(apiMock.listJoinRequests).toHaveBeenCalledWith('cg-join');
+    await act(async () => root.unmount());
+  });
+
+  it('PendingJoinRequestsSection refetches when an SSE `join_request` event arrives for this CG', async () => {
+    // Initial fetch returns an empty list (mount-time call).
+    apiMock.listJoinRequests.mockResolvedValueOnce({ requests: [] });
+    const { container, root } = await render(
+      React.createElement(PendingJoinRequestsSection, {
+        contextGraphId: 'cg-join',
+        curatorStatus: 'curator' as const,
+      }),
+    );
+    expect(apiMock.listJoinRequests).toHaveBeenCalledTimes(1);
+    // No row yet.
+    expect(container.querySelector('.v10-po-join-item')).toBeNull();
+
+    // Next fetch resolves with a row — simulating the daemon
+    // having recorded a new join request just before the SSE
+    // `join_request` event fires.
+    apiMock.listJoinRequests.mockResolvedValueOnce({
+      requests: [
+        { agentAddress: '0xabc1230000000000000000000000000000000123', status: 'pending', name: 'Pending Bob' },
+      ],
+    });
+    await act(async () => {
+      nodeEventsMock.emit({ type: 'join_request', data: { contextGraphId: 'cg-join' } });
+    });
+    expect(apiMock.listJoinRequests).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain('Pending Bob');
+
+    await act(async () => root.unmount());
+  });
+
+  it('PendingJoinRequestsSection ignores SSE `join_request` events scoped to a different CG', async () => {
+    apiMock.listJoinRequests.mockResolvedValue({ requests: [] });
+    const { root } = await render(
+      React.createElement(PendingJoinRequestsSection, {
+        contextGraphId: 'cg-join',
+        curatorStatus: 'curator' as const,
+      }),
+    );
+    expect(apiMock.listJoinRequests).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      nodeEventsMock.emit({ type: 'join_request', data: { contextGraphId: 'cg-other' } });
+    });
+    // Different CG — no refetch.
+    expect(apiMock.listJoinRequests).toHaveBeenCalledTimes(1);
+
+    await act(async () => root.unmount());
+  });
+
+  it('PendingJoinRequestsSection refetches on `join_approved` and `join_rejected` events too', async () => {
+    apiMock.listJoinRequests.mockResolvedValue({ requests: [] });
+    const { root } = await render(
+      React.createElement(PendingJoinRequestsSection, {
+        contextGraphId: 'cg-join',
+        curatorStatus: 'curator' as const,
+      }),
+    );
+    expect(apiMock.listJoinRequests).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      nodeEventsMock.emit({ type: 'join_approved', data: { contextGraphId: 'cg-join' } });
+    });
+    expect(apiMock.listJoinRequests).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      nodeEventsMock.emit({ type: 'join_rejected', data: { contextGraphId: 'cg-join' } });
+    });
+    expect(apiMock.listJoinRequests).toHaveBeenCalledTimes(3);
+
+    await act(async () => root.unmount());
+  });
+
+  it('Overview role badge reads "Curator" when only agentAddress matches cg.curator (Codex issue P — shared predicate with curatorStatusForOverview)', async () => {
+    const address = '0xcafe000000000000000000000000000000000a0e';
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: {
+          id: 'cg-issue-p',
+          name: 'Issue P',
+          accessPolicy: 'private',
+          curator: `did:dkg:agent:${address}`,
+          callerInvolved: true,
+        },
+        memory: baseMemory,
+        participants: [],
+        currentAgent: { agentAddress: address } as any,
+        currentAgentStatus: 'ok',
+      }),
+    );
+    // Role badge must match `curatorStatusForOverview`'s verdict.
+    // Pre-fix, this read 'Joined' (the role helper only matched
+    // agentDid); the curator predicate now consults both.
+    const roleBadge = container.querySelector('.v10-po-badge[data-role]');
+    expect(roleBadge?.getAttribute('data-role')).toBe('curator');
+    expect(roleBadge?.textContent?.trim()).toBe('Curator');
+    expect(container.textContent).not.toContain('Joined');
+    expect(container.textContent).not.toContain('Role unknown');
+    await act(async () => root.unmount());
+  });
+
+  it('curatorStatusForOverview returns "curator" when only agentAddress is available and matches cg.curator (Codex bug G)', () => {
+    const address = '0xcafe000000000000000000000000000000000a01';
+    expect(curatorStatusForOverview({
+      cg: { curator: `did:dkg:agent:${address}`, accessPolicy: 'private' },
+      currentAgent: { agentAddress: address } as any,
+      currentAgentStatus: 'ok',
+    })).toBe('curator');
+  });
+
+  it('curatorStatusForOverview returns "curator" when agentAddress matches even on currentAgentStatus error (Codex bug G — fall-back identity)', () => {
+    const address = '0xcafe000000000000000000000000000000000a02';
+    // Real-world scenario: `/api/agent/identity` errored, but we still have a
+    // cached `agentAddress` from a prior load. Should NOT fail closed.
+    expect(curatorStatusForOverview({
+      cg: { curator: `did:dkg:agent:${address}`, accessPolicy: 'private' },
+      currentAgent: { agentAddress: address } as any,
+      currentAgentStatus: 'error',
+    })).toBe('curator');
+  });
+
+  it('curatorStatusForOverview tolerates case differences between curator DID and agentAddress (Codex bug G)', () => {
+    // EVM addresses are case-insensitive; `canonicalAgentDid` already
+    // lowercases bare EVM addresses, so this should equate.
+    const upper = '0xCAFE000000000000000000000000000000000A03';
+    const lower = '0xcafe000000000000000000000000000000000a03';
+    expect(curatorStatusForOverview({
+      cg: { curator: `did:dkg:agent:${upper}`, accessPolicy: 'private' },
+      currentAgent: { agentAddress: lower } as any,
+      currentAgentStatus: 'ok',
+    })).toBe('curator');
+  });
+
+  it('curatorStatusForOverview returns "unknown" when curator is set but no identity material is present', () => {
+    expect(curatorStatusForOverview({
+      cg: { curator: 'did:dkg:agent:0xABC', accessPolicy: 'private' },
+      currentAgent: null,
+      currentAgentStatus: 'loading',
+    })).toBe('unknown');
+
+    expect(curatorStatusForOverview({
+      cg: { curator: 'did:dkg:agent:0xABC', accessPolicy: 'private' },
+      currentAgent: null,
+      currentAgentStatus: 'error',
+    })).toBe('unknown');
+  });
+
+  it('curatorStatusForOverview returns "unknown" when cg.curator is missing entirely (Codex bug I)', () => {
+    // Older / partial CG payloads may omit `curator`. Returning
+    // `'not-curator'` here hard-hides PendingJoinRequestsSection
+    // from a real curator whose daemon simply didn't surface the
+    // field; route through the `'unknown'` verifying-access state
+    // instead. The eventual server-side authorisation in
+    // /join-requests still gates real actions.
+    expect(curatorStatusForOverview({
+      cg: { accessPolicy: 'private' }, // no `curator` field
+      currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      currentAgentStatus: 'ok',
+    })).toBe('unknown');
+
+    expect(curatorStatusForOverview({
+      cg: { curator: '', accessPolicy: 'private' }, // empty string
+      currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      currentAgentStatus: 'ok',
+    })).toBe('unknown');
+  });
+
+  it('renders At a glance status hints as title tooltips, not inline (§4.2.1 Delta 2)', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-tooltip', name: 'Tooltip', accessPolicy: 'public', callerInvolved: true },
+        memory: baseMemory,
+        subGraphCount: 2,
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    // Each of the four cells is addressable via `[data-stat-id]`
+    // and carries a non-empty `title`. The hint copy never leaks
+    // into rendered text; `.v10-stat-strip-hint` is never rendered
+    // (the inline-hint surface is intentionally unused by the
+    // Overview — qa-engineer's defensive check).
+    const ids = ['entities', 'triples', 'subgraphs', 'participants'] as const;
+    for (const id of ids) {
+      const cell = container.querySelector<HTMLElement>(`[data-stat-id="${id}"]`);
+      expect(cell, `missing [data-stat-id="${id}"]`).toBeTruthy();
+      expect(cell!.title?.trim().length ?? 0).toBeGreaterThan(0);
+      expect(cell!.querySelector('.v10-stat-strip-hint')).toBeNull();
+    }
+    expect(container.textContent).not.toContain('Topical partitions inside this Context Graph.');
+    expect(container.textContent).not.toContain('Canonical triple total across all layers.');
+    expect(container.textContent).not.toContain('Canonical current-layer entity counts.');
+    expect(container.querySelectorAll('.v10-stat-strip-hint')).toHaveLength(0);
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders an unknown subgraph count while subGraphCount is loading', async () => {
+    const { container, root } = await render(
+      React.createElement(ProjectOverviewCard, {
+        cg: { id: 'cg-loading-sg', name: 'Loading', accessPolicy: 'private' },
+        memory: baseMemory,
+        // subGraphCount intentionally omitted — caller has not resolved yet.
+        participants: [],
+        currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
+      }),
+    );
+
+    const subgraphsCell = container.querySelector<HTMLElement>('[data-stat-id="subgraphs"]');
+    expect(subgraphsCell).toBeTruthy();
+    // ui-lead review finding #4 — loading state collapses to '...'
+    // (mono ellipsis convention used everywhere else in the file)
+    // instead of 'Loading...'.
+    expect(subgraphsCell!.querySelector('.v10-stat-strip-value')?.textContent?.trim())
+      .toBe('...');
 
     await act(async () => root.unmount());
   });
@@ -319,7 +1129,7 @@ describe('Context Graph IA and Overview', () => {
     await act(async () => root.unmount());
   });
 
-  it('labels public graph participant lists as known, not allowlisted', async () => {
+  it('renders the participants section under the canonical "Participant agents" heading regardless of access policy', async () => {
     const { container, root } = await render(
       React.createElement(ProjectOverviewCard, {
         cg: {
@@ -329,13 +1139,18 @@ describe('Context Graph IA and Overview', () => {
           callerInvolved: true,
         },
         memory: baseMemory,
-        participants: ['0x1234567890abcdef'],
+        participants: ['0x1234567890abcdef1234567890abcdef12345678'],
         currentAgent: { agentDid: 'did:dkg:agent:0xdef' },
       }),
     );
 
-    expect(container.textContent).toContain('Known participants');
+    // S2 finalize §4.2.1 — the section is "Participant agents"
+    // everywhere. Public-vs-curated semantics live on the CG-type
+    // badge and the access stat hint, not the participants heading.
+    expect(container.textContent).toContain('Participant agents');
+    expect(container.textContent).not.toContain('Known participants');
     expect(container.textContent).not.toContain('Allowlisted participants');
+    expect(container.querySelectorAll('.v10-po-participant')).toHaveLength(1);
 
     await act(async () => root.unmount());
   });
@@ -362,9 +1177,16 @@ describe('Context Graph IA and Overview', () => {
       }),
     );
 
+    // §4.2.1 Delta 2 — the M6 status sentence now lives on the
+    // Entities cell as a `title` tooltip, not inline text. Read it
+    // from the cell's attribute via the stable `[data-stat-id]`
+    // hook (qa-engineer's selector convention). Defensive check
+    // confirms no inline `.v10-stat-strip-hint` was rendered alongside.
     expect(container.textContent).toContain('Unavailable');
-    expect(container.textContent).toContain('Live memory counts are unavailable.');
-    expect(container.textContent).not.toContain('Canonical current-layer entity counts.');
+    const entitiesCell = container.querySelector<HTMLElement>('[data-stat-id="entities"]');
+    expect(entitiesCell).toBeTruthy();
+    expect(entitiesCell?.getAttribute('title')).toBe('Live memory counts are unavailable.');
+    expect(entitiesCell?.querySelector('.v10-stat-strip-hint')).toBeNull();
 
     await act(async () => root.unmount());
   });
@@ -391,7 +1213,15 @@ describe('Context Graph IA and Overview', () => {
       }),
     );
 
-    expect(container.textContent).toContain('One or more layer counts are currently a lower bound.');
+    // §4.2.1 Delta 2 — the partial-bound hint now lives on the
+    // Entities cell as a `title` tooltip via the stable
+    // `[data-stat-id]` hook. Pipeline rendering assertions
+    // unchanged.
+    const entitiesCell = container.querySelector<HTMLElement>('[data-stat-id="entities"]');
+    expect(entitiesCell).toBeTruthy();
+    expect(entitiesCell?.getAttribute('title'))
+      .toBe('One or more layer counts are currently a lower bound.');
+    expect(entitiesCell?.querySelector('.v10-stat-strip-hint')).toBeNull();
     expect(container.querySelector('.v10-po-pipeline-step.vm .v10-po-pipeline-step-count')?.textContent)
       .toBe('Unavailable');
     expect(container.querySelectorAll('.v10-po-pipeline-seg')).toHaveLength(0);
@@ -420,6 +1250,28 @@ describe('Context Graph IA and Overview', () => {
     expect(container.textContent).toContain('Agents with access');
     expect(container.textContent).toContain('Unavailable');
     expect(container.textContent).not.toContain('Allowlisted agents');
+
+    await act(async () => root.unmount());
+  });
+
+  it('renders the OverviewPrimerEntry footer with locked copy + clickable primer link', async () => {
+    const onOpenPrimer = vi.fn();
+    const { container, root } = await render(
+      React.createElement(OverviewPrimerEntry, { onOpenPrimer }),
+    );
+
+    const footer = container.querySelector('.v10-po-primer-footer');
+    expect(footer).toBeTruthy();
+    expect(footer!.textContent).toContain('New here?');
+    expect(footer!.textContent).toContain('What is a Context Graph?');
+    expect(footer!.textContent).toContain('A short primer on context graphs, the WM → SWM → VM pipeline');
+
+    const link = container.querySelector<HTMLButtonElement>('.v10-po-primer-footer-link');
+    expect(link).toBeTruthy();
+    await act(async () => {
+      link!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onOpenPrimer).toHaveBeenCalledTimes(1);
 
     await act(async () => root.unmount());
   });

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -162,6 +162,9 @@ const apiWrapperMock = vi.hoisted(() => ({
   fetchContextGraphs: vi.fn(),
   fetchCurrentAgent: vi.fn(),
   listParticipants: vi.fn(),
+  // Codex review bug F — ProjectView now routes through api-wrapper
+  // so the Subgraphs stat resolves in mock mode. Default to empty.
+  fetchSubGraphs: vi.fn(async (id: string) => ({ contextGraphId: id, subGraphs: [] })),
 }));
 
 vi.mock('../src/ui/api-wrapper.js', () => ({
@@ -170,6 +173,11 @@ vi.mock('../src/ui/api-wrapper.js', () => ({
 
 vi.mock('../src/ui/api.js', () => ({
   listParticipants: vi.fn(async () => ({ allowedAgents: [] })),
+}));
+
+vi.mock('../src/ui/hooks/useNodeEvents.js', () => ({
+  useNodeEvents: () => {},
+  useMemoryGraphEvents: () => {},
 }));
 
 vi.mock('../src/ui/hooks/useMemoryEntities.js', () => ({
@@ -247,50 +255,27 @@ vi.mock('../src/ui/views/project/components.js', () => ({
       React.createElement('button', { 'data-testid': 'subgraph-tab-graph', onClick: () => onTabChange('graph') }, 'Graph'),
       React.createElement('div', { 'data-testid': 'subgraph-scroll', 'data-cg-scroll-key': `subgraph:${slug}:${activeTab}` },
         React.createElement('button', { 'data-testid': 'open-subgraph-entity', onClick: () => onSelectEntity('urn:entity:demo') }, 'Open demo entity'))),
-  ProjectOverviewCard: ({ onOpenPrimer, participants, participantsStatus }: {
+  ProjectOverviewCard: ({ onOpenPrimer, participants, participantsStatus, subGraphCount, subGraphFetchFailed }: {
     onOpenPrimer: () => void;
     participants: string[];
     participantsStatus: string;
+    subGraphCount?: number | null;
+    subGraphFetchFailed?: boolean;
   }) =>
     React.createElement('div', {
       'data-testid': 'overview-card',
       'data-participants': participants.join(','),
       'data-participants-status': participantsStatus,
+      'data-sub-graph-count': subGraphCount == null ? '' : String(subGraphCount),
+      'data-sub-graph-fetch-failed': subGraphFetchFailed ? 'true' : 'false',
     },
       'Overview',
       React.createElement('button', { 'data-testid': 'open-primer', onClick: onOpenPrimer }, 'What is a Context Graph?')),
-  PendingJoinRequestsBar: () => null,
-  MemoryStrip: ({ expandedLayer, onExpandedLayerChange, expandTabs, onExpandTabChange, onSelectEntity }: {
-    expandedLayer: 'wm' | 'swm' | 'vm' | null;
-    onExpandedLayerChange: (layer: 'wm' | 'swm' | 'vm' | null) => void;
-    expandTabs: Record<'wm' | 'swm' | 'vm', string>;
-    onExpandTabChange: (layer: 'wm' | 'swm' | 'vm', tab: string) => void;
-    onSelectEntity: (uri: string) => void;
-  }) => {
-    const activeTab = expandedLayer ? expandTabs[expandedLayer] : 'items';
-    return React.createElement('section', {
-      'data-testid': 'memory-strip',
-      'data-expanded': expandedLayer ?? '',
-      'data-tab': activeTab,
-    },
-      React.createElement('button', {
-        'data-testid': 'expand-strip-swm',
-        onClick: () => onExpandedLayerChange(expandedLayer === 'swm' ? null : 'swm'),
-      }, 'Expand SWM'),
-      expandedLayer && React.createElement(React.Fragment, {},
-        React.createElement('button', {
-          'data-testid': 'strip-tab-graph',
-          onClick: () => onExpandTabChange(expandedLayer, 'graph'),
-        }, 'Graph'),
-        React.createElement('div', {
-          'data-testid': 'strip-scroll',
-          'data-cg-scroll-key': `layer:${expandedLayer}:${activeTab}`,
-        },
-          React.createElement('button', {
-            'data-testid': 'open-strip-entity',
-            onClick: () => onSelectEntity('urn:entity:working'),
-          }, 'Open strip entity'))));
-  },
+  PendingJoinRequestsSection: () => null,
+  OverviewPrimerEntry: ({ onOpenPrimer }: { onOpenPrimer: () => void }) =>
+    React.createElement('div', { 'data-testid': 'primer-footer' },
+      React.createElement('button', { 'data-testid': 'open-primer-footer', onClick: onOpenPrimer }, 'What is a Context Graph?')),
+  curatorStatusForOverview: () => 'not-curator',
   SubGraphOverviewGrid: ({ onSelectSubGraph }: { onSelectSubGraph: (slug: string) => void }) =>
     React.createElement('button', {
       'data-testid': 'select-subgraph-demo',
@@ -353,6 +338,7 @@ describe('ProjectView entity detail navigation', () => {
       peerId: 'peer-1',
     });
     apiWrapperMock.listParticipants.mockResolvedValue({ allowedAgents: [] });
+    apiWrapperMock.fetchSubGraphs.mockResolvedValue({ contextGraphId: 'cg-test', subGraphs: [] });
     document.body.innerHTML = '<div id="root"></div>';
     originalRaf = window.requestAnimationFrame;
     Object.defineProperty(window, 'requestAnimationFrame', {
@@ -415,6 +401,48 @@ describe('ProjectView entity detail navigation', () => {
 
     expect(query('active-layer').dataset.layer).toBe('overview');
     expect(scrollRoot('page').scrollTop).toBe(140);
+  });
+
+  it('routes the Overview Subgraphs lift through api-wrapper so mock-mode resolves (Codex bug F)', async () => {
+    // ProjectView should fire its sub-graph fetch via the wrapped
+    // `api.fetchSubGraphs`, NOT via a direct `../api.js` import that
+    // would bypass mock/offline fallback. Asserting the wrapper was
+    // called proves the route — `apiWrapperMock.fetchSubGraphs`
+    // only resolves when the wrapper is actually used.
+    expect(apiWrapperMock.fetchSubGraphs).toHaveBeenCalledWith('cg-test');
+  });
+
+  it('Overview Subgraphs count filters the `meta` slug', async () => {
+    // Same filter as SubGraphBar (chips) and SubGraphOverviewGrid
+    // (cards) — only `meta` is excluded. The daemon's
+    // `listSubGraphs` returns only registered `dkg:SubGraph` rows;
+    // `meta` is the auto-registered profile slug.
+    apiWrapperMock.fetchSubGraphs.mockResolvedValue({
+      contextGraphId: 'cg-test',
+      subGraphs: [
+        { name: 'meta', uri: 'urn:meta', entityCount: 0, tripleCount: 0 },
+        { name: 'recipes', uri: 'urn:recipes', entityCount: 3, tripleCount: 12 },
+        { name: 'reviews', uri: 'urn:reviews', entityCount: 5, tripleCount: 18 },
+        { name: 'docs', uri: 'urn:docs', entityCount: 2, tripleCount: 7 },
+      ],
+    });
+
+    // Remount ProjectView so the updated mockResolvedValue takes
+    // effect (the global beforeEach() resolved an empty list).
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.innerHTML = '<div id="root"></div>';
+    const container = document.getElementById('root');
+    if (!container) throw new Error('Missing root');
+    root = createRoot(container);
+    await act(async () => {
+      root.render(React.createElement(ProjectView, { contextGraphId: 'cg-test' }));
+    });
+    await flush();
+
+    // Expect 3 = 4 total - 1 (meta filtered).
+    expect(query('overview-card').dataset.subGraphCount).toBe('3');
   });
 
   it('opens graph nodes with the layer context they came from', async () => {

--- a/packages/node-ui/test/sub-graphs-helper.test.ts
+++ b/packages/node-ui/test/sub-graphs-helper.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { isUserFacingSubGraph, RESERVED_SUB_GRAPH_SLUGS } from '../src/ui/lib/subGraphs.js';
+
+describe('isUserFacingSubGraph', () => {
+  it('rejects the reserved `meta` slug', () => {
+    expect(isUserFacingSubGraph({ name: 'meta' })).toBe(false);
+  });
+
+  it('accepts any non-reserved slug', () => {
+    expect(isUserFacingSubGraph({ name: 'recipes' })).toBe(true);
+    expect(isUserFacingSubGraph({ name: 'reviews' })).toBe(true);
+    expect(isUserFacingSubGraph({ name: 'docs' })).toBe(true);
+  });
+
+  it('exposes RESERVED_SUB_GRAPH_SLUGS as the single source of truth', () => {
+    expect(RESERVED_SUB_GRAPH_SLUGS.has('meta')).toBe(true);
+    expect(RESERVED_SUB_GRAPH_SLUGS.size).toBe(1);
+  });
+});

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -346,6 +346,53 @@ describe('UI API tests', () => {
     });
   });
 
+  // The Node UI mounts `useMemoryEntities` and `useProjectProfile` from
+  // multiple sibling views simultaneously when a project is opened
+  // (e.g. Dashboard card + ProjectView). Pre-dedup, each duplicate
+  // fan-out hit `/api/query` separately and added seconds of wall-time
+  // on a multi-GB Oxigraph store. These tests pin the contract that
+  // `executeQuery` collapses concurrent identical POSTs to one fetch
+  // while still firing fresh requests once a prior one settles.
+  describe('executeQuery in-flight dedup', () => {
+    it('coalesces concurrent identical queries to one /api/query POST', async () => {
+      const results = await Promise.all([
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-dedup'),
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-dedup'),
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-dedup'),
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-dedup'),
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-dedup'),
+      ]);
+      const queryCalls = requestLog.filter(
+        r => r.method === 'POST' && r.url.startsWith('/api/query'),
+      );
+      expect(queryCalls).toHaveLength(1);
+      expect(results).toHaveLength(5);
+      for (const r of results) {
+        expect(r).toEqual({ result: { bindings: [] } });
+      }
+    });
+
+    it('does not coalesce when args differ', async () => {
+      await Promise.all([
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-a'),
+        executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-b'),
+      ]);
+      const queryCalls = requestLog.filter(
+        r => r.method === 'POST' && r.url.startsWith('/api/query'),
+      );
+      expect(queryCalls).toHaveLength(2);
+    });
+
+    it('issues a fresh fetch once the prior request has settled', async () => {
+      await executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-sequential');
+      await executeQuery('SELECT * WHERE { ?s ?p ?o }', 'cg-sequential');
+      const queryCalls = requestLog.filter(
+        r => r.method === 'POST' && r.url.startsWith('/api/query'),
+      );
+      expect(queryCalls).toHaveLength(2);
+    });
+  });
+
   // IMPORT_SOURCES test block removed — the constant was retired along
   // with /api/memory/import as part of the openclaw-dkg-primary-memory
   // work. See Dashboard / ui/api.ts for the deletion context.

--- a/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
+++ b/packages/node-ui/test/use-assertion-lifecycle-events.test.ts
@@ -266,6 +266,86 @@ describe('useAssertionLifecycleEvents — bindings parse', () => {
   // consumers (ProjectView → ActivityFeed) plumb it through to
   // render an error indicator. This test pins the hook contract:
   // error message is exposed verbatim so the UI can surface it.
+  it('preserves the last-known-good `events` cache when a same-graph refresh fails (PR #694 polish carry-over a)', async () => {
+    let latest: AssertionLifecycleEventsResult | null = null;
+    function Probe({ id }: { id: string | undefined }) {
+      latest = useAssertionLifecycleEvents(id);
+      return null;
+    }
+    // First mount on `cg-A`. Resolve with one row so the hook has a
+    // populated cache + `resultContextGraphId === 'cg-A'`.
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-A' }));
+    });
+    await flush();
+    pending.get('cg-A')!.resolve([
+      row({
+        event: 'urn:event:1',
+        kind: 'created',
+        assertion: 'urn:assertion:1',
+        name: 'a1',
+        agent: 'urn:agent:1',
+        ts: '2026-05-27T12:00:00Z',
+      }),
+    ]);
+    await flush();
+    expect(latest!.events).toHaveLength(1);
+    expect(latest!.resultContextGraphId).toBe('cg-A');
+    expect(latest!.error).toBeNull();
+
+    // User navigates away from Overview — Probe receives `id={undefined}`.
+    // Per PR #694 Comment 20 the hook PRESERVES `events` /
+    // `resultContextGraphId` in this gated-off state.
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: undefined }));
+    });
+    await flush();
+    expect(latest!.events).toHaveLength(1);
+    expect(latest!.resultContextGraphId).toBe('cg-A');
+
+    // User returns to Overview — Probe receives `id='cg-A'` again,
+    // which re-fires the effect. This time the daemon errors
+    // (transient 503).
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('SPARQL query failed: 503');
+    }) as any;
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-A' }));
+    });
+    await flush();
+
+    // The carry-over fix — the cached row from the earlier success
+    // must NOT be clobbered to `[]`. The error message surfaces
+    // alongside.
+    expect(latest!.error).toBe('SPARQL query failed: 503');
+    expect(latest!.events).toHaveLength(1);
+    expect(latest!.events[0].assertionUri).toBe('urn:assertion:1');
+    // The discriminator still points at the current graph.
+    expect(latest!.resultContextGraphId).toBe('cg-A');
+  });
+
+  it('clears `events` when a fetch errors on a graph with no prior cached result', async () => {
+    // Regression guard for the fix: the cache-preservation only
+    // applies when `resultContextGraphId === contextGraphId` (i.e.,
+    // we had a prior success on THIS graph). A first-mount error on
+    // a fresh graph still produces an empty list.
+    let latest: AssertionLifecycleEventsResult | null = null;
+    function Probe({ id }: { id: string }) {
+      latest = useAssertionLifecycleEvents(id);
+      return null;
+    }
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('SPARQL query failed: 503');
+    }) as any;
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-fresh' }));
+    });
+    await flush();
+    expect(latest!.error).toBe('SPARQL query failed: 503');
+    expect(latest!.events).toHaveLength(0);
+    expect(latest!.resultContextGraphId).toBe('cg-fresh');
+  });
+
   it('exposes the rejection message verbatim on error (Comment 8 distinguishability)', async () => {
     let latest: AssertionLifecycleEventsResult | null = null;
     function Probe({ id }: { id: string }) {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import type { Publisher, PublishOptions, PublishResult, KAManifestEntry, PhaseCallback, V10CoreNodeACK } from './publisher.js';
 import { autoPartition } from './auto-partition.js';
@@ -948,6 +948,7 @@ export class DKGPublisher implements Publisher {
       rootEntities,
       quads: normalized,
       publisherPeerId: options.publisherPeerId,
+      agentAddress: options.senderAgentAddress,
       subGraphName: options.subGraphName,
       timestamp: operationTimestamp,
       publicSnapshotStore: this.publicSnapshotStore,
@@ -3064,12 +3065,22 @@ export class DKGPublisher implements Publisher {
       return new Map();
     }
 
+    // GH #748: prefer the dedicated `dkg:publisherPeerId` literal; fall
+    // back to a literal-form `prov:wasAttributedTo` for legacy un-migrated
+    // rows. Skip post-fix URI attribution — `workspaceOwner` (queried
+    // above) is always a peer-ID literal, so a URI `?creator` from
+    // `wasAttributedTo` would never match and every ownership row would
+    // be rejected as unvalidated. `FILTER(BOUND(?creator))` guards against
+    // an op having `rootEntity` but neither peer-ID source.
     const operationResult = await this.store.query(
       `SELECT DISTINCT ?entity ?creator WHERE {
         GRAPH <${assertSafeIri(swmMetaGraph)}> {
           ${valuesClause}
-          ?op <${DKG}rootEntity> ?entity ;
-              <${PROV}wasAttributedTo> ?creator .
+          ?op <${DKG}rootEntity> ?entity .
+          OPTIONAL { ?op <${DKG}publisherPeerId> ?pidField }
+          OPTIONAL { ?op <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
+          BIND(COALESCE(?pidField, ?attrField) AS ?creator)
+          FILTER(BOUND(?creator))
         }
       }`,
     );
@@ -3155,6 +3166,305 @@ export class DKGPublisher implements Publisher {
   /** @deprecated Use reconstructSharedMemoryOwnership */
   async reconstructWorkspaceOwnership(): Promise<number> {
     return this.reconstructSharedMemoryOwnership();
+  }
+
+  /**
+   * One-shot startup migration for GH #748: rewrite SWM
+   * `prov:wasAttributedTo` from peer-ID string literals to agent DID
+   * URIs (`<did:dkg:agent:0x…>`). Idempotent — each CG carries a
+   * `<urn:dkg:migration:swm-attr-agent-did> dkg:appliedAt "<ts>"`
+   * marker in `_meta` after a successful pass; subsequent boots skip
+   * marked CGs. Best-effort: rows whose peer ID can't be resolved
+   * against the AGENTS system graph are left in place.
+   */
+  async migrateSwmAttributionToAgentDid(): Promise<{ rewritten: number; skipped: number; swmMetaGraphs: number }> {
+    // GH #748 Codex round 3: the AGENTS registry vocabulary is the spec-aligned
+    // `https://dkg.network/ontology#` namespace (see `buildAgentProfile` and
+    // `discovery.ts:findAgentByPeerId`), distinct from the internal
+    // `http://dkg.io/ontology/` namespace used by SWM meta predicates
+    // (`dkg:rootEntity`, `dkg:publisherPeerId`, `dkg:workspaceOwner`, etc.).
+    // The migration touches both: SWM meta predicates use DKG_INTERNAL; the
+    // AGENTS registry lookup uses DKG_REGISTRY. Confirmed against live data:
+    // a real node's `did:dkg:context-graph:agents` graph carries
+    // `https://dkg.network/ontology#peerId`, not `http://dkg.io/ontology/peerId`.
+    const DKG = 'http://dkg.io/ontology/';
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+    const XSD = 'http://www.w3.org/2001/XMLSchema#';
+    const SWM_META_SUFFIX = '/_shared_memory_meta';
+    const CG_PREFIX = 'did:dkg:context-graph:';
+    const MIGRATION_MARKER_SUBJECT = 'urn:dkg:migration:swm-attr-agent-did';
+    // Use the canonical AGENTS system-graph URI helper rather than hardcoding;
+    // `contextGraphDataGraphUri('agents')` yields `did:dkg:context-graph:agents`
+    // (no `/_data` suffix), which is where `registerAgent()` actually writes.
+    const AGENTS_GRAPH = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const ctx = createOperationContext('migrate-swm-attr');
+
+    let totalRewritten = 0;
+    let totalSkipped = 0;
+    // GH #748 Codex round 7: counts SWM-meta graphs processed (root + any
+    // sub-graph-scoped ones), not distinct context graphs — the migration
+    // operates per SWM-meta graph after the round-6 enumeration fix. Field
+    // name kept honest so the startup log doesn't over-report "CG(s)".
+    let swmMetaGraphsProcessed = 0;
+
+    try {
+      const peerToAddress = new Map<string, string | null>();
+      const allGraphs = await this.store.listGraphs();
+      // GH #748 Codex round 6 (user report): enumerate `_shared_memory_meta`
+      // graphs directly via `store.listGraphs()`. The earlier approach used
+      // `graphManager.listContextGraphs()`, but that helper filters out CG
+      // IDs containing a slash (storage/graph-manager.ts:104) to dedupe
+      // sub-graph paths — which also excludes legitimate curated CGs of the
+      // `<addr>/<slug>` shape (the on-chain-anchored ones a user is NOT the
+      // curator of). On a real node, that meant the migration silently
+      // skipped every curated CG and only touched bare-slug shadows.
+      // Iterating the SWM-meta graphs directly catches both forms (curated
+      // root + sub-graph-scoped) naturally — each graph is processed once,
+      // marker stored adjacent at `<...>/_meta`.
+      const swmMetaGraphs = allGraphs.filter(
+        g => g.startsWith(CG_PREFIX) && g.endsWith(SWM_META_SUFFIX),
+      );
+
+      for (const swmMetaGraph of swmMetaGraphs) {
+        // Defensive: skip system graphs even though they shouldn't carry SWM.
+        const cgPath = swmMetaGraph.slice(CG_PREFIX.length, swmMetaGraph.length - SWM_META_SUFFIX.length);
+        if (cgPath === 'agents' || cgPath === 'ontology') continue;
+
+        // Derive marker graph by swapping the suffix — works for root CG
+        // and sub-graph-scoped SWMs alike. Marker lives in the adjacent
+        // `_meta` graph so a SWM graph wipe doesn't accidentally re-arm
+        // the migration.
+        const markerGraph = `${CG_PREFIX}${cgPath}/_meta`;
+
+        const markerResult = await this.store.query(
+          `SELECT ?ts WHERE { GRAPH <${markerGraph}> { <${MIGRATION_MARKER_SUBJECT}> <${DKG}appliedAt> ?ts } } LIMIT 1`,
+        );
+        const markerPresent =
+          markerResult.type === 'bindings' && markerResult.bindings.length > 0;
+
+        // GH #748 (user-reported regression): the round-1 → round-6 delete
+        // logic used `store.delete([{ object: literalString }])` which
+        // silently no-op'd against `xsd:string`-typed literals on a
+        // persistent oxigraph store — the URI insert succeeded but the
+        // literal stayed. Affected stores end up with BOTH forms for the
+        // same subject. If a marker is present BUT subjects exist with
+        // BOTH a literal AND a URI `wasAttributedTo`, the previous pass
+        // was broken — override the marker so we re-process and clean up.
+        // Only this exact broken state triggers re-run; legitimate
+        // remaining literals (e.g. `"unknown"` permanent placeholders) do
+        // not, because they don't also have a URI counterpart.
+        if (markerPresent) {
+          const staleCheck = await this.store.query(
+            `ASK { GRAPH <${swmMetaGraph}> {
+              ?s <${PROV}wasAttributedTo> ?lit . FILTER(isLiteral(?lit))
+              ?s <${PROV}wasAttributedTo> ?uri . FILTER(isURI(?uri))
+            } }`,
+          );
+          const hasBrokenDuplicates = staleCheck.type === 'boolean' && staleCheck.value;
+          if (!hasBrokenDuplicates) continue;
+          // Drop the stale marker so we record a fresh `appliedAt`
+          // timestamp when the (now-fixed) pass completes.
+          await this.store.deleteByPattern({
+            graph: markerGraph,
+            subject: MIGRATION_MARKER_SUBJECT,
+            predicate: `${DKG}appliedAt`,
+          });
+        }
+
+        let swmRewritten = 0;
+        // GH #748 Codex round 4: track retriable vs permanent skips
+        // separately. Marker-block decision uses retriable only — permanent
+        // misses (sentinel `"unknown"`, empty string) can never be resolved,
+        // so they must not keep the migration hot on every boot.
+        let swmRetriableSkipped = 0;
+        let swmPermanentSkipped = 0;
+
+        const sparql = `SELECT ?s ?o WHERE { GRAPH <${swmMetaGraph}> { ?s <${PROV}wasAttributedTo> ?o . FILTER(isLiteral(?o)) } }`;
+        const result = await this.store.query(sparql);
+        if (result.type === 'bindings') {
+          for (const row of result.bindings) {
+            const subject = row['s'];
+            const objectLit = row['o'];
+            if (!subject || !objectLit) continue;
+
+            const peerId = objectLit.startsWith('"')
+              ? objectLit.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '')
+              : objectLit;
+            // Permanent skip: the literal sentinel `"unknown"` (legacy
+            // `generateKCMetadata` placeholder when peer ID wasn't supplied)
+            // or empty — neither can ever resolve to an agent address.
+            if (!peerId || peerId === 'unknown') {
+              swmPermanentSkipped++;
+              continue;
+            }
+
+            let address: string | null;
+            if (peerToAddress.has(peerId)) {
+              address = peerToAddress.get(peerId)!;
+            } else {
+              address = await this.resolveAgentAddressForPeer(peerId, AGENTS_GRAPH, DKG_REGISTRY, RDF);
+              peerToAddress.set(peerId, address);
+            }
+
+            if (!address) {
+              // Retriable: AGENTS record might sync on a future boot.
+              swmRetriableSkipped++;
+              continue;
+            }
+
+            // Backward-compat: per-root snapshot rows historically stored the
+            // peer ID only via `wasAttributedTo`. If this subject has no
+            // `dkg:publisherPeerId` quad yet, materialise one from the literal
+            // we're about to rewrite — otherwise the post-fix readers (which
+            // now query `dkg:publisherPeerId` rather than `wasAttributedTo`)
+            // would lose the peer ID entirely for migrated rows.
+            const hasPeerIdField = await this.store.query(
+              `ASK { GRAPH <${swmMetaGraph}> { <${subject}> <${DKG}publisherPeerId> ?x } }`,
+            );
+            const peerIdFieldPresent =
+              hasPeerIdField.type === 'boolean' ? hasPeerIdField.value : false;
+            if (!peerIdFieldPresent) {
+              await this.store.insert([{
+                subject,
+                predicate: `${DKG}publisherPeerId`,
+                object: objectLit,
+                graph: swmMetaGraph,
+              }]);
+            }
+
+            // GH #748 (user-reported regression): use `deleteByPattern` rather
+            // than `store.delete([{ object: literalString }])`. Exact-match
+            // delete silently no-op'd against `xsd:string`-typed literals on
+            // a persistent oxigraph store — the literal stayed alongside the
+            // newly-inserted URI, leaving the legend with duplicate
+            // peer-ID + agent-DID attribution for every migrated row.
+            // Pattern-based delete is form-agnostic; safe to wipe all
+            // wasAttributedTo for this subject because writers only ever
+            // emit one (we're about to insert the canonical URI).
+            await this.store.deleteByPattern({
+              graph: swmMetaGraph,
+              subject,
+              predicate: `${PROV}wasAttributedTo`,
+            });
+            await this.store.insert([{
+              subject,
+              predicate: `${PROV}wasAttributedTo`,
+              object: `did:dkg:agent:${address}`,
+              graph: swmMetaGraph,
+            }]);
+            swmRewritten++;
+          }
+        }
+
+        // GH #748 Codex rounds 2 + 4: write the marker when there are no
+        // RETRIABLE misses left. Permanent placeholders (sentinel
+        // `"unknown"`) are never resolvable, so blocking the marker on them
+        // would keep the migration hot on every boot forever. Retriable
+        // misses (AGENTS record not yet synced) still suppress the marker so
+        // future boots retry. The re-run cost is bounded by the residual
+        // literal count — already-rewritten rows fail the `isLiteral(?o)`
+        // filter and contribute zero work.
+        if (swmRetriableSkipped === 0) {
+          await this.store.insert([{
+            subject: MIGRATION_MARKER_SUBJECT,
+            predicate: `${DKG}appliedAt`,
+            object: `"${new Date().toISOString()}"^^<${XSD}dateTime>`,
+            graph: markerGraph,
+          }]);
+        }
+
+        const swmSkipped = swmRetriableSkipped + swmPermanentSkipped;
+        totalRewritten += swmRewritten;
+        totalSkipped += swmSkipped;
+        swmMetaGraphsProcessed++;
+
+        if (swmRewritten > 0 || swmSkipped > 0) {
+          const retryNote = swmRetriableSkipped > 0
+            ? ` (${swmRetriableSkipped} will retry on next boot, ${swmPermanentSkipped} permanent placeholders)`
+            : swmPermanentSkipped > 0
+              ? ` (${swmPermanentSkipped} permanent placeholders)`
+              : '';
+          this.log.info(
+            ctx,
+            `SWM ${cgPath}: rewrote ${swmRewritten} attribution literal(s) to agent DID, left ${swmSkipped} unresolved${retryNote}`,
+          );
+        }
+      }
+
+      return { rewritten: totalRewritten, skipped: totalSkipped, swmMetaGraphs: swmMetaGraphsProcessed };
+    } catch (err) {
+      this.log.warn(
+        ctx,
+        `migrateSwmAttributionToAgentDid failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return { rewritten: totalRewritten, skipped: totalSkipped, swmMetaGraphs: swmMetaGraphsProcessed };
+    }
+  }
+
+  private async resolveAgentAddressForPeer(
+    peerId: string, agentsGraph: string, dkgRegistry: string, RDF: string,
+  ): Promise<string | null> {
+    // SPARQL string-literal escape: only `"` and `\` are special inside `"..."`.
+    const escaped = peerId.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    // GH #748 Codex rounds 2, 3, 5: resolve the agent address for a peer ID.
+    // - Round 3: vocabulary is `https://dkg.network/ontology#` (the registry
+    //   namespace `buildAgentProfile` writes), NOT the internal
+    //   `http://dkg.io/ontology/` one — the latter matches zero rows.
+    // - Round 2: a libp2p PeerId can be shared across multiple registered
+    //   agents on the same node (multi-agent-per-node via
+    //   `DKGAgent.registerAgent`). Reject genuine cross-agent ambiguity.
+    // - Round 5: an upgraded store can legitimately have multiple AGENTS
+    //   records for the SAME agent — e.g. the legacy
+    //   `did:dkg:agent:<peerId>` subject (profile.ts fallback) plus the
+    //   canonical `did:dkg:agent:<address>` subject. Prefer the explicit
+    //   `dkg:agentAddress` literal as the source of truth, and dedup by
+    //   normalised address before deciding the mapping is ambiguous.
+    // - The fallback subject-URI parse handles records that pre-date the
+    //   `dkg:agentAddress` field and still encode the address only in the
+    //   subject (`did:dkg:agent:0x<40hex>`).
+    const sparql = `SELECT ?agent ?addr WHERE {
+      GRAPH <${agentsGraph}> {
+        ?agent <${RDF}type> <${dkgRegistry}Agent> ;
+               <${dkgRegistry}peerId> "${escaped}" .
+        OPTIONAL { ?agent <${dkgRegistry}agentAddress> ?addr }
+      }
+    }`;
+    const result = await this.store.query(sparql);
+    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+
+    const addresses = new Set<string>();
+    for (const row of result.bindings) {
+      const explicit = row['addr'];
+      if (explicit) {
+        // `dkg:agentAddress` is a literal — strip surrounding quotes.
+        const raw = explicit.startsWith('"')
+          ? explicit.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '')
+          : explicit;
+        if (/^0x[0-9a-fA-F]{40}$/.test(raw)) {
+          addresses.add(raw.toLowerCase());
+          continue;
+        }
+      }
+      // Fallback: parse the subject URI for records without an explicit
+      // `agentAddress` field. Only accept the canonical wallet-DID shape
+      // — a legacy `did:dkg:agent:<peerId>` subject is NOT an address and
+      // contributes nothing useful here.
+      const agentUri = row['agent'];
+      if (agentUri && agentUri.startsWith('did:dkg:agent:')) {
+        const tail = agentUri.slice('did:dkg:agent:'.length);
+        if (/^0x[0-9a-fA-F]{40}$/.test(tail)) {
+          addresses.add(tail.toLowerCase());
+        }
+      }
+    }
+
+    // 0 distinct addresses → no resolvable mapping.
+    // 1 → unambiguous: same agent (possibly across multiple profile records).
+    // 2+ → genuinely multiple agents on this peer; refuse to mis-attribute.
+    if (addresses.size !== 1) return null;
+    return [...addresses][0];
   }
 
   private async deleteMetaForRoot(metaGraph: string, rootEntity: string): Promise<void> {
@@ -3575,6 +3885,7 @@ export class DKGPublisher implements Publisher {
         rootEntities: effectiveRoots,
         quads: swmQuads,
         publisherPeerId: opts.publisherPeerId,
+        agentAddress,
         subGraphName: opts.subGraphName,
         timestamp: operationTimestamp,
         publicSnapshotStore: this.publicSnapshotStore,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3008,66 +3008,148 @@ export class DKGPublisher implements Publisher {
   private async reconstructOwnershipFromGraph(
     ownershipKey: string, swmMetaGraph: string, DKG: string, PROV: string,
   ): Promise<number> {
-    const result = await this.store.query(
-      `SELECT ?entity ?creator WHERE { GRAPH <${swmMetaGraph}> { ?entity <${DKG}workspaceOwner> ?creator } }`,
+    const durableOwners = await this.loadValidatedSharedMemoryOwners(
+      swmMetaGraph,
+      DKG,
+      PROV,
+      undefined,
+      'reconstruct',
     );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return 0;
-
-    const opsResult = await this.store.query(
-      `SELECT ?op ?peer ?root WHERE { GRAPH <${swmMetaGraph}> { ?op <${PROV}wasAttributedTo> ?peer . ?op <${DKG}rootEntity> ?root } }`,
-    );
-    const validatedOwners = new Map<string, Set<string>>();
-    if (opsResult.type === 'bindings') {
-      for (const row of opsResult.bindings) {
-        const root = row['root'];
-        const peer = row['peer'];
-        if (!root || !peer) continue;
-        const peerStr = peer.startsWith('"')
-          ? peer.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '')
-          : peer;
-        if (!validatedOwners.has(root)) validatedOwners.set(root, new Set());
-        validatedOwners.get(root)!.add(peerStr);
-      }
-    }
+    if (durableOwners.size === 0) return 0;
 
     if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {
       this.sharedMemoryOwnedEntities.set(ownershipKey, new Map());
     }
     const ownedMap = this.sharedMemoryOwnedEntities.get(ownershipKey)!;
     let count = 0;
-    for (const row of result.bindings) {
-      const entity = row['entity'];
-      const creator = row['creator'];
-      if (!entity || !creator) continue;
-      const creatorStr = creator.startsWith('"')
-        ? creator.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '')
-        : creator;
-
-      const validPeers = validatedOwners.get(entity);
-      if (!validPeers || !validPeers.has(creatorStr)) {
-        this.log.warn(
-          createOperationContext('reconstruct'),
-          `Skipping unvalidated ownership: entity=${entity} creator=${creatorStr}`,
-        );
-        continue;
-      }
-
+    for (const [entity, creator] of durableOwners) {
       if (ownedMap.has(entity)) {
         const existing = ownedMap.get(entity)!;
-        if (existing !== creatorStr) {
+        if (existing !== creator) {
           this.log.warn(
             createOperationContext('reconstruct'),
-            `Conflicting ownership for ${entity}: "${existing}" vs "${creatorStr}"; keeping alphabetically first`,
+            `Conflicting ownership for ${entity}: "${existing}" vs "${creator}"; keeping alphabetically first`,
           );
-          if (creatorStr < existing) ownedMap.set(entity, creatorStr);
+          setEffectiveOwner(ownedMap, entity, creator);
         }
         continue;
       }
 
-      ownedMap.set(entity, creatorStr);
+      ownedMap.set(entity, creator);
       count++;
     }
     return count;
+  }
+
+  private async loadValidatedSharedMemoryOwners(
+    swmMetaGraph: string,
+    DKG: string,
+    PROV: string,
+    rootEntities: readonly string[] | undefined,
+    logOperation: 'reconstruct' | 'share',
+  ): Promise<Map<string, string>> {
+    const valuesClause = rootEntities?.length
+      ? `VALUES ?entity { ${rootEntities.map((root) => `<${assertSafeIri(root)}>`).join(' ')} }`
+      : '';
+
+    const ownershipResult = await this.store.query(
+      `SELECT DISTINCT ?entity ?creator WHERE {
+        GRAPH <${assertSafeIri(swmMetaGraph)}> {
+          ${valuesClause}
+          ?entity <${DKG}workspaceOwner> ?creator .
+        }
+      }`,
+    );
+    if (ownershipResult.type !== 'bindings' || ownershipResult.bindings.length === 0) {
+      return new Map();
+    }
+
+    const operationResult = await this.store.query(
+      `SELECT DISTINCT ?entity ?creator WHERE {
+        GRAPH <${assertSafeIri(swmMetaGraph)}> {
+          ${valuesClause}
+          ?op <${DKG}rootEntity> ?entity ;
+              <${PROV}wasAttributedTo> ?creator .
+        }
+      }`,
+    );
+
+    const validatedOwners = new Map<string, Set<string>>();
+    if (operationResult.type === 'bindings') {
+      for (const row of operationResult.bindings) {
+        const entity = row['entity'];
+        const creator = stripSparqlLiteral(row['creator']);
+        if (!entity || !creator) continue;
+        addOwner(validatedOwners, entity, creator);
+      }
+    }
+
+    const durableOwners = new Map<string, string>();
+    for (const row of ownershipResult.bindings) {
+      const entity = row['entity'];
+      const creator = stripSparqlLiteral(row['creator']);
+      if (!entity || !creator) continue;
+      const validPeers = validatedOwners.get(entity);
+      if (!validPeers?.has(creator)) {
+        this.log.warn(
+          createOperationContext(logOperation),
+          `Skipping unvalidated ownership: entity=${entity} creator=${creator}`,
+        );
+        continue;
+      }
+
+      const existing = durableOwners.get(entity);
+      if (existing && existing !== creator) {
+        this.log.warn(
+          createOperationContext(logOperation),
+          `Conflicting ownership for ${entity}: "${existing}" vs "${creator}"; keeping alphabetically first`,
+        );
+      }
+      setEffectiveOwner(durableOwners, entity, creator);
+    }
+
+    return durableOwners;
+  }
+
+  private async sharedMemoryOwnersForPromotion(
+    contextGraphId: string,
+    subGraphName: string | undefined,
+    ownershipKey: string,
+    rootEntities: readonly string[],
+  ): Promise<Map<string, string>> {
+    const owners = new Map<string, string>();
+    const liveOwned = this.sharedMemoryOwnedEntities.get(ownershipKey);
+    if (liveOwned) {
+      for (const [root, owner] of liveOwned) {
+        setEffectiveOwner(owners, root, owner);
+      }
+    }
+
+    if (rootEntities.length === 0) return owners;
+
+    const DKG = 'http://dkg.io/ontology/';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(contextGraphId, subGraphName);
+    const durableOwners = await this.loadValidatedSharedMemoryOwners(
+      swmMetaGraph,
+      DKG,
+      PROV,
+      rootEntities,
+      'share',
+    );
+    if (durableOwners.size === 0) return owners;
+
+    if (!this.sharedMemoryOwnedEntities.has(ownershipKey)) {
+      this.sharedMemoryOwnedEntities.set(ownershipKey, new Map());
+    }
+    const hydratedOwned = this.sharedMemoryOwnedEntities.get(ownershipKey)!;
+
+    for (const [entity, creator] of durableOwners) {
+      setEffectiveOwner(owners, entity, creator);
+      setEffectiveOwner(hydratedOwned, entity, creator);
+    }
+
+    return owners;
   }
 
   /** @deprecated Use reconstructSharedMemoryOwnership */
@@ -3324,6 +3406,12 @@ export class DKGPublisher implements Publisher {
 
     const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(contextGraphId, opts?.subGraphName);
     const ownershipKey = opts?.subGraphName ? `${contextGraphId}\0${opts.subGraphName}` : contextGraphId;
+    const swmOwners = await this.sharedMemoryOwnersForPromotion(
+      contextGraphId,
+      opts?.subGraphName,
+      ownershipKey,
+      rootEntities,
+    );
     const swmOwned = this.sharedMemoryOwnedEntities.get(ownershipKey) ?? new Map<string, string>();
 
     // Pre-encode gossip message and enforce size limit BEFORE any destructive
@@ -3388,7 +3476,7 @@ export class DKGPublisher implements Publisher {
     // Rule 4: reject roots owned by a different peer before any mutations.
     const skippedRoots = new Set<string>();
     for (const root of rootEntities) {
-      const owner = swmOwned.get(root);
+      const owner = swmOwners.get(root);
       if (!owner) continue;
       if (opts?.publisherPeerId) {
         if (owner !== opts.publisherPeerId) {
@@ -3575,4 +3663,22 @@ function parseCountLiteral(val: string | false | undefined): number {
   const stripped = val.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '');
   const n = Number(stripped);
   return Number.isFinite(n) ? n : NaN;
+}
+
+function stripSparqlLiteral(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (!value.startsWith('"')) return value;
+  return value.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '');
+}
+
+function addOwner(owners: Map<string, Set<string>>, root: string, owner: string): void {
+  if (!owners.has(root)) owners.set(root, new Set());
+  owners.get(root)!.add(owner);
+}
+
+function setEffectiveOwner(owners: Map<string, string>, root: string, owner: string): void {
+  const existing = owners.get(root);
+  if (!existing || owner < existing) {
+    owners.set(root, owner);
+  }
 }

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -621,7 +621,7 @@ export function generateAssertionCreatedMetadata(meta: AssertionCreatedMeta): Qu
   const agentUri = `did:dkg:agent:${meta.agentAddress}`;
   const eventUri = `${subject}/event/${nextEventId()}`;
 
-  return [
+  const quads: Quad[] = [
     // Assertion entity (prov:Entity + DKG identity)
     mq(subject, `${RDF}type`, `${PROV}Entity`, metaGraph),
     mq(subject, `${RDF}type`, `${DKG}Assertion`, metaGraph),
@@ -641,6 +641,12 @@ export function generateAssertionCreatedMetadata(meta: AssertionCreatedMeta): Qu
     mq(eventUri, `${DKG}fromLayer`, lit('none'), metaGraph),
     mq(eventUri, `${DKG}toLayer`, lit(MemoryLayer.WorkingMemory), metaGraph),
   ];
+
+  if (meta.subGraphName) {
+    quads.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), metaGraph));
+  }
+
+  return quads;
 }
 
 export interface AssertionPromotedMeta {
@@ -680,6 +686,9 @@ export function generateAssertionPromotedMetadata(meta: AssertionPromotedMeta): 
   for (const entity of meta.rootEntities) {
     ins.push(mq(eventUri, `${DKG}rootEntity`, entity, metaGraph));
   }
+  if (meta.subGraphName) {
+    ins.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), metaGraph));
+  }
   return { insert: ins, delete: del };
 }
 
@@ -697,19 +706,23 @@ export function generateAssertionPublishedMetadata(meta: AssertionPublishedMeta)
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
   const agentUri = `did:dkg:agent:${meta.agentAddress}`;
   const eventUri = `${subject}/event/${nextEventId()}`;
+  const ins: Quad[] = [
+    mq(subject, `${DKG}state`, lit('published'), metaGraph),
+    mq(subject, `${DKG}memoryLayer`, lit(MemoryLayer.VerifiedMemory), metaGraph),
+    mq(eventUri, `${RDF}type`, `${PROV}Activity`, metaGraph),
+    mq(eventUri, `${RDF}type`, `${DKG}AssertionPublished`, metaGraph),
+    mq(eventUri, `${PROV}startedAtTime`, dateLit(meta.timestamp), metaGraph),
+    mq(eventUri, `${PROV}wasAssociatedWith`, agentUri, metaGraph),
+    mq(eventUri, `${PROV}used`, subject, metaGraph),
+    mq(eventUri, `${DKG}fromLayer`, lit(MemoryLayer.SharedWorkingMemory), metaGraph),
+    mq(eventUri, `${DKG}toLayer`, lit(MemoryLayer.VerifiedMemory), metaGraph),
+    mq(eventUri, `${DKG}kcUal`, meta.kcUal, metaGraph),
+  ];
+  if (meta.subGraphName) {
+    ins.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), metaGraph));
+  }
   return {
-    insert: [
-      mq(subject, `${DKG}state`, lit('published'), metaGraph),
-      mq(subject, `${DKG}memoryLayer`, lit(MemoryLayer.VerifiedMemory), metaGraph),
-      mq(eventUri, `${RDF}type`, `${PROV}Activity`, metaGraph),
-      mq(eventUri, `${RDF}type`, `${DKG}AssertionPublished`, metaGraph),
-      mq(eventUri, `${PROV}startedAtTime`, dateLit(meta.timestamp), metaGraph),
-      mq(eventUri, `${PROV}wasAssociatedWith`, agentUri, metaGraph),
-      mq(eventUri, `${PROV}used`, subject, metaGraph),
-      mq(eventUri, `${DKG}fromLayer`, lit(MemoryLayer.SharedWorkingMemory), metaGraph),
-      mq(eventUri, `${DKG}toLayer`, lit(MemoryLayer.VerifiedMemory), metaGraph),
-      mq(eventUri, `${DKG}kcUal`, meta.kcUal, metaGraph),
-    ],
+    insert: ins,
     delete: [
       assertionStateQuad(subject, 'promoted', metaGraph),
       assertionLayerQuad(subject, MemoryLayer.SharedWorkingMemory, metaGraph),
@@ -730,18 +743,22 @@ export function generateAssertionDiscardedMetadata(meta: AssertionDiscardedMeta)
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
   const agentUri = `did:dkg:agent:${meta.agentAddress}`;
   const eventUri = `${subject}/event/${nextEventId()}`;
+  const ins: Quad[] = [
+    mq(subject, `${DKG}state`, lit('discarded'), metaGraph),
+    mq(subject, `${PROV}wasInvalidatedBy`, eventUri, metaGraph),
+    mq(eventUri, `${RDF}type`, `${PROV}Activity`, metaGraph),
+    mq(eventUri, `${RDF}type`, `${DKG}AssertionDiscarded`, metaGraph),
+    mq(eventUri, `${PROV}startedAtTime`, dateLit(meta.timestamp), metaGraph),
+    mq(eventUri, `${PROV}wasAssociatedWith`, agentUri, metaGraph),
+    mq(eventUri, `${PROV}used`, subject, metaGraph),
+    mq(eventUri, `${DKG}fromLayer`, lit(MemoryLayer.WorkingMemory), metaGraph),
+    mq(eventUri, `${DKG}toLayer`, lit('none'), metaGraph),
+  ];
+  if (meta.subGraphName) {
+    ins.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), metaGraph));
+  }
   return {
-    insert: [
-      mq(subject, `${DKG}state`, lit('discarded'), metaGraph),
-      mq(subject, `${PROV}wasInvalidatedBy`, eventUri, metaGraph),
-      mq(eventUri, `${RDF}type`, `${PROV}Activity`, metaGraph),
-      mq(eventUri, `${RDF}type`, `${DKG}AssertionDiscarded`, metaGraph),
-      mq(eventUri, `${PROV}startedAtTime`, dateLit(meta.timestamp), metaGraph),
-      mq(eventUri, `${PROV}wasAssociatedWith`, agentUri, metaGraph),
-      mq(eventUri, `${PROV}used`, subject, metaGraph),
-      mq(eventUri, `${DKG}fromLayer`, lit(MemoryLayer.WorkingMemory), metaGraph),
-      mq(eventUri, `${DKG}toLayer`, lit('none'), metaGraph),
-    ],
+    insert: ins,
     delete: [
       assertionStateQuad(subject, 'created', metaGraph),
       assertionLayerQuad(subject, MemoryLayer.WorkingMemory, metaGraph),

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -21,6 +21,14 @@ export interface KCMetadata {
   merkleRoot: Uint8Array;
   kaCount: number;
   publisherPeerId: string;
+  /**
+   * Durable on-chain agent identifier (EVM address, bare `0x…`). When
+   * supplied, `prov:wasAttributedTo` is emitted as `<did:dkg:agent:0x…>`.
+   * When omitted, falls back to `lit(publisherPeerId)` for backwards
+   * compatibility with callers that don't yet have the agent address.
+   * See GH #748.
+   */
+  agentAddress?: string;
   accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
   allowedPeers?: string[];
   timestamp: Date;
@@ -103,7 +111,21 @@ export function generateKCMetadata(
     mq(
       meta.ual,
       `${PROV}wasAttributedTo`,
-      lit(meta.publisherPeerId || 'unknown'),
+      // KC publishes always know their author on-chain (`authorAddress`),
+      // so prefer that when `agentAddress` wasn't explicitly threaded.
+      // Falls back to the peer-ID literal only for legacy/tentative
+      // callers with neither identity available.
+      // GH #748 Codex round 7: treat `0x0000…0000` as the no-author sentinel
+      // (used when `publisherNodeIdentityIdOverride = 0`). Without this guard
+      // an unattributed publish would mint `did:dkg:agent:0x000…000`, making
+      // the provenance look like a real agent authored the KC.
+      ((): string => {
+        const candidate = meta.agentAddress ?? meta.authorAddress;
+        if (candidate && !isZeroEthAddress(candidate)) {
+          return agentDid(candidate);
+        }
+        return lit(meta.publisherPeerId || 'unknown');
+      })(),
       metaGraph,
     ),
     mq(
@@ -284,6 +306,28 @@ function dateLit(d: Date): string {
   return `"${d.toISOString()}"^^<${XSD}dateTime>`;
 }
 
+/**
+ * Returns true for the EVM zero address sentinel `0x0000…0000` (any casing).
+ * Used to detect "unattributed publish" intent (`publisherNodeIdentityIdOverride = 0`)
+ * so callers don't mint a fake `did:dkg:agent:0x000…000` URI for it.
+ */
+export function isZeroEthAddress(address: string): boolean {
+  return /^0x0{40}$/i.test(address);
+}
+
+export function agentDid(address: string): string {
+  // GH #748 Codex round 3: canonicalise EVM-address DID subjects to lowercase
+  // so the same wallet doesn't split into multiple RDF subjects when callers
+  // pass checksummed vs lowercased forms (e.g. `ethers.getAddress(...)` in
+  // workspace-handler returns checksummed, while config files often carry
+  // lowercase). Mirrors `canonicalAgentDidSubject` in
+  // `packages/agent/src/profile.ts:20` — the canonical writer for agent
+  // registry records, which has lowercased EVM subjects since A-12. Non-EVM
+  // shapes (peer IDs, names) pass through unchanged.
+  const subject = /^0x[0-9a-fA-F]{40}$/.test(address) ? address.toLowerCase() : address;
+  return `did:dkg:agent:${subject}`;
+}
+
 function hexLit(hex: string): string {
   // `xsd:hexBinary` lexical space is hex digits ONLY — no `0x` prefix
   // (per XML Schema Part 2: Datatypes, §3.2.16). A typed literal
@@ -313,7 +357,7 @@ export function generateAuthorshipProof(proof: AuthorshipProof): Quad[] {
   return [
     mq(proof.kcUal, `${DKG}authoredBy`, blankNode, metaGraph),
     mq(blankNode, `${RDF}type`, `${DKG}AuthorshipProof`, metaGraph),
-    mq(blankNode, `${DKG}agent`, `did:dkg:agent:${proof.agentAddress}`, metaGraph),
+    mq(blankNode, `${DKG}agent`, agentDid(proof.agentAddress), metaGraph),
     mq(blankNode, `${DKG}signature`, lit(proof.signature), metaGraph),
     mq(blankNode, `${DKG}signedHash`, lit(proof.signedHash), metaGraph),
   ];
@@ -338,7 +382,7 @@ export function generateShareTransitionMetadata(meta: ShareTransitionMetadata): 
   const quads: Quad[] = [
     mq(subject, `${RDF}type`, `${DKG}ShareTransition`, metaGraph),
     mq(subject, `${DKG}source`, lit(`assertion/${meta.agentAddress}/${meta.assertionName}`), metaGraph),
-    mq(subject, `${DKG}agent`, `did:dkg:agent:${meta.agentAddress}`, metaGraph),
+    mq(subject, `${DKG}agent`, agentDid(meta.agentAddress), metaGraph),
     mq(subject, `${DKG}timestamp`, dateLit(meta.timestamp), metaGraph),
   ];
   for (const entity of meta.entities) {
@@ -353,6 +397,14 @@ export interface ShareMetadata {
   contextGraphId: string;
   rootEntities: string[];
   publisherPeerId: string;
+  /**
+   * Durable on-chain agent identifier (EVM address, bare `0x…`). When
+   * supplied, `prov:wasAttributedTo` is emitted as `<did:dkg:agent:0x…>`.
+   * When omitted, falls back to `lit(publisherPeerId)` so legacy callers
+   * (notably the gossip-received `SharedMemoryHandler` path) continue to
+   * work until the peer-ID → agent-address lookup is wired in. See GH #748.
+   */
+  agentAddress?: string;
   timestamp: Date;
   subGraphName?: string;
 }
@@ -379,7 +431,7 @@ export function generateShareMetadata(
     mq(
       subject,
       `${PROV}wasAttributedTo`,
-      lit(meta.publisherPeerId),
+      meta.agentAddress ? agentDid(meta.agentAddress) : lit(meta.publisherPeerId),
       swmMetaGraph,
     ),
     mq(
@@ -519,7 +571,7 @@ export function generateSubGraphRegistration(reg: SubGraphRegistration): Quad[] 
     mq(subGraphUri, `${RDF}type`, `${DKG}SubGraph`, metaGraph),
     mq(subGraphUri, `${DKG}parentContextGraph`, parentUri, metaGraph),
     mq(subGraphUri, `${SCHEMA}name`, lit(reg.subGraphName), metaGraph),
-    mq(subGraphUri, `${DKG}createdBy`, `did:dkg:agent:${reg.createdBy}`, metaGraph),
+    mq(subGraphUri, `${DKG}createdBy`, agentDid(reg.createdBy), metaGraph),
     mq(subGraphUri, `${DKG}createdAt`, dateLit(reg.timestamp), metaGraph),
   ];
 
@@ -529,7 +581,7 @@ export function generateSubGraphRegistration(reg: SubGraphRegistration): Quad[] 
 
   if (reg.authorizedWriters && reg.authorizedWriters.length > 0) {
     for (const writer of reg.authorizedWriters) {
-      const writerUri = `did:dkg:agent:${writer}`;
+      const writerUri = agentDid(writer);
       if (!isSafeIri(writerUri)) continue;
       quads.push(mq(subGraphUri, `${DKG}authorizedWriter`, writerUri, metaGraph));
     }
@@ -618,7 +670,7 @@ export function generateAssertionCreatedMetadata(meta: AssertionCreatedMeta): Qu
   const metaGraph = `did:dkg:context-graph:${meta.contextGraphId}/_meta`;
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
   const graphUri = contextGraphAssertionUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
-  const agentUri = `did:dkg:agent:${meta.agentAddress}`;
+  const agentUri = agentDid(meta.agentAddress);
   const eventUri = `${subject}/event/${nextEventId()}`;
 
   const quads: Quad[] = [
@@ -662,7 +714,7 @@ export interface AssertionPromotedMeta {
 export function generateAssertionPromotedMetadata(meta: AssertionPromotedMeta): { insert: Quad[]; delete: Quad[] } {
   const metaGraph = `did:dkg:context-graph:${meta.contextGraphId}/_meta`;
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
-  const agentUri = `did:dkg:agent:${meta.agentAddress}`;
+  const agentUri = agentDid(meta.agentAddress);
   const eventUri = `${subject}/event/${nextEventId()}`;
 
   const del = [
@@ -704,7 +756,7 @@ export interface AssertionPublishedMeta {
 export function generateAssertionPublishedMetadata(meta: AssertionPublishedMeta): { insert: Quad[]; delete: Quad[] } {
   const metaGraph = `did:dkg:context-graph:${meta.contextGraphId}/_meta`;
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
-  const agentUri = `did:dkg:agent:${meta.agentAddress}`;
+  const agentUri = agentDid(meta.agentAddress);
   const eventUri = `${subject}/event/${nextEventId()}`;
   const ins: Quad[] = [
     mq(subject, `${DKG}state`, lit('published'), metaGraph),
@@ -741,7 +793,7 @@ export interface AssertionDiscardedMeta {
 export function generateAssertionDiscardedMetadata(meta: AssertionDiscardedMeta): { insert: Quad[]; delete: Quad[] } {
   const metaGraph = `did:dkg:context-graph:${meta.contextGraphId}/_meta`;
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
-  const agentUri = `did:dkg:agent:${meta.agentAddress}`;
+  const agentUri = agentDid(meta.agentAddress);
   const eventUri = `${subject}/event/${nextEventId()}`;
   const ins: Quad[] = [
     mq(subject, `${DKG}state`, lit('discarded'), metaGraph),

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1056,6 +1056,20 @@ export class SharedMemoryHandler {
         if (metaQuads.length > 0) {
           await this.store.insert(metaQuads);
         }
+        // The gossip envelope carries the verified author address
+        // (`verifyAgentEnvelope` above already cryptographically bound
+        // it to `recovered`); use it for SWM `prov:wasAttributedTo` so
+        // attribution survives peer-key rotation. Falls back to peer-ID
+        // literal in the writer if envelope agentAddress is missing or
+        // unparseable. See GH #748.
+        let senderAgentAddress: string | undefined;
+        if (envelope?.agentAddress && envelope.agentAddress.length > 0) {
+          try {
+            senderAgentAddress = ethers.getAddress(envelope.agentAddress);
+          } catch {
+            senderAgentAddress = undefined;
+          }
+        }
         await storeWorkspaceOperationPublicQuads({
           store: this.store,
           graphManager: this.graphManager,
@@ -1064,6 +1078,7 @@ export class SharedMemoryHandler {
           rootEntities,
           quads: normalized,
           publisherPeerId,
+          agentAddress: senderAgentAddress,
           subGraphName,
           timestamp: operationTimestamp,
           publicSnapshotStore: this.publicSnapshotStore,

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -3,7 +3,7 @@ import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-sto
 import { assertSafeIri, isSafeIri, validateSubGraphName } from '@origintrail-official/dkg-core';
 import type { LiftRequest } from './lift-job.js';
 import type { LiftResolvedPublishSlice } from './async-lift-publish-options.js';
-import { generateShareMetadata } from './metadata.js';
+import { agentDid, generateShareMetadata } from './metadata.js';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 
 const DKG = 'http://dkg.io/ontology/';
@@ -64,6 +64,16 @@ export async function storeWorkspaceOperationPublicQuads(params: {
   // Retained for API compatibility; new metadata stores roots, not serialized payloads.
   quads: readonly Quad[];
   publisherPeerId?: string;
+  /**
+   * Durable on-chain agent identifier (EVM address, bare `0x…`). When
+   * supplied, both the share-operation `prov:wasAttributedTo` (via
+   * `generateShareMetadata`) and the per-root attribution emit
+   * `<did:dkg:agent:0x…>` URIs. When omitted, attribution falls back to
+   * `lit(publisherPeerId)` — preserves behaviour for the gossip-received
+   * `SharedMemoryHandler` path until peer-ID → agent-address resolution
+   * is wired in there. See GH #748.
+   */
+  agentAddress?: string;
   subGraphName?: string;
   timestamp?: Date;
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
@@ -75,6 +85,7 @@ export async function storeWorkspaceOperationPublicQuads(params: {
   const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, subGraphName);
   const operationSubject = workspaceOperationSubject(params.contextGraphId, params.shareOperationId);
   const publisherPeerId = params.publisherPeerId?.trim() || 'unknown';
+  const agentAddress = params.agentAddress?.trim() || undefined;
   const timestamp = params.timestamp ?? new Date();
 
   for (const root of roots) {
@@ -94,6 +105,7 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       contextGraphId: params.contextGraphId,
       rootEntities: roots,
       publisherPeerId,
+      agentAddress,
       timestamp,
       subGraphName,
     },
@@ -133,7 +145,11 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       { subject, predicate: `${DKG}publicSliceRootEntity`, object: root, graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicQuadsDigest`, object: lit(digest), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publicQuadsCount`, object: intLit(rootQuads.length), graph: workspaceMetaGraph },
-      { subject, predicate: `${PROV}wasAttributedTo`, object: lit(publisherPeerId), graph: workspaceMetaGraph },
+      // GH #748: dedicated `dkg:publisherPeerId` field for peer-ID-bound reads
+      // (resolveCompactWorkspaceOperationPublicQuads / Legacy variant + finalization);
+      // `prov:wasAttributedTo` carries the durable agent DID URI when known.
+      { subject, predicate: `${DKG}publisherPeerId`, object: lit(publisherPeerId), graph: workspaceMetaGraph },
+      { subject, predicate: `${PROV}wasAttributedTo`, object: agentAddress ? agentDid(agentAddress) : lit(publisherPeerId), graph: workspaceMetaGraph },
       { subject, predicate: `${DKG}publishedAt`, object: dateLit(timestamp), graph: workspaceMetaGraph },
     );
     if (snapshotRef) {
@@ -166,10 +182,18 @@ export async function resolveWorkspaceOperation(params: {
   const workspaceMetaGraph = params.graphManager.sharedMemoryMetaUri(params.contextGraphId, subGraphName);
   const subject = workspaceOperationSubject(params.contextGraphId, params.shareOperationId);
   const result = await params.store.query(
+    // GH #748: prefer the dedicated `dkg:publisherPeerId` literal; fall back
+    // to a literal-form `prov:wasAttributedTo` for legacy/un-migrated rows
+    // that only have the deprecated peer-ID-in-attribution shape. The
+    // `FILTER(isLiteral(...))` guard skips post-fix rows where
+    // `wasAttributedTo` carries an agent DID URI (which downstream contact
+    // code would mis-interpret as a libp2p peer ID).
     `SELECT ?root ?publisherPeerId WHERE {
       GRAPH <${workspaceMetaGraph}> {
         OPTIONAL { <${subject}> <${DKG}rootEntity> ?root }
-        OPTIONAL { <${subject}> <${PROV}wasAttributedTo> ?publisherPeerId }
+        OPTIONAL { <${subject}> <${DKG}publisherPeerId> ?pidField }
+        OPTIONAL { <${subject}> <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
+        BIND(COALESCE(?pidField, ?attrField) AS ?publisherPeerId)
       }
     }`,
   );
@@ -353,7 +377,12 @@ async function resolveCompactWorkspaceOperationPublicQuads(params: {
             <${DKG}publicQuadsCount> ?count .
           OPTIONAL { <${assertSafeIri(subject)}> <${DKG}publicSnapshotRef> ?snapshotRef }
           OPTIONAL { <${assertSafeIri(subject)}> <${DKG}publicSnapshotGraph> ?snapshotGraph }
-          OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?publisherPeerId }
+          # GH #748: prefer dedicated peer-ID field; fall back to a literal
+          # wasAttributedTo for legacy/un-migrated snapshots. Skip URI form
+          # (agent DID) — that's not a peer ID.
+          OPTIONAL { <${assertSafeIri(subject)}> <${DKG}publisherPeerId> ?pidField }
+          OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
+          BIND(COALESCE(?pidField, ?attrField) AS ?publisherPeerId)
         }
       } LIMIT 1`,
     );
@@ -431,7 +460,11 @@ async function resolveLegacyWorkspaceOperationPublicQuads(params: {
       `SELECT ?payload ?publisherPeerId WHERE {
         GRAPH <${assertSafeIri(workspaceMetaGraph)}> {
           <${assertSafeIri(subject)}> <${DKG}publicStagedQuads> ?payload .
-          OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?publisherPeerId }
+          # GH #748: prefer dedicated peer-ID field; fall back to literal
+          # wasAttributedTo for legacy snapshots. Skip URI form (agent DID).
+          OPTIONAL { <${assertSafeIri(subject)}> <${DKG}publisherPeerId> ?pidField }
+          OPTIONAL { <${assertSafeIri(subject)}> <${PROV}wasAttributedTo> ?attrField . FILTER(isLiteral(?attrField)) }
+          BIND(COALESCE(?pidField, ?attrField) AS ?publisherPeerId)
         }
       } LIMIT 1`,
     );

--- a/packages/publisher/test/access-protocol.test.ts
+++ b/packages/publisher/test/access-protocol.test.ts
@@ -310,8 +310,16 @@ describe('Access Protocol', () => {
     await storeA.delete([
       { subject: kcUal, predicate: 'http://dkg.io/ontology/accessPolicy', object: '"ownerOnly"', graph: metaGraph },
       { subject: kcUal, predicate: 'http://dkg.io/ontology/publisherPeerId', object: `"${nodeA.peerId}"`, graph: metaGraph },
-      { subject: kcUal, predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: `"${nodeA.peerId}"`, graph: metaGraph },
     ]);
+    // GH #748: `wasAttributedTo` may be either a peer-ID literal (legacy)
+    // or a `did:dkg:agent:0x…` URI (post-fix when authorAddress is known).
+    // Drop the quad by pattern to cover both shapes for this "owner identity
+    // missing" simulation.
+    await storeA.deleteByPattern({
+      graph: metaGraph,
+      subject: kcUal,
+      predicate: 'http://www.w3.org/ns/prov#wasAttributedTo',
+    });
 
     const accessHandler = new AccessHandler(storeA, bus);
     const routerA = new ProtocolRouter(nodeA);
@@ -349,8 +357,15 @@ describe('Access Protocol', () => {
     const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
     await storeA.delete([
       { subject: kcUal, predicate: 'http://dkg.io/ontology/publisherPeerId', object: `"${nodeA.peerId}"`, graph: metaGraph },
-      { subject: kcUal, predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: `"${nodeA.peerId}"`, graph: metaGraph },
     ]);
+    // GH #748: `wasAttributedTo` may be either a peer-ID literal or an
+    // agent DID URI; drop by pattern to simulate the "owner identity missing"
+    // case regardless of which shape is stored.
+    await storeA.deleteByPattern({
+      graph: metaGraph,
+      subject: kcUal,
+      predicate: 'http://www.w3.org/ns/prov#wasAttributedTo',
+    });
 
     const kaUal = `${result.ual}/1`;
     const accessResult = await accessClient.requestAccess(nodeA.peerId, kaUal);

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -15,9 +15,11 @@ import { createEVMAdapter, getSharedContext, HARDHAT_KEYS } from '../../chain/te
 
 const CG_ID = 'test-assertion-cg';
 const SWM_GRAPH = `did:dkg:context-graph:${CG_ID}/_shared_memory`;
+const SWM_META_GRAPH = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
 const AGENT = '0x1234567890abcdef1234567890abcdef12345678';
 const AGENT_B = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
 const PEER = '12D3KooWPromoteBoundary';
+const PEER_B = '12D3KooWPromoteBoundaryB';
 const ASSERTION_NAME = 'my-assertion';
 
 const TRIPLES = [
@@ -111,6 +113,185 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(swmResult.type).toBe('bindings');
     if (swmResult.type === 'bindings') {
       expect(swmResult.bindings.length).toBe(3);
+    }
+  });
+
+  it('durable SWM ownership blocks cross-author promote after publisher restart with empty map', async () => {
+    const root = 'urn:test:entity:restart-owned';
+    const firstAssertion = 'restart-owner-a';
+    const secondAssertion = 'restart-owner-b';
+
+    await publisher.assertionCreate(CG_ID, firstAssertion, AGENT);
+    await publisher.assertionWrite(CG_ID, firstAssertion, AGENT, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Original"' },
+    ]);
+    await publisher.assertionPromote(CG_ID, firstAssertion, AGENT, { publisherPeerId: PEER });
+
+    const ownerBefore = await store.query(
+      `SELECT ?creator WHERE { GRAPH <${SWM_META_GRAPH}> { <${root}> <http://dkg.io/ontology/workspaceOwner> ?creator } }`,
+    );
+    expect(ownerBefore.type).toBe('bindings');
+    if (ownerBefore.type === 'bindings') {
+      expect(ownerBefore.bindings.map((row) => row['creator'])).toEqual([`"${PEER}"`]);
+    }
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const restartedPublisher = new DKGPublisher({
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: new Map(),
+    });
+
+    await restartedPublisher.assertionCreate(CG_ID, secondAssertion, AGENT_B);
+    await restartedPublisher.assertionWrite(CG_ID, secondAssertion, AGENT_B, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Overwritten"' },
+    ]);
+
+    await expect(
+      restartedPublisher.assertionPromote(CG_ID, secondAssertion, AGENT_B, { publisherPeerId: PEER_B }),
+    ).rejects.toThrow(
+      `Cannot promote entity <${root}>: owned by peer ${PEER}, not by caller ${PEER_B}.`,
+    );
+
+    const remaining = await restartedPublisher.assertionQuery(CG_ID, secondAssertion, AGENT_B);
+    expect(remaining).toHaveLength(1);
+
+    const swmAfter = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${root}> <http://schema.org/name> ?o } }`,
+    );
+    expect(swmAfter.type).toBe('bindings');
+    if (swmAfter.type === 'bindings') {
+      expect(swmAfter.bindings.map((row) => row['o'])).toEqual(['"Original"']);
+    }
+
+    const ownerAfter = await store.query(
+      `SELECT ?creator WHERE { GRAPH <${SWM_META_GRAPH}> { <${root}> <http://dkg.io/ontology/workspaceOwner> ?creator } }`,
+    );
+    expect(ownerAfter.type).toBe('bindings');
+    if (ownerAfter.type === 'bindings') {
+      expect(ownerAfter.bindings.map((row) => row['creator'])).toEqual([`"${PEER}"`]);
+    }
+  });
+
+  it('durable SWM ownership allows owner promote after publisher restart with empty map', async () => {
+    const root = 'urn:test:entity:restart-owned-upsert';
+    const firstAssertion = 'restart-owner-upsert-a';
+    const secondAssertion = 'restart-owner-upsert-b';
+
+    await publisher.assertionCreate(CG_ID, firstAssertion, AGENT);
+    await publisher.assertionWrite(CG_ID, firstAssertion, AGENT, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Original"' },
+    ]);
+    await publisher.assertionPromote(CG_ID, firstAssertion, AGENT, { publisherPeerId: PEER });
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const restartedPublisher = new DKGPublisher({
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: new Map(),
+    });
+
+    await restartedPublisher.assertionCreate(CG_ID, secondAssertion, AGENT_B);
+    await restartedPublisher.assertionWrite(CG_ID, secondAssertion, AGENT_B, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Updated"' },
+    ]);
+
+    const result = await restartedPublisher.assertionPromote(CG_ID, secondAssertion, AGENT_B, {
+      publisherPeerId: PEER,
+    });
+    expect(result.promotedCount).toBe(1);
+
+    const remaining = await restartedPublisher.assertionQuery(CG_ID, secondAssertion, AGENT_B);
+    expect(remaining).toHaveLength(0);
+
+    const swmAfter = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${root}> <http://schema.org/name> ?o } }`,
+    );
+    expect(swmAfter.type).toBe('bindings');
+    if (swmAfter.type === 'bindings') {
+      expect(swmAfter.bindings.map((row) => row['o'])).toEqual(['"Updated"']);
+    }
+
+    const ownerAfter = await store.query(
+      `SELECT ?creator WHERE { GRAPH <${SWM_META_GRAPH}> { <${root}> <http://dkg.io/ontology/workspaceOwner> ?creator } }`,
+    );
+    expect(ownerAfter.type).toBe('bindings');
+    if (ownerAfter.type === 'bindings') {
+      expect(ownerAfter.bindings.map((row) => row['creator'])).toEqual([`"${PEER}"`]);
+    }
+  });
+
+  it('durable SWM ownership collapses conflicts before owner promote after restart', async () => {
+    const root = 'urn:test:entity:restart-owned-conflict';
+    const firstAssertion = 'restart-owner-conflict-a';
+    const secondAssertion = 'restart-owner-conflict-b';
+    const conflictOperation = 'urn:dkg:share:test-assertion-cg:restart-owner-conflict';
+
+    await publisher.assertionCreate(CG_ID, firstAssertion, AGENT);
+    await publisher.assertionWrite(CG_ID, firstAssertion, AGENT, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Original"' },
+    ]);
+    await publisher.assertionPromote(CG_ID, firstAssertion, AGENT, { publisherPeerId: PEER });
+
+    await store.insert([
+      {
+        subject: root,
+        predicate: 'http://dkg.io/ontology/workspaceOwner',
+        object: `"${PEER_B}"`,
+        graph: SWM_META_GRAPH,
+      },
+      {
+        subject: conflictOperation,
+        predicate: 'http://dkg.io/ontology/rootEntity',
+        object: root,
+        graph: SWM_META_GRAPH,
+      },
+      {
+        subject: conflictOperation,
+        predicate: 'http://www.w3.org/ns/prov#wasAttributedTo',
+        object: `"${PEER_B}"`,
+        graph: SWM_META_GRAPH,
+      },
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const restartedPublisher = new DKGPublisher({
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: new Map(),
+    });
+
+    await restartedPublisher.assertionCreate(CG_ID, secondAssertion, AGENT_B);
+    await restartedPublisher.assertionWrite(CG_ID, secondAssertion, AGENT_B, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"Effective owner update"' },
+    ]);
+
+    const result = await restartedPublisher.assertionPromote(CG_ID, secondAssertion, AGENT_B, {
+      publisherPeerId: PEER,
+    });
+    expect(result.promotedCount).toBe(1);
+
+    const swmAfter = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <${root}> <http://schema.org/name> ?o } }`,
+    );
+    expect(swmAfter.type).toBe('bindings');
+    if (swmAfter.type === 'bindings') {
+      expect(swmAfter.bindings.map((row) => row['o'])).toEqual(['"Effective owner update"']);
     }
   });
 

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -413,6 +413,389 @@ describe('Working Memory Assertion Lifecycle', () => {
     }
   });
 
+  it('GH #748 migration: rewrites peer-ID literal wasAttributedTo → agent DID URI when AGENTS lookup hits, leaves miss as-is, backfills dkg:publisherPeerId on legacy per-root snapshots, skips marked CGs on re-run', async () => {
+    // Canonical AGENTS graph URI — `did:dkg:context-graph:agents` (no /_data
+    // suffix) per `contextGraphDataGraphUri('agents')` in @origintrail-official/dkg-core.
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const CG_META = `did:dkg:context-graph:${CG_ID}/_meta`;
+    const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    // GH #748 Codex round 3: AGENTS registry uses the spec-aligned
+    // `https://dkg.network/ontology#` namespace (same as `buildAgentProfile`
+    // in agent/profile.ts), not the internal `http://dkg.io/ontology/` one
+    // used by SWM meta predicates.
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
+    const PROV = 'http://www.w3.org/ns/prov#';
+
+    // Seed AGENTS registry: one peer with a known agent address, one without.
+    const PEER_KNOWN = '12D3KooWKnownPeer';
+    const PEER_UNKNOWN = '12D3KooWUnknownPeer';
+    // Lowercased per `canonicalAgentDidSubject` — matches what
+    // `buildAgentProfile` writes when registering an agent.
+    const ADDR_KNOWN = '0xaf7e932f79263f1a303790bd6c01b096f5334bbb';
+
+    await store.insert([
+      { subject: `did:dkg:agent:${ADDR_KNOWN}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_KNOWN}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER_KNOWN}"`, graph: AGENTS_GRAPH },
+    ]);
+
+    // Seed SWM meta with three legacy rows that mirror real shapes:
+    //   - WorkspaceOperation (resolvable peer) — already has both
+    //     `dkg:publisherPeerId` and `prov:wasAttributedTo` (the new field
+    //     should NOT be re-inserted by the backfill).
+    //   - WorkspaceOperation (unresolved peer) — same two fields.
+    //   - Per-root snapshot (resolvable peer) — only `prov:wasAttributedTo`
+    //     literal, NO `dkg:publisherPeerId`. The migration must materialise
+    //     the peer-ID field from the literal before rewriting.
+    const OP_KNOWN = `urn:dkg:share:${CG_ID}:op-known`;
+    const OP_UNKNOWN = `urn:dkg:share:${CG_ID}:op-unknown`;
+    const SNAPSHOT_LEGACY = `urn:dkg:share:${CG_ID}:op-known:snapshot/urn:test:root`;
+    await store.insert([
+      { subject: OP_KNOWN, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
+      { subject: OP_KNOWN, predicate: `${DKG}publisherPeerId`, object: `"${PEER_KNOWN}"`, graph: SWM_META },
+      { subject: OP_KNOWN, predicate: `${PROV}wasAttributedTo`, object: `"${PEER_KNOWN}"`, graph: SWM_META },
+      { subject: OP_UNKNOWN, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
+      { subject: OP_UNKNOWN, predicate: `${DKG}publisherPeerId`, object: `"${PEER_UNKNOWN}"`, graph: SWM_META },
+      { subject: OP_UNKNOWN, predicate: `${PROV}wasAttributedTo`, object: `"${PEER_UNKNOWN}"`, graph: SWM_META },
+      // Legacy per-root snapshot row — wasAttributedTo only, no dkg:publisherPeerId
+      { subject: SNAPSHOT_LEGACY, predicate: `${PROV}wasAttributedTo`, object: `"${PEER_KNOWN}"`, graph: SWM_META },
+    ]);
+    // Ensure the CG itself appears in `listContextGraphs` so the migration
+    // visits its meta graph (the bare `_meta` graph plus any data is enough).
+    await store.insert([
+      { subject: `did:dkg:context-graph:${CG_ID}`, predicate: RDF_TYPE, object: `${DKG}ContextGraph`, graph: CG_META },
+    ]);
+
+    // First pass: rewrite resolvable rows (OP_KNOWN + SNAPSHOT_LEGACY = 2),
+    // leave the unresolved one, drop a marker.
+    const r1 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r1.rewritten).toBe(2);
+    expect(r1.skipped).toBe(1);
+
+    const rowsAfter = await store.query(
+      `SELECT ?s ?o WHERE { GRAPH <${SWM_META}> { ?s <${PROV}wasAttributedTo> ?o } }`,
+    );
+    expect(rowsAfter.type).toBe('bindings');
+    if (rowsAfter.type === 'bindings') {
+      const known = rowsAfter.bindings.find((b) => b['s'] === OP_KNOWN);
+      const unknown = rowsAfter.bindings.find((b) => b['s'] === OP_UNKNOWN);
+      const snapshot = rowsAfter.bindings.find((b) => b['s'] === SNAPSHOT_LEGACY);
+      // Resolvable rows → URI form (no surrounding quotes).
+      expect(known!['o']).toBe(`did:dkg:agent:${ADDR_KNOWN}`);
+      expect(snapshot!['o']).toBe(`did:dkg:agent:${ADDR_KNOWN}`);
+      // Unresolved peer → still a literal.
+      expect(unknown!['o']).toBe(`"${PEER_UNKNOWN}"`);
+    }
+
+    // Backward-compat backfill: SNAPSHOT_LEGACY had no `dkg:publisherPeerId`
+    // before the migration. After migration, it MUST carry the peer-ID
+    // literal materialised from the old `wasAttributedTo` value, so the
+    // post-fix readers (which now query `dkg:publisherPeerId`) still find it.
+    const peerIdAfter = await store.query(
+      `SELECT ?s ?o WHERE { GRAPH <${SWM_META}> { ?s <${DKG}publisherPeerId> ?o } }`,
+    );
+    expect(peerIdAfter.type).toBe('bindings');
+    if (peerIdAfter.type === 'bindings') {
+      const snapshotPid = peerIdAfter.bindings.find((b) => b['s'] === SNAPSHOT_LEGACY);
+      expect(snapshotPid).toBeDefined();
+      expect(snapshotPid!['o']).toBe(`"${PEER_KNOWN}"`);
+      // OP_KNOWN already had a dkg:publisherPeerId — the migration must NOT
+      // have duplicated it.
+      const opKnownPids = peerIdAfter.bindings.filter((b) => b['s'] === OP_KNOWN);
+      expect(opKnownPids.length).toBe(1);
+    }
+
+    // Codex round 2 Finding 6: marker is NOT written when cgSkipped > 0 (one
+    // unresolved row remained). Future boots must retry as AGENTS data syncs.
+    const markerAfter = await store.query(
+      `SELECT ?ts WHERE { GRAPH <${CG_META}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
+    );
+    expect(markerAfter.type).toBe('bindings');
+    if (markerAfter.type === 'bindings') expect(markerAfter.bindings.length).toBe(0);
+
+    // Second pass with no AGENTS changes: nothing new to resolve, marker
+    // still not written, no churn — the literal-only filter eliminates the
+    // already-rewritten URI rows so we only retry the genuine unresolved one.
+    const r2 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r2.rewritten).toBe(0);
+    expect(r2.skipped).toBe(1);
+
+    // Add the previously-missing AGENTS record for the unresolved peer.
+    const ADDR_LATE = '0xba7e932f79263f1a303790bd6c01b096f5334bba';
+    await store.insert([
+      { subject: `did:dkg:agent:${ADDR_LATE}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_LATE}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER_UNKNOWN}"`, graph: AGENTS_GRAPH },
+    ]);
+    // Third pass: the previously-unresolved row now resolves, and since
+    // cgSkipped reaches 0 the marker finally gets written.
+    const r3 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r3.rewritten).toBe(1);
+    expect(r3.skipped).toBe(0);
+    const markerFinal = await store.query(
+      `SELECT ?ts WHERE { GRAPH <${CG_META}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
+    );
+    if (markerFinal.type === 'bindings') expect(markerFinal.bindings.length).toBe(1);
+
+    // Fourth pass: marker present → fast-path skip; no SPARQL work.
+    const r4 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r4.rewritten).toBe(0);
+    expect(r4.skipped).toBe(0);
+  });
+
+  it('GH #748 user-reported: stale literal duplicates from a broken previous pass are cleaned up despite marker present', async () => {
+    // Regression: round-1 → round-6 `store.delete([{ object: literalString }])`
+    // silently no-op'd against `xsd:string`-typed literals on a persistent
+    // store. The URI insert succeeded, leaving BOTH forms behind. The
+    // user's daemon ended up with 52 literals + 52 URIs after a single
+    // migration pass, with the marker set so subsequent boots wouldn't
+    // self-heal.
+    //
+    // This test seeds that exact end state — marker present + both literal
+    // AND URI form `wasAttributedTo` on the same subject — and asserts the
+    // next migration pass overrides the marker, deletes the literal via
+    // `deleteByPattern`, and writes a fresh marker.
+    const CG_META_LOCAL = `did:dkg:context-graph:${CG_ID}/_meta`;
+    const SWM_META_LOCAL = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const PEER = '12D3KooWStaleLiteralPeer';
+    const ADDR = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+    await store.insert([
+      { subject: `did:dkg:agent:${ADDR}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}agentAddress`, object: `"${ADDR}"`, graph: AGENTS_GRAPH },
+    ]);
+
+    // Seed inconsistent state: WorkspaceOperation with BOTH literal and URI
+    // form `wasAttributedTo`, marker present from the broken previous pass.
+    const OP = `urn:dkg:share:${CG_ID}:op-stale-dup`;
+    await store.insert([
+      { subject: OP, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META_LOCAL },
+      { subject: OP, predicate: `${DKG}publisherPeerId`, object: `"${PEER}"`, graph: SWM_META_LOCAL },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: `"${PEER}"`, graph: SWM_META_LOCAL },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: `did:dkg:agent:${ADDR}`, graph: SWM_META_LOCAL },
+      { subject: 'urn:dkg:migration:swm-attr-agent-did', predicate: `${DKG}appliedAt`, object: `"2026-05-26T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>`, graph: CG_META_LOCAL },
+    ]);
+
+    const r = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r.rewritten).toBeGreaterThanOrEqual(1);
+
+    // After cleanup, exactly ONE wasAttributedTo (the URI form) remains.
+    const after = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_META_LOCAL}> { <${OP}> <${PROV}wasAttributedTo> ?o } }`,
+    );
+    if (after.type === 'bindings') {
+      expect(after.bindings.length).toBe(1);
+      expect(after.bindings[0]['o']).toBe(`did:dkg:agent:${ADDR}`);
+    }
+
+    // Marker still present, refreshed with a new timestamp (we deleted the
+    // stale one before re-running). Just assert presence.
+    const marker = await store.query(
+      `SELECT ?ts WHERE { GRAPH <${CG_META_LOCAL}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
+    );
+    if (marker.type === 'bindings') expect(marker.bindings.length).toBe(1);
+  });
+
+  it('GH #748 Codex round 6: curated CG (<addr>/<slug> form) is migrated, not silently skipped', async () => {
+    // Regression for a user-reported bug: the previous version iterated
+    // `graphManager.listContextGraphs()`, which filters out IDs containing
+    // a slash — silently skipping every curated `<addr>/<slug>` CG (the
+    // ones a user is NOT the curator of). The migration now enumerates
+    // `_shared_memory_meta` graphs directly so both bare-slug and curated
+    // CGs are processed.
+    const CURATOR = '0xE5B88968Ed464F4e3f5354C54DFAB9e39dfEAfBd';
+    const CURATED_CG = `${CURATOR}/tuesday-cg-curated`;
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const CURATED_META = `did:dkg:context-graph:${CURATED_CG}/_meta`;
+    const CURATED_SWM_META = `did:dkg:context-graph:${CURATED_CG}/_shared_memory_meta`;
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const PEER = '12D3KooWCuratedAgent';
+    const ADDR = '0xc7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7c7';
+
+    await store.insert([
+      { subject: `did:dkg:agent:${ADDR}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}agentAddress`, object: `"${ADDR}"`, graph: AGENTS_GRAPH },
+    ]);
+
+    // Seed a SWM op in the curated CG with the legacy literal shape.
+    const OP = `urn:dkg:share:${CURATED_CG}:op-curated`;
+    await store.insert([
+      { subject: OP, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: CURATED_SWM_META },
+      { subject: OP, predicate: `${DKG}publisherPeerId`, object: `"${PEER}"`, graph: CURATED_SWM_META },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: `"${PEER}"`, graph: CURATED_SWM_META },
+      // No CG existence triple — the migration must find the SWM-meta
+      // graph by direct enumeration, not via `listContextGraphs()`.
+    ]);
+
+    const r = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r.rewritten).toBeGreaterThanOrEqual(1);
+
+    // Curated CG's SWM-meta row was rewritten to URI form.
+    const after = await store.query(
+      `SELECT ?o WHERE { GRAPH <${CURATED_SWM_META}> { <${OP}> <${PROV}wasAttributedTo> ?o } }`,
+    );
+    if (after.type === 'bindings') {
+      expect(after.bindings.length).toBe(1);
+      expect(after.bindings[0]['o']).toBe(`did:dkg:agent:${ADDR}`);
+    }
+
+    // Marker landed in the adjacent CG `_meta` for the curated form (note
+    // the `<addr>/<slug>` segment is preserved verbatim in the marker path).
+    const marker = await store.query(
+      `SELECT ?ts WHERE { GRAPH <${CURATED_META}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
+    );
+    if (marker.type === 'bindings') expect(marker.bindings.length).toBe(1);
+  });
+
+  it('GH #748 Codex round 4: permanent "unknown" sentinel does not block the marker', async () => {
+    // Legacy `generateKCMetadata` wrote `prov:wasAttributedTo "unknown"`
+    // when no peer ID was supplied. That value can never resolve to an
+    // agent address — it's permanent, not retriable. The migration must
+    // still write the per-CG marker so subsequent boots fast-path skip
+    // instead of re-scanning every time.
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const CG_META = `did:dkg:context-graph:${CG_ID}/_meta`;
+    const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const PROV = 'http://www.w3.org/ns/prov#';
+
+    const OP = `urn:dkg:share:${CG_ID}:op-unknown-sentinel`;
+    await store.insert([
+      { subject: OP, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: '"unknown"', graph: SWM_META },
+      { subject: `did:dkg:context-graph:${CG_ID}`, predicate: RDF_TYPE, object: `${DKG}ContextGraph`, graph: CG_META },
+    ]);
+
+    const r1 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r1.rewritten).toBe(0);
+    expect(r1.skipped).toBe(1); // counted as permanent skip
+
+    // Marker IS written even though one row was skipped (permanent).
+    const marker = await store.query(
+      `SELECT ?ts WHERE { GRAPH <${CG_META}> { <urn:dkg:migration:swm-attr-agent-did> <${DKG}appliedAt> ?ts } }`,
+    );
+    if (marker.type === 'bindings') expect(marker.bindings.length).toBe(1);
+
+    // The "unknown" literal is left in place — there's no real attribution
+    // to migrate to.
+    const after = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_META}> { <${OP}> <${PROV}wasAttributedTo> ?o } }`,
+    );
+    if (after.type === 'bindings') {
+      expect(after.bindings.length).toBe(1);
+      expect(after.bindings[0]['o']).toBe('"unknown"');
+    }
+
+    // Second pass: marker present → fast-path skip, no work.
+    const r2 = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r2.rewritten).toBe(0);
+    expect(r2.skipped).toBe(0);
+  });
+
+  it('GH #748 Codex round 5: legacy + canonical AGENTS records for the same agent resolve unambiguously', async () => {
+    // Upgraded stores can carry two profile records for the same wallet:
+    // - the legacy `did:dkg:agent:<peerId>` subject (profile.ts fallback)
+    // - the canonical `did:dkg:agent:<address>` subject
+    // The resolver must dedupe by normalised address (preferring the
+    // explicit `dkg:agentAddress` literal) and treat them as one agent
+    // rather than rejecting as ambiguous.
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const CG_META = `did:dkg:context-graph:${CG_ID}/_meta`;
+    const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const PEER = '12D3KooWUpgradedNode';
+    const ADDR = '0xaf7e932f79263f1a303790bd6c01b096f5334bbb';
+
+    await store.insert([
+      // Legacy profile: subject is the peer ID, no explicit agentAddress.
+      { subject: `did:dkg:agent:${PEER}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${PEER}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER}"`, graph: AGENTS_GRAPH },
+      // Canonical profile: subject is the wallet DID, explicit agentAddress literal.
+      { subject: `did:dkg:agent:${ADDR}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR}`, predicate: `${DKG_REGISTRY}agentAddress`, object: `"${ADDR}"`, graph: AGENTS_GRAPH },
+    ]);
+
+    const OP = `urn:dkg:share:${CG_ID}:op-legacy-canonical`;
+    await store.insert([
+      { subject: OP, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
+      { subject: OP, predicate: `${DKG}publisherPeerId`, object: `"${PEER}"`, graph: SWM_META },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: `"${PEER}"`, graph: SWM_META },
+      { subject: `did:dkg:context-graph:${CG_ID}`, predicate: RDF_TYPE, object: `${DKG}ContextGraph`, graph: CG_META },
+    ]);
+
+    const r = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r.rewritten).toBe(1);
+    expect(r.skipped).toBe(0);
+
+    const after = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_META}> { <${OP}> <${PROV}wasAttributedTo> ?o } }`,
+    );
+    if (after.type === 'bindings') {
+      expect(after.bindings.length).toBe(1);
+      expect(after.bindings[0]['o']).toBe(`did:dkg:agent:${ADDR}`);
+    }
+  });
+
+  it('GH #748 Codex round 2: ambiguous peer→agent mapping (multi-agent-per-node) leaves literal in place', async () => {
+    // Two agents share the same libp2p peer ID (multi-agent-per-node, e.g.
+    // via `DKGAgent.registerAgent`). The resolver must NOT pick one
+    // arbitrarily — the migration leaves the legacy literal alone.
+    const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+    const CG_META = `did:dkg:context-graph:${CG_ID}/_meta`;
+    const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+    const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const DKG = 'http://dkg.io/ontology/';
+    const PROV = 'http://www.w3.org/ns/prov#';
+    const PEER_SHARED = '12D3KooWMultiAgentNode';
+    const ADDR_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const ADDR_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    // GH #748 Codex round 3: registry namespace is `https://dkg.network/ontology#`.
+    const DKG_REGISTRY = 'https://dkg.network/ontology#';
+
+    await store.insert([
+      { subject: `did:dkg:agent:${ADDR_A}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_A}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER_SHARED}"`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_B}`, predicate: RDF_TYPE, object: `${DKG_REGISTRY}Agent`, graph: AGENTS_GRAPH },
+      { subject: `did:dkg:agent:${ADDR_B}`, predicate: `${DKG_REGISTRY}peerId`, object: `"${PEER_SHARED}"`, graph: AGENTS_GRAPH },
+    ]);
+
+    const OP = `urn:dkg:share:${CG_ID}:op-ambiguous`;
+    await store.insert([
+      { subject: OP, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation`, graph: SWM_META },
+      { subject: OP, predicate: `${DKG}publisherPeerId`, object: `"${PEER_SHARED}"`, graph: SWM_META },
+      { subject: OP, predicate: `${PROV}wasAttributedTo`, object: `"${PEER_SHARED}"`, graph: SWM_META },
+      { subject: `did:dkg:context-graph:${CG_ID}`, predicate: RDF_TYPE, object: `${DKG}ContextGraph`, graph: CG_META },
+    ]);
+
+    const r = await publisher.migrateSwmAttributionToAgentDid();
+    expect(r.rewritten).toBe(0);
+    expect(r.skipped).toBe(1);
+
+    // The row stays as a literal — no arbitrary attribution.
+    const after = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_META}> { <${OP}> <${PROV}wasAttributedTo> ?o } }`,
+    );
+    if (after.type === 'bindings') {
+      expect(after.bindings.length).toBe(1);
+      expect(after.bindings[0]['o']).toBe(`"${PEER_SHARED}"`);
+    }
+  });
+
   it('full lifecycle: create → write → promote → verify SWM → discard', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -551,6 +551,22 @@ describe('generateAssertionCreatedMetadata', () => {
       expect(q.graph).toBe(META_GRAPH);
     }
   });
+
+  it('emits dkg:subGraphName on the assertion subject when scoped to a sub-graph', () => {
+    const scopedLifecycleUri = assertionLifecycleUri(CONTEXT_GRAPH, AGENT_ADDR, ASSERTION, 'players');
+    const quads = generateAssertionCreatedMetadata({ ...meta, subGraphName: 'players' });
+    expect(quads).toContainEqual(expect.objectContaining({
+      subject: scopedLifecycleUri,
+      predicate: `${DKG}subGraphName`,
+      object: '"players"',
+      graph: META_GRAPH,
+    }));
+  });
+
+  it('omits dkg:subGraphName when assertion is in the root bucket', () => {
+    const quads = generateAssertionCreatedMetadata(meta);
+    expect(quads.find(q => q.predicate === `${DKG}subGraphName`)).toBeUndefined();
+  });
 });
 
 describe('generateAssertionPromotedMetadata', () => {
@@ -602,6 +618,22 @@ describe('generateAssertionPromotedMetadata', () => {
     expect(entities.map(q => q.object)).toContain('urn:test:alice');
     expect(entities.map(q => q.object)).toContain('urn:test:bob');
   });
+
+  it('emits dkg:subGraphName on the assertion subject when scoped to a sub-graph', () => {
+    const scopedLifecycleUri = assertionLifecycleUri(CONTEXT_GRAPH, AGENT_ADDR, ASSERTION, 'players');
+    const { insert } = generateAssertionPromotedMetadata({ ...meta, subGraphName: 'players' });
+    expect(insert).toContainEqual(expect.objectContaining({
+      subject: scopedLifecycleUri,
+      predicate: `${DKG}subGraphName`,
+      object: '"players"',
+      graph: META_GRAPH,
+    }));
+  });
+
+  it('omits dkg:subGraphName when assertion is in the root bucket', () => {
+    const { insert } = generateAssertionPromotedMetadata(meta);
+    expect(insert.find(q => q.predicate === `${DKG}subGraphName`)).toBeUndefined();
+  });
 });
 
 describe('generateAssertionPublishedMetadata', () => {
@@ -625,6 +657,22 @@ describe('generateAssertionPublishedMetadata', () => {
     const { insert } = generateAssertionPublishedMetadata(meta);
     const eventUri = findEventUriFromInsert(insert);
     expect(insert.find(q => q.subject === eventUri && q.predicate === `${DKG}kcUal`)!.object).toBe('did:dkg:kc:test-kc-001');
+  });
+
+  it('emits dkg:subGraphName on the assertion subject when scoped to a sub-graph', () => {
+    const scopedLifecycleUri = assertionLifecycleUri(CONTEXT_GRAPH, AGENT_ADDR, ASSERTION, 'players');
+    const { insert } = generateAssertionPublishedMetadata({ ...meta, subGraphName: 'players' });
+    expect(insert).toContainEqual(expect.objectContaining({
+      subject: scopedLifecycleUri,
+      predicate: `${DKG}subGraphName`,
+      object: '"players"',
+      graph: META_GRAPH,
+    }));
+  });
+
+  it('omits dkg:subGraphName when assertion is in the root bucket', () => {
+    const { insert } = generateAssertionPublishedMetadata(meta);
+    expect(insert.find(q => q.predicate === `${DKG}subGraphName`)).toBeUndefined();
   });
 });
 
@@ -654,6 +702,22 @@ describe('generateAssertionDiscardedMetadata', () => {
     const eventUri = findEventUriFromInsert(insert);
     expect(insert.find(q => q.subject === eventUri && q.predicate === `${DKG}fromLayer`)!.object).toBe(`"${MemoryLayer.WorkingMemory}"`);
     expect(insert.find(q => q.subject === eventUri && q.predicate === `${DKG}toLayer`)!.object).toBe('"none"');
+  });
+
+  it('emits dkg:subGraphName on the assertion subject when scoped to a sub-graph', () => {
+    const scopedLifecycleUri = assertionLifecycleUri(CONTEXT_GRAPH, AGENT_ADDR, ASSERTION, 'players');
+    const { insert } = generateAssertionDiscardedMetadata({ ...meta, subGraphName: 'players' });
+    expect(insert).toContainEqual(expect.objectContaining({
+      subject: scopedLifecycleUri,
+      predicate: `${DKG}subGraphName`,
+      object: '"players"',
+      graph: META_GRAPH,
+    }));
+  });
+
+  it('omits dkg:subGraphName when assertion is in the root bucket', () => {
+    const { insert } = generateAssertionDiscardedMetadata(meta);
+    expect(insert.find(q => q.predicate === `${DKG}subGraphName`)).toBeUndefined();
   });
 });
 

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -121,6 +121,76 @@ describe('generateKCMetadata', () => {
     const kaSubjects = new Set(quads.filter(q => q.predicate === RDF_TYPE && q.object === `${DKG}KnowledgeAsset`).map(q => q.subject));
     expect(kaSubjects.size).toBe(2);
   });
+
+  it('GH #748 fallback: attribution is the peer-ID literal when neither agentAddress nor authorAddress is supplied', () => {
+    const quads = generateKCMetadata(makeMeta(), [makeKA()]);
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution).toBeDefined();
+    expect(attribution!.object).toBe('"12D3KooWTestPeer"');
+  });
+
+  it('GH #748: attribution is the agent DID URI when agentAddress is supplied', () => {
+    const ADDR = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
+    const quads = generateKCMetadata(makeMeta({ agentAddress: ADDR }), [makeKA()]);
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution).toBeDefined();
+    // GH #748 Codex round 3: EVM-shape addresses lowercased so the same
+    // wallet doesn't split into multiple RDF subjects (see `agentDid()`
+    // and `canonicalAgentDidSubject` in agent/profile.ts:20).
+    expect(attribution!.object).toBe(`did:dkg:agent:${ADDR.toLowerCase()}`);
+  });
+
+  it('GH #748: attribution falls back to authorAddress when agentAddress is omitted but publication provenance is set', () => {
+    const ADDR = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+    const quads = generateKCMetadata(
+      makeMeta({ authorAddress: ADDR, publishOperationId: 'op-x' }),
+      [makeKA()],
+    );
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution).toBeDefined();
+    // GH #748 Codex round 3: EVM-shape addresses lowercased so the same
+    // wallet doesn't split into multiple RDF subjects (see `agentDid()`
+    // and `canonicalAgentDidSubject` in agent/profile.ts:20).
+    expect(attribution!.object).toBe(`did:dkg:agent:${ADDR.toLowerCase()}`);
+  });
+
+  it('GH #748 Codex round 7: zero-address authorAddress is treated as unattributed (no fake agent DID)', () => {
+    // `publisherNodeIdentityIdOverride = 0` writes `authorAddress = 0x0…0`
+    // as the sentinel for "no author". The fallback chain must NOT mint a
+    // real-looking `did:dkg:agent:0x000…000` URI — fall through to the
+    // peer-ID literal so downstream provenance correctly reflects the
+    // unattributed publish.
+    const ZERO = '0x0000000000000000000000000000000000000000';
+    const quads = generateKCMetadata(
+      makeMeta({ authorAddress: ZERO, publishOperationId: 'op-x' }),
+      [makeKA()],
+    );
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution).toBeDefined();
+    // Must NOT be the synthesised zero-address agent DID.
+    expect(attribution!.object).not.toBe(`did:dkg:agent:${ZERO}`);
+    // Falls back to peer-ID literal — preserves the pre-fix unattributed shape.
+    expect(attribution!.object).toBe('"12D3KooWTestPeer"');
+  });
+
+  it('GH #748 Codex round 7: zero-address with mixed casing also treated as unattributed', () => {
+    // Sanity: case-insensitive zero-address detection.
+    const ZERO_MIXED = '0x0000000000000000000000000000000000000000';
+    const quads = generateKCMetadata(makeMeta({ agentAddress: ZERO_MIXED }), [makeKA()]);
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution!.object).toBe('"12D3KooWTestPeer"');
+  });
+
+  it('GH #748: explicit agentAddress takes precedence over authorAddress', () => {
+    const AGENT = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
+    const AUTHOR = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+    const quads = generateKCMetadata(
+      makeMeta({ agentAddress: AGENT, authorAddress: AUTHOR, publishOperationId: 'op-x' }),
+      [makeKA()],
+    );
+    const attribution = quads.find(q => q.subject === UAL && q.predicate === `${PROV}wasAttributedTo`);
+    expect(attribution!.object).toBe(`did:dkg:agent:${AGENT.toLowerCase()}`);
+  });
 });
 
 describe('generateKCMetadata — RFC-001 §3.5 publication provenance', () => {
@@ -322,6 +392,45 @@ describe('generateShareMetadata', () => {
     const preds = quads.map(q => q.predicate);
     expect(preds).toContain(`${DKG}publishedAt`);
     expect(preds).toContain('http://www.w3.org/ns/prov#wasAttributedTo');
+  });
+
+  it('GH #748 fallback: attribution is the peer-ID literal when agentAddress is omitted', () => {
+    const quads = generateShareMetadata(wsMeta, wsGraph);
+    const attribution = quads.find(q => q.predicate === 'http://www.w3.org/ns/prov#wasAttributedTo');
+    expect(attribution).toBeDefined();
+    expect(attribution!.object).toBe('"12D3KooWTestPeer"');
+  });
+
+  it('GH #748: attribution is the agent DID URI when agentAddress is supplied', () => {
+    const ADDR = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
+    const quads = generateShareMetadata(
+      { ...wsMeta, agentAddress: ADDR },
+      wsGraph,
+    );
+    const attribution = quads.find(q => q.predicate === 'http://www.w3.org/ns/prov#wasAttributedTo');
+    expect(attribution).toBeDefined();
+    // GH #748 Codex round 3: EVM-shape addresses lowercased to converge with
+    // `canonicalAgentDidSubject` in agent/profile.ts:20.
+    expect(attribution!.object).toBe(`did:dkg:agent:${ADDR.toLowerCase()}`);
+    // The peer ID is still recorded separately for transport-layer audit.
+    const peerIdQuad = quads.find(q => q.predicate === `${DKG}publisherPeerId`);
+    expect(peerIdQuad!.object).toBe('"12D3KooWTestPeer"');
+  });
+
+  it('GH #748 Codex round 3: agentDid lowercases EVM-shape addresses, passes through non-EVM', () => {
+    // EVM checksummed → lowercased (test via the share writer which calls agentDid)
+    const checksummedAddr = '0xaF7E932F79263f1A303790Bd6C01b096f5334BBB';
+    const lowerQuads = generateShareMetadata(
+      { ...wsMeta, agentAddress: checksummedAddr.toLowerCase() }, wsGraph,
+    );
+    const upperQuads = generateShareMetadata(
+      { ...wsMeta, agentAddress: checksummedAddr }, wsGraph,
+    );
+    const lowerAttr = lowerQuads.find(q => q.predicate === 'http://www.w3.org/ns/prov#wasAttributedTo');
+    const upperAttr = upperQuads.find(q => q.predicate === 'http://www.w3.org/ns/prov#wasAttributedTo');
+    // Same wallet, two casings, must converge on one DID.
+    expect(lowerAttr!.object).toBe(upperAttr!.object);
+    expect(lowerAttr!.object).toBe('did:dkg:agent:0xaf7e932f79263f1a303790bd6c01b096f5334bbb');
   });
 
   it('includes compact operation reference fields', () => {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -10,6 +10,9 @@ export {
   type LargeLiteralStorageConfig,
   registerTripleStoreAdapter,
   createTripleStore,
+  isExternalBackend,
+  getSparqlEndpoint,
+  type SparqlEndpoint,
 } from './triple-store.js';
 export {
   EXTERNAL_LITERAL_REF_DATATYPE,

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -65,6 +65,70 @@ export interface TripleStore {
 
 export type TripleStoreBackend = 'oxigraph' | 'oxigraph-persistent' | 'oxigraph-worker' | 'blazegraph' | 'sparql-http' | string;
 
+// Backends that talk to a remote SPARQL endpoint over HTTP rather than
+// owning local files. The local/external split governs three pieces of
+// daemon behaviour:
+//   1. Store-size metric — local backends report file bytes, external
+//      backends have no file to stat (`getStoreBytes` returns null).
+//   2. Chain-reset wipe — local backends `rm` files, external backends
+//      issue SPARQL UPDATE (scoped DELETE for operator-provided URLs to
+//      avoid clobbering V6/V8 data sharing the instance; DROP ALL only
+//      when the namespace is owned by the CLI, signalled via
+//      `storeConfig.options.managedByDkg`).
+//   3. Boot health check — for external backends, an ASK probe runs at
+//      daemon start; an unreachable endpoint exits the daemon with an
+//      actionable message rather than booting half-broken.
+const EXTERNAL_BACKENDS: ReadonlySet<string> = new Set(['blazegraph', 'sparql-http']);
+
+export function isExternalBackend(backend: string | undefined | null): boolean {
+  return typeof backend === 'string' && EXTERNAL_BACKENDS.has(backend);
+}
+
+/**
+ * Shape-normalised SPARQL endpoint extracted from a TripleStoreConfig.
+ *
+ * `blazegraph` adapters use a single `options.url`; `sparql-http`
+ * adapters use distinct `options.queryEndpoint` / `options.updateEndpoint`
+ * with an optional auth header. Callers that need to issue raw SPARQL
+ * (chain-reset wipe, boot health check, namespace identity tag) use this
+ * helper instead of duplicating the options-shape logic in three places.
+ */
+export interface SparqlEndpoint {
+  queryUrl: string;
+  updateUrl: string;
+  headers: Record<string, string>;
+}
+
+export function getSparqlEndpoint(storeConfig: TripleStoreConfig): SparqlEndpoint {
+  if (!isExternalBackend(storeConfig.backend)) {
+    throw new Error(
+      `getSparqlEndpoint called for non-external backend "${storeConfig.backend}"`,
+    );
+  }
+  const opts = (storeConfig.options ?? {}) as Record<string, unknown>;
+  if (storeConfig.backend === 'blazegraph') {
+    const url = typeof opts.url === 'string' ? opts.url : '';
+    if (!url) {
+      throw new Error('blazegraph storeConfig requires options.url');
+    }
+    return { queryUrl: url, updateUrl: url, headers: {} };
+  }
+  // sparql-http
+  const queryEndpoint = typeof opts.queryEndpoint === 'string' ? opts.queryEndpoint : '';
+  if (!queryEndpoint) {
+    throw new Error('sparql-http storeConfig requires options.queryEndpoint');
+  }
+  const updateEndpoint =
+    typeof opts.updateEndpoint === 'string' && opts.updateEndpoint
+      ? opts.updateEndpoint
+      : queryEndpoint;
+  const headers: Record<string, string> = {};
+  if (typeof opts.auth === 'string' && opts.auth) {
+    headers['Authorization'] = opts.auth;
+  }
+  return { queryUrl: queryEndpoint, updateUrl: updateEndpoint, headers };
+}
+
 export interface LargeLiteralStorageConfig {
   /** Enable large SWM literal blob storage. Defaults to true when present. */
   enabled?: boolean;

--- a/packages/storage/test/is-external-backend.test.ts
+++ b/packages/storage/test/is-external-backend.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit coverage for the `isExternalBackend` helper that gates
+ * backend-aware daemon behaviour (metrics, chain-reset-wipe, health
+ * check). Plan: `.cursor/plans/blazegraph_v10_support_178da670.plan.md`
+ * §PR 1 item 1.
+ */
+import { describe, it, expect } from 'vitest';
+import { isExternalBackend } from '../src/triple-store.js';
+
+describe('isExternalBackend', () => {
+  it('returns true for blazegraph', () => {
+    expect(isExternalBackend('blazegraph')).toBe(true);
+  });
+
+  it('returns true for sparql-http', () => {
+    expect(isExternalBackend('sparql-http')).toBe(true);
+  });
+
+  it('returns false for the oxigraph family', () => {
+    expect(isExternalBackend('oxigraph')).toBe(false);
+    expect(isExternalBackend('oxigraph-worker')).toBe(false);
+    expect(isExternalBackend('oxigraph-persistent')).toBe(false);
+  });
+
+  it('returns false for unknown backends', () => {
+    expect(isExternalBackend('neptune')).toBe(false);
+    expect(isExternalBackend('graphdb')).toBe(false);
+    expect(isExternalBackend('')).toBe(false);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(isExternalBackend(undefined)).toBe(false);
+    expect(isExternalBackend(null)).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,12 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  devnet/edge-update-flow:
+    devDependencies:
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
   devnet/v10-core-flows:
     dependencies:
       ethers:
@@ -5896,10 +5902,6 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
@@ -8614,7 +8616,7 @@ snapshots:
       '@vitest/spy': 4.0.18
       '@vitest/utils': 4.0.18
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -8643,7 +8645,7 @@ snapshots:
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -12607,8 +12609,6 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.0.2: {}
-
   tinyexec@1.1.2: {}
 
   tinyglobby@0.2.15:
@@ -13040,9 +13040,9 @@ snapshots:
       picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@22.19.11)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -13078,9 +13078,9 @@ snapshots:
       picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@22.19.11)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
   - "devnet/v10-end-to-end"
   - "devnet/v10-stress"
   - "devnet/conviction-lazy-settle"
+  - "devnet/edge-update-flow"

--- a/scripts/_devnet-full-sweep.sh
+++ b/scripts/_devnet-full-sweep.sh
@@ -24,6 +24,7 @@ SCRIPTS=(
   "rfc38-unclean-restart"
   "publish"
   "sharing"
+  "swm-ownership-restart"
   "invite-flow"
   "cli-invite"
   "reject-flow"

--- a/scripts/devnet-test-edge-update.sh
+++ b/scripts/devnet-test-edge-update.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+#
+# RFC-41 Bundle B — Edge node npm-only update + rollback flow validation.
+#
+# Closes the §6.2 testing gap by exercising the production
+# `performNpmUpdateEdge` and `dkg rollback` (Edge branch) code paths
+# against a real `npm install -g` against a real (local) npm registry.
+# Unit tests cover the LOGIC with mocked `exec`; this script covers
+# the INTEGRATION:
+#
+#   * `npm install -g @origintrail-official/dkg@<v>` actually mutates
+#     the global prefix.
+#   * The installed `dkg` binary runs and reports the expected version.
+#   * A minimal Edge `config.json` routes `dkg update` through the
+#     `performNpmUpdateEdge` branch (rather than the slot branch).
+#   * `dkg update <new-version>` reinstalls globally, writes
+#     `~/.dkg/previous-version` containing the OLD version, and the
+#     binary now reports `<new-version>`.
+#   * `dkg rollback` reads `~/.dkg/previous-version` and reinstalls the
+#     OLD version. Round-trip lands back on the original version.
+#
+# The script does NOT exercise `dkg init` (interactive; ~12 prompts).
+# That command's monorepo guard + `--role` flag are covered by unit
+# tests in `packages/cli/test/rfc-41-bundle-b.test.ts`. The runbook in
+# `docs/devnet/EDGE_UPDATE_VALIDATION.md` documents the bypass.
+#
+# Verdaccio runs locally as the npm registry. Because the CLI declares
+# 10+ `workspace:*` dependencies, the script must publish EVERY public
+# workspace package at v1 (mirrors `.github/workflows/npm-publish.yml`),
+# then bump the CLI to v2 and publish that one tarball. v2 CLI depends
+# on v1 workspace deps already in verdaccio, so `npm install -g` works.
+# The scratch npm prefix and scratch `DKG_HOME` are isolated under a
+# per-run mktemp dir; no system state is touched.
+#
+# Flow:
+#   1. mktemp scratch root → NPM_CONFIG_PREFIX, DKG_HOME, verdaccio storage.
+#   2. Boot verdaccio on a free port (default 4873; override with VERDACCIO_PORT).
+#   3. `pnpm pack` every public `packages/*` at HEAD → publish v1 of all.
+#      Bump `packages/cli/package.json` → repack CLI only → publish v2.
+#   4. `npm install -g @origintrail-official/dkg@<v1>` into the scratch prefix.
+#   5. Bootstrap a minimal Edge `config.json` under DKG_HOME.
+#   6. `dkg update <v2>` → assert previous-version file + new binary version.
+#   7. `dkg rollback` → assert binary version back to v1.
+#   8. Trap cleans up: stop verdaccio, rm scratch root.
+#
+# Exit 0 on full round-trip pass. Non-zero on any assertion failure
+# with a clear "[edge-update] FAIL: ..." line on stderr.
+#
+# Runtime: ~3-5 minutes (verdaccio cold-start + pack/publish of ~15
+# workspace packages + two `npm install -g` round-trips dominate).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI_PKG_DIR="$REPO_ROOT/packages/cli"
+
+# ---------------------------------------------------------------------------
+# Logging helpers (match existing devnet-test-*.sh conventions).
+# ---------------------------------------------------------------------------
+
+log()  { echo "[edge-update] $*"; }
+warn() { echo "[edge-update] WARN: $*" >&2; }
+fail() { echo "[edge-update] FAIL: $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Tunables (env-overridable).
+# ---------------------------------------------------------------------------
+
+VERDACCIO_PORT="${VERDACCIO_PORT:-4873}"
+# Allow the operator to pre-create a scratch root (useful for debugging
+# state between runs); otherwise mktemp.
+SCRATCH_ROOT="${EDGE_UPDATE_SCRATCH:-$(mktemp -d -t dkg-edge-update.XXXXXX)}"
+KEEP_SCRATCH="${EDGE_UPDATE_KEEP_SCRATCH:-0}"
+
+NPM_PREFIX="$SCRATCH_ROOT/npm-global"
+DKG_HOME_DIR="$SCRATCH_ROOT/dkg-home"
+VERDACCIO_STORAGE="$SCRATCH_ROOT/verdaccio-storage"
+VERDACCIO_CONFIG="$SCRATCH_ROOT/verdaccio-config.yaml"
+VERDACCIO_LOG="$SCRATCH_ROOT/verdaccio.log"
+NPMRC="$SCRATCH_ROOT/.npmrc"
+TARBALL_DIR="$SCRATCH_ROOT/tarballs"
+
+mkdir -p "$NPM_PREFIX" "$DKG_HOME_DIR" "$VERDACCIO_STORAGE" "$TARBALL_DIR"
+
+log "scratch root: $SCRATCH_ROOT"
+log "npm prefix:   $NPM_PREFIX"
+log "DKG_HOME:     $DKG_HOME_DIR"
+log "verdaccio:    http://127.0.0.1:$VERDACCIO_PORT (log: $VERDACCIO_LOG)"
+
+# ---------------------------------------------------------------------------
+# Cleanup trap.
+# ---------------------------------------------------------------------------
+
+VERDACCIO_PID=""
+ORIGINAL_PKG_JSON_BACKUP=""
+
+cleanup() {
+  local exit_code=$?
+  set +e
+  if [ -n "$VERDACCIO_PID" ] && kill -0 "$VERDACCIO_PID" 2>/dev/null; then
+    log "stopping verdaccio (pid=$VERDACCIO_PID)"
+    kill "$VERDACCIO_PID" 2>/dev/null
+    wait "$VERDACCIO_PID" 2>/dev/null
+  fi
+  # Restore package.json if we mutated it for the v2 pack and didn't
+  # already restore on the happy path.
+  if [ -n "$ORIGINAL_PKG_JSON_BACKUP" ] && [ -f "$ORIGINAL_PKG_JSON_BACKUP" ]; then
+    cp "$ORIGINAL_PKG_JSON_BACKUP" "$CLI_PKG_DIR/package.json"
+    log "restored $CLI_PKG_DIR/package.json from backup"
+  fi
+  if [ "$KEEP_SCRATCH" = "1" ]; then
+    log "keeping scratch root for inspection: $SCRATCH_ROOT"
+  else
+    rm -rf "$SCRATCH_ROOT"
+  fi
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Stage 1 — boot verdaccio.
+#
+# Config allows anonymous publish for the `@origintrail-official/*`
+# scope so we don't have to `npm adduser`. A dummy `_authToken` in the
+# scratch npmrc satisfies npm's "must have an auth header" check; the
+# token value is never validated server-side because `$anonymous` is
+# the publish ACL.
+# ---------------------------------------------------------------------------
+
+cat > "$VERDACCIO_CONFIG" <<EOF
+storage: $VERDACCIO_STORAGE
+auth:
+  htpasswd:
+    file: $SCRATCH_ROOT/htpasswd
+    # max_users: -1 disables registration but does NOT disable
+    # anonymous access — \$anonymous below still works.
+    max_users: -1
+uplinks: {}
+packages:
+  '@origintrail-official/*':
+    access: \$anonymous
+    publish: \$anonymous
+    unpublish: \$anonymous
+  '**':
+    access: \$anonymous
+    # Block accidental publishes of unrelated packages.
+    publish: \$authenticated
+log:
+  type: stdout
+  format: pretty
+  level: warn
+EOF
+
+cat > "$NPMRC" <<EOF
+registry=http://127.0.0.1:$VERDACCIO_PORT/
+//127.0.0.1:$VERDACCIO_PORT/:_authToken=anon-token-for-verdaccio
+@origintrail-official:registry=http://127.0.0.1:$VERDACCIO_PORT/
+EOF
+
+# Always-on env so every subsequent `npm` / `dkg` invocation in this
+# shell uses the scratch registry + scratch prefix + scratch npmrc.
+export NPM_CONFIG_USERCONFIG="$NPMRC"
+export NPM_CONFIG_PREFIX="$NPM_PREFIX"
+export NPM_CONFIG_REGISTRY="http://127.0.0.1:$VERDACCIO_PORT/"
+# `dkg init` and `dkg rollback` read DKG_HOME for state. Without this
+# they'd write into the operator's real ~/.dkg, polluting the host.
+export DKG_HOME="$DKG_HOME_DIR"
+# Put the scratch npm prefix's bin on PATH ahead of the system one so
+# `dkg` after install resolves to the scratch install, not a global
+# `@origintrail-official/dkg` the operator might already have.
+export PATH="$NPM_PREFIX/bin:$PATH"
+
+log "stage 1: launching verdaccio"
+nohup npx -y verdaccio@latest --listen "$VERDACCIO_PORT" --config "$VERDACCIO_CONFIG" \
+  >"$VERDACCIO_LOG" 2>&1 &
+VERDACCIO_PID=$!
+
+# Wait for verdaccio to be ready.
+for i in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:$VERDACCIO_PORT/-/ping" >/dev/null 2>&1; then
+    log "verdaccio up after ${i}s (pid=$VERDACCIO_PID)"
+    break
+  fi
+  if ! kill -0 "$VERDACCIO_PID" 2>/dev/null; then
+    fail "verdaccio process exited during startup — see $VERDACCIO_LOG"
+  fi
+  sleep 1
+done
+if ! curl -fsS "http://127.0.0.1:$VERDACCIO_PORT/-/ping" >/dev/null 2>&1; then
+  fail "verdaccio did not respond to /-/ping within 60s — see $VERDACCIO_LOG"
+fi
+
+# ---------------------------------------------------------------------------
+# Stage 2 — pack every public workspace package, then a v2 of just the CLI.
+#
+# The CLI declares 10+ workspace-protocol dependencies. `pnpm pack`
+# rewrites `workspace:*` to the resolved version at pack time, but the
+# resulting tarball still REQUIRES those packages to be resolvable
+# from the registry npm hits. We therefore mirror the CI publish flow
+# (.github/workflows/npm-publish.yml step "Pack public packages") and
+# publish every non-private `packages/*` to verdaccio at v1.
+#
+# v1 = the repo's current version (e.g. `10.0.0-rc.11`).
+# v2 = `<v1>-edge-update-test.1`. Suffix keeps semver order so npm
+#      correctly considers v2 > v1, AND `^v1` does NOT match v2 (npm's
+#      caret semantics on prereleases are strict), so v2 CLI installs
+#      sit cleanly on top of v1 workspace deps already in verdaccio.
+#
+# Pre-requisite: `pnpm build` must have produced `packages/*/dist/`
+# before this script runs. Otherwise `pnpm pack` emits stub tarballs
+# missing the daemon JS and the v1 install reports a phantom
+# `Cannot find module ./dist/cli.js` at first invocation.
+# ---------------------------------------------------------------------------
+
+cd "$REPO_ROOT"
+V1_VERSION="$(node -p "require('./packages/cli/package.json').version")"
+V2_VERSION="${V1_VERSION}-edge-update-test.1"
+log "stage 2: v1=$V1_VERSION  v2=$V2_VERSION"
+
+# Sanity-check that the workspace is built.
+if [ ! -f "$CLI_PKG_DIR/dist/cli.js" ]; then
+  fail "CLI build output missing at $CLI_PKG_DIR/dist/cli.js — run 'pnpm build' from the repo root first"
+fi
+
+# Discover public packages — same logic the CI workflow uses, kept in
+# sync deliberately.
+PUBLIC_PKG_DIRS_RAW="$(node -e "
+  const fs = require('fs');
+  const path = require('path');
+  const pkgsDir = path.join(process.cwd(), 'packages');
+  const result = [];
+  for (const dir of fs.readdirSync(pkgsDir)) {
+    const pkgPath = path.join(pkgsDir, dir, 'package.json');
+    if (!fs.existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    if (pkg.private) continue;
+    result.push(path.join(pkgsDir, dir));
+  }
+  process.stdout.write(result.join('\n'));
+")"
+[ -n "$PUBLIC_PKG_DIRS_RAW" ] || fail "no public workspace packages discovered under packages/*"
+
+# Pack every public package at v1.
+log "packing public packages at v1 ($V1_VERSION)"
+PUBLIC_PKG_COUNT=0
+while IFS= read -r pkg_dir; do
+  [ -n "$pkg_dir" ] || continue
+  PUBLIC_PKG_COUNT=$((PUBLIC_PKG_COUNT + 1))
+  ( cd "$pkg_dir" && pnpm pack --pack-destination "$TARBALL_DIR" >/dev/null ) \
+    || fail "pnpm pack failed for $pkg_dir"
+done <<< "$PUBLIC_PKG_DIRS_RAW"
+log "packed $PUBLIC_PKG_COUNT v1 tarballs into $TARBALL_DIR"
+
+# Bump ONLY the CLI to v2 → repack → restore. v2's workspace deps are
+# left at v1 (already in verdaccio); npm's semver matcher resolves them
+# against the v1 packages we just packed.
+ORIGINAL_PKG_JSON_BACKUP="$SCRATCH_ROOT/cli-package.json.v1.bak"
+cp "$CLI_PKG_DIR/package.json" "$ORIGINAL_PKG_JSON_BACKUP"
+
+log "packing v2 (CLI only, with bumped version $V2_VERSION)"
+node -e "
+  const fs = require('fs');
+  const pkg = JSON.parse(fs.readFileSync('packages/cli/package.json', 'utf8'));
+  pkg.version = '$V2_VERSION';
+  fs.writeFileSync('packages/cli/package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+( cd "$CLI_PKG_DIR" && pnpm pack --pack-destination "$TARBALL_DIR" >/dev/null ) \
+  || { cp "$ORIGINAL_PKG_JSON_BACKUP" "$CLI_PKG_DIR/package.json"; fail "pnpm pack v2 failed"; }
+V2_TARBALL="$TARBALL_DIR/origintrail-official-dkg-${V2_VERSION}.tgz"
+[ -f "$V2_TARBALL" ] || { cp "$ORIGINAL_PKG_JSON_BACKUP" "$CLI_PKG_DIR/package.json"; fail "expected v2 tarball at $V2_TARBALL"; }
+log "v2 tarball: $V2_TARBALL"
+
+# Restore package.json immediately (don't wait for EXIT trap).
+cp "$ORIGINAL_PKG_JSON_BACKUP" "$CLI_PKG_DIR/package.json"
+ORIGINAL_PKG_JSON_BACKUP=""
+log "restored $CLI_PKG_DIR/package.json"
+
+# ---------------------------------------------------------------------------
+# Stage 3 — publish every packed tarball to verdaccio.
+#
+# `npm publish` reads .npmrc via NPM_CONFIG_USERCONFIG. The dummy
+# `_authToken` satisfies npm; verdaccio's `$anonymous` publish ACL
+# accepts the upload regardless of token value.
+# ---------------------------------------------------------------------------
+
+log "stage 3: publishing $(ls -1 "$TARBALL_DIR"/*.tgz | wc -l | tr -d ' ') tarballs to verdaccio"
+for tarball in "$TARBALL_DIR"/*.tgz; do
+  pkg_name="$(tar -xOf "$tarball" package/package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf-8')).name")"
+  npm publish --registry "$NPM_CONFIG_REGISTRY" "$tarball" >/dev/null 2>&1 \
+    || fail "npm publish failed for $tarball ($pkg_name) — see $VERDACCIO_LOG"
+done
+log "published all tarballs"
+
+# Sanity: verify verdaccio knows about CLI v1 + v2.
+VERSIONS_JSON="$(curl -fsS "http://127.0.0.1:$VERDACCIO_PORT/@origintrail-official%2Fdkg" \
+  || fail "verdaccio metadata fetch failed for @origintrail-official/dkg")"
+node -e "
+  const meta = $VERSIONS_JSON;
+  const versions = Object.keys(meta.versions || {});
+  if (!versions.includes('$V1_VERSION')) { console.error('missing v1: $V1_VERSION'); process.exit(1); }
+  if (!versions.includes('$V2_VERSION')) { console.error('missing v2: $V2_VERSION'); process.exit(1); }
+" || fail "verdaccio is missing CLI v1 or v2 — see $VERDACCIO_LOG"
+log "verdaccio knows CLI v1 + v2"
+
+# ---------------------------------------------------------------------------
+# Stage 4 — install v1 into the scratch prefix.
+#
+# `npm install -g @origintrail-official/dkg@<v1>` mirrors what
+# operators run for first install. The scratch prefix isolates state
+# from any pre-existing system install.
+# ---------------------------------------------------------------------------
+
+log "stage 4: npm install -g @origintrail-official/dkg@$V1_VERSION"
+npm install -g "@origintrail-official/dkg@$V1_VERSION" >/dev/null \
+  || fail "initial install failed"
+
+INSTALLED_BIN="$NPM_PREFIX/bin/dkg"
+[ -x "$INSTALLED_BIN" ] || fail "expected dkg binary at $INSTALLED_BIN after install"
+
+REPORTED_V1="$("$INSTALLED_BIN" --version 2>&1 | tail -1 | tr -d '\r\n')"
+[ "$REPORTED_V1" = "$V1_VERSION" ] \
+  || fail "expected dkg --version=$V1_VERSION after initial install, got: $REPORTED_V1"
+log "v1 installed and reports version $REPORTED_V1"
+
+# ---------------------------------------------------------------------------
+# Stage 5 — bootstrap a minimal Edge config under DKG_HOME.
+#
+# `dkg init` in rc.12 is interactive (~12 prompts: name, relay, context
+# graphs, API port, auto-update, chain RPC, hub address, auth, etc.)
+# and does not expose a `--yes` / `--non-interactive` flag — the
+# operator runs it once at first install and accepts defaults via
+# Enter. Piping `\n` x 12 to stdin would work but breaks silently the
+# moment a new prompt is added, which is brittle for an integration
+# test whose subject is the UPDATE flow, not init.
+#
+# Instead we write `$DKG_HOME/config.json` directly with the fields
+# that `dkg update` / `dkg rollback` read:
+#
+#   * `nodeRole: 'edge'`   → dispatches update/rollback through the
+#                            Edge branch (`performNpmUpdateEdge`).
+#   * `autoUpdate.source: 'npm'` → marks the install as npm-managed
+#                                  (no legacy git-build dispatch).
+#
+# The `dkg init --role edge` monorepo guard + --role flag are covered
+# by Bundle B's unit tests in `packages/cli/test/rfc-41-bundle-b.test.ts`;
+# this script does not duplicate that coverage.
+# ---------------------------------------------------------------------------
+
+log "stage 5: bootstrap minimal Edge config at $DKG_HOME/config.json"
+mkdir -p "$DKG_HOME"
+cat > "$DKG_HOME/config.json" <<EOF
+{
+  "name": "dkg-edge-update-test",
+  "nodeRole": "edge",
+  "apiPort": 8901,
+  "autoUpdate": {
+    "enabled": false,
+    "source": "npm"
+  },
+  "auth": {
+    "enabled": false
+  }
+}
+EOF
+INIT_ROLE="$(node -p "JSON.parse(require('fs').readFileSync('$DKG_HOME/config.json','utf8')).nodeRole" 2>/dev/null || echo '')"
+[ "$INIT_ROLE" = "edge" ] || fail "expected nodeRole=edge in config.json, got: $INIT_ROLE"
+log "config.json nodeRole=edge, autoUpdate.source=npm"
+
+# ---------------------------------------------------------------------------
+# Stage 6 — `dkg update <V2_VERSION>`.
+#
+# This is the headline Bundle B assertion: the Edge branch of
+# `dkg update` runs `npm install -g @origintrail-official/dkg@<v2>`,
+# writes the OLD version to `$DKG_HOME/previous-version`, and the
+# binary now reports v2.
+# ---------------------------------------------------------------------------
+
+log "stage 6: dkg update $V2_VERSION"
+"$INSTALLED_BIN" update "$V2_VERSION" >/dev/null 2>&1 \
+  || fail "dkg update $V2_VERSION failed — re-run with EDGE_UPDATE_KEEP_SCRATCH=1 and inspect $DKG_HOME"
+
+PREV_FILE="$DKG_HOME/previous-version"
+[ -f "$PREV_FILE" ] || fail "expected $PREV_FILE after dkg update (Edge rollback breadcrumb)"
+PREV_CONTENT="$(tr -d '\r\n[:space:]' <"$PREV_FILE")"
+[ "$PREV_CONTENT" = "$V1_VERSION" ] \
+  || fail "expected previous-version=$V1_VERSION, got: '$PREV_CONTENT'"
+log "previous-version=$PREV_CONTENT (matches v1)"
+
+REPORTED_V2="$("$INSTALLED_BIN" --version 2>&1 | tail -1 | tr -d '\r\n')"
+[ "$REPORTED_V2" = "$V2_VERSION" ] \
+  || fail "expected dkg --version=$V2_VERSION after update, got: $REPORTED_V2"
+log "binary now reports $REPORTED_V2"
+
+# ---------------------------------------------------------------------------
+# Stage 7 — `dkg rollback`.
+#
+# Edge rollback reads `previous-version`, runs `npm install -g
+# @origintrail-official/dkg@<old>`, and the binary returns to v1.
+# ---------------------------------------------------------------------------
+
+log "stage 7: dkg rollback (expected back to $V1_VERSION)"
+"$INSTALLED_BIN" rollback >/dev/null 2>&1 \
+  || fail "dkg rollback failed — re-run with EDGE_UPDATE_KEEP_SCRATCH=1 and inspect $DKG_HOME"
+
+REPORTED_ROLLBACK="$("$INSTALLED_BIN" --version 2>&1 | tail -1 | tr -d '\r\n')"
+[ "$REPORTED_ROLLBACK" = "$V1_VERSION" ] \
+  || fail "expected dkg --version=$V1_VERSION after rollback, got: $REPORTED_ROLLBACK"
+log "binary back to $REPORTED_ROLLBACK after rollback — round-trip complete"
+
+# ---------------------------------------------------------------------------
+# Done.
+# ---------------------------------------------------------------------------
+
+log "PASS — Edge npm-only update + rollback round-trip ($V1_VERSION → $V2_VERSION → $V1_VERSION)"
+exit 0

--- a/scripts/devnet-test-edge-update.sh
+++ b/scripts/devnet-test-edge-update.sh
@@ -312,14 +312,35 @@ done
 log "published all tarballs"
 
 # Sanity: verify verdaccio knows about CLI v1 + v2.
+#
+# Stream the registry JSON to Node via stdin (NOT shell-interpolated)
+# and pass the expected versions through env vars. The package
+# metadata can legitimately contain shell-significant characters
+# like `$` or backticks (e.g. in `description`, `readme`, or
+# `repository.url` fields), and direct interpolation into `node -e`
+# would let bash expand them before Node ever parses the script.
+# Single-quoting the node script keeps bash out of its body entirely.
 VERSIONS_JSON="$(curl -fsS "http://127.0.0.1:$VERDACCIO_PORT/@origintrail-official%2Fdkg" \
   || fail "verdaccio metadata fetch failed for @origintrail-official/dkg")"
-node -e "
-  const meta = $VERSIONS_JSON;
-  const versions = Object.keys(meta.versions || {});
-  if (!versions.includes('$V1_VERSION')) { console.error('missing v1: $V1_VERSION'); process.exit(1); }
-  if (!versions.includes('$V2_VERSION')) { console.error('missing v2: $V2_VERSION'); process.exit(1); }
-" || fail "verdaccio is missing CLI v1 or v2 — see $VERDACCIO_LOG"
+printf '%s' "$VERSIONS_JSON" | \
+  V1_VERSION="$V1_VERSION" V2_VERSION="$V2_VERSION" node -e '
+    let d = "";
+    process.stdin.on("data", (c) => { d += c; });
+    process.stdin.on("end", () => {
+      const meta = JSON.parse(d);
+      const versions = Object.keys(meta.versions || {});
+      const want1 = process.env.V1_VERSION;
+      const want2 = process.env.V2_VERSION;
+      if (!versions.includes(want1)) {
+        console.error("missing v1: " + want1);
+        process.exit(1);
+      }
+      if (!versions.includes(want2)) {
+        console.error("missing v2: " + want2);
+        process.exit(1);
+      }
+    });
+  ' || fail "verdaccio is missing CLI v1 or v2 — see $VERDACCIO_LOG"
 log "verdaccio knows CLI v1 + v2"
 
 # ---------------------------------------------------------------------------

--- a/scripts/devnet-test-edge-update.sh
+++ b/scripts/devnet-test-edge-update.sh
@@ -157,11 +157,20 @@ registry=http://127.0.0.1:$VERDACCIO_PORT/
 @origintrail-official:registry=http://127.0.0.1:$VERDACCIO_PORT/
 EOF
 
-# Always-on env so every subsequent `npm` / `dkg` invocation in this
-# shell uses the scratch registry + scratch prefix + scratch npmrc.
+# PUBLIC_REGISTRY is the upstream we fetch verdaccio's own package
+# from. Required because once `NPM_CONFIG_REGISTRY` flips to the
+# scratch verdaccio (below, after it's up), a cold `npx -y
+# verdaccio@latest` would chicken-and-egg itself — npx would try to
+# fetch verdaccio's tarball from `http://127.0.0.1:$VERDACCIO_PORT/`
+# and get ECONNREFUSED before the registry has been launched.
+PUBLIC_REGISTRY="https://registry.npmjs.org/"
+
+# DKG_HOME, NPM_CONFIG_PREFIX, NPM_CONFIG_USERCONFIG can be exported
+# unconditionally — they don't affect the `npx verdaccio` fetch
+# (npx's own cache lives outside our scratch prefix). NPM_CONFIG_REGISTRY
+# is the dangerous one and is applied AFTER verdaccio is up.
 export NPM_CONFIG_USERCONFIG="$NPMRC"
 export NPM_CONFIG_PREFIX="$NPM_PREFIX"
-export NPM_CONFIG_REGISTRY="http://127.0.0.1:$VERDACCIO_PORT/"
 # `dkg init` and `dkg rollback` read DKG_HOME for state. Without this
 # they'd write into the operator's real ~/.dkg, polluting the host.
 export DKG_HOME="$DKG_HOME_DIR"
@@ -170,8 +179,14 @@ export DKG_HOME="$DKG_HOME_DIR"
 # `@origintrail-official/dkg` the operator might already have.
 export PATH="$NPM_PREFIX/bin:$PATH"
 
-log "stage 1: launching verdaccio"
-nohup npx -y verdaccio@latest --listen "$VERDACCIO_PORT" --config "$VERDACCIO_CONFIG" \
+log "stage 1: launching verdaccio (npx fetch via $PUBLIC_REGISTRY)"
+# Inline `NPM_CONFIG_REGISTRY` override for the npx subprocess only:
+# npx fetches verdaccio's tarball from the public registry, NOT from
+# the local verdaccio that doesn't exist yet. The export below
+# (after verdaccio is reachable) then flips NPM_CONFIG_REGISTRY to
+# the scratch instance for all subsequent npm/dkg invocations.
+NPM_CONFIG_REGISTRY="$PUBLIC_REGISTRY" nohup npx -y verdaccio@latest \
+  --listen "$VERDACCIO_PORT" --config "$VERDACCIO_CONFIG" \
   >"$VERDACCIO_LOG" 2>&1 &
 VERDACCIO_PID=$!
 
@@ -189,6 +204,11 @@ done
 if ! curl -fsS "http://127.0.0.1:$VERDACCIO_PORT/-/ping" >/dev/null 2>&1; then
   fail "verdaccio did not respond to /-/ping within 60s — see $VERDACCIO_LOG"
 fi
+
+# Verdaccio is now serving — safe to flip the default registry. Every
+# subsequent npm / dkg invocation in this shell now uses the scratch
+# verdaccio for resolution + publish.
+export NPM_CONFIG_REGISTRY="http://127.0.0.1:$VERDACCIO_PORT/"
 
 # ---------------------------------------------------------------------------
 # Stage 2 — pack every public workspace package, then a v2 of just the CLI.

--- a/scripts/devnet-test-edge-update.sh
+++ b/scripts/devnet-test-edge-update.sh
@@ -160,10 +160,17 @@ EOF
 # PUBLIC_REGISTRY is the upstream we fetch verdaccio's own package
 # from. Required because once `NPM_CONFIG_REGISTRY` flips to the
 # scratch verdaccio (below, after it's up), a cold `npx -y
-# verdaccio@latest` would chicken-and-egg itself — npx would try to
+# verdaccio@<pin>` would chicken-and-egg itself — npx would try to
 # fetch verdaccio's tarball from `http://127.0.0.1:$VERDACCIO_PORT/`
 # and get ECONNREFUSED before the registry has been launched.
 PUBLIC_REGISTRY="https://registry.npmjs.org/"
+
+# Verdaccio version is pinned to keep this gate reproducible — an
+# unpinned `@latest` would let an upstream Verdaccio release break
+# CI without any change in this repo. Bump deliberately by editing
+# this constant; verify the new version against the manual runbook
+# in docs/devnet/EDGE_UPDATE_VALIDATION.md before merging.
+VERDACCIO_VERSION="${VERDACCIO_VERSION:-6.7.2}"
 
 # DKG_HOME, NPM_CONFIG_PREFIX, NPM_CONFIG_USERCONFIG can be exported
 # unconditionally — they don't affect the `npx verdaccio` fetch
@@ -179,13 +186,13 @@ export DKG_HOME="$DKG_HOME_DIR"
 # `@origintrail-official/dkg` the operator might already have.
 export PATH="$NPM_PREFIX/bin:$PATH"
 
-log "stage 1: launching verdaccio (npx fetch via $PUBLIC_REGISTRY)"
+log "stage 1: launching verdaccio@$VERDACCIO_VERSION (npx fetch via $PUBLIC_REGISTRY)"
 # Inline `NPM_CONFIG_REGISTRY` override for the npx subprocess only:
 # npx fetches verdaccio's tarball from the public registry, NOT from
 # the local verdaccio that doesn't exist yet. The export below
 # (after verdaccio is reachable) then flips NPM_CONFIG_REGISTRY to
 # the scratch instance for all subsequent npm/dkg invocations.
-NPM_CONFIG_REGISTRY="$PUBLIC_REGISTRY" nohup npx -y verdaccio@latest \
+NPM_CONFIG_REGISTRY="$PUBLIC_REGISTRY" nohup npx -y "verdaccio@$VERDACCIO_VERSION" \
   --listen "$VERDACCIO_PORT" --config "$VERDACCIO_CONFIG" \
   >"$VERDACCIO_LOG" 2>&1 &
 VERDACCIO_PID=$!

--- a/scripts/devnet-test-swm-ownership-restart.sh
+++ b/scripts/devnet-test-swm-ownership-restart.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+#
+# SWM ownership restart regression.
+#
+# Reproduces the Phase 0 correctness slice for issue #747 against real
+# devnet daemons:
+#
+#   1. Node 1 promotes a root entity into the public devnet CG.
+#   2. Node 2 receives the SWM data plus _shared_memory_meta owner row.
+#   3. Node 1 is stopped, so the original owner is offline.
+#   4. Node 2 is restarted, clearing process-local publisher ownership maps
+#      while preserving its local store and without live owner help.
+#   5. Node 2 attempts to promote the same root. This must hard-fail from
+#      durable local SWM metadata, and must not overwrite SWM data or owner.
+#
+# Preconditions:
+#   ./scripts/devnet.sh clean
+#   ./scripts/devnet.sh start 6
+#
+# No bootstrap publishes are required; the script only uses the daemon HTTP API.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+API_PORT_BASE=9201
+CONTEXT_GRAPH="${CONTEXT_GRAPH:-devnet-test}"
+OWNER_NODE="${OWNER_NODE:-1}"
+ATTACKER_NODE="${ATTACKER_NODE:-2}"
+TMPDIR="${TMPDIR:-/tmp}"
+
+DKG_WORKSPACE_OWNER="http://dkg.io/ontology/workspaceOwner"
+SCHEMA_NAME="http://schema.org/name"
+
+log()  { echo "[swm-own] $*"; }
+warn() { echo "[swm-own] WARN: $*" >&2; }
+fail() { echo "[swm-own] FAIL: $*" >&2; exit 1; }
+act()  { echo ""; echo "[swm-own] === $1 ==="; }
+
+node_dir()     { echo "$DEVNET_DIR/node$1"; }
+node_token()   { grep -v '^#' "$(node_dir "$1")/auth.token" 2>/dev/null | tr -d '[:space:]'; }
+node_port()    { echo $((API_PORT_BASE + $1 - 1)); }
+node_pidfile() { echo "$(node_dir "$1")/devnet.pid"; }
+
+require_node() {
+  local node="$1"
+  [ -d "$(node_dir "$node")" ] || fail "node $node home missing; run ./scripts/devnet.sh start 6 first"
+  [ -n "$(node_token "$node")" ] || fail "node $node auth token missing"
+}
+
+api_capture() {
+  local node="$1" method="$2" path="$3" data="${4:-}" body_out="$5" code_out="$6"
+  local port token tmp code content
+  port=$(node_port "$node")
+  token=$(node_token "$node")
+  tmp="$(mktemp "$TMPDIR/swm-own-response-XXXXXX")"
+  local -a curl_args=(-sS --max-time 180 --connect-timeout 5 -o "$tmp" -w "%{http_code}" -X "$method")
+  curl_args+=(-H "Authorization: Bearer $token" -H "Content-Type: application/json")
+  [ -n "$data" ] && curl_args+=(-d "$data")
+  curl_args+=("http://127.0.0.1:${port}${path}")
+  code=$(curl "${curl_args[@]}" 2>/dev/null || echo "000")
+  content="$(cat "$tmp" 2>/dev/null || true)"
+  rm -f "$tmp"
+  printf -v "$body_out" '%s' "$content"
+  printf -v "$code_out" '%s' "$code"
+}
+
+api_call() {
+  local node="$1" method="$2" path="$3" data="${4:-}" body code
+  api_capture "$node" "$method" "$path" "$data" body code
+  if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
+    fail "$method $path on node $node failed with HTTP $code: $body"
+  fi
+  printf '%s' "$body"
+}
+
+parse_json() {
+  printf '%s' "$1" | node -e "
+    let d='';
+    process.stdin.on('data', c => d += c);
+    process.stdin.on('end', () => {
+      try {
+        const j = JSON.parse(d);
+        const v = j$2;
+        console.log(v == null ? '' : v);
+      } catch {
+        process.exit(1);
+      }
+    });
+  "
+}
+
+binding_values() {
+  local json="$1" var="$2"
+  printf '%s' "$json" | VAR="$var" node -e '
+    let d = "";
+    process.stdin.on("data", c => d += c);
+    process.stdin.on("end", () => {
+      try {
+        const j = JSON.parse(d);
+        const bindings = j?.result?.bindings ?? j?.bindings ?? [];
+        const unwrap = (cell) => {
+          if (cell == null) return "";
+          if (typeof cell === "object" && "value" in cell) return String(cell.value);
+          const s = String(cell);
+          const m = s.match(/^"((?:\\.|[^"\\])*)"(?:\^\^<[^>]+>|@[A-Za-z-]+)?$/);
+          if (!m) return s;
+          try { return JSON.parse("\"" + m[1] + "\""); } catch { return m[1]; }
+        };
+        for (const b of bindings) {
+          const v = unwrap(b[process.env.VAR]);
+          if (v) console.log(v);
+        }
+      } catch {
+        process.exit(1);
+      }
+    });
+  '
+}
+
+bindings_count() {
+  local json="$1"
+  printf '%s' "$json" | node -e '
+    let d = "";
+    process.stdin.on("data", c => d += c);
+    process.stdin.on("end", () => {
+      try {
+        const j = JSON.parse(d);
+        const bindings = j?.result?.bindings ?? j?.bindings ?? [];
+        console.log(Array.isArray(bindings) ? bindings.length : "PARSE_ERR");
+      } catch {
+        console.log("PARSE_ERR");
+      }
+    });
+  '
+}
+
+quads_count() {
+  local json="$1"
+  printf '%s' "$json" | node -e '
+    let d = "";
+    process.stdin.on("data", c => d += c);
+    process.stdin.on("end", () => {
+      try {
+        const j = JSON.parse(d);
+        const quads = j?.quads ?? j?.result ?? [];
+        console.log(Array.isArray(quads) ? quads.length : "PARSE_ERR");
+      } catch {
+        console.log("PARSE_ERR");
+      }
+    });
+  '
+}
+
+json_write_payload() {
+  ROOT="$1" VALUE="$2" CG="$CONTEXT_GRAPH" PRED="$SCHEMA_NAME" node -e '
+    console.log(JSON.stringify({
+      contextGraphId: process.env.CG,
+      quads: [{
+        subject: process.env.ROOT,
+        predicate: process.env.PRED,
+        object: JSON.stringify(process.env.VALUE),
+        graph: "",
+      }],
+    }));
+  '
+}
+
+json_owner_query_payload() {
+  ROOT="$1" CG="$CONTEXT_GRAPH" OWNER_PRED="$DKG_WORKSPACE_OWNER" node -e '
+    const metaGraph = `did:dkg:context-graph:${process.env.CG}/_shared_memory_meta`;
+    console.log(JSON.stringify({
+      contextGraphId: process.env.CG,
+      sparql:
+        `SELECT DISTINCT ?owner WHERE { GRAPH <${metaGraph}> { <${process.env.ROOT}> <${process.env.OWNER_PRED}> ?owner } }`,
+    }));
+  '
+}
+
+json_swm_value_query_payload() {
+  ROOT="$1" CG="$CONTEXT_GRAPH" PRED="$SCHEMA_NAME" node -e '
+    console.log(JSON.stringify({
+      contextGraphId: process.env.CG,
+      graphSuffix: "_shared_memory",
+      sparql: `SELECT DISTINCT ?value WHERE { <${process.env.ROOT}> <${process.env.PRED}> ?value }`,
+    }));
+  '
+}
+
+wait_for_node_down() {
+  local node="$1" port
+  port=$(node_port "$node")
+  for _ in $(seq 1 60); do
+    if ! curl -sf --max-time 1 -o /dev/null "http://127.0.0.1:${port}/api/status" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  fail "node $node did not stop within 30s"
+}
+
+wait_for_node_up() {
+  local node="$1" port
+  port=$(node_port "$node")
+  for _ in $(seq 1 240); do
+    if curl -sf --max-time 1 -o /dev/null "http://127.0.0.1:${port}/api/status" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  fail "node $node did not start within 120s"
+}
+
+kill_node() {
+  local node="$1" pid
+  pid=$(cat "$(node_pidfile "$node")" 2>/dev/null || true)
+  [ -n "$pid" ] || return 0
+  kill "$pid" 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.5
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    log "node $node not down after SIGTERM, sending SIGKILL"
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+  wait_for_node_down "$node"
+}
+
+restart_node() {
+  local node="$1"
+  ( cd "$REPO_ROOT" && ./scripts/devnet.sh restart-node "$node" 2>&1 | sed "s/^/  [devnet] /" )
+  wait_for_node_up "$node"
+}
+
+OWNER_STOPPED=0
+restart_owner_if_stopped() {
+  if [ "$OWNER_STOPPED" -eq 1 ]; then
+    log "trap: restarting owner node $OWNER_NODE so the devnet stays usable"
+    restart_node "$OWNER_NODE" || warn "trap: failed to restart owner node $OWNER_NODE"
+  fi
+}
+trap restart_owner_if_stopped EXIT
+
+get_peer_id() {
+  local node="$1" identity
+  identity=$(api_call "$node" GET /api/agent/identity)
+  parse_json "$identity" '.peerId'
+}
+
+assertion_create_write_finalize() {
+  local node="$1" assertion="$2" root="$3" value="$4" response count payload assertion_uri merkle_root
+  response=$(api_call "$node" POST /api/assertion/create "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"name\":\"$assertion\"}")
+  assertion_uri=$(parse_json "$response" '.assertionUri')
+  [ -n "$assertion_uri" ] || fail "create response missing assertionUri: $response"
+
+  payload=$(json_write_payload "$root" "$value")
+  response=$(api_call "$node" POST "/api/assertion/${assertion}/write" "$payload")
+  count=$(parse_json "$response" '.written')
+  [ "$count" = "1" ] || fail "expected one written quad for $assertion, got '$count': $response"
+
+  response=$(api_call "$node" POST "/api/assertion/${assertion}/finalize" "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}")
+  merkle_root=$(parse_json "$response" '.merkleRoot')
+  [ -n "$merkle_root" ] || fail "finalize response missing merkleRoot: $response"
+}
+
+promote_expect_success() {
+  local node="$1" assertion="$2" response count
+  response=$(api_call "$node" POST "/api/assertion/${assertion}/promote" "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}")
+  count=$(parse_json "$response" '.promotedCount')
+  [ "$count" = "1" ] || fail "expected one promoted quad for $assertion, got '$count': $response"
+}
+
+owner_values_on_node() {
+  local node="$1" root="$2" response
+  response=$(api_call "$node" POST /api/query "$(json_owner_query_payload "$root")")
+  binding_values "$response" owner
+}
+
+swm_values_on_node() {
+  local node="$1" root="$2" response
+  response=$(api_call "$node" POST /api/query "$(json_swm_value_query_payload "$root")")
+  binding_values "$response" value
+}
+
+wait_for_owner_meta() {
+  local node="$1" root="$2" expected_owner="$3" values
+  for _ in $(seq 1 90); do
+    values="$(owner_values_on_node "$node" "$root" 2>/dev/null || true)"
+    if [ "$values" = "$expected_owner" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail "node $node did not observe durable owner '$expected_owner' for $root; last owners='$values'"
+}
+
+wait_for_swm_value() {
+  local node="$1" root="$2" expected_value="$3" values
+  for _ in $(seq 1 90); do
+    values="$(swm_values_on_node "$node" "$root" 2>/dev/null || true)"
+    if printf '%s\n' "$values" | grep -Fxq "$expected_value"; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail "node $node did not observe SWM value '$expected_value' for $root; last values='$values'"
+}
+
+require_node "$OWNER_NODE"
+require_node "$ATTACKER_NODE"
+wait_for_node_up "$OWNER_NODE"
+wait_for_node_up "$ATTACKER_NODE"
+
+OWNER_PEER=$(get_peer_id "$OWNER_NODE")
+ATTACKER_PEER=$(get_peer_id "$ATTACKER_NODE")
+[ -n "$OWNER_PEER" ] || fail "owner peer id missing"
+[ -n "$ATTACKER_PEER" ] || fail "attacker peer id missing"
+[ "$OWNER_PEER" != "$ATTACKER_PEER" ] || fail "owner and attacker peer IDs unexpectedly match"
+
+STAMP="$(date +%s)-$$"
+ROOT="urn:swm-ownership-restart:${STAMP}"
+OWNER_ASSERTION="swm-owner-${STAMP}"
+ATTACKER_ASSERTION="swm-attacker-${STAMP}"
+OWNER_VALUE="owner-original-${STAMP}"
+ATTACKER_VALUE="attacker-overwrite-${STAMP}"
+
+log "Context graph: $CONTEXT_GRAPH"
+log "Owner:        node $OWNER_NODE peer=$OWNER_PEER"
+log "Attacker:     node $ATTACKER_NODE peer=$ATTACKER_PEER"
+log "Root:         $ROOT"
+
+act "1. Owner promotes a root into SWM"
+assertion_create_write_finalize "$OWNER_NODE" "$OWNER_ASSERTION" "$ROOT" "$OWNER_VALUE"
+promote_expect_success "$OWNER_NODE" "$OWNER_ASSERTION"
+log "owner promote succeeded"
+
+act "2. Replica has SWM data and durable owner metadata"
+wait_for_swm_value "$ATTACKER_NODE" "$ROOT" "$OWNER_VALUE"
+wait_for_owner_meta "$ATTACKER_NODE" "$ROOT" "$OWNER_PEER"
+log "node $ATTACKER_NODE has owner metadata before restart"
+
+act "3. Stop owner so enforcement cannot depend on live owner gossip"
+OWNER_STOPPED=1
+kill_node "$OWNER_NODE"
+log "owner node $OWNER_NODE is offline"
+
+act "4. Restart replica to clear process-local ownership state while owner is offline"
+restart_node "$ATTACKER_NODE"
+wait_for_swm_value "$ATTACKER_NODE" "$ROOT" "$OWNER_VALUE"
+wait_for_owner_meta "$ATTACKER_NODE" "$ROOT" "$OWNER_PEER"
+log "node $ATTACKER_NODE still has durable owner metadata after offline-owner restart"
+
+act "5. Cross-owner promote must fail from durable local metadata"
+assertion_create_write_finalize "$ATTACKER_NODE" "$ATTACKER_ASSERTION" "$ROOT" "$ATTACKER_VALUE"
+
+PROMOTE_BODY=""
+PROMOTE_CODE=""
+api_capture "$ATTACKER_NODE" POST "/api/assertion/${ATTACKER_ASSERTION}/promote" "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}" PROMOTE_BODY PROMOTE_CODE
+if [ "$PROMOTE_CODE" -ge 200 ] && [ "$PROMOTE_CODE" -lt 300 ]; then
+  fail "cross-owner promote unexpectedly succeeded with HTTP $PROMOTE_CODE: $PROMOTE_BODY"
+fi
+EXPECTED_ERROR="Cannot promote entity <${ROOT}>: owned by peer ${OWNER_PEER}, not by caller ${ATTACKER_PEER}."
+case "$PROMOTE_BODY" in
+  *"$EXPECTED_ERROR"*) log "cross-owner promote failed with expected ownership error" ;;
+  *) fail "promote failed with unexpected body (HTTP $PROMOTE_CODE): $PROMOTE_BODY; expected '$EXPECTED_ERROR'" ;;
+esac
+
+act "6. Failed promote left WM, SWM, and ownership metadata intact"
+ASSERTION_QUERY=$(api_call "$ATTACKER_NODE" POST "/api/assertion/${ATTACKER_ASSERTION}/query" "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}")
+ASSERTION_CT=$(quads_count "$ASSERTION_QUERY")
+[ "$ASSERTION_CT" = "1" ] || fail "attacker WM assertion should still have 1 quad after failed promote, got '$ASSERTION_CT': $ASSERTION_QUERY"
+
+VALUES_AFTER="$(swm_values_on_node "$ATTACKER_NODE" "$ROOT")"
+printf '%s\n' "$VALUES_AFTER" | grep -Fxq "$OWNER_VALUE" \
+  || fail "owner SWM value missing after failed promote; values='$VALUES_AFTER'"
+if printf '%s\n' "$VALUES_AFTER" | grep -Fxq "$ATTACKER_VALUE"; then
+  fail "attacker value leaked into SWM after failed promote; values='$VALUES_AFTER'"
+fi
+
+OWNERS_AFTER="$(owner_values_on_node "$ATTACKER_NODE" "$ROOT")"
+[ "$OWNERS_AFTER" = "$OWNER_PEER" ] \
+  || fail "owner metadata changed after failed promote; owners='$OWNERS_AFTER', expected '$OWNER_PEER'"
+
+log "PASS: durable SWM ownership blocks cross-author promote after restart while owner is offline"

--- a/scripts/devnet-test-swm-ownership-restart.sh
+++ b/scripts/devnet-test-swm-ownership-restart.sh
@@ -58,17 +58,18 @@ api_capture() {
   curl_args+=(-H "Authorization: Bearer $token" -H "Content-Type: application/json")
   [ -n "$data" ] && curl_args+=(-d "$data")
   curl_args+=("http://127.0.0.1:${port}${path}")
-  # Capture curl's exit status separately and only trust the printed
-  # `%{http_code}` when curl actually finished the request. Codex
-  # review on #778: on transport failures curl can already emit `000`
-  # via `-w` and *then* the `|| echo "000"` fallback appends another
-  # `000`, leaving `$code = "000000"` which then fails the `-lt 200`
-  # arithmetic with "integer expression expected" — the very bug this
-  # script is trying to avoid surfacing. Branching on `$?` keeps `$code`
-  # to either a real 3-digit HTTP status or a single canonical `000`.
-  code=$(curl "${curl_args[@]}" 2>/dev/null)
-  rc=$?
-  if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
+  # `set -euo pipefail` is in effect (line 22), so a bare
+  # `code=$(curl ...) ; rc=$?` would `errexit` the whole script before
+  # `$?` is captured (Codex review on #778). Wrap the call in
+  # `if cmd; then ... else ...; fi` — that branch is one of the
+  # documented `errexit` exceptions, so a transport failure flows to
+  # the `else` arm and we get a single canonical `000` back. We also
+  # guard against `curl` exiting cleanly while emitting nothing
+  # (rare, but `-w "%{http_code}"` can yield an empty stdout if the
+  # request is aborted between connect and first byte).
+  if code=$(curl "${curl_args[@]}" 2>/dev/null); then
+    [ -z "$code" ] && code="000"
+  else
     code="000"
   fi
   content="$(cat "$tmp" 2>/dev/null || true)"

--- a/scripts/devnet-test-swm-ownership-restart.sh
+++ b/scripts/devnet-test-swm-ownership-restart.sh
@@ -58,7 +58,19 @@ api_capture() {
   curl_args+=(-H "Authorization: Bearer $token" -H "Content-Type: application/json")
   [ -n "$data" ] && curl_args+=(-d "$data")
   curl_args+=("http://127.0.0.1:${port}${path}")
-  code=$(curl "${curl_args[@]}" 2>/dev/null || echo "000")
+  # Capture curl's exit status separately and only trust the printed
+  # `%{http_code}` when curl actually finished the request. Codex
+  # review on #778: on transport failures curl can already emit `000`
+  # via `-w` and *then* the `|| echo "000"` fallback appends another
+  # `000`, leaving `$code = "000000"` which then fails the `-lt 200`
+  # arithmetic with "integer expression expected" — the very bug this
+  # script is trying to avoid surfacing. Branching on `$?` keeps `$code`
+  # to either a real 3-digit HTTP status or a single canonical `000`.
+  code=$(curl "${curl_args[@]}" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
+    code="000"
+  fi
   content="$(cat "$tmp" 2>/dev/null || true)"
   rm -f "$tmp"
   printf -v "$body_out" '%s' "$content"
@@ -68,14 +80,15 @@ api_capture() {
 api_call() {
   local node="$1" method="$2" path="$3" data="${4:-}" body code
   api_capture "$node" "$method" "$path" "$data" body code
-  # `$code` can be empty when curl exits before printing `%{http_code}`
-  # (timeouts, connection refused under load, the API returning an
-  # empty body, etc.). Without this guard the arithmetic compares
-  # below blow up with "integer expression expected" and obscure the
-  # real "node ack'd nothing" failure (#774 finding #3 fired this on
-  # every probe). Normalize to `000` so the HTTP-status check below
-  # surfaces a single clean "transport failure" error instead.
-  [ -z "$code" ] && code="000"
+  # Defensive normalization for any caller that bypasses `api_capture`
+  # — transport failures should always surface as a clean `000` so the
+  # HTTP-status arithmetic below never blows up with "integer
+  # expression expected" and obscures the real "node ack'd nothing"
+  # failure mode (#774 finding #3 fired this on every probe).
+  case "$code" in
+    [0-9][0-9][0-9]) ;;
+    *) code="000" ;;
+  esac
   if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
     fail "$method $path on node $node failed with HTTP $code: $body"
   fi

--- a/scripts/devnet-test-swm-ownership-restart.sh
+++ b/scripts/devnet-test-swm-ownership-restart.sh
@@ -68,6 +68,14 @@ api_capture() {
 api_call() {
   local node="$1" method="$2" path="$3" data="${4:-}" body code
   api_capture "$node" "$method" "$path" "$data" body code
+  # `$code` can be empty when curl exits before printing `%{http_code}`
+  # (timeouts, connection refused under load, the API returning an
+  # empty body, etc.). Without this guard the arithmetic compares
+  # below blow up with "integer expression expected" and obscure the
+  # real "node ack'd nothing" failure (#774 finding #3 fired this on
+  # every probe). Normalize to `000` so the HTTP-status check below
+  # surfaces a single clean "transport failure" error instead.
+  [ -z "$code" ] && code="000"
   if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
     fail "$method $path on node $node failed with HTTP $code: $body"
   fi


### PR DESCRIPTION
## Summary
Test-script-only fix for the bash bug called out in [#774 finding #3](https://github.com/OriginTrail/dkg/issues/774). The `api_call` helper's `[ "\$code" -lt 200 ]` arithmetic exploded with "integer expression expected" on every probe in the failing run because curl can exit before printing the status code on transport failures, leaving `\$code` empty. Normalize empty → "000" so the HTTP-status check below surfaces a clean error instead of cascading shell faults.

This targets the `integration/rc.12-stabilize-20260527-2147` branch because the script itself is added by [PR #754](https://github.com/OriginTrail/dkg/pull/754) and hasn't merged to `release/rc.12` yet. The fix will travel with #754 when it lands on rc.12.

## Out of scope
The actual product bug from finding #3 — node 2 doesn't observe the durable owner-peer triple after the owner promotes — reproduces consistently and needs deeper investigation. Likely interaction between PR #754's SWM promote-ownership enforcement and PR #695's owner-meta sync. Tracking separately.

## Test plan
- [x] Re-ran `scripts/devnet-test-swm-ownership-restart.sh` against `integration/rc.12-stabilize` post-fix — bash spam gone, real "node 2 did not observe durable owner" failure now visible immediately at step 2.

Made with [Cursor](https://cursor.com)