### PR TITLE
Fix Blazegraph namespace creation (HTTP 500)

### DIFF
--- a/packages/cli/src/daemon/blazegraph-docker.ts
+++ b/packages/cli/src/daemon/blazegraph-docker.ts
@@ -40,13 +40,15 @@ import * as net from 'node:net';
  * Mirrors the body inlined at scripts/devnet.sh:287-294. Kept here so
  * future tweaks land in one place.
  */
-export const BLAZEGRAPH_NAMESPACE_XML_TEMPLATE = `<?xml version="1.0" encoding="UTF-8"?>
+export const BLAZEGRAPH_NAMESPACE_XML_TEMPLATE = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
   <entry key="com.bigdata.rdf.sail.namespace">{namespace}</entry>
   <entry key="com.bigdata.rdf.store.AbstractTripleStore.quads">true</entry>
   <entry key="com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers">false</entry>
   <entry key="com.bigdata.rdf.store.AbstractTripleStore.textIndex">false</entry>
   <entry key="com.bigdata.rdf.sail.truthMaintenance">false</entry>
+  <entry key="com.bigdata.rdf.store.AbstractTripleStore.axiomsClass">com.bigdata.rdf.axioms.NoAxioms</entry>
 </properties>`;
 
 /** Pinned image tag — matches devnet.sh and Blazegraph mainnet. */

--- a/packages/cli/test/blazegraph-docker.test.ts
+++ b/packages/cli/test/blazegraph-docker.test.ts
@@ -429,5 +429,9 @@ describe('BLAZEGRAPH_NAMESPACE_XML_TEMPLATE', () => {
     expect(body).toContain('com.bigdata.rdf.store.AbstractTripleStore.quads">true');
     expect(body).toContain('truthMaintenance">false');
     expect(body).toContain('statementIdentifiers">false');
+    // Blazegraph requires the Java properties DOCTYPE for XML parsing.
+    expect(body).toContain('<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">');
+    // Quads mode requires inference disabled via NoAxioms.
+    expect(body).toContain('axiomsClass">com.bigdata.rdf.axioms.NoAxioms');
   });
 });

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -284,13 +284,15 @@ start_blazegraph() {
         local ns="node${n}"
         curl -s -X POST "http://127.0.0.1:$BLAZEGRAPH_PORT/bigdata/namespace" \
           -H "Content-Type: application/xml" \
-          -d "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+          -d "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>
+<!DOCTYPE properties SYSTEM \"http://java.sun.com/dtd/properties.dtd\">
 <properties>
   <entry key=\"com.bigdata.rdf.sail.namespace\">$ns</entry>
   <entry key=\"com.bigdata.rdf.store.AbstractTripleStore.quads\">true</entry>
   <entry key=\"com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers\">false</entry>
   <entry key=\"com.bigdata.rdf.store.AbstractTripleStore.textIndex\">false</entry>
   <entry key=\"com.bigdata.rdf.sail.truthMaintenance\">false</entry>
+  <entry key=\"com.bigdata.rdf.store.AbstractTripleStore.axiomsClass\">com.bigdata.rdf.axioms.NoAxioms</entry>
 </properties>" > /dev/null 2>&1
         log "Created Blazegraph namespace: $ns"
       done


### PR DESCRIPTION
### Problem
The Docker provisioner's namespace XML template is missing two things Blazegraph 2.x requires for quads-mode namespace creation:
1. **Java properties DOCTYPE declaration** — without it the XML parser rejects the document with `SAXParseException: Document root element "properties", must match DOCTYPE root "null"`.
2. **`axiomsClass=NoAxioms` property** — quads mode does not support inference, so the axiom class must be explicitly disabled. Without it: `UnsupportedOperationException: quads does not support inference (axiomsClass)`.
Both errors result in HTTP 500 from Blazegraph, causing `dkg init` with Docker provisioning to fail.
### Found during
RC.12 Blazegraph testnet validation on a fresh Ubuntu 24.04 server with `lyrasis/blazegraph:2.1.5`. The namespace was manually created with the corrected XML to confirm the fix before patching.
### What's fixed
| File | Change |
|------|--------|
| `packages/cli/src/daemon/blazegraph-docker.ts` | Added DOCTYPE declaration and `axiomsClass=NoAxioms` to `BLAZEGRAPH_NAMESPACE_XML_TEMPLATE` |
| `scripts/devnet.sh` | Same fix for the inline namespace creation XML (lines 287–295) |
| `packages/cli/test/blazegraph-docker.test.ts` | Added assertions for DOCTYPE and axiomsClass in the template test |
### Note on devnet.sh
The devnet script had the same bug but it went unnoticed because namespace creation errors are piped to `/dev/null 2>&1` — the script logs "Created Blazegraph namespace" regardless of success. Nodes assigned to Blazegraph in devnet likely fell back to Oxigraph silently.
### Verified
```bash
# Before fix — HTTP 500
curl -s -X POST "http://127.0.0.1:9999/bigdata/namespace" \
  -H "Content-Type: application/xml" \
  -d '<?xml version="1.0" encoding="UTF-8"?><properties>...</properties>'
# After fix — CREATED
curl -s -X POST "http://127.0.0.1:9999/bigdata/namespace" \
  -H "Content-Type: application/xml" \
  -d '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
<properties>
  ...
  <entry key="com.bigdata.rdf.store.AbstractTripleStore.axiomsClass">com.bigdata.rdf.axioms.NoAxioms</entry>
</properties>'