### PR TITLE
chore(node-ui): S3 polish — vocab + cross-layer pills + mini-graph colors + dedupe

### DIFF
--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -62,8 +62,7 @@ export interface SubGraphBarProps {
    *   • size 1 → single-layer slice (matches the legacy `layer`)
    *   • size 2 → narrowed across 2 layers
    *   • size 3 → semantically all-three, treated as layer-agnostic
-   *     for the `inLayerMode` discriminant (the #7 hint / Bug K
-   *     rephrase / tooltip-branch logic stays at "no narrowing")
+   *     (no narrowing — `allowedTrustLevels` collapses to null)
    *
    * Always trumps `layer` when both are non-empty. Forwarded as
    * a fresh Set on chip click via `originatingScope` — see below.
@@ -146,13 +145,6 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
     if (layer) return new Set<TrustLevel>([LAYER_TRUST_LEVEL[layer]]);
     return null;
   }, [enabledScope, layer]);
-  // `isNarrowed` is true when the bar reports a sliced view (any
-  // non-null `allowedTrustLevels`). Pre-Bug-O this was just
-  // `layer !== undefined`; the Set carrier generalises it for the
-  // multi-layer cases. Drives the #7 / Bug K layer-mode tooltip
-  // branching and the All chip Root-inclusion rule.
-  const isNarrowed = allowedTrustLevels !== null;
-
   // When `entities` is provided we derive per-sub-graph counts locally
   // so the chip count matches what the entity list below it shows.
   // Without narrowing, count every entity that belongs to the
@@ -180,31 +172,25 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
   // more sub-graphs (the entity list under us is layer-filtered
   // without sub-graph multiplicity, so the sum disagrees with it).
   //
-  // Layer-scoped semantic differs from layer-agnostic semantic:
-  //   • Layer mode (WM/SWM/VM page): "All" should match the layer tab
-  //     badge — every distinct entity at that layer, including
-  //     root-bucket SWM entities whose graph URI is
-  //     `<cg>/_shared_memory` (subGraphOf filters underscore-prefixed
-  //     segments, leaving an empty `subGraphs` set). Without them
-  //     "All" undercut the badge (e.g. 25 vs 27) and confused users.
-  //   • Layer-agnostic mode (sub-graph page): "All" is the umbrella
-  //     over named-sub-graph chips, so entities with no chip
-  //     membership stay excluded — including them would inflate the
-  //     total past anything the user can drill into by clicking a chip.
+  // Round 4 (ux-lead reversal of §4.4.1): every distinct entity in
+  // scope is counted — including root-bucket entities — in BOTH
+  // layer and layer-agnostic modes. The earlier "All is the umbrella
+  // over drillable chips" carve-out was a pre-Root-chip hypothesis;
+  // once the Root chip shipped (S3 #772) it became drillable too, so
+  // excluding root from `All` in layer-agnostic mode no longer
+  // reflected the chip row. User manual-test on round 3 surfaced the
+  // contradiction; ux-lead locked option (A) — unify to "always
+  // includes Root" so `All` matches the layer-tab badge in narrowed
+  // mode AND the Root + named-chip union in layer-agnostic mode.
   const entityScopedAllTotal = React.useMemo(() => {
     if (!entities) return null;
     let n = 0;
     for (const e of entities) {
       if (allowedTrustLevels && !allowedTrustLevels.has(e.trustLevel)) continue;
-      // Layer-agnostic mode (no narrowing) excludes root entities
-      // by design — `All` is the umbrella over named-sub-graph
-      // chips. In layer / narrowed mode root entities are
-      // included so the total matches the layer-tab badge.
-      if (!isNarrowed && e.subGraphs.size === 0) continue;
       n++;
     }
     return n;
-  }, [allowedTrustLevels, isNarrowed, entities]);
+  }, [allowedTrustLevels, entities]);
 
   // S3 fold-in: the synthesized "Root" bucket is "all entities minus
   // those in any named sub-graph". Computed from the same entity list
@@ -302,29 +288,15 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
     : null;
   const scopeSuffix = layerLabel ? ` in ${layerLabel}` : '';
 
-  // S3 polish #7 — the `All` semantic differs between narrowed
-  // and layer-agnostic mode (see `entityScopedAllTotal` for the
-  // locked rule):
-  //   • Narrowed (WM/SWM/VM or a multi-layer slice): All includes
-  //     root-bucket entities so it matches the layer-tab badge.
-  //   • Layer-agnostic mode (Subgraph Explorer overview): All
-  //     EXCLUDES root by design — it's the umbrella over named
-  //     sub-graph chips; including root would inflate the total
-  //     past anything the user can drill into.
-  // Surface different tooltip / aria-label / inline hint copy on
-  // each mode so the math reads consistently with the chip count.
-  // (PR #793 Codex sweep 1 — gating fix.)
-  const inLayerMode = isNarrowed;
-  // Round 3 (ux-lead lock): "distinct" prefix added to both mode
-  // tooltips to disambiguate that the count reflects unique
-  // entities, not chip-row sum (entities may belong to more than
-  // one named subgraph and would otherwise appear double-counted).
-  const allTooltipCopy = inLayerMode
-    ? `Total distinct entities — includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`
-    : `Total distinct entities in named subgraphs (some may belong to more than one). Root entities are counted separately on the Root chip · ${totalEntities} entities · ${totalTriples} triples`;
-  const allAriaCopy = inLayerMode
-    ? `All — total distinct entities. Includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph. ${totalEntities} entities${scopeSuffix}.`
-    : `All — total distinct entities in named subgraphs (some may belong to more than one). Root entities are counted separately on the Root chip. ${totalEntities} entities.`;
+  // Round 4 (ux-lead reversal of §4.4.1): `All` now always includes
+  // Root — same semantic in narrowed AND layer-agnostic mode — so
+  // the tooltip prose collapses to a single literal. The mode-tagged
+  // branching from sweep 1 / round 3 is gone because the underlying
+  // semantic split is gone. The dynamic suffix still narrows the
+  // count display (`scopeSuffix` for narrowed mode, conditional
+  // triples for layer-agnostic), but the prose stays one shape.
+  const allTooltipCopy = `Total distinct entities — includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`;
+  const allAriaCopy = `All — total distinct entities. Includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph. ${totalEntities} entities${scopeSuffix}.`;
 
   return (
     <div className="v10-subgraph-bar">
@@ -403,9 +375,9 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
           design failed to communicate. Cross-membership
           disclosure now lives ONLY in the long-form All-chip
           tooltip (hover-only, low-cost, right disclosure for
-          users who investigate). The `inLayerMode` discriminator
-          above stays — it still drives the mode-tagged tooltip /
-          aria branching from sweep 1. */}
+          users who investigate). Round 4 collapsed the tooltip
+          to a single literal — the mode discriminator that used
+          to drive sweep-1 / round-3 branching is also gone. */}
     </div>
   );
 };

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -245,7 +245,15 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
         type="button"
         className={`v10-subgraph-chip${selected === null ? ' active' : ''}`}
         onClick={() => onSelect(null)}
-        title={`All subgraphs · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`}
+        /* #7 polish (ux-locked option ii) — long-form tooltip
+           clarifies the All math because `MemoryEntity.subGraphs`
+           is a Set: cross-membership entities count once in `All`
+           but may also appear under multiple chip totals, and
+           Root holds entities in no sub-graph at all. The shorter
+           inline hint after the Root chip carries the same
+           semantic at a glance. */
+        title={`Total entities — includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`}
+        aria-label={`All — total entities. Includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph. ${totalEntities} entities${scopeSuffix}.`}
       >
         <span className="v10-subgraph-chip-icon">⊚</span>
         <span className="v10-subgraph-chip-label">All</span>
@@ -295,6 +303,15 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
           </button>
         );
       })()}
+      {showRootChip && (
+        /* #7 polish (ux-locked). Inline arithmetic-style hint
+           after the Root chip — explains the All math at a
+           glance. Muted tone so it doesn't compete with the
+           chip row; single line, never wraps (CSS). */
+        <span className="v10-subgraph-bar-hint" aria-hidden="true">
+          All = Root + subgraphs
+        </span>
+      )}
     </div>
   );
 };

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -11,7 +11,7 @@
 import React from 'react';
 import { fetchSubGraphs, type SubGraphInfo } from '../api.js';
 import type { ProjectProfile } from '../hooks/useProjectProfile.js';
-import type { MemoryEntity } from '../hooks/useMemoryEntities.js';
+import type { MemoryEntity, TrustLevel } from '../hooks/useMemoryEntities.js';
 import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
 import { isUserFacingSubGraph, ROOT_SLUG_SENTINEL } from '../lib/subGraphs.js';
 
@@ -37,15 +37,38 @@ export interface SubGraphBarProps {
   /** Optional entity list for computing live badges (proposed / p0 / open PRs). */
   entities?: MemoryEntity[];
   /**
-   * When set, the chip counts reflect entities whose canonical layer
-   * (`trustLevel`) matches this layer — so on the WM/SWM/VM pages the
-   * row reports a per-layer slice instead of the daemon's project-wide
-   * total. Without this prop the row falls back to daemon totals
-   * (used on the Overview / Subgraphs pages). Also used as the
-   * `originatingLayer` argument forwarded to `onSelect` when a chip
-   * is clicked (#9 polish).
+   * Single-layer scope (back-compat). When set, the chip counts
+   * reflect entities whose canonical layer (`trustLevel`) matches
+   * this layer — so on the WM/SWM/VM pages the row reports a
+   * per-layer slice instead of the daemon's project-wide total.
+   * Without this prop the row falls back to daemon totals (used
+   * on the Overview / Subgraphs pages). Also used as the
+   * `originatingLayer` argument forwarded to `onSelect` when a
+   * chip is clicked (#9 polish).
+   *
+   * Superseded by `enabledScope` when both are set. New callers
+   * (PR #793 sweep 6 Bug O onward) should use `enabledScope`.
    */
   layer?: 'wm' | 'swm' | 'vm';
+  /**
+   * Multi-layer scope (PR #793 sweep 6 Bug O). Carries the
+   * user's current detail-view `enabledLayers` Set so the
+   * sibling bar's chip counts agree with the detail pane's
+   * filtered slice. Pre-Bug-O the bar mounted alongside a
+   * scoped detail was layer-agnostic, showing all-three chip
+   * counts above a filtered detail body — same-screen
+   * disagreement. The Set is interpreted as:
+   *   • size 0 or undefined → layer-agnostic (Overview / Subgraphs)
+   *   • size 1 → single-layer slice (matches the legacy `layer`)
+   *   • size 2 → narrowed across 2 layers
+   *   • size 3 → semantically all-three, treated as layer-agnostic
+   *     for the `inLayerMode` discriminant (the #7 hint / Bug K
+   *     rephrase / tooltip-branch logic stays at "no narrowing")
+   *
+   * Always trumps `layer` when both are non-empty. Forwarded as
+   * a fresh Set on chip click via `originatingScope` — see below.
+   */
+  enabledScope?: ReadonlySet<TrustLevel>;
 }
 
 const LAYER_TRUST_LEVEL = {
@@ -100,34 +123,57 @@ function computeBadges(entities: MemoryEntity[] | undefined): Map<string, SubGra
   return out;
 }
 
-export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profile, selected, onSelect, entities, layer }) => {
+export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profile, selected, onSelect, entities, layer, enabledScope }) => {
   const [subGraphs, setSubGraphs] = React.useState<SubGraphInfo[]>([]);
   const [loading, setLoading] = React.useState(true);
   const badges = React.useMemo(() => computeBadges(entities), [entities]);
   const requestIdRef = React.useRef(0);
 
+  // PR #793 sweep 6 Bug O — resolve a single "allowed trust
+  // levels" Set from the (preferred) `enabledScope` Set carrier or
+  // the legacy `layer` single-layer prop. A Set of size 3 collapses
+  // to null (no narrowing — same semantic as undefined). The legacy
+  // `layer` path maps through `LAYER_TRUST_LEVEL` into a size-1
+  // Set. Once a Set or null is in hand, every derivation below
+  // reads it the same way and the multi-layer case round-trips
+  // cleanly. When the carrier collapses to null we're in layer-
+  // agnostic mode.
+  const allowedTrustLevels = React.useMemo<ReadonlySet<TrustLevel> | null>(() => {
+    if (enabledScope && enabledScope.size > 0 && enabledScope.size < 3) {
+      return new Set(enabledScope);
+    }
+    if (enabledScope && enabledScope.size >= 3) return null;
+    if (layer) return new Set<TrustLevel>([LAYER_TRUST_LEVEL[layer]]);
+    return null;
+  }, [enabledScope, layer]);
+  // `isNarrowed` is true when the bar reports a sliced view (any
+  // non-null `allowedTrustLevels`). Pre-Bug-O this was just
+  // `layer !== undefined`; the Set carrier generalises it for the
+  // multi-layer cases. Drives the #7 / Bug K layer-mode tooltip
+  // branching and the All chip Root-inclusion rule.
+  const isNarrowed = allowedTrustLevels !== null;
+
   // When `entities` is provided we derive per-sub-graph counts locally
   // so the chip count matches what the entity list below it shows.
-  // Without `layer`, count every entity that belongs to the sub-graph
-  // (any layer) — used on the sub-graph page where the per-pyramid
-  // header sums across layers (Issue B: the daemon's
+  // Without narrowing, count every entity that belongs to the
+  // sub-graph (any layer) — used on the sub-graph page where the
+  // per-pyramid header sums across layers (Issue B: the daemon's
   // `/api/sub-graph/list` `entityCount` counts entities once per
   // sub-graph membership, double-counting cross-sub-graph entities,
-  // so the chip said "27" while the list said "11"). With `layer`
-  // set, scope to entities whose canonical `trustLevel` matches —
-  // used on the WM/SWM/VM page (post-P4).
+  // so the chip said "27" while the list said "11"). With
+  // narrowing, scope to entities whose canonical `trustLevel` is
+  // in the allowed set.
   const entityScopedCounts = React.useMemo(() => {
     if (!entities) return null;
-    const trust = layer ? LAYER_TRUST_LEVEL[layer] : null;
     const counts = new Map<string, number>();
     for (const e of entities) {
-      if (trust !== null && e.trustLevel !== trust) continue;
+      if (allowedTrustLevels && !allowedTrustLevels.has(e.trustLevel)) continue;
       for (const sg of e.subGraphs) {
         counts.set(sg, (counts.get(sg) ?? 0) + 1);
       }
     }
     return counts;
-  }, [layer, entities]);
+  }, [allowedTrustLevels, entities]);
 
   // Distinct count of in-scope entities for the "All" chip. Summing
   // per-sub-graph counts would double-count entities living in two or
@@ -147,30 +193,32 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
   //     total past anything the user can drill into by clicking a chip.
   const entityScopedAllTotal = React.useMemo(() => {
     if (!entities) return null;
-    const trust = layer ? LAYER_TRUST_LEVEL[layer] : null;
     let n = 0;
     for (const e of entities) {
-      if (trust !== null && e.trustLevel !== trust) continue;
-      if (layer === undefined && e.subGraphs.size === 0) continue;
+      if (allowedTrustLevels && !allowedTrustLevels.has(e.trustLevel)) continue;
+      // Layer-agnostic mode (no narrowing) excludes root entities
+      // by design — `All` is the umbrella over named-sub-graph
+      // chips. In layer / narrowed mode root entities are
+      // included so the total matches the layer-tab badge.
+      if (!isNarrowed && e.subGraphs.size === 0) continue;
       n++;
     }
     return n;
-  }, [layer, entities]);
+  }, [allowedTrustLevels, isNarrowed, entities]);
 
   // S3 fold-in: the synthesized "Root" bucket is "all entities minus
   // those in any named sub-graph". Computed from the same entity list
   // the named chips use so the counts agree row-by-row.
   const rootEntityCount = React.useMemo(() => {
     if (!entities) return null;
-    const trust = layer ? LAYER_TRUST_LEVEL[layer] : null;
     let n = 0;
     for (const e of entities) {
-      if (trust !== null && e.trustLevel !== trust) continue;
+      if (allowedTrustLevels && !allowedTrustLevels.has(e.trustLevel)) continue;
       if (e.subGraphs.size > 0) continue;
       n++;
     }
     return n;
-  }, [layer, entities]);
+  }, [allowedTrustLevels, entities]);
 
   const loadSubGraphs = React.useCallback(() => {
     const requestId = ++requestIdRef.current;
@@ -238,20 +286,27 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
   // the daemon-sum only when no entities prop was passed.
   const totalEntities = entityScopedAllTotal ?? merged.reduce((a, b) => a + b.entityCount, 0);
   const totalTriples = merged.reduce((a, b) => a + b.tripleCount, 0);
-  // Tooltip suffix tells the user the count is layer-scoped on a
-  // WM/SWM/VM page; on the Overview / Subgraphs page it stays implicit
-  // (project-wide totals match the daemon view).
-  const layerLabel = layer === 'wm' ? 'Working Memory'
-    : layer === 'swm' ? 'Shared Working Memory'
-    : layer === 'vm' ? 'Verifiable Memory'
+  // Tooltip suffix tells the user the count is narrowed on a
+  // WM/SWM/VM (or multi-layer) page; on the Overview / Subgraphs
+  // page it stays implicit (project-wide totals match the daemon
+  // view). For a single-layer scope the suffix reads as the
+  // layer's full canonical title; for a multi-layer narrowing
+  // it concatenates the present layer labels.
+  const TRUST_LAYER_TITLE: Record<TrustLevel, string> = {
+    working: 'Working Memory',
+    shared: 'Shared Working Memory',
+    verified: 'Verifiable Memory',
+  };
+  const layerLabel = allowedTrustLevels
+    ? [...allowedTrustLevels].map(t => TRUST_LAYER_TITLE[t]).join(' + ')
     : null;
   const scopeSuffix = layerLabel ? ` in ${layerLabel}` : '';
 
-  // S3 polish #7 — the `All` semantic differs between layer mode
-  // and layer-agnostic mode (see `entityScopedAllTotal` at :139
-  // for the locked rule):
-  //   • Layer mode (WM/SWM/VM): All includes root-bucket entities
-  //     so it matches the layer-tab badge.
+  // S3 polish #7 — the `All` semantic differs between narrowed
+  // and layer-agnostic mode (see `entityScopedAllTotal` for the
+  // locked rule):
+  //   • Narrowed (WM/SWM/VM or a multi-layer slice): All includes
+  //     root-bucket entities so it matches the layer-tab badge.
   //   • Layer-agnostic mode (Subgraph Explorer overview): All
   //     EXCLUDES root by design — it's the umbrella over named
   //     sub-graph chips; including root would inflate the total
@@ -259,7 +314,7 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
   // Surface different tooltip / aria-label / inline hint copy on
   // each mode so the math reads consistently with the chip count.
   // (PR #793 Codex sweep 1 — gating fix.)
-  const inLayerMode = layer !== undefined;
+  const inLayerMode = isNarrowed;
   const allTooltipCopy = inLayerMode
     ? `Total entities — includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`
     : `Total entities in named subgraphs (some may belong to more than one). Root entities are counted separately on the Root chip · ${totalEntities} entities · ${totalTriples} triples`;

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -337,15 +337,21 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
         );
       })()}
       {showRootChip && inLayerMode && (
-        /* #7 polish (ux-locked). Inline arithmetic-style hint
-           after the Root chip — explains the All math at a
-           glance. Muted tone so it doesn't compete with the
-           chip row; single line, never wraps (CSS).
-           Gated on `inLayerMode` (PR #793 Codex sweep 1 — the
-           layer-agnostic All total excludes Root by design, so
-           the equation only holds on WM/SWM/VM pages). */
+        /* #7 polish — inline legend-style hint after the Root
+           chip. Reads as "this row includes Root and the
+           subgraph chips", NOT as arithmetic — `MemoryEntity.subGraphs`
+           is a Set, so cross-membership entities count once in
+           the All total while potentially appearing under
+           multiple chip totals. Leading `+` mirrors set
+           membership ("plus these things"); the comma list
+           avoids a second `+` that would read as a sum.
+           Cross-membership disclosure lives in the long-form
+           All-chip tooltip — two-tier: hint = visual cue,
+           tooltip = explanation. ux-locked at PR #793 Codex
+           sweep 3 Bug K. Gated on `inLayerMode` (sweep 1 — the
+           layer-agnostic All total excludes Root by design). */
         <span className="v10-subgraph-bar-hint" aria-hidden="true">
-          All = Root + subgraphs
+          + Root, subgraphs
         </span>
       )}
     </div>

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -391,24 +391,17 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
           </button>
         );
       })()}
-      {showRootChip && inLayerMode && (
-        /* #7 polish — inline legend-style hint after the Root
-           chip. Reads as "this row includes Root and the
-           subgraph chips", NOT as arithmetic — `MemoryEntity.subGraphs`
-           is a Set, so cross-membership entities count once in
-           the All total while potentially appearing under
-           multiple chip totals. Leading `+` mirrors set
-           membership ("plus these things"); the comma list
-           avoids a second `+` that would read as a sum.
-           Cross-membership disclosure lives in the long-form
-           All-chip tooltip — two-tier: hint = visual cue,
-           tooltip = explanation. ux-locked at PR #793 Codex
-           sweep 3 Bug K. Gated on `inLayerMode` (sweep 1 — the
-           layer-agnostic All total excludes Root by design). */
-        <span className="v10-subgraph-bar-hint" aria-hidden="true">
-          + Root, subgraphs
-        </span>
-      )}
+      {/* PR #793 round 2 — the inline "+ Root, subgraphs" legend
+          hint (sweep 3 Bug K's locked replacement for the
+          rejected arithmetic form) was removed after manual test:
+          users saw the literal and asked what it meant, so the
+          two-tier "hint = visual cue, tooltip = explanation"
+          design failed to communicate. Cross-membership
+          disclosure now lives ONLY in the long-form All-chip
+          tooltip (hover-only, low-cost, right disclosure for
+          users who investigate). The `inLayerMode` discriminator
+          above stays — it still drives the mode-tagged tooltip /
+          aria branching from sweep 1. */}
     </div>
   );
 };

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -315,12 +315,16 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
   // each mode so the math reads consistently with the chip count.
   // (PR #793 Codex sweep 1 — gating fix.)
   const inLayerMode = isNarrowed;
+  // Round 3 (ux-lead lock): "distinct" prefix added to both mode
+  // tooltips to disambiguate that the count reflects unique
+  // entities, not chip-row sum (entities may belong to more than
+  // one named subgraph and would otherwise appear double-counted).
   const allTooltipCopy = inLayerMode
-    ? `Total entities — includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`
-    : `Total entities in named subgraphs (some may belong to more than one). Root entities are counted separately on the Root chip · ${totalEntities} entities · ${totalTriples} triples`;
+    ? `Total distinct entities — includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`
+    : `Total distinct entities in named subgraphs (some may belong to more than one). Root entities are counted separately on the Root chip · ${totalEntities} entities · ${totalTriples} triples`;
   const allAriaCopy = inLayerMode
-    ? `All — total entities. Includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph. ${totalEntities} entities${scopeSuffix}.`
-    : `All — total entities in named subgraphs (some may belong to more than one). Root entities are counted separately on the Root chip. ${totalEntities} entities.`;
+    ? `All — total distinct entities. Includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph. ${totalEntities} entities${scopeSuffix}.`
+    : `All — total distinct entities in named subgraphs (some may belong to more than one). Root entities are counted separately on the Root chip. ${totalEntities} entities.`;
 
   return (
     <div className="v10-subgraph-bar">

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -26,7 +26,14 @@ export interface SubGraphBarProps {
   contextGraphId: string;
   profile: ProjectProfile;
   selected: string | null;   // null === "All"
-  onSelect: (slug: string | null) => void;
+  /** Second arg `originatingLayer` carries the active layer
+   *  context when the bar is mounted on a WM/SWM/VM page so the
+   *  detail view can seed its `enabledLayers` to match what the
+   *  user was scoped to (§4.4.1 fold-in #4 — "scope must never
+   *  silently change semantics across a navigation transition").
+   *  Optional and only meaningful when transitioning INTO a chip
+   *  detail; clearing back to All passes undefined. */
+  onSelect: (slug: string | null, originatingLayer?: 'wm' | 'swm' | 'vm') => void;
   /** Optional entity list for computing live badges (proposed / p0 / open PRs). */
   entities?: MemoryEntity[];
   /**
@@ -34,7 +41,9 @@ export interface SubGraphBarProps {
    * (`trustLevel`) matches this layer — so on the WM/SWM/VM pages the
    * row reports a per-layer slice instead of the daemon's project-wide
    * total. Without this prop the row falls back to daemon totals
-   * (used on the Overview / Subgraphs pages).
+   * (used on the Overview / Subgraphs pages). Also used as the
+   * `originatingLayer` argument forwarded to `onSelect` when a chip
+   * is clicked (#9 polish).
    */
   layer?: 'wm' | 'swm' | 'vm';
 }
@@ -244,6 +253,8 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
       <button
         type="button"
         className={`v10-subgraph-chip${selected === null ? ' active' : ''}`}
+        /* All chip clears the selection — no originatingLayer
+           seed because the All view shows daemon-wide totals. */
         onClick={() => onSelect(null)}
         /* #7 polish (ux-locked option ii) — long-form tooltip
            clarifies the All math because `MemoryEntity.subGraphs`
@@ -266,7 +277,13 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
             key={sg.slug}
             type="button"
             className={`v10-subgraph-chip${selected === sg.slug ? ' active' : ''}${badge ? ' has-badge' : ''}`}
-            onClick={() => onSelect(sg.slug)}
+            /* #9 polish — forward the bar's `layer` prop as the
+               originating layer so the detail view's
+               `enabledLayers` is seeded to match the scope the
+               user was already in. Clicking from Overview or
+               the Subgraphs page leaves `layer` undefined → no
+               narrowing, default to all three. */
+            onClick={() => onSelect(sg.slug, layer)}
             title={`${sg.displayName}${sg.description ? ' · ' + sg.description : ''} · ${sg.entityCount} entities${scopeSuffix}${layerLabel ? '' : ` · ${sg.tripleCount} triples`}${badge ? ' · ' + badge.label : ''}`}
             style={{
               '--sg-color': sg.color,
@@ -293,7 +310,10 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
             className={`v10-subgraph-chip v10-subgraph-chip-root${isActive ? ' active' : ''}`}
             data-active={isActive}
             data-count={displayCount}
-            onClick={() => onSelect(ROOT_SLUG_SENTINEL)}
+            /* #9 polish — Root chip carries the originating layer
+               just like the named chips so a click from a layer
+               page keeps the layer scope when entering Root. */
+            onClick={() => onSelect(ROOT_SLUG_SENTINEL, layer)}
             title={`Entities not in any subgraph (Context Graph root) · ${displayCount} entities${scopeSuffix}`}
             aria-label="Entities not in any subgraph (Context Graph root)"
           >

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -247,6 +247,26 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
     : null;
   const scopeSuffix = layerLabel ? ` in ${layerLabel}` : '';
 
+  // S3 polish #7 — the `All` semantic differs between layer mode
+  // and layer-agnostic mode (see `entityScopedAllTotal` at :139
+  // for the locked rule):
+  //   • Layer mode (WM/SWM/VM): All includes root-bucket entities
+  //     so it matches the layer-tab badge.
+  //   • Layer-agnostic mode (Subgraph Explorer overview): All
+  //     EXCLUDES root by design — it's the umbrella over named
+  //     sub-graph chips; including root would inflate the total
+  //     past anything the user can drill into.
+  // Surface different tooltip / aria-label / inline hint copy on
+  // each mode so the math reads consistently with the chip count.
+  // (PR #793 Codex sweep 1 — gating fix.)
+  const inLayerMode = layer !== undefined;
+  const allTooltipCopy = inLayerMode
+    ? `Total entities — includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`
+    : `Total entities in named subgraphs (some may belong to more than one). Root entities are counted separately on the Root chip · ${totalEntities} entities · ${totalTriples} triples`;
+  const allAriaCopy = inLayerMode
+    ? `All — total entities. Includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph. ${totalEntities} entities${scopeSuffix}.`
+    : `All — total entities in named subgraphs (some may belong to more than one). Root entities are counted separately on the Root chip. ${totalEntities} entities.`;
+
   return (
     <div className="v10-subgraph-bar">
       <div className="v10-subgraph-bar-label">Subgraphs</div>
@@ -256,15 +276,8 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
         /* All chip clears the selection — no originatingLayer
            seed because the All view shows daemon-wide totals. */
         onClick={() => onSelect(null)}
-        /* #7 polish (ux-locked option ii) — long-form tooltip
-           clarifies the All math because `MemoryEntity.subGraphs`
-           is a Set: cross-membership entities count once in `All`
-           but may also appear under multiple chip totals, and
-           Root holds entities in no sub-graph at all. The shorter
-           inline hint after the Root chip carries the same
-           semantic at a glance. */
-        title={`Total entities — includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`}
-        aria-label={`All — total entities. Includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph. ${totalEntities} entities${scopeSuffix}.`}
+        title={allTooltipCopy}
+        aria-label={allAriaCopy}
       >
         <span className="v10-subgraph-chip-icon">⊚</span>
         <span className="v10-subgraph-chip-label">All</span>
@@ -323,11 +336,14 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
           </button>
         );
       })()}
