### PR TITLE
test(node-ui): regression-guard Header + JoinProjectModal a11y + useFetch visibility

### DIFF
--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -10,6 +10,7 @@ import { useAgentsStore } from './stores/agents.js';
 import { useTabsStore } from './stores/tabs.js';
 import { api } from './api-wrapper.js';
 import { CONTEXT_GRAPH_PRIMER_TAB } from './lib/contextGraphPrimer.js';
+import { applyTheme } from './lib/applyTheme.js';
 import { useVisibilityPolling } from './hooks/useVisibilityPolling.js';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts.js';
 import { useShellRouting } from './hooks/useShellRouting.js';
@@ -135,17 +136,10 @@ function AppShell() {
   const [, setVpTick] = useState(0);
 
   useEffect(() => {
-    // Toggle the class on `<html>` (documentElement) — not `<body>` —
-    // because `:root` defines `--bg-root: #000000` and the
-    // `html, body, #root { background: var(--bg-root) }` rule applies
-    // that variable to the `<html>` element first. Putting the override
-    // class on `<body>` only re-cascaded the variable to the body, so
-    // the html element kept rendering the dark colour and rubber-band
-    // overscroll on macOS showed a black strip in light mode. Keep the
-    // body class as well for any selectors authored against `body.light`
-    // historically.
-    document.documentElement.classList.toggle('light', theme === 'light');
-    document.body.classList.toggle('light', theme === 'light');
+    // BUG-004: see applyTheme for why both <html> AND <body> need the
+    // class. The helper lives in src/ui/lib/applyTheme so a unit test
+    // can pin the contract without mounting AppShell.
+    applyTheme(theme);
   }, [theme]);
 
   // Re-render on viewport resize so the render-time clamp in PanelBottom

--- a/packages/node-ui/src/ui/components/Shell/Header.tsx
+++ b/packages/node-ui/src/ui/components/Shell/Header.tsx
@@ -9,6 +9,7 @@ import { useNodeEvents } from '../../hooks/useNodeEvents.js';
 import { useCurrentAgent } from '../../hooks/useCurrentAgent.js';
 import { useVisibilityPolling } from '../../hooks/useVisibilityPolling.js';
 import { compareNotificationByTsDesc, formatNotificationTimestamp } from '../../lib/formatTimestamp.js';
+import { formatPeerStatusTooltip } from '../../lib/formatPeerStatus.js';
 
 /** OriginTrail wordmark — same paths as `v9-stable` packages/node-ui App.tsx sidebar. */
 const ORIGINTRAIL_WORDMARK = (
@@ -76,38 +77,6 @@ const OBSERVABILITY_ICON = (
     <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
   </svg>
 );
-
-/** Build the tooltip string surfaced on the status pill so the user can
- *  see the direct/relayed connection breakdown and uptime without
- *  jumping to Settings. Returns a string suitable for the `title`
- *  attribute (newline-separated lines render as separate lines in
- *  Chrome's tooltip). */
-export function formatPeerStatusTooltip(
-  synced: boolean,
-  peers: number,
-  direct: number,
-  relayed: number,
-  uptimeMs: number,
-): string {
-  const lines = [
-    synced ? 'Synced with the network' : 'Syncing with the network',
-    `${peers} peer${peers === 1 ? '' : 's'} (${direct} direct, ${relayed} relayed)`,
-  ];
-  if (uptimeMs > 0) lines.push(`Uptime ${formatUptimeShort(uptimeMs)}`);
-  return lines.join('\n');
-}
-
-function formatUptimeShort(ms: number): string {
-  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-  const d = Math.floor(totalSeconds / 86400);
-  const h = Math.floor((totalSeconds % 86400) / 3600);
-  const m = Math.floor((totalSeconds % 3600) / 60);
-  const parts: string[] = [];
-  if (d > 0) parts.push(`${d}d`);
-  if (h > 0 || d > 0) parts.push(`${h}h`);
-  parts.push(`${m}m`);
-  return parts.join(' ');
-}
 
 export function Header() {
   const { theme, setTheme, leftCollapsed, toggleLeft, rightCollapsed, toggleRight } = useLayoutStore();

--- a/packages/node-ui/src/ui/lib/applyTheme.ts
+++ b/packages/node-ui/src/ui/lib/applyTheme.ts
@@ -1,0 +1,19 @@
+/**
+ * Toggles the `light` class on BOTH `<html>` (documentElement) and
+ * `<body>`. The `<html>`-level toggle is what BUG-004 fixed: `:root`
+ * defines `--bg-root: #000000`, and the `html, body, #root { background:
+ * var(--bg-root) }` rule applies that variable to `<html>` first. Putting
+ * the override class on `<body>` alone re-cascaded the variable to the
+ * body but `<html>` kept the dark colour, so macOS rubber-band overscroll
+ * flashed a black strip in light mode. We keep `body.light` as well so
+ * pre-rc.11 selectors (`body.light .v10-modal-box`, etc.) still apply.
+ *
+ * Pulling the toggle into a pure helper lets a unit test pin the
+ * contract: a regression that drops the documentElement half — or starts
+ * applying `.light` to one and `.dark` to the other — fails immediately.
+ */
+export function applyTheme(theme: 'light' | 'dark', doc: Document = document): void {
+  const isLight = theme === 'light';
+  doc.documentElement.classList.toggle('light', isLight);
+  doc.body.classList.toggle('light', isLight);
+}

--- a/packages/node-ui/src/ui/lib/formatPeerStatus.ts
+++ b/packages/node-ui/src/ui/lib/formatPeerStatus.ts
@@ -1,0 +1,41 @@
+/**
+ * Render the multiline tooltip surfaced on the global header status
+ * pill (BUG-020). Operators previously had no way to see the
+ * direct/relayed connection breakdown or the node uptime without
+ * jumping to Settings; the tooltip puts both one hover away.
+ *
+ * Deliberately a separate module so Vitest can import the helper
+ * without booting `Header.tsx` (which transitively pulls in the
+ * layout store, which calls `localStorage` at module init and so
+ * can't be loaded in a node test environment).
+ *
+ * The output is a `\n`-separated string suitable for the `title=`
+ * attribute. Chrome wraps `title=` on `\n` but NOT on `\r` or
+ * `<br>`, so the choice of separator is part of the contract.
+ */
+export function formatPeerStatusTooltip(
+  synced: boolean,
+  peers: number,
+  direct: number,
+  relayed: number,
+  uptimeMs: number,
+): string {
+  const lines = [
+    synced ? 'Synced with the network' : 'Syncing with the network',
+    `${peers} peer${peers === 1 ? '' : 's'} (${direct} direct, ${relayed} relayed)`,
+  ];
+  if (uptimeMs > 0) lines.push(`Uptime ${formatUptimeShort(uptimeMs)}`);
+  return lines.join('\n');
+}
+
+function formatUptimeShort(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const d = Math.floor(totalSeconds / 86400);
+  const h = Math.floor((totalSeconds % 86400) / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const parts: string[] = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0 || d > 0) parts.push(`${h}h`);
+  parts.push(`${m}m`);
+  return parts.join(' ');
+}

--- a/packages/node-ui/test/apply-theme.test.ts
+++ b/packages/node-ui/test/apply-theme.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applyTheme } from '../src/ui/lib/applyTheme.js';
+
+/**
+ * BUG-004 regression guard. The fix migrated the `light` class from
+ * `<body>` to BOTH `<html>` (documentElement) and `<body>`, because
+ * `:root` defines `--bg-root: #000000` and the `html` element rendered
+ * the dark colour first; macOS rubber-band overscroll then flashed a
+ * black strip on light-mode pages. The contract is:
+ *
+ *   - light  → both <html> AND <body> carry the `light` class
+ *   - dark   → neither element carries the `light` class
+ *   - toggling back to dark must remove the class from BOTH (no orphan
+ *     class on `<html>` after a dark→light→dark cycle)
+ */
+describe('applyTheme (BUG-004)', () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove('light');
+    document.body.classList.remove('light');
+  });
+
+  afterEach(() => {
+    document.documentElement.classList.remove('light');
+    document.body.classList.remove('light');
+  });
+
+  it('light: adds .light to BOTH documentElement AND body', () => {
+    applyTheme('light');
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+    expect(document.body.classList.contains('light')).toBe(true);
+  });
+
+  it('dark: ensures NEITHER element carries .light (clean dark baseline)', () => {
+    applyTheme('dark');
+    expect(document.documentElement.classList.contains('light')).toBe(false);
+    expect(document.body.classList.contains('light')).toBe(false);
+  });
+
+  it('dark→light→dark: cleanly removes the class from documentElement (the BUG-004 reproducer)', () => {
+    applyTheme('dark');
+    applyTheme('light');
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+    applyTheme('dark');
+    // Pre-fix this assertion failed: documentElement was never managed,
+    // so the rubber-band area kept a stale background colour.
+    expect(document.documentElement.classList.contains('light')).toBe(false);
+    expect(document.body.classList.contains('light')).toBe(false);
+  });
+
+  it('idempotent: applying the same theme twice does not stack duplicate tokens', () => {
+    applyTheme('light');
+    applyTheme('light');
+    // classList is a token list — duplicates are illegal anyway, but
+    // pin the count to catch any future re-implementation that uses
+    // `classList.add` without checks against a custom string.
+    expect(document.documentElement.className.split(/\s+/).filter((c) => c === 'light').length).toBe(1);
+    expect(document.body.className.split(/\s+/).filter((c) => c === 'light').length).toBe(1);
+  });
+
+  it('preserves unrelated classes on documentElement / body (additive toggle, not class replacement)', () => {
+    document.documentElement.classList.add('has-touch');
+    document.body.classList.add('cursor-default');
+    applyTheme('light');
+    expect(document.documentElement.classList.contains('has-touch')).toBe(true);
+    expect(document.body.classList.contains('cursor-default')).toBe(true);
+    applyTheme('dark');
+    expect(document.documentElement.classList.contains('has-touch')).toBe(true);
+    expect(document.body.classList.contains('cursor-default')).toBe(true);
+  });
+
+  it('accepts an injected Document so server-side / iframe consumers can theme a different doc', () => {
+    // applyTheme defaults to the global `document`, but the helper
+    // takes an optional second arg so tests / iframe hosts can theme
+    // a different document tree without monkey-patching globals.
+    const fakeHtml = document.createElement('html');
+    const fakeBody = document.createElement('body');
+    const fakeDoc = {
+      documentElement: fakeHtml,
+      body: fakeBody,
+    } as unknown as Document;
+
+    applyTheme('light', fakeDoc);
+    expect(fakeHtml.classList.contains('light')).toBe(true);
+    expect(fakeBody.classList.contains('light')).toBe(true);
+    // The real document must NOT have been touched.
+    expect(document.documentElement.classList.contains('light')).toBe(false);
+    expect(document.body.classList.contains('light')).toBe(false);
+  });
+});

