### PR TITLE
fix: address #716 review feedback (8 items from Brano)

### DIFF
--- a/.github/workflows/supply-chain-scan.yml
+++ b/.github/workflows/supply-chain-scan.yml
@@ -149,6 +149,13 @@ jobs:
         # the ignored workflows for known publishing-action markers, and
         # fails the audit if any are found.
         #
+        # Self-match protection: this step itself contains every marker as
+        # a literal string in `PATTERNS`. To avoid a false-positive when
+        # scanning `supply-chain-scan.yml`, the guard's own pattern block
+        # is bracketed with sentinel comments and stripped from the scan
+        # input via `sed` before grep runs. Any future literal-pattern
+        # additions MUST stay inside the sentinels.
+        #
         # Note: this does NOT catch cross-workflow artifact promotion via
         # `actions/upload-artifact` consumed by a separate publishing
         # workflow — that requires its own audit. For now, in-workflow
@@ -160,6 +167,7 @@ jobs:
             .github/workflows/evm-integration.yml
             .github/workflows/supply-chain-scan.yml
           )
+          # zizmor-cache-poisoning-guard-patterns-start
           # Patterns that indicate a workflow is shipping bytes to a
           # user-visible publishing surface. Keep this list synced with the
           # rationale in `.github/zizmor.yml` `cache-poisoning:` block.
@@ -175,13 +183,18 @@ jobs:
             'docker push'
             'docker buildx[^#]*--push'
           )
+          # zizmor-cache-poisoning-guard-patterns-end
           fail=0
           for wf in "${IGNORED[@]}"; do
             if [ ! -f "$wf" ]; then continue; fi
+            # Strip the guard's own PATTERNS block from the scan input so
+            # the step does not self-match on its own literal-pattern array.
+            scan_input=$(sed '/zizmor-cache-poisoning-guard-patterns-start/,/zizmor-cache-poisoning-guard-patterns-end/d' "$wf")
             for pat in "${PATTERNS[@]}"; do
-              if grep -nE "$pat" "$wf" > /dev/null 2>&1; then
+              hits=$(echo "$scan_input" | grep -nE "$pat" || true)
+              if [ -n "$hits" ]; then
                 echo "::error file=$wf::cache-poisoning exception applies to this workflow, but it now contains a publishing action (\"$pat\"). Re-evaluate the .github/zizmor.yml exception."
-                grep -nE "$pat" "$wf" || true
+                echo "$hits"
                 fail=1
               fi
             done

--- a/.github/workflows/supply-chain-scan.yml
+++ b/.github/workflows/supply-chain-scan.yml
@@ -137,6 +137,63 @@ jobs:
           pip install --require-hashes --no-deps -r "${RUNNER_TEMP}/zizmor-requirements.txt"
           zizmor --version
 
+      - name: Guard zizmor `cache-poisoning` exception scope
+        # The `cache-poisoning` rule in `.github/zizmor.yml` ignores entire
+        # workflow files (ci.yml, evm-integration.yml, supply-chain-scan.yml)
+        # on the rationale that they are NOT publishing surfaces — they only
+        # run tests/lints/scanners. The exception is sound for the workflows'
+        # CURRENT shape, but zizmor cannot enforce that they STAY non-
+        # publishing. If a future PR adds a publish step to any ignored
+        # workflow, the cache-poisoning risk becomes real and the exception
+        # must be re-evaluated. This step encodes that invariant: it greps
+        # the ignored workflows for known publishing-action markers, and
+        # fails the audit if any are found.
+        #
+        # Note: this does NOT catch cross-workflow artifact promotion via
+        # `actions/upload-artifact` consumed by a separate publishing
+        # workflow — that requires its own audit. For now, in-workflow
+        # publish actions are the high-confidence signal.
+        run: |
+          set -euo pipefail
+          IGNORED=(
+            .github/workflows/ci.yml
+            .github/workflows/evm-integration.yml
+            .github/workflows/supply-chain-scan.yml
+          )
+          # Patterns that indicate a workflow is shipping bytes to a
+          # user-visible publishing surface. Keep this list synced with the
+          # rationale in `.github/zizmor.yml` `cache-poisoning:` block.
+          PATTERNS=(
+            'gh release create'
+            'gh release upload'
+            'softprops/action-gh-release'
+            'actions/create-release'
+            'actions/upload-release-asset'
+            'JS-DevTools/npm-publish'
+            'npm publish'
+            'pnpm publish'
+            'docker push'
+            'docker buildx[^#]*--push'
+          )
+          fail=0
+          for wf in "${IGNORED[@]}"; do
+            if [ ! -f "$wf" ]; then continue; fi
+            for pat in "${PATTERNS[@]}"; do
+              if grep -nE "$pat" "$wf" > /dev/null 2>&1; then
+                echo "::error file=$wf::cache-poisoning exception applies to this workflow, but it now contains a publishing action (\"$pat\"). Re-evaluate the .github/zizmor.yml exception."
+                grep -nE "$pat" "$wf" || true
+                fail=1
+              fi
+            done
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo
+            echo "The cache-poisoning ignore-list in .github/zizmor.yml is scoped to non-publishing CI workflows."
+            echo "One of those workflows now contains a publishing action — the exception is no longer safe."
+            echo "Either remove the publishing action, move it to a workflow not in the ignore-list, or revise the exception."
+            exit 1
+          fi
+
       - name: Resolve zizmor scan targets
         # Scan EVERYTHING under `.github/` that can land code on the runner:
         # workflows + composite actions + reusable workflows. The previous

