### PR TITLE
Fix selected DKG_HOME daemon status detection

### DIFF
--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -127,7 +127,7 @@ export class ApiClient {
   }
 
   async status(): Promise<DaemonStatusResponse> {
-    return this.get('/api/status');
+    return this.get('/api/status', { auth: false });
   }
 
   async agents(): Promise<{
@@ -1499,9 +1499,9 @@ export class ApiClient {
     return { Authorization: `Bearer ${this.token}` };
   }
 
-  private async get<T>(path: string): Promise<T> {
+  private async get<T>(path: string, opts: { auth?: boolean } = {}): Promise<T> {
     const res = await fetch(`${this.baseUrl}${path}`, {
-      headers: this.authHeaders(),
+      headers: opts.auth === false ? {} : this.authHeaders(),
     });
     if (!res.ok) {
       const body = await res.json().catch(() => ({ error: res.statusText }));

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -1,6 +1,7 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
-import { readApiPort, readPid, isProcessRunning, configExists, loadConfig } from './config.js';
+import { readApiPort, readPid, isProcessRunning, configExists, configYamlPath, loadConfig } from './config.js';
 import { loadTokens } from './auth.js';
 
 export type QueryResult =
@@ -79,6 +80,10 @@ function controlPlaneWarning(missingFiles: string[]): string | undefined {
   return `Warning: selected DKG home is missing control-plane file(s): ${missingFiles.join(', ')}. Using configured API port fallback.`;
 }
 
+function statusFallbackConfigExists(): boolean {
+  return configExists() || existsSync(configYamlPath());
+}
+
 function isConnectionFailure(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   if ('httpStatus' in err) return false;
@@ -144,7 +149,7 @@ export class ApiClient {
 
     if (!port) {
       const pid = await readPid();
-      if (opts.allowConfigFallback && !hasEnvPort && configExists()) {
+      if (opts.allowConfigFallback && !hasEnvPort && statusFallbackConfigExists()) {
         const config = await loadConfig();
         const configuredPort = Number.isFinite(config.apiPort) && config.apiPort > 0 ? config.apiPort : null;
         if (configuredPort) {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -77,16 +77,47 @@ function controlPlaneWarning(missingFiles: string[]): string | undefined {
   return `Warning: selected DKG home is missing control-plane file(s): ${missingFiles.join(', ')}. Using configured API port fallback.`;
 }
 
+function isDaemonStatusResponse(value: unknown): value is DaemonStatusResponse {
+  if (!value || typeof value !== 'object') return false;
+  const status = value as Record<string, unknown>;
+  return typeof status.name === 'string'
+    && typeof status.peerId === 'string'
+    && typeof status.uptimeMs === 'number'
+    && Number.isFinite(status.uptimeMs)
+    && typeof status.connectedPeers === 'number'
+    && Number.isFinite(status.connectedPeers)
+    && typeof status.relayConnected === 'boolean'
+    && Array.isArray(status.multiaddrs)
+    && status.multiaddrs.every(addr => typeof addr === 'string');
+}
+
+function requireDaemonStatusResponse(value: unknown, expectedName?: string): DaemonStatusResponse {
+  if (!isDaemonStatusResponse(value)) {
+    throw new Error('Configured API port did not return a DKG daemon status response.');
+  }
+  if (expectedName && value.name !== expectedName) {
+    throw new Error(
+      `Configured API port responded as DKG node "${value.name}", expected selected home node "${expectedName}".`,
+    );
+  }
+  return value;
+}
+
 export class ApiClient {
   private baseUrl: string;
   private token?: string;
+  private expectedStatusName?: string;
   readonly controlPlaneWarning?: string;
 
-  constructor(portOrBaseUrl: number | string, token?: string, opts?: { controlPlaneWarning?: string }) {
+  constructor(portOrBaseUrl: number | string, token?: string, opts?: {
+    controlPlaneWarning?: string;
+    expectedStatusName?: string;
+  }) {
     this.baseUrl = typeof portOrBaseUrl === 'number'
       ? `http://127.0.0.1:${portOrBaseUrl}`
       : portOrBaseUrl.replace(/\/+$/, '');
     this.token = token;
+    this.expectedStatusName = opts?.expectedStatusName;
     this.controlPlaneWarning = opts?.controlPlaneWarning;
   }
 
@@ -99,6 +130,7 @@ export class ApiClient {
     const filePort = hasEnvPort ? null : await readApiPort();
     let port = envPort ?? filePort;
     let warning: string | undefined;
+    let expectedStatusName: string | undefined;
 
     if (!port) {
       const pid = await readPid();
@@ -108,6 +140,7 @@ export class ApiClient {
         if (configuredPort) {
           const missingFiles = ['api.port', ...(pid ? [] : ['daemon.pid'])];
           port = configuredPort;
+          expectedStatusName = config.name;
           warning = controlPlaneWarning(missingFiles);
         }
       }
@@ -123,11 +156,12 @@ export class ApiClient {
 
     const tokens = await loadTokens();
     const token = tokens.size > 0 ? tokens.values().next().value : undefined;
-    return new ApiClient(port, token, { controlPlaneWarning: warning });
+    return new ApiClient(port, token, { controlPlaneWarning: warning, expectedStatusName });
   }
 
   async status(): Promise<DaemonStatusResponse> {
-    return this.get('/api/status', { auth: false });
+    const status = await this.get<unknown>('/api/status', { auth: false });
+    return requireDaemonStatusResponse(status, this.expectedStatusName);
   }
 
   async agents(): Promise<{

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -73,10 +73,15 @@ export interface ApiClientConnectOptions {
 }
 
 const DAEMON_NOT_RUNNING_MESSAGE = 'Daemon is not running. Start it with: dkg start';
+const DEFAULT_NODE_NAME = 'dkg-node';
 
 function controlPlaneWarning(missingFiles: string[]): string | undefined {
   if (missingFiles.length === 0) return undefined;
   return `Warning: selected DKG home is missing control-plane file(s): ${missingFiles.join(', ')}. Using configured API port fallback.`;
+}
+
+function isAmbiguousFallbackName(name: unknown): boolean {
+  return typeof name !== 'string' || name.trim() === '' || name.trim() === DEFAULT_NODE_NAME;
 }
 
 function isConnectionFailure(err: unknown): boolean {
@@ -147,7 +152,7 @@ export class ApiClient {
       if (opts.allowConfigFallback && !hasEnvPort && configExists()) {
         const config = await loadConfig();
         const configuredPort = Number.isFinite(config.apiPort) && config.apiPort > 0 ? config.apiPort : null;
-        if (configuredPort) {
+        if (configuredPort && !isAmbiguousFallbackName(config.name)) {
           const missingFiles = ['api.port', ...(pid ? [] : ['daemon.pid'])];
           port = configuredPort;
           expectedStatusName = config.name;

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -72,9 +72,19 @@ export interface ApiClientConnectOptions {
   allowConfigFallback?: boolean;
 }
 
+const DAEMON_NOT_RUNNING_MESSAGE = 'Daemon is not running. Start it with: dkg start';
+
 function controlPlaneWarning(missingFiles: string[]): string | undefined {
   if (missingFiles.length === 0) return undefined;
   return `Warning: selected DKG home is missing control-plane file(s): ${missingFiles.join(', ')}. Using configured API port fallback.`;
+}
+
+function isConnectionFailure(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  if ('httpStatus' in err) return false;
+  const name = 'name' in err ? String((err as { name?: unknown }).name) : '';
+  const message = 'message' in err ? String((err as { message?: unknown }).message) : '';
+  return name === 'TypeError' && /fetch failed|ECONNREFUSED|ECONNRESET|ENOTFOUND|EAI_AGAIN|terminated/i.test(message);
 }
 
 function isDaemonStatusResponse(value: unknown): value is DaemonStatusResponse {
@@ -149,7 +159,7 @@ export class ApiClient {
     if (!port) {
       const pid = await readPid();
       if (!pid || !isProcessRunning(pid)) {
-        throw new Error('Daemon is not running. Start it with: dkg start');
+        throw new Error(DAEMON_NOT_RUNNING_MESSAGE);
       }
       throw new Error('Cannot read API port. Set DKG_API_PORT or restart: dkg stop && dkg start');
     }
@@ -160,7 +170,15 @@ export class ApiClient {
   }
 
   async status(): Promise<DaemonStatusResponse> {
-    const status = await this.get<unknown>('/api/status', { auth: false });
+    let status: unknown;
+    try {
+      status = await this.get<unknown>('/api/status', { auth: false });
+    } catch (err) {
+      if (this.expectedStatusName && isConnectionFailure(err)) {
+        throw new Error(DAEMON_NOT_RUNNING_MESSAGE);
+      }
+      throw err;
+    }
     return requireDaemonStatusResponse(status, this.expectedStatusName);
   }
 

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
-import { readApiPort, readPid, isProcessRunning } from './config.js';
+import { readApiPort, readPid, isProcessRunning, configExists, loadConfig } from './config.js';
 import { loadTokens } from './auth.js';
 
 export type QueryResult =
@@ -68,23 +68,50 @@ export interface DaemonStatusResponse {
   storeQuads?: number | null;
 }
 
+export interface ApiClientConnectOptions {
+  allowConfigFallback?: boolean;
+}
+
+function controlPlaneWarning(missingFiles: string[]): string | undefined {
+  if (missingFiles.length === 0) return undefined;
+  return `Warning: selected DKG home is missing control-plane file(s): ${missingFiles.join(', ')}. Using configured API port fallback.`;
+}
+
 export class ApiClient {
   private baseUrl: string;
   private token?: string;
+  readonly controlPlaneWarning?: string;
 
-  constructor(portOrBaseUrl: number | string, token?: string) {
+  constructor(portOrBaseUrl: number | string, token?: string, opts?: { controlPlaneWarning?: string }) {
     this.baseUrl = typeof portOrBaseUrl === 'number'
       ? `http://127.0.0.1:${portOrBaseUrl}`
       : portOrBaseUrl.replace(/\/+$/, '');
     this.token = token;
+    this.controlPlaneWarning = opts?.controlPlaneWarning;
   }
 
-  static async connect(): Promise<ApiClient> {
-    const envPort = process.env.DKG_API_PORT
-      ? parseInt(process.env.DKG_API_PORT, 10)
+  static async connect(opts: ApiClientConnectOptions = {}): Promise<ApiClient> {
+    const hasEnvPort = process.env.DKG_API_PORT !== undefined && process.env.DKG_API_PORT !== '';
+    const envPort = hasEnvPort
+      ? parseInt(process.env.DKG_API_PORT as string, 10)
       : null;
 
-    let port = envPort ?? (await readApiPort());
+    const filePort = hasEnvPort ? null : await readApiPort();
+    let port = envPort ?? filePort;
+    let warning: string | undefined;
+
+    if (!port) {
+      const pid = await readPid();
+      if (opts.allowConfigFallback && !hasEnvPort && configExists()) {
+        const config = await loadConfig();
+        const configuredPort = Number.isFinite(config.apiPort) && config.apiPort > 0 ? config.apiPort : null;
+        if (configuredPort) {
+          const missingFiles = ['api.port', ...(pid ? [] : ['daemon.pid'])];
+          port = configuredPort;
+          warning = controlPlaneWarning(missingFiles);
+        }
+      }
+    }
 
     if (!port) {
       const pid = await readPid();
@@ -96,7 +123,7 @@ export class ApiClient {
 
     const tokens = await loadTokens();
     const token = tokens.size > 0 ? tokens.values().next().value : undefined;
-    return new ApiClient(port, token);
+    return new ApiClient(port, token, { controlPlaneWarning: warning });
   }
 
   async status(): Promise<DaemonStatusResponse> {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -1,7 +1,6 @@
-import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
-import { readApiPort, readPid, isProcessRunning, configExists, configYamlPath, loadConfig } from './config.js';
+import { readApiPort, readPid, isProcessRunning, configExists, loadConfig } from './config.js';
 import { loadTokens } from './auth.js';
 
 export type QueryResult =
@@ -80,10 +79,6 @@ function controlPlaneWarning(missingFiles: string[]): string | undefined {
   return `Warning: selected DKG home is missing control-plane file(s): ${missingFiles.join(', ')}. Using configured API port fallback.`;
 }
 
-function statusFallbackConfigExists(): boolean {
-  return configExists() || existsSync(configYamlPath());
-}
-
 function isConnectionFailure(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   if ('httpStatus' in err) return false;
@@ -149,7 +144,7 @@ export class ApiClient {
 
     if (!port) {
       const pid = await readPid();
-      if (opts.allowConfigFallback && !hasEnvPort && statusFallbackConfigExists()) {
+      if (opts.allowConfigFallback && !hasEnvPort && configExists()) {
         const config = await loadConfig();
         const configuredPort = Number.isFinite(config.apiPort) && config.apiPort > 0 ? config.apiPort : null;
         if (configuredPort) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1225,7 +1225,7 @@ program
   .description('Show node status')
   .action(async () => {
     try {
-      const client = await ApiClient.connect();
+      const client = await ApiClient.connect({ allowConfigFallback: true });
       const s = await client.status();
       const uptime = formatUptime(s.uptimeMs);
       console.log(`  Node:      ${s.name}`);
@@ -1249,6 +1249,7 @@ program
       } else {
         console.log(`  Store:     ${backend}`);
       }
+      if (client.controlPlaneWarning) console.warn(client.controlPlaneWarning);
     } catch (err) {
       console.error(toErrorMessage(err));
       process.exit(1);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -407,6 +407,14 @@ function probeHostForApiHost(apiHost: string | undefined): string {
   return apiHost;
 }
 
+function selectedDkgHomeForEnv(env: NodeJS.ProcessEnv): string {
+  return resolveDkgConfigHome({ env, isDkgMonorepo: isDkgMonorepo() });
+}
+
+function withSelectedDkgHome(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return { ...env, DKG_HOME: selectedDkgHomeForEnv(env) };
+}
+
 /**
  * Wire up the supervisor-liveness watchdog for a spawned worker child.
  *
@@ -474,6 +482,7 @@ async function maybeStartSupervisorLivenessWatcher(
 }
 
 async function runDaemonSupervisor(): Promise<void> {
+  process.env.DKG_HOME = selectedDkgHomeForEnv(process.env);
   const maxCrashRestarts = 5;
   let crashRestartCount = 0;
 
@@ -488,7 +497,7 @@ async function runDaemonSupervisor(): Promise<void> {
       [...process.execArgv, resolveDaemonEntryPoint(), 'daemon-worker'],
       {
         stdio: ['ignore', 'ignore', 'ignore'],
-        env: process.env,
+        env: withSelectedDkgHome(process.env),
       },
     );
 
@@ -1131,7 +1140,7 @@ program
     // declaration order first.
     const relayPreferredOpt = Array.isArray(opts.relayPreferred) ? (opts.relayPreferred as string[]) : [];
     const cleanedRelayPreferred = relayPreferredOpt.map((s) => s.trim()).filter((s) => s.length > 0);
-    const daemonEnv: NodeJS.ProcessEnv = { ...process.env };
+    const daemonEnv: NodeJS.ProcessEnv = withSelectedDkgHome(process.env);
     if (cleanedRelayPreferred.length > 0) {
       daemonEnv.DKG_RELAY_PREFERRED = cleanedRelayPreferred.join(',');
       console.log(

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,6 +28,7 @@ import {
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
+  readNodeRoleFromConfigSync,
   type AutoUpdateConfig,
 } from './config.js';
 import { ApiClient } from './api-client.js';
@@ -357,29 +358,6 @@ async function loadQuadsFromInput(
 }
 
 /**
- * Synchronous best-effort read of `~/.dkg/config.json#nodeRole`. Used
- * by {@link resolveDaemonEntryPoint} which runs from supervisor /
- * spawn paths that cannot afford an async config load.
- *
- * Returns `'edge'` on any failure (default role) so a malformed or
- * missing config does NOT silently keep Edge nodes pinned to a stale
- * blue-green slot — the worst case is "we try the npm-global entry
- * and let the daemon's own startup error out with a useful message"
- * rather than "we run rc.10 instead of rc.12 because slots survived
- * the upgrade".
- */
-function readNodeRoleSync(): 'edge' | 'core' {
-  try {
-    const configPath = join(dkgDir(), 'config.json');
-    if (!existsSync(configPath)) return 'edge';
-    const parsed = JSON.parse(readFileSync(configPath, 'utf-8')) as { nodeRole?: unknown };
-    return parsed.nodeRole === 'core' ? 'core' : 'edge';
-  } catch {
-    return 'edge';
-  }
-}
-
-/**
  * Resolve the daemon entry point passed to spawned worker processes.
  *
  * OT-RFC-41 §4.1 / Bundle B1a: Edge nodes run from the npm-global
@@ -392,7 +370,7 @@ function readNodeRoleSync(): 'edge' | 'core' {
  */
 function resolveDaemonEntryPoint(): string {
   if (process.env.DKG_NO_BLUE_GREEN) return fileURLToPath(import.meta.url);
-  if (readNodeRoleSync() === 'edge') return fileURLToPath(import.meta.url);
+  if (readNodeRoleFromConfigSync() === 'edge') return fileURLToPath(import.meta.url);
   const rDir = releasesDir();
   if (existsSync(rDir)) {
     const entry = slotEntryPoint(join(rDir, 'current'));

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir, symlink, rename, unlink, readlink } from 'n
 import { join, dirname, basename } from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
 import {
   blueGreenSlotEntryPoint,
   blueGreenSlotReady,
@@ -1093,6 +1094,10 @@ export function configPath(): string {
   return join(dkgDir(), 'config.json');
 }
 
+export function configYamlPath(): string {
+  return join(dkgDir(), 'config.yaml');
+}
+
 export function pidPath(): string {
   return join(dkgDir(), 'daemon.pid');
 }
@@ -1109,13 +1114,23 @@ export async function ensureDkgDir(): Promise<void> {
   await mkdir(dkgDir(), { recursive: true });
 }
 
+function mergePersistedConfig(raw: unknown): DkgConfig {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ...DEFAULT_CONFIG };
+  return { ...DEFAULT_CONFIG, ...(raw as Partial<DkgConfig>) };
+}
+
 export async function loadConfig(): Promise<DkgConfig> {
   try {
     const raw = await readFile(configPath(), 'utf-8');
-    return { ...DEFAULT_CONFIG, ...JSON.parse(raw) };
-  } catch {
-    return { ...DEFAULT_CONFIG };
-  }
+    return mergePersistedConfig(JSON.parse(raw));
+  } catch { /* try YAML fallback */ }
+
+  try {
+    const raw = await readFile(configYamlPath(), 'utf-8');
+    return mergePersistedConfig(yaml.load(raw));
+  } catch { /* fall through to defaults */ }
+
+  return { ...DEFAULT_CONFIG };
 }
 
 // =====================================================================
@@ -1235,7 +1250,7 @@ export async function saveConfig(config: DkgConfig): Promise<void> {
 }
 
 export function configExists(): boolean {
-  return existsSync(configPath());
+  return existsSync(configPath()) || existsSync(configYamlPath());
 }
 
 export async function readPid(): Promise<number | null> {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1123,6 +1123,26 @@ function isEnoent(err: unknown): boolean {
   return !!err && typeof err === 'object' && (err as { code?: unknown }).code === 'ENOENT';
 }
 
+function readPersistedConfigSync(): unknown {
+  if (existsSync(configPath())) {
+    return JSON.parse(readFileSync(configPath(), 'utf-8'));
+  }
+  if (existsSync(configYamlPath())) {
+    return yaml.load(readFileSync(configYamlPath(), 'utf-8'));
+  }
+  return null;
+}
+
+export function readNodeRoleFromConfigSync(): 'edge' | 'core' {
+  try {
+    const parsed = readPersistedConfigSync();
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return 'edge';
+    return (parsed as { nodeRole?: unknown }).nodeRole === 'core' ? 'core' : 'edge';
+  } catch {
+    return 'edge';
+  }
+}
+
 export async function loadConfig(): Promise<DkgConfig> {
   try {
     const raw = await readFile(configPath(), 'utf-8');
@@ -1258,7 +1278,7 @@ export async function saveConfig(config: DkgConfig): Promise<void> {
 }
 
 export function configExists(): boolean {
-  return existsSync(configPath());
+  return existsSync(configPath()) || existsSync(configYamlPath());
 }
 
 export async function readPid(): Promise<number | null> {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1134,7 +1134,9 @@ export async function loadConfig(): Promise<DkgConfig> {
   try {
     const raw = await readFile(configYamlPath(), 'utf-8');
     return mergePersistedConfig(yaml.load(raw));
-  } catch { /* fall through to defaults */ }
+  } catch (err) {
+    if (!isEnoent(err)) throw err;
+  }
 
   return { ...DEFAULT_CONFIG };
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1256,7 +1256,7 @@ export async function saveConfig(config: DkgConfig): Promise<void> {
 }
 
 export function configExists(): boolean {
-  return existsSync(configPath()) || existsSync(configYamlPath());
+  return existsSync(configPath());
 }
 
 export async function readPid(): Promise<number | null> {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1119,11 +1119,17 @@ function mergePersistedConfig(raw: unknown): DkgConfig {
   return { ...DEFAULT_CONFIG, ...(raw as Partial<DkgConfig>) };
 }
 
+function isEnoent(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as { code?: unknown }).code === 'ENOENT';
+}
+
 export async function loadConfig(): Promise<DkgConfig> {
   try {
     const raw = await readFile(configPath(), 'utf-8');
     return mergePersistedConfig(JSON.parse(raw));
-  } catch { /* try YAML fallback */ }
+  } catch (err) {
+    if (!isEnoent(err)) throw err;
+  }
 
   try {
     const raw = await readFile(configYamlPath(), 'utf-8');

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -117,7 +117,7 @@ describe('ApiClient', () => {
       expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
     });
 
-    it('connect() can use a yaml-only selected home config for status when control-plane files are missing', async () => {
+    it('connect() does not use yaml-only selected home config for status fallback', async () => {
       process.env.DKG_HOME = tempDir;
       delete process.env.DKG_API_PORT;
       await writeFile(join(tempDir, 'config.yaml'), 'name: isolated\napiPort: 9317\n', 'utf8');
@@ -126,15 +126,9 @@ describe('ApiClient', () => {
       const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body });
       globalThis.fetch = fetch;
 
-      const connected = await ApiClient.connect({ allowConfigFallback: true });
-      const result = await connected.status();
-
-      expect(result).toEqual(body);
-      expect(connected.controlPlaneWarning).toContain('api.port');
-      expect(connected.controlPlaneWarning).toContain('daemon.pid');
-      expect(calls).toHaveLength(1);
-      expect(calls[0].url).toBe('http://127.0.0.1:9317/api/status');
-      expect((calls[0].opts.headers as any).Authorization).toBeUndefined();
+      await expect(ApiClient.connect({ allowConfigFallback: true }))
+        .rejects.toThrow('Daemon is not running. Start it with: dkg start');
+      expect(calls).toHaveLength(0);
       expect(existsSync(join(tempDir, 'api.port'))).toBe(false);
       expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
     });

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -139,6 +139,22 @@ describe('ApiClient', () => {
       expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
     });
 
+    it('connect() refuses config fallback when selected home has the default node name', async () => {
+      process.env.DKG_HOME = tempDir;
+      delete process.env.DKG_API_PORT;
+      await writeFile(join(tempDir, 'config.json'), JSON.stringify({ name: 'dkg-node', apiPort: 9317 }));
+      await writeFile(join(tempDir, 'auth.token'), 'local-token\n', 'utf8');
+      const body = { name: 'dkg-node', peerId: 'peer1', uptimeMs: 1000, connectedPeers: 2, relayConnected: true, multiaddrs: [] };
+      const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body });
+      globalThis.fetch = fetch;
+
+      await expect(ApiClient.connect({ allowConfigFallback: true }))
+        .rejects.toThrow('Daemon is not running. Start it with: dkg start');
+      expect(calls).toHaveLength(0);
+      expect(existsSync(join(tempDir, 'api.port'))).toBe(false);
+      expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
+    });
+
     it('connect() rejects selected home config fallback when status belongs to a different node', async () => {
       process.env.DKG_HOME = tempDir;
       delete process.env.DKG_API_PORT;

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -368,18 +368,18 @@ describe('ApiClient', () => {
 
   describe('auth headers', () => {
     it('includes Bearer token when set', async () => {
-      const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body: {} });
+      const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body: { agents: [] } });
       globalThis.fetch = fetch;
-      await client.status();
+      await client.agents();
 
       expect((calls[0].opts.headers as any).Authorization).toBe('Bearer test-token');
     });
 
     it('omits Authorization header when no token', async () => {
       const noTokenClient = new ApiClient(PORT);
-      const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body: {} });
+      const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body: { agents: [] } });
       globalThis.fetch = fetch;
-      await noTokenClient.status();
+      await noTokenClient.agents();
 
       expect(calls[0].opts.headers).not.toHaveProperty('Authorization');
     });

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -108,6 +108,22 @@ describe('ApiClient', () => {
       expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
     });
 
+    it('connect() rejects selected home config fallback when status belongs to a different node', async () => {
+      process.env.DKG_HOME = tempDir;
+      delete process.env.DKG_API_PORT;
+      await writeFile(join(tempDir, 'config.json'), JSON.stringify({ name: 'isolated', apiPort: 9317 }));
+      await writeFile(join(tempDir, 'auth.token'), 'local-token\n', 'utf8');
+      const body = { name: 'other-node', peerId: 'peer1', uptimeMs: 1000, connectedPeers: 2, relayConnected: true, multiaddrs: [] };
+      const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body });
+      globalThis.fetch = fetch;
+
+      const connected = await ApiClient.connect({ allowConfigFallback: true });
+
+      await expect(connected.status()).rejects.toThrow('expected selected home node "isolated"');
+      expect(calls).toHaveLength(1);
+      expect((calls[0].opts.headers as any).Authorization).toBeUndefined();
+    });
+
     it('agents() calls /api/agents', async () => {
       const body = { agents: [{ agentUri: 'urn:a', name: 'A', peerId: 'p1' }] };
       const { fetch } = createTrackingFetch({ ok: true, status: 200, body });

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -117,7 +117,7 @@ describe('ApiClient', () => {
       expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
     });
 
-    it('connect() does not use yaml-only selected home config for status fallback', async () => {
+    it('connect() can use a yaml-only selected home config for status when control-plane files are missing', async () => {
       process.env.DKG_HOME = tempDir;
       delete process.env.DKG_API_PORT;
       await writeFile(join(tempDir, 'config.yaml'), 'name: isolated\napiPort: 9317\n', 'utf8');
@@ -126,9 +126,15 @@ describe('ApiClient', () => {
       const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body });
       globalThis.fetch = fetch;
 
-      await expect(ApiClient.connect({ allowConfigFallback: true }))
-        .rejects.toThrow('Daemon is not running. Start it with: dkg start');
-      expect(calls).toHaveLength(0);
+      const connected = await ApiClient.connect({ allowConfigFallback: true });
+      const result = await connected.status();
+
+      expect(result).toEqual(body);
+      expect(connected.controlPlaneWarning).toContain('api.port');
+      expect(connected.controlPlaneWarning).toContain('daemon.pid');
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe('http://127.0.0.1:9317/api/status');
+      expect((calls[0].opts.headers as any).Authorization).toBeUndefined();
       expect(existsSync(join(tempDir, 'api.port'))).toBe(false);
       expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
     });

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -74,7 +74,7 @@ describe('ApiClient', () => {
   });
 
   describe('GET endpoints', () => {
-    it('status() calls /api/status with auth header', async () => {
+    it('status() calls public /api/status without auth header', async () => {
       const body = { name: 'test', peerId: 'peer1', uptimeMs: 1000, connectedPeers: 2, relayConnected: true, multiaddrs: [] };
       const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body });
       globalThis.fetch = fetch;
@@ -83,7 +83,7 @@ describe('ApiClient', () => {
       expect(result).toEqual(body);
       expect(calls).toHaveLength(1);
       expect(calls[0].url).toBe(`http://127.0.0.1:${PORT}/api/status`);
-      expect((calls[0].opts.headers as any).Authorization).toBe('Bearer test-token');
+      expect((calls[0].opts.headers as any).Authorization).toBeUndefined();
     });
 
     it('connect() can use the selected home config for status when control-plane files are missing', async () => {
@@ -103,7 +103,7 @@ describe('ApiClient', () => {
       expect(connected.controlPlaneWarning).toContain('daemon.pid');
       expect(calls).toHaveLength(1);
       expect(calls[0].url).toBe('http://127.0.0.1:9317/api/status');
-      expect((calls[0].opts.headers as any).Authorization).toBe('Bearer local-token');
+      expect((calls[0].opts.headers as any).Authorization).toBeUndefined();
       expect(existsSync(join(tempDir, 'api.port'))).toBe(false);
       expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
     });

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'node:fs';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ApiClient } from '../src/api-client.js';
 
 const PORT = 8899;
+const originalDkgHome = process.env.DKG_HOME;
+const originalDkgApiPort = process.env.DKG_API_PORT;
 
 interface FetchCall {
   url: string;
@@ -63,6 +66,10 @@ describe('ApiClient', () => {
 
   afterEach(async () => {
     globalThis.fetch = originalFetch;
+    if (originalDkgHome === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = originalDkgHome;
+    if (originalDkgApiPort === undefined) delete process.env.DKG_API_PORT;
+    else process.env.DKG_API_PORT = originalDkgApiPort;
     await rm(tempDir, { recursive: true, force: true });
   });
 
@@ -77,6 +84,28 @@ describe('ApiClient', () => {
       expect(calls).toHaveLength(1);
       expect(calls[0].url).toBe(`http://127.0.0.1:${PORT}/api/status`);
       expect((calls[0].opts.headers as any).Authorization).toBe('Bearer test-token');
+    });
+
+    it('connect() can use the selected home config for status when control-plane files are missing', async () => {
+      process.env.DKG_HOME = tempDir;
+      delete process.env.DKG_API_PORT;
+      await writeFile(join(tempDir, 'config.json'), JSON.stringify({ name: 'isolated', apiPort: 9317 }));
+      await writeFile(join(tempDir, 'auth.token'), 'local-token\n', 'utf8');
+      const body = { name: 'isolated', peerId: 'peer1', uptimeMs: 1000, connectedPeers: 2, relayConnected: true, multiaddrs: [] };
+      const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body });
+      globalThis.fetch = fetch;
+
+      const connected = await ApiClient.connect({ allowConfigFallback: true });
+      const result = await connected.status();
+
+      expect(result).toEqual(body);
+      expect(connected.controlPlaneWarning).toContain('api.port');
+      expect(connected.controlPlaneWarning).toContain('daemon.pid');
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe('http://127.0.0.1:9317/api/status');
+      expect((calls[0].opts.headers as any).Authorization).toBe('Bearer local-token');
+      expect(existsSync(join(tempDir, 'api.port'))).toBe(false);
+      expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
     });
 
     it('agents() calls /api/agents', async () => {

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -54,6 +54,15 @@ function createTrackingFetch(response: { ok: boolean; status: number; statusText
   return { fetch: fn as typeof globalThis.fetch, calls };
 }
 
+function createRejectingFetch(error: Error): { fetch: typeof globalThis.fetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fn = async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), opts: init as RequestInit });
+    throw error;
+  };
+  return { fetch: fn as typeof globalThis.fetch, calls };
+}
+
 describe('ApiClient', () => {
   let client: ApiClient;
   const originalFetch = globalThis.fetch;
@@ -121,6 +130,22 @@ describe('ApiClient', () => {
 
       await expect(connected.status()).rejects.toThrow('expected selected home node "isolated"');
       expect(calls).toHaveLength(1);
+      expect((calls[0].opts.headers as any).Authorization).toBeUndefined();
+    });
+
+    it('connect() reports daemon not running when selected home config fallback port is unreachable', async () => {
+      process.env.DKG_HOME = tempDir;
+      delete process.env.DKG_API_PORT;
+      await writeFile(join(tempDir, 'config.json'), JSON.stringify({ name: 'isolated', apiPort: 9317 }));
+      await writeFile(join(tempDir, 'auth.token'), 'local-token\n', 'utf8');
+      const { fetch, calls } = createRejectingFetch(new TypeError('fetch failed'));
+      globalThis.fetch = fetch;
+
+      const connected = await ApiClient.connect({ allowConfigFallback: true });
+
+      await expect(connected.status()).rejects.toThrow('Daemon is not running. Start it with: dkg start');
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe('http://127.0.0.1:9317/api/status');
       expect((calls[0].opts.headers as any).Authorization).toBeUndefined();
     });
 

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -117,6 +117,28 @@ describe('ApiClient', () => {
       expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
     });
 
+    it('connect() can use a yaml-only selected home config for status when control-plane files are missing', async () => {
+      process.env.DKG_HOME = tempDir;
+      delete process.env.DKG_API_PORT;
+      await writeFile(join(tempDir, 'config.yaml'), 'name: isolated\napiPort: 9317\n', 'utf8');
+      await writeFile(join(tempDir, 'auth.token'), 'local-token\n', 'utf8');
+      const body = { name: 'isolated', peerId: 'peer1', uptimeMs: 1000, connectedPeers: 2, relayConnected: true, multiaddrs: [] };
+      const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body });
+      globalThis.fetch = fetch;
+
+      const connected = await ApiClient.connect({ allowConfigFallback: true });
+      const result = await connected.status();
+
+      expect(result).toEqual(body);
+      expect(connected.controlPlaneWarning).toContain('api.port');
+      expect(connected.controlPlaneWarning).toContain('daemon.pid');
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe('http://127.0.0.1:9317/api/status');
+      expect((calls[0].opts.headers as any).Authorization).toBeUndefined();
+      expect(existsSync(join(tempDir, 'api.port'))).toBe(false);
+      expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
+    });
+
     it('connect() rejects selected home config fallback when status belongs to a different node', async () => {
       process.env.DKG_HOME = tempDir;
       delete process.env.DKG_API_PORT;

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -233,7 +233,15 @@ describe('localAgentIntegrations config round-trip', () => {
   it('surfaces malformed config.yaml instead of falling back to defaults', async () => {
     await writeFile(join(tempDir, 'config.yaml'), 'name: [unterminated\napiPort: 9317\n', 'utf8');
 
-    await expect(loadConfig()).rejects.toThrow();
+    let thrown: unknown;
+    try {
+      await loadConfig();
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).name).toBe('YAMLException');
   });
 
   it('does not treat yaml-only homes as globally initialized configs', async () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -230,6 +230,12 @@ describe('localAgentIntegrations config round-trip', () => {
     await expect(loadConfig()).rejects.toThrow(SyntaxError);
   });
 
+  it('surfaces malformed config.yaml instead of falling back to defaults', async () => {
+    await writeFile(join(tempDir, 'config.yaml'), 'name: [unterminated\napiPort: 9317\n', 'utf8');
+
+    await expect(loadConfig()).rejects.toThrow();
+  });
+
   it('does not treat yaml-only homes as globally initialized configs', async () => {
     await writeFile(join(tempDir, 'config.yaml'), 'name: yaml-only\napiPort: 9317\n', 'utf8');
 

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -16,6 +16,7 @@ import {
   readPid,
   readApiPort,
   ensureDkgDir,
+  configExists,
   isDkgMonorepo,
   dkgDir,
   repoDir,
@@ -227,6 +228,12 @@ describe('localAgentIntegrations config round-trip', () => {
     await writeFile(join(tempDir, 'config.yaml'), 'name: stale-yaml\napiPort: 9317\n', 'utf8');
 
     await expect(loadConfig()).rejects.toThrow(SyntaxError);
+  });
+
+  it('does not treat yaml-only homes as globally initialized configs', async () => {
+    await writeFile(join(tempDir, 'config.yaml'), 'name: yaml-only\napiPort: 9317\n', 'utf8');
+
+    expect(configExists()).toBe(false);
   });
 
   it('round-trips relayServerCapacity through saveConfig/loadConfig (operator override)', async () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -17,6 +17,7 @@ import {
   readApiPort,
   ensureDkgDir,
   configExists,
+  readNodeRoleFromConfigSync,
   isDkgMonorepo,
   dkgDir,
   repoDir,
@@ -244,10 +245,23 @@ describe('localAgentIntegrations config round-trip', () => {
     expect((thrown as Error).name).toBe('YAMLException');
   });
 
-  it('does not treat yaml-only homes as globally initialized configs', async () => {
+  it('treats yaml-only homes as initialized configs', async () => {
     await writeFile(join(tempDir, 'config.yaml'), 'name: yaml-only\napiPort: 9317\n', 'utf8');
 
-    expect(configExists()).toBe(false);
+    expect(configExists()).toBe(true);
+  });
+
+  it('reads nodeRole from yaml-only config for sync daemon entrypoint routing', async () => {
+    await writeFile(join(tempDir, 'config.yaml'), 'name: yaml-core\nnodeRole: core\n', 'utf8');
+
+    expect(readNodeRoleFromConfigSync()).toBe('core');
+  });
+
+  it('keeps config.json precedence for sync nodeRole reads', async () => {
+    await writeFile(join(tempDir, 'config.json'), JSON.stringify({ nodeRole: 'edge' }), 'utf8');
+    await writeFile(join(tempDir, 'config.yaml'), 'nodeRole: core\n', 'utf8');
+
+    expect(readNodeRoleFromConfigSync()).toBe('edge');
   });
 
   it('round-trips relayServerCapacity through saveConfig/loadConfig (operator override)', async () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -222,6 +222,13 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(loaded.localAgentIntegrations?.openclaw?.runtime?.status).toBe('ready');
   });
 
+  it('surfaces malformed config.json instead of falling back to stale YAML', async () => {
+    await writeFile(join(tempDir, 'config.json'), '{ not valid json', 'utf8');
+    await writeFile(join(tempDir, 'config.yaml'), 'name: stale-yaml\napiPort: 9317\n', 'utf8');
+
+    await expect(loadConfig()).rejects.toThrow(SyntaxError);
+  });
+
   it('round-trips relayServerCapacity through saveConfig/loadConfig (operator override)', async () => {
     // PR #524 review (branarakic): the README documents
     // `relayServerCapacity` as a `config.json` knob, so the CLI

--- a/packages/cli/test/daemon-lifecycle.test.ts
+++ b/packages/cli/test/daemon-lifecycle.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..', '..');
+const cliSource = join(__dirname, '..', 'src', 'cli.ts');
+const tsxLoader = join(repoRoot, 'node_modules', 'tsx', 'dist', 'loader.mjs');
+
+async function writeWorkspaceTsconfig(tsconfigPath: string): Promise<void> {
+  const packagesDir = join(repoRoot, 'packages');
+  const paths: Record<string, string[]> = {};
+
+  for (const packageDir of await readdir(packagesDir)) {
+    const packageJsonPath = join(packagesDir, packageDir, 'package.json');
+    if (!existsSync(packageJsonPath)) continue;
+    const parsed = JSON.parse(await readFile(packageJsonPath, 'utf8')) as { name?: string };
+    if (!parsed.name) continue;
+    paths[parsed.name] = [`packages/${packageDir}/src/index.ts`];
+    paths[`${parsed.name}/*`] = [`packages/${packageDir}/src/*`];
+  }
+
+  await writeFile(
+    tsconfigPath,
+    JSON.stringify({ compilerOptions: { baseUrl: repoRoot, paths } }),
+  );
+}
+
+async function runSupervisor(tempHome: string, tsconfigPath: string): Promise<void> {
+  const env = {
+    ...process.env,
+    HOME: tempHome,
+    USERPROFILE: tempHome,
+    TSX_TSCONFIG_PATH: tsconfigPath,
+    DKG_DISABLE_TELEMETRY: '1',
+  };
+  delete env.DKG_HOME;
+  delete env.DKG_NO_BLUE_GREEN;
+
+  const child = spawn(
+    process.execPath,
+    ['--import', tsxLoader, cliSource, 'daemon-supervisor'],
+    { env, stdio: 'pipe' },
+  );
+
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout?.on('data', chunk => stdout.push(Buffer.from(chunk)));
+  child.stderr?.on('data', chunk => stderr.push(Buffer.from(chunk)));
+
+  const code = await new Promise<number | null>((resolveExit, reject) => {
+    child.once('error', reject);
+    child.once('exit', code => resolveExit(code));
+  });
+
+  if (code !== 0) {
+    throw new Error(
+      `daemon-supervisor exited with ${code}\n` +
+      Buffer.concat(stdout).toString('utf8') +
+      Buffer.concat(stderr).toString('utf8'),
+    );
+  }
+  expect(code).toBe(0);
+}
+
+describe('daemon lifecycle control-plane files', () => {
+  let tempRoot: string | undefined;
+
+  afterEach(async () => {
+    if (tempRoot) await rm(tempRoot, { recursive: true, force: true });
+    tempRoot = undefined;
+  });
+
+  it('passes the selected DKG home to the supervised daemon worker', async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), 'dkg-supervised-home-'));
+    const selectedHome = join(tempRoot, '.dkg-dev');
+    const defaultHome = join(tempRoot, '.dkg');
+    const tsconfigPath = join(tempRoot, 'tsx-tsconfig.json');
+    const slotDir = join(selectedHome, 'releases', 'a');
+    const fakeWorker = join(slotDir, 'packages', 'cli', 'dist', 'cli.js');
+
+    await mkdir(dirname(fakeWorker), { recursive: true });
+    await mkdir(join(selectedHome, 'releases'), { recursive: true });
+    await writeWorkspaceTsconfig(tsconfigPath);
+    await writeFile(
+      join(selectedHome, 'config.json'),
+      JSON.stringify({
+        name: 'supervisor-home-regression',
+        apiPort: 25001,
+        listenPort: 0,
+        nodeRole: 'core',
+      }),
+    );
+    await symlink('a', join(selectedHome, 'releases', 'current'));
+    await writeFile(
+      fakeWorker,
+      [
+        '#!/usr/bin/env node',
+        "const fs = require('node:fs');",
+        "const os = require('node:os');",
+        "const path = require('node:path');",
+        "const home = process.env.DKG_HOME || path.join(os.homedir(), '.dkg');",
+        'fs.mkdirSync(home, { recursive: true });',
+        "if (process.argv[2] !== 'daemon-worker') process.exit(2);",
+        "fs.writeFileSync(path.join(home, 'daemon.pid'), String(process.pid));",
+        "fs.writeFileSync(path.join(home, 'api.port'), '25001');",
+        'process.exit(0);',
+        '',
+      ].join('\n'),
+    );
+    await chmod(fakeWorker, 0o755);
+
+    await runSupervisor(tempRoot, tsconfigPath);
+
+    expect(readFileSync(join(selectedHome, 'api.port'), 'utf8')).toBe('25001');
+    expect(readFileSync(join(selectedHome, 'daemon.pid'), 'utf8')).toMatch(/^\d+$/);
+    expect(existsSync(join(defaultHome, 'api.port'))).toBe(false);
+    expect(existsSync(join(defaultHome, 'daemon.pid'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Make `dkg status` fall back to the configured API host/port from the selected DKG home when control files are missing.
- Propagate the resolved selected `DKG_HOME` into supervised daemon workers so `daemon.pid` and `api.port` are written in the selected home.
- Add regression coverage for both the status fallback and supervisor/worker lifecycle handoff.

Fixes #862

## Test Plan
- `pnpm install --frozen-lockfile`
- `pnpm --filter @origintrail-official/dkg-core run build`
- `pnpm --dir packages/cli exec vitest run test/api-client.test.ts test/config.test.ts test/daemon-lifecycle.test.ts`
