### PR TITLE
fix(hermes): provision + forward API_SERVER_KEY so UI chat survives Hermes v0.15.0 (#794)

### DIFF
--- a/packages/adapter-hermes/README.md
+++ b/packages/adapter-hermes/README.md
@@ -224,11 +224,21 @@ client, and payload contracts that call into them.
 | `POST /api/hermes-channel/persist-turn` | Persist a completed Hermes turn through DKG chat memory with duplicate-turn protection. |
 
 The daemon forwards Node UI chat to Hermes' OpenAI-compatible API server at
-`http://127.0.0.1:8642` by default. Set `API_SERVER_ENABLED=true` in the active
-Hermes profile `.env`, then restart `hermes gateway run --replace -v`. Use
-`dkg hermes setup --gateway-url <url>` when the Hermes API server is reachable
-through WSL2 or a remote gateway. `--bridge-url` is reserved for a custom
-loopback bridge that implements `/health`, `/send`, and `/stream`.
+`http://127.0.0.1:8642` by default. Since Hermes v0.15.0 that API server
+refuses to start without `API_SERVER_KEY`, even on loopback. For the local
+loopback transport, `dkg hermes setup` provisions this automatically: it writes
+`API_SERVER_ENABLED=true` and a generated `API_SERVER_KEY` into the active
+Hermes profile `.env` (an existing key is never overwritten), and the daemon
+forwards `Authorization: Bearer <API_SERVER_KEY>` to `/v1/chat/completions`.
+You only need to restart `hermes gateway run --replace -v` so Hermes picks up
+the key — the same restart the provider install already requires.
+
+Use `dkg hermes setup --gateway-url <url>` when the Hermes API server is
+reachable through WSL2 or a remote gateway. In that case Hermes' `.env` lives on
+another host, so DKG does not write it; set `DKG_HERMES_API_SERVER_KEY` in the
+daemon environment to the key configured on the remote Hermes and DKG forwards
+it as the bearer. `--bridge-url` is reserved for a custom loopback bridge that
+implements `/health`, `/send`, and `/stream`.
 
 Attachment references are node-owned assertion refs. The daemon verifies their
 provenance before forwarding them to Hermes.

--- a/packages/adapter-hermes/src/setup.ts
+++ b/packages/adapter-hermes/src/setup.ts
@@ -1563,16 +1563,26 @@ function readActiveEnvVar(filePath: string, key: string): string | undefined {
 }
 
 function parseEnvLine(line: string): { key: string; value: string } | null {
-  const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/);
+  const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/);
   if (!match) return null; // comments, blanks, malformed lines