-      {showRootChip && (
+      {showRootChip && inLayerMode && (
         /* #7 polish (ux-locked). Inline arithmetic-style hint
            after the Root chip — explains the All math at a
            glance. Muted tone so it doesn't compete with the
-           chip row; single line, never wraps (CSS). */
+           chip row; single line, never wraps (CSS).
+           Gated on `inLayerMode` (PR #793 Codex sweep 1 — the
+           layer-agnostic All total excludes Root by design, so
+           the equation only holds on WM/SWM/VM pages). */
         <span className="v10-subgraph-bar-hint" aria-hidden="true">
           All = Root + subgraphs
         </span>

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -7714,7 +7714,15 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
     color-mix(in srgb, var(--sg-color, #a855f7) 8%, transparent) 0%,
     transparent 40%
   );
-  min-height: 34px;
+  /* PR #793 round 2 — `min-height: 44px` reserves space for the
+     fully-populated breadcrumb state (project name + `›`
+     separator + subgraph chip + description). Pre-fix the row
+     was 34px when only the project name showed (e.g. on the
+     Subgraphs / WM / SWM / VM tabs without an active subgraph)
+     and grew to ~42-44px when the breadcrumb expanded, pushing
+     the body content down on transition. Reserving the
+     expanded height at all times eliminates the layout shift. */
+  min-height: 44px;
 }
 .v10-project-strip-dot {
   width: 9px; height: 9px; border-radius: 50%;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6941,7 +6941,11 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  /* 8/12 asymmetry (ui-lead, round 3): caption reads as
+     "grouped with the strip above (tight 8px), terminated
+     from the chrome below (looser 12px)". */
   margin-top: 8px;              /* was: 14px */
+  margin-bottom: 12px;          /* round 3: terminate before entity-tab strip */
   padding: 0;
   border: 0;
   background: transparent;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -4321,6 +4321,19 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   color: var(--text-tertiary, #94a3b8);
   padding-right: 4px;
 }
+/* #7 polish — inline "All = Root + subgraphs" arithmetic hint
+   trailing the chip row. Muted tone (same `--text-tertiary`
+   token used by the row label) so it doesn't compete with the
+   chip counts. `white-space: nowrap` keeps the equation
+   readable as a single phrase even on narrow viewports — the
+   chip row already wraps independently. */
+.v10-subgraph-bar-hint {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  padding-left: 8px;
+  font-variant-numeric: tabular-nums;
+}
 .v10-subgraph-chip {
   display: inline-flex;
   align-items: center;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6564,7 +6564,18 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
 .v10-subgraph-detail-icon {
   font-size: 20px; line-height: 1;
 }
-.v10-subgraph-detail-title-wrap { flex: 1; min-width: 0; }
+.v10-subgraph-detail-title-wrap {
+  flex: 1;
+  min-width: 0;
+  /* #10a polish — reserve a consistent vertical slot for the
+     title block so 1-line and 2-line titles occupy the same
+     space. No layout shift navigating between subgraphs whose
+     descriptions differ in length. */
+  min-height: 44px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
 .v10-subgraph-detail-title {
   font-size: 15px; font-weight: 600; color: var(--text-primary);
 }
@@ -6839,7 +6850,9 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
    so it never silently changes meaning across a navigation
    transition (M2 / S5 strand). */
 .v10-subgraph-cross-layer {
-  padding: 10px 16px 12px;
+  /* #11 polish (ui-locked) — +4px top padding, lede/pill carry
+     their own +2px / +14px margins for the layered breathing room. */
+  padding: 16px 16px 0;
   border-bottom: 1px solid var(--border-subtle);
   display: flex;
   flex-direction: column;
@@ -6850,6 +6863,9 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   font-size: 11px;
   color: var(--text-tertiary);
   letter-spacing: 0.01em;
+  /* #11 polish (ui-locked) — +2px below the lede so the count
+     strip sits cleanly beneath. */
+  margin-bottom: 10px;
 }
 .v10-subgraph-cross-layer-strip {
   display: flex;
@@ -6906,6 +6922,10 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   font-size: 12px;
 }
 .v10-subgraph-active-layer-pill {
+  /* #11 polish (ui-locked) — +14px above the pill so the
+     count strip / pill cluster reads as a single breathing
+     three-tier band instead of stacked rows. */
+  margin-top: 14px;
   align-self: flex-start;
   display: inline-flex;
   align-items: center;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -4321,12 +4321,18 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   color: var(--text-tertiary, #94a3b8);
   padding-right: 4px;
 }
-/* #7 polish — inline "All = Root + subgraphs" arithmetic hint
-   trailing the chip row. Muted tone (same `--text-tertiary`
-   token used by the row label) so it doesn't compete with the
-   chip counts. `white-space: nowrap` keeps the equation
-   readable as a single phrase even on narrow viewports — the
-   chip row already wraps independently. */
+/* #7 polish (literal updated at sweep 3 Bug K) — inline
+   legend-style hint trailing the chip row. Reads as "this row
+   includes Root and the subgraph chips" via the locked literal
+   `+ Root, subgraphs`, NOT as arithmetic — the original
+   `All = Root + subgraphs` form was a false equation when
+   entities have cross-membership in 2+ subgraphs. Cross-
+   membership disclosure lives in the long-form All-chip
+   tooltip; this hint is the at-a-glance visual cue. Muted tone
+   (same `--text-tertiary` token used by the row label) so it
+   doesn't compete with the chip counts. `white-space: nowrap`
+   keeps the phrase readable as a single line even on narrow
+   viewports — the chip row already wraps independently. */
 .v10-subgraph-bar-hint {
   font-size: 11px;
   color: var(--text-tertiary);
@@ -6850,8 +6856,12 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
    so it never silently changes meaning across a navigation
    transition (M2 / S5 strand). */
 .v10-subgraph-cross-layer {
-  /* #11 polish (ui-locked) — +4px top padding, lede/pill carry
-     their own +2px / +14px margins for the layered breathing room. */
+  /* #11 polish (ui-locked) — `padding: 16px 16px 0` is +6px top
+     and -12px bottom vs. the prior `10px 16px 12px`. The bottom
+     padding moves into the active-layer-pill's `margin-top: 14px`,
+     so the cluster reads as a single layered breathing band (lede
+     +2px / count strip / pill +14px) instead of stacked rows with
+     bottom container padding. */
   padding: 16px 16px 0;
   border-bottom: 1px solid var(--border-subtle);
   display: flex;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6943,6 +6943,37 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   font-weight: 600;
 }
 
+/* #8 polish — SWM-attribution discoverability badge. Renders
+   above LayerGraphPanel when the Graph tab is narrowed to
+   SWM-only, surfacing the agent-attribution coloring rule
+   that the existing legend documents. SWM amber dot matches
+   the layer's canonical hex (TRUST_COLORS.shared #f59e0b). */
+.v10-subgraph-swm-attribution-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 8px;
+  padding: 4px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--bg-elevated);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.v10-subgraph-swm-attribution-badge-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  /* Reuse the canonical SWM layer token (existing precedent at
+     styles.css:3330) instead of hardcoding the hex. Matches
+     TRUST_COLORS.shared in helpers.ts. */
+  background: var(--layer-shared, #f59e0b);
+}
+.v10-subgraph-swm-attribution-badge-text {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
 /* ── Verify on DKG CTA (in KA detail right pane) ── */
 /* Two variants: .promote (WM -> SWM, amber) and .publish (SWM -> VM, green).
    The layer-transition icon (◈ / ◉) matches LAYER_CONFIG so the CTA

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6960,36 +6960,14 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   font-weight: 600;
 }
 
-/* #8 polish — SWM-attribution discoverability badge. Renders
-   above LayerGraphPanel when the Graph tab is narrowed to
-   SWM-only, surfacing the agent-attribution coloring rule
-   that the existing legend documents. SWM amber dot matches
-   the layer's canonical hex (TRUST_COLORS.shared #f59e0b). */
-.v10-subgraph-swm-attribution-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin: 0 0 8px;
-  padding: 4px 10px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 12px;
-  background: var(--bg-elevated);
-  font-size: 11px;
-  color: var(--text-secondary);
-}
-.v10-subgraph-swm-attribution-badge-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  /* Reuse the canonical SWM layer token (existing precedent at
-     styles.css:3330) instead of hardcoding the hex. Matches
-     TRUST_COLORS.shared in helpers.ts. */
-  background: var(--layer-shared, #f59e0b);
-}
-.v10-subgraph-swm-attribution-badge-text {
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
+/* PR #793 round 2 — `.v10-subgraph-swm-attribution-badge` rule
+   (sweep 0 Bug #8's "Colored by contributing agent" inline
+   badge above LayerGraphPanel) removed alongside the
+   corresponding render in SubGraphDetailView. The existing
+   SwmAttributionLegend inside LayerGraphPanel carries the
+   load-bearing disclosure; the badge added visual noise
+   without signal. The context-sensitive tooltip on the SWM
+   cross-layer cell remains as hover-only insurance. */
 
 /* ── Verify on DKG CTA (in KA detail right pane) ── */
 /* Two variants: .promote (WM -> SWM, amber) and .publish (SWM -> VM, green).

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -4302,6 +4302,18 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
 .v10-me-loading-text { font-size: 12px; color: var(--text-tertiary); }
 
 /* ── Sub-graph Bar ── */
+/* PR #793 round 2 (ui-locked option a) — capsule chrome dropped.
+   The bar previously had a tinted background + 10px border-radius
+   that made it read as a separate widget hovering above the
+   content; on the Subgraph Explorer page where the strip sits
+   inside the page chrome, that pill-island look broke the
+   continuous strip semantics. Reduced to a single-edge bottom
+   border so the row terminates cleanly without claiming
+   container chrome.
+
+   This also kills the stale `--surface-1` and `--border-subtle`
+   rgba fallbacks that were S2 sweep regressions (undefined token
+   + dead rgba), closing the loop while in here. */
 .v10-subgraph-bar {
   display: flex;
   align-items: center;
@@ -4310,9 +4322,10 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   flex-wrap: wrap;
   padding: 8px 12px;
   margin-bottom: 8px;
-  background: var(--surface-1, rgba(255,255,255,0.02));
-  border: 1px solid var(--border-subtle, rgba(255,255,255,0.06));
-  border-radius: 10px;
+  background: transparent;                          /* was: var(--surface-1, rgba(255,255,255,0.02)) */
+  border: 0;                                        /* was: 1px solid var(--border-subtle, ...) */
+  border-bottom: 1px solid var(--border-subtle);    /* single-edge termination */
+  border-radius: 0;                                 /* was: 10px */
 }
 .v10-subgraph-bar-label {
   font-size: 11px;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -4321,25 +4321,12 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   color: var(--text-tertiary, #94a3b8);
   padding-right: 4px;
 }
-/* #7 polish (literal updated at sweep 3 Bug K) — inline
-   legend-style hint trailing the chip row. Reads as "this row
-   includes Root and the subgraph chips" via the locked literal
-   `+ Root, subgraphs`, NOT as arithmetic — the original
-   `All = Root + subgraphs` form was a false equation when
-   entities have cross-membership in 2+ subgraphs. Cross-
-   membership disclosure lives in the long-form All-chip
-   tooltip; this hint is the at-a-glance visual cue. Muted tone
-   (same `--text-tertiary` token used by the row label) so it
-   doesn't compete with the chip counts. `white-space: nowrap`
-   keeps the phrase readable as a single line even on narrow
-   viewports — the chip row already wraps independently. */
-.v10-subgraph-bar-hint {
-  font-size: 11px;
-  color: var(--text-tertiary);
-  white-space: nowrap;
-  padding-left: 8px;
-  font-variant-numeric: tabular-nums;
-}
+/* PR #793 round 2 — the `.v10-subgraph-bar-hint` rule (sweep 3
+   Bug K's locked literal `+ Root, subgraphs`) was removed
+   alongside the corresponding render in SubGraphBar.tsx. Users
+   asked what the literal meant on manual test; the inline hint
+   was demoted entirely. The long-form tooltip on the All chip's
+   count badge still carries the cross-membership disclosure. */
 .v10-subgraph-chip {
   display: inline-flex;
   align-items: center;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6918,35 +6918,35 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   color: var(--text-tertiary);
   font-size: 12px;
 }
+/* PR #793 round 2 (ui-locked option c) — demoted from
+   clickable pill chrome to inline caption-style metadata. The
+   pill used to be dressed as a chip but didn't go anywhere;
+   the `Reset filters` button is the canonical "restore scope"
+   affordance. Reduced to a transparent text label so it reads
+   as caption metadata, not a control. */
 .v10-subgraph-active-layer-pill {
-  /* #11 polish (ui-locked) — +14px above the pill so the
-     count strip / pill cluster reads as a single breathing
-     three-tier band instead of stacked rows. */
-  margin-top: 14px;
-  align-self: flex-start;
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 3px 10px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 12px;
+  margin-top: 8px;              /* was: 14px */
+  padding: 0;
+  border: 0;
+  background: transparent;
+  border-radius: 0;
+  font-family: var(--font-sans); /* was: --font-mono */
   font-size: 11px;
-  font-family: var(--font-mono);
-  color: var(--text-secondary);
-  background: rgba(255,255,255,0.02);
-  cursor: pointer;
-  transition: all 0.15s;
+  color: var(--text-tertiary);
+  cursor: default;               /* not a clickable widget */
+  transition: color 0.15s;
 }
 .v10-subgraph-active-layer-pill:hover:not(:disabled) {
-  border-color: var(--border-strong);
-  color: var(--text-primary);
+  color: var(--text-secondary);
+  border-color: transparent;
 }
-.v10-subgraph-active-layer-pill:disabled {
-  cursor: default;
-  opacity: 0.85;
-}
+.v10-subgraph-active-layer-pill:disabled,
 .v10-subgraph-active-layer-pill.all-layers {
   color: var(--text-tertiary);
+  opacity: 1;
 }
 .v10-subgraph-active-layer-pill-label {
   text-transform: uppercase;
@@ -6956,7 +6956,7 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   color: var(--text-tertiary);
 }
 .v10-subgraph-active-layer-pill-value {
-  color: var(--text-primary);
+  color: var(--text-secondary); /* was: --text-primary */
   font-weight: 600;
 }
 

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6848,12 +6848,30 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 12px;
   border: 1px solid var(--border-subtle);
-  border-radius: 14px;
   font-size: 12px;
   color: var(--text-primary);
   background: var(--bg-elevated);
+  /* #6 polish — cells become interactive buttons (ui-locked).
+     The padding + negative margin pair enlarges the hit target
+     for click affordance while keeping the visual rhythm stable
+     (the negative margin negates the added padding so neighbours
+     don't shift). */
+  cursor: pointer;
+  border-radius: 6px;
+  padding: 4px 8px;
+  margin: -4px -8px;
+  transition: background 0.15s, color 0.15s, opacity 0.15s;
+  /* Native button reset so the cell inherits the rest of the
+     strip's typography rather than the UA <button> defaults. */
+  font-family: inherit;
+  text-align: left;
+}
+.v10-subgraph-cross-layer-cell:hover {
+  background: var(--bg-hover);
+}
+.v10-subgraph-cross-layer-cell[aria-pressed="false"] {
+  opacity: 0.5;
 }
 .v10-subgraph-cross-layer-cell-icon {
   font-size: 13px;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6491,29 +6491,29 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
 }
 
 /* ── Mini layer pyramid (WM/SWM/VM segmented bar + legend) ── */
-.v10-minipyr {
+.v10-minibar {
   display: flex; flex-direction: column; gap: 4px;
   min-width: 0;
 }
-.v10-minipyr.compact { flex-direction: row; align-items: center; gap: 6px; }
-.v10-minipyr-empty {
+.v10-minibar.compact { flex-direction: row; align-items: center; gap: 6px; }
+.v10-minibar-empty {
   font-size: 10px; color: var(--text-tertiary); font-style: italic;
 }
-.v10-minipyr-bar {
+.v10-minibar-bar {
   display: flex; height: 6px; width: 100%;
   border-radius: 3px; overflow: hidden;
   background: rgba(255,255,255,0.04);
 }
-.v10-minipyr-seg {
+.v10-minibar-seg {
   height: 100%;
   transition: opacity 0.15s ease, filter 0.15s ease;
 }
-.v10-minipyr-seg.dim { opacity: 0.3; filter: grayscale(0.6); }
-.v10-minipyr-legend {
+.v10-minibar-seg.dim { opacity: 0.3; filter: grayscale(0.6); }
+.v10-minibar-legend {
   display: flex; gap: 4px; flex-wrap: wrap;
   align-items: center;
 }
-.v10-minipyr-chip {
+.v10-minibar-chip {
   display: inline-flex; align-items: center; gap: 4px;
   padding: 2px 7px;
   background: none;
@@ -6525,14 +6525,14 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   cursor: default;
   transition: border-color 0.15s, color 0.15s, opacity 0.15s;
 }
-.v10-minipyr-chip.interactive { cursor: pointer; }
-.v10-minipyr-chip.interactive:hover { border-color: var(--border-strong); color: var(--text-primary); }
-.v10-minipyr-chip.dim { opacity: 0.4; }
-.v10-minipyr-dot {
+.v10-minibar-chip.interactive { cursor: pointer; }
+.v10-minibar-chip.interactive:hover { border-color: var(--border-strong); color: var(--text-primary); }
+.v10-minibar-chip.dim { opacity: 0.4; }
+.v10-minibar-dot {
   display: inline-block; width: 6px; height: 6px; border-radius: 50%;
 }
-.v10-minipyr-short { letter-spacing: 0.04em; }
-.v10-minipyr-count { font-variant-numeric: tabular-nums; color: var(--text-tertiary); }
+.v10-minibar-short { letter-spacing: 0.04em; }
+.v10-minibar-count { font-variant-numeric: tabular-nums; color: var(--text-tertiary); }
 
 /* ── Sub-graph detail view header + filters ── */
 .v10-subgraph-detail {

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -139,9 +139,20 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // `handleSelectSubGraph`'s layer-agnostic branch when the user
   // hops between subgraphs from the detail-view internal bar —
   // we route the current scope through, NOT the stale seed.
+  //
+  // PR #793 sweep 6 Bug O — also stored as React state so the
+  // sibling `SubGraphBar` mounted next to the detail view can
+  // pass it through as `enabledScope`. The bar's chip counts
+  // were pre-Bug-O layer-agnostic above a filtered detail body,
+  // causing on-screen number disagreement. Ref + state stay in
+  // lockstep — the ref carries the SYNC value for race-window
+  // discriminators (Bug L); the state drives the bar's re-render
+  // when the user widens/narrows inside the detail view.
   const detailScopeRef = useRef<ReadonlySet<TrustLevel> | null>(null);
+  const [currentDetailScope, setCurrentDetailScope] = useState<ReadonlySet<TrustLevel> | null>(null);
   const handleDetailEnabledLayersChange = useCallback((layers: ReadonlySet<TrustLevel>) => {
     detailScopeRef.current = layers;
+    setCurrentDetailScope(layers);
   }, []);
   // PR #793 sweep 4 Bug L — `activeSubGraph` from the useCallback
   // closure can be stale during a fast chip-to-chip burst (the
@@ -175,7 +186,10 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     if (slug === null) {
       // Exit always clears the scope mirror so the next chip
       // click from a fresh route doesn't see a stale carry-over.
+      // Both the ref (sync read path) and the state (bar
+      // re-render path) clear in lockstep.
       detailScopeRef.current = null;
+      setCurrentDetailScope(null);
     }
     setActiveSubGraph(slug);
   }, []);
@@ -508,12 +522,19 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     setActiveSubGraphSync(slug);
     if (slug === null) {
       setSubGraphInitialEnabledLayers(null);
-      // detailScopeRef.current already cleared by the helper.
+      // detailScopeRef.current and currentDetailScope already
+      // cleared by the helper.
     } else if (originatingLayer !== undefined) {
       // Single-layer seed (layer-tab entry).
       const seed = new Set<TrustLevel>([TRUST_FOR_LAYER[originatingLayer]]);
       setSubGraphInitialEnabledLayers(seed);
       detailScopeRef.current = seed;
+      // Bar's `enabledScope` prop needs the current scope state
+      // immediately so the chip counts agree with the detail
+      // view's seed on first render (Bug O — same-screen
+      // disagreement at the moment of entry, before the detail
+      // view's mirror effect has fired).
+      setCurrentDetailScope(seed);
     } else {
       // Layer-agnostic — preserve user's CURRENT scope on
       // detail→detail hops (Bug J); clear on fresh entry from the
@@ -530,9 +551,11 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
         const snapshot = new Set<TrustLevel>(detailScopeRef.current);
         setSubGraphInitialEnabledLayers(snapshot);
         detailScopeRef.current = snapshot;
+        setCurrentDetailScope(snapshot);
       } else {
         setSubGraphInitialEnabledLayers(null);
         detailScopeRef.current = null;
+        setCurrentDetailScope(null);
       }
     }
     setSelectedUri(null);
@@ -709,6 +732,13 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             selected={activeSubGraph}
             entities={chipBarEntities}
             onSelect={handleSelectSubGraph}
+            /* Bug O — chip counts now reflect the detail's
+               current scope so the bar and the body show
+               consistent numbers (no all-three counts above
+               a filtered detail). The state is updated
+               synchronously by `handleSelectSubGraph` on entry
+               + on user toggles via the mirror callback. */
+            enabledScope={currentDetailScope ?? undefined}
           />
           <SubGraphDetailView
             slug={activeSubGraph}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -143,6 +143,15 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const handleDetailEnabledLayersChange = useCallback((layers: ReadonlySet<TrustLevel>) => {
     detailScopeRef.current = layers;
   }, []);
+  // PR #793 sweep 4 Bug L — `activeSubGraph` from the useCallback
+  // closure can be stale during a fast chip-to-chip burst (the
+  // state update from click 1 hasn't re-rendered before click 2
+  // fires). A ref kept in sync at the top of every
+  // handleSelectSubGraph call captures the latest active-subgraph
+  // identity synchronously so the layer-agnostic branch's
+  // "overview-vs-detail" discriminator stays fresh across the
+  // race window.
+  const activeSubGraphRef = useRef<string | null>(null);
   const [selectedLayerContext, setSelectedLayerContext] = useState<MemoryLayerView | null>(null);
   // Mirror `selectedUri` into a ref so `handleNavigate` can read the
   // current value without listing it in deps — listing it caused the
@@ -443,30 +452,61 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   //           hops to another subgraph → next detail silently
   //           narrowed back to WM-only). Reading `detailScopeRef`
   //           gives us the user's actual current scope at click time.
+  // PR #793 Codex sweep 4 (Bug L) — every branch that updates the
+  // `subGraphInitialEnabledLayers` state also writes
+  // `detailScopeRef.current` synchronously to the same value. The
+  // mirror effect inside SubGraphDetailView only fires after React
+  // paints, so without a sync ref write a fast chip-to-chip hop
+  // (overview → A → B before A's mount effect runs, or any
+  // hop-faster-than-effect-schedule) would read a stale ref and
+  // silently lose the intended seed.
+  //
+  // The new detail view's mirror effect still overwrites
+  // `ref.current` once it mounts — usually with the same value —
+  // and subsequently with the user's scope changes inside the
+  // detail view (which is what Bug J's fix is supposed to
+  // capture). The sync write here just closes the pre-mount
+  // timing window.
   const handleSelectSubGraph = useCallback((slug: string | null, originatingLayer?: MemoryLayerView) => {
+    // Read the prior `activeSubGraph` identity from the ref so
+    // the overview-vs-detail discriminator survives a fast
+    // chip-to-chip burst that fires before React re-renders
+    // (Bug L). Then commit the new slug to the ref + state.
+    const priorActiveSubGraph = activeSubGraphRef.current;
+    activeSubGraphRef.current = slug;
     clearDetailOrigin();
     setActiveSubGraph(slug);
     if (slug === null) {
       setSubGraphInitialEnabledLayers(null);
+      detailScopeRef.current = null;
     } else if (originatingLayer !== undefined) {
       // Single-layer seed (layer-tab entry).
-      setSubGraphInitialEnabledLayers(new Set<TrustLevel>([TRUST_FOR_LAYER[originatingLayer]]));
+      const seed = new Set<TrustLevel>([TRUST_FOR_LAYER[originatingLayer]]);
+      setSubGraphInitialEnabledLayers(seed);
+      detailScopeRef.current = seed;
     } else {
       // Layer-agnostic — preserve user's CURRENT scope on
       // detail→detail hops (Bug J); clear on fresh entry from the
-      // overview.
-      if (activeSubGraph !== null && detailScopeRef.current) {
+      // overview. Discriminator read from the ref (not stale
+      // closure state) so a fast hop right after another chip
+      // click sees the prior detail context correctly.
+      if (priorActiveSubGraph !== null && detailScopeRef.current) {
         // Snapshot the current scope into a fresh Set so the
         // unmounting detail view's state mutation (via the next
-        // mirror tick) doesn't share the reference.
-        setSubGraphInitialEnabledLayers(new Set<TrustLevel>(detailScopeRef.current));
+        // mirror tick) doesn't share the reference. Subsequent
+        // fast hops read this snapshot, not the about-to-unmount
+        // detail's mutating Set.
+        const snapshot = new Set<TrustLevel>(detailScopeRef.current);
+        setSubGraphInitialEnabledLayers(snapshot);
+        detailScopeRef.current = snapshot;
       } else {
         setSubGraphInitialEnabledLayers(null);
+        detailScopeRef.current = null;
       }
     }
     setSelectedUri(null);
     setSelectedLayerContext(null);
-  }, [activeSubGraph, clearDetailOrigin]);
+  }, [clearDetailOrigin]);
 
   const handleLayerSwitch = useCallback((layer: LayerView) => {
     clearDetailOrigin();

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -125,13 +125,24 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // a sibling of `activeLayer`, not a filter over it: sub-graphs are a peer
   // axis to layers, and each axis gets its own first-class page.
   const [activeSubGraph, setActiveSubGraph] = useState<string | null>(null);
-  // S3 polish #9 — when a chip click on a WM/SWM/VM page transitions
-  // into the sub-graph detail, carry the originating layer through
-  // so the detail view's `enabledLayers` seeds to that layer
-  // (instead of the default all-three) — UX §4.4.1 fold-in #4
-  // ("scope must never silently change semantics across a
-  // navigation transition"). null = no narrowing (default).
-  const [subGraphInitialLayer, setSubGraphInitialLayer] = useState<MemoryLayerView | null>(null);
+  // S3 polish #9 + PR #793 Bug J — multi-layer carry-over for the
+  // subgraph detail view's `enabledLayers` seed. Storing the Set
+  // (rather than the single-layer alias #9 originally used) lets
+  // the user's exact scope survive across detail→detail hops
+  // even when they've widened past one layer (e.g. WM seeded
+  // entry → user widens to WM+SWM → hops to bakers → bakers
+  // detail seeds WM+SWM, not WM-only). null = no narrowing
+  // (default — fresh entries land at all-three).
+  const [subGraphInitialEnabledLayers, setSubGraphInitialEnabledLayers] = useState<ReadonlySet<TrustLevel> | null>(null);
+  // Mirror of the detail view's current `enabledLayers` state,
+  // pushed up via `onEnabledLayersChange` (Bug J). Read by
+  // `handleSelectSubGraph`'s layer-agnostic branch when the user
+  // hops between subgraphs from the detail-view internal bar —
+  // we route the current scope through, NOT the stale seed.
+  const detailScopeRef = useRef<ReadonlySet<TrustLevel> | null>(null);
+  const handleDetailEnabledLayersChange = useCallback((layers: ReadonlySet<TrustLevel>) => {
+    detailScopeRef.current = layers;
+  }, []);
   const [selectedLayerContext, setSelectedLayerContext] = useState<MemoryLayerView | null>(null);
   // Mirror `selectedUri` into a ref so `handleNavigate` can read the
   // current value without listing it in deps — listing it caused the
@@ -415,36 +426,43 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // existing layer scope follows them across the navigation (#9
   // polish, fold-in #4).
   //
-  // PR #793 Codex sweep 2 (Bug H) — three distinct call patterns must
-  // route differently:
+  // Three distinct call patterns route differently (PR #793 sweeps 2-3):
   //   1. Exit (slug === null) → clear scope.
   //   2. Layer-mode entry (originatingLayer is set, fired from the bar
-  //      mounted on a WM/SWM/VM tab) → set scope to that layer.
+  //      mounted on a WM/SWM/VM tab) → seed scope to that single layer.
   //   3. Layer-agnostic entry (originatingLayer === undefined):
   //        a. From the Subgraph Explorer overview (no activeSubGraph
-  //           before the click) → keep null (fresh entry lands at
+  //           before the click) → clear (fresh entry lands at
   //           all-layers).
   //        b. From an already-scoped detail (activeSubGraph != null
   //           before the click — detail→detail hop on the layer-
-  //           agnostic bar inside the detail view) → PRESERVE the
-  //           prior `subGraphInitialLayer` instead of dropping back
-  //           to null. Pre-fix this silently widened scope on every
-  //           hop ≥ 2 (e.g. WM → recipes → bakers reverted to
-  //           all-three).
-  // Capturing `activeSubGraph` in the deps keeps the discriminator
-  // fresh across renders; the functional `setSubGraphInitialLayer`
-  // setter reads the latest scope state at the time the click fires.
+  //           agnostic bar inside the detail view) → carry the
+  //           DETAIL VIEW'S CURRENT scope through, NOT the stale
+  //           seed. Pre-Bug-J this preserved the original seed
+  //           (e.g. user enters from WM, widens to WM+SWM in detail,
+  //           hops to another subgraph → next detail silently
+  //           narrowed back to WM-only). Reading `detailScopeRef`
+  //           gives us the user's actual current scope at click time.
   const handleSelectSubGraph = useCallback((slug: string | null, originatingLayer?: MemoryLayerView) => {
     clearDetailOrigin();
     setActiveSubGraph(slug);
     if (slug === null) {
-      setSubGraphInitialLayer(null);
+      setSubGraphInitialEnabledLayers(null);
     } else if (originatingLayer !== undefined) {
-      setSubGraphInitialLayer(originatingLayer);
+      // Single-layer seed (layer-tab entry).
+      setSubGraphInitialEnabledLayers(new Set<TrustLevel>([TRUST_FOR_LAYER[originatingLayer]]));
     } else {
-      // Layer-agnostic — preserve existing scope on detail→detail
-      // hops, fall to null on fresh entry from the overview.
-      setSubGraphInitialLayer(prev => (activeSubGraph !== null ? prev : null));
+      // Layer-agnostic — preserve user's CURRENT scope on
+      // detail→detail hops (Bug J); clear on fresh entry from the
+      // overview.
+      if (activeSubGraph !== null && detailScopeRef.current) {
+        // Snapshot the current scope into a fresh Set so the
+        // unmounting detail view's state mutation (via the next
+        // mirror tick) doesn't share the reference.
+        setSubGraphInitialEnabledLayers(new Set<TrustLevel>(detailScopeRef.current));
+      } else {
+        setSubGraphInitialEnabledLayers(null);
+      }
     }
     setSelectedUri(null);
     setSelectedLayerContext(null);
@@ -614,7 +632,8 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             onSelectEntity={handleNavigate}
             activeTab={subGraphTabs[activeSubGraph] ?? 'items'}
             onTabChange={tab => handleSubGraphTabChange(activeSubGraph, tab)}
-            initialLayer={subGraphInitialLayer ?? undefined}
+            initialEnabledLayers={subGraphInitialEnabledLayers ?? undefined}
+            onEnabledLayersChange={handleDetailEnabledLayersChange}
           />
         </>
       )}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -414,13 +414,41 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // bar's `layer` prop through to the detail view so the user's
   // existing layer scope follows them across the navigation (#9
   // polish, fold-in #4).
+  //
+  // PR #793 Codex sweep 2 (Bug H) — three distinct call patterns must
+  // route differently:
+  //   1. Exit (slug === null) → clear scope.
+  //   2. Layer-mode entry (originatingLayer is set, fired from the bar
+  //      mounted on a WM/SWM/VM tab) → set scope to that layer.
+  //   3. Layer-agnostic entry (originatingLayer === undefined):
+  //        a. From the Subgraph Explorer overview (no activeSubGraph
+  //           before the click) → keep null (fresh entry lands at
+  //           all-layers).
+  //        b. From an already-scoped detail (activeSubGraph != null
+  //           before the click — detail→detail hop on the layer-
+  //           agnostic bar inside the detail view) → PRESERVE the
+  //           prior `subGraphInitialLayer` instead of dropping back
+  //           to null. Pre-fix this silently widened scope on every
+  //           hop ≥ 2 (e.g. WM → recipes → bakers reverted to
+  //           all-three).
+  // Capturing `activeSubGraph` in the deps keeps the discriminator
+  // fresh across renders; the functional `setSubGraphInitialLayer`
+  // setter reads the latest scope state at the time the click fires.
   const handleSelectSubGraph = useCallback((slug: string | null, originatingLayer?: MemoryLayerView) => {
     clearDetailOrigin();
     setActiveSubGraph(slug);
-    setSubGraphInitialLayer(slug ? (originatingLayer ?? null) : null);
+    if (slug === null) {
+      setSubGraphInitialLayer(null);
+    } else if (originatingLayer !== undefined) {
+      setSubGraphInitialLayer(originatingLayer);
+    } else {
+      // Layer-agnostic — preserve existing scope on detail→detail
+      // hops, fall to null on fresh entry from the overview.
+      setSubGraphInitialLayer(prev => (activeSubGraph !== null ? prev : null));
+    }
     setSelectedUri(null);
     setSelectedLayerContext(null);
-  }, [clearDetailOrigin]);
+  }, [activeSubGraph, clearDetailOrigin]);
 
   const handleLayerSwitch = useCallback((layer: LayerView) => {
     clearDetailOrigin();

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -556,13 +556,26 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
       // disagreement at the moment of entry, before the detail
       // view's mirror effect has fired).
       setCurrentDetailScope(seed);
+    } else if (priorActiveSubGraph !== null && slug === priorActiveSubGraph) {
+      // PR #793 sweep 7 Bug Q — same-chip click. Pre-fix this
+      // fell through the detail→detail branch and snapshotted
+      // the live `detailScopeRef.current` (which may have
+      // widened past the entry seed) into
+      // `subGraphInitialEnabledLayers`. Result: the user's
+      // entry baseline silently became their current scope; the
+      // Bug I `isAtSeededScope` predicate then flipped true so
+      // the active-layer pill's "restore originating scope"
+      // affordance disappeared. The natural user expectation —
+      // pre-PR semantic — is that clicking the chip you're
+      // already on is a no-op. Honour that: leave seed and
+      // current-scope mirrors untouched.
+      return;
     } else {
-      // Layer-agnostic — preserve user's CURRENT scope on
-      // detail→detail hops (Bug J); clear on fresh entry from the
-      // overview. Discriminator read from the prior-ref snapshot
-      // (not stale closure state) so a fast hop right after
-      // another chip click sees the prior detail context
-      // correctly.
+      // Layer-agnostic detail→detail hop (different chip) OR
+      // fresh entry from the overview. Discriminator read from
+      // the prior-ref snapshot (not stale closure state) so a
+      // fast hop right after another chip click sees the prior
+      // detail context correctly.
       if (priorActiveSubGraph !== null && detailScopeRef.current) {
         // Snapshot the current scope into a fresh Set so the
         // unmounting detail view's state mutation (via the next

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -55,6 +55,17 @@ interface DetailOrigin {
   layerTabs: Record<MemoryLayerView, LayerContentTab>;
   subGraphTabs: Record<string, SubGraphTab>;
   scroll: { key: string; top: number };
+  /** PR #793 sweep 6 Bug P — snapshot of the detail view's
+   *  `enabledLayers` at the moment the entity was opened. Pre-Bug-P
+   *  the user could enter subgraph A from a WM tab, widen scope
+   *  to WM+SWM in the detail, open an entity, then close back —
+   *  and `SubGraphDetailView` would remount from the STALE
+   *  `subGraphInitialEnabledLayers` seed (still WM-only) and
+   *  silently snap back. Capturing the current scope here and
+   *  restoring it in `handleDetailClose` preserves the user's
+   *  widening/narrowing across the round-trip. `null` when the
+   *  entity was opened from a layer-tab (no subgraph context). */
+  subGraphEnabledLayers: ReadonlySet<TrustLevel> | null;
 }
 
 const DEFAULT_LAYER_TABS: Record<MemoryLayerView, LayerContentTab> = {
@@ -232,6 +243,16 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
       layerTabs: { ...layerContentTabs },
       subGraphTabs: { ...subGraphTabs },
       scroll: { key, top: scrollEl?.scrollTop ?? 0 },
+      // Bug P — snapshot the current detail scope into a fresh
+      // Set so the unmounting SubGraphDetailView's state mutation
+      // can't share the reference. `null` when there's no
+      // subgraph in scope (origin is a layer tab → no scope to
+      // preserve). Read from the ref (sync source of truth) so
+      // the snapshot reflects the user's exact scope at the
+      // moment the entity opened.
+      subGraphEnabledLayers: activeSubGraph !== null && detailScopeRef.current
+        ? new Set<TrustLevel>(detailScopeRef.current)
+        : null,
     };
   }, [
     activeLayer,
@@ -618,6 +639,18 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     // null branch also clears detailScopeRef so the next chip
     // click sees a clean overview-entry context.
     setActiveSubGraphSync(origin.activeSubGraph);
+    // PR #793 sweep 6 Bug P — restore the subgraph scope the
+    // user had at entity-open time. Without this the remounted
+    // SubGraphDetailView would seed from the stale
+    // `subGraphInitialEnabledLayers` (the original entry seed)
+    // and silently snap back to it, losing any widening or
+    // narrowing the user did inside the detail.
+    if (origin.activeSubGraph !== null && origin.subGraphEnabledLayers) {
+      const restored = new Set<TrustLevel>(origin.subGraphEnabledLayers);
+      setSubGraphInitialEnabledLayers(restored);
+      detailScopeRef.current = restored;
+      setCurrentDetailScope(restored);
+    }
     setLayerContentTabs(origin.layerTabs);
     setSubGraphTabs(origin.subGraphTabs);
     pendingScrollRestoreRef.current = origin.scroll;

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -152,6 +152,33 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // "overview-vs-detail" discriminator stays fresh across the
   // race window.
   const activeSubGraphRef = useRef<string | null>(null);
+  // PR #793 sweep 5 Bug N — `activeSubGraph` is mutated by THREE
+  // paths in ProjectView: handleSelectSubGraph (chip click),
+  // handleLayerSwitch (layer tab click), handleDetailClose (M2
+  // origin restore). Each must keep both `activeSubGraphRef` and
+  // `detailScopeRef` in sync or the next chip click's
+  // discriminator misfires (Bug N: subgraph A → WM tab → overview
+  // → click B misclassified as detail→detail hop because
+  // activeSubGraphRef still held 'A' from a path that bypassed
+  // the ref sync). This helper makes both refs invariant: refs
+  // always equal the state they model, regardless of mutation
+  // path. Any future caller that mutates `activeSubGraph` MUST
+  // go through this helper.
+  //
+  // The seed scope (`subGraphInitialEnabledLayers`) is NOT mirrored
+  // here because callers route it explicitly — chip clicks read
+  // the live scope via `detailScopeRef`; layer-switch and
+  // detail-close paths clear it via the slug === null branch
+  // below or directly when needed.
+  const setActiveSubGraphSync = useCallback((slug: string | null) => {
+    activeSubGraphRef.current = slug;
+    if (slug === null) {
+      // Exit always clears the scope mirror so the next chip
+      // click from a fresh route doesn't see a stale carry-over.
+      detailScopeRef.current = null;
+    }
+    setActiveSubGraph(slug);
+  }, []);
   const [selectedLayerContext, setSelectedLayerContext] = useState<MemoryLayerView | null>(null);
   // Mirror `selectedUri` into a ref so `handleNavigate` can read the
   // current value without listing it in deps — listing it caused the
@@ -468,17 +495,20 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // capture). The sync write here just closes the pre-mount
   // timing window.
   const handleSelectSubGraph = useCallback((slug: string | null, originatingLayer?: MemoryLayerView) => {
-    // Read the prior `activeSubGraph` identity from the ref so
-    // the overview-vs-detail discriminator survives a fast
-    // chip-to-chip burst that fires before React re-renders
-    // (Bug L). Then commit the new slug to the ref + state.
+    // Snapshot the prior subgraph identity BEFORE
+    // `setActiveSubGraphSync` overwrites it — the layer-agnostic
+    // branch's overview-vs-detail discriminator needs the value
+    // that was current at click time.
     const priorActiveSubGraph = activeSubGraphRef.current;
-    activeSubGraphRef.current = slug;
     clearDetailOrigin();
-    setActiveSubGraph(slug);
+    // Commit the new slug — the helper writes both the ref and
+    // (for slug === null) the scope-mirror ref, so any
+    // sub-branch below that needs to write `detailScopeRef`
+    // overrides the helper's clear with a fresh value.
+    setActiveSubGraphSync(slug);
     if (slug === null) {
       setSubGraphInitialEnabledLayers(null);
-      detailScopeRef.current = null;
+      // detailScopeRef.current already cleared by the helper.
     } else if (originatingLayer !== undefined) {
       // Single-layer seed (layer-tab entry).
       const seed = new Set<TrustLevel>([TRUST_FOR_LAYER[originatingLayer]]);
@@ -487,9 +517,10 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     } else {
       // Layer-agnostic — preserve user's CURRENT scope on
       // detail→detail hops (Bug J); clear on fresh entry from the
-      // overview. Discriminator read from the ref (not stale
-      // closure state) so a fast hop right after another chip
-      // click sees the prior detail context correctly.
+      // overview. Discriminator read from the prior-ref snapshot
+      // (not stale closure state) so a fast hop right after
+      // another chip click sees the prior detail context
+      // correctly.
       if (priorActiveSubGraph !== null && detailScopeRef.current) {
         // Snapshot the current scope into a fresh Set so the
         // unmounting detail view's state mutation (via the next
@@ -506,15 +537,24 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     }
     setSelectedUri(null);
     setSelectedLayerContext(null);
-  }, [clearDetailOrigin]);
+  }, [clearDetailOrigin, setActiveSubGraphSync]);
 
   const handleLayerSwitch = useCallback((layer: LayerView) => {
     clearDetailOrigin();
     setActiveLayer(layer);
     setSelectedUri(null);
     setSelectedLayerContext(null);
-    setActiveSubGraph(null);
-  }, [clearDetailOrigin]);
+    // PR #793 sweep 5 Bug N — go through the sync helper so the
+    // refs stay invariant with state. Pre-fix this path bypassed
+    // the refs entirely, leaving `activeSubGraphRef` holding the
+    // prior subgraph slug. A subsequent layer-agnostic chip
+    // click would then misclassify itself as a detail→detail
+    // hop and reuse the stale scope.
+    setActiveSubGraphSync(null);
+    // The seed-state must also clear so the next chip click
+    // starts fresh.
+    setSubGraphInitialEnabledLayers(null);
+  }, [clearDetailOrigin, setActiveSubGraphSync]);
 
   const handleLayerTabChange = useCallback((layer: MemoryLayerView, tab: LayerContentTab) => {
     setLayerContentTabs(prev => prev[layer] === tab ? prev : { ...prev, [layer]: tab });
@@ -548,11 +588,17 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     setSelectedLayerContext(null);
     if (!origin) return;
     setActiveLayer(origin.activeLayer);
-    setActiveSubGraph(origin.activeSubGraph);
+    // PR #793 sweep 5 Bug N — restoring the M2 origin's
+    // activeSubGraph must go through the sync helper so the refs
+    // mirror the restored state. When origin.activeSubGraph is
+    // null (entity opened from a layer-tab origin), the helper's
+    // null branch also clears detailScopeRef so the next chip
+    // click sees a clean overview-entry context.
+    setActiveSubGraphSync(origin.activeSubGraph);
     setLayerContentTabs(origin.layerTabs);
     setSubGraphTabs(origin.subGraphTabs);
     pendingScrollRestoreRef.current = origin.scroll;
-  }, []);
+  }, [setActiveSubGraphSync]);
 
   const handleNodeClick = useCallback((node: any) => {
     if (!node?.id) return;

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -125,6 +125,13 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // a sibling of `activeLayer`, not a filter over it: sub-graphs are a peer
   // axis to layers, and each axis gets its own first-class page.
   const [activeSubGraph, setActiveSubGraph] = useState<string | null>(null);
+  // S3 polish #9 — when a chip click on a WM/SWM/VM page transitions
+  // into the sub-graph detail, carry the originating layer through
+  // so the detail view's `enabledLayers` seeds to that layer
+  // (instead of the default all-three) — UX §4.4.1 fold-in #4
+  // ("scope must never silently change semantics across a
+  // navigation transition"). null = no narrowing (default).
+  const [subGraphInitialLayer, setSubGraphInitialLayer] = useState<MemoryLayerView | null>(null);
   const [selectedLayerContext, setSelectedLayerContext] = useState<MemoryLayerView | null>(null);
   // Mirror `selectedUri` into a ref so `handleNavigate` can read the
   // current value without listing it in deps — listing it caused the
@@ -403,10 +410,14 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
 
   // Route a sub-graph chip click to the sub-graph page. Selecting "All"
   // (null) exits the page back to the current layer view, or overview if
-  // we were already on one.
-  const handleSelectSubGraph = useCallback((slug: string | null) => {
+  // we were already on one. The optional `originatingLayer` carries the
+  // bar's `layer` prop through to the detail view so the user's
+  // existing layer scope follows them across the navigation (#9
+  // polish, fold-in #4).
+  const handleSelectSubGraph = useCallback((slug: string | null, originatingLayer?: MemoryLayerView) => {
     clearDetailOrigin();
     setActiveSubGraph(slug);
+    setSubGraphInitialLayer(slug ? (originatingLayer ?? null) : null);
     setSelectedUri(null);
     setSelectedLayerContext(null);
   }, [clearDetailOrigin]);
@@ -575,6 +586,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             onSelectEntity={handleNavigate}
             activeTab={subGraphTabs[activeSubGraph] ?? 'items'}
             onTabChange={tab => handleSubGraphTabChange(activeSubGraph, tab)}
+            initialLayer={subGraphInitialLayer ?? undefined}
           />
         </>
       )}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3979,6 +3979,26 @@ export function SubGraphOverviewGrid({
     return out;
   }, [memory.entityList]);
 
+  // Per-sub-graph URI → trust-level map. Drives the mini-graph
+  // per-node trust colouring (#3 polish, ui-locked priority chain).
+  // Keyed by canonical URI to match the entity-only filter
+  // (`filterTriplesToEntities`) that gates the rendered triple set.
+  // Same `entityList` loop as `entityUrisBySubGraph` so the two
+  // collections stay aligned (every entity in `entityUrisBySubGraph`
+  // has a corresponding `entityTrustByUri` entry).
+  const entityTrustByUriBySubGraph = useMemo(() => {
+    const out = new Map<string, Map<string, TrustLevel>>();
+    for (const e of memory.entityList) {
+      const canonical = canonicalEntityUri(e.uri);
+      for (const sg of e.subGraphs) {
+        let m = out.get(sg);
+        if (!m) { m = new Map<string, TrustLevel>(); out.set(sg, m); }
+        m.set(canonical, e.trustLevel);
+      }
+    }
+    return out;
+  }, [memory.entityList]);
+
   // Merge registered user-facing sub-graphs with profile bindings so
   // icon/color/label/rank all flow from the single source of truth.
   // `isUserFacingSubGraph` centralises the reserved-slug rule
@@ -3991,6 +4011,7 @@ export function SubGraphOverviewGrid({
         const binding = profile?.forSubGraph(sg.name) ?? {};
         const rawTriples = triplesBySubGraph.get(sg.name) ?? [];
         const cardEntityUris = entityUrisBySubGraph.get(sg.name) ?? new Set<string>();
+        const cardEntityTrust = entityTrustByUriBySubGraph.get(sg.name) ?? new Map<string, TrustLevel>();
         return {
           slug: sg.name,
           icon: binding.icon ?? '•',
@@ -4009,10 +4030,11 @@ export function SubGraphOverviewGrid({
           tripleCount: sg.tripleCount,
           triples: filterTriplesToEntities(rawTriples, cardEntityUris),
           layerCounts: layerCountsBySubGraph.get(sg.name) ?? { wm: 0, swm: 0, vm: 0 },
+          entityTrustByUri: cardEntityTrust,
         };
       })
       .sort((a, b) => a.rank - b.rank);
-  }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph]);
+  }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph]);
 
   if (loading && cards.length === 0) {
     return (
@@ -4097,10 +4119,33 @@ export function SubGraphMiniCard({
     description?: string; entityCount: number; tripleCount: number;
     triples: Triple[];
     layerCounts: { wm: number; swm: number; vm: number };
+    entityTrustByUri: Map<string, TrustLevel>;
   };
   onNodeClick?: (node: any) => void;
   onOpen: () => void;
 }) {
+  // Per-URI trust palette for the mini-graph (#3 polish).
+  // ui-locked priority chain (graph-viz style engine):
+  //   1. `nodeColors[uri]` — wins for any entity carrying a
+  //      canonical trust level (TRUST_COLORS[e.trustLevel]).
+  //   2. `defaultNodeColor: card.color` — fallback for non-entity
+  //      URIs (vocabulary IRIs, blank-node anchors) preserves the
+  //      card's chrome identity.
+  //   3. `namespaceColors` — built-in graph-viz tints, neutralised
+  //      to `card.color` so cross-cutting namespaces don't drown
+  //      the per-trust signal.
+  // Build at the card scope from `card.entityTrustByUri` (attached
+  // by the parent `cards` derivation; same canonical key the
+  // entity-only filter uses, so a coloured node here matches the
+  // node the entity-only filter admitted on the canvas).
+  const nodeColors = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const [uri, trustLevel] of card.entityTrustByUri) {
+      out[uri] = TRUST_COLORS[trustLevel];
+    }
+    return out;
+  }, [card.entityTrustByUri]);
+
   // A compact-mode graph options block — pared-down labels, smaller nodes,
   // brighter default color (driven by the sub-graph's profile color) so each
   // card reads as a distinct "island" at a glance.
@@ -4112,6 +4157,10 @@ export function SubGraphMiniCard({
       classColors: CODE_CLASS_COLORS,
       predicateColors: CODE_PREDICATE_COLORS,
       namespaceColors: neutraliseBuiltinNamespaces(card.color),
+      // Per-URI tints sit ABOVE classColors / namespaceColors in
+      // the style-engine priority stack — TRUST_COLORS wins for
+      // every entity in the card's scope (#3 polish).
+      ...(Object.keys(nodeColors).length > 0 ? { nodeColors } : {}),
       defaultNodeColor: card.color,
       defaultEdgeColor: '#475569',
       edgeWidth: 1.0,
@@ -4121,7 +4170,7 @@ export function SubGraphMiniCard({
     },
     hexagon: { baseSize: 6, minSize: 3, maxSize: 16, scaleWithDegree: true },
     focus: { maxNodes: 5000, hops: 999 },
-  }), [card.color]);
+  }), [card.color, nodeColors]);
 
   return (
     <div

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4047,6 +4047,15 @@ export function SubGraphOverviewGrid({
           // membership rule. Fall back to the server count if we have no
           // client set for this sub-graph (e.g. nothing yet hydrated).
           entityCount: cardEntityUris.size > 0 ? cardEntityUris.size : sg.entityCount,
+          // Round 4 (GH #812) — carry the canonical URI set out so
+          // the header subtitle can dedupe distinct entities across
+          // cards. `cards.reduce((a, b) => a + b.entityCount, 0)`
+          // double-counts cross-membership entities (an entity in 2
+          // sub-graphs appears in both cards' count); summing
+          // `entityUris.size` doesn't dedupe across cards either.
+          // The header instead unions the URI sets — see
+          // `distinctEntitiesAcrossCards` below.
+          entityUris: cardEntityUris,
           tripleCount: sg.tripleCount,
           triples: filterTriplesToEntities(rawTriples, cardEntityUris),
           layerCounts: layerCountsBySubGraph.get(sg.name) ?? { wm: 0, swm: 0, vm: 0 },
@@ -4055,6 +4064,26 @@ export function SubGraphOverviewGrid({
       })
       .sort((a, b) => a.rank - b.rank);
   }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph]);
+
+  // Round 4 (GH #812) — header subtitle previously did
+  // `cards.reduce((a, b) => a + b.entityCount, 0)` which sums per-card
+  // entity counts. An entity living in 2 sub-graphs is counted twice
+  // (once per card), so the subtitle double-counted cross-membership
+  // entities and disagreed with the SubGraphBar `All` chip count.
+  // Union the canonical URI sets across user-facing cards instead, so
+  // the subtitle reads as "distinct entities across all sub-graphs"
+  // (matches what `All` shows when the bar is mounted on this page).
+  // Triple double-counting from cross-graph SPO duplicates is the
+  // same family as GH #805 and deferred to that fix.
+  const distinctEntitiesAcrossCards = useMemo(() => {
+    const seen = new Set<string>();
+    for (const card of cards) {
+      const uris = card.entityUris;
+      if (!uris) continue;
+      for (const uri of uris) seen.add(uri);
+    }
+    return seen.size;
+  }, [cards]);
 
   if (loading && cards.length === 0) {
     return (
@@ -4112,7 +4141,7 @@ export function SubGraphOverviewGrid({
       <div className="v10-sgov-header">
         <div className="v10-sgov-title">Subgraphs</div>
         <div className="v10-sgov-sub">
-          {cards.length} subgraphs · {cards.reduce((a, b) => a + b.entityCount, 0)} entities · {cards.reduce((a, b) => a + b.tripleCount, 0)} triples
+          {cards.length} subgraphs · {distinctEntitiesAcrossCards} entities · {cards.reduce((a, b) => a + b.tripleCount, 0)} triples
         </div>
       </div>
       <div className="v10-sgov-grid">
@@ -4140,6 +4169,10 @@ export function SubGraphMiniCard({
     triples: Triple[];
     layerCounts: { wm: number; swm: number; vm: number };
     entityTrustByUri: Map<string, TrustLevel>;
+    // Round 4 (GH #812) — surfaces the canonical entity-URI set so
+    // the parent header can dedupe distinct entities across cards
+    // for the subtitle count. Not consumed inside the mini-card.
+    entityUris?: Set<string>;
   };
   onNodeClick?: (node: any) => void;
   onOpen: () => void;

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4394,6 +4394,8 @@ export function SubGraphDetailView({
   activeTab,
   onTabChange,
   initialLayer,
+  initialEnabledLayers: initialEnabledLayersProp,
+  onEnabledLayersChange,
 }: {
   slug: string;
   rawMemory: ReturnType<typeof useMemoryEntities>;
@@ -4402,15 +4404,33 @@ export function SubGraphDetailView({
   onSelectEntity: (uri: string) => void;
   activeTab?: SubGraphTab;
   onTabChange?: (tab: SubGraphTab) => void;
-  /** S3 polish #9 — when the chip click came from a layer page
+  /** S3 polish #9 — single-layer seed for the common chip-click
+   *  case. When the chip click came from a layer page
    *  (WM/SWM/VM) the originating layer is forwarded here so
    *  `enabledLayers` seeds to that layer instead of the
    *  default all-three. Fold-in #4 from §4.4.1: scope must
    *  never silently change semantics across a navigation
-   *  transition. Omitting (or `undefined`) restores the
-   *  default all-three semantic for chip clicks from Overview
-   *  or the Subgraphs page. */
+   *  transition. Superseded by `initialEnabledLayers` when both
+   *  are set. */
   initialLayer?: 'wm' | 'swm' | 'vm';
+  /** S3 polish PR #793 Bug J — multi-layer seed for
+   *  detail→detail navigation. Pre-fix the chip-click handler
+   *  preserved the STALE seed across hops, dropping any
+   *  user-applied widening (e.g. WM-seeded entry → user widens
+   *  to WM+SWM → hops to another subgraph → next detail
+   *  silently narrowed back to WM-only). Routing the current
+   *  scope through this prop lets the user's exact narrow OR
+   *  widen survive the hop. Single-layer current scope can also
+   *  route through `initialLayer` for callers that prefer the
+   *  simpler shape; multi-layer must use this prop. Wins over
+   *  `initialLayer` when both are set. */
+  initialEnabledLayers?: ReadonlySet<TrustLevel>;
+  /** S3 polish PR #793 Bug J — mirrors the detail view's
+   *  `enabledLayers` state up to the parent so it can route the
+   *  current scope through chip clicks. Optional — without it
+   *  the detail view stays uncontrolled and chip-hop navigation
+   *  reverts to the stale seed shape. */
+  onEnabledLayersChange?: (layers: ReadonlySet<TrustLevel>) => void;
 }) {
   const profile = useProjectProfileContext();
   const binding = profile?.forSubGraph(slug);
@@ -4435,19 +4455,29 @@ export function SubGraphDetailView({
   useEffect(() => {
     setEntitySort(binding?.timelinePredicate ? 'created-desc' : 'triples');
   }, [slug, binding?.timelinePredicate]);
-  // #9 polish — `initialLayer` (when supplied by the chip-row
-  // click) seeds `enabledLayers` to that single layer instead of
-  // the default all-three. Carrying the originating scope
-  // across the navigation transition is the §4.4.1 fold-in #4
-  // contract. The chip click's `originatingLayer` arg flows from
-  // SubGraphBar → ProjectView.handleSelectSubGraph → here.
+  // #9 polish + PR #793 Bug J — derive the seeded scope from
+  // `initialEnabledLayers` (multi-layer Set form, Bug J) or
+  // `initialLayer` (single-layer convenience, #9), in that
+  // precedence. Carrying the user's scope across the navigation
+  // transition is the §4.4.1 fold-in #4 contract.
   const initialEnabledLayers = useMemo(() => {
+    if (initialEnabledLayersProp && initialEnabledLayersProp.size > 0) {
+      return new Set<TrustLevel>(initialEnabledLayersProp);
+    }
     if (initialLayer === 'wm') return new Set<TrustLevel>(['working']);
     if (initialLayer === 'swm') return new Set<TrustLevel>(['shared']);
     if (initialLayer === 'vm') return new Set<TrustLevel>(['verified']);
     return new Set<TrustLevel>(['working', 'shared', 'verified']);
-  }, [initialLayer]);
+  }, [initialLayer, initialEnabledLayersProp]);
   const [enabledLayers, setEnabledLayers] = useState<Set<TrustLevel>>(initialEnabledLayers);
+  // Mirror current scope up to the parent so chip-hop navigation
+  // routes the user's actual current scope (not the stale seed)
+  // through the layer-agnostic chip-click handler. Stable callback
+  // identity from the parent is assumed; the deps capture the Set
+  // identity so widening/narrowing pushes a fresh value through.
+  useEffect(() => {
+    onEnabledLayersChange?.(enabledLayers);
+  }, [enabledLayers, onEnabledLayersChange]);
   const [chipState, setChipState] = useState<Map<string, Set<string>>>(new Map());
   const [activeQuerySlug, setActiveQuerySlug] = useState<string | null>(null);
   const [queryResults, setQueryResults] = useState<Set<string> | null>(null);

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1841,7 +1841,7 @@ export function LayerWidgetStrip({ layer, entities, entityCount, tripleCount, co
 const TRUST_BADGE_CONFIG: Record<TrustLevel, { layerKey: 'wm' | 'swm' | 'vm'; icon: string; label: string }> = {
   working:  { layerKey: 'wm',  icon: '◇', label: 'Working'  },
   shared:   { layerKey: 'swm', icon: '◈', label: 'Shared'   },
-  verified: { layerKey: 'vm',  icon: '◉', label: 'Verified' },
+  verified: { layerKey: 'vm',  icon: '◉', label: 'Verifiable' },
 };
 
 export function EntityList({
@@ -1893,7 +1893,7 @@ export function EntityList({
     return copy;
   }, [entities, externallySorted]);
 
-  const trustLabel = layerKey === 'vm' ? 'Verified' : layerKey === 'swm' ? 'Shared' : 'Working';
+  const trustLabel = layerKey === 'vm' ? 'Verifiable' : layerKey === 'swm' ? 'Shared' : 'Working';
 
   if (entities.length === 0) {
     return (
@@ -2187,7 +2187,7 @@ export function VerifiedMemoryHeroBanner({ entities, tripleCount, contextGraphId
         layer="vm"
         items={[
           { id: 'assets', value: totalAssets, label: 'Knowledge Assets' },
-          { id: 'triples', value: tripleCount.toLocaleString(), label: 'Verified Triples' },
+          { id: 'triples', value: tripleCount.toLocaleString(), label: 'Verifiable Triples' },
           { id: 'types', value: typeCount, label: 'Entity Types' },
         ]}
       />
@@ -4192,7 +4192,7 @@ export function MiniLayerBar({
     return compact ? null : <div className="v10-minibar v10-minibar-empty">No data</div>;
   }
   const rows: Array<{ key: TrustLevel; short: string; count: number; color: string; label: string }> = [
-    { key: 'verified', short: 'VM',  count: counts.vm,  color: '#22c55e', label: 'Verified' },
+    { key: 'verified', short: 'VM',  count: counts.vm,  color: '#22c55e', label: 'Verifiable' },
     { key: 'shared',   short: 'SWM', count: counts.swm, color: '#f59e0b', label: 'Shared' },
     { key: 'working',  short: 'WM',  count: counts.wm,  color: '#64748b', label: 'Working' },
   ];
@@ -4814,7 +4814,7 @@ export function SubGraphDetailView({
           <span className="v10-subgraph-cross-layer-arrow" aria-hidden="true">→</span>
           <span className="v10-subgraph-cross-layer-cell" data-layer="vm">
             <span className="v10-subgraph-cross-layer-cell-icon" style={{ color: TRUST_COLORS.verified }}>◉</span>
-            <span className="v10-subgraph-cross-layer-cell-label">Verified</span>
+            <span className="v10-subgraph-cross-layer-cell-label">Verifiable</span>
             <span className="v10-subgraph-cross-layer-cell-count">{layerCounts.vm}</span>
           </span>
         </div>

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4393,6 +4393,7 @@ export function SubGraphDetailView({
   onSelectEntity,
   activeTab,
   onTabChange,
+  initialLayer,
 }: {
   slug: string;
   rawMemory: ReturnType<typeof useMemoryEntities>;
@@ -4401,6 +4402,15 @@ export function SubGraphDetailView({
   onSelectEntity: (uri: string) => void;
   activeTab?: SubGraphTab;
   onTabChange?: (tab: SubGraphTab) => void;
+  /** S3 polish #9 — when the chip click came from a layer page
+   *  (WM/SWM/VM) the originating layer is forwarded here so
+   *  `enabledLayers` seeds to that layer instead of the
+   *  default all-three. Fold-in #4 from §4.4.1: scope must
+   *  never silently change semantics across a navigation
+   *  transition. Omitting (or `undefined`) restores the
+   *  default all-three semantic for chip clicks from Overview
+   *  or the Subgraphs page. */
+  initialLayer?: 'wm' | 'swm' | 'vm';
 }) {
   const profile = useProjectProfileContext();
   const binding = profile?.forSubGraph(slug);
@@ -4425,9 +4435,19 @@ export function SubGraphDetailView({
   useEffect(() => {
     setEntitySort(binding?.timelinePredicate ? 'created-desc' : 'triples');
   }, [slug, binding?.timelinePredicate]);
-  const [enabledLayers, setEnabledLayers] = useState<Set<TrustLevel>>(
-    () => new Set<TrustLevel>(['working', 'shared', 'verified']),
-  );
+  // #9 polish — `initialLayer` (when supplied by the chip-row
+  // click) seeds `enabledLayers` to that single layer instead of
+  // the default all-three. Carrying the originating scope
+  // across the navigation transition is the §4.4.1 fold-in #4
+  // contract. The chip click's `originatingLayer` arg flows from
+  // SubGraphBar → ProjectView.handleSelectSubGraph → here.
+  const initialEnabledLayers = useMemo(() => {
+    if (initialLayer === 'wm') return new Set<TrustLevel>(['working']);
+    if (initialLayer === 'swm') return new Set<TrustLevel>(['shared']);
+    if (initialLayer === 'vm') return new Set<TrustLevel>(['verified']);
+    return new Set<TrustLevel>(['working', 'shared', 'verified']);
+  }, [initialLayer]);
+  const [enabledLayers, setEnabledLayers] = useState<Set<TrustLevel>>(initialEnabledLayers);
   const [chipState, setChipState] = useState<Map<string, Set<string>>>(new Map());
   const [activeQuerySlug, setActiveQuerySlug] = useState<string | null>(null);
   const [queryResults, setQueryResults] = useState<Set<string> | null>(null);
@@ -4803,12 +4823,13 @@ export function SubGraphDetailView({
 
   // Reset filters when the sub-graph changes — otherwise chips from
   // `tasks` would linger when the user jumps to `decisions` and silently
-  // zero out the list.
+  // zero out the list. `enabledLayers` re-seeds to `initialEnabledLayers`
+  // (default all-three OR the originating-layer scope per #9 polish).
   useEffect(() => {
-    setEnabledLayers(new Set<TrustLevel>(['working', 'shared', 'verified']));
+    setEnabledLayers(initialEnabledLayers);
     setChipState(new Map());
     clearQuery();
-  }, [slug, clearQuery]);
+  }, [slug, clearQuery, initialEnabledLayers]);
 
   useEffect(() => {
     if (!activeTab) setLocalActiveTab('items');

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4859,23 +4859,48 @@ export function SubGraphDetailView({
             : 'This subgraph, across the three memory layers:'}
         </div>
         <div className="v10-subgraph-cross-layer-strip" data-testid="cross-layer-strip">
-          <span className="v10-subgraph-cross-layer-cell" data-layer="wm">
+          {/* Cells are interactive buttons wired to `toggleLayer`
+              (#6, ui-locked). The `→` arrows stay inert span
+              separators — they shouldn't grow click targets. The
+              "refuse last enabled" safeguard at `toggleLayer:4683`
+              already prevents the all-empty state; the
+              `aria-pressed="false"` cells render at 0.5 opacity
+              (CSS) to signal the dimmed state. */}
+          <button
+            type="button"
+            className="v10-subgraph-cross-layer-cell"
+            data-layer="wm"
+            aria-pressed={enabledLayers.has('working')}
+            onClick={() => toggleLayer('working')}
+          >
             <span className="v10-subgraph-cross-layer-cell-icon" style={{ color: TRUST_COLORS.working }}>◇</span>
             <span className="v10-subgraph-cross-layer-cell-label">Working</span>
             <span className="v10-subgraph-cross-layer-cell-count">{layerCounts.wm}</span>
-          </span>
+          </button>
           <span className="v10-subgraph-cross-layer-arrow" aria-hidden="true">→</span>
-          <span className="v10-subgraph-cross-layer-cell" data-layer="swm">
+          <button
+            type="button"
+            className="v10-subgraph-cross-layer-cell"
+            data-layer="swm"
+            aria-pressed={enabledLayers.has('shared')}
+            onClick={() => toggleLayer('shared')}
+          >
             <span className="v10-subgraph-cross-layer-cell-icon" style={{ color: TRUST_COLORS.shared }}>◈</span>
             <span className="v10-subgraph-cross-layer-cell-label">Shared</span>
             <span className="v10-subgraph-cross-layer-cell-count">{layerCounts.swm}</span>
-          </span>
+          </button>
           <span className="v10-subgraph-cross-layer-arrow" aria-hidden="true">→</span>
-          <span className="v10-subgraph-cross-layer-cell" data-layer="vm">
+          <button
+            type="button"
+            className="v10-subgraph-cross-layer-cell"
+            data-layer="vm"
+            aria-pressed={enabledLayers.has('verified')}
+            onClick={() => toggleLayer('verified')}
+          >
             <span className="v10-subgraph-cross-layer-cell-icon" style={{ color: TRUST_COLORS.verified }}>◉</span>
             <span className="v10-subgraph-cross-layer-cell-label">Verifiable</span>
             <span className="v10-subgraph-cross-layer-cell-count">{layerCounts.vm}</span>
-          </span>
+          </button>
         </div>
         <button
           type="button"

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4884,6 +4884,13 @@ export function SubGraphDetailView({
             data-layer="swm"
             aria-pressed={enabledLayers.has('shared')}
             onClick={() => toggleLayer('shared')}
+            /* #8 polish (c) — when SWM is the only enabled layer
+               the Graph pane swaps to agent-attribution coloring;
+               the tooltip surfaces that context-sensitive
+               behaviour so the user understands the colour change. */
+            title={singleLayer === 'swm'
+              ? 'Showing Shared Working Memory only — graph is colored by contributing agent (see legend).'
+              : undefined}
           >
             <span className="v10-subgraph-cross-layer-cell-icon" style={{ color: TRUST_COLORS.shared }}>◈</span>
             <span className="v10-subgraph-cross-layer-cell-label">Shared</span>
@@ -5062,6 +5069,24 @@ export function SubGraphDetailView({
 
         {selectedTab === 'graph' && (
           <div className="v10-layer-expand-body full-width" data-cg-scroll-key={`subgraph:${slug}:graph`}>
+            {/* #8 polish (ux-locked (a)) — discoverability badge
+                surfaces the SWM-attribution coloring rule when the
+                user has narrowed the Graph pane to SWM-only. Pairs
+                with the existing SwmAttributionLegend (which lives
+                inside LayerGraphPanel for the swm layer). */}
+            {singleLayer === 'swm' && (
+              <div
+                className="v10-subgraph-swm-attribution-badge"
+                data-testid="swm-attribution-badge"
+                role="status"
+                aria-label="Graph is colored by contributing agent"
+              >
+                <span className="v10-subgraph-swm-attribution-badge-dot" aria-hidden="true" />
+                <span className="v10-subgraph-swm-attribution-badge-text">
+                  Colored by contributing agent
+                </span>
+              </div>
+            )}
             <LayerGraphPanel
               layer={singleLayer ?? 'wm'}
               triples={graphPanelTriples}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4839,9 +4839,25 @@ export function SubGraphDetailView({
     if (rawSelectedTab !== selectedTab) setSelectedTab(selectedTab);
   }, [rawSelectedTab, selectedTab, setSelectedTab]);
 
-  const hasAnyFilter = enabledLayers.size < 3 || chipState.size > 0 || !!queryResults;
+  // PR #793 Codex sweep 2 (Bug I) — derive the "are we at the
+  // seeded state?" predicate against `initialEnabledLayers`,
+  // NOT the hard-coded all-three set. Pre-fix the seeded
+  // single-layer scope was indistinguishable from a user-applied
+  // filter, so:
+  //   • `Reset filters` was visible immediately on a WM-seeded
+  //     entry — clicking it widened to all-three instead of
+  //     restoring WM.
+  //   • The active-layer pill was clickable at the seeded scope —
+  //     it would widen the same way.
+  // Comparing against `initialEnabledLayers` makes both
+  // affordances honest: hidden / disabled when the user is at
+  // their entry scope; visible / enabled only after they've
+  // actually narrowed or widened.
+  const isAtSeededScope = enabledLayers.size === initialEnabledLayers.size
+    && [...enabledLayers].every(l => initialEnabledLayers.has(l));
+  const hasAnyFilter = !isAtSeededScope || chipState.size > 0 || !!queryResults;
   const resetFilters = () => {
-    setEnabledLayers(new Set<TrustLevel>(['working', 'shared', 'verified']));
+    setEnabledLayers(new Set<TrustLevel>(initialEnabledLayers));
     setChipState(new Map());
     clearQuery();
   };
@@ -4930,16 +4946,26 @@ export function SubGraphDetailView({
             <span className="v10-subgraph-cross-layer-cell-count">{layerCounts.vm}</span>
           </button>
         </div>
+        {/* Bug I — pill restores `initialEnabledLayers`, NOT
+            hard-coded all-three. Disabled at the seeded scope so
+            the affordance doesn't lie. Copy branches on whether
+            the seeded scope is all-three (the Overview / Subgraphs
+            fresh-entry default) or a single layer (entered via
+            WM/SWM/VM tab). */}
         <button
           type="button"
           className={`v10-subgraph-active-layer-pill${enabledLayers.size === 3 ? ' all-layers' : ''}`}
-          onClick={() => setEnabledLayers(new Set<TrustLevel>(['working', 'shared', 'verified']))}
-          disabled={enabledLayers.size === 3}
+          onClick={() => setEnabledLayers(new Set<TrustLevel>(initialEnabledLayers))}
+          disabled={isAtSeededScope}
           data-testid="active-layer-pill"
-          aria-label={`Active layer scope: ${activeLayerLabel}${enabledLayers.size === 3 ? '' : ' — click to reset to all layers'}`}
-          title={enabledLayers.size === 3
-            ? 'Active layer scope: all three memory layers'
-            : 'Click to reset to all layers'}
+          aria-label={`Active layer scope: ${activeLayerLabel}${isAtSeededScope ? '' : (initialEnabledLayers.size === 3 ? ' — click to reset to all layers' : ' — click to restore originating scope')}`}
+          title={isAtSeededScope
+            ? (initialEnabledLayers.size === 3
+                ? 'Active layer scope: all three memory layers'
+                : 'Active layer scope: originating layer from prior navigation')
+            : (initialEnabledLayers.size === 3
+                ? 'Click to reset to all layers'
+                : 'Click to restore originating scope')}
         >
           <span className="v10-subgraph-active-layer-pill-label">Active layer:</span>
           <span className="v10-subgraph-active-layer-pill-value">{activeLayerLabel}</span>

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -5170,24 +5170,17 @@ export function SubGraphDetailView({
 
         {selectedTab === 'graph' && (
           <div className="v10-layer-expand-body full-width" data-cg-scroll-key={`subgraph:${slug}:graph`}>
-            {/* #8 polish (ux-locked (a)) — discoverability badge
-                surfaces the SWM-attribution coloring rule when the
-                user has narrowed the Graph pane to SWM-only. Pairs
-                with the existing SwmAttributionLegend (which lives
-                inside LayerGraphPanel for the swm layer). */}
-            {singleLayer === 'swm' && (
-              <div
-                className="v10-subgraph-swm-attribution-badge"
-                data-testid="swm-attribution-badge"
-                role="status"
-                aria-label="Graph is colored by contributing agent"
-              >
-                <span className="v10-subgraph-swm-attribution-badge-dot" aria-hidden="true" />
-                <span className="v10-subgraph-swm-attribution-badge-text">
-                  Colored by contributing agent
-                </span>
-              </div>
-            )}
+            {/* PR #793 round 2 — the inline "Colored by
+                contributing agent" badge (sweep 0 Bug #8's
+                ux-locked (a) discoverability surface) was removed
+                after manual-test feedback from the original
+                requester. The `SwmAttributionLegend` inside
+                LayerGraphPanel already carries the load-bearing
+                disclosure; the badge above the canvas added
+                visual noise without adding signal. The
+                context-sensitive tooltip on the SWM cross-layer
+                cell (`title` when `singleLayer === 'swm'`) is
+                hover-only insurance and stays. */}
             <LayerGraphPanel
               layer={singleLayer ?? 'wm'}
               triples={graphPanelTriples}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -5000,30 +5000,23 @@ export function SubGraphDetailView({
             <span className="v10-subgraph-cross-layer-cell-count">{layerCounts.vm}</span>
           </button>
         </div>
-        {/* Bug I — pill restores `initialEnabledLayers`, NOT
-            hard-coded all-three. Disabled at the seeded scope so
-            the affordance doesn't lie. Copy branches on whether
-            the seeded scope is all-three (the Overview / Subgraphs
-            fresh-entry default) or a single layer (entered via
-            WM/SWM/VM tab). */}
-        <button
-          type="button"
+        {/* PR #793 round 2 — demoted from clickable pill to
+            inline caption per ui-lead (option c). The
+            "restore" affordance the button used to claim was
+            confusing (it looked dressable but didn't go
+            anywhere); the `Reset filters` button covers the
+            same semantic when chip filters exist. `Bug I`'s
+            `isAtSeededScope` predicate stays — it still gates
+            the Reset button's visibility — but no longer
+            affects this element. Rendered as a `<span>` with
+            metadata role. */}
+        <span
           className={`v10-subgraph-active-layer-pill${enabledLayers.size === 3 ? ' all-layers' : ''}`}
-          onClick={() => setEnabledLayers(new Set<TrustLevel>(initialEnabledLayers))}
-          disabled={isAtSeededScope}
           data-testid="active-layer-pill"
-          aria-label={`Active layer scope: ${activeLayerLabel}${isAtSeededScope ? '' : (initialEnabledLayers.size === 3 ? ' — click to reset to all layers' : ' — click to restore originating scope')}`}
-          title={isAtSeededScope
-            ? (initialEnabledLayers.size === 3
-                ? 'Active layer scope: all three memory layers'
-                : 'Active layer scope: originating layer from prior navigation')
-            : (initialEnabledLayers.size === 3
-                ? 'Click to reset to all layers'
-                : 'Click to restore originating scope')}
         >
           <span className="v10-subgraph-active-layer-pill-label">Active layer:</span>
           <span className="v10-subgraph-active-layer-pill-value">{activeLayerLabel}</span>
-        </button>
+        </span>
       </div>
 
       {queryCatalogs.length > 0 && (

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3993,14 +3993,25 @@ export function SubGraphOverviewGrid({
       for (const sg of e.subGraphs) {
         let m = out.get(sg);
         if (!m) { m = new Map<string, TrustLevel>(); out.set(sg, m); }
-        // PR #793 Codex sweep 4 (Bug M) — store BOTH raw and
-        // canonical URI forms. Triples in the mini-graph may
-        // carry the raw `<urn:...>` form even when entity
-        // membership is keyed canonically; the consumer
-        // `nodeColors` map needs to resolve both forms or the
-        // override falls through to `card.color` and the per-
-        // trust signal is lost. Mirrors the dual-key pattern in
-        // `trustNodeColors` further down this file.
+        // PR #793 Codex sweep 4 (Bug M) — defensive dual-key
+        // write. Mirrors the dual-key shape in `trustNodeColors`
+        // further down this file so consumers can resolve both
+        // raw and canonical URI forms.
+        //
+        // Important: as of HEAD, `useMemoryEntities.ts` calls
+        // `canonicalEntityUri(uri)` at entity-storage time
+        // (`getOrCreate` ~:386) AND graph-viz's `addTriple`
+        // applies `cleanUri()` at ingestion (~core/graph-model.ts:128).
+        // Both pipelines therefore canonicalize, so
+        // `canonical !== e.uri` is currently unreachable and the
+        // raw-key write never fires. Codex sweep 7 (local
+        // reviewer) flagged Bug M's fix as dead code under the
+        // current architecture — keep this as defence-in-depth
+        // against future de-canonicalisation in either pipeline,
+        // but DO NOT trust this branch as the active fix for any
+        // current wrapped-URI lookup failure. If you remove
+        // either canonicalisation, this branch becomes load-
+        // bearing again.
         m.set(canonical, e.trustLevel);
         if (canonical !== e.uri) m.set(e.uri, e.trustLevel);
       }

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3993,7 +3993,16 @@ export function SubGraphOverviewGrid({
       for (const sg of e.subGraphs) {
         let m = out.get(sg);
         if (!m) { m = new Map<string, TrustLevel>(); out.set(sg, m); }
+        // PR #793 Codex sweep 4 (Bug M) — store BOTH raw and
+        // canonical URI forms. Triples in the mini-graph may
+        // carry the raw `<urn:...>` form even when entity
+        // membership is keyed canonically; the consumer
+        // `nodeColors` map needs to resolve both forms or the
+        // override falls through to `card.color` and the per-
+        // trust signal is lost. Mirrors the dual-key pattern in
+        // `trustNodeColors` further down this file.
         m.set(canonical, e.trustLevel);
+        if (canonical !== e.uri) m.set(e.uri, e.trustLevel);
       }
     }
     return out;
@@ -4135,9 +4144,13 @@ export function SubGraphMiniCard({
   //      to `card.color` so cross-cutting namespaces don't drown
   //      the per-trust signal.
   // Build at the card scope from `card.entityTrustByUri` (attached
-  // by the parent `cards` derivation; same canonical key the
-  // entity-only filter uses, so a coloured node here matches the
-  // node the entity-only filter admitted on the canvas).
+  // by the parent `cards` derivation). The upstream map carries
+  // BOTH canonical AND raw URI forms (PR #793 sweep 4 Bug M), so
+  // this loop produces a `nodeColors` map that resolves either
+  // form the rendered triple set may carry — wrapped `<urn:...>`
+  // subjects/objects survive promotion without falling through to
+  // `card.color`. Mirrors the dual-key shape in `trustNodeColors`
+  // further down this file.
   const nodeColors = useMemo(() => {
     const out: Record<string, string> = {};
     for (const [uri, trustLevel] of card.entityTrustByUri) {

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4148,7 +4148,7 @@ export function SubGraphMiniCard({
         <span className="v10-sgov-card-stat"><b>{card.tripleCount}</b> triples</span>
       </div>
       <div className="v10-sgov-card-pyramid">
-        <MiniLayerPyramid counts={card.layerCounts} />
+        <MiniLayerBar counts={card.layerCounts} />
       </div>
       <div className="v10-sgov-card-graph">
         {card.triples.length === 0 ? (
@@ -4172,11 +4172,11 @@ export function SubGraphMiniCard({
   );
 }
 
-// ─── MiniLayerPyramid ────────────────────────────────────────
+// ─── MiniLayerBar ────────────────────────────────────────
 // Three-segment WM/SWM/VM bar. Used as a header widget in the sub-graph
 // page (clickable — toggles which layers contribute entities) and as a
 // compact badge on SubGraphOverviewGrid cards (read-only).
-export function MiniLayerPyramid({
+export function MiniLayerBar({
   counts,
   activeLayers,
   onClickLayer,
@@ -4189,7 +4189,7 @@ export function MiniLayerPyramid({
 }) {
   const total = counts.wm + counts.swm + counts.vm;
   if (total === 0) {
-    return compact ? null : <div className="v10-minipyr v10-minipyr-empty">No data</div>;
+    return compact ? null : <div className="v10-minibar v10-minibar-empty">No data</div>;
   }
   const rows: Array<{ key: TrustLevel; short: string; count: number; color: string; label: string }> = [
     { key: 'verified', short: 'VM',  count: counts.vm,  color: '#22c55e', label: 'Verified' },
@@ -4198,16 +4198,16 @@ export function MiniLayerPyramid({
   ];
   const interactive = !!onClickLayer;
   return (
-    <div className={`v10-minipyr${compact ? ' compact' : ''}`}>
+    <div className={`v10-minibar${compact ? ' compact' : ''}`}>
       {!compact && (
-        <div className="v10-minipyr-bar">
+        <div className="v10-minibar-bar">
           {rows.filter(r => r.count > 0).map(r => {
             const pct = (r.count / total) * 100;
             const active = activeLayers ? activeLayers.has(r.key) : true;
             return (
               <div
                 key={r.key}
-                className={`v10-minipyr-seg${active ? '' : ' dim'}`}
+                className={`v10-minibar-seg${active ? '' : ' dim'}`}
                 style={{ width: `${pct}%`, background: r.color }}
                 title={`${r.label}: ${r.count}`}
               />
@@ -4215,21 +4215,21 @@ export function MiniLayerPyramid({
           })}
         </div>
       )}
-      <div className="v10-minipyr-legend">
+      <div className="v10-minibar-legend">
         {rows.map(r => {
           const active = activeLayers ? activeLayers.has(r.key) : true;
           return (
             <button
               key={r.key}
               type="button"
-              className={`v10-minipyr-chip${active ? '' : ' dim'}${interactive ? ' interactive' : ''}`}
+              className={`v10-minibar-chip${active ? '' : ' dim'}${interactive ? ' interactive' : ''}`}
               onClick={interactive ? () => onClickLayer!(r.key) : undefined}
               disabled={!interactive}
               title={`${r.label} Memory — ${r.count} entities${interactive ? ' (click to toggle)' : ''}`}
             >
-              <span className="v10-minipyr-dot" style={{ background: r.color }} />
-              <span className="v10-minipyr-short">{r.short}</span>
-              <span className="v10-minipyr-count">{r.count}</span>
+              <span className="v10-minibar-dot" style={{ background: r.color }} />
+              <span className="v10-minibar-short">{r.short}</span>
+              <span className="v10-minibar-count">{r.count}</span>
             </button>
           );
         })}
@@ -4778,7 +4778,7 @@ export function SubGraphDetailView({
           <div className="v10-subgraph-detail-title">{title}</div>
           {desc && <div className="v10-subgraph-detail-desc">{desc}</div>}
         </div>
-        <MiniLayerPyramid
+        <MiniLayerBar
           counts={{ wm: layerCounts.wm, swm: layerCounts.swm, vm: layerCounts.vm }}
           activeLayers={enabledLayers}
           onClickLayer={toggleLayer}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4047,15 +4047,6 @@ export function SubGraphOverviewGrid({
           // membership rule. Fall back to the server count if we have no
           // client set for this sub-graph (e.g. nothing yet hydrated).
           entityCount: cardEntityUris.size > 0 ? cardEntityUris.size : sg.entityCount,
-          // Round 4 (GH #812) — carry the canonical URI set out so
-          // the header subtitle can dedupe distinct entities across
-          // cards. `cards.reduce((a, b) => a + b.entityCount, 0)`
-          // double-counts cross-membership entities (an entity in 2
-          // sub-graphs appears in both cards' count); summing
-          // `entityUris.size` doesn't dedupe across cards either.
-          // The header instead unions the URI sets — see
-          // `distinctEntitiesAcrossCards` below.
-          entityUris: cardEntityUris,
           tripleCount: sg.tripleCount,
           triples: filterTriplesToEntities(rawTriples, cardEntityUris),
           layerCounts: layerCountsBySubGraph.get(sg.name) ?? { wm: 0, swm: 0, vm: 0 },
@@ -4064,26 +4055,6 @@ export function SubGraphOverviewGrid({
       })
       .sort((a, b) => a.rank - b.rank);
   }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph]);
-
-  // Round 4 (GH #812) — header subtitle previously did
-  // `cards.reduce((a, b) => a + b.entityCount, 0)` which sums per-card
-  // entity counts. An entity living in 2 sub-graphs is counted twice
-  // (once per card), so the subtitle double-counted cross-membership
-  // entities and disagreed with the SubGraphBar `All` chip count.
-  // Union the canonical URI sets across user-facing cards instead, so
-  // the subtitle reads as "distinct entities across all sub-graphs"
-  // (matches what `All` shows when the bar is mounted on this page).
-  // Triple double-counting from cross-graph SPO duplicates is the
-  // same family as GH #805 and deferred to that fix.
-  const distinctEntitiesAcrossCards = useMemo(() => {
-    const seen = new Set<string>();
-    for (const card of cards) {
-      const uris = card.entityUris;
-      if (!uris) continue;
-      for (const uri of uris) seen.add(uri);
-    }
-    return seen.size;
-  }, [cards]);
 
   if (loading && cards.length === 0) {
     return (
@@ -4140,8 +4111,20 @@ export function SubGraphOverviewGrid({
     <div className="v10-sgov">
       <div className="v10-sgov-header">
         <div className="v10-sgov-title">Subgraphs</div>
+        {/* Round 4.1 (ux-lead, GH #812) — subtitle anchors to the
+            canonical hook surfaces (`memory.counts.total` for
+            entities, `memory.allTriples.length` for triples) so it
+            matches the SubGraphBar `All` chip by construction.
+            Pre-round-4.1 the subtitle derived from card-level
+            aggregates (sum-of-`entityCount` double-counted
+            cross-membership entities; sum-of-`tripleCount` excluded
+            the root bucket). After round 4's `All`-includes-Root
+            reversal the right anchor is the same source the chip
+            row reads from — single source of truth, and when GH
+            #805 fixes the triple total upstream both surfaces fix
+            together. */}
         <div className="v10-sgov-sub">
-          {cards.length} subgraphs · {distinctEntitiesAcrossCards} entities · {cards.reduce((a, b) => a + b.tripleCount, 0)} triples
+          {cards.length} subgraphs · {memory.counts.total} entities · {memory.allTriples.length} triples
         </div>
       </div>
       <div className="v10-sgov-grid">
@@ -4169,10 +4152,6 @@ export function SubGraphMiniCard({
     triples: Triple[];
     layerCounts: { wm: number; swm: number; vm: number };
     entityTrustByUri: Map<string, TrustLevel>;
-    // Round 4 (GH #812) — surfaces the canonical entity-URI set so
-    // the parent header can dedupe distinct entities across cards
-    // for the subtitle count. Not consumed inside the mini-card.
-    entityUris?: Set<string>;
   };
   onNodeClick?: (node: any) => void;
   onOpen: () => void;

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4148,12 +4148,21 @@ export function SubGraphMiniCard({
         <span className="v10-sgov-card-stat"><b>{card.tripleCount}</b> triples</span>
       </div>
       <div className="v10-sgov-card-pyramid">
-        <MiniLayerBar counts={card.layerCounts} />
+        {/* compact mode collapses the empty-counts branch to `null`
+            inside MiniLayerBar, eliminating the duplicate "No data"
+            label that sat next to the card-body fallback. Populated
+            cards render identically. (#2 — ui-locked) */}
+        <MiniLayerBar counts={card.layerCounts} compact />
       </div>
       <div className="v10-sgov-card-graph">
         {card.triples.length === 0 ? (
           <div className="v10-sgov-card-empty">
-            {card.entityCount > 0 ? 'No WM triples · promoted data only' : 'No data yet'}
+            {/* Two-branch wording locked by ux-lead in the #2 amendment.
+                `entityCount > 0` AND mini-graph empty means the
+                sub-graph has content but no WM-shaped data this card
+                can render — pair the literal with the existing ↗ open
+                button so the next action is obvious. */}
+            {card.entityCount > 0 ? 'Promoted — open to view' : 'No data yet'}
           </div>
         ) : (
           <Suspense fallback={<div className="v10-sgov-card-empty">Loading…</div>}>
@@ -4782,6 +4791,7 @@ export function SubGraphDetailView({
           counts={{ wm: layerCounts.wm, swm: layerCounts.swm, vm: layerCounts.vm }}
           activeLayers={enabledLayers}
           onClickLayer={toggleLayer}
+          compact
         />
       </div>
 

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -196,7 +196,7 @@ export const LAYER_CONFIG: Record<'wm' | 'swm' | 'vm', {
     color: '#22c55e',
     title: 'Verifiable Memory',
     desc: 'Endorsed, published, on-chain knowledge',
-    trustLabel: 'Verified',
+    trustLabel: 'Verifiable',
     trustLevel: 'verified',
   },
 };

--- a/packages/node-ui/test/context-graph-empty-stat-components.test.ts
+++ b/packages/node-ui/test/context-graph-empty-stat-components.test.ts
@@ -112,7 +112,7 @@ describe('Context Graph shared empty/stat patterns', () => {
         layer: 'vm',
         items: [
           { id: 'assets', value: 2, label: 'Knowledge Assets' },
-          { id: 'triples', value: '1,234', label: 'Verified Triples' },
+          { id: 'triples', value: '1,234', label: 'Verifiable Triples' },
         ],
       }),
     );
@@ -121,7 +121,7 @@ describe('Context Graph shared empty/stat patterns', () => {
     expect(Array.from(container.querySelectorAll('.v10-stat-strip-value')).map(el => el.textContent))
       .toEqual(['2', '1,234']);
     expect(container.textContent).toContain('Knowledge Assets');
-    expect(container.textContent).toContain('Verified Triples');
+    expect(container.textContent).toContain('Verifiable Triples');
 
     await unmount();
   });

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -132,7 +132,9 @@ describe('Context Graph IA and Overview', () => {
     ]);
     expect(container.textContent).not.toContain('Graph Overview');
     expect(container.textContent).not.toContain('Shared Memory4');
-    expect(container.textContent).not.toContain('Verified Memory');
+    // The legacy "Verified Memory" leak guard is moot post-#4 vocab
+    // sweep — "Verifiable Memory" is now the canonical full-form
+    // layer-switcher label and is intentionally rendered.
 
     const more = container.querySelector<HTMLButtonElement>('.v10-layer-more-btn');
     expect(more).toBeTruthy();

--- a/packages/node-ui/test/project-strip-height.test.ts
+++ b/packages/node-ui/test/project-strip-height.test.ts
@@ -1,0 +1,30 @@
+// PR #793 round 2 — locks `.v10-project-strip { min-height: 44px }`
+// against accidental reversion. The breadcrumb container's
+// reserved height eliminates the layout shift when the breadcrumb
+// transitions from "no subgraph in scope" (project name only) to
+// "subgraph in scope" (project name + `›` + subgraph chip +
+// description).
+//
+// happy-dom doesn't implement layout, so we can't drive a
+// browser and compare rendered heights. Reading the stylesheet
+// source is the practical regression guard — if the rule
+// regresses to 34px or a different value, this test catches it.
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const css = readFileSync(resolve(here, '../src/ui/styles.css'), 'utf8');
+
+describe('PR #793 round 2 — breadcrumb container reserves consistent height', () => {
+  it('reserves min-height: 44px on .v10-project-strip to eliminate layout shift on breadcrumb appearance', () => {
+    // Match the rule block whose selector is exactly
+    // `.v10-project-strip` (NOT one of its child selectors).
+    const blockMatch = css.match(/\.v10-project-strip\s*\{[^}]*\}/m);
+    expect(blockMatch).toBeTruthy();
+    const body = blockMatch![0];
+    expect(body).toMatch(/min-height\s*:\s*44px\s*;/);
+  });
+});

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -226,7 +226,17 @@ vi.mock('../src/ui/components/ActivityFeed.js', () => ({
 }));
 
 vi.mock('../src/ui/components/SubGraphBar.js', () => ({
-  SubGraphBar: ({ selected, onSelect, entities }: { selected: string | null; onSelect: (slug: string | null) => void; entities?: ReadonlyArray<unknown> }) =>
+  SubGraphBar: ({
+    selected,
+    onSelect,
+    entities,
+    layer,
+  }: {
+    selected: string | null;
+    onSelect: (slug: string | null, originatingLayer?: 'wm' | 'swm' | 'vm') => void;
+    entities?: ReadonlyArray<unknown>;
+    layer?: 'wm' | 'swm' | 'vm';
+  }) =>
     React.createElement('div', {
       'data-testid': 'subgraph-bar',
       'data-selected': selected ?? '',
@@ -237,8 +247,25 @@ vi.mock('../src/ui/components/SubGraphBar.js', () => ({
       // client-scoped counting (count contradiction with the
       // grid's daemon-side fallback).
       'data-entities': entities === undefined ? 'undefined' : 'defined',
+      // PR #793 Codex sweep 2 (Bug H) — surface the bar's `layer`
+      // prop so the test can distinguish layer-mode mounts (the
+      // WM/SWM/VM tab path) from layer-agnostic mounts (Subgraph
+      // Explorer overview + the detail-view internal bar).
+      'data-layer': layer ?? '-',
     },
+      // Layer-agnostic chip click — fires onSelect with no
+      // originating layer. Used by the existing tests AND by
+      // Bug H tests to simulate the detail-view internal bar
+      // (which is mounted without `layer`).
       React.createElement('button', { 'data-testid': 'select-subgraph-demo', onClick: () => onSelect('demo') }, 'demo'),
+      React.createElement('button', { 'data-testid': 'select-subgraph-other', onClick: () => onSelect('other') }, 'other'),
+      // Layer-mode chip click — fires onSelect with the bar's
+      // own `layer` prop forwarded as originatingLayer. Used to
+      // simulate the WM/SWM/VM-tab bar's behaviour in tests.
+      React.createElement('button', {
+        'data-testid': 'select-subgraph-alpha-with-layer',
+        onClick: () => onSelect('alpha', layer),
+      }, 'alpha (with layer)'),
       React.createElement('button', { 'data-testid': 'clear-subgraph', onClick: () => onSelect(null) }, 'all')),
 }));
 
@@ -255,13 +282,24 @@ vi.mock('../src/ui/views/project/components.js', () => ({
       React.createElement('div', {}, entity.label),
       React.createElement('button', { 'data-testid': 'open-related-entity', onClick: () => onNavigate('urn:entity:other') }, 'Open related'),
       React.createElement('button', { 'data-testid': 'detail-back', onClick: onClose }, 'Back to Context Graph')),
-  SubGraphDetailView: ({ slug, activeTab = 'items', onTabChange, onSelectEntity }: {
+  SubGraphDetailView: ({ slug, activeTab = 'items', onTabChange, onSelectEntity, initialLayer }: {
     slug: string;
     activeTab?: string;
     onTabChange: (tab: string) => void;
     onSelectEntity: (uri: string) => void;
+    /* PR #793 Codex sweep 2 — surface the `initialLayer` prop so
+       Bug H tests can assert that detail→detail navigation
+       preserves the originating layer scope. `'-'` is the
+       sentinel for undefined so the data attr is always a
+       string (cleaner DOM assertions). */
+    initialLayer?: 'wm' | 'swm' | 'vm';
   }) =>
-    React.createElement('section', { 'data-testid': 'subgraph-detail', 'data-slug': slug, 'data-tab': activeTab },
+    React.createElement('section', {
+      'data-testid': 'subgraph-detail',
+      'data-slug': slug,
+      'data-tab': activeTab,
+      'data-initial-layer': initialLayer ?? '-',
+    },
       React.createElement('button', { 'data-testid': 'subgraph-tab-graph', onClick: () => onTabChange('graph') }, 'Graph'),
       React.createElement('div', { 'data-testid': 'subgraph-scroll', 'data-cg-scroll-key': `subgraph:${slug}:${activeTab}` },
         React.createElement('button', { 'data-testid': 'open-subgraph-entity', onClick: () => onSelectEntity('urn:entity:demo') }, 'Open demo entity'))),
@@ -675,6 +713,87 @@ describe('ProjectView entity detail navigation', () => {
 
     memory.error = null;
     resetMemory();
+  });
+
+  // S3 polish PR #793 Codex sweep 2 (Bug H) — `handleSelectSubGraph`
+  // was unconditionally writing `null` to `subGraphInitialLayer`
+  // whenever `originatingLayer === undefined`. The detail-view
+  // internal SubGraphBar is mounted without a `layer` prop (it's
+  // layer-agnostic by design), so a WM → recipes → bakers nav
+  // silently widened scope back to all three layers on hop 2.
+  // Three call patterns must route differently — see the new
+  // discriminator in handleSelectSubGraph.
+  it('preserves subGraphInitialLayer on detail→detail navigation (Bug H load-bearing)', async () => {
+    // 1. Land on WM tab.
+    await click('switch-wm');
+    await flush();
+    // The WM tab's SubGraphBar mount carries `layer="wm"`.
+    expect(query('subgraph-bar').dataset.layer).toBe('wm');
+
+    // 2. Click `alpha (with layer)` — layer-mode click → enters
+    //    subgraph detail with initialLayer === 'wm'.
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').dataset.slug).toBe('alpha');
+    expect(query('subgraph-detail').dataset.initialLayer).toBe('wm');
+    // The detail-view internal bar is layer-agnostic.
+    expect(query('subgraph-bar').dataset.layer).toBe('-');
+
+    // 3. Click `demo` — layer-agnostic click from inside an
+    //    already-scoped detail. Pre-fix this silently widened to
+    //    all-three; post-fix it preserves WM.
+    await click('select-subgraph-demo');
+    await flush();
+    expect(query('subgraph-detail').dataset.slug).toBe('demo');
+    expect(query('subgraph-detail').dataset.initialLayer).toBe('wm');
+
+    // 4. One more hop — `other` chip; scope still preserved.
+    await click('select-subgraph-other');
+    await flush();
+    expect(query('subgraph-detail').dataset.slug).toBe('other');
+    expect(query('subgraph-detail').dataset.initialLayer).toBe('wm');
+  });
+
+  it('keeps initialLayer === undefined on fresh entry from Subgraph Explorer overview (Bug H regression guard)', async () => {
+    // 1. Land on the Subgraphs tab — no activeSubGraph yet, the
+    //    bar mounts layer-agnostic.
+    await click('switch-subgraphs');
+    await flush();
+    expect(query('subgraph-bar').dataset.layer).toBe('-');
+
+    // 2. Click `demo` from the overview — layer-agnostic but
+    //    activeSubGraph was null before the click → fresh entry
+    //    path → initialLayer stays undefined (detail lands at
+    //    all-three).
+    await click('select-subgraph-demo');
+    await flush();
+    expect(query('subgraph-detail').dataset.slug).toBe('demo');
+    expect(query('subgraph-detail').dataset.initialLayer).toBe('-');
+  });
+
+  it('exit (slug === null) clears any prior initialLayer scope (Bug H regression guard)', async () => {
+    // 1. WM tab → alpha with layer → scope is WM.
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialLayer).toBe('wm');
+
+    // 2. Click clear (the All chip — layer-agnostic, slug === null).
+    //    The detail view unmounts; we re-enter via Subgraphs tab
+    //    overview to confirm scope was cleared.
+    await click('clear-subgraph');
+    await flush();
+    // No detail view at this point — we should be back on WM tab.
+    expect(document.querySelector('[data-testid="subgraph-detail"]')).toBeNull();
+
+    // 3. Switch to Subgraphs tab and enter detail fresh — must
+    //    land at all-three (initialLayer === undefined),
+    //    confirming the exit cleared the prior WM scope rather
+    //    than preserving it across the round-trip.
+    await click('switch-subgraphs');
+    await click('select-subgraph-demo');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialLayer).toBe('-');
   });
 
 });

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -1014,4 +1014,87 @@ describe('ProjectView entity detail navigation', () => {
     expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('-');
   });
 
+  // S3 polish PR #793 Codex sweep 5 (Bug N) — `activeSubGraphRef`
+  // and `detailScopeRef` go stale on any state-mutation path
+  // that bypasses the sync helper. Pre-Bug-N the layer-switcher
+  // and detail-close paths called `setActiveSubGraph` directly,
+  // so the next layer-agnostic chip click would misclassify
+  // itself as a detail→detail hop and reuse stale scope.
+  it('subgraph A (WM-seeded) → layer switch → overview → click B is a FRESH overview entry (Bug N load-bearing)', async () => {
+    // 1. WM tab → alpha-with-layer → seeds Set(['working']).
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('working');
+
+    // 2. Switch to WM tab again (layer-switch path). Pre-fix
+    //    this called setActiveSubGraph(null) directly, leaving
+    //    activeSubGraphRef='alpha' AND detailScopeRef=Set(['working']).
+    await click('switch-wm');
+    await flush();
+    // Detail view unmounts; we're back on the WM layer page.
+    expect(document.querySelector('[data-testid="subgraph-detail"]')).toBeNull();
+
+    // 3. Go to the Subgraphs overview, click `demo`. The chip
+    //    click is layer-agnostic. Pre-Bug-N the stale refs would
+    //    misroute this through the detail→detail branch and
+    //    re-seed Set(['working']). Post-fix the helper clears
+    //    both refs so demo lands at all-three.
+    await click('switch-subgraphs');
+    await click('select-subgraph-demo');
+    await flush();
+    expect(query('subgraph-detail').dataset.slug).toBe('demo');
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('-');
+  });
+
+  it('subgraph A → layer switch → layer-mode chip click still seeds the new layer (Bug N regression guard)', async () => {
+    // Layer-mode entry path must remain correct after a
+    // layer-switch reset — proves the helper's null-clear didn't
+    // accidentally break the originating-layer carry-over for
+    // the next chip click.
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('working');
+
+    // Switch to SWM tab (this clears scope via the helper).
+    await click('switch-swm');
+    await flush();
+
+    // Click the layer-mode chip from SWM — should seed Set(['shared']).
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('shared');
+  });
+
+  it('subgraph A → open entity → detail-close → click B is a FRESH layer-tab entry (Bug N close-path)', async () => {
+    // The detail-close path restores M2 origin. Pre-Bug-N this
+    // called setActiveSubGraph(origin.activeSubGraph) directly,
+    // leaving refs stale across the round-trip. Verify the close
+    // path goes through the helper and the next chip click sees
+    // a clean state matching the restored origin.
+
+    // 1. WM tab → open an entity directly from the layer list
+    //    (no sub-graph in scope). detail.activeSubGraph in
+    //    origin is null.
+    await click('switch-wm');
+    await click('open-layer-overlap-entity');
+    await flush();
+    expect(query('entity-detail').dataset.entity).toBe('urn:entity:overlap');
+
+    // 2. detail-back → handleDetailClose restores origin
+    //    (activeSubGraph=null since we opened from a layer tab).
+    //    Helper must clear refs.
+    await click('detail-back');
+    await flush();
+    expect(document.querySelector('[data-testid="entity-detail"]')).toBeNull();
+
+    // 3. Navigate to Subgraphs overview → click `demo`. Must
+    //    land at all-three (fresh overview entry).
+    await click('switch-subgraphs');
+    await click('select-subgraph-demo');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('-');
+  });
+
 });

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -282,7 +282,7 @@ vi.mock('../src/ui/views/project/components.js', () => ({
       React.createElement('div', {}, entity.label),
       React.createElement('button', { 'data-testid': 'open-related-entity', onClick: () => onNavigate('urn:entity:other') }, 'Open related'),
       React.createElement('button', { 'data-testid': 'detail-back', onClick: onClose }, 'Back to Context Graph')),
-  SubGraphDetailView: ({ slug, activeTab = 'items', onTabChange, onSelectEntity, initialLayer }: {
+  SubGraphDetailView: ({ slug, activeTab = 'items', onTabChange, onSelectEntity, initialLayer, initialEnabledLayers, onEnabledLayersChange }: {
     slug: string;
     activeTab?: string;
     onTabChange: (tab: string) => void;
@@ -293,16 +293,82 @@ vi.mock('../src/ui/views/project/components.js', () => ({
        sentinel for undefined so the data attr is always a
        string (cleaner DOM assertions). */
     initialLayer?: 'wm' | 'swm' | 'vm';
-  }) =>
-    React.createElement('section', {
+    /* PR #793 sweep 3 Bug J — multi-layer seed prop. Mock
+       surfaces both `data-initial-layer` (single-layer back-compat
+       derived from initialEnabledLayers when size === 1) AND
+       `data-initial-enabled-layers` (comma-joined trust levels,
+       e.g. "working,shared"; '-' when absent). Existing Bug H
+       assertions on data-initial-layer continue to pass via the
+       derivation. */
+    initialEnabledLayers?: ReadonlySet<'working' | 'shared' | 'verified'>;
+    /* The detail view normally pushes its enabledLayers up via
+       this callback so ProjectView can route the user's CURRENT
+       scope through chip clicks (Bug J). Mock exposes buttons
+       per layer combo so tests can simulate widening / narrowing
+       inside the detail view. */
+    onEnabledLayersChange?: (layers: ReadonlySet<'working' | 'shared' | 'verified'>) => void;
+  }) => {
+    const derivedSingleLayer =
+      initialEnabledLayers && initialEnabledLayers.size === 1
+        ? (() => {
+            const only = initialEnabledLayers.values().next().value as string;
+            if (only === 'working') return 'wm';
+            if (only === 'shared') return 'swm';
+            if (only === 'verified') return 'vm';
+            return '-';
+          })()
+        : (initialLayer ?? '-');
+    const enabledSummary = initialEnabledLayers
+      ? [...initialEnabledLayers].sort().join(',')
+      : (initialLayer === 'wm' ? 'working'
+        : initialLayer === 'swm' ? 'shared'
+        : initialLayer === 'vm' ? 'verified'
+        : '-');
+    // Bug J — the real SubGraphDetailView mirrors its
+    // `enabledLayers` state up via `onEnabledLayersChange` so
+    // ProjectView can route the current scope through chip
+    // clicks. The mock needs to honour the same contract or
+    // detail→detail tests see an empty mirror and fall to the
+    // null branch.
+    React.useEffect(() => {
+      if (!onEnabledLayersChange) return;
+      if (initialEnabledLayers && initialEnabledLayers.size > 0) {
+        onEnabledLayersChange(new Set(initialEnabledLayers));
+      } else if (initialLayer) {
+        const only = initialLayer === 'wm' ? 'working'
+          : initialLayer === 'swm' ? 'shared' : 'verified';
+        onEnabledLayersChange(new Set([only as 'working' | 'shared' | 'verified']));
+      } else {
+        onEnabledLayersChange(new Set(['working', 'shared', 'verified']));
+      }
+    }, [initialEnabledLayers, initialLayer, onEnabledLayersChange]);
+    return React.createElement('section', {
       'data-testid': 'subgraph-detail',
       'data-slug': slug,
       'data-tab': activeTab,
-      'data-initial-layer': initialLayer ?? '-',
+      'data-initial-layer': derivedSingleLayer,
+      'data-initial-enabled-layers': enabledSummary,
     },
       React.createElement('button', { 'data-testid': 'subgraph-tab-graph', onClick: () => onTabChange('graph') }, 'Graph'),
+      // Bug J — buttons to simulate the user widening / narrowing
+      // inside the detail view; each fires the mirror callback so
+      // ProjectView captures the current scope ahead of any
+      // chip-hop click.
+      React.createElement('button', {
+        'data-testid': 'detail-widen-wm-swm',
+        onClick: () => onEnabledLayersChange?.(new Set(['working', 'shared'])),
+      }, 'widen WM+SWM'),
+      React.createElement('button', {
+        'data-testid': 'detail-set-vm-only',
+        onClick: () => onEnabledLayersChange?.(new Set(['verified'])),
+      }, 'narrow to VM'),
+      React.createElement('button', {
+        'data-testid': 'detail-set-all-three',
+        onClick: () => onEnabledLayersChange?.(new Set(['working', 'shared', 'verified'])),
+      }, 'all three'),
       React.createElement('div', { 'data-testid': 'subgraph-scroll', 'data-cg-scroll-key': `subgraph:${slug}:${activeTab}` },
-        React.createElement('button', { 'data-testid': 'open-subgraph-entity', onClick: () => onSelectEntity('urn:entity:demo') }, 'Open demo entity'))),
+        React.createElement('button', { 'data-testid': 'open-subgraph-entity', onClick: () => onSelectEntity('urn:entity:demo') }, 'Open demo entity')));
+  },
   ProjectOverviewCard: ({ onOpenPrimer, participants, participantsStatus, subGraphCount, subGraphFetchFailed }: {
     onOpenPrimer: () => void;
     participants: string[];
@@ -794,6 +860,78 @@ describe('ProjectView entity detail navigation', () => {
     await click('select-subgraph-demo');
     await flush();
     expect(query('subgraph-detail').dataset.initialLayer).toBe('-');
+  });
+
+  // S3 polish PR #793 Codex sweep 3 (Bug J) — `handleSelectSubGraph`
+  // was preserving the STALE seed across detail→detail hops, not
+  // the user's current scope. A WM-tab entry that widens to
+  // WM+SWM in the detail view then hops to another subgraph
+  // silently snapped back to WM-only. Fix: ProjectView reads
+  // the detail view's current scope from a mirror ref (populated
+  // via `onEnabledLayersChange`) and routes it through.
+  it('detail→detail nav preserves USER\'S CURRENT scope after widening, not the stale seed (Bug J load-bearing)', async () => {
+    // 1. WM tab → alpha-with-layer → detail seeds Set(['working']).
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('working');
+
+    // 2. User widens to WM+SWM inside the detail view (mock
+    //    button drives the mirror callback directly).
+    await click('detail-widen-wm-swm');
+    await flush();
+
+    // 3. Hop to a different subgraph via the detail-view internal
+    //    bar (layer-agnostic click). Pre-fix this re-seeded to WM
+    //    only (the stale seed); post-fix it carries WM+SWM.
+    await click('select-subgraph-demo');
+    await flush();
+    expect(query('subgraph-detail').dataset.slug).toBe('demo');
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('shared,working');
+  });
+
+  it('detail→detail nav carries narrowed-to-VM scope through the hop (Bug J symmetric)', async () => {
+    // 1. WM tab → alpha-with-layer → detail seeds Set(['working']).
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+
+    // 2. User switches focus entirely to VM (a different single
+    //    layer from the seed).
+    await click('detail-set-vm-only');
+    await flush();
+
+    // 3. Hop — next detail seeds Set(['verified']), not the
+    //    stale 'working' seed.
+    await click('select-subgraph-demo');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('verified');
+  });
+
+  it('detail→detail nav when current scope === seed still preserves correctly (Bug J / Bug H regression guard)', async () => {
+    // The Bug H case must continue to work — the user hasn't
+    // touched the seed, so the hop should carry it through.
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    // (no widen/narrow click — current scope === seed)
+    await click('select-subgraph-demo');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('working');
+  });
+
+  it('detail→detail nav when user widens to all-three carries multi-layer scope through (Bug J)', async () => {
+    // Edge case: user reverts to all-three inside the detail
+    // view, then hops. Next detail should land at all-three, not
+    // the WM seed.
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    await click('detail-set-all-three');
+    await flush();
+    await click('select-subgraph-demo');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('shared,verified,working');
   });
 
 });

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -934,4 +934,84 @@ describe('ProjectView entity detail navigation', () => {
     expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('shared,verified,working');
   });
 
+  // S3 polish PR #793 Codex sweep 4 (Bug L) — `detailScopeRef.current`
+  // was only refreshed by SubGraphDetailView's mirror effect, which
+  // fires AFTER React paints. A fast chip-to-chip hop that fires
+  // before the mirror effect would read a stale ref → seeds lost.
+  // The fix writes the ref synchronously in every branch of
+  // handleSelectSubGraph that updates the seed state.
+  //
+  // Testing approach: pack both clicks into a single act() block
+  // without flushing between them. The mirror useEffect's setState
+  // batches into the act() boundary, so when the second click fires
+  // mid-batch the ref is the only sync state available — exactly the
+  // race window Bug L closes.
+  it('WM-tab → A → B fast hop synchronously preserves the WM seed (Bug L load-bearing)', async () => {
+    await click('switch-wm');
+    await flush();
+
+    // Two clicks in a single act() block — mimics a user-input
+    // burst that completes before React's effect schedule runs the
+    // mirror useEffect for the A detail mount. Pre-Bug-L the second
+    // click would read ref=null and route through the layer-agnostic
+    // overview branch, losing the WM seed.
+    await act(async () => {
+      query('select-subgraph-alpha-with-layer').click();
+      query('select-subgraph-demo').click();
+    });
+    await flush();
+
+    expect(query('subgraph-detail').dataset.slug).toBe('demo');
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('working');
+  });
+
+  it('exit-then-immediate-entry clears scope synchronously (Bug L exit-branch guard)', async () => {
+    // 1. WM tab → alpha (seeds WM, ref=Set(['working'])).
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('working');
+
+    // 2. Exit → Subgraphs → demo in a single batch. The exit
+    //    branch's sync ref clear is load-bearing: pre-fix, the
+    //    Subgraphs → demo hop would read the stale Set(['working'])
+    //    ref and silently narrow scope to WM-only.
+    await act(async () => {
+      query('clear-subgraph').click();
+    });
+    await flush();
+    await act(async () => {
+      query('switch-subgraphs').click();
+      query('select-subgraph-demo').click();
+    });
+    await flush();
+
+    expect(query('subgraph-detail').dataset.slug).toBe('demo');
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('-');
+  });
+
+  it('overview → A → B fast hop reads non-null ref on the layer-agnostic path (Bug L cold-start)', async () => {
+    // Overview path: A click sets ref=null (fresh entry). Before
+    // A's mirror effect runs (which would push Set(['working',
+    // 'shared', 'verified']) — the default — into the ref), B
+    // click fires. The B click's layer-agnostic branch reads
+    // `activeSubGraph !== null && detailScopeRef.current` — Bug L
+    // ensures `detailScopeRef.current` was nulled SYNCHRONOUSLY
+    // by A's click, so B correctly falls to the fresh-entry path
+    // (initialEnabledLayers === undefined → all-three default).
+    // Pre-fix this race could leave a STALE seed from a prior
+    // detail visit in the ref, contaminating the new chip click.
+    await click('switch-subgraphs');
+    await flush();
+
+    await act(async () => {
+      query('select-subgraph-demo').click();
+      query('select-subgraph-other').click();
+    });
+    await flush();
+
+    expect(query('subgraph-detail').dataset.slug).toBe('other');
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('-');
+  });
+
 });

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -265,6 +265,10 @@ vi.mock('../src/ui/components/SubGraphBar.js', () => ({
       // (which is mounted without `layer`).
       React.createElement('button', { 'data-testid': 'select-subgraph-demo', onClick: () => onSelect('demo') }, 'demo'),
       React.createElement('button', { 'data-testid': 'select-subgraph-other', onClick: () => onSelect('other') }, 'other'),
+      // Layer-agnostic alpha click — simulates the detail-view
+      // internal bar clicking the active chip (a same-chip
+      // click). Used by Bug Q to assert the no-op invariant.
+      React.createElement('button', { 'data-testid': 'select-subgraph-alpha', onClick: () => onSelect('alpha') }, 'alpha'),
       // Layer-mode chip click — fires onSelect with the bar's
       // own `layer` prop forwarded as originatingLayer. Used to
       // simulate the WM/SWM/VM-tab bar's behaviour in tests.
@@ -1247,6 +1251,41 @@ describe('ProjectView entity detail navigation', () => {
     // path, not enabledScope, so `data-enabled-scope` is '-'
     // (the mock returns '-' when enabledScope is undefined).
     expect(query('subgraph-bar').dataset.enabledScope).toBe('-');
+  });
+
+  // S3 polish PR #793 local-reviewer sweep 7 (Bug Q) — same-chip
+  // click was overwriting the entry seed with the user's
+  // current (post-widening) scope, silently breaking Bug I's
+  // `isAtSeededScope` semantic so the active-layer pill's
+  // "restore originating scope" affordance disappeared. The
+  // natural pre-PR semantic is "same-chip click is a no-op".
+  it('same-chip click preserves the entry seed when user has widened (Bug Q load-bearing)', async () => {
+    // 1. WM tab → alpha (seeds Set(['working'])).
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').getAttribute('data-initial-enabled-layers')).toBe('working');
+
+    // 2. User widens to WM+SWM via the mirror callback.
+    await click('detail-widen-wm-swm');
+    await flush();
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('shared,working');
+
+    // 3. User clicks the alpha chip again from the detail-view
+    //    internal bar (layer-agnostic). Pre-Bug-Q this would
+    //    snapshot the widened scope into the seed; post-fix the
+    //    seed stays at the original WM-only entry baseline.
+    await click('select-subgraph-alpha');
+    await flush();
+
+    // Detail view still on alpha — but more importantly the seed
+    // was NOT overwritten.
+    expect(query('subgraph-detail').dataset.slug).toBe('alpha');
+    expect(query('subgraph-detail').getAttribute('data-initial-enabled-layers')).toBe('working');
+    // Current scope mirror should also stay at the user's
+    // widened scope (the no-op invariant means no mirror writes
+    // occur; previously-set widened scope persists).
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('shared,working');
   });
 
 });

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -231,15 +231,21 @@ vi.mock('../src/ui/components/SubGraphBar.js', () => ({
     onSelect,
     entities,
     layer,
+    enabledScope,
   }: {
     selected: string | null;
     onSelect: (slug: string | null, originatingLayer?: 'wm' | 'swm' | 'vm') => void;
     entities?: ReadonlyArray<unknown>;
     layer?: 'wm' | 'swm' | 'vm';
+    enabledScope?: ReadonlySet<'working' | 'shared' | 'verified'>;
   }) =>
     React.createElement('div', {
       'data-testid': 'subgraph-bar',
       'data-selected': selected ?? '',
+      // PR #793 sweep 6 Bug O — comma-joined sorted trust
+      // levels in `enabledScope`, `-` when absent. Lets Bug O
+      // tests assert the bar's scope mirrors the detail view.
+      'data-enabled-scope': enabledScope ? [...enabledScope].sort().join(',') : '-',
       // S3 Codex Bug C — surface the `entities` prop's
       // resolution so tests can assert ProjectView gates it on
       // a fully-loaded memory snapshot. `defined` while
@@ -1095,6 +1101,72 @@ describe('ProjectView entity detail navigation', () => {
     await click('select-subgraph-demo');
     await flush();
     expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('-');
+  });
+
+  // S3 polish PR #793 Codex sweep 6 (Bug O) — the SubGraphBar
+  // mounted alongside an active subgraph detail must receive the
+  // detail's current `enabledLayers` scope so its chip counts
+  // reflect the same filtered slice. Pre-fix the bar was
+  // layer-agnostic (showing all-three counts) above a layer-
+  // filtered detail body — same-screen disagreement.
+  it('detail-view sibling SubGraphBar receives the detail scope as enabledScope (Bug O load-bearing — single-layer entry)', async () => {
+    // WM-tab entry → seeds Set(['working']) on both the detail
+    // AND the sibling bar.
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('working');
+    // The detail-view sibling bar mounts on this branch — assert
+    // its enabledScope matches.
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('working');
+  });
+
+  it('detail-view sibling SubGraphBar updates when the user widens detail scope (Bug O multi-layer)', async () => {
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    // Baseline: WM only.
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('working');
+
+    // User widens the detail's scope to WM+SWM. The mirror
+    // callback updates the parent state → bar re-renders.
+    await click('detail-widen-wm-swm');
+    await flush();
+
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('shared,working');
+  });
+
+  it('detail-view sibling SubGraphBar reflects all-three scope on overview-entry (Bug O regression guard)', async () => {
+    // Fresh-entry from Subgraphs overview: detail seeds at
+    // all-three; bar's enabledScope should reflect the same
+    // (or fall through to layer-agnostic, which the mock
+    // surfaces identically when scope is the full set).
+    await click('switch-subgraphs');
+    await click('select-subgraph-demo');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('-');
+    // The mirror effect fires on mount with all-three. The bar
+    // receives that Set; per the bar's collapse rule (sweep 6
+    // Bug O — size 3 is treated as layer-agnostic in display
+    // logic but the carrier still flows through) the mock
+    // surfaces the comma-joined string.
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('shared,verified,working');
+  });
+
+  it('exit from detail clears the sibling SubGraphBar scope state (Bug O exit invariant)', async () => {
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('working');
+
+    // Exit to the WM tab — sync helper's null-clear branch
+    // wipes both the ref and the bar's scope state.
+    await click('clear-subgraph');
+    await flush();
+    // Detail view unmounted; the WM-tab branch's bar (a different
+    // mount) has no enabledScope by design (it's the layer-tab
+    // mount, which uses the legacy `layer={activeLayer}` path).
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('-');
   });
 
 });

--- a/packages/node-ui/test/project-view-navigation.test.ts
+++ b/packages/node-ui/test/project-view-navigation.test.ts
@@ -1169,4 +1169,84 @@ describe('ProjectView entity detail navigation', () => {
     expect(query('subgraph-bar').dataset.enabledScope).toBe('-');
   });
 
+  // S3 polish PR #793 Codex sweep 6 (Bug P) — handleDetailClose
+  // restored activeSubGraph but never restored the user's
+  // current `enabledLayers` scope, so the SubGraphDetailView
+  // would remount from the stale `subGraphInitialEnabledLayers`
+  // seed and snap back to the original scope. Fix: DetailOrigin
+  // captures `subGraphEnabledLayers` at entity-open; close-path
+  // restores from the snapshot.
+  it('subgraph A widened to WM+SWM → open entity → close-back → scope stays at WM+SWM (Bug P load-bearing)', async () => {
+    // 1. WM tab → alpha (seeds Set(['working'])).
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').dataset.initialEnabledLayers).toBe('working');
+
+    // 2. User widens to WM+SWM in the detail view. Mirror
+    //    callback updates currentDetailScope.
+    await click('detail-widen-wm-swm');
+    await flush();
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('shared,working');
+
+    // 3. Open an entity from inside the subgraph detail. This
+    //    captures the DetailOrigin including the current scope.
+    await click('open-subgraph-entity');
+    await flush();
+    expect(query('entity-detail').dataset.entity).toBe('urn:entity:demo');
+    expect(document.querySelector('[data-testid="subgraph-detail"]')).toBeNull();
+
+    // 4. Close the entity → handleDetailClose restores from
+    //    origin. Pre-Bug-P this would snap back to WM-only
+    //    (stale seed); post-fix preserves WM+SWM.
+    await click('detail-back');
+    await flush();
+    expect(query('subgraph-detail').dataset.slug).toBe('alpha');
+    // `data-initial-enabled-layers` is the Set carrier; assert
+    // both layers survive the round-trip.
+    expect(query('subgraph-detail').getAttribute('data-initial-enabled-layers')).toBe('shared,working');
+    // Single-layer alias collapses to '-' for size > 1 (the
+    // mock's derivation only resolves a layer abbreviation when
+    // scope size === 1).
+    expect(query('subgraph-detail').dataset.initialLayer).toBe('-');
+    // The sibling bar receives the restored scope.
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('shared,working');
+  });
+
+  it('subgraph A at seed scope → open entity → close-back → scope still at seed (Bug P regression guard)', async () => {
+    // No-op case — user didn't widen/narrow, the restored scope
+    // equals the seed.
+    await click('switch-wm');
+    await click('select-subgraph-alpha-with-layer');
+    await flush();
+    expect(query('subgraph-detail').getAttribute('data-initial-enabled-layers')).toBe('working');
+
+    await click('open-subgraph-entity');
+    await flush();
+    await click('detail-back');
+    await flush();
+    expect(query('subgraph-detail').dataset.slug).toBe('alpha');
+    expect(query('subgraph-detail').getAttribute('data-initial-enabled-layers')).toBe('working');
+  });
+
+  it('entity opened from a layer-tab origin → close-back → no scope restoration (Bug P origin-shape guard)', async () => {
+    // When the entity opens from a layer-tab page (no subgraph
+    // in scope), origin.activeSubGraph is null. The restore
+    // branch must NOT touch the scope mirrors — there was no
+    // scope to preserve. Proves Bug P's null guard.
+    await click('switch-wm');
+    await click('open-layer-overlap-entity');
+    await flush();
+    expect(query('entity-detail').dataset.entity).toBe('urn:entity:overlap');
+
+    await click('detail-back');
+    await flush();
+    // Back on the WM tab — no subgraph-detail mount.
+    expect(document.querySelector('[data-testid="subgraph-detail"]')).toBeNull();
+    // The WM-tab bar mount uses the legacy `layer={activeLayer}`
+    // path, not enabledScope, so `data-enabled-scope` is '-'
+    // (the mock returns '-' when enabledScope is undefined).
+    expect(query('subgraph-bar').dataset.enabledScope).toBe('-');
+  });
+
 });

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -266,13 +266,17 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(allCount).toBe(3);
   });
 
-  // Layer-agnostic counterpart of the previous case: on the sub-graph
-  // page `ProjectView` passes `entities` without `layer`, and "All"
-  // represents the umbrella over named-sub-graph chips. Entities with
-  // no chip membership (root-bucket SWM entities, empty `subGraphs`)
-  // must STAY excluded here — including them would inflate the total
-  // past anything the user can reach by clicking a chip.
-  it('without `layer`: the "All" chip total excludes entities with no named sub-graph membership (umbrella over chips)', async () => {
+  // Layer-agnostic counterpart of the previous case. Round 4 reversal
+  // of §4.4.1 (ux-lead): `All` now INCLUDES Root in BOTH layer and
+  // layer-agnostic modes. Pre-round-4 lock excluded root-bucket
+  // entities here on the rationale that `All` should be the umbrella
+  // over drillable named-sub-graph chips. That rationale didn't
+  // survive S3 #772 shipping the Root chip — once Root became
+  // drillable too, excluding it from `All` reintroduced the same
+  // "All ≠ chip-row union" contradiction the bar was meant to fix.
+  // User manual-test on round 3 surfaced it; ux-lead locked option
+  // (A): unify both modes to "every distinct entity in scope".
+  it('without `layer`: the "All" chip total INCLUDES root-bucket entities (round 4 §4.4.1 reversal)', async () => {
     const rootEntity = (uri: string, trust: 'working' | 'shared' | 'verified'): any => ({
       uri, label: uri, types: [],
       trustLevel: trust,
@@ -303,8 +307,65 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     const allChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
       .find(b => b.textContent?.includes('All'));
     const allCount = Number(allChip?.querySelector('.v10-subgraph-chip-count')?.textContent ?? 'NaN');
-    // 2 chip-reachable entities (alpha, beta). Root entities excluded.
-    expect(allCount).toBe(2);
+    // 4 distinct entities (alpha, beta, root-1, root-2). Root
+    // bucket included alongside named-sub-graph members.
+    expect(allCount).toBe(4);
+  });
+
+  // Round 4 regression guard — cross-membership entities must NOT be
+  // double-counted when `All` includes root in layer-agnostic mode.
+  // Fixture: 1 entity in both 'alpha' AND 'beta' (chip row would show
+  // alpha=2, beta=2 if anything else were in each); 1 entity in only
+  // 'alpha'; 1 entity in only 'beta'; 1 root entity. Naive
+  // sum-of-chips would give alpha(2)+beta(2)+root(1)=5 (double-counts
+  // the cross entity); distinct count is 4. The `All` chip must show
+  // the distinct count.
+  it('without `layer`: the "All" chip distinct-counts cross-membership entities + root (round 4 regression)', async () => {
+    const rootEntity = (uri: string, trust: 'working' | 'shared' | 'verified'): any => ({
+      uri, label: uri, types: [],
+      trustLevel: trust,
+      layers: new Set([trust]),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    });
+    const entities: any[] = [
+      mkEntity('urn:e:alpha-only', 'working', 'alpha'),
+      mkEntity('urn:e:beta-only', 'working', 'beta'),
+      {
+        uri: 'urn:e:cross',
+        label: 'cross',
+        types: [],
+        trustLevel: 'working' as const,
+        layers: new Set(['working']),
+        subGraphs: new Set(['alpha', 'beta']),
+        properties: new Map(),
+        connections: [],
+      },
+      rootEntity('urn:e:root-only', 'working'),
+    ];
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        entities,
+        // intentionally no `layer` — exercises the path that round 4
+        // unified (was the carve-out that excluded root).
+      }));
+    });
+    await flushNet();
+    // Chip row: alpha includes the cross entity, beta includes the
+    // cross entity → 2 each.
+    expect(chipCount('alpha')).toBe(2);
+    expect(chipCount('beta')).toBe(2);
+    const allChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
+      .find(b => b.textContent?.includes('All'));
+    const allCount = Number(allChip?.querySelector('.v10-subgraph-chip-count')?.textContent ?? 'NaN');
+    // Distinct: alpha-only + beta-only + cross + root-only = 4.
+    // NOT sum-of-chips (5) which double-counts the cross entity.
+    expect(allCount).toBe(4);
   });
 
   // Issue B regression — sub-graph page chip row in layer-agnostic mode.
@@ -538,7 +599,13 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(container.querySelector('.v10-subgraph-bar-hint')).toBeNull();
   });
 
-  it('extends the All chip tooltip in layer mode with the cross-membership clarification (includes Root)', async () => {
+  // Round 4 (ux-lead reversal of §4.4.1): `All` semantic is now
+  // unified across layer + layer-agnostic modes (both include Root),
+  // so the tooltip / aria prose is a single literal in BOTH modes.
+  // Sweep-1 / round-3 mode-tagged branching is gone. The two tests
+  // below assert the SAME prose under each mode, locking the
+  // collapsed single-literal shape.
+  it('All chip tooltip in layer mode reads the unified Root-inclusion prose (round 4 §4.4.1 reversal)', async () => {
     await act(async () => {
       root.render(React.createElement(SubGraphBar, {
         contextGraphId: 'cg',
@@ -554,21 +621,22 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(allChip).toBeTruthy();
     const title = allChip.getAttribute('title') ?? '';
     const aria = allChip.getAttribute('aria-label') ?? '';
-    // Round 3 (ux-lead lock): "distinct entities" prefix added
-    // to both tooltip modes — lock the new phrasing so it can't
-    // regress. Title leads with "Total", aria with "All — total"
-    // (sentence-cased like the rest of the aria label); the
-    // load-bearing token is `distinct entities`.
-    expect(title).toContain('Total distinct entities');
-    expect(aria).toContain('distinct entities');
+    // Locked prose (title): leads with "Total distinct entities",
+    // discloses cross-membership + Root inclusion.
+    expect(title).toContain('Total distinct entities — includes those in named subgraphs');
     expect(title).toContain('some may belong to more than one');
     expect(title).toContain('plus Root entities not in any subgraph');
+    // Locked prose (aria): sentence-cased per existing aria pattern,
+    // same disclosure of cross-membership + Root inclusion.
+    expect(aria).toContain('All — total distinct entities');
     expect(aria).toContain('plus Root entities not in any subgraph');
-    // Must NOT carry the layer-agnostic phrasing.
+    // The layer-agnostic-only phrasing from sweep 1 / round 3 must
+    // NOT appear in EITHER mode after round 4.
     expect(title).not.toContain('counted separately');
+    expect(aria).not.toContain('counted separately');
   });
 
-  it('uses the layer-agnostic All chip tooltip in overview mode (Codex sweep 1 — Root counted separately)', async () => {
+  it('All chip tooltip in layer-agnostic mode reads the SAME unified prose (round 4 §4.4.1 reversal)', async () => {
     await act(async () => {
       root.render(React.createElement(SubGraphBar, {
         contextGraphId: 'cg',
@@ -584,17 +652,16 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(allChip).toBeTruthy();
     const title = allChip.getAttribute('title') ?? '';
     const aria = allChip.getAttribute('aria-label') ?? '';
-    // Round 3 (ux-lead lock): "distinct entities" prefix added
-    // to both tooltip modes — lock the new phrasing so it can't
-    // regress. Title leads with "Total", aria with "All — total"
-    // (sentence-cased like the rest of the aria label); the
-    // load-bearing token is `distinct entities in named subgraphs`.
-    expect(title).toContain('Total distinct entities in named subgraphs');
-    expect(aria).toContain('distinct entities in named subgraphs');
-    expect(title).toContain('counted separately on the Root chip');
-    expect(aria).toContain('counted separately on the Root chip');
-    // Must NOT carry the layer-mode phrasing that includes Root.
-    expect(title).not.toContain('plus Root entities not in any subgraph');
+    // Same locked prose as the layer-mode test above — the
+    // mode-tagged branching from sweep 1 / round 3 is gone.
+    expect(title).toContain('Total distinct entities — includes those in named subgraphs');
+    expect(title).toContain('some may belong to more than one');
+    expect(title).toContain('plus Root entities not in any subgraph');
+    expect(aria).toContain('All — total distinct entities');
+    expect(aria).toContain('plus Root entities not in any subgraph');
+    // Round 4 deletion guards:
+    expect(title).not.toContain('counted separately');
+    expect(aria).not.toContain('counted separately');
   });
 
   // S3 polish #9 — when SubGraphBar is mounted on a WM/SWM/VM

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -488,14 +488,15 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(chip!.getAttribute('data-count')).toBe('0');
   });
 
-  // S3 polish #7 — `All = Root + subgraphs` inline arithmetic
-  // hint + extended tooltip on the All chip (ux-locked).
-  // `MemoryEntity.subGraphs` is a Set, so the All count is a
-  // distinct total — cross-membership entities count once in
-  // All but may appear under multiple chip totals. The hint
-  // surfaces that math without changing the canonical All
-  // semantics.
-  it('renders the "All = Root + subgraphs" inline hint when Root is visible AND in layer mode', async () => {
+  // S3 polish #7 (literal updated at sweep 3 Bug K) — inline
+  // legend-style hint after the Root chip. Reads as
+  // "this row includes Root and the subgraph chips"; the earlier
+  // arithmetic literal `All = Root + subgraphs` was a false
+  // equation when entities have cross-membership in 2+ subgraphs.
+  // ux-lead-locked replacement: `+ Root, subgraphs`. The hint is
+  // the at-a-glance cue; cross-membership disclosure lives in
+  // the long-form All-chip tooltip.
+  it('renders the "+ Root, subgraphs" inline hint when Root is visible AND in layer mode', async () => {
     const rootEntity = {
       uri: 'urn:e:root', label: 'Root', types: [],
       trustLevel: 'working' as const,
@@ -518,10 +519,13 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
 
     const hint = container.querySelector('.v10-subgraph-bar-hint');
     expect(hint).toBeTruthy();
-    expect(hint!.textContent).toContain('All = Root + subgraphs');
+    expect(hint!.textContent).toContain('+ Root, subgraphs');
+    // The earlier arithmetic literal must NOT leak back in (regression
+    // guard against any accidental copy revert).
+    expect(hint!.textContent).not.toContain('All =');
   });
 
-  it('does NOT render the "All = Root + subgraphs" hint when there is no Root chip', async () => {
+  it('does NOT render the "+ Root, subgraphs" hint when there is no Root chip', async () => {
     // No root-bucket entities — Root chip is hidden, and so is
     // the hint (since the hint references a chip that's not on
     // screen).
@@ -544,9 +548,9 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
   // PR #793 Codex sweep 1 — the `entityScopedAllTotal` math at
   // SubGraphBar.tsx:139 EXCLUDES root-bucket entities in layer-
   // agnostic mode (the Subgraph Explorer overview). The All-chip
-  // tooltip / aria-label and the "All = Root + subgraphs" hint
+  // tooltip / aria-label and the "+ Root, subgraphs" hint
   // would silently contradict that math; both must mode-branch.
-  it('does NOT render the "All = Root + subgraphs" hint in layer-agnostic mode (Codex sweep 1)', async () => {
+  it('does NOT render the "+ Root, subgraphs" hint in layer-agnostic mode (Codex sweep 1)', async () => {
     // Root entity present (would normally show the chip + hint
     // in layer mode), but the bar is mounted WITHOUT a `layer`
     // prop — Subgraph Explorer overview shape. All excludes

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -554,7 +554,13 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(allChip).toBeTruthy();
     const title = allChip.getAttribute('title') ?? '';
     const aria = allChip.getAttribute('aria-label') ?? '';
-    expect(title).toContain('Total entities');
+    // Round 3 (ux-lead lock): "distinct entities" prefix added
+    // to both tooltip modes — lock the new phrasing so it can't
+    // regress. Title leads with "Total", aria with "All — total"
+    // (sentence-cased like the rest of the aria label); the
+    // load-bearing token is `distinct entities`.
+    expect(title).toContain('Total distinct entities');
+    expect(aria).toContain('distinct entities');
     expect(title).toContain('some may belong to more than one');
     expect(title).toContain('plus Root entities not in any subgraph');
     expect(aria).toContain('plus Root entities not in any subgraph');
@@ -578,7 +584,13 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(allChip).toBeTruthy();
     const title = allChip.getAttribute('title') ?? '';
     const aria = allChip.getAttribute('aria-label') ?? '';
-    expect(title).toContain('Total entities in named subgraphs');
+    // Round 3 (ux-lead lock): "distinct entities" prefix added
+    // to both tooltip modes — lock the new phrasing so it can't
+    // regress. Title leads with "Total", aria with "All — total"
+    // (sentence-cased like the rest of the aria label); the
+    // load-bearing token is `distinct entities in named subgraphs`.
+    expect(title).toContain('Total distinct entities in named subgraphs');
+    expect(aria).toContain('distinct entities in named subgraphs');
     expect(title).toContain('counted separately on the Root chip');
     expect(aria).toContain('counted separately on the Root chip');
     // Must NOT carry the layer-mode phrasing that includes Root.

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -485,4 +485,74 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(chip!.getAttribute('data-active')).toBe('true');
     expect(chip!.getAttribute('data-count')).toBe('0');
   });
+
+  // S3 polish #7 — `All = Root + subgraphs` inline arithmetic
+  // hint + extended tooltip on the All chip (ux-locked).
+  // `MemoryEntity.subGraphs` is a Set, so the All count is a
+  // distinct total — cross-membership entities count once in
+  // All but may appear under multiple chip totals. The hint
+  // surfaces that math without changing the canonical All
+  // semantics.
+  it('renders the "All = Root + subgraphs" inline hint when the Root chip is visible', async () => {
+    const rootEntity = {
+      uri: 'urn:e:root', label: 'Root', types: [],
+      trustLevel: 'working' as const,
+      layers: new Set(['working']),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    };
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        entities: [rootEntity, mkEntity('urn:e:named', 'shared', 'alpha')],
+      }));
+    });
+    await flushNet();
+
+    const hint = container.querySelector('.v10-subgraph-bar-hint');
+    expect(hint).toBeTruthy();
+    expect(hint!.textContent).toContain('All = Root + subgraphs');
+  });
+
+  it('does NOT render the "All = Root + subgraphs" hint when there is no Root chip', async () => {
+    // No root-bucket entities — Root chip is hidden, and so is
+    // the hint (since the hint references a chip that's not on
+    // screen).
+    const a = mkEntity('urn:a', 'working', 'alpha');
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        entities: [a],
+      }));
+    });
+    await flushNet();
+
+    expect(container.querySelector('.v10-subgraph-bar-hint')).toBeNull();
+  });
+
+  it('extends the All chip tooltip with the cross-membership clarification', async () => {
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+      }));
+    });
+    await flushNet();
+    const allChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
+      .find(b => b.textContent?.includes('All')) as HTMLButtonElement;
+    expect(allChip).toBeTruthy();
+    const title = allChip.getAttribute('title') ?? '';
+    expect(title).toContain('Total entities');
+    expect(title).toContain('some may belong to more than one');
+    expect(title).toContain('Root entities not in any subgraph');
+  });
 });

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -704,4 +704,108 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     await act(async () => { allChip.click(); });
     expect(onSelect).toHaveBeenCalledWith(null);
   });
+
+  // S3 polish PR #793 Codex sweep 6 (Bug O) — the `enabledScope`
+  // Set carrier supersedes the legacy single-layer `layer` prop
+  // so a detail view's multi-layer scope can flow into the
+  // sibling bar's chip counts. Pre-Bug-O the bar mounted next to
+  // a filtered detail body was layer-agnostic, showing all-three
+  // chip counts above the filtered slice — same-screen
+  // disagreement.
+  it('with `enabledScope=Set([working])`: chip counts match a WM-only slice (Bug O single-layer)', async () => {
+    const entities = [
+      mkEntity('urn:wm-a', 'working', 'alpha'),
+      mkEntity('urn:promoted-a', 'shared', 'alpha'),
+      mkEntity('urn:swm-b', 'shared', 'beta'),
+    ];
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: 'alpha',
+        onSelect: vi.fn(),
+        entities,
+        enabledScope: new Set<'working' | 'shared' | 'verified'>(['working']),
+      }));
+    });
+    await flushNet();
+    expect(chipCount('alpha')).toBe(1);
+    expect(chipCount('beta')).toBe(0);
+  });
+
+  it('with `enabledScope=Set([working, shared])`: chip counts include entities at either layer (Bug O multi-layer)', async () => {
+    // Pre-Bug-O the bar could only express single-layer scope via
+    // `layer`. Multi-layer detail scope (e.g. the user widened
+    // WM-only entry to WM+SWM) had no carrier — the bar reverted
+    // to layer-agnostic. Post-fix the Set carrier maps cleanly.
+    const entities = [
+      mkEntity('urn:wm-a', 'working', 'alpha'),
+      mkEntity('urn:promoted-a', 'shared', 'alpha'),
+      mkEntity('urn:vm-a', 'verified', 'alpha'),
+      mkEntity('urn:swm-b', 'shared', 'beta'),
+    ];
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: 'alpha',
+        onSelect: vi.fn(),
+        entities,
+        enabledScope: new Set<'working' | 'shared' | 'verified'>(['working', 'shared']),
+      }));
+    });
+    await flushNet();
+    // alpha: 1 WM + 1 promoted-SWM ∈ scope → 2; VM excluded.
+    expect(chipCount('alpha')).toBe(2);
+    // beta: 1 SWM ∈ scope → 1.
+    expect(chipCount('beta')).toBe(1);
+  });
+
+  it('with `enabledScope=Set([all-three])`: collapses to layer-agnostic (Bug O size-3 sentinel)', async () => {
+    // A size-3 Set is semantically equivalent to undefined —
+    // nothing is being narrowed, so the bar should behave as
+    // layer-agnostic (per-sub-graph distinct counts across all
+    // layers, Root chip excluded from All total).
+    const entities = [
+      mkEntity('urn:wm-a', 'working', 'alpha'),
+      mkEntity('urn:swm-a', 'shared', 'alpha'),
+      mkEntity('urn:vm-b', 'verified', 'beta'),
+    ];
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        entities,
+        enabledScope: new Set<'working' | 'shared' | 'verified'>(['working', 'shared', 'verified']),
+      }));
+    });
+    await flushNet();
+    expect(chipCount('alpha')).toBe(2);
+    expect(chipCount('beta')).toBe(1);
+  });
+
+  it('`enabledScope` wins over `layer` when both are set (Bug O precedence)', async () => {
+    // Defensive — if a caller passes both (shouldn't, but),
+    // `enabledScope` is the multi-layer carrier and takes
+    // precedence.
+    const entities = [
+      mkEntity('urn:wm-a', 'working', 'alpha'),
+      mkEntity('urn:swm-a', 'shared', 'alpha'),
+    ];
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: 'alpha',
+        onSelect: vi.fn(),
+        entities,
+        layer: 'wm',                                                              // would mean WM-only
+        enabledScope: new Set<'working' | 'shared' | 'verified'>(['shared']),     // but Set wins → SWM-only
+      }));
+    });
+    await flushNet();
+    expect(chipCount('alpha')).toBe(1);                                           // only the SWM entity
+  });
 });

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -429,7 +429,9 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     const { ROOT_SLUG_SENTINEL } = await import('../src/ui/lib/subGraphs.js');
     const rootChip = container.querySelector('.v10-subgraph-chip-root') as HTMLButtonElement;
     await act(async () => { rootChip.click(); });
-    expect(onSelect).toHaveBeenCalledWith(ROOT_SLUG_SENTINEL);
+    // #9 polish — the second arg carries the originating layer; on
+    // this Overview-shaped mount (no `layer` prop) it's undefined.
+    expect(onSelect).toHaveBeenCalledWith(ROOT_SLUG_SENTINEL, undefined);
   });
 
   // S3 Codex follow-up (Issue B on PR #772). The Root chip must stay
@@ -554,5 +556,82 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(title).toContain('Total entities');
     expect(title).toContain('some may belong to more than one');
     expect(title).toContain('Root entities not in any subgraph');
+  });
+
+  // S3 polish #9 — when SubGraphBar is mounted on a WM/SWM/VM
+  // page (the `layer` prop is set) and the user clicks a chip,
+  // `onSelect` carries the originating layer as the second arg
+  // so the detail view can seed `enabledLayers` to that layer
+  // (§4.4.1 fold-in #4). On the Subgraphs / Overview mount the
+  // bar has no `layer` prop and the second arg stays undefined.
+  it('forwards the bar `layer` prop as originatingLayer when a named chip is clicked', async () => {
+    const onSelect = vi.fn();
+    const wmEntity = mkEntity('urn:e:wm-a', 'working', 'alpha');
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect,
+        entities: [wmEntity],
+        layer: 'wm',
+      }));
+    });
+    await flushNet();
+
+    const alphaChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
+      .find(b => b.textContent?.includes('alpha')) as HTMLButtonElement;
+    expect(alphaChip).toBeTruthy();
+    await act(async () => { alphaChip.click(); });
+    expect(onSelect).toHaveBeenCalledWith('alpha', 'wm');
+  });
+
+  it('forwards the bar `layer` prop as originatingLayer when the Root chip is clicked', async () => {
+    const onSelect = vi.fn();
+    const rootEntity = {
+      uri: 'urn:e:root', label: 'Root', types: [],
+      trustLevel: 'shared' as const,
+      layers: new Set(['shared']),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    };
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect,
+        entities: [rootEntity, mkEntity('urn:e:named', 'shared', 'alpha')],
+        layer: 'swm',
+      }));
+    });
+    await flushNet();
+
+    const { ROOT_SLUG_SENTINEL } = await import('../src/ui/lib/subGraphs.js');
+    const rootChip = container.querySelector('.v10-subgraph-chip-root') as HTMLButtonElement;
+    await act(async () => { rootChip.click(); });
+    expect(onSelect).toHaveBeenCalledWith(ROOT_SLUG_SENTINEL, 'swm');
+  });
+
+  it('All chip click clears the originating-layer carry (passes undefined)', async () => {
+    // Selecting "All" exits the sub-graph page entirely — the
+    // bar passes undefined so any prior originating-layer scope
+    // is cleared.
+    const onSelect = vi.fn();
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: 'alpha',
+        onSelect,
+        layer: 'wm',
+      }));
+    });
+    await flushNet();
+    const allChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
+      .find(b => b.textContent?.includes('All')) as HTMLButtonElement;
+    await act(async () => { allChip.click(); });
+    expect(onSelect).toHaveBeenCalledWith(null);
   });
 });

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -495,7 +495,7 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
   // All but may appear under multiple chip totals. The hint
   // surfaces that math without changing the canonical All
   // semantics.
-  it('renders the "All = Root + subgraphs" inline hint when the Root chip is visible', async () => {
+  it('renders the "All = Root + subgraphs" inline hint when Root is visible AND in layer mode', async () => {
     const rootEntity = {
       uri: 'urn:e:root', label: 'Root', types: [],
       trustLevel: 'working' as const,
@@ -510,7 +510,8 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
         profile,
         selected: null,
         onSelect: vi.fn(),
-        entities: [rootEntity, mkEntity('urn:e:named', 'shared', 'alpha')],
+        entities: [rootEntity, mkEntity('urn:e:named', 'working', 'alpha')],
+        layer: 'wm',
       }));
     });
     await flushNet();
@@ -532,6 +533,7 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
         selected: null,
         onSelect: vi.fn(),
         entities: [a],
+        layer: 'wm',
       }));
     });
     await flushNet();
@@ -539,13 +541,50 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(container.querySelector('.v10-subgraph-bar-hint')).toBeNull();
   });
 
-  it('extends the All chip tooltip with the cross-membership clarification', async () => {
+  // PR #793 Codex sweep 1 — the `entityScopedAllTotal` math at
+  // SubGraphBar.tsx:139 EXCLUDES root-bucket entities in layer-
+  // agnostic mode (the Subgraph Explorer overview). The All-chip
+  // tooltip / aria-label and the "All = Root + subgraphs" hint
+  // would silently contradict that math; both must mode-branch.
+  it('does NOT render the "All = Root + subgraphs" hint in layer-agnostic mode (Codex sweep 1)', async () => {
+    // Root entity present (would normally show the chip + hint
+    // in layer mode), but the bar is mounted WITHOUT a `layer`
+    // prop — Subgraph Explorer overview shape. All excludes
+    // Root by design; the hint must hide.
+    const rootEntity = {
+      uri: 'urn:e:root', label: 'Root', types: [],
+      trustLevel: 'working' as const,
+      layers: new Set(['working']),
+      subGraphs: new Set<string>(),
+      properties: new Map(),
+      connections: [],
+    };
     await act(async () => {
       root.render(React.createElement(SubGraphBar, {
         contextGraphId: 'cg',
         profile,
         selected: null,
         onSelect: vi.fn(),
+        entities: [rootEntity, mkEntity('urn:e:named', 'shared', 'alpha')],
+        /* no layer prop → layer-agnostic */
+      }));
+    });
+    await flushNet();
+
+    // Root chip itself stays visible (the chip-visibility gate
+    // doesn't depend on layer mode); only the hint is gated.
+    expect(container.querySelector('.v10-subgraph-chip-root')).toBeTruthy();
+    expect(container.querySelector('.v10-subgraph-bar-hint')).toBeNull();
+  });
+
+  it('extends the All chip tooltip in layer mode with the cross-membership clarification (includes Root)', async () => {
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        layer: 'wm',
       }));
     });
     await flushNet();
@@ -553,9 +592,36 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
       .find(b => b.textContent?.includes('All')) as HTMLButtonElement;
     expect(allChip).toBeTruthy();
     const title = allChip.getAttribute('title') ?? '';
+    const aria = allChip.getAttribute('aria-label') ?? '';
     expect(title).toContain('Total entities');
     expect(title).toContain('some may belong to more than one');
-    expect(title).toContain('Root entities not in any subgraph');
+    expect(title).toContain('plus Root entities not in any subgraph');
+    expect(aria).toContain('plus Root entities not in any subgraph');
+    // Must NOT carry the layer-agnostic phrasing.
+    expect(title).not.toContain('counted separately');
+  });
+
+  it('uses the layer-agnostic All chip tooltip in overview mode (Codex sweep 1 — Root counted separately)', async () => {
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        /* no layer prop → layer-agnostic */
+      }));
+    });
+    await flushNet();
+    const allChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
+      .find(b => b.textContent?.includes('All')) as HTMLButtonElement;
+    expect(allChip).toBeTruthy();
+    const title = allChip.getAttribute('title') ?? '';
+    const aria = allChip.getAttribute('aria-label') ?? '';
+    expect(title).toContain('Total entities in named subgraphs');
+    expect(title).toContain('counted separately on the Root chip');
+    expect(aria).toContain('counted separately on the Root chip');
+    // Must NOT carry the layer-mode phrasing that includes Root.
+    expect(title).not.toContain('plus Root entities not in any subgraph');
   });
 
   // S3 polish #9 — when SubGraphBar is mounted on a WM/SWM/VM

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -488,15 +488,17 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(chip!.getAttribute('data-count')).toBe('0');
   });
 
-  // S3 polish #7 (literal updated at sweep 3 Bug K) — inline
-  // legend-style hint after the Root chip. Reads as
-  // "this row includes Root and the subgraph chips"; the earlier
-  // arithmetic literal `All = Root + subgraphs` was a false
-  // equation when entities have cross-membership in 2+ subgraphs.
-  // ux-lead-locked replacement: `+ Root, subgraphs`. The hint is
-  // the at-a-glance cue; cross-membership disclosure lives in
-  // the long-form All-chip tooltip.
-  it('renders the "+ Root, subgraphs" inline hint when Root is visible AND in layer mode', async () => {
+  // PR #793 round 2 — the inline `+ Root, subgraphs` hint
+  // (sweep 3 Bug K's locked literal, which itself replaced
+  // sweep 1's `All = Root + subgraphs` arithmetic form) was
+  // dropped entirely after manual-test feedback. Users asked
+  // what the literal meant; the in-row hint failed to
+  // communicate even at its second iteration. Cross-membership
+  // disclosure now lives ONLY in the long-form tooltip on the
+  // All chip (hover-only). This regression guard locks the
+  // deletion against any accidental re-introduction in either
+  // layer mode or layer-agnostic mode.
+  it('does NOT render any inline hint after the Root chip (round 2 deletion — applies in BOTH layer + layer-agnostic modes)', async () => {
     const rootEntity = {
       uri: 'urn:e:root', label: 'Root', types: [],
       trustLevel: 'working' as const,
@@ -505,6 +507,8 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
       properties: new Map(),
       connections: [],
     };
+
+    // Layer mode — pre-sweep-3 the hint was visible here.
     await act(async () => {
       root.render(React.createElement(SubGraphBar, {
         contextGraphId: 'cg',
@@ -516,53 +520,9 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
       }));
     });
     await flushNet();
-
-    const hint = container.querySelector('.v10-subgraph-bar-hint');
-    expect(hint).toBeTruthy();
-    expect(hint!.textContent).toContain('+ Root, subgraphs');
-    // The earlier arithmetic literal must NOT leak back in (regression
-    // guard against any accidental copy revert).
-    expect(hint!.textContent).not.toContain('All =');
-  });
-
-  it('does NOT render the "+ Root, subgraphs" hint when there is no Root chip', async () => {
-    // No root-bucket entities — Root chip is hidden, and so is
-    // the hint (since the hint references a chip that's not on
-    // screen).
-    const a = mkEntity('urn:a', 'working', 'alpha');
-    await act(async () => {
-      root.render(React.createElement(SubGraphBar, {
-        contextGraphId: 'cg',
-        profile,
-        selected: null,
-        onSelect: vi.fn(),
-        entities: [a],
-        layer: 'wm',
-      }));
-    });
-    await flushNet();
-
     expect(container.querySelector('.v10-subgraph-bar-hint')).toBeNull();
-  });
 
-  // PR #793 Codex sweep 1 — the `entityScopedAllTotal` math at
-  // SubGraphBar.tsx:139 EXCLUDES root-bucket entities in layer-
-  // agnostic mode (the Subgraph Explorer overview). The All-chip
-  // tooltip / aria-label and the "+ Root, subgraphs" hint
-  // would silently contradict that math; both must mode-branch.
-  it('does NOT render the "+ Root, subgraphs" hint in layer-agnostic mode (Codex sweep 1)', async () => {
-    // Root entity present (would normally show the chip + hint
-    // in layer mode), but the bar is mounted WITHOUT a `layer`
-    // prop — Subgraph Explorer overview shape. All excludes
-    // Root by design; the hint must hide.
-    const rootEntity = {
-      uri: 'urn:e:root', label: 'Root', types: [],
-      trustLevel: 'working' as const,
-      layers: new Set(['working']),
-      subGraphs: new Set<string>(),
-      properties: new Map(),
-      connections: [],
-    };
+    // Layer-agnostic — Root chip stays, hint is gone.
     await act(async () => {
       root.render(React.createElement(SubGraphBar, {
         contextGraphId: 'cg',
@@ -574,9 +534,6 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
       }));
     });
     await flushNet();
-
-    // Root chip itself stays visible (the chip-visibility gate
-    // doesn't depend on layer mode); only the hint is gated.
     expect(container.querySelector('.v10-subgraph-chip-root')).toBeTruthy();
     expect(container.querySelector('.v10-subgraph-bar-hint')).toBeNull();
   });

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -1486,4 +1486,134 @@ describe('SubGraphDetailView tabs', () => {
     // the legacy "No data" copy either.
     expect(container.textContent).not.toContain('No data\n');
   });
+
+  // S3 polish #6 — cross-layer strip cells are interactive
+  // buttons wired to `toggleLayer`. Pre-polish they were inert
+  // span elements; the user had to use the (smaller) header
+  // MiniLayerBar chips to narrow the layer scope. Same handler,
+  // same "refuse last enabled" safeguard, broader hit target.
+  it('toggles a layer when the WM cross-layer cell is clicked', async () => {
+    const wmOnly = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const swmOnly = {
+      uri: 'urn:e:swm', label: 'SWM', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmOnly.uri, wmOnly], [swmOnly.uri, swmOnly]]),
+      entityList: [wmOnly, swmOnly],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+    await flush();
+
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      const el = container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`);
+      if (!el) throw new Error(`Missing cell for ${layer}`);
+      return el as HTMLButtonElement;
+    }
+
+    // Default: all three layers enabled — every cell is pressed.
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('true');
+
+    // Click the WM cell — narrows scope to {swm, vm}.
+    await act(async () => { cellFor('wm').click(); });
+    await flush();
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('false');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('true');
+
+    // Click WM again — re-adds it.
+    await act(async () => { cellFor('wm').click(); });
+    await flush();
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('does NOT allow the last-enabled cell to be toggled off (safeguard inherited from toggleLayer)', async () => {
+    const wmOnly = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmOnly.uri, wmOnly]]),
+      entityList: [wmOnly],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+    await flush();
+
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
+    }
+
+    // Narrow down to WM only.
+    await act(async () => { cellFor('swm').click(); });
+    await act(async () => { cellFor('vm').click(); });
+    await flush();
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('false');
+    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('false');
+
+    // Clicking WM (the last enabled) MUST NOT disable it.
+    await act(async () => { cellFor('wm').click(); });
+    await flush();
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+  });
 });

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -1617,13 +1617,13 @@ describe('SubGraphDetailView tabs', () => {
     expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
   });
 
-  // S3 polish #8 — SWM-attribution discoverability. When the
-  // Graph pane has narrowed to SWM-only the existing
-  // SwmAttributionLegend explains the coloring rule, but there's
-  // no explicit "this canvas is currently colored by agent" cue
-  // above the graph. Add an inline badge that surfaces alongside
-  // the legend so the rule isn't buried in the side rail.
-  it('renders the "Colored by contributing agent" badge when narrowed to SWM-only on the Graph tab', async () => {
+  // PR #793 round 2 — the inline "Colored by contributing agent"
+  // badge (sweep 0 Bug #8's discoverability surface) was dropped
+  // after manual-test feedback. Verify the badge is gone in the
+  // SWM-only state (its previous trigger condition), while the
+  // SWM cell's context-sensitive tooltip stays as hover-only
+  // insurance.
+  it('does NOT render the "Colored by contributing agent" badge when narrowed to SWM-only — tooltip stays (round 2 deletion)', async () => {
     const swmOnly = {
       uri: 'urn:e:swm', label: 'SWM', types: [],
       trustLevel: 'shared',
@@ -1668,21 +1668,24 @@ describe('SubGraphDetailView tabs', () => {
     });
     await flush();
 
-    // Baseline (all three enabled) — no badge.
-    expect(container.querySelector('[data-testid="swm-attribution-badge"]')).toBeNull();
-
-    // Narrow to SWM-only via the cross-layer cells.
     function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
       return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
     }
+
+    // Baseline (all three enabled) — no badge, no SWM tooltip.
+    expect(container.querySelector('[data-testid="swm-attribution-badge"]')).toBeNull();
+
+    // Narrow to SWM-only via the cross-layer cells — the prior
+    // trigger condition for the (now-deleted) badge.
     await act(async () => { cellFor('wm').click(); });
     await act(async () => { cellFor('vm').click(); });
     await flush();
 
-    const badge = container.querySelector('[data-testid="swm-attribution-badge"]');
-    expect(badge).toBeTruthy();
-    expect(badge!.textContent).toContain('Colored by contributing agent');
-    // The SWM cell carries the context-sensitive tooltip per #8 (c).
+    // Badge MUST stay absent — the round 2 deletion is the
+    // load-bearing assertion here.
+    expect(container.querySelector('[data-testid="swm-attribution-badge"]')).toBeNull();
+    // The SWM cell's context-sensitive tooltip stays as the
+    // hover-only insurance per the round 2 brief.
     expect(cellFor('swm').getAttribute('title')).toContain('colored by contributing agent');
   });
 

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -928,10 +928,15 @@ describe('SubGraphDetailView tabs', () => {
     expect(entityCards[0]?.textContent).toContain('Rooted');
   });
 
-  // S3 — cross-layer count strip + active-layer chip pill (UX §4.4.1).
-  // The pill must be visible whenever scope is narrower than "all
-  // three", and clicking it must reset to All layers.
-  it('renders the active-layer pill and resets to "All layers" on click', async () => {
+  // S3 — cross-layer count strip + active-layer pill caption
+  // (UX §4.4.1). Post round 2 the pill was demoted from a
+  // clickable button to an inline caption label (ui-lead
+  // option c). It still surfaces the active layer scope but
+  // is no longer interactive — the `Reset filters` button is
+  // the canonical "restore scope" affordance when chip filters
+  // exist. The pill renders as a `<span>` so `disabled` /
+  // `click` are no longer meaningful.
+  it('renders the active-layer pill caption (non-interactive after round 2 demotion)', async () => {
     const wmOnly = {
       uri: 'urn:e:wm', label: 'WM only', types: [],
       trustLevel: 'working',
@@ -979,29 +984,26 @@ describe('SubGraphDetailView tabs', () => {
     });
     await flush();
 
-    const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLButtonElement | null;
+    const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLElement | null;
     expect(pill).toBeTruthy();
-    // Default: all three layers — pill reads "All layers" and is disabled.
+    // Default: all three layers — pill reads "All layers".
     expect(pill!.textContent).toContain('All layers');
-    expect(pill!.disabled).toBe(true);
+    // Round 2 — element is a <span>, NOT a button. No `disabled`
+    // semantic; no `onClick` to fire.
+    expect(pill!.tagName.toLowerCase()).toBe('span');
 
-    // Narrow to WM only via the mini-pyramid chips.
+    // Narrow to WM only via the mini-pyramid chips. Pill caption
+    // updates to reflect the active scope but stays
+    // non-interactive — the `Reset filters` button is the
+    // canonical restore affordance.
     const chips = Array.from(container.querySelectorAll('button.v10-minibar-chip')) as HTMLButtonElement[];
     const swmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Shared Memory'));
     const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verifiable Memory'));
     await act(async () => { swmChip!.click(); });
     await act(async () => { vmChip!.click(); });
     await flush();
-
-    // Pill now surfaces the narrowed scope and becomes clickable.
     expect(pill!.textContent).toContain('Working Memory');
-    expect(pill!.disabled).toBe(false);
-
-    // Clicking resets to all layers.
-    await act(async () => { pill!.click(); });
-    await flush();
-    expect(pill!.textContent).toContain('All layers');
-    expect(pill!.disabled).toBe(true);
+    expect(pill!.tagName.toLowerCase()).toBe('span');
   });
 
   // S3 fold-in #6 (PR #677 follow-up). Multi-layer sub-graph Graph
@@ -1799,14 +1801,14 @@ describe('SubGraphDetailView tabs', () => {
     expect(cellFor('swm').getAttribute('aria-pressed')).toBe('false');
     expect(cellFor('vm').getAttribute('aria-pressed')).toBe('false');
 
-    // Active-layer pill surfaces the scope. Post-Bug-I (PR #793
-    // sweep 2) the pill is DISABLED at the seeded scope — it
-    // would just no-op a "click to restore" affordance — so the
-    // assertion now reflects the honest affordance.
-    const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLButtonElement;
+    // Active-layer pill caption surfaces the scope. Post round
+    // 2 (ui-lead option c) the pill is a non-interactive
+    // `<span>`; the `Reset filters` button is the canonical
+    // restore affordance.
+    const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLElement;
     expect(pill).toBeTruthy();
     expect(pill.textContent).toContain('Working Memory');
-    expect(pill.disabled).toBe(true);
+    expect(pill.tagName.toLowerCase()).toBe('span');
   });
 
   it('seeds enabledLayers to all three when initialLayer is omitted (default)', async () => {
@@ -1855,81 +1857,12 @@ describe('SubGraphDetailView tabs', () => {
     expect(cellFor('vm').getAttribute('aria-pressed')).toBe('true');
   });
 
-  // S3 polish PR #793 Codex sweep 2 (Bug I) — `resetFilters` and
-  // the active-layer pill must restore `initialEnabledLayers`,
-  // NOT a hard-coded all-three set. Pre-fix entering a sub-graph
-  // from a WM tab (initialEnabledLayers === Set(['working'])) and
-  // then clicking Reset would widen scope to all-three instead of
-  // restoring WM. Same shape on the pill click.
-  it('active-layer pill click restores initialEnabledLayers when seeded to a single layer (Bug I)', async () => {
-    const wmEntity = {
-      uri: 'urn:e:wm', label: 'WM', types: [],
-      trustLevel: 'working',
-      layers: new Set(['working']),
-      subGraphs: new Set(['demo']),
-      properties: new Map(), connections: [],
-    };
-    const swmEntity = {
-      uri: 'urn:e:swm', label: 'SWM', types: [],
-      trustLevel: 'shared',
-      layers: new Set(['shared']),
-      subGraphs: new Set(['demo']),
-      properties: new Map(), connections: [],
-    };
-    const fixture = {
-      entities: new Map([[wmEntity.uri, wmEntity], [swmEntity.uri, swmEntity]]),
-      entityList: [wmEntity, swmEntity],
-      allTriples: [], graphTriples: [],
-      trustMap: new Map(),
-      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
-      loading: false, error: null, partial: false,
-      refresh: vi.fn(),
-    } as any;
-
-    container = document.createElement('div');
-    document.body.appendChild(container);
-    root = createRoot(container);
-
-    await act(async () => {
-      root!.render(
-        React.createElement(ProjectProfileContext.Provider, { value: profile },
-          React.createElement(SubGraphDetailView, {
-            slug: 'demo',
-            rawMemory: fixture,
-            contextGraphId: 'cg-test',
-            onNodeClick: vi.fn(),
-            onSelectEntity: vi.fn(),
-            activeTab: 'items',
-            onTabChange: vi.fn(),
-            initialLayer: 'wm',
-          })),
-      );
-    });
-    await flush();
-
-    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
-      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
-    }
-    const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLButtonElement;
-
-    // Seeded state: WM only, pill disabled (no-op affordance).
-    expect(pill.disabled).toBe(true);
-    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
-    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('false');
-
-    // User widens scope by clicking the SWM cell → pill enables.
-    await act(async () => { cellFor('swm').click(); });
-    await flush();
-    expect(pill.disabled).toBe(false);
-
-    // Click pill — restores the seeded WM scope, NOT all-three.
-    await act(async () => { pill.click(); });
-    await flush();
-    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
-    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('false');
-    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('false');
-    expect(pill.disabled).toBe(true);
-  });
+  // PR #793 round 2 — Bug I's `active-layer pill click restores
+  // initialEnabledLayers when seeded to a single layer` test was
+  // removed alongside the pill demotion (ui-lead option c). The
+  // pill is no longer a clickable widget; `Reset filters` is the
+  // sole "restore scope" affordance. The companion Reset test
+  // below survives because the Reset button itself is unchanged.
 
   it('Reset filters restores initialEnabledLayers when seeded AND when chip filters exist (Bug I)', async () => {
     // Profile carries a filter chip so the `Reset filters` button
@@ -2072,17 +2005,17 @@ describe('SubGraphDetailView tabs', () => {
     function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
       return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
     }
-    const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLButtonElement;
+    // Pill is now a caption-style `<span>` (round 2 demotion);
+    // assertions track the Reset button's visibility, not the
+    // pill's `disabled` semantic.
 
-    // Default state: all three pressed, pill disabled, no Reset.
-    expect(pill.disabled).toBe(true);
+    // Default state: all three pressed, no Reset button.
     expect(container.querySelector('.v10-subgraph-filter-reset')).toBeNull();
 
-    // Narrow to WM → Reset + pill enable.
+    // Narrow to WM → Reset surfaces.
     await act(async () => { cellFor('swm').click(); });
     await act(async () => { cellFor('vm').click(); });
     await flush();
-    expect(pill.disabled).toBe(false);
     const reset = container.querySelector('.v10-subgraph-filter-reset') as HTMLButtonElement;
     expect(reset).toBeTruthy();
 
@@ -2092,7 +2025,8 @@ describe('SubGraphDetailView tabs', () => {
     expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
     expect(cellFor('swm').getAttribute('aria-pressed')).toBe('true');
     expect(cellFor('vm').getAttribute('aria-pressed')).toBe('true');
-    expect(pill.disabled).toBe(true);
+    // Reset button hides again post-restore.
+    expect(container.querySelector('.v10-subgraph-filter-reset')).toBeNull();
   });
 
   // S3 polish PR #793 Codex sweep 3 Bug J — `initialEnabledLayers`

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -1616,4 +1616,124 @@ describe('SubGraphDetailView tabs', () => {
     await flush();
     expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
   });
+
+  // S3 polish #8 — SWM-attribution discoverability. When the
+  // Graph pane has narrowed to SWM-only the existing
+  // SwmAttributionLegend explains the coloring rule, but there's
+  // no explicit "this canvas is currently colored by agent" cue
+  // above the graph. Add an inline badge that surfaces alongside
+  // the legend so the rule isn't buried in the side rail.
+  it('renders the "Colored by contributing agent" badge when narrowed to SWM-only on the Graph tab', async () => {
+    const swmOnly = {
+      uri: 'urn:e:swm', label: 'SWM', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const wmOnly = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[swmOnly.uri, swmOnly], [wmOnly.uri, wmOnly]]),
+      entityList: [swmOnly, wmOnly],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'graph',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+    await flush();
+
+    // Baseline (all three enabled) — no badge.
+    expect(container.querySelector('[data-testid="swm-attribution-badge"]')).toBeNull();
+
+    // Narrow to SWM-only via the cross-layer cells.
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
+    }
+    await act(async () => { cellFor('wm').click(); });
+    await act(async () => { cellFor('vm').click(); });
+    await flush();
+
+    const badge = container.querySelector('[data-testid="swm-attribution-badge"]');
+    expect(badge).toBeTruthy();
+    expect(badge!.textContent).toContain('Colored by contributing agent');
+    // The SWM cell carries the context-sensitive tooltip per #8 (c).
+    expect(cellFor('swm').getAttribute('title')).toContain('colored by contributing agent');
+  });
+
+  it('does NOT render the SWM-attribution badge when WM is the only enabled layer', async () => {
+    const wmOnly = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmOnly.uri, wmOnly]]),
+      entityList: [wmOnly],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'graph',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+    await flush();
+
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
+    }
+    await act(async () => { cellFor('swm').click(); });
+    await act(async () => { cellFor('vm').click(); });
+    await flush();
+
+    // singleLayer === 'wm' — badge should NOT render.
+    expect(container.querySelector('[data-testid="swm-attribution-badge"]')).toBeNull();
+    // SWM cell carries no SWM-attribution tooltip in this state.
+    expect(cellFor('swm').getAttribute('title')).toBeNull();
+  });
 });

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -1438,4 +1438,52 @@ describe('SubGraphDetailView tabs', () => {
     const rootShelfChip = container.querySelector('.v10-graph-singleton-item[title="urn:e:root"]');
     expect(rootShelfChip).toBeTruthy();
   });
+
+  // S3 polish #10b — the detail-view header used to render a
+  // duplicate "No data" badge in its top-right corner whenever the
+  // sub-graph had no entities to populate the MiniLayerBar with.
+  // The fix passes `compact={true}` so the empty branch returns
+  // null. No badge on either the empty-named or empty-Root case.
+  it('does NOT render a "No data" header badge when the sub-graph is empty', async () => {
+    const empty = {
+      entities: new Map(),
+      entityList: [],
+      allTriples: [],
+      graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'team-notes',
+            rawMemory: empty,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'graph',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+    await flush();
+
+    // The detail header wraps a MiniLayerBar in compact mode. The
+    // compact-empty branch returns null, so the `.v10-minibar`
+    // element should be absent.
+    const header = container.querySelector('.v10-subgraph-detail-header');
+    expect(header).toBeTruthy();
+    expect(header!.querySelector('.v10-minibar')).toBeNull();
+    // The card-body / detail-body fallback path must NOT carry
+    // the legacy "No data" copy either.
+    expect(container.textContent).not.toContain('No data\n');
+  });
 });

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -1736,4 +1736,116 @@ describe('SubGraphDetailView tabs', () => {
     // SWM cell carries no SWM-attribution tooltip in this state.
     expect(cellFor('swm').getAttribute('title')).toBeNull();
   });
+
+  // S3 polish #9 — when SubGraphDetailView mounts with
+  // `initialLayer="wm"` the enabledLayers seed to `Set(['working'])`
+  // instead of all three. Active-layer pill reads "Working Memory"
+  // and the WM cross-layer cell is the only one pressed. The user
+  // sees the same scope they had on the WM page; no silent change.
+  it('seeds enabledLayers to the originating layer when initialLayer is provided (#9)', async () => {
+    const wmEntity = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const swmEntity = {
+      uri: 'urn:e:swm', label: 'SWM', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmEntity.uri, wmEntity], [swmEntity.uri, swmEntity]]),
+      entityList: [wmEntity, swmEntity],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+            initialLayer: 'wm',
+          })),
+      );
+    });
+    await flush();
+
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
+    }
+    // Only WM is pressed.
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('false');
+    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('false');
+
+    // Active-layer pill surfaces the scope.
+    const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLButtonElement;
+    expect(pill).toBeTruthy();
+    expect(pill.textContent).toContain('Working Memory');
+    expect(pill.disabled).toBe(false);
+  });
+
+  it('seeds enabledLayers to all three when initialLayer is omitted (default)', async () => {
+    const wmEntity = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmEntity.uri, wmEntity]]),
+      entityList: [wmEntity],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+          })),
+      );
+    });
+    await flush();
+
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
+    }
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('true');
+  });
 });

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -275,8 +275,8 @@ describe('SubGraphDetailView tabs', () => {
     });
 
     // Narrow the trust filter to WM only by toggling off SWM and VM via
