### PR TITLE
Deduplicate EVM publishing reward math

### DIFF
--- a/packages/evm-module/contracts/DKGPublishingConvictionNFT.sol
+++ b/packages/evm-module/contracts/DKGPublishingConvictionNFT.sol
@@ -6,6 +6,7 @@ import {INamed} from "./interfaces/INamed.sol";
 import {IVersioned} from "./interfaces/IVersioned.sol";
 import {IInitializable} from "./interfaces/IInitializable.sol";
 import {HubDependent} from "./abstract/HubDependent.sol";
+import {PublishingMathLib} from "./libraries/PublishingMathLib.sol";
 import {PublishingConviction} from "./PublishingConviction.sol";
 import {PublishingConvictionStorage} from "./storage/PublishingConvictionStorage.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -384,17 +385,10 @@ contract DKGPublishingConvictionNFT is INamed, IVersioned, HubDependent, IInitia
         return publishingConvictionStorage.isRegisteredAgent(accountId, agent);
     }
 
-    /// @notice Discrete 6-tier discount ladder. Pure helper duplicated
-    ///         on the wrapper for cheap caller-side reads. Stays in
-    ///         lockstep with `PublishingConviction.getDiscountBps`.
+    /// @notice Discrete 6-tier discount ladder. Selector-compatible
+    ///         wrapper read over the shared publishing math helper.
     function getDiscountBps(uint96 committedTRAC) public pure returns (uint256) {
-        if (committedTRAC >= 1_000_000 ether) return 7500;
-        if (committedTRAC >= 500_000 ether)   return 5000;
-        if (committedTRAC >= 250_000 ether)   return 4000;
-        if (committedTRAC >= 100_000 ether)   return 3000;
-        if (committedTRAC >= 50_000 ether)    return 2000;
-        if (committedTRAC >= 25_000 ether)    return 1000;
-        return 0;
+        return PublishingMathLib.discountBps(committedTRAC);
     }
 
     /// @notice Discount basis points fixed at creation for `accountId`.

--- a/packages/evm-module/contracts/KnowledgeAssetsV10.sol
+++ b/packages/evm-module/contracts/KnowledgeAssetsV10.sol
@@ -15,6 +15,7 @@ import {ContextGraphStorage} from "./storage/ContextGraphStorage.sol";
 import {ContextGraphValueStorage} from "./storage/ContextGraphValueStorage.sol";
 import {KnowledgeAssetsLib} from "./libraries/KnowledgeAssetsLib.sol";
 import {KnowledgeCollectionLib} from "./libraries/KnowledgeCollectionLib.sol";
+import {PublishingMathLib} from "./libraries/PublishingMathLib.sol";
 import {TokenLib} from "./libraries/TokenLib.sol";
 import {IdentityLib} from "./libraries/IdentityLib.sol";
 import {INamed} from "./interfaces/INamed.sol";
@@ -1418,37 +1419,17 @@ contract KnowledgeAssetsV10 is INamed, IVersioned, ContractStatus, IInitializabl
 
         uint256 epochLengthInSeconds = chronos.epochLength();
         uint256 timeRemainingInCurrentEpoch = chronos.timeUntilNextEpoch();
-        uint256 baseTokensPerFullEpoch = tokenAmount / epochs;
-        uint256 currentEpochAllocation = (baseTokensPerFullEpoch * timeRemainingInCurrentEpoch) / epochLengthInSeconds;
-        uint256 finalEpochAllocation = baseTokensPerFullEpoch - currentEpochAllocation;
-        uint256 numberOfFullEpochs = epochs - 1;
-        uint256 totalTokensForFullEpochs = baseTokensPerFullEpoch * numberOfFullEpochs;
+        PublishingMathLib.ActiveSinkRange[3] memory ranges = PublishingMathLib.prorateActiveSink(
+            tokenAmount,
+            currentEpoch,
+            epochs,
+            epochLengthInSeconds,
+            timeRemainingInCurrentEpoch
+        );
 
