### PR TITLE
fix(agent): skip redundant boot-time getIdentityId recovery on BOOT_CHAIN_TIMEOUT (follow-up to #894)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1760,16 +1760,31 @@ export class DKGAgent {
         }
       } catch (err) {
         this.log.warn(ctx, `ensureProfile error: ${err instanceof Error ? err.message : String(err)}`);
-        try {
-          onChainIdentityId = await raceWithBootTimeout(
-            this.chain.getIdentityId(),
-            BOOT_CHAIN_IDENTITY_TIMEOUT_MS,
-            'boot getIdentityId (recovery)',
-          );
-          if (onChainIdentityId > 0n) {
-            this.log.info(ctx, `Recovered identityId=${onChainIdentityId} after partial failure`);
-          }
-        } catch { /* ignore — boot proceeds with identity unresolved */ }
+        // The recovery `getIdentityId` is only useful when the original
+        // `getIdentityId` succeeded but `ensureProfile` later failed (e.g.
+        // gas exhaustion / chain revert) — in that case the chain is
+        // reachable and a fresh read may pick up a partially-created
+        // identity. When the original itself timed out (BOOT_CHAIN_TIMEOUT,
+        // see #894), the RPC is unreachable / rate-limited and a recovery
+        // attempt just doubles the boot delay (40s → past the 45s harness
+        // ceiling), surfacing as `Daemon did not become ready within 45s`
+        // in `daemon-http-behavior-extra.test.ts`. Skip the redundant retry
+        // on that path; on every other path keep the recovery behaviour.
+        const bootChainTimeout =
+          err instanceof Error &&
+          (err as Error & { code?: string }).code === 'BOOT_CHAIN_TIMEOUT';
+        if (!bootChainTimeout) {
+          try {
+            onChainIdentityId = await raceWithBootTimeout(
+              this.chain.getIdentityId(),
+              BOOT_CHAIN_IDENTITY_TIMEOUT_MS,
+              'boot getIdentityId (recovery)',
+            );
+            if (onChainIdentityId > 0n) {
+              this.log.info(ctx, `Recovered identityId=${onChainIdentityId} after partial failure`);
+            }
+          } catch { /* ignore — boot proceeds with identity unresolved */ }
+        }
         // The boot identity block threw. If it left identity at 0n AND the
         // failure is TRANSIENT (RPC unreachable/slow/rate-limited), flag it so
         // the StorageACK path re-resolves and recovers once the chain is back


### PR DESCRIPTION
## Summary

Small follow-up to @Jurij89's #894 (`8c6a88aa`) on this PR (#901).

The catch block after the wrapped \`raceWithBootTimeout(getIdentityId)\` / \`ensureProfile\` always runs a *recovery* \`getIdentityId\` retry. That retry is correct when \`ensureProfile\` itself failed on a reachable chain (the original \`getIdentityId\` succeeded — a fresh read may pick up a partially-created identity).

But when the original \`getIdentityId\` itself **timed out** (\`code === 'BOOT_CHAIN_TIMEOUT'\`), the chain is unreachable / rate-limited and the recovery retry just doubles the boot delay (\`20s + 20s = 40s\`), pushing daemon HTTP readiness right at the edge of the CLI harness's 45s ceiling.

Locally on \`daemon-http-behavior-extra.test.ts > returns 503 when context graph register exhausts configured chain RPC endpoints\`, this manifests as the original \`Daemon did not become ready within 45s\` failure even with #894 in place. With this fix, boot succeeds (the test then reveals a separate \`register\`-hang issue that's flagged in my comment on #901).

## Diff

```ts
} catch (err) {
  this.log.warn(ctx, \`ensureProfile error: ...\`);
+ const bootChainTimeout =
+   err instanceof Error &&
+   (err as Error & { code?: string }).code === 'BOOT_CHAIN_TIMEOUT';
+ if (!bootChainTimeout) {
    try {
      onChainIdentityId = await raceWithBootTimeout(
        this.chain.getIdentityId(),
        BOOT_CHAIN_IDENTITY_TIMEOUT_MS,
        'boot getIdentityId (recovery)',
      );
      // ...
    } catch { /* ignore */ }
+ }
}
```

## Test plan

- [x] \`pnpm exec vitest run packages/cli/test/daemon-http-behavior-extra.test.ts -t \"returns 503 when context graph register exhausts\"\` → **boot phase now succeeds** locally (no 45s ready failure). The test still hits the 120s vitest timeout because of the separate \`register\`-route hang documented in my comment on #901.
- [ ] CI on this PR.
- [ ] Once register-route is bounded too, this test should fully pass.

Made with [Cursor](https://cursor.com)