-    // MiniLayerPyramid chips (their title text disambiguates which is which).
-    const chips = Array.from(container.querySelectorAll('button.v10-minipyr-chip')) as HTMLButtonElement[];
+    // MiniLayerBar chips (their title text disambiguates which is which).
+    const chips = Array.from(container.querySelectorAll('button.v10-minibar-chip')) as HTMLButtonElement[];
     const swmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Shared Memory'));
     const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verified Memory'));
     expect(swmChip).toBeTruthy();
@@ -397,7 +397,7 @@ describe('SubGraphDetailView tabs', () => {
     }
 
     // Narrow to SWM only by toggling off WM + VM.
-    const chips = Array.from(container.querySelectorAll('button.v10-minipyr-chip')) as HTMLButtonElement[];
+    const chips = Array.from(container.querySelectorAll('button.v10-minibar-chip')) as HTMLButtonElement[];
     const wmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Working Memory'));
     const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verified Memory'));
     expect(wmChip).toBeTruthy();
@@ -551,7 +551,7 @@ describe('SubGraphDetailView tabs', () => {
     // `filteredEntities` here — the pre-C18 gate would then drop its WM
     // rdf:type / label triples even though its WM-layer membership is
     // exactly what the narrowed view is asking for.
-    const chips = Array.from(container.querySelectorAll('button.v10-minipyr-chip')) as HTMLButtonElement[];
+    const chips = Array.from(container.querySelectorAll('button.v10-minibar-chip')) as HTMLButtonElement[];
     const swmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Shared Memory'));
     const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verified Memory'));
     expect(swmChip).toBeTruthy();
@@ -654,12 +654,12 @@ describe('SubGraphDetailView tabs', () => {
     });
     await flush();
 
-    // Chips are buttons with class `v10-minipyr-chip`; the count is the
-    // `.v10-minipyr-count` span. Title prefixes disambiguate them.
-    const chips = Array.from(container.querySelectorAll('button.v10-minipyr-chip')) as HTMLButtonElement[];
+    // Chips are buttons with class `v10-minibar-chip`; the count is the
+    // `.v10-minibar-count` span. Title prefixes disambiguate them.
+    const chips = Array.from(container.querySelectorAll('button.v10-minibar-chip')) as HTMLButtonElement[];
     const countFor = (labelPrefix: string) => {
       const chip = chips.find(b => (b.getAttribute('title') ?? '').startsWith(labelPrefix));
-      return Number(chip?.querySelector('.v10-minipyr-count')?.textContent ?? 'NaN');
+      return Number(chip?.querySelector('.v10-minibar-count')?.textContent ?? 'NaN');
     };
     // Trust convention: WM=1 (the WM-only entity), SWM=1 (the promoted
     // entity, counted in its canonical layer only), VM=0. Pre-P3 this
@@ -986,7 +986,7 @@ describe('SubGraphDetailView tabs', () => {
     expect(pill!.disabled).toBe(true);
 
     // Narrow to WM only via the mini-pyramid chips.
-    const chips = Array.from(container.querySelectorAll('button.v10-minipyr-chip')) as HTMLButtonElement[];
+    const chips = Array.from(container.querySelectorAll('button.v10-minibar-chip')) as HTMLButtonElement[];
     const swmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Shared Memory'));
     const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verified Memory'));
     await act(async () => { swmChip!.click(); });

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -278,7 +278,7 @@ describe('SubGraphDetailView tabs', () => {
     // MiniLayerBar chips (their title text disambiguates which is which).
     const chips = Array.from(container.querySelectorAll('button.v10-minibar-chip')) as HTMLButtonElement[];
     const swmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Shared Memory'));
-    const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verified Memory'));
+    const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verifiable Memory'));
     expect(swmChip).toBeTruthy();
     expect(vmChip).toBeTruthy();
 
@@ -399,7 +399,7 @@ describe('SubGraphDetailView tabs', () => {
     // Narrow to SWM only by toggling off WM + VM.
     const chips = Array.from(container.querySelectorAll('button.v10-minibar-chip')) as HTMLButtonElement[];
     const wmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Working Memory'));
-    const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verified Memory'));
+    const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verifiable Memory'));
     expect(wmChip).toBeTruthy();
     expect(vmChip).toBeTruthy();
 
@@ -553,7 +553,7 @@ describe('SubGraphDetailView tabs', () => {
     // exactly what the narrowed view is asking for.
     const chips = Array.from(container.querySelectorAll('button.v10-minibar-chip')) as HTMLButtonElement[];
     const swmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Shared Memory'));
-    const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verified Memory'));
+    const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verifiable Memory'));
     expect(swmChip).toBeTruthy();
     expect(vmChip).toBeTruthy();
 
@@ -666,7 +666,7 @@ describe('SubGraphDetailView tabs', () => {
     // would have been WM=2 / SWM=1 / VM=0.
     expect(countFor('Working Memory')).toBe(1);
     expect(countFor('Shared Memory')).toBe(1);
-    expect(countFor('Verified Memory')).toBe(0);
+    expect(countFor('Verifiable Memory')).toBe(0);
   });
 
   // R3 regression: `splitGraphTriplesForShelf` normalises subjects /
@@ -988,7 +988,7 @@ describe('SubGraphDetailView tabs', () => {
     // Narrow to WM only via the mini-pyramid chips.
     const chips = Array.from(container.querySelectorAll('button.v10-minibar-chip')) as HTMLButtonElement[];
     const swmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Shared Memory'));
-    const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verified Memory'));
+    const vmChip = chips.find(b => (b.getAttribute('title') ?? '').startsWith('Verifiable Memory'));
     await act(async () => { swmChip!.click(); });
     await act(async () => { vmChip!.click(); });
     await flush();
@@ -1159,7 +1159,7 @@ describe('SubGraphDetailView tabs', () => {
     }
     expect(byLabel.get('WM row')?.querySelector('.v10-trust-badge.wm')?.textContent).toContain('Working');
     expect(byLabel.get('SWM row')?.querySelector('.v10-trust-badge.swm')?.textContent).toContain('Shared');
-    expect(byLabel.get('VM row')?.querySelector('.v10-trust-badge.vm')?.textContent).toContain('Verified');
+    expect(byLabel.get('VM row')?.querySelector('.v10-trust-badge.vm')?.textContent).toContain('Verifiable');
   });
 
   // S3 fold-in #7 — multi-layer `scopedTriples` predicate admits

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -1796,11 +1796,14 @@ describe('SubGraphDetailView tabs', () => {
     expect(cellFor('swm').getAttribute('aria-pressed')).toBe('false');
     expect(cellFor('vm').getAttribute('aria-pressed')).toBe('false');
 
-    // Active-layer pill surfaces the scope.
+    // Active-layer pill surfaces the scope. Post-Bug-I (PR #793
+    // sweep 2) the pill is DISABLED at the seeded scope — it
+    // would just no-op a "click to restore" affordance — so the
+    // assertion now reflects the honest affordance.
     const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLButtonElement;
     expect(pill).toBeTruthy();
     expect(pill.textContent).toContain('Working Memory');
-    expect(pill.disabled).toBe(false);
+    expect(pill.disabled).toBe(true);
   });
 
   it('seeds enabledLayers to all three when initialLayer is omitted (default)', async () => {
@@ -1847,5 +1850,245 @@ describe('SubGraphDetailView tabs', () => {
     expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
     expect(cellFor('swm').getAttribute('aria-pressed')).toBe('true');
     expect(cellFor('vm').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  // S3 polish PR #793 Codex sweep 2 (Bug I) — `resetFilters` and
+  // the active-layer pill must restore `initialEnabledLayers`,
+  // NOT a hard-coded all-three set. Pre-fix entering a sub-graph
+  // from a WM tab (initialEnabledLayers === Set(['working'])) and
+  // then clicking Reset would widen scope to all-three instead of
+  // restoring WM. Same shape on the pill click.
+  it('active-layer pill click restores initialEnabledLayers when seeded to a single layer (Bug I)', async () => {
+    const wmEntity = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const swmEntity = {
+      uri: 'urn:e:swm', label: 'SWM', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmEntity.uri, wmEntity], [swmEntity.uri, swmEntity]]),
+      entityList: [wmEntity, swmEntity],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+            initialLayer: 'wm',
+          })),
+      );
+    });
+    await flush();
+
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
+    }
+    const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLButtonElement;
+
+    // Seeded state: WM only, pill disabled (no-op affordance).
+    expect(pill.disabled).toBe(true);
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('false');
+
+    // User widens scope by clicking the SWM cell → pill enables.
+    await act(async () => { cellFor('swm').click(); });
+    await flush();
+    expect(pill.disabled).toBe(false);
+
+    // Click pill — restores the seeded WM scope, NOT all-three.
+    await act(async () => { pill.click(); });
+    await flush();
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('false');
+    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('false');
+    expect(pill.disabled).toBe(true);
+  });
+
+  it('Reset filters restores initialEnabledLayers when seeded AND when chip filters exist (Bug I)', async () => {
+    // Profile carries a filter chip so the `Reset filters` button
+    // actually mounts. The chip itself isn't toggled — we just
+    // need the chip row to render so the Reset button surfaces.
+    const chipProfile: typeof profile = {
+      ...profile,
+      chipsFor: () => [
+        { slug: 'status', predicate: 'http://example.org/status', label: 'Status', values: ['open', 'done'] },
+      ],
+    };
+    const wmEntity = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const swmEntity = {
+      uri: 'urn:e:swm', label: 'SWM', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmEntity.uri, wmEntity], [swmEntity.uri, swmEntity]]),
+      entityList: [wmEntity, swmEntity],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: chipProfile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+            initialLayer: 'wm',
+          })),
+      );
+    });
+    await flush();
+
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
+    }
+    const resetSelector = '.v10-subgraph-filter-reset';
+
+    // Seeded scope + no chip filters → hasAnyFilter === false →
+    // Reset button hidden. Pre-Bug-I fix this was VISIBLE even
+    // at the seeded state because the predicate was
+    // `enabledLayers.size < 3`.
+    expect(container.querySelector(resetSelector)).toBeNull();
+
+    // Widen scope to WM + SWM → hasAnyFilter flips → Reset
+    // surfaces.
+    await act(async () => { cellFor('swm').click(); });
+    await flush();
+    const resetBtn = container.querySelector(resetSelector) as HTMLButtonElement | null;
+    expect(resetBtn).toBeTruthy();
+
+    // Click Reset — restores the seeded WM scope, not all-three.
+    await act(async () => { resetBtn!.click(); });
+    await flush();
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('false');
+    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('false');
+    // Reset button hidden again post-restore.
+    expect(container.querySelector(resetSelector)).toBeNull();
+  });
+
+  it('Reset filters and pill restore all-three when initialEnabledLayers is the default (regression guard)', async () => {
+    // Without `initialLayer`, the seeded scope IS all-three — the
+    // pre-existing behaviour. Reset and pill should still work
+    // exactly as before for this path.
+    const chipProfile: typeof profile = {
+      ...profile,
+      chipsFor: () => [
+        { slug: 'status', predicate: 'http://example.org/status', label: 'Status', values: ['open', 'done'] },
+      ],
+    };
+    const wmEntity = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const swmEntity = {
+      uri: 'urn:e:swm', label: 'SWM', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmEntity.uri, wmEntity], [swmEntity.uri, swmEntity]]),
+      entityList: [wmEntity, swmEntity],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: chipProfile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+            /* no initialLayer → default all-three */
+          })),
+      );
+    });
+    await flush();
+
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
+    }
+    const pill = container.querySelector('[data-testid="active-layer-pill"]') as HTMLButtonElement;
+
+    // Default state: all three pressed, pill disabled, no Reset.
+    expect(pill.disabled).toBe(true);
+    expect(container.querySelector('.v10-subgraph-filter-reset')).toBeNull();
+
+    // Narrow to WM → Reset + pill enable.
+    await act(async () => { cellFor('swm').click(); });
+    await act(async () => { cellFor('vm').click(); });
+    await flush();
+    expect(pill.disabled).toBe(false);
+    const reset = container.querySelector('.v10-subgraph-filter-reset') as HTMLButtonElement;
+    expect(reset).toBeTruthy();
+
+    // Click Reset → restores all-three.
+    await act(async () => { reset.click(); });
+    await flush();
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('true');
+    expect(pill.disabled).toBe(true);
   });
 });

