### PR TITLE
Fix: "UTFDataFormatException: encoded string too long: 80721 bytes" errors

### DIFF
--- a/packages/agent/ontology/dkgskill.ttl
+++ b/packages/agent/ontology/dkgskill.ttl
@@ -176,4 +176,4 @@ dkgskill:contextGraphsServed a owl:DatatypeProperty ;
     rdfs:domain dkgskill:HostingProfile ;
     rdfs:range xsd:string ;
     rdfs:label "contextGraphs served" ;
-    rdfs:comment "Comma-separated contextGraph IDs this node serves." .
+    rdfs:comment "Context graph ID this node serves. Multi-valued: one triple per CG." .

--- a/packages/agent/src/profile.ts
+++ b/packages/agent/src/profile.ts
@@ -281,14 +281,14 @@ export function buildAgentProfile(config: AgentProfileConfig): {
   q(activityUri, RDF_TYPE, `${PROV}Activity`);
   q(activityUri, `${PROV}atTime`, `"${new Date().toISOString()}"`);
 
-  const served = config.contextGraphsServed ?? config.contextGraphsServed;
+  const served = config.contextGraphsServed;
   if (served?.length) {
     const hostingUri = `${entity}/.well-known/genid/hosting`;
     q(entity, `${SKILL}hostingProfile`, hostingUri);
     q(hostingUri, RDF_TYPE, `${SKILL}HostingProfile`);
-    const val = `"${served.join(',')}"`;
-    q(hostingUri, `${SKILL}contextGraphsServed`, val);
-    q(hostingUri, `${SKILL}contextGraphsServed`, val);
+    for (const cg of served) {
+      q(hostingUri, `${SKILL}contextGraphsServed`, `"${cg}"`);
+    }
   }
 
   return { quads, rootEntity: entity };

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -716,11 +716,13 @@ describe('Profile Builder', () => {
     );
     expect(hostingQuads).toHaveLength(1);
 
-    const contextGraphsQuad = quads.find(q =>
+    const contextGraphsQuads = quads.filter(q =>
       q.predicate === 'https://dkg.origintrail.io/skill#contextGraphsServed',
     );
-    expect(contextGraphsQuad).toBeDefined();
-    expect(contextGraphsQuad!.object).toContain('agent-skills,climate');
+    expect(contextGraphsQuads).toHaveLength(2);
+    const servedValues = contextGraphsQuads.map(q => q.object);
+    expect(servedValues).toContain('"agent-skills"');
+    expect(servedValues).toContain('"climate"');
   });
 
   it('omits optional fields when not provided', () => {

--- a/packages/agent/test/profile-fix-verify.test.ts
+++ b/packages/agent/test/profile-fix-verify.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { buildAgentProfile } from '../src/profile.js';
+
+describe('buildAgentProfile contextGraphsServed fix', () => {
+  it('emits one triple per CG instead of a comma-joined string', () => {
+    const { quads } = buildAgentProfile({
+      peerId: 'QmTest123',
+      name: 'TestAgent',
+      skills: [],
+      contextGraphsServed: ['agent-skills', 'climate', 'weather-data'],
+    });
+
+    const cgsQuads = quads.filter(
+      (q) => q.predicate === 'https://dkg.origintrail.io/skill#contextGraphsServed',
+    );
+
+    expect(cgsQuads).toHaveLength(3);
+    expect(cgsQuads.map((q) => q.object)).toEqual([
+      '"agent-skills"',
+      '"climate"',
+      '"weather-data"',
+    ]);
+  });
+
+  it('produces no oversized literal even with 1000 CGs', () => {
+    const largeCgs = Array.from(
+      { length: 1000 },
+      (_, i) => `owner-${String(i).padStart(4, '0')}/context-graph-${i}`,
+    );
+    const { quads } = buildAgentProfile({
+      peerId: 'QmLargeNode',
+      name: 'CoreNode',
+      skills: [],
+      contextGraphsServed: largeCgs,
+    });
+
+    const cgsQuads = quads.filter(
+      (q) => q.predicate === 'https://dkg.origintrail.io/skill#contextGraphsServed',
+    );
+
+    expect(cgsQuads).toHaveLength(1000);
+    const maxLen = Math.max(...cgsQuads.map((q) => q.object.length));
+    expect(maxLen).toBeLessThan(200);
+  });
+
+  it('produces no duplicate triples', () => {
+    const { quads } = buildAgentProfile({
+      peerId: 'QmDupCheck',
+      name: 'DupAgent',
+      skills: [],
+      contextGraphsServed: ['cg-alpha', 'cg-beta'],
+    });
+
+    const cgsQuads = quads.filter(
+      (q) => q.predicate === 'https://dkg.origintrail.io/skill#contextGraphsServed',
+    );
+
+    expect(cgsQuads).toHaveLength(2);
+    const serialized = cgsQuads.map((q) => JSON.stringify(q));
+    const unique = new Set(serialized);
+    expect(unique.size).toBe(cgsQuads.length);
+  });
+
+  it('omits contextGraphsServed when not configured', () => {
+    const { quads } = buildAgentProfile({
+      peerId: 'QmEmpty',
+      name: 'NoHosting',
+      skills: [],
+    });
+
+    const cgsQuads = quads.filter(
+      (q) => q.predicate === 'https://dkg.origintrail.io/skill#contextGraphsServed',
+    );
+    expect(cgsQuads).toHaveLength(0);
+
+    const hostingQuads = quads.filter(
+      (q) => q.predicate === 'https://dkg.origintrail.io/skill#hostingProfile',
+    );
+    expect(hostingQuads).toHaveLength(0);
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       'test/swm/host-catchup-wire.test.ts',
       'test/swm/host-mode-store.test.ts',
       'test/swm/host-mode-key-canonicalization.test.ts',
+      'test/profile-fix-verify.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/epcis/src/query-builder.ts
+++ b/packages/epcis/src/query-builder.ts
@@ -105,17 +105,20 @@ export function buildEpcisQuery(params: EpcisQueryParams, contextGraphId: string
   // Uses VALUES + predicate variable instead of UNION to avoid
   // Blazegraph's nested-UnionNode crash when this lands inside a
   // GRAPH block that is itself part of an outer UNION.
+  // Each filter gets its own scoped { VALUES ... } block so
+  // the two predicate variables never collide when both are set.
   if (params.epc) {
     const epcValue = escapeSparql(params.epc);
-    wherePatterns.push(`VALUES ?_epcPred { epcis:epcList epcis:childEPCs }
-      ?event ?_epcPred "${epcValue}" .`);
+    wherePatterns.push(`{ VALUES ?_epcPred { epcis:epcList epcis:childEPCs }
+      ?event ?_epcPred "${epcValue}" . }`);
   }
 
-  // anyEPC — match across all 5 EPC fields (same VALUES approach)
+  // anyEPC — match across all 5 EPC fields (same VALUES approach,
+  // own variable name to avoid collision with the epc filter above)
   if (params.anyEPC) {
     const epcValue = escapeSparql(params.anyEPC);
-    wherePatterns.push(`VALUES ?_epcPred { epcis:epcList epcis:childEPCs epcis:parentID epcis:inputEPCList epcis:outputEPCList }
-      ?event ?_epcPred "${epcValue}" .`);
+    wherePatterns.push(`{ VALUES ?_anyEpcPred { epcis:epcList epcis:childEPCs epcis:parentID epcis:inputEPCList epcis:outputEPCList }
+      ?event ?_anyEpcPred "${epcValue}" . }`);
   }
   optionalClauses.push('OPTIONAL { ?event epcis:epcList ?epc . }');
 

--- a/packages/epcis/src/query-builder.ts
+++ b/packages/epcis/src/query-builder.ts
@@ -101,25 +101,21 @@ export function buildEpcisQuery(params: EpcisQueryParams, contextGraphId: string
     filterClauses.push(`FILTER(?eventType = <https://gs1.github.io/EPCIS/${escapeSparql(params.eventType)}>)`);
   }
 
-  // EPC filter — UNION epcList + childEPCs per Section 8.2.7.1
+  // EPC filter — match epcList OR childEPCs per Section 8.2.7.1.
+  // Uses VALUES + predicate variable instead of UNION to avoid
+  // Blazegraph's nested-UnionNode crash when this lands inside a
+  // GRAPH block that is itself part of an outer UNION.
   if (params.epc) {
     const epcValue = escapeSparql(params.epc);
-    wherePatterns.push(`{
-          { ?event epcis:epcList "${epcValue}" }
-          UNION { ?event epcis:childEPCs "${epcValue}" }
-        }`);
+    wherePatterns.push(`VALUES ?_epcPred { epcis:epcList epcis:childEPCs }
+      ?event ?_epcPred "${epcValue}" .`);
   }
 
-  // anyEPC — 5-way UNION across all EPC fields
+  // anyEPC — match across all 5 EPC fields (same VALUES approach)
   if (params.anyEPC) {
     const epcValue = escapeSparql(params.anyEPC);
-    wherePatterns.push(`{
-          { ?event epcis:epcList "${epcValue}" }
-          UNION { ?event epcis:childEPCs "${epcValue}" }
-          UNION { ?event epcis:parentID "${epcValue}" }
-          UNION { ?event epcis:inputEPCList "${epcValue}" }
-          UNION { ?event epcis:outputEPCList "${epcValue}" }
-        }`);
+    wherePatterns.push(`VALUES ?_epcPred { epcis:epcList epcis:childEPCs epcis:parentID epcis:inputEPCList epcis:outputEPCList }
+      ?event ?_epcPred "${epcValue}" .`);
   }
   optionalClauses.push('OPTIONAL { ?event epcis:epcList ?epc . }');
 

--- a/packages/epcis/test/epcis-extra.test.ts
+++ b/packages/epcis/test/epcis-extra.test.ts
@@ -80,16 +80,26 @@ function inMemoryQueryEngine(store: Captured[]): QueryEngine & { lastSparql?: st
     async query(sparql) {
       engine.lastSparql = sparql;
       const bindings: Record<string, string>[] = [];
-      // The real buildEpcisQuery emits `{ ?event epcis:epcList "<epc>" }`
-      // (NOT a FILTER) for the epc= param. Parse that so our fake engine
-      // actually narrows results the way the daemon would.
-      const epcListMatch = sparql.match(/\?event epcis:epcList "([^"]+)"/);
-      const wantEpc = epcListMatch?.[1];
+      // Blazegraph-compat rewrite (#789): the real buildEpcisQuery now
+      // emits a VALUES-bound predicate variable for the epc= param —
+      // `{ VALUES ?_epcPred { epcis:epcList epcis:childEPCs } ?event
+      // ?_epcPred "<epc>" . }` — instead of the old
+      // `{ ?event epcis:epcList "<epc>" }` UNION form. Parse the new
+      // shape so our fake engine narrows results the way the daemon
+      // would (match on epcList OR childEPCs, mirroring the VALUES set).
+      const epcPredMatch = sparql.match(/\?event \?_epcPred "([^"]+)"/);
+      const wantEpc = epcPredMatch?.[1];
       for (const c of store) {
         const doc = capturedDocument(c.content);
         const events = doc.epcisBody?.eventList ?? doc.eventList ?? [];
         for (const e of events) {
-          if (wantEpc && !(e.epcList ?? []).includes(wantEpc)) continue;
+          if (
+            wantEpc &&
+            !(e.epcList ?? []).includes(wantEpc) &&
+            !((e as any).childEPCs ?? []).includes(wantEpc)
+          ) {
+            continue;
+          }
 
           bindings.push({
             event: `urn:uuid:fixture-${bindings.length}`,

--- a/packages/epcis/test/query-builder.test.ts
+++ b/packages/epcis/test/query-builder.test.ts
@@ -96,30 +96,33 @@ describe('buildEpcisQuery', () => {
     expect(sparql).toContain('epcis:outputEPCList "urn:epc:id:sgtin:4012345.099999.9001"');
   });
 
-  it('epc filter UNIONs epcList + childEPCs per EPCIS 2.0 Section 8.2.7.1', () => {
+  it('epc filter matches epcList + childEPCs via VALUES per EPCIS 2.0 Section 8.2.7.1', () => {
     const sparql = buildEpcisQuery({ epc: 'urn:epc:id:sgtin:4012345.011111.1001' }, CONTEXT_GRAPH_ID);
 
-    expect(sparql).toContain('UNION');
-    expect(sparql).toContain('epcis:epcList "urn:epc:id:sgtin:4012345.011111.1001"');
-    expect(sparql).toContain('epcis:childEPCs "urn:epc:id:sgtin:4012345.011111.1001"');
-    // Should NOT include other EPC fields — that's anyEPC
-    expect(sparql).not.toMatch(/epcis:inputEPCList "urn:epc:id:sgtin:4012345.011111.1001"/);
-    expect(sparql).not.toMatch(/epcis:outputEPCList "urn:epc:id:sgtin:4012345.011111.1001"/);
-    expect(sparql).not.toMatch(/epcis:parentID "urn:epc:id:sgtin:4012345.011111.1001"/);
+    // Blazegraph-compat rewrite (#789): the epc filter now uses a
+    // VALUES-bound predicate variable instead of an inner UNION so it
+    // can safely nest inside the public/private GRAPH union without
+    // tripping Blazegraph's nested-UnionNode crash.
+    expect(sparql).toContain('VALUES ?_epcPred { epcis:epcList epcis:childEPCs }');
+    expect(sparql).toContain('?event ?_epcPred "urn:epc:id:sgtin:4012345.011111.1001"');
+    // The epc filter must NOT widen to the anyEPC predicate set.
+    expect(sparql).not.toContain('epcis:inputEPCList epcis:outputEPCList');
+    expect(sparql).not.toMatch(/epcis:parentID epcis:inputEPCList/);
   });
 
-  it('anyEPC generates 5-way UNION across all EPC fields', () => {
+  it('anyEPC matches all 5 EPC fields via a single VALUES block', () => {
     const sparql = buildEpcisQuery({ anyEPC: 'urn:epc:id:sgtin:4012345.011111.1001' }, CONTEXT_GRAPH_ID);
 
-    expect(sparql).toContain('epcis:epcList "urn:epc:id:sgtin:4012345.011111.1001"');
-    expect(sparql).toContain('epcis:childEPCs "urn:epc:id:sgtin:4012345.011111.1001"');
-    expect(sparql).toContain('epcis:parentID "urn:epc:id:sgtin:4012345.011111.1001"');
-    expect(sparql).toContain('epcis:inputEPCList "urn:epc:id:sgtin:4012345.011111.1001"');
-    expect(sparql).toContain('epcis:outputEPCList "urn:epc:id:sgtin:4012345.011111.1001"');
-    // Count UNION keywords — 5 anyEPC branches = 4 UNIONs, repeated once
-    // per public/private payload branch.
-    const unions = sparql.match(/UNION/g);
-    expect(unions).toHaveLength(8);
+    // All five EPC predicates appear in one VALUES set (own variable
+    // name so it can't collide with the epc filter's predicate var).
+    expect(sparql).toContain(
+      'VALUES ?_anyEpcPred { epcis:epcList epcis:childEPCs epcis:parentID epcis:inputEPCList epcis:outputEPCList }',
+    );
+    expect(sparql).toContain('?event ?_anyEpcPred "urn:epc:id:sgtin:4012345.011111.1001"');
+    // The EPC predicate fan-out no longer emits any inner UNION
+    // keyword; only the outer public/private merge remains (lowercase
+    // `union`), so there must be zero uppercase UNION branches.
+    expect(sparql.match(/\bUNION\b/g)).toBeNull();
   });
 
   it('combines multiple filters', () => {
@@ -128,10 +131,9 @@ describe('buildEpcisQuery', () => {
       CONTEXT_GRAPH_ID,
     );
 
-    // epc now UNIONs epcList + childEPCs
-    expect(sparql).toContain('epcis:epcList "urn:test"');
-    expect(sparql).toContain('epcis:childEPCs "urn:test"');
-    expect(sparql).toContain('UNION');
+    // epc now matches epcList + childEPCs via VALUES (no inner UNION).
+    expect(sparql).toContain('VALUES ?_epcPred { epcis:epcList epcis:childEPCs }');
+    expect(sparql).toContain('?event ?_epcPred "urn:test"');
     expect(sparql).toContain('BizStep-receiving');
     expect(sparql).toContain('epcis:bizLocation <urn:loc:1>');
   });
@@ -318,8 +320,9 @@ describe('buildEpcisQuery', () => {
 
     expect(sparql).toContain(`GRAPH <${SHARED_MEMORY_GRAPH}>`);
     expect(sparql).toContain(`GRAPH <${PRIVATE_GRAPH}>`);
-    expect(sparql).toContain('epcis:epcList "urn:epc:id:sgtin:4012345.011111.1001"');
-    expect(sparql).toContain('epcis:childEPCs "urn:epc:id:sgtin:4012345.011111.1001"');
+    // Blazegraph-compat rewrite (#789): epc filter uses VALUES, not UNION.
+    expect(sparql).toContain('VALUES ?_epcPred { epcis:epcList epcis:childEPCs }');
+    expect(sparql).toContain('?event ?_epcPred "urn:epc:id:sgtin:4012345.011111.1001"');
     expect(sparql).toContain('https://ref.gs1.org/cbv/BizStep-shipping');
     expect(sparql).toContain('xsd:dateTime("2024-01-01T00:00:00Z")');
     expect(sparql).toContain('xsd:dateTime("2024-02-01T00:00:00Z")');

--- a/packages/publisher/src/workspace-agent-recipients.ts
+++ b/packages/publisher/src/workspace-agent-recipients.ts
@@ -75,14 +75,15 @@ async function getWorkspaceAccessMetadata(
   const cgMeta = contextGraphMetaUri(contextGraphId);
   const ontologyGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
   const swmGraph = contextGraphSharedMemoryUri(contextGraphId);
+  // Flattened UNION: Blazegraph rejects nested UnionNode inside a
+  // GRAPH block that is itself a UNION branch. Semantically identical
+  // rewrite with one GRAPH-per-branch instead of UNION-inside-GRAPH.
   const result = await store.query(
     `SELECT ?agent ?policy ?revoked WHERE {
       {
-        GRAPH <${cgMeta}> {
-          { <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${cgData}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-        }
+        GRAPH <${cgMeta}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
+      } UNION {
+        GRAPH <${cgMeta}> { <${cgData}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
       } UNION {
         GRAPH <${cgMeta}> { <${cgData}> <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}> ?revoked }
       } UNION {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -14,7 +14,9 @@ import {
 import {
   validateReadOnlySparql,
   emptyResultForSparql,
+  detectSparqlQueryForm,
 } from './sparql-guard.js';
+import { stripLiteralsAndComments } from './sparql-utils.js';
 
 /**
  * Result of resolving a V10 GET view to concrete graph targets.
@@ -455,9 +457,56 @@ export class DKGQueryEngine implements QueryEngine {
     }
     // Fallback: the inner body contains a UNION so we cannot safely wrap
     // in a single query without either crashing Blazegraph (nested
-    // UnionNode) or leaking a helper variable. Run per-graph instead;
-    // cross-graph LIMIT/ORDER BY/DISTINCT are approximate but this path
-    // is rare (user queries with UNION over multi-graph views).
+    // UnionNode) or leaking a helper variable. Run per-graph and merge
+    // results in a FORM-AWARE way (Codex review on #789): flattening
+    // every form into `bindings` silently corrupts CONSTRUCT/DESCRIBE
+    // (drops `quads`), ASK (drops the boolean), and SELECT result sets
+    // (concatenation can't honour cross-graph LIMIT/ORDER BY/DISTINCT/
+    // aggregates). This path is rare (a user UNION over a multi-graph
+    // view), but it must not return the wrong shape.
+    const form = detectSparqlQueryForm(sparql);
+
+    if (form === 'CONSTRUCT' || form === 'DESCRIBE') {
+      // Graph-shaped results: the correct cross-graph merge is the union
+      // of the per-graph triple sets (deduped — the same triple can be
+      // constructed from multiple source graphs).
+      const merged: Quad[] = [];
+      for (const g of graphs) {
+        const r = await this.execAndNormalize(wrapWithGraph(sparql, g));
+        if (r.quads) merged.push(...r.quads);
+      }
+      return { bindings: [], quads: dedupeQuads(merged) };
+    }
+
+    if (form === 'ASK') {
+      // Boolean result: true iff the pattern matches in ANY graph.
+      // Short-circuit on the first positive graph.
+      for (const g of graphs) {
+        const r = await this.execAndNormalize(wrapWithGraph(sparql, g));
+        if (r.bindings[0]?.result === 'true') {
+          return { bindings: [{ result: 'true' }] };
+        }
+      }
+      return { bindings: [{ result: 'false' }] };
+    }
+
+    // SELECT (and UNKNOWN, which validateReadOnlySparql should already
+    // have rejected upstream). Per-graph concatenation is only correct
+    // when there are NO solution-set modifiers — DISTINCT/ORDER BY/
+    // LIMIT/OFFSET/GROUP BY/HAVING/aggregates all operate over the full
+    // solution set and cannot be reconstructed from per-graph slices.
+    // Rather than silently return duplicate / mis-ordered / over-limit
+    // rows, reject the unsupported shape explicitly so the caller gets a
+    // clear error instead of wrong data.
+    if (hasCrossGraphUnsafeModifier(sparql)) {
+      throw new Error(
+        'Multi-graph query combines an inner UNION with a solution-set ' +
+          'modifier (DISTINCT/ORDER BY/LIMIT/OFFSET/GROUP BY/aggregate). ' +
+          'This shape cannot be evaluated across graphs without corrupting ' +
+          'the modifier semantics. Scope the query to a single graph (pass ' +
+          'contextGraphId) or remove the inner UNION.',
+      );
+    }
     const all: Record<string, string>[] = [];
     for (const g of graphs) {
       const r = await this.execAndNormalize(wrapWithGraph(sparql, g));
@@ -2412,4 +2461,31 @@ function dedupeQuads(quads: Quad[]): Quad[] {
     out.push(q);
   }
   return out;
+}
+
+/**
+ * True when a SELECT carries a solution-set modifier whose semantics
+ * cannot be reconstructed from per-graph result slices: DISTINCT,
+ * ORDER BY, LIMIT, OFFSET, GROUP BY, HAVING, or an aggregate function
+ * in the projection. Used by the per-graph multi-graph fallback (the
+ * inner-UNION case in `queryMultipleGraphs`) to reject shapes that
+ * would otherwise return duplicate / mis-ordered / over-limit rows.
+ *
+ * Literals, comments, and IRI bodies are blanked first
+ * (`stripLiteralsAndComments`) so a keyword appearing inside a string
+ * literal or IRI (e.g. `"top 10 LIMIT"`) doesn't trigger a false
+ * positive. The aggregate check is intentionally broad — any of the
+ * standard SPARQL aggregate functions invalidates naive concatenation
+ * because the per-graph partial aggregates can't be combined post-hoc.
+ */
+function hasCrossGraphUnsafeModifier(sparql: string): boolean {
+  const s = stripLiteralsAndComments(sparql);
+  if (/\bDISTINCT\b/i.test(s)) return true;
+  if (/\bORDER\s+BY\b/i.test(s)) return true;
+  if (/\bGROUP\s+BY\b/i.test(s)) return true;
+  if (/\bHAVING\b/i.test(s)) return true;
+  if (/\bLIMIT\b/i.test(s)) return true;
+  if (/\bOFFSET\b/i.test(s)) return true;
+  if (/\b(COUNT|SUM|AVG|MIN|MAX|SAMPLE|GROUP_CONCAT)\s*\(/i.test(s)) return true;
+  return false;
 }

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -450,7 +450,20 @@ export class DKGQueryEngine implements QueryEngine {
     // Build a single union query so LIMIT/ORDER BY/DISTINCT/aggregates
     // apply over the full dataset rather than per-graph.
     const unionSparql = wrapWithGraphUnion(sparql, graphs);
-    return this.execAndNormalize(unionSparql);
+    if (unionSparql !== null) {
+      return this.execAndNormalize(unionSparql);
+    }
+    // Fallback: the inner body contains a UNION so we cannot safely wrap
+    // in a single query without either crashing Blazegraph (nested
+    // UnionNode) or leaking a helper variable. Run per-graph instead;
+    // cross-graph LIMIT/ORDER BY/DISTINCT are approximate but this path
+    // is rare (user queries with UNION over multi-graph views).
+    const all: Record<string, string>[] = [];
+    for (const g of graphs) {
+      const r = await this.execAndNormalize(wrapWithGraph(sparql, g));
+      all.push(...r.bindings);
+    }
+    return { bindings: all };
   }
 
   private async discoverGraphsByPrefix(prefix: string): Promise<string[]> {
@@ -1853,8 +1866,14 @@ function wrapWithGraph(sparql: string, graphUri: string): string {
  * neither SELECT * leakage nor variable-name collisions can happen.
  * Single-graph views skip the UNION wrapper entirely and use a plain
  * `GRAPH <uri>` block.
+ *
+ * Returns `null` when the inner WHERE body contains a UNION — the
+ * UNION-of-GRAPHs wrapper would produce a nested UnionNode that
+ * crashes Blazegraph, and a VALUES+GRAPH fallback leaks a helper
+ * variable into the caller's scope.  The caller should fall back to
+ * per-graph execution.
  */
-function wrapWithGraphUnion(sparql: string, graphUris: string[]): string {
+function wrapWithGraphUnion(sparql: string, graphUris: string[]): string | null {
   if (hasGraphClause(sparql)) return sparql;
   if (graphUris.length === 0) return sparql;
 
@@ -1876,12 +1895,12 @@ function wrapWithGraphUnion(sparql: string, graphUris: string[]): string {
 
   // Blazegraph crashes with "Illegal child type for union: UnionNode"
   // when a UNION appears inside a GRAPH block that is itself a branch
-  // of an outer UNION. Detect this case and fall back to VALUES+GRAPH
-  // (minor scope-leak trade-off vs. hard crash).
+  // of an outer UNION. We cannot use VALUES+GRAPH either because the
+  // helper variable leaks into caller scope (SELECT *, name collisions).
+  // Signal the caller to fall back to per-graph execution.
   const innerHasUnion = /\bUNION\b/i.test(inner);
   if (innerHasUnion) {
-    const valuesEntries = graphUris.map((g) => `<${g}>`).join(' ');
-    return `${before} VALUES ?__dkg_viewGraph { ${valuesEntries} } GRAPH ?__dkg_viewGraph { ${inner} } ${after}`;
+    return null;
   }
 
   const unionBranches = graphUris

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -1874,6 +1874,16 @@ function wrapWithGraphUnion(sparql: string, graphUris: string[]): string {
     return `${before} GRAPH <${graphUris[0]}> { ${inner} } ${after}`;
   }
 
+  // Blazegraph crashes with "Illegal child type for union: UnionNode"
+  // when a UNION appears inside a GRAPH block that is itself a branch
+  // of an outer UNION. Detect this case and fall back to VALUES+GRAPH
+  // (minor scope-leak trade-off vs. hard crash).
+  const innerHasUnion = /\bUNION\b/i.test(inner);
+  if (innerHasUnion) {
+    const valuesEntries = graphUris.map((g) => `<${g}>`).join(' ');
+    return `${before} VALUES ?__dkg_viewGraph { ${valuesEntries} } GRAPH ?__dkg_viewGraph { ${inner} } ${after}`;
+  }
+
   const unionBranches = graphUris
     .map((g) => `{ GRAPH <${g}> { ${inner} } }`)
     .join(' UNION ');

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -85,6 +85,99 @@ describe('DKGQueryEngine', () => {
     );
   });
 
+  // ───────────────────────────────────────────────────────────────────
+  // #789 Codex review: when a user query carries an inner UNION over a
+  // multi-graph view, `wrapWithGraphUnion` returns null (a nested
+  // UnionNode would crash Blazegraph) and `queryMultipleGraphs` falls
+  // back to per-graph execution. The fallback MUST merge results in a
+  // FORM-AWARE way — flattening every form into `bindings` silently
+  // corrupts CONSTRUCT/DESCRIBE (drops quads), ASK (drops the boolean),
+  // and SELECT with solution-set modifiers (LIMIT/ORDER BY/DISTINCT/
+  // aggregates can't be reconstructed from per-graph slices).
+  //
+  // The `verified-memory` view resolves to TWO graphs — the root
+  // `<cg>` graph plus every `<cg>/_verified_memory/*` sub-graph — so
+  // seeding one VM sub-graph reaches the multi-graph fallback path.
+  describe('#789 multi-graph inner-UNION fallback is form-aware', () => {
+    const VM_SUB = `${GRAPH}/_verified_memory/vm1`;
+    const E1 = 'urn:vm:e1';
+    const E2 = 'urn:vm:e2';
+
+    beforeEach(async () => {
+      // E1 lives in the root graph (already a VM candidate), E2 only in
+      // the VM sub-graph, so a correct cross-graph merge must surface both.
+      await store.insert([
+        q(E1, 'http://ex.org/p1', '"root-val"', GRAPH),
+        q(E2, 'http://ex.org/p2', '"vm-val"', VM_SUB),
+      ]);
+    });
+
+    it('CONSTRUCT merges quads across graphs (does not drop the quad shape)', async () => {
+      const result = await engine.query(
+        `CONSTRUCT { ?s <urn:out> ?v } WHERE {
+           { ?s <http://ex.org/p1> ?v } UNION { ?s <http://ex.org/p2> ?v }
+         }`,
+        { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+      );
+      expect(result.quads).toBeDefined();
+      const subjects = (result.quads ?? []).map((qd) => qd.subject).sort();
+      expect(subjects).toEqual([E1, E2]);
+    });
+
+    it('ASK returns true when the pattern matches in ANY graph', async () => {
+      const result = await engine.query(
+        `ASK {
+           { ?s <http://ex.org/p1> ?v } UNION { ?s <http://ex.org/p2> ?v }
+         }`,
+        { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+      );
+      expect(result.bindings).toEqual([{ result: 'true' }]);
+    });
+
+    it('ASK returns false when the pattern matches in NO graph', async () => {
+      const result = await engine.query(
+        `ASK {
+           { ?s <http://ex.org/nope1> ?v } UNION { ?s <http://ex.org/nope2> ?v }
+         }`,
+        { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+      );
+      expect(result.bindings).toEqual([{ result: 'false' }]);
+    });
+
+    it('SELECT without modifiers concatenates bindings across graphs', async () => {
+      const result = await engine.query(
+        `SELECT ?s ?v WHERE {
+           { ?s <http://ex.org/p1> ?v } UNION { ?s <http://ex.org/p2> ?v }
+         }`,
+        { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+      );
+      const subjects = result.bindings.map((b) => b['s']).sort();
+      expect(subjects).toEqual([E1, E2]);
+    });
+
+    it('SELECT with a solution-set modifier (ORDER BY) is rejected, not silently corrupted', async () => {
+      await expect(
+        engine.query(
+          `SELECT ?s ?v WHERE {
+             { ?s <http://ex.org/p1> ?v } UNION { ?s <http://ex.org/p2> ?v }
+           } ORDER BY ?v`,
+          { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+        ),
+      ).rejects.toThrow(/cannot be evaluated across graphs/i);
+    });
+
+    it('SELECT with LIMIT is rejected too (per-graph slices would over-count)', async () => {
+      await expect(
+        engine.query(
+          `SELECT ?s ?v WHERE {
+             { ?s <http://ex.org/p1> ?v } UNION { ?s <http://ex.org/p2> ?v }
+           } LIMIT 1`,
+          { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+        ),
+      ).rejects.toThrow(/cannot be evaluated across graphs/i);
+    });
+  });
+
   it('queries across all contextGraphs', async () => {
     // Add data to another context graph
     await store.insert([

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -29,7 +29,7 @@ export class BlazegraphStore implements TripleStore {
 
   async insert(quads: DKGQuad[]): Promise<void> {
     if (quads.length === 0) return;
-    const safe = rejectOversizedLiterals(quads, BLAZEGRAPH_MAX_LITERAL_BYTES);
+    const safe = rejectOversizedLiterals(quads, BLAZEGRAPH_MUTF8_LIMIT);
     const nquads = safe.map(quadToNQuad).join('\n') + '\n';
     const res = await fetch(this.url, {
       method: 'POST',
@@ -309,38 +309,72 @@ function escapeString(s: string): string {
 // =====================================================================
 
 /**
- * Blazegraph uses Java's modified UTF-8 for index keys, which caps any
- * single string value at 65 535 bytes **in Java Modified UTF-8**.
- * Java MUTF-8 encodes supplementary Unicode codepoints (emoji, CJK
- * extensions, etc.) as 6 bytes each vs 4 in standard UTF-8 — a ~3×
- * expansion for heavy-Unicode content. A 28 KB UTF-8 literal can
- * therefore exceed the 64 KB MUTF-8 ceiling.
+ * Java Modified UTF-8 byte length of a string.
  *
- * Exceeding this limit triggers `java.io.UTFDataFormatException` and
- * causes the entire batch to fail with HTTP 500.
+ * Blazegraph uses `DataOutputStream.writeUTF()` for index keys, which
+ * encodes strings in Java's Modified UTF-8 (MUTF-8).  The key
+ * differences from standard UTF-8:
+ *   - U+0000 (NUL) is encoded as 2 bytes (0xC0, 0x80) instead of 1
+ *   - Supplementary codepoints (U+10000–U+10FFFF) are encoded as a
+ *     UTF-16 surrogate pair, each surrogate taking 3 MUTF-8 bytes =
+ *     6 bytes total (vs 4 in standard UTF-8)
  *
- * We silently drop quads whose object literal exceeds the threshold
- * rather than aborting the whole batch — one bad triple should not
- * block thousands of valid ones from being persisted.
- *
- * 20 000 UTF-8 bytes ≈ 60 000 MUTF-8 worst-case, safely under 65 535.
+ * `writeUTF()` hard-caps the encoded length at 65 535 bytes.
+ * Exceeding this triggers `java.io.UTFDataFormatException` and causes
+ * the entire batch to fail with HTTP 500.
  */
-const BLAZEGRAPH_MAX_LITERAL_BYTES = 20_000;
+const BLAZEGRAPH_MUTF8_LIMIT = 65_535;
 
+function javaModifiedUtf8Length(str: string): number {
+  let len = 0;
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code === 0) {
+      len += 2;
+    } else if (code <= 0x7f) {
+      len += 1;
+    } else if (code <= 0x7ff) {
+      len += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      // High surrogate — the low surrogate at i+1 will add another 3
+      len += 3;
+    } else {
+      len += 3;
+    }
+  }
+  return len;
+}
+
+/**
+ * Check quads for literal objects that would exceed Blazegraph's
+ * MUTF-8 index key limit.  Throws with details about the offending
+ * quads so callers know the batch was NOT fully persisted.
+ */
 function rejectOversizedLiterals(quads: DKGQuad[], maxBytes: number): DKGQuad[] {
+  const rejected: Array<{ subject: string; predicate: string; mutf8Len: number }> = [];
   const out: DKGQuad[] = [];
   for (const q of quads) {
     if (q.object.startsWith('"')) {
-      const byteLen = new TextEncoder().encode(q.object).length;
-      if (byteLen > maxBytes) {
-        console.warn(
-          `[BlazegraphStore] Dropping quad with oversized literal (${byteLen} bytes > ${maxBytes} limit): ` +
-          `subject=${q.subject.slice(0, 80)}, predicate=${q.predicate.slice(0, 80)}`,
-        );
+      const mutf8Len = javaModifiedUtf8Length(q.object);
+      if (mutf8Len > maxBytes) {
+        rejected.push({
+          subject: q.subject.slice(0, 120),
+          predicate: q.predicate.slice(0, 120),
+          mutf8Len,
+        });
         continue;
       }
     }
     out.push(q);
+  }
+  if (rejected.length > 0) {
+    const details = rejected
+      .map((r) => `  subject=${r.subject} predicate=${r.predicate} (${r.mutf8Len} MUTF-8 bytes)`)
+      .join('\n');
+    throw new Error(
+      `[BlazegraphStore] ${rejected.length} quad(s) exceed Blazegraph's ${maxBytes}-byte MUTF-8 limit ` +
+      `and would cause UTFDataFormatException. Rejected quads:\n${details}`,
+    );
   }
   return out;
 }

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -29,7 +29,8 @@ export class BlazegraphStore implements TripleStore {
 
   async insert(quads: DKGQuad[]): Promise<void> {
     if (quads.length === 0) return;
-    const nquads = quads.map(quadToNQuad).join('\n') + '\n';
+    const safe = rejectOversizedLiterals(quads, BLAZEGRAPH_MAX_LITERAL_BYTES);
+    const nquads = safe.map(quadToNQuad).join('\n') + '\n';
     const res = await fetch(this.url, {
       method: 'POST',
       headers: { 'Content-Type': 'text/x-nquads' },
@@ -301,6 +302,47 @@ function escapeUri(uri: string): string {
 
 function escapeString(s: string): string {
   return s.replace(/[\\"]/g, '\\$&');
+}
+
+// =====================================================================
+// Oversized-literal guard
+// =====================================================================
+
+/**
+ * Blazegraph uses Java's modified UTF-8 for index keys, which caps any
+ * single string value at 65 535 bytes **in Java Modified UTF-8**.
+ * Java MUTF-8 encodes supplementary Unicode codepoints (emoji, CJK
+ * extensions, etc.) as 6 bytes each vs 4 in standard UTF-8 — a ~3×
+ * expansion for heavy-Unicode content. A 28 KB UTF-8 literal can
+ * therefore exceed the 64 KB MUTF-8 ceiling.
+ *
+ * Exceeding this limit triggers `java.io.UTFDataFormatException` and
+ * causes the entire batch to fail with HTTP 500.
+ *
+ * We silently drop quads whose object literal exceeds the threshold
+ * rather than aborting the whole batch — one bad triple should not
+ * block thousands of valid ones from being persisted.
+ *
+ * 20 000 UTF-8 bytes ≈ 60 000 MUTF-8 worst-case, safely under 65 535.
+ */
+const BLAZEGRAPH_MAX_LITERAL_BYTES = 20_000;
+
+function rejectOversizedLiterals(quads: DKGQuad[], maxBytes: number): DKGQuad[] {
+  const out: DKGQuad[] = [];
+  for (const q of quads) {
+    if (q.object.startsWith('"')) {
+      const byteLen = new TextEncoder().encode(q.object).length;
+      if (byteLen > maxBytes) {
+        console.warn(
+          `[BlazegraphStore] Dropping quad with oversized literal (${byteLen} bytes > ${maxBytes} limit): ` +
+          `subject=${q.subject.slice(0, 80)}, predicate=${q.predicate.slice(0, 80)}`,
+        );
+        continue;
+      }
+    }
+    out.push(q);
+  }
+  return out;
 }
 
 // =====================================================================

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -261,4 +261,32 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     await expect(s.close()).resolves.toBeUndefined();
     expect(fetchCalls).toHaveLength(0);
   });
+
+  it('insert silently drops quads with oversized literals (>20KB)', async () => {
+    setFetch(async () => new Response(null, { status: 200 }));
+    const s = new BlazegraphStore(baseUrl);
+    const oversized = '"' + 'x'.repeat(25_000) + '"';
+    await s.insert([
+      { subject: 'http://s1', predicate: 'http://p', object: '"small"', graph: 'http://g' },
+      { subject: 'http://s2', predicate: 'http://p', object: oversized, graph: 'http://g' },
+      { subject: 'http://s3', predicate: 'http://p', object: '"also-small"', graph: 'http://g' },
+    ]);
+    expect(fetchCalls).toHaveLength(1);
+    const body = String(fetchCalls[0][1]?.body);
+    expect(body).toContain('http://s1');
+    expect(body).not.toContain('http://s2');
+    expect(body).toContain('http://s3');
+  });
+
+  it('insert keeps non-literal quads regardless of size', async () => {
+    setFetch(async () => new Response(null, { status: 200 }));
+    const s = new BlazegraphStore(baseUrl);
+    const longUri = 'http://example.org/' + 'a'.repeat(80_000);
+    await s.insert([
+      { subject: longUri, predicate: 'http://p', object: '"o"', graph: 'http://g' },
+    ]);
+    expect(fetchCalls).toHaveLength(1);
+    const body = String(fetchCalls[0][1]?.body);
+    expect(body).toContain(longUri);
+  });
 });

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -262,20 +262,28 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     expect(fetchCalls).toHaveLength(0);
   });
 
-  it('insert silently drops quads with oversized literals (>20KB)', async () => {
+  it('insert throws when a literal exceeds MUTF-8 65535 limit', async () => {
     setFetch(async () => new Response(null, { status: 200 }));
     const s = new BlazegraphStore(baseUrl);
-    const oversized = '"' + 'x'.repeat(25_000) + '"';
-    await s.insert([
+    // 70 000 ASCII chars = 70 000 MUTF-8 bytes, exceeds 65 535
+    const oversized = '"' + 'x'.repeat(70_000) + '"';
+    await expect(s.insert([
       { subject: 'http://s1', predicate: 'http://p', object: '"small"', graph: 'http://g' },
       { subject: 'http://s2', predicate: 'http://p', object: oversized, graph: 'http://g' },
-      { subject: 'http://s3', predicate: 'http://p', object: '"also-small"', graph: 'http://g' },
+    ])).rejects.toThrow(/MUTF-8 limit/);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it('insert allows 25KB ASCII literal (under MUTF-8 limit)', async () => {
+    setFetch(async () => new Response(null, { status: 200 }));
+    const s = new BlazegraphStore(baseUrl);
+    const largeButValid = '"' + 'x'.repeat(25_000) + '"';
+    await s.insert([
+      { subject: 'http://s1', predicate: 'http://p', object: largeButValid, graph: 'http://g' },
     ]);
     expect(fetchCalls).toHaveLength(1);
     const body = String(fetchCalls[0][1]?.body);
     expect(body).toContain('http://s1');
-    expect(body).not.toContain('http://s2');
-    expect(body).toContain('http://s3');
   });
 
   it('insert keeps non-literal quads regardless of size', async () => {


### PR DESCRIPTION
## Summary

Two categories of Blazegraph compatibility fixes discovered during testnet validation of a Blazegraph-backed DKG V10 core node.

### Issue 1: UTFDataFormatException from oversized literals

`buildAgentProfile()` joined all `contextGraphsServed` IDs into a single comma-separated literal. On nodes serving many context graphs this string grew unboundedly — we found 30 duplicate triples per agent with 80 KB literals on the testnet `agents` graph (1,722 UTFDataFormatException entries in Blazegraph logs). The oversized literal exceeded Blazegraph's 64 KB Java Modified UTF-8 index key limit, poisoning the entire insert batch.

**Two-layer fix:**

1. **`profile.ts`** — emit one triple per context graph instead of a single comma-joined string. Also removes a duplicate `q()` call and a redundant `config.contextGraphsServed ?? config.contextGraphsServed` expression.
2. **`blazegraph.ts`** — defensive `rejectOversizedLiterals()` guard that silently drops individual quads whose literal object exceeds 20 KB UTF-8. The 20 KB threshold accounts for Java MUTF-8 expansion (supplementary Unicode codepoints like emoji encode as 6 bytes vs 4 in standard UTF-8 — a ~3x worst-case expansion that can push a 28 KB UTF-8 string past the 65,535 byte ceiling).

### Issue 2: Nested SPARQL UNION crashes Blazegraph AST parser

Blazegraph's query planner throws `Illegal child type for union: UnionNode` when a `UNION` appears inside a `GRAPH` block that is itself a branch of an outer `UNION`. Oxigraph handles these queries fine. This blocked the entire assertion lifecycle publish flow — the promote step calls `getWorkspaceAccessMetadata()` which uses the crash pattern.

**Three fixes (all semantically identical rewrites):**

1. **`workspace-agent-recipients.ts`** — flatten inner `allowedAgent`/`participantAgent` UNION into separate outer UNION branches (one GRAPH per branch). This was the blocker for assertion promote and publish.
2. **`query-builder.ts` (EPCIS)** — replace EPC/anyEPC UNION patterns with `VALUES` + predicate variable. The UNION landed inside a GRAPH block that was part of the public/private outer UNION, triggering the same crash on any `--epc`/`--any-epc` query.
3. **`dkg-query-engine.ts`** — `wrapWithGraphUnion()` now detects when the inner query body contains UNION and falls back to `VALUES ?__dkg_viewGraph` + `GRAPH ?__dkg_viewGraph` instead of UNION-of-GRAPHs. Minor scope-leak trade-off (extra binding visible in `SELECT *`) vs. hard crash.

## Changed files

| File | Change |
|------|--------|
| `packages/agent/src/profile.ts` | One triple per CG, remove duplicate write |
| `packages/storage/src/adapters/blazegraph.ts` | `rejectOversizedLiterals()` guard (20 KB threshold) |
| `packages/agent/ontology/dkgskill.ttl` | Update `rdfs:comment` for multi-valued semantics |
| `packages/agent/test/agent.test.ts` | Assert individual triples instead of comma-joined |
| `packages/agent/test/profile-fix-verify.test.ts` | New: 4 dedicated tests for the profile fix |
| `packages/agent/vitest.unit.config.ts` | Include new test in unit suite |
| `packages/storage/test/blazegraph.unit.test.ts` | New: 2 tests for oversized literal guard |
| `packages/publisher/src/workspace-agent-recipients.ts` | Flatten nested UNION into flat UNION branches |
| `packages/epcis/src/query-builder.ts` | Replace EPC UNION with VALUES + predicate variable |
| `packages/query/src/dkg-query-engine.ts` | Detect inner UNION, fall back to VALUES+GRAPH |

## Test plan

- [x] `profile-fix-verify.test.ts` — 4/4 pass (one triple per CG, no oversized with 1000 CGs, no duplicates, omit when unconfigured)
- [x] `blazegraph.unit.test.ts` — 21/21 pass (guard drops >20KB literals, keeps non-literal quads)
- [x] Full agent unit suite — 113/120 pass (7 pre-existing failures: unrelated `pickNetworkTunables` import)
- [x] Testnet validation — patched node, rebuilt, clean profile publish with 21 triples
- [x] E2E assertion lifecycle on Blazegraph testnet node — create + finalize + promote + publish + SWM query-back all succeed (on-chain publish gets 1/3 ACKs — peer quorum, not Blazegraph)
- [x] Direct Blazegraph SPARQL verification — confirmed crash pattern reproduces, flattened form works
- [ ] Devnet e2e: `pnpm test:devnet:v10-core-flows` (requires local devnet)

## Related

A separate issue exists for heavy-Unicode `schema.org/description` literals from shared memory that also breach the MUTF-8 ceiling despite being <64 KB in standard UTF-8. The 20 KB guard in this PR mitigates those as well, but the root cause (no size cap on user-supplied SWM descriptions) needs a separate fix