### PR TITLE
Fix RC12 context graph count queries

### DIFF
--- a/agent-docs/rc12-context-graph-counts-regression.md
+++ b/agent-docs/rc12-context-graph-counts-regression.md
@@ -79,6 +79,8 @@ The injected graph-variable constraint leaves the UI queries with no matching ro
 - [x] Run focused query tests first, then targeted Node UI count tests if the query fix is isolated.
 - [x] GitHub review follow-up: gate same-CG partition enumeration behind explicit `includeContextGraphPartitions` opt-in, and use it only from UI/subgraph count surfaces.
 - [x] GitHub review follow-up: restrict child context graph discovery to canonical candidate `/_meta` facts so arbitrary user triples cannot poison the parent count allow-list.
+- [x] GitHub review follow-up: mark widened UI count reads partial when a successful layer reaches its fixed SPARQL `LIMIT`, so clipped totals are displayed as lower bounds rather than exact.
+- [x] GitHub review follow-up: memoize same-CG partition allow-list discovery for concurrent count scans to avoid repeating full named-graph discovery for WM/SWM/VM in the same render.
 
 Implementation note: explicit `GRAPH <...>` targets still use the static route-specific allow-list. Only `GRAPH ?g` bindings receive the expanded allow-list, and that expansion is limited to same-context root protocol content partitions, registered assertion graphs, and registered subgraph partitions. Subgraph metadata and private partitions remain excluded from broad graph-variable scans.
 
@@ -112,6 +114,9 @@ GitHub review follow-up for PR #844:
 - Local follow-up review against `pr-diff.patch` returned `{"comments":[]}`.
 - Second Codex Review sweep found two valid follow-ups: typed `ApiClient.query()` did not expose/send `includeContextGraphPartitions`, and `/api/sub-graph/list` lacked route-level coverage for forwarding the flag. Both were fixed with focused CLI tests.
 - Local second follow-up review against `pr-diff.patch` returned `{"comments":[]}`.
+- Third Codex Review sweep found two valid follow-ups: widened UI fetches could clip at fixed `LIMIT`s while still looking exact, and each count query rebuilt the same partition allow-list. Both were fixed with focused UI/query tests.
+- Third local follow-up review found one valid cache-staleness issue: a TTL cache could hide a just-created graph from an immediate post-write count refresh. Fix: make the allow-list memoization in-flight-only and add coverage proving a completed scan is not reused after new graph registration.
+- Final third follow-up local review against regenerated `pr-diff.patch` returned `{"comments":[]}`.
 
 ## Final Outcome
 

--- a/agent-docs/rc12-context-graph-counts-regression.md
+++ b/agent-docs/rc12-context-graph-counts-regression.md
@@ -77,6 +77,8 @@ The injected graph-variable constraint leaves the UI queries with no matching ro
 - [x] Preserve explicit cross-context-graph rejection for direct `GRAPH <other-cg>` scoped queries.
 - [x] Preserve view-based routing behavior for `working-memory`, `shared-working-memory`, and `verified-memory`.
 - [x] Run focused query tests first, then targeted Node UI count tests if the query fix is isolated.
+- [x] GitHub review follow-up: gate same-CG partition enumeration behind explicit `includeContextGraphPartitions` opt-in, and use it only from UI/subgraph count surfaces.
+- [x] GitHub review follow-up: restrict child context graph discovery to canonical candidate `/_meta` facts so arbitrary user triples cannot poison the parent count allow-list.
 
 Implementation note: explicit `GRAPH <...>` targets still use the static route-specific allow-list. Only `GRAPH ?g` bindings receive the expanded allow-list, and that expansion is limited to same-context root protocol content partitions, registered assertion graphs, and registered subgraph partitions. Subgraph metadata and private partitions remain excluded from broad graph-variable scans.
 
