### PR TITLE
fix(query): relax over-strict SPARQL PREFIX validation (#764 follow-up)

### DIFF
--- a/packages/query/src/query-handler.ts
+++ b/packages/query/src/query-handler.ts
@@ -310,7 +310,21 @@ export class QueryHandler {
       return errorResponse(opId, 'ERROR', `SPARQL rejected: ${guard.reason}`);
     }
 
-    // Execute with timeout
+    // Execute with timeout.
+    //
+    // KNOWN LIMITATION (tracked follow-up to #764): this `Promise.race`
+    // bounds the *response* latency but does not cancel the underlying
+    // SPARQL execution — the engine has no cancellation hook, so an
+    // expensive remote query keeps consuming CPU/memory in the background
+    // until it completes naturally. Likewise `limit` below is applied as a
+    // post-materialization `.slice()`, so a high-cardinality query is fully
+    // materialized before being truncated. Genuinely enforcing either bound
+    // requires threading an `AbortSignal` + result cap through
+    // `QueryEngine.query()` → storage → the oxigraph worker. Injecting a
+    // `LIMIT` into the user query here is NOT a safe shortcut: for scoped
+    // queries it would push the statement into the multi-graph
+    // solution-set-modifier rejection path (see #789), so it is
+    // deliberately left to the engine-level follow-up.
     let timer: ReturnType<typeof setTimeout> | undefined;
     const result = await Promise.race([
       this.queryEngine.query(sparql, { contextGraphId }),

--- a/packages/query/src/sparql-guard.ts
+++ b/packages/query/src/sparql-guard.ts
@@ -27,9 +27,19 @@ const MUTATING_PATTERN = new RegExp(
 );
 
 // Matches the query form keyword after optional PREFIX/BASE preamble.
-// `stripLiteralsAndComments` blanks IRI bodies first, so this accepts both
-// newline-separated and inline declarations, e.g. `PREFIX ex: <...> SELECT`.
-const READ_ONLY_FORMS = /^\s*(?:(?:PREFIX\s+(?:[A-Za-z][A-Za-z0-9_-]*)?:\s*)|(?:BASE\s+))*\s*(SELECT|CONSTRUCT|ASK|DESCRIBE)\b/i;
+// `stripLiteralsAndComments` blanks IRI bodies (and the surrounding `<>`)
+// to spaces first, so this accepts both newline-separated and inline
+// declarations, e.g. `PREFIX ex: <...> SELECT`.
+//
+// The prefix LABEL is matched permissively (`[^\s:]*` — any run of
+// non-whitespace, non-colon chars, including the empty default prefix
+// `PREFIX : <...>`). The previous `[A-Za-z][A-Za-z0-9_-]*` charset was
+// stricter than SPARQL's `PN_PREFIX` grammar and rejected legal labels
+// containing dots (`foaf.core:`) or non-ASCII characters, even on
+// otherwise read-only queries. The label charset is irrelevant to the
+// read-only safety decision — that is enforced separately by anchoring on
+// the SELECT/CONSTRUCT/ASK/DESCRIBE form keyword and by `MUTATING_PATTERN`.
+const READ_ONLY_FORMS = /^\s*(?:(?:PREFIX\s+[^\s:]*:\s*)|(?:BASE\s+))*\s*(SELECT|CONSTRUCT|ASK|DESCRIBE)\b/i;
 
 /** SPARQL query form — enough to shape a `QueryResult` correctly. */
 export type SparqlQueryForm = 'SELECT' | 'CONSTRUCT' | 'ASK' | 'DESCRIBE' | 'UNKNOWN';

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -1040,4 +1040,28 @@ describe('validateReadOnlySparql', () => {
     `);
     expect(result.safe).toBe(true);
   });
+
+  // #764 follow-up: the previous `[A-Za-z][A-Za-z0-9_-]*` label charset was
+  // stricter than SPARQL's PN_PREFIX grammar and rejected valid read-only
+  // queries whose PREFIX label contained a dot or non-ASCII characters.
+  it('allows PREFIX labels containing dots (PN_PREFIX)', () => {
+    const result = validateReadOnlySparql(
+      'PREFIX foaf.core: <http://xmlns.com/foaf/0.1/> SELECT ?s WHERE { ?s foaf.core:name ?n }',
+    );
+    expect(result.safe).toBe(true);
+  });
+
+  it('allows PREFIX labels containing non-ASCII characters', () => {
+    const result = validateReadOnlySparql(
+      'PREFIX naïve: <http://example.org/> SELECT ?s WHERE { ?s naïve:p ?o }',
+    );
+    expect(result.safe).toBe(true);
+  });
+
+  it('still rejects mutations even with an exotic PREFIX label', () => {
+    const result = validateReadOnlySparql(
+      'PREFIX foaf.core: <http://xmlns.com/foaf/0.1/> INSERT DATA { <s> <p> <o> }',
+    );
+    expect(result.safe).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
Addresses unresolved 🔴 review bugs from **#764**.

- **Over-strict PREFIX validation (fixed).** #764 narrowed the read-only-form PREFIX label charset to `[A-Za-z][A-Za-z0-9_-]*`, stricter than SPARQL's `PN_PREFIX` grammar. Valid read-only queries with a dotted (`foaf.core:`) or non-ASCII prefix label were rejected before reaching the engine. The label is now matched permissively (`[^\s:]*`); read-only safety remains anchored on the form keyword + `MUTATING_PATTERN`.
- **Limit/timeout enforcement gap (documented).** The handler's `Promise.race` timeout bounds *response* latency but does not cancel the underlying SPARQL execution, and `sparqlMaxResults` is applied as a post-materialization `.slice()`. Real enforcement needs an `AbortSignal` + result cap threaded through `QueryEngine.query()` → storage → the oxigraph worker. Injecting a `LIMIT` at the handler is **unsafe** — it would push scoped queries into the multi-graph modifier-rejection path added in #789 — so it is left as a tracked engine-level follow-up rather than faked. Captured as a precise code comment.

## Test plan
- [x] `query-engine.test.ts` / `query-security.test.ts` / `query-handler.test.ts` — 138/138 pass
- [x] New regression tests: dotted + non-ASCII prefix labels accepted; mutations still rejected with exotic labels
- [ ] CI green on `release/rc.12`

Targeting `release/rc.12` (the over-strict regex was introduced there; `main` still has the older preamble form).

Made with [Cursor](https://cursor.com)