### PR TITLE
fix(cli): gate doctor 'safe to delete releases/' advisory (#750 follow-up)

### DIFF
--- a/packages/cli/src/doctor/checks/install-layout.ts
+++ b/packages/cli/src/doctor/checks/install-layout.ts
@@ -144,29 +144,48 @@ export async function runInstallLayoutCheck(
     // A freshly-upgraded Edge node can still be *running* from
     // `~/.dkg/releases/current` until the next restart materializes the
     // npm-global entry point. In that state `rm -rf ~/.dkg/releases/`
-    // would delete the live runtime, so only advise deletion when the
-    // daemon's resolved entry point is NOT inside the releases tree.
-    const runningFromReleases =
-      !!state.daemon.entryPoint && isPathInside(state.daemon.entryPoint, releasesDir);
+    // would delete the live runtime, so we only advise deletion when we
+    // have POSITIVELY proven the daemon's entry point is outside the
+    // releases tree.
+    //
+    // Three cases, because `state.daemon.entryPoint` can be unknown
+    // (`null`) — e.g. `collectStateSummary()` cannot resolve the entry
+    // point on `win32`. Treating "unknown" as "outside" would re-introduce
+    // the dangerous delete advice on exactly the platforms where we can't
+    // prove it's safe, so unknown gets its own cautious advisory.
+    const entryPoint = state.daemon.entryPoint;
+    const runningFromReleases = !!entryPoint && isPathInside(entryPoint, releasesDir);
+    const provenOutsideReleases = !!entryPoint && !runningFromReleases;
     findings.push(
       runningFromReleases
         ? {
             check: 'install-layout',
             severity: 'warning',
-            message: `Edge daemon is still running from a legacy slot under the releases tree (${releasesDir}): ${state.daemon.entryPoint}`,
+            message: `Edge daemon is still running from a legacy slot under the releases tree (${releasesDir}): ${entryPoint}`,
             advisory:
               `Edge nodes do not use blue-green slots under RFC-41, but this daemon is currently running from the legacy releases tree. Do NOT delete ${releasesDir} yet — that is the live runtime. Run 'dkg restart' (or re-install) so the daemon runs from the npm-global install, re-run 'dkg doctor' to confirm, and only then 'rm -rf ${releasesDir}'.`,
             subject: releasesDir,
-            details: { entryPoint: state.daemon.entryPoint },
+            details: { entryPoint },
           }
-        : {
-            check: 'install-layout',
-            severity: 'warning',
-            message: `Legacy releases directory detected on an Edge node: ${releasesDir}`,
-            advisory:
-              `Edge nodes do not use blue-green slots under RFC-41. Safe to delete: 'rm -rf ${releasesDir}'. The daemon runs directly from the npm-global install.`,
-            subject: releasesDir,
-          },
+        : provenOutsideReleases
+          ? {
+              check: 'install-layout',
+              severity: 'warning',
+              message: `Legacy releases directory detected on an Edge node: ${releasesDir}`,
+              advisory:
+                `Edge nodes do not use blue-green slots under RFC-41. Safe to delete: 'rm -rf ${releasesDir}'. The daemon runs directly from the npm-global install.`,
+              subject: releasesDir,
+              details: { entryPoint },
+            }
+          : {
+              check: 'install-layout',
+              severity: 'warning',
+              message: `Legacy releases directory detected on an Edge node: ${releasesDir} (could not resolve the running daemon's entry point on this platform)`,
+              advisory:
+                `Edge nodes do not use blue-green slots under RFC-41, so ${releasesDir} is normally safe to delete — but the daemon's entry point could not be resolved here, so it cannot be confirmed that the daemon is not currently running from this tree. Verify via 'dkg status' / the process list that no daemon is running from ${releasesDir}, then 'rm -rf ${releasesDir}'.`,
+              subject: releasesDir,
+              details: { entryPoint: null },
+            },
     );
   }
 

--- a/packages/cli/src/doctor/checks/install-layout.ts
+++ b/packages/cli/src/doctor/checks/install-layout.ts
@@ -25,8 +25,16 @@ function normalizePathForContainment(p: string): string {
 
 /** True when `child` is `parent` itself or nested under it. */
 function isPathInside(child: string, parent: string): boolean {
-  const c = normalizePathForContainment(child);
-  const p = normalizePathForContainment(parent);
+  let c = normalizePathForContainment(child);
+  let p = normalizePathForContainment(parent);
+  // Windows paths are case-insensitive and the same absolute path can come
+  // back with different drive-letter / segment casing. A case-sensitive
+  // compare here would misclassify a live `releases/` runtime as "not
+  // inside" and fall back to the dangerous "Safe to delete" advisory.
+  if (process.platform === 'win32') {
+    c = c.toLowerCase();
+    p = p.toLowerCase();
+  }
   return c === p || c.startsWith(p + '/');
 }
 
@@ -145,18 +153,18 @@ export async function runInstallLayoutCheck(
         ? {
             check: 'install-layout',
             severity: 'warning',
-            message: `Edge daemon is still running from a legacy slot under ~/.dkg/releases/: ${state.daemon.entryPoint}`,
+            message: `Edge daemon is still running from a legacy slot under the releases tree (${releasesDir}): ${state.daemon.entryPoint}`,
             advisory:
-              "Edge nodes do not use blue-green slots under RFC-41, but this daemon is currently running from the legacy releases tree. Do NOT delete ~/.dkg/releases/ yet — that is the live runtime. Run 'dkg restart' (or re-install) so the daemon runs from the npm-global install, re-run 'dkg doctor' to confirm, and only then 'rm -rf ~/.dkg/releases/'.",
+              `Edge nodes do not use blue-green slots under RFC-41, but this daemon is currently running from the legacy releases tree. Do NOT delete ${releasesDir} yet — that is the live runtime. Run 'dkg restart' (or re-install) so the daemon runs from the npm-global install, re-run 'dkg doctor' to confirm, and only then 'rm -rf ${releasesDir}'.`,
             subject: releasesDir,
             details: { entryPoint: state.daemon.entryPoint },
           }
         : {
             check: 'install-layout',
             severity: 'warning',
-            message: `Legacy ~/.dkg/releases/ directory detected on an Edge node: ${releasesDir}`,
+            message: `Legacy releases directory detected on an Edge node: ${releasesDir}`,
             advisory:
-              "Edge nodes do not use blue-green slots under RFC-41. Safe to delete: 'rm -rf ~/.dkg/releases/'. The daemon runs directly from the npm-global install.",
+              `Edge nodes do not use blue-green slots under RFC-41. Safe to delete: 'rm -rf ${releasesDir}'. The daemon runs directly from the npm-global install.`,
             subject: releasesDir,
           },
     );

--- a/packages/cli/src/doctor/checks/install-layout.ts
+++ b/packages/cli/src/doctor/checks/install-layout.ts
@@ -19,6 +19,17 @@
 import { join } from 'node:path';
 import type { DoctorDeps, Finding, StateSummary } from '../types.js';
 
+function normalizePathForContainment(p: string): string {
+  return p.replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+/** True when `child` is `parent` itself or nested under it. */
+function isPathInside(child: string, parent: string): boolean {
+  const c = normalizePathForContainment(child);
+  const p = normalizePathForContainment(parent);
+  return c === p || c.startsWith(p + '/');
+}
+
 async function slotEntryPointResolves(deps: DoctorDeps, slotDir: string): Promise<boolean> {
   // Mirrors `blueGreenSlotEntryPoint` semantics — git layout
   // (`packages/cli/dist/cli.js`) OR npm layout
@@ -122,21 +133,37 @@ export async function runInstallLayoutCheck(
 
   // Edge branch.
   if (deps.exists(releasesDir)) {
-    findings.push({
-      check: 'install-layout',
-      severity: 'warning',
-      message: `Legacy ~/.dkg/releases/ directory detected on an Edge node: ${releasesDir}`,
-      advisory: "Edge nodes do not use blue-green slots under RFC-41. Safe to delete: 'rm -rf ~/.dkg/releases/'. The daemon runs directly from the npm-global install.",
-      subject: releasesDir,
-    });
+    // A freshly-upgraded Edge node can still be *running* from
+    // `~/.dkg/releases/current` until the next restart materializes the
+    // npm-global entry point. In that state `rm -rf ~/.dkg/releases/`
+    // would delete the live runtime, so only advise deletion when the
+    // daemon's resolved entry point is NOT inside the releases tree.
+    const runningFromReleases =
+      !!state.daemon.entryPoint && isPathInside(state.daemon.entryPoint, releasesDir);
+    findings.push(
+      runningFromReleases
+        ? {
+            check: 'install-layout',
+            severity: 'warning',
+            message: `Edge daemon is still running from a legacy slot under ~/.dkg/releases/: ${state.daemon.entryPoint}`,
+            advisory:
+              "Edge nodes do not use blue-green slots under RFC-41, but this daemon is currently running from the legacy releases tree. Do NOT delete ~/.dkg/releases/ yet — that is the live runtime. Run 'dkg restart' (or re-install) so the daemon runs from the npm-global install, re-run 'dkg doctor' to confirm, and only then 'rm -rf ~/.dkg/releases/'.",
+            subject: releasesDir,
+            details: { entryPoint: state.daemon.entryPoint },
+          }
+        : {
+            check: 'install-layout',
+            severity: 'warning',
+            message: `Legacy ~/.dkg/releases/ directory detected on an Edge node: ${releasesDir}`,
+            advisory:
+              "Edge nodes do not use blue-green slots under RFC-41. Safe to delete: 'rm -rf ~/.dkg/releases/'. The daemon runs directly from the npm-global install.",
+            subject: releasesDir,
+          },
+    );
   }
 
   if (state.daemon.entryPoint && state.paths.npmGlobalDkg) {
-    const normalizePathForContainment = (p: string) =>
-      p.replace(/\\/g, '/').replace(/\/+$/, '');
-    const ep = normalizePathForContainment(state.daemon.entryPoint);
-    const npm = normalizePathForContainment(state.paths.npmGlobalDkg);
-    const insideNpmGlobal = ep === npm || ep.startsWith(npm + '/');
+    const insideNpmGlobal = isPathInside(state.daemon.entryPoint, state.paths.npmGlobalDkg);
     if (!insideNpmGlobal) {
       // Edge daemon is running from somewhere unexpected. Possible
       // causes: stale slot, contributor monorepo, manual override.

--- a/packages/cli/test/dkg-doctor.test.ts
+++ b/packages/cli/test/dkg-doctor.test.ts
@@ -442,6 +442,26 @@ describe('install-layout check (§4.7.3)', () => {
     expect(m!.advisory).toMatch(/rm -rf ~\/\.dkg\/releases\//);
   });
 
+  it('Edge: does NOT advise deleting releases/ while the daemon is running from it', async () => {
+    // #750 follow-up: an upgraded Edge node can still be running from
+    // ~/.dkg/releases/current until restart. The advisory must not tell
+    // the operator to delete the live runtime.
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+        '/test/.dkg/releases/a/packages/cli/dist/cli.js': '// live slot',
+      },
+    });
+    const state = await collectStateSummary(deps);
+    state.daemon.entryPoint = '/test/.dkg/releases/a/packages/cli/dist/cli.js';
+    const findings = await runInstallLayoutCheck(deps, state);
+    const m = findings.find((f) => f.subject === '/test/.dkg/releases');
+    expect(m).toBeDefined();
+    expect(m!.advisory).not.toMatch(/Safe to delete/);
+    expect(m!.advisory).toMatch(/Do NOT delete/);
+    expect(m!.message).toMatch(/still running from a legacy slot/);
+  });
+
   it('Edge: warns when daemon entryPoint is outside the npm-global install', async () => {
     const deps = makeDeps({
       fs: {

--- a/packages/cli/test/dkg-doctor.test.ts
+++ b/packages/cli/test/dkg-doctor.test.ts
@@ -427,7 +427,7 @@ describe('config-sanity check (§4.7.2)', () => {
 // ---------------------------------------------------------------------------
 
 describe('install-layout check (§4.7.3)', () => {
-  it('Edge: warns on legacy ~/.dkg/releases/ directory', async () => {
+  it('Edge: advises deleting releases/ when the daemon is proven to run from outside it', async () => {
     const deps = makeDeps({
       fs: {
         '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
@@ -435,11 +435,35 @@ describe('install-layout check (§4.7.3)', () => {
       },
     });
     const state = await collectStateSummary(deps);
+    // Daemon resolved to the npm-global install, i.e. positively outside releases/.
+    state.daemon.entryPoint = '/usr/local/lib/node_modules/@origintrail-official/dkg/dist/cli.js';
     const findings = await runInstallLayoutCheck(deps, state);
     const m = findings.find((f) => f.subject === '/test/.dkg/releases');
     expect(m).toBeDefined();
     expect(m!.severity).toBe('warning');
+    expect(m!.advisory).toMatch(/Safe to delete/);
     expect(m!.advisory).toMatch(/rm -rf \/test\/\.dkg\/releases/);
+  });
+
+  it('Edge: does NOT promise "Safe to delete" releases/ when the daemon entry point is unknown (e.g. win32)', async () => {
+    // #750 follow-up: collectStateSummary() can return a null entryPoint
+    // (notably on win32). We must not fall back to the unconditional
+    // "Safe to delete" advisory there, because we cannot prove the daemon
+    // isn't running from the releases tree.
+    const deps = makeDeps({
+      fs: {
+        '/test/.dkg/config.json': JSON.stringify({ nodeRole: 'edge' }),
+        '/test/.dkg/releases/a/dist/cli.js': '// possibly live slot',
+      },
+    });
+    const state = await collectStateSummary(deps);
+    state.daemon.entryPoint = null;
+    const findings = await runInstallLayoutCheck(deps, state);
+    const m = findings.find((f) => f.subject === '/test/.dkg/releases');
+    expect(m).toBeDefined();
+    expect(m!.advisory).not.toMatch(/Safe to delete/);
+    expect(m!.advisory).toMatch(/could not be resolved|Verify/);
+    expect(m!.message).toMatch(/could not resolve/);
   });
 
   it('Edge: does NOT advise deleting releases/ while the daemon is running from it', async () => {

--- a/packages/cli/test/dkg-doctor.test.ts
+++ b/packages/cli/test/dkg-doctor.test.ts
@@ -439,7 +439,7 @@ describe('install-layout check (§4.7.3)', () => {
     const m = findings.find((f) => f.subject === '/test/.dkg/releases');
     expect(m).toBeDefined();
     expect(m!.severity).toBe('warning');
-    expect(m!.advisory).toMatch(/rm -rf ~\/\.dkg\/releases\//);
+    expect(m!.advisory).toMatch(/rm -rf \/test\/\.dkg\/releases/);
   });
 
   it('Edge: does NOT advise deleting releases/ while the daemon is running from it', async () => {


### PR DESCRIPTION
## Summary
Addresses an unresolved 🔴 review bug from **#750**.

The Edge `install-layout` doctor check advised `rm -rf ~/.dkg/releases/` unconditionally. But a freshly-upgraded Edge node can still be **running from `~/.dkg/releases/current`** until the next restart materializes the npm-global entry point — following the advice in that window would delete the live runtime.

- "Safe to delete" advisory is now only emitted when the daemon's resolved entry point is **not** inside the releases tree.
- When the daemon *is* running from a legacy slot, the check now emits a distinct warning telling the operator to `dkg restart` / re-install and re-run `dkg doctor` first, then delete.
- Hoisted a shared `isPathInside` containment helper (also reused by the existing npm-global containment check).

## Test plan
- [x] `dkg-doctor.test.ts` — 39/39 pass (added running-from-releases regression test)
- [ ] CI green on `release/rc.12`

Targeting `release/rc.12` (the doctor `install-layout` check doesn't exist on `main`).

Made with [Cursor](https://cursor.com)