### PR TITLE
fix(agent/sync): cover sub-graph SWM in catchup + close approve-time race

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2539,7 +2539,16 @@ export class DKGAgent {
             // yet at this point on multi-agent nodes).
             this.localApprovedAgentByCG.set(contextGraphId, approvedAddr.toLowerCase());
             this.log.info(createOperationContext('system'), `Join request approved for "${contextGraphId}" — auto-subscribing`);
-            this.subscribeToContextGraph(contextGraphId);
+            // Defer the SWM gossip subscribe specifically: the curator's
+            // allowlist hasn't synced into our local `_meta` yet, so a
+            // pre-meta `canReadContextGraph` check would deny and emit a
+            // misleading WARN. `runImmediatePostApprovalSync` below pulls
+            // `_meta`, then `refreshMetaSyncedFlags` (called from
+            // `runCatchupOverPeers`) re-queues the SWM gossip subscribe
+            // once the allowlist is locally visible — clean self-heal,
+            // no spurious denial. Other gossip topics (publish/app/
+            // update/finalization) wire up immediately as before.
+            this.subscribeToContextGraph(contextGraphId, { deferSharedMemoryGossipSubscribe: true });
             this.upsertContextGraphMember({
               contextGraphId,
               principalType: 'agent',
@@ -10305,14 +10314,29 @@ export class DKGAgent {
     });
   }
 
-  subscribeToContextGraph(contextGraphId: string, options?: { trackSyncScope?: boolean; persist?: boolean }): void {
+  subscribeToContextGraph(contextGraphId: string, options?: { trackSyncScope?: boolean; persist?: boolean; deferSharedMemoryGossipSubscribe?: boolean }): void {
     if (options?.trackSyncScope !== false) {
       this.trackSyncContextGraph(contextGraphId);
     }
 
+    // SWM gossip subscribe runs `canReadContextGraph` against the local
+    // `_meta` graph. On a fresh `join-approved` notification the curator
+    // has just written the allowlist into ITS _meta, but the requesting
+    // node hasn't synced that allowlist yet — so the very first SWM
+    // gossip subscribe attempt fails with `local node is not authorized`,
+    // emitting a misleading WARN. The real fix is to land the allowlist
+    // first via `runImmediatePostApprovalSync`; once `_meta` syncs,
+    // `refreshMetaSyncedFlags` re-queues the SWM gossip subscribe (line
+    // 3738) and it succeeds silently. This option lets the join-approved
+    // path opt out of the immediate SWM subscribe and rely on that
+    // self-heal — see urn:dkg:finding:swm-gap-1-initial-sync-race.
+    const deferSwmGossip = options?.deferSharedMemoryGossipSubscribe === true;
+
     // Idempotent: skip if gossip handlers already installed for this context graph.
     if (this.gossipRegistered.has(contextGraphId)) {
-      this.queueSharedMemoryGossipSubscription(contextGraphId);
+      if (!deferSwmGossip) {
+        this.queueSharedMemoryGossipSubscription(contextGraphId);
+      }
       const existing = this.subscribedContextGraphs.get(contextGraphId);
       if (!existing?.subscribed) {
         this.setContextGraphSubscription(
@@ -10343,7 +10367,9 @@ export class DKGAgent {
       await gph.handlePublishMessage(data, contextGraphId, undefined, from);
     });
 
-    this.queueSharedMemoryGossipSubscription(contextGraphId);
+    if (!deferSwmGossip) {
+      this.queueSharedMemoryGossipSubscription(contextGraphId);
+    }
 
     const updateTopic = contextGraphUpdateTopic(contextGraphId);
     this.gossip.subscribe(updateTopic);

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -238,9 +238,6 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
   // BOTH `rdf:type WorkspaceOperation` AND `dkg:publishedAt` in the
   // SAME meta graph to count.
   const validOpsByMeta = new Map<string, Set<string>>();
-  // Also keep a flat union for callers (entityCreators emission below)
-  // that don't need graph-scoping — the per-entity creator mapping is
-  // first-write-wins across graphs by design.
   const validOps = new Set<string>();
   for (const [metaGraph, typedOps] of opsWithTypeByMeta) {
     const publishedOps = opsWithPublishedAtByMeta.get(metaGraph);
@@ -307,13 +304,17 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
     if (peer) opCreators.set(op, peer);
   }
 
-  const entityCreators = new Map<string, string>();
+  const entityCreators = new Map<string, { dataGraph: string; entity: string; creator: string }>();
   for (const q of wsMetaQuads) {
-    if (q.predicate === DKG_ROOT_ENTITY && validOps.has(q.subject)) {
+    const validForGraph = validOpsByMeta.get(q.graph);
+    if (q.predicate === DKG_ROOT_ENTITY && validForGraph?.has(q.subject)) {
+      if (!q.graph.endsWith(META_SUFFIX)) continue;
+      const dataGraph = q.graph.slice(0, -META_SUFFIX.length);
       const entity = q.object.startsWith('"') ? stripLiteral(q.object) : q.object;
       const creator = opCreators.get(q.subject);
-      if (creator && !entityCreators.has(entity)) {
-        entityCreators.set(entity, creator);
+      const key = `${dataGraph}\0${entity}`;
+      if (creator && !entityCreators.has(key)) {
+        entityCreators.set(key, { dataGraph, entity, creator });
       }
     }
   }
@@ -321,7 +322,7 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
   return {
     validQuads,
     dropped: wsDataQuads.length - validQuads.length,
-    entityCreators: [...entityCreators.entries()],
+    entityCreators: [...entityCreators.values()],
   };
 }
 

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -207,26 +207,78 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
   const DKG_PUBLISHER_PEER_ID = 'http://dkg.io/ontology/publisherPeerId';
   const PROV_ATTRIBUTED_TO = 'http://www.w3.org/ns/prov#wasAttributedTo';
   const SKOLEM_PREFIX = '/.well-known/genid/';
+  // SWM meta graphs are derived from data graphs by appending "_meta"
+  // (see `contextGraphSharedMemoryMetaUri` in dkg-core/constants.ts:
+  //   <cgPrefix>/_shared_memory      <-> <cgPrefix>/_shared_memory_meta
+  //   <cgPrefix>/<sub>/_shared_memory <-> <cgPrefix>/<sub>/_shared_memory_meta
+  // Stripping the suffix yields the matching data graph URI.
+  const META_SUFFIX = '_meta';
 
-  const opsWithType = new Set<string>();
-  const opsWithPublishedAt = new Set<string>();
+  // Codex review on #885 — keep validity scoped per (meta graph, op
+  // subject). Pre-fix the Sets were global, so an op subject that
+  // appeared in two `_shared_memory_meta` graphs (sub-A + sub-B) had
+  // its `rootEntity` admitted as universally valid even when only one
+  // of the graphs actually contained the matching data quads. The
+  // graph-keyed maps below preserve the responder's per-graph scoping
+  // exactly, then the data filter consults the same scope.
+  const opsWithTypeByMeta = new Map<string, Set<string>>();
+  const opsWithPublishedAtByMeta = new Map<string, Set<string>>();
   for (const q of wsMetaQuads) {
-    if (q.predicate === RDF_TYPE && q.object === DKG_WORKSPACE_OP) opsWithType.add(q.subject);
-    if (q.predicate === DKG_PUBLISHED_AT) opsWithPublishedAt.add(q.subject);
-  }
-  const validOps = new Set<string>([...opsWithType].filter((subject) => opsWithPublishedAt.has(subject)));
-
-  const allowedRoots = new Set<string>();
-  for (const q of wsMetaQuads) {
-    if (q.predicate === DKG_ROOT_ENTITY && validOps.has(q.subject)) {
-      const entity = q.object.startsWith('"') ? stripLiteral(q.object) : q.object;
-      allowedRoots.add(entity);
+    if (q.predicate === RDF_TYPE && q.object === DKG_WORKSPACE_OP) {
+      let s = opsWithTypeByMeta.get(q.graph);
+      if (!s) { s = new Set(); opsWithTypeByMeta.set(q.graph, s); }
+      s.add(q.subject);
+    } else if (q.predicate === DKG_PUBLISHED_AT) {
+      let s = opsWithPublishedAtByMeta.get(q.graph);
+      if (!s) { s = new Set(); opsWithPublishedAtByMeta.set(q.graph, s); }
+      s.add(q.subject);
     }
+  }
+  // (metaGraph → set of op subjects valid in that graph). An op needs
+  // BOTH `rdf:type WorkspaceOperation` AND `dkg:publishedAt` in the
+  // SAME meta graph to count.
+  const validOpsByMeta = new Map<string, Set<string>>();
+  // Also keep a flat union for callers (entityCreators emission below)
+  // that don't need graph-scoping — the per-entity creator mapping is
+  // first-write-wins across graphs by design.
+  const validOps = new Set<string>();
+  for (const [metaGraph, typedOps] of opsWithTypeByMeta) {
+    const publishedOps = opsWithPublishedAtByMeta.get(metaGraph);
+    if (!publishedOps) continue;
+    const valid = new Set<string>();
+    for (const op of typedOps) {
+      if (publishedOps.has(op)) {
+        valid.add(op);
+        validOps.add(op);
+      }
+    }
+    if (valid.size > 0) validOpsByMeta.set(metaGraph, valid);
+  }
+
+  // (dataGraph → set of allowed rootEntities). Derived from each meta
+  // graph by stripping the `_meta` suffix to yield the partner data
+  // graph URI. Op-meta quads from a graph that doesn't follow the
+  // suffix convention are skipped — they cannot be paired with a
+  // matching `_shared_memory` data graph and would only contribute
+  // unsoundness.
+  const allowedRootsByDataGraph = new Map<string, Set<string>>();
+  for (const q of wsMetaQuads) {
+    if (q.predicate !== DKG_ROOT_ENTITY) continue;
+    const validForGraph = validOpsByMeta.get(q.graph);
+    if (!validForGraph || !validForGraph.has(q.subject)) continue;
+    if (!q.graph.endsWith(META_SUFFIX)) continue;
+    const dataGraph = q.graph.slice(0, -META_SUFFIX.length);
+    const entity = q.object.startsWith('"') ? stripLiteral(q.object) : q.object;
+    let s = allowedRootsByDataGraph.get(dataGraph);
+    if (!s) { s = new Set(); allowedRootsByDataGraph.set(dataGraph, s); }
+    s.add(entity);
   }
 
   const validQuads = wsDataQuads.filter((q) => {
-    if (allowedRoots.has(q.subject)) return true;
-    for (const root of allowedRoots) {
+    const allowed = allowedRootsByDataGraph.get(q.graph);
+    if (!allowed) return false;
+    if (allowed.has(q.subject)) return true;
+    for (const root of allowed) {
       if (q.subject.startsWith(root + SKOLEM_PREFIX)) return true;
     }
     return false;

--- a/packages/agent/src/sync-verify-worker.ts
+++ b/packages/agent/src/sync-verify-worker.ts
@@ -24,7 +24,7 @@ export interface SyncParseResult {
 export interface SharedMemoryProcessResult {
   validQuads: Quad[];
   dropped: number;
-  entityCreators: Array<[string, string]>;
+  entityCreators: Array<{ dataGraph: string; entity: string; creator: string }>;
 }
 
 export interface SharedMemoryBatchProcessResult {
@@ -34,7 +34,7 @@ export interface SharedMemoryBatchProcessResult {
   totalFetchedMetaQuads: number;
   droppedDataTriples: number;
   emptyResponses: number;
-  entityCreators: Array<[string, string]>;
+  entityCreators: Array<{ dataGraph: string; entity: string; creator: string }>;
 }
 
 export interface DurableBatchProcessResult {

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -1,4 +1,4 @@
-import { contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri } from '@origintrail-official/dkg-core';
+import { contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri, validateSubGraphName } from '@origintrail-official/dkg-core';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
@@ -43,14 +43,14 @@ interface SharedMemorySyncContext {
     totalFetchedMetaQuads: number;
     droppedDataTriples: number;
     emptyResponses: number;
-    entityCreators: Array<[string, string]>;
+    entityCreators: Array<{ dataGraph: string; entity: string; creator: string }>;
   }>;
   ensureContextGraph: (contextGraphId: string) => Promise<void>;
   storeInsert: (quads: Quad[]) => Promise<void>;
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
   deleteCheckpoint: (key: string) => void;
   setCheckpoint: (key: string, offset: number) => void;
-  ensureOwnedMap: (contextGraphId: string) => Map<string, string>;
+  ensureOwnedMap: (ownershipKey: string) => Map<string, string>;
   logInfo: (ctx: OperationContext, message: string) => void;
   logWarn: (ctx: OperationContext, message: string) => void;
   logDebug: (ctx: OperationContext, message: string) => void;
@@ -157,8 +157,13 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       if (wsDataResult.completed) deleteCheckpoint(wsDataResult.checkpointKey);
       else setCheckpoint(wsDataResult.checkpointKey, wsDataResult.nextOffset);
 
-      const ownedMap = ensureOwnedMap(pid);
-      for (const [entity, creator] of processed.entityCreators) {
+      for (const { dataGraph, entity, creator } of processed.entityCreators) {
+        const ownershipKey = sharedMemoryOwnershipKeyFromGraph(pid, dataGraph);
+        if (!ownershipKey) {
+          logWarn(ctx, `SWM sync skipped ownership cache hydration for "${entity}" from unexpected graph "${dataGraph}"`);
+          continue;
+        }
+        const ownedMap = ensureOwnedMap(ownershipKey);
         if (!ownedMap.has(entity)) {
           ownedMap.set(entity, creator);
         }
@@ -185,6 +190,21 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
   }
 
   return summary;
+}
+
+function sharedMemoryOwnershipKeyFromGraph(contextGraphId: string, dataGraph: string): string | undefined {
+  const rootGraph = contextGraphWorkspaceGraphUri(contextGraphId);
+  if (dataGraph === rootGraph) return contextGraphId;
+
+  const prefix = `did:dkg:context-graph:${contextGraphId}/`;
+  const suffix = '/_shared_memory';
+  if (!dataGraph.startsWith(prefix) || !dataGraph.endsWith(suffix)) return undefined;
+
+  const subGraphName = dataGraph.slice(prefix.length, -suffix.length);
+  if (!subGraphName || subGraphName.includes('/')) return undefined;
+  if (!validateSubGraphName(subGraphName).valid) return undefined;
+
+  return `${contextGraphId}\0${subGraphName}`;
 }
 
 interface PublicSnapshotMetadata {

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -117,10 +117,15 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       // and the auto-register in
       // `FinalizationHandler.ensureContextGraphAndSubGraph`,
       // finalization-handler.ts:540). Admit only the root SWM and the
-      // SWM of registered sub-graphs of THIS CG; nested CGs that share
-      // a URI prefix have their registration in their own
-      // `<nestedPrefix>/_meta`, not the parent CG's, so they are
-      // naturally excluded.
+      // SWM of registered sub-graphs of THIS CG.
+      //
+      // Codex review round 5: a parent sub-graph and a known child CG can
+      // still collide on the exact same graph URI:
+      //   parent sub-graph "code" => <parent>/code/_shared_memory
+      //   child CG "parent/code"  => <parent>/code/_shared_memory
+      // Match dkg-query-engine's scoped allowlist and reject registered
+      // sub-graph candidates whose `<cgPrefix>/<name>` is also known as a
+      // child context graph via its own `_meta` graph.
       const cgPrefix = `did:dkg:context-graph:${contextGraphId}`;
       const cgMetaGraph = `${cgPrefix}/_meta`;
       const rootSwm = `${cgPrefix}/_shared_memory`;
@@ -138,6 +143,17 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             ?sg <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dkg.io/ontology/SubGraph> .
             ?sg <http://schema.org/name> ?subGraphName .
             FILTER(STR(?g) = CONCAT("${cgPrefix}/", STR(?subGraphName), "${suffix}"))
+          }
+          FILTER NOT EXISTS {
+            GRAPH ?childMetaGraph {
+              {
+                ?childContextGraph <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://dkg.network/ontology#ContextGraph> .
+              } UNION {
+                ?childContextGraph <https://dkg.network/ontology#registrationStatus> ?childStatus .
+              }
+            }
+            FILTER(STR(?childContextGraph) = CONCAT("${cgPrefix}/", STR(?subGraphName)))
+            FILTER(STR(?childMetaGraph) = CONCAT(STR(?childContextGraph), "/_meta"))
           }
         }`;
       };

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -1,5 +1,5 @@
 import { createOperationContext, DKG_ONTOLOGY, MemoryLayer, type OperationContext } from '@origintrail-official/dkg-core';
-import { contextGraphDataGraphUri, contextGraphMetaGraphUri, contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri } from '@origintrail-official/dkg-core';
+import { contextGraphDataGraphUri, contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { serializeWorkspacePublicSnapshotQuads, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
@@ -78,9 +78,28 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     }
 
     if (isWorkspace) {
-      const wsGraph = contextGraphWorkspaceGraphUri(contextGraphId);
-      const wsMetaGraph = contextGraphWorkspaceMetaGraphUri(contextGraphId);
       const cutoff = sharedMemoryTtlMs > 0 ? new Date(Date.now() - sharedMemoryTtlMs).toISOString() : null;
+      // SWM lives at two URI shapes per CG (see `contextGraphSharedMemoryUri`
+      // / `contextGraphSharedMemoryMetaUri` in dkg-core/constants.ts):
+      //   <cgPrefix>/_shared_memory                  (root SWM)
+      //   <cgPrefix>/<sub>/_shared_memory            (sub-graph SWM)
+      //   <cgPrefix>/_shared_memory_meta             (root SWM meta)
+      //   <cgPrefix>/<sub>/_shared_memory_meta       (sub-graph SWM meta)
+      //
+      // Pre-PR-X this branch only queried the root graphs (via
+      // `contextGraphWorkspaceGraphUri`/`...MetaGraphUri`, which are
+      // hardcoded aliases for the root). A sync requester therefore
+      // received zero bytes of any sub-graph SWM the responder had
+      // locally, so a late joiner who joined AFTER the curator had
+      // published into a sub-graph could not backfill that history
+      // through `/dkg/10.0.1/sync` — see the SWM late-joiner backfill
+      // gap (urn:dkg:finding:swm-gap-2-subgraph-blind-spot). Filter
+      // by URI shape under the CG prefix and emit `?g` per binding so
+      // the requester reconstructs the correct graph at write time.
+      // Sub-graph names cannot contain `/` and cannot start with `_`
+      // (`validateSubGraphName` in dkg-core/constants.ts), so the
+      // shape-based FILTER is exact.
+      const cgPrefix = `did:dkg:context-graph:${contextGraphId}`;
 
       if (phase === 'snapshot') {
         const snapshotRef = request.snapshotRef?.trim();
@@ -99,16 +118,20 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         logDebug(createOperationContext('sync'), `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
       } else if (phase === 'meta') {
         const metaQuery = cutoff != null
-          ? `SELECT ?s ?p ?o WHERE {
-              GRAPH <${wsMetaGraph}> { ?s ?p ?o }
+          ? `SELECT ?s ?p ?o ?g WHERE {
+              GRAPH ?g { ?s ?p ?o }
+              FILTER(STRSTARTS(STR(?g), "${cgPrefix}/") && STRENDS(STR(?g), "/_shared_memory_meta"))
               FILTER EXISTS {
-                GRAPH <${wsMetaGraph}> {
+                GRAPH ?g {
                   ?s <http://dkg.io/ontology/publishedAt> ?ts .
                   FILTER(?ts >= "${cutoff}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
                 }
               }
-            } ORDER BY ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`
-          : `SELECT ?s ?p ?o WHERE { GRAPH <${wsMetaGraph}> { ?s ?p ?o } } ORDER BY ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`;
+            } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`
+          : `SELECT ?s ?p ?o ?g WHERE {
+              GRAPH ?g { ?s ?p ?o }
+              FILTER(STRSTARTS(STR(?g), "${cgPrefix}/") && STRENDS(STR(?g), "/_shared_memory_meta"))
+            } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`;
 
         const queryStartedAt = Date.now();
         const metaResult = await store.query(metaQuery);
@@ -117,24 +140,41 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         if (metaResult.type === 'bindings') {
           for (const b of metaResult.bindings) {
             const obj = b['o'].startsWith('"') ? b['o'] : `<${b['o']}>`;
-            nquads.push(`<${b['s']}> <${b['p']}> ${obj} <${wsMetaGraph}> .`);
+            nquads.push(`<${b['s']}> <${b['p']}> ${obj} <${b['g']}> .`);
           }
         }
         const serializeDurationMs = Date.now() - serializeStartedAt;
         logDebug(createOperationContext('sync'), `Sync responder SWM meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
       } else {
+        // The TTL branch joins a WorkspaceOperation entry (in the
+        // matching `_shared_memory_meta` graph) to its root entity
+        // and skolemized children (in the same-prefix `_shared_memory`
+        // graph). Bind the two graphs together by URI structure:
+        //   STR(?gMeta) = CONCAT(STR(?g), "_meta")
+        // so a publish into sub-graph "foo" pairs ops in
+        // `<cgPrefix>/foo/_shared_memory_meta` with entities in
+        // `<cgPrefix>/foo/_shared_memory` only — without bleeding into
+        // a different sub-graph's ops or into root ops.
         const wsQuery = cutoff != null
-          ? `SELECT DISTINCT ?s ?p ?o WHERE {
-  GRAPH <${wsMetaGraph}> {
+          ? `SELECT DISTINCT ?s ?p ?o ?g WHERE {
+  GRAPH ?gMeta {
     ?op <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dkg.io/ontology/WorkspaceOperation> .
     ?op <http://dkg.io/ontology/publishedAt> ?ts .
     ?op <http://dkg.io/ontology/rootEntity> ?re .
     FILTER(?ts >= "${cutoff}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
   }
-  GRAPH <${wsGraph}> { ?s ?p ?o }
+  GRAPH ?g { ?s ?p ?o }
+  FILTER(
+    STRSTARTS(STR(?g), "${cgPrefix}/") &&
+    STRENDS(STR(?g), "/_shared_memory") &&
+    STR(?gMeta) = CONCAT(STR(?g), "_meta")
+  )
   FILTER(?s = ?re || STRSTARTS(STR(?s), CONCAT(STR(?re), "/.well-known/genid/")))
-} ORDER BY ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`
-          : `SELECT ?s ?p ?o WHERE { GRAPH <${wsGraph}> { ?s ?p ?o } } ORDER BY ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`;
+} ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`
+          : `SELECT ?s ?p ?o ?g WHERE {
+              GRAPH ?g { ?s ?p ?o }
+              FILTER(STRSTARTS(STR(?g), "${cgPrefix}/") && STRENDS(STR(?g), "/_shared_memory"))
+            } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`;
 
         const queryStartedAt = Date.now();
         const wsResult = await store.query(wsQuery);
@@ -145,7 +185,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const serializeStartedAt = Date.now();
         for (const b of wsResult.bindings) {
           const obj = b['o'].startsWith('"') ? b['o'] : `<${b['o']}>`;
-          nquads.push(`<${b['s']}> <${b['p']}> ${obj} <${wsGraph}> .`);
+          nquads.push(`<${b['s']}> <${b['p']}> ${obj} <${b['g']}> .`);
         }
         const serializeDurationMs = Date.now() - serializeStartedAt;
         logDebug(createOperationContext('sync'), `Sync responder SWM data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -98,8 +98,49 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       // the requester reconstructs the correct graph at write time.
       // Sub-graph names cannot contain `/` and cannot start with `_`
       // (`validateSubGraphName` in dkg-core/constants.ts), so the
-      // shape-based FILTER is exact.
+      // segment between `<cgPrefix>/` and `/_shared_memory[_meta]` is
+      // always a single path component when it represents a sub-graph.
+      //
+      // Codex review on #885 — URI shape alone is NOT a sufficient CG
+      // boundary because `contextGraphId` itself permits `/` (wallet-
+      // scoped IDs do, e.g. `0xabc/project`, and `validateContextGraphId`
+      // accepts `/`). For a request on CG `cg-A`, the URI
+      // `<cgPrefix>/child/_shared_memory` is structurally
+      // indistinguishable from a sub-graph "child" of cg-A AND from the
+      // root SWM of a different CG `cg-A/child` — even with a tightened
+      // STRBEFORE/STRAFTER segment check that allows exactly one path
+      // segment.
+      //
+      // Disambiguate by registration: the `<cgPrefix>/_meta` graph
+      // carries the SubGraph registration triples (see
+      // `DKGPublisher.isSubGraphRegistered` in dkg-publisher.ts:3828
+      // and the auto-register in
+      // `FinalizationHandler.ensureContextGraphAndSubGraph`,
+      // finalization-handler.ts:540). Admit only the root SWM and the
+      // SWM of registered sub-graphs of THIS CG; nested CGs that share
+      // a URI prefix have their registration in their own
+      // `<nestedPrefix>/_meta`, not the parent CG's, so they are
+      // naturally excluded.
       const cgPrefix = `did:dkg:context-graph:${contextGraphId}`;
+      const cgMetaGraph = `${cgPrefix}/_meta`;
+      const rootSwm = `${cgPrefix}/_shared_memory`;
+      const rootSwmMeta = `${cgPrefix}/_shared_memory_meta`;
+      // Registered sub-graphs are identified by their schema:name
+      // literal in `<cgPrefix>/_meta`. Reconstruct the canonical
+      // SWM/SWM_meta URI from that name (matching
+      // `contextGraphSharedMemoryUri` in dkg-core/constants.ts) so
+      // sub-graph entities slated under arbitrary `<cgPrefix>/<name>/...`
+      // shapes (e.g. assertion graphs) are not accidentally admitted.
+      const registeredSubGraphSwmFilter = (forMeta: boolean) => {
+        const suffix = forMeta ? '/_shared_memory_meta' : '/_shared_memory';
+        return `EXISTS {
+          GRAPH <${cgMetaGraph}> {
+            ?sg <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dkg.io/ontology/SubGraph> .
+            ?sg <http://schema.org/name> ?subGraphName .
+            FILTER(STR(?g) = CONCAT("${cgPrefix}/", STR(?subGraphName), "${suffix}"))
+          }
+        }`;
+      };
 
       if (phase === 'snapshot') {
         const snapshotRef = request.snapshotRef?.trim();
@@ -117,10 +158,15 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         nquads.push(serializeWorkspacePublicSnapshotQuads(page).trimEnd());
         logDebug(createOperationContext('sync'), `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
       } else if (phase === 'meta') {
+        // Codex review on #885 — admit only the root SWM_meta + the
+        // SWM_meta of REGISTERED sub-graphs of this CG. Nested CGs
+        // sharing the prefix have their registration in their own
+        // `_meta`, not this CG's, so they are excluded.
+        const metaBoundaryFilter = `STR(?g) = "${rootSwmMeta}" || ${registeredSubGraphSwmFilter(true)}`;
         const metaQuery = cutoff != null
           ? `SELECT ?s ?p ?o ?g WHERE {
               GRAPH ?g { ?s ?p ?o }
-              FILTER(STRSTARTS(STR(?g), "${cgPrefix}/") && STRENDS(STR(?g), "/_shared_memory_meta"))
+              FILTER(${metaBoundaryFilter})
               FILTER EXISTS {
                 GRAPH ?g {
                   ?s <http://dkg.io/ontology/publishedAt> ?ts .
@@ -130,7 +176,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`
           : `SELECT ?s ?p ?o ?g WHERE {
               GRAPH ?g { ?s ?p ?o }
-              FILTER(STRSTARTS(STR(?g), "${cgPrefix}/") && STRENDS(STR(?g), "/_shared_memory_meta"))
+              FILTER(${metaBoundaryFilter})
             } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`;
 
         const queryStartedAt = Date.now();
@@ -155,6 +201,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         // `<cgPrefix>/foo/_shared_memory_meta` with entities in
         // `<cgPrefix>/foo/_shared_memory` only — without bleeding into
         // a different sub-graph's ops or into root ops.
+        // Codex review on #885 — admit only the root SWM + the SWM of
+        // REGISTERED sub-graphs of this CG. The TTL branch still
+        // pairs `?gMeta = ?g + "_meta"` to scope op→entity matching to
+        // a single sub-graph; the registration check is what rejects
+        // nested-CG SWM that shares the URI prefix.
+        const dataBoundaryFilter = `STR(?g) = "${rootSwm}" || ${registeredSubGraphSwmFilter(false)}`;
         const wsQuery = cutoff != null
           ? `SELECT DISTINCT ?s ?p ?o ?g WHERE {
   GRAPH ?gMeta {
@@ -165,15 +217,14 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
   }
   GRAPH ?g { ?s ?p ?o }
   FILTER(
-    STRSTARTS(STR(?g), "${cgPrefix}/") &&
-    STRENDS(STR(?g), "/_shared_memory") &&
+    (${dataBoundaryFilter}) &&
     STR(?gMeta) = CONCAT(STR(?g), "_meta")
   )
   FILTER(?s = ?re || STRSTARTS(STR(?s), CONCAT(STR(?re), "/.well-known/genid/")))
 } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`
           : `SELECT ?s ?p ?o ?g WHERE {
               GRAPH ?g { ?s ?p ?o }
-              FILTER(STRSTARTS(STR(?g), "${cgPrefix}/") && STRENDS(STR(?g), "/_shared_memory"))
+              FILTER(${dataBoundaryFilter})
             } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`;
 
         const queryStartedAt = Date.now();

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { createOperationContext, contextGraphSharedMemoryUri } from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import type { SyncPhase } from '../src/sync/auth/request-build.js';
+import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
+
+const CG_ID = 'sync-owned-cg';
+const SUB_GRAPH = 'code';
+const ROOT_ENTITY = 'urn:swm:shared-root';
+const ROOT_GRAPH = contextGraphSharedMemoryUri(CG_ID);
+const SUB_GRAPH_SWM = contextGraphSharedMemoryUri(CG_ID, SUB_GRAPH);
+
+function page(quads: Quad[], phase: SyncPhase): SyncPageResult {
+  return {
+    quads,
+    bytesReceived: 1,
+    resumedFromOffset: 0,
+    nextOffset: quads.length,
+    checkpointKey: `${phase}-checkpoint`,
+    completed: true,
+  };
+}
+
+describe('runSharedMemorySync ownership hydration', () => {
+  it('hydrates root and sub-graph SWM ownership under separate keys', async () => {
+    const ownedMaps = new Map<string, Map<string, string>>();
+    const inserted: Quad[] = [];
+    const deletedCheckpoints: string[] = [];
+
+    const dataQuads: Quad[] = [
+      { graph: ROOT_GRAPH, subject: ROOT_ENTITY, predicate: 'http://schema.org/name', object: '"root"' },
+      { graph: SUB_GRAPH_SWM, subject: ROOT_ENTITY, predicate: 'http://schema.org/name', object: '"sub"' },
+    ];
+
+    const summary = await runSharedMemorySync({
+      ctx: createOperationContext('sync'),
+      remotePeerId: '12D3KooWRequesterOwnership',
+      contextGraphIds: [CG_ID],
+      createContextGraphSyncDeadline: () => Date.now() + 30_000,
+      fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
+        phase === 'data' ? page(dataQuads, phase) : page([], phase)
+      ),
+      processSharedMemoryBatch: async () => ({
+        verifiedData: dataQuads,
+        verifiedMeta: [],
+        totalFetchedDataQuads: dataQuads.length,
+        totalFetchedMetaQuads: 0,
+        droppedDataTriples: 0,
+        emptyResponses: 0,
+        entityCreators: [
+          { dataGraph: ROOT_GRAPH, entity: ROOT_ENTITY, creator: 'peer-root' },
+          { dataGraph: SUB_GRAPH_SWM, entity: ROOT_ENTITY, creator: 'peer-sub' },
+        ],
+      }),
+      ensureContextGraph: async () => {},
+      storeInsert: async (quads) => {
+        inserted.push(...quads);
+      },
+      deleteCheckpoint: (key) => {
+        deletedCheckpoints.push(key);
+      },
+      setCheckpoint: () => {},
+      ensureOwnedMap: (key) => {
+        let map = ownedMaps.get(key);
+        if (!map) {
+          map = new Map<string, string>();
+          ownedMaps.set(key, map);
+        }
+        return map;
+      },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.failedPeers).toBe(0);
+    expect(summary.insertedDataTriples).toBe(2);
+    expect(inserted).toHaveLength(2);
+    expect(deletedCheckpoints.sort()).toEqual(['data-checkpoint', 'meta-checkpoint']);
+    expect(ownedMaps.get(CG_ID)?.get(ROOT_ENTITY)).toBe('peer-root');
+    expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(ROOT_ENTITY)).toBe('peer-sub');
+  });
+});

--- a/packages/agent/test/swm-late-joiner-deferred-gossip.test.ts
+++ b/packages/agent/test/swm-late-joiner-deferred-gossip.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  contextGraphAppTopic,
+  contextGraphDataUri,
+  contextGraphFinalizationTopic,
+  contextGraphMetaUri,
+  contextGraphPublishTopic,
+  contextGraphSharedMemoryUri,
+  contextGraphUpdateTopic,
+  contextGraphWorkspaceTopic,
+  DKG_ONTOLOGY,
+} from '@origintrail-official/dkg-core';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent, agentFromPrivateKey, type AgentKeyRecord } from '../src/index.js';
+
+/**
+ * Regression test for #885 Codex feedback on the deferred SWM gossip
+ * subscribe flow. The `join-approved` handler in dkg-agent.ts (around
+ * line 2309) calls
+ *   subscribeToContextGraph(cgId, { deferSharedMemoryGossipSubscribe: true })
+ * to skip the immediate SWM gossip subscription, because the curator's
+ * allowlist hasn't synced into the local `_meta` graph yet — a
+ * pre-meta `canReadContextGraph` check would deny and emit a misleading
+ * "SWM gossip subscription denied" WARN. The deferral relies on
+ * `runImmediatePostApprovalSync` pulling `_meta` and
+ * `refreshMetaSyncedFlags` (called from `runCatchupOverPeers`) re-
+ * queuing the SWM gossip subscribe once the allowlist becomes locally
+ * visible.
+ *
+ * This test pins the contract end-to-end so future refactors do not
+ * silently strand newly approved peers without SWM updates:
+ *
+ *   1. `subscribeToContextGraph(cgId, { deferSharedMemoryGossipSubscribe: true })`
+ *      installs the publish/app/update/finalization handlers but
+ *      does NOT subscribe to the SWM workspace topic, even when the
+ *      ACL would already allow it.
+ *
+ *   2. After `_meta` lands locally (allowlist + ACL quads),
+ *      `refreshMetaSyncedFlags(cgIds)` clears `pendingMeta`/sets
+ *      `metaSynced=true` AND queues the SWM gossip subscribe — the
+ *      workspace topic now appears in the gossip subscription set.
+ *
+ *   3. Without the option (default behaviour), `subscribeToContextGraph`
+ *      subscribes to SWM immediately when the ACL passes — pinning the
+ *      pre-fix path so we don't accidentally silently disable SWM
+ *      gossip everywhere.
+ *
+ * See urn:dkg:finding:swm-gap-1-initial-sync-race for the fuller
+ * analysis behind the deferral.
+ */
+
+const LOCAL_PEER_ID = '12D3KooWLateJoinerDeferGossip';
+
+interface DKGAgentInternals {
+  localAgents: Map<string, AgentKeyRecord>;
+  defaultAgentAddress?: string;
+  refreshMetaSyncedFlags(contextGraphIds: Iterable<string>): Promise<void>;
+}
+
+class FakeGossip {
+  readonly subscribed = new Set<string>();
+  readonly subscribeCalls: string[] = [];
+
+  subscribe(topic: string): void {
+    this.subscribeCalls.push(topic);
+    this.subscribed.add(topic);
+  }
+
+  unsubscribe(topic: string): void {
+    this.subscribed.delete(topic);
+  }
+
+  onMessage(): void {}
+
+  async publish(): Promise<void> {}
+
+  getSubscribers(_topic: string): string[] {
+    return [];
+  }
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+async function createAgent(): Promise<{
+  agent: DKGAgent;
+  internals: DKGAgentInternals;
+  gossip: FakeGossip;
+}> {
+  const agent = await DKGAgent.create({
+    name: `SwmLateJoinerDeferGossip-${Math.random().toString(36).slice(2)}`,
+    chainAdapter: new MockChainAdapter(),
+  });
+  const gossip = new FakeGossip();
+  Object.defineProperty(agent, 'peerId', { value: LOCAL_PEER_ID, configurable: true });
+  (agent as unknown as { gossip: FakeGossip }).gossip = gossip;
+  return { agent, internals: agent as unknown as DKGAgentInternals, gossip };
+}
+
+function workspaceTopic(contextGraphId: string): string {
+  return contextGraphWorkspaceTopic(
+    ethers.keccak256(ethers.toUtf8Bytes(contextGraphId)).toLowerCase(),
+  );
+}
+
+async function insertCgMetaWithAllowlist(
+  agent: DKGAgent,
+  contextGraphId: string,
+  agentAddress: string,
+): Promise<void> {
+  const contextGraphUri = contextGraphDataUri(contextGraphId);
+  const metaGraph = contextGraphMetaUri(contextGraphId);
+  await agent.store.insert([
+    {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph: metaGraph,
+    },
+    {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+      object: '"private"',
+      graph: metaGraph,
+    },
+    {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_PEER,
+      object: `"${LOCAL_PEER_ID}"`,
+      graph: metaGraph,
+    },
+    {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      object: `"${agentAddress}"`,
+      graph: metaGraph,
+    },
+  ]);
+}
+
+describe('SWM late-joiner deferred gossip subscribe (#885 Codex)', () => {
+  it('skips the SWM workspace topic when deferSharedMemoryGossipSubscribe=true, but still wires the other gossip topics', async () => {
+    const { agent, internals, gossip } = await createAgent();
+    const contextGraphId = 'cg-deferred-swm';
+    const wallet = ethers.Wallet.createRandom();
+    const record = agentFromPrivateKey(wallet.privateKey, 'local');
+    internals.localAgents.set(record.agentAddress, record);
+    internals.defaultAgentAddress = record.agentAddress;
+
+    // The ACL is already in place locally — the ONLY reason the
+    // workspace topic should remain unsubscribed in this scenario is
+    // the explicit deferral. This isolates the option's effect from
+    // the ACL-deny path tested in swm-agent-gate-access.test.ts.
+    await insertCgMetaWithAllowlist(agent, contextGraphId, record.agentAddress);
+
+    agent.subscribeToContextGraph(contextGraphId, {
+      deferSharedMemoryGossipSubscribe: true,
+    });
+    await flushAsync();
+
+    // SWM topic MUST NOT be subscribed — that's the whole point of the
+    // option. A future refactor that drops the gate would silently re-
+    // introduce the misleading "SWM gossip subscription denied" warn
+    // on every join-approved.
+    expect(gossip.subscribed.has(workspaceTopic(contextGraphId))).toBe(false);
+
+    // The other gossip topics MUST still be wired up immediately. The
+    // join-approved path expects publish/app/update/finalization to
+    // start flowing right away — only the SWM channel waits for meta.
+    expect(gossip.subscribed.has(contextGraphPublishTopic(contextGraphId))).toBe(true);
+    expect(gossip.subscribed.has(contextGraphAppTopic(contextGraphId))).toBe(true);
+    expect(gossip.subscribed.has(contextGraphUpdateTopic(contextGraphId))).toBe(true);
+    expect(gossip.subscribed.has(contextGraphFinalizationTopic(contextGraphId))).toBe(true);
+  });
+
+  it('refreshMetaSyncedFlags re-queues the SWM workspace subscribe once meta lands', async () => {
+    const { agent, internals, gossip } = await createAgent();
+    const contextGraphId = 'cg-deferred-then-meta';
+    const wallet = ethers.Wallet.createRandom();
+    const record = agentFromPrivateKey(wallet.privateKey, 'local');
+    internals.localAgents.set(record.agentAddress, record);
+    internals.defaultAgentAddress = record.agentAddress;
+
+    // Step 1: simulate the join-approved handler exactly. Mark
+    // pending-meta and defer the SWM gossip subscribe.
+    agent.subscribeToContextGraph(contextGraphId, {
+      deferSharedMemoryGossipSubscribe: true,
+    });
+    agent.markContextGraphSubscriptionState(contextGraphId, {
+      pendingMeta: true,
+      metaSynced: false,
+    });
+    await flushAsync();
+
+    expect(gossip.subscribed.has(workspaceTopic(contextGraphId))).toBe(false);
+
+    // Step 2: simulate `runImmediatePostApprovalSync` landing `_meta`
+    // by writing the curator's CG metadata + ACL into the local store.
+    // `hasConfirmedMetaState` returns true once `_meta` has any quads,
+    // which in turn unlocks `refreshMetaSyncedFlags`'s SWM re-queue.
+    await insertCgMetaWithAllowlist(agent, contextGraphId, record.agentAddress);
+
+    // Step 3: drive the same call site that `runCatchupOverPeers` uses
+    // after a successful `_meta` page lands (sync-on-connect.ts:85 and
+    // dkg-agent.ts:3589).
+    await internals.refreshMetaSyncedFlags([contextGraphId]);
+    await flushAsync();
+
+    // The SWM workspace topic MUST now be subscribed — that's the
+    // self-heal step the deferred path relies on. Without this, a
+    // newly approved peer would never receive SWM gossip updates
+    // until the next catchup cycle (~minutes).
+    expect(gossip.subscribed.has(workspaceTopic(contextGraphId))).toBe(true);
+  });
+
+  it('without deferSharedMemoryGossipSubscribe, SWM workspace topic subscribes immediately when the ACL allows', async () => {
+    const { agent, internals, gossip } = await createAgent();
+    const contextGraphId = 'cg-no-defer-immediate';
+    const wallet = ethers.Wallet.createRandom();
+    const record = agentFromPrivateKey(wallet.privateKey, 'local');
+    internals.localAgents.set(record.agentAddress, record);
+    internals.defaultAgentAddress = record.agentAddress;
+
+    await insertCgMetaWithAllowlist(agent, contextGraphId, record.agentAddress);
+
+    // No option object → defer is OFF (the pre-#885 default behaviour).
+    // This is the regression guard: a careless refactor that flipped
+    // the default to "always defer" would break every non-join-approved
+    // call site (chain-event auto-subscribe, restore-from-disk,
+    // explicit user joins, etc).
+    agent.subscribeToContextGraph(contextGraphId);
+    await flushAsync();
+
+    expect(gossip.subscribed.has(workspaceTopic(contextGraphId))).toBe(true);
+  });
+});

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -360,6 +360,7 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
   describe('CG boundary tightening — nested CGs sharing a prefix do not leak (#885 Codex)', () => {
     const NESTED_CG_ID = `${CG_ID}/child`;
     const NESTED_PREFIX = `did:dkg:context-graph:${NESTED_CG_ID}`;
+    const NESTED_META = `${NESTED_PREFIX}/_meta`;
     const NESTED_ROOT_SWM = `${NESTED_PREFIX}/_shared_memory`;
     const NESTED_ROOT_SWM_META = `${NESTED_PREFIX}/_shared_memory_meta`;
     const NESTED_SUB_SWM = `${NESTED_PREFIX}/extra/_shared_memory`;
@@ -437,6 +438,69 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       expect(graphs.has(ROOT_SWM_META)).toBe(true);
       expect(graphs.has(NESTED_ROOT_SWM_META)).toBe(false);
       expect(graphs.has(NESTED_SUB_SWM_META)).toBe(false);
+    });
+
+    it('rejects a parent sub-graph candidate when the same URI is a known child CG', async () => {
+      const storeCollision = new OxigraphStore();
+      const capCollision = captureHandler();
+      const NOW_ISO = '2026-06-01T00:00:00.000Z';
+
+      await storeCollision.insert([
+        { graph: ROOT_SWM, subject: ROOT_ENTITY, predicate: 'http://schema.org/n', object: '"keep-me-root"' },
+        ...workspaceOpQuads(SHARE_OP_ROOT, ROOT_ENTITY, ROOT_SWM_META, NOW_ISO),
+
+        // Parent CG registers a sub-graph named "child". That makes the
+        // graph URI below look valid as parent sub-graph SWM.
+        ...subGraphRegistrationQuads(CG_ID, 'child'),
+
+        // The same URI is also the root SWM graph for a known child CG
+        // `${CG_ID}/child`. The responder must reject this ambiguous
+        // partition during a sync of the parent CG, matching
+        // dkg-query-engine's known-child-CG exclusion.
+        { graph: NESTED_META, subject: NESTED_PREFIX, predicate: RDF_TYPE, object: 'https://dkg.network/ontology#ContextGraph' },
+        { graph: NESTED_ROOT_SWM, subject: 'urn:nested:root', predicate: 'http://schema.org/n', object: '"NESTED-COLLISION-LEAK"' },
+        { graph: NESTED_ROOT_SWM_META, subject: 'urn:dkg:share:nested-root-op', predicate: RDF_TYPE, object: `${DKG_NS}WorkspaceOperation` },
+        { graph: NESTED_ROOT_SWM_META, subject: 'urn:dkg:share:nested-root-op', predicate: `${DKG_NS}publishedAt`, object: `"${NOW_ISO}"^^<http://www.w3.org/2001/XMLSchema#dateTime>` },
+        { graph: NESTED_ROOT_SWM_META, subject: 'urn:dkg:share:nested-root-op', predicate: `${DKG_NS}rootEntity`, object: 'urn:nested:root' },
+      ]);
+
+      registerSyncHandler({
+        register: capCollision.register,
+        protocolSync: '/origintrail/dkg/sync/1.0.0',
+        syncDeniedResponse: 'sync-denied',
+        syncPageSize: 5000,
+        sharedMemoryTtlMs: 0,
+        store: storeCollision,
+        peerId: 'self-peer',
+        parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
+        authorizeSyncRequest: async () => true,
+        logWarn: noopLog,
+        logDebug: noopLog,
+      });
+
+      const dataOut = await capCollision.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'data',
+      });
+      const dataGraphs = lineGraphsFromNquads(dataOut);
+      expect(dataGraphs.has(ROOT_SWM)).toBe(true);
+      expect(dataGraphs.has(NESTED_ROOT_SWM)).toBe(false);
+      expect(dataOut).toContain('"keep-me-root"');
+      expect(dataOut).not.toContain('"NESTED-COLLISION-LEAK"');
+
+      const metaOut = await capCollision.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'meta',
+      });
+      const metaGraphs = lineGraphsFromNquads(metaOut);
+      expect(metaGraphs.has(ROOT_SWM_META)).toBe(true);
+      expect(metaGraphs.has(NESTED_ROOT_SWM_META)).toBe(false);
     });
   });
 

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -100,6 +100,23 @@ function workspaceOpQuads(opId: string, rootEntity: string, metaGraph: string, p
   ];
 }
 
+// Sub-graph registration triples in `<cgPrefix>/_meta`. Mirrors the
+// shape that `DKGPublisher.isSubGraphRegistered` (dkg-publisher.ts:3828)
+// looks for and `FinalizationHandler.ensureContextGraphAndSubGraph`
+// (finalization-handler.ts:540) writes. The sync responder's boundary
+// check (post-#885 Codex) requires this registration to admit the
+// sub-graph SWM into a sync response, disambiguating it from a nested
+// CG that shares the same URI prefix.
+function subGraphRegistrationQuads(cgId: string, subGraphName: string) {
+  const cgMeta = `did:dkg:context-graph:${cgId}/_meta`;
+  const sgUri = `did:dkg:context-graph:${cgId}/${subGraphName}`;
+  return [
+    { graph: cgMeta, subject: sgUri, predicate: RDF_TYPE, object: `${DKG_NS}SubGraph` },
+    { graph: cgMeta, subject: sgUri, predicate: 'http://schema.org/name', object: `"${subGraphName}"` },
+    { graph: cgMeta, subject: sgUri, predicate: `${DKG_NS}createdBy`, object: '"test-creator"' },
+  ];
+}
+
 describe('sync responder workspace branch — sub-graph SWM coverage', () => {
   let store: OxigraphStore;
   let cap: ReturnType<typeof captureHandler>;
@@ -120,10 +137,12 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       // --- SUB-GRAPH SWM (the gap target) ---
       { graph: SUB_SWM, subject: SUB_ROOT, predicate: 'http://schema.org/name', object: '"sub-ai-tools-payload"' },
       ...workspaceOpQuads(SHARE_OP_SUB, SUB_ROOT, SUB_SWM_META, NOW_ISO),
+      ...subGraphRegistrationQuads(CG_ID, SUB_NAME),
 
       // --- ANOTHER SUB-GRAPH (covers fan-out across multiple subs) ---
       { graph: OTHER_SUB_SWM, subject: OTHER_SUB_ROOT, predicate: 'http://schema.org/name', object: '"sub-decisions-payload"' },
       ...workspaceOpQuads(SHARE_OP_OTHER_SUB, OTHER_SUB_ROOT, OTHER_SUB_SWM_META, NOW_ISO),
+      ...subGraphRegistrationQuads(CG_ID, OTHER_SUB),
 
       // --- NOISE: durable-tier graphs that share the CG prefix but are
       //     not SWM. The shape filter must exclude these from BOTH the
@@ -279,6 +298,7 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
         { graph: SUB_SWM, subject: 'urn:swm:stale:sub', predicate: 'http://schema.org/n', object: '"stale-sub"' },
         ...workspaceOpQuads('op-fresh-sub', 'urn:swm:fresh:sub', SUB_SWM_META, FRESH_ISO),
         ...workspaceOpQuads('op-stale-sub', 'urn:swm:stale:sub', SUB_SWM_META, STALE_ISO),
+        ...subGraphRegistrationQuads(CG_ID, SUB_NAME),
       ]);
 
       capTtl = captureHandler();
@@ -316,6 +336,107 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       const graphs = lineGraphsFromNquads(out);
       expect(graphs.has(ROOT_SWM)).toBe(true);
       expect(graphs.has(SUB_SWM)).toBe(true);
+    });
+  });
+
+  // Codex review on #885 — URI shape alone is NOT a sufficient CG
+  // boundary because `validateContextGraphId` permits `/` in the CG
+  // ID (wallet-scoped IDs do, e.g. `0xabc/project`). For a request on
+  // `cg-A`, the URI `<cgPrefix>/child/_shared_memory` is structurally
+  // indistinguishable from a sub-graph "child" of cg-A AND from the
+  // root SWM of a different CG `cg-A/child` — even with a tightened
+  // STRBEFORE/STRAFTER segment check that allows exactly one path
+  // segment.
+  //
+  // The fix: admit the CG's root SWM unconditionally and admit a
+  // sub-graph SWM only if the sub-graph is REGISTERED in this CG's
+  // `<cgPrefix>/_meta` graph (via the `<sgUri> a SubGraph; schema:name
+  // "<name>"` triples that `DKGPublisher.isSubGraphRegistered` looks
+  // for). The nested CG `cg-A/child` puts its registration in its
+  // OWN `<cg-A/child-prefix>/_meta` graph, not cg-A's, so it is
+  // naturally excluded. This test pins that contract: with no
+  // registration of "child" or "child/extra" in cg-A's `_meta`, the
+  // nested-CG SWM data and meta MUST NOT leak into a sync of cg-A.
+  describe('CG boundary tightening — nested CGs sharing a prefix do not leak (#885 Codex)', () => {
+    const NESTED_CG_ID = `${CG_ID}/child`;
+    const NESTED_PREFIX = `did:dkg:context-graph:${NESTED_CG_ID}`;
+    const NESTED_ROOT_SWM = `${NESTED_PREFIX}/_shared_memory`;
+    const NESTED_ROOT_SWM_META = `${NESTED_PREFIX}/_shared_memory_meta`;
+    const NESTED_SUB_SWM = `${NESTED_PREFIX}/extra/_shared_memory`;
+    const NESTED_SUB_SWM_META = `${NESTED_PREFIX}/extra/_shared_memory_meta`;
+
+    let storeNested: OxigraphStore;
+    let capNested: ReturnType<typeof captureHandler>;
+
+    beforeEach(async () => {
+      storeNested = new OxigraphStore();
+      const NOW_ISO = '2026-06-01T00:00:00.000Z';
+      await storeNested.insert([
+        // The CG we are syncing.
+        { graph: ROOT_SWM, subject: ROOT_ENTITY, predicate: 'http://schema.org/n', object: '"keep-me-root"' },
+        ...workspaceOpQuads(SHARE_OP_ROOT, ROOT_ENTITY, ROOT_SWM_META, NOW_ISO),
+        // A DIFFERENT CG whose ID extends the queried CG's prefix —
+        // pre-fix, this leaked because the prefix filter matched it.
+        { graph: NESTED_ROOT_SWM, subject: 'urn:nested:root', predicate: 'http://schema.org/n', object: '"NESTED-ROOT-LEAK"' },
+        { graph: NESTED_ROOT_SWM_META, subject: 'urn:dkg:share:nested-root-op', predicate: RDF_TYPE, object: `${DKG_NS}WorkspaceOperation` },
+        { graph: NESTED_ROOT_SWM_META, subject: 'urn:dkg:share:nested-root-op', predicate: `${DKG_NS}publishedAt`, object: `"${NOW_ISO}"^^<http://www.w3.org/2001/XMLSchema#dateTime>` },
+        { graph: NESTED_ROOT_SWM_META, subject: 'urn:dkg:share:nested-root-op', predicate: `${DKG_NS}rootEntity`, object: 'urn:nested:root' },
+        // Sub-graph of the OTHER CG — also must not leak.
+        { graph: NESTED_SUB_SWM, subject: 'urn:nested:sub', predicate: 'http://schema.org/n', object: '"NESTED-SUB-LEAK"' },
+        { graph: NESTED_SUB_SWM_META, subject: 'urn:dkg:share:nested-sub-op', predicate: RDF_TYPE, object: `${DKG_NS}WorkspaceOperation` },
+        { graph: NESTED_SUB_SWM_META, subject: 'urn:dkg:share:nested-sub-op', predicate: `${DKG_NS}publishedAt`, object: `"${NOW_ISO}"^^<http://www.w3.org/2001/XMLSchema#dateTime>` },
+        { graph: NESTED_SUB_SWM_META, subject: 'urn:dkg:share:nested-sub-op', predicate: `${DKG_NS}rootEntity`, object: 'urn:nested:sub' },
+      ]);
+      capNested = captureHandler();
+      registerSyncHandler({
+        register: capNested.register,
+        protocolSync: '/origintrail/dkg/sync/1.0.0',
+        syncDeniedResponse: 'sync-denied',
+        syncPageSize: 5000,
+        sharedMemoryTtlMs: 0,
+        store: storeNested,
+        peerId: 'self-peer',
+        parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
+        authorizeSyncRequest: async () => true,
+        logWarn: noopLog,
+        logDebug: noopLog,
+      });
+    });
+
+    it('phase=data: nested-CG SWM (root and sub-graph) must NOT leak into a sync of the parent CG', async () => {
+      const out = await capNested.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'data',
+      });
+
+      const graphs = lineGraphsFromNquads(out);
+      expect(graphs.has(ROOT_SWM)).toBe(true);
+      // The pre-fix regression: NESTED_ROOT_SWM and NESTED_SUB_SWM
+      // would both have appeared because their URIs start with the
+      // queried CG prefix. The tightened FILTER rejects them.
+      expect(graphs.has(NESTED_ROOT_SWM)).toBe(false);
+      expect(graphs.has(NESTED_SUB_SWM)).toBe(false);
+      expect(out).not.toContain('"NESTED-ROOT-LEAK"');
+      expect(out).not.toContain('"NESTED-SUB-LEAK"');
+      expect(out).toContain('"keep-me-root"');
+    });
+
+    it('phase=meta: nested-CG SWM meta must NOT leak into a sync of the parent CG', async () => {
+      const out = await capNested.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'meta',
+      });
+
+      const graphs = lineGraphsFromNquads(out);
+      expect(graphs.has(ROOT_SWM_META)).toBe(true);
+      expect(graphs.has(NESTED_ROOT_SWM_META)).toBe(false);
+      expect(graphs.has(NESTED_SUB_SWM_META)).toBe(false);
     });
   });
 

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { registerSyncHandler } from '../src/sync/responder/sync-handler.js';
+import type { SyncRequestEnvelope } from '../src/sync/auth/request-build.js';
+import type { OperationContext } from '@origintrail-official/dkg-core';
+
+/**
+ * Regression test for the SWM sub-graph blind spot in the sync responder.
+ *
+ * Pre-PR-X the workspace branch hardcoded the response to query
+ * `contextGraphWorkspaceGraphUri(cgId)` / `...MetaGraphUri(cgId)`, both of
+ * which alias the CG-root SWM URI:
+ *   <cgPrefix>/_shared_memory
+ *   <cgPrefix>/_shared_memory_meta
+ *
+ * Any publish that supplied a `subGraphName` lands in the per-sub-graph
+ * variants instead:
+ *   <cgPrefix>/<sub>/_shared_memory
+ *   <cgPrefix>/<sub>/_shared_memory_meta
+ *
+ * The responder's static graph filter never saw those, so a sync requester
+ * (e.g. a freshly approved late joiner running `runImmediatePostApprovalSync`
+ * or any later `fetchSyncPages` round) received zero bytes of any sub-graph
+ * SWM history. After PR-X the responder filters by URI shape under
+ * `<cgPrefix>/`, so both root and sub-graph SWM flow through.
+ *
+ * See urn:dkg:finding:swm-gap-2-subgraph-blind-spot in the staking-ui-v10
+ * decisions sub-graph for the full analysis.
+ */
+
+const CG_ID = 'devnet-test';
+const CG_PREFIX = `did:dkg:context-graph:${CG_ID}`;
+const ROOT_SWM = `${CG_PREFIX}/_shared_memory`;
+const ROOT_SWM_META = `${CG_PREFIX}/_shared_memory_meta`;
+const SUB_NAME = 'ai-tools';
+const SUB_SWM = `${CG_PREFIX}/${SUB_NAME}/_shared_memory`;
+const SUB_SWM_META = `${CG_PREFIX}/${SUB_NAME}/_shared_memory_meta`;
+const OTHER_SUB = 'decisions';
+const OTHER_SUB_SWM = `${CG_PREFIX}/${OTHER_SUB}/_shared_memory`;
+const OTHER_SUB_SWM_META = `${CG_PREFIX}/${OTHER_SUB}/_shared_memory_meta`;
+
+// A graph that lives at <cgPrefix>/<...>/_shared_memory_meta MUST NOT match
+// the data-phase filter (STRENDS test on `_shared_memory` vs `_shared_memory_meta`
+// is the structural guard). Conversely the meta-phase filter MUST match it.
+// Per `validateSubGraphName` (dkg-core/constants.ts), sub-graph names cannot
+// contain "/" and cannot start with "_", so there is no other URI shape that
+// could land under `<cgPrefix>/.../_shared_memory[_meta]`.
+const UNRELATED_DATA_GRAPH = `${CG_PREFIX}`;
+const UNRELATED_DURABLE_META = `${CG_PREFIX}/_meta`;
+
+const ROOT_ENTITY = 'urn:swm:root:r0';
+const SUB_ROOT = 'urn:swm:root:s1';
+const OTHER_SUB_ROOT = 'urn:swm:root:s2';
+const SHARE_OP_ROOT = 'op-root-1';
+const SHARE_OP_SUB = 'op-sub-1';
+const SHARE_OP_OTHER_SUB = 'op-other-1';
+
+const DKG_NS = 'http://dkg.io/ontology/';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const REMOTE_PEER_ID = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+
+const noopLog = (_ctx: OperationContext, _msg: string) => {};
+
+function captureHandler(): {
+  register: (proto: string, h: (data: Uint8Array, peerId: string) => Promise<Uint8Array>) => void;
+  invoke: (envelope: SyncRequestEnvelope) => Promise<string>;
+} {
+  let captured: ((data: Uint8Array, peerId: string) => Promise<Uint8Array>) | null = null;
+  return {
+    register: (_proto, h) => {
+      captured = h;
+    },
+    invoke: async (envelope) => {
+      if (!captured) throw new Error('handler not registered');
+      const bytes = new TextEncoder().encode(JSON.stringify(envelope));
+      const out = await captured(bytes, REMOTE_PEER_ID);
+      return new TextDecoder().decode(out);
+    },
+  };
+}
+
+function lineGraphsFromNquads(text: string): Set<string> {
+  const graphs = new Set<string>();
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    const m = line.match(/<([^<>]+)>\s*\.\s*$/);
+    if (m) graphs.add(m[1]);
+  }
+  return graphs;
+}
+
+function workspaceOpQuads(opId: string, rootEntity: string, metaGraph: string, publishedAt: string) {
+  const subject = `urn:dkg:share:${CG_ID}:${opId}`;
+  return [
+    { graph: metaGraph, subject, predicate: RDF_TYPE, object: `${DKG_NS}WorkspaceOperation` },
+    { graph: metaGraph, subject, predicate: `${DKG_NS}publishedAt`, object: `"${publishedAt}"^^<http://www.w3.org/2001/XMLSchema#dateTime>` },
+    { graph: metaGraph, subject, predicate: `${DKG_NS}rootEntity`, object: rootEntity },
+    { graph: metaGraph, subject, predicate: `${DKG_NS}contextGraphId`, object: `"${CG_ID}"` },
+    { graph: metaGraph, subject, predicate: `${DKG_NS}shareOperationId`, object: `"${opId}"` },
+  ];
+}
+
+describe('sync responder workspace branch — sub-graph SWM coverage', () => {
+  let store: OxigraphStore;
+  let cap: ReturnType<typeof captureHandler>;
+
+  beforeEach(async () => {
+    store = new OxigraphStore();
+
+    const NOW_ISO = '2026-06-01T00:00:00.000Z';
+
+    await store.insert([
+      // --- ROOT SWM ---
+      // root-entity payload + a skolemized child (the FILTER in the TTL
+      // branch widens past the root URI to genid descendants).
+      { graph: ROOT_SWM, subject: ROOT_ENTITY, predicate: 'http://schema.org/name', object: '"root-payload"' },
+      { graph: ROOT_SWM, subject: `${ROOT_ENTITY}/.well-known/genid/abc`, predicate: 'http://schema.org/value', object: '"root-child"' },
+      ...workspaceOpQuads(SHARE_OP_ROOT, ROOT_ENTITY, ROOT_SWM_META, NOW_ISO),
+
+      // --- SUB-GRAPH SWM (the gap target) ---
+      { graph: SUB_SWM, subject: SUB_ROOT, predicate: 'http://schema.org/name', object: '"sub-ai-tools-payload"' },
+      ...workspaceOpQuads(SHARE_OP_SUB, SUB_ROOT, SUB_SWM_META, NOW_ISO),
+
+      // --- ANOTHER SUB-GRAPH (covers fan-out across multiple subs) ---
+      { graph: OTHER_SUB_SWM, subject: OTHER_SUB_ROOT, predicate: 'http://schema.org/name', object: '"sub-decisions-payload"' },
+      ...workspaceOpQuads(SHARE_OP_OTHER_SUB, OTHER_SUB_ROOT, OTHER_SUB_SWM_META, NOW_ISO),
+
+      // --- NOISE: durable-tier graphs that share the CG prefix but are
+      //     not SWM. The shape filter must exclude these from BOTH the
+      //     workspace meta and data phases.
+      { graph: UNRELATED_DATA_GRAPH, subject: 'urn:durable:1', predicate: `${DKG_NS}label`, object: '"durable"' },
+      { graph: UNRELATED_DURABLE_META, subject: CG_PREFIX, predicate: `${DKG_NS}createdAt`, object: '"2026-05-10T00:00:00Z"' },
+    ]);
+
+    cap = captureHandler();
+    registerSyncHandler({
+      register: cap.register,
+      protocolSync: '/origintrail/dkg/sync/1.0.0',
+      syncDeniedResponse: 'sync-denied',
+      syncPageSize: 5000,
+      sharedMemoryTtlMs: 0,
+      store,
+      peerId: 'self-peer',
+      parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
+      authorizeSyncRequest: async () => true,
+      logWarn: noopLog,
+      logDebug: noopLog,
+    });
+  });
+
+  describe('phase=data (no TTL)', () => {
+    it('returns root SWM AND every sub-graph SWM in one response', async () => {
+      const out = await cap.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'data',
+      });
+
+      const graphs = lineGraphsFromNquads(out);
+      expect(graphs.has(ROOT_SWM)).toBe(true);
+      expect(graphs.has(SUB_SWM)).toBe(true);
+      expect(graphs.has(OTHER_SUB_SWM)).toBe(true);
+
+      // Spot-check the actual payloads landed.
+      expect(out).toContain('"root-payload"');
+      expect(out).toContain('"sub-ai-tools-payload"');
+      expect(out).toContain('"sub-decisions-payload"');
+      expect(out).toContain('"root-child"');
+    });
+
+    it('does NOT return SWM meta graphs (those are the meta phase)', async () => {
+      const out = await cap.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'data',
+      });
+
+      const graphs = lineGraphsFromNquads(out);
+      expect(graphs.has(ROOT_SWM_META)).toBe(false);
+      expect(graphs.has(SUB_SWM_META)).toBe(false);
+      expect(graphs.has(OTHER_SUB_SWM_META)).toBe(false);
+    });
+
+    it('does NOT bleed durable-tier graphs into the workspace data response', async () => {
+      const out = await cap.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'data',
+      });
+
+      const graphs = lineGraphsFromNquads(out);
+      expect(graphs.has(UNRELATED_DATA_GRAPH)).toBe(false);
+      expect(graphs.has(UNRELATED_DURABLE_META)).toBe(false);
+      expect(out).not.toContain('"durable"');
+    });
+  });
+
+  describe('phase=meta (no TTL)', () => {
+    it('returns root SWM meta AND every sub-graph SWM meta', async () => {
+      const out = await cap.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'meta',
+      });
+
+      const graphs = lineGraphsFromNquads(out);
+      expect(graphs.has(ROOT_SWM_META)).toBe(true);
+      expect(graphs.has(SUB_SWM_META)).toBe(true);
+      expect(graphs.has(OTHER_SUB_SWM_META)).toBe(true);
+
+      // Spot-check that each WorkspaceOperation rode along.
+      expect(out).toContain(`urn:dkg:share:${CG_ID}:${SHARE_OP_ROOT}`);
+      expect(out).toContain(`urn:dkg:share:${CG_ID}:${SHARE_OP_SUB}`);
+      expect(out).toContain(`urn:dkg:share:${CG_ID}:${SHARE_OP_OTHER_SUB}`);
+    });
+
+    it('does NOT return SWM data graphs (those are the data phase)', async () => {
+      const out = await cap.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'meta',
+      });
+
+      const graphs = lineGraphsFromNquads(out);
+      expect(graphs.has(ROOT_SWM)).toBe(false);
+      expect(graphs.has(SUB_SWM)).toBe(false);
+      expect(graphs.has(OTHER_SUB_SWM)).toBe(false);
+    });
+
+    it('does NOT include the durable top-level _meta', async () => {
+      const out = await cap.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'meta',
+      });
+
+      const graphs = lineGraphsFromNquads(out);
+      expect(graphs.has(UNRELATED_DURABLE_META)).toBe(false);
+    });
+  });
+
+  describe('phase=data (TTL on)', () => {
+    let storeTtl: OxigraphStore;
+    let capTtl: ReturnType<typeof captureHandler>;
+
+    beforeEach(async () => {
+      // Two ops per graph: one fresh (within cutoff), one stale (older
+      // than cutoff). The TTL branch must keep the fresh root/sub
+      // entities and drop the stale ones — even though the stale ones
+      // physically still live in the store. Verifies both:
+      //   (a) the (?gMeta = ?g + "_meta") binding correctly pairs the
+      //       per-sub-graph op graph with its data graph, and
+      //   (b) the ?ts >= cutoff filter is applied per sub-graph.
+      storeTtl = new OxigraphStore();
+      const FRESH_ISO = new Date(Date.now() - 1_000).toISOString();
+      const STALE_ISO = new Date(Date.now() - 10_000).toISOString();
+
+      await storeTtl.insert([
+        // root: fresh entity (kept), stale entity (dropped)
+        { graph: ROOT_SWM, subject: 'urn:swm:fresh:root', predicate: 'http://schema.org/n', object: '"fresh-root"' },
+        { graph: ROOT_SWM, subject: 'urn:swm:stale:root', predicate: 'http://schema.org/n', object: '"stale-root"' },
+        ...workspaceOpQuads('op-fresh-root', 'urn:swm:fresh:root', ROOT_SWM_META, FRESH_ISO),
+        ...workspaceOpQuads('op-stale-root', 'urn:swm:stale:root', ROOT_SWM_META, STALE_ISO),
+
+        // sub: fresh entity (kept), stale entity (dropped)
+        { graph: SUB_SWM, subject: 'urn:swm:fresh:sub', predicate: 'http://schema.org/n', object: '"fresh-sub"' },
+        { graph: SUB_SWM, subject: 'urn:swm:stale:sub', predicate: 'http://schema.org/n', object: '"stale-sub"' },
+        ...workspaceOpQuads('op-fresh-sub', 'urn:swm:fresh:sub', SUB_SWM_META, FRESH_ISO),
+        ...workspaceOpQuads('op-stale-sub', 'urn:swm:stale:sub', SUB_SWM_META, STALE_ISO),
+      ]);
+
+      capTtl = captureHandler();
+      registerSyncHandler({
+        register: capTtl.register,
+        protocolSync: '/origintrail/dkg/sync/1.0.0',
+        syncDeniedResponse: 'sync-denied',
+        syncPageSize: 5000,
+        sharedMemoryTtlMs: 5_000,
+        store: storeTtl,
+        peerId: 'self-peer',
+        parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
+        authorizeSyncRequest: async () => true,
+        logWarn: noopLog,
+        logDebug: noopLog,
+      });
+    });
+
+    it('keeps fresh root + sub entities and drops stale ones, scoped by sub-graph', async () => {
+      const out = await capTtl.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'data',
+      });
+
+      expect(out).toContain('"fresh-root"');
+      expect(out).toContain('"fresh-sub"');
+      expect(out).not.toContain('"stale-root"');
+      expect(out).not.toContain('"stale-sub"');
+
+      // Both sub-graph variants of `_shared_memory` MUST appear in the
+      // graph-id position of the emitted nquads — the regression target.
+      const graphs = lineGraphsFromNquads(out);
+      expect(graphs.has(ROOT_SWM)).toBe(true);
+      expect(graphs.has(SUB_SWM)).toBe(true);
+    });
+  });
+
+  describe('graph URI is emitted per binding (not the static wsGraph alias)', () => {
+    it('serializes each n-quad with the source graph URI, so a sub-graph entity lands back in the sub-graph on the requester', async () => {
+      const out = await cap.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'data',
+      });
+
+      // Every line ending in <SUB_SWM> . MUST carry a sub-graph subject,
+      // never a root subject (and vice versa). This guards against the
+      // pre-fix bug where the responder serialized everything as
+      // `<root_swm> .` regardless of where it came from.
+      for (const line of out.split('\n')) {
+        if (!line.trim()) continue;
+        if (line.endsWith(`<${SUB_SWM}> .`)) {
+          expect(line).toContain(SUB_ROOT);
+        }
+        if (line.endsWith(`<${OTHER_SUB_SWM}> .`)) {
+          expect(line).toContain(OTHER_SUB_ROOT);
+        }
+        if (line.endsWith(`<${ROOT_SWM}> .`)) {
+          expect(line).toContain(ROOT_ENTITY);
+        }
+      }
+    });
+  });
+});

