### PR TITLE
docs(chain): correct update-path token floor rationale + track removal (#781)

### DIFF
--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -2814,9 +2814,9 @@ export class EVMChainAdapter implements ChainAdapter {
     // 1-wei delta (and revert a final-epoch metadata update via
     // `NoRemainingLifetimeForDelta`). Removing it — relying purely on the
     // publish-time invariant — is tracked as a post-testnet follow-up
-    // (#781); it is left in place for the rc.12 cut to avoid touching
-    // signed-ACK-digest math right before the testnet release, where it is
-    // provably inert.
+    // (#781; issue #803); it is left in place for the rc.12 cut to avoid
+    // touching signed-ACK-digest math right before the testnet release,
+    // where it is provably inert.
     const newTokenAmount = floorPublishTokenAmount(
       baseTokenAmount > requiredForNewSize ? baseTokenAmount : requiredForNewSize,
     );

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -2796,11 +2796,27 @@ export class EVMChainAdapter implements ChainAdapter {
       } catch { /* use 0 */ }
     }
     const baseTokenAmount = params.newTokenAmount ?? currentTokenAmount;
-    // KAV10 10.1.1: floor at 1n so the contract's strict-positive
-    // `_validateTokenAmount` check accepts metadata-only updates where
-    // both the carry-forward amount and the size-derived requirement are
-    // 0. The same floor runs through both the inline ACK-digest hash
-    // below and (canonically) `computeUpdateACKDigest`.
+    // KAV10 10.1.1: this floor is REDUNDANT for any KC that can exist on a
+    // V10 chain and is kept only as belt-and-suspenders. The publish path's
+    // own floor (see `floorPublishTokenAmount` at the publish struct site)
+    // plus the on-chain `_validateTokenAmount` revert on `tokenAmount == 0`
+    // guarantee every V10 KC carries `tokenAmount >= 1`, so the
+    // carry-forward `currentTokenAmount` (and therefore `baseTokenAmount`)
+    // is already >= 1 and this clamp is a no-op. It is NOT what lets
+    // metadata-only updates through: the contract skips `_validateTokenAmount`
+    // entirely unless `newByteSize > currentByteSize`
+    // (KnowledgeAssetsV10.sol §"Byte-size growth cost check"), so a
+    // metadata-only update with delta 0 is accepted without any floor.
+    //
+    // The clamp would only change anything for a legacy `tokenAmount == 0`
+    // KC (none can exist on a fresh V10 chain — only via a future V8/V9
+    // import path), where it would WRONGLY turn a free re-attestation into a
+    // 1-wei delta (and revert a final-epoch metadata update via
+    // `NoRemainingLifetimeForDelta`). Removing it — relying purely on the
+    // publish-time invariant — is tracked as a post-testnet follow-up
+    // (#781); it is left in place for the rc.12 cut to avoid touching
+    // signed-ACK-digest math right before the testnet release, where it is
+    // provably inert.
     const newTokenAmount = floorPublishTokenAmount(
       baseTokenAmount > requiredForNewSize ? baseTokenAmount : requiredForNewSize,
     );

--- a/packages/core/src/crypto/ack.ts
+++ b/packages/core/src/crypto/ack.ts
@@ -268,7 +268,7 @@ export function computeUpdateACKDigest(
   // >= 1`, and metadata-only updates skip `_validateTokenAmount` entirely.
   // It only changes a legacy `tokenAmount == 0` KC (which a fresh V10 chain
   // cannot produce). Removing it is tracked as a post-testnet follow-up
-  // (#781); see the matching note in evm-adapter.ts.
+  // (#781; issue #803); see the matching note in evm-adapter.ts.
   const flooredNewTokenAmount = floorPublishTokenAmount(newTokenAmount);
 
   // keccak256(abi.encodePacked(burnTokenIds))

--- a/packages/core/src/crypto/ack.ts
+++ b/packages/core/src/crypto/ack.ts
@@ -261,7 +261,14 @@ export function computeUpdateACKDigest(
     throw new Error(`newMerkleRoot must be 32 bytes, got ${newMerkleRoot.length}`);
   }
   const addrBytes = addressToBytes(kav10Address);
-  // KAV10 10.1.1 — same floor as publish; see floorPublishTokenAmount.
+  // KAV10 10.1.1 — kept in lockstep with the adapter's update struct so the
+  // signed digest matches the on-chain `newTokenAmount`. NOTE: this floor is
+  // redundant for any KC that can exist on a V10 chain — the publish-time
+  // floor + on-chain `_validateTokenAmount` guarantee `currentTokenAmount
+  // >= 1`, and metadata-only updates skip `_validateTokenAmount` entirely.
+  // It only changes a legacy `tokenAmount == 0` KC (which a fresh V10 chain
+  // cannot produce). Removing it is tracked as a post-testnet follow-up
+  // (#781); see the matching note in evm-adapter.ts.
   const flooredNewTokenAmount = floorPublishTokenAmount(newTokenAmount);
 
   // keccak256(abi.encodePacked(burnTokenIds))


### PR DESCRIPTION
## Summary
Comment-only follow-up to the #781 audit. No behavior change.

The update-path `floorPublishTokenAmount` (`evm-adapter.ts`) carried a misleading rationale: it claimed to exist so the contract's `_validateTokenAmount` check "accepts metadata-only updates". In fact the contract **skips** `_validateTokenAmount` unless `newByteSize > currentByteSize`, so metadata-only updates never reach that check.

This corrects the comment (and the matching `ack.ts` digest-helper note) to state the real situation, decided in review:

- The floor is **redundant** for any KC that can exist on a V10 chain. The publish-time floor + the on-chain revert on `tokenAmount == 0` guarantee every V10 KC carries `tokenAmount >= 1`, so the carry-forward `currentTokenAmount` is already `>= 1` and the clamp is a no-op (including for the signed ACK digest, which hashes the identical value).
- It would only change a **legacy `tokenAmount == 0` KC** — which a fresh V10 chain cannot produce (only a future V8/V9 import path could) — where it wrongly turns a free re-attestation into a 1-wei delta and can revert a final-epoch metadata update via `NoRemainingLifetimeForDelta`.

### Decision (rc.12 cut)
Keep the floor for the testnet cut — it's provably inert on a fresh V10 chain — rather than touch signed-ACK-digest math right before release. **Removing it** (relying purely on the publish-time invariant, with byte-identical-digest determinism tests) is the post-testnet follow-up tracked in the linked issue.

## Test plan
- [x] Comment-only; no runtime change
- [x] Lints clean
- [ ] Post-testnet: implement the removal + determinism tests (separate PR)

Made with [Cursor](https://cursor.com)