### PR TITLE
fix(hermes): provision + forward API_SERVER_KEY so UI chat survives Hermes v0.15.0 (#794) [backport to rc.12]

### DIFF
--- a/packages/adapter-hermes/README.md
+++ b/packages/adapter-hermes/README.md
@@ -224,11 +224,21 @@ client, and payload contracts that call into them.
 | `POST /api/hermes-channel/persist-turn` | Persist a completed Hermes turn through DKG chat memory with duplicate-turn protection. |
 
 The daemon forwards Node UI chat to Hermes' OpenAI-compatible API server at
-`http://127.0.0.1:8642` by default. Set `API_SERVER_ENABLED=true` in the active
-Hermes profile `.env`, then restart `hermes gateway run --replace -v`. Use
-`dkg hermes setup --gateway-url <url>` when the Hermes API server is reachable
-through WSL2 or a remote gateway. `--bridge-url` is reserved for a custom
-loopback bridge that implements `/health`, `/send`, and `/stream`.
+`http://127.0.0.1:8642` by default. Since Hermes v0.15.0 that API server
+refuses to start without `API_SERVER_KEY`, even on loopback. For the local
+loopback transport, `dkg hermes setup` provisions this automatically: it writes
+`API_SERVER_ENABLED=true` and a generated `API_SERVER_KEY` into the active
+Hermes profile `.env` (an existing key is never overwritten), and the daemon
+forwards `Authorization: Bearer <API_SERVER_KEY>` to `/v1/chat/completions`.
+You only need to restart `hermes gateway run --replace -v` so Hermes picks up
+the key — the same restart the provider install already requires.
+
+Use `dkg hermes setup --gateway-url <url>` when the Hermes API server is
+reachable through WSL2 or a remote gateway. In that case Hermes' `.env` lives on
+another host, so DKG does not write it; set `DKG_HERMES_API_SERVER_KEY` in the
+daemon environment to the key configured on the remote Hermes and DKG forwards
+it as the bearer. `--bridge-url` is reserved for a custom loopback bridge that
+implements `/health`, `/send`, and `/stream`.
 
 Attachment references are node-owned assertion refs. The daemon verifies their
 provenance before forwarding them to Hermes.

--- a/packages/adapter-hermes/src/setup.ts
+++ b/packages/adapter-hermes/src/setup.ts
@@ -1,11 +1,12 @@
-import { cpSync, existsSync, readFileSync, renameSync, rmSync, writeFileSync, mkdirSync, statSync, rmdirSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, readFileSync, renameSync, rmSync, writeFileSync, mkdirSync, statSync, rmdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { isIP } from 'node:net';
 import {
   fundWalletsBestEffort,
+  parseDotenvValue,
   resolveDkgConfigHome,
   resolveDkgHome,
   startDaemon,
@@ -185,16 +186,27 @@ export function planHermesSetup(options: HermesSetupOptions = {}): HermesSetupPl
     managedFiles,
   };
 
+  const actions: HermesSetupPlan['actions'] = managedFiles.map((path) => ({
+    type: existsSync(path) ? 'update' : 'create',
+    path,
+    reason: 'adapter-managed Hermes profile artifact',
+  }));
+  // `.env` is user/Hermes-owned (kept OUT of managedFiles so disconnect
+  // preserves it); surface the key provisioning as a separate action only.
+  if (shouldProvisionApiServerEnv(bridge)) {
+    actions.push({
+      type: 'update',
+      path: join(profile.hermesHome, '.env'),
+      reason: 'ensure API_SERVER_KEY + API_SERVER_ENABLED for Hermes api_server (hermes-openai transport)',
+    });
+  }
+
   return {
     dryRun: options.dryRun === true,
     profile,
     warnings,
     state,
-    actions: managedFiles.map((path) => ({
-      type: existsSync(path) ? 'update' : 'create',
-      path,
-      reason: 'adapter-managed Hermes profile artifact',
-    })),
+    actions,
   };
 }
 
@@ -286,6 +298,14 @@ export function setupHermesProfile(options: HermesSetupOptions = {}): HermesSetu
     writeOwnedText(skillPath, options.nodeSkillContent);
   }
 
+  // Provision API_SERVER_KEY (+ API_SERVER_ENABLED) into the Hermes profile
+  // `.env` LAST — after every step that can throw (the provider-block rewrite,
+  // skill write) — so an aborted setup never leaves a new key behind as a
+  // side effect. The user's existing `hermes gateway run --replace` restart
+  // picks it up; the daemon forwards the bearer. No-op for the loopback bridge
+  // and remote gateways.
+  const apiServerKeyConfigured = maybeProvisionHermesApiServerEnv(plan.profile, plan.state.bridge);
+
   // Re-write setup-state.json post-rewrite with the freshest
   // `updatedAt`. The `priorMemoryProvider` slot is still first-wins
   // and unchanged from the pre-rewrite write — we only refresh the
@@ -297,6 +317,7 @@ export function setupHermesProfile(options: HermesSetupOptions = {}): HermesSetu
   const state = {
     ...stateBeforeRewrite,
     updatedAt: new Date().toISOString(),
+    ...(apiServerKeyConfigured ? { apiServerKeyConfigured: true } : {}),
   };
   writeOwnedJson(join(plan.profile.stateDir, 'setup-state.json'), state);
   plan.state = state;
@@ -1480,6 +1501,103 @@ function isOwnedJson(path: string): boolean {
     return raw?.managedBy === MANAGED_BY;
   } catch {
     return false;
+  }
+}
+
+const API_SERVER_KEY_ENV = 'API_SERVER_KEY';
+const API_SERVER_ENABLED_ENV = 'API_SERVER_ENABLED';
+
+/**
+ * Hermes' OpenAI-compatible api_server — the transport the Node UI chat
+ * path forwards to — has refused to start without `API_SERVER_KEY` since
+ * Hermes v0.15.0, even on loopback `127.0.0.1`. The adapter provisions the
+ * key into the Hermes profile `.env` (the only place Hermes reads it from;
+ * config.yaml support is not yet available upstream) so the
+ * already-documented `hermes gateway run --replace` restart brings the
+ * api_server online with auth, and the daemon forwards
+ * `Authorization: Bearer <key>`.
+ *
+ * Returns whether the profile `.env` now carries an active key. Only
+ * loopback gateways are provisioned: a remote/WSL `--gateway-url` points at
+ * a Hermes whose `.env` lives on another host, so DKG cannot (and must not)
+ * write it — that case relies on the `DKG_HERMES_API_SERVER_KEY` daemon
+ * fallback instead. The existing key is never overwritten, and disconnect
+ * preserves `.env`.
+ */
+function maybeProvisionHermesApiServerEnv(
+  profile: HermesProfileMetadata,
+  bridge: HermesSetupState['bridge'] | undefined,
+): boolean {
+  if (!shouldProvisionApiServerEnv(bridge)) return false;
+  const envPath = join(profile.hermesHome, '.env');
+  if (!readActiveEnvVar(envPath, API_SERVER_KEY_ENV)) {
+    upsertEnvVar(envPath, API_SERVER_KEY_ENV, generateApiServerKey());
+  }
+  if ((readActiveEnvVar(envPath, API_SERVER_ENABLED_ENV) ?? '').toLowerCase() !== 'true') {
+    upsertEnvVar(envPath, API_SERVER_ENABLED_ENV, 'true');
+  }
+  return true;
+}
+
+function shouldProvisionApiServerEnv(bridge: HermesSetupState['bridge'] | undefined): boolean {
+  return bridge?.protocol === 'hermes-openai'
+    && !!bridge.gatewayUrl
+    && isLoopbackUrl(bridge.gatewayUrl);
+}
+
+function generateApiServerKey(): string {
+  // Any non-empty string is a valid Hermes API_SERVER_KEY; 32 random bytes
+  // gives a 43-char URL-safe secret with no shell-hostile characters.
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Last uncommented `KEY=value` wins (dotenv semantics). Returns undefined
+ * when the key is absent, blank, or only present in commented-out lines.
+ */
+function readActiveEnvVar(filePath: string, key: string): string | undefined {
+  if (!existsSync(filePath)) return undefined;
+  let value: string | undefined;
+  for (const line of readFileSync(filePath, 'utf-8').split(/\r?\n/)) {
+    const parsed = parseEnvLine(line);
+    if (parsed && parsed.key === key) value = parsed.value;
+  }
+  return value && value.length > 0 ? value : undefined;
+}
+
+function parseEnvLine(line: string): { key: string; value: string } | null {
+  const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/);
+  if (!match) return null; // comments, blanks, malformed lines
+  // parseDotenvValue (shared with the daemon via dkg-core) matches
+  // python-dotenv so the key we read here is identical to the one Hermes loads.
+  return { key: match[1], value: parseDotenvValue(match[2]) };
+}
+
+/**
+ * Idempotently set `KEY=value` in a `.env`, replacing the last uncommented
+ * occurrence in place (or appending) and preserving every other line. The
+ * file is shared with the user / Hermes, so it is NOT ownership-marked; we
+ * only ever touch the targeted key. Written `0600` because it holds a secret.
+ */
+function upsertEnvVar(filePath: string, key: string, value: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const lines = existsSync(filePath)
+    ? readFileSync(filePath, 'utf-8').split(/\r?\n/)
+    : [];
+  if (lines.length && lines[lines.length - 1] === '') lines.pop();
+  let lastIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const parsed = parseEnvLine(lines[i]);
+    if (parsed && parsed.key === key) lastIdx = i;
+  }
+  const next = `${key}=${value}`;
+  if (lastIdx >= 0) lines[lastIdx] = next;
+  else lines.push(next);
+  writeFileSync(filePath, `${lines.join('\n')}\n`, { mode: 0o600 });
+  try {
+    chmodSync(filePath, 0o600);
+  } catch {
+    // best-effort: Windows / restricted filesystems ignore POSIX modes
   }
 }
 

--- a/packages/adapter-hermes/src/setup.ts
+++ b/packages/adapter-hermes/src/setup.ts
@@ -194,9 +194,10 @@ export function planHermesSetup(options: HermesSetupOptions = {}): HermesSetupPl
   // `.env` is user/Hermes-owned (kept OUT of managedFiles so disconnect
   // preserves it); surface the key provisioning as a separate action only.
   if (shouldProvisionApiServerEnv(bridge)) {
+    const envPath = join(profile.hermesHome, '.env');
     actions.push({
-      type: 'update',
-      path: join(profile.hermesHome, '.env'),
+      type: existsSync(envPath) ? 'update' : 'create',
+      path: envPath,
       reason: 'ensure API_SERVER_KEY + API_SERVER_ENABLED for Hermes api_server (hermes-openai transport)',
     });
   }

