### PR TITLE
feat(agent): Cores fill their own gaps from chain (Phase D)

### DIFF
--- a/devnet/core-peers-features/.gitignore
+++ b/devnet/core-peers-features/.gitignore
@@ -1,0 +1,2 @@
+# Generated per-run witness nquads from the publish helpers.
+turns/

--- a/devnet/core-peers-features/README.md
+++ b/devnet/core-peers-features/README.md
@@ -1,0 +1,26 @@
+# core-peers-features — devnet validation
+
+End-to-end devnet gate for the chain-driven VM reconciliation effort
+("full Telegram on top of chain"): Phases **B / C / D / E / F**.
+
+## What it proves
+
+| Phase | Assertion |
+|-------|-----------|
+| **F** | Every node serves `/api/replication/{summary,per-cg,timeline,cursors,events}` backed by the V19 `replication_events` table. |
+| **B + E** | A public publish drives the reconciler: a core's per-CG contiguous watermark advances past 0, telemetry is persisted, and `daemon.log` carries the `chain-promote` grep surface. |
+| **D (recording)** | A core that signs a StorageACK for a public CG marks it `coreHosted` (cursor inspector Role = `host`), persisted. |
+| **D (fill-the-gap)** | A core taken **offline during a publish** learns the missed KA from chain on restart and fills its own gap — observed as a `core-fill` replication event and/or the missed triple landing in that core's verified-memory. |
+| **C** | The additive, unsigned `sinceBatchId` hint does not regress normal catch-up sync. (Its responder/envelope behaviour is unit-pinned in `packages/agent/test/sync-{responder,envelope}-cursor.test.ts`; it has no active production caller yet, so it isn't independently triggerable on devnet.) |
+
+## Run
+
+```bash
+pnpm run build
+./scripts/devnet.sh clean && ./scripts/devnet.sh start 6
+pnpm test:devnet:core-peers-features
+```
+
+Runtime ~3-6 min. The fill-the-gap test stops and restarts **node2** (a core)
+via `./scripts/devnet.sh restart-node 2`, so expect that node to blip during
+the run.

--- a/devnet/core-peers-features/automated.test.ts
+++ b/devnet/core-peers-features/automated.test.ts
@@ -42,7 +42,7 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { execFileSync, spawn } from 'node:child_process';
-import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import * as http from 'node:http';
 import { ethers } from 'ethers';
@@ -121,6 +121,17 @@ function readNodePids(num: number): number[] {
     if (Number.isFinite(pid) && !pids.includes(pid)) pids.push(pid);
   }
   return pids;
+}
+
+/** Remove a node's pid files. After a manual SIGKILL the files still hold the
+ *  now-dead PIDs; `devnet.sh restart-node` trusts them and could signal an
+ *  unrelated process if the OS recycled a PID before the restart. Clear them
+ *  so the restart starts from a clean slate. */
+function clearNodePidFiles(num: number): void {
+  for (const f of ['daemon.pid', 'devnet.pid']) {
+    const pidf = join(DEVNET_DIR, `node${num}`, f);
+    try { if (existsSync(pidf)) rmSync(pidf); } catch { /* best-effort */ }
+  }
 }
 
 // ───────────────────────────── HTTP helpers ──────────────────────────────