--- a/.github/workflows/supply-chain-scan.yml
+++ b/.github/workflows/supply-chain-scan.yml
@@ -171,6 +171,22 @@ jobs:
           # Patterns that indicate a workflow is shipping bytes to a
           # user-visible publishing surface. Keep this list synced with the
           # rationale in `.github/zizmor.yml` `cache-poisoning:` block.
+          #
+          # Coverage notes:
+          # - `gh release create|upload`, `softprops/action-gh-release`,
+          #   `actions/create-release`, `actions/upload-release-asset` →
+          #   GitHub Releases (binary or tag-based).
+          # - `npm publish`, `pnpm publish`, `JS-DevTools/npm-publish` → npm.
+          # - `pypa/gh-action-pypi-publish`, `twine upload` → PyPI.
+          # - `docker push`, `docker buildx ... --push` → Docker registries
+          #   via the docker CLI.
+          # - `docker/build-push-action` → Docker registries via the
+          #   official GHA. The action is flagged regardless of `with.push`
+          #   because that input is set in a separate block grep cannot
+          #   correlate; flagging on action-use is conservative (build-only
+          #   adoption is uncommon in CI and an operator can confirm).
+          # - `goreleaser/goreleaser-action` → Go release toolchain.
+          # - `cargo publish` → crates.io.
           PATTERNS=(
             'gh release create'
             'gh release upload'
@@ -180,8 +196,13 @@ jobs:
             'JS-DevTools/npm-publish'
             'npm publish'
             'pnpm publish'
+            'pypa/gh-action-pypi-publish'
+            'twine upload'
             'docker push'
             'docker buildx[^#]*--push'
+            'docker/build-push-action'
+            'goreleaser/goreleaser-action'
+            'cargo publish'
           )
           # zizmor-cache-poisoning-guard-patterns-end
           fail=0

--- a/.github/workflows/supply-chain-scan.yml
+++ b/.github/workflows/supply-chain-scan.yml
@@ -208,9 +208,18 @@ jobs:
           fail=0
           for wf in "${IGNORED[@]}"; do
             if [ ! -f "$wf" ]; then continue; fi
-            # Strip the guard's own PATTERNS block from the scan input so
-            # the step does not self-match on its own literal-pattern array.
-            scan_input=$(sed '/zizmor-cache-poisoning-guard-patterns-start/,/zizmor-cache-poisoning-guard-patterns-end/d' "$wf")
+            # 1. Strip the guard's own PATTERNS block so the step does not
+            #    self-match on its own literal-pattern array.
+            # 2. Normalize shell backslash-continuations by joining lines
+            #    that end with `\` into a single line. Without this, the
+            #    common multi-line publish form (e.g. `docker buildx build
+            #    \<newline>  --push \<newline>  .`) escapes a single-line
+            #    grep — a future PR could add a real multi-line publish
+            #    step to an ignored workflow and silently pass this guard.
+            #    The `\` gets replaced with a single space so adjacent
+            #    tokens stay separated for the subsequent grep.
+            scan_input=$(sed '/zizmor-cache-poisoning-guard-patterns-start/,/zizmor-cache-poisoning-guard-patterns-end/d' "$wf" \
+              | awk '/\\$/ { sub(/\\$/, " "); printf "%s", $0; next } { print }')
             for pat in "${PATTERNS[@]}"; do
               hits=$(echo "$scan_input" | grep -nE "$pat" || true)
               if [ -n "$hits" ]; then

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -105,6 +105,14 @@ rules:
   # If a future maintainer wires publishing, release-asset creation, or
   # cross-workflow artifact promotion into any ignored workflow, this
   # exception MUST be re-evaluated before that PR lands.
