### PR TITLE
Fix markdown section root partitioning

### DIFF
--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -351,6 +351,11 @@ type PreSignedAuthorAttestation = {
 
 type SharedMemoryPublishSelection = "all" | { rootEntities: string[] };
 const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
+const SKOLEM_GENID_SEGMENT = '/.well-known/genid/';
+
+function subjectMatchesPublishRoot(subject: string, root: string): boolean {
+  return subject === root || (isSkolemizedUri(subject) && subject.startsWith(`${root}${SKOLEM_GENID_SEGMENT}`));
+}
 
 async function resolvePublishRootEntities(
   agent: DKGAgent,
@@ -372,16 +377,24 @@ async function resolvePublishRootEntities(
     const result = await agent.store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE {
         GRAPH <${swmGraph}> {
-          VALUES ?s { ${values} }
+          VALUES ?root { ${values} }
           ?s ?p ?o .
           FILTER(?p != <${WORKSPACE_OWNER_PREDICATE}>)
+          FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "${SKOLEM_GENID_SEGMENT}")))
         }
       }`,
     );
     const quads: Quad[] = result.type === "quads"
       ? result.quads.filter((quad) => quad.predicate !== WORKSPACE_OWNER_PREDICATE)
       : [];
-    const availableRoots = new Set(autoPartition(quads).keys());
+    const availableRoots = new Set<string>();
+    for (const quad of quads) {
+      for (const root of requestedRoots) {
+        if (subjectMatchesPublishRoot(quad.subject, root)) {
+          availableRoots.add(root);
+        }
+      }
+    }
     return requestedRoots.filter((root) => availableRoots.has(root));
   }
 

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -50,7 +50,7 @@ const SCHEMA_KEYWORDS = 'http://schema.org/keywords';
 const DKG_HAS_SECTION = 'http://dkg.io/ontology/hasSection';
 const DKG_SOURCE_FILE = 'http://dkg.io/ontology/sourceFile';
 const DKG_ROOT_ENTITY = 'http://dkg.io/ontology/rootEntity';
-const SKOLEM_GENID_SEGMENT = '/.well-known/genid/';
+const MARKDOWN_SECTION_BLANK_PREFIX = '_:dkg-md-section-';
 const XSD_BOOLEAN = 'http://www.w3.org/2001/XMLSchema#boolean';
 const XSD_DATE = 'http://www.w3.org/2001/XMLSchema#date';
 const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
@@ -195,6 +195,10 @@ function slugify(input: string): string {
 
 function shortHash(input: string): string {
   return createHash('sha256').update(input).digest('hex').slice(0, 12);
+}
+
+function markdownSectionBlankNode(subject: string, index: number, headingText: string): string {
+  return `${MARKDOWN_SECTION_BLANK_PREFIX}${shortHash(subject)}-${index}-${slugify(headingText)}`;
 }
 
 // Issue #123 / Round 11 Bug 33 follow-up: user-content extraction paths
@@ -475,7 +479,7 @@ export function extractFromMarkdown(input: MarkdownExtractInput): MarkdownExtrac
   for (const heading of extractHeadings(body)) {
     if (heading.level === 1) continue; // H1 is the document title, not a section
     sectionIndex += 1;
-    const sectionIri = `${subject}${SKOLEM_GENID_SEGMENT}section-${sectionIndex}-${slugify(heading.text)}`;
+    const sectionIri = markdownSectionBlankNode(subject, sectionIndex, heading.text);
     while (sectionStack.length > 0 && sectionStack[sectionStack.length - 1]!.level >= heading.level) {
       sectionStack.pop();
     }

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -50,6 +50,7 @@ const SCHEMA_KEYWORDS = 'http://schema.org/keywords';
 const DKG_HAS_SECTION = 'http://dkg.io/ontology/hasSection';
 const DKG_SOURCE_FILE = 'http://dkg.io/ontology/sourceFile';
 const DKG_ROOT_ENTITY = 'http://dkg.io/ontology/rootEntity';
+const SKOLEM_GENID_SEGMENT = '/.well-known/genid/';
 const XSD_BOOLEAN = 'http://www.w3.org/2001/XMLSchema#boolean';
 const XSD_DATE = 'http://www.w3.org/2001/XMLSchema#date';
 const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
@@ -180,7 +181,7 @@ function findFirstH1(body: string): string | null {
 }
 
 /**
- * Slugify a string for use in an IRI fragment. Keeps alphanumerics and hyphens.
+ * Slugify a string for use in a generated child IRI. Keeps alphanumerics and hyphens.
  */
 function slugify(input: string): string {
   const slug = input
@@ -474,7 +475,7 @@ export function extractFromMarkdown(input: MarkdownExtractInput): MarkdownExtrac
   for (const heading of extractHeadings(body)) {
     if (heading.level === 1) continue; // H1 is the document title, not a section
     sectionIndex += 1;
-    const sectionIri = `${subject}#section-${sectionIndex}-${slugify(heading.text)}`;
+    const sectionIri = `${subject}${SKOLEM_GENID_SEGMENT}section-${sectionIndex}-${slugify(heading.text)}`;
     while (sectionStack.length > 0 && sectionStack[sectionStack.length - 1]!.level >= heading.level) {
       sectionStack.pop();
     }

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
+import { autoPartition } from '@origintrail-official/dkg-publisher';
 import { extractFromMarkdown } from '../src/extraction/markdown-extractor.js';
 
 const AGENT = 'did:dkg:agent:0xAbC123';
 const FILE_URI = 'urn:dkg:file:keccak256:1111111111111111111111111111111111111111111111111111111111111111';
