### PR TITLE
fix(agent): respect explicit accessPolicy="public" over allowlist heuristic (forward-port #873 → main)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -14557,6 +14557,16 @@ export class DKGAgent {
     }
     this.assertCallerIsOwner(owner, callerAgentAddress, 'manage peer invitations');
 
+    // Issue #865 — log a clear warning when growing a peer allowlist
+    // on a CG that has an explicit `accessPolicy="public"` triple. The
+    // allowlist write is allowed (legitimate uses include populating
+    // an authorized-publisher set on a public-but-curated-publish CG),
+    // but post-#865 the publisher's `isPrivateContextGraph` no longer
+    // silently flips the CG to curated just because an allowlist was
+    // written — so the operator should know the allowlist is
+    // informational for read access on this CG.
+    await this.warnIfAllowlistWriteOnPublicCg(contextGraphId, ctx, 'inviteToContextGraph (peer)');
+
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
     const escapedPeerId = escapeSparqlLiteral(peerId);
@@ -14654,6 +14664,14 @@ export class DKGAgent {
       );
     }
     this.assertCallerIsOwner(owner, callerAgentAddress, 'manage invitations');
+
+    // Issue #865 — companion warning to the peer-invite path above.
+    // Allowlist writes on explicit-public CGs are allowed (the
+    // publishPolicy=curated + accessPolicy=public combination is a
+    // valid CG mode where the allowlist gates publishers, not
+    // subscribers), but the operator should know that the read-side
+    // gate stays open per the explicit `accessPolicy="public"`.
+    await this.warnIfAllowlistWriteOnPublicCg(contextGraphId, ctx, 'inviteAgentToContextGraph');
 
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
@@ -17949,6 +17967,63 @@ export class DKGAgent {
     }
   }
 