@@ -85,7 +87,7 @@ Implementation note: explicit `GRAPH <...>` targets still use the static route-s
 - [x] `pnpm --filter @origintrail-official/dkg-query exec vitest run test/query-engine.test.ts`
 - [x] `pnpm --filter @origintrail-official/dkg-query run build`
 - [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/use-memory-entities-counts.test.ts test/context-graph-ia-overview.test.ts test/subgraph-overview-grid.test.ts test/sub-graph-bar-layer-scope.test.ts test/ui-api-pure.test.ts`
-- [ ] `pnpm --filter @origintrail-official/dkg-node-ui run build`
+- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build`
 - [ ] Generate a PR diff and run the local PR reviewer using `.codex/review-prompt.md` and `.codex/review-schema.json`.
 - [ ] Re-run any tests affected by valid local review findings.
 
@@ -102,6 +104,13 @@ Completed with the local `.codex` review prompt and schema against `pr-diff.patc
 
 All valid findings were addressed with regression coverage before push.
 
+GitHub review follow-up for PR #844:
+
+- Valid finding: broad same-CG partition enumeration was available on every scoped `GRAPH ?g` query, widening legacy `{ contextGraphId }` and `{ includeSharedMemory: true }` semantics. Fix: added `includeContextGraphPartitions` and threaded it only through count callers.
+- Valid finding: child context graph discovery trusted `?ctxGraph a dkg:ContextGraph` triples in arbitrary graphs. Fix: child discovery now accepts `rdf:type dkg:ContextGraph` or `registrationStatus` only from the candidate context graph's own `/_meta` graph.
+- Added regression tests proving legacy routes stay narrow, count callers opt in explicitly, and non-canonical user data cannot hide registered parent partitions.
+- Local follow-up review against `pr-diff.patch` returned `{"comments":[]}`.
+
 ## Final Outcome
 
 Implemented on `codex/rc12-context-graph-counts` for PR into `release/rc.12`.
@@ -115,6 +124,9 @@ Verification passed:
 - `pnpm --filter @origintrail-official/dkg-query run build`
 - `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/use-memory-entities-counts.test.ts test/context-graph-ia-overview.test.ts test/subgraph-overview-grid.test.ts test/sub-graph-bar-layer-scope.test.ts test/ui-api-pure.test.ts`
 - `pnpm --filter @origintrail-official/dkg-node-ui run build`
+- `pnpm --filter @origintrail-official/dkg-agent run build`
+- `pnpm --filter @origintrail-official/dkg run build`
+- Production UI build verified by direct Vite invocation after the local `node_modules/.bin/vite` shim was missing: `node node_modules/.pnpm/vite@6.4.2_.../node_modules/vite/bin/vite.js build`
 - `git diff --check`
 
 The fix restores same-context-graph count visibility for registered WM/SWM/VM content partitions while preserving explicit cross-CG rejection, excluding VM staging graphs, and refusing slash-ID child context graph collisions.

--- a/agent-docs/rc12-context-graph-counts-regression.md
+++ b/agent-docs/rc12-context-graph-counts-regression.md
@@ -1,0 +1,120 @@
+# RC12 Context Graph Counts Regression
+
+## Issue Summary
+
+Branch `release/rc.12` shows every context graph in the Node UI dashboard with `0 entities` and `0 triples`, even when the same local context graphs are known to contain WM/SWM/VM data. The same UI surfaces work on `main`.
+
+Risk classification: Medium. The fix touches query routing used by the UI and API consumers, and must preserve scoped-query isolation while restoring known-good count behavior.
+
+## Observed Behavior
+
+- Dashboard "My Context Graphs" rows render exact `0 entities - 0 triples`.
+- Dashboard "Context Graph Size" renders `0 entities / Knowledge Assets` and `0 triples`.
+- A selected context graph overview can still show activity and subgraph metadata, which indicates the context graph itself is present but the live count query path is returning empty data.
+
+## Expected Behavior
+
+- Context graphs with local data should show nonzero entity and triple counts.
+- Empty context graphs should remain zero.
+- Query scoping must not leak unrelated context graph data.
+
+## Reproduction Notes
+
+The provided screenshots characterize the regression. Local code comparison also reproduces the failure mode at the query-engine boundary:
+
+- Node UI count queries use `GRAPH ?g` to enumerate named graphs inside a context graph.
+- On `release/rc.12`, the query engine constrains `?g` to a small static graph set for `contextGraphId` scoped queries.
+- That constraint filters out assertion graphs, subgraph SWM graphs, and subgraph VM graphs before the UI can count them.
+
+Manual daemon verification, if a populated daemon is available:
+
+```powershell
+$body = @{
+  contextGraphId = "<CG_ID>"
+  sparql = 'SELECT ?s ?p ?o ?g WHERE { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "did:dkg:context-graph:<CG_ID>")) } LIMIT 100'
+} | ConvertTo-Json
+
+Invoke-RestMethod "http://127.0.0.1:<PORT>/api/query" -Method Post -Headers @{ Authorization = "Bearer <TOKEN>" } -ContentType "application/json" -Body $body
+```
+
+## Branch Comparison Notes
+
+- Fix branch: `codex/rc12-context-graph-counts`, created from `origin/release/rc.12`.
+- `main` is used only as a known-good reference.
+- `DashboardView.tsx` and the dashboard count math are materially the same between `release/rc.12` and `main`.
+- `packages/node-ui/src/ui/hooks/useMemoryEntities.ts` builds the WM/SWM/VM count queries using `GRAPH ?g` and graph URI filters.
+- `packages/query/src/dkg-query-engine.ts` differs substantially. `release/rc.12` contains scoped graph-variable hardening for no-view `contextGraphId` queries; `main` no longer applies that clamp in the same way.
+
+## Suspected Areas
+
+- Primary: `packages/query/src/dkg-query-engine.ts`
+  - `assertExplicitGraphIrisAllowed`
+  - `constrainGraphVariablesToAllowedSet`
+  - default no-view `contextGraphId` routing
+  - `GRAPH ?g` handling
+- Secondary: `packages/node-ui/src/ui/hooks/useMemoryEntities.ts`
+  - Query shape and response mapping, likely a victim rather than root cause.
+- Unlikely: `packages/node-ui/src/ui/views/DashboardView.tsx`
+  - Rendering converts successful empty bindings into exact zeros, but does not appear to manufacture zeros from populated data.
+- Unlikely: `postQueryDeduped`
+  - It changes request coalescing but still sends the same `/api/query` body; evidence points to backend empty results.
+
+## Confirmed Root Cause
+
+`release/rc.12` query hardening constrains `GRAPH ?g` variables for `contextGraphId` scoped, no-view queries to an allow-list that defaults to the root context graph data graph and selected metadata graphs. The Node UI count queries intentionally need to enumerate all same-context-graph named graphs, including:
+
+- `did:dkg:context-graph:<id>/assertion/...`
+- `did:dkg:context-graph:<id>/_shared_memory`
+- `did:dkg:context-graph:<id>/<subgraph>/_shared_memory`
+- `did:dkg:context-graph:<id>/<subgraph>`
+
+The injected graph-variable constraint leaves the UI queries with no matching rows for those content partitions. The requests succeed, so the UI treats the result as authoritative empty data and displays `0 entities - 0 triples`.
+
+## Implementation Plan
+
+- [x] Add targeted query-engine regression coverage for the exact Node UI `GRAPH ?g` query shape against populated WM, SWM, and VM named graphs.
+- [x] Patch `packages/query/src/dkg-query-engine.ts` so self-scoped same-context-graph `GRAPH ?g` scans used by the UI are not clamped to only the root/static graph allow-list.
+- [x] Preserve explicit cross-context-graph rejection for direct `GRAPH <other-cg>` scoped queries.
+- [x] Preserve view-based routing behavior for `working-memory`, `shared-working-memory`, and `verified-memory`.
+- [x] Run focused query tests first, then targeted Node UI count tests if the query fix is isolated.
+
+Implementation note: explicit `GRAPH <...>` targets still use the static route-specific allow-list. Only `GRAPH ?g` bindings receive the expanded allow-list, and that expansion is limited to same-context root protocol content partitions, registered assertion graphs, and registered subgraph partitions. Subgraph metadata and private partitions remain excluded from broad graph-variable scans.
+
+## Verification Plan
+
+- [x] `pnpm --filter @origintrail-official/dkg-query exec vitest run test/query-engine.test.ts`
+- [x] `pnpm --filter @origintrail-official/dkg-query run build`
+- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/use-memory-entities-counts.test.ts test/context-graph-ia-overview.test.ts test/subgraph-overview-grid.test.ts test/sub-graph-bar-layer-scope.test.ts test/ui-api-pure.test.ts`
+- [ ] `pnpm --filter @origintrail-official/dkg-node-ui run build`
+- [ ] Generate a PR diff and run the local PR reviewer using `.codex/review-prompt.md` and `.codex/review-schema.json`.
+- [ ] Re-run any tests affected by valid local review findings.
+
+## Local PR Review Results
+
+Completed with the local `.codex` review prompt and schema against `pr-diff.patch`.
+
+- Round 1 found two valid blockers:
+  - `_verified_memory/staging/*` graphs were admitted by the widened `GRAPH ?g` allow-list.
+  - same-prefix child context graph roots could be misclassified as parent subgraph partitions.
+- Round 2 found one valid blocker:
+  - once a child context graph root was known, its child partitions such as `_shared_memory` and `_verified_memory/*` still needed to be excluded.
+- Round 3 returned `{"comments":[]}`.
+
+All valid findings were addressed with regression coverage before push.
+
+## Final Outcome
+
+Implemented on `codex/rc12-context-graph-counts` for PR into `release/rc.12`.
+
+PR opened: https://github.com/OriginTrail/dkg/pull/844
+
+Verification passed:
+
+- `pnpm --filter @origintrail-official/dkg-core run build` (refreshes local workspace declarations used by query build)
+- `pnpm --filter @origintrail-official/dkg-query exec vitest run test/query-engine.test.ts`
+- `pnpm --filter @origintrail-official/dkg-query run build`
+- `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/use-memory-entities-counts.test.ts test/context-graph-ia-overview.test.ts test/subgraph-overview-grid.test.ts test/sub-graph-bar-layer-scope.test.ts test/ui-api-pure.test.ts`
+- `pnpm --filter @origintrail-official/dkg-node-ui run build`
+- `git diff --check`
+
+The fix restores same-context-graph count visibility for registered WM/SWM/VM content partitions while preserving explicit cross-CG rejection, excluding VM staging graphs, and refusing slash-ID child context graph collisions.

--- a/agent-docs/rc12-context-graph-counts-regression.md
+++ b/agent-docs/rc12-context-graph-counts-regression.md
@@ -110,6 +110,8 @@ GitHub review follow-up for PR #844:
 - Valid finding: child context graph discovery trusted `?ctxGraph a dkg:ContextGraph` triples in arbitrary graphs. Fix: child discovery now accepts `rdf:type dkg:ContextGraph` or `registrationStatus` only from the candidate context graph's own `/_meta` graph.
 - Added regression tests proving legacy routes stay narrow, count callers opt in explicitly, and non-canonical user data cannot hide registered parent partitions.
 - Local follow-up review against `pr-diff.patch` returned `{"comments":[]}`.
+- Second Codex Review sweep found two valid follow-ups: typed `ApiClient.query()` did not expose/send `includeContextGraphPartitions`, and `/api/sub-graph/list` lacked route-level coverage for forwarding the flag. Both were fixed with focused CLI tests.
+- Local second follow-up review against `pr-diff.patch` returned `{"comments":[]}`.
 
 ## Final Outcome
 
@@ -126,6 +128,7 @@ Verification passed:
 - `pnpm --filter @origintrail-official/dkg-node-ui run build`
 - `pnpm --filter @origintrail-official/dkg-agent run build`
 - `pnpm --filter @origintrail-official/dkg run build`
+- `node node_modules/.pnpm/vitest@4.0.18_.../node_modules/vitest/vitest.mjs run --config vitest.unit.config.ts test/api-client.test.ts test/context-graph-write-path-validation.test.ts`
 - Production UI build verified by direct Vite invocation after the local `node_modules/.bin/vite` shim was missing: `node node_modules/.pnpm/vite@6.4.2_.../node_modules/vite/bin/vite.js build`
 - `git diff --check`
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -9152,6 +9152,11 @@ export class DKGAgent {
       /** @deprecated Use includeSharedMemory */
       includeWorkspace?: boolean;
       /**
+       * Opt-in for dashboard/count queries that intentionally enumerate all
+       * registered public content partitions in a scoped `GRAPH ?g` scan.
+       */
+      includeContextGraphPartitions?: boolean;
+      /**
        * Opt-in: allow the scoped query to reference the context graph's own
        * `_private` partition (excluded from the scope guard's allow-set by
        * default). Used by the EPCIS events query, whose SPARQL always names
@@ -9377,6 +9382,7 @@ export class DKGAgent {
       excludeGraphPrefixes,
       graphSuffix: opts.graphSuffix,
       includeSharedMemory: opts.includeSharedMemory,
+      includeContextGraphPartitions: opts.includeContextGraphPartitions,
       includePrivate: opts.includePrivate,
       view: opts.view,
       agentAddress: agentAddressStr ?? (opts.view === 'working-memory' ? this.peerId : undefined),

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -800,9 +800,9 @@ export class ApiClient {
   /**
    * Run SPARQL via the daemon. `opts` covers the full /api/query surface —
    * memory-layer routing (`view`, `graphSuffix`, `verifiedGraph`,
-   * `subGraphName`, `includeSharedMemory`, `agentAddress`,
-   * `assertionName`), and P-13's `minTrust` (only meaningful on
-   * `view: "verified-memory"`; ignored elsewhere). `contextGraphId` stays
+   * `subGraphName`, `includeSharedMemory`, `includeContextGraphPartitions`,
+   * `agentAddress`, `assertionName`), and P-13's `minTrust` (only meaningful
+   * on `view: "verified-memory"`; ignored elsewhere). `contextGraphId` stays
    * in the 2nd positional slot for backwards compatibility.
    */
   async query(
@@ -811,6 +811,7 @@ export class ApiClient {
     opts?: {
       graphSuffix?: string;
       includeSharedMemory?: boolean;
+      includeContextGraphPartitions?: boolean;
       view?: 'working-memory' | 'shared-working-memory' | 'verified-memory';
       agentAddress?: string;
       assertionName?: string;
@@ -832,6 +833,7 @@ export class ApiClient {
       contextGraphId,
       graphSuffix: opts?.graphSuffix,
       includeSharedMemory: opts?.includeSharedMemory,
+      includeContextGraphPartitions: opts?.includeContextGraphPartitions,
       view: opts?.view,
       agentAddress: opts?.agentAddress,
       assertionName: opts?.assertionName,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -766,7 +766,10 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
           WHERE { GRAPH ?g { ?s ?p ?o } }
           GROUP BY ?g
         `;
-        const result = await agent.query(sparql, { contextGraphId: contextGraphId! });
+        const result = await agent.query(sparql, {
+          contextGraphId: contextGraphId!,
+          includeContextGraphPartitions: true,
+        });
         const prefix = `did:dkg:context-graph:${contextGraphId}/`;
         const parseCount = (v: any) => {
           if (v === undefined || v === null) return 0;

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -404,6 +404,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
     const graphSuffix = parsed.graphSuffix;
     const includeSharedMemory =
       parsed.includeSharedMemory ?? parsed.includeWorkspace;
+    const includeContextGraphPartitions = parsed.includeContextGraphPartitions === true;
     const view = parsed.view;
     const agentAddress = parsed.agentAddress;
     // the
@@ -584,6 +585,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
         contextGraphId,
         graphSuffix,
         includeSharedMemory,
+        includeContextGraphPartitions,
         view,
         agentAddress,
         verifiedGraph,

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -152,14 +152,17 @@ describe('ApiClient', () => {
       expect(body.quads).toHaveLength(1);
     });
 
-    it('query() sends sparql and optional context graph id', async () => {
+    it('query() sends sparql, optional context graph id, and partition opt-in', async () => {
       const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body: { result: [] } });
       globalThis.fetch = fetch;
-      await client.query('SELECT * { ?s ?p ?o }', 'my-contextGraph');
+      await client.query('SELECT * { ?s ?p ?o }', 'my-contextGraph', {
+        includeContextGraphPartitions: true,
+      });
 
       const body = JSON.parse(calls[0].opts.body as string);
       expect(body.sparql).toBe('SELECT * { ?s ?p ?o }');
       expect(body.contextGraphId).toBe('my-contextGraph');
+      expect(body.includeContextGraphPartitions).toBe(true);
     });
 
     // LU-2 (SPEC_CG_MEMORY_MODEL): the legacy participantIdentityIds /

--- a/packages/cli/test/context-graph-write-path-validation.test.ts
+++ b/packages/cli/test/context-graph-write-path-validation.test.ts
@@ -63,6 +63,7 @@ describe('context graph write-path validation', () => {
       kaManifest: [],
     }));
     const createSubGraph = vi.fn(async () => undefined);
+    const listSubGraphs = vi.fn(async () => []);
     const registerContextGraph = vi.fn(async () => ({ onChainId: '5' }));
     const inviteToContextGraph = vi.fn(async () => undefined);
     const inviteAgentToContextGraph = vi.fn(async () => undefined);
@@ -81,6 +82,7 @@ describe('context graph write-path validation', () => {
       ),
       resolveAgentByToken: vi.fn(() => undefined),
       peerId: 'peer-test',
+      query,
       assertion: {
         create,
         write,
@@ -111,6 +113,7 @@ describe('context graph write-path validation', () => {
         ),
       ),
       createSubGraph,
+      listSubGraphs,
       store: {
         insert: storeInsert,
       },
@@ -134,6 +137,7 @@ describe('context graph write-path validation', () => {
         rejectJoinRequest,
         assertContextGraphOwner,
         createSubGraph,
+        listSubGraphs,
         storeInsert,
       },
     };
@@ -218,6 +222,12 @@ describe('context graph write-path validation', () => {
     return { status: res.status, body: json };
   }
 
+  async function get(path: string) {
+    const res = await fetch(`${baseUrl}${path}`);
+    const json = await res.json().catch(() => null);
+    return { status: res.status, body: json };
+  }
+
   it('accepts an exact existing canonical id for assertion create', async () => {
     const agent = makeAgent();
     await startRoutes(agent);
@@ -229,6 +239,46 @@ describe('context graph write-path validation', () => {
 
     expect(result.status).toBe(200);
     expect(agent.calls.create).toHaveBeenCalledWith(CANONICAL_CG, 'draft', undefined);
+  });
+
+  it('sub-graph list opts into same-CG partition counts', async () => {
+    const agent = makeAgent();
+    agent.calls.listSubGraphs.mockResolvedValueOnce([
+      {
+        name: 'code',
+        uri: `${CANONICAL_URI}/code`,
+        description: 'Code sub-graph',
+        createdBy: CALLER,
+      },
+    ]);
+    agent.calls.query.mockResolvedValueOnce({
+      bindings: [
+        {
+          g: `${CANONICAL_URI}/code/_shared_memory`,
+          entities: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+          triples: '"5"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        },
+      ],
+    });
+    await startRoutes(agent);
+
+    const result = await get(`/api/sub-graph/list?contextGraphId=${encodeURIComponent(CANONICAL_CG)}`);
+
+    expect(result.status).toBe(200);
+    expect(agent.calls.query).toHaveBeenCalledWith(
+      expect.stringContaining('GRAPH ?g'),
+      {
+        contextGraphId: CANONICAL_CG,
+        includeContextGraphPartitions: true,
+      },
+    );
+    expect(result.body.subGraphs).toEqual([
+      expect.objectContaining({
+        name: 'code',
+        entityCount: 2,
+        tripleCount: 5,
+      }),
+    ]);
   });
 
   it('accepts a full context graph DID and passes the canonical id downstream', async () => {

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -71,8 +71,7 @@ export interface MemoryData {
   counts: { wm: number; swm: number; vm: number; total: number };
   loading: boolean;
   error: string | null;
-  /** True when some (but not all) layer queries failed — counts are
-   *  incomplete but not absent. `error` stays null in this case. */
+  /** True when counts are lower bounds because a layer failed or clipped at its query limit. */
   partial: boolean;
   /** Per-layer query status so UI can distinguish a VM miss from WM/SWM failures. */
   layerStatus: Record<MemoryLayerKey, MemoryLayerStatus>;
@@ -326,7 +325,16 @@ export function subGraphOf(gUri: string, cgId: string): string | undefined {
   return seg;
 }
 
-interface LayerResult { triples: Triple[]; ok: boolean }
+interface LayerResult { triples: Triple[]; ok: boolean; truncated: boolean }
+
+interface QueryLayerOptions {
+  view?: string;
+  includeSharedMemory?: boolean;
+  graphSuffix?: string;
+  includeContextGraphPartitions?: boolean;
+  /** Local-only result limit used to detect lower-bound totals; never sent to /api/query. */
+  layerLimit?: number;
+}
 
 const LOADING_LAYER_STATUS: Record<MemoryLayerKey, MemoryLayerStatus> = {
   wm: 'loading',
@@ -343,15 +351,10 @@ const ERROR_LAYER_STATUS: Record<MemoryLayerKey, MemoryLayerStatus> = {
 async function queryLayer(
   sparql: string,
   contextGraphId: string,
-  opts?: {
-    view?: string;
-    includeSharedMemory?: boolean;
-    graphSuffix?: string;
-    includeContextGraphPartitions?: boolean;
-  },
+  opts?: QueryLayerOptions,
 ): Promise<LayerResult> {
   // Never throws and never loses the failed-vs-empty distinction: it
-  // returns `{ triples, ok }`. A failed/unreachable `/api/query` yields
+  // returns `{ triples, ok, truncated }`. A failed/unreachable `/api/query` yields
   // `{ triples: [], ok: false }` so triple data still degrades to
   // "empty" for every consumer (unchanged behavior), while `ok=false`
   // lets the hook compute `partial` UNCONDITIONALLY — previously it was
@@ -363,9 +366,11 @@ async function queryLayer(
     // here coalesces with any other concurrently-mounted instance of
     // this hook (e.g. Dashboard card + ProjectView both subscribed to
     // the same CG). One underlying fetch instead of N for each layer.
-    const body: any = { sparql, contextGraphId, ...opts };
+    const { layerLimit, ...requestOpts } = opts ?? {};
+    const body: any = { sparql, contextGraphId, ...requestOpts };
     const data: any = await postQueryDeduped(body);
     const bindings = data?.result?.bindings ?? data?.results?.bindings ?? [];
+    const truncated = typeof layerLimit === 'number' && bindings.length >= layerLimit;
     const triples = bindings
       .map((row: any) => {
         const g = bv(row.g);
@@ -377,9 +382,9 @@ async function queryLayer(
         };
       })
       .filter((t: Triple) => t.subject && t.predicate && t.object);
-    return { triples, ok: true };
+    return { triples, ok: true, truncated };
   } catch {
-    return { triples: [], ok: false };
+    return { triples: [], ok: false, truncated: false };
   }
 }
 
@@ -613,9 +618,9 @@ export function useMemoryEntities(
       // single-layer 500 never blanks the others for any consumer.
       const countScope = { includeContextGraphPartitions: true };
       const [wmR, swmR, vmR] = await Promise.all([
-        queryLayer(wmSparql(contextGraphId), contextGraphId, countScope),
-        queryLayer(swmSparql(contextGraphId), contextGraphId, countScope),
-        queryLayer(vmSparql(contextGraphId), contextGraphId, countScope),
+        queryLayer(wmSparql(contextGraphId), contextGraphId, { ...countScope, layerLimit: WM_LIMIT }),
+        queryLayer(swmSparql(contextGraphId), contextGraphId, { ...countScope, layerLimit: SWM_LIMIT }),
+        queryLayer(vmSparql(contextGraphId), contextGraphId, { ...countScope, layerLimit: VM_LIMIT }),
       ]);
 
       if (version !== versionRef.current) return;
@@ -632,14 +637,18 @@ export function useMemoryEntities(
         swm: swmR.ok ? 'ok' : 'error',
         vm: vmR.ok ? 'ok' : 'error',
       });
-      const failed = [wmR, swmR, vmR].filter(r => !r.ok).length;
+      const layerResults = [wmR, swmR, vmR];
+      const failed = layerResults.filter(r => !r.ok).length;
+      const clipped = layerResults.some(r => r.truncated);
       // `partial` is computed UNCONDITIONALLY for every caller — it was
       // previously dead unless a caller opted in, making truncated
       // counts look exact in MemoryStackView/ProjectView (Codex).
+      // With same-CG partition scans, a successful layer can also hit
+      // its fixed LIMIT; those counts are lower bounds, not exact totals.
       // Whether a *total* failure also escalates to a hard `error`
       // (dashboard assetCount fallback / views' error screen) stays the
       // configurable part via `signalErrors`.
-      setPartial(failed > 0 && failed < 3);
+      setPartial((failed > 0 && failed < 3) || clipped);
       setError(signalErrors && failed === 3 ? 'Failed to load memory data' : null);
     } catch (err: any) {
       if (version === versionRef.current) {

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -343,7 +343,12 @@ const ERROR_LAYER_STATUS: Record<MemoryLayerKey, MemoryLayerStatus> = {
 async function queryLayer(
   sparql: string,
   contextGraphId: string,
-  opts?: { view?: string; includeSharedMemory?: boolean; graphSuffix?: string },
+  opts?: {
+    view?: string;
+    includeSharedMemory?: boolean;
+    graphSuffix?: string;
+    includeContextGraphPartitions?: boolean;
+  },
 ): Promise<LayerResult> {
   // Never throws and never loses the failed-vs-empty distinction: it
   // returns `{ triples, ok }`. A failed/unreachable `/api/query` yields
@@ -606,10 +611,11 @@ export function useMemoryEntities(
       // queryLayer never throws — it returns { triples, ok }. We keep
       // whatever layers succeeded (failed layers contribute []), so a
       // single-layer 500 never blanks the others for any consumer.
+      const countScope = { includeContextGraphPartitions: true };
       const [wmR, swmR, vmR] = await Promise.all([
-        queryLayer(wmSparql(contextGraphId), contextGraphId),
-        queryLayer(swmSparql(contextGraphId), contextGraphId),
-        queryLayer(vmSparql(contextGraphId), contextGraphId),
+        queryLayer(wmSparql(contextGraphId), contextGraphId, countScope),
+        queryLayer(swmSparql(contextGraphId), contextGraphId, countScope),
+        queryLayer(vmSparql(contextGraphId), contextGraphId, countScope),
       ]);
 
       if (version !== versionRef.current) return;

--- a/packages/node-ui/test/use-memory-entities-counts.test.ts
+++ b/packages/node-ui/test/use-memory-entities-counts.test.ts
@@ -126,6 +126,11 @@ describe('useMemoryEntities canonical layer counts', () => {
     expect(el.getAttribute('data-current-layers')).toContain('urn:test:full-pipeline:verified');
     expect(el.getAttribute('data-current-layers')).not.toContain('urn:test:object-only');
 
+    const queryBodies = vi.mocked(fetch).mock.calls
+      .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { sparql?: string; includeContextGraphPartitions?: boolean });
+    expect(queryBodies).toHaveLength(3);
+    expect(queryBodies.every(body => body.includeContextGraphPartitions === true)).toBe(true);
+
     const vmRequest = vi.mocked(fetch).mock.calls
       .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { sparql?: string })
       .find(body => body.sparql?.includes('_verified_memory_meta'));

--- a/packages/node-ui/test/use-memory-entities-partial.test.ts
+++ b/packages/node-ui/test/use-memory-entities-partial.test.ts
@@ -26,6 +26,10 @@ function triple(subject: string, graph: string) {
   return { s: { value: subject }, p: { value: RDF_TYPE }, o: { value: 'http://schema.org/Thing' }, g: { value: graph } };
 }
 
+function sparqlLimit(sparql: string): number {
+  return Number(sparql.match(/\bLIMIT\s+(\d+)/i)?.[1] ?? 0);
+}
+
 function Probe({ id }: { id: string }) {
   // Dashboard-style consumer: opts into failed-vs-empty signalling.
   const m = useMemoryEntities(id, { signalErrors: true });
@@ -38,6 +42,7 @@ function Probe({ id }: { id: string }) {
     'data-swm-status': m.layerStatus.swm,
     'data-vm-status': m.layerStatus.vm,
     'data-wm': String(m.counts.wm),
+    'data-swm': String(m.counts.swm),
     'data-vm': String(m.counts.vm),
     'data-total': String(m.counts.total),
   });
@@ -48,8 +53,10 @@ async function flush() { await act(async () => { await Promise.resolve(); await 
 describe('useMemoryEntities — partial layer failure', () => {
   let container: HTMLDivElement;
   let root: Root;
+  let scenario: 'swm-error' | 'swm-limit';
 
   beforeEach(() => {
+    scenario = 'swm-error';
     MockEventSource.instances = [];
     (globalThis as any).EventSource = MockEventSource;
     (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -72,7 +79,16 @@ describe('useMemoryEntities — partial layer failure', () => {
       const isVm = sparql.includes('_verified_memory_meta');
       const isSwm = !isVm && sparql.includes('STRENDS(STR(?g), "/_shared_memory")');
       const isWm = !isVm && !isSwm;
-      if (isSwm) return { ok: false, status: 500, json: async () => ({}) } as Response;
+      if (isSwm && scenario === 'swm-error') {
+        return { ok: false, status: 500, json: async () => ({}) } as Response;
+      }
+      if (isSwm && scenario === 'swm-limit') {
+        const limit = sparqlLimit(sparql);
+        return { ok: true, json: async () => ({ result: { bindings: Array.from(
+          { length: limit },
+          () => triple(`urn:${contextGraphId}:swm-limited`, `did:dkg:context-graph:${contextGraphId}/n/_shared_memory`),
+        ) } }) } as Response;
+      }
       if (isWm) {
         return { ok: true, json: async () => ({ result: { bindings: [
           triple(`urn:${contextGraphId}:wm-1`, `did:dkg:context-graph:${contextGraphId}/n/assertion/a/x-1`),
@@ -108,5 +124,25 @@ describe('useMemoryEntities — partial layer failure', () => {
     expect(el.getAttribute('data-wm')).toBe('2');
     expect(el.getAttribute('data-vm')).toBe('1');
     expect(Number(el.getAttribute('data-total'))).toBeGreaterThan(0);
+  });
+
+  it('marks counts partial when a successful layer reaches its query limit', async () => {
+    scenario = 'swm-limit';
+
+    await act(async () => { root.render(React.createElement(Probe, { id: 'cg-limited' })); });
+    await flush();
+
+    const el = container.querySelector('#probe')!;
+    expect(el.getAttribute('data-loading')).toBe('false');
+    expect(el.getAttribute('data-error')).toBe('null');
+    expect(el.getAttribute('data-partial')).toBe('true');
+    expect(el.getAttribute('data-wm-status')).toBe('ok');
+    expect(el.getAttribute('data-swm-status')).toBe('ok');
+    expect(el.getAttribute('data-vm-status')).toBe('ok');
+    expect(el.getAttribute('data-swm')).toBe('1');
+
+    const queryBodies = vi.mocked(fetch).mock.calls
+      .map(([, init]) => JSON.parse(String(init?.body ?? '{}')) as { layerLimit?: number });
+    expect(queryBodies.every(body => body.layerLimit === undefined)).toBe(true);
   });
 });

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -170,6 +170,9 @@ export function resolveViewGraphs(
 export class DKGQueryEngine implements QueryEngine {
   private readonly store: TripleStore;
   private readonly graphManager: GraphManager;
+  // Collapse the dashboard's parallel WM/SWM/VM count scans without retaining
+  // a completed allow-list that could miss newly-created assertion graphs.
+  private readonly scopedContentGraphAllowListInFlight = new Map<string, Promise<string[]>>();
 
   constructor(store: TripleStore) {
     this.store = store;
@@ -527,8 +530,46 @@ export class DKGQueryEngine implements QueryEngine {
     }
 
     const allowed = new Set(staticAllowedGraphs);
-    const registeredSubGraphs = opts.subGraphName
-      ? new Set([opts.subGraphName])
+    const scopedContentGraphs = await this.resolveScopedContentGraphAllowList(
+      contextGraphId,
+      opts.subGraphName,
+    );
+    for (const graph of scopedContentGraphs) {
+      allowed.add(graph);
+    }
+
+    return [...allowed];
+  }
+
+  private async resolveScopedContentGraphAllowList(
+    contextGraphId: string,
+    subGraphName?: string,
+  ): Promise<string[]> {
+    const key = JSON.stringify([contextGraphId, subGraphName ?? null]);
+    const cached = this.scopedContentGraphAllowListInFlight.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const promise = this.discoverScopedContentGraphAllowList(contextGraphId, subGraphName);
+    this.scopedContentGraphAllowListInFlight.set(key, promise);
+
+    try {
+      return await promise;
+    } finally {
+      if (this.scopedContentGraphAllowListInFlight.get(key) === promise) {
+        this.scopedContentGraphAllowListInFlight.delete(key);
+      }
+    }
+  }
+
+  private async discoverScopedContentGraphAllowList(
+    contextGraphId: string,
+    subGraphName?: string,
+  ): Promise<string[]> {
+    const allowed = new Set<string>();
+    const registeredSubGraphs = subGraphName
+      ? new Set([subGraphName])
       : await this.discoverRegisteredSubGraphNames(contextGraphId);
     const registeredAssertionGraphs = await this.discoverRegisteredAssertionGraphs(contextGraphId);
     const knownChildContextGraphs = await this.discoverKnownChildContextGraphUris(contextGraphId);
@@ -542,7 +583,7 @@ export class DKGQueryEngine implements QueryEngine {
           registeredSubGraphs,
           registeredAssertionGraphs,
           knownChildContextGraphs,
-          opts.subGraphName,
+          subGraphName,
         )
       ) {
         allowed.add(graph);

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -280,39 +280,17 @@ export class DKGQueryEngine implements QueryEngine {
           ]
         : [];
       const explicitAllowedGraphs = [...allowedGraphs, ...metaAllowList, ...privateAllowList];
-      const variableAllowedGraphs = [...allowedGraphs, ...metaAllowList, ...privateAllowList];
-      // Codex r5 RED on #776: dynamic sub-graph metadata enumeration
-      // (originally added to fix `useSwmAttributions` /
-      // `useVerifiedMemoryAnchors` / `useVerifiedEntityIdentity`
-      // `GRAPH ?g` enumeration over `*_shared_memory_meta`)
-      // fundamentally cannot tell, *from URI structure alone*,
-      // whether a candidate URI like
-      // `did:dkg:context-graph:<cg>/<seg>/_meta` is sub-graph `<seg>`
-      // metadata of `<cg>` (admit) or the root `_meta` of a separate
-      // registered CG `<cg>/<seg>` (cross-CG leak). The collision is
-      // possible whether or not `<cg>` itself contains `/`, because
-      // `validateContextGraphId` allows `/` in CG ids, and the URI
-      // scheme uses `/` as the only sub-graph separator. Resolving
-      // the ambiguity requires a CG-registry lookup on every scoped
-      // `GRAPH ?g` query — and threading a registry interface
-      // through the engine is out of scope for the #774 F4+F3 fix
-      // this PR is targeting.
-      //
-      // The static `metaAllowList` above (`<cg>/_meta` +
-      // `<cg>/_shared_memory_meta`, or the explicit
-      // `<cg>/<sub>/...meta` when `subGraphName` is supplied) covers
-      // exactly the use cases #774 needs (invite-flow curator probe,
-      // SWM-ownership workspaceOwner probe). UI hooks that enumerate
-      // sub-graph metadata via `GRAPH ?g + CONTAINS(...)` are NOT
-      // exercised by the SWM-ownership / invite-flow devnet tests
-      // and remain a tracked follow-up: the proper fix is a
-      // CG-registry-aware allow-set construction so wallet-scoped
-      // and id-prefix-colliding CGs can be authoritatively
-      // disambiguated. Until that lands, we keep the variable allow
-      // set strictly equal to the explicit allow set — same-CG `?g`
-      // bindings against the root `_meta` / `_shared_memory_meta`
-      // work, and there is no path through this branch that can
-      // leak another CG's metadata.
+      const variableAllowedGraphs = collectGraphVariables(sparql).length > 0
+        ? await this.resolveScopedGraphVariableAllowList(
+            effectiveContextGraphId,
+            explicitAllowedGraphs,
+            { subGraphName, isSwmOnlyRoute },
+          )
+        : explicitAllowedGraphs;
+      // Explicit GRAPH IRIs remain limited to the static route-specific
+      // allow-list. GRAPH variables are additionally constrained to known
+      // same-CG content partitions so dashboard/count queries can enumerate
+      // WM/SWM/VM data without dropping back to unscoped store access.
       assertExplicitGraphIrisAllowed(sparql, explicitAllowedGraphs);
       sparql = constrainGraphVariablesToAllowedSet(sparql, variableAllowedGraphs);
     }
@@ -546,6 +524,111 @@ export class DKGQueryEngine implements QueryEngine {
     );
   }
 
+  private async resolveScopedGraphVariableAllowList(
+    contextGraphId: string,
+    staticAllowedGraphs: string[],
+    opts: { subGraphName?: string; isSwmOnlyRoute: boolean },
+  ): Promise<string[]> {
+    if (opts.isSwmOnlyRoute) {
+      return staticAllowedGraphs;
+    }
+
+    const allowed = new Set(staticAllowedGraphs);
+    const registeredSubGraphs = opts.subGraphName
+      ? new Set([opts.subGraphName])
+      : await this.discoverRegisteredSubGraphNames(contextGraphId);
+    const registeredAssertionGraphs = await this.discoverRegisteredAssertionGraphs(contextGraphId);
+    const knownChildContextGraphs = await this.discoverKnownChildContextGraphUris(contextGraphId);
+    const allGraphs = await this.store.listGraphs();
+
+    for (const graph of allGraphs) {
+      if (
+        isScopedContentGraph(
+          graph,
+          contextGraphId,
+          registeredSubGraphs,
+          registeredAssertionGraphs,
+          knownChildContextGraphs,
+          opts.subGraphName,
+        )
+      ) {
+        allowed.add(graph);
+      }
+    }
+
+    return [...allowed];
+  }
+
+  private async discoverRegisteredSubGraphNames(contextGraphId: string): Promise<Set<string>> {
+    const names = new Set<string>();
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?name WHERE {
+        GRAPH <${assertSafeIri(metaGraph)}> {
+          ?subGraph a <http://dkg.io/ontology/SubGraph> ;
+                    <http://schema.org/name> ?name .
+        }
+      }`,
+    );
+    if (result.type !== 'bindings') return names;
+
+    for (const row of result.bindings) {
+      const name = stripSparqlLiteralValue(row['name']);
+      if (validateSubGraphName(name).valid) {
+        names.add(name);
+      }
+    }
+    return names;
+  }
+
+  private async discoverRegisteredAssertionGraphs(contextGraphId: string): Promise<Set<string>> {
+    const graphs = new Set<string>();
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?graph WHERE {
+        GRAPH <${assertSafeIri(metaGraph)}> {
+          ?assertion <http://dkg.io/ontology/assertionGraph> ?graph .
+        }
+      }`,
+    );
+    if (result.type !== 'bindings') return graphs;
+
+    for (const row of result.bindings) {
+      const graph = row['graph'];
+      if (typeof graph === 'string' && graph.length > 0) {
+        graphs.add(graph);
+      }
+    }
+    return graphs;
+  }
+
+  private async discoverKnownChildContextGraphUris(contextGraphId: string): Promise<Set<string>> {
+    const rootPrefix = `${contextGraphDataUri(contextGraphId)}/`;
+    const result = await this.store.query(
+      `SELECT DISTINCT ?ctxGraph WHERE {
+        GRAPH ?g {
+          {
+            ?ctxGraph <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://dkg.network/ontology#ContextGraph> .
+          } UNION {
+            ?ctxGraph <https://dkg.network/ontology#registrationStatus> ?status .
+            FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_meta"))
+          }
+        }
+        FILTER(STRSTARTS(STR(?ctxGraph), "${escapeSparqlLiteral(rootPrefix)}"))
+      }`,
+    );
+    const uris = new Set<string>();
+    if (result.type !== 'bindings') return uris;
+
+    for (const row of result.bindings) {
+      const uri = row['ctxGraph'];
+      if (typeof uri === 'string' && uri.length > 0) {
+        uris.add(uri);
+      }
+    }
+    return uris;
+  }
+
   private async execAndNormalize(sparql: string): Promise<QueryResult> {
     const result = await this.store.query(sparql);
 
@@ -637,6 +720,88 @@ export class DKGQueryEngine implements QueryEngine {
     return { bindings: allBindings };
   }
 
+}
+
+function isScopedContentGraph(
+  graph: string,
+  contextGraphId: string,
+  registeredSubGraphs: Set<string>,
+  registeredAssertionGraphs: Set<string>,
+  knownChildContextGraphs: Set<string>,
+  subGraphName?: string,
+): boolean {
+  const root = contextGraphDataUri(contextGraphId);
+  if (graph === root) return !subGraphName;
+  if (!graph.startsWith(`${root}/`)) return false;
+  if (isKnownChildContextGraphPartition(graph, knownChildContextGraphs)) return false;
+
+  const tail = graph.slice(root.length + 1);
+  if (
+    !tail ||
+    isMetadataGraphTail(tail) ||
+    isPrivateGraphTail(tail) ||
+    isRulesGraphTail(tail) ||
+    isStagingGraphTail(tail)
+  ) {
+    return false;
+  }
+
+  if (!subGraphName) {
+    if (tail === '_shared_memory') return true;
+    if (tail.startsWith('_verified_memory/')) return !isMetadataGraphTail(tail);
+    if (tail.startsWith('assertion/')) return registeredAssertionGraphs.has(graph);
+  }
+
+  const slash = tail.indexOf('/');
+  const firstSegment = slash >= 0 ? tail.slice(0, slash) : tail;
+  const remaining = slash >= 0 ? tail.slice(slash + 1) : '';
+  if (subGraphName && firstSegment !== subGraphName) return false;
+  if (!registeredSubGraphs.has(firstSegment) || !validateSubGraphName(firstSegment).valid) {
+    return false;
+  }
+
+  if (!remaining) return true;
+  if (remaining === '_shared_memory') return true;
+  if (remaining.startsWith('_verified_memory/')) return !isMetadataGraphTail(remaining);
+  if (remaining.startsWith('assertion/')) return registeredAssertionGraphs.has(graph);
+  return false;
+}
+
+function isMetadataGraphTail(tail: string): boolean {
+  return (
+    tail === '_meta' ||
+    tail === '_shared_memory_meta' ||
+    tail.endsWith('/_meta') ||
+    tail.endsWith('/_shared_memory_meta') ||
+    tail.includes('/_meta/') ||
+    tail.includes('/_shared_memory_meta/')
+  );
+}
+
+function isPrivateGraphTail(tail: string): boolean {
+  return tail === '_private' || tail.startsWith('_private/') || tail.endsWith('/_private') || tail.includes('/_private/');
+}
+
+function isRulesGraphTail(tail: string): boolean {
+  return tail === '_rules' || tail.startsWith('_rules/') || tail.endsWith('/_rules') || tail.includes('/_rules/');
+}
+
+function isKnownChildContextGraphPartition(graph: string, knownChildContextGraphs: Set<string>): boolean {
+  for (const childContextGraph of knownChildContextGraphs) {
+    if (graph === childContextGraph || graph.startsWith(`${childContextGraph}/`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isStagingGraphTail(tail: string): boolean {
+  return tail.startsWith('_verified_memory/staging/') || tail.includes('/_verified_memory/staging/');
+}
+
+function stripSparqlLiteralValue(value: string | undefined): string {
+  if (!value) return '';
+  return value.replace(/^"/, '').replace(/"(?:\^\^<[^>]+>|@[a-zA-Z-]+)?$/, '');
 }
 
 function assertNoCallerDatasetClauses(sparql: string): void {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -229,20 +229,11 @@ export class DKGQueryEngine implements QueryEngine {
       // `/context/<sub>/_meta` shape produced by `contextGraphMetaUri`
       // when a subGraphId is passed.
       //
-      // The widening applies to BOTH the explicit-IRI allow set
-      // (`assertExplicitGraphIrisAllowed`) AND the graph-variable
-      // allow set (`constrainGraphVariablesToAllowedSet`). The UI
-      // hooks `useSwmAttributions`, `useVerifiedMemoryAnchors` and
-      // `useVerifiedEntityIdentity` enumerate sub-graph metadata via
-      // `GRAPH ?g { … } FILTER(CONTAINS(STR(?g), "_shared_memory_meta"))`
-      // with `contextGraphId` scope only — the strict variable allow
-      // (Codex r2 on #776) was breaking those callers in addition to
-      // the bash-test paths. Authenticated CG-scoped callers already
-      // have read access to that CG, so widening the variable allow
-      // to the same set as the explicit allow does not enlarge the
-      // privacy boundary; the boundary is the `contextGraphId` scope
-      // itself. Cross-CG access is still rejected by the data-graph
-      // allow construction above.
+      // Metadata graphs are always part of the scoped explicit allow-set:
+      // UI helpers enumerate sub-graph metadata with `GRAPH ?g` under a
+      // contextGraphId, while explicit GRAPH IRIs still need the same static
+      // route checks. Broader content-partition scans are handled later and
+      // require an explicit count-query opt-in.
       const subGraphName = options?.subGraphName;
       const isSwmOnlyRoute = options?.graphSuffix === '_shared_memory';
       const metaAllowList = [
@@ -280,7 +271,9 @@ export class DKGQueryEngine implements QueryEngine {
           ]
         : [];
       const explicitAllowedGraphs = [...allowedGraphs, ...metaAllowList, ...privateAllowList];
-      const variableAllowedGraphs = collectGraphVariables(sparql).length > 0
+      const shouldExpandGraphVariables =
+        options?.includeContextGraphPartitions === true && collectGraphVariables(sparql).length > 0;
+      const variableAllowedGraphs = shouldExpandGraphVariables
         ? await this.resolveScopedGraphVariableAllowList(
             effectiveContextGraphId,
             explicitAllowedGraphs,
@@ -288,9 +281,9 @@ export class DKGQueryEngine implements QueryEngine {
           )
         : explicitAllowedGraphs;
       // Explicit GRAPH IRIs remain limited to the static route-specific
-      // allow-list. GRAPH variables are additionally constrained to known
-      // same-CG content partitions so dashboard/count queries can enumerate
-      // WM/SWM/VM data without dropping back to unscoped store access.
+      // allow-list. GRAPH variables only gain known same-CG content
+      // partitions for callers that explicitly opt into broad count scans;
+      // legacy scoped routes keep their selected memory-layer contract.
       assertExplicitGraphIrisAllowed(sparql, explicitAllowedGraphs);
       sparql = constrainGraphVariablesToAllowedSet(sparql, variableAllowedGraphs);
     }
@@ -611,9 +604,9 @@ export class DKGQueryEngine implements QueryEngine {
             ?ctxGraph <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://dkg.network/ontology#ContextGraph> .
           } UNION {
             ?ctxGraph <https://dkg.network/ontology#registrationStatus> ?status .
-            FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_meta"))
           }
         }
+        FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_meta"))
         FILTER(STRSTARTS(STR(?ctxGraph), "${escapeSparqlLiteral(rootPrefix)}"))
       }`,
     );

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -17,6 +17,14 @@ export interface QueryOptions {
   /** @deprecated Use includeSharedMemory */
   includeWorkspace?: boolean;
   /**
+   * Opt-in for aggregate/count callers that intentionally need scoped
+   * `GRAPH ?g` queries to enumerate all registered public content partitions
+   * in the same context graph (root data, registered assertion graphs, SWM,
+   * VM, and registered sub-graph content). Legacy scoped routes stay limited
+   * to their selected graph set unless this is true.
+   */
+  includeContextGraphPartitions?: boolean;
+  /**
    * Opt-in: allow the scoped query to explicitly reference the context
    * graph's own `_private` partition (`<cg>/_private`, or the sub-graph
    * private graph when `subGraphName` is set). The scope guard excludes

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -13,6 +13,7 @@ const DKG_ASSERTION_GRAPH = 'http://dkg.io/ontology/assertionGraph';
 const DKG_CONTEXT_GRAPH = 'https://dkg.network/ontology#ContextGraph';
 const DKG_REGISTRATION_STATUS = 'https://dkg.network/ontology#registrationStatus';
 const SCHEMA_NAME = 'http://schema.org/name';
+const COUNT_NAME = 'http://example.com/countName';
 
 function q(s: string, p: string, o: string, g = GRAPH): Quad {
   return { subject: s, predicate: p, object: o, graph: g };
@@ -857,6 +858,61 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings.map((row) => row['g']).sort()).toEqual([GRAPH, sharedMemoryGraph].sort());
   });
 
+  it('keeps legacy GRAPH-variable scans on the selected data graph without partition opt-in', async () => {
+    const rootAssertionGraph = `${GRAPH}/assertion/0xAgent/root-draft`;
+    const rootVerifiedGraph = `${GRAPH}/_verified_memory/vm-1`;
+    const subGraph = `${GRAPH}/code`;
+    const subGraphSharedMemoryGraph = `${GRAPH}/code/_shared_memory`;
+
+    await store.insert([
+      ...subGraphRegistration('code'),
+      assertionGraphRegistration(rootAssertionGraph, 'root-draft'),
+      q('urn:root:data', COUNT_NAME, '"RootData"', GRAPH),
+      q('urn:root:wm', COUNT_NAME, '"RootWM"', rootAssertionGraph),
+      q('urn:root:vm', COUNT_NAME, '"RootVM"', rootVerifiedGraph),
+      q('urn:code:data', COUNT_NAME, '"CodeData"', subGraph),
+      q('urn:code:swm', COUNT_NAME, '"CodeSWM"', subGraphSharedMemoryGraph),
+    ]);
+
+    const result = await engine.query(
+      `SELECT ?g ?name WHERE { GRAPH ?g { ?s <${COUNT_NAME}> ?name } } ORDER BY ?name`,
+      { contextGraphId: CONTEXT_GRAPH },
+    );
+
+    expect(result.bindings).toEqual([
+      { g: GRAPH, name: '"RootData"' },
+    ]);
+  });
+
+  it('keeps includeSharedMemory GRAPH-variable scans on data plus SWM without partition opt-in', async () => {
+    const rootSharedMemoryGraph = `${GRAPH}/_shared_memory`;
+    const rootAssertionGraph = `${GRAPH}/assertion/0xAgent/root-draft`;
+    const rootVerifiedGraph = `${GRAPH}/_verified_memory/vm-1`;
+    const subGraph = `${GRAPH}/code`;
+    const subGraphSharedMemoryGraph = `${GRAPH}/code/_shared_memory`;
+
+    await store.insert([
+      ...subGraphRegistration('code'),
+      assertionGraphRegistration(rootAssertionGraph, 'root-draft'),
+      q('urn:root:data', COUNT_NAME, '"RootData"', GRAPH),
+      q('urn:root:swm', COUNT_NAME, '"RootSWM"', rootSharedMemoryGraph),
+      q('urn:root:wm', COUNT_NAME, '"RootWM"', rootAssertionGraph),
+      q('urn:root:vm', COUNT_NAME, '"RootVM"', rootVerifiedGraph),
+      q('urn:code:data', COUNT_NAME, '"CodeData"', subGraph),
+      q('urn:code:swm', COUNT_NAME, '"CodeSWM"', subGraphSharedMemoryGraph),
+    ]);
+
+    const result = await engine.query(
+      `SELECT ?g ?name WHERE { GRAPH ?g { ?s <${COUNT_NAME}> ?name } } ORDER BY ?name`,
+      { contextGraphId: CONTEXT_GRAPH, includeSharedMemory: true },
+    );
+
+    expect(result.bindings).toEqual([
+      { g: GRAPH, name: '"RootData"' },
+      { g: rootSharedMemoryGraph, name: '"RootSWM"' },
+    ]);
+  });
+
   it('allows scoped GRAPH variable count scans across registered same-CG content partitions', async () => {
     const rootAssertionGraph = `${GRAPH}/assertion/0xAgent/root-draft`;
     const rootSharedMemoryGraph = `${GRAPH}/_shared_memory`;
@@ -893,7 +949,7 @@ describe('DKGQueryEngine', () => {
       `SELECT ?g (COUNT(DISTINCT ?s) AS ?entities) (COUNT(*) AS ?triples)
        WHERE { GRAPH ?g { ?s ?p ?o } }
        GROUP BY ?g`,
-      { contextGraphId: CONTEXT_GRAPH },
+      { contextGraphId: CONTEXT_GRAPH, includeContextGraphPartitions: true },
     );
     const graphs = new Set(result.bindings.map((row) => row['g']));
 
@@ -941,7 +997,7 @@ describe('DKGQueryEngine', () => {
 
     const result = await engine.query(
       `SELECT ?g ?name WHERE { GRAPH ?g { ?s <${SCHEMA_NAME}> ?name } } ORDER BY ?name`,
-      { contextGraphId: CONTEXT_GRAPH },
+      { contextGraphId: CONTEXT_GRAPH, includeContextGraphPartitions: true },
     );
     const names = new Set(result.bindings.map((row) => row['name']));
 
@@ -957,6 +1013,27 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings.some((row) => row['g'] === collidingRootVerified)).toBe(false);
   });
 
+  it('does not let non-canonical child-CG type triples hide registered parent partitions', async () => {
+    const subGraph = `${GRAPH}/code`;
+
+    await store.insert([
+      ...subGraphRegistration('code'),
+      // User data can mention `dkg:ContextGraph`; only the candidate's own
+      // `/_meta` graph may prove a child context graph during count scans.
+      q(subGraph, RDF_TYPE, DKG_CONTEXT_GRAPH, GRAPH),
+      q('urn:code:data', COUNT_NAME, '"ParentCode"', subGraph),
+    ]);
+
+    const result = await engine.query(
+      `SELECT ?g ?name WHERE { GRAPH ?g { ?s <${COUNT_NAME}> ?name } } ORDER BY ?name`,
+      { contextGraphId: CONTEXT_GRAPH, includeContextGraphPartitions: true },
+    );
+
+    expect(result.bindings).toEqual([
+      { g: subGraph, name: '"ParentCode"' },
+    ]);
+  });
+
   it('does not treat unregistered same-prefix child graphs as same-CG sub-graph content', async () => {
     const unregisteredSubGraph = `${GRAPH}/code`;
     await store.insert([
@@ -965,7 +1042,7 @@ describe('DKGQueryEngine', () => {
 
     const result = await engine.query(
       `SELECT ?g ?name WHERE { GRAPH ?g { ?s <${SCHEMA_NAME}> ?name } } ORDER BY ?name`,
-      { contextGraphId: CONTEXT_GRAPH },
+      { contextGraphId: CONTEXT_GRAPH, includeContextGraphPartitions: true },
     );
 
     expect(result.bindings.some((row) => row['g'] === unregisteredSubGraph)).toBe(false);

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -7,9 +7,28 @@ const CONTEXT_GRAPH = 'agent-registry';
 const GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
 const META = `${GRAPH}/_meta`;
 const ENTITY = 'did:dkg:agent:QmImageBot';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const DKG_SUB_GRAPH = 'http://dkg.io/ontology/SubGraph';
+const DKG_ASSERTION_GRAPH = 'http://dkg.io/ontology/assertionGraph';
+const DKG_CONTEXT_GRAPH = 'https://dkg.network/ontology#ContextGraph';
+const DKG_REGISTRATION_STATUS = 'https://dkg.network/ontology#registrationStatus';
+const SCHEMA_NAME = 'http://schema.org/name';
 
 function q(s: string, p: string, o: string, g = GRAPH): Quad {
   return { subject: s, predicate: p, object: o, graph: g };
+}
+
+function subGraphRegistration(name: string): Quad[] {
+  const subGraphUri = `${GRAPH}/${name}`;
+  return [
+    q(subGraphUri, RDF_TYPE, DKG_SUB_GRAPH, META),
+    q(subGraphUri, SCHEMA_NAME, `"${name}"`, META),
+    q(subGraphUri, 'http://dkg.io/ontology/createdBy', 'did:dkg:agent:test', META),
+  ];
+}
+
+function assertionGraphRegistration(graph: string, name: string): Quad {
+  return q(`urn:dkg:assertion:${name}`, DKG_ASSERTION_GRAPH, graph, META);
 }
 
 describe('DKGQueryEngine', () => {
@@ -836,6 +855,121 @@ describe('DKGQueryEngine', () => {
 
     expect(result.bindings.map((row) => row['name'])).toEqual(['"ImageBot"', '"Workspace Only"']);
     expect(result.bindings.map((row) => row['g']).sort()).toEqual([GRAPH, sharedMemoryGraph].sort());
+  });
+
+  it('allows scoped GRAPH variable count scans across registered same-CG content partitions', async () => {
+    const rootAssertionGraph = `${GRAPH}/assertion/0xAgent/root-draft`;
+    const rootSharedMemoryGraph = `${GRAPH}/_shared_memory`;
+    const rootVerifiedGraph = `${GRAPH}/_verified_memory/vm-1`;
+    const rootVerifiedStagingGraph = `${GRAPH}/_verified_memory/staging/vm-1`;
+    const subGraph = `${GRAPH}/code`;
+    const subGraphAssertionGraph = `${GRAPH}/code/assertion/0xAgent/code-draft`;
+    const subGraphSharedMemoryGraph = `${GRAPH}/code/_shared_memory`;
+    const subGraphVerifiedGraph = `${GRAPH}/code/_verified_memory/vm-1`;
+    const subGraphVerifiedStagingGraph = `${GRAPH}/code/_verified_memory/staging/vm-1`;
+    const subGraphMeta = `${GRAPH}/code/_meta`;
+    const subGraphPrivate = `${GRAPH}/code/_private`;
+    const otherGraph = 'did:dkg:context-graph:other-agent-registry/code/_shared_memory';
+
+    await store.insert([
+      ...subGraphRegistration('code'),
+      assertionGraphRegistration(rootAssertionGraph, 'root-draft'),
+      assertionGraphRegistration(subGraphAssertionGraph, 'code-draft'),
+      q('urn:root:wm', SCHEMA_NAME, '"RootWM"', rootAssertionGraph),
+      q('urn:root:swm', SCHEMA_NAME, '"RootSWM"', rootSharedMemoryGraph),
+      q('urn:root:vm', SCHEMA_NAME, '"RootVM"', rootVerifiedGraph),
+      q('urn:root:staging', SCHEMA_NAME, '"RootStaging"', rootVerifiedStagingGraph),
+      q('urn:code:data', SCHEMA_NAME, '"CodeData"', subGraph),
+      q('urn:code:wm', SCHEMA_NAME, '"CodeWM"', subGraphAssertionGraph),
+      q('urn:code:swm', SCHEMA_NAME, '"CodeSWM"', subGraphSharedMemoryGraph),
+      q('urn:code:vm', SCHEMA_NAME, '"CodeVM"', subGraphVerifiedGraph),
+      q('urn:code:staging', SCHEMA_NAME, '"CodeStaging"', subGraphVerifiedStagingGraph),
+      q('urn:code:meta', SCHEMA_NAME, '"CodeMeta"', subGraphMeta),
+      q('urn:code:private', SCHEMA_NAME, '"CodePrivate"', subGraphPrivate),
+      q('urn:other:swm', SCHEMA_NAME, '"OtherSWM"', otherGraph),
+    ]);
+
+    const result = await engine.query(
+      `SELECT ?g (COUNT(DISTINCT ?s) AS ?entities) (COUNT(*) AS ?triples)
+       WHERE { GRAPH ?g { ?s ?p ?o } }
+       GROUP BY ?g`,
+      { contextGraphId: CONTEXT_GRAPH },
+    );
+    const graphs = new Set(result.bindings.map((row) => row['g']));
+
+    for (const expected of [
+      GRAPH,
+      META,
+      rootAssertionGraph,
+      rootSharedMemoryGraph,
+      rootVerifiedGraph,
+      subGraph,
+      subGraphAssertionGraph,
+      subGraphSharedMemoryGraph,
+      subGraphVerifiedGraph,
+    ]) {
+      expect(graphs.has(expected)).toBe(true);
+    }
+    expect(graphs.has(rootVerifiedStagingGraph)).toBe(false);
+    expect(graphs.has(subGraphVerifiedStagingGraph)).toBe(false);
+    expect(graphs.has(subGraphMeta)).toBe(false);
+    expect(graphs.has(subGraphPrivate)).toBe(false);
+    expect(graphs.has(otherGraph)).toBe(false);
+  });
+
+  it('does not bind same-prefix child context graphs as parent content partitions', async () => {
+    const collidingSubGraph = `${GRAPH}/code`;
+    const collidingSubGraphSharedMemory = `${collidingSubGraph}/_shared_memory`;
+    const collidingSubGraphVerified = `${collidingSubGraph}/_verified_memory/vm-1`;
+    const collidingSubGraphMeta = `${collidingSubGraph}/_meta`;
+    const collidingRootSharedMemory = `${GRAPH}/_shared_memory`;
+    const collidingRootSharedMemoryMeta = `${collidingRootSharedMemory}/_meta`;
+    const collidingRootVerified = `${GRAPH}/_verified_memory/vm-1`;
+    const collidingRootVerifiedMeta = `${collidingRootVerified}/_meta`;
+
+    await store.insert([
+      ...subGraphRegistration('code'),
+      q(collidingSubGraph, RDF_TYPE, DKG_CONTEXT_GRAPH, collidingSubGraphMeta),
+      q(collidingRootSharedMemory, DKG_REGISTRATION_STATUS, '"unregistered"', collidingRootSharedMemoryMeta),
+      q(collidingRootVerified, DKG_REGISTRATION_STATUS, '"unregistered"', collidingRootVerifiedMeta),
+      q('urn:child:code', SCHEMA_NAME, '"ChildCodeRoot"', collidingSubGraph),
+      q('urn:child:code-swm', SCHEMA_NAME, '"ChildCodeSharedMemory"', collidingSubGraphSharedMemory),
+      q('urn:child:code-vm', SCHEMA_NAME, '"ChildCodeVerified"', collidingSubGraphVerified),
+      q('urn:child:swm', SCHEMA_NAME, '"ChildSharedMemoryRoot"', collidingRootSharedMemory),
+      q('urn:child:vm', SCHEMA_NAME, '"ChildVerifiedRoot"', collidingRootVerified),
+    ]);
+
+    const result = await engine.query(
+      `SELECT ?g ?name WHERE { GRAPH ?g { ?s <${SCHEMA_NAME}> ?name } } ORDER BY ?name`,
+      { contextGraphId: CONTEXT_GRAPH },
+    );
+    const names = new Set(result.bindings.map((row) => row['name']));
+
+    expect(names.has('"ChildCodeRoot"')).toBe(false);
+    expect(names.has('"ChildCodeSharedMemory"')).toBe(false);
+    expect(names.has('"ChildCodeVerified"')).toBe(false);
+    expect(names.has('"ChildSharedMemoryRoot"')).toBe(false);
+    expect(names.has('"ChildVerifiedRoot"')).toBe(false);
+    expect(result.bindings.some((row) => row['g'] === collidingSubGraph)).toBe(false);
+    expect(result.bindings.some((row) => row['g'] === collidingSubGraphSharedMemory)).toBe(false);
+    expect(result.bindings.some((row) => row['g'] === collidingSubGraphVerified)).toBe(false);
+    expect(result.bindings.some((row) => row['g'] === collidingRootSharedMemory)).toBe(false);
+    expect(result.bindings.some((row) => row['g'] === collidingRootVerified)).toBe(false);
+  });
+
+  it('does not treat unregistered same-prefix child graphs as same-CG sub-graph content', async () => {
+    const unregisteredSubGraph = `${GRAPH}/code`;
+    await store.insert([
+      q('urn:child:entity', SCHEMA_NAME, '"UnregisteredPrefixChild"', unregisteredSubGraph),
+    ]);
+
+    const result = await engine.query(
+      `SELECT ?g ?name WHERE { GRAPH ?g { ?s <${SCHEMA_NAME}> ?name } } ORDER BY ?name`,
+      { contextGraphId: CONTEXT_GRAPH },
+    );
+
+    expect(result.bindings.some((row) => row['g'] === unregisteredSubGraph)).toBe(false);
+    expect(result.bindings.some((row) => row['name'] === '"UnregisteredPrefixChild"')).toBe(false);
   });
 
   it('constrains GRAPH variables to shared memory when graphSuffix is _shared_memory', async () => {

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { DKGQueryEngine } from '../src/dkg-query-engine.js';
 import { validateReadOnlySparql } from '../src/sparql-guard.js';
@@ -971,6 +971,70 @@ describe('DKGQueryEngine', () => {
     expect(graphs.has(subGraphMeta)).toBe(false);
     expect(graphs.has(subGraphPrivate)).toBe(false);
     expect(graphs.has(otherGraph)).toBe(false);
+  });
+
+  it('memoizes same-CG partition discovery across concurrent count scans', async () => {
+    const rootSharedMemoryGraph = `${GRAPH}/_shared_memory`;
+    const rootVerifiedGraph = `${GRAPH}/_verified_memory/vm-1`;
+    const subGraph = `${GRAPH}/code`;
+    const subGraphSharedMemoryGraph = `${GRAPH}/code/_shared_memory`;
+
+    await store.insert([
+      ...subGraphRegistration('code'),
+      q('urn:root:swm', SCHEMA_NAME, '"RootSWM"', rootSharedMemoryGraph),
+      q('urn:root:vm', SCHEMA_NAME, '"RootVM"', rootVerifiedGraph),
+      q('urn:code:data', SCHEMA_NAME, '"CodeData"', subGraph),
+      q('urn:code:swm', SCHEMA_NAME, '"CodeSWM"', subGraphSharedMemoryGraph),
+    ]);
+
+    const listGraphsSpy = vi.spyOn(store, 'listGraphs');
+    const sparql = `SELECT ?g ?name WHERE { GRAPH ?g { ?s <${SCHEMA_NAME}> ?name } } ORDER BY ?name`;
+
+    const results = await Promise.all([
+      engine.query(sparql, { contextGraphId: CONTEXT_GRAPH, includeContextGraphPartitions: true }),
+      engine.query(sparql, { contextGraphId: CONTEXT_GRAPH, includeContextGraphPartitions: true }),
+      engine.query(sparql, { contextGraphId: CONTEXT_GRAPH, includeContextGraphPartitions: true }),
+    ]);
+
+    expect(listGraphsSpy).toHaveBeenCalledTimes(1);
+    for (const result of results) {
+      const graphs = new Set(result.bindings.map((row) => row['g']));
+      expect(graphs.has(rootSharedMemoryGraph)).toBe(true);
+      expect(graphs.has(rootVerifiedGraph)).toBe(true);
+      expect(graphs.has(subGraph)).toBe(true);
+      expect(graphs.has(subGraphSharedMemoryGraph)).toBe(true);
+    }
+  });
+
+  it('does not reuse partition discovery after an in-flight count scan completes', async () => {
+    const codeSubGraph = `${GRAPH}/code`;
+    const docsSubGraph = `${GRAPH}/docs`;
+
+    await store.insert([
+      ...subGraphRegistration('code'),
+      q('urn:code:data', SCHEMA_NAME, '"CodeData"', codeSubGraph),
+    ]);
+
+    const listGraphsSpy = vi.spyOn(store, 'listGraphs');
+    const sparql = `SELECT ?g ?name WHERE { GRAPH ?g { ?s <${SCHEMA_NAME}> ?name } } ORDER BY ?name`;
+    const first = await engine.query(
+      sparql,
+      { contextGraphId: CONTEXT_GRAPH, includeContextGraphPartitions: true },
+    );
+    expect(first.bindings.some((row) => row['g'] === codeSubGraph)).toBe(true);
+    expect(listGraphsSpy).toHaveBeenCalledTimes(1);
+
+    await store.insert([
+      ...subGraphRegistration('docs'),
+      q('urn:docs:data', SCHEMA_NAME, '"DocsData"', docsSubGraph),
+    ]);
+
+    const second = await engine.query(
+      sparql,
+      { contextGraphId: CONTEXT_GRAPH, includeContextGraphPartitions: true },
+    );
+    expect(listGraphsSpy).toHaveBeenCalledTimes(2);
+    expect(second.bindings.some((row) => row['g'] === docsSubGraph)).toBe(true);
   });
 
   it('does not bind same-prefix child context graphs as parent content partitions', async () => {


### PR DESCRIPTION
## Summary

- Fix RC12 scoped `GRAPH ?g` query handling so Node UI context graph counts can enumerate same-CG WM/SWM/VM content partitions again.
- Keep explicit `GRAPH <...>` scope checks strict, exclude staging/private/metadata partitions from broad count scans, and block slash-ID child context graph collisions.
- Add regression coverage and a permanent analysis artifact for the RC12 count regression.

## Related

- RC12 regression: Node UI dashboard showed populated context graphs as `0 entities` / `0 triples`.

## Files changed

| File | Notes |
| --- | --- |
| `agent-docs/rc12-context-graph-counts-regression.md` | Issue analysis, root cause, plan, verification, and local review results. |
| `packages/query/src/dkg-query-engine.ts` | Expands scoped graph-variable allow-list to registered same-CG content partitions while preserving isolation guards. |
| `packages/query/test/query-engine.test.ts` | Adds regression coverage for UI-shaped count scans, staging exclusion, child-CG collision exclusion, and unregistered same-prefix graphs. |

## Test plan

- `pnpm --filter @origintrail-official/dkg-core run build`
- `pnpm --filter @origintrail-official/dkg-query exec vitest run test/query-engine.test.ts`
- `pnpm --filter @origintrail-official/dkg-query run build`
- `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/use-memory-entities-counts.test.ts test/context-graph-ia-overview.test.ts test/subgraph-overview-grid.test.ts test/sub-graph-bar-layer-scope.test.ts test/ui-api-pure.test.ts`
- `pnpm --filter @origintrail-official/dkg-node-ui run build`
- `git diff --check`
- Local PR reviewer with `.codex/review-prompt.md` + `.codex/review-schema.json` reached `{comments:[]}` after valid blocker findings were addressed.