### PR TITLE
node-ui: post-#847 follow-ups — GH #881 fused counts helper + #882 hydrating tooltip

### DIFF
--- a/packages/node-ui/src/ui/views/DashboardView.tsx
+++ b/packages/node-ui/src/ui/views/DashboardView.tsx
@@ -6,7 +6,7 @@ import { useTabsStore } from '../stores/tabs.js';
 import { useProjectsStore, type ContextGraph } from '../stores/projects.js';
 import { useMyContextGraphs } from '../hooks/useMyContextGraphs.js';
 import { useMemoryEntities } from '../hooks/useMemoryEntities.js';
-import { useCanonicalTriples, useLayerTriples } from './project/helpers.js';
+import { useMemoryCounts } from './project/helpers.js';
 import { useNodeEvents } from '../hooks/useNodeEvents.js';
 import {
   canonicalAgentDid,
@@ -342,39 +342,31 @@ function CgRow({
     const subjects = new Set(mem.allTriples.map((t) => t.subject)).size;
     return { wm: mem.counts.wm, swm: mem.counts.swm, vm: mem.counts.vm, total: subjects };
   }, [mem.error, mem.allTriples, mem.counts.wm, mem.counts.swm, mem.counts.vm, summaryAssets]);
-  // GH #819 — total via `useCanonicalTriples`, per-layer cells via
-  // `useLayerTriples`. Pre-#819 this iterated `mem.allTriples`
-  // directly; per-layer counts and total were both inflated by SWM
-  // cross-graph SPO duplicates + post-promote WM residue (the same
-  // family GH #805 closed for the Overview stat, never wired
-  // through to Dashboard). The "413 → 372 on the recipe-app CG"
-  // acceptance lands on the total.
+  // GH #819 — counts derive from canonical/per-layer admission rules
+  // (residue + SPO dedup) instead of raw `mem.allTriples`. Per-layer
+  // cells use the OR-rule (drop if subject OR resource-object moved
+  // past t.layer); total uses the canonical AND-rule (drop only
+  // when BOTH moved). Pre-#819 this iterated `mem.allTriples`
+  // directly and inflated both numbers via SWM cross-graph SPO
+  // duplicates + post-promote WM residue.
   //
-  // Per-layer cells use `useLayerTriples` (OR-rule: drops a row if
-  // subject OR resource-object has moved past t.layer — correct
-  // semantics for "facts canonically at this layer", matches the
-  // Overview LayerStats per-layer cells cell-for-cell). Total uses
-  // `useCanonicalTriples` (drops only when BOTH endpoints moved
-  // past t.layer — preserves legitimate mixed-layer edges across
-  // the aggregate).
+  // GH #881 (post-#847) — single fused pass via `useMemoryCounts`
+  // replaces 3× `useLayerTriples` + 1× `useCanonicalTriples` (4
+  // iterations) with one. Same numbers, ~4× less work per `CgRow`
+  // — meaningful on many-CG dashboards.
   //
   // CONTRACT: `wm + swm + vm ≤ total` on Dashboard. The gap is the
   // count of mixed-layer edges (one endpoint at t.layer, other
   // moved past) that canonical keeps but per-layer slices drop.
   // Restoring strict equality would require migrating LayerStats
-  // consumers off `useLayerTriples` — out of GH #819 scope. The
-  // ux-lead brief is explicit: "Don't refactor `useLayerTriples`;
-  // just stop summing its outputs at the 6 aggregate sites."
-  const wmLayer = useLayerTriples(mem, 'wm');
-  const swmLayer = useLayerTriples(mem, 'swm');
-  const vmLayer = useLayerTriples(mem, 'vm');
-  const canonical = useCanonicalTriples(mem);
+  // consumers off the OR-rule — out of GH #819 / #881 scope.
+  const memCounts = useMemoryCounts(mem);
   const triples: LayerCounts = useMemo(() => ({
-    wm: wmLayer.length,
-    swm: swmLayer.length,
-    vm: vmLayer.length,
-    total: canonical.total,
-  }), [wmLayer, swmLayer, vmLayer, canonical]);
+    wm: memCounts.wm,
+    swm: memCounts.swm,
+    vm: memCounts.vm,
+    total: memCounts.canonical,
+  }), [memCounts]);
 
   const sig = [
     mem.loading ? 1 : 0, mem.error ? 1 : 0, mem.partial ? 1 : 0, agentsLoading ? 1 : 0, agentsError ? 1 : 0, isPublicCg ? 1 : 0,

--- a/packages/node-ui/src/ui/views/MemoryStackView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryStackView.tsx
@@ -17,7 +17,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useProjectsStore, type ContextGraph } from '../stores/projects.js';
 import { useTabsStore } from '../stores/tabs.js';
 import { useMemoryEntities, type MemoryEntity, type TrustLevel } from '../hooks/useMemoryEntities.js';
-import { useLayerTriples } from './project/helpers.js';
+import { useMemoryCounts } from './project/helpers.js';
 import { relativeTime } from '../hooks/useProjectActivity.js';
 import { useHiddenContextGraphIds } from '../hooks/useHiddenContextGraphIds.js';
 
