### PR TITLE
test(rc.12): repair greenfield KA model test fallout (Solidity + publisher/agent/chain)

### DIFF
--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -222,6 +222,12 @@ class OperationalKeyOnlyPublishChainAdapter implements ChainAdapter {
     return '0x00000000000000000000000000000000000000A1';
   }
 
+  // Greenfield (PR #815): the publisher needs the DKGKnowledgeAssets address
+  // to build the KA UAL after an on-chain publish.
+  async getDKGKnowledgeAssetsAddress(): Promise<string> {
+    return '0x00000000000000000000000000000000000000A2';
+  }
+
   async createKnowledgeAssetsV10(params: V10PublishDirectParams): Promise<OnChainPublishResult> {
     this.capturedPublisherAddress = params.publisherAddress;
     if (params.publisherAddress.toLowerCase() !== this.wallet.address.toLowerCase()) {
@@ -255,6 +261,12 @@ class ExternalOperationalKeyPublishChainAdapter implements ChainAdapter {
 
   async getKnowledgeAssetsV10Address(): Promise<string> {
     return '0x00000000000000000000000000000000000000A1';
+  }
+
+  // Greenfield (PR #815): the publisher needs the DKGKnowledgeAssets address
+  // to build the KA UAL after an on-chain publish.
+  async getDKGKnowledgeAssetsAddress(): Promise<string> {
+    return '0x00000000000000000000000000000000000000A2';
   }
 
   async createKnowledgeAssetsV10(params: V10PublishDirectParams): Promise<OnChainPublishResult> {

--- a/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
+++ b/packages/chain/test/evm-adapter-hub-rotation.e2e.test.ts
@@ -538,7 +538,10 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
       const replacementAddr = freshAddress();
 
       try {
-        await rotateHubContract(ctx.hubAddress, deployer, 'KnowledgeAssetsV10', replacementAddr);
+        // Greenfield (PR #815): the lifecycle contract is registered under
+        // the Hub key KnowledgeAssetsLifecycle (was KnowledgeAssetsV10), which
+        // is what getKnowledgeAssetsV10Address() resolves. Rotate that key.
+        await rotateHubContract(ctx.hubAddress, deployer, 'KnowledgeAssetsLifecycle', replacementAddr);
 
         const observed = await waitFor(
           () =>
@@ -554,7 +557,7 @@ describe('EVMChainAdapter — Hub rotation self-refresh (E2E)', () => {
         const kav10After = await adapter.getKnowledgeAssetsV10Address();
         expect(kav10After.toLowerCase()).toBe(replacementAddr.toLowerCase());
       } finally {
-        await rotateHubContract(ctx.hubAddress, deployer, 'KnowledgeAssetsV10', kav10Before);
+        await rotateHubContract(ctx.hubAddress, deployer, 'KnowledgeAssetsLifecycle', kav10Before);
       }
     },
     60_000,

--- a/packages/chain/test/evm-adapter.test.ts
+++ b/packages/chain/test/evm-adapter.test.ts
@@ -30,8 +30,10 @@ describe('EVMChainAdapter integration', () => {
     // V8 `KnowledgeCollection` + `Staking` were archived in TB-1 (PRD §4.1)
     // — their Hub bindings no longer exist. Hub-resolve the V10 successors
     // instead to assert the adapter still talks to a fresh V10 deploy.
-    const kav10 = await adapter.getContract('KnowledgeAssetsV10');
-    expect(await kav10.name()).toBe('KnowledgeAssetsV10');
+    // Greenfield (PR #815): the lifecycle contract's Hub key + `name()` were
+    // renamed KnowledgeAssetsV10 → KnowledgeAssetsLifecycle.
+    const kav10 = await adapter.getContract('KnowledgeAssetsLifecycle');
+    expect(await kav10.name()).toBe('KnowledgeAssetsLifecycle');
 
     const stakingV10 = await adapter.getContract('StakingV10');
     expect(await stakingV10.name()).toBe('StakingV10');

--- a/packages/evm-module/abi/ConvictionStakingStorage.json
+++ b/packages/evm-module/abi/ConvictionStakingStorage.json
@@ -60,6 +60,17 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "TokenTransferFailed",
     "type": "error"

--- a/packages/evm-module/abi/StakingV10.json
+++ b/packages/evm-module/abi/StakingV10.json
@@ -83,8 +83,61 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "SameIdentity",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "allowance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expected",
+        "type": "uint256"
+      }
+    ],
+    "name": "TooLowAllowance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expected",
+        "type": "uint256"
+      }
+    ],
+    "name": "TooLowBalance",
     "type": "error"
   },
   {

--- a/packages/evm-module/test/integration/RandomSampling.test.ts
+++ b/packages/evm-module/test/integration/RandomSampling.test.ts
@@ -11,7 +11,7 @@ import {
   RandomSamplingStorage,
   IdentityStorage,
   StakingStorage,
-  KnowledgeCollectionStorage,
+  DKGKnowledgeAssets,
   ProfileStorage,
   EpochStorage,
   Chronos,
@@ -63,7 +63,7 @@ type RandomSamplingFixture = {
   RandomSamplingStorage: RandomSamplingStorage;
   IdentityStorage: IdentityStorage;
   StakingStorage: StakingStorage;
-  KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  DKGKnowledgeAssets: DKGKnowledgeAssets;
   ProfileStorage: ProfileStorage;
   EpochStorage: EpochStorage;
   Chronos: Chronos;
@@ -196,7 +196,7 @@ describe.skip('@integration RandomSampling (OBSOLETE: V8 stake pipeline)', () =>
   let RandomSamplingStorage: RandomSamplingStorage;
   let IdentityStorage: IdentityStorage;
   let StakingStorage: StakingStorage;
-  let KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  let DKGKnowledgeAssets: DKGKnowledgeAssets;
   let ProfileStorage: ProfileStorage;
   let EpochStorage: EpochStorage;
   let Chronos: Chronos;
@@ -263,9 +263,9 @@ describe.skip('@integration RandomSampling (OBSOLETE: V8 stake pipeline)', () =>
       await hre.ethers.getContract<IdentityStorage>('IdentityStorage');
     StakingStorage =
       await hre.ethers.getContract<StakingStorage>('StakingStorage');
-    KnowledgeCollectionStorage =
-      await hre.ethers.getContract<KnowledgeCollectionStorage>(
-        'KnowledgeCollectionStorage',
+    DKGKnowledgeAssets =
+      await hre.ethers.getContract<DKGKnowledgeAssets>(
+        'DKGKnowledgeAssets',
       );
     ProfileStorage =
       await hre.ethers.getContract<ProfileStorage>('ProfileStorage');
@@ -308,7 +308,7 @@ describe.skip('@integration RandomSampling (OBSOLETE: V8 stake pipeline)', () =>
       RandomSamplingStorage,
       IdentityStorage,
       StakingStorage,
-      KnowledgeCollectionStorage,
+      DKGKnowledgeAssets,
       ProfileStorage,
       EpochStorage,
       Chronos,
@@ -335,7 +335,7 @@ describe.skip('@integration RandomSampling (OBSOLETE: V8 stake pipeline)', () =>
       accounts,
       IdentityStorage,
       StakingStorage,
-      KnowledgeCollectionStorage,
+      DKGKnowledgeAssets,
       ProfileStorage,
       EpochStorage,
       Chronos,
@@ -382,7 +382,7 @@ describe.skip('@integration RandomSampling (OBSOLETE: V8 stake pipeline)', () =>
         await RandomSamplingStorage.getAddress(),
       );
       expect(await RandomSampling.knowledgeCollectionStorage()).to.equal(
-        await KnowledgeCollectionStorage.getAddress(),
+        await DKGKnowledgeAssets.getAddress(),
       );
       expect(await RandomSampling.stakingStorage()).to.equal(
         await StakingStorage.getAddress(),

--- a/packages/evm-module/test/unit/DKGPublishingConvictionNFT-conservation.test.ts
+++ b/packages/evm-module/test/unit/DKGPublishingConvictionNFT-conservation.test.ts
@@ -164,7 +164,7 @@ describe('@unit DKGPublishingConvictionNFT — TRAC conservation across full lif
     // ---- Setup: impersonate KAV10 and register an agent ----
     const Kav10Signer = accounts[5];
     const agent = accounts[6];
-    await HubContract.setContractAddress('KnowledgeAssetsV10', Kav10Signer.address);
+    await HubContract.setContractAddress('KnowledgeAssetsLifecycle', Kav10Signer.address);
 
     // Use committedTRAC NOT divisible by 12 to exercise the dust path.
     const committed = hre.ethers.parseEther('120000') + 7n; // 30% tier, ~10K per window

--- a/packages/evm-module/test/unit/DKGPublishingConvictionNFT-extra.test.ts
+++ b/packages/evm-module/test/unit/DKGPublishingConvictionNFT-extra.test.ts
@@ -258,7 +258,7 @@ describe('@unit DKGPublishingConvictionNFT — extra audit coverage (E-6)', func
       // Point the Hub's "KnowledgeAssetsV10" entry at an EOA we control so
       // we can call coverPublishingCost directly from it.
       const kav10 = accounts[2];
-      await HubContract.setContractAddress('KnowledgeAssetsV10', kav10.address);
+      await HubContract.setContractAddress('KnowledgeAssetsLifecycle', kav10.address);
 
       const committed = hre.ethers.parseEther('100000');
       const owner = accounts[0];

--- a/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
@@ -350,7 +350,7 @@ describe('@unit DKGPublishingConvictionNFT', function () {
       // Impersonate KAV10 by registering accounts[5] under that Hub name. The
       // NFT resolves the caller via Hub on every coverPublishingCost call.
       const Kav10Signer = accounts[5];
-      await HubContract.setContractAddress('KnowledgeAssetsV10', Kav10Signer.address);
+      await HubContract.setContractAddress('KnowledgeAssetsLifecycle', Kav10Signer.address);
 
       // committedTRAC divisible by 12 → clean per-epoch allowance math.
       const committed = hre.ethers.parseEther('120000');
@@ -741,7 +741,7 @@ describe('@unit DKGPublishingConvictionNFT', function () {
     beforeEach(async () => {
       Kav10Signer = accounts[5];
       agent = accounts[6];
-      await HubContract.setContractAddress('KnowledgeAssetsV10', Kav10Signer.address);
+      await HubContract.setContractAddress('KnowledgeAssetsLifecycle', Kav10Signer.address);
     });
 
     async function createAt(amount: bigint) {
@@ -1297,7 +1297,7 @@ describe('@unit DKGPublishingConvictionNFT', function () {
     beforeEach(async () => {
       Kav10Signer = accounts[5];
       agent = accounts[6];
-      await HubContract.setContractAddress('KnowledgeAssetsV10', Kav10Signer.address);
+      await HubContract.setContractAddress('KnowledgeAssetsLifecycle', Kav10Signer.address);
     });
 
     /**

--- a/packages/evm-module/test/unit/KnowledgeAssetsV10-ciphertextCommitment.test.ts
+++ b/packages/evm-module/test/unit/KnowledgeAssetsV10-ciphertextCommitment.test.ts
@@ -12,8 +12,8 @@ import type {
   DKGPublishingConvictionNFT,
   DKGStakingConvictionNFT,
   Hub,
-  KnowledgeAssetsV10,
-  KnowledgeCollectionStorage,
+  KnowledgeAssetsLifecycle,
+  DKGKnowledgeAssets,
   Profile,
   StakingV10,
   Token,
@@ -32,7 +32,7 @@ import {
 import { NodeAccounts } from '../helpers/types';
 
 /**
- * RFC-39 Phase A.5 — `KnowledgeAssetsV10` ciphertext-commitment surface.
+ * RFC-39 Phase A.5 — `KnowledgeAssetsLifecycle` ciphertext-commitment surface.
  *
  * Locks the curated-vs-public branching introduced by the new
  * `(ciphertextChunksRoot, ciphertextChunkCount)` `PublishParams` fields:
@@ -44,20 +44,20 @@ import { NodeAccounts } from '../helpers/types';
  *     event fires, KCS getters return the persisted values
  *   - Curated CG + exactly one zero   → reverts `IncompleteCiphertextCommitment`
  *
- * Dedicated test file (separate from `KnowledgeAssetsV10.test.ts`) so the
+ * Dedicated test file (separate from `KnowledgeAssetsLifecycle.test.ts`) so the
  * companion contract PR doesn't conflict with PR #595, which is also
  * modifying the legacy test file.
  *
- * Fixture mirrors the legacy `KnowledgeAssetsV10.test.ts` fixture exactly so
+ * Fixture mirrors the legacy `KnowledgeAssetsLifecycle.test.ts` fixture exactly so
  * the test surface is identical (full V10 stack + V8 KC infra + min-stake
  * profile setup). Diverging would tempt drift between RFC-39 coverage and
  * the rest of the V10 publish suite.
  */
-describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
+describe('@unit KnowledgeAssetsLifecycle — RFC-39 ciphertext commitment', () => {
   let accounts: SignerWithAddress[];
   let HubContract: Hub;
-  let KAV10: KnowledgeAssetsV10;
-  let KCS: KnowledgeCollectionStorage;
+  let KAV10: KnowledgeAssetsLifecycle;
+  let KCS: DKGKnowledgeAssets;
   let AskStorageContract: AskStorage;
   let ChronosContract: Chronos;
   let TokenContract: Token;
@@ -84,14 +84,14 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
       'Identity',
       'ParametersStorage',
       'IdentityStorage',
-      'KnowledgeCollectionStorage',
+      'DKGKnowledgeAssets',
       'ContextGraphStorage',
       'ContextGraphs',
       'ContextGraphValueStorage',
       'DKGPublishingConvictionNFT',
       'StakingV10',
       'DKGStakingConvictionNFT',
-      'KnowledgeAssetsV10',
+      'KnowledgeAssetsLifecycle',
     ]);
 
     const signers = await hre.ethers.getSigners();
@@ -101,9 +101,9 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
     return {
       accounts: signers,
       HubContract: Hub,
-      KAV10: await hre.ethers.getContract<KnowledgeAssetsV10>('KnowledgeAssetsV10'),
-      KCS: await hre.ethers.getContract<KnowledgeCollectionStorage>(
-        'KnowledgeCollectionStorage',
+      KAV10: await hre.ethers.getContract<KnowledgeAssetsLifecycle>('KnowledgeAssetsLifecycle'),
+      KCS: await hre.ethers.getContract<DKGKnowledgeAssets>(
+        'DKGKnowledgeAssets',
       ),
       AskStorageContract: await hre.ethers.getContract<AskStorage>('AskStorage'),
       ChronosContract: await hre.ethers.getContract<Chronos>('Chronos'),
@@ -240,7 +240,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('public-zero-ct')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: 1000,
         epochs: 2,
         tokenAmount,
@@ -272,7 +272,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('public-root-only')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: 1000,
         epochs: 2,
         tokenAmount,
@@ -303,7 +303,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('public-count-only')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: 1000,
         epochs: 2,
         tokenAmount,
@@ -339,7 +339,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('public-both-set')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: 1000,
         epochs: 2,
         tokenAmount,
@@ -378,7 +378,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('public-atomic-revert')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: 1000,
         epochs: 2,
         tokenAmount,
@@ -416,7 +416,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-zero-ct')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: 1000,
         epochs: 2,
         tokenAmount,
@@ -449,7 +449,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-full-ct')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: 1000,
         epochs: 2,
         tokenAmount,
@@ -461,7 +461,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
 
       await TokenContract.connect(creator).approve(kav10Address, tokenAmount);
 
-      // The contract reads `KnowledgeCollectionStorage.getLatestKnowledgeCollectionId() + 1`
+      // The contract reads `DKGKnowledgeAssets.getLatestKnowledgeCollectionId() + 1`
       // for the next id (counter increments on create). Snapshot before to
       // pin the expected kcId for the event matcher.
       const nextKcId = (await KCS.getLatestKnowledgeCollectionId()) + 1n;
@@ -490,7 +490,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-partial-root')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: 1000,
         epochs: 2,
         tokenAmount,
@@ -527,7 +527,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         chainId, kav10Address, receivingNodes, publisherIdentityId,
         receiverIdentityIds, author: creator, contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-multi-1')),
-        knowledgeAssetsAmount: 10, byteSize: 1000, epochs: 2,
+        knowledgeAssetsAmount: 1, byteSize: 1000, epochs: 2,
         tokenAmount, isImmutable: false,
         publishOperationId: 'curated-multi-1-op',
         ciphertextChunksRoot: ROOT_1, ciphertextChunkCount: COUNT_1,
@@ -540,7 +540,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         chainId, kav10Address, receivingNodes, publisherIdentityId,
         receiverIdentityIds, author: creator, contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-multi-2')),
-        knowledgeAssetsAmount: 10, byteSize: 1000, epochs: 2,
+        knowledgeAssetsAmount: 1, byteSize: 1000, epochs: 2,
         tokenAmount, isImmutable: false,
         publishOperationId: 'curated-multi-2-op',
         ciphertextChunksRoot: ROOT_2, ciphertextChunkCount: COUNT_2,
@@ -573,7 +573,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-partial-count')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: 1000,
         epochs: 2,
         tokenAmount,
@@ -634,7 +634,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-baseline')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: Number(byteSize),
         epochs: 5,
         tokenAmount,
@@ -680,7 +680,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('public-baseline')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: Number(byteSize),
         epochs: 5,
         tokenAmount,
@@ -716,7 +716,7 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         author: creator,
         contextGraphId: cgId,
         merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-legacy-baseline')),
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: Number(byteSize),
         epochs: 5,
         tokenAmount,
@@ -741,8 +741,9 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         newMerkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-legacy-update')),
         newByteSize: byteSize,
         newTokenAmount: tokenAmount,
-        mintKnowledgeAssetsAmount: 1n,
+        mintKnowledgeAssetsAmount: 0n,
         knowledgeAssetsToBurn: [],
+        author: creator,
         updateOperationId: 'curated-legacy-update-op',
       });
 
@@ -774,8 +775,9 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         newMerkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-update-zero')),
         newByteSize: base.byteSize,
         newTokenAmount: base.tokenAmount, // delta == 0 so no approval/payment needed
-        mintKnowledgeAssetsAmount: 1n,
+        mintKnowledgeAssetsAmount: 0n,
         knowledgeAssetsToBurn: [],
+        author: base.creator,
         updateOperationId: 'curated-update-zero-op',
       });
 
@@ -802,8 +804,9 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         newMerkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-update-asym')),
         newByteSize: base.byteSize,
         newTokenAmount: base.tokenAmount,
-        mintKnowledgeAssetsAmount: 1n,
+        mintKnowledgeAssetsAmount: 0n,
         knowledgeAssetsToBurn: [],
+        author: base.creator,
         updateOperationId: 'curated-update-asym-op',
       });
       const upPartial = {
@@ -832,8 +835,9 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         newMerkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-update-asym-count')),
         newByteSize: base.byteSize,
         newTokenAmount: base.tokenAmount,
-        mintKnowledgeAssetsAmount: 1n,
+        mintKnowledgeAssetsAmount: 0n,
         knowledgeAssetsToBurn: [],
+        author: base.creator,
         updateOperationId: 'curated-update-asym-count-op',
       });
       const upPartial = {
@@ -863,8 +867,9 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         newMerkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-update-same')),
         newByteSize: base.byteSize,
         newTokenAmount: base.tokenAmount,
-        mintKnowledgeAssetsAmount: 1n,
+        mintKnowledgeAssetsAmount: 0n,
         knowledgeAssetsToBurn: [],
+        author: base.creator,
         updateOperationId: 'curated-update-same-op',
       });
       const upSame = {
@@ -892,8 +897,9 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         newMerkleRoot: ethers.keccak256(ethers.toUtf8Bytes('curated-update-full')),
         newByteSize: base.byteSize,
         newTokenAmount: base.tokenAmount, // delta == 0
-        mintKnowledgeAssetsAmount: 1n,
+        mintKnowledgeAssetsAmount: 0n,
         knowledgeAssetsToBurn: [],
+        author: base.creator,
         updateOperationId: 'curated-update-full-op',
       });
       // Ciphertext-commitment fields live outside the ACK digest (RFC-38
@@ -929,8 +935,9 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         newMerkleRoot: ethers.keccak256(ethers.toUtf8Bytes('public-update-zero')),
         newByteSize: base.byteSize,
         newTokenAmount: base.tokenAmount,
-        mintKnowledgeAssetsAmount: 1n,
+        mintKnowledgeAssetsAmount: 0n,
         knowledgeAssetsToBurn: [],
+        author: base.creator,
         updateOperationId: 'public-update-zero-op',
       });
       await expect(KAV10.connect(base.creator).update(up)).to.not.be.reverted;
@@ -953,8 +960,9 @@ describe('@unit KnowledgeAssetsV10 — RFC-39 ciphertext commitment', () => {
         newMerkleRoot: ethers.keccak256(ethers.toUtf8Bytes('public-update-stray')),
         newByteSize: base.byteSize,
         newTokenAmount: base.tokenAmount,
-        mintKnowledgeAssetsAmount: 1n,
+        mintKnowledgeAssetsAmount: 0n,
         knowledgeAssetsToBurn: [],
+        author: base.creator,
         updateOperationId: 'public-update-stray-op',
       });
       const up2WithCt = { ...up2, newCiphertextChunksRoot: NEW_CT_ROOT };

--- a/packages/evm-module/test/unit/KnowledgeAssetsV10.test.ts
+++ b/packages/evm-module/test/unit/KnowledgeAssetsV10.test.ts
@@ -512,7 +512,7 @@ describe('@unit KnowledgeAssetsLifecycle', () => {
           author: creator,
           contextGraphId: cgId,
           merkleRoot,
-          knowledgeAssetsAmount: 10,
+          knowledgeAssetsAmount: 1,
           byteSize: 1000,
           epochs,
           tokenAmount,

--- a/packages/evm-module/test/unit/RandomSampling-curated.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling-curated.test.ts
@@ -9,7 +9,7 @@ import {
   ContextGraphStorage,
   ContextGraphValueStorage,
   Hub,
-  KnowledgeCollectionStorage,
+  DKGKnowledgeAssets,
   RandomSampling,
 } from '../../typechain';
 
@@ -62,7 +62,7 @@ describe('@unit RandomSampling — RFC-39 curated picker [Phase B enabled]', () 
   let HubContract: Hub;
   let RandomSamplingContract: RandomSampling;
   let ChronosContract: Chronos;
-  let KCSContract: KnowledgeCollectionStorage;
+  let KCSContract: DKGKnowledgeAssets;
   let CGStorageContract: ContextGraphStorage;
   let CGValueStorage: ContextGraphValueStorage;
 
@@ -83,7 +83,7 @@ describe('@unit RandomSampling — RFC-39 curated picker [Phase B enabled]', () 
       'ProfileStorage',
       'Chronos',
       'EpochStorage',
-      'KnowledgeCollectionStorage',
+      'DKGKnowledgeAssets',
       'AskStorage',
       'DelegatorsInfo',
       'RandomSamplingStorage',
@@ -106,8 +106,8 @@ describe('@unit RandomSampling — RFC-39 curated picker [Phase B enabled]', () 
       HubContract: Hub,
       RandomSamplingContract: await hre.ethers.getContract<RandomSampling>('RandomSampling'),
       ChronosContract: await hre.ethers.getContract<Chronos>('Chronos'),
-      KCSContract: await hre.ethers.getContract<KnowledgeCollectionStorage>(
-        'KnowledgeCollectionStorage',
+      KCSContract: await hre.ethers.getContract<DKGKnowledgeAssets>(
+        'DKGKnowledgeAssets',
       ),
       CGStorageContract: await hre.ethers.getContract<ContextGraphStorage>(
         'ContextGraphStorage',
@@ -178,7 +178,7 @@ describe('@unit RandomSampling — RFC-39 curated picker [Phase B enabled]', () 
   }
 
   /**
-   * Seed a KC directly on KnowledgeCollectionStorage and register it to the
+   * Seed a KC directly on DKGKnowledgeAssets and register it to the
    * given CG. Returns the new KC id.
    *
    * For curated CGs, pass `ciphertext` to also call
@@ -193,7 +193,7 @@ describe('@unit RandomSampling — RFC-39 curated picker [Phase B enabled]', () 
     const currentEpoch = await ChronosContract.getCurrentEpoch();
     const createTx = await KCSContract.connect(opSigner).createKnowledgeCollection(
       opSigner.address,
-      ethers.ZeroAddress,
+      opSigner.address,
       'rfc39-curated-test-op',
       ethers.keccak256(
         ethers.toUtf8Bytes(
@@ -210,7 +210,7 @@ describe('@unit RandomSampling — RFC-39 curated picker [Phase B enabled]', () 
     );
     const receipt = await createTx.wait();
     const iface = KCSContract.interface;
-    const topic = iface.getEvent('KnowledgeCollectionCreated')!.topicHash;
+    const topic = iface.getEvent('KnowledgeAssetCreated')!.topicHash;
     const log = receipt!.logs.find((l) => l.topics[0] === topic);
     if (!log) {
       throw new Error('KnowledgeCollectionCreated event not found');

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -21,7 +21,7 @@ import {
   AskStorage,
   EpochStorage,
   ParametersStorage,
-  KnowledgeCollectionStorage,
+  DKGKnowledgeAssets,
   Profile,
   ContextGraphStorage,
   ContextGraphValueStorage,
@@ -41,7 +41,7 @@ type RandomSamplingFixture = {
   AskStorage: AskStorage;
   EpochStorage: EpochStorage;
   ParametersStorage: ParametersStorage;
-  KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  DKGKnowledgeAssets: DKGKnowledgeAssets;
   ContextGraphStorage: ContextGraphStorage;
   ContextGraphValueStorage: ContextGraphValueStorage;
   Profile: Profile;
@@ -63,7 +63,7 @@ describe('@unit RandomSampling', () => {
   let AskStorage: AskStorage;
   let EpochStorage: EpochStorage;
   let ParametersStorage: ParametersStorage;
-  let KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  let DKGKnowledgeAssets: DKGKnowledgeAssets;
   let ContextGraphStorage: ContextGraphStorage;
   let ContextGraphValueStorage: ContextGraphValueStorage;
   let Profile: Profile;
@@ -80,7 +80,7 @@ describe('@unit RandomSampling', () => {
       'ProfileStorage',
       'Chronos',
       'EpochStorage',
-      'KnowledgeCollectionStorage',
+      'DKGKnowledgeAssets',
       'AskStorage',
       'DelegatorsInfo',
       'RandomSamplingStorage',
@@ -121,9 +121,9 @@ describe('@unit RandomSampling', () => {
     EpochStorage = await hre.ethers.getContract<EpochStorage>('EpochStorageV8');
     ParametersStorage =
       await hre.ethers.getContract<ParametersStorage>('ParametersStorage');
-    KnowledgeCollectionStorage =
-      await hre.ethers.getContract<KnowledgeCollectionStorage>(
-        'KnowledgeCollectionStorage',
+    DKGKnowledgeAssets =
+      await hre.ethers.getContract<DKGKnowledgeAssets>(
+        'DKGKnowledgeAssets',
       );
     Profile = await hre.ethers.getContract<Profile>('Profile');
     ContextGraphStorage = await hre.ethers.getContract<ContextGraphStorage>(
@@ -136,7 +136,7 @@ describe('@unit RandomSampling', () => {
 
     // Register a sentinel signer as a Hub contract so Phase 10 weighted-
     // selection tests can call `onlyContracts` methods on ContextGraphStorage /
-    // ContextGraphValueStorage / KnowledgeCollectionStorage directly, without
+    // ContextGraphValueStorage / DKGKnowledgeAssets directly, without
     // routing through the production facades (ContextGraphs, KnowledgeCollection).
     // Must run after HubOwner is set so `setContractAddress` passes the auth
     // check. Safe for existing tests because accounts[19] is never used elsewhere.
@@ -156,7 +156,7 @@ describe('@unit RandomSampling', () => {
       AskStorage,
       EpochStorage,
       ParametersStorage,
-      KnowledgeCollectionStorage,
+      DKGKnowledgeAssets,
       ContextGraphStorage,
       ContextGraphValueStorage,
       Profile,
@@ -185,7 +185,7 @@ describe('@unit RandomSampling', () => {
       AskStorage,
       EpochStorage,
       ParametersStorage,
-      KnowledgeCollectionStorage,
+      DKGKnowledgeAssets,
       ContextGraphStorage,
       ContextGraphValueStorage,
       Profile,
@@ -392,7 +392,7 @@ describe('@unit RandomSampling', () => {
         await ParametersStorage.getAddress(),
       );
       expect(await RandomSampling.knowledgeCollectionStorage()).to.equal(
-        await KnowledgeCollectionStorage.getAddress(),
+        await DKGKnowledgeAssets.getAddress(),
       );
     });
   });
@@ -875,18 +875,18 @@ describe('@unit RandomSampling', () => {
     }
 
     /**
-     * Seed a KC directly on KnowledgeCollectionStorage and register it to the
+     * Seed a KC directly on DKGKnowledgeAssets and register it to the
      * given CG. Returns the new KC id. `endEpoch` controls the expiry — pass
      * `currentEpoch - 1` to create an already-expired KC.
      */
     async function createKC(cgId: bigint, endEpoch: bigint): Promise<bigint> {
       const currentEpoch = await Chronos.getCurrentEpoch();
       const startEpoch = currentEpoch;
-      const createTx = await KnowledgeCollectionStorage.connect(
+      const createTx = await DKGKnowledgeAssets.connect(
         opSigner,
       ).createKnowledgeCollection(
         opSigner.address, // publisher
-        ethers.ZeroAddress, // author — Phase 10 fixture predates author attestation
+        opSigner.address, // author — ERC-721 KA mint recipient (greenfield model)
         'phase-10-test-op',
         ethers.keccak256(
           ethers.toUtf8Bytes(
@@ -903,8 +903,8 @@ describe('@unit RandomSampling', () => {
       );
       const receipt = await createTx.wait();
       // Parse kc id from the KnowledgeCollectionCreated event.
-      const iface = KnowledgeCollectionStorage.interface;
-      const topic = iface.getEvent('KnowledgeCollectionCreated')!.topicHash;
+      const iface = DKGKnowledgeAssets.interface;
+      const topic = iface.getEvent('KnowledgeAssetCreated')!.topicHash;
       const log = receipt!.logs.find((l) => l.topics[0] === topic);
       if (!log) {
         throw new Error('KnowledgeCollectionCreated event not found');

--- a/packages/evm-module/test/unit/RandomSamplingStorage.test.ts
+++ b/packages/evm-module/test/unit/RandomSamplingStorage.test.ts
@@ -9,7 +9,7 @@ import {
   Hub,
   RandomSamplingStorage,
   Chronos,
-  KnowledgeCollectionStorage,
+  DKGKnowledgeAssets,
   RandomSampling,
 } from '../../typechain';
 import { RandomSamplingLib } from '../../typechain/contracts/storage/RandomSamplingStorage';
@@ -19,7 +19,7 @@ const HUNDRED_ETH = ethers.parseEther('100');
 // Helper functions for random sampling
 async function createMockChallenge(
   randomSampling: RandomSampling,
-  knowledgeCollectionStorage: KnowledgeCollectionStorage,
+  knowledgeCollectionStorage: DKGKnowledgeAssets,
   chronos: Chronos,
 ): Promise<RandomSamplingLib.ChallengeStruct> {
   const currentEpoch = await chronos.getCurrentEpoch();
@@ -75,7 +75,7 @@ describe('@unit RandomSamplingStorage', function () {
   let RandomSamplingStorage: RandomSamplingStorage;
   let RandomSampling: RandomSampling;
   let Chronos: Chronos;
-  let KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  let DKGKnowledgeAssets: DKGKnowledgeAssets;
   let MockChallenge: RandomSamplingLib.ChallengeStruct;
   let accounts: SignerWithAddress[];
 
@@ -88,7 +88,7 @@ describe('@unit RandomSamplingStorage', function () {
   async function deployRandomSamplingFixture(): Promise<RandomStorageFixture> {
     await hre.deployments.fixture([
       'Token',
-      'KnowledgeCollectionStorage',
+      'DKGKnowledgeAssets',
       'KnowledgeCollection',
       'RandomSamplingStorage',
       'RandomSampling',
@@ -108,9 +108,9 @@ describe('@unit RandomSamplingStorage', function () {
 
     RandomSampling =
       await hre.ethers.getContract<RandomSampling>('RandomSampling');
-    KnowledgeCollectionStorage =
-      await hre.ethers.getContract<KnowledgeCollectionStorage>(
-        'KnowledgeCollectionStorage',
+    DKGKnowledgeAssets =
+      await hre.ethers.getContract<DKGKnowledgeAssets>(
+        'DKGKnowledgeAssets',
       );
 
     await RandomSamplingStorage.initialize();
@@ -140,7 +140,7 @@ describe('@unit RandomSamplingStorage', function () {
 
     MockChallenge = await createMockChallenge(
       RandomSampling,
-      KnowledgeCollectionStorage,
+      DKGKnowledgeAssets,
       Chronos,
     );
   });

--- a/packages/evm-module/test/v10-e2e-conviction.test.ts
+++ b/packages/evm-module/test/v10-e2e-conviction.test.ts
@@ -423,12 +423,12 @@ describe('V10 E2E Conviction System', function () {
         await DKGKnowledgeAssets.getLatestMerkleRootPublisher(kcId);
       expect(latestPublisher).to.equal(creator.address);
       // The KA NFT (ERC-721, one token per KC id) is minted to the author on
-      // publish (`DKGKnowledgeAssets._safeMint(author, kcId)`), so the
-      // creator's balance is non-zero. A follow-up `update` passes the
-      // author-ownership gate.
-      expect(
-        await DKGKnowledgeAssets.balanceOf(creator.address),
-      ).to.be.gt(0n);
+      // publish (`DKGKnowledgeAssets._safeMint(author, kcId)`). Assert the
+      // specific token `kcId` is owned by `creator` — a `balanceOf > 0` check
+      // would also pass if some unrelated KA were owned by `creator` while
+      // `kcId` was minted to the wrong address. A follow-up `update` passes
+      // the author-ownership gate.
+      expect(await DKGKnowledgeAssets.ownerOf(kcId)).to.equal(creator.address);
 
       // ---- Step 8: Atomic CG binding written ----
       expect(await CGS.kcToContextGraph(kcId)).to.equal(cgId);

--- a/packages/evm-module/test/v10-e2e-conviction.test.ts
+++ b/packages/evm-module/test/v10-e2e-conviction.test.ts
@@ -14,8 +14,8 @@ import {
   StakingV10,
   DKGStakingConvictionNFT,
   ParametersStorage,
-  KnowledgeAssetsV10,
-  KnowledgeCollectionStorage,
+  KnowledgeAssetsLifecycle,
+  DKGKnowledgeAssets,
   EpochStorage,
   AskStorage,
   ContextGraphs,
@@ -44,8 +44,8 @@ type E2EFixture = {
   StakingV10: StakingV10;
   StakingNFT: DKGStakingConvictionNFT;
   ParametersStorage: ParametersStorage;
-  KnowledgeAssetsV10: KnowledgeAssetsV10;
-  KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  KnowledgeAssetsLifecycle: KnowledgeAssetsLifecycle;
+  DKGKnowledgeAssets: DKGKnowledgeAssets;
   EpochStorage: EpochStorage;
   AskStorage: AskStorage;
   ContextGraphs: ContextGraphs;
@@ -62,8 +62,8 @@ async function deployE2EFixture(): Promise<E2EFixture> {
     'Chronos',
     'Profile',
     'Identity',
-    'KnowledgeAssetsV10',
-    // V10 Phase 8 stack — required by the new `KnowledgeAssetsV10.initialize()`
+    'KnowledgeAssetsLifecycle',
+    // V10 Phase 8 stack — required by the new `KnowledgeAssetsLifecycle.initialize()`
     // fail-fast Hub lookups (commit e89ecb75). Flow 3 (V10 publish via NFT)
     // depends on the full V10 stack being deployed in the same fixture.
     'ContextGraphStorage',
@@ -97,8 +97,8 @@ async function deployE2EFixture(): Promise<E2EFixture> {
       'DKGStakingConvictionNFT',
     ),
     ParametersStorage: await hre.ethers.getContract<ParametersStorage>('ParametersStorage'),
-    KnowledgeAssetsV10: await hre.ethers.getContract<KnowledgeAssetsV10>('KnowledgeAssetsV10'),
-    KnowledgeCollectionStorage: await hre.ethers.getContract<KnowledgeCollectionStorage>('KnowledgeCollectionStorage'),
+    KnowledgeAssetsLifecycle: await hre.ethers.getContract<KnowledgeAssetsLifecycle>('KnowledgeAssetsLifecycle'),
+    DKGKnowledgeAssets: await hre.ethers.getContract<DKGKnowledgeAssets>('DKGKnowledgeAssets'),
     EpochStorage: await hre.ethers.getContract<EpochStorage>('EpochStorageV8'),
     AskStorage: await hre.ethers.getContract<AskStorage>('AskStorage'),
     ContextGraphs: await hre.ethers.getContract<ContextGraphs>('ContextGraphs'),
@@ -118,8 +118,8 @@ describe('V10 E2E Conviction System', function () {
   let ProfileContract: Profile;
   let StakingStorage: StakingStorage;
   let ParametersStorage: ParametersStorage;
-  let KAV10: KnowledgeAssetsV10;
-  let KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  let KAV10: KnowledgeAssetsLifecycle;
+  let DKGKnowledgeAssets: DKGKnowledgeAssets;
 
   beforeEach(async () => {
     hre.helpers.resetDeploymentsJson();
@@ -130,11 +130,11 @@ describe('V10 E2E Conviction System', function () {
       Token,
       Chronos,
       ParametersStorage,
-      KnowledgeCollectionStorage,
+      DKGKnowledgeAssets,
     } = fixture);
     ProfileContract = fixture.Profile;
     StakingStorage = fixture.StakingStorage;
-    KAV10 = fixture.KnowledgeAssetsV10;
+    KAV10 = fixture.KnowledgeAssetsLifecycle;
   });
 
   // ========================================================================
@@ -168,7 +168,7 @@ describe('V10 E2E Conviction System', function () {
   //      emitted by `EpochStorage` sum to `discountedCost` across the KC's
   //      `[currentEpoch, currentEpoch + epochs]` chain-epoch range
   //      (prorated current-epoch partial + middle full + tail partial,
-  //      mirroring `KnowledgeAssetsV10._distributeTokens`). The NFT
+  //      mirroring `KnowledgeAssetsLifecycle._distributeTokens`). The NFT
   //      is the funding agent on the conviction branch — KAV10 MUST NOT
   //      call `_distributeTokens` (no double-count).
   //  11. KC retrieval through the KCS public reader
@@ -196,13 +196,13 @@ describe('V10 E2E Conviction System', function () {
         Token,
         Chronos,
         ParametersStorage,
-        KnowledgeCollectionStorage,
+        DKGKnowledgeAssets,
       } = fixture);
       ProfileContract = fixture.Profile;
       StakingStorage = fixture.StakingStorage;
       StakingV10Contract = fixture.StakingV10;
       StakingNFT = fixture.StakingNFT;
-      KAV10 = fixture.KnowledgeAssetsV10;
+      KAV10 = fixture.KnowledgeAssetsLifecycle;
       NFT = fixture.PublishingConvictionNFT;
       CGFacade = fixture.ContextGraphs;
       CGS = fixture.ContextGraphStorage;
@@ -331,7 +331,7 @@ describe('V10 E2E Conviction System', function () {
         author: creator,
         contextGraphId: cgId,
         merkleRoot,
-        knowledgeAssetsAmount: 10,
+        knowledgeAssetsAmount: 1,
         byteSize: 1000,
         epochs,
         tokenAmount,
@@ -343,7 +343,7 @@ describe('V10 E2E Conviction System', function () {
       //
       // Capture the receipt so we can count `TokensAddedToEpochRange`
       // emits from EpochStorage. The active sink mirrors
-      // `KnowledgeAssetsV10._distributeTokens` semantics: the discounted
+      // `KnowledgeAssetsLifecycle._distributeTokens` semantics: the discounted
       // amount is prorated across `epochs + 1` chain epochs (current
       // partial + epochs-1 full + tail partial), producing 1-3 events.
       // We assert: (a) every event sits within `[currentEpoch,
@@ -410,7 +410,7 @@ describe('V10 E2E Conviction System', function () {
 
       // ---- Step 7: KC registered in KCS; publisher of record is msg.sender ----
       const kcId = 1n;
-      const meta = await KnowledgeCollectionStorage.getKnowledgeCollectionMetadata(kcId);
+      const meta = await DKGKnowledgeAssets.getKnowledgeCollectionMetadata(kcId);
       // meta[3] = byteSize, meta[4] = startEpoch, meta[5] = endEpoch, meta[6] = tokenAmount
       expect(meta[3]).to.equal(1000n);
       expect(meta[4]).to.equal(currentEpoch);
@@ -420,19 +420,14 @@ describe('V10 E2E Conviction System', function () {
       // (commit 41be7c71). This is what enables the N16 ERC-1155 balanceOf
       // gate to work on follow-up updates.
       const latestPublisher =
-        await KnowledgeCollectionStorage.getLatestMerkleRootPublisher(kcId);
+        await DKGKnowledgeAssets.getLatestMerkleRootPublisher(kcId);
       expect(latestPublisher).to.equal(creator.address);
-      // ERC-1155 KA tokens minted to msg.sender. A follow-up `update` would
-      // pass the `balanceOf(msg.sender, kcRange) > 0` gate.
-      const maxSize = await KnowledgeCollectionStorage.KNOWLEDGE_COLLECTION_MAX_SIZE();
-      const startTokenId = (kcId - 1n) * maxSize + 1n;
-      const stopTokenId = startTokenId + 10n; // knowledgeAssetsAmount = 10
+      // The KA NFT (ERC-721, one token per KC id) is minted to the author on
+      // publish (`DKGKnowledgeAssets._safeMint(author, kcId)`), so the
+      // creator's balance is non-zero. A follow-up `update` passes the
+      // author-ownership gate.
       expect(
-        await KnowledgeCollectionStorage['balanceOf(address,uint256,uint256)'](
-          creator.address,
-          startTokenId,
-          stopTokenId,
-        ),
+        await DKGKnowledgeAssets.balanceOf(creator.address),
       ).to.be.gt(0n);
 
       // ---- Step 8: Atomic CG binding written ----
@@ -457,7 +452,7 @@ describe('V10 E2E Conviction System', function () {
       // sum is the canonical guard.
 
       // ---- Step 11: KC retrieval via public reader ----
-      const retrievedKc = await KnowledgeCollectionStorage.getKnowledgeCollection(kcId);
+      const retrievedKc = await DKGKnowledgeAssets.getKnowledgeCollection(kcId);
       expect(retrievedKc.byteSize).to.equal(1000n);
       expect(retrievedKc.startEpoch).to.equal(currentEpoch);
       expect(retrievedKc.endEpoch).to.equal(currentEpoch + BigInt(epochs));
@@ -472,10 +467,10 @@ describe('V10 E2E Conviction System', function () {
       // MerkleRoot struct at 3 storage slots so prior KCs decode correctly
       // post-upgrade — see KnowledgeCollectionLib comments).
       expect(
-        await KnowledgeCollectionStorage.getMerkleRootAuthorByIndex(kcId, 0),
+        await DKGKnowledgeAssets.getMerkleRootAuthorByIndex(kcId, 0),
       ).to.equal(creator.address);
       expect(
-        await KnowledgeCollectionStorage.getLatestMerkleRootAuthor(kcId),
+        await DKGKnowledgeAssets.getLatestMerkleRootAuthor(kcId),
       ).to.equal(creator.address);
     });
   });

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -1,6 +1,6 @@
 // Standalone V10 Publishing Conviction NFT lifecycle: create → topUp →
 // registerAgent → deregisterAgent → settle, plus the discounted publish
-// path through a real KnowledgeAssetsV10.publish() and the post-expiry
+// path through a real KnowledgeAssetsLifecycle.publish() and the post-expiry
 // revert. Peer of test/v10-e2e-conviction.test.ts (Flow 3).
 
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
@@ -18,8 +18,8 @@ import {
   DKGStakingConvictionNFT,
   EpochStorage,
   Hub,
-  KnowledgeAssetsV10,
-  KnowledgeCollectionStorage,
+  KnowledgeAssetsLifecycle,
+  DKGKnowledgeAssets,
   Profile,
   PublishingConviction,
   StakingV10,
@@ -47,8 +47,8 @@ type Fixture = {
   ConvictionStakingStorage: ConvictionStakingStorage;
   StakingV10: StakingV10;
   StakingNFT: DKGStakingConvictionNFT;
-  KnowledgeAssetsV10: KnowledgeAssetsV10;
-  KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  KnowledgeAssetsLifecycle: KnowledgeAssetsLifecycle;
+  DKGKnowledgeAssets: DKGKnowledgeAssets;
   EpochStorage: EpochStorage;
   ContextGraphs: ContextGraphs;
   ContextGraphStorage: ContextGraphStorage;
@@ -64,7 +64,7 @@ async function deployFixture(): Promise<Fixture> {
     'Chronos',
     'Profile',
     'Identity',
-    'KnowledgeAssetsV10',
+    'KnowledgeAssetsLifecycle',
     'ContextGraphStorage',
     'ContextGraphs',
     'ContextGraphValueStorage',
@@ -91,12 +91,12 @@ async function deployFixture(): Promise<Fixture> {
     StakingNFT: await hre.ethers.getContract<DKGStakingConvictionNFT>(
       'DKGStakingConvictionNFT',
     ),
-    KnowledgeAssetsV10: await hre.ethers.getContract<KnowledgeAssetsV10>(
-      'KnowledgeAssetsV10',
+    KnowledgeAssetsLifecycle: await hre.ethers.getContract<KnowledgeAssetsLifecycle>(
+      'KnowledgeAssetsLifecycle',
     ),
-    KnowledgeCollectionStorage:
-      await hre.ethers.getContract<KnowledgeCollectionStorage>(
-        'KnowledgeCollectionStorage',
+    DKGKnowledgeAssets:
+      await hre.ethers.getContract<DKGKnowledgeAssets>(
+        'DKGKnowledgeAssets',
       ),
     EpochStorage: await hre.ethers.getContract<EpochStorage>('EpochStorageV8'),
     ContextGraphs: await hre.ethers.getContract<ContextGraphs>('ContextGraphs'),
@@ -120,8 +120,8 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
   let ConvictionStakingStorage: ConvictionStakingStorage;
   let StakingV10Contract: StakingV10;
   let StakingNFT: DKGStakingConvictionNFT;
-  let KAV10: KnowledgeAssetsV10;
-  let KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  let KAV10: KnowledgeAssetsLifecycle;
+  let DKGKnowledgeAssets: DKGKnowledgeAssets;
   let EpochStorageContract: EpochStorage;
   let CGFacade: ContextGraphs;
   let CGS: ContextGraphStorage;
@@ -138,8 +138,8 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
       ConvictionStakingStorage,
       StakingV10: StakingV10Contract,
       StakingNFT,
-      KnowledgeAssetsV10: KAV10,
-      KnowledgeCollectionStorage,
+      KnowledgeAssetsLifecycle: KAV10,
+      DKGKnowledgeAssets,
       EpochStorage: EpochStorageContract,
       ContextGraphs: CGFacade,
       ContextGraphStorage: CGS,
@@ -311,7 +311,7 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
   };
 
   // --------------------------------------------------------------------------
-  // 2. registered agent publishes via real KnowledgeAssetsV10.publish()
+  // 2. registered agent publishes via real KnowledgeAssetsLifecycle.publish()
   // --------------------------------------------------------------------------
   it('takes the discount branch when epochs == lockDurationEpochs and the discounted cost is asserted on chain', async () => {
     const {
@@ -341,7 +341,7 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
       author: creator,
       contextGraphId: cgId,
       merkleRoot,
-      knowledgeAssetsAmount: 10,
+      knowledgeAssetsAmount: 1,
       byteSize: 1000,
       epochs,
       tokenAmount,
@@ -386,7 +386,7 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     // spend) executed.
     const kcId = 1n;
     const meta =
-      await KnowledgeCollectionStorage.getKnowledgeCollectionMetadata(kcId);
+      await DKGKnowledgeAssets.getKnowledgeCollectionMetadata(kcId);
     expect(meta[6]).to.equal(tokenAmount);
     expect(activeSinkSum).to.be.lessThan(meta[6]);
   });
@@ -395,7 +395,7 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
   // 3. expired account: real publish() loses the discount and reverts
   // --------------------------------------------------------------------------
   //
-  // On an expired PCA `KnowledgeAssetsV10.publish()` gates the conviction
+  // On an expired PCA `KnowledgeAssetsLifecycle.publish()` gates the conviction
   // discount off (block.timestamp >= expiresAtTimestamp) and falls through
   // to the direct-spend branch — `_addTokens` pulls the FULL cost from the
   // agent. The registered agent here was only ever funded for the up-front
@@ -437,7 +437,7 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
       author: creator,
       contextGraphId: cgId,
       merkleRoot,
-      knowledgeAssetsAmount: 10,
+      knowledgeAssetsAmount: 1,
       byteSize: 1000,
       epochs,
       tokenAmount,
@@ -451,7 +451,7 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
 
     // Atomic rollback: the expired publish minted no knowledge collection.
     expect(
-      await KnowledgeCollectionStorage.getLatestKnowledgeCollectionId(),
+      await DKGKnowledgeAssets.getLatestKnowledgeCollectionId(),
     ).to.equal(0n);
   });
 });

--- a/packages/publisher/test/agent-provenance-e2e.test.ts
+++ b/packages/publisher/test/agent-provenance-e2e.test.ts
@@ -106,7 +106,9 @@ beforeAll(async () => {
     ],
     provider,
   );
-  kcsAddress = await hub.getAssetStorageAddress('KnowledgeCollectionStorage');
+  // Greenfield (PR #815): the asset-storage Hub key was renamed
+  // KnowledgeCollectionStorage → DKGKnowledgeAssets.
+  kcsAddress = await hub.getAssetStorageAddress('DKGKnowledgeAssets');
   pcaAddress = await hub.getContractAddress('DKGPublishingConvictionNFT');
   tokenAddress = await hub.getContractAddress('Token');
   epsAddress = await hub.getContractAddress('EpochStorageV8');
@@ -180,7 +182,7 @@ function token() {
 // share the ceremony. Local thin wrappers preserve the call shape used
 // throughout this file (CORE_OP author by default; `cgId` defaults to
 // the file-scope `CONTEXT_GRAPH`).
-import { buildSeal as buildSealCore, publishSealed as publishSealedCore } from './_helpers/seal.js';
+import { buildSeal as buildSealCore, publishSealed as publishSealedCore, updateSealed as updateSealedCore } from './_helpers/seal.js';
 import { hardhatACKProvider } from './_helpers/acks.js';
 
 async function buildSeal(
@@ -209,6 +211,24 @@ async function publishSealed(
   // quorum now that the self-signed ACK fallback is gone.
   return publishSealedCore(
     publisher,
+    args,
+    new ethers.Wallet(authorKey),
+    { provider, kav10Address },
+    { v10ACKProvider: hardhatACKProvider(kav10Address) },
+  );
+}
+
+async function updateSealed(
+  publisher: DKGPublisher,
+  kcId: bigint,
+  args: Parameters<DKGPublisher['update']>[1],
+  authorKey: string = HARDHAT_KEYS.CORE_OP,
+) {
+  // Greenfield (PR #815): on-chain updates are owner-sealed — mint the
+  // UpdateAuthorAttestation seal + supply the ACK quorum, same as publish.
+  return updateSealedCore(
+    publisher,
+    kcId,
     args,
     new ethers.Wallet(authorKey),
     { provider, kav10Address },
@@ -412,19 +432,20 @@ describe('Diagram 4 — KC update writes merkleRootAuthors[len-1] unconditionall
     const idx0Author: string = await kcs().getMerkleRootAuthorByIndex(kcId, 0);
     expect(idx0Author.toLowerCase()).toBe(author.address.toLowerCase());
 
-    const updated = await publisher.update(kcId, {
+    const updated = await updateSealed(publisher, kcId, {
       contextGraphId: CONTEXT_GRAPH,
       quads: [q(`${ENTITY}/D4`, 'http://schema.org/name', '"Updated"')],
     });
     expect(updated.status).toBe('confirmed');
 
-    // Index 0 unchanged; index 1 is address(0) since V10.1 update path
-    // doesn't sign authors yet — the unconditional overwrite means a stale
-    // value at this index from a prior pop+push couldn't leak through.
+    // Index 0 unchanged. Greenfield (PR #815): owner-sealed updates carry a
+    // signed UpdateAuthorAttestation, so the update path now records the
+    // author at the appended index — index 1 is the update signer, not
+    // address(0) as in the pre-greenfield V10.1 path.
     expect((await kcs().getMerkleRootAuthorByIndex(kcId, 0)).toLowerCase())
       .toBe(author.address.toLowerCase());
     expect((await kcs().getMerkleRootAuthorByIndex(kcId, 1)).toLowerCase())
-      .toBe(ethers.ZeroAddress);
+      .toBe(author.address.toLowerCase());
   });
 });
 
@@ -607,28 +628,32 @@ describe('Diagram 8 — multi-update author array stays consistent with the cano
     });
     const kcId = created.onChainResult!.batchId;
 
-    const u1 = await publisher.update(kcId, {
+    const u1 = await updateSealed(publisher, kcId, {
       contextGraphId: CONTEXT_GRAPH,
       quads: [q(`${ENTITY}/D8`, 'http://schema.org/name', '"V1"')],
     });
     expect(u1.status).toBe('confirmed');
 
-    const u2 = await publisher.update(kcId, {
+    const u2 = await updateSealed(publisher, kcId, {
       contextGraphId: CONTEXT_GRAPH,
       quads: [q(`${ENTITY}/D8`, 'http://schema.org/name', '"V2"')],
     });
     expect(u2.status).toBe('confirmed');
 
+    // Greenfield (PR #815): owner-sealed updates carry a signed author
+    // attestation, so every appended merkle root is attributed to the
+    // update signer — [author, author, author] rather than the
+    // pre-greenfield [author, 0, 0].
     expect((await kcs().getMerkleRootAuthorByIndex(kcId, 0)).toLowerCase())
       .toBe(author.address.toLowerCase());
     expect((await kcs().getMerkleRootAuthorByIndex(kcId, 1)).toLowerCase())
-      .toBe(ethers.ZeroAddress);
+      .toBe(author.address.toLowerCase());
     expect((await kcs().getMerkleRootAuthorByIndex(kcId, 2)).toLowerCase())
-      .toBe(ethers.ZeroAddress);
+      .toBe(author.address.toLowerCase());
 
-    // Latest reader returns the most-recent slot (index 2) → address(0).
+    // Latest reader returns the most-recent slot (index 2) → update signer.
     expect((await kcs().getLatestMerkleRootAuthor(kcId)).toLowerCase())
-      .toBe(ethers.ZeroAddress);
+      .toBe(author.address.toLowerCase());
   });
 });
 

--- a/packages/publisher/test/dkg-publisher.test.ts
+++ b/packages/publisher/test/dkg-publisher.test.ts
@@ -169,20 +169,19 @@ describe('DKGPublisher', () => {
     expect(metaCount).toBeGreaterThan(0);
   });
 
-  it('publishes multiple KAs in one KC', async () => {
-    const result = await publishWS({
-      contextGraphId: CONTEXT_GRAPH,
-      quads: [
-        q(ENTITY, 'http://schema.org/name', '"ImageBot"'),
-        q(ENTITY2, 'http://schema.org/name', '"TextBot"'),
-      ],
-    });
-
-    expect(result.kaManifest).toHaveLength(2);
-    expect(result.kaManifest.map((m) => m.rootEntity).sort()).toEqual(
-      [ENTITY, ENTITY2].sort(),
-    );
-    expect(result.status).toBe('confirmed');
+  it('rejects publishing multiple KAs in one KC (greenfield: one KA per tx)', async () => {
+    // Greenfield KA model (PR #815): a V10 on-chain publish must carry
+    // exactly one Knowledge Asset per transaction. Publishing two root
+    // entities (ENTITY + ENTITY2) in a single call is now rejected.
+    await expect(
+      publishWS({
+        contextGraphId: CONTEXT_GRAPH,
+        quads: [
+          q(ENTITY, 'http://schema.org/name', '"ImageBot"'),
+          q(ENTITY2, 'http://schema.org/name', '"TextBot"'),
+        ],
+      }),
+    ).rejects.toThrow(/exactly one Knowledge Asset per transaction/i);
   });
 
   it('publishes with blank nodes (auto-skolemized)', async () => {

--- a/packages/publisher/test/publish-lifecycle.test.ts
+++ b/packages/publisher/test/publish-lifecycle.test.ts
@@ -27,7 +27,7 @@ import { computeTripleHashV10 as computeTripleHash } from '../src/merkle.js';
 import { ethers } from 'ethers';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, createTestContextGraph, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 import { mintTokens } from '../../chain/test/hardhat-harness.js';
-import { withSeal as _withSeal } from './_helpers/seal.js';
+import { withSeal as _withSeal, withUpdateSeal as _withUpdateSeal } from './_helpers/seal.js';
 import { hardhatACKProvider } from './_helpers/acks.js';
 
 let CONTEXT_GRAPH: string;
@@ -59,7 +59,11 @@ async function pubS(p: DKGPublisher, args: Parameters<DKGPublisher['publish']>[0
   } as Parameters<DKGPublisher['publish']>[0]);
 }
 async function updS(p: DKGPublisher, kcId: bigint, args: Parameters<DKGPublisher['update']>[1]) {
-  const sealed = await _withSeal(args, _author, { provider: _provider, kav10Address: _kav10Address });
+  // Greenfield (PR #815): on-chain updates are owner-sealed — the publisher
+  // refuses to self-sign and requires a `precomputedUpdateAttestation` over
+  // `UpdateAuthorAttestation(kaId, newMerkleRoot, author)`. Mint it here so
+  // existing update tests stay structurally identical.
+  const sealed = await _withUpdateSeal(kcId, args, _author, { provider: _provider, kav10Address: _kav10Address });
   return p.update(kcId, {
     ...sealed,
     v10ACKProvider: sealed.v10ACKProvider ?? hardhatACKProvider(_kav10Address),
@@ -139,13 +143,17 @@ describe('Publish lifecycle (aligned with diagram)', () => {
       publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
     });
 
-    const entityA = 'did:dkg:agent:QmEntityA';
-    const entityB = 'did:dkg:agent:QmEntityB';
+    // Greenfield (PR #815): one KA per publish. The flat-kcMerkleRoot
+    // property is independent of how many triples the single KA carries —
+    // the root is always a flat MerkleTree over every triple hash (no
+    // per-entity grouping). Exercise it with a single root entity holding
+    // four triples.
+    const entity = 'did:dkg:agent:QmFlatOptions';
     const triples = [
-      q(entityA, 'http://schema.org/name', '"EntityA"'),
-      q(entityA, 'http://schema.org/version', '"1"'),
-      q(entityB, 'http://schema.org/name', '"EntityB"'),
-      q(entityB, 'http://schema.org/version', '"2"'),
+      q(entity, 'http://schema.org/name', '"EntityA"'),
+      q(entity, 'http://schema.org/version', '"1"'),
+      q(entity, 'http://schema.org/description', '"EntityB"'),
+      q(entity, 'http://schema.org/url', '"2"'),
     ];
 
     const result = await pubS(publisher, {
@@ -175,13 +183,18 @@ describe('Publish lifecycle (aligned with diagram)', () => {
       publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
     });
 
+    // Greenfield (PR #815): one KA per publish. The golden now pins the
+    // flat-merkle pipeline output for a single root entity carrying six
+    // fixed triples (the old golden combined three entities into one KC,
+    // which the single-KA invariant no longer allows). Re-derived via
+    // V10MerkleTree(quads.map(computeTripleHashV10)) over the quads below.
     const fixedQuads = [
       q('did:dkg:agent:Entity1', 'http://schema.org/name', '"Entity1"'),
       q('did:dkg:agent:Entity1', 'http://schema.org/version', '"1"'),
-      q('did:dkg:agent:Entity2', 'http://schema.org/name', '"Entity2"'),
-      q('did:dkg:agent:Entity2', 'http://schema.org/version', '"2"'),
-      q('did:dkg:agent:Entity3', 'http://schema.org/name', '"Entity3"'),
-      q('did:dkg:agent:Entity3', 'http://schema.org/version', '"3"'),
+      q('did:dkg:agent:Entity1', 'http://schema.org/alternateName', '"Entity2"'),
+      q('did:dkg:agent:Entity1', 'http://schema.org/identifier', '"2"'),
+      q('did:dkg:agent:Entity1', 'http://schema.org/description', '"Entity3"'),
+      q('did:dkg:agent:Entity1', 'http://schema.org/sameAs', '"3"'),
     ];
 
     const result = await pubS(publisher, {
@@ -191,7 +204,7 @@ describe('Publish lifecycle (aligned with diagram)', () => {
 
     const actualHex = Buffer.from(result.merkleRoot).toString('hex');
     const goldenHex =
-      'd0d2a43d52a4925eabf280043ac3fa21043d7da90f9813fb22fecfc038d3da97';
+      '0a3a66a345e5e8a25c50dd01be3373ae3d6b242807b62cbe7ada5ec208812a16';
     expect(actualHex).toBe(goldenHex);
   });
 
@@ -316,33 +329,40 @@ describe('Publisher ↔ Receiver merkle consistency (regression)', () => {
       publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
     });
 
+    // Greenfield (PR #815): one KA per publish, so the historical
+    // single-KC-with-two-entities publish is now split into two
+    // single-KA publishes. The receiver-consistency invariant is
+    // per-publish: for each KA, the receiver rebuilding a flat
+    // MerkleTree from the public quads MUST reproduce the publisher's
+    // root — otherwise the finalization handler logs "merkle mismatch"
+    // and falls back to full-payload sync.
     const entityA = 'did:dkg:agent:QmEntityAlpha';
     const entityB = 'did:dkg:agent:QmEntityBeta';
-    const triples = [
+    const triplesA = [
       q(entityA, 'http://schema.org/name', '"Alpha"'),
       q(entityA, 'http://schema.org/version', '"1"'),
       q(entityA, 'http://schema.org/description', '"First entity"'),
+    ];
+    const triplesB = [
       q(entityB, 'http://schema.org/name', '"Beta"'),
       q(entityB, 'http://schema.org/version', '"2"'),
     ];
 
-    const result = await pubS(publisher, {
-      contextGraphId: CONTEXT_GRAPH,
-      quads: triples,
-    });
+    for (const triples of [triplesA, triplesB]) {
+      const result = await pubS(publisher, {
+        contextGraphId: CONTEXT_GRAPH,
+        quads: triples,
+      });
 
-    expect(result.merkleRoot).toHaveLength(32);
-    const publisherHex = Buffer.from(result.merkleRoot).toString('hex');
+      expect(result.merkleRoot).toHaveLength(32);
+      const publisherHex = Buffer.from(result.merkleRoot).toString('hex');
 
-    // Simulate what a receiver does: hash all received public quads with
-    // computeTripleHash and build a flat MerkleTree. This MUST match the
-    // publisher's root — if it doesn't, the finalization handler will log
-    // "merkle mismatch" and fall back to full-payload sync.
-    const receiverHashes = result.publicQuads!.map(computeTripleHash);
-    const receiverRoot = new MerkleTree(receiverHashes).root;
-    const receiverHex = Buffer.from(receiverRoot).toString('hex');
+      const receiverHashes = result.publicQuads!.map(computeTripleHash);
+      const receiverRoot = new MerkleTree(receiverHashes).root;
+      const receiverHex = Buffer.from(receiverRoot).toString('hex');
 
-    expect(receiverHex).toBe(publisherHex);
+      expect(receiverHex).toBe(publisherHex);
+    }
   });
 
   it('single-entity publish: receiver flat merkle matches publisher merkle', async () => {

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -40,6 +40,25 @@ import { ethers } from 'ethers';
 import { wrapPublisherForTest, mockSealCtx, updateSealed } from './_helpers/seal.js';
 import { mockChainStubACKProvider } from './_helpers/acks.js';
 
+// Greenfield (PR #815): the confirmed UAL embeds the DKGKnowledgeAssets
+// storage address resolved via `getDKGKnowledgeAssetsAddress()`, not the
+// publisher address. Asserting only the UAL shape (40-hex) would still pass
+// if the publisher embedded the zero address, the legacy storage contract,
+// or any other 40-hex value. Compare the embedded address against the
+// adapter's resolved storage address so the specific result stays covered.
+async function expectUalEmbedsStorageAddress(
+  ual: string | undefined,
+  chain: { getDKGKnowledgeAssetsAddress(): Promise<string> },
+  tokenId: number,
+): Promise<void> {
+  expect(ual).toMatch(/^did:dkg:mock:31337\/0x[0-9a-fA-F]{40}\/\d+$/);
+  const [, embeddedAddr, embeddedTokenId] = (ual ?? '').split('/');
+  expect(embeddedAddr.toLowerCase()).toBe(
+    (await chain.getDKGKnowledgeAssetsAddress()).toLowerCase(),
+  );
+  expect(embeddedTokenId).toBe(String(tokenId));
+}
+
 // Phase C (commit `d353c6a5`) made `DKGPublisher.publish` reject on-chain
 // publishes that arrive without a `precomputedAttestation`. The mock-chain
 // tests in this file pre-date that requirement; wrap each publisher so the
@@ -968,7 +987,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     // Greenfield (PR #815): the UAL embeds the DKGKnowledgeAssets storage
     // address, not the publisher address — attribution lives in
     // `onChainResult.publisherAddress` below.
-    expect(updated.ual).toMatch(/^did:dkg:mock:31337\/0x[0-9a-fA-F]{40}\/11$/);
+    await expectUalEmbedsStorageAddress(updated.ual, chain, 11);
     expect(updated.onChainResult?.publisherAddress.toLowerCase()).toBe(wallet.address.toLowerCase());
   });
 
@@ -1023,7 +1042,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     expect(updated.status).toBe('confirmed');
     // Greenfield (PR #815): UAL embeds the DKGKnowledgeAssets storage
     // address; attribution is asserted via onChainResult below.
-    expect(updated.ual).toMatch(/^did:dkg:mock:31337\/0x[0-9a-fA-F]{40}\/11$/);
+    await expectUalEmbedsStorageAddress(updated.ual, chain, 11);
     expect(updated.onChainResult?.publisherAddress.toLowerCase()).toBe(wallet.address.toLowerCase());
   });
 
@@ -1052,7 +1071,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     expect(updated.status).toBe('failed');
     // Greenfield (PR #815): UAL embeds the DKGKnowledgeAssets storage
     // address; attribution is asserted via capturedPublisherAddress above.
-    expect(updated.ual).toMatch(/^did:dkg:mock:31337\/0x[0-9a-fA-F]{40}\/12$/);
+    await expectUalEmbedsStorageAddress(updated.ual, chain, 12);
   });
 
   it('preserves failed adapter-managed updates when publisher attribution is unavailable', async () => {
@@ -1077,7 +1096,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
 
     expect(chain.capturedPublisherAddress).toBeUndefined();
     expect(updated.status).toBe('failed');
-    expect(updated.ual).toMatch(/^did:dkg:mock:31337\/0x[0-9a-fA-F]{40}\/12$/);
+    await expectUalEmbedsStorageAddress(updated.ual, chain, 12);
   });
 
   it('does not confirm adapter-managed updates from local metadata alone', async () => {
@@ -1131,7 +1150,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     expect(chain.capturedPublisherAddress?.toLowerCase()).toBe(wallet.address.toLowerCase());
     expect(updated.status).toBe('tentative');
     expect(updated.onChainResult).toBeUndefined();
-    expect(updated.ual).toMatch(/^did:dkg:mock:31337\/0x[0-9a-fA-F]{40}\/13$/);
+    await expectUalEmbedsStorageAddress(updated.ual, chain, 13);
 
     const stored = await store.query(`
       SELECT ?p ?o WHERE {
@@ -1168,7 +1187,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     expect(chain.capturedPublisherAddress).toBeUndefined();
     expect(updated.status).toBe('tentative');
     expect(updated.onChainResult).toBeUndefined();
-    expect(updated.ual).toMatch(/^did:dkg:mock:31337\/0x[0-9a-fA-F]{40}\/12$/);
+    await expectUalEmbedsStorageAddress(updated.ual, chain, 12);
 
     const stored = await store.query(`
       SELECT ?p ?o WHERE {

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -37,7 +37,7 @@ import {
   type V10UpdateKCParams,
 } from '@origintrail-official/dkg-chain';
 import { ethers } from 'ethers';
-import { wrapPublisherForTest, mockSealCtx } from './_helpers/seal.js';
+import { wrapPublisherForTest, mockSealCtx, updateSealed } from './_helpers/seal.js';
 import { mockChainStubACKProvider } from './_helpers/acks.js';
 
 // Phase C (commit `d353c6a5`) made `DKGPublisher.publish` reject on-chain
@@ -69,6 +69,20 @@ async function sealForWallet(
 
 const TEST_KEY = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d';
 const TEST_KEY_ALT = '0x5de4111a56f4c24611d9ed4d5318a7e03f9b9a9d73f3a5f3f6324a2a0e6fbb36';
+
+// Greenfield (PR #815): on-chain updates require an owner seal
+// (`precomputedUpdateAttestation`). The adapter-managed update tests below
+// assert publisher *attribution* resolution, not seal ceremony, so this
+// helper mints a self-consistent seal (author == recovered signer) over
+// the mock chain's `mockSealCtx()` domain and forwards to `update()`.
+const _SEAL_WALLET = new ethers.Wallet(TEST_KEY);
+function updS(
+  publisher: DKGPublisher,
+  kcId: bigint,
+  args: Parameters<DKGPublisher['update']>[1],
+) {
+  return updateSealed(publisher, kcId, args, _SEAL_WALLET, mockSealCtx());
+}
 
 // Minimal stub — DKGPublisher's constructor only reads `chain.chainId`.
 // All other ChainAdapter methods are unused in this test.
@@ -116,6 +130,14 @@ class AsyncAddressSigningChain implements ChainAdapter {
 
   async getKnowledgeAssetsV10Address(): Promise<string> {
     return '0x00000000000000000000000000000000000000A1';
+  }
+
+  // Greenfield (PR #815): the publisher resolves the asset-storage
+  // address via `getDKGKnowledgeAssetsAddress()` (Hub name changed from
+  // KnowledgeCollectionStorage → DKGKnowledgeAssets) when assigning the
+  // confirmed UAL. Mirror MockChainAdapter and reuse the V10 address.
+  async getDKGKnowledgeAssetsAddress(): Promise<string> {
+    return this.getKnowledgeAssetsV10Address();
   }
 
   async getSignerAddress(): Promise<string> {
@@ -285,6 +307,25 @@ class AdapterManagedUpdateChain implements ChainAdapter {
     private readonly latestPublisherAddress?: string,
     private readonly success = true,
   ) {}
+
+  // Greenfield (PR #815): the owner-sealed update path rebuilds the
+  // UpdateAuthorAttestation typed data from `getEvmChainId()` +
+  // `getKnowledgeAssetsV10Address()` to verify the seal before
+  // submitting. These values must match the `mockSealCtx()` defaults the
+  // seal is signed against (chainId 31337, kav10 `0x…c10a`).
+  async getEvmChainId(): Promise<bigint> {
+    return 31337n;
+  }
+
+  async getKnowledgeAssetsV10Address(): Promise<string> {
+    return '0x000000000000000000000000000000000000c10a';
+  }
+
+  // Greenfield (PR #815): `resolveKaUal()` reads the asset-storage
+  // address via `getDKGKnowledgeAssetsAddress()` when building the UAL.
+  async getDKGKnowledgeAssetsAddress(): Promise<string> {
+    return '0x000000000000000000000000000000000000c10a';
+  }
 
   async updateKnowledgeCollectionV10(params: V10UpdateKCParams): Promise<TxResult> {
     this.capturedPublisherAddress = params.publisherAddress;
@@ -886,7 +927,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       publisherAddress: wallet.address,
     });
 
-    const updated = await publisher.update(99n, {
+    const updated = await updS(publisher, 99n, {
       contextGraphId: '1',
       quads: [{
         subject: 'urn:test:update-configured-publisher-fallback',
@@ -912,7 +953,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       keypair,
     });
 
-    const updated = await publisher.update(11n, {
+    const updated = await updS(publisher, 11n, {
       contextGraphId: '1',
       quads: [{
         subject: 'urn:test:adapter-managed-update',
@@ -924,7 +965,10 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
 
     expect(chain.capturedPublisherAddress).toBeUndefined();
     expect(updated.status).toBe('confirmed');
-    expect(updated.ual.toLowerCase()).toContain(wallet.address.toLowerCase());
+    // Greenfield (PR #815): the UAL embeds the DKGKnowledgeAssets storage
+    // address, not the publisher address — attribution lives in
+    // `onChainResult.publisherAddress` below.
+    expect(updated.ual).toMatch(/^did:dkg:mock:31337\/0x[0-9a-fA-F]{40}\/11$/);
     expect(updated.onChainResult?.publisherAddress.toLowerCase()).toBe(wallet.address.toLowerCase());
   });
 
@@ -938,7 +982,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       keypair,
     });
 
-    const updated = await publisher.update(14n, {
+    const updated = await updS(publisher, 14n, {
       contextGraphId: '1',
       quads: [{
         subject: 'urn:test:adapter-managed-update-without-reservation',
@@ -965,7 +1009,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       keypair,
     });
 
-    const updated = await publisher.update(11n, {
+    const updated = await updS(publisher, 11n, {
       contextGraphId: '1',
       quads: [{
         subject: 'urn:test:adapter-managed-update-chain-attribution',
@@ -977,7 +1021,9 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
 
     expect(chain.capturedPublisherAddress?.toLowerCase()).toBe(wallet.address.toLowerCase());
     expect(updated.status).toBe('confirmed');
-    expect(updated.ual.toLowerCase()).toContain(wallet.address.toLowerCase());
+    // Greenfield (PR #815): UAL embeds the DKGKnowledgeAssets storage
+    // address; attribution is asserted via onChainResult below.
+    expect(updated.ual).toMatch(/^did:dkg:mock:31337\/0x[0-9a-fA-F]{40}\/11$/);
     expect(updated.onChainResult?.publisherAddress.toLowerCase()).toBe(wallet.address.toLowerCase());
   });
 
@@ -992,7 +1038,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       keypair,
     });
 
-    const updated = await publisher.update(12n, {
+    const updated = await updS(publisher, 12n, {
       contextGraphId: '1',
       quads: [{
         subject: 'urn:test:adapter-managed-failed-update-chain-attribution',
@@ -1004,7 +1050,9 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
 
     expect(chain.capturedPublisherAddress?.toLowerCase()).toBe(wallet.address.toLowerCase());
     expect(updated.status).toBe('failed');
-    expect(updated.ual.toLowerCase()).toContain(wallet.address.toLowerCase());
+    // Greenfield (PR #815): UAL embeds the DKGKnowledgeAssets storage
+    // address; attribution is asserted via capturedPublisherAddress above.
+    expect(updated.ual).toMatch(/^did:dkg:mock:31337\/0x[0-9a-fA-F]{40}\/12$/);
   });
 
   it('preserves failed adapter-managed updates when publisher attribution is unavailable', async () => {
@@ -1017,7 +1065,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       keypair,
     });
 
-    const updated = await publisher.update(12n, {
+    const updated = await updS(publisher, 12n, {
       contextGraphId: '1',
       quads: [{
         subject: 'urn:test:adapter-managed-failed-update-without-address',
@@ -1070,7 +1118,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       },
     ));
 
-    const updated = await publisher.update(13n, {
+    const updated = await updS(publisher, 13n, {
       contextGraphId: '1',
       quads: [{
         subject: 'urn:test:adapter-managed-update-local-attribution',
@@ -1107,7 +1155,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       keypair,
     });
 
-    const updated = await publisher.update(12n, {
+    const updated = await updS(publisher, 12n, {
       contextGraphId: '1',
       quads: [{
         subject: 'urn:test:adapter-managed-update-without-address',

--- a/packages/publisher/test/security-regressions.test.ts
+++ b/packages/publisher/test/security-regressions.test.ts
@@ -223,7 +223,11 @@ describe('Prefix deletion safety', () => {
       const fooQuads = [q('urn:x:foo', 'http://schema.org/name', '"Foo"')];
       const foobarQuads = [q('urn:x:foobar', 'http://schema.org/name', '"Foobar"')];
 
-      const published = await publisher.publish({ contextGraphId: CONTEXT_GRAPH, quads: [...fooQuads, ...foobarQuads] });
+      // Greenfield (PR #815): one KA per publish, so foo and foobar are
+      // published as two separate single-KA assets. Both land in the same
+      // data graph, which is what the prefix-deletion-safety check needs.
+      const published = await publisher.publish({ contextGraphId: CONTEXT_GRAPH, quads: fooQuads });
+      await publisher.publish({ contextGraphId: CONTEXT_GRAPH, quads: foobarQuads });
 
       const updateQuads = [q('urn:x:foo', 'http://schema.org/name', '"Foo Updated"')];
       const updateResult = await publisher.update(published.kcId, {

--- a/packages/publisher/test/swm-subset-cleanup.test.ts
+++ b/packages/publisher/test/swm-subset-cleanup.test.ts
@@ -152,19 +152,30 @@ describe('SWM subset publish cleanup', () => {
       v10ACKProvider: hardhatACKProvider(_kav10Address),
     });
 
-    // Publish remaining (Bob + Carol) — should not fail with "already exists"
-    const remainingQuads = allQuads.filter((quad) => quad.subject !== alice);
-    const result = await publisher.publishFromSharedMemory(CONTEXT_GRAPH, 'all', {
-      clearSharedMemoryAfter: true,
-      precomputedAttestation: await sealForAll(remainingQuads),
+    // Publish the remaining entities — should not fail with "already
+    // exists". Greenfield (PR #815) allows one KA per transaction, so
+    // Bob and Carol are published in separate single-KA publishes rather
+    // than a single multi-KA `'all'` call.
+    const bobResult = await publisher.publishFromSharedMemory(CONTEXT_GRAPH, { rootEntities: [bob] }, {
+      clearSharedMemoryAfter: false,
+      precomputedAttestation: await sealForRoots(allQuads, [bob]),
       v10ACKProvider: hardhatACKProvider(_kav10Address),
     });
+    expect(bobResult.status).toBe('confirmed');
+    const bobRoots = bobResult.kaManifest.map((ka) => ka.rootEntity);
+    expect(bobRoots).toContain(bob);
+    expect(bobRoots).not.toContain(alice);
 
-    expect(result.status).toBe('confirmed');
-    const roots = result.kaManifest.map((ka) => ka.rootEntity);
-    expect(roots).toContain(bob);
-    expect(roots).toContain(carol);
-    expect(roots).not.toContain(alice);
+    // Carol is the last entity left in SWM; publish it and clear.
+    const carolResult = await publisher.publishFromSharedMemory(CONTEXT_GRAPH, 'all', {
+      clearSharedMemoryAfter: true,
+      precomputedAttestation: await sealForRoots(allQuads, [carol]),
+      v10ACKProvider: hardhatACKProvider(_kav10Address),
+    });
+    expect(carolResult.status).toBe('confirmed');
+    const carolRoots = carolResult.kaManifest.map((ka) => ka.rootEntity);
+    expect(carolRoots).toContain(carol);
+    expect(carolRoots).not.toContain(alice);
 
     // SWM should be empty
     expect(await countInGraph(store, WORKSPACE_GRAPH)).toBe(0);

--- a/packages/publisher/test/swm-subset-cleanup.test.ts
+++ b/packages/publisher/test/swm-subset-cleanup.test.ts
@@ -174,8 +174,13 @@ describe('SWM subset publish cleanup', () => {
     });
     expect(carolResult.status).toBe('confirmed');
     const carolRoots = carolResult.kaManifest.map((ka) => ka.rootEntity);
-    expect(carolRoots).toContain(carol);
+    // The final `'all'` publish must cover exactly Carol: Alice was published
+    // first, and Bob's confirmed publish above must have removed him from SWM.
+    // Asserting only `toContain(carol)` would still pass if cleanup regressed
+    // and Bob were republished here alongside Carol — pin the exact set.
+    expect(carolRoots).toEqual([carol]);
     expect(carolRoots).not.toContain(alice);
+    expect(carolRoots).not.toContain(bob);
 
     // SWM should be empty
     expect(await countInGraph(store, WORKSPACE_GRAPH)).toBe(0);

--- a/packages/publisher/test/v10-publish-e2e.test.ts
+++ b/packages/publisher/test/v10-publish-e2e.test.ts
@@ -265,8 +265,11 @@ describe('V10 Publish E2E', () => {
       receiverKeys.map(async (key, idx) => {
         const wallet = new ethers.Wallet(key);
         const digest = computePublishACKDigest(
+          // Greenfield (PR #815): exactly one KA per tx. The quads above are
+          // a single root entity (urn:experiment:wsd), so knowledgeAssetsAmount
+          // is 1 — not the triple count.
           TEST_CHAIN_ID, realKAV10Addr, chainCgId, merkleRoot,
-          BigInt(publishQuads.length), byteSize, epochs, tokenAmount,
+          1n, byteSize, epochs, tokenAmount,
           BigInt(publishMerkleLeafCount),
         );
         const sig = ethers.Signature.from(await wallet.signMessage(digest));
@@ -296,7 +299,7 @@ describe('V10 Publish E2E', () => {
       publishOperationId: 'v10-e2e-test',
       contextGraphId: chainCgId,
       merkleRoot,
-      knowledgeAssetsAmount: publishQuads.length,
+      knowledgeAssetsAmount: 1,
       byteSize,
       epochs: Number(epochs),
       tokenAmount,


### PR DESCRIPTION
## Summary

`release/rc.12` is currently red on **Tornado: Solidity [1–4]**, **publisher [1–4]**, **core+storage+chain**, and **agent [5/10]**. This is pre-existing baseline breakage — the bare `release/rc.12` push run (`fc9e3b14d`) fails the same jobs, and both #820 and #821 inherit it.

Root cause: the greenfield KA merge (**commit `accfa7a00`, #815**) renamed the deployed contracts and changed publish/update semantics, but the test suites were not updated. This PR adapts the tests to the (intended) greenfield model. **Tests only — no production or contract source changes.**

### Solidity (`packages/evm-module/test`)
- Rename deploy/Hub references `KnowledgeCollectionStorage → DKGKnowledgeAssets` and `KnowledgeAssetsV10 → KnowledgeAssetsLifecycle` (type, fixture tag, `getContract` name, Hub key). The custom error `OnlyKnowledgeAssetsV10` is deliberately left unchanged — the conviction-NFT cases reverted it because the gate dependency resolved to `address(0)` under the stale Hub key.
- Adapt to greenfield contract behaviour: `knowledgeAssetsAmount == 1` (single KA per publish), ERC-721 `_safeMint(author, kcId)` ownership (replacing the old ERC-1155 range `balanceOf`), `KnowledgeAssetCreated` event, and the now-required `author` arg on update params.

### publisher / agent / chain (test only)
- **Single-KA-per-tx**: multi-KA publish cases now assert rejection (`/exactly one Knowledge Asset per transaction/`) or split into one publish per root entity.
- **Owner-sealed updates**: `update()` calls now carry a precomputed `UpdateAuthorAttestation` seal via `test/_helpers/seal.ts`.
- **Hub-key rename**: chain adapter + agent stub adapters resolve `KnowledgeAssetsLifecycle` / `DKGKnowledgeAssets`; UAL-shape and owner-sealed author-array expectations updated.

## Local results
- evm-module (11 files): **250 passing, 35 pending, 0 failing**
- publisher (7 files): **147 passing, 3 skipped**
- chain: `evm-adapter` **7 passing**, `evm-adapter-hub-rotation.e2e` **13 passing**
- agent: `agent.test.ts` **121 passing**

## Scope notes
- **ABI regen** (`StakingV10`, `ConvictionStakingStorage`, `IERC1363`, `PublishingMathLibHarness`) and the `Profile` caller change ride in **#820** — that PR touches contracts, and the ABI-freshness gate is contracts-gated (it does not run on this tests-only PR).
- The `Bura: cli` SIGTERM test (a real-daemon integration test) is a separate, likely-flaky/timing failure — not addressed here.
- One stale-coupling caveat (not a failure): `KnowledgeAssetsV10.test.ts > PublishingMathLib integration` still reads the legacy `KnowledgeAssetsV10.sol` source for a static `to.include` guard; the deployed `KnowledgeAssetsLifecycle` inlines equivalent math. Its behavioural assertions pass against the live contract.

## Test plan
- [ ] Tornado: Solidity [1–4] green
- [ ] Tornado: publisher [1–4] green
- [ ] Tornado: core + storage + chain green
- [ ] Tornado: agent [5/10] green

Made with [Cursor](https://cursor.com)