--- a/packages/adapter-hermes/src/types.ts
+++ b/packages/adapter-hermes/src/types.ts
@@ -58,6 +58,15 @@ export interface HermesSetupState {
   updatedAt: string;
   managedFiles: string[];
   /**
+   * `true` when setup ensured a non-empty `API_SERVER_KEY` (and
+   * `API_SERVER_ENABLED=true`) in the Hermes profile `.env` for the
+   * loopback `hermes-openai` UI-chat transport. Hermes' api_server has
+   * refused to start without a key since v0.15.0; the daemon forwards
+   * `Authorization: Bearer <key>` to `/v1/chat/completions`. Never carries
+   * the secret itself (the key lives only in `<hermesHome>/.env`).
+   */
+  apiServerKeyConfigured?: boolean;
+  /**
    * Captured at the first install that replaced a non-DKG memory.provider
    * in `<hermesHome>/config.yaml`. First-wins: re-runs do NOT overwrite
    * this snapshot. `restoreHermesProfile` consumes it to put the user

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -380,7 +380,10 @@ describe('Hermes profile setup helpers', () => {
     const plan = planHermesSetup({ hermesHome, dryRun: true });
 
     expect(existsSync(join(hermesHome, '.env'))).toBe(false);
-    expect(plan.actions.some((action) => action.path.endsWith('.env'))).toBe(true);
+    const envAction = plan.actions.find((action) => action.path.endsWith('.env'));
+    // Fresh profile → the dry-run preview must say `create`, not `update`, so it
+    // is clear a brand-new secret file is about to be written.
+    expect(envAction?.type).toBe('create');
   });
 
   it('does not provision .env for a remote (non-loopback) gateway transport', () => {

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -340,6 +340,56 @@ describe('Hermes profile setup helpers', () => {
     expect(readFileSync(join(hermesHome, 'plugins', 'dkg', '.dkg-adapter-hermes-owner.json'), 'utf-8')).toContain('@origintrail-official/dkg-adapter-hermes');
   });
 
+  it('provisions API_SERVER_KEY and API_SERVER_ENABLED in .env for the loopback hermes-openai transport', () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    const result = setupHermesProfile({ hermesHome });
+    const envPath = join(hermesHome, '.env');
+
+    expect(existsSync(envPath)).toBe(true);
+    const env = readFileSync(envPath, 'utf-8');
+    const keyMatch = env.match(/^API_SERVER_KEY=(.+)$/m);
+    expect(keyMatch?.[1] && keyMatch[1].length).toBeGreaterThan(0);
+    expect(env).toMatch(/^API_SERVER_ENABLED=true$/m);
+    expect(result.state.apiServerKeyConfigured).toBe(true);
+
+    // Re-run is idempotent: the generated key is never regenerated/overwritten.
+    const generatedKey = keyMatch![1];
+    setupHermesProfile({ hermesHome });
+    expect(readFileSync(envPath, 'utf-8')).toContain(`API_SERVER_KEY=${generatedKey}`);
+  });
+
+  it('preserves an existing user API_SERVER_KEY (incl. inline comments) and unrelated .env lines', () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    // Inline comments must be parsed (dotenv) so the existing key is detected
+    // (not overwritten) and an already-true API_SERVER_ENABLED is not duplicated.
+    writeFileSync(
+      join(hermesHome, '.env'),
+      'FOO=bar\nAPI_SERVER_ENABLED=true # on\nAPI_SERVER_KEY=user-secret # mine\n',
+    );
+
+    setupHermesProfile({ hermesHome });
+
+    const env = readFileSync(join(hermesHome, '.env'), 'utf-8');
+    expect(env).toContain('API_SERVER_KEY=user-secret # mine');
+    expect(env).toContain('FOO=bar');
+    expect((env.match(/^API_SERVER_ENABLED=/gm) ?? []).length).toBe(1);
+  });
+
+  it('does not write .env in dry-run but reports the provisioning action', () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    const plan = planHermesSetup({ hermesHome, dryRun: true });
+
+    expect(existsSync(join(hermesHome, '.env'))).toBe(false);
+    expect(plan.actions.some((action) => action.path.endsWith('.env'))).toBe(true);
+  });
+
+  it('does not provision .env for a remote (non-loopback) gateway transport', () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    setupHermesProfile({ hermesHome, gatewayUrl: 'https://hermes.example.com:8642' });
+
+    expect(existsSync(join(hermesHome, '.env'))).toBe(false);
+  });
+
   it('loads the installed provider from Hermes user plugin discovery path', () => {
     const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
     setupHermesProfile({
@@ -610,6 +660,17 @@ assert config["allow_context_graph_admin_tools"] is False, config
     // throw path.
     expect(() => setupHermesProfile({ hermesHome, memoryMode: 'provider', preserveProvider: true }))
       .toThrow('memory.provider: mem0');
+  });
+
+  it('does not provision .env when setup aborts (no side effect on failure)', () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    writeFileSync(join(hermesHome, 'config.yaml'), 'memory: # existing provider\n  provider: mem0\n');
+
+    // preserveProvider throws on the existing non-DKG provider BEFORE the
+    // (now last) .env provisioning step, so no API_SERVER_KEY is written.
+    expect(() => setupHermesProfile({ hermesHome, memoryMode: 'provider', preserveProvider: true }))
+      .toThrow('memory.provider: mem0');
+    expect(existsSync(join(hermesHome, '.env'))).toBe(false);
   });
 
   it('ignores nested memory provider blocks when managing Hermes provider config', () => {

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -288,11 +288,14 @@ export function resolveHermesApiServerKey(config: DkgConfig): string | undefined
 
 /**
  * Locate the Hermes profile home whose `.env` carries the key. Prefer the
- * `hermesHome` stored on the integration record, but fall back to the resolved
- * default/named profile (the same resolver `dkg hermes setup` uses) so
- * integration records that predate that metadata — or where connect was
- * skipped — can still find the `.env` setup wrote, instead of staying stuck in
- * missing-key/401 until the user reconnects.
+ * `hermesHome` stored on the integration record. When it's absent (records that
+ * predate that metadata, or where connect was skipped) fall back ONLY to an
+ * exact profile recovered from a stored `profileName`. We never guess the
+ * default profile from no metadata: a record connected to a *named* profile
+ * would then read a different profile's `.env` and forward the wrong key,
+ * causing false 401s. With no recoverable profile we return undefined, so the
+ * caller surfaces the actionable "run dkg hermes setup" missing-key hint
+ * instead of silently sending another profile's secret.
  */
 function resolveHermesHomeForKey(config: DkgConfig): string | undefined {
   const metadata = getLocalAgentIntegration(config, 'hermes')?.metadata as
@@ -300,9 +303,10 @@ function resolveHermesHomeForKey(config: DkgConfig): string | undefined {
     | undefined;
   const fromMetadata = optionalTrimmedString(metadata?.hermesHome);
   if (fromMetadata) return fromMetadata;
+  const profileName = optionalTrimmedString(metadata?.profileName);
+  if (!profileName) return undefined;
   try {
-    const profileName = optionalTrimmedString(metadata?.profileName);
-    return resolveHermesProfile(profileName ? { profileName } : {}).hermesHome;
+    return resolveHermesProfile({ profileName }).hermesHome;
   } catch {
     return undefined;
   }

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -286,19 +286,21 @@ export function resolveHermesApiServerKey(config: DkgConfig): string | undefined
 }
 
 function resolveRawHermesApiServerKey(config: DkgConfig): string | undefined {
-  // The override is the REMOTE mechanism: a remote/WSL `--gateway-url` Hermes
-  // keeps its `.env` on another host, so DKG_HERMES_API_SERVER_KEY is the only
-  // source there.
-  if (!hasLoopbackHermesOpenAiTarget(config)) {
-    return optionalTrimmedString(process.env.DKG_HERMES_API_SERVER_KEY);
-  }
-  // Loopback: the key comes EXCLUSIVELY from the resolved local profile `.env`.
-  // The override never applies here — using it would let a value meant for a
-  // (former) remote gateway shadow or substitute for the local setup. If the
-  // profile can't be resolved, or the key is absent/blank, there is no bearer
-  // and the caller surfaces the missing-key hint.
+  const override = optionalTrimmedString(process.env.DKG_HERMES_API_SERVER_KEY);
+  // Non-loopback `--gateway-url`: the Hermes `.env` is on another host, so the
+  // explicit override is the only source.
+  if (!hasLoopbackHermesOpenAiTarget(config)) return override;
+  // Loopback decision keys off PROFILE LOCALITY, not the URL: a loopback host
+  // can be a genuinely local Hermes OR a remote/WSL2 one reached through a
+  // localhost forward. When no locally-managed profile resolves, there is no
+  // local `.env` to read (the WSL2-forward case), so honor the explicit
+  // override — otherwise that correctly-configured setup would 401 forever.
   const hermesHome = resolveHermesHomeForKey(config);
-  if (!hermesHome) return undefined;
+  if (!hermesHome) return override;
+  // A locally-managed profile resolved: its `.env` is fully authoritative — a
+  // present key, an explicit blank, or no key line all stand, and the override
+  // (which targets a different/remote Hermes) must not shadow or substitute for
+  // it.
   return readApiServerKeyFromEnv(join(hermesHome, '.env')) || undefined;
 }
 

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { readFileSync, statSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { isIP } from 'node:net';
 import { join } from 'node:path';
 
@@ -268,8 +268,8 @@ export function buildHermesChannelHeaders(
  * Resolve the Hermes API server key for the `hermes-openai` UI-chat
  * transport. `.env` (in the stored profile's `hermesHome`) is the source of
  * truth — the same file `dkg hermes setup` provisions and the one Hermes
- * itself reads. Reads are cached by path+mtime so we don't touch disk on
- * every chat request. `DKG_HERMES_API_SERVER_KEY` is the source for remote/WSL
+ * itself reads (read fresh each call so a rotated key is picked up immediately).
+ * `DKG_HERMES_API_SERVER_KEY` is the source for remote/WSL
  * gateways ONLY (whose `.env` is not on the daemon's filesystem); for loopback
  * the key comes exclusively from the local profile `.env`. Returns undefined
  * when no key is available (older key-less Hermes → no bearer is sent).
@@ -358,18 +358,11 @@ export function hermesApiServerKeyRejectionRemediation(config: DkgConfig): strin
     : 'set DKG_HERMES_API_SERVER_KEY in the daemon environment to the key the remote Hermes is running with, then restart the daemon';
 }
 
-const apiServerKeyCache = new Map<string, { mtimeMs: number; key: string | undefined }>();
-
+// Read directly on each call (no cache). The `.env` is tiny and this runs once
+// per user-initiated chat/health request, not in a hot loop — and a path+mtime
+// cache could serve a stale key when `.env` is rewritten twice within the
+// filesystem's timestamp resolution (e.g. a quick setup rerun + key rotation).
 function readApiServerKeyFromEnv(envPath: string): string | undefined {
-  let mtimeMs: number;
-  try {
-    mtimeMs = statSync(envPath).mtimeMs;
-  } catch {
-    apiServerKeyCache.delete(envPath);
-    return undefined;
-  }
-  const cached = apiServerKeyCache.get(envPath);
-  if (cached && cached.mtimeMs === mtimeMs) return cached.key;
   let key: string | undefined;
   try {
     for (const line of readFileSync(envPath, 'utf-8').split(/\r?\n/)) {
@@ -382,9 +375,8 @@ function readApiServerKeyFromEnv(envPath: string): string | undefined {
       key = parseDotenvValue(match[1]);
     }
   } catch {
-    key = undefined;
+    return undefined;
   }
-  apiServerKeyCache.set(envPath, { mtimeMs, key });
   return key;
 }
 

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -269,21 +269,23 @@ export function buildHermesChannelHeaders(
  * transport. `.env` (in the stored profile's `hermesHome`) is the source of
  * truth — the same file `dkg hermes setup` provisions and the one Hermes
  * itself reads. Reads are cached by path+mtime so we don't touch disk on
- * every chat request. `DKG_HERMES_API_SERVER_KEY` overrides for remote/WSL
- * gateways whose `.env` is not on the daemon's filesystem. Returns undefined
- * when no key is available (older key-less Hermes → no bearer is sent).
+ * every chat request. `DKG_HERMES_API_SERVER_KEY` is the source for remote/WSL
+ * gateways whose `.env` is not on the daemon's filesystem, and a fallback for
+ * loopback. Returns undefined when no key is available (older key-less Hermes →
+ * no bearer is sent).
  */
 export function resolveHermesApiServerKey(config: DkgConfig): string | undefined {
   const override = optionalTrimmedString(process.env.DKG_HERMES_API_SERVER_KEY);
-  if (override) return override;
-  // Only the LOOPBACK api_server reads a key from a local `.env`. A remote/WSL
-  // `--gateway-url` Hermes keeps its `.env` on another host, so reading the
-  // local profile here would forward a stale, unrelated key and make remote
-  // chat fail — those setups must use DKG_HERMES_API_SERVER_KEY (handled above).
-  if (!hasLoopbackHermesOpenAiTarget(config)) return undefined;
+  // Remote/WSL `--gateway-url` Hermes keeps its `.env` on another host, so the
+  // explicit override is the only source there.
+  if (!hasLoopbackHermesOpenAiTarget(config)) return override;
+  // Loopback: the profile `.env` is the source of truth and MUST win over the
+  // override — otherwise a stale `DKG_HERMES_API_SERVER_KEY` (left set after a
+  // former remote setup) would shadow the correct local key and 401 forever.
+  // The override stays only as a last-resort fallback (e.g. an unreadable .env).
   const hermesHome = resolveHermesHomeForKey(config);
-  if (!hermesHome) return undefined;
-  return readApiServerKeyFromEnv(join(hermesHome, '.env'));
+  const fromEnv = hermesHome ? readApiServerKeyFromEnv(join(hermesHome, '.env')) : undefined;
+  return fromEnv ?? override;
 }
 
 /**
@@ -347,8 +349,10 @@ function readApiServerKeyFromEnv(envPath: string): string | undefined {
     for (const line of readFileSync(envPath, 'utf-8').split(/\r?\n/)) {
       const match = line.match(/^\s*(?:export\s+)?API_SERVER_KEY\s*=(.*)$/);
       if (!match) continue;
-      const value = parseDotenvValue(match[1]);
-      if (value) key = value; // last uncommented assignment wins (dotenv)
+      // dotenv "last assignment wins" — including a blank/cleared final
+      // assignment (`API_SERVER_KEY=` or `=""`), which must reset an earlier
+      // value so a rotated/blanked key isn't forwarded stale.
+      key = parseDotenvValue(match[1]) || undefined;
     }
   } catch {
     key = undefined;

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -1,7 +1,11 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { readFileSync, statSync } from 'node:fs';
 import { isIP } from 'node:net';
+import { join } from 'node:path';
 
+import { resolveHermesProfile } from '@origintrail-official/dkg-adapter-hermes';
 import type { DKGAgent } from '@origintrail-official/dkg-agent';
+import { parseDotenvValue } from '@origintrail-official/dkg-core';
 import type { ChatMemoryManager } from '@origintrail-official/dkg-node-ui';
 import type {
   DkgConfig,
@@ -237,7 +241,19 @@ export function buildHermesChannelHeaders(
   bridgeAuthToken: string | undefined,
   baseHeaders: Record<string, string> = {},
   requestUrl = target.inboundUrl,
+  apiServerKey?: string,
 ): Record<string, string> {
+  // Hermes' OpenAI-compatible api_server requires `Authorization: Bearer
+  // <API_SERVER_KEY>` on `/v1/chat/completions` since v0.15.0. We add it only
+  // when a key is resolved AND the request is not the health probe: `/health`
+  // is unauthenticated upstream, so sending the bearer there is pointless and
+  // would risk leaking it to health-endpoint/proxy logs. Key-less older Hermes
+  // installs keep their current (no-auth) behavior.
+  if (target.protocol === 'hermes-openai') {
+    return apiServerKey && requestUrl !== target.healthUrl
+      ? { ...baseHeaders, Authorization: `Bearer ${apiServerKey}` }
+      : baseHeaders;
+  }
   if (
     target.name !== 'bridge' ||
     !bridgeAuthToken ||
@@ -246,6 +262,95 @@ export function buildHermesChannelHeaders(
     return baseHeaders;
   }
   return { ...baseHeaders, 'x-dkg-bridge-token': bridgeAuthToken };
+}
+
+/**
+ * Resolve the Hermes API server key for the `hermes-openai` UI-chat
+ * transport. `.env` (in the stored profile's `hermesHome`) is the source of
+ * truth — the same file `dkg hermes setup` provisions and the one Hermes
+ * itself reads. Reads are cached by path+mtime so we don't touch disk on
+ * every chat request. `DKG_HERMES_API_SERVER_KEY` overrides for remote/WSL
+ * gateways whose `.env` is not on the daemon's filesystem. Returns undefined
+ * when no key is available (older key-less Hermes → no bearer is sent).
+ */
+export function resolveHermesApiServerKey(config: DkgConfig): string | undefined {
+  const override = optionalTrimmedString(process.env.DKG_HERMES_API_SERVER_KEY);
+  if (override) return override;
+  // Only the LOOPBACK api_server reads a key from a local `.env`. A remote/WSL
+  // `--gateway-url` Hermes keeps its `.env` on another host, so reading the
+  // local profile here would forward a stale, unrelated key and make remote
+  // chat fail — those setups must use DKG_HERMES_API_SERVER_KEY (handled above).
+  if (!hasLoopbackHermesOpenAiTarget(config)) return undefined;
+  const hermesHome = resolveHermesHomeForKey(config);
+  if (!hermesHome) return undefined;
+  return readApiServerKeyFromEnv(join(hermesHome, '.env'));
+}
+
+/**
+ * Locate the Hermes profile home whose `.env` carries the key. Prefer the
+ * `hermesHome` stored on the integration record, but fall back to the resolved
+ * default/named profile (the same resolver `dkg hermes setup` uses) so
+ * integration records that predate that metadata — or where connect was
+ * skipped — can still find the `.env` setup wrote, instead of staying stuck in
+ * missing-key/401 until the user reconnects.
+ */
+function resolveHermesHomeForKey(config: DkgConfig): string | undefined {
+  const metadata = getLocalAgentIntegration(config, 'hermes')?.metadata as
+    | Record<string, unknown>
+    | undefined;
+  const fromMetadata = optionalTrimmedString(metadata?.hermesHome);
+  if (fromMetadata) return fromMetadata;
+  try {
+    const profileName = optionalTrimmedString(metadata?.profileName);
+    return resolveHermesProfile(profileName ? { profileName } : {}).hermesHome;
+  } catch {
+    return undefined;
+  }
+}
+
+/** True when the active hermes-openai target is a loopback api_server. */
+function hasLoopbackHermesOpenAiTarget(config: DkgConfig): boolean {
+  const target = getHermesChannelTargets(config).find((t) => t.protocol === 'hermes-openai');
+  return !!target && isHermesLoopbackUrl(target.inboundUrl);
+}
+
+/**
+ * Actionable remediation for a Hermes api_server auth failure, branched on
+ * transport: a loopback gateway is fixed by `dkg hermes setup` (which writes
+ * the local `.env`); a remote/WSL gateway is fixed by the daemon-side
+ * DKG_HERMES_API_SERVER_KEY override, since setup never touches a remote `.env`.
+ */
+export function hermesApiServerKeyRemediation(config: DkgConfig): string {
+  return hasLoopbackHermesOpenAiTarget(config)
+    ? 'run "dkg hermes setup" to provision API_SERVER_KEY, then restart "hermes gateway run --replace -v"'
+    : 'set DKG_HERMES_API_SERVER_KEY in the daemon environment to the remote Hermes API_SERVER_KEY (setup does not modify a remote .env), then restart the daemon';
+}
+
+const apiServerKeyCache = new Map<string, { mtimeMs: number; key: string | undefined }>();
+
+function readApiServerKeyFromEnv(envPath: string): string | undefined {
+  let mtimeMs: number;
+  try {
+    mtimeMs = statSync(envPath).mtimeMs;
+  } catch {
+    apiServerKeyCache.delete(envPath);
+    return undefined;
+  }
+  const cached = apiServerKeyCache.get(envPath);
+  if (cached && cached.mtimeMs === mtimeMs) return cached.key;
+  let key: string | undefined;
+  try {
+    for (const line of readFileSync(envPath, 'utf-8').split(/\r?\n/)) {
+      const match = line.match(/^\s*(?:export\s+)?API_SERVER_KEY\s*=(.*)$/);
+      if (!match) continue;
+      const value = parseDotenvValue(match[1]);
+      if (value) key = value; // last uncommented assignment wins (dotenv)
+    }
+  } catch {
+    key = undefined;
+  }
+  apiServerKeyCache.set(envPath, { mtimeMs, key });
+  return key;
 }
 
 export function transportPatchFromHermesTarget(
@@ -351,6 +456,17 @@ export async function probeHermesChannelHealth(
       else gateway = result;
       lastError = err.message;
     }
+  }
+
+  // The api_server has refused to start without API_SERVER_KEY since Hermes
+  // v0.15.0, so an unreachable hermes-openai target with no key resolvable is
+  // overwhelmingly a missing-key problem — surface that instead of a bare
+  // "fetch failed" in the Node UI's degraded status.
+  if (
+    targets.some((t) => t.protocol === 'hermes-openai')
+    && !resolveHermesApiServerKey(config)
+  ) {
+    lastError = `${lastError} — Hermes api_server requires API_SERVER_KEY (Hermes v0.15.0+); ${hermesApiServerKeyRemediation(config)}.`;
   }
 
   return { ok: false, bridge, gateway, error: lastError };

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -335,6 +335,18 @@ export function hermesApiServerKeyRemediation(config: DkgConfig): string {
     : 'set DKG_HERMES_API_SERVER_KEY in the daemon environment to the remote Hermes API_SERVER_KEY (setup does not modify a remote .env), then restart the daemon';
 }
 
+/**
+ * Remediation when Hermes explicitly REJECTS the bearer (401/403): a key is
+ * present but wrong, so "run dkg hermes setup" is a no-op (setup never
+ * overwrites an existing API_SERVER_KEY). The fix is to realign or rotate the
+ * key so DKG forwards what the running gateway expects.
+ */
+export function hermesApiServerKeyRejectionRemediation(config: DkgConfig): string {
+  return hasLoopbackHermesOpenAiTarget(config)
+    ? 'the API_SERVER_KEY in the Hermes profile .env does not match the running gateway — align them, or clear API_SERVER_KEY and re-run "dkg hermes setup" to regenerate (setup never overwrites an existing key), then restart "hermes gateway run --replace -v"'
+    : 'set DKG_HERMES_API_SERVER_KEY in the daemon environment to the key the remote Hermes is running with, then restart the daemon';
+}
+
 const apiServerKeyCache = new Map<string, { mtimeMs: number; key: string | undefined }>();
 
 function readApiServerKeyFromEnv(envPath: string): string | undefined {

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -275,6 +275,17 @@ export function buildHermesChannelHeaders(
  * no bearer is sent).
  */
 export function resolveHermesApiServerKey(config: DkgConfig): string | undefined {
+  const key = resolveRawHermesApiServerKey(config);
+  // A bearer can't contain CR/LF or other control characters: `fetch`/`Headers`
+  // throw on them, and Hermes' own HTTP api_server could never receive such a
+  // token either. parseDotenvValue faithfully decodes `\n`/`\t`/`\r`, so a
+  // quoted key like `"abc\n123"` would otherwise crash the request — treat a
+  // control-char key as unusable so callers surface the missing-key hint.
+  if (key && /[\u0000-\u001f\u007f]/.test(key)) return undefined;
+  return key;
+}
+
+function resolveRawHermesApiServerKey(config: DkgConfig): string | undefined {
   const override = optionalTrimmedString(process.env.DKG_HERMES_API_SERVER_KEY);
   // Remote/WSL `--gateway-url` Hermes keeps its `.env` on another host, so the
   // explicit override is the only source there.

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -270,9 +270,9 @@ export function buildHermesChannelHeaders(
  * truth — the same file `dkg hermes setup` provisions and the one Hermes
  * itself reads. Reads are cached by path+mtime so we don't touch disk on
  * every chat request. `DKG_HERMES_API_SERVER_KEY` is the source for remote/WSL
- * gateways whose `.env` is not on the daemon's filesystem, and a fallback for
- * loopback. Returns undefined when no key is available (older key-less Hermes →
- * no bearer is sent).
+ * gateways ONLY (whose `.env` is not on the daemon's filesystem); for loopback
+ * the key comes exclusively from the local profile `.env`. Returns undefined
+ * when no key is available (older key-less Hermes → no bearer is sent).
  */
 export function resolveHermesApiServerKey(config: DkgConfig): string | undefined {
   const key = resolveRawHermesApiServerKey(config);
@@ -286,20 +286,20 @@ export function resolveHermesApiServerKey(config: DkgConfig): string | undefined
 }
 
 function resolveRawHermesApiServerKey(config: DkgConfig): string | undefined {
-  const override = optionalTrimmedString(process.env.DKG_HERMES_API_SERVER_KEY);
-  // Remote/WSL `--gateway-url` Hermes keeps its `.env` on another host, so the
-  // explicit override is the only source there.
-  if (!hasLoopbackHermesOpenAiTarget(config)) return override;
-  // Loopback: the profile `.env` is the source of truth. An EXPLICIT local
-  // assignment is authoritative — even a blank `API_SERVER_KEY=` (intentionally
-  // cleared/rotated) yields no bearer rather than falling through to a stale
-  // `DKG_HERMES_API_SERVER_KEY`. The override is used only when `.env` has no
-  // API_SERVER_KEY line at all or is missing/unreadable (readApiServerKeyFromEnv
-  // returns `''` for a present-but-blank key, `undefined` for absent/unreadable).
+  // The override is the REMOTE mechanism: a remote/WSL `--gateway-url` Hermes
+  // keeps its `.env` on another host, so DKG_HERMES_API_SERVER_KEY is the only
+  // source there.
+  if (!hasLoopbackHermesOpenAiTarget(config)) {
+    return optionalTrimmedString(process.env.DKG_HERMES_API_SERVER_KEY);
+  }
+  // Loopback: the key comes EXCLUSIVELY from the resolved local profile `.env`.
+  // The override never applies here — using it would let a value meant for a
+  // (former) remote gateway shadow or substitute for the local setup. If the
+  // profile can't be resolved, or the key is absent/blank, there is no bearer
+  // and the caller surfaces the missing-key hint.
   const hermesHome = resolveHermesHomeForKey(config);
-  const fromEnv = hermesHome ? readApiServerKeyFromEnv(join(hermesHome, '.env')) : undefined;
-  if (fromEnv !== undefined) return fromEnv || undefined;
-  return override;
+  if (!hermesHome) return undefined;
+  return readApiServerKeyFromEnv(join(hermesHome, '.env')) || undefined;
 }
 
 /**

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -279,13 +279,16 @@ export function resolveHermesApiServerKey(config: DkgConfig): string | undefined
   // Remote/WSL `--gateway-url` Hermes keeps its `.env` on another host, so the
   // explicit override is the only source there.
   if (!hasLoopbackHermesOpenAiTarget(config)) return override;
-  // Loopback: the profile `.env` is the source of truth and MUST win over the
-  // override — otherwise a stale `DKG_HERMES_API_SERVER_KEY` (left set after a
-  // former remote setup) would shadow the correct local key and 401 forever.
-  // The override stays only as a last-resort fallback (e.g. an unreadable .env).
+  // Loopback: the profile `.env` is the source of truth. An EXPLICIT local
+  // assignment is authoritative — even a blank `API_SERVER_KEY=` (intentionally
+  // cleared/rotated) yields no bearer rather than falling through to a stale
+  // `DKG_HERMES_API_SERVER_KEY`. The override is used only when `.env` has no
+  // API_SERVER_KEY line at all or is missing/unreadable (readApiServerKeyFromEnv
+  // returns `''` for a present-but-blank key, `undefined` for absent/unreadable).
   const hermesHome = resolveHermesHomeForKey(config);
   const fromEnv = hermesHome ? readApiServerKeyFromEnv(join(hermesHome, '.env')) : undefined;
-  return fromEnv ?? override;
+  if (fromEnv !== undefined) return fromEnv || undefined;
+  return override;
 }
 
 /**
@@ -349,10 +352,11 @@ function readApiServerKeyFromEnv(envPath: string): string | undefined {
     for (const line of readFileSync(envPath, 'utf-8').split(/\r?\n/)) {
       const match = line.match(/^\s*(?:export\s+)?API_SERVER_KEY\s*=(.*)$/);
       if (!match) continue;
-      // dotenv "last assignment wins" — including a blank/cleared final
-      // assignment (`API_SERVER_KEY=` or `=""`), which must reset an earlier
-      // value so a rotated/blanked key isn't forwarded stale.
-      key = parseDotenvValue(match[1]) || undefined;
+      // dotenv "last assignment wins". An assigned-but-blank line yields `''`
+      // (a present, intentionally-cleared key) which the caller treats as
+      // authoritative; `key` stays `undefined` only when NO line is present, so
+      // the caller can distinguish "cleared locally" from "absent / unreadable".
+      key = parseDotenvValue(match[1]);
     }
   } catch {
     key = undefined;

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { isIP } from 'node:net';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import { resolveHermesProfile } from '@origintrail-official/dkg-adapter-hermes';
@@ -324,7 +325,15 @@ function resolveHermesHomeForKey(config: DkgConfig): string | undefined {
   const profileName = optionalTrimmedString(metadata?.profileName);
   if (!profileName) return undefined;
   try {
-    return resolveHermesProfile({ profileName }).hermesHome;
+    // Pass an explicit hermesHome so resolution can't be swayed by a daemon-side
+    // `HERMES_HOME` pointing at a different profile (resolveHermesProfile prefers
+    // `process.env.HERMES_HOME` over the profile-derived default, which would
+    // read the wrong profile's `.env`). resolveHermesProfile still validates the
+    // profileName (rejecting path separators).
+    return resolveHermesProfile({
+      profileName,
+      hermesHome: join(homedir(), '.hermes', 'profiles', profileName),
+    }).hermesHome;
   } catch {
     return undefined;
   }

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -65,8 +65,15 @@ function isHermesApiKeyRejection(target: { protocol?: string }, status: number):
   return target.protocol === 'hermes-openai' && (status === 401 || status === 403);
 }
 
-function hermesApiKeyRejectedDetails(config: RequestContext['config']): string {
-  return `Hermes API server rejected the API_SERVER_KEY — ${hermesApiServerKeyRejectionRemediation(config)}.`;
+function hermesApiKeyRejectedDetails(
+  config: RequestContext['config'],
+  apiServerKey: string | undefined,
+): string {
+  // A 401/403 with a key forwarded means the key is wrong (realign/rotate); with
+  // no key forwarded it means one is missing/unresolved (provision + reconnect).
+  return apiServerKey
+    ? `Hermes API server rejected the API_SERVER_KEY — ${hermesApiServerKeyRejectionRemediation(config)}.`
+    : `Hermes API server requires an API_SERVER_KEY but none was resolved — ${hermesApiServerKeyRemediation(config)}.`;
 }
 
 /**
@@ -161,7 +168,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
             return jsonResponse(res, 502, {
               error: 'Hermes API server rejected the API_SERVER_KEY',
               code: 'HERMES_API_KEY_REJECTED',
-              details: details || hermesApiKeyRejectedDetails(config),
+              details: details || hermesApiKeyRejectedDetails(config, apiServerKey),
             });
           }
           if (shouldTryNextHermesTarget(forwardRes.status)) {
@@ -279,7 +286,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
             return jsonResponse(res, 502, {
               error: 'Hermes API server rejected the API_SERVER_KEY',
               code: 'HERMES_API_KEY_REJECTED',
-              details: details || hermesApiKeyRejectedDetails(config),
+              details: details || hermesApiKeyRejectedDetails(config, apiServerKey),
             });
           }
           if (shouldTryNextHermesTarget(transportRes.status)) {

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -21,8 +21,10 @@ import {
   hermesPersistTurnKey,
   normalizeHermesChatPayload,
   normalizeHermesPersistTurnPayload,
+  hermesApiServerKeyRemediation,
   pipeHermesStream,
   probeHermesChannelHealth,
+  resolveHermesApiServerKey,
   shouldTryNextHermesTarget,
   verifyHermesAttachmentRefsProvenance,
   verifyHermesAttachmentImportResultsProvenance,
@@ -55,6 +57,33 @@ function withVerifiedAttachmentImportContextEntries(
       ...importContextEntries,
     ],
   };
+}
+
+/** Hermes' OpenAI api_server returns 401/403 when the bearer key is wrong/absent. */
+function isHermesApiKeyRejection(target: { protocol?: string }, status: number): boolean {
+  return target.protocol === 'hermes-openai' && (status === 401 || status === 403);
+}
+
+function hermesApiKeyRejectedDetails(config: RequestContext['config']): string {
+  return `Hermes API server rejected the API_SERVER_KEY — ${hermesApiServerKeyRemediation(config)}.`;
+}
+
+/**
+ * Enrich the generic unreachable/error detail with an actionable hint when a
+ * hermes-openai target exists but no API_SERVER_KEY is resolvable — the most
+ * common cause of the api_server never coming up on Hermes v0.15.0+. The
+ * remediation is branched on loopback vs remote transport.
+ */
+function hermesUnreachableDetails(
+  details: string | undefined,
+  targets: Array<{ protocol?: string }>,
+  apiServerKey: string | undefined,
+  config: RequestContext['config'],
+): string | undefined {
+  const needsKey = !apiServerKey && targets.some((t) => t.protocol === 'hermes-openai');
+  if (!needsKey) return details;
+  const hint = `Hermes api_server is unreachable; since Hermes v0.15.0 it requires API_SERVER_KEY — ${hermesApiServerKeyRemediation(config)}.`;
+  return details ? `${details} — ${hint}` : hint;
 }
 
 export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
@@ -103,6 +132,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     const verifiedPayload = withVerifiedAttachmentImportContextEntries(payload, attachmentImportResults);
 
     const targets = getHermesChannelTargets(config);
+    const apiServerKey = resolveHermesApiServerKey(config);
     let lastFailure: { status?: number; details?: string; offline?: boolean } | null = null;
 
     for (const target of targets) {
@@ -120,12 +150,19 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
           method: 'POST',
           headers: buildHermesChannelHeaders(target, bridgeAuthToken, {
             'Content-Type': 'application/json',
-          }),
+          }, target.inboundUrl, apiServerKey),
           body: JSON.stringify(forwardBody),
           signal: AbortSignal.timeout(HERMES_CHANNEL_RESPONSE_TIMEOUT_MS),
         });
         if (!forwardRes.ok) {
           const details = await forwardRes.text().catch(() => '');
+          if (isHermesApiKeyRejection(target, forwardRes.status)) {
+            return jsonResponse(res, 502, {
+              error: 'Hermes API server rejected the API_SERVER_KEY',
+              code: 'HERMES_API_KEY_REJECTED',
+              details: details || hermesApiKeyRejectedDetails(config),
+            });
+          }
           if (shouldTryNextHermesTarget(forwardRes.status)) {
             lastFailure = {
               status: forwardRes.status,
@@ -173,7 +210,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     return jsonResponse(res, lastFailure?.offline ? 503 : 502, {
       error: lastFailure?.offline ? 'Hermes bridge unreachable' : 'Hermes bridge error',
       code: lastFailure?.offline ? 'BRIDGE_OFFLINE' : 'BRIDGE_ERROR',
-      details: lastFailure?.details,
+      details: hermesUnreachableDetails(lastFailure?.details, targets, apiServerKey, config),
     });
   }
 
@@ -210,6 +247,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     const verifiedPayload = withVerifiedAttachmentImportContextEntries(payload, attachmentImportResults);
 
     const targets = getHermesChannelTargets(config);
+    const apiServerKey = resolveHermesApiServerKey(config);
     let lastFailure: { status?: number; details?: string; offline?: boolean } | null = null;
 
     for (const target of targets) {
@@ -223,18 +261,26 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         const forwardBody = target.protocol === 'hermes-openai'
           ? buildHermesOpenAiChatBody(verifiedPayload, attachmentRefs, requestAgentAddress, true)
           : buildHermesChannelBody(verifiedPayload, attachmentRefs, requestAgentAddress);
-        const transportRes = await fetch(target.streamUrl ?? target.inboundUrl, {
+        const streamUrl = target.streamUrl ?? target.inboundUrl;
+        const transportRes = await fetch(streamUrl, {
           method: 'POST',
           headers: buildHermesChannelHeaders(target, bridgeAuthToken, {
             'Content-Type': 'application/json',
             Accept: 'text/event-stream',
-          }),
+          }, streamUrl, apiServerKey),
           body: JSON.stringify(forwardBody),
           signal: AbortSignal.timeout(HERMES_CHANNEL_RESPONSE_TIMEOUT_MS),
         });
 
         if (!transportRes.ok) {
           const details = await transportRes.text().catch(() => '');
+          if (isHermesApiKeyRejection(target, transportRes.status)) {
+            return jsonResponse(res, 502, {
+              error: 'Hermes API server rejected the API_SERVER_KEY',
+              code: 'HERMES_API_KEY_REJECTED',
+              details: details || hermesApiKeyRejectedDetails(config),
+            });
+          }
           if (shouldTryNextHermesTarget(transportRes.status)) {
             lastFailure = {
               status: transportRes.status,
@@ -332,7 +378,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     return jsonResponse(res, lastFailure?.offline ? 503 : 502, {
       error: lastFailure?.offline ? 'Hermes bridge unreachable' : 'Hermes bridge error',
       code: lastFailure?.offline ? 'BRIDGE_OFFLINE' : 'BRIDGE_ERROR',
-      details: lastFailure?.details,
+      details: hermesUnreachableDetails(lastFailure?.details, targets, apiServerKey, config),
     });
   }
 

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -22,6 +22,7 @@ import {
   normalizeHermesChatPayload,
   normalizeHermesPersistTurnPayload,
   hermesApiServerKeyRemediation,
+  hermesApiServerKeyRejectionRemediation,
   pipeHermesStream,
   probeHermesChannelHealth,
   resolveHermesApiServerKey,
@@ -65,7 +66,7 @@ function isHermesApiKeyRejection(target: { protocol?: string }, status: number):
 }
 
 function hermesApiKeyRejectedDetails(config: RequestContext['config']): string {
-  return `Hermes API server rejected the API_SERVER_KEY — ${hermesApiServerKeyRemediation(config)}.`;
+  return `Hermes API server rejected the API_SERVER_KEY — ${hermesApiServerKeyRejectionRemediation(config)}.`;
 }
 
 /**

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi, afterEach } from 'vitest';
@@ -13,6 +13,7 @@ import {
   normalizeHermesChatPayload,
   normalizeHermesPersistTurnPayload,
   probeHermesChannelHealth,
+  resolveHermesApiServerKey,
 } from '../src/daemon/hermes.js';
 import {
   connectLocalAgentIntegrationFromUi,
@@ -162,8 +163,13 @@ function makeHermesRouteContext(
   };
 }
 
+const cleanupDirs: string[] = [];
+
 afterEach(() => {
   vi.unstubAllGlobals();
+  while (cleanupDirs.length) {
+    rmSync(cleanupDirs.pop()!, { recursive: true, force: true });
+  }
   disconnectHermesProfileMock.mockReset();
   resolveHermesProfileMock.mockReset();
   resolveHermesProfileMock.mockReturnValue({
@@ -453,6 +459,162 @@ describe('Hermes channel helpers', () => {
       { Accept: 'application/json' },
       'https://hermes.example.com/health',
     )).toEqual({ Accept: 'application/json' });
+  });
+
+  it('forwards Authorization: Bearer to hermes-openai targets only when a key is resolved', () => {
+    const target = {
+      name: 'gateway' as const,
+      protocol: 'hermes-openai' as const,
+      inboundUrl: 'http://127.0.0.1:8642/v1/chat/completions',
+      healthUrl: 'http://127.0.0.1:8642/health',
+    };
+    // The unauthenticated /health probe never receives the bearer, even when a
+    // key is available, so it cannot leak to health-endpoint/proxy logs.
+    expect(buildHermesChannelHeaders(
+      target,
+      'bridge-token',
+      { Accept: 'application/json' },
+      target.healthUrl,
+      'api-key-123',
+    )).toEqual({ Accept: 'application/json' });
+    // Key present → bearer added; the loopback bridge token is NOT added.
+    expect(buildHermesChannelHeaders(
+      target,
+      'bridge-token',
+      { 'Content-Type': 'application/json' },
+      target.inboundUrl,
+      'api-key-123',
+    )).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer api-key-123',
+    });
+    // No key → behavior identical to today (no auth header), so key-less
+    // older Hermes installs keep working.
+    expect(buildHermesChannelHeaders(
+      target,
+      'bridge-token',
+      { 'Content-Type': 'application/json' },
+      target.inboundUrl,
+    )).toEqual({ 'Content-Type': 'application/json' });
+    // The api server key never leaks onto the loopback bridge transport.
+    expect(buildHermesChannelHeaders(
+      { name: 'bridge', inboundUrl: 'http://127.0.0.1:9202/send' },
+      'bridge-token',
+      { 'Content-Type': 'application/json' },
+      'http://127.0.0.1:9202/send',
+      'api-key-123',
+    )).toEqual({
+      'Content-Type': 'application/json',
+      'x-dkg-bridge-token': 'bridge-token',
+    });
+  });
+
+  it('resolves the Hermes API server key from the profile .env and DKG_HERMES_API_SERVER_KEY override', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-env-'));
+    cleanupDirs.push(home);
+    // Inline `#` comment on an unquoted value must be stripped (dotenv
+    // semantics) so the forwarded bearer matches the key Hermes loads.
+    writeFileSync(
+      join(home, '.env'),
+      '# managed by user\nAPI_SERVER_ENABLED=true\nAPI_SERVER_KEY=from-env-file # local dev\nOTHER=keep\n',
+    );
+    const config = makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+          metadata: { hermesHome: home },
+        },
+      },
+    });
+
+    expect(resolveHermesApiServerKey(config)).toBe('from-env-file');
+
+    // A quoted value keeps an inner `#`; the last assignment wins.
+    const quotedHome = mkdtempSync(join(tmpdir(), 'hermes-env-q-'));
+    cleanupDirs.push(quotedHome);
+    writeFileSync(join(quotedHome, '.env'), 'API_SERVER_KEY="se#cret value"\n');
+    expect(resolveHermesApiServerKey(makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+          metadata: { hermesHome: quotedHome },
+        },
+      },
+    }))).toBe('se#cret value');
+
+    // Explicit daemon override (remote/WSL Hermes) wins over the local .env.
+    process.env.DKG_HERMES_API_SERVER_KEY = 'override-key';
+    try {
+      expect(resolveHermesApiServerKey(config)).toBe('override-key');
+    } finally {
+      delete process.env.DKG_HERMES_API_SERVER_KEY;
+    }
+
+    // No hermesHome / no .env → undefined (older key-less Hermes: no bearer).
+    expect(resolveHermesApiServerKey(makeConfig({
+      localAgentIntegrations: {
+        hermes: { enabled: true, transport: { kind: 'hermes-openai' } },
+      },
+    }))).toBeUndefined();
+
+    // Remote (non-loopback) gateway must NOT read the local .env, even when a
+    // stale local profile key exists — that key belongs to a different Hermes
+    // and would make the remote reject with 401 (Codex review). Such setups
+    // rely solely on DKG_HERMES_API_SERVER_KEY.
+    expect(resolveHermesApiServerKey(makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'https://hermes.example.com:8642' },
+          metadata: { hermesHome: home },
+        },
+      },
+    }))).toBeUndefined();
+  });
+
+  it('falls back to the resolved Hermes profile when metadata.hermesHome is absent', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-fallback-'));
+    cleanupDirs.push(home);
+    writeFileSync(join(home, '.env'), 'API_SERVER_KEY=fallback-key\n');
+    // Integration record predates hermesHome metadata (or connect was skipped):
+    // resolution falls back to the default profile the same way setup does.
+    resolveHermesProfileMock.mockReturnValue({
+      profileName: undefined,
+      hermesHome: home,
+      memoryMode: 'provider',
+    });
+
+    expect(resolveHermesApiServerKey(makeConfig({
+      localAgentIntegrations: {
+        hermes: { enabled: true, transport: { kind: 'hermes-openai' } },
+      },
+    }))).toBe('fallback-key');
+  });
+
+  it('annotates an unreachable hermes-openai health probe with the missing-key hint', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-nokey-'));
+    cleanupDirs.push(home);
+    // .env exists but has no active API_SERVER_KEY (issue #794 shape).
+    writeFileSync(join(home, '.env'), 'API_SERVER_ENABLED=true\n# API_SERVER_KEY=disabled\n');
+    const config = makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+          metadata: { hermesHome: home },
+        },
+      },
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('fetch failed');
+    }));
+
+    const report = await probeHermesChannelHealth(config, undefined, { timeoutMs: 50 });
+    expect(report.ok).toBe(false);
+    expect(report.error).toContain('API_SERVER_KEY');
+    expect(report.error).toContain('dkg hermes setup');
   });
 
   it('normalizes profile for send and persist payloads', () => {
@@ -1278,6 +1440,33 @@ describe('Hermes daemon routes', () => {
       code: 'INTEGRATION_DISABLED',
     });
   });
+
+  it.each(['/api/hermes-channel/send', '/api/hermes-channel/stream'])(
+    'returns HERMES_API_KEY_REJECTED when the hermes-openai api_server replies 401 (%s)',
+    async (path) => {
+      const { ctx, res } = makeHermesRouteContext({
+        text: 'hello',
+        correlationId: 'corr-1',
+      }, {
+        hasChatTurn: vi.fn(async () => false),
+        storeChatExchange: vi.fn(async () => {}),
+      }, {
+        localAgentIntegrations: {
+          hermes: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+          },
+        },
+      }, path);
+      vi.stubGlobal('fetch', vi.fn(async () => new Response('unauthorized', { status: 401 })));
+
+      await handleHermesRoutes(ctx);
+
+      expect(res.statusCode).toBe(502);
+      expect(JSON.parse(res.body)).toMatchObject({ code: 'HERMES_API_KEY_REJECTED' });
+    },
+  );
 
   it('forwards attachment refs, import context, and contextGraphId to Hermes channel send', async () => {
     const attachmentRef = {

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -609,6 +609,25 @@ describe('Hermes channel helpers', () => {
     }
   });
 
+  it('drops a key containing control characters (unusable as an HTTP bearer)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-ctrl-'));
+    cleanupDirs.push(home);
+    // A double-quoted `\n` decodes to a real newline (python-dotenv parity), but
+    // CR/LF are illegal in HTTP header values and would crash fetch — so the
+    // resolver must drop it rather than forward an unusable bearer (Codex review).
+    writeFileSync(join(home, '.env'), 'API_SERVER_KEY="abc\\n123"\n');
+
+    expect(resolveHermesApiServerKey(makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+          metadata: { hermesHome: home },
+        },
+      },
+    }))).toBeUndefined();
+  });
+
   it('falls back to the override only when loopback .env has no API_SERVER_KEY line', () => {
     const home = mkdtempSync(join(tmpdir(), 'hermes-nokeyline-'));
     cleanupDirs.push(home);
@@ -1524,8 +1543,12 @@ describe('Hermes daemon routes', () => {
   });
 
   it.each(['/api/hermes-channel/send', '/api/hermes-channel/stream'])(
-    'returns HERMES_API_KEY_REJECTED when the hermes-openai api_server replies 401 (%s)',
+    'returns HERMES_API_KEY_REJECTED with realign guidance when a forwarded key is rejected (%s)',
     async (path) => {
+      // A key IS resolved (present in the profile .env) → 401 means it's wrong.
+      const home = mkdtempSync(join(tmpdir(), 'hermes-401-'));
+      cleanupDirs.push(home);
+      writeFileSync(join(home, '.env'), 'API_SERVER_KEY=present-but-wrong\n');
       const { ctx, res } = makeHermesRouteContext({
         text: 'hello',
         correlationId: 'corr-1',
@@ -1538,6 +1561,7 @@ describe('Hermes daemon routes', () => {
             enabled: true,
             capabilities: { localChat: true },
             transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+            metadata: { hermesHome: home },
           },
         },
       }, path);
@@ -1549,12 +1573,40 @@ describe('Hermes daemon routes', () => {
       expect(res.statusCode).toBe(502);
       const body = JSON.parse(res.body);
       expect(body).toMatchObject({ code: 'HERMES_API_KEY_REJECTED' });
-      // Rejected (key present but wrong) → realign/rotate guidance, NOT the
-      // missing-key "provision" path (setup never overwrites an existing key).
+      // Key present but wrong → realign/rotate guidance, NOT the missing-key
+      // "provision" path (setup never overwrites an existing key).
       expect(body.details).toContain('does not match');
       expect(body.details).not.toContain('provision API_SERVER_KEY');
     },
   );
+
+  it('returns missing-key guidance on 401 when no key was resolved/forwarded', async () => {
+    // No metadata / no resolvable key → DKG sent no bearer → 401 means MISSING,
+    // so the remediation must point to provisioning, not realigning.
+    const { ctx, res } = makeHermesRouteContext({
+      text: 'hello',
+      correlationId: 'corr-1',
+    }, {
+      hasChatTurn: vi.fn(async () => false),
+      storeChatExchange: vi.fn(async () => {}),
+    }, {
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          capabilities: { localChat: true },
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+        },
+      },
+    }, '/api/hermes-channel/send');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 401 })));
+
+    await handleHermesRoutes(ctx);
+
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.body);
+    expect(body.details).toContain('provision API_SERVER_KEY');
+    expect(body.details).not.toContain('does not match');
+  });
 
   it('forwards attachment refs, import context, and contextGraphId to Hermes channel send', async () => {
     const attachmentRef = {

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -628,7 +628,7 @@ describe('Hermes channel helpers', () => {
     }))).toBeUndefined();
   });
 
-  it('falls back to the override only when loopback .env has no API_SERVER_KEY line', () => {
+  it('never uses the override on loopback — even with no API_SERVER_KEY line (override is remote-only)', () => {
     const home = mkdtempSync(join(tmpdir(), 'hermes-nokeyline-'));
     cleanupDirs.push(home);
     writeFileSync(join(home, '.env'), 'API_SERVER_ENABLED=true\nOTHER=keep\n'); // no API_SERVER_KEY
@@ -643,9 +643,11 @@ describe('Hermes channel helpers', () => {
     });
 
     expect(resolveHermesApiServerKey(config)).toBeUndefined();
-    process.env.DKG_HERMES_API_SERVER_KEY = 'fallback-override';
+    // DKG_HERMES_API_SERVER_KEY is the REMOTE mechanism — it must not substitute
+    // for a local loopback key (Codex review). Loopback stays undefined.
+    process.env.DKG_HERMES_API_SERVER_KEY = 'remote-only-override';
     try {
-      expect(resolveHermesApiServerKey(config)).toBe('fallback-override');
+      expect(resolveHermesApiServerKey(config)).toBeUndefined();
     } finally {
       delete process.env.DKG_HERMES_API_SERVER_KEY;
     }

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import type { DkgConfig } from '../src/config.js';
@@ -699,6 +699,12 @@ describe('Hermes channel helpers', () => {
         },
       },
     }))).toBe('fallback-key');
+    // The profile is resolved with an EXPLICIT hermesHome so a daemon-side
+    // HERMES_HOME can't redirect us to a different profile's .env (Codex review).
+    expect(resolveHermesProfileMock).toHaveBeenCalledWith({
+      profileName: 'research',
+      hermesHome: join(homedir(), '.hermes', 'profiles', 'research'),
+    });
   });
 
   it('does NOT guess the default profile when neither hermesHome nor profileName is known', () => {

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -574,12 +574,36 @@ describe('Hermes channel helpers', () => {
     }))).toBeUndefined();
   });
 
-  it('falls back to the resolved Hermes profile when metadata.hermesHome is absent', () => {
+  it('falls back to an EXACT named profile when metadata.hermesHome is absent but profileName is known', () => {
     const home = mkdtempSync(join(tmpdir(), 'hermes-fallback-'));
     cleanupDirs.push(home);
     writeFileSync(join(home, '.env'), 'API_SERVER_KEY=fallback-key\n');
-    // Integration record predates hermesHome metadata (or connect was skipped):
-    // resolution falls back to the default profile the same way setup does.
+    // Record predates hermesHome metadata but still carries profileName, so we
+    // resolve that exact profile (never a guessed default).
+    resolveHermesProfileMock.mockReturnValue({
+      profileName: 'research',
+      hermesHome: home,
+      memoryMode: 'provider',
+    });
+
+    expect(resolveHermesApiServerKey(makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai' },
+          metadata: { profileName: 'research' },
+        },
+      },
+    }))).toBe('fallback-key');
+  });
+
+  it('does NOT guess the default profile when neither hermesHome nor profileName is known', () => {
+    // Guessing the default profile here could read a *different* profile's .env
+    // and forward the wrong key (Codex review). Return undefined so the caller
+    // surfaces the "run dkg hermes setup" hint instead.
+    const home = mkdtempSync(join(tmpdir(), 'hermes-noprofile-'));
+    cleanupDirs.push(home);
+    writeFileSync(join(home, '.env'), 'API_SERVER_KEY=wrong-profile-key\n');
     resolveHermesProfileMock.mockReturnValue({
       profileName: undefined,
       hermesHome: home,
@@ -590,7 +614,7 @@ describe('Hermes channel helpers', () => {
       localAgentIntegrations: {
         hermes: { enabled: true, transport: { kind: 'hermes-openai' } },
       },
-    }))).toBe('fallback-key');
+    }))).toBeUndefined();
   });
 
   it('annotates an unreachable hermes-openai health probe with the missing-key hint', async () => {

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -582,14 +582,14 @@ describe('Hermes channel helpers', () => {
     }))).toBeUndefined();
   });
 
-  it('clears the key when the last .env assignment is blank (dotenv last-wins)', () => {
+  it('treats a blank local .env assignment as authoritative, even over a stale override', () => {
     const home = mkdtempSync(join(tmpdir(), 'hermes-blank-'));
     cleanupDirs.push(home);
-    // A later blank assignment must reset an earlier value, matching how Hermes
-    // (python-dotenv) reads it — otherwise DKG forwards a rotated-away key.
+    // A later blank assignment must reset an earlier value (dotenv last-wins).
+    // An explicit (even blank) local key is authoritative on loopback, so a
+    // stale DKG_HERMES_API_SERVER_KEY must NOT be forwarded (Codex review).
     writeFileSync(join(home, '.env'), 'API_SERVER_KEY=old-key\nAPI_SERVER_KEY=\n');
-
-    expect(resolveHermesApiServerKey(makeConfig({
+    const config = makeConfig({
       localAgentIntegrations: {
         hermes: {
           enabled: true,
@@ -597,7 +597,39 @@ describe('Hermes channel helpers', () => {
           metadata: { hermesHome: home },
         },
       },
-    }))).toBeUndefined();
+    });
+
+    expect(resolveHermesApiServerKey(config)).toBeUndefined();
+
+    process.env.DKG_HERMES_API_SERVER_KEY = 'stale-override';
+    try {
+      expect(resolveHermesApiServerKey(config)).toBeUndefined();
+    } finally {
+      delete process.env.DKG_HERMES_API_SERVER_KEY;
+    }
+  });
+
+  it('falls back to the override only when loopback .env has no API_SERVER_KEY line', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-nokeyline-'));
+    cleanupDirs.push(home);
+    writeFileSync(join(home, '.env'), 'API_SERVER_ENABLED=true\nOTHER=keep\n'); // no API_SERVER_KEY
+    const config = makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+          metadata: { hermesHome: home },
+        },
+      },
+    });
+
+    expect(resolveHermesApiServerKey(config)).toBeUndefined();
+    process.env.DKG_HERMES_API_SERVER_KEY = 'fallback-override';
+    try {
+      expect(resolveHermesApiServerKey(config)).toBe('fallback-override');
+    } finally {
+      delete process.env.DKG_HERMES_API_SERVER_KEY;
+    }
   });
 
   it('falls back to an EXACT named profile when metadata.hermesHome is absent but profileName is known', () => {

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -643,11 +643,36 @@ describe('Hermes channel helpers', () => {
     });
 
     expect(resolveHermesApiServerKey(config)).toBeUndefined();
-    // DKG_HERMES_API_SERVER_KEY is the REMOTE mechanism — it must not substitute
-    // for a local loopback key (Codex review). Loopback stays undefined.
+    // A locally-managed profile resolved, so its .env is authoritative — the
+    // override (which targets a different/remote Hermes) must not substitute for
+    // a local setup that simply has no key (Codex review).
     process.env.DKG_HERMES_API_SERVER_KEY = 'remote-only-override';
     try {
       expect(resolveHermesApiServerKey(config)).toBeUndefined();
+    } finally {
+      delete process.env.DKG_HERMES_API_SERVER_KEY;
+    }
+  });
+
+  it('honors the override on a loopback gateway with no locally-managed profile (WSL2 localhost forward)', () => {
+    // A WSL2/remote Hermes reached via a localhost forward looks "loopback" but
+    // has no local .env on the daemon host. With no resolvable local profile,
+    // honor DKG_HERMES_API_SERVER_KEY — otherwise this correctly-configured
+    // setup would 401 forever (Codex review).
+    const config = makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          // No metadata.hermesHome / profileName → no local profile resolves.
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
+        },
+      },
+    });
+
+    expect(resolveHermesApiServerKey(config)).toBeUndefined();
+    process.env.DKG_HERMES_API_SERVER_KEY = 'forwarded-remote-key';
+    try {
+      expect(resolveHermesApiServerKey(config)).toBe('forwarded-remote-key');
     } finally {
       delete process.env.DKG_HERMES_API_SERVER_KEY;
     }

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -1541,12 +1541,18 @@ describe('Hermes daemon routes', () => {
           },
         },
       }, path);
-      vi.stubGlobal('fetch', vi.fn(async () => new Response('unauthorized', { status: 401 })));
+      // Empty upstream body so the route surfaces our own remediation text.
+      vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 401 })));
 
       await handleHermesRoutes(ctx);
 
       expect(res.statusCode).toBe(502);
-      expect(JSON.parse(res.body)).toMatchObject({ code: 'HERMES_API_KEY_REJECTED' });
+      const body = JSON.parse(res.body);
+      expect(body).toMatchObject({ code: 'HERMES_API_KEY_REJECTED' });
+      // Rejected (key present but wrong) → realign/rotate guidance, NOT the
+      // missing-key "provision" path (setup never overwrites an existing key).
+      expect(body.details).toContain('does not match');
+      expect(body.details).not.toContain('provision API_SERVER_KEY');
     },
   );
 

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -544,13 +544,35 @@ describe('Hermes channel helpers', () => {
       },
     }))).toBe('se#cret value');
 
-    // Explicit daemon override (remote/WSL Hermes) wins over the local .env.
-    process.env.DKG_HERMES_API_SERVER_KEY = 'override-key';
+    // Loopback: the profile .env wins over a stale DKG_HERMES_API_SERVER_KEY
+    // (e.g. left set from a former remote setup) so it can't shadow the correct
+    // local key (Codex review).
+    process.env.DKG_HERMES_API_SERVER_KEY = 'stale-override';
     try {
-      expect(resolveHermesApiServerKey(config)).toBe('override-key');
+      expect(resolveHermesApiServerKey(config)).toBe('from-env-file');
     } finally {
       delete process.env.DKG_HERMES_API_SERVER_KEY;
     }
+
+    // Remote (non-loopback) gateway: the .env is on another host, so the
+    // explicit override is the only source and the local .env is never read.
+    const remoteConfig = makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-openai', gatewayUrl: 'https://hermes.example.com:8642' },
+          metadata: { hermesHome: home },
+        },
+      },
+    });
+    process.env.DKG_HERMES_API_SERVER_KEY = 'remote-override';
+    try {
+      expect(resolveHermesApiServerKey(remoteConfig)).toBe('remote-override');
+    } finally {
+      delete process.env.DKG_HERMES_API_SERVER_KEY;
+    }
+    // Remote with no override → undefined (local .env never read).
+    expect(resolveHermesApiServerKey(remoteConfig)).toBeUndefined();
 
     // No hermesHome / no .env → undefined (older key-less Hermes: no bearer).
     expect(resolveHermesApiServerKey(makeConfig({
@@ -558,16 +580,20 @@ describe('Hermes channel helpers', () => {
         hermes: { enabled: true, transport: { kind: 'hermes-openai' } },
       },
     }))).toBeUndefined();
+  });
 
-    // Remote (non-loopback) gateway must NOT read the local .env, even when a
-    // stale local profile key exists — that key belongs to a different Hermes
-    // and would make the remote reject with 401 (Codex review). Such setups
-    // rely solely on DKG_HERMES_API_SERVER_KEY.
+  it('clears the key when the last .env assignment is blank (dotenv last-wins)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hermes-blank-'));
+    cleanupDirs.push(home);
+    // A later blank assignment must reset an earlier value, matching how Hermes
+    // (python-dotenv) reads it — otherwise DKG forwards a rotated-away key.
+    writeFileSync(join(home, '.env'), 'API_SERVER_KEY=old-key\nAPI_SERVER_KEY=\n');
+
     expect(resolveHermesApiServerKey(makeConfig({
       localAgentIntegrations: {
         hermes: {
           enabled: true,
-          transport: { kind: 'hermes-openai', gatewayUrl: 'https://hermes.example.com:8642' },
+          transport: { kind: 'hermes-openai', gatewayUrl: 'http://127.0.0.1:8642' },
           metadata: { hermesHome: home },
         },
       },

--- a/packages/core/src/dotenv.ts
+++ b/packages/core/src/dotenv.ts
@@ -7,13 +7,24 @@
  *
  * Rules (python-dotenv):
  *  - A quoted value keeps everything between the matching quotes, including an
- *    inner `#` (`"se#cret"` → `se#cret`). In double-quoted values a backslash
- *    escapes the next character (`"abc\"def"` → `abc"def`, `"a\\b"` → `a\b`);
- *    single-quoted values are literal.
+ *    inner `#` (`"se#cret"` → `se#cret`). In double-quoted values escape
+ *    sequences are decoded the way python-dotenv decodes them — `\n`/`\t`/`\r`
+ *    become newline/tab/CR, `\"`/`\\`/`\'` become the literal char, and any
+ *    other `\x` drops the backslash (`"abc\"def"` → `abc"def`, `"a\nb"` → a
+ *    newline-separated value). Single-quoted values are literal.
  *  - An unquoted value is truncated at the first whitespace-preceded `#` (an
  *    inline comment) and trimmed (`secret # dev` → `secret`); a `#` with no
  *    preceding whitespace is literal (`a#b` → `a#b`).
  */
+const DOUBLE_QUOTE_ESCAPES: Record<string, string> = {
+  n: '\n',
+  t: '\t',
+  r: '\r',
+  '\\': '\\',
+  '"': '"',
+  "'": "'",
+};
+
 export function parseDotenvValue(raw: string): string {
   const value = raw.replace(/^\s+/, '');
   const quote = value[0];
@@ -21,10 +32,12 @@ export function parseDotenvValue(raw: string): string {
     let result = '';
     for (let i = 1; i < value.length; i += 1) {
       const ch = value[i];
-      // Backslash escapes the next char in double-quoted values (python-dotenv
-      // `\\(.) -> \1`); single-quoted values treat backslash literally.
+      // In double-quoted values a backslash introduces an escape sequence
+      // (python-dotenv decodes `\n`/`\t`/`\r`/`\\`/`\"`/`\'`; any other `\x`
+      // becomes `x`). Single-quoted values treat backslash literally.
       if (ch === '\\' && quote === '"' && i + 1 < value.length) {
-        result += value[i + 1];
+        const next = value[i + 1];
+        result += DOUBLE_QUOTE_ESCAPES[next] ?? next;
         i += 1;
         continue;
       }

--- a/packages/core/src/dotenv.ts
+++ b/packages/core/src/dotenv.ts
@@ -1,0 +1,38 @@
+/**
+ * Minimal `.env` value parser matching python-dotenv semantics, shared by the
+ * Hermes adapter (which provisions `API_SERVER_KEY` into the Hermes profile
+ * `.env`) and the daemon (which reads it back to forward as a bearer). Keeping
+ * a single implementation here prevents the two sides from drifting and
+ * silently breaking auth.
+ *
+ * Rules (python-dotenv):
+ *  - A quoted value keeps everything between the matching quotes, including an
+ *    inner `#` (`"se#cret"` → `se#cret`). In double-quoted values a backslash
+ *    escapes the next character (`"abc\"def"` → `abc"def`, `"a\\b"` → `a\b`);
+ *    single-quoted values are literal.
+ *  - An unquoted value is truncated at the first whitespace-preceded `#` (an
+ *    inline comment) and trimmed (`secret # dev` → `secret`); a `#` with no
+ *    preceding whitespace is literal (`a#b` → `a#b`).
+ */
+export function parseDotenvValue(raw: string): string {
+  const value = raw.replace(/^\s+/, '');
+  const quote = value[0];
+  if (quote === '"' || quote === "'") {
+    let result = '';
+    for (let i = 1; i < value.length; i += 1) {
+      const ch = value[i];
+      // Backslash escapes the next char in double-quoted values (python-dotenv
+      // `\\(.) -> \1`); single-quoted values treat backslash literally.
+      if (ch === '\\' && quote === '"' && i + 1 < value.length) {
+        result += value[i + 1];
+        i += 1;
+        continue;
+      }
+      if (ch === quote) return result; // matching close quote
+      result += ch;
+    }
+    // Unterminated quote: fall through and treat the raw text as unquoted.
+  }
+  const comment = value.match(/\s#/);
+  return (comment?.index !== undefined ? value.slice(0, comment.index) : value).trim();
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types.js';
 export * from './constants.js';
+export { parseDotenvValue } from './dotenv.js';
 export * from './memory-model.js';
 export * from './trust.js';
 export * from './publisher-extension.js';

--- a/packages/core/test/dotenv.test.ts
+++ b/packages/core/test/dotenv.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { parseDotenvValue } from '../src/dotenv.js';
+
+describe('parseDotenvValue', () => {
+  it('returns a plain unquoted value unchanged', () => {
+    expect(parseDotenvValue('secret')).toBe('secret');
+    expect(parseDotenvValue('  secret  ')).toBe('secret');
+  });
+
+  it('strips a whitespace-preceded inline comment from unquoted values', () => {
+    expect(parseDotenvValue('secret # local dev')).toBe('secret');
+    expect(parseDotenvValue('true # on')).toBe('true');
+  });
+
+  it('keeps a `#` with no preceding whitespace as literal', () => {
+    expect(parseDotenvValue('a#b')).toBe('a#b');
+  });
+
+  it('preserves inner `#` inside quoted values', () => {
+    expect(parseDotenvValue('"se#cret value"')).toBe('se#cret value');
+    expect(parseDotenvValue("'se#cret'")).toBe('se#cret');
+  });
+
+  it('handles backslash escapes in double-quoted values', () => {
+    expect(parseDotenvValue('"abc\\"def"')).toBe('abc"def');
+    expect(parseDotenvValue('"a\\\\b"')).toBe('a\\b');
+  });
+
+  it('treats backslash literally in single-quoted values', () => {
+    expect(parseDotenvValue("'a\\b'")).toBe('a\\b');
+  });
+
+  it('ignores anything after a closing quote', () => {
+    expect(parseDotenvValue('"secret" # trailing comment')).toBe('secret');
+  });
+});

--- a/packages/core/test/dotenv.test.ts
+++ b/packages/core/test/dotenv.test.ts
@@ -26,6 +26,16 @@ describe('parseDotenvValue', () => {
     expect(parseDotenvValue('"a\\\\b"')).toBe('a\\b');
   });
 
+  it('decodes python-dotenv escape sequences in double-quoted values', () => {
+    // Hermes (python-dotenv) decodes these; the daemon must forward the same
+    // bytes or a valid key would 401.
+    expect(parseDotenvValue('"abc\\n123"')).toBe('abc\n123');
+    expect(parseDotenvValue('"a\\tb"')).toBe('a\tb');
+    expect(parseDotenvValue('"a\\rb"')).toBe('a\rb');
+    // Single-quoted values stay literal (no escape decoding).
+    expect(parseDotenvValue("'a\\nb'")).toBe('a\\nb');
+  });
+
   it('treats backslash literally in single-quoted values', () => {
     expect(parseDotenvValue("'a\\b'")).toBe('a\\b');
   });


### PR DESCRIPTION
## Summary

Backport of #795 (merged to `main`) onto `release/rc.12`.

Hermes v0.15.0 made `API_SERVER_KEY` mandatory for the OpenAI-compatible `api_server` even on loopback, so it refuses to start without one. The Node UI Hermes chat path forwards to that api_server but never provisioned or forwarded a key — the platform never started (health `fetch failed` → UI stuck on a generic "unavailable") and, even with a manual key, chat failed because DKG didn't send `Authorization: Bearer <key>` to `/v1/chat/completions`.

- **Setup** provisions `API_SERVER_KEY` (generated if absent, never overwriting an existing one) + `API_SERVER_ENABLED=true` into the Hermes profile `.env` for the loopback `hermes-openai` transport — written last so an aborted setup leaves no side effect. Picked up by the existing `hermes gateway run --replace -v` restart; no new manual step. Remote/non-loopback gateways are not written.
- **Daemon** forwards the bearer for `hermes-openai` targets only when a key resolves (gated to loopback; never on `/health`), reading the key from `<hermesHome>/.env` (cached) with a `DKG_HERMES_API_SERVER_KEY` override for remote gateways and a default-profile fallback when `metadata.hermesHome` is absent. Key-less older Hermes and the loopback-bridge path are unchanged.
- **Errors** branch loopback vs remote remediation; the key never appears in responses, the integration record, or logs.
- Shared python-dotenv value parser centralized in `dkg-core` so the adapter and daemon can't drift.

## Related

- Backport of #795 (→ `main`)
- Fixes #794 (on the rc.12 line)
- Upstream cause: NousResearch/hermes-agent@`1a9ef83` (require API_SERVER_KEY), first shipped in Hermes v0.15.0.

## Files changed

| File | What |
|------|------|
| `packages/adapter-hermes/src/setup.ts` | Read-or-provision `API_SERVER_KEY` + `API_SERVER_ENABLED` in `<hermesHome>/.env` (loopback only, idempotent, `0600`, dry-run-aware, last step); dry-run plan action |
| `packages/adapter-hermes/src/types.ts` | `apiServerKeyConfigured` flag on `HermesSetupState` |
| `packages/cli/src/daemon/hermes.ts` | `resolveHermesApiServerKey` (loopback-gated `.env` read + `DKG_HERMES_API_SERVER_KEY` override + profile fallback); bearer in `buildHermesChannelHeaders` (never on `/health`); branched remediation; missing-key health hint |
| `packages/cli/src/daemon/routes/hermes.ts` | Resolve + forward the key on send/stream; `HERMES_API_KEY_REJECTED` on 401/403; missing-key hint |
| `packages/core/src/dotenv.ts` + `index.ts` | Shared `parseDotenvValue` (python-dotenv semantics: inline comments, escaped quotes) |
| `packages/adapter-hermes/README.md` | Document auto-provisioning + `DKG_HERMES_API_SERVER_KEY` fallback |
| `packages/{core,cli,adapter-hermes}/test/*` | Parser unit tests, `.env` provision tests, header/resolution tests, route-level 401 coverage |

## Test plan

- [x] Clean cherry-pick of the squashed `main` commit (`93aad03e`) onto `release/rc.12`
- [ ] rc.12 CI green (build + core/cli/adapter-hermes suites)
- [x] Verified on `main`: core dotenv (7), cli daemon-hermes (77), adapter-hermes (88), `tsc` clean
- [x] Live round-trip confirmed working by the reporter
