### PR TITLE
fix(publisher): enforce single-root SWM publish boundary

### DIFF
--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -281,6 +281,21 @@ export class AssertionNotPersistedError extends Error {
   }
 }
 
+export class MultiRootPublishNotAtomicError extends Error {
+  readonly code = 'MULTI_ROOT_PUBLISH_NOT_ATOMIC' as const;
+  readonly contextGraphId: string;
+  readonly rootEntities: string[];
+  constructor(contextGraphId: string, rootEntities: readonly string[]) {
+    super(
+      `V10 shared-memory publish is single-root only for this operation. ` +
+        `Resolved ${rootEntities.length} root entities; select exactly one root or use a durable multi-publish flow.`,
+    );
+    this.name = 'MultiRootPublishNotAtomicError';
+    this.contextGraphId = contextGraphId;
+    this.rootEntities = [...rootEntities];
+  }
+}
+
 // Round 12 Bug 34: module-private token proving an internal caller
 // (specifically `publishFromSharedMemory`) is the origin of a
 // `publish()` call so the reserved-namespace guard can be bypassed
@@ -1279,6 +1294,10 @@ export class DKGPublisher implements Publisher {
 
     if (quads.length === 0) {
       throw new Error(`No quads in shared memory for context graph ${contextGraphId} matching selection`);
+    }
+    const rootEntities = [...autoPartition(quads).keys()];
+    if (rootEntities.length > 1) {
+      throw new MultiRootPublishNotAtomicError(contextGraphId, rootEntities);
     }
 
     const ctxGraphId = options?.publishContextGraphId;

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -29,6 +29,7 @@ export {
   DKGPublisher,
   StaleWriteError,
   AssertionNotPersistedError,
+  MultiRootPublishNotAtomicError,
   type DKGPublisherConfig,
   type WorkspaceSenderKeyEncryptInput,
   type WorkspaceSenderKeyEncryptor,

--- a/packages/publisher/test/shared-memory-publish-boundary.test.ts
+++ b/packages/publisher/test/shared-memory-publish-boundary.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  TRUST_LEVEL_PREDICATE,
+  TrustLevel,
+  TypedEventBus,
+  generateEd25519Keypair,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { DKGPublisher, MultiRootPublishNotAtomicError } from '../src/index.js';
+import type { PublishResult } from '../src/publisher.js';
+
+const CONTEXT_GRAPH = 'publish-boundary';
+const SWM_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;
+const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
+
+function q(subject: string, predicate = 'http://schema.org/name', object = '"value"', graph = SWM_GRAPH): Quad {
+  return { subject, predicate, object, graph };
+}
+
+async function makePublisher() {
+  const store = new OxigraphStore();
+  const publisher = new DKGPublisher({
+    store,
+    chain: new NoChainAdapter(),
+    eventBus: new TypedEventBus(),
+    keypair: await generateEd25519Keypair(),
+  });
+  const publishResult: PublishResult = {
+    kaId: 1n,
+    ual: 'did:dkg:0x0000000000000000000000000000000000000001/1',
+    merkleRoot: new Uint8Array(32),
+    kaManifest: [
+      {
+        tokenId: 1n,
+        rootEntity: 'urn:test:root:one',
+        privateTripleCount: 0,
+      },
+    ],
+    status: 'tentative',
+    publicQuads: [],
+  };
+  const publishSpy = vi.spyOn(publisher, 'publish').mockResolvedValue(publishResult);
+  return { publisher, store, publishSpy };
+}
+
+describe('publishFromSharedMemory single-root boundary', () => {
+  it('allows selection "all" when shared memory resolves to one payload root', async () => {
+    const { publisher, store, publishSpy } = await makePublisher();
+    await store.insert([
+      q('urn:test:root:one'),
+      q('urn:test:root:one', WORKSPACE_OWNER_PREDICATE, '"peer-a"'),
+      q('urn:test:root:one', TRUST_LEVEL_PREDICATE, `"${TrustLevel.SelfAttested}"`),
+      q('urn:test:root:metadata-only', WORKSPACE_OWNER_PREDICATE, '"peer-b"'),
+      q('urn:test:root:metadata-only', TRUST_LEVEL_PREDICATE, `"${TrustLevel.SelfAttested}"`),
+    ]);
+
+    await expect(publisher.publishFromSharedMemory(CONTEXT_GRAPH, 'all')).resolves.toMatchObject({
+      status: 'tentative',
+    });
+
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    const publishArgs = publishSpy.mock.calls[0][0];
+    expect(publishArgs.quads).toEqual([
+      { subject: 'urn:test:root:one', predicate: 'http://schema.org/name', object: '"value"', graph: '' },
+    ]);
+  });
+
+  it('throws before publish when selection "all" resolves to multiple payload roots', async () => {
+    const { publisher, store, publishSpy } = await makePublisher();
+    await store.insert([
+      q('urn:test:root:one'),
+      q('urn:test:root:two'),
+      q('urn:test:root:two', WORKSPACE_OWNER_PREDICATE, '"peer-b"'),
+      q('urn:test:root:two', TRUST_LEVEL_PREDICATE, `"${TrustLevel.SelfAttested}"`),
+    ]);
+
+    const error = await publisher.publishFromSharedMemory(CONTEXT_GRAPH, 'all').catch((err) => err);
+
+    expect(error).toBeInstanceOf(MultiRootPublishNotAtomicError);
+    expect(error).toMatchObject({
+      code: 'MULTI_ROOT_PUBLISH_NOT_ATOMIC',
+      contextGraphId: CONTEXT_GRAPH,
+    });
+    expect([...error.rootEntities].sort()).toEqual(['urn:test:root:one', 'urn:test:root:two']);
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws before publish when explicit rootEntities resolve to multiple payload roots', async () => {
+    const { publisher, store, publishSpy } = await makePublisher();
+    await store.insert([
+      q('urn:test:root:one'),
+      q('urn:test:root:two'),
+    ]);
+
+    const error = await publisher.publishFromSharedMemory(CONTEXT_GRAPH, {
+      rootEntities: ['urn:test:root:one', 'urn:test:root:two'],
+    }).catch((err) => err);
+
+    expect(error).toBeInstanceOf(MultiRootPublishNotAtomicError);
+    expect(error).toMatchObject({
+      code: 'MULTI_ROOT_PUBLISH_NOT_ATOMIC',
+      contextGraphId: CONTEXT_GRAPH,
+    });
+    expect([...error.rootEntities].sort()).toEqual(['urn:test:root:one', 'urn:test:root:two']);
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: [
       'test/trust-metadata.test.ts',
+      'test/shared-memory-publish-boundary.test.ts',
       'test/storage-ack-roster-and-verify-mofn-extra.test.ts',
       'test/verification-metadata.test.ts',
       'test/verify-collector.test.ts',


### PR DESCRIPTION
## Summary

- Keep synchronous shared-memory publish single-root and return an `asyncRoute` hint when multiple roots are selected.
- Add `POST /api/shared-memory/publish-async` for explicit multi-root UX.
- Resolve async roots against shared-memory metadata scoped by `contextGraphId`, `subGraphName`, and `shareOperationId`.
- Fan out async publishes into one `publisherControl.lift` job per root, with exactly one root per job.
- Reject missing async lift fields and roots outside the share operation before enqueueing.
- Normalize both selection shapes: arrays and `{ rootEntities: [...] }`.

## UX

The sync endpoint remains the atomic/single-root path. Multi-root publish is an explicit async batch path that returns `rootEntity`/`jobId` pairs so callers can track each independent publish.

## Testing

- `pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/memory-graph-events.test.ts`
- `pnpm --filter @origintrail-official/dkg exec tsc --noEmit --pretty false`
- `pnpm --filter @origintrail-official/dkg-publisher exec vitest run --config vitest.unit.config.ts test/shared-memory-publish-boundary.test.ts`
- `git diff --check`