+  #
+  # Defense-in-depth: the `Guard zizmor cache-poisoning exception scope`
+  # step in `supply-chain-scan.yml` greps the ignored workflows for known
+  # publishing-action markers (`gh release create`, `npm publish`,
+  # `docker push`, etc.) on every audit run and fails the gate if any are
+  # found — so the moment one of these workflows gains a publish step,
+  # this exception is forced back through review instead of silently
+  # going stale.
   cache-poisoning:
     ignore:
       - ci.yml

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -57,7 +57,7 @@ const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, escapeDkgRdfLiteral } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, escapeDkgRdfLiteral, escapeSparqlLiteral } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri, type PublishOptions } from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
@@ -2218,8 +2218,11 @@ WHERE {
       }
     }
 
-    // Fan-out 2: SPARQL text search (scoped to the requested CG + layers)
-    const escapedQuery = query.replace(/"/g, '\\"').toLowerCase();
+    // Fan-out 2: SPARQL text search (scoped to the requested CG + layers).
+    // escapeSparqlLiteral escapes backslashes, quotes, and CR/LF/TAB per the
+    // SPARQL STRING_LITERAL2 grammar — a simple `replace(/"/g, '\\"')` would
+    // still allow `\` to escape the closing quote and break out of the literal.
+    const escapedQuery = escapeSparqlLiteral(query.toLowerCase());
     const cgUri = `did:dkg:context-graph:${contextGraphId}`;
     const graphFilters = memoryLayers.map((l: string) => {
       if (l === 'swm') return `STRSTARTS(STR(?g), "${cgUri}/_shared_memory")`;

--- a/packages/cli/test/backfill-rs-percgid-meta-route.test.ts
+++ b/packages/cli/test/backfill-rs-percgid-meta-route.test.ts
@@ -172,9 +172,15 @@ describe('POST /api/random-sampling/backfill-percgid-meta', () => {
           res.end();
         }
       } catch (err) {
+        // Test-harness only: emit a fixed body so the test cannot leak
+        // exception text into a CodeQL stack-disclosure alert. Route
+        // under test sets its own body upstream; this catch is a safety
+        // net. Diagnostics still surface via console.error.
+        // eslint-disable-next-line no-console
+        console.error('[test-harness] unhandled route error:', err);
         res.statusCode = 500;
         res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+        res.end(JSON.stringify({ error: 'internal error' }));
       }
     });
     await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));

