### PR TITLE
fix(publisher,node-ui): rich error when promote finds an empty assertion graph (forward-port #874 → main)

### DIFF
--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -1599,6 +1599,21 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
       }
       return jsonResponse(res, 200, result);
     } catch (err: any) {
+      // Issue #864 — translate the publisher's typed "_meta says completed
+      // but data graph is empty" error into a 409 with a structured body
+      // the UI can pattern-match on. Keep it ahead of the generic 400
+      // branch so the more specific code wins. Duck-type the check by
+      // name + code so we don't have to import the publisher's error
+      // class into the cli package's compile graph.
+      if (err?.name === "AssertionNotPersistedError" || err?.code === "ASSERTION_NOT_PERSISTED") {
+        return jsonResponse(res, 409, {
+          error: err.message,
+          code: "ASSERTION_NOT_PERSISTED",
+          contextGraphId: err.contextGraphId,
+          assertionGraph: err.assertionGraph,
+          expectedTripleCount: err.expectedTripleCount,
+        });
+      }
       if (
         err.message?.includes("not found") ||
         err.message?.includes("Invalid") ||

--- a/packages/cli/test/promote-route-not-persisted.test.ts
+++ b/packages/cli/test/promote-route-not-persisted.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Regression coverage for issue #864 — the daemon-side 409
+ * `ASSERTION_NOT_PERSISTED` response envelope on
+ * `POST /api/assertion/:name/promote`.
+ *
+ * The UI in `packages/node-ui/src/ui/api.ts` (`describePromoteError`)
+ * pattern-matches on `code === "ASSERTION_NOT_PERSISTED"` to render
+ * the actionable "extracted N triples but the data graph is empty,
+ * re-import the source file" copy instead of the misleading "Promoted
+ * 0 triples" toast. This test pins the wire contract so a future
+ * refactor of the publisher's typed error or the route's catch branch
+ * cannot silently change the envelope the UI now depends on.
+ *
+ * Pattern mirrors `promote-async-routes.test.ts`: spin up a real HTTP
+ * server with `handleAssertionRoutes`, hand it a minimal mock agent
+ * whose `assertion.promote` throws a synthetic error matching what
+ * `DKGPublisher.assertionPromote` throws (duck-typed by `name` +
+ * `code` — same shape the daemon catch branch matches). No publisher
+ * dependency needed: the test asserts the route's translation, not
+ * the publisher's throwing logic (the publisher has its own dedicated
+ * tests in `packages/publisher/test/draft-lifecycle.test.ts`).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { handleAssertionRoutes } from '../src/daemon/routes/assertion.js';
+
+const CG_ID = 'issue-864-cg';
+const ASSERTION_NAME = 'orphan-assertion';
+const ASSERTION_GRAPH = `did:dkg:context-graph:${CG_ID}/main/assertion/did:dkg:agent:test/${ASSERTION_NAME}`;
+const EXPECTED_TRIPLE_COUNT = 49;
+
+class FakeAssertionNotPersistedError extends Error {
+  readonly name = 'AssertionNotPersistedError';
+  readonly code = 'ASSERTION_NOT_PERSISTED';
+  readonly contextGraphId: string;
+  readonly assertionGraph: string;
+  readonly expectedTripleCount: number;
+  constructor() {
+    super(
+      `Assertion data graph <${ASSERTION_GRAPH}> is empty, but its _meta record ` +
+        `reports extractionStatus="completed" with structuralTripleCount=${EXPECTED_TRIPLE_COUNT}. ` +
+        `The extracted triples were never persisted (or have been deleted) so promote has nothing to move. ` +
+        `Re-import the source file or re-write the assertion before promoting.`,
+    );
+    this.contextGraphId = CG_ID;
+    this.assertionGraph = ASSERTION_GRAPH;
+    this.expectedTripleCount = EXPECTED_TRIPLE_COUNT;
+  }
+}
+
+describe('POST /api/assertion/:name/promote — issue #864 not-persisted envelope', () => {
+  let server: Server | undefined;
+  let baseUrl: string;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server!.close((err) => (err ? reject(err) : resolve()));
+      });
+      server = undefined;
+    }
+  });
+
+  async function startWithPromoteImpl(
+    promote: (cgId: string, name: string, opts: unknown) => Promise<{ promotedCount: number }>,
+  ) {
+    const agent = {
+      async listContextGraphs() {
+        return [{
+          id: CG_ID,
+          uri: `did:dkg:context-graph:${CG_ID}`,
+          name: CG_ID,
+          subscribed: true,
+          synced: true,
+        }];
+      },
+      async contextGraphExists(cgId: string) {
+        return cgId === CG_ID;
+      },
+      assertion: {
+        promote,
+      },
+    };
+    server = createServer(async (req, res) => {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      try {
+        await handleAssertionRoutes({
+          req,
+          res,
+          agent,
+          publisherControl: {},
+          publisherRuntime: null,
+          config: {},
+          startedAt: Date.now(),
+          dashDb: {},
+          opWallets: {},
+          network: {},
+          tracker: {},
+          memoryManager: {},
+          bridgeAuthToken: undefined,
+          nodeVersion: 'test',
+          nodeCommit: 'test',
+          catchupTracker: { jobs: new Map(), latestByContextGraph: new Map() },
+          extractionRegistry: {},
+          fileStore: {},
+          extractionStatus: new Map(),
+          assertionImportLocks: new Map(),
+          vectorStore: {},
+          embeddingProvider: null,
+          validTokens: new Set(),
+          apiHost: '127.0.0.1',
+          apiPortRef: { value: 0 },
+          url,
+          path: url.pathname,
+          requestToken: undefined,
+          requestAgentAddress: 'did:dkg:agent:test',
+          emitMemoryGraphChanged: () => {},
+        } as any);
+        if (!res.writableEnded) {
+          res.statusCode = 404;
+          res.end();
+        }
+      } catch (err: any) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: `Unhandled: ${err?.message ?? err}` }));
+      }
+    });
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+    const addr = server!.address();
+    if (!addr || typeof addr === 'string') throw new Error('server did not bind');
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  }
+
+  async function postPromote(body: Record<string, unknown>) {
+    const res = await fetch(`${baseUrl}/api/assertion/${ASSERTION_NAME}/promote`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const json = await res.json().catch(() => null);
+    return { status: res.status, body: json };
+  }
+
+  it('translates AssertionNotPersistedError to a 409 with the structured body the UI expects', async () => {
+    await startWithPromoteImpl(async () => {
+      throw new FakeAssertionNotPersistedError();
+    });
+
+    const res = await postPromote({ contextGraphId: CG_ID, entities: 'all' });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      // The publisher's full error message is forwarded so debug
+      // tools / curl users get the same explanation the UI builds
+      // via `describePromoteError`.
+      error: expect.stringContaining('Re-import the source file or re-write the assertion before promoting.'),
+      // UI matches on this exact code in `describePromoteError`.
+      // Changing the literal here breaks the toast translation.
+      code: 'ASSERTION_NOT_PERSISTED',
+      contextGraphId: CG_ID,
+      assertionGraph: ASSERTION_GRAPH,
+      expectedTripleCount: EXPECTED_TRIPLE_COUNT,
+    });
+  });
+
+  it('also matches when only the .code is set (defensive: ducktype fallback)', async () => {
+    // The route's catch branch checks `err?.name === "AssertionNotPersistedError" ||
+    // err?.code === "ASSERTION_NOT_PERSISTED"`. Cover the second arm so a
+    // future tidy that drops the named class but keeps the code still
+    // routes through the structured envelope path.
+    await startWithPromoteImpl(async () => {
+      const err = new Error('data graph empty, expected 7') as Error & {
+        code?: string;
+        contextGraphId?: string;
+        assertionGraph?: string;
+        expectedTripleCount?: number;
+      };
+      err.code = 'ASSERTION_NOT_PERSISTED';
+      err.contextGraphId = CG_ID;
+      err.assertionGraph = ASSERTION_GRAPH;
+      err.expectedTripleCount = 7;
+      throw err;
+    });
+
+    const res = await postPromote({ contextGraphId: CG_ID, entities: 'all' });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      code: 'ASSERTION_NOT_PERSISTED',
+      contextGraphId: CG_ID,
+      assertionGraph: ASSERTION_GRAPH,
+      expectedTripleCount: 7,
+    });
+  });
+
+  it('returns 200 with the publisher result for a normal promote', async () => {
+    // Sanity: the new 409 branch must not steal happy-path responses.
+    await startWithPromoteImpl(async () => ({ promotedCount: 49 }));
+
+    const res = await postPromote({ contextGraphId: CG_ID, entities: 'all' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ promotedCount: 49 });
+  });
+
+  it('returns 200 with promotedCount=0 for a legitimately empty promote (no error thrown)', async () => {
+    // The publisher returns `{ promotedCount: 0 }` (does NOT throw) when
+    // the data graph is empty AND `_meta` either has no extraction
+    // record or says structuralTripleCount=0. The route must forward
+    // that 200 as-is — the UI's `describePromoteResult` handles the
+    // user-facing "nothing to promote" copy. If the route accidentally
+    // mapped 0-count to 409, every freshly-created empty draft would
+    // light up as "ASSERTION_NOT_PERSISTED".
+    await startWithPromoteImpl(async () => ({ promotedCount: 0 }));
+
+    const res = await postPromote({ contextGraphId: CG_ID, entities: 'all' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ promotedCount: 0 });
+  });
+});

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -706,6 +706,64 @@ export const promoteAssertion = (
     { contextGraphId, entities, ...(subGraphName ? { subGraphName } : {}) },
   );
 