-  let value = match[2];
-  if (
-    (value.startsWith('"') && value.endsWith('"'))
-    || (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    value = value.slice(1, -1);
+  return { key: match[1], value: parseDotenvValue(match[2]) };
+}
+
+/**
+ * Extract a `.env` value the way Hermes (python-dotenv) does: a quoted value
+ * keeps everything between the quotes (inline `#` included); an unquoted value
+ * is truncated at the first whitespace-preceded `#` (an inline comment) and
+ * trimmed. Matching this is what keeps DKG's forwarded key identical to the
+ * one Hermes loads.
+ */
+function parseDotenvValue(raw: string): string {
+  const value = raw.replace(/^\s+/, '');
+  if (value[0] === '"' || value[0] === "'") {
+    const end = value.indexOf(value[0], 1);
+    if (end > 0) return value.slice(1, end);
   }
-  return { key: match[1], value };
+  const comment = value.match(/\s#/);
+  return (comment?.index !== undefined ? value.slice(0, comment.index) : value).trim();
 }
 
 /**

--- a/packages/adapter-hermes/src/setup.ts
+++ b/packages/adapter-hermes/src/setup.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { isIP } from 'node:net';
 import {
   fundWalletsBestEffort,
+  parseDotenvValue,
   resolveDkgConfigHome,
   resolveDkgHome,
   startDaemon,
@@ -243,12 +244,6 @@ export function setupHermesProfile(options: HermesSetupOptions = {}): HermesSetu
 
   installHermesProviderPlugin(plan.profile);
 
-  // Provision API_SERVER_KEY (+ API_SERVER_ENABLED) into the Hermes profile
-  // `.env` for the loopback hermes-openai UI-chat transport. The user's
-  // existing `hermes gateway run --replace` restart picks it up; the daemon
-  // forwards the bearer. No-op for the loopback bridge / remote gateways.
-  const apiServerKeyConfigured = maybeProvisionHermesApiServerEnv(plan.profile, plan.state.bridge);
-
   // S4 vector-6 fix (adversarial-findings.md §6): peek the
   // provider-swap intent BEFORE the destructive `config.yaml` rewrite,
   // and persist `setup-state.json` with `priorMemoryProvider` set to
@@ -302,6 +297,14 @@ export function setupHermesProfile(options: HermesSetupOptions = {}): HermesSetu
     const skillPath = join(plan.profile.hermesHome, 'skills', 'dkg-node', 'SKILL.md');
     writeOwnedText(skillPath, options.nodeSkillContent);
   }
+
+  // Provision API_SERVER_KEY (+ API_SERVER_ENABLED) into the Hermes profile
+  // `.env` LAST — after every step that can throw (the provider-block rewrite,
+  // skill write) — so an aborted setup never leaves a new key behind as a
+  // side effect. The user's existing `hermes gateway run --replace` restart
+  // picks it up; the daemon forwards the bearer. No-op for the loopback bridge
+  // and remote gateways.
+  const apiServerKeyConfigured = maybeProvisionHermesApiServerEnv(plan.profile, plan.state.bridge);
 
   // Re-write setup-state.json post-rewrite with the freshest
   // `updatedAt`. The `priorMemoryProvider` slot is still first-wins
@@ -1565,24 +1568,9 @@ function readActiveEnvVar(filePath: string, key: string): string | undefined {
 function parseEnvLine(line: string): { key: string; value: string } | null {
   const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/);
   if (!match) return null; // comments, blanks, malformed lines
+  // parseDotenvValue (shared with the daemon via dkg-core) matches
+  // python-dotenv so the key we read here is identical to the one Hermes loads.
   return { key: match[1], value: parseDotenvValue(match[2]) };
-}
-
-/**
- * Extract a `.env` value the way Hermes (python-dotenv) does: a quoted value
- * keeps everything between the quotes (inline `#` included); an unquoted value
- * is truncated at the first whitespace-preceded `#` (an inline comment) and
- * trimmed. Matching this is what keeps DKG's forwarded key identical to the
- * one Hermes loads.
- */
-function parseDotenvValue(raw: string): string {
-  const value = raw.replace(/^\s+/, '');
-  if (value[0] === '"' || value[0] === "'") {
-    const end = value.indexOf(value[0], 1);
-    if (end > 0) return value.slice(1, end);
-  }
-  const comment = value.match(/\s#/);
-  return (comment?.index !== undefined ? value.slice(0, comment.index) : value).trim();
 }
 
 /**

--- a/packages/adapter-hermes/src/setup.ts
+++ b/packages/adapter-hermes/src/setup.ts
@@ -1,7 +1,7 @@
-import { cpSync, existsSync, readFileSync, renameSync, rmSync, writeFileSync, mkdirSync, statSync, rmdirSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, readFileSync, renameSync, rmSync, writeFileSync, mkdirSync, statSync, rmdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { isIP } from 'node:net';
 import {
@@ -185,16 +185,27 @@ export function planHermesSetup(options: HermesSetupOptions = {}): HermesSetupPl
     managedFiles,
   };
 
+  const actions: HermesSetupPlan['actions'] = managedFiles.map((path) => ({
+    type: existsSync(path) ? 'update' : 'create',
+    path,
+    reason: 'adapter-managed Hermes profile artifact',
+  }));
+  // `.env` is user/Hermes-owned (kept OUT of managedFiles so disconnect
+  // preserves it); surface the key provisioning as a separate action only.
+  if (shouldProvisionApiServerEnv(bridge)) {
+    actions.push({
+      type: 'update',
+      path: join(profile.hermesHome, '.env'),
+      reason: 'ensure API_SERVER_KEY + API_SERVER_ENABLED for Hermes api_server (hermes-openai transport)',
+    });
+  }
+
   return {
     dryRun: options.dryRun === true,
     profile,
     warnings,
     state,
-    actions: managedFiles.map((path) => ({
-      type: existsSync(path) ? 'update' : 'create',
-      path,
-      reason: 'adapter-managed Hermes profile artifact',
-    })),
+    actions,
   };
 }
 
@@ -231,6 +242,12 @@ export function setupHermesProfile(options: HermesSetupOptions = {}): HermesSetu
   });
 
   installHermesProviderPlugin(plan.profile);
+
+  // Provision API_SERVER_KEY (+ API_SERVER_ENABLED) into the Hermes profile
+  // `.env` for the loopback hermes-openai UI-chat transport. The user's
+  // existing `hermes gateway run --replace` restart picks it up; the daemon
+  // forwards the bearer. No-op for the loopback bridge / remote gateways.
+  const apiServerKeyConfigured = maybeProvisionHermesApiServerEnv(plan.profile, plan.state.bridge);
 
   // S4 vector-6 fix (adversarial-findings.md §6): peek the
   // provider-swap intent BEFORE the destructive `config.yaml` rewrite,
@@ -297,6 +314,7 @@ export function setupHermesProfile(options: HermesSetupOptions = {}): HermesSetu
   const state = {
     ...stateBeforeRewrite,
     updatedAt: new Date().toISOString(),
+    ...(apiServerKeyConfigured ? { apiServerKeyConfigured: true } : {}),
   };
   writeOwnedJson(join(plan.profile.stateDir, 'setup-state.json'), state);
   plan.state = state;
@@ -1480,6 +1498,108 @@ function isOwnedJson(path: string): boolean {
     return raw?.managedBy === MANAGED_BY;
   } catch {
     return false;
+  }
+}
+
+const API_SERVER_KEY_ENV = 'API_SERVER_KEY';
+const API_SERVER_ENABLED_ENV = 'API_SERVER_ENABLED';
+
+/**
+ * Hermes' OpenAI-compatible api_server — the transport the Node UI chat
+ * path forwards to — has refused to start without `API_SERVER_KEY` since
+ * Hermes v0.15.0, even on loopback `127.0.0.1`. The adapter provisions the
+ * key into the Hermes profile `.env` (the only place Hermes reads it from;
+ * config.yaml support is not yet available upstream) so the
+ * already-documented `hermes gateway run --replace` restart brings the
+ * api_server online with auth, and the daemon forwards
+ * `Authorization: Bearer <key>`.
+ *
+ * Returns whether the profile `.env` now carries an active key. Only
+ * loopback gateways are provisioned: a remote/WSL `--gateway-url` points at
+ * a Hermes whose `.env` lives on another host, so DKG cannot (and must not)
+ * write it — that case relies on the `DKG_HERMES_API_SERVER_KEY` daemon
+ * fallback instead. The existing key is never overwritten, and disconnect
+ * preserves `.env`.
+ */
+function maybeProvisionHermesApiServerEnv(
+  profile: HermesProfileMetadata,
+  bridge: HermesSetupState['bridge'] | undefined,
+): boolean {
+  if (!shouldProvisionApiServerEnv(bridge)) return false;
+  const envPath = join(profile.hermesHome, '.env');
+  if (!readActiveEnvVar(envPath, API_SERVER_KEY_ENV)) {
+    upsertEnvVar(envPath, API_SERVER_KEY_ENV, generateApiServerKey());
+  }
+  if ((readActiveEnvVar(envPath, API_SERVER_ENABLED_ENV) ?? '').toLowerCase() !== 'true') {
+    upsertEnvVar(envPath, API_SERVER_ENABLED_ENV, 'true');
+  }
+  return true;
+}
+
+function shouldProvisionApiServerEnv(bridge: HermesSetupState['bridge'] | undefined): boolean {
+  return bridge?.protocol === 'hermes-openai'
+    && !!bridge.gatewayUrl
+    && isLoopbackUrl(bridge.gatewayUrl);
+}
+
+function generateApiServerKey(): string {
+  // Any non-empty string is a valid Hermes API_SERVER_KEY; 32 random bytes
+  // gives a 43-char URL-safe secret with no shell-hostile characters.
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Last uncommented `KEY=value` wins (dotenv semantics). Returns undefined
+ * when the key is absent, blank, or only present in commented-out lines.
+ */
+function readActiveEnvVar(filePath: string, key: string): string | undefined {
+  if (!existsSync(filePath)) return undefined;
+  let value: string | undefined;
+  for (const line of readFileSync(filePath, 'utf-8').split(/\r?\n/)) {
+    const parsed = parseEnvLine(line);
+    if (parsed && parsed.key === key) value = parsed.value;
+  }
+  return value && value.length > 0 ? value : undefined;
+}
+
+function parseEnvLine(line: string): { key: string; value: string } | null {
+  const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/);
+  if (!match) return null; // comments, blanks, malformed lines
+  let value = match[2];
+  if (
+    (value.startsWith('"') && value.endsWith('"'))
+    || (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+  return { key: match[1], value };
+}
+
+/**
+ * Idempotently set `KEY=value` in a `.env`, replacing the last uncommented
+ * occurrence in place (or appending) and preserving every other line. The
+ * file is shared with the user / Hermes, so it is NOT ownership-marked; we
+ * only ever touch the targeted key. Written `0600` because it holds a secret.
+ */
+function upsertEnvVar(filePath: string, key: string, value: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const lines = existsSync(filePath)
+    ? readFileSync(filePath, 'utf-8').split(/\r?\n/)
+    : [];
+  if (lines.length && lines[lines.length - 1] === '') lines.pop();
+  let lastIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const parsed = parseEnvLine(lines[i]);
+    if (parsed && parsed.key === key) lastIdx = i;
+  }
+  const next = `${key}=${value}`;
+  if (lastIdx >= 0) lines[lastIdx] = next;
+  else lines.push(next);
+  writeFileSync(filePath, `${lines.join('\n')}\n`, { mode: 0o600 });
+  try {
+    chmodSync(filePath, 0o600);
+  } catch {
+    // best-effort: Windows / restricted filesystems ignore POSIX modes
   }
 }
 

--- a/packages/adapter-hermes/src/types.ts
+++ b/packages/adapter-hermes/src/types.ts
@@ -58,6 +58,15 @@ export interface HermesSetupState {
   updatedAt: string;
   managedFiles: string[];
   /**
+   * `true` when setup ensured a non-empty `API_SERVER_KEY` (and
+   * `API_SERVER_ENABLED=true`) in the Hermes profile `.env` for the
+   * loopback `hermes-openai` UI-chat transport. Hermes' api_server has
+   * refused to start without a key since v0.15.0; the daemon forwards
+   * `Authorization: Bearer <key>` to `/v1/chat/completions`. Never carries
+   * the secret itself (the key lives only in `<hermesHome>/.env`).
+   */
+  apiServerKeyConfigured?: boolean;
+  /**
    * Captured at the first install that replaced a non-DKG memory.provider
    * in `<hermesHome>/config.yaml`. First-wins: re-runs do NOT overwrite
    * this snapshot. `restoreHermesProfile` consumes it to put the user

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -340,6 +340,51 @@ describe('Hermes profile setup helpers', () => {
     expect(readFileSync(join(hermesHome, 'plugins', 'dkg', '.dkg-adapter-hermes-owner.json'), 'utf-8')).toContain('@origintrail-official/dkg-adapter-hermes');
   });
 
+  it('provisions API_SERVER_KEY and API_SERVER_ENABLED in .env for the loopback hermes-openai transport', () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    const result = setupHermesProfile({ hermesHome });
+    const envPath = join(hermesHome, '.env');
+
+    expect(existsSync(envPath)).toBe(true);
+    const env = readFileSync(envPath, 'utf-8');
+    const keyMatch = env.match(/^API_SERVER_KEY=(.+)$/m);
+    expect(keyMatch?.[1] && keyMatch[1].length).toBeGreaterThan(0);
+    expect(env).toMatch(/^API_SERVER_ENABLED=true$/m);
+    expect(result.state.apiServerKeyConfigured).toBe(true);
+
+    // Re-run is idempotent: the generated key is never regenerated/overwritten.
+    const generatedKey = keyMatch![1];
+    setupHermesProfile({ hermesHome });
+    expect(readFileSync(envPath, 'utf-8')).toContain(`API_SERVER_KEY=${generatedKey}`);
+  });
+
+  it('preserves an existing user API_SERVER_KEY and unrelated .env lines', () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    writeFileSync(join(hermesHome, '.env'), 'FOO=bar\nAPI_SERVER_KEY=user-secret\n');
+
+    setupHermesProfile({ hermesHome });
+
+    const env = readFileSync(join(hermesHome, '.env'), 'utf-8');
+    expect(env).toContain('API_SERVER_KEY=user-secret');
+    expect(env).toContain('FOO=bar');
+    expect(env).toMatch(/^API_SERVER_ENABLED=true$/m);
+  });
+
+  it('does not write .env in dry-run but reports the provisioning action', () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    const plan = planHermesSetup({ hermesHome, dryRun: true });
+
+    expect(existsSync(join(hermesHome, '.env'))).toBe(false);
+    expect(plan.actions.some((action) => action.path.endsWith('.env'))).toBe(true);
+  });
+
+  it('does not provision .env for a remote (non-loopback) gateway transport', () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    setupHermesProfile({ hermesHome, gatewayUrl: 'https://hermes.example.com:8642' });
+
+    expect(existsSync(join(hermesHome, '.env'))).toBe(false);
+  });
+
   it('loads the installed provider from Hermes user plugin discovery path', () => {
     const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
     setupHermesProfile({

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -662,6 +662,17 @@ assert config["allow_context_graph_admin_tools"] is False, config
       .toThrow('memory.provider: mem0');
   });
 
+  it('does not provision .env when setup aborts (no side effect on failure)', () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    writeFileSync(join(hermesHome, 'config.yaml'), 'memory: # existing provider\n  provider: mem0\n');
+
+    // preserveProvider throws on the existing non-DKG provider BEFORE the
+    // (now last) .env provisioning step, so no API_SERVER_KEY is written.
+    expect(() => setupHermesProfile({ hermesHome, memoryMode: 'provider', preserveProvider: true }))
+      .toThrow('memory.provider: mem0');
+    expect(existsSync(join(hermesHome, '.env'))).toBe(false);
+  });
+
   it('ignores nested memory provider blocks when managing Hermes provider config', () => {
     const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
     writeFileSync(join(hermesHome, 'config.yaml'), [

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -358,16 +358,21 @@ describe('Hermes profile setup helpers', () => {
     expect(readFileSync(envPath, 'utf-8')).toContain(`API_SERVER_KEY=${generatedKey}`);
   });
 
-  it('preserves an existing user API_SERVER_KEY and unrelated .env lines', () => {
+  it('preserves an existing user API_SERVER_KEY (incl. inline comments) and unrelated .env lines', () => {
     const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
-    writeFileSync(join(hermesHome, '.env'), 'FOO=bar\nAPI_SERVER_KEY=user-secret\n');
+    // Inline comments must be parsed (dotenv) so the existing key is detected
+    // (not overwritten) and an already-true API_SERVER_ENABLED is not duplicated.
+    writeFileSync(
+      join(hermesHome, '.env'),
+      'FOO=bar\nAPI_SERVER_ENABLED=true # on\nAPI_SERVER_KEY=user-secret # mine\n',
+    );
 
     setupHermesProfile({ hermesHome });
 
     const env = readFileSync(join(hermesHome, '.env'), 'utf-8');
-    expect(env).toContain('API_SERVER_KEY=user-secret');
+    expect(env).toContain('API_SERVER_KEY=user-secret # mine');
     expect(env).toContain('FOO=bar');
-    expect(env).toMatch(/^API_SERVER_ENABLED=true$/m);
+    expect((env.match(/^API_SERVER_ENABLED=/gm) ?? []).length).toBe(1);
   });
 
   it('does not write .env in dry-run but reports the provisioning action', () => {

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -1,5 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { readFileSync, statSync } from 'node:fs';
 import { isIP } from 'node:net';
+import { join } from 'node:path';
 
 import type { DKGAgent } from '@origintrail-official/dkg-agent';
 import type { ChatMemoryManager } from '@origintrail-official/dkg-node-ui';
@@ -237,7 +239,17 @@ export function buildHermesChannelHeaders(
   bridgeAuthToken: string | undefined,
   baseHeaders: Record<string, string> = {},
   requestUrl = target.inboundUrl,
+  apiServerKey?: string,
 ): Record<string, string> {
+  // Hermes' OpenAI-compatible api_server requires `Authorization: Bearer
+  // <API_SERVER_KEY>` on `/v1/chat/completions` since v0.15.0. We only add it
+  // when a key is resolved, so older key-less Hermes installs and the
+  // unauthenticated `/health` probe keep their current behavior.
+  if (target.protocol === 'hermes-openai') {
+    return apiServerKey
+      ? { ...baseHeaders, Authorization: `Bearer ${apiServerKey}` }
+      : baseHeaders;
+  }
   if (
     target.name !== 'bridge' ||
     !bridgeAuthToken ||
@@ -246,6 +258,59 @@ export function buildHermesChannelHeaders(
     return baseHeaders;
   }
   return { ...baseHeaders, 'x-dkg-bridge-token': bridgeAuthToken };
+}
+
+/**
+ * Resolve the Hermes API server key for the `hermes-openai` UI-chat
+ * transport. `.env` (in the stored profile's `hermesHome`) is the source of
+ * truth — the same file `dkg hermes setup` provisions and the one Hermes
+ * itself reads. Reads are cached by path+mtime so we don't touch disk on
+ * every chat request. `DKG_HERMES_API_SERVER_KEY` overrides for remote/WSL
+ * gateways whose `.env` is not on the daemon's filesystem. Returns undefined
+ * when no key is available (older key-less Hermes → no bearer is sent).
+ */
+export function resolveHermesApiServerKey(config: DkgConfig): string | undefined {
+  const override = optionalTrimmedString(process.env.DKG_HERMES_API_SERVER_KEY);
+  if (override) return override;
+  const integration = getLocalAgentIntegration(config, 'hermes');
+  const hermesHome = optionalTrimmedString(
+    (integration?.metadata as Record<string, unknown> | undefined)?.hermesHome,
+  );
+  if (!hermesHome) return undefined;
+  return readApiServerKeyFromEnv(join(hermesHome, '.env'));
+}
+
+const apiServerKeyCache = new Map<string, { mtimeMs: number; key: string | undefined }>();
+
+function readApiServerKeyFromEnv(envPath: string): string | undefined {
+  let mtimeMs: number;
+  try {
+    mtimeMs = statSync(envPath).mtimeMs;
+  } catch {
+    apiServerKeyCache.delete(envPath);
+    return undefined;
+  }
+  const cached = apiServerKeyCache.get(envPath);
+  if (cached && cached.mtimeMs === mtimeMs) return cached.key;
+  let key: string | undefined;
+  try {
+    for (const line of readFileSync(envPath, 'utf-8').split(/\r?\n/)) {
+      const match = line.match(/^\s*(?:export\s+)?API_SERVER_KEY\s*=\s*(.*?)\s*$/);
+      if (!match) continue;
+      let value = match[1];
+      if (
+        (value.startsWith('"') && value.endsWith('"'))
+        || (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (value) key = value; // last uncommented assignment wins (dotenv)
+    }
+  } catch {
+    key = undefined;
+  }
+  apiServerKeyCache.set(envPath, { mtimeMs, key });
+  return key;
 }
 
 export function transportPatchFromHermesTarget(
@@ -351,6 +416,17 @@ export async function probeHermesChannelHealth(
       else gateway = result;
       lastError = err.message;
     }
+  }
+
+  // The api_server has refused to start without API_SERVER_KEY since Hermes
+  // v0.15.0, so an unreachable hermes-openai target with no key resolvable is
+  // overwhelmingly a missing-key problem — surface that instead of a bare
+  // "fetch failed" in the Node UI's degraded status.
+  if (
+    targets.some((t) => t.protocol === 'hermes-openai')
+    && !resolveHermesApiServerKey(config)
+  ) {
+    lastError = `${lastError} — Hermes api_server requires API_SERVER_KEY (Hermes v0.15.0+); run "dkg hermes setup" then restart "hermes gateway run --replace -v".`;
   }
 
   return { ok: false, bridge, gateway, error: lastError };

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -4,6 +4,7 @@ import { isIP } from 'node:net';
 import { join } from 'node:path';
 
 import type { DKGAgent } from '@origintrail-official/dkg-agent';
+import { parseDotenvValue } from '@origintrail-official/dkg-core';
 import type { ChatMemoryManager } from '@origintrail-official/dkg-node-ui';
 import type {
   DkgConfig,
@@ -328,23 +329,6 @@ function readApiServerKeyFromEnv(envPath: string): string | undefined {
   }
   apiServerKeyCache.set(envPath, { mtimeMs, key });
   return key;
-}
-
-/**
- * Extract a `.env` value the way Hermes (python-dotenv) does: a quoted value
- * keeps everything between the quotes (inline `#` included); an unquoted value
- * is truncated at the first whitespace-preceded `#` (inline comment) and
- * trimmed. Matching this keeps the bearer DKG forwards identical to the key
- * Hermes loads (`API_SERVER_KEY=secret # dev` → `secret`, not `secret # dev`).
- */
-function parseDotenvValue(raw: string): string {
-  const value = raw.replace(/^\s+/, '');
-  if (value[0] === '"' || value[0] === "'") {
-    const end = value.indexOf(value[0], 1);
-    if (end > 0) return value.slice(1, end);
-  }
-  const comment = value.match(/\s#/);
-  return (comment?.index !== undefined ? value.slice(0, comment.index) : value).trim();
 }
 
 export function transportPatchFromHermesTarget(

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -272,12 +272,35 @@ export function buildHermesChannelHeaders(
 export function resolveHermesApiServerKey(config: DkgConfig): string | undefined {
   const override = optionalTrimmedString(process.env.DKG_HERMES_API_SERVER_KEY);
   if (override) return override;
+  // Only the LOOPBACK api_server reads a key from a local `.env`. A remote/WSL
+  // `--gateway-url` Hermes keeps its `.env` on another host, so reading the
+  // local profile here would forward a stale, unrelated key and make remote
+  // chat fail — those setups must use DKG_HERMES_API_SERVER_KEY (handled above).
+  if (!hasLoopbackHermesOpenAiTarget(config)) return undefined;
   const integration = getLocalAgentIntegration(config, 'hermes');
   const hermesHome = optionalTrimmedString(
     (integration?.metadata as Record<string, unknown> | undefined)?.hermesHome,
   );
   if (!hermesHome) return undefined;
   return readApiServerKeyFromEnv(join(hermesHome, '.env'));
+}
+
+/** True when the active hermes-openai target is a loopback api_server. */
+function hasLoopbackHermesOpenAiTarget(config: DkgConfig): boolean {
+  const target = getHermesChannelTargets(config).find((t) => t.protocol === 'hermes-openai');
+  return !!target && isHermesLoopbackUrl(target.inboundUrl);
+}
+
+/**
+ * Actionable remediation for a Hermes api_server auth failure, branched on
+ * transport: a loopback gateway is fixed by `dkg hermes setup` (which writes
+ * the local `.env`); a remote/WSL gateway is fixed by the daemon-side
+ * DKG_HERMES_API_SERVER_KEY override, since setup never touches a remote `.env`.
+ */
+export function hermesApiServerKeyRemediation(config: DkgConfig): string {
+  return hasLoopbackHermesOpenAiTarget(config)
+    ? 'run "dkg hermes setup" to provision API_SERVER_KEY, then restart "hermes gateway run --replace -v"'
+    : 'set DKG_HERMES_API_SERVER_KEY in the daemon environment to the remote Hermes API_SERVER_KEY (setup does not modify a remote .env), then restart the daemon';
 }
 
 const apiServerKeyCache = new Map<string, { mtimeMs: number; key: string | undefined }>();
@@ -437,7 +460,7 @@ export async function probeHermesChannelHealth(
     targets.some((t) => t.protocol === 'hermes-openai')
     && !resolveHermesApiServerKey(config)
   ) {
-    lastError = `${lastError} — Hermes api_server requires API_SERVER_KEY (Hermes v0.15.0+); run "dkg hermes setup" then restart "hermes gateway run --replace -v".`;
+    lastError = `${lastError} — Hermes api_server requires API_SERVER_KEY (Hermes v0.15.0+); ${hermesApiServerKeyRemediation(config)}.`;
   }
 
   return { ok: false, bridge, gateway, error: lastError };

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -243,11 +243,13 @@ export function buildHermesChannelHeaders(
   apiServerKey?: string,
 ): Record<string, string> {
   // Hermes' OpenAI-compatible api_server requires `Authorization: Bearer
-  // <API_SERVER_KEY>` on `/v1/chat/completions` since v0.15.0. We only add it
-  // when a key is resolved, so older key-less Hermes installs and the
-  // unauthenticated `/health` probe keep their current behavior.
+  // <API_SERVER_KEY>` on `/v1/chat/completions` since v0.15.0. We add it only
+  // when a key is resolved AND the request is not the health probe: `/health`
+  // is unauthenticated upstream, so sending the bearer there is pointless and
+  // would risk leaking it to health-endpoint/proxy logs. Key-less older Hermes
+  // installs keep their current (no-auth) behavior.
   if (target.protocol === 'hermes-openai') {
-    return apiServerKey
+    return apiServerKey && requestUrl !== target.healthUrl
       ? { ...baseHeaders, Authorization: `Bearer ${apiServerKey}` }
       : baseHeaders;
   }

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -3,6 +3,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { isIP } from 'node:net';
 import { join } from 'node:path';
 
+import { resolveHermesProfile } from '@origintrail-official/dkg-adapter-hermes';
 import type { DKGAgent } from '@origintrail-official/dkg-agent';
 import { parseDotenvValue } from '@origintrail-official/dkg-core';
 import type { ChatMemoryManager } from '@origintrail-official/dkg-node-ui';
@@ -280,12 +281,31 @@ export function resolveHermesApiServerKey(config: DkgConfig): string | undefined
   // local profile here would forward a stale, unrelated key and make remote
   // chat fail — those setups must use DKG_HERMES_API_SERVER_KEY (handled above).
   if (!hasLoopbackHermesOpenAiTarget(config)) return undefined;
-  const integration = getLocalAgentIntegration(config, 'hermes');
-  const hermesHome = optionalTrimmedString(
-    (integration?.metadata as Record<string, unknown> | undefined)?.hermesHome,
-  );
+  const hermesHome = resolveHermesHomeForKey(config);
   if (!hermesHome) return undefined;
   return readApiServerKeyFromEnv(join(hermesHome, '.env'));
+}
+
+/**
+ * Locate the Hermes profile home whose `.env` carries the key. Prefer the
+ * `hermesHome` stored on the integration record, but fall back to the resolved
+ * default/named profile (the same resolver `dkg hermes setup` uses) so
+ * integration records that predate that metadata — or where connect was
+ * skipped — can still find the `.env` setup wrote, instead of staying stuck in
+ * missing-key/401 until the user reconnects.
+ */
+function resolveHermesHomeForKey(config: DkgConfig): string | undefined {
+  const metadata = getLocalAgentIntegration(config, 'hermes')?.metadata as
+    | Record<string, unknown>
+    | undefined;
+  const fromMetadata = optionalTrimmedString(metadata?.hermesHome);
+  if (fromMetadata) return fromMetadata;
+  try {
+    const profileName = optionalTrimmedString(metadata?.profileName);
+    return resolveHermesProfile(profileName ? { profileName } : {}).hermesHome;
+  } catch {
+    return undefined;
+  }
 }
 
 /** True when the active hermes-openai target is a loopback api_server. */

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -295,15 +295,9 @@ function readApiServerKeyFromEnv(envPath: string): string | undefined {
   let key: string | undefined;
   try {
     for (const line of readFileSync(envPath, 'utf-8').split(/\r?\n/)) {
-      const match = line.match(/^\s*(?:export\s+)?API_SERVER_KEY\s*=\s*(.*?)\s*$/);
+      const match = line.match(/^\s*(?:export\s+)?API_SERVER_KEY\s*=(.*)$/);
       if (!match) continue;
-      let value = match[1];
-      if (
-        (value.startsWith('"') && value.endsWith('"'))
-        || (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.slice(1, -1);
-      }
+      const value = parseDotenvValue(match[1]);
       if (value) key = value; // last uncommented assignment wins (dotenv)
     }
   } catch {
@@ -311,6 +305,23 @@ function readApiServerKeyFromEnv(envPath: string): string | undefined {
   }
   apiServerKeyCache.set(envPath, { mtimeMs, key });
   return key;
+}
+
+/**
+ * Extract a `.env` value the way Hermes (python-dotenv) does: a quoted value
+ * keeps everything between the quotes (inline `#` included); an unquoted value
+ * is truncated at the first whitespace-preceded `#` (inline comment) and
+ * trimmed. Matching this keeps the bearer DKG forwards identical to the key
+ * Hermes loads (`API_SERVER_KEY=secret # dev` → `secret`, not `secret # dev`).
+ */
+function parseDotenvValue(raw: string): string {
+  const value = raw.replace(/^\s+/, '');
+  if (value[0] === '"' || value[0] === "'") {
+    const end = value.indexOf(value[0], 1);
+    if (end > 0) return value.slice(1, end);
+  }
+  const comment = value.match(/\s#/);
+  return (comment?.index !== undefined ? value.slice(0, comment.index) : value).trim();
 }
 
 export function transportPatchFromHermesTarget(

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -21,6 +21,7 @@ import {
   hermesPersistTurnKey,
   normalizeHermesChatPayload,
   normalizeHermesPersistTurnPayload,
+  hermesApiServerKeyRemediation,
   pipeHermesStream,
   probeHermesChannelHealth,
   resolveHermesApiServerKey,
@@ -58,34 +59,31 @@ function withVerifiedAttachmentImportContextEntries(
   };
 }
 
-const HERMES_API_KEY_REJECTED_HINT =
-  'Hermes api_server rejected the API_SERVER_KEY. Re-run "dkg hermes setup" '
-  + 'then restart "hermes gateway run --replace -v" so the key DKG forwards '
-  + 'matches the one in the Hermes profile .env.';
-
-const HERMES_API_KEY_MISSING_HINT =
-  'Hermes api_server is not reachable. Since Hermes v0.15.0 it refuses to '
-  + 'start without API_SERVER_KEY. Run "dkg hermes setup" to provision the key, '
-  + 'then start "hermes gateway run --replace -v".';
-
 /** Hermes' OpenAI api_server returns 401/403 when the bearer key is wrong/absent. */
 function isHermesApiKeyRejection(target: { protocol?: string }, status: number): boolean {
   return target.protocol === 'hermes-openai' && (status === 401 || status === 403);
 }
 
+function hermesApiKeyRejectedDetails(config: RequestContext['config']): string {
+  return `Hermes API server rejected the API_SERVER_KEY — ${hermesApiServerKeyRemediation(config)}.`;
+}
+
 /**
  * Enrich the generic unreachable/error detail with an actionable hint when a
  * hermes-openai target exists but no API_SERVER_KEY is resolvable — the most
- * common cause of the api_server never coming up on Hermes v0.15.0+.
+ * common cause of the api_server never coming up on Hermes v0.15.0+. The
+ * remediation is branched on loopback vs remote transport.
  */
 function hermesUnreachableDetails(
   details: string | undefined,
   targets: Array<{ protocol?: string }>,
   apiServerKey: string | undefined,
+  config: RequestContext['config'],
 ): string | undefined {
   const needsKey = !apiServerKey && targets.some((t) => t.protocol === 'hermes-openai');
   if (!needsKey) return details;
-  return details ? `${details} — ${HERMES_API_KEY_MISSING_HINT}` : HERMES_API_KEY_MISSING_HINT;
+  const hint = `Hermes api_server is unreachable; since Hermes v0.15.0 it requires API_SERVER_KEY — ${hermesApiServerKeyRemediation(config)}.`;
+  return details ? `${details} — ${hint}` : hint;
 }
 
 export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
@@ -162,7 +160,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
             return jsonResponse(res, 502, {
               error: 'Hermes API server rejected the API_SERVER_KEY',
               code: 'HERMES_API_KEY_REJECTED',
-              details: details || HERMES_API_KEY_REJECTED_HINT,
+              details: details || hermesApiKeyRejectedDetails(config),
             });
           }
           if (shouldTryNextHermesTarget(forwardRes.status)) {
@@ -212,7 +210,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     return jsonResponse(res, lastFailure?.offline ? 503 : 502, {
       error: lastFailure?.offline ? 'Hermes bridge unreachable' : 'Hermes bridge error',
       code: lastFailure?.offline ? 'BRIDGE_OFFLINE' : 'BRIDGE_ERROR',
-      details: hermesUnreachableDetails(lastFailure?.details, targets, apiServerKey),
+      details: hermesUnreachableDetails(lastFailure?.details, targets, apiServerKey, config),
     });
   }
 
@@ -280,7 +278,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
             return jsonResponse(res, 502, {
               error: 'Hermes API server rejected the API_SERVER_KEY',
               code: 'HERMES_API_KEY_REJECTED',
-              details: details || HERMES_API_KEY_REJECTED_HINT,
+              details: details || hermesApiKeyRejectedDetails(config),
             });
           }
           if (shouldTryNextHermesTarget(transportRes.status)) {
@@ -380,7 +378,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     return jsonResponse(res, lastFailure?.offline ? 503 : 502, {
       error: lastFailure?.offline ? 'Hermes bridge unreachable' : 'Hermes bridge error',
       code: lastFailure?.offline ? 'BRIDGE_OFFLINE' : 'BRIDGE_ERROR',
-      details: hermesUnreachableDetails(lastFailure?.details, targets, apiServerKey),
+      details: hermesUnreachableDetails(lastFailure?.details, targets, apiServerKey, config),
     });
   }
 

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -23,6 +23,7 @@ import {
   normalizeHermesPersistTurnPayload,
   pipeHermesStream,
   probeHermesChannelHealth,
+  resolveHermesApiServerKey,
   shouldTryNextHermesTarget,
   verifyHermesAttachmentRefsProvenance,
   verifyHermesAttachmentImportResultsProvenance,
@@ -55,6 +56,36 @@ function withVerifiedAttachmentImportContextEntries(
       ...importContextEntries,
     ],
   };
+}
+
+const HERMES_API_KEY_REJECTED_HINT =
+  'Hermes api_server rejected the API_SERVER_KEY. Re-run "dkg hermes setup" '
+  + 'then restart "hermes gateway run --replace -v" so the key DKG forwards '
+  + 'matches the one in the Hermes profile .env.';
+
+const HERMES_API_KEY_MISSING_HINT =
+  'Hermes api_server is not reachable. Since Hermes v0.15.0 it refuses to '
+  + 'start without API_SERVER_KEY. Run "dkg hermes setup" to provision the key, '
+  + 'then start "hermes gateway run --replace -v".';
+
+/** Hermes' OpenAI api_server returns 401/403 when the bearer key is wrong/absent. */
+function isHermesApiKeyRejection(target: { protocol?: string }, status: number): boolean {
+  return target.protocol === 'hermes-openai' && (status === 401 || status === 403);
+}
+
+/**
+ * Enrich the generic unreachable/error detail with an actionable hint when a
+ * hermes-openai target exists but no API_SERVER_KEY is resolvable — the most
+ * common cause of the api_server never coming up on Hermes v0.15.0+.
+ */
+function hermesUnreachableDetails(
+  details: string | undefined,
+  targets: Array<{ protocol?: string }>,
+  apiServerKey: string | undefined,
+): string | undefined {
+  const needsKey = !apiServerKey && targets.some((t) => t.protocol === 'hermes-openai');
+  if (!needsKey) return details;
+  return details ? `${details} — ${HERMES_API_KEY_MISSING_HINT}` : HERMES_API_KEY_MISSING_HINT;
 }
 
 export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
@@ -103,6 +134,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     const verifiedPayload = withVerifiedAttachmentImportContextEntries(payload, attachmentImportResults);
 
     const targets = getHermesChannelTargets(config);
+    const apiServerKey = resolveHermesApiServerKey(config);
     let lastFailure: { status?: number; details?: string; offline?: boolean } | null = null;
 
     for (const target of targets) {
@@ -120,12 +152,19 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
           method: 'POST',
           headers: buildHermesChannelHeaders(target, bridgeAuthToken, {
             'Content-Type': 'application/json',
-          }),
+          }, target.inboundUrl, apiServerKey),
           body: JSON.stringify(forwardBody),
           signal: AbortSignal.timeout(HERMES_CHANNEL_RESPONSE_TIMEOUT_MS),
         });
         if (!forwardRes.ok) {
           const details = await forwardRes.text().catch(() => '');
+          if (isHermesApiKeyRejection(target, forwardRes.status)) {
+            return jsonResponse(res, 502, {
+              error: 'Hermes API server rejected the API_SERVER_KEY',
+              code: 'HERMES_API_KEY_REJECTED',
+              details: details || HERMES_API_KEY_REJECTED_HINT,
+            });
+          }
           if (shouldTryNextHermesTarget(forwardRes.status)) {
             lastFailure = {
               status: forwardRes.status,
@@ -173,7 +212,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     return jsonResponse(res, lastFailure?.offline ? 503 : 502, {
       error: lastFailure?.offline ? 'Hermes bridge unreachable' : 'Hermes bridge error',
       code: lastFailure?.offline ? 'BRIDGE_OFFLINE' : 'BRIDGE_ERROR',
-      details: lastFailure?.details,
+      details: hermesUnreachableDetails(lastFailure?.details, targets, apiServerKey),
     });
   }
 
@@ -210,6 +249,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     const verifiedPayload = withVerifiedAttachmentImportContextEntries(payload, attachmentImportResults);
 
     const targets = getHermesChannelTargets(config);
+    const apiServerKey = resolveHermesApiServerKey(config);
     let lastFailure: { status?: number; details?: string; offline?: boolean } | null = null;
 
     for (const target of targets) {
@@ -223,18 +263,26 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         const forwardBody = target.protocol === 'hermes-openai'
           ? buildHermesOpenAiChatBody(verifiedPayload, attachmentRefs, requestAgentAddress, true)
           : buildHermesChannelBody(verifiedPayload, attachmentRefs, requestAgentAddress);
-        const transportRes = await fetch(target.streamUrl ?? target.inboundUrl, {
+        const streamUrl = target.streamUrl ?? target.inboundUrl;
+        const transportRes = await fetch(streamUrl, {
           method: 'POST',
           headers: buildHermesChannelHeaders(target, bridgeAuthToken, {
             'Content-Type': 'application/json',
             Accept: 'text/event-stream',
-          }),
+          }, streamUrl, apiServerKey),
           body: JSON.stringify(forwardBody),
           signal: AbortSignal.timeout(HERMES_CHANNEL_RESPONSE_TIMEOUT_MS),
         });
 
         if (!transportRes.ok) {
           const details = await transportRes.text().catch(() => '');
+          if (isHermesApiKeyRejection(target, transportRes.status)) {
+            return jsonResponse(res, 502, {
+              error: 'Hermes API server rejected the API_SERVER_KEY',
+              code: 'HERMES_API_KEY_REJECTED',
+              details: details || HERMES_API_KEY_REJECTED_HINT,
+            });
+          }
           if (shouldTryNextHermesTarget(transportRes.status)) {
             lastFailure = {
               status: transportRes.status,
@@ -332,7 +380,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     return jsonResponse(res, lastFailure?.offline ? 503 : 502, {
       error: lastFailure?.offline ? 'Hermes bridge unreachable' : 'Hermes bridge error',
       code: lastFailure?.offline ? 'BRIDGE_OFFLINE' : 'BRIDGE_ERROR',
-      details: lastFailure?.details,
+      details: hermesUnreachableDetails(lastFailure?.details, targets, apiServerKey),
     });
   }
 

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -502,9 +502,11 @@ describe('Hermes channel helpers', () => {
   it('resolves the Hermes API server key from the profile .env and DKG_HERMES_API_SERVER_KEY override', () => {
     const home = mkdtempSync(join(tmpdir(), 'hermes-env-'));
     cleanupDirs.push(home);
+    // Inline `#` comment on an unquoted value must be stripped (dotenv
+    // semantics) so the forwarded bearer matches the key Hermes loads.
     writeFileSync(
       join(home, '.env'),
-      '# managed by user\nAPI_SERVER_ENABLED=true\nAPI_SERVER_KEY=from-env-file\nOTHER=keep\n',
+      '# managed by user\nAPI_SERVER_ENABLED=true\nAPI_SERVER_KEY=from-env-file # local dev\nOTHER=keep\n',
     );
     const config = makeConfig({
       localAgentIntegrations: {
@@ -517,6 +519,20 @@ describe('Hermes channel helpers', () => {
     });
 
     expect(resolveHermesApiServerKey(config)).toBe('from-env-file');
+
+    // A quoted value keeps an inner `#`; the last assignment wins.
+    const quotedHome = mkdtempSync(join(tmpdir(), 'hermes-env-q-'));
+    cleanupDirs.push(quotedHome);
+    writeFileSync(join(quotedHome, '.env'), 'API_SERVER_KEY="se#cret value"\n');
+    expect(resolveHermesApiServerKey(makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+          metadata: { hermesHome: quotedHome },
+        },
+      },
+    }))).toBe('se#cret value');
 
     // Explicit daemon override (remote/WSL Hermes) wins over the local .env.
     process.env.DKG_HERMES_API_SERVER_KEY = 'override-key';

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -574,6 +574,25 @@ describe('Hermes channel helpers', () => {
     }))).toBeUndefined();
   });
 
+  it('falls back to the resolved Hermes profile when metadata.hermesHome is absent', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-fallback-'));
+    cleanupDirs.push(home);
+    writeFileSync(join(home, '.env'), 'API_SERVER_KEY=fallback-key\n');
+    // Integration record predates hermesHome metadata (or connect was skipped):
+    // resolution falls back to the default profile the same way setup does.
+    resolveHermesProfileMock.mockReturnValue({
+      profileName: undefined,
+      hermesHome: home,
+      memoryMode: 'provider',
+    });
+
+    expect(resolveHermesApiServerKey(makeConfig({
+      localAgentIntegrations: {
+        hermes: { enabled: true, transport: { kind: 'hermes-openai' } },
+      },
+    }))).toBe('fallback-key');
+  });
+
   it('annotates an unreachable hermes-openai health probe with the missing-key hint', async () => {
     const home = mkdtempSync(join(tmpdir(), 'hermes-nokey-'));
     cleanupDirs.push(home);
@@ -1421,6 +1440,33 @@ describe('Hermes daemon routes', () => {
       code: 'INTEGRATION_DISABLED',
     });
   });
+
+  it.each(['/api/hermes-channel/send', '/api/hermes-channel/stream'])(
+    'returns HERMES_API_KEY_REJECTED when the hermes-openai api_server replies 401 (%s)',
+    async (path) => {
+      const { ctx, res } = makeHermesRouteContext({
+        text: 'hello',
+        correlationId: 'corr-1',
+      }, {
+        hasChatTurn: vi.fn(async () => false),
+        storeChatExchange: vi.fn(async () => {}),
+      }, {
+        localAgentIntegrations: {
+          hermes: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+          },
+        },
+      }, path);
+      vi.stubGlobal('fetch', vi.fn(async () => new Response('unauthorized', { status: 401 })));
+
+      await handleHermesRoutes(ctx);
+
+      expect(res.statusCode).toBe(502);
+      expect(JSON.parse(res.body)).toMatchObject({ code: 'HERMES_API_KEY_REJECTED' });
+    },
+  );
 
   it('forwards attachment refs, import context, and contextGraphId to Hermes channel send', async () => {
     const attachmentRef = {

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -466,7 +466,17 @@ describe('Hermes channel helpers', () => {
       name: 'gateway' as const,
       protocol: 'hermes-openai' as const,
       inboundUrl: 'http://127.0.0.1:8642/v1/chat/completions',
+      healthUrl: 'http://127.0.0.1:8642/health',
     };
+    // The unauthenticated /health probe never receives the bearer, even when a
+    // key is available, so it cannot leak to health-endpoint/proxy logs.
+    expect(buildHermesChannelHeaders(
+      target,
+      'bridge-token',
+      { Accept: 'application/json' },
+      target.healthUrl,
+      'api-key-123',
+    )).toEqual({ Accept: 'application/json' });
     // Key present → bearer added; the loopback bridge token is NOT added.
     expect(buildHermesChannelHeaders(
       target,

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi, afterEach } from 'vitest';
@@ -13,6 +13,7 @@ import {
   normalizeHermesChatPayload,
   normalizeHermesPersistTurnPayload,
   probeHermesChannelHealth,
+  resolveHermesApiServerKey,
 } from '../src/daemon/hermes.js';
 import {
   connectLocalAgentIntegrationFromUi,
@@ -162,8 +163,13 @@ function makeHermesRouteContext(
   };
 }
 
+const cleanupDirs: string[] = [];
+
 afterEach(() => {
   vi.unstubAllGlobals();
+  while (cleanupDirs.length) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
   disconnectHermesProfileMock.mockReset();
   resolveHermesProfileMock.mockReset();
   resolveHermesProfileMock.mockReturnValue({
@@ -453,6 +459,103 @@ describe('Hermes channel helpers', () => {
       { Accept: 'application/json' },
       'https://hermes.example.com/health',
     )).toEqual({ Accept: 'application/json' });
+  });
+
+  it('forwards Authorization: Bearer to hermes-openai targets only when a key is resolved', () => {
+    const target = {
+      name: 'gateway' as const,
+      protocol: 'hermes-openai' as const,
+      inboundUrl: 'http://127.0.0.1:8642/v1/chat/completions',
+    };
+    // Key present → bearer added; the loopback bridge token is NOT added.
+    expect(buildHermesChannelHeaders(
+      target,
+      'bridge-token',
+      { 'Content-Type': 'application/json' },
+      target.inboundUrl,
+      'api-key-123',
+    )).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer api-key-123',
+    });
+    // No key → behavior identical to today (no auth header), so key-less
+    // older Hermes installs keep working.
+    expect(buildHermesChannelHeaders(
+      target,
+      'bridge-token',
+      { 'Content-Type': 'application/json' },
+      target.inboundUrl,
+    )).toEqual({ 'Content-Type': 'application/json' });
+    // The api server key never leaks onto the loopback bridge transport.
+    expect(buildHermesChannelHeaders(
+      { name: 'bridge', inboundUrl: 'http://127.0.0.1:9202/send' },
+      'bridge-token',
+      { 'Content-Type': 'application/json' },
+      'http://127.0.0.1:9202/send',
+      'api-key-123',
+    )).toEqual({
+      'Content-Type': 'application/json',
+      'x-dkg-bridge-token': 'bridge-token',
+    });
+  });
+
+  it('resolves the Hermes API server key from the profile .env and DKG_HERMES_API_SERVER_KEY override', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-env-'));
+    cleanupDirs.push(home);
+    writeFileSync(
+      join(home, '.env'),
+      '# managed by user\nAPI_SERVER_ENABLED=true\nAPI_SERVER_KEY=from-env-file\nOTHER=keep\n',
+    );
+    const config = makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+          metadata: { hermesHome: home },
+        },
+      },
+    });
+
+    expect(resolveHermesApiServerKey(config)).toBe('from-env-file');
+
+    // Explicit daemon override (remote/WSL Hermes) wins over the local .env.
+    process.env.DKG_HERMES_API_SERVER_KEY = 'override-key';
+    try {
+      expect(resolveHermesApiServerKey(config)).toBe('override-key');
+    } finally {
+      delete process.env.DKG_HERMES_API_SERVER_KEY;
+    }
+
+    // No hermesHome / no .env → undefined (older key-less Hermes: no bearer).
+    expect(resolveHermesApiServerKey(makeConfig({
+      localAgentIntegrations: {
+        hermes: { enabled: true, transport: { kind: 'hermes-openai' } },
+      },
+    }))).toBeUndefined();
+  });
+
+  it('annotates an unreachable hermes-openai health probe with the missing-key hint', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-nokey-'));
+    cleanupDirs.push(home);
+    // .env exists but has no active API_SERVER_KEY (issue #794 shape).
+    writeFileSync(join(home, '.env'), 'API_SERVER_ENABLED=true\n# API_SERVER_KEY=disabled\n');
+    const config = makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+          metadata: { hermesHome: home },
+        },
+      },
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('fetch failed');
+    }));
+
+    const report = await probeHermesChannelHealth(config, undefined, { timeoutMs: 50 });
+    expect(report.ok).toBe(false);
+    expect(report.error).toContain('API_SERVER_KEY');
+    expect(report.error).toContain('dkg hermes setup');
   });
 
   it('normalizes profile for send and persist payloads', () => {

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -548,6 +548,20 @@ describe('Hermes channel helpers', () => {
         hermes: { enabled: true, transport: { kind: 'hermes-openai' } },
       },
     }))).toBeUndefined();
+
+    // Remote (non-loopback) gateway must NOT read the local .env, even when a
+    // stale local profile key exists — that key belongs to a different Hermes
+    // and would make the remote reject with 401 (Codex review). Such setups
+    // rely solely on DKG_HERMES_API_SERVER_KEY.
+    expect(resolveHermesApiServerKey(makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'https://hermes.example.com:8642' },
+          metadata: { hermesHome: home },
+        },
+      },
+    }))).toBeUndefined();
   });
 
   it('annotates an unreachable hermes-openai health probe with the missing-key hint', async () => {

--- a/packages/core/src/dotenv.ts
+++ b/packages/core/src/dotenv.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal `.env` value parser matching python-dotenv semantics, shared by the
+ * Hermes adapter (which provisions `API_SERVER_KEY` into the Hermes profile
+ * `.env`) and the daemon (which reads it back to forward as a bearer). Keeping
+ * a single implementation here prevents the two sides from drifting and
+ * silently breaking auth.
+ *
+ * Rules (python-dotenv):
+ *  - A quoted value keeps everything between the matching quotes, including an
+ *    inner `#` (`"se#cret"` → `se#cret`).
+ *  - An unquoted value is truncated at the first whitespace-preceded `#` (an
+ *    inline comment) and trimmed (`secret # dev` → `secret`); a `#` with no
+ *    preceding whitespace is literal (`a#b` → `a#b`).
+ */
+export function parseDotenvValue(raw: string): string {
+  const value = raw.replace(/^\s+/, '');
+  if (value[0] === '"' || value[0] === "'") {
+    const end = value.indexOf(value[0], 1);
+    if (end > 0) return value.slice(1, end);
+  }
+  const comment = value.match(/\s#/);
+  return (comment?.index !== undefined ? value.slice(0, comment.index) : value).trim();
+}

--- a/packages/core/src/dotenv.ts
+++ b/packages/core/src/dotenv.ts
@@ -7,16 +7,31 @@
  *
  * Rules (python-dotenv):
  *  - A quoted value keeps everything between the matching quotes, including an
- *    inner `#` (`"se#cret"` → `se#cret`).
+ *    inner `#` (`"se#cret"` → `se#cret`). In double-quoted values a backslash
+ *    escapes the next character (`"abc\"def"` → `abc"def`, `"a\\b"` → `a\b`);
+ *    single-quoted values are literal.
  *  - An unquoted value is truncated at the first whitespace-preceded `#` (an
  *    inline comment) and trimmed (`secret # dev` → `secret`); a `#` with no
  *    preceding whitespace is literal (`a#b` → `a#b`).
  */
 export function parseDotenvValue(raw: string): string {
   const value = raw.replace(/^\s+/, '');
-  if (value[0] === '"' || value[0] === "'") {
-    const end = value.indexOf(value[0], 1);
-    if (end > 0) return value.slice(1, end);
+  const quote = value[0];
+  if (quote === '"' || quote === "'") {
+    let result = '';
+    for (let i = 1; i < value.length; i += 1) {
+      const ch = value[i];
+      // Backslash escapes the next char in double-quoted values (python-dotenv
+      // `\\(.) -> \1`); single-quoted values treat backslash literally.
+      if (ch === '\\' && quote === '"' && i + 1 < value.length) {
+        result += value[i + 1];
+        i += 1;
+        continue;
+      }
+      if (ch === quote) return result; // matching close quote
+      result += ch;
+    }
+    // Unterminated quote: fall through and treat the raw text as unquoted.
   }
   const comment = value.match(/\s#/);
   return (comment?.index !== undefined ? value.slice(0, comment.index) : value).trim();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types.js';
 export * from './constants.js';
+export { parseDotenvValue } from './dotenv.js';
 export * from './memory-model.js';
 export * from './trust.js';
 export * from './publisher-extension.js';

--- a/packages/core/test/dotenv.test.ts
+++ b/packages/core/test/dotenv.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { parseDotenvValue } from '../src/dotenv.js';
+
+describe('parseDotenvValue', () => {
+  it('returns a plain unquoted value unchanged', () => {
+    expect(parseDotenvValue('secret')).toBe('secret');
+    expect(parseDotenvValue('  secret  ')).toBe('secret');
+  });
+
+  it('strips a whitespace-preceded inline comment from unquoted values', () => {
+    expect(parseDotenvValue('secret # local dev')).toBe('secret');
+    expect(parseDotenvValue('true # on')).toBe('true');
+  });
+
+  it('keeps a `#` with no preceding whitespace as literal', () => {
+    expect(parseDotenvValue('a#b')).toBe('a#b');
+  });
+
+  it('preserves inner `#` inside quoted values', () => {
+    expect(parseDotenvValue('"se#cret value"')).toBe('se#cret value');
+    expect(parseDotenvValue("'se#cret'")).toBe('se#cret');
+  });
+
+  it('handles backslash escapes in double-quoted values', () => {
+    expect(parseDotenvValue('"abc\\"def"')).toBe('abc"def');
+    expect(parseDotenvValue('"a\\\\b"')).toBe('a\\b');
+  });
+
+  it('treats backslash literally in single-quoted values', () => {
+    expect(parseDotenvValue("'a\\b'")).toBe('a\\b');
+  });
+
+  it('ignores anything after a closing quote', () => {
+    expect(parseDotenvValue('"secret" # trailing comment')).toBe('secret');
+  });
+});


### PR DESCRIPTION
## Summary

Hermes v0.15.0 (`v2026.5.28`, upstream commit `1a9ef83`) made `API_SERVER_KEY` **mandatory** for the OpenAI-compatible `api_server` — it now refuses to start even on loopback `127.0.0.1` without one. The Node UI Hermes chat path forwards to that api_server (`hermes-openai` transport, `127.0.0.1:8642`) but never configured or forwarded a key, producing two failure modes from #794: the api_server never starts (health `fetch failed` → UI stuck on a generic "unavailable/setup" message), and even with a manually-set key chat still fails because DKG never sent `Authorization: Bearer <key>` to `/v1/chat/completions`.

This makes the integration handle Hermes api_server auth explicitly, with **no new manual setup step** and full backward compatibility:

- **Setup provisions the key.** For the loopback `hermes-openai` transport, `dkg hermes setup` now writes `API_SERVER_KEY` (generated if absent — **an existing key is never overwritten**) and `API_SERVER_ENABLED=true` into the Hermes profile `.env`, which is the only place Hermes reads it from (config.yaml support is not yet available upstream). This is folded into the **same** `hermes gateway run --replace -v` restart the provider install already requires, so the user does nothing new — and no longer has to set `API_SERVER_ENABLED` by hand. `.env` is deliberately kept out of `managedFiles`, so disconnect still preserves it. Remote/non-loopback gateways are not written (their `.env` lives on another host).
- **Daemon forwards the bearer.** `resolveHermesApiServerKey` reads the key from `<hermesHome>/.env` (cached by path+mtime), with a `DKG_HERMES_API_SERVER_KEY` daemon override for remote/WSL gateways. `buildHermesChannelHeaders` adds `Authorization: Bearer <key>` for `hermes-openai` targets **only when a key resolves** — so older key-less Hermes installs and the loopback bridge (`x-dkg-bridge-token`) path are byte-for-byte unchanged.
- **Clear errors, no secret leakage.** 401/403 from `/v1/chat/completions` now returns a specific `HERMES_API_KEY_REJECTED` with remediation; an unreachable `hermes-openai` target with no key resolvable annotates the health/`runtime.lastError` (shown in the UI's degraded state) with the missing-key cause instead of a bare `fetch failed`. The key never appears in responses, the integration record, or logs.

## Related

- Fixes #794
- Upstream cause: NousResearch/hermes-agent@`1a9ef83` ("require API_SERVER_KEY before dispatching API server work"), first shipped in Hermes v0.15.0.

## Files changed

| File | What |
|------|------|
| `packages/adapter-hermes/src/setup.ts` | Read-or-provision `API_SERVER_KEY` + `API_SERVER_ENABLED` in `<hermesHome>/.env` for the loopback hermes-openai transport (idempotent KEY=VALUE upsert, `0600`, dry-run-aware, never overwrites an existing key); dry-run plan action |
| `packages/adapter-hermes/src/types.ts` | `apiServerKeyConfigured` flag on `HermesSetupState` (boolean, never the secret) |
| `packages/cli/src/daemon/hermes.ts` | `resolveHermesApiServerKey` (`.env` read cached by mtime + `DKG_HERMES_API_SERVER_KEY` override); `buildHermesChannelHeaders` forwards the bearer for hermes-openai when a key resolves; missing-key hint on the health probe error |
| `packages/cli/src/daemon/routes/hermes.ts` | Resolve + forward the key on send/stream; specific `HERMES_API_KEY_REJECTED` on 401/403; missing-key hint on the unreachable fallthrough |
| `packages/adapter-hermes/README.md` | Document auto-provisioning + the `DKG_HERMES_API_SERVER_KEY` fallback for remote gateways |
| `packages/adapter-hermes/test/hermes-adapter.test.ts` | `.env` provision tests: generate / preserve existing key + unrelated lines / dry-run no-write / remote-gateway skip |
| `packages/cli/test/daemon-hermes.test.ts` | Header construction (key / no-key / bridge unchanged); key resolution + `DKG_HERMES_API_SERVER_KEY` override; missing-key health hint |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-hermes test` — 87 passed (incl. 4 new `.env` provision cases)
- [x] cli daemon-hermes suite: `npx vitest run test/daemon-hermes.test.ts` — 74 passed (incl. 3 new cases)
- [x] `tsc --noEmit` on cli + adapter-hermes — no errors in changed files
- [x] Backward compatibility verified by tests: no key resolved → no `Authorization` header (identical to current); loopback bridge `x-dkg-bridge-token` path unchanged
- [ ] Live (optional, needs Hermes v0.15.0): on a non-9200 port + temp `DKG_HOME`, connect Hermes from the Node UI, restart `hermes gateway run --replace -v`, send a chat message → streamed reply + persisted turn; confirm #794 no longer reproduces