--- a/packages/cli/test/memory-search-sparql-injection.test.ts
+++ b/packages/cli/test/memory-search-sparql-injection.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { escapeSparqlLiteral } from '@origintrail-official/dkg-core';
+import { handleMemoryRoutes } from '../src/daemon/routes/memory.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+function fakeRes() {
+  const res: any = { statusCode: 0, body: '', headers: {} as Record<string, string> };
+  res.writeHead = (status: number, headers?: Record<string, string>) => {
+    res.statusCode = status;
+    if (headers) Object.assign(res.headers, headers);
+  };
+  res.setHeader = (k: string, v: string) => { res.headers[k] = v; };
+  res.end = (body: string) => { res.body = body; };
+  return res;
+}
+
+function fakeReq(method: string, body: unknown) {
+  return {
+    method,
+    headers: {},
+    __dkgPrebufferedBody: Buffer.from(JSON.stringify(body)),
+  } as any;
+}
+
+function buildCtx(body: unknown, captureSparql: (s: string) => void) {
+  const res = fakeRes();
+  const url = new URL('http://127.0.0.1/api/memory/search');
+  const agent = {
+    store: {
+      query: async (sparql: string) => {
+        captureSparql(sparql);
+        return { type: 'bindings' as const, bindings: [] };
+      },
+    },
+  };
+  const ctx = {
+    req: fakeReq('POST', body),
+    res,
+    agent,
+    // Force the vector fan-out to be skipped so we only exercise the SPARQL path.
+    embeddingProvider: null,
+    vectorStore: { search: async () => [] },
+    path: url.pathname,
+    url,
+  } as unknown as RequestContext;
+  return { ctx, res };
+}
+
+describe('POST /api/memory/search — SPARQL injection regression (PR #849)', () => {
+  // Regression for the high-severity finding fixed in 1d02e55d's parent commit:
+  // memory.ts used to escape via `query.replace(/"/g, '\\"').toLowerCase()`,
+  // which left raw backslashes intact — a malicious `\"` payload would escape
+  // the SPARQL literal's closing quote and break out of the literal context.
+  //
+  // The fix routes the query through `escapeSparqlLiteral`, which escapes
+  // backslashes, double-quotes, CR, LF, and TAB per the SPARQL grammar.
+  // These tests pin that contract at the route level so a future refactor
+  // that reverts to quote-only escaping fails CI.
+
+  it('routes special-character queries through escapeSparqlLiteral before interpolation', async () => {
+    // Real backslash, real double-quote, real newline, real tab — the four
+    // characters that a quote-only escape leaves dangerous.
+    const rawQuery = 'hello\\world"\nfoo\tbar';
+    let capturedSparql = '';
+    const { ctx, res } = buildCtx(
+      { query: rawQuery, contextGraphId: 'test-cg' },
+      (s) => { capturedSparql = s; },
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(capturedSparql).not.toBe('');
+
+    // The route lower-cases first, then escapes — pin both behaviors.
+    const expectedEscaped = escapeSparqlLiteral(rawQuery.toLowerCase());
+    expect(capturedSparql).toContain(`"${expectedEscaped}"`);
+
+    // Verify the dangerous chars survived as their SPARQL escape sequences
+    // (not the raw chars that would break out of the literal).
+    expect(expectedEscaped).toContain('\\\\');   // backslash → \\
+    expect(expectedEscaped).toContain('\\"');    // dquote   → \"
+    expect(expectedEscaped).toContain('\\n');    // LF       → \n
+    expect(expectedEscaped).toContain('\\t');    // TAB      → \t
+  });
+
+  it('refuses to produce a SPARQL string vulnerable to the legacy quote-only escape', async () => {
+    // The exact breakout payload the legacy escape failed against:
+    // `\"` after the prefix would, with quote-only escaping, become
+    // `\\"` — the backslash escapes the closing quote, allowing the
+    // attacker to inject SPARQL after the literal.
+    const breakoutPayload = 'safe\\"; DROP GRAPH <urn:victim> ; #';
+    let capturedSparql = '';
+    const { ctx, res } = buildCtx(
+      { query: breakoutPayload, contextGraphId: 'test-cg' },
+      (s) => { capturedSparql = s; },
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+
+    // What the legacy buggy path would have produced.
+    const legacyBuggyOutput = breakoutPayload.toLowerCase().replace(/"/g, '\\"');
+    // What the current safe path produces.
+    const safeOutput = escapeSparqlLiteral(breakoutPayload.toLowerCase());
+
+    // The safe form must be present; the buggy form must NOT appear inside
+    // any string-literal pair. Pin the wrapping quotes around the safe form,
+    // and assert the buggy form does not appear in that exact `"..."`
+    // context. (The buggy form is a strict prefix of the safe form, so the
+    // wrapping-quote pin is what makes the negative assertion meaningful.)
+    expect(capturedSparql).toContain(`"${safeOutput}"`);
+    expect(capturedSparql).not.toContain(`"${legacyBuggyOutput}"`);
+    // The safe and buggy escapes MUST differ — if they didn't, the route
+    // would have regressed to quote-only escaping.
+    expect(safeOutput).not.toBe(legacyBuggyOutput);
+  });
+
+  it('preserves unicode payloads verbatim (no double-escape, no mojibake)', async () => {
+    const unicodeQuery = 'café ☕ привет';
+    let capturedSparql = '';
+    const { ctx, res } = buildCtx(
+      { query: unicodeQuery, contextGraphId: 'test-cg' },
+      (s) => { capturedSparql = s; },
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(capturedSparql).toContain(`"${unicodeQuery.toLowerCase()}"`);
+  });
+});

--- a/packages/cli/test/notifications-route.test.ts
+++ b/packages/cli/test/notifications-route.test.ts
@@ -72,8 +72,16 @@ describe('GET/POST /api/notifications (scoped daemon route, A4)', () => {
         await handleNotificationRoutes(ctx);
         if (!res.writableEnded) { res.statusCode = 404; res.end(); }
       } catch (err: any) {
+        // Test-harness only: emit a fixed JSON body so the test cannot
+        // leak raw exception text (CodeQL flagged the prior
+        // `err.message` echo as stack-disclosure + reinterpret-as-HTML).
+        // The route under test sets its own body upstream; this catch
+        // is a safety net. Diagnostics still surface via console.error.
+        // eslint-disable-next-line no-console
+        console.error('[test-harness] unhandled route error:', err);
         res.statusCode = 500;
-        res.end(JSON.stringify({ error: String(err?.message ?? err) }));
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: 'internal error' }));
       }
     });
     await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -103,9 +103,17 @@ describe('status route multi-RPC shape', () => {
           res.end();
         }
       } catch (err: any) {
+        // Test-harness only: emit a fixed body so the test cannot leak
+        // exception text into a CodeQL `stack-trace-exposure` /
+        // `XSS-via-error-text` alert. The route under test sets its own
+        // body upstream; this catch is purely a safety net.
+        // The thrown error is re-surfaced via console.error so the test
+        // log still has full diagnostics if a route assertion fails.
+        // eslint-disable-next-line no-console
+        console.error('[test-harness] unhandled route error:', err);
         res.statusCode = 500;
         res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ error: err?.message ?? String(err) }));
