### PR TITLE
fix(node-ui): WM Assertions subtab empty after #844 (derive list from _meta)

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1,3 +1,5 @@
+import { subGraphFromAssertionGraphUri } from './lib/sub-graph-uri.js';
+
 const BASE = '';
 declare global {
   interface Window { __DKG_TOKEN__?: string; }
@@ -703,12 +705,13 @@ export async function listAssertions(
   // the SWM branch and what promote/preview lookups key on (name + subGraph).
   const DKG = 'http://dkg.io/ontology/';
   const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
-  const sparql = `SELECT DISTINCT ?assertion ?name ?sg WHERE {
+  const sparql = `SELECT DISTINCT ?assertion ?name ?sg ?assertionGraph WHERE {
     GRAPH <${metaGraph}> {
       ?assertion a <${DKG}Assertion> ;
                  <${DKG}memoryLayer> "WM" ;
                  <${DKG}assertionName> ?name .
       OPTIONAL { ?assertion <${DKG}subGraphName> ?sg }
+      OPTIONAL { ?assertion <${DKG}assertionGraph> ?assertionGraph }
     }
   }`;
   const data = await executeQuery(sparql, contextGraphId);
@@ -719,10 +722,21 @@ export async function listAssertions(
     const lifecycle = bv(b.assertion);
     const name = bv(b.name);
     if (!lifecycle || !name) continue;
-    // `dkg:subGraphName` is emitted by the lifecycle writer only for
-    // sub-graph-scoped assertions (#710), so its presence is the
-    // authoritative sub-graph signal; undefined → root bucket.
-    const subGraph = bv(b.sg) || undefined;
+    // Sub-graph scope: prefer the explicit `dkg:subGraphName` literal
+    // (emitted by the lifecycle writer for sub-graph-scoped assertions
+    // since #710). Drafts created BEFORE #710 carry `dkg:assertionGraph`
+    // but NO `dkg:subGraphName`, so fall back to parsing the sub-graph
+    // segment out of the assertion-graph URI — same migration fallback
+    // the lifecycle hook uses (`subGraphFromAssertionGraphUri`). Without
+    // it, a pre-#710 sub-graph draft would surface as root-bucket and
+    // mis-scope promote/preview lookups.
+    const assertionGraph = bv(b.assertionGraph);
+    const subGraph =
+      bv(b.sg) ||
+      (assertionGraph
+        ? subGraphFromAssertionGraphUri(assertionGraph, contextGraphId)
+        : undefined) ||
+      undefined;
     if (seen.has(lifecycle)) continue;
     seen.add(lifecycle);
     // Mirror the SWM branch: no per-assertion triple count (the data-graph

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -679,43 +679,57 @@ export async function listAssertions(
   }
 
   // layer === 'wm'
-  const sparql = `SELECT DISTINCT ?g (COUNT(?s) AS ?cnt) WHERE { GRAPH ?g { ?s ?p ?o } } GROUP BY ?g`;
+  //
+  // #844 regression fix — the prior WM listing enumerated data graphs via
+  // `SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }`. Merge #844 gated
+  // that whole-store `GRAPH ?g` enumeration in the WM view behind the
+  // `includeContextGraphPartitions` flag (which `listAssertions` does not
+  // set), so the WM view returned no assertion data-graphs and the
+  // Assertions subtab went empty.
+  //
+  // Derive WM assertions from the `<cg>/_meta` lifecycle graph instead —
+  // the same source of truth the SWM branch uses (just `_meta` rather than
+  // `_shared_memory_meta`). Each WM assertion is recorded by
+  // `generateAssertionCreatedMetadata` as a `dkg:Assertion` entity carrying
+  // `dkg:assertionName`, `dkg:assertionGraph`, and a MUTABLE
+  // `dkg:memoryLayer` literal whose value is the assertion's CURRENT layer.
+  // `MemoryLayer.WorkingMemory` is `"WM"`; on promote the lifecycle writer
+  // flips it to `"SWM"` — so filtering on `dkg:memoryLayer "WM"` yields
+  // exactly the not-yet-promoted assertions (promoted ones correctly drop
+  // out of the WM list). The explicit `GRAPH <…/_meta> { … }` makes the
+  // query self-scoping (the engine's `wrapWithGraph` early-returns when the
+  // SPARQL already names a graph), so it runs raw — same shape as the SWM
+  // branch above. `graphUri` is the lifecycle URN (`?assertion`), matching
+  // the SWM branch and what promote/preview lookups key on (name + subGraph).
+  const DKG = 'http://dkg.io/ontology/';
+  const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
+  const sparql = `SELECT DISTINCT ?assertion ?name ?sg WHERE {
+    GRAPH <${metaGraph}> {
+      ?assertion a <${DKG}Assertion> ;
+                 <${DKG}memoryLayer> "WM" ;
+                 <${DKG}assertionName> ?name .
+      OPTIONAL { ?assertion <${DKG}subGraphName> ?sg }
+    }
+  }`;
   const data = await executeQuery(sparql, contextGraphId);
   const bindings: any[] = data?.result?.bindings ?? [];
-  // #706 fix — the prior `startsWith('did:dkg:context-graph:<cg>/assertion/')`
-  // shape silently dropped sub-graph-scoped WM assertions, whose graph
-  // URI is `did:dkg:context-graph:<cg>/<sg>/assertion/<agent>/<name>`
-  // (the sub-graph segment sits between `<cg>/` and `/assertion/`).
-  // We accept exactly two shapes, post-cgPrefix:
-  //   root-bucket : ['assertion', <agent>, <name>]            (3 segs)
-  //   sub-graph   : [<subGraphName>, 'assertion', <agent>, <name>] (4 segs)
-  // Anything else (extra segments on either side, internal meta
-  // graphs sharing the prefix, etc.) is silently dropped. The parse
-  // is deliberately strict so a row never gets admitted with a
-  // mis-derived name — promote/preview lookups key on `name` and
-  // would silently miss otherwise. The cgId itself is treated as
-  // opaque (it may contain `/assertion/` as a literal substring,
-  // per `validateContextGraphId`).
-  const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
+  const seen = new Set<string>();
   const result: AssertionInfo[] = [];
   for (const b of bindings) {
-    const g = typeof b.g === 'string' ? b.g : b.g?.value;
-    if (!g || !g.startsWith(cgPrefix)) continue;
-    const segments = g.slice(cgPrefix.length).split('/');
-    let subGraph: string | undefined;
-    let name: string;
-    if (segments.length === 3 && segments[0] === 'assertion') {
-      subGraph = undefined;
-      name = segments[2];
-    } else if (segments.length === 4 && segments[1] === 'assertion') {
-      subGraph = segments[0];
-      name = segments[3];
-    } else {
-      continue;
-    }
-    if (!name) continue;
-    const cnt = typeof b.cnt === 'string' ? parseInt(b.cnt, 10) : (b.cnt?.value ? parseInt(b.cnt.value, 10) : undefined);
-    result.push({ name, graphUri: g, tripleCount: Number.isFinite(cnt) ? cnt : undefined, subGraph });
+    const lifecycle = bv(b.assertion);
+    const name = bv(b.name);
+    if (!lifecycle || !name) continue;
+    // `dkg:subGraphName` is emitted by the lifecycle writer only for
+    // sub-graph-scoped assertions (#710), so its presence is the
+    // authoritative sub-graph signal; undefined → root bucket.
+    const subGraph = bv(b.sg) || undefined;
+    if (seen.has(lifecycle)) continue;
+    seen.add(lifecycle);
+    // Mirror the SWM branch: no per-assertion triple count (the data-graph
+    // COUNT was exactly the gated enumeration; the renderer already guards
+    // `tripleCount != null`, so the count chip is simply omitted for WM —
+    // consistent with SWM rows).
+    result.push({ name, graphUri: lifecycle, subGraph });
   }
   return result;
 }

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -18,9 +18,20 @@ import { listAssertions } from '../src/ui/api.js';
 // parser code-path under test verbatim. Same pattern as
 // `use-swm-attributions.test.ts` from the prior round.
 
-function bRow(g: string, cnt: number) {
-  // Daemon's SPARQL JSON-binding shape: object with `value`.
-  return { g: { value: g }, cnt: { value: String(cnt) } };
+// #844 fix — WM listing now derives from the `<cg>/_meta` lifecycle graph
+// (filtering on `dkg:memoryLayer "WM"`) rather than enumerating data graphs,
+// because #844 gated the WM view's `GRAPH ?g` enumeration. The SPARQL applies
+// the `"WM"` filter server-side, so a mocked response represents rows the
+// daemon already filtered to WM; these fixtures exercise the JS mapping
+// (binding → {name, graphUri, subGraph}, dedup, skip-incomplete).
+//
+// Binding shape mirrors the new SELECT: ?assertion (lifecycle URN, used as
+// graphUri), ?name (dkg:assertionName), optional ?sg (dkg:subGraphName).
+function metaRow(opts: { assertion: string; name?: string; sg?: string }) {
+  const b: Record<string, { value: string }> = { assertion: { value: opts.assertion } };
+  if (opts.name !== undefined) b.name = { value: opts.name };
+  if (opts.sg !== undefined) b.sg = { value: opts.sg };
+  return b;
 }
 
 function jsonResponse(body: unknown) {
@@ -31,7 +42,7 @@ function jsonResponse(body: unknown) {
   } as any;
 }
 
-describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
+describe('listAssertions (WM) — derives from _meta (memoryLayer="WM")', () => {
   let originalFetch: typeof globalThis.fetch | undefined;
   let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -51,27 +62,34 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
     );
   }
 
-  it('parses root-bucket assertion: name extracted, subGraph undefined', async () => {
+  it('queries the <cg>/_meta graph filtered to memoryLayer "WM"', async () => {
     setBindings([
-      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5),
+      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:notes', name: 'notes' }),
+    ]);
+    await listAssertions('cg-A', 'wm');
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.sparql).toContain('did:dkg:context-graph:cg-A/_meta');
+    expect(body.sparql).toContain('memoryLayer> "WM"');
+    expect(body.sparql).toContain('assertionName');
+  });
+
+  it('maps a root-bucket WM assertion: name + lifecycle-URN graphUri, subGraph undefined', async () => {
+    setBindings([
+      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:notes', name: 'notes' }),
     ]);
     const out = await listAssertions('cg-A', 'wm');
     expect(out).toHaveLength(1);
     expect(out[0]).toMatchObject({
       name: 'notes',
-      graphUri: 'did:dkg:context-graph:cg-A/assertion/0xabc/notes',
-      tripleCount: 5,
+      graphUri: 'urn:dkg:assertion:cg-A:0xabc:notes',
       subGraph: undefined,
     });
   });
 
-  it('parses sub-graph-scoped + root in the same response (#706 regression guard)', async () => {
-    // Both shapes must surface. Pre-fix, the `startsWith(…/assertion/)`
-    // filter silently dropped sub-graph rows entirely; this test
-    // pins that they're surfaced AND that the slug + name parse out.
+  it('surfaces sub-graph-scoped + root rows; subGraph comes from dkg:subGraphName (#710)', async () => {
     setBindings([
-      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/root-doc', 3),
-      bRow('did:dkg:context-graph:cg-A/research/assertion/0xabc/scoped-doc', 7),
+      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:root-doc', name: 'root-doc' }),
+      metaRow({ assertion: 'urn:dkg:assertion:cg-A:research:0xabc:scoped-doc', name: 'scoped-doc', sg: 'research' }),
     ]);
     const out = await listAssertions('cg-A', 'wm');
     expect(out).toHaveLength(2);
@@ -79,98 +97,41 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
     const scoped = out.find(a => a.name === 'scoped-doc')!;
     expect(root.subGraph).toBeUndefined();
     expect(scoped.subGraph).toBe('research');
-    expect(scoped.tripleCount).toBe(7);
+    expect(scoped.graphUri).toBe('urn:dkg:assertion:cg-A:research:0xabc:scoped-doc');
   });
 
-  it('silently drops malformed graph URIs that lack `/assertion/`', async () => {
-    // E.g. internal meta graphs, prefix-only matches, or any future
-    // graph layout that shares the CG prefix but isn't an assertion.
+  it('skips bindings missing the lifecycle URN or the name', async () => {
     setBindings([
-      bRow('did:dkg:context-graph:cg-A/_meta', 12),
-      bRow('did:dkg:context-graph:cg-A/research', 1),
-      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/real', 4),
+      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:real', name: 'real' }),
+      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:noname' }), // no ?name → skipped
+      { name: { value: 'orphan' } } as any,                          // no ?assertion → skipped
     ]);
     const out = await listAssertions('cg-A', 'wm');
     expect(out).toHaveLength(1);
     expect(out[0].name).toBe('real');
   });
 
-  it('scopes by cgPrefix — only the queried cgId surfaces', async () => {
-    // Multi-CG responses can arise if the SPARQL is run against a
-    // wider store. The `startsWith(cgPrefix)` filter must reject
-    // bindings from other CGs. Note: the prefix is
-    // `did:dkg:context-graph:cg-A/` (trailing slash); a CG named
-    // `cg-A-suffix` has prefix `…cg-A-suffix/` which does NOT
-    // startsWith the queried prefix.
+  it('dedups repeated lifecycle URNs (e.g. multiple events for one assertion) to the first', async () => {
     setBindings([
-      bRow('did:dkg:context-graph:cg-OTHER/assertion/0xabc/other', 2),
-      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/mine', 6),
-      bRow('did:dkg:context-graph:cg-A-suffix/assertion/0xabc/foo', 1),
+      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:dup', name: 'dup' }),
+      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:dup', name: 'dup' }),
     ]);
     const out = await listAssertions('cg-A', 'wm');
     expect(out).toHaveLength(1);
-    expect(out[0].name).toBe('mine');
+    expect(out[0].name).toBe('dup');
   });
 
-  it('returns an empty list when no bindings match the cg-prefix + /assertion/ filter', async () => {
+  it('does NOT set tripleCount (renderer guards tripleCount != null; mirrors SWM)', async () => {
     setBindings([
-      bRow('did:dkg:context-graph:cg-B/assertion/0xabc/foo', 1),
+      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:notes', name: 'notes' }),
     ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out[0].tripleCount).toBeUndefined();
+  });
+
+  it('returns an empty list when _meta has no WM assertions', async () => {
+    setBindings([]);
     const out = await listAssertions('cg-A', 'wm');
     expect(out).toEqual([]);
-  });
-
-  it('drops bindings with 3+ segments before `assertion/` (left-side strict shape)', async () => {
-    // Reviewer-flagged case: a binding like `<cg>/foo/bar/assertion/<a>/<n>`
-    // doesn't match either accepted shape (root = 3 segs, sub-graph =
-    // 4 segs). The prior `indexOf('/assertion/')` branch admitted it
-    // as a `subGraph: undefined` row with a mis-derived name —
-    // promote/preview lookups would silently miss. Strict-shape parse
-    // drops it.
-    setBindings([
-      bRow('did:dkg:context-graph:cg-A/foo/bar/assertion/0xabc/baz', 9),
-      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/keep', 1),
-    ]);
-    const out = await listAssertions('cg-A', 'wm');
-    expect(out).toHaveLength(1);
-    expect(out[0].name).toBe('keep');
-  });
-
-  it('drops bindings with extra segments after the name (right-side strict shape)', async () => {
-    // Pins the right-side strict-shape contract. The sub-graph branch
-    // expects exactly `<sg>/assertion/<agent>/<name>` — anything
-    // longer would mis-extract the name and orphan the row from
-    // promote/preview.
-    setBindings([
-      bRow('did:dkg:context-graph:cg-A/sg/assertion/0xabc/foo/extra', 2),
-      bRow('did:dkg:context-graph:cg-A/sg/assertion/0xabc/clean', 3),
-    ]);
-    const out = await listAssertions('cg-A', 'wm');
-    expect(out).toHaveLength(1);
-    expect(out[0]).toMatchObject({
-      name: 'clean',
-      subGraph: 'sg',
-      tripleCount: 3,
-    });
-  });
-
-  it('scopes the /assertion/ discriminator to the tail when cgId itself contains "/assertion/"', async () => {
-    // PR #710 reviewer guard — `validateContextGraphId` permits
-    // slashes, so a cgId can literally contain `/assertion/` as a
-    // substring. The prior `g.indexOf('/assertion/')` (full URI)
-    // would have hit the cgId's internal `/assertion/` and
-    // mis-sliced the name. After tail-scoping the parse, the cgId
-    // is treated as opaque and only the tail's `/assertion/`
-    // delimiter is consulted.
-    setBindings([
-      bRow('did:dkg:context-graph:weird/assertion/cg/assertion/0xabc/foo', 4),
-    ]);
-    const out = await listAssertions('weird/assertion/cg', 'wm');
-    expect(out).toHaveLength(1);
-    expect(out[0]).toMatchObject({
-      name: 'foo',
-      subGraph: undefined,
-      tripleCount: 4,
-    });
   });
 });

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -27,10 +27,11 @@ import { listAssertions } from '../src/ui/api.js';
 //
 // Binding shape mirrors the new SELECT: ?assertion (lifecycle URN, used as
 // graphUri), ?name (dkg:assertionName), optional ?sg (dkg:subGraphName).
-function metaRow(opts: { assertion: string; name?: string; sg?: string }) {
+function metaRow(opts: { assertion: string; name?: string; sg?: string; assertionGraph?: string }) {
   const b: Record<string, { value: string }> = { assertion: { value: opts.assertion } };
   if (opts.name !== undefined) b.name = { value: opts.name };
   if (opts.sg !== undefined) b.sg = { value: opts.sg };
+  if (opts.assertionGraph !== undefined) b.assertionGraph = { value: opts.assertionGraph };
   return b;
 }
 
@@ -71,6 +72,8 @@ describe('listAssertions (WM) — derives from _meta (memoryLayer="WM")', () => 
     expect(body.sparql).toContain('did:dkg:context-graph:cg-A/_meta');
     expect(body.sparql).toContain('memoryLayer> "WM"');
     expect(body.sparql).toContain('assertionName');
+    // assertionGraph is bound again (pre-#710 sub-graph fallback).
+    expect(body.sparql).toContain('assertionGraph');
   });
 
   it('maps a root-bucket WM assertion: name + lifecycle-URN graphUri, subGraph undefined', async () => {
@@ -98,6 +101,48 @@ describe('listAssertions (WM) — derives from _meta (memoryLayer="WM")', () => 
     expect(root.subGraph).toBeUndefined();
     expect(scoped.subGraph).toBe('research');
     expect(scoped.graphUri).toBe('urn:dkg:assertion:cg-A:research:0xabc:scoped-doc');
+  });
+
+  it('pre-#710 compat: derives subGraph from the assertionGraph URI when subGraphName is absent', async () => {
+    // Drafts created before #710 carry dkg:assertionGraph but NO
+    // dkg:subGraphName. The sub-graph segment must be recovered from the
+    // assertion-graph URI so promote/preview stay correctly scoped.
+    setBindings([
+      metaRow({
+        assertion: 'urn:dkg:assertion:cg-A:legacy:0xabc:old-scoped',
+        name: 'old-scoped',
+        // no `sg` — pre-#710 row
+        assertionGraph: 'did:dkg:context-graph:cg-A/legacy/assertion/0xabc/old-scoped',
+      }),
+      // Root-bucket legacy row (assertionGraph has no sub-graph segment) →
+      // stays root, NOT misparsed.
+      metaRow({
+        assertion: 'urn:dkg:assertion:cg-A:0xabc:old-root',
+        name: 'old-root',
+        assertionGraph: 'did:dkg:context-graph:cg-A/assertion/0xabc/old-root',
+      }),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(2);
+    const scoped = out.find(a => a.name === 'old-scoped')!;
+    const root = out.find(a => a.name === 'old-root')!;
+    expect(scoped.subGraph).toBe('legacy');
+    expect(root.subGraph).toBeUndefined();
+  });
+
+  it('prefers the explicit subGraphName literal over the assertionGraph URI parse', async () => {
+    // When both are present, the literal wins (it is authoritative and the
+    // URI parse is only the migration fallback).
+    setBindings([
+      metaRow({
+        assertion: 'urn:dkg:assertion:cg-A:research:0xabc:both',
+        name: 'both',
+        sg: 'research',
+        assertionGraph: 'did:dkg:context-graph:cg-A/research/assertion/0xabc/both',
+      }),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out[0].subGraph).toBe('research');
   });
 
   it('skips bindings missing the lifecycle URN or the name', async () => {


### PR DESCRIPTION
## Summary

The Node UI's Working Memory **Assertions** subtab rendered the empty state ("No Working Memory assertions yet.") even when the WM layer clearly had assertions — a regression introduced when `release/rc.12` was merged into `main`.

- **Root cause:** merge #844 ("Fix RC12 context graph count queries") gated the query engine's whole-store `GRAPH ?g { ?s ?p ?o }` enumeration behind an opt-in `includeContextGraphPartitions` flag. By default the WM view now exposes only the meta graphs (`<cg>/_meta`, `<cg>/_shared_memory_meta`); per-assertion content partitions are no longer enumerated. `useMemoryEntities` was migrated to opt in (so the layer **count badges** stay correct), but **`listAssertions`' WM branch was not** — its `GRAPH ?g` enumeration returned no per-assertion graphs, so every row was filtered out and the list went empty.
- **Fix (frontend, UI-only):** rewrite the WM branch of `listAssertions` to derive the list from the `<cg>/_meta` lifecycle graph, filtering `dkg:memoryLayer "WM"` — the same provenance source the SWM branch already uses (just `_meta` instead of `_shared_memory_meta`). `graphUri` is the assertion lifecycle URN (SWM-consistent, stable across promote; promote/preview key on `name`+`subGraph`). Promoted assertions flip `memoryLayer`→`"SWM"`, so they correctly drop out of the WM list. Sub-graph assertions (#710) are preserved via the authoritative `dkg:subGraphName` predicate.
- **No daemon change** — the #844 gate is intentional (CG-scope isolation). WM rows show no triple-count chip (consistent with SWM rows; the old count came from the now-gated enumeration and the renderer already hides the chip when absent).

## Related

- Regression from #844 (merged into `main`).
- Supersedes the `GRAPH ?g` segment-parse approach from #710 (whose premise #844 removed) while preserving its sub-graph capability.
- No GitHub issue — found during final release testing.

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/api.ts` | Rewrite `listAssertions` WM branch to derive from `<cg>/_meta` (`memoryLayer="WM"`), reusing `bv()`; `graphUri` = lifecycle URN. SWM branch + daemon untouched. |
| `packages/node-ui/test/list-assertions.test.ts` | Rewrite WM fixtures around the `_meta` contract (root-bucket, sub-graph-scoped, dedup, skip-incomplete, lifecycle-URN graphUri, no-tripleCount, empty). |

## Test plan

- [x] node-ui `tsc --noEmit`: 0 errors
- [x] node-ui suite (`--no-file-parallelism`): 1244 passed / 38 skipped / 0 fail (incl. rewritten `list-assertions.test.ts`, 7 cases)
- [x] Live node: new WM query returns **6** assertions for `ui-refresh` (incl. 2 sub-graph rows), **1** for `medical-data`; negative control (old `GRAPH ?g` query) returns only the two meta graphs
- [ ] UI: open a context graph → WM → Assertions: rows populate; promote (root + sub-graph) still resolves; SWM subtab unaffected