-        uint256 totalAllocated = currentEpochAllocation + totalTokensForFullEpochs + finalEpochAllocation;
-        if (totalAllocated < tokenAmount) {
-            finalEpochAllocation += tokenAmount - totalAllocated;
-        }
-
-        if (currentEpochAllocation > 0) {
-            epochStorage.addTokensToEpochRange(1, currentEpoch, currentEpoch, uint96(currentEpochAllocation));
-        }
-
-        if (numberOfFullEpochs > 0 && totalTokensForFullEpochs > 0) {
-            epochStorage.addTokensToEpochRange(
-                1,
-                currentEpoch + 1,
-                currentEpoch + uint40(numberOfFullEpochs),
-                uint96(totalTokensForFullEpochs)
-            );
-        }
-
-        if (finalEpochAllocation > 0) {
-            epochStorage.addTokensToEpochRange(
-                1,
-                currentEpoch + uint40(epochs),
-                currentEpoch + uint40(epochs),
-                uint96(finalEpochAllocation)
-            );
+        for (uint256 i; i < ranges.length; i++) {
+            if (ranges[i].tokenAmount == 0) continue;
+            epochStorage.addTokensToEpochRange(1, ranges[i].startEpoch, ranges[i].endEpoch, ranges[i].tokenAmount);
         }
     }
 }

--- a/packages/evm-module/contracts/PublishingConviction.sol
+++ b/packages/evm-module/contracts/PublishingConviction.sol
@@ -8,6 +8,7 @@ import {IInitializable} from "./interfaces/IInitializable.sol";
 import {ContractStatus} from "./abstract/ContractStatus.sol";
 import {Chronos} from "./storage/Chronos.sol";
 import {EpochStorage} from "./storage/EpochStorage.sol";
+import {PublishingMathLib} from "./libraries/PublishingMathLib.sol";
 import {ParametersStorage} from "./storage/ParametersStorage.sol";
 import {PublishingConvictionStorage} from "./storage/PublishingConvictionStorage.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -816,15 +817,8 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
 
     /// @notice Discrete 6-tier discount ladder. Tiers are evaluated
     ///         highest-first so the largest commit that qualifies is
-    ///         selected. Pure — duplicated on the NFT wrapper for
-    ///         caller-side cheap reads.
+    ///         selected.
     function getDiscountBps(uint96 committedTRAC) public pure returns (uint256) {
-        if (committedTRAC >= 1_000_000 ether) return 7500; // 75%
-        if (committedTRAC >= 500_000 ether)   return 5000; // 50%
-        if (committedTRAC >= 250_000 ether)   return 4000; // 40%
-        if (committedTRAC >= 100_000 ether)   return 3000; // 30%
-        if (committedTRAC >= 50_000 ether)    return 2000; // 20%
-        if (committedTRAC >= 25_000 ether)    return 1000; // 10%
-        return 0;
+        return PublishingMathLib.discountBps(committedTRAC);
     }
 }