+        res.end(JSON.stringify({ error: 'internal error' }));
       }
     });
     await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));

--- a/packages/epcis/src/handlers.ts
+++ b/packages/epcis/src/handlers.ts
@@ -68,12 +68,36 @@ const EPCIS_TYPE_PREFIX = 'https://gs1.github.io/EPCIS/';
 /**
  * Strip N-Quads literal wrapping from a SPARQL binding value.
  * The triplestore returns string literals as '"value"' or '"value"^^<type>'.
+ *
+ * Implemented as a linear scan rather than the prior greedy regex
+ * `/^"(.*)"(?:\^\^<.*>)?$/s` — that pattern is vulnerable to catastrophic
+ * backtracking on malformed inputs (e.g. repeated typed-literal suffixes)
+ * because `(.*)` is greedy with the `s` flag and the optional trailing
+ * group forces an exponential backoff. Since the input comes from a
+ * remote triplestore, that is reachable input. The linear parser below
+ * runs in O(n) regardless of input shape.
  */
-function unwrapLiteral(value: string): string {
-  if (!value) return value;
-  // Handle typed literals: "value"^^<type>
-  const typedMatch = value.match(/^"(.*)"(?:\^\^<.*>)?$/s);
-  if (typedMatch) return typedMatch[1];
+export function unwrapLiteral(value: string): string {
+  if (!value || value.length < 2 || value.charCodeAt(0) !== 34 /* '"' */) {
+    return value;
+  }
+  // Find the closing quote, honouring backslash escapes per N-Quads.
+  let i = 1;
+  for (; i < value.length; i++) {
+    const ch = value.charCodeAt(i);
+    if (ch === 92 /* '\\' */) {
+      i++;
+      continue;
+    }
+    if (ch === 34 /* '"' */) break;
+  }
+  if (i >= value.length) return value; // no closing quote — return as-is
+  const inner = value.slice(1, i);
+  const tail = value.slice(i + 1);
+  // Tail must be empty or a typed-literal suffix `^^<...>`.
+  if (tail.length === 0) return inner;
+  if (tail.startsWith('^^<') && tail.endsWith('>')) return inner;
+  // Anything else: not a recognised literal shape — return as-is.
   return value;
 }
 

--- a/packages/epcis/test/events-query.test.ts
+++ b/packages/epcis/test/events-query.test.ts
@@ -695,15 +695,50 @@ describe('unwrapLiteral (CodeQL ReDoS regression)', () => {
     // The prior greedy regex `/^"(.*)"(?:\^\^<.*>)?$/s` exponentially
     // backtracks on inputs that look like repeated typed-literal suffixes
     // without ever matching the closing anchor. The linear parser must
-    // process N=10_000 such inputs in well under a second.
-    const adversarial = '"' + '"^^<x>'.repeat(10_000);
-    const t0 = performance.now();
-    const result = unwrapLiteral(adversarial);
-    const elapsed = performance.now() - t0;
-    // The result is allowed to be either the unwrapped inner or the
-    // original (depending on tail recognition); the important property
-    // here is that we did not spend exponential time getting there.
-    expect(typeof result).toBe('string');
-    expect(elapsed).toBeLessThan(100);
+    // process N such inputs in O(N) time.
+    //
+    // The regression we care about is asymptotic, NOT absolute speed on
+    // any given machine — a fixed wall-clock ceiling (e.g. `<100ms`) is
+    // flake-prone on busy CI runners. Instead, sample two input sizes
+    // (1k and 10k) and assert the 10x-larger input does not blow up
+    // catastrophically. Catastrophic backtracking is exponential; any
+    // linear scan stays well within the generous 25x ratio bound even
+    // with GC pauses and CPU contention.
+    //
+    // The 1000ms absolute ceiling is the hang guard: if the parser ever
+    // becomes pathologically slow on the larger input, the test fails
+    // cleanly instead of timing out the suite.
+    const adversarial = (n: number) => '"' + '"^^<x>'.repeat(n);
+
+    // Take min across repeats to filter out GC / scheduler noise. The
+    // O(n) parser is allocation-light, so the spread between repeats is
+    // typically <2x even on cold runs.
+    const measure = (n: number) => {
+      let minMs = Infinity;
+      for (let i = 0; i < 5; i++) {
+        const input = adversarial(n);
+        const t0 = performance.now();
+        const result = unwrapLiteral(input);
+        const elapsed = performance.now() - t0;
+        // Sanity: result is always a string regardless of tail recognition.
+        expect(typeof result).toBe('string');
+        if (elapsed < minMs) minMs = elapsed;
+      }
+      return minMs;
+    };
+
+    const smallMs = measure(1_000);
+    const largeMs = measure(10_000);
+
+    // Hang guard: 10k repetitions should finish in well under a second
+    // on any modern CI. The exponential regex would take >>10s here.
+    expect(largeMs).toBeLessThan(1000);
+
+    // Linearity guard: 10x input → ratio must stay bounded. The `+ 25ms`
+    // cushion guards against the degenerate case where `smallMs ≈ 0` and
+    // any wall-clock noise on `largeMs` would otherwise blow the ratio.
+    // A 25x ceiling on linear growth leaves ample headroom for jitter
+    // while still failing decisively on exponential blow-up.
+    expect(largeMs).toBeLessThan(smallMs * 25 + 25);
   });
 });