--- a/packages/node-ui/test/subgraph-detail-view.test.ts
+++ b/packages/node-ui/test/subgraph-detail-view.test.ts
@@ -2091,4 +2091,197 @@ describe('SubGraphDetailView tabs', () => {
     expect(cellFor('vm').getAttribute('aria-pressed')).toBe('true');
     expect(pill.disabled).toBe(true);
   });
+
+  // S3 polish PR #793 Codex sweep 3 Bug J — `initialEnabledLayers`
+  // is the multi-layer carrier that lets the user's exact scope
+  // round-trip through detail→detail hops. Verify the new prop
+  // seeds correctly at the SubGraphDetailView boundary.
+  it('seeds enabledLayers from `initialEnabledLayers` prop (multi-layer, Bug J)', async () => {
+    const wmEntity = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const swmEntity = {
+      uri: 'urn:e:swm', label: 'SWM', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const vmEntity = {
+      uri: 'urn:e:vm', label: 'VM', types: [],
+      trustLevel: 'verified',
+      layers: new Set(['verified']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmEntity.uri, wmEntity], [swmEntity.uri, swmEntity], [vmEntity.uri, vmEntity]]),
+      entityList: [wmEntity, swmEntity, vmEntity],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 1, total: 3 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+            initialEnabledLayers: new Set(['working', 'shared']),
+          })),
+      );
+    });
+    await flush();
+
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
+    }
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('`initialEnabledLayers` wins over `initialLayer` when both are set (Bug J precedence)', async () => {
+    // Defensive: callers shouldn't pass both, but if they do the
+    // multi-layer prop carries strictly more info — wins.
+    const wmEntity = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const swmEntity = {
+      uri: 'urn:e:swm', label: 'SWM', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmEntity.uri, wmEntity], [swmEntity.uri, swmEntity]]),
+      entityList: [wmEntity, swmEntity],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+            initialLayer: 'wm',                                // would seed WM only
+            initialEnabledLayers: new Set(['shared']),          // but this wins
+          })),
+      );
+    });
+    await flush();
+
+    function cellFor(layer: 'wm' | 'swm' | 'vm'): HTMLButtonElement {
+      return container.querySelector(`button.v10-subgraph-cross-layer-cell[data-layer="${layer}"]`) as HTMLButtonElement;
+    }
+    expect(cellFor('wm').getAttribute('aria-pressed')).toBe('false');
+    expect(cellFor('swm').getAttribute('aria-pressed')).toBe('true');
+    expect(cellFor('vm').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('mirrors enabledLayers up via `onEnabledLayersChange` on mount and on user toggles (Bug J)', async () => {
+    // Bug J's structural piece — the detail view must publish its
+    // current scope to the parent so chip clicks can route the
+    // user's exact scope through. Verify the callback fires on
+    // initial seed AND when the user toggles a cross-layer cell.
+    const wmEntity = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const swmEntity = {
+      uri: 'urn:e:swm', label: 'SWM', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['demo']),
+      properties: new Map(), connections: [],
+    };
+    const fixture = {
+      entities: new Map([[wmEntity.uri, wmEntity], [swmEntity.uri, swmEntity]]),
+      entityList: [wmEntity, swmEntity],
+      allTriples: [], graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+      loading: false, error: null, partial: false,
+      refresh: vi.fn(),
+    } as any;
+
+    const onEnabledLayersChange = vi.fn();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphDetailView, {
+            slug: 'demo',
+            rawMemory: fixture,
+            contextGraphId: 'cg-test',
+            onNodeClick: vi.fn(),
+            onSelectEntity: vi.fn(),
+            activeTab: 'items',
+            onTabChange: vi.fn(),
+            initialEnabledLayers: new Set(['working']),
+            onEnabledLayersChange,
+          })),
+      );
+    });
+    await flush();
+
+    // Initial mirror — Set(['working']) emitted at least once.
+    // Snapshot the count (not the array reference — `mock.calls`
+    // is live).
+    const initialCount = onEnabledLayersChange.mock.calls.length;
+    expect(initialCount).toBeGreaterThanOrEqual(1);
+    const initialLast = onEnabledLayersChange.mock.calls[initialCount - 1][0] as Set<string>;
+    expect([...initialLast].sort()).toEqual(['working']);
+
+    // User clicks the SWM cell → mirror fires again with WM+SWM.
+    const swmCell = container.querySelector('button.v10-subgraph-cross-layer-cell[data-layer="swm"]') as HTMLButtonElement;
+    await act(async () => { swmCell.click(); });
+    await flush();
+
+    const afterCount = onEnabledLayersChange.mock.calls.length;
+    expect(afterCount).toBeGreaterThan(initialCount);
+    const last = onEnabledLayersChange.mock.calls[afterCount - 1][0] as Set<string>;
+    expect([...last].sort()).toEqual(['shared', 'working']);
+  });
 });

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -24,13 +24,24 @@ vi.mock('../src/ui/api.js', () => ({
 vi.mock('@origintrail-official/dkg-graph-viz/react', async () => {
   const React = await import('react');
   return {
-    RdfGraph() {
-      return React.createElement('div', { 'data-testid': 'rdf-graph' });
+    RdfGraph(props: {
+      data?: ReadonlyArray<{ subject: string; predicate: string; object: string }>;
+      options?: { style?: { nodeColors?: Record<string, string> } };
+    }) {
+      // Surface the nodeColors style override so #3 polish tests
+      // can assert per-URI trust-color plumbing without reaching
+      // into the canvas internals.
+      const nodeColors = props.options?.style?.nodeColors ?? {};
+      return React.createElement('div', {
+        'data-testid': 'rdf-graph',
+        'data-node-colors': JSON.stringify(nodeColors),
+      });
     },
   };
 });
 
 import { SubGraphOverviewGrid } from '../src/ui/views/project/components.js';
+import { TRUST_COLORS } from '../src/ui/views/project/helpers.js';
 
 const profile: ProjectProfile = {
   contextGraphId: 'cg-test',
@@ -257,5 +268,125 @@ describe('SubGraphMiniCard — empty-card-body two-branch copy (S3 polish #2, ux
     // Only the card-body literal remains.
     const cardBody = container.querySelector('.v10-sgov-card-empty');
     expect(cardBody?.textContent).toBe('No data yet');
+  });
+});
+
+describe('SubGraphMiniCard — per-trust nodeColors (S3 polish #3, ui-locked priority chain)', () => {
+  // The mini-graph previously rendered every node in the card's
+  // chrome color (`card.color`), losing the trust signal that the
+  // detail-view Graph pane already preserves. Build a per-URI
+  // `nodeColors` override from TRUST_COLORS[trustLevel] so each
+  // mini-graph reads the same per-trust palette the detail view
+  // does. Chrome color (border, header icon, namespace fallback)
+  // stays unchanged.
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    fetchSubGraphsMock.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderWith(memoryOverride: any) {
+    return act(async () => {
+      root.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphOverviewGrid, {
+            contextGraphId: 'cg-test',
+            memory: memoryOverride,
+            onNodeClick: vi.fn(),
+            onSelectSubGraph: vi.fn(),
+          })),
+      );
+    });
+  }
+
+  it('passes per-URI nodeColors keyed by TRUST_COLORS[trustLevel] for every card entity', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'recipes', entityCount: 3, tripleCount: 3, description: '' }],
+    });
+    const wmEntity = {
+      uri: 'urn:e:wm', label: 'WM', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['recipes']),
+      properties: new Map(), connections: [],
+    };
+    const swmEntity = {
+      uri: 'urn:e:swm', label: 'SWM', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['recipes']),
+      properties: new Map(), connections: [],
+    };
+    const vmEntity = {
+      uri: 'urn:e:vm', label: 'VM', types: [],
+      trustLevel: 'verified',
+      layers: new Set(['verified']),
+      subGraphs: new Set(['recipes']),
+      properties: new Map(), connections: [],
+    };
+    // A triple between the WM and SWM entities so the mini-graph
+    // actually renders (canvas-empty branch is the other path).
+    const edge = {
+      subject: 'urn:e:wm',
+      predicate: 'http://schema.org/relatedTo',
+      object: 'urn:e:swm',
+      subGraph: 'recipes',
+      layer: 'working' as const,
+    };
+
+    await renderWith({
+      ...memory,
+      entityList: [wmEntity, swmEntity, vmEntity],
+      entities: new Map([
+        [wmEntity.uri, wmEntity],
+        [swmEntity.uri, swmEntity],
+        [vmEntity.uri, vmEntity],
+      ]),
+      allTriples: [edge],
+    });
+    await flush();
+
+    // RdfGraph is React.lazy'd — pump microtasks until the Suspense
+    // boundary resolves and our mock renders.
+    async function waitForGraph(maxMs = 1000): Promise<HTMLElement | null> {
+      const start = Date.now();
+      while (Date.now() - start < maxMs) {
+        const el = container.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+        if (el) return el;
+        await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+      }
+      return container.querySelector('[data-testid="rdf-graph"]');
+    }
+    const graph = await waitForGraph();
+    expect(graph).toBeTruthy();
+    const nodeColors = JSON.parse(graph!.getAttribute('data-node-colors') ?? '{}');
+    // Each entity URI keys to its canonical trust hex — same
+    // palette as the detail-view Graph pane (TRUST_COLORS in
+    // helpers.ts:47).
+    expect(nodeColors['urn:e:wm']).toBe(TRUST_COLORS.working);
+    expect(nodeColors['urn:e:swm']).toBe(TRUST_COLORS.shared);
+    expect(nodeColors['urn:e:vm']).toBe(TRUST_COLORS.verified);
+  });
+
+  it('omits nodeColors entirely when the card has no entities (chrome-color fallback wins)', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'recipes', entityCount: 0, tripleCount: 0, description: '' }],
+    });
+    await renderWith({ ...memory, entityList: [], allTriples: [] });
+    await flush();
+
+    // Empty entity set + no triples → card-body falls through to
+    // the empty placeholder, no RdfGraph mount.
+    const graph = container.querySelector('[data-testid="rdf-graph"]');
+    expect(graph).toBeNull();
   });
 });

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -149,3 +149,113 @@ describe('SubGraphOverviewGrid — fetch failure state (S3 Codex sweep 3 Issue G
     expect(empty!.getAttribute('data-tone')).toBe('neutral');
   });
 });
