### PR TITLE
feat(agent): warm/pinned connections to staked Core nodes (A.4-lite+)

### DIFF
--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -22,6 +22,23 @@ export const SYNC_PROTOCOL_CHECK_ATTEMPTS = 3;
 export const SYNC_PROTOCOL_CHECK_DELAY_MS = 500;
 export const SYNC_AUTH_MAX_AGE_MS = 90_000;
 
+// ── Warm core connections (A.4-lite+) ─────────────────────────────────
+/**
+ * Opt-in: when set, the agent keeps a small set of Core nodes warm
+ * (connection pinned + auto-redialed by libp2p) so catch-up / chain-driven
+ * reconciliation never pays a cold circuit-relay dial to reach a Core.
+ * Conservative default (off) — flip to '1' to enable.
+ */
+export const WARM_CORE_CONNECTIONS_ENABLED = process.env.DKG_WARM_CORE_CONNECTIONS === '1';
+/** How often to refresh the warm-core set from the phonebook + redial drops. */
+export const WARM_CORE_RECONCILE_INTERVAL_MS = 90_000;
+/** Upper bound on simultaneously pinned Cores (slot-exhaustion guard). */
+export const WARM_CORE_MAX = 8;
+/** keep-alive peerStore tag for warm Cores (mirrors the relay keep-alive tag). */
+export const WARM_CORE_KEEPALIVE_TAG = 'keep-alive-dkg-core';
+/** Per-dial budget when warming a Core. */
+export const WARM_CORE_DIAL_TIMEOUT_MS = 20_000;
+
 // ── Join ──────────────────────────────────────────────────────────────
 /**
  * How long an agent's join-request delegation is valid for. The same

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -192,6 +192,7 @@ import {
 } from './swm/ciphertext-chunk-catchup.js';
 import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
 import { orderCatchupPeers } from './p2p/peer-selection.js';
+import { reconcileWarmCoreConnections, type WarmCoreAgent } from './p2p/warm-core-connections.js';
 import { fetchSyncPages, type SyncPageResult } from './sync/requester/page-fetch.js';
 import { getSyncCheckpointKey } from './sync/checkpoint/state.js';
 import { runDurableSync } from './sync/requester/durable-sync.js';
@@ -274,6 +275,11 @@ import {
   MESSAGE_OUTBOX_TICK_MS,
   AGENT_PROFILE_HEARTBEAT_MS,
   AGENT_PROFILE_STALE_THRESHOLD_MS,
+  WARM_CORE_CONNECTIONS_ENABLED,
+  WARM_CORE_RECONCILE_INTERVAL_MS,
+  WARM_CORE_MAX,
+  WARM_CORE_KEEPALIVE_TAG,
+  WARM_CORE_DIAL_TIMEOUT_MS,
 } from './dkg-agent-constants.js';
 import {
   ContextGraphNotFoundError,
@@ -1099,6 +1105,8 @@ export class DKGAgent {
    */
   private readonly lastSuccessfulSyncAt = new Map<string, number>();
   private syncReconcilerTimer: ReturnType<typeof setInterval> | null = null;