--- a/scripts/devnet-test-swm-late-joiner-subgraph.sh
+++ b/scripts/devnet-test-swm-late-joiner-subgraph.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+#
+# SWM late-joiner sub-graph backfill — devnet regression for PR #885.
+#
+# Reproduces the gap that motivated PR #885 against a freshly built local
+# devnet and asserts both fixes:
+#
+#   Gap 2 (sub-graph blind spot in sync responder)
+#     Pre-PR-885 the workspace branch only queried the CG-root SWM
+#     graph. Anything published into a sub-graph
+#     (`<cgPrefix>/<sub>/_shared_memory`) was invisible to a sync
+#     requester. A late joiner who joined AFTER the curator wrote
+#     into a sub-graph received `sharedMemory=0` and an empty SPARQL
+#     count for that sub-graph. After the fix, both root + sub-graph
+#     SWM flow through.
+#
+#   Gap 1 (approve-time `_meta` race against SWM gossip subscribe)
+#     Pre-PR-885 the `join-approved` handler called
+#     `subscribeToContextGraph` synchronously, which queued an SWM
+#     gossip subscribe whose `canReadContextGraph` check ran against
+#     a not-yet-synced local `_meta` and emitted a misleading
+#     `SWM gossip subscription denied for "<cg>": local node is not
+#     authorized` warning before `refreshMetaSyncedFlags` self-healed
+#     it. After the fix the SWM gossip subscribe is deferred until
+#     `_meta` lands; no spurious WARN.
+#
+# Scenario:
+#   • CURATOR (N5) creates curated CG with allowlist=[CURATOR] only.
+#     The late joiner is NOT in the initial allowlist — it joins
+#     later via signed `requestJoin → approveJoin`, exactly the
+#     flow that triggered the gap on the live testnet.
+#   • CURATOR creates a sub-graph `ai-tools` and publishes 5 SWM
+#     triples into it. CURATOR also publishes 3 SWM triples into the
+#     CG-root SWM as a control set (so the test fails distinguishably
+#     when only one of the two graphs flows back).
+#   • LATE_JOINER (N1) signs a join delegation, sends `request-join`
+#     to CURATOR, CURATOR approves.
+#   • Wait for the post-approval sync to settle.
+#   • LATE_JOINER SPARQLs the CG it just joined:
+#       - sub-graph `ai-tools` SWM count → MUST be 5
+#       - root SWM count                  → MUST be 3
+#       - total                           → MUST be 8
+#   • LATE_JOINER daemon log MUST NOT contain a `SWM gossip
+#     subscription denied for "<cg>": local node is not authorized`
+#     line for this specific CG — confirms Gap 1 self-heal lands
+#     before the misleading WARN ever fires.
+#
+# Talks ONLY to the daemon HTTP API. Re-runnable: every CG id is
+# timestamp-suffixed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+API_PORT_BASE="${API_PORT_BASE:-9201}"
+CURATOR_NODE="${CURATOR_NODE:-5}"
+LATE_JOINER_NODE="${LATE_JOINER_NODE:-1}"
+SUB_GRAPH_NAME="${SUB_GRAPH_NAME:-ai-tools}"
+SUB_GRAPH_TRIPLES="${SUB_GRAPH_TRIPLES:-5}"
+ROOT_TRIPLES="${ROOT_TRIPLES:-3}"
+POST_APPROVAL_WAIT_S="${POST_APPROVAL_WAIT_S:-10}"
+
+log()  { echo "[swm-lj-sg] $*"; }
+warn() { echo "[swm-lj-sg] WARN: $*" >&2; }
+fail() { echo "[swm-lj-sg] FAIL: $*" >&2; exit 1; }
+act()  { echo ""; echo "[swm-lj-sg] === $1 ==="; }
+
+node_dir()    { echo "$DEVNET_DIR/node$1"; }
+node_token()  { tail -1 "$(node_dir "$1")/auth.token" 2>/dev/null | tr -d '\r\n'; }
+node_port()   { echo $((API_PORT_BASE + $1 - 1)); }
+node_log()    { echo "$(node_dir "$1")/daemon.log"; }
+
+api_call() {
+  local node="$1" method="$2" path="$3" data="${4:-}"
+  local port; port=$(node_port "$node")
+  local token; token=$(node_token "$node")
+  local -a curl_args=(-sS --max-time 60 -X "$method" -H "Authorization: Bearer $token" -H 'Content-Type: application/json')
+  [ -n "$data" ] && curl_args+=(-d "$data")
+  curl_args+=("http://127.0.0.1:${port}${path}")
+  curl "${curl_args[@]}"
+}
+
+parse_json() {
+  printf '%s' "$1" | node -e "
+    let d=''; process.stdin.on('data',c=>d+=c);
+    process.stdin.on('end',()=>{
+      try { const j=JSON.parse(d); const v=j$2; console.log(v == null ? '' : v); }
+      catch (e) { process.exit(1); }
+    })
+  "
+}
+
+# Bare numeric value out of a SPARQL bindings response. Matches the
+# helper used by the existing rfc38-late-joiner script so behaviour
+# stays consistent across the suite.
+sparql_count() {
+  printf '%s' "$1" | node -e '
+    let d=""; process.stdin.on("data",c=>d+=c);
+    process.stdin.on("end",()=>{
+      try {
+        const j = JSON.parse(d);
+        const b = (j && j.result && j.result.bindings && j.result.bindings[0]) || {};
+        const raw = b.n || b.cnt || b.count || "";
+        const m = String(raw).match(/^"?(-?\d+)"?/);
+        console.log(m ? m[1] : "");
+      } catch { console.log(""); }
+    });
+  '
+}
+
+build_swm_payload() {
+  local cg_id="$1" n="$2" label="$3" sub_graph="${4:-}"
+  CG_ID="$cg_id" N="$n" LABEL="$label" SUB="$sub_graph" node -e '
+    const cgId = process.env.CG_ID;
+    const n = parseInt(process.env.N, 10);
+    const label = process.env.LABEL;
+    const sub = process.env.SUB || "";
+    const quads = [];
+    for (let i = 0; i < n; i++) {
+      quads.push({
+        subject: "urn:swm-lj-sg:" + label + ":e" + i,
+        predicate: "http://schema.org/name",
+        object: "\"value-" + label + "-" + i + "\"",
+        graph: "did:dkg:context-graph:" + cgId,
+      });
+    }
+    const out = { contextGraphId: cgId, quads };
+    if (sub) out.subGraphName = sub;
+    console.log(JSON.stringify(out));
+  '
+}
+
+CURATOR_IDENTITY=$(api_call "$CURATOR_NODE" GET /api/agent/identity)
+CURATOR_AGENT=$(printf '%s' "$CURATOR_IDENTITY" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d).agentAddress))')
+CURATOR_PEER=$(printf  '%s' "$CURATOR_IDENTITY" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d).peerId))')
+LATE_JOINER_IDENTITY=$(api_call "$LATE_JOINER_NODE" GET /api/agent/identity)
+LATE_JOINER_AGENT=$(printf '%s' "$LATE_JOINER_IDENTITY" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d).agentAddress))')
+LATE_JOINER_PEER=$(printf  '%s' "$LATE_JOINER_IDENTITY" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d).peerId))')
+
+log "Curator:     $CURATOR_AGENT (node $CURATOR_NODE, peer=$CURATOR_PEER)"
+log "Late joiner: $LATE_JOINER_AGENT (node $LATE_JOINER_NODE, peer=$LATE_JOINER_PEER)"
+
+STAMP=$(date +%s)
+CG_ID="${CURATOR_AGENT}/swm-lj-sg-${STAMP}"
+
+# ===========================================================================
+act "STEP 1: curator creates CG with allowlist=[curator] only (late joiner NOT pre-allowlisted)"
+# ===========================================================================
+CR=$(api_call "$CURATOR_NODE" POST /api/context-graph/create "$(cat <<EOF
+{ "id": "$CG_ID", "name": "swm-lj-sg ${STAMP}",
+  "accessPolicy": 1, "publishPolicy": 0,
+  "allowedAgents": ["$CURATOR_AGENT"],
+  "register": true }
+EOF
+)")
+ON_CHAIN=$(parse_json "$CR" '.onChainId')
+[ -n "$ON_CHAIN" ] || fail "curator CG create failed: $CR"
+log "✓ created curated CG: onChainId=$ON_CHAIN"
+
+# ===========================================================================
+act "STEP 2: curator creates sub-graph \"$SUB_GRAPH_NAME\""
+# ===========================================================================
+SG_RESP=$(api_call "$CURATOR_NODE" POST /api/sub-graph/create "$(cat <<EOF
+{ "contextGraphId": "$CG_ID", "subGraphName": "$SUB_GRAPH_NAME" }
+EOF
+)")
+SG_CREATED=$(parse_json "$SG_RESP" '.created')
+[ "$SG_CREATED" = "$SUB_GRAPH_NAME" ] || fail "sub-graph create failed: $SG_RESP"
+log "✓ sub-graph \"$SUB_GRAPH_NAME\" created"
+
+# ===========================================================================
+act "STEP 3: curator publishes $SUB_GRAPH_TRIPLES SWM triples into sub-graph + $ROOT_TRIPLES into root"
+# ===========================================================================
+SUB_PAYLOAD=$(build_swm_payload "$CG_ID" "$SUB_GRAPH_TRIPLES" "sub" "$SUB_GRAPH_NAME")
+WROTE_SUB=$(api_call "$CURATOR_NODE" POST /api/shared-memory/write "$SUB_PAYLOAD")
+TRIPLES_WROTE_SUB=$(parse_json "$WROTE_SUB" '.triplesWritten')
+[ "$TRIPLES_WROTE_SUB" = "$SUB_GRAPH_TRIPLES" ] \
+  || fail "expected $SUB_GRAPH_TRIPLES sub-graph triplesWritten, got '$TRIPLES_WROTE_SUB' (response: $WROTE_SUB)"
+log "✓ wrote $SUB_GRAPH_TRIPLES SWM triples into sub-graph \"$SUB_GRAPH_NAME\""
+
+ROOT_PAYLOAD=$(build_swm_payload "$CG_ID" "$ROOT_TRIPLES" "root" "")
+WROTE_ROOT=$(api_call "$CURATOR_NODE" POST /api/shared-memory/write "$ROOT_PAYLOAD")
+TRIPLES_WROTE_ROOT=$(parse_json "$WROTE_ROOT" '.triplesWritten')
+[ "$TRIPLES_WROTE_ROOT" = "$ROOT_TRIPLES" ] \
+  || fail "expected $ROOT_TRIPLES root triplesWritten, got '$TRIPLES_WROTE_ROOT' (response: $WROTE_ROOT)"
+log "✓ wrote $ROOT_TRIPLES SWM triples into CG root"
+
+# Sanity-check the curator can see what it just wrote (proves the
+# fixtures are real, not just write-side ACKs).
+QC_SUB=$(api_call "$CURATOR_NODE" POST /api/query "$(cat <<EOF
+{ "contextGraphId": "$CG_ID", "subGraphName": "$SUB_GRAPH_NAME", "graphSuffix": "_shared_memory",
+  "sparql": "SELECT (COUNT(*) AS ?n) WHERE { ?s <http://schema.org/name> ?o }" }
+EOF
+)")
+NC_SUB=$(sparql_count "$QC_SUB")
+[ "$NC_SUB" = "$SUB_GRAPH_TRIPLES" ] \
+  || fail "curator's own sub-graph SWM count was '$NC_SUB', expected $SUB_GRAPH_TRIPLES"
+QC_ROOT=$(api_call "$CURATOR_NODE" POST /api/query "$(cat <<EOF
+{ "contextGraphId": "$CG_ID", "graphSuffix": "_shared_memory",
+  "sparql": "SELECT (COUNT(*) AS ?n) WHERE { ?s <http://schema.org/name> ?o }" }
+EOF
+)")
+NC_ROOT=$(sparql_count "$QC_ROOT")
+[ "$NC_ROOT" = "$ROOT_TRIPLES" ] \
+  || fail "curator's own root SWM count was '$NC_ROOT', expected $ROOT_TRIPLES"
+log "✓ curator can locally see sub-graph=$NC_SUB + root=$NC_ROOT"
+
+# ===========================================================================
+act "STEP 4: late joiner signs a join delegation"
+# ===========================================================================
+SIGN_RESP=$(api_call "$LATE_JOINER_NODE" POST "/api/context-graph/$(printf '%s' "$CG_ID" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>process.stdout.write(encodeURIComponent(d)))')/sign-join" "{}")
+SIGN_OK=$(parse_json "$SIGN_RESP" '.ok')
+[ "$SIGN_OK" = "true" ] || fail "sign-join failed: $SIGN_RESP"
+DELEGATION_JSON=$(printf '%s' "$SIGN_RESP" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.stringify(JSON.parse(d).delegation)))')
+log "✓ late joiner signed delegation (agent=$LATE_JOINER_AGENT)"
+
+# ===========================================================================
+act "STEP 5: late joiner sends request-join to curator (peer=$CURATOR_PEER)"
+# ===========================================================================
+REQ_BODY=$(DELEGATION="$DELEGATION_JSON" CURATOR_PEER="$CURATOR_PEER" node -e '
+  const out = {
+    delegation: JSON.parse(process.env.DELEGATION),
+    curatorPeerId: process.env.CURATOR_PEER,
+    agentName: "swm-lj-sg-test",
+  };
+  console.log(JSON.stringify(out));
+')
+REQ_RESP=$(api_call "$LATE_JOINER_NODE" POST "/api/context-graph/$(printf '%s' "$CG_ID" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>process.stdout.write(encodeURIComponent(d)))')/request-join" "$REQ_BODY")
+REQ_STATUS=$(parse_json "$REQ_RESP" '.status')
+[ "$REQ_STATUS" = "pending" ] \
+  || fail "request-join expected status=pending, got '$REQ_STATUS' (response: $REQ_RESP)"
+log "✓ join request delivered to curator"
+
+# Curator processes the inbound delegation asynchronously; give it a
+# moment to land in the pending queue before approving.
+sleep 2
+
+# ===========================================================================
+act "STEP 6: curator approves the join"
+# ===========================================================================
+APPROVE_RESP=$(api_call "$CURATOR_NODE" POST "/api/context-graph/$(printf '%s' "$CG_ID" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>process.stdout.write(encodeURIComponent(d)))')/approve-join" "$(cat <<EOF
+{ "agentAddress": "$LATE_JOINER_AGENT" }
+EOF
+)")
+APPROVE_STATUS=$(parse_json "$APPROVE_RESP" '.status')
+[ "$APPROVE_STATUS" = "approved" ] \
+  || fail "approve-join expected status=approved, got '$APPROVE_STATUS' (response: $APPROVE_RESP)"
+log "✓ curator approved late joiner"
+
+# ===========================================================================
+act "STEP 7: wait ${POST_APPROVAL_WAIT_S}s for join-approved notification + post-approval sync to settle"
+# ===========================================================================
+log "  (approve-join → notifyJoinApproval → late joiner runImmediatePostApprovalSync → catchup)"
+sleep "$POST_APPROVAL_WAIT_S"
+
+# ===========================================================================
+act "STEP 8: late joiner queries SWM — sub-graph + root MUST both be present"
+# ===========================================================================
+Q_SUB=$(api_call "$LATE_JOINER_NODE" POST /api/query "$(cat <<EOF
+{ "contextGraphId": "$CG_ID", "subGraphName": "$SUB_GRAPH_NAME", "graphSuffix": "_shared_memory",
+  "sparql": "SELECT (COUNT(*) AS ?n) WHERE { ?s <http://schema.org/name> ?o }" }
+EOF
+)")
+N_SUB=$(sparql_count "$Q_SUB")
+log "  late joiner sub-graph \"$SUB_GRAPH_NAME\" SWM count: $N_SUB (expect $SUB_GRAPH_TRIPLES)"
+
+Q_ROOT=$(api_call "$LATE_JOINER_NODE" POST /api/query "$(cat <<EOF
+{ "contextGraphId": "$CG_ID", "graphSuffix": "_shared_memory",
+  "sparql": "SELECT (COUNT(*) AS ?n) WHERE { ?s <http://schema.org/name> ?o }" }
+EOF
+)")
+N_ROOT=$(sparql_count "$Q_ROOT")
+log "  late joiner root SWM count: $N_ROOT (expect $ROOT_TRIPLES)"
+
+# Surface both numbers up-front so a failure run shows the full
+# picture (e.g. sub=0 + root=3 is the EXACT pre-fix signature; sub=5
+# + root=3 is the post-fix signature; sub=0 + root=0 means the join
+# flow itself broke).
+if [ "$N_ROOT" != "$ROOT_TRIPLES" ]; then
+  fail "late joiner root SWM count was '$N_ROOT', expected $ROOT_TRIPLES (root SWM backfill is the BASELINE — if this fails, the join/catchup flow itself broke, not gap 2)"
+fi
+if [ "$N_SUB" != "$SUB_GRAPH_TRIPLES" ]; then
+  fail "late joiner sub-graph SWM count was '$N_SUB', expected $SUB_GRAPH_TRIPLES (this is the EXACT gap 2 regression signature — root flowed but sub-graph did not, because the sync responder's SPARQL only matched the root SWM URI). PR #885's sync-handler.ts patch is missing or broken."
+fi
+log "✓ STEP 8: late joiner sees sub-graph=$N_SUB AND root=$N_ROOT — gap 2 closed"
+
+# ===========================================================================
+act "STEP 9: late joiner daemon log MUST NOT contain the gap-1 misleading WARN for this CG"
+# ===========================================================================
+LATE_LOG=$(node_log "$LATE_JOINER_NODE")
+if [ ! -f "$LATE_LOG" ]; then
+  warn "late joiner log file not found at $LATE_LOG — skipping gap 1 assertion"
+else
+  # The exact text emitted by `reconcileSharedMemoryGossipSubscription`
+  # at the point that PR #885 closes. Anchored to the CG_ID so we
+  # don't false-positive on unrelated CGs that happened to be
+  # exercised by the same daemon during this run. `grep ... || true`
+  # because grep exits 1 when there are zero matches — which is the
+  # success case for this assertion, not an error.
+  DENIED_HITS=$(grep -F "SWM gossip subscription denied for \"$CG_ID\": local node is not authorized" "$LATE_LOG" 2>/dev/null | wc -l | tr -d '[:space:]' || true)
+  : "${DENIED_HITS:=0}"
+  if [ "$DENIED_HITS" != "0" ]; then
+    fail "gap 1 regression: late joiner emitted $DENIED_HITS 'SWM gossip subscription denied for \"$CG_ID\"' line(s). PR #885's deferSharedMemoryGossipSubscribe path is missing or broken. (Without the fix the count is reliably ≥1.)"
+  fi
+  log "✓ STEP 9: zero spurious 'SWM gossip subscription denied' lines for this CG — gap 1 closed"
+fi
+
+echo ""
+log "============================================================"
+log "PASS: SWM late-joiner sub-graph backfill works end-to-end."
+log "  Gap 2 (sub-graph blind spot in sync responder)  — closed."
+log "  Gap 1 (approve-time _meta race for SWM gossip)  — closed."
+log "  CG: $CG_ID"
+log "  triples: sub-graph=$N_SUB, root=$N_ROOT"
+log "============================================================"


### PR DESCRIPTION
## Summary

Fixes two related gaps that prevent a freshly-approved late joiner from seeing a CG's SWM history when it lives in sub-graphs, and that emit a misleading `SWM gossip subscription denied: local node is not authorized` warning on every fresh approve.

**Reproducer (real network, devnet):**

1. Curator creates CG `<cgPrefix>` and publishes SWM into a sub-graph (e.g. `<cgPrefix>/ai-tools/_shared_memory`).
2. New node sends a signed `requestJoin`; curator `approveJoin`s it.
3. Late joiner observes the `denied` WARN in the daemon log.
4. `runImmediatePostApprovalSync` returns `data=N sharedMemory=0` even though the curator has thousands of SWM triples in `<cgPrefix>/ai-tools/_shared_memory`.

This PR ships a standalone devnet regression harness (`scripts/devnet-test-swm-late-joiner-subgraph.sh`) that mechanises the above and asserts both fixes end-to-end. The existing `devnet-test-rfc38-late-joiner.sh` scenarios pre-allowlist members and only exercise root-level SWM, so neither path was covered until now.

## What changed

### Gap 2 — sub-graph blind spot in the sync responder

`packages/agent/src/sync/responder/sync-handler.ts`

The workspace branch hardcoded its SPARQL to `contextGraphWorkspaceGraphUri(cgId)` / `...MetaGraphUri(cgId)`, both of which alias the CG-root SWM URI:

- `<cgPrefix>/_shared_memory`
- `<cgPrefix>/_shared_memory_meta`

Any publish that supplied `subGraphName` lands at the per-sub-graph variants (`<cgPrefix>/<sub>/_shared_memory[_meta]`), so the responder's static graph filter never saw them. After this PR the responder filters by URI shape under the CG prefix and emits `?g` per binding so the requester reconstructs the correct graph at write time. The TTL data branch binds the ops graph to the entity graph via `STR(?gMeta) = CONCAT(STR(?g), "_meta")` so per-sub-graph ops only pair with their own entities (no bleeding across sub-graphs or into root).

URI shape filter is exact: `validateSubGraphName` (dkg-core/constants.ts) prohibits `/` and leading `_`, so the only graphs matching `<cgPrefix>/[<sub>/]_shared_memory[_meta]` are the SWM graphs we want. `_shared_memory_meta` does not match `STRENDS(?g, "/_shared_memory")` (length mismatch), so the data and meta phases stay cleanly partitioned.

This same fix also closes Gap 3 — the perceived "pre-join SWM is undecryptable" issue. Forward secrecy protects the gossip ciphertext from non-members; it does not prevent the curator (who holds plaintext in its local SWM store) from shipping that plaintext over the authenticated `/dkg/10.0.1/sync` link to a peer who is now allowlisted. That's exactly what bilateral sync was designed for. The pre-existing `authorizePrivateSyncRequest` gate (envelope freshness + replay protection + signer recovery + identity verification + participant/agent-gate/peer/delegation allowlist + `refreshMetaFromCurator` on first miss) ensures only authorized peers receive plaintext.

### Gap 1 — approve-time SWM gossip auth race

`packages/agent/src/dkg-agent.ts`

On a fresh `join-approved` notification, the curator has just written the allowlist into ITS `_meta`, but the requesting node hasn't synced that allowlist yet. The current handler called `subscribeToContextGraph(cgId)` synchronously, which queued an SWM gossip subscribe whose `canReadContextGraph` check ran against an empty local `_meta` — denying with the misleading `local node is not authorized` warning before `refreshMetaSyncedFlags` self-healed it seconds later.

Added opt-in `deferSharedMemoryGossipSubscribe: boolean` to `subscribeToContextGraph` and wired it through the join-approved handler. Other gossip topics (publish, app, update, finalization) wire up immediately as before — UI feedback unchanged. Only SWM gossip subscribe is deferred until `_meta` is locally visible.

The self-heal path already exists: `runImmediatePostApprovalSync` calls `runCatchupOverPeers` which awaits `refreshMetaSyncedFlags([cgId])` (line 3580), which calls `queueSharedMemoryGossipSubscription` once `hasConfirmedMetaState` is true (line 3738). Robust against post-approval sync failure too: `refreshMetaSyncedFlags` is also called from `sync-on-connect.ts:85` on every new peer connection and from the periodic catchup reconciler.

### Test coverage

**Unit (`packages/agent/test/sync-responder-swm-subgraphs.test.ts`)** — new, 350 lines, 8 cases — modelled on the existing `sync-responder-per-cgid-meta.test.ts` regression style. Covers:

- `phase=data`: returns root + every sub-graph SWM in one response, excludes SWM meta graphs, excludes durable-tier graphs.
- `phase=meta`: returns root + every sub-graph SWM meta, excludes SWM data graphs, excludes durable top-level `_meta`.
- `phase=data` with TTL: keeps fresh root + sub entities, drops stale ones, scoped per sub-graph (verifies the `?gMeta = ?g + "_meta"` binding).
- Per-line nquad serialization correctly emits the source graph URI (no longer the static root alias).

**Devnet (`scripts/devnet-test-swm-late-joiner-subgraph.sh`)** — new, 315 lines — exercises the full `requestJoin → approveJoin → catchup → assert both root + sub-graph SWM visible` flow against `./scripts/devnet.sh start`. Curator (N5) creates CG with allowlist=[curator] only, creates sub-graph `ai-tools`, publishes 5 SWM triples into the sub-graph + 3 into root. Late joiner (N1, NOT pre-allowlisted) signs a delegation, request-joins, gets approved, then SPARQLs both layers. Two anchored assertions:

- Sub-graph `ai-tools` SWM count == 5 (gap 2 — pre-fix this is reliably 0).
- CG_ID-anchored grep for `SWM gossip subscription denied for "<cgId>"` returns 0 hits in the late joiner's daemon log (gap 1 — pre-fix this is reliably ≥1).

## Test plan

- [x] `pnpm -F @origintrail-official/dkg-agent exec vitest run --no-coverage test/sync-responder-swm-subgraphs.test.ts test/sync-responder-per-cgid-meta.test.ts test/sync-fresh-per-attempt.test.ts test/request-authorize.test.ts test/swm-snapshot-sync.test.ts test/swm-first-writer-wins-extra.test.ts` — 38/38 pass
- [x] `./scripts/devnet.sh start && ./scripts/devnet-test-swm-late-joiner-subgraph.sh` — PASS on local 6-node devnet (curator catchup line: `Catch-up sync ... data=144 sharedMemory=106 denied=0`; SPARQL `sub-graph=5, root=3`; zero gap-1 WARNs for the test CG).
- [ ] Hardhat-backed e2e suite runs green in CI