+
+describe('SubGraphMiniCard — empty-card-body two-branch copy (S3 polish #2, ux-locked)', () => {
+  // The card-body fallback is rendered when card.triples.length === 0.
+  // Two branches the user can land on:
+  //   `entityCount === 0` (sub-graph has nothing yet) → "No data yet"
+  //   `entityCount > 0`  (sub-graph has SWM/VM entities promoted out of
+  //                       the WM origin and no WM triples this card can
+  //                       render) → "Promoted — open to view"
+  // The previous power-user copy ("No WM triples · promoted data only")
+  // assumed familiarity with WM/SWM mechanics the typical user doesn't
+  // share. Pair the new literal with the existing ↗ open button so the
+  // implied action is obvious.
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    fetchSubGraphsMock.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderWith(memoryOverride: any) {
+    return act(async () => {
+      root.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphOverviewGrid, {
+            contextGraphId: 'cg-test',
+            memory: memoryOverride,
+            onNodeClick: vi.fn(),
+            onSelectSubGraph: vi.fn(),
+          })),
+      );
+    });
+  }
+
+  it('renders "No data yet" on a sub-graph with no entities and no triples (entityCount === 0)', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'team-notes', entityCount: 0, tripleCount: 0, description: '' }],
+    });
+    // memory.entityList is also empty — entityUrisBySubGraph yields
+    // an empty Set, so `cardEntityUris.size === 0` falls back to the
+    // server entityCount of 0 → "No data yet" branch.
+    await renderWith({ ...memory, entityList: [], allTriples: [] });
+    await flush();
+
+    const cardEmpty = container.querySelector('.v10-sgov-card-empty');
+    expect(cardEmpty).toBeTruthy();
+    expect(cardEmpty!.textContent).toContain('No data yet');
+    // The other branch must NOT also fire.
+    expect(cardEmpty!.textContent).not.toContain('Promoted — open to view');
+  });
+
+  it('renders "Promoted — open to view" when the sub-graph has entities but no WM triples', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'team-notes', entityCount: 3, tripleCount: 0, description: '' }],
+    });
+    // Entities scoped to `team-notes` exist (canonical entityList view
+    // — cardEntityUris.size > 0), but no triples carry the sub-graph
+    // origin tag, so card.triples is empty → "Promoted" branch.
+    const promotedEntity = {
+      uri: 'urn:e:promoted',
+      label: 'Promoted',
+      types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['team-notes']),
+      properties: new Map(),
+      connections: [],
+    };
+    await renderWith({
+      ...memory,
+      entityList: [promotedEntity],
+      entities: new Map([[promotedEntity.uri, promotedEntity]]),
+      allTriples: [],
+    });
+    await flush();
+
+    const cardEmpty = container.querySelector('.v10-sgov-card-empty');
+    expect(cardEmpty).toBeTruthy();
+    expect(cardEmpty!.textContent).toContain('Promoted — open to view');
+    expect(cardEmpty!.textContent).not.toContain('No data yet');
+    expect(cardEmpty!.textContent).not.toContain('No WM triples');
+  });
+
+  // #2 / #10b — the duplicate "No data" label that appeared next to
+  // the card-body fallback came from MiniLayerBar's own non-compact
+  // empty branch. Pass `compact={true}` and that branch returns null.
+  it('does NOT render a duplicate "No data" pyramid label on an empty card', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'team-notes', entityCount: 0, tripleCount: 0, description: '' }],
+    });
+    await renderWith({ ...memory, entityList: [], allTriples: [] });
+    await flush();
+
+    // The pyramid wrapper exists but MiniLayerBar in compact mode
+    // returns null when total === 0, so the legend strip is empty.
+    const pyramid = container.querySelector('.v10-sgov-card-pyramid');
+    expect(pyramid).toBeTruthy();
+    expect(pyramid!.querySelector('.v10-minibar')).toBeNull();
+    // Only the card-body literal remains.
+    const cardBody = container.querySelector('.v10-sgov-card-empty');
+    expect(cardBody?.textContent).toBe('No data yet');
+  });
+});

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -271,6 +271,139 @@ describe('SubGraphMiniCard — empty-card-body two-branch copy (S3 polish #2, ux
   });
 });
 