--- a/packages/epcis/test/events-query.test.ts
+++ b/packages/epcis/test/events-query.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { handleEventsQuery, EpcisQueryError, toEpcisEvent } from '../src/handlers.js';
+import { handleEventsQuery, EpcisQueryError, toEpcisEvent, unwrapLiteral } from '../src/handlers.js';
 import type { QueryEngine } from '../src/types.js';
 
 const CONTEXT_GRAPH_ID = 'test-cg';
@@ -646,5 +646,64 @@ describe('handleEventsQuery — per-request sub-graph', () => {
       includePrivate: true,
     });
     expect(calls[0].opts.subGraphName).toBeUndefined();
+  });
+});
+
+// Regression coverage for the linear-scan rewrite of `unwrapLiteral`. The
+// prior greedy regex (`/^"(.*)"(?:\^\^<.*>)?$/s`) was vulnerable to
+// catastrophic backtracking on malformed inputs because triplestore-
+// controlled strings flow through this function. The linear parser must
+// stay O(n) in input length AND preserve the same observable behaviour
+// on the typed/plain/raw paths used elsewhere in handlers.ts.
+describe('unwrapLiteral (CodeQL ReDoS regression)', () => {
+  it('unwraps a plain N-Quads string literal', () => {
+    expect(unwrapLiteral('"hello"')).toBe('hello');
+  });
+
+  it('unwraps a typed N-Quads literal', () => {
+    expect(unwrapLiteral('"2024-03-01T08:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>'))
+      .toBe('2024-03-01T08:00:00.000Z');
+  });
+
+  it('returns empty / falsy inputs unchanged', () => {
+    expect(unwrapLiteral('')).toBe('');
+    expect(unwrapLiteral(undefined as unknown as string)).toBeUndefined();
+  });
+
+  it('returns bare unquoted strings unchanged (URI bindings)', () => {
+    expect(unwrapLiteral('urn:epc:id:sgtin:001.001.001'))
+      .toBe('urn:epc:id:sgtin:001.001.001');
+    expect(unwrapLiteral('https://gs1.github.io/EPCIS/ObjectEvent'))
+      .toBe('https://gs1.github.io/EPCIS/ObjectEvent');
+  });
+
+  it('returns malformed inputs (no closing quote) unchanged', () => {
+    expect(unwrapLiteral('"missing close')).toBe('"missing close');
+  });
+
+  it('returns malformed inputs (trailing garbage after literal) unchanged', () => {
+    // `"value"trailing` is not a recognised N-Quads shape — must NOT unwrap.
+    expect(unwrapLiteral('"value"trailing')).toBe('"value"trailing');
+  });
+
+  it('honours backslash-escaped quotes inside the literal', () => {
+    // \" stays inside the literal — the closing quote is the unescaped one.
+    expect(unwrapLiteral('"foo\\"bar"')).toBe('foo\\"bar');
+  });
+
+  it('runs in linear time on adversarial inputs that broke the old regex', () => {
+    // The prior greedy regex `/^"(.*)"(?:\^\^<.*>)?$/s` exponentially
+    // backtracks on inputs that look like repeated typed-literal suffixes
+    // without ever matching the closing anchor. The linear parser must
+    // process N=10_000 such inputs in well under a second.
+    const adversarial = '"' + '"^^<x>'.repeat(10_000);
+    const t0 = performance.now();
+    const result = unwrapLiteral(adversarial);
+    const elapsed = performance.now() - t0;
+    // The result is allowed to be either the unwrapped inner or the
+    // original (depending on tail recognition); the important property
+    // here is that we did not spend exponential time getting there.
+    expect(typeof result).toBe('string');
+    expect(elapsed).toBeLessThan(100);
   });
 });

