### PR TITLE
fix(rc.12): publish ACK/allowance races + SPARQL parse-error classifier (#887, #888, #889)

### DIFF
--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -1332,9 +1332,19 @@ export class EVMChainAdapter implements ChainAdapter {
     for (let i = 0; i < POLL_ATTEMPTS; i += 1) {
       let current = -1n;
       try {
-        current = (await token.allowance(owner, spender)) as bigint;
+        // Bound each read: a raw `token.allowance()` on a hung / read-stalled
+        // RPC would otherwise never reject and could block this "bounded"
+        // recovery poll indefinitely. `withTimeout` rejects after
+        // `RPC_READ_STALL_TIMEOUT_MS`, which the catch below treats as a
+        // not-yet-visible read and backs off (same as a thrown read error).
+        current = (await withTimeout(
+          token.allowance(owner, spender),
+          RPC_READ_STALL_TIMEOUT_MS,
+          'allowance visibility poll',
+        )) as bigint;
       } catch {
-        // Transient read failure — treat as not-yet-visible and back off.
+        // Transient read failure / stall timeout — treat as not-yet-visible
+        // and back off.
         current = -1n;
       }
       if (current >= target) return;

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -1094,6 +1094,59 @@ export class EVMChainAdapter implements ChainAdapter {
     return { signedTx, txHash };
   }
 
+  /**
+   * #888: populate + sign a V10 write tx with one-shot recovery for a
+   * stale-RPC `TooLowAllowance` revert, shared by BOTH V10 write paths
+   * (`createKnowledgeAssets` publish and `updateV10` — incl. metadata-only
+   * updates). ethers estimates gas while populating; on an internally
+   * load-balanced RPC that estimate can read a stale TRAC allowance and
+   * revert `TooLowAllowance` even though the approve above succeeded
+   * (post-approve propagation lag) or was skipped on a stale-high read of an
+   * allowance the prior write already consumed. This is strictly
+   * pre-broadcast (before the `onBroadcast` WAL checkpoint), so on that one
+   * revert we force a fresh approve up to the publish floor — confirming it
+   * is visible on the same read path via `ensureV10ApproveTrac(force=true)` —
+   * and retry populate+sign exactly once. Any other error, or a second
+   * `TooLowAllowance`, propagates unchanged.
+   */
+  private async populateAndSignV10WithAllowanceRecovery(
+    signer: Wallet,
+    kaContract: Contract,
+    method: 'publish' | 'update',
+    methodParams: unknown,
+    kav10Address: string,
+    tokenAmount: bigint,
+    reapproveLabel: string,
+  ): Promise<{ signedTx: string; txHash: string }> {
+    let forcedReapprove = false;
+    for (;;) {
+      try {
+        const populated = await (kaContract as any)[method].populateTransaction(
+          methodParams,
+        );
+        return await this.signPopulatedTransaction(signer, populated);
+      } catch (err) {
+        if (!forcedReapprove && isTooLowAllowanceError(err)) {
+          forcedReapprove = true;
+          console.warn(
+            `[chain] V10 ${method} gas-estimation reverted TooLowAllowance for ` +
+            `signer=${signer.address} — forcing a fresh TRAC approve and ` +
+            `retrying once (likely a stale RPC allowance read, #888).`,
+          );
+          await this.ensureV10ApproveTrac(
+            signer,
+            kav10Address,
+            tokenAmount,
+            reapproveLabel,
+            true,
+          );
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
+
   private async sendSignedTransactionAndWait(
     signedTx: string,
     txHash: string,
@@ -2931,49 +2984,22 @@ export class EVMChainAdapter implements ChainAdapter {
     // This also gives the WAL the pre-broadcast tx hash (ethers v6
     // exposes it on the returned TransactionResponse), so recovery can
     // reconcile an in-flight tx after a daemon crash.
-    // #888: ethers estimates gas while populating the publish tx. On an
-    // internally load-balanced RPC that estimate can read a stale TRAC
-    // allowance and revert `TooLowAllowance` even though the approve
-    // above succeeded (post-approve propagation lag) or was skipped on a
-    // stale-high read of an allowance the prior publish already consumed.
-    // This happens strictly BEFORE the `onBroadcast` WAL checkpoint and
-    // the broadcast below, so on that one revert we force a fresh approve
-    // and retry the populate+sign exactly once. Any other error — or a
-    // second `TooLowAllowance` — propagates unchanged.
-    let signedTx!: string;
-    let preBroadcastTxHash!: string;
-    {
-      let forcedReapprove = false;
-      for (;;) {
-        try {
-          const populated = await (ka as any).publish.populateTransaction(
-            publishParamsStruct,
-          );
-          const signed = await this.signPopulatedTransaction(txSigner, populated);
-          signedTx = signed.signedTx;
-          preBroadcastTxHash = signed.txHash;
-          break;
-        } catch (err) {
-          if (!forcedReapprove && isTooLowAllowanceError(err)) {
-            forcedReapprove = true;
-            console.warn(
-              `[chain] V10 publish gas-estimation reverted TooLowAllowance for ` +
-              `signer=${txSigner.address} — forcing a fresh TRAC approve and ` +
-              `retrying once (likely a stale RPC allowance read, #888).`,
-            );
-            await this.ensureV10ApproveTrac(
-              txSigner,
-              kaAddress,
-              params.tokenAmount,
-              'approve V10 publish TRAC (forced re-approve, #888)',
-              true,
-            );
-            continue;
-          }
-          throw err;
-        }
-      }
-    }
+    // #888: populate (which gas-estimates and can revert `TooLowAllowance`
+    // on a stale RPC allowance read) + sign, with a one-shot forced-approve
+    // recovery shared with `updateV10` — see
+    // `populateAndSignV10WithAllowanceRecovery`. This runs strictly BEFORE
+    // the `onBroadcast` WAL checkpoint and the broadcast below, so the
+    // forced re-approve + single retry has no on-chain side effect.
+    const { signedTx, txHash: preBroadcastTxHash } =
+      await this.populateAndSignV10WithAllowanceRecovery(
+        txSigner,
+        ka as Contract,
+        'publish',
+        publishParamsStruct,
+        kaAddress,
+        params.tokenAmount,
+        'approve V10 publish TRAC (forced re-approve, #888)',
+      );
     // Derive the pre-broadcast tx hash from the signed raw hex so WAL
     // consumers can log the exact identity of the tx about to hit the
     // wire. After broadcast completes, the receipt hash matches this.
@@ -3526,8 +3552,21 @@ export class EVMChainAdapter implements ChainAdapter {
     // into a single entrypoint: the contract auto-detects PCA discount
     // via `agentToAccountId(msg.sender)` for any positive
     // `deltaTokenAmount`.
-    const populated = await (ka as any).update.populateTransaction(updateParams);
-    const { signedTx, txHash: preBroadcastTxHash } = await this.signPopulatedTransaction(signer, populated);
+    // #888: same stale-allowance recovery as the publish path. Metadata-only
+    // updates (`newTokenAmount === 0n`, floored to a 1-wei approve) are just
+    // as exposed to a stale `TooLowAllowance` read on a load-balanced RPC, so
+    // route both V10 write paths through the shared helper. Strictly
+    // pre-broadcast — no on-chain side effect from the forced re-approve.
+    const { signedTx, txHash: preBroadcastTxHash } =
+      await this.populateAndSignV10WithAllowanceRecovery(
+        signer,
+        ka as Contract,
+        'update',
+        updateParams,
+        kav10Address,
+        newTokenAmount,
+        'approve V10 update TRAC (forced re-approve, #888)',
+      );
     // Codex PR #241 iter-7: `await` so async WAL writes complete
     // before broadcast (see publish above for the full rationale).
     try {

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -280,6 +280,45 @@ export function computeApprovalAction(
   }
 }
 
+/**
+ * #888 — true iff `err` is the V10 publish `TooLowAllowance(TRAC, ...)`
+ * custom-error revert.
+ *
+ * The on-chain allowance read that gates the auto-approve and the
+ * `estimateGas` that ethers runs while populating the publish tx can
+ * observe a *stale* allowance on an internally load-balanced RPC: a
+ * just-consumed per-publish `1`-wei floor still reads as `1` (so the
+ * re-approve is skipped), or a freshly-sent approve has not yet
+ * propagated to the read replica. Either way the contract reverts
+ * `TooLowAllowance` during gas estimation — strictly BEFORE broadcast —
+ * and the publisher can recover by forcing a fresh approve and retrying.
+ *
+ * Matches ethers v6's decoded custom-error shape (`err.revert.name`) and
+ * falls back to string matching on the message / shortMessage / reason /
+ * nested cause so a stringified or re-wrapped revert is still caught.
+ */
+export function isTooLowAllowanceError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as {
+    revert?: { name?: unknown };
+    message?: unknown;
+    shortMessage?: unknown;
+    reason?: unknown;
+    cause?: unknown;
+  };
+  if (typeof e.revert?.name === 'string' && e.revert.name === 'TooLowAllowance') {
+    return true;
+  }
+  const causeMessage =
+    e.cause && typeof e.cause === 'object'
+      ? (e.cause as { message?: unknown }).message
+      : undefined;
+  const haystack = [e.message, e.shortMessage, e.reason, causeMessage]
+    .filter((s): s is string => typeof s === 'string')
+    .join(' ');
+  return /TooLowAllowance/i.test(haystack);
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -1060,6 +1099,11 @@ export class EVMChainAdapter implements ChainAdapter {
     kav10Address: string,
     tokenAmount: bigint,
     txLabel: string,
+    // #888: set on the retry after a `TooLowAllowance` revert. Forces a
+    // fresh approve up to the publish floor regardless of the (possibly
+    // stale) on-chain allowance read, then confirms it is visible before
+    // returning. See `isTooLowAllowanceError` / `createKnowledgeAssets`.
+    force = false,
   ): Promise<void> {
     if (!this.contracts.token) return;
     const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
@@ -1072,7 +1116,12 @@ export class EVMChainAdapter implements ChainAdapter {
       tokenAmount,
       currentAllowance,
     );
-    if (needsApprove) {
+    // When forced, approve at least the publish floor even if the gating
+    // read above said `needsApprove === false` — that "false" may be a
+    // stale-high read of an allowance the prior publish already consumed.
+    const publishFloor = effectivePublishAllowance(tokenAmount);
+    const target = force && targetAllowance < publishFloor ? publishFloor : targetAllowance;
+    if (needsApprove || force) {
       // Surface the per-publish floor explicitly when (and only when) the
       // policy lifted `targetAllowance` above the caller's `tokenAmount`
       // — i.e. `tokenAmount === 0n` and the floor in
@@ -1091,7 +1140,7 @@ export class EVMChainAdapter implements ChainAdapter {
       if (
         this.approvalPolicy.mode === 'per-publish' &&
         tokenAmount === 0n &&
-        targetAllowance === V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE
+        target === V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE
       ) {
         console.warn(
           `[chain] V10 per-publish auto-approve floor: signer=${signer.address} ` +
@@ -1103,10 +1152,52 @@ export class EVMChainAdapter implements ChainAdapter {
       await this.sendContractTransaction(
         tokenWithSigner,
         'approve',
-        [kav10Address, targetAllowance],
+        [kav10Address, target],
         signer,
         txLabel,
       );
+      // #888: only on the forced re-approve (the retry after a
+      // `TooLowAllowance` revert) do we confirm the approve is visible on
+      // the same read path the caller's gas-estimation will use, so the
+      // retry doesn't immediately re-hit the RPC read-after-write lag
+      // that prompted it. Gated on `force` so the steady-state publish
+      // path issues exactly one allowance read + one approve (unchanged
+      // behaviour / latency); the bounded poll returns as soon as the
+      // allowance reflects the target.
+      if (force) {
+        await this.confirmAllowanceVisible(tokenWithSigner, signer.address, kav10Address, target);
+      }
+    }
+  }
+
+  /**
+   * #888 — poll `allowance(owner, spender)` until it reflects `target`,
+   * bounded by `ALLOWANCE_VISIBILITY_POLL_ATTEMPTS`. Best-effort: if the
+   * allowance still hasn't propagated after the budget, we return anyway
+   * and let the caller's gas-estimation surface a definitive revert (the
+   * `createKnowledgeAssets` retry then forces a fresh approve). Exits on
+   * the first read in the common case where the approve is immediately
+   * visible, so steady-state publish latency is unchanged.
+   */
+  private async confirmAllowanceVisible(
+    token: Contract,
+    owner: string,
+    spender: string,
+    target: bigint,
+  ): Promise<void> {
+    const POLL_ATTEMPTS = 6;
+    for (let i = 0; i < POLL_ATTEMPTS; i += 1) {
+      let current = -1n;
+      try {
+        current = (await token.allowance(owner, spender)) as bigint;
+      } catch {
+        // Transient read failure — treat as not-yet-visible and back off.
+        current = -1n;
+      }
+      if (current >= target) return;
+      if (i < POLL_ATTEMPTS - 1) {
+        await sleep(Math.min(250 * (i + 1), 1500));
+      }
     }
   }
 
@@ -2725,10 +2816,49 @@ export class EVMChainAdapter implements ChainAdapter {
     // This also gives the WAL the pre-broadcast tx hash (ethers v6
     // exposes it on the returned TransactionResponse), so recovery can
     // reconcile an in-flight tx after a daemon crash.
-    const populated = await (ka as any).publish.populateTransaction(
-      publishParamsStruct,
-    );
-    const { signedTx, txHash: preBroadcastTxHash } = await this.signPopulatedTransaction(txSigner, populated);
+    // #888: ethers estimates gas while populating the publish tx. On an
+    // internally load-balanced RPC that estimate can read a stale TRAC
+    // allowance and revert `TooLowAllowance` even though the approve
+    // above succeeded (post-approve propagation lag) or was skipped on a
+    // stale-high read of an allowance the prior publish already consumed.
+    // This happens strictly BEFORE the `onBroadcast` WAL checkpoint and
+    // the broadcast below, so on that one revert we force a fresh approve
+    // and retry the populate+sign exactly once. Any other error — or a
+    // second `TooLowAllowance` — propagates unchanged.
+    let signedTx!: string;
+    let preBroadcastTxHash!: string;
+    {
+      let forcedReapprove = false;
+      for (;;) {
+        try {
+          const populated = await (ka as any).publish.populateTransaction(
+            publishParamsStruct,
+          );
+          const signed = await this.signPopulatedTransaction(txSigner, populated);
+          signedTx = signed.signedTx;
+          preBroadcastTxHash = signed.txHash;
+          break;
+        } catch (err) {
+          if (!forcedReapprove && isTooLowAllowanceError(err)) {
+            forcedReapprove = true;
+            console.warn(
+              `[chain] V10 publish gas-estimation reverted TooLowAllowance for ` +
+              `signer=${txSigner.address} — forcing a fresh TRAC approve and ` +
+              `retrying once (likely a stale RPC allowance read, #888).`,
+            );
+            await this.ensureV10ApproveTrac(
+              txSigner,
+              kaAddress,
+              params.tokenAmount,
+              'approve V10 publish TRAC (forced re-approve, #888)',
+              true,
+            );
+            continue;
+          }
+          throw err;
+        }
+      }
+    }
     // Derive the pre-broadcast tx hash from the signed raw hex so WAL
     // consumers can log the exact identity of the tx about to hit the
     // wire. After broadcast completes, the receipt hash matches this.

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -9,7 +9,6 @@ export {
   resolveRpcUrls,
   effectivePublishAllowance,
   computeApprovalAction,
-  isTooLowAllowanceError,
   V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE,
 } from './evm-adapter.js';
 export { NoChainAdapter } from './no-chain-adapter.js';

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -8,6 +8,7 @@ export {
   resolveRpcUrls,
   effectivePublishAllowance,
   computeApprovalAction,
+  isTooLowAllowanceError,
   V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE,
 } from './evm-adapter.js';
 export { NoChainAdapter } from './no-chain-adapter.js';

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -2518,6 +2518,34 @@ describe('ensureV10ApproveTrac — forced re-approve + visibility poll (#888)', 
     // revert if the allowance genuinely never propagates.
     expect(tokenWithSigner.allowance).toHaveBeenCalledTimes(7);
   }, 15_000);
+
+  // PR #896 review (🔴): each visibility-poll read must be bounded by a
+  // timeout. A raw `token.allowance()` on a hung / read-stalled RPC never
+  // rejects, so without `withTimeout` the supposedly-bounded recovery poll
+  // could block publish/update indefinitely. Drive the whole loop under fake
+  // timers and assert it resolves (does not hang) even when every read stalls
+  // forever.
+  it('bounds each visibility poll with a timeout so a hung RPC read cannot block the recovery (#896)', async () => {
+    vi.useFakeTimers();
+    try {
+      const a = new EVMChainAdapter(minimalConfig());
+      // allowance() returns a promise that never settles — a hung RPC read.
+      const token = { allowance: vi.fn(() => new Promise<bigint>(() => {})) };
+      const done = vi.fn();
+      const poll = (a as any)
+        .confirmAllowanceVisible(token, '0xowner', V10_KA_ADDRESS, 1n)
+        .then(done);
+      // Advance past 6 × (4s read timeout) + the capped backoff sleeps.
+      await vi.advanceTimersByTimeAsync(60_000);
+      await poll;
+      // Resolved rather than hanging, and each of the 6 bounded reads was
+      // attempted (and timed out) instead of blocking on the first one.
+      expect(done).toHaveBeenCalledTimes(1);
+      expect(token.allowance).toHaveBeenCalledTimes(6);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 // PR #896 review (🔴): the forced-re-approve recovery was inlined in the

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -10,6 +10,7 @@ import {
   effectivePublishAllowance,
   enrichEvmError,
   EVMChainAdapter,
+  isTooLowAllowanceError,
   resolveRpcUrls,
   V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE,
   type EVMAdapterConfig,
@@ -2174,4 +2175,131 @@ describe('createKnowledgeAssets / updateKnowledgeCollectionV10 — approval sign
     expect(signSpy).toHaveBeenCalledTimes(1);
     expect(signSpy.mock.calls[0][0]).toBe(walletB);
   });
+});
+
+// -----------------------------------------------------------------------------
+// #888 — intermittent `TooLowAllowance(TRAC, 0, 1)` on consecutive zero-cost
+// publishes. The on-chain allowance read that gates the auto-approve and the
+// `estimateGas` ethers runs while populating the publish tx can observe a
+// STALE allowance on an internally load-balanced RPC: either a just-consumed
+// per-publish 1-wei floor still reads as `1` (so the re-approve is skipped) or
+// a freshly-sent approve hasn't propagated to the read replica yet. The fix:
+//   1. `isTooLowAllowanceError` classifies the revert,
+//   2. `createKnowledgeAssets` retries populate+sign once on that revert with a
+//      forced re-approve (the revert is strictly pre-broadcast, so it's safe),
+//   3. the forced re-approve approves up to the publish floor regardless of the
+//      gating read and confirms the new allowance is visible before returning.
+// -----------------------------------------------------------------------------
+
+describe('isTooLowAllowanceError (#888)', () => {
+  it('matches the ethers v6 decoded custom-error shape (revert.name)', () => {
+    expect(isTooLowAllowanceError({ revert: { name: 'TooLowAllowance' }, message: 'execution reverted' })).toBe(true);
+  });
+
+  it('matches a stringified revert in message / shortMessage / reason', () => {
+    expect(isTooLowAllowanceError(new Error('execution reverted: TooLowAllowance(0xTRAC, 0, 1)'))).toBe(true);
+    expect(isTooLowAllowanceError({ shortMessage: 'execution reverted (TooLowAllowance)' })).toBe(true);
+    expect(isTooLowAllowanceError({ reason: 'TooLowAllowance' })).toBe(true);
+  });
+
+  it('matches a nested cause.message', () => {
+    expect(isTooLowAllowanceError({ message: 'wrapped', cause: new Error('inner: TooLowAllowance(...)') })).toBe(true);
+  });
+
+  it('does not match unrelated reverts / errors', () => {
+    expect(isTooLowAllowanceError(new Error('TooLowStake(node, 0, 50000)'))).toBe(false);
+    expect(isTooLowAllowanceError({ revert: { name: 'NotBatchPublisher' }, message: 'execution reverted' })).toBe(false);
+    expect(isTooLowAllowanceError(new Error('insufficient funds for gas'))).toBe(false);
+  });
+
+  it('handles non-object / null / numeric / string inputs safely', () => {
+    expect(isTooLowAllowanceError(null)).toBe(false);
+    expect(isTooLowAllowanceError(undefined)).toBe(false);
+    expect(isTooLowAllowanceError('TooLowAllowance')).toBe(false);
+    expect(isTooLowAllowanceError(42)).toBe(false);
+  });
+});
+
+function makeV10AdapterWithAllowanceSequence(values: bigint[]) {
+  const a = new EVMChainAdapter(minimalConfig());
+  let i = 0;
+  const tokenWithSigner = {
+    allowance: vi.fn(async () => values[Math.min(i++, values.length - 1)]),
+    approve: vi.fn(),
+  };
+  const tokenRoot = { connect: vi.fn(() => tokenWithSigner) };
+  (a as any).contracts.token = tokenRoot;
+  const sendSpy = vi.fn(async () => ({} as unknown));
+  (a as any).sendContractTransaction = sendSpy;
+  const signer = new ethers.Wallet(DEPLOYER_PK);
+  return { a, signer, tokenWithSigner, sendSpy };
+}
+
+describe('ensureV10ApproveTrac — forced re-approve + visibility poll (#888)', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('force=true re-approves even when the gating read says the allowance is already sufficient (stale-high skip)', async () => {
+    // The "stale-high" sub-race: the per-publish 1-wei floor consumed by
+    // the previous publish still reads as `1`, so `needsApprove` is false
+    // and the un-forced path would skip the approve — but the real
+    // on-chain allowance is 0 and the publish would revert. Forcing the
+    // re-approve corrects this.
+    const { a, signer, tokenWithSigner, sendSpy } = makeV10Adapter(undefined, 1n);
+
+    await (a as any).ensureV10ApproveTrac(
+      signer,
+      V10_KA_ADDRESS,
+      0n,
+      'approve V10 publish TRAC (forced re-approve, #888)',
+      true,
+    );
+
+    const call = getApproveCallArgs(sendSpy);
+    expect(call.method).toBe('approve');
+    expect(call.args).toEqual([V10_KA_ADDRESS, 1n]);
+    // gating read (1n) + one visibility-poll read (1n ≥ target → confirmed).
+    expect(tokenWithSigner.allowance).toHaveBeenCalledTimes(2);
+  });
+
+  it('force=false with a sufficient allowance issues NO approve and NO visibility poll (steady-state unchanged)', async () => {
+    const { a, signer, tokenWithSigner, sendSpy } = makeV10Adapter(undefined, 1n);
+
+    await (a as any).ensureV10ApproveTrac(
+      signer,
+      V10_KA_ADDRESS,
+      0n,
+      'approve V10 publish TRAC',
+    );
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    // Only the single gating read — the poll is gated on `force`.
+    expect(tokenWithSigner.allowance).toHaveBeenCalledTimes(1);
+  });
+
+  it('forced re-approve polls until the fresh approve becomes visible on the RPC read path', async () => {
+    const { a, signer, tokenWithSigner, sendSpy } = makeV10AdapterWithAllowanceSequence([
+      0n, // gating read → needsApprove
+      0n, // poll read 1 → approve not yet propagated to the read replica
+      1n, // poll read 2 → now visible
+    ]);
+
+    await (a as any).ensureV10ApproveTrac(signer, V10_KA_ADDRESS, 0n, 'forced', true);
+
+    expect(sendSpy).toHaveBeenCalledTimes(1); // exactly one approve
+    expect(tokenWithSigner.allowance).toHaveBeenCalledTimes(3); // gating + 2 polls
+  });
+
+  it('forced re-approve is best-effort: gives up after the bounded poll budget without throwing', async () => {
+    const { a, signer, tokenWithSigner, sendSpy } = makeV10AdapterWithAllowanceSequence([0n]); // never visible
+
+    await expect(
+      (a as any).ensureV10ApproveTrac(signer, V10_KA_ADDRESS, 0n, 'forced', true),
+    ).resolves.toBeUndefined();
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    // gating read + 6 bounded poll attempts. Proves the poll is bounded
+    // (no hang); the caller's gas-estimation then surfaces a definitive
+    // revert if the allowance genuinely never propagates.
+    expect(tokenWithSigner.allowance).toHaveBeenCalledTimes(7);
+  }, 15_000);
 });

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -2519,3 +2519,88 @@ describe('ensureV10ApproveTrac — forced re-approve + visibility poll (#888)', 
     expect(tokenWithSigner.allowance).toHaveBeenCalledTimes(7);
   }, 15_000);
 });
+
+// PR #896 review (🔴): the forced-re-approve recovery was inlined in the
+// publish path only, leaving `updateV10` exposed to the same stale-allowance
+// race on metadata-only updates. The recovery now lives in a shared helper
+// (`populateAndSignV10WithAllowanceRecovery`) used by BOTH V10 write paths.
+// These tests pin that shared behaviour directly.
+function makeRecoveryAdapter() {
+  const a = new EVMChainAdapter(minimalConfig());
+  const ensureSpy = vi.fn(async () => {});
+  const signSpy = vi.fn(async () => ({ signedTx: '0xsigned', txHash: '0xhash' }));
+  (a as any).ensureV10ApproveTrac = ensureSpy;
+  (a as any).signPopulatedTransaction = signSpy;
+  return { a, ensureSpy, signSpy, signer: new ethers.Wallet(DEPLOYER_PK) };
+}
+
+const tooLowAllowanceRevert = () =>
+  new Error('execution reverted: TooLowAllowance(0xTRAC, 0, 1)');
+
+describe('populateAndSignV10WithAllowanceRecovery — shared publish/update recovery (#888/#896)', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  // The 🔴 fix: BOTH write paths recover from a pre-broadcast
+  // `TooLowAllowance` revert, not just publish.
+  it.each(['publish', 'update'] as const)(
+    'forces a fresh approve and retries populate+sign exactly once on a stale TooLowAllowance (%s)',
+    async (method) => {
+      const { a, ensureSpy, signSpy, signer } = makeRecoveryAdapter();
+      const populate = vi.fn()
+        .mockRejectedValueOnce(tooLowAllowanceRevert())
+        .mockResolvedValueOnce({ to: V10_KA_ADDRESS, data: '0xabcd' });
+      const kaContract = { [method]: { populateTransaction: populate } };
+
+      const result = await (a as any).populateAndSignV10WithAllowanceRecovery(
+        signer,
+        kaContract,
+        method,
+        { some: 'params' },
+        V10_KA_ADDRESS,
+        0n,
+        `approve V10 ${method} TRAC (forced re-approve, #888)`,
+      );
+
+      expect(result).toEqual({ signedTx: '0xsigned', txHash: '0xhash' });
+      expect(populate).toHaveBeenCalledTimes(2); // initial revert + one retry
+      expect(signSpy).toHaveBeenCalledTimes(1);  // signed only after the retry
+      // forced re-approve fired once, against the right KA + with force=true.
+      expect(ensureSpy).toHaveBeenCalledTimes(1);
+      expect(ensureSpy.mock.calls[0][0]).toBe(signer);
+      expect(ensureSpy.mock.calls[0][1]).toBe(V10_KA_ADDRESS);
+      expect(ensureSpy.mock.calls[0][4]).toBe(true);
+    },
+  );
+
+  it('propagates a SECOND consecutive TooLowAllowance (recovery is one-shot, no infinite loop)', async () => {
+    const { a, ensureSpy, signSpy, signer } = makeRecoveryAdapter();
+    const populate = vi.fn().mockRejectedValue(tooLowAllowanceRevert());
+    const kaContract = { publish: { populateTransaction: populate } };
+
+    await expect(
+      (a as any).populateAndSignV10WithAllowanceRecovery(
+        signer, kaContract, 'publish', {}, V10_KA_ADDRESS, 0n, 'label',
+      ),
+    ).rejects.toThrow('TooLowAllowance');
+
+    expect(populate).toHaveBeenCalledTimes(2); // initial + one forced retry, then give up
+    expect(ensureSpy).toHaveBeenCalledTimes(1);
+    expect(signSpy).not.toHaveBeenCalled();
+  });
+
+  it('propagates an unrelated revert immediately without forcing a re-approve', async () => {
+    const { a, ensureSpy, signSpy, signer } = makeRecoveryAdapter();
+    const populate = vi.fn().mockRejectedValue(new Error('execution reverted: NotBatchPublisher()'));
+    const kaContract = { update: { populateTransaction: populate } };
+
+    await expect(
+      (a as any).populateAndSignV10WithAllowanceRecovery(
+        signer, kaContract, 'update', {}, V10_KA_ADDRESS, 0n, 'label',
+      ),
+    ).rejects.toThrow('NotBatchPublisher');
+
+    expect(populate).toHaveBeenCalledTimes(1); // no retry on a non-allowance error
+    expect(ensureSpy).not.toHaveBeenCalled();
+    expect(signSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -110,6 +110,10 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   // the `chain.approvalPolicy` dispatch and the `transferFrom(..., 1n)`
   // floor; the mock has no ERC-20 allowance surface to mirror.
   'ensureV10ApproveTrac',
+  // TS-private post-approve allowance visibility poll (#888). Backs the
+  // forced re-approve retry on a stale-RPC `TooLowAllowance` revert; the
+  // mock has no ERC-20 allowance surface to mirror.
+  'confirmAllowanceVisible',
   // Lazy-cache helpers for frequently-resolved contracts — TS-private,
   // not part of the ChainAdapter interface.
   'getIdentityStorage',

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -115,6 +115,10 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   // forced re-approve retry on a stale-RPC `TooLowAllowance` revert; the
   // mock has no ERC-20 allowance surface to mirror.
   'confirmAllowanceVisible',
+  // TS-private populate+sign helper with shared stale-allowance recovery
+  // (#888) backing both V10 write paths (publish + update); the mock has no
+  // populate/gas-estimation surface to mirror.
+  'populateAndSignV10WithAllowanceRecovery',
   // Lazy-cache helpers for frequently-resolved contracts — TS-private,
   // not part of the ChainAdapter interface.
   'getIdentityStorage',

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -617,6 +617,13 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       if (
         msg.startsWith("SPARQL rejected:") ||
         msg.startsWith("Parse error") ||
+        // #889: oxigraph surfaces SPARQL syntax errors as
+        // `error at <line>:<col>: expected one of ...` (e.g. a missing
+        // closing brace or an incomplete triple). These are client input
+        // errors, not server faults — classify them as 400 to match the
+        // existing `SPARQL rejected:` / `must start with ...` handling
+        // instead of letting them fall through to a 500.
+        /^error at \d+:\d+:/.test(msg) ||
         /must start with (SELECT|CONSTRUCT|ASK|DESCRIBE)/i.test(msg) ||
         msg.includes("was removed in V10") ||
         msg.includes("agentAddress is required") ||

--- a/packages/cli/test/daemon/routes/query.test.ts
+++ b/packages/cli/test/daemon/routes/query.test.ts
@@ -89,4 +89,44 @@ describe('handleQueryRoutes /api/query', () => {
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toBe(error.message);
   });
+
+  it('maps oxigraph SPARQL syntax errors ("error at L:C: ...") to HTTP 400, not 500 (#889)', async () => {
+    // Reproduces the rc.12 finding: a malformed query (missing closing
+    // brace / incomplete triple) makes oxigraph throw
+    // `error at <line>:<col>: expected one of ...`. Before the fix this
+    // fell through to the top-level 500 handler; it must be a 400.
+    const error = new Error(
+      'error at 1:27: expected one of ",", ".", ";", "{", "}", ...',
+    );
+    const agent = {
+      resolveAgentByToken: vi.fn(),
+      query: vi.fn().mockRejectedValue(error),
+    };
+    const { ctx, res } = makeCtx(agent, {
+      sparql: 'SELECT ?s WHERE { ?s ?p ?o',
+      contextGraphId: 'all',
+    });
+
+    await handleQueryRoutes(ctx);
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe(error.message);
+  });
+
+  it('still surfaces genuine server-side errors as 500 (not misclassified as 400)', async () => {
+    // Guard: the #889 widening must not swallow real server faults whose
+    // message happens to differ from the parser-error shape.
+    const error = new Error('Database connection lost');
+    const agent = {
+      resolveAgentByToken: vi.fn(),
+      query: vi.fn().mockRejectedValue(error),
+    };
+    const { ctx, res } = makeCtx(agent, {
+      sparql: 'SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } } LIMIT 1',
+      contextGraphId: 'all',
+    });
+
+    await expect(handleQueryRoutes(ctx)).rejects.toThrow('Database connection lost');
+    expect(res.statusCode).not.toBe(400);
+  });
 });

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -410,6 +410,18 @@ export class ACKCollector {
       });
     };
 
+    // PR #896 review (🟡): once the round is decided — quorum reached, timed
+    // out, or proven impossible — any `requestACK` loop still sleeping
+    // between retries must bail on wake instead of continuing to dial. With
+    // the widened #887 transient-decline budget (~31s) a losing peer could
+    // otherwise keep retrying long after `collect()` already resolved,
+    // emitting avoidable ACK traffic and log noise. `roundSettled` is set
+    // when the outer race settles; `roundIsOver()` also treats a satisfied
+    // quorum as terminal so a peer mid-backoff bails the instant the last
+    // needed ACK lands elsewhere.
+    let roundSettled = false;
+    const roundIsOver = () => roundSettled || collected.length >= REQUIRED_ACKS;
+
     const sleep = this.deps.sleep ?? ((ms: number) => new Promise<void>(r => setTimeout(r, ms)));
 
     const requestACK = async (peerId: string): Promise<CollectedACK | null> => {
@@ -453,6 +465,13 @@ export class ACKCollector {
             // transport retries gave only ~3s, which a fresh CG's first
             // gossip push to its assigned cores routinely overran.
             if (isTransientStorageACKDeclineCode(code) && declineRetries < MAX_TRANSIENT_DECLINE_RETRIES) {
+              if (roundIsOver()) {
+                log(
+                  `[ACKCollector] Quorum already settled — abandoning transient-decline ` +
+                  `retry for ${peerId.slice(-8)} (${code})`,
+                );
+                return null;
+              }
               declineRetries += 1;
               const waitMs = transientDeclineBackoffMs(declineRetries);
               log(
@@ -539,6 +558,13 @@ export class ACKCollector {
           const msg = err instanceof Error ? err.message : String(err);
           transportAttempts += 1;
           if (transportAttempts < MAX_RETRIES) {
+            if (roundIsOver()) {
+              log(
+                `[ACKCollector] Quorum already settled — abandoning transport retry ` +
+                `for ${peerId.slice(-8)}: ${msg}`,
+              );
+              return null;
+            }
             log(`[ACKCollector] Retry ${transportAttempts}/${MAX_RETRIES} for ${peerId.slice(-8)}: ${msg}`);
             await sleep(transportAttempts * 1000);
             continue;
@@ -595,43 +621,53 @@ export class ACKCollector {
       }
     };
 
-    await Promise.race([
-      (async () => {
-        const promises = corePeers.map(async (peerId) => {
-          if (collected.length >= REQUIRED_ACKS) {
-            settlePeer();
-            return;
-          }
-          try {
-            const ack = await requestACK(peerId);
-            if (ack && !seenPeers.has(ack.peerId) && !seenIdentityIds.has(ack.nodeIdentityId)) {
-              seenPeers.add(ack.peerId);
-              seenIdentityIds.add(ack.nodeIdentityId);
-              collected.push(ack);
-              if (collected.length >= REQUIRED_ACKS) {
-                quorumResolve?.();
-              }
+    try {
+      await Promise.race([
+        (async () => {
+          const promises = corePeers.map(async (peerId) => {
+            if (collected.length >= REQUIRED_ACKS) {
+              settlePeer();
+              return;
             }
-          } finally {
-            settlePeer();
-          }
-        });
-        await Promise.race([Promise.allSettled(promises), quorumPromise]);
-      })(),
-      impossiblePromise,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new QuorumUnmetError({
-          collected: collected.length,
-          required: REQUIRED_ACKS,
-          dialled: corePeers.length,
-          peerOutcomes: snapshotPeerOutcomes(),
-          legacyMessage:
-            `storage_ack_timeout: only ${collected.length}/${REQUIRED_ACKS} ACKs received within ${ACK_TIMEOUT_MS}ms.${formatDeclineDetail()}`,
-        })),
-          ACK_TIMEOUT_MS,
+            try {
+              const ack = await requestACK(peerId);
+              if (ack && !seenPeers.has(ack.peerId) && !seenIdentityIds.has(ack.nodeIdentityId)) {
+                seenPeers.add(ack.peerId);
+                seenIdentityIds.add(ack.nodeIdentityId);
+                collected.push(ack);
+                if (collected.length >= REQUIRED_ACKS) {
+                  // Eagerly mark the round settled so any peers still mid-
+                  // backoff bail before their next dial (see `roundIsOver`).
+                  roundSettled = true;
+                  quorumResolve?.();
+                }
+              }
+            } finally {
+              settlePeer();
+            }
+          });
+          await Promise.race([Promise.allSettled(promises), quorumPromise]);
+        })(),
+        impossiblePromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new QuorumUnmetError({
+            collected: collected.length,
+            required: REQUIRED_ACKS,
+            dialled: corePeers.length,
+            peerOutcomes: snapshotPeerOutcomes(),
+            legacyMessage:
+              `storage_ack_timeout: only ${collected.length}/${REQUIRED_ACKS} ACKs received within ${ACK_TIMEOUT_MS}ms.${formatDeclineDetail()}`,
+          })),
+            ACK_TIMEOUT_MS,
+          ),
         ),
-      ),
-    ]);
+      ]);
+    } finally {
+      // The round is decided (quorum, timeout, or impossible-quorum). Signal
+      // any `requestACK` loops still sleeping between retries to abandon on
+      // wake rather than keep dialing after the caller has its answer.
+      roundSettled = true;
+    }
 
     if (collected.length < REQUIRED_ACKS) {
       throw new QuorumUnmetError({

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -480,6 +480,17 @@ export class ACKCollector {
                 ` (retry ${declineRetries}/${MAX_TRANSIENT_DECLINE_RETRIES}, waiting ${waitMs}ms for SWM gossip)`,
               );
               await sleep(waitMs);
+              // #896 review: quorum may have settled DURING the backoff above
+              // (collect() resolves the instant the last needed ACK lands on
+              // another peer). Re-check before re-dialing so a decided round
+              // never leaks one more `sendP2P` after the caller moved on.
+              if (roundIsOver()) {
+                log(
+                  `[ACKCollector] Quorum settled during backoff — abandoning ` +
+                  `transient-decline retry for ${peerId.slice(-8)} (${code})`,
+                );
+                return null;
+              }
               continue;
             }
 
@@ -567,6 +578,15 @@ export class ACKCollector {
             }
             log(`[ACKCollector] Retry ${transportAttempts}/${MAX_RETRIES} for ${peerId.slice(-8)}: ${msg}`);
             await sleep(transportAttempts * 1000);
+            // #896 review: re-check after the backoff too — quorum may have
+            // settled while we waited, so don't re-dial a decided round.
+            if (roundIsOver()) {
+              log(
+                `[ACKCollector] Quorum settled during backoff — abandoning ` +
+                `transport retry for ${peerId.slice(-8)}: ${msg}`,
+              );
+              return null;
+            }
             continue;
           }
           // Terminal transport failure on the final attempt. If this

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -53,6 +53,13 @@ export interface ACKCollectorDeps {
     claimedIdentityId: bigint,
   ) => Promise<ACKVerifyResult>;
   log?: (msg: string) => void;
+  /**
+   * Backoff sleep between transport-error retries and transient
+   * SWM-decline retries (#887). Injectable so unit tests can exercise
+   * the multi-retry budget without waiting real seconds. Defaults to a
+   * real `setTimeout` delay.
+   */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 export interface CollectedACK {
@@ -80,6 +87,24 @@ export interface ACKCollectionResult {
 const DEFAULT_REQUIRED_ACKS = 3;
 const ACK_TIMEOUT_MS = 120_000;
 const MAX_RETRIES = 3;
+// #887: transient declines (the core's SWM replica is still catching up
+// via gossip — NO_DATA_IN_SWM / MERKLE_MISMATCH_IN_SWM /
+// MISSING_CIPHERTEXT_CHUNKS) get their own, larger retry budget than
+// transport errors. For a freshly-created CG the publisher's ACK round
+// routinely races the very first SWM gossip push to the newly-assigned
+// core peers, and propagation can take well over the ~3s the old shared
+// 3-attempt / 1s+2s budget allowed — so a core that would have ACKed a
+// few seconds later was permanently dropped and the publish failed with
+// `storage_ack_insufficient`. The capped-exponential schedule below
+// spans ~31s across 6 retries, comfortably under `ACK_TIMEOUT_MS`, and
+// keeps quorum reachable once the data lands. Transport errors keep the
+// unchanged `MAX_RETRIES` budget (a peer that never answers shouldn't
+// hold the round open for 30s).
+const MAX_TRANSIENT_DECLINE_RETRIES = 6;
+const TRANSIENT_DECLINE_BACKOFF_CAP_MS = 8_000;
+function transientDeclineBackoffMs(retry: number): number {
+  return Math.min(1000 * 2 ** Math.max(0, retry - 1), TRANSIENT_DECLINE_BACKOFF_CAP_MS);
+}
 const MAX_DECLINE_CODE_CHARS = 64;
 const MAX_DECLINE_MESSAGE_CHARS = 240;
 
@@ -385,8 +410,19 @@ export class ACKCollector {
       });
     };
 
+    const sleep = this.deps.sleep ?? ((ms: number) => new Promise<void>(r => setTimeout(r, ms)));
+
     const requestACK = async (peerId: string): Promise<CollectedACK | null> => {
-      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      // #887: transient SWM declines and transport errors now have
+      // independent retry budgets. A core whose SWM is still catching up
+      // (transient decline) is given the larger `MAX_TRANSIENT_DECLINE_
+      // RETRIES` budget below; a core that simply won't answer keeps the
+      // unchanged transport `MAX_RETRIES` budget. Mixing them in one
+      // counter (the pre-#887 behaviour) let a couple of transport blips
+      // burn the whole budget a slow-gossip core needed to ACK.
+      let transportAttempts = 0;
+      let declineRetries = 0;
+      for (;;) {
         try {
           const response = await this.deps.sendP2P(peerId, ackProtocolId, intentBytes);
           const ack: StorageACKMsg = decodeStorageACK(response);
@@ -407,20 +443,24 @@ export class ACKCollector {
             declines.set(peerId, { code, message: declineMessage });
 
             // Transient declines (SWM replication catching up via
-            // gossip) can resolve on a retry, so re-send through the
-            // same backoff as transport errors instead of permanently
-            // deselecting the peer. Codex review on PR #559 flagged
-            // the "every decline is permanent" path as a regression:
-            // a core that would have ACKed seconds later was being
-            // removed from the quorum pool the moment its SWM trailed
-            // the publish by even one gossip cycle.
-            if (isTransientStorageACKDeclineCode(code) && attempt < MAX_RETRIES - 1) {
+            // gossip) can resolve on a retry, so re-send with backoff
+            // instead of permanently deselecting the peer. Codex review
+            // on PR #559 flagged the "every decline is permanent" path
+            // as a regression: a core that would have ACKed seconds
+            // later was being removed from the quorum pool the moment
+            // its SWM trailed the publish by even one gossip cycle.
+            // #887 widened this further — the old budget shared with
+            // transport retries gave only ~3s, which a fresh CG's first
+            // gossip push to its assigned cores routinely overran.
+            if (isTransientStorageACKDeclineCode(code) && declineRetries < MAX_TRANSIENT_DECLINE_RETRIES) {
+              declineRetries += 1;
+              const waitMs = transientDeclineBackoffMs(declineRetries);
               log(
                 `[ACKCollector] Transient decline from ${peerId.slice(-8)}: ${code}` +
                 (declineMessage ? ` — ${declineMessage}` : '') +
-                ` (retry ${attempt + 1}/${MAX_RETRIES})`,
+                ` (retry ${declineRetries}/${MAX_TRANSIENT_DECLINE_RETRIES}, waiting ${waitMs}ms for SWM gossip)`,
               );
-              await new Promise(r => setTimeout(r, (attempt + 1) * 1000));
+              await sleep(waitMs);
               continue;
             }
 
@@ -497,29 +537,30 @@ export class ACKCollector {
           };
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          if (attempt < MAX_RETRIES - 1) {
-            log(`[ACKCollector] Retry ${attempt + 1}/${MAX_RETRIES} for ${peerId.slice(-8)}: ${msg}`);
-            await new Promise(r => setTimeout(r, (attempt + 1) * 1000));
-          } else {
-            // Terminal transport failure on the final attempt. If this
-            // peer transient-declined on an earlier attempt the
-            // `declines` map still holds that stale code — overwrite
-            // it with the actual terminal reason so the aggregated
-            // `storage_ack_insufficient` diagnostic reflects the last
-            // observed outcome (the codex review on PR #559 caught
-            // the original "stale decline shadows the real failure"
-            // path here).
-            if (declines.has(peerId)) {
-              declines.set(peerId, {
-                code: 'TRANSPORT_ERROR',
-                message: sanitizeDeclineField(msg, MAX_DECLINE_MESSAGE_CHARS),
-              });
-            }
-            log(`[ACKCollector] Failed to get ACK from ${peerId.slice(-8)} after ${MAX_RETRIES} attempts: ${msg}`);
+          transportAttempts += 1;
+          if (transportAttempts < MAX_RETRIES) {
+            log(`[ACKCollector] Retry ${transportAttempts}/${MAX_RETRIES} for ${peerId.slice(-8)}: ${msg}`);
+            await sleep(transportAttempts * 1000);
+            continue;
           }
+          // Terminal transport failure on the final attempt. If this
+          // peer transient-declined on an earlier attempt the
+          // `declines` map still holds that stale code — overwrite
+          // it with the actual terminal reason so the aggregated
+          // `storage_ack_insufficient` diagnostic reflects the last
+          // observed outcome (the codex review on PR #559 caught
+          // the original "stale decline shadows the real failure"
+          // path here).
+          if (declines.has(peerId)) {
+            declines.set(peerId, {
+              code: 'TRANSPORT_ERROR',
+              message: sanitizeDeclineField(msg, MAX_DECLINE_MESSAGE_CHARS),
+            });
+          }
+          log(`[ACKCollector] Failed to get ACK from ${peerId.slice(-8)} after ${MAX_RETRIES} attempts: ${msg}`);
+          return null;
         }
       }
-      return null;
     };
 
     let quorumResolve: (() => void) | undefined;

--- a/packages/publisher/test/ack-collector.test.ts
+++ b/packages/publisher/test/ack-collector.test.ts
@@ -378,6 +378,77 @@ describe('ACKCollector', () => {
     expect(callsByPeer.get('peer-3')).toBe(1);
   });
 
+  // PR #896 review (🔴): the `roundIsOver()` guard must also be checked AFTER
+  // each backoff sleep — quorum can settle WHILE a peer is mid-backoff, and
+  // without the second guard the next `continue` would still fire one more
+  // `sendP2P`. Here peer-3 declines BEFORE quorum (so the pre-sleep guard
+  // passes and it sleeps), quorum forms during that sleep, and the post-sleep
+  // guard must catch it — leaving peer-3 at exactly one dial.
+  it('abandons a retry when quorum settles DURING the backoff sleep (#896 post-sleep guard)', async () => {
+    const callsByPeer = new Map<string, number>();
+    let releaseFastPeers!: () => void;
+    const fastPeersGate = new Promise<void>((r) => { releaseFastPeers = r; });
+    let sleepCount = 0;
+
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      // The first sleep is peer-3's backoff. Release the three fast peers so
+      // they ACK and form quorum, then hold the sleep open long enough for
+      // their ACKs to be collected — so the round is settled by the time the
+      // sleep resolves and peer-3 re-checks `roundIsOver()` on wake.
+      sleep: async () => {
+        sleepCount += 1;
+        if (sleepCount === 1) {
+          releaseFastPeers();
+          await new Promise((r) => setTimeout(r, 100));
+        }
+      },
+      sendP2P: async (peerId) => {
+        callsByPeer.set(peerId, (callsByPeer.get(peerId) ?? 0) + 1);
+        if (peerId === 'peer-3') {
+          // Declines immediately, before any fast peer has ACKed — so the
+          // pre-sleep guard sees collected=0 and lets peer-3 sleep.
+          return encodeDecline('NO_DATA_IN_SWM');
+        }
+        await fastPeersGate;
+        const idx = parseInt(peerId.replace('peer-', ''), 10);
+        const { r, vs } = await signACK(coreWallets[idx], testCGId, merkleRoot, 1, 100n);
+        return encodeStorageACK({
+          merkleRoot,
+          coreNodeSignatureR: r,
+          coreNodeSignatureVS: vs,
+          contextGraphId: testCGIdStr,
+          nodeIdentityId: idx + 1,
+        });
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2', 'peer-3'],
+      log: () => {},
+    };
+
+    const collector = new ACKCollector(deps);
+    const result = await collector.collect({
+      merkleRoot,
+      contextGraphId: testCGId,
+      contextGraphIdStr: testCGIdStr,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 100n,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:a'],
+      chainId: TEST_CHAIN_ID,
+      kav10Address: TEST_KAV10_ADDR,
+      merkleLeafCount,
+    });
+
+    expect(result.acks).toHaveLength(3);
+    // Give any (buggy) post-sleep re-dial a chance to fire before asserting.
+    await new Promise((r) => setTimeout(r, 100));
+    // Exactly one dial: declined once, slept, and bailed on wake because the
+    // round had settled. The pre-#896 (before-only) guard would have issued a
+    // second `sendP2P` here.
+    expect(callsByPeer.get('peer-3')).toBe(1);
+  });
+
   it('rejects ACKs with wrong merkle root', async () => {
     const wrongRoot = new Uint8Array(32).fill(0xff);
     const deps: ACKCollectorDeps = {

--- a/packages/publisher/test/ack-collector.test.ts
+++ b/packages/publisher/test/ack-collector.test.ts
@@ -314,6 +314,70 @@ describe('ACKCollector', () => {
     }
   });
 
+  // PR #896 review (🟡): the widened #887 transient-decline budget (~31s)
+  // must NOT keep a losing peer dialing after quorum has already formed
+  // elsewhere. A peer still mid-retry when the last needed ACK lands must
+  // bail on its next wake instead of burning its full budget — otherwise a
+  // successful publish leaves ~30s of avoidable ACK traffic + log noise
+  // running in the background after `collect()` returned.
+  it('abandons transient-decline retries once quorum is reached elsewhere (#896)', async () => {
+    const callsByPeer = new Map<string, number>();
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      // Collapse the collector's own backoff so an unfixed build would
+      // race through all 7 transient-decline sends near-instantly.
+      sleep: async () => {},
+      sendP2P: async (peerId) => {
+        callsByPeer.set(peerId, (callsByPeer.get(peerId) ?? 0) + 1);
+        if (peerId === 'peer-3') {
+          // The slow peer: its SWM is catching up, and each response
+          // arrives well after the three fast cores have already formed
+          // quorum. The real delay guarantees quorum is settled before
+          // peer-3's first decline is processed, so the bail is
+          // deterministic rather than scheduler-dependent.
+          await new Promise((r) => setTimeout(r, 25));
+          return encodeDecline('NO_DATA_IN_SWM');
+        }
+        const idx = parseInt(peerId.replace('peer-', ''), 10);
+        const { r, vs } = await signACK(coreWallets[idx], testCGId, merkleRoot, 1, 100n);
+        return encodeStorageACK({
+          merkleRoot,
+          coreNodeSignatureR: r,
+          coreNodeSignatureVS: vs,
+          contextGraphId: testCGIdStr,
+          nodeIdentityId: idx + 1,
+        });
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2', 'peer-3'],
+      log: () => {},
+    };
+
+    const collector = new ACKCollector(deps);
+    const result = await collector.collect({
+      merkleRoot,
+      contextGraphId: testCGId,
+      contextGraphIdStr: testCGIdStr,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 100n,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:a'],
+      chainId: TEST_CHAIN_ID,
+      kav10Address: TEST_KAV10_ADDR,
+      merkleLeafCount,
+    });
+
+    expect(result.acks).toHaveLength(3);
+    // Let peer-3's in-flight decline resolve and the bail decision land.
+    // A budget long enough that an unfixed build (which keeps retrying
+    // after quorum) would have issued all 7 sends.
+    await new Promise((r) => setTimeout(r, 300));
+    // Fixed: peer-3 issued exactly its one in-flight dial, then bailed on
+    // wake because quorum was already settled. Unfixed: it would have run
+    // the full 1 + MAX_TRANSIENT_DECLINE_RETRIES = 7 sends.
+    expect(callsByPeer.get('peer-3')).toBe(1);
+  });
+
   it('rejects ACKs with wrong merkle root', async () => {
     const wrongRoot = new Uint8Array(32).fill(0xff);
     const deps: ACKCollectorDeps = {

--- a/packages/publisher/test/ack-collector.test.ts
+++ b/packages/publisher/test/ack-collector.test.ts
@@ -210,6 +210,110 @@ describe('ACKCollector', () => {
     })).rejects.toThrow('storage_ack_insufficient');
   });
 
+  // #887: a freshly-created CG's first SWM gossip push to its assigned
+  // cores can land seconds after the publish ACK round starts. Cores
+  // decline NO_DATA_IN_SWM (a transient code) until the data arrives.
+  // The pre-#887 budget shared a single 3-attempt counter with transport
+  // errors (~3s), so a peer that would have ACKed a few seconds later was
+  // permanently dropped and the publish failed. These tests pin the
+  // dedicated, larger transient-decline retry budget.
+  function encodeDecline(code: string, message = 'SWM gossip catching up') {
+    return encodeStorageACK({
+      merkleRoot: new Uint8Array(),
+      coreNodeSignatureR: new Uint8Array(),
+      coreNodeSignatureVS: new Uint8Array(),
+      contextGraphId: testCGIdStr,
+      nodeIdentityId: 0,
+      declineCode: code,
+      declineMessage: message,
+    });
+  }
+
+  it('retries transient NO_DATA_IN_SWM declines past the transport budget until SWM gossip lands (#887)', async () => {
+    const callsByPeer = new Map<string, number>();
+    // 4 declines is more than the old 3-attempt cap — pre-#887 every
+    // peer would have been dropped here and quorum would never form.
+    const DECLINES_BEFORE_ACK = 4;
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sleep: async () => {}, // collapse backoff so the test is instant
+      sendP2P: async (peerId) => {
+        const n = (callsByPeer.get(peerId) ?? 0) + 1;
+        callsByPeer.set(peerId, n);
+        if (n <= DECLINES_BEFORE_ACK) return encodeDecline('NO_DATA_IN_SWM');
+        const idx = parseInt(peerId.replace('peer-', ''), 10);
+        const { r, vs } = await signACK(coreWallets[idx], testCGId, merkleRoot, 1, 100n);
+        return encodeStorageACK({
+          merkleRoot,
+          coreNodeSignatureR: r,
+          coreNodeSignatureVS: vs,
+          contextGraphId: testCGIdStr,
+          nodeIdentityId: idx + 1,
+        });
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: () => {},
+    };
+
+    const collector = new ACKCollector(deps);
+    const result = await collector.collect({
+      merkleRoot,
+      contextGraphId: testCGId,
+      contextGraphIdStr: testCGIdStr,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 100n,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:a'],
+      chainId: TEST_CHAIN_ID,
+      kav10Address: TEST_KAV10_ADDR,
+      merkleLeafCount,
+    });
+
+    expect(result.acks).toHaveLength(3);
+    for (const peerId of ['peer-0', 'peer-1', 'peer-2']) {
+      // 4 declines + 1 successful ACK = 5 sends; impossible under the
+      // old 3-attempt budget.
+      expect(callsByPeer.get(peerId)).toBe(DECLINES_BEFORE_ACK + 1);
+    }
+  });
+
+  it('gives up on a transient decline that never clears, bounded by the retry budget (#887)', async () => {
+    const callsByPeer = new Map<string, number>();
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sleep: async () => {},
+      // Never recovers — the SWM data genuinely never shows up.
+      sendP2P: async (peerId) => {
+        callsByPeer.set(peerId, (callsByPeer.get(peerId) ?? 0) + 1);
+        return encodeDecline('NO_DATA_IN_SWM');
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: () => {},
+    };
+
+    const collector = new ACKCollector(deps);
+    await expect(collector.collect({
+      merkleRoot,
+      contextGraphId: testCGId,
+      contextGraphIdStr: testCGIdStr,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 100n,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:a'],
+      chainId: TEST_CHAIN_ID,
+      kav10Address: TEST_KAV10_ADDR,
+      merkleLeafCount,
+    })).rejects.toThrow('storage_ack_insufficient');
+
+    for (const peerId of ['peer-0', 'peer-1', 'peer-2']) {
+      // 1 initial attempt + MAX_TRANSIENT_DECLINE_RETRIES (6) = 7 sends,
+      // then the peer is dropped. Proves the budget is bounded (no hang).
+      expect(callsByPeer.get(peerId)).toBe(7);
+    }
+  });
+
   it('rejects ACKs with wrong merkle root', async () => {
     const wrongRoot = new Uint8Array(32).fill(0xff);
     const deps: ACKCollectorDeps = {

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -1225,7 +1225,7 @@ describe('ACKCollector typed declines (#541)', () => {
     )).toBe(true);
   });
 
-  it('transient declines (NO_DATA_IN_SWM) are retried against the same peer up to MAX_RETRIES', async () => {
+  it('transient declines (NO_DATA_IN_SWM) are retried against the same peer up to the transient-decline budget (#887)', async () => {
     // Codex review on PR #559: treating NO_DATA_IN_SWM as permanent
     // shrinks the quorum pool the moment a core's SWM trails the
     // publish by even one gossip cycle. The fix is to retry transient
@@ -1249,6 +1249,9 @@ describe('ACKCollector typed declines (#541)', () => {
     const log = noop();
     const deps: ACKCollectorDeps = {
       gossipPublish: noop(),
+      // #887: collapse the (now larger) transient-decline backoff so the
+      // test exercises the retry budget without waiting real seconds.
+      sleep: async () => {},
       sendP2P: sendP2P as any,
       getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
       log,
@@ -1259,12 +1262,13 @@ describe('ACKCollector typed declines (#541)', () => {
       collector.collect(buildCollectParams({ requiredACKs: 3 })),
     ).rejects.toThrow(/storage_ack_insufficient/);
 
-    // peer-0 was dialled 3 times (MAX_RETRIES) before giving up;
-    // every transient decline triggered another attempt. Lower bound
-    // is 2 (1 initial + ≥1 retry) so the test is robust to a future
-    // MAX_RETRIES bump; upper bound pins the current contract.
-    expect(sendCounts.get('peer-0')).toBeGreaterThanOrEqual(2);
-    expect(sendCounts.get('peer-0')).toBeLessThanOrEqual(3);
+    // #887: NO_DATA_IN_SWM is transient, so peer-0 is retried on its own
+    // (larger) decline budget — 1 initial dial + MAX_TRANSIENT_DECLINE_
+    // RETRIES (6) = 7 — before giving up. Lower bound proves we now retry
+    // PAST the old shared 3-attempt transport budget; upper bound pins
+    // the current contract.
+    expect(sendCounts.get('peer-0')).toBeGreaterThanOrEqual(4);
+    expect(sendCounts.get('peer-0')).toBeLessThanOrEqual(7);
 
     expect(log.calls.some(
       (c: unknown[]) => (c[0] as string).includes('Transient decline from peer-0')
@@ -1281,6 +1285,11 @@ describe('ACKCollector typed declines (#541)', () => {
     // sending operators down the wrong investigation path.
     const sendCounts = new Map<string, number>();
     const transportErrorMessage = 'simulated stream reset on retry';
+    // peer-1 / peer-2 ACK so quorum stays *reachable* until peer-0
+    // settles — otherwise the fast-fail (their failure already makes 3
+    // ACKs impossible) would fire before peer-0 reaches its terminal
+    // transport error, and we couldn't observe its final recorded reason.
+    const ackBuilder = buildSendP2P();
     const sendP2P = tracked(async (peerId: string) => {
       const calls = (sendCounts.get(peerId) ?? 0) + 1;
       sendCounts.set(peerId, calls);
@@ -1298,11 +1307,12 @@ describe('ACKCollector typed declines (#541)', () => {
         }
         throw new Error(transportErrorMessage);
       }
-      throw new Error('no other peers configured');
+      return ackBuilder(peerId);
     });
 
     const deps: ACKCollectorDeps = {
       gossipPublish: noop(),
+      sleep: async () => {},
       sendP2P: sendP2P as any,
       getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
       log: noop(),
@@ -1324,7 +1334,11 @@ describe('ACKCollector typed declines (#541)', () => {
     expect(captured).not.toContain('NO_DATA_IN_SWM');
     expect(captured).not.toContain('replication lagging (stale on transport tail)');
 
-    expect(sendCounts.get('peer-0')).toBe(3);
+    // #887: call 1 is the transient decline (its own budget), then 3
+    // transport attempts (the unchanged transport `MAX_RETRIES`), the
+    // last of which is terminal — 4 dials total. The terminal reason is
+    // TRANSPORT_ERROR, not the stale NO_DATA_IN_SWM (asserted above).
+    expect(sendCounts.get('peer-0')).toBe(4);
   }, 15_000);
 
   it('a transient decline that resolves to a valid ACK on retry contributes to quorum', async () => {
@@ -1354,6 +1368,7 @@ describe('ACKCollector typed declines (#541)', () => {
 
     const deps: ACKCollectorDeps = {
       gossipPublish: noop(),
+      sleep: async () => {},
       sendP2P: sendP2P as any,
       getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
       log: noop(),
@@ -1378,6 +1393,7 @@ describe('ACKCollector typed declines (#541)', () => {
     });
     const deps: ACKCollectorDeps = {
       gossipPublish: noop(),
+      sleep: async () => {},
       sendP2P: sendP2P as any,
       getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2', 'peer-3'],
       log: noop(),
@@ -1432,6 +1448,7 @@ describe('ACKCollector typed declines (#541)', () => {
     });
     const deps: ACKCollectorDeps = {
       gossipPublish: noop(),
+      sleep: async () => {},
       sendP2P: sendP2P as any,
       getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
       log: noop(),
@@ -1463,6 +1480,7 @@ describe('ACKCollector typed declines (#541)', () => {
     const log = noop();
     const deps: ACKCollectorDeps = {
       gossipPublish: noop(),
+      sleep: async () => {},
       sendP2P: sendP2P as any,
       getConnectedCorePeers: () => ['peer-0', 'peer-1'],
       log,
@@ -1527,6 +1545,11 @@ describe('ACKCollector typed declines (#541)', () => {
     };
     const deps: ACKCollectorDeps = {
       gossipPublish: noop(),
+      // #887: collapse the transient-decline backoff. peer-0/peer-1
+      // exhaust their (now larger) NO_DATA retry budget, then the
+      // fast-fail fires the moment the still-pending pool (the lone hung
+      // peer-2) can no longer reach quorum.
+      sleep: async () => {},
       sendP2P: sendP2P as any,
       getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
       log: noop(),
@@ -1555,10 +1578,12 @@ describe('ACKCollector typed declines (#541)', () => {
 
     // Sanity check: peer-2 was actually dialled (so the hang is real)
     // and the failure landed well below the ACK_TIMEOUT_MS budget.
-    // Floor pushed up from the original ~instant decline path now that
-    // NO_DATA_IN_SWM is a TRANSIENT decline that retries through the
-    // 1s + 2s transport backoff before settling — the fast-fail still
-    // beats the 120s ACK_TIMEOUT_MS budget by two orders of magnitude.
+    // peer-0/peer-1's NO_DATA_IN_SWM is a TRANSIENT decline that retries
+    // through the #887 transient-decline budget before settling; with
+    // the backoff collapsed here the fast-fail fires immediately once
+    // they exhaust it, far under the 120s ACK_TIMEOUT_MS budget. (In
+    // production the budget spans ~31s — still ~4x faster than waiting
+    // out ACK_TIMEOUT_MS for the hung peer.)
     expect(hung).toContain('peer-2');
     expect(elapsed).toBeLessThan(15_000);
   }, 30_000);


### PR DESCRIPTION
## Summary

Three independent rc.12 bugs found during live devnet / edge-node testing. Each is a distinct root cause with its own deterministic unit tests; they're bundled here because they were all found in the same publish/query smoke pass. All three issues are open with the `rc 12` label and **no other PR addresses them** (verified against open + recently-merged PRs).

### Fixes #887 — fresh public-CG publish fails with `NO_DATA_IN_SWM`
A freshly-created public CG fails publish with `storage_ack_insufficient` because the publisher's ACK round races SWM-gossip propagation to its newly-assigned cores. `NO_DATA_IN_SWM` was already classified as a *transient* decline and retried, but it shared the transport budget (`MAX_RETRIES = 3`, ~3s total) — shorter than gossip propagation to fresh cores.

- `packages/publisher/src/ack-collector.ts`: transient declines now get their **own** budget — `MAX_TRANSIENT_DECLINE_RETRIES = 6` with capped-exponential backoff (~31s total, still well under the 120s `ACK_TIMEOUT_MS`). Transport errors keep the unchanged 3-attempt budget (a peer that never answers shouldn't hold the round open).
- Added an injectable `sleep` dep so the multi-retry path is unit-testable without real delays.

### Fixes #888 — intermittent `TooLowAllowance(TRAC,0,1)` on consecutive zero-cost publishes
This is the **`#870` residual**. PR #876 closed #870 with **tests only**, explicitly naming *"stale allowance from an RPC-side read cache"* as the unaddressed candidate root cause. This adds the actual code fix:

- `packages/chain/src/evm-adapter.ts`:
  - `isTooLowAllowanceError(err)` — robust classifier (decoded `revert.name`, message/shortMessage/reason, nested cause).
  - On a `TooLowAllowance` revert during populate/gas-estimation — which happens **strictly pre-broadcast**, before the `onBroadcast` WAL checkpoint — force a fresh approve up to the publish floor and **confirm it is visible** on the same read path (`confirmAllowanceVisible`, bounded poll) before retrying populate+sign **exactly once**. Any other error, or a second revert, propagates.
  - The visibility poll is **gated on `force`**, so the steady-state publish path issues exactly one allowance read + one approve as before (latency unchanged).
- `packages/chain/src/index.ts`: export `isTooLowAllowanceError`.

### Fixes #889 — `POST /api/query` returns 500 (not 400) for invalid SPARQL
The parse-error classifier missed oxigraph's native `error at <line>:<col>: expected one of …` shape, so malformed queries fell through to the 500 path.

- `packages/cli/src/daemon/routes/query.ts`: widen the 400 classifier to match that shape, while still surfacing genuine server faults as 500.

## Test plan

- [x] `packages/publisher` — **1097 passed / 6 skipped** (incl. 2 new `ack-collector.test.ts` cases: retries past the old budget then succeeds; bounded give-up at 7 sends; and the 6 typed-decline edge-case tests updated for the new budget with collapsed backoff).
- [x] `packages/chain` unit — **117 passed** (9 new: `isTooLowAllowanceError` classifier + `ensureV10ApproveTrac` forced re-approve / visibility-poll / stale-high-skip / bounded-give-up), plus **48** V10 publish-path / decode tests.
- [x] `packages/cli` — `query.test.ts` **3 passed** (oxigraph-parse→400 + a guard that real server faults stay 500).
- All deterministic (no live network). #887/#888's *live* failure modes (gossip timing / RPC read-after-write) can't be reproduced on demand; verification is at the unit level.

## Notes / coordination

- **#556** (open) edits the same two `#887` files (`ack-collector.ts`, `v10-ack-edge-cases.test.ts`) for an orthogonal hosting-filter fix — whichever lands second needs a small rebase. Different logic, not a conflict in intent.
- Built on top of merged **#876** (signer-parity tests) and **#875** (1-wei floor `console.warn`); my changes are additive (separate `describe` blocks, no test collision).

Made with [Cursor](https://cursor.com)