+describe('SubGraphOverviewGrid — header subtitle anchors (PR #793 round 4.1, GH #812)', () => {
+  // Round 4.1 (ux-lead) — the subtitle now reads from the canonical
+  // hook surfaces (`memory.counts.total` for entities,
+  // `memory.allTriples.length` for triples) so it agrees with the
+  // SubGraphBar `All` chip by construction. Pre-round-4.1 the
+  // subtitle derived from card-level aggregates and either
+  // double-counted cross-membership entities (round-4-prior
+  // sum-of-`entityCount`) or excluded the root bucket. The tests
+  // below lock the new anchor: a fixture where the hook total
+  // disagrees with the card sum must render the hook total in the
+  // subtitle.
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    fetchSubGraphsMock.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderWith(memoryOverride: any) {
+    return act(async () => {
+      root.render(
+        React.createElement(ProjectProfileContext.Provider, { value: profile },
+          React.createElement(SubGraphOverviewGrid, {
+            contextGraphId: 'cg-test',
+            memory: memoryOverride,
+            onNodeClick: vi.fn(),
+            onSelectSubGraph: vi.fn(),
+          })),
+      );
+    });
+  }
+
+  it('renders the subtitle entity count from memory.counts.total and triple count from memory.allTriples.length', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [
+        { name: 'alpha', entityCount: 2, tripleCount: 5, description: '' },
+        { name: 'beta', entityCount: 2, tripleCount: 7, description: '' },
+      ],
+    });
+    const triples = [
+      // alpha sub-graph triples
+      { subject: 'urn:e:a1', predicate: 'p', object: 'o1', subGraph: 'alpha' },
+      { subject: 'urn:e:a2', predicate: 'p', object: 'o2', subGraph: 'alpha' },
+      // beta sub-graph triples
+      { subject: 'urn:e:b1', predicate: 'p', object: 'o3', subGraph: 'beta' },
+      { subject: 'urn:e:b2', predicate: 'p', object: 'o4', subGraph: 'beta' },
+      // a root-bucket triple (no sub-graph origin) — counted by the
+      // hook total but never reaches a card aggregate.
+      { subject: 'urn:e:root', predicate: 'p', object: 'o5' },
+    ];
+    const entityList = [
+      { uri: 'urn:e:a1', label: 'a1', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:a2', label: 'a2', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:b1', label: 'b1', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['beta']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:b2', label: 'b2', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['beta']), properties: new Map(), connections: [] },
+      // A root-bucket entity with no sub-graph membership — would
+      // be missing from any card-derived count.
+      { uri: 'urn:e:root', label: 'root', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 5, swm: 0, vm: 0, total: 5 },
+    });
+    await flush();
+
+    const sub = container.querySelector('.v10-sgov-sub');
+    expect(sub).toBeTruthy();
+    expect(sub!.textContent).toContain('2 subgraphs');
+    expect(sub!.textContent).toContain('5 entities');
+    expect(sub!.textContent).toContain('5 triples');
+  });
+
+  it('subtitle uses memory.counts.total even when it disagrees with sum-of-card entityCount (cross-membership regression)', async () => {
+    // Fixture mirrors the §4.4.1 reversal scenario:
+    //   - One entity belongs to BOTH 'alpha' AND 'beta'.
+    //   - card[alpha].entityCount === 2 (alpha-only + cross)
+    //   - card[beta].entityCount  === 2 (beta-only + cross)
+    //   - sum-of-cards            === 4 (double-counts the cross entity)
+    //   - memory.counts.total      === 3 (distinct entities)
+    // Round 4.1 lock: the subtitle reads memory.counts.total (3),
+    // NOT the sum-of-cards (4). Same logic for triples — the hook
+    // total wins.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [
+        { name: 'alpha', entityCount: 2, tripleCount: 3, description: '' },
+        { name: 'beta', entityCount: 2, tripleCount: 3, description: '' },
+      ],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha-only', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:beta-only', label: 'b', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['beta']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:cross', label: 'c', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha', 'beta']), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // 4 raw triple rows even though the cross-graph SPO duplicate
+      // means distinct triples are fewer — exactly the GH #805
+      // family the subtitle now defers to.
+      { subject: 'urn:e:alpha-only', predicate: 'p', object: 'o', subGraph: 'alpha' },
+      { subject: 'urn:e:beta-only', predicate: 'p', object: 'o', subGraph: 'beta' },
+      { subject: 'urn:e:cross', predicate: 'p', object: 'o', subGraph: 'alpha' },
+      { subject: 'urn:e:cross', predicate: 'p', object: 'o', subGraph: 'beta' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 3, swm: 0, vm: 0, total: 3 },
+    });
+    await flush();
+
+    const sub = container.querySelector('.v10-sgov-sub');
+    expect(sub).toBeTruthy();
+    // Subtitle anchors to hook total (3), NOT sum-of-cards (4).
+    expect(sub!.textContent).toContain('3 entities');
+    expect(sub!.textContent).not.toContain('4 entities');
+    // Subtitle anchors to allTriples.length (4), matching what the
+    // SubGraphBar `All` chip tooltip surfaces.
+    expect(sub!.textContent).toContain('4 triples');
+  });
+});
+
 describe('SubGraphMiniCard — per-trust nodeColors (S3 polish #3, ui-locked priority chain)', () => {
   // The mini-graph previously rendered every node in the card's
   // chrome color (`card.color`), losing the trust signal that the

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -389,4 +389,126 @@ describe('SubGraphMiniCard — per-trust nodeColors (S3 polish #3, ui-locked pri
     const graph = container.querySelector('[data-testid="rdf-graph"]');
     expect(graph).toBeNull();
   });
+
+  // S3 polish PR #793 Codex sweep 4 (Bug M) — `entityTrustByUri`
+  // upstream loop now writes BOTH canonical AND raw URI forms so
+  // the mini-graph `nodeColors` override resolves either form
+  // the triple set may carry. Pre-fix a wrapped `<urn:...>`
+  // subject/object missed the canonical-only key and fell back
+  // to `card.color` (chrome), defeating #3's per-trust signal
+  // exactly in the cases (wrapped URIs from a daemon query path)
+  // where it matters most.
+  it('mini-graph nodeColors maps both raw <urn:...> and canonical urn:... forms to TRUST_COLORS (Bug M load-bearing)', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'recipes', entityCount: 1, tripleCount: 1, description: '' }],
+    });
+    // Entity carries the raw wrapped form on its `.uri`.
+    const wrappedEntity = {
+      uri: '<urn:e:wrapped>',
+      label: 'Wrapped', types: [],
+      trustLevel: 'shared',
+      layers: new Set(['shared']),
+      subGraphs: new Set(['recipes']),
+      properties: new Map(), connections: [],
+    };
+    // A triple anchoring the entity to the card's render set so
+    // the mini-graph mounts.
+    const edge = {
+      subject: '<urn:e:wrapped>',
+      predicate: 'http://schema.org/name',
+      object: '<urn:e:other>',
+      subGraph: 'recipes',
+      layer: 'shared' as const,
+    };
+    const otherEntity = {
+      uri: 'urn:e:other',
+      label: 'Other', types: [],
+      trustLevel: 'working',
+      layers: new Set(['working']),
+      subGraphs: new Set(['recipes']),
+      properties: new Map(), connections: [],
+    };
+
+    await renderWith({
+      ...memory,
+      entityList: [wrappedEntity, otherEntity],
+      entities: new Map([
+        [wrappedEntity.uri, wrappedEntity],
+        [otherEntity.uri, otherEntity],
+      ]),
+      allTriples: [edge],
+    });
+    await flush();
+
+    async function waitForGraph(maxMs = 1000): Promise<HTMLElement | null> {
+      const start = Date.now();
+      while (Date.now() - start < maxMs) {
+        const el = container.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+        if (el) return el;
+        await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+      }
+      return container.querySelector('[data-testid="rdf-graph"]');
+    }
+    const graph = await waitForGraph();
+    expect(graph).toBeTruthy();
+    const nodeColors = JSON.parse(graph!.getAttribute('data-node-colors') ?? '{}');
+
+    // BOTH forms must resolve to TRUST_COLORS.shared — the
+    // override has to win for whichever form the rendered
+    // triple carries (`<urn:e:wrapped>` here).
+    expect(nodeColors['<urn:e:wrapped>']).toBe(TRUST_COLORS.shared);
+    expect(nodeColors['urn:e:wrapped']).toBe(TRUST_COLORS.shared);
+    // The unwrapped sibling still resolves correctly (regression
+    // guard against the upstream change accidentally inverting
+    // the canonical-vs-raw write order).
+    expect(nodeColors['urn:e:other']).toBe(TRUST_COLORS.working);
+  });
+
+  it('mini-graph nodeColors keeps the canonical mapping for unwrapped entities (Bug M regression guard)', async () => {
+    // Defensive — when all URIs are already canonical, the dual
+    // write collapses to a single key and the map size is just
+    // the entity count.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'recipes', entityCount: 1, tripleCount: 1, description: '' }],
+    });
+    const e = {
+      uri: 'urn:e:plain',
+      label: 'Plain', types: [],
+      trustLevel: 'verified',
+      layers: new Set(['verified']),
+      subGraphs: new Set(['recipes']),
+      properties: new Map(), connections: [],
+    };
+    const edge = {
+      subject: 'urn:e:plain',
+      predicate: 'http://schema.org/name',
+      object: '"Plain"',
+      subGraph: 'recipes',
+      layer: 'verified' as const,
+    };
+    await renderWith({
+      ...memory,
+      entityList: [e],
+      entities: new Map([[e.uri, e]]),
+      allTriples: [edge],
+    });
+    await flush();
+
+    async function waitForGraph(maxMs = 1000): Promise<HTMLElement | null> {
+      const start = Date.now();
+      while (Date.now() - start < maxMs) {
+        const el = container.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+        if (el) return el;
+        await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+      }
+      return container.querySelector('[data-testid="rdf-graph"]');
+    }
+    const graph = await waitForGraph();
+    expect(graph).toBeTruthy();
+    const nodeColors = JSON.parse(graph!.getAttribute('data-node-colors') ?? '{}');
+    expect(nodeColors['urn:e:plain']).toBe(TRUST_COLORS.verified);
+    // The dual-key shape MUST NOT introduce a phantom wrapped
+    // form when the entity didn't have one.
+    expect(nodeColors['<urn:e:plain>']).toBeUndefined();
+  });
 });

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -621,10 +621,10 @@ describe.skip('ProjectView as Memory Explorer', () => {
     expect(pv).toContain('isConversationTurn(e)) continue');
   });
 