--- a/packages/evm-module/contracts/PublishingConviction.sol
+++ b/packages/evm-module/contracts/PublishingConviction.sol
@@ -467,43 +467,21 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
     ) internal {
         uint256 epochLengthSec = chronos.epochLength();
         uint256 timeRemainingInCurrentEpoch = chronos.timeUntilNextEpoch();
-        uint96 baseTokensPerFullEpoch = uint96(uint256(amount) / storageUnits);
-        uint96 currentEpochAllocation = uint96(
-            (uint256(baseTokensPerFullEpoch) * timeRemainingInCurrentEpoch) / epochLengthSec
+        PublishingMathLib.ActiveSinkRange[3] memory ranges = PublishingMathLib.prorateActiveSink(
+            amount,
+            firstEpoch,
+            storageUnits,
+            epochLengthSec,
+            timeRemainingInCurrentEpoch
         );
-        uint96 finalEpochAllocation = baseTokensPerFullEpoch - currentEpochAllocation;
-        uint256 numberOfFullEpochs = storageUnits - 1;
-        uint96 totalTokensForFullEpochs = uint96(uint256(baseTokensPerFullEpoch) * numberOfFullEpochs);
 
-        uint96 totalAllocated = currentEpochAllocation + totalTokensForFullEpochs + finalEpochAllocation;
-        if (totalAllocated < amount) {
-            finalEpochAllocation += (amount - totalAllocated);
-        }
-
-        if (currentEpochAllocation > 0) {
+        for (uint256 i; i < ranges.length; i++) {
+            if (ranges[i].tokenAmount == 0) continue;
             epochStorage.addTokensToEpochRange(
                 STAKER_SHARD_ID,
-                firstEpoch,
-                firstEpoch,
-                currentEpochAllocation
-            );
-        }
-
-        if (numberOfFullEpochs > 0 && totalTokensForFullEpochs > 0) {
-            epochStorage.addTokensToEpochRange(
-                STAKER_SHARD_ID,
-                firstEpoch + 1,
-                firstEpoch + uint40(numberOfFullEpochs),
-                totalTokensForFullEpochs
-            );
-        }
-
-        if (finalEpochAllocation > 0) {
-            epochStorage.addTokensToEpochRange(
-                STAKER_SHARD_ID,
-                firstEpoch + uint40(storageUnits),
-                firstEpoch + uint40(storageUnits),
-                finalEpochAllocation
+                ranges[i].startEpoch,
+                ranges[i].endEpoch,
+                ranges[i].tokenAmount
             );
         }
     }

--- a/packages/evm-module/contracts/libraries/PublishingMathLib.sol
+++ b/packages/evm-module/contracts/libraries/PublishingMathLib.sol
@@ -3,6 +3,12 @@
 pragma solidity ^0.8.20;
 
 library PublishingMathLib {
+    struct ActiveSinkRange {
+        uint40 startEpoch;
+        uint40 endEpoch;
+        uint96 tokenAmount;
+    }
+
     function discountBps(uint96 committedTRAC) internal pure returns (uint256) {
         if (committedTRAC >= 1_000_000 ether) return 7500;
         if (committedTRAC >= 500_000 ether)   return 5000;
@@ -11,5 +17,35 @@ library PublishingMathLib {
         if (committedTRAC >= 50_000 ether)    return 2000;
         if (committedTRAC >= 25_000 ether)    return 1000;
         return 0;
+    }
+
+    function prorateActiveSink(
+        uint96 tokenAmount,
+        uint40 currentEpoch,
+        uint256 epochs,
+        uint256 epochLengthInSeconds,
+        uint256 timeRemainingInCurrentEpoch
+    ) internal pure returns (ActiveSinkRange[3] memory ranges) {
+        uint256 baseTokensPerFullEpoch = tokenAmount / epochs;
+        uint256 currentEpochAllocation = (baseTokensPerFullEpoch * timeRemainingInCurrentEpoch) / epochLengthInSeconds;
+        uint256 finalEpochAllocation = baseTokensPerFullEpoch - currentEpochAllocation;
+        uint256 numberOfFullEpochs = epochs - 1;
+        uint256 totalTokensForFullEpochs = baseTokensPerFullEpoch * numberOfFullEpochs;
+
+        ranges[0] = ActiveSinkRange({
+            startEpoch: currentEpoch,
+            endEpoch: currentEpoch,
+            tokenAmount: uint96(currentEpochAllocation)
+        });
+        ranges[1] = ActiveSinkRange({
+            startEpoch: currentEpoch + 1,
+            endEpoch: currentEpoch + uint40(numberOfFullEpochs),
+            tokenAmount: uint96(totalTokensForFullEpochs)
+        });
+        ranges[2] = ActiveSinkRange({
+            startEpoch: currentEpoch + uint40(epochs),
+            endEpoch: currentEpoch + uint40(epochs),
+            tokenAmount: uint96(finalEpochAllocation)
+        });
     }
 }

--- a/packages/evm-module/contracts/libraries/PublishingMathLib.sol
+++ b/packages/evm-module/contracts/libraries/PublishingMathLib.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+library PublishingMathLib {
+    function discountBps(uint96 committedTRAC) internal pure returns (uint256) {
+        if (committedTRAC >= 1_000_000 ether) return 7500;
+        if (committedTRAC >= 500_000 ether)   return 5000;
+        if (committedTRAC >= 250_000 ether)   return 4000;
+        if (committedTRAC >= 100_000 ether)   return 3000;
+        if (committedTRAC >= 50_000 ether)    return 2000;
+        if (committedTRAC >= 25_000 ether)    return 1000;
+        return 0;
+    }
+}

--- a/packages/evm-module/contracts/libraries/PublishingMathLib.sol
+++ b/packages/evm-module/contracts/libraries/PublishingMathLib.sol
@@ -36,11 +36,13 @@ library PublishingMathLib {
             finalEpochAllocation += tokenAmount - totalAllocated;
         }
 
-        ranges[0] = ActiveSinkRange({
-            startEpoch: currentEpoch,
-            endEpoch: currentEpoch,
-            tokenAmount: uint96(currentEpochAllocation)
-        });
+        if (currentEpochAllocation > 0) {
+            ranges[0] = ActiveSinkRange({
+                startEpoch: currentEpoch,
+                endEpoch: currentEpoch,
+                tokenAmount: uint96(currentEpochAllocation)
+            });
+        }
         if (numberOfFullEpochs > 0 && totalTokensForFullEpochs > 0) {
             ranges[1] = ActiveSinkRange({
                 startEpoch: currentEpoch + 1,

--- a/packages/evm-module/contracts/libraries/PublishingMathLib.sol
+++ b/packages/evm-module/contracts/libraries/PublishingMathLib.sol
@@ -31,6 +31,10 @@ library PublishingMathLib {
         uint256 finalEpochAllocation = baseTokensPerFullEpoch - currentEpochAllocation;
         uint256 numberOfFullEpochs = epochs - 1;
         uint256 totalTokensForFullEpochs = baseTokensPerFullEpoch * numberOfFullEpochs;
+        uint256 totalAllocated = currentEpochAllocation + totalTokensForFullEpochs + finalEpochAllocation;
+        if (totalAllocated < tokenAmount) {
+            finalEpochAllocation += tokenAmount - totalAllocated;
+        }
 
         ranges[0] = ActiveSinkRange({
             startEpoch: currentEpoch,

--- a/packages/evm-module/contracts/libraries/PublishingMathLib.sol
+++ b/packages/evm-module/contracts/libraries/PublishingMathLib.sol
@@ -37,11 +37,13 @@ library PublishingMathLib {
             endEpoch: currentEpoch,
             tokenAmount: uint96(currentEpochAllocation)
         });
-        ranges[1] = ActiveSinkRange({
-            startEpoch: currentEpoch + 1,
-            endEpoch: currentEpoch + uint40(numberOfFullEpochs),
-            tokenAmount: uint96(totalTokensForFullEpochs)
-        });
+        if (numberOfFullEpochs > 0 && totalTokensForFullEpochs > 0) {
+            ranges[1] = ActiveSinkRange({
+                startEpoch: currentEpoch + 1,
+                endEpoch: currentEpoch + uint40(numberOfFullEpochs),
+                tokenAmount: uint96(totalTokensForFullEpochs)
+            });
+        }
         if (finalEpochAllocation > 0) {
             ranges[2] = ActiveSinkRange({
                 startEpoch: currentEpoch + uint40(epochs),

--- a/packages/evm-module/contracts/libraries/PublishingMathLib.sol
+++ b/packages/evm-module/contracts/libraries/PublishingMathLib.sol
@@ -42,10 +42,12 @@ library PublishingMathLib {
             endEpoch: currentEpoch + uint40(numberOfFullEpochs),
             tokenAmount: uint96(totalTokensForFullEpochs)
         });
-        ranges[2] = ActiveSinkRange({
-            startEpoch: currentEpoch + uint40(epochs),
-            endEpoch: currentEpoch + uint40(epochs),
-            tokenAmount: uint96(finalEpochAllocation)
-        });
+        if (finalEpochAllocation > 0) {
+            ranges[2] = ActiveSinkRange({
+                startEpoch: currentEpoch + uint40(epochs),
+                endEpoch: currentEpoch + uint40(epochs),
+                tokenAmount: uint96(finalEpochAllocation)
+            });
+        }
     }
 }

--- a/packages/evm-module/contracts/test/PublishingMathLibHarness.sol
+++ b/packages/evm-module/contracts/test/PublishingMathLibHarness.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import {PublishingMathLib} from "../libraries/PublishingMathLib.sol";
+
+contract PublishingMathLibHarness {
+    function prorateActiveSink(
+        uint96 tokenAmount,
+        uint40 currentEpoch,
+        uint256 epochs,
+        uint256 epochLengthInSeconds,
+        uint256 timeRemainingInCurrentEpoch
+    )
+        external
+        pure
+        returns (uint40[3] memory starts, uint40[3] memory ends, uint96[3] memory amounts)
+    {
+        PublishingMathLib.ActiveSinkRange[3] memory ranges = PublishingMathLib.prorateActiveSink(
+            tokenAmount,
+            currentEpoch,
+            epochs,
+            epochLengthInSeconds,
+            timeRemainingInCurrentEpoch
+        );
+
+        for (uint256 i; i < ranges.length; i++) {
+            starts[i] = ranges[i].startEpoch;
+            ends[i] = ranges[i].endEpoch;
+            amounts[i] = ranges[i].tokenAmount;
+        }
+    }
+}

--- a/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
@@ -819,6 +819,68 @@ describe('@unit DKGPublishingConvictionNFT', function () {
       expect((await NFT.getAccountInfo(1)).topUpBuffer).to.equal(0n);
     });
 
+    describe('PublishingMathLib integration', () => {
+      it('PCA coverPublishingCost event ranges match the shared active-sink calculator', async () => {
+        const source = readFileSync(
+          join(__dirname, '../../contracts/PublishingConviction.sol'),
+          'utf8',
+        );
+        expect(source).to.include('PublishingMathLib.prorateActiveSink(');
+
+        const committed = hre.ethers.parseEther('1200000');
+        await createAtWithAgent(committed, agent.address);
+
+        const baseCost = hre.ethers.parseEther('10000');
+        const expectedDiscount = (baseCost * (BPS - 7500n)) / BPS;
+        const kcEpochs = 3n;
+
+        const Harness = await hre.ethers.getContractFactory('PublishingMathLibHarness');
+        const harness = await Harness.deploy();
+        const epochLength = await ChronosContract.epochLength();
+        const targetTimestamp = BigInt(await time.latest()) + (epochLength / 2n);
+        const targetEpoch = await ChronosContract.epochAtTimestamp(targetTimestamp);
+        const timeRemaining =
+          (await ChronosContract.timestampForEpoch(targetEpoch + 1n)) - targetTimestamp;
+        const [starts, ends, amounts] = await harness.prorateActiveSink(
+          expectedDiscount,
+          targetEpoch,
+          kcEpochs,
+          epochLength,
+          timeRemaining,
+        );
+
+        await time.setNextBlockTimestamp(Number(targetTimestamp));
+        const tx = await NFT.connect(Kav10Signer).coverPublishingCost(
+          agent.address,
+          baseCost,
+          targetEpoch,
+          kcEpochs,
+        );
+        const receipt = await tx.wait();
+        const epsAddr = (await EpochStorageContract.getAddress()).toLowerCase();
+        const iface = EpochStorageContract.interface;
+        const actual: Array<[bigint, bigint, bigint]> = [];
+        for (const log of receipt!.logs) {
+          if (log.address.toLowerCase() !== epsAddr) continue;
+          let parsed;
+          try { parsed = iface.parseLog({ topics: log.topics as string[], data: log.data }); }
+          catch { continue; }
+          if (parsed?.name !== 'TokensAddedToEpochRange') continue;
+          expect(parsed.args.shardId).to.equal(STAKER_SHARD_ID);
+          actual.push([
+            BigInt(parsed.args.startEpoch),
+            BigInt(parsed.args.endEpoch),
+            BigInt(parsed.args.tokenAmount),
+          ]);
+        }
+
+        const expected = starts
+          .map((start, i) => [BigInt(start), BigInt(ends[i]), BigInt(amounts[i])] as [bigint, bigint, bigint])
+          .filter((range) => range[2] > 0n);
+        expect(actual).to.deep.equal(expected);
+      });
+    });
+
     it('spends epoch allowance first, then topUpBalance', async () => {
       const committed = hre.ethers.parseEther('120000');
       await createAtWithAgent(committed, agent.address);

--- a/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
@@ -2,6 +2,8 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import hre from 'hardhat';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import {
   Chronos,
@@ -153,6 +155,36 @@ describe('@unit DKGPublishingConvictionNFT', function () {
         expect(expectedBps(amount)).to.equal(bps);
       });
     }
+
+    it('logic contract and NFT wrapper share the ladder around every threshold', async () => {
+      const sources = [
+        readFileSync(join(__dirname, '../../contracts/PublishingConviction.sol'), 'utf8'),
+        readFileSync(join(__dirname, '../../contracts/DKGPublishingConvictionNFT.sol'), 'utf8'),
+      ];
+      for (const source of sources) {
+        expect(source).to.include('PublishingMathLib.discountBps(committedTRAC)');
+      }
+
+      const thresholds = [
+        hre.ethers.parseEther('25000'),
+        hre.ethers.parseEther('50000'),
+        hre.ethers.parseEther('100000'),
+        hre.ethers.parseEther('250000'),
+        hre.ethers.parseEther('500000'),
+        hre.ethers.parseEther('1000000'),
+      ];
+      const amounts = [
+        0n,
+        ...thresholds.flatMap((threshold) => [threshold - 1n, threshold, threshold + 1n]),
+        (1n << 96n) - 1n,
+      ];
+
+      for (const amount of amounts) {
+        const expected = expectedBps(amount);
+        expect(await NFT.getDiscountBps(amount)).to.equal(expected);
+        expect(await LogicContract.getDiscountBps(amount)).to.equal(expected);
+      }
+    });
   });
 
   // ======================================================================

--- a/packages/evm-module/test/unit/KnowledgeAssetsV10.test.ts
+++ b/packages/evm-module/test/unit/KnowledgeAssetsV10.test.ts
@@ -3,6 +3,8 @@ import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 import hre from 'hardhat';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import type {
   AskStorage,
@@ -477,6 +479,87 @@ describe('@unit KnowledgeAssetsV10', () => {
         // CG binding + value ledger written.
         expect(await CGStorageContract.kcToContextGraph(1)).to.equal(cgId);
         expect(await CGValueStorage.getCurrentCGValue(cgId)).to.be.gt(0n);
+      });
+    });
+
+    describe('PublishingMathLib integration', () => {
+      it('direct publish event ranges match the shared active-sink calculator', async () => {
+        const source = readFileSync(
+          join(__dirname, '../../contracts/KnowledgeAssetsV10.sol'),
+          'utf8',
+        );
+        expect(source).to.include('PublishingMathLib.prorateActiveSink(');
+
+        const creator = getDefaultKCCreator(accounts);
+        const { publishingNode, publisherIdentityId, receivingNodes, receiverIdentityIds } =
+          await setupNodes();
+        const cgId = await createOpenCG(creator);
+        const tokenAmount = ethers.parseEther('1000');
+        const epochs = 3;
+        const merkleRoot = ethers.keccak256(
+          ethers.toUtf8Bytes('publishing-math-direct-root'),
+        );
+
+        const p = await buildPublishParams({
+          chainId,
+          kav10Address,
+          receivingNodes,
+          publisherIdentityId,
+          receiverIdentityIds,
+          author: creator,
+          contextGraphId: cgId,
+          merkleRoot,
+          knowledgeAssetsAmount: 10,
+          byteSize: 1000,
+          epochs,
+          tokenAmount,
+          isImmutable: false,
+          publishOperationId: 'publishing-math-direct-op',
+        });
+
+        await TokenContract.connect(creator).approve(kav10Address, tokenAmount);
+
+        const epochLength = await ChronosContract.epochLength();
+        const targetEpoch = (await ChronosContract.getCurrentEpoch()) + 1n;
+        const elapsed = epochLength / 2n;
+        const targetTimestamp =
+          (await ChronosContract.timestampForEpoch(targetEpoch)) + elapsed;
+        const timeRemaining = epochLength - elapsed;
+
+        const Harness = await hre.ethers.getContractFactory('PublishingMathLibHarness');
+        const harness = await Harness.deploy();
+        const [starts, ends, amounts] = await harness.prorateActiveSink(
+          tokenAmount,
+          targetEpoch,
+          epochs,
+          epochLength,
+          timeRemaining,
+        );
+
+        await time.setNextBlockTimestamp(Number(targetTimestamp));
+        const tx = await KAV10.connect(creator).publish(p);
+        const receipt = await tx.wait();
+        const epsAddr = (await EpochStorageContract.getAddress()).toLowerCase();
+        const iface = EpochStorageContract.interface;
+        const actual: Array<[bigint, bigint, bigint]> = [];
+        for (const log of receipt!.logs) {
+          if (log.address.toLowerCase() !== epsAddr) continue;
+          let parsed;
+          try { parsed = iface.parseLog({ topics: log.topics as string[], data: log.data }); }
+          catch { continue; }
+          if (parsed?.name !== 'TokensAddedToEpochRange') continue;
+          expect(parsed.args.shardId).to.equal(STAKER_SHARD_ID);
+          actual.push([
+            BigInt(parsed.args.startEpoch),
+            BigInt(parsed.args.endEpoch),
+            BigInt(parsed.args.tokenAmount),
+          ]);
+        }
+
+        const expected = starts
+          .map((start, i) => [BigInt(start), BigInt(ends[i]), BigInt(amounts[i])] as [bigint, bigint, bigint])
+          .filter((range) => range[2] > 0n);
+        expect(actual).to.deep.equal(expected);
       });
     });
 

--- a/packages/evm-module/test/unit/PublishingMathLib.test.ts
+++ b/packages/evm-module/test/unit/PublishingMathLib.test.ts
@@ -52,4 +52,25 @@ describe('@unit PublishingMathLib', () => {
     expect(ends).to.deep.equal([20n, 0n, 21n]);
     expect(amounts).to.deep.equal([250n, 0n, 750n]);
   });
+
+  it('places large active sink remainder dust in the final epoch', async () => {
+    const Harness = await hre.ethers.getContractFactory('PublishingMathLibHarness');
+    const harness = await Harness.deploy();
+
+    const [starts, ends, amounts] = await harness.prorateActiveSink(
+      hre.ethers.parseEther('123456789.123456789123456789'),
+      12345,
+      365,
+      86_400,
+      43_210,
+    );
+
+    expect(starts).to.deep.equal([12345n, 12346n, 12710n]);
+    expect(ends).to.deep.equal([12345n, 12709n, 12710n]);
+    expect(amounts).to.deep.equal([
+      169158037101235662672011n,
+      123118551345036359564214308n,
+      169079741319193896570470n,
+    ]);
+  });
 });

--- a/packages/evm-module/test/unit/PublishingMathLib.test.ts
+++ b/packages/evm-module/test/unit/PublishingMathLib.test.ts
@@ -73,4 +73,21 @@ describe('@unit PublishingMathLib', () => {
       169079741319193896570470n,
     ]);
   });
+
+  it('leaves the current active sink slot empty when a small allocation rounds to zero', async () => {
+    const Harness = await hre.ethers.getContractFactory('PublishingMathLibHarness');
+    const harness = await Harness.deploy();
+
+    const [starts, ends, amounts] = await harness.prorateActiveSink(
+      10n,
+      10,
+      3,
+      10,
+      1,
+    );
+
+    expect(starts).to.deep.equal([0n, 11n, 13n]);
+    expect(ends).to.deep.equal([0n, 12n, 13n]);
+    expect(amounts).to.deep.equal([0n, 6n, 4n]);
+  });
 });

--- a/packages/evm-module/test/unit/PublishingMathLib.test.ts
+++ b/packages/evm-module/test/unit/PublishingMathLib.test.ts
@@ -18,4 +18,21 @@ describe('@unit PublishingMathLib', () => {
     expect(ends).to.deep.equal([10n, 13n, 14n]);
     expect(amounts).to.deep.equal([125n, 750n, 125n]);
   });
+
+  it('leaves the final active sink slot empty when the tail allocation is zero', async () => {
+    const Harness = await hre.ethers.getContractFactory('PublishingMathLibHarness');
+    const harness = await Harness.deploy();
+
+    const [starts, ends, amounts] = await harness.prorateActiveSink(
+      1000n,
+      10,
+      4,
+      100,
+      100,
+    );
+
+    expect(starts).to.deep.equal([10n, 11n, 0n]);
+    expect(ends).to.deep.equal([10n, 13n, 0n]);
+    expect(amounts).to.deep.equal([250n, 750n, 0n]);
+  });
 });