--- a/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
+++ b/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
@@ -79,12 +79,15 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
 
     uint256 private _knowledgeAssetsCounter;
     uint256 private _totalMintedKnowledgeAssetsCounter;
-    // Explicit `= 0` is a no-op at runtime (Solidity zero-initializes
-    // state) but silences Slither's high-severity `uninitialized-state`
-    // alert. V10 retired burn semantics — `burnKnowledgeAssetsTokens` is
-    // a `pure` revert stub — so this counter remains permanently zero
-    // and `totalBurned()` correctly returns 0 for legacy consumers.
-    uint256 private _totalBurnedKnowledgeAssetsCounter = 0;
+    // V10 retired burn semantics — `burnKnowledgeAssetsTokens` is a
+    // `pure` revert stub — so this counter is intentionally never
+    // written. Solidity zero-initializes it, and `totalBurned()`
+    // correctly returns 0 for legacy ABI consumers. The Slither
+    // directive silences the rule WITHOUT changing storage layout;
+    // making this `constant` would shift every slot declared below
+    // and is out of scope for an ABI-only legacy field.
+    // slither-disable-next-line uninitialized-state
+    uint256 private _totalBurnedKnowledgeAssetsCounter;
 
     uint96 private _totalTokenAmount;
 

--- a/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
+++ b/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
@@ -79,7 +79,12 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
 
     uint256 private _knowledgeAssetsCounter;
     uint256 private _totalMintedKnowledgeAssetsCounter;
