### PR TITLE
feat(node-ui): GH #819 — unified render-correct triple derivation via useCanonicalTriples

### DIFF
--- a/packages/node-ui/src/ui/views/DashboardView.tsx
+++ b/packages/node-ui/src/ui/views/DashboardView.tsx
@@ -6,7 +6,7 @@ import { useTabsStore } from '../stores/tabs.js';
 import { useProjectsStore, type ContextGraph } from '../stores/projects.js';
 import { useMyContextGraphs } from '../hooks/useMyContextGraphs.js';
 import { useMemoryEntities } from '../hooks/useMemoryEntities.js';
-import { useCanonicalTriples } from './project/helpers.js';
+import { useCanonicalTriples, useLayerTriples } from './project/helpers.js';
 import { useNodeEvents } from '../hooks/useNodeEvents.js';
 import {
   canonicalAgentDid,
@@ -342,24 +342,39 @@ function CgRow({
     const subjects = new Set(mem.allTriples.map((t) => t.subject)).size;
     return { wm: mem.counts.wm, swm: mem.counts.swm, vm: mem.counts.vm, total: subjects };
   }, [mem.error, mem.allTriples, mem.counts.wm, mem.counts.swm, mem.counts.vm, summaryAssets]);
-  // GH #819 — canonical triple total via `useCanonicalTriples` so
-  // the Dashboard per-CG row + aggregate agree with the CG Overview
-  // Triples stat by construction. Pre-#819 this iterated
-  // `mem.allTriples` directly: per-layer counts and total were both
-  // inflated by SWM cross-graph SPO duplicates + post-promote WM
-  // residue (the same family GH #805 closed for the Overview stat,
-  // never wired through to Dashboard). The "413 → 372 on the
-  // recipe-app CG" acceptance lands here.
+  // GH #819 — total via `useCanonicalTriples`, per-layer cells via
+  // `useLayerTriples`. Pre-#819 this iterated `mem.allTriples`
+  // directly; per-layer counts and total were both inflated by SWM
+  // cross-graph SPO duplicates + post-promote WM residue (the same
+  // family GH #805 closed for the Overview stat, never wired
+  // through to Dashboard). The "413 → 372 on the recipe-app CG"
+  // acceptance lands on the total.
+  //
+  // Per-layer cells use `useLayerTriples` (OR-rule: drops a row if
+  // subject OR resource-object has moved past t.layer — correct
+  // semantics for "facts canonically at this layer", matches the
+  // Overview LayerStats per-layer cells cell-for-cell). Total uses
+  // `useCanonicalTriples` (drops only when BOTH endpoints moved
+  // past t.layer — preserves legitimate mixed-layer edges across
+  // the aggregate).
+  //
+  // CONTRACT: `wm + swm + vm ≤ total` on Dashboard. The gap is the
+  // count of mixed-layer edges (one endpoint at t.layer, other
+  // moved past) that canonical keeps but per-layer slices drop.
+  // Restoring strict equality would require migrating LayerStats
+  // consumers off `useLayerTriples` — out of GH #819 scope. The
+  // ux-lead brief is explicit: "Don't refactor `useLayerTriples`;
+  // just stop summing its outputs at the 6 aggregate sites."
+  const wmLayer = useLayerTriples(mem, 'wm');
+  const swmLayer = useLayerTriples(mem, 'swm');
+  const vmLayer = useLayerTriples(mem, 'vm');
   const canonical = useCanonicalTriples(mem);
-  const triples: LayerCounts = useMemo(() => {
-    let wm = 0, swm = 0, vm = 0;
-    for (const t of canonical.triples) {
-      if (t.layer === 'working') wm++;
-      else if (t.layer === 'shared') swm++;
-      else if (t.layer === 'verified') vm++;
-    }
-    return { wm, swm, vm, total: canonical.total };
-  }, [canonical]);
+  const triples: LayerCounts = useMemo(() => ({
+    wm: wmLayer.length,
+    swm: swmLayer.length,
+    vm: vmLayer.length,
+    total: canonical.total,
+  }), [wmLayer, swmLayer, vmLayer, canonical]);
 
   const sig = [
     mem.loading ? 1 : 0, mem.error ? 1 : 0, mem.partial ? 1 : 0, agentsLoading ? 1 : 0, agentsError ? 1 : 0, isPublicCg ? 1 : 0,

--- a/packages/node-ui/src/ui/views/DashboardView.tsx
+++ b/packages/node-ui/src/ui/views/DashboardView.tsx
@@ -6,6 +6,7 @@ import { useTabsStore } from '../stores/tabs.js';
 import { useProjectsStore, type ContextGraph } from '../stores/projects.js';
 import { useMyContextGraphs } from '../hooks/useMyContextGraphs.js';
 import { useMemoryEntities } from '../hooks/useMemoryEntities.js';
+import { useCanonicalTriples } from './project/helpers.js';
 import { useNodeEvents } from '../hooks/useNodeEvents.js';
 import {
   canonicalAgentDid,
@@ -341,15 +342,24 @@ function CgRow({
     const subjects = new Set(mem.allTriples.map((t) => t.subject)).size;
     return { wm: mem.counts.wm, swm: mem.counts.swm, vm: mem.counts.vm, total: subjects };
   }, [mem.error, mem.allTriples, mem.counts.wm, mem.counts.swm, mem.counts.vm, summaryAssets]);
+  // GH #819 — canonical triple total via `useCanonicalTriples` so
+  // the Dashboard per-CG row + aggregate agree with the CG Overview
+  // Triples stat by construction. Pre-#819 this iterated
+  // `mem.allTriples` directly: per-layer counts and total were both
+  // inflated by SWM cross-graph SPO duplicates + post-promote WM
+  // residue (the same family GH #805 closed for the Overview stat,
+  // never wired through to Dashboard). The "413 → 372 on the
+  // recipe-app CG" acceptance lands here.
+  const canonical = useCanonicalTriples(mem);
   const triples: LayerCounts = useMemo(() => {
     let wm = 0, swm = 0, vm = 0;
-    for (const t of mem.allTriples) {
+    for (const t of canonical.triples) {
       if (t.layer === 'working') wm++;
       else if (t.layer === 'shared') swm++;
       else if (t.layer === 'verified') vm++;
     }
-    return { wm, swm, vm, total: mem.allTriples.length };
-  }, [mem.allTriples]);
+    return { wm, swm, vm, total: canonical.total };
+  }, [canonical]);
 
   const sig = [
     mem.loading ? 1 : 0, mem.error ? 1 : 0, mem.partial ? 1 : 0, agentsLoading ? 1 : 0, agentsError ? 1 : 0, isPublicCg ? 1 : 0,

--- a/packages/node-ui/src/ui/views/MemoryStackView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryStackView.tsx
@@ -17,7 +17,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useProjectsStore, type ContextGraph } from '../stores/projects.js';
 import { useTabsStore } from '../stores/tabs.js';
 import { useMemoryEntities, type MemoryEntity, type TrustLevel } from '../hooks/useMemoryEntities.js';
-import { useCanonicalTriples } from './project/helpers.js';
+import { useLayerTriples } from './project/helpers.js';
 import { relativeTime } from '../hooks/useProjectActivity.js';
 import { useHiddenContextGraphIds } from '../hooks/useHiddenContextGraphIds.js';
 
@@ -90,25 +90,36 @@ export function MemoryStackView() {
 function MemoryStackRow({ cg }: { cg: ContextGraph }) {
   const memory = useMemoryEntities(cg.id);
   const { openTab } = useTabsStore();
-  // GH #819 — per-layer triple totals read the canonical residue-
-  // filtered + SPO-deduped universe so they agree with the
-  // Overview Triples + Dashboard cells by construction.
-  // Pre-#819 this iterated `memory.allTriples` raw — SWM cross-graph
-  // duplicates + WM residue inflated both totals.
-  const canonical = useCanonicalTriples(memory);
+  // GH #819 round 3 (Codex sweep 1 🔴 #2) — per-layer buckets use
+  // `useLayerTriples` (OR-rule: drops if subject OR resource-object
+  // moved past t.layer; matches the per-layer Triples-tab the
+  // layer-card buttons open by clicking). Pre-round-3 this read
+  // from `useCanonicalTriples` for per-layer cells too — which
+  // kept mixed-layer edges via the BOTH-endpoints rule, so the
+  // Memory Stack per-layer cells exceeded the layer pages they
+  // navigate to. Same family as the Dashboard round-2 fix, same
+  // option (a) shape: per-layer cells revert, total stays
+  // canonical.
+  const wmLayer = useLayerTriples(memory, 'wm');
+  const swmLayer = useLayerTriples(memory, 'swm');
+  const vmLayer = useLayerTriples(memory, 'vm');
 
   // Bucket entities + triple-counts per layer in one pass.
+  // CONTRACT (mirrors `DashboardView.tsx`): per-layer cells use
+  // `useLayerTriples` — matches the per-layer Triples tab the
+  // layer-card buttons open cell-for-cell. If a project-wide
+  // canonical total is added to this view later (e.g. a footer
+  // total stat), source it from `useCanonicalTriples(memory).total`
+  // and document `wm+swm+vm ≤ total` at THAT site, same as
+  // Dashboard's contract.
   const byLayer = useMemo(() => {
     const buckets: Record<TrustLevel, { entities: MemoryEntity[]; tripleCount: number }> = {
-      working:  { entities: [], tripleCount: 0 },
-      shared:   { entities: [], tripleCount: 0 },
-      verified: { entities: [], tripleCount: 0 },
+      working:  { entities: [], tripleCount: wmLayer.length },
+      shared:   { entities: [], tripleCount: swmLayer.length },
+      verified: { entities: [], tripleCount: vmLayer.length },
     };
     for (const e of memory.entityList) {
       buckets[e.trustLevel].entities.push(e);
-    }
-    for (const t of canonical.triples) {
-      buckets[t.layer].tripleCount++;
     }
     // Sort each bucket newest-first using whichever timestamp predicate
     // each entity has; undated items slide to the back.
@@ -122,7 +133,7 @@ function MemoryStackRow({ cg }: { cg: ContextGraph }) {
       });
     }
     return buckets;
-  }, [memory.entityList, canonical]);
+  }, [memory.entityList, wmLayer, swmLayer, vmLayer]);
 
   const openProject = () =>
     openTab({

--- a/packages/node-ui/src/ui/views/MemoryStackView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryStackView.tsx
@@ -17,6 +17,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useProjectsStore, type ContextGraph } from '../stores/projects.js';
 import { useTabsStore } from '../stores/tabs.js';
 import { useMemoryEntities, type MemoryEntity, type TrustLevel } from '../hooks/useMemoryEntities.js';
+import { useCanonicalTriples } from './project/helpers.js';
 import { relativeTime } from '../hooks/useProjectActivity.js';
 import { useHiddenContextGraphIds } from '../hooks/useHiddenContextGraphIds.js';
 
@@ -89,6 +90,12 @@ export function MemoryStackView() {
 function MemoryStackRow({ cg }: { cg: ContextGraph }) {
   const memory = useMemoryEntities(cg.id);
   const { openTab } = useTabsStore();
+  // GH #819 — per-layer triple totals read the canonical residue-
+  // filtered + SPO-deduped universe so they agree with the
+  // Overview Triples + Dashboard cells by construction.
+  // Pre-#819 this iterated `memory.allTriples` raw — SWM cross-graph
+  // duplicates + WM residue inflated both totals.
+  const canonical = useCanonicalTriples(memory);
 
   // Bucket entities + triple-counts per layer in one pass.
   const byLayer = useMemo(() => {
@@ -100,7 +107,7 @@ function MemoryStackRow({ cg }: { cg: ContextGraph }) {
     for (const e of memory.entityList) {
       buckets[e.trustLevel].entities.push(e);
     }
-    for (const t of memory.allTriples) {
+    for (const t of canonical.triples) {
       buckets[t.layer].tripleCount++;
     }
     // Sort each bucket newest-first using whichever timestamp predicate
@@ -115,7 +122,7 @@ function MemoryStackRow({ cg }: { cg: ContextGraph }) {
       });
     }
     return buckets;
-  }, [memory.entityList, memory.allTriples]);
+  }, [memory.entityList, canonical]);
 
   const openProject = () =>
     openTab({

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4108,18 +4108,27 @@ export function SubGraphOverviewGrid({
           // distinct total when summed without double-counting
           // cross-graph duplicates. Pre-#819 this read `sg.tripleCount`
           // (daemon-reported raw count) which inflated on CGs with
-          // cross-graph SPO duplicates. Falls back to `sg.tripleCount`
-          // ONLY when the canonical helper has no rows for this slug
-          // (loading state / sub-graph hydrated but no triples yet),
-          // matching the entityCount fallback pattern above.
-          tripleCount: tripleCountBySubGraph.get(sg.name) ?? sg.tripleCount,
+          // cross-graph SPO duplicates.
+          //
+          // GH #819 round 2 (Codex sweep 1 yellow finding) — fallback
+          // to the daemon-reported `sg.tripleCount` ONLY while
+          // `memory.loading` is true. Pre-round-2 the fallback also
+          // fired on hydrated-but-genuinely-empty buckets (canonical
+          // helper has no rows for the slug because the sub-graph
+          // truly has no triples), which masked legitimate zeros with
+          // the daemon's inflated count. Gating on `memory.loading`
+          // keeps the not-yet-hydrated case covered while letting
+          // hydrated-zero surface honestly.
+          tripleCount: memory.loading
+            ? (tripleCountBySubGraph.get(sg.name) ?? sg.tripleCount)
+            : (tripleCountBySubGraph.get(sg.name) ?? 0),
           triples: filterTriplesToEntities(rawTriples, cardEntityUris),
           layerCounts: layerCountsBySubGraph.get(sg.name) ?? { wm: 0, swm: 0, vm: 0 },
           entityTrustByUri: cardEntityTrust,
         };
       })
       .sort((a, b) => a.rank - b.rank);
-  }, [subGraphs, profile, triplesBySubGraph, tripleCountBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph]);
+  }, [subGraphs, profile, triplesBySubGraph, tripleCountBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph, memory.loading]);
 
   // GH #813 — Root mini-card. Synthesizes a card for the
   // "entities not in any named sub-graph" bucket so the grid

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3962,6 +3962,24 @@ export function SubGraphOverviewGrid({
   // those mixed-layer edges as facts.
   const { total: subtitleTripleCount } = useCanonicalTriples(memory);
 
+  // GH #819 round 6 (Codex sweep 4 🔴 #11) — hydration-state gate
+  // for the per-card badge. `useMemoryEntities` initializes
+  // `allTriples = []` (`useMemoryEntities.ts:590`), so between
+  // `/sub-graph/list` resolving (which fills `subGraphs`) and
+  // WM/SWM/VM finishing (which fills `allTriples`), every named-
+  // and Root-card derives `tripleCount = 0`. Round 5 collapsed
+  // the badge to `card.tripleCount ?? 0`, conflating "still
+  // loading" with "genuine empty". Revive the discriminator at
+  // the grid scope; the badge below uses it to render a hydration
+  // affordance ("…") instead of `0 triples` while canonical is
+  // incomplete. Hydrated-fully state still reads `0 triples`
+  // honestly (genuine zero shows through).
+  const canonicalIncomplete =
+    memory.loading
+    || memory.error !== null
+    || memory.partial
+    || Object.values(memory.layerStatus ?? {}).some(s => s !== 'ok');
+
   // Bucket every triple by its origin sub-graph so each mini-graph
   // renders just its slice. Cap per-bucket via the shared
   // `applyHeaviestSubjectsCap` helper at module scope (see its doc
@@ -4410,6 +4428,7 @@ export function SubGraphOverviewGrid({
           <SubGraphMiniCard
             key={card.slug}
             card={card}
+            canonicalIncomplete={canonicalIncomplete}
             onNodeClick={onNodeClick}
             onOpen={() => onSelectSubGraph(card.slug)}
           />
@@ -4423,6 +4442,7 @@ export function SubGraphOverviewGrid({
         <SubGraphMiniCard
           key={ROOT_SLUG_SENTINEL}
           card={rootCard}
+          canonicalIncomplete={canonicalIncomplete}
           onNodeClick={onNodeClick}
           onOpen={() => onSelectSubGraph(ROOT_SLUG_SENTINEL)}
           variant="root"
@@ -4434,6 +4454,7 @@ export function SubGraphOverviewGrid({
 
 export function SubGraphMiniCard({
   card,
+  canonicalIncomplete = false,
   onNodeClick,
   onOpen,
   variant,
@@ -4445,6 +4466,14 @@ export function SubGraphMiniCard({
     layerCounts: { wm: number; swm: number; vm: number };
     entityTrustByUri: Map<string, TrustLevel>;
   };
+  // GH #819 round 6 — true while WM/SWM/VM are still hydrating
+  // (or any layer query errored). Drives the badge's hydration
+  // affordance so a non-empty subgraph doesn't flash `0 triples`
+  // between `/sub-graph/list` resolve and full layer hydration
+  // (Codex sweep 4 🔴 #11). Defaults to false so consumers that
+  // don't (or can't) thread the discriminator render the badge
+  // exactly as before.
+  canonicalIncomplete?: boolean;
   onNodeClick?: (node: any) => void;
   onOpen: () => void;
   // GH #813 — `root` opts into the quieter neutral-border chrome
@@ -4545,14 +4574,26 @@ export function SubGraphMiniCard({
             quiet case. Same conditional-when-it-has-something-to-
             say pattern as S2's `Pending join requests` empty
             state. */}
+        {/* GH #819 round 6 (Codex sweep 4 🔴 #11) — hydration
+            affordance. `useMemoryEntities` initializes
+            `allTriples = []`, so between `/sub-graph/list`
+            resolve (which fills `subGraphs`) and WM/SWM/VM
+            finishing (which fills `allTriples`), `card.tripleCount`
+            derives 0 even for non-empty subgraphs. Render `…`
+            during that window so the badge doesn't masquerade
+            a hydration race as a genuine empty bucket. Once
+            canonical hydrates, the actual count (including a
+            genuine 0) shows through honestly. */}
         <span
           className="v10-sgov-card-stat"
           title={
-            card.tripleCount !== card.triples.length
-              ? `${card.tripleCount} triples in this subgraph's scope; ${card.triples.length} rendered (cross-card edges whose other endpoint isn't in this subgraph aren't drawn here).`
-              : undefined
+            canonicalIncomplete && card.tripleCount === 0
+              ? 'Loading triples for this subgraph…'
+              : card.tripleCount !== card.triples.length
+                ? `${card.tripleCount} triples in this subgraph's scope; ${card.triples.length} rendered (cross-card edges whose other endpoint isn't in this subgraph aren't drawn here).`
+                : undefined
           }
-        ><b>{card.tripleCount}</b> triples</span>
+        ><b>{canonicalIncomplete && card.tripleCount === 0 ? '…' : card.tripleCount}</b> triples</span>
       </div>
       <div className="v10-sgov-card-pyramid">
         {/* compact mode collapses the empty-counts branch to `null`

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4314,6 +4314,20 @@ export function SubGraphOverviewGrid({
     const rootScopedRaw = memory.allTriples.filter(t => !t.subGraph);
     const candidateTriples = applyCanonicalAdmission(rootScopedRaw, memory.entities)
       .map(t => ({ subject: t.subject, predicate: t.predicate, object: t.object }));
+    // GH #819 round 11 (Codex sweep 9 🟡 #20) — Root tripleCount
+    // is the PRE-`filterTriplesToEntities` candidate count, mirroring
+    // the named-card contract (`tripleCountBySubGraph` is set from
+    // `applyCanonicalAdmission` output, also pre-filter). Pre-round-11
+    // Root read `rootTriples.length` (post-AND-filter), so an
+    // untagged root-scoped edge to a non-root entity contributed to
+    // the subtitle total (canonical pass admits it) but showed as
+    // 0 on the Root card (AND-filter drops it because the non-root
+    // object isn't in `rootEntityUris`). Stat (0) === rendered (0)
+    // meant the β stat-vs-rendered tooltip never fired — no
+    // disclosure of the asymmetry. Carrying the pre-filter count
+    // restores symmetry with named cards and lets the β tooltip
+    // fire naturally when the count exceeds the rendered slice.
+    const rootTripleCount = candidateTriples.length;
     const rootTriples = filterTriplesToEntities(candidateTriples, rootEntityUris);
     // PR #818 Codex sweep 4 (finding 3) — shared cap helper. The
     // earlier inline copy duplicated the named-card sampling shape
@@ -4339,7 +4353,7 @@ export function SubGraphOverviewGrid({
       // Mirrors the named-card behaviour where `sg.tripleCount`
       // (daemon-reported) decouples the badge from the rendered
       // slice.
-      tripleCount: rootTriples.length,
+      tripleCount: rootTripleCount,
       triples: cappedRootTriples,
       layerCounts: { wm, swm, vm },
       entityTrustByUri: rootEntityTrust,

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -18,7 +18,7 @@ import {
   useMemoryEntities,
   canonicalEntityUri,
   isFirstClassEntity,
-  type TrustLevel, type MemoryEntity, type Triple,
+  type TrustLevel, type MemoryEntity, type Triple, type LayeredTriple,
 } from '../../hooks/useMemoryEntities.js';
 import { decodeRdfStringLiteral } from '../../../rdf-literal.js';
 import {
@@ -4606,7 +4606,15 @@ export function SubGraphMiniCard({
               : isFailedOrPartial && card.tripleCount === 0
                 ? 'Some layers unavailable; count may be incomplete.'
                 : card.tripleCount !== card.triples.length
-                  ? `${card.tripleCount} triples in this subgraph's scope; ${card.triples.length} rendered (cross-card edges whose other endpoint isn't in this subgraph aren't drawn here).`
+                  // GH #819 round 8 (Codex sweep 6 🟡 #4 / #9 / #12,
+                  // team-lead call β) — broader wording so the
+                  // tooltip covers both causes of stat-vs-rendered
+                  // gap: (1) cross-card edges whose other endpoint
+                  // sits outside the subgraph and (2) cap-trimmed
+                  // rows in dense buckets via `applyHeaviestSubjectsCap`.
+                  // Earlier copy blamed only cause (1); Codex
+                  // re-raised the cap-trim case 5 sweeps in a row.
+                  ? `${card.tripleCount} triples in this subgraph's scope; ${card.triples.length} rendered (some in-scope edges aren't drawn — either endpoints outside this subgraph, or cap-trimmed in dense buckets).`
                   : undefined
           }
         ><b>{isHydrating && card.tripleCount === 0 ? '…' : card.tripleCount}</b> triples</span>

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4164,8 +4164,19 @@ export function SubGraphOverviewGrid({
           // case (`loading` flips false but the canonical universe
           // is still incomplete because a layer query failed).
           //
+          // GH #819 round 4 (Codex sweep 2 🔴 #6) — precedence fix.
+          // Round 3's `?? sg.tripleCount` only fell through when
+          // the bucket was undefined, but a partial-hydrated bucket
+          // (e.g. 3 of an expected 10) had a value and won the
+          // discriminator — the badge undercounted to 3 instead of
+          // the daemon's 10. `Math.max(...)` clamps to the LARGER
+          // of the partial-hydrated bucket and the daemon count
+          // when canonical is incomplete: surfaces the truer
+          // lower-bound either way (defends against the daemon
+          // undershooting too). Hydrated-fully state still reads
+          // the canonical bucket honestly (zero shows through).
           tripleCount: canonicalIncomplete
-            ? (tripleCountBySubGraph.get(sg.name) ?? sg.tripleCount)
+            ? Math.max(sg.tripleCount, tripleCountBySubGraph.get(sg.name) ?? 0)
             : (tripleCountBySubGraph.get(sg.name) ?? 0),
           triples: filterTriplesToEntities(rawTriples, cardEntityUris),
           layerCounts: layerCountsBySubGraph.get(sg.name) ?? { wm: 0, swm: 0, vm: 0 },

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3962,25 +3962,66 @@ export function SubGraphOverviewGrid({
   // those mixed-layer edges as facts.
   const { triples: canonicalTriples, total: subtitleTripleCount } = useCanonicalTriples(memory);
 
+  // GH #819 round 3 (Codex sweep 1 🔴 #3) — discriminator for the
+  // named-card `tripleCount` fallback below. The canonical universe
+  // is INCOMPLETE when any of these is true:
+  //   • `memory.loading` — initial hydration in flight
+  //   • `memory.error`   — hard error (e.g. /api/query unreachable)
+  //   • `memory.partial` — some-but-not-all layer queries failed
+  //   • any layer status pending or errored — narrowest signal
+  // Round 2 gated on `memory.loading` alone, which missed the
+  // hydrated-after-layer-failure case (loading flips false but
+  // canonical is still incomplete). The widened gate keeps the
+  // daemon-reported `sg.tripleCount` lower-bound active for every
+  // state where the canonical universe can't be trusted as the
+  // ground truth.
+  const canonicalIncomplete =
+    memory.loading
+    || memory.error !== null
+    || memory.partial
+    || Object.values(memory.layerStatus ?? {}).some(s => s !== 'ok');
+
   // Bucket every triple by its origin sub-graph so each mini-graph
   // renders just its slice. Cap per-bucket via the shared
   // `applyHeaviestSubjectsCap` helper at module scope (see its doc
   // block for the sampling / dense-pack / residual-fallback
   // rationale carried over from sweeps 1-3).
   //
-  // GH #819 — source from `canonicalTriples` (residue-filtered,
-  // SPO-deduped, mixed-layer-preserving) instead of iterating
-  // `memory.allTriples` with an inline canonical-SPO dedup. The
-  // helper has already done that work; per-subgraph buckets just
-  // narrow to `t.subGraph === sg` from the canonical universe.
+  // Bucket every triple by its origin sub-graph so each mini-graph
+  // renders just its slice. Cap per-bucket via the shared
+  // `applyHeaviestSubjectsCap` helper at module scope (see its doc
+  // block for the sampling / dense-pack / residual-fallback
+  // rationale carried over from PR #818 sweeps 1-3).
+  //
+  // GH #819 round 3 (Codex sweep 1 🔴 #1) — re-dedupe per
+  // sub-graph bucket here rather than reading from
+  // `canonicalTriples`. `useCanonicalTriples` dedupes by
+  // `(canonical(s), p, canonical(o))` GLOBALLY across the whole
+  // project (correct for aggregate-total consumers). But the same
+  // `(s, p, o)` legitimately shipped under TWO different named
+  // sub-graphs (e.g. a cross-membership entity referenced from
+  // both alpha and beta) must surface in BOTH cards — only one
+  // copy survives in `canonicalTriples`, whichever row was
+  // visited first. Reading per-bucket from a globally-deduped set
+  // under-counts the late-arrival card by exactly the shared SPO
+  // count. Iterate `memory.allTriples` here and re-dedupe with
+  // `subGraph` implicit in the bucket scope so each card keeps
+  // its own scoped copy.
+  //
   // `tripleCountBySubGraph` carries the pre-cap distinct total so
   // the card stat reads the true count (decoupled from the
   // post-cap rendered slice — same convention as Root card +
-  // sweep 2's helper-extract contract).
+  // PR #839 sweep 2's helper-extract contract).
   const { triplesBySubGraph, tripleCountBySubGraph } = useMemo(() => {
     const bySg = new Map<string, Triple[]>();
-    for (const t of canonicalTriples) {
+    const seenBySg = new Map<string, Set<string>>();
+    for (const t of memory.allTriples) {
       if (!t.subGraph) continue;
+      const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
+      let seen = seenBySg.get(t.subGraph);
+      if (!seen) { seen = new Set(); seenBySg.set(t.subGraph, seen); }
+      if (seen.has(key)) continue;
+      seen.add(key);
       let arr = bySg.get(t.subGraph);
       if (!arr) { arr = []; bySg.set(t.subGraph, arr); }
       arr.push({ subject: t.subject, predicate: t.predicate, object: t.object });
@@ -3991,7 +4032,7 @@ export function SubGraphOverviewGrid({
       bySg.set(sg, applyHeaviestSubjectsCap(triples));
     }
     return { triplesBySubGraph: bySg, tripleCountBySubGraph: countBySg };
-  }, [canonicalTriples]);
+  }, [memory.allTriples]);
 
   // Per-sub-graph layer counts — drives the mini pyramid on each card so
   // you can see at a glance which sub-graphs are mostly verified vs still
@@ -4110,16 +4151,20 @@ export function SubGraphOverviewGrid({
           // (daemon-reported raw count) which inflated on CGs with
           // cross-graph SPO duplicates.
           //
-          // GH #819 round 2 (Codex sweep 1 yellow finding) — fallback
-          // to the daemon-reported `sg.tripleCount` ONLY while
-          // `memory.loading` is true. Pre-round-2 the fallback also
-          // fired on hydrated-but-genuinely-empty buckets (canonical
-          // helper has no rows for the slug because the sub-graph
-          // truly has no triples), which masked legitimate zeros with
-          // the daemon's inflated count. Gating on `memory.loading`
-          // keeps the not-yet-hydrated case covered while letting
-          // hydrated-zero surface honestly.
-          tripleCount: memory.loading
+          // GH #819 round 3 (Codex sweep 1 🔴 #3) — fallback to the
+          // daemon-reported `sg.tripleCount` while the canonical
+          // universe is INCOMPLETE for any reason: loading, hard
+          // error, partial result (some layer query failed), or any
+          // per-layer status not yet 'ok'. Round 2 gated only on
+          // `memory.loading` which missed the post-hydration error
+          // case (`loading` flips false but `canonicalTriples` is
+          // still incomplete because a layer query failed). After a
+          // layer failure, a sub-graph whose triples live in the
+          // missing layer would render `0 triples` instead of
+          // falling back to the daemon's lower-bound. The widened
+          // gate keeps the fallback active for every state where
+          // the canonical universe can't be trusted as complete.
+          tripleCount: canonicalIncomplete
             ? (tripleCountBySubGraph.get(sg.name) ?? sg.tripleCount)
             : (tripleCountBySubGraph.get(sg.name) ?? 0),
           triples: filterTriplesToEntities(rawTriples, cardEntityUris),
@@ -4128,7 +4173,7 @@ export function SubGraphOverviewGrid({
         };
       })
       .sort((a, b) => a.rank - b.rank);
-  }, [subGraphs, profile, triplesBySubGraph, tripleCountBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph, memory.loading]);
+  }, [subGraphs, profile, triplesBySubGraph, tripleCountBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph, canonicalIncomplete]);
 
   // GH #813 — Root mini-card. Synthesizes a card for the
   // "entities not in any named sub-graph" bucket so the grid

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4474,7 +4474,27 @@ export function SubGraphMiniCard({
       </div>
       <div className="v10-sgov-card-stats">
         <span className="v10-sgov-card-stat"><b>{card.entityCount}</b> entities</span>
-        <span className="v10-sgov-card-stat"><b>{card.tripleCount}</b> triples</span>
+        {/* GH #819 round 2 — conditional stat-vs-rendered tooltip
+            (ux-lead lock, option (i) from sweep 1 yellow finding).
+            When the in-scope canonical count differs from what
+            actually renders on the mini-graph (cross-card edges
+            whose other endpoint isn't in this subgraph drop via
+            `filterTriplesToEntities`, or `applyHeaviestSubjectsCap`
+            truncated a populated bucket), surface the gap via a
+            native `title` tooltip on the badge. When equal (most
+            common — no cross-card edges + bucket under the cap),
+            no tooltip is added so we don't add chrome to the
+            quiet case. Same conditional-when-it-has-something-to-
+            say pattern as S2's `Pending join requests` empty
+            state. */}
+        <span
+          className="v10-sgov-card-stat"
+          title={
+            card.tripleCount !== card.triples.length
+              ? `${card.tripleCount} triples in this subgraph's scope; ${card.triples.length} rendered (cross-card edges whose other endpoint isn't in this subgraph aren't drawn here).`
+              : undefined
+          }
+        ><b>{card.tripleCount}</b> triples</span>
       </div>
       <div className="v10-sgov-card-pyramid">
         {/* compact mode collapses the empty-counts branch to `null`

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -59,7 +59,7 @@ import {
   entityAuthorUri, transitionAgentUri, transitionAtISO,
   shortType, shortPred, entityMeta,
   buildLayerGraphOptions, getDescription, neighborhoodTriples, neutraliseBuiltinNamespaces,
-  matchesSearch, humanizeLabel, layerNoun, useLayerTriples,
+  matchesSearch, humanizeLabel, layerNoun, useLayerTriples, useCanonicalTriples,
   filterTriplesToEntities, admitTripleForScope,
   entityTimestamp, formatRelativeTime, formatTimelineBucket, formatTrailTimestamp,
   type LayerView, type LayerContentTab, type KAPane,
@@ -836,30 +836,26 @@ export function ProjectOverviewCard({
           ? 'One or more layer counts are currently a lower bound.'
           : 'Canonical current-layer entity counts.';
   const totalEntitiesValue = allLayerCountsUnavailable ? 'Unavailable' : layerSum.toLocaleString();
-  // Triples: canonical layer-correct total via `useLayerTriples`
-  // summed across all three layers (§4.2.1 trap — do NOT sum
-  // per-entity tripleCount, do NOT borrow SubGraphBar's
-  // `totalTriples` which excludes the root bucket, and do NOT
-  // read `allTriples.length` directly because it skips neither
-  // SWM cross-graph SPO duplication nor WM residue from promoted
-  // entities, both of which `useLayerTriples` correctly filters).
+  // Triples: canonical project-wide total via `useCanonicalTriples`
+  // (GH #819 helper — single source of truth for all aggregate
+  // triple-count surfaces).
   //
-  // GH #805 fix: prior shape `memory.allTriples?.length ?? 0`
-  // surfaced an inflated total on any CG with published SWM (the
-  // same SPO row appears in both `<cg>/_shared_memory` and per-
-  // sub-graph `<cg>/<sg>/_shared_memory` graphs) or post-promote
-  // WM residue (assertion graphs left on disk). Summing the
-  // layer-correct slices makes the Overview "Triples" match the
-  // per-layer LayerStats by construction.
+  // §4.2.1 trap reminder: do NOT sum per-entity tripleCount, do
+  // NOT borrow SubGraphBar's `totalTriples` which excludes the
+  // root bucket, do NOT read `allTriples.length` directly (it
+  // skips neither SWM cross-graph SPO duplication nor WM residue
+  // from promoted entities). PR #818 sweep 4's interim shape
+  // (sum-across-`useLayerTriples`) was closer but still dropped
+  // mixed-layer edges where one endpoint hadn't promoted past
+  // `t.layer`. The canonical helper's "drop only when BOTH
+  // endpoints moved past" rule keeps those edges as legitimate
+  // facts.
   //
   // Codex review bug B (still applies — partial-result preserving
   // behaviour is unchanged): when a layer query fails the slice
-  // is empty; sum stays a lower bound and the '+' suffix renders
-  // via `triplesIsPartial`.
-  const wmLayerTriples = useLayerTriples(memory, 'wm');
-  const swmLayerTriples = useLayerTriples(memory, 'swm');
-  const vmLayerTriples = useLayerTriples(memory, 'vm');
-  const triplesCount = wmLayerTriples.length + swmLayerTriples.length + vmLayerTriples.length;
+  // is empty; `total` stays a lower bound and the '+' suffix
+  // renders via `triplesIsPartial`.
+  const { total: triplesCount } = useCanonicalTriples(memory);
   const triplesIsPartial = !memory.loading && (memory.partial || hasUnavailableLayer);
   const triplesValue = allLayerCountsUnavailable
     ? 'Unavailable'
@@ -3954,30 +3950,48 @@ export function SubGraphOverviewGrid({
     return () => { cancelled = true; };
   }, [contextGraphId]);
 
-  // Bucket every triple by its origin sub-graph so each mini-graph renders
-  // just its slice. We dedupe on (s,p,o) and cap per-bucket via the
-  // shared `applyHeaviestSubjectsCap` helper at module scope (see the
-  // doc block there for the sampling / dense-pack / residual-fallback
+  // GH #819 — canonical triple set: single helper call surfaces
+  // both the subtitle total AND the input for `triplesBySubGraph`
+  // + Root mini-card derivations below. Lock subtitle + Overview
+  // Triples stat + named cards' `tripleCount` + Root card to one
+  // source of truth.
+  // History: GH #805 swapped subtitle from `memory.allTriples.length`
+  // to a `useLayerTriples` layer-sum; that was correct on per-layer
+  // residue + cross-graph dedup but still dropped mixed-layer
+  // edges. The canonical helper's BOTH-endpoints-moved rule keeps
+  // those mixed-layer edges as facts.
+  const { triples: canonicalTriples, total: subtitleTripleCount } = useCanonicalTriples(memory);
+
+  // Bucket every triple by its origin sub-graph so each mini-graph
+  // renders just its slice. Cap per-bucket via the shared
+  // `applyHeaviestSubjectsCap` helper at module scope (see its doc
+  // block for the sampling / dense-pack / residual-fallback
   // rationale carried over from sweeps 1-3).
-  const triplesBySubGraph = useMemo(() => {
+  //
+  // GH #819 — source from `canonicalTriples` (residue-filtered,
+  // SPO-deduped, mixed-layer-preserving) instead of iterating
+  // `memory.allTriples` with an inline canonical-SPO dedup. The
+  // helper has already done that work; per-subgraph buckets just
+  // narrow to `t.subGraph === sg` from the canonical universe.
+  // `tripleCountBySubGraph` carries the pre-cap distinct total so
+  // the card stat reads the true count (decoupled from the
+  // post-cap rendered slice — same convention as Root card +
+  // sweep 2's helper-extract contract).
+  const { triplesBySubGraph, tripleCountBySubGraph } = useMemo(() => {
     const bySg = new Map<string, Triple[]>();
-    const seen = new Map<string, Set<string>>();
-    for (const t of memory.allTriples) {
+    for (const t of canonicalTriples) {
       if (!t.subGraph) continue;
-      const key = `${t.subject}|${t.predicate}|${t.object}`;
-      let s = seen.get(t.subGraph);
-      if (!s) { s = new Set(); seen.set(t.subGraph, s); }
-      if (s.has(key)) continue;
-      s.add(key);
       let arr = bySg.get(t.subGraph);
       if (!arr) { arr = []; bySg.set(t.subGraph, arr); }
       arr.push({ subject: t.subject, predicate: t.predicate, object: t.object });
     }
+    const countBySg = new Map<string, number>();
     for (const [sg, triples] of bySg) {
+      countBySg.set(sg, triples.length);
       bySg.set(sg, applyHeaviestSubjectsCap(triples));
     }
-    return bySg;
-  }, [memory.allTriples]);
+    return { triplesBySubGraph: bySg, tripleCountBySubGraph: countBySg };
+  }, [canonicalTriples]);
 
   // Per-sub-graph layer counts — drives the mini pyramid on each card so
   // you can see at a glance which sub-graphs are mostly verified vs still
@@ -4087,31 +4101,25 @@ export function SubGraphOverviewGrid({
           // membership rule. Fall back to the server count if we have no
           // client set for this sub-graph (e.g. nothing yet hydrated).
           entityCount: cardEntityUris.size > 0 ? cardEntityUris.size : sg.entityCount,
-          tripleCount: sg.tripleCount,
+          // GH #819 — `tripleCount` reads the canonical per-subgraph
+          // pre-cap distinct total (`tripleCountBySubGraph` derived
+          // from `canonicalTriples` post-residue-filter +
+          // post-dedup). Card stat now agrees with the subtitle's
+          // distinct total when summed without double-counting
+          // cross-graph duplicates. Pre-#819 this read `sg.tripleCount`
+          // (daemon-reported raw count) which inflated on CGs with
+          // cross-graph SPO duplicates. Falls back to `sg.tripleCount`
+          // ONLY when the canonical helper has no rows for this slug
+          // (loading state / sub-graph hydrated but no triples yet),
+          // matching the entityCount fallback pattern above.
+          tripleCount: tripleCountBySubGraph.get(sg.name) ?? sg.tripleCount,
           triples: filterTriplesToEntities(rawTriples, cardEntityUris),
           layerCounts: layerCountsBySubGraph.get(sg.name) ?? { wm: 0, swm: 0, vm: 0 },
           entityTrustByUri: cardEntityTrust,
         };
       })
       .sort((a, b) => a.rank - b.rank);
-  }, [subGraphs, profile, triplesBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph]);
-
-  // GH #805 — subtitle triple total swapped to the same
-  // `useLayerTriples` layer-sum derivation now used by the
-  // Overview Triples stat (`:801`). Pre-GH-#805 the subtitle
-  // read `memory.allTriples.length` directly (canonical-source
-  // discipline established by round 4.1's chip-row anchor); that
-  // anchor was correct *given* the upstream value was honest, but
-  // `allTriples` lifts SWM cross-graph SPO duplicates + WM residue,
-  // so even the chip-row-anchored value was over-counting on CGs
-  // with published SWM or promoted entities. Summing per-layer
-  // slices restores the "subtitle agrees with LayerStats" invariant
-  // round 4.1 was actually after.
-  const wmSubtitleTriples = useLayerTriples(memory, 'wm');
-  const swmSubtitleTriples = useLayerTriples(memory, 'swm');
-  const vmSubtitleTriples = useLayerTriples(memory, 'vm');
-  const subtitleTripleCount =
-    wmSubtitleTriples.length + swmSubtitleTriples.length + vmSubtitleTriples.length;
+  }, [subGraphs, profile, triplesBySubGraph, tripleCountBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph]);
 
   // GH #813 — Root mini-card. Synthesizes a card for the
   // "entities not in any named sub-graph" bucket so the grid
@@ -4192,37 +4200,22 @@ export function SubGraphOverviewGrid({
     // canonical-URI membership check + canonical SPO-dedup key
     // still apply on the symmetric-with-named universe.
     //
-    // PR #818 Codex sweep 6 — admission rule symmetry. Sweep 4's
-    // inline check was OR-membership ("admit if either endpoint
-    // is in rootEntityUris"), but named cards route through
-    // `filterTriplesToEntities(rawTriples, cardEntityUris)` at
-    // `:4051`, which is AND-membership with an `rdf:type`
-    // exemption. User caught the divergence on `ui-refresh`:
-    // entity `urn:epcis:...:gtin:50127962004651:lot:P240526X`
-    // lives in `epcis-supply-chain` (subGraphs non-empty → not
-    // in rootEntityUris → correctly absent from the Root entity
-    // list), but the daemon ships untagged copies of its triples
-    // in `<cg>/_shared_memory`. Pre-sweep-6 OR-membership
-    // admitted those rows because the SUBJECT was in
-    // rootEntityUris (a different entity), so the non-root
-    // object rendered as a node — Root mini-graph had more
-    // nodes than the badge claimed.
+    // PR #818 Codex sweep 6 — admission rule symmetry. Named
+    // cards route through `filterTriplesToEntities(rawTriples,
+    // cardEntityUris)` at `:4051` (AND-membership with rdf:type
+    // exemption). User caught the divergence on `ui-refresh`:
+    // pre-sweep-6 OR-membership admitted rows whose non-root
+    // object rendered as a phantom node in the Root mini-graph.
     //
-    // Fix: dedup SPO first (Bug M canonicalization preserved),
-    // then route through `filterTriplesToEntities` so admission
-    // matches the named-card rule exactly. Same machinery now
-    // includes the same AND-membership + rdf:type exemption.
-    const candidateTriples: Triple[] = [];
-    const seenSpo = new Set<string>();
-    for (const t of memory.allTriples) {
-      if (t.subGraph) continue;
-      const subjCanon = canonicalEntityUri(t.subject);
-      const objCanon = canonicalEntityUri(t.object);
-      const key = `${subjCanon}|${t.predicate}|${objCanon}`;
-      if (seenSpo.has(key)) continue;
-      seenSpo.add(key);
-      candidateTriples.push({ subject: t.subject, predicate: t.predicate, object: t.object });
-    }
+    // GH #819 — source from `useCanonicalTriples` so the Root
+    // card inherits the canonical dedup + residue rule (same
+    // input every other aggregate triple consumer reads from);
+    // then narrow to `!t.subGraph` for the Root scope and route
+    // through `filterTriplesToEntities` for AND-membership +
+    // rdf:type exemption. Replaces the inline canonical-SPO
+    // dedup that lived here from sweeps 1+4+6 — the helper has
+    // already done that work.
+    const candidateTriples = canonicalTriples.filter(t => !t.subGraph);
     const rootTriples = filterTriplesToEntities(candidateTriples, rootEntityUris);
     // PR #818 Codex sweep 4 (finding 3) — shared cap helper. The
     // earlier inline copy duplicated the named-card sampling shape
@@ -4253,7 +4246,7 @@ export function SubGraphOverviewGrid({
       layerCounts: { wm, swm, vm },
       entityTrustByUri: rootEntityTrust,
     };
-  }, [memory.entityList, memory.allTriples, profile]);
+  }, [memory.entityList, canonicalTriples, profile]);
 
   if (loading && cards.length === 0) {
     return (

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -59,7 +59,7 @@ import {
   entityAuthorUri, transitionAgentUri, transitionAtISO,
   shortType, shortPred, entityMeta,
   buildLayerGraphOptions, getDescription, neighborhoodTriples, neutraliseBuiltinNamespaces,
-  matchesSearch, humanizeLabel, layerNoun, useLayerTriples, useCanonicalTriples,
+  matchesSearch, humanizeLabel, layerNoun, useLayerTriples, useCanonicalTriples, applyCanonicalAdmission,
   filterTriplesToEntities, admitTripleForScope,
   entityTimestamp, formatRelativeTime, formatTimelineBucket, formatTrailTimestamp,
   type LayerView, type LayerContentTab, type KAPane,
@@ -3960,7 +3960,7 @@ export function SubGraphOverviewGrid({
   // residue + cross-graph dedup but still dropped mixed-layer
   // edges. The canonical helper's BOTH-endpoints-moved rule keeps
   // those mixed-layer edges as facts.
-  const { triples: canonicalTriples, total: subtitleTripleCount } = useCanonicalTriples(memory);
+  const { total: subtitleTripleCount } = useCanonicalTriples(memory);
 
   // GH #819 round 3 (Codex sweep 1 🔴 #3) — discriminator for the
   // named-card `tripleCount` fallback below. The canonical universe
@@ -3993,46 +3993,50 @@ export function SubGraphOverviewGrid({
   // block for the sampling / dense-pack / residual-fallback
   // rationale carried over from PR #818 sweeps 1-3).
   //
-  // GH #819 round 3 (Codex sweep 1 🔴 #1) — re-dedupe per
-  // sub-graph bucket here rather than reading from
-  // `canonicalTriples`. `useCanonicalTriples` dedupes by
-  // `(canonical(s), p, canonical(o))` GLOBALLY across the whole
-  // project (correct for aggregate-total consumers). But the same
-  // `(s, p, o)` legitimately shipped under TWO different named
-  // sub-graphs (e.g. a cross-membership entity referenced from
-  // both alpha and beta) must surface in BOTH cards — only one
-  // copy survives in `canonicalTriples`, whichever row was
-  // visited first. Reading per-bucket from a globally-deduped set
-  // under-counts the late-arrival card by exactly the shared SPO
-  // count. Iterate `memory.allTriples` here and re-dedupe with
-  // `subGraph` implicit in the bucket scope so each card keeps
-  // its own scoped copy.
+  // GH #819 round 4 (Codex sweep 2 🔴 #5) — apply the canonical
+  // admission rule (residue filter + canonical-SPO dedup) PER
+  // BUCKET. Round 3's per-bucket SPO dedup correctly preserved
+  // cross-membership multiplicity (same SPO in two sub-graphs →
+  // both cards admit) but lacked the residue filter — so a WM
+  // residue row + its promoted SWM/VM copy in the SAME bucket
+  // (different objects, distinct SPO keys) could double-count
+  // and inflate `card.tripleCount` above the canonicalized
+  // subtitle total. `applyCanonicalAdmission` (shared with
+  // `useCanonicalTriples`) applies the residue rule + SPO dedup
+  // independently per scope — per-call dedup namespace means
+  // cross-membership multiplicity stays correct.
   //
   // `tripleCountBySubGraph` carries the pre-cap distinct total so
   // the card stat reads the true count (decoupled from the
   // post-cap rendered slice — same convention as Root card +
   // PR #839 sweep 2's helper-extract contract).
   const { triplesBySubGraph, tripleCountBySubGraph } = useMemo(() => {
-    const bySg = new Map<string, Triple[]>();
-    const seenBySg = new Map<string, Set<string>>();
+    // First pass: group raw rows by their subGraph tag.
+    const rawBySg = new Map<string, LayeredTriple[]>();
     for (const t of memory.allTriples) {
       if (!t.subGraph) continue;
-      const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
-      let seen = seenBySg.get(t.subGraph);
-      if (!seen) { seen = new Set(); seenBySg.set(t.subGraph, seen); }
-      if (seen.has(key)) continue;
-      seen.add(key);
-      let arr = bySg.get(t.subGraph);
-      if (!arr) { arr = []; bySg.set(t.subGraph, arr); }
-      arr.push({ subject: t.subject, predicate: t.predicate, object: t.object });
+      let arr = rawBySg.get(t.subGraph);
+      if (!arr) { arr = []; rawBySg.set(t.subGraph, arr); }
+      arr.push(t);
     }
+    // Second pass: apply canonical admission (residue +
+    // canonical-SPO dedup) per bucket independently. Per-call
+    // dedup state means cross-scope SPOs each admit in their
+    // own scope (round 3 🔴 #1 property preserved).
+    const bySg = new Map<string, Triple[]>();
     const countBySg = new Map<string, number>();
-    for (const [sg, triples] of bySg) {
-      countBySg.set(sg, triples.length);
-      bySg.set(sg, applyHeaviestSubjectsCap(triples));
+    for (const [sg, rawRows] of rawBySg) {
+      const admitted = applyCanonicalAdmission(rawRows, memory.entities);
+      const stripped = admitted.map(t => ({
+        subject: t.subject,
+        predicate: t.predicate,
+        object: t.object,
+      }));
+      countBySg.set(sg, stripped.length);
+      bySg.set(sg, applyHeaviestSubjectsCap(stripped));
     }
     return { triplesBySubGraph: bySg, tripleCountBySubGraph: countBySg };
-  }, [memory.allTriples]);
+  }, [memory.allTriples, memory.entities]);
 
   // Per-sub-graph layer counts — drives the mini pyramid on each card so
   // you can see at a glance which sub-graphs are mostly verified vs still
@@ -4157,13 +4161,9 @@ export function SubGraphOverviewGrid({
           // error, partial result (some layer query failed), or any
           // per-layer status not yet 'ok'. Round 2 gated only on
           // `memory.loading` which missed the post-hydration error
-          // case (`loading` flips false but `canonicalTriples` is
-          // still incomplete because a layer query failed). After a
-          // layer failure, a sub-graph whose triples live in the
-          // missing layer would render `0 triples` instead of
-          // falling back to the daemon's lower-bound. The widened
-          // gate keeps the fallback active for every state where
-          // the canonical universe can't be trusted as complete.
+          // case (`loading` flips false but the canonical universe
+          // is still incomplete because a layer query failed).
+          //
           tripleCount: canonicalIncomplete
             ? (tripleCountBySubGraph.get(sg.name) ?? sg.tripleCount)
             : (tripleCountBySubGraph.get(sg.name) ?? 0),
@@ -4261,15 +4261,26 @@ export function SubGraphOverviewGrid({
     // pre-sweep-6 OR-membership admitted rows whose non-root
     // object rendered as a phantom node in the Root mini-graph.
     //
-    // GH #819 — source from `useCanonicalTriples` so the Root
-    // card inherits the canonical dedup + residue rule (same
-    // input every other aggregate triple consumer reads from);
-    // then narrow to `!t.subGraph` for the Root scope and route
-    // through `filterTriplesToEntities` for AND-membership +
-    // rdf:type exemption. Replaces the inline canonical-SPO
-    // dedup that lived here from sweeps 1+4+6 — the helper has
-    // already done that work.
-    const candidateTriples = canonicalTriples.filter(t => !t.subGraph);
+    // GH #819 round 4 (Codex sweep 2 🔴 #7) — Root candidates
+    // are root-scoped rows (`!t.subGraph`) from raw
+    // `memory.allTriples`, then passed through
+    // `applyCanonicalAdmission` for independent per-scope
+    // residue + SPO dedup. Pre-round-4 this filtered
+    // `canonicalTriples` (which had already been GLOBALLY
+    // deduped) for `!t.subGraph` rows — order-dependent: if a
+    // tagged copy of the same SPO arrived first in the global
+    // pass, the root copy lost the dedup race and `filter(!t.subGraph)`
+    // dropped the surviving entry, leaving Root showing 0.
+    // Same root-cause family as 🔴 #5 — global dedup namespace
+    // collided with per-scope needs. Per-call namespace via
+    // `applyCanonicalAdmission` fixes both.
+    //
+    // Then routed through `filterTriplesToEntities` for AND-
+    // membership + rdf:type exemption (PR #818 sweep 6
+    // admission rule preserved).
+    const rootScopedRaw = memory.allTriples.filter(t => !t.subGraph);
+    const candidateTriples = applyCanonicalAdmission(rootScopedRaw, memory.entities)
+      .map(t => ({ subject: t.subject, predicate: t.predicate, object: t.object }));
     const rootTriples = filterTriplesToEntities(candidateTriples, rootEntityUris);
     // PR #818 Codex sweep 4 (finding 3) — shared cap helper. The
     // earlier inline copy duplicated the named-card sampling shape
@@ -4300,7 +4311,7 @@ export function SubGraphOverviewGrid({
       layerCounts: { wm, swm, vm },
       entityTrustByUri: rootEntityTrust,
     };
-  }, [memory.entityList, canonicalTriples, profile]);
+  }, [memory.entityList, memory.allTriples, memory.entities, profile]);
 
   if (loading && cards.length === 0) {
     return (

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3984,12 +3984,30 @@ export function SubGraphOverviewGrid({
     || memory.partial
     || layerStatuses.some(s => s === 'error');
 
-  // Bucket every triple by its origin sub-graph so each mini-graph
-  // renders just its slice. Cap per-bucket via the shared
-  // `applyHeaviestSubjectsCap` helper at module scope (see its doc
-  // block for the sampling / dense-pack / residual-fallback
-  // rationale carried over from sweeps 1-3).
+  // Task #25 (PR #677) — entity-only filter for the mini-card
+  // thumbnails. Same rule the Entities tab uses; computed per card
+  // scoped to that card's sub-graph (Codex Ev_S2): an entity that's
+  // first-class in sub-graph B but only a value/provenance object in
+  // sub-graph A must not render on A's thumbnail. Per-sub-graph scope
+  // = `memory.entityList.filter(e => e.subGraphs.has(sg.name))`.
   //
+  // GH #819 round 11 (Codex sweep 9 🔴 #19) — also consumed by the
+  // bucketer below for promoted-untagged row recovery (via
+  // `admitTripleForScope`), so it's hoisted above the bucketer's
+  // useMemo.
+  const entityUrisBySubGraph = useMemo(() => {
+    const out = new Map<string, Set<string>>();
+    for (const e of memory.entityList) {
+      const canonical = canonicalEntityUri(e.uri);
+      for (const sg of e.subGraphs) {
+        let s = out.get(sg);
+        if (!s) { s = new Set(); out.set(sg, s); }
+        s.add(canonical);
+      }
+    }
+    return out;
+  }, [memory.entityList]);
+
   // Bucket every triple by its origin sub-graph so each mini-graph
   // renders just its slice. Cap per-bucket via the shared
   // `applyHeaviestSubjectsCap` helper at module scope (see its doc
@@ -3998,34 +4016,53 @@ export function SubGraphOverviewGrid({
   //
   // GH #819 round 4 (Codex sweep 2 🔴 #5) — apply the canonical
   // admission rule (residue filter + canonical-SPO dedup) PER
-  // BUCKET. Round 3's per-bucket SPO dedup correctly preserved
-  // cross-membership multiplicity (same SPO in two sub-graphs →
-  // both cards admit) but lacked the residue filter — so a WM
-  // residue row + its promoted SWM/VM copy in the SAME bucket
-  // (different objects, distinct SPO keys) could double-count
-  // and inflate `card.tripleCount` above the canonicalized
-  // subtitle total. `applyCanonicalAdmission` (shared with
-  // `useCanonicalTriples`) applies the residue rule + SPO dedup
-  // independently per scope — per-call dedup namespace means
-  // cross-membership multiplicity stays correct.
+  // BUCKET. Per-call dedup state means cross-scope SPOs each admit
+  // in their own scope (round 3 🔴 #1 property preserved).
+  //
+  // GH #819 round 11 (Codex sweep 9 🔴 #19) — recover promoted-
+  // untagged rows. After promote/publish the daemon strips
+  // `subGraph` from triples; pre-round-11 we filtered to tagged
+  // rows only, so a fully-promoted subgraph's mini-card showed
+  // `0 triples` even though deep-dive listed the data. The rest
+  // of the UI recovers via `admitTripleForScope` entity-scope
+  // membership; the bucketer now mirrors that. Pass 1 keeps tagged
+  // rows in their declared bucket; pass 2 admits each untagged row
+  // to EVERY bucket whose `entityUrisBySubGraph` contains the
+  // subject or resource-object (no inner-loop break — a cross-
+  // membership entity's untagged edges legitimately appear in
+  // multiple subgraphs, preserving the round 3 #1 contract).
   //
   // `tripleCountBySubGraph` carries the pre-cap distinct total so
   // the card stat reads the true count (decoupled from the
   // post-cap rendered slice — same convention as Root card +
   // PR #839 sweep 2's helper-extract contract).
   const { triplesBySubGraph, tripleCountBySubGraph } = useMemo(() => {
-    // First pass: group raw rows by their subGraph tag.
     const rawBySg = new Map<string, LayeredTriple[]>();
+    // Pass 1: tagged rows route to their declared bucket.
     for (const t of memory.allTriples) {
       if (!t.subGraph) continue;
       let arr = rawBySg.get(t.subGraph);
       if (!arr) { arr = []; rawBySg.set(t.subGraph, arr); }
       arr.push(t);
     }
-    // Second pass: apply canonical admission (residue +
-    // canonical-SPO dedup) per bucket independently. Per-call
-    // dedup state means cross-scope SPOs each admit in their
-    // own scope (round 3 🔴 #1 property preserved).
+    // Pass 2: untagged rows recover via entity-scope membership
+    // (`admitTripleForScope` with `isRoot: false` and the bucket's
+    // scoped URI set — same rule the rest of the UI uses for
+    // sub-graph scope, PR #839 sweep 2 helper-extract).
+    for (const t of memory.allTriples) {
+      if (t.subGraph) continue;
+      for (const [sg, scopedUris] of entityUrisBySubGraph) {
+        if (admitTripleForScope(t, { slug: sg, isRoot: false, scopedUris })) {
+          let arr = rawBySg.get(sg);
+          if (!arr) { arr = []; rawBySg.set(sg, arr); }
+          arr.push(t);
+          // No break — cross-membership entity's untagged edges
+          // legitimately appear in multiple subgraphs.
+        }
+      }
+    }
+    // Pass 3: apply canonical admission (residue + canonical-SPO
+    // dedup) per bucket independently.
     const bySg = new Map<string, Triple[]>();
     const countBySg = new Map<string, number>();
     for (const [sg, rawRows] of rawBySg) {
@@ -4039,7 +4076,7 @@ export function SubGraphOverviewGrid({
       bySg.set(sg, applyHeaviestSubjectsCap(stripped));
     }
     return { triplesBySubGraph: bySg, tripleCountBySubGraph: countBySg };
-  }, [memory.allTriples, memory.entities]);
+  }, [memory.allTriples, memory.entities, entityUrisBySubGraph]);
 
   // Per-sub-graph layer counts — drives the mini pyramid on each card so
   // you can see at a glance which sub-graphs are mostly verified vs still
@@ -4057,25 +4094,6 @@ export function SubGraphOverviewGrid({
         if (e.trustLevel === 'verified') counts.vm++;
         else if (e.trustLevel === 'shared') counts.swm++;
         else counts.wm++;
-      }
-    }
-    return out;
-  }, [memory.entityList]);
-
-  // Task #25 (PR #677) — entity-only filter for the mini-card
-  // thumbnails. Same rule the Entities tab uses; computed per card
-  // scoped to that card's sub-graph (Codex Ev_S2): an entity that's
-  // first-class in sub-graph B but only a value/provenance object in
-  // sub-graph A must not render on A's thumbnail. Per-sub-graph scope
-  // = `memory.entityList.filter(e => e.subGraphs.has(sg.name))`.
-  const entityUrisBySubGraph = useMemo(() => {
-    const out = new Map<string, Set<string>>();
-    for (const e of memory.entityList) {
-      const canonical = canonicalEntityUri(e.uri);
-      for (const sg of e.subGraphs) {
-        let s = out.get(sg);
-        if (!s) { s = new Set(); out.set(sg, s); }
-        s.add(canonical);
       }
     }
     return out;

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3962,23 +3962,27 @@ export function SubGraphOverviewGrid({
   // those mixed-layer edges as facts.
   const { total: subtitleTripleCount } = useCanonicalTriples(memory);
 
-  // GH #819 round 6 (Codex sweep 4 🔴 #11) — hydration-state gate
-  // for the per-card badge. `useMemoryEntities` initializes
-  // `allTriples = []` (`useMemoryEntities.ts:590`), so between
-  // `/sub-graph/list` resolving (which fills `subGraphs`) and
-  // WM/SWM/VM finishing (which fills `allTriples`), every named-
-  // and Root-card derives `tripleCount = 0`. Round 5 collapsed
-  // the badge to `card.tripleCount ?? 0`, conflating "still
-  // loading" with "genuine empty". Revive the discriminator at
-  // the grid scope; the badge below uses it to render a hydration
-  // affordance ("…") instead of `0 triples` while canonical is
-  // incomplete. Hydrated-fully state still reads `0 triples`
-  // honestly (genuine zero shows through).
-  const canonicalIncomplete =
-    memory.loading
-    || memory.error !== null
+  // GH #819 round 7 (Codex sweep 5 🔴 #14) — split the hydration
+  // gate from the failure gate. Round 6 collapsed both into one
+  // `canonicalIncomplete` flag and rendered the "Loading…"
+  // affordance for both — so a settled error/partial result kept
+  // masquerading as in-progress hydration forever.
+  //
+  // `MemoryLayerStatus` is `'loading' | 'ok' | 'error'`
+  // (`useMemoryEntities.ts:8`). `isHydrating` covers the transient
+  // state (initial fetch in flight, or any layer's status === 'loading');
+  // `isFailedOrPartial` covers the settled-incomplete state
+  // (hard error, partial result, or any layer's status === 'error').
+  // The badge matrix at the render site routes them to different
+  // affordances: loading → `…`, failed/partial → `0 triples` with
+  // a "Some layers unavailable" tooltip.
+  const layerStatuses = Object.values(memory.layerStatus ?? {});
+  const isHydrating =
+    memory.loading || layerStatuses.some(s => s === 'loading');
+  const isFailedOrPartial =
+    memory.error !== null
     || memory.partial
-    || Object.values(memory.layerStatus ?? {}).some(s => s !== 'ok');
+    || layerStatuses.some(s => s === 'error');
 
   // Bucket every triple by its origin sub-graph so each mini-graph
   // renders just its slice. Cap per-bucket via the shared
@@ -4428,7 +4432,8 @@ export function SubGraphOverviewGrid({
           <SubGraphMiniCard
             key={card.slug}
             card={card}
-            canonicalIncomplete={canonicalIncomplete}
+            isHydrating={isHydrating}
+            isFailedOrPartial={isFailedOrPartial}
             onNodeClick={onNodeClick}
             onOpen={() => onSelectSubGraph(card.slug)}
           />
@@ -4442,7 +4447,8 @@ export function SubGraphOverviewGrid({
         <SubGraphMiniCard
           key={ROOT_SLUG_SENTINEL}
           card={rootCard}
-          canonicalIncomplete={canonicalIncomplete}
+          isHydrating={isHydrating}
+          isFailedOrPartial={isFailedOrPartial}
           onNodeClick={onNodeClick}
           onOpen={() => onSelectSubGraph(ROOT_SLUG_SENTINEL)}
           variant="root"
@@ -4454,7 +4460,8 @@ export function SubGraphOverviewGrid({
 
 export function SubGraphMiniCard({
   card,
-  canonicalIncomplete = false,
+  isHydrating = false,
+  isFailedOrPartial = false,
   onNodeClick,
   onOpen,
   variant,
@@ -4466,14 +4473,17 @@ export function SubGraphMiniCard({
     layerCounts: { wm: number; swm: number; vm: number };
     entityTrustByUri: Map<string, TrustLevel>;
   };
-  // GH #819 round 6 — true while WM/SWM/VM are still hydrating
-  // (or any layer query errored). Drives the badge's hydration
-  // affordance so a non-empty subgraph doesn't flash `0 triples`
-  // between `/sub-graph/list` resolve and full layer hydration
-  // (Codex sweep 4 🔴 #11). Defaults to false so consumers that
-  // don't (or can't) thread the discriminator render the badge
+  // GH #819 round 7 (Codex sweep 5 🔴 #14) — split hydration vs
+  // failure flags. `isHydrating` is the transient state (still
+  // fetching, no settled result yet); the badge renders the `…`
+  // loading affordance when bucket is empty. `isFailedOrPartial`
+  // is the settled-incomplete state (hard error or partial
+  // result); the badge keeps `0 triples` but adds a tooltip so
+  // users see the result is best-effort. Both default to false
+  // so consumers that don't thread the gates render the badge
   // exactly as before.
-  canonicalIncomplete?: boolean;
+  isHydrating?: boolean;
+  isFailedOrPartial?: boolean;
   onNodeClick?: (node: any) => void;
   onOpen: () => void;
   // GH #813 — `root` opts into the quieter neutral-border chrome
@@ -4574,26 +4584,32 @@ export function SubGraphMiniCard({
             quiet case. Same conditional-when-it-has-something-to-
             say pattern as S2's `Pending join requests` empty
             state. */}
-        {/* GH #819 round 6 (Codex sweep 4 🔴 #11) — hydration
-            affordance. `useMemoryEntities` initializes
-            `allTriples = []`, so between `/sub-graph/list`
-            resolve (which fills `subGraphs`) and WM/SWM/VM
-            finishing (which fills `allTriples`), `card.tripleCount`
-            derives 0 even for non-empty subgraphs. Render `…`
-            during that window so the badge doesn't masquerade
-            a hydration race as a genuine empty bucket. Once
-            canonical hydrates, the actual count (including a
-            genuine 0) shows through honestly. */}
+        {/* GH #819 round 7 (Codex sweep 5 🔴 #14) — split badge
+            matrix. Round 6 lumped loading + error into one gate
+            and showed the loading affordance for both; after a
+            settled failure the badge masqueraded as "still
+            loading" forever. The split routes each state:
+              • bucket > 0 → render the count normally.
+              • bucket 0 + hydrating → `…` "Loading triples…"
+              • bucket 0 + failed/partial (not hydrating) →
+                `0 triples` with "Some layers unavailable;
+                count may be incomplete" tooltip.
+              • bucket 0 + neither → honest `0 triples`.
+            `isHydrating` wins over `isFailedOrPartial` when both
+            are true — a transient state takes precedence over
+            the settled-incomplete signal. */}
         <span
           className="v10-sgov-card-stat"
           title={
-            canonicalIncomplete && card.tripleCount === 0
+            isHydrating && card.tripleCount === 0
               ? 'Loading triples for this subgraph…'
-              : card.tripleCount !== card.triples.length
-                ? `${card.tripleCount} triples in this subgraph's scope; ${card.triples.length} rendered (cross-card edges whose other endpoint isn't in this subgraph aren't drawn here).`
-                : undefined
+              : isFailedOrPartial && card.tripleCount === 0
+                ? 'Some layers unavailable; count may be incomplete.'
+                : card.tripleCount !== card.triples.length
+                  ? `${card.tripleCount} triples in this subgraph's scope; ${card.triples.length} rendered (cross-card edges whose other endpoint isn't in this subgraph aren't drawn here).`
+                  : undefined
           }
-        ><b>{canonicalIncomplete && card.tripleCount === 0 ? '…' : card.tripleCount}</b> triples</span>
+        ><b>{isHydrating && card.tripleCount === 0 ? '…' : card.tripleCount}</b> triples</span>
       </div>
       <div className="v10-sgov-card-pyramid">
         {/* compact mode collapses the empty-counts branch to `null`

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4584,27 +4584,30 @@ export function SubGraphMiniCard({
             quiet case. Same conditional-when-it-has-something-to-
             say pattern as S2's `Pending join requests` empty
             state. */}
-        {/* GH #819 round 7 (Codex sweep 5 🔴 #14) — split badge
-            matrix. Round 6 lumped loading + error into one gate
-            and showed the loading affordance for both; after a
-            settled failure the badge masqueraded as "still
-            loading" forever. The split routes each state:
-              • bucket > 0 → render the count normally.
-              • bucket 0 + hydrating → `…` "Loading triples…"
-              • bucket 0 + failed/partial (not hydrating) →
-                `0 triples` with "Some layers unavailable;
-                count may be incomplete" tooltip.
-              • bucket 0 + neither → honest `0 triples`.
-            `isHydrating` wins over `isFailedOrPartial` when both
-            are true — a transient state takes precedence over
-            the settled-incomplete signal. */}
+        {/* GH #819 round 10 (Codex sweep 8 🟡 #18) — extended badge
+            matrix. Rounds 6/7 only fired the failure tooltip on
+            zero-bucket cards; a partial-layer-failure with a
+            non-zero bucket rendered the count with no disclosure
+            that some layers were unavailable. Now `isFailedOrPartial`
+            fires for ALL bucket values — when bucket > 0 the
+            tooltip prefixes the count with "{N} triples (some
+            layers unavailable; count may be incomplete)."
+            Precedence (top wins):
+              • hydrating + bucket 0  → `…` "Loading triples…"
+              • failed/partial (any bucket) → "{N} triples (some
+                layers unavailable; count may be incomplete)."
+              • stat-vs-rendered mismatch → β literal (round 8)
+              • otherwise → no tooltip
+            Failure wins over the stat-vs-rendered tooltip — once
+            layers re-hydrate the cap-truncation gap recomputes
+            correctly; the failure signal is the louder one. */}
         <span
           className="v10-sgov-card-stat"
           title={
             isHydrating && card.tripleCount === 0
               ? 'Loading triples for this subgraph…'
-              : isFailedOrPartial && card.tripleCount === 0
-                ? 'Some layers unavailable; count may be incomplete.'
+              : isFailedOrPartial
+                ? `${card.tripleCount} triples (some layers unavailable; count may be incomplete).`
                 : card.tripleCount !== card.triples.length
                   // GH #819 round 8 (Codex sweep 6 🟡 #4 / #9 / #12,
                   // team-lead call β) — broader wording so the

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -3962,25 +3962,6 @@ export function SubGraphOverviewGrid({
   // those mixed-layer edges as facts.
   const { total: subtitleTripleCount } = useCanonicalTriples(memory);
 
-  // GH #819 round 3 (Codex sweep 1 🔴 #3) — discriminator for the
-  // named-card `tripleCount` fallback below. The canonical universe
-  // is INCOMPLETE when any of these is true:
-  //   • `memory.loading` — initial hydration in flight
-  //   • `memory.error`   — hard error (e.g. /api/query unreachable)
-  //   • `memory.partial` — some-but-not-all layer queries failed
-  //   • any layer status pending or errored — narrowest signal
-  // Round 2 gated on `memory.loading` alone, which missed the
-  // hydrated-after-layer-failure case (loading flips false but
-  // canonical is still incomplete). The widened gate keeps the
-  // daemon-reported `sg.tripleCount` lower-bound active for every
-  // state where the canonical universe can't be trusted as the
-  // ground truth.
-  const canonicalIncomplete =
-    memory.loading
-    || memory.error !== null
-    || memory.partial
-    || Object.values(memory.layerStatus ?? {}).some(s => s !== 'ok');
-
   // Bucket every triple by its origin sub-graph so each mini-graph
   // renders just its slice. Cap per-bucket via the shared
   // `applyHeaviestSubjectsCap` helper at module scope (see its doc
@@ -4164,27 +4145,28 @@ export function SubGraphOverviewGrid({
           // case (`loading` flips false but the canonical universe
           // is still incomplete because a layer query failed).
           //
-          // GH #819 round 4 (Codex sweep 2 🔴 #6) — precedence fix.
-          // Round 3's `?? sg.tripleCount` only fell through when
-          // the bucket was undefined, but a partial-hydrated bucket
-          // (e.g. 3 of an expected 10) had a value and won the
-          // discriminator — the badge undercounted to 3 instead of
-          // the daemon's 10. `Math.max(...)` clamps to the LARGER
-          // of the partial-hydrated bucket and the daemon count
-          // when canonical is incomplete: surfaces the truer
-          // lower-bound either way (defends against the daemon
-          // undershooting too). Hydrated-fully state still reads
-          // the canonical bucket honestly (zero shows through).
-          tripleCount: canonicalIncomplete
-            ? Math.max(sg.tripleCount, tripleCountBySubGraph.get(sg.name) ?? 0)
-            : (tripleCountBySubGraph.get(sg.name) ?? 0),
+          // GH #819 round 5 (Codex sweep 3 🔴 #8) — never read the
+          // daemon-reported `sg.tripleCount`. The daemon route
+          // (`packages/cli/src/daemon/routes/context-graph.ts:769`)
+          // builds it via raw `COUNT(*)` SPARQL grouped by named
+          // graph and sums per first-path-segment — NO SPO-dedup,
+          // NO residue filter. So `sg.tripleCount` is structurally
+          // inflated by the same cross-graph dupes + WM residue
+          // this PR is removing. Earlier rounds tried to use it as
+          // a lower-bound fallback when canonical was incomplete;
+          // that was wrong — it's an UPPER bound (inflated), not a
+          // lower one. Render the client-canonical bucket honestly,
+          // even when a layer query errored mid-hydration: missing
+          // bucket → 0 (genuine empty), partial-hydrated → the
+          // count of what we could honestly admit. No upward clamp.
+          tripleCount: tripleCountBySubGraph.get(sg.name) ?? 0,
           triples: filterTriplesToEntities(rawTriples, cardEntityUris),
           layerCounts: layerCountsBySubGraph.get(sg.name) ?? { wm: 0, swm: 0, vm: 0 },
           entityTrustByUri: cardEntityTrust,
         };
       })
       .sort((a, b) => a.rank - b.rank);
-  }, [subGraphs, profile, triplesBySubGraph, tripleCountBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph, canonicalIncomplete]);
+  }, [subGraphs, profile, triplesBySubGraph, tripleCountBySubGraph, layerCountsBySubGraph, entityUrisBySubGraph, entityTrustByUriBySubGraph]);
 
   // GH #813 — Root mini-card. Synthesizes a card for the
   // "entities not in any named sub-graph" bucket so the grid

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -461,6 +461,92 @@ export function admitTripleForScope(
     : opts.scopedUris.has(t.object);
 }
 
+/**
+ * GH #819 — canonical triple total across the whole project.
+ *
+ * Returns a single, deduplicated, residue-filtered set of triples that
+ * every "aggregate triple count" surface in the UI should anchor on
+ * (Overview Triples stat, SubGraphOverviewGrid subtitle, Root +
+ * Named mini-card `tripleCount`, Dashboard per-CG and aggregate
+ * totals). The pattern is the same shared-helper-with-different-
+ * consumption shape S3 [#2/#7] established for `useLayerTriples` —
+ * one source of truth, different read shapes per consumer.
+ *
+ * Single iteration over `memory.allTriples` applying three rules in
+ * order:
+ *
+ *   1. Subject-side residue. If the subject's canonical
+ *      `trustLevel` doesn't match the row's `layer`, the row may be
+ *      residue (post-promote the daemon leaves the WM
+ *      `/assertion/<addr>/<name>` graphs on disk; the WM rows keep
+ *      coming back from `wmSparql` even after the entity has been
+ *      promoted to SWM/VM). Carry the subject-mismatch flag forward
+ *      and combine with the object check below.
+ *
+ *   2. Object-side residue — only when the object's canonical
+ *      `trustLevel` ALSO disagrees with the row's `layer`. This is
+ *      the key distinction from `useLayerTriples`:454-458 — the
+ *      per-layer rule drops a mixed-layer edge whose object has
+ *      moved past the requested layer, because per-layer tabs are
+ *      tallying "facts canonically at this layer". The canonical
+ *      total is summing across layers, so a mixed-layer edge (one
+ *      endpoint still at `t.layer`) is a legitimate fact and stays.
+ *      Only drop when BOTH endpoints have moved past — that's
+ *      unambiguous residue.
+ *
+ *   3. Global canonical-SPO dedup. Same `(s,p,o)` in multiple named
+ *      graphs (e.g. SWM cross-graph shipping — root SWM + per-sub-
+ *      graph SWM) admits exactly once. Wrapped + bare variants of
+ *      the same SPO collapse via `canonicalEntityUri()` on both
+ *      subject and object.
+ *
+ * Orphan-entity pass-through: a triple whose subject isn't in the
+ * entity map (literal orphans, class IRIs that only ever appear as
+ * objects) admits unfiltered. Without the `subjectEntity &&` guard
+ * rdf:type / class-IRI rows would silently drop and the canonical
+ * total would miss them. Mirror of the same guard
+ * `useLayerTriples:487-488` carries.
+ *
+ * Out of scope: this helper does NOT apply
+ * `applyHeaviestSubjectsCap` (render-only; mini-card consumers
+ * apply it downstream) and does NOT take an `entityScope` arg
+ * (consumer-side responsibility — see `admitTripleForScope` for
+ * the scope primitive). `total` is a convenience for count-only
+ * consumers that don't need the underlying array.
+ */
+export function useCanonicalTriples(
+  memory: ReturnType<typeof useMemoryEntities>,
+): { triples: Triple[]; total: number } {
+  return useMemo(() => {
+    const seen = new Set<string>();
+    const out: Triple[] = [];
+    for (const t of memory.allTriples) {
+      const subjectEntity = memory.entities.get(canonicalEntityUri(t.subject));
+      const subjectMoved =
+        subjectEntity !== undefined && subjectEntity.trustLevel !== t.layer;
+      // Object-side residue check only fires for resource-shaped
+      // objects (literals can't be entities and so can't be
+      // "promoted"). When both endpoints have moved past the row's
+      // layer the triple is unambiguous residue and drops.
+      let dropAsResidue = false;
+      if (subjectMoved && isResourceObject(t.object)) {
+        const objectEntity = memory.entities.get(canonicalEntityUri(t.object));
+        if (objectEntity && objectEntity.trustLevel !== t.layer) {
+          dropAsResidue = true;
+        }
+      }
+      if (dropAsResidue) continue;
+      // Canonical-SPO dedup keyed on the canonical forms so wrapped
+      // (`<urn:...>`) and bare variants of the same triple collapse.
+      const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(t);
+    }
+    return { triples: out, total: out.length };
+  }, [memory.allTriples, memory.entities]);
+}
+
 export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, layer: 'wm' | 'swm' | 'vm'): Triple[] {
   const targetLayer = LAYER_CONFIG[layer].trustLevel;
   return useMemo(() => {

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -520,35 +520,62 @@ export function admitTripleForScope(
  * the scope primitive). `total` is a convenience for count-only
  * consumers that don't need the underlying array.
  */
+/**
+ * Pure non-hook admission pass shared by `useCanonicalTriples`
+ * (project-wide) and per-scope consumers (named-subgraph buckets,
+ * Root mini-card). Applies the canonical residue rule + canonical-
+ * SPO dedup to whatever triple slice the caller provides. The
+ * dedup state lives PER CALL, so per-scope consumers get an
+ * independent `(s,p,o)` namespace — same SPO that appears in two
+ * different scopes (cross-membership entity referenced from both
+ * alpha and beta sub-graphs) admits in each scope's call.
+ *
+ * Residue rule (matches `useCanonicalTriples`): drops a triple
+ * only when BOTH endpoints have canonical `trustLevel`s
+ * disagreeing with the row's `layer`. Mixed-layer edges (one
+ * endpoint still at `t.layer`, e.g. a cross-layer reference) and
+ * literal-object rows (object can't have moved, since literals
+ * aren't entities) admit. Orphan subjects (no entity record) pass
+ * through unfiltered — same `subjectEntity &&` guard as
+ * `useLayerTriples`.
+ *
+ * GH #819 round 4 (Codex sweep 2 🔴 #5 + 🔴 #7) — extracted so
+ * `triplesBySubGraph` per-bucket admission and Root card
+ * derivation can share the canonical helper's row-level admission
+ * rule WITHOUT sharing its global dedup namespace (which would
+ * collide cross-scope SPOs).
+ */
+export function applyCanonicalAdmission(
+  triples: readonly LayeredTriple[],
+  entities: ReadonlyMap<string, MemoryEntity>,
+): LayeredTriple[] {
+  const seen = new Set<string>();
+  const out: LayeredTriple[] = [];
+  for (const t of triples) {
+    const subjectEntity = entities.get(canonicalEntityUri(t.subject));
+    const subjectMoved =
+      subjectEntity !== undefined && subjectEntity.trustLevel !== t.layer;
+    let dropAsResidue = false;
+    if (subjectMoved && isResourceObject(t.object)) {
+      const objectEntity = entities.get(canonicalEntityUri(t.object));
+      if (objectEntity && objectEntity.trustLevel !== t.layer) {
+        dropAsResidue = true;
+      }
+    }
+    if (dropAsResidue) continue;
+    const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+  }
+  return out;
+}
+
 export function useCanonicalTriples(
   memory: ReturnType<typeof useMemoryEntities>,
 ): { triples: LayeredTriple[]; total: number } {
   return useMemo(() => {
-    const seen = new Set<string>();
-    const out: LayeredTriple[] = [];
-    for (const t of memory.allTriples) {
-      const subjectEntity = memory.entities.get(canonicalEntityUri(t.subject));
-      const subjectMoved =
-        subjectEntity !== undefined && subjectEntity.trustLevel !== t.layer;
-      // Object-side residue check only fires for resource-shaped
-      // objects (literals can't be entities and so can't be
-      // "promoted"). When both endpoints have moved past the row's
-      // layer the triple is unambiguous residue and drops.
-      let dropAsResidue = false;
-      if (subjectMoved && isResourceObject(t.object)) {
-        const objectEntity = memory.entities.get(canonicalEntityUri(t.object));
-        if (objectEntity && objectEntity.trustLevel !== t.layer) {
-          dropAsResidue = true;
-        }
-      }
-      if (dropAsResidue) continue;
-      // Canonical-SPO dedup keyed on the canonical forms so wrapped
-      // (`<urn:...>`) and bare variants of the same triple collapse.
-      const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push(t);
-    }
+    const out = applyCanonicalAdmission(memory.allTriples, memory.entities);
     return { triples: out, total: out.length };
   }, [memory.allTriples, memory.entities]);
 }

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -486,7 +486,10 @@ export function admitTripleForScope(
  *
  *   2. Object-side residue — only when the object's canonical
  *      `trustLevel` ALSO disagrees with the row's `layer`. This is
- *      the key distinction from `useLayerTriples`:454-458 — the
+ *      the key distinction from `useLayerTriples` (see its
+ *      object-side residue branch — same canonicalised
+ *      `objectEntity.trustLevel !== targetLayer` check, but ANDed
+ *      with the subject mismatch here rather than ORed). The
  *      per-layer rule drops a mixed-layer edge whose object has
  *      moved past the requested layer, because per-layer tabs are
  *      tallying "facts canonically at this layer". The canonical
@@ -505,8 +508,10 @@ export function admitTripleForScope(
  * entity map (literal orphans, class IRIs that only ever appear as
  * objects) admits unfiltered. Without the `subjectEntity &&` guard
  * rdf:type / class-IRI rows would silently drop and the canonical
- * total would miss them. Mirror of the same guard
- * `useLayerTriples:487-488` carries.
+ * total would miss them. Mirror of the same `subjectEntity &&`
+ * guard `useLayerTriples` carries on its subject-side residue
+ * check (see the matching `if (subjectEntity && ...)` pattern
+ * there).
  *
  * Out of scope: this helper does NOT apply
  * `applyHeaviestSubjectsCap` (render-only; mini-card consumers

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -5,6 +5,7 @@ import {
   type TrustLevel,
   type MemoryEntity,
   type Triple,
+  type LayeredTriple,
 } from '../../hooks/useMemoryEntities.js';
 import {
   VIZ_ANCHOR_TYPE, VIZ_AGENT_TYPE,
@@ -516,10 +517,10 @@ export function admitTripleForScope(
  */
 export function useCanonicalTriples(
   memory: ReturnType<typeof useMemoryEntities>,
-): { triples: Triple[]; total: number } {
+): { triples: LayeredTriple[]; total: number } {
   return useMemo(() => {
     const seen = new Set<string>();
-    const out: Triple[] = [];
+    const out: LayeredTriple[] = [];
     for (const t of memory.allTriples) {
       const subjectEntity = memory.entities.get(canonicalEntityUri(t.subject));
       const subjectMoved =

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -549,36 +549,26 @@ export function applyCanonicalAdmission(
   triples: readonly LayeredTriple[],
   entities: ReadonlyMap<string, MemoryEntity>,
 ): LayeredTriple[] {
-  // GH #819 round 7 (Codex sweep 5 🔴 #13) — pass 1 indexes the
-  // `(canonical-subject, predicate)` pairs that have a literal-
-  // object row stored AT the subject's canonical layer. That row
-  // is the "source of truth" for that (s,p) — any literal-object
-  // row at a LOWER layer for the same (s,p) where the subject
-  // has moved past that lower layer is residue from the
-  // pre-promotion state and must drop. The earlier residue rule
-  // (line 559 family) only handled resource-object residue;
-  // literal-object residue admitted both (old + new) because
-  // SPO dedup keys on the literal VALUE, so divergent literals
-  // produce distinct keys and both survive.
+  // GH #819 round 9 (Codex sweep 7 🔴 #16) — DESIGN NOTE.
+  // On literal-object rows: ALL literal values admit (no
+  // predicate-cardinality inference). Without metadata distinguishing
+  // single-valued predicates (e.g. `rdfs:label`, `schema:name`) from
+  // multi-valued ones (e.g. `skos:altLabel`, `dcat:keyword`,
+  // `rdfs:seeAlso`), we can't tell "stale literal residue" from
+  // "distinct multi-value fact". SPO dedup below collapses exact
+  // matches; divergent literal values both admit.
   //
-  // Edge cases this pass preserves:
-  // - Same literal at both layers (subject promoted): SPO dedup
-  //   collapses both to one row regardless of this pass.
-  // - Different literal, subject NOT promoted: subject's
-  //   canonical layer is the lower layer too, so no
-  //   canonical-layer row is indexed → no drop, both keep.
-  // - Literal at WM only, no canonical-layer literal for same
-  //   (s,p): pass-1 index is empty for that (s,p) → WM row
-  //   keeps (lower-layer-only fact).
-  const canonicalLiteralSP = new Set<string>();
-  for (const t of triples) {
-    if (isResourceObject(t.object)) continue;
-    const subjectEntity = entities.get(canonicalEntityUri(t.subject));
-    if (!subjectEntity) continue;
-    if (subjectEntity.trustLevel !== t.layer) continue;
-    canonicalLiteralSP.add(`${canonicalEntityUri(t.subject)}|${t.predicate}`);
-  }
-
+  // Trade-off: a single-valued predicate whose value changed on
+  // promotion (e.g. `name "old"` at WM, `name "new"` at SWM with
+  // the subject promoted) surfaces BOTH values until the daemon
+  // GCs the lower-layer assertion. Round 7 attempted to drop
+  // those as residue via a `(subject, predicate)` index, but
+  // that over-reached into multi-valued predicates (sweep 7
+  // finding #16 — a `(s, tag, "a")` WM row would silently lose
+  // its `"a"` value when `(s, tag, "b")` was promoted to SWM).
+  // Losing real multi-valued facts is worse than transiently
+  // double-showing single-valued ones; the round 7 logic was
+  // reverted.
   const seen = new Set<string>();
   const out: LayeredTriple[] = [];
   for (const t of triples) {
@@ -591,17 +581,6 @@ export function applyCanonicalAdmission(
       if (objectEntity && objectEntity.trustLevel !== t.layer) {
         dropAsResidue = true;
       }
-    }
-    // GH #819 round 7 — literal-residue. Subject moved past the
-    // row's layer AND a canonical-layer literal exists for the
-    // same (s,p) — drop the lower-layer literal as residue.
-    if (
-      !dropAsResidue
-      && subjectMoved
-      && !isResourceObject(t.object)
-      && canonicalLiteralSP.has(`${canonicalEntityUri(t.subject)}|${t.predicate}`)
-    ) {
-      dropAsResidue = true;
     }
     if (dropAsResidue) continue;
     const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -549,6 +549,36 @@ export function applyCanonicalAdmission(
   triples: readonly LayeredTriple[],
   entities: ReadonlyMap<string, MemoryEntity>,
 ): LayeredTriple[] {
+  // GH #819 round 7 (Codex sweep 5 🔴 #13) — pass 1 indexes the
+  // `(canonical-subject, predicate)` pairs that have a literal-
+  // object row stored AT the subject's canonical layer. That row
+  // is the "source of truth" for that (s,p) — any literal-object
+  // row at a LOWER layer for the same (s,p) where the subject
+  // has moved past that lower layer is residue from the
+  // pre-promotion state and must drop. The earlier residue rule
+  // (line 559 family) only handled resource-object residue;
+  // literal-object residue admitted both (old + new) because
+  // SPO dedup keys on the literal VALUE, so divergent literals
+  // produce distinct keys and both survive.
+  //
+  // Edge cases this pass preserves:
+  // - Same literal at both layers (subject promoted): SPO dedup
+  //   collapses both to one row regardless of this pass.
+  // - Different literal, subject NOT promoted: subject's
+  //   canonical layer is the lower layer too, so no
+  //   canonical-layer row is indexed → no drop, both keep.
+  // - Literal at WM only, no canonical-layer literal for same
+  //   (s,p): pass-1 index is empty for that (s,p) → WM row
+  //   keeps (lower-layer-only fact).
+  const canonicalLiteralSP = new Set<string>();
+  for (const t of triples) {
+    if (isResourceObject(t.object)) continue;
+    const subjectEntity = entities.get(canonicalEntityUri(t.subject));
+    if (!subjectEntity) continue;
+    if (subjectEntity.trustLevel !== t.layer) continue;
+    canonicalLiteralSP.add(`${canonicalEntityUri(t.subject)}|${t.predicate}`);
+  }
+
   const seen = new Set<string>();
   const out: LayeredTriple[] = [];
   for (const t of triples) {
@@ -561,6 +591,17 @@ export function applyCanonicalAdmission(
       if (objectEntity && objectEntity.trustLevel !== t.layer) {
         dropAsResidue = true;
       }
+    }
+    // GH #819 round 7 — literal-residue. Subject moved past the
+    // row's layer AND a canonical-layer literal exists for the
+    // same (s,p) — drop the lower-layer literal as residue.
+    if (
+      !dropAsResidue
+      && subjectMoved
+      && !isResourceObject(t.object)
+      && canonicalLiteralSP.has(`${canonicalEntityUri(t.subject)}|${t.predicate}`)
+    ) {
+      dropAsResidue = true;
     }
     if (dropAsResidue) continue;
     const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;

--- a/packages/node-ui/test/dashboard-memorystack-contract.test.ts
+++ b/packages/node-ui/test/dashboard-memorystack-contract.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  useCanonicalTriples,
+  useLayerTriples,
+} from '../src/ui/views/project/helpers.js';
+import {
+  buildMemoryEntities,
+  type LayeredTriple,
+  type MemoryData,
+} from '../src/ui/hooks/useMemoryEntities.js';
+
+// GH #819 round 5 (Codex sweep 3 🟡 #10) — view-level regression
+// guard for DashboardView + MemoryStackView. Both views derive
+// per-layer triple counts from `useLayerTriples(memory, layer)`
+// and the total from `useCanonicalTriples(memory).total`. The
+// guard locks two invariants the views rely on:
+//
+//   (1) `wm + swm + vm <= total` — per-layer cells use the OR-rule
+//       (drop if subject OR resource-object moved past `t.layer`)
+//       while the total uses the canonical AND-rule (drop only
+//       when BOTH endpoints moved). The gap = mixed-layer edges
+//       canonical keeps but per-layer slices drop.
+//   (2) Cross-graph SPO duplicates + WM residue drop out of all
+//       four numbers. Pre-#819 the views iterated `mem.allTriples`
+//       directly and inflated both the total and the per-layer
+//       cells. Post-#819 the helpers handle dedup + residue so the
+//       view-level numbers stay honest.
+//
+// We don't render the views (heavy `useFetch` + `useNodeEvents`
+// state machines wouldn't add coverage over what the helpers
+// already test). We DO render the helpers through React so the
+// hook-level memoization runs end-to-end; an isomorphic Probe
+// surfaces the four numbers as data attributes for assertion.
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+function memoryFor(triples: LayeredTriple[]): MemoryData {
+  const entities = buildMemoryEntities(triples);
+  return {
+    entities,
+    entityList: [...entities.values()],
+    allTriples: triples,
+    graphTriples: [],
+    trustMap: new Map(),
+    counts: { wm: 0, swm: 0, vm: 0, total: entities.size },
+    loading: false,
+    error: null,
+    partial: false,
+    layerStatus: { wm: 'ok', swm: 'ok', vm: 'ok' },
+    refresh: () => {},
+  } as unknown as MemoryData;
+}
+
+// Mirror of DashboardView.tsx:368-377 / MemoryStackView.tsx:103-105
+// — the exact derivation both views ship.
+function ViewCountsProbe({ memory }: { memory: MemoryData }) {
+  const wm = useLayerTriples(memory as any, 'wm').length;
+  const swm = useLayerTriples(memory as any, 'swm').length;
+  const vm = useLayerTriples(memory as any, 'vm').length;
+  const { total } = useCanonicalTriples(memory as any);
+  return React.createElement('div', {
+    id: 'probe',
+    'data-wm': String(wm),
+    'data-swm': String(swm),
+    'data-vm': String(vm),
+    'data-total': String(total),
+  });
+}
+
+function readProbe(container: Element) {
+  const probe = container.querySelector('#probe')!;
+  return {
+    wm: Number(probe.getAttribute('data-wm')),
+    swm: Number(probe.getAttribute('data-swm')),
+    vm: Number(probe.getAttribute('data-vm')),
+    total: Number(probe.getAttribute('data-total')),
+  };
+}
+
+describe('Dashboard + MemoryStack derivation contract (GH #819 round 5 — Codex sweep 3 🟡 #10)', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(memory: MemoryData) {
+    act(() => {
+      root.render(React.createElement(ViewCountsProbe, { memory }));
+    });
+  }
+
+  it('wm + swm + vm <= total invariant holds; gap == mixed-layer edge count', () => {
+    // Fixture mirrors the recipe-app CG shape that motivated #819:
+    // - Two WM-only entities with literal-name rows (cleanly WM)
+    // - One SWM entity with a literal-name row (cleanly SWM)
+    // - One mixed-layer edge from the SWM entity to a WM entity
+    //   (subject moved past WM, object still WM — KEEPS as fact)
+    const triples: LayeredTriple[] = [
+      // Two WM-only literal-name rows — admit per-layer wm, admit canonical.
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+      { subject: 'urn:e:wm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'working' },
+      // SWM entity literal-name row — admits per-layer swm, admits canonical.
+      { subject: 'urn:e:swm-c', predicate: 'http://schema.org/name', object: '"C"', layer: 'shared' },
+      // Mixed-layer edge: subject SWM canonical, object WM canonical, row
+      // stored at WM. Per-layer wm DROPS this (subject moved past WM via
+      // OR-rule). Canonical KEEPS this (only one endpoint moved via
+      // BOTH-endpoints AND-rule). This row IS the wm+swm+vm vs total gap.
+      { subject: 'urn:e:swm-c', predicate: 'http://schema.org/knows', object: 'urn:e:wm-a', layer: 'working' },
+    ];
+    render(memoryFor(triples));
+    const { wm, swm, vm, total } = readProbe(container);
+
+    // wm = 2 (the two WM-only literal-name rows). The mixed-layer
+    // edge dropped from wm because subject moved past WM.
+    expect(wm).toBe(2);
+    // swm = 1 (the SWM literal-name row only). The mixed-layer
+    // edge is stored at layer=working, so it does NOT contribute
+    // to swm's count either.
+    expect(swm).toBe(1);
+    expect(vm).toBe(0);
+    // canonical keeps all 4 rows (3 cleanly-per-layer + 1 mixed-layer fact).
+    expect(total).toBe(4);
+
+    // Invariant: per-layer sum <= total.
+    expect(wm + swm + vm).toBeLessThanOrEqual(total);
+    // Gap === count of mixed-layer edges (1 in this fixture).
+    expect(total - (wm + swm + vm)).toBe(1);
+  });
+
+  it('WM-residue post-promote drops from every cell + total (no inflation vs raw allTriples)', () => {
+    // Two entities both promoted past WM (canonical 'shared').
+    // The WM-residue row connecting them is unambiguous residue
+    // (BOTH endpoints moved) — drops from wm-layer AND from
+    // canonical. Raw `allTriples.length` would have counted it;
+    // the helpers correctly exclude it.
+    const triples: LayeredTriple[] = [
+      // Promote both entities to SWM canonical via their literal-name rows.
+      { subject: 'urn:e:promoted-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'shared' },
+      { subject: 'urn:e:promoted-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared' },
+      // Honest SWM resource-edge between them — admits in swm + total.
+      { subject: 'urn:e:promoted-a', predicate: 'http://schema.org/knows', object: 'urn:e:promoted-b', layer: 'shared' },
+      // WM residue resource-edge — both endpoints SWM canonical,
+      // row stored at WM. Drops in wm-layer (OR-rule, subject moved)
+      // AND in canonical (AND-rule, both endpoints moved). This is
+      // the GH #805 / GH #819 residue family.
+      { subject: 'urn:e:promoted-a', predicate: 'http://schema.org/knows', object: 'urn:e:promoted-b', layer: 'working' },
+    ];
+    render(memoryFor(triples));
+    const { wm, swm, vm, total } = readProbe(container);
+
+    // Raw `allTriples.length` would be 4 (the inflated, pre-#819 value).
+    // Post-#819:
+    expect(wm).toBe(0); // residue row dropped from wm-layer
+    expect(swm).toBe(3); // 2 literal-name + 1 honest resource-edge
+    expect(vm).toBe(0);
+    // Canonical: 3 (residue row dropped, no mixed-layer fact present).
+    expect(total).toBe(3);
+    expect(wm + swm + vm).toBe(total); // no gap on this fixture
+    // Verify the helpers strictly under-report raw `allTriples` by
+    // the residue-row count (1).
+    expect(total).toBeLessThan(triples.length);
+  });
+
+  it('Cross-graph SPO duplicate (same row in two named graphs) deduplicates in per-layer + total', () => {
+    // Same SPO row at the SAME layer, shipped via two different
+    // graphs (e.g. `<cg>/<sg>` and `<cg>/<sg>/_shared_memory`).
+    // `useLayerTriples` SPO-dedups within the layer; canonical
+    // SPO-dedups globally. Both should report 1, not 2.
+    const triples: LayeredTriple[] = [
+      // Promote subject to SWM canonical.
+      { subject: 'urn:e:swm-c', predicate: 'http://schema.org/name', object: '"C"', layer: 'shared' },
+      // Same literal-name row again — different graph in production,
+      // identical SPO. Must collapse.
+      { subject: 'urn:e:swm-c', predicate: 'http://schema.org/name', object: '"C"', layer: 'shared' },
+    ];
+    render(memoryFor(triples));
+    const { wm, swm, vm, total } = readProbe(container);
+
+    // Pre-#819 view-level totals would have inflated to 2.
+    expect(wm).toBe(0);
+    expect(swm).toBe(1);
+    expect(vm).toBe(0);
+    expect(total).toBe(1);
+    expect(wm + swm + vm).toBe(total);
+  });
+});

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1348,20 +1348,22 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(betaStats).toContain('1 triples');
   });
 
-  it('Named card tripleCount falls back to sg.tripleCount when canonical universe is incomplete (GH #819 round 3 — Codex sweep 1 🔴 #3)', async () => {
-    // PR #847 round 3 (Codex sweep 1 🔴 #3) — round 2 gated the
-    // `sg.tripleCount` fallback on `memory.loading` alone, missing
-    // the hydrated-after-layer-failure case (loading flips false
-    // but `canonicalTriples` is still incomplete because a layer
-    // query errored). The fixture below holds `memory.loading`
-    // false but reports a layer status of 'error' AND a partial
-    // result — canonical universe is missing rows from that
-    // layer. Pre-fix the fallback didn't fire (loading was
-    // false), card rendered `0 triples` instead of the daemon
-    // lower-bound. Post-fix the widened gate
-    // (`canonicalIncomplete`) kicks in.
+  it('Named card tripleCount ignores daemon sg.tripleCount under hydrated-after-layer-failure (GH #819 round 5 — Codex sweep 3 🔴 #8 inversion)', async () => {
+    // PR #847 round 5 (🔴 #8) — round 3 was written to lock in a
+    // `?? sg.tripleCount` "lower-bound fallback" when canonical
+    // universe was incomplete. Codex sweep 3 invalidated that
+    // contract: the daemon route builds `sg.tripleCount` via raw
+    // `COUNT(*)` SPARQL grouped by named graph, then sums per
+    // first-path-segment — NO SPO-dedup, NO residue filter. So
+    // `sg.tripleCount` is INFLATED (upper-bound), not a lower
+    // bound. Round-5 drops the daemon read entirely.
+    //
+    // Same fixture as the original round-3 lock, opposite
+    // assertion: card NEVER reads daemon `sg.tripleCount`, even
+    // when canonical universe is incomplete. Honest zero shows
+    // through when the bucket is empty.
     fetchSubGraphsMock.mockResolvedValueOnce({
-      // Daemon-reported lower-bound count (the fallback target).
+      // Daemon-reported (inflated, raw COUNT(*)) count.
       subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 42, description: '' }],
     });
     const entityList = [
@@ -1383,10 +1385,12 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const cards = container.querySelectorAll('.v10-sgov-card');
     const alphaCardEl = cards[0];
     const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
-    // Fallback fires — card shows the daemon-reported lower-bound
-    // (42) rather than the empty canonical universe (0).
-    expect(stats).toContain('42 triples');
-    expect(stats).not.toContain('0 triples');
+    // Round-5 contract: card never reads daemon `sg.tripleCount`.
+    // Empty client-canonical bucket renders `0 triples` honestly,
+    // even when canonical universe is incomplete; daemon's
+    // potentially-inflated 42 is ignored.
+    expect(stats).toContain('0 triples');
+    expect(stats).not.toContain('42 triples');
   });
 
   it('Named card bucket applies canonical residue filter per scope (GH #819 round 4 — Codex sweep 2 🔴 #5)', async () => {
@@ -1434,28 +1438,33 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).not.toContain('2 triples');
   });
 
-  it('Named card tripleCount Math.max-clamps daemon lower-bound vs partial-hydrated bucket (GH #819 round 4 — Codex sweep 2 🔴 #6)', async () => {
-    // PR #847 round 4 (🔴 #6) — round 3 used `??` precedence:
-    // `tripleCountBySubGraph.get(sg) ?? sg.tripleCount` only fell
-    // through when the bucket was undefined. A partial-hydrated
-    // bucket (e.g. 3 rows of an expected 10) had a defined value
-    // and won — card stat undercounted to 3 instead of the
-    // daemon's 10.
+  it('Named card tripleCount never reads daemon sg.tripleCount, even on partial-hydrated bucket (GH #819 round 5 — Codex sweep 3 🔴 #8)', async () => {
+    // PR #847 round 5 (🔴 #8) — earlier rounds tried to fall
+    // back to the daemon-reported `sg.tripleCount` when the
+    // canonical universe was incomplete. Codex sweep 3 flagged
+    // that the daemon route (`/api/sub-graph/list` in
+    // `packages/cli/src/daemon/routes/context-graph.ts:769-794`)
+    // builds that field via raw `COUNT(*)` grouped by named
+    // graph then summed per first-path-segment — NO SPO-dedup,
+    // NO residue filter. So `sg.tripleCount` is INFLATED by the
+    // same dupes + residue this PR removes. Round 3's `?? sg.tripleCount`
+    // and round 4's `Math.max(...)` both clamped UPWARD to an
+    // inflated value, not a lower-bound.
     //
-    // Round-4 fix: `Math.max(sg.tripleCount, bucket ?? 0)` in the
-    // `canonicalIncomplete` branch — clamps to the larger of the
-    // two when the canonical universe can't be trusted, surfacing
-    // the truer lower-bound either way (defends against daemon
-    // undershoot too).
+    // Round-5 fix: drop the daemon read entirely. Card stat
+    // is always `tripleCountBySubGraph.get(sg.name) ?? 0` —
+    // honest client-canonical count, even when partial.
     fetchSubGraphsMock.mockResolvedValueOnce({
-      // Daemon reports the higher count (10).
+      // Daemon reports an INFLATED count (10) — raw COUNT(*) over
+      // alpha's named graphs picks up cross-graph dupes / residue.
       subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 10, description: '' }],
     });
     const entityList = [
       { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
     ];
-    // 3 partially-hydrated rows in alpha's bucket — incomplete
-    // canonical universe (one layer errored, so only WM made it).
+    // 3 partially-hydrated rows in alpha's bucket — canonical
+    // universe is partial (SWM errored), so the bucket only
+    // sees the 3 WM rows that admitted.
     const triples = [
       { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"a-name-1"', subGraph: 'alpha', layer: 'working' },
       { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"a-name-2"', subGraph: 'alpha', layer: 'working' },
@@ -1469,8 +1478,9 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
       counts: { wm: 1, swm: 0, vm: 0, total: 1 },
       loading: false,
       partial: true,
-      // SWM errored — canonical universe is missing rows from
-      // there. Daemon still reports 10 as the true total.
+      // SWM errored — canonical universe is incomplete. Round-4
+      // would have Math.max-clamped to the daemon's 10; round-5
+      // renders the honest client-canonical 3.
       layerStatus: { wm: 'ok', swm: 'error', vm: 'ok' },
     });
     await flush();
@@ -1478,10 +1488,11 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const cards = container.querySelectorAll('.v10-sgov-card');
     const alphaCardEl = cards[0];
     const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
-    // Pre-round-4 the bucket value (3) won via `??`. Post-fix
-    // `Math.max(10, 3) === 10` — the daemon lower-bound surfaces.
-    expect(stats).toContain('10 triples');
-    expect(stats).not.toContain('3 triples');
+    // Round-5 contract: card never reads daemon `sg.tripleCount`.
+    // Partial canonical bucket of 3 surfaces honestly; daemon's
+    // inflated 10 is ignored.
+    expect(stats).toContain('3 triples');
+    expect(stats).not.toContain('10 triples');
   });
 
   it('Root card keeps its scoped copy when same SPO also appears under a named subgraph (GH #819 round 4 — Codex sweep 2 🔴 #7)', async () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1348,20 +1348,19 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(betaStats).toContain('1 triples');
   });
 
-  it('Named card tripleCount ignores daemon sg.tripleCount under hydrated-after-layer-failure (GH #819 round 5 — Codex sweep 3 🔴 #8 inversion)', async () => {
-    // PR #847 round 5 (🔴 #8) — round 3 was written to lock in a
-    // `?? sg.tripleCount` "lower-bound fallback" when canonical
-    // universe was incomplete. Codex sweep 3 invalidated that
-    // contract: the daemon route builds `sg.tripleCount` via raw
-    // `COUNT(*)` SPARQL grouped by named graph, then sums per
-    // first-path-segment — NO SPO-dedup, NO residue filter. So
-    // `sg.tripleCount` is INFLATED (upper-bound), not a lower
-    // bound. Round-5 drops the daemon read entirely.
+  it('Named card tripleCount ignores daemon sg.tripleCount when canonical is incomplete (GH #819 round 5+6 — Codex sweep 3 🔴 #8 + sweep 4 🔴 #11)', async () => {
+    // Round 5 (🔴 #8): drop the daemon-reported `sg.tripleCount`
+    // fallback entirely — the daemon route builds it via raw
+    // `COUNT(*)` (no SPO-dedup, no residue filter), so it's
+    // inflated, not a lower-bound.
+    // Round 6 (🔴 #11): with an empty bucket AND canonical
+    // incomplete, render the hydration affordance (`…`) instead
+    // of `0 triples` — Codex sweep 4 flagged that round 5 was
+    // conflating "loading" with "genuine empty".
     //
-    // Same fixture as the original round-3 lock, opposite
-    // assertion: card NEVER reads daemon `sg.tripleCount`, even
-    // when canonical universe is incomplete. Honest zero shows
-    // through when the bucket is empty.
+    // Combined contract on this fixture (empty bucket + canonical
+    // incomplete): badge must NOT show the inflated daemon 42,
+    // and must NOT flash `0 triples`. It renders `…`.
     fetchSubGraphsMock.mockResolvedValueOnce({
       // Daemon-reported (inflated, raw COUNT(*)) count.
       subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 42, description: '' }],
@@ -1385,12 +1384,11 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const cards = container.querySelectorAll('.v10-sgov-card');
     const alphaCardEl = cards[0];
     const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
-    // Round-5 contract: card never reads daemon `sg.tripleCount`.
-    // Empty client-canonical bucket renders `0 triples` honestly,
-    // even when canonical universe is incomplete; daemon's
-    // potentially-inflated 42 is ignored.
-    expect(stats).toContain('0 triples');
+    // Combined contract: no daemon read (no 42), and hydration
+    // affordance (`…`) instead of a `0 triples` flash.
+    expect(stats).toContain('…');
     expect(stats).not.toContain('42 triples');
+    expect(stats).not.toContain('0 triples');
   });
 
   it('Named card bucket applies canonical residue filter per scope (GH #819 round 4 — Codex sweep 2 🔴 #5)', async () => {
@@ -1493,6 +1491,102 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // inflated 10 is ignored.
     expect(stats).toContain('3 triples');
     expect(stats).not.toContain('10 triples');
+  });
+
+  it('Named card badge renders hydration affordance while canonical is incomplete and bucket is empty (GH #819 round 6 — Codex sweep 4 🔴 #11)', async () => {
+    // PR #847 round 6 (🔴 #11) — round 5 dropped the daemon
+    // fallback entirely, which was correct on the daemon-trust
+    // axis but stripped the gate that distinguished "still
+    // hydrating" from "genuine 0". `useMemoryEntities` initializes
+    // `allTriples = []` (`useMemoryEntities.ts:590`), so between
+    // `/sub-graph/list` resolve (which fills `subGraphs`) and
+    // WM/SWM/VM finishing (which fills `allTriples`), every
+    // non-empty subgraph derived `tripleCount = 0` and the badge
+    // flashed `0 triples`. Round-6 fix: revive the
+    // `canonicalIncomplete` discriminator; when it's true AND
+    // the bucket is empty, the badge renders `…` instead of `0`.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 5, tripleCount: 0, description: '' }],
+    });
+    await renderWith({
+      ...memory,
+      // Mid-hydration: `/sub-graph/list` resolved but layer queries
+      // haven't finished, so `allTriples` is still its initial [].
+      entities: new Map(),
+      entityList: [],
+      allTriples: [],
+      counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+      loading: true,
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // Pre-round-6 this read `0 triples` mid-hydration. Post-fix
+    // the badge renders the affordance.
+    expect(stats).toContain('…');
+    expect(stats).not.toContain('0 triples');
+  });
+
+  it('Named card badge renders genuine 0 once canonical is fully hydrated (GH #819 round 6 — no regression on honest empty)', async () => {
+    // Round-6 regression guard — once canonical is hydrated
+    // (`loading=false`, no `partial`, all layers 'ok'), a
+    // genuinely empty subgraph must still surface `0 triples`
+    // honestly. The hydration affordance fires ONLY when the
+    // canonical universe can't be trusted; the hydrated-fully
+    // branch is unchanged from round 5.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'empty', entityCount: 0, tripleCount: 0, description: '' }],
+    });
+    await renderWith({
+      ...memory,
+      // Fully hydrated, genuinely empty subgraph (no triples in any
+      // layer for this subgraph).
+      entities: new Map(),
+      entityList: [],
+      allTriples: [],
+      counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+      loading: false,
+      partial: false,
+      layerStatus: { wm: 'ok', swm: 'ok', vm: 'ok' },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const emptyCardEl = cards[0];
+    const stats = emptyCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // Genuine 0 surfaces — no affordance, no daemon read.
+    expect(stats).toContain('0 triples');
+    expect(stats).not.toContain('…');
+  });
+
+  it('Root card badge renders hydration affordance while canonical is incomplete (GH #819 round 6 — Root parity)', async () => {
+    // Round-6 parity guard — the Root card has the same race:
+    // it derives `tripleCount = rootTriples.length` from
+    // `memory.allTriples`, which starts at []. Same gate +
+    // affordance applies, threaded via the same
+    // `canonicalIncomplete` prop on the SubGraphMiniCard.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 0, tripleCount: 0, description: '' }],
+    });
+    await renderWith({
+      ...memory,
+      entities: new Map(),
+      entityList: [],
+      allTriples: [],
+      counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+      loading: true,
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    // Root card is last in the grid (rank 999).
+    const rootCardEl = cards[cards.length - 1];
+    expect(rootCardEl.classList.contains('root')).toBe(true);
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    expect(stats).toContain('…');
+    expect(stats).not.toContain('0 triples');
   });
 
   it('Root card keeps its scoped copy when same SPO also appears under a named subgraph (GH #819 round 4 — Codex sweep 2 🔴 #7)', async () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1395,7 +1395,7 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).not.toContain('42 triples');
     // Tooltip surfaces the failure caveat on the triples stat.
     const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
-    expect(triplesStat?.getAttribute('title')).toBe('Some layers unavailable; count may be incomplete.');
+    expect(triplesStat?.getAttribute('title')).toBe('0 triples (some layers unavailable; count may be incomplete).');
   });
 
   it('Named card bucket applies canonical residue filter per scope (GH #819 round 4 — Codex sweep 2 🔴 #5)', async () => {
@@ -1631,7 +1631,7 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).toContain('0 triples');
     expect(stats).not.toContain('…');
     const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
-    expect(triplesStat?.getAttribute('title')).toBe('Some layers unavailable; count may be incomplete.');
+    expect(triplesStat?.getAttribute('title')).toBe('0 triples (some layers unavailable; count may be incomplete).');
   });
 
   it('Named card badge surfaces honest 0 with failure tooltip on memory.partial (GH #819 round 7 — Codex sweep 5 🔴 #14)', async () => {
@@ -1666,7 +1666,101 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).toContain('0 triples');
     expect(stats).not.toContain('…');
     const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
-    expect(triplesStat?.getAttribute('title')).toBe('Some layers unavailable; count may be incomplete.');
+    expect(triplesStat?.getAttribute('title')).toBe('0 triples (some layers unavailable; count may be incomplete).');
+  });
+
+  it('Named card badge surfaces failure tooltip on non-zero bucket too (GH #819 round 10 — Codex sweep 8 🟡 #18)', async () => {
+    // Rounds 6/7 routed the failure tooltip only when the bucket
+    // was 0; a partial-layer-failure with a non-zero bucket
+    // (some layers succeeded with rows, others errored) rendered
+    // the count with no disclosure that it might be incomplete.
+    // Round 10 extends the failure-tooltip branch to ALL bucket
+    // values; the count is prefixed onto the disclosure wording.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    // 2 WM rows admit; SWM errored so the SWM contribution is
+    // missing — the rendered count is a best-effort lower bound.
+    const triples = [
+      { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"alpha-1"', subGraph: 'alpha', layer: 'working' },
+      { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"alpha-2"', subGraph: 'alpha', layer: 'working' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 2, swm: 0, vm: 0, total: 1 },
+      loading: false,
+      partial: true,
+      layerStatus: { wm: 'ok', swm: 'error', vm: 'ok' },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const cardStats = alphaCardEl.querySelector('.v10-sgov-card-stats');
+    const stats = cardStats?.textContent ?? '';
+    // Bucket renders the count honestly (no `…`).
+    expect(stats).toContain('2 triples');
+    expect(stats).not.toContain('…');
+    // Round-10 contract: failure tooltip fires for non-zero
+    // buckets too, with the count value prefixed.
+    const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
+    expect(triplesStat?.getAttribute('title')).toBe('2 triples (some layers unavailable; count may be incomplete).');
+  });
+
+  it('Named card failure tooltip wins over stat-vs-rendered tooltip when both apply (GH #819 round 10 — precedence)', async () => {
+    // Round-10 precedence lock — when a card is both
+    // failed/partial AND has a stat-vs-rendered mismatch
+    // (cross-card edges or cap-trimmed rows), the failure
+    // tooltip wins. The cap-truncation gap recomputes correctly
+    // once layers re-hydrate; the failure signal is the louder
+    // disclosure.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      // beta sits outside alpha's subgraph; the alpha→beta edge
+      // below has `card.tripleCount = 1` (in alpha's canonical
+      // scope) but `card.triples.length = 0` (dropped from the
+      // rendered slice by `filterTriplesToEntities` because beta
+      // isn't in alpha's entityUris). That difference normally
+      // triggers the β stat-vs-rendered tooltip; under round-10
+      // precedence the failure tooltip wins instead.
+      { uri: 'urn:e:beta', label: 'b', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      { subject: 'urn:e:alpha', predicate: 'p', object: 'urn:e:beta', subGraph: 'alpha', layer: 'working' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 2, swm: 0, vm: 0, total: 2 },
+      loading: false,
+      partial: true,
+      layerStatus: { wm: 'ok', swm: 'error', vm: 'ok' },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const cardStats = alphaCardEl.querySelector('.v10-sgov-card-stats');
+    const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
+    // Failure tooltip wins even when the β literal would also
+    // have qualified. β substrings ("in this subgraph's scope",
+    // "cap-trimmed") must NOT appear; failure tooltip is the
+    // only disclosure.
+    const title = triplesStat?.getAttribute('title') ?? '';
+    expect(title).toBe('1 triples (some layers unavailable; count may be incomplete).');
+    expect(title).not.toContain("in this subgraph's scope");
+    expect(title).not.toContain('cap-trimmed');
   });
 
   it('Root card keeps its scoped copy when same SPO also appears under a named subgraph (GH #819 round 4 — Codex sweep 2 🔴 #7)', async () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -687,12 +687,16 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
 
     const cards = container.querySelectorAll('.v10-sgov-card');
     const rootCardEl = cards[cards.length - 1];
-    // Root card stats: 2 root entities, 1 admitted triple (the
-    // untagged root↔root edge). Tagged + non-scoped triples
-    // dropped.
+    // Root card stats: 2 root entities. GH #819 round 11 (Codex
+    // sweep 9 🟡 #20): badge reads the PRE-filter candidate count
+    // (mirrors named-card contract). Tagged triple drops in the
+    // `!t.subGraph` filter; untagged `(alpha, p, somewhere-else)`
+    // and `(root1, p, root2)` both pass canonical admission → 2
+    // candidates. Post-AND-filter only `(root1, p, root2)`
+    // renders, so the β stat-vs-rendered tooltip fires.
     const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
     expect(stats).toContain('2 entities');
-    expect(stats).toContain('1 triples');
+    expect(stats).toContain('2 triples');
   });
 
   it('Root card canonicalizes triple endpoints + SPO dedup key (Codex sweep 1, Bug M family)', async () => {
@@ -1141,12 +1145,22 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
 
     const cards = container.querySelectorAll('.v10-sgov-card');
     const rootCardEl = cards[cards.length - 1];
-    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
-    // 1 root entity, 0 triples — the root→non-root edge dropped
-    // by AND-filter. Pre-sweep this read `1 triples`.
+    const cardStats = rootCardEl.querySelector('.v10-sgov-card-stats');
+    const stats = cardStats?.textContent ?? '';
+    // GH #819 round 11 (Codex sweep 9 🟡 #20) — Root badge reads
+    // the PRE-`filterTriplesToEntities` candidate count, mirroring
+    // named-card contract. The untagged `(root, p, non-root)` row
+    // passes canonical admission (1 candidate) but drops in the
+    // AND-membership filter (non-root object not in rootEntityUris),
+    // so the rendered slice is empty. Stat (1) !== rendered (0) →
+    // β stat-vs-rendered tooltip fires.
     expect(stats).toContain('1 entities');
-    expect(stats).toContain('0 triples');
-    expect(stats).not.toContain('1 triples');
+    expect(stats).toContain('1 triples');
+    // β tooltip fires on the triples stat (cross-card edge cause).
+    const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
+    expect(triplesStat?.getAttribute('title')).toBe(
+      `1 triples in this subgraph's scope; 0 rendered (some in-scope edges aren't drawn — either endpoints outside this subgraph, or cap-trimmed in dense buckets).`,
+    );
   });
 
   it('Root card admits rdf:type edges to class URIs (Codex sweep 6 — class IRIs exempted from AND-filter)', async () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1360,19 +1360,17 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(betaStats).toContain('1 triples');
   });
 
-  it('Named card tripleCount ignores daemon sg.tripleCount when canonical is incomplete (GH #819 round 5+6 — Codex sweep 3 🔴 #8 + sweep 4 🔴 #11)', async () => {
+  it('Named card tripleCount ignores daemon sg.tripleCount under settled layer-error (GH #819 round 5+7 — Codex sweep 3 🔴 #8 + sweep 5 🔴 #14)', async () => {
     // Round 5 (🔴 #8): drop the daemon-reported `sg.tripleCount`
     // fallback entirely — the daemon route builds it via raw
     // `COUNT(*)` (no SPO-dedup, no residue filter), so it's
     // inflated, not a lower-bound.
-    // Round 6 (🔴 #11): with an empty bucket AND canonical
-    // incomplete, render the hydration affordance (`…`) instead
-    // of `0 triples` — Codex sweep 4 flagged that round 5 was
-    // conflating "loading" with "genuine empty".
-    //
-    // Combined contract on this fixture (empty bucket + canonical
-    // incomplete): badge must NOT show the inflated daemon 42,
-    // and must NOT flash `0 triples`. It renders `…`.
+    // Round 7 (🔴 #14): a settled layer-error (`loading=false`,
+    // `partial=true`, `layerStatus.wm === 'error'`) is NOT a
+    // hydration race — it's a final incomplete result. Badge
+    // surfaces `0 triples` honestly with a "Some layers
+    // unavailable" tooltip; doesn't render `…` (which is
+    // reserved for the in-flight hydration window).
     fetchSubGraphsMock.mockResolvedValueOnce({
       // Daemon-reported (inflated, raw COUNT(*)) count.
       subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 42, description: '' }],
@@ -1384,7 +1382,7 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
       ...memory,
       entities: new Map(entityList.map(e => [e.uri, e])),
       entityList,
-      // Hydrated but incomplete: layer query errored.
+      // Settled but incomplete: one layer errored.
       allTriples: [],
       counts: { wm: 1, swm: 0, vm: 0, total: 1 },
       loading: false,
@@ -1395,12 +1393,17 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
 
     const cards = container.querySelectorAll('.v10-sgov-card');
     const alphaCardEl = cards[0];
-    const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
-    // Combined contract: no daemon read (no 42), and hydration
-    // affordance (`…`) instead of a `0 triples` flash.
-    expect(stats).toContain('…');
+    const cardStats = alphaCardEl.querySelector('.v10-sgov-card-stats');
+    const stats = cardStats?.textContent ?? '';
+    // Combined contract: no daemon read (no 42), no `…` (this is
+    // settled failure, not in-flight hydration); honest `0 triples`
+    // surfaces with the failure tooltip.
+    expect(stats).toContain('0 triples');
+    expect(stats).not.toContain('…');
     expect(stats).not.toContain('42 triples');
-    expect(stats).not.toContain('0 triples');
+    // Tooltip surfaces the failure caveat on the triples stat.
+    const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
+    expect(triplesStat?.getAttribute('title')).toBe('Some layers unavailable; count may be incomplete.');
   });
 
   it('Named card bucket applies canonical residue filter per scope (GH #819 round 4 — Codex sweep 2 🔴 #5)', async () => {
@@ -1599,6 +1602,79 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
     expect(stats).toContain('…');
     expect(stats).not.toContain('0 triples');
+  });
+
+  it('Named card badge surfaces honest 0 with failure tooltip on memory.error (GH #819 round 7 — Codex sweep 5 🔴 #14)', async () => {
+    // Round 6 collapsed loading + error into one
+    // `canonicalIncomplete` gate; round 7 splits them. A settled
+    // `memory.error` (not loading) must NOT render the `…`
+    // affordance — that would masquerade a settled failure as
+    // in-progress hydration. Instead, render honest `0 triples`
+    // with a "Some layers unavailable" tooltip.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: [],
+      counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+      // Settled error state — NOT loading.
+      loading: false,
+      error: new Error('SPARQL endpoint unavailable'),
+      layerStatus: { wm: 'ok', swm: 'ok', vm: 'ok' },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const cardStats = alphaCardEl.querySelector('.v10-sgov-card-stats');
+    const stats = cardStats?.textContent ?? '';
+    // Failed/partial branch: 0 triples surfaces honestly with the
+    // failure-state tooltip, NOT the `…` affordance.
+    expect(stats).toContain('0 triples');
+    expect(stats).not.toContain('…');
+    const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
+    expect(triplesStat?.getAttribute('title')).toBe('Some layers unavailable; count may be incomplete.');
+  });
+
+  it('Named card badge surfaces honest 0 with failure tooltip on memory.partial (GH #819 round 7 — Codex sweep 5 🔴 #14)', async () => {
+    // Same round-7 contract as the `error` test above, but
+    // exercising the `partial` branch instead — settled-incomplete
+    // result (some layers succeeded, some errored). Still renders
+    // honest `0 triples` with the failure tooltip; not `…`.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: [],
+      counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+      loading: false,
+      partial: true,
+      // Round 7: SWM errored is a settled failure, not in-flight
+      // hydration (no layerStatus === 'loading').
+      layerStatus: { wm: 'ok', swm: 'error', vm: 'ok' },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const cardStats = alphaCardEl.querySelector('.v10-sgov-card-stats');
+    const stats = cardStats?.textContent ?? '';
+    expect(stats).toContain('0 triples');
+    expect(stats).not.toContain('…');
+    const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
+    expect(triplesStat?.getAttribute('title')).toBe('Some layers unavailable; count may be incomplete.');
   });
 
   it('Root card keeps its scoped copy when same SPO also appears under a named subgraph (GH #819 round 4 — Codex sweep 2 🔴 #7)', async () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1296,6 +1296,99 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(tripleStat!.getAttribute('title')).toBeNull();
   });
 
+  it('Both cards surface their own scoped copy of an SPO shipped under two named subgraphs (GH #819 round 3 — Codex sweep 1 🔴 #1)', async () => {
+    // PR #847 round 3 (Codex sweep 1 🔴 #1) — `useCanonicalTriples`
+    // dedupes globally by `(canonical(s), p, canonical(o))` which
+    // is correct for the aggregate total but WRONG for per-bucket
+    // card counts: the same `(s, p, o)` legitimately shipped under
+    // two named sub-graphs (cross-membership entity referenced
+    // from both) would only survive in whichever row the canonical
+    // helper saw first, leaving the late-arrival card under-
+    // counted. Fix: `triplesBySubGraph` re-dedupes per bucket from
+    // raw `memory.allTriples`, keeping `subGraph` implicit in the
+    // bucket scope so each card keeps its own scoped copy.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [
+        { name: 'alpha', entityCount: 1, tripleCount: 0, description: '' },
+        { name: 'beta', entityCount: 1, tripleCount: 0, description: '' },
+      ],
+    });
+    const entityList = [
+      // Cross-membership entity in both alpha and beta.
+      { uri: 'urn:e:cross', label: 'c', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set(['alpha', 'beta']), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // Same SPO shipped under two named sub-graphs. Pre-fix
+      // canonical's global dedup collapsed both to the row that
+      // arrived first; only the first card showed the edge. Post-
+      // fix each bucket admits its own copy.
+      { subject: 'urn:e:cross', predicate: 'http://schema.org/name', object: '"C"', subGraph: 'alpha', layer: 'shared' },
+      { subject: 'urn:e:cross', predicate: 'http://schema.org/name', object: '"C"', subGraph: 'beta', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 1, vm: 0, total: 1 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    // 2 named cards + Root card. alpha first (rank order), beta
+    // second, Root last.
+    expect(cards.length).toBeGreaterThanOrEqual(2);
+    const alphaCardEl = cards[0];
+    const betaCardEl = cards[1];
+    const alphaStats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    const betaStats = betaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // BOTH cards show their scoped copy. Pre-fix one of them
+    // showed `0 triples`.
+    expect(alphaStats).toContain('1 triples');
+    expect(betaStats).toContain('1 triples');
+  });
+
+  it('Named card tripleCount falls back to sg.tripleCount when canonical universe is incomplete (GH #819 round 3 — Codex sweep 1 🔴 #3)', async () => {
+    // PR #847 round 3 (Codex sweep 1 🔴 #3) — round 2 gated the
+    // `sg.tripleCount` fallback on `memory.loading` alone, missing
+    // the hydrated-after-layer-failure case (loading flips false
+    // but `canonicalTriples` is still incomplete because a layer
+    // query errored). The fixture below holds `memory.loading`
+    // false but reports a layer status of 'error' AND a partial
+    // result — canonical universe is missing rows from that
+    // layer. Pre-fix the fallback didn't fire (loading was
+    // false), card rendered `0 triples` instead of the daemon
+    // lower-bound. Post-fix the widened gate
+    // (`canonicalIncomplete`) kicks in.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      // Daemon-reported lower-bound count (the fallback target).
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 42, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      // Hydrated but incomplete: layer query errored.
+      allTriples: [],
+      counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+      loading: false,
+      partial: true,
+      layerStatus: { wm: 'error', swm: 'ok', vm: 'ok' },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // Fallback fires — card shows the daemon-reported lower-bound
+    // (42) rather than the empty canonical universe (0).
+    expect(stats).toContain('42 triples');
+    expect(stats).not.toContain('0 triples');
+  });
+
   it('Root card cap honors MAX_PER_CARD even with a single dominant subject (Codex sweep 2)', async () => {
     // PR #818 sweep 2 — sweep-1 sampling shape had a defect:
     // `if (kept >= MAX_PER_CARD) break;` checked AFTER adding the

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1252,18 +1252,22 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).toContain('1 entities');
     expect(stats).toContain('1 triples');
 
-    // GH #819 round 2 (ux-lead locked literal) — when the in-scope
-    // canonical count differs from what actually renders on the
-    // mini-graph, the triple-count badge gets a `title` tooltip
-    // explaining the gap. Here the alpha→beta edge is in alpha's
-    // canonical bucket (count = 1) but drops from the rendered
-    // slice via `filterTriplesToEntities` (rendered = 0). Tooltip
-    // surfaces this asymmetry.
+    // GH #819 round 8 (Codex sweep 6 🟡 #4 / #9 / #12, team-lead
+    // call β) — when the in-scope canonical count differs from
+    // what actually renders on the mini-graph, the triple-count
+    // badge gets a `title` tooltip explaining the gap. Round 2
+    // locked the original wording on cross-card edges only; sweeps
+    // 1-6 re-raised the cap-trim cause (`applyHeaviestSubjectsCap`)
+    // 5 times in a row. Round 8 broadens the literal to cover both
+    // causes. Here the alpha→beta edge is in alpha's canonical
+    // bucket (count = 1) but drops from the rendered slice via
+    // `filterTriplesToEntities` (rendered = 0) — the
+    // endpoints-outside-subgraph cause.
     const tripleStat = Array.from(alphaCardEl.querySelectorAll('.v10-sgov-card-stat'))
       .find(el => el.textContent?.includes('triples')) as HTMLElement | undefined;
     expect(tripleStat).toBeTruthy();
     expect(tripleStat!.getAttribute('title')).toBe(
-      `1 triples in this subgraph's scope; 0 rendered (cross-card edges whose other endpoint isn't in this subgraph aren't drawn here).`,
+      `1 triples in this subgraph's scope; 0 rendered (some in-scope edges aren't drawn — either endpoints outside this subgraph, or cap-trimmed in dense buckets).`,
     );
   });
 

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1434,6 +1434,56 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).not.toContain('2 triples');
   });
 
+  it('Named card tripleCount Math.max-clamps daemon lower-bound vs partial-hydrated bucket (GH #819 round 4 — Codex sweep 2 🔴 #6)', async () => {
+    // PR #847 round 4 (🔴 #6) — round 3 used `??` precedence:
+    // `tripleCountBySubGraph.get(sg) ?? sg.tripleCount` only fell
+    // through when the bucket was undefined. A partial-hydrated
+    // bucket (e.g. 3 rows of an expected 10) had a defined value
+    // and won — card stat undercounted to 3 instead of the
+    // daemon's 10.
+    //
+    // Round-4 fix: `Math.max(sg.tripleCount, bucket ?? 0)` in the
+    // `canonicalIncomplete` branch — clamps to the larger of the
+    // two when the canonical universe can't be trusted, surfacing
+    // the truer lower-bound either way (defends against daemon
+    // undershoot too).
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      // Daemon reports the higher count (10).
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 10, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    // 3 partially-hydrated rows in alpha's bucket — incomplete
+    // canonical universe (one layer errored, so only WM made it).
+    const triples = [
+      { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"a-name-1"', subGraph: 'alpha', layer: 'working' },
+      { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"a-name-2"', subGraph: 'alpha', layer: 'working' },
+      { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"a-name-3"', subGraph: 'alpha', layer: 'working' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 1, swm: 0, vm: 0, total: 1 },
+      loading: false,
+      partial: true,
+      // SWM errored — canonical universe is missing rows from
+      // there. Daemon still reports 10 as the true total.
+      layerStatus: { wm: 'ok', swm: 'error', vm: 'ok' },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // Pre-round-4 the bucket value (3) won via `??`. Post-fix
+    // `Math.max(10, 3) === 10` — the daemon lower-bound surfaces.
+    expect(stats).toContain('10 triples');
+    expect(stats).not.toContain('3 triples');
+  });
+
   it('Root card keeps its scoped copy when same SPO also appears under a named subgraph (GH #819 round 4 — Codex sweep 2 🔴 #7)', async () => {
     // PR #847 round 4 (🔴 #7) — Root card sourced from
     // `canonicalTriples.filter(!t.subGraph)`. Global SPO dedup

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1239,6 +1239,61 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // canonical bucket-size lock anchors the new behavior.
     expect(stats).toContain('1 entities');
     expect(stats).toContain('1 triples');
+
+    // GH #819 round 2 (ux-lead locked literal) — when the in-scope
+    // canonical count differs from what actually renders on the
+    // mini-graph, the triple-count badge gets a `title` tooltip
+    // explaining the gap. Here the alpha→beta edge is in alpha's
+    // canonical bucket (count = 1) but drops from the rendered
+    // slice via `filterTriplesToEntities` (rendered = 0). Tooltip
+    // surfaces this asymmetry.
+    const tripleStat = Array.from(alphaCardEl.querySelectorAll('.v10-sgov-card-stat'))
+      .find(el => el.textContent?.includes('triples')) as HTMLElement | undefined;
+    expect(tripleStat).toBeTruthy();
+    expect(tripleStat!.getAttribute('title')).toBe(
+      `1 triples in this subgraph's scope; 0 rendered (cross-card edges whose other endpoint isn't in this subgraph aren't drawn here).`,
+    );
+  });
+
+  it('Named card omits the stat-vs-rendered tooltip when count and rendered agree (GH #819 round 2 conditional render)', async () => {
+    // ux-lead locked the tooltip as conditional — added only when
+    // `tripleCount !== renderedTripleCount`. When equal (the
+    // common case: bucket is small, no cross-card edges, no cap),
+    // no chrome is added; the badge reads cleanly. Same
+    // visible-when-it-has-something-to-say pattern as S2's
+    // `Pending join requests` empty state.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 2, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // Both entities in alpha's scope.
+      { uri: 'urn:e:alpha-a', label: 'aa', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:alpha-b', label: 'ab', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // alpha-a → alpha-b edge: both endpoints in alpha's
+      // entityUris, so `filterTriplesToEntities` admits → rendered
+      // count == bucket count. No tooltip.
+      { subject: 'urn:e:alpha-a', predicate: 'p', object: 'urn:e:alpha-b', subGraph: 'alpha', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 2, vm: 0, total: 2 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const tripleStat = Array.from(alphaCardEl.querySelectorAll('.v10-sgov-card-stat'))
+      .find(el => el.textContent?.includes('triples')) as HTMLElement | undefined;
+    expect(tripleStat).toBeTruthy();
+    expect(tripleStat!.textContent).toContain('1 triples');
+    // Conditional render — title attribute is absent (or empty)
+    // when stat and rendered agree.
+    expect(tripleStat!.getAttribute('title')).toBeNull();
   });
 
   it('Root card cap honors MAX_PER_CARD even with a single dominant subject (Codex sweep 2)', async () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -490,21 +490,13 @@ describe('SubGraphOverviewGrid — header subtitle anchors (PR #793 round 4.1, G
 
     const sub = container.querySelector('.v10-sgov-sub');
     expect(sub).toBeTruthy();
-    // GH #819 round 7 (Codex sweep 5 🔴 #13) — `'o-wm-mixed'`
-    // (and `'o-swm'`) are bare strings with no `urn:`/`http:`
-    // prefix → `isResourceObject` returns false → they're treated
-    // as literals. Row 2 has the same (subject, predicate) as the
-    // SWM-canonical row 1, the subject has moved past WM, and a
-    // canonical-layer literal exists for `(promoted-a, p)` → row 2
-    // IS literal-residue and drops under the round-7 rule.
-    // Pre-round-7 the resource-only residue rule admitted row 2;
-    // this test originally locked that "consistent-wrong" shape
-    // (ux-lead verdict-A revert, see PR #818 sweep 4). Round 7
-    // corrects it. Row 3 (promoted→promoted at WM, both endpoints
-    // moved) still drops as full-residue. Only the honest SWM
-    // row 1 admits.
-    expect(sub!.textContent).toContain('1 triples');
-    expect(sub!.textContent).not.toContain('2 triples');
+    // 2 of 3 rows admit: the honest SWM row + the orphan-object
+    // WM row (legitimate post-promotion subject-local property).
+    // The full-residue WM row between two promoted entities drops.
+    // Pre-#819 (`useLayerTriples` per-layer rule) would have
+    // dropped both WM rows → `1 triples`. The canonical rule
+    // keeps mixed-layer.
+    expect(sub!.textContent).toContain('2 triples');
     expect(sub!.textContent).not.toContain('3 triples');
   });
 });
@@ -991,17 +983,13 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const cards = container.querySelectorAll('.v10-sgov-card');
     const rootCardEl = cards[cards.length - 1];
     const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
-    // GH #819 round 7 (Codex sweep 5 🔴 #13) — `"o-swm"` and
-    // `"o-wm-residue"` are literal objects (quoted form). Row 2
-    // has the same (subject, predicate) as the SWM-canonical
-    // row 1, the subject moved past WM, and a canonical-layer
-    // literal exists for `(promoted, p)` → row 2 IS literal-
-    // residue and drops. Pre-round-7 the resource-only residue
-    // rule admitted both rows; this test originally locked that
-    // "consistent-wrong" shape (PR #818 sweep 4 ux-lead verdict-A
-    // revert). Round 7 corrects it.
-    expect(stats).toContain('1 triples');
-    expect(stats).not.toContain('2 triples');
+    // PR #818 sweep 4 (ux-lead Finding 1 verdict A — revert): the
+    // sweep-2 layer-correctness filter has been removed; Root now
+    // mirrors the named-card pattern over `memory.allTriples`. The
+    // WM residue row admits alongside the honest SWM row — same
+    // inflation behavior as named cards (consistent-wrong rather
+    // than divergent-wrong; render-side fix is GH #819).
+    expect(stats).toContain('2 triples');
   });
 
   it('Root card admits SWM cross-graph SPO collision via the untagged variant (Codex sweep 4 regression — under-count prevented)', async () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1763,6 +1763,86 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(title).not.toContain('cap-trimmed');
   });
 
+  it('Named card recovers promoted-untagged triples via entity-scope membership (GH #819 round 11 — Codex sweep 9 🔴 #19)', async () => {
+    // After promote/publish, the daemon strips `subGraph` from
+    // triples. Pre-round-11 the bucketer filtered to tagged rows
+    // only, so a fully-promoted subgraph's mini-card regressed
+    // to `0 triples` even though the rest of the UI listed the
+    // data. The bucketer now mirrors `admitTripleForScope` —
+    // untagged rows admit to a bucket whose `entityUrisBySubGraph`
+    // contains the subject or resource-object.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // alpha-membership entity, promoted past WM.
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // Untagged literal-name row — the daemon stripped the
+      // `subGraph` tag on promote. Pre-round-11 this dropped
+      // from alpha's bucket entirely; post-fix `admitTripleForScope`
+      // recovers it (subject URI is in alpha's scoped set).
+      { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"alpha-promoted"', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 1, vm: 0, total: 1 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // Card reports the recovered count (1), not the pre-fix 0.
+    expect(stats).toContain('1 triples');
+    expect(stats).not.toContain('0 triples');
+  });
+
+  it('Untagged row between two cross-membership entities admits in BOTH buckets (GH #819 round 11 — cross-membership preservation)', async () => {
+    // Round 3 #1 contract: a cross-membership entity (member of
+    // alpha AND beta) appearing in two subgraphs' buckets is
+    // expected behavior. Round-11 untagged-recovery must preserve
+    // that: when an untagged row's subject is a cross-membership
+    // entity, it admits to EVERY matching bucket (no inner-loop
+    // break in the recovery pass).
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [
+        { name: 'alpha', entityCount: 1, tripleCount: 0, description: '' },
+        { name: 'beta', entityCount: 1, tripleCount: 0, description: '' },
+      ],
+    });
+    const entityList = [
+      // Single entity that's a member of BOTH alpha and beta.
+      { uri: 'urn:e:cross', label: 'c', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set(['alpha', 'beta']), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // Untagged row — `subGraph` stripped on promote. Subject is
+      // in BOTH alpha's and beta's scoped URI sets.
+      { subject: 'urn:e:cross', predicate: 'http://schema.org/name', object: '"cross-promoted"', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 1, vm: 0, total: 1 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    // Two named cards (alpha + beta) + Root card.
+    expect(cards.length).toBe(3);
+    // Both named cards report the recovered count.
+    const alphaStats = cards[0].querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    const betaStats = cards[1].querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    expect(alphaStats).toContain('1 triples');
+    expect(betaStats).toContain('1 triples');
+  });
+
   it('Root card keeps its scoped copy when same SPO also appears under a named subgraph (GH #819 round 4 — Codex sweep 2 🔴 #7)', async () => {
     // PR #847 round 4 (🔴 #7) — Root card sourced from
     // `canonicalTriples.filter(!t.subGraph)`. Global SPO dedup

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1389,6 +1389,99 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).not.toContain('0 triples');
   });
 
+  it('Named card bucket applies canonical residue filter per scope (GH #819 round 4 — Codex sweep 2 🔴 #5)', async () => {
+    // PR #847 round 4 (🔴 #5) — round 3 per-bucket dedup correctly
+    // preserved cross-membership multiplicity but lacked the
+    // residue filter. A WM-residue resource-edge + its promoted
+    // SWM/VM copy in the same subgraph (different SPO keys) would
+    // double-count: both rows survived per-bucket SPO dedup, but
+    // the WM row is unambiguous residue (both endpoints moved).
+    // Round-4 fix: apply `applyCanonicalAdmission` per bucket so
+    // residue drops at the bucket level too.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 2, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // Both entities promoted past WM (canonical 'shared').
+      { uri: 'urn:e:promoted-a', label: 'a', types: [], trustLevel: 'shared', layers: new Set(['working', 'shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:promoted-b', label: 'b', types: [], trustLevel: 'shared', layers: new Set(['working', 'shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // WM residue resource-edge — both endpoints SWM canonical,
+      // row stored at WM → unambiguous residue → MUST DROP from
+      // the bucket per canonical admission.
+      { subject: 'urn:e:promoted-a', predicate: 'http://schema.org/knows', object: 'urn:e:promoted-b', subGraph: 'alpha', layer: 'working' },
+      // The honest SWM copy — admits.
+      { subject: 'urn:e:promoted-a', predicate: 'http://schema.org/knows', object: 'urn:e:promoted-b', subGraph: 'alpha', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 2, vm: 0, total: 2 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // 1 admitted SPO post-residue + canonical-dedup. Pre-fix the
+    // bucket counted both rows (SPO keys collapsed them, BUT the
+    // residue row would have admitted distinct copies if the
+    // objects differed). Lock the residue-drop invariant.
+    expect(stats).toContain('1 triples');
+    expect(stats).not.toContain('2 triples');
+  });
+
+  it('Root card keeps its scoped copy when same SPO also appears under a named subgraph (GH #819 round 4 — Codex sweep 2 🔴 #7)', async () => {
+    // PR #847 round 4 (🔴 #7) — Root card sourced from
+    // `canonicalTriples.filter(!t.subGraph)`. Global SPO dedup
+    // made this order-dependent: if a tagged copy of the same
+    // SPO arrived first, the root untagged copy lost the dedup
+    // race; `filter(!t.subGraph)` then dropped the surviving
+    // tagged entry; Root rendered 0.
+    //
+    // Round-4 fix: build Root candidates from raw root-scoped
+    // rows (`!t.subGraph`), then `applyCanonicalAdmission` with
+    // per-call dedup state. Each scope keeps its own copy.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 0, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      // Root entity (no subGraph membership).
+      { uri: 'urn:e:r', label: 'r', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set<string>(), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      // Same SPO shipped under named subgraph alpha — arrives
+      // first in iteration order so it wins the global SPO dedup
+      // pre-fix.
+      { subject: 'urn:e:r', predicate: 'http://schema.org/name', object: '"R"', subGraph: 'alpha', layer: 'shared' },
+      // Untagged root copy — pre-fix this lost the global SPO
+      // dedup; `filter(!t.subGraph)` then dropped the tagged
+      // survivor; Root rendered 0.
+      { subject: 'urn:e:r', predicate: 'http://schema.org/name', object: '"R"', layer: 'shared' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 0, swm: 1, vm: 0, total: 1 },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    // Root card is last in the grid (rank 999).
+    const rootCardEl = cards[cards.length - 1];
+    expect(rootCardEl.classList.contains('root')).toBe(true);
+    const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
+    // Root keeps its scoped SPO copy — pre-fix this was 0
+    // (order-dependent dedup race lost).
+    expect(stats).toContain('1 triples');
+    expect(stats).not.toContain('0 triples');
+  });
+
   it('Root card cap honors MAX_PER_CARD even with a single dominant subject (Codex sweep 2)', async () => {
     // PR #818 sweep 2 — sweep-1 sampling shape had a defect:
     // `if (kept >= MAX_PER_CARD) break;` checked AFTER adding the

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -442,45 +442,62 @@ describe('SubGraphOverviewGrid — header subtitle anchors (PR #793 round 4.1, G
     expect(sub!.textContent).not.toContain('4 triples');
   });
 
-  it('subtitle drops WM residue triples whose subject has been promoted to SWM (GH #805 layer-correctness)', async () => {
-    // The other half of GH #805 — WM residue. The daemon leaves
-    // `/assertion/<addr>/<name>` graphs on disk after promote, so a
-    // promoted entity's WM-origin triples keep coming back from
-    // `wmSparql`. The entity's canonical `trustLevel` has moved to
-    // `shared`, so `useLayerTriples('wm')` drops those residue
-    // rows. Pre-#805 `allTriples.length` counted them and the
-    // subtitle disagreed with the per-layer LayerStats.
+  it('subtitle drops WM residue rows only when BOTH endpoints have moved past the row layer (GH #819 mixed-layer-preserving rule)', async () => {
+    // The residue-drop semantic shifted from PR #805's per-layer
+    // rule ("drop if subject moved") to GH #819's canonical-total
+    // rule ("drop ONLY if BOTH endpoints moved past `t.layer`").
+    // The new rule preserves legitimate mixed-layer edges — the
+    // common case after promotion where an entity moves up but
+    // still has cross-layer references.
+    //
+    // This test exercises BOTH branches:
+    //   • promoted → orphan object (literal / class IRI / non-
+    //     entity URN): orphan never "moves", so the row is not
+    //     unambiguous residue → ADMITS as a legitimate
+    //     subject-local property of the promoted entity.
+    //   • promoted → promoted (both endpoints SWM canonical) at
+    //     row layer 'working': both moved past WM → DROPS as
+    //     unambiguous residue.
     fetchSubGraphsMock.mockResolvedValueOnce({
-      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+      subGraphs: [{ name: 'alpha', entityCount: 2, tripleCount: 0, description: '' }],
     });
     const entityList = [
-      // 1 alpha entity, canonical layer SWM (promoted out of WM).
-      { uri: 'urn:e:promoted', label: 'p', types: [], trustLevel: 'shared', layers: new Set(['working', 'shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      // Both entities canonical layer SWM (promoted past WM).
+      { uri: 'urn:e:promoted-a', label: 'a', types: [], trustLevel: 'shared', layers: new Set(['working', 'shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+      { uri: 'urn:e:promoted-b', label: 'b', types: [], trustLevel: 'shared', layers: new Set(['working', 'shared']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
     ];
     const triples = [
-      // Honest SWM triple — kept.
-      { subject: 'urn:e:promoted', predicate: 'p', object: 'o-swm', layer: 'shared' },
-      // WM residue — same subject, but its canonical trustLevel is
-      // 'shared', so `useLayerTriples('wm')` drops this row.
-      // Pre-#805 it would have inflated the subtitle by 1.
-      { subject: 'urn:e:promoted', predicate: 'p', object: 'o-wm-residue', layer: 'working' },
+      // Honest SWM triple to an orphan object — kept.
+      { subject: 'urn:e:promoted-a', predicate: 'p', object: 'o-swm', layer: 'shared' },
+      // WM row to an orphan object. Subject moved past WM but
+      // object is an orphan (no entity record), so this is NOT
+      // unambiguous residue under the canonical rule. Admits as a
+      // subject-local property (the GH #819 mixed-layer-preserving
+      // behavior the per-layer rule incorrectly dropped).
+      { subject: 'urn:e:promoted-a', predicate: 'p', object: 'o-wm-mixed', layer: 'working' },
+      // WM row between two promoted entities. BOTH endpoints
+      // moved past WM → unambiguous residue → drops.
+      { subject: 'urn:e:promoted-a', predicate: 'p', object: 'urn:e:promoted-b', layer: 'working' },
     ];
     await renderWith({
       ...memory,
       entities: new Map(entityList.map(e => [e.uri, e])),
       entityList,
       allTriples: triples,
-      counts: { wm: 0, swm: 1, vm: 0, total: 1 },
+      counts: { wm: 0, swm: 2, vm: 0, total: 2 },
     });
     await flush();
 
     const sub = container.querySelector('.v10-sgov-sub');
     expect(sub).toBeTruthy();
-    // Only the honest SWM triple survives — WM residue dropped by
-    // the per-layer trustLevel filter.
-    expect(sub!.textContent).toContain('1 triples');
-    // Pre-#805 raw `allTriples.length` would have shown 2.
-    expect(sub!.textContent).not.toContain('2 triples');
+    // 2 of 3 rows admit: the honest SWM row + the orphan-object
+    // WM row (legitimate post-promotion subject-local property).
+    // The full-residue WM row between two promoted entities drops.
+    // Pre-#819 (`useLayerTriples` per-layer rule) would have
+    // dropped both WM rows → `1 triples`. The canonical rule
+    // keeps mixed-layer.
+    expect(sub!.textContent).toContain('2 triples');
+    expect(sub!.textContent).not.toContain('3 triples');
   });
 });
 
@@ -1169,12 +1186,22 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).toContain('1 triples');
   });
 
-  it('Named card drops triples to non-scoped entities (parity lock for sweep 6)', async () => {
-    // PR #818 sweep 6 — named-card path has used
-    // `filterTriplesToEntities` since the original implementation
-    // (`:4051`). This test locks the architectural symmetry that
-    // sweep 6 establishes: same input shape, same AND-membership
-    // behavior on the named-card side as the Root card side.
+  it('Named card renders the per-subgraph canonical-bucket triple count (GH #819 decoupled from AND-filtered rendered slice)', async () => {
+    // PR #818 sweep 6 + GH #819 separation of concerns:
+    //   - `tripleCount` STAT reports the canonical per-subgraph
+    //     bucket size (post-residue-filter, post-canonical-SPO-
+    //     dedup, pre-cap, pre-AND-filter). This is the "true
+    //     count" the user sees on the card chrome — agrees with
+    //     the subtitle distinct total when summed without
+    //     double-counting cross-graph duplicates.
+    //   - `triples` RENDERED slice further applies
+    //     `filterTriplesToEntities` (AND-membership +
+    //     rdf:type exemption) so non-scoped objects don't render
+    //     as phantom nodes. The two are intentionally decoupled.
+    //
+    // Pre-#819 the stat read `sg.tripleCount` (daemon-reported)
+    // which was the inflated raw count — agreed with neither the
+    // canonical universe nor the rendered slice.
     fetchSubGraphsMock.mockResolvedValueOnce({
       subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
     });
@@ -1185,9 +1212,12 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
       { uri: 'urn:e:beta', label: 'b', types: [], trustLevel: 'shared', layers: new Set(['shared']), subGraphs: new Set(['beta']), properties: new Map(), connections: [] },
     ];
     const triples = [
-      // alpha → beta edge tagged to alpha's subgraph. Named-card
-      // admission AND-filters: subject in scope, object NOT, so
-      // the edge drops from the alpha card.
+      // alpha → beta edge tagged to alpha's subgraph. The triple
+      // genuinely belongs to alpha's bucket (subGraph tag), so it
+      // counts in the alpha card's stat. The AND-filtered render
+      // slice still drops it because beta isn't in alpha's
+      // entityUris — but that's a render concern, not a count
+      // concern.
       { subject: 'urn:e:alpha', predicate: 'p', object: 'urn:e:beta', subGraph: 'alpha', layer: 'shared' },
     ];
     await renderWith({
@@ -1203,11 +1233,12 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const cards = container.querySelectorAll('.v10-sgov-card');
     const alphaCardEl = cards[0];
     const stats = alphaCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
-    // 1 entity (alpha), 0 triples (the edge to beta dropped by
-    // AND-filter). Locks that the Root card now mirrors this
-    // behavior post-sweep-6.
+    // 1 entity (alpha — the only entity in alpha's subgraph),
+    // 1 triple (the alpha-tagged edge is in alpha's canonical
+    // bucket). Pre-#819 read `sg.tripleCount` (daemon 0); the
+    // canonical bucket-size lock anchors the new behavior.
     expect(stats).toContain('1 entities');
-    expect(stats).toContain('0 triples');
+    expect(stats).toContain('1 triples');
   });
 
   it('Root card cap honors MAX_PER_CARD even with a single dominant subject (Codex sweep 2)', async () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -490,13 +490,21 @@ describe('SubGraphOverviewGrid — header subtitle anchors (PR #793 round 4.1, G
 
     const sub = container.querySelector('.v10-sgov-sub');
     expect(sub).toBeTruthy();
-    // 2 of 3 rows admit: the honest SWM row + the orphan-object
-    // WM row (legitimate post-promotion subject-local property).
-    // The full-residue WM row between two promoted entities drops.
-    // Pre-#819 (`useLayerTriples` per-layer rule) would have
-    // dropped both WM rows → `1 triples`. The canonical rule
-    // keeps mixed-layer.
-    expect(sub!.textContent).toContain('2 triples');
+    // GH #819 round 7 (Codex sweep 5 🔴 #13) — `'o-wm-mixed'`
+    // (and `'o-swm'`) are bare strings with no `urn:`/`http:`
+    // prefix → `isResourceObject` returns false → they're treated
+    // as literals. Row 2 has the same (subject, predicate) as the
+    // SWM-canonical row 1, the subject has moved past WM, and a
+    // canonical-layer literal exists for `(promoted-a, p)` → row 2
+    // IS literal-residue and drops under the round-7 rule.
+    // Pre-round-7 the resource-only residue rule admitted row 2;
+    // this test originally locked that "consistent-wrong" shape
+    // (ux-lead verdict-A revert, see PR #818 sweep 4). Round 7
+    // corrects it. Row 3 (promoted→promoted at WM, both endpoints
+    // moved) still drops as full-residue. Only the honest SWM
+    // row 1 admits.
+    expect(sub!.textContent).toContain('1 triples');
+    expect(sub!.textContent).not.toContain('2 triples');
     expect(sub!.textContent).not.toContain('3 triples');
   });
 });
@@ -983,13 +991,17 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     const cards = container.querySelectorAll('.v10-sgov-card');
     const rootCardEl = cards[cards.length - 1];
     const stats = rootCardEl.querySelector('.v10-sgov-card-stats')?.textContent ?? '';
-    // PR #818 sweep 4 (ux-lead Finding 1 verdict A — revert): the
-    // sweep-2 layer-correctness filter has been removed; Root now
-    // mirrors the named-card pattern over `memory.allTriples`. The
-    // WM residue row admits alongside the honest SWM row — same
-    // inflation behavior as named cards (consistent-wrong rather
-    // than divergent-wrong; render-side fix is GH #819).
-    expect(stats).toContain('2 triples');
+    // GH #819 round 7 (Codex sweep 5 🔴 #13) — `"o-swm"` and
+    // `"o-wm-residue"` are literal objects (quoted form). Row 2
+    // has the same (subject, predicate) as the SWM-canonical
+    // row 1, the subject moved past WM, and a canonical-layer
+    // literal exists for `(promoted, p)` → row 2 IS literal-
+    // residue and drops. Pre-round-7 the resource-only residue
+    // rule admitted both rows; this test originally locked that
+    // "consistent-wrong" shape (PR #818 sweep 4 ux-lead verdict-A
+    // revert). Round 7 corrects it.
+    expect(stats).toContain('1 triples');
+    expect(stats).not.toContain('2 triples');
   });
 
   it('Root card admits SWM cross-graph SPO collision via the untagged variant (Codex sweep 4 regression — under-count prevented)', async () => {

--- a/packages/node-ui/test/use-canonical-triples.test.ts
+++ b/packages/node-ui/test/use-canonical-triples.test.ts
@@ -285,4 +285,89 @@ describe('useCanonicalTriples — canonical project-wide triple total (GH #819)'
     expect(spo).toContain('urn:e:a|http://schema.org/knows|urn:e:c');
     expect(spo).not.toContain('urn:e:a|http://schema.org/knows|urn:e:b');
   });
+
+  // T7 — GH #819 round 7 (Codex sweep 5 🔴 #13). Literal-divergence
+  // residue: when a subject is promoted past a row's layer AND a
+  // canonical-layer literal exists for the same (s,p), the lower-
+  // layer literal is residue from the pre-promotion state and
+  // must drop. Pre-fix the resource-only residue rule admitted
+  // BOTH, and SPO dedup couldn't collapse them because the literal
+  // VALUE differed — entity surfaced with two label values.
+  it('T7 — drops literal-divergence residue when subject moved past row.layer', () => {
+    const triples: LayeredTriple[] = [
+      // Promote urn:e:X to SWM canonical via its "new" literal.
+      { subject: 'urn:e:X', predicate: 'http://schema.org/name', object: '"new"', layer: 'shared' },
+      // WM-stored literal with a DIFFERENT value — residue from
+      // before the entity was promoted. Pre-fix: this admitted
+      // (resource-only residue rule) and yielded total === 2.
+      { subject: 'urn:e:X', predicate: 'http://schema.org/name', object: '"old"', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    expect(memory.entities.get('urn:e:X')?.trustLevel).toBe('shared');
+    render(memory);
+    const { total, spo } = readProbe(container);
+    // Only the canonical-layer literal survives.
+    expect(total).toBe(1);
+    expect(spo).toContain('urn:e:X|http://schema.org/name|"new"');
+    expect(spo).not.toContain('urn:e:X|http://schema.org/name|"old"');
+  });
+
+  // T7-edge-A — same literal value at both layers (subject promoted).
+  // SPO dedup already collapses these; the new literal-residue
+  // rule should not double-drop.
+  it('T7 edge — same literal at both layers with promoted subject still admits one row', () => {
+    const triples: LayeredTriple[] = [
+      // Both rows have the same literal "X". Subject is SWM canonical.
+      { subject: 'urn:e:X', predicate: 'http://schema.org/name', object: '"X"', layer: 'shared' },
+      { subject: 'urn:e:X', predicate: 'http://schema.org/name', object: '"X"', layer: 'working' },
+    ];
+    render(memoryFor(triples));
+    const { total } = readProbe(container);
+    expect(total).toBe(1);
+  });
+
+  // T7-edge-B — different literals at two layers where the subject
+  // is NOT promoted. Both rows are legitimate — no residue.
+  // (In practice an entity's `trustLevel` is the highest layer it
+  // appears in; if it appears at both WM and SWM, canonical is SWM,
+  // so this scenario requires the entity to appear ONLY at one
+  // canonical layer. We use a WM-only entity with two literal-
+  // valued rows at WM to lock the no-promotion case.)
+  it('T7 edge — WM-only entity with two same-(s,p) literal rows at WM admits both', () => {
+    const triples: LayeredTriple[] = [
+      // urn:e:wm only appears at WM, so trustLevel === 'working'.
+      { subject: 'urn:e:wm', predicate: 'http://schema.org/keyword', object: '"alpha"', layer: 'working' },
+      { subject: 'urn:e:wm', predicate: 'http://schema.org/keyword', object: '"beta"', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    expect(memory.entities.get('urn:e:wm')?.trustLevel).toBe('working');
+    render(memory);
+    const { total } = readProbe(container);
+    // Neither row's subject moved past `t.layer` → neither is
+    // residue. SPO keys differ (literal values differ) → no dedup
+    // collapse. Both admit.
+    expect(total).toBe(2);
+  });
+
+  // T7-edge-C — promoted subject with a literal at WM that has NO
+  // canonical-layer counterpart for the same (s,p). The lower-
+  // layer literal is the ONLY recording of that fact → keeps.
+  it('T7 edge — promoted subject keeps a WM literal with no canonical-layer counterpart', () => {
+    const triples: LayeredTriple[] = [
+      // Promote urn:e:Y to SWM via a DIFFERENT predicate.
+      { subject: 'urn:e:Y', predicate: 'http://schema.org/name', object: '"Y"', layer: 'shared' },
+      // WM-only literal under a different predicate — no
+      // canonical-layer literal exists for (Y, keyword), so this
+      // is a lower-layer-only fact, not residue.
+      { subject: 'urn:e:Y', predicate: 'http://schema.org/keyword', object: '"draft"', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    expect(memory.entities.get('urn:e:Y')?.trustLevel).toBe('shared');
+    render(memory);
+    const { total, spo } = readProbe(container);
+    // Both rows survive: (Y, name, "Y") is canonical, (Y, keyword,
+    // "draft") is a WM-only fact with no canonical counterpart.
+    expect(total).toBe(2);
+    expect(spo).toContain('urn:e:Y|http://schema.org/keyword|"draft"');
+  });
 });

--- a/packages/node-ui/test/use-canonical-triples.test.ts
+++ b/packages/node-ui/test/use-canonical-triples.test.ts
@@ -286,88 +286,35 @@ describe('useCanonicalTriples — canonical project-wide triple total (GH #819)'
     expect(spo).not.toContain('urn:e:a|http://schema.org/knows|urn:e:b');
   });
 
-  // T7 — GH #819 round 7 (Codex sweep 5 🔴 #13). Literal-divergence
-  // residue: when a subject is promoted past a row's layer AND a
-  // canonical-layer literal exists for the same (s,p), the lower-
-  // layer literal is residue from the pre-promotion state and
-  // must drop. Pre-fix the resource-only residue rule admitted
-  // BOTH, and SPO dedup couldn't collapse them because the literal
-  // VALUE differed — entity surfaced with two label values.
-  it('T7 — drops literal-divergence residue when subject moved past row.layer', () => {
+  // T8 — GH #819 round 9 (Codex sweep 7 🔴 #16). Multi-valued
+  // predicate across layers with promoted subject. Round 7
+  // attempted to drop lower-layer literals as residue when a
+  // canonical-layer `(s,p)` row existed — that over-reached:
+  // `(s, tag, "a")` at WM is a legitimate distinct fact, not
+  // residue, even when `(s, tag, "b")` exists at SWM. We have
+  // no predicate-cardinality metadata to tell single-valued
+  // from multi-valued, so the round 7 logic was reverted.
+  //
+  // This regression guard locks the post-revert contract:
+  // BOTH literal values admit. SPO dedup collapses exact-match
+  // duplicates; divergent literal VALUES both survive.
+  it('T8 — admits both literals on a multi-valued predicate across layers (post-round-9 revert)', () => {
     const triples: LayeredTriple[] = [
-      // Promote urn:e:X to SWM canonical via its "new" literal.
-      { subject: 'urn:e:X', predicate: 'http://schema.org/name', object: '"new"', layer: 'shared' },
-      // WM-stored literal with a DIFFERENT value — residue from
-      // before the entity was promoted. Pre-fix: this admitted
-      // (resource-only residue rule) and yielded total === 2.
-      { subject: 'urn:e:X', predicate: 'http://schema.org/name', object: '"old"', layer: 'working' },
+      // Promote urn:e:S to SWM canonical via the "b" tag.
+      { subject: 'urn:e:S', predicate: 'http://schema.org/keyword', object: '"b"', layer: 'shared' },
+      // WM-stored literal with a DIFFERENT value — legitimate
+      // multi-value fact on a predicate like `keyword` /
+      // `altLabel`. Round 7 wrongly dropped this as residue;
+      // round 9 admits it.
+      { subject: 'urn:e:S', predicate: 'http://schema.org/keyword', object: '"a"', layer: 'working' },
     ];
     const memory = memoryFor(triples);
-    expect(memory.entities.get('urn:e:X')?.trustLevel).toBe('shared');
+    expect(memory.entities.get('urn:e:S')?.trustLevel).toBe('shared');
     render(memory);
     const { total, spo } = readProbe(container);
-    // Only the canonical-layer literal survives.
-    expect(total).toBe(1);
-    expect(spo).toContain('urn:e:X|http://schema.org/name|"new"');
-    expect(spo).not.toContain('urn:e:X|http://schema.org/name|"old"');
-  });
-
-  // T7-edge-A — same literal value at both layers (subject promoted).
-  // SPO dedup already collapses these; the new literal-residue
-  // rule should not double-drop.
-  it('T7 edge — same literal at both layers with promoted subject still admits one row', () => {
-    const triples: LayeredTriple[] = [
-      // Both rows have the same literal "X". Subject is SWM canonical.
-      { subject: 'urn:e:X', predicate: 'http://schema.org/name', object: '"X"', layer: 'shared' },
-      { subject: 'urn:e:X', predicate: 'http://schema.org/name', object: '"X"', layer: 'working' },
-    ];
-    render(memoryFor(triples));
-    const { total } = readProbe(container);
-    expect(total).toBe(1);
-  });
-
-  // T7-edge-B — different literals at two layers where the subject
-  // is NOT promoted. Both rows are legitimate — no residue.
-  // (In practice an entity's `trustLevel` is the highest layer it
-  // appears in; if it appears at both WM and SWM, canonical is SWM,
-  // so this scenario requires the entity to appear ONLY at one
-  // canonical layer. We use a WM-only entity with two literal-
-  // valued rows at WM to lock the no-promotion case.)
-  it('T7 edge — WM-only entity with two same-(s,p) literal rows at WM admits both', () => {
-    const triples: LayeredTriple[] = [
-      // urn:e:wm only appears at WM, so trustLevel === 'working'.
-      { subject: 'urn:e:wm', predicate: 'http://schema.org/keyword', object: '"alpha"', layer: 'working' },
-      { subject: 'urn:e:wm', predicate: 'http://schema.org/keyword', object: '"beta"', layer: 'working' },
-    ];
-    const memory = memoryFor(triples);
-    expect(memory.entities.get('urn:e:wm')?.trustLevel).toBe('working');
-    render(memory);
-    const { total } = readProbe(container);
-    // Neither row's subject moved past `t.layer` → neither is
-    // residue. SPO keys differ (literal values differ) → no dedup
-    // collapse. Both admit.
+    // Both values admit — multi-valued correctness preserved.
     expect(total).toBe(2);
-  });
-
-  // T7-edge-C — promoted subject with a literal at WM that has NO
-  // canonical-layer counterpart for the same (s,p). The lower-
-  // layer literal is the ONLY recording of that fact → keeps.
-  it('T7 edge — promoted subject keeps a WM literal with no canonical-layer counterpart', () => {
-    const triples: LayeredTriple[] = [
-      // Promote urn:e:Y to SWM via a DIFFERENT predicate.
-      { subject: 'urn:e:Y', predicate: 'http://schema.org/name', object: '"Y"', layer: 'shared' },
-      // WM-only literal under a different predicate — no
-      // canonical-layer literal exists for (Y, keyword), so this
-      // is a lower-layer-only fact, not residue.
-      { subject: 'urn:e:Y', predicate: 'http://schema.org/keyword', object: '"draft"', layer: 'working' },
-    ];
-    const memory = memoryFor(triples);
-    expect(memory.entities.get('urn:e:Y')?.trustLevel).toBe('shared');
-    render(memory);
-    const { total, spo } = readProbe(container);
-    // Both rows survive: (Y, name, "Y") is canonical, (Y, keyword,
-    // "draft") is a WM-only fact with no canonical counterpart.
-    expect(total).toBe(2);
-    expect(spo).toContain('urn:e:Y|http://schema.org/keyword|"draft"');
+    expect(spo).toContain('urn:e:S|http://schema.org/keyword|"a"');
+    expect(spo).toContain('urn:e:S|http://schema.org/keyword|"b"');
   });
 });

--- a/packages/node-ui/test/use-canonical-triples.test.ts
+++ b/packages/node-ui/test/use-canonical-triples.test.ts
@@ -1,0 +1,288 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { useCanonicalTriples } from '../src/ui/views/project/helpers.js';
+import { buildMemoryEntities, type LayeredTriple, type MemoryData } from '../src/ui/hooks/useMemoryEntities.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+// Build a MemoryData fixture from a flat triple list. `entities` is
+// produced by `buildMemoryEntities` so `trustLevel` (the canonical
+// highest-layer-membership) is computed correctly — the residue rule
+// is keyed on this exact derivation.
+function memoryFor(triples: LayeredTriple[]): MemoryData {
+  const entities = buildMemoryEntities(triples);
+  return {
+    entities,
+    entityList: [...entities.values()],
+    allTriples: triples,
+    graphTriples: [],
+    trustMap: new Map(),
+    counts: { wm: 0, swm: 0, vm: 0, total: entities.size },
+    loading: false,
+    error: null,
+    partial: false,
+    layerStatus: { wm: 'ok', swm: 'ok', vm: 'ok' },
+    refresh: () => {},
+  } as unknown as MemoryData;
+}
+
+// Surface the canonical helper's `total` + a SPO-joined list via
+// data-attributes so individual test assertions can pattern-match
+// without React-testing-library overhead.
+function ProbeCanonicalTriples({ memory }: { memory: MemoryData }) {
+  const { triples, total } = useCanonicalTriples(memory as any);
+  const spo = triples
+    .map(t => `${t.subject}|${t.predicate}|${t.object}`)
+    .join('\n');
+  return React.createElement('div', {
+    id: 'probe',
+    'data-total': String(total),
+    'data-spo': spo,
+  });
+}
+
+function readProbe(container: Element): { total: number; spo: string[] } {
+  const probe = container.querySelector('#probe')!;
+  return {
+    total: Number(probe.getAttribute('data-total') ?? 'NaN'),
+    spo: (probe.getAttribute('data-spo') ?? '').split('\n').filter(Boolean),
+  };
+}
+
+describe('useCanonicalTriples — canonical project-wide triple total (GH #819)', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(memory: MemoryData) {
+    act(() => {
+      root.render(React.createElement(ProbeCanonicalTriples, { memory }));
+    });
+  }
+
+  // T1 — untagged WM-only triple stays. Locks the baseline: a row
+  // whose subject is canonically at the row's layer (no promotion)
+  // passes the residue check and admits.
+  it('T1 — admits a WM-only triple whose subject is canonically WM', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:wm-only', predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
+    ];
+    render(memoryFor(triples));
+    const { total, spo } = readProbe(container);
+    expect(total).toBe(1);
+    expect(spo[0]).toBe('urn:e:wm-only|' + RDF_TYPE + '|http://schema.org/Thing');
+  });
+
+  // T2 — cross-layer subject promoted: the triple drops if the
+  // OBJECT was also promoted past `t.layer` (unambiguous residue);
+  // it STAYS if the object is still at the row's layer (legitimate
+  // mixed-layer edge that `useLayerTriples` would have dropped).
+  //
+  // This is the load-bearing distinction from the per-layer rule.
+  it('T2 — keeps a mixed-layer edge where only the subject moved past `t.layer`', () => {
+    // urn:e:moved is canonically SWM (has both working + shared
+    // layers); urn:e:wm-still is canonically WM (only working).
+    // The WM row connecting them: subject moved past WM, object
+    // still at WM → KEEP (mixed-layer edge is a fact).
+    const triples: LayeredTriple[] = [
+      // Promotes urn:e:moved to SWM canonical.
+      { subject: 'urn:e:moved', predicate: 'http://schema.org/name', object: '"Moved"', layer: 'shared' },
+      // urn:e:wm-still stays WM canonical (no SWM membership).
+      { subject: 'urn:e:wm-still', predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
+      // The mixed-layer edge — subject is SWM canonical, object is
+      // WM canonical, row stored at WM. Per ux-lead's rule this is
+      // a legitimate fact (one endpoint still at `t.layer`) and
+      // must admit.
+      { subject: 'urn:e:moved', predicate: 'http://schema.org/knows', object: 'urn:e:wm-still', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    expect(memory.entities.get('urn:e:moved')?.trustLevel).toBe('shared');
+    expect(memory.entities.get('urn:e:wm-still')?.trustLevel).toBe('working');
+    render(memory);
+    const { total, spo } = readProbe(container);
+    // All 3 facts survive — mixed-layer edge is NOT dropped.
+    expect(total).toBe(3);
+    expect(spo).toContain('urn:e:moved|http://schema.org/knows|urn:e:wm-still');
+  });
+
+  // T2 companion — when BOTH endpoints moved past `t.layer` the row
+  // IS unambiguous residue and drops. Mirrors the
+  // `useLayerTriples` behavior on the worst-case shape; ensures
+  // the new helper doesn't over-include.
+  it('T2-residue — drops a WM row whose subject AND object both moved past WM', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:a', predicate: 'http://schema.org/name', object: '"A"', layer: 'shared' },
+      { subject: 'urn:e:b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared' },
+      // Both endpoints SWM canonical; row stored at WM = residue.
+      { subject: 'urn:e:a', predicate: 'http://schema.org/knows', object: 'urn:e:b', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    expect(memory.entities.get('urn:e:a')?.trustLevel).toBe('shared');
+    expect(memory.entities.get('urn:e:b')?.trustLevel).toBe('shared');
+    render(memory);
+    const { total, spo } = readProbe(container);
+    // Only the 2 SWM literal-name rows survive; the WM residue
+    // row drops.
+    expect(total).toBe(2);
+    expect(spo).not.toContain('urn:e:a|http://schema.org/knows|urn:e:b');
+  });
+
+  // T3 — SPO dedup across multiple graph URIs. The same canonical
+  // `(s, p, o)` shipped from multiple sources collapses to a single
+  // admitted row (this is the SWM cross-graph duplication shape +
+  // any other cross-graph collision).
+  it('T3 — collapses SPO duplicates across multiple graph URIs to a single row', () => {
+    const triples: LayeredTriple[] = [
+      // Same SPO, two graph URIs (one tagged + one untagged — both
+      // canonicalize to the same dedup key).
+      { subject: 'urn:e:x', predicate: 'http://schema.org/name', object: '"X"', layer: 'shared', subGraph: 'recipes' },
+      { subject: 'urn:e:x', predicate: 'http://schema.org/name', object: '"X"', layer: 'shared' },
+      // Distinct second SPO to verify total isn't trivially 1.
+      { subject: 'urn:e:y', predicate: 'http://schema.org/name', object: '"Y"', layer: 'shared' },
+    ];
+    render(memoryFor(triples));
+    const { total } = readProbe(container);
+    // 2 distinct SPOs after dedup, not 3.
+    expect(total).toBe(2);
+  });
+
+  // T4 — layered residue interacting with dedup. Across multiple
+  // layers, ensures the per-layer SPO-tracking works: an SPO that
+  // legitimately appears in WM AND its mixed-layer variant in SWM
+  // admits once (same SPO key collapses them); a WM residue copy
+  // of an SWM-canonical SPO drops AFTER dedup, not before.
+  it('T4 — per-layer residue interacts cleanly with global SPO dedup', () => {
+    const triples: LayeredTriple[] = [
+      // urn:e:p promotes to SWM via this row.
+      { subject: 'urn:e:p', predicate: 'http://schema.org/name', object: '"P"', layer: 'shared' },
+      // Same SPO shipped at WM — would be residue (subject is SWM
+      // canonical, object is literal so no second-endpoint
+      // promotion). BUT the SPO collapses via dedup with the SWM
+      // copy above, so total stays at 1 even before residue logic
+      // gets a vote.
+      { subject: 'urn:e:p', predicate: 'http://schema.org/name', object: '"P"', layer: 'working' },
+      // A separate WM-only entity for total-counting.
+      { subject: 'urn:e:wm', predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
+    ];
+    render(memoryFor(triples));
+    const { total } = readProbe(container);
+    expect(total).toBe(2);
+  });
+
+  // T5 — canonicalization: wrapped IRI `<urn:...>` and bare `urn:...`
+  // of the same SPO collapse to one. Discrete lock — easy to under-
+  // cover; the wrapped-form is what the daemon ships in places.
+  it('T5 — collapses wrapped + bare IRI variants of the same SPO', () => {
+    const triples: LayeredTriple[] = [
+      // Wrapped subject form.
+      { subject: '<urn:e:wrapped>', predicate: 'http://schema.org/knows', object: 'urn:e:other', layer: 'working' },
+      // Bare subject form — same canonical SPO. Object also varies
+      // in wrap to exercise the object-side canonicalisation.
+      { subject: 'urn:e:wrapped', predicate: 'http://schema.org/knows', object: '<urn:e:other>', layer: 'working' },
+    ];
+    render(memoryFor(triples));
+    const { total } = readProbe(container);
+    expect(total).toBe(1);
+  });
+
+  // T6 — orphan-entity guard. A triple whose subject is NOT in the
+  // entity map (literal orphan / class IRI / blank node anchor)
+  // must admit unfiltered — without the `subjectEntity &&` guard
+  // these rows would silently drop because the residue check would
+  // crash (undefined `trustLevel`) or fail the equality.
+  //
+  // Construct a fixture where the subject is a synthetic URN never
+  // emitted with its own typed triples — `buildMemoryEntities` only
+  // adds entries when a subject has at least one outgoing row, so
+  // a hand-crafted memory fixture WITHOUT the subject in the
+  // entity map exercises this branch.
+  it('T6 — admits a triple whose subject is not in the entity map (orphan-entity guard)', () => {
+    // Build a memory fixture manually so we can prove the orphan
+    // case — entity map empty, but allTriples has a row.
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:class:OrphanType', predicate: RDF_TYPE, object: 'http://schema.org/Class', layer: 'working' },
+    ];
+    const memory: MemoryData = {
+      entities: new Map(), // orphan — subject not present
+      entityList: [],
+      allTriples: triples,
+      graphTriples: [],
+      trustMap: new Map(),
+      counts: { wm: 0, swm: 0, vm: 0, total: 0 },
+      loading: false,
+      error: null,
+      partial: false,
+      layerStatus: { wm: 'ok', swm: 'ok', vm: 'ok' },
+      refresh: () => {},
+    } as unknown as MemoryData;
+    render(memory);
+    const { total, spo } = readProbe(container);
+    // Orphan triple admits — without the guard the row would have
+    // been silently dropped or thrown.
+    expect(total).toBe(1);
+    expect(spo).toContain('urn:class:OrphanType|' + RDF_TYPE + '|http://schema.org/Class');
+  });
+
+  // T7 — canonical regression-prevent. A composite scenario that
+  // hits the full pipeline: residue + cross-graph dedup + mixed-
+  // layer keep + orphan + canonicalisation, all in one fixture.
+  // Locks the helper against ANY single-rule regression.
+  it('T7 — composite scenario (residue + dedup + mixed-layer + canonicalisation, all interacting)', () => {
+    const triples: LayeredTriple[] = [
+      // 1) Promotes urn:e:a to SWM.
+      { subject: 'urn:e:a', predicate: 'http://schema.org/name', object: '"A"', layer: 'shared' },
+      // 2) Promotes urn:e:b to SWM.
+      { subject: 'urn:e:b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared' },
+      // 3) WM-canonical entity urn:e:c with its name.
+      { subject: 'urn:e:c', predicate: 'http://schema.org/name', object: '"C"', layer: 'working' },
+      // 4) WM residue — same SPO as (1), shipped under WM
+      //    via a `/_assertion/` graph. Dedups with (1).
+      { subject: 'urn:e:a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+      // 5) Mixed-layer edge — SWM subject, WM object, stored at
+      //    WM. Per ux-lead's rule: KEEP (one endpoint still at
+      //    t.layer).
+      { subject: 'urn:e:a', predicate: 'http://schema.org/knows', object: 'urn:e:c', layer: 'working' },
+      // 6) Full-residue edge — both endpoints SWM canonical,
+      //    stored at WM. Drops as residue.
+      { subject: 'urn:e:a', predicate: 'http://schema.org/knows', object: 'urn:e:b', layer: 'working' },
+      // 7) Cross-graph dedup — same SPO as (2), shipped under a
+      //    per-sub-graph SWM graph. Dedups with (2).
+      { subject: 'urn:e:b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared', subGraph: 'demo' },
+      // 8) Wrapped variant of (3) — collapses with (3) via
+      //    canonicalisation.
+      { subject: '<urn:e:c>', predicate: 'http://schema.org/name', object: '"C"', layer: 'working' },
+    ];
+    const memory = memoryFor(triples);
+    // Sanity-check the canonical trust levels the residue rule
+    // hangs on.
+    expect(memory.entities.get('urn:e:a')?.trustLevel).toBe('shared');
+    expect(memory.entities.get('urn:e:b')?.trustLevel).toBe('shared');
+    expect(memory.entities.get('urn:e:c')?.trustLevel).toBe('working');
+    render(memory);
+    const { total, spo } = readProbe(container);
+    // 4 distinct admitted facts:
+    //   - (a, name, "A")     — rows 1 + 4 dedup
+    //   - (b, name, "B")     — rows 2 + 7 dedup
+    //   - (c, name, "C")     — rows 3 + 8 dedup via canonicalisation
+    //   - (a, knows, c)      — mixed-layer edge admits (row 5)
+    // Row 6 (a→b at WM) drops as full-residue.
+    expect(total).toBe(4);
+    expect(spo).toContain('urn:e:a|http://schema.org/knows|urn:e:c');
+    expect(spo).not.toContain('urn:e:a|http://schema.org/knows|urn:e:b');
+  });
+});


### PR DESCRIPTION
> **Stacked PR.** Base is `feat/node-ui-followups-771-singlelayerpanel` (PR #839), NOT `main`. GitHub will auto-rebase this branch onto `main` once #839 lands. Review the diff for THIS PR only — github-pr-driver should compare against the stacked base.

## Summary

- New `useCanonicalTriples(memory) → { triples: LayeredTriple[]; total: number }` helper in `packages/node-ui/src/ui/views/project/helpers.ts` — single iteration over `memory.allTriples` applying subject-residue carry-forward + BOTH-endpoints-moved object-side residue rule + canonical SPO dedup + orphan-entity guard. Sibling of `useLayerTriples` (per-layer correct) and `admitTripleForScope` (scope predicate from PR #839); same canonical triple-selection site.
- Six aggregate consumer sites migrated to `canonical.total`: Overview Triples stat, SubGraphOverviewGrid subtitle, Root mini-card, Named subgraph cards (per-bucket count), Dashboard per-CG row total, Dashboard aggregate. Plus `MemoryStackView.tsx:103` per-layer breakdown.
- Dashboard per-layer wm/swm/vm cells stay on `useLayerTriples` (matches Overview LayerStats cell-for-cell). Documented `wm+swm+vm ≤ total` contract at the derivation site (ux-lead-locked artifact per round-2 review).
- Conditional stat-vs-rendered tooltip on Named subgraph card triple-count badge (ux-lead-locked literal). Fires only when `tripleCount !== renderedTripleCount` — no chrome added to the quiet case.
- Two existing test rewrites (not relaxations) for the new mixed-layer-preserving rule + stat-vs-render decoupling. T1-T7 isolation tests for the helper itself.

## Related

- Fixes #819
- Stacked on #839 (merge target until #839 lands on main)
- Closes the GH #805 family on the aggregate-derivation axis. Per-layer disaggregation invariant intentionally documented as `wm+swm+vm ≤ total` (not `=`), with rationale at the site — preserving cell-for-cell agreement between Dashboard per-layer and Overview LayerStats was the load-bearing call.
- Deferred from PR #818 sweep 4 (ux-lead locked the §4.4.1 architectural symmetry there + flagged the shared render-correct derivation as a follow-up rather than fold it into the polish PR)

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/views/project/helpers.ts` | Add `useCanonicalTriples` helper with full doc block (residue rule + dedup + orphan guard + out-of-scope notes); refresh doc anchors on `useLayerTriples` neighbour |
| `packages/node-ui/src/ui/views/project/components.tsx` | 4 consumer sites: Overview Triples stat, SubGraphOverviewGrid subtitle, `triplesBySubGraph` bucketing (sourced from canonical), Named card `tripleCount` + Root mini-card derivation. Conditional tooltip on Named card triple badge. `memory.loading` gate on the `tripleCount` fallback to `sg.tripleCount` (only fires while not-yet-hydrated; hydrated-zero surfaces honestly) |
| `packages/node-ui/src/ui/views/DashboardView.tsx` | Per-CG row + aggregate total → `useCanonicalTriples`; per-layer cells stay on `useLayerTriples`; contract comment at site documenting `wm+swm+vm ≤ total` invariant + the explicit ux-lead "don't refactor useLayerTriples" scope constraint |
| `packages/node-ui/src/ui/views/MemoryStackView.tsx` | +1 consumer site: per-layer triple bucketing reads canonical instead of raw `memory.allTriples` |
| `packages/node-ui/test/use-canonical-triples.test.ts` (NEW) | T1-T7 isolation tests for the helper (T1 baseline, T2 mixed-layer keep, T2-residue both-moved drop, T3 cross-graph dedup, T4 per-layer dedup interaction, T5 wrapped/bare canonicalisation, T6 orphan-entity guard, T7 composite regression-prevent) |
| `packages/node-ui/test/subgraph-overview-grid.test.ts` | Two test rewrites for new architecture (WM-residue subtitle test now covers BOTH branches: mixed-layer keep + both-endpoints-moved drop; Named-card test now locks stat-vs-render decoupling) + NEW conditional-tooltip render lock (tooltip absent when stat == rendered) |

## Test plan

- [x] `pnpm exec tsc --noEmit` exit 0 (no new errors beyond pre-existing daemon-side `structured-logger` noise)
- [x] Extended slice (20 files): **346/346 pass deterministically across two warm reruns** (38 pre-existing skips unchanged)
- [x] T1-T7 isolation tests for `useCanonicalTriples`: 8/8 pass (T1, T2-keep, T2-residue, T3, T4, T5, T6, T7)
- [x] `agent-docs/` absent from stacked diff (`git diff origin/feat/node-ui-followups-771-singlelayerpanel...979ff461a -- agent-docs/` empty)
- [x] No new design tokens / raw hex
- [x] `RESERVED_SUB_GRAPH_SLUGS` unchanged
- [x] Stacked PR base verified: `feat/node-ui-followups-771-singlelayerpanel`, NOT `main`
- [ ] **Manual verify on `ui-refresh` CG**: Dashboard Triples reads **372** (not 413). The headline acceptance from the GH #819 brief — Dashboard now agrees with the Overview Triples stat by construction.
- [ ] **Manual verify on cross-membership CG**: Overview "At a glance" Triples == SubGraphOverviewGrid subtitle Triples
- [ ] **Manual verify on cross-membership CG**: Named card tooltip surfaces ONLY when `tripleCount !== renderedTripleCount`; no `title` attr when equal
- [ ] **Manual verify**: Dashboard per-layer cells (WM/SWM/VM) match Overview LayerStats per-layer cells cell-for-cell
- [ ] **Regression-prevent**: on CG with no cross-membership / no promoted entities, per-card `tripleCount` sum still equals subtitle (no surprise gap on simple CGs)

## Notes for review

- **Stacked PR discipline**: the diff against `main` would include #839's commits — review against the stacked base only. GitHub's "compare" UI handles this when you pick the right base in the dropdown.
- **The `wm+swm+vm ≤ total` contract on Dashboard is deliberate**, not a regression. Pre-#819 the equality was visual coincidence (both sides inflated by the same SWM cross-graph + WM residue counts). Post-#819 the total is honest and the per-layer cells match Overview LayerStats by construction; the gap is the count of mixed-layer edges canonical keeps but per-layer slices drop. Restoring strict equality would require migrating LayerStats consumers off `useLayerTriples` — explicitly out of ux-lead's scope brief ("don't refactor useLayerTriples; just stop summing its outputs at the 6 aggregate sites").
- **Helper name `useCanonicalTriples`**: kept after the round-1 💡 suggestion. The file uses "canonical" as "single source of truth derivation" in multiple places (`canonicalEntityUri` is sibling). Defensible parlance, doesn't read as overloaded once the doc block context lands.
- **Two test rewrites are honest expectation updates, not loosening**. The `subtitle drops WM residue` test now covers both the mixed-layer-keep branch AND the full-residue-drop branch (more coverage, not less); the Named-card test now locks the intentional stat-vs-render decoupling that was implicit pre-#819. Round-1 reviewer flagged this concern; both rewrites pass round-2 review clean.