@@ -398,23 +409,29 @@ describe('Phase D — Cores host public CGs and fill their own gaps', () => {
   }, 120_000);
 
   it('a core offline during a publish fills its gap from chain on restart (core-fill)', async () => {
-    const victim = 2; // a core node
-    const victimNode = nodes[victim]!;
-
-    // Pre-req: the victim must already host the public CG (it ACKed earlier).
-    await waitFor(
-      `node${victim} hosts CONTEXT_GRAPH before the gap`,
+    // Pick a victim that HOSTS the public CG WITHOUT being member-subscribed to
+    // it (core_hosted=1 AND subscribed=0). That isolation is what makes this an
+    // end-to-end gate for the NEW Phase D path: a member-subscriber would refill
+    // the gap via its ordinary subscriber reconcile even if `coreHosted` were
+    // broken, so only a pure host proves the host-only recovery. The publishing
+    // core (node1) is the subscriber/curator; the other cores ACK as hosts.
+    const victim = await waitFor(
+      `a host-only core (core_hosted=1, subscribed=0) for CONTEXT_GRAPH`,
       90_000,
       4_000,
       async () => {
-        const cursors = await getJson(victimNode, '/api/replication/cursors');
-        if (cursors.status !== 200) return null;
-        const row = (cursors.body.cursors as any[]).find(
-          (c) => c.context_graph_id === CONTEXT_GRAPH && c.core_hosted === 1,
-        );
-        return row ? true : null;
+        for (const n of CORE_NODES) {
+          const cursors = await getJson(nodes[n]!, '/api/replication/cursors');
+          if (cursors.status !== 200) continue;
+          const row = (cursors.body.cursors as any[]).find(
+            (c) => c.context_graph_id === CONTEXT_GRAPH && c.core_hosted === 1 && c.subscribed !== 1,
+          );
+          if (row) return n;
+        }
+        return null;
       },
     );
+    const victimNode = nodes[victim]!;
 
     // 1. Take the victim core OFFLINE. Kill the real worker (daemon.pid),
     //    not just the already-exited `cli.js start` launcher (devnet.pid).
@@ -426,6 +443,9 @@ describe('Phase D — Cores host public CGs and fill their own gaps', () => {
     await waitFor(`node${victim} offline`, 45_000, 1_000, async () =>
       (await nodeReachable(victimNode)) ? null : true,
     );
+    // Stale pid files now hold dead PIDs — clear them so `restart-node` can't
+    // signal a recycled PID.
+    clearNodePidFiles(victim);
 
     // 2. Publish a fresh KA to the CG from node1 while the victim is down.
     const pub = await publishFromCore(nodes[1]!, 'gap');
@@ -441,13 +461,12 @@ describe('Phase D — Cores host public CGs and fill their own gaps', () => {
       (await nodeReachable(victimNode)) ? true : null,
     );
 
-    // 4. The victim must fill its gap FROM CHAIN after restart. The headline
-    //    proof is the missed triple landing in its verified-memory (the KA it
-    //    never received over gossip while offline). We also accept the distinct
-    //    `core-fill` telemetry as a bonus signal, but on devnet the cores are
-    //    also member-subscribers, so the reconciler emits the regular
-    //    `fetch`/`promote` surface rather than the host-only `core-fill` label —
-    //    the VM witness is the authoritative end-to-end signal.
+    // 4. The victim must fill its gap FROM CHAIN after restart. Because it is
+    //    NOT member-subscribed (subscribed=0), the missed KA can ONLY reach its
+    //    verified-memory via the Phase D host-fill path — so the VM witness here
+    //    is an authoritative end-to-end proof of the new behavior, not something
+    //    a subscriber reconcile could have produced. We still surface the
+    //    explicit `core-fill` telemetry as the headline signal when present.
     const filled = await waitFor(
       `node${victim} fills the gap (VM witness or core-fill event)`,
       240_000,

--- a/devnet/core-peers-features/automated.test.ts
+++ b/devnet/core-peers-features/automated.test.ts
@@ -108,11 +108,19 @@ function devnetPortEnv(): Record<string, string> {
   };
 }
 
-function readNodePid(num: number): number | null {
-  const pidf = join(DEVNET_DIR, `node${num}`, 'devnet.pid');
-  if (!existsSync(pidf)) return null;
-  const pid = parseInt(readFileSync(pidf, 'utf8').trim(), 10);
-  return Number.isFinite(pid) ? pid : null;
+/** Every pid that belongs to a node. `devnet.pid` is just the `cli.js start`
+ *  launcher, which double-forks the real worker (`daemon.pid`, reparented to
+ *  init) and then EXITS — so killing only `devnet.pid` leaves the API serving.
+ *  Return both (daemon first) so the caller can take the node truly offline. */
+function readNodePids(num: number): number[] {
+  const pids: number[] = [];
+  for (const f of ['daemon.pid', 'devnet.pid']) {
+    const pidf = join(DEVNET_DIR, `node${num}`, f);
+    if (!existsSync(pidf)) continue;
+    const pid = parseInt(readFileSync(pidf, 'utf8').trim(), 10);
+    if (Number.isFinite(pid) && !pids.includes(pid)) pids.push(pid);
+  }
+  return pids;
 }
 
 // ───────────────────────────── HTTP helpers ──────────────────────────────
@@ -158,6 +166,21 @@ function request(
 const getJson = (node: DevnetNode, path: string) => request('GET', api(node) + path, node.authToken);
 const postJson = (node: DevnetNode, path: string, body: unknown) =>
   request('POST', api(node) + path, node.authToken, body);
+
+/** Interpret an `/api/query` ASK response across the shapes the node may emit.
+ *  The current store returns `{ result: { bindings: [{ result: "true" }] } }`;
+ *  older/simple paths use `{ boolean }` or `{ value }`. Accept all. */
+function askIsTrue(body: any): boolean {
+  if (typeof body?.boolean === 'boolean') return body.boolean;
+  if (typeof body?.value === 'boolean') return body.value;
+  const bindings = body?.result?.bindings;
+  if (Array.isArray(bindings) && bindings.length > 0) {
+    const first = bindings[0] ?? {};
+    const v = first.result ?? first.boolean ?? Object.values(first)[0];
+    return v === true || v === 'true';
+  }
+  return false;
+}
 
 async function nodeReachable(node: DevnetNode): Promise<boolean> {
   try {
@@ -393,11 +416,14 @@ describe('Phase D — Cores host public CGs and fill their own gaps', () => {
       },
     );
 
-    // 1. Take the victim core OFFLINE (kill its daemon process).
-    const pid = readNodePid(victim);
-    expect(pid, `node${victim} pid not found`).toBeTruthy();
-    try { process.kill(pid!, 'SIGKILL'); } catch { /* may already be gone */ }
-    await waitFor(`node${victim} offline`, 30_000, 1_000, async () =>
+    // 1. Take the victim core OFFLINE. Kill the real worker (daemon.pid),
+    //    not just the already-exited `cli.js start` launcher (devnet.pid).
+    const pids = readNodePids(victim);
+    expect(pids.length, `node${victim} pids not found`).toBeGreaterThan(0);
+    for (const pid of pids) {
+      try { process.kill(pid, 'SIGKILL'); } catch { /* may already be gone */ }
+    }
+    await waitFor(`node${victim} offline`, 45_000, 1_000, async () =>
       (await nodeReachable(victimNode)) ? null : true,
     );
 
@@ -415,26 +441,30 @@ describe('Phase D — Cores host public CGs and fill their own gaps', () => {
       (await nodeReachable(victimNode)) ? true : null,
     );
 
-    // 4. The victim should fill its gap from chain: either a `core-fill`
-    //    replication event for the CG, or the missed triple landing in its
-    //    verified-memory. Poll both signals.
+    // 4. The victim must fill its gap FROM CHAIN after restart. The headline
+    //    proof is the missed triple landing in its verified-memory (the KA it
+    //    never received over gossip while offline). We also accept the distinct
+    //    `core-fill` telemetry as a bonus signal, but on devnet the cores are
+    //    also member-subscribers, so the reconciler emits the regular
+    //    `fetch`/`promote` surface rather than the host-only `core-fill` label —
+    //    the VM witness is the authoritative end-to-end signal.
     const filled = await waitFor(
-      `node${victim} fills the gap (core-fill event or VM witness)`,
+      `node${victim} fills the gap (VM witness or core-fill event)`,
       240_000,
       5_000,
       async () => {
-        const events = await getJson(victimNode, `/api/replication/events?cg=${encodeURIComponent(CONTEXT_GRAPH)}&limit=200`);
-        if (events.status === 200) {
-          const coreFill = (events.body.events as any[]).find((e) => e.action === 'core-fill');
-          if (coreFill) return { via: 'core-fill', detail: coreFill };
-        }
         const vm = await postJson(victimNode, '/api/query', {
           sparql: `ASK { <${pub.subject}> <https://schema.org/name> ?o }`,
           contextGraphId: CONTEXT_GRAPH,
           view: 'verified-memory',
         });
-        const ask = vm.body?.boolean ?? vm.body?.value ?? false;
-        if (vm.status === 200 && ask === true) return { via: 'vm-witness' };
+        if (vm.status === 200 && askIsTrue(vm.body)) return { via: 'vm-witness' };
+
+        const events = await getJson(victimNode, `/api/replication/events?cg=${encodeURIComponent(CONTEXT_GRAPH)}&limit=200`);
+        if (events.status === 200) {
+          const coreFill = (events.body.events as any[]).find((e) => e.action === 'core-fill');
+          if (coreFill) return { via: 'core-fill', detail: coreFill };
+        }
         return null;
       },
     );

--- a/devnet/core-peers-features/automated.test.ts
+++ b/devnet/core-peers-features/automated.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Core-peers features — devnet validation of the chain-driven VM
+ * reconciliation effort (Phases B / C / D / E / F).
+ *
+ * Confirms, against a live 6-node devnet (4 core + 2 edge), that the
+ * "full Telegram on top of chain" stack is functional end-to-end:
+ *
+ *   Phase F — every node serves the `/api/replication/*` surface
+ *             (summary / per-cg / timeline / cursors / events) backed by the
+ *             V19 `replication_events` table. (Pure API/DB wiring check.)
+ *
+ *   Phase B + E — publishing a KA to a public CG drives the chain-driven VM
+ *             reconciler: cores accumulate replication telemetry, the per-CG
+ *             contiguous watermark advances past 0, and the daemon log carries
+ *             the structured `chain-promote` grep surface.
+ *
+ *   Phase D (recording) — when a core signs a StorageACK for a PUBLIC CG it
+ *             marks the CG `coreHosted` (cursor inspector Role = host),
+ *             persisted across restart.
+ *
+ *   Phase D (fill-the-gap, headline) — a core taken OFFLINE during a publish
+ *             learns the missed KA from chain on restart and fills its own gap
+ *             (observable as a `core-fill` replication event and/or the missed
+ *             triple landing in that core's verified-memory).
+ *
+ *   Phase C — the `sinceBatchId` delta-sync hint is an additive, unsigned,
+ *             backward-compatible protocol field with no active production
+ *             caller yet (the contiguous-watermark resolver is intentionally
+ *             unwired). We assert only that normal catch-up sync is unaffected
+ *             — its responder/envelope behaviour is pinned by the agent unit
+ *             tests (`sync-responder-cursor`, `sync-envelope-cursor`).
+ *
+ * Preconditions:
+ *   pnpm run build
+ *   ./scripts/devnet.sh clean && ./scripts/devnet.sh start 6
+ *
+ * Run:
+ *   pnpm test:devnet:core-peers-features
+ *
+ * Runtime: ~3-6 minutes (the fill-the-gap test stops + restarts a core and
+ * waits a couple of reconcile sweeps).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import * as http from 'node:http';
+import { ethers } from 'ethers';
+
+// ───────────────────────────── constants ─────────────────────────────────
+const REPO_ROOT = resolve(__dirname, '../..');
+const DEVNET_DIR = join(REPO_ROOT, '.devnet');
+/** RPC is read from node1's config (devnet.sh wires it from HARDHAT_PORT), so a
+ *  non-default Hardhat port works without editing the test. */
+function detectRpc(): string {
+  if (process.env.DEVNET_RPC) return process.env.DEVNET_RPC;
+  try {
+    const cfg = JSON.parse(readFileSync(join(DEVNET_DIR, 'node1', 'config.json'), 'utf8'));
+    if (cfg?.chain?.rpcUrl) return cfg.chain.rpcUrl;
+  } catch { /* fall through */ }
+  return 'http://127.0.0.1:8545';
+}
+const RPC = detectRpc();
+const DEVNET_SH = join(REPO_ROOT, 'scripts/devnet.sh');
+const CONTEXT_GRAPH = 'devnet-test';
+const CORE_NODES = [1, 2, 3, 4];
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ───────────────────────────── node harness ──────────────────────────────
+interface DevnetNode {
+  num: number;
+  apiPort: number;
+  home: string;
+  authToken: string;
+}
+
+function readNodeConfig(num: number): DevnetNode {
+  const home = join(DEVNET_DIR, `node${num}`);
+  if (!existsSync(home)) {
+    throw new Error(`Devnet node${num} home missing — run ./scripts/devnet.sh start 6 first`);
+  }
+  const config = JSON.parse(readFileSync(join(home, 'config.json'), 'utf8'));
+  let authToken = '';
+  if (existsSync(join(home, 'auth.token'))) {
+    authToken =
+      readFileSync(join(home, 'auth.token'), 'utf8')
+        .split('\n')
+        .map((l) => l.trim())
+        .find((l) => l.length > 0 && !l.startsWith('#')) ?? '';
+  }
+  return { num, apiPort: config.apiPort, home, authToken };
+}
+
+function api(node: DevnetNode): string {
+  return `http://127.0.0.1:${node.apiPort}`;
+}
+
+/** Port env for `devnet.sh restart-node`, derived from node1's config so the
+ *  restart matches whatever (possibly non-default) ports this devnet uses. */
+function devnetPortEnv(): Record<string, string> {
+  const cfg = JSON.parse(readFileSync(join(DEVNET_DIR, 'node1', 'config.json'), 'utf8'));
+  const rpcPort = new URL(RPC).port || '8545';
+  return {
+    HARDHAT_PORT: rpcPort,
+    API_PORT_BASE: String(cfg.apiPort ?? 9201),
+    LIBP2P_PORT_BASE: String(cfg.listenPort ?? 10001),
+  };
+}
+
+function readNodePid(num: number): number | null {
+  const pidf = join(DEVNET_DIR, `node${num}`, 'devnet.pid');
+  if (!existsSync(pidf)) return null;
+  const pid = parseInt(readFileSync(pidf, 'utf8').trim(), 10);
+  return Number.isFinite(pid) ? pid : null;
+}
+
+// ───────────────────────────── HTTP helpers ──────────────────────────────
+function request(
+  method: 'GET' | 'POST',
+  url: string,
+  token: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolveP, rejectP) => {
+    const u = new URL(url);
+    const data = body ? JSON.stringify(body) : '';
+    const req = http.request(
+      {
+        host: u.hostname,
+        port: u.port,
+        method,
+        path: u.pathname + u.search,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+          ...(data ? { 'Content-Length': Buffer.byteLength(data) } : {}),
+        },
+      },
+      (res) => {
+        let buf = '';
+        res.on('data', (c) => (buf += c));
+        res.on('end', () => {
+          try {
+            resolveP({ status: res.statusCode ?? 0, body: JSON.parse(buf) });
+          } catch {
+            resolveP({ status: res.statusCode ?? 0, body: buf });
+          }
+        });
+      },
+    );
+    req.on('error', rejectP);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+const getJson = (node: DevnetNode, path: string) => request('GET', api(node) + path, node.authToken);
+const postJson = (node: DevnetNode, path: string, body: unknown) =>
+  request('POST', api(node) + path, node.authToken, body);
+
+async function nodeReachable(node: DevnetNode): Promise<boolean> {
+  try {
+    const r = await request('GET', api(node) + '/api/status', node.authToken);
+    return r.status === 200;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor<T>(
+  label: string,
+  timeoutMs: number,
+  intervalMs: number,
+  probe: () => Promise<T | null>,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: T | null = null;
+  while (Date.now() < deadline) {
+    last = await probe();
+    if (last) return last;
+    await sleep(intervalMs);
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for: ${label}`);
+}
+
+// ───────────────────────────── publish helpers ───────────────────────────
+function runDkgCli(node: DevnetNode, args: string[], timeoutMs = 120_000): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolveResult, rejectResult) => {
+    const child = spawn(process.execPath, [join(REPO_ROOT, 'packages/cli/dist/cli.js'), ...args], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, DKG_NO_BLUE_GREEN: '1', DKG_HOME: node.home, DKG_API_PORT: String(node.apiPort) },
+    });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      rejectResult(new Error(`dkg CLI timeout after ${timeoutMs}ms: ${args.join(' ')}`));
+    }, timeoutMs);
+    child.stdout?.on('data', (d) => (stdout += d.toString()));
+    child.stderr?.on('data', (d) => (stderr += d.toString()));
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolveResult({ code: code ?? -1, stdout, stderr });
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      rejectResult(err);
+    });
+  });
+}
+
+/** Write a unique nquads file and return its path + the subject we can later look for in VM. */
+function makeWitnessFile(name: string): { path: string; subject: string; literal: string } {
+  const dir = join(__dirname, 'turns');
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const ts = Date.now().toString(36);
+  const subject = `urn:test:core-peers:${name}:${ts}`;
+  const literal = `core-peers ${name} ${ts}`;
+  const path = join(dir, `${name}-${ts}.nq`);
+  const g = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
+  writeFileSync(
+    path,
+    `<${subject}> <https://schema.org/name> "${literal}" <${g}> .\n` +
+      `<${subject}> <https://schema.org/description> "core-peers feature devnet" <${g}> .\n`,
+  );
+  return { path, subject, literal };
+}
+
+async function publishFromCore(node: DevnetNode, name: string): Promise<{ subject: string; literal: string; kaId?: string; status: string }> {
+  const witness = makeWitnessFile(name);
+  const result = await runDkgCli(node, ['publish', CONTEXT_GRAPH, '--file', witness.path]);
+  if (result.code !== 0) {
+    throw new Error(`publish failed (exit ${result.code}) stdout=${result.stdout} stderr=${result.stderr}`);
+  }
+  const status = /Status:\s*(\w+)/i.exec(result.stdout)?.[1]?.toLowerCase() ?? 'unknown';
+  const kaId = /KC ID:\s*(\d+)/i.exec(result.stdout)?.[1];
+  return { subject: witness.subject, literal: witness.literal, kaId, status };
+}
+
+async function ensureIdentity(node: DevnetNode): Promise<void> {
+  const st = await getJson(node, '/api/status');
+  if (st.status === 200 && BigInt(st.body?.identityId ?? '0') > 0n) return;
+  await postJson(node, '/api/identity/ensure', {});
+  await waitFor(`node${node.num} identity`, 30_000, 1_000, async () => {
+    const s = await getJson(node, '/api/status');
+    return s.status === 200 && BigInt(s.body?.identityId ?? '0') > 0n ? true : null;
+  });
+}
+
+function daemonLogTail(num: number, maxBytes = 2_000_000): string {
+  const logf = join(DEVNET_DIR, `node${num}`, 'daemon.log');
+  if (!existsSync(logf)) return '';
+  const buf = readFileSync(logf);
+  return buf.subarray(Math.max(0, buf.length - maxBytes)).toString('utf8');
+}
+
+// ───────────────────────────── fixtures ──────────────────────────────────
+let nodes: Record<number, DevnetNode>;
+
+beforeAll(async () => {
+  if (!existsSync(DEVNET_DIR)) {
+    throw new Error(`${DEVNET_DIR} missing — run \`./scripts/devnet.sh clean && ./scripts/devnet.sh start 6\` first.`);
+  }
+  // Hardhat must be reachable.
+  const provider = new ethers.JsonRpcProvider(RPC, { chainId: 31337, name: 'localhost' });
+  const chainId = await provider.send('eth_chainId', []);
+  expect(chainId, 'devnet hardhat not reachable on :8545').toBeTruthy();
+
+  nodes = {};
+  for (let i = 1; i <= 6; i++) nodes[i] = readNodeConfig(i);
+
+  // Cores need an on-chain identity to publish + sign ACKs.
+  for (const n of CORE_NODES) await ensureIdentity(nodes[n]!);
+}, 180_000);
+
+// ─────────────────── 1. Phase F — replication API surface ─────────────────
+describe('Phase F — /api/replication surface is served by every node', () => {
+  it('summary / per-cg / timeline / cursors respond well-formed on all cores + an edge', async () => {
+    for (const n of [...CORE_NODES, 5]) {
+      const node = nodes[n]!;
+
+      const summary = await getJson(node, '/api/replication/summary?periodMs=86400000');
+      expect(summary.status, `node${n} summary: ${JSON.stringify(summary.body)}`).toBe(200);
+      expect(summary.body).toHaveProperty('counts');
+      expect(summary.body).toHaveProperty('promotes');
+      expect(summary.body).toHaveProperty('successRate'); // null or number
+      expect(typeof summary.body.totalEvents).toBe('number');
+
+      const perCg = await getJson(node, '/api/replication/per-cg?periodMs=86400000');
+      expect(perCg.status).toBe(200);
+      expect(Array.isArray(perCg.body.rows)).toBe(true);
+
+      const timeline = await getJson(node, '/api/replication/timeline?periodMs=86400000&bucketMs=3600000');
+      expect(timeline.status).toBe(200);
+      expect(Array.isArray(timeline.body.buckets)).toBe(true);
+
+      const cursors = await getJson(node, '/api/replication/cursors');
+      expect(cursors.status).toBe(200);
+      expect(Array.isArray(cursors.body.cursors)).toBe(true);
+    }
+  }, 60_000);
+
+  it('events endpoint requires a cg param (400) and returns an array when given one', async () => {
+    const node = nodes[1]!;
+    const missing = await getJson(node, '/api/replication/events');
+    expect(missing.status).toBe(400);
+    const ok = await getJson(node, `/api/replication/events?cg=${encodeURIComponent(CONTEXT_GRAPH)}&limit=10`);
+    expect(ok.status).toBe(200);
+    expect(Array.isArray(ok.body.events)).toBe(true);
+  }, 30_000);
+});
+
+// ────────── 2. Phase B + E — reconciler runs, watermark + telemetry ─────────
+describe('Phase B + E — chain-driven VM reconciliation + structured telemetry', () => {
+  it('a public publish advances a per-CG watermark and emits chain-promote telemetry on a core', async () => {
+    // Publish from a core so the KA is registered on-chain under CONTEXT_GRAPH.
+    const pub = await publishFromCore(nodes[1]!, 'reconcile');
+    expect(pub.status, `publish status=${pub.status}`).toBe('confirmed');
+
+    // The reconcile sweep (periodic, plus the live KACG nudge) should run on
+    // the cores and advance the contiguous watermark for this CG past 0, with
+    // telemetry persisted. Poll all cores; succeed on the first that shows it.
+    const hit = await waitFor(
+      'a core cursor watermark > 0 for CONTEXT_GRAPH with telemetry',
+      120_000,
+      4_000,
+      async () => {
+        for (const n of CORE_NODES) {
+          const node = nodes[n]!;
+          const cursors = await getJson(node, '/api/replication/cursors');
+          if (cursors.status !== 200) continue;
+          const row = (cursors.body.cursors as any[]).find((c) => c.context_graph_id === CONTEXT_GRAPH);
+          const summary = await getJson(node, '/api/replication/summary?periodMs=86400000');
+          const totalEvents = summary.body?.totalEvents ?? 0;
+          if (row && (row.last_reconciled_ordinal ?? 0) > 0 && totalEvents > 0) {
+            return { node: n, ordinal: row.last_reconciled_ordinal, totalEvents };
+          }
+        }
+        return null;
+      },
+    );
+    expect(hit.ordinal).toBeGreaterThan(0);
+
+    // Phase E grep surface: the daemon log carries structured chain-promote lines.
+    const log = daemonLogTail(hit.node);
+    expect(log, `node${hit.node} daemon.log missing 'chain-promote' lines`).toMatch(/chain-promote action=/);
+  }, 200_000);
+});
+
+// ────────────────── 3. Phase D — core-hosted recording + fill ──────────────
+describe('Phase D — Cores host public CGs and fill their own gaps', () => {
+  it('a core marks the public CG core-hosted (cursor Role = host), persisted', async () => {
+    // The publish in suite 2 made every core sign a StorageACK for the public
+    // CONTEXT_GRAPH, which marks it coreHosted. Poll cores for core_hosted=1.
+    const host = await waitFor(
+      'a core cursor with core_hosted=1 for CONTEXT_GRAPH',
+      90_000,
+      4_000,
+      async () => {
+        for (const n of CORE_NODES) {
+          const cursors = await getJson(nodes[n]!, '/api/replication/cursors');
+          if (cursors.status !== 200) continue;
+          const row = (cursors.body.cursors as any[]).find(
+            (c) => c.context_graph_id === CONTEXT_GRAPH && c.core_hosted === 1,
+          );
+          if (row) return { node: n, onChainId: row.on_chain_id };
+        }
+        return null;
+      },
+    );
+    expect(host.node).toBeGreaterThan(0);
+    // core_hosted is only ever set for PUBLIC CGs (curated stay on the
+    // ciphertext host-mode path), so this is also the public-detection proof.
+  }, 120_000);
+
+  it('a core offline during a publish fills its gap from chain on restart (core-fill)', async () => {
+    const victim = 2; // a core node
+    const victimNode = nodes[victim]!;
+
+    // Pre-req: the victim must already host the public CG (it ACKed earlier).
+    await waitFor(
+      `node${victim} hosts CONTEXT_GRAPH before the gap`,
+      90_000,
+      4_000,
+      async () => {
+        const cursors = await getJson(victimNode, '/api/replication/cursors');
+        if (cursors.status !== 200) return null;
+        const row = (cursors.body.cursors as any[]).find(
+          (c) => c.context_graph_id === CONTEXT_GRAPH && c.core_hosted === 1,
+        );
+        return row ? true : null;
+      },
+    );
+
+    // 1. Take the victim core OFFLINE (kill its daemon process).
+    const pid = readNodePid(victim);
+    expect(pid, `node${victim} pid not found`).toBeTruthy();
+    try { process.kill(pid!, 'SIGKILL'); } catch { /* may already be gone */ }
+    await waitFor(`node${victim} offline`, 30_000, 1_000, async () =>
+      (await nodeReachable(victimNode)) ? null : true,
+    );
+
+    // 2. Publish a fresh KA to the CG from node1 while the victim is down.
+    const pub = await publishFromCore(nodes[1]!, 'gap');
+    expect(pub.status).toBe('confirmed');
+
+    // 3. Bring the victim back online.
+    execFileSync('bash', [DEVNET_SH, 'restart-node', String(victim)], {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+      env: { ...process.env, ...devnetPortEnv() },
+    });
+    await waitFor(`node${victim} back online`, 90_000, 2_000, async () =>
+      (await nodeReachable(victimNode)) ? true : null,
+    );
+
+    // 4. The victim should fill its gap from chain: either a `core-fill`
+    //    replication event for the CG, or the missed triple landing in its
+    //    verified-memory. Poll both signals.
+    const filled = await waitFor(
+      `node${victim} fills the gap (core-fill event or VM witness)`,
+      240_000,
+      5_000,
+      async () => {
+        const events = await getJson(victimNode, `/api/replication/events?cg=${encodeURIComponent(CONTEXT_GRAPH)}&limit=200`);
+        if (events.status === 200) {
+          const coreFill = (events.body.events as any[]).find((e) => e.action === 'core-fill');
+          if (coreFill) return { via: 'core-fill', detail: coreFill };
+        }
+        const vm = await postJson(victimNode, '/api/query', {
+          sparql: `ASK { <${pub.subject}> <https://schema.org/name> ?o }`,
+          contextGraphId: CONTEXT_GRAPH,
+          view: 'verified-memory',
+        });
+        const ask = vm.body?.boolean ?? vm.body?.value ?? false;
+        if (vm.status === 200 && ask === true) return { via: 'vm-witness' };
+        return null;
+      },
+    );
+    expect(filled).toBeTruthy();
+    console.log(`Phase D fill-the-gap PASS via ${(filled as any).via}`);
+  }, 600_000);
+});
+
+// ───────────────────── 4. Phase C — no catch-up regression ─────────────────
+describe('Phase C — sinceBatchId is additive; normal sync is unaffected', () => {
+  it('a fresh core publish still reaches confirmed (full-scan sync path intact)', async () => {
+    // Phase C adds an OPTIONAL unsigned hint with no active production caller
+    // yet; its responder/envelope behaviour is unit-pinned. Here we only
+    // confirm the publish + catch-up path (which exercises PROTOCOL_SYNC) is
+    // not regressed by the additive field.
+    const pub = await publishFromCore(nodes[1]!, 'phasec');
+    expect(pub.status).toBe('confirmed');
+  }, 200_000);
+});

--- a/devnet/core-peers-features/package.json
+++ b/devnet/core-peers-features/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@origintrail-official/dkg-devnet-core-peers-features",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:devnet": "vitest run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "ethers": "^6.16.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
+  }
+}

--- a/devnet/core-peers-features/vitest.config.ts
+++ b/devnet/core-peers-features/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+/**
+ * Core-peers features — devnet validation of the chain-driven VM
+ * reconciliation effort (Phases B / C / D / E / F).
+ *
+ * Standalone config (out of the root vitest projects) because it requires a
+ * live devnet and stops/restarts a node mid-run.
+ *
+ * Run via: `pnpm test:devnet:core-peers-features`
+ *
+ * Preconditions:
+ *   pnpm run build
+ *   ./scripts/devnet.sh clean && ./scripts/devnet.sh start 6
+ */
+export default defineConfig({
+  test: {
+    include: [resolve(import.meta.dirname, 'automated.test.ts')],
+    testTimeout: 600_000,
+    hookTimeout: 300_000,
+    pool: 'forks',
+    sequence: { concurrent: false },
+    globals: false,
+  },
+  resolve: {
+    modules: [resolve(import.meta.dirname, '../../node_modules'), 'node_modules'],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:devnet:v10-e2e": "vitest run --config devnet/v10-end-to-end/vitest.config.ts",
     "test:devnet:v10-stress": "vitest run --config devnet/v10-stress/vitest.config.ts",
     "test:devnet:conviction-lazy-settle": "vitest run --config devnet/conviction-lazy-settle/vitest.config.ts",
+    "test:devnet:core-peers-features": "vitest run --config devnet/core-peers-features/vitest.config.ts",
     "test:devnet:edge-update-flow": "vitest run --config devnet/edge-update-flow/vitest.config.ts",
     "test:devnet:greenfield-10min": "vitest run --config devnet/greenfield-10min/vitest.config.ts",
     "test:devnet:rich-scenario": "vitest run --config devnet/rich-scenario/vitest.config.ts",

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -524,6 +524,17 @@ export interface ContextGraphSub {
    * of canonical chain state.
    */
   lastReconciledOrdinal?: number;
+  /**
+   * Phase D (Cores fill their own gaps) — set on a Core when it signs a
+   * StorageACK for a *public* CG, marking the CG as one this node hosts. The
+   * chain-driven VM reconciler (sweep + KACG nudge) runs for hosted CGs even
+   * without a member subscription, so a Core that was offline during a publish
+   * learns about the missed KA from chain on restart and pulls it from another
+   * Core. Persisted (survives restart — the whole point). Only ever set for
+   * public CGs: curated/ciphertext host-mode coverage stays on the host-mode
+   * reconciler + chunk-backfill path (Cores can't promote plaintext to VM).
+   */
+  coreHosted?: boolean;
   /** Participant agent addresses (V10 agent identity model). */
   participantAgents?: string[];
   /**
@@ -556,6 +567,8 @@ export interface ContextGraphSubscriptionRecord {
   onChainHash?: string;
   /** Phase B — persisted per-CG registration-ordinal VM watermark (see ContextGraphSub). */
   lastReconciledOrdinal?: number;
+  /** Phase D — persisted "this Core hosts a public CG" flag (see ContextGraphSub). */
+  coreHosted?: boolean;
   syncScoped: boolean;
 }
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2123,7 +2123,7 @@ export class DKGAgent {
                 // hosts the CG so the chain-driven VM reconciler fills its gaps
                 // across restarts. Best-effort + public-CG-gated inside the
                 // helper; never blocks or affects the (sync) provenance return.
-                void this.recordCoreHostedPublicCg(cgId);
+                void this.recordCoreHostedPublicCg(cgId, swmGraphId);
                 const wireFromCgId = cgId ? this.gossipWireIdFor(cgId) : undefined;
                 const wireFromSwmGraphId = swmGraphId && swmGraphId !== cgId
                   ? this.gossipWireIdFor(swmGraphId)
@@ -12127,7 +12127,7 @@ export class DKGAgent {
    * a Core cannot promote to plaintext VM — their coverage stays on the
    * host-mode reconciler + LU-11 chunk-backfill path. Best-effort + idempotent.
    */
-  private async recordCoreHostedPublicCg(cgId: string): Promise<void> {
+  private async recordCoreHostedPublicCg(cgId: string, swmGraphId?: string): Promise<void> {
     if (!this.vmReconcileEnabled()) return;
     let numeric: bigint;
     try {
@@ -12141,7 +12141,21 @@ export class DKGAgent {
     if (policy !== 0) return; // curated / unknown — not the public VM-promote path
 
     const numericStr = numeric.toString();
-    const localCgId = this.resolveLocalCgIdByOnChainId(numeric) ?? numericStr;
+    // Pick the local CG id to key the host-only record under. Prefer an
+    // existing local mapping; otherwise use the publisher-supplied cleartext
+    // `swmGraphId` (the local CG name for a public/cleartext publish). On the
+    // FIRST ACK for a CG we only host (never subscribed to),
+    // `resolveLocalCgIdByOnChainId()` is still empty — falling back to the
+    // numeric id would persist the row under `did:dkg:context-graph:<numeric>`,
+    // a namespace that doesn't hold the hosted SWM snapshot, so after restart
+    // the reconciler + active-fetch would sync/promote against the wrong graph
+    // and miss the KA this core already ACKed. The cleartext hint keeps the
+    // row under the same id the reconciler uses. Numeric/empty hints are
+    // ignored (last-resort numericStr keeps legacy behaviour).
+    const cleartextHint = swmGraphId && swmGraphId !== numericStr && !/^\d+$/.test(swmGraphId)
+      ? swmGraphId
+      : undefined;
+    const localCgId = this.resolveLocalCgIdByOnChainId(numeric) ?? cleartextHint ?? numericStr;
     const existing = this.subscribedContextGraphs.get(localCgId);
     if (existing?.coreHosted && existing.onChainId === numericStr) return; // already recorded
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -12283,9 +12283,13 @@ export class DKGAgent {
     // a namespace that doesn't hold the hosted SWM snapshot, so after restart
     // the reconciler + active-fetch would sync/promote against the wrong graph
     // and miss the KA this core already ACKed. The cleartext hint keeps the
-    // row under the same id the reconciler uses. Numeric/empty hints are
-    // ignored (last-resort numericStr keeps legacy behaviour).
-    const cleartextHint = swmGraphId && swmGraphId !== numericStr && !/^\d+$/.test(swmGraphId)
+    // row under the same id the reconciler uses.
+    // Discard the hint ONLY when it's empty or literally the on-chain numeric
+    // id (no information) — NOT merely because it's all-digits: a public CG's
+    // local cleartext id can be numeric (e.g. "1" is a valid contextGraphId
+    // elsewhere in the repo), and rejecting it would wrongly key the row under
+    // the on-chain id and miss the hosted KA after restart.
+    const cleartextHint = swmGraphId && swmGraphId !== numericStr
       ? swmGraphId
       : undefined;
     const localCgId = this.resolveLocalCgIdByOnChainId(numeric) ?? cleartextHint ?? numericStr;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2117,6 +2117,13 @@ export class DKGAgent {
               // having to round-trip it. Variadic + internal `seen` Set
               // dedups, so over-passing is cheap and order-independent.
               getSubscriptionSourceForCg: (cgId, swmGraphId) => {
+                // Phase D — this hook fires immediately before EVERY StorageACK
+                // sign (the universal pre-sign chokepoint across the plaintext /
+                // encrypted / chunked paths). Use it to record that this Core
+                // hosts the CG so the chain-driven VM reconciler fills its gaps
+                // across restarts. Best-effort + public-CG-gated inside the
+                // helper; never blocks or affects the (sync) provenance return.
+                void this.recordCoreHostedPublicCg(cgId);
                 const wireFromCgId = cgId ? this.gossipWireIdFor(cgId) : undefined;
                 const wireFromSwmGraphId = swmGraphId && swmGraphId !== cgId
                   ? this.gossipWireIdFor(swmGraphId)
@@ -2388,7 +2395,9 @@ export class DKGAgent {
               const localCgId = this.resolveLocalCgIdByOnChainId(BigInt(onChainId));
               if (!localCgId) return; // chain replay hasn't resolved the cleartext CG yet; sweep heals it
               const sub = this.subscribedContextGraphs.get(localCgId);
-              if (!sub?.subscribed) return; // only populate VM for CGs we actually subscribe to
+              // Populate VM for CGs we member-subscribe to OR (Phase D) public
+              // CGs this Core hosts — a hosted Core fills its own gaps too.
+              if (!sub?.subscribed && !sub?.coreHosted) return;
               this.log.info(ctx, `Phase B: KACG nudge cg=${onChainId} ka=${kaId} -> reconcile "${localCgId}"`);
               if (this.reconcileCoalescer) void this.reconcileCoalescer.trigger(localCgId);
             }
@@ -4187,7 +4196,11 @@ export class DKGAgent {
     const store = this.config.contextGraphSubscriptionStore;
     if (!store) return;
     const sub = this.subscribedContextGraphs.get(contextGraphId);
-    if (!sub?.subscribed) {
+    // Persist member subscriptions AND (Phase D) public CGs this Core hosts —
+    // the host-only record MUST survive restart so a Core that was offline
+    // during a publish remembers it hosts the CG and fills its gap. Drop the
+    // row only when the node neither subscribes to nor hosts the CG.
+    if (!sub?.subscribed && !sub?.coreHosted) {
       void store.delete(contextGraphId).catch((err) => {
         this.log.warn(
           createOperationContext('system'),
@@ -4206,6 +4219,7 @@ export class DKGAgent {
       onChainId: sub.onChainId,
       onChainHash: sub.onChainHash,
       lastReconciledOrdinal: sub.lastReconciledOrdinal,
+      coreHosted: sub.coreHosted,
       syncScoped: (this.config.syncContextGraphs ?? []).includes(contextGraphId),
     }).catch((err) => {
       this.log.warn(
@@ -4293,6 +4307,7 @@ export class DKGAgent {
           onChainId: row.onChainId,
           onChainHash: row.onChainHash,
           lastReconciledOrdinal: row.lastReconciledOrdinal,
+          coreHosted: row.coreHosted,
         }, { persist: false });
       }
       for (const row of rows) {
@@ -12079,6 +12094,70 @@ export class DKGAgent {
     return null;
   }
 
+  /**
+   * Phase D — resolve the on-chain access policy for a numeric CG id, public(0)
+   * / curated(1) / unknown(null). Cache-first (the StorageACK `isCgCurated`
+   * oracle seeds the same cache), single lazy chain read on miss. Never throws.
+   */
+  private async resolveAccessPolicy(numericCgId: bigint): Promise<0 | 1 | null> {
+    const key = numericCgId.toString();
+    const cached = this.onChainAccessPolicyCache.get(key);
+    if (cached === 0 || cached === 1) return cached;
+    const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
+    if (typeof getAccessPolicy !== 'function') return null;
+    try {
+      const policy = await getAccessPolicy.call(this.chain, numericCgId);
+      if (policy === 0 || policy === 1) {
+        this.onChainAccessPolicyCache.set(key, policy);
+        return policy;
+      }
+    } catch { /* unknown — fall through */ }
+    return null;
+  }
+
+  /**
+   * Phase D (Cores fill their own gaps) — invoked from the StorageACK
+   * pre-sign hook. When this Core signs an ACK for a PUBLIC CG it becomes a
+   * storage node for it; mark the CG `coreHosted` (persisted) so the
+   * chain-driven VM reconciler runs for it across restarts even without a
+   * member subscription. A Core that was offline during the *next* publish
+   * then learns the missed KA from chain on restart and pulls it core-first.
+   *
+   * Public-only by design: curated CGs are hosted as opaque ciphertext, which
+   * a Core cannot promote to plaintext VM — their coverage stays on the
+   * host-mode reconciler + LU-11 chunk-backfill path. Best-effort + idempotent.
+   */
+  private async recordCoreHostedPublicCg(cgId: string): Promise<void> {
+    if (!this.vmReconcileEnabled()) return;
+    let numeric: bigint;
+    try {
+      numeric = BigInt(cgId);
+    } catch {
+      return; // non-numeric id can't be reconciled against the chain ordinal list
+    }
+    if (numeric <= 0n) return;
+
+    const policy = await this.resolveAccessPolicy(numeric);
+    if (policy !== 0) return; // curated / unknown — not the public VM-promote path
+
+    const numericStr = numeric.toString();
+    const localCgId = this.resolveLocalCgIdByOnChainId(numeric) ?? numericStr;
+    const existing = this.subscribedContextGraphs.get(localCgId);
+    if (existing?.coreHosted && existing.onChainId === numericStr) return; // already recorded
+
+    const next: ContextGraphSub = existing
+      ? { ...existing, coreHosted: true, onChainId: numericStr }
+      : { subscribed: false, synced: false, onChainId: numericStr, coreHosted: true };
+    this.setContextGraphSubscription(localCgId, next);
+    this.log.info(
+      createOperationContext('system'),
+      `Phase D: marked public cg=${numericStr} as core-hosted (will chain-reconcile to VM across restarts)`,
+    );
+    // Nudge a reconcile now so the first hosted publish lands promptly; the
+    // periodic sweep is the safety net.
+    if (this.reconcileCoalescer) void this.reconcileCoalescer.trigger(localCgId);
+  }
+
   // ===== Phase B — chain-driven VM reconciliation (B.4 agent wiring) =========
 
   /**
@@ -12135,7 +12214,8 @@ export class DKGAgent {
   private async runVmReconcileSweep(): Promise<void> {
     if (!this.vmReconcileEnabled() || !this.reconcileCoalescer) return;
     for (const [localCgId, sub] of this.subscribedContextGraphs) {
-      if (!sub.subscribed || !sub.onChainId) continue;
+      // Member subscriptions AND Phase D core-hosted public CGs get swept.
+      if ((!sub.subscribed && !sub.coreHosted) || !sub.onChainId) continue;
       void this.reconcileCoalescer.trigger(localCgId);
     }
   }
@@ -12148,7 +12228,7 @@ export class DKGAgent {
    */
   private async runVmReconcileForCg(localCgId: string): Promise<void> {
     const sub = this.subscribedContextGraphs.get(localCgId);
-    if (!sub?.subscribed || !sub.onChainId || !this.vmReconcileEnabled()) return;
+    if ((!sub?.subscribed && !sub?.coreHosted) || !sub.onChainId || !this.vmReconcileEnabled()) return;
     const onChainCgId = BigInt(sub.onChainId);
 
     let cursor = this.reconcileCursors.get(localCgId);
@@ -12198,6 +12278,19 @@ export class DKGAgent {
           toWatermark: result.watermark,
           reconciled: result.reconciled,
           pending: result.pending,
+        });
+      }
+      // Phase D — a host-only (non-member) reconcile that actually promoted KAs
+      // is a Core filling its own gap. Distinct telemetry so operators can see
+      // the Core-to-Core fill path working (success-criteria metric).
+      if (result.reconciled > 0 && sub.coreHosted && !sub.subscribed) {
+        this.emitReplication({
+          contextGraphId: localCgId,
+          onChainCgId: sub.onChainId,
+          action: 'core-fill',
+          head: result.head,
+          toWatermark: result.watermark,
+          reconciled: result.reconciled,
         });
       }
     } catch (err) {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -31,7 +31,7 @@ import type { ReplicationEvent, ContextGraphSubscriptionRecord } from '../src/dk
 import { DKGAgent } from '../src/index.js';
 
 interface AgentInternals {
-  recordCoreHostedPublicCg(cgId: string): Promise<void>;
+  recordCoreHostedPublicCg(cgId: string, swmGraphId?: string): Promise<void>;
   runVmReconcileForCg(localCgId: string): Promise<void>;
   runVmReconcileSweep(): Promise<void>;
   subscribedContextGraphs: Map<string, { subscribed: boolean; coreHosted?: boolean; onChainId?: string; lastReconciledOrdinal?: number }>;
@@ -111,6 +111,37 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     const persisted = saved.find((r) => r.id === '42');
     expect(persisted?.coreHosted).toBe(true);
     expect(persisted?.subscribed).toBe(false);
+  });
+
+  it('keys the host row under the cleartext swmGraphId (not the numeric id) on first ACK', async () => {
+    // Regression: on the first ACK for a CG we only host, there is no local
+    // mapping yet, so without the cleartext hint the row would land under the
+    // numeric id ("1") instead of the local CG name ("devnet-test"), and the
+    // reconciler would sync against the wrong namespace.
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = async () => 0; // public
+
+    await internals.recordCoreHostedPublicCg('1', 'devnet-test');
+
+    // Recorded under the cleartext local id, with the numeric on-chain id bound.
+    const sub = internals.subscribedContextGraphs.get('devnet-test');
+    expect(sub).toBeDefined();
+    expect(sub!.coreHosted).toBe(true);
+    expect(sub!.onChainId).toBe('1');
+    // NOT under the numeric id.
+    expect(internals.subscribedContextGraphs.get('1')).toBeUndefined();
+    const persisted = saved.find((r) => r.id === 'devnet-test');
+    expect(persisted?.coreHosted).toBe(true);
+  });
+
+  it('ignores a numeric swmGraphId hint and falls back to the numeric id', async () => {
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = async () => 0;
+
+    // A numeric (or equal-to-cgId) hint carries no cleartext info → numericStr.
+    await internals.recordCoreHostedPublicCg('8', '8');
+
+    expect(internals.subscribedContextGraphs.get('8')?.coreHosted).toBe(true);
   });
 
   it('does NOT mark a CURATED CG (Cores host curated as opaque ciphertext, not VM)', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Phase D — Cores fill their own gaps.
+ *
+ * When a Core signs a StorageACK for a PUBLIC CG it becomes a storage node for
+ * it. The chain-driven VM reconciler (Phase B) must then run for that CG even
+ * without a member subscription, so a Core that was offline during the next
+ * publish learns the missed KA from chain on restart and pulls it core-first.
+ *
+ * This file pins the Phase-D-specific agent seams that the pure
+ * reconcile-cursor / chain-reconciler unit tests can't reach:
+ *
+ *   1. `recordCoreHostedPublicCg` — the StorageACK pre-sign chokepoint. Marks
+ *      PUBLIC CGs `coreHosted` (persisted), skips curated/unknown/non-numeric.
+ *   2. The lifted reconcile gate — sweep + per-CG reconcile run for a
+ *      `coreHosted` CG that has NO member subscription.
+ *   3. The `core-fill` telemetry — a host-only reconcile that promotes KAs to
+ *      VM emits the distinct `core-fill` replication event.
+ *
+ * The reconcile→VM engine itself is covered by `chain-reconcile-e2e.test.ts`;
+ * here we only prove the host-only path lights it up end-to-end.
+ */
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { MockChainAdapter, buildKnowledgeAssetUal } from '@origintrail-official/dkg-chain';
+import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
+import {
+  contextGraphWorkspaceGraphUri,
+  contextGraphWorkspaceMetaGraphUri,
+} from '@origintrail-official/dkg-core';
+import type { TripleStore } from '@origintrail-official/dkg-storage';
+import type { ReplicationEvent, ContextGraphSubscriptionRecord } from '../src/dkg-agent-types.js';
+import { DKGAgent } from '../src/index.js';
+
+interface AgentInternals {
+  recordCoreHostedPublicCg(cgId: string): Promise<void>;
+  runVmReconcileForCg(localCgId: string): Promise<void>;
+  runVmReconcileSweep(): Promise<void>;
+  subscribedContextGraphs: Map<string, { subscribed: boolean; coreHosted?: boolean; onChainId?: string; lastReconciledOrdinal?: number }>;
+  reconcileCoalescer: { trigger: (cg: string) => void } | null;
+  store: TripleStore;
+  chain: MockChainAdapter & { getContextGraphAccessPolicy?: (id: bigint) => Promise<number> };
+}
+
+/**
+ * Without a real `start()` the `DKGNode` getter throws on `peerId` access,
+ * which `setContextGraphSubscription`'s membership bookkeeping hits. Stub a
+ * structurally-typed node so the subscription map mutation path runs. Mirrors
+ * `v10-ack-provider-wiring.test.ts`.
+ */
+function stubNode(agent: DKGAgent): void {
+  (agent as unknown as { node: unknown }).node = {
+    peerId: '12D3KooWCoreFillTestPeer',
+    libp2p: { getPeers: () => [] },
+  };
+}
+
+/** Seed a local SWM snapshot for one KA under a CG and return its flat-KC root. */
+async function seedSwmSnapshot(store: TripleStore, localCgId: string, entity: string, value: string): Promise<Uint8Array> {
+  const wsGraph = contextGraphWorkspaceGraphUri(localCgId);
+  const wsMetaGraph = contextGraphWorkspaceMetaGraphUri(localCgId);
+  await store.insert([
+    { subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: wsGraph },
+    { subject: `urn:dkg:share:${entity}`, predicate: 'http://dkg.io/ontology/rootEntity', object: entity, graph: wsMetaGraph },
+  ]);
+  return computeFlatKCRootV10(
+    [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
+    [],
+  );
+}
+
+describe('Phase D — recordCoreHostedPublicCg', () => {
+  let agent: DKGAgent | null = null;
+  const saved: ContextGraphSubscriptionRecord[] = [];
+
+  afterEach(async () => {
+    if (agent) {
+      await agent.stop().catch(() => undefined);
+      agent = null;
+    }
+    saved.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  async function boot(): Promise<AgentInternals> {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({
+      name: 'CoreFillTest',
+      chainAdapter: chain,
+      contextGraphSubscriptionStore: {
+        loadAll: async () => [],
+        save: async (record) => { saved.push(record); },
+        delete: async () => undefined,
+      },
+    });
+    stubNode(agent);
+    return agent as unknown as AgentInternals;
+  }
+
+  it('marks a PUBLIC CG core-hosted (subscribed=false) and persists it', async () => {
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = async () => 0; // public
+
+    await internals.recordCoreHostedPublicCg('42');
+
+    const sub = internals.subscribedContextGraphs.get('42');
+    expect(sub).toBeDefined();
+    expect(sub!.coreHosted).toBe(true);
+    expect(sub!.subscribed).toBe(false);
+    expect(sub!.onChainId).toBe('42');
+
+    // Persisted across restart — the whole point of Phase D.
+    const persisted = saved.find((r) => r.id === '42');
+    expect(persisted?.coreHosted).toBe(true);
+    expect(persisted?.subscribed).toBe(false);
+  });
+
+  it('does NOT mark a CURATED CG (Cores host curated as opaque ciphertext, not VM)', async () => {
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = async () => 1; // curated
+
+    await internals.recordCoreHostedPublicCg('99');
+
+    expect(internals.subscribedContextGraphs.get('99')?.coreHosted).toBeUndefined();
+    expect(saved.find((r) => r.id === '99')).toBeUndefined();
+  });
+
+  it('ignores a non-numeric id (cannot index the on-chain ordinal list)', async () => {
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = async () => 0;
+
+    await internals.recordCoreHostedPublicCg('not-a-number');
+
+    expect(internals.subscribedContextGraphs.size).toBe(0);
+    expect(saved).toHaveLength(0);
+  });
+
+  it('is idempotent — a second ACK for the same hosted CG does not churn state', async () => {
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = async () => 0;
+
+    await internals.recordCoreHostedPublicCg('7');
+    const savesAfterFirst = saved.length;
+    await internals.recordCoreHostedPublicCg('7');
+
+    expect(internals.subscribedContextGraphs.get('7')?.coreHosted).toBe(true);
+    expect(saved.length).toBe(savesAfterFirst); // no second persist
+  });
+
+  it('preserves a pre-existing member subscription while adding coreHosted', async () => {
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = async () => 0;
+    internals.subscribedContextGraphs.set('5', { subscribed: true, onChainId: '5', lastReconciledOrdinal: 3 });
+
+    await internals.recordCoreHostedPublicCg('5');
+
+    const sub = internals.subscribedContextGraphs.get('5');
+    expect(sub!.subscribed).toBe(true);          // not clobbered
+    expect(sub!.coreHosted).toBe(true);
+    expect(sub!.lastReconciledOrdinal).toBe(3);  // watermark preserved
+  });
+});
+
+describe('Phase D — reconcile gate + core-fill telemetry', () => {
+  let agent: DKGAgent | null = null;
+
+  afterEach(async () => {
+    if (agent) {
+      await agent.stop().catch(() => undefined);
+      agent = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('sweep triggers a reconcile for a core-hosted CG with NO member subscription', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'CoreFillSweep', chainAdapter: chain });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+
+    // Host-only CG (subscribed:false, coreHosted:true) + a never-hosted member CG.
+    internals.subscribedContextGraphs.set('100', { subscribed: false, coreHosted: true, onChainId: '100' });
+    internals.subscribedContextGraphs.set('200', { subscribed: false, onChainId: '200' }); // neither subscribed nor hosted
+
+    const triggered: string[] = [];
+    internals.reconcileCoalescer = { trigger: (cg: string) => { triggered.push(cg); } };
+
+    await internals.runVmReconcileSweep();
+
+    expect(triggered).toContain('100');     // hosted → swept
+    expect(triggered).not.toContain('200'); // neither → skipped
+  });
+
+  it('a host-only reconcile promotes the missed KA to VM and emits core-fill', async () => {
+    const captured: ReplicationEvent[] = [];
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({
+      name: 'CoreFillE2E',
+      chainAdapter: chain,
+      onReplicationEvent: (ev) => { captured.push(ev); },
+    });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    internals.chain.getContextGraphAccessPolicy = async () => 0;
+
+    const ON_CHAIN_CG = 42n;
+    // The Core already has the SWM snapshot locally (simulating a pull from
+    // another Core), but never member-subscribed — it only hosts the CG.
+    const root = await seedSwmSnapshot(internals.store, '42', 'urn:fact:monday', 'Monday fun fact');
+    const { ethers } = await import('ethers');
+    chain.__registerKC({ kaId: 4242n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(root), chunks: [] });
+
+    await internals.recordCoreHostedPublicCg('42');
+    await internals.runVmReconcileForCg('42');
+
+    // Promoted into the per-CG VM graph.
+    const storageAddr = await chain.getDKGKnowledgeAssetsAddress();
+    const ual = buildKnowledgeAssetUal(chain.chainId, storageAddr, 4242n);
+    expect(ual).toContain('4242');
+    const vmGraph = `did:dkg:context-graph:42/context/${ON_CHAIN_CG}`;
+    const res = await internals.store.query(
+      `ASK { GRAPH <${vmGraph}> { <urn:fact:monday> <http://schema.org/name> "Monday fun fact" } }`,
+    );
+    expect(res.type === 'boolean' && res.value).toBe(true);
+
+    // Watermark advanced + distinct core-fill telemetry emitted.
+    expect(internals.subscribedContextGraphs.get('42')?.lastReconciledOrdinal).toBe(1);
+    const coreFill = captured.find((e) => e.action === 'core-fill');
+    expect(coreFill).toBeDefined();
+    expect(coreFill?.reconciled).toBe(1);
+    expect(coreFill?.contextGraphId).toBe('42');
+  });
+});

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1165,6 +1165,7 @@ export async function runDaemonInner(
         onChainId: row.on_chain_id ?? undefined,
         onChainHash: row.on_chain_hash ?? undefined,
         lastReconciledOrdinal: row.last_reconciled_ordinal ?? undefined,
+        coreHosted: row.core_hosted == null ? undefined : row.core_hosted === 1,
         syncScoped: row.sync_scoped === 1,
       })),
       save: async (record) => {
@@ -1178,6 +1179,7 @@ export async function runDaemonInner(
           on_chain_id: record.onChainId ?? null,
           on_chain_hash: record.onChainHash ?? null,
           last_reconciled_ordinal: record.lastReconciledOrdinal ?? null,
+          core_hosted: record.coreHosted == null ? null : record.coreHosted ? 1 : 0,
           sync_scoped: record.syncScoped ? 1 : 0,
           updated_at: Date.now(),
         });

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -1036,6 +1036,7 @@ export class DashboardDB {
              s.on_chain_id                 AS on_chain_id,
              s.last_reconciled_ordinal     AS last_reconciled_ordinal,
              s.core_hosted                 AS core_hosted,
+             s.subscribed                  AS subscribed,
              (SELECT MAX(head) FROM replication_events e
                 WHERE e.context_graph_id = s.context_graph_id) AS last_head,
              (SELECT MAX(ts) FROM replication_events e
@@ -2762,6 +2763,7 @@ export interface ReplicationCursorRow {
   on_chain_id: string | null;
   last_reconciled_ordinal: number | null;
   core_hosted: number | null;
+  subscribed: number | null;
   last_head: number | null;
   last_event_ts: number | null;
 }

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -9,7 +9,7 @@ import {
   type ProtocolOutboxStore,
 } from '@origintrail-official/dkg-core';
 
-const SCHEMA_VERSION = 18;
+const SCHEMA_VERSION = 19;
 // Default operator retention. Lowered from 90 → 14 days on V15 (2026-05) after
 // a production incident in which the `logs` table + its FTS5 shadow tables
 // grew to ~9 GB on a 12-day-old node and corrupted the SQLite page (header
@@ -697,6 +697,24 @@ export class DashboardDB {
       this.db.exec(`CREATE INDEX IF NOT EXISTS idx_repl_action ON replication_events(action, ts);`);
     }
 
+    if (version < 19) {
+      // Phase D (Cores fill their own gaps): persist `core_hosted` on the
+      // subscription row. Set when a Core signs a StorageACK for a PUBLIC CG,
+      // it marks the CG as one this node hosts so the chain-driven VM
+      // reconciler runs for it across restarts even without a member
+      // subscription. Without persistence a Core that ACKed a CG, went down
+      // during the next publish, and restarted would forget it hosts the CG
+      // and never fill the gap — defeating the phase. Same additive + nullable
+      // PRAGMA-then-ALTER pattern as V17.
+      const cols = new Set(
+        (this.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
+          .map((c) => c.name),
+      );
+      if (!cols.has('core_hosted')) {
+        this.db.exec(`ALTER TABLE context_graph_subscriptions ADD COLUMN core_hosted INTEGER;`);
+      }
+    }
+
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
     if (upgradedExistingDb && !this.explicitRetentionDays) {
       this.retentionDays = LEGACY_IMPLICIT_RETENTION_DAYS;
@@ -806,16 +824,17 @@ export class DashboardDB {
     on_chain_id?: string | null;
     on_chain_hash?: string | null;
     last_reconciled_ordinal?: number | null;
+    core_hosted?: number | null;
     sync_scoped: number;
     updated_at: number;
   }): void {
     this.stmt('upsertContextGraphSubscription', `
       INSERT INTO context_graph_subscriptions (
         context_graph_id, name, subscribed, synced, shared_memory_synced, meta_synced,
-        on_chain_id, on_chain_hash, last_reconciled_ordinal, sync_scoped, updated_at
+        on_chain_id, on_chain_hash, last_reconciled_ordinal, core_hosted, sync_scoped, updated_at
       ) VALUES (
         @context_graph_id, @name, @subscribed, @synced, @shared_memory_synced, @meta_synced,
-        @on_chain_id, @on_chain_hash, @last_reconciled_ordinal, @sync_scoped, @updated_at
+        @on_chain_id, @on_chain_hash, @last_reconciled_ordinal, @core_hosted, @sync_scoped, @updated_at
       )
       ON CONFLICT(context_graph_id) DO UPDATE SET
         name = excluded.name,
@@ -826,6 +845,7 @@ export class DashboardDB {
         on_chain_id = excluded.on_chain_id,
         on_chain_hash = excluded.on_chain_hash,
         last_reconciled_ordinal = excluded.last_reconciled_ordinal,
+        core_hosted = excluded.core_hosted,
         sync_scoped = excluded.sync_scoped,
         updated_at = excluded.updated_at
     `).run({
@@ -838,6 +858,7 @@ export class DashboardDB {
       on_chain_id: record.on_chain_id ?? null,
       on_chain_hash: record.on_chain_hash ?? null,
       last_reconciled_ordinal: record.last_reconciled_ordinal ?? null,
+      core_hosted: record.core_hosted ?? null,
       sync_scoped: record.sync_scoped,
       updated_at: record.updated_at,
     });
@@ -1006,6 +1027,7 @@ export class DashboardDB {
       SELECT s.context_graph_id            AS context_graph_id,
              s.on_chain_id                 AS on_chain_id,
              s.last_reconciled_ordinal     AS last_reconciled_ordinal,
+             s.core_hosted                 AS core_hosted,
              (SELECT MAX(head) FROM replication_events e
                 WHERE e.context_graph_id = s.context_graph_id) AS last_head,
              (SELECT MAX(ts) FROM replication_events e
@@ -2671,6 +2693,7 @@ export interface ContextGraphSubscriptionRow {
   on_chain_id: string | null;
   on_chain_hash: string | null;
   last_reconciled_ordinal: number | null;
+  core_hosted: number | null;
   sync_scoped: number;
   updated_at: number;
 }
@@ -2730,6 +2753,7 @@ export interface ReplicationCursorRow {
   context_graph_id: string;
   on_chain_id: string | null;
   last_reconciled_ordinal: number | null;
+  core_hosted: number | null;
   last_head: number | null;
   last_event_ts: number | null;
 }

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -187,6 +187,7 @@ export interface ReplicationCursorRow {
   context_graph_id: string;
   on_chain_id: string | null;
   last_reconciled_ordinal: number | null;
+  core_hosted: number | null;
   last_head: number | null;
   last_event_ts: number | null;
 }

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -188,6 +188,7 @@ export interface ReplicationCursorRow {
   on_chain_id: string | null;
   last_reconciled_ordinal: number | null;
   core_hosted: number | null;
+  subscribed: number | null;
   last_head: number | null;
   last_event_ts: number | null;
 }

--- a/packages/node-ui/src/ui/pages/Operations.tsx
+++ b/packages/node-ui/src/ui/pages/Operations.tsx
@@ -278,7 +278,7 @@ function ReplicationTab() {
           <div className="empty-state empty-state--compact"><div className="empty-state-title">No subscriptions</div></div>
         ) : (
           <table className="data-table">
-            <thead><tr><th>Context graph</th><th>On-chain id</th><th>Watermark</th><th>Chain head</th><th>Lag</th><th>Last event</th></tr></thead>
+            <thead><tr><th>Context graph</th><th>On-chain id</th><th>Role</th><th>Watermark</th><th>Chain head</th><th>Lag</th><th>Last event</th></tr></thead>
             <tbody>
               {cursors.map((c) => {
                 const wm = c.last_reconciled_ordinal ?? 0;
@@ -288,6 +288,7 @@ function ReplicationTab() {
                   <tr key={c.context_graph_id}>
                     <td className="mono">{c.context_graph_id}</td>
                     <td className="mono">{c.on_chain_id ?? '—'}</td>
+                    <td>{c.core_hosted ? <span className="badge badge-info" title="Core hosts this public CG; fills its own gaps from chain (Phase D)">host</span> : <span className="badge">member</span>}</td>
                     <td>{wm}</td>
                     <td>{head ?? '—'}</td>
                     <td>{lag == null ? '—' : <span className={`badge ${lag === 0 ? 'badge-success' : 'badge-error'}`}>{lag}</span>}</td>

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -86,7 +86,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(18);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
 
     const cols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -142,7 +142,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(18);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
 
     const newSnapshotCols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as { name: string }[])
       .map(c => c.name);
@@ -545,7 +545,7 @@ describe('DashboardDB — V15 migration: drop FTS5 logs index', () => {
 
     const upgraded = new DashboardDB({ dataDir: upgradeDir });
     try {
-      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(18);
+      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(19);
 
       const ftsTables = upgraded.db.prepare(
         `SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name LIKE 'logs_fts%'`,
@@ -710,7 +710,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(18);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -731,7 +731,101 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
       .map((c) => c.name);
     expect(cols).toContain('on_chain_hash');
     expect(cols).toContain('last_reconciled_ordinal');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(18);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+  });
+});
+
+describe('DashboardDB — V19 core_hosted column migration (Phase D)', () => {
+  let db: DashboardDB;
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dkg-db-v19-test-'));
+    db = new DashboardDB({ dataDir: dir });
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips core_hosted, defaulting to NULL', () => {
+    // Omitted → NULL (member-only / legacy subscription).
+    db.upsertContextGraphSubscription({
+      context_graph_id: 'cg-member',
+      subscribed: 1,
+      synced: 1,
+      sync_scoped: 1,
+      updated_at: 1000,
+    });
+    expect(db.listContextGraphSubscriptions()).toMatchObject([{
+      context_graph_id: 'cg-member',
+      core_hosted: null,
+    }]);
+
+    // A Core that ACKed a public CG records itself as a host (subscribed=0).
+    db.upsertContextGraphSubscription({
+      context_graph_id: '42',
+      subscribed: 0,
+      synced: 0,
+      on_chain_id: '42',
+      core_hosted: 1,
+      sync_scoped: 0,
+      updated_at: 2000,
+    });
+    const rows = db.listContextGraphSubscriptions();
+    expect(rows.find((r) => r.context_graph_id === '42')).toMatchObject({
+      subscribed: 0,
+      on_chain_id: '42',
+      core_hosted: 1,
+    });
+  });
+
+  it('surfaces core_hosted in the cursor inspector join', () => {
+    db.upsertContextGraphSubscription({
+      context_graph_id: '7',
+      subscribed: 0,
+      synced: 0,
+      on_chain_id: '7',
+      core_hosted: 1,
+      last_reconciled_ordinal: 3,
+      sync_scoped: 0,
+      updated_at: 1000,
+    });
+    const cursors = db.getReplicationCursors();
+    expect(cursors.find((c) => c.context_graph_id === '7')).toMatchObject({
+      on_chain_id: '7',
+      last_reconciled_ordinal: 3,
+      core_hosted: 1,
+    });
+  });
+
+  it('adds core_hosted when upgrading a pre-V19 DB, preserving rows', () => {
+    const dbPath = join(dir, 'node-ui.db');
+    db.close();
+
+    const raw = new Database(dbPath);
+    raw.exec('ALTER TABLE context_graph_subscriptions DROP COLUMN core_hosted;');
+    raw.prepare(
+      `INSERT INTO context_graph_subscriptions
+         (context_graph_id, name, subscribed, synced, on_chain_id, sync_scoped, updated_at)
+       VALUES ('cg-pre19', 'Pre19', 1, 1, '0xabc', 1, 1000)`,
+    ).run();
+    raw.pragma('user_version = 18');
+    raw.close();
+
+    db = new DashboardDB({ dataDir: dir });
+    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+
+    const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
+      .map((c) => c.name);
+    expect(cols).toContain('core_hosted');
+
+    expect(db.listContextGraphSubscriptions()).toMatchObject([{
+      context_graph_id: 'cg-pre19',
+      on_chain_id: '0xabc',
+      core_hosted: null,
+    }]);
   });
 });
 
@@ -1089,7 +1183,7 @@ describe('DashboardDB — V11→V13 chat schema migration chain', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(18);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
 
     const cols = (db.db.prepare('PRAGMA table_info(chat_messages)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1155,7 +1249,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(18);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
 
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1184,7 +1278,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
     expect(cols).toContain('context_graph_id');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(18);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
   });
 
   it('insertNotification writes context_graph_id to the column; omitted → NULL', () => {
@@ -1363,7 +1457,7 @@ describe('DashboardDB — replication telemetry (Phase F)', () => {
     raw.pragma('user_version = 17');
     raw.close();
     const upgraded = new DashboardDB({ dataDir: dir });
-    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(18);
+    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(19);
     // insert works → table exists
     upgraded.insertReplicationEvent({ ts: now, context_graph_id: 'cg', action: 'promote' });
     expect(upgraded.getReplicationSummary(60_000).promotes).toBe(1);

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -46,7 +46,7 @@ describe('V12 migration', () => {
     // DB layer in `db.test.ts`; this assertion just pins that
     // the substrate store fixtures are created against the
     // current SCHEMA_VERSION.
-    expect(db.db.pragma('user_version', { simple: true })).toBe(18);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,16 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  devnet/core-peers-features:
+    dependencies:
+      ethers:
+        specifier: ^6.16.0
+        version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
   devnet/edge-update-flow:
     devDependencies:
       vitest:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "packages/*"
   - "demo"
   - "devnet/agent-provenance"
+  - "devnet/core-peers-features"
   - "devnet/v10-core-flows"
   - "devnet/v10-end-to-end"
   - "devnet/v10-stress"


### PR DESCRIPTION
## Summary

Phase D of the chain-driven VM reconciliation effort — the final phase (stacked on #912 → #911 → #910 → #908). Core-side only; edges are not affected.

Makes Cores a reliable storage layer rather than a collection of individually-flaky nodes. When a Core signs a StorageACK for a **public** CG it becomes a storage node for it; we now mark that CG `coreHosted` (persisted) so the Phase B chain-driven VM reconciler runs for it **even without a member subscription**. A Core that was offline during the next publish learns the missed KA from chain on restart and pulls it core-first (Phase A peer order) using the Phase C `sinceBatchId` delta hint. The edge layer above benefits for free.

This reuses the entire Phase B engine (sweep, contiguous watermark, reorg-depth gate, active core-first fetch, `FinalizationHandler` promote), so the new surface is small:

- **`recordCoreHostedPublicCg(cgId)`** — invoked from the StorageACK pre-sign chokepoint (`getSubscriptionSourceForCg`, which fires for every ACK across the plaintext / encrypted / chunked paths). **Public-only by design**: curated CGs are hosted as opaque ciphertext a Core can't promote to plaintext VM, so they stay on the host-mode reconciler + LU-11 chunk-backfill path. Idempotent, best-effort, never blocks the (sync) provenance return.
- **Lifted reconcile gate** — the sweep, the live KACG nudge, and `runVmReconcileForCg` now run for `subscribed OR coreHosted` CGs (was subscribed-only).
- **`core-fill` telemetry** — a host-only reconcile that promotes KAs is the Core-to-Core fill working; distinct event so the `/ui/observability` Replication tab and `grep core-fill` surface it (success-criteria metric).

## Persistence (the whole point — must survive the restart)

- `ContextGraphSub` / `ContextGraphSubscriptionRecord` gain `coreHosted`; node-ui **V19** migration adds a nullable `core_hosted` column (additive PRAGMA-then-ALTER, same style as V17); CLI subscription store maps it both ways.
- **Latent bug fix (load-bearing for Phase D):** `persistContextGraphSubscription` previously **deleted** the persisted row for any non-subscribed CG, so a host-only record would never survive restart. It now persists `subscribed OR coreHosted` and drops the row only when the node neither subscribes to nor hosts the CG.
- Cursor inspector surfaces a host/member **Role** badge.

## Test plan

- [x] `core-fills-gap` (7): public-marks / curated-skips / non-numeric-skips / idempotent / preserves-member; sweep gate runs a host-only CG; **headline e2e** — a host-only Core promotes a missed KA to VM and emits `core-fill`
- [x] node-ui db: V19 migration + `core_hosted` round-trip + cursor-join (3); SCHEMA_VERSION 18→19 across db/messenger tests
- [x] agent reconcile + ACK-wiring regression (77) green
- [x] node-ui db / api-routes / messenger (118) green
- [x] agent + node-ui + cli `tsc` clean; lint clean

## Acceptance (from the plan)

Scripted scenario: Core offline during publish → restart → observe `core-fill` log line → verify the Core's local store now contains the missed batch in VM. The headline e2e test encodes exactly this (host-only Core, missed KA on chain, local SWM present → promoted to the per-CG VM graph + `core-fill` emitted).

Made with [Cursor](https://cursor.com)