### PR TITLE
Set default publish lifetime to 12 epochs

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -243,6 +243,8 @@ export interface PublishOpts {
   allowedPeers?: string[];
   /** Target sub-graph within the context graph (e.g. "code", "decisions"). */
   subGraphName?: string;
+  /** Optional on-chain publish lifetime override in epochs. */
+  publishEpochs?: number;
 }
 
 export interface PublishAsyncOpts extends PublishOpts {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -7873,6 +7873,7 @@ export class DKGAgent {
       accessPolicy: opts?.accessPolicy,
       allowedPeers: opts?.allowedPeers,
       entityProofs: opts?.entityProofs,
+      publishEpochs: opts?.publishEpochs,
       // Stringify bigint for JSON-safe persistence; preserve `0n` (mode d).
       publisherNodeIdentityIdOverride: opts?.publisherNodeIdentityIdOverride !== undefined
         ? (opts.publisherNodeIdentityIdOverride.toString() as `${bigint}`)
@@ -8127,6 +8128,7 @@ export class DKGAgent {
       onPhase,
       v10ACKProvider,
       publishContextGraphId: onChainId ?? undefined,
+      publishEpochs: opts?.publishEpochs,
       precomputedAttestation,
       encryptInlinePayload,
       encryptInlineChunked,
@@ -9402,6 +9404,7 @@ export class DKGAgent {
       operationCtx?: OperationContext;
       onPhase?: PhaseCallback;
       publisherNodeIdentityIdOverride?: bigint;
+      publishEpochs?: number;
       clearSharedMemoryAfter?: boolean;
     },
   ): Promise<PublishResult & { assertionUri: string; seal: AssertionSeal }> {
@@ -9474,6 +9477,7 @@ export class DKGAgent {
         onPhase: opts?.onPhase,
         subGraphName: opts?.subGraphName,
         publisherNodeIdentityIdOverride: opts?.publisherNodeIdentityIdOverride,
+        publishEpochs: opts?.publishEpochs,
         clearSharedMemoryAfter: opts?.clearSharedMemoryAfter,
         // Wired through to the inner publisher.publish() via
         // publishFromSharedMemory's `precomputedAttestation` option.
@@ -9546,6 +9550,7 @@ export class DKGAgent {
        * used for ACK self-signing and signer resolution.
        */
       publisherNodeIdentityIdOverride?: bigint;
+      publishEpochs?: number;
       /**
        * RFC-001 §9.x — pre-computed attestation captured by
        * `agent.assertion.finalize()`. When the caller has already
@@ -9676,6 +9681,7 @@ export class DKGAgent {
       v10ACKProvider,
       subGraphName: options?.subGraphName,
       publisherNodeIdentityIdOverride: options?.publisherNodeIdentityIdOverride,
+      publishEpochs: options?.publishEpochs,
       precomputedAttestation: resolvedSeal,
       encryptInlinePayload,
       encryptInlineChunked,

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -80,6 +80,12 @@ export class MockChainAdapter implements ChainAdapter {
     authorAddress: string;
     /** On-chain context graph id (0n when the mock V8 path didn't carry one). */
     cgId: bigint;
+    /** Mock Chronos epoch where this KC became active. */
+    startEpoch: bigint;
+    /** Exclusive mock Chronos epoch where this KC expires. */
+    endEpoch: bigint;
+    /** Token amount paid for the KC lifetime. Used to model per-epoch CG value. */
+    tokenAmount: bigint;
     /**
      * OT-RFC-38 LU-11 / OT-RFC-39 — ciphertext-chunks commitment for
      * curated KCs. `bytes32(0)` + 0 when omitted (default for legacy
@@ -379,6 +385,9 @@ export class MockChainAdapter implements ChainAdapter {
       // Legacy V8 path — no attestation, mirror the on-chain `address(0)`.
       authorAddress: ethers.ZeroAddress,
       cgId: 0n,
+      startEpoch: this.rsEpoch,
+      endEpoch: this.rsEpoch + 1n,
+      tokenAmount: 0n,
       ciphertextChunksRoot: new Uint8Array(32),
       ciphertextChunkCount: 0,
     });
@@ -1204,10 +1213,19 @@ export class MockChainAdapter implements ChainAdapter {
       publisherAddress,
       authorAddress: ethers.getAddress(params.author.address),
       cgId: params.contextGraphId,
+      startEpoch: this.rsEpoch,
+      endEpoch: this.rsEpoch + BigInt(params.epochs),
+      tokenAmount: params.tokenAmount,
       ciphertextChunksRoot: params.ciphertextChunksRoot && params.ciphertextChunksRoot.length === 32
         ? params.ciphertextChunksRoot
         : new Uint8Array(32),
       ciphertextChunkCount: params.ciphertextChunkCount ?? 0,
+    });
+    this.rsKCs.set(kaId, {
+      merkleRootHex: toHex(params.merkleRoot),
+      chunks: new Map([[0n, toHex(params.merkleRoot)]]),
+      kasContract: await this.getDKGKnowledgeAssetsAddress(),
+      cgId: params.contextGraphId,
     });
     // Also store in batches so verify() can find this publish
     this.batches.set(kaId, {
@@ -1387,6 +1405,9 @@ export class MockChainAdapter implements ChainAdapter {
     chunks: Array<{ chunkId: bigint; chunk: string }>;
     merkleLeafCount?: number;
     publisherAddress?: string;
+    startEpoch?: bigint;
+    endEpoch?: bigint;
+    tokenAmount?: bigint;
   }): void {
     const chunks = new Map<bigint, string>();
     for (const c of input.chunks) chunks.set(c.chunkId, c.chunk);
@@ -1406,6 +1427,9 @@ export class MockChainAdapter implements ChainAdapter {
       // the on-chain `address(0)` semantics for un-attested writes.
       authorAddress: ethers.ZeroAddress,
       cgId: input.contextGraphId,
+      startEpoch: input.startEpoch ?? this.rsEpoch,
+      endEpoch: input.endEpoch ?? ((input.startEpoch ?? this.rsEpoch) + 1n),
+      tokenAmount: input.tokenAmount ?? 1n,
       ciphertextChunksRoot: new Uint8Array(32),
       ciphertextChunkCount: 0,
     });
@@ -1450,8 +1474,22 @@ export class MockChainAdapter implements ChainAdapter {
       throw new Error('An unsolved challenge already exists for this node in the current proof period');
     }
 
-    // Round-robin pick over registered KCs (deterministic across runs).
-    const kcEntries = Array.from(this.rsKCs.entries());
+    // Round-robin pick over KCs whose context graph still has non-zero
+    // value in the current mock epoch. This mirrors the contract's
+    // ContextGraphValueStorage eligibility gate closely enough to catch
+    // lifetime/tokenAmount regressions in publisher tests.
+    const kcEntries = Array.from(this.rsKCs.entries()).filter(([kaId]) => {
+      const collection = this.collections.get(kaId);
+      if (!collection) return false;
+      if (collection.cgId <= 0n) return false;
+      if (this.rsEpoch < collection.startEpoch || this.rsEpoch >= collection.endEpoch) return false;
+      const lifetime = collection.endEpoch - collection.startEpoch;
+      if (lifetime <= 0n) return false;
+      return collection.tokenAmount / lifetime > 0n;
+    });
+    if (kcEntries.length === 0) {
+      throw new NoEligibleContextGraphError();
+    }
     const [kaId, kcEntry] = kcEntries[this.rsKCPickIndex % kcEntries.length];
     this.rsKCPickIndex++;
 

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -345,6 +345,7 @@ export class ApiClient {
   }>, options?: {
     accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
     allowedPeers?: string[];
+    publishEpochs?: number;
     publisherNodeIdentityIdOverride?: bigint;
   }): Promise<{
     kaId: string;
@@ -364,6 +365,9 @@ export class ApiClient {
     }
     const autoName = `cli-publish-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     return this.publishAssertion(contextGraphId, autoName, quads, {
+      ...(options?.publishEpochs !== undefined
+        ? { publishEpochs: options.publishEpochs }
+        : {}),
       ...(options?.publisherNodeIdentityIdOverride !== undefined
         ? { publisherNodeIdentityIdOverride: options.publisherNodeIdentityIdOverride }
         : {}),
@@ -414,7 +418,7 @@ export class ApiClient {
     contextGraphId: string,
     selection: 'all' | { rootEntities: string[] } = 'all',
     clearAfter = true,
-    options?: { subGraphName?: string; publisherNodeIdentityIdOverride?: bigint },
+    options?: { subGraphName?: string; publishEpochs?: number; publisherNodeIdentityIdOverride?: bigint },
   ): Promise<{
     kaId: string;
     status: 'tentative' | 'confirmed';
@@ -427,6 +431,7 @@ export class ApiClient {
       selection,
       clearAfter,
       ...(options?.subGraphName ? { subGraphName: options.subGraphName } : {}),
+      ...(options?.publishEpochs !== undefined ? { publishEpochs: options.publishEpochs } : {}),
       ...(options?.publisherNodeIdentityIdOverride !== undefined
         ? { publisherNodeIdentityIdOverride: options.publisherNodeIdentityIdOverride.toString() }
         : {}),
@@ -570,6 +575,7 @@ export class ApiClient {
     options?: {
       subGraphName?: string;
       clearAfter?: boolean;
+      publishEpochs?: number;
       publisherNodeIdentityIdOverride?: bigint;
     },
   ): Promise<{
@@ -588,6 +594,7 @@ export class ApiClient {
       assertionName,
       ...(options?.subGraphName ? { subGraphName: options.subGraphName } : {}),
       ...(options?.clearAfter !== undefined ? { clearAfter: options.clearAfter } : {}),
+      ...(options?.publishEpochs !== undefined ? { publishEpochs: options.publishEpochs } : {}),
       ...(options?.publisherNodeIdentityIdOverride !== undefined
         ? { publisherNodeIdentityIdOverride: options.publisherNodeIdentityIdOverride.toString() }
         : {}),
@@ -614,6 +621,7 @@ export class ApiClient {
       };
       schemeVersion?: number;
       clearAfter?: boolean;
+      publishEpochs?: number;
       publisherNodeIdentityIdOverride?: bigint;
     },
   ): Promise<{
@@ -648,6 +656,9 @@ export class ApiClient {
         ...(options?.subGraphName ? { subGraphName: options.subGraphName } : {}),
         ...(options?.clearAfter !== undefined
           ? { clearAfter: options.clearAfter }
+          : {}),
+        ...(options?.publishEpochs !== undefined
+          ? { publishEpochs: options.publishEpochs }
           : {}),
         ...(options?.publisherNodeIdentityIdOverride !== undefined
           ? { publisherNodeIdentityIdOverride: options.publisherNodeIdentityIdOverride }
@@ -759,6 +770,7 @@ export class ApiClient {
     allowedPeers?: string[];
     // V10 sign-at-enqueue. Absent `seal` → tentative; supply for on-chain attestation.
     entityProofs?: boolean;
+    publishEpochs?: number;
     /** Stringified bigint; `'0'` = mode d (no attribution) per RFC-001 §4. */
     publisherNodeIdentityIdOverride?: string;
     seal?: {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1440,6 +1440,7 @@ program
   .option('-o, --object <value>', 'Object value for simple publish')
   .option('--access-policy <policy>', 'Access policy for private triples (public|ownerOnly|allowList)')
   .option('--allowed-peer <peerId>', 'Peer ID allowed when using allowList policy', (v, prev: string[] = []) => [...prev, v], [])
+  .option('--publish-epochs <count>', 'On-chain publish lifetime in epochs (default: 12; PCA-funded publishes may coerce to PCA lock duration)')
   .option('--publisher-node-identity-id <id>', 'Override the publisherNodeIdentityId for THIS publish only (RFC §4 attribution; pass `0` for an unattributed publish)')
   .action(async (contextGraph: string, opts: ActionOpts) => {
     try {
@@ -1473,6 +1474,9 @@ program
         process.exit(1);
       }
 
+      const publishEpochs = opts.publishEpochs !== undefined
+        ? parsePositiveIntegerOption(String(opts.publishEpochs), '--publish-epochs')
+        : undefined;
       let publisherNodeIdentityIdOverride: bigint | undefined;
       if (opts.publisherNodeIdentityId !== undefined) {
         const raw = String(opts.publisherNodeIdentityId);
@@ -1485,6 +1489,7 @@ program
       const result = await client.publish(contextGraph, quads, privateQuads, {
         accessPolicy,
         allowedPeers,
+        publishEpochs,
         publisherNodeIdentityIdOverride,
       });
       console.log(`Published to context graph "${contextGraph}":`);
@@ -3126,12 +3131,16 @@ sharedMemoryCmd
   .requiredOption('--name <name>', 'Assertion name (from `dkg shared-memory write --name ...`)')
   .option('--sub-graph-name <name>', 'Optional sub-graph name')
   .option('--author-agent-address <address>', 'Override author EOA (must be a registered local agent)')
+  .option('--publish-epochs <count>', 'On-chain publish lifetime in epochs (default: 12; PCA-funded publishes may coerce to PCA lock duration)')
   .action(async (contextGraph: string | undefined, opts: ActionOpts) => {
     try {
       const targetContextGraph = contextGraph ?? 'dev-coordination';
       const assertionName = String(opts.name);
       const subGraphOption = (opts.subGraphName as string | undefined) ?? undefined;
       const authorAgentAddress = (opts.authorAgentAddress as string | undefined) ?? undefined;
+      const publishEpochs = opts.publishEpochs !== undefined
+        ? parsePositiveIntegerOption(String(opts.publishEpochs), '--publish-epochs')
+        : undefined;
       const client = await ApiClient.connect();
 
       // RFC-001 §9.x assertion lifecycle:
@@ -3153,7 +3162,12 @@ sharedMemoryCmd
       const result = await client.publishFromFinalizedAssertion(
         targetContextGraph,
         assertionName,
-        subGraphOption ? { subGraphName: subGraphOption } : undefined,
+        (subGraphOption || publishEpochs !== undefined)
+          ? {
+              ...(subGraphOption ? { subGraphName: subGraphOption } : {}),
+              ...(publishEpochs !== undefined ? { publishEpochs } : {}),
+            }
+          : undefined,
       );
       console.log(`Published WM assertion to "${targetContextGraph}":`);
       console.log(`  Assertion:    ${seal.assertionUri}`);
@@ -3466,6 +3480,7 @@ publisherCmd
   .option('--transition-type <value>', 'Transition type (CREATE|MUTATE|REVOKE)', 'CREATE')
   .option('--authority-type <value>', 'Authority type (owner|multisig|quorum|capability)', 'owner')
   .option('--prior-version <value>', 'Prior version reference for MUTATE/REVOKE flows')
+  .option('--publish-epochs <count>', 'On-chain publish lifetime in epochs (default: 12; PCA-funded publishes may coerce to PCA lock duration)')
   .action(async (contextGraph: string, opts: ActionOpts) => {
     try {
       const shareOperationId = opts.shareOperationId;
@@ -3488,6 +3503,9 @@ publisherCmd
         console.error('Invalid --authority-type. Use owner, multisig, quorum, or capability.');
         process.exit(1);
       }
+      const publishEpochs = opts.publishEpochs !== undefined
+        ? parsePositiveIntegerOption(String(opts.publishEpochs), '--publish-epochs')
+        : undefined;
 
       const enqueueFields = {
         swmId: opts.swmId ?? opts.workspaceId ?? 'swm-main',
@@ -3500,6 +3518,7 @@ publisherCmd
         authorityType: authorityType as 'owner' | 'multisig' | 'quorum' | 'capability',
         authorityProofRef: String(opts.authorityProofRef),
         priorVersion: opts.priorVersion ? String(opts.priorVersion) : undefined,
+        publishEpochs,
       };
 
       let jobId: string;

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -41,6 +41,7 @@ import { existsSync, readdirSync, readFileSync, openSync, closeSync, writeFileSy
 // below so both sites coexist without a duplicate-module import.
 import * as osModule from 'node:os';
 const { homedir } = osModule;
+const MAX_PUBLISH_EPOCHS = 0xffffffff;
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { ethers } from 'ethers';
@@ -1546,6 +1547,8 @@ WHERE {
       preSignedAuthorAttestation: bodyPreSignedAttestation,
       assertionName: bodyAssertionName,
     } = parsed;
+    const rawPublishEpochs = parsed.publishEpochs ?? parsed.epochs;
+    const publishEpochsField = parsed.publishEpochs !== undefined ? "publishEpochs" : "epochs";
     const contextGraphId = parsed.contextGraphId;
     const resolvedContextGraphId = await resolveRequiredWriteContextGraphId(
       agent,
@@ -1570,6 +1573,27 @@ WHERE {
         });
       }
       resolvedPublisherIdentityOverride = BigInt(raw);
+    }
+    let resolvedPublishEpochs: number | undefined;
+    if (rawPublishEpochs !== undefined && rawPublishEpochs !== null) {
+      const raw = String(rawPublishEpochs).trim();
+      if (!/^[1-9]\d*$/.test(raw)) {
+        return jsonResponse(res, 400, {
+          error: `"${publishEpochsField}" must be a positive integer (string or number)`,
+        });
+      }
+      const parsedEpochs = Number(raw);
+      if (!Number.isSafeInteger(parsedEpochs)) {
+        return jsonResponse(res, 400, {
+          error: `"${publishEpochsField}" is too large to safely represent as a JavaScript integer`,
+        });
+      }
+      if (parsedEpochs > MAX_PUBLISH_EPOCHS) {
+        return jsonResponse(res, 400, {
+          error: `"${publishEpochsField}" must be less than or equal to ${MAX_PUBLISH_EPOCHS}`,
+        });
+      }
+      resolvedPublishEpochs = parsedEpochs;
     }
 
     // RFC-001 §4(b) Phase 4 — author attribution resolution.
@@ -1678,6 +1702,9 @@ WHERE {
               operationCtx: ctx2,
               ...(resolvedPublisherIdentityOverride !== undefined
                 ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }
+                : {}),
+              ...(resolvedPublishEpochs !== undefined
+                ? { publishEpochs: resolvedPublishEpochs }
                 : {}),
               // Pass `clearAfter` straight through (incl. `undefined`) so the
               // publisher's own default — `false` — applies for the named
@@ -1892,6 +1919,9 @@ WHERE {
           : {}),
         ...(resolvedPublisherIdentityOverride !== undefined
           ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }
+          : {}),
+        ...(resolvedPublishEpochs !== undefined
+          ? { publishEpochs: resolvedPublishEpochs }
           : {}),
         ...(resolvedAuthorAgentAddress != null
           ? { authorAgentAddress: resolvedAuthorAgentAddress }

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -41,6 +41,7 @@ import { existsSync, readdirSync, readFileSync, openSync, closeSync, writeFileSy
 // below so both sites coexist without a duplicate-module import.
 import * as osModule from 'node:os';
 const { homedir } = osModule;
+const MAX_PUBLISH_EPOCHS = 0xffffffff;
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { ethers } from 'ethers';
@@ -378,9 +379,12 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
       accessPolicy,
       allowedPeers,
       entityProofs,
+      publishEpochs,
       publisherNodeIdentityIdOverride,
       seal,
     } = parsed;
+    const rawPublishEpochs = publishEpochs ?? parsed.epochs;
+    const publishEpochsField = publishEpochs !== undefined ? "publishEpochs" : "epochs";
     const contextGraphId = parsed.contextGraphId;
     const shareOperationId = parsed.shareOperationId;
     const swmId = parsed.swmId ?? parsed.workspaceId ?? "swm-main";
@@ -401,6 +405,27 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
         error: "Missing required enqueue fields",
       });
     }
+    let resolvedPublishEpochs: number | undefined;
+    if (rawPublishEpochs !== undefined && rawPublishEpochs !== null) {
+      const raw = String(rawPublishEpochs).trim();
+      if (!/^[1-9]\d*$/.test(raw)) {
+        return jsonResponse(res, 400, {
+          error: `"${publishEpochsField}" must be a positive integer (string or number)`,
+        });
+      }
+      const parsedEpochs = Number(raw);
+      if (!Number.isSafeInteger(parsedEpochs)) {
+        return jsonResponse(res, 400, {
+          error: `"${publishEpochsField}" is too large to safely represent as a JavaScript integer`,
+        });
+      }
+      if (parsedEpochs > MAX_PUBLISH_EPOCHS) {
+        return jsonResponse(res, 400, {
+          error: `"${publishEpochsField}" must be less than or equal to ${MAX_PUBLISH_EPOCHS}`,
+        });
+      }
+      resolvedPublishEpochs = parsedEpochs;
+    }
     // V10 sign-at-enqueue: callers build the EIP-712 AuthorAttestation themselves and pass it as `seal`. Sealless enqueues fall back to tentative.
     const jobId = await publisherControl.lift({
       swmId,
@@ -417,6 +442,7 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
       ...(Array.isArray(allowedPeers) && allowedPeers.length > 0 ? { allowedPeers } : {}),
       // Strict boolean — `!!"false"` is `true`, silently inverting intent.
       ...(typeof entityProofs === 'boolean' ? { entityProofs } : {}),
+      ...(resolvedPublishEpochs !== undefined ? { publishEpochs: resolvedPublishEpochs } : {}),
       ...(publisherNodeIdentityIdOverride !== undefined
         ? { publisherNodeIdentityIdOverride: String(publisherNodeIdentityIdOverride) }
         : {}),

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -558,6 +558,31 @@ describe('daemon memory_graph_changed route emissions', () => {
     expect(responseBody(ctx)).toMatchObject({ publishContextGraphId: '7' });
   });
 
+  it('forwards explicit publishEpochs to SWM publish options', async () => {
+    const publishFromSharedMemory = vi.fn().mockResolvedValue({
+      kaId: 'kc-1',
+      status: 'confirmed',
+      kaManifest: [{ tokenId: 1n, rootEntity: 'urn:root' }],
+      publicQuads: [{ subject: 'urn:root', predicate: 'urn:p', object: 'urn:o', graph: 'urn:g' }],
+    });
+    const getContextGraphOnChainId = vi.fn().mockResolvedValue('7');
+    const store = createSwmStore(['urn:root']);
+    const ctx = createContext('/api/shared-memory/publish', {
+      contextGraphId: 'project-a',
+      selection: ['urn:root'],
+      publishEpochs: '9',
+    }, {
+      agent: { publishFromSharedMemory, getContextGraphOnChainId, store } as unknown as RequestContext['agent'],
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(publishFromSharedMemory.mock.calls[0][2]).toMatchObject({
+      publishEpochs: 9,
+    });
+  });
+
   it('normalizes full publishContextGraphId DIDs to a positive on-chain remap id', async () => {
     const publishFromSharedMemory = vi.fn().mockResolvedValue({
       kaId: 'kc-1',

--- a/packages/cli/test/publisher-route-snapshot.test.ts
+++ b/packages/cli/test/publisher-route-snapshot.test.ts
@@ -50,6 +50,7 @@ describe('publisher routes with disk public snapshot refs', () => {
       scope: 'person-profile',
       transitionType: 'CREATE',
       authorityProofRef: 'proof:owner:route',
+      publishEpochs: '9',
     }, publisherControl);
 
     await handlePublisherRoutes(enqueue);
@@ -61,8 +62,14 @@ describe('publisher routes with disk public snapshot refs', () => {
 
     expect(responseStatus(payloadCtx)).toBe(200);
     const body = responseBody(payloadCtx) as {
-      payload?: { publishOptions?: { quads?: Array<{ subject: string; predicate: string; object: string }> } };
+      payload?: {
+        publishOptions?: {
+          quads?: Array<{ subject: string; predicate: string; object: string }>;
+          publishEpochs?: number;
+        };
+      };
     };
+    expect(body.payload?.publishOptions?.publishEpochs).toBe(9);
     expect(body.payload?.publishOptions?.quads).toEqual([
       expect.objectContaining({
         subject: expect.stringMatching(/^dkg:publisher-route-snapshot:aloha:person-profile\/entity-/),

--- a/packages/publisher/src/async-lift-publish-options.ts
+++ b/packages/publisher/src/async-lift-publish-options.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { OperationContext } from '@origintrail-official/dkg-core';
+import { MAX_PUBLISH_EPOCHS } from './publisher.js';
 import type {
   PhaseCallback,
   PublishOptions,
@@ -109,6 +110,10 @@ export function mapLiftRequestToPublishOptions(input: LiftPublishMappingInput): 
 
   // Request flags (enqueue-time caller intent) win over resolved hints (per-process defaults).
   const entityProofs = input.request.entityProofs ?? input.resolved.entityProofs;
+  const publishEpochs = input.request.publishEpochs;
+  if (publishEpochs !== undefined && (!Number.isSafeInteger(publishEpochs) || publishEpochs < 1 || publishEpochs > MAX_PUBLISH_EPOCHS)) {
+    throw new Error(`Lift publish mapping requires request.publishEpochs to be a positive uint32 integer; got ${String(publishEpochs)}`);
+  }
   const publisherNodeIdentityIdOverride = input.request.publisherNodeIdentityIdOverride !== undefined
     ? BigInt(input.request.publisherNodeIdentityIdOverride)
     : undefined;
@@ -128,6 +133,9 @@ export function mapLiftRequestToPublishOptions(input: LiftPublishMappingInput): 
     onPhase: input.resolved.onPhase,
     receiverSignatureProvider: input.resolved.receiverSignatureProvider,
     publishContextGraphId: input.resolved.publishContextGraphId,
+    ...(publishEpochs !== undefined
+      ? { publishEpochs }
+      : {}),
     ...(publisherNodeIdentityIdOverride !== undefined
       ? { publisherNodeIdentityIdOverride }
       : {}),

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -4,7 +4,7 @@ import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
 import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
-import type { Publisher, PublishOptions, PublishResult, KAManifestEntry, PhaseCallback, V10CoreNodeACK } from './publisher.js';
+import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
 import { autoPartition } from './auto-partition.js';
 import { canonicalPublishPayload } from './canonical-publish-payload.js';
 import { RESERVED_SUBJECT_PREFIXES, findReservedSubjectPrefix, isReservedSubject } from './reserved-subjects.js';
@@ -119,6 +119,14 @@ function normalizePublisherAddress(address: string | undefined): string | undefi
     throw new Error('Invalid publisherAddress: zero address is not a valid publisher');
   }
   return normalized;
+}
+
+function resolvePublishEpochsOverride(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isSafeInteger(value) || value < 1 || value > MAX_PUBLISH_EPOCHS) {
+    throw new Error(`publishEpochs must be a positive uint32 integer, got ${String(value)}`);
+  }
+  return value;
 }
 
 function coercePublisherAddress(value: unknown): string | undefined {
@@ -1204,6 +1212,8 @@ export class DKGPublisher implements Publisher {
        * semantics.
        */
       encryptInlineChunked?: PublishOptions['encryptInlineChunked'];
+      /** Per-publish on-chain lifetime override in epochs. */
+      publishEpochs?: number;
     },
   ): Promise<PublishResult> {
     const ctx = options?.operationCtx ?? createOperationContext('publishFromSWM');
@@ -1322,6 +1332,7 @@ export class DKGPublisher implements Publisher {
       precomputedAttestation: options?.precomputedAttestation,
       encryptInlinePayload: options?.encryptInlinePayload,
       encryptInlineChunked: options?.encryptInlineChunked,
+      publishEpochs: options?.publishEpochs,
       [INTERNAL_ORIGIN_TOKEN]: true,
     };
     const publishResult = await this.publish(internalPublishOptions);
@@ -1648,6 +1659,8 @@ export class DKGPublisher implements Publisher {
   }
 
   async publish(options: PublishOptions): Promise<PublishResult> {
+    const explicitPublishEpochs = resolvePublishEpochsOverride(options.publishEpochs);
+
     // Sub-graph routing: data triples go to `did:dkg:context-graph:{id}/{subGraph}`.
     // KC metadata (status, authorship proofs) stays in the root `_meta` graph so that
     // AccessHandler.lookupKAMeta() and DKGQueryEngine.resolveKA() can still discover
@@ -1968,10 +1981,12 @@ export class DKGPublisher implements Publisher {
     // through to direct spend at FULL price. To make sure registered
     // agents actually get the discount they paid for, we probe for the
     // PCA mapping and snap `publishEpochs` to the PCA's
-    // `lockDurationEpochs` when one is found. Wallets without a PCA
-    // (direct-spend branch) keep the default lifetime of `1` epoch.
-    let publishEpochs = 1;
+    // `lockDurationEpochs` when one is found AND the caller did not
+    // explicitly override the publish lifetime. Wallets without a PCA
+    // (direct-spend branch) use the ordinary default lifetime.
+    let publishEpochs = explicitPublishEpochs ?? DEFAULT_PUBLISH_EPOCHS;
     if (
+      explicitPublishEpochs === undefined &&
       canAttemptOnChainPublish &&
       publisherSigner !== undefined &&
       typeof this.chain.getConvictionAgentAccountId === 'function' &&
@@ -1991,7 +2006,7 @@ export class DKGPublisher implements Publisher {
         }
       } catch (err) {
         // PCA probe is best-effort. On any RPC hiccup we keep the
-        // default `publishEpochs=1`. The contract is still the source
+        // already-resolved publish lifetime. The contract is still the source
         // of truth: if the signer turns out to be a PCA agent but
         // `p.epochs != lockDurationEpochs`, the publish silently
         // falls through to direct spend at full price (no revert).
@@ -2000,7 +2015,7 @@ export class DKGPublisher implements Publisher {
         // `CostCovered` event on the receipt.
         this.log.warn(
           ctx,
-          `PCA epochs probe failed — falling back to publishEpochs=1: ` +
+          `PCA epochs probe failed — falling back to publishEpochs=${publishEpochs}: ` +
           `${err instanceof Error ? err.message : String(err)}`,
         );
       }
@@ -2010,13 +2025,14 @@ export class DKGPublisher implements Publisher {
     // ciphertext byte count; for public publishes it stays as plaintext
     // bytes. Single source of truth so ACK pricing == chain tx pricing.
     const effectiveByteSize = useEncryptedInline ? stagingByteSize : publicByteSize;
-    let precomputedTokenAmount = 0n;
+    let precomputedTokenAmount = canAttemptOnChainPublish ? BigInt(publishEpochs) : 0n;
     if (canAttemptOnChainPublish && typeof this.chain.getRequiredPublishTokenAmount === 'function') {
       try {
         precomputedTokenAmount = await this.chain.getRequiredPublishTokenAmount(effectiveByteSize, publishEpochs);
-        if (precomputedTokenAmount <= 0n) {
-          this.log.warn(ctx, `getRequiredPublishTokenAmount returned ${precomputedTokenAmount} for byteSize=${effectiveByteSize} — using 1n as minimum`);
-          precomputedTokenAmount = 1n;
+        const minTokenAmount = BigInt(publishEpochs);
+        if (precomputedTokenAmount < minTokenAmount) {
+          this.log.warn(ctx, `getRequiredPublishTokenAmount returned ${precomputedTokenAmount} for byteSize=${effectiveByteSize}, epochs=${publishEpochs} — using ${minTokenAmount} as minimum so per-epoch CG value stays non-zero`);
+          precomputedTokenAmount = minTokenAmount;
         }
       } catch (err) {
         this.log.warn(

--- a/packages/publisher/src/lift-job-types.ts
+++ b/packages/publisher/src/lift-job-types.ts
@@ -41,6 +41,8 @@ export interface LiftRequest {
   readonly allowedPeers?: readonly string[];
   /** V10 selective-disclosure mode; agent must sign over the same flag value. */
   readonly entityProofs?: boolean;
+  /** Optional on-chain publish lifetime override in epochs. */
+  readonly publishEpochs?: number;
   /** RFC-001 §4 attribution; stringified bigint, `'0'` = mode d (no attribution). */
   readonly publisherNodeIdentityIdOverride?: LiftJobBigInt;
   /** Agent-signed seal. Publisher rejects on-chain publish if absent on V10. */
@@ -61,6 +63,7 @@ export const LIFT_REQUEST_IMMUTABLE_FIELDS = [
   'accessPolicy',
   'allowedPeers',
   'entityProofs',
+  'publishEpochs',
   'publisherNodeIdentityIdOverride',
   'seal',
 ] as const;

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -2,6 +2,10 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 import type { OnChainPublishResult } from '@origintrail-official/dkg-chain';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 
+export const DEFAULT_PUBLISH_EPOCHS = 12;
+/** PublishIntent encodes epochs as uint32; reject larger overrides before wire encoding. */
+export const MAX_PUBLISH_EPOCHS = 0xffffffff;
+
 export interface KAManifestEntry {
   tokenId: bigint;
   rootEntity: string;
@@ -231,6 +235,12 @@ export interface PublishOptions {
   }>;
   /** When true, the KC was created via V10 and updates should use the V10 path. */
   v10Origin?: boolean;
+  /**
+   * On-chain publish lifetime in epochs. Omitted ordinary publishes use
+   * {@link DEFAULT_PUBLISH_EPOCHS}; PCA-funded publishes with no explicit
+   * override are coerced to the PCA lockDurationEpochs for discount parity.
+   */
+  publishEpochs?: number;
   /**
    * Per-publish override for the on-chain `PublishParams.publisherNodeIdentityId`
    * attribution field (RFC-001 §4 attribution control).

--- a/packages/publisher/test/async-lift-publish-options.test.ts
+++ b/packages/publisher/test/async-lift-publish-options.test.ts
@@ -452,6 +452,38 @@ describe('mapLiftRequestToPublishOptions', () => {
     expect(options.entityProofs).toBe(true);
   });
 
+  it('forwards request.publishEpochs to PublishOptions', () => {
+    const options = mapLiftRequestToPublishOptions({
+      ...baseInput(),
+      request: {
+        ...baseInput().request,
+        publishEpochs: 7,
+      },
+      resolved: {
+        ...baseInput().resolved,
+        publisherPeerId: '12D3KooWPublisher',
+      },
+    });
+
+    expect(options.publishEpochs).toBe(7);
+  });
+
+  it('rejects invalid request.publishEpochs before building PublishOptions', () => {
+    expect(() =>
+      mapLiftRequestToPublishOptions({
+        ...baseInput(),
+        request: {
+          ...baseInput().request,
+          publishEpochs: 0,
+        },
+        resolved: {
+          ...baseInput().resolved,
+          publisherPeerId: '12D3KooWPublisher',
+        },
+      }),
+    ).toThrow(/request\.publishEpochs.*positive uint32 integer/);
+  });
+
   it('parses request.publisherNodeIdentityIdOverride (stringified bigint) into PublishOptions (bigint)', () => {
     // BigInt persisted as `${bigint}` for JSON safety; mapper parses back.
     const options = mapLiftRequestToPublishOptions({

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -25,6 +25,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { DKGPublisher } from '../src/dkg-publisher.js';
+import { DEFAULT_PUBLISH_EPOCHS, type V10ACKProvider } from '../src/publisher.js';
 import { generateConfirmedFullMetadata } from '../src/metadata.js';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
@@ -131,6 +132,54 @@ class AdapterSigningChain extends MockChainAdapter {
   ): Promise<string> {
     return this.wallet.signTypedData(domain, types, value);
   }
+}
+
+class EpochCapturingChain extends AdapterSigningChain {
+  capturedCreateParams?: V10PublishDirectParams;
+  pcaLockDurationEpochs?: number;
+
+  override async createKnowledgeAssets(params: V10PublishDirectParams): Promise<OnChainPublishResult> {
+    this.capturedCreateParams = params;
+    return super.createKnowledgeAssets(params);
+  }
+
+  override async getConvictionAccountLockDurationEpochs(accountId: bigint): Promise<number> {
+    return this.pcaLockDurationEpochs ?? super.getConvictionAccountLockDurationEpochs(accountId);
+  }
+}
+
+interface AckEpochCapture {
+  epochs?: number;
+  tokenAmount?: bigint;
+}
+
+function captureACKInputs(capture: AckEpochCapture): V10ACKProvider {
+  const provider = mockChainStubACKProvider();
+  return async (...args: Parameters<V10ACKProvider>) => {
+    capture.epochs = args[6];
+    capture.tokenAmount = args[7];
+    return provider(...args);
+  };
+}
+
+async function makeEpochPublisher(chain: EpochCapturingChain, wallet: ethers.Wallet): Promise<DKGPublisher> {
+  const keypair = await generateEd25519Keypair();
+  return sealForWallet(new DKGPublisher({
+    store: new OxigraphStore(),
+    chain,
+    eventBus: new TypedEventBus(),
+    keypair,
+    publisherNodeIdentityId: 1n,
+  }), wallet, chain);
+}
+
+function epochTestQuads(label: string) {
+  return [{
+    subject: `urn:test:${label}`,
+    predicate: 'http://schema.org/name',
+    object: `"${label}"`,
+    graph: 'did:dkg:context-graph:1',
+  }];
 }
 
 class AsyncAddressSigningChain implements ChainAdapter {
@@ -828,6 +877,96 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
 
     expect(result.status).toBe('confirmed');
     expect(chain.capturedTokenAmount).toBe(123n);
+  });
+
+  it('uses the default publish lifetime for direct publishes and keeps random sampling eligible after epoch rollover', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new EpochCapturingChain(wallet);
+    const publisher = await makeEpochPublisher(chain, wallet);
+    const ack: AckEpochCapture = {};
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: epochTestQuads('default-publish-epochs'),
+      v10ACKProvider: captureACKInputs(ack),
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(ack.epochs).toBe(DEFAULT_PUBLISH_EPOCHS);
+    expect(ack.tokenAmount).toBe(BigInt(DEFAULT_PUBLISH_EPOCHS));
+    expect(chain.capturedCreateParams?.epochs).toBe(DEFAULT_PUBLISH_EPOCHS);
+    expect(chain.capturedCreateParams?.tokenAmount).toBe(BigInt(DEFAULT_PUBLISH_EPOCHS));
+
+    chain.__advanceEpoch();
+    chain.__advanceProofPeriod();
+    const challenge = await chain.createChallenge();
+    expect(challenge.contextGraphId).toBe(1n);
+    expect(challenge.challenge.knowledgeAssetId).toBe(result.kaId);
+  });
+
+  it('respects an explicit publishEpochs override in ACK intent and createKnowledgeAssets params', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new EpochCapturingChain(wallet);
+    const publisher = await makeEpochPublisher(chain, wallet);
+    const ack: AckEpochCapture = {};
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: epochTestQuads('explicit-publish-epochs'),
+      publishEpochs: 5,
+      v10ACKProvider: captureACKInputs(ack),
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(ack.epochs).toBe(5);
+    expect(ack.tokenAmount).toBe(5n);
+    expect(chain.capturedCreateParams?.epochs).toBe(5);
+    expect(chain.capturedCreateParams?.tokenAmount).toBe(5n);
+  });
+
+  it('coerces omitted PCA-funded publish lifetime to the PCA lock duration', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new EpochCapturingChain(wallet);
+    chain.pcaLockDurationEpochs = 24;
+    const { accountId } = await chain.createPublishingConvictionAccount(ethers.parseEther('10000'));
+    await chain.registerPublishingConvictionAgent(accountId, wallet.address);
+    const publisher = await makeEpochPublisher(chain, wallet);
+    const ack: AckEpochCapture = {};
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: epochTestQuads('pca-default-publish-epochs'),
+      v10ACKProvider: captureACKInputs(ack),
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(ack.epochs).toBe(24);
+    expect(ack.tokenAmount).toBe(24n);
+    expect(chain.capturedCreateParams?.epochs).toBe(24);
+    expect(chain.capturedCreateParams?.tokenAmount).toBe(24n);
+  });
+
+  it('keeps explicit publishEpochs when the publisher is also a PCA agent', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new EpochCapturingChain(wallet);
+    chain.pcaLockDurationEpochs = 24;
+    const { accountId } = await chain.createPublishingConvictionAccount(ethers.parseEther('10000'));
+    await chain.registerPublishingConvictionAgent(accountId, wallet.address);
+    const publisher = await makeEpochPublisher(chain, wallet);
+    const ack: AckEpochCapture = {};
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: epochTestQuads('pca-explicit-publish-epochs'),
+      publishEpochs: 5,
+      v10ACKProvider: captureACKInputs(ack),
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(ack.epochs).toBe(5);
+    expect(ack.tokenAmount).toBe(5n);
+    expect(chain.capturedCreateParams?.epochs).toBe(5);
+    expect(chain.capturedCreateParams?.tokenAmount).toBe(5n);
   });
 
   it('initializes V10 readiness before resolving adapter-backed signer addresses', async () => {

--- a/packages/publisher/test/v10-remap-wire.test.ts
+++ b/packages/publisher/test/v10-remap-wire.test.ts
@@ -159,6 +159,8 @@ describe('V10 remap wire (PublishIntent.swmGraphId + subGraphName)', () => {
     expect(decoded.swmGraphId).toBe(SOURCE_SWM_GRAPH_ID);
     expect(decoded.subGraphName).toBe(SUB_GRAPH_NAME);
     expect(decoded.kaCount).toBe(KA_COUNT);
+    expect(decoded.epochs).toBe(Number(EPOCHS));
+    expect(decoded.tokenAmountStr).toBe(TOKEN_AMOUNT.toString());
 
     // Per-ACK crypto verification. `toHaveLength(3)` alone would be
     // satisfied by three OPAQUE ACKs, including ones forged against
@@ -267,6 +269,8 @@ describe('V10 remap wire (PublishIntent.swmGraphId + subGraphName)', () => {
     // could be mistaken for a non-trivial remap source.
     expect(decoded.swmGraphId ?? '').toBe('');
     expect(decoded.subGraphName ?? '').toBe('');
+    expect(decoded.epochs).toBe(Number(EPOCHS));
+    expect(decoded.tokenAmountStr).toBe(TOKEN_AMOUNT.toString());
   });
 
   it('StorageACKHandler resolves SWM via (swmGraphId, subGraphName) and signs the target digest', async () => {


### PR DESCRIPTION
# Set default publish lifetime to 12 epochs

## Description
This fixes random-sampling eligibility across epoch rollover by changing ordinary/direct publishes from the implicit 1-epoch lifetime to a 12-epoch default.

## Changes
- Adds `DEFAULT_PUBLISH_EPOCHS = 12` and validates `publishEpochs` as a positive uint32.
- Threads `publishEpochs` through publisher options, agent APIs, CLI/API routes, SWM publish, and async lift jobs.
- Preserves PCA behavior: omitted lifetime still coerces to PCA `lockDurationEpochs`; explicit overrides remain respected.
- Clamps token amount to at least `epochs` so mock/devnet publishes do not produce zero per-epoch CG value.
- Updates mock random sampling eligibility to account for epoch lifetime and per-epoch value.

## Tests
- `pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/publisher-no-random-wallet.test.ts test/async-lift-publish-options.test.ts test/v10-remap-wire.test.ts`
- `pnpm --filter @origintrail-official/dkg exec vitest run test/memory-graph-events.test.ts test/publisher-route-snapshot.test.ts`
- `pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/dkg-publisher.test.ts test/ack-collector.test.ts test/storage-ack-handler.test.ts test/v10-publish-e2e.test.ts`
- `pnpm --filter @origintrail-official/dkg-evm-module exec hardhat test test/unit/ContextGraphValueStorage.test.ts test/unit/RandomSampling.test.ts --network hardhat --config hardhat.node.config.ts`
- `pnpm --filter @origintrail-official/dkg run build`
- `git diff --check`