### PR TITLE
Fix RC13 devnet runtime regressions

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -5885,6 +5885,35 @@ export class DKGAgent {
     return fallback;
   }
 
+  /**
+   * Codex review on PR #916 (`a15f25d` round 3) — return the local
+   * agent record that matches `targetAddress`, or null if none of
+   * `localAgents` is registered for that address (or has no
+   * private key). Distinct from {@link getWorkspaceGossipSigningAgent}
+   * which always picks the default/first available agent.
+   *
+   * Used by the beacon-registration path to honour
+   * `createContextGraph(opts.callerAgentAddress)` on multi-agent
+   * nodes: if the caller specified the curator address explicitly,
+   * the beacon must be signed by THAT agent so the wireId-pinned
+   * curator EOA matches whatever signer the host-catchup path
+   * later recovers (which uses the same lookup tied to the
+   * `beaconRegistry` entry for this CG).
+   */
+  private getWorkspaceSigningAgentForAddress(
+    targetAddress: string | undefined,
+  ): (AgentKeyRecord & { privateKey: string }) | null {
+    if (!targetAddress) return null;
+    const target = targetAddress.toLowerCase();
+    for (const record of this.localAgents.values()) {
+      if (!record.privateKey) continue;
+      if (record.agentAddress.toLowerCase() === target) {
+        return { ...record, privateKey: record.privateKey };
+      }
+    }
+    return null;
+  }
+
   private async getContextGraphAgentGateAddresses(contextGraphId: string): Promise<string[] | null> {
     const seen = new Set<string>();
     const agents: string[] = [];
@@ -11316,7 +11345,22 @@ export class DKGAgent {
    * auto-subscribe path on register, which still works for cores
    * that come online after registration.
    */
-  private async registerCgForBeaconAnnouncement(localCgId: string, accessPolicy: number): Promise<void> {
+  /**
+   * @param curatorAgentAddress
+   *   Optional explicit curator agent address (typically the
+   *   `opts.callerAgentAddress` resolved from the create-CG token).
+   *   When provided AND a matching workspace agent has a private
+   *   key, the beacon is signed by THAT agent so the wireId-pinned
+   *   `curatorEoa` matches what host-catchup envelopes will recover.
+   *   Without this, multi-agent nodes silently default to the first
+   *   workspace agent and the catchup path can authorize the wrong
+   *   identity. Codex review on PR #916.
+   */
+  private async registerCgForBeaconAnnouncement(
+    localCgId: string,
+    accessPolicy: number,
+    curatorAgentAddress?: string,
+  ): Promise<void> {
     if (accessPolicy !== BEACON_ACCESS_POLICY_CURATED) {
       // Public CGs don't need pre-registration auto-host: their
       // SWM substrate carries plaintext that any core can apply
@@ -11324,7 +11368,26 @@ export class DKGAgent {
       // specifically for curated ciphertext custody.
       return;
     }
-    const beaconAgentSigner = this.getWorkspaceGossipSigningAgent();
+    // Prefer the caller-specified curator agent on multi-agent
+    // nodes; only fall back to the default workspace agent when
+    // the caller didn't pin one.
+    const callerScopedSigner = this.getWorkspaceSigningAgentForAddress(curatorAgentAddress);
+    if (curatorAgentAddress && !callerScopedSigner) {
+      // The caller pinned a curator that isn't in `localAgents`
+      // with a privateKey. Defaulting to another agent here would
+      // mint a beacon whose `curatorEoa` doesn't match what the
+      // host-catchup path later recovers — silently pinning the
+      // wrong identity is worse than skipping the beacon. Drop
+      // the registration and log; the chain-event auto-subscribe
+      // path on register still works for cores that come online
+      // after registration.
+      this.log.warn(
+        createOperationContext('system'),
+        `Beacon registration skipped for "${localCgId}": caller curator ${curatorAgentAddress} has no local signer; would pin wrong curator EOA`,
+      );
+      return;
+    }
+    const beaconAgentSigner = callerScopedSigner ?? this.getWorkspaceGossipSigningAgent();
     const chainSignerEoa = beaconAgentSigner ? null : await this.getRegistrationTxSignerAddress();
     const curatorEoa = beaconAgentSigner?.agentAddress ?? chainSignerEoa;
     if (!curatorEoa) {
@@ -14023,7 +14086,11 @@ export class DKGAgent {
     // listening before the curator pays gas can already start
     // hosting.
     if (isCurated && !opts.private) {
-      this.registerCgForBeaconAnnouncement(opts.id, BEACON_ACCESS_POLICY_CURATED).catch((err) => {
+      this.registerCgForBeaconAnnouncement(
+        opts.id,
+        BEACON_ACCESS_POLICY_CURATED,
+        opts.callerAgentAddress,
+      ).catch((err) => {
         const msg = err instanceof Error ? err.message : String(err);
         this.log.warn(ctx, `Beacon registration for "${opts.id}" failed: ${msg}`);
       });

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -885,6 +885,7 @@ export class DKGAgent {
   private readonly beaconRegistry = new Map<string, {
     wireId: string;
     curatorEoa: string;
+    signerPrivateKey?: string;
     accessPolicy: number;
   }>();
   /**
@@ -10767,6 +10768,7 @@ export class DKGAgent {
     if (!curated) return;
 
     this.wireSwmHostModeHandler(contextGraphId, source);
+    await this.awaitHostModePersistence(contextGraphId);
 
     await this.maybeMarkRegisteredForHostMode(contextGraphId);
 
@@ -10928,6 +10930,11 @@ export class DKGAgent {
         this.hostModePersistenceQueues.delete(contextGraphId);
       }
     });
+  }
+
+  private async awaitHostModePersistence(contextGraphId: string): Promise<void> {
+    const pending = this.hostModePersistenceQueues.get(contextGraphId);
+    if (pending) await pending;
   }
 
   /**
@@ -11316,11 +11323,13 @@ export class DKGAgent {
       // specifically for curated ciphertext custody.
       return;
     }
-    const curatorEoa = await this.getRegistrationTxSignerAddress();
+    const beaconAgentSigner = this.getWorkspaceGossipSigningAgent();
+    const chainSignerEoa = beaconAgentSigner ? null : await this.getRegistrationTxSignerAddress();
+    const curatorEoa = beaconAgentSigner?.agentAddress ?? chainSignerEoa;
     if (!curatorEoa) {
       this.log.warn(
         createOperationContext('system'),
-        `Beacon registration skipped for "${localCgId}": no chain tx signer (likely a chain-disabled config); pre-registration auto-host won't run for this CG`,
+        `Beacon registration skipped for "${localCgId}": no DKG agent signer or chain tx signer; pre-registration auto-host won't run for this CG`,
       );
       return;
     }
@@ -11328,6 +11337,7 @@ export class DKGAgent {
     this.beaconRegistry.set(localCgId, {
       wireId,
       curatorEoa: curatorEoa.toLowerCase(),
+      ...(beaconAgentSigner?.privateKey ? { signerPrivateKey: beaconAgentSigner.privateKey } : {}),
       accessPolicy,
     });
     await this.broadcastCgDiscoveryBeacon(localCgId);
@@ -11351,6 +11361,9 @@ export class DKGAgent {
         accessPolicy: entry.accessPolicy,
         curatorEoa: entry.curatorEoa,
         sign: async (digest) => {
+          if (entry.signerPrivateKey) {
+            return new ethers.Wallet(entry.signerPrivateKey).signMessage(digest);
+          }
           // Chain adapter's `signMessage` returns `{r, vs}`; re-
           // serialise to the 65-byte hex shape ethers expects. The
           // EVM adapter routes through `Signer.signMessage` which
@@ -12121,7 +12134,9 @@ export class DKGAgent {
    *      explicit peer-allowlist meta (member CG context, not host-only
    *      core), require `fromPeerId ∈ allowedPeers`. Defence in depth
    *      against a signed-but-out-of-band requester.
-   *   6. Otherwise: DENY. The previous behaviour ("serve openly when
+   *   6. Ciphertext-only fallback: registered node-operator EOAs may
+   *      fetch opaque host-mode envelopes, matching LU-11 chunk catchup.
+   *   7. Otherwise: DENY. The previous behaviour ("serve openly when
    *      no authority source available") was the metadata-leak vector
    *      Codex flagged on PR #610 round-2 #6.
    *
@@ -12175,6 +12190,7 @@ export class DKGAgent {
     //   3c. locally-persisted agent-gate set (allowedAgent UNION
     //       participantAgent from _meta + subscription cache)
     //   3d. transport-layer allowedPeers (libp2p peer-id allowlist)
+    //   3e. registered node-operator EOA for ciphertext-only host catchup
     // Only if none accept do we deny.
     const requesterLower = requesterEoa.toLowerCase();
     let anyAuthoritySourceFound = false;
@@ -12236,8 +12252,32 @@ export class DKGAgent {
       // local-meta probe failure is non-fatal; the deny below still applies.
     }
 
+    // Ciphertext host-catchup parity with LU-11 chunk-catchup: the responder
+    // serves opaque SWM envelopes, not decrypted triples. A requester that can
+    // prove control of a registered node-operator EOA is allowed to fetch these
+    // bytes so host-only cores and member daemons whose operational wallet is
+    // distinct from their DKG agent address can recover missed ciphertext.
+    if (typeof this.chain.getIdentityIdForAddress === 'function') {
+      try {
+        const reqIdentityId = await this.chain.getIdentityIdForAddress(requesterEoa);
+        if (reqIdentityId > 0n) {
+          anyAuthoritySourceFound = true;
+          this.log.debug(
+            createOperationContext('share'),
+            `host-catchup admitted via node-operator authority cg=${req.contextGraphId} requesterEoa=${requesterEoa} identityId=${reqIdentityId.toString()}`,
+          );
+          return { ok: true, recoveredSigner: requesterEoa };
+        }
+      } catch (err) {
+        this.log.debug(
+          createOperationContext('share'),
+          `host-catchup node-operator probe failed cg=${req.contextGraphId} requesterEoa=${requesterEoa}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     const reason = anyAuthoritySourceFound
-      ? 'requester EOA not in any of: on-chain participants, beacon curator, local agent-gate, allowedPeers'
+      ? 'requester EOA not in any of: on-chain participants, beacon curator, local agent-gate, allowedPeers, node-operator-registry'
       : 'no authority source available for context graph';
     return { ok: false, reason };
   }
@@ -12625,6 +12665,7 @@ export class DKGAgent {
       return { subscribed: false, alreadySubscribed: true, hostingEnabled: true };
     }
     this.wireSwmHostModeHandler(contextGraphId, SUBSCRIPTION_SOURCES.MANUAL);
+    await this.awaitHostModePersistence(contextGraphId);
     // Codex PR #610 R1 comment 5: a core that only knows the CG by
     // topic id (the explicit /host-mode/subscribe entrypoint) must
     // still transition the store to the registered-CG limits as

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -10932,23 +10932,52 @@ export class DKGAgent {
    */
   private readonly hostModePersistenceQueues = new Map<string, Promise<void>>();
 
+  /**
+   * Resolve the on-disk store key for a host-mode persistence
+   * mutation. The {@link SwmHostModeStore} is cleartext-keyed by
+   * design (`append` / `iterate` / `markRegistered` all key off the
+   * cleartext id the gossip envelope carries — see
+   * {@link ingestSwmHostModeEnvelope}). The persisted
+   * `hostModeSubscribed` flag MUST use that same cleartext key so a
+   * `mark` taken in one id shape and a later `unmark` in the other
+   * (e.g. beacon/chain auto-host engages by wire-hash, then a
+   * promoted-to-member or curator-revoke unwire arrives in cleartext)
+   * collapse onto a single `.meta` file instead of leaving the flag
+   * stuck under an orphan key — which would re-engage a torn-down CG
+   * on the next restart. Wire-form (0x-hash) inputs are translated
+   * back through the {@link wireIdToLocalCgId} reverse index; an
+   * as-yet-unmapped hash falls back to itself.
+   */
+  private hostModePersistenceStoreKey(rawCgId: string): string {
+    if (/^0x[0-9a-fA-F]{64}$/.test(rawCgId)) {
+      const lower = rawCgId.toLowerCase();
+      return this.wireIdToLocalCgId.get(lower) ?? lower;
+    }
+    return rawCgId;
+  }
+
   private enqueueHostModePersistence(contextGraphId: string, subscribe: boolean): void {
     if (!this.swmHostModeStore) return;
+    // The in-memory queue stays wire-keyed so ordering dedups across
+    // id shapes (cleartext vs wire-hash for the same CG); the store
+    // mutation itself is cleartext-keyed via
+    // {@link hostModePersistenceStoreKey}.
     const queueKey = this.canonicalSwmHostModeKey(contextGraphId);
+    const storeCgId = this.hostModePersistenceStoreKey(contextGraphId);
     const store = this.swmHostModeStore;
     const op = subscribe ? 'mark' : 'unmark';
     const apply = async (): Promise<void> => {
       try {
         if (subscribe) {
-          await store.markHostModeSubscribed(contextGraphId);
+          await store.markHostModeSubscribed(storeCgId);
         } else {
-          await store.markHostModeUnsubscribed(contextGraphId);
+          await store.markHostModeUnsubscribed(storeCgId);
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         this.log.debug(
           createOperationContext('system'),
-          `Host-mode persistence (${op}) failed for "${contextGraphId}": ${msg}`,
+          `Host-mode persistence (${op}) failed for "${storeCgId}": ${msg}`,
         );
       }
     };

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -11396,11 +11396,20 @@ export class DKGAgent {
     }
   }
 
-  private getBeaconCatchupSigner(contextGraphId: string): { privateKey: string } | null {
+  private async getWorkspaceCatchupSigner(contextGraphId: string): Promise<{ privateKey: string } | null> {
     const wireId = this.gossipWireIdFor(contextGraphId);
     for (const entry of this.beaconRegistry.values()) {
       if (entry.signerPrivateKey && entry.wireId.toLowerCase() === wireId.toLowerCase()) {
         return { privateKey: entry.signerPrivateKey };
+      }
+    }
+
+    const allowedAgents = await this.getContextGraphAgentGateAddresses(contextGraphId).catch(() => null);
+    if (!allowedAgents || allowedAgents.length === 0) return null;
+    const allowedSet = new Set(allowedAgents.map((agent) => agent.toLowerCase()));
+    for (const record of this.localAgents.values()) {
+      if (record.privateKey && allowedSet.has(record.agentAddress.toLowerCase())) {
+        return { privateKey: record.privateKey };
       }
     }
     return null;
@@ -12337,19 +12346,20 @@ export class DKGAgent {
     const maxEntries = options?.maxEntriesPerRound ?? SWM_HOST_CATCHUP_DEFAULT_MAX_ENTRIES;
     const maxBytes = SWM_HOST_CATCHUP_DEFAULT_MAX_BYTES;
     // OT-RFC-38 LU-6 B1 — every catchup request is signed by the
-    // requesting agent's chain EOA so the host can authenticate via
-    // on-chain participant set without trusting the libp2p peer-id.
+    // requesting participant key so the host can authenticate via
+    // on-chain / agent-gated membership without trusting the libp2p
+    // peer-id.
     //
     // Codex PR #618 R2: we deliberately do NOT pre-compute the
     // requester EOA from `getRegistrationTxSignerAddress()`. The
     // chain adapter's tx-signer can differ from its message-signer
-    // (per the helper's own doc-comment), and binding the two
-    // independently produced "signer mismatch" rejections in every
-    // adapter except the EVM one. `mintSignedCatchupRequest` now
-    // recovers the actual signer from the signature itself and
-    // binds the digest to it — no caller-side lookup needed.
-    const beaconCatchupSigner = this.getBeaconCatchupSigner(contextGraphId);
-    if (!beaconCatchupSigner && typeof this.chain.signMessage !== 'function') {
+    // (per the helper's own doc-comment), and workspace-agent
+    // deployments can sign with a local custodial agent key instead.
+    // `mintSignedCatchupRequest` recovers the actual signer from
+    // the signature itself and binds the digest to it — no caller-
+    // side lookup needed.
+    const workspaceCatchupSigner = await this.getWorkspaceCatchupSigner(contextGraphId);
+    if (!workspaceCatchupSigner && typeof this.chain.signMessage !== 'function') {
       const reason = 'chain adapter does not implement signMessage — cannot mint signed catchup request';
       this.log.warn(ctx, `host-catchup ${reason} to=${remotePeerId} cg=${contextGraphId}`);
       return { rounds: 0, fetched: 0, applied: 0, appliedTriples: 0, skipped: 0, nextSeqno: sinceSeqno, denied: reason };
@@ -12374,8 +12384,8 @@ export class DKGAgent {
         // differ). See `MintSignedCatchupRequestInput.requesterEoa`
         // doc comment for the full rationale.
         sign: async (digest) => {
-          if (beaconCatchupSigner) {
-            return new ethers.Wallet(beaconCatchupSigner.privateKey).signMessage(digest);
+          if (workspaceCatchupSigner) {
+            return new ethers.Wallet(workspaceCatchupSigner.privateKey).signMessage(digest);
           }
           const { r, vs } = await this.chain.signMessage!(digest);
           const sig = ethers.Signature.from({ r: ethers.hexlify(r), yParityAndS: ethers.hexlify(vs) });

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -10905,6 +10905,7 @@ export class DKGAgent {
 
   private enqueueHostModePersistence(contextGraphId: string, subscribe: boolean): void {
     if (!this.swmHostModeStore) return;
+    const queueKey = this.canonicalSwmHostModeKey(contextGraphId);
     const store = this.swmHostModeStore;
     const op = subscribe ? 'mark' : 'unmark';
     const apply = async (): Promise<void> => {
@@ -10922,18 +10923,18 @@ export class DKGAgent {
         );
       }
     };
-    const prev = this.hostModePersistenceQueues.get(contextGraphId) ?? Promise.resolve();
+    const prev = this.hostModePersistenceQueues.get(queueKey) ?? Promise.resolve();
     const next = prev.then(apply, apply);
-    this.hostModePersistenceQueues.set(contextGraphId, next);
+    this.hostModePersistenceQueues.set(queueKey, next);
     void next.finally(() => {
-      if (this.hostModePersistenceQueues.get(contextGraphId) === next) {
-        this.hostModePersistenceQueues.delete(contextGraphId);
+      if (this.hostModePersistenceQueues.get(queueKey) === next) {
+        this.hostModePersistenceQueues.delete(queueKey);
       }
     });
   }
 
   private async awaitHostModePersistence(contextGraphId: string): Promise<void> {
-    const pending = this.hostModePersistenceQueues.get(contextGraphId);
+    const pending = this.hostModePersistenceQueues.get(this.canonicalSwmHostModeKey(contextGraphId));
     if (pending) await pending;
   }
 
@@ -11393,6 +11394,16 @@ export class DKGAgent {
       const msg = err instanceof Error ? err.message : String(err);
       this.log.debug(ctx, `Beacon publish for "${localCgId}" had no subscribers / failed: ${msg}`);
     }
+  }
+
+  private getBeaconCatchupSigner(contextGraphId: string): { privateKey: string } | null {
+    const wireId = this.gossipWireIdFor(contextGraphId);
+    for (const entry of this.beaconRegistry.values()) {
+      if (entry.signerPrivateKey && entry.wireId.toLowerCase() === wireId.toLowerCase()) {
+        return { privateKey: entry.signerPrivateKey };
+      }
+    }
+    return null;
   }
 
   /**
@@ -12337,7 +12348,8 @@ export class DKGAgent {
     // adapter except the EVM one. `mintSignedCatchupRequest` now
     // recovers the actual signer from the signature itself and
     // binds the digest to it — no caller-side lookup needed.
-    if (typeof this.chain.signMessage !== 'function') {
+    const beaconCatchupSigner = this.getBeaconCatchupSigner(contextGraphId);
+    if (!beaconCatchupSigner && typeof this.chain.signMessage !== 'function') {
       const reason = 'chain adapter does not implement signMessage — cannot mint signed catchup request';
       this.log.warn(ctx, `host-catchup ${reason} to=${remotePeerId} cg=${contextGraphId}`);
       return { rounds: 0, fetched: 0, applied: 0, appliedTriples: 0, skipped: 0, nextSeqno: sinceSeqno, denied: reason };
@@ -12362,6 +12374,9 @@ export class DKGAgent {
         // differ). See `MintSignedCatchupRequestInput.requesterEoa`
         // doc comment for the full rationale.
         sign: async (digest) => {
+          if (beaconCatchupSigner) {
+            return new ethers.Wallet(beaconCatchupSigner.privateKey).signMessage(digest);
+          }
           const { r, vs } = await this.chain.signMessage!(digest);
           const sig = ethers.Signature.from({ r: ethers.hexlify(r), yParityAndS: ethers.hexlify(vs) });
           return sig.serialized;

--- a/packages/agent/test/swm/cg-discovery-beacon-curator-selection.test.ts
+++ b/packages/agent/test/swm/cg-discovery-beacon-curator-selection.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Codex review on PR #916 (commit `a15f25d`) — multi-agent curator
+ * selection regression.
+ *
+ * Bug: `getWorkspaceGossipSigningAgent()` picked the default/first
+ * local agent regardless of which agent actually created the CG via
+ * `createContextGraph(opts.callerAgentAddress)`. On multi-agent
+ * nodes the beacon was therefore signed by the wrong agent and the
+ * pre-registration host-catchup path authorized only the
+ * beacon-pinned curator, so envelopes from the real creating agent
+ * were rejected until chain metadata caught up.
+ *
+ * Fix: thread `callerAgentAddress` from `createContextGraph` into
+ * `registerCgForBeaconAnnouncement` and prefer the matching local
+ * agent over the workspace default. When the caller pinned an
+ * agent that isn't actually a local custodial agent, drop the
+ * registration entirely (silently pinning a different agent would
+ * misalign beacon vs. catchup signers).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import { DKGAgent } from '../../src/index.js';
+import { BEACON_ACCESS_POLICY_CURATED } from '../../src/swm/cg-discovery-beacon.js';
+
+class InMemoryGossipBus {
+  subscribe(_topic: string): void {}
+  unsubscribe(_topic: string): void {}
+  onMessage(_topic: string, _handler: unknown): void {}
+  offMessage(_topic: string, _handler: unknown): void {}
+  async publish(_topic: string, _data: Uint8Array, _from?: string): Promise<void> {}
+  getSubscribers(_topic: string): string[] { return []; }
+}
+
+interface AgentInternals {
+  gossip: InMemoryGossipBus;
+  beaconRegistry: Map<string, {
+    wireId: string;
+    curatorEoa: string;
+    signerPrivateKey?: string;
+    accessPolicy: number;
+  }>;
+  registerCgForBeaconAnnouncement(
+    localCgId: string,
+    accessPolicy: number,
+    curatorAgentAddress?: string,
+  ): Promise<void>;
+}
+
+describe('beacon registration — multi-agent curator selection (PR #916)', () => {
+  const agents: DKGAgent[] = [];
+  afterEach(async () => {
+    await Promise.all(agents.splice(0).map((a) => a.stop().catch(() => {}).then(() => a.store.close().catch(() => {}))));
+  });
+
+  it('uses the caller-pinned local agent over the workspace default', async () => {
+    const node = await DKGAgent.create({ name: 'MultiAgentCurator', listenHost: '127.0.0.1' });
+    agents.push(node);
+    (node as unknown as AgentInternals).gossip = new InMemoryGossipBus();
+
+    // Register two custodial agents; the FIRST one becomes the
+    // default (matches `defaultAgentAddress`). The SECOND one is
+    // the actual curator the test pins via `callerAgentAddress`.
+    const defaultAgent = await node.registerAgent('default-agent');
+    const curatorAgent = await node.registerAgent('curator-agent');
+    expect(defaultAgent.agentAddress).not.toEqual(curatorAgent.agentAddress);
+
+    const cgId = 'multi-agent-curator-cg';
+    const expectedWireId = ethers.keccak256(ethers.toUtf8Bytes(cgId)).toLowerCase();
+
+    await (node as unknown as AgentInternals).registerCgForBeaconAnnouncement(
+      cgId,
+      BEACON_ACCESS_POLICY_CURATED,
+      curatorAgent.agentAddress,
+    );
+
+    const entry = (node as unknown as AgentInternals).beaconRegistry.get(cgId);
+    expect(entry).toBeDefined();
+    expect(entry?.wireId).toBe(expectedWireId);
+    expect(entry?.curatorEoa).toBe(curatorAgent.agentAddress.toLowerCase());
+    // The signer private key MUST be the curator's, not the default's,
+    // so the host-catchup path (which recovers the EOA from the
+    // signature) authorizes the same identity the beacon pinned.
+    expect(entry?.signerPrivateKey).toBe(curatorAgent.privateKey);
+    expect(entry?.signerPrivateKey).not.toBe(defaultAgent.privateKey);
+  });
+
+  it('falls back to the workspace default when no curator is pinned', async () => {
+    const node = await DKGAgent.create({ name: 'NoPinFallback', listenHost: '127.0.0.1' });
+    agents.push(node);
+    (node as unknown as AgentInternals).gossip = new InMemoryGossipBus();
+
+    const defaultAgent = await node.registerAgent('default-agent');
+    await node.registerAgent('secondary-agent');
+
+    const cgId = 'no-pin-fallback-cg';
+    await (node as unknown as AgentInternals).registerCgForBeaconAnnouncement(
+      cgId,
+      BEACON_ACCESS_POLICY_CURATED,
+    );
+
+    const entry = (node as unknown as AgentInternals).beaconRegistry.get(cgId);
+    expect(entry).toBeDefined();
+    expect(entry?.curatorEoa).toBe(defaultAgent.agentAddress.toLowerCase());
+    expect(entry?.signerPrivateKey).toBe(defaultAgent.privateKey);
+  });
+
+  it('skips registration when the caller pinned an agent with no local signer', async () => {
+    const node = await DKGAgent.create({ name: 'UnknownCuratorSkip', listenHost: '127.0.0.1' });
+    agents.push(node);
+    (node as unknown as AgentInternals).gossip = new InMemoryGossipBus();
+
+    await node.registerAgent('default-agent');
+    const stranger = ethers.Wallet.createRandom();
+
+    const cgId = 'unknown-curator-cg';
+    await (node as unknown as AgentInternals).registerCgForBeaconAnnouncement(
+      cgId,
+      BEACON_ACCESS_POLICY_CURATED,
+      stranger.address,
+    );
+
+    // Better to skip than to silently pin the default agent's EOA
+    // here: that would cause the host-catchup verification to deny
+    // every envelope the actual curator (who is off-node) signs.
+    expect((node as unknown as AgentInternals).beaconRegistry.has(cgId)).toBe(false);
+  });
+});

--- a/packages/agent/test/swm/host-mode-key-canonicalization.test.ts
+++ b/packages/agent/test/swm/host-mode-key-canonicalization.test.ts
@@ -86,6 +86,10 @@ interface AgentInternals {
   swmHostModeStore?: SwmHostModeStore;
   swmHostModeSubscribed: Map<string, string>;
   swmHostModeHandlers: Map<string, unknown>;
+  wireIdToLocalCgId: Map<string, string>;
+  enqueueHostModePersistence(contextGraphId: string, subscribe: boolean): void;
+  awaitHostModePersistence(contextGraphId: string): Promise<void>;
+  hostModePersistenceStoreKey(rawCgId: string): string;
 }
 
 async function installHostModeStore(core: DKGAgent, dataDir: string): Promise<SwmHostModeStore> {
@@ -207,5 +211,68 @@ describe('host-mode bookkeeping key canonicalisation', () => {
 
     expect(internals.swmHostModeSubscribed.size).toBe(0);
     expect(internals.swmHostModeHandlers.size).toBe(0);
+  });
+
+  // PR #916 Codex review (commit `445a852`): the in-memory maps above
+  // canonicalize to the wire hash, but the PERSISTED `hostModeSubscribed`
+  // flag in the SwmHostModeStore is keyed by the CLEARTEXT id — the same
+  // form `append` / `markRegistered` / catchup use (see the
+  // `ingestSwmHostModeEnvelope` design note). `enqueueHostModePersistence`
+  // used to forward the raw caller id straight to
+  // `markHostModeSubscribed/Unsubscribed`, so a `mark` taken in one shape
+  // and an `unmark` in the other landed in different `.meta` files and
+  // the flag was never cleared — re-engaging a torn-down CG on restart.
+  // The fix resolves the store key to cleartext via the
+  // `wireIdToLocalCgId` reverse index while keeping the queue key
+  // wire-canonical for ordering.
+
+  it('hostModePersistenceStoreKey maps a known wire-hash to cleartext and leaves cleartext / unmapped hashes alone', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    const cleartext = 'persist-key-unit-cg';
+    const wireHash = ethers.keccak256(ethers.toUtf8Bytes(cleartext)).toLowerCase();
+    internals.wireIdToLocalCgId.set(wireHash, cleartext);
+
+    expect(internals.hostModePersistenceStoreKey(wireHash)).toBe(cleartext);
+    expect(internals.hostModePersistenceStoreKey(cleartext)).toBe(cleartext);
+    // A valid wire-hash with no reverse-index entry falls back to a
+    // lowercased copy of itself (stable key for the pre-cleartext window).
+    const orphanHash = '0x' + 'AB'.repeat(32);
+    expect(internals.hostModePersistenceStoreKey(orphanHash)).toBe(orphanHash.toLowerCase());
+  });
+
+  it('persisted host-mode flag: mark by wire-hash then unmark by cleartext collapse onto one record', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    const cleartext = 'persist-wire-then-clear-cg';
+    const wireHash = ethers.keccak256(ethers.toUtf8Bytes(cleartext)).toLowerCase();
+    internals.wireIdToLocalCgId.set(wireHash, cleartext);
+
+    // Beacon/chain auto-host engages by wire-hash.
+    internals.enqueueHostModePersistence(wireHash, true);
+    await internals.awaitHostModePersistence(wireHash);
+    expect(await internals.swmHostModeStore!.listHostModeSubscribedCgs()).toEqual([cleartext]);
+
+    // Promoted-to-member / revoke unwire arrives in cleartext — must
+    // clear the SAME record, not write an orphan one.
+    internals.enqueueHostModePersistence(cleartext, false);
+    await internals.awaitHostModePersistence(cleartext);
+    expect(await internals.swmHostModeStore!.listHostModeSubscribedCgs()).toEqual([]);
+  });
+
+  it('persisted host-mode flag: mark by cleartext then unmark by wire-hash collapse onto one record', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    const cleartext = 'persist-clear-then-wire-cg';
+    const wireHash = ethers.keccak256(ethers.toUtf8Bytes(cleartext)).toLowerCase();
+    internals.wireIdToLocalCgId.set(wireHash, cleartext);
+
+    internals.enqueueHostModePersistence(cleartext, true);
+    await internals.awaitHostModePersistence(cleartext);
+    expect(await internals.swmHostModeStore!.listHostModeSubscribedCgs()).toEqual([cleartext]);
+
+    internals.enqueueHostModePersistence(wireHash, false);
+    await internals.awaitHostModePersistence(wireHash);
+    expect(await internals.swmHostModeStore!.listHostModeSubscribedCgs()).toEqual([]);
   });
 });

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -394,6 +394,19 @@ function normalizeIriBinding(cell: unknown): string {
   return bindingCellValue(cell).replace(/^<|>$/g, '').trim();
 }
 
+function singletonMetadataBinding(
+  bindings: Array<Record<string, unknown>>,
+  key: string,
+  normalize: (cell: unknown) => string,
+  label: string,
+): string {
+  const values = [...new Set(bindings.map((binding) => normalize(binding[key])).filter(Boolean))];
+  if (values.length > 1) {
+    throw new ImportArtifactRouteError(409, `Import metadata contains conflicting ${label} values`);
+  }
+  return values[0] ?? '';
+}
+
 function optionalPositiveInteger(cell: unknown): number | undefined {
   return parseOpenClawAttachmentTripleCount(bindingCellValue(cell));
 }
@@ -864,12 +877,11 @@ async function resolveImportedArtifactFromSharedMemory(
         OPTIONAL { <${args.assertionUri}> <${DKG_ONTOLOGY}markdownForm> ?markdownForm }
       }
     }
-    LIMIT 1
   `) as { type?: string; bindings?: Array<Record<string, unknown>> };
-  const binding = result.bindings?.[0];
-  if (!binding) return undefined;
+  const bindings = result.bindings ?? [];
+  if (bindings.length === 0) return undefined;
 
-  const sourceFile = normalizeIriBinding(binding.sourceFile);
+  const sourceFile = singletonMetadataBinding(bindings, 'sourceFile', normalizeIriBinding, 'source file');
   const sourceFileHash = hashFromFileUrn(sourceFile);
   if (!sourceFileHash || !validateContentHash(sourceFileHash)) {
     throw new ImportArtifactRouteError(409, 'Shared-memory import metadata is missing a valid source file hash');
@@ -878,10 +890,15 @@ async function resolveImportedArtifactFromSharedMemory(
     throw new ImportArtifactRouteError(400, 'fileHash does not match import metadata');
   }
 
-  const durableSourceContentType = normalizeLiteralBinding(binding.contentType) || undefined;
+  const durableSourceContentType = singletonMetadataBinding(
+    bindings,
+    'contentType',
+    normalizeLiteralBinding,
+    'source content type',
+  ) || undefined;
   const sourceContentType = normalizeDetectedContentType(durableSourceContentType);
-  const rootEntity = normalizeIriBinding(binding.rootEntity) || undefined;
-  const markdownFormValue = normalizeIriBinding(binding.markdownForm) || undefined;
+  const rootEntity = singletonMetadataBinding(bindings, 'rootEntity', normalizeIriBinding, 'root entity') || undefined;
+  const markdownFormValue = singletonMetadataBinding(bindings, 'markdownForm', normalizeIriBinding, 'Markdown form') || undefined;
   const markdownFormHash = hashFromFileUrn(markdownFormValue);
   if (markdownFormValue && (!markdownFormHash || !validateContentHash(markdownFormHash))) {
     throw new ImportArtifactRouteError(409, 'Import metadata is missing a valid Markdown intermediate hash');

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -842,6 +842,78 @@ function handleImportArtifactRouteError(res: ServerResponse, err: unknown): bool
   return false;
 }
 
+async function resolveImportedArtifactFromSharedMemory(
+  ctx: RequestContext,
+  args: {
+    contextGraphId: string;
+    assertionUri: string;
+    assertionName: string;
+    assertionAgentAddress: string;
+    subGraphName?: string;
+    requestedFileHash?: string;
+    ownerGuardRelaxed: boolean;
+  },
+): Promise<ImportedArtifactResolution | undefined> {
+  const swmGraph = contextGraphSharedMemoryUri(args.contextGraphId, args.subGraphName);
+  const result = await ctx.agent.store.query(`
+    SELECT ?sourceFile ?contentType ?rootEntity ?markdownForm WHERE {
+      GRAPH <${swmGraph}> {
+        <${args.assertionUri}> <${DKG_ONTOLOGY}sourceFile> ?sourceFile .
+        OPTIONAL { <${args.assertionUri}> <${DKG_ONTOLOGY}sourceContentType> ?contentType }
+        OPTIONAL { <${args.assertionUri}> <${DKG_ONTOLOGY}rootEntity> ?rootEntity }
+        OPTIONAL { <${args.assertionUri}> <${DKG_ONTOLOGY}markdownForm> ?markdownForm }
+      }
+    }
+    LIMIT 1
+  `) as { type?: string; bindings?: Array<Record<string, unknown>> };
+  const binding = result.bindings?.[0];
+  if (!binding) return undefined;
+
+  const sourceFile = normalizeIriBinding(binding.sourceFile);
+  const sourceFileHash = hashFromFileUrn(sourceFile);
+  if (!sourceFileHash || !validateContentHash(sourceFileHash)) {
+    throw new ImportArtifactRouteError(409, 'Shared-memory import metadata is missing a valid source file hash');
+  }
+  if (args.requestedFileHash && args.requestedFileHash !== sourceFileHash) {
+    throw new ImportArtifactRouteError(400, 'fileHash does not match import metadata');
+  }
+
+  const durableSourceContentType = normalizeLiteralBinding(binding.contentType) || undefined;
+  const sourceContentType = normalizeDetectedContentType(durableSourceContentType);
+  const rootEntity = normalizeIriBinding(binding.rootEntity) || undefined;
+  const markdownFormValue = normalizeIriBinding(binding.markdownForm) || undefined;
+  const markdownFormHash = hashFromFileUrn(markdownFormValue);
+  if (markdownFormValue && (!markdownFormHash || !validateContentHash(markdownFormHash))) {
+    throw new ImportArtifactRouteError(409, 'Import metadata is missing a valid Markdown intermediate hash');
+  }
+  const markdownHash = markdownFormHash
+    ?? (sourceContentType === 'text/markdown' ? sourceFileHash : undefined);
+  const markdownForm = markdownHash ? `urn:dkg:file:${markdownHash}` : undefined;
+  const markdownAvailableLocally = markdownHash
+    ? await ctx.fileStore.has(markdownHash).catch(() => false)
+    : false;
+
+  return {
+    contextGraphId: args.contextGraphId,
+    assertionUri: args.assertionUri,
+    assertionName: args.assertionName,
+    assertionAgentAddress: args.assertionAgentAddress,
+    ...(args.subGraphName ? { subGraphName: args.subGraphName } : {}),
+    fileHash: sourceFileHash,
+    sourceFileHash,
+    detectedContentType: sourceContentType,
+    sourceContentType,
+    extractionStatus: 'completed',
+    extractionMethod: 'structural',
+    ...(rootEntity ? { rootEntity } : {}),
+    ...(markdownHash && markdownHash !== sourceFileHash ? { mdIntermediateHash: markdownHash } : {}),
+    ...(markdownForm ? { markdownForm } : {}),
+    ...(markdownHash ? { markdownHash } : {}),
+    canReadMarkdown: markdownAvailableLocally,
+    ...(args.ownerGuardRelaxed ? { ownerGuardRelaxed: true } : {}),
+  };
+}
+
 async function resolveImportedArtifact(
   ctx: RequestContext,
   raw: Record<string, unknown>,
@@ -1013,6 +1085,18 @@ async function resolveImportedArtifact(
   `) as { type?: string; bindings?: Array<Record<string, unknown>> };
   const metaBinding = metaResult.bindings?.[0];
   if (!metaBinding) {
+    if (ownerGuardRelaxed) {
+      const swmArtifact = await resolveImportedArtifactFromSharedMemory(ctx, {
+        contextGraphId,
+        assertionUri,
+        assertionName: parsedAssertion.assertionName,
+        assertionAgentAddress: parsedAssertion.assertionAgentAddress,
+        ...(parsedAssertion.subGraphName ? { subGraphName: parsedAssertion.subGraphName } : {}),
+        ...(requestedFileHash ? { requestedFileHash } : {}),
+        ownerGuardRelaxed,
+      });
+      if (swmArtifact) return swmArtifact;
+    }
     throw new ImportArtifactRouteError(404, 'No completed import metadata found for assertionUri');
   }
 

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import {
   contextGraphAssertionUri,
   contextGraphMetaUri,
+  contextGraphSharedMemoryUri,
 } from '@origintrail-official/dkg-core';
 import { FileStore } from '../src/file-store.js';
 import type { ExtractionStatusRecord } from '../src/extraction-status.js';
@@ -115,6 +116,7 @@ describe('import artifact daemon routes', () => {
     omitExtractionStatus?: boolean;
     structuralTripleCount?: string;
     mdIntermediateHash?: string;
+    omitImportMeta?: boolean;
     publisherCreateError?: Error;
     publisherWriteError?: Error;
     publisherDiscardError?: Error;
@@ -230,6 +232,9 @@ describe('import artifact daemon routes', () => {
           if (sparql.includes('SELECT ?fileHash')) {
             expect(sparql).toContain(`<${contextGraphMetaUri(args.contextGraphId)}>`);
             expect(sparql).toContain(`<${args.assertionUri}> <${DKG}sourceFileHash>`);
+            if (args.omitImportMeta) {
+              return { type: 'bindings', bindings: [] };
+            }
             return {
               type: 'bindings',
               bindings: [{
@@ -242,6 +247,19 @@ describe('import artifact daemon routes', () => {
                 ...(args.omitExtractionStatus ? {} : { extractionStatus: args.extractionStatus ?? 'completed' }),
                 ...(args.mdIntermediateHash ? { mdIntermediateHash: args.mdIntermediateHash } : {}),
                 sourceFileName: 'imported.md',
+              }],
+            };
+          }
+          if (sparql.includes('SELECT ?sourceFile')) {
+            expect(sparql).toContain(`<${contextGraphSharedMemoryUri(args.contextGraphId)}>`);
+            expect(sparql).toContain(`<${args.assertionUri}> <${DKG}sourceFile>`);
+            return {
+              type: 'bindings',
+              bindings: [{
+                sourceFile: `urn:dkg:file:${args.fileHash}`,
+                ...(args.contentType !== null ? { contentType: args.contentType ?? 'text/markdown' } : {}),
+                rootEntity: args.assertionUri,
+                markdownForm: Array.isArray(args.markdownForm) ? args.markdownForm[0] : args.markdownForm,
               }],
             };
           }
@@ -552,6 +570,52 @@ describe('import artifact daemon routes', () => {
     });
     expect(resolved.status).toBe(200);
     expect(resolved.body.artifact.ownerGuardRelaxed).toBe(true);
+
+    const read = await post('/api/assertion/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri,
+      maxBytes: 1024,
+    });
+    expect(read.status).toBe(404);
+    expect(read.body.error).toMatch(/not replicated locally/);
+    expect(read.body.error).not.toMatch(/owned by the requesting agent/);
+    expect(read.body.artifact.ownerGuardRelaxed).toBe(true);
+  });
+
+  it('derives non-owner public + open read metadata from replicated SWM linkage when _meta is absent (#872 devnet)', async () => {
+    // Devnet peers receive the promoted SWM assertion triples but do not
+    // receive the origin node's CG-root `_meta` rows. The read route should
+    // still resolve enough metadata from the promoted source-file linkage to
+    // report the policy-relaxed artifact, then honestly 404 on missing bytes.
+    const markdownHash = `keccak256:${'b'.repeat(64)}`;
+    const contextGraphId = 'cg-public-open-swm-linkage-only';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: markdownHash,
+      markdownHash,
+      markdownForm: `urn:dkg:file:${markdownHash}`,
+      omitImportMeta: true,
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 1 },
+    });
+    await startRoutes({ agent });
+
+    const resolved = await post('/api/assertion/import-artifact/resolve', {
+      contextGraphId,
+      assertionUri,
+    });
+    expect(resolved.status).toBe(200);
+    expect(resolved.body.artifact).toMatchObject({
+      assertionUri,
+      assertionAgentAddress: 'did:dkg:agent:source',
+      sourceFileHash: markdownHash,
+      markdownHash,
+      canReadMarkdown: false,
+      ownerGuardRelaxed: true,
+    });
 
     const read = await post('/api/assertion/import-artifact/read-markdown', {
       contextGraphId,

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -537,6 +537,7 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
   private async writeJob(job: PromoteJob): Promise<void> {
     await this.store.deleteByPattern({ subject: jobSubject(job.jobId), graph: this.graphUri });
     await this.store.insert(serializeJob(job, this.graphUri));
+    await this.store.flush?.();
   }
 
   private assertLeaseHeld(job: PromoteJob, claimToken: string): void {

--- a/packages/publisher/test/async-promote-queue.test.ts
+++ b/packages/publisher/test/async-promote-queue.test.ts
@@ -87,6 +87,27 @@ describe('TripleStoreAsyncPromoteQueue', () => {
     expect(job!.request).toEqual(makeRequest());
   });
 
+  it('1b. queue mutations flush the store so crash recovery sees the latest lease state', async () => {
+    let flushes = 0;
+    const originalFlush = store.flush.bind(store);
+    store.flush = async () => {
+      flushes += 1;
+      await originalFlush();
+    };
+
+    const queue = createQueue();
+    const jobId = await queue.enqueue(makeRequest());
+    expect(flushes).toBe(1);
+
+    const claimed = await queue.claimNext('worker-1');
+    expect(claimed?.jobId).toBe(jobId);
+    expect(claimed?.state).toBe('running');
+    expect(flushes).toBe(2);
+
+    await queue.recordCommitMarker(jobId, claimed!.lease!.claimToken, 'promoteStarted');
+    expect(flushes).toBe(3);
+  });
+
   it('2. enqueue() rejects an empty assertionName as a fatal validation error', async () => {
     const queue = createQueue();
     await expect(queue.enqueue(makeRequest({ assertionName: '' }))).rejects.toThrow(/assertionName/);


### PR DESCRIPTION
## Summary
- flush async promote queue mutations so crash recovery observes the latest lease state
- allow public/open import artifact metadata resolution from replicated SWM linkage when owner _meta rows are absent
- fix host-mode persistence/catchup authority for preregistration and ciphertext-only recovery

## Validation
- POST_RC12_ONLY=1 SKIP_SOAK=1 ./scripts/devnet-comprehensive.sh
- pnpm --filter @origintrail-official/dkg-publisher test:unit -- test/async-promote-queue.test.ts -t 'queue mutations flush'
- pnpm run build
- broader devnet validation passed with the stacked validation branch