### PR TITLE
feat(agent): prefer Core nodes in catch-up peer ordering

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3640,6 +3640,11 @@ export class DKGAgent {
       preferredPeerId,
       isPrivateContextGraph,
     );
+    const coreCount = peers.filter((p) => this.knownCorePeerIds.has(p.toString())).length;
+    this.log.info(
+      ctx,
+      `catchup peer order for "${contextGraphId}": preferred=${preferredPeerId ?? 'none'} cores=${coreCount} total=${peers.length}`,
+    );
     return this.runCatchupOverPeers(contextGraphId, includeSharedMemory, peers);
   }
 
@@ -3934,7 +3939,7 @@ export class DKGAgent {
     preferredPeerId?: string,
     privateOnly = false,
   ): Array<{ toString(): string }> {
-    return orderCatchupPeers(peers, preferredPeerId, privateOnly);
+    return orderCatchupPeers(peers, preferredPeerId, privateOnly, this.knownCorePeerIds);
   }
 
   private async resolvePreferredSyncPeerId(contextGraphId: string): Promise<string | undefined> {
@@ -12346,7 +12351,7 @@ export class DKGAgent {
   }>> {
     const ctx = createOperationContext('share');
     const explicitPeers = options?.peers;
-    const candidates: string[] = (() => {
+    const rawCandidates: string[] = (() => {
       if (explicitPeers && explicitPeers.length > 0) return [...new Set(explicitPeers)];
       const connections = this.node.libp2p.getConnections();
       const seen = new Set<string>();
@@ -12356,6 +12361,16 @@ export class DKGAgent {
       }
       return [...seen];
     })();
+    // Contact reliable Core hosts first. This serial loop still reaches
+    // every candidate, but Cores first means faster time-to-first-data
+    // and a better resume-seqno baseline before any flaky edge is tried.
+    const candidates = orderCatchupPeers(rawCandidates, undefined, false, this.knownCorePeerIds)
+      .map((p) => p.toString());
+    const coreCount = candidates.filter((id) => this.knownCorePeerIds.has(id)).length;
+    this.log.info(
+      ctx,
+      `host-catchup peer order for "${contextGraphId}": cores=${coreCount} total=${candidates.length}`,
+    );
     const results: Array<{
       peerId: string;
       rounds: number;

--- a/packages/agent/src/p2p/peer-selection.ts
+++ b/packages/agent/src/p2p/peer-selection.ts
@@ -1,20 +1,41 @@
+/**
+ * Order connected peers for a catch-up round.
+ *
+ * Tiered, stable ordering:
+ *   1. the preferred peer (typically the CG curator), if present;
+ *   2. known Core nodes (always-on, staked, advertise `PROTOCOL_STORAGE_ACK`)
+ *      — reliable hosts we want to reach first;
+ *   3. everyone else.
+ *
+ * The order is stable within each tier so callers keep deterministic
+ * behaviour. Catch-up contacts every connected peer regardless of order,
+ * so this changes which peers are *reached first* (faster time-to-first-
+ * data, and reliable Cores ahead of flaky edges), not which are reached.
+ *
+ * `privateOnly` is retained for signature/back-compat with existing
+ * callers. It does not act as a privacy gate (catch-up already contacts
+ * all connected peers for every CG); it is kept so the curator-first
+ * intent stays explicit at the call sites.
+ */
 export function orderCatchupPeers(
   peers: Array<{ toString(): string }>,
   preferredPeerId?: string,
   privateOnly = false,
+  corePeerIds?: ReadonlySet<string>,
 ): Array<{ toString(): string }> {
-  if (!preferredPeerId) return peers;
+  void privateOnly;
+  const hasCores = !!corePeerIds && corePeerIds.size > 0;
+  if (!preferredPeerId && !hasCores) return peers;
 
-  if (privateOnly) {
-    const preferredPeer = peers.find((peer) => peer.toString() === preferredPeerId);
-    if (preferredPeer) {
-      return [preferredPeer, ...peers.filter((peer) => peer.toString() !== preferredPeerId)];
-    }
-  }
+  const tierOf = (peer: { toString(): string }): number => {
+    const id = peer.toString();
+    if (preferredPeerId && id === preferredPeerId) return 0;
+    if (hasCores && corePeerIds!.has(id)) return 1;
+    return 2;
+  };
 
-  return [...peers].sort((a, b) => {
-    if (a.toString() === preferredPeerId) return -1;
-    if (b.toString() === preferredPeerId) return 1;
-    return 0;
-  });
+  return peers
+    .map((peer, index) => ({ peer, index, tier: tierOf(peer) }))
+    .sort((a, b) => a.tier - b.tier || a.index - b.index)
+    .map((entry) => entry.peer);
 }

--- a/packages/agent/test/peer-selection.test.ts
+++ b/packages/agent/test/peer-selection.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { orderCatchupPeers } from '../src/p2p/peer-selection.js';
+
+/**
+ * Unit tests for `orderCatchupPeers` — the tiered catch-up peer ordering
+ * (preferred curator → known Core nodes → everyone else).
+ *
+ * Strings are valid `{ toString() }` peers, so we use plain ids.
+ */
+describe('orderCatchupPeers', () => {
+  it('returns peers unchanged when there is no preferred peer and no cores', () => {
+    const peers = ['a', 'b', 'c'];
+    expect(orderCatchupPeers(peers)).toBe(peers);
+    expect(orderCatchupPeers(peers, undefined, false, new Set())).toBe(peers);
+  });
+
+  it('puts the preferred peer first, preserving the order of the rest', () => {
+    const peers = ['a', 'b', 'c', 'd'];
+    expect(orderCatchupPeers(peers, 'c')).toEqual(['c', 'a', 'b', 'd']);
+  });
+
+  it('orders known cores ahead of non-cores (stable within tier)', () => {
+    const peers = ['edge1', 'core1', 'edge2', 'core2'];
+    const cores = new Set(['core1', 'core2']);
+    expect(orderCatchupPeers(peers, undefined, false, cores)).toEqual([
+      'core1',
+      'core2',
+      'edge1',
+      'edge2',
+    ]);
+  });
+
+  it('ranks preferred first, then cores, then others', () => {
+    const peers = ['edge1', 'core1', 'curator', 'edge2', 'core2'];
+    const cores = new Set(['core1', 'core2']);
+    expect(orderCatchupPeers(peers, 'curator', false, cores)).toEqual([
+      'curator',
+      'core1',
+      'core2',
+      'edge1',
+      'edge2',
+    ]);
+  });
+
+  it('keeps the preferred peer first even if it is also a core', () => {
+    const peers = ['edge1', 'core1', 'core2'];
+    const cores = new Set(['core1', 'core2']);
+    expect(orderCatchupPeers(peers, 'core2', false, cores)).toEqual([
+      'core2',
+      'core1',
+      'edge1',
+    ]);
+  });
+
+  it('is backward compatible: privateOnly does not change ordering output', () => {
+    const peers = ['a', 'b', 'c'];
+    expect(orderCatchupPeers(peers, 'b', true)).toEqual(['b', 'a', 'c']);
+    expect(orderCatchupPeers(peers, 'b', false)).toEqual(['b', 'a', 'c']);
+  });
+});


### PR DESCRIPTION
## Summary

Phase A of the *Telegram-style chain-anchored sync* plan: make catch-up reach reliable, always-on **Core nodes first**.

- `orderCatchupPeers` gains an optional `corePeerIds` arg and does a **stable tiered sort**: preferred curator -> known Cores -> everyone else. Output is byte-for-byte identical when no cores are supplied, so it's fully backward compatible.
- `selectCatchupPeers` now passes `this.knownCorePeerIds` (the existing `PROTOCOL_STORAGE_ACK` advertiser set); `catchupSwmFromConnectedHosts` orders its candidate hosts Cores-first.
- Added ordering log lines at both sites (`catchup peer order ...` / `host-catchup peer order ...`) for observability.

### Scope / honest framing
Both catch-up paths already contact **every** connected peer (regular sync probes serially then syncs in parallel; SWM host-catchup loops over all candidates). So this PR changes **which peers are reached first** — faster time-to-first-data, reliable Cores ahead of flaky edges, better resume baseline — **not which peers are reached**. The larger latency/reliability wins (warm pinned core links, chain-driven VM reconciliation, delta sync) land in follow-up phases (A.4, B, C, D). This PR also lays the `corePeerIds` plumbing those phases reuse.

`privateOnly` is confirmed **not** a privacy gate (catch-up contacts all peers regardless); it is retained only for call-site signature back-compat.

## Test plan
- [x] `packages/agent/test/peer-selection.test.ts` — 6 cases: no-preferred/no-cores passthrough, preferred-first, cores-tier, preferred+cores+others ranking, preferred-also-core, `privateOnly` back-compat. All passing.
- [x] Agent package builds clean.
- [x] Regression: `p2p-peer-connect.test.ts` + `sync-on-connect-retry.test.ts` green.
- [ ] Manual: confirm `catchup peer order ... cores=N` log shows Cores leading on a node connected to a Core.

Made with [Cursor](https://cursor.com)