--- a/packages/node-ui/test/create-project-modal.test.ts
+++ b/packages/node-ui/test/create-project-modal.test.ts
@@ -271,4 +271,74 @@ describe('CreateProjectModal partial registration flow', () => {
     const closeBtn = container!.querySelector('button[aria-label*="lose"], button[aria-label*="ismiss"]');
     expect(closeBtn).toBeTruthy();
   });
+
+  // BUG-017 dismiss wiring: Create CG modal shares useModalDismiss with
+  // Join CG. The hook itself is unit-tested separately; these tests pin
+  // that the modal is actually wired into it (Escape closes; clicking
+  // the overlay closes; clicking inside the dialog body does NOT).
+  async function renderModalWithCustomOnClose(onClose: () => void) {
+    const { CreateProjectModal } = await import('../src/ui/components/Modals/CreateProjectModal.js');
+    const { useProjectsStore } = await import('../src/ui/stores/projects.js');
+    const { useTabsStore } = await import('../src/ui/stores/tabs.js');
+    const { useJourneyStore } = await import('../src/ui/stores/journey.js');
+    act(() => {
+      useProjectsStore.setState({ contextGraphs: [], loading: false, activeProjectId: null });
+      useTabsStore.setState({
+        tabs: [{ id: 'dashboard', label: 'Dashboard', closable: false }],
+        activeTabId: 'dashboard',
+      });
+      useJourneyStore.setState({ stage: 0 });
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(React.createElement(CreateProjectModal, { open: true, onClose }));
+    });
+    await flush();
+  }
+
+  it('Escape key invokes onClose (BUG-017 hook wiring)', async () => {
+    const onClose = vi.fn();
+    await renderModalWithCustomOnClose(onClose);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking the explicit Close (×) button invokes onClose (BUG-017)', async () => {
+    const onClose = vi.fn();
+    await renderModalWithCustomOnClose(onClose);
+    const closeBtn = container!.querySelector(
+      'button[aria-label*="lose"], button[aria-label*="ismiss"]',
+    ) as HTMLButtonElement | null;
+    expect(closeBtn).toBeTruthy();
+    await act(async () => {
+      closeBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking the overlay backdrop invokes onClose exactly once (BUG-017)', async () => {
+    const onClose = vi.fn();
+    await renderModalWithCustomOnClose(onClose);
+    const overlay = container!.querySelector('.v10-modal-overlay') as HTMLElement | null;
+    expect(overlay).toBeTruthy();
+    act(() => {
+      overlay!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking inside the dialog body does NOT invoke onClose (target===currentTarget guard)', async () => {
+    const onClose = vi.fn();
+    await renderModalWithCustomOnClose(onClose);
+    const dialog = container!.querySelector('[role="dialog"]') as HTMLElement | null;
+    expect(dialog).toBeTruthy();
+    act(() => {
+      dialog!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/packages/node-ui/test/format-peer-status-tooltip.test.ts
+++ b/packages/node-ui/test/format-peer-status-tooltip.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { formatPeerStatusTooltip } from '../src/ui/lib/formatPeerStatus.js';
+
+/**
+ * The status pill in the global header now exposes a multiline tooltip
+ * (BUG-020) that breaks down peers into direct/relayed and surfaces
+ * uptime so operators don't have to jump into Settings to diagnose
+ * sync issues. The helper is pure — these tests pin the exact shape so
+ * a copy regression (e.g. "0 peers (0 direct, 0 relayed)" silently
+ * becoming "0 peer (0 direct, 0 relayed)") is caught.
+ */
+describe('formatPeerStatusTooltip (BUG-020)', () => {
+  it('reports the synced + plural peer counts with both connection breakdowns', () => {
+    const out = formatPeerStatusTooltip(true, 12, 7, 5, 2 * 86_400_000);
+    const lines = out.split('\n');
+    expect(lines).toEqual([
+      'Synced with the network',
+      '12 peers (7 direct, 5 relayed)',
+      'Uptime 2d 0h 0m',
+    ]);
+  });
+
+  it('reports "Syncing" when synced=false', () => {
+    const out = formatPeerStatusTooltip(false, 0, 0, 0, 0);
+    expect(out).toMatch(/^Syncing with the network/);
+  });
+
+  it('singularises "1 peer" (no trailing s) and keeps the parenthetical breakdown plural-agnostic', () => {
+    const out = formatPeerStatusTooltip(true, 1, 1, 0, 0);
+    expect(out).toContain('1 peer (1 direct, 0 relayed)');
+    expect(out).not.toContain('1 peers');
+  });
+
+  it('uses "peers" for 0 (zero is plural in English)', () => {
+    const out = formatPeerStatusTooltip(true, 0, 0, 0, 0);
+    expect(out).toContain('0 peers (0 direct, 0 relayed)');
+  });
+
+  it('omits the Uptime line when uptimeMs is 0 (avoids "Uptime 0m" noise on cold start)', () => {
+    const out = formatPeerStatusTooltip(true, 5, 3, 2, 0);
+    expect(out).not.toContain('Uptime');
+    expect(out.split('\n')).toHaveLength(2);
+  });
+
+  it('emits "Xh Ym" for sub-day uptime, omitting the days component', () => {
+    const fiveHoursMs = (5 * 3600 + 23 * 60) * 1000;
+    const out = formatPeerStatusTooltip(true, 1, 1, 0, fiveHoursMs);
+    expect(out).toContain('Uptime 5h 23m');
+    expect(out).not.toContain('0d');
+  });
+
+  it('emits "Xm" only when uptime is < 1h (clean tooltip for fresh nodes)', () => {
+    const out = formatPeerStatusTooltip(true, 1, 1, 0, 4 * 60 * 1000);
+    expect(out).toContain('Uptime 4m');
+    expect(out).not.toContain('0h');
+  });
+
+  it('always includes the minutes component, even at 0m on the day boundary', () => {
+    const exactlyOneDay = 86_400_000;
+    const out = formatPeerStatusTooltip(true, 1, 1, 0, exactlyOneDay);
+    expect(out).toContain('Uptime 1d 0h 0m');
+  });
+
+  it('clamps negative uptime values to zero rather than reporting nonsense (defensive)', () => {
+    const out = formatPeerStatusTooltip(true, 1, 1, 0, -1);
+    // A negative value should have skipped the `if (uptimeMs > 0)`
+    // guard so no Uptime line is rendered. This pins the contract:
+    // the helper never invents a positive uptime from a clock skew.
+    expect(out).not.toContain('Uptime');
+  });
+
+  it('newline-separates the lines so the browser tooltip renders them on separate rows', () => {
+    const out = formatPeerStatusTooltip(true, 1, 1, 0, 1000);
+    // The `\n` splitter is the contract — Chrome's `title=` attribute
+    // wraps on `\n` by default but not on `\r` or `<br>`.
+    expect(out).toContain('\n');
+    expect(out).not.toContain('<br>');
+    expect(out).not.toContain('\r');
+  });
+});

--- a/packages/node-ui/test/header-notifications.test.ts
+++ b/packages/node-ui/test/header-notifications.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+// ─────────────────────────────────────────────────────────────────────
+// Header pulls in `useCurrentAgent` (network), `useNodeEvents`
+// (EventSource), `useVisibilityPolling` (interval timer over
+// fetchNotifications), and the live api wrapper. We mock the API
+// surface so the dropdown renders deterministic data, and stub
+// EventSource because happy-dom doesn't ship one.
+// ─────────────────────────────────────────────────────────────────────
+
+const fetchNotificationsMock = vi.fn();
+const markNotificationsReadMock = vi.fn();
+const fetchCurrentAgentMock = vi.fn();
+const fetchStatusMock = vi.fn();
+
+vi.mock('../src/ui/api.js', async () => {
+  const actual = await vi.importActual<any>('../src/ui/api.js');
+  return {
+    ...actual,
+    fetchNotifications: fetchNotificationsMock,
+    markNotificationsRead: markNotificationsReadMock,
+    fetchCurrentAgent: fetchCurrentAgentMock,
+  };
+});
+
+vi.mock('../src/ui/api-wrapper.js', () => ({
+  api: {
+    fetchNotifications: fetchNotificationsMock,
+    markNotificationsRead: markNotificationsReadMock,
+    fetchCurrentAgent: fetchCurrentAgentMock,
+    fetchStatus: fetchStatusMock,
+  },
+}));
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function flush(): Promise<void> {
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+}
+
+async function renderHeader() {
+  const { Header } = await import('../src/ui/components/Shell/Header.js');
+  const { useAgentsStore } = await import('../src/ui/stores/agents.js');
+  act(() => {
+    useAgentsStore.setState({
+      nodeStatus: {
+        synced: true,
+        connectedPeers: 3,
+        connections: { direct: 2, relayed: 1 },
+        uptimeMs: 60_000,
+        name: 'TestNode',
+      } as any,
+    });
+  });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(Header));
+  });
+  await flush();
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  return container;
+}
+
+function findBellButton(container: HTMLElement): HTMLButtonElement {
+  const btn = container.querySelector('button[aria-label^="Notifications"]') as HTMLButtonElement | null;
+  if (!btn) throw new Error('bell button not found');
+  return btn;
+}
+
+describe('Header — notification dropdown wiring', () => {
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+    // EventSource stub for useNodeEvents — happy-dom doesn't provide one.
+    (globalThis as any).EventSource = class StubEventSource {
+      url: string;
+      readyState = 0;
+      onopen: ((e: any) => void) | null = null;
+      onmessage: ((e: any) => void) | null = null;
+      onerror: ((e: any) => void) | null = null;
+      constructor(url: string) { this.url = url; }
+      addEventListener() {}
+      removeEventListener() {}
+      close() {}
+    };
+    fetchCurrentAgentMock.mockResolvedValue({
+      agentAddress: '0xabcd00000000000000000000000000000000abcd',
+      agentDid: 'did:dkg:agent:0xabcd',
+      name: 'Local Agent',
+      peerId: 'peer-x',
+    });
+    fetchStatusMock.mockResolvedValue({
+      synced: true,
+      connectedPeers: 3,
+      connections: { direct: 2, relayed: 1 },
+      uptimeMs: 60_000,
+    });
+    markNotificationsReadMock.mockResolvedValue({ marked: 0 });
+  });
+
+  afterEach(() => {
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+    vi.useRealTimers();
+  });
+
+  it('bell button exposes a Notifications aria-label and tooltip (BUG-002 a11y wiring)', async () => {
+    fetchNotificationsMock.mockResolvedValue({ notifications: [], unreadCount: 0 });
+    const container = await renderHeader();
+    const bell = findBellButton(container);
+    expect(bell.getAttribute('aria-label')).toBe('Notifications');
+    expect(bell.getAttribute('title')).toBe('Notifications');
+  });
+
+  it('bell aria-label includes the unread count when > 0 (screen reader announcement)', async () => {
+    fetchNotificationsMock.mockResolvedValue({
+      notifications: [
+        { id: 1, ts: 1_716_000_000_000, type: 'join_request', title: 'A', message: 'A', source: null, peer: null, read: 0, meta: null },
+        { id: 2, ts: 1_716_001_000_000, type: 'join_request', title: 'B', message: 'B', source: null, peer: null, read: 0, meta: null },
+      ],
+      unreadCount: 2,
+    });
+    const container = await renderHeader();
+    const bell = findBellButton(container);
+    expect(bell.getAttribute('aria-label')).toBe('Notifications, 2 unread');
+    expect(bell.getAttribute('title')).toBe('Notifications (2 unread)');
+  });
+
+  it('opens the dropdown on bell click and renders notifications newest-first (RED-2 sort regression)', async () => {
+    // Deliberately shuffled: middle is newest, first is oldest.
+    fetchNotificationsMock.mockResolvedValue({
+      notifications: [
+        { id: 1, ts: 1_716_000_000_000, type: 'join_request', title: 'OLD', message: 'OLDEST', source: null, peer: null, read: 1, meta: null },
+        { id: 2, ts: 1_716_900_000_000, type: 'join_request', title: 'NEW', message: 'NEWEST', source: null, peer: null, read: 1, meta: null },
+        { id: 3, ts: 1_716_400_000_000, type: 'join_request', title: 'MID', message: 'MIDDLE', source: null, peer: null, read: 1, meta: null },
+      ],
+      unreadCount: 0,
+    });
+    const container = await renderHeader();
+    const bell = findBellButton(container);
+    await act(async () => { bell.click(); });
+    await flush();
+
+    const items = Array.from(container.querySelectorAll('.v10-header-notif-item-text'))
+      .map((n) => n.textContent);
+    expect(items).toEqual(['NEWEST', 'MIDDLE', 'OLDEST']);
+  });
+
+  it('renders the empty-state copy when there are zero notifications', async () => {
+    fetchNotificationsMock.mockResolvedValue({ notifications: [], unreadCount: 0 });
+    const container = await renderHeader();
+    const bell = findBellButton(container);
+    await act(async () => { bell.click(); });
+    await flush();
+    expect(container.textContent).toContain('No notifications');
+  });
+
+  it('Mark all read button is present only when unread > 0 (Codex YEL-3 copy + visibility)', async () => {
+    fetchNotificationsMock.mockResolvedValue({ notifications: [], unreadCount: 0 });
+    const container = await renderHeader();
+    const bell = findBellButton(container);
+    await act(async () => { bell.click(); });
+    await flush();
+    // Empty + zero unread → no button
+    expect(container.querySelector('.v10-header-notif-clear')).toBe(null);
+  });
+
+  it('Mark all read button: click marks-but-does-NOT-clear the dropdown rows (YEL-3 alignment with API)', async () => {
+    // The bell-click handler ALSO calls markNotificationsRead when
+    // unread > 0; we want to test the explicit Mark all read button,
+    // so we hang the bell's promise indefinitely (until we resolve
+    // it manually) so the button stays visible long enough to click.
+    let resolveBellMark: (v: any) => void = () => {};
+    let resolveButtonMark: (v: any) => void = () => {};
+    markNotificationsReadMock
+      .mockImplementationOnce(() => new Promise((r) => { resolveBellMark = r; }))
+      .mockImplementationOnce(() => new Promise((r) => { resolveButtonMark = r; }));
+
+    fetchNotificationsMock.mockResolvedValue({
+      notifications: [
+        { id: 1, ts: 1_716_900_000_000, type: 'join_request', title: 'A', message: 'A', source: null, peer: null, read: 0, meta: null },
+        { id: 2, ts: 1_716_000_000_000, type: 'join_request', title: 'B', message: 'B', source: null, peer: null, read: 0, meta: null },
+      ],
+      unreadCount: 2,
+    });
+    const container = await renderHeader();
+    const bell = findBellButton(container);
+    await act(async () => { bell.click(); });
+    await flush();
+
+    // The bell-click fired markNotificationsRead but it's still
+    // pending — `unread` is therefore still 2, so the Mark all read
+    // button is rendered.
+    const markBtn = container.querySelector('.v10-header-notif-clear') as HTMLButtonElement | null;
+    expect(markBtn).toBeTruthy();
+    expect(markBtn?.textContent).toBe('Mark all read');
+
+    // Click it explicitly (this is the surface YEL-3 fixed).
+    await act(async () => { markBtn!.click(); });
+    await flush();
+
+    // Resolve both pending promises so React commits the state
+    // updates (read=1 and unread=0).
+    await act(async () => {
+      resolveBellMark({ marked: 0 });
+      resolveButtonMark({ marked: 2 });
+      await Promise.resolve();
+    });
+    await flush();
+
+    // Critical YEL-3 assertion: rows must remain in the dropdown
+    // (the API only flips `read=1`; clearing the array would
+    // misrepresent the API behaviour and re-populate on next poll).
+    const remaining = container.querySelectorAll('.v10-header-notif-item-text').length;
+    expect(remaining).toBe(2);
+    expect(markNotificationsReadMock).toHaveBeenCalledTimes(2);
+
+    // The unread badge button copy should disappear because unread
+    // is now 0 (the button is conditional on `unread > 0`).
+    expect(container.querySelector('.v10-header-notif-clear')).toBe(null);
+    expect(findBellButton(container).getAttribute('aria-label')).toBe('Notifications');
+  });
+
+  it('clicking the bell with unread notifications fires markNotificationsRead exactly once', async () => {
+    fetchNotificationsMock.mockResolvedValue({
+      notifications: [
+        { id: 1, ts: 1_716_900_000_000, type: 'join_request', title: 'A', message: 'A', source: null, peer: null, read: 0, meta: null },
+      ],
+      unreadCount: 1,
+    });
+    const container = await renderHeader();
+    const bell = findBellButton(container);
+    await act(async () => { bell.click(); });
+    await flush();
+    expect(markNotificationsReadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('status pill exposes the multiline tooltip with synced + peer breakdown (BUG-020 wiring)', async () => {
+    fetchNotificationsMock.mockResolvedValue({ notifications: [], unreadCount: 0 });
+    const container = await renderHeader();
+    const meta = container.querySelector('.v10-header-meta') as HTMLElement | null;
+    expect(meta).toBeTruthy();
+    const tooltip = meta!.getAttribute('title') ?? '';
+    expect(tooltip).toContain('Synced with the network');
+    expect(tooltip).toContain('3 peers (2 direct, 1 relayed)');
+    expect(tooltip).toContain('Uptime');
+  });
+});

--- a/packages/node-ui/test/join-project-modal.a11y.test.ts
+++ b/packages/node-ui/test/join-project-modal.a11y.test.ts
@@ -129,39 +129,40 @@ describe('JoinProjectModal — BUG-017 a11y dismiss wiring', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('clicking the backdrop dismisses; clicking inside the dialog body does NOT', async () => {
+  it('clicking inside the dialog body does NOT invoke onClose', async () => {
+    // useModalDismiss.onBackdropClick is wired to the OVERLAY
+    // (`.v10-modal-overlay`). It only fires onClose when
+    // `event.target === event.currentTarget` — i.e. only when the
+    // click landed on the overlay itself, not on a child. A click
+    // inside the dialog bubbles up to the overlay's onClick, but the
+    // target/currentTarget identity check filters it out.
     const onClose = vi.fn();
     const container = await renderModal({ open: true, onClose });
     const dialog = container.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog).toBeTruthy();
 
-    // Click inside the dialog (the inner panel container) — should
-    // NOT propagate to onClose because useModalDismiss only fires
-    // when target === currentTarget on the backdrop.
     act(() => {
       dialog.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(onClose).not.toHaveBeenCalled();
+  });
 
-    // Click the backdrop directly. JoinProjectModal wires the
-    // backdrop click to the same useModalDismiss-returned handler;
-    // the backdrop is the dialog's parent. Find it via class names
-    // typical for the modal overlay.
-    const backdrop = dialog.parentElement!;
-    expect(backdrop).toBeTruthy();
+  it('clicking the backdrop overlay invokes onClose exactly once', async () => {
+    // The dismissable backdrop is `.v10-modal-overlay`, which is the
+    // dialog's parent in the rendered tree. Dispatching a bubbling
+    // click directly on the overlay sends target === currentTarget
+    // through React's synthetic event, so onBackdropClick fires.
+    // This test pins the behaviour: backdrop dismissal IS wired (a
+    // pre-rc.11 BUG-017 regression where Esc worked but the backdrop
+    // didn't would re-fail this).
+    const onClose = vi.fn();
+    const container = await renderModal({ open: true, onClose });
+    const overlay = container.querySelector('.v10-modal-overlay') as HTMLElement;
+    expect(overlay).toBeTruthy();
+
     act(() => {
-      backdrop.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    // The backdrop's onClick is `onBackdropClick`, which checks
-    // event.target === event.currentTarget; in a happy-dom dispatch
-    // the synthetic React onClick still fires through the React tree
-    // — assert at least one of dialog-click or backdrop-click did
-    // NOT spuriously invoke onClose, and that explicit Close did.
-    // (We've already proven Escape + close-button paths above.)
-    // The dispatched native event on the parent passes target ===
-    // currentTarget for the React handler if it's actually wired
-    // to the parent. If JoinProjectModal hasn't wired the backdrop
-    // (some implementations forward only Esc + close-button), this
-    // expectation is informational only — not a regression.
-    expect(onClose.mock.calls.length).toBeLessThanOrEqual(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/node-ui/test/join-project-modal.a11y.test.ts
+++ b/packages/node-ui/test/join-project-modal.a11y.test.ts
@@ -136,6 +136,10 @@ describe('JoinProjectModal — BUG-017 a11y dismiss wiring', () => {
     // click landed on the overlay itself, not on a child. A click
     // inside the dialog bubbles up to the overlay's onClick, but the
     // target/currentTarget identity check filters it out.
+    //
+    // Backdrop dismissal (`onClose` called exactly once) is covered
+    // by the dedicated test immediately below — kept separate so a
+    // broken backdrop handler cannot hide behind this negative case.
     const onClose = vi.fn();
     const container = await renderModal({ open: true, onClose });
     const dialog = container.querySelector('[role="dialog"]') as HTMLElement;

--- a/packages/node-ui/test/join-project-modal.a11y.test.ts
+++ b/packages/node-ui/test/join-project-modal.a11y.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+// Mock the api surface JoinProjectModal pulls in so the modal renders
+// without a live daemon. Most calls are happy-path stubs; the test
+// only asserts a11y wiring on the open dialog.
+const fetchContextGraphsMock = vi.fn();
+const signJoinRequestMock = vi.fn();
+const submitJoinRequestMock = vi.fn();
+const fetchCurrentAgentMock = vi.fn();
+const connectToPeerWithTimeoutMock = vi.fn();
+const connectToPeerIdWithTimeoutMock = vi.fn();
+
+vi.mock('../src/ui/api.js', async () => {
+  const actual = await vi.importActual<any>('../src/ui/api.js');
+  return {
+    ...actual,
+    fetchContextGraphs: fetchContextGraphsMock,
+    signJoinRequest: signJoinRequestMock,
+    submitJoinRequest: submitJoinRequestMock,
+    fetchCurrentAgent: fetchCurrentAgentMock,
+    connectToPeerWithTimeout: connectToPeerWithTimeoutMock,
+    connectToPeerIdWithTimeout: connectToPeerIdWithTimeoutMock,
+  };
+});
+
+vi.mock('../src/ui/components/Workspace/WireWorkspacePanel.js', () => ({
+  WireWorkspacePanel: ({ contextGraphId }: { contextGraphId: string }) =>
+    React.createElement('div', { 'data-testid': 'wire-workspace' }, contextGraphId),
+}));
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function flush(): Promise<void> {
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+}
+
+async function renderModal(props: { open: boolean; onClose: () => void }) {
+  const { JoinProjectModal } = await import('../src/ui/components/Modals/JoinProjectModal.js');
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(JoinProjectModal, props));
+  });
+  await flush();
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  return container;
+}
+
+describe('JoinProjectModal — BUG-017 a11y dismiss wiring', () => {
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+    (globalThis as any).EventSource = class {
+      constructor(_url: string) {}
+      addEventListener() {}
+      removeEventListener() {}
+      close() {}
+      onopen = null;
+      onmessage = null;
+      onerror = null;
+    };
+    fetchContextGraphsMock.mockResolvedValue({ contextGraphs: [] });
+    fetchCurrentAgentMock.mockResolvedValue({
+      agentAddress: '0x00000000000000000000000000000000000000a1',
+      agentDid: 'did:dkg:agent:0x00000000000000000000000000000000000000a1',
+      name: 'Test',
+      peerId: 'peer-x',
+    });
+  });
+
+  afterEach(() => {
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+  });
+
+  it('renders nothing when open=false (modal is unmounted, no aria-hidden ghost on the page)', async () => {
+    const container = await renderModal({ open: false, onClose: vi.fn() });
+    expect(container.querySelector('[role="dialog"]')).toBe(null);
+  });
+
+  it('renders role="dialog" + aria-modal="true" + aria-labelledby pointing at the title', async () => {
+    const container = await renderModal({ open: true, onClose: vi.fn() });
+    const dialog = container.querySelector('[role="dialog"]') as HTMLElement | null;
+    expect(dialog).toBeTruthy();
+    expect(dialog?.getAttribute('aria-modal')).toBe('true');
+    const labelledBy = dialog?.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    // The labelled-by id must resolve to a real element so screen
+    // readers can announce the dialog title.
+    expect(container.querySelector(`#${labelledBy}`)).toBeTruthy();
+  });
+
+  it('exposes an explicit Close button with an aria-label (BUG-017 explicit dismiss control)', async () => {
+    const container = await renderModal({ open: true, onClose: vi.fn() });
+    const closeBtn = container.querySelector('button[aria-label*="Close"]') as HTMLButtonElement | null;
+    expect(closeBtn).toBeTruthy();
+    // The visible glyph is `×`; aria-label carries the descriptive copy.
+    expect(closeBtn?.getAttribute('aria-label')).toMatch(/[Cc]lose/);
+  });
+
+  it('Escape key invokes onClose (useModalDismiss wiring)', async () => {
+    const onClose = vi.fn();
+    await renderModal({ open: true, onClose });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking the explicit Close button invokes onClose', async () => {
+    const onClose = vi.fn();
+    const container = await renderModal({ open: true, onClose });
+    const closeBtn = container.querySelector('button[aria-label*="Close"]') as HTMLButtonElement;
+    await act(async () => {
+      closeBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking the backdrop dismisses; clicking inside the dialog body does NOT', async () => {
+    const onClose = vi.fn();
+    const container = await renderModal({ open: true, onClose });
+    const dialog = container.querySelector('[role="dialog"]') as HTMLElement;
+
+    // Click inside the dialog (the inner panel container) — should
+    // NOT propagate to onClose because useModalDismiss only fires
+    // when target === currentTarget on the backdrop.
+    act(() => {
+      dialog.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Click the backdrop directly. JoinProjectModal wires the
+    // backdrop click to the same useModalDismiss-returned handler;
+    // the backdrop is the dialog's parent. Find it via class names
+    // typical for the modal overlay.
+    const backdrop = dialog.parentElement!;
+    expect(backdrop).toBeTruthy();
+    act(() => {
+      backdrop.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    // The backdrop's onClick is `onBackdropClick`, which checks
+    // event.target === event.currentTarget; in a happy-dom dispatch
+    // the synthetic React onClick still fires through the React tree
+    // — assert at least one of dialog-click or backdrop-click did
+    // NOT spuriously invoke onClose, and that explicit Close did.
+    // (We've already proven Escape + close-button paths above.)
+    // The dispatched native event on the parent passes target ===
+    // currentTarget for the React handler if it's actually wired
+    // to the parent. If JoinProjectModal hasn't wired the backdrop
+    // (some implementations forward only Esc + close-button), this
+    // expectation is informational only — not a regression.
+    expect(onClose.mock.calls.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/node-ui/test/use-fetch-visibility.test.ts
+++ b/packages/node-ui/test/use-fetch-visibility.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { useFetch } from '../src/ui/hooks.js';
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+interface HostProps {
+  fetcher: () => Promise<number>;
+  intervalMs: number;
+}
+
+function FetchHost({ fetcher, intervalMs }: HostProps) {
+  useFetch(fetcher, [], intervalMs);
+  return null;
+}
+
+function mount(props: HostProps): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => { root.render(React.createElement(FetchHost, props)); });
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+}
+
+function setHidden(hidden: boolean): void {
+  Object.defineProperty(document, 'hidden', { value: hidden, configurable: true });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+async function flush(): Promise<void> {
+  await act(async () => { await Promise.resolve(); });
+  await act(async () => { await Promise.resolve(); });
+}
+
+describe('useFetch visibility-pause (BUG-007 path B)', () => {
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+  });
+
+  afterEach(() => {
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+    vi.useRealTimers();
+  });
+
+  it('fetches once on mount + on each interval while visible', async () => {
+    const fetcher = vi.fn().mockResolvedValue(42);
+    mount({ fetcher, intervalMs: 1000 });
+    await flush();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    await act(async () => { vi.advanceTimersByTime(1000); });
+    await flush();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    await act(async () => { vi.advanceTimersByTime(2000); });
+    await flush();
+    expect(fetcher).toHaveBeenCalledTimes(4);
+  });
+
+  it('pauses the polling interval when the tab becomes hidden', async () => {
+    const fetcher = vi.fn().mockResolvedValue(1);
+    mount({ fetcher, intervalMs: 1000 });
+    await flush();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    act(() => { setHidden(true); });
+
+    // 10s of fake time elapses while hidden — must not fire any
+    // additional fetches.
+    await act(async () => { vi.advanceTimersByTime(10_000); });
+    await flush();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes with one immediate refresh + interval cadence on visibility=true', async () => {
+    const fetcher = vi.fn().mockResolvedValue(1);
+    mount({ fetcher, intervalMs: 1000 });
+    await flush();
+    fetcher.mockClear();
+
+    act(() => { setHidden(true); });
+    await act(async () => { vi.advanceTimersByTime(5000); });
+    expect(fetcher).not.toHaveBeenCalled();
+
+    // Resume: hook fires `load()` once + restarts the interval.
+    act(() => { setHidden(false); });
+    await flush();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    await act(async () => { vi.advanceTimersByTime(1000); });
+    await flush();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up the visibilitychange listener on unmount (no leaked fetches after teardown)', async () => {
+    const fetcher = vi.fn().mockResolvedValue(1);
+    mount({ fetcher, intervalMs: 1000 });
+    await flush();
+    fetcher.mockClear();
+
+    while (mountedRoots.length > 0) {
+      const root = mountedRoots.pop()!;
+      const container = mountedContainers.pop()!;
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+
+    // Both visibility transitions and timer ticks must be inert.
+    act(() => { setHidden(true); setHidden(false); });
+    await act(async () => { vi.advanceTimersByTime(5000); });
+    await flush();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('intervalMs=0: initial load fires + resume-on-visible refreshes once (no interval started)', async () => {
+    const fetcher = vi.fn().mockResolvedValue(1);
+    mount({ fetcher, intervalMs: 0 });
+    await flush();
+    expect(fetcher).toHaveBeenCalledTimes(1); // initial load
+
+    act(() => { setHidden(true); });
+    act(() => { setHidden(false); });
+    await flush();
+    // The hook calls load() once on resume even without a polling
+    // interval — that's defensible (long-hidden tabs benefit from a
+    // fresh snapshot on return). Pin the contract: exactly one
+    // additional fetch fires.
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    // Crucially, no INTERVAL was started — advance the clock and
+    // confirm no extra ticks fire.
+    await act(async () => { vi.advanceTimersByTime(10_000); });
+    await flush();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up audit to PR #699 (the rc.11 22-bug fix). The first audit pass
(included in #699) added regression guards for the extracted hooks. This
PR closes the remaining Header / JoinProjectModal / useFetch gaps **and**
the BUG-004 theme-toggle gap so a regression on any of those rc.11 fixes
is caught at the test layer instead of in manual QA.

**Net delta vs `main`:** **1068 unit tests pass / 38 skipped** (was 1028/38).
**+40** new assertions, **0** behaviour changes outside of two pure
extractions (`formatPeerStatusTooltip` and `applyTheme`).

## What's in this PR

### 1. Pure helper extractions (no behavioural change)

- `formatPeerStatusTooltip` extracted from `Header.tsx` →
  `src/ui/lib/formatPeerStatus.ts`. Lets the multiline tooltip be
  unit-tested without booting Header's `localStorage` dependency.
- `applyTheme(theme, doc?)` extracted from `App.tsx` →
  `src/ui/lib/applyTheme.ts`. Lets the BUG-004 contract be pinned
  without mounting `AppShell`.

### 2. Coverage delta

| File | Tests | Surface |
|---|---|---|
| `format-peer-status-tooltip.test.ts` | 10 | **BUG-020** — pluralisation (`1 peer` vs `0/12 peers`), uptime omission, sub-day formatting, day-boundary edge, negative-clamp, `\n` separator contract |
| `header-notifications.test.ts` | 8 | **BUG-002** bell aria-label/title, **BUG-019** RED-2 sort regression (shuffled epoch ts → newest-first), YEL-3 "Mark all read" mark-but-don't-clear, bell-click auto-mark, status pill tooltip wiring |
| `join-project-modal.a11y.test.ts` | 7 | **BUG-017** — role/aria-modal/aria-labelledby resolution, × close button, Escape via `useModalDismiss`, click-inside-dialog no-op, **strict backdrop-click guard** (exactly 1) |
| `use-fetch-visibility.test.ts` | 5 | **BUG-007** (useFetch path B) — pause-on-hidden, resume-immediately + cadence restart, listener cleanup, `intervalMs=0` contract |
| `apply-theme.test.ts` | 6 | **BUG-004** — light/dark on BOTH `<html>` AND `<body>`, dark→light→dark cleanup (the rubber-band overscroll reproducer), idempotence, additive (preserves unrelated classes), injectable `Document` |
| `create-project-modal.test.ts` | +4 | **BUG-017** dismiss wiring on Create CG modal: Escape, × button, overlay click, inside-dialog no-op |

### 3. Tightening pass on existing additions (this commit)

After the bot review on the JoinProjectModal backdrop test:

- **`join-project-modal.a11y.test.ts`** — split the lenient
  "click backdrop OR click inside" combo test into two strict
  assertions. The previous backdrop expectation was
  `expect(...).toBeLessThanOrEqual(1)`, which would silently pass
  if backdrop dismissal stopped wiring entirely. Now:
  - inside-the-dialog click → `onClose` NOT called (target ≠ currentTarget)
  - overlay/backdrop click  → `onClose` called **exactly once**
- **`create-project-modal.test.ts`** — added 4 dismiss-wiring guards
  parallel to the JoinProjectModal suite. The original tests covered
  role/aria/close-button presence but not the actual dismiss paths.
- **BUG-004 (`apply-theme.test.ts`)** — previously only covered by an
  E2E that asserted `body.light`. The `documentElement` half of the fix
  (the actual rubber-band-overscroll culprit) was untested. The new
  unit suite reproduces the dark→light→dark cycle that pre-fix would
  leave a stale class on `<html>`.

## Out of scope (broader test-suite audit findings)

While auditing this PR I ran the full repo-wide test suites. **None of
these are touched here** — they live in unrelated packages and need
their own focused fixes — but flagging them so they don't get lost:

| Package | Failure | Triage |
|---|---|---|
| `adapter-hermes` | `hermes-adapter.test.ts > Hermes Python provider > uploads Hermes assertion imports as safe multipart requests` | Python sidecar is sending multipart as `(filename, BufferedReader, application/octet-stream)`; test expects clean bytes |
| `agent` | `finalization-handler.test.ts` — `registration.value` expected `true`, got `false` | Possible behavioural regression |
| `agent` | `generic-sql-source.test.ts` — `Error: No such built-in module: node:sqlite` | Node 22.5+ flag (`--experimental-sqlite`) or version pin needed |
| `agent` | `swm-snapshot-sync.test.ts` — expected > 0 inserted, got 0 | Fixture / sync regression |
| `random-sampling` | `e2e-hardhat-chain.test.ts` — `beforeAll` reverts on `test.skip` suite | `beforeAll` should respect the same skip gate |
| `chain` | `Cannot find module '.../vitest@4.0.18.../vitest.mjs'` | pnpm install / lockfile state, not a test bug |
| `adapter-hermes/test/hermes-adapter.test.ts` | 3,693 lines / 83 tests in one file | Tightening opportunity: refactor into smaller files |

Healthy suites (no failures): `adapter-elizaos`, `adapter-openclaw`,
`core`, `mcp-dkg`, `query`, `storage`, `network-sim`, `epcis`,
`evm-module`, `publisher`, `cli`, `node-ui`. **~7,400 tests pass.**

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui run test` — **1068 pass / 38 skipped**
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec tsc --noEmit` — clean
- [x] No source-code behaviour changes outside the two pure extractions
- [x] Bot review comment on lenient `≤ 1` assertion addressed (now exactly 1)
- [ ] CI green

Made with [Cursor](https://cursor.com)