### PR TITLE
fix(cli): improve Blazegraph store selection UX in dkg init

### DIFF
--- a/packages/cli/src/daemon/blazegraph-docker.ts
+++ b/packages/cli/src/daemon/blazegraph-docker.ts
@@ -219,7 +219,7 @@ async function findFreePort(
 ): Promise<number> {
   for (let p = start; p < start + range; p++) {
     if (await isPortFree(p)) {
-      if (p !== start) log(`  Port ${start} taken; using ${p} instead.`);
+      if (p !== start) log(`  Port ${start} is in use (another Blazegraph or service?). Using port ${p} instead.`);
       return p;
     }
   }

--- a/packages/cli/src/store-wizard.ts
+++ b/packages/cli/src/store-wizard.ts
@@ -127,14 +127,22 @@ export async function promptStoreBackend(
   const defaultBackend = opts.flagBackend
     ?? (existingBackend === 'blazegraph' || existingBackend === 'sparql-http' ? existingBackend : 'oxigraph');
 
-  const backendAnswer = (await opts.ask(
-    'Triple store backend (oxigraph / blazegraph)',
-    defaultBackend,
-  )).toLowerCase();
+  const backendChoices = ['oxigraph', 'blazegraph'] as const;
+  const defaultIdx = Math.max(0, backendChoices.indexOf(defaultBackend as typeof backendChoices[number]));
+  log('  Triple store backend:');
+  for (let i = 0; i < backendChoices.length; i++) {
+    log(`    ${i + 1}) ${backendChoices[i]}`);
+  }
+  const backendInput = (await opts.ask(
+    `Choose (1-${backendChoices.length})`,
+    String(defaultIdx + 1),
+  )).trim();
 
-  // Normalise: anything that isn't a known external alias falls back to
-  // the local default. We accept the internal alias `oxigraph-worker`
-  // for power users but don't advertise it.
+  // Accept both the number ("1", "2") and the name ("blazegraph")
+  const backendAnswer = /^\d+$/.test(backendInput)
+    ? (backendChoices[parseInt(backendInput, 10) - 1] ?? 'oxigraph')
+    : backendInput.toLowerCase();
+
   if (backendAnswer !== 'blazegraph' && backendAnswer !== 'sparql-http') {
     return { storeBlock: null };
   }
@@ -146,7 +154,7 @@ export async function promptStoreBackend(
     const defaultUrl = opts.flagUrl ?? existingUrl;
     const url = (await opts.ask(
       backend === 'blazegraph'
-        ? 'Blazegraph SPARQL endpoint URL'
+        ? 'Blazegraph SPARQL endpoint URL (leave empty to auto-provision via Docker)'
         : 'SPARQL query endpoint URL',
       defaultUrl,
     )).trim();
@@ -160,7 +168,7 @@ export async function promptStoreBackend(
         const dockerOk = await probeDocker();
         if (dockerOk) {
           const yes = (await opts.ask(
-            'No URL provided. Provision a Blazegraph container via Docker? (y/n)',
+            'Provision a Blazegraph container via Docker? (y/n)',
             'y',
           )).toLowerCase();
           if (yes !== 'n') {
@@ -188,8 +196,11 @@ export async function promptStoreBackend(
             }
           }
         } else {
-          log('  Docker not detected on PATH. Install Docker Desktop or the Docker Engine');
-          log('  to use the convenience path, or provide a URL to an existing instance.');
+          log('');
+          log('  Docker is not installed on this system.');
+          log('  Install Docker to auto-provision Blazegraph, or start it manually');
+          log('  and enter its SPARQL endpoint URL below.');
+          log('');
         }
       }
       const retry = (await opts.ask('Retry with a URL? (y/n)', 'y')).toLowerCase();


### PR DESCRIPTION
## Summary
- Replace free-text "Triple store backend (oxigraph / blazegraph)" prompt with a numbered menu — users pick `1` or `2` instead of typing the full name (still accepts names for scripts/power users)
- URL prompt now hints that leaving it empty auto-provisions via Docker
- Friendlier message when Docker is not installed (no external URLs that could drift)
- Clearer port-bump log when default port 9999 is already occupied
## Before / After
**Before:**
Triple store backend (oxigraph / blazegraph) (oxigraph): blazegraph Blazegraph SPARQL endpoint URL: No URL provided. Provision a Blazegraph container via Docker? (y/n) (y):

**After:**
Triple store backend: 1) oxigraph 2) blazegraph Choose (1-2) (1): 2 Blazegraph SPARQL endpoint URL (leave empty to auto-provision via Docker): Provision a Blazegraph container via Docker? (y/n) (y):


## Changed files
| File | Change |
|------|--------|
| `packages/cli/src/store-wizard.ts` | Numbered menu, hint text, Docker-missing message |
| `packages/cli/src/daemon/blazegraph-docker.ts` | Clearer port-bump log message |
## Test plan
- No test assertions on prompt wording (tests mock `log: () => {}`)
- Manual verification via `dkg init` on a fresh node