### PR TITLE
feat(node-ui): S3 polish carryover — Root mini-card + count-accuracy fixes

### DIFF
--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -287,9 +287,15 @@ export function subGraphOf(gUri: string, cgId: string): string | undefined {
   // `assertion` is the WM assertion-graph segment
   // (`<cg>/assertion/<addr>/<name>`), not a user-facing sub-graph; leaking
   // it as a slug surfaces a phantom "Assertion" sub-graph chip on entity
-  // detail pages. Filter alongside underscore-prefixed bookkeeping
+  // detail pages. `meta` is the profile / bookkeeping graph
+  // (`<cg>/meta/_shared_memory`); it's filtered downstream by
+  // `RESERVED_SUB_GRAPH_SLUGS` so it never gets a chip, but pre-filter
+  // it here too so entities with ONLY a `meta` membership don't end up
+  // with `subGraphs = Set{'meta'}` — that produced the GH #806 SWM
+  // layer-mode gap where `All N · Root M` disagreed by the count of
+  // such entities. Filter alongside underscore-prefixed bookkeeping
   // segments so `entity.subGraphs` stays semantically pure.
-  if (!seg || seg.startsWith('_') || seg === 'assertion') return undefined;
+  if (!seg || seg.startsWith('_') || seg === 'assertion' || seg === 'meta') return undefined;
   return seg;
 }
 

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -222,11 +222,28 @@ function wmSparql(cgId: string) {
   const cgUri = `did:dkg:context-graph:${cgId}`;
   // WM = every per-agent assertion under the project, regardless of
   // sub-graph. We match any graph whose path contains `/assertion/`.
+  //
+  // PR #818 Codex sweep 3 (ux-lead Finding 1 verdict) — exclude the
+  // `meta` namespace. Profile artifacts (prof:Profile,
+  // prof:SubGraphBinding, prof:FilterChip, prof:QueryCatalog,
+  // prof:SavedQuery) are published as assertions under
+  // `<cg>/meta/assertion/<addr>/<name>`, so the pre-fix
+  // `CONTAINS(/assertion/)` filter scooped them into `memory.entityList`
+  // alongside real user knowledge. Those entities are UI configuration,
+  // not user knowledge — they have their own surfaces via
+  // `useProjectProfile` (which queries the meta graphs directly via
+  // its own SPARQL, not via this hook). Mirrors the meta-exclusion
+  // policy that `vmSparql` already enforces (`:262-269`); GH #806's
+  // `subGraphOf` `meta` filter handles the chip-row side and this
+  // upstream filter handles the entity-list side — same family.
   return `SELECT ?s ?p ?o ?g WHERE {
     GRAPH ?g { ?s ?p ?o }
     FILTER(
       STRSTARTS(STR(?g), "${cgUri}/") &&
-      CONTAINS(STR(?g), "/assertion/")
+      CONTAINS(STR(?g), "/assertion/") &&
+      STR(?g) != "${cgUri}/meta" &&
+      !CONTAINS(STR(?g), "/meta/") &&
+      !STRENDS(STR(?g), "/_meta")
     )
   } LIMIT ${WM_LIMIT}`;
 }
@@ -236,11 +253,21 @@ function swmSparql(cgId: string) {
   // Any graph whose tail ends in `_shared_memory` (excluding the sibling
   // `_shared_memory_meta` bookkeeping graphs which carry lifecycle
   // provenance rather than user data).
+  //
+  // PR #818 Codex sweep 3 (ux-lead Finding 1 verdict) — exclude
+  // `<cg>/meta/_shared_memory` so SWM-promoted profile artifacts don't
+  // surface in the user-facing entityList. Mirrors `vmSparql`'s
+  // existing meta-exclusion policy (`:262-269`). Without this,
+  // `STRENDS(/_shared_memory)` admits `<cg>/meta/_shared_memory` —
+  // a profile-namespace graph — and the entity becomes a "root SWM
+  // entity" in every consumer downstream.
   return `SELECT ?s ?p ?o ?g WHERE {
     GRAPH ?g { ?s ?p ?o }
     FILTER(
       STRSTARTS(STR(?g), "${cgUri}") &&
-      STRENDS(STR(?g), "/_shared_memory")
+      STRENDS(STR(?g), "/_shared_memory") &&
+      STR(?g) != "${cgUri}/meta/_shared_memory" &&
+      !CONTAINS(STR(?g), "/meta/")
     )
   } LIMIT ${SWM_LIMIT}`;
 }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6455,18 +6455,28 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   transform: translateY(-1px);
   box-shadow: 0 8px 24px -12px var(--sg-color, rgba(100,116,139,0.6));
 }