+const GRAPH = 'did:dkg:context-graph:test';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const SCHEMA_NAME = 'http://schema.org/name';
@@ -20,6 +22,10 @@ const XSD_DATE = 'http://www.w3.org/2001/XMLSchema#date';
 const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
 const XSD_DECIMAL = 'http://www.w3.org/2001/XMLSchema#decimal';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+
+function sectionIri(subjectIri: string, index: number, slug: string): string {
+  return `${subjectIri}/.well-known/genid/section-${index}-${slug}`;
+}
 
 describe('extractFromMarkdown - frontmatter', () => {
   it('extracts rdf:type from frontmatter `type` key (schema.org convention)', () => {
@@ -357,33 +363,63 @@ describe('extractFromMarkdown - headings', () => {
     const rootSections = triples.filter(t => t.subject === subjectIri && t.predicate === DKG_HAS_SECTION);
     expect(rootSections).toHaveLength(2);
     expect(rootSections.map(t => t.object)).toEqual([
-      `${subjectIri}#section-1-intro`,
-      `${subjectIri}#section-2-methods`,
+      sectionIri(subjectIri, 1, 'intro'),
+      sectionIri(subjectIri, 2, 'methods'),
     ]);
     expect(triples).toContainEqual({
-      subject: `${subjectIri}#section-2-methods`,
+      subject: sectionIri(subjectIri, 2, 'methods'),
       predicate: DKG_HAS_SECTION,
-      object: `${subjectIri}#section-3-sub-method`,
+      object: sectionIri(subjectIri, 3, 'sub-method'),
     });
     for (const section of [...rootSections, {
-      subject: `${subjectIri}#section-2-methods`,
+      subject: sectionIri(subjectIri, 2, 'methods'),
       predicate: DKG_HAS_SECTION,
-      object: `${subjectIri}#section-3-sub-method`,
+      object: sectionIri(subjectIri, 3, 'sub-method'),
     }]) {
       expect(triples.some(t => t.subject === section.object && t.predicate === SCHEMA_NAME)).toBe(true);
     }
   });
 
-  it('disambiguates repeated headings by prefixing a stable section index', () => {
+  it('disambiguates repeated headings by prefixing a stable section index under the document genid path', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Title\n\n## Overview\n\nText.\n\n## Overview\n\nMore text.\n`,
       agentDid: AGENT,
     });
     const sections = triples.filter(t => t.predicate === DKG_HAS_SECTION).map(t => t.object);
     expect(sections).toEqual([
-      `${subjectIri}#section-1-overview`,
-      `${subjectIri}#section-2-overview`,
+      sectionIri(subjectIri, 1, 'overview'),
+      sectionIri(subjectIri, 2, 'overview'),
     ]);
+  });
+
+  it('keeps markdown sections as skolemized children, not standalone autoPartition roots', () => {
+    const { triples, subjectIri } = extractFromMarkdown({
+      markdown: `# Title\n\n## Intro\n\n### Detail\n`,
+      agentDid: AGENT,
+    });
+    const quads = triples.map((triple) => ({ ...triple, graph: GRAPH }));
+
+    const partitioned = autoPartition(quads);
+    expect([...partitioned.keys()]).toEqual([subjectIri]);
+
+    const selectedRootQuads = quads.filter(
+      (quad) =>
+        quad.subject === subjectIri ||
+        quad.subject.startsWith(`${subjectIri}/.well-known/genid/`),
+    );
+    expect(selectedRootQuads).toHaveLength(quads.length);
+    expect(selectedRootQuads).toContainEqual({
+      subject: sectionIri(subjectIri, 1, 'intro'),
+      predicate: DKG_HAS_SECTION,
+      object: sectionIri(subjectIri, 2, 'detail'),
+      graph: GRAPH,
+    });
+    expect(selectedRootQuads).toContainEqual({
+      subject: sectionIri(subjectIri, 2, 'detail'),
+      predicate: SCHEMA_NAME,
+      object: '"Detail"',
+      graph: GRAPH,
+    });
   });
 
   it('H1 promotes to schema:name on the document subject', () => {
@@ -448,7 +484,7 @@ describe('extractFromMarkdown - subject IRI resolution', () => {
     const mentions = triples.filter(t => t.predicate === SCHEMA_MENTIONS).map(t => t.object);
     expect(mentions).toEqual([expect.stringMatching(/^urn:dkg:md:hash-[0-9a-f]{12}$/)]);
     const sections = triples.filter(t => t.predicate === DKG_HAS_SECTION).map(t => t.object);
-    expect(sections).toEqual([expect.stringMatching(new RegExp(`^${subjectIri.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}#section-1-hash-[0-9a-f]{12}$`))]);
+    expect(sections).toEqual([expect.stringMatching(new RegExp(`^${subjectIri.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/\\.well-known/genid/section-1-hash-[0-9a-f]{12}$`))]);
   });
 
   it('produces a stable anonymous fallback when there is no title', () => {
@@ -734,8 +770,8 @@ Our method relies on [[SPARQL]] queries.
     // Sections
     const sections = triples.filter(t => t.predicate === DKG_HAS_SECTION).map(t => t.object);
     expect(sections).toEqual([
-      `${subjectIri}#section-1-background`,
-      `${subjectIri}#section-2-methods`,
+      sectionIri(subjectIri, 1, 'background'),
+      sectionIri(subjectIri, 2, 'methods'),
     ]);
 
     // Section 10.1 linkage present: rows 1 (sourceFile) and 3 (rootEntity).

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
 import { autoPartition } from '@origintrail-official/dkg-publisher';
 import { extractFromMarkdown } from '../src/extraction/markdown-extractor.js';
 
@@ -23,8 +24,16 @@ const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
 const XSD_DECIMAL = 'http://www.w3.org/2001/XMLSchema#decimal';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
+function shortHash(input: string): string {
+  return createHash('sha256').update(input).digest('hex').slice(0, 12);
+}
+
 function sectionIri(subjectIri: string, index: number, slug: string): string {
-  return `${subjectIri}/.well-known/genid/section-${index}-${slug}`;
+  return `_:dkg-md-section-${shortHash(subjectIri)}-${index}-${slug}`;
+}
+
+function skolemizedSectionIri(subjectIri: string, index: number, slug: string): string {
+  return `${subjectIri}/.well-known/genid/dkg-md-section-${shortHash(subjectIri)}-${index}-${slug}`;
 }
 
 describe('extractFromMarkdown - frontmatter', () => {
@@ -380,7 +389,7 @@ describe('extractFromMarkdown - headings', () => {
     }
   });
 
-  it('disambiguates repeated headings by prefixing a stable section index under the document genid path', () => {
+  it('disambiguates repeated headings by prefixing a stable section index in markdown-owned blank nodes', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Title\n\n## Overview\n\nText.\n\n## Overview\n\nMore text.\n`,
       agentDid: AGENT,
@@ -392,7 +401,7 @@ describe('extractFromMarkdown - headings', () => {
     ]);
   });
 
-  it('keeps markdown sections as skolemized children, not standalone autoPartition roots', () => {
+  it('keeps markdown section blank nodes as skolemized children, not standalone autoPartition roots', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Title\n\n## Intro\n\n### Detail\n`,
       agentDid: AGENT,
@@ -402,24 +411,51 @@ describe('extractFromMarkdown - headings', () => {
     const partitioned = autoPartition(quads);
     expect([...partitioned.keys()]).toEqual([subjectIri]);
 
-    const selectedRootQuads = quads.filter(
-      (quad) =>
-        quad.subject === subjectIri ||
-        quad.subject.startsWith(`${subjectIri}/.well-known/genid/`),
-    );
+    const selectedRootQuads = partitioned.get(subjectIri) ?? [];
     expect(selectedRootQuads).toHaveLength(quads.length);
     expect(selectedRootQuads).toContainEqual({
-      subject: sectionIri(subjectIri, 1, 'intro'),
+      subject: skolemizedSectionIri(subjectIri, 1, 'intro'),
       predicate: DKG_HAS_SECTION,
-      object: sectionIri(subjectIri, 2, 'detail'),
+      object: skolemizedSectionIri(subjectIri, 2, 'detail'),
       graph: GRAPH,
     });
     expect(selectedRootQuads).toContainEqual({
-      subject: sectionIri(subjectIri, 2, 'detail'),
+      subject: skolemizedSectionIri(subjectIri, 2, 'detail'),
       predicate: SCHEMA_NAME,
       object: '"Detail"',
       graph: GRAPH,
     });
+  });
+
+  it('does not collide with existing blank nodes when markdown sections are skolemized', () => {
+    const documentIri = 'urn:dkg:md:collision';
+    const { triples } = extractFromMarkdown({
+      markdown: `# Title\n\n## Intro\n`,
+      agentDid: AGENT,
+      documentIri,
+    });
+    const realBlankNode = '_:section-1-intro';
+    const quads = [
+      ...triples.map((triple) => ({ ...triple, graph: GRAPH })),
+      { subject: documentIri, predicate: 'http://schema.org/about', object: realBlankNode, graph: GRAPH },
+      { subject: realBlankNode, predicate: SCHEMA_NAME, object: '"Existing blank node"', graph: GRAPH },
+    ];
+
+    const selectedRootQuads = autoPartition(quads).get(documentIri) ?? [];
+
+    expect(selectedRootQuads).toContainEqual({
+      subject: skolemizedSectionIri(documentIri, 1, 'intro'),
+      predicate: SCHEMA_NAME,
+      object: '"Intro"',
+      graph: GRAPH,
+    });
+    expect(selectedRootQuads).toContainEqual({
+      subject: `${documentIri}/.well-known/genid/section-1-intro`,
+      predicate: SCHEMA_NAME,
+      object: '"Existing blank node"',
+      graph: GRAPH,
+    });
+    expect(skolemizedSectionIri(documentIri, 1, 'intro')).not.toBe(`${documentIri}/.well-known/genid/section-1-intro`);
   });
 
   it('H1 promotes to schema:name on the document subject', () => {
@@ -484,7 +520,9 @@ describe('extractFromMarkdown - subject IRI resolution', () => {
     const mentions = triples.filter(t => t.predicate === SCHEMA_MENTIONS).map(t => t.object);
     expect(mentions).toEqual([expect.stringMatching(/^urn:dkg:md:hash-[0-9a-f]{12}$/)]);
     const sections = triples.filter(t => t.predicate === DKG_HAS_SECTION).map(t => t.object);
-    expect(sections).toEqual([expect.stringMatching(new RegExp(`^${subjectIri.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/\\.well-known/genid/section-1-hash-[0-9a-f]{12}$`))]);
+    expect(sections).toEqual([
+      expect.stringMatching(/^_:dkg-md-section-[0-9a-f]{12}-1-hash-[0-9a-f]{12}$/),
+    ]);
   });
 
   it('produces a stable anonymous fallback when there is no title', () => {

--- a/packages/cli/test/import-file-integration.test.ts
+++ b/packages/cli/test/import-file-integration.test.ts
@@ -1295,29 +1295,27 @@ describe('import-file orchestration — happy paths', () => {
     expect(writtenTriples.some(t =>
       t.predicate === 'http://dkg.io/ontology/hasSection',
     )).toBe(true);
-    const sectionSubjects = writtenTriples
+    const sectionSubjectsBeforePartition = writtenTriples
       .filter(t =>
-        t.subject.startsWith(`${result.assertionUri}/.well-known/genid/`) ||
-        (t.predicate === 'http://dkg.io/ontology/hasSection' && t.object.startsWith(`${result.assertionUri}/.well-known/genid/`)),
+        t.subject.startsWith('_:dkg-md-section-') ||
+        (t.predicate === 'http://dkg.io/ontology/hasSection' && t.object.startsWith('_:dkg-md-section-')),
       )
       .flatMap(t => [t.subject, t.object])
-      .filter(term => term.startsWith(`${result.assertionUri}/.well-known/genid/`));
-    expect(sectionSubjects.length).toBeGreaterThan(0);
-    expect(sectionSubjects.every(term => !term.includes('#section-'))).toBe(true);
+      .filter(term => term.startsWith('_:dkg-md-section-'));
+    expect(sectionSubjectsBeforePartition.length).toBeGreaterThan(0);
+    expect(sectionSubjectsBeforePartition.every(term => !term.includes('#section-'))).toBe(true);
 
     const promotionEligible = writtenTriples
       .filter(t => !findReservedSubjectPrefix(t.subject))
       .map(t => ({ ...t, graph: 'did:dkg:context-graph:research-cg' }));
-    const selectedRootQuads = promotionEligible.filter(t =>
-      t.subject === result.assertionUri ||
-      t.subject.startsWith(`${result.assertionUri}/.well-known/genid/`),
-    );
-    expect(selectedRootQuads).toEqual(promotionEligible);
+    const partitioned = autoPartition(promotionEligible);
+    const selectedRootQuads = partitioned.get(result.assertionUri) ?? [];
+    expect(selectedRootQuads).toHaveLength(promotionEligible.length);
     expect(selectedRootQuads.some(t =>
-      t.subject.startsWith(`${result.assertionUri}/.well-known/genid/`) &&
+      t.subject.startsWith(`${result.assertionUri}/.well-known/genid/dkg-md-section-`) &&
       t.predicate === 'http://schema.org/name',
     )).toBe(true);
-    expect([...autoPartition(selectedRootQuads).keys()]).toEqual([result.assertionUri]);
+    expect([...partitioned.keys()]).toEqual([result.assertionUri]);
 
     // Status map populated
     expect(status.size).toBe(1);

--- a/packages/cli/test/import-file-integration.test.ts
+++ b/packages/cli/test/import-file-integration.test.ts
@@ -43,7 +43,7 @@ import {
   contextGraphMetaUri,
   assertionLifecycleUri,
 } from '@origintrail-official/dkg-core';
-import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
+import { autoPartition, findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import { FileStore } from '../src/file-store.js';
 import type { ExtractionStatusRecord } from '../src/extraction-status.js';
 import { parseBoundary, parseMultipart } from '../src/http/multipart.js';
@@ -1295,6 +1295,29 @@ describe('import-file orchestration — happy paths', () => {
     expect(writtenTriples.some(t =>
       t.predicate === 'http://dkg.io/ontology/hasSection',
     )).toBe(true);
+    const sectionSubjects = writtenTriples
+      .filter(t =>
+        t.subject.startsWith(`${result.assertionUri}/.well-known/genid/`) ||
+        (t.predicate === 'http://dkg.io/ontology/hasSection' && t.object.startsWith(`${result.assertionUri}/.well-known/genid/`)),
+      )
+      .flatMap(t => [t.subject, t.object])
+      .filter(term => term.startsWith(`${result.assertionUri}/.well-known/genid/`));
+    expect(sectionSubjects.length).toBeGreaterThan(0);
+    expect(sectionSubjects.every(term => !term.includes('#section-'))).toBe(true);
+
+    const promotionEligible = writtenTriples
+      .filter(t => !findReservedSubjectPrefix(t.subject))
+      .map(t => ({ ...t, graph: 'did:dkg:context-graph:research-cg' }));
+    const selectedRootQuads = promotionEligible.filter(t =>
+      t.subject === result.assertionUri ||
+      t.subject.startsWith(`${result.assertionUri}/.well-known/genid/`),
+    );
+    expect(selectedRootQuads).toEqual(promotionEligible);
+    expect(selectedRootQuads.some(t =>
+      t.subject.startsWith(`${result.assertionUri}/.well-known/genid/`) &&
+      t.predicate === 'http://schema.org/name',
+    )).toBe(true);
+    expect([...autoPartition(selectedRootQuads).keys()]).toEqual([result.assertionUri]);
 
     // Status map populated
     expect(status.size).toBe(1);

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -465,6 +465,44 @@ describe('daemon memory_graph_changed route emissions', () => {
     expect(publishFromSharedMemory.mock.calls[0][1]).toEqual({ rootEntities: ['urn:root:present'] });
   });
 
+  it('preflights explicit SWM roots against skolemized descendants', async () => {
+    const root = 'urn:doc:markdown';
+    const section = `${root}/.well-known/genid/section-1-intro`;
+    const store = {
+      query: vi.fn(async () => ({
+        type: 'quads',
+        quads: [
+          {
+            subject: section,
+            predicate: 'http://schema.org/name',
+            object: '"Intro"',
+            graph: 'did:dkg:context-graph:project-a/_shared_memory',
+          },
+        ],
+      })),
+    };
+    const publishFromSharedMemory = vi.fn().mockResolvedValue({
+      kaId: 'kc-1',
+      status: 'confirmed',
+      kaManifest: [{ tokenId: 1n, rootEntity: root }],
+      publicQuads: [{ subject: section, predicate: 'http://schema.org/name', object: '"Intro"', graph: 'urn:g' }],
+    });
+    const getContextGraphOnChainId = vi.fn().mockResolvedValue('7');
+    const ctx = createContext('/api/shared-memory/publish', {
+      contextGraphId: 'project-a',
+      selection: [root],
+    }, {
+      agent: { publishFromSharedMemory, getContextGraphOnChainId, store } as unknown as RequestContext['agent'],
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(store.query.mock.calls[0][0]).toContain('STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/"))');
+    expect(publishFromSharedMemory).toHaveBeenCalledTimes(1);
+    expect(publishFromSharedMemory.mock.calls[0][1]).toEqual({ rootEntities: [root] });
+  });
+
   it('rejects multi-root synchronous SWM publishes before any root is published', async () => {
     const store = {
       query: vi.fn(async () => ({

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -897,6 +897,22 @@ export interface SwmRootEntity {
   tripleCount: number;
 }
 
+const SKOLEM_GENID_SEGMENT = '/.well-known/genid/';
+
+function canonicalSwmRootUri(uri: string): string {
+  const trimmed = uri.trim();
+  const unwrapped = trimmed.startsWith('<') && trimmed.endsWith('>') ? trimmed.slice(1, -1) : trimmed;
+  const idx = unwrapped.indexOf(SKOLEM_GENID_SEGMENT);
+  return idx === -1 ? unwrapped : unwrapped.slice(0, idx);
+}
+
+function labelFromUri(uri: string): string {
+  const hash = uri.lastIndexOf('#');
+  const slash = uri.lastIndexOf('/');
+  const cut = Math.max(hash, slash);
+  return cut >= 0 ? uri.slice(cut + 1) : uri;
+}
+
 /** List root entities in SWM with their triple counts. */
 export async function listSwmEntities(contextGraphId: string): Promise<SwmRootEntity[]> {
   const swmGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory`;
@@ -909,17 +925,19 @@ export async function listSwmEntities(contextGraphId: string): Promise<SwmRootEn
   } GROUP BY ?s ORDER BY DESC(?cnt)`;
   const data = await post<{ result: any }>('/api/query', { sparql, contextGraphId, view: 'shared-working-memory' });
   const bindings: any[] = data?.result?.bindings ?? [];
-  return bindings.map((b) => {
+  const countsByRoot = new Map<string, number>();
+  for (const b of bindings) {
     const uri = typeof b.s === 'string' ? b.s : b.s?.value ?? '';
     const cntRaw = typeof b.cnt === 'string' ? b.cnt : b.cnt?.value ?? '0';
     const m = cntRaw.match(/^"?(\d+)/);
     const tripleCount = m ? parseInt(m[1], 10) : 0;
-    const hash = uri.lastIndexOf('#');
-    const slash = uri.lastIndexOf('/');
-    const cut = Math.max(hash, slash);
-    const label = cut >= 0 ? uri.slice(cut + 1) : uri;
-    return { uri, label, tripleCount };
-  });
+    const rootUri = canonicalSwmRootUri(uri);
+    if (!rootUri) continue;
+    countsByRoot.set(rootUri, (countsByRoot.get(rootUri) ?? 0) + tripleCount);
+  }
+  return [...countsByRoot.entries()]
+    .map(([uri, tripleCount]) => ({ uri, label: labelFromUri(uri), tripleCount }))
+    .sort((a, b) => b.tripleCount - a.tripleCount || a.label.localeCompare(b.label));
 }
 
 export interface PublishResult {

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -79,7 +79,6 @@ export interface MemoryData {
 }
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
-const SKOLEM_GENID_SEGMENT = '/.well-known/genid/';
 
 function bv(v: unknown): string | undefined {
   if (v == null) return undefined;
@@ -103,9 +102,7 @@ function isUri(s: string): boolean {
 export function canonicalEntityUri(uri: string): string {
   const trimmed = uri.trim();
   if (trimmed.startsWith('"')) return trimmed;
-  const unwrapped = trimmed.startsWith('<') && trimmed.endsWith('>') ? trimmed.slice(1, -1) : trimmed;
-  const skolemIndex = unwrapped.indexOf(SKOLEM_GENID_SEGMENT);
-  return skolemIndex === -1 ? unwrapped : unwrapped.slice(0, skolemIndex);
+  return trimmed.startsWith('<') && trimmed.endsWith('>') ? trimmed.slice(1, -1) : trimmed;
 }
 
 function shortLabel(uri: string): string {

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -79,6 +79,7 @@ export interface MemoryData {
 }
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const SKOLEM_GENID_SEGMENT = '/.well-known/genid/';
 
 function bv(v: unknown): string | undefined {
   if (v == null) return undefined;
@@ -101,8 +102,10 @@ function isUri(s: string): boolean {
 // would miss the entity record.
 export function canonicalEntityUri(uri: string): string {
   const trimmed = uri.trim();
-  if (trimmed.startsWith('<') && trimmed.endsWith('>')) return trimmed.slice(1, -1);
-  return trimmed;
+  if (trimmed.startsWith('"')) return trimmed;
+  const unwrapped = trimmed.startsWith('<') && trimmed.endsWith('>') ? trimmed.slice(1, -1) : trimmed;
+  const skolemIndex = unwrapped.indexOf(SKOLEM_GENID_SEGMENT);
+  return skolemIndex === -1 ? unwrapped : unwrapped.slice(0, skolemIndex);
 }
 
 function shortLabel(uri: string): string {

--- a/packages/node-ui/test/build-entities-triple-count.test.ts
+++ b/packages/node-ui/test/build-entities-triple-count.test.ts
@@ -251,12 +251,12 @@ describe('buildEntities — MemoryEntity.tripleCount', () => {
     expect(dual.tripleCount).toBe(1);
   });
 
-  it('collapses skolemized section subjects without rewriting literals containing the marker', () => {
+  it('keeps skolemized child resources inspectable without rewriting marker literals', () => {
     const root = 'urn:doc:markdown';
     const section = `${root}/.well-known/genid/section-1-intro`;
     const literal = '"see /.well-known/genid/a"';
 
-    expect(canonicalEntityUri(section)).toBe(root);
+    expect(canonicalEntityUri(section)).toBe(section);
     expect(canonicalEntityUri(literal)).toBe(literal);
 
     const entities = buildEntities([
@@ -265,10 +265,12 @@ describe('buildEntities — MemoryEntity.tripleCount', () => {
       triple(section, 'http://schema.org/description', literal, 'shared'),
     ]);
 
-    const entity = entities.get(root);
-    expect(entity).toBeDefined();
-    expect(entities.has(section)).toBe(false);
-    expect(isFirstClassEntity(entity!)).toBe(true);
-    expect(entity?.properties.get('http://schema.org/description')).toEqual(['see /.well-known/genid/a']);
+    const rootEntity = entities.get(root);
+    const sectionEntity = entities.get(section);
+    expect(rootEntity).toBeDefined();
+    expect(sectionEntity).toBeDefined();
+    expect(isFirstClassEntity(rootEntity!)).toBe(true);
+    expect(isFirstClassEntity(sectionEntity!)).toBe(true);
+    expect(sectionEntity?.properties.get('http://schema.org/description')).toEqual(['see /.well-known/genid/a']);
   });
 });

--- a/packages/node-ui/test/build-entities-triple-count.test.ts
+++ b/packages/node-ui/test/build-entities-triple-count.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildEntities, type LayeredTriple, type TrustLevel } from '../src/ui/hooks/useMemoryEntities.js';
+import {
+  buildEntities,
+  canonicalEntityUri,
+  isFirstClassEntity,
+  type LayeredTriple,
+  type TrustLevel,
+} from '../src/ui/hooks/useMemoryEntities.js';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
@@ -243,5 +249,26 @@ describe('buildEntities — MemoryEntity.tripleCount', () => {
     // (which we don't surface via `tripleCount` for an SWM-canonical
     // entity).
     expect(dual.tripleCount).toBe(1);
+  });
+
+  it('collapses skolemized section subjects without rewriting literals containing the marker', () => {
+    const root = 'urn:doc:markdown';
+    const section = `${root}/.well-known/genid/section-1-intro`;
+    const literal = '"see /.well-known/genid/a"';
+
+    expect(canonicalEntityUri(section)).toBe(root);
+    expect(canonicalEntityUri(literal)).toBe(literal);
+
+    const entities = buildEntities([
+      triple(root, 'http://dkg.io/ontology/hasSection', section, 'shared'),
+      triple(section, 'http://schema.org/name', '"Intro"', 'shared'),
+      triple(section, 'http://schema.org/description', literal, 'shared'),
+    ]);
+
+    const entity = entities.get(root);
+    expect(entity).toBeDefined();
+    expect(entities.has(section)).toBe(false);
+    expect(isFirstClassEntity(entity!)).toBe(true);
+    expect(entity?.properties.get('http://schema.org/description')).toEqual(['see /.well-known/genid/a']);
   });
 });

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -42,6 +42,7 @@ import {
 let server: Server;
 let baseUrl: string;
 const requestLog: Array<{ url: string; method: string; body: string }> = [];
+let queryBindings: any[] = [];
 
 function startTestServer(): Promise<void> {
   return new Promise((resolve) => {
@@ -94,7 +95,7 @@ function startTestServer(): Promise<void> {
         } else if (url.startsWith('/api/context-graph/list') || url.startsWith('/api/context-graphs')) {
           res.end(JSON.stringify({ contextGraphs: [{ id: 'cg1' }] }));
         } else if (url.startsWith('/api/query')) {
-          res.end(JSON.stringify({ result: { bindings: [] } }));
+          res.end(JSON.stringify({ result: { bindings: queryBindings } }));
         } else if (url.startsWith('/api/shared-memory')) {
           res.end(JSON.stringify({ success: true, ual: 'did:dkg:test' }));
         } else if (url.includes('/promote')) {
@@ -140,6 +141,7 @@ describe('UI API tests', () => {
 
   beforeEach(() => {
     requestLog.length = 0;
+    queryBindings = [];
   });
 
   describe('fileUrl', () => {
@@ -303,6 +305,19 @@ describe('UI API tests', () => {
       expect(body.view).toBe('shared-working-memory');
       expect(body.sparql).toContain('/_shared_memory');
       expect(body.sparql).toContain('workspaceOwner');
+    });
+
+    it('listSwmEntities collapses skolemized section subjects into canonical roots', async () => {
+      queryBindings = [
+        { s: { value: 'https://example.org/doc/root' }, cnt: { value: '2' } },
+        { s: { value: 'https://example.org/doc/root/.well-known/genid/section-1-intro' }, cnt: { value: '3' } },
+        { s: { value: '<https://example.org/doc/child-only/.well-known/genid/section-1-only>' }, cnt: { value: '4' } },
+      ];
+
+      await expect(listSwmEntities('cg-1')).resolves.toEqual([
+        { uri: 'https://example.org/doc/root', label: 'root', tripleCount: 5 },
+        { uri: 'https://example.org/doc/child-only', label: 'child-only', tripleCount: 4 },
+      ]);
     });
 
     it('createSavedQuery sends POST', async () => {


### PR DESCRIPTION
## Summary

Fix Markdown/import-file extraction so an imported document remains one V10 Knowledge Asset/root.

Markdown section entities now use the existing skolem child convention:

`<document-root>/.well-known/genid/section-*`

instead of:

`<document-root>#section-*`

This prevents section nodes from being treated as independent KA roots by `autoPartition`, while keeping them included by selected-root publish filters.

## Changes

- Emit Markdown section IRIs under `/.well-known/genid/`.
- Update Markdown extraction expectations from fragment section IRIs to skolem child IRIs.
- Add regression coverage proving:
  - section nodes do not become standalone `autoPartition` roots
  - selected-root filtering keeps section triples
  - import-file output no longer emits `#section-*` section nodes

## Validation

- `git diff --check`
- Built required workspace packages for focused test imports
- Focused tests passed:
  - `test/extraction-markdown.test.ts`
  - `test/import-file-integration.test.ts`

Result: `147 passed`