-  it('has TrustStatusBox component showing Verified/Shared/Private label', () => {
+  it('has TrustStatusBox component showing Verifiable/Shared/Private label', () => {
     expect(pv).toContain('TrustStatusBox');
     expect(pv).toContain('TRUST_LABELS');
-    expect(pv).toContain("verified: 'Verified'");
+    expect(pv).toContain("verified: 'Verifiable'");
     expect(pv).toContain("shared: 'Shared'");
     expect(pv).toContain("working: 'Private'");
     expect(pv).toContain('v10-trust-status-box');


### PR DESCRIPTION
## Summary

Single polish PR bundling 10 of the 11 manual-test items from PR #772's review (item #5 deferred to Track A / S5 per ux-lead). Each item is a per-finding commit; lead-citation tags in the commit messages and below.

**Behaviour fixes**
- **#4** User-facing `"Verified"` → `"Verifiable"` vocab sweep (6 sites). Code identifiers (`TrustLevel = 'verified'`, `TRUST_COLORS.verified`) stay untouched per ux-lead's keep-list. _(ux-locked §1.5)_
- **#6** Cross-layer strip cells become interactive `<button aria-pressed=...>` wired to `toggleLayer`; `→` arrows stay inert. Inherits the "refuse last enabled" safeguard from `toggleLayer`. _(ui-locked)_
- **#7** `All` chip — extended tooltip clarifying the distinct-total math; inline `All = Root + subgraphs` hint (muted 11px, single line) after the Root chip. _(ux-locked option ii)_
- **#8** SWM-attribution discoverability — `Colored by contributing agent` badge above the Graph pane when narrowed to SWM-only; context-sensitive tooltip on the SWM cell. _(ux-locked a + c, b rejected)_
- **#9** `activeLayer` preservation on subgraph-chip navigation. `SubGraphBar.onSelect` carries `originatingLayer` as a 2nd arg; `ProjectView` plumbs it to `SubGraphDetailView.initialLayer`; that seeds `enabledLayers` to the originating layer instead of defaulting to all-three. Closes the §4.4.1 fold-in #4 contract. _(ux-locked §3 + §4.4.1 fold-in #4)_

**Visual polish**
- **#1** Mechanical rename `MiniLayerPyramid` → `MiniLayerBar`; `.v10-minipyr*` → `.v10-minibar*`. No visual change. _(ui-locked option b)_
- **#2 + #10b** `compact={true}` on both consumer mounts collapses MiniLayerBar's empty branch to `null`, eliminating the duplicate "No data" labels (card grid + detail-header corner). Card-body copy override: `entityCount > 0 ? 'Promoted — open to view' : 'No data yet'` (was `'No WM triples · promoted data only'` / `'No data yet'`). _(ui-locked compact, ux-locked card-body copy)_
- **#3** Per-trust mini-graph `nodeColors` plumbed via `graphOptions.style.nodeColors`. ui-locked priority chain: per-URI TRUST_COLORS wins → `defaultNodeColor` (card chrome) → namespaceColors. _(ui-locked)_
- **#10a** `.v10-subgraph-detail-title-wrap` reserves `min-height: 44px`; 1- and 2-line subgraph titles occupy the same vertical slot, no layout shift on navigation. _(ui-locked)_
- **#11** Cross-layer strip / lede / pill breathing room — `padding: 16px 16px 0` / `margin-bottom: 10px` / `margin-top: 14px`. Numeric deltas only, no new tokens, no DOM. _(ui-locked)_

**No-work**
- **#5** Partial breadcrumb ships as-is until Track A / S5 lands the deep multi-hop breadcrumb model. _(ux-locked)_

## Related

- Follows #772 (parent — S3 Subgraph Explorer)
- Track A S5 will carry #5 forward (Task #7)
- GH #771 / GH #773 are separate follow-ups, not in this PR
- Out-of-scope: Task #19 (`singleLayerPanelTriples` exact-tag-routing parallel construct)

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/components/SubGraphBar.tsx` | #7 hint + tooltip on All chip; #9 `onSelect` 2-arg signature forwarding `originatingLayer` to every chip click |
| `packages/node-ui/src/ui/views/ProjectView.tsx` | #9 `subGraphInitialLayer` state + `handleSelectSubGraph` arg + `SubGraphDetailView.initialLayer` plumbing |
| `packages/node-ui/src/ui/views/project/components.tsx` | #1 component + mount rename; #2/#10b `compact` mounts + card-body copy; #3 `entityTrustByUriBySubGraph` derivation + `SubGraphMiniCard` per-URI nodeColors; #4 user-facing label rename (4 sites); #6 cross-layer cells become buttons + `aria-pressed`; #8 SWM-attribution badge + cell tooltip; #9 `initialLayer` prop + `initialEnabledLayers` seed |
| `packages/node-ui/src/ui/views/project/helpers.ts` | #4 `LAYER_CONFIG.vm.trustLabel` rename |
| `packages/node-ui/src/ui/styles.css` | #1 `.v10-minipyr*` → `.v10-minibar*` sweep; #6 cell hover / `aria-pressed` rules + `--bg-hover`; #7 `.v10-subgraph-bar-hint`; #8 attribution badge styles (reuses `--layer-shared` token); #10a title-wrap `min-height`; #11 spacing deltas |
| `packages/node-ui/test/context-graph-empty-stat-components.test.ts` | #4 vocab assertion update |
| `packages/node-ui/test/context-graph-ia-overview.test.ts` | #4 — legacy "Verified Memory" leak guard removed (moot post-sweep) |
| `packages/node-ui/test/sub-graph-bar-layer-scope.test.ts` | #7 hint + tooltip cases; #9 onSelect arg-forwarding cases (4 total new + 1 updated) |
| `packages/node-ui/test/subgraph-detail-view.test.ts` | #1 class-name updates; #2/#10b symmetric detail-header empty case; #6 cell click + safeguard; #8 SWM badge presence/absence; #9 `initialLayer` seeding (6 total new) |
| `packages/node-ui/test/subgraph-overview-grid.test.ts` | #2/#10b card-body two-branch cases + duplicate-label regression; #3 per-URI nodeColors + chrome-fallback regression (5 total new) |
| `packages/node-ui/test/ui-compat.test.ts` | #4 source-line guard update + test-description rename (inside `describe.skip`) |

## Test plan

- [x] `tsc --noEmit` exit 0
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui` clean (only the existing chunk-size warning)
- [x] Extended S3 regression slice — **330 passed / 38 skipped** across 23 files, deterministic on warm rerun
  - Net new cases by item: #1 mechanical (no new); #2+#10b 4 new; #3 2 new; #4 vocab (existing updated, 1 line removed); #6 2 new; #7 3 new; #8 2 new; #9 5 new (1 existing updated)
- [x] Pre-flight gates:
  - `agent-docs/` NOT in diff
  - No new raw hex colors (`#3` uses `TRUST_COLORS[trustLevel]`; `#8` SWM dot reuses existing `--layer-shared` token)
  - No new design tokens introduced (`#11` numeric deltas; `#6` reuses `--bg-hover`)
  - `RESERVED_SUB_GRAPH_SLUGS` stays `Set(['meta'])`
- [ ] (Reviewer manual walkthrough — happy path) navigate Subgraphs → click a chip from WM tab → assert detail view's Active layer pill reads "Working Memory" + cross-layer cells show only WM pressed (#9). Click cells to toggle; click the last enabled WM cell → assert it stays pressed (#6 safeguard). Narrow to SWM → assert "Colored by contributing agent" badge above graph + SWM cell tooltip (#8).

## Commit history (per-finding)

- `afe9f0b13` #10a + #11 spacing (ui-locked, CSS-only)
- `fc20b6dde` #9 layer preservation (ux-locked §4.4.1 fold-in #4)
- `2d89c2c31` #8 SWM-attribution discoverability (ux-locked a + c)
- `e46ed609c` #7 All count hint + tooltip (ux-locked option ii)
- `762b1b2cf` #6 interactive cross-layer cells (ui-locked)
- `355af0115` #3 per-trust nodeColors (ui-locked priority chain)
- `878b0ecba` #2 + #10b compact mounts + card-body copy (ui-locked + ux-locked)
- `36c9647ba` #4 Verifiable vocab sweep (ux-locked §1.5)
- `6ad1eaa6f` #1 MiniLayerPyramid → MiniLayerBar (ui-locked option b)