### PR TITLE
fix(storage,query): unblock large Blazegraph publishes + EPCIS events scoped query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: CI
 
 # Trigger rules — chosen so the same SHA is never tested twice:
-#   * push to main/v10-rc : always runs (merge-gate safety net, full
-#     Solidity coverage, required status checks for protected branches).
+#   * push to main/v10-rc/release/rc.12 : always runs (merge-gate safety
+#     net, full Solidity coverage, required status checks for protected
+#     branches). `release/rc.12` is the active release-stabilisation
+#     branch that feature/fix work currently lands on (and where bugs
+#     are reproduced/fixed), so it gets the same gate as main/v10-rc —
+#     otherwise the Node test suites only run once rc.12 merges upward.
 #   * pull_request         : runs on every open/synchronize/reopen event.
 #   * No `push` trigger on feature branches (e.g. `test/**`). When a PR
 #     is open, the `pull_request` event already covers every new commit;
@@ -10,9 +14,9 @@ name: CI
 #     or trigger the workflow manually via `workflow_dispatch`.
 on:
   push:
-    branches: [main, v10-rc]
+    branches: [main, v10-rc, release/rc.12]
   pull_request:
-    branches: [main, v10-rc]
+    branches: [main, v10-rc, release/rc.12]
   workflow_dispatch:
 
 concurrency:
@@ -258,6 +262,75 @@ jobs:
         run: pnpm --filter @origintrail-official/dkg-storage test
       - name: "Chain unit (46 tests)"
         run: pnpm --filter @origintrail-official/dkg-chain test
