### PR TITLE
docs(rc.12): builders' upgrade guide + consolidated release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,44 +4,113 @@ All notable changes to the DKG V9 node are documented here. The format is based 
 
 ## [Unreleased]
 
-### Changed — Knowledge Collection → Knowledge Asset rename (BREAKING, rc.12 stack)
+_No changes yet._
 
-Clean cutover from the V8/V9/V10.0 "Knowledge Collection" terminology to the V10.1 "Knowledge Asset" terminology, both on-chain and off-chain. No compat shims, no fallback resolvers — testnet is intentionally broken by this change. Forward-only release for rc.12.
+## [10.0.0-rc.12] - 2026-06-01
 
-This ships as three stacked PRs against `release/rc.12`:
+**Cutover release.** No compatibility shims, no fallback resolvers, no backward-compatible codepaths. Testnet (Base Sepolia) and devnet are intentionally broken by this change and must be redeployed. Every package in the workspace upgrades in lockstep. This is a forward-only release.
+
+**For builders upgrading from rc.11**, see [`docs/UPGRADE_RC11_TO_RC12.md`](docs/UPGRADE_RC11_TO_RC12.md) for the focused migration guide (TS rename tables, Solidity selector changes, greenfield KA model, economic floors, agent-prompt template).
+
+### Added — Greenfield Knowledge Asset model (BREAKING)
+
+- **Greenfield KA model** (PR #815, `packages/evm-module/contracts/DKGKnowledgeAssets.sol`, `packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol`, `packages/publisher/src/dkg-publisher.ts`, `packages/agent/src/dkg-agent.ts`, `packages/evm-module/docs/greenfield-ka-ual.md`): exactly **one** ERC-721 KA per publish (`knowledgeAssetsAmount == 1` is the only valid value). Stable UAL — `did:dkg:{chainId}/{DKGKnowledgeAssetsAddress}/{kaId}` — that does **not** change across merkle-root updates. ERC-721 minted to the **author** at publish (publisher pays TRAC; author holds the token). Owner-sealed updates: only the current `ownerOf(kaId)` can update, by signing an EIP-712 `UpdateAuthorAttestation(kaId, newMerkleRoot, authorAddress, schemeVersion)` once (domain `KnowledgeAssetsLifecycle` v2.0.0, kept stable for attestation continuity) and passing it as `precomputedUpdateAttestation` on the first `publisher.update()` call. The publisher (any node operator) does the chain write; the attestation is the seal the chain validates against `ownerOf`. No ERC-1155 mint/burn on update — the ERC-721 stays bound to the same `kaId`. Devnet gates: `pnpm test:devnet:greenfield-10min`, `pnpm test:devnet:rich-scenario`. Canonical UAL builder exported as `buildKnowledgeAssetUal(chainId, contract, kaId)` from `@origintrail-official/dkg-chain`. Surface reference: `packages/evm-module/docs/greenfield-ka-ual.md`.
+
+### Added — Protocol treasury fee on publish / update / extend
+
+- **Governance-set bps fee** (PR #821, `packages/evm-module/contracts/storage/ParametersStorage.sol`, `packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol`, `packages/evm-module/contracts/PublishingConviction.sol`, `packages/chain/abi/ParametersStorage.json`, `packages/chain/abi/PublishingConviction.json`): skims a governance-set bps cut (default **300 bps = 3 %**, capped at **MAX_PROTOCOL_TREASURY_FEE = 1000 bps**) from the staker-bound TRAC on every paid publish/update/extend and routes it to a treasury address. **The publisher pays the same gross price** — the fee comes out of what would otherwise flow into the staker reward pool. **Dormant by default** (`treasury == address(0) ⇒ fee == 0`), so a fresh deploy is unchanged until governance opts in via the new owner-gated `setProtocolTreasury` / `setProtocolTreasuryFee` setters. New `ProtocolTreasurySet(uint256 fee, address treasury)` event. `KnowledgeAssetsLifecycle._addTokens` splits at the source (`net → CSS vault, fee → treasury`) and returns `net` so publish/update/extend distribute `net` into the pool while CG-value writes stay on gross. `PublishingConviction` skims the fee on the active sink + every passive window sweep + final dust/topUp tail, accumulates, and pays via a single `CSS.transferStake` **after** all state writes so the permissionless `settle()` stays reentrancy-safe. **Lifetime invariant**: `pool + treasury == committed + topUps`. ParametersStorage version: `1.0.0` → `1.1.0`. PublishingConviction version: `1.0.1` → `1.1.0`. `KnowledgeAssetsLifecycle` patch bump `2.0.0` → `2.0.1`; the EIP-712 domain hash is **pinned at `KnowledgeAssetsLifecycle@2.0.0`** so existing author attestations keep verifying across the patch bump.
+
+### Added — Blazegraph + SPARQL-HTTP external triple-store (RFC 120)
+
+- **External triple-store backend** (PR #766, `packages/storage/src/blazegraph-store.ts`, `packages/storage/src/sparql-http-store.ts`, `packages/cli/src/storage-wizard.ts`, `docs/setup/STORAGE_SPARQL_HTTP.md`): the daemon's persistence layer can now point at an external Blazegraph or generic SPARQL-HTTP endpoint instead of (or alongside) the embedded Oxigraph store. Configured via `storage.backend: "sparql-http"` + `storage.endpoint: "<url>"` in `~/.dkg/config.json`, or via the new interactive `dkg storage` wizard. Operator runbook at `docs/setup/STORAGE_SPARQL_HTTP.md`. Companion fixes for Blazegraph integration: (PR #782) namespace-creation 500 on first boot; (PR #810) large publishes + EPCIS private-scope queries; (PR #789) oversized literal guard.
+
+### Added — Operator tooling and observability
+
+- **`dkg doctor`** (RFC-41 Bundle A, `packages/cli/src/commands/doctor.ts`): diagnoses common install/upgrade issues. Six structured checks + a state-summary; JSON-parseable output. Run `dkg doctor` after upgrading to confirm the install is healthy.
+- **`/api/build-info`** (RFC-41 Bundle A3, `packages/cli/src/daemon/routes/status.ts`): surfaces `{ version, commit, installMode, builtAt }` so monitoring can correlate daemon behaviour with build provenance.
+- **`/api/status` `relay` block** (carried from rc.11; pinned at every node): uniform `{ isCore, reservationsHeld, reservationCapacity, activeCircuits, bytesIn, bytesOut, natStatus, listenAddresses, announcedAddresses }` so dashboards parse one schema rather than switching on `nodeRole`.
+- **RFC-41 Bundle B — Edge npm-only update path** (`packages/cli/src/daemon/auto-update.ts`, `packages/cli/src/migrate-to-npm.ts`): Edge nodes update via `npm install -g @origintrail-official/dkg` instead of git-build. Git-based updates are hard-refused at user-facing entry points for edges; Core nodes retain the git-build path for now. Includes `--role` flag on `dkg init`, monorepo guard, stable plugin install root, `installMode` telemetry, deprecation banner on `install.sh` (which has been removed).
+- **Node UI — Context Graph Overview and notifications redesign** (PR #745, #818, #811): redesigned Context Graph view with Root mini-card, cross-layer pills, mini-graph colors, count-accuracy fixes; membership-scoped notifications pane with inline join approve/deny actions.
+
+### Changed — Knowledge Collection → Knowledge Asset rename (BREAKING)
+
+Clean cutover from the V8/V9/V10.0 "Knowledge Collection" terminology to the V10.1 "Knowledge Asset" terminology, both on-chain and off-chain. No compat shims, no fallback resolvers — testnet is intentionally broken by this change.
+
+Ships as three stacked PRs:
 
 - **PR #836 (Solidity surface)** — `KnowledgeCollectionLib.sol` → `KnowledgeAssetLib.sol`, struct `KnowledgeCollection` → `KnowledgeAsset`, every `KnowledgeCollection*` error/event renamed to `KnowledgeAsset*`, every `create/update/get/isPartOf/isOwnerOf/extendKnowledgeCollection*` view/mutator renamed on `DKGKnowledgeAssets.sol` and `KnowledgeAssetsLifecycle.sol`. `ContextGraphStorage.kcToContextGraph` → `kaToContextGraph`, `registerKnowledgeCollection` → `registerKnowledgeAsset`. Legacy V10.0 contracts `KnowledgeAssetsV10.sol` and `KnowledgeCollectionStorage.sol` are deleted (they were dead code in V10.1 — the active path is `KnowledgeAssetsLifecycle` + `DKGKnowledgeAssets`). The V8 archive `KnowledgeCollection.sol` is deleted (referenced the renamed lib). `deployments/parameters.json` config block `KnowledgeCollectionStorage.knowledgeCollectionSize` → `DKGKnowledgeAssets.knowledgeAssetBatchSize`. ABIs regenerated; legacy ABIs removed from `packages/chain/abi/`.
 
 - **PR #837 (TS surface)** — `ChainAdapter.createKnowledgeAssetsV10` → `createKnowledgeAssets`, `getKnowledgeAssetsV10Address` → `getKnowledgeAssetsLifecycleAddress`, `getKCContextGraphId` → `getKAContextGraphId`. `NodeChallenge.knowledgeCollectionId` → `knowledgeAssetId`. `PublishResult.kcId` was already `kaId` in the publisher; all consumers now agree. `ASSERTION_PUBLISH_RECEIPT_PREDICATES.PUBLISHED_AT_KC_ID` → `PUBLISHED_AT_KA_ID` (predicate URI `publishedAtKcId` → `publishedAtKaId`). Adapter internal handles `knowledgeAssetsV10` → `knowledgeAssetsLifecycle`, `knowledgeCollectionStorage` → `knowledgeAssetStorage`. The legacy V10.0 fallback resolver in `EVMChainAdapter.init` is removed — when `KnowledgeAssetsLifecycle` doesn't resolve, the adapter raises rather than silently trying `KnowledgeAssetsV10`. `BOUND_CONTRACT_INVALIDATORS` and `ERROR_ABI_CONTRACTS` drop the legacy entries.
 
-- **PR #838 (docs/tests/scripts/UI) — this PR** — every remaining `kcId`/`KCId`/`KnowledgeCollection*` reference across `scripts/`, `docs/`, `demo/`, `bench/`, `devnet/`, `packages/{evm-module,cli,adapter-openclaw,adapter-elizaos,mcp-dkg,node-ui,network-sim,epcis}/{src,test}`, and the chain README. CHANGELOG entry (this entry). Prose-level term renames "Knowledge Collection" → "Knowledge Asset" / "KC" → "KA" in active docs.
+- **PR #838 (docs/tests/scripts/UI)** — every remaining `kcId`/`KCId`/`KnowledgeCollection*` reference across `scripts/`, `docs/`, `demo/`, `bench/`, `devnet/`, `packages/{evm-module,cli,adapter-openclaw,adapter-elizaos,mcp-dkg,node-ui,network-sim,epcis}/{src,test}`, and the chain README. Prose-level term renames "Knowledge Collection" → "Knowledge Asset" / "KC" → "KA" in active docs.
 
 **Migration impact** for downstream consumers (off-chain SDK callers, custom scripts, dashboards):
 
 - Solidity callers: 4-byte selectors on `DKGKnowledgeAssets` and `ContextGraphStorage` change for every renamed function. Old call data reverts; consumers must rebuild against the new ABIs in `packages/chain/abi/`.
-- TS callers: type names + property names renamed as above. The 1-pass mechanical search-and-replace (`kcId` → `kaId`, `knowledgeCollectionId` → `knowledgeAssetId`, `createKnowledgeCollection` → `createKnowledgeAsset`, etc.) covers all known consumers.
+- TS callers: type names + property names renamed as above. The 1-pass mechanical search-and-replace (`kcId` → `kaId`, `knowledgeCollectionId` → `knowledgeAssetId`, `createKnowledgeCollection` → `createKnowledgeAsset`, etc.) covers all known consumers. The `docs/UPGRADE_RC11_TO_RC12.md` guide ships the exact regex sweep.
 - ABI-pin tests: `packages/chain/test/abi-pinning.test.ts` pinned digests for `KnowledgeAssetsLifecycle`, `DKGKnowledgeAssets`, `ContextGraphs`, `ContextGraphStorage` match the rename; `KnowledgeAssetsV10` and `KnowledgeCollectionStorage` entries are dropped.
 - Hub registration: `KnowledgeAssetsLifecycle` and `DKGKnowledgeAssets` are the only V10.1 entries the daemon looks up. Hub deployments that still expose `KnowledgeAssetsV10` or `KnowledgeCollectionStorage` will silently be ignored by the rc.12 daemon — re-deploy the V10.1 surface before upgrading.
 
-## [10.0.0-rc.12] - 2026-05-29
+### Changed — V10 EVM module hardening pass (BREAKING for two surfaces)
 
-### Added
+Consistency and defense-in-depth refinements across the V10 EVM-module contracts (PR #781). No behaviour change for valid callers except where flagged BREAKING.
 
-- **Greenfield Knowledge Asset model** (see PR #815): `DKGKnowledgeAssets` + `KnowledgeAssetsLifecycle`, one ERC-721 KA per publish, stable UAL, owner-sealed updates via `precomputedUpdateAttestation`. Devnet gates: `pnpm test:devnet:greenfield-10min`, `pnpm test:devnet:rich-scenario`.
-
-### Changed — V10 EVM module hardening pass (carried from integration branch)
-
-Consistency and defense-in-depth refinements across the V10 EVM-module contracts. No behaviour change for valid callers.
-
-- **CEI ordering on `DKGStakingConvictionNFT.withdraw`.** The receipt NFT is now burned before `StakingV10.withdraw` drives the CSS teardown + TRAC payout. `StakingV10.withdraw` gates on the CSS position (`pos.identityId == 0`), not NFT existence, so the CSS teardown is unaffected.
-- **`nonReentrant` perimeter on KAV10 entrypoints.** `publish` / `update` / `extendKnowledgeAssetLifetime` now carry OZ `ReentrancyGuard.nonReentrant` as a defense-in-depth perimeter against the ERC-1155 receiver-hook callback path. ~50 gas/call overhead. KAV10 version: `10.1.0` → `10.1.1`.
-- **Strict-positive `tokenAmount` floor in KAV10 `_validateTokenAmount` AND post-discount floor in `PublishingConviction.coverPublishingCost`.** Both branches of the publish flow now charge a non-zero economic cost regardless of input rounding: direct-spend reverts `InvalidTokenAmount(1, 0)` on `tokenAmount == 0`; the conviction (PCA) branch inflates a truncated `discountedCost == 0` to `1` wei TRAC when `baseCost > 0` so the active-sink reward distribution + `windowSpent` accounting always fire. **BREAKING for any caller that previously relied on dust-CG zero-amount publishes** — the on-chain revert is the floor of truth; off-chain callers must encode `tokenAmount >= 1`. PublishingConviction version: `1.0.0` → `1.0.1`.
-- **Single source of truth for op-wallet validation in `Identity.addOperationalWallets`.** Same-identity collisions (primary added by `createIdentity` OR intra-array duplicate within the same call) surface as `OperationalWalletDuplicate(wallet)`; cross-identity collisions still fire `OperationalKeyTaken(key)`; admin/operational wallet overlap surfaces as the existing `KeyAlreadyAttached(key)`. `Profile.createProfile`'s pre-flight validation loop is removed — atomic-revert semantics make the prior "fail-fast at the entrypoint" rationale moot, and the relocation removes the duplicate validation pass on the happy path. Identity version: `1.0.0` → `1.1.0`; Profile version: `1.3.0` → `1.4.2`.
-- **`Profile.recreateProfile` signature refinement.** Drops the `uint16 initialOperatorFee` argument; the recovered profile is seeded at fee = 0 and the admin sets the real value via the cooldown-gated `updateOperatorFee` path. Keeps the recovery and steady-state surfaces symmetric on the operator-fee dimension. ADR `docs/adr/0001-recreate-profile-admin-only.md` updated.
-- **Chain-package ABI sync.** `packages/chain/abi/KnowledgeAssetsV10.json` and `packages/chain/abi/Profile.json` re-exported from the freshly regenerated `evm-module/abi/` copies so the chain adapter's error decoder (which prefers its local override over the published artifact) resolves `ReentrancyGuardReentrantCall`, `InvalidTokenAmount`, and the new Profile error surface as structured errors instead of opaque reverts.
+- **CEI ordering on `DKGStakingConvictionNFT.withdraw`.** The receipt NFT is now burned **before** `StakingV10.withdraw` drives the CSS teardown + TRAC payout. `StakingV10.withdraw` gates on the CSS position (`pos.identityId == 0`), not NFT existence, so the CSS teardown is unaffected. Same CEI-mint-last ordering applied on every ERC-721 mint path on `DKGKnowledgeAssets` (PR #681, supersedes #663).
+- **`nonReentrant` perimeter on KAV10 entrypoints.** `publish` / `update` / `extendKnowledgeAssetLifetime` now carry OZ `ReentrancyGuard.nonReentrant` as a defense-in-depth perimeter against the ERC-1155 receiver-hook callback path. ~50 gas/call overhead. KAV10 version: `10.1.0` → `10.1.1`. Surfaces as `ReentrancyGuardReentrantCall()` if a receiver hook re-enters; chain adapter decoder updated to surface it as a structured error.
+- **Strict-positive `tokenAmount` floor in `_validateTokenAmount` AND post-discount floor in `PublishingConviction.coverPublishingCost`.** Both branches of the publish flow now charge a non-zero economic cost regardless of input rounding: direct-spend reverts `InvalidTokenAmount(1, 0)` on `tokenAmount == 0`; the conviction (PCA) branch inflates a truncated `discountedCost == 0` to `1` wei TRAC when `baseCost > 0` so the active-sink reward distribution + `windowSpent` accounting always fire. **BREAKING** for any caller that previously relied on dust-CG zero-amount publishes — the on-chain revert is the floor of truth; off-chain callers MUST encode `tokenAmount >= 1`. Same floor applies to the update path (PR #831, #833): `update` and `extendKnowledgeAssetLifetime` enforce the floor in both direct-spend and conviction branches. PublishingConviction version: `1.0.0` → `1.0.1` → `1.1.0`.
+- **Single source of truth for op-wallet validation in `Identity.addOperationalWallets`.** Same-identity collisions (primary added by `createIdentity` OR intra-array duplicate within the same call) surface as `OperationalWalletDuplicate(wallet)`; cross-identity collisions still fire `OperationalKeyTaken(key)`; admin/operational wallet overlap surfaces as the existing `KeyAlreadyAttached(key)`. `Profile.createProfile`'s pre-flight validation loop is removed — atomic-revert semantics make the prior "fail-fast at the entrypoint" rationale moot. Identity version: `1.0.0` → `1.1.0`; Profile version: `1.3.0` → `1.4.2`.
+- **`Profile.recreateProfile` signature refinement (BREAKING for recovery scripts).** Drops the `uint16 initialOperatorFee` argument; the recovered profile is seeded at fee = 0 and the admin sets the real value via the cooldown-gated `updateOperatorFee` path. Keeps the recovery and steady-state surfaces symmetric on the operator-fee dimension. ADR `packages/evm-module/docs/adr/0001-recreate-profile-admin-only.md` updated.
+- **Chain-package ABI sync.** `packages/chain/abi/*.json` re-exported from the freshly regenerated `evm-module/abi/` copies so the chain adapter's error decoder (which prefers its local override over the published artifact) resolves `ReentrancyGuardReentrantCall`, `InvalidTokenAmount`, `OperationalWalletDuplicate`, and the new Profile error surface as structured errors instead of opaque reverts.
 - **Regression coverage.** New unit tests pin every new revert surface: `publish` + `extendKnowledgeAssetLifetime` revert `InvalidTokenAmount(1, 0)` on `tokenAmount == 0`; `publish` reverts `ReentrancyGuardReentrantCall()` when re-entered from the ERC-1155 mint acceptance callback (via the new `MockReentrantPublisher` test harness); `PublishingConviction.coverPublishingCost(baseCost=1, ...)` floors `discountedCost` at 1 and propagates that floor through the active-sink reward distribution + `windowSpent` accounting; `Identity.addOperationalWallets` per-class disambiguation; `Profile.createProfile` per-class diagnostics.
 
-Compatibility: `recreateProfile`'s signature is a BREAKING change for the recovery script. The `tokenAmount > 0` floor is a BREAKING change for any zero-cost publish flows. Off-chain consumers pinned to `KnowledgeAssetsV10@10.1.0` or `Profile@1.3.0` need a version bump. No storage-layout changes — KAV10's added `ReentrancyGuard` storage slot lands at the end of the inheritance chain, and V10's redeploy-and-reinit pattern doesn't preserve storage across upgrades anyway.
+Storage layout: no changes — KAV10's added `ReentrancyGuard` storage slot lands at the end of the inheritance chain, and V10's redeploy-and-reinit pattern doesn't preserve storage across upgrades anyway.
+
+### Changed — Active-sink proration + publishing discount ladder centralisation
+
+- **PCA active-sink proration math** (PR #817, multiple commits): centralised the publishing discount ladder, wired the active-sink proration helper into both the direct-publish and conviction paths, preserved final-range dust, handled empty middle and final ranges, and covered one-epoch and large-dust cases. The math is now uniform across publish and update; the previous discount-recomputation drift on update is gone.
+- **ConvictionStakingStorage added to the 052b deploy dependency graph** so the treasury-fee + active-sink rework deploys reliably from a clean Hub.
+
+### Fixed — Random Sampling on updated Knowledge Assets (GH #842)
+
+- **Updated KAs are now provable by Random Sampling** (PRs #842, #845; `packages/publisher/src/metadata.ts`, `packages/publisher/src/dkg-publisher.ts`, `packages/publisher/src/update-handler.ts`, `packages/agent/src/finalization-handler.ts`, `packages/random-sampling/test/ka-extractor.test.ts`, `packages/publisher/test/update-handler-gh842.test.ts`): every updated KA was permanently unprovable by Random Sampling pre-rc.12, producing a steady stream of `rs.tick.data-corrupted` on core nodes once any KA was updated. Root cause was a race in the daemon's local projection of the chain's ordered update log: two concurrent writers to the per-cgId materialisation partition (`publishFromSharedMemory`'s publish→per-cgId promotion and the inline update-promotion) had no version discipline, so a late publish-promotion could clobber an already-applied update with no guard. Three changes give the projection layer the same ordering guarantee the chain log already has: (1) **full label-graph restatement** on both update paths (`storeUpdatedQuads` and `UpdateHandler`) via the shared `restateLabelGraphForUpdate` helper — prior root entities' data is purged, `rootEntity` is repointed (rich provenance like `dkg:authoredBy` preserved), `merkleRoot` refreshed; (2) **a per-KA `dkg:materializedVersion` (`block:txIndex`) guard** stamped on the KC's `<ual>` in the meta graph each canonical writer touches (publisher promotion, update promotion, receiver `FinalizationHandler`) — every canonical writer now refuses to apply a state older than what's already materialised, so a late publish-promotion is a no-op; (3) **a deterministic-UAL fallback** in `UpdateHandler` (`did:dkg:<chainId>/<kasAddress>/<batchId>`, matching the publisher's own `resolveKaUal`) so a gossip receiver that hasn't yet materialised the `dkg:batchId` edge still promotes instead of silently skipping. Helpers live in `packages/publisher/src/metadata.ts`. Regression coverage drives the actual ordering (publish-promotion after update-promotion) rather than just final-state shape. Full root-cause analysis in `GH842-rs-update-race-analysis.md`.
+
+### Fixed — ERC-20 non-reverting `false` returns (PR #814)
+
+- **Staking deposits + withdrawals + operator-fee finalisation now guard against ERC-20 implementations that return `false` instead of reverting** (`packages/evm-module/contracts/StakingV10.sol`, `packages/evm-module/contracts/ConvictionStakingStorage.sol`, `packages/evm-module/contracts/Staking.sol`): every `transferFrom` / `transfer` call site that previously checked only revert behaviour now asserts the bool return, so a misbehaving (or malicious) ERC-20 cannot silently strand TRAC mid-flow. The default v9TRAC token reverts, so this is defence in depth — but it closes the surface for any token that follows the early-OpenZeppelin "return false" pattern.
+
+### Fixed — Update path token-amount floor + ACK digest alignment (PR #831, #833)
+
+- **`update` and `extendKnowledgeAssetLifetime` now pay the marginal growth cost for `byteSize` updates** so the on-chain economic floor matches the publish path (`packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol`).
+- **Storage ACK digest binds the precomputed `newTokenAmount`** (`packages/chain/src/evm-adapter.ts`, `packages/publisher/src/storage-ack-handler.ts`) so ACK collectors can't be tricked into signing for a different fee than what the chain enforced. Includes epoch-boundary growth handling + mock parity exempts so the unit-tests stay deterministic.
+- **Fail-fast KA / ask / Chronos reads** in the chain adapter so a transient RPC mismatch surfaces as an explicit error rather than silently using stale data on the update path.
+
+### Fixed — Ethers `PollingEventSubscriber` CPU spin
+
+- **Forced ethers' `PollingEventSubscriber` to stop the `FilterId` CPU spin** (`packages/chain/src/evm-adapter.ts`) that was producing 100 % single-core utilization on long-uptime daemons. The subscriber was tight-looping on a stale filter id; the adapter now invalidates and reinstalls the subscription. Companion to rc.11's `createFilterErrorSilencer` work (which masked the *log* spam but not the *CPU* spin).
+
+### Fixed — Context Graph count queries, query scoping, SWM promote ownership
+
+- **RC.12 Context Graph count queries fixed** (PR #844, `packages/cli/src/daemon/routes/context-graph.ts`, `packages/node-ui/src/components/ContextGraphOverview/*`): KA URN encoding follow-ups so per-CG KA counts are accurate end-to-end.
+- **Query scoping fixes** (PRs #761, #764, #774, #776, #777, #779): structural sub-graph match, allowing same-CG `_meta` + `_shared_memory_meta` on explicit-IRI scoped queries, dropped unsafe dynamic sub-graph enumeration for wallet-scoped cgIds, gossip recipient dual-write parity, F1 mismatch regression coverage, relaxed over-strict SPARQL PREFIX validation. Net effect: `agent.query()` returns the right rows against curated sub-graphs and the workspace-scoped surface.
+- **Durable SWM promote ownership enforcement** (PR #754): a promote-to-canonical that doesn't own its source SWM is now rejected.
+- **SWM `prov:wasAttributedTo` binds to agent DID, not peer ID** (PR #756, #748): assertions in the shared sub-graph carry the canonical agent identifier so cross-node attribution stays stable across libp2p peer-id rotation.
+- **`dkg:subGraphName` emitted from assertion-lifecycle writers** (PR #696, #770): publish receipts in sub-graph contexts now carry the sub-graph label, fixing UI / query routing for sub-graph publishes.
+
+### Fixed — Misc
+
+- **Receiver defensive `cg-id` lookup + RS backfill for pre-`cd68fa689` KCs** (PR #763): cores that received gossip before the chain `cgId` materialised in their meta graph were skipping the per-cgId promotion; lookups now plumb the on-chain id end to end (PR #cd68fa68 follow-up), and a one-shot backfill walks the historical KCs.
+- **Greenfield ACK / profile / devnet fallout** (PR #820): bind ciphertext + `isImmutable` into V10 ACK digests, flexible `createProfile` caller for the rebased rc.12 baseline.
+- **Hermes `API_SERVER_KEY` forwarded** (PR #794, #795, #799): Node UI chat survives Hermes v0.15.0's auth tightening.
+- **`graph-viz` SPARQL protocol headers pin after caller headers** so callers can't accidentally override the `Accept` / `Content-Type` envelope.
+- **`graph-viz` `_triples` normalised on ingress** (PR #692, #768): `removeTriples` now round-trips across bracket styles.
+- **CLI strict-TS double-cast for doctor config overlay**; **`dkg doctor` `safe to delete releases/` advisory gated** (PR #750 follow-up); **store-wizard red-tests + sparql-http default** (PR #791 follow-up).
+- **Validate context graph write targets** (PR #761): a published assertion can no longer name a CG it doesn't belong to.
+- **Slither annotations** for the random-sampling contracts to mute the documented-safe findings in CI.
+
+### Operations — Testnet contract redeploy required
+
+- **Base Sepolia (chainId 84532)**: full V10.1 contract surface redeployed off the rc.12 commit. Hub at `0xC056e67Da4F51377Ad1B01f50F655fFdcCD809F6` and Token at `0x2A58BdD13176D85906D804cdbFFA0D9119282DC8` retain their addresses; every other contract address rotates. `chainResetMarker` bumped accordingly; first boot on rc.12 wipes per-node chain-derived state.
+- **Operator action**: bump `@origintrail-official/dkg` to `10.0.0-rc.12`, restart the daemon, run `dkg doctor` to verify. Stakers with V10 conviction NFTs are unaffected (positions live on `ConvictionStakingStorage` keyed by `identityId`, which is preserved across the contract-address rotation since identities aren't redeployed).
 
 ## [10.0.0-rc.11] - 2026-05-26
 
@@ -316,7 +385,15 @@ V10 RandomSampling + V8/V10 staking consolidation. Testnet reset required (Base 
 - **`ensureProfile` profile-without-stake on partial failure**: profile creation and staking are now in separate `try/catch` blocks so a failed stake leaves the on-chain identity intact for retry instead of leaving the operator without either.
 - **ABI pinning test drift** for V10 publish/update functions after `merkleLeafCount` was added (`abi-pinning.test.ts`): pin digests refreshed.
 
-[Unreleased]: https://github.com/OriginTrail/dkg/compare/v10.0.0-rc.3...HEAD
+[Unreleased]: https://github.com/OriginTrail/dkg/compare/v10.0.0-rc.12...HEAD
+[10.0.0-rc.12]: https://github.com/OriginTrail/dkg/releases/tag/v10.0.0-rc.12
+[10.0.0-rc.11]: https://github.com/OriginTrail/dkg/releases/tag/v10.0.0-rc.11
+[10.0.0-rc.10]: https://github.com/OriginTrail/dkg/releases/tag/v10.0.0-rc.10
+[10.0.0-rc.9]: https://github.com/OriginTrail/dkg/releases/tag/v10.0.0-rc.9
+[10.0.0-rc.8]: https://github.com/OriginTrail/dkg/releases/tag/v10.0.0-rc.8
+[10.0.0-rc.7]: https://github.com/OriginTrail/dkg/releases/tag/v10.0.0-rc.7
+[10.0.0-rc.6]: https://github.com/OriginTrail/dkg/releases/tag/v10.0.0-rc.6
+[10.0.0-rc.4]: https://github.com/OriginTrail/dkg/releases/tag/v10.0.0-rc.4
 [10.0.0-rc.3]: https://github.com/OriginTrail/dkg/releases/tag/v10.0.0-rc.3
 [10.0.0-rc.2]: https://github.com/OriginTrail/dkg/releases/tag/v10.0.0-rc.2
 [9.0.0]: https://github.com/OriginTrail/dkg-v9/releases/tag/v9.0.0

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -160,7 +160,21 @@ Then start node again:
 dkg start
 ```
 
-## 9) Promotion policy
+## 9) Builder upgrade guides (per release)
+
+Every breaking or builder-impacting release ships a focused upgrade guide alongside the CHANGELOG entry. The guide lives at `docs/UPGRADE_<PRIOR>_TO_<NEW>.md` (e.g. `docs/UPGRADE_RC11_TO_RC12.md`).
+
+A good upgrade guide:
+
+- Opens with an agent-prompt template builders can paste into Cursor / Claude Code / Codex CLI / any AGENTS.md-honouring tool to drive the migration end-to-end.
+- Includes a breaking-change matrix at the top so a reader can grep for what affects them in 30 seconds.
+- Provides mechanical search-and-replace tables for the TS and Solidity surfaces (sed / git-grep examples are fine — most rename work is regex-shaped).
+- Documents every economic / contract / wire-format change a downstream caller could trip on, with concrete `tokenAmount`, ABI, and Hub-registration steps.
+- Cross-links the relevant `CHANGELOG.md` section for per-PR detail.
+
+Cross-link the new guide from [`docs/RELEASE.md`](docs/RELEASE.md) § "Upgrading from a prior release" before tagging.
+
+## 10) Promotion policy
 
 Recommended progression:
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,6 +2,14 @@
 
 This document describes how to cut a new release of the DKG V9 node so that users can install and track specific versions.
 
+## Upgrading from a prior release
+
+Each rc/stable ships a focused upgrade guide for builders that captures breaking changes, mechanical TS/Solidity rename tables, and an agent-prompt template:
+
+- **rc.11 → rc.12** — see [`docs/UPGRADE_RC11_TO_RC12.md`](./UPGRADE_RC11_TO_RC12.md).
+
+The full per-PR detail lives in [`CHANGELOG.md`](../CHANGELOG.md). The upgrade guides are the recommended starting point for builders pointing an AI agent at their codebase.
+
 ## Versioning
 
 - **Single version**: The repo uses one version for the node as a product. It is set in:

--- a/docs/UPGRADE_RC11_TO_RC12.md
+++ b/docs/UPGRADE_RC11_TO_RC12.md
@@ -1,0 +1,401 @@
+# Upgrading from `v10.0.0-rc.11` to `v10.0.0-rc.12`
+
+**Audience:** builders integrating with the DKG node (`@origintrail-official/dkg` and friends) — SDK callers, dApp authors, Obsidian-style note integrations, agent frameworks, chain consumers.
+
+**Compatibility posture:** this is a **forward-only, breaking release**. There are no shims, no fallback resolvers, and no compatibility codepaths. Every package in the workspace upgrades in lockstep; testnet (Base Sepolia) and devnet are intentionally broken by this change and must be redeployed.
+
+If your project pins `@origintrail-official/dkg@10.0.0-rc.11`, you need to do the work below before the daemon will boot against rc.12 contracts. The good news: the surface area is well-bounded and most of it is mechanical search-and-replace.
+
+---
+
+## Use this guide as an agent prompt
+
+The fastest way to upgrade an existing integration is to point an AI coding agent at this document and your codebase. Drop the block below into Cursor, Claude Code, Codex CLI, or any AGENTS.md-honouring tool, then let it run:
+
+```
+You are upgrading a DKG integration from @origintrail-official/dkg v10.0.0-rc.11
+to v10.0.0-rc.12. Read docs/UPGRADE_RC11_TO_RC12.md from the dkg repository
+(https://github.com/OriginTrail/dkg/blob/main/docs/UPGRADE_RC11_TO_RC12.md) end
+to end before changing any code.
+
+Then, in this order:
+
+1. Bump the @origintrail-official/dkg* dependency versions in every package.json
+   in this workspace to ^10.0.0-rc.12.
+2. Apply the mechanical TypeScript renames in §2 (Knowledge Collection → Knowledge
+   Asset). Use a workspace-wide search-and-replace, then run tsc to catch the
+   residual call sites that need follow-up.
+3. If this integration calls the Solidity surface directly (custom scripts,
+   ethers contracts, subgraphs), apply §3 (ABI + selector changes). Re-fetch ABIs
+   from packages/chain/abi/ at the new version.
+4. If this integration publishes Knowledge Assets, apply §4 (greenfield KA
+   model) — exactly one KA per publish; owner-sealed updates via
+   precomputedUpdateAttestation; UAL is now did:dkg:{chainId}/{contract}/{kaId}.
+5. If this integration sends any tokenAmount or relies on PCA discounts, apply §5
+   (economic floors). Zero-cost publishes now revert.
+6. Apply any §6 chain adapter / Hub registration changes if you operate a node.
+7. Read §8 (new capabilities) and surface any that are relevant.
+8. Run the integration's own test suite. For any failure, locate the matching
+   row in the §2/§3 rename tables before debugging further — most rc.11→rc.12
+   breakage is rename-induced.
+
+When you're done, summarise the changes you made and call out any sites where
+you weren't sure about the right migration.
+```
+
+---
+
+## 1. TL;DR breaking-change matrix
+
+| # | Area | Change | Affects |
+|---|------|--------|---------|
+| 1 | Terminology | `KnowledgeCollection` → `KnowledgeAsset` rename, on-chain and off-chain | Everyone. TS, Solidity, ABIs, predicate URIs, daemon API |
+| 2 | Solidity ABI | 4-byte selectors on `DKGKnowledgeAssets` and `ContextGraphStorage` change for every renamed function | Direct chain consumers (custom scripts, dApps, subgraphs) |
+| 3 | Hub resolution | Legacy `KnowledgeAssetsV10` fallback resolver removed | Operators on older Hub deploys |
+| 4 | KA model | Greenfield: exactly one ERC-721 KA per publish, stable UAL, owner-sealed updates via `precomputedUpdateAttestation` | Publishers, updaters |
+| 5 | Economic | Strict-positive `tokenAmount >= 1` floor; zero-cost publishes now revert | Any caller sending `tokenAmount: 0` |
+| 6 | Economic | Protocol treasury fee skim (default 300 bps = 3%) on publish/update/extend; dormant by default | Stakers (net reward), publishers (caller pays gross) |
+| 7 | Profile | `Profile.recreateProfile` drops the `initialOperatorFee` argument | Operator recovery scripts |
+| 8 | Storage | `nonReentrant` perimeter on KAV10 entrypoints | ERC-1155 receiver hooks (~50 gas/call) |
+| 9 | RS | Updated Knowledge Assets are now provable by Random Sampling (GH #842) | Cores running RS; observable as the disappearance of `rs.tick.data-corrupted` |
+| 10 | Chain | Testnet contract redeploy required on Base Sepolia | Operators; chain readers caching addresses |
+
+The rest of this document is the concrete migration for each row.
+
+---
+
+## 2. TypeScript SDK migration (the rename)
+
+This is mechanical and covers ~95% of builder-side churn. Do it with a workspace-wide search-and-replace, then let `tsc` find the rest.
+
+### 2.1 Identifier rename table
+
+| rc.11 | rc.12 | Where it surfaces |
+|-------|-------|-------------------|
+| `ChainAdapter.createKnowledgeAssetsV10` | `ChainAdapter.createKnowledgeAssets` | `@origintrail-official/dkg-chain` |
+| `ChainAdapter.getKnowledgeAssetsV10Address` | `ChainAdapter.getKnowledgeAssetsLifecycleAddress` | `@origintrail-official/dkg-chain` |
+| `ChainAdapter.getKCContextGraphId` | `ChainAdapter.getKAContextGraphId` | `@origintrail-official/dkg-chain` |
+| `NodeChallenge.knowledgeCollectionId` | `NodeChallenge.knowledgeAssetId` | `@origintrail-official/dkg-random-sampling` |
+| `PublishResult.kcId` *(was already `kaId` in publisher; alias dropped)* | `PublishResult.kaId` | `@origintrail-official/dkg-publisher` |
+| `ASSERTION_PUBLISH_RECEIPT_PREDICATES.PUBLISHED_AT_KC_ID` | `ASSERTION_PUBLISH_RECEIPT_PREDICATES.PUBLISHED_AT_KA_ID` | `@origintrail-official/dkg-publisher` |
+| Predicate URI `<…/publishedAtKcId>` (RDF) | `<…/publishedAtKaId>` (RDF) | Any consumer of assertion-publish receipt triples |
+| Adapter handles `knowledgeAssetsV10` / `knowledgeCollectionStorage` | `knowledgeAssetsLifecycle` / `knowledgeAssetStorage` | Internal to adapter, but exposed via debug surfaces |
+
+### 2.2 Property / param renames inside structs
+
+If your code constructs request bodies by hand (e.g. through `fetch`), update these keys:
+
+| rc.11 | rc.12 |
+|-------|-------|
+| `kcId` | `kaId` |
+| `knowledgeCollectionId` | `knowledgeAssetId` |
+| `createKnowledgeCollection(...)` | `createKnowledgeAsset(...)` |
+| `getKnowledgeCollection(...)` | `getKnowledgeAsset(...)` |
+| `extendKnowledgeCollectionLifetime(...)` | `extendKnowledgeAssetLifetime(...)` |
+| `isPartOfKnowledgeCollection(...)` | `isPartOfKnowledgeAsset(...)` |
+| `isOwnerOfKnowledgeCollection(...)` | `isOwnerOfKnowledgeAsset(...)` |
+| `updateKnowledgeCollection(...)` | `updateKnowledgeAsset(...)` |
+
+### 2.3 Mechanical search-and-replace
+
+If your codebase is small enough to risk a single pass, this regex sweep covers 95% of cases (re-run `tsc` after; expect a handful of context-sensitive holdouts):
+
+```bash
+# CASE-SENSITIVE — preserve TitleCase / camelCase / SCREAMING_SNAKE
+git grep -l 'KnowledgeCollection' | xargs sed -i '' 's/KnowledgeCollection/KnowledgeAsset/g'
+git grep -l 'knowledgeCollection' | xargs sed -i '' 's/knowledgeCollection/knowledgeAsset/g'
+git grep -l 'KNOWLEDGE_COLLECTION' | xargs sed -i '' 's/KNOWLEDGE_COLLECTION/KNOWLEDGE_ASSET/g'
+git grep -l 'kcId\b'              | xargs sed -i '' 's/\bkcId\b/kaId/g'
+git grep -l 'KCId\b'              | xargs sed -i '' 's/\bKCId\b/KAId/g'
+git grep -l 'publishedAtKcId'     | xargs sed -i '' 's/publishedAtKcId/publishedAtKaId/g'
+```
+
+The legacy V10.0 fallback resolver is **gone** — if `KnowledgeAssetsLifecycle` doesn't resolve from the Hub, `EVMChainAdapter.init` now raises instead of silently trying `KnowledgeAssetsV10`. Make sure your operator Hub has the V10.1 surface registered before pointing the daemon at it (see §6).
+
+### 2.4 Property renames you can't grep for
+
+`BOUND_CONTRACT_INVALIDATORS` and `ERROR_ABI_CONTRACTS` (in `@origintrail-official/dkg-chain`) drop their legacy entries. If you've extended these maps in your own code, drop the corresponding keys (`KnowledgeAssetsV10`, `KnowledgeCollectionStorage`).
+
+---
+
+## 3. Solidity / ABI migration
+
+This affects you if you call the contracts directly (ethers, web3.js, viem, custom scripts, subgraphs).
+
+### 3.1 Contract renames
+
+| rc.11 Solidity name | rc.12 Solidity name |
+|---|---|
+| `KnowledgeCollectionLib.sol` | `KnowledgeAssetLib.sol` |
+| `struct KnowledgeCollection` | `struct KnowledgeAsset` |
+| `error KnowledgeCollection*` (all) | `error KnowledgeAsset*` |
+| `event KnowledgeCollection*` (all) | `event KnowledgeAsset*` |
+| `KnowledgeAssetsV10.sol` (legacy V10.0 contract) | **DELETED** |
+| `KnowledgeCollectionStorage.sol` (legacy V10.0 storage) | **DELETED** |
+| `KnowledgeCollection.sol` (V8 archive) | **DELETED** |
+
+### 3.2 Active V10.1 surface
+
+Active V10.1 lives on these two contracts (look them up via `Hub.getContractAddress(...)`):
+
+- `KnowledgeAssetsLifecycle` (formerly the call surface on `KnowledgeAssetsV10`)
+- `DKGKnowledgeAssets` (the ERC-721 storage / mint surface)
+
+### 3.3 Selector changes
+
+Every renamed function has a fresh 4-byte selector. Old calldata reverts. Rebuild against the new ABIs:
+
+```bash
+# In the dkg repo at the rc.12 tag:
+ls packages/chain/abi/
+
+# Pull the JSON for whichever contract you bind to:
+cat packages/chain/abi/KnowledgeAssetsLifecycle.json
+cat packages/chain/abi/DKGKnowledgeAssets.json
+cat packages/chain/abi/ContextGraphs.json
+cat packages/chain/abi/ContextGraphStorage.json
+cat packages/chain/abi/ParametersStorage.json
+```
+
+The `packages/chain/abi/abi-pinning.test.ts` pinned digests reflect the rename. If you've pinned ABI hashes downstream, regenerate them.
+
+### 3.4 Storage / config renames
+
+`deployments/parameters.json` config keys:
+
+- `KnowledgeCollectionStorage.knowledgeCollectionSize` → `DKGKnowledgeAssets.knowledgeAssetBatchSize`
+- `ContextGraphStorage.kcToContextGraph` (mapping name) → `kaToContextGraph`
+- `registerKnowledgeCollection` → `registerKnowledgeAsset`
+
+### 3.5 Predicate URIs in RDF / SPARQL
+
+If you write SPARQL against published assertions, update predicate IRIs:
+
+| rc.11 predicate | rc.12 predicate |
+|---|---|
+| `<…/publishedAtKcId>` | `<…/publishedAtKaId>` |
+
+Other on-chain-derived RDF surfaces (`dkg:authoredBy`, `dkg:trustLevel`, etc.) are unchanged.
+
+---
+
+## 4. Greenfield Knowledge Asset model
+
+The headline new feature in rc.12, and the reason for the rename: a unified, simplified KA lifecycle.
+
+### 4.1 What's new
+
+- **One KA per publish** — `publish` mints exactly one ERC-721 `DKGKnowledgeAssets` token. `knowledgeAssetsAmount == 1` is now the only valid value. ERC-1155 batching is gone.
+- **Stable UAL** — `did:dkg:{chainId}/{DKGKnowledgeAssetsAddress}/{kaId}`. `kaId` equals the ERC-721 `tokenId`. The UAL no longer changes when the KA is updated.
+- **ERC-721 minted to author at publish** — the author (recovered from EIP-712 author attestation) holds the NFT; the publisher pays TRAC.
+- **Owner-sealed updates** — only the current ERC-721 holder can update. The owner signs an EIP-712 `UpdateAuthorAttestation(kaId, newMerkleRoot, authorAddress, schemeVersion)` (domain `KnowledgeAssetsLifecycle` v2.0.0) **once**, then passes it as `precomputedUpdateAttestation` on the first `publisher.update()` call. The publisher (which can be any node operator) does the chain write; the attestation is the seal that the chain validates against `ownerOf(kaId)`.
+- **No ERC-1155 mint/burn on update** — updates only refresh the merkle root + leaf count; the ERC-721 stays bound to the same `kaId`.
+
+### 4.2 Code changes
+
+```ts
+// rc.11: ERC-1155 batched, kcId, batched signing
+const result = await publisher.publish({
+  kcSize: 1,
+  // ... old fields
+});
+const kcId = result.kcId;
+
+// rc.12: ERC-721 singleton, kaId, stable UAL
+const result = await publisher.publish({
+  // knowledgeAssetsAmount is implicit / fixed at 1
+  // ... new fields
+});
+const kaId = result.kaId; // also the ERC-721 tokenId
+const ual = `did:dkg:${chainId}/${dkgKnowledgeAssetsAddress.toLowerCase()}/${kaId}`;
+
+// rc.12: updates require precomputedUpdateAttestation on the first update
+const updateResult = await publisher.update({
+  kaId,
+  newMerkleRoot,
+  precomputedUpdateAttestation: eip712Sig, // signed by ownerOf(kaId)
+  // ...
+});
+```
+
+The canonical UAL builder is `buildKnowledgeAssetUal(chainId, dkgKnowledgeAssetsAddress, kaId)` exported from `@origintrail-official/dkg-chain`. Use it instead of templating the URN yourself.
+
+### 4.3 Verifying the surface
+
+```bash
+pnpm test:devnet:greenfield-10min   # the 10-minute happy-path smoke
+pnpm test:devnet:rich-scenario      # mixed publish / update / extend scenarios
+```
+
+See `packages/evm-module/docs/greenfield-ka-ual.md` for the canonical reference.
+
+---
+
+## 5. Economic changes (mandatory)
+
+### 5.1 `tokenAmount >= 1` floor — **BREAKING**
+
+Both branches of the publish flow now charge a non-zero economic cost regardless of input rounding:
+
+- **Direct-spend** path: `tokenAmount == 0` reverts with `InvalidTokenAmount(1, 0)`.
+- **PCA (Publishing Conviction Account)** path: when the discount math would truncate to `discountedCost == 0` but `baseCost > 0`, the cost is floored at **1 wei TRAC** so the active-sink reward distribution and `windowSpent` accounting always fire.
+
+**What you have to do:** every off-chain caller MUST encode `tokenAmount >= 1`. Zero-cost publish flows are no longer permitted. If your integration was relying on a "free publish on dust CG" pattern, that's gone.
+
+The same floor applies to `update` and `extendKnowledgeAssetLifetime` — they enforce the floor in both the direct-spend and conviction branches.
+
+### 5.2 Protocol treasury fee — new, dormant by default
+
+A governance-set bps cut (default **300 bps = 3 %**, capped at **1000 bps = 10 %**) is skimmed from the staker-bound TRAC on every paid publish, update, and lifetime-extension and routed to a treasury address.
+
+- **The publisher pays the same gross price.** The fee comes out of what would otherwise flow into the staker reward pool.
+- **Dormant by default**: `treasury == address(0)` ⇒ `fee == 0`, so a fresh deploy is unchanged until governance opts in. (`ProtocolTreasurySet` is emitted when it flips.)
+- New `ParametersStorage` fields: `protocolTreasuryFee` (bps), `protocolTreasury` (address), `MAX_PROTOCOL_TREASURY_FEE` (1000 bps cap).
+- New `ParametersStorage.ProtocolTreasurySet(uint256 fee, address treasury)` event.
+
+If you display "estimated staker rewards" in your UI, you'll want to net out the treasury fee from the displayed reward yield once governance enables it. The fee is `0` until then.
+
+`PublishingConviction` accumulates the fee across active sink + every passive window sweep + final dust/topUp tail, and pays it via a single `CSS.transferStake` after all state writes (so the permissionless `settle()` stays reentrancy-safe). The lifetime invariant is now `pool + treasury == committed + topUps`.
+
+### 5.3 Reentrancy guard on KAV10 entrypoints
+
+`publish` / `update` / `extendKnowledgeAssetLifetime` now carry OZ `ReentrancyGuard.nonReentrant` as a defense-in-depth perimeter against the ERC-1155 receiver-hook callback path. Cost is ~50 gas per call. Failing this guard reverts with `ReentrancyGuardReentrantCall()` — surface that error in any UI that decodes contract errors.
+
+---
+
+## 6. Chain adapter & Hub registration
+
+This only affects you if you operate a node or maintain a custom deploy of the V10 contract stack.
+
+### 6.1 Hub registration
+
+`KnowledgeAssetsLifecycle` and `DKGKnowledgeAssets` are the **only** V10.1 entries the rc.12 daemon looks up. Hub deployments that still expose `KnowledgeAssetsV10` or `KnowledgeCollectionStorage` will be silently ignored — the daemon won't resolve them.
+
+**Required action for self-hosted deploys:** re-deploy and re-register the V10.1 contract surface against your Hub before upgrading the daemon. For Base Sepolia operators on the OriginTrail-managed Hub, the redeploy is already done; just bump your daemon to `v10.0.0-rc.12` and let the chain-reset wipe re-derive state on first boot.
+
+### 6.2 Legacy fallback resolver removed
+
+`EVMChainAdapter.init` previously fell back to `KnowledgeAssetsV10` if `KnowledgeAssetsLifecycle` didn't resolve. That fallback is gone. The adapter raises on init if the V10.1 surface isn't registered — fail-fast instead of silently running on the wrong contract.
+
+### 6.3 ABI re-pin
+
+`packages/chain/abi/` is regenerated for every renamed contract. If you have a downstream pin (e.g. you've forked the chain package), regenerate it:
+
+```bash
+pnpm --filter @origintrail-official/dkg-evm-module build
+git add packages/evm-module/abi packages/chain/abi
+```
+
+CI gates this via the `abi-freshness` workflow.
+
+### 6.4 Profile recovery signature change
+
+`Profile.recreateProfile` drops the `uint16 initialOperatorFee` argument. The recovered profile is seeded at `operatorFee = 0`; the admin sets the real value via the cooldown-gated `updateOperatorFee` path. If you have an operator recovery script (a la `scripts/recreate-profile.ts`), drop the fourth argument and follow up with a separate `updateOperatorFee` call.
+
+### 6.5 Operational-wallet validation rewire
+
+`Identity.addOperationalWallets` is now the single source of truth for op-wallet validation. Same-identity collisions surface as `OperationalWalletDuplicate(wallet)`; cross-identity collisions still fire `OperationalKeyTaken(key)`; admin/operational overlap surfaces as the existing `KeyAlreadyAttached(key)`. `Profile.createProfile`'s pre-flight validation loop is removed — atomic-revert semantics make the prior "fail-fast at the entrypoint" rationale moot. Identity bumps to `v1.1.0`, Profile to `v1.4.2`.
+
+### 6.6 CEI ordering on staking withdrawal
+
+`DKGStakingConvictionNFT.withdraw` now burns the receipt NFT **before** `StakingV10.withdraw` drives the CSS teardown + TRAC payout. `StakingV10.withdraw` gates on the CSS position (`pos.identityId == 0`), not NFT existence, so the CSS teardown is unaffected. If you have a staking dashboard subscribing to `Transfer`/`Withdrawn` events, expect the burn event to land before the TRAC transfer event for a given withdrawal.
+
+---
+
+## 7. Random Sampling proof health (GH #842 fix)
+
+If you operate a Core node, this is the change you'll see in your logs:
+
+**Before rc.12:** every *updated* Knowledge Asset became permanently unprovable by Random Sampling, producing a steady stream of `rs.tick.data-corrupted` on core nodes once any KA was updated. The defect was a race between two writers to the per-cgId materialization partition (publish-promotion and update-promotion), with no version guard.
+
+**After rc.12:** updated KAs stay provable. Three changes:
+
+1. **Full label-graph restatement on both update paths** (publisher `storeUpdatedQuads` and gossip `UpdateHandler`).
+2. **Per-KA `dkg:materializedVersion` (`block:txIndex`) guard** stamped on the KC's `<ual>` in the meta graph. Every canonical writer (publisher promotion, update promotion, receiver `FinalizationHandler`) refuses to apply a state older than what's already materialised.
+3. **Deterministic UAL fallback** in `UpdateHandler` so a gossip receiver that hasn't yet materialised the `dkg:batchId` edge still promotes instead of silently skipping.
+
+**What you have to do:** nothing — it's purely a daemon-side fix. The `rs.tick.data-corrupted` metric should drop to zero on the updated cohort once you upgrade. The fix is fully described in [`GH842-rs-update-race-analysis.md`](../GH842-rs-update-race-analysis.md) if you want the deep-dive.
+
+---
+
+## 8. New capabilities (non-breaking, but builders should know)
+
+### 8.1 Blazegraph + SPARQL-HTTP external triple-store support (RFC 120)
+
+The daemon's persistence layer can now point at an external Blazegraph or generic SPARQL-HTTP endpoint instead of (or in addition to) the embedded Oxigraph store. Useful for large-scale deployments and for integrations that want to share a query backend with other services.
+
+Configure via `~/.dkg/config.json`:
+
+```json
+{
+  "storage": {
+    "backend": "sparql-http",
+    "endpoint": "http://localhost:9999/blazegraph/namespace/kb/sparql"
+  }
+}
+```
+
+Or use the new interactive `dkg storage` wizard (`dkg storage` on the CLI). See `docs/setup/STORAGE_SPARQL_HTTP.md` for the operator runbook.
+
+### 8.2 `dkg doctor`
+
+A new operator command that diagnoses common install/upgrade issues. Run `dkg doctor` after upgrading to confirm the install is healthy. Six structured checks + a state-summary. Output is JSON-parseable.
+
+### 8.3 `dkg migrate-to-npm` (carried from rc.11, now production-ready)
+
+One-shot conversion from a git-checkout install (`~/dkg-v9/`) to the npm-pinned auto-update path. Dry-run by default; `--apply` to mutate. Recommended for any operator still on a git-clone install path.
+
+### 8.4 `/api/build-info` + `/api/status` `relay` block
+
+- New `/api/build-info` endpoint surfaces `{ version, commit, installMode, builtAt }` so monitoring can correlate daemon behaviour with build provenance.
+- `/api/status` now includes a uniform `relay` block on every node (edge + core): `isCore`, `reservationsHeld`, `reservationCapacity`, `activeCircuits`, `bytesIn`, `bytesOut` (stringified BigInt), `natStatus`, `listenAddresses`, `announcedAddresses`.
+
+### 8.5 RFC-41 Bundle B — Edge node npm-only update path
+
+Edge nodes now update via `npm install -g @origintrail-official/dkg` rather than a git-clone build. Git-based updates are hard-refused at user-facing entry points for edges. Core nodes retain the git-build path for now (will follow in a later RC).
+
+### 8.6 Node UI — Context Graph Overview (S2 + S3 polish)
+
+The Node UI's Context Graph view ships a redesigned overview with a Root mini-card, cross-layer pills, mini-graph colors, and de-duplication. The notifications pane is membership-scoped with inline join-approve/deny actions.
+
+### 8.7 Ethers polling subscriber fix
+
+The chain adapter now forces ethers' `PollingEventSubscriber` to stop the `FilterId` CPU spin that was producing 100% single-core utilization on long-uptime daemons.
+
+---
+
+## 9. Things that did NOT change (sanity check)
+
+- **Hub address** (Base Sepolia): `0xC056e67Da4F51377Ad1B01f50F655fFdcCD809F6` — unchanged.
+- **Token address** (Base Sepolia v9TRAC): `0x2A58BdD13176D85906D804cdbFFA0D9119282DC8` — unchanged.
+- **Storage layout** of upgradeable contracts — no migration is required; rc.12 doesn't preserve state across the V10 redeploy-and-reinit pattern anyway.
+- **MCP tool surface** for AI agents (`dkg_memory_search`, `dkg_assertion_create/write/promote`, `dkg_query`, `dkg_send_message`, etc.) — V10 tool surface is unchanged from rc.11.
+- **EIP-712 domain hash** on `KnowledgeAssetsLifecycle` — pinned at `v2.0.0` so previously-signed author attestations keep verifying across the `v2.0.0 → v2.0.1` patch bump.
+- **Chat / agent-to-agent messaging** wire format — `/dkg/10.0.1/*` protocol surface from rc.9 is unchanged.
+
+---
+
+## 10. Verification checklist for builders
+
+After upgrading, run through this list:
+
+- [ ] `pnpm tsc` (or your TS build) is clean — no residual `kcId` / `KnowledgeCollection*` references.
+- [ ] Your test suite passes against a local devnet or a freshly-upgraded daemon.
+- [ ] Any `tokenAmount` values your integration sends are `>= 1`.
+- [ ] Your update flow signs a `precomputedUpdateAttestation` with the **current ERC-721 owner's** key, not the publisher's.
+- [ ] If you operate a node: `dkg doctor` is green, `/api/build-info` reports `10.0.0-rc.12`, and `rs.tick.data-corrupted` is zero on the updated-KA cohort.
+- [ ] If you decode chain errors in a UI: you handle `InvalidTokenAmount`, `ReentrancyGuardReentrantCall`, `OperationalWalletDuplicate`, and the new `Profile` error surface.
+- [ ] Your SPARQL queries against publish-receipts use `publishedAtKaId`, not `publishedAtKcId`.
+
+---
+
+## 11. Where to get help
+
+- **Full per-PR detail:** [`CHANGELOG.md`](../CHANGELOG.md) under the `[10.0.0-rc.12]` section.
+- **Greenfield KA reference:** [`packages/evm-module/docs/greenfield-ka-ual.md`](../packages/evm-module/docs/greenfield-ka-ual.md).
+- **Random Sampling update fix deep-dive:** [`GH842-rs-update-race-analysis.md`](../GH842-rs-update-race-analysis.md).
+- **CG memory model (the design that made edge-curator publishing possible):** [`docs/specs/SPEC_CG_MEMORY_MODEL.md`](specs/SPEC_CG_MEMORY_MODEL.md).
+- **GitHub:** issues on [`OriginTrail/dkg`](https://github.com/OriginTrail/dkg/issues) — tag with `rc.12-upgrade` so we can triage them as a group.
+- **The DKG node Discord** — the maintainers monitor #builders for upgrade questions.
+
+If you hit an upgrade snag this document doesn't cover, please open an issue or PR against this file so the next builder benefits.

--- a/docs/UPGRADE_RC11_TO_RC12.md
+++ b/docs/UPGRADE_RC11_TO_RC12.md
@@ -102,12 +102,12 @@ If your codebase is small enough to risk a single pass, this regex sweep covers 
 
 ```bash
 # CASE-SENSITIVE — preserve TitleCase / camelCase / SCREAMING_SNAKE
-git grep -l 'KnowledgeCollection' | xargs sed -i '' 's/KnowledgeCollection/KnowledgeAsset/g'
-git grep -l 'knowledgeCollection' | xargs sed -i '' 's/knowledgeCollection/knowledgeAsset/g'
-git grep -l 'KNOWLEDGE_COLLECTION' | xargs sed -i '' 's/KNOWLEDGE_COLLECTION/KNOWLEDGE_ASSET/g'
-git grep -l 'kcId\b'              | xargs sed -i '' 's/\bkcId\b/kaId/g'
-git grep -l 'KCId\b'              | xargs sed -i '' 's/\bKCId\b/KAId/g'
-git grep -l 'publishedAtKcId'     | xargs sed -i '' 's/publishedAtKcId/publishedAtKaId/g'
+git grep -l 'KnowledgeCollection' | while IFS= read -r f; do perl -pi -e 's/KnowledgeCollection/KnowledgeAsset/g' "$f"; done
+git grep -l 'knowledgeCollection' | while IFS= read -r f; do perl -pi -e 's/knowledgeCollection/knowledgeAsset/g' "$f"; done
+git grep -l 'KNOWLEDGE_COLLECTION' | while IFS= read -r f; do perl -pi -e 's/KNOWLEDGE_COLLECTION/KNOWLEDGE_ASSET/g' "$f"; done
+git grep -l 'kcId'                | while IFS= read -r f; do perl -pi -e 's/\bkcId\b/kaId/g' "$f"; done
+git grep -l 'KCId'                | while IFS= read -r f; do perl -pi -e 's/\bKCId\b/KAId/g' "$f"; done
+git grep -l 'publishedAtKcId'     | while IFS= read -r f; do perl -pi -e 's/publishedAtKcId/publishedAtKaId/g' "$f"; done
 ```
 
 The legacy V10.0 fallback resolver is **gone** — if `KnowledgeAssetsLifecycle` doesn't resolve from the Hub, `EVMChainAdapter.init` now raises instead of silently trying `KnowledgeAssetsV10`. Make sure your operator Hub has the V10.1 surface registered before pointing the daemon at it (see §6).

--- a/docs/UPGRADE_RC11_TO_RC12.md
+++ b/docs/UPGRADE_RC11_TO_RC12.md
@@ -188,7 +188,7 @@ The headline new feature in rc.12, and the reason for the rename: a unified, sim
 - **One KA per publish** — `publish` mints exactly one ERC-721 `DKGKnowledgeAssets` token. `knowledgeAssetsAmount == 1` is now the only valid value. ERC-1155 batching is gone.
 - **Stable UAL** — `did:dkg:{chainId}/{DKGKnowledgeAssetsAddress}/{kaId}`. `kaId` equals the ERC-721 `tokenId`. The UAL no longer changes when the KA is updated.
 - **ERC-721 minted to author at publish** — the author (recovered from EIP-712 author attestation) holds the NFT; the publisher pays TRAC.
-- **Owner-sealed updates** — only the current ERC-721 holder can update. The owner signs an EIP-712 `UpdateAuthorAttestation(kaId, newMerkleRoot, authorAddress, schemeVersion)` (domain `KnowledgeAssetsLifecycle` v2.0.0) **once**, then passes it as `precomputedUpdateAttestation` on the first `publisher.update()` call. The publisher (which can be any node operator) does the chain write; the attestation is the seal that the chain validates against `ownerOf(kaId)`.
+- **Owner-sealed updates** — only the current ERC-721 holder can update. Every update needs a fresh EIP-712 `UpdateAuthorAttestation(kaId, newMerkleRoot, authorAddress, schemeVersion)` (domain `KnowledgeAssetsLifecycle` v2.0.0), passed as `precomputedUpdateAttestation` on that same `publisher.update(kaId, options)` call. The `newMerkleRoot` is recomputed from the update's `quads` / `privateQuads`, so seals are not reusable across later updates. The publisher (which can be any node operator) does the chain write; the attestation is the seal that the chain validates against `ownerOf(kaId)`.
 - **No ERC-1155 mint/burn on update** — updates only refresh the merkle root + leaf count; the ERC-721 stays bound to the same `kaId`.
 
 ### 4.2 Code changes
@@ -209,12 +209,26 @@ const result = await publisher.publish({
 const kaId = result.kaId; // also the ERC-721 tokenId
 const ual = `did:dkg:${chainId}/${dkgKnowledgeAssetsAddress.toLowerCase()}/${kaId}`;
 
-// rc.12: updates require precomputedUpdateAttestation on the first update
-const updateResult = await publisher.update({
+// rc.12: every update requires a fresh precomputedUpdateAttestation
+const updateQuads = [
+  // ... complete replacement public quads for this KA
+];
+const updatePrivateQuads = [
+  // ... optional replacement private quads for this KA
+];
+// Your signing helper must compute expectedNewMerkleRoot over these exact
+// updateQuads/updatePrivateQuads using the publisher's V10 root rules.
+const precomputedUpdateAttestation = await signUpdateAuthorAttestation({
   kaId,
-  newMerkleRoot,
-  precomputedUpdateAttestation: eip712Sig, // signed by ownerOf(kaId)
-  // ...
+  quads: updateQuads,
+  privateQuads: updatePrivateQuads,
+  owner: ownerWallet, // current ERC-721 owner of kaId
+});
+const updateResult = await publisher.update(kaId, {
+  contextGraphId,
+  quads: updateQuads,
+  privateQuads: updatePrivateQuads,
+  precomputedUpdateAttestation, // signed by ownerOf(kaId) for these exact quads
 });
 ```
 

--- a/docs/UPGRADE_RC11_TO_RC12.md
+++ b/docs/UPGRADE_RC11_TO_RC12.md
@@ -157,7 +157,7 @@ cat packages/chain/abi/ContextGraphStorage.json
 cat packages/chain/abi/ParametersStorage.json
 ```
 
-The `packages/chain/abi/abi-pinning.test.ts` pinned digests reflect the rename. If you've pinned ABI hashes downstream, regenerate them.
+The `packages/chain/test/abi-pinning.test.ts` pinned digests reflect the rename. If you've pinned ABI hashes downstream, regenerate them.
 
 ### 3.4 Storage / config renames
 

--- a/docs/UPGRADE_RC11_TO_RC12.md
+++ b/docs/UPGRADE_RC11_TO_RC12.md
@@ -249,9 +249,11 @@ The same floor applies to `update` and `extendKnowledgeAssetLifetime` — they e
 A governance-set bps cut (default **300 bps = 3 %**, capped at **1000 bps = 10 %**) is skimmed from the staker-bound TRAC on every paid publish, update, and lifetime-extension and routed to a treasury address.
 
 - **The publisher pays the same gross price.** The fee comes out of what would otherwise flow into the staker reward pool.
-- **Dormant by default**: `treasury == address(0)` ⇒ `fee == 0`, so a fresh deploy is unchanged until governance opts in. (`ProtocolTreasurySet` is emitted when it flips.)
+- **Dormant by default**: `treasury == address(0)` ⇒ `fee == 0`, so a fresh deploy is unchanged until governance opts in. (`ProtocolTreasurySet` is emitted when the treasury address changes.)
 - New `ParametersStorage` fields: `protocolTreasuryFee` (bps), `protocolTreasury` (address), `MAX_PROTOCOL_TREASURY_FEE` (1000 bps cap).
-- New `ParametersStorage.ProtocolTreasurySet(uint256 fee, address treasury)` event.
+- Event surface:
+  - `setProtocolTreasury(address)` emits `ParametersStorage.ProtocolTreasurySet(address indexed treasury)`.
+  - `setProtocolTreasuryFee(uint16)` still emits `ParameterChanged("protocolTreasuryFee", fee)`.
 
 If you display "estimated staker rewards" in your UI, you'll want to net out the treasury fee from the displayed reward yield once governance enables it. The fee is `0` until then.
 
@@ -328,22 +330,27 @@ Configure via `~/.dkg/config.json`:
 
 ```json
 {
-  "storage": {
+  "store": {
     "backend": "sparql-http",
-    "endpoint": "http://localhost:9999/blazegraph/namespace/kb/sparql"
+    "options": {
+      "queryEndpoint": "http://localhost:9999/blazegraph/namespace/kb/sparql",
+      "updateEndpoint": "http://localhost:9999/blazegraph/namespace/kb/sparql"
+    }
   }
 }
 ```
 
-Or use the new interactive `dkg storage` wizard (`dkg storage` on the CLI). See `docs/setup/STORAGE_SPARQL_HTTP.md` for the operator runbook.
+For a fresh config, `dkg init --store sparql-http --store-url <SPARQL_URL>` pre-fills and validates the same `store` block. Setup flows that expose `--store` / `--store-url` persist the same shape after their normal setup completes. See `docs/setup/STORAGE_SPARQL_HTTP.md` for the manual operator runbook.
+
+If you choose the Blazegraph-specific backend instead of generic `sparql-http`, the config shape is `store.backend = "blazegraph"` with `store.options.url = "<SPARQL_URL>"`.
 
 ### 8.2 `dkg doctor`
 
-A new operator command that diagnoses common install/upgrade issues. Run `dkg doctor` after upgrading to confirm the install is healthy. Six structured checks + a state-summary. Output is JSON-parseable.
+A new operator command that diagnoses common install/upgrade issues. Run `dkg doctor` after upgrading to confirm the install is healthy. The default output is human-readable; use `dkg doctor --json` when upgrade automation needs the structured six-check report + state summary.
 
-### 8.3 `dkg migrate-to-npm` (carried from rc.11, now production-ready)
+### 8.3 Legacy install migration to npm
 
-One-shot conversion from a git-checkout install (`~/dkg-v9/`) to the npm-pinned auto-update path. Dry-run by default; `--apply` to mutate. Recommended for any operator still on a git-clone install path.
+`dkg migrate-to-npm` is no longer a CLI command in rc.12. Edge nodes with a legacy `~/.dkg/releases/` tree migrate automatically on first `dkg start` and keep `~/.dkg/previous-version` populated for rollback continuity. Core operators still running from a git checkout should follow the manual path in `docs/archive/MIGRATE_TO_NPM.md`; use `dkg doctor --json` before and after the upgrade to verify the active install layout.
 
 ### 8.4 `/api/build-info` + `/api/status` `relay` block
 


### PR DESCRIPTION
## Summary

Ships two builder-facing docs alongside the rc.12 release:

- **`docs/UPGRADE_RC11_TO_RC12.md` (new)** — focused builder migration guide with a paste-ready agent-prompt template (Cursor / Claude Code / Codex CLI), a 10-row breaking-change matrix, mechanical TS + Solidity rename tables, and concrete migrations for the greenfield KA model, `tokenAmount >= 1` floor, protocol treasury fee, Hub registration, and the GH #842 Random Sampling fix.
- **`CHANGELOG.md`** — consolidates the prior `[Unreleased]` (KC→KA rename PRs #836/#837/#838) and the early `[10.0.0-rc.12] - 2026-05-29` entry into a single comprehensive `[10.0.0-rc.12] - 2026-06-01` release entry, adding items that were missing from earlier drafts (protocol treasury fee #821, Blazegraph / SPARQL-HTTP RFC 120 #766, active-sink proration #817, GH #842 RS fix #842/#845, ERC-20 false-return guards #814, update path token-amount floor + ACK digest alignment #831/#833, ethers `PollingEventSubscriber` CPU-spin fix, context-graph / query-scoping / SWM-promote-ownership fixes). Resets `[Unreleased]` to empty and refreshes tag-compare links to cover every published RC.
- **`docs/RELEASE.md` + `RELEASE_PROCESS.md`** — cross-links the upgrade guide and documents the per-release builder-guide convention so future RCs follow the same pattern.

No code changes; documentation only.

## Motivation

Builders building integrations on rc.11 (Obsidian-style note tools, agent frameworks, dApp authors, anyone pinning `@origintrail-official/dkg`) will hit a lot of breakage in rc.12 (KC→KA rename, greenfield KA model, economic floors, Hub registration). The upgrade guide is structured so they can point their AI coding agents at it and have the agent walk the migration end-to-end.

## Test plan

- [ ] Render `docs/UPGRADE_RC11_TO_RC12.md` on GitHub and verify the agent-prompt block, change matrix, rename tables, and code samples render correctly.
- [ ] Render `CHANGELOG.md` and verify the `[10.0.0-rc.12]` section parses cleanly and tag-compare links at the bottom resolve.
- [ ] Spot-check the relative links from the upgrade guide back to `CHANGELOG.md`, `GH842-rs-update-race-analysis.md`, `packages/evm-module/docs/greenfield-ka-ual.md`, and `docs/specs/SPEC_CG_MEMORY_MODEL.md` — confirm they resolve in the GitHub UI.
- [ ] Verify the `chainResetMarker` value referenced in the Operations note matches the actual rc.12 marker once contracts are redeployed (the entry says "bumped accordingly" — fill in the concrete marker string before tagging if you want it pinned).
- [ ] Sanity-check the date `2026-06-01` matches the tag-cutting day; swap if tagging on a different day.

## Notes for reviewers

- The intent is for the upgrade guide to be **stable** for the duration of the rc.11→rc.12 migration window. Subsequent fixups should go to a new `docs/UPGRADE_RC12_TO_<next>.md` per the convention added to `RELEASE_PROCESS.md` §9.
- A couple of PR numbers in the CHANGELOG were attributed from git log — happy to retake any of them; flag anything that's misattributed.
- The agent-prompt block embeds a literal GitHub URL pointing at `main` (`https://github.com/OriginTrail/dkg/blob/main/docs/UPGRADE_RC11_TO_RC12.md`). Once the rc.12 tag is cut, builders pointing at the tag URL get a stable artifact.


Made with [Cursor](https://cursor.com)