### PR TITLE
chore(evm): align all V10 contract versions to 10.0.2

### DIFF
--- a/packages/evm-module/contracts/Ask.sol
+++ b/packages/evm-module/contracts/Ask.sol
@@ -19,7 +19,7 @@ contract Ask is INamed, IVersioned, ContractStatus, IInitializable {
     //   2.0.0 — v4.0.0 storage consolidation: reads V10 canonical stake
     //           (`ConvictionStakingStorage.getNodeStakeV10`) so post-migration
     //           V10 nodes are not silently filtered out of the active set.
-    string private constant _VERSION = "2.0.0";
+    string private constant _VERSION = "10.0.2";
 
     uint256 public constant ASK_SCALING_FACTOR = 1e18;
 

--- a/packages/evm-module/contracts/ContextGraphs.sol
+++ b/packages/evm-module/contracts/ContextGraphs.sol
@@ -54,7 +54,7 @@ import {KnowledgeAssetsLib} from "./libraries/KnowledgeAssetsLib.sol";
  */
 contract ContextGraphs is INamed, IVersioned, ContractStatus, IInitializable {
     string private constant _NAME = "ContextGraphs";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     ContextGraphStorage public contextGraphStorage;
 

--- a/packages/evm-module/contracts/DKGPublishingConvictionNFT.sol
+++ b/packages/evm-module/contracts/DKGPublishingConvictionNFT.sol
@@ -89,7 +89,7 @@ contract DKGPublishingConvictionNFT is INamed, IVersioned, HubDependent, IInitia
     //           mint counter + TRAC-pull only. Public selectors are
     //           preserved so `IDKGPublishingConvictionNFT` consumers
     //           (`KnowledgeAssetsV10`, `ContextGraphs`) need no changes.
-    string private constant _VERSION = "3.0.0";
+    string private constant _VERSION = "10.0.2";
 
     uint256 public constant BPS_DENOMINATOR = 10_000;
 

--- a/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
+++ b/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
@@ -89,7 +89,7 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
     //           points and events.
     //         * L8 — `identityId != 0` guard added on mint paths so
     //           ambiguous "zero-node" mints fail fast at the wrapper.
-    string private constant _VERSION = "1.2.0";
+    string private constant _VERSION = "10.0.2";
 
     // ========================================================================
     // Constants

--- a/packages/evm-module/contracts/Identity.sol
+++ b/packages/evm-module/contracts/Identity.sol
@@ -23,7 +23,7 @@ contract Identity is INamed, IVersioned, ContractStatus, IInitializable {
     //           error. `OperationalKeyTaken(key)` remains reserved for
     //           the cross-identity case. Dropped the dead `KeyIsEmpty()`
     //           pre-check (impossible after the zero-address check).
-    string private constant _VERSION = "1.1.0";
+    string private constant _VERSION = "10.0.2";
 
     IdentityStorage public identityStorage;
 

--- a/packages/evm-module/contracts/KnowledgeAssetsV10.sol
+++ b/packages/evm-module/contracts/KnowledgeAssetsV10.sol
@@ -98,7 +98,7 @@ contract KnowledgeAssetsV10 is INamed, IVersioned, ContractStatus, IInitializabl
     // storage slot at the end of the inheritance chain; KAV10 owns its
     // slots below the inherited chain and V10 deploys are redeploy +
     // reinit, so no storage-layout migration is required.
-    string private constant _VERSION = "10.1.1";
+    string private constant _VERSION = "10.0.2";
 
     // --- V10 publish input (grouped to bypass the 16-arg stack limit) ---
 

--- a/packages/evm-module/contracts/Profile.sol
+++ b/packages/evm-module/contracts/Profile.sol
@@ -63,7 +63,7 @@ contract Profile is INamed, IVersioned, ContractStatus, IInitializable {
     // semantics make the prior "fail-fast at the entrypoint" rationale
     // moot. `OperationalWalletAlreadyPrimary` and
     // `OperationalWalletEqualsAdmin` are dropped from `IdentityLib`.
-    string private constant _VERSION = "1.4.3";
+    string private constant _VERSION = "10.0.2";
 
     Ask public askContract;
     Identity public identityContract;

--- a/packages/evm-module/contracts/PublishingConviction.sol
+++ b/packages/evm-module/contracts/PublishingConviction.sol
@@ -92,7 +92,7 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
     //           and the active-sink reward distribution. Twin of KAV10
     //           10.1.1's `tokenAmount > 0` floor, which protects only
     //           the direct-spend branch.
-    string private constant _VERSION = "1.0.1";
+    string private constant _VERSION = "10.0.2";
 
     uint256 public constant BPS_DENOMINATOR = 10_000;
     /// @notice EpochStorage shard ID for the staker reward pool. Mirrors

--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -26,7 +26,7 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     string private constant _NAME = "RandomSampling";
-    string private constant _VERSION = "1.1.0";
+    string private constant _VERSION = "10.0.2";
     uint256 public constant SCALE18 = 1e18;
 
     /// @notice Maximum number of in-CG resamples when the picker hits an

--- a/packages/evm-module/contracts/ShardingTable.sol
+++ b/packages/evm-module/contracts/ShardingTable.sol
@@ -23,7 +23,7 @@ contract ShardingTable is INamed, IVersioned, ContractStatus, IInitializable {
     // `019_deploy_sharding_table.ts` that referenced `migrateOldShardingTable`
     // is removed in the same PR (the function it called no longer exists,
     // so the branch was already unreachable on V10 deploys).
-    string private constant _VERSION = "2.0.0";
+    string private constant _VERSION = "10.0.2";
 
     ProfileStorage public profileStorage;
     ShardingTableStorage public shardingTableStorage;

--- a/packages/evm-module/contracts/StakingKPI.sol
+++ b/packages/evm-module/contracts/StakingKPI.sol
@@ -29,7 +29,7 @@ contract StakingKPI is INamed, IVersioned, ContractStatus, IInitializable {
     //           simulator) remain V8 stake-base keyed; they are accurate for
     //           V8 archive queries but return 0 for V10 nodes. A V10
     //           tokenId-keyed equivalent is a separate follow-up PR.
-    string private constant _VERSION = "2.0.0";
+    string private constant _VERSION = "10.0.2";
     uint256 public constant SCALE18 = 1e18;
 
     IdentityStorage public identityStorage;

--- a/packages/evm-module/contracts/StakingV10.sol
+++ b/packages/evm-module/contracts/StakingV10.sol
@@ -128,7 +128,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
     //             new `expiryShortenedBy` arg (CSS v4.1.0). `stake` always
     //             passes 0; `_convertToNFT` passes 0 except for eligible
     //             6m/12m migrants.
-    string private constant _VERSION = "3.1.0";
+    string private constant _VERSION = "10.0.2";
 
     // ========================================================================
     // Constants

--- a/packages/evm-module/contracts/storage/AskStorage.sol
+++ b/packages/evm-module/contracts/storage/AskStorage.sol
@@ -10,7 +10,7 @@ import {ContractStatus} from "../abstract/ContractStatus.sol";
 
 contract AskStorage is INamed, IVersioned, ContractStatus, IInitializable {
     string private constant _NAME = "AskStorage";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     ParametersStorage public parametersStorage;
 

--- a/packages/evm-module/contracts/storage/ContextGraphStorage.sol
+++ b/packages/evm-module/contracts/storage/ContextGraphStorage.sol
@@ -41,7 +41,7 @@ import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/
  */
 contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
     string private constant _NAME = "ContextGraphStorage";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     // -----------------------------------------------------------------------
     // Bounds on participant list — anti-griefing cap.

--- a/packages/evm-module/contracts/storage/ContextGraphValueStorage.sol
+++ b/packages/evm-module/contracts/storage/ContextGraphValueStorage.sol
@@ -32,7 +32,7 @@ import {IVersioned} from "../interfaces/IVersioned.sol";
  */
 contract ContextGraphValueStorage is INamed, IVersioned, HubDependent {
     string private constant _NAME = "ContextGraphValueStorage";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     event CGValueAddedForEpochRange(
         uint256 indexed cgId,

--- a/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
@@ -134,7 +134,7 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     //             the 60 days preceding V10 launch. Validated against
     //             `_tierDuration(lockTier)` and the current block
     //             timestamp; tier-0 callers MUST pass 0.
-    string private constant _VERSION = "4.1.0";
+    string private constant _VERSION = "10.0.2";
 
     // Multiplier scale, matches DKGStakingConvictionNFT._convictionMultiplier
     // (returns 1e18-scaled values so fractional tiers like 1.5x and 3.5x

--- a/packages/evm-module/contracts/storage/EpochStorage.sol
+++ b/packages/evm-module/contracts/storage/EpochStorage.sol
@@ -9,7 +9,7 @@ import {IVersioned} from "../interfaces/IVersioned.sol";
 
 contract EpochStorage is INamed, IVersioned, HubDependent {
     string private constant _NAME = "EpochStorage";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     event EpochProducedKnowledgeValueAdded(uint72 indexed identityId, uint256 indexed epoch, uint96 knowledgeValue);
     event TokensAddedToEpochRange(

--- a/packages/evm-module/contracts/storage/IdentityStorage.sol
+++ b/packages/evm-module/contracts/storage/IdentityStorage.sol
@@ -14,7 +14,7 @@ contract IdentityStorage is IERC734Extended, INamed, IVersioned, HubDependent {
     using ByteArr for bytes32[];
 
     string private constant _NAME = "IdentityStorage";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     uint72 public lastIdentityId;
 

--- a/packages/evm-module/contracts/storage/KnowledgeCollectionStorage.sol
+++ b/packages/evm-module/contracts/storage/KnowledgeCollectionStorage.sol
@@ -76,7 +76,7 @@ contract KnowledgeCollectionStorage is
     );
 
     string private constant _NAME = "KnowledgeCollectionStorage";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     uint256 public immutable KNOWLEDGE_COLLECTION_MAX_SIZE;
 

--- a/packages/evm-module/contracts/storage/ParametersStorage.sol
+++ b/packages/evm-module/contracts/storage/ParametersStorage.sol
@@ -11,7 +11,7 @@ contract ParametersStorage is INamed, IVersioned, HubDependent {
     event ParameterChanged(string parameterName, uint256 parameterValue);
 
     string private constant _NAME = "ParametersStorage";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     uint96 public minimumStake;
     uint96 public maximumStake;

--- a/packages/evm-module/contracts/storage/ProfileStorage.sol
+++ b/packages/evm-module/contracts/storage/ProfileStorage.sol
@@ -13,7 +13,7 @@ contract ProfileStorage is INamed, IVersioned, HubDependent {
     // (RFC 04 v0.3 / Issue #461). New mapping reads on existing keys return
     // false for the new field. Multiaddrs were briefly added on a prior
     // revision but are deliberately not stored on Profile (RFC 04 §5.2).
-    string private constant _VERSION = "1.1.0";
+    string private constant _VERSION = "10.0.2";
 
     event ProfileCreated(uint72 indexed identityId, string nodeName, bytes nodeId, uint16 initialOperatorFee);
     event ProfileDeleted(uint72 indexed identityId, bytes nodeId);

--- a/packages/evm-module/contracts/storage/PublishingConvictionStorage.sol
+++ b/packages/evm-module/contracts/storage/PublishingConvictionStorage.sol
@@ -95,7 +95,7 @@ contract PublishingConvictionStorage is INamed, IVersioned, HubDependent, IIniti
     string private constant _NAME = "PublishingConvictionStorage";
     // 1.0.0 — initial split-out from `DKGPublishingConvictionNFT` v2.0.0.
     //         Identical state shape; no semantic changes.
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     /// @notice Default cap on registered agents per account, applied on
     ///         first `initialize()` so a fresh deploy has a sane bound

--- a/packages/evm-module/contracts/storage/RandomSamplingStorage.sol
+++ b/packages/evm-module/contracts/storage/RandomSamplingStorage.sol
@@ -33,7 +33,7 @@ contract RandomSamplingStorage is INamed, IVersioned, IInitializable, ContractSt
     //           and silently corrupt claim math. Tests now drive state
     //           through `appendCheckpoint`.
     //         * `getEpochFirstScorePerStake` retired (always 0 under D26).
-    string private constant _VERSION = "3.0.0";
+    string private constant _VERSION = "10.0.2";
     uint8 public constant CHUNK_BYTE_SIZE = 32;
     Chronos public chronos;
 

--- a/packages/evm-module/contracts/storage/ShardingTableStorage.sol
+++ b/packages/evm-module/contracts/storage/ShardingTableStorage.sol
@@ -9,7 +9,7 @@ import {ShardingTableLib} from "../libraries/ShardingTableLib.sol";
 
 contract ShardingTableStorage is INamed, IVersioned, HubDependent {
     string private constant _NAME = "ShardingTableStorage";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     event NodesCountIncremented(uint72 newCount);
     event NodesCountDecremented(uint72 newCount);

--- a/packages/evm-module/contracts/storage/StakingStorage.sol
+++ b/packages/evm-module/contracts/storage/StakingStorage.sol
@@ -12,7 +12,7 @@ contract StakingStorage is INamed, IVersioned, Guardian {
     using EnumerableSetLib for EnumerableSetLib.Uint256Set;
 
     string private constant _NAME = "StakingStorage";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     event TotalStakeUpdated(uint96 totalStake);
     event NodeStakeUpdated(uint72 indexed identityId, uint96 stake);

--- a/packages/evm-module/contracts/storage/V8MigrationEligibility.sol
+++ b/packages/evm-module/contracts/storage/V8MigrationEligibility.sol
@@ -63,7 +63,7 @@ import {IVersioned} from "../interfaces/IVersioned.sol";
  */
 contract V8MigrationEligibility is INamed, IVersioned, HubDependent {
     string private constant _NAME = "V8MigrationEligibility";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     /// @notice One-shot lock. While `false`, HubOwner may grow the
     ///         registry. Once `true`, the registry is immutable.

--- a/packages/evm-module/contracts/storage/WhitelistStorage.sol
+++ b/packages/evm-module/contracts/storage/WhitelistStorage.sol
@@ -8,7 +8,7 @@ import {IVersioned} from "../interfaces/IVersioned.sol";
 
 contract WhitelistStorage is INamed, IVersioned, HubDependent {
     string private constant _NAME = "WhitelistStorage";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "10.0.2";
 
     event AddressWhitelisted(address indexed addr);
     event AddressBlacklisted(address indexed addr);

--- a/packages/evm-module/test/integration/RandomSampling.test.ts
+++ b/packages/evm-module/test/integration/RandomSampling.test.ts
@@ -360,7 +360,7 @@ describe.skip('@integration RandomSampling (OBSOLETE: V8 stake pipeline)', () =>
       const name = await RandomSampling.name();
       const version = await RandomSampling.version();
       expect(name).to.equal('RandomSampling');
-      expect(version).to.equal('1.0.0');
+      expect(version).to.equal('10.0.2');
     });
 
     it('Should have the correct W1 after initialization', async () => {

--- a/packages/evm-module/test/unit/ContextGraphValueStorage.test.ts
+++ b/packages/evm-module/test/unit/ContextGraphValueStorage.test.ts
@@ -46,7 +46,7 @@ describe('@unit ContextGraphValueStorage', () => {
 
   it('Should have correct name and version', async () => {
     expect(await CGV.name()).to.equal('ContextGraphValueStorage');
-    expect(await CGV.version()).to.equal('1.0.0');
+    expect(await CGV.version()).to.equal('10.0.2');
   });
 
   it('Single-epoch publish: value lives in start epoch, zero after', async () => {

--- a/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
@@ -78,7 +78,7 @@ describe('@unit ConvictionStakingStorage', () => {
     expect(await ConvictionStakingStorage.name()).to.equal('ConvictionStakingStorage');
     // v4.1.0 — `createPosition` accepts the `expiryShortenedBy` arg used
     // by `StakingV10._convertToNFT` for the V8→V10 conviction credit.
-    expect(await ConvictionStakingStorage.version()).to.equal('4.1.0');
+    expect(await ConvictionStakingStorage.version()).to.equal('10.0.2');
   });
 
   // ------------------------------------------------------------

--- a/packages/evm-module/test/unit/EpochStorage.test.ts
+++ b/packages/evm-module/test/unit/EpochStorage.test.ts
@@ -39,7 +39,7 @@ describe('@unit EpochStorage', () => {
 
   it('Should have correct name and version', async () => {
     expect(await EpochStorage.name()).to.equal('EpochStorage');
-    expect(await EpochStorage.version()).to.equal('1.0.0');
+    expect(await EpochStorage.version()).to.equal('10.0.2');
   });
 
   it('Add knowledge value for single epoch, verify totals and max', async () => {

--- a/packages/evm-module/test/unit/Identity.test.ts
+++ b/packages/evm-module/test/unit/Identity.test.ts
@@ -84,8 +84,8 @@ describe('@unit Identity contract', function () {
     expect(await Identity.name()).to.equal('Identity');
   });
 
-  it('The contract is version "1.1.0"', async () => {
-    expect(await Identity.version()).to.equal('1.1.0');
+  it('The contract is version "10.0.2"', async () => {
+    expect(await Identity.version()).to.equal('10.0.2');
   });
 
   it('Create an identity as a contract, expect to pass', async () => {

--- a/packages/evm-module/test/unit/IdentityStorage.test.ts
+++ b/packages/evm-module/test/unit/IdentityStorage.test.ts
@@ -63,8 +63,8 @@ describe('@unit IdentityStorage contract', function () {
     expect(await IdentityStorage.name()).to.equal('IdentityStorage');
   });
 
-  it('The contract is version "1.0.0"', async () => {
-    expect(await IdentityStorage.version()).to.equal('1.0.0');
+  it('The contract is version "10.0.2"', async () => {
+    expect(await IdentityStorage.version()).to.equal('10.0.2');
   });
 
   it('Get the identity id for operational key, expect to pass', async () => {

--- a/packages/evm-module/test/unit/Profile.test.ts
+++ b/packages/evm-module/test/unit/Profile.test.ts
@@ -105,8 +105,8 @@ describe('@unit Profile contract', function () {
     expect(await Profile.name()).to.equal('Profile');
   });
 
-  it('The contract is version "1.4.3"', async () => {
-    expect(await Profile.version()).to.equal('1.4.3');
+  it('The contract is version "10.0.2"', async () => {
+    expect(await Profile.version()).to.equal('10.0.2');
   });
 
   it('Create a profile with valid inputs, expect to pass', async () => {

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -253,7 +253,7 @@ describe('@unit RandomSampling', () => {
 
   describe('version()', () => {
     it('Should return correct version', async () => {
-      expect(await RandomSampling.version()).to.equal('1.1.0');
+      expect(await RandomSampling.version()).to.equal('10.0.2');
     });
   });
 

--- a/packages/evm-module/test/unit/RandomSamplingStorage.test.ts
+++ b/packages/evm-module/test/unit/RandomSamplingStorage.test.ts
@@ -514,7 +514,7 @@ describe('@unit RandomSamplingStorage', function () {
       expect(await RandomSamplingStorage.name()).to.equal(
         'RandomSamplingStorage',
       );
-      expect(await RandomSamplingStorage.version()).to.equal('3.0.0');
+      expect(await RandomSamplingStorage.version()).to.equal('10.0.2');
     });
 
     it('Should set the initial parameters correctly', async function () {

--- a/packages/evm-module/test/unit/ShardingTable.test.ts
+++ b/packages/evm-module/test/unit/ShardingTable.test.ts
@@ -197,7 +197,7 @@ describe('@unit ShardingTable contract', function () {
     const version = await ShardingTable.version();
 
     expect(name).to.equal('ShardingTable');
-    expect(version).to.equal('2.0.0');
+    expect(version).to.equal('10.0.2');
   });
 
   // v2.0.0 — `migrationPeriodEnd` (V8→V9 carry-over) was removed along

--- a/packages/evm-module/test/unit/WhitelistStorage.test.ts
+++ b/packages/evm-module/test/unit/WhitelistStorage.test.ts
@@ -43,8 +43,8 @@ describe('@unit WhitelistStorage contract', function () {
     expect(await WhitelistStorage.name()).to.equal('WhitelistStorage');
   });
 
-  it('The contract is version "1.0.0"', async () => {
-    expect(await WhitelistStorage.version()).to.equal('1.0.0');
+  it('The contract is version "10.0.2"', async () => {
+    expect(await WhitelistStorage.version()).to.equal('10.0.2');
   });
 
   it('Address is not whitelisted; expect to be false', async () => {

--- a/packages/evm-module/test/v10-migration-conviction-credit.test.ts
+++ b/packages/evm-module/test/v10-migration-conviction-credit.test.ts
@@ -182,7 +182,7 @@ describe('@integration V8→V10 migration conviction credit', function () {
   describe('V8MigrationEligibility lifecycle', () => {
     it('Has the expected name and version', async () => {
       expect(await RegistryContract.name()).to.equal('V8MigrationEligibility');
-      expect(await RegistryContract.version()).to.equal('1.0.0');
+      expect(await RegistryContract.version()).to.equal('10.0.2');
     });
 
     it('setEligibleBatch records pairs and bumps the counter, idempotently', async () => {


### PR DESCRIPTION
## Summary
Unifies the EVM contract suite under a single product-aligned version string **`10.0.2`** (V10), replacing the divergent per-contract histories that motivated this cleanup.

- `_VERSION = "10.0.2"` on **all 27 deployable app contracts** (logic + storage).
- Includes the two rc.12 functional changes that shipped **without a version bump** — `RandomSampling` (re-enables curated-CG random sampling, RFC-39 Phase B) and `DKGStakingConvictionNFT` (CEI: burn before `stakingV10.withdraw`). Without a bump these would be silently skipped by a version-driven redeploy list.
- **`Hub` (1.0.0) and `Token` left untouched** — preserved across the clean testnet redeploy (stable addresses + TRAC balances).
- `archive/` contracts left untouched (not deployed).
- Updated `version()` unit/integration assertions to `10.0.2`.

## Safety note
`version()` is recorded as deployment metadata only — it is **never compared** on-chain or by the deploy framework (`isDeployed()` keys off the `deployed` flag in the deployments JSON, not the version). So realigning numerically-higher versions (e.g. `KnowledgeAssetsV10` 10.1.1 → 10.0.2) *down* to 10.0.2 is cosmetic and safe.

## Deploy implication
Every app contract now differs from the currently-deployed testnet, which is consistent with the planned **clean testnet redeploy** (redeploy everything except Hub + Token, re-register in the existing Hub).

## Test plan
- [x] `npx hardhat compile` — 31 files compile clean
- [ ] `version()` unit tests pass in CI

Made with [Cursor](https://cursor.com)