--- a/packages/evm-module/test/unit/PublishingMathLib.test.ts
+++ b/packages/evm-module/test/unit/PublishingMathLib.test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import hre from 'hardhat';
+
+describe('@unit PublishingMathLib', () => {
+  it('prorates active sink rewards across current, full, and final epochs', async () => {
+    const Harness = await hre.ethers.getContractFactory('PublishingMathLibHarness');
+    const harness = await Harness.deploy();
+
+    const [starts, ends, amounts] = await harness.prorateActiveSink(
+      1000n,
+      10,
+      4,
+      100,
+      50,
+    );
+
+    expect(starts).to.deep.equal([10n, 11n, 14n]);
+    expect(ends).to.deep.equal([10n, 13n, 14n]);
+    expect(amounts).to.deep.equal([125n, 750n, 125n]);
+  });
+});

--- a/packages/evm-module/test/unit/PublishingMathLib.test.ts
+++ b/packages/evm-module/test/unit/PublishingMathLib.test.ts
@@ -35,4 +35,21 @@ describe('@unit PublishingMathLib', () => {
     expect(ends).to.deep.equal([10n, 13n, 0n]);
     expect(amounts).to.deep.equal([250n, 750n, 0n]);
   });
+
+  it('leaves the middle active sink slot empty for one storage epoch', async () => {
+    const Harness = await hre.ethers.getContractFactory('PublishingMathLibHarness');
+    const harness = await Harness.deploy();
+
+    const [starts, ends, amounts] = await harness.prorateActiveSink(
+      1000n,
+      20,
+      1,
+      100,
+      25,
+    );
+
+    expect(starts).to.deep.equal([20n, 0n, 21n]);
+    expect(ends).to.deep.equal([20n, 0n, 21n]);
+    expect(amounts).to.deep.equal([250n, 0n, 750n]);
+  });
 });


### PR DESCRIPTION
## Summary
- Centralizes publishing conviction discount tier math in `PublishingMathLib` while preserving existing public selectors.
- Extracts active-sink proration into `PublishingMathLib.prorateActiveSink` and wires direct publish/update plus conviction-funded publish through it.
- Adds harness-backed unit/integration coverage for discount tiers, active-sink edge cases, and emitted reward ranges.

## Test Plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --dir packages/evm-module exec hardhat test --network hardhat --config hardhat.node.config.ts test/unit/DKGPublishingConvictionNFT.test.ts --grep "discount tier ladder"`
- [x] `pnpm --dir packages/evm-module exec hardhat test --network hardhat --config hardhat.node.config.ts --grep "PublishingMathLib"`
- [x] `pnpm --dir packages/evm-module exec hardhat test --network hardhat --config hardhat.node.config.ts test/unit/KnowledgeAssetsV10.test.ts test/unit/DKGPublishingConvictionNFT.test.ts --grep "PublishingMathLib integration"`