-/* GH #813 — Root mini-card chrome. Dashed outer border reads as
-   "synthesized bucket" vs the solid borders of daemon-emitted
-   named-subgraph cards, mirroring the SubGraphBar Root chip's
-   neutral chrome. Per-card `--sg-color` injection is suppressed
-   in the JSX so the gradient + hover-shadow fall through to the
-   neutral fallback (--border-strong / rgba(100,116,139,…)), and
-   the icon picks up its color from the inherited tertiary token
-   instead of a per-slug accent. Position: rendered last in the
-   grid (mirrors Root chip's rightmost chip-row position). */
+/* GH #813 — Root mini-card chrome. Solid `--border-subtle` reads
+   as a quieter daemon-emitted card vs the tinted named-subgraph
+   cards' `card.color + '55'` accent; the synthesized bucket stays
+   visually present without competing with the named cards for
+   attention.
+   Per-card `--sg-color` injection is suppressed in the JSX so the
+   gradient + hover-shadow fall through to the neutral fallback
+   (rgba(100,116,139,…)), and the icon picks up its color from
+   the inherited tertiary token instead of a per-slug accent.
+   Position: rendered last in the grid (mirrors Root chip's
+   rightmost chip-row position).
+   Round 1 visual revision (ui-lead): the original dashed +
+   `--border-strong` treatment was rejected — in this codebase
+   dashed reads as broken/disabled/drop-zone, `--border-strong`
+   is the loud active/hover token (so the Root card became the
+   LOUDEST card in the grid, opposite of intent), and dashed
+   truncates into irregular dot artifacts on the 12px
+   border-radius corners. Solid + subtle is the locked
+   treatment; base `.v10-sgov-card` rule's `border: 1px solid …`
+   cascades, so only the color token swaps here. */
 .v10-sgov-card.root {
-  border-style: dashed;
-  border-color: var(--border-strong);
+  border-color: var(--border-subtle);
 }
 .v10-sgov-card.root .v10-sgov-card-icon {
   color: var(--text-tertiary);

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -6455,6 +6455,22 @@ body.light .v10-ka-graph-shell .v10-graph-canvas {
   transform: translateY(-1px);
   box-shadow: 0 8px 24px -12px var(--sg-color, rgba(100,116,139,0.6));
 }
+/* GH #813 — Root mini-card chrome. Dashed outer border reads as
+   "synthesized bucket" vs the solid borders of daemon-emitted
+   named-subgraph cards, mirroring the SubGraphBar Root chip's
+   neutral chrome. Per-card `--sg-color` injection is suppressed
+   in the JSX so the gradient + hover-shadow fall through to the
+   neutral fallback (--border-strong / rgba(100,116,139,…)), and
+   the icon picks up its color from the inherited tertiary token
+   instead of a per-slug accent. Position: rendered last in the
+   grid (mirrors Root chip's rightmost chip-row position). */
+.v10-sgov-card.root {
+  border-style: dashed;
+  border-color: var(--border-strong);
+}
+.v10-sgov-card.root .v10-sgov-card-icon {
+  color: var(--text-tertiary);
+}
 .v10-sgov-card-head {
   display: flex; align-items: flex-start; gap: 10px;
   padding: 10px 12px 8px 12px;

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4157,40 +4157,43 @@ export function SubGraphOverviewGrid({
     // fires for Root"). A triple admitted here must have NO
     // subGraph tag AND an endpoint in scope.
     //
-    // PR #818 Codex sweep 2 — GH #805 family on this new surface.
-    // Iterating `memory.allTriples` directly (the original shape)
-    // reintroduces the WM-residue + SWM cross-graph duplication
-    // GH #805 just fixed for the Overview/subtitle totals: the
-    // daemon's raw triples include `<assertion>` residue from
-    // promoted entities (the entity's canonical trustLevel has
-    // moved past WM but its WM-origin row keeps returning from
-    // `wmSparql`) and per-sub-graph SWM duplicates (the same SPO
-    // shipped under both `<cg>/_shared_memory` and
-    // `<cg>/<sg>/_shared_memory`). Both inflate `tripleCount` AND
-    // the rendered mini-graph slice.
-    //
-    // Fix: iterate the union of the per-layer slices the same
-    // surface above (`subtitleTripleCount`) already reads from.
-    // `useLayerTriples` applies the canonical-SPO dedup AND the
-    // subject-trust-level residue filter, so the resulting union
-    // is the layer-correct triple universe the Root card should
-    // scope into. Card-level seenSpo still runs (per-layer slices
-    // dedup within each layer, but a triple legitimately appearing
-    // in multiple layers — e.g. an `rdfs:label` published under
-    // both WM and SWM via lifecycle metadata — would survive as
-    // distinct entries before the card-level dedup).
+    // PR #818 Codex sweep 4 (ux-lead Finding 1+2 verdict A) —
+    // reverted from sweep-2's `useLayerTriples` union back to
+    // `memory.allTriples` filtered by `!t.subGraph`. Sweep 2's
+    // layer-correct universe was a fix at the symptom (Root
+    // inflation) that introduced two regressions of its own at
+    // the next consumer downstream:
+    //   • Per-slice SPO-dedup race — `useLayerTriples` dedupes
+    //     within each layer independently, so the same SPO under
+    //     both root and per-sub-graph SWM graphs collapsed to one
+    //     ENTRY in the swm slice. Joining the slices then admitted
+    //     it once. Outcome: a cross-graph triple involving a root
+    //     entity could under-count to zero on the Root mini-card.
+    //   • Mixed-layer edge drop — `useLayerTriples` applies a
+    //     subject-trust-level residue filter (drops triples whose
+    //     subject's canonical trustLevel doesn't match the slice's
+    //     layer). For a WM root entity pointing at an SWM entity,
+    //     the row enters the wm slice (subject is WM), passes the
+    //     subject check, but the row's `layer: 'shared'` means it
+    //     was never in the wm slice. The same row enters the swm
+    //     slice but fails the subject-trust check (subject is WM,
+    //     slice is SWM). The mixed-layer edge falls through every
+    //     slice and never reaches the Root card.
+    // ux-lead's call: restoring symmetry with the named-card path
+    // (`memory.allTriples` filtered by `!t.subGraph` vs
+    // `t.subGraph === slug`) gives both cards the same machinery
+    // and the same edge cases. Inflation (WM residue + SWM cross-
+    // graph) is consistent across Root AND named cards — easier
+    // to reason about and easier to fix in one render-side follow-
+    // up (GH #819) than a Root-specific divergence between
+    // under-count and inflation.
     //
     // PR #818 Codex sweep 1 — Bug M family (preserved). The
     // canonical-URI membership check + canonical SPO-dedup key
-    // still apply on the layer-filtered universe.
+    // still apply on the symmetric-with-named universe.
     const rootTriples: Triple[] = [];
     const seenSpo = new Set<string>();
-    const layerCorrectUniverse: Triple[] = [
-      ...wmSubtitleTriples,
-      ...swmSubtitleTriples,
-      ...vmSubtitleTriples,
-    ];
-    for (const t of layerCorrectUniverse) {
+    for (const t of memory.allTriples) {
       if (t.subGraph) continue;
       const subjCanon = canonicalEntityUri(t.subject);
       const objCanon = canonicalEntityUri(t.object);
@@ -4200,47 +4203,11 @@ export function SubGraphOverviewGrid({
       seenSpo.add(key);
       rootTriples.push({ subject: t.subject, predicate: t.predicate, object: t.object });
     }
-    // PR #818 Codex sweep 1 — apply the same `MAX_PER_CARD`
-    // heaviest-subjects sampling the named-card path uses at
-    // `:3935-3949`. The earlier comment waved this off on the
-    // theory that the root entity set is small, but Codex flagged
-    // the counterexample: large initial seeds + agents writing
-    // without sub-graph tags can produce thousands of untagged
-    // triples whose endpoints touch root entities — same
-    // RdfGraph layout lock the named-card cap was added to
-    // prevent. Same sampling preserves cluster topology better
-    // than a random first-N truncation.
-    // PR #818 Codex sweep 2 — pre-check `kept + subjectDegree >
-    // MAX_PER_CARD` BEFORE adding (instead of `kept >= MAX_PER_CARD`
-    // AFTER) so a single dominant subject can't smuggle the whole
-    // heavy cluster through. When the heaviest subject's degree
-    // alone exceeds the cap the pre-check exits with an empty
-    // `keep` — fall back to admitting that one subject so the
-    // card shows the dominant hub instead of an empty body; the
-    // post-filter `slice(0, MAX_PER_CARD)` trims its long tail.
-    // PR #818 Codex sweep 3 — `continue` (was `break`) so the loop
-    // scans further for smaller satellites that still fit. Same
-    // dense-pack rationale as the named-card path above; see the
-    // sweep-3 comment block at `:3935-3953` for the full trade-off.
-    // Same fix applied at the named-card path above (`:3935-3953`).
-    let cappedRootTriples = rootTriples;
-    if (rootTriples.length > MAX_PER_CARD) {
-      const degree = new Map<string, number>();
-      for (const t of rootTriples) degree.set(t.subject, (degree.get(t.subject) ?? 0) + 1);
-      const order = [...degree.entries()]
-        .sort((a, b) => b[1] - a[1])
-        .map(([uri]) => uri);
-      const keep = new Set<string>();
-      let kept = 0;
-      for (const uri of order) {
-        const subjectDegree = degree.get(uri) ?? 0;
-        if (kept + subjectDegree > MAX_PER_CARD) continue;
-        keep.add(uri);
-        kept += subjectDegree;
-      }
-      if (keep.size === 0 && order.length > 0) keep.add(order[0]);
-      cappedRootTriples = rootTriples.filter(t => keep.has(t.subject)).slice(0, MAX_PER_CARD);
-    }
+    // PR #818 Codex sweep 4 (finding 3) — shared cap helper. The
+    // earlier inline copy duplicated the named-card sampling shape
+    // verbatim; refactored to call `applyHeaviestSubjectsCap` so
+    // both paths stay in lockstep when the sampling rule evolves.
+    const cappedRootTriples = applyHeaviestSubjectsCap(rootTriples);
     const binding = profile?.forSubGraph(ROOT_SLUG_SENTINEL) ?? {};
     return {
       slug: ROOT_SLUG_SENTINEL,
@@ -4265,7 +4232,7 @@ export function SubGraphOverviewGrid({
       layerCounts: { wm, swm, vm },
       entityTrustByUri: rootEntityTrust,
     };
-  }, [memory.entityList, wmSubtitleTriples, swmSubtitleTriples, vmSubtitleTriples, profile]);
+  }, [memory.entityList, memory.allTriples, profile]);
 
   if (loading && cards.length === 0) {
     return (

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4127,16 +4127,27 @@ export function SubGraphOverviewGrid({
     // Untagged-recovery only — Root bucket has no tagged triples
     // by definition (see SubGraphDetailView's rule 1 → "never
     // fires for Root"). A triple admitted here must have NO
-    // subGraph tag AND an endpoint in scope; the same
-    // `MAX_PER_CARD` sampling the named branch applies isn't
-    // needed at the mini-card scale because the recovery slice
-    // is bounded by the root entity set.
+    // subGraph tag AND an endpoint in scope.
+    //
+    // PR #818 Codex sweep 1 — Bug M family. `rootEntityUris` is
+    // built from `canonicalEntityUri(e.uri)` above, but triples
+    // from `memory.allTriples` carry the daemon-emitted raw forms
+    // (often wrapped `<urn:...>`). The membership check needs the
+    // canonical form on the triple endpoints to match the set, and
+    // the SPO-dedup key needs the canonical form too — otherwise
+    // wrapped/bare variants of the same `(s,p,o)` enter as two
+    // distinct rows. Same shape as the upstream Bug M fix at the
+    // `entityTrustByUriBySubGraph` producer; canonicalising on the
+    // consumer side here keeps the rootEntityUris set single-form
+    // and fixes the dedup key in the same pass.
     const rootTriples: Triple[] = [];
     const seenSpo = new Set<string>();
     for (const t of memory.allTriples) {
       if (t.subGraph) continue;
-      if (!rootEntityUris.has(t.subject) && !rootEntityUris.has(t.object)) continue;
-      const key = `${t.subject}|${t.predicate}|${t.object}`;
+      const subjCanon = canonicalEntityUri(t.subject);
+      const objCanon = canonicalEntityUri(t.object);
+      if (!rootEntityUris.has(subjCanon) && !rootEntityUris.has(objCanon)) continue;
+      const key = `${subjCanon}|${t.predicate}|${objCanon}`;
       if (seenSpo.has(key)) continue;
       seenSpo.add(key);
       rootTriples.push({ subject: t.subject, predicate: t.predicate, object: t.object });

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4275,10 +4275,10 @@ export function SubGraphMiniCard({
   };
   onNodeClick?: (node: any) => void;
   onOpen: () => void;
-  // GH #813 — `root` opts into the dashed-border, neutral-color
-  // chrome that distinguishes the synthesized Root bucket from
-  // daemon-emitted named sub-graphs. Same render shape, different
-  // chrome modifier.
+  // GH #813 — `root` opts into the quieter neutral-border chrome
+  // that distinguishes the synthesized Root bucket from daemon-
+  // emitted named sub-graphs (which carry per-card `--sg-color`
+  // tinted borders). Same render shape, different chrome modifier.
   variant?: 'root';
 }) {
   // Per-URI trust palette for the mini-graph (#3 polish).

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4129,20 +4129,40 @@ export function SubGraphOverviewGrid({
     // fires for Root"). A triple admitted here must have NO
     // subGraph tag AND an endpoint in scope.
     //
-    // PR #818 Codex sweep 1 — Bug M family. `rootEntityUris` is
-    // built from `canonicalEntityUri(e.uri)` above, but triples
-    // from `memory.allTriples` carry the daemon-emitted raw forms
-    // (often wrapped `<urn:...>`). The membership check needs the
-    // canonical form on the triple endpoints to match the set, and
-    // the SPO-dedup key needs the canonical form too — otherwise
-    // wrapped/bare variants of the same `(s,p,o)` enter as two
-    // distinct rows. Same shape as the upstream Bug M fix at the
-    // `entityTrustByUriBySubGraph` producer; canonicalising on the
-    // consumer side here keeps the rootEntityUris set single-form
-    // and fixes the dedup key in the same pass.
+    // PR #818 Codex sweep 2 — GH #805 family on this new surface.
+    // Iterating `memory.allTriples` directly (the original shape)
+    // reintroduces the WM-residue + SWM cross-graph duplication
+    // GH #805 just fixed for the Overview/subtitle totals: the
+    // daemon's raw triples include `<assertion>` residue from
+    // promoted entities (the entity's canonical trustLevel has
+    // moved past WM but its WM-origin row keeps returning from
+    // `wmSparql`) and per-sub-graph SWM duplicates (the same SPO
+    // shipped under both `<cg>/_shared_memory` and
+    // `<cg>/<sg>/_shared_memory`). Both inflate `tripleCount` AND
+    // the rendered mini-graph slice.
+    //
+    // Fix: iterate the union of the per-layer slices the same
+    // surface above (`subtitleTripleCount`) already reads from.
+    // `useLayerTriples` applies the canonical-SPO dedup AND the
+    // subject-trust-level residue filter, so the resulting union
+    // is the layer-correct triple universe the Root card should
+    // scope into. Card-level seenSpo still runs (per-layer slices
+    // dedup within each layer, but a triple legitimately appearing
+    // in multiple layers — e.g. an `rdfs:label` published under
+    // both WM and SWM via lifecycle metadata — would survive as
+    // distinct entries before the card-level dedup).
+    //
+    // PR #818 Codex sweep 1 — Bug M family (preserved). The
+    // canonical-URI membership check + canonical SPO-dedup key
+    // still apply on the layer-filtered universe.
     const rootTriples: Triple[] = [];
     const seenSpo = new Set<string>();
-    for (const t of memory.allTriples) {
+    const layerCorrectUniverse: Triple[] = [
+      ...wmSubtitleTriples,
+      ...swmSubtitleTriples,
+      ...vmSubtitleTriples,
+    ];
+    for (const t of layerCorrectUniverse) {
       if (t.subGraph) continue;
       const subjCanon = canonicalEntityUri(t.subject);
       const objCanon = canonicalEntityUri(t.object);
@@ -4202,7 +4222,7 @@ export function SubGraphOverviewGrid({
       layerCounts: { wm, swm, vm },
       entityTrustByUri: rootEntityTrust,
     };
-  }, [memory.entityList, memory.allTriples, profile]);
+  }, [memory.entityList, wmSubtitleTriples, swmSubtitleTriples, vmSubtitleTriples, profile]);
 
   if (loading && cards.length === 0) {
     return (

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -201,6 +201,55 @@ function GraphSingletonShelf({
   );
 }
 
+// PR #818 Codex sweep 4 (finding 3) — extracted shared cap helper.
+// Both `SubGraphOverviewGrid`'s named-card path and the Root mini-
+// card consume this so the cap shape stays in lockstep across the
+// dual paths (the post-PR-#793 polish cycle accumulated two
+// parallel inline copies; sweep 2-3 fixes had to be applied twice
+// and qa caught the parity drift). Extracting it here closes the
+// duplication and gives one site to evolve the sampling rule.
+//
+// Sampling strategy: cluster topology matters more than uniform
+// random first-N. We keep every triple for the N heaviest-degree
+// subjects so the rendered slice reads as a representative slice
+// of the bucket's connected structure.
+//
+// Pre-check `kept + subjectDegree > MAX_PER_CARD` BEFORE adding so
+// a single dominant subject can't smuggle the whole heavy cluster
+// through (`break` shape would leave 100s of rows unaccounted for
+// because `keep.has(subject)` is true for every row of the
+// dominant subject). `continue` (not `break`) so the loop scans
+// further for smaller satellites that still fit — denser pack at
+// the cap, friendlier user-facing outcome than under-fill.
+//
+// Residual fallback: when EVERY subject's degree alone exceeds
+// MAX_PER_CARD, the pre-check rejects every subject and exits
+// with an empty `keep`. The card would render the empty-body
+// branch on a clearly-populated bucket — strictly worse UX. Fall
+// back to admitting the heaviest subject so SOMETHING renders;
+// the post-`slice(0, MAX_PER_CARD)` then trims its long tail.
+// The rendered slice loses some cluster topology in that residual
+// case, but the user sees the dominant hub vs an empty card.
+const MAX_PER_CARD = 2500;
+function applyHeaviestSubjectsCap(triples: Triple[], maxPerCard: number = MAX_PER_CARD): Triple[] {
+  if (triples.length <= maxPerCard) return triples;
+  const degree = new Map<string, number>();
+  for (const t of triples) degree.set(t.subject, (degree.get(t.subject) ?? 0) + 1);
+  const order = [...degree.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([uri]) => uri);
+  const keep = new Set<string>();
+  let kept = 0;
+  for (const uri of order) {
+    const subjectDegree = degree.get(uri) ?? 0;
+    if (kept + subjectDegree > maxPerCard) continue;
+    keep.add(uri);
+    kept += subjectDegree;
+  }
+  if (keep.size === 0 && order.length > 0) keep.add(order[0]);
+  return triples.filter(t => keep.has(t.subject)).slice(0, maxPerCard);
+}
+
 function GraphSurface({
   title,
   scopeLabel,
@@ -3906,15 +3955,10 @@ export function SubGraphOverviewGrid({
   }, [contextGraphId]);
 
   // Bucket every triple by its origin sub-graph so each mini-graph renders
-  // just its slice. We dedupe on (s,p,o) and cap per-bucket to keep the
-  // mini-graph canvases snappy. Without the cap, sub-graphs like `code`
-  // (~25k triples) can lock up the tab while force-graph runs its layout.
-  //
-  // Sampling strategy: when a sub-graph exceeds MAX_PER_CARD, we keep
-  // every triple for the N heaviest root entities (highest degree) so
-  // the user sees a representative, connected slice rather than a
-  // random first-N truncation that breaks clusters apart.
-  const MAX_PER_CARD = 2500;
+  // just its slice. We dedupe on (s,p,o) and cap per-bucket via the
+  // shared `applyHeaviestSubjectsCap` helper at module scope (see the
+  // doc block there for the sampling / dense-pack / residual-fallback
+  // rationale carried over from sweeps 1-3).
   const triplesBySubGraph = useMemo(() => {
     const bySg = new Map<string, Triple[]>();
     const seen = new Map<string, Set<string>>();
@@ -3929,56 +3973,8 @@ export function SubGraphOverviewGrid({
       if (!arr) { arr = []; bySg.set(t.subGraph, arr); }
       arr.push({ subject: t.subject, predicate: t.predicate, object: t.object });
     }
-    // If a bucket is over the cap, fall back to sampling the heaviest
-    // subjects and dropping the long tail. This preserves cluster
-    // topology far better than truncation.
-    //
-    // PR #818 Codex sweep 2 — earlier shape `if (kept >= MAX_PER_CARD)
-    // break;` checked AFTER adding the current subject's full row
-    // count, so a single dominant subject with N > MAX_PER_CARD rows
-    // would let the entire heavy cluster through (`keep.has(subject)`
-    // is true for every row of the dominant subject, returning all N
-    // from the filter). Pre-check `kept + subjectDegree > MAX_PER_CARD`
-    // BEFORE adding so we stop on the subject that would push us
-    // over.
-    //
-    // Residual case: when the heaviest subject's degree alone exceeds
-    // MAX_PER_CARD, the pre-check rejects every subject and exits
-    // with an empty `keep` — the card would render the empty-body
-    // branch even though the bucket clearly has content. Fall back
-    // to admitting that single heaviest subject so SOMETHING
-    // renders; the post-filter `slice(0, MAX_PER_CARD)` then trims
-    // its long tail. The rendered slice loses some cluster topology
-    // but the user sees the dominant hub, which is the right user-
-    // facing trade-off (vs an empty card on a populated bucket).
-    //
-    // PR #818 Codex sweep 3 — `continue` (was `break`) on a subject
-    // that doesn't fit, so the loop scans further for smaller
-    // satellites that DO fit. With degrees `[2400, 200, 50, 50]`
-    // and cap 2500: `break` would stop at B(200) leaving 100
-    // headroom unused (renders 2400). `continue` skips B but lets
-    // C+D land for a dense pack at 2500. Trade-off: `break`
-    // preserved the heaviest-cluster topology contract; `continue`
-    // packs the cap denser at the cost of potentially picking a
-    // satellite over a third heavy hub that didn't quite fit. The
-    // denser pack is the friendlier user-facing outcome.
     for (const [sg, triples] of bySg) {
-      if (triples.length <= MAX_PER_CARD) continue;
-      const degree = new Map<string, number>();
-      for (const t of triples) degree.set(t.subject, (degree.get(t.subject) ?? 0) + 1);
-      const order = [...degree.entries()]
-        .sort((a, b) => b[1] - a[1])
-        .map(([uri]) => uri);
-      const keep = new Set<string>();
-      let kept = 0;
-      for (const uri of order) {
-        const subjectDegree = degree.get(uri) ?? 0;
-        if (kept + subjectDegree > MAX_PER_CARD) continue;
-        keep.add(uri);
-        kept += subjectDegree;
-      }
-      if (keep.size === 0 && order.length > 0) keep.add(order[0]);
-      bySg.set(sg, triples.filter(t => keep.has(t.subject)).slice(0, MAX_PER_CARD));
+      bySg.set(sg, applyHeaviestSubjectsCap(triples));
     }
     return bySg;
   }, [memory.allTriples]);

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4197,7 +4197,24 @@ export function SubGraphOverviewGrid({
       />
     );
   }
-  if (cards.length === 0) {
+  // PR #818 Codex sweep 1 — the teaching empty state fires when
+  // there are no named sub-graphs registered. Pre-sweep the gate
+  // was `cards.length === 0` alone, which short-circuited the
+  // grid render BEFORE the Root mini-card render block — so a CG
+  // with no named sub-graphs but non-zero root entities lost the
+  // direct Root affordance (user had to click the empty-state's
+  // "View root" CTA instead of seeing the Root card in-place).
+  //
+  // Post-sweep: only render the teaching empty state when BOTH the
+  // named-sub-graph set AND the Root bucket are empty — the only
+  // truly "nothing to show" case. Three resulting states:
+  //   • named cards + Root entities → full grid (named cards +
+  //     Root card last)
+  //   • zero named cards + Root entities → grid renders only the
+  //     Root card (it stands alone as the entire grid)
+  //   • zero named cards + zero Root entities → teaching empty
+  //     state (unchanged behaviour for the truly-empty case)
+  if (cards.length === 0 && rootCard.entityCount === 0) {
     // Teaching empty state (UX §4.4.1). Replaces the previous bare
     // "No sub-graphs registered yet." — explains what a subgraph is,
     // how one comes into being, and offers a one-click jump to the

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4191,18 +4191,39 @@ export function SubGraphOverviewGrid({
     // PR #818 Codex sweep 1 — Bug M family (preserved). The
     // canonical-URI membership check + canonical SPO-dedup key
     // still apply on the symmetric-with-named universe.
-    const rootTriples: Triple[] = [];
+    //
+    // PR #818 Codex sweep 6 — admission rule symmetry. Sweep 4's
+    // inline check was OR-membership ("admit if either endpoint
+    // is in rootEntityUris"), but named cards route through
+    // `filterTriplesToEntities(rawTriples, cardEntityUris)` at
+    // `:4051`, which is AND-membership with an `rdf:type`
+    // exemption. User caught the divergence on `ui-refresh`:
+    // entity `urn:epcis:...:gtin:50127962004651:lot:P240526X`
+    // lives in `epcis-supply-chain` (subGraphs non-empty → not
+    // in rootEntityUris → correctly absent from the Root entity
+    // list), but the daemon ships untagged copies of its triples
+    // in `<cg>/_shared_memory`. Pre-sweep-6 OR-membership
+    // admitted those rows because the SUBJECT was in
+    // rootEntityUris (a different entity), so the non-root
+    // object rendered as a node — Root mini-graph had more
+    // nodes than the badge claimed.
+    //
+    // Fix: dedup SPO first (Bug M canonicalization preserved),
+    // then route through `filterTriplesToEntities` so admission
+    // matches the named-card rule exactly. Same machinery now
+    // includes the same AND-membership + rdf:type exemption.
+    const candidateTriples: Triple[] = [];
     const seenSpo = new Set<string>();
     for (const t of memory.allTriples) {
       if (t.subGraph) continue;
       const subjCanon = canonicalEntityUri(t.subject);
       const objCanon = canonicalEntityUri(t.object);
-      if (!rootEntityUris.has(subjCanon) && !rootEntityUris.has(objCanon)) continue;
       const key = `${subjCanon}|${t.predicate}|${objCanon}`;
       if (seenSpo.has(key)) continue;
       seenSpo.add(key);
-      rootTriples.push({ subject: t.subject, predicate: t.predicate, object: t.object });
+      candidateTriples.push({ subject: t.subject, predicate: t.predicate, object: t.object });
     }
+    const rootTriples = filterTriplesToEntities(candidateTriples, rootEntityUris);
     // PR #818 Codex sweep 4 (finding 3) — shared cap helper. The
     // earlier inline copy duplicated the named-card sampling shape
     // verbatim; refactored to call `applyHeaviestSubjectsCap` so

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3932,6 +3932,25 @@ export function SubGraphOverviewGrid({
     // If a bucket is over the cap, fall back to sampling the heaviest
     // subjects and dropping the long tail. This preserves cluster
     // topology far better than truncation.
+    //
+    // PR #818 Codex sweep 2 — earlier shape `if (kept >= MAX_PER_CARD)
+    // break;` checked AFTER adding the current subject's full row
+    // count, so a single dominant subject with N > MAX_PER_CARD rows
+    // would let the entire heavy cluster through (`keep.has(subject)`
+    // is true for every row of the dominant subject, returning all N
+    // from the filter). Pre-check `kept + subjectDegree > MAX_PER_CARD`
+    // BEFORE adding so we stop on the subject that would push us
+    // over.
+    //
+    // Residual case: when the heaviest subject's degree alone exceeds
+    // MAX_PER_CARD, the pre-check would reject it on iteration 1 and
+    // exit with an empty `keep` — the card would render the empty-
+    // body branch even though the bucket clearly has content. Fall
+    // back to admitting that single heaviest subject so SOMETHING
+    // renders; the post-filter `slice(0, MAX_PER_CARD)` then trims
+    // its long tail. The rendered slice loses some cluster topology
+    // but the user sees the dominant hub, which is the right user-
+    // facing trade-off (vs an empty card on a populated bucket).
     for (const [sg, triples] of bySg) {
       if (triples.length <= MAX_PER_CARD) continue;
       const degree = new Map<string, number>();
@@ -3942,11 +3961,13 @@ export function SubGraphOverviewGrid({
       const keep = new Set<string>();
       let kept = 0;
       for (const uri of order) {
-        if (kept >= MAX_PER_CARD) break;
+        const subjectDegree = degree.get(uri) ?? 0;
+        if (kept + subjectDegree > MAX_PER_CARD) break;
         keep.add(uri);
-        kept += degree.get(uri)!;
+        kept += subjectDegree;
       }
-      bySg.set(sg, triples.filter(t => keep.has(t.subject)));
+      if (keep.size === 0 && order.length > 0) keep.add(order[0]);
+      bySg.set(sg, triples.filter(t => keep.has(t.subject)).slice(0, MAX_PER_CARD));
     }
     return bySg;
   }, [memory.allTriples]);
@@ -4182,6 +4203,15 @@ export function SubGraphOverviewGrid({
     // RdfGraph layout lock the named-card cap was added to
     // prevent. Same sampling preserves cluster topology better
     // than a random first-N truncation.
+    // PR #818 Codex sweep 2 — pre-check `kept + subjectDegree >
+    // MAX_PER_CARD` BEFORE adding (instead of `kept >= MAX_PER_CARD`
+    // AFTER) so a single dominant subject can't smuggle the whole
+    // heavy cluster through. When the heaviest subject's degree
+    // alone exceeds the cap the pre-check exits with an empty
+    // `keep` — fall back to admitting that one subject so the
+    // card shows the dominant hub instead of an empty body; the
+    // post-filter `slice(0, MAX_PER_CARD)` trims its long tail.
+    // Same fix applied at the named-card path above (`:3935-3953`).
     let cappedRootTriples = rootTriples;
     if (rootTriples.length > MAX_PER_CARD) {
       const degree = new Map<string, number>();
@@ -4192,11 +4222,13 @@ export function SubGraphOverviewGrid({
       const keep = new Set<string>();
       let kept = 0;
       for (const uri of order) {
-        if (kept >= MAX_PER_CARD) break;
+        const subjectDegree = degree.get(uri) ?? 0;
+        if (kept + subjectDegree > MAX_PER_CARD) break;
         keep.add(uri);
-        kept += degree.get(uri)!;
+        kept += subjectDegree;
       }
-      cappedRootTriples = rootTriples.filter(t => keep.has(t.subject));
+      if (keep.size === 0 && order.length > 0) keep.add(order[0]);
+      cappedRootTriples = rootTriples.filter(t => keep.has(t.subject)).slice(0, MAX_PER_CARD);
     }
     const binding = profile?.forSubGraph(ROOT_SLUG_SENTINEL) ?? {};
     return {

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4152,6 +4152,32 @@ export function SubGraphOverviewGrid({
       seenSpo.add(key);
       rootTriples.push({ subject: t.subject, predicate: t.predicate, object: t.object });
     }
+    // PR #818 Codex sweep 1 — apply the same `MAX_PER_CARD`
+    // heaviest-subjects sampling the named-card path uses at
+    // `:3935-3949`. The earlier comment waved this off on the
+    // theory that the root entity set is small, but Codex flagged
+    // the counterexample: large initial seeds + agents writing
+    // without sub-graph tags can produce thousands of untagged
+    // triples whose endpoints touch root entities — same
+    // RdfGraph layout lock the named-card cap was added to
+    // prevent. Same sampling preserves cluster topology better
+    // than a random first-N truncation.
+    let cappedRootTriples = rootTriples;
+    if (rootTriples.length > MAX_PER_CARD) {
+      const degree = new Map<string, number>();
+      for (const t of rootTriples) degree.set(t.subject, (degree.get(t.subject) ?? 0) + 1);
+      const order = [...degree.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([uri]) => uri);
+      const keep = new Set<string>();
+      let kept = 0;
+      for (const uri of order) {
+        if (kept >= MAX_PER_CARD) break;
+        keep.add(uri);
+        kept += degree.get(uri)!;
+      }
+      cappedRootTriples = rootTriples.filter(t => keep.has(t.subject));
+    }
     const binding = profile?.forSubGraph(ROOT_SLUG_SENTINEL) ?? {};
     return {
       slug: ROOT_SLUG_SENTINEL,
@@ -4164,8 +4190,15 @@ export function SubGraphOverviewGrid({
       description: binding.description,
       rank: 999,
       entityCount: rootEntities.length,
+      // tripleCount stays the pre-cap distinct total so the
+      // stats badge reports the true count (matches what the
+      // Root detail view would show), while `triples` carries
+      // the post-cap sampled slice the mini-graph renders.
+      // Mirrors the named-card behaviour where `sg.tripleCount`
+      // (daemon-reported) decouples the badge from the rendered
+      // slice.
       tripleCount: rootTriples.length,
-      triples: rootTriples,
+      triples: cappedRootTriples,
       layerCounts: { wm, swm, vm },
       entityTrustByUri: rootEntityTrust,
     };

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4339,11 +4339,20 @@ export function SubGraphOverviewGrid({
             Round 4.1 swapped to `memory.counts.total` + raw
             `memory.allTriples.length` — entity anchor was correct,
             triple anchor was still inflated by SWM cross-graph SPO
-            duplicates + WM residue (GH #805). This commit lands the
-            #805 layer-sum fix on the same surface so subtitle ==
-            Overview Triples == per-layer LayerStats. */}
+            duplicates + WM residue (GH #805). The #805 layer-sum
+            fix on the same surface makes subtitle == Overview
+            Triples == per-layer LayerStats.
+            PR #818 Codex sweep 2 — label says "named subgraphs"
+            (was "subgraphs"). The Root mini-card is a peer-but-
+            different surface that now renders in the grid; the
+            old label overstated what `cards.length` includes
+            (named subgraphs only, never Root) and produced a
+            "0 subgraphs" subtitle reading while a Root card
+            visibly rendered. The new label is honest about the
+            count's scope and applies regardless of Root
+            presence. */}
         <div className="v10-sgov-sub">
-          {cards.length} subgraphs · {memory.counts.total} entities · {subtitleTripleCount} triples
+          {cards.length} named subgraphs · {memory.counts.total} entities · {subtitleTripleCount} triples
         </div>
       </div>
       <div className="v10-sgov-grid">

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3943,14 +3943,25 @@ export function SubGraphOverviewGrid({
     // over.
     //
     // Residual case: when the heaviest subject's degree alone exceeds
-    // MAX_PER_CARD, the pre-check would reject it on iteration 1 and
-    // exit with an empty `keep` — the card would render the empty-
-    // body branch even though the bucket clearly has content. Fall
-    // back to admitting that single heaviest subject so SOMETHING
+    // MAX_PER_CARD, the pre-check rejects every subject and exits
+    // with an empty `keep` — the card would render the empty-body
+    // branch even though the bucket clearly has content. Fall back
+    // to admitting that single heaviest subject so SOMETHING
     // renders; the post-filter `slice(0, MAX_PER_CARD)` then trims
     // its long tail. The rendered slice loses some cluster topology
     // but the user sees the dominant hub, which is the right user-
     // facing trade-off (vs an empty card on a populated bucket).
+    //
+    // PR #818 Codex sweep 3 — `continue` (was `break`) on a subject
+    // that doesn't fit, so the loop scans further for smaller
+    // satellites that DO fit. With degrees `[2400, 200, 50, 50]`
+    // and cap 2500: `break` would stop at B(200) leaving 100
+    // headroom unused (renders 2400). `continue` skips B but lets
+    // C+D land for a dense pack at 2500. Trade-off: `break`
+    // preserved the heaviest-cluster topology contract; `continue`
+    // packs the cap denser at the cost of potentially picking a
+    // satellite over a third heavy hub that didn't quite fit. The
+    // denser pack is the friendlier user-facing outcome.
     for (const [sg, triples] of bySg) {
       if (triples.length <= MAX_PER_CARD) continue;
       const degree = new Map<string, number>();
@@ -3962,7 +3973,7 @@ export function SubGraphOverviewGrid({
       let kept = 0;
       for (const uri of order) {
         const subjectDegree = degree.get(uri) ?? 0;
-        if (kept + subjectDegree > MAX_PER_CARD) break;
+        if (kept + subjectDegree > MAX_PER_CARD) continue;
         keep.add(uri);
         kept += subjectDegree;
       }
@@ -4211,6 +4222,10 @@ export function SubGraphOverviewGrid({
     // `keep` — fall back to admitting that one subject so the
     // card shows the dominant hub instead of an empty body; the
     // post-filter `slice(0, MAX_PER_CARD)` trims its long tail.
+    // PR #818 Codex sweep 3 — `continue` (was `break`) so the loop
+    // scans further for smaller satellites that still fit. Same
+    // dense-pack rationale as the named-card path above; see the
+    // sweep-3 comment block at `:3935-3953` for the full trade-off.
     // Same fix applied at the named-card path above (`:3935-3953`).
     let cappedRootTriples = rootTriples;
     if (rootTriples.length > MAX_PER_CARD) {
@@ -4223,7 +4238,7 @@ export function SubGraphOverviewGrid({
       let kept = 0;
       for (const uri of order) {
         const subjectDegree = degree.get(uri) ?? 0;
-        if (kept + subjectDegree > MAX_PER_CARD) break;
+        if (kept + subjectDegree > MAX_PER_CARD) continue;
         keep.add(uri);
         kept += subjectDegree;
       }

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -787,18 +787,30 @@ export function ProjectOverviewCard({
           ? 'One or more layer counts are currently a lower bound.'
           : 'Canonical current-layer entity counts.';
   const totalEntitiesValue = allLayerCountsUnavailable ? 'Unavailable' : layerSum.toLocaleString();
-  // Triples: canonical layer-correct total exposed by the hook
-  // (§4.2.1 trap — do NOT sum per-entity tripleCount, do NOT borrow
-  // SubGraphBar's `totalTriples` which excludes the root bucket).
+  // Triples: canonical layer-correct total via `useLayerTriples`
+  // summed across all three layers (§4.2.1 trap — do NOT sum
+  // per-entity tripleCount, do NOT borrow SubGraphBar's
+  // `totalTriples` which excludes the root bucket, and do NOT
+  // read `allTriples.length` directly because it skips neither
+  // SWM cross-graph SPO duplication nor WM residue from promoted
+  // entities, both of which `useLayerTriples` correctly filters).
   //
-  // Codex review bug B — `useMemoryEntities` preserves partial
-  // results when one layer query fails, so `allTriples.length` is
-  // only a LOWER BOUND in that case. Mirror the Entities cell
-  // logic: 'Unavailable' if every layer errored, '<n>+' when
-  // partial, the plain number otherwise. The tooltip carries the
-  // explanation (consistent with the Delta-2 tooltip-only hint
-  // pattern).
-  const triplesCount = memory.allTriples?.length ?? 0;
+  // GH #805 fix: prior shape `memory.allTriples?.length ?? 0`
+  // surfaced an inflated total on any CG with published SWM (the
+  // same SPO row appears in both `<cg>/_shared_memory` and per-
+  // sub-graph `<cg>/<sg>/_shared_memory` graphs) or post-promote
+  // WM residue (assertion graphs left on disk). Summing the
+  // layer-correct slices makes the Overview "Triples" match the
+  // per-layer LayerStats by construction.
+  //
+  // Codex review bug B (still applies — partial-result preserving
+  // behaviour is unchanged): when a layer query fails the slice
+  // is empty; sum stays a lower bound and the '+' suffix renders
+  // via `triplesIsPartial`.
+  const wmLayerTriples = useLayerTriples(memory, 'wm');
+  const swmLayerTriples = useLayerTriples(memory, 'swm');
+  const vmLayerTriples = useLayerTriples(memory, 'vm');
+  const triplesCount = wmLayerTriples.length + swmLayerTriples.length + vmLayerTriples.length;
   const triplesIsPartial = !memory.loading && (memory.partial || hasUnavailableLayer);
   const triplesValue = allLayerCountsUnavailable
     ? 'Unavailable'
@@ -4056,6 +4068,23 @@ export function SubGraphOverviewGrid({
       .sort((a, b) => a.rank - b.rank);
   }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph]);
 
+  // GH #805 — subtitle triple total swapped to the same
+  // `useLayerTriples` layer-sum derivation now used by the
+  // Overview Triples stat (`:801`). Pre-GH-#805 the subtitle
+  // read `memory.allTriples.length` directly (canonical-source
+  // discipline established by round 4.1's chip-row anchor); that
+  // anchor was correct *given* the upstream value was honest, but
+  // `allTriples` lifts SWM cross-graph SPO duplicates + WM residue,
+  // so even the chip-row-anchored value was over-counting on CGs
+  // with published SWM or promoted entities. Summing per-layer
+  // slices restores the "subtitle agrees with LayerStats" invariant
+  // round 4.1 was actually after.
+  const wmSubtitleTriples = useLayerTriples(memory, 'wm');
+  const swmSubtitleTriples = useLayerTriples(memory, 'swm');
+  const vmSubtitleTriples = useLayerTriples(memory, 'vm');
+  const subtitleTripleCount =
+    wmSubtitleTriples.length + swmSubtitleTriples.length + vmSubtitleTriples.length;
+
   // GH #813 — Root mini-card. Synthesizes a card for the
   // "entities not in any named sub-graph" bucket so the grid
   // mirrors the SubGraphBar chip row (which already exposes Root
@@ -4186,20 +4215,22 @@ export function SubGraphOverviewGrid({
     <div className="v10-sgov">
       <div className="v10-sgov-header">
         <div className="v10-sgov-title">Subgraphs</div>
-        {/* Round 4.1 (ux-lead, GH #812) — subtitle anchors to the
+        {/* Round 4.1 (ux-lead, GH #812) — subtitle anchors to
             canonical hook surfaces (`memory.counts.total` for
-            entities, `memory.allTriples.length` for triples) so it
-            matches the SubGraphBar `All` chip by construction.
-            Pre-round-4.1 the subtitle derived from card-level
-            aggregates (sum-of-`entityCount` double-counted
-            cross-membership entities; sum-of-`tripleCount` excluded
-            the root bucket). After round 4's `All`-includes-Root
-            reversal the right anchor is the same source the chip
-            row reads from — single source of truth, and when GH
-            #805 fixes the triple total upstream both surfaces fix
-            together. */}
+            entities, layer-sum via `useLayerTriples` for triples)
+            so it matches both the SubGraphBar `All` chip AND the
+            per-layer LayerStats by construction.
+            Pre-round-4.1: derived from card-level aggregates
+            (sum-of-`entityCount` double-counted cross-membership
+            entities; sum-of-`tripleCount` excluded the root bucket).
+            Round 4.1 swapped to `memory.counts.total` + raw
+            `memory.allTriples.length` — entity anchor was correct,
+            triple anchor was still inflated by SWM cross-graph SPO
+            duplicates + WM residue (GH #805). This commit lands the
+            #805 layer-sum fix on the same surface so subtitle ==
+            Overview Triples == per-layer LayerStats. */}
         <div className="v10-sgov-sub">
-          {cards.length} subgraphs · {memory.counts.total} entities · {memory.allTriples.length} triples
+          {cards.length} subgraphs · {memory.counts.total} entities · {subtitleTripleCount} triples
         </div>
       </div>
       <div className="v10-sgov-grid">

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4056,6 +4056,81 @@ export function SubGraphOverviewGrid({
       .sort((a, b) => a.rank - b.rank);
   }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph]);
 
+  // GH #813 — Root mini-card. Synthesizes a card for the
+  // "entities not in any named sub-graph" bucket so the grid
+  // mirrors the SubGraphBar chip row (which already exposes Root
+  // as a peer of the named chips). Renders LAST, after named
+  // cards, mirroring the Root chip's rightmost chip-row position.
+  //
+  // The derivations below mirror SubGraphDetailView's Root branch
+  // (`isRoot = slug === ROOT_SLUG_SENTINEL` at `:4527`):
+  //   • scoped entities: `subGraphs.size === 0` (same rule as
+  //     SubGraphBar.rootEntityCount).
+  //   • scoped triples: rule (1) "exact-tag-routing" can never
+  //     fire for Root (the Root bucket carries no tagged triples
+  //     by definition) — only the untagged-recovery branch admits
+  //     triples whose subject OR resource-object is in scope.
+  // Same canonical-source discipline as round 4.1's subtitle
+  // anchor; what you click maps to the same scope the Root
+  // detail view shows.
+  //
+  // Edge case — CG with zero root entities: we still render the
+  // card (option b per team-lead lean). Named subgraphs with 0
+  // entities render the same "No data yet" empty-state branch;
+  // hiding Root only would create inconsistency (and a missing
+  // affordance for the user wondering whether the bucket exists).
+  const rootCard = useMemo(() => {
+    const rootEntities: typeof memory.entityList = [];
+    const rootEntityUris = new Set<string>();
+    const rootEntityTrust = new Map<string, TrustLevel>();
+    let wm = 0, swm = 0, vm = 0;
+    for (const e of memory.entityList) {
+      if (e.subGraphs.size > 0) continue;
+      rootEntities.push(e);
+      const canonical = canonicalEntityUri(e.uri);
+      rootEntityUris.add(canonical);
+      rootEntityTrust.set(canonical, e.trustLevel);
+      if (canonical !== e.uri) rootEntityTrust.set(e.uri, e.trustLevel);
+      if (e.trustLevel === 'verified') vm++;
+      else if (e.trustLevel === 'shared') swm++;
+      else wm++;
+    }
+    // Untagged-recovery only — Root bucket has no tagged triples
+    // by definition (see SubGraphDetailView's rule 1 → "never
+    // fires for Root"). A triple admitted here must have NO
+    // subGraph tag AND an endpoint in scope; the same
+    // `MAX_PER_CARD` sampling the named branch applies isn't
+    // needed at the mini-card scale because the recovery slice
+    // is bounded by the root entity set.
+    const rootTriples: Triple[] = [];
+    const seenSpo = new Set<string>();
+    for (const t of memory.allTriples) {
+      if (t.subGraph) continue;
+      if (!rootEntityUris.has(t.subject) && !rootEntityUris.has(t.object)) continue;
+      const key = `${t.subject}|${t.predicate}|${t.object}`;
+      if (seenSpo.has(key)) continue;
+      seenSpo.add(key);
+      rootTriples.push({ subject: t.subject, predicate: t.predicate, object: t.object });
+    }
+    const binding = profile?.forSubGraph(ROOT_SLUG_SENTINEL) ?? {};
+    return {
+      slug: ROOT_SLUG_SENTINEL,
+      icon: binding.icon ?? '⊘',
+      // Color left unset — the chrome falls through to neutral
+      // tokens via the `.v10-sgov-card.root` modifier (mirrors
+      // the chip's `--text-tertiary` neutral fallback).
+      color: binding.color ?? '#64748b',
+      displayName: binding.displayName ?? 'Root',
+      description: binding.description,
+      rank: 999,
+      entityCount: rootEntities.length,
+      tripleCount: rootTriples.length,
+      triples: rootTriples,
+      layerCounts: { wm, swm, vm },
+      entityTrustByUri: rootEntityTrust,
+    };
+  }, [memory.entityList, memory.allTriples, profile]);
+
   if (loading && cards.length === 0) {
     return (
       <EmptyState
@@ -4136,6 +4211,19 @@ export function SubGraphOverviewGrid({
             onOpen={() => onSelectSubGraph(card.slug)}
           />
         ))}
+        {/* GH #813 — Root mini-card. Last position mirrors the
+            Root chip's rightmost chip-row position. Rendered even
+            at 0 entities (consistency with named cards' empty
+            branches; option b per team-lead lean). The `root`
+            modifier on the card chrome reads as "synthesized
+            bucket" vs the solid borders of daemon-emitted cards. */}
+        <SubGraphMiniCard
+          key={ROOT_SLUG_SENTINEL}
+          card={rootCard}
+          onNodeClick={onNodeClick}
+          onOpen={() => onSelectSubGraph(ROOT_SLUG_SENTINEL)}
+          variant="root"
+        />
       </div>
     </div>
   );
@@ -4145,6 +4233,7 @@ export function SubGraphMiniCard({
   card,
   onNodeClick,
   onOpen,
+  variant,
 }: {
   card: {
     slug: string; icon: string; color: string; displayName: string;
@@ -4155,6 +4244,11 @@ export function SubGraphMiniCard({
   };
   onNodeClick?: (node: any) => void;
   onOpen: () => void;
+  // GH #813 — `root` opts into the dashed-border, neutral-color
+  // chrome that distinguishes the synthesized Root bucket from
+  // daemon-emitted named sub-graphs. Same render shape, different
+  // chrome modifier.
+  variant?: 'root';
 }) {
   // Per-URI trust palette for the mini-graph (#3 polish).
   // ui-locked priority chain (graph-viz style engine):
@@ -4208,16 +4302,21 @@ export function SubGraphMiniCard({
     focus: { maxNodes: 5000, hops: 999 },
   }), [card.color, nodeColors]);
 
+  const isRoot = variant === 'root';
   return (
     <div
-      className="v10-sgov-card"
-      style={{
-        '--sg-color': card.color,
-        borderColor: card.color + '55',
-      } as React.CSSProperties}
+      className={`v10-sgov-card${isRoot ? ' root' : ''}`}
+      style={isRoot
+        // Root card: chrome falls through to neutral tokens via
+        // the `.root` modifier — no per-card color injection.
+        ? undefined
+        : {
+            '--sg-color': card.color,
+            borderColor: card.color + '55',
+          } as React.CSSProperties}
     >
       <div className="v10-sgov-card-head">
-        <span className="v10-sgov-card-icon" style={{ color: card.color }}>{card.icon}</span>
+        <span className="v10-sgov-card-icon" style={isRoot ? undefined : { color: card.color }}>{card.icon}</span>
         <div className="v10-sgov-card-title-wrap">
           <div className="v10-sgov-card-title">{card.displayName}</div>
           {card.description && (

--- a/packages/node-ui/test/context-graph-ia-overview.test.ts
+++ b/packages/node-ui/test/context-graph-ia-overview.test.ts
@@ -408,12 +408,16 @@ describe('Context Graph IA and Overview', () => {
   });
 
   it('renders Triples as a lower bound when a layer query is partial (Codex bug B)', async () => {
+    // GH #805 — Overview Triples now sums `useLayerTriples` per
+    // layer; that hook SPO-deduplicates, so the fixture's 120
+    // distinct rows must be uniquely-keyed (not 120 identical
+    // copies of one triple) for the count to land at 120.
     const partialMemory = {
       ...baseMemory,
       counts: { wm: 4, swm: 2, vm: 0, total: 6 },
       layerStatus: { wm: 'ok', swm: 'ok', vm: 'error' },
       partial: true,
-      allTriples: new Array(120).fill({ subject: 's', predicate: 'p', object: 'o', layer: 'working' }),
+      allTriples: Array.from({ length: 120 }, (_, i) => ({ subject: `urn:s${i}`, predicate: 'p', object: `urn:o${i}`, layer: 'working' })),
       error: null,
     };
     const { container, root } = await render(

--- a/packages/node-ui/test/sub-graphs-helper.test.ts
+++ b/packages/node-ui/test/sub-graphs-helper.test.ts
@@ -68,4 +68,34 @@ describe('subGraphOf — reserved-bookkeeping slug guards (fold-in #5)', () => {
     expect(subGraphOf('did:dkg:context-graph:other/research', 'cg-1')).toBeUndefined();
     expect(subGraphOf('urn:not-a-cg', 'cg-1')).toBeUndefined();
   });
+
+  // GH #806 — pre-fix this URI emitted `'meta'` as the slug, so
+  // entities whose only sub-graph membership came from a
+  // `<cg>/meta/_shared_memory` write ended up with
+  // `subGraphs = Set{'meta'}`. Downstream `RESERVED_SUB_GRAPH_SLUGS`
+  // filtered the chip render but `SubGraphBar.entityScopedAllTotal`
+  // and `rootEntityCount` both counted those entities incorrectly:
+  // `All` included them (non-zero subGraphs in narrowed mode passes
+  // the layer filter) while `Root` excluded them (`subGraphs.size > 0`
+  // skip), producing the `Tuesday CG SWM 36 / 34` 2-entity gap. The
+  // fix treats `meta` symmetrically to `assertion` — both are
+  // internal bookkeeping prefixes, neither is a user-facing slug.
+  it('returns undefined for `meta` bookkeeping graphs (GH #806)', () => {
+    expect(subGraphOf('did:dkg:context-graph:cg-1/meta/_shared_memory', 'cg-1')).toBeUndefined();
+    expect(subGraphOf('did:dkg:context-graph:cg-1/meta/_verified_memory', 'cg-1')).toBeUndefined();
+    expect(subGraphOf('did:dkg:context-graph:cg-1/meta', 'cg-1')).toBeUndefined();
+  });
+
+  // Regression guard — the fix must not regress the
+  // user-facing-slug + bookkeeping-tail pattern. Sub-graphs whose
+  // NAME happens to be `meta` would never reach here in practice
+  // (RESERVED_SUB_GRAPH_SLUGS rejects them downstream and the daemon
+  // doesn't emit `meta` as a registered sub-graph), but a user-facing
+  // slug containing `meta` as a path segment in some non-leading
+  // position must survive: e.g. a hypothetical `recipes` sub-graph
+  // with `<cg>/recipes/meta/...` keeps `'recipes'` as the slug.
+  it('keeps user-facing sub-graph slugs intact when `meta` appears in a non-leading segment (GH #806 regression)', () => {
+    expect(subGraphOf('did:dkg:context-graph:cg-1/recipes/_shared_memory', 'cg-1')).toBe('recipes');
+    expect(subGraphOf('did:dkg:context-graph:cg-1/recipes/meta/anything', 'cg-1')).toBe('recipes');
+  });
 });

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -853,7 +853,10 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // was brittle (Suspense fallback shares the empty class) AND
     // would have missed the single-dominant-subject defect Codex
     // surfaced in sweep 2 — assert against the cap directly now.
-    const graphEl = rootCardEl.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+    // PR #818 sweep 3 — wait for Suspense resolution before
+    // reading the data attribute so isolated runs don't race
+    // the lazy import.
+    const graphEl = await waitForGraph(container, { scope: rootCardEl });
     expect(graphEl).toBeTruthy();
     const renderedTripleCount = Number(graphEl!.getAttribute('data-triple-count') ?? 'NaN');
     expect(renderedTripleCount).toBeLessThanOrEqual(2500); // MAX_PER_CARD
@@ -1043,7 +1046,10 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
 
     const cards = container.querySelectorAll('.v10-sgov-card');
     const rootCardEl = cards[cards.length - 1];
-    const graphEl = rootCardEl.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+    // PR #818 sweep 3 — wait for Suspense resolution before
+    // reading the data attribute so isolated runs don't race
+    // the lazy import.
+    const graphEl = await waitForGraph(container, { scope: rootCardEl });
     expect(graphEl).toBeTruthy();
     const renderedTripleCount = Number(graphEl!.getAttribute('data-triple-count') ?? 'NaN');
     // Pre-sweep this would have rendered 5000 (the dominant
@@ -1102,7 +1108,10 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // First card is the named alpha card; Root card is last.
     const cards = container.querySelectorAll('.v10-sgov-card');
     const alphaCardEl = cards[0];
-    const graphEl = alphaCardEl.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+    // PR #818 sweep 3 — wait for Suspense resolution before
+    // reading the data attribute so isolated runs don't race
+    // the lazy import.
+    const graphEl = await waitForGraph(container, { scope: alphaCardEl });
     expect(graphEl).toBeTruthy();
     const renderedTripleCount = Number(graphEl!.getAttribute('data-triple-count') ?? 'NaN');
     // Pre-sweep: 5000 rows leaked through. Post-sweep: cap is

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -404,6 +404,198 @@ describe('SubGraphOverviewGrid — header subtitle anchors (PR #793 round 4.1, G
   });
 });
 
+describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
+  // The Root mini-card mirrors SubGraphBar's Root chip on the
+  // overview surface. Synthesizes a card for the bucket of
+  // entities not in any named sub-graph; rendered LAST in the
+  // grid (mirrors the Root chip's rightmost chip-row position);
+  // carries the dashed-border `.root` chrome modifier so it
+  // reads as a synthesized bucket vs daemon-emitted cards.
+  let root: Root;
+  let container: HTMLDivElement;
+
+  // Profile fixture that mirrors useProjectProfile's
+  // ROOT_SUBGRAPH_BINDING short-circuit at `:622` so the Root card
+  // resolves to the same `⊘` / `Root` identity production renders.
+  const rootAwareProfile = {
+    ...profile,
+    forSubGraph: (slug: string) => {
+      if (slug === '__root__') {
+        return { slug: '__root__', displayName: 'Root', description: 'Entities not in any subgraph (Context Graph root)', icon: '⊘', rank: 999 };
+      }
+      return { slug, displayName: slug, color: '#38bdf8', icon: '#', rank: 0 };
+    },
+  } as any;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    fetchSubGraphsMock.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderWith(memoryOverride: any) {
+    return act(async () => {
+      root.render(
+        React.createElement(ProjectProfileContext.Provider, { value: rootAwareProfile },
+          React.createElement(SubGraphOverviewGrid, {
+            contextGraphId: 'cg-test',
+            memory: memoryOverride,
+            onNodeClick: vi.fn(),
+            onSelectSubGraph: vi.fn(),
+          })),
+      );
+    });
+  }
+
+  it('renders a Root mini-card with the dashed `.root` chrome modifier', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // 1 entity in a named sub-graph (alpha) + 1 root-bucket entity.
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:root', label: 'r', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: [],
+      counts: { wm: 2, swm: 0, vm: 0, total: 2 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    // 1 named card + 1 Root card = 2 cards rendered.
+    expect(cards.length).toBe(2);
+    // Root card is LAST (mirrors chip-row position).
+    const rootCardEl = cards[cards.length - 1];
+    expect(rootCardEl.classList.contains('root')).toBe(true);
+    // Root card renders the canonical `Root` identity (icon + label).
+    expect(rootCardEl.querySelector('.v10-sgov-card-title')?.textContent).toBe('Root');
+    expect(rootCardEl.querySelector('.v10-sgov-card-icon')?.textContent).toBe('⊘');
+    // Stats reflect the 1 root-bucket entity.
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    expect(stats).toContain('1');
+    expect(stats).toContain('entities');
+  });
+
+  it('renders the Root mini-card even at 0 root entities (consistency with named-card empty branch)', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // Every entity belongs to a named sub-graph — root bucket is
+      // empty. Per option (b) the card still renders, matching how
+      // named subgraphs with 0 entities render the empty branch.
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: [],
+      counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    expect(cards.length).toBe(2);
+    const rootCardEl = cards[cards.length - 1];
+    expect(rootCardEl.classList.contains('root')).toBe(true);
+    // Empty branch literal — same one named cards use.
+    expect(rootCardEl.querySelector('.v10-sgov-card-empty')?.textContent).toBe('No data yet');
+  });
+
+  it('Root card open button calls onSelectSubGraph with ROOT_SLUG_SENTINEL', async () => {
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:root', label: 'r', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const onSelectSubGraph = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(ProjectProfileContext.Provider, { value: rootAwareProfile },
+          React.createElement(SubGraphOverviewGrid, {
+            contextGraphId: 'cg-test',
+            memory: {
+              ...memory,
+              entities: new Map(entityList.map(e => [e.uri, e])),
+              entityList,
+              allTriples: [],
+              counts: { wm: 2, swm: 0, vm: 0, total: 2 },
+            },
+            onNodeClick: vi.fn(),
+            onSelectSubGraph,
+          })),
+      );
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    const openBtn = rootCardEl.querySelector('.v10-sgov-card-open') as HTMLButtonElement;
+    expect(openBtn).toBeTruthy();
+    await act(async () => { openBtn.click(); });
+    expect(onSelectSubGraph).toHaveBeenCalledWith('__root__');
+  });
+
+  it('Root card scopes triples to untagged-recovery-only (mirrors SubGraphDetailView Root rule)', async () => {
+    // SubGraphDetailView Root branch: rule 1 "exact-tag-routing"
+    // never fires for Root (the bucket carries no tagged triples
+    // by definition); only untagged triples with an in-scope
+    // endpoint are admitted. Mini-card must mirror that — a
+    // tagged triple between two root entities must NOT appear in
+    // the Root card's graph slice (lives on the tagged
+    // sub-graph's card instead).
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 1, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:root1', label: 'r1', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+      { uri: 'urn:e:root2', label: 'r2', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // Tagged triple — root entity but tagged to a different
+      // sub-graph. Must NOT appear in Root's slice.
+      { subject: 'urn:e:root1', predicate: 'p', object: 'urn:e:alpha', subGraph: 'alpha' },
+      // Untagged triple between two root entities — admitted by
+      // the untagged-recovery branch.
+      { subject: 'urn:e:root1', predicate: 'p', object: 'urn:e:root2' },
+      // Untagged triple with no endpoint in scope — must NOT
+      // appear in Root's slice.
+      { subject: 'urn:e:alpha', predicate: 'p', object: 'urn:e:somewhere-else' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 3, swm: 0, vm: 0, total: 3 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    // Root card stats: 2 root entities, 1 admitted triple (the
+    // untagged root↔root edge). Tagged + non-scoped triples
+    // dropped.
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    expect(stats).toContain('2 entities');
+    expect(stats).toContain('1 triples');
+  });
+});
+
 describe('SubGraphMiniCard — per-trust nodeColors (S3 polish #3, ui-locked priority chain)', () => {
   // The mini-graph previously rendered every node in the card's
   // chrome color (`card.color`), losing the trust signal that the

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -700,6 +700,62 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).toContain('1 entities');
     expect(stats).toContain('2 triples');
   });
+
+  it('renders the Root card when the CG has zero named subgraphs but non-zero root entities (Codex sweep 1)', async () => {
+    // PR #818 sweep 1 — the teaching empty state gate previously
+    // fired on `cards.length === 0` alone. A CG with no named
+    // sub-graphs but populated root entities lost the direct Root
+    // affordance: user landed on the teaching state and had to
+    // click "View root" instead of seeing the Root card in place.
+    // Gate is now `cards.length === 0 && rootCard.entityCount === 0`,
+    // so this scenario renders only the Root card as the entire
+    // grid.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      // Zero named sub-graphs.
+      subGraphs: [],
+    });
+    const entityList = [
+      { uri: 'urn:e:root-only', label: 'r', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: [],
+      counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+    });
+    await flush();
+
+    // Teaching empty state must NOT render — its title is the
+    // tell.
+    expect(container.textContent ?? '').not.toContain('No subgraphs in this Context Graph yet.');
+    // Exactly one card renders — the Root card.
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    expect(cards.length).toBe(1);
+    expect(cards[0].classList.contains('root')).toBe(true);
+    expect(cards[0].querySelector('.v10-sgov-card-title')?.textContent).toBe('Root');
+  });
+
+  it('renders the teaching empty state when the CG has zero named subgraphs AND zero root entities (Codex sweep 1)', async () => {
+    // Companion test — the truly-empty case must keep showing the
+    // teaching empty state (unchanged behaviour). Locks against a
+    // regression where someone widens the Root card gate too far.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [],
+    });
+    await renderWith({
+      ...memory,
+      entityList: [],
+      allTriples: [],
+      counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+    });
+    await flush();
+
+    // Teaching empty state renders — its title is the tell.
+    expect(container.textContent ?? '').toContain('No subgraphs in this Context Graph yet.');
+    // No mini-cards.
+    expect(container.querySelectorAll('.v10-sgov-card').length).toBe(0);
+  });
 });
 
 describe('SubGraphMiniCard — per-trust nodeColors (S3 polish #3, ui-locked priority chain)', () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -31,10 +31,15 @@ vi.mock('@origintrail-official/dkg-graph-viz/react', async () => {
       // Surface the nodeColors style override so #3 polish tests
       // can assert per-URI trust-color plumbing without reaching
       // into the canvas internals.
+      // PR #818 sweep 2 — also surface the data length via
+      // `data-triple-count` so MAX_PER_CARD cap tests can assert
+      // the rendered slice length directly (would have caught
+      // the single-dominant-subject cap defect).
       const nodeColors = props.options?.style?.nodeColors ?? {};
       return React.createElement('div', {
         'data-testid': 'rdf-graph',
         'data-node-colors': JSON.stringify(nodeColors),
+        'data-triple-count': String(props.data?.length ?? 0),
       });
     },
   };
@@ -810,17 +815,20 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // slice is sampled).
     const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
     expect(stats).toContain('3000 triples');
-    // The rendered mini-graph receives the post-cap sampled
-    // slice. The RdfGraph stub surfaces the data length via
-    // its `data-node-colors` attribute side-channel, but we
-    // don't have a direct hook for the data prop here. Instead
-    // verify behaviour at the prop boundary: with `MAX_PER_CARD
-    // = 2500`, sampling keeps the first 2500 rows whose subject
-    // hits the cap. (Behavioural assertion below — the rendered
-    // graph DOM element exists, the empty branch did NOT fire.)
-    const emptyBranch = rootCardEl.querySelector('.v10-sgov-card-empty');
-    expect(emptyBranch).toBeNull();
-    expect(rootCardEl.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
+    // PR #818 sweep 2 — the rendered mini-graph slice receives
+    // the post-cap sampled rows. The RdfGraph stub exposes
+    // `data-triple-count` so we can assert the cap is honored
+    // directly. Earlier shape `expect(emptyBranch).toBeNull()`
+    // was brittle (Suspense fallback shares the empty class) AND
+    // would have missed the single-dominant-subject defect Codex
+    // surfaced in sweep 2 — assert against the cap directly now.
+    const graphEl = rootCardEl.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+    expect(graphEl).toBeTruthy();
+    const renderedTripleCount = Number(graphEl!.getAttribute('data-triple-count') ?? 'NaN');
+    expect(renderedTripleCount).toBeLessThanOrEqual(2500); // MAX_PER_CARD
+    // And the cap actually fires (we're well over with 3000) —
+    // not just trivially under it because the input degraded.
+    expect(renderedTripleCount).toBeGreaterThan(0);
   });
 
   it('Root card retains all triples under the MAX_PER_CARD cap (no spurious sampling)', async () => {
@@ -967,6 +975,111 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // would have counted 2.
     expect(stats).toContain('1 triples');
     expect(stats).not.toContain('2 triples');
+  });
+
+  it('Root card cap honors MAX_PER_CARD even with a single dominant subject (Codex sweep 2)', async () => {
+    // PR #818 sweep 2 — sweep-1 sampling shape had a defect:
+    // `if (kept >= MAX_PER_CARD) break;` checked AFTER adding the
+    // current subject's full degree. A single dominant subject
+    // with degree > MAX_PER_CARD passed the check at `kept = 0`,
+    // got added, contributed its full row count to `kept`, then
+    // the break fired the next iteration — but `keep.has(subject)`
+    // returned every row of the dominant subject from the filter,
+    // including thousands above the cap. Fix: pre-check
+    // `kept + subjectDegree > MAX_PER_CARD` before adding +
+    // defensive `slice(0, MAX_PER_CARD)` post-filter.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      // ONE dominant root entity with 5000 untagged out-edges
+      // (degree = 5000, well above MAX_PER_CARD = 2500).
+      { uri: 'urn:e:dominant', label: 'd', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [];
+    for (let i = 0; i < 5000; i++) {
+      triples.push({ subject: 'urn:e:dominant', predicate: 'p', object: `urn:e:obj-${i}`, layer: 'working' });
+    }
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 2, swm: 0, vm: 0, total: 2 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    const graphEl = rootCardEl.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+    expect(graphEl).toBeTruthy();
+    const renderedTripleCount = Number(graphEl!.getAttribute('data-triple-count') ?? 'NaN');
+    // Pre-sweep this would have rendered 5000 (the dominant
+    // subject's full row count, since `keep.has(subject)`
+    // returned every row from the filter). Post-sweep the
+    // pre-check halts the loop before adding the dominant
+    // subject (degree 5000 > MAX_PER_CARD), so the keep set
+    // would normally be empty — but the residual fallback
+    // (`if (keep.size === 0 && order.length > 0) keep.add(order[0])`)
+    // admits that single dominant subject so the card still
+    // shows the hub, and the post-filter `slice(0, MAX_PER_CARD)`
+    // trims its long tail. Net: cap is HONORED and the user
+    // sees the dominant cluster instead of an empty card.
+    expect(renderedTripleCount).toBeLessThanOrEqual(2500); // MAX_PER_CARD
+    expect(renderedTripleCount).toBeGreaterThan(0);         // not degraded to empty
+    // And `tripleCount` stat still reports the true pre-cap
+    // total — the cap affects only the rendered mini-graph
+    // slice, not the user-visible distinct count.
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    expect(stats).toContain('5000 triples');
+  });
+
+  it('Named card cap honors MAX_PER_CARD even with a single dominant subject (Codex sweep 2, parity fix)', async () => {
+    // PR #818 sweep 2 — same defect exists in the named-card
+    // path at the original `triplesBySubGraph` sampling (Root
+    // inherited the pattern from there). Fix is applied at both
+    // sites so the named-card path stops smuggling dominant
+    // clusters through too. This test locks the named-card path
+    // independently of the Root card.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 5000, description: '' }],
+    });
+    const entityList = [
+      // One named-subgraph entity that's the dominant subject.
+      { uri: 'urn:e:dominant', label: 'd', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    const triples = [];
+    for (let i = 0; i < 5000; i++) {
+      // Tag with sub-graph 'alpha' so the named-card bucket
+      // path at `triplesBySubGraph` picks them up. Use literal
+      // objects so `filterTriplesToEntities` (applied to the
+      // bucket on the named-card render path at `:4084`) admits
+      // them — resource-object edges would otherwise be dropped
+      // because `urn:e:obj-N` isn't in the entityUris set.
+      triples.push({ subject: 'urn:e:dominant', predicate: 'p', object: `"v-${i}"`, subGraph: 'alpha', layer: 'working' });
+    }
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+    });
+    await flush();
+
+    // First card is the named alpha card; Root card is last.
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const graphEl = alphaCardEl.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+    expect(graphEl).toBeTruthy();
+    const renderedTripleCount = Number(graphEl!.getAttribute('data-triple-count') ?? 'NaN');
+    // Pre-sweep: 5000 rows leaked through. Post-sweep: cap is
+    // honored, and the residual fallback keeps the dominant
+    // subject visible (same trade-off as the Root card test
+    // above).
+    expect(renderedTripleCount).toBeLessThanOrEqual(2500); // MAX_PER_CARD
+    expect(renderedTripleCount).toBeGreaterThan(0);         // dominant hub still renders
   });
 });
 

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -706,13 +706,18 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
       // the unwrapped set) failed and this triple was dropped.
       // PR #818 sweep 2 — fixtures tagged `layer: 'working'` so
       // `useLayerTriples` admits them (GH #805 family).
-      { subject: '<urn:e:root1>', predicate: 'p', object: 'urn:e:o-bare', layer: 'working' },
-      // Same SPO emitted twice — once wrapped, once bare. Pre-
-      // sweep these had distinct seenSpo keys and counted as 2.
-      // Post-sweep both map to the same canonical key and dedup
-      // to 1.
-      { subject: 'urn:e:root1', predicate: 'p', object: '<urn:e:o-other>', layer: 'working' },
-      { subject: 'urn:e:root1', predicate: 'p', object: 'urn:e:o-other', layer: 'working' },
+      // PR #818 sweep 6 — Root now AND-filters via
+      // `filterTriplesToEntities`; resource-object endpoints
+      // would otherwise need to be entities. Use literal objects
+      // so admission lands solely on the canonical-URI subject
+      // check this test is actually exercising.
+      { subject: '<urn:e:root1>', predicate: 'p', object: '"o-bare"', layer: 'working' },
+      // Same SPO emitted twice — once wrapped on the object
+      // side, once bare. Pre-sweep these had distinct seenSpo
+      // keys and counted as 2. Post-sweep both map to the same
+      // canonical key and dedup to 1.
+      { subject: 'urn:e:root1', predicate: 'p', object: '"o-other"', layer: 'working' },
+      { subject: 'urn:e:root1', predicate: 'p', object: '"o-other"', layer: 'working' },
     ];
     await renderWith({
       ...memory,
@@ -827,7 +832,10 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
       // PR #818 sweep 2 — tag `layer: 'working'` so the layer-correct
       // universe `useLayerTriples` produces (GH #805 family) admits
       // these rows for the Root card to scope over.
-      triples.push({ subject: 'urn:e:heavy-root', predicate: 'p', object: `urn:e:obj-${i}`, layer: 'working' });
+      // PR #818 sweep 6 — literal objects so AND-membership via
+      // `filterTriplesToEntities` admits them (resource-object
+      // edges would need both endpoints in the entity set).
+      triples.push({ subject: 'urn:e:heavy-root', predicate: 'p', object: `"v-${i}"`, layer: 'working' });
     }
     await renderWith({
       ...memory,
@@ -879,11 +887,13 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const triples = [
       // PR #818 sweep 2 — `layer: 'working'` so the layer-correct
       // universe (GH #805) admits the rows.
-      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o1', layer: 'working' },
-      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o2', layer: 'working' },
-      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o3', layer: 'working' },
-      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o4', layer: 'working' },
-      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o5', layer: 'working' },
+      // PR #818 sweep 6 — literal objects so AND-membership
+      // admits them past `filterTriplesToEntities`.
+      { subject: 'urn:e:r1', predicate: 'p', object: '"o1"', layer: 'working' },
+      { subject: 'urn:e:r1', predicate: 'p', object: '"o2"', layer: 'working' },
+      { subject: 'urn:e:r1', predicate: 'p', object: '"o3"', layer: 'working' },
+      { subject: 'urn:e:r1', predicate: 'p', object: '"o4"', layer: 'working' },
+      { subject: 'urn:e:r1', predicate: 'p', object: '"o5"', layer: 'working' },
     ];
     await renderWith({
       ...memory,
@@ -932,12 +942,17 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     ];
     const triples = [
       // Honest SWM triple — admitted into the SWM layer slice.
-      { subject: 'urn:e:promoted', predicate: 'p', object: 'urn:e:o-swm', layer: 'shared' },
+      // PR #818 sweep 6 — literal objects so AND-membership via
+      // `filterTriplesToEntities` admits them on the canonical-
+      // URI subject check (the residue/inflation semantic this
+      // test exercises is orthogonal to the resource-vs-literal
+      // distinction).
+      { subject: 'urn:e:promoted', predicate: 'p', object: '"o-swm"', layer: 'shared' },
       // WM residue — same subject, but canonical trustLevel is
       // 'shared', so `useLayerTriples('wm')` drops this row via
       // the subject-trust-level filter at helpers.ts:436-437.
       // Pre-sweep this would have inflated the Root card stat by 1.
-      { subject: 'urn:e:promoted', predicate: 'p', object: 'urn:e:o-wm-residue', layer: 'working' },
+      { subject: 'urn:e:promoted', predicate: 'p', object: '"o-wm-residue"', layer: 'working' },
     ];
     await renderWith({
       ...memory,
@@ -1066,6 +1081,135 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).toContain('1 triples');
   });
 
+  it('Root card drops triples to non-root entities (Codex sweep 6 — AND-membership symmetric with named cards)', async () => {
+    // PR #818 sweep 6 — sweep 4's inline OR-membership ("admit if
+    // either endpoint is in rootEntityUris") let untagged triples
+    // from `<cg>/_shared_memory` whose SUBJECT happened to be a
+    // root entity admit even when the OBJECT was a non-root
+    // entity. User caught the bug on `ui-refresh`: entity
+    // `urn:epcis:...:gtin:50127962004651:lot:P240526X` lived in
+    // `epcis-supply-chain` (subGraphs non-empty → not in Root
+    // entity list), but the daemon ships untagged copies of its
+    // triples in `<cg>/_shared_memory` → rendered as a node in
+    // the Root mini-graph (broke the visual count check).
+    //
+    // Fix: route through `filterTriplesToEntities(candidates,
+    // rootEntityUris)` so admission is AND-membership (both
+    // endpoints must be root entities, with `rdf:type` exempted)
+    // — exactly the named-card rule.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // Non-root entity (in a named sub-graph).
+      { uri: 'urn:e:non-root', label: 'nr', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      // Root-bucket entity.
+      { uri: 'urn:e:root', label: 'r', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // Untagged edge from root → non-root. Pre-sweep-6 OR-
+      // membership admitted this (subject IS in rootEntityUris)
+      // and `urn:e:non-root` rendered as a node in the Root
+      // mini-graph. Post-sweep-6 AND-membership drops it.
+      { subject: 'urn:e:root', predicate: 'p', object: 'urn:e:non-root', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 2, vm: 0, total: 2 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // 1 root entity, 0 triples — the root→non-root edge dropped
+    // by AND-filter. Pre-sweep this read `1 triples`.
+    expect(stats).toContain('1 entities');
+    expect(stats).toContain('0 triples');
+    expect(stats).not.toContain('1 triples');
+  });
+
+  it('Root card admits rdf:type edges to class URIs (Codex sweep 6 — class IRIs exempted from AND-filter)', async () => {
+    // PR #818 sweep 6 — `filterTriplesToEntities` exempts
+    // `rdf:type` from the object-side membership check because
+    // class IRIs aren't entities but the triple is needed for
+    // `classColors` styling (helpers.ts:533-535). Lock that the
+    // Root card preserves this exemption when it routes through
+    // the helper.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 0, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // Root-bucket entity.
+      { uri: 'urn:e:root', label: 'r', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // rdf:type to a class IRI — admits via the exemption.
+      { subject: 'urn:e:root', predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'urn:type:Document', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 1, vm: 0, total: 1 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // rdf:type row admits despite the class URI not being in
+    // rootEntityUris — the exemption preserves the type signal
+    // for classColors on the rendered mini-graph.
+    expect(stats).toContain('1 entities');
+    expect(stats).toContain('1 triples');
+  });
+
+  it('Named card drops triples to non-scoped entities (parity lock for sweep 6)', async () => {
+    // PR #818 sweep 6 — named-card path has used
+    // `filterTriplesToEntities` since the original implementation
+    // (`:4051`). This test locks the architectural symmetry that
+    // sweep 6 establishes: same input shape, same AND-membership
+    // behavior on the named-card side as the Root card side.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // 'alpha' entity (in-scope for the alpha card).
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      // 'beta' entity — out-of-scope for the alpha card.
+      { uri: 'urn:e:beta', label: 'b', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set(['beta']), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // alpha → beta edge tagged to alpha's subgraph. Named-card
+      // admission AND-filters: subject in scope, object NOT, so
+      // the edge drops from the alpha card.
+      { subject: 'urn:e:alpha', predicate: 'p', object: 'urn:e:beta', subGraph: 'alpha', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 2, vm: 0, total: 2 },
+    });
+    await flush();
+
+    // alpha card is first.
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // 1 entity (alpha), 0 triples (the edge to beta dropped by
+    // AND-filter). Locks that the Root card now mirrors this
+    // behavior post-sweep-6.
+    expect(stats).toContain('1 entities');
+    expect(stats).toContain('0 triples');
+  });
+
   it('Root card cap honors MAX_PER_CARD even with a single dominant subject (Codex sweep 2)', async () => {
     // PR #818 sweep 2 — sweep-1 sampling shape had a defect:
     // `if (kept >= MAX_PER_CARD) break;` checked AFTER adding the
@@ -1088,7 +1232,10 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     ];
     const triples = [];
     for (let i = 0; i < 5000; i++) {
-      triples.push({ subject: 'urn:e:dominant', predicate: 'p', object: `urn:e:obj-${i}`, layer: 'working' });
+      // PR #818 sweep 6 — literal objects so AND-membership
+      // admits them past `filterTriplesToEntities` (this test
+      // exercises the cap, not endpoint admission).
+      triples.push({ subject: 'urn:e:dominant', predicate: 'p', object: `"v-${i}"`, layer: 'working' });
     }
     await renderWith({
       ...memory,
@@ -1199,10 +1346,13 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
       { uri: 'urn:e:r-50b', label: 'r4', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
     ];
     const triples = [];
-    for (let i = 0; i < 2400; i++) triples.push({ subject: 'urn:e:r-2400', predicate: 'p', object: `urn:e:obj-2400-${i}`, layer: 'working' });
-    for (let i = 0; i < 200; i++) triples.push({ subject: 'urn:e:r-200', predicate: 'p', object: `urn:e:obj-200-${i}`, layer: 'working' });
-    for (let i = 0; i < 50; i++) triples.push({ subject: 'urn:e:r-50a', predicate: 'p', object: `urn:e:obj-50a-${i}`, layer: 'working' });
-    for (let i = 0; i < 50; i++) triples.push({ subject: 'urn:e:r-50b', predicate: 'p', object: `urn:e:obj-50b-${i}`, layer: 'working' });
+    // PR #818 sweep 6 — literal objects so AND-membership admits
+    // them past `filterTriplesToEntities` (this test exercises
+    // dense-pack cap behavior, not endpoint admission).
+    for (let i = 0; i < 2400; i++) triples.push({ subject: 'urn:e:r-2400', predicate: 'p', object: `"v-2400-${i}"`, layer: 'working' });
+    for (let i = 0; i < 200; i++) triples.push({ subject: 'urn:e:r-200', predicate: 'p', object: `"v-200-${i}"`, layer: 'working' });
+    for (let i = 0; i < 50; i++) triples.push({ subject: 'urn:e:r-50a', predicate: 'p', object: `"v-50a-${i}"`, layer: 'working' });
+    for (let i = 0; i < 50; i++) triples.push({ subject: 'urn:e:r-50b', predicate: 'p', object: `"v-50b-${i}"`, layer: 'working' });
     await renderWith({
       ...memory,
       entities: new Map(entityList.map(e => [e.uri, e])),

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -903,15 +903,23 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(rootCardEl.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
   });
 
-  it('Root card drops WM residue triples whose subject has been promoted to SWM (Codex sweep 2, GH #805 family)', async () => {
-    // PR #818 sweep 2 — the Root card previously iterated raw
-    // `memory.allTriples`, reintroducing the residue + cross-
-    // graph bug GH #805 just fixed for the Overview/subtitle
-    // surface. Promoted-entity WM residue (the daemon leaves
-    // `/assertion/<addr>/<name>` graphs on disk after promote)
-    // would inflate `rootCard.tripleCount`. Fix: scope into the
-    // union of the per-layer `useLayerTriples` slices, which
-    // apply the subject-trust-level residue filter.
+  it('Root card admits WM residue alongside honest SWM rows (Codex sweep 4 revert — consistent-wrong vs named cards, fix-side scoped for GH #819)', async () => {
+    // PR #818 sweep 4 (ux-lead Finding 1 verdict A — revert).
+    // Sweep 2 added a `useLayerTriples` layer-correctness filter
+    // that dropped WM-residue rows for a promoted entity. That
+    // filter introduced two regressions of its own at the next
+    // consumer downstream (per-slice SPO-dedup race + mixed-layer
+    // edge drop) — moving the symptom rather than fixing the
+    // source. ux-lead's verdict (A): revert to the symmetric
+    // `memory.allTriples` filtered by `!t.subGraph` shape so the
+    // Root card uses the same machinery as the named cards.
+    //
+    // Post-revert: the WM residue row admits alongside the honest
+    // SWM row. Inflation is consistent across Root AND named
+    // cards (consistent-wrong is easier to reason about and to
+    // fix in one render-side follow-up than divergent-wrong).
+    // GH #819 owns the shared render-correct derivation for both
+    // surfaces.
     fetchSubGraphsMock.mockResolvedValueOnce({
       subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
     });
@@ -943,25 +951,33 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const cards = container.querySelectorAll('.v10-sgov-card');
     const rootCardEl = cards[cards.length - 1];
     const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
-    // Only the honest SWM triple survives — WM residue dropped.
-    expect(stats).toContain('1 triples');
-    expect(stats).not.toContain('2 triples');
+    // PR #818 sweep 4 (ux-lead Finding 1 verdict A — revert): the
+    // sweep-2 layer-correctness filter has been removed; Root now
+    // mirrors the named-card pattern over `memory.allTriples`. The
+    // WM residue row admits alongside the honest SWM row — same
+    // inflation behavior as named cards (consistent-wrong rather
+    // than divergent-wrong; render-side fix is GH #819).
+    expect(stats).toContain('2 triples');
   });
 
-  it('Root card collapses SWM cross-graph SPO duplicates (Codex sweep 2, GH #805 family)', async () => {
-    // PR #818 sweep 2 — same family, different mechanism. SWM
-    // content published into a named sub-graph appears in both
-    // `<cg>/_shared_memory` (root SWM graph) AND
-    // `<cg>/<sg>/_shared_memory` (per-sub-graph SWM graph). Raw
-    // `memory.allTriples` counts both rows; `useLayerTriples`
-    // SPO-deduplicates them to 1. The Root card now scopes into
-    // that deduped universe.
+  it('Root card admits SWM cross-graph SPO collision via the untagged variant (Codex sweep 4 regression — under-count prevented)', async () => {
+    // PR #818 sweep 4 (ux-lead Finding 1 verdict A — revert).
+    // The sweep-2 `useLayerTriples` derivation had a per-slice
+    // dedup race: when the SAME `(s, p, o)` shipped under BOTH
+    // the root SWM graph (untagged) AND a per-sub-graph SWM graph
+    // (tagged), the SWM layer slice's canonical-SPO dedup
+    // collapsed both rows into the one that arrived first. If
+    // the tagged row won, the Root card's `if (t.subGraph)
+    // continue` guard then dropped it — and the untagged variant
+    // never got a second chance to admit. Outcome: Root card
+    // under-counted the SPO to ZERO on the cross-graph collision
+    // shape.
     //
-    // The crucial test: a root-bucket entity whose `rdfs:label`
-    // ships under both the root SWM graph AND a named-sub-graph
-    // SWM graph (one of its OTHER assertions targeted a sub-graph,
-    // promoting the label via lifecycle metadata). Pre-sweep the
-    // Root card would count 2; post-sweep it counts 1.
+    // Post-revert: `memory.allTriples` is the input, so both the
+    // tagged and untagged variants reach the Root loop. The
+    // `!t.subGraph` filter drops the tagged row; the untagged row
+    // admits and renders. Regression-prevent: the row admits at
+    // least once — not the sweep-2 outcome of 0.
     fetchSubGraphsMock.mockResolvedValueOnce({
       subGraphs: [{ name: 'alpha', entityCount: 0, tripleCount: 0, description: '' }],
     });
@@ -970,26 +986,13 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
       { uri: 'urn:e:root-swm', label: 'rsm', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
     ];
     const triples = [
-      // Same SPO emitted twice with different subGraph tags
-      // (root SWM vs named-sub-graph SWM cross-graph duplicate).
-      // Both share `layer: 'shared'` so the layer slice picks up
-      // both rows; the layer slice's canonical-SPO dedup
-      // (helpers.ts:465-466) collapses them to 1 before the Root
-      // card's untagged-recovery branch even sees the universe.
-      //
-      // Note: both rows ALSO carry `subGraph` tags, so the Root
-      // card's `if (t.subGraph) continue;` guard would also drop
-      // them — but the union of per-layer slices is the
-      // load-bearing fix here, because untagged variants (the
-      // common shape post-promote) would still reach the loop
-      // and could re-duplicate without it.
-      { subject: 'urn:e:root-swm', predicate: 'rdfs:label', object: '"r"', subGraph: 'meta', layer: 'shared' },
+      // The crucial cross-graph collision: the SAME SPO ships
+      // under both an untagged variant (root SWM graph) AND a
+      // tagged variant (per-sub-graph SWM graph). Sweep 2's per-
+      // layer dedup collapsed them and could drop the survivor.
+      // Post-revert the untagged row admits.
+      { subject: 'urn:e:root-swm', predicate: 'rdfs:label', object: '"r"', layer: 'shared' },
       { subject: 'urn:e:root-swm', predicate: 'rdfs:label', object: '"r"', subGraph: 'alpha', layer: 'shared' },
-      // The untagged variant — what survives to the Root card's
-      // loop. Counts ONCE because the upstream per-layer SPO-
-      // dedup ran on the layer slice.
-      { subject: 'urn:e:root-swm', predicate: 'rdfs:comment', object: '"c"', layer: 'shared' },
-      { subject: 'urn:e:root-swm', predicate: 'rdfs:comment', object: '"c"', layer: 'shared' },
     ];
     await renderWith({
       ...memory,
@@ -1003,12 +1006,64 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const cards = container.querySelectorAll('.v10-sgov-card');
     const rootCardEl = cards[cards.length - 1];
     const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
-    // 1 distinct untagged SPO after upstream dedup; the tagged
-    // rows are dropped by the Root card's `if (t.subGraph)
-    // continue` guard. Pre-sweep the duplicate rdfs:comment
-    // would have counted 2.
+    // Lock-test: the cross-graph SPO admits via the untagged row.
+    // Pre-revert (sweep 2) this fixture rendered `0 triples` when
+    // the tagged row won the per-slice dedup race. Loose lower-
+    // bound rather than strict equality because the render-side
+    // inflation behavior is left for GH #819 to lock precisely;
+    // the regression-prevent contract here is "not zero".
+    expect(stats).toContain('1 entities');
+    expect(stats).not.toContain('0 triples');
+  });
+
+  it('Root card admits mixed-layer resource edges (Codex sweep 4 regression — WM→SWM cross-layer drop prevented)', async () => {
+    // PR #818 sweep 4 (ux-lead Finding 2 verdict A — revert).
+    // Sweep 2's `useLayerTriples` derivation applied a subject-
+    // trust-level residue filter inside each layer slice. For a
+    // WM root entity pointing at an SWM entity, the row's
+    // `t.layer === 'shared'` sent it to the SWM slice — but the
+    // SWM slice's residue filter drops rows whose subject's
+    // canonical trustLevel doesn't match the slice (subject is
+    // WM, slice is SWM → dropped). The row never entered any
+    // layer slice and never reached the Root card.
+    //
+    // Post-revert: `memory.allTriples` carries the row, the Root
+    // loop sees it, the untagged check passes (no subGraph), and
+    // canonical-URI membership admits because the WM subject IS
+    // in `rootEntityUris`. Lock-test: the cross-layer edge
+    // renders on the Root card.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 0, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // WM root entity (subject of the cross-layer edge).
+      { uri: 'urn:e:wm-root', label: 'w', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+      // SWM root entity (object of the cross-layer edge).
+      { uri: 'urn:e:swm-root', label: 's', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // The crucial cross-layer edge: WM subject → SWM object,
+      // row layer matches the object's (SWM). Sweep 2 dropped
+      // it; post-revert it admits.
+      { subject: 'urn:e:wm-root', predicate: 'rel', object: 'urn:e:swm-root', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 1, swm: 1, vm: 0, total: 2 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // Both endpoints are root entities; the cross-layer edge
+    // admits. Pre-revert (sweep 2) the residue filter dropped it
+    // → Root card showed `0 triples`. Post-revert it shows `1`.
+    expect(stats).toContain('2 entities');
     expect(stats).toContain('1 triples');
-    expect(stats).not.toContain('2 triples');
   });
 
   it('Root card cap honors MAX_PER_CARD even with a single dominant subject (Codex sweep 2)', async () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -82,6 +82,27 @@ const memory = {
   refresh: vi.fn(),
 } as any;
 
+// RdfGraph is React.lazy'd — pump microtasks until the Suspense
+// boundary resolves and the stub renders. Sweep 1 cap tests
+// asserted against a transient Suspense fallback that shares the
+// empty-branch class; tighten by waiting for the actual graph
+// element before reading `data-triple-count`. Optional `scope`
+// restricts the lookup (e.g. to a specific card element).
+async function waitForGraph(
+  container: Element,
+  options?: { scope?: Element; maxMs?: number },
+): Promise<HTMLElement | null> {
+  const root = options?.scope ?? container;
+  const maxMs = options?.maxMs ?? 1000;
+  const start = Date.now();
+  while (Date.now() - start < maxMs) {
+    const el = root.querySelector('[data-testid="rdf-graph"]') as HTMLElement | null;
+    if (el) return el;
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+  }
+  return root.querySelector('[data-testid="rdf-graph"]');
+}
+
 async function flush(): Promise<void> {
   // Two microtask drains — one for the promise the effect kicks
   // off, one for the setState in the resolver/finally.
@@ -1090,6 +1111,94 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // above).
     expect(renderedTripleCount).toBeLessThanOrEqual(2500); // MAX_PER_CARD
     expect(renderedTripleCount).toBeGreaterThan(0);         // dominant hub still renders
+  });
+
+  it('Root card cap densely-packs the available capacity instead of under-filling on a non-fitting subject (Codex sweep 3)', async () => {
+    // PR #818 sweep 3 — sweep-2 used `break` on a non-fitting
+    // subject, which under-filled the cap when smaller satellites
+    // would still have fit. Fixture: degrees `[2400, 200, 50, 50]`
+    // with MAX_PER_CARD = 2500.
+    //   • `break` shape: admit 2400 → reject 200 (kept+200 > 2500)
+    //     → stop. Rendered = 2400 (100 headroom unused).
+    //   • `continue` shape: admit 2400 → skip 200 → admit 50 →
+    //     admit 50. Rendered = 2500 (dense pack at the cap).
+    // The dense-pack outcome is the friendlier user-facing
+    // result.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:r-2400', label: 'r1', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+      { uri: 'urn:e:r-200', label: 'r2', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+      { uri: 'urn:e:r-50a', label: 'r3', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+      { uri: 'urn:e:r-50b', label: 'r4', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [];
+    for (let i = 0; i < 2400; i++) triples.push({ subject: 'urn:e:r-2400', predicate: 'p', object: `urn:e:obj-2400-${i}`, layer: 'working' });
+    for (let i = 0; i < 200; i++) triples.push({ subject: 'urn:e:r-200', predicate: 'p', object: `urn:e:obj-200-${i}`, layer: 'working' });
+    for (let i = 0; i < 50; i++) triples.push({ subject: 'urn:e:r-50a', predicate: 'p', object: `urn:e:obj-50a-${i}`, layer: 'working' });
+    for (let i = 0; i < 50; i++) triples.push({ subject: 'urn:e:r-50b', predicate: 'p', object: `urn:e:obj-50b-${i}`, layer: 'working' });
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 5, swm: 0, vm: 0, total: 5 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    const graphEl = await waitForGraph(container, { scope: rootCardEl });
+    expect(graphEl).toBeTruthy();
+    const renderedTripleCount = Number(graphEl!.getAttribute('data-triple-count') ?? 'NaN');
+    // Dense pack: 2400 + 50 + 50 = 2500 (continue skips the 200
+    // that wouldn't fit). The `break` shape would have rendered
+    // 2400 (skipping the satellites that fit). Floor at 2450
+    // catches the 2400 under-fill defect while permitting minor
+    // sampling variance in future tweaks.
+    expect(renderedTripleCount).toBeLessThanOrEqual(2500); // MAX_PER_CARD
+    expect(renderedTripleCount).toBeGreaterThanOrEqual(2450); // dense pack
+  });
+
+  it('Named card cap densely-packs the available capacity (Codex sweep 3, parity)', async () => {
+    // PR #818 sweep 3 — same defect on the named-card sampling at
+    // `:3935-3953`. Same `[2400, 200, 50, 50]` fixture shape,
+    // tagged into a single sub-graph, with literal objects so
+    // `filterTriplesToEntities` doesn't drop the resource-edge
+    // rows.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 4, tripleCount: 2700, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:a-2400', label: 'a1', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:a-200', label: 'a2', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:a-50a', label: 'a3', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:a-50b', label: 'a4', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    const triples = [];
+    for (let i = 0; i < 2400; i++) triples.push({ subject: 'urn:e:a-2400', predicate: 'p', object: `"v-2400-${i}"`, subGraph: 'alpha', layer: 'working' });
+    for (let i = 0; i < 200; i++) triples.push({ subject: 'urn:e:a-200', predicate: 'p', object: `"v-200-${i}"`, subGraph: 'alpha', layer: 'working' });
+    for (let i = 0; i < 50; i++) triples.push({ subject: 'urn:e:a-50a', predicate: 'p', object: `"v-50a-${i}"`, subGraph: 'alpha', layer: 'working' });
+    for (let i = 0; i < 50; i++) triples.push({ subject: 'urn:e:a-50b', predicate: 'p', object: `"v-50b-${i}"`, subGraph: 'alpha', layer: 'working' });
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 4, swm: 0, vm: 0, total: 4 },
+    });
+    await flush();
+
+    // First card is the named alpha card.
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const graphEl = await waitForGraph(container, { scope: alphaCardEl });
+    expect(graphEl).toBeTruthy();
+    const renderedTripleCount = Number(graphEl!.getAttribute('data-triple-count') ?? 'NaN');
+    expect(renderedTripleCount).toBeLessThanOrEqual(2500); // MAX_PER_CARD
+    expect(renderedTripleCount).toBeGreaterThanOrEqual(2450); // dense pack
   });
 });
 

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -645,6 +645,61 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).toContain('2 entities');
     expect(stats).toContain('1 triples');
   });
+
+  it('Root card canonicalizes triple endpoints + SPO dedup key (Codex sweep 1, Bug M family)', async () => {
+    // PR #818 sweep 1 — `rootEntityUris` is built from
+    // `canonicalEntityUri(e.uri)` but `t.subject` / `t.object` from
+    // `memory.allTriples` carry the daemon-emitted raw forms (often
+    // wrapped `<urn:...>`). Without canonicalisation on the
+    // consumer side:
+    //   1. The membership check fails when a wrapped endpoint's
+    //      canonical form IS in the set — the in-scope triple
+    //      gets silently dropped from the card slice.
+    //   2. The SPO-dedup key counts wrapped + bare variants of the
+    //      same (s,p,o) as distinct rows — inflates the count.
+    // The fix canonicalises subject + object once per iteration,
+    // uses canonical forms for BOTH the membership check AND the
+    // seenSpo key. Mirrors the upstream Bug M dual-key pattern.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      // Root entity in canonical (unwrapped) form. `rootEntityUris`
+      // therefore contains 'urn:e:root1' only.
+      { uri: 'urn:e:root1', label: 'r1', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // Subject wrapped — pre-sweep the membership check (against
+      // the unwrapped set) failed and this triple was dropped.
+      { subject: '<urn:e:root1>', predicate: 'p', object: 'urn:e:o-bare' },
+      // Same SPO emitted twice — once wrapped, once bare. Pre-
+      // sweep these had distinct seenSpo keys and counted as 2.
+      // Post-sweep both map to the same canonical key and dedup
+      // to 1.
+      { subject: 'urn:e:root1', predicate: 'p', object: '<urn:e:o-other>' },
+      { subject: 'urn:e:root1', predicate: 'p', object: 'urn:e:o-other' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 2, swm: 0, vm: 0, total: 2 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // 1 root entity, 2 distinct triples after canonical-SPO dedup
+    // (the wrapped/bare object pair collapses to 1; the wrapped-
+    // subject row is admitted via the canonicalised membership
+    // check). Pre-sweep this fixture would have rendered "1 triple"
+    // (wrapped subject dropped) OR "3 triples" (no dedup).
+    expect(stats).toContain('1 entities');
+    expect(stats).toContain('2 triples');
+  });
 });
 
 describe('SubGraphMiniCard — per-trust nodeColors (S3 polish #3, ui-locked priority chain)', () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -319,15 +319,17 @@ describe('SubGraphOverviewGrid — header subtitle anchors (PR #793 round 4.1, G
       ],
     });
     const triples = [
-      // alpha sub-graph triples
-      { subject: 'urn:e:a1', predicate: 'p', object: 'o1', subGraph: 'alpha' },
-      { subject: 'urn:e:a2', predicate: 'p', object: 'o2', subGraph: 'alpha' },
+      // alpha sub-graph triples. GH #805 — fixture now tags
+      // `layer: 'working'` so the `useLayerTriples` sum
+      // (which the subtitle now reads) admits them.
+      { subject: 'urn:e:a1', predicate: 'p', object: 'o1', subGraph: 'alpha', layer: 'working' },
+      { subject: 'urn:e:a2', predicate: 'p', object: 'o2', subGraph: 'alpha', layer: 'working' },
       // beta sub-graph triples
-      { subject: 'urn:e:b1', predicate: 'p', object: 'o3', subGraph: 'beta' },
-      { subject: 'urn:e:b2', predicate: 'p', object: 'o4', subGraph: 'beta' },
+      { subject: 'urn:e:b1', predicate: 'p', object: 'o3', subGraph: 'beta', layer: 'working' },
+      { subject: 'urn:e:b2', predicate: 'p', object: 'o4', subGraph: 'beta', layer: 'working' },
       // a root-bucket triple (no sub-graph origin) — counted by the
       // hook total but never reaches a card aggregate.
-      { subject: 'urn:e:root', predicate: 'p', object: 'o5' },
+      { subject: 'urn:e:root', predicate: 'p', object: 'o5', layer: 'working' },
     ];
     const entityList = [
       { uri: 'urn:e:a1', label: 'a1', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
@@ -376,13 +378,15 @@ describe('SubGraphOverviewGrid — header subtitle anchors (PR #793 round 4.1, G
       { uri: 'urn:e:cross', label: 'c', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha', 'beta']), properties: new Map(), connections: [] },
     ];
     const triples = [
-      // 4 raw triple rows even though the cross-graph SPO duplicate
-      // means distinct triples are fewer — exactly the GH #805
-      // family the subtitle now defers to.
-      { subject: 'urn:e:alpha-only', predicate: 'p', object: 'o', subGraph: 'alpha' },
-      { subject: 'urn:e:beta-only', predicate: 'p', object: 'o', subGraph: 'beta' },
-      { subject: 'urn:e:cross', predicate: 'p', object: 'o', subGraph: 'alpha' },
-      { subject: 'urn:e:cross', predicate: 'p', object: 'o', subGraph: 'beta' },
+      // 4 raw triple rows; the (urn:e:cross, p, o) SPO appears in
+      // both alpha and beta named graphs — exactly the SWM
+      // cross-graph duplication GH #805 fixes. After
+      // `useLayerTriples` SPO-dedup the layer slice carries 3
+      // distinct triples, not 4.
+      { subject: 'urn:e:alpha-only', predicate: 'p', object: 'o', subGraph: 'alpha', layer: 'working' },
+      { subject: 'urn:e:beta-only', predicate: 'p', object: 'o', subGraph: 'beta', layer: 'working' },
+      { subject: 'urn:e:cross', predicate: 'p', object: 'o', subGraph: 'alpha', layer: 'working' },
+      { subject: 'urn:e:cross', predicate: 'p', object: 'o', subGraph: 'beta', layer: 'working' },
     ];
     await renderWith({
       ...memory,
@@ -398,9 +402,56 @@ describe('SubGraphOverviewGrid — header subtitle anchors (PR #793 round 4.1, G
     // Subtitle anchors to hook total (3), NOT sum-of-cards (4).
     expect(sub!.textContent).toContain('3 entities');
     expect(sub!.textContent).not.toContain('4 entities');
-    // Subtitle anchors to allTriples.length (4), matching what the
-    // SubGraphBar `All` chip tooltip surfaces.
-    expect(sub!.textContent).toContain('4 triples');
+    // Subtitle triples now sums `useLayerTriples` per layer
+    // (GH #805): the (urn:e:cross, p, o) SPO row that appeared
+    // in both alpha and beta named graphs collapses to 1 after
+    // canonical-SPO dedup, so the 4 raw rows project down to 3
+    // distinct triples in the WM layer slice.
+    expect(sub!.textContent).toContain('3 triples');
+    // The raw `allTriples.length` (4) must NOT appear — that's
+    // the bug GH #805 fixed.
+    expect(sub!.textContent).not.toContain('4 triples');
+  });
+
+  it('subtitle drops WM residue triples whose subject has been promoted to SWM (GH #805 layer-correctness)', async () => {
+    // The other half of GH #805 — WM residue. The daemon leaves
+    // `/assertion/<addr>/<name>` graphs on disk after promote, so a
+    // promoted entity's WM-origin triples keep coming back from
+    // `wmSparql`. The entity's canonical `trustLevel` has moved to
+    // `shared`, so `useLayerTriples('wm')` drops those residue
+    // rows. Pre-#805 `allTriples.length` counted them and the
+    // subtitle disagreed with the per-layer LayerStats.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // 1 alpha entity, canonical layer SWM (promoted out of WM).
+      { uri: 'urn:e:promoted', label: 'p', types: [], trustLevel: 'shared', layers: new Set(['working', 'shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // Honest SWM triple — kept.
+      { subject: 'urn:e:promoted', predicate: 'p', object: 'o-swm', layer: 'shared' },
+      // WM residue — same subject, but its canonical trustLevel is
+      // 'shared', so `useLayerTriples('wm')` drops this row.
+      // Pre-#805 it would have inflated the subtitle by 1.
+      { subject: 'urn:e:promoted', predicate: 'p', object: 'o-wm-residue', layer: 'working' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 1, vm: 0, total: 1 },
+    });
+    await flush();
+
+    const sub = container.querySelector('.v10-sgov-sub');
+    expect(sub).toBeTruthy();
+    // Only the honest SWM triple survives — WM residue dropped by
+    // the per-layer trustLevel filter.
+    expect(sub!.textContent).toContain('1 triples');
+    // Pre-#805 raw `allTriples.length` would have shown 2.
+    expect(sub!.textContent).not.toContain('2 triples');
   });
 });
 

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -619,13 +619,16 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const triples = [
       // Tagged triple — root entity but tagged to a different
       // sub-graph. Must NOT appear in Root's slice.
-      { subject: 'urn:e:root1', predicate: 'p', object: 'urn:e:alpha', subGraph: 'alpha' },
+      // PR #818 sweep 2 — fixtures tagged `layer: 'working'` so
+      // `useLayerTriples` admits them into the layer-correct
+      // universe the Root card now scopes into (GH #805 family).
+      { subject: 'urn:e:root1', predicate: 'p', object: 'urn:e:alpha', subGraph: 'alpha', layer: 'working' },
       // Untagged triple between two root entities — admitted by
       // the untagged-recovery branch.
-      { subject: 'urn:e:root1', predicate: 'p', object: 'urn:e:root2' },
+      { subject: 'urn:e:root1', predicate: 'p', object: 'urn:e:root2', layer: 'working' },
       // Untagged triple with no endpoint in scope — must NOT
       // appear in Root's slice.
-      { subject: 'urn:e:alpha', predicate: 'p', object: 'urn:e:somewhere-else' },
+      { subject: 'urn:e:alpha', predicate: 'p', object: 'urn:e:somewhere-else', layer: 'working' },
     ];
     await renderWith({
       ...memory,
@@ -672,13 +675,15 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const triples = [
       // Subject wrapped — pre-sweep the membership check (against
       // the unwrapped set) failed and this triple was dropped.
-      { subject: '<urn:e:root1>', predicate: 'p', object: 'urn:e:o-bare' },
+      // PR #818 sweep 2 — fixtures tagged `layer: 'working'` so
+      // `useLayerTriples` admits them (GH #805 family).
+      { subject: '<urn:e:root1>', predicate: 'p', object: 'urn:e:o-bare', layer: 'working' },
       // Same SPO emitted twice — once wrapped, once bare. Pre-
       // sweep these had distinct seenSpo keys and counted as 2.
       // Post-sweep both map to the same canonical key and dedup
       // to 1.
-      { subject: 'urn:e:root1', predicate: 'p', object: '<urn:e:o-other>' },
-      { subject: 'urn:e:root1', predicate: 'p', object: 'urn:e:o-other' },
+      { subject: 'urn:e:root1', predicate: 'p', object: '<urn:e:o-other>', layer: 'working' },
+      { subject: 'urn:e:root1', predicate: 'p', object: 'urn:e:o-other', layer: 'working' },
     ];
     await renderWith({
       ...memory,
@@ -783,7 +788,10 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     ];
     const triples = [];
     for (let i = 0; i < 3000; i++) {
-      triples.push({ subject: 'urn:e:heavy-root', predicate: 'p', object: `urn:e:obj-${i}` });
+      // PR #818 sweep 2 — tag `layer: 'working'` so the layer-correct
+      // universe `useLayerTriples` produces (GH #805 family) admits
+      // these rows for the Root card to scope over.
+      triples.push({ subject: 'urn:e:heavy-root', predicate: 'p', object: `urn:e:obj-${i}`, layer: 'working' });
     }
     await renderWith({
       ...memory,
@@ -827,11 +835,13 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
       { uri: 'urn:e:r1', label: 'r1', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
     ];
     const triples = [
-      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o1' },
-      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o2' },
-      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o3' },
-      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o4' },
-      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o5' },
+      // PR #818 sweep 2 — `layer: 'working'` so the layer-correct
+      // universe (GH #805) admits the rows.
+      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o1', layer: 'working' },
+      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o2', layer: 'working' },
+      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o3', layer: 'working' },
+      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o4', layer: 'working' },
+      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o5', layer: 'working' },
     ];
     await renderWith({
       ...memory,
@@ -849,6 +859,114 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // RdfGraph renders (not the empty branch), confirming all 5
     // triples survived to the mini-graph slice.
     expect(rootCardEl.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
+  });
+
+  it('Root card drops WM residue triples whose subject has been promoted to SWM (Codex sweep 2, GH #805 family)', async () => {
+    // PR #818 sweep 2 — the Root card previously iterated raw
+    // `memory.allTriples`, reintroducing the residue + cross-
+    // graph bug GH #805 just fixed for the Overview/subtitle
+    // surface. Promoted-entity WM residue (the daemon leaves
+    // `/assertion/<addr>/<name>` graphs on disk after promote)
+    // would inflate `rootCard.tripleCount`. Fix: scope into the
+    // union of the per-layer `useLayerTriples` slices, which
+    // apply the subject-trust-level residue filter.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      // Root-bucket entity, canonical trustLevel is SWM (promoted
+      // past WM, but `subGraphs.size === 0` keeps it in the Root
+      // bucket).
+      { uri: 'urn:e:promoted', label: 'p', types: [], trustLevel: 'shared', layers: new Set(['working', 'shared']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // Honest SWM triple — admitted into the SWM layer slice.
+      { subject: 'urn:e:promoted', predicate: 'p', object: 'urn:e:o-swm', layer: 'shared' },
+      // WM residue — same subject, but canonical trustLevel is
+      // 'shared', so `useLayerTriples('wm')` drops this row via
+      // the subject-trust-level filter at helpers.ts:436-437.
+      // Pre-sweep this would have inflated the Root card stat by 1.
+      { subject: 'urn:e:promoted', predicate: 'p', object: 'urn:e:o-wm-residue', layer: 'working' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 1, vm: 0, total: 1 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // Only the honest SWM triple survives — WM residue dropped.
+    expect(stats).toContain('1 triples');
+    expect(stats).not.toContain('2 triples');
+  });
+
+  it('Root card collapses SWM cross-graph SPO duplicates (Codex sweep 2, GH #805 family)', async () => {
+    // PR #818 sweep 2 — same family, different mechanism. SWM
+    // content published into a named sub-graph appears in both
+    // `<cg>/_shared_memory` (root SWM graph) AND
+    // `<cg>/<sg>/_shared_memory` (per-sub-graph SWM graph). Raw
+    // `memory.allTriples` counts both rows; `useLayerTriples`
+    // SPO-deduplicates them to 1. The Root card now scopes into
+    // that deduped universe.
+    //
+    // The crucial test: a root-bucket entity whose `rdfs:label`
+    // ships under both the root SWM graph AND a named-sub-graph
+    // SWM graph (one of its OTHER assertions targeted a sub-graph,
+    // promoting the label via lifecycle metadata). Pre-sweep the
+    // Root card would count 2; post-sweep it counts 1.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 0, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // Single root-bucket entity at SWM.
+      { uri: 'urn:e:root-swm', label: 'rsm', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // Same SPO emitted twice with different subGraph tags
+      // (root SWM vs named-sub-graph SWM cross-graph duplicate).
+      // Both share `layer: 'shared'` so the layer slice picks up
+      // both rows; the layer slice's canonical-SPO dedup
+      // (helpers.ts:465-466) collapses them to 1 before the Root
+      // card's untagged-recovery branch even sees the universe.
+      //
+      // Note: both rows ALSO carry `subGraph` tags, so the Root
+      // card's `if (t.subGraph) continue;` guard would also drop
+      // them — but the union of per-layer slices is the
+      // load-bearing fix here, because untagged variants (the
+      // common shape post-promote) would still reach the loop
+      // and could re-duplicate without it.
+      { subject: 'urn:e:root-swm', predicate: 'rdfs:label', object: '"r"', subGraph: 'meta', layer: 'shared' },
+      { subject: 'urn:e:root-swm', predicate: 'rdfs:label', object: '"r"', subGraph: 'alpha', layer: 'shared' },
+      // The untagged variant — what survives to the Root card's
+      // loop. Counts ONCE because the upstream per-layer SPO-
+      // dedup ran on the layer slice.
+      { subject: 'urn:e:root-swm', predicate: 'rdfs:comment', object: '"c"', layer: 'shared' },
+      { subject: 'urn:e:root-swm', predicate: 'rdfs:comment', object: '"c"', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 1, vm: 0, total: 1 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // 1 distinct untagged SPO after upstream dedup; the tagged
+    // rows are dropped by the Root card's `if (t.subGraph)
+    // continue` guard. Pre-sweep the duplicate rdfs:comment
+    // would have counted 2.
+    expect(stats).toContain('1 triples');
+    expect(stats).not.toContain('2 triples');
   });
 });
 

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -356,7 +356,10 @@ describe('SubGraphOverviewGrid — header subtitle anchors (PR #793 round 4.1, G
 
     const sub = container.querySelector('.v10-sgov-sub');
     expect(sub).toBeTruthy();
-    expect(sub!.textContent).toContain('2 subgraphs');
+    // PR #818 sweep 2 — subtitle label is "named subgraphs" so
+    // it's honest about the count's scope (Root is a peer-but-
+    // different surface in the grid).
+    expect(sub!.textContent).toContain('2 named subgraphs');
     expect(sub!.textContent).toContain('5 entities');
     expect(sub!.textContent).toContain('5 triples');
   });
@@ -739,6 +742,13 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // Teaching empty state must NOT render — its title is the
     // tell.
     expect(container.textContent ?? '').not.toContain('No subgraphs in this Context Graph yet.');
+    // PR #818 sweep 2 — subtitle reads `0 named subgraphs` here.
+    // Locks the rename: pre-sweep this said `0 subgraphs` while
+    // a Root card visibly rendered (the inconsistency Codex
+    // flagged in sweep 2 finding 3). The "named" qualifier makes
+    // the count honest about what `cards.length` covers.
+    const sub = container.querySelector('.v10-sgov-sub');
+    expect(sub?.textContent).toContain('0 named subgraphs');
     // Exactly one card renders — the Root card.
     const cards = container.querySelectorAll('.v10-sgov-card');
     expect(cards.length).toBe(1);

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -756,6 +756,100 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // No mini-cards.
     expect(container.querySelectorAll('.v10-sgov-card').length).toBe(0);
   });
+
+  it('Root card caps mini-graph triples at MAX_PER_CARD via heaviest-subjects sampling (Codex sweep 1)', async () => {
+    // PR #818 sweep 1 — earlier the Root card had no cap on the
+    // theory that the recovery slice was small. Codex flagged
+    // the counterexample: large initial seeds + agents writing
+    // without sub-graph tags can produce thousands of untagged
+    // triples touching root entities, locking RdfGraph's layout
+    // on the overview tab. Cap = 2500 (same constant as the
+    // named-card path); sampling keeps every triple for the
+    // heaviest-degree subjects so cluster topology survives.
+    //
+    // Fixture: 1 high-degree root entity with 3000 untagged
+    // triples. Without the cap the mini-graph would receive
+    // 3000 triples; with it, only the 2500-row sample
+    // (every triple stays in this case because the one heaviest
+    // subject hits the cap first, so the `kept >= MAX_PER_CARD`
+    // break trips after the first iteration and only 2500 of
+    // its rows survive the filter).
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:heavy-root', label: 'hr', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [];
+    for (let i = 0; i < 3000; i++) {
+      triples.push({ subject: 'urn:e:heavy-root', predicate: 'p', object: `urn:e:obj-${i}` });
+    }
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 2, swm: 0, vm: 0, total: 2 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    // tripleCount stat reports the TRUE pre-cap distinct total
+    // (3000 — matches the named-card convention where the badge
+    // reads the daemon-reported total even when the mini-graph
+    // slice is sampled).
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    expect(stats).toContain('3000 triples');
+    // The rendered mini-graph receives the post-cap sampled
+    // slice. The RdfGraph stub surfaces the data length via
+    // its `data-node-colors` attribute side-channel, but we
+    // don't have a direct hook for the data prop here. Instead
+    // verify behaviour at the prop boundary: with `MAX_PER_CARD
+    // = 2500`, sampling keeps the first 2500 rows whose subject
+    // hits the cap. (Behavioural assertion below — the rendered
+    // graph DOM element exists, the empty branch did NOT fire.)
+    const emptyBranch = rootCardEl.querySelector('.v10-sgov-card-empty');
+    expect(emptyBranch).toBeNull();
+    expect(rootCardEl.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
+  });
+
+  it('Root card retains all triples under the MAX_PER_CARD cap (no spurious sampling)', async () => {
+    // Companion test — the cap must not fire when the root
+    // triple slice is small. Fixture: 5 distinct root↔root
+    // triples → both stat AND rendered graph carry 5.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:r1', label: 'r1', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o1' },
+      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o2' },
+      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o3' },
+      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o4' },
+      { subject: 'urn:e:r1', predicate: 'p', object: 'urn:e:o5' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 2, swm: 0, vm: 0, total: 2 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const rootCardEl = cards[cards.length - 1];
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    expect(stats).toContain('5 triples');
+    // RdfGraph renders (not the empty branch), confirming all 5
+    // triples survived to the mini-graph slice.
+    expect(rootCardEl.querySelector('[data-testid="rdf-graph"]')).toBeTruthy();
+  });
 });
 
 describe('SubGraphMiniCard — per-trust nodeColors (S3 polish #3, ui-locked priority chain)', () => {

--- a/packages/node-ui/test/use-memory-entities-counts.test.ts
+++ b/packages/node-ui/test/use-memory-entities-counts.test.ts
@@ -74,7 +74,11 @@ describe('useMemoryEntities canonical layer counts', () => {
       const { sparql = '', contextGraphId = 'cg' } =
         JSON.parse(String(init?.body ?? '{}')) as { sparql?: string; contextGraphId?: string };
       const isVm = sparql.includes('_verified_memory_meta');
-      const isSwm = !isVm && sparql.includes('STRENDS');
+      // PR #818 sweep 3 — WM SPARQL now contains `STRENDS(...,
+      // "/_meta")` for the meta-exclusion filter, so the SWM
+      // detection needs the discriminating clause that's still
+      // SWM-exclusive: the `/_shared_memory` tail check.
+      const isSwm = !isVm && sparql.includes('STRENDS(STR(?g), "/_shared_memory")');
       const graphBase = `did:dkg:context-graph:${contextGraphId}`;
       const bindings = isVm
         ? [
@@ -127,5 +131,26 @@ describe('useMemoryEntities canonical layer counts', () => {
       .find(body => body.sparql?.includes('_verified_memory_meta'));
     expect(vmRequest?.sparql).toContain('STR(?g) != "did:dkg:context-graph:cg-counts/meta"');
     expect(vmRequest?.sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
+
+    // PR #818 Codex sweep 3 (ux-lead Finding 1 verdict) — WM and
+    // SWM SPARQL queries gain the same meta-namespace exclusions VM
+    // already enforces. Profile artifacts (prof:* — project profile
+    // configuration) live under `<cg>/meta/...` and are loaded by
+    // `useProjectProfile` directly via its own SPARQL; without the
+    // upstream filter here they also leak into `memory.entityList`,
+    // becoming "root entities" in every consumer downstream (the
+    // GH #806 family root cause).
+    const wmRequest = vi.mocked(fetch).mock.calls
+      .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { sparql?: string })
+      .find(body => body.sparql?.includes('CONTAINS(STR(?g), "/assertion/")'));
+    expect(wmRequest?.sparql).toContain('STR(?g) != "did:dkg:context-graph:cg-counts/meta"');
+    expect(wmRequest?.sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
+    expect(wmRequest?.sparql).toContain('!STRENDS(STR(?g), "/_meta")');
+
+    const swmRequest = vi.mocked(fetch).mock.calls
+      .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { sparql?: string })
+      .find(body => body.sparql?.includes('STRENDS(STR(?g), "/_shared_memory")'));
+    expect(swmRequest?.sparql).toContain('STR(?g) != "did:dkg:context-graph:cg-counts/meta/_shared_memory"');
+    expect(swmRequest?.sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
   });
 });

--- a/packages/node-ui/test/use-memory-entities-labels.test.ts
+++ b/packages/node-ui/test/use-memory-entities-labels.test.ts
@@ -62,7 +62,10 @@ describe('useMemoryEntities readable labels', () => {
       const { sparql = '', contextGraphId = 'cg' } =
         JSON.parse(String(init?.body ?? '{}')) as { sparql?: string; contextGraphId?: string };
       const isVm = sparql.includes('_verified_memory_meta');
-      const isSwm = !isVm && sparql.includes('STRENDS');
+      // PR #818 sweep 3 — WM SPARQL also contains STRENDS (for the
+      // `/_meta` exclusion); discriminate by the SWM-exclusive
+      // `/_shared_memory` tail check.
+      const isSwm = !isVm && sparql.includes('STRENDS(STR(?g), "/_shared_memory")');
       const graph = `did:dkg:context-graph:${contextGraphId}/notes/assertion/agent/a-1`;
       const extraction = 'urn:dkg:extraction:123e4567-e89b-12d3-a456-426614174000';
       const bindings = isVm || isSwm

--- a/packages/node-ui/test/use-memory-entities-live-updates.test.ts
+++ b/packages/node-ui/test/use-memory-entities-live-updates.test.ts
@@ -44,7 +44,10 @@ function tripleBinding(subject: string, graph: string) {
 
 function bindingsForLayer(sparql: string, contextGraphId: string, revision: number) {
   const isVm = sparql.includes('_verified_memory_meta');
-  const isSwm = !isVm && sparql.includes('STRENDS');
+  // PR #818 sweep 3 — WM SPARQL also contains STRENDS (for the
+  // `/_meta` exclusion); discriminate by the SWM-exclusive
+  // `/_shared_memory` tail check.
+  const isSwm = !isVm && sparql.includes('STRENDS(STR(?g), "/_shared_memory")');
   if (isVm || isSwm) return [];
   return Array.from({ length: revision }, (_, i) =>
     tripleBinding(

--- a/packages/node-ui/test/use-memory-entities-partial.test.ts
+++ b/packages/node-ui/test/use-memory-entities-partial.test.ts
@@ -65,9 +65,12 @@ describe('useMemoryEntities — partial layer failure', () => {
       // Robust layer discriminators: every query references both
       // "/assertion/" and "/_shared_memory" (inside FILTER negations),
       // so match on tokens unique to each — `_verified_memory_meta`
-      // only appears in the VM query, `STRENDS` only in the SWM query.
+      // only appears in the VM query, the `/_shared_memory` tail
+      // check only in the SWM query (PR #818 sweep 3: WM also has
+      // `STRENDS(..., "/_meta")` now so the bare `STRENDS` token
+      // no longer discriminates).
       const isVm = sparql.includes('_verified_memory_meta');
-      const isSwm = !isVm && sparql.includes('STRENDS');
+      const isSwm = !isVm && sparql.includes('STRENDS(STR(?g), "/_shared_memory")');
       const isWm = !isVm && !isSwm;
       if (isSwm) return { ok: false, status: 500, json: async () => ({}) } as Response;
       if (isWm) {


### PR DESCRIPTION
## Summary

- **#813** — Adds a synthesized Root mini-card to `SubGraphOverviewGrid`. Mirrors the SubGraphBar Root chip on the overview surface: entities not in any named sub-graph, untagged-recovery triples only. Dashed outer border + `⊘` icon (ux-locked option B); rendered last in the grid (mirrors the Root chip's rightmost chip-row position); renders even at 0 root entities (consistency with named-card empty branches).
- **#806** — One-line fix in `subGraphOf` adding `meta` to the bookkeeping-segment filter alongside `assertion`. Closes the Tuesday CG SWM `All 36 · Root 34` gap by treating `meta` (profile / bookkeeping graph) symmetrically with the `assertion` graph (also internal). `RESERVED_SUB_GRAPH_SLUGS` stays `Set(['meta'])` — that chip-row filter was correct; the bug was the upstream asymmetry.
- **#805** — Overview Triples stat AND SubGraphOverviewGrid subtitle triple count both swap from raw `memory.allTriples.length` to a per-layer `useLayerTriples` sum. The hook applies SPO-dedup + the subject-trust-level residue filter, so both surfaces now agree with the per-layer LayerStats by construction. Restores the "subtitle agrees with layer-tab triple totals" invariant round 4.1 was actually after.

## Related

- Closes #813
- Closes #806
- Closes #805
- Follow-up to #793 (S3 polish bundle)
- Round-4.1 anchor discipline (`memory.counts.total` / canonical layer-sum) preserved

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/hooks/useMemoryEntities.ts` | `subGraphOf` extends bookkeeping-segment filter to include `meta` (GH #806) |
| `packages/node-ui/src/ui/views/project/components.tsx` | (1) Overview Triples derivation swapped to per-layer `useLayerTriples` sum (GH #805); (2) Root mini-card synthesis (rootCard memo + variant-aware SubGraphMiniCard, GH #813); (3) Subgraphs subtitle triple count swapped to per-layer sum (GH #805 consistency) |
| `packages/node-ui/src/ui/styles.css` | `.v10-sgov-card.root` modifier: dashed border + neutral icon color (GH #813 chrome) |
| `packages/node-ui/test/sub-graphs-helper.test.ts` | `subGraphOf('<cg>/meta/_shared_memory')` returns undefined; regression guard keeps `<cg>/recipes/meta/...` resolving to `'recipes'` (GH #806) |
| `packages/node-ui/test/subgraph-overview-grid.test.ts` | (1) Root mini-card describe block with 4 tests covering chrome modifier, 0-entity edge case, click handler, and untagged-recovery triple scoping (GH #813); (2) round-4.1 anchor lock + cross-membership tests updated for per-layer-sum semantic; (3) NEW WM-residue lock test (GH #805) |
| `packages/node-ui/test/context-graph-ia-overview.test.ts` | Codex bug B partial fixture rewritten — 120 identical triples → 120 unique-SPO rows so the post-#805 layer-sum still lands at 120 |

## Test plan

- [x] `pnpm exec tsc --noEmit` exit 0 (no new errors beyond pre-existing baseline)
- [x] PR-touched node-ui slice (10 files): **267/267 pass** (+4 Root mini-card tests, +1 WM-residue test, +2 GH #806 tests; 38 pre-existing skips unchanged)
- [x] `agent-docs/` absent from worktree
- [x] No new design tokens (reuses `--border-strong`, `--text-tertiary`)
- [x] No new raw hex
- [x] `RESERVED_SUB_GRAPH_SLUGS` unchanged (stays `Set(['meta'])`)
- [x] Branch off fresh `origin/main` at `1fd877a72`
- [ ] ui-lead visual check on dashed-vs-solid Root card chrome on a rendered build (dashed = ux-locked option B; fallback option (a) `1px solid var(--border-subtle)` if dashed reads as "broken/disabled")
- [ ] qa final delta verify on a populated multi-layer CG (G-VERIFY-S3 carryover bundle, GH #773)

## Notes for review

- **Engineer's call on the #805 fold**: per team-lead's "fold if 2-3 small commits" guidance. The diff stays bounded (3 commits, +/- 477 lines including tests), all touching the same Overview/Subgraphs surfaces. Peel-off would have created cross-PR coordination on the subtitle anchor.
- **Engineer's call on the Root-card 0-entity edge case**: option (b) — always render. Named subgraphs with 0 entities already render via the `No data yet` empty branch; hiding Root only would create an inconsistent affordance.
- **`SubGraphMiniCard` gains a `variant?: 'root'` prop**: opt-in. Existing named-card render path is unchanged; the variant only suppresses per-card `--sg-color` injection and adds the `.root` className modifier.