+
+  # ------------------------------------------------------------------
+  # Tornado Blazegraph integration lane — runs the storage adapter's
+  # `*.integration.test.ts` against a REAL Blazegraph (Docker service
+  # container), with no mocks. The mocked `blazegraph.unit.test.ts`
+  # (in the tornado-core lane) asserts the wire format; this lane proves
+  # the end-to-end behaviour the mocks cannot:
+  #
+  #   * Large publishes used to fail on Blazegraph with HTTP 400
+  #     "Unable to parse form content". A publish issues a single large
+  #     DELETE DATA over the full quad set; the old adapter sent it as
+  #     URL-encoded form data (`update=…`), which Jetty's form parser
+  #     caps at `maxFormContentSize` (~200 KB on the stock image). The
+  #     fix switched the transport to a W3C SPARQL 1.1 direct POST
+  #     (`application/sparql-update` / `application/sparql-query`), which
+  #     is not form parsed and so has no size cap.
+  #
+  # The image is the same stock `lyrasis/blazegraph:2.1.5` our node-setup
+  # wizard provisions, so this reproduces exactly what an operator runs.
+  # The integration suite is gated on BLAZEGRAPH_TEST_URL — without it the
+  # tests `describe.skipIf`-skip, so local `pnpm test` needs no Docker.
+  # ------------------------------------------------------------------
+  tornado-blazegraph:
+    name: "Tornado: storage Blazegraph integration (live server)"
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      blazegraph:
+        image: lyrasis/blazegraph:2.1.5
+        ports:
+          - 9999:8080
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: build-outputs
+          path: /tmp
+      - name: Restore build outputs
+        run: tar -xzf /tmp/build-outputs.tgz
+
+      - name: Wait for Blazegraph to be ready
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null "http://127.0.0.1:9999/bigdata/status"; then
+              echo "Blazegraph ready after ${i} attempt(s)."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Blazegraph did not become ready within 120s"
+          exit 1
+
+      - name: "Storage Blazegraph integration tests (no mocks)"
+        env:
+          # Stock image ships the default `kb` namespace; that's all the
+          # adapter needs (it isolates per-test via unique GRAPH IRIs).
+          BLAZEGRAPH_TEST_URL: http://127.0.0.1:9999/bigdata/namespace/kb/sparql
+        run: pnpm --filter @origintrail-official/dkg-storage exec vitest run test/blazegraph.integration.test.ts
 
   # ------------------------------------------------------------------
   # Tornado publisher lane — sharded across 4 parallel runners.

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -9146,6 +9146,13 @@ export class DKGAgent {
       includeSharedMemory?: boolean;
       /** @deprecated Use includeSharedMemory */
       includeWorkspace?: boolean;
+      /**
+       * Opt-in: allow the scoped query to reference the context graph's own
+       * `_private` partition (excluded from the scope guard's allow-set by
+       * default). Used by the EPCIS events query, whose SPARQL always names
+       * `<cg>/_private`. Does not widen access for other callers.
+       */
+      includePrivate?: boolean;
       operationCtx?: OperationContext;
       view?: GetView;
       agentAddress?: string;
@@ -9365,6 +9372,7 @@ export class DKGAgent {
       excludeGraphPrefixes,
       graphSuffix: opts.graphSuffix,
       includeSharedMemory: opts.includeSharedMemory,
+      includePrivate: opts.includePrivate,
       view: opts.view,
       agentAddress: agentAddressStr ?? (opts.view === 'working-memory' ? this.peerId : undefined),
       verifiedGraph: opts.verifiedGraph,

--- a/packages/cli/src/daemon/routes/epcis.ts
+++ b/packages/cli/src/daemon/routes/epcis.ts
@@ -438,7 +438,7 @@ export async function handleEpcisRoutes(ctx: RequestContext): Promise<void> {
     if (!sg.ok) return jsonResponse(res, sg.status, sg.body);
 
     const epcisQueryEngine = {
-      query: (sparql: string, opts?: { contextGraphId?: string }) =>
+      query: (sparql: string, opts?: { contextGraphId?: string; includePrivate?: boolean }) =>
         agent.query(sparql, opts),
     };
     try {

--- a/packages/cli/src/daemon/routes/epcis.ts
+++ b/packages/cli/src/daemon/routes/epcis.ts
@@ -438,8 +438,15 @@ export async function handleEpcisRoutes(ctx: RequestContext): Promise<void> {
     if (!sg.ok) return jsonResponse(res, sg.status, sg.body);
 
     const epcisQueryEngine = {
-      query: (sparql: string, opts?: { contextGraphId?: string; includePrivate?: boolean }) =>
-        agent.query(sparql, opts),
+      query: (
+        sparql: string,
+        opts?: {
+          contextGraphId?: string;
+          subGraphName?: string;
+          graphSuffix?: '_shared_memory';
+          includePrivate?: boolean;
+        },
+      ) => agent.query(sparql, opts),
     };
     try {
       const result = await handleEventsQuery(searchParams, {

--- a/packages/cli/test/epcis-route-readiness.test.ts
+++ b/packages/cli/test/epcis-route-readiness.test.ts
@@ -336,7 +336,11 @@ describe('EPCIS events query route — per-request CG + sub-graph', () => {
     expect(ctx.res.statusCode).toBe(200);
     expect(calls).toHaveLength(1);
     expect(calls[0].sparql).toContain('GRAPH <did:dkg:context-graph:epcis-test>');
-    expect(calls[0].opts).toEqual({ contextGraphId: 'epcis-test' });
+    // The EPCIS events query references the CG's `<cg>/_private` partition, so
+    // the route must opt into private-graph access via `includePrivate: true`;
+    // otherwise the query engine's scope guard rejects it (see #789 follow-up:
+    // packages/query/test/scoped-private-graph.test.ts).
+    expect(calls[0].opts).toEqual({ contextGraphId: 'epcis-test', includePrivate: true });
   });
 
   it('per-request contextGraphId overrides config and reaches the SPARQL builder', async () => {
@@ -349,7 +353,7 @@ describe('EPCIS events query route — per-request CG + sub-graph', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].sparql).toContain('GRAPH <did:dkg:context-graph:per-request-cg>');
     expect(calls[0].sparql).not.toContain('GRAPH <did:dkg:context-graph:epcis-test>');
-    expect(calls[0].opts).toEqual({ contextGraphId: 'per-request-cg' });
+    expect(calls[0].opts).toEqual({ contextGraphId: 'per-request-cg', includePrivate: true });
   });
 
   it('per-request subGraphName reaches the SPARQL builder for both public and private graphs', async () => {

--- a/packages/epcis/src/handlers.ts
+++ b/packages/epcis/src/handlers.ts
@@ -174,7 +174,15 @@ export async function handleEventsQuery(
     { ...params, subGraphName: config.subGraphName, limit: perPage + 1, offset },
     config.contextGraphId,
   );
-  const result = await config.queryEngine.query(sparql, { contextGraphId: config.contextGraphId });
+  // The EPCIS query always references the context graph's `_private`
+  // partition (the branch that surfaces private-anchored events), so the
+  // scoped query must opt into private-graph access. Without this the
+  // engine's scope guard rejects every events query with
+  // "GRAPH <…/_private> is outside the allowed graph set".
+  const result = await config.queryEngine.query(sparql, {
+    contextGraphId: config.contextGraphId,
+    includePrivate: true,
+  });
 
   const hasMore = result.bindings.length > perPage;
   const bindings = hasMore ? result.bindings.slice(0, perPage) : result.bindings;

--- a/packages/epcis/src/handlers.ts
+++ b/packages/epcis/src/handlers.ts
@@ -174,13 +174,24 @@ export async function handleEventsQuery(
     { ...params, subGraphName: config.subGraphName, limit: perPage + 1, offset },
     config.contextGraphId,
   );
-  // The EPCIS query always references the context graph's `_private`
-  // partition (the branch that surfaces private-anchored events), so the
-  // scoped query must opt into private-graph access. Without this the
-  // engine's scope guard rejects every events query with
-  // "GRAPH <…/_private> is outside the allowed graph set".
+  // The engine's scope guard rejects any explicit GRAPH IRI outside the
+  // allow-set it derives from the query options, so the options MUST match
+  // exactly the graphs `buildEpcisQuery` references for this route:
+  //   - `includePrivate`        → the `<cg>[/<sub>]/_private` partition the
+  //                               private-anchored-events branch always names.
+  //   - `subGraphName`          → reads `<cg>/<sub>` (finalized) /
+  //                               `<cg>/<sub>/_shared_memory` (SWM) plus the
+  //                               sub-graph private/meta graphs.
+  //   - `graphSuffix:'_shared_memory'` (finalized=false) → reads the SWM
+  //                               partition (`…/_shared_memory[_meta]`) instead
+  //                               of the canonical data graph.
+  // Omitting any of these makes the guard reject the query with
+  // "GRAPH <…> is outside the allowed graph set" (it fails for every
+  // sub-graph or non-finalized request, on every store backend).
   const result = await config.queryEngine.query(sparql, {
     contextGraphId: config.contextGraphId,
+    subGraphName: config.subGraphName,
+    graphSuffix: params.finalized === false ? '_shared_memory' : undefined,
     includePrivate: true,
   });
 

--- a/packages/epcis/src/types.ts
+++ b/packages/epcis/src/types.ts
@@ -95,7 +95,16 @@ export interface EpcisQueryParams {
 export interface QueryEngine {
   query(
     sparql: string,
-    opts?: { contextGraphId?: string },
+    opts?: {
+      contextGraphId?: string;
+      /**
+       * Allow the scoped query to reference the context graph's own
+       * `_private` partition. The EPCIS events query always references
+       * `<cg>/_private`, so this must be set or the engine's scope guard
+       * rejects the query.
+       */
+      includePrivate?: boolean;
+    },
   ): Promise<{ bindings: Record<string, string>[] }>;
 }
 

--- a/packages/epcis/src/types.ts
+++ b/packages/epcis/src/types.ts
@@ -98,10 +98,22 @@ export interface QueryEngine {
     opts?: {
       contextGraphId?: string;
       /**
+       * Sub-graph name within the context graph. Must match the sub-graph
+       * the query was built for so the engine's scope guard admits the
+       * `<cg>/<sub>` data graph (and the sub-graph private/meta graphs).
+       */
+      subGraphName?: string;
+      /**
+       * Route the scoped read to the shared-memory partition
+       * (`<cg>[/<sub>]/_shared_memory`). Set for `finalized=false` queries,
+       * which read non-finalized (SWM) events.
+       */
+      graphSuffix?: '_shared_memory';
+      /**
        * Allow the scoped query to reference the context graph's own
        * `_private` partition. The EPCIS events query always references
-       * `<cg>/_private`, so this must be set or the engine's scope guard
-       * rejects the query.
+       * `<cg>[/<sub>]/_private`, so this must be set or the engine's scope
+       * guard rejects the query.
        */
       includePrivate?: boolean;
     },

--- a/packages/epcis/test/events-query.test.ts
+++ b/packages/epcis/test/events-query.test.ts
@@ -80,7 +80,9 @@ describe('handleEventsQuery', () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0].sparql).toContain('GRAPH <did:dkg:context-graph:test-cg>');
-    expect(calls[0].opts).toEqual({ contextGraphId: CONTEXT_GRAPH_ID });
+    // The events query references the CG's `_private` partition, so the
+    // engine must be told to allow it (else the scope guard rejects it).
+    expect(calls[0].opts).toEqual({ contextGraphId: CONTEXT_GRAPH_ID, includePrivate: true });
   });
 
   it('returns multiple events in eventList', async () => {

--- a/packages/epcis/test/events-query.test.ts
+++ b/packages/epcis/test/events-query.test.ts
@@ -567,6 +567,16 @@ describe('handleEventsQuery — per-request sub-graph', () => {
     expect(calls[0].sparql).toContain('GRAPH <did:dkg:context-graph:test-cg/research/_private>');
     expect(calls[0].sparql).not.toContain('GRAPH <did:dkg:context-graph:test-cg>');
     expect(calls[0].sparql).not.toContain('GRAPH <did:dkg:context-graph:test-cg/_private>');
+    // Bug 3: the handler MUST thread `subGraphName` into the engine options so
+    // the scope guard admits `<cg>/<sub>` (+ `<cg>/<sub>/_private`). Without it
+    // every sub-graph events request fails with "Scoped query violation".
+    // Finalized route → no graphSuffix (reads the canonical data partition).
+    expect(calls[0].opts).toMatchObject({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: 'research',
+      includePrivate: true,
+    });
+    expect(calls[0].opts.graphSuffix).toBeUndefined();
   });
 
   it('threads subGraphName into SPARQL graph URIs (finalized=false SWM partition)', async () => {
@@ -586,6 +596,15 @@ describe('handleEventsQuery — per-request sub-graph', () => {
     expect(calls[0].sparql).toContain('GRAPH <did:dkg:context-graph:test-cg/research/_private>');
     expect(calls[0].sparql).not.toContain('GRAPH <did:dkg:context-graph:test-cg/_shared_memory>');
     expect(calls[0].sparql).not.toContain('GRAPH <did:dkg:context-graph:test-cg/_private>');
+    // Bug 3: finalized=false routes the read to the SWM partition, so the
+    // handler must thread BOTH `subGraphName` and `graphSuffix:'_shared_memory'`
+    // (else the guard rejects `<cg>/<sub>/_shared_memory[_meta]`).
+    expect(calls[0].opts).toMatchObject({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      subGraphName: 'research',
+      graphSuffix: '_shared_memory',
+      includePrivate: true,
+    });
   });
 
   it('falls back to root partition when subGraphName is omitted', async () => {
@@ -603,5 +622,29 @@ describe('handleEventsQuery — per-request sub-graph', () => {
     expect(calls[0].sparql).toContain('GRAPH <did:dkg:context-graph:test-cg>');
     expect(calls[0].sparql).toContain('GRAPH <did:dkg:context-graph:test-cg/_private>');
     expect(calls[0].sparql).not.toContain('test-cg/research');
+    // Finalized canonical root route: no sub-graph, no SWM suffix.
+    expect(calls[0].opts).toMatchObject({ contextGraphId: CONTEXT_GRAPH_ID, includePrivate: true });
+    expect(calls[0].opts.subGraphName).toBeUndefined();
+    expect(calls[0].opts.graphSuffix).toBeUndefined();
+  });
+
+  it('threads graphSuffix for finalized=false on the root partition (no sub-graph)', async () => {
+    const { engine, calls } = createTrackingQueryEngine([makeBindings()]);
+
+    await handleEventsQuery(
+      new URLSearchParams('finalized=false&eventType=ObjectEvent'),
+      { contextGraphId: CONTEXT_GRAPH_ID, queryEngine: engine, basePath: BASE_PATH },
+    );
+
+    expect(calls[0].sparql).toContain('GRAPH <did:dkg:context-graph:test-cg/_shared_memory>');
+    // Bug 3: SWM route on the root CG still needs the graphSuffix or the guard
+    // rejects `<cg>/_shared_memory` (only the canonical `<cg>` is allowed
+    // otherwise).
+    expect(calls[0].opts).toMatchObject({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      graphSuffix: '_shared_memory',
+      includePrivate: true,
+    });
+    expect(calls[0].opts.subGraphName).toBeUndefined();
   });
 });

--- a/packages/graph-viz/src/data-sources/remote-sparql-source.ts
+++ b/packages/graph-viz/src/data-sources/remote-sparql-source.ts
@@ -113,14 +113,26 @@ export class RemoteSparqlSource implements GraphDataSource {
     const timeout = setTimeout(() => controller.abort(), this._config.timeoutMs);
 
     try {
+      // W3C SPARQL 1.1 Protocol "query via POST directly" (§2.1.3): send the
+      // raw query as the request body with `Content-Type:
+      // application/sparql-query`, NOT URL-encoded form data.
+      //
+      // The old `application/x-www-form-urlencoded` + `query=<encoded>` form
+      // hits Jetty's default 200 KB form-content limit on Blazegraph
+      // (`UTFDataFormatException` / HTTP 400 "Unable to parse form content")
+      // for large queries — e.g. a CONSTRUCT/SELECT carrying a big `VALUES`
+      // block — which is the same defect fixed in the Blazegraph/SPARQL-HTTP
+      // storage adapters. Direct POST has no such form-size cap and is
+      // supported by every SPARQL 1.1 endpoint (Blazegraph, GraphDB,
+      // Virtuoso, OriginTrail DKG node, …).
       const response = await fetch(this.endpointUrl, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
+          'Content-Type': 'application/sparql-query',
           'Accept': accept,
           ...this._config.headers,
         },
-        body: `query=${encodeURIComponent(sparql)}`,
+        body: sparql,
         signal: controller.signal,
       });
 

--- a/packages/graph-viz/src/data-sources/remote-sparql-source.ts
+++ b/packages/graph-viz/src/data-sources/remote-sparql-source.ts
@@ -128,9 +128,15 @@ export class RemoteSparqlSource implements GraphDataSource {
       const response = await fetch(this.endpointUrl, {
         method: 'POST',
         headers: {
+          // Caller-supplied headers (e.g. auth) go FIRST so the
+          // protocol-required headers below cannot be overridden. The body is
+          // always a raw SPARQL query, so a caller default like
+          // `Content-Type: application/x-www-form-urlencoded` would corrupt the
+          // request (and recreate the large-query form-size regression) or make
+          // a compliant endpoint reject it.
+          ...this._config.headers,
           'Content-Type': 'application/sparql-query',
           'Accept': accept,
-          ...this._config.headers,
         },
         body: sparql,
         signal: controller.signal,

--- a/packages/graph-viz/tests/remote-sparql-source.test.ts
+++ b/packages/graph-viz/tests/remote-sparql-source.test.ts
@@ -117,4 +117,24 @@ describe('RemoteSparqlSource — W3C direct POST transport (Bug 4)', () => {
     expect(headers['Authorization']).toBe('Bearer xyz');
     expect(headers['Content-Type']).toBe('application/sparql-query');
   });
+
+  it('does NOT let caller headers override the protocol Content-Type/Accept', async () => {
+    // The raw-body transport requires `application/sparql-query`; a caller that
+    // (accidentally) supplies a form-encoded Content-Type must not be able to
+    // recreate the large-query regression.
+    const overriding = new RemoteSparqlSource({
+      endpoint: 'http://blazegraph.test/sparql',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': 'text/csv',
+      },
+    });
+    const { calls } = stubFetch(() => jsonResponse({ head: { vars: [] }, results: { bindings: [] } }));
+
+    await overriding.select('SELECT ?s WHERE { ?s ?p ?o }');
+
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/sparql-query');
+    expect(headers['Accept']).toBe('application/sparql-results+json');
+  });
 });

--- a/packages/graph-viz/tests/remote-sparql-source.test.ts
+++ b/packages/graph-viz/tests/remote-sparql-source.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { RemoteSparqlSource } from '../src/data-sources/remote-sparql-source.js';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Regression (#789 follow-up — Bug 4): RemoteSparqlSource form-encoded queries.
+//
+// Same defect class as the Blazegraph / SPARQL-HTTP storage adapters: the viz
+// source POSTed `application/x-www-form-urlencoded` with `query=<encoded>`,
+// which trips Jetty's default 200 KB form-content limit on Blazegraph
+// (HTTP 400 "Unable to parse form content") for large queries. The fix uses the
+// W3C SPARQL 1.1 Protocol "query via POST directly" form: raw query body with
+// `Content-Type: application/sparql-query`, which has no form-size cap.
+// ───────────────────────────────────────────────────────────────────────────
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function stubFetch(responder: () => Response): { calls: CapturedRequest[] } {
+  const calls: CapturedRequest[] = [];
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return responder();
+  }));
+  return { calls };
+}
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function textResponse(body: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('RemoteSparqlSource — W3C direct POST transport (Bug 4)', () => {
+  const source = new RemoteSparqlSource({ endpoint: 'http://blazegraph.test/sparql' });
+
+  it('select() POSTs the raw query with Content-Type application/sparql-query', async () => {
+    const { calls } = stubFetch(() => jsonResponse({ head: { vars: ['s'] }, results: { bindings: [] } }));
+    const sparql = 'SELECT ?s WHERE { ?s ?p ?o } LIMIT 1';
+
+    await source.select(sparql);
+
+    expect(calls).toHaveLength(1);
+    const { init } = calls[0];
+    const headers = init.headers as Record<string, string>;
+    expect(init.method).toBe('POST');
+    expect(headers['Content-Type']).toBe('application/sparql-query');
+    expect(headers['Accept']).toBe('application/sparql-results+json');
+    // Body is the raw query — NOT form-encoded.
+    expect(init.body).toBe(sparql);
+    expect(String(init.body)).not.toMatch(/^query=/);
+    expect(String(init.body)).not.toContain('%20');
+  });
+
+  it('construct() POSTs the raw query with the n-triples Accept header', async () => {
+    const { calls } = stubFetch(() => textResponse('<urn:s> <urn:p> <urn:o> .'));
+    const sparql = 'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }';
+
+    const result = await source.construct(sparql);
+
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(calls[0].init.method).toBe('POST');
+    expect(headers['Content-Type']).toBe('application/sparql-query');
+    expect(headers['Accept']).toBe('application/n-triples');
+    expect(calls[0].init.body).toBe(sparql);
+    expect(result.triples).toHaveLength(1);
+  });
+
+  it('sends large queries verbatim (no form-encoding size blow-up)', async () => {
+    const { calls } = stubFetch(() => jsonResponse({ head: { vars: ['s'] }, results: { bindings: [] } }));
+    // A query big enough that form-encoding would have pushed it over the
+    // ~200 KB Jetty form limit (URL-encoding inflates further). Direct POST
+    // sends it byte-for-byte.
+    const values = Array.from({ length: 12_000 }, (_, i) => `<urn:item:${i}>`).join(' ');
+    const sparql = `SELECT ?s WHERE { VALUES ?s { ${values} } ?s ?p ?o }`;
+    // Raw query already ~190 KB; the old `query=<percent-encoded>` form would
+    // inflate `<`/`>`/spaces ~3× and sail well past Jetty's ~200 KB form cap.
+    expect(sparql.length).toBeGreaterThan(150_000);
+
+    await source.select(sparql);
+
+    expect(calls[0].init.body).toBe(sparql);
+    // The exact bytes are sent; nothing prepends `query=` or percent-encodes.
+    expect(String(calls[0].init.body)).not.toMatch(/^query=/);
+    expect(String(calls[0].init.body)).not.toContain('%3C');
+  });
+
+  it('propagates caller headers without overriding the SPARQL content type', async () => {
+    const authed = new RemoteSparqlSource({
+      endpoint: 'http://blazegraph.test/sparql',
+      headers: { Authorization: 'Bearer xyz' },
+    });
+    const { calls } = stubFetch(() => jsonResponse({ head: { vars: [] }, results: { bindings: [] } }));
+
+    await authed.select('SELECT ?s WHERE { ?s ?p ?o }');
+
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer xyz');
+    expect(headers['Content-Type']).toBe('application/sparql-query');
+  });
+});

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -248,11 +248,22 @@ export class DKGQueryEngine implements QueryEngine {
       const metaAllowList = [
         ...(isSwmOnlyRoute
           ? []
-          : [
-              subGraphName
-                ? contextGraphSubGraphMetaUri(effectiveContextGraphId, subGraphName)
-                : contextGraphMetaUri(effectiveContextGraphId),
-            ]),
+          : subGraphName
+            ? [
+                // Sub-graph metadata graph (`<cg>/<sub>/_meta`).
+                contextGraphSubGraphMetaUri(effectiveContextGraphId, subGraphName),
+                // Root CG metadata graph (`<cg>/_meta`). Canonical KA provenance
+                // (`rootEntity` / `partOf` / `confirmed` status) is written to the
+                // ROOT `_meta` even for sub-graph publishes — see
+                // `finalization-handler.ts` (the confirmed-meta writes hardcode
+                // `<cg>/_meta`). A sub-graph-scoped reader (e.g. the EPCIS events
+                // query) joins provenance from there, so the root `_meta` must be
+                // admitted alongside the sub-graph `_meta`. Both are within the
+                // same `contextGraphId`, so this does not cross the privacy
+                // boundary (which is the CG scope itself).
+                contextGraphMetaUri(effectiveContextGraphId),
+              ]
+            : [contextGraphMetaUri(effectiveContextGraphId)]),
         contextGraphSharedMemoryMetaUri(effectiveContextGraphId, subGraphName),
       ];
       // `_private` is excluded from the allow-set by default (it is more

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -4,7 +4,7 @@ import type { QueryResult, QueryOptions, QueryEngine } from './query-engine.js';
 import {
   contextGraphDataUri, contextGraphSharedMemoryUri, contextGraphVerifiedMemoryUri, contextGraphAssertionUri,
   contextGraphSubGraphUri, contextGraphMetaUri, contextGraphSharedMemoryMetaUri,
-  contextGraphSubGraphMetaUri,
+  contextGraphSubGraphMetaUri, contextGraphPrivateUri, contextGraphSubGraphPrivateUri,
   assertSafeIri, escapeSparqlLiteral, validateSubGraphName,
   type GetView,
   REMOVED_VIEWS,
@@ -255,8 +255,21 @@ export class DKGQueryEngine implements QueryEngine {
             ]),
         contextGraphSharedMemoryMetaUri(effectiveContextGraphId, subGraphName),
       ];
-      const explicitAllowedGraphs = [...allowedGraphs, ...metaAllowList];
-      const variableAllowedGraphs = [...allowedGraphs, ...metaAllowList];
+      // `_private` is excluded from the allow-set by default (it is more
+      // sensitive than the `_meta` graphs above). Only callers that opt in
+      // via `includePrivate` may name the CG's own private partition — the
+      // EPCIS events query does this to surface private-anchored events to
+      // the hosting node. This stays strictly within the queried CG, so it
+      // is not a cross-CG leak, and it does not widen any other caller.
+      const privateAllowList = options?.includePrivate
+        ? [
+            subGraphName
+              ? contextGraphSubGraphPrivateUri(effectiveContextGraphId, subGraphName)
+              : contextGraphPrivateUri(effectiveContextGraphId),
+          ]
+        : [];
+      const explicitAllowedGraphs = [...allowedGraphs, ...metaAllowList, ...privateAllowList];
+      const variableAllowedGraphs = [...allowedGraphs, ...metaAllowList, ...privateAllowList];
       // Codex r5 RED on #776: dynamic sub-graph metadata enumeration
       // (originally added to fix `useSwmAttributions` /
       // `useVerifiedMemoryAnchors` / `useVerifiedEntityIdentity`

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -16,6 +16,17 @@ export interface QueryOptions {
   includeSharedMemory?: boolean;
   /** @deprecated Use includeSharedMemory */
   includeWorkspace?: boolean;
+  /**
+   * Opt-in: allow the scoped query to explicitly reference the context
+   * graph's own `_private` partition (`<cg>/_private`, or the sub-graph
+   * private graph when `subGraphName` is set). The scope guard excludes
+   * `_private` by default — it is treated as more sensitive than the
+   * `_meta` graphs that CG-scoped callers may always read. Callers that
+   * legitimately need private-partition data (e.g. the EPCIS events query,
+   * which surfaces private-anchored events to the hosting node) set this.
+   * Does not widen access for any other CG-scoped caller.
+   */
+  includePrivate?: boolean;
   /** V10 declared state view — determines which graph(s) the query targets. */
   view?: GetView;
   /** Agent address — required when view is 'working-memory' to resolve assertion graphs. */

--- a/packages/query/test/scoped-private-graph.test.ts
+++ b/packages/query/test/scoped-private-graph.test.ts
@@ -4,6 +4,8 @@ import {
   contextGraphDataUri,
   contextGraphMetaUri,
   contextGraphPrivateUri,
+  contextGraphSharedMemoryMetaUri,
+  contextGraphSharedMemoryUri,
   contextGraphSubGraphPrivateUri,
   contextGraphSubGraphUri,
 } from '@origintrail-official/dkg-core';
@@ -42,12 +44,54 @@ const OTHER_PRIVATE_GRAPH = contextGraphPrivateUri(OTHER_CG);
 const SUB_DATA_GRAPH = contextGraphSubGraphUri(CG, SUB);
 const SUB_PRIVATE_GRAPH = contextGraphSubGraphPrivateUri(CG, SUB);
 
+// Shared-memory (non-finalized) partitions — the `finalized=false` route.
+const SWM_GRAPH = contextGraphSharedMemoryUri(CG);
+const SWM_META_GRAPH = contextGraphSharedMemoryMetaUri(CG);
+const SUB_SWM_GRAPH = contextGraphSharedMemoryUri(CG, SUB);
+const SUB_SWM_META_GRAPH = contextGraphSharedMemoryMetaUri(CG, SUB);
+
 const EVENT_TYPE = 'https://gs1.github.io/EPCIS/ObjectEvent';
 const PUBLIC_EVENT = 'urn:uuid:public-event-1';
 const PRIVATE_EVENT = 'urn:uuid:private-event-1';
+// Sub-graph finalized event + its canonical (root `_meta`) provenance.
+const SUB_FINAL_EVENT = 'urn:uuid:sub-final-event-1';
+const SUB_FINAL_KA = 'urn:dkg:ka:sub-final-1';
+const SUB_FINAL_UAL = 'did:dkg:otp:2043/0xabc/1';
+// SWM (non-finalized) events for the root and sub-graph routes.
+const SWM_EVENT = 'urn:uuid:swm-event-1';
+const SUB_SWM_EVENT = 'urn:uuid:sub-swm-event-1';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const DKG_ROOT_ENTITY = 'http://dkg.io/ontology/rootEntity';
+const DKG_PART_OF = 'http://dkg.io/ontology/partOf';
+const DKG_PRIVATE_ANCHOR = 'http://dkg.io/ontology/privateDataAnchor';
 
 function q(s: string, p: string, o: string, g: string): Quad {
   return { subject: s, predicate: p, object: o, graph: g };
+}
+
+// Mirror of the explicit-GRAPH structure emitted by
+// packages/epcis/src/query-builder.ts (public branch, private branch gated on
+// the public anchor, OPTIONAL root-meta provenance join) — parameterised by the
+// route-specific graph URIs so each of the 4 routing combinations is exercised
+// against the REAL engine with the EXACT graphs the builder names.
+function epcisShapedQuery(publicGraph: string, privateGraph: string, metaGraph: string): string {
+  return `SELECT ?event ?eventType ?ual WHERE {
+    {
+      GRAPH <${publicGraph}> { ?event a ?eventType }
+    }
+    union
+    {
+      GRAPH <${publicGraph}> { ?event <${DKG_PRIVATE_ANCHOR}> "true" }
+      GRAPH <${privateGraph}> { ?event a ?eventType }
+    }
+    OPTIONAL {
+      GRAPH <${metaGraph}> {
+        ?ka <${DKG_ROOT_ENTITY}> ?event .
+        ?ka <${DKG_PART_OF}> ?ual .
+      }
+    }
+  }`;
 }
 
 describe('DKGQueryEngine — `_private` graph scope guard (#789 follow-up: EPCIS events)', () => {
@@ -70,6 +114,17 @@ describe('DKGQueryEngine — `_private` graph scope guard (#789 follow-up: EPCIS
       // Sub-graph private partition (sub-graph scoped variant).
       q(`${PRIVATE_EVENT}/sub`, 'http://example.org/secret', '"sub-classified"', SUB_PRIVATE_GRAPH),
       q(`${PUBLIC_EVENT}/sub`, 'http://example.org/k', '"v"', SUB_DATA_GRAPH),
+      // Finalized SUB-GRAPH event: body in `<cg>/<sub>`, but its canonical
+      // KA provenance (rootEntity/partOf) lands in the ROOT `<cg>/_meta`
+      // (finalization-handler writes confirmed meta to root regardless of
+      // sub-graph) — so the engine must admit root `_meta` for a sub-graph
+      // scoped read or the OPTIONAL join graph itself trips the scope guard.
+      q(SUB_FINAL_EVENT, RDF_TYPE, `<${EVENT_TYPE}>`, SUB_DATA_GRAPH),
+      q(SUB_FINAL_KA, DKG_ROOT_ENTITY, `<${SUB_FINAL_EVENT}>`, META_GRAPH),
+      q(SUB_FINAL_KA, DKG_PART_OF, `<${SUB_FINAL_UAL}>`, META_GRAPH),
+      // Non-finalized (SWM) events for the `finalized=false` routes.
+      q(SWM_EVENT, RDF_TYPE, `<${EVENT_TYPE}>`, SWM_GRAPH),
+      q(SUB_SWM_EVENT, RDF_TYPE, `<${EVENT_TYPE}>`, SUB_SWM_GRAPH),
       // Another CG's private partition — must NEVER be reachable from CG.
       q('urn:uuid:foreign', 'http://example.org/secret', '"leak"', OTHER_PRIVATE_GRAPH),
     ]);
@@ -171,5 +226,85 @@ describe('DKGQueryEngine — `_private` graph scope guard (#789 follow-up: EPCIS
       includePrivate: true,
     });
     expect(result.bindings.some((b) => b['o'] === '"sub-classified"')).toBe(true);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Bug 3 (#789 follow-up): the EPCIS events handler systematically failed to
+  // thread its routing scope (`subGraphName`, and `finalized=false` → SWM) into
+  // the engine. The query-builder still referenced `<cg>/<sub>`,
+  // `<cg>[/<sub>]/_shared_memory[_meta]` and (for sub-graphs) the ROOT
+  // `<cg>/_meta`, none of which were in the allow-set the engine derived from
+  // `{ contextGraphId, includePrivate }` alone — so every sub-graph or
+  // non-finalized events request died with a "Scoped query violation" on BOTH
+  // store backends. These exercise all 4 routing combinations end-to-end.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('Bug 3 — finalized sub-graph: rejected without subGraphName, allowed (with root-meta join) once threaded', async () => {
+    // Exactly what the builder emits for a finalized sub-graph request.
+    const query = epcisShapedQuery(SUB_DATA_GRAPH, SUB_PRIVATE_GRAPH, META_GRAPH);
+
+    // Pre-fix handler shape (`{ contextGraphId, includePrivate }` only): the
+    // sub-graph data/private graphs are outside the allow-set → rejected.
+    await expect(
+      engine.query(query, { contextGraphId: CG, includePrivate: true }),
+    ).rejects.toThrowError(ScopedQueryViolationError);
+
+    // Post-fix: threading subGraphName admits `<cg>/<sub>` + `<cg>/<sub>/_private`,
+    // and the engine now also admits the ROOT `<cg>/_meta` (where canonical KA
+    // provenance lives) for sub-graph reads, so the OPTIONAL join resolves.
+    const result = await engine.query(query, {
+      contextGraphId: CG,
+      subGraphName: SUB,
+      includePrivate: true,
+    });
+    const row = result.bindings.find((b) => b['event'] === SUB_FINAL_EVENT);
+    expect(row).toBeDefined();
+    // The root-`_meta` provenance join must resolve through the sub-graph scope.
+    expect(row?.['ual']).toBe(SUB_FINAL_UAL);
+  });
+
+  it('Bug 3 — non-finalized (SWM) root: rejected without graphSuffix, allowed once threaded', async () => {
+    const query = epcisShapedQuery(SWM_GRAPH, PRIVATE_GRAPH, SWM_META_GRAPH);
+
+    // Without `graphSuffix:'_shared_memory'` the engine only allows the
+    // canonical `<cg>` data graph, so the SWM data graph is rejected.
+    await expect(
+      engine.query(query, { contextGraphId: CG, includePrivate: true }),
+    ).rejects.toThrowError(ScopedQueryViolationError);
+
+    const result = await engine.query(query, {
+      contextGraphId: CG,
+      graphSuffix: '_shared_memory',
+      includePrivate: true,
+    });
+    expect(result.bindings.some((b) => b['event'] === SWM_EVENT)).toBe(true);
+  });
+
+  it('Bug 3 — non-finalized (SWM) sub-graph: rejected without scope, allowed once both are threaded', async () => {
+    const query = epcisShapedQuery(SUB_SWM_GRAPH, SUB_PRIVATE_GRAPH, SUB_SWM_META_GRAPH);
+
+    await expect(
+      engine.query(query, { contextGraphId: CG, includePrivate: true }),
+    ).rejects.toThrowError(ScopedQueryViolationError);
+
+    const result = await engine.query(query, {
+      contextGraphId: CG,
+      subGraphName: SUB,
+      graphSuffix: '_shared_memory',
+      includePrivate: true,
+    });
+    expect(result.bindings.some((b) => b['event'] === SUB_SWM_EVENT)).toBe(true);
+  });
+
+  it('does NOT leak: a foreign CG\'s root `_meta` stays out even when subGraphName is set', async () => {
+    // Guards the engine widening (sub-graph reads now also admit root `<cg>/_meta`):
+    // it must admit ONLY the queried CG's root meta, never another CG's.
+    const foreignRootMeta = contextGraphMetaUri(OTHER_CG);
+    const crossCgMeta = `SELECT ?s ?p ?o WHERE {
+      GRAPH <${foreignRootMeta}> { ?s ?p ?o }
+    }`;
+    await expect(
+      engine.query(crossCgMeta, { contextGraphId: CG, subGraphName: SUB, includePrivate: true }),
+    ).rejects.toThrowError(ScopedQueryViolationError);
   });
 });

--- a/packages/query/test/scoped-private-graph.test.ts
+++ b/packages/query/test/scoped-private-graph.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  contextGraphDataUri,
+  contextGraphMetaUri,
+  contextGraphPrivateUri,
+  contextGraphSubGraphPrivateUri,
+  contextGraphSubGraphUri,
+} from '@origintrail-official/dkg-core';
+import { DKGQueryEngine, ScopedQueryViolationError } from '../src/dkg-query-engine.js';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Regression: EPCIS events API "Scoped query violation" on every node.
+//
+// Two recent rc.12 changes collided:
+//   * the EPCIS query-builder always references the context graph's
+//     `<cg>/_private` partition (to surface private-anchored events), and
+//   * the query engine's scope guard (`assertExplicitGraphIrisAllowed`) never
+//     listed `/_private` in the allow-set for a `contextGraphId`-scoped query.
+//
+// Result: GET /api/epcis/events failed with
+//   "Scoped query violation: GRAPH <…/_private> is outside the allowed graph set"
+// on BOTH Oxigraph and Blazegraph nodes (it lives in the engine, not the
+// store), and CI never caught it because the EPCIS e2e test skips without a
+// live node and the handler unit test mocks the engine.
+//
+// The fix adds an opt-in `includePrivate` query option: only callers that set
+// it (the EPCIS events handler) get the queried CG's own `_private` partition
+// added to the allow-set. These tests exercise the REAL engine over an
+// in-process store — no mocks, no live node — so they run in the normal CI
+// `query` lane and lock the behaviour in permanently.
+// ───────────────────────────────────────────────────────────────────────────
+
+const CG = 'epcis-private-regression';
+const OTHER_CG = 'some-other-cg';
+const SUB = 'shipments';
+
+const DATA_GRAPH = contextGraphDataUri(CG);
+const META_GRAPH = contextGraphMetaUri(CG);
+const PRIVATE_GRAPH = contextGraphPrivateUri(CG);
+const OTHER_PRIVATE_GRAPH = contextGraphPrivateUri(OTHER_CG);
+const SUB_DATA_GRAPH = contextGraphSubGraphUri(CG, SUB);
+const SUB_PRIVATE_GRAPH = contextGraphSubGraphPrivateUri(CG, SUB);
+
+const EVENT_TYPE = 'https://gs1.github.io/EPCIS/ObjectEvent';
+const PUBLIC_EVENT = 'urn:uuid:public-event-1';
+const PRIVATE_EVENT = 'urn:uuid:private-event-1';
+
+function q(s: string, p: string, o: string, g: string): Quad {
+  return { subject: s, predicate: p, object: o, graph: g };
+}
+
+describe('DKGQueryEngine — `_private` graph scope guard (#789 follow-up: EPCIS events)', () => {
+  let store: OxigraphStore;
+  let engine: DKGQueryEngine;
+
+  beforeEach(async () => {
+    store = new OxigraphStore();
+    engine = new DKGQueryEngine(store);
+
+    await store.insert([
+      // Fully public event — body lives in the CG data graph.
+      q(PUBLIC_EVENT, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', `<${EVENT_TYPE}>`, DATA_GRAPH),
+      // Private event — the data graph holds only the public anchor; the event
+      // body lives in the CG's `_private` partition under the SAME subject URI
+      // (this is how the publisher splits a private-anchored event).
+      q(PRIVATE_EVENT, 'http://dkg.io/ontology/privateDataAnchor', '"true"', DATA_GRAPH),
+      q(PRIVATE_EVENT, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', `<${EVENT_TYPE}>`, PRIVATE_GRAPH),
+      q(PRIVATE_EVENT, 'http://example.org/secret', '"classified"', PRIVATE_GRAPH),
+      // Sub-graph private partition (sub-graph scoped variant).
+      q(`${PRIVATE_EVENT}/sub`, 'http://example.org/secret', '"sub-classified"', SUB_PRIVATE_GRAPH),
+      q(`${PUBLIC_EVENT}/sub`, 'http://example.org/k', '"v"', SUB_DATA_GRAPH),
+      // Another CG's private partition — must NEVER be reachable from CG.
+      q('urn:uuid:foreign', 'http://example.org/secret', '"leak"', OTHER_PRIVATE_GRAPH),
+    ]);
+  });
+
+  const privateOnlyQuery = `SELECT ?s ?p ?o WHERE {
+    GRAPH <${PRIVATE_GRAPH}> { ?s ?p ?o }
+  }`;
+
+  it('THE BUG: a CG-scoped query that names <cg>/_private is rejected by default', async () => {
+    await expect(
+      engine.query(privateOnlyQuery, { contextGraphId: CG }),
+    ).rejects.toThrowError(ScopedQueryViolationError);
+
+    await expect(
+      engine.query(privateOnlyQuery, { contextGraphId: CG }),
+    ).rejects.toThrow(/_private.*outside the allowed graph set/);
+  });
+
+  it('THE FIX: `includePrivate: true` admits <cg>/_private and returns the private rows', async () => {
+    const result = await engine.query(privateOnlyQuery, {
+      contextGraphId: CG,
+      includePrivate: true,
+    });
+    const subjects = result.bindings.map((b) => b['s']);
+    expect(subjects).toContain(PRIVATE_EVENT);
+    expect(result.bindings.some((b) => b['o'] === '"classified"')).toBe(true);
+  });
+
+  it('reproduces the full EPCIS-shaped query (public UNION private + meta OPTIONAL)', async () => {
+    // Mirrors the structure emitted by packages/epcis/src/query-builder.ts:
+    // a public branch, a private branch gated on the public anchor, and an
+    // OPTIONAL meta join — all as explicit GRAPH IRIs.
+    const epcisShaped = `SELECT ?event ?eventType WHERE {
+      {
+        GRAPH <${DATA_GRAPH}> { ?event a ?eventType }
+      }
+      union
+      {
+        GRAPH <${DATA_GRAPH}> { ?event <http://dkg.io/ontology/privateDataAnchor> "true" }
+        GRAPH <${PRIVATE_GRAPH}> { ?event a ?eventType }
+      }
+      OPTIONAL {
+        GRAPH <${META_GRAPH}> { ?ka <http://dkg.io/ontology/rootEntity> ?event }
+      }
+    }`;
+
+    // Default scope rejects it (this is exactly what broke the events API).
+    await expect(
+      engine.query(epcisShaped, { contextGraphId: CG }),
+    ).rejects.toThrowError(ScopedQueryViolationError);
+
+    // With includePrivate it runs and sees both the public and private events.
+    const result = await engine.query(epcisShaped, {
+      contextGraphId: CG,
+      includePrivate: true,
+    });
+    const events = new Set(result.bindings.map((b) => b['event']));
+    expect(events.has(PUBLIC_EVENT)).toBe(true);
+    expect(events.has(PRIVATE_EVENT)).toBe(true);
+  });
+
+  it('does NOT leak: includePrivate only opens the QUERIED CG, never another CG', async () => {
+    const crossCgPrivate = `SELECT ?s ?p ?o WHERE {
+      GRAPH <${OTHER_PRIVATE_GRAPH}> { ?s ?p ?o }
+    }`;
+    // Even with the opt-in flag set, a foreign CG's `_private` stays out of
+    // the allow-set — the flag only admits the scoped CG's own partition.
+    await expect(
+      engine.query(crossCgPrivate, { contextGraphId: CG, includePrivate: true }),
+    ).rejects.toThrowError(ScopedQueryViolationError);
+  });
+
+  it('still allows the CG data + meta graphs alongside the private opt-in', async () => {
+    const dataAndMeta = `SELECT ?s WHERE {
+      { GRAPH <${DATA_GRAPH}> { ?s a <${EVENT_TYPE}> } }
+      UNION
+      { GRAPH <${META_GRAPH}> { ?s ?p ?o } }
+    }`;
+    const result = await engine.query(dataAndMeta, {
+      contextGraphId: CG,
+      includePrivate: true,
+    });
+    expect(result.bindings.some((b) => b['s'] === PUBLIC_EVENT)).toBe(true);
+  });
+
+  it('sub-graph scope: includePrivate admits <cg>/<sub>/_private', async () => {
+    const subPrivateQuery = `SELECT ?s ?p ?o WHERE {
+      GRAPH <${SUB_PRIVATE_GRAPH}> { ?s ?p ?o }
+    }`;
+
+    await expect(
+      engine.query(subPrivateQuery, { contextGraphId: CG, subGraphName: SUB }),
+    ).rejects.toThrowError(ScopedQueryViolationError);
+
+    const result = await engine.query(subPrivateQuery, {
+      contextGraphId: CG,
+      subGraphName: SUB,
+      includePrivate: true,
+    });
+    expect(result.bindings.some((b) => b['o'] === '"sub-classified"')).toBe(true);
+  });
+});

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -94,13 +94,20 @@ export class BlazegraphStore implements TripleStore {
       return this.queryConstruct(trimmed);
     }
 
+    // Direct POST (W3C SPARQL 1.1 Protocol): send the query as the raw
+    // request body with `application/sparql-query` rather than URL-encoded
+    // form data. Form-encoded bodies (`query=...`) are parsed by Jetty's
+    // form handler, which caps at `maxFormContentSize` (~200 KB by default
+    // on stock Blazegraph) and rejects larger payloads with HTTP 400
+    // "Unable to parse form content". The direct-POST body is not form
+    // parsed, so large queries (e.g. CONSTRUCT/VALUES) are not capped.
     const res = await fetch(this.url, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Type': 'application/sparql-query',
         Accept: 'application/sparql-results+json',
       },
-      body: `query=${encodeURIComponent(trimmed)}`,
+      body: trimmed,
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');
@@ -130,10 +137,10 @@ export class BlazegraphStore implements TripleStore {
     const res = await fetch(this.url, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Type': 'application/sparql-query',
         Accept: 'text/x-nquads, application/n-quads',
       },
-      body: `query=${encodeURIComponent(sparql)}`,
+      body: sparql,
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');
@@ -201,10 +208,17 @@ export class BlazegraphStore implements TripleStore {
   // -------------------------------------------------------------------
 
   private async sparqlUpdate(update: string): Promise<void> {
+    // Direct POST (W3C SPARQL 1.1 Protocol): send the update as the raw
+    // request body with `application/sparql-update` rather than URL-encoded
+    // form data (`update=...`). Form-encoded bodies hit Jetty's
+    // `maxFormContentSize` cap (~200 KB on stock Blazegraph) and fail with
+    // HTTP 400 "Unable to parse form content" — which broke large publishes
+    // (a publish issues a DELETE DATA / INSERT over the full quad set). The
+    // raw body is not form parsed, so large updates succeed.
     const res = await fetch(this.url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: `update=${encodeURIComponent(update)}`,
+      headers: { 'Content-Type': 'application/sparql-update' },
+      body: update,
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -1,9 +1,13 @@
 /**
  * SparqlHttpStore — TripleStore adapter for any SPARQL 1.1 Protocol endpoint.
  *
- * Uses standard W3C SPARQL 1.1 Protocol:
- * - Query: POST to queryEndpoint (application/x-www-form-urlencoded, query=)
- * - Update: POST to updateEndpoint (application/x-www-form-urlencoded, update=)
+ * Uses standard W3C SPARQL 1.1 Protocol "direct POST":
+ * - Query: POST to queryEndpoint (Content-Type: application/sparql-query, raw body)
+ * - Update: POST to updateEndpoint (Content-Type: application/sparql-update, raw body)
+ *
+ * Direct POST (not URL-encoded form data) avoids server-side form-size caps
+ * such as Jetty's maxFormContentSize (~200 KB on stock Blazegraph), which
+ * otherwise rejects large queries/updates with HTTP 400.
  *
  * Works with Oxigraph server, Apache Jena Fuseki, GraphDB, Blazegraph,
  * Amazon Neptune, Stardog, and any SPARQL 1.1–compliant server.
@@ -51,29 +55,40 @@ export class SparqlHttpStore implements TripleStore {
     this.queryEndpoint = options.queryEndpoint.replace(/\/$/, '');
     this.updateEndpoint = (options.updateEndpoint ?? options.queryEndpoint).replace(/\/$/, '');
     this.timeout = options.timeout ?? 30_000;
-    this.headers = {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    };
+    // Content-Type is set per-request in postQuery/postUpdate (direct POST:
+    // application/sparql-query | application/sparql-update). Only shared
+    // headers (e.g. Authorization) belong here.
+    this.headers = {};
     if (options.auth) {
       this.headers['Authorization'] = options.auth;
     }
   }
 
   private async postQuery(sparql: string, accept: string): Promise<Response> {
+    // Direct POST (W3C SPARQL 1.1 Protocol §2.1.3): the query is the raw
+    // request body with `application/sparql-query`, not URL-encoded form
+    // data. Form-encoded bodies (`query=...`) are parsed by the server's
+    // form handler, which on Jetty-backed stores (Blazegraph) caps at
+    // `maxFormContentSize` (~200 KB) and rejects larger payloads with
+    // HTTP 400 "Unable to parse form content". The direct-POST body is not
+    // form parsed, so large queries are not capped.
     const res = await fetch(this.queryEndpoint, {
       method: 'POST',
-      headers: { ...this.headers, Accept: accept },
-      body: `query=${encodeURIComponent(sparql)}`,
+      headers: { ...this.headers, 'Content-Type': 'application/sparql-query', Accept: accept },
+      body: sparql,
       signal: AbortSignal.timeout(this.timeout),
     });
     return res;
   }
 
   private async postUpdate(update: string): Promise<Response> {
+    // Direct POST (W3C SPARQL 1.1 Protocol §2.2.2): the update is the raw
+    // request body with `application/sparql-update`, not URL-encoded form
+    // data. See postQuery for why form encoding breaks large payloads.
     const res = await fetch(this.updateEndpoint, {
       method: 'POST',
-      headers: this.headers,
-      body: `update=${encodeURIComponent(update)}`,
+      headers: { ...this.headers, 'Content-Type': 'application/sparql-update' },
+      body: update,
       signal: AbortSignal.timeout(this.timeout),
     });
     return res;

--- a/packages/storage/test/adapter-parity.test.ts
+++ b/packages/storage/test/adapter-parity.test.ts
@@ -21,13 +21,17 @@ describe('TripleStore adapter parity (Oxigraph vs test-server Blazegraph)', () =
         let body = '';
         req.on('data', (chunk) => { body += chunk; });
         req.on('end', () => {
-          if (!body.startsWith('query=')) {
+          // Direct POST (W3C SPARQL 1.1): queries arrive as a raw body with
+          // Content-Type application/sparql-query; writes (n-quads insert /
+          // application/sparql-update) are everything else.
+          const contentType = String(req.headers['content-type'] ?? '');
+          if (!contentType.includes('application/sparql-query')) {
             res.writeHead(200);
             res.end();
             return;
           }
           queryCount++;
-          const decoded = decodeURIComponent(body.replace('query=', ''));
+          const decoded = body;
           if (decoded.includes('COUNT(*)')) {
             const c = queryCount <= 1 ? '2' : '1';
             res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/packages/storage/test/blazegraph.integration.test.ts
+++ b/packages/storage/test/blazegraph.integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * BlazegraphStore INTEGRATION tests — run against a REAL Blazegraph server.
+ *
+ * These are the no-mock regression tests for the large-publish bug: publishing
+ * a bigger batch (~1,800 triples / ~200 KB) to a Blazegraph node used to fail
+ * with HTTP 400 "Unable to parse form content". Root cause: the adapter sent
+ * SPARQL updates/queries as URL-encoded form data (`update=…` / `query=…`),
+ * which Jetty's form parser caps at `maxFormContentSize` (~200 KB on a stock
+ * Blazegraph image). A publish issues a single large DELETE DATA over the full
+ * quad set, so any operator on the default node-setup image hit the wall. The
+ * fix switches the transport to a W3C SPARQL 1.1 direct POST
+ * (`application/sparql-update` / `application/sparql-query`), which is not form
+ * parsed and so has no size cap.
+ *
+ * The unit suite (`blazegraph.unit.test.ts`) asserts the wire format with a
+ * mocked fetch; this suite proves the behaviour end-to-end against a live
+ * server. It is gated on BLAZEGRAPH_TEST_URL so local `pnpm test` runs skip it
+ * (no Docker required); CI provisions a Blazegraph service container and sets
+ * the env var (see `.github/workflows/ci.yml`, job `tornado-blazegraph`).
+ *
+ * BLAZEGRAPH_TEST_URL example:
+ *   http://127.0.0.1:9999/bigdata/namespace/kb/sparql
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { BlazegraphStore } from '../src/adapters/blazegraph.js';
+import type { Quad } from '../src/triple-store.js';
+
+const BLAZEGRAPH_URL = process.env.BLAZEGRAPH_TEST_URL;
+
+// A unique graph prefix per run so repeated runs against a persistent
+// namespace never collide or see stale data.
+const RUN = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const GRAPH = `urn:bg-int:${RUN}:graph`;
+const PRED = 'urn:bg-int:prop';
+
+// ~120-char ASCII literal so each DELETE DATA line is ~300 bytes; well under
+// the per-literal MUTF-8 cap (65 535 bytes) but big enough that the whole
+// batch blows past Jetty's ~200 KB form-content limit.
+const PADDING = 'x'.repeat(120);
+
+function makeQuads(n: number): Quad[] {
+  const quads: Quad[] = [];
+  for (let i = 0; i < n; i++) {
+    quads.push({
+      subject: `urn:bg-int:${RUN}:subject-${i}`,
+      predicate: PRED,
+      object: `"value-${i}-${PADDING}"`,
+      graph: GRAPH,
+    });
+  }
+  return quads;
+}
+
+describe.skipIf(!BLAZEGRAPH_URL)('BlazegraphStore integration (live server)', () => {
+  let store: BlazegraphStore;
+
+  beforeAll(async () => {
+    store = new BlazegraphStore(BLAZEGRAPH_URL as string);
+    // Start from a clean graph in case the namespace persists across runs.
+    await store.dropGraph(GRAPH);
+  });
+
+  afterAll(async () => {
+    if (store) await store.dropGraph(GRAPH).catch(() => {});
+  });
+
+  it(
+    'large DELETE DATA (publish path) succeeds — the form-content-limit regression',
+    async () => {
+      // 2 000 quads → a single DELETE DATA body of ~600 KB raw. Form-encoded
+      // (`update=` + URL-escaping) this is >1 MB, far past Jetty's ~200 KB
+      // cap — the exact shape a large publish produces.
+      const quads = makeQuads(2000);
+
+      await store.insert(quads);
+      expect(await store.countQuads(GRAPH)).toBe(quads.length);
+
+      // Sanity-check the assumption: the DELETE DATA body really is large
+      // enough that the old form-encoded transport would have been rejected.
+      const deleteBodyBytes = quads
+        .map((q) => `GRAPH <${q.graph}> { <${q.subject}> <${q.predicate}> ${q.object} . }`)
+        .join('\n').length;
+      expect(deleteBodyBytes).toBeGreaterThan(200_000);
+
+      // This is the operation that used to throw HTTP 400 on Blazegraph.
+      await expect(store.delete(quads)).resolves.toBeUndefined();
+      expect(await store.countQuads(GRAPH)).toBe(0);
+    },
+    60_000,
+  );
+
+  it(
+    'large SELECT query body succeeds — the query-path form-limit regression',
+    async () => {
+      const quads = makeQuads(3);
+      await store.insert(quads);
+
+      // Build a SELECT whose VALUES block alone exceeds ~200 KB so the old
+      // form-encoded `query=` transport would have been rejected. Includes
+      // the 3 real subjects plus thousands of decoys. A non-aggregate
+      // projection (`SELECT ?s`) is used deliberately — Blazegraph evaluates
+      // `VALUES + COUNT(*)` without GROUP BY as a per-binding aggregate, so we
+      // count the returned rows instead.
+      const realIris = quads.map((q) => `<${q.subject}>`);
+      const decoyIris: string[] = [];
+      for (let i = 0; i < 4000; i++) {
+        decoyIris.push(`<urn:bg-int:${RUN}:decoy-${i}-${PADDING}>`);
+      }
+      const values = [...realIris, ...decoyIris].join('\n');
+      const sparql = `SELECT ?s WHERE {
+        VALUES ?s { ${values} }
+        GRAPH <${GRAPH}> { ?s <${PRED}> ?o }
+      }`;
+      expect(sparql.length).toBeGreaterThan(200_000);
+
+      const result = await store.query(sparql);
+      expect(result.type).toBe('bindings');
+      if (result.type === 'bindings') {
+        const matched = new Set(result.bindings.map((b) => b.s));
+        expect(matched.size).toBe(quads.length);
+        for (const q of quads) expect(matched.has(q.subject)).toBe(true);
+      }
+
+      await store.delete(quads);
+    },
+    60_000,
+  );
+
+  it(
+    'round-trips data through the live server (insert → query → delete)',
+    async () => {
+      const quads = makeQuads(50);
+      await store.insert(quads);
+
+      const r = await store.query(
+        `SELECT ?o WHERE { GRAPH <${GRAPH}> { <urn:bg-int:${RUN}:subject-7> <${PRED}> ?o } }`,
+      );
+      expect(r.type).toBe('bindings');
+      if (r.type === 'bindings') {
+        expect(r.bindings).toHaveLength(1);
+        expect(r.bindings[0].o).toContain('value-7-');
+      }
+
+      await store.delete(quads);
+      expect(await store.countQuads(GRAPH)).toBe(0);
+    },
+    60_000,
+  );
+});

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -95,7 +95,11 @@ describe('BlazegraphStore (mocked HTTP)', () => {
       expect(r.bindings[0].name).toBe('"Alice"');
     }
     const [, init] = fetchCalls[0];
-    expect(String(init?.body)).toMatch(/^query=/);
+    // Direct POST: raw query as the request body with application/sparql-query,
+    // NOT URL-encoded form data (which would hit Jetty's maxFormContentSize cap).
+    expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/sparql-query');
+    expect(String(init?.body)).toMatch(/^SELECT /);
+    expect(String(init?.body)).not.toMatch(/^query=/);
   });
 
   it('ASK query returns boolean result', async () => {
@@ -133,10 +137,12 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     const s = new BlazegraphStore(baseUrl);
     await s.dropGraph('http://ex.org/g1');
     expect(fetchCalls.length).toBeGreaterThan(0);
+    // Direct POST: raw update body with application/sparql-update (not form-encoded).
     const call = fetchCalls.find((c) =>
-      String(c[1]?.body).includes('DROP%20SILENT%20GRAPH'),
+      String(c[1]?.body).includes('DROP SILENT GRAPH'),
     );
     expect(call).toBeDefined();
+    expect((call?.[1]?.headers as Record<string, string>)['Content-Type']).toBe('application/sparql-update');
   });
 
   it('delete is a no-op for empty quad list', async () => {
@@ -152,7 +158,7 @@ describe('BlazegraphStore (mocked HTTP)', () => {
       { subject: 'http://s', predicate: 'http://p', object: '"o"', graph: 'http://g' },
     ]);
     const call = fetchCalls.find((c) =>
-      decodeURIComponent(String(c[1]?.body)).includes('DELETE DATA'),
+      String(c[1]?.body).includes('DELETE DATA'),
     );
     expect(call).toBeDefined();
   });
@@ -169,7 +175,7 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     let call = 0;
     setFetch(async (_url, init) => {
       const body = String(init?.body ?? '');
-      if (body.startsWith('query=')) {
+      if (body.startsWith('SELECT')) {
         call++;
         return new Response(
           JSON.stringify({
@@ -186,11 +192,31 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     expect(removed).toBe(3);
   });
 
+  it('deleteByPattern count branch keyed on direct-POST SELECT body', async () => {
+    // Guards the direct-POST migration: count queries are sent as a raw
+    // SPARQL body starting with SELECT, not as `query=...` form data.
+    let sawRawSelect = false;
+    setFetch(async (_url, init) => {
+      const body = String(init?.body ?? '');
+      if (body.startsWith('SELECT')) {
+        sawRawSelect = true;
+        return new Response(
+          JSON.stringify({ head: { vars: ['c'] }, results: { bindings: [{ c: { type: 'literal', value: '1' } }] } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(null, { status: 200 });
+    });
+    const s = new BlazegraphStore(baseUrl);
+    await s.deleteByPattern({ graph: 'http://g', subject: 'http://s' });
+    expect(sawRawSelect).toBe(true);
+  });
+
   it('deleteBySubjectPrefix returns count delta', async () => {
     let call = 0;
     setFetch(async (_url, init) => {
       const body = String(init?.body ?? '');
-      if (body.startsWith('query=')) {
+      if (body.startsWith('SELECT')) {
         call++;
         return new Response(
           JSON.stringify({
@@ -218,7 +244,7 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     const s = new BlazegraphStore(baseUrl);
     const n = await s.countQuads();
     expect(n).toBe(99);
-    const body = decodeURIComponent(String(fetchCalls[0][1]?.body));
+    const body = String(fetchCalls[0][1]?.body);
     expect(body).toContain('UNION');
   });
 


### PR DESCRIPTION
## Summary

Two pre-existing bugs surfaced while running the **full publish flow** against a real local devnet (Hardhat chain + 4 node daemons — 2 Oxigraph, 2 Blazegraph — **no mocks**) on top of the #789 Blazegraph work. Both are independent of #789's oversized-literal / nested-UNION fixes, and both are fixed here with tests that run on CI.

### Bug 1 — large publishes fail on Blazegraph (HTTP 400 "Unable to parse form content")
- A publish issues a single large `DELETE DATA` over the full quad set. The `blazegraph` and `sparql-http` adapters sent SPARQL queries/updates as **URL-encoded form data** (`query=` / `update=`), which Jetty's form parser caps at `maxFormContentSize` (~200 KB on the stock `lyrasis/blazegraph` image our node-setup wizard provisions). The same publish works fine on Oxigraph.
- I confirmed it's purely the transport: the **identical ~370 KB payload** returns HTTP 400 as `application/x-www-form-urlencoded` but **HTTP 200** as raw `application/sparql-update` on the same server. Not a config issue — any operator on the default image hits it. It fails safely (clean error, no corruption).
- **Fix:** switch both adapters to the W3C SPARQL 1.1 **direct POST** transport (raw body + `application/sparql-query` / `application/sparql-update`). Not form-parsed → no size cap.

### Bug 2 — `GET /api/epcis/events` broken on every node
- Always returns `Scoped query violation: GRAPH <…/_private> is outside the allowed graph set` — on **both** Oxigraph and Blazegraph, so it's in the query engine, not a Blazegraph/#789 thing.
- The EPCIS query-builder always references the CG's `<cg>/_private` partition, but the engine's scope guard never listed `_private` in the allow-set for a `contextGraphId`-scoped query. Two recent rc.12 changes collided. CI didn't catch it because the EPCIS e2e test skips when there's no live node.
- **Fix:** add an opt-in `includePrivate` query option that admits **only the queried CG's own** private partition; the EPCIS events handler sets it. No other caller is widened; cross-CG private graphs stay rejected.

## Tests added (and wired to run on CI)
- **`packages/query/test/scoped-private-graph.test.ts`** — real `DKGQueryEngine` over an in-process `OxigraphStore` reproduces the scope violation and verifies the `includePrivate` fix (incl. cross-CG leak guard + sub-graph variant). Runs in the existing **query** CI lane; no live node needed.
- **`packages/storage/test/blazegraph.integration.test.ts`** — gated on `BLAZEGRAPH_TEST_URL`; runs a large `DELETE DATA` / `SELECT` (>200 KB) against a **real Blazegraph** and asserts success (the exact payload the old form transport rejected with 400). Skips locally without the env var (no Docker required).
- **`.github/workflows/ci.yml`** — new `tornado-blazegraph` job spins up a `lyrasis/blazegraph:2.1.5` service container and runs the integration suite. Also added `release/rc.12` to the push/pull_request triggers so the full Node test suite (incl. these tests) actually runs on rc.12 PRs — previously CI only triggered on `main`/`v10-rc`, so rc.12 PRs ran none of the test lanes.
- Updated `blazegraph.unit` / `adapter-parity` / `events-query` / `epcis-route-readiness` to the new wire format and `includePrivate` opt-in.

## Test plan
- [x] `storage` suite — 142 pass, integration cleanly skips without env var
- [x] `storage` Blazegraph integration — 3/3 pass against a live server; verified old form transport returns 400 and direct POST returns 200 on the same 370 KB payload
- [x] `query` suite — 230 pass (incl. 6 new regression tests)
- [x] `epcis` suite — 147 pass
- [x] `cli` suite — 1767 pass
- [x] `agent` suite — 987 pass; 2 remaining failures (`generic-sql-source` `node:sqlite`, `swm-snapshot-sync` worker `.ts` loader) are local-Node-runtime-only and unrelated to these changes
- [x] End-to-end on the live devnet: large publish to a Blazegraph node succeeds and is queryable; `GET /api/epcis/events` returns 200 on both Oxigraph and Blazegraph nodes

Made with [Cursor](https://cursor.com)