### PR TITLE
chore(testnet): redeploy contracts + bump marker for v10.0.0-rc.12

### DIFF
--- a/network/testnet.json
+++ b/network/testnet.json
@@ -16,7 +16,7 @@
     "branch": "main",
     "checkIntervalMinutes": 5
   },
-  "chainResetMarker": "v10-rc11-pca-split-2026-05-25",
+  "chainResetMarker": "v10-rc12-ka-rename-2026-06-01",
   "chain": {
     "type": "evm",
     "rpcUrl": "https://sepolia.base.org",

--- a/packages/evm-module/deployments/base_sepolia_v10_contracts.json
+++ b/packages/evm-module/deployments/base_sepolia_v10_contracts.json
@@ -19,75 +19,75 @@
             "deployed": true
         },
         "ParametersStorage": {
-            "evmAddress": "0x16aCc81F7595e50edc6566149EA1D67f03db4999",
-            "version": "1.0.0",
+            "evmAddress": "0xd73D9D2ac659d79aED2B8e4CEa169758c8E1a2F6",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978622,
-            "deploymentTimestamp": 1779725536347,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265715,
+            "deploymentTimestamp": 1780299720090,
             "deployed": true
         },
         "WhitelistStorage": {
-            "evmAddress": "0x07E3743595530A18077ED5873Cd185e270059Ece",
-            "version": "1.0.0",
+            "evmAddress": "0x0a3020BA9BF8E853c306dFE4d3C8AB0449d99c99",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978625,
-            "deploymentTimestamp": 1779725542090,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265717,
+            "deploymentTimestamp": 1780299725227,
             "deployed": true
         },
         "IdentityStorage": {
-            "evmAddress": "0xA1F93f18B6aE3924Ec227bC04213334a78887Dcb",
-            "version": "1.0.0",
+            "evmAddress": "0x038f9382F2c90A7f88c9145Ed77f6757efBFBA13",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978628,
-            "deploymentTimestamp": 1779725547017,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265719,
+            "deploymentTimestamp": 1780299729883,
             "deployed": true
         },
         "ShardingTableStorage": {
-            "evmAddress": "0xD3B4E47f8e29865Bee614A7Ae036CbD26EdCdB23",
-            "version": "1.0.0",
+            "evmAddress": "0x3D7265337C49777CC3400e1bC6ba223b4d22c0C7",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978630,
-            "deploymentTimestamp": 1779725551916,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265722,
+            "deploymentTimestamp": 1780299734690,
             "deployed": true
         },
         "StakingStorage": {
-            "evmAddress": "0xE7a3D4bF506F1566EcEd63809cf08a219452aF7a",
-            "version": "1.0.0",
+            "evmAddress": "0xc3f82688933BCa73Eca3B5cE75850819438f1a69",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978633,
-            "deploymentTimestamp": 1779725556930,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265724,
+            "deploymentTimestamp": 1780299739538,
             "deployed": true
         },
         "ProfileStorage": {
-            "evmAddress": "0x18183945D0d3aDd34011A0097BEf085e19494474",
-            "version": "1.1.0",
+            "evmAddress": "0x4723e340D7D815b5f0edA06DE19a18b19145e673",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978635,
-            "deploymentTimestamp": 1779725561865,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265727,
+            "deploymentTimestamp": 1780299744284,
             "deployed": true
         },
         "Chronos": {
-            "evmAddress": "0x935fC1F2d2eA6c08EDFafe952DC26Bc4373C4107",
+            "evmAddress": "0xB8fad5167274162fD845c05F44959c299c79e7c7",
             "version": null,
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978638,
-            "deploymentTimestamp": 1779725566866,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265729,
+            "deploymentTimestamp": 1780299748988,
             "deployed": true
         },
         "EpochStorageV8": {
-            "evmAddress": "0xE258eBa6B3d06FF8bA14Afd6e3503972aDFB3d21",
-            "version": "1.0.0",
+            "evmAddress": "0x93a8e3e4E42B5B41f4AB336568779A0deDdaCC45",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978643,
-            "deploymentTimestamp": 1779725576904,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265734,
+            "deploymentTimestamp": 1780299758505,
             "deployed": true
         },
         "KnowledgeCollectionStorage": {
@@ -97,7 +97,7 @@
             "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
             "deploymentBlock": 41978645,
             "deploymentTimestamp": 1779725582201,
-            "deployed": true
+            "deployed": false
         },
         "PaymasterManager": {
             "evmAddress": "0x073aFC5cDf6e81d2Ccfb66d39E1F1224B39b8F15",
@@ -109,39 +109,39 @@
             "deployed": false
         },
         "AskStorage": {
-            "evmAddress": "0xAE9114dd85B8a28f786025749B5944a75286CE1d",
-            "version": "1.0.0",
+            "evmAddress": "0xa1f9d67c3a04C6592952f5F9Eb61C32591deAD4A",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978648,
-            "deploymentTimestamp": 1779725587291,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265738,
+            "deploymentTimestamp": 1780299767998,
             "deployed": true
         },
         "Identity": {
-            "evmAddress": "0x95d8e47be9fAd3d03148f1f904c219634BD7D817",
-            "version": "1.0.0",
+            "evmAddress": "0x1Cb0f89674E7AA777ceD184A1b5998A62378543c",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978651,
-            "deploymentTimestamp": 1779725592409,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265741,
+            "deploymentTimestamp": 1780299772828,
             "deployed": true
         },
         "ShardingTable": {
-            "evmAddress": "0xb4eF1571d87F23cD948dD61745D4f70372d9b628",
-            "version": "2.0.0",
+            "evmAddress": "0xEd480B9e6B3485eFC5583fA4485D1FB3507f278E",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "d7a79c71628b4ef5495fa31e137812f358129060",
-            "deploymentBlock": 42014794,
-            "deploymentTimestamp": 1779797878615,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265746,
+            "deploymentTimestamp": 1780299782398,
             "deployed": true
         },
         "Ask": {
-            "evmAddress": "0xDBCEE93596d0F6505c0b27381C2336f9243E701A",
-            "version": "2.0.0",
+            "evmAddress": "0x3BDF5293DB9D65Bde8A74706530E206bC74eFE77",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978658,
-            "deploymentTimestamp": 1779725607799,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265748,
+            "deploymentTimestamp": 1780299787177,
             "deployed": true
         },
         "DelegatorsInfo": {
@@ -154,12 +154,12 @@
             "deployed": false
         },
         "RandomSamplingStorage": {
-            "evmAddress": "0xd84640BA70F18527827A3572C8Acf52E10ff5BC5",
-            "version": "3.0.0",
+            "evmAddress": "0x2DB6D9Fd656880f9E435fBA4270575cd1f7c90d1",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978661,
-            "deploymentTimestamp": 1779725612837,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265750,
+            "deploymentTimestamp": 1780299788277,
             "deployed": true
         },
         "Staking": {
@@ -172,21 +172,21 @@
             "deployed": false
         },
         "StakingKPI": {
-            "evmAddress": "0xE474d707326A4e20649266359543372bCaF0C688",
-            "version": "2.0.0",
+            "evmAddress": "0xC1070340690593a513dbDA5982117921c3c3AE9f",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978663,
-            "deploymentTimestamp": 1779725618193,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265751,
+            "deploymentTimestamp": 1780299792971,
             "deployed": true
         },
         "Profile": {
-            "evmAddress": "0xC9059Ea3082a681903815D65901e5CF14C5911D1",
-            "version": "1.3.0",
+            "evmAddress": "0xc4cB76186E562396e17B98ea5A6b1794Fce6e5E4",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978666,
-            "deploymentTimestamp": 1779725623311,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265753,
+            "deploymentTimestamp": 1780299797776,
             "deployed": true
         },
         "KnowledgeCollection": {
@@ -199,12 +199,12 @@
             "deployed": false
         },
         "RandomSampling": {
-            "evmAddress": "0x73AefE8AD301f7eac8c45C1B91A60Ed01BF24B1b",
-            "version": "1.1.0",
+            "evmAddress": "0x950D8E6fa4d0351f73219a300026C35497cd1BF0",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978674,
-            "deploymentTimestamp": 1779725638602,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265761,
+            "deploymentTimestamp": 1780299811977,
             "deployed": true
         },
         "KnowledgeAssetsStorage": {
@@ -226,48 +226,48 @@
             "deployed": false
         },
         "EpochStorageV6": {
-            "evmAddress": "0x6AEbd39161d940bEd38D0031031c84969a97e852",
-            "version": "1.0.0",
+            "evmAddress": "0x5392BcBeadc91EF5CcB4a23662B3DD93e275E635",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978640,
-            "deploymentTimestamp": 1779725571824,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265731,
+            "deploymentTimestamp": 1780299753784,
             "deployed": true
         },
         "ConvictionStakingStorage": {
-            "evmAddress": "0x5AE3dB1AAdd55E001108aFb9195f5B50F2a20787",
-            "version": "4.0.0",
+            "evmAddress": "0x60301ac1C95a4dDbDab502e52CE2E23dFb54d13e",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978653,
-            "deploymentTimestamp": 1779725597804,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265743,
+            "deploymentTimestamp": 1780299777585,
             "deployed": true
         },
         "ContextGraphStorage": {
-            "evmAddress": "0x664209250243b8F6405b33A25198f9829afFCC81",
-            "version": "1.0.0",
+            "evmAddress": "0x9B70896bd3Fc116e413199A198206d0dA8Cd6602",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "d7a79c71628b4ef5495fa31e137812f358129060",
-            "deploymentBlock": 42014796,
-            "deploymentTimestamp": 1779797883397,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265756,
+            "deploymentTimestamp": 1780299802564,
             "deployed": true
         },
         "ContextGraphValueStorage": {
-            "evmAddress": "0x1f28F7Be6f404e319F88b2520b43fcf07eB226Df",
-            "version": "1.0.0",
+            "evmAddress": "0xd965b289fD9E831131BDd0096879E5e96fA2Db1F",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978671,
-            "deploymentTimestamp": 1779725633437,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265758,
+            "deploymentTimestamp": 1780299807242,
             "deployed": true
         },
         "ContextGraphs": {
-            "evmAddress": "0x479b4edd9D42123C296D2b2FEf784F95852f0F2f",
-            "version": "1.0.0",
+            "evmAddress": "0x95eb8d2bb8B8C2EAd581589AAc7C2465f8b7FcF3",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978676,
-            "deploymentTimestamp": 1779725643551,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265763,
+            "deploymentTimestamp": 1780299816671,
             "deployed": true
         },
         "ContextGraphNameRegistry": {
@@ -289,12 +289,12 @@
             "deployed": false
         },
         "DKGPublishingConvictionNFT": {
-            "evmAddress": "0xbd247CFbf198735F152728A367955250018EA3C6",
-            "version": "3.0.0",
+            "evmAddress": "0xc3d4A1BD76eB10C99549e4A155A05A93A360678d",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "d7a79c71628b4ef5495fa31e137812f358129060",
-            "deploymentBlock": 42014804,
-            "deploymentTimestamp": 1779797899640,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265770,
+            "deploymentTimestamp": 1780299831101,
             "deployed": true
         },
         "KnowledgeAssetsV10": {
@@ -304,42 +304,69 @@
             "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
             "deploymentBlock": 41978681,
             "deploymentTimestamp": 1779725653922,
-            "deployed": true
+            "deployed": false
         },
         "StakingV10": {
-            "evmAddress": "0xb5d530709678FA35bD65840018AA33F4434F7b3B",
-            "version": "3.0.0",
+            "evmAddress": "0xD8e0daF736e082F779e7BA62B28e8d7A38A82E7c",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978684,
-            "deploymentTimestamp": 1779725659114,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265778,
+            "deploymentTimestamp": 1780299846566,
             "deployed": true
         },
         "DKGStakingConvictionNFT": {
-            "evmAddress": "0xF49c1C002Ca8D46fb15739Bdd0c7F4f3Db0C84a2",
-            "version": "1.2.0",
+            "evmAddress": "0x44DC019876ce9CF961186Fc4657f71f6786e705C",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "d7a79c71628b4ef5495fa31e137812f358129060",
-            "deploymentBlock": 42014807,
-            "deploymentTimestamp": 1779797904650,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265780,
+            "deploymentTimestamp": 1780299851374,
             "deployed": true
         },
         "PublishingConvictionStorage": {
-            "evmAddress": "0x2621a84446c739251cC2F1d1893E8219f681F422",
-            "version": "1.0.0",
+            "evmAddress": "0x1345AEaf6f4DF612D0902efa9366F8AB8b4c7781",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "d7a79c71628b4ef5495fa31e137812f358129060",
-            "deploymentBlock": 42014799,
-            "deploymentTimestamp": 1779797888597,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265765,
+            "deploymentTimestamp": 1780299821480,
             "deployed": true
         },
         "PublishingConviction": {
-            "evmAddress": "0xAA3809Ab8907834CB34FdcC6536410097011958a",
-            "version": "1.0.0",
+            "evmAddress": "0x8916820Ba089ca2604978acfE9a5E8f56baf5709",
+            "version": "10.0.2",
             "gitBranch": "main",
-            "gitCommitHash": "d7a79c71628b4ef5495fa31e137812f358129060",
-            "deploymentBlock": 42014801,
-            "deploymentTimestamp": 1779797894694,
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265768,
+            "deploymentTimestamp": 1780299826375,
+            "deployed": true
+        },
+        "DKGKnowledgeAssets": {
+            "evmAddress": "0x85a04440645d4a7CF1844cdb9A34C598e2F75b85",
+            "version": "2.0.0",
+            "gitBranch": "main",
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265736,
+            "deploymentTimestamp": 1780299763226,
+            "deployed": true
+        },
+        "KnowledgeAssetsLifecycle": {
+            "evmAddress": "0x7558E9B30BeFA87F68C808c1f705b30507d19146",
+            "version": "2.0.1",
+            "gitBranch": "main",
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265772,
+            "deploymentTimestamp": 1780299836348,
+            "deployed": true
+        },
+        "V8MigrationEligibility": {
+            "evmAddress": "0xF00FA3d29a2d45Fce44324C67C7Eb9C645F3DA1C",
+            "version": "10.0.2",
+            "gitBranch": "main",
+            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
+            "deploymentBlock": 42265775,
+            "deploymentTimestamp": 1780299841721,
             "deployed": true
         }
     }