-    uint256 private _totalBurnedKnowledgeAssetsCounter;
+    // Explicit `= 0` is a no-op at runtime (Solidity zero-initializes
+    // state) but silences Slither's high-severity `uninitialized-state`
+    // alert. V10 retired burn semantics — `burnKnowledgeAssetsTokens` is
+    // a `pure` revert stub — so this counter remains permanently zero
+    // and `totalBurned()` correctly returns 0 for legacy consumers.
+    uint256 private _totalBurnedKnowledgeAssetsCounter = 0;
 
     uint96 private _totalTokenAmount;
 

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -209,7 +209,7 @@ describe('backward-compatible URL redirects (V10 consolidation)', () => {
   for (const path of ['/agent', '/explorer', '/messages', '/apps/*']) {
     it(`redirects ${path} to /`, () => {
       expect(app).toContain(`path="${path}"`);
-      const pattern = new RegExp(`path="${path.replace('*', '\\*')}".*element=\\{<Navigate to="/"`);
+      const pattern = new RegExp(`path="${path.replaceAll('*', '\\*')}".*element=\\{<Navigate to="/"`);
       expect(app).toMatch(pattern);
     });
   }


### PR DESCRIPTION
## Summary

Per-thread fixes for the eight inline review comments on #716 that remained after the rc.12 work landed. Five touch test/CI hygiene only (no runtime impact); three address real defects (two High, one Medium).

## What's addressed

| Sev | File | Fix |
|---|---|---|
| **High** | `packages/cli/src/daemon/routes/memory.ts:2222` | SPARQL text-search now routes through `escapeSparqlLiteral` (escapes `\\`, `"`, CR/LF/TAB) instead of an ad-hoc `replace(/"/g, '\\"')`. |
| **High** | `packages/epcis/src/handlers.ts:75` | Replaced greedy `/^"(.*)"(?:\^\^<.*>)?$/s` regex with a linear scan parser. Input is triplestore-controlled — reachable. Added 8 regression tests including an O(n) timing assertion on an adversarial 10k-suffix input. |
| **Medium** | `.github/zizmor.yml` + `supply-chain-scan.yml` | Added `Guard zizmor cache-poisoning exception scope` step that greps the 3 ignored workflows for publish markers (`gh release create`, `npm publish`, `docker push`, etc.) and fails the gate if any are found. Closes the "future cache-to-publish drift won't be caught" gap. |
| Medium/CI | `packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol:82` | Explicit `= 0` on `_totalBurnedKnowledgeAssetsCounter` — no-op at runtime, silences Slither's high `uninitialized-state` alert. V10 retired burn semantics (`burnKnowledgeAssetsTokens` is a `pure` revert stub) so the counter is correctly always 0. |
| Low/CI | `packages/cli/test/status-route-rpc.test.ts:108` | Fixed `{ error: "internal error" }` JSON body + `application/json` content type. Diagnostics surface via `console.error`. |
| Low/CI | `packages/cli/test/notifications-route.test.ts:76` | Same pattern as above (was missing both fixed body AND content type). |
| Low/CI | `packages/cli/test/backfill-rs-percgid-meta-route.test.ts:177` | Same pattern as above. |
| Low/CI | `packages/node-ui/test/ui-compat.test.ts:212` | `replaceAll("*", "\\*")` instead of `replace("*", "\\*")` — current array has one `*` but the guard stays correct if another wildcard route is added. |

## Why this lands on rc.12 not main

`release/rc.12` is the integration branch that #716 will merge into `main`. Landing these fixes here makes them ride along with #716 instead of being a separate follow-up PR against main.

## Verified locally

- turbo `build:packages` — 17/17 tasks pass
- CLI vitest — 29/29 in the 3 affected files (`status-route-rpc`, `notifications-route`, `backfill-rs-percgid-meta-route`)
- epcis vitest — 43/43 (incl. 8 new `unwrapLiteral` regression tests)
- node-ui vitest — 82/82 in `ui-compat.test.ts`
- evm-module hardhat compile — 97 contracts compile

## Test plan

- [ ] CI passes including the new zizmor scope-guard step
- [ ] Slither no longer flags `DKGKnowledgeAssets._totalBurnedKnowledgeAssetsCounter` as uninitialized-state
- [ ] CodeQL no longer flags the 4 test-harness `err.message` echoes
- [ ] CodeQL `unwrapLiteral` ReDoS alert clears on `epcis/handlers.ts:75`
- [ ] CodeQL SPARQL-injection alert clears on `memory.ts:2222`

Closes Brano's 8 inline threads on #716.

Made with [Cursor](https://cursor.com)