### PR TITLE
fix(core): augment NodeJS.ProcessEnv with DKG_HOME to unblock main build (#891)

### DIFF
--- a/packages/core/src/dkg-home.ts
+++ b/packages/core/src/dkg-home.ts
@@ -12,6 +12,21 @@ import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { keccak_256 } from '@noble/hashes/sha3.js';
 
+// Make `DKG_HOME` a declared property of `NodeJS.ProcessEnv` so the
+// `Pick<NodeJS.ProcessEnv, 'DKG_HOME'>` reference on
+// `ResolveDkgConfigHomeOptions.env` resolves under strict typecheck.
+// Without this declaration `Pick` finds no `DKG_HOME` key on the
+// default `ProcessEnv` indexer-only interface and downstream callers
+// fail with TS2741. Co-located with the only callers that pick it so
+// the augmentation lives next to its consumer.
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      DKG_HOME?: string;
+    }
+  }
+}
+
 /** Resolve the DKG home directory ($DKG_HOME or ~/.dkg). */
 export function dkgHomeDir(): string {
   return process.env.DKG_HOME ?? join(homedir(), '.dkg');


### PR DESCRIPTION
## Summary

- One-line augmentation: `packages/core/src/dkg-home.ts` declares `DKG_HOME?: string` on `NodeJS.ProcessEnv` so the existing `Pick<NodeJS.ProcessEnv, 'DKG_HOME'>` reference resolves under strict typecheck.
- Unblocks main CI (currently red on every PR) and all in-flight PRs targeting main.

## Related

- Fixes #891
- Unblocks #890 (and every other open PR; main itself fails CI today)
- The breaking call site is `packages/cli/src/cli.ts:387-389` (`withSelectedDkgHome`), introduced by `eb79800e1` without the matching ambient declaration

## Files changed

| File | What |
|------|------|
| `packages/core/src/dkg-home.ts` | Add `declare global { namespace NodeJS { interface ProcessEnv { DKG_HOME?: string } } }` co-located with `Pick<NodeJS.ProcessEnv, 'DKG_HOME'>`; comment explains why |

## Root cause

The `Pick<NodeJS.ProcessEnv, 'DKG_HOME'>` shape on `ResolveDkgConfigHomeOptions.env` requires `DKG_HOME` to be a discrete property of `NodeJS.ProcessEnv`. The default Node typings model `ProcessEnv` as an indexer (`{ [key: string]: string | undefined }`) with no named keys, so `Pick` resolves to a type with no usable property and TypeScript errors when a plain `NodeJS.ProcessEnv` is passed in. The fix is the standard ambient augmentation pattern.

## Repro / CI evidence

- Latest main `f745828d2` CI run https://github.com/OriginTrail/dkg/actions/runs/26757066687 → `src/cli.ts(389,33): error TS2741`
- PR #890 hits the same error on the same line — verified the failure is pre-existing on main, not introduced by either of my recent PRs (`packages/node-ui` only)

## Test plan

- [x] `git diff --stat` shows one-file change (15 insertions, 0 deletions)
- [ ] CI `Build packages` workflow turns green on this branch
- [ ] No other typecheck errors surface (the fix is additive — declares an optional property; doesn't change runtime behavior anywhere)
- [ ] Manual smoke: `process.env.DKG_HOME` usage in cli + adapter + test files remains semantically identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)