+  /**
+   * Issue #865 — observability hook for the invite write paths. Emits a
+   * warn log when the caller writes an allowlist quad on a CG that
+   * carries an explicit `accessPolicy="public"` triple in `_meta` or
+   * the ontology graph. We don't throw here:
+   *
+   *   1. `publishPolicy=curated` on a public-discoverable CG is a
+   *      legitimate combo (allowlist gates publishers, subscribers
+   *      stay public). Rejecting would break it.
+   *   2. The primary `isPrivateContextGraph` fix already prevents the
+   *      original bug (silent re-route to the curated publish path).
+   *   3. Pre-existing tests and adapter flows create CGs with no
+   *      explicit accessPolicy and then invite — those should keep
+   *      working.
+   *
+   * The warn line is the documentation: it tells the operator
+   * "your allowlist write landed but read access stays open per the
+   * explicit accessPolicy=public" so the next publisher confusion
+   * has an obvious breadcrumb. Read-only, single SELECT — does not
+   * mutate state.
+   */
+  private async warnIfAllowlistWriteOnPublicCg(
+    contextGraphId: string,
+    ctx: OperationContext,
+    operation: string,
+  ): Promise<void> {
+    if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
+      return;
+    }
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
+    const result = await this.store.query(
+      `SELECT ?policy WHERE {
+        {
+          GRAPH <${ontologyGraph}> {
+            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
+          }
+        } UNION {
+          GRAPH <${cgMetaGraph}> {
+            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
+          }
+        }
+      } LIMIT 1`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return;
+    const policy = result.bindings[0]?.['policy'];
+    if (policy !== '"public"') return;
+    this.log.warn(
+      ctx,
+      `${operation}: writing allowlist on context graph "${contextGraphId}" which has explicit accessPolicy="public". ` +
+        `The allowlist quad is being persisted but does NOT enforce read access — anyone can still subscribe. ` +
+        `Issue #865: as of this commit, the publisher no longer auto-flips public CGs to the curated publish path ` +
+        `just because an allowlist exists. If you intended to make this CG invite-only, recreate it with accessPolicy=1.`,
+    );
+  }
+
   private async isPrivateContextGraph(contextGraphId: string): Promise<boolean> {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return false;
@@ -17971,18 +18046,41 @@ export class DKGAgent {
       } LIMIT 1`,
     );
 
-    if (result.type === 'bindings' && result.bindings[0]?.['policy'] === '"private"') {
-      return true;
+    // Issue #865 — explicit `accessPolicy` ALWAYS wins over the allowlist
+    // heuristic below. The previous behavior fell through to the ASK
+    // check whenever `policy` was anything other than `"private"`, which
+    // silently flipped a CG the curator explicitly created with
+    // `accessPolicy="public"` into "private" the moment ANY invite landed
+    // (`DKG_ALLOWED_AGENT` / `DKG_ALLOWED_PEER` write in `_meta`). The
+    // publisher then took the LU-5 / LU-11 curated path, the publish
+    // hung waiting for V2 ACKs from invitees, and the user had no
+    // recovery path short of recreating the CG.
+    //
+    // Semantics post-#865: an allowlist on a public CG is INFORMATIONAL
+    // (matches on-chain `accessPolicy=0` which the contract does not
+    // enforce). Curator can still see "who I would have invited" in the
+    // member list, but the publisher stays on the plaintext / public
+    // path so cores can verify against SWM and the on-chain tx
+    // actually submits.
+    if (result.type === 'bindings' && result.bindings.length > 0) {
+      const policyValue = result.bindings[0]?.['policy'];
+      if (policyValue === '"private"') return true;
+      if (policyValue === '"public"') return false;
+      // Any other (unknown) literal value falls through to the
+      // allowlist heuristic — defensive for forward-compatibility
+      // with future policy values, but in practice the
+      // `createContextGraph` writer is the only producer and it
+      // only ever writes "public" or "private".
     }
 
-    // Also treat CGs with any allowlist predicate as private, even when no
-    // explicit `accessPolicy` triple exists (e.g. `inviteToContextGraph`
-    // writes `DKG_ALLOWED_PEER` straight into `_meta` without touching the
-    // ontology's access_policy; `inviteAgentToContextGraph` does the same
-    // with `DKG_ALLOWED_AGENT`). Both the V10 agent model AND the legacy
-    // peer-ID model need to be recognized here, otherwise the store-
-    // discovery path would misclassify a freshly-invited CG as "open /
-    // discoverable only" and skip the same-connect catchup.
+    // Legacy / discovered-CG fallback: when no explicit `accessPolicy`
+    // triple exists (e.g. an old CG materialized before the predicate
+    // was added, or a peer-only CG discovered via gossip without
+    // ontology bootstrap), treat the presence of an allowlist
+    // predicate as the curated signal. Both the V10 agent model AND
+    // the legacy peer-ID model need to be recognized here so the
+    // store-discovery path doesn't misclassify a freshly-invited CG
+    // as "open / discoverable only" and skip the same-connect catchup.
     const allowlistResult = await this.store.query(
       `ASK WHERE {
         GRAPH <${cgMetaGraph}> {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -14671,19 +14671,51 @@ export class DKGAgent {
     }
     this.assertCallerIsOwner(owner, callerAgentAddress, 'manage invitations');
 
+    const existingParticipants = await this.getPrivateContextGraphParticipants(contextGraphId);
+    const alreadyAllowed = existingParticipants?.some(
+      (a) => a.toLowerCase() === agentAddress.toLowerCase(),
+    ) ?? false;
+
+    // Codex review on #873 (line 14061) — idempotency early-return.
+    // Mirrors the peer-path branch at ~line 13967. A no-op re-invite
+    // of an agent that's already in the allowlist with no fresh
+    // delegation must not insert duplicate quads OR emit the
+    // public-CG warn — pre-fix, the warn ran on every call regardless
+    // of whether the store was about to mutate, which misled
+    // operators auditing the warn stream (empirically reproduced by
+    // @branarakic on the patched daemon at `704b49cf`).
+    if (alreadyAllowed && !delegation) {
+      this.upsertContextGraphMember({
+        contextGraphId,
+        principalType: 'agent',
+        principalId: agentAddress,
+        role: 'participant',
+        status: 'active',
+        source: 'allowed-agent',
+      });
+      this.log.info(ctx, `Agent ${agentAddress} already in allowlist for "${contextGraphId}" — skipping`);
+      return;
+    }
+
     // Issue #865 — companion warning to the peer-invite path above.
     // Allowlist writes on explicit-public CGs are allowed (the
     // publishPolicy=curated + accessPolicy=public combination is a
     // valid CG mode where the allowlist gates publishers, not
     // subscribers), but the operator should know that the read-side
     // gate stays open per the explicit `accessPolicy="public"`.
-    await this.warnIfAllowlistWriteOnPublicCg(contextGraphId, ctx, 'inviteAgentToContextGraph');
+    //
+    // Codex review on #873 (line 14061) — gated on `!alreadyAllowed`
+    // so re-approves that only refresh a delegation (allowlist quad
+    // is already there) don't emit a misleading "writing allowlist"
+    // warning either.
+    if (!alreadyAllowed) {
+      await this.warnIfAllowlistWriteOnPublicCg(contextGraphId, ctx, 'inviteAgentToContextGraph');
+    }
 
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
     const quadsToInsert: Quad[] = [];
 
-    const existingParticipants = await this.getPrivateContextGraphParticipants(contextGraphId);
     if ((!existingParticipants || existingParticipants.length === 0) && this.defaultAgentAddress) {
       quadsToInsert.push({
         subject: contextGraphUri,
@@ -14701,12 +14733,18 @@ export class DKGAgent {
       });
     }
 
-    quadsToInsert.push({
-      subject: contextGraphUri,
-      predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
-      object: `"${agentAddress}"`,
-      graph: cgMetaGraph,
-    });
+    // Codex review on #873 — only push the bare allowlist quad when
+    // the list is actually growing. Re-approving an existing agent
+    // with a fresh delegation overwrites the delegation node (below)
+    // but must not re-insert the DKG_ALLOWED_AGENT triple.
+    if (!alreadyAllowed) {
+      quadsToInsert.push({
+        subject: contextGraphUri,
+        predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+        object: `"${agentAddress}"`,
+        graph: cgMetaGraph,
+      });
+    }
 
     // If the agent gave us a signed delegation (via the join-request
     // path), promote its delegatee identifiers into the CG's allowlist

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -14596,16 +14596,6 @@ export class DKGAgent {
       return;
     }
 
-    // Issue #865 — log a clear warning when growing a peer allowlist
-    // on a CG that has an explicit `accessPolicy="public"` triple. The
-    // allowlist write is allowed (legitimate uses include populating
-    // an authorized-publisher set on a public-but-curated-publish CG),
-    // but post-#865 the publisher's `isPrivateContextGraph` no longer
-    // silently flips the CG to curated just because an allowlist was
-    // written — so the operator should know the allowlist is
-    // informational for read access on this CG.
-    await this.warnIfAllowlistWriteOnPublicCg(contextGraphId, ctx, 'inviteToContextGraph (peer)');
-
     quadsToInsert.push({
       subject: contextGraphUri,
       predicate: DKG_ONTOLOGY.DKG_ALLOWED_PEER,
@@ -14614,6 +14604,23 @@ export class DKGAgent {
     });
 
     await this.store.insert(quadsToInsert);
+
+    // Issue #865 — log a clear warning AFTER the allowlist quad has
+    // landed on a CG with an explicit `accessPolicy="public"` triple.
+    // The allowlist write is allowed (legitimate uses include
+    // populating an authorized-publisher set on a public-but-curated-
+    // publish CG), but post-#865 the publisher's
+    // `isPrivateContextGraph` no longer silently flips the CG to
+    // curated just because an allowlist was written — so the
+    // operator should know the allowlist is informational for read
+    // access on this CG.
+    //
+    // Codex review round 5 on #873 (line 17485) — call site is
+    // post-insert so the breadcrumb only fires for writes that
+    // actually hit the store. A failing `store.insert` throws to the
+    // caller before we reach this point, so the warn is a faithful
+    // record of persisted state.
+    await this.warnIfAllowlistWriteOnPublicCg(contextGraphId, ctx, 'inviteToContextGraph (peer)');
 
     if (existingAllowlist === null || existingAllowlist.length === 0) {
       this.upsertContextGraphMember({
@@ -14697,21 +14704,6 @@ export class DKGAgent {
       return;
     }
 
-    // Issue #865 — companion warning to the peer-invite path above.
-    // Allowlist writes on explicit-public CGs are allowed (the
-    // publishPolicy=curated + accessPolicy=public combination is a
-    // valid CG mode where the allowlist gates publishers, not
-    // subscribers), but the operator should know that the read-side
-    // gate stays open per the explicit `accessPolicy="public"`.
-    //
-    // Codex review on #873 (line 14061) — gated on `!alreadyAllowed`
-    // so re-approves that only refresh a delegation (allowlist quad
-    // is already there) don't emit a misleading "writing allowlist"
-    // warning either.
-    if (!alreadyAllowed) {
-      await this.warnIfAllowlistWriteOnPublicCg(contextGraphId, ctx, 'inviteAgentToContextGraph');
-    }
-
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
     const quadsToInsert: Quad[] = [];
@@ -14774,6 +14766,24 @@ export class DKGAgent {
     }
 
     await this.store.insert(quadsToInsert);
+
+    // Issue #865 — companion warning to the peer-invite path above.
+    // Allowlist writes on explicit-public CGs are allowed (the
+    // publishPolicy=curated + accessPolicy=public combination is a
+    // valid CG mode where the allowlist gates publishers, not
+    // subscribers), but the operator should know that the read-side
+    // gate stays open per the explicit `accessPolicy="public"`.
+    //
+    // Codex review round 4/5 on #873 — fires AFTER `store.insert`
+    // succeeds so the breadcrumb is a faithful record of persisted
+    // state (a failing insert throws before this point). Gated on
+    // `!alreadyAllowed` because re-approves that only refresh a
+    // delegation don't grow the allowlist, so they don't warrant
+    // the public-CG breadcrumb.
+    if (!alreadyAllowed) {
+      await this.warnIfAllowlistWriteOnPublicCg(contextGraphId, ctx, 'inviteAgentToContextGraph');
+    }
+
     this.upsertContextGraphMember({
       contextGraphId,
       principalType: 'agent',
@@ -18077,19 +18087,21 @@ export class DKGAgent {
    * has an obvious breadcrumb. Read-only, single SELECT (delegated
    * to `getExplicitAccessPolicy`) — does not mutate state.
    *
-   * Codex review on #873 — callers MUST defer this until they've
-   * confirmed an allowlist write will actually happen (i.e. AFTER
-   * the idempotency early-return). Logging when no quad is inserted
-   * misleads operators about which writes hit the store.
+   * Codex review rounds 1, 4, and 5 on #873 — callers MUST defer
+   * this until AFTER `store.insert(quadsToInsert)` succeeds. Two
+   * constraints converge on the post-insert call site:
    *
-   * Codex review round 4 on #873 (line 17475) — the warn fires
-   * BEFORE `store.insert()` is awaited, so a transient store
-   * failure would leave a breadcrumb claiming the quad was
-   * persisted when it wasn't. Wording is intentionally pre-write
-   * ("about to write" / "will be persisted") so the audit trail
-   * stays accurate whether or not the subsequent insert succeeds —
-   * the operator still gets the public-CG breadcrumb and any
-   * thrown insert error surfaces separately, no contradiction.
+   *   - Round 1 / round 4 (idempotency): logging when no quad
+   *     would be inserted (no-op re-invite) misleads operators
+   *     about which writes hit the store.
+   *   - Round 5 (state truthfulness): logging BEFORE the insert
+   *     resolves leaves a phantom breadcrumb if the insert throws.
+   *
+   * The current call sites in `inviteToContextGraph` /
+   * `inviteAgentToContextGraph` fire this AFTER the awaited insert
+   * (gated on `!alreadyAllowed` for the agent path's
+   * delegation-only refresh case), so the warn is a faithful
+   * record of persisted state and the wording is past-tense.
    */
   private async warnIfAllowlistWriteOnPublicCg(
     contextGraphId: string,
@@ -18100,8 +18112,8 @@ export class DKGAgent {
     if (policy !== 'public') return;
     this.log.warn(
       ctx,
-      `${operation}: about to write allowlist on context graph "${contextGraphId}" which has explicit accessPolicy="public". ` +
-        `The allowlist quad will be persisted but does NOT enforce read access — anyone can still subscribe. ` +
+      `${operation}: wrote allowlist quad on context graph "${contextGraphId}" which has explicit accessPolicy="public". ` +
+        `The persisted quad does NOT enforce read access — anyone can still subscribe. ` +
         `Issue #865: as of this commit, the publisher no longer auto-flips public CGs to the curated publish path ` +
         `just because an allowlist exists. If you intended to make this CG invite-only, recreate it with accessPolicy=1.`,
     );

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -18081,6 +18081,15 @@ export class DKGAgent {
    * confirmed an allowlist write will actually happen (i.e. AFTER
    * the idempotency early-return). Logging when no quad is inserted
    * misleads operators about which writes hit the store.
+   *
+   * Codex review round 4 on #873 (line 17475) — the warn fires
+   * BEFORE `store.insert()` is awaited, so a transient store
+   * failure would leave a breadcrumb claiming the quad was
+   * persisted when it wasn't. Wording is intentionally pre-write
+   * ("about to write" / "will be persisted") so the audit trail
+   * stays accurate whether or not the subsequent insert succeeds —
+   * the operator still gets the public-CG breadcrumb and any
+   * thrown insert error surfaces separately, no contradiction.
    */
   private async warnIfAllowlistWriteOnPublicCg(
     contextGraphId: string,
@@ -18091,8 +18100,8 @@ export class DKGAgent {
     if (policy !== 'public') return;
     this.log.warn(
       ctx,
-      `${operation}: writing allowlist on context graph "${contextGraphId}" which has explicit accessPolicy="public". ` +
-        `The allowlist quad is being persisted but does NOT enforce read access — anyone can still subscribe. ` +
+      `${operation}: about to write allowlist on context graph "${contextGraphId}" which has explicit accessPolicy="public". ` +
+        `The allowlist quad will be persisted but does NOT enforce read access — anyone can still subscribe. ` +
         `Issue #865: as of this commit, the publisher no longer auto-flips public CGs to the curated publish path ` +
         `just because an allowlist exists. If you intended to make this CG invite-only, recreate it with accessPolicy=1.`,
     );

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -14557,16 +14557,6 @@ export class DKGAgent {
     }
     this.assertCallerIsOwner(owner, callerAgentAddress, 'manage peer invitations');
 
-    // Issue #865 — log a clear warning when growing a peer allowlist
-    // on a CG that has an explicit `accessPolicy="public"` triple. The
-    // allowlist write is allowed (legitimate uses include populating
-    // an authorized-publisher set on a public-but-curated-publish CG),
-    // but post-#865 the publisher's `isPrivateContextGraph` no longer
-    // silently flips the CG to curated just because an allowlist was
-    // written — so the operator should know the allowlist is
-    // informational for read access on this CG.
-    await this.warnIfAllowlistWriteOnPublicCg(contextGraphId, ctx, 'inviteToContextGraph (peer)');
-
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
     const escapedPeerId = escapeSparqlLiteral(peerId);
@@ -14586,7 +14576,13 @@ export class DKGAgent {
       });
     }
 
-    // Skip if already in the allowlist (idempotent)
+    // Skip if already in the allowlist (idempotent).
+    //
+    // Codex review on #873 — the `warnIfAllowlistWriteOnPublicCg`
+    // call must come AFTER this early-return. Pre-fix, the warning
+    // ran first and logged "writing allowlist quad" even on
+    // re-invites that didn't insert anything, so operators got
+    // misleading audit trails for no-op calls.
     if (existingAllowlist?.includes(peerId)) {
       this.upsertContextGraphMember({
         contextGraphId,
@@ -14599,6 +14595,16 @@ export class DKGAgent {
       this.log.info(ctx, `Peer ${peerId} already in allowlist for "${contextGraphId}" — skipping`);
       return;
     }
+
+    // Issue #865 — log a clear warning when growing a peer allowlist
+    // on a CG that has an explicit `accessPolicy="public"` triple. The
+    // allowlist write is allowed (legitimate uses include populating
+    // an authorized-publisher set on a public-but-curated-publish CG),
+    // but post-#865 the publisher's `isPrivateContextGraph` no longer
+    // silently flips the CG to curated just because an allowlist was
+    // written — so the operator should know the allowlist is
+    // informational for read access on this CG.
+    await this.warnIfAllowlistWriteOnPublicCg(contextGraphId, ctx, 'inviteToContextGraph (peer)');
 
     quadsToInsert.push({
       subject: contextGraphUri,
@@ -17968,33 +17974,22 @@ export class DKGAgent {
   }
 
   /**
-   * Issue #865 — observability hook for the invite write paths. Emits a
-   * warn log when the caller writes an allowlist quad on a CG that
-   * carries an explicit `accessPolicy="public"` triple in `_meta` or
-   * the ontology graph. We don't throw here:
+   * Issue #865 — single source of truth for "what does this CG's
+   * explicit accessPolicy say". Returns `'public'` / `'private'` if
+   * an `accessPolicy` triple is present in either the ONTOLOGY graph
+   * or this CG's `_meta` graph, otherwise `null` (no explicit
+   * policy written — fall through to callers' legacy heuristics).
    *
-   *   1. `publishPolicy=curated` on a public-discoverable CG is a
-   *      legitimate combo (allowlist gates publishers, subscribers
-   *      stay public). Rejecting would break it.
-   *   2. The primary `isPrivateContextGraph` fix already prevents the
-   *      original bug (silent re-route to the curated publish path).
-   *   3. Pre-existing tests and adapter flows create CGs with no
-   *      explicit accessPolicy and then invite — those should keep
-   *      working.
-   *
-   * The warn line is the documentation: it tells the operator
-   * "your allowlist write landed but read access stays open per the
-   * explicit accessPolicy=public" so the next publisher confusion
-   * has an obvious breadcrumb. Read-only, single SELECT — does not
-   * mutate state.
+   * Extracted so `isPrivateContextGraph` (read-path routing) and
+   * `warnIfAllowlistWriteOnPublicCg` (write-path observability) can
+   * never drift on the policy-resolution rules. If we ever add a new
+   * policy value, the parsing fix lands in one place.
    */
-  private async warnIfAllowlistWriteOnPublicCg(
+  private async getExplicitAccessPolicy(
     contextGraphId: string,
-    ctx: OperationContext,
-    operation: string,
-  ): Promise<void> {
+  ): Promise<'public' | 'private' | null> {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
-      return;
+      return null;
     }
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
@@ -18012,9 +18007,50 @@ export class DKGAgent {
         }
       } LIMIT 1`,
     );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return;
-    const policy = result.bindings[0]?.['policy'];
-    if (policy !== '"public"') return;
+    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+    const policyValue = result.bindings[0]?.['policy'];
+    if (policyValue === '"public"') return 'public';
+    if (policyValue === '"private"') return 'private';
+    // Defensive: any unknown literal (e.g. a future policy value the
+    // older agent code doesn't recognize) is reported as `null` so
+    // callers fall through to the legacy heuristic instead of
+    // mis-routing on an opaque string.
+    return null;
+  }
+
+  /**
+   * Issue #865 — observability hook for the invite write paths. Emits a
+   * warn log when the caller writes an allowlist quad on a CG that
+   * carries an explicit `accessPolicy="public"` triple. We don't
+   * throw here:
+   *
+   *   1. `publishPolicy=curated` on a public-discoverable CG is a
+   *      legitimate combo (allowlist gates publishers, subscribers
+   *      stay public). Rejecting would break it.
+   *   2. The primary `isPrivateContextGraph` fix already prevents the
+   *      original bug (silent re-route to the curated publish path).
+   *   3. Pre-existing tests and adapter flows create CGs with no
+   *      explicit accessPolicy and then invite — those should keep
+   *      working.
+   *
+   * The warn line is the documentation: it tells the operator
+   * "your allowlist write landed but read access stays open per the
+   * explicit accessPolicy=public" so the next publisher confusion
+   * has an obvious breadcrumb. Read-only, single SELECT (delegated
+   * to `getExplicitAccessPolicy`) — does not mutate state.
+   *
+   * Codex review on #873 — callers MUST defer this until they've
+   * confirmed an allowlist write will actually happen (i.e. AFTER
+   * the idempotency early-return). Logging when no quad is inserted
+   * misleads operators about which writes hit the store.
+   */
+  private async warnIfAllowlistWriteOnPublicCg(
+    contextGraphId: string,
+    ctx: OperationContext,
+    operation: string,
+  ): Promise<void> {
+    const policy = await this.getExplicitAccessPolicy(contextGraphId);
+    if (policy !== 'public') return;
     this.log.warn(
       ctx,
       `${operation}: writing allowlist on context graph "${contextGraphId}" which has explicit accessPolicy="public". ` +
@@ -18029,22 +18065,8 @@ export class DKGAgent {
       return false;
     }
 
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(
-      `SELECT ?policy WHERE {
-        {
-          GRAPH <${ontologyGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
-          }
-        }
-      } LIMIT 1`,
-    );
 
     // Issue #865 — explicit `accessPolicy` ALWAYS wins over the allowlist
     // heuristic below. The previous behavior fell through to the ASK
@@ -18062,16 +18084,14 @@ export class DKGAgent {
     // member list, but the publisher stays on the plaintext / public
     // path so cores can verify against SWM and the on-chain tx
     // actually submits.
-    if (result.type === 'bindings' && result.bindings.length > 0) {
-      const policyValue = result.bindings[0]?.['policy'];
-      if (policyValue === '"private"') return true;
-      if (policyValue === '"public"') return false;
-      // Any other (unknown) literal value falls through to the
-      // allowlist heuristic — defensive for forward-compatibility
-      // with future policy values, but in practice the
-      // `createContextGraph` writer is the only producer and it
-      // only ever writes "public" or "private".
-    }
+    //
+    // Codex review on #873 — policy lookup now delegated to the
+    // shared `getExplicitAccessPolicy()` helper so this routing
+    // function and the invite-path warning helper can never drift.
+    const policy = await this.getExplicitAccessPolicy(contextGraphId);
+    if (policy === 'private') return true;
+    if (policy === 'public') return false;
+    // policy === null falls through to the legacy heuristic below.
 
     // Legacy / discovered-CG fallback: when no explicit `accessPolicy`
     // triple exists (e.g. an old CG materialized before the predicate

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -2954,9 +2954,21 @@ decisions: []
     });
     await agent.registerContextGraph('register-curated-policy', { callerAgentAddress: ownerAgent });
 
+    // Issue #865 — pre-#865 this case created the CG with NO explicit
+    // accessPolicy and relied on `inviteAgentToContextGraph` writing a
+    // DKG_ALLOWED_AGENT triple to silently promote the CG to curated
+    // via `isPrivateContextGraph`'s allowlist heuristic on register.
+    // That auto-promote was the rc.12 bug surfaced as the
+    // "modal said Open but CG persisted as invite-only" symptom; the
+    // heuristic now only fires when no explicit accessPolicy exists.
+    // Express the curated intent up-front so this test continues to
+    // assert the "registers as curated and forwards the allowlist as
+    // participantAgents" contract (the on-chain effect the original
+    // test was protecting).
     await agent.createContextGraph({
       id: 'register-agent-allowlist-policy',
       name: 'Agent Allowlist Policy',
+      accessPolicy: 1,
       callerAgentAddress: ownerAgent,
     });
     await agent.inviteAgentToContextGraph('register-agent-allowlist-policy', allowedAgent, ownerAgent);
@@ -2996,10 +3008,19 @@ decisions: []
     // This CG was registered via `inviteAgentToContextGraph(... allowedAgent)`
     // which writes a DKG_ALLOWED_AGENT triple; under Phase B the
     // chain registration must forward that wallet so cores can
-    // authority-check its envelopes after auto-hosting. Pre-Phase-B
-    // expectation was `[]` (only explicit participantAgents flowed);
-    // updated to assert the new superset semantics.
-    expect(chain.createOnChainContextGraphCalls[3]?.participantAgents).toEqual([allowedAgent]);
+    // authority-check its envelopes after auto-hosting.
+    //
+    // Issue #865 follow-up: because the create call now passes
+    // `accessPolicy: 1` up-front (the previous test relied on the
+    // now-removed "invite auto-promotes to curated" inference), the
+    // creator-auto-include at `dkg-agent.ts:13085` adds the curator
+    // (`ownerAgent`) to the local allowlist at create-time. The
+    // subsequent invite layers `allowedAgent` on top, so the
+    // chain-forwarded participant set is the union of both.
+    expect(chain.createOnChainContextGraphCalls[3]?.participantAgents).toEqual(
+      expect.arrayContaining([allowedAgent, ownerAgent]),
+    );
+    expect(chain.createOnChainContextGraphCalls[3]?.participantAgents).toHaveLength(2);
     expect(chain.createOnChainContextGraphCalls[4]?.accessPolicy).toBe(0);
     expect(chain.createOnChainContextGraphCalls[4]?.publishPolicy).toBe(0);
     expect(chain.createOnChainContextGraphCalls[4]?.publishAuthority).toBe(ethers.getAddress(chain.signerAddress));

--- a/packages/agent/test/issue-865-public-cg-allowlist.test.ts
+++ b/packages/agent/test/issue-865-public-cg-allowlist.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Regression coverage for issue #865 — UI "Open / publicly discoverable"
+ * choice silently persisting as curated/invite-only after a follow-up
+ * invite landed.
+ *
+ * Pre-#865 root cause: `DKGAgent.isPrivateContextGraph` fell through to
+ * an "allowlist heuristic" whenever the explicit `accessPolicy` triple
+ * was anything other than `"private"`. A user-invoked
+ * `inviteToContextGraph` / `inviteAgentToContextGraph` would then write
+ * a `DKG_ALLOWED_PEER` / `DKG_ALLOWED_AGENT` quad into `_meta`, the
+ * heuristic would flip the CG to "private" on the next probe, and the
+ * publisher would route Verifiable Memory publish through the curated
+ * LU-5 / LU-11 chunked ACK path — which hangs indefinitely waiting for
+ * invitee acknowledgements that never arrive on an actually-public CG.
+ *
+ * Post-#865: when the explicit `accessPolicy` triple says `"public"`,
+ * `isPrivateContextGraph` returns false REGARDLESS of allowlist
+ * presence. The allowlist heuristic stays as a legacy fallback only
+ * for CGs that have no explicit policy at all (the pre-V10 discovery
+ * case the original code was written for).
+ */
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
+  contextGraphDataGraphUri,
+  contextGraphMetaUri,
+} from '@origintrail-official/dkg-core';
+import { DKGAgent } from '../src/index.js';
+import { createEVMAdapter, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
+
+const CG_ID = 'issue-865-public-cg';
+const INVITEE_AGENT = '0x0000000000000000000000000000000000000865';
+const INVITEE_PEER_ID = '12D3KooWRdP3mMN9KkQCWKFjFxhgpXp8Q2y8zQZkgRYfGQ4bQh3a';
+const CONTEXT_GRAPH_URI = `did:dkg:context-graph:${CG_ID}`;
+
+async function makeAgent() {
+  const store = new OxigraphStore();
+  const agent = await DKGAgent.create({
+    name: 'Issue865Host',
+    framework: 'DKG',
+    listenPort: 0,
+    store,
+    skills: [],
+    chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+  });
+  await agent.start();
+  return { agent, store };
+}
+
+async function ownerAddress(agent: DKGAgent): Promise<string> {
+  // Mirror what the modal does: createContextGraph attributes ownership
+  // to `defaultAgentAddress` when no `callerAgentAddress` is passed.
+  // Surface it for the invite calls below so the owner check passes.
+  return (agent as unknown as { defaultAgentAddress?: string }).defaultAgentAddress
+    ?? (agent as unknown as { peerId: string }).peerId;
+}
+
+describe('Issue #865 — public CG + allowlist must not be classified as private', () => {
+  it('createContextGraph({accessPolicy: 0}) followed by inviteAgentToContextGraph keeps the CG public', async () => {
+    const { agent, store } = await makeAgent();
+    try {
+      const owner = await ownerAddress(agent);
+      await agent.createContextGraph({
+        id: CG_ID,
+        name: 'Issue 865 Public CG',
+        accessPolicy: 0,
+        callerAgentAddress: owner,
+      });
+
+      // Sanity check: the modal's "Open / publicly discoverable" choice
+      // lands as a `DKG_ACCESS_POLICY="public"` triple in the ontology
+      // graph. This is the witness the post-#865 fix keys on.
+      const policyResult = await store.query(
+        `SELECT ?policy WHERE {
+           GRAPH <${contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY)}> {
+             <${CONTEXT_GRAPH_URI}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
+           }
+         }`,
+      );
+      expect(policyResult.type).toBe('bindings');
+      if (policyResult.type === 'bindings') {
+        expect(policyResult.bindings[0]?.['policy']).toBe('"public"');
+      }
+
+      await agent.inviteAgentToContextGraph(CG_ID, INVITEE_AGENT, owner);
+
+      // The allowlist quad lands — that's still allowed (publishPolicy=
+      // curated on a public-discoverable CG is a valid combo) — but
+      // `isPrivateContextGraph` MUST not silently flip the CG to curated
+      // just because of the quad's presence. That was the rc.12 bug.
+      const allowlistResult = await store.query(
+        `ASK WHERE {
+           GRAPH <${contextGraphMetaUri(CG_ID)}> {
+             <${CONTEXT_GRAPH_URI}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?a
+           }
+         }`,
+      );
+      expect(allowlistResult.type).toBe('boolean');
+      if (allowlistResult.type === 'boolean') {
+        expect(allowlistResult.value).toBe(true);
+      }
+
+      const isPrivate = await (agent as unknown as {
+        isPrivateContextGraph(id: string): Promise<boolean>;
+      }).isPrivateContextGraph(CG_ID);
+      expect(isPrivate).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('explicit accessPolicy="public" overrides DKG_ALLOWED_PEER allowlist writes too', async () => {
+    const { agent, store } = await makeAgent();
+    try {
+      const owner = await ownerAddress(agent);
+      await agent.createContextGraph({
+        id: CG_ID,
+        name: 'Issue 865 Public CG (peer-invite variant)',
+        accessPolicy: 0,
+        callerAgentAddress: owner,
+      });
+
+      await agent.inviteToContextGraph(CG_ID, INVITEE_PEER_ID, owner);
+
+      const peerListed = await store.query(
+        `ASK WHERE {
+           GRAPH <${contextGraphMetaUri(CG_ID)}> {
+             <${CONTEXT_GRAPH_URI}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?p
+           }
+         }`,
+      );
+      expect(peerListed.type).toBe('boolean');
+      if (peerListed.type === 'boolean') {
+        expect(peerListed.value).toBe(true);
+      }
+
+      const isPrivate = await (agent as unknown as {
+        isPrivateContextGraph(id: string): Promise<boolean>;
+      }).isPrivateContextGraph(CG_ID);
+      expect(isPrivate).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('explicit accessPolicy="private" still reports curated regardless of allowlist contents', async () => {
+    // Mirror image of the previous tests — this guards against a fix
+    // that over-corrects by ignoring `accessPolicy` entirely. Explicit
+    // "private" must still win.
+    const { agent } = await makeAgent();
+    try {
+      const owner = await ownerAddress(agent);
+      await agent.createContextGraph({
+        id: CG_ID,
+        name: 'Issue 865 Private CG',
+        accessPolicy: 1,
+        allowedAgents: [owner],
+        callerAgentAddress: owner,
+      });
+
+      const isPrivate = await (agent as unknown as {
+        isPrivateContextGraph(id: string): Promise<boolean>;
+      }).isPrivateContextGraph(CG_ID);
+      expect(isPrivate).toBe(true);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('legacy CGs with no explicit accessPolicy + allowlist still report curated (back-compat with the heuristic fallback)', async () => {
+    // The pre-#865 heuristic existed for a reason: V10 CGs discovered
+    // via gossip without an ontology bootstrap genuinely have no
+    // `accessPolicy` triple, and the only available curated signal is
+    // the allowlist. The fix must preserve that fallback so the
+    // store-discovery path doesn't misclassify a legitimately curated
+    // legacy CG as open.
+    const { agent, store } = await makeAgent();
+    try {
+      const cgMetaGraph = contextGraphMetaUri(CG_ID);
+      await store.insert([
+        // Note: no DKG_ACCESS_POLICY triple. Just the allowlist quad
+        // a discovered curated CG would carry after a peer invite.
+        {
+          subject: CONTEXT_GRAPH_URI,
+          predicate: DKG_ONTOLOGY.DKG_ALLOWED_PEER,
+          object: `"${INVITEE_PEER_ID}"`,
+          graph: cgMetaGraph,
+        },
+      ]);
+
+      const isPrivate = await (agent as unknown as {
+        isPrivateContextGraph(id: string): Promise<boolean>;
+      }).isPrivateContextGraph(CG_ID);
+      expect(isPrivate).toBe(true);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+});

--- a/packages/agent/test/issue-865-public-cg-allowlist.test.ts
+++ b/packages/agent/test/issue-865-public-cg-allowlist.test.ts
@@ -223,6 +223,52 @@ describe('Issue #865 — public CG + allowlist must not be classified as private
         await agent.stop().catch(() => {});
       }
     });
+
+    // Codex review on #873 (line 14061) — sibling of the peer-path
+    // test above. The agent path (`inviteAgentToContextGraph`) had
+    // the same bug PLUS no idempotency check at all: re-inviting an
+    // already-allowed agent re-pushed the duplicate DKG_ALLOWED_AGENT
+    // quad, re-ran upsertContextGraphMember, AND fired the warn.
+    // @branarakic empirically reproduced this against the patched
+    // daemon at `704b49cf` (#873 PR comment, 2026-06-01 12:42 UTC).
+    it('inviteAgentToContextGraph re-invite of an already-allowed agent on a public CG fires the warn exactly once', async () => {
+      const warnings: string[] = [];
+      Logger.setSink((entry) => {
+        if (entry.level === 'warn') warnings.push(entry.message);
+      });
+
+      const { agent } = await makeAgent();
+      try {
+        const owner = await ownerAddress(agent);
+        await agent.createContextGraph({
+          id: CG_ID,
+          name: 'Issue 865 Public CG (agent-warn-ordering)',
+          accessPolicy: 0,
+          callerAgentAddress: owner,
+        });
+
+        await agent.inviteAgentToContextGraph(CG_ID, INVITEE_AGENT, owner);
+
+        const publicWarnsAfterFirst = warnings.filter((m) =>
+          m.includes('inviteAgentToContextGraph') &&
+          m.includes('accessPolicy="public"'),
+        );
+        expect(publicWarnsAfterFirst).toHaveLength(1);
+
+        // Second invite — agent is already in the allowlist, no
+        // delegation supplied, so the new idempotency branch must
+        // return early. Warn count stays at 1.
+        await agent.inviteAgentToContextGraph(CG_ID, INVITEE_AGENT, owner);
+
+        const publicWarnsAfterSecond = warnings.filter((m) =>
+          m.includes('inviteAgentToContextGraph') &&
+          m.includes('accessPolicy="public"'),
+        );
+        expect(publicWarnsAfterSecond).toHaveLength(1);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
   });
 
   it('legacy CGs with no explicit accessPolicy + allowlist still report curated (back-compat with the heuristic fallback)', async () => {

--- a/packages/agent/test/issue-865-public-cg-allowlist.test.ts
+++ b/packages/agent/test/issue-865-public-cg-allowlist.test.ts
@@ -19,10 +19,11 @@
  * for CGs that have no explicit policy at all (the pre-V10 discovery
  * case the original code was written for).
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   DKG_ONTOLOGY,
+  Logger,
   SYSTEM_CONTEXT_GRAPHS,
   contextGraphDataGraphUri,
   contextGraphMetaUri,
@@ -167,6 +168,61 @@ describe('Issue #865 — public CG + allowlist must not be classified as private
     } finally {
       await agent.stop().catch(() => {});
     }
+  });
+
+  // Codex review on #873 — the `warnIfAllowlistWriteOnPublicCg` call
+  // in `inviteToContextGraph` (peer path) used to run BEFORE the
+  // idempotency early-return. A no-op re-invite would log "writing
+  // allowlist quad" even though nothing got persisted, misleading
+  // operators auditing their warn stream. The fix moved the call
+  // AFTER the early-return; this test pins it.
+  describe('Codex review on #873 — warn must not fire on no-op peer re-invite', () => {
+    afterEach(() => {
+      Logger.setSink(null);
+    });
+
+    it('inviteToContextGraph re-invite of an already-allowed peer on a public CG fires the warn exactly once', async () => {
+      const warnings: string[] = [];
+      Logger.setSink((entry) => {
+        if (entry.level === 'warn') warnings.push(entry.message);
+      });
+
+      const { agent } = await makeAgent();
+      try {
+        const owner = await ownerAddress(agent);
+        await agent.createContextGraph({
+          id: CG_ID,
+          name: 'Issue 865 Public CG (warn-ordering)',
+          accessPolicy: 0,
+          callerAgentAddress: owner,
+        });
+
+        // First invite — a real allowlist write happens, so the warn
+        // MUST fire (the operator should see exactly one breadcrumb
+        // explaining the allowlist landed on a public CG).
+        await agent.inviteToContextGraph(CG_ID, INVITEE_PEER_ID, owner);
+
+        const publicWarnsAfterFirst = warnings.filter((m) =>
+          m.includes('inviteToContextGraph (peer)') &&
+          m.includes('accessPolicy="public"'),
+        );
+        expect(publicWarnsAfterFirst).toHaveLength(1);
+
+        // Second invite — peer is already in the allowlist, so the
+        // idempotency branch returns early without inserting any
+        // quad. The warn MUST NOT fire a second time, otherwise the
+        // operator's audit trail shows phantom writes.
+        await agent.inviteToContextGraph(CG_ID, INVITEE_PEER_ID, owner);
+
+        const publicWarnsAfterSecond = warnings.filter((m) =>
+          m.includes('inviteToContextGraph (peer)') &&
+          m.includes('accessPolicy="public"'),
+        );
+        expect(publicWarnsAfterSecond).toHaveLength(1);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
   });
 
   it('legacy CGs with no explicit accessPolicy + allowlist still report curated (back-compat with the heuristic fallback)', async () => {


### PR DESCRIPTION
Forward-port of [#873](https://github.com/OriginTrail/dkg/pull/873) (merged to `release/rc.12` at `872f8cb4`) onto `main`. No code differences vs. the rc.12 commits — clean cherry-pick.

## Why this needs a separate PR

The original PR was opened against `release/rc.12` and merged there. `main` doesn't auto-pull from rc.12, so the public-CG / allowlist-heuristic fix needs to land here independently before it ships in any non-rc.12 release.

## What's included

5 commits cherry-picked in original order from #873:

| rc.12 SHA | This branch SHA | Subject |
|---|---|---|
| `92c3aa89` | `00014de0` | `fix(agent): respect explicit accessPolicy="public" over allowlist heuristic (#865)` — primary fix: `isPrivateContextGraph` now lets explicit `accessPolicy` win over the allowlist heuristic, fixing the rc.12 publish-stall regression on public-but-curated CGs |
| `2ecd15bb` | `c2f5ce3a` | `refactor(agent): address Codex review on #873` — round 2: extract shared `getExplicitAccessPolicy()` helper consumed by both `isPrivateContextGraph` (read-path) and `warnIfAllowlistWriteOnPublicCg` (write-path observability) so they can't drift |
| `2003015a` | `187103c2` | `fix(agent): inviteAgentToContextGraph idempotency + warn ordering (#873, codex line 14061)` — round 3: hoist participants lookup, add `alreadyAllowed && !delegation` early-return, mirror peer-path's structure |
| `bed4c250` | `cf45ecce` | `fix(agent): pre-write warn wording on public-CG allowlist (#873, codex round 4 line 17475)` — round 4: pre-write tense to avoid phantom-write breadcrumbs (superseded by round 5 below — kept for review history) |
| `53442582` | `cb5c2fdb` | `fix(agent): defer public-CG warn until after store.insert succeeds (#873, codex round 5)` — round 5: warn deferred to after the awaited insert in both call sites; past-tense wording |

## Conflict resolution

None. All 5 commits cherry-picked clean against current main HEAD. Files touched: `packages/agent/src/dkg-agent.ts`, `packages/agent/test/issue-865-public-cg-allowlist.test.ts`. `git diff origin/release/rc.12 -- <touched files>` returns empty — byte-identical to the rc.12 state.

## Test plan

- [ ] `pnpm vitest run test/issue-865-public-cg-allowlist.test.ts` — 6/6 pass on rc.12, expect same here
- [ ] CI on this branch passes against `main`
- [ ] `Tornado: core + storage + chain` passes (was the suspect upstream regression from PR #883's wrap; should be unaffected here since the patch doesn't touch chain code)

Ref: original PR #873, issue #865.

Made with [Cursor](https://cursor.com)