+  /** A.4-lite+: periodic warm/pinned Core-connection reconcile (opt-in). */
+  private warmCoreTimer: ReturnType<typeof setInterval> | null = null;
   /**
    * v10-rc sync-refactor: per-(peer+CG) checkpoint offsets so the paged
    * sync requester in `sync/requester/page-fetch.ts` can resume where it
@@ -3001,6 +3009,23 @@ export class DKGAgent {
     }, SYNC_RECONCILER_INTERVAL_MS);
     if (this.syncReconcilerTimer.unref) this.syncReconcilerTimer.unref();
 
+    // A.4-lite+: keep a small set of Core nodes warm (connection pinned +
+    // auto-redialed by libp2p) so catch-up / chain reconciliation never pays
+    // a cold circuit-relay dial to reach a Core. Opt-in via
+    // DKG_WARM_CORE_CONNECTIONS=1. See `p2p/warm-core-connections.ts`.
+    if (WARM_CORE_CONNECTIONS_ENABLED) {
+      const runWarmCore = (): void => {
+        this.reconcileWarmCoreConnections().catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          this.log.warn(ctx, `Warm-core reconcile tick failed: ${message}`);
+        });
+      };
+      // Prime once now (after startup), then on a steady cadence.
+      runWarmCore();
+      this.warmCoreTimer = setInterval(runWarmCore, WARM_CORE_RECONCILE_INTERVAL_MS);
+      if (this.warmCoreTimer.unref) this.warmCoreTimer.unref();
+    }
+
     // rc.9 PR-10: dedicated join-approval retry tick removed. The
     // substrate's Messenger.processOutboxTick (set up immediately
     // below) now drives retries for /dkg/10.0.1/join-request the
@@ -3278,6 +3303,78 @@ export class DKGAgent {
         const message = err instanceof Error ? err.message : String(err);
         this.log.warn(ctx, `Sync reconciler retry failed for ${shortPeer}: ${message}`);
       });
+    }
+  }
+
+  /**
+   * A.4-lite+: discover Core nodes from the Agent Registry phonebook, gate
+   * them on on-chain ShardingTable membership, and keep a small set warm
+   * (connection pinned + auto-redialed). Best-effort; never throws into the
+   * timer. See `p2p/warm-core-connections.ts`.
+   */
+  private async reconcileWarmCoreConnections(): Promise<void> {
+    if (!this.started) return;
+    await reconcileWarmCoreConnections({
+      selfPeerId: this.node.libp2p.peerId.toString(),
+      maxCores: WARM_CORE_MAX,
+      findCoreAgents: async (): Promise<WarmCoreAgent[]> => {
+        const agents = await this.discovery.findAgents();
+        return agents.map((a) => ({
+          peerId: a.peerId,
+          nodeRole: a.nodeRole,
+          agentAddress: a.agentAddress,
+        }));
+      },
+      isShardingTableCore: (agentAddress) => this.isShardingTableCore(agentAddress),
+      isConnected: (peerId) =>
+        this.node.libp2p.getConnections().some((c) => c.remotePeer.toString() === peerId),
+      pinAndDial: (peerId, ctx) => this.pinAndDialWarmCore(peerId, ctx),
+      log: (ctx, msg) => this.log.info(ctx, msg),
+    });
+  }
+
+  /**
+   * Trust gate for warm-core pinning: only pin Cores that are members of the
+   * on-chain ShardingTable (staked nodes). Best-effort — when the chain
+   * adapter can't answer (no chain bound, optional reads absent) the gate
+   * passes so the phonebook `nodeRole='core'` alone decides. A transient
+   * RPC failure denies (we don't pin on an unverifiable gate).
+   */
+  private async isShardingTableCore(agentAddress: string | undefined): Promise<boolean> {
+    const getIdentityIdForAddress = this.chain.getIdentityIdForAddress?.bind(this.chain);
+    const isShardingTableMember = this.chain.isShardingTableMember?.bind(this.chain);
+    if (!getIdentityIdForAddress || !isShardingTableMember) return true; // gate unavailable
+    if (!agentAddress) return false; // can't resolve identity without the operational wallet
+    try {
+      const identityId = await getIdentityIdForAddress(agentAddress);
+      if (identityId === 0n) return false;
+      return await isShardingTableMember(identityId);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Tag a Core keep-alive in the peerStore — so libp2p's connection manager
+   * maintains + auto-redials it (mirrors the relay keep-alive path in
+   * `core/node.ts`) — then dial it via the existing resolve+dial path.
+   * Returns true on a successful dial.
+   */
+  private async pinAndDialWarmCore(peerIdStr: string, ctx: OperationContext): Promise<boolean> {
+    const shortPeer = peerIdStr.slice(-8);
+    try {
+      const { peerIdFromString } = await import('@libp2p/peer-id');
+      const peerId = peerIdFromString(peerIdStr);
+      await this.node.libp2p.peerStore.merge(peerId, {
+        tags: { [WARM_CORE_KEEPALIVE_TAG]: { value: 100 } },
+      });
+      await this.connectToPeerId(peerIdStr, { timeoutMs: WARM_CORE_DIAL_TIMEOUT_MS });
+      this.log.info(ctx, `warm-core: pinned + dialed ${shortPeer}`);
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.log.info(ctx, `warm-core: pin/dial ${shortPeer} failed (retry next tick): ${message}`);
+      return false;
     }
   }
 
@@ -20033,6 +20130,10 @@ export class DKGAgent {
     if (this.syncReconcilerTimer) {
       clearInterval(this.syncReconcilerTimer);
       this.syncReconcilerTimer = null;
+    }
+    if (this.warmCoreTimer) {
+      clearInterval(this.warmCoreTimer);
+      this.warmCoreTimer = null;
     }
     if (this.messengerOutboxTimer) {
       clearInterval(this.messengerOutboxTimer);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1107,6 +1107,9 @@ export class DKGAgent {
   private syncReconcilerTimer: ReturnType<typeof setInterval> | null = null;
   /** A.4-lite+: periodic warm/pinned Core-connection reconcile (opt-in). */
   private warmCoreTimer: ReturnType<typeof setInterval> | null = null;
+  /** Cores keep-alive-pinned on the last warm-core pass, so the next pass can
+   *  unpin Cores that fell out of the selection (stale-pin / cap-drift guard). */
+  private warmedCores: Set<string> = new Set();
   /**
    * v10-rc sync-refactor: per-(peer+CG) checkpoint offsets so the paged
    * sync requester in `sync/requester/page-fetch.ts` can resume where it
@@ -3314,7 +3317,7 @@ export class DKGAgent {
    */
   private async reconcileWarmCoreConnections(): Promise<void> {
     if (!this.started) return;
-    await reconcileWarmCoreConnections({
+    const result = await reconcileWarmCoreConnections({
       selfPeerId: this.node.libp2p.peerId.toString(),
       maxCores: WARM_CORE_MAX,
       findCoreAgents: async (): Promise<WarmCoreAgent[]> => {
@@ -3328,9 +3331,14 @@ export class DKGAgent {
       isShardingTableCore: (agentAddress) => this.isShardingTableCore(agentAddress),
       isConnected: (peerId) =>
         this.node.libp2p.getConnections().some((c) => c.remotePeer.toString() === peerId),
-      pinAndDial: (peerId, ctx) => this.pinAndDialWarmCore(peerId, ctx),
+      pin: (peerId) => this.pinWarmCore(peerId),
+      unpin: (peerId, ctx) => this.unpinWarmCore(peerId, ctx),
+      dial: (peerId, ctx) => this.dialWarmCore(peerId, ctx),
+      previouslyWarmed: this.warmedCores,
       log: (ctx, msg) => this.log.info(ctx, msg),
     });
+    // Carry the pinned set into the next tick so stale Cores get unpinned.
+    this.warmedCores = result.warmed;
   }
 
   /**
@@ -3344,7 +3352,12 @@ export class DKGAgent {
     const getIdentityIdForAddress = this.chain.getIdentityIdForAddress?.bind(this.chain);
     const isShardingTableMember = this.chain.isShardingTableMember?.bind(this.chain);
     if (!getIdentityIdForAddress || !isShardingTableMember) return true; // gate unavailable
-    if (!agentAddress) return false; // can't resolve identity without the operational wallet
+    // A legacy/mixed-version core profile may not carry an operational wallet.
+    // Discovery elsewhere supports profiles without `agentAddress`, so treat
+    // its absence as "gate unavailable" (fall back to phonebook nodeRole)
+    // rather than a hard denial — otherwise the warm set can collapse to zero
+    // in a network with healthy but pre-agentAddress cores.
+    if (!agentAddress) return true; // gate unavailable for this profile
     try {
       const identityId = await getIdentityIdForAddress(agentAddress);
       if (identityId === 0n) return false;
@@ -3357,23 +3370,50 @@ export class DKGAgent {
   /**
    * Tag a Core keep-alive in the peerStore — so libp2p's connection manager
    * maintains + auto-redials it (mirrors the relay keep-alive path in
-   * `core/node.ts`) — then dial it via the existing resolve+dial path.
-   * Returns true on a successful dial.
+   * `core/node.ts`). Idempotent; does NOT dial (see {@link dialWarmCore}).
    */
-  private async pinAndDialWarmCore(peerIdStr: string, ctx: OperationContext): Promise<boolean> {
+  private async pinWarmCore(peerIdStr: string): Promise<void> {
+    const { peerIdFromString } = await import('@libp2p/peer-id');
+    const peerId = peerIdFromString(peerIdStr);
+    await this.node.libp2p.peerStore.merge(peerId, {
+      tags: { [WARM_CORE_KEEPALIVE_TAG]: { value: 100 } },
+    });
+  }
+
+  /**
+   * Remove the warm-core keep-alive tag from a Core that fell out of the warm
+   * set, so the connection manager stops protecting/redialing it and the
+   * pinned count can't drift above WARM_CORE_MAX over time.
+   */
+  private async unpinWarmCore(peerIdStr: string, ctx: OperationContext): Promise<void> {
     const shortPeer = peerIdStr.slice(-8);
     try {
       const { peerIdFromString } = await import('@libp2p/peer-id');
       const peerId = peerIdFromString(peerIdStr);
+      // peerStore.merge deletes a tag whose value is `undefined`.
       await this.node.libp2p.peerStore.merge(peerId, {
-        tags: { [WARM_CORE_KEEPALIVE_TAG]: { value: 100 } },
+        tags: { [WARM_CORE_KEEPALIVE_TAG]: undefined },
       });
+      this.log.info(ctx, `warm-core: unpinned ${shortPeer} (no longer selected)`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.log.info(ctx, `warm-core: unpin ${shortPeer} failed: ${message}`);
+    }
+  }
+
+  /**
+   * Dial a (pinned, not-yet-connected) Core via the existing resolve+dial
+   * path. Returns true on a successful dial.
+   */
+  private async dialWarmCore(peerIdStr: string, ctx: OperationContext): Promise<boolean> {
+    const shortPeer = peerIdStr.slice(-8);
+    try {
       await this.connectToPeerId(peerIdStr, { timeoutMs: WARM_CORE_DIAL_TIMEOUT_MS });
-      this.log.info(ctx, `warm-core: pinned + dialed ${shortPeer}`);
+      this.log.info(ctx, `warm-core: dialed ${shortPeer}`);
       return true;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      this.log.info(ctx, `warm-core: pin/dial ${shortPeer} failed (retry next tick): ${message}`);
+      this.log.info(ctx, `warm-core: dial ${shortPeer} failed (retry next tick): ${message}`);
       return false;
     }
   }

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3017,11 +3017,22 @@ export class DKGAgent {
     // a cold circuit-relay dial to reach a Core. Opt-in via
     // DKG_WARM_CORE_CONNECTIONS=1. See `p2p/warm-core-connections.ts`.
     if (WARM_CORE_CONNECTIONS_ENABLED) {
+      // Serialize passes: one reconcile can run longer than the interval
+      // (discovery + chain gate + up to WARM_CORE_MAX sequential dials, each
+      // with a 20s timeout). Without this guard, overlapping passes race on
+      // `this.warmedCores` and can unpin a Core a newer pass just selected.
+      let warmCoreInFlight = false;
       const runWarmCore = (): void => {
-        this.reconcileWarmCoreConnections().catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          this.log.warn(ctx, `Warm-core reconcile tick failed: ${message}`);
-        });
+        if (warmCoreInFlight) return;
+        warmCoreInFlight = true;
+        this.reconcileWarmCoreConnections()
+          .catch((err: unknown) => {
+            const message = err instanceof Error ? err.message : String(err);
+            this.log.warn(ctx, `Warm-core reconcile tick failed: ${message}`);
+          })
+          .finally(() => {
+            warmCoreInFlight = false;
+          });
       };
       // Prime once now (after startup), then on a steady cadence.
       runWarmCore();
@@ -3320,12 +3331,17 @@ export class DKGAgent {
     const result = await reconcileWarmCoreConnections({
       selfPeerId: this.node.libp2p.peerId.toString(),
       maxCores: WARM_CORE_MAX,
+      // Drop Cores not seen within the profile-stale window before the cap, so
+      // a stale phonebook slice can't crowd out live Cores or keep redialing
+      // dead entries (reuses the directory's freshness threshold).
+      staleThresholdMs: AGENT_PROFILE_STALE_THRESHOLD_MS,
       findCoreAgents: async (): Promise<WarmCoreAgent[]> => {
         const agents = await this.discovery.findAgents();
         return agents.map((a) => ({
           peerId: a.peerId,
           nodeRole: a.nodeRole,
           agentAddress: a.agentAddress,
+          lastSeen: a.lastSeen,
         }));
       },
       isShardingTableCore: (agentAddress) => this.isShardingTableCore(agentAddress),

--- a/packages/agent/src/p2p/warm-core-connections.ts
+++ b/packages/agent/src/p2p/warm-core-connections.ts
@@ -81,11 +81,28 @@ export interface WarmCoreDeps {
   /** True if a live connection to this peer already exists. */
   isConnected: (peerId: string) => boolean;
   /**
-   * Tag the peer keep-alive in the peerStore and dial it. Returns true on a
-   * successful dial. Implementation lives in `DKGAgent` (peerStore.merge +
-   * libp2p.dial); errors are swallowed by the caller.
+   * Tag the peer keep-alive in the peerStore (idempotent, no dial). Called for
+   * every selected Core — including already-connected ones — so libp2p's
+   * connection manager protects + auto-redials it after a disconnect.
    */
-  pinAndDial: (peerId: string, ctx: OperationContext) => Promise<boolean>;
+  pin: (peerId: string, ctx: OperationContext) => Promise<void>;
+  /**
+   * Remove the keep-alive tag from a peer that fell out of the warm set, so
+   * the pinned count can't drift above `maxCores` over time.
+   */
+  unpin: (peerId: string, ctx: OperationContext) => Promise<void>;
+  /**
+   * Dial the peer. Returns true on a successful dial. Only called for Cores
+   * that aren't already connected. Errors are swallowed by the caller.
+   */
+  dial: (peerId: string, ctx: OperationContext) => Promise<boolean>;
+  /**
+   * The set of Cores pinned on the previous reconcile pass. Cores in here that
+   * are NOT re-selected this pass get {@link unpin}ned. The caller owns this
+   * set across ticks; {@link WarmCoreReconcileResult.warmed} is the value to
+   * carry into the next pass.
+   */
+  previouslyWarmed?: ReadonlySet<string>;
   log: (ctx: OperationContext, msg: string) => void;
 }
 
@@ -94,12 +111,15 @@ export interface WarmCoreReconcileResult {
   pinned: number;
   dialed: number;
   skippedGate: number;
+  unpinned: number;
+  /** Cores pinned this pass — feed back as `previouslyWarmed` next tick. */
+  warmed: Set<string>;
 }
 
 /**
- * One reconcile pass: discover Cores, gate them, pin+dial up to `maxCores`.
- * Idempotent — already-connected Cores are re-tagged (cheap) but not
- * re-dialed. Safe to call on a timer and once at startup.
+ * One reconcile pass: discover Cores, gate them, pin (+ dial when not yet
+ * connected) up to `maxCores`, then unpin any Core that was warm last pass but
+ * is no longer selected. Idempotent and safe to call on a timer and at startup.
  */
 export async function reconcileWarmCoreConnections(
   deps: WarmCoreDeps,
@@ -110,12 +130,12 @@ export async function reconcileWarmCoreConnections(
   const agents = await deps.findCoreAgents();
   const candidates = selectWarmCoreCandidates(agents, deps.selfPeerId);
 
-  let pinned = 0;
+  const warmed = new Set<string>();
   let dialed = 0;
   let skippedGate = 0;
 
   for (const core of candidates) {
-    if (pinned >= deps.maxCores) break;
+    if (warmed.size >= deps.maxCores) break;
 
     const allowed = await deps.isShardingTableCore(core.agentAddress).catch(() => false);
     if (!allowed) {
@@ -123,17 +143,32 @@ export async function reconcileWarmCoreConnections(
       continue;
     }
 
-    pinned += 1;
-    if (deps.isConnected(core.peerId)) continue;
+    // Pin BEFORE the connected-check so an already-connected Core still gets
+    // (and keeps) its keep-alive tag — otherwise libp2p won't auto-redial it.
+    await deps.pin(core.peerId, ctx).catch(() => {});
+    warmed.add(core.peerId);
 
-    const ok = await deps.pinAndDial(core.peerId, ctx).catch(() => false);
+    if (deps.isConnected(core.peerId)) continue;
+    const ok = await deps.dial(core.peerId, ctx).catch(() => false);
     if (ok) dialed += 1;
+  }
+
+  // Prune: drop the keep-alive tag from Cores warmed last pass but not this
+  // one, so the pinned set tracks the live selection and never exceeds the cap.
+  let unpinned = 0;
+  if (deps.previouslyWarmed) {
+    for (const peerId of deps.previouslyWarmed) {
+      if (!warmed.has(peerId)) {
+        await deps.unpin(peerId, ctx).catch(() => {});
+        unpinned += 1;
+      }
+    }
   }
 
   deps.log(
     ctx,
-    `warm-core reconcile: candidates=${candidates.length} pinned=${pinned} dialed=${dialed} skippedGate=${skippedGate} (cap=${deps.maxCores})`,
+    `warm-core reconcile: candidates=${candidates.length} pinned=${warmed.size} dialed=${dialed} skippedGate=${skippedGate} unpinned=${unpinned} (cap=${deps.maxCores})`,
   );
 
-  return { candidates: candidates.length, pinned, dialed, skippedGate };
+  return { candidates: candidates.length, pinned: warmed.size, dialed, skippedGate, unpinned, warmed };
 }

--- a/packages/agent/src/p2p/warm-core-connections.ts
+++ b/packages/agent/src/p2p/warm-core-connections.ts
@@ -1,0 +1,139 @@
+import { createOperationContext, type OperationContext } from '@origintrail-official/dkg-core';
+
+/**
+ * A.4-lite+ — phonebook-driven warm/pinned connections to Core nodes.
+ *
+ * Why
+ * ---
+ * Catch-up and chain-driven reconciliation (Phase A/B) prefer Core nodes
+ * because they're always-on, staked, and persist content. But an edge that
+ * isn't *connected* to a Core when it needs to sync pays the full
+ * circuit-relay dial cost first (the May 2026 soak measured 200-365 ms per
+ * establishment, p95 ~8.5 s — see `message-stream-pool.ts`). Keeping a small
+ * set of Cores **warm** (connection pinned + auto-redialed by libp2p's
+ * connection manager) removes that cold-dial from the critical path.
+ *
+ * This is the same trick the node already uses for relay servers
+ * (`node.ts`: `peerStore.merge(..., tags: { 'keep-alive-...': { value } })`
+ * + `dial` + watchdog). We mirror it for Cores.
+ *
+ * Scope (deliberately narrow)
+ * ---------------------------
+ *   * Warm the *connection*, not a dedicated sync *stream*. A warm
+ *     connection captures ~90 % of the latency win; pooling a long-lived
+ *     `PROTOCOL_SYNC` stream is a structural mismatch (the message pool is a
+ *     one-small-request/response multiplexer; sync streams pages) and is out
+ *     of scope.
+ *   * Identity of Cores comes from the Agent Registry CG phonebook
+ *     (`nodeRole='core'`), which already carries `peerId` + `agentAddress`.
+ *   * Trust gate: optionally confirm on-chain ShardingTable membership before
+ *     pinning, so we only warm *staked* Cores. Best-effort — when the chain
+ *     adapter can't answer (no chain, method absent), the gate passes.
+ *
+ * Pure selection (`selectWarmCoreCandidates`) is separated from the
+ * side-effecting orchestration (`reconcileWarmCoreConnections`) so the
+ * filtering is unit-testable without a libp2p/chain harness.
+ */
+
+/** Minimal phonebook shape this module needs. */
+export interface WarmCoreAgent {
+  peerId: string;
+  nodeRole?: string;
+  agentAddress?: string;
+}
+
+/**
+ * From the phonebook agent list, the Cores worth warm-pinning: role
+ * `core`, not ourselves, de-duplicated by peerId. Input order is preserved
+ * (callers may pre-sort by `lastSeen`); the per-tick cap is applied later
+ * in `reconcileWarmCoreConnections` so it counts *gated* Cores, not raw
+ * candidates.
+ */
+export function selectWarmCoreCandidates(
+  agents: WarmCoreAgent[],
+  selfPeerId: string,
+): WarmCoreAgent[] {
+  const seen = new Set<string>();
+  const out: WarmCoreAgent[] = [];
+  for (const agent of agents) {
+    if (agent.nodeRole !== 'core') continue;
+    if (!agent.peerId || agent.peerId === selfPeerId) continue;
+    if (seen.has(agent.peerId)) continue;
+    seen.add(agent.peerId);
+    out.push(agent);
+  }
+  return out;
+}
+
+export interface WarmCoreDeps {
+  /** Phonebook lookup — typically `discovery.findAgents()` mapped to {@link WarmCoreAgent}. */
+  findCoreAgents: () => Promise<WarmCoreAgent[]>;
+  /** This node's peerId string, so we never warm-dial ourselves. */
+  selfPeerId: string;
+  /** Upper bound on simultaneously pinned Cores (slot-exhaustion guard). */
+  maxCores: number;
+  /**
+   * Trust gate: resolve true if this Core may be pinned. Production wires
+   * this to `getIdentityIdForAddress(addr) -> isShardingTableMember(id)`.
+   * Best-effort: returns true when gating is unavailable.
+   */
+  isShardingTableCore: (agentAddress: string | undefined) => Promise<boolean>;
+  /** True if a live connection to this peer already exists. */
+  isConnected: (peerId: string) => boolean;
+  /**
+   * Tag the peer keep-alive in the peerStore and dial it. Returns true on a
+   * successful dial. Implementation lives in `DKGAgent` (peerStore.merge +
+   * libp2p.dial); errors are swallowed by the caller.
+   */
+  pinAndDial: (peerId: string, ctx: OperationContext) => Promise<boolean>;
+  log: (ctx: OperationContext, msg: string) => void;
+}
+
+export interface WarmCoreReconcileResult {
+  candidates: number;
+  pinned: number;
+  dialed: number;
+  skippedGate: number;
+}
+
+/**
+ * One reconcile pass: discover Cores, gate them, pin+dial up to `maxCores`.
+ * Idempotent — already-connected Cores are re-tagged (cheap) but not
+ * re-dialed. Safe to call on a timer and once at startup.
+ */
+export async function reconcileWarmCoreConnections(
+  deps: WarmCoreDeps,
+): Promise<WarmCoreReconcileResult> {
+  // 'sync' is the closest operation name in the logger's union; the
+  // `warm-core` topic is carried in the log message itself.
+  const ctx = createOperationContext('sync');
+  const agents = await deps.findCoreAgents();
+  const candidates = selectWarmCoreCandidates(agents, deps.selfPeerId);
+
+  let pinned = 0;
+  let dialed = 0;
+  let skippedGate = 0;
+
+  for (const core of candidates) {
+    if (pinned >= deps.maxCores) break;
+
+    const allowed = await deps.isShardingTableCore(core.agentAddress).catch(() => false);
+    if (!allowed) {
+      skippedGate += 1;
+      continue;
+    }
+
+    pinned += 1;
+    if (deps.isConnected(core.peerId)) continue;
+
+    const ok = await deps.pinAndDial(core.peerId, ctx).catch(() => false);
+    if (ok) dialed += 1;
+  }
+
+  deps.log(
+    ctx,
+    `warm-core reconcile: candidates=${candidates.length} pinned=${pinned} dialed=${dialed} skippedGate=${skippedGate} (cap=${deps.maxCores})`,
+  );
+
+  return { candidates: candidates.length, pinned, dialed, skippedGate };
+}

--- a/packages/agent/src/p2p/warm-core-connections.ts
+++ b/packages/agent/src/p2p/warm-core-connections.ts
@@ -40,18 +40,34 @@ export interface WarmCoreAgent {
   peerId: string;
   nodeRole?: string;
   agentAddress?: string;
+  /** ISO-8601 `dkg:lastSeen` from the phonebook, when known. */
+  lastSeen?: string;
+}
+
+/** Parse an ISO-8601 `lastSeen` to epoch ms; 0 when absent/unparseable. */
+function lastSeenMs(iso?: string): number {
+  if (!iso) return 0;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? 0 : t;
 }
 
 /**
  * From the phonebook agent list, the Cores worth warm-pinning: role
- * `core`, not ourselves, de-duplicated by peerId. Input order is preserved
- * (callers may pre-sort by `lastSeen`); the per-tick cap is applied later
- * in `reconcileWarmCoreConnections` so it counts *gated* Cores, not raw
- * candidates.
+ * `core`, not ourselves, de-duplicated by peerId.
+ *
+ * The phonebook (`discovery.findAgents()`) is unordered and freshness-blind,
+ * but `reconcileWarmCoreConnections` only pins up to `maxCores`. So this
+ * function ranks **freshest-first** by `lastSeen` and (when `staleThresholdMs`
+ * + `nowMs` are supplied) drops Cores we can prove are stale — otherwise the
+ * capped set would be an arbitrary slice that churns between ticks and keeps
+ * dialing long-dead registry entries forever. Cores without a parseable
+ * `lastSeen` are kept (freshness unknown) and, because the sort is stable,
+ * retain their relative phonebook order behind any timestamped Cores.
  */
 export function selectWarmCoreCandidates(
   agents: WarmCoreAgent[],
   selfPeerId: string,
+  opts?: { nowMs?: number; staleThresholdMs?: number },
 ): WarmCoreAgent[] {
   const seen = new Set<string>();
   const out: WarmCoreAgent[] = [];
@@ -62,7 +78,19 @@ export function selectWarmCoreCandidates(
     seen.add(agent.peerId);
     out.push(agent);
   }
-  return out;
+  const nowMs = opts?.nowMs;
+  const staleThresholdMs = opts?.staleThresholdMs;
+  const filtered =
+    nowMs !== undefined && staleThresholdMs !== undefined
+      ? out.filter((a) => {
+          const ls = lastSeenMs(a.lastSeen);
+          // ls === 0 → unknown freshness, keep it; otherwise must be recent.
+          return ls === 0 || nowMs - ls <= staleThresholdMs;
+        })
+      : out;
+  // Stable freshest-first sort (Array.prototype.sort is stable since ES2019),
+  // so equal/unknown freshness preserves phonebook order.
+  return filtered.sort((a, b) => lastSeenMs(b.lastSeen) - lastSeenMs(a.lastSeen));
 }
 
 export interface WarmCoreDeps {
@@ -72,6 +100,13 @@ export interface WarmCoreDeps {
   selfPeerId: string;
   /** Upper bound on simultaneously pinned Cores (slot-exhaustion guard). */
   maxCores: number;
+  /**
+   * When set, Cores whose `lastSeen` is older than this many ms are dropped
+   * before the `maxCores` cap, so we don't keep redialing dead registry
+   * entries. Cores without a `lastSeen` are kept. Production wires this to
+   * `AGENT_PROFILE_STALE_THRESHOLD_MS`.
+   */
+  staleThresholdMs?: number;
   /**
    * Trust gate: resolve true if this Core may be pinned. Production wires
    * this to `getIdentityIdForAddress(addr) -> isShardingTableMember(id)`.
@@ -128,7 +163,10 @@ export async function reconcileWarmCoreConnections(
   // `warm-core` topic is carried in the log message itself.
   const ctx = createOperationContext('sync');
   const agents = await deps.findCoreAgents();
-  const candidates = selectWarmCoreCandidates(agents, deps.selfPeerId);
+  const candidates = selectWarmCoreCandidates(agents, deps.selfPeerId, {
+    nowMs: Date.now(),
+    staleThresholdMs: deps.staleThresholdMs,
+  });
 
   const warmed = new Set<string>();
   let dialed = 0;
@@ -145,7 +183,14 @@ export async function reconcileWarmCoreConnections(
 
     // Pin BEFORE the connected-check so an already-connected Core still gets
     // (and keeps) its keep-alive tag — otherwise libp2p won't auto-redial it.
-    await deps.pin(core.peerId, ctx).catch(() => {});
+    // A pin failure (malformed peerId, peerStore.merge error) must NOT consume
+    // a warm slot or be reported as pinned: skip to the next candidate so a
+    // healthy Core can take the slot.
+    let pinOk = true;
+    await deps.pin(core.peerId, ctx).catch(() => {
+      pinOk = false;
+    });
+    if (!pinOk) continue;
     warmed.add(core.peerId);
 
     if (deps.isConnected(core.peerId)) continue;

--- a/packages/agent/test/warm-core-connections.test.ts
+++ b/packages/agent/test/warm-core-connections.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  selectWarmCoreCandidates,
+  reconcileWarmCoreConnections,
+  type WarmCoreAgent,
+  type WarmCoreDeps,
+} from '../src/p2p/warm-core-connections.js';
+
+describe('selectWarmCoreCandidates', () => {
+  it('keeps only nodeRole=core, drops self, dedupes, preserves order', () => {
+    const agents: WarmCoreAgent[] = [
+      { peerId: 'edge1', nodeRole: 'edge' },
+      { peerId: 'core1', nodeRole: 'core' },
+      { peerId: 'self', nodeRole: 'core' },
+      { peerId: 'core2', nodeRole: 'core' },
+      { peerId: 'core1', nodeRole: 'core' }, // dup
+      { peerId: 'noRole' },
+    ];
+    expect(selectWarmCoreCandidates(agents, 'self').map((a) => a.peerId)).toEqual([
+      'core1',
+      'core2',
+    ]);
+  });
+
+  it('returns empty when there are no cores', () => {
+    expect(selectWarmCoreCandidates([{ peerId: 'e', nodeRole: 'edge' }], 'self')).toEqual([]);
+  });
+});
+
+/** Build deps with sensible spies; override per test. */
+function makeDeps(overrides: Partial<WarmCoreDeps> = {}): {
+  deps: WarmCoreDeps;
+  dialed: string[];
+} {
+  const dialed: string[] = [];
+  const deps: WarmCoreDeps = {
+    selfPeerId: 'self',
+    maxCores: 8,
+    findCoreAgents: async () => [
+      { peerId: 'core1', nodeRole: 'core', agentAddress: '0x1' },
+      { peerId: 'core2', nodeRole: 'core', agentAddress: '0x2' },
+      { peerId: 'edge1', nodeRole: 'edge', agentAddress: '0x3' },
+    ],
+    isShardingTableCore: async () => true,
+    isConnected: () => false,
+    pinAndDial: async (peerId) => {
+      dialed.push(peerId);
+      return true;
+    },
+    log: () => undefined,
+    ...overrides,
+  };
+  return { deps, dialed };
+}
+
+describe('reconcileWarmCoreConnections', () => {
+  it('pins + dials all gated cores when none are connected', async () => {
+    const { deps, dialed } = makeDeps();
+    const res = await reconcileWarmCoreConnections(deps);
+    expect(res).toMatchObject({ candidates: 2, pinned: 2, dialed: 2, skippedGate: 0 });
+    expect(dialed).toEqual(['core1', 'core2']);
+  });
+
+  it('skips cores that fail the ShardingTable gate', async () => {
+    const { deps, dialed } = makeDeps({
+      isShardingTableCore: async (addr) => addr === '0x1',
+    });
+    const res = await reconcileWarmCoreConnections(deps);
+    expect(res).toMatchObject({ pinned: 1, dialed: 1, skippedGate: 1 });
+    expect(dialed).toEqual(['core1']);
+  });
+
+  it('pins but does not redial cores that are already connected', async () => {
+    const { deps, dialed } = makeDeps({ isConnected: (id) => id === 'core1' });
+    const res = await reconcileWarmCoreConnections(deps);
+    expect(res).toMatchObject({ pinned: 2, dialed: 1 });
+    expect(dialed).toEqual(['core2']);
+  });
+
+  it('honors the maxCores cap, counting only gated cores', async () => {
+    const { deps, dialed } = makeDeps({
+      maxCores: 1,
+      findCoreAgents: async () => [
+        { peerId: 'core1', nodeRole: 'core', agentAddress: '0x1' },
+        { peerId: 'core2', nodeRole: 'core', agentAddress: '0x2' },
+        { peerId: 'core3', nodeRole: 'core', agentAddress: '0x3' },
+      ],
+    });
+    const res = await reconcileWarmCoreConnections(deps);
+    expect(res.pinned).toBe(1);
+    expect(dialed).toEqual(['core1']);
+  });
+
+  it('treats a throwing gate as a denial (does not pin)', async () => {
+    const { deps, dialed } = makeDeps({
+      isShardingTableCore: async () => {
+        throw new Error('rpc down');
+      },
+    });
+    const res = await reconcileWarmCoreConnections(deps);
+    expect(res).toMatchObject({ pinned: 0, dialed: 0, skippedGate: 2 });
+    expect(dialed).toEqual([]);
+  });
+
+  it('counts a failed dial as pinned-but-not-dialed', async () => {
+    const { deps } = makeDeps({ pinAndDial: async () => false });
+    const res = await reconcileWarmCoreConnections(deps);
+    expect(res).toMatchObject({ pinned: 2, dialed: 0 });
+  });
+});

--- a/packages/agent/test/warm-core-connections.test.ts
+++ b/packages/agent/test/warm-core-connections.test.ts
@@ -25,6 +25,36 @@ describe('selectWarmCoreCandidates', () => {
   it('returns empty when there are no cores', () => {
     expect(selectWarmCoreCandidates([{ peerId: 'e', nodeRole: 'edge' }], 'self')).toEqual([]);
   });
+
+  it('ranks freshest-first by lastSeen; unknown freshness sorts last (stable)', () => {
+    const now = Date.parse('2026-06-02T00:00:00Z');
+    const agents: WarmCoreAgent[] = [
+      { peerId: 'old', nodeRole: 'core', lastSeen: '2026-06-01T06:00:00Z' },
+      { peerId: 'noTs', nodeRole: 'core' }, // unknown freshness
+      { peerId: 'fresh', nodeRole: 'core', lastSeen: '2026-06-01T23:00:00Z' },
+    ];
+    expect(
+      selectWarmCoreCandidates(agents, 'self', {
+        nowMs: now,
+        staleThresholdMs: 24 * 60 * 60 * 1000,
+      }).map((a) => a.peerId),
+    ).toEqual(['fresh', 'old', 'noTs']);
+  });
+
+  it('drops cores staler than the threshold but keeps those without a lastSeen', () => {
+    const now = Date.parse('2026-06-02T00:00:00Z');
+    const agents: WarmCoreAgent[] = [
+      { peerId: 'stale', nodeRole: 'core', lastSeen: '2026-05-01T00:00:00Z' }, // ~1mo old
+      { peerId: 'noTs', nodeRole: 'core' },
+      { peerId: 'fresh', nodeRole: 'core', lastSeen: '2026-06-01T23:00:00Z' },
+    ];
+    expect(
+      selectWarmCoreCandidates(agents, 'self', {
+        nowMs: now,
+        staleThresholdMs: 24 * 60 * 60 * 1000,
+      }).map((a) => a.peerId),
+    ).toEqual(['fresh', 'noTs']);
+  });
 });
 
 /** Build deps with sensible spies; override per test. */
@@ -120,6 +150,29 @@ describe('reconcileWarmCoreConnections', () => {
     const { deps } = makeDeps({ dial: async () => false });
     const res = await reconcileWarmCoreConnections(deps);
     expect(res).toMatchObject({ pinned: 2, dialed: 0 });
+  });
+
+  it('does not consume a slot for a core whose pin throws; frees it for the next', async () => {
+    // Regression: a pin failure (malformed peerId / peerStore.merge error) must
+    // not be counted as pinned or eat a maxCores slot — a healthy core takes it.
+    const localPinned: string[] = [];
+    const { deps, dialed } = makeDeps({
+      maxCores: 2,
+      findCoreAgents: async () => [
+        { peerId: 'bad', nodeRole: 'core', agentAddress: '0x1' },
+        { peerId: 'core2', nodeRole: 'core', agentAddress: '0x2' },
+        { peerId: 'core3', nodeRole: 'core', agentAddress: '0x3' },
+      ],
+      pin: async (peerId) => {
+        if (peerId === 'bad') throw new Error('peerStore.merge failed');
+        localPinned.push(peerId);
+      },
+    });
+    const res = await reconcileWarmCoreConnections(deps);
+    expect(res.pinned).toBe(2); // 'bad' not counted; core2 + core3 fill the 2 slots
+    expect(localPinned).toEqual(['core2', 'core3']);
+    expect(dialed).toEqual(['core2', 'core3']); // 'bad' never dialed
+    expect([...res.warmed].sort()).toEqual(['core2', 'core3']);
   });
 
   it('unpins cores that were warm last pass but are no longer selected', async () => {

--- a/packages/agent/test/warm-core-connections.test.ts
+++ b/packages/agent/test/warm-core-connections.test.ts
@@ -31,8 +31,12 @@ describe('selectWarmCoreCandidates', () => {
 function makeDeps(overrides: Partial<WarmCoreDeps> = {}): {
   deps: WarmCoreDeps;
   dialed: string[];
+  pinned: string[];
+  unpinned: string[];
 } {
   const dialed: string[] = [];
+  const pinned: string[] = [];
+  const unpinned: string[] = [];
   const deps: WarmCoreDeps = {
     selfPeerId: 'self',
     maxCores: 8,
@@ -43,22 +47,29 @@ function makeDeps(overrides: Partial<WarmCoreDeps> = {}): {
     ],
     isShardingTableCore: async () => true,
     isConnected: () => false,
-    pinAndDial: async (peerId) => {
+    pin: async (peerId) => {
+      pinned.push(peerId);
+    },
+    unpin: async (peerId) => {
+      unpinned.push(peerId);
+    },
+    dial: async (peerId) => {
       dialed.push(peerId);
       return true;
     },
     log: () => undefined,
     ...overrides,
   };
-  return { deps, dialed };
+  return { deps, dialed, pinned, unpinned };
 }
 
 describe('reconcileWarmCoreConnections', () => {
   it('pins + dials all gated cores when none are connected', async () => {
-    const { deps, dialed } = makeDeps();
+    const { deps, dialed, pinned } = makeDeps();
     const res = await reconcileWarmCoreConnections(deps);
-    expect(res).toMatchObject({ candidates: 2, pinned: 2, dialed: 2, skippedGate: 0 });
+    expect(res).toMatchObject({ candidates: 2, pinned: 2, dialed: 2, skippedGate: 0, unpinned: 0 });
     expect(dialed).toEqual(['core1', 'core2']);
+    expect(pinned).toEqual(['core1', 'core2']);
   });
 
   it('skips cores that fail the ShardingTable gate', async () => {
@@ -70,11 +81,14 @@ describe('reconcileWarmCoreConnections', () => {
     expect(dialed).toEqual(['core1']);
   });
 
-  it('pins but does not redial cores that are already connected', async () => {
-    const { deps, dialed } = makeDeps({ isConnected: (id) => id === 'core1' });
+  it('still pins (tags) an already-connected core, but does not redial it', async () => {
+    // Regression: a connected core MUST be tagged keep-alive so libp2p
+    // auto-redials it after a disconnect — the old `continue` skipped pinning.
+    const { deps, dialed, pinned } = makeDeps({ isConnected: (id) => id === 'core1' });
     const res = await reconcileWarmCoreConnections(deps);
     expect(res).toMatchObject({ pinned: 2, dialed: 1 });
-    expect(dialed).toEqual(['core2']);
+    expect(pinned).toEqual(['core1', 'core2']); // both tagged
+    expect(dialed).toEqual(['core2']); // only the disconnected one dialed
   });
 
   it('honors the maxCores cap, counting only gated cores', async () => {
@@ -103,8 +117,32 @@ describe('reconcileWarmCoreConnections', () => {
   });
 
   it('counts a failed dial as pinned-but-not-dialed', async () => {
-    const { deps } = makeDeps({ pinAndDial: async () => false });
+    const { deps } = makeDeps({ dial: async () => false });
     const res = await reconcileWarmCoreConnections(deps);
     expect(res).toMatchObject({ pinned: 2, dialed: 0 });
+  });
+
+  it('unpins cores that were warm last pass but are no longer selected', async () => {
+    // Regression: the keep-alive tag must be removed when a core drops out of
+    // the candidate/gated set, else pins leak and drift above maxCores.
+    const { deps, unpinned } = makeDeps({
+      previouslyWarmed: new Set(['core1', 'core2', 'gone1', 'gone2']),
+    });
+    const res = await reconcileWarmCoreConnections(deps);
+    expect(res.pinned).toBe(2);
+    expect(res.unpinned).toBe(2);
+    expect(unpinned.sort()).toEqual(['gone1', 'gone2']);
+    // the returned warmed set is what the caller carries into the next pass
+    expect([...res.warmed].sort()).toEqual(['core1', 'core2']);
+  });
+
+  it('unpins a core that newly fails the gate (cap-drift guard)', async () => {
+    const { deps, unpinned } = makeDeps({
+      previouslyWarmed: new Set(['core1', 'core2']),
+      isShardingTableCore: async (addr) => addr === '0x1', // core2 now ungated
+    });
+    const res = await reconcileWarmCoreConnections(deps);
+    expect(res).toMatchObject({ pinned: 1, skippedGate: 1, unpinned: 1 });
+    expect(unpinned).toEqual(['core2']);
   });
 });


### PR DESCRIPTION
## Summary

Phase **A.4-lite+** of the *Telegram-style chain-anchored sync* plan. Keeps a small set of Core nodes **warm** (connection pinned + auto-redialed) so catch-up and chain-driven reconciliation never pay a cold circuit-relay dial to reach a Core — the May 2026 soak measured 200–365 ms per relay establishment and p95 ~8.5 s.

- **Mirrors the proven relay keep-alive path** in `core/node.ts`: `peerStore.merge(..., tags: { 'keep-alive-dkg-core': { value: 100 } })` + `dial`, then libp2p's connection manager maintains and auto-redials.
- **Cores from the phonebook**: `discovery.findAgents()` filtered to `nodeRole='core'` (already carries `peerId` + `agentAddress`).
- **Trust-gated on-chain**: only pins Cores that are **ShardingTable members** (`getIdentityIdForAddress` → `isShardingTableMember`). Best-effort — the gate **passes** when the chain adapter can't answer (no chain / optional reads absent) and **denies** on a transient RPC error (we don't pin on an unverifiable gate).
- Periodic reconcile (90 s) + once at startup; capped at **8** pinned Cores; already-connected Cores are re-tagged but not re-dialed.
- **Opt-in** behind `DKG_WARM_CORE_CONNECTIONS=1` (conservative default: off).

### Scope decision (from plan review)
Deliberately warms the **connection**, not a dedicated sync **stream**. A warm connection captures ~90% of the latency win (the soak pain was relay *connection* re-dials, not stream opens); pooling a long-lived `PROTOCOL_SYNC` stream is a structural mismatch (the message-stream-pool is a one-small-request/response multiplexer; sync streams pages) for the last ~10% — so the stream-pool extension from the original A.4 is dropped.

## Stacking
Stacked on **#906** (`feat/core-preferred-catchup-peers`) because both touch `packages/agent/src/dkg-agent.ts` in overlapping regions. Base will retarget to `main` once #906 merges. Review/merge #906 first.

## Test plan
- [x] `packages/agent/test/warm-core-connections.test.ts` — 8 cases: pure `selectWarmCoreCandidates` (role filter / self / dedupe / order), gate-denial skips, already-connected not redialed, `maxCores` cap counts gated cores, throwing gate = denial, failed dial = pinned-but-not-dialed.
- [x] Agent package builds clean; lint clean.
- [x] Regression: `peer-selection` + `p2p-peer-connect` + `sync-on-connect-retry` green.
- [ ] Manual: with `DKG_WARM_CORE_CONNECTIONS=1`, confirm `warm-core reconcile: ... pinned=N dialed=M` log and that pinned cores stay connected across idle periods.

Made with [Cursor](https://cursor.com)