### PR TITLE
fix(routes): relax owner-guard on import-artifact reads for public-open CGs (#872)

### DIFF
--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -72,6 +72,7 @@ export interface ImportedArtifactResolution {
   markdownForm?: string;
   markdownHash?: string;
   canReadMarkdown: boolean;
+  ownerGuardRelaxed?: boolean;
 }
 
 export interface SemanticEnrichmentWriteRequest extends ImportedArtifactRequest {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -16016,17 +16016,15 @@ export class DKGAgent {
    *      passed a cleartext local id, we re-key via
    *      {@link subscribedContextGraphs} or {@link getContextGraphOnChainId}.
    *
-   *   2. Local `_meta` / ontology triple store. The CG creator
-   *      persists `dkg:publishPolicy` in `_meta` at create time and
-   *      `dkg:accessPolicy` as `"public"` / `"private"` in either the
-   *      ontology graph (open CGs) or `_meta` (curated CGs). Peers
-   *      that joined or replicated via gossip / catchup may have a
-   *      subset of these triples — notably, `dkg:publishPolicy` is
-   *      creator-only and never reaches non-creator peers via SWM.
+   *   2. Local `_meta` / ontology triple store for `accessPolicy`
+   *      only. The CG creator also persists `dkg:publishPolicy` in
+   *      `_meta` at create time, but that triple is not updated by
+   *      `updatePublishPolicy`, so it is never used as an
+   *      authorization-positive publish-policy answer here.
    *
    *   3. Direct chain RPC (Codex round-3 fix): for registered CGs
-   *      where steps 1 and 2 still leave a field undefined — the
-   *      common case for non-creator peers after a daemon restart —
+   *      where the cache leaves `publishPolicy` undefined/stale, or
+   *      where steps 1 and 2 still leave `accessPolicy` undefined,
    *      query the contract directly via
    *      `chain.getContextGraphAccessPolicy` /
    *      `chain.getContextGraphPublishPolicy`. The result populates
@@ -16035,7 +16033,7 @@ export class DKGAgent {
    * Steps 2 and 3 are GATED on {@link isContextGraphRegistered}
    * (Codex round-2 fix): unregistered locally-created CGs reflect
    * create-time *intent* via local triples, not an on-chain
-   * commitment, and the chain itself has no record. Treating either
+   * commitment, and the chain itself has no record. Treating local
    * source as authoritative pre-registration would bypass the
    * owner-guard on a CG the curator hasn't actually committed to.
    *
@@ -16087,9 +16085,9 @@ export class DKGAgent {
       }
     }
 
-    // Codex review (round 2, finding B): the local-triple fallback
-    // below reads `dkg:publishPolicy` / `dkg:accessPolicy` triples
-    // that `createContextGraph` writes synchronously — BEFORE
+    // Codex review (round 2, finding B): the local access-policy
+    // fallback below reads triples that `createContextGraph` writes
+    // synchronously — BEFORE
     // `registerContextGraph` confirms the CG on-chain. For a CG
     // that's still in the local-only `unregistered` state, those
     // triples reflect the creator's *intent*, not an on-chain
@@ -16137,13 +16135,6 @@ export class DKGAgent {
           ...(accessPolicy === 0 || accessPolicy === 1 ? { accessPolicy } : {}),
           ...(publishPolicy === 0 || publishPolicy === 1 ? { publishPolicy } : {}),
         };
-      }
-    }
-
-    if (publishPolicy === undefined) {
-      const stored: { publishPolicy?: number } = await this.getStoredContextGraphRegistrationOptions(contextGraphId).catch(() => ({}));
-      if (stored.publishPolicy === 0 || stored.publishPolicy === 1) {
-        publishPolicy = stored.publishPolicy;
       }
     }
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -516,6 +516,15 @@ const SWM_SENDER_KEY_PENDING_DRAIN_LOG_CTX: OperationContext = {
   operationName: 'share',
 };
 
+/**
+ * Sentinel returned by the chain-RPC-fallback timeout race inside
+ * {@link DKGAgent.getContextGraphOnChainPolicy}. Distinct from
+ * `undefined` so the caller can tell a timed-out probe apart from
+ * an RPC that legitimately resolved to "no policy". Module-scoped
+ * so the inner `withTimeout` helper can reuse the same identity.
+ */
+const TIMEOUT_SENTINEL = Symbol('chain-rpc-fallback-timeout');
+
 export class DKGAgent {
   readonly wallet: AgentWallet;
   readonly node: DKGNode;
@@ -16095,15 +16104,49 @@ export class DKGAgent {
       }
       if (numericId !== undefined) {
         const rpcCtx = createOperationContext('resolve');
+        // Round-4 fix: bound each chain-RPC call so an unreachable
+        // RPC stack (every endpoint returning 429 / hanging on
+        // connect) cannot block the caller past the daemon-ready
+        // budget. The fallback is an optimisation — failing fast
+        // and returning undefined is correct (fail-closed via the
+        // strict guard at the route layer). 2.5s is tight enough
+        // to stay well under the 45s daemon-ready budget even when
+        // both fallbacks fire back-to-back, while still allowing a
+        // single slow eth_call hop to succeed under normal load.
+        const CHAIN_RPC_FALLBACK_TIMEOUT_MS = 2_500;
+        const withTimeout = <T,>(p: Promise<T>, label: string): Promise<T | typeof TIMEOUT_SENTINEL> => {
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          const timeout = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+            timer = setTimeout(() => {
+              this.log.warn(
+                rpcCtx,
+                `getContextGraphOnChainPolicy: chain.${label}(${onChainId}) timed out after ${CHAIN_RPC_FALLBACK_TIMEOUT_MS}ms — treating as UNKNOWN (fail-closed)`,
+              );
+              resolve(TIMEOUT_SENTINEL);
+            }, CHAIN_RPC_FALLBACK_TIMEOUT_MS);
+            // Allow node to exit even if the chain promise never
+            // settles (test scenario: dead RPC + fake daemon).
+            timer.unref?.();
+          });
+          return Promise.race([
+            p.finally(() => { if (timer) clearTimeout(timer); }),
+            timeout,
+          ]);
+        };
         if (publishPolicy === undefined) {
           const getPublishPolicy = this.chain.getContextGraphPublishPolicy;
           if (typeof getPublishPolicy === 'function') {
             try {
-              const result = await getPublishPolicy.call(this.chain, numericId);
-              const pp = result?.publishPolicy;
-              if (pp === 0 || pp === 1) {
-                publishPolicy = pp;
-                this.onChainPublishPolicyCache.set(onChainId!, pp);
+              const result = await withTimeout(
+                getPublishPolicy.call(this.chain, numericId),
+                'getContextGraphPublishPolicy',
+              );
+              if (result !== TIMEOUT_SENTINEL) {
+                const pp = result?.publishPolicy;
+                if (pp === 0 || pp === 1) {
+                  publishPolicy = pp;
+                  this.onChainPublishPolicyCache.set(onChainId!, pp);
+                }
               }
             } catch (err) {
               this.log.warn(
@@ -16117,8 +16160,11 @@ export class DKGAgent {
           const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
           if (typeof getAccessPolicy === 'function') {
             try {
-              const ap = await getAccessPolicy.call(this.chain, numericId);
-              if (ap === 0 || ap === 1) {
+              const ap = await withTimeout(
+                getAccessPolicy.call(this.chain, numericId),
+                'getContextGraphAccessPolicy',
+              );
+              if (ap !== TIMEOUT_SENTINEL && (ap === 0 || ap === 1)) {
                 accessPolicy = ap;
                 this.onChainAccessPolicyCache.set(onChainId!, ap);
               }

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -15957,7 +15957,7 @@ export class DKGAgent {
   }
 
   /**
-   * Issue #872 — best-effort, no-network read of the on-chain
+   * Issue #872 — best-effort read of the on-chain
    * `(accessPolicy, publishPolicy)` enum pair for a CG. Sources, in
    * order:
    *
@@ -15972,17 +15972,30 @@ export class DKGAgent {
    *      `dkg:accessPolicy` as `"public"` / `"private"` in either the
    *      ontology graph (open CGs) or `_meta` (curated CGs). Peers
    *      that joined or replicated via gossip / catchup may have a
-   *      subset of these triples.
+   *      subset of these triples — notably, `dkg:publishPolicy` is
+   *      creator-only and never reaches non-creator peers via SWM.
+   *
+   *   3. Direct chain RPC (Codex round-3 fix): for registered CGs
+   *      where steps 1 and 2 still leave a field undefined — the
+   *      common case for non-creator peers after a daemon restart —
+   *      query the contract directly via
+   *      `chain.getContextGraphAccessPolicy` /
+   *      `chain.getContextGraphPublishPolicy`. The result populates
+   *      the in-memory cache so subsequent calls don't re-query.
+   *
+   * Steps 2 and 3 are GATED on {@link isContextGraphRegistered}
+   * (Codex round-2 fix): unregistered locally-created CGs reflect
+   * create-time *intent* via local triples, not an on-chain
+   * commitment, and the chain itself has no record. Treating either
+   * source as authoritative pre-registration would bypass the
+   * owner-guard on a CG the curator hasn't actually committed to.
    *
    * Returns `{}` (both fields `undefined`) when neither source has an
    * answer. Callers MUST treat `undefined` fields as unknown — fail
    * closed for policy-gated decisions rather than assuming a
-   * permissive default. The method intentionally avoids per-request
-   * chain RPCs; the eager event-driven cache is enough for any node
-   * that's been online since the CG's create block (the only case
-   * where this gap matters is a brand-new node that joined after the
-   * chain poller's lookback window rolled past — those nodes fail
-   * closed and the existing owner-guard remains in effect).
+   * permissive default. Failures in the chain RPC fallback (RPC
+   * unavailable, contract not deployed, transient errors) are logged
+   * and the field is left undefined.
    */
   async getContextGraphOnChainPolicy(contextGraphId: string): Promise<{
     accessPolicy?: number;
@@ -15990,9 +16003,14 @@ export class DKGAgent {
   }> {
     let accessPolicy = this.onChainAccessPolicyCache.get(contextGraphId);
     let publishPolicy = this.onChainPublishPolicyCache.get(contextGraphId);
+    // Track the resolved numeric on-chain id so we can both look it
+    // up in the cache (round-2) and use it as the chain-RPC fallback
+    // key (round-3). Lazily resolved — creators may pass the
+    // numeric id directly in which case no extra SPARQL is needed.
+    let onChainId: string | undefined;
 
     if (accessPolicy === undefined || publishPolicy === undefined) {
-      const onChainId = this.subscribedContextGraphs.get(contextGraphId)?.onChainId
+      onChainId = this.subscribedContextGraphs.get(contextGraphId)?.onChainId
         ?? (await this.getContextGraphOnChainId(contextGraphId).catch(() => null))
         ?? undefined;
       if (onChainId && onChainId !== contextGraphId) {
@@ -16011,11 +16029,11 @@ export class DKGAgent {
     // relaxation kick in for a CG the curator hasn't actually
     // committed to making public, bypassing the owner guard.
     //
-    // Gate the fallback on `isContextGraphRegistered` so only CGs
-    // confirmed on-chain (or replicated from a registered peer)
-    // contribute a local policy answer. Unregistered CGs that miss
-    // the chain-event cache return `{}` and the daemon route fails
-    // closed.
+    // Gate the fallback (local + chain RPC) on
+    // `isContextGraphRegistered` so only CGs confirmed on-chain (or
+    // replicated from a registered peer) contribute a policy
+    // answer. Unregistered CGs that miss the chain-event cache
+    // return `{}` and the daemon route fails closed.
     if (accessPolicy === undefined || publishPolicy === undefined) {
       const registered = await this.isContextGraphRegistered(contextGraphId).catch(() => false);
       if (!registered) {
@@ -16036,6 +16054,83 @@ export class DKGAgent {
     if (accessPolicy === undefined) {
       const stored = await this.readLocalAccessPolicyEnum(contextGraphId).catch(() => undefined);
       if (stored !== undefined) accessPolicy = stored;
+    }
+
+    // Codex review (round 3): non-creator peers never receive the
+    // `dkg:publishPolicy` triple — it's only written to local
+    // `_meta` on the creator's node. They observe the chain event
+    // at subscribe time which populates the in-memory caches above,
+    // but those caches are lost on daemon restart. Without a
+    // durable replicated source, `publishPolicy` permanently
+    // disappears for non-creator peers once the chain poller's
+    // replay window rolls past the create block — which makes
+    // `isPublicOpenContextGraph()` return false and cross-agent
+    // `/import-artifact/*` reads regress to 403 on legitimately
+    // public + open CGs.
+    //
+    // Fall back to a direct chain RPC for the missing fields. The
+    // fallback is gated on `registered === true` above so an
+    // unregistered local-only CG cannot poison the answer; the
+    // chain itself is the authoritative source. Failures (RPC
+    // unavailable, contract not deployed, transient errors) leave
+    // the field undefined and the daemon route falls back to the
+    // strict guard — fail-closed.
+    if (
+      (accessPolicy === undefined || publishPolicy === undefined)
+      && this.chain
+    ) {
+      if (onChainId === undefined) {
+        onChainId = this.subscribedContextGraphs.get(contextGraphId)?.onChainId
+          ?? (await this.getContextGraphOnChainId(contextGraphId).catch(() => null))
+          ?? undefined;
+      }
+      let numericId: bigint | undefined;
+      if (onChainId) {
+        try {
+          const parsed = BigInt(onChainId);
+          if (parsed > 0n) numericId = parsed;
+        } catch {
+          numericId = undefined;
+        }
+      }
+      if (numericId !== undefined) {
+        const rpcCtx = createOperationContext('resolve');
+        if (publishPolicy === undefined) {
+          const getPublishPolicy = this.chain.getContextGraphPublishPolicy;
+          if (typeof getPublishPolicy === 'function') {
+            try {
+              const result = await getPublishPolicy.call(this.chain, numericId);
+              const pp = result?.publishPolicy;
+              if (pp === 0 || pp === 1) {
+                publishPolicy = pp;
+                this.onChainPublishPolicyCache.set(onChainId!, pp);
+              }
+            } catch (err) {
+              this.log.warn(
+                rpcCtx,
+                `getContextGraphOnChainPolicy: chain.getContextGraphPublishPolicy(${onChainId}) failed — treating as UNKNOWN (fail-closed): ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          }
+        }
+        if (accessPolicy === undefined) {
+          const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
+          if (typeof getAccessPolicy === 'function') {
+            try {
+              const ap = await getAccessPolicy.call(this.chain, numericId);
+              if (ap === 0 || ap === 1) {
+                accessPolicy = ap;
+                this.onChainAccessPolicyCache.set(onChainId!, ap);
+              }
+            } catch (err) {
+              this.log.warn(
+                rpcCtx,
+                `getContextGraphOnChainPolicy: chain.getContextGraphAccessPolicy(${onChainId}) failed — treating as UNKNOWN (fail-closed): ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          }
+        }
+      }
     }
 
     return {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -16097,14 +16097,42 @@ export class DKGAgent {
     // relaxation kick in for a CG the curator hasn't actually
     // committed to making public, bypassing the owner guard.
     //
-    // Gate the fallback (local + chain RPC) on
-    // `isContextGraphRegistered` so only CGs confirmed on-chain (or
-    // replicated from a registered peer) contribute a policy
-    // answer. Unregistered CGs that miss the chain-event cache
-    // return `{}` and the daemon route fails closed.
+    // Codex review (round 6, line 15487 — 2026-06-01): the prior gate
+    // only consulted `dkg:registrationStatus = "registered"`, which
+    // `registerContextGraph` writes ON THE CREATOR'S NODE only. Non-
+    // creator peers bootstrap CG metadata via `ensureContextGraphLocally`
+    // with status="unregistered" and never flip it. After a daemon
+    // restart the chain-event cache loses its in-memory entries, the
+    // status check still returns false, this gate fails closed, and
+    // cross-agent reads on legitimately public+open CGs regress to
+    // 403 for non-creators.
+    //
+    // Accept any of these as proof of an on-chain commitment:
+    //   - `dkg:registrationStatus = "registered"` (creator path), OR
+    //   - a non-zero numeric `onChainId` already resolved from
+    //     subscribed state or local meta (replicator path — the
+    //     on-chain id is only ever known if the chain assigned it).
+    //
+    // An unregistered locally-created CG has neither, so the gate
+    // still fails closed for it.
     if (accessPolicy === undefined || publishPolicy === undefined) {
-      const registered = await this.isContextGraphRegistered(contextGraphId).catch(() => false);
-      if (!registered) {
+      const registeredViaStatus = await this.isContextGraphRegistered(contextGraphId).catch(() => false);
+      let registeredViaOnChainId = false;
+      if (!registeredViaStatus) {
+        if (onChainId === undefined) {
+          onChainId = this.subscribedContextGraphs.get(contextGraphId)?.onChainId
+            ?? (await this.getContextGraphOnChainId(contextGraphId).catch(() => null))
+            ?? undefined;
+        }
+        if (onChainId) {
+          try {
+            registeredViaOnChainId = BigInt(onChainId) > 0n;
+          } catch {
+            registeredViaOnChainId = false;
+          }
+        }
+      }
+      if (!registeredViaStatus && !registeredViaOnChainId) {
         return {
           ...(accessPolicy === 0 || accessPolicy === 1 ? { accessPolicy } : {}),
           ...(publishPolicy === 0 || publishPolicy === 1 ? { publishPolicy } : {}),

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -16001,6 +16001,31 @@ export class DKGAgent {
       }
     }
 
+    // Codex review (round 2, finding B): the local-triple fallback
+    // below reads `dkg:publishPolicy` / `dkg:accessPolicy` triples
+    // that `createContextGraph` writes synchronously — BEFORE
+    // `registerContextGraph` confirms the CG on-chain. For a CG
+    // that's still in the local-only `unregistered` state, those
+    // triples reflect the creator's *intent*, not an on-chain
+    // commitment. Treating them as authoritative would let the read
+    // relaxation kick in for a CG the curator hasn't actually
+    // committed to making public, bypassing the owner guard.
+    //
+    // Gate the fallback on `isContextGraphRegistered` so only CGs
+    // confirmed on-chain (or replicated from a registered peer)
+    // contribute a local policy answer. Unregistered CGs that miss
+    // the chain-event cache return `{}` and the daemon route fails
+    // closed.
+    if (accessPolicy === undefined || publishPolicy === undefined) {
+      const registered = await this.isContextGraphRegistered(contextGraphId).catch(() => false);
+      if (!registered) {
+        return {
+          ...(accessPolicy === 0 || accessPolicy === 1 ? { accessPolicy } : {}),
+          ...(publishPolicy === 0 || publishPolicy === 1 ? { publishPolicy } : {}),
+        };
+      }
+    }
+
     if (publishPolicy === undefined) {
       const stored: { publishPolicy?: number } = await this.getStoredContextGraphRegistrationOptions(contextGraphId).catch(() => ({}));
       if (stored.publishPolicy === 0 || stored.publishPolicy === 1) {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -525,6 +525,21 @@ const SWM_SENDER_KEY_PENDING_DRAIN_LOG_CTX: OperationContext = {
  */
 const TIMEOUT_SENTINEL = Symbol('chain-rpc-fallback-timeout');
 
+/**
+ * Codex review on #872 — TTL for the eagerly-seeded `publishPolicy`
+ * cache. `publishPolicy` is mutable on-chain (`PublishPolicyUpdated`
+ * is emitted by `ContextGraphStorage.updatePublishPolicy`), but the
+ * cache is only populated by `ContextGraphCreated`, so a curator
+ * flipping a CG from open → curated would otherwise leave a stale
+ * `1` in this node's cache until restart and keep relaxing the
+ * import-artifact owner guard. The TTL bounds staleness to one
+ * window without wiring a full `PublishPolicyUpdated` event watcher
+ * through the chain-event poller. 60s is conservative because the
+ * cached value gates an authorization decision — one extra eth_call
+ * per minute per active CG is cheap.
+ */
+const ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS = 60_000;
+
 export class DKGAgent {
   readonly wallet: AgentWallet;
   readonly node: DKGNode;
@@ -976,8 +991,32 @@ export class DKGAgent {
    * the chain answer hasn't reached this node yet — callers MUST
    * treat that as unknown (fail-closed) rather than a positive
    * "publish-policy is open" signal.
+   *
+   * Codex review on #872 — `publishPolicy` is mutable on-chain via
+   * `ContextGraphStorage.updatePublishPolicy` (which emits
+   * `PublishPolicyUpdated`), but this cache is only seeded from the
+   * `ContextGraphCreated` event. Without listening to the update event
+   * AND without a freshness check, a stale `1` survives until daemon
+   * restart and keeps `isPublicOpenContextGraph()` relaxing the
+   * import-artifact owner guard after a curator flips the CG from
+   * open → curated. The TTL companion map below stamps every cache
+   * write with `Date.now()`; reads in `getContextGraphOnChainPolicy`
+   * treat entries older than {@link ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS}
+   * as miss and fall through to the chain-RPC fallback (which already
+   * exists for the round-3 non-creator-peer path). Stale data drifts
+   * authoritative within at most one TTL window. The bound is set
+   * conservatively because the cache gates an authorization decision —
+   * one extra eth_call per minute per active CG is cheap.
    */
   private readonly onChainPublishPolicyCache = new Map<string, number>();
+  /**
+   * Codex review on #872 — companion timestamp map for {@link onChainPublishPolicyCache}.
+   * `now - fetchedAt > ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS` is treated
+   * as a cache miss. Kept as a sibling map (rather than refactoring the
+   * cache value to `{ value, fetchedAt }`) so existing test fixtures
+   * that read `cache.get(id)` and expect a bare number still pass.
+   */
+  private readonly onChainPublishPolicyCacheUpdatedAt = new Map<string, number>();
   /**
    * OT-RFC-38 / LU-6 Phase B — chain-backed participant-agent
    * allowlist cache. Keyed by `contextGraphId.toString()` (stringified
@@ -2294,6 +2333,7 @@ export class DKGAgent {
           // local state and relax owner-scoped artifact-read guards.
           if (publishPolicy === 0 || publishPolicy === 1) {
             this.onChainPublishPolicyCache.set(contextGraphId, publishPolicy);
+            this.onChainPublishPolicyCacheUpdatedAt.set(contextGraphId, Date.now());
           }
 
           // OT-RFC-38 / LU-6 Phase B — host-mode auto-subscribe path for
@@ -16011,7 +16051,24 @@ export class DKGAgent {
     publishPolicy?: number;
   }> {
     let accessPolicy = this.onChainAccessPolicyCache.get(contextGraphId);
-    let publishPolicy = this.onChainPublishPolicyCache.get(contextGraphId);
+    // Codex review on #872 — `publishPolicy` is mutable on-chain
+    // (`PublishPolicyUpdated`) but the cache is only seeded by
+    // `ContextGraphCreated`. Treat entries older than
+    // `ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS` as stale so the chain-RPC
+    // fallback below re-verifies before the caller relaxes the
+    // import-artifact owner guard. The accessPolicy cache is left
+    // untouched here: it's also used by SWM gossip authorization paths
+    // (lines ~1779, ~8403, ~10073) where stale-permissive cannot
+    // escalate privilege (gossip decrypt is gated by sender-key
+    // issuance) and stale-restrictive only causes a transient deny.
+    const isPublishPolicyCacheFresh = (key: string): boolean => {
+      const fetchedAt = this.onChainPublishPolicyCacheUpdatedAt.get(key);
+      if (fetchedAt === undefined) return false;
+      return Date.now() - fetchedAt <= ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS;
+    };
+    let publishPolicy = isPublishPolicyCacheFresh(contextGraphId)
+      ? this.onChainPublishPolicyCache.get(contextGraphId)
+      : undefined;
     // Track the resolved numeric on-chain id so we can both look it
     // up in the cache (round-2) and use it as the chain-RPC fallback
     // key (round-3). Lazily resolved — creators may pass the
@@ -16024,7 +16081,9 @@ export class DKGAgent {
         ?? undefined;
       if (onChainId && onChainId !== contextGraphId) {
         if (accessPolicy === undefined) accessPolicy = this.onChainAccessPolicyCache.get(onChainId);
-        if (publishPolicy === undefined) publishPolicy = this.onChainPublishPolicyCache.get(onChainId);
+        if (publishPolicy === undefined && isPublishPolicyCacheFresh(onChainId)) {
+          publishPolicy = this.onChainPublishPolicyCache.get(onChainId);
+        }
       }
     }
 
@@ -16146,6 +16205,7 @@ export class DKGAgent {
                 if (pp === 0 || pp === 1) {
                   publishPolicy = pp;
                   this.onChainPublishPolicyCache.set(onChainId!, pp);
+                  this.onChainPublishPolicyCacheUpdatedAt.set(onChainId!, Date.now());
                 }
               }
             } catch (err) {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -957,6 +957,19 @@ export class DKGAgent {
    */
   private readonly onChainAccessPolicyCache = new Map<string, number>();
   /**
+   * Issue #872 — companion cache for the per-CG `publishPolicy` enum
+   * (`0` = curators-only, `1` = open). Populated lazily by the
+   * `ContextGraphCreated` chain-event handler (the event already
+   * carries both enums; the only thing missing was the cache slot).
+   * Consumed by {@link getContextGraphOnChainPolicy} so daemon routes
+   * can decide whether to apply owner-scoped guards or relax them for
+   * public + open CGs without a per-request RPC. `undefined` means
+   * the chain answer hasn't reached this node yet — callers MUST
+   * treat that as unknown (fail-closed) rather than a positive
+   * "publish-policy is open" signal.
+   */
+  private readonly onChainPublishPolicyCache = new Map<string, number>();
+  /**
    * OT-RFC-38 / LU-6 Phase B — chain-backed participant-agent
    * allowlist cache. Keyed by `contextGraphId.toString()` (stringified
    * on-chain numeric id; the resolver normalises any cleartext form
@@ -2245,8 +2258,8 @@ export class DKGAgent {
       this.chainPoller = new ChainEventPoller({
         chain: this.chain,
         publishHandler,
-        onContextGraphCreated: async ({ contextGraphId, creator, accessPolicy, nameHash, blockNumber }) => {
-          this.log.info(ctx, `Discovered on-chain context graph ${contextGraphId.slice(0, 16)}… (block ${blockNumber}, creator ${creator.slice(0, 10)}…, policy ${accessPolicy}, nameHash ${nameHash ? nameHash.slice(0, 10) + '…' : '(opt-out)'})`);
+        onContextGraphCreated: async ({ contextGraphId, creator, accessPolicy, publishPolicy, nameHash, blockNumber }) => {
+          this.log.info(ctx, `Discovered on-chain context graph ${contextGraphId.slice(0, 16)}… (block ${blockNumber}, creator ${creator.slice(0, 10)}…, policy ${accessPolicy}, publishPolicy ${publishPolicy ?? '?'}, nameHash ${nameHash ? nameHash.slice(0, 10) + '…' : '(opt-out)'})`);
 
           // Track the numeric on-chain id for dedup.
           const alreadyKnown = this.seenOnChainIds.has(contextGraphId)
@@ -2266,6 +2279,12 @@ export class DKGAgent {
           // so the keying matches the lazy-fallback lookup below.
           if (accessPolicy === 0 || accessPolicy === 1) {
             this.onChainAccessPolicyCache.set(contextGraphId, accessPolicy);
+          }
+          // Issue #872 — same eager-cache pattern for the `publishPolicy`
+          // enum so daemon routes can recognise a public + open CG from
+          // local state and relax owner-scoped artifact-read guards.
+          if (publishPolicy === 0 || publishPolicy === 1) {
+            this.onChainPublishPolicyCache.set(contextGraphId, publishPolicy);
           }
 
           // OT-RFC-38 / LU-6 Phase B — host-mode auto-subscribe path for
@@ -15935,6 +15954,100 @@ export class DKGAgent {
     if (result.type !== 'bindings' || result.bindings.length === 0) return null;
     const value = result.bindings[0]?.['id'];
     return typeof value === 'string' ? value.replace(/^"|"$/g, '') : null;
+  }
+
+  /**
+   * Issue #872 — best-effort, no-network read of the on-chain
+   * `(accessPolicy, publishPolicy)` enum pair for a CG. Sources, in
+   * order:
+   *
+   *   1. {@link onChainAccessPolicyCache} / {@link onChainPublishPolicyCache} —
+   *      populated eagerly by the `ContextGraphCreated` chain-event
+   *      handler. The keys are the on-chain numeric ids; if the caller
+   *      passed a cleartext local id, we re-key via
+   *      {@link subscribedContextGraphs} or {@link getContextGraphOnChainId}.
+   *
+   *   2. Local `_meta` / ontology triple store. The CG creator
+   *      persists `dkg:publishPolicy` in `_meta` at create time and
+   *      `dkg:accessPolicy` as `"public"` / `"private"` in either the
+   *      ontology graph (open CGs) or `_meta` (curated CGs). Peers
+   *      that joined or replicated via gossip / catchup may have a
+   *      subset of these triples.
+   *
+   * Returns `{}` (both fields `undefined`) when neither source has an
+   * answer. Callers MUST treat `undefined` fields as unknown — fail
+   * closed for policy-gated decisions rather than assuming a
+   * permissive default. The method intentionally avoids per-request
+   * chain RPCs; the eager event-driven cache is enough for any node
+   * that's been online since the CG's create block (the only case
+   * where this gap matters is a brand-new node that joined after the
+   * chain poller's lookback window rolled past — those nodes fail
+   * closed and the existing owner-guard remains in effect).
+   */
+  async getContextGraphOnChainPolicy(contextGraphId: string): Promise<{
+    accessPolicy?: number;
+    publishPolicy?: number;
+  }> {
+    let accessPolicy = this.onChainAccessPolicyCache.get(contextGraphId);
+    let publishPolicy = this.onChainPublishPolicyCache.get(contextGraphId);
+
+    if (accessPolicy === undefined || publishPolicy === undefined) {
+      const onChainId = this.subscribedContextGraphs.get(contextGraphId)?.onChainId
+        ?? (await this.getContextGraphOnChainId(contextGraphId).catch(() => null))
+        ?? undefined;
+      if (onChainId && onChainId !== contextGraphId) {
+        if (accessPolicy === undefined) accessPolicy = this.onChainAccessPolicyCache.get(onChainId);
+        if (publishPolicy === undefined) publishPolicy = this.onChainPublishPolicyCache.get(onChainId);
+      }
+    }
+
+    if (publishPolicy === undefined) {
+      const stored: { publishPolicy?: number } = await this.getStoredContextGraphRegistrationOptions(contextGraphId).catch(() => ({}));
+      if (stored.publishPolicy === 0 || stored.publishPolicy === 1) {
+        publishPolicy = stored.publishPolicy;
+      }
+    }
+
+    if (accessPolicy === undefined) {
+      const stored = await this.readLocalAccessPolicyEnum(contextGraphId).catch(() => undefined);
+      if (stored !== undefined) accessPolicy = stored;
+    }
+
+    return {
+      ...(accessPolicy === 0 || accessPolicy === 1 ? { accessPolicy } : {}),
+      ...(publishPolicy === 0 || publishPolicy === 1 ? { publishPolicy } : {}),
+    };
+  }
+
+  /**
+   * Issue #872 — read the persisted `dkg:accessPolicy` literal from
+   * the ontology graph (open CGs) or `_meta` (curated CGs) and map it
+   * back to the on-chain enum (`"public"` → `0`, `"private"` → `1`).
+   * Returns `undefined` when no triple is present locally. Used by
+   * {@link getContextGraphOnChainPolicy} as a fallback after the
+   * chain-event cache miss.
+   */
+  private async readLocalAccessPolicyEnum(contextGraphId: string): Promise<number | undefined> {
+    if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
+      return undefined;
+    }
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
+    const result = await this.store.query(
+      `SELECT ?policy WHERE {
+        { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy } }
+        UNION
+        { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy } }
+      } LIMIT 1`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
+    const raw = result.bindings[0]?.['policy'];
+    if (typeof raw !== 'string') return undefined;
+    const stripped = raw.replace(/^"|"$/g, '');
+    if (stripped === 'public') return 0;
+    if (stripped === 'private') return 1;
+    return undefined;
   }
 
   /**

--- a/packages/agent/test/dkg-agent-on-chain-policy.test.ts
+++ b/packages/agent/test/dkg-agent-on-chain-policy.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Issue #872 / Codex review round 2, finding B regression tests for
+ * `DKGAgent.getContextGraphOnChainPolicy`.
+ *
+ * The bug: the method's local-triple fallback used to read
+ * `dkg:publishPolicy` / `dkg:accessPolicy` triples that
+ * `createContextGraph` writes to `_meta` BEFORE on-chain
+ * registration. For a CG still in the local-only `unregistered`
+ * state those triples reflect the creator's intent, not an on-chain
+ * commitment — but the daemon's import-artifact read relaxation
+ * (`/api/assertion/import-artifact/{resolve,read-markdown}`) treats
+ * a `{accessPolicy:0, publishPolicy:1}` answer as authoritative.
+ * The combination meant the owner-guard could be bypassed on a CG
+ * the curator hadn't actually committed to making public yet.
+ *
+ * Fix: gate the local-triple fallback on `isContextGraphRegistered`.
+ * If the CG isn't registered on-chain (or replicated from a
+ * registered peer), return `{}` and let callers fail closed.
+ *
+ * These tests bind `DKGAgent.prototype.getContextGraphOnChainPolicy`
+ * to a minimal stub (same pattern as `dkg-agent-diagnostics.test.ts`)
+ * so the assertions stay focused on the gating logic and don't drag
+ * in libp2p / chain / storage initialisation.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+interface AgentStub {
+  onChainAccessPolicyCache: Map<string, number>;
+  onChainPublishPolicyCache: Map<string, number>;
+  subscribedContextGraphs: Map<string, { onChainId?: string }>;
+  getContextGraphOnChainId: (id: string) => Promise<string | null>;
+  isContextGraphRegistered: (id: string) => Promise<boolean>;
+  getStoredContextGraphRegistrationOptions: (id: string) => Promise<{
+    publishPolicy?: number;
+    publishAuthorityAccountId?: bigint;
+  }>;
+  readLocalAccessPolicyEnum: (id: string) => Promise<number | undefined>;
+}
+
+function makeStub(overrides: Partial<AgentStub> = {}): AgentStub {
+  return {
+    onChainAccessPolicyCache: new Map(),
+    onChainPublishPolicyCache: new Map(),
+    subscribedContextGraphs: new Map(),
+    getContextGraphOnChainId: vi.fn(async () => null),
+    isContextGraphRegistered: vi.fn(async () => false),
+    getStoredContextGraphRegistrationOptions: vi.fn(async () => ({})),
+    readLocalAccessPolicyEnum: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+async function callPolicy(stub: AgentStub, contextGraphId: string) {
+  return (DKGAgent.prototype as any).getContextGraphOnChainPolicy.call(stub, contextGraphId);
+}
+
+describe('DKGAgent.getContextGraphOnChainPolicy', () => {
+  // Cache-hit path: chain-event-populated entries answer immediately
+  // without consulting registration status or local triples.
+  it('returns cached on-chain policies when both enums are present', async () => {
+    const stub = makeStub({
+      onChainAccessPolicyCache: new Map([['cg-1', 0]]),
+      onChainPublishPolicyCache: new Map([['cg-1', 1]]),
+    });
+    const result = await callPolicy(stub, 'cg-1');
+    expect(result).toEqual({ accessPolicy: 0, publishPolicy: 1 });
+    // Cache hit short-circuits before registration status / local
+    // fallback — neither stub should have been invoked.
+    expect(stub.isContextGraphRegistered).not.toHaveBeenCalled();
+    expect(stub.getStoredContextGraphRegistrationOptions).not.toHaveBeenCalled();
+    expect(stub.readLocalAccessPolicyEnum).not.toHaveBeenCalled();
+  });
+
+  // Round 2, finding B: the regression test. A CG that exists
+  // locally (with public + open create-time triples) but has NOT
+  // been confirmed on-chain must NOT contribute a positive policy
+  // answer via the local fallback — that would let the daemon's
+  // read relaxation bypass the owner guard on a CG the curator
+  // hasn't actually committed to making public yet.
+  it('returns {} when on-chain caches miss AND the CG is not registered (#872 Codex round 2 finding B)', async () => {
+    const stub = makeStub({
+      isContextGraphRegistered: vi.fn(async () => false),
+      // These stubs would return public + open if the fallback ran —
+      // the gating must short-circuit BEFORE calling them. Use
+      // `.toHaveBeenCalled` to prove the gate fired.
+      getStoredContextGraphRegistrationOptions: vi.fn(async () => ({ publishPolicy: 1 })),
+      readLocalAccessPolicyEnum: vi.fn(async () => 0),
+    });
+    const result = await callPolicy(stub, 'cg-unregistered');
+    expect(result).toEqual({});
+    expect(stub.isContextGraphRegistered).toHaveBeenCalledWith('cg-unregistered');
+    expect(stub.getStoredContextGraphRegistrationOptions).not.toHaveBeenCalled();
+    expect(stub.readLocalAccessPolicyEnum).not.toHaveBeenCalled();
+  });
+
+  // Companion: when the CG IS registered, the local-triple fallback
+  // still runs so creators and gossip-recipients of a registered CG
+  // get the relaxation immediately after a daemon restart (no chain
+  // RPC required). This is the original #872 fallback behaviour;
+  // round 2's gate doesn't break it for registered CGs.
+  it('falls back to local triples when the CG is registered but caches are cold', async () => {
+    const stub = makeStub({
+      isContextGraphRegistered: vi.fn(async () => true),
+      getStoredContextGraphRegistrationOptions: vi.fn(async () => ({ publishPolicy: 1 })),
+      readLocalAccessPolicyEnum: vi.fn(async () => 0),
+    });
+    const result = await callPolicy(stub, 'cg-registered');
+    expect(result).toEqual({ accessPolicy: 0, publishPolicy: 1 });
+    expect(stub.isContextGraphRegistered).toHaveBeenCalledWith('cg-registered');
+    expect(stub.getStoredContextGraphRegistrationOptions).toHaveBeenCalledWith('cg-registered');
+    expect(stub.readLocalAccessPolicyEnum).toHaveBeenCalledWith('cg-registered');
+  });
+
+  // Defensive: `isContextGraphRegistered` failing (e.g. SPARQL
+  // store transient error) must NOT unlock the fallback. We
+  // catch-and-treat-as-false in the production code so the gate
+  // remains closed even when the registration probe itself errors.
+  it('treats isContextGraphRegistered() rejections as not-registered', async () => {
+    const stub = makeStub({
+      isContextGraphRegistered: vi.fn(async () => { throw new Error('store unavailable'); }),
+      getStoredContextGraphRegistrationOptions: vi.fn(async () => ({ publishPolicy: 1 })),
+      readLocalAccessPolicyEnum: vi.fn(async () => 0),
+    });
+    const result = await callPolicy(stub, 'cg-probe-failed');
+    expect(result).toEqual({});
+    expect(stub.getStoredContextGraphRegistrationOptions).not.toHaveBeenCalled();
+    expect(stub.readLocalAccessPolicyEnum).not.toHaveBeenCalled();
+  });
+
+  // Mixed cache hit: when only one enum is cached AND the CG is
+  // registered, the fallback fills in the missing half.
+  it('uses local triples only for the half of the answer that the cache misses (registered CG)', async () => {
+    const stub = makeStub({
+      onChainAccessPolicyCache: new Map([['cg-2', 0]]),
+      onChainPublishPolicyCache: new Map(),
+      isContextGraphRegistered: vi.fn(async () => true),
+      getStoredContextGraphRegistrationOptions: vi.fn(async () => ({ publishPolicy: 1 })),
+      readLocalAccessPolicyEnum: vi.fn(async () => 0),
+    });
+    const result = await callPolicy(stub, 'cg-2');
+    expect(result).toEqual({ accessPolicy: 0, publishPolicy: 1 });
+    // Access policy was a cache hit; we still ran the registered
+    // gate then filled in publishPolicy from local triples. The
+    // access-policy local lookup may or may not run depending on
+    // ordering; the only invariant we need is that the answer is
+    // correct.
+    expect(stub.getStoredContextGraphRegistrationOptions).toHaveBeenCalled();
+  });
+});

--- a/packages/agent/test/dkg-agent-on-chain-policy.test.ts
+++ b/packages/agent/test/dkg-agent-on-chain-policy.test.ts
@@ -237,23 +237,86 @@ describe('DKGAgent.getContextGraphOnChainPolicy', () => {
   });
 
   // Round 3 cross-check with round 2's gate. The unregistered case
-  // MUST NOT hit the chain — the round-2 fail-closed return short-
-  // circuits before any RPC.
-  it('does NOT make a chain RPC call when the CG is unregistered (round 2 gate still holds)', async () => {
+  // MUST NOT hit the chain — the fail-closed return short-circuits
+  // before any RPC. This pins the creator's pre-register state where
+  // `createContextGraph` has written local-intent triples but
+  // `registerContextGraph` has NOT yet been called, so neither the
+  // status flag nor an on-chain id exists locally.
+  it('does NOT make a chain RPC call when the CG is unregistered AND no on-chain id is known (round 2 gate still holds)', async () => {
     const getContextGraphPublishPolicy = vi.fn(async () => ({
       publishPolicy: 1,
       publishAuthority: '0x0000000000000000000000000000000000000000',
     }));
     const getContextGraphAccessPolicy = vi.fn(async () => 0);
     const stub = makeStub({
-      subscribedContextGraphs: new Map([['cg-unregistered', { onChainId: '99' }]]),
+      // No on-chain id — `createContextGraph` has run but
+      // `registerContextGraph` has not, so the chain hasn't assigned
+      // a numeric id yet.
+      subscribedContextGraphs: new Map(),
       isContextGraphRegistered: vi.fn(async () => false),
+      getContextGraphOnChainId: vi.fn(async () => null),
       chain: { getContextGraphPublishPolicy, getContextGraphAccessPolicy },
     });
     const result = await callPolicy(stub, 'cg-unregistered');
     expect(result).toEqual({});
     expect(getContextGraphPublishPolicy).not.toHaveBeenCalled();
     expect(getContextGraphAccessPolicy).not.toHaveBeenCalled();
+  });
+
+  // Round 6 (Codex on #879, line 15487, 2026-06-01): the round-2
+  // gate keyed on `dkg:registrationStatus = "registered"`, which
+  // ONLY the creator's `registerContextGraph` writes — non-creator
+  // peers bootstrap CG metadata via `ensureContextGraphLocally` with
+  // status="unregistered" and never flip it. After a daemon restart
+  // the in-memory chain-event cache is empty, the status check
+  // returns false, and the original gate fail-closed for legitimate
+  // public+open CGs even though the on-chain id is known. The fix
+  // accepts a non-zero numeric `onChainId` from
+  // `subscribedContextGraphs` (or the local ontology triple) as
+  // proof of an on-chain commitment, so the chain-RPC fallback can
+  // run for these peers.
+  it('falls through to the chain RPC fallback when status is "unregistered" but onChainId is known (#879 Codex round 6)', async () => {
+    const getContextGraphPublishPolicy = vi.fn(async () => ({
+      publishPolicy: 1,
+      publishAuthority: '0x0000000000000000000000000000000000000000',
+    }));
+    const getContextGraphAccessPolicy = vi.fn(async () => 0);
+    const stub = makeStub({
+      // Replicated CG: subscribed via chain event, so we have the
+      // on-chain id, but `registrationStatus` was never flipped to
+      // "registered" because that flag is creator-only.
+      subscribedContextGraphs: new Map([['cg-replicated', { onChainId: '77' }]]),
+      isContextGraphRegistered: vi.fn(async () => false),
+      // Non-creator peer: no local creator-written triples.
+      getStoredContextGraphRegistrationOptions: vi.fn(async () => ({})),
+      readLocalAccessPolicyEnum: vi.fn(async () => undefined),
+      chain: { getContextGraphPublishPolicy, getContextGraphAccessPolicy },
+    });
+    const result = await callPolicy(stub, 'cg-replicated');
+    expect(result).toEqual({ accessPolicy: 0, publishPolicy: 1 });
+    expect(getContextGraphPublishPolicy).toHaveBeenCalledWith(77n);
+    expect(getContextGraphAccessPolicy).toHaveBeenCalledWith(77n);
+  });
+
+  // Round 6 negative: a CG with NEITHER status="registered" NOR a
+  // known on-chain id stays fail-closed. This is the
+  // create-without-register state on the creator's own node — no
+  // chain commitment exists, so the local-intent triples must NOT
+  // contribute a positive policy answer.
+  it('still fails closed when neither status nor onChainId proves an on-chain commitment (#879 Codex round 6 negative)', async () => {
+    const stub = makeStub({
+      // No `subscribedContextGraphs` entry, no ontology triple.
+      subscribedContextGraphs: new Map(),
+      getContextGraphOnChainId: vi.fn(async () => null),
+      isContextGraphRegistered: vi.fn(async () => false),
+      // These would return public+open if the gate let them run.
+      getStoredContextGraphRegistrationOptions: vi.fn(async () => ({ publishPolicy: 1 })),
+      readLocalAccessPolicyEnum: vi.fn(async () => 0),
+    });
+    const result = await callPolicy(stub, 'cg-create-only');
+    expect(result).toEqual({});
+    expect(stub.getStoredContextGraphRegistrationOptions).not.toHaveBeenCalled();
+    expect(stub.readLocalAccessPolicyEnum).not.toHaveBeenCalled();
   });
 
   // Round 3 — creator's local-triple path stays fast: when local

--- a/packages/agent/test/dkg-agent-on-chain-policy.test.ts
+++ b/packages/agent/test/dkg-agent-on-chain-policy.test.ts
@@ -36,6 +36,15 @@ interface ChainStub {
 interface AgentStub {
   onChainAccessPolicyCache: Map<string, number>;
   onChainPublishPolicyCache: Map<string, number>;
+  /**
+   * Codex review on #872 — companion timestamp map for {@link onChainPublishPolicyCache}.
+   * `getContextGraphOnChainPolicy` reads it to gate stale entries
+   * (`now - fetchedAt > ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS` ⇒
+   * miss). Tests that pre-populate the publishPolicy cache to model
+   * a fresh chain-event seed must also bump the timestamp here, or
+   * the cache-hit path will fall through to the chain-RPC fallback.
+   */
+  onChainPublishPolicyCacheUpdatedAt: Map<string, number>;
   subscribedContextGraphs: Map<string, { onChainId?: string }>;
   getContextGraphOnChainId: (id: string) => Promise<string | null>;
   isContextGraphRegistered: (id: string) => Promise<boolean>;
@@ -52,6 +61,7 @@ function makeStub(overrides: Partial<AgentStub> = {}): AgentStub {
   return {
     onChainAccessPolicyCache: new Map(),
     onChainPublishPolicyCache: new Map(),
+    onChainPublishPolicyCacheUpdatedAt: new Map(),
     subscribedContextGraphs: new Map(),
     getContextGraphOnChainId: vi.fn(async () => null),
     isContextGraphRegistered: vi.fn(async () => false),
@@ -74,6 +84,10 @@ describe('DKGAgent.getContextGraphOnChainPolicy', () => {
     const stub = makeStub({
       onChainAccessPolicyCache: new Map([['cg-1', 0]]),
       onChainPublishPolicyCache: new Map([['cg-1', 1]]),
+      // Codex review on #872 — bump the publishPolicy freshness
+      // timestamp so the TTL gate (`ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS`)
+      // treats this entry as still-fresh and the cache-hit path runs.
+      onChainPublishPolicyCacheUpdatedAt: new Map([['cg-1', Date.now()]]),
     });
     const result = await callPolicy(stub, 'cg-1');
     expect(result).toEqual({ accessPolicy: 0, publishPolicy: 1 });
@@ -304,6 +318,46 @@ describe('DKGAgent.getContextGraphOnChainPolicy', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // Codex review on #872 — `publishPolicy` is mutable on-chain
+  // (`PublishPolicyUpdated`), but the cache is only seeded by the
+  // `ContextGraphCreated` event. Without a freshness gate, a stale
+  // `1` survives until daemon restart and keeps relaxing the
+  // import-artifact owner guard after a curator flips a CG from
+  // open → curated. Pin the TTL behaviour: a cache entry older than
+  // `ON_CHAIN_PUBLISH_POLICY_CACHE_TTL_MS` is treated as miss and
+  // the chain-RPC fallback re-verifies (and overwrites the cache
+  // with the fresh value). Same pattern works for stale `0` entries
+  // — both directions re-verify.
+  it('treats publishPolicy cache entries older than the TTL as stale and falls through to chain RPC', async () => {
+    const TTL_MS = 60_000;
+    const STALE_AGE_MS = TTL_MS + 1_000;
+    const getContextGraphPublishPolicy = vi.fn(async () => ({
+      publishPolicy: 0, // the curator just flipped open → curated
+      publishAuthority: '0x0000000000000000000000000000000000000000',
+    }));
+    const getContextGraphAccessPolicy = vi.fn(async () => 0);
+    const stub = makeStub({
+      subscribedContextGraphs: new Map([['cg-stale', { onChainId: '55' }]]),
+      // Cached value says "1" (open), seeded by an old
+      // `ContextGraphCreated` event before the curator flipped policy.
+      onChainPublishPolicyCache: new Map([['cg-stale', 1]]),
+      onChainPublishPolicyCacheUpdatedAt: new Map([['cg-stale', Date.now() - STALE_AGE_MS]]),
+      onChainAccessPolicyCache: new Map([['cg-stale', 0]]),
+      isContextGraphRegistered: vi.fn(async () => true),
+      chain: { getContextGraphPublishPolicy, getContextGraphAccessPolicy },
+    });
+    const result = await callPolicy(stub, 'cg-stale');
+    // Stale "1" was discarded; chain re-verify returned "0" (curated).
+    expect(result).toEqual({ accessPolicy: 0, publishPolicy: 0 });
+    expect(getContextGraphPublishPolicy).toHaveBeenCalledWith(55n);
+    // Cache overwritten with the fresh chain answer keyed on
+    // numericOnChainId; freshness timestamp also bumped so the
+    // next read inside the TTL window is a fast cache-hit.
+    expect(stub.onChainPublishPolicyCache.get('55')).toBe(0);
+    const newTs = stub.onChainPublishPolicyCacheUpdatedAt.get('55') ?? 0;
+    expect(Date.now() - newTs).toBeLessThan(1_000);
   });
 
   // Round 3 — degenerate state: registered locally but the on-chain

--- a/packages/agent/test/dkg-agent-on-chain-policy.test.ts
+++ b/packages/agent/test/dkg-agent-on-chain-policy.test.ts
@@ -25,6 +25,14 @@
 import { describe, it, expect, vi } from 'vitest';
 import { DKGAgent } from '../src/dkg-agent.js';
 
+interface ChainStub {
+  getContextGraphAccessPolicy?: (id: bigint) => Promise<number>;
+  getContextGraphPublishPolicy?: (id: bigint) => Promise<{
+    publishPolicy: number;
+    publishAuthority: string;
+  }>;
+}
+
 interface AgentStub {
   onChainAccessPolicyCache: Map<string, number>;
   onChainPublishPolicyCache: Map<string, number>;
@@ -36,6 +44,8 @@ interface AgentStub {
     publishAuthorityAccountId?: bigint;
   }>;
   readLocalAccessPolicyEnum: (id: string) => Promise<number | undefined>;
+  chain?: ChainStub;
+  log: { warn: (ctx: unknown, msg: string) => void };
 }
 
 function makeStub(overrides: Partial<AgentStub> = {}): AgentStub {
@@ -47,6 +57,8 @@ function makeStub(overrides: Partial<AgentStub> = {}): AgentStub {
     isContextGraphRegistered: vi.fn(async () => false),
     getStoredContextGraphRegistrationOptions: vi.fn(async () => ({})),
     readLocalAccessPolicyEnum: vi.fn(async () => undefined),
+    chain: undefined,
+    log: { warn: vi.fn() },
     ...overrides,
   };
 }
@@ -146,5 +158,127 @@ describe('DKGAgent.getContextGraphOnChainPolicy', () => {
     // ordering; the only invariant we need is that the answer is
     // correct.
     expect(stub.getStoredContextGraphRegistrationOptions).toHaveBeenCalled();
+  });
+
+  // Round 3, the regression test. Non-creator peers never receive
+  // the `dkg:publishPolicy` triple — it's only written to local
+  // `_meta` by the creator's `createContextGraph` call. After a
+  // daemon restart, the in-memory chain-event cache is empty too,
+  // so the only durable answer for `publishPolicy` is the chain
+  // itself. The fallback runs `chain.getContextGraphPublishPolicy`
+  // (and `getContextGraphAccessPolicy` for parity) when the CG is
+  // confirmed registered, populates the cache, and returns the
+  // chain values.
+  it('falls back to chain RPC when a registered CG has no local publishPolicy (non-creator peer) (#872 Codex round 3)', async () => {
+    const getContextGraphPublishPolicy = vi.fn(async () => ({
+      publishPolicy: 1,
+      publishAuthority: '0x0000000000000000000000000000000000000000',
+    }));
+    const getContextGraphAccessPolicy = vi.fn(async () => 0);
+    const stub = makeStub({
+      // Subscribed CG — cleartext id maps to a numeric on-chain id.
+      // The fallback must look up that mapping (creators get it
+      // from `subscribedContextGraphs`; non-creator peers via the
+      // local ontology triple read by `getContextGraphOnChainId`).
+      subscribedContextGraphs: new Map([['cg-public-open', { onChainId: '42' }]]),
+      isContextGraphRegistered: vi.fn(async () => true),
+      // Non-creator peer: no creator-written local triples.
+      getStoredContextGraphRegistrationOptions: vi.fn(async () => ({})),
+      readLocalAccessPolicyEnum: vi.fn(async () => undefined),
+      chain: { getContextGraphPublishPolicy, getContextGraphAccessPolicy },
+    });
+    const result = await callPolicy(stub, 'cg-public-open');
+    expect(result).toEqual({ accessPolicy: 0, publishPolicy: 1 });
+    expect(getContextGraphPublishPolicy).toHaveBeenCalledWith(42n);
+    expect(getContextGraphAccessPolicy).toHaveBeenCalledWith(42n);
+    // Cache populated under the numeric on-chain id so subsequent
+    // calls don't re-RPC.
+    expect(stub.onChainPublishPolicyCache.get('42')).toBe(1);
+    expect(stub.onChainAccessPolicyCache.get('42')).toBe(0);
+  });
+
+  // Round 3, defensive: chain RPC failure must not throw out of
+  // `getContextGraphOnChainPolicy`. The function logs a warning
+  // and leaves the field undefined; the daemon route then falls
+  // back to the strict guard (fail-closed).
+  it('treats chain.getContextGraphPublishPolicy() rejections as unknown and logs a warning', async () => {
+    const getContextGraphPublishPolicy = vi.fn(async () => { throw new Error('rpc unavailable'); });
+    const stub = makeStub({
+      subscribedContextGraphs: new Map([['cg-rpc-fail', { onChainId: '7' }]]),
+      isContextGraphRegistered: vi.fn(async () => true),
+      // accessPolicy IS available locally (open-CG ontology
+      // triple); only publishPolicy needs the chain.
+      readLocalAccessPolicyEnum: vi.fn(async () => 0),
+      chain: { getContextGraphPublishPolicy },
+    });
+    const result = await callPolicy(stub, 'cg-rpc-fail');
+    expect(result).toEqual({ accessPolicy: 0 });
+    expect(getContextGraphPublishPolicy).toHaveBeenCalledWith(7n);
+    expect(stub.log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ operationId: expect.any(String) }),
+      expect.stringMatching(/chain\.getContextGraphPublishPolicy\(7\) failed/),
+    );
+    // Cache MUST NOT be populated with an undefined value.
+    expect(stub.onChainPublishPolicyCache.has('7')).toBe(false);
+  });
+
+  // Round 3 cross-check with round 2's gate. The unregistered case
+  // MUST NOT hit the chain — the round-2 fail-closed return short-
+  // circuits before any RPC.
+  it('does NOT make a chain RPC call when the CG is unregistered (round 2 gate still holds)', async () => {
+    const getContextGraphPublishPolicy = vi.fn(async () => ({
+      publishPolicy: 1,
+      publishAuthority: '0x0000000000000000000000000000000000000000',
+    }));
+    const getContextGraphAccessPolicy = vi.fn(async () => 0);
+    const stub = makeStub({
+      subscribedContextGraphs: new Map([['cg-unregistered', { onChainId: '99' }]]),
+      isContextGraphRegistered: vi.fn(async () => false),
+      chain: { getContextGraphPublishPolicy, getContextGraphAccessPolicy },
+    });
+    const result = await callPolicy(stub, 'cg-unregistered');
+    expect(result).toEqual({});
+    expect(getContextGraphPublishPolicy).not.toHaveBeenCalled();
+    expect(getContextGraphAccessPolicy).not.toHaveBeenCalled();
+  });
+
+  // Round 3 — creator's local-triple path stays fast: when local
+  // triples answer both fields, no chain RPC is issued.
+  it('does NOT make a chain RPC call when local triples cover both fields (creator path)', async () => {
+    const getContextGraphPublishPolicy = vi.fn(async () => ({
+      publishPolicy: 1,
+      publishAuthority: '0x0000000000000000000000000000000000000000',
+    }));
+    const getContextGraphAccessPolicy = vi.fn(async () => 0);
+    const stub = makeStub({
+      subscribedContextGraphs: new Map([['cg-creator', { onChainId: '11' }]]),
+      isContextGraphRegistered: vi.fn(async () => true),
+      getStoredContextGraphRegistrationOptions: vi.fn(async () => ({ publishPolicy: 1 })),
+      readLocalAccessPolicyEnum: vi.fn(async () => 0),
+      chain: { getContextGraphPublishPolicy, getContextGraphAccessPolicy },
+    });
+    const result = await callPolicy(stub, 'cg-creator');
+    expect(result).toEqual({ accessPolicy: 0, publishPolicy: 1 });
+    expect(getContextGraphPublishPolicy).not.toHaveBeenCalled();
+    expect(getContextGraphAccessPolicy).not.toHaveBeenCalled();
+  });
+
+  // Round 3 — degenerate state: registered locally but the on-chain
+  // id resolution fails (e.g. corrupted ontology graph). We can't
+  // RPC without a numeric id, so we return whatever local triples
+  // gave us and let the caller fail-closed.
+  it('returns whatever local triples gave us when registered but on-chain id cannot be resolved', async () => {
+    const getContextGraphPublishPolicy = vi.fn();
+    const stub = makeStub({
+      // No subscribed entry, and the SPARQL lookup returns null too.
+      subscribedContextGraphs: new Map(),
+      getContextGraphOnChainId: vi.fn(async () => null),
+      isContextGraphRegistered: vi.fn(async () => true),
+      readLocalAccessPolicyEnum: vi.fn(async () => 0),
+      chain: { getContextGraphPublishPolicy },
+    });
+    const result = await callPolicy(stub, 'cg-no-onchain-id');
+    expect(result).toEqual({ accessPolicy: 0 });
+    expect(getContextGraphPublishPolicy).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/test/dkg-agent-on-chain-policy.test.ts
+++ b/packages/agent/test/dkg-agent-on-chain-policy.test.ts
@@ -263,6 +263,49 @@ describe('DKGAgent.getContextGraphOnChainPolicy', () => {
     expect(getContextGraphAccessPolicy).not.toHaveBeenCalled();
   });
 
+  // Round 4 — the regression test for the daemon-ready hang. If
+  // the configured chain RPC stack is exhausted (every endpoint
+  // returning 429 / hanging on connect / unreachable), the
+  // fallback RPC call would block indefinitely waiting for the
+  // chain client to give up. That's catastrophic on the daemon-
+  // ready path (the CLI-7 `register exhausts configured chain RPC
+  // endpoints` test exceeds its 45s readiness budget). The fix is
+  // a bounded 2.5s per-call timeout inside the fallback: the race
+  // returns `TIMEOUT_SENTINEL`, the policy field is left
+  // undefined, a warning is logged, and the caller fails-closed.
+  it('returns undefined (with warning) when the chain-RPC fallback exceeds the bounded timeout (#872 Codex round 4)', async () => {
+    vi.useFakeTimers();
+    try {
+      // Promise that never resolves — emulates an RPC stack that
+      // hasn't given up yet because every endpoint is 429-ing.
+      const neverResolves = new Promise<{ publishPolicy: number; publishAuthority: string }>(() => {});
+      const getContextGraphPublishPolicy = vi.fn(() => neverResolves);
+      const stub = makeStub({
+        subscribedContextGraphs: new Map([['cg-slow-rpc', { onChainId: '13' }]]),
+        isContextGraphRegistered: vi.fn(async () => true),
+        // accessPolicy answered locally so the test isolates the
+        // publishPolicy timeout path.
+        readLocalAccessPolicyEnum: vi.fn(async () => 0),
+        chain: { getContextGraphPublishPolicy },
+      });
+      const promise = callPolicy(stub, 'cg-slow-rpc');
+      // Drain microtasks (so the fallback is awaiting the race)
+      // and then trip the 2.5s timer.
+      await vi.advanceTimersByTimeAsync(3_000);
+      const result = await promise;
+      expect(result).toEqual({ accessPolicy: 0 });
+      expect(getContextGraphPublishPolicy).toHaveBeenCalledWith(13n);
+      expect(stub.log.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ operationId: expect.any(String) }),
+        expect.stringMatching(/getContextGraphPublishPolicy\(13\) timed out after 2500ms/),
+      );
+      // Cache MUST NOT be populated with an undefined / partial answer.
+      expect(stub.onChainPublishPolicyCache.has('13')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // Round 3 — degenerate state: registered locally but the on-chain
   // id resolution fails (e.g. corrupted ontology graph). We can't
   // RPC without a numeric id, so we return whatever local triples

--- a/packages/agent/test/dkg-agent-on-chain-policy.test.ts
+++ b/packages/agent/test/dkg-agent-on-chain-policy.test.ts
@@ -2,9 +2,9 @@
  * Issue #872 / Codex review round 2, finding B regression tests for
  * `DKGAgent.getContextGraphOnChainPolicy`.
  *
- * The bug: the method's local-triple fallback used to read
+ * The bug: the method's local fallback used to read
  * `dkg:publishPolicy` / `dkg:accessPolicy` triples that
- * `createContextGraph` writes to `_meta` BEFORE on-chain
+ * `createContextGraph` writes BEFORE on-chain
  * registration. For a CG still in the local-only `unregistered`
  * state those triples reflect the creator's intent, not an on-chain
  * commitment — but the daemon's import-artifact read relaxation
@@ -13,9 +13,10 @@
  * The combination meant the owner-guard could be bypassed on a CG
  * the curator hadn't actually committed to making public yet.
  *
- * Fix: gate the local-triple fallback on `isContextGraphRegistered`.
- * If the CG isn't registered on-chain (or replicated from a
- * registered peer), return `{}` and let callers fail closed.
+ * Fix: gate the local access-policy fallback on
+ * `isContextGraphRegistered` and never treat the creator's stored
+ * `publishPolicy` as authorization-positive; publish policy must
+ * come from a fresh cache or a chain RPC revalidation.
  *
  * These tests bind `DKGAgent.prototype.getContextGraphOnChainPolicy`
  * to a minimal stub (same pattern as `dkg-agent-diagnostics.test.ts`)
@@ -120,22 +121,29 @@ describe('DKGAgent.getContextGraphOnChainPolicy', () => {
     expect(stub.readLocalAccessPolicyEnum).not.toHaveBeenCalled();
   });
 
-  // Companion: when the CG IS registered, the local-triple fallback
-  // still runs so creators and gossip-recipients of a registered CG
-  // get the relaxation immediately after a daemon restart (no chain
-  // RPC required). This is the original #872 fallback behaviour;
-  // round 2's gate doesn't break it for registered CGs.
-  it('falls back to local triples when the CG is registered but caches are cold', async () => {
+  // Companion: when the CG IS registered, the local fallback can
+  // still fill accessPolicy, but publishPolicy is revalidated from
+  // chain. The stored create-time publishPolicy is intentionally
+  // ignored because `updatePublishPolicy` does not update that
+  // local triple.
+  it('uses local accessPolicy and chain publishPolicy when the CG is registered but caches are cold', async () => {
+    const getContextGraphPublishPolicy = vi.fn(async () => ({
+      publishPolicy: 1,
+      publishAuthority: '0x0000000000000000000000000000000000000000',
+    }));
     const stub = makeStub({
+      subscribedContextGraphs: new Map([['cg-registered', { onChainId: '9' }]]),
       isContextGraphRegistered: vi.fn(async () => true),
       getStoredContextGraphRegistrationOptions: vi.fn(async () => ({ publishPolicy: 1 })),
       readLocalAccessPolicyEnum: vi.fn(async () => 0),
+      chain: { getContextGraphPublishPolicy },
     });
     const result = await callPolicy(stub, 'cg-registered');
     expect(result).toEqual({ accessPolicy: 0, publishPolicy: 1 });
     expect(stub.isContextGraphRegistered).toHaveBeenCalledWith('cg-registered');
-    expect(stub.getStoredContextGraphRegistrationOptions).toHaveBeenCalledWith('cg-registered');
+    expect(stub.getStoredContextGraphRegistrationOptions).not.toHaveBeenCalled();
     expect(stub.readLocalAccessPolicyEnum).toHaveBeenCalledWith('cg-registered');
+    expect(getContextGraphPublishPolicy).toHaveBeenCalledWith(9n);
   });
 
   // Defensive: `isContextGraphRegistered` failing (e.g. SPARQL
@@ -154,24 +162,27 @@ describe('DKGAgent.getContextGraphOnChainPolicy', () => {
     expect(stub.readLocalAccessPolicyEnum).not.toHaveBeenCalled();
   });
 
-  // Mixed cache hit: when only one enum is cached AND the CG is
-  // registered, the fallback fills in the missing half.
-  it('uses local triples only for the half of the answer that the cache misses (registered CG)', async () => {
+  // Mixed cache hit: when only accessPolicy is cached AND the CG is
+  // registered, the missing publishPolicy is still revalidated from
+  // chain rather than filled from the creator's stored options.
+  it('uses chain RPC for a missing publishPolicy even when accessPolicy is cached', async () => {
+    const getContextGraphPublishPolicy = vi.fn(async () => ({
+      publishPolicy: 1,
+      publishAuthority: '0x0000000000000000000000000000000000000000',
+    }));
     const stub = makeStub({
+      subscribedContextGraphs: new Map([['cg-2', { onChainId: '10' }]]),
       onChainAccessPolicyCache: new Map([['cg-2', 0]]),
       onChainPublishPolicyCache: new Map(),
       isContextGraphRegistered: vi.fn(async () => true),
       getStoredContextGraphRegistrationOptions: vi.fn(async () => ({ publishPolicy: 1 })),
       readLocalAccessPolicyEnum: vi.fn(async () => 0),
+      chain: { getContextGraphPublishPolicy },
     });
     const result = await callPolicy(stub, 'cg-2');
     expect(result).toEqual({ accessPolicy: 0, publishPolicy: 1 });
-    // Access policy was a cache hit; we still ran the registered
-    // gate then filled in publishPolicy from local triples. The
-    // access-policy local lookup may or may not run depending on
-    // ordering; the only invariant we need is that the answer is
-    // correct.
-    expect(stub.getStoredContextGraphRegistrationOptions).toHaveBeenCalled();
+    expect(stub.getStoredContextGraphRegistrationOptions).not.toHaveBeenCalled();
+    expect(getContextGraphPublishPolicy).toHaveBeenCalledWith(10n);
   });
 
   // Round 3, the regression test. Non-creator peers never receive
@@ -319,11 +330,14 @@ describe('DKGAgent.getContextGraphOnChainPolicy', () => {
     expect(stub.readLocalAccessPolicyEnum).not.toHaveBeenCalled();
   });
 
-  // Round 3 — creator's local-triple path stays fast: when local
-  // triples answer both fields, no chain RPC is issued.
-  it('does NOT make a chain RPC call when local triples cover both fields (creator path)', async () => {
+  // Codex review on #879 — creator-written `publishPolicy` in
+  // `_meta` is create-time state; `updatePublishPolicy` does not
+  // refresh it. Even on the creator path, a cached/stored "open"
+  // value must not keep relaxing the import-artifact owner guard
+  // after the curator flips the CG to curated on-chain.
+  it('ignores stored publishPolicy and revalidates from chain even on the creator path', async () => {
     const getContextGraphPublishPolicy = vi.fn(async () => ({
-      publishPolicy: 1,
+      publishPolicy: 0,
       publishAuthority: '0x0000000000000000000000000000000000000000',
     }));
     const getContextGraphAccessPolicy = vi.fn(async () => 0);
@@ -335,8 +349,9 @@ describe('DKGAgent.getContextGraphOnChainPolicy', () => {
       chain: { getContextGraphPublishPolicy, getContextGraphAccessPolicy },
     });
     const result = await callPolicy(stub, 'cg-creator');
-    expect(result).toEqual({ accessPolicy: 0, publishPolicy: 1 });
-    expect(getContextGraphPublishPolicy).not.toHaveBeenCalled();
+    expect(result).toEqual({ accessPolicy: 0, publishPolicy: 0 });
+    expect(stub.getStoredContextGraphRegistrationOptions).not.toHaveBeenCalled();
+    expect(getContextGraphPublishPolicy).toHaveBeenCalledWith(11n);
     expect(getContextGraphAccessPolicy).not.toHaveBeenCalled();
   });
 
@@ -409,11 +424,13 @@ describe('DKGAgent.getContextGraphOnChainPolicy', () => {
       onChainPublishPolicyCacheUpdatedAt: new Map([['cg-stale', Date.now() - STALE_AGE_MS]]),
       onChainAccessPolicyCache: new Map([['cg-stale', 0]]),
       isContextGraphRegistered: vi.fn(async () => true),
+      getStoredContextGraphRegistrationOptions: vi.fn(async () => ({ publishPolicy: 1 })),
       chain: { getContextGraphPublishPolicy, getContextGraphAccessPolicy },
     });
     const result = await callPolicy(stub, 'cg-stale');
     // Stale "1" was discarded; chain re-verify returned "0" (curated).
     expect(result).toEqual({ accessPolicy: 0, publishPolicy: 0 });
+    expect(stub.getStoredContextGraphRegistrationOptions).not.toHaveBeenCalled();
     expect(getContextGraphPublishPolicy).toHaveBeenCalledWith(55n);
     // Cache overwritten with the fresh chain answer keyed on
     // numericOnChainId; freshness timestamp also bumped so the

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -1205,6 +1205,35 @@ export interface ChainAdapter {
   getContextGraphAccessPolicy?(contextGraphId: bigint): Promise<number>;
 
   /**
+   * On-chain publish policy for `contextGraphId`. Read from
+   * `ContextGraphStorage.getPublishPolicy(uint256)`. Returns the
+   * Solidity tuple `(uint8 publishPolicy, address publishAuthority)`:
+   * - `publishPolicy`: `0` = curators-only, `1` = open.
+   * - `publishAuthority`: address authorized when the policy is
+   *   restricted (zero address when irrelevant).
+   *
+   * Issue #872 / Codex round-3 use case: non-creator peers do NOT
+   * receive `dkg:publishPolicy` triples via SWM (only the creator
+   * writes them to local `_meta`). They observe the chain event at
+   * subscribe time which populates the in-memory cache, but the
+   * cache is lost on daemon restart. To preserve the public+open
+   * read-relaxation after a restart for peers, the agent's policy
+   * resolver falls back to this RPC when the CG is confirmed
+   * registered on-chain but `publishPolicy` is still missing
+   * locally. Cheap (single eth_call); callers cache the result.
+   *
+   * Unregistered ids return `(0, address(0))` from Solidity's
+   * default-zero mapping. Callers MUST cross-check registration
+   * status before treating the answer as authoritative — a zero
+   * publish policy on an unregistered id is NOT a positive "open"
+   * signal.
+   */
+  getContextGraphPublishPolicy?(contextGraphId: bigint): Promise<{
+    publishPolicy: number;
+    publishAuthority: string;
+  }>;
+
+  /**
    * On-chain participant agent allowlist for `contextGraphId`. Read
    * from `ContextGraphStorage.getParticipantAgents(uint256)`.
    *

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -4517,6 +4517,33 @@ export class EVMChainAdapter implements ChainAdapter {
   }
 
   /**
+   * Issue #872 / Codex round-3 — chain-backed publish-policy oracle
+   * for non-creator peers. `ContextGraphStorage.getPublishPolicy`
+   * returns the tuple `(uint8 publishPolicy, address publishAuthority)`.
+   * `publishPolicy: 0` = curators-only, `1` = open. Unregistered ids
+   * return `(0, address(0))` from Solidity's default-zero mapping —
+   * the caller is responsible for cross-checking registration
+   * status before treating that as a positive "curators-only" signal.
+   */
+  async getContextGraphPublishPolicy(contextGraphId: bigint): Promise<{
+    publishPolicy: number;
+    publishAuthority: string;
+  }> {
+    await this.init();
+    const cgs = this.requireContextGraphStorage();
+    const result = await cgs.getPublishPolicy(contextGraphId);
+    // Ethers v6 returns named tuple as both array and object access;
+    // destructure positionally to stay robust against ABI naming
+    // changes.
+    const rawPolicy: bigint = BigInt(result[0] ?? result.publishPolicy ?? 0);
+    const rawAuthority: string = String(result[1] ?? result.publishAuthority ?? ethers.ZeroAddress);
+    return {
+      publishPolicy: Number(rawPolicy),
+      publishAuthority: ethers.getAddress(rawAuthority),
+    };
+  }
+
+  /**
    * OT-RFC-38 / LU-6 Phase B — chain-backed participant-agent
    * allowlist read. Mirrors {@link getContextGraphAccessPolicy}
    * (single eth_call, used as the authoritative oracle when the

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -1073,6 +1073,26 @@ export class MockChainAdapter implements ChainAdapter {
   }
 
   /**
+   * Issue #872 / Codex round-3: chain-backed publish-policy oracle
+   * parity for the mock chain. Returns the same `(uint8, address)`
+   * shape the EVM adapter does. Unknown ids yield
+   * `(0, address(0))` to match the Solidity default-zero mapping.
+   */
+  async getContextGraphPublishPolicy(contextGraphId: bigint): Promise<{
+    publishPolicy: number;
+    publishAuthority: string;
+  }> {
+    const cg = this.contextGraphs.get(contextGraphId);
+    if (!cg) return { publishPolicy: 0, publishAuthority: ethers.ZeroAddress };
+    const pp = (cg as { publishPolicy?: number }).publishPolicy;
+    const pa = (cg as { publishAuthority?: string }).publishAuthority;
+    return {
+      publishPolicy: typeof pp === 'number' ? pp : 0,
+      publishAuthority: pa ? ethers.getAddress(pa) : ethers.ZeroAddress,
+    };
+  }
+
+  /**
    * OT-RFC-38 / LU-6 Phase B: chain-backed participant-agent allowlist
    * parity for the mock. Mirrors {@link getContextGraphAccessPolicy}
    * shape. Returns an empty array when the CG is unknown or has no

--- a/packages/chain/test/evm-adapter-pca-enrich.test.ts
+++ b/packages/chain/test/evm-adapter-pca-enrich.test.ts
@@ -132,12 +132,7 @@ describe('PCA write methods enrich opaque custom-error reverts on rethrow (codex
       .then(() => null)
       .catch((e) => e as Error);
     expect(e1).toBeInstanceOf(Error);
-    // After main's `e3e58429` / `50089d22`, settle*-style helpers
-    // wrap per-RPC failures in an `RPC_ENDPOINTS_EXHAUSTED` error
-    // whose message embeds the original failure verbatim. Use a
-    // substring match so the assertion passes both before and after
-    // the rebase against main that picks up the wrapper.
-    expect(e1!.message).toContain('connect ECONNREFUSED 127.0.0.1:8545');
+    expect(e1!.message).toBe('connect ECONNREFUSED 127.0.0.1:8545');
 
     // (b) non-Error throw (string) — propagated as-is, not wrapped.
     const nonError = adapterWithFakeNft({

--- a/packages/chain/test/evm-adapter-pca-enrich.test.ts
+++ b/packages/chain/test/evm-adapter-pca-enrich.test.ts
@@ -132,7 +132,12 @@ describe('PCA write methods enrich opaque custom-error reverts on rethrow (codex
       .then(() => null)
       .catch((e) => e as Error);
     expect(e1).toBeInstanceOf(Error);
-    expect(e1!.message).toBe('connect ECONNREFUSED 127.0.0.1:8545');
+    // After main's `e3e58429` / `50089d22`, settle*-style helpers
+    // wrap per-RPC failures in an `RPC_ENDPOINTS_EXHAUSTED` error
+    // whose message embeds the original failure verbatim. Use a
+    // substring match so the assertion passes both before and after
+    // the rebase against main that picks up the wrapper.
+    expect(e1!.message).toContain('connect ECONNREFUSED 127.0.0.1:8545');
 
     // (b) non-Error throw (string) — propagated as-is, not wrapped.
     const nonError = adapterWithFakeNft({

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -355,6 +355,17 @@ type ImportedArtifactResolution = {
   markdownForm?: string;
   markdownHash?: string;
   canReadMarkdown: boolean;
+  /**
+   * Issue #872 — set to `true` when the request would have been
+   * blocked by the legacy owner guard but the CG's on-chain policy
+   * (`accessPolicy === 0` AND `publishPolicy === 1`) made the guard
+   * inapplicable. The read-markdown route uses this to distinguish
+   * "owner request, missing bytes" (genuine corruption) from
+   * "cross-agent request, bytes not replicated locally" (expected
+   * until the source-artifact gossip follow-up lands). Omitted when
+   * the requester IS the assertion owner.
+   */
+  ownerGuardRelaxed?: boolean;
 };
 
 class ImportArtifactRouteError extends Error {
@@ -780,6 +791,38 @@ function assertImportedArtifactOwnerAddress(
   }
 }
 
+/**
+ * Issue #872 — public + open context graphs ship their SWM triples to
+ * every subscribed peer, so the owner-scoped artifact-read guard is
+ * the wrong policy for them: peers that legitimately replicated the
+ * triples can't even resolve metadata about the source markdown
+ * artifact, let alone fetch its bytes. This helper consults the
+ * agent's local on-chain policy cache (populated eagerly by the
+ * chain-event poller) to decide whether the guard should be relaxed.
+ *
+ * Returns `true` only when both policies are confirmed
+ * (`accessPolicy === 0` AND `publishPolicy === 1`). Any other state
+ * — including missing cache entries — yields `false`, which keeps
+ * the existing owner guard in effect (fail-closed).
+ *
+ * DEFERRED FOLLOW-UP: peers replicate SWM triples but NOT the source
+ * artifact bytes; with the guard relaxed, the read-markdown route
+ * will return 404 on every cross-agent read until byte-replication is
+ * added. Tracked in the PR body for #872.
+ */
+async function isPublicOpenContextGraph(
+  agent: { getContextGraphOnChainPolicy?: (id: string) => Promise<{ accessPolicy?: number; publishPolicy?: number }> },
+  contextGraphId: string,
+): Promise<boolean> {
+  if (typeof agent.getContextGraphOnChainPolicy !== 'function') return false;
+  try {
+    const policy = await agent.getContextGraphOnChainPolicy(contextGraphId);
+    return policy.accessPolicy === 0 && policy.publishPolicy === 1;
+  } catch {
+    return false;
+  }
+}
+
 function handleImportArtifactRouteError(res: ServerResponse, err: unknown): boolean {
   if (err instanceof ImportArtifactRouteError) {
     jsonResponse(res, err.statusCode, { error: err.message });
@@ -869,12 +912,27 @@ async function resolveImportedArtifact(
     throw new ImportArtifactRouteError(400, 'assertionUri is not in canonical assertion URI form');
   }
   const assertionUri = reconstructedAssertionUri;
+  let ownerGuardRelaxed = false;
   if (ownerGuard) {
-    assertImportedArtifactOwnerAddress(
-      parsedAssertion.assertionAgentAddress,
-      ownerGuard.requestAgentAddress,
-      ownerGuard.message,
-    );
+    // Issue #872 — drop the owner guard for public + open CGs. Their
+    // SWM triples are gossipped to every subscribed peer, so blocking
+    // cross-agent reads of the imported source artifact contradicts
+    // the very access policy the curator chose on-chain. For every
+    // other policy combo (curated, or curators-only publish), the
+    // guard stays in force.
+    const isPublicOpen = await isPublicOpenContextGraph(ctx.agent, contextGraphId);
+    if (isPublicOpen) {
+      ownerGuardRelaxed = !isSameAgentAddress(
+        parsedAssertion.assertionAgentAddress,
+        ownerGuard.requestAgentAddress,
+      );
+    } else {
+      assertImportedArtifactOwnerAddress(
+        parsedAssertion.assertionAgentAddress,
+        ownerGuard.requestAgentAddress,
+        ownerGuard.message,
+      );
+    }
   }
   if (assertionName && assertionName !== parsedAssertion.assertionName) {
     throw new ImportArtifactRouteError(400, '"assertionName" does not match assertionUri');
@@ -993,6 +1051,7 @@ async function resolveImportedArtifact(
     ...(markdownForm ? { markdownForm } : {}),
     ...(markdownHash ? { markdownHash } : {}),
     canReadMarkdown: Boolean(markdownHash),
+    ...(ownerGuardRelaxed ? { ownerGuardRelaxed: true } : {}),
   };
 }
 
@@ -1075,8 +1134,23 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
       }
       const bytes = await fileStore.get(artifact.markdownHash);
       if (!bytes) {
+        // Issue #872 — when the owner guard was relaxed (public + open
+        // CG, cross-agent request), the missing bytes are the
+        // expected outcome: peers replicate the SWM triples for the
+        // assertion but the source-artifact bytes are NOT gossipped
+        // yet. Surface that explicitly so callers can decide whether
+        // to retry against the origin agent instead of treating this
+        // as local corruption.
+        //
+        // DEFERRED FOLLOW-UP: gossip the imported-artifact bytes to
+        // peers replicating a public + open CG, so cross-agent reads
+        // can complete locally without an out-of-band fetch. Tracked
+        // in the PR body for #872.
+        const message = artifact.ownerGuardRelaxed
+          ? 'Markdown source bytes are not replicated locally on this peer; the assertion graph triples synced but the source artifact bytes were not. Fetch from the origin agent (assertionAgentAddress).'
+          : 'Markdown content is not present in the file store';
         return jsonResponse(res, 404, {
-          error: 'Markdown content is not present in the file store',
+          error: message,
           artifact,
         });
       }

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -1068,6 +1068,24 @@ async function resolveImportedArtifact(
   const markdownHash = authoritativeMarkdownHash;
   const markdownForm = markdownHash ? `urn:dkg:file:${markdownHash}` : undefined;
 
+  // Codex review on #872 — when the owner guard is relaxed for a
+  // public + open CG, replicated `_meta` may have a `markdownHash`
+  // even though the bytes were never replicated to this node's
+  // file-store (only the SWM/_meta triples gossip across peers; the
+  // raw file bytes don't auto-replicate). The previous
+  // `Boolean(markdownHash)` would have returned `canReadMarkdown:
+  // true` and then `/import-artifact/read-markdown` would
+  // deterministically 404. Derive presence from the local file-store
+  // when the relaxation is in effect so the flag is honest. Owner
+  // self-reads (no relaxation) keep the existing fast-path —
+  // `_meta` and bytes land together at import time on the importing
+  // node, so a `markdownHash` there really does mean readable.
+  const markdownAvailableLocally = markdownHash
+    ? ownerGuardRelaxed
+      ? await ctx.fileStore.has(markdownHash).catch(() => false)
+      : true
+    : false;
+
   return {
     contextGraphId,
     assertionUri,
@@ -1088,7 +1106,7 @@ async function resolveImportedArtifact(
     ...(mdIntermediateHash ? { mdIntermediateHash } : {}),
     ...(markdownForm ? { markdownForm } : {}),
     ...(markdownHash ? { markdownHash } : {}),
-    canReadMarkdown: Boolean(markdownHash),
+    canReadMarkdown: markdownAvailableLocally,
     ...(ownerGuardRelaxed ? { ownerGuardRelaxed: true } : {}),
   };
 }

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -848,6 +848,17 @@ async function resolveImportedArtifact(
   ownerGuard?: {
     requestAgentAddress: string;
     message: string;
+    /**
+     * Issue #872 / Codex review finding 1: opt-in for the public + open
+     * CG owner-guard relaxation. Only the two READ routes
+     * (`/import-artifact/resolve`, `/import-artifact/read-markdown`)
+     * set this to `true`. The semantic-enrichment WRITE route
+     * intentionally leaves it `false` (default) so the strict owner
+     * guard remains in effect regardless of the CG's on-chain policy
+     * — a non-owner peer on a public + open CG must not be allowed
+     * to mutate someone else's imported assertion.
+     */
+    relaxOnPublicOpenCg?: boolean;
   },
 ): Promise<ImportedArtifactResolution> {
   const rawContextGraphId = typeof raw.contextGraphId === 'string' ? raw.contextGraphId.trim() : '';
@@ -890,6 +901,20 @@ async function resolveImportedArtifact(
   }
 
   const inputAssertionUri = rawAssertionUri;
+  // Issue #872 Codex finding 1: only the READ routes opt into the
+  // public + open relaxation. The write callers (e.g.
+  // `/semantic-enrichment/write`) leave `relaxOnPublicOpenCg`
+  // unset/false so the strict owner guard stays in effect — a
+  // non-owner peer on a public + open CG must NOT be able to mutate
+  // someone else's imported assertion just because cross-agent READS
+  // are allowed.
+  const canRelaxGuard = Boolean(ownerGuard?.relaxOnPublicOpenCg);
+  // Probing the on-chain policy is a no-op for the write path (which
+  // never relaxes). Skip it there to keep the diff scoped and avoid
+  // adding chain-cache reads to a code path that doesn't need them.
+  const isPublicOpen = canRelaxGuard
+    ? await isPublicOpenContextGraph(ctx.agent, contextGraphId)
+    : false;
   const parsedAssertion = parseImportedAssertionUri(
     inputAssertionUri,
     contextGraphId,
@@ -897,6 +922,25 @@ async function resolveImportedArtifact(
   );
   if (!parsedAssertion) {
     throw new ImportArtifactRouteError(400, 'assertionUri is not an assertion in the supplied contextGraphId');
+  }
+  // Issue #872 Codex finding 2: a legacy ownerless URI
+  // (`.../assertion/<name>`) is canonicalized by
+  // `parseImportedAssertionUri` via the requester's agent DID
+  // because the URI itself doesn't carry an owner segment. That
+  // works for the original owner-self-read back-compat path, but on
+  // a public + open CG it silently produces the wrong canonical URI
+  // for cross-agent peers — the meta lookup then 404s with a
+  // confusing "no metadata" message instead of telling the caller
+  // their URI is ambiguous. Reject these early on the relaxed read
+  // paths so callers get a clear signal to pass the canonical form.
+  // Owner self-reads of legacy URIs on curated CGs are unaffected
+  // (canRelaxGuard is set only on read routes AND isPublicOpen has
+  // to be true), and V10 always emits canonical URIs.
+  if (parsedAssertion.legacy && canRelaxGuard && isPublicOpen) {
+    throw new ImportArtifactRouteError(
+      400,
+      'Legacy ownerless assertionUri form cannot be resolved on public + open CGs because the original owner is not encoded in the URI. Pass the canonical assertion URI: did:dkg:context-graph:<contextGraphId>/assertion/<assertionAgentAddress>/<assertionName>.',
+    );
   }
   const parsedNameValidation = validateAssertionName(parsedAssertion.assertionName);
   if (!parsedNameValidation.valid) {
@@ -918,10 +962,10 @@ async function resolveImportedArtifact(
     // SWM triples are gossipped to every subscribed peer, so blocking
     // cross-agent reads of the imported source artifact contradicts
     // the very access policy the curator chose on-chain. For every
-    // other policy combo (curated, or curators-only publish), the
-    // guard stays in force.
-    const isPublicOpen = await isPublicOpenContextGraph(ctx.agent, contextGraphId);
-    if (isPublicOpen) {
+    // other policy combo (curated, curators-only publish, or any
+    // write path), the guard stays in force regardless of the
+    // on-chain policy.
+    if (canRelaxGuard && isPublicOpen) {
       ownerGuardRelaxed = !isSameAgentAddress(
         parsedAssertion.assertionAgentAddress,
         ownerGuard.requestAgentAddress,
@@ -1106,6 +1150,9 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
       const artifact = await resolveImportedArtifact(ctx, parsed as Record<string, unknown>, {
         requestAgentAddress,
         message: 'Import artifact metadata can only be read from imported assertions owned by the requesting agent',
+        // Issue #872 — this is a read; opt into the public + open
+        // policy relaxation. The write route below does NOT set this.
+        relaxOnPublicOpenCg: true,
       });
       return jsonResponse(res, 200, { artifact });
     } catch (err) {
@@ -1124,6 +1171,8 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
       const artifact = await resolveImportedArtifact(ctx, parsed as Record<string, unknown>, {
         requestAgentAddress,
         message: 'Import artifact Markdown can only be read from imported assertions owned by the requesting agent',
+        // Issue #872 — read path; opt into the public + open relaxation.
+        relaxOnPublicOpenCg: true,
       });
       const maxBytes = normalizeMarkdownReadLimit((parsed as Record<string, unknown>).maxBytes);
       if (!artifact.markdownHash) {

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -923,25 +923,6 @@ async function resolveImportedArtifact(
   if (!parsedAssertion) {
     throw new ImportArtifactRouteError(400, 'assertionUri is not an assertion in the supplied contextGraphId');
   }
-  // Issue #872 Codex finding 2: a legacy ownerless URI
-  // (`.../assertion/<name>`) is canonicalized by
-  // `parseImportedAssertionUri` via the requester's agent DID
-  // because the URI itself doesn't carry an owner segment. That
-  // works for the original owner-self-read back-compat path, but on
-  // a public + open CG it silently produces the wrong canonical URI
-  // for cross-agent peers — the meta lookup then 404s with a
-  // confusing "no metadata" message instead of telling the caller
-  // their URI is ambiguous. Reject these early on the relaxed read
-  // paths so callers get a clear signal to pass the canonical form.
-  // Owner self-reads of legacy URIs on curated CGs are unaffected
-  // (canRelaxGuard is set only on read routes AND isPublicOpen has
-  // to be true), and V10 always emits canonical URIs.
-  if (parsedAssertion.legacy && canRelaxGuard && isPublicOpen) {
-    throw new ImportArtifactRouteError(
-      400,
-      'Legacy ownerless assertionUri form cannot be resolved on public + open CGs because the original owner is not encoded in the URI. Pass the canonical assertion URI: did:dkg:context-graph:<contextGraphId>/assertion/<assertionAgentAddress>/<assertionName>.',
-    );
-  }
   const parsedNameValidation = validateAssertionName(parsedAssertion.assertionName);
   if (!parsedNameValidation.valid) {
     throw new ImportArtifactRouteError(400, `Invalid assertionUri assertion name: ${parsedNameValidation.reason}`);
@@ -965,7 +946,20 @@ async function resolveImportedArtifact(
     // other policy combo (curated, curators-only publish, or any
     // write path), the guard stays in force regardless of the
     // on-chain policy.
-    if (canRelaxGuard && isPublicOpen) {
+    //
+    // Codex review (round 2, finding A): the relaxation is skipped
+    // for legacy ownerless URIs (`parsedAssertion.legacy === true`).
+    // `parseImportedAssertionUri` already canonicalizes those by
+    // defaulting the missing owner segment to `requestAgentAddress`
+    // — which is the right answer ONLY for owner self-reads. For
+    // cross-agent reads the canonical URI silently points at the
+    // wrong owner, so the meta SPARQL below misses and returns 404.
+    // Letting the strict guard run for legacy URIs preserves the
+    // owner-self-read back-compat path (the legacy default makes
+    // `assertionAgentAddress === requestAgentAddress` so the guard
+    // passes) while non-owner cross-agent reads get the same 404
+    // they got pre-PR rather than a misleading 200.
+    if (canRelaxGuard && isPublicOpen && !parsedAssertion.legacy) {
       ownerGuardRelaxed = !isSameAgentAddress(
         parsedAssertion.assertionAgentAddress,
         ownerGuard.requestAgentAddress,

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -655,20 +655,25 @@ describe('import artifact daemon routes', () => {
     expect(queries).toHaveLength(0);
   });
 
-  // Issue #872 / Codex review finding 2: legacy ownerless URIs
-  // (`.../assertion/<name>`) get canonicalized by
-  // `parseImportedAssertionUri` via the requester's agent DID, which
-  // is wrong for cross-agent peers on a public + open CG. Without
-  // explicit handling the meta lookup 404s with a confusing message;
-  // the relaxed read paths reject these up front with a clear 400
-  // pointing at the canonical URI form.
-  it('rejects legacy ownerless assertionUri form on public + open CG reads with a clear 400 (#872 Codex finding 2)', async () => {
-    const entry = await fileStore.put(Buffer.from('# Legacy Public\n'), 'text/markdown');
-    const contextGraphId = 'cg-public-open-legacy-uri-reject';
+  // Issue #872 / Codex review round 2, finding A: the round-1 fix
+  // unconditionally rejected legacy ownerless URIs on public + open
+  // CGs with 400. That broke owner self-reads — the existing legacy
+  // back-compat path canonicalizes the missing owner segment to the
+  // requester, which is correct for the owner. The round-2 fix
+  // skips the relaxation entirely for legacy URIs and lets the
+  // strict guard run; for owner self-reads the legacy fallback
+  // makes the strict guard a no-op so the read completes normally.
+  it('lets owner self-reads of legacy ownerless URIs through on public + open CGs (#872 Codex round 2 finding A)', async () => {
+    const entry = await fileStore.put(Buffer.from('# Legacy Owner Public\n'), 'text/markdown');
+    const contextGraphId = 'cg-public-open-legacy-owner-self-read';
     const assertionName = 'legacy-md';
     const legacyAssertionUri = `did:dkg:context-graph:${contextGraphId}/assertion/${assertionName}`;
-    const canonicalAssertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
-    const { agent, queries } = makeAgent({
+    // The mock's requestAgentAddress is `did:dkg:agent:test`. The
+    // legacy fallback canonicalizes the missing owner segment to
+    // that address, so the stored canonical URI is keyed by the
+    // requester (i.e. owner self-read).
+    const canonicalAssertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent } = makeAgent({
       contextGraphId,
       assertionName,
       assertionUri: canonicalAssertionUri,
@@ -679,27 +684,135 @@ describe('import artifact daemon routes', () => {
     });
     await startRoutes({ agent });
 
+    const resolved = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri: legacyAssertionUri,
+    });
+    expect(resolved.status).toBe(200);
+    expect(resolved.body.artifact).toMatchObject({
+      contextGraphId,
+      assertionUri: canonicalAssertionUri,
+      assertionAgentAddress: 'did:dkg:agent:test',
+      assertionName,
+      markdownHash: entry.keccak256,
+    });
+    // Owner self-read: the relaxation does NOT apply (it's gated on
+    // `!parsedAssertion.legacy`) so `ownerGuardRelaxed` is absent.
+    expect(resolved.body.artifact.ownerGuardRelaxed).toBeUndefined();
+
+    const read = await post('/api/assertion/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri: legacyAssertionUri,
+    });
+    expect(read.status).toBe(200);
+    expect(read.body.markdown).toBe('# Legacy Owner Public\n');
+  });
+
+  // Issue #872 / Codex review round 2, finding A — companion test
+  // for the cross-agent half. Non-owner peers sending a legacy
+  // ownerless URI on a public + open CG: the relaxation does not
+  // apply (legacy URIs always go through the strict guard); the
+  // legacy fallback canonicalizes to the requester's address, the
+  // strict guard equality check passes (requester == requester),
+  // and the meta SPARQL then misses because the actual owner is
+  // someone else. Caller gets the pre-PR 404 "no metadata"
+  // back-compat response — same as before the relaxation existed.
+  it('returns 4xx (no misleading 200) for cross-agent legacy ownerless reads on public + open CGs (#872 Codex round 2 finding A)', async () => {
+    const entry = await fileStore.put(Buffer.from('# Legacy Public\n'), 'text/markdown');
+    const contextGraphId = 'cg-public-open-legacy-cross-agent';
+    const assertionName = 'legacy-md';
+    const legacyAssertionUri = `did:dkg:context-graph:${contextGraphId}/assertion/${assertionName}`;
+    // The mock has metadata keyed by `did:dkg:agent:source`; the
+    // requester is `did:dkg:agent:test`. The legacy fallback
+    // canonicalizes to `.../assertion/did:dkg:agent:test/legacy-md`
+    // which DOES NOT match the mock's stored URI — i.e. the
+    // canonical-URI-pointing-at-wrong-owner case Codex flagged.
+    const canonicalAssertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent, queries } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri: canonicalAssertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 1 },
+    });
+
+    // Tolerate URI mismatch on the meta SPARQL: return empty
+    // bindings when the query targets a URI other than the stored
+    // one. Mirrors how the real Oxigraph store would respond.
+    const storeAny = agent.store as unknown as { query: (sparql: string) => Promise<unknown> };
+    const originalQuery = storeAny.query.bind(agent.store);
+    storeAny.query = async (sparql: string) => {
+      if (sparql.includes('SELECT ?fileHash') && !sparql.includes(canonicalAssertionUri)) {
+        queries.push(sparql);
+        return { type: 'bindings', bindings: [] } as never;
+      }
+      return originalQuery(sparql);
+    };
+
+    await startRoutes({ agent });
+
     const read = await post('/api/assertion/import-artifact/read-markdown', {
       contextGraphId,
       assertionUri: legacyAssertionUri,
       maxBytes: 1024,
     });
+    expect(read.status).toBe(404);
+    expect(read.body.error).toMatch(/No completed import metadata/);
+    // The SPARQL that ran targeted the requester-canonicalized URI,
+    // not the stored owner URI — this is what Codex flagged as
+    // "silently canonicalizes to the wrong assertion URI". The 404
+    // is the pre-PR back-compat behaviour.
+    expect(queries.some((q) => q.includes('did%3Adkg%3Aagent%3Atest') || q.includes('did:dkg:agent:test'))).toBe(true);
+  });
 
-    expect(read.status).toBe(400);
-    expect(read.body.error).toMatch(/Legacy ownerless assertionUri form/);
-    expect(read.body.error).toMatch(/canonical assertion URI/);
-    // No SPARQL should have been issued — the legacy URI is rejected
-    // before the meta lookup that would otherwise return 404 with a
-    // misleading "no metadata" message.
-    expect(queries).toHaveLength(0);
+  // Issue #872 / Codex review round 2, finding B: the dkg-agent
+  // local-policy fallback used to mark unregistered locally-created
+  // CGs as public + open by reading the create-time
+  // `dkg:publishPolicy` / `dkg:accessPolicy` triples that
+  // `createContextGraph` writes BEFORE on-chain registration. That
+  // bypassed the owner guard on CGs that hadn't actually been
+  // committed on-chain yet. The fix in `dkg-agent.ts` gates the
+  // local fallback on `isContextGraphRegistered`, so unregistered
+  // CGs return `{}` and the daemon route fails closed.
+  //
+  // This test simulates the post-fix agent contract — the mock's
+  // `getContextGraphOnChainPolicy` returns `{}` (matching what the
+  // fixed agent returns for an unregistered CG) and asserts the
+  // route preserves the strict guard for a non-owner cross-agent
+  // request. The corresponding unit test for the agent method
+  // itself lives in `packages/agent/test/dkg-agent-on-chain-policy.test.ts`.
+  it('keeps the owner guard in force when on-chain policy is unknown (e.g. CG not yet registered) (#872 Codex round 2 finding B)', async () => {
+    const entry = await fileStore.put(Buffer.from('# Unregistered\n'), 'text/markdown');
+    const contextGraphId = 'cg-locally-created-not-registered';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent, queries } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      // Post-fix agent contract: an unregistered CG resolves to
+      // `{}` regardless of the local create-time triples. The
+      // daemon route sees `accessPolicy=undefined,
+      // publishPolicy=undefined`, isPublicOpen evaluates to false,
+      // and the strict guard fires for the non-owner request.
+      onChainPolicy: {},
+    });
+    await startRoutes({ agent });
 
-    // Sanity: the same legacy rejection applies to /resolve.
     const resolved = await post('/api/assertion/import-artifact/resolve', {
       contextGraphId,
-      assertionUri: legacyAssertionUri,
+      assertionUri,
     });
-    expect(resolved.status).toBe(400);
-    expect(resolved.body.error).toMatch(/Legacy ownerless assertionUri form/);
+    expect(resolved.status).toBe(403);
+    expect(resolved.body.error).toMatch(/owned by the requesting agent/);
+    // The guard short-circuits before any SPARQL: no leak about
+    // the unregistered CG's contents.
+    expect(queries).toHaveLength(0);
   });
 
   it('requires full assertionUri instead of guessing the source author from assertionName', async () => {

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -120,6 +120,14 @@ describe('import artifact daemon routes', () => {
     publisherDiscardError?: Error;
     targetGraphExists?: boolean;
     queryQuads?: Quad[];
+    /**
+     * Issue #872 — optional on-chain policy enum pair (`accessPolicy`,
+     * `publishPolicy`) returned by the mock agent's
+     * `getContextGraphOnChainPolicy`. When omitted, the method is not
+     * exposed at all — exercising the "policy unknown, fail closed"
+     * branch that preserves the legacy owner guard.
+     */
+    onChainPolicy?: { accessPolicy?: number; publishPolicy?: number };
   }) {
     const created: Array<{
       contextGraphId: string;
@@ -147,7 +155,7 @@ describe('import artifact daemon routes', () => {
       { subject: 'urn:z', predicate: 'urn:p', object: 'urn:o' },
       { subject: 'urn:a', predicate: 'urn:p', object: '"A"' },
     ];
-    const agent = {
+    const agent: Record<string, unknown> = {
       async listContextGraphs() {
         return [{
           id: args.contextGraphId,
@@ -203,6 +211,13 @@ describe('import artifact daemon routes', () => {
           discards.push({ contextGraphId, name, agentAddress, subGraphName });
         },
       },
+      ...(args.onChainPolicy
+        ? {
+            async getContextGraphOnChainPolicy() {
+              return args.onChainPolicy ?? {};
+            },
+          }
+        : {}),
       store: {
         async hasGraph() {
           return Boolean(args.targetGraphExists);
@@ -460,6 +475,145 @@ describe('import artifact daemon routes', () => {
     expect(read.status).toBe(403);
     expect(read.body.error).toMatch(/owned by the requesting agent/);
     expect(queries).toHaveLength(0);
+  });
+
+  // Issue #872 — public + open CGs gossip their SWM triples to every
+  // subscribed peer, so the legacy owner guard at
+  // `assertImportedArtifactOwnerAddress` contradicts the curator's
+  // on-chain policy choice. The next three tests pin down the relaxed
+  // shape: cross-agent reads succeed (200) when bytes are local, fail
+  // cleanly (404) when bytes haven't been replicated, and the existing
+  // 403 path stays in force for any other policy combo (covered above).
+  it('allows non-owner reads on public + open CGs when bytes are locally available (#872)', async () => {
+    const entry = await fileStore.put(Buffer.from('# Public Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-public-open-bytes-local';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 1 },
+    });
+    await startRoutes({ agent });
+
+    const resolved = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+      fileHash: entry.keccak256,
+    });
+    expect(resolved.status).toBe(200);
+    expect(resolved.body.artifact).toMatchObject({
+      assertionUri,
+      assertionAgentAddress: 'did:dkg:agent:source',
+      markdownHash: entry.keccak256,
+      canReadMarkdown: true,
+      ownerGuardRelaxed: true,
+    });
+
+    const read = await post('/api/assertion/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri,
+      maxBytes: 1024,
+    });
+    expect(read.status).toBe(200);
+    expect(read.body.markdown).toBe('# Public Imported\n');
+    expect(read.body.artifact.ownerGuardRelaxed).toBe(true);
+  });
+
+  it('returns 404 (not 403) for non-owner reads on public + open CGs when bytes are missing (#872)', async () => {
+    // Use a deterministic, well-formed keccak256 hash that's never been
+    // put into the test file store. The markdownForm URN matches the
+    // meta `sourceFileHash`, so the 409 markdown-mismatch path stays
+    // dormant — the only failure surface left is the file-store miss,
+    // which is exactly the path peers will hit until source-artifact
+    // bytes are gossipped (deferred follow-up for #872).
+    const markdownHash = `keccak256:${'a'.repeat(64)}`;
+    const contextGraphId = 'cg-public-open-bytes-missing';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: markdownHash,
+      markdownHash,
+      markdownForm: `urn:dkg:file:${markdownHash}`,
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 1 },
+    });
+    await startRoutes({ agent });
+
+    const resolved = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+    expect(resolved.status).toBe(200);
+    expect(resolved.body.artifact.ownerGuardRelaxed).toBe(true);
+
+    const read = await post('/api/assertion/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri,
+      maxBytes: 1024,
+    });
+    expect(read.status).toBe(404);
+    expect(read.body.error).toMatch(/not replicated locally/);
+    expect(read.body.error).not.toMatch(/owned by the requesting agent/);
+    expect(read.body.artifact.ownerGuardRelaxed).toBe(true);
+  });
+
+  it('keeps the owner guard in force when a non-owner reads from a CG that is public but curators-only (#872)', async () => {
+    // Mixed policy: accessPolicy=0 (public discovery) but publishPolicy=0
+    // (curators-only). Only `accessPolicy===0 && publishPolicy===1`
+    // relaxes the guard; this combo MUST still 403.
+    const entry = await fileStore.put(Buffer.from('# Mixed Policy\n'), 'text/markdown');
+    const contextGraphId = 'cg-public-curators-only';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent, queries } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 0 },
+    });
+    await startRoutes({ agent });
+
+    const resolved = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+    expect(resolved.status).toBe(403);
+    expect(resolved.body.error).toMatch(/owned by the requesting agent/);
+    expect(queries).toHaveLength(0);
+  });
+
+  it('does not surface ownerGuardRelaxed for owner reads on public + open CGs (#872)', async () => {
+    const entry = await fileStore.put(Buffer.from('# Owner Public\n'), 'text/markdown');
+    const contextGraphId = 'cg-public-open-owner';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 1 },
+    });
+    await startRoutes({ agent });
+
+    const resolved = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+    expect(resolved.status).toBe(200);
+    expect(resolved.body.artifact.ownerGuardRelaxed).toBeUndefined();
   });
 
   it('requires full assertionUri instead of guessing the source author from assertionName', async () => {

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -616,6 +616,92 @@ describe('import artifact daemon routes', () => {
     expect(resolved.body.artifact.ownerGuardRelaxed).toBeUndefined();
   });
 
+  // Issue #872 / Codex review finding 1: the public + open relaxation
+  // is opt-in via `relaxOnPublicOpenCg: true` and ONLY the two read
+  // routes set it. The semantic-enrichment WRITE route must continue
+  // to reject cross-agent writes regardless of the CG's on-chain
+  // policy — otherwise a non-owner peer on a public + open CG could
+  // mutate someone else's imported assertion graph.
+  it('rejects non-owner semantic enrichment writes on public + open CGs (#872 Codex finding 1)', async () => {
+    const entry = await fileStore.put(Buffer.from('# Public Imported\n'), 'text/markdown');
+    const contextGraphId = 'cg-public-open-write-rejected';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent, writes, queries } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 1 },
+    });
+    await startRoutes({ agent });
+
+    const enriched = await post('/api/assertion/semantic-enrichment/write', {
+      contextGraphId,
+      assertionUri,
+      semanticQuads: [
+        { subject: 'urn:doc:imported', predicate: 'http://schema.org/about', object: '"Cross-agent topic"' },
+      ],
+    });
+
+    expect(enriched.status).toBe(403);
+    expect(enriched.body.error).toMatch(/owned by the requesting agent/);
+    expect(writes).toHaveLength(0);
+    // Sanity: short-circuit before any SPARQL — the strict guard
+    // fires the moment the URI is parsed, just like the legacy code
+    // path for curated CGs.
+    expect(queries).toHaveLength(0);
+  });
+
+  // Issue #872 / Codex review finding 2: legacy ownerless URIs
+  // (`.../assertion/<name>`) get canonicalized by
+  // `parseImportedAssertionUri` via the requester's agent DID, which
+  // is wrong for cross-agent peers on a public + open CG. Without
+  // explicit handling the meta lookup 404s with a confusing message;
+  // the relaxed read paths reject these up front with a clear 400
+  // pointing at the canonical URI form.
+  it('rejects legacy ownerless assertionUri form on public + open CG reads with a clear 400 (#872 Codex finding 2)', async () => {
+    const entry = await fileStore.put(Buffer.from('# Legacy Public\n'), 'text/markdown');
+    const contextGraphId = 'cg-public-open-legacy-uri-reject';
+    const assertionName = 'legacy-md';
+    const legacyAssertionUri = `did:dkg:context-graph:${contextGraphId}/assertion/${assertionName}`;
+    const canonicalAssertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent, queries } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri: canonicalAssertionUri,
+      fileHash: entry.keccak256,
+      markdownHash: entry.keccak256,
+      markdownForm: `urn:dkg:file:${entry.keccak256}`,
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 1 },
+    });
+    await startRoutes({ agent });
+
+    const read = await post('/api/assertion/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri: legacyAssertionUri,
+      maxBytes: 1024,
+    });
+
+    expect(read.status).toBe(400);
+    expect(read.body.error).toMatch(/Legacy ownerless assertionUri form/);
+    expect(read.body.error).toMatch(/canonical assertion URI/);
+    // No SPARQL should have been issued — the legacy URI is rejected
+    // before the meta lookup that would otherwise return 404 with a
+    // misleading "no metadata" message.
+    expect(queries).toHaveLength(0);
+
+    // Sanity: the same legacy rejection applies to /resolve.
+    const resolved = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri: legacyAssertionUri,
+    });
+    expect(resolved.status).toBe(400);
+    expect(resolved.body.error).toMatch(/Legacy ownerless assertionUri form/);
+  });
+
   it('requires full assertionUri instead of guessing the source author from assertionName', async () => {
     const entry = await fileStore.put(Buffer.from('# Imported\n'), 'text/markdown');
     const contextGraphId = 'cg-import-artifact-uri-required';


### PR DESCRIPTION
Refs #872 — closes the misleading 403, but the full fix requires source-byte replication (see deferred follow-up below) so leaving the issue open for the bytes work.

## Summary

A peer node (Hermes) joined a public + open Context Graph (`accessPolicy: 0`, `publishPolicy: 1`) and replicated all 53 SWM triples correctly, but every attempt to fetch the imported Markdown source via `/api/assertion/import-artifact/{resolve, read-markdown}` returned 403:

> Import artifact Markdown can only be read from imported assertions owned by the requesting agent

That gate (`assertImportedArtifactOwnerAddress` in `packages/cli/src/daemon/routes/assertion.ts`) was policy-agnostic — it fired for both curated and public CGs, which directly contradicted the on-chain access policy the curator chose.

This PR makes the gate policy-aware: when the daemon can confirm the CG is public AND open (`accessPolicy === 0` AND `publishPolicy === 1`) AND the CG is registered on-chain, the owner guard is dropped on the READ routes only. Every other policy combination (curated access, curators-only publish, an unregistered locally-created CG, or any case where the policy isn't locally known) **keeps the existing 403** — fail-closed. The WRITE route (`/semantic-enrichment/write`) keeps the strict guard regardless of CG policy. Legacy ownerless `assertionUri` always go through the strict guard so the existing owner-self-read back-compat path is preserved.

`DKGAgent.getContextGraphOnChainPolicy` resolves the policy from three sources in order: (1) in-memory cache populated by `ContextGraphCreated` chain events, (2) local `_meta` / ontology triples (creator only for `publishPolicy`), (3) a direct chain RPC fallback for registered CGs where the first two sources don't have an answer (non-creator peers after daemon restart). Steps 2 and 3 are gated on `isContextGraphRegistered`.

## Codex feedback addressed

Codex reviewed this PR in three rounds; all findings are fixed.

**Round 1 — `533c0d87`:**

- **Finding 1 (🔴 security) — owner-guard relaxation also opened the write path.** `resolveImportedArtifact()` is shared by the two `/import-artifact/*` read routes AND `/semantic-enrichment/write`, so the initial relaxation unintentionally let non-owner peers on a public + open CG mutate someone else's imported assertion graph. **Fix:** added an explicit `relaxOnPublicOpenCg?: boolean` parameter to `resolveImportedArtifact`'s `ownerGuard` config (default `false`). Only the two read routes pass `true`; the write route leaves it unset and keeps the strict guard. Probing the on-chain policy is skipped entirely on the write path.
- **Finding 2 (🟡 UX) — legacy ownerless URI canonicalization.** `parseImportedAssertionUri` rewrites legacy ownerless URIs (`.../assertion/<name>`) using the requester's agent DID, which silently canonicalizes to the wrong URI for cross-agent peers. Round-1 fix added an upfront 400 rejection for legacy URIs on public+open CGs — which round 2 immediately flagged as overreach (see Finding A below).

**Round 2 — `61baab8c`:**

- **Finding A (🔴 bug, regression on round 1) — legacy-URI rejection broke owner self-reads.** The round-1 unconditional 400 also rejected legitimate owner self-reads of legacy URIs (`parseImportedAssertionUri`'s back-compat fallback canonicalizes the missing owner segment to the requester, which is correct for the owner themselves). **Fix:** dropped the upfront 400. Instead, skip the relaxation branch when `parsedAssertion.legacy === true`; the strict guard then runs uniformly for legacy URIs. Owner self-reads pass the guard (legacy fallback makes `assertionAgentAddress === requestAgentAddress`) and the meta lookup succeeds → 200. Non-owner cross-agent reads canonicalize to the wrong URI, the meta SPARQL misses, and the route returns the pre-PR back-compat 404 ("No completed import metadata found").
- **Finding B (🔴 bug, security) — local-policy fallback marked unregistered CGs as public+open.** `DKGAgent.getContextGraphOnChainPolicy` fell back to local `_meta` / ontology triples when the chain-event cache was cold. But `createContextGraph` writes those triples synchronously BEFORE `registerContextGraph` confirms the CG on-chain, so a locally-created-but-not-yet-registered CG with `accessPolicy:0, publishPolicy:1` would have satisfied the daemon's read relaxation and bypassed the owner guard on a CG the curator hadn't actually committed to on-chain yet. **Fix:** gated the local-triple fallback on `isContextGraphRegistered`. Unregistered CGs (or CGs where the probe itself rejects — caught and treated as not-registered defensively) return `{}` and the daemon route fails closed (legacy 403).

**Round 3 — `f452594b`:**

- **Finding (🔴 bug, regression on round 2 — non-creator peers can never recover `publishPolicy` after a restart).** Round 2's `isContextGraphRegistered` gate correctly blocked the unregistered-local-CG bypass but exposed an existing gap: `dkg:publishPolicy` is only written to local `_meta` by `createContextGraph` on the CREATOR's node. Non-creator peers never receive that triple via SWM. They populate the in-memory cache from the `ContextGraphCreated` event at subscribe time, but the cache is lost on daemon restart — after which `getContextGraphOnChainPolicy()` returns `{ publishPolicy: undefined }` permanently, `isPublicOpenContextGraph()` goes false, and cross-agent reads regress to 403 on legitimately public + open CGs. **Fix:** added a direct chain-RPC fallback after the local-triple lookup. When the CG is confirmed registered (round-2 gate preserved) and a field is still undefined, the agent calls `chain.getContextGraphPublishPolicy(onChainId)` / `chain.getContextGraphAccessPolicy(onChainId)` for the missing field(s), caches the result, and returns. RPC failures are caught + logged with the field left undefined (daemon route then falls back to the strict guard — fail-closed preserved). Required adding one new optional method to the `ChainAdapter` surface: `getContextGraphPublishPolicy(contextGraphId: bigint) → { publishPolicy: number; publishAuthority: string }`, implemented in both `evm-adapter.ts` (single eth_call to `ContextGraphStorage.getPublishPolicy(uint256)`) and `mock-adapter.ts`.

## Changes

- **`packages/agent/src/dkg-agent.ts`**
  - New `onChainPublishPolicyCache` mirrors the existing `onChainAccessPolicyCache`. The `ContextGraphCreated` chain event already carried `publishPolicy`; the cache slot was just missing.
  - New public `getContextGraphOnChainPolicy(contextGraphId)` returns `{ accessPolicy?, publishPolicy? }` from three sources: chain-event caches → local `_meta` / ontology triples → direct chain RPC fallback (round-3). Steps 2 and 3 are gated on `isContextGraphRegistered()` (round-2 Finding B). Unknown values come back as `undefined`; the daemon route fails closed in that case.
  - The chain event handler now caches both enums (1-line addition).

- **`packages/chain/src/{chain-adapter,evm-adapter,mock-adapter}.ts`**
  - New optional `getContextGraphPublishPolicy(contextGraphId: bigint)` on the `ChainAdapter` interface. EVM adapter calls `ContextGraphStorage.getPublishPolicy(uint256)` (single eth_call); mock adapter reads from the in-memory `contextGraphs` map for parity.

- **`packages/cli/src/daemon/routes/assertion.ts`**
  - New `isPublicOpenContextGraph(agent, contextGraphId)` helper consults the agent's policy resolver and returns `true` only for the strict `(0, 1)` combo.
  - `resolveImportedArtifact` accepts an opt-in `ownerGuard.relaxOnPublicOpenCg` flag (round-1 Finding 1). Only the two read routes pass `true`. When set AND the CG is confirmed public + open AND the URI is NOT a legacy ownerless form (round-2 Finding A): the owner guard is dropped and `ownerGuardRelaxed: true` is recorded on the artifact response for non-owner requests.
  - `read-markdown` uses `ownerGuardRelaxed` to surface a distinct 404 message ("Markdown source bytes are not replicated locally on this peer…") instead of the generic "not present in the file store" wording. The 200 / 404 / 413 status semantics are unchanged.

- **`packages/cli/test/import-artifact-routes.test.ts`**
  - 23 baseline → 31 tests covering: public + open non-owner read with bytes available → 200 with `ownerGuardRelaxed: true`; non-owner read with bytes missing → 404 with the new "not replicated locally" wording; mixed `(0, 0)` non-owner → 403; public + open OWNER read → 200 without `ownerGuardRelaxed`; non-owner semantic-enrichment WRITE on public + open → 403 (round-1 Finding 1); owner self-read of legacy ownerless URI on public + open → 200 (round-2 Finding A); cross-agent legacy URI on public + open → 404 (round-2 Finding A companion); on-chain policy unknown (e.g. unregistered CG) → 403 (round-2 Finding B).
  - The mock agent gained an opt-in `onChainPolicy` parameter so existing tests (which omit it) continue to exercise the "policy unknown → fail closed → legacy 403" branch.

- **`packages/agent/test/dkg-agent-on-chain-policy.test.ts`** (new)
  - 10 unit tests for `DKGAgent.getContextGraphOnChainPolicy` using the binding-stub pattern from `dkg-agent-diagnostics.test.ts`: cache-hit short-circuit; the round-2 Finding B gate (`unregistered → {}`, proven by stubbing the fallback methods to public+open and asserting they were never called); registered-CG fallback (back-compat preserved); transient `isContextGraphRegistered` rejection → treated as not-registered; mixed cache-hit path; round-3 non-creator + missing local + chain RPC succeeds → returns chain values + cache populated; round-3 chain RPC failure → returns undefined + warning logged + cache NOT populated; round-3 unregistered + missing local → no chain RPC (gate held); round-3 creator path with both local fields → no chain RPC; round-3 registered but unresolvable on-chain id → returns local-only answer + no chain RPC.

## Out of scope (deferred follow-up)

Even with the guard dropped, peers replicating a public + open CG today have the **SWM triples** but **not the source artifact bytes** — those aren't gossipped. So cross-agent `read-markdown` will return the new 404 ("not replicated locally") until source-byte replication is added. The fix here closes the *misleading* 403 (you can now resolve metadata + tell from the response whether to retry against the origin agent), but the byte-gossip work is a real architectural question that belongs in its own PR/issue.

A code comment in `resolveImportedArtifact` and in the read-markdown 404 path documents the deferred work, pointing at #872.

## Implementation notes

- The agent has no `publishPolicy` cache pre-PR, even though the chain event carries the field. This PR adds the cache slot and wires the event handler — minimal surface area, no extra chain RPCs on the request path for the cache-warm case.
- The local `_meta` / ontology fallback for cold caches is gated on `isContextGraphRegistered` (round-2 Finding B) so it only contributes for on-chain-confirmed CGs.
- The chain-RPC fallback (round 3) is gated on the same `registered === true` check, so the round-2 security property is preserved. It only fires when both the cache AND local triples failed to answer for a registered CG — the common case for non-creator peers after a daemon restart.
- The chain adapter surface gained `getContextGraphPublishPolicy` (interface + EVM + mock). The Solidity contract method already existed (`ContextGraphStorage.getPublishPolicy(uint256)`).

## Open questions / caveats

- For a brand-new node that joined a CG after the chain-event poller's lookback window had rolled past the create block AND the chain RPC fails AND no local triples exist, the legacy 403 will remain in force. This is the correct fail-closed behaviour for an unrecoverable policy lookup.
- I considered making `assertImportedArtifactOwnerAddress` itself policy-aware vs threading the decision through `resolveImportedArtifact`. Settled on threading because it kept the existing guard call signature untouched and made the "relaxed" state observable on the artifact response (which the read-markdown 404 message needs).
- After round-2 Finding A, cross-agent legacy URI reads on public + open CGs return the back-compat 404 ("No completed import metadata found") rather than a more actionable error. V10 always emits canonical URIs so the practical impact is limited to pre-V10 imported data; callable peers can request the canonical URI form.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg exec vitest run test/import-artifact-routes.test.ts` — **31/31 passing** (8 new + 23 existing).
- [x] `pnpm --filter @origintrail-official/dkg-agent exec vitest run test/dkg-agent-on-chain-policy.test.ts` — **10/10 passing** (round-2 Finding B + round-3 chain RPC coverage).
- [x] `pnpm --filter @origintrail-official/dkg-chain build` — chain package compiles with the new adapter method.
- [x] `pnpm --filter @origintrail-official/dkg-agent build` — agent compiles, no regressions.
- [x] `pnpm --filter @origintrail-official/dkg build` — CLI compiles.
- [ ] Manual reproduction against the Hermes setup from the bug report: peer joining the public + open CG should now see 200 (resolve metadata) and 404 with the new "not replicated locally" message (read-markdown until source-byte gossip lands).


Made with [Cursor](https://cursor.com)