+// Issue #864 — central UI translator for `promoteAssertion` outcomes so
+// every call-site speaks the same language. Two shapes get massaged
+// here that the bare-promotedCount path used to render confusingly:
+//
+//   • `promotedCount === 0` is technically a success but normally
+//     means "the assertion graph was already empty when promote ran"
+//     (already-promoted re-click, discarded draft, or — the rc.12
+//     bug from issue #864 — a transient state where _meta indicates
+//     persistence but the data graph isn't visible yet). Surface that
+//     ambiguity instead of the misleading literal "Promoted 0 triples
+//     to Shared Memory" toast.
+//   • An HttpError with `body.code === 'ASSERTION_NOT_PERSISTED'`
+//     (the new 409 from the /promote route) means we caught the
+//     inconsistency on the daemon side. Re-render the daemon's hint
+//     as a UI-friendly sentence that includes the expected count so
+//     the user understands re-import is the recovery path.
+export type PromoteOutcome =
+  | { kind: 'success'; promotedCount: number; message: string }
+  | { kind: 'noop'; message: string }
+  | { kind: 'not-persisted'; message: string; expectedTripleCount?: number };
+
+export function describePromoteResult(
+  assertionName: string,
+  res: { promotedCount: number },
+): PromoteOutcome {
+  if (res.promotedCount > 0) {
+    return {
+      kind: 'success',
+      promotedCount: res.promotedCount,
+      message: `Promoted ${res.promotedCount} triple${res.promotedCount === 1 ? '' : 's'} from ${assertionName} to Shared Working Memory.`,
+    };
+  }
+  return {
+    kind: 'noop',
+    message: `${assertionName} had no triples to promote. It may already be in Shared Working Memory, or the extracted content is still being committed — refresh and try again.`,
+  };
+}
+
+export function describePromoteError(
+  assertionName: string,
+  err: unknown,
+): PromoteOutcome | null {
+  if (err instanceof HttpError && err.status === 409) {
+    const body = err.body as { code?: string; expectedTripleCount?: number } | undefined;
+    if (body?.code === 'ASSERTION_NOT_PERSISTED') {
+      const expected = typeof body.expectedTripleCount === 'number' ? body.expectedTripleCount : undefined;
+      return {
+        kind: 'not-persisted',
+        expectedTripleCount: expected,
+        message: expected
+          ? `${assertionName} was imported with ${expected} extracted triple${expected === 1 ? '' : 's'} but the data graph is empty. Re-import the source file (or re-write the assertion) before promoting.`
+          : `${assertionName}'s data graph is empty but its extraction metadata says it should hold content. Re-import the source file before promoting.`,
+      };
+    }
+  }
+  return null;
+}
+
 // --- File preview ---
 
 export interface ExtractionStatus {

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -703,7 +703,25 @@ export async function listAssertions(
   // already uses brings the assertion partitions back into `GRAPH ?g`
   // expansion. Same `/api/query` route, same `postQueryDeduped` cache,
   // same privacy/cost envelope as the dashboard counters.
-  const sparql = `SELECT DISTINCT ?g (COUNT(?s) AS ?cnt) WHERE { GRAPH ?g { ?s ?p ?o } } GROUP BY ?g`;
+  // Codex review on #898 — listing WM by raw `GRAPH ?g { ?s ?p ?o }`
+  // counts re-listed promoted assertions because `assertionPromote`
+  // intentionally leaves daemon-owned `urn:dkg:file:*` /
+  // `urn:dkg:extraction:*` quads behind in the assertion data graph
+  // (publisher Bug 8 / Round 9 Bug 25 import-bookkeeping filter), so
+  // those graphs stay non-empty after promote even though the
+  // lifecycle in `_meta` has flipped to `dkg:memoryLayer "SWM"`. The
+  // UI was therefore offering Promote on assertions that were no
+  // longer in WM. Derive WM membership from the lifecycle marker the
+  // publisher itself owns: `<assertionGraphUri> dkg:memoryLayer "WM"`
+  // in `<cg>/_meta` (set by `assertionCreate`, flipped to "SWM" by
+  // `assertionPromote`). The OPTIONAL keeps WM rows visible even when
+  // the data graph is genuinely empty (fresh create with no writes
+  // yet), matching the prior listing semantics for that case.
+  const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
+  const sparql = `SELECT ?g (COUNT(?s) AS ?cnt) WHERE {
+    GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" }
+    OPTIONAL { GRAPH ?g { ?s ?p ?o } }
+  } GROUP BY ?g`;
   const data = await postQueryDeduped({
     sparql,
     contextGraphId,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1,5 +1,3 @@
-import { subGraphFromAssertionGraphUri } from './lib/sub-graph-uri.js';
-
 const BASE = '';
 declare global {
   interface Window { __DKG_TOKEN__?: string; }
@@ -77,10 +75,14 @@ async function del<T>(path: string): Promise<T> {
 export const fetchStatus = () => get<any>('/api/status');
 
 // --- LLM Settings ---
-// NOTE: the LLM settings CLIENT exports (fetchLlmSettings/updateLlmSettings)
-// were removed with the Settings LLM section (Settings cleanup). The daemon
-// route /api/settings/llm + llmSettings plumbing STAY — they gate import/
-// entity-extraction (routes/memory.ts, routes/epcis.ts). UI-only removal.
+export interface LlmSettingsResponse {
+  configured: boolean;
+  model?: string;
+  baseURL?: string;
+}
+export const fetchLlmSettings = () => get<LlmSettingsResponse>('/api/settings/llm');
+export const updateLlmSettings = (data: { apiKey?: string; model?: string; baseURL?: string; clear?: boolean }) =>
+  put<LlmSettingsResponse & { ok: boolean }>('/api/settings/llm', data);
 export const fetchRetentionSettings = () => get<{ retentionDays: number }>('/api/settings/retention');
 export const updateRetentionSettings = (retentionDays: number) =>
   put<{ ok: boolean; retentionDays: number }>('/api/settings/retention', { retentionDays });
@@ -330,6 +332,67 @@ export const approveJoinRequest = (contextGraphId: string, agentAddress: string)
 
 export const rejectJoinRequest = (contextGraphId: string, agentAddress: string) =>
   post<{ ok: boolean; status: string; agentAddress: string }>(`/api/context-graph/${encodeURIComponent(contextGraphId)}/reject-join`, { agentAddress });
+
+// --- Catch-up sync jobs ---
+export interface CatchupStatusResponse {
+  jobId: string;
+  contextGraphId: string;
+  includeSharedMemory: boolean;
+  /**
+   * `unreachable` is the V10 terminal status emitted when the daemon
+   * subscribed and ran the catchup, but no peer could deliver the CG
+   * content (curator offline, no node holds the CG, or transport
+   * failures across the whole peer set). Distinct from `denied`
+   * (responder explicitly refused) so the UI can render targeted
+   * copy + a "send signed join request" CTA.
+   */
+  status: 'queued' | 'running' | 'done' | 'denied' | 'failed' | 'unreachable';
+  queuedAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+  result?: {
+    connectedPeers: number;
+    syncCapablePeers: number;
+    peersTried: number;
+    /** See `unreachable` above; subset of `peersTried` that responded without failure or denial. */
+    peersSucceeded: number;
+    dataSynced: number;
+    sharedMemorySynced: number;
+    denied: boolean;
+    deniedPeers: number;
+    diagnostics?: {
+      noProtocolPeers: number;
+      durable: {
+        fetchedMetaTriples: number;
+        fetchedDataTriples: number;
+        insertedMetaTriples: number;
+        insertedDataTriples: number;
+        bytesReceived: number;
+        resumedPhases: number;
+        emptyResponses: number;
+        metaOnlyResponses: number;
+        dataRejectedMissingMeta: number;
+        rejectedKcs: number;
+        failedPeers: number;
+      };
+      sharedMemory: {
+        fetchedMetaTriples: number;
+        fetchedDataTriples: number;
+        insertedMetaTriples: number;
+        insertedDataTriples: number;
+        bytesReceived: number;
+        resumedPhases: number;
+        emptyResponses: number;
+        droppedDataTriples: number;
+        failedPeers: number;
+      };
+    };
+  };
+  error?: string;
+}
+
+export const fetchCatchupStatus = (contextGraphId: string) =>
+  get<CatchupStatusResponse>(`/api/sync/catchup-status?contextGraphId=${encodeURIComponent(contextGraphId)}`);
 
 // --- File import to Working Memory ---
 export interface ImportFileResult {
@@ -617,68 +680,70 @@ export async function listAssertions(
 
   // layer === 'wm'
   //
-  // #844 regression fix — the prior WM listing enumerated data graphs via
-  // `SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }`. Merge #844 gated
-  // that whole-store `GRAPH ?g` enumeration in the WM view behind the
-  // `includeContextGraphPartitions` flag (which `listAssertions` does not
-  // set), so the WM view returned no assertion data-graphs and the
-  // Assertions subtab went empty.
-  //
-  // Derive WM assertions from the `<cg>/_meta` lifecycle graph instead —
-  // the same source of truth the SWM branch uses (just `_meta` rather than
-  // `_shared_memory_meta`). Each WM assertion is recorded by
-  // `generateAssertionCreatedMetadata` as a `dkg:Assertion` entity carrying
-  // `dkg:assertionName`, `dkg:assertionGraph`, and a MUTABLE
-  // `dkg:memoryLayer` literal whose value is the assertion's CURRENT layer.
-  // `MemoryLayer.WorkingMemory` is `"WM"`; on promote the lifecycle writer
-  // flips it to `"SWM"` — so filtering on `dkg:memoryLayer "WM"` yields
-  // exactly the not-yet-promoted assertions (promoted ones correctly drop
-  // out of the WM list). The explicit `GRAPH <…/_meta> { … }` makes the
-  // query self-scoping (the engine's `wrapWithGraph` early-returns when the
-  // SPARQL already names a graph), so it runs raw — same shape as the SWM
-  // branch above. `graphUri` is the lifecycle URN (`?assertion`), matching
-  // the SWM branch and what promote/preview lookups key on (name + subGraph).
-  const DKG = 'http://dkg.io/ontology/';
-  const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
-  const sparql = `SELECT DISTINCT ?assertion ?name ?sg ?assertionGraph WHERE {
-    GRAPH <${metaGraph}> {
-      ?assertion a <${DKG}Assertion> ;
-                 <${DKG}memoryLayer> "WM" ;
-                 <${DKG}assertionName> ?name .
-      OPTIONAL { ?assertion <${DKG}subGraphName> ?sg }
-      OPTIONAL { ?assertion <${DKG}assertionGraph> ?assertionGraph }
-    }
-  }`;
-  const data = await executeQuery(sparql, contextGraphId);
+  // #864 rc.12 follow-up — without `includeContextGraphPartitions`, the
+  // daemon's contextGraphId-scoped routing (DKGQueryEngine.query, the
+  // `effectiveContextGraphId && !options?.view` branch) restricts
+  // `GRAPH ?g { … }` reads to the static allow-list
+  //   { <cg>, <cg>/_meta, <cg>/_shared_memory_meta }
+  // via `constrainGraphVariablesToAllowedSet`. Every WM assertion lives
+  // in a content partition (`<cg>/assertion/<agent>/<name>` or the
+  // sub-graph variant `<cg>/<sg>/assertion/<agent>/<name>`) — none of
+  // which are in that allow-list — so this enumeration came back empty
+  // for any CG no matter how many assertions actually existed.
+  // Downstream that surfaced as:
+  //   - `AssertionsList` rendered "no assertions" right after import.
+  //   - `LayerActionsWidget` showed the correct "Promote N to SWM" badge
+  //     (the count comes from `useMemoryEntities`, which already opts
+  //     into `includeContextGraphPartitions`), but on click its
+  //     `handleAction` loop iterated zero times and hit the no-op
+  //     bulk-promote branch — the exact "0 triples promoted" symptom
+  //     the rc.12 issue reported even after the publisher-side
+  //     `AssertionNotPersistedError` fix landed.
+  // Opting into the same partition-aware scope `useMemoryEntities`
+  // already uses brings the assertion partitions back into `GRAPH ?g`
+  // expansion. Same `/api/query` route, same `postQueryDeduped` cache,
+  // same privacy/cost envelope as the dashboard counters.
+  const sparql = `SELECT DISTINCT ?g (COUNT(?s) AS ?cnt) WHERE { GRAPH ?g { ?s ?p ?o } } GROUP BY ?g`;
+  const data = await postQueryDeduped({
+    sparql,
+    contextGraphId,
+    includeContextGraphPartitions: true,
+  });
   const bindings: any[] = data?.result?.bindings ?? [];
-  const seen = new Set<string>();
+  // #706 fix — the prior `startsWith('did:dkg:context-graph:<cg>/assertion/')`
+  // shape silently dropped sub-graph-scoped WM assertions, whose graph
+  // URI is `did:dkg:context-graph:<cg>/<sg>/assertion/<agent>/<name>`
+  // (the sub-graph segment sits between `<cg>/` and `/assertion/`).
+  // We accept exactly two shapes, post-cgPrefix:
+  //   root-bucket : ['assertion', <agent>, <name>]            (3 segs)
+  //   sub-graph   : [<subGraphName>, 'assertion', <agent>, <name>] (4 segs)
+  // Anything else (extra segments on either side, internal meta
+  // graphs sharing the prefix, etc.) is silently dropped. The parse
+  // is deliberately strict so a row never gets admitted with a
+  // mis-derived name — promote/preview lookups key on `name` and
+  // would silently miss otherwise. The cgId itself is treated as
+  // opaque (it may contain `/assertion/` as a literal substring,
+  // per `validateContextGraphId`).
+  const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
   const result: AssertionInfo[] = [];
   for (const b of bindings) {
-    const lifecycle = bv(b.assertion);
-    const name = bv(b.name);
-    if (!lifecycle || !name) continue;
-    // Sub-graph scope: prefer the explicit `dkg:subGraphName` literal
-    // (emitted by the lifecycle writer for sub-graph-scoped assertions
-    // since #710). Drafts created BEFORE #710 carry `dkg:assertionGraph`
-    // but NO `dkg:subGraphName`, so fall back to parsing the sub-graph
-    // segment out of the assertion-graph URI — same migration fallback
-    // the lifecycle hook uses (`subGraphFromAssertionGraphUri`). Without
-    // it, a pre-#710 sub-graph draft would surface as root-bucket and
-    // mis-scope promote/preview lookups.
-    const assertionGraph = bv(b.assertionGraph);
-    const subGraph =
-      bv(b.sg) ||
-      (assertionGraph
-        ? subGraphFromAssertionGraphUri(assertionGraph, contextGraphId)
-        : undefined) ||
-      undefined;
-    if (seen.has(lifecycle)) continue;
-    seen.add(lifecycle);
-    // Mirror the SWM branch: no per-assertion triple count (the data-graph
-    // COUNT was exactly the gated enumeration; the renderer already guards
-    // `tripleCount != null`, so the count chip is simply omitted for WM —
-    // consistent with SWM rows).
-    result.push({ name, graphUri: lifecycle, subGraph });
+    const g = typeof b.g === 'string' ? b.g : b.g?.value;
+    if (!g || !g.startsWith(cgPrefix)) continue;
+    const segments = g.slice(cgPrefix.length).split('/');
+    let subGraph: string | undefined;
+    let name: string;
+    if (segments.length === 3 && segments[0] === 'assertion') {
+      subGraph = undefined;
+      name = segments[2];
+    } else if (segments.length === 4 && segments[1] === 'assertion') {
+      subGraph = segments[0];
+      name = segments[3];
+    } else {
+      continue;
+    }
+    if (!name) continue;
+    const cnt = typeof b.cnt === 'string' ? parseInt(b.cnt, 10) : (b.cnt?.value ? parseInt(b.cnt.value, 10) : undefined);
+    result.push({ name, graphUri: g, tripleCount: Number.isFinite(cnt) ? cnt : undefined, subGraph });
   }
   return result;
 }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -3531,6 +3531,12 @@ button.v10-notif-row:hover { background: var(--bg-hover); }
 .v10-promote-result { padding: 8px 12px; font-size: 12px; }
 .v10-promote-result.success { color: var(--text-success); background: rgba(34,197,94,.06); }
 .v10-promote-result.error { color: var(--text-danger); background: rgba(239,68,68,.06); }
+/* Issue #864 (Codex review on #874) — the `info` variant now backs
+   the no-op promote outcome ("Nothing to promote — already up to
+   date"). Without this rule the message rendered with bare base
+   styling, indistinguishable from a stray <div>. Muted grey-blue so
+   it reads as informational, not success / not error. */
+.v10-promote-result.info { color: var(--text-secondary); background: rgba(59,130,246,.06); }
 
 /* ── Publish Panel (SWM → VM) ── */
 .v10-publish-panel {

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useCallback, lazy, Suspense } from 'react';
 import { useFetch } from '../hooks.js';
-import { executeQuery, listAssertions, promoteAssertion, publishSharedMemory, listSwmEntities, type AssertionInfo, type PublishResult, type SwmRootEntity } from '../api.js';
+import { executeQuery, listAssertions, promoteAssertion, publishSharedMemory, listSwmEntities, describePromoteResult, describePromoteError, type AssertionInfo, type PublishResult, type SwmRootEntity } from '../api.js';
 import { FilePreviewModal } from '../components/Modals/FilePreviewModal.js';
 import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
 import { memoryGraphLabels } from '../lib/memoryLabels.js';
@@ -402,8 +402,16 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
   // copy can disambiguate which partition was promoted. Two rows
   // labeled `draft` (one root, one sub-graph) would otherwise emit
   // the same message and leave the user guessing.
-  const [promoteResult, setPromoteResult] = useState<{ name: string; count: number; subGraph?: string } | null>(null);
-  const [promoteError, setPromoteError] = useState<string | null>(null);
+  // Issue #864 — render the unified `PromoteOutcome` so success, no-op,
+  // and ASSERTION_NOT_PERSISTED 409 responses each get their own
+  // contextual message, instead of the legacy "Promoted 0 triples"
+  // string that hid every failure mode behind a fake success.
+  const [promoteResult, setPromoteResult] = useState<{
+    message: string;
+    kind: 'success' | 'noop';
+    subGraph?: string;
+  } | null>(null);
+  const [promoteError, setPromoteError] = useState<{ message: string; kind: 'not-persisted' | 'other' } | null>(null);
   // PR #710 Fix E — preview state carries the sub-graph slug too so
   // `FilePreviewModal` can pass it through to the daemon's
   // `/extraction-status` route. Pre-fix, clicking a sub-graph
@@ -420,11 +428,21 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
       // `(cg, name, subGraph)` lookup hits the right partition;
       // mirrors the AssertionsList fix in components.tsx.
       const res = await promoteAssertion(contextGraphId, assertion.name, 'all', assertion.subGraph);
-      setPromoteResult({ name: assertion.name, count: res.promotedCount, subGraph: assertion.subGraph });
+      const outcome = describePromoteResult(assertion.name, res);
+      setPromoteResult({
+        message: outcome.message + (assertion.subGraph ? ` (in ${assertion.subGraph})` : ''),
+        kind: outcome.kind === 'success' ? 'success' : 'noop',
+        subGraph: assertion.subGraph,
+      });
       refresh();
       onPromoted();
     } catch (err: any) {
-      setPromoteError(err.message ?? 'Promote failed');
+      const typed = describePromoteError(assertion.name, err);
+      setPromoteError(
+        typed
+          ? { message: typed.message, kind: 'not-persisted' }
+          : { message: err?.message ?? 'Promote failed', kind: 'other' },
+      );
     } finally {
       setPromoting(null);
     }
@@ -436,17 +454,30 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
     setPromoteResult(null);
     setPromoteError(null);
     let totalPromoted = 0;
+    let noopCount = 0;
     try {
       for (const a of assertions) {
         // PR #710 — see comment on the single-row handler above.
         const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
         totalPromoted += res.promotedCount;
+        if (res.promotedCount === 0) noopCount += 1;
       }
-      setPromoteResult({ name: 'all assertions', count: totalPromoted });
+      const tail = noopCount > 0 ? ` (${noopCount} assertion${noopCount === 1 ? '' : 's'} had nothing to promote)` : '';
+      setPromoteResult({
+        message: totalPromoted > 0
+          ? `Promoted ${totalPromoted} triple${totalPromoted === 1 ? '' : 's'} across ${assertions.length} assertion${assertions.length === 1 ? '' : 's'}.${tail}`
+          : `No triples were promoted — every assertion was already in Shared Working Memory or its content has not been committed yet.`,
+        kind: totalPromoted > 0 ? 'success' : 'noop',
+      });
       refresh();
       onPromoted();
     } catch (err: any) {
-      setPromoteError(err.message ?? 'Promote failed');
+      const typed = describePromoteError('selected assertion', err);
+      setPromoteError(
+        typed
+          ? { message: typed.message, kind: 'not-persisted' }
+          : { message: err?.message ?? 'Promote failed', kind: 'other' },
+      );
     } finally {
       setPromoting(null);
     }
@@ -506,14 +537,13 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
         ))}
       </div>
       {promoteResult && (
-        <div className="v10-promote-result success">
-          Promoted {promoteResult.count} triples from {promoteResult.name}
-          {promoteResult.subGraph ? ` (in ${promoteResult.subGraph})` : ''} to Shared Working Memory.
+        <div className={promoteResult.kind === 'success' ? 'v10-promote-result success' : 'v10-promote-result info'}>
+          {promoteResult.message}
         </div>
       )}
       {promoteError && (
         <div className="v10-promote-result error">
-          {promoteError}
+          {promoteError.message}
         </div>
       )}
 

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -455,8 +455,15 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
     setPromoteError(null);
     let totalPromoted = 0;
     let noopCount = 0;
+    // Issue #864 (Codex review on #874) — capture the in-flight
+    // assertion name so a mid-loop failure surfaces "<name>: …"
+    // instead of the generic "selected assertion …". Without this,
+    // bulk promote with a 409 ASSERTION_NOT_PERSISTED on one item
+    // gave the user no way to tell which draft needs re-importing.
+    let currentAssertion: string | null = null;
     try {
       for (const a of assertions) {
+        currentAssertion = a.name;
         // PR #710 — see comment on the single-row handler above.
         const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
         totalPromoted += res.promotedCount;
@@ -472,7 +479,7 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
       refresh();
       onPromoted();
     } catch (err: any) {
-      const typed = describePromoteError('selected assertion', err);
+      const typed = describePromoteError(currentAssertion ?? 'selected assertion', err);
       setPromoteError(
         typed
           ? { message: typed.message, kind: 'not-persisted' }

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -6,7 +6,7 @@ import { encodeDocTabId, resolveDocRef } from '../../lib/doc-tab-id.js';
 import { truncateMiddle } from '../../lib/truncate.js';
 import {
   listJoinRequests, approveJoinRequest, rejectJoinRequest,
-  listAssertions, promoteAssertion,
+  listAssertions, promoteAssertion, describePromoteResult, describePromoteError,
   publishSharedMemory, listSwmEntities, executeQuery,
   writeProfileQueryCatalog,
   fetchSubGraphs,
@@ -1816,13 +1816,23 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
       if (isWm) {
         const assertions = await listAssertions(contextGraphId, 'wm');
         let promoted = 0;
+        let noopCount = 0;
         for (const a of assertions) {
           // PR #710 — thread `subGraph` so sub-graph-scoped assertions
           // hit the correct daemon lookup key `(cg, name, subGraph)`.
           const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
           promoted += res.promotedCount;
+          if (res.promotedCount === 0) noopCount += 1;
         }
-        setResult(`Promoted ${promoted} triple${promoted !== 1 ? 's' : ''} to Shared Memory`);
+        // Issue #864 — flag the "nothing was actually moved" case so
+        // users on the bulk-promote widget aren't lied to by a
+        // "Promoted 0 triples" success toast.
+        if (promoted > 0) {
+          const tail = noopCount > 0 ? ` (${noopCount} had nothing to promote)` : '';
+          setResult(`Promoted ${promoted} triple${promoted !== 1 ? 's' : ''} to Shared Memory${tail}`);
+        } else {
+          setResult('No triples were promoted — every assertion was already in Shared Memory or its content is still being committed.');
+        }
       } else {
         const roots = requireSinglePublishRoot(entities.map((entity) => entity.uri));
         await publishSharedMemory(contextGraphId, roots);
@@ -1830,7 +1840,8 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
       }
       onComplete?.();
     } catch (err: any) {
-      setError(err.message ?? 'Action failed');
+      const typed = describePromoteError('an assertion', err);
+      setError(typed ? typed.message : (err?.message ?? 'Action failed'));
     } finally {
       setBusy(false);
     }
@@ -2964,7 +2975,11 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
         // sub-graph partition resolves to that partition's
         // assertion, not a same-named root one.
         const res = await promoteAssertion(contextGraphId, assertion.name, 'all', assertion.subGraph);
-        setResult(`Promoted ${res.promotedCount} triples to Shared Memory`);
+        // Issue #864 — fan the promote response through the central
+        // describe helper so 0-count returns get an actionable hint
+        // instead of the misleading "Promoted 0 triples" toast.
+        const outcome = describePromoteResult(assertion.name, res);
+        setResult(outcome.message);
       } else {
         const roots = await fetchSingleSwmRoot(contextGraphId);
         await publishSharedMemory(contextGraphId, roots);
@@ -2973,7 +2988,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
       refresh();
       onComplete();
     } catch (err: any) {
-      setError(err.message ?? 'Action failed');
+      const typed = describePromoteError(assertion.name, err);
+      setError(typed ? typed.message : (err?.message ?? 'Action failed'));
     } finally {
       setBusy(null);
     }
@@ -2987,12 +3003,21 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
     try {
       if (layer === 'wm') {
         let total = 0;
+        let noopCount = 0;
         for (const a of assertions) {
           // PR #710 — see comment on the single-row handler above.
           const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
           total += res.promotedCount;
+          if (res.promotedCount === 0) noopCount += 1;
         }
-        setResult(`Promoted ${total} triples across ${assertions.length} assertion${assertions.length !== 1 ? 's' : ''}`);
+        // Issue #864 — distinguish "some moved, some no-ops" from
+        // "literally nothing moved" so the user gets the truth.
+        if (total > 0) {
+          const tail = noopCount > 0 ? ` (${noopCount} had nothing to promote)` : '';
+          setResult(`Promoted ${total} triples across ${assertions.length} assertion${assertions.length !== 1 ? 's' : ''}${tail}`);
+        } else {
+          setResult('No triples were promoted — every assertion was already in Shared Memory or its content is still being committed.');
+        }
       } else {
         const roots = await fetchSingleSwmRoot(contextGraphId);
         await publishSharedMemory(contextGraphId, roots);
@@ -3001,7 +3026,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
       refresh();
       onComplete();
     } catch (err: any) {
-      setError(err.message ?? 'Action failed');
+      const typed = describePromoteError('selected assertion', err);
+      setError(typed ? typed.message : (err?.message ?? 'Action failed'));
     } finally {
       setBusy(null);
     }

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -1812,12 +1812,17 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
     setBusy(true);
     setError(null);
     setResult(null);
+    // Issue #864 (Codex review on #874) — track the in-flight
+    // assertion so mid-loop failures surface "<name>: …" instead of
+    // the generic "an assertion …".
+    let currentAssertion: string | null = null;
     try {
       if (isWm) {
         const assertions = await listAssertions(contextGraphId, 'wm');
         let promoted = 0;
         let noopCount = 0;
         for (const a of assertions) {
+          currentAssertion = a.name;
           // PR #710 — thread `subGraph` so sub-graph-scoped assertions
           // hit the correct daemon lookup key `(cg, name, subGraph)`.
           const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
@@ -1840,7 +1845,7 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
       }
       onComplete?.();
     } catch (err: any) {
-      const typed = describePromoteError('an assertion', err);
+      const typed = describePromoteError(currentAssertion ?? 'an assertion', err);
       setError(typed ? typed.message : (err?.message ?? 'Action failed'));
     } finally {
       setBusy(false);
@@ -3000,11 +3005,16 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
     setBusy('__all__');
     setResult(null);
     setError(null);
+    // Issue #864 (Codex review on #874) — track the in-flight
+    // assertion so mid-loop failures surface "<name>: …" instead of
+    // "selected assertion …".
+    let currentAssertion: string | null = null;
     try {
       if (layer === 'wm') {
         let total = 0;
         let noopCount = 0;
         for (const a of assertions) {
+          currentAssertion = a.name;
           // PR #710 — see comment on the single-row handler above.
           const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
           total += res.promotedCount;
@@ -3026,7 +3036,7 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
       refresh();
       onComplete();
     } catch (err: any) {
-      const typed = describePromoteError('selected assertion', err);
+      const typed = describePromoteError(currentAssertion ?? 'selected assertion', err);
       setError(typed ? typed.message : (err?.message ?? 'Action failed'));
     } finally {
       setBusy(null);

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -10,7 +10,7 @@ import {
   publishSharedMemory, listSwmEntities, executeQuery,
   writeProfileQueryCatalog,
   fetchSubGraphs,
-  type AgentIdentity, type AssertionInfo, type PendingJoinRequest, type PublishResult, type SubGraphInfo,
+  type AgentIdentity, type AssertionInfo, type PendingJoinRequest, type PromoteOutcome, type PublishResult, type SubGraphInfo,
 } from '../../api.js';
 import { ImportFilesModal } from '../../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../../components/Modals/ShareProjectModal.js';
@@ -3336,7 +3336,14 @@ export function VerifyOnDkgButton({
 }) {
   const profile = useProjectProfileContext();
   const [busy, setBusy] = useState(false);
-  const [result, setResult] = useState<PublishResult | { promotedCount: number } | null>(null);
+  // Codex review on #874 / #898 round 2 — promote results now flow
+  // through `describePromoteResult` so a `promotedCount === 0`
+  // response surfaces the same actionable hint the WMAssertionsPane
+  // shows ("had no triples to promote …"), and `ASSERTION_NOT_PERSISTED`
+  // surfaces the typed describePromoteError message instead of the
+  // raw "409 …" backend string. The promote branch stores a
+  // `PromoteOutcome`; the publish branch stores a `PublishResult`.
+  const [result, setResult] = useState<PublishResult | PromoteOutcome | null>(null);
   const [resultKind, setResultKind] = useState<'promote' | 'publish' | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -3399,6 +3406,7 @@ export function VerifyOnDkgButton({
     setError(null);
     setResult(null);
     setResultKind(action.kind);
+    const assertionName = sgBinding?.binding.sourceAssertion ?? 'assertion';
     try {
       if (action.kind === 'promote') {
         // PR #710 — `sgBinding.sourceAssertion` is itself
@@ -3413,20 +3421,28 @@ export function VerifyOnDkgButton({
           [entity.uri],
           sgBinding!.subGraph,
         );
-        setResult(r);
+        // Issue #864 — fan the promote response through the central
+        // describe helper so 0-count returns get an actionable hint
+        // instead of the misleading "Promoted 0 triples" toast.
+        setResult(describePromoteResult(assertionName, r));
       } else {
         const r = await publishSharedMemory(contextGraphId, [entity.uri]);
         setResult(r);
       }
       onVerified();
     } catch (err: any) {
-      setError(err?.message ?? 'Action failed');
+      // Issue #864 — `ASSERTION_NOT_PERSISTED` (HTTP 409) gets a
+      // typed message that points the user at the re-import path
+      // instead of the raw backend error string.
+      const typed = action.kind === 'promote' ? describePromoteError(assertionName, err) : null;
+      setError(typed ? typed.message : (err?.message ?? 'Action failed'));
     } finally {
       setBusy(false);
     }
   };
 
   const isPublishResult = (r: typeof result): r is PublishResult => !!r && 'status' in r;
+  const isPromoteOutcome = (r: typeof result): r is PromoteOutcome => !!r && 'kind' in r;
 
   return (
     <div className={`v10-ka-verify v10-ka-verify-${action.kind}`}>
@@ -3450,7 +3466,7 @@ export function VerifyOnDkgButton({
         </button>
       )}
       {error && <div className="v10-ka-verify-err">✕ {error}</div>}
-      {result && resultKind === 'promote' && !isPublishResult(result) && (
+      {result && resultKind === 'promote' && isPromoteOutcome(result) && result.kind === 'success' && (
         <div className="v10-ka-verify-ok">
           <div className="v10-ka-verify-ok-row">
             <span className="v10-ka-verify-ok-lbl">Promoted</span>
@@ -3462,6 +3478,13 @@ export function VerifyOnDkgButton({
             Refresh the entity to see the next step appear.
           </div>
         </div>
+      )}
+      {result && resultKind === 'promote' && isPromoteOutcome(result) && result.kind !== 'success' && (
+        // 0-count or not-persisted — surface the typed message as a
+        // warning, not a faux success. Mirrors the WMAssertionsPane's
+        // describePromoteResult/describePromoteError handling so the
+        // entity-level CTA stops misreporting empty promotes as "✓".
+        <div className="v10-ka-verify-err">! {result.message}</div>
       )}
       {result && resultKind === 'publish' && isPublishResult(result) && (() => {
         // OT-RFC-38 §1.1 — a publish without a TX hash never made it to chain.

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -18,21 +18,9 @@ import { listAssertions } from '../src/ui/api.js';
 // parser code-path under test verbatim. Same pattern as
 // `use-swm-attributions.test.ts` from the prior round.
 
-// #844 fix — WM listing now derives from the `<cg>/_meta` lifecycle graph
-// (filtering on `dkg:memoryLayer "WM"`) rather than enumerating data graphs,
-// because #844 gated the WM view's `GRAPH ?g` enumeration. The SPARQL applies
-// the `"WM"` filter server-side, so a mocked response represents rows the
-// daemon already filtered to WM; these fixtures exercise the JS mapping
-// (binding → {name, graphUri, subGraph}, dedup, skip-incomplete).
-//
-// Binding shape mirrors the new SELECT: ?assertion (lifecycle URN, used as
-// graphUri), ?name (dkg:assertionName), optional ?sg (dkg:subGraphName).
-function metaRow(opts: { assertion: string; name?: string; sg?: string; assertionGraph?: string }) {
-  const b: Record<string, { value: string }> = { assertion: { value: opts.assertion } };
-  if (opts.name !== undefined) b.name = { value: opts.name };
-  if (opts.sg !== undefined) b.sg = { value: opts.sg };
-  if (opts.assertionGraph !== undefined) b.assertionGraph = { value: opts.assertionGraph };
-  return b;
+function bRow(g: string, cnt: number) {
+  // Daemon's SPARQL JSON-binding shape: object with `value`.
+  return { g: { value: g }, cnt: { value: String(cnt) } };
 }
 
 function jsonResponse(body: unknown) {
@@ -43,7 +31,7 @@ function jsonResponse(body: unknown) {
   } as any;
 }
 
-describe('listAssertions (WM) — derives from _meta (memoryLayer="WM")', () => {
+describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
   let originalFetch: typeof globalThis.fetch | undefined;
   let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -63,36 +51,27 @@ describe('listAssertions (WM) — derives from _meta (memoryLayer="WM")', () => 
     );
   }
 
-  it('queries the <cg>/_meta graph filtered to memoryLayer "WM"', async () => {
+  it('parses root-bucket assertion: name extracted, subGraph undefined', async () => {
     setBindings([
-      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:notes', name: 'notes' }),
-    ]);
-    await listAssertions('cg-A', 'wm');
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body.sparql).toContain('did:dkg:context-graph:cg-A/_meta');
-    expect(body.sparql).toContain('memoryLayer> "WM"');
-    expect(body.sparql).toContain('assertionName');
-    // assertionGraph is bound again (pre-#710 sub-graph fallback).
-    expect(body.sparql).toContain('assertionGraph');
-  });
-
-  it('maps a root-bucket WM assertion: name + lifecycle-URN graphUri, subGraph undefined', async () => {
-    setBindings([
-      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:notes', name: 'notes' }),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5),
     ]);
     const out = await listAssertions('cg-A', 'wm');
     expect(out).toHaveLength(1);
     expect(out[0]).toMatchObject({
       name: 'notes',
-      graphUri: 'urn:dkg:assertion:cg-A:0xabc:notes',
+      graphUri: 'did:dkg:context-graph:cg-A/assertion/0xabc/notes',
+      tripleCount: 5,
       subGraph: undefined,
     });
   });
 
-  it('surfaces sub-graph-scoped + root rows; subGraph comes from dkg:subGraphName (#710)', async () => {
+  it('parses sub-graph-scoped + root in the same response (#706 regression guard)', async () => {
+    // Both shapes must surface. Pre-fix, the `startsWith(…/assertion/)`
+    // filter silently dropped sub-graph rows entirely; this test
+    // pins that they're surfaced AND that the slug + name parse out.
     setBindings([
-      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:root-doc', name: 'root-doc' }),
-      metaRow({ assertion: 'urn:dkg:assertion:cg-A:research:0xabc:scoped-doc', name: 'scoped-doc', sg: 'research' }),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/root-doc', 3),
+      bRow('did:dkg:context-graph:cg-A/research/assertion/0xabc/scoped-doc', 7),
     ]);
     const out = await listAssertions('cg-A', 'wm');
     expect(out).toHaveLength(2);
@@ -100,83 +79,122 @@ describe('listAssertions (WM) — derives from _meta (memoryLayer="WM")', () => 
     const scoped = out.find(a => a.name === 'scoped-doc')!;
     expect(root.subGraph).toBeUndefined();
     expect(scoped.subGraph).toBe('research');
-    expect(scoped.graphUri).toBe('urn:dkg:assertion:cg-A:research:0xabc:scoped-doc');
+    expect(scoped.tripleCount).toBe(7);
   });
 
-  it('pre-#710 compat: derives subGraph from the assertionGraph URI when subGraphName is absent', async () => {
-    // Drafts created before #710 carry dkg:assertionGraph but NO
-    // dkg:subGraphName. The sub-graph segment must be recovered from the
-    // assertion-graph URI so promote/preview stay correctly scoped.
+  it('silently drops malformed graph URIs that lack `/assertion/`', async () => {
+    // E.g. internal meta graphs, prefix-only matches, or any future
+    // graph layout that shares the CG prefix but isn't an assertion.
     setBindings([
-      metaRow({
-        assertion: 'urn:dkg:assertion:cg-A:legacy:0xabc:old-scoped',
-        name: 'old-scoped',
-        // no `sg` — pre-#710 row
-        assertionGraph: 'did:dkg:context-graph:cg-A/legacy/assertion/0xabc/old-scoped',
-      }),
-      // Root-bucket legacy row (assertionGraph has no sub-graph segment) →
-      // stays root, NOT misparsed.
-      metaRow({
-        assertion: 'urn:dkg:assertion:cg-A:0xabc:old-root',
-        name: 'old-root',
-        assertionGraph: 'did:dkg:context-graph:cg-A/assertion/0xabc/old-root',
-      }),
-    ]);
-    const out = await listAssertions('cg-A', 'wm');
-    expect(out).toHaveLength(2);
-    const scoped = out.find(a => a.name === 'old-scoped')!;
-    const root = out.find(a => a.name === 'old-root')!;
-    expect(scoped.subGraph).toBe('legacy');
-    expect(root.subGraph).toBeUndefined();
-  });
-
-  it('prefers the explicit subGraphName literal over the assertionGraph URI parse', async () => {
-    // When both are present, the literal wins (it is authoritative and the
-    // URI parse is only the migration fallback).
-    setBindings([
-      metaRow({
-        assertion: 'urn:dkg:assertion:cg-A:research:0xabc:both',
-        name: 'both',
-        sg: 'research',
-        assertionGraph: 'did:dkg:context-graph:cg-A/research/assertion/0xabc/both',
-      }),
-    ]);
-    const out = await listAssertions('cg-A', 'wm');
-    expect(out[0].subGraph).toBe('research');
-  });
-
-  it('skips bindings missing the lifecycle URN or the name', async () => {
-    setBindings([
-      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:real', name: 'real' }),
-      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:noname' }), // no ?name → skipped
-      { name: { value: 'orphan' } } as any,                          // no ?assertion → skipped
+      bRow('did:dkg:context-graph:cg-A/_meta', 12),
+      bRow('did:dkg:context-graph:cg-A/research', 1),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/real', 4),
     ]);
     const out = await listAssertions('cg-A', 'wm');
     expect(out).toHaveLength(1);
     expect(out[0].name).toBe('real');
   });
 
-  it('dedups repeated lifecycle URNs (e.g. multiple events for one assertion) to the first', async () => {
+  it('scopes by cgPrefix — only the queried cgId surfaces', async () => {
+    // Multi-CG responses can arise if the SPARQL is run against a
+    // wider store. The `startsWith(cgPrefix)` filter must reject
+    // bindings from other CGs. Note: the prefix is
+    // `did:dkg:context-graph:cg-A/` (trailing slash); a CG named
+    // `cg-A-suffix` has prefix `…cg-A-suffix/` which does NOT
+    // startsWith the queried prefix.
     setBindings([
-      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:dup', name: 'dup' }),
-      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:dup', name: 'dup' }),
+      bRow('did:dkg:context-graph:cg-OTHER/assertion/0xabc/other', 2),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/mine', 6),
+      bRow('did:dkg:context-graph:cg-A-suffix/assertion/0xabc/foo', 1),
     ]);
     const out = await listAssertions('cg-A', 'wm');
     expect(out).toHaveLength(1);
-    expect(out[0].name).toBe('dup');
+    expect(out[0].name).toBe('mine');
   });
 
-  it('does NOT set tripleCount (renderer guards tripleCount != null; mirrors SWM)', async () => {
+  it('returns an empty list when no bindings match the cg-prefix + /assertion/ filter', async () => {
     setBindings([
-      metaRow({ assertion: 'urn:dkg:assertion:cg-A:0xabc:notes', name: 'notes' }),
+      bRow('did:dkg:context-graph:cg-B/assertion/0xabc/foo', 1),
     ]);
     const out = await listAssertions('cg-A', 'wm');
-    expect(out[0].tripleCount).toBeUndefined();
+    expect(out).toEqual([]);
   });
 
-  it('returns an empty list when _meta has no WM assertions', async () => {
-    setBindings([]);
+  it('drops bindings with 3+ segments before `assertion/` (left-side strict shape)', async () => {
+    // Reviewer-flagged case: a binding like `<cg>/foo/bar/assertion/<a>/<n>`
+    // doesn't match either accepted shape (root = 3 segs, sub-graph =
+    // 4 segs). The prior `indexOf('/assertion/')` branch admitted it
+    // as a `subGraph: undefined` row with a mis-derived name —
+    // promote/preview lookups would silently miss. Strict-shape parse
+    // drops it.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/foo/bar/assertion/0xabc/baz', 9),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/keep', 1),
+    ]);
     const out = await listAssertions('cg-A', 'wm');
-    expect(out).toEqual([]);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('keep');
+  });
+
+  it('drops bindings with extra segments after the name (right-side strict shape)', async () => {
+    // Pins the right-side strict-shape contract. The sub-graph branch
+    // expects exactly `<sg>/assertion/<agent>/<name>` — anything
+    // longer would mis-extract the name and orphan the row from
+    // promote/preview.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/sg/assertion/0xabc/foo/extra', 2),
+      bRow('did:dkg:context-graph:cg-A/sg/assertion/0xabc/clean', 3),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: 'clean',
+      subGraph: 'sg',
+      tripleCount: 3,
+    });
+  });
+
+  it('opts into includeContextGraphPartitions so assertion partitions show up (#864 rc.12 follow-up)', async () => {
+    // Without this flag, `DKGQueryEngine.query` constrains `GRAPH ?g`
+    // expansion to the static `{<cg>, <cg>/_meta, <cg>/_shared_memory_meta}`
+    // allow-list, hiding every assertion data partition. The
+    // bulk-promote button then sees an empty assertion list, iterates
+    // zero times, and falls into the rc.12 "0 triples promoted" no-op
+    // branch even when WM clearly contains data. Pin the request body
+    // here so any future refactor that drops the opt-in fails this
+    // test instead of silently re-breaking promote-all.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5),
+    ]);
+    await listAssertions('cg-A', 'wm');
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain('/api/query');
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({
+      contextGraphId: 'cg-A',
+      includeContextGraphPartitions: true,
+    });
+    expect(typeof body.sparql).toBe('string');
+  });
+
+  it('scopes the /assertion/ discriminator to the tail when cgId itself contains "/assertion/"', async () => {
+    // PR #710 reviewer guard — `validateContextGraphId` permits
+    // slashes, so a cgId can literally contain `/assertion/` as a
+    // substring. The prior `g.indexOf('/assertion/')` (full URI)
+    // would have hit the cgId's internal `/assertion/` and
+    // mis-sliced the name. After tail-scoping the parse, the cgId
+    // is treated as opaque and only the tail's `/assertion/`
+    // delimiter is consulted.
+    setBindings([
+      bRow('did:dkg:context-graph:weird/assertion/cg/assertion/0xabc/foo', 4),
+    ]);
+    const out = await listAssertions('weird/assertion/cg', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: 'foo',
+      subGraph: undefined,
+      tripleCount: 4,
+    });
   });
 });

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -178,6 +178,25 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
     expect(typeof body.sparql).toBe('string');
   });
 
+  it('SPARQL gates WM membership on dkg:memoryLayer "WM" in <cg>/_meta (#898 Codex)', async () => {
+    // Codex review on #898 — `assertionPromote` empties the assertion
+    // data graph but intentionally leaves daemon-owned `urn:dkg:file:*`
+    // / `urn:dkg:extraction:*` quads behind, so a raw `GRAPH ?g { ?s ?p
+    // ?o }` count keeps returning promoted assertions. Pin the new
+    // gate: the SPARQL must JOIN against `<cg>/_meta` filtered on
+    // `dkg:memoryLayer "WM"` so promoted assertions (flipped to "SWM"
+    // by `assertionPromote`) drop out cleanly.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5),
+    ]);
+    await listAssertions('cg-A', 'wm');
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body.sparql).toContain('did:dkg:context-graph:cg-A/_meta');
+    expect(body.sparql).toContain('http://dkg.io/ontology/memoryLayer');
+    expect(body.sparql).toContain('"WM"');
+  });
+
   it('scopes the /assertion/ discriminator to the tail when cgId itself contains "/assertion/"', async () => {
     // PR #710 reviewer guard — `validateContextGraphId` permits
     // slashes, so a cgId can literally contain `/assertion/` as a

--- a/packages/node-ui/test/promote-outcome-helpers.test.ts
+++ b/packages/node-ui/test/promote-outcome-helpers.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describePromoteResult,
+  describePromoteError,
+  HttpError,
+} from '../src/ui/api.js';
+
+/**
+ * Codex review on #874 / #898 round 2 — pin the contract that the
+ * entity-level WM→SWM CTA in
+ * `packages/node-ui/src/ui/views/project/components.tsx`
+ * (`VerifyOnDkgButton`) depends on.
+ *
+ * Pre-fix that CTA called `promoteAssertion()` directly and rendered
+ * `promotedCount` verbatim, so `promotedCount === 0` showed as a faux
+ * "✓ 0 triples now in Shared Memory" success and the
+ * `ASSERTION_NOT_PERSISTED` 409 surfaced as a generic backend error.
+ * Both paths now run through these helpers; this test keeps the helper
+ * contract stable so a future refactor of either helper doesn't
+ * silently re-break that CTA.
+ */
+describe('describePromoteResult', () => {
+  it('returns kind="success" with a positive triple count message when promotedCount > 0', () => {
+    const out = describePromoteResult('character-sheet', { promotedCount: 7 });
+    expect(out.kind).toBe('success');
+    if (out.kind !== 'success') return;
+    expect(out.promotedCount).toBe(7);
+    expect(out.message).toContain('Promoted 7 triples');
+    expect(out.message).toContain('character-sheet');
+  });
+
+  it('returns kind="noop" with a re-import hint when promotedCount === 0', () => {
+    const out = describePromoteResult('character-sheet', { promotedCount: 0 });
+    expect(out.kind).toBe('noop');
+    if (out.kind !== 'noop') return;
+    // The CTA now renders `outcome.message` verbatim instead of the
+    // misleading "✓ 0 triples now in Shared Memory" toast.
+    expect(out.message).toContain('character-sheet');
+    expect(out.message.toLowerCase()).toContain('no triples');
+  });
+
+  it('uses singular "triple" when promotedCount === 1', () => {
+    const out = describePromoteResult('character-sheet', { promotedCount: 1 });
+    expect(out.kind).toBe('success');
+    if (out.kind !== 'success') return;
+    expect(out.message).toContain('Promoted 1 triple ');
+    expect(out.message).not.toContain('1 triples');
+  });
+});
+
+describe('describePromoteError', () => {
+  it('returns kind="not-persisted" with a re-import hint when the daemon throws ASSERTION_NOT_PERSISTED (409)', () => {
+    const err = new HttpError(409, 'Conflict', {
+      code: 'ASSERTION_NOT_PERSISTED',
+      expectedTripleCount: 12,
+    });
+    const out = describePromoteError('character-sheet', err);
+    expect(out).not.toBeNull();
+    if (!out || out.kind !== 'not-persisted') throw new Error('expected not-persisted outcome');
+    expect(out.expectedTripleCount).toBe(12);
+    expect(out.message).toContain('character-sheet');
+    expect(out.message).toContain('12 extracted triples');
+    expect(out.message.toLowerCase()).toContain('re-import');
+  });
+
+  it('returns kind="not-persisted" without an expectedTripleCount when the daemon body lacks it', () => {
+    const err = new HttpError(409, 'Conflict', { code: 'ASSERTION_NOT_PERSISTED' });
+    const out = describePromoteError('character-sheet', err);
+    expect(out).not.toBeNull();
+    if (!out || out.kind !== 'not-persisted') throw new Error('expected not-persisted outcome');
+    expect(out.expectedTripleCount).toBeUndefined();
+    expect(out.message).toContain('character-sheet');
+    expect(out.message).toContain('extraction metadata');
+  });
+
+  it('returns null for non-409 HttpErrors so the CTA falls back to err.message', () => {
+    expect(describePromoteError('x', new HttpError(500, 'Internal'))).toBeNull();
+    expect(describePromoteError('x', new HttpError(404, 'Not Found'))).toBeNull();
+  });
+
+  it('returns null for 409 HttpErrors that are NOT ASSERTION_NOT_PERSISTED', () => {
+    const err = new HttpError(409, 'Conflict', { code: 'ASSERTION_PROMOTE_RACE' });
+    expect(describePromoteError('x', err)).toBeNull();
+  });
+
+  it('returns null for non-HttpError throwables (network errors, generic Error)', () => {
+    expect(describePromoteError('x', new Error('network'))).toBeNull();
+    expect(describePromoteError('x', 'string error' as unknown)).toBeNull();
+  });
+});

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -252,6 +252,35 @@ export class ReservedNamespaceError extends Error {
   }
 }
 
+// Issue #864 — surface the "_meta promised structural triples but the data
+// graph is empty" inconsistency as a typed, machine-readable error so the
+// daemon route can map it to a 409 and the UI can render an actionable
+// hint instead of the misleading "Promoted 0 triples to Shared Memory"
+// toast. The code field is the contract the daemon/UI rely on; do not
+// rename without updating both call-sites.
+export class AssertionNotPersistedError extends Error {
+  readonly code = 'ASSERTION_NOT_PERSISTED' as const;
+  readonly contextGraphId: string;
+  readonly assertionGraph: string;
+  readonly expectedTripleCount: number;
+  constructor(args: {
+    contextGraphId: string;
+    assertionGraph: string;
+    expectedTripleCount: number;
+  }) {
+    super(
+      `Assertion data graph <${args.assertionGraph}> is empty, but its _meta record ` +
+        `reports extractionStatus="completed" with structuralTripleCount=${args.expectedTripleCount}. ` +
+        `The extracted triples were never persisted (or have been deleted) so promote has nothing to move. ` +
+        `Re-import the source file or re-write the assertion before promoting.`,
+    );
+    this.name = 'AssertionNotPersistedError';
+    this.contextGraphId = args.contextGraphId;
+    this.assertionGraph = args.assertionGraph;
+    this.expectedTripleCount = args.expectedTripleCount;
+  }
+}
+
 // Round 12 Bug 34: module-private token proving an internal caller
 // (specifically `publishFromSharedMemory`) is the origin of a
 // `publish()` call so the reserved-namespace guard can be bypassed
@@ -3796,6 +3825,56 @@ export class DKGPublisher implements Publisher {
     return [...addresses][0];
   }
 
+  /**
+   * Issue #864 — guard the silent "Promoted 0 triples" path.
+   *
+   * Called from `assertionPromote` whenever the CONSTRUCT against the
+   * assertion's data graph returns zero quads. Inspects the CG's `_meta`
+   * graph for the two markers `routes/assertion.ts` stamps when an
+   * `import-file` request finishes a structural extraction:
+   *   <assertionGraph> dkg:extractionStatus "completed"
+   *   <assertionGraph> dkg:structuralTripleCount "<n>"^^xsd:integer
+   *
+   * If BOTH are present AND the count is positive, the graph SHOULD hold
+   * content — the inconsistency is a real failure, not a no-op. Throws
+   * `AssertionNotPersistedError` so the daemon route can translate it to
+   * a 409 with a structured body. In every other case (no markers at
+   * all, status not "completed", count is zero) this is a legitimate
+   * empty promote: return silently and let the caller fall through to
+   * the existing `{ promotedCount: 0 }` return.
+   *
+   * Read-only, single SELECT — does not mutate state.
+   */
+  private async assertAssertionDataPersisted(
+    contextGraphId: string,
+    assertionGraph: string,
+  ): Promise<void> {
+    const DKG = 'http://dkg.io/ontology/';
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?status ?count WHERE {
+         GRAPH <${metaGraph}> {
+           OPTIONAL { <${assertionGraph}> <${DKG}extractionStatus> ?status }
+           OPTIONAL { <${assertionGraph}> <${DKG}structuralTripleCount> ?count }
+         }
+       } LIMIT 1`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return;
+    const row = result.bindings[0];
+    const statusRaw = row?.['status'];
+    const countRaw = row?.['count'];
+    if (typeof statusRaw !== 'string' || typeof countRaw !== 'string') return;
+    const statusValue = stripSparqlLiteral(statusRaw);
+    if (statusValue !== 'completed') return;
+    const expected = parseCountLiteral(countRaw);
+    if (!Number.isFinite(expected) || expected <= 0) return;
+    throw new AssertionNotPersistedError({
+      contextGraphId,
+      assertionGraph,
+      expectedTripleCount: expected,
+    });
+  }
+
   private async deleteMetaForRoot(metaGraph: string, rootEntity: string): Promise<void> {
     const DKG = 'http://dkg.io/ontology/';
     const result = await this.store.query(
@@ -3952,7 +4031,31 @@ export class DKGPublisher implements Publisher {
     const result = await this.store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${graphUri}> { ?s ?p ?o } }`,
     );
-    if (result.type !== 'quads' || result.quads.length === 0) return { promotedCount: 0 };
+    if (result.type !== 'quads' || result.quads.length === 0) {
+      // Issue #864 — when the assertion data graph is empty, distinguish two
+      // failure modes so the caller (and ultimately the UI) gets an
+      // actionable signal instead of a silent "Promoted 0 triples":
+      //
+      //   a) genuine empty assertion (never imported, never written, or
+      //      already discarded) → keep the legacy `{ promotedCount: 0 }`
+      //      success-shape return so polling/retry paths keep working.
+      //   b) `_meta` says structural extraction *completed* with a non-zero
+      //      triple count → the data graph SHOULD hold content. Returning
+      //      0 here silently leaves the user staring at "Promoted 0" with
+      //      no recovery path; raise a typed error so the daemon route
+      //      can map it to a 409 the UI knows to surface.
+      //
+      // Rows 18 (`dkg:extractionStatus`) and 19 (`dkg:structuralTripleCount`)
+      // are stamped by the daemon's import-file flow on the data-graph URI
+      // subject (NOT the lifecycle URN) — see
+      // `packages/cli/src/daemon/routes/assertion.ts:metaQuads`. That makes
+      // them a clean witness of "extraction landed", scoped to the same
+      // graphUri we just CONSTRUCTed against. Lifecycle-URN rows from
+      // `assertionCreate` are not consulted: they fire for empty-write
+      // flows where promoting nothing is legitimate.
+      await this.assertAssertionDataPersisted(contextGraphId, graphUri);
+      return { promotedCount: 0 };
+    }
 
     let quadsToPromote = result.quads;
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3852,10 +3852,11 @@ export class DKGPublisher implements Publisher {
     const DKG = 'http://dkg.io/ontology/';
     const metaGraph = contextGraphMetaUri(contextGraphId);
     const result = await this.store.query(
-      `SELECT ?status ?count WHERE {
+      `SELECT ?status ?count ?layer WHERE {
          GRAPH <${metaGraph}> {
            OPTIONAL { <${assertionGraph}> <${DKG}extractionStatus> ?status }
            OPTIONAL { <${assertionGraph}> <${DKG}structuralTripleCount> ?count }
+           OPTIONAL { <${assertionGraph}> <${DKG}memoryLayer> ?layer }
          }
        } LIMIT 1`,
     );
@@ -3863,6 +3864,23 @@ export class DKGPublisher implements Publisher {
     const row = result.bindings[0];
     const statusRaw = row?.['status'];
     const countRaw = row?.['count'];
+    const layerRaw = row?.['layer'];
+    // Codex review on #898 — the previous version raised
+    // `AssertionNotPersistedError` whenever `extractionStatus="completed"`
+    // + a positive `structuralTripleCount` were stamped, even after a
+    // successful promote. `assertionPromote` empties the assertion data
+    // graph as part of the WM → SWM transition (line ~4260) but
+    // intentionally leaves those two extraction markers behind in
+    // `_meta` for audit purposes. The lifecycle marker that DOES move
+    // is `dkg:memoryLayer`, set to `"WM"` by `assertionCreate` and
+    // flipped to `"SWM"` by `assertionPromote` (line ~4270). A retry /
+    // stale double-click then hits this guard with `layer="SWM"` and
+    // must be treated as a harmless no-op rather than misclassified as
+    // ASSERTION_NOT_PERSISTED.
+    if (typeof layerRaw === 'string') {
+      const layerValue = stripSparqlLiteral(layerRaw);
+      if (layerValue !== 'WM') return;
+    }
     if (typeof statusRaw !== 'string' || typeof countRaw !== 'string') return;
     const statusValue = stripSparqlLiteral(statusRaw);
     if (statusValue !== 'completed') return;

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -28,6 +28,7 @@ export { generateKCMetadata, generateTentativeMetadata, generateConfirmedFullMet
 export {
   DKGPublisher,
   StaleWriteError,
+  AssertionNotPersistedError,
   type DKGPublisherConfig,
   type WorkspaceSenderKeyEncryptInput,
   type WorkspaceSenderKeyEncryptor,

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -6,10 +6,11 @@ import {
   TypedEventBus,
   generateEd25519Keypair,
   contextGraphAssertionUri,
+  contextGraphMetaUri,
   contextGraphSharedMemoryUri,
   assertionLifecycleUri,
 } from '@origintrail-official/dkg-core';
-import { DKGPublisher } from '../src/index.js';
+import { DKGPublisher, AssertionNotPersistedError } from '../src/index.js';
 import { ethers } from 'ethers';
 import { createEVMAdapter, getSharedContext, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 
@@ -114,6 +115,96 @@ describe('Working Memory Assertion Lifecycle', () => {
     if (swmResult.type === 'bindings') {
       expect(swmResult.bindings.length).toBe(3);
     }
+  });
+
+  // Issue #864 — when the assertion data graph is empty but `_meta` says
+  // an extraction completed with N > 0 triples, the legacy
+  // `{ promotedCount: 0 }` return hid the inconsistency behind a
+  // misleading "Promoted 0 triples" toast. The publisher now throws
+  // `AssertionNotPersistedError` so the daemon route can map it to a
+  // 409 with an actionable hint.
+  it('promote throws AssertionNotPersistedError when _meta says extraction completed but data graph is empty', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+
+    // Simulate the post-import-file state: extraction metadata landed in
+    // `_meta`, but the structural triples never made it into the data
+    // graph (the rc.12 bug reported in #864). The metaQuads mirror what
+    // `packages/cli/src/daemon/routes/assertion.ts` writes on a
+    // successful import-file with text/markdown content.
+    const graphUri = contextGraphAssertionUri(CG_ID, AGENT, ASSERTION_NAME);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    await store.insert([
+      {
+        subject: graphUri,
+        predicate: 'http://dkg.io/ontology/extractionStatus',
+        object: '"completed"',
+        graph: metaGraph,
+      },
+      {
+        subject: graphUri,
+        predicate: 'http://dkg.io/ontology/structuralTripleCount',
+        object: '"49"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: metaGraph,
+      },
+    ]);
+
+    await expect(
+      publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT),
+    ).rejects.toBeInstanceOf(AssertionNotPersistedError);
+
+    // Re-run to capture the structured fields the daemon route reads
+    // when building its 409 response body.
+    try {
+      await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
+      throw new Error('expected promote to throw');
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(AssertionNotPersistedError);
+      const typed = err as AssertionNotPersistedError;
+      expect(typed.code).toBe('ASSERTION_NOT_PERSISTED');
+      expect(typed.contextGraphId).toBe(CG_ID);
+      expect(typed.assertionGraph).toBe(graphUri);
+      expect(typed.expectedTripleCount).toBe(49);
+    }
+  });
+
+  // Issue #864 — guard the legitimate empty-promote path. When there's
+  // no extraction metadata in `_meta` at all, an empty data graph is a
+  // perfectly valid no-op (e.g. a `create` with no subsequent `write`,
+  // or a re-promote of an already-promoted assertion). The publisher
+  // must keep returning `{ promotedCount: 0 }` instead of throwing, so
+  // existing polling/retry call-sites don't regress.
+  it('promote returns { promotedCount: 0 } when data graph is empty and _meta has no extraction record', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+
+    const result = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
+    expect(result.promotedCount).toBe(0);
+  });
+
+  // Issue #864 — same shape as the previous test but exercises the
+  // partial-metadata case: status present, count = 0 → not an
+  // inconsistency, still a legitimate no-op (e.g. a Phase-1 file with
+  // no extractable structural content).
+  it('promote returns { promotedCount: 0 } when _meta says completed but structuralTripleCount is 0', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    const graphUri = contextGraphAssertionUri(CG_ID, AGENT, ASSERTION_NAME);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    await store.insert([
+      {
+        subject: graphUri,
+        predicate: 'http://dkg.io/ontology/extractionStatus',
+        object: '"completed"',
+        graph: metaGraph,
+      },
+      {
+        subject: graphUri,
+        predicate: 'http://dkg.io/ontology/structuralTripleCount',
+        object: '"0"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        graph: metaGraph,
+      },
+    ]);
+
+    const result = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
+    expect(result.promotedCount).toBe(0);
   });
 
   it('durable SWM ownership blocks cross-author promote after publisher restart with empty map', async () => {

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -180,6 +180,48 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(result.promotedCount).toBe(0);
   });
 
+  // Codex review on #898 — `assertionPromote` empties the assertion
+  // data graph but intentionally leaves daemon-owned `urn:dkg:file:*`
+  // / `urn:dkg:extraction:*` quads behind, AND keeps the
+  // `extractionStatus="completed"` + positive `structuralTripleCount`
+  // markers in `_meta` for audit purposes. Without the lifecycle gate
+  // (`dkg:memoryLayer "WM"`), a retry / stale double-click after a
+  // successful promote was misclassified as ASSERTION_NOT_PERSISTED.
+  // The lifecycle marker is flipped to "SWM" by `assertionPromote`, so
+  // the second promote must short-circuit cleanly to a no-op.
+  it('promote is a no-op (no AssertionNotPersistedError) when re-running after a successful promote', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+
+    // Stamp the post-import-file extraction markers that
+    // `assertionPromote` deliberately preserves. After the success run
+    // the data graph is empty + lifecycle is "SWM", but these two
+    // markers stick around in `_meta`.
+    const graphUri = contextGraphAssertionUri(CG_ID, AGENT, ASSERTION_NAME);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    await store.insert([
+      {
+        subject: graphUri,
+        predicate: 'http://dkg.io/ontology/extractionStatus',
+        object: '"completed"',
+        graph: metaGraph,
+      },
+      {
+        subject: graphUri,
+        predicate: 'http://dkg.io/ontology/structuralTripleCount',
+        object: `"${TRIPLES.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+        graph: metaGraph,
+      },
+    ]);
+
+    const first = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER });
+    expect(first.promotedCount).toBeGreaterThan(0);
+
+    // Stale second click — must be a harmless no-op, not an error.
+    const second = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, { publisherPeerId: PEER });
+    expect(second.promotedCount).toBe(0);
+  });
+
   // Issue #864 — same shape as the previous test but exercises the
   // partial-metadata case: status present, count = 0 → not an
   // inconsistency, still a legitimate no-op (e.g. a Phase-1 file with


### PR DESCRIPTION
Forward-port of [#874](https://github.com/OriginTrail/dkg/pull/874) (merged to `release/rc.12` at `fa0ea47d`) onto `main`. The cherry-pick of the third commit hit a conflict on `packages/node-ui/src/ui/api.ts` and `packages/node-ui/test/list-assertions.test.ts` because the third commit (`4137aa41`) replaces the WM listAssertions implementation that the second commit (`63e7b73a`, the Codex review fix) had introduced — the team picked the later `_meta`-lifecycle approach over the earlier strict-shape SPARQL approach. Resolution: take the rc.12 final state for both files, which is what landed on rc.12 anyway.

## Why this needs a separate PR

Same reason as the [forward-port of #873](#TODO link to other PR): `main` doesn't auto-pull from rc.12. This PR isolates the `#864` fix so it ships outside the rc.12 line.

## What's included

3 commits cherry-picked in original order from #874:

| rc.12 SHA | This branch SHA | Subject |
|---|---|---|
| `bcf4eb5b` | `bfa2e92e` | `fix(publisher): rich error when promote finds an empty assertion graph (#864)` — primary fix: `promoteAssertion` now distinguishes "no such assertion graph" from "graph exists but is empty" and returns the right HTTP code + actionable message |
| `63e7b73a` | `40520836` | `fix(node-ui,cli): address Codex review on #874` — Codex review hardening on the WM listAssertions strict-shape parse (later superseded by `4137aa41`'s lifecycle approach for the WM branch, but the CLI changes from this commit remain) |
| `4137aa41` | `d196946e` | `fix(node-ui): listAssertions(wm) must include CG partitions (#864)` — derive WM assertions from `<cg>/_meta` `dkg:Assertion` lifecycle nodes (filtering on `dkg:memoryLayer "WM"`) instead of enumerating `<cg>/assertion/...` content partitions, which were excluded by the daemon's contextGraphId-scoped graph allow-list and broke `LayerActionsWidget`'s "Promote N to SWM" flow |

## Conflict resolution

Cherry-pick of `4137aa41` conflicted with `63e7b73a`'s changes on the WM branch of `listAssertions` in `api.ts` (alternative implementations of the same function) and on the matching test file — both files were resolved by checking out the rc.12 final state (`git show origin/release/rc.12:<file>`), which is byte-identical to what shipped on rc.12. `git diff origin/release/rc.12 -- packages/node-ui/src/ui/api.ts packages/node-ui/test/list-assertions.test.ts packages/publisher` returns empty.

## Test plan

- [ ] `packages/node-ui/test/list-assertions.test.ts` passes
- [ ] `packages/cli/test/promote-route-not-persisted.test.ts` passes (added in `40520836`)
- [ ] CI on this branch passes against `main`

Ref: original PR #874, issue #864.

Made with [Cursor](https://cursor.com)