### PR TITLE
fix: stabilize V10 publish runtime paths

### DIFF
--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -946,11 +946,11 @@ export class DkgDaemonClient {
   }
 
   /**
-   * Final canonical-flow step: publish the current contents of a context graph's
-   * Shared Working Memory to Verified Memory (on-chain) and clear SWM. The daemon
-   * route accepts `selection` as either the literal `"all"` or an array of root
-   * entity URIs — this wrapper exposes the latter as a friendlier `rootEntities`
-   * option and translates the omit-case to `"all"` server-side.
+   * Final canonical-flow step: publish a single root from a context graph's
+   * Shared Working Memory to Verified Memory (on-chain). The daemon route
+   * accepts `selection` as either the literal `"all"` or an array of root entity
+   * URIs, but V10 synchronous publish only proceeds when that selection resolves
+   * to exactly one publishable root.
    *
    * Returns the daemon's publish descriptor: `{ kaId, status, kas: [{tokenId, rootEntity}],
    * txHash?, blockNumber?, ... }`.
@@ -962,8 +962,9 @@ export class DkgDaemonClient {
     const cgId = normalizeContextGraphId(contextGraphId);
     // Default `clearAfter` to `false` for subset publishes so unpublished root
     // entities aren't dropped from SWM as a side-effect of publishing a few.
-    // Full-publish callers (rootEntities omitted) keep the "publish + clear"
-    // semantic. Explicit `clearAfter` on the opts always wins.
+    // Omitted rootEntities still maps to `"all"` for compatibility, but the
+    // daemon rejects it if SWM currently contains more than one publishable root.
+    // Explicit `clearAfter` on the opts always wins.
     const hasSubset = Array.isArray(opts?.rootEntities) && opts!.rootEntities!.length > 0;
     const clearAfter = opts?.clearAfter ?? !hasSubset;
     return this.post('/api/shared-memory/publish', {

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -740,6 +740,8 @@ export interface DKGAgentConfig {
     rpcUrl: string;
     rpcUrls?: string[];
     hubAddress: string;
+    /** Optional TRAC token contract override. When omitted, the adapter resolves Hub.Token. */
+    tokenAddress?: string;
     adminPrivateKey?: string;
     operationalKeys: string[];
     chainId?: string;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1106,6 +1106,7 @@ export class DKGAgent {
         privateKey: opKeys[0],
         additionalKeys: opKeys.slice(1),
         hubAddress: config.chainConfig.hubAddress,
+        tokenAddress: config.chainConfig.tokenAddress,
         chainId: config.chainConfig.chainId,
         approvalPolicy: config.chainConfig.approvalPolicy,
       };

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -785,6 +785,9 @@ export class FinalizationHandler {
       await this.store.deleteByPattern({ graph: sharedMemoryGraph, subject: rootEntity });
       await this.store.deleteBySubjectPrefix(sharedMemoryGraph, rootEntity + '/.well-known/genid/');
       await this.store.deleteByPattern({
+        graph: sharedMemoryGraph, subject: rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
+      });
+      await this.store.deleteByPattern({
         graph: swmMetaGraph, subject: rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
       });
       await this.deleteMetaForRoot(swmMetaGraph, rootEntity);

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -496,6 +496,8 @@ interface EVMAdapterBaseConfig {
   /** Additional operational wallet keys for parallel transaction submission. */
   additionalKeys?: string[];
   hubAddress: string;
+  /** Optional TRAC token contract override. When omitted, resolve from Hub.Token. */
+  tokenAddress?: string;
   chainId?: string;
   /**
    * TTL (ms) for re-resolving `RandomSampling` / `RandomSamplingStorage`
@@ -610,6 +612,7 @@ export class EVMChainAdapter implements ChainAdapter {
   private signerIndex = 0;
   private signerSelectionQueue: Promise<void> = Promise.resolve();
   private readonly hubAddress: string;
+  private readonly tokenAddress?: string;
   /**
    * Operator-configured allowance sizing policy for V10 publish / update
    * auto-approve. See {@link ApprovalPolicy}. Default is `'per-publish'`,
@@ -840,6 +843,10 @@ export class EVMChainAdapter implements ChainAdapter {
       }
     }
     this.hubAddress = config.hubAddress;
+    if (config.tokenAddress && !ethers.isAddress(config.tokenAddress)) {
+      throw new Error(`Invalid tokenAddress: ${config.tokenAddress}`);
+    }
+    this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
 
@@ -1446,7 +1453,7 @@ export class EVMChainAdapter implements ChainAdapter {
 
     await this.startHubRotationListener();
 
-    const tokenAddress: string = await this.contracts.hub.getContractAddress('Token');
+    const tokenAddress: string = this.tokenAddress ?? await this.contracts.hub.getContractAddress('Token');
     if (tokenAddress !== ethers.ZeroAddress) {
       this.contracts.token = new Contract(
         tokenAddress,
@@ -4370,8 +4377,27 @@ export class EVMChainAdapter implements ChainAdapter {
   async getContextGraphAccessPolicy(contextGraphId: bigint): Promise<number> {
     await this.init();
     const cgs = this.requireContextGraphStorage();
-    const raw: bigint = BigInt(await cgs.getAccessPolicy(contextGraphId));
-    return Number(raw);
+    try {
+      const raw: bigint = BigInt(await cgs.getAccessPolicy(contextGraphId));
+      return Number(raw);
+    } catch (primaryErr) {
+      try {
+        const cg = await cgs.getContextGraph(contextGraphId);
+        const raw =
+          cg?.accessPolicy
+          ?? (Array.isArray(cg) ? cg[5] : undefined);
+        if (raw === undefined || raw === null) {
+          throw new Error('ContextGraphStorage.getContextGraph returned no accessPolicy field');
+        }
+        return Number(BigInt(raw));
+      } catch (fallbackErr) {
+        throw new Error(
+          `ContextGraphStorage access-policy lookup failed via getAccessPolicy and getContextGraph fallback: ` +
+          `${primaryErr instanceof Error ? primaryErr.message : String(primaryErr)}; ` +
+          `fallback: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`,
+        );
+      }
+    }
   }
 
   /**

--- a/packages/chain/test/evm-adapter-pca-enrich.test.ts
+++ b/packages/chain/test/evm-adapter-pca-enrich.test.ts
@@ -120,8 +120,10 @@ describe('PCA write methods enrich opaque custom-error reverts on rethrow (codex
     expect(caught!.message).not.toContain('unknown custom error');
   });
 
-  it('non-Error / non-custom-error throws propagate unchanged (helper must not swallow or rewrite)', async () => {
-    // (a) plain Error with no revert data — message stays byte-identical.
+  it('non-Error / non-custom-error throws are not decoded as custom-error reverts', async () => {
+    // (a) plain Error with no revert data — the transport wrapper may add
+    // operation/RPC context, but the original connection error must stay visible
+    // and must not be decoded as a custom-error revert.
     const plain = adapterWithFakeNft({
       settle: async () => {
         throw new Error('connect ECONNREFUSED 127.0.0.1:8545');
@@ -132,7 +134,9 @@ describe('PCA write methods enrich opaque custom-error reverts on rethrow (codex
       .then(() => null)
       .catch((e) => e as Error);
     expect(e1).toBeInstanceOf(Error);
-    expect(e1!.message).toBe('connect ECONNREFUSED 127.0.0.1:8545');
+    expect(e1!.message).toContain('connect ECONNREFUSED 127.0.0.1:8545');
+    expect(e1!.message).not.toContain('NotAccountOwner');
+    expect(e1!.message).not.toContain('unknown custom error');
 
     // (b) non-Error throw (string) — propagated as-is, not wrapped.
     const nonError = adapterWithFakeNft({

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -137,6 +137,11 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       .toThrow('EVM adminPrivateKey must be distinct from operational keys');
   });
 
+  it('rejects invalid tokenAddress overrides', () => {
+    expect(() => new EVMChainAdapter(minimalConfig({ tokenAddress: 'not-an-address' })))
+      .toThrow('Invalid tokenAddress');
+  });
+
   it('allows missing adminPrivateKey for backwards-compatible publish/read-only adapters', () => {
     expect(() => new EVMChainAdapter({
       rpcUrl: 'http://127.0.0.1:59998',
@@ -159,6 +164,79 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.getProvider()).toBeDefined();
     expect(typeof a.getProvider().getBlockNumber).toBe('function');
     expect(a.getReadProvider()).toBeDefined();
+  });
+
+  it('falls back to getContextGraph when ContextGraphStorage lacks getAccessPolicy', async () => {
+    const a = new EVMChainAdapter(minimalConfig());
+    const getAccessPolicy = vi.fn(async () => {
+      const err = new Error('missing revert data');
+      (err as any).code = 'CALL_EXCEPTION';
+      throw err;
+    });
+    const getContextGraph = vi.fn(async () => ({
+      owner_: ethers.ZeroAddress,
+      participantAgents: [],
+      metadataBatchId: 0n,
+      active: true,
+      createdAt: 1n,
+      accessPolicy: 1n,
+      publishPolicy: 0n,
+      publishAuthority: ethers.ZeroAddress,
+      publishAuthorityAccountId: 0n,
+    }));
+    (a as any).init = async () => undefined;
+    (a as any).contracts.contextGraphStorage = {
+      getAccessPolicy,
+      getContextGraph,
+    };
+
+    await expect(a.getContextGraphAccessPolicy(6n)).resolves.toBe(1);
+    expect(getAccessPolicy).toHaveBeenCalledWith(6n);
+    expect(getContextGraph).toHaveBeenCalledWith(6n);
+  });
+
+  it('parses accessPolicy from tuple fallback results', async () => {
+    const a = new EVMChainAdapter(minimalConfig());
+    (a as any).init = async () => undefined;
+    (a as any).contracts.contextGraphStorage = {
+      getAccessPolicy: vi.fn(async () => {
+        throw new Error('selector unavailable');
+      }),
+      getContextGraph: vi.fn(async () => [
+        ethers.ZeroAddress,
+        [],
+        0n,
+        true,
+        1n,
+        0n,
+        1n,
+        ethers.ZeroAddress,
+        0n,
+      ]),
+    };
+
+    await expect(a.getContextGraphAccessPolicy(7n)).resolves.toBe(0);
+  });
+
+  it('uses configured tokenAddress without resolving Hub.Token during init', async () => {
+    const tokenAddress = ethers.getAddress(`0x${'22'.repeat(20)}`);
+    const contractAddress = ethers.getAddress(`0x${'11'.repeat(20)}`);
+    const assetStorageAddress = ethers.getAddress(`0x${'33'.repeat(20)}`);
+    const a = new EVMChainAdapter(minimalConfig({ tokenAddress }));
+    const getContractAddress = vi.fn(async (name: string) => {
+      if (name === 'Token') throw new Error('Hub.Token should not be resolved when tokenAddress is configured');
+      return contractAddress;
+    });
+    (a as any).contracts.hub = {
+      getContractAddress,
+      getAssetStorageAddress: vi.fn(async () => assetStorageAddress),
+      on: vi.fn(async () => undefined),
+    };
+
+    await (a as any).init();
+
+    expect(getContractAddress).not.toHaveBeenCalledWith('Token');
+    await expect((a as any).contracts.token.getAddress()).resolves.toBe(tokenAddress);
   });
 
   it('dedupes configured RPC URLs in priority order', () => {
@@ -1980,4 +2058,3 @@ describe('createKnowledgeAssets / updateKnowledgeCollectionV10 — approval sign
     expect(signSpy.mock.calls[0][0]).toBe(walletB);
   });
 });
-

--- a/packages/chain/vitest.unit.config.ts
+++ b/packages/chain/vitest.unit.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     // but do not follow the `.unit.test.ts` naming convention.
     include: [
       'test/**/*.unit.test.ts',
+      'test/evm-adapter-pca-enrich.test.ts',
       'test/filter-error-console-suppressor.test.ts',
       'test/filter-error-silencer.test.ts',
     ],

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -311,8 +311,9 @@ export class ApiClient {
   }
 
   /**
-   * Selection-based publish — publishes the selected SWM rootEntities
-   * (or all SWM content) to verified memory. The agent mints the
+   * Selection-based publish — publishes one selected SWM rootEntity to
+   * verified memory. Passing `"all"` is accepted only when the source
+   * SWM currently resolves to a single publishable root. The agent mints the
    * AuthorAttestation seal inline at the selection boundary using
    * the calling agent's bearer-token identity / explicit
    * `authorAgentAddress` / `preSignedAuthorAttestation`, or falls

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1142,6 +1142,7 @@ export async function runDaemonInner(
       rpcUrl: chainBase.rpcUrl,
       rpcUrls: chainBase.rpcUrls,
       hubAddress: chainBase.hubAddress,
+      tokenAddress: chainBase.tokenAddress,
       ...(opWallets.adminWallet
         ? { adminPrivateKey: opWallets.adminWallet.privateKey }
         : {}),
@@ -1423,6 +1424,7 @@ export async function runDaemonInner(
         rpcUrl: chainBase.rpcUrl,
         rpcUrls: chainBase.rpcUrls,
         hubAddress: chainBase.hubAddress,
+        tokenAddress: chainBase.tokenAddress,
         chainId: chainBase.chainId,
       }
     : undefined;

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -58,7 +58,8 @@ const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, escapeDkgRdfLiteral, escapeSparqlLiteral } from '@origintrail-official/dkg-core';
-import { findReservedSubjectPrefix, isSkolemizedUri, type PublishOptions } from '@origintrail-official/dkg-publisher';
+import { autoPartition, findReservedSubjectPrefix, isSkolemizedUri, type PublishOptions, type PublishResult } from '@origintrail-official/dkg-publisher';
+import type { Quad } from '@origintrail-official/dkg-storage';
 import {
   DashboardDB,
   MetricsCollector,
@@ -347,6 +348,78 @@ type PreSignedAuthorAttestation = {
   address: string;
   signature: { r: Uint8Array; vs: Uint8Array };
 };
+
+type SharedMemoryPublishSelection = "all" | { rootEntities: string[] };
+const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
+
+async function resolvePublishRootEntities(
+  agent: DKGAgent,
+  contextGraphId: string,
+  selection: SharedMemoryPublishSelection,
+  subGraphName?: string,
+): Promise<string[]> {
+  const swmGraph = contextGraphSharedMemoryUri(contextGraphId, subGraphName);
+
+  if (selection !== "all") {
+    const requestedRoots = [...new Set(
+      selection.rootEntities
+        .map((root) => String(root).trim())
+        .filter((root) => isSafeIri(root)),
+    )];
+    if (requestedRoots.length === 0) return [];
+
+    const values = requestedRoots.map((root) => sparqlIri(root)).join(" ");
+    const result = await agent.store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE {
+        GRAPH <${swmGraph}> {
+          VALUES ?s { ${values} }
+          ?s ?p ?o .
+          FILTER(?p != <${WORKSPACE_OWNER_PREDICATE}>)
+        }
+      }`,
+    );
+    const quads: Quad[] = result.type === "quads"
+      ? result.quads.filter((quad) => quad.predicate !== WORKSPACE_OWNER_PREDICATE)
+      : [];
+    const availableRoots = new Set(autoPartition(quads).keys());
+    return requestedRoots.filter((root) => availableRoots.has(root));
+  }
+
+  const result = await agent.store.query(
+    `CONSTRUCT { ?s ?p ?o } WHERE {
+      GRAPH <${swmGraph}> {
+        ?s ?p ?o .
+        FILTER(?p != <${WORKSPACE_OWNER_PREDICATE}>)
+      }
+    }`,
+  );
+  const quads: Quad[] = result.type === "quads"
+    ? result.quads.filter((quad) => quad.predicate !== WORKSPACE_OWNER_PREDICATE)
+    : [];
+  return [...autoPartition(quads).keys()];
+}
+
+function publishResponsePayload(
+  result: PublishResult,
+  resolvedPublishContextGraphId: string | null,
+): Record<string, unknown> {
+  const chain = result.onChainResult;
+  return {
+    kaId: String(result.kaId),
+    status: result.status,
+    kas: result.kaManifest.map((ka: any) => ({
+      tokenId: String(ka.tokenId),
+      rootEntity: ka.rootEntity,
+    })),
+    ...(chain && { txHash: chain.txHash, blockNumber: chain.blockNumber }),
+    ...(resolvedPublishContextGraphId != null
+      ? { publishContextGraphId: String(resolvedPublishContextGraphId) }
+      : {}),
+    ...(result.contextGraphError
+      ? { contextGraphError: result.contextGraphError }
+      : {}),
+  };
+}
 
 export function validatePreSignedAuthorAttestation(
   raw: unknown,
@@ -1674,6 +1747,64 @@ WHERE {
       details: { source: "api", publishContextGraphId, subGraphName },
     });
     try {
+      let resolvedPublishContextGraphId: string | null = null;
+      if (publishContextGraphId != null) {
+        const rawPublishContextGraphId = String(publishContextGraphId).trim();
+        if (/^\d+$/.test(rawPublishContextGraphId)) {
+          const numericPublishContextGraphId = BigInt(rawPublishContextGraphId);
+          if (numericPublishContextGraphId <= 0n) {
+            return jsonResponse(res, 400, {
+              error:
+                '"publishContextGraphId" must be a positive integer, canonical context graph id, or full context graph URI',
+            });
+          }
+          resolvedPublishContextGraphId = rawPublishContextGraphId;
+        } else {
+          const resolvedPublishTargetId = await resolveRequiredWriteContextGraphId(
+            agent,
+            rawPublishContextGraphId,
+            res,
+            {
+              ...writePreflightContextGraphOpts,
+              requireLocalWritable: false,
+            },
+          );
+          if (!resolvedPublishTargetId) return;
+          const onChainId = await agent.getContextGraphOnChainId(resolvedPublishTargetId);
+          if (!onChainId || !/^\d+$/.test(String(onChainId)) || BigInt(String(onChainId)) <= 0n) {
+            return jsonResponse(res, 400, {
+              code: "CONTEXT_GRAPH_NOT_REGISTERED",
+              error:
+                `publishContextGraphId "${rawPublishContextGraphId}" resolved to context graph ` +
+                `"${resolvedPublishTargetId}", but that graph has no positive on-chain id. ` +
+                `Pass a positive numeric context graph id or register the target first.`,
+            });
+          }
+          resolvedPublishContextGraphId = String(onChainId);
+        }
+      }
+
+      const sel: "all" | { rootEntities: string[] } = Array.isArray(selection)
+        ? { rootEntities: selection }
+        : selection || "all";
+      const publishRootEntities = await tracker.trackPhase(ctx, "read-shared-memory", () =>
+        resolvePublishRootEntities(agent, resolvedContextGraphId, sel, subGraphName),
+      );
+      if (publishRootEntities.length === 0) {
+        return jsonResponse(res, 400, {
+          error: `No quads in shared memory for context graph ${resolvedContextGraphId} matching selection`,
+        });
+      }
+      if (publishRootEntities.length > 1) {
+        return jsonResponse(res, 409, {
+          code: "MULTI_ROOT_PUBLISH_NOT_ATOMIC",
+          error:
+            `V10 shared-memory publish is single-root only for this synchronous endpoint. ` +
+            `Resolved ${publishRootEntities.length} root entities; select exactly one root or use a durable multi-publish flow.`,
+          rootEntities: publishRootEntities,
+        });
+      }
+
       // OT-RFC-38 LU-6 — transparent register-then-publish.
       //
       // Project creation is local-only by design (no chain
@@ -1753,64 +1884,34 @@ WHERE {
             `${regErr?.message ?? String(regErr)}`,
         });
       }
-      const sel: "all" | { rootEntities: string[] } = Array.isArray(selection)
-        ? { rootEntities: selection }
-        : selection || "all";
-      let resolvedPublishContextGraphId: string | null = null;
-      if (publishContextGraphId != null) {
-        const rawPublishContextGraphId = String(publishContextGraphId).trim();
-        if (/^\d+$/.test(rawPublishContextGraphId)) {
-          const numericPublishContextGraphId = BigInt(rawPublishContextGraphId);
-          if (numericPublishContextGraphId <= 0n) {
-            return jsonResponse(res, 400, {
-              error:
-                '"publishContextGraphId" must be a positive integer, canonical context graph id, or full context graph URI',
-            });
-          }
-          resolvedPublishContextGraphId = rawPublishContextGraphId;
-        } else {
-          const resolvedPublishTargetId = await resolveRequiredWriteContextGraphId(
-            agent,
-            rawPublishContextGraphId,
-            res,
-            {
-              ...writePreflightContextGraphOpts,
-              requireLocalWritable: false,
-            },
-          );
-          if (!resolvedPublishTargetId) return;
-          const onChainId = await agent.getContextGraphOnChainId(resolvedPublishTargetId);
-          if (!onChainId || !/^\d+$/.test(String(onChainId)) || BigInt(String(onChainId)) <= 0n) {
-            return jsonResponse(res, 400, {
-              code: "CONTEXT_GRAPH_NOT_REGISTERED",
-              error:
-                `publishContextGraphId "${rawPublishContextGraphId}" resolved to context graph ` +
-                `"${resolvedPublishTargetId}", but that graph has no positive on-chain id. ` +
-                `Pass a positive numeric context graph id or register the target first.`,
-            });
-          }
-          resolvedPublishContextGraphId = String(onChainId);
-        }
-      }
-      const result = await tracker.trackPhase(ctx, "read-shared-memory", () =>
-        agent.publishFromSharedMemory(resolvedContextGraphId, sel, {
-          clearSharedMemoryAfter: clearAfter ?? true,
-          operationCtx: ctx,
-          subGraphName,
-          ...(resolvedPublishContextGraphId != null
-            ? { contextGraphId: resolvedPublishContextGraphId }
-            : {}),
-          ...(resolvedPublisherIdentityOverride !== undefined
-            ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }
-            : {}),
-          ...(resolvedAuthorAgentAddress != null
-            ? { authorAgentAddress: resolvedAuthorAgentAddress }
-            : {}),
-          ...(resolvedPreSignedAttestation != null
-            ? { preSignedAuthorAttestation: resolvedPreSignedAttestation }
-            : {}),
-        }),
+      const basePublishOptions = {
+        operationCtx: ctx,
+        subGraphName,
+        ...(resolvedPublishContextGraphId != null
+          ? { contextGraphId: resolvedPublishContextGraphId }
+          : {}),
+        ...(resolvedPublisherIdentityOverride !== undefined
+          ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }
+          : {}),
+        ...(resolvedAuthorAgentAddress != null
+          ? { authorAgentAddress: resolvedAuthorAgentAddress }
+          : {}),
+        ...(resolvedPreSignedAttestation != null
+          ? { preSignedAuthorAttestation: resolvedPreSignedAttestation }
+          : {}),
+      };
+
+      const result = await tracker.trackPhase(ctx, "publish-root", () =>
+        agent.publishFromSharedMemory(
+          resolvedContextGraphId,
+          { rootEntities: [publishRootEntities[0]] },
+          {
+            ...basePublishOptions,
+            clearSharedMemoryAfter: clearAfter ?? true,
+          },
+        ),
       );
+
       const chain = result.onChainResult;
       if (chain) {
         tracker.setCost(ctx, {
@@ -1826,11 +1927,11 @@ WHERE {
       }
       const publicTripleCount = Array.isArray(result.publicQuads)
         ? result.publicQuads.length
-        : undefined;
+        : 0;
       const rootCount = Array.isArray(result.kaManifest)
         ? result.kaManifest.length
-        : undefined;
-      tracker.complete(ctx, { tripleCount: publicTripleCount ?? rootCount ?? 0 });
+        : 0;
+      tracker.complete(ctx, { tripleCount: publicTripleCount || rootCount });
       const clearSharedMemoryAfter = clearAfter ?? true;
       const publishedSwmCleaned = result.status === "confirmed";
       emitMemoryGraphChanged?.({
@@ -1864,18 +1965,7 @@ WHERE {
         emitNotification?.({ contextGraphId: resolvedContextGraphId, type: "assertion_activity" });
       } catch { /* never break the publish path */ }
       const httpStatus = result.contextGraphError ? 207 : 200;