--- a/packages/evm-module/deployments/base_sepolia_v10_contracts.json
+++ b/packages/evm-module/deployments/base_sepolia_v10_contracts.json
@@ -90,15 +90,6 @@
             "deploymentTimestamp": 1780299758505,
             "deployed": true
         },
-        "KnowledgeCollectionStorage": {
-            "evmAddress": "0x4fCA405d46ADeDD7050420C1937842D2a36a04D8",
-            "version": "1.0.0",
-            "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978645,
-            "deploymentTimestamp": 1779725582201,
-            "deployed": false
-        },
         "PaymasterManager": {
             "evmAddress": "0x073aFC5cDf6e81d2Ccfb66d39E1F1224B39b8F15",
             "version": "1.0.0",
@@ -296,15 +287,6 @@
             "deploymentBlock": 42265770,
             "deploymentTimestamp": 1780299831101,
             "deployed": true
-        },
-        "KnowledgeAssetsV10": {
-            "evmAddress": "0x65dcDD2484F6db18c53Ea9b31541237d7E005566",
-            "version": "10.1.0",
-            "gitBranch": "main",
-            "gitCommitHash": "aa9260311f87e9e5cf7fedea2f9c0d8aa547b641",
-            "deploymentBlock": 41978681,
-            "deploymentTimestamp": 1779725653922,
-            "deployed": false
         },
         "StakingV10": {
             "evmAddress": "0xD8e0daF736e082F779e7BA62B28e8d7A38A82E7c",


### PR DESCRIPTION
## Summary

Phase B of `docs/TESTNET_RESET.md` for the **v10.0.0-rc.12** rollout on Base Sepolia.

- Redeployed every contract in `deploy/active/` except **Hub** (`0xC056e6…09F6`) and **Token** (`0x2A58Bd…82DC8`) — 28 redeployed + `V8MigrationEligibility` freshly deployed.
- Re-registered all 30 addresses in Hub via the batched `setAndReinitializeContracts` call inside `998_initialize_contracts.ts`. Atomic — same deployer EOA holds Hub ownership, no MultiSig handoff needed.
- Sealed `ConvictionStakingStorage.v10LaunchEpoch = 504` via `DKGStakingConvictionNFT.finalizeMigrationBatch(504)` ([tx `0x4c48997c…`](https://sepolia.basescan.org/tx/0x4c48997c6e38598895f3015dd2a77b47c94d63377b6c3fa7fed8ed0dbe9da8bd), gas 87553).
- Bumped `network/testnet.json#chainResetMarker` from `v10-rc11-pca-split-2026-05-25` → `v10-rc12-ka-rename-2026-06-01`. This is what triggers `chain-reset-wipe.ts` on operator nodes once they pick up the rc.12 daemon — Phase C ([TESTNET_RESET.md](../docs/TESTNET_RESET.md)) is automatic.

## Why redeploy was unavoidable

The KC → KA rename (PR #836) is a **forward-only break** — see `docs/UPGRADE_RC11_TO_RC12.md` and the rc.12 CHANGELOG entry:
- `KnowledgeAssetsV10.sol` + `KnowledgeCollectionStorage.sol` are **deleted**.
- 4-byte selectors changed across `DKGKnowledgeAssets`, `KnowledgeAssetsLifecycle`, and `ContextGraphStorage` (`kcToContextGraph` → `kaToContextGraph`, `registerKnowledgeCollection` → `registerKnowledgeAsset`).
- `Identity` → 1.1.0, `Profile` → 1.4.2, `PublishingConviction` → 1.0.1, `KnowledgeAssetsLifecycle` (KAV10) → 10.1.1 carry logic changes from the V10 hardening pass.

The rc.11 daemon-side fallback resolver (`EVMChainAdapter.init` → `KnowledgeAssetsV10`) was removed in PR #837, so the rc.12 daemon will **refuse to bind** against a Hub that still only exposes the old V10.0 surface. Hence: full redeploy + Hub re-register.

## Key new addresses (Base Sepolia)

The full set is in `packages/evm-module/deployments/base_sepolia_v10_contracts.json`. Highlights:

| Contract | Address | `version()` |
|---|---|---|
| `KnowledgeAssetsLifecycle` | `0x7558E9B30BeFA87F68C808c1f705b30507d19146` | 2.0.1 |
| `DKGKnowledgeAssets` (asset storage) | `0x85a04440645d4a7CF1844cdb9A34C598e2F75b85` | 2.0.0 |
| `ContextGraphStorage` (asset storage) | `0x9B70896bd3Fc116e413199A198206d0dA8Cd6602` | 10.0.2 |
| `ContextGraphs` | `0x95eb8d2bb8B8C2EAd581589AAc7C2465f8b7FcF3` | 10.0.2 |
| `Identity` | `0x1Cb0f89674E7AA777ceD184A1b5998A62378543c` | 10.0.2 |
| `Profile` | `0xc4cB76186E562396e17B98ea5A6b1794Fce6e5E4` | 10.0.2 |
| `PublishingConviction` | `0x8916820Ba089ca2604978acfE9a5E8f56baf5709` | 10.0.2 |
| `PublishingConvictionStorage` | `0x1345AEaf6f4DF612D0902efa9366F8AB8b4c7781` | 10.0.2 |
| `RandomSampling` | `0x950D8E6fa4d0351f73219a300026C35497cd1BF0` | 10.0.2 |
| `StakingV10` | `0xD8e0daF736e082F779e7BA62B28e8d7A38A82E7c` | 10.0.2 |
| `DKGStakingConvictionNFT` | `0x44DC019876ce9CF961186Fc4657f71f6786e705C` | 10.0.2 |
| `DKGPublishingConvictionNFT` | `0xc3d4A1BD76eB10C99549e4A155A05A93A360678d` | 10.0.2 |

All ten critical Hub registrations verified on-chain via `Hub.getContractAddress` / `getAssetStorageAddress`.

Stale Hub entries for `KnowledgeAssetsV10` (`0x65dcDD24…`) and `KnowledgeCollectionStorage` (`0x4fCA405d…`) remain pointing at the rc.11 contracts but the rc.12 daemon never looks them up, so they are harmless leftovers.

## Test plan

- [x] Pre-flight: `Hub.owner() == deployer EOA`, deployer has 8.44 ETH on Base Sepolia, chainId 84532 confirmed.
- [x] `pnpm install --frozen-lockfile` + `hardhat compile` clean against rc.12 sources.
- [x] `hardhat deploy --network base_sepolia_v10` ran clean (~2 min, ~45 txs, exit 0). Final batched `setAndReinitializeContracts` lands all 27 contracts + 2 asset-storage contracts in one tx.
- [x] On-chain `Hub.getContractAddress` for every renamed/version-bumped contract matches the JSON entry.
- [x] `version()` reads cleanly on `KnowledgeAssetsLifecycle`, `Identity`, `Profile`, `PublishingConviction`, `DKGKnowledgeAssets`.
- [x] `ConvictionStakingStorage.v10LaunchEpoch == 504` after `finalizeMigrationBatch(504)`.
- [ ] After this PR merges + `v10.0.0-rc.12` is tagged + npm published, beacons (`178.104.54.178`, `157.180.37.169`, `178.156.252.147`, `49.12.4.64`) auto-update within ≤5 min and Phase C wipe fires on respawn.
- [ ] Post-rollout RS smoke (`scripts/devnet-test-random-sampling.sh` pointed at a beacon) returns `score > 0`.

Deploy log preserved at `.rc12-testnet-deploy/deploy-20260601T094153Z.log` (gitignored).


Made with [Cursor](https://cursor.com)