@@ -91,32 +91,25 @@ function MemoryStackRow({ cg }: { cg: ContextGraph }) {
   const memory = useMemoryEntities(cg.id);
   const { openTab } = useTabsStore();
   // GH #819 round 3 (Codex sweep 1 🔴 #2) — per-layer buckets use
-  // `useLayerTriples` (OR-rule: drops if subject OR resource-object
-  // moved past t.layer; matches the per-layer Triples-tab the
-  // layer-card buttons open by clicking). Pre-round-3 this read
-  // from `useCanonicalTriples` for per-layer cells too — which
-  // kept mixed-layer edges via the BOTH-endpoints rule, so the
-  // Memory Stack per-layer cells exceeded the layer pages they
-  // navigate to. Same family as the Dashboard round-2 fix, same
-  // option (a) shape: per-layer cells revert, total stays
-  // canonical.
-  const wmLayer = useLayerTriples(memory, 'wm');
-  const swmLayer = useLayerTriples(memory, 'swm');
-  const vmLayer = useLayerTriples(memory, 'vm');
+  // the OR-rule admission (drop if subject OR resource-object moved
+  // past t.layer; matches the per-layer Triples tab the layer-card
+  // buttons open by clicking). Pre-round-3 this read from canonical
+  // for per-layer cells too — which kept mixed-layer edges via the
+  // BOTH-endpoints rule, so the Memory Stack per-layer cells
+  // exceeded the layer pages they navigate to.
+  //
+  // GH #881 (post-#847) — single fused pass via `useMemoryCounts`
+  // replaces 3× `useLayerTriples` (3 iterations) with one. The
+  // helper returns counts only — this row only ever read `.length`
+  // off the per-layer arrays, so the swap is contract-identical.
+  const memCounts = useMemoryCounts(memory);
 
   // Bucket entities + triple-counts per layer in one pass.
-  // CONTRACT (mirrors `DashboardView.tsx`): per-layer cells use
-  // `useLayerTriples` — matches the per-layer Triples tab the
-  // layer-card buttons open cell-for-cell. If a project-wide
-  // canonical total is added to this view later (e.g. a footer
-  // total stat), source it from `useCanonicalTriples(memory).total`
-  // and document `wm+swm+vm ≤ total` at THAT site, same as
-  // Dashboard's contract.
   const byLayer = useMemo(() => {
     const buckets: Record<TrustLevel, { entities: MemoryEntity[]; tripleCount: number }> = {
-      working:  { entities: [], tripleCount: wmLayer.length },
-      shared:   { entities: [], tripleCount: swmLayer.length },
-      verified: { entities: [], tripleCount: vmLayer.length },
+      working:  { entities: [], tripleCount: memCounts.wm },
+      shared:   { entities: [], tripleCount: memCounts.swm },
+      verified: { entities: [], tripleCount: memCounts.vm },
     };
     for (const e of memory.entityList) {
       buckets[e.trustLevel].entities.push(e);
@@ -133,7 +126,7 @@ function MemoryStackRow({ cg }: { cg: ContextGraph }) {
       });
     }
     return buckets;
-  }, [memory.entityList, wmLayer, swmLayer, vmLayer]);
+  }, [memory.entityList, memCounts]);
 
   const openProject = () =>
     openTab({

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4616,28 +4616,36 @@ export function SubGraphMiniCard({
             quiet case. Same conditional-when-it-has-something-to-
             say pattern as S2's `Pending join requests` empty
             state. */}
-        {/* GH #819 round 10 (Codex sweep 8 🟡 #18) — extended badge
-            matrix. Rounds 6/7 only fired the failure tooltip on
-            zero-bucket cards; a partial-layer-failure with a
-            non-zero bucket rendered the count with no disclosure
-            that some layers were unavailable. Now `isFailedOrPartial`
-            fires for ALL bucket values — when bucket > 0 the
-            tooltip prefixes the count with "{N} triples (some
-            layers unavailable; count may be incomplete)."
-            Precedence (top wins):
-              • hydrating + bucket 0  → `…` "Loading triples…"
-              • failed/partial (any bucket) → "{N} triples (some
-                layers unavailable; count may be incomplete)."
+        {/* GH #882 (post-#847 follow-up) — extended hydrating
+            tooltip to non-zero buckets, mirroring the round-10
+            #18 pattern for the failure branch. Before #882 the
+            hydrating tooltip only fired on zero buckets; a
+            non-zero card rendered the partial count silently
+            while WM/SWM/VM were still loading. Now `isHydrating`
+            fires for ALL bucket values:
+              • bucket 0 + hydrating → `…` "Loading triples…"
+              • bucket > 0 + hydrating → "{N} triples (still
+                loading; count may grow)."
+            Precedence (top wins, unchanged from round 10):
+              • hydrating (any bucket) → loading affordance/tooltip
+              • failed/partial (any bucket) → failure tooltip
               • stat-vs-rendered mismatch → β literal (round 8)
               • otherwise → no tooltip
-            Failure wins over the stat-vs-rendered tooltip — once
-            layers re-hydrate the cap-truncation gap recomputes
-            correctly; the failure signal is the louder one. */}
+            `isHydrating` wins over `isFailedOrPartial` —
+            transient state takes precedence over settled-
+            incomplete signal (round 7 #14 contract).
+            Engineer-placeholder wording for the new
+            hydrating-with-count cell ("still loading; count may
+            grow"); gate logic is decoupled from copy so ux-lead
+            can tighten the wording in a follow-up without
+            touching the matrix. */}
         <span
           className="v10-sgov-card-stat"
           title={
-            isHydrating && card.tripleCount === 0
-              ? 'Loading triples for this subgraph…'
+            isHydrating
+              ? card.tripleCount === 0
+                ? 'Loading triples for this subgraph…'
+                : `${card.tripleCount} triples (still loading; count may grow).`
               : isFailedOrPartial
                 ? `${card.tripleCount} triples (some layers unavailable; count may be incomplete).`
                 : card.tripleCount !== card.triples.length

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -4616,49 +4616,51 @@ export function SubGraphMiniCard({
             quiet case. Same conditional-when-it-has-something-to-
             say pattern as S2's `Pending join requests` empty
             state. */}
-        {/* GH #882 (post-#847 follow-up) — extended hydrating
-            tooltip to non-zero buckets, mirroring the round-10
-            #18 pattern for the failure branch. Before #882 the
-            hydrating tooltip only fired on zero buckets; a
-            non-zero card rendered the partial count silently
-            while WM/SWM/VM were still loading. Now `isHydrating`
-            fires for ALL bucket values:
-              • bucket 0 + hydrating → `…` "Loading triples…"
-              • bucket > 0 + hydrating → "{N} triples (still
-                loading; count may grow)."
-            Precedence (top wins, unchanged from round 10):
-              • hydrating (any bucket) → loading affordance/tooltip
-              • failed/partial (any bucket) → failure tooltip
-              • stat-vs-rendered mismatch → β literal (round 8)
-              • otherwise → no tooltip
-            `isHydrating` wins over `isFailedOrPartial` —
-            transient state takes precedence over settled-
-            incomplete signal (round 7 #14 contract).
-            Engineer-placeholder wording for the new
-            hydrating-with-count cell ("still loading; count may
-            grow"); gate logic is decoupled from copy so ux-lead
-            can tighten the wording in a follow-up without
-            touching the matrix. */}
+        {/* GH #890 round 2 (Codex sweep 1 🟡 A) — bucket-aware
+            precedence. Round 1 (#882) made `isHydrating`
+            short-circuit the entire chain, so a mixed state
+            (some layers `loading`, others `error`) on a non-zero
+            bucket rendered the optimistic "still loading; count
+            may grow" tooltip and masked the known-incomplete
+            failure. Round 2 splits the precedence so the failure
+            disclosure wins everywhere except the zero-bucket
+            initial-fetch window:
+              1. hydrating + bucket 0 → `…` "Loading triples…"
+                 (loading affordance is the priority signal when
+                 we have no count yet — preserves the round 6 #11
+                 anti-flash contract: `useMemoryEntities`
+                 initializes `allTriples = []` so a real subgraph
+                 briefly shows 0 during initial fetch)
+              2. failed/partial (any bucket) → failure tooltip
+                 (wins over hydrating on non-zero — the count is
+                 already known-incomplete because a layer errored)
+              3. hydrating + bucket > 0 (no failure) → "still
+                 loading; count may grow" (#882 wording, only
+                 fires when no failure flag is set)
+              4. stat-vs-rendered mismatch → β literal (round 8)
+              5. otherwise → no tooltip */}
         <span
           className="v10-sgov-card-stat"
           title={
-            isHydrating
-              ? card.tripleCount === 0
-                ? 'Loading triples for this subgraph…'
-                : `${card.tripleCount} triples (still loading; count may grow).`
+            isHydrating && card.tripleCount === 0
+              ? 'Loading triples for this subgraph…'
               : isFailedOrPartial
-                ? `${card.tripleCount} triples (some layers unavailable; count may be incomplete).`
-                : card.tripleCount !== card.triples.length
-                  // GH #819 round 8 (Codex sweep 6 🟡 #4 / #9 / #12,
-                  // team-lead call β) — broader wording so the
-                  // tooltip covers both causes of stat-vs-rendered
-                  // gap: (1) cross-card edges whose other endpoint
-                  // sits outside the subgraph and (2) cap-trimmed
-                  // rows in dense buckets via `applyHeaviestSubjectsCap`.
-                  // Earlier copy blamed only cause (1); Codex
-                  // re-raised the cap-trim case 5 sweeps in a row.
-                  ? `${card.tripleCount} triples in this subgraph's scope; ${card.triples.length} rendered (some in-scope edges aren't drawn — either endpoints outside this subgraph, or cap-trimmed in dense buckets).`
-                  : undefined
+                ? card.tripleCount === 0
+                  ? 'Some layers unavailable; count may be incomplete.'
+                  : `${card.tripleCount} triples (some layers unavailable; count may be incomplete).`
+                : isHydrating
+                  ? `${card.tripleCount} triples (still loading; count may grow).`
+                  : card.tripleCount !== card.triples.length
+                    // GH #819 round 8 (Codex sweep 6 🟡 #4 / #9 / #12,
+                    // team-lead call β) — broader wording so the
+                    // tooltip covers both causes of stat-vs-rendered
+                    // gap: (1) cross-card edges whose other endpoint
+                    // sits outside the subgraph and (2) cap-trimmed
+                    // rows in dense buckets via `applyHeaviestSubjectsCap`.
+                    // Earlier copy blamed only cause (1); Codex
+                    // re-raised the cap-trim case 5 sweeps in a row.
+                    ? `${card.tripleCount} triples in this subgraph's scope; ${card.triples.length} rendered (some in-scope edges aren't drawn — either endpoints outside this subgraph, or cap-trimmed in dense buckets).`
+                    : undefined
           }
         ><b>{isHydrating && card.tripleCount === 0 ? '…' : card.tripleCount}</b> triples</span>
       </div>

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -545,6 +545,55 @@ export function admitTripleForScope(
  * rule WITHOUT sharing its global dedup namespace (which would
  * collide cross-scope SPOs).
  */
+/**
+ * GH #890 round 2 (Codex sweep 1 🟡 B) — row-level residue
+ * predicates shared by `useLayerTriples`, `applyCanonicalAdmission`,
+ * and `useMemoryCounts`. The triple-producing helpers and the
+ * fused counter ran three hand-rolled copies of the same logic;
+ * the #819 cycle had ~10 rule refinements and each had to be
+ * propagated to every copy. Extracting these as exported pure
+ * predicates makes the drop rule a single source of truth.
+ *
+ * `isSubjectResidue` — subject has moved past the row's layer.
+ * `isObjectResourceResidue` — object is a resource AND has moved
+ *   past the row's layer (literal objects always return false).
+ * `isPerLayerResidue` — OR-rule (matches `useLayerTriples`):
+ *   drop if either endpoint moved past `t.layer`.
+ * `isCanonicalResidue` — AND-rule (matches
+ *   `applyCanonicalAdmission`): drop only when BOTH endpoints
+ *   moved past `t.layer`. Preserves mixed-layer edges as facts.
+ */
+export function isSubjectResidue(
+  t: LayeredTriple,
+  entities: ReadonlyMap<string, MemoryEntity>,
+): boolean {
+  const subj = entities.get(canonicalEntityUri(t.subject));
+  return subj !== undefined && subj.trustLevel !== t.layer;
+}
+
+export function isObjectResourceResidue(
+  t: LayeredTriple,
+  entities: ReadonlyMap<string, MemoryEntity>,
+): boolean {
+  if (!isResourceObject(t.object)) return false;
+  const obj = entities.get(canonicalEntityUri(t.object));
+  return obj !== undefined && obj.trustLevel !== t.layer;
+}
+
+export function isPerLayerResidue(
+  t: LayeredTriple,
+  entities: ReadonlyMap<string, MemoryEntity>,
+): boolean {
+  return isSubjectResidue(t, entities) || isObjectResourceResidue(t, entities);
+}
+
+export function isCanonicalResidue(
+  t: LayeredTriple,
+  entities: ReadonlyMap<string, MemoryEntity>,
+): boolean {
+  return isSubjectResidue(t, entities) && isObjectResourceResidue(t, entities);
+}
+
 export function applyCanonicalAdmission(
   triples: readonly LayeredTriple[],
   entities: ReadonlyMap<string, MemoryEntity>,
@@ -569,20 +618,15 @@ export function applyCanonicalAdmission(
   // Losing real multi-valued facts is worse than transiently
   // double-showing single-valued ones; the round 7 logic was
   // reverted.
+  //
+  // GH #890 round 2 — uses the shared `isCanonicalResidue`
+  // predicate. Behavior identical to the prior inline check
+  // (subject moved past `t.layer` AND object is a resource that
+  // also moved past `t.layer`).
   const seen = new Set<string>();
   const out: LayeredTriple[] = [];
   for (const t of triples) {
-    const subjectEntity = entities.get(canonicalEntityUri(t.subject));
-    const subjectMoved =
-      subjectEntity !== undefined && subjectEntity.trustLevel !== t.layer;
-    let dropAsResidue = false;
-    if (subjectMoved && isResourceObject(t.object)) {
-      const objectEntity = entities.get(canonicalEntityUri(t.object));
-      if (objectEntity && objectEntity.trustLevel !== t.layer) {
-        dropAsResidue = true;
-      }
-    }
-    if (dropAsResidue) continue;
+    if (isCanonicalResidue(t, entities)) continue;
     const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
     if (seen.has(key)) continue;
     seen.add(key);
@@ -634,32 +678,19 @@ export function useMemoryCounts(
     const seenVm = new Set<string>();
     const seenCanonical = new Set<string>();
     let wm = 0, swm = 0, vm = 0, canonical = 0;
+    // GH #890 round 2 — drop predicates come from the shared
+    // helpers (`isCanonicalResidue` / `isPerLayerResidue`). Same
+    // single source of truth `applyCanonicalAdmission` and
+    // `useLayerTriples` consume.
     for (const t of memory.allTriples) {
-      const canonicalSubject = canonicalEntityUri(t.subject);
-      const canonicalObject = canonicalEntityUri(t.object);
-      const subjectEntity = memory.entities.get(canonicalSubject);
-      const subjectMoved =
-        subjectEntity !== undefined && subjectEntity.trustLevel !== t.layer;
-      const objectIsResource = isResourceObject(t.object);
-      const objectEntity = objectIsResource
-        ? memory.entities.get(canonicalObject)
-        : undefined;
-      const objectMoved =
-        objectEntity !== undefined && objectEntity.trustLevel !== t.layer;
-      const key = `${canonicalSubject}|${t.predicate}|${canonicalObject}`;
+      const key = `${canonicalEntityUri(t.subject)}|${t.predicate}|${canonicalEntityUri(t.object)}`;
 
-      // Canonical (AND-rule residue drop): only drop when subject
-      // AND a resource-object endpoint both moved past `t.layer`.
-      const canonicalResidue = subjectMoved && objectIsResource && objectMoved;
-      if (!canonicalResidue && !seenCanonical.has(key)) {
+      if (!isCanonicalResidue(t, memory.entities) && !seenCanonical.has(key)) {
         seenCanonical.add(key);
         canonical++;
       }
 
-      // Per-layer (OR-rule): drop if either endpoint moved past
-      // `t.layer`. Bucket dispatched by `t.layer`.
-      const layerResidue = subjectMoved || (objectIsResource && objectMoved);
-      if (!layerResidue) {
+      if (!isPerLayerResidue(t, memory.entities)) {
         if (t.layer === 'working' && !seenWm.has(key)) {
           seenWm.add(key);
           wm++;
@@ -683,45 +714,26 @@ export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, la
     const out: Triple[] = [];
     for (const t of memory.allTriples) {
       if (t.layer !== targetLayer) continue;
-      // Skip residual triples for a subject that has been promoted past
-      // this layer: post-promote the daemon currently leaves the WM
-      // `/assertion/<addr>/<name>` graphs on disk, so a promoted entity's
-      // WM triples keep coming back from `wmSparql` even though the
-      // entity has logically moved to SWM. The entity's canonical layer
-      // is `trustLevel` (its highest layer); a triple whose subject has
-      // moved past `targetLayer` would otherwise be counted on the
-      // prior layer's tally. Triples whose subject has no entity record
-      // (literal orphans / class IRIs that only ever appear as objects)
-      // pass through unfiltered.
+      // GH #890 round 2 — per-layer drop check delegated to the
+      // shared `isPerLayerResidue` predicate (OR-rule: drop if
+      // subject OR resource-object has moved past `t.layer`).
+      // Since the layer-mismatch filter above already enforces
+      // `t.layer === targetLayer`, the predicate's `t.layer`
+      // comparison is equivalent to comparing against `targetLayer`.
       //
-      // R2-1 fix: `entities.get` is keyed by the canonical (trimmed,
-      // unwrapped) URI per `buildEntities`. The daemon sometimes ships
-      // subjects wrapped (`<urn:...>`) — looking them up raw misses the
-      // entity record, silently bypasses this filter, and the phantom
-      // triple returns. Canonicalise first.
-      const subjectEntity = memory.entities.get(canonicalEntityUri(t.subject));
-      if (subjectEntity && subjectEntity.trustLevel !== targetLayer) continue;
-      // Issue-A fix (object-side, asymmetric C17 form): a WM triple
-      // `wm-entity-A relatesTo swm-entity-B` (B promoted to SWM) has
-      // a WM subject but its object has moved past WM. The triple is
-      // residue — counting it on WM would inflate the count and
-      // would leak the promoted-entity URI as an object in any
-      // downstream rendering. Drop resource→resource edges whose
-      // object has been promoted past the requested layer.
-      // Literal-valued triples (labels, names, etc.) have a
-      // non-resource object so this check no-ops; they always pass.
-      //
-      // This stays in `useLayerTriples` because it's a per-LAYER
-      // correctness rule (a triple shouldn't be tallied on a layer
-      // where neither endpoint canonically lives). Entity-filtering
-      // for the graph view happens downstream in `LayerGraphPanel`
-      // via `filterTriplesToEntities` — `useLayerTriples` is the
-      // honest layer source for triple counts and VM hero stats.
-      if (isResourceObject(t.object)) {
-        const canonicalObject = canonicalEntityUri(t.object);
-        const objectEntity = memory.entities.get(canonicalObject);
-        if (objectEntity && objectEntity.trustLevel !== targetLayer) continue;
-      }
+      // Rule rationale (preserved from the prior inline checks):
+      // (1) Subject residue — post-promote the daemon leaves the
+      //     WM `/assertion/<addr>/<name>` graphs on disk so a
+      //     promoted entity's WM triples keep coming back. Drop
+      //     them on this layer's tally.
+      // (2) Object resource residue — Issue-A fix: a WM triple
+      //     `wm-A relatesTo swm-B` (B promoted) would otherwise
+      //     leak the promoted URI as a phantom node and inflate
+      //     the count.
+      // Literal orphans (no entity record) and literal objects
+      // pass through unfiltered — same behavior as the prior
+      // inline checks.
+      if (isPerLayerResidue(t, memory.entities)) continue;
       // Canonicalise the dedup key so wrapped/bare duplicates of the
       // same `(s,p,o)` collapse — mirrors `dedupeTriplesBySpo` in
       // `ProjectView.tsx` and `buildEntities`' per-entity SPO key.

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -600,6 +600,82 @@ export function useCanonicalTriples(
   }, [memory.allTriples, memory.entities]);
 }
 
+/**
+ * GH #881 (post-#847 follow-up) — fused single-pass count helper
+ * for views that need all four counts (per-layer wm/swm/vm +
+ * canonical total) in one shot. `DashboardView`'s `CgRow` and
+ * `MemoryStackView` previously called `useLayerTriples` ×3 +
+ * `useCanonicalTriples` ×1, doing 4 separate iterations over
+ * `memory.allTriples` per row. On many-CG dashboards that adds up.
+ *
+ * Returns COUNTS only (not the underlying triple arrays); views
+ * that need the actual triples should keep using `useLayerTriples`
+ * / `useCanonicalTriples`. Inline per-bucket admission rules
+ * mirror the source helpers exactly:
+ *   - Per-layer (wm/swm/vm): only rows whose `t.layer` matches the
+ *     bucket AND whose subject hasn't moved past the bucket AND
+ *     whose resource-object (if any) hasn't moved past the bucket
+ *     (`useLayerTriples` OR-rule). Per-layer SPO dedup.
+ *   - Canonical: subject-and-object-both-moved residue drop only
+ *     (`applyCanonicalAdmission` AND-rule). Global SPO dedup
+ *     across all layers.
+ *
+ * Contract from `DashboardView.tsx`: `wm + swm + vm ≤ total`.
+ * Gap = mixed-layer edges canonical keeps but per-layer slices
+ * drop (subject moved past `t.layer`, object still at `t.layer` →
+ * canonical AND-rule keeps, per-layer OR-rule drops).
+ */
+export function useMemoryCounts(
+  memory: ReturnType<typeof useMemoryEntities>,
+): { wm: number; swm: number; vm: number; canonical: number } {
+  return useMemo(() => {
+    const seenWm = new Set<string>();
+    const seenSwm = new Set<string>();
+    const seenVm = new Set<string>();
+    const seenCanonical = new Set<string>();
+    let wm = 0, swm = 0, vm = 0, canonical = 0;
+    for (const t of memory.allTriples) {
+      const canonicalSubject = canonicalEntityUri(t.subject);
+      const canonicalObject = canonicalEntityUri(t.object);
+      const subjectEntity = memory.entities.get(canonicalSubject);
+      const subjectMoved =
+        subjectEntity !== undefined && subjectEntity.trustLevel !== t.layer;
+      const objectIsResource = isResourceObject(t.object);
+      const objectEntity = objectIsResource
+        ? memory.entities.get(canonicalObject)
+        : undefined;
+      const objectMoved =
+        objectEntity !== undefined && objectEntity.trustLevel !== t.layer;
+      const key = `${canonicalSubject}|${t.predicate}|${canonicalObject}`;
+
+      // Canonical (AND-rule residue drop): only drop when subject
+      // AND a resource-object endpoint both moved past `t.layer`.
+      const canonicalResidue = subjectMoved && objectIsResource && objectMoved;
+      if (!canonicalResidue && !seenCanonical.has(key)) {
+        seenCanonical.add(key);
+        canonical++;
+      }
+
+      // Per-layer (OR-rule): drop if either endpoint moved past
+      // `t.layer`. Bucket dispatched by `t.layer`.
+      const layerResidue = subjectMoved || (objectIsResource && objectMoved);
+      if (!layerResidue) {
+        if (t.layer === 'working' && !seenWm.has(key)) {
+          seenWm.add(key);
+          wm++;
+        } else if (t.layer === 'shared' && !seenSwm.has(key)) {
+          seenSwm.add(key);
+          swm++;
+        } else if (t.layer === 'verified' && !seenVm.has(key)) {
+          seenVm.add(key);
+          vm++;
+        }
+      }
+    }
+    return { wm, swm, vm, canonical };
+  }, [memory.allTriples, memory.entities]);
+}
+
 export function useLayerTriples(memory: ReturnType<typeof useMemoryEntities>, layer: 'wm' | 'swm' | 'vm'): Triple[] {
   const targetLayer = LAYER_CONFIG[layer].trustLevel;
   return useMemo(() => {

--- a/packages/node-ui/test/dashboard-memorystack-contract.test.ts
+++ b/packages/node-ui/test/dashboard-memorystack-contract.test.ts
@@ -6,6 +6,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import {
   useCanonicalTriples,
   useLayerTriples,
+  useMemoryCounts,
 } from '../src/ui/views/project/helpers.js';
 import {
   buildMemoryEntities,
@@ -197,5 +198,139 @@ describe('Dashboard + MemoryStack derivation contract (GH #819 round 5 — Codex
     expect(vm).toBe(0);
     expect(total).toBe(1);
     expect(wm + swm + vm).toBe(total);
+  });
+});
+
+// GH #881 (post-#847 follow-up) — single-pass `useMemoryCounts`
+// helper that produces the same four counts in one iteration over
+// `memory.allTriples`. The fixtures above each ran `useLayerTriples`
+// ×3 + `useCanonicalTriples` ×1 = 4 passes per render. This suite
+// locks: (1) the fused helper produces identical numbers across all
+// 3 fixtures; (2) it iterates `memory.allTriples` exactly once per
+// memoized result.
+
+function FusedCountsProbe({ memory }: { memory: MemoryData }) {
+  const { wm, swm, vm, canonical } = useMemoryCounts(memory as any);
+  return React.createElement('div', {
+    id: 'probe-fused',
+    'data-wm': String(wm),
+    'data-swm': String(swm),
+    'data-vm': String(vm),
+    'data-total': String(canonical),
+  });
+}
+
+function readFusedProbe(container: Element) {
+  const probe = container.querySelector('#probe-fused')!;
+  return {
+    wm: Number(probe.getAttribute('data-wm')),
+    swm: Number(probe.getAttribute('data-swm')),
+    vm: Number(probe.getAttribute('data-vm')),
+    total: Number(probe.getAttribute('data-total')),
+  };
+}
+
+describe('useMemoryCounts — fused single-pass helper (GH #881)', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(memory: MemoryData) {
+    act(() => {
+      root.render(React.createElement(FusedCountsProbe, { memory }));
+    });
+  }
+
+  // Same 3 fixtures as the legacy contract above, asserting
+  // identical numbers via the fused helper.
+
+  it('mixed-layer fixture — fused counts match 4-pass output', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+      { subject: 'urn:e:wm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'working' },
+      { subject: 'urn:e:swm-c', predicate: 'http://schema.org/name', object: '"C"', layer: 'shared' },
+      { subject: 'urn:e:swm-c', predicate: 'http://schema.org/knows', object: 'urn:e:wm-a', layer: 'working' },
+    ];
+    render(memoryFor(triples));
+    const { wm, swm, vm, total } = readFusedProbe(container);
+    expect(wm).toBe(2);
+    expect(swm).toBe(1);
+    expect(vm).toBe(0);
+    expect(total).toBe(4);
+    expect(wm + swm + vm).toBeLessThanOrEqual(total);
+    expect(total - (wm + swm + vm)).toBe(1);
+  });
+
+  it('WM-residue fixture — fused counts match 4-pass output', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:promoted-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'shared' },
+      { subject: 'urn:e:promoted-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared' },
+      { subject: 'urn:e:promoted-a', predicate: 'http://schema.org/knows', object: 'urn:e:promoted-b', layer: 'shared' },
+      { subject: 'urn:e:promoted-a', predicate: 'http://schema.org/knows', object: 'urn:e:promoted-b', layer: 'working' },
+    ];
+    render(memoryFor(triples));
+    const { wm, swm, vm, total } = readFusedProbe(container);
+    expect(wm).toBe(0);
+    expect(swm).toBe(3);
+    expect(vm).toBe(0);
+    expect(total).toBe(3);
+    expect(total).toBeLessThan(triples.length);
+  });
+
+  it('cross-graph-dedup fixture — fused counts match 4-pass output', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:swm-c', predicate: 'http://schema.org/name', object: '"C"', layer: 'shared' },
+      { subject: 'urn:e:swm-c', predicate: 'http://schema.org/name', object: '"C"', layer: 'shared' },
+    ];
+    render(memoryFor(triples));
+    const { wm, swm, vm, total } = readFusedProbe(container);
+    expect(wm).toBe(0);
+    expect(swm).toBe(1);
+    expect(vm).toBe(0);
+    expect(total).toBe(1);
+  });
+
+  // Iteration-count guard: the fused helper must iterate
+  // `memory.allTriples` exactly once per memoized result, vs the
+  // 4 passes the legacy 4-call setup did. A counting Proxy wraps
+  // the array's Symbol.iterator; we render the Probe once and
+  // assert the iteration count is 1.
+  it('iterates memory.allTriples exactly once per render (single-pass guarantee)', () => {
+    const baseTriples: LayeredTriple[] = [
+      { subject: 'urn:e:a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+      { subject: 'urn:e:b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared' },
+      { subject: 'urn:e:c', predicate: 'http://schema.org/name', object: '"C"', layer: 'verified' },
+    ];
+    const baseMemory = memoryFor(baseTriples);
+    let iterationCount = 0;
+    const countingTriples = new Proxy(baseTriples, {
+      get(target, prop) {
+        if (prop === Symbol.iterator) {
+          iterationCount++;
+          return target[Symbol.iterator].bind(target);
+        }
+        return (target as any)[prop];
+      },
+    });
+    const wrappedMemory = { ...baseMemory, allTriples: countingTriples };
+    render(wrappedMemory as unknown as MemoryData);
+    const { wm, swm, vm, total } = readFusedProbe(container);
+    // Correctness sanity-check.
+    expect(wm).toBe(1);
+    expect(swm).toBe(1);
+    expect(vm).toBe(1);
+    expect(total).toBe(3);
+    // Single-pass guarantee.
+    expect(iterationCount).toBe(1);
   });
 });

--- a/packages/node-ui/test/residue-predicates.test.ts
+++ b/packages/node-ui/test/residue-predicates.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import {
+  isSubjectResidue,
+  isObjectResourceResidue,
+  isPerLayerResidue,
+  isCanonicalResidue,
+} from '../src/ui/views/project/helpers.js';
+import {
+  buildMemoryEntities,
+  type LayeredTriple,
+  type MemoryEntity,
+} from '../src/ui/hooks/useMemoryEntities.js';
+
+// GH #890 round 2 (Codex sweep 1 🟡 B) — unit tests for the
+// row-level residue predicates extracted as a single source of
+// truth for `useLayerTriples`, `applyCanonicalAdmission`, and
+// `useMemoryCounts`. The triple-producing helpers and the fused
+// counter previously ran three hand-rolled copies; future rule
+// refinements (the #819 cycle had ~10 of them) now update the
+// predicate once, all consumers get it.
+//
+// Boundary cases per predicate:
+// - `isSubjectResidue`: subject not in entities (orphan literal)
+//   → false; subject at the row's layer → false; subject past it
+//   → true.
+// - `isObjectResourceResidue`: literal object → false (always);
+//   resource object not in entities → false; resource object at
+//   the row's layer → false; resource object past it → true.
+// - `isPerLayerResidue` = OR of the two.
+// - `isCanonicalResidue` = AND of the two.
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+function entitiesFor(triples: LayeredTriple[]): ReadonlyMap<string, MemoryEntity> {
+  return buildMemoryEntities(triples);
+}
+
+describe('isSubjectResidue', () => {
+  it('false when subject has no entity record (orphan, e.g. class IRI)', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:wm-a', predicate: RDF_TYPE, object: 'http://schema.org/Thing', layer: 'working' },
+    ];
+    const t = triples[0];
+    expect(isSubjectResidue(t, entitiesFor(triples))).toBe(false);
+  });
+
+  it('false when subject canonical layer equals row layer', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+    ];
+    const ents = entitiesFor(triples);
+    expect(ents.get('urn:e:wm-a')?.trustLevel).toBe('working');
+    expect(isSubjectResidue(triples[0], ents)).toBe(false);
+  });
+
+  it('true when subject has moved past the row layer (promoted)', () => {
+    const triples: LayeredTriple[] = [
+      // Promote subject to SWM via this row.
+      { subject: 'urn:e:promoted', predicate: 'http://schema.org/name', object: '"P"', layer: 'shared' },
+      // WM-stored row for the same subject — subject canonical
+      // is now 'shared', row layer is 'working' → residue.
+      { subject: 'urn:e:promoted', predicate: 'http://schema.org/keyword', object: '"k"', layer: 'working' },
+    ];
+    const ents = entitiesFor(triples);
+    expect(ents.get('urn:e:promoted')?.trustLevel).toBe('shared');
+    expect(isSubjectResidue(triples[1], ents)).toBe(true);
+  });
+});
+
+describe('isObjectResourceResidue', () => {
+  it('false when object is a literal (always, regardless of subject)', () => {
+    const triples: LayeredTriple[] = [
+      // Promote subject — verifies the predicate ignores subject status.
+      { subject: 'urn:e:p', predicate: 'http://schema.org/name', object: '"P"', layer: 'shared' },
+      // WM row with literal object — even with subject promoted,
+      // object-residue is FALSE because the object is a literal.
+      { subject: 'urn:e:p', predicate: 'http://schema.org/keyword', object: '"k"', layer: 'working' },
+    ];
+    expect(isObjectResourceResidue(triples[1], entitiesFor(triples))).toBe(false);
+  });
+
+  it('false when resource object has no entity record', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:a', predicate: 'http://schema.org/knows', object: 'urn:e:dangling', layer: 'working' },
+    ];
+    expect(isObjectResourceResidue(triples[0], entitiesFor(triples))).toBe(false);
+  });
+
+  it('false when resource object canonical layer equals row layer', () => {
+    const triples: LayeredTriple[] = [
+      // Both subject and object at WM canonical.
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+      { subject: 'urn:e:wm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'working' },
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/knows', object: 'urn:e:wm-b', layer: 'working' },
+    ];
+    expect(isObjectResourceResidue(triples[2], entitiesFor(triples))).toBe(false);
+  });
+
+  it('true when resource object has moved past the row layer', () => {
+    const triples: LayeredTriple[] = [
+      // Subject stays WM canonical.
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+      // Promote object to SWM.
+      { subject: 'urn:e:swm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared' },
+      // WM-stored row pointing at the promoted object.
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/knows', object: 'urn:e:swm-b', layer: 'working' },
+    ];
+    const ents = entitiesFor(triples);
+    expect(ents.get('urn:e:swm-b')?.trustLevel).toBe('shared');
+    expect(isObjectResourceResidue(triples[2], ents)).toBe(true);
+  });
+});
+
+describe('isPerLayerResidue — OR of subject and object', () => {
+  it('false when neither endpoint moved', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+      { subject: 'urn:e:wm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'working' },
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/knows', object: 'urn:e:wm-b', layer: 'working' },
+    ];
+    expect(isPerLayerResidue(triples[2], entitiesFor(triples))).toBe(false);
+  });
+
+  it('true when only subject moved (mixed-layer edge — per-layer drops it)', () => {
+    const triples: LayeredTriple[] = [
+      // Promote subject to SWM.
+      { subject: 'urn:e:swm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'shared' },
+      // WM object stays at WM.
+      { subject: 'urn:e:wm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'working' },
+      // Mixed-layer edge stored at WM. Subject moved past WM →
+      // per-layer drops; canonical (AND) keeps.
+      { subject: 'urn:e:swm-a', predicate: 'http://schema.org/knows', object: 'urn:e:wm-b', layer: 'working' },
+    ];
+    expect(isPerLayerResidue(triples[2], entitiesFor(triples))).toBe(true);
+  });
+
+  it('true when only resource object moved', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+      { subject: 'urn:e:swm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared' },
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/knows', object: 'urn:e:swm-b', layer: 'working' },
+    ];
+    expect(isPerLayerResidue(triples[2], entitiesFor(triples))).toBe(true);
+  });
+
+  it('true when both endpoints moved (full residue — per-layer drops)', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:swm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'shared' },
+      { subject: 'urn:e:swm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared' },
+      { subject: 'urn:e:swm-a', predicate: 'http://schema.org/knows', object: 'urn:e:swm-b', layer: 'working' },
+    ];
+    expect(isPerLayerResidue(triples[2], entitiesFor(triples))).toBe(true);
+  });
+});
+
+describe('isCanonicalResidue — AND of subject and object', () => {
+  it('false when neither endpoint moved', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+      { subject: 'urn:e:wm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'working' },
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/knows', object: 'urn:e:wm-b', layer: 'working' },
+    ];
+    expect(isCanonicalResidue(triples[2], entitiesFor(triples))).toBe(false);
+  });
+
+  it('false when only subject moved (mixed-layer edge — canonical KEEPS)', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:swm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'shared' },
+      { subject: 'urn:e:wm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'working' },
+      // Mixed-layer edge: subject moved, object still at row's layer.
+      // Canonical's AND-rule keeps this as a legitimate cross-layer fact.
+      { subject: 'urn:e:swm-a', predicate: 'http://schema.org/knows', object: 'urn:e:wm-b', layer: 'working' },
+    ];
+    expect(isCanonicalResidue(triples[2], entitiesFor(triples))).toBe(false);
+  });
+
+  it('false when only resource object moved (mixed-layer — canonical KEEPS)', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'working' },
+      { subject: 'urn:e:swm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared' },
+      { subject: 'urn:e:wm-a', predicate: 'http://schema.org/knows', object: 'urn:e:swm-b', layer: 'working' },
+    ];
+    expect(isCanonicalResidue(triples[2], entitiesFor(triples))).toBe(false);
+  });
+
+  it('true when BOTH endpoints moved (full residue — canonical drops)', () => {
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:swm-a', predicate: 'http://schema.org/name', object: '"A"', layer: 'shared' },
+      { subject: 'urn:e:swm-b', predicate: 'http://schema.org/name', object: '"B"', layer: 'shared' },
+      { subject: 'urn:e:swm-a', predicate: 'http://schema.org/knows', object: 'urn:e:swm-b', layer: 'working' },
+    ];
+    expect(isCanonicalResidue(triples[2], entitiesFor(triples))).toBe(true);
+  });
+
+  it('false when subject moved but object is a literal (literals always pass canonical)', () => {
+    // Literal-object residue is the GH #819 round 9 design note:
+    // we don't infer predicate cardinality, so literal-divergence
+    // admits.
+    const triples: LayeredTriple[] = [
+      { subject: 'urn:e:swm-c', predicate: 'http://schema.org/name', object: '"new"', layer: 'shared' },
+      // Subject moved past WM, but object is a literal → canonical keeps.
+      { subject: 'urn:e:swm-c', predicate: 'http://schema.org/name', object: '"old"', layer: 'working' },
+    ];
+    expect(isCanonicalResidue(triples[1], entitiesFor(triples))).toBe(false);
+  });
+});

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1409,7 +1409,10 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).not.toContain('42 triples');
     // Tooltip surfaces the failure caveat on the triples stat.
     const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
-    expect(triplesStat?.getAttribute('title')).toBe('0 triples (some layers unavailable; count may be incomplete).');
+    // GH #890 round 2 — zero-bucket failure wording dropped the
+    // `0 triples ` prefix (the badge already renders the count;
+    // the tooltip needs only the disclosure).
+    expect(triplesStat?.getAttribute('title')).toBe('Some layers unavailable; count may be incomplete.');
   });
 
   it('Named card bucket applies canonical residue filter per scope (GH #819 round 4 — Codex sweep 2 🔴 #5)', async () => {
@@ -1645,7 +1648,10 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).toContain('0 triples');
     expect(stats).not.toContain('…');
     const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
-    expect(triplesStat?.getAttribute('title')).toBe('0 triples (some layers unavailable; count may be incomplete).');
+    // GH #890 round 2 — zero-bucket failure wording dropped the
+    // `0 triples ` prefix (the badge already renders the count;
+    // the tooltip needs only the disclosure).
+    expect(triplesStat?.getAttribute('title')).toBe('Some layers unavailable; count may be incomplete.');
   });
 
   it('Named card badge surfaces honest 0 with failure tooltip on memory.partial (GH #819 round 7 — Codex sweep 5 🔴 #14)', async () => {
@@ -1680,7 +1686,10 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(stats).toContain('0 triples');
     expect(stats).not.toContain('…');
     const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
-    expect(triplesStat?.getAttribute('title')).toBe('0 triples (some layers unavailable; count may be incomplete).');
+    // GH #890 round 2 — zero-bucket failure wording dropped the
+    // `0 triples ` prefix (the badge already renders the count;
+    // the tooltip needs only the disclosure).
+    expect(triplesStat?.getAttribute('title')).toBe('Some layers unavailable; count may be incomplete.');
   });
 
   it('Named card badge surfaces failure tooltip on non-zero bucket too (GH #819 round 10 — Codex sweep 8 🟡 #18)', async () => {
@@ -1775,6 +1784,52 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     // buckets too, with the count value prefixed.
     const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
     expect(triplesStat?.getAttribute('title')).toBe('2 triples (still loading; count may grow).');
+  });
+
+  it('Named card mixed loading+error state on non-zero bucket — failure tooltip wins over hydrating (GH #890 round 2 — Codex sweep 1 🟡 A)', async () => {
+    // PR #890 round 1 made `isHydrating` short-circuit the entire
+    // precedence chain. Mixed state (some layers loading, others
+    // errored) on a non-zero bucket then masked the known-
+    // incomplete failure behind the optimistic "still loading"
+    // tooltip. Round 2 splits precedence so failure wins for
+    // every non-zero case; hydrating only wins on bucket = 0
+    // (anti-flash affordance from round 6 #11).
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    const triples = [
+      { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"alpha-1"', subGraph: 'alpha', layer: 'working' },
+      { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"alpha-2"', subGraph: 'alpha', layer: 'working' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 2, swm: 0, vm: 0, total: 1 },
+      loading: false,
+      partial: true,
+      // Mixed: VM still loading, SWM errored. Both `isHydrating`
+      // and `isFailedOrPartial` are true.
+      layerStatus: { wm: 'ok', swm: 'error', vm: 'loading' },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const cardStats = alphaCardEl.querySelector('.v10-sgov-card-stats');
+    const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
+    const title = triplesStat?.getAttribute('title') ?? '';
+    // Round 2 precedence: failure wins on non-zero buckets. The
+    // count is already known-incomplete because SWM errored —
+    // hiding that behind "still loading" would mask a real
+    // failure during a refresh.
+    expect(title).toBe('2 triples (some layers unavailable; count may be incomplete).');
+    expect(title).not.toContain('still loading');
+    expect(title).not.toContain('count may grow');
   });
 
   it('Named card failure tooltip wins over stat-vs-rendered tooltip when both apply (GH #819 round 10 — precedence)', async () => {

--- a/packages/node-ui/test/subgraph-overview-grid.test.ts
+++ b/packages/node-ui/test/subgraph-overview-grid.test.ts
@@ -1727,6 +1727,56 @@ describe('SubGraphOverviewGrid — Root mini-card (GH #813)', () => {
     expect(triplesStat?.getAttribute('title')).toBe('2 triples (some layers unavailable; count may be incomplete).');
   });
 
+  it('Named card badge surfaces hydrating tooltip on non-zero bucket too (GH #882 — post-#847 follow-up)', async () => {
+    // #819 round 6 (#11) added the `…` affordance when bucket is 0
+    // and `isHydrating` is true; round 10 (#18) extended the
+    // failure tooltip to non-zero buckets. The hydrating branch
+    // still only fired on zero buckets, so a hydrating card with
+    // partial data (some layers admitted rows while others were
+    // still loading) rendered the partial count with NO
+    // disclosure. GH #882 mirrors the round-10 #18 pattern for
+    // the hydrating branch — `isHydrating` now fires for all
+    // bucket values; non-zero buckets get a "{N} triples (still
+    // loading; count may grow)." tooltip.
+    fetchSubGraphsMock.mockResolvedValueOnce({
+      subGraphs: [{ name: 'alpha', entityCount: 1, tripleCount: 0, description: '' }],
+    });
+    const entityList = [
+      { uri: 'urn:e:alpha', label: 'a', types: [], trustLevel: 'working', layers: new Set(['working']), subGraphs: new Set(['alpha']), properties: new Map(), connections: [] },
+    ];
+    // 2 WM rows already admitted; SWM still loading → mid-flight
+    // canonical universe with partial data.
+    const triples = [
+      { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"alpha-1"', subGraph: 'alpha', layer: 'working' },
+      { subject: 'urn:e:alpha', predicate: 'http://schema.org/name', object: '"alpha-2"', subGraph: 'alpha', layer: 'working' },
+    ];
+    await renderWith({
+      ...memory,
+      entities: new Map(entityList.map(e => [e.uri, e])),
+      entityList,
+      allTriples: triples,
+      counts: { wm: 2, swm: 0, vm: 0, total: 1 },
+      // Mid-flight hydration: SWM layer still loading.
+      loading: false,
+      partial: false,
+      layerStatus: { wm: 'ok', swm: 'loading', vm: 'ok' },
+    });
+    await flush();
+
+    const cards = container.querySelectorAll('.v10-sgov-card');
+    const alphaCardEl = cards[0];
+    const cardStats = alphaCardEl.querySelector('.v10-sgov-card-stats');
+    const stats = cardStats?.textContent ?? '';
+    // Bucket renders the count honestly (no `…` — that's the
+    // zero-bucket affordance).
+    expect(stats).toContain('2 triples');
+    expect(stats).not.toContain('…');
+    // GH #882 contract: hydrating tooltip fires for non-zero
+    // buckets too, with the count value prefixed.
+    const triplesStat = cardStats?.querySelectorAll('.v10-sgov-card-stat')[1];
+    expect(triplesStat?.getAttribute('title')).toBe('2 triples (still loading; count may grow).');
+  });
+
   it('Named card failure tooltip wins over stat-vs-rendered tooltip when both apply (GH #819 round 10 — precedence)', async () => {
     // Round-10 precedence lock — when a card is both
     // failed/partial AND has a stat-vs-rendered mismatch


### PR DESCRIPTION
## Summary

Two bounded refinements of the SubGraphOverviewGrid + DashboardView + MemoryStackView triple-count derivation shipped in #847.

- **GH #882 — hydrating tooltip on non-zero buckets.** PR #847's `isHydrating` tooltip only fired on zero-bucket cards; a hydrating card with partial data (some layers admitted while others were still loading) rendered the partial count silently. Mirror the round-10 #18 pattern for the failure branch: `isHydrating` now fires for all bucket values; non-zero cards get `"{N} triples (still loading; count may grow)."` Precedence matrix unchanged (`isHydrating` wins over `isFailedOrPartial`, round 7 #14 contract).

- **GH #881 — single-pass `useMemoryCounts` helper.** `DashboardView`'s `CgRow` and `MemoryStackView`'s `MemoryStackRow` each iterated `memory.allTriples` four times (`useLayerTriples` ×3 + `useCanonicalTriples` ×1) per render. Add fused `useMemoryCounts` next to the other count helpers in `packages/node-ui/src/ui/views/project/helpers.ts` — single iteration, four counts, contract-identical numbers. Port both views.

## Related

- Follow-up to #847 (merged at `199b42579`)
- Fixes #881
- Fixes #882

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/views/project/components.tsx` | #882: extend `isHydrating` badge-title branch to non-zero buckets with `"{N} triples (still loading; count may grow)."` placeholder. |
| `packages/node-ui/src/ui/views/project/helpers.ts` | #881: add `useMemoryCounts(memory)` — fused single-pass helper returning `{ wm, swm, vm, canonical }`. Inline per-bucket admission rules mirror `useLayerTriples` (OR-rule) + `applyCanonicalAdmission` (AND-rule) exactly. |
| `packages/node-ui/src/ui/views/DashboardView.tsx` | #881: replace 3× `useLayerTriples` + 1× `useCanonicalTriples` with `useMemoryCounts`. Same numbers, ~4× less work per row. |
| `packages/node-ui/src/ui/views/MemoryStackView.tsx` | #881: same swap on `MemoryStackRow`. View only consumed `.length` off the per-layer arrays, so count-only return is contract-identical. |
| `packages/node-ui/test/subgraph-overview-grid.test.ts` | #882: new test — hydrating + non-zero bucket → tooltip fires with prefixed wording. |
| `packages/node-ui/test/dashboard-memorystack-contract.test.ts` | #881: new `useMemoryCounts` describe block — 3 identity tests vs the legacy 4-pass output on the existing fixtures, plus an iteration-count guard (Proxy on `Symbol.iterator` asserts exactly 1 iteration per memoized result). |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/subgraph-overview-grid.test.ts test/use-canonical-triples.test.ts test/use-layer-triples.test.ts test/dashboard-memorystack-contract.test.ts test/admit-triple-for-scope.test.ts` — 81/81 green, warm rerun ×2 deterministic.
- [x] Full node-ui suite — 1070 tests passing, 0 test-level failures (10 pre-existing file-level `@origintrail-official/dkg-core` import errors per worktree-prereq memory; not introduced by this PR).
- [x] `agent-docs/` clean — verified via `git diff origin/main..HEAD -- agent-docs/` (empty).
- [ ] Manual smoke on a multi-CG dashboard (post-CI): visually confirm Dashboard / Memory Stack rows render identical numbers vs pre-PR; no visual regressions on the SubGraphOverviewGrid hydrating-tooltip path.

## Notes

- #882 wording (`"still loading; count may grow"`) is an engineer placeholder mirroring the round-10 failure-tooltip placeholder. Gate logic is decoupled from copy — ux-lead can tighten in a follow-up without touching the matrix.
- #881 is a pure perf refactor: identical-numbers tests guard against derivation drift, iteration-count test guards against accidental fanout.