### PR TITLE
test(chain): tolerate sendContractTransaction RPC-exhaustion wrap in PCA enrich test

### DIFF
--- a/packages/chain/test/evm-adapter-pca-enrich.test.ts
+++ b/packages/chain/test/evm-adapter-pca-enrich.test.ts
@@ -121,7 +121,12 @@ describe('PCA write methods enrich opaque custom-error reverts on rethrow (codex
   });
 
   it('non-Error / non-custom-error throws propagate unchanged (helper must not swallow or rewrite)', async () => {
-    // (a) plain Error with no revert data — message stays byte-identical.
+    // (a) plain Error with no revert data — the PCA-enrichment helper
+    // must not rewrite or swallow the inner classification. The
+    // transport (`sendContractTransaction`) is allowed to prefix
+    // operator context (RPC endpoint exhaustion) and attach the
+    // original via `.cause`, so we assert the original message is
+    // preserved as a substring rather than byte-identical.
     const plain = adapterWithFakeNft({
       settle: async () => {
         throw new Error('connect ECONNREFUSED 127.0.0.1:8545');
@@ -132,7 +137,7 @@ describe('PCA write methods enrich opaque custom-error reverts on rethrow (codex
       .then(() => null)
       .catch((e) => e as Error);
     expect(e1).toBeInstanceOf(Error);
-    expect(e1!.message).toBe('connect ECONNREFUSED 127.0.0.1:8545');
+    expect(e1!.message).toContain('connect ECONNREFUSED 127.0.0.1:8545');
 
     // (b) non-Error throw (string) — propagated as-is, not wrapped.
     const nonError = adapterWithFakeNft({


### PR DESCRIPTION
## Summary

PR #883 (`9810bf72`) introduced operator-context wrapping in `EVMChainAdapter.sendContractTransaction` so that when every configured RPC endpoint exhausts, the rethrown `Error` is prefixed with

```
<label> transaction preparation failed on all configured RPC endpoints (<urls>): <inner>
```

and the original error is attached via `.cause`.

`packages/chain/test/evm-adapter-pca-enrich.test.ts` — `non-Error / non-custom-error throws propagate unchanged` — was written before that wrap existed and asserts byte-identical message equality (`toBe`) on the rethrown plain `Error`. With the wrap in place the assertion fails deterministically on **every** PR targeting `main`, blocking the entire `Tornado: core + storage + chain` job and gating downstream merges.

The test's stated invariant — *"helper must not swallow or rewrite"* — is about the PCA custom-error **enrichment helper**, not the transport. The transport's added context is intentional and the original message is preserved as a substring (and via `.cause`), so relaxing `toBe` → `toContain` keeps the spirit while unblocking CI.

### Confirmed CI failure on every recent PR

```
AssertionError: expected 'settle publishing conviction account …' to be 'connect ECONNREFUSED 127.0.0.1:8545'

Expected: "connect ECONNREFUSED 127.0.0.1:8545"
Received: "settle publishing conviction account transaction preparation failed on all
           configured RPC endpoints (http://127.0.0.1:59998): connect ECONNREFUSED 127.0.0.1:8545"

  packages/chain/test/evm-adapter-pca-enrich.test.ts:135
```

### Diff

A 1-line assertion relax + a comment update explaining the contract:

- `expect(e1!.message).toBe('connect ECONNREFUSED 127.0.0.1:8545');`
- `expect(e1!.message).toContain('connect ECONNREFUSED 127.0.0.1:8545');`

### PRs unblocked by this fix (chain-test axis)

#693, #884, #885, #896, #897, #898, #899

(`Bura: cli` is a separate main-CI regression and will be addressed in a follow-up.)

## Test plan

- [x] `pnpm exec vitest run packages/chain/test/evm-adapter-pca-enrich.test.ts` → **3/3 passed** locally
- [ ] CI green on this PR
- [ ] After merge: re-run CI on #897 / #898 / #899 / #884 / #693 to confirm chain test now passes

Made with [Cursor](https://cursor.com)