### PR TITLE
Guard V10 staking against false-return ERC20s

### DIFF
--- a/packages/evm-module/contracts/StakingV10.sol
+++ b/packages/evm-module/contracts/StakingV10.sol
@@ -23,6 +23,7 @@ import {Permissions} from "./libraries/Permissions.sol";
 import {StakingLib} from "./libraries/StakingLib.sol";
 import {TokenLib} from "./libraries/TokenLib.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @title StakingV10
@@ -76,6 +77,8 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  *     because relock materially changes tier / multiplier / expiry.
  */
 contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
+    using SafeERC20 for IERC20;
+
     // ========================================================================
     // Metadata
     // ========================================================================
@@ -334,13 +337,21 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         uint256 totalNodeStakeAfter = convictionStorage.getNodeStakeV10(identityId) + uint256(amount);
         if (totalNodeStakeAfter > maxStake) revert MaxStakeExceeded();
 
+        if (token.allowance(staker, address(this)) < amount) {
+            revert TokenLib.TooLowAllowance(address(token), token.allowance(staker, address(this)), amount);
+        }
+
+        if (token.balanceOf(staker) < amount) {
+            revert TokenLib.TooLowBalance(address(token), token.balanceOf(staker), amount);
+        }
+
         _prepareForStakeChangeV10(chronos.getCurrentEpoch(), tokenId, identityId);
 
         // v4.0.0 — TRAC flows into the CSS vault. CSS extends Guardian and
         // exposes `transferStake` for the withdraw outflow side. The NFT
         // wrapper never holds funds; the V8 StakingStorage is no longer in
         // the deposit path.
-        token.transferFrom(staker, address(convictionStorage), amount);
+        token.safeTransferFrom(staker, address(convictionStorage), amount);
 
         // L11 — multiplier18 is no longer passed in; CSS reads it from the
         //       tier table (single source of truth).

--- a/packages/evm-module/contracts/mocks/FalseReturnERC20.sol
+++ b/packages/evm-module/contracts/mocks/FalseReturnERC20.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract FalseReturnERC20 is ERC20 {
+    bool public transferReturnsFalse;
+    bool public transferFromReturnsFalse;
+
+    constructor(string memory tokenName, string memory tokenSymbol) ERC20(tokenName, tokenSymbol) {}
+
+    function setTransferReturnsFalse(bool value) external {
+        transferReturnsFalse = value;
+    }
+
+    function setTransferFromReturnsFalse(bool value) external {
+        transferFromReturnsFalse = value;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        if (transferReturnsFalse) {
+            return false;
+        }
+
+        return super.transfer(to, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        if (transferFromReturnsFalse) {
+            return false;
+        }
+
+        return super.transferFrom(from, to, amount);
+    }
+}

--- a/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
@@ -10,6 +10,7 @@ import {IVersioned} from "../interfaces/IVersioned.sol";
 import {HubLib} from "../libraries/HubLib.sol";
 import {StakingLib} from "../libraries/StakingLib.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @title ConvictionStakingStorage
@@ -70,6 +71,8 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  *     consumers that need them should settle and read "current" state.
  */
 contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
+    using SafeERC20 for IERC20;
+
     string private constant _NAME = "ConvictionStakingStorage";
     // Version history:
     //   1.1.0 — split-bucket rewards, discrete tier ladder.
@@ -1446,7 +1449,7 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     // ============================================================
 
     function transferStake(address receiver, uint96 stakeAmount) external onlyContracts {
-        tokenContract.transfer(receiver, stakeAmount);
+        tokenContract.safeTransfer(receiver, stakeAmount);
         emit StakedTokensTransferred(receiver, stakeAmount);
     }
 

--- a/packages/evm-module/test/v10-erc20-false-return.test.ts
+++ b/packages/evm-module/test/v10-erc20-false-return.test.ts
@@ -1,0 +1,115 @@
+import { randomBytes } from 'crypto';
+
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import hre from 'hardhat';
+
+import {
+  ConvictionStakingStorage,
+  DKGStakingConvictionNFT,
+  FalseReturnERC20,
+  Hub,
+  Profile,
+  StakingV10,
+} from '../typechain';
+
+type Fixture = {
+  accounts: SignerWithAddress[];
+  Hub: Hub;
+  NFT: DKGStakingConvictionNFT;
+  StakingV10: StakingV10;
+  ConvictionStakingStorage: ConvictionStakingStorage;
+  Profile: Profile;
+};
+
+async function deployFixture(): Promise<Fixture> {
+  await hre.deployments.fixture(['DKGStakingConvictionNFT', 'StakingV10', 'Profile']);
+
+  const accounts = await hre.ethers.getSigners();
+  const Hub = await hre.ethers.getContract<Hub>('Hub');
+
+  await Hub.setContractAddress('HubOwner', accounts[0].address);
+
+  return {
+    accounts,
+    Hub,
+    NFT: await hre.ethers.getContract<DKGStakingConvictionNFT>('DKGStakingConvictionNFT'),
+    StakingV10: await hre.ethers.getContract<StakingV10>('StakingV10'),
+    ConvictionStakingStorage: await hre.ethers.getContract<ConvictionStakingStorage>(
+      'ConvictionStakingStorage',
+    ),
+    Profile: await hre.ethers.getContract<Profile>('Profile'),
+  };
+}
+
+describe('@integration V10 ERC-20 false-return staking guards', () => {
+  let accounts: SignerWithAddress[];
+  let Hub: Hub;
+  let NFT: DKGStakingConvictionNFT;
+  let StakingV10Contract: StakingV10;
+  let ConvictionStakingStorageContract: ConvictionStakingStorage;
+  let ProfileContract: Profile;
+
+  beforeEach(async () => {
+    hre.helpers.resetDeploymentsJson();
+    ({
+      accounts,
+      Hub,
+      NFT,
+      StakingV10: StakingV10Contract,
+      ConvictionStakingStorage: ConvictionStakingStorageContract,
+      Profile: ProfileContract,
+    } = await loadFixture(deployFixture));
+  });
+
+  const createProfile = async () => {
+    const nodeId = '0x' + randomBytes(32).toString('hex');
+    const tx = await ProfileContract.connect(accounts[1]).createProfile(
+      accounts[0].address,
+      [],
+      `False Return Node ${Math.floor(Math.random() * 1_000_000)}`,
+      nodeId,
+      0,
+    );
+    const receipt = await tx.wait();
+    const identityId = Number(receipt!.logs[0].topics[1]);
+    return { nodeId, identityId };
+  };
+
+  const useFalseReturnToken = async () => {
+    const TokenFactory = await hre.ethers.getContractFactory('FalseReturnERC20');
+    const token = (await TokenFactory.deploy('False TRAC', 'fTRAC')) as unknown as FalseReturnERC20;
+    await token.waitForDeployment();
+
+    await Hub.setContractAddress('Token', await token.getAddress());
+    await Hub.forwardCall(
+      await StakingV10Contract.getAddress(),
+      StakingV10Contract.interface.encodeFunctionData('initialize'),
+    );
+
+    return token;
+  };
+
+  it('reverts before creating a CSS position when transferFrom returns false', async () => {
+    const { identityId } = await createProfile();
+    const amount = hre.ethers.parseEther('1000');
+    const token = await useFalseReturnToken();
+
+    await token.mint(accounts[0].address, amount);
+    await token.connect(accounts[0]).approve(await StakingV10Contract.getAddress(), amount);
+    await token.setTransferFromReturnsFalse(true);
+
+    const cssAddress = await ConvictionStakingStorageContract.getAddress();
+    const cssBalanceBefore = await token.balanceOf(cssAddress);
+    const nodeStakeBefore = await ConvictionStakingStorageContract.getNodeStakeV10(identityId);
+
+    await expect(NFT.connect(accounts[0]).createConviction(identityId, amount, 12)).to.be.reverted;
+
+    const position = await ConvictionStakingStorageContract.getPosition(1);
+    expect(position.identityId).to.equal(0n);
+    expect(position.raw).to.equal(0n);
+    expect(await ConvictionStakingStorageContract.getNodeStakeV10(identityId)).to.equal(nodeStakeBefore);
+    expect(await token.balanceOf(cssAddress)).to.equal(cssBalanceBefore);
+  });
+});

--- a/packages/evm-module/test/v10-erc20-false-return.test.ts
+++ b/packages/evm-module/test/v10-erc20-false-return.test.ts
@@ -84,6 +84,10 @@ describe('@integration V10 ERC-20 false-return staking guards', () => {
 
     await Hub.setContractAddress('Token', await token.getAddress());
     await Hub.forwardCall(
+      await ConvictionStakingStorageContract.getAddress(),
+      ConvictionStakingStorageContract.interface.encodeFunctionData('initialize'),
+    );
+    await Hub.forwardCall(
       await StakingV10Contract.getAddress(),
       StakingV10Contract.interface.encodeFunctionData('initialize'),
     );
@@ -111,5 +115,24 @@ describe('@integration V10 ERC-20 false-return staking guards', () => {
     expect(position.raw).to.equal(0n);
     expect(await ConvictionStakingStorageContract.getNodeStakeV10(identityId)).to.equal(nodeStakeBefore);
     expect(await token.balanceOf(cssAddress)).to.equal(cssBalanceBefore);
+  });
+
+  it('keeps the CSS position when withdrawal transfer returns false', async () => {
+    const { identityId } = await createProfile();
+    const amount = hre.ethers.parseEther('1000');
+    const token = await useFalseReturnToken();
+
+    await token.mint(accounts[0].address, amount);
+    await token.connect(accounts[0]).approve(await StakingV10Contract.getAddress(), amount);
+    await NFT.connect(accounts[0]).createConviction(identityId, amount, 0);
+
+    const positionBefore = await ConvictionStakingStorageContract.getPosition(1);
+    await token.setTransferReturnsFalse(true);
+
+    await expect(NFT.connect(accounts[0]).withdraw(1)).to.be.reverted;
+
+    const positionAfter = await ConvictionStakingStorageContract.getPosition(1);
+    expect(positionAfter.identityId).to.equal(positionBefore.identityId);
+    expect(positionAfter.raw).to.equal(positionBefore.raw);
   });
 });

--- a/packages/evm-module/test/v10-erc20-false-return.test.ts
+++ b/packages/evm-module/test/v10-erc20-false-return.test.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'crypto';
 
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import hre from 'hardhat';
 
@@ -134,5 +134,26 @@ describe('@integration V10 ERC-20 false-return staking guards', () => {
     const positionAfter = await ConvictionStakingStorageContract.getPosition(1);
     expect(positionAfter.identityId).to.equal(positionBefore.identityId);
     expect(positionAfter.raw).to.equal(positionBefore.raw);
+  });
+
+  it('keeps the operator-fee withdrawal request when finalization transfer returns false', async () => {
+    const { identityId } = await createProfile();
+    const amount = hre.ethers.parseEther('1000');
+    const token = await useFalseReturnToken();
+
+    await token.mint(await ConvictionStakingStorageContract.getAddress(), amount);
+    await ConvictionStakingStorageContract.increaseOperatorFeeBalance(identityId, amount);
+    await StakingV10Contract.requestOperatorFeeWithdrawal(identityId, amount);
+
+    const requestBefore = await ConvictionStakingStorageContract.getOperatorFeeWithdrawalRequest(identityId);
+    await time.increaseTo(requestBefore[2]);
+    await token.setTransferReturnsFalse(true);
+
+    await expect(StakingV10Contract.finalizeOperatorFeeWithdrawal(identityId)).to.be.reverted;
+
+    const requestAfter = await ConvictionStakingStorageContract.getOperatorFeeWithdrawalRequest(identityId);
+    expect(requestAfter[0]).to.equal(requestBefore[0]);
+    expect(requestAfter[1]).to.equal(requestBefore[1]);
+    expect(requestAfter[2]).to.equal(requestBefore[2]);
   });
 });


### PR DESCRIPTION
## Summary

- Add a false-return ERC-20 mock plus V10 regression coverage for staking deposits, withdrawals, and operator-fee finalization.
- Guard `StakingV10.stake()` with `SafeERC20.safeTransferFrom` while keeping the existing balance and allowance prechecks.
- Guard CSS staking vault outflows in `ConvictionStakingStorage.transferStake()` with `SafeERC20.safeTransfer`.

## Test Plan

- `pnpm --dir packages/evm-module exec hardhat test --network hardhat --config hardhat.node.config.ts test/v10-erc20-false-return.test.ts`