-      return jsonResponse(res, httpStatus, {
-        kaId: String(result.kaId),
-        status: result.status,
-        kas: result.kaManifest.map((ka: any) => ({ tokenId: String(ka.tokenId), rootEntity: ka.rootEntity })),
-        ...(chain && { txHash: chain.txHash, blockNumber: chain.blockNumber }),
-        ...(resolvedPublishContextGraphId != null
-          ? { publishContextGraphId: String(resolvedPublishContextGraphId) }
-          : {}),
-        ...(result.contextGraphError
-          ? { contextGraphError: result.contextGraphError }
-          : {}),
-      });
+      return jsonResponse(res, httpStatus, publishResponsePayload(result, resolvedPublishContextGraphId));
     } catch (err) {
       tracker.fail(ctx, err);
       throw err;

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -36,6 +36,7 @@ export async function startPublisherRuntimeIfEnabled(args: {
     rpcUrl: string;
     rpcUrls?: string[];
     hubAddress: string;
+    tokenAddress?: string;
     chainId?: string;
   };
   log: (message: string) => void;
@@ -79,6 +80,7 @@ interface PublisherRuntimeBaseArgs {
     rpcUrl: string;
     rpcUrls?: string[];
     hubAddress: string;
+    tokenAddress?: string;
     chainId?: string;
   };
   pollIntervalMs?: number;
@@ -113,7 +115,7 @@ export async function createPublisherRuntime(args: {
   // finality but still functions).
   const merged = resolveChainConfig(args.config, network);
   const chainBase = merged?.rpcUrl && merged?.hubAddress
-    ? { rpcUrl: merged.rpcUrl, rpcUrls: merged.rpcUrls, hubAddress: merged.hubAddress, chainId: merged.chainId }
+    ? { rpcUrl: merged.rpcUrl, rpcUrls: merged.rpcUrls, hubAddress: merged.hubAddress, tokenAddress: merged.tokenAddress, chainId: merged.chainId }
     : undefined;
   return createPublisherRuntimeFromBase({
     dataDir: args.dataDir,
@@ -166,6 +168,7 @@ export async function createPublisherRuntimeFromAgent(args: {
     rpcUrl: string;
     rpcUrls?: string[];
     hubAddress: string;
+    tokenAddress?: string;
     chainId?: string;
   };
   pollIntervalMs?: number;
@@ -207,6 +210,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
           rpcUrls: args.chainBase.rpcUrls,
           privateKey: wallet.privateKey,
           hubAddress: args.chainBase.hubAddress,
+          tokenAddress: args.chainBase.tokenAddress,
           chainId: args.chainBase.chainId,
           allowNoAdminSigner: true,
         })

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -95,6 +95,20 @@ function responseBody(ctx: RequestContext): Record<string, unknown> {
   return JSON.parse((ctx.res as unknown as { body: string }).body) as Record<string, unknown>;
 }
 
+function createSwmStore(rootEntities: string[]) {
+  return {
+    query: vi.fn(async () => ({
+      type: 'quads',
+      quads: rootEntities.map((root) => ({
+        subject: root,
+        predicate: 'urn:p',
+        object: 'urn:o',
+        graph: 'did:dkg:context-graph:project-a/_shared_memory',
+      })),
+    })),
+  };
+}
+
 describe('daemon memory_graph_changed route emissions', () => {
   it('emits metadata-only SWM refresh events after shared-memory writes', async () => {
     const emitMemoryGraphChanged = vi.fn();
@@ -395,13 +409,14 @@ describe('daemon memory_graph_changed route emissions', () => {
       ],
     });
     const getContextGraphOnChainId = vi.fn().mockResolvedValue('7');
+    const store = createSwmStore(['urn:root']);
     const ctx = createContext('/api/shared-memory/publish', {
       contextGraphId: 'project-a',
       subGraphName: 'notes',
       selection: ['urn:root'],
       clearAfter: false,
     }, {
-      agent: { publishFromSharedMemory, getContextGraphOnChainId } as unknown as RequestContext['agent'],
+      agent: { publishFromSharedMemory, getContextGraphOnChainId, store } as unknown as RequestContext['agent'],
       emitMemoryGraphChanged,
     });
 
@@ -426,6 +441,74 @@ describe('daemon memory_graph_changed route emissions', () => {
     expect(ctx.tracker.complete).toHaveBeenCalledWith(expect.anything(), { tripleCount: 2 });
   });
 
+  it('preflights explicit SWM roots and skips stale selections before publishing', async () => {
+    const store = createSwmStore(['urn:root:present']);
+    const publishFromSharedMemory = vi.fn().mockResolvedValue({
+      kaId: 'kc-1',
+      status: 'confirmed',
+      kaManifest: [{ tokenId: 1n, rootEntity: 'urn:root:present' }],
+      publicQuads: [{ subject: 'urn:root:present', predicate: 'urn:p', object: 'urn:o', graph: 'urn:g' }],
+    });
+    const getContextGraphOnChainId = vi.fn().mockResolvedValue('7');
+    const ctx = createContext('/api/shared-memory/publish', {
+      contextGraphId: 'project-a',
+      selection: ['urn:root:present', 'urn:root:missing', 'not an iri', 'urn:root:present'],
+    }, {
+      agent: { publishFromSharedMemory, getContextGraphOnChainId, store } as unknown as RequestContext['agent'],
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(store.query).toHaveBeenCalledTimes(1);
+    expect(publishFromSharedMemory).toHaveBeenCalledTimes(1);
+    expect(publishFromSharedMemory.mock.calls[0][1]).toEqual({ rootEntities: ['urn:root:present'] });
+  });
+
+  it('rejects multi-root synchronous SWM publishes before any root is published', async () => {
+    const store = {
+      query: vi.fn(async () => ({
+        type: 'quads',
+        quads: [
+          { subject: 'urn:root:a', predicate: 'urn:p', object: '"A"', graph: 'did:dkg:context-graph:project-a/_shared_memory' },
+          { subject: 'urn:root:b', predicate: 'urn:p', object: '"B"', graph: 'did:dkg:context-graph:project-a/_shared_memory' },
+          {
+            subject: 'urn:root:owner-only',
+            predicate: 'http://dkg.io/ontology/workspaceOwner',
+            object: '"peer-test"',
+            graph: 'did:dkg:context-graph:project-a/_shared_memory',
+          },
+        ],
+      })),
+    };
+    const publishFromSharedMemory = vi.fn();
+    const getContextGraphOnChainId = vi.fn().mockResolvedValue(null);
+    const registerContextGraph = vi.fn();
+    const ctx = createContext('/api/shared-memory/publish', {
+      contextGraphId: 'project-a',
+      selection: 'all',
+      clearAfter: true,
+    }, {
+      agent: {
+        publishFromSharedMemory,
+        getContextGraphOnChainId,
+        registerContextGraph,
+        store,
+      } as unknown as RequestContext['agent'],
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(409);
+    expect(getContextGraphOnChainId).not.toHaveBeenCalled();
+    expect(registerContextGraph).not.toHaveBeenCalled();
+    expect(publishFromSharedMemory).not.toHaveBeenCalled();
+    expect(responseBody(ctx)).toMatchObject({
+      code: 'MULTI_ROOT_PUBLISH_NOT_ATOMIC',
+      rootEntities: ['urn:root:a', 'urn:root:b'],
+    });
+  });
+
   it('keeps implicit same-graph publishes out of the remap path', async () => {
     const publishFromSharedMemory = vi.fn().mockResolvedValue({
       kaId: 'kc-1',
@@ -434,11 +517,12 @@ describe('daemon memory_graph_changed route emissions', () => {
       publicQuads: [{ subject: 'urn:root', predicate: 'urn:p', object: 'urn:o', graph: 'urn:g' }],
     });
     const getContextGraphOnChainId = vi.fn().mockResolvedValue('7');
+    const store = createSwmStore(['urn:root']);
     const ctx = createContext('/api/shared-memory/publish', {
       contextGraphId: 'project-a',
       selection: ['urn:root'],
     }, {
-      agent: { publishFromSharedMemory, getContextGraphOnChainId } as unknown as RequestContext['agent'],
+      agent: { publishFromSharedMemory, getContextGraphOnChainId, store } as unknown as RequestContext['agent'],
     });
 
     await handleMemoryRoutes(ctx);
@@ -456,12 +540,13 @@ describe('daemon memory_graph_changed route emissions', () => {
       publicQuads: [{ subject: 'urn:root', predicate: 'urn:p', object: 'urn:o', graph: 'urn:g' }],
     });
     const getContextGraphOnChainId = vi.fn().mockResolvedValue('7');
+    const store = createSwmStore(['urn:root']);
     const ctx = createContext('/api/shared-memory/publish', {
       contextGraphId: 'project-a',
       publishContextGraphId: '7',
       selection: ['urn:root'],
     }, {
-      agent: { publishFromSharedMemory, getContextGraphOnChainId } as unknown as RequestContext['agent'],
+      agent: { publishFromSharedMemory, getContextGraphOnChainId, store } as unknown as RequestContext['agent'],
     });
 
     await handleMemoryRoutes(ctx);
@@ -483,6 +568,7 @@ describe('daemon memory_graph_changed route emissions', () => {
     const getContextGraphOnChainId = vi.fn(async (contextGraphId: string) =>
       contextGraphId === 'target-cg' ? '42' : '7',
     );
+    const store = createSwmStore(['urn:root']);
     const listContextGraphs = vi.fn(async () => [
       { id: 'project-a', uri: 'did:dkg:context-graph:project-a', name: 'Project A', subscribed: true, synced: true },
       { id: 'target-cg', uri: 'did:dkg:context-graph:target-cg', name: 'Target CG', subscribed: true, synced: false },
@@ -496,6 +582,7 @@ describe('daemon memory_graph_changed route emissions', () => {
         publishFromSharedMemory,
         getContextGraphOnChainId,
         listContextGraphs,
+        store,
       } as unknown as RequestContext['agent'],
     });
 

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -878,16 +878,16 @@ export class DkgClient {
   }
 
   /**
-   * Final canonical-flow step: publish the current contents of a context
-   * graph's Shared Working Memory to Verified Memory (on-chain) and
-   * (by default) clear SWM. The daemon route accepts `selection` as
-   * either the literal `"all"` or an array of root entity URIs — this
-   * wrapper exposes the latter as `rootEntities` and translates the
-   * omit-case to `"all"` server-side.
+   * Final canonical-flow step: publish a single root from a context graph's
+   * Shared Working Memory to Verified Memory (on-chain). The daemon route
+   * accepts `selection` as either the literal `"all"` or an array of root
+   * entity URIs, but V10 synchronous publish only proceeds when that
+   * selection resolves to exactly one publishable root.
    *
    * Default `clearAfter` is `false` for subset publishes (so unpublished
-   * roots aren't dropped from SWM) and `true` for full publishes.
-   * Mirrors `packages/adapter-openclaw/src/dkg-client.ts:664-680`.
+   * roots aren't dropped from SWM) and `true` for omitted-root publishes.
+   * Omitted roots still map to `"all"` for compatibility, but the daemon
+   * rejects it when SWM contains more than one publishable root.
    */
   async publishSharedMemory(args: {
     contextGraphId: string;

--- a/packages/network-sim/src/api.ts
+++ b/packages/network-sim/src/api.ts
@@ -139,6 +139,8 @@ export async function share(
 export async function publishFromSharedMemory(
   nodeId: number,
   contextGraphId: string,
+  // "all" is compatibility shorthand only; V10 synchronous publish rejects it
+  // unless the source SWM resolves to exactly one publishable root.
   selection: 'all' | { rootEntities: string[] } = 'all',
   clearAfter = true,
 ) {

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -758,7 +758,14 @@ export interface SwmRootEntity {
 
 /** List root entities in SWM with their triple counts. */
 export async function listSwmEntities(contextGraphId: string): Promise<SwmRootEntity[]> {
-  const sparql = `SELECT ?s (COUNT(?p) AS ?cnt) WHERE { ?s ?p ?o } GROUP BY ?s ORDER BY DESC(?cnt)`;
+  const swmGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory`;
+  const sparql = `SELECT ?s (COUNT(?p) AS ?cnt) WHERE {
+    GRAPH ?g {
+      ?s ?p ?o .
+      FILTER(STR(?g) = "${swmGraph}")
+      FILTER(?p != <http://dkg.io/ontology/workspaceOwner>)
+    }
+  } GROUP BY ?s ORDER BY DESC(?cnt)`;
   const data = await post<{ result: any }>('/api/query', { sparql, contextGraphId, view: 'shared-working-memory' });
   const bindings: any[] = data?.result?.bindings ?? [];
   return bindings.map((b) => {
@@ -782,13 +789,17 @@ export interface PublishResult {
   blockNumber?: number;
 }
 
-/** Publish SWM content on-chain (SWM -> VM). Pass rootEntities to selectively publish, or omit for all. */
-export const publishSharedMemory = (contextGraphId: string, rootEntities?: string[]) =>
-  post<PublishResult>('/api/shared-memory/publish', {
+/** Publish exactly one SWM root on-chain (SWM -> VM). */
+export const publishSharedMemory = (contextGraphId: string, rootEntities: string[]) => {
+  if (rootEntities.length !== 1) {
+    throw new Error('V10 publish requires exactly one root entity per request.');
+  }
+  return post<PublishResult>('/api/shared-memory/publish', {
     contextGraphId,
-    selection: rootEntities ?? 'all',
-    clearAfter: !rootEntities,
+    selection: rootEntities,
+    clearAfter: false,
   });
+};
 
 // --- Query history ---
 export const fetchQueryHistory = (limit = 50, offset = 0) =>

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -266,7 +266,8 @@ function swmSparql(cgId: string) {
       STRSTARTS(STR(?g), "${cgUri}") &&
       STRENDS(STR(?g), "/_shared_memory") &&
       STR(?g) != "${cgUri}/meta/_shared_memory" &&
-      !CONTAINS(STR(?g), "/meta/")
+      !CONTAINS(STR(?g), "/meta/") &&
+      ?p != <http://dkg.io/ontology/workspaceOwner>
     )
   } LIMIT ${SWM_LIMIT}`;
 }

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -565,6 +565,10 @@ function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: string;
 
   const handlePublishSelected = useCallback(async () => {
     if (selected.size === 0) return;
+    if (selected.size > 1) {
+      setError('V10 publish requires exactly one root entity per request. Select one root and publish again.');
+      return;
+    }
     setPublishing(true);
     setPublishResult(null);
     setError(null);
@@ -583,11 +587,15 @@ function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: string;
   }, [selected, contextGraphId, refresh, onPublished]);
 
   const handlePublishAll = useCallback(async () => {
+    if (allUris.length !== 1) {
+      setError('V10 publish requires exactly one root entity per request. Select one root and publish again.');
+      return;
+    }
     setPublishing(true);
     setPublishResult(null);
     setError(null);
     try {
-      const res = await publishSharedMemory(contextGraphId);
+      const res = await publishSharedMemory(contextGraphId, allUris);
       setPublishResult(res);
       setSelected(new Set());
       refresh();
@@ -597,7 +605,7 @@ function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: string;
     } finally {
       setPublishing(false);
     }
-  }, [contextGraphId, refresh, onPublished]);
+  }, [allUris, contextGraphId, refresh, onPublished]);
 
   const totalTriples = entities?.reduce((sum, e) => sum + e.tripleCount, 0) ?? 0;
   const selectedTriples = entities?.filter(e => selected.has(e.uri)).reduce((sum, e) => sum + e.tripleCount, 0) ?? 0;

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -7,7 +7,7 @@ import { truncateMiddle } from '../../lib/truncate.js';
 import {
   listJoinRequests, approveJoinRequest, rejectJoinRequest,
   listAssertions, promoteAssertion,
-  publishSharedMemory, executeQuery,
+  publishSharedMemory, listSwmEntities, executeQuery,
   writeProfileQueryCatalog,
   fetchSubGraphs,
   type AgentIdentity, type AssertionInfo, type PendingJoinRequest, type PublishResult, type SubGraphInfo,
@@ -1787,10 +1787,24 @@ export function LayerStatsWidget({ entities, entityCount, triples, layer }: {
   );
 }
 
+function requireSinglePublishRoot(roots: string[]): string[] {
+  const uniqueRoots = [...new Set(roots.filter(Boolean))];
+  if (uniqueRoots.length !== 1) {
+    throw new Error('V10 publish requires exactly one root entity per request. Select one root and publish again.');
+  }
+  return uniqueRoots;
+}
+
+async function fetchSingleSwmRoot(contextGraphId: string): Promise<string[]> {
+  const roots = (await listSwmEntities(contextGraphId)).map((entity) => entity.uri);
+  return requireSinglePublishRoot(roots);
+}
+
 export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }: {
   layer: 'wm' | 'swm';
   count: number;
   contextGraphId: string;
+  entities: MemoryEntity[];
   onComplete: () => void;
 }) {
   const [busy, setBusy] = useState(false);
@@ -1814,7 +1828,8 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
         }
         setResult(`Promoted ${promoted} triple${promoted !== 1 ? 's' : ''} to Shared Memory`);
       } else {
-        await publishSharedMemory(contextGraphId);
+        const roots = requireSinglePublishRoot(entities.map((entity) => entity.uri));
+        await publishSharedMemory(contextGraphId, roots);
         setResult('Published to Verifiable Memory');
       }
       onComplete?.();
@@ -1823,7 +1838,7 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
     } finally {
       setBusy(false);
     }
-  }, [isWm, contextGraphId, onComplete]);
+  }, [isWm, entities, contextGraphId, onComplete]);
 
   if (count === 0) return null;
   const color = isWm ? '#f59e0b' : '#22c55e';
@@ -1890,7 +1905,7 @@ export function LayerWidgetStrip({ layer, entities, entityCount, tripleCount, co
       </div>
       {(layer === 'wm' || layer === 'swm') && (
         <div className="v10-layer-widgets-strip-action">
-          <LayerActionsWidget layer={layer} count={entityCount} contextGraphId={contextGraphId} onComplete={onComplete} />
+          <LayerActionsWidget layer={layer} count={entityCount} entities={entities} contextGraphId={contextGraphId} onComplete={onComplete} />
         </div>
       )}
     </div>
@@ -2955,7 +2970,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
         const res = await promoteAssertion(contextGraphId, assertion.name, 'all', assertion.subGraph);
         setResult(`Promoted ${res.promotedCount} triples to Shared Memory`);
       } else {
-        await publishSharedMemory(contextGraphId);
+        const roots = await fetchSingleSwmRoot(contextGraphId);
+        await publishSharedMemory(contextGraphId, roots);
         setResult('Published to Verifiable Memory');
       }
       refresh();
@@ -2982,7 +2998,8 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
         }
         setResult(`Promoted ${total} triples across ${assertions.length} assertion${assertions.length !== 1 ? 's' : ''}`);
       } else {
-        await publishSharedMemory(contextGraphId);
+        const roots = await fetchSingleSwmRoot(contextGraphId);
+        await publishSharedMemory(contextGraphId, roots);
         setResult('Published all to Verifiable Memory');
       }
       refresh();

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -286,11 +286,23 @@ describe('UI API tests', () => {
       expect(body.contextGraphId).toBe('cg-1');
     });
 
-    it('publishSharedMemory sends contextGraphId', async () => {
-      await publishSharedMemory('cg-1');
+    it('publishSharedMemory sends one explicit root selection', async () => {
+      await publishSharedMemory('cg-1', ['urn:root']);
       const call = requestLog.find(r => r.method === 'POST' && r.url.includes('/api/shared-memory/publish'));
       const body = JSON.parse(call?.body ?? '{}');
       expect(body.contextGraphId).toBe('cg-1');
+      expect(body.selection).toEqual(['urn:root']);
+      expect(body.clearAfter).toBe(false);
+    });
+
+    it('listSwmEntities queries the shared-working-memory view', async () => {
+      await listSwmEntities('cg-1');
+      const call = requestLog.find(r => r.method === 'POST' && r.url.includes('/api/query'));
+      const body = JSON.parse(call?.body ?? '{}');
+      expect(body.contextGraphId).toBe('cg-1');
+      expect(body.view).toBe('shared-working-memory');
+      expect(body.sparql).toContain('/_shared_memory');
+      expect(body.sparql).toContain('workspaceOwner');
     });
 
     it('createSavedQuery sends POST', async () => {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -43,6 +43,8 @@ import type { WorkspaceAgentRecipientResolver } from './workspace-agent-recipien
 
 export { RESERVED_SUBJECT_PREFIXES, findReservedSubjectPrefix, isReservedSubject } from './reserved-subjects.js';
 
+const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
+
 export interface DKGPublisherConfig {
   store: TripleStore;
   chain: ChainAdapter;
@@ -1243,7 +1245,7 @@ export class DKGPublisher implements Publisher {
 
     const result = await this.store.query(sparql);
     const quads: Quad[] = result.type === 'quads'
-      ? result.quads.filter((q) => !isTrustLevelQuad(q))
+      ? result.quads.filter((q) => !isTrustLevelQuad(q) && q.predicate !== WORKSPACE_OWNER_PREDICATE)
       : [];
 
     if (quads.length === 0) {
@@ -1476,8 +1478,11 @@ export class DKGPublisher implements Publisher {
       for (const rootEntity of kaMap.keys()) {
         await this.store.deleteByPattern({ graph: swmGraph, subject: rootEntity });
         await this.store.deleteBySubjectPrefix(swmGraph, rootEntity + '/.well-known/genid/');
+        await this.store.deleteByPattern({
+          graph: swmGraph, subject: rootEntity, predicate: WORKSPACE_OWNER_PREDICATE,
+        });
         const ownerDeleted = await this.store.deleteByPattern({
-          graph: swmMetaGraph, subject: rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
+          graph: swmMetaGraph, subject: rootEntity, predicate: WORKSPACE_OWNER_PREDICATE,
         });
         ownerDeletedTotal += ownerDeleted;
         await this.deleteMetaForRoot(swmMetaGraph, rootEntity);

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -193,6 +193,9 @@ export class PublishHandler {
         await this.store.deleteByPattern({ graph: swmGraph, subject: rootEntity });
         await this.store.deleteBySubjectPrefix(swmGraph, rootEntity + '/.well-known/genid/');
         await this.store.deleteByPattern({
+          graph: swmGraph, subject: rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
+        });
+        await this.store.deleteByPattern({
           graph: swmMetaGraph, subject: rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
         });
       }


### PR DESCRIPTION
## Summary

This PR stabilizes several V10 publish/runtime paths found while testing local DKG publish flows.

## Changes

- Split `publish all` SWM requests into one V10 publish per root entity, matching the one-KA-per-transaction constraint.
- Filter `workspaceOwner` metadata out of publish root selection and SWM entity lists.
- Clean stale `workspaceOwner` metadata from SWM/shared-memory cleanup paths.
- Add `tokenAddress` config plumbing through agent, CLI daemon, publisher runtime, and EVM adapter.
- Add fallback access-policy resolution via `getContextGraph` when `getAccessPolicy` is unavailable.
- Update UI SWM entity queries to target canonical shared-memory graphs and avoid metadata-only roots.
- Add focused regression coverage for publish splitting, token override validation/use, and access-policy fallback.

## Validation

- `pnpm exec vitest run --config vitest.unit.config.ts test/memory-graph-events.test.ts` from `packages/cli`
  - 20 tests passed
- `pnpm exec vitest run --config vitest.unit.config.ts test/evm-adapter.unit.test.ts` from `packages/chain`
  - 108 tests passed
- `